### PR TITLE
change internal code to only import from _quantize_pt2e

### DIFF
--- a/backends/xnnpack/test/test_xnnpack_utils.py
+++ b/backends/xnnpack/test/test_xnnpack_utils.py
@@ -42,11 +42,14 @@ from torch.ao.quantization import (  # @manual
     QConfig,
     QConfigMapping,
 )
-from torch.ao.quantization._pt2e.quantizer import QNNPackQuantizer
-from torch.ao.quantization._pt2e.quantizer.qnnpack_quantizer import (
+
+from torch.ao.quantization._quantize_pt2e import (
+    convert_pt2e,
     get_symmetric_quantization_config,
+    prepare_pt2e_quantizer,
+    QNNPackQuantizer,
 )
-from torch.ao.quantization._quantize_pt2e import convert_pt2e, prepare_pt2e_quantizer
+
 from torch.ao.quantization.backend_config.executorch import (
     get_executorch_backend_config,
 )


### PR DESCRIPTION
Summary: This is to make public api clear so that we can make implementation details change easier in the future

Differential Revision: D47445767

