### PR TITLE
Checkout submodules and install lld linker

### DIFF
--- a/.ci/docker/common/install_clang.sh
+++ b/.ci/docker/common/install_clang.sh
@@ -7,6 +7,8 @@ install_ubuntu() {
 
   apt-get install -y --no-install-recommends clang-"$CLANG_VERSION"
   apt-get install -y --no-install-recommends llvm-"$CLANG_VERSION"
+  # Also require LLD linker from llvm
+  apt-get install -y lld
 
   # Use update-alternatives to make this version the default
   update-alternatives --install /usr/bin/clang clang /usr/bin/clang-"$CLANG_VERSION" 50

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -28,6 +28,10 @@ jobs:
         ln -s "${WORKSPACE}" executorch
         # Install executorch
         source executorch/install.sh
+        popd
 
         # Just print out the list of packages for debugging
         pip list
+
+        buck2 build //test:size_test_all_ops
+        sleep 300

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   buck-build-test:
     name: buck-build-test
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@init-submodules
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.2xlarge
       docker-image: executorch-ubuntu-22.04-clang12
@@ -33,5 +33,3 @@ jobs:
 
         # Just print out the list of packages for debugging
         pip list
-
-        buck2 build //test:size_test_all_ops

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -33,5 +33,5 @@ jobs:
         # Just print out the list of packages for debugging
         pip list
 
-        buck2 build //test:size_test_all_ops
         sleep 300
+        buck2 build //test:size_test_all_ops

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -14,11 +14,12 @@ concurrency:
 jobs:
   buck-build-test:
     name: buck-build-test
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@init-submodules
     with:
       runner: linux.2xlarge
       docker-image: executorch-ubuntu-22.04-clang12
       fetch-depth: 0
+      submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         WORKSPACE=$(pwd)
@@ -33,5 +34,4 @@ jobs:
         # Just print out the list of packages for debugging
         pip list
 
-        sleep 300
         buck2 build //test:size_test_all_ops


### PR DESCRIPTION
They are the some missing steps to run buck2.  https://github.com/pytorch/executorch/pull/18 needs this.

### Testing

Manually login to the runner, go to the docker container and run the following steps:

```
cd third-party/prelude
git checkout 971986683b987d399473969831bca6338833736d <-- the working prelude commit
buck2 build //test:size_test_all_ops
```