### PR TITLE
Simplify pip install process

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -26,8 +26,9 @@ jobs:
         pushd "${HOME}"
         # Create the softlink to the workspace as install.sh requires to run from its parent directory
         ln -s "${WORKSPACE}" executorch
-
-        ls
+        # Install executorch
+        # source executorch/install.sh
+        sleep 300
         python3 -m pip install executorch
 
         # Just print out the list of packages for debugging

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -26,8 +26,9 @@ jobs:
         pushd "${HOME}"
         # Create the softlink to the workspace as install.sh requires to run from its parent directory
         ln -s "${WORKSPACE}" executorch
-        # Install executorch
-        source executorch/install.sh
+
+        ls
+        python3 -m pip install executorch
 
         # Just print out the list of packages for debugging
         pip list

--- a/docs/website/docs/tutorials/setting_up_executorch.md
+++ b/docs/website/docs/tutorials/setting_up_executorch.md
@@ -21,29 +21,27 @@ pip install --pre torch -i https://download.pytorch.org/whl/nightly/cpu
 
 **Step 2: Set up Executorch**. This will install an  `executorch` pip package to your conda environment.
 ```bash
-mkdir -p ~/src/
-cd ~/src/
 
 # Do one of these, depending on how your auth is set up
 git clone https://github.com/pytorch/executorch.git
 git clone git@github.com:pytorch/executorch.git
 
-# Run the following to get all submodules
+# [Runtime requirement] Run the following to get all submodules, only need for runtime setup
 git submodule update --init --recursive
 
-./executorch/install.sh
+pip install executorch
 
 # cd into a directory that doesn't contain a `./executorch/exir` directory, since
 # otherwise python will try using it for `import executorch.exir...` instead of using the
 # installed pip package.
-cd ~/
+cd executorch
 ```
 
 **Step 3: Try it out**
 
 Via python script:
 ```
-python ~/src/executorch/examples/export/export_example.py -m "add"
+python ~/executorch/examples/export/export_example.py -m "add"
 ```
 
 Or via python interpreter:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,6 @@ dependencies=[
   "sympy",
 ]
 
-[tool.setuptools.packages.find]
-where = ["src"]
-
 [tool.setuptools.package-data]
 "*" = ["*.fbs", "*.yaml"]
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,57 @@
+# from setuptools import setup, find_packages
+import os
+import shutil
+
+from setuptools import setup
+from setuptools.command.develop import develop
+from setuptools.command.egg_info import egg_info
+from setuptools.command.install import install
+
+
+def custom_command():
+    src_dst_list = [
+        ("schema/scalar_type.fbs", "exir/serialize/scalar_type.fbs"),
+        ("schema/schema.fbs", "exir/serialize/schema.fbs"),
+    ]
+    for src, dst in src_dst_list:
+        print(f"copying from {src} to {dst}")
+        shutil.copyfile(src, dst)
+
+    for _, dst in src_dst_list:
+        if not os.path.isfile(dst):
+            raise FileNotFoundError(
+                f"Could not find {dst}, copying file from {src} fails."
+            )
+
+
+class CustomInstallCommand(install):
+    def run(self):
+        custom_command()
+        install.run(self)
+
+
+class CustomDevelopCommand(develop):
+    def run(self):
+        custom_command()
+        develop.run(self)
+
+
+class CustomEggInfoCommand(egg_info):
+    def run(self):
+        custom_command()
+        egg_info.run(self)
+
+
+setup(
+    package_dir={
+        "executorch/backends": "backends",
+        "executorch/exir": "exir",
+        "executorch/schema": "schema",
+        "executorch/extension": "extension",
+    },
+    cmdclass={
+        "install": CustomInstallCommand,
+        "develop": CustomDevelopCommand,
+        "egg_info": CustomEggInfoCommand,
+    },
+)


### PR DESCRIPTION
Summary: setup.py is noted as legacy (https://pip.pypa.io/en/stable/reference/build-system/setup-py/) however there are many features not supported with pyprojects.toml, and it's more handy to have do `pip install executorch` directly as we can set up examples in colab directly as part of the demos. pytorch core also users [`setup.py`](https://github.com/pytorch/pytorch/blob/main/setup.py) so I think it should be ok
