### PR TITLE
Fix export config in tests

### DIFF
--- a/examples/export/test/TARGETS
+++ b/examples/export/test/TARGETS
@@ -10,5 +10,6 @@ python_unittest(
         "//executorch/examples/export:utils",
         "//executorch/examples/models:models",
         "//executorch/exir:lib",
+        "//executorch/extension/pybindings:portable",  # @manual
     ],
 )

--- a/examples/export/utils.py
+++ b/examples/export/utils.py
@@ -11,7 +11,7 @@ import executorch.exir as exir
 # Reason is that there memory allocation ops with symbolic shape nodes.
 # and when evaulating shape, it doesnt seem that we presenting them with shape env
 # that contain those variables.
-_CAPTURE_CONFIG = exir.CaptureConfig(enable_aot=True, _unlift=False)
+_CAPTURE_CONFIG = exir.CaptureConfig(enable_aot=True)
 _EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(
     _check_ir_validity=False,
 )

--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -19,8 +19,8 @@ from torch.fx._compatibility import compatibility
 class CaptureConfig:
     pt2_mode: bool = True
     enable_functionalization: bool = True
-    enable_dynamic_shape: bool = False
-    enable_aot: bool = False
+    enable_dynamic_shape: bool = False  # This flag does nothing if enable_aot is True
+    enable_aot: bool = False  # When it's true it implies automatic dynamic shapes via default dynamo config
     _dynamo_config: "ExirDynamoConfig" = field(default_factory=ExirDynamoConfig)
     _unlift: bool = False
     _use_old_decomp_table: bool = False


### PR DESCRIPTION
Summary:
## Context
It doesn't look correct that want to export models with one config but test the export with a different one. 

## This DIff
 - Ensure canonical config is used for both export and tests
 - Ensure the test is loading the lowered model through `_load_for_executorch_from_buffer` for output consistency checking 
 - Remove confusion about certain export flags by adding more inline comments to those flags, e.g. why  is `enable_dynamic_shape` there not enabled by default, what does `enable_aot` do with dynamic shapes, etc.

Differential Revision: D48018569

