### PR TITLE
Update ExecuTorch cpuinfo generate-wrapper script

### DIFF
--- a/backends/xnnpack/third-party/cpuinfo-wrappers/arm/mach/init.c
+++ b/backends/xnnpack/third-party/cpuinfo-wrappers/arm/mach/init.c
@@ -4,6 +4,6 @@
 	#include <TargetConditionals.h>
 #endif /* __APPLE__ */
 
-#if (defined(__arm__) || defined(__aarch64__)) && defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+#if (defined(__arm__) || defined(__aarch64__)) && defined(TARGET_OS_MAC) && TARGET_OS_MAC
 #include <arm/mach/init.c>
-#endif /* (defined(__arm__) || defined(__aarch64__)) && defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE */
+#endif /* (defined(__arm__) || defined(__aarch64__)) && defined(TARGET_OS_MAC) && TARGET_OS_MAC */

--- a/backends/xnnpack/third-party/generate-cpuinfo-wrappers.py
+++ b/backends/xnnpack/third-party/generate-cpuinfo-wrappers.py
@@ -63,7 +63,7 @@ CPUINFO_SOURCES = {
     "(defined(__arm__) || defined(__aarch64__)) && defined(__ANDROID__)": [
         "arm/android/properties.c",
     ],
-    "(defined(__arm__) || defined(__aarch64__)) && defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE": [
+    "(defined(__arm__) || defined(__aarch64__)) && defined(TARGET_OS_MAC) && TARGET_OS_MAC": [
         "arm/mach/init.c",
     ],}
 


### PR DESCRIPTION
Summary: Current there is an error with cpuinfo build in executorch updating the following line in the generate-wrapper script and regenerating seems to fix

Reviewed By: larryliu0820

Differential Revision: D48277357

