### PR TITLE
delete py_bin for quant. Add message to indicate succesful finish

### DIFF
--- a/examples/quantization/TARGETS
+++ b/examples/quantization/TARGETS
@@ -1,6 +1,6 @@
-load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-python_binary(
+runtime.python_binary(
     name = "example",
     main_src = "example.py",
     deps = [

--- a/examples/quantization/example.py
+++ b/examples/quantization/example.py
@@ -133,3 +133,4 @@ if __name__ == "__main__":
         )
 
     quantize(args.model_name, model, example_inputs)
+    print("finished")


### PR DESCRIPTION
Summary: instead of using buck for this we should do 'python3 -m examples.quantization.example --model_name mv2'

Reviewed By: larryliu0820

Differential Revision: D48325202

