### PR TITLE
Fix CPUINFO dependency for xnnpack/threadpool

### DIFF
--- a/backends/xnnpack/threadpool/targets.bzl
+++ b/backends/xnnpack/threadpool/targets.bzl
@@ -27,8 +27,8 @@ def define_common_targets():
         exported_headers = _THREADPOOL_HEADERS,
         exported_deps = [
             third_party_dep("pthreadpool"),
+            third_party_dep("cpuinfo"),
         ],
-        external_deps = ["cpuinfo"],
         exported_preprocessor_flags = [
             "-DET_USE_THREADPOOL",
         ],

--- a/shim/xplat/executorch/backends/xnnpack/third-party/third_party_libs.bzl
+++ b/shim/xplat/executorch/backends/xnnpack/third-party/third_party_libs.bzl
@@ -8,7 +8,7 @@ _THIRD_PARTY_LIBS = {
     "FXdiv": ["//xplat/third-party/FXdiv:FXdiv", "//backends/xnnpack/third-party:FXdiv"],
     "XNNPACK": ["//xplat/third-party/XNNPACK:XNNPACK", "//backends/xnnpack/third-party:XNNPACK"],
     "clog": ["//xplat/third-party/clog:clog", "//backends/xnnpack/third-party:clog"],
-    "cpuinfo": ["//third-party/cpuinfo:cpuinfo", "//backends/xnnpack/third-party:cpuinfo"],
+    "cpuinfo": ["fbsource//third-party/cpuinfo:cpuinfo", "//backends/xnnpack/third-party:cpuinfo"],
     "pthreadpool": ["//xplat/third-party/pthreadpool:pthreadpool", "//backends/xnnpack/third-party:pthreadpool"],
     "pthreadpool_header": ["//xplat/third-party/pthreadpool:pthreadpool_header", "//backends/xnnpack/third-party:pthreadpool_header"],
 }


### PR DESCRIPTION
Summary: Forgot to fix this third_party_dep for threadpool. In OSS it should be pointing to xnnpack/third-party/cpuinfo instead of internal cpuinfo

Reviewed By: kimishpatel

Differential Revision: D48335278

