### PR TITLE
Dtype compliance: clamp

### DIFF
--- a/kernels/test/op_clamp_test.cpp
+++ b/kernels/test/op_clamp_test.cpp
@@ -303,12 +303,12 @@ TEST(OpClampOutTest, ByteTensorFloatingPointClampDies) {
 
 #ifndef USE_ATEN_LIB
 TEST(OpClampOutTest, IntTensorTooSmallClampDies) {
-  // Cannot be represented by a uint32_t.
+  // Cannot be represented by a int32_t.
   expect_bad_clamp_value_dies<ScalarType::Int>(-2147483649);
 }
 
 TEST(OpClampOutTest, IntTensorTooLargeClampDies) {
-  // Cannot be represented by a uint32_t.
+  // Cannot be represented by a int32_t.
   expect_bad_clamp_value_dies<ScalarType::Int>(2147483648);
 }
 #endif


### PR DESCRIPTION
Summary:
Adjust clamp portable op have near-complete Dtype compliance with aten version.

The Aten version of clamp has a weird quirk where it allows you to pass in a value for the min and/or max args which is below the normal range of the input/output tensor dataype when that datatype is uint8 specifically. But it doesn't allow ABOVE the range, and it doesn't allow below or above for any other datatype. We are choosing to leave a discrepancy between aten and portable by making uint8 behave like the rest of the datatypes for portable (not allowing below the range). This is already tested by the ByteTensorNegativeClampDies test (which is skipped when running the aten tests).

Reviewed By: manuelcandales

Differential Revision: D47573238

