### PR TITLE
Fix CI job

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -51,7 +51,7 @@ jobs:
         bash .ci/scripts/test.sh
 
         # Test custom ops
-        bash examples/custom_ops/test_custom_ops.sh buck2
+        PYTHON_EXECUTABLE=python bash examples/custom_ops/test_custom_ops.sh buck2
         popd
 
   cmake-build-test-linux:
@@ -90,5 +90,5 @@ jobs:
         bash .ci/scripts/setup-macos.sh
 
         # Build and test custom ops
-        bash examples/custom_ops/test_custom_ops.sh cmake
+        PYTHON_EXECUTABLE=python bash examples/custom_ops/test_custom_ops.sh cmake
         popd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ endif()
 if(NOT BUCK2)
   set(BUCK2 buck2)
 endif()
+if(NOT PYTHON_EXECUTABLE)
+  set(PYTHON_EXECUTABLE python3)
+endif()
 
 # TODO(dbort): Fix these warnings and remove this flag.
 set(_common_compile_options -Wno-deprecated-declarations)
@@ -87,7 +90,7 @@ if(NOT EXECUTORCH_SRCS_FILE)
   message(STATUS "executorch: Generating source lists")
   set(EXECUTORCH_SRCS_FILE "${CMAKE_CURRENT_BINARY_DIR}/executorch_srcs.cmake")
   execute_process(
-    COMMAND python3 build/extract_sources.py --buck2=${BUCK2}
+    COMMAND ${PYTHON_EXECUTABLE} build/extract_sources.py --buck2=${BUCK2}
             --config=build/cmake_deps.toml --out=${EXECUTORCH_SRCS_FILE}
     OUTPUT_VARIABLE gen_srcs_output
     ERROR_VARIABLE gen_srcs_error

--- a/third-party/link_torch.sh
+++ b/third-party/link_torch.sh
@@ -33,7 +33,7 @@ while getopts ":o:f:" opt; do
   esac
 done
 
-LIB=$(python3 -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')
+LIB=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')
 
 # delimiter ,
 export IFS=","


### PR DESCRIPTION
Summary:
Apparently in macos CI, python3 and python are pointing to different python environment.

python3 -> /Library/Python/3.9/site-packages/

python -> /Users/ec2-user/runner/_work/_temp/miniconda/lib/python3.9/site-packages

This diff is fixing the CI failure:
```
[2023-08-17T02:59:12.739+00:00] Local command: env -- "ASAN_OPTIONS=detect_leaks=0,detect_odr_violation=0" "GEN_DIR=GEN_DIR_DEPRECATED" "OUT=././../out" "SRCDIR=./." "SRCS=././link_torch.sh" /usr/bin/env bash -e buck-out/v2/gen/root/213ed1b7ab869379/third-party/__libtorch_gen__/sh/genrule.sh
[2023-08-17T02:59:12.739+00:00] Stdout: Error: /Library/Python/3.9/site-packages/torch/lib/libtorch.dylib doesn't exist
```

Differential Revision: D48423480

