### PR TITLE
Fix linear's with permute copy

### DIFF
--- a/backends/xnnpack/operators/__init__.py
+++ b/backends/xnnpack/operators/__init__.py
@@ -30,6 +30,7 @@ from . import (  # noqa
     op_minimum,
     op_multiply,
     op_negate,
+    op_permute,
     op_prelu,
     op_quantize_per_tensor,
     op_relu,
@@ -42,7 +43,6 @@ from . import (  # noqa
     op_squeeze,
     op_static_constant_pad,
     op_static_resize_bilinear_2d,
-    op_static_transpose,
     op_sub,
     op_to_copy,
 )

--- a/backends/xnnpack/operators/op_permute.py
+++ b/backends/xnnpack/operators/op_permute.py
@@ -20,7 +20,7 @@ from executorch.backends.xnnpack.utils.utils import get_input_node
 
 
 @register_node_visitor
-class StaticTransposeVisitor(NodeVisitor):
+class PermuteVisitor(NodeVisitor):
     target = "aten.permute_copy.default"
 
     def __init__(self, *args) -> None:

--- a/backends/xnnpack/operators/op_skip_ops.py
+++ b/backends/xnnpack/operators/op_skip_ops.py
@@ -113,12 +113,3 @@ class OpSymSizeInt(OpSkipOps):
     """
 
     target = "sym_size.int"
-
-
-@register_node_visitor
-class OpPermuteCopyDefault(OpSkipOps):
-    """
-    do nothing if node is permute_copy.default
-    """
-
-    target = "aten.permute_copy.default"

--- a/backends/xnnpack/partition/configs.py
+++ b/backends/xnnpack/partition/configs.py
@@ -111,6 +111,10 @@ SUPPORTED_QUANT_MODULES = [
     torch.nn.functional.leaky_relu,
     torch.nn.functional.leaky_relu_,
     torch.nn.LeakyReLU,
+    # TODO(): In quant --> export flow source_fn is operator target instead of module name
+    # This is actively being fixed, but until, we add these operator target names to partitioenr
+    torch.ops.aten.convolution.default,
+    torch.ops.aten.addmm.default,
 ]
 
 SUPPORTED_IMPLICIT_Q_DQ_MODULES_SET = set(SUPPORTED_QUANT_MODULES)

--- a/backends/xnnpack/partition/xnnpack_partitioner.py
+++ b/backends/xnnpack/partition/xnnpack_partitioner.py
@@ -682,6 +682,9 @@ class XnnpackQuantizedPartitioner2(XnnpackFloatingPointPartitioner):
         """
         nodes = set()
         for inp in input_nodes:
+            if inp.target == exir_ops.edge.aten.permute_copy.default:
+                nodes.add(inp)
+                inp = cast(torch.fx.Node, inp.args[0])
             if inp.target in self._DQ_OPS:
                 # dequant node
                 nodes.add(inp)

--- a/backends/xnnpack/passes/convert_to_linear.py
+++ b/backends/xnnpack/passes/convert_to_linear.py
@@ -120,6 +120,8 @@ class ConvertToLinearPass(ExportPass):
             src_partition.input_nodes
             + src_partition.params,  # non quant weight can be in params
         )
+        if linear_weight.target == exir_ops.edge.aten.permute_copy.default:
+            linear_weight = linear_weight.args[0]
         logger.debug(f"Found weight: {linear_weight} from node {node}")
 
         linear_bias = self.find(

--- a/backends/xnnpack/passes/convert_to_linear.py
+++ b/backends/xnnpack/passes/convert_to_linear.py
@@ -27,6 +27,7 @@ class ConvertToLinearPass(ExportPass):
     linear_modules = [
         torch.nn.Linear,
         torch.nn.functional.linear,
+        torch.ops.aten.addmm.default,
     ]
 
     targets = [


### PR DESCRIPTION
Summary:
There are some issues with permute_copy in both partitioner as well as convert_to_linear pass

### Partitioner:
For Quantized Partitions, we fail to pull in the q/dq nodes above permute_copy.

```
get_attr --> q --> dq --> permute_copy --> addm
```
The solution is checking the inputs to the source_partition for permute_copy node, and if it is one of them, then we add it to the partition and check its inputs

### Convert to Linear Pass
In the pattern
```
get_attr --> q --> dq --> permute_copy --> addmm
```
We replace the entire source partition with just linear, however we fail to delete the permute_copy because it is an input to the source partition instead of the dq (dq should actually be the input to the linear source partition). The weight given to linear should not be the result of permute copy, but should instead be the input to permute copy.

This happens because q and dq are not tagged as part of the linear source partition, so permute_copy becomes the input to the source partition.

Differential Revision: D48488931

