### PR TITLE
Temporarily add aten.op to supported quant modules

### DIFF
--- a/backends/xnnpack/operators/__init__.py
+++ b/backends/xnnpack/operators/__init__.py
@@ -30,6 +30,7 @@ from . import (  # noqa
     op_minimum,
     op_multiply,
     op_negate,
+    op_permute,
     op_prelu,
     op_quantize_per_tensor,
     op_relu,
@@ -42,7 +43,6 @@ from . import (  # noqa
     op_squeeze,
     op_static_constant_pad,
     op_static_resize_bilinear_2d,
-    op_static_transpose,
     op_sub,
     op_to_copy,
 )

--- a/backends/xnnpack/operators/op_permute.py
+++ b/backends/xnnpack/operators/op_permute.py
@@ -20,7 +20,7 @@ from executorch.backends.xnnpack.utils.utils import get_input_node
 
 
 @register_node_visitor
-class StaticTransposeVisitor(NodeVisitor):
+class PermuteVisitor(NodeVisitor):
     target = "aten.permute_copy.default"
 
     def __init__(self, *args) -> None:

--- a/backends/xnnpack/operators/op_skip_ops.py
+++ b/backends/xnnpack/operators/op_skip_ops.py
@@ -113,12 +113,3 @@ class OpSymSizeInt(OpSkipOps):
     """
 
     target = "sym_size.int"
-
-
-@register_node_visitor
-class OpPermuteCopyDefault(OpSkipOps):
-    """
-    do nothing if node is permute_copy.default
-    """
-
-    target = "aten.permute_copy.default"

--- a/backends/xnnpack/partition/configs.py
+++ b/backends/xnnpack/partition/configs.py
@@ -111,6 +111,10 @@ SUPPORTED_QUANT_MODULES = [
     torch.nn.functional.leaky_relu,
     torch.nn.functional.leaky_relu_,
     torch.nn.LeakyReLU,
+    # TODO(): In quant --> export flow source_fn is operator target instead of module name
+    # This is actively being fixed, but until, we add these operator target names to partitioenr
+    torch.ops.aten.convolution.default,
+    torch.ops.aten.addmm.default,
 ]
 
 SUPPORTED_IMPLICIT_Q_DQ_MODULES_SET = set(SUPPORTED_QUANT_MODULES)

--- a/backends/xnnpack/passes/convert_to_linear.py
+++ b/backends/xnnpack/passes/convert_to_linear.py
@@ -27,6 +27,7 @@ class ConvertToLinearPass(ExportPass):
     linear_modules = [
         torch.nn.Linear,
         torch.nn.functional.linear,
+        torch.ops.aten.addmm.default,
     ]
 
     targets = [


### PR DESCRIPTION
Summary:
Quant flow for graph capturing is out lined here:

https://fb.workplace.com/groups/257735836456307/permalink/545316467698241/

The flow becomes:
```
capture_pre_autograd_graph --> prepare --> convert --> exir.capture
```

As a result, when we capture the converted graphmodule, the source_fn is changed from torch.nn.module to <OpOverload torch.ops.aten.*>(we are recapturing a graphmodule not a torch.nn.module) I believe someone is currently working on the fix for this, but until then we have to add torch.ops.aten.* to our supported modules

Differential Revision: D48488927

