### PR TITLE
Dtype compliance: clamp

### DIFF
--- a/kernels/test/op_clamp_test.cpp
+++ b/kernels/test/op_clamp_test.cpp
@@ -303,12 +303,12 @@ TEST(OpClampOutTest, ByteTensorFloatingPointClampDies) {
 
 #ifndef USE_ATEN_LIB
 TEST(OpClampOutTest, IntTensorTooSmallClampDies) {
-  // Cannot be represented by a uint32_t.
+  // Cannot be represented by a int32_t.
   expect_bad_clamp_value_dies<ScalarType::Int>(-2147483649);
 }
 
 TEST(OpClampOutTest, IntTensorTooLargeClampDies) {
-  // Cannot be represented by a uint32_t.
+  // Cannot be represented by a int32_t.
   expect_bad_clamp_value_dies<ScalarType::Int>(2147483648);
 }
 #endif


### PR DESCRIPTION
Summary:
Reland of D47573238 (Adjusting clamp portable op have near-complete Dtype compliance with aten version), but with the supernova build fixed.

In the original diff, we were doing something like:
```
if isFloatingType(out_type)
     assert (double(min_val) >= out_type_min_value)
```
The problem with this is if out_type is ```long```, then this comparison causes the long min value to be converted to double, which is unsafe. Even though it's impossible for this to happen when running the code due to the if statement, the compiler isn't smart enough to know that, so it was giving errors.

The fix is to wrap these checks within ET_SWITCH_INT_TYPES or ET_SWITCH_FLOAT_TYPES macros within the if statements

Differential Revision: D48491102

