### PR TITLE
Remainder: std::fmod vs aten remainder

### DIFF
--- a/kernels/portable/cpu/op_remainder.cpp
+++ b/kernels/portable/cpu/op_remainder.cpp
@@ -24,7 +24,11 @@ template <
     typename std::enable_if<std::is_floating_point<CTYPE>::value, int>::type =
         0>
 CTYPE remainder_override(CTYPE a, CTYPE b) {
-  return std::fmod(a, b);
+  float rem = std::fmod(a, b);
+  if (((a < 0) ^ (b < 0)) && rem != 0) {
+    rem += b;
+  }
+  return rem;
 }
 
 template <


### PR DESCRIPTION
Summary:
There is a slight difference in how std::fmod (which we use to compute float remainder) works compared to how aten determines remainders.

For ```x mod y```

std::fmod:

(From https://en.cppreference.com/w/cpp/numeric/math/fmod)

> The returned value has the same sign as x and is less than y in magnitude.

On the other hand, aten remainder always matches the sign of y

To correct this, we need to add y to the remainder when one but not both of x and y is negative and the remainder is not 0

Reviewed By: digantdesai

Differential Revision: D48532672

