### PR TITLE
export_example should be python_binary

### DIFF
--- a/examples/export/TARGETS
+++ b/examples/export/TARGETS
@@ -1,3 +1,4 @@
+load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
 python_library(
@@ -10,11 +11,12 @@ python_library(
     ],
 )
 
-python_library(
+python_binary(
     name = "export_example",
     srcs = [
         "export_example.py",
     ],
+    main_module = "executorch.examples.export.export_example",
     deps = [
         ":utils",
         "//executorch/examples/models:models",


### PR DESCRIPTION
Summary: Should be a binary, not library

Reviewed By: dbort

Differential Revision: D48523786

