### PR TITLE
Support graphs which return get_attr nodes directly as output

### DIFF
--- a/exir/tests/test_serde.py
+++ b/exir/tests/test_serde.py
@@ -175,3 +175,20 @@ class TestSerde(unittest.TestCase):
         edge = exir.capture(m, inputs, exir.CaptureConfig()).to_edge()
         edge_new = deserialize(*serialize(edge.exported_program))
         self.check_ep(edge, edge_new, inputs)
+
+    # Get rid of this test once parameters are lifted by default.
+    def test_return_get_attr_as_outputs(self) -> None:
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = torch.ones([1, 1])
+
+            def forward(self, x):
+                return self.a
+
+        m = Model()
+        inputs = (torch.ones([1, 1]),)
+
+        edge = exir.capture(m, inputs, exir.CaptureConfig(pt2_mode=True)).to_edge()
+        edge_new = deserialize(*serialize(edge.exported_program))
+        self.check_ep(edge, edge_new, inputs)


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/107610

Currently serializing graphs which return get_attr's directly as output fails. This diff adds support for that only in EXIR serializer while we still support unlifted params.

Reviewed By: angelayi

Differential Revision: D48258552

