### PR TITLE
Split out :executor_runner_lib

### DIFF
--- a/examples/executor_runner/targets.bzl
+++ b/examples/executor_runner/targets.bzl
@@ -7,6 +7,25 @@ def define_common_targets():
     TARGETS and BUCK files that call this function.
     """
 
+    # Wraps a commandline executable that can be linked against any desired
+    # kernel or backend implementations. Contains a main() function.
+    runtime.cxx_library(
+        name = "executor_runner_lib",
+        srcs = ["executor_runner.cpp"],
+        deps = [
+            "//executorch/runtime/executor:program",
+            "//executorch/extension/data_loader:file_data_loader",
+            "//executorch/util:util",
+        ],
+        external_deps = [
+            "gflags",
+        ],
+        define_static_target = True,
+        visibility = [
+            "//executorch/examples/...",
+        ],
+    )
+
     register_custom_op = native.read_config("executorch", "register_custom_op", "0")
 
     if register_custom_op == "1":
@@ -16,20 +35,18 @@ def define_common_targets():
     else:
         custom_ops_lib = []
 
-    # Test driver for models, uses all portable kernels.
+    # Test driver for models, uses all portable kernels and a demo backend. This
+    # is intended to have minimal dependencies. If you want a runner that links
+    # against a different backend or kernel library, define a new executable
+    # based on :executor_runner_lib.
     runtime.cxx_binary(
         name = "executor_runner",
-        srcs = ["executor_runner.cpp"],
+        srcs = [],
         deps = [
+            ":executor_runner_lib",
             "//executorch/runtime/executor/test:test_backend_compiler_lib",
-            "//executorch/runtime/executor:program",
-            "//executorch/extension/data_loader:file_data_loader",
-            "//executorch/util:util",
             "//executorch/kernels/portable:generated_lib_all_ops",
         ] + custom_ops_lib,
-        external_deps = [
-            "gflags",
-        ],
         define_static_target = True,
         **get_oss_build_kwargs()
     )


### PR DESCRIPTION
Summary: It will be helpful to create other runner targets that link against specific backends or kernel libs. Rather than adding those dependencies to this common target, create a library that can be used to create, e.g., `xnnpack_runner`.

Reviewed By: mcr229, cccclai

Differential Revision: D48579335

