### PR TITLE
Enable quantized ops in fbcode

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -42,7 +42,6 @@ test_model() {
   fi
 }
 
-
 which python
 
 echo "Testing ${MODEL_NAME} with ${BUILD_TOOL}..."
@@ -50,7 +49,15 @@ echo "Testing ${MODEL_NAME} with ${BUILD_TOOL}..."
 test_model
 
 if [[ "${QUANTIZATION}" == true ]]; then
-  bash examples/quantization/test_quantize.sh "${MODEL_NAME}"
+  if [[ "${BUILD_TOOL}" == "buck2" ]]; then
+    bash examples/quantization/test_quantize.sh buck2 "${MODEL_NAME}"
+  elif [[ "${BUILD_TOOL}" == "cmake" ]]; then
+    CMAKE_OUTPUT_DIR=cmake-out
+    bash examples/quantization/test_quantize.sh cmake "${MODEL_NAME}"
+  else
+    echo "Invalid build tool ${BUILD_TOOL}. Only buck2 and cmake are supported atm"
+    exit 1
+  fi
 else
   echo "The model ${MODEL_NAME} doesn't support quantization yet"
 fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,16 +44,14 @@ cmake_minimum_required(VERSION 3.19)
 project(executorch)
 include(build/Utils.cmake)
 
-# option to register custom operator `my_ops::mul3` in
-# `examples/custom_ops/custom_ops_1.py`
-option(REGISTER_EXAMPLE_CUSTOM_OP_1
-       "Register custom operator defined in examples/custom_ops/custom_ops_1.py"
-       OFF)
-# option to register custom operator `my_ops::mul4` in
-# `examples/custom_ops/custom_ops_2.py`
-option(REGISTER_EXAMPLE_CUSTOM_OP_2
-       "Register custom operator defined in examples/custom_ops/custom_ops_2.py"
-       OFF)
+# Option to register custom operator `my_ops::mul3` or `my_ops::mul4` or no
+# custom ops at all. Custom ops are defined in
+# `examples/custom_ops/custom_ops_1.py` and
+# `examples/custom_ops/custom_ops_2.cpp`.
+option(
+  REGISTER_EXAMPLE_CUSTOM_OP
+  "Register whether custom op 1 (my_ops::mul3) or custom op 2 (my_ops::mul4) or no custom op at all."
+  OFF)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if(NOT CMAKE_CXX_STANDARD)
@@ -67,12 +65,7 @@ if(NOT PYTHON_EXECUTABLE)
 endif()
 
 # TODO(dbort): Fix these warnings and remove this flag.
-set(_common_compile_options -Wno-deprecated-declarations)
-
-if(REGISTER_EXAMPLE_CUSTOM_OP_2)
-  # Need to be linked to a shared library
-  list(APPEND _common_compile_options -fPIC)
-endif()
+set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 
 # Let files say "include <executorch/path/to/header.h>".
 set(_common_include_directories ${CMAKE_CURRENT_SOURCE_DIR}/..)
@@ -272,18 +265,19 @@ endif()
 # executor_runner: A simple commandline tool that loads and runs a program file.
 #
 
+set(_libs executorch portable_kernels_bindings gflags)
+
+# Generate custom_ops_lib based on REGISTER_EXAMPLE_CUSTOM_OP
+if(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 1 OR REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples/custom_ops)
+  list(APPEND _libs custom_ops_lib)
+endif()
+
 # ios can only build library but not binary
 if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*ios\.toolchain\.cmake$")
   add_executable(executor_runner ${_executor_runner__srcs})
-  target_link_libraries(executor_runner executorch portable_kernels_bindings
-                        gflags)
+  target_link_libraries(executor_runner ${_libs})
   target_compile_options(executor_runner PUBLIC ${_common_compile_options})
-endif()
-
-# Generate custom_ops_lib based on REGISTER_EXAMPLE_CUSTOM_OPS
-if(REGISTER_EXAMPLE_CUSTOM_OP_1 OR REGISTER_EXAMPLE_CUSTOM_OP_2)
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples/custom_ops)
-  target_link_libraries(executor_runner custom_ops_lib)
 endif()
 
 # Print all summary

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,11 @@ option(
   "Register whether custom op 1 (my_ops::mul3) or custom op 2 (my_ops::mul4) or no custom op at all."
   OFF)
 
+# Option to register quantized ops with quantized kernels. See
+# kernels/quantized/CMakeLists.txt
+option(REGISTER_QUANTIZED_OPS
+       "Register quantized ops defined in kernels/quantized/" OFF)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
@@ -264,13 +269,17 @@ endif()
 #
 # executor_runner: A simple commandline tool that loads and runs a program file.
 #
-
 set(_libs executorch portable_kernels_bindings gflags)
 
 # Generate custom_ops_lib based on REGISTER_EXAMPLE_CUSTOM_OP
 if(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 1 OR REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples/custom_ops)
   list(APPEND _libs custom_ops_lib)
+endif()
+
+# Generate lib to register quantized ops
+if(REGISTER_QUANTIZED_OPS)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/kernels/quantized)
 endif()
 
 # ios can only build library but not binary

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -1,0 +1,131 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This file contains util functions to generate code for kernel registration for
+# both AOT and runtime.
+
+# Selective build. See codegen/tools/gen_oplist.py for how to use these
+# arguments.
+function(gen_selected_ops ops_schema_yaml root_ops include_all_ops)
+  set(_oplist_yaml ${CMAKE_CURRENT_BINARY_DIR}/selected_operators.yaml)
+  file(GLOB_RECURSE _codegen_tools_srcs "${EXECUTORCH_ROOT}/codegen/tools/*.py")
+
+  set(_gen_oplist_command "${PYTHON_EXECUTABLE}" -m codegen.tools.gen_oplist
+                          --output_path=${_oplist_yaml})
+
+  if(ops_schema_yaml)
+    list(APPEND _gen_oplist_command --ops_schema_yaml_path="${ops_schema_yaml}")
+  endif()
+  if(root_ops)
+    list(APPEND _gen_oplist_command --root_ops="${root_ops}")
+  endif()
+  if(include_all_ops)
+    list(APPEND _gen_oplist_command
+         --include_all_operators="${include_all_ops}")
+  endif()
+
+  add_custom_command(
+    COMMENT "Generating selected_operators.yaml for custom ops"
+    OUTPUT ${_oplist_yaml}
+    COMMAND ${_gen_oplist_command}
+    DEPENDS ${ops_schema_yaml} ${_codegen_tools_srcs}
+    WORKING_DIRECTORY ${EXECUTORCH_ROOT})
+
+endfunction()
+
+# Codegen for registering kernels. Kernels are defined in functions_yaml and
+# custom_ops_yaml
+function(generate_bindings_for_kernels functions_yaml custom_ops_yaml)
+  # Command to generate selected_operators.yaml from custom_ops.yaml.
+  file(GLOB_RECURSE _codegen_templates "${EXECUTORCH_ROOT}/codegen/templates/*")
+  file(GLOB_RECURSE _torchgen_srcs "${TORCH_ROOT}/torchgen/*.py")
+  # By default selective build output is selected_operators.yaml
+  set(_oplist_yaml ${CMAKE_CURRENT_BINARY_DIR}/selected_operators.yaml)
+
+  # Command to codegen C++ wrappers to register custom ops to both PyTorch and
+  # Executorch runtime.
+  set(_gen_command
+      "${PYTHON_EXECUTABLE}" -m torchgen.gen_executorch
+      --source-path=${EXECUTORCH_ROOT}/codegen
+      --install-dir=${CMAKE_CURRENT_BINARY_DIR}
+      --tags-path=${TORCH_ROOT}/aten/src/ATen/native/tags.yaml
+      --aten-yaml-path=${TORCH_ROOT}/aten/src/ATen/native/native_functions.yaml
+      --op-selection-yaml-path=${_oplist_yaml})
+
+  set(_gen_command_sources
+      ${CMAKE_CURRENT_BINARY_DIR}/RegisterCodegenUnboxedKernelsEverything.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/Functions.h
+      ${CMAKE_CURRENT_BINARY_DIR}/NativeFunctions.h)
+
+  if(functions_yaml)
+    list(APPEND _gen_command --functions-yaml-path=${functions_yaml})
+  endif()
+  if(custom_ops_yaml)
+    list(APPEND _gen_command --custom-ops-yaml-path=${custom_ops_yaml})
+    list(
+      APPEND
+      _gen_command_sources
+      ${CMAKE_CURRENT_BINARY_DIR}/RegisterCPUCustomOps.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/RegisterSchema.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/CustomOpsNativeFunctions.h)
+  endif()
+
+  add_custom_command(
+    COMMENT "Generating code for kernel registration"
+    OUTPUT ${_gen_command_sources}
+    COMMAND ${_gen_command}
+    DEPENDS ${_oplist_yaml} ${custom_ops_yaml} ${functions_yaml}
+            ${_codegen_templates} ${_torchgen_srcs}
+    WORKING_DIRECTORY ${EXECUTORCH_ROOT})
+  # Make generated file list available in parent scope
+  set(gen_command_sources
+      ${_gen_command_sources}
+      PARENT_SCOPE)
+endfunction()
+
+# Generate an AOT lib for registering custom ops into PyTorch
+function(gen_custom_ops_aot_lib lib_name kernel_sources)
+  add_library(
+    ${lib_name} SHARED
+    ${CMAKE_CURRENT_BINARY_DIR}/RegisterCPUCustomOps.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/RegisterSchema.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/CustomOpsNativeFunctions.h ${kernel_sources})
+  # Find `Torch`.
+  find_package(Torch REQUIRED)
+  target_compile_definitions(${lib_name} PRIVATE USE_ATEN_LIB=1)
+  include_directories(${TORCH_INCLUDE_DIRS})
+  target_link_libraries(${lib_name} PRIVATE torch executorch)
+
+  include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+
+  # Ensure that the load-time constructor functions run. By default, the linker
+  # would remove them since there are no other references to them.
+  if(APPLE)
+    macos_kernel_link_options(${lib_name})
+  else()
+    kernel_link_options(${lib_name})
+  endif()
+endfunction()
+
+# Generate a runtime lib for registering operators in Executorch
+function(gen_operators_lib lib_name kernel_sources)
+  add_library(
+    ${lib_name} SHARED
+    ${CMAKE_CURRENT_BINARY_DIR}/RegisterCodegenUnboxedKernelsEverything.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/Functions.h
+    ${CMAKE_CURRENT_BINARY_DIR}/NativeFunctions.h ${kernel_sources})
+  target_link_libraries(${lib_name} PRIVATE executorch)
+
+  include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+
+  # Ensure that the load-time constructor functions run. By default, the linker
+  # would remove them since there are no other references to them.
+  if(APPLE)
+    macos_kernel_link_options(${lib_name})
+  else()
+    kernel_link_options(${lib_name})
+  endif()
+endfunction()

--- a/examples/custom_ops/CMakeLists.txt
+++ b/examples/custom_ops/CMakeLists.txt
@@ -33,117 +33,37 @@ if(NOT TORCH_ROOT)
 endif()
 
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
 
-# Command to generate selected_operators.yaml from custom_ops.yaml.
-set(_oplist_yaml ${CMAKE_CURRENT_BINARY_DIR}/selected_operators.yaml)
-file(GLOB_RECURSE _codegen_tools_srcs "${EXECUTORCH_ROOT}/codegen/tools/*.py")
-file(GLOB_RECURSE _codegen_templates "${EXECUTORCH_ROOT}/codegen/templates/*")
-file(GLOB_RECURSE _torchgen_srcs "${TORCH_ROOT}/torchgen/*.py")
-
-# Selective build. If we want to register all ops in custom_ops.yaml, do
-# `--ops_schema_yaml_path=${CMAKE_CURRENT_LIST_DIR}/custom_ops.yaml)` instead of
-# `root_ops`
-set(_gen_oplist_command "${PYTHON_EXECUTABLE}" -m codegen.tools.gen_oplist
-                        --output_path=${_oplist_yaml})
-
-if(REGISTER_EXAMPLE_CUSTOM_OP_2)
-  list(APPEND _gen_oplist_command --root_ops="my_ops::mul4.out")
-elseif(REGISTER_EXAMPLE_CUSTOM_OP_1)
-  list(APPEND _gen_oplist_command --root_ops="my_ops::mul3.out")
+# Generate C++ bindings to register kernels into both PyTorch (for AOT) and
+# Executorch (for runtime).
+if(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 1)
+  gen_selected_ops("" "my_ops::mul3.out" "")
+elseif(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
+  gen_selected_ops("" "my_ops::mul4.out" "")
 endif()
+# Expect gen_selected_ops output file to be selected_operators.yaml
+generate_bindings_for_kernels("" ${CMAKE_CURRENT_LIST_DIR}/custom_ops.yaml)
+message("Generated files ${gen_command_sources}")
 
-# Command to codegen C++ wrappers to register custom ops to both PyTorch and
-# Executorch runtime.
-set(_gen_command
-    "${PYTHON_EXECUTABLE}" -m torchgen.gen_executorch
-    --source-path=${EXECUTORCH_ROOT}/codegen
-    --install-dir=${CMAKE_CURRENT_BINARY_DIR}
-    --tags-path=${TORCH_ROOT}/aten/src/ATen/native/tags.yaml
-    --aten-yaml-path=${TORCH_ROOT}/aten/src/ATen/native/native_functions.yaml
-    --op-selection-yaml-path=${_oplist_yaml}
-    --custom-ops-yaml-path=${CMAKE_CURRENT_LIST_DIR}/custom_ops.yaml)
-
-set(_gen_command_sources
-    ${CMAKE_CURRENT_BINARY_DIR}/RegisterCodegenUnboxedKernelsEverything.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/RegisterCPUCustomOps.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/RegisterSchema.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/Functions.h
-    ${CMAKE_CURRENT_BINARY_DIR}/NativeFunctions.h
-    ${CMAKE_CURRENT_BINARY_DIR}/CustomOpsNativeFunctions.h)
-message(STATUS "Generating selected operator list ${_gen_oplist_command}")
-
-add_custom_command(
-  COMMENT "Generating selected_operators.yaml for custom ops"
-  OUTPUT ${_oplist_yaml}
-  COMMAND ${_gen_oplist_command}
-  DEPENDS ${CMAKE_CURRENT_LIST_DIR}/custom_ops.yaml ${_codegen_tools_srcs}
-  WORKING_DIRECTORY ${EXECUTORCH_ROOT})
-
-add_custom_command(
-  COMMENT "Generating code for custom operator registration"
-  OUTPUT ${_gen_command_sources}
-  COMMAND ${_gen_command}
-  DEPENDS ${_oplist_yaml} ${CMAKE_CURRENT_LIST_DIR}/custom_ops.yaml
-          ${_codegen_templates} ${_torchgen_srcs}
-  WORKING_DIRECTORY ${EXECUTORCH_ROOT})
 # Prepare for C++ libraries.
 
-# 1. C++ library to register custom ops into PyTorch.
-if(REGISTER_EXAMPLE_CUSTOM_OP_2)
-  add_library(
-    custom_ops_aot_lib SHARED
-    ${CMAKE_CURRENT_BINARY_DIR}/RegisterCPUCustomOps.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/RegisterSchema.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/CustomOpsNativeFunctions.h
-    ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2.cpp # register my_ops::mul4
-    ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2_out.cpp # register my_ops::mul4.out
+# C++ library to register custom ops into PyTorch.
+if(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
+  set(custom_ops_kernel_sources
+      ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2.cpp # register my_ops::mul4
+      ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2_out.cpp # register
+      # my_ops::mul4.out)
   )
-  # Find `Torch`.
-  find_package(Torch REQUIRED)
-  # ATen mode is on
-  target_compile_definitions(custom_ops_aot_lib PRIVATE USE_ATEN_LIB=1)
+  gen_custom_ops_aot_lib("custom_ops_aot_lib" "${custom_ops_kernel_sources}")
   target_include_directories(custom_ops_aot_lib
                              PUBLIC ${_common_include_directories})
-  include_directories(${TORCH_INCLUDE_DIRS})
-
-  target_link_libraries(custom_ops_aot_lib PRIVATE torch executorch)
-
-  # Ensure that the load-time constructor functions run. By default, the linker
-  # would remove them since there are no other references to them.
-  if(APPLE)
-    macos_kernel_link_options("custom_ops_aot_lib")
-  else()
-    kernel_link_options("custom_ops_aot_lib")
-  endif()
 endif()
 
-# 1. C++ library to register custom ops into Executorch runtime.
-add_library(custom_ops_lib)
-target_sources(
-  custom_ops_lib
-  PRIVATE
-    ${CMAKE_CURRENT_BINARY_DIR}/RegisterCodegenUnboxedKernelsEverything.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/Functions.h
-    ${CMAKE_CURRENT_BINARY_DIR}/NativeFunctions.h
-    ${CMAKE_CURRENT_BINARY_DIR}/CustomOpsNativeFunctions.h)
-if(REGISTER_EXAMPLE_CUSTOM_OP_1)
-  target_sources(custom_ops_lib
-                 PRIVATE ${CMAKE_CURRENT_LIST_DIR}/custom_ops_1_out.cpp)
-elseif(REGISTER_EXAMPLE_CUSTOM_OP_2)
-  target_sources(custom_ops_lib
-                 PRIVATE ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2_out.cpp)
+# C++ library to register custom ops into Executorch runtime.
+if(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 1)
+  set(kernel_sources ${CMAKE_CURRENT_LIST_DIR}/custom_ops_1_out.cpp)
+elseif(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
+  set(kernel_sources ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2_out.cpp)
 endif()
-
-target_link_libraries(custom_ops_lib PRIVATE executorch)
-
-# Ensure that the load-time constructor functions run. By default, the linker
-# would remove them since there are no other references to them.
-if((CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
-   OR (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
-  target_link_options(custom_ops_lib INTERFACE
-                      "-Wl,-force_load,$<TARGET_FILE:custom_ops_lib>")
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-  target_link_options(
-    custom_ops_lib INTERFACE
-    "-Wl,--whole-archive,$<TARGET_FILE:custom_ops_lib>,--no-whole-archive")
-endif()
+gen_operators_lib("custom_ops_lib" "${kernel_sources}")

--- a/examples/custom_ops/custom_ops_1.py
+++ b/examples/custom_ops/custom_ops_1.py
@@ -29,8 +29,8 @@ my_op_lib.define(
 
 @impl(my_op_lib, "mul3.out", dispatch_key="CompositeExplicitAutograd")
 def mul3_out_impl(a: torch.Tensor, *, out: torch.Tensor) -> torch.Tensor:
-    a.mul_(3)
     out.copy_(a)
+    out.mul_(3)
     return out
 
 

--- a/examples/custom_ops/test_custom_ops.sh
+++ b/examples/custom_ops/test_custom_ops.sh
@@ -35,7 +35,7 @@ test_cmake_custom_op_1() {
     && mkdir cmake-out \
     && cd cmake-out \
     && cmake -DBUCK2=buck2 \
-        -DREGISTER_EXAMPLE_CUSTOM_OP_1=ON \
+        -DREGISTER_EXAMPLE_CUSTOM_OP=1 \
         -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
 
   echo 'Building executor_runner'
@@ -86,7 +86,7 @@ test_cmake_custom_op_2() {
     && mkdir cmake-out \
     && cd cmake-out \
     && cmake -DBUCK2=buck2 \
-      -DREGISTER_EXAMPLE_CUSTOM_OP_2=ON \
+      -DREGISTER_EXAMPLE_CUSTOM_OP=2 \
       -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
       -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
 

--- a/examples/quantization/TARGETS
+++ b/examples/quantization/TARGETS
@@ -3,8 +3,10 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 runtime.python_binary(
     name = "example",
     main_src = "example.py",
+    preload_deps = ["//executorch/kernels/quantized:aot_lib"],
     deps = [
         "//caffe2:torch",
+        "//executorch/examples/export:export_example",
         "//executorch/examples/models:models",
     ],
 )

--- a/examples/quantization/test_quantize.sh
+++ b/examples/quantization/test_quantize.sh
@@ -9,13 +9,62 @@
 
 set -e
 
-# TODO(larryliu0820): Add CMake build
+get_shared_lib_ext() {
+  UNAME=$(uname)
+  if [[ $UNAME == "Darwin" ]];
+  then
+    EXT=".dylib"
+  elif [[ $UNAME == "Linux" ]];
+  then
+    EXT=".so"
+  else
+    echo "Unsupported platform $UNAME"
+    exit 1
+  fi
+  echo $EXT
+}
+
 test_buck2_quantization() {
   echo "Building quantized ops shared library"
   SO_LIB=$(buck2 build //kernels/quantized:aot_lib --show-output | grep "buck-out" | cut -d" " -f2)
 
   echo "Run example.py"
-  python -m "examples.quantization.example" --so_library="$SO_LIB" --model_name="$1"
+  ${PYTHON_EXECUTABLE} -m "examples.quantization.example" --so_library="$SO_LIB" --model_name="$1"
 }
 
-test_buck2_quantization "$1"
+test_cmake_quantization() {
+  echo "Building quantized ops shared library"
+  SITE_PACKAGES="$(${PYTHON_EXECUTABLE} -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')"
+  CMAKE_PREFIX_PATH="${SITE_PACKAGES}/torch"
+
+  (rm -rf cmake-out \
+    && mkdir cmake-out \
+    && cd cmake-out \
+    && cmake -DBUCK2=buck2 \
+      -DREGISTER_QUANTIZED_OPS=ON \
+      -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
+      -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
+
+  cmake --build cmake-out -j4
+
+  EXT=$(get_shared_lib_ext)
+  SO_LIB="cmake-out/kernels/quantized/libquantized_ops_aot_lib$EXT"
+
+  echo "Run example.py, shared library $SO_LIB"
+  ${PYTHON_EXECUTABLE} -m "examples.quantization.example" --so_library="$SO_LIB" --model_name="$1"
+}
+
+if [[ -z $PYTHON_EXECUTABLE ]];
+then
+  PYTHON_EXECUTABLE=python3
+fi
+if [[ "$1" == "cmake" ]];
+then
+  test_cmake_quantization "$2"
+elif [[ "$1" == "buck2" ]];
+then
+  test_buck2_quantization "$2"
+else
+  test_cmake_quantization "$2"
+  test_buck2_quantization "$2"
+fi

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -1,0 +1,56 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Kernel library for quantized operators. Please this file formatted by running:
+# ~~~
+# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# ~~~
+cmake_minimum_required(VERSION 3.19)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(NOT PYTHON_EXECUTABLE)
+  set(PYTHON_EXECUTABLE python3)
+endif()
+# Source root directory for executorch.
+if(NOT EXECUTORCH_ROOT)
+  set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+endif()
+# Source root directory for pytorch.
+if(NOT TORCH_ROOT)
+  set(TORCH_ROOT ${EXECUTORCH_ROOT}/third-party/pytorch)
+endif()
+
+set(_common_compile_options -Wno-deprecated-declarations)
+
+include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
+# Quantized ops kernel sources TODO(larryliu0820): use buck2 to gather the
+# sources
+file(GLOB_RECURSE _quantized_kernels__srcs
+     "${CMAKE_CURRENT_SOURCE_DIR}/cpu/*.cpp")
+# Generate C++ bindings to register kernels into both PyTorch (for AOT) and
+# Executorch (for runtime). Here select all ops in quantized.yaml
+gen_selected_ops("${CMAKE_CURRENT_LIST_DIR}/quantized.yaml" "" "")
+# Expect gen_selected_ops output file to be selected_operators.yaml
+generate_bindings_for_kernels("" ${CMAKE_CURRENT_SOURCE_DIR}/quantized.yaml)
+message("Generated files ${gen_command_sources}")
+
+# Build a AOT library to register quantized ops into PyTorch.
+set(_quantized_sources
+    ${_quantized_kernels__srcs}
+    ${EXECUTORCH_ROOT}/runtime/core/exec_aten/util/tensor_util_aten.cpp # This is a
+    # hack
+)
+gen_custom_ops_aot_lib("quantized_ops_aot_lib" "${_quantized_sources}")
+
+# Build a library for _quantized_kernels_srcs
+#
+# quantized_kernels: Pure-C++ kernel library for quantized ops
+gen_operators_lib("quantized_kernels" "${_quantized_kernels__srcs}")


### PR DESCRIPTION
Summary: Internally we can use `preload_deps` to load shared libray, so that our quantized ops can be registered.

Reviewed By: jerryzh168

Differential Revision: D48584235

