### PR TITLE
Enable IR validity check

### DIFF
--- a/examples/export/utils.py
+++ b/examples/export/utils.py
@@ -12,15 +12,10 @@ import executorch.exir as exir
 # and when evaulating shape, it doesnt seem that we presenting them with shape env
 # that contain those variables.
 _CAPTURE_CONFIG = exir.CaptureConfig(enable_aot=True)
-_EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(
-    _check_ir_validity=False,
-)
 
 
 def export_to_edge(model, example_inputs):
     m = model.eval()
-    edge = exir.capture(m, example_inputs, _CAPTURE_CONFIG).to_edge(
-        _EDGE_COMPILE_CONFIG
-    )
+    edge = exir.capture(m, example_inputs, _CAPTURE_CONFIG).to_edge()
     print("Exported graph:\n", edge.exported_program.graph)
     return edge


### PR DESCRIPTION
Summary:
For the models in example (MV2, MV3, IC3, IC4, VIT, W2L) we have core IR coverage.

Export should work without `_check_ir_validity=False`.  Runtime ops can be covered by portable lib.

Will follow up with other `_check_ir_validity=False` use cases later.

Reviewed By: larryliu0820

Differential Revision: D48578050

