### PR TITLE
Pybindings Module is more flexible with non_const set ups

### DIFF
--- a/exir/backend/test/test_backends.py
+++ b/exir/backend/test/test_backends.py
@@ -345,7 +345,7 @@ class TestBackends(unittest.TestCase):
     def test_backend_with_compiler_out_of_range(self, extract_segments: bool):
         with self.assertRaisesRegex(
             RuntimeError,
-            "initializing executor for method forward failed with error 0x:12",
+            "loading method forward failed with error 0x12",
         ):
             self.run_model_in_unsupported_backend(extract_segments=extract_segments)
 

--- a/exir/backend/test/test_backends_lifted.py
+++ b/exir/backend/test/test_backends_lifted.py
@@ -354,7 +354,7 @@ class TestBackends(unittest.TestCase):
     def test_backend_with_compiler_out_of_range(self, extract_segments: bool):
         with self.assertRaisesRegex(
             RuntimeError,
-            "initializing executor for method forward failed with error 0x:12",
+            "loading method forward failed with error 0x12",
         ):
             self.run_model_in_unsupported_backend(extract_segments=extract_segments)
 

--- a/extension/pybindings/TARGETS
+++ b/extension/pybindings/TARGETS
@@ -2,7 +2,7 @@
 # Any targets that should be shared between fbcode and xplat must be defined in
 # targets.bzl. This file can contain fbcode-only targets.
 
-load("@fbcode//executorch/extension/pybindings:targets.bzl", "MODELS_ATEN_OPS_ATEN_MODE_GENERATED_LIB", "MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB", "MODULE_DEPS", "define_common_targets", "executorch_pybindings")
+load("@fbcode//executorch/extension/pybindings:targets.bzl", "ATEN_MODULE_DEPS", "MODELS_ATEN_OPS_ATEN_MODE_GENERATED_LIB", "MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB", "PORTABLE_MODULE_DEPS", "define_common_targets", "executorch_pybindings")
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
 define_common_targets()
@@ -11,7 +11,7 @@ executorch_pybindings(
     srcs = [
         "module.cpp",
     ],
-    cppdeps = MODULE_DEPS,
+    cppdeps = PORTABLE_MODULE_DEPS,
     python_module_name = "core",
     visibility = ["PUBLIC"],
 )
@@ -20,7 +20,7 @@ executorch_pybindings(
     srcs = [
         "module.cpp",
     ],
-    cppdeps = MODULE_DEPS + MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB,
+    cppdeps = PORTABLE_MODULE_DEPS + MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB,
     python_module_name = "portable",
     visibility = ["PUBLIC"],
 )
@@ -29,20 +29,7 @@ executorch_pybindings(
     srcs = [
         "module.cpp",
     ],
-    cppdeps = [
-        "//executorch/runtime/kernel:operator_registry",
-        "//executorch/runtime/executor:executor_aten",
-        "//executorch/runtime/core/exec_aten:lib",
-        "//executorch/schema:bundled_program_schema",
-        "//executorch/schema:program",
-        "//executorch/extension/data_loader:buffer_data_loader",
-        "//executorch/extension/data_loader:mmap_data_loader",
-        "//executorch/util:read_file",
-        "//executorch/util:test_memory_config",
-        "//executorch/util:bundled_program_verification_aten",
-        "//caffe2:torch-cpp",
-        "//executorch/runtime/executor/test:test_backend_compiler_lib_aten",
-    ] + MODELS_ATEN_OPS_ATEN_MODE_GENERATED_LIB,
+    cppdeps = ATEN_MODULE_DEPS + MODELS_ATEN_OPS_ATEN_MODE_GENERATED_LIB,
     python_module_name = "aten_mode_lib",
     visibility = ["PUBLIC"],
 )

--- a/extension/pybindings/module.cpp
+++ b/extension/pybindings/module.cpp
@@ -114,10 +114,6 @@ class Module final {
     return run_method("forward", std::forward<Types>(args)...);
   }
 
-  void set_delete_memory(std::shared_ptr<char> mem_to_delete) {
-    mem_to_delete_ = mem_to_delete;
-  }
-
  private:
   run_method_return_type run_method_internal(
       const std::string& method_name,
@@ -164,22 +160,10 @@ class Module final {
     return result;
   }
 
-  std::shared_ptr<char> mem_to_delete_; // loader_ may point to this.
   std::unique_ptr<DataLoader> loader_; // program_ points to this.
   std::unique_ptr<const Program> program_; // methods_ entries points to this.
   std::unordered_map<std::string, std::unique_ptr<Method>> methods_;
 };
-
-inline std::unique_ptr<Module> load_from_buffer(
-    std::shared_ptr<char> ptr,
-    size_t ptr_len,
-    MemoryManager* memory_manager) {
-  EXECUTORCH_SCOPE_PROF("load_from_buffer");
-  auto loader = std::make_unique<BufferDataLoader>(ptr.get(), ptr_len);
-  auto m = std::make_unique<Module>(std::move(loader), memory_manager);
-  m->set_delete_memory(std::move(ptr));
-  return m;
-}
 
 inline std::unique_ptr<Module> load_from_buffer(
     const void* ptr,

--- a/extension/pybindings/targets.bzl
+++ b/extension/pybindings/targets.bzl
@@ -6,7 +6,7 @@ MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB = [
     "//executorch/kernels/portable:generated_lib",
 ]
 
-MODULE_DEPS = [
+PORTABLE_MODULE_DEPS = [
     "//caffe2:ATen",
     "//caffe2:torch",
     "//caffe2:torch_extension",
@@ -18,10 +18,27 @@ MODULE_DEPS = [
     "//executorch/util:bundled_program_verification",
     "//executorch/extension/data_loader:buffer_data_loader",
     "//executorch/extension/data_loader:mmap_data_loader",
+    "//executorch/extension/memory_allocator:malloc_memory_allocator",
     "//executorch/util:test_memory_config",
     "//executorch/util:util",
     "//executorch/runtime/executor/test:test_backend_compiler_lib",
 ] + get_all_cpu_backend_targets()
+
+ATEN_MODULE_DEPS = [
+    "//executorch/runtime/kernel:operator_registry",
+    "//executorch/runtime/executor:executor_aten",
+    "//executorch/runtime/core/exec_aten:lib",
+    "//executorch/schema:bundled_program_schema",
+    "//executorch/schema:program",
+    "//executorch/extension/data_loader:buffer_data_loader",
+    "//executorch/extension/data_loader:mmap_data_loader",
+    "//executorch/extension/memory_allocator:malloc_memory_allocator",
+    "//executorch/util:read_file",
+    "//executorch/util:test_memory_config",
+    "//executorch/util:bundled_program_verification_aten",
+    "//caffe2:torch-cpp",
+    "//executorch/runtime/executor/test:test_backend_compiler_lib_aten",
+]
 
 # Generated lib for all ATen ops with aten kernel used by models in model inventory
 MODELS_ATEN_OPS_ATEN_MODE_GENERATED_LIB = [


### PR DESCRIPTION
Summary: Made the module handle models with more then one non_const buffer level, and made it allocate the needed memory dynamically rather then relying on static constants which historically have needed to be updated a ton.

Differential Revision: D48583639

