### PR TITLE
Introduce a new interface in lib.py and the ETInspector class

### DIFF
--- a/sdk/TARGETS
+++ b/sdk/TARGETS
@@ -12,6 +12,7 @@ python_library(
     deps = [
         "//executorch/sdk/edir:et_schema",
         "//executorch/sdk/etdb:etdb",
+        "//executorch/sdk/etdb:inspector",
         "//executorch/sdk/etrecord:etrecord",
     ],
 )
@@ -23,6 +24,7 @@ python_binary(
     deps = [
         "//executorch/sdk/edir:et_schema",
         "//executorch/sdk/etdb:etdb",
+        "//executorch/sdk/etdb:inspector",
         "//executorch/sdk/etrecord:etrecord",
     ],
 )

--- a/sdk/etdb/TARGETS
+++ b/sdk/etdb/TARGETS
@@ -25,3 +25,14 @@ python_library(
         "//executorch/sdk/edir:et_schema",
     ],
 )
+
+python_library(
+    name = "inspector",
+    srcs = [
+        "inspector.py",
+    ],
+    deps = [
+        "fbsource//third-party/pypi/pandas:pandas",
+        "//executorch/sdk/edir:et_schema",
+    ],
+)

--- a/sdk/etdb/inspector.py
+++ b/sdk/etdb/inspector.py
@@ -1,0 +1,105 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from typing import Mapping, Optional
+
+from executorch.sdk.edir.et_schema import InferenceRun, OperatorGraphWithStats
+from pandas import DataFrame
+
+
+class Inspector:
+
+    """
+    APIs for examining model architecture and performance stats
+    """
+
+    def __init__(
+        self,
+        op_graph_dict: Mapping[str, OperatorGraphWithStats],
+        show_stack_trace: Optional[bool] = False,
+        verbose: Optional[bool] = False,
+    ) -> None:
+        """
+        Constructor that returns a Debugger instance from a dict of OperatorGraph instances and some optional parameters
+        """
+        # Save the parameters into class members
+        self.op_graph_dict = op_graph_dict
+        self.show_stack_trace = show_stack_trace
+        self.verbose = verbose
+
+        # Construct the initial tables and save in class members
+        self.architecture_table = self._gen_architecture_table()
+        self.high_level_profile_info_table = self._gen_high_level_profile_info_table()
+
+    def attach_etdump(self, etdump_path: str) -> None:
+        """
+        API that attaches ETDump to this inspector instance
+        """
+        op_graph = self.op_graph_dict["et_dialect_graph_module/forward"]
+
+        if os.path.exists(etdump_path):
+            op_graph.attach_metadata(
+                inference_run=InferenceRun.extract_runs_from_path(
+                    file_path=etdump_path
+                )[0]
+            )
+        else:
+            raise Exception("Invalid ET Dump path")
+
+    def get_high_level_profile_info_table(self) -> DataFrame:
+        """
+        API that returns the high level profile information table from class member
+        """
+        return self.high_level_profile_info_table
+
+    def get_architecture_table(self) -> DataFrame:
+        """
+        API that returns the architecture table from class member, filtered by user options (e.g. self.show_stack_trace)
+        """
+        # TODO: filter based on user options (self.show_stack_trace) before return
+        return self.architecture_table
+
+    def cli_flow(self):
+        """
+        API that enters the CLI debugging flow
+        """
+        print("Entering the CLI debugging flow...")
+
+        print("High level profile information table:")
+        print(self.get_high_level_profile_info_table())
+        print("Architecture table:")
+        print(self.get_architecture_table())
+
+        # TODO: Take user commands, process by calling other APIs in the Inspector class
+
+    def select_by_instance_id(self, instance_id: str) -> DataFrame:
+        """
+        API that returns a DataFrame containing information for a specific instance id
+        """
+        # TODO: filter the architecture table by the instance id before return
+        return self.architecture_table
+
+    def select_by_instance_type(self, instance_type: str) -> DataFrame:
+        """
+        API that returns a DataFrame containing instances with the given instance type
+        """
+        # TODO: filter the architecture table by the instance type before return
+        return self.architecture_table
+
+    def _gen_high_level_profile_info_table(self) -> DataFrame:
+        """
+        Private helper function that generates the high level profile information table
+        """
+        # TODO: implement
+        pass
+
+    def _gen_architecture_table(self) -> DataFrame:
+        """
+        Private helper function that generates the architecture table
+        """
+        # TODO: implement
+        pass


### PR DESCRIPTION
Summary:
## About this stack
To upgrade the SDK debugger so that it offers not only the CLI experience, but also public APIs that return DataFrames containing model architecture info and profiling stats info.
Once this tool is in a usable state, we can migrate the new logic to the internal flow (executorch/sdk/fb/lib.py)

## About this diff
Define the skeleton of the ETInspector class (including all the high-pri APIs). In lib.py, defines the APIs that initialize an ETInspector.
Note that this diff basically turns the CLI useless temporarily. No one is using the CLI rn so it should be fine.

## Next
Define the DataFrame schemas

Reviewed By: Jack-Khuu

Differential Revision: D48456830

