### PR TITLE
Store the arguments used to trace the exported program in itself

### DIFF
--- a/exir/backend/backend_api.py
+++ b/exir/backend/backend_api.py
@@ -302,6 +302,7 @@ def _(
         copy.deepcopy(edge_program.range_constraints),
         copy.deepcopy(edge_program.equality_constraints),
         copy.deepcopy(edge_program.module_call_graph),
+        (),
     )
 
 

--- a/exir/capture/_capture.py
+++ b/exir/capture/_capture.py
@@ -213,6 +213,7 @@ def capture(
         {},
         [],
         [],
+        (),
     )
     return ExirExportedProgram(ep, False)
 

--- a/exir/lowered_backend_module.py
+++ b/exir/lowered_backend_module.py
@@ -253,6 +253,7 @@ def create_exported_program_from_submodule(
         range_constraints=copy.deepcopy(owning_program.range_constraints),
         equality_constraints=[],
         module_call_graph=[],
+        original_traced_arguments=(),
     )
 
 

--- a/sdk/etrecord/_etrecord.py
+++ b/sdk/etrecord/_etrecord.py
@@ -38,7 +38,7 @@ def _handle_exported_program(
     etrecord_zip: ZipFile, module_name: str, method_name: str, ep: ExportedProgram
 ) -> None:
     assert isinstance(ep, ExportedProgram)
-    serialized_ep, serialized_state_dict = serialize(ep)
+    serialized_ep, serialized_state_dict, _ = serialize(ep)
     etrecord_zip.writestr(f"{module_name}/{method_name}", serialized_ep)
     etrecord_zip.writestr(
         f"{module_name}/{method_name}_state_dict", serialized_state_dict
@@ -217,6 +217,7 @@ def parse_etrecord(etrecord_path: str) -> ETRecord:
         graph_map[serialized_file] = deserialize(
             etrecord_zip.read(serialized_file),
             etrecord_zip.read(serialized_state_dict_file),
+            b"",
         )
 
     return ETRecord(


### PR DESCRIPTION
Summary: Continuation of https://github.com/pytorch/pytorch/pull/107704

Differential Revision: D48637348

