### PR TITLE
Add proper error message when shared library is missing

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -60,9 +60,17 @@ Here is the [Quantization Flow Docs](/docs/website/docs/tutorials/quantization_f
 
 You can run quantization test with the following command:
 ```bash
-python3 -m examples.quantization.example --model_name "mv2" # for MobileNetv2
+python3 -m examples.quantization.example --model_name "mv2" --so-library "<path/to/so/lib>" # for MobileNetv2
 ```
-It will print both the original model after capture and quantized model.
+
+Note that the shared library being passed into `example.py` is required to register the out variants of the quantized operators (e.g., `quantized_decomposed::add.out`)into EXIR. To build this library, run the following command if using buck2:
+```bash
+buck2 build //kernels/quantized:aot_lib --show-output
+```
+
+If on cmake, follow the instructions in `test_quantize.sh` to build it, the default path is `cmake-out/kernels/quantized/libquantized_ops_lib.so`.
+
+This command will print both the original model after capture and quantized model.
 
 The flow produces a quantized model that could be lowered through partitioner or the runtime directly.
 

--- a/examples/custom_ops/custom_ops_2.py
+++ b/examples/custom_ops/custom_ops_2.py
@@ -37,7 +37,24 @@ if __name__ == "__main__":
         help="Provide path to so library. E.g., cmake-out/examples/custom_ops/libcustom_ops_aot_lib.so",
     )
     args = parser.parse_args()
-    torch.ops.load_library(args.so_library)
+    # See if we have custom op my_ops::mul4.out registered
+    has_out_ops = True
+    try:
+        op = torch.ops.my_ops.mul4.out
+    except AttributeError:
+        print("No registered custom op my_ops::mul4.out")
+        has_out_ops = False
+    if not has_out_ops:
+        if args.so_library:
+            torch.ops.load_library(args.so_library)
+        else:
+            raise RuntimeError(
+                "Need to specify shared library path to register custom op my_ops::mul4.out into"
+                "EXIR. The required shared library is defined as `custom_ops_aot_lib` in "
+                "examples/custom_ops/CMakeLists.txt if you are using CMake build, or `custom_ops_aot_lib_2` in "
+                "examples/custom_ops/targets.bzl for buck2. One example path would be cmake-out/examples/custom_ops/"
+                "libcustom_ops_aot_lib.[so|dylib]."
+            )
     print(args.so_library)
 
     main()

--- a/examples/quantization/test_quantize.sh
+++ b/examples/quantization/test_quantize.sh
@@ -7,7 +7,7 @@
 
 # Test the end-to-end quantization flow.
 
-set -eu
+set -e
 
 get_shared_lib_ext() {
   UNAME=$(uname)


### PR DESCRIPTION
Summary: Make sure the user has good enough error message, when they don't pass in the shared library for registering out operators.

Reviewed By: guangy10

Differential Revision: D48664907

