### PR TITLE
Fix fbcode buck run quantize example

### DIFF
--- a/examples/export/TARGETS
+++ b/examples/export/TARGETS
@@ -11,15 +11,22 @@ python_library(
     ],
 )
 
-python_binary(
-    name = "export_example",
+python_library(
+    name = "lib",
     srcs = [
         "export_example.py",
     ],
-    main_module = "executorch.examples.export.export_example",
     deps = [
         ":utils",
         "//executorch/examples/models:models",
         "//executorch/exir:lib",
+    ],
+)
+
+python_binary(
+    name = "export_example",
+    main_module = "executorch.examples.export.export_example",
+    deps = [
+        ":lib",
     ],
 )

--- a/examples/quantization/TARGETS
+++ b/examples/quantization/TARGETS
@@ -7,7 +7,7 @@ runtime.python_binary(
     deps = [
         ":quant_utils",
         "//caffe2:torch",
-        "//executorch/examples/export:export_example",
+        "//executorch/examples/export:lib",
         "//executorch/examples/models:models",
     ],
 )


### PR DESCRIPTION
Summary: Need to depend on a library instead of a binary. Adding executorch/examples/export:lib for this purpose.

Reviewed By: jerryzh168

Differential Revision: D48667036

