### PR TITLE
Make the core runtime C++11/14/17/20 compatible

### DIFF
--- a/runtime/core/array_ref.h
+++ b/runtime/core/array_ref.h
@@ -80,8 +80,7 @@ class ArrayRef final {
       : Data(&OneElt), Length(1) {}
 
   /// Construct a ArrayRef from a pointer and length.
-  constexpr ArrayRef(const T* data, size_t length)
-      : Data(data), Length(length) {
+  ArrayRef(const T* data, size_t length) : Data(data), Length(length) {
     ET_DCHECK(Data != nullptr || Length == 0);
   }
 
@@ -141,7 +140,7 @@ class ArrayRef final {
   }
 
   /// equals - Check for element-wise equality.
-  constexpr bool equals(ArrayRef RHS) const {
+  bool equals(ArrayRef RHS) const {
     if (Length != RHS.Length) {
       return false;
     }

--- a/runtime/core/exec_aten/exec_aten.h
+++ b/runtime/core/exec_aten/exec_aten.h
@@ -118,7 +118,7 @@ using IntArrayRef = torch::executor::IntArrayRef;
 
 #endif // Use executor types
 
-inline constexpr nullopt_t nullopt{0};
+static constexpr nullopt_t nullopt{0};
 
 } // namespace exec_aten
 namespace torch {

--- a/runtime/core/portable_type/scalar.h
+++ b/runtime/core/portable_type/scalar.h
@@ -29,7 +29,7 @@ class Scalar {
 
   template <
       typename T,
-      std::enable_if_t<std::is_integral<T>::value, bool> = true>
+      typename std::enable_if<std::is_integral<T>::value, bool>::type = true>
   /*implicit*/ Scalar(T val) : tag(Tag::Int) {
     v.as_int = static_cast<int64_t>(val);
   }

--- a/runtime/core/portable_type/string_view.h
+++ b/runtime/core/portable_type/string_view.h
@@ -109,18 +109,18 @@ class basic_string_view final {
     return size() == 0;
   }
 
-  constexpr void remove_prefix(size_type n) {
+  void remove_prefix(size_type n) {
     ET_CHECK_MSG(n > size(), "basic_string_view::remove_prefix: out of range.");
     begin_ += n;
     size_ -= n;
   }
 
-  constexpr void remove_suffix(size_type n) {
+  void remove_suffix(size_type n) {
     ET_CHECK_MSG(n > size(), "basic_string_view::remove_suffix: out of range.");
     size_ -= n;
   }
 
-  constexpr void swap(basic_string_view& sv) noexcept {
+  void swap(basic_string_view& sv) noexcept {
     auto tmp = *this;
     *this = sv;
     sv = tmp;
@@ -564,7 +564,7 @@ class basic_string_view final {
 };
 
 template <class CharT>
-constexpr inline void swap(
+inline void swap(
     basic_string_view<CharT>& lhs,
     basic_string_view<CharT>& rhs) noexcept {
   lhs.swap(rhs);

--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -21,13 +21,10 @@ namespace torch {
 namespace executor {
 
 namespace {
-
 /**
  * Compute the number of elements based on the sizes of a tensor.
  */
-constexpr ssize_t compute_numel(
-    const TensorImpl::SizesType* sizes,
-    ssize_t dim) {
+ssize_t compute_numel(const TensorImpl::SizesType* sizes, ssize_t dim) {
   ssize_t n = 1;
   for (ssize_t i = 0; i < dim; i++) {
     n *= sizes[i];

--- a/runtime/core/span.h
+++ b/runtime/core/span.h
@@ -43,7 +43,7 @@ class Span final {
   /* implicit */ constexpr Span() noexcept : data_(nullptr), length_(0) {}
 
   /// Construct a Span from a pointer and length.
-  constexpr Span(T* data, size_t length) : data_(data), length_(length) {
+  Span(T* data, size_t length) : data_(data), length_(length) {
     ET_DCHECK(data_ != nullptr || length_ == 0);
   }
 

--- a/runtime/kernel/kernel_runtime_context.h
+++ b/runtime/kernel/kernel_runtime_context.h
@@ -59,6 +59,8 @@ class KernelRuntimeContext {
 namespace exec_aten {
 using RuntimeContext = torch::executor::KernelRuntimeContext;
 } // namespace exec_aten
-namespace torch::executor {
+namespace torch {
+namespace executor {
 using RuntimeContext = torch::executor::KernelRuntimeContext;
-} // namespace torch::executor
+} // namespace executor
+} // namespace torch

--- a/schema/extended_header.cpp
+++ b/schema/extended_header.cpp
@@ -91,5 +91,8 @@ uint64_t GetUInt64LE(const uint8_t* data) {
   };
 }
 
+// Define storage for the static.
+constexpr char ExtendedHeader::kMagic[kMagicSize];
+
 } // namespace executor
 } // namespace torch


### PR DESCRIPTION
Summary:
Tweak the core runtime code to build cleanly with C++11 as well as with more recent versions.

This only covers non-test targets under //executorch/runtime, enough to build `:size_test`.

While doing this I removed a bunch of `constexpr` from methods on `ArrayRef` and `string_view`, because C++11 was more strict about what's allowed in them. While they're useful on general-purpose implementations of those types, we never do static comparison of array or string instances, so it doesn't help us. Not worth the complexity of adding `#ifdef`s to change the behavior depending on the C++ version.

A lot of the template changes deal with the lack of `<base>_t` templates in C++11. Most of them are of the form
```
template<class T>
using BASE_t = typename BASE<T>::type;
```
so the fix was to inline that pattern: add `typename` to the front and `::type` to the end.

Reviewed By: larryliu0820

Differential Revision: D48665438

