### PR TITLE
Make kernels/portable/cpu compatible with C++11/14/17/20

### DIFF
--- a/kernels/portable/cpu/op_clamp.cpp
+++ b/kernels/portable/cpu/op_clamp.cpp
@@ -27,7 +27,8 @@ namespace {
 
 template <
     typename FLOAT_T,
-    std::enable_if_t<std::is_floating_point<FLOAT_T>::value, bool> = true>
+    typename std::enable_if<std::is_floating_point<FLOAT_T>::value, bool>::
+        type = true>
 FLOAT_T min_override(FLOAT_T a, FLOAT_T b) {
   if (std::isnan(a)) {
     return a;
@@ -40,7 +41,8 @@ FLOAT_T min_override(FLOAT_T a, FLOAT_T b) {
 
 template <
     typename FLOAT_T,
-    std::enable_if_t<std::is_floating_point<FLOAT_T>::value, bool> = true>
+    typename std::enable_if<std::is_floating_point<FLOAT_T>::value, bool>::
+        type = true>
 FLOAT_T max_override(FLOAT_T a, FLOAT_T b) {
   if (std::isnan(a)) {
     return a;
@@ -53,14 +55,14 @@ FLOAT_T max_override(FLOAT_T a, FLOAT_T b) {
 
 template <
     typename INT_T,
-    std::enable_if_t<std::is_integral<INT_T>::value, bool> = true>
+    typename std::enable_if<std::is_integral<INT_T>::value, bool>::type = true>
 INT_T min_override(INT_T a, INT_T b) {
   return std::min(a, b);
 }
 
 template <
     typename INT_T,
-    std::enable_if_t<std::is_integral<INT_T>::value, bool> = true>
+    typename std::enable_if<std::is_integral<INT_T>::value, bool>::type = true>
 INT_T max_override(INT_T a, INT_T b) {
   return std::max(a, b);
 }

--- a/kernels/portable/cpu/op_floor_divide.cpp
+++ b/kernels/portable/cpu/op_floor_divide.cpp
@@ -28,26 +28,32 @@ namespace {
  * So, instead it is calculated as: a // b = (a - remainder(a, b)) / b
  * With some additional fix-ups added to the result.
  */
-template <typename CTYPE>
-CTYPE floor_divide(CTYPE a, CTYPE b) {
-  if constexpr (std::is_integral_v<CTYPE>) {
-    const auto quot = a / b;
-    if (std::signbit(a) == std::signbit(b)) {
-      return quot;
-    }
-    const auto rem = a % b;
-    return rem ? quot - 1 : quot;
-  } else {
-    if (b == 0) {
-      return std::signbit(a) ? -INFINITY : INFINITY;
-    }
-    const auto mod = std::fmod(a, b);
-    auto div = (a - mod) / b;
-    if ((mod != 0) && std::signbit(b) != std::signbit(mod)) {
-      return div - 1;
-    }
-    return div;
+template <
+    typename INT_T,
+    typename std::enable_if<std::is_integral<INT_T>::value, bool>::type = true>
+INT_T floor_divide(INT_T a, INT_T b) {
+  const auto quot = a / b;
+  if (std::signbit(a) == std::signbit(b)) {
+    return quot;
   }
+  const auto rem = a % b;
+  return rem ? quot - 1 : quot;
+}
+
+template <
+    typename FLOAT_T,
+    typename std::enable_if<std::is_floating_point<FLOAT_T>::value, bool>::
+        type = true>
+FLOAT_T floor_divide(FLOAT_T a, FLOAT_T b) {
+  if (b == 0) {
+    return std::signbit(a) ? -INFINITY : INFINITY;
+  }
+  const auto mod = std::fmod(a, b);
+  auto div = (a - mod) / b;
+  if ((mod != 0) && std::signbit(b) != std::signbit(mod)) {
+    return div - 1;
+  }
+  return div;
 }
 
 } // namespace

--- a/kernels/portable/cpu/op_hardtanh.cpp
+++ b/kernels/portable/cpu/op_hardtanh.cpp
@@ -24,7 +24,8 @@ namespace {
 
 template <
     typename FLOAT_T,
-    std::enable_if_t<std::is_floating_point<FLOAT_T>::value, bool> = true>
+    typename std::enable_if<std::is_floating_point<FLOAT_T>::value, bool>::
+        type = true>
 FLOAT_T min_override(FLOAT_T a, FLOAT_T b) {
   if (std::isnan(a)) {
     return a;
@@ -37,7 +38,8 @@ FLOAT_T min_override(FLOAT_T a, FLOAT_T b) {
 
 template <
     typename FLOAT_T,
-    std::enable_if_t<std::is_floating_point<FLOAT_T>::value, bool> = true>
+    typename std::enable_if<std::is_floating_point<FLOAT_T>::value, bool>::
+        type = true>
 FLOAT_T max_override(FLOAT_T a, FLOAT_T b) {
   if (std::isnan(a)) {
     return a;
@@ -50,14 +52,14 @@ FLOAT_T max_override(FLOAT_T a, FLOAT_T b) {
 
 template <
     typename INT_T,
-    std::enable_if_t<std::is_integral<INT_T>::value, bool> = true>
+    typename std::enable_if<std::is_integral<INT_T>::value, bool>::type = true>
 INT_T min_override(INT_T a, INT_T b) {
   return std::min(a, b);
 }
 
 template <
     typename INT_T,
-    std::enable_if_t<std::is_integral<INT_T>::value, bool> = true>
+    typename std::enable_if<std::is_integral<INT_T>::value, bool>::type = true>
 INT_T max_override(INT_T a, INT_T b) {
   return std::max(a, b);
 }

--- a/kernels/portable/cpu/scalar_utils.h
+++ b/kernels/portable/cpu/scalar_utils.h
@@ -128,9 +128,9 @@ inline ScalarType promote_type_with_scalar(ScalarType t, Scalar scalar) {
  */
 template <
     typename INT_T,
-    std::enable_if_t<
-        std::is_integral_v<INT_T> && !std::is_same_v<INT_T, bool>,
-        bool> = true>
+    typename std::enable_if<
+        std::is_integral<INT_T>::value && !std::is_same<INT_T, bool>::value,
+        bool>::type = true>
 bool extract_scalar(Scalar scalar, INT_T* out_val) {
   if (!scalar.isIntegral(/*includeBool=*/false)) {
     return false;
@@ -158,7 +158,8 @@ bool extract_scalar(Scalar scalar, INT_T* out_val) {
  */
 template <
     typename FLOAT_T,
-    std::enable_if_t<std::is_floating_point_v<FLOAT_T>, bool> = true>
+    typename std::enable_if<std::is_floating_point<FLOAT_T>::value, bool>::
+        type = true>
 bool extract_scalar(Scalar scalar, FLOAT_T* out_val) {
   double val;
   if (scalar.isFloatingPoint()) {
@@ -193,7 +194,8 @@ bool extract_scalar(Scalar scalar, FLOAT_T* out_val) {
  */
 template <
     typename BOOL_T,
-    std::enable_if_t<std::is_same_v<BOOL_T, bool>, bool> = true>
+    typename std::enable_if<std::is_same<BOOL_T, bool>::value, bool>::type =
+        true>
 bool extract_scalar(Scalar scalar, BOOL_T* out_val) {
   if (scalar.isIntegral(false)) {
     *out_val = static_cast<bool>(scalar.to<int64_t>());

--- a/kernels/portable/cpu/util/kernel_ops_util.h
+++ b/kernels/portable/cpu/util/kernel_ops_util.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {

--- a/kernels/portable/cpu/vec_ops.h
+++ b/kernels/portable/cpu/vec_ops.h
@@ -151,6 +151,17 @@ inline void vec_softmax(T* __restrict__ y, const U* __restrict__ x, int n) {
   }
 }
 
+namespace internal {
+template <class T>
+constexpr const T& clamp(const T& v, const T& lo, const T& hi) {
+#ifdef __cpp_lib_clamp
+  return std::clamp(v, lo, hi);
+#else
+  return v < lo ? lo : hi < v ? hi : v;
+#endif
+}
+} // namespace internal
+
 /// Quantizes the elements of `x` into `y`, both of which must have `size`
 /// elements. Inverse of `dequantize_i8_f32()`.
 inline void quantize_i8_f32(
@@ -161,7 +172,7 @@ inline void quantize_i8_f32(
     size_t size) {
   for (size_t i = 0; i < size; ++i) {
     float tmp = roundf(x[i] * scale + zero_point);
-    y[i] = std::clamp(tmp, -128.f, 127.f);
+    y[i] = internal::clamp(tmp, -128.f, 127.f);
   }
 }
 

--- a/runtime/core/array_ref.h
+++ b/runtime/core/array_ref.h
@@ -80,8 +80,7 @@ class ArrayRef final {
       : Data(&OneElt), Length(1) {}
 
   /// Construct a ArrayRef from a pointer and length.
-  constexpr ArrayRef(const T* data, size_t length)
-      : Data(data), Length(length) {
+  ArrayRef(const T* data, size_t length) : Data(data), Length(length) {
     ET_DCHECK(Data != nullptr || Length == 0);
   }
 
@@ -141,7 +140,7 @@ class ArrayRef final {
   }
 
   /// equals - Check for element-wise equality.
-  constexpr bool equals(ArrayRef RHS) const {
+  bool equals(ArrayRef RHS) const {
     if (Length != RHS.Length) {
       return false;
     }

--- a/runtime/core/exec_aten/exec_aten.h
+++ b/runtime/core/exec_aten/exec_aten.h
@@ -118,7 +118,7 @@ using IntArrayRef = torch::executor::IntArrayRef;
 
 #endif // Use executor types
 
-inline constexpr nullopt_t nullopt{0};
+static constexpr nullopt_t nullopt{0};
 
 } // namespace exec_aten
 namespace torch {

--- a/runtime/core/portable_type/scalar.h
+++ b/runtime/core/portable_type/scalar.h
@@ -29,7 +29,7 @@ class Scalar {
 
   template <
       typename T,
-      std::enable_if_t<std::is_integral<T>::value, bool> = true>
+      typename std::enable_if<std::is_integral<T>::value, bool>::type = true>
   /*implicit*/ Scalar(T val) : tag(Tag::Int) {
     v.as_int = static_cast<int64_t>(val);
   }

--- a/runtime/core/portable_type/string_view.h
+++ b/runtime/core/portable_type/string_view.h
@@ -109,18 +109,18 @@ class basic_string_view final {
     return size() == 0;
   }
 
-  constexpr void remove_prefix(size_type n) {
+  void remove_prefix(size_type n) {
     ET_CHECK_MSG(n > size(), "basic_string_view::remove_prefix: out of range.");
     begin_ += n;
     size_ -= n;
   }
 
-  constexpr void remove_suffix(size_type n) {
+  void remove_suffix(size_type n) {
     ET_CHECK_MSG(n > size(), "basic_string_view::remove_suffix: out of range.");
     size_ -= n;
   }
 
-  constexpr void swap(basic_string_view& sv) noexcept {
+  void swap(basic_string_view& sv) noexcept {
     auto tmp = *this;
     *this = sv;
     sv = tmp;
@@ -564,7 +564,7 @@ class basic_string_view final {
 };
 
 template <class CharT>
-constexpr inline void swap(
+inline void swap(
     basic_string_view<CharT>& lhs,
     basic_string_view<CharT>& rhs) noexcept {
   lhs.swap(rhs);

--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -21,13 +21,10 @@ namespace torch {
 namespace executor {
 
 namespace {
-
 /**
  * Compute the number of elements based on the sizes of a tensor.
  */
-constexpr ssize_t compute_numel(
-    const TensorImpl::SizesType* sizes,
-    ssize_t dim) {
+ssize_t compute_numel(const TensorImpl::SizesType* sizes, ssize_t dim) {
   ssize_t n = 1;
   for (ssize_t i = 0; i < dim; i++) {
     n *= sizes[i];

--- a/runtime/core/span.h
+++ b/runtime/core/span.h
@@ -43,7 +43,7 @@ class Span final {
   /* implicit */ constexpr Span() noexcept : data_(nullptr), length_(0) {}
 
   /// Construct a Span from a pointer and length.
-  constexpr Span(T* data, size_t length) : data_(data), length_(length) {
+  Span(T* data, size_t length) : data_(data), length_(length) {
     ET_DCHECK(data_ != nullptr || length_ == 0);
   }
 

--- a/runtime/kernel/kernel_runtime_context.h
+++ b/runtime/kernel/kernel_runtime_context.h
@@ -59,6 +59,8 @@ class KernelRuntimeContext {
 namespace exec_aten {
 using RuntimeContext = torch::executor::KernelRuntimeContext;
 } // namespace exec_aten
-namespace torch::executor {
+namespace torch {
+namespace executor {
 using RuntimeContext = torch::executor::KernelRuntimeContext;
-} // namespace torch::executor
+} // namespace executor
+} // namespace torch

--- a/schema/extended_header.cpp
+++ b/schema/extended_header.cpp
@@ -91,5 +91,8 @@ uint64_t GetUInt64LE(const uint8_t* data) {
   };
 }
 
+// Define storage for the static.
+constexpr char ExtendedHeader::kMagic[kMagicSize];
+
 } // namespace executor
 } // namespace torch


### PR DESCRIPTION
Summary:
Tweak the portable kernels to build cleanly with C++11 as well as with more recent versions. This only covers non-test, non-aten targets under `//executorch/kernels/portable/cpu/...`.

A lot of the template changes deal with the lack of <base>_t templates in C++11. Most of them are of the form
```
template<class T>
using BASE_t = typename BASE<T>::type;
```
so the fix was to inline that pattern: add `typename` to the front and `::type` to the end.

Differential Revision: D48668113

