### PR TITLE
Reinstall buck2 arm64 binary on MacOS if the wrong version (x86) is installed

### DIFF
--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -27,7 +27,20 @@ install_buck() {
     brew install wget
   fi
 
+  BUCK2_NOT_AVAILABLE=false
   if ! command -v buck2 &> /dev/null; then
+    BUCK2_NOT_AVAILABLE=true
+  else
+    BUCK2_BINARY=$(which buck2)
+    BUCK2_ARCH=$(file -b "${BUCK2_BINARY}")
+
+    if [[ "${BUCK2_ARCH}" != "Mach-O 64-bit executable arm64" ]]; then
+      echo "Reinstall buck2 because ${BUCK2_BINARY} is ${BUCK2_ARCH}, not 64-bit arm64"
+      BUCK2_NOT_AVAILABLE=true
+    fi
+  fi
+
+  if [[ "${BUCK2_NOT_AVAILABLE}" == true ]]; then
     pushd .ci/docker
 
     BUCK2=buck2-aarch64-apple-darwin.zst


### PR DESCRIPTION
This fixes the flaky linking issue on MacOS where the x86 version of `libtorch.dylib` instead of the correct arm64 version.  The root cause turns out to be buck2 binary itself where its x86 version was wrongly installed on some runners (probably my fault when adding macos support).  With the current logic, buck2 is installed only once when the binary isn't there, so when a wrong version sneaks in, it stays and causes troubles for all future jobs.

The fix here is to check for the arch of the binary to ensure that we have the correct 64-bit arm64 buck2 installed.