### PR TITLE
Attach debug handle to control flow modules

### DIFF
--- a/exir/passes/TARGETS
+++ b/exir/passes/TARGETS
@@ -245,6 +245,7 @@ python_library(
     ],
     deps = [
         "//caffe2:torch",
+        "//executorch/exir:graph_module",
         "//executorch/exir:pass_base",
     ],
 )

--- a/exir/passes/debug_handle_generator_pass.py
+++ b/exir/passes/debug_handle_generator_pass.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from executorch.exir.graph_module import get_control_flow_submodules
 from executorch.exir.pass_base import ExportPass
 from torch.fx import GraphModule
 from torch.fx.passes.infra.pass_base import PassResult
@@ -14,6 +15,18 @@ class DebugHandleGeneratorPass(ExportPass):
         """Lower a quantized reference model (with reference quantized operator patterns)
         to executorch backend, that has a canonical set of quantized operators
         """
-        for index, node in enumerate(graph_module.graph.nodes):
-            node.meta["debug_handle"] = index
+
+        queue = [graph_module]
+        index = 0
+        # bfs to traverse all modules including control flow submodules to attached debug handle id
+        while queue:
+            current_graph_module = queue.pop(0)
+            for node in current_graph_module.graph.nodes:
+                node.meta["debug_handle"] = index
+                index += 1
+            control_flow_submodules = [
+                submodule
+                for _, submodule, _ in get_control_flow_submodules(current_graph_module)
+            ]
+            queue.extend(control_flow_submodules)
         return PassResult(graph_module, True)

--- a/exir/tests/TARGETS
+++ b/exir/tests/TARGETS
@@ -204,6 +204,8 @@ python_unittest(
         ":lib",
         ":models",
         "//caffe2:torch",
+        "//caffe2/functorch:functorch_src",
+        "//executorch/exir:graph_module",
         "//executorch/exir:lib",
         "//executorch/exir:memory",
         "//executorch/exir:memory_planning",


### PR DESCRIPTION
Summary: Previously we only add debug handle in the top level graph module but not the ones in control flow. This diff handles the control flow modules too.

Reviewed By: tarun292

Differential Revision: D48651108

