### PR TITLE
Add `transform_exported_program` stub to ease renaming of `transform` method

### DIFF
--- a/docs/website/docs/tutorials/exporting_to_executorch.md
+++ b/docs/website/docs/tutorials/exporting_to_executorch.md
@@ -92,7 +92,7 @@ ExportedProgram:
 ```
 
 At this point, users can choose to run additional passes through the
-`exported_program.transform(passes)` function. A tutorial on how to write
+`exported_program._transform(passes)` function. A tutorial on how to write
 transformations can be found [here](./passes.md).
 
 Additionally, users can run quantization at this step. A tutorial for doing so can be found [here](./quantization_flow.md).
@@ -128,7 +128,7 @@ ExportedProgram:
 ```
 
 Users can also choose to run additional passes through the
-`exported_program.transform(passes)` function. A tutorial on how to write
+`exported_program._transform(passes)` function. A tutorial on how to write
 transformations can be found [here](./passes.md). Note that since the graph is
 now in Edge Dialect, all passes must also result in a valid Edge Dialect graph
 (specifically one thing to point out is that the operators are now in the

--- a/exir/capture/_capture.py
+++ b/exir/capture/_capture.py
@@ -15,6 +15,7 @@ import torch._export
 from executorch.exir.capture._config import CaptureConfig
 from executorch.exir.error import ExportError, ExportErrorType, InternalError
 from executorch.exir.program import ExirExportedProgram, MultiMethodExirExportedProgram
+from executorch.exir.program._program import transform_exported_program
 from executorch.exir.tracer import (
     _default_decomposition_table,
     dispatch_trace,
@@ -82,7 +83,7 @@ def capture(
             # TODO remove this later
             with patch("torch._export.DECOMP_TABLE", _default_decomposition_table()):
                 ep = export(f, args, constraints=constraints)
-            ep = ep.transform(ReplaceViewOpsWithViewCopyOpsPass())
+            ep = transform_exported_program(ep, ReplaceViewOpsWithViewCopyOpsPass())
             if not config._unlift:
                 return ExirExportedProgram(ep, False)
             graph_module = ep.module()

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -34,6 +34,14 @@ from torch.fx._compatibility import compatibility
 Val = Any
 
 
+# Stub to ease migration from `transform` to private `_transform`
+def transform_exported_program(ep, *passes: PassType) -> ExportedProgram:
+    if hasattr(ep, "_transform"):
+        return ep._transform(*passes)
+    else:
+        return ep.transform(*passes)
+
+
 @compatibility(is_backward_compatible=False)
 class ExirExportedProgram:
     def __init__(
@@ -48,7 +56,9 @@ class ExirExportedProgram:
         self.after_to_edge_passes = after_to_edge_passes
 
     def transform(self, *passes: PassType) -> "ExirExportedProgram":
-        self.exported_program = self.exported_program.transform(*passes)
+        self.exported_program = transform_exported_program(
+            self.exported_program, *passes
+        )
         return self
 
     def __call__(self, *args: Any) -> Any:
@@ -76,7 +86,7 @@ class ExirExportedProgram:
             raise RuntimeError("Must run to_edge before to_executorch.")
         config = config or ExecutorchBackendConfig()
         ep = self.exported_program
-        new_prog = ep.transform(*edge_to_executorch_passes(config))
+        new_prog = transform_exported_program(ep, *edge_to_executorch_passes(config))
         new_prog = ExirExportedProgram(new_prog, self.after_to_edge_passes)
         executorch_prog = ExecutorchProgram(
             new_prog,


### PR DESCRIPTION
Summary: To avoid using co-dev mode, I am adding a helper that automatically tries both _transform and transform on ExportedProgram. Then I will be able to change OSS code without breaking internal tests.

Differential Revision: D48668701

