### PR TITLE
Use IDs for placeholder/outputs of implicit q/dq nodes

### DIFF
--- a/backends/xnnpack/operators/node_visitor.py
+++ b/backends/xnnpack/operators/node_visitor.py
@@ -230,6 +230,7 @@ class NodeVisitor:
         # Get new xnn id for tensor value
         ext_id, id_out, flag = self.gen_ids_and_flags(tensor, xnn_graph, quant_params)
         dims = get_shape(tensor)
+        dims = [1] if len(dims) == 0 else dims
 
         # constant values serialize data
         buffer_idx = self.get_serialized_buffer(
@@ -336,6 +337,10 @@ class NodeVisitor:
         # Quantize buffer if static data is indeed quantized
         if quant_params is not None and not quant_params.is_dynamic:
             const_val = quant_params.quantize_tensor(const_val).contiguous()
+        else:
+            # ensure that the const is fp32
+            const_val = const_val.to(dtype=torch.float32).contiguous()
+
         if swap_nc_for_depthwise_weights:
             const_val = const_val.permute(
                 dims=((1, 0) + tuple(range(2, const_val.dim())))

--- a/backends/xnnpack/partition/configs.py
+++ b/backends/xnnpack/partition/configs.py
@@ -37,6 +37,9 @@ SUPPORTED_OPS = [
 
 SUPPORTED_MODULES = [
     torch.nn.Conv1d,
+    # TODO(T161981984) recomposed hardswish into a single node
+    torch.nn.Hardswish,
+    torch.nn.Hardsigmoid,
     torch.nn.Conv2d,
     torch.nn.ReLU,
     torch.nn.Sigmoid,

--- a/examples/models/models.py
+++ b/examples/models/models.py
@@ -155,4 +155,5 @@ MODEL_NAME_TO_OPTIONS = {
     "add": OptimizationOptions(True, True),
     "add_mul": OptimizationOptions(True, True),
     "mv2": OptimizationOptions(True, True),
+    "mv3": OptimizationOptions(True, False),
 }

--- a/examples/quantization/example.py
+++ b/examples/quantization/example.py
@@ -46,6 +46,7 @@ def verify_xnnpack_quantizer_matching_fx_quant_model(model_name, model, example_
     m = prepare_pt2e(m, quantizer)
     # calibration
     after_prepare_result = m(*example_inputs)
+    print("pt2e prepare:", m)
     m = convert_pt2e(m)
     after_quant_result = m(*example_inputs)
 
@@ -57,6 +58,7 @@ def verify_xnnpack_quantizer_matching_fx_quant_model(model_name, model, example_
         m_copy, qconfig_mapping, example_inputs, backend_config=backend_config
     )
     after_prepare_result_fx = m_fx(*example_inputs)
+    print("fx prepare:", m_fx)
     m_fx = _convert_to_reference_decomposed_fx(m_fx, backend_config=backend_config)
     after_quant_result_fx = m_fx(*example_inputs)
 
@@ -69,10 +71,10 @@ def verify_xnnpack_quantizer_matching_fx_quant_model(model_name, model, example_
     print("m_fx:", m_fx)
     print("prepare sqnr:", compute_sqnr(after_prepare_result, after_prepare_result_fx))
     assert compute_sqnr(after_prepare_result, after_prepare_result_fx) > 100
-    print("quant diff max:", torch.max(after_quant_result - after_quant_result_fx))
+    print("diff max:", torch.max(after_quant_result - after_quant_result_fx))
+    print("sqnr:", compute_sqnr(after_quant_result, after_quant_result_fx))
     assert torch.max(after_quant_result - after_quant_result_fx) < 1e-1
-    print("quant sqnr:", compute_sqnr(after_quant_result, after_quant_result_fx))
-    assert compute_sqnr(after_quant_result, after_quant_result_fx) > 30
+    assert compute_sqnr(after_quant_result, after_quant_result_fx) > 35
 
 
 if __name__ == "__main__":
@@ -121,7 +123,7 @@ if __name__ == "__main__":
         raise RuntimeError(
             f"Model {args.model_name} is not a valid name. or not quantizable right now, "
             "please contact executorch team if you want to learn why or how to support "
-            "quantization for the requested model"
+            "quantization for the requested model "
             f"Available models are {list(MODEL_NAME_TO_OPTIONS.keys())}."
         )
 


### PR DESCRIPTION
Summary:
In XNNPACK from the partitioner we encounter quantize node that are outputs to the graph. Since these quantize nodes are implicit and not actually quantizing the values, we must give its externalness to the node with which it quantizes.

### Outputs
```
                 |
conv --> q ----> | ----> dq -->
                 |
         Delegate boundary
```
In this example the output of the delegate is the output of quantized Conv. In XNNPACK, we must designate the output of Conv to be an external value. In this graph, however, the q node is the output. Since q is an implicit node (it does not actually running quantize) We pass its externalness to the conv node.

### Inputs
i.e.
```
        |
q ----> | ----> dq --> conv -->
        |
Delegate boundary
```
In this example q is the placeholder node and is given as input to the first dq. But we are running a quantized conv within the delegate. Since dq is implicit, we pass the externalness of the q place holder to dq, so that the input to Conv is external.

Reviewed By: digantdesai

Differential Revision: D48667676

