### PR TITLE
Create an initital recipe for xnnpack optimization

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -9,7 +9,8 @@ import json
 import os
 from typing import Any
 
-from examples.models import MODEL_NAME_TO_MODEL, MODEL_NAME_TO_OPTIONS
+from examples.models import MODEL_NAME_TO_MODEL
+from examples.recipes.xnnpack_optimization import MODEL_NAME_TO_OPTIONS
 
 BUILD_TOOLS = [
     "buck2",

--- a/examples/backend/targets.bzl
+++ b/examples/backend/targets.bzl
@@ -22,7 +22,7 @@ def define_common_targets():
         ],
         deps = [
             "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
-            "//executorch/examples/models:models",
+            "//executorch/examples/recipes/xnnpack_optimization:models",
             "//executorch/examples/quantization:quant_utils",
             "//executorch/exir:lib",
             "//executorch/exir/backend:backend_api",

--- a/examples/backend/xnnpack_examples.py
+++ b/examples/backend/xnnpack_examples.py
@@ -16,8 +16,9 @@ from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
 )
 from executorch.exir.backend.backend_api import to_backend
 
-from ..models import MODEL_NAME_TO_MODEL, MODEL_NAME_TO_OPTIONS
+from ..models import MODEL_NAME_TO_MODEL
 from ..quantization.utils import quantize
+from ..recipes.xnnpack_optimization import MODEL_NAME_TO_OPTIONS
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/examples/models/models.py
+++ b/examples/models/models.py
@@ -142,17 +142,3 @@ MODEL_NAME_TO_MODEL = {
     "resnet18": gen_resnet18_model_and_inputs,
     "resnet50": gen_resnet50_model_and_inputs,
 }
-
-
-@dataclass
-class OptimizationOptions(object):
-    quantization: bool
-    xnnpack_delegation: bool
-
-
-MODEL_NAME_TO_OPTIONS = {
-    "linear": OptimizationOptions(True, True),
-    "add": OptimizationOptions(True, True),
-    "add_mul": OptimizationOptions(True, True),
-    "mv2": OptimizationOptions(True, True),
-}

--- a/examples/quantization/example.py
+++ b/examples/quantization/example.py
@@ -26,9 +26,8 @@ from torch.ao.quantization.quantizer.xnnpack_quantizer import (
 )
 
 from ..export.export_example import export_to_pte
-
-from ..models import MODEL_NAME_TO_MODEL, MODEL_NAME_TO_OPTIONS
-
+from ..models import MODEL_NAME_TO_MODEL
+from ..recipes.xnnpack_optimization import MODEL_NAME_TO_OPTIONS
 from .utils import quantize
 
 

--- a/examples/recipes/xnnpack_optimization/TARGETS
+++ b/examples/recipes/xnnpack_optimization/TARGETS
@@ -1,0 +1,12 @@
+load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
+
+python_library(
+    name = "models",
+    srcs = [
+        "__init__.py",
+        "models.py",
+    ],
+    deps = [
+        "//executorch/examples/models:models",  # @manual
+    ],
+)

--- a/examples/recipes/xnnpack_optimization/__init__.py
+++ b/examples/recipes/xnnpack_optimization/__init__.py
@@ -4,6 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .models import MODEL_NAME_TO_MODEL
+from .models import MODEL_NAME_TO_OPTIONS
 
-__all__ = [MODEL_NAME_TO_MODEL]
+__all__ = [MODEL_NAME_TO_OPTIONS]

--- a/examples/recipes/xnnpack_optimization/models.py
+++ b/examples/recipes/xnnpack_optimization/models.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+
+
+@dataclass
+class OptimizationOptions(object):
+    quantization: bool
+    xnnpack_delegation: bool
+
+
+MODEL_NAME_TO_OPTIONS = {
+    "linear": OptimizationOptions(True, True),
+    "add": OptimizationOptions(True, True),
+    "add_mul": OptimizationOptions(True, True),
+    "mv2": OptimizationOptions(True, True),
+}


### PR DESCRIPTION
Summary:
This is just a very initial attempt to define composable recipes for our demos.

**The goal for this diff is just to move xnnpack specific stuff out from the `examples/models` to `examples/recipes/xnnpack_optimization`**.

In follow-up diffs, we will continue moving pieces from `examples/backend` to create a complete recipe to demonstrate xnnpack optimization e2e.

Differential Revision: D48704007

