### PR TITLE
Fix XNNPACK Example for MV3

### DIFF
--- a/backends/xnnpack/operators/node_visitor.py
+++ b/backends/xnnpack/operators/node_visitor.py
@@ -230,6 +230,7 @@ class NodeVisitor:
         # Get new xnn id for tensor value
         ext_id, id_out, flag = self.gen_ids_and_flags(tensor, xnn_graph, quant_params)
         dims = get_shape(tensor)
+        dims = [1] if len(dims) == 0 else dims
 
         # constant values serialize data
         buffer_idx = self.get_serialized_buffer(
@@ -336,6 +337,10 @@ class NodeVisitor:
         # Quantize buffer if static data is indeed quantized
         if quant_params is not None and not quant_params.is_dynamic:
             const_val = quant_params.quantize_tensor(const_val).contiguous()
+        else:
+            # ensure that the const is fp32
+            const_val = const_val.to(dtype=torch.float32).contiguous()
+
         if swap_nc_for_depthwise_weights:
             const_val = const_val.permute(
                 dims=((1, 0) + tuple(range(2, const_val.dim())))

--- a/backends/xnnpack/partition/configs.py
+++ b/backends/xnnpack/partition/configs.py
@@ -81,6 +81,11 @@ SUPPORTED_IMPLICIT_Q_DQ_OP_NAMES_SET = {
     )
 }
 
+UNSUPPORTED_QUANT_MODULES = [
+    torch.nn.Hardswish,
+    torch.nn.Hardsigmoid,
+]
+
 # TODO delete this and should use SUPPORTED_MODULES instead once we align fp32 and quant support
 SUPPORTED_QUANT_MODULES = [
     torch.clamp,

--- a/backends/xnnpack/partition/configs.py
+++ b/backends/xnnpack/partition/configs.py
@@ -37,6 +37,9 @@ SUPPORTED_OPS = [
 
 SUPPORTED_MODULES = [
     torch.nn.Conv1d,
+    # TODO(T161981984) recomposed hardswish into a single node
+    torch.nn.Hardswish,
+    torch.nn.Hardsigmoid,
     torch.nn.Conv2d,
     torch.nn.ReLU,
     torch.nn.Sigmoid,

--- a/backends/xnnpack/test/models/mobilenet_v3.py
+++ b/backends/xnnpack/test/models/mobilenet_v3.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torchvision.models as models
+from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
+    XnnpackQuantizedPartitioner2,
+)
+from executorch.backends.xnnpack.test.tester import Partition, Tester
+from executorch.backends.xnnpack.test.tester.tester import Export
+from executorch.backends.xnnpack.utils.configs import get_xnnpack_capture_config
+
+
+class TestMobileNetV3(unittest.TestCase):
+    export_stage = Export(get_xnnpack_capture_config(enable_aot=True))
+
+    mv3 = models.mobilenetv3.mobilenet_v3_small(pretrained=True)
+    mv3 = mv3.eval()
+    model_inputs = (torch.ones(1, 3, 224, 244),)
+
+    all_operators = {
+        "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
+        "executorch_exir_dialects_edge__ops_aten_clamp_default",
+        "executorch_exir_dialects_edge__ops_aten_permute_copy_default",
+        "executorch_exir_dialects_edge__ops_aten_addmm_default",
+        "executorch_exir_dialects_edge__ops_aten__to_copy_default",
+        "executorch_exir_dialects_edge__ops_aten_convolution_default",
+        "executorch_exir_dialects_edge__ops_aten_relu_default",
+        "executorch_exir_dialects_edge__ops_aten_add_Tensor",
+        "executorch_exir_dialects_edge__ops_aten_mul_Tensor",
+        "executorch_exir_dialects_edge__ops_aten_div_Tensor",
+        "executorch_exir_dialects_edge__ops_aten_mean_dim",
+    }
+
+    def test_fp32(self):
+        (
+            Tester(self.mv3, self.model_inputs)
+            .export(self.export_stage)
+            .to_edge()
+            .check(list(self.all_operators))
+            .partition()
+            .check(["torch.ops.executorch_call_delegate"])
+            .check_not(list(self.all_operators))
+            .to_executorch()
+            .serialize()
+            .run_method()
+            .compare_outputs()
+        )
+
+    def test_qs8_pt2e(self):
+        ops_after_quantization = self.all_operators - {
+            "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
+        }
+        ops_after_lowering = self.all_operators - {
+            # TODO: unified partitioner since hardswish/hardsigmoid decomposed operators are not quantized
+            # They will not be partitioned by quantized partitioner
+            "executorch_exir_dialects_edge__ops_aten_add_Tensor",
+            "executorch_exir_dialects_edge__ops_aten_mul_Tensor",
+            "executorch_exir_dialects_edge__ops_aten_div_Tensor",
+            "executorch_exir_dialects_edge__ops_aten_clamp_default",
+            "executorch_exir_dialects_edge__ops_aten__to_copy_default",
+        }
+
+        (
+            Tester(self.mv3, self.model_inputs)
+            .quantize2()
+            .export(self.export_stage)
+            .to_edge()
+            .check(list(ops_after_quantization))
+            .partition(Partition(partitioner=XnnpackQuantizedPartitioner2))
+            .check(["torch.ops.executorch_call_delegate"])
+            .check_not(list(ops_after_lowering))
+            .to_executorch()
+            .serialize()
+            .run_method()
+            .compare_outputs()
+        )

--- a/examples/backend/xnnpack_examples.py
+++ b/examples/backend/xnnpack_examples.py
@@ -15,6 +15,9 @@ from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
     XnnpackQuantizedPartitioner2,
 )
 from executorch.exir.backend.backend_api import to_backend
+from executorch.exir.backend.canonical_partitioners.duplicate_dequant_node_pass import (
+    DuplicateDequantNodePass,
+)
 
 from ..models import MODEL_NAME_TO_MODEL, MODEL_NAME_TO_OPTIONS
 from ..quantization.utils import quantize
@@ -77,7 +80,13 @@ if __name__ == "__main__":
     # It will eventually be changed to a lifted graph, in which _unlift=False,
     edge = exir.capture(
         model, example_inputs, exir.CaptureConfig(enable_aot=True, _unlift=True)
-    ).to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
+    ).to_edge(
+        exir.EdgeCompileConfig(
+            # TODO(T162080278): Duplicated Dequant nodes will be in quantizer spec
+            _check_ir_validity=False,
+            passes=[DuplicateDequantNodePass()],
+        )
+    )
     logging.info(f"Exported graph:\n{edge.exported_program.graph}")
 
     edge.exported_program = to_backend(edge.exported_program, partitioner)


### PR DESCRIPTION
Summary:
xnnpack requires dequant nodes to be duplicated such that len(dq.users) == 1. We run this pass on our internal XNNPACK tests

From Jerry: This will be a config that is used within the XNNPACKQuantizer. This will be added later, for the sake of enabling this in the example, we add the duplicatedequantnodepass to our edge compile config

Additionally, graph_validation is failing for MV3, so we have to disable_validation for now. cccclai is looking into it

Reviewed By: digantdesai

Differential Revision: D48703639

