### PR TITLE
Enable MV3 in xnnpack_examples

### DIFF
--- a/examples/recipes/xnnpack_optimization/models.py
+++ b/examples/recipes/xnnpack_optimization/models.py
@@ -18,4 +18,5 @@ MODEL_NAME_TO_OPTIONS = {
     "add": OptimizationOptions(True, True),
     "add_mul": OptimizationOptions(True, True),
     "mv2": OptimizationOptions(True, True),
+    "mv3": OptimizationOptions(False, True),
 }


### PR DESCRIPTION
Summary: "mv3" needs to be added to `MODEL_NAME_TO_OPTIONS` in order to run it in `xnnpack_example` or for CI to pick it up.

Differential Revision: D48710936

