### PR TITLE
Remove dependency of bundled program from testing:tensors_are_close

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,11 @@ def custom_command():
     src_dst_list = [
         ("schema/scalar_type.fbs", "exir/serialize/scalar_type.fbs"),
         ("schema/program.fbs", "exir/serialize/program.fbs"),
+        (
+            "schema/bundled_program_schema.fbs",
+            "bundled_program/serialize/bundled_program_schema.fbs",
+        ),
+        ("schema/scalar_type.fbs", "bundled_program/serialize/scalar_type.fbs"),
     ]
     for src, dst in src_dst_list:
         print(f"copying from {src} to {dst}")
@@ -53,6 +58,7 @@ setup(
         "executorch/exir": "exir",
         "executorch/schema": "schema",
         "executorch/extension": "extension",
+        "executorch/bundled_program": "bundled_program",
     },
     cmdclass={
         "install": CustomInstallCommand,

--- a/util/targets.bzl
+++ b/util/targets.bzl
@@ -46,7 +46,6 @@ def define_common_targets():
                 "@EXECUTORCH_CLIENTS",
             ],
             deps = [
-                "//executorch/runtime/core/exec_aten/testing_util:tensor_util" + aten_suffix,
                 "//executorch/runtime/core/exec_aten/util:dim_order_util" + aten_suffix,
                 "//executorch/schema:bundled_program_schema",
                 "//executorch/schema:program",


### PR DESCRIPTION
Summary: Bundled program was using tensors_are_close from the testing utils folder which depends on gmock which isn't supported in OSS. Copying over that implementation into a private copy in `bundled_program_verification.cpp`

Reviewed By: Gasoonjia, cccclai

Differential Revision: D48768256

