### PR TITLE
Add example script to generate bundled program and consume in examples/executor_runner

### DIFF
--- a/bundled_program/serialize/__init__.py
+++ b/bundled_program/serialize/__init__.py
@@ -12,14 +12,13 @@ import json
 import os
 import tempfile
 
-# pyre-ignore[21]: Could not find module `executorch.exir.serialize.bindings`.
-import executorch.exir.serialize.bindings as bindings  # @manual=//executorch/exir/serialize:bindings
-
 # @manual=fbsource//third-party/pypi/setuptools:setuptools
 import pkg_resources
 from executorch.bundled_program.schema import BundledProgram
 
 from executorch.exir.serialize._dataclass import _DataclassEncoder, _json_to_dataclass
+
+from executorch.exir.serialize._flatbuffer import _flatc_compile, _flatc_decompile
 
 # The prefix of schema files used for bundled program
 BUNDLED_PROGRAM_SCHEMA_NAME = "bundled_program_schema"
@@ -54,9 +53,7 @@ def convert_to_flatbuffer(program_json: str) -> bytes:
         json_path = os.path.join(d, "{}.json".format(BUNDLED_PROGRAM_SCHEMA_NAME))
         with open(json_path, "wb") as json_file:
             json_file.write(program_json.encode("ascii"))
-
-        # pyre-ignore
-        bindings.flatc_compile(d, schema_path, json_path)
+        _flatc_compile(d, schema_path, json_path)
         output_path = os.path.join(d, "{}.bp".format(BUNDLED_PROGRAM_SCHEMA_NAME))
         with open(output_path, "rb") as output_file:
             return output_file.read()
@@ -71,8 +68,7 @@ def convert_from_flatbuffer(program_flatbuffer: bytes) -> bytes:
         bin_path = os.path.join(d, "schema.bin")
         with open(bin_path, "wb") as bin_file:
             bin_file.write(program_flatbuffer)
-        # pyre-ignore
-        bindings.flatc_decompile(d, schema_path, bin_path)
+        _flatc_decompile(d, schema_path, bin_path)
         output_path = os.path.join(d, "schema.json")
         with open(output_path, "rb") as output_file:
             return output_file.read()

--- a/examples/bundled_executor_runner/TARGETS
+++ b/examples/bundled_executor_runner/TARGETS
@@ -1,0 +1,8 @@
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/examples/bundled_executor_runner/bundled_executor_runner.cpp
+++ b/examples/bundled_executor_runner/bundled_executor_runner.cpp
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file
+ *
+ * This tool can run Executorch model files that only use operators that
+ * are covered by the portable kernels, with possible delegate to the
+ * test_backend_compiler_lib.
+ *
+ * It sets all input tensor data to ones, and assumes that the outputs are
+ * all fp32 tensors.
+ */
+
+#include <memory>
+
+#include <gflags/gflags.h>
+
+#include <executorch/extension/data_loader/buffer_data_loader.h>
+#include <executorch/extension/data_loader/file_data_loader.h>
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/program.h>
+#include <executorch/runtime/platform/log.h>
+#include <executorch/runtime/platform/profiler.h>
+#include <executorch/runtime/platform/runtime.h>
+#include <executorch/util/bundled_program_verification.h>
+#include <executorch/util/util.h>
+
+static constexpr size_t kRuntimeMemorySize = 4 * 1024U * 1024U; // 4 MB
+static uint8_t runtime_pool[kRuntimeMemorySize];
+static constexpr size_t kBundledAllocatorPoolSize = 16 * 1024U;
+static uint8_t bundled_allocator_pool[kBundledAllocatorPoolSize];
+
+DEFINE_string(
+    model_path,
+    "model.pte",
+    "Model serialized in flatbuffer format.");
+DEFINE_string(
+    prof_result_path,
+    "prof_result.bin",
+    "Executorch profiler output path.");
+
+DEFINE_bool(
+    bundled_program,
+    false,
+    "True for running bundled program, false for executorch_flatbuffer::program");
+
+DEFINE_int32(
+    testset_idx,
+    0,
+    "Index of bundled verification set to be run "
+    "by bundled model for verification");
+
+using namespace torch::executor;
+using torch::executor::util::FileDataLoader;
+
+int main(int argc, char** argv) {
+  runtime_init();
+
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  if (argc != 1) {
+    std::string msg = "Extra commandline args:";
+    for (int i = 1 /* skip argv[0] (program name) */; i < argc; i++) {
+      msg += std::string(" ") + argv[i];
+    }
+    ET_LOG(Error, "%s", msg.c_str());
+    return 1;
+  }
+
+  // Create a loader to get the data of the program file. There are other
+  // DataLoaders that use mmap() or point to data that's already in memory, and
+  // users can create their own DataLoaders to load from arbitrary sources.
+  const char* model_path = FLAGS_model_path.c_str();
+  Result<FileDataLoader> loader = FileDataLoader::From(model_path);
+  ET_CHECK_MSG(
+      loader.ok(), "FileDataLoader::From() failed: 0x%" PRIx32, loader.error());
+
+  // Read in the entire file.
+  Result<FreeableBuffer> file_data = loader->Load(0, loader->size().get());
+  ET_CHECK_MSG(
+      file_data.ok(),
+      "Could not load contents of file '%s': 0x%x",
+      model_path,
+      (unsigned int)file_data.error());
+
+  // Find the offset to the embedded Program.
+  const void* program_data;
+  size_t program_data_len;
+  Error status = torch::executor::util::GetProgramData(
+      const_cast<void*>(file_data->data()),
+      file_data->size(),
+      &program_data,
+      &program_data_len);
+  ET_CHECK_MSG(
+      status == Error::Ok,
+      "GetProgramData() failed on file '%s': 0x%x",
+      model_path,
+      (unsigned int)status);
+
+  auto buffer_data_loader =
+      util::BufferDataLoader(program_data, program_data_len);
+
+  // Parse the program file. This is immutable, and can also be reused
+  // between multiple execution invocations across multiple threads.
+  Result<Program> program = Program::Load(&buffer_data_loader);
+  if (!program.ok()) {
+    ET_LOG(Error, "Failed to parse model file %s", model_path);
+    return 1;
+  }
+  ET_LOG(Info, "Model file %s is loaded.", model_path);
+
+  // Use the first method in the program.
+  const size_t plan_index = 0;
+  const char* method_name = nullptr;
+  {
+    const auto method_name_result = program->get_method_name(plan_index);
+    ET_CHECK_MSG(method_name_result.ok(), "Program has no methods");
+    method_name = *method_name_result;
+  }
+  ET_LOG(Info, "Running method %s", method_name);
+
+  //
+  // The runtime does not use malloc/new; it allocates all memory using the
+  // MemoryManger provided by the client. Clients are responsible for allocating
+  // the memory ahead of time, or providing MemoryAllocator subclasses that can
+  // do it dynamically.
+  //
+
+  // The runtime allocator is used to allocate all dynamic C++ metadata/objects
+  // used to represent the loaded program. This allocator is only used during
+  // loading a method of the program, which will return an error if there was
+  // not enough memory.
+  //
+  // The amount of memory required depends on the loaded program and the runtime
+  // code itself. The amount of memory here is usually determined by running the
+  // program and seeing how much memory is actually used, though it's possible
+  // to subclass MemoryAllocator so that it calls malloc() under the hood.
+
+  // In this example we using statically allocated gloabl runtime_pool of
+  // size kRuntimeMemorySize
+  MemoryAllocator runtime_allocator{
+      MemoryAllocator(kRuntimeMemorySize, runtime_pool)};
+  runtime_allocator.enable_profiling("runtime allocator");
+
+  // The non-const allocator is used to provide the memory-planned buffers that
+  // back mutable tensors. Since it was planned ahead of time, the Program knows
+  // how big each of the allocators needs to be.
+  //
+  // These buffers correspond to different hardware memory banks. Most mobile
+  // environments will only have a single buffer. Some embedded environments may
+  // have more than one for, e.g., slow/large DRAM and fast/small SRAM.
+  std::vector<std::unique_ptr<uint8_t[]>> non_const_buffers;
+  std::vector<MemoryAllocator> non_const_allocators;
+  size_t num_non_const_buffers = 0;
+  {
+    auto result = program->num_non_const_buffers(method_name);
+    ET_CHECK_MSG(
+        result.ok(),
+        "Failed to get number of non-const buffers for method %s: 0x%x",
+        method_name,
+        (unsigned int)result.error());
+    num_non_const_buffers = *result;
+  }
+  // Note that this loop starts at ID 1, because ID 0 is reserved. But, the
+  // HierarchicalAllocator indices are zero-based, so it's later adjusted by -1.
+  for (size_t id = 1; id < num_non_const_buffers; ++id) {
+    auto buffer_size = program->get_non_const_buffer_size(id, method_name);
+    ET_CHECK_MSG(
+        buffer_size.ok(),
+        "Failed to get size of non-const buffer %zu for method %s: 0x%x",
+        id,
+        method_name,
+        (unsigned int)buffer_size.error());
+    ET_LOG(
+        Info, "Setting up non-const buffer %zu, size %zu.", id, *buffer_size);
+    non_const_buffers.push_back(std::make_unique<uint8_t[]>(*buffer_size));
+    // Since the list of allocators began empty, buffer ID N will live at index
+    // N-1.
+    non_const_allocators.push_back(
+        MemoryAllocator(*buffer_size, non_const_buffers.back().get()));
+    non_const_allocators.back().enable_profiling("non_const_allocators");
+  }
+  HierarchicalAllocator non_const_allocator(
+      non_const_allocators.size(), non_const_allocators.data());
+
+  // Allocator for bundled input.
+  MemoryAllocator bundled_input_allocator{
+      MemoryAllocator(kBundledAllocatorPoolSize, bundled_allocator_pool)};
+
+  // The constant allocator is not currently used. Please initialize with a
+  // zero-sized allocator.
+  MemoryAllocator const_allocator{MemoryAllocator(0, nullptr)};
+  const_allocator.enable_profiling("const allocator");
+
+  // The kernel temporary allocator is not currently used. Please initialize
+  // with a zero-sized allocator.
+  MemoryAllocator temp_allocator{MemoryAllocator(0, nullptr)};
+  temp_allocator.enable_profiling("temp allocator");
+
+  // Assemble all of the allocators into the MemoryManager that the Executor
+  // will use.
+  MemoryManager memory_manager(
+      &const_allocator,
+      &non_const_allocator,
+      &runtime_allocator,
+      &temp_allocator);
+
+  //
+  // Load method from the program, using the provided
+  // allocators. Running the method can mutate allocated non_const buffers,
+  // so should only be used by a single thread at at time, but it can be reused.
+  //
+
+  Result<Method> method = program->load_method(method_name, &memory_manager);
+  ET_CHECK_MSG(
+      method.ok(),
+      "Loading of method %s failed with status 0x%" PRIx32,
+      method_name,
+      method.error());
+  ET_LOG(Info, "Method loaded.");
+
+  // Prepare the inputs.
+  // Use ones-initialized inputs or bundled inputs.
+  exec_aten::ArrayRef<void*> inputs;
+  if (FLAGS_bundled_program) {
+    // Use the inputs embedded in the bundled program.
+    status = torch::executor::util::LoadBundledInput(
+        *method,
+        file_data->data(),
+        &bundled_input_allocator,
+        0, // Using the 0th indexed program
+        FLAGS_testset_idx);
+    ET_CHECK_MSG(
+        status == Error::Ok,
+        "LoadBundledInput failed with status 0x%" PRIx32,
+        status);
+  } else {
+    // Use ones-initialized inputs.
+    inputs = torch::executor::util::PrepareInputTensors(*method);
+  }
+  ET_LOG(Info, "Inputs prepared.");
+
+  // Run the model.
+  status = method->execute();
+  ET_CHECK_MSG(
+      status == Error::Ok,
+      "Execution of method %s failed with status 0x%" PRIx32,
+      method_name,
+      status);
+  ET_LOG(Info, "Model executed successfully.");
+
+  auto output_list =
+      runtime_allocator.allocateList<EValue>(method->outputs_size());
+  status = method->get_outputs(output_list, method->outputs_size());
+  ET_CHECK(status == Error::Ok);
+  // The following code assumes all output EValues are floating point
+  // tensors. We need to handle other types of EValues and tensor
+  // dtypes. Furthermore, we need a util to print tensors in a more
+  // interpretable (e.g. size, dtype) and readable way.
+  // TODO for the above at T159700776
+  for (size_t i = 0; i < method->outputs_size(); i++) {
+    auto output_tensor = output_list[i].toTensor();
+    auto data_output = output_tensor.const_data_ptr<float>();
+    for (size_t j = 0; j < output_list[i].toTensor().numel(); ++j) {
+      ET_LOG(Info, "%f", data_output[j]);
+    }
+  }
+
+  // Dump the profiling data to the specified file.
+  torch::executor::prof_result_t prof_result;
+  EXECUTORCH_DUMP_PROFILE_RESULTS(&prof_result);
+  if (prof_result.num_bytes != 0) {
+    FILE* ptr = fopen(FLAGS_prof_result_path.c_str(), "w+");
+    fwrite(prof_result.prof_data, 1, prof_result.num_bytes, ptr);
+    fclose(ptr);
+  }
+
+  // Handle the outputs.
+  if (FLAGS_bundled_program) {
+    status = torch::executor::util::VerifyResultWithBundledExpectedOutput(
+        *method,
+        file_data->data(),
+        &bundled_input_allocator,
+        0,
+        FLAGS_testset_idx,
+        1e-5, // rtol
+        1e-8 // atol
+    );
+    ET_CHECK_MSG(
+        status == Error::Ok,
+        "Bundle verification failed with status 0x%" PRIx32,
+        status);
+    ET_LOG(Info, "Model verified successfully.");
+  } else {
+    torch::executor::util::FreeInputs(inputs);
+  }
+  return 0;
+}

--- a/examples/bundled_executor_runner/targets.bzl
+++ b/examples/bundled_executor_runner/targets.bzl
@@ -1,0 +1,30 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "get_oss_build_kwargs", "runtime")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    # Test driver for models with bundled inputs.
+    runtime.cxx_binary(
+        name = "bundled_executor_runner",
+        srcs = [
+            "bundled_executor_runner.cpp",
+        ],
+        deps = [
+            "//executorch/runtime/executor/test:test_backend_compiler_lib",
+            "//executorch/kernels/portable:generated_lib_all_ops",
+            "//executorch/runtime/executor:program",
+            "//executorch/extension/data_loader:file_data_loader",
+            "//executorch/extension/data_loader:buffer_data_loader",
+            "//executorch/util:util",
+            "//executorch/util:bundled_program_verification",
+        ],
+        external_deps = [
+            "gflags",
+        ],
+        define_static_target = True,
+        **get_oss_build_kwargs()
+    )

--- a/examples/export/export_bundled_program.py
+++ b/examples/export/export_bundled_program.py
@@ -1,0 +1,97 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Example script for exporting simple models to flatbuffer
+
+import argparse
+
+from executorch.bundled_program.config import BundledConfig
+from executorch.bundled_program.core import create_bundled_program
+from executorch.bundled_program.serialize import (
+    serialize_from_bundled_program_to_flatbuffer,
+)
+
+from ..models import MODEL_NAME_TO_MODEL
+from ..models.model_factory import EagerModelFactory
+
+from .utils import export_to_edge
+
+
+def save_bundled_program(
+    inputs,
+    exec_prog,
+    graph_module,
+    output_path,
+):
+    # Here inputs is List[Tuple[Union[torch.tenor, int, bool]]]. Each tuple is one input test
+    # set for the model. If we wish to test the model with multiple inputs then they can be
+    # appended to this list. len(inputs) == number of test sets we want to run.
+    #
+    # If we have multiple execution plans in this program then we add another list of tuples
+    # to test that corresponding execution plan. Index of list of tuples will match the index
+    # of the execution plan against which it will be tested.
+    bundled_inputs = [inputs for _ in range(len(exec_prog.program.execution_plan))]
+
+    # For each input tuple we run the graph module and put the resulting output in a list. This
+    # is repeated over all the tuples present in the input list and then repeated for each execution
+    # plan we want to test against.
+    expected_outputs = [
+        [[graph_module(*x)] for x in inputs]
+        for i in range(len(exec_prog.program.execution_plan))
+    ]
+
+    bundled_config = BundledConfig(bundled_inputs, expected_outputs)
+
+    bundled_program = create_bundled_program(exec_prog.program, bundled_config)
+    bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
+        bundled_program
+    )
+
+    with open(output_path, "wb") as file:
+        file.write(bundled_program_buffer)
+
+
+def export_to_pte(model_name, model, example_inputs):
+    edge = export_to_edge(model, example_inputs)
+    exec_prog = edge.to_executorch()
+
+    buffer = exec_prog.buffer
+
+    filename = f"{model_name}.pte"
+    print(f"Saving exported program to {filename}")
+    with open(filename, "wb") as file:
+        file.write(buffer)
+
+    # Just as an example to show how multiple input sets can be bundled along, here we
+    # create a list with the example_inputs tuple used twice. Each instance of example_inputs
+    # is a Tuple[Union[torch.tenor, int, bool]] which represents one test set for the model.
+    bundled_inputs = [example_inputs, example_inputs]
+    print(f"Saving exported program to {model_name}_bundled.pte")
+    save_bundled_program(bundled_inputs, exec_prog, model, f"{model_name}_bundled.pte")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-m",
+        "--model_name",
+        required=True,
+        help=f"provide a model name. Valid ones: {list(MODEL_NAME_TO_MODEL.keys())}",
+    )
+
+    args = parser.parse_args()
+
+    if args.model_name not in MODEL_NAME_TO_MODEL:
+        raise RuntimeError(
+            f"Model {args.model_name} is not a valid name. "
+            f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}."
+        )
+
+    model, example_inputs = EagerModelFactory.create_model(
+        *MODEL_NAME_TO_MODEL[args.model_name]
+    )
+
+    export_to_pte(args.model_name, model, example_inputs)


### PR DESCRIPTION
Summary:
This diff has a couple of changes:
- Added an example script that generates bundled programs from supported example models
- Added support in `examples/executor_runner.cpp` to consume bundled programs.

Reviewed By: larryliu0820

Differential Revision: D48768254

