### PR TITLE
Add CMake selective build examples

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -145,7 +145,7 @@ jobs:
       matrix:
         include:
           - build-tool: buck2
-          # - build-tool: cmake (TODO)
+          - build-tool: cmake
       fail-fast: false
     with:
       runner: linux.2xlarge
@@ -170,7 +170,7 @@ jobs:
       matrix:
         include:
           - build-tool: buck2
-          # - build-tool: cmake (TODO)
+          - build-tool: cmake
       fail-fast: false
     with:
       runner: macos-m1-12

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,20 @@ option(
 option(REGISTER_QUANTIZED_OPS
        "Register quantized ops defined in kernels/quantized/" OFF)
 
+option(BUILD_SELECTIVE_BUILD_TEST
+       "Whether to build binary for demo selective build" OFF)
+
+if(BUILD_SELECTIVE_BUILD_TEST)
+  option(SELECT_ALL_OPS
+         "Whether to register all ops defined in portable kernel library." OFF)
+
+  # Option to register op list
+  option(SELECT_OPS_LIST "Register the following list of ops" OFF)
+
+  # Option to register ops from yaml file
+  option(SELECT_OPS_YAML "Register all the ops from a given yaml file" OFF)
+endif()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
@@ -87,20 +101,7 @@ if(NOT EXECUTORCH_SRCS_FILE)
   # if the buck2 targets change.
   message(STATUS "executorch: Generating source lists")
   set(EXECUTORCH_SRCS_FILE "${CMAKE_CURRENT_BINARY_DIR}/executorch_srcs.cmake")
-  execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} build/extract_sources.py --buck2=${BUCK2}
-            --config=build/cmake_deps.toml --out=${EXECUTORCH_SRCS_FILE}
-    OUTPUT_VARIABLE gen_srcs_output
-    ERROR_VARIABLE gen_srcs_error
-    RESULT_VARIABLE gen_srcs_exit_code
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-  if(NOT gen_srcs_exit_code EQUAL 0)
-    message("Error while generating ${EXECUTORCH_SRCS_FILE}. "
-            "Exit code: ${gen_srcs_exit_code}")
-    message("Output:\n${gen_srcs_output}")
-    message("Error:\n${gen_srcs_error}")
-    message(FATAL_ERROR "executorch: source list generation failed")
-  endif()
+  extract_sources(${EXECUTORCH_SRCS_FILE})
 endif()
 
 # This file defines the `_<target>__srcs` variables used below.
@@ -173,5 +174,9 @@ endif()
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backends/xnnpack)
 
+# Add selective build subdirectory
+if(BUILD_SELECTIVE_BUILD_TEST)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples/selective_build)
+endif()
 # Print all summary
 executorch_print_configuration_summary()

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -23,10 +23,9 @@ function(gen_selected_ops ops_schema_yaml root_ops include_all_ops)
     list(APPEND _gen_oplist_command --root_ops="${root_ops}")
   endif()
   if(include_all_ops)
-    list(APPEND _gen_oplist_command
-         --include_all_operators="${include_all_ops}")
+    list(APPEND _gen_oplist_command --include_all_operators)
   endif()
-
+  message("Command - ${_gen_oplist_command}")
   add_custom_command(
     COMMENT "Generating selected_operators.yaml for custom ops"
     OUTPUT ${_oplist_yaml}

--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -60,9 +60,14 @@ endfunction()
 # Extract source files based on toml config. This is useful to keep buck2 and
 # cmake aligned.
 function(extract_sources sources_file)
+  if(NOT EXECUTORCH_ROOT)
+    set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} build/extract_sources.py --buck2=${BUCK2}
-            --config=build/cmake_deps.toml --out=${sources_file}
+    COMMAND
+      ${PYTHON_EXECUTABLE} ${EXECUTORCH_ROOT}/build/extract_sources.py
+      --buck2=${BUCK2} --config=${EXECUTORCH_ROOT}/build/cmake_deps.toml
+      --out=${sources_file}
     OUTPUT_VARIABLE gen_srcs_output
     ERROR_VARIABLE gen_srcs_error
     RESULT_VARIABLE gen_srcs_exit_code

--- a/examples/selective_build/CMakeLists.txt
+++ b/examples/selective_build/CMakeLists.txt
@@ -1,0 +1,69 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# Simple CMake build system for selective build demo.
+#
+# ### Editing this file ###
+#
+# This file should be formatted with
+# ~~~
+# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# ~~~
+# It should also be cmake-lint clean.
+#
+
+cmake_minimum_required(VERSION 3.19)
+set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+set(TORCH_ROOT ${EXECUTORCH_ROOT}/third-party/pytorch)
+include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
+
+#
+# select_build_lib: C++ library to register selected ops in custom kernel
+# library
+#
+set(_kernel_lib)
+if(SELECT_ALL_OPS)
+  gen_selected_ops("" "" ${SELECT_ALL_OPS})
+  list(APPEND _kernel_lib portable_kernels)
+elseif(SELECT_OPS_LIST)
+  gen_selected_ops("" ${SELECT_OPS_LIST} "")
+  list(APPEND _kernel_lib portable_kernels)
+elseif(SELECT_OPS_YAML)
+  set(_custom_ops_yaml ${EXECUTORCH_ROOT}/examples/custom_ops/custom_ops.yaml)
+  gen_selected_ops(${_custom_ops_yaml} "" "")
+  set(kernel_sources
+      ${EXECUTORCH_ROOT}/examples/custom_ops/custom_ops_1_out.cpp
+      ${EXECUTORCH_ROOT}/examples/custom_ops/custom_ops_2_out.cpp)
+  #
+  # custom_kernels: C++ kernel implementations of custom ops
+  #
+  add_library(custom_kernels ${kernel_sources})
+  target_link_libraries(custom_kernels PRIVATE executorch)
+  target_compile_options(custom_kernels PUBLIC ${_common_compile_options})
+
+  list(APPEND _kernel_lib custom_kernels)
+endif()
+generate_bindings_for_kernels(${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
+                              "${_custom_ops_yaml}")
+gen_operators_lib("select_build_lib" ${_kernel_lib} executorch)
+
+set(_updated__srcs)
+foreach(_src ${_executor_runner__srcs})
+  list(APPEND _updated__srcs "${EXECUTORCH_ROOT}/${_src}")
+endforeach()
+
+#
+# selective_build_test: test binary to allow different operator libraries to
+# link to
+#
+add_executable(selective_build_test ${_updated__srcs})
+target_link_libraries(selective_build_test executorch gflags select_build_lib)
+target_compile_options(selective_build_test PUBLIC ${_common_compile_options})
+
+# Print all summary
+executorch_print_configuration_summary()

--- a/examples/selective_build/README.md
+++ b/examples/selective_build/README.md
@@ -8,18 +8,22 @@ Prerequisite: finish the [setting up wiki](https://github.com/pytorch/executorch
 Run:
 
 ```bash
-bash test_selective_build.sh
+bash test_selective_build.sh [cmake|buck2]
 ```
 
 ## BUCK2 examples
 
 Check out `targets.bzl` for demo of 3 selective build APIs:
-1. Select all ops from the dependency kernel libraries, register all of them into Executorch runtime.
-2. Only select ops from `ops` kwarg in `et_operator_library` macro.
-3. Only select from a yaml file from `ops_schema_yaml_target` kwarg in `et_operator_library` macro.
+1. `--config executorch.select_ops=all`: Select all ops from the dependency kernel libraries, register all of them into Executorch runtime.
+2. `--config executorch.select_ops=list`: Only select ops from `ops` kwarg in `et_operator_library` macro.
+3. `--config executorch.select_ops=yaml`:Only select from a yaml file from `ops_schema_yaml_target` kwarg in `et_operator_library` macro.
 
-We have one more API incoming: only select from an exported model file (.pte).
 
 ## CMake examples
 
-TODO
+Check out `CMakeLists.txt` for demo of 3 selective build APIs:
+1. `SELECT_ALL_OPS`
+2. `SELECT_OPS_LIST`
+3. `SELECT_OPS_YAML`
+
+We have one more API incoming: only select from an exported model file (.pte).


### PR DESCRIPTION
Summary: As titled. This adds 3 examples, to build selective build demo binary with different ways of selecting operators.

Reviewed By: guangy10

Differential Revision: D48773605

