### PR TITLE
sanity check prim inputs

### DIFF
--- a/runtime/executor/test/method_meta_test.cpp
+++ b/runtime/executor/test/method_meta_test.cpp
@@ -70,7 +70,7 @@ TEST_F(MethodMetaTest, MethodMetaApi) {
   ASSERT_EQ(method_meta.error(), Error::Ok);
 
   // Appropriate amount of inputs
-  EXPECT_EQ(method_meta->num_inputs(), 2);
+  EXPECT_EQ(method_meta->num_inputs(), 3);
 
   // Appropriate amount of outputs
   EXPECT_EQ(method_meta->num_outputs(), 1);

--- a/test/models/export_program.py
+++ b/test/models/export_program.py
@@ -75,11 +75,11 @@ class ModuleAdd(nn.Module):
     def __init__(self):
         super(ModuleAdd, self).__init__()
 
-    def forward(self, x, y):
-        return torch.add(x, y)
+    def forward(self, x, y, alpha):
+        return torch.add(x, y, alpha=alpha)
 
     def get_random_inputs(self):
-        return (torch.randn(2, 2), torch.randn(2, 2))
+        return (torch.randn(2, 2), torch.randn(2, 2), 1.0)
 
 
 class ModuleLinear(torch.nn.Module):


### PR DESCRIPTION
Summary: Users cant pass prim inputs that are not what the model was traced with.

Differential Revision: D48793537

