### PR TITLE
Remove executor.h includes 1/N

### DIFF
--- a/runtime/executor/test/targets.bzl
+++ b/runtime/executor/test/targets.bzl
@@ -195,7 +195,7 @@ def define_common_targets(is_fbcode = False):
             deps = [
                 ":managed_memory_manager",
                 "//executorch/runtime/backend:backend_registry",
-                "//executorch/runtime/executor:executor",
+                "//executorch/runtime/executor:program",
                 "//executorch/extension/data_loader:buffer_data_loader",
                 "//executorch/extension/data_loader:file_data_loader",
                 "//executorch/util:util",


### PR DESCRIPTION
Summary: This is deprecated so going around removing them. Theres a bunch of usages floating around still.

Reviewed By: larryliu0820

Differential Revision: D48844125

