### PR TITLE
Add div_mode_out

### DIFF
--- a/kernels/aten/functions.yaml
+++ b/kernels/aten/functions.yaml
@@ -112,6 +112,8 @@
 
 - op: div.Scalar_out
 
+- op: div.out_mode
+
 - op: embedding.out
 
 - op: empty.out

--- a/kernels/portable/functions.yaml
+++ b/kernels/portable/functions.yaml
@@ -243,6 +243,12 @@
     - arg_meta: null
       kernel_name: torch::executor::div_scalar_out
 
+- op: div.out_mode
+  kernels:
+    - arg_meta: null
+      kernel_name: torch::executor::div_out_mode
+
+
 - op: embedding.out
   kernels:
     - arg_meta: null

--- a/kernels/portable/test/op_div_test.cpp
+++ b/kernels/portable/test/op_div_test.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/kernels/portable/Functions.h> // Declares the operator
+#include <executorch/kernels/test/TestUtil.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
+#include <algorithm>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using exec_aten::ScalarType;
+using exec_aten::SizesType;
+using exec_aten::StridesType;
+using exec_aten::Tensor;
+using torch::executor::testing::TensorFactory;
+
+// Note: This file is used for testing op_div for *portable kernel specific*.
+// If your test case is generic and should be tested on all kernels, add it to
+// executorch/kernels/test/op_div_test.cpp instead.
+
+Tensor& op_div_out_mode(
+    const Tensor& a,
+    const Tensor& b,
+    exec_aten::optional<exec_aten::string_view> mode,
+    Tensor& out) {
+  exec_aten::RuntimeContext context{};
+  return torch::executor::aten::div_outf(context, a, b, mode, out);
+}
+
+TEST(OpDivScalarOutKernelTest, SanityCheckModeTrunc) {
+  TensorFactory<ScalarType::Int> tf_a;
+  TensorFactory<ScalarType::Float> tf_out;
+
+  const std::vector<int32_t> sizes = {2, 2};
+
+  Tensor out = tf_out.zeros(sizes);
+
+  op_div_out_mode(
+      tf_a.make(sizes, {1, 2, 4, -9}),
+      tf_a.make(sizes, {2, 2, 2, 2}),
+      exec_aten::optional<exec_aten::string_view>("trunc"),
+      out);
+
+  // Check that it matches the expected output.
+  EXPECT_TENSOR_EQ(out, tf_out.make(sizes, {0.0, 1.0, 2.0, -4.0}));
+}
+
+TEST(OpDivScalarOutKernelTest, SanityCheckModeFloor) {
+  TensorFactory<ScalarType::Int> tf_a;
+  TensorFactory<ScalarType::Float> tf_out;
+
+  const std::vector<int32_t> sizes = {2, 2};
+
+  Tensor out = tf_out.zeros(sizes);
+
+  op_div_out_mode(
+      tf_a.make(sizes, {1, 2, 4, -9}),
+      tf_a.make(sizes, {2, 2, 2, 2}),
+      exec_aten::optional<exec_aten::string_view>("floor"),
+      out);
+
+  // Check that it matches the expected output.
+  EXPECT_TENSOR_EQ(out, tf_out.make(sizes, {0.0, 1.0, 2.0, -5.0}));
+}

--- a/kernels/portable/test/targets.bzl
+++ b/kernels/portable/test/targets.bzl
@@ -9,4 +9,5 @@ def define_common_targets():
     define_supported_features_lib()
 
     op_test(name = "op_allclose_test", aten_compatible = False)
+    op_test(name = "op_div_test")
     op_test(name = "op_mul_test")


### PR DESCRIPTION
Summary:
It is not core op yet (to be discussed), but it appears in torchaudio RNN-T torchaudio/models/rnnt.py.  Adding it to portable kernel for now to unblock the model.

Use the impl from div_Tensor.

Differential Revision: D48873657

