### PR TITLE
Set max kernel num

### DIFF
--- a/examples/selective_build/README.md
+++ b/examples/selective_build/README.md
@@ -16,8 +16,10 @@ bash test_selective_build.sh [cmake|buck2]
 Check out `targets.bzl` for demo of 3 selective build APIs:
 1. `--config executorch.select_ops=all`: Select all ops from the dependency kernel libraries, register all of them into Executorch runtime.
 2. `--config executorch.select_ops=list`: Only select ops from `ops` kwarg in `et_operator_library` macro.
-3. `--config executorch.select_ops=yaml`:Only select from a yaml file from `ops_schema_yaml_target` kwarg in `et_operator_library` macro.
+3. `--config executorch.select_ops=yaml`: Only select from a yaml file from `ops_schema_yaml_target` kwarg in `et_operator_library` macro.
 
+Other configs:
+- `--config executorch.max_kernel_num=N`: Only allocate memory for the required number of operators. Take this result from `selected_operators.yaml`.
 
 ## CMake examples
 
@@ -25,5 +27,8 @@ Check out `CMakeLists.txt` for demo of 3 selective build APIs:
 1. `SELECT_ALL_OPS`
 2. `SELECT_OPS_LIST`
 3. `SELECT_OPS_YAML`
+
+Other configs:
+- `MAX_KERNEL_NUM=N`
 
 We have one more API incoming: only select from an exported model file (.pte).

--- a/examples/selective_build/test_selective_build.sh
+++ b/examples/selective_build/test_selective_build.sh
@@ -29,7 +29,9 @@ test_buck2_select_ops_in_list() {
     ${PYTHON_EXECUTABLE} -m examples.export.export_example --model_name="add_mul"
 
     echo "Running selective build test"
+    # set max_kernel_num=16: 13 primops, add, mul
     buck2 run //examples/selective_build:selective_build_test \
+        --config=executorch.max_kernel_num=16 \
         --config=executorch.select_ops=list -- --model_path=./add_mul.pte
 
     echo "Removing add_mul.pte"
@@ -74,10 +76,12 @@ test_cmake_select_ops_in_list() {
     echo "Exporting add_mul"
     ${PYTHON_EXECUTABLE} -m examples.export.export_example --model_name="add_mul"
 
+    # set MAX_KERNEL_NUM=16: 13 primops, add, mul
     (rm -rf cmake-out \
         && mkdir cmake-out \
         && cd cmake-out \
         && cmake -DBUCK2=buck2 \
+            -DMAX_KERNEL_NUM=16 \
             -DBUILD_SELECTIVE_BUILD_TEST=ON \
             -DSELECT_OPS_LIST="aten::add.out,aten::mm.out" \
             -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)

--- a/runtime/kernel/operator_registry.h
+++ b/runtime/kernel/operator_registry.h
@@ -205,9 +205,12 @@ struct Kernel {
 // registered.
 constexpr uint32_t kOperatorTableMaxSize = 250;
 constexpr uint32_t kMaxNumOfKernelPerOp = 8;
+#ifdef MAX_KERNEL_NUM
+constexpr uint32_t kMaxNumOfKernels = MAX_KERNEL_NUM;
+#else
 constexpr uint32_t kMaxNumOfKernels =
     kOperatorTableMaxSize * kMaxNumOfKernelPerOp;
-
+#endif
 /**
  * See OperatorRegistry::hasOpsFn()
  */

--- a/runtime/kernel/targets.bzl
+++ b/runtime/kernel/targets.bzl
@@ -7,6 +7,7 @@ def define_common_targets():
     TARGETS and BUCK files that call this function.
     """
 
+    max_kernel_num = native.read_config("executorch", "max_kernel_num", None)
     runtime.cxx_library(
         name = "operator_registry",
         srcs = ["operator_registry.cpp"],
@@ -19,6 +20,22 @@ def define_common_targets():
             "//executorch/runtime/core:core",
             "//executorch/runtime/core:evalue",
         ],
+        preprocessor_flags = ["-DMAX_KERNEL_NUM=" + max_kernel_num] if max_kernel_num != None else [],
+    )
+
+    runtime.cxx_library(
+        name = "operator_registry_TWO_KERNELS_TEST_ONLY",
+        srcs = ["operator_registry.cpp"],
+        exported_headers = ["operator_registry.h"],
+        visibility = [
+            "//executorch/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+        exported_deps = [
+            "//executorch/runtime/core:core",
+            "//executorch/runtime/core:evalue",
+        ],
+        preprocessor_flags = ["-DMAX_KERNEL_NUM=2"],
     )
 
     for aten_mode in (True, False):

--- a/runtime/kernel/test/operator_registry_max_kernel_num_test.cpp
+++ b/runtime/kernel/test/operator_registry_max_kernel_num_test.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <vector>
+
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/kernel/kernel_runtime_context.h>
+#include <executorch/runtime/kernel/operator_registry.h>
+#include <executorch/runtime/platform/runtime.h>
+#include <executorch/test/utils/DeathTest.h>
+
+using namespace ::testing;
+
+namespace torch {
+namespace executor {
+
+class OperatorRegistryMaxKernelNumTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    torch::executor::runtime_init();
+  }
+};
+
+// Register one kernel when max_kernel_num=2; success
+TEST_F(OperatorRegistryMaxKernelNumTest, RegisterOneOp) {
+  Kernel kernels[] = {Kernel("foo", [](RuntimeContext&, EValue**) {})};
+  ArrayRef<Kernel> kernels_array = ArrayRef<Kernel>(kernels);
+  auto s1 = register_kernels(kernels_array);
+  EXPECT_EQ(s1, Error::Ok);
+  EXPECT_FALSE(hasOpsFn("fpp"));
+  EXPECT_TRUE(hasOpsFn("foo"));
+}
+
+// Register two kernels when max_kernel_num=2; fail
+TEST_F(OperatorRegistryMaxKernelNumTest, RegisterTwoOpsFail) {
+  Kernel kernels[] = {
+      Kernel("foo1", [](RuntimeContext&, EValue**) {}),
+      Kernel("foo2", [](RuntimeContext&, EValue**) {})};
+  ArrayRef<Kernel> kernels_array = ArrayRef<Kernel>(kernels);
+  ET_EXPECT_DEATH({ register_kernels(kernels_array); }, "");
+}
+
+} // namespace executor
+} // namespace torch

--- a/runtime/kernel/test/targets.bzl
+++ b/runtime/kernel/test/targets.bzl
@@ -19,6 +19,17 @@ def define_common_targets():
         ],
     )
 
+    runtime.cxx_test(
+        name = "operator_registry_max_kernel_num_test",
+        srcs = [
+            "operator_registry_max_kernel_num_test.cpp",
+        ],
+        deps = [
+            "//executorch/runtime/kernel:operator_registry_TWO_KERNELS_TEST_ONLY",
+            "//executorch/runtime/kernel:kernel_runtime_context",
+        ],
+    )
+
     et_operator_library(
         name = "executorch_all_ops",
         include_all_operators = True,


### PR DESCRIPTION
Summary: Currently, max number of kernels is [hardcoded in operator_registry.h](https://github.com/pytorch/executorch/blob/main/runtime/kernel/operator_registry.h). This diff adds a preprocessor flag to set the max kernel num to save binary size.

Reviewed By: larryliu0820

Differential Revision: D48922452


