### PR TITLE
clean up xnnpack_examples workflow

### DIFF
--- a/examples/backend/targets.bzl
+++ b/examples/backend/targets.bzl
@@ -10,6 +10,7 @@ def define_common_targets():
     runtime.python_binary(
         name = "xnnpack_examples",
         main_module = "executorch.examples.backend.xnnpack_examples",
+        preload_deps = ["//executorch/kernels/quantized:aot_lib"],
         deps = [
             ":xnnpack_examples_lib",
         ],
@@ -22,6 +23,7 @@ def define_common_targets():
         ],
         deps = [
             "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
+            "//executorch/examples/export:lib",
             "//executorch/examples/recipes/xnnpack_optimization:models",
             "//executorch/examples/quantization:quant_utils",
             "//executorch/exir:lib",

--- a/examples/recipes/xnnpack_optimization/__init__.py
+++ b/examples/recipes/xnnpack_optimization/__init__.py
@@ -4,6 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .models import MODEL_NAME_TO_OPTIONS
+from .models import MODEL_NAME_TO_OPTIONS, OptimizationOptions
 
-__all__ = [MODEL_NAME_TO_OPTIONS]
+__all__ = [MODEL_NAME_TO_OPTIONS, OptimizationOptions]

--- a/examples/recipes/xnnpack_optimization/models.py
+++ b/examples/recipes/xnnpack_optimization/models.py
@@ -9,8 +9,8 @@ from dataclasses import dataclass
 
 @dataclass
 class OptimizationOptions(object):
-    quantization: bool
-    xnnpack_delegation: bool
+    quantization: bool = False
+    xnnpack_delegation: bool = False
 
 
 MODEL_NAME_TO_OPTIONS = {


### PR DESCRIPTION
Summary:
Allow 4 modes:
- xnnpack delegation, quantization
- xnnpack delegation, no quantization
- no xnnpack delegation (use portable lib), no quantization
- no xnnpack delegation (use portable lib), quantization

For quantization without delegation, additional aot library is needed.

Clean up the work flow and fix deps.

Reviewed By: salilsdesai

Differential Revision: D48987438


