### PR TITLE
Increase the job timeout duration from 30m to 60m

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -47,6 +47,7 @@ jobs:
       docker-image: executorch-ubuntu-22.04-clang12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 60
       script: |
         PYTHON_VERSION=3.10
         # TODO: Figure out why /opt/conda/envs/py_$PYTHON_VERSION/bin is not in the path
@@ -73,6 +74,7 @@ jobs:
       runner: macos-m1-12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 60
       script: |
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"


### PR DESCRIPTION
I see the large model `resnes50` testing timing out after 30m, i.e. https://github.com/pytorch/executorch/actions/runs/6092644935/job/16531150306, it must be close to that. So, I preemptively increase the timeout to 60m.