### PR TITLE
[lint][py] Set up lintrunner for executorch

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,37 @@
+[flake8]
+# NOTE: **Mirror any changes** to this file the [tool.ruff] config in pyproject.toml
+# before we can fully move to use ruff
+enable-extensions = G
+select = B,C,E,F,G,P,SIM1,T4,W,B9
+max-line-length = 120
+# C408 ignored because we like the dict keyword argument syntax
+# E501 is not flexible enough, we're using B950 instead
+ignore =
+    E203,E305,E402,E501,E721,E741,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,
+    # fix these lints in the future
+    E275,
+    # shebang has extra meaning in fbcode lints, so I think it's not worth trying
+    # to line this up with executable bit
+    EXE001,
+    # these ignores are from flake8-bugbear; please fix!
+    B007,B008,B017,B019,B020,B023,B024,B026,B028,B903,B904,B905,B906,B907
+    # these ignores are from flake8-comprehensions; please fix!
+    C407,
+    # these ignores are from flake8-logging-format; please fix!
+    G100,G101,G200,G201,G202
+    # these ignores are from flake8-simplify. please fix or ignore with commented reason
+    SIM105,SIM108,SIM110,SIM111,SIM113,SIM114,SIM115,SIM116,SIM117,SIM118,SIM119,SIM12,
+    # flake8-simplify code styles
+    SIM102,SIM103,SIM106,SIM112,
+optional-ascii-coding = True
+exclude =
+    ./.git,
+    ./backends/xnnpack/third-party,
+    ./build,
+    ./configurations,
+    ./docs,
+    ./docs/cpp/src,
+    ./docs/src,
+    ./tools/linter/adapters,
+    ./third_party,
+    *.pyi

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ bundled_program/serialize/scalar_type.fbs
 *.swp
 *~
 .~lock.*
+
+# clang tooling storage location
+.clang-format-bin
+.clang-tidy-bin
+.lintbin

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1,0 +1,59 @@
+merge_base_with = "origin/main"
+
+[[linter]]
+code = 'FLAKE8'
+include_patterns = ['**/*.py']
+exclude_patterns = [
+    '.git/**',
+    'backends/xnnpack/third-party/**',
+    'build/**',
+    'configurations/**',
+    'docs/**',
+    'tools/linter/adapters/**',
+    'third_party/**',
+    '**/*.pyi',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/flake8_linter.py',
+    '--',
+    '@{{PATHSFILE}}'
+]
+init_command = [
+    'python3',
+    'tools/linter/adapters/pip_init.py',
+    '--dry-run={{DRYRUN}}',
+    'flake8==6.0.0',
+    'flake8-bugbear==23.3.23',
+    'flake8-comprehensions==3.12.0',
+    'flake8-executable==2.1.3',
+    'flake8-logging-format==0.9.0',
+    'flake8-pyi==23.3.1',
+    'flake8-simplify==0.19.3',
+    'mccabe==0.7.0',
+    'pycodestyle==2.10.0',
+    'pyflakes==3.0.1',
+]
+is_formatter = true
+
+
+[[linter]]
+code = 'NEWLINE'
+include_patterns=['**']
+exclude_patterns=[
+    'backends/xnnpack/third-party/**',
+    'third_party/**',
+    '**/*.bat',
+    '**/*.expect',
+    '**/*.ipynb',
+    '**/*.ps1',
+    '**/*.ptl',
+    '**/*.png',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/newlines_linter.py',
+    '--',
+    '@{{PATHSFILE}}',
+]
+is_formatter = true

--- a/tools/linter/adapters/flake8_linter.py
+++ b/tools/linter/adapters/flake8_linter.py
@@ -1,0 +1,369 @@
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import time
+from enum import Enum
+from typing import Any, Dict, List, NamedTuple, Optional, Pattern, Set
+
+
+IS_WINDOWS: bool = os.name == "nt"
+
+
+def eprint(*args: Any, **kwargs: Any) -> None:
+    print(*args, file=sys.stderr, flush=True, **kwargs)
+
+
+class LintSeverity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+    ADVICE = "advice"
+    DISABLED = "disabled"
+
+
+class LintMessage(NamedTuple):
+    path: Optional[str]
+    line: Optional[int]
+    char: Optional[int]
+    code: str
+    severity: LintSeverity
+    name: str
+    original: Optional[str]
+    replacement: Optional[str]
+    description: Optional[str]
+
+
+def as_posix(name: str) -> str:
+    return name.replace("\\", "/") if IS_WINDOWS else name
+
+
+# fmt: off
+# https://www.flake8rules.com/
+DOCUMENTED_IN_FLAKE8RULES: Set[str] = {
+    "E101", "E111", "E112", "E113", "E114", "E115", "E116", "E117",
+    "E121", "E122", "E123", "E124", "E125", "E126", "E127", "E128", "E129",
+    "E131", "E133",
+    "E201", "E202", "E203",
+    "E211",
+    "E221", "E222", "E223", "E224", "E225", "E226", "E227", "E228",
+    "E231",
+    "E241", "E242",
+    "E251",
+    "E261", "E262", "E265", "E266",
+    "E271", "E272", "E273", "E274", "E275",
+    "E301", "E302", "E303", "E304", "E305", "E306",
+    "E401", "E402",
+    "E501", "E502",
+    "E701", "E702", "E703", "E704",
+    "E711", "E712", "E713", "E714",
+    "E721", "E722",
+    "E731",
+    "E741", "E742", "E743",
+    "E901", "E902", "E999",
+    "W191",
+    "W291", "W292", "W293",
+    "W391",
+    "W503", "W504",
+    "W601", "W602", "W603", "W604", "W605",
+    "F401", "F402", "F403", "F404", "F405",
+    "F811", "F812",
+    "F821", "F822", "F823",
+    "F831",
+    "F841",
+    "F901",
+    "C901",
+}
+
+# https://pypi.org/project/flake8-comprehensions/#rules
+DOCUMENTED_IN_FLAKE8COMPREHENSIONS: Set[str] = {
+    "C400", "C401", "C402", "C403", "C404", "C405", "C406", "C407", "C408", "C409",
+    "C410",
+    "C411", "C412", "C413", "C414", "C415", "C416",
+}
+
+# https://github.com/PyCQA/flake8-bugbear#list-of-warnings
+DOCUMENTED_IN_BUGBEAR: Set[str] = {
+    "B001", "B002", "B003", "B004", "B005", "B006", "B007", "B008", "B009", "B010",
+    "B011", "B012", "B013", "B014", "B015",
+    "B301", "B302", "B303", "B304", "B305", "B306",
+    "B901", "B902", "B903", "B950",
+}
+# fmt: on
+
+
+# stdin:2: W802 undefined name 'foo'
+# stdin:3:6: T484 Name 'foo' is not defined
+# stdin:3:-100: W605 invalid escape sequence '\/'
+# stdin:3:1: E302 expected 2 blank lines, found 1
+RESULTS_RE: Pattern[str] = re.compile(
+    r"""(?mx)
+    ^
+    (?P<file>.*?):
+    (?P<line>\d+):
+    (?:(?P<column>-?\d+):)?
+    \s(?P<code>\S+?):?
+    \s(?P<message>.*)
+    $
+    """
+)
+
+
+def _test_results_re() -> None:
+    """
+    >>> def t(s): return RESULTS_RE.search(s).groupdict()
+
+    >>> t(r"file.py:80:1: E302 expected 2 blank lines, found 1")
+    ... # doctest: +NORMALIZE_WHITESPACE
+    {'file': 'file.py', 'line': '80', 'column': '1', 'code': 'E302',
+     'message': 'expected 2 blank lines, found 1'}
+
+    >>> t(r"file.py:7:1: P201: Resource `stdout` is acquired but not always released.")
+    ... # doctest: +NORMALIZE_WHITESPACE
+    {'file': 'file.py', 'line': '7', 'column': '1', 'code': 'P201',
+     'message': 'Resource `stdout` is acquired but not always released.'}
+
+    >>> t(r"file.py:8:-10: W605 invalid escape sequence '/'")
+    ... # doctest: +NORMALIZE_WHITESPACE
+    {'file': 'file.py', 'line': '8', 'column': '-10', 'code': 'W605',
+     'message': "invalid escape sequence '/'"}
+    """
+    pass
+
+
+def _run_command(
+    args: List[str],
+    *,
+    extra_env: Optional[Dict[str, str]],
+) -> "subprocess.CompletedProcess[str]":
+    logging.debug(
+        "$ %s",
+        " ".join(
+            ([f"{k}={v}" for (k, v) in extra_env.items()] if extra_env else []) + args
+        ),
+    )
+    start_time = time.monotonic()
+    try:
+        return subprocess.run(
+            args,
+            capture_output=True,
+            check=True,
+            encoding="utf-8",
+        )
+    finally:
+        end_time = time.monotonic()
+        logging.debug("took %dms", (end_time - start_time) * 1000)
+
+
+def run_command(
+    args: List[str],
+    *,
+    extra_env: Optional[Dict[str, str]],
+    retries: int,
+) -> "subprocess.CompletedProcess[str]":
+    remaining_retries = retries
+    while True:
+        try:
+            return _run_command(args, extra_env=extra_env)
+        except subprocess.CalledProcessError as err:
+            if remaining_retries == 0 or not re.match(
+                r"^ERROR:1:1: X000 linting with .+ timed out after \d+ seconds",
+                err.stdout,
+            ):
+                raise err
+            remaining_retries -= 1
+            logging.warning(
+                "(%s/%s) Retrying because command failed with: %r",
+                retries - remaining_retries,
+                retries,
+                err,
+            )
+            time.sleep(1)
+
+
+def get_issue_severity(code: str) -> LintSeverity:
+    # "B901": `return x` inside a generator
+    # "B902": Invalid first argument to a method
+    # "B903": __slots__ efficiency
+    # "B950": Line too long
+    # "C4": Flake8 Comprehensions
+    # "C9": Cyclomatic complexity
+    # "E2": PEP8 horizontal whitespace "errors"
+    # "E3": PEP8 blank line "errors"
+    # "E5": PEP8 line length "errors"
+    # "F401": Name imported but unused
+    # "F403": Star imports used
+    # "F405": Name possibly from star imports
+    # "T400": type checking Notes
+    # "T49": internal type checker errors or unmatched messages
+    if any(
+        code.startswith(x)
+        for x in [
+            "B9",
+            "C4",
+            "C9",
+            "E2",
+            "E3",
+            "E5",
+            "F401",
+            "F403",
+            "F405",
+            "T400",
+            "T49",
+        ]
+    ):
+        return LintSeverity.ADVICE
+
+    # "F821": Undefined name
+    # "E999": syntax error
+    if any(code.startswith(x) for x in ["F821", "E999"]):
+        return LintSeverity.ERROR
+
+    # "F": PyFlakes Error
+    # "B": flake8-bugbear Error
+    # "E": PEP8 "Error"
+    # "W": PEP8 Warning
+    # possibly other plugins...
+    return LintSeverity.WARNING
+
+
+def get_issue_documentation_url(code: str) -> str:
+    if code in DOCUMENTED_IN_FLAKE8RULES:
+        return f"https://www.flake8rules.com/rules/{code}.html"
+
+    if code in DOCUMENTED_IN_FLAKE8COMPREHENSIONS:
+        return "https://pypi.org/project/flake8-comprehensions/#rules"
+
+    if code in DOCUMENTED_IN_BUGBEAR:
+        return "https://github.com/PyCQA/flake8-bugbear#list-of-warnings"
+
+    return ""
+
+
+def check_files(
+    filenames: List[str],
+    flake8_plugins_path: Optional[str],
+    severities: Dict[str, LintSeverity],
+    retries: int,
+) -> List[LintMessage]:
+    try:
+        proc = run_command(
+            [sys.executable, "-mflake8", "--exit-zero"] + filenames,
+            extra_env={"FLAKE8_PLUGINS_PATH": flake8_plugins_path}
+            if flake8_plugins_path
+            else None,
+            retries=retries,
+        )
+    except (OSError, subprocess.CalledProcessError) as err:
+        return [
+            LintMessage(
+                path=None,
+                line=None,
+                char=None,
+                code="FLAKE8",
+                severity=LintSeverity.ERROR,
+                name="command-failed",
+                original=None,
+                replacement=None,
+                description=(
+                    f"Failed due to {err.__class__.__name__}:\n{err}"
+                    if not isinstance(err, subprocess.CalledProcessError)
+                    else (
+                        "COMMAND (exit code {returncode})\n"
+                        "{command}\n\n"
+                        "STDERR\n{stderr}\n\n"
+                        "STDOUT\n{stdout}"
+                    ).format(
+                        returncode=err.returncode,
+                        command=" ".join(as_posix(x) for x in err.cmd),
+                        stderr=err.stderr.strip() or "(empty)",
+                        stdout=err.stdout.strip() or "(empty)",
+                    )
+                ),
+            )
+        ]
+
+    return [
+        LintMessage(
+            path=match["file"],
+            name=match["code"],
+            description=f"{match['message']}\nSee {get_issue_documentation_url(match['code'])}",
+            line=int(match["line"]),
+            char=int(match["column"])
+            if match["column"] is not None and not match["column"].startswith("-")
+            else None,
+            code="FLAKE8",
+            severity=severities.get(match["code"]) or get_issue_severity(match["code"]),
+            original=None,
+            replacement=None,
+        )
+        for match in RESULTS_RE.finditer(proc.stdout)
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Flake8 wrapper linter.",
+        fromfile_prefix_chars="@",
+    )
+    parser.add_argument(
+        "--flake8-plugins-path",
+        help="FLAKE8_PLUGINS_PATH env value",
+    )
+    parser.add_argument(
+        "--severity",
+        action="append",
+        help="map code to severity (e.g. `B950:advice`)",
+    )
+    parser.add_argument(
+        "--retries",
+        default=3,
+        type=int,
+        help="times to retry timed out flake8",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="verbose logging",
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="+",
+        help="paths to lint",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="<%(threadName)s:%(levelname)s> %(message)s",
+        level=logging.NOTSET
+        if args.verbose
+        else logging.DEBUG
+        if len(args.filenames) < 1000
+        else logging.INFO,
+        stream=sys.stderr,
+    )
+
+    flake8_plugins_path = (
+        None
+        if args.flake8_plugins_path is None
+        else os.path.realpath(args.flake8_plugins_path)
+    )
+
+    severities: Dict[str, LintSeverity] = {}
+    if args.severity:
+        for severity in args.severity:
+            parts = severity.split(":", 1)
+            assert len(parts) == 2, f"invalid severity `{severity}`"
+            severities[parts[0]] = LintSeverity(parts[1])
+
+    lint_messages = check_files(
+        args.filenames, flake8_plugins_path, severities, args.retries
+    )
+    for lint_message in lint_messages:
+        print(json.dumps(lint_message._asdict()), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/linter/adapters/newlines_linter.py
+++ b/tools/linter/adapters/newlines_linter.py
@@ -1,0 +1,163 @@
+"""
+NEWLINE: Checks files to make sure there are no trailing newlines.
+"""
+import argparse
+import json
+import logging
+import sys
+
+from enum import Enum
+from typing import List, NamedTuple, Optional
+
+NEWLINE = 10  # ASCII "\n"
+CARRIAGE_RETURN = 13  # ASCII "\r"
+LINTER_CODE = "NEWLINE"
+
+
+class LintSeverity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+    ADVICE = "advice"
+    DISABLED = "disabled"
+
+
+class LintMessage(NamedTuple):
+    path: Optional[str]
+    line: Optional[int]
+    char: Optional[int]
+    code: str
+    severity: LintSeverity
+    name: str
+    original: Optional[str]
+    replacement: Optional[str]
+    description: Optional[str]
+
+
+def check_file(filename: str) -> Optional[LintMessage]:
+    logging.debug("Checking file %s", filename)
+
+    with open(filename, "rb") as f:
+        lines = f.readlines()
+
+    if len(lines) == 0:
+        # File is empty, just leave it alone.
+        return None
+
+    if len(lines) == 1 and len(lines[0]) == 1:
+        # file is wrong whether or not the only byte is a newline
+        return LintMessage(
+            path=filename,
+            line=None,
+            char=None,
+            code=LINTER_CODE,
+            severity=LintSeverity.ERROR,
+            name="testestTrailing newline",
+            original=None,
+            replacement=None,
+            description="Trailing newline found. Run `lintrunner --take NEWLINE -a` to apply changes.",
+        )
+
+    if len(lines[-1]) == 1 and lines[-1][0] == NEWLINE:
+        try:
+            original = b"".join(lines).decode("utf-8")
+        except Exception as err:
+            return LintMessage(
+                path=filename,
+                line=None,
+                char=None,
+                code=LINTER_CODE,
+                severity=LintSeverity.ERROR,
+                name="Decoding failure",
+                original=None,
+                replacement=None,
+                description=f"utf-8 decoding failed due to {err.__class__.__name__}:\n{err}",
+            )
+
+        return LintMessage(
+            path=filename,
+            line=None,
+            char=None,
+            code=LINTER_CODE,
+            severity=LintSeverity.ERROR,
+            name="Trailing newline",
+            original=original,
+            replacement=original.rstrip("\n") + "\n",
+            description="Trailing newline found. Run `lintrunner --take NEWLINE -a` to apply changes.",
+        )
+    has_changes = False
+    original_lines: Optional[List[bytes]] = None
+    for idx, line in enumerate(lines):
+        if len(line) >= 2 and line[-1] == NEWLINE and line[-2] == CARRIAGE_RETURN:
+            if not has_changes:
+                original_lines = list(lines)
+                has_changes = True
+            lines[idx] = line[:-2] + b"\n"
+
+    if has_changes:
+        try:
+            assert original_lines is not None
+            original = b"".join(original_lines).decode("utf-8")
+            replacement = b"".join(lines).decode("utf-8")
+        except Exception as err:
+            return LintMessage(
+                path=filename,
+                line=None,
+                char=None,
+                code=LINTER_CODE,
+                severity=LintSeverity.ERROR,
+                name="Decoding failure",
+                original=None,
+                replacement=None,
+                description=f"utf-8 decoding failed due to {err.__class__.__name__}:\n{err}",
+            )
+        return LintMessage(
+            path=filename,
+            line=None,
+            char=None,
+            code=LINTER_CODE,
+            severity=LintSeverity.ERROR,
+            name="DOS newline",
+            original=original,
+            replacement=replacement,
+            description="DOS newline found. Run `lintrunner --take NEWLINE -a` to apply changes.",
+        )
+
+    return None
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="native functions linter",
+        fromfile_prefix_chars="@",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="location of native_functions.yaml",
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="+",
+        help="paths to lint",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="<%(threadName)s:%(levelname)s> %(message)s",
+        level=logging.NOTSET
+        if args.verbose
+        else logging.DEBUG
+        if len(args.filenames) < 1000
+        else logging.INFO,
+        stream=sys.stderr,
+    )
+
+    lint_messages = []
+    for filename in args.filenames:
+        lint_message = check_file(filename)
+        if lint_message is not None:
+            lint_messages.append(lint_message)
+
+    for lint_message in lint_messages:
+        print(json.dumps(lint_message._asdict()), flush=True)

--- a/tools/linter/adapters/pip_init.py
+++ b/tools/linter/adapters/pip_init.py
@@ -1,0 +1,83 @@
+"""
+Initializer script that installs stuff to pip.
+"""
+import argparse
+import logging
+import os
+import subprocess
+import sys
+import time
+
+from typing import List
+
+
+def run_command(args: List[str]) -> "subprocess.CompletedProcess[bytes]":
+    logging.debug("$ %s", " ".join(args))
+    start_time = time.monotonic()
+    try:
+        return subprocess.run(args, check=True)
+    finally:
+        end_time = time.monotonic()
+        logging.debug("took %dms", (end_time - start_time) * 1000)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="pip initializer")
+    parser.add_argument(
+        "packages",
+        nargs="+",
+        help="pip packages to install",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="verbose logging",
+    )
+    parser.add_argument(
+        "--dry-run", help="do not install anything, just print what would be done."
+    )
+    parser.add_argument(
+        "--no-black-binary",
+        help="do not use pre-compiled binaries from pip for black.",
+        action="store_true",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="<%(threadName)s:%(levelname)s> %(message)s",
+        level=logging.NOTSET if args.verbose else logging.DEBUG,
+        stream=sys.stderr,
+    )
+
+    pip_args = ["pip3", "install"]
+
+    # If we are in a global install, use `--user` to install so that you do not
+    # need root access in order to initialize linters.
+    #
+    # However, `pip install --user` interacts poorly with virtualenvs (see:
+    # https://bit.ly/3vD4kvl) and conda (see: https://bit.ly/3KG7ZfU). So in
+    # these cases perform a regular installation.
+    in_conda = os.environ.get("CONDA_PREFIX") is not None
+    in_virtualenv = os.environ.get("VIRTUAL_ENV") is not None
+    if not in_conda and not in_virtualenv:
+        pip_args.append("--user")
+
+    pip_args.extend(args.packages)
+
+    for package in args.packages:
+        package_name, _, version = package.partition("=")
+        if version == "":
+            raise RuntimeError(
+                "Package {package_name} did not have a version specified. "
+                "Please specify a version to produce a consistent linting experience."
+            )
+        if args.no_black_binary and "black" in package_name:
+            pip_args.append(f"--no-binary={package_name}")
+
+    dry_run = args.dry_run == "1"
+    if dry_run:
+        print(f"Would have run: {pip_args}")
+        sys.exit(0)
+
+    run_command(pip_args)

--- a/tools/linter/adapters/s3_init.py
+++ b/tools/linter/adapters/s3_init.py
@@ -1,0 +1,216 @@
+import argparse
+import hashlib
+import json
+import logging
+import os
+import platform
+import stat
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# String representing the host platform (e.g. Linux, Darwin).
+HOST_PLATFORM = platform.system()
+HOST_PLATFORM_ARCH = platform.system() + "-" + platform.processor()
+
+# PyTorch directory root
+try:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+    PYTORCH_ROOT = result.stdout.decode("utf-8").strip()
+except subprocess.CalledProcessError:
+    # If git is not installed, compute repo root as 3 folders up from this file
+    path_ = os.path.abspath(__file__)
+    for _ in range(4):
+        path_ = os.path.dirname(path_)
+    PYTORCH_ROOT = path_
+
+DRY_RUN = False
+
+
+def compute_file_sha256(path: str) -> str:
+    """Compute the SHA256 hash of a file and return it as a hex string."""
+    # If the file doesn't exist, return an empty string.
+    if not os.path.exists(path):
+        return ""
+
+    hash = hashlib.sha256()
+
+    # Open the file in binary mode and hash it.
+    with open(path, "rb") as f:
+        for b in f:
+            hash.update(b)
+
+    # Return the hash as a hexadecimal string.
+    return hash.hexdigest()
+
+
+def report_download_progress(
+    chunk_number: int, chunk_size: int, file_size: int
+) -> None:
+    """
+    Pretty printer for file download progress.
+    """
+    if file_size != -1:
+        percent = min(1, (chunk_number * chunk_size) / file_size)
+        bar = "#" * int(64 * percent)
+        sys.stdout.write(f"\r0% |{bar:<64}| {int(percent * 100)}%")
+
+
+def check(binary_path: Path, reference_hash: str) -> bool:
+    """Check whether the binary exists and is the right one.
+
+    If there is hash difference, delete the actual binary.
+    """
+    if not binary_path.exists():
+        logging.info("%s does not exist.", binary_path)
+        return False
+
+    existing_binary_hash = compute_file_sha256(str(binary_path))
+    if existing_binary_hash == reference_hash:
+        return True
+
+    logging.warning(
+        """\
+Found binary hash does not match reference!
+
+Found hash: %s
+Reference hash: %s
+
+Deleting %s just to be safe.
+""",
+        existing_binary_hash,
+        reference_hash,
+        binary_path,
+    )
+    if DRY_RUN:
+        logging.critical(
+            "In dry run mode, so not actually deleting the binary. But consider deleting it ASAP!"
+        )
+        return False
+
+    try:
+        binary_path.unlink()
+    except OSError as e:
+        logging.critical("Failed to delete binary: %s", e)
+        logging.critical(
+            "Delete this binary as soon as possible and do not execute it!"
+        )
+
+    return False
+
+
+def download(
+    name: str,
+    output_dir: str,
+    url: str,
+    reference_bin_hash: str,
+) -> bool:
+    """
+    Download a platform-appropriate binary if one doesn't already exist at the expected location and verifies
+    that it is the right binary by checking its SHA256 hash against the expected hash.
+    """
+    # First check if we need to do anything
+    binary_path = Path(output_dir, name)
+    if check(binary_path, reference_bin_hash):
+        logging.info("Correct binary already exists at %s. Exiting.", binary_path)
+        return True
+
+    # Create the output folder
+    binary_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Download the binary
+    logging.info("Downloading %s to %s", url, binary_path)
+
+    if DRY_RUN:
+        logging.info("Exiting as there is nothing left to do in dry run mode")
+        return True
+
+    urllib.request.urlretrieve(
+        url,
+        binary_path,
+        reporthook=report_download_progress if sys.stdout.isatty() else None,
+    )
+
+    logging.info("Downloaded %s successfully.", name)
+
+    # Check the downloaded binary
+    if not check(binary_path, reference_bin_hash):
+        logging.critical("Downloaded binary %s failed its hash check", name)
+        return False
+
+    # Ensure that executable bits are set
+    mode = os.stat(binary_path).st_mode
+    mode |= stat.S_IXUSR
+    os.chmod(binary_path, mode)
+
+    logging.info("Using %s located at %s", name, binary_path)
+    return True
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="downloads and checks binaries from s3",
+    )
+    parser.add_argument(
+        "--config-json",
+        required=True,
+        help="Path to config json that describes where to find binaries and hashes",
+    )
+    parser.add_argument(
+        "--linter",
+        required=True,
+        help="Which linter to initialize from the config json",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="place to put the binary",
+    )
+    parser.add_argument(
+        "--output-name",
+        required=True,
+        help="name of binary",
+    )
+    parser.add_argument(
+        "--dry-run",
+        default=False,
+        help="do not download, just print what would be done",
+    )
+
+    args = parser.parse_args()
+    if args.dry_run == "0":
+        DRY_RUN = False
+    else:
+        DRY_RUN = True
+
+    logging.basicConfig(
+        format="[DRY_RUN] %(levelname)s: %(message)s"
+        if DRY_RUN
+        else "%(levelname)s: %(message)s",
+        level=logging.INFO,
+        stream=sys.stderr,
+    )
+
+    config = json.load(open(args.config_json))
+    config = config[args.linter]
+
+    # Allow processor specific binaries for platform (namely Intel and M1 binaries for MacOS)
+    host_platform = HOST_PLATFORM if HOST_PLATFORM in config else HOST_PLATFORM_ARCH
+    # If the host platform is not in platform_to_hash, it is unsupported.
+    if host_platform not in config:
+        logging.error("Unsupported platform: %s/%s", HOST_PLATFORM, HOST_PLATFORM_ARCH)
+        exit(1)
+
+    url = config[host_platform]["download_url"]
+    hash = config[host_platform]["hash"]
+
+    ok = download(args.output_name, args.output_dir, url, hash)
+    if not ok:
+        logging.critical("Unable to initialize %s", args.linter)
+        sys.exit(1)

--- a/tools/linter/adapters/s3_init_config.json
+++ b/tools/linter/adapters/s3_init_config.json
@@ -1,0 +1,53 @@
+{
+    "HOW TO UPDATE THE BINARIES": [
+        "Upload the new file to S3 under a new folder with the version number embedded in (see actionlint for an example).",
+        "(Don't override the old files, otherwise you'll break `lintrunner install` for anyone using an older commit of pytorch.)",
+        "'Hash' is the sha256 of the uploaded file.",
+        "Validate the new download url and hash by running 'lintrunner init' to pull the new binaries and then run 'lintrunner' to try linting the files.",
+        "Some binaries have custom builds; see https://github.com/pytorch/test-infra/blob/main/.github/workflows/clang-tidy-linux.yml and https://github.com/pytorch/test-infra/blob/main/.github/workflows/clang-tidy-macos.yml"
+    ],
+    "clang-format": {
+        "Darwin": {
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/mac/clang-format-mojave",
+            "hash": "1485a242a96c737ba7cdd9f259114f2201accdb46d87ac7a8650b1a814cd4d4d"
+        },
+        "Linux": {
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/clang-format-linux64",
+            "hash": "e1c8b97b919541a99e0a355df5c3f9e8abebc64259dbee6f8c68e1ef90582856"
+        }
+    },
+    "clang-tidy": {
+        "Darwin-i386": {
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/macos-i386/15.0.6/clang-tidy",
+            "hash": "11c9234155dd5b7aec8cf46ea9629401c4432576615b6eff2a5a4c5e3f9e6504"
+        },
+        "Darwin-arm": {
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/macos-arm/15.0.6/clang-tidy",
+            "hash": "4ed664cf50bb9fddec2d4170b3d7bbe0135dc5648acbd620b61c8d25a5a2fdb7"
+        },
+        "Linux": {
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/15.0.6/clang-tidy",
+            "hash": "8defeb3a2698caca60251f9d682bc08374f1a37eec77d515533affdd03f93add"
+        }
+    },
+    "actionlint": {
+        "Darwin": {
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/actionlint/1.6.21/Darwin_amd64/actionlint",
+            "hash": "b354db83815384d3c3a07f68f44b30cb0a70899757a0d185d7322de9952e8813"
+        },
+        "Linux": {
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/actionlint/1.6.21/Linux_arm64/actionlint",
+            "hash": "025ac157db121b33971ef24af72d73d71cda3cb1e3a94795bb2708ef4032ca76"
+        }
+    },
+    "bazel": {
+        "Darwin": {
+            "download_url": "https://raw.githubusercontent.com/bazelbuild/bazelisk/v1.16.0/bazelisk.py",
+            "hash": "1f6d76d023ddd5f1625f34d934418e7334a267318d084f31be09df8a8835ed16"
+        },
+        "Linux": {
+            "download_url": "https://raw.githubusercontent.com/bazelbuild/bazelisk/v1.16.0/bazelisk.py",
+            "hash": "1f6d76d023ddd5f1625f34d934418e7334a267318d084f31be09df8a8835ed16"
+        }
+    }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #219


Enable linter for `.py` code first. `clang-format` for `.cpp` is removed from this PR to simplify the initial bringup of `lintrunner` to `executorch` for 3P integration.


Drop-in `flake8` related linters from pytorch `tools/linter/adapters/*`.
Drop-in and cast `.flake8`, `.lintrunner.toml` for `executorch` (by modifying the copy from `pytorch`).


 1. `pip install lintrunner`
 2. `lintrunner init`
 3. Make local changes to a file, e.g. `examples/backend/xnnpack_examples.py`, then run `lintrunner -a`
 
```
Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.


>>> Lint for examples/backend/xnnpack_examples.py:

  Advice (FLAKE8) E251
    unexpected spaces around keyword / parameter equals
    See https://www.flake8rules.com/rules/E251.html

         46  |        "-q",
         47  |        "--quantize",
         48  |        action="store_true",
    >>>  49  |        required   =False,
         50  |        default=False,
         51  |        help="Flag for producing quantized or floating-point model",
         52  |    )

  Advice (FLAKE8) E221
    multiple spaces before operator
    See https://www.flake8rules.com/rules/E221.html

         46  |        "-q",
         47  |        "--quantize",
         48  |        action="store_true",
    >>>  49  |        required   =False,
         50  |        default=False,
         51  |        help="Flag for producing quantized or floating-point model",
         52  |    )

  Warning (FLAKE8) G004
    Logging statement uses f-string
    See

         99  |            passes=[DuplicateDequantNodePass()],
        100  |        ),
        101  |    )
    >>> 102  |    logging.info(f"Exported graph:\n{edge.exported_program.graph}")
        103  |
        104  |    edge.exported_program = to_backend(edge.exported_program, partitioner)
        105  |    logging.info(f"Lowered graph:\n{edge.exported_program.graph}")

  Warning (FLAKE8) G004
    Logging statement uses f-string
    See

        102  |    logging.info(f"Exported graph:\n{edge.exported_program.graph}")
        103  |
        104  |    edge.exported_program = to_backend(edge.exported_program, partitioner)
    >>> 105  |    logging.info(f"Lowered graph:\n{edge.exported_program.graph}")
        106  |
        107  |    exec_prog = edge.to_executorch()
        108  |

Successfully applied all patches.
```

**TODO:** Thought the linter says "Successfully applied all patches", however, the code are not modified by the linter.