### PR TITLE
Add demo backend with delegate mapping generation

### DIFF
--- a/docs/website/docs/tutorials/profiling_and_debugging_delegates.md
+++ b/docs/website/docs/tutorials/profiling_and_debugging_delegates.md
@@ -1,0 +1,140 @@
+# Profiling and debugging delegates
+
+Delegate backends are a prominent component of Edge Models. One attribute of
+delegated backends is that they operate mostly as an opaque transformation.
+This gives delegate authors greater freedom when defining backend behavior,
+but also prevents the Executorch authoring flow from tracking underlying changes.
+
+This makes associating profiling and debug information through delegated
+graphs difficult. We have provided a framework that will enable delegate authors
+to propagate this information and retrieve it for post run analysis. The process is
+broken down into two stages:
+
+1) **Ahead-of-time delegation stage** - Delegate authors need to generate
+a debug handle map using the process described below.
+
+2) **Runtime stage** - Delegate authors need to log the profiling data along with the
+delegate debug identifiers generated in stage 1 using the API's described below in
+the runtime section.
+
+## 1). AOT (ahead-of-time) delegation Stage
+### Generating a debug handle map:
+**Delegate debug identifiers** are used by delegate authors to mark points of
+interest in the lowered graph. Identifiers are associated with operator
+nodes of the pre-lowered model graph.
+
+- *For example: If a delegate author wants to signal the fusion of 3 operators
+into a single operator of the lowered graph, they would register the 3
+original operators to the delegate debug identifier ahead-of-time and then log using the
+delegate debug identifier at runtime.*
+
+This is tracked by the `debug_handle_map` and returned as a part of
+**PreprocessResult** by the call to `preprocess` from the ahead-of-time implementation of the delegated
+backends. The `debug_handle_map` is essentially used as a mechanism to communicate what transformations
+occurred in the backend.
+
+```python
+class PreprocessResult:
+    processed_bytes: bytes = bytes()
+
+    debug_handle_map: Optional[
+        Union[Dict[int, Tuple[int]], Dict[str, Tuple[int]]]
+    ] = None
+
+    ...
+```
+
+The construction of this map is done via a **DelegateMappingBuilder**.
+
+
+### DelegateMappingBuilder
+
+**DelegateMappingBuilder** is a helper class for managing and constructing
+`delegate_handle_map`. A new instance should be used in each `preprocess` call
+and the result of this builder should be passed in when constructing
+`PreprocessResult`
+
+First, create a DelegateMappingBuilder instance that uses either
+manually provided identifiers or generated identifiers for node association.
+
+- `DelegateMappingBuilder()`
+  - With __manual identifiers__, users pass in a str or int delegate debug identifier
+  when creating entries
+- `DelegateMappingBuilder(generated_identifiers=True)`
+  - With __generated identifier__, the builder will auto-assign an delegate debug identifier
+
+**Note: A single DelegateMappingBuilder instance can use either manual
+or generated identifiers, but not both**
+
+
+Next, use `insert_delegate_mapping_entry` to iteratively construct the
+delegate_map. It takes Node(s) to associate and an optional
+delegate debug identifier (only intended to be used for the manual identifiers case described above).
+The identifier used is returned from the call.
+
+```python
+def insert_delegate_mapping_entry(
+    self,
+    nodes: Union[fx.Node, List[fx.Node]],
+    identifier: Optional[Union[int, str]] = None,
+) -> Union[int, str]:
+```
+
+Finally, use `get_delegate_mapping` to retrieve the constructed map.
+The return value can be directly passed to **PreprocessResults**.
+
+```python
+def get_delegate_mapping(
+    self,
+) -> Union[Dict[int, Tuple[int]], Dict[str, Tuple[int]]]
+```
+
+## 2). Runtime stage
+
+NOTE : These API's are not available yet but shown here to give a representation of what the
+runtime side of things looks like.
+
+### ID based API's:
+
+If users used integer ID's to generate delegate_debug_identifiers during the AOT process then
+they should log their profiling events using the following API's.
+
+Option 1 (For when users can explicitly mark the start and end of an event):
+```C++
+EventEntry event_entry = EVENT_TRACER_BEGIN_DELEGATE_PROFILING_EVENT_ID(event_tracer, id)
+EVENT_TRACER_END_DELEGATE_PROFILING_EVENT_ID(event_entry)
+```
+
+Option 2 (For when users only have access to the start and end time of the events after they have occurred.)
+```C++
+EVENT_TRACER_LOG_DELEGATE_PROFILING_EVENT_ID(event_tracer, id, start_time, end_time)
+```
+
+### String based API's:
+
+If users used strings to generate delegate_debug_identifiers during the AOT process then they
+should log their profiling events using the following API's.
+
+Option 1 (For when users can explicitly mark the start and end of an event):
+```C++
+EventEntry = EVENT_TRACER_BEGIN_DELEGATE_PROFILING_EVENT_NAME(event_tracer, name)
+EVENT_TRACER_END_DELEGATE_PROFILING_EVENT_NAME(event_entry)
+```
+
+Option 2 (For when users only have access to the start and end time of the events after they have occurred.)
+```C++
+EVENT_TRACER_LOG_DELEGATE_PROFILING_EVENT_NAME(event_tracer, name, start_time, end_time)
+```
+
+## Examples:
+
+To indicate how these API's can be used we have provided an end-to-end representative example.
+
+Demo backend that generates delegate mapping for a model that undergoes some simple transformations
+in the backend.
+`executorch/exir/backend/test/backend_with_delegate_mapping_demo.py`
+
+Corresponding runtime backend code that logs the delegate debug identifiers that were generated
+during the ahead-of-time processing done in the above backend example.
+
+`executorch/runtime/executor/test/test_backend_with_delegate_mapping.cpp`

--- a/exir/backend/test/TARGETS
+++ b/exir/backend/test/TARGETS
@@ -21,6 +21,24 @@ python_library(
 )
 
 python_library(
+    name = "backend_with_delegate_mapping_demo",
+    srcs = [
+        "backend_with_delegate_mapping_demo.py",
+    ],
+    visibility = [
+        "//executorch/...",
+        "//executorch/test/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir/backend:backend_details",
+        "//executorch/exir/backend:compile_spec_schema",
+        "//executorch/exir/backend:utils",
+        "//executorch/exir/dialects:lib",
+    ],
+)
+
+python_library(
     name = "qnn_backend_demo",
     srcs = [
         "qnn_backend_demo.py",
@@ -234,8 +252,10 @@ python_unittest(
         "test_delegate_map_builder.py",
     ],
     deps = [
+        ":backend_with_delegate_mapping_demo",
         "//caffe2:torch",
         "//executorch/exir:lib",
+        "//executorch/exir/backend:backend_api",
         "//executorch/exir/backend:utils",
     ],
 )

--- a/exir/backend/test/backend_with_delegate_mapping_demo.py
+++ b/exir/backend/test/backend_with_delegate_mapping_demo.py
@@ -1,0 +1,180 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Union
+
+import torch
+from executorch.exir.backend.backend_details import BackendDetails, PreprocessResult
+from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.exir.backend.utils import DelegateMappingBuilder
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch import nn
+from torch._export.exported_program import ExportedProgram
+
+# A simple way to represent an op along with its delegate debug identifier.
+class DummyOp:
+    def __init__(
+        self,
+        op: str,
+        delegate_debug_identifier: Union[int, str],
+    ):
+        self.op = op
+        self.delegate_debug_identifier = delegate_debug_identifier
+        self.__name__ = self.__repr__()
+
+    def __repr__(self):
+        return f"{self.op}"
+
+    def serialize(self):
+        return f"{self.op},{self.delegate_debug_identifier},"
+
+
+"""
+This demo implementation is mainly intended to show how the DelegateMappingBuilder should be used
+in backends. There are two use cases represented here:
+1. A list of decomposed ops are fused into a single backend op and how the delegate debug identifier
+mapping is generated for that.
+2. A single op is decomposed into two backend ops and we show how the delegate debug identifier mapping
+is generated for that.
+
+Here is what the graph looks like for the demo model ConvReLUAddModel implemented in this class:
+input
+ ↓
+conv (debug_handle : 1)
+ ↓
+relu (debug_handle : 2)
+ ↓
+tan (debug_handle : 3)
+ ↓
+output
+
+Here is what the graph that runs in the backend looks like:
+input
+ ↓
+fused_conv_relu (delegate_debug_identifier : a)
+ ↓
+sin (delegate_debug_identifier : b)
+ ↓
+cos (delegate_debug_identifier : c)
+ ↓
+div (delegate_debug_identifier : d)
+output
+
+Here is what the delegate mapping looks like. The key is the delegate_debug_identifier and the value
+is the debug handles.
+{ a : (1,2), b : (3), c: (3), d: (3)}
+(NOTE: Here a,b,c can be integers or strings, the decision is left to the user, but whatever is
+used during the AOT process to generate the mapping should be the same int/string logged in the
+runtime.)
+
+NOTE: these two graphs are not necessarily functionally equivalent but rather representative
+examples on how to generated delegate debug identifieres for various use cases such as fusion of ops
+in the backend, decomposition of ops in the backend etc.
+"""
+
+
+class BackendWithDelegateMappingDemo(BackendDetails):
+    @staticmethod
+    def preprocess(
+        edge_program: ExportedProgram,
+        compile_specs: List[CompileSpec],
+    ) -> PreprocessResult:
+        processed_bytes = ""
+        number_of_instruction = 0
+        delegate_builder = DelegateMappingBuilder(generated_identifiers=True)
+
+        for node in edge_program.graph.nodes:
+            if node.op == "call_function":
+                # Here we demonstrate case 1 where a couple of ops are fused into a single op.
+                # In this case the pattern of conv + relu is detected and fused into a single
+                # delegated op and the corresponding delegate debug identifier for that is generated
+                # and stored in the serialized blob.
+                if node.target == exir_ops.edge.aten.relu.default:
+                    input_node = node.args[0]
+                    if input_node.target == exir_ops.edge.aten.convolution.default:
+                        delegate_debug_identifier = (
+                            delegate_builder.insert_delegate_mapping_entry(
+                                [input_node, node]
+                            )
+                        )
+                        conv_relu_op = DummyOp(
+                            "conv_relu_op",
+                            delegate_debug_identifier,
+                        )
+                        number_of_instruction += 1
+                        processed_bytes += conv_relu_op.serialize()
+
+                # Here we demonstrate case 2 where a single op is decomposed into three backend ops.
+                # In this case the tan op is detected and decomposed into sin, cos and div ops. The
+                # corresponding delegate debug identifieres are generated for the three delegatged ops which
+                # map to the original tan op. These delegate debug identifieres are then serialized into the
+                # blob.
+                elif node.target == exir_ops.edge.aten.tan.default:
+                    delegate_debug_identifier = (
+                        delegate_builder.insert_delegate_mapping_entry(node)
+                    )
+                    sin_decomp_from_addmm = DummyOp(
+                        "sin_decomp_from_tan",
+                        delegate_debug_identifier,
+                    )
+                    number_of_instruction += 1
+                    processed_bytes += sin_decomp_from_addmm.serialize()
+
+                    delegate_debug_identifier = (
+                        delegate_builder.insert_delegate_mapping_entry(node)
+                    )
+                    cos_decomp_from_addmm = DummyOp(
+                        "cos_decomp_from_tan",
+                        delegate_debug_identifier,
+                    )
+                    number_of_instruction += 1
+                    processed_bytes += cos_decomp_from_addmm.serialize()
+
+                    delegate_debug_identifier = (
+                        delegate_builder.insert_delegate_mapping_entry(node)
+                    )
+                    div_decomp_from_addmm = DummyOp(
+                        "div_decomp_from_tan",
+                        delegate_debug_identifier,
+                    )
+                    number_of_instruction += 1
+                    processed_bytes += div_decomp_from_addmm.serialize()
+            elif node.op in ["placeholder", "output", "get_attr"]:
+                continue
+            else:
+                raise RuntimeError(
+                    f"{node.op} is not supported in backend BackendWithCompilerDemo"
+                )
+
+        return PreprocessResult(
+            processed_bytes=bytes(
+                str(number_of_instruction) + "#" + processed_bytes, encoding="utf8"
+            ),
+            # pyre-ignore
+            debug_handle_map=delegate_builder.get_delegate_mapping(),
+        )
+
+    @staticmethod
+    # The sample model that will work with BackendWithDelegateMapping show above.
+    def get_test_model_and_inputs():
+        class ConvReLUAddModel(nn.Module):
+            def __init__(self):
+                super(ConvReLUAddModel, self).__init__()
+                # Define a convolutional layer
+                self.conv_layer = nn.Conv2d(
+                    in_channels=1, out_channels=64, kernel_size=3, padding=1
+                )
+
+            def forward(self, x):
+                # Forward pass through convolutional layer
+                conv_output = self.conv_layer(x)
+                # Apply ReLU activation
+                relu_output = nn.functional.relu(conv_output)
+                # Perform tan on relu output
+                added_output = torch.tan(relu_output)
+                return added_output
+
+        return (ConvReLUAddModel(), (torch.randn(1, 1, 32, 32),))

--- a/exir/backend/test/test_delegate_map_builder.py
+++ b/exir/backend/test/test_delegate_map_builder.py
@@ -40,12 +40,12 @@ class TestDelegateMapBuilder(unittest.TestCase):
         delegate_builder = DelegateMappingBuilder(generated_identifiers=True)
 
         expected_mapping = {0: (0, 1, 2, 3)}
-        self.assertEqual(delegate_builder.upsert_delegate_mapping_entry(self.nodes), 0)
+        self.assertEqual(delegate_builder.insert_delegate_mapping_entry(self.nodes), 0)
         self.assertEqual(delegate_builder.get_delegate_mapping(), expected_mapping)
 
         expected_mapping = {0: (0, 1, 2, 3), 1: (0,)}
         self.assertEqual(
-            delegate_builder.upsert_delegate_mapping_entry(self.nodes[0]), 1
+            delegate_builder.insert_delegate_mapping_entry(self.nodes[0]), 1
         )
         self.assertEqual(delegate_builder.get_delegate_mapping(), expected_mapping)
 
@@ -60,37 +60,34 @@ class TestDelegateMapBuilder(unittest.TestCase):
 
         expected_mapping = {0: (0,)}
         self.assertEqual(
-            delegate_builder.upsert_delegate_mapping_entry(self.nodes[0]), 0
+            delegate_builder.insert_delegate_mapping_entry(self.nodes[0]), 0
         )
         self.assertEqual(delegate_builder.get_delegate_mapping(), expected_mapping)
-        self._test_appending_nodes(delegate_builder, 0)
 
     def test_appending_nodes_manual_int_identifier(self):
         delegate_builder = DelegateMappingBuilder()
 
         expected_mapping = {22: (0,)}
         self.assertEqual(
-            delegate_builder.upsert_delegate_mapping_entry(self.nodes[0], 22), 22
+            delegate_builder.insert_delegate_mapping_entry(self.nodes[0], 22), 22
         )
         self.assertEqual(delegate_builder.get_delegate_mapping(), expected_mapping)
-        self._test_appending_nodes(delegate_builder, 22)
 
     def test_appending_nodes_manual_string_identifier(self):
         delegate_builder = DelegateMappingBuilder()
 
         expected_mapping = {"22": (0,)}
         self.assertEqual(
-            delegate_builder.upsert_delegate_mapping_entry(self.nodes[0], "22"), "22"
+            delegate_builder.insert_delegate_mapping_entry(self.nodes[0], "22"), "22"
         )
         self.assertEqual(delegate_builder.get_delegate_mapping(), expected_mapping)
-        self._test_appending_nodes(delegate_builder, "22")
 
     def test_adding_manual_identifier_when_generated(self):
         delegate_builder = DelegateMappingBuilder(generated_identifiers=True)
 
         self.assertRaises(
             Exception,
-            lambda: delegate_builder.upsert_delegate_mapping_entry(self.nodes, "22"),
+            lambda: delegate_builder.insert_delegate_mapping_entry(self.nodes, "22"),
         )
 
     def test_omitting_identifier_when_not_generated(self):
@@ -98,7 +95,15 @@ class TestDelegateMapBuilder(unittest.TestCase):
 
         self.assertRaises(
             Exception,
-            lambda: delegate_builder.upsert_delegate_mapping_entry(self.nodes),
+            lambda: delegate_builder.insert_delegate_mapping_entry(self.nodes),
+        )
+
+    def test_resinsert_delegate_debug_identifier(self):
+        delegate_builder = DelegateMappingBuilder()
+        delegate_builder.insert_delegate_mapping_entry(self.nodes[0], "1")
+        self.assertRaises(
+            Exception,
+            lambda: delegate_builder.insert_delegate_mapping_entry(self.nodes[0], "1"),
         )
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -118,7 +123,7 @@ class TestDelegateMapBuilder(unittest.TestCase):
         iden_1 = next(identifiers)
         expected_mapping = {iden_1: (0, 1, 2, 3)}
         self.assertEqual(
-            delegate_builder.upsert_delegate_mapping_entry(self.nodes, iden_1), iden_1
+            delegate_builder.insert_delegate_mapping_entry(self.nodes, iden_1), iden_1
         )
         self.assertEqual(delegate_builder.get_delegate_mapping(), expected_mapping)
 
@@ -126,42 +131,7 @@ class TestDelegateMapBuilder(unittest.TestCase):
         iden_2 = next(identifiers)
         expected_mapping = {iden_1: (0, 1, 2, 3), iden_2: (0,)}
         self.assertEqual(
-            delegate_builder.upsert_delegate_mapping_entry(self.nodes[0], iden_2),
+            delegate_builder.insert_delegate_mapping_entry(self.nodes[0], iden_2),
             iden_2,
-        )
-        self.assertEqual(delegate_builder.get_delegate_mapping(), expected_mapping)
-
-    def _test_appending_nodes(
-        self, delegate_builder: DelegateMappingBuilder, identifier: Union[int, str]
-    ):
-        """
-        For the provided delegate_builder and identifier:
-        1) Append a duplicate Node (previously in builder)
-        2) Append a list of Nodes
-        3) Append a single Node
-
-        Verify behavior results
-        """
-        # Add a duplicate node
-        expected_mapping = {identifier: (0,)}
-        self.assertEqual(
-            delegate_builder.upsert_delegate_mapping_entry(self.nodes[0], identifier),
-            identifier,
-        )
-        self.assertEqual(delegate_builder.get_delegate_mapping(), expected_mapping)
-
-        # Add a list of nodes
-        expected_mapping = {identifier: (0, 1, 2)}
-        self.assertEqual(
-            delegate_builder.upsert_delegate_mapping_entry(self.nodes[1:5], identifier),
-            identifier,
-        )
-        self.assertEqual(delegate_builder.get_delegate_mapping(), expected_mapping)
-
-        # Add a single node
-        expected_mapping = {identifier: (0, 1, 2, 3)}
-        self.assertEqual(
-            delegate_builder.upsert_delegate_mapping_entry(self.nodes[5], identifier),
-            identifier,
         )
         self.assertEqual(delegate_builder.get_delegate_mapping(), expected_mapping)

--- a/exir/backend/utils.py
+++ b/exir/backend/utils.py
@@ -200,7 +200,7 @@ class DelegateMappingBuilder:
         # pyre-ignore Warning between Union[Dict[K, V], Dict[K2, V]] vs Dict[Union[K, K2], V]
         return {k: tuple(sorted(v)) for k, v in self._debug_handle_map.items()}
 
-    def upsert_delegate_mapping_entry(
+    def insert_delegate_mapping_entry(
         self,
         nodes: Union[Node, List[Node]],
         identifier: Optional[Union[int, str]] = None,
@@ -230,13 +230,14 @@ class DelegateMappingBuilder:
         """
 
         # Check for manual addition of identifier (with generated identifiers enabled)
-        if (
-            self._generated_identifiers
-            and identifier is not None
-            and identifier not in self._debug_handle_map
-        ):
+        if self._generated_identifiers and identifier is not None:
             raise Exception(
                 f"Builders using generated identifiers can't manually add identifiers: {identifier}. Failed to add or update entry"
+            )
+
+        if identifier is not None and identifier in self._debug_handle_map:
+            raise Exception(
+                "This delegate debug identifier was already inserted. Duplicate delegate debug identifiers are not allowed."
             )
 
         # Resolve Identifier

--- a/runtime/executor/test/targets.bzl
+++ b/runtime/executor/test/targets.bzl
@@ -33,6 +33,30 @@ def define_common_targets(is_fbcode = False):
             link_whole = True,
         )
 
+        runtime.cxx_library(
+            name = "test_backend_with_delegate_mapping" + aten_suffix,
+            srcs = [
+                "test_backend_with_delegate_mapping.cpp",
+            ],
+            visibility = [
+                "//executorch/exir/backend/test/...",
+                "//executorch/runtime/backend/...",
+                "//executorch/extension/pybindings/...",
+                "//executorch/sdk/runners/...",
+                "//executorch/test/...",
+                "//executorch/examples/...",
+            ],
+            # registration of backends is done through a static global
+            compiler_flags = ["-Wno-global-constructors"],
+            preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],
+            exported_deps = [
+                "//executorch/runtime/backend:backend_registry" + aten_suffix,
+            ],
+            # TestBackendCompilerLib.cpp needs to compile with executor as whole
+            # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
+            link_whole = True,
+        )
+
     runtime.cxx_test(
         name = "executor_test",
         srcs = [

--- a/runtime/executor/test/test_backend_with_delegate_mapping.cpp
+++ b/runtime/executor/test/test_backend_with_delegate_mapping.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/backend/backend_registry.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/evalue.h>
+
+#include <cstdlib> /* strtol */
+#include <cstring>
+
+namespace torch {
+namespace executor {
+
+struct DemoOp {
+  const char* name;
+  long int debug_handle;
+};
+
+struct DemoOpList {
+  DemoOp* ops;
+  size_t numops;
+};
+
+class BackendWithDelegateMapping final : public PyTorchBackendInterface {
+ public:
+  ~BackendWithDelegateMapping() = default;
+
+  bool is_available() const override {
+    return true;
+  }
+
+  // The delegate blob schema will be a list of instruction:
+  // {op_name:{str},delegate debug identifier:{int}}
+  // Instructions will be separated by #, for example:
+  // `op_name:demo_linear,delegate debug
+  // identifier:0#op_name:mm_decomp_from_addmm,\ delegate debug
+  // identifier:1#op_name:mm_decomp_from_addmm,delegate debug identifier:2`
+  Error parse_delegate(
+      const char* str,
+      DemoOpList* op_list,
+      MemoryAllocator* runtime_allocator) const {
+    char* op_name;
+    char* delegate_debug_identifier;
+    size_t num_ops = 0;
+    char* copy = strdup(str);
+
+    while (true) {
+      op_name = strtok(copy, ",");
+      delegate_debug_identifier = strtok(nullptr, ",");
+
+      if (op_name == nullptr || delegate_debug_identifier == nullptr) {
+        break;
+      }
+
+      if (op_name != nullptr && delegate_debug_identifier != nullptr) {
+        char* op_name_mem = (char*)ET_ALLOCATE_OR_RETURN_ERROR(
+            runtime_allocator, strlen(op_name) + 1);
+        memcpy(op_name_mem, op_name, strlen(op_name) + 1);
+        op_list->ops[num_ops].name = op_name_mem;
+        op_list->ops[num_ops].debug_handle = atoi(delegate_debug_identifier);
+      }
+
+      num_ops += 1;
+      if (num_ops == op_list->numops) {
+        break;
+      }
+      copy = nullptr;
+    }
+
+    free(copy);
+    return Error::Ok;
+  }
+
+  Result<DelegateHandle*> init(
+      FreeableBuffer* processed,
+      ArrayRef<CompileSpec> compile_specs,
+      MemoryAllocator* runtime_allocator) const override {
+    (void)compile_specs;
+    const char* kSignLiteral = "#";
+    // The first number is the number of total instruction
+    const char* start = static_cast<const char*>(processed->data());
+    char* instruction_number_end =
+        const_cast<char*>(strstr(start, kSignLiteral));
+    long int instruction_number = strtol(start, &instruction_number_end, 10);
+    ET_CHECK_OR_RETURN_ERROR(
+        instruction_number >= 0,
+        InvalidArgument,
+        "Instruction count must be non-negative: %ld",
+        instruction_number);
+
+    auto op_list =
+        ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(runtime_allocator, DemoOpList);
+    op_list->ops = ET_ALLOCATE_LIST_OR_RETURN_ERROR(
+        runtime_allocator, DemoOp, instruction_number);
+    op_list->numops = static_cast<size_t>(instruction_number);
+
+    Error error =
+        parse_delegate(instruction_number_end + 1, op_list, runtime_allocator);
+    if (error != Error::Ok) {
+      return error;
+    }
+
+    return op_list;
+  }
+
+  // This function doesn't actually execute the op but just prints out the op
+  // name and the corresponding delegate debug identifier.
+  Error execute(DelegateHandle* handle, EValue** args) const override {
+    (void)args;
+    // example: [('prim::Constant#1', 14), ('aten::add', 15)]
+    auto op_list = static_cast<const DemoOpList*>(handle);
+
+    for (size_t index = 0; index < op_list->numops; index++) {
+      ET_LOG(
+          Info,
+          "Op name = %s Delegate debug index = %ld",
+          op_list->ops[index].name,
+          op_list->ops[index].debug_handle);
+    }
+    // The below API's are not available yet but they are a representative
+    // example of what we'll be enabling.
+    /*
+    Option 1: Log performance event with an ID. An integer ID must have been
+    provided to DelegateMappingBuilder during AOT compilation.
+    */
+    // EVENT_TRACER_LOG_DELEGATE_PROFILING_EVENT_ID(op_list->ops[index].debug_handle,
+    // start_time, end_time);
+    /*
+    Option 2: Log performance event with a name. A string
+    name must have been provided to DelegateMappingBuilder during AOT
+    compilation.
+    */
+    // EVENT_TRACER_LOG_DELEGATE_PROFILING_EVENT_NAME(op_list->ops[index].name,
+    // start_time, end_time);
+
+    return Error::Ok;
+  }
+};
+
+namespace {
+auto cls = BackendWithDelegateMapping();
+Backend backend{"BackendWithDelegateMappingDemo", &cls};
+static auto success_with_compiler = register_backend(backend);
+} // namespace
+
+} // namespace executor
+} // namespace torch

--- a/sdk/runners/targets.bzl
+++ b/sdk/runners/targets.bzl
@@ -21,6 +21,7 @@ def define_common_targets():
             srcs = ["executor_runner.cpp"],
             deps = [
                 "//executorch/runtime/executor/test:test_backend_compiler_lib" + aten_suffix,
+                "//executorch/runtime/executor/test:test_backend_with_delegate_mapping" + aten_suffix,
                 "//executorch/runtime/executor:program" + aten_suffix,
                 "//executorch/sdk/etdump:etdump",
                 "//executorch/util:bundled_program_verification" + aten_suffix,


### PR DESCRIPTION
Summary:
This diff does two things:
1) Adds a demo backend that generates debug maps for a simple model
2) Adds a cpp backend that can run the model generated in step 1.

The demo backend aims to demonstrate mainly how a debug mapping can be generated using `DelegateMappingBuilder` mainly for 2 cases
- For fusion of a couple of ops into a single delegate op
- For decomposition of an op into multiple delegate ops.

Reviewed By: digantdesai, cccclai

Differential Revision: D48975979


