### PR TITLE
Update the development guide with an improved package management script and newly added packages

### DIFF
--- a/docs/website/docs/tutorials/00_setting_up_executorch.md
+++ b/docs/website/docs/tutorials/00_setting_up_executorch.md
@@ -19,13 +19,30 @@ conda activate executorch
 conda install -c conda-forge flatbuffers
 ```
 
-Setting up PyTorch
+### Step 2: Clone the `executorch` repo
+
 ```bash
-# Install the nightly builds
+# Do one of these, depending on how your auth is set up
+git clone https://github.com/pytorch/executorch.git
+git clone git@github.com:pytorch/executorch.git
+```
+Ensure that git has fetched and updated the submodules. This is necessary anytime
+commit hash of any of the submodules changes. Thus it is safe and necessary at times to apply this step after you pull changes from upstream.
+
+```bash
+cd executorch
+git submodule sync
+git submodule update --init
+```
+
+### Step 3: Install `executorch` pip package and dependencies
+
+Install all required python dependencies and PyTorch dependencies.
+```bash
+cd executorch
 # Note: if you are behind a firewall an appropriate proxy server must be setup
 # for all subsequent steps.
-TORCH_VERSION=2.1.0.dev20230831
-pip install --force-reinstall --pre torch=="${TORCH_VERSION}" -i https://download.pytorch.org/whl/nightly/cpu
+bash ./install_requirements.sh
 ```
 
 When getting a new version of the executorch repo (via clone, fetch, or pull),
@@ -33,21 +50,7 @@ you may need to re-install a new version the PyTorch nightly pip package. The
 `TORCH_VERSION` value in this document will be the correct version for the
 corresponsing version of the repo.
 
-### Step 2: Install the `executorch` pip package
-
-This will install an  `executorch` pip package to your conda environment.
-
-```bash
-# Do one of these, depending on how your auth is set up
-git clone https://github.com/pytorch/executorch.git
-git clone git@github.com:pytorch/executorch.git
-
-# Install the pip package
-cd executorch
-pip install .
-```
-
-### Step 3: Generate a program file from an `nn.Module`
+### Step 4: Generate a program file from an `nn.Module`
 
 Via python script:
 ```bash
@@ -68,7 +71,11 @@ $ python3
 >>> open("mul.pte", "wb").write(exir.capture(m, m.get_random_inputs()).to_edge().to_executorch().buffer)
 ```
 
+Please refer to the [More Examples](./00_setting_up_executorch.md#more-examples) section for running with more popular models.
+
 ## Runtime Setup
+
+Follow [AOT Setup: Step 2](./00_setting_up_executorch.md#step-2-clone-the-executorch-repo) above to clone the `executorch` repo if you haven't already.
 
 ### Step 1: Install buck2
 
@@ -83,26 +90,7 @@ zstd -cdq buck2-DOWNLOADED_FILENAME.zst > /tmp/buck2 && chmod +x /tmp/buck2
 
 You may want to copy the `buck2` binary into your `$PATH` so you can run it as `buck2`.
 
-### Step 2: Clone the `executorch` repo
-
-Clone the repo if you haven't already.
-
-```bash
-# Do one of these, depending on how your auth is set up
-git clone https://github.com/pytorch/executorch.git
-git clone git@github.com:pytorch/executorch.git
-```
-
-Ensure that git has fetched and updated the submodules. This is necessary anytime
-commit hash of any of the submodules changes. Thus it is safe and necessary at times to apply this step after you pull changes from upstream.
-
-```bash
-cd executorch
-git submodule sync
-git submodule update --init
-```
-
-### Step 3: Build a binary
+### Step 2: Build a binary
 
 `executor_runner` is an example wrapper around executorch runtime which includes all the operators and backends
 
@@ -133,7 +121,7 @@ or execute the binary directly from the `--show-output` path shown when building
 ./buck-out/.../executor_runner --model_path add.pte
 ```
 
-## More examples
+## More Examples
 
-The `executorch/examples` directory contains useful scripts with a guide to lower and run
-popular models like MobileNetv2 on Executorch.
+The [`executorch/examples`](https://github.com/pytorch/executorch/blob/main/examples) directory contains useful examples with a guide to lower and run
+popular models like MobileNet V3, Torchvision ViT, Wav2Letter, etc. on Executorch.

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,8 +36,6 @@ model name from the list of available models in the `models` dir.
 ```bash
 cd executorch # To the top level dir
 
-bash examples/install_requirements.sh
-
 # To get a list of example models
 python3 -m examples.export.export_example -h
 
@@ -104,4 +102,10 @@ In order to make sure model's listed in examples are importable, e.g. via
 from executorch.examples.models.mobilenet_v3d import MV3Model
 m = MV3Model.get_model()
 ```
-we need to have appropriate packages installed. You should install these deps via install_requirements.sh.
+You need to follow the setup guide in [Setting up ExecuTorch from GitHub](/docs/website/docs/tutorials/00_setting_up_executorch.md) to have appropriate packages installed. If you haven't already, install these deps via
+
+```bash
+cd executorch
+
+bash ./install_requirements.sh
+```

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -5,17 +5,20 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# install pre-requisite
-# here it is used to install torchvision's nighlty package because the latest
-# variant install an older version of pytorch, 1.8,
-# tested only on linux
+# Install required python dependencies for developing
+# Dependencies are defined in .pyproject.toml
+pip install .
 
+# Install pytorch dependencies
+#
 # Note:
 # When getting a new version of the executorch repo (via clone, fetch, or pull),
-# you may need to re-install a new version for all dependencies in order to the
+# you may need to re-install a new version for all pytorch dependencies in order to the
 # models in executorch/examples/models.
 # The version in this file will be the correct version for the
 # corresponsing version of the repo.
+TORCH_VERSION=2.1.0.dev20230831
+pip install --force-reinstall --pre torch=="${TORCH_VERSION}" -i https://download.pytorch.org/whl/nightly/cpu
 
 TORCH_VISION_VERSION=0.16.0.dev20230831
 pip install --force-reinstall --pre torchvision=="${TORCH_VISION_VERSION}" -i https://download.pytorch.org/whl/nightly/cpu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,19 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "executorch"
 version = "0.1.0"
+# Python dependencies required for development
 dependencies=[
-  "ruamel.yaml",
-  "pyyaml",
-  "sympy",
+  "expecttest",
+  "hypothesis",
   "numpy",
-  "zstd",
-  "flatbuffers",
+  "packaging",
+  "parameterized",
+  "pytest",
+  "pyyaml",
+  "ruamel.yaml",
+  "sympy",
   "tomli",
+  "zstd",
 ]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
# Summary:

## This PR
 - Added `pytest` and other packages to enable running python tests with `pytest` (`pytest.ini` will be added separately)
 - Added all required python packages to `requirements.txt`
 - Moved `install_requirements.sh` to `executorch` root
 - Consolidated py deps installation by simply running `bash ./install_requirements.sh`
 - Updated `examples/README.md` to reflect the package installation changes
 - Revisited `00_setting_up_executorch.md` with simplified workflow to set up executorch dev

## Next
  1. Add a global config for pytest, i.e. `pytest.init`
  2. Cover all successfully runnable python tests in OSS CI

NOTE: Not all python tests could run successfully, so we will need to resolve issues one-by-one.

-----

# Test Plan:

WARNING: Make sure you run `bash ./install_requirements.sh` from `executorch` dir after this Diff/PR landed.

With that, you will be able to run `pytest` in `executorch`, e.g.

```
pytest exir/tests/test_capture.py -v
```
```
=========================================================== test session starts ============================================================
platform linux -- Python 3.10.0, pytest-7.4.1, pluggy-1.3.0 -- /home/guangyang/.conda/envs/executorch/bin/python3.10
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/data/users/guangyang/executorch/.hypothesis/examples')
rootdir: /data/users/guangyang/executorch
plugins: hypothesis-6.84.2
collected 14 items

exir/tests/test_capture.py::TestCapture::test_capture_multiple PASSED                                                                [  7%]
exir/tests/test_capture.py::TestCapture::test_capture_multiple_capture_default_forward PASSED                                        [ 14%]
exir/tests/test_capture.py::TestCapture::test_capture_multiple_merge PASSED                                                          [ 21%]
exir/tests/test_capture.py::TestCapture::test_capture_multiple_merge_failure PASSED                                                  [ 28%]
exir/tests/test_capture.py::TestCapture::test_capture_multiple_no_method_specified PASSED                                            [ 35%]
exir/tests/test_capture.py::TestCapture::test_capture_multiple_non_module_callable PASSED                                            [ 42%]
exir/tests/test_capture.py::TestCapture::test_capture_multiple_non_module_callable_dict_args PASSED                                  [ 50%]
exir/tests/test_capture.py::TestCapture::test_capture_multiple_part_of_method PASSED                                                 [ 57%]
exir/tests/test_capture.py::TestCapture::test_capture_multiple_program_property_access_failure PASSED                                [ 64%]
exir/tests/test_capture.py::TestCapture::test_capture_multiple_program_property_access_success_forward PASSED                        [ 71%]
exir/tests/test_capture.py::TestCapture::test_capture_multiple_program_property_access_success_non_forward PASSED                    [ 78%]
exir/tests/test_capture.py::TestCapture::test_capture_prim PASSED                                                                    [ 85%]
exir/tests/test_capture.py::TestCapture::test_module_call_0_basic_sin_max PASSED                                                     [ 92%]
exir/tests/test_capture.py::TestCapture::test_module_call_1_composite_delegate PASSED                                                [100%]

============================================================= warnings summary =============================================================
../../../../home/guangyang/.conda/envs/executorch/lib/python3.10/site-packages/executorch/exir/dialects/edge/_ops.py:11
  /home/guangyang/.conda/envs/executorch/lib/python3.10/site-packages/executorch/exir/dialects/edge/_ops.py:11: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================== 14 passed, 1 warning in 3.95s =======================================================
```

Differential Revision: D49037160


