### PR TITLE
[ghexport] update relative path to fit thrift input

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,6 @@ executorch
 
 ## License
 ExecuTorch is BSD licensed, as found in the LICENSE file.
+
+# Hello I'm a useless probably doesn't need to get committed change which is used to test ghexport for executorch
+# Hello I am another change :)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #226
* __->__ #231

updates shipit.py to use the correct relative path. It used to be the case that the relative path would be something like "pytorch/executorch" which doesn't work with the translate_paths thrift request, but "pytorch/executorch/" does.

Differential Revision: [D49027012](https://our.internmc.facebook.com/intern/diff/D49027012/)