### PR TITLE
Add option to disable XNNPACK executor runner build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,10 @@ if(BUILD_SELECTIVE_BUILD_TEST)
   option(SELECT_OPS_YAML "Register all the ops from a given yaml file" OFF)
 endif()
 
+# Build xnn_executor_runner which depends on XNNPACK
+option(EXECUTORCH_BUILD_XNNPACK
+       "Build xnn_executor_runner which depends on XNNPACK" OFF)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
@@ -152,7 +156,8 @@ target_link_libraries(executorch PRIVATE dl) # For dladdr()
 target_include_directories(executorch PUBLIC ${_common_include_directories})
 target_compile_options(executorch PUBLIC ${_common_compile_options})
 if(MAX_KERNEL_NUM)
-  target_compile_definitions(executorch PRIVATE MAX_KERNEL_NUM=${MAX_KERNEL_NUM})
+  target_compile_definitions(executorch
+                             PRIVATE MAX_KERNEL_NUM=${MAX_KERNEL_NUM})
 endif()
 
 #
@@ -187,7 +192,10 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*ios\.toolchain\.cmake$")
   target_compile_options(executor_runner PUBLIC ${_common_compile_options})
 endif()
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backends/xnnpack)
+# Add XNNPACK subdirectory
+if(EXECUTORCH_BUILD_XNNPACK)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backends/xnnpack)
+endif()
 
 # Add selective build subdirectory
 if(BUILD_SELECTIVE_BUILD_TEST)

--- a/examples/quantization/test_quantize.sh
+++ b/examples/quantization/test_quantize.sh
@@ -29,17 +29,17 @@ get_shared_lib_ext() {
 
 test_buck2_quantization() {
   echo "Building quantized ops shared library"
-  SO_LIB=$(buck2 build //kernels/quantized:aot_lib --show-output | grep "buck-out" | cut -d" " -f2)
+  SO_LIB=$($BUCK build //kernels/quantized:aot_lib --show-output | grep "buck-out" | cut -d" " -f2)
 
   echo "Run example.py"
   ${PYTHON_EXECUTABLE} -m "examples.quantization.example" --so_library="$SO_LIB" --model_name="$1"
 
   echo 'Running executor_runner'
-  buck2 run //examples/executor_runner:executor_runner -- --model_path="./$1.pte"
+  $BUCK run //examples/executor_runner:executor_runner -- --model_path="./${1}_quantized.pte"
   # should give correct result
 
-  echo "Removing $1.pte"
-  rm "./$1.pte"
+  echo "Removing ${1}_quantized.pte"
+  rm "./${1}_quantized.pte"
 }
 
 test_cmake_quantization() {
@@ -50,7 +50,8 @@ test_cmake_quantization() {
   (rm -rf cmake-out \
     && mkdir cmake-out \
     && cd cmake-out \
-    && retry cmake -DBUCK2=buck2 \
+    && retry cmake -DBUCK2="$BUCK" \
+      -DEXECUTORCH_BUILD_XNNPACK="$EXECUTORCH_BUILD_XNNPACK" \
       -DREGISTER_QUANTIZED_OPS=ON \
       -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
       -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
@@ -64,16 +65,26 @@ test_cmake_quantization() {
   ${PYTHON_EXECUTABLE} -m "examples.quantization.example" --so_library="$SO_LIB" --model_name="$1"
 
   echo 'Running executor_runner'
-  cmake-out/executor_runner --model_path="./$1.pte"
+  cmake-out/executor_runner --model_path="./${1}_quantized.pte"
   # should give correct result
 
-  echo "Removing $1.pte"
-  rm "./$1.pte"
+  echo "Removing ${1}_quantized.pte"
+  rm "./${1}_quantized.pte"
 }
 
 if [[ -z $PYTHON_EXECUTABLE ]];
 then
   PYTHON_EXECUTABLE=python3
+fi
+if [[ -z $BUCK ]];
+then
+  BUCK=buck2
+fi
+if [[ "${XNNPACK_DELEGATION}" == true ]];
+then
+  EXECUTORCH_BUILD_XNNPACK=ON
+else
+  EXECUTORCH_BUILD_XNNPACK=OFF
 fi
 if [[ "$1" == "cmake" ]];
 then


### PR DESCRIPTION
Summary:
As titled. This turns it off by default for CMake so that we can build faster.

Did a search didn't see this being used by anyone else so should be fine.

Differential Revision: D49075107


