### PR TITLE
Fix executorch/exir/tests:quantization

### DIFF
--- a/exir/tests/TARGETS
+++ b/exir/tests/TARGETS
@@ -329,6 +329,7 @@ python_unittest(
         "//executorch/kernels/quantized:custom_ops_generated_lib",
     ],
     deps = [
+        "fbsource//third-party/pypi/expecttest:expecttest",  # @manual
         "//caffe2:torch",
         "//executorch/exir:lib",
         "//executorch/exir/passes:quant_fusion_pass",


### PR DESCRIPTION
Summary:
Seems like it is failing for a while

Error ModuleNotFoundError: No module named 'expecttest'

Fixed by importing directly

After that, had to add export_program

Reviewed By: jerryzh168

Differential Revision: D49058674


