### PR TITLE
Update torch.ops.higher_order.cond

### DIFF
--- a/exir/TARGETS
+++ b/exir/TARGETS
@@ -158,7 +158,6 @@ python_library(
         ":schema",
         ":tensor",
         "//caffe2:torch",
-        "//caffe2/functorch:functorch_src",
         "//executorch/exir/operator:convert",
     ],
 )

--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -861,7 +861,7 @@ class _Emitter(torch.fx.Interpreter):
             self.node.meta["spec"],
         )
 
-        if target is control_flow.cond:
+        if target is torch.ops.higher_order.cond:
             return self._emit_cond(args, subemitter_binding_output_values)
         elif target is torch.ops.map_impl:
             return self._emit_map(args, subemitter_binding_output_values)
@@ -1212,7 +1212,7 @@ class _Emitter(torch.fx.Interpreter):
             # pyre-ignore
             return self._emit_free(args[0])
 
-        elif target is control_flow.cond:
+        elif target is torch.ops.higher_order.cond:
             return self._emit_control_flow(target, args, kwargs)
 
         elif target is torch.ops.map_impl:

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -649,6 +649,48 @@ class TestEmit(unittest.TestCase):
             program.execution_plan[0].values[4].val, schema.OptionalTensorList
         )
 
+    def test_emit_cond(self) -> None:
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, pred, x):
+                def true_fn(y: torch.Tensor) -> torch.Tensor:
+                    y = y + y
+                    y = torch.mm(y, y)
+                    return y
+
+                def false_fn(y: torch.Tensor) -> torch.Tensor:
+                    return torch.mm(y, y)
+
+                ret = control_flow.cond(pred, true_fn, false_fn, [x])
+                return ret
+
+        module = exir.capture(M(), (torch.tensor(True), torch.ones(2, 2))).to_edge(
+            exir.EdgeCompileConfig(_check_ir_validity=False)
+        )
+        program = module.to_executorch().program
+
+        num_mm = 0
+        num_add = 0
+        num_other = 0
+        for inst in program.execution_plan[0].chains[0].instructions:
+            if not isinstance(inst.instr_args, KernelCall):
+                continue
+
+            op = program.execution_plan[0].operators[inst.instr_args.op_index].name
+
+            if "mm" in op:
+                num_mm += 1
+            elif "add" in op:
+                num_add += 1
+            else:
+                num_other += 1
+
+        self.assertEqual(num_mm, 2)
+        self.assertEqual(num_add, 1)
+        self.assertEqual(num_other, 0)
+
     def test_emit_map(self) -> None:
         def f(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             def map_fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:

--- a/exir/memory_planning.py
+++ b/exir/memory_planning.py
@@ -27,7 +27,6 @@ from executorch.exir.error import (
 from executorch.exir.operator.convert import is_out_variant
 from executorch.exir.schema import TensorShapeDynamism
 from executorch.exir.tensor import TensorSpec
-from functorch.experimental import control_flow
 from torch import fx
 from torch.fx import Node
 from torch.utils._pytree import tree_flatten
@@ -320,7 +319,7 @@ def collect_specs_from_nodes(
                 in [
                     memory.alloc,
                     operator.getitem,
-                    control_flow.cond,
+                    torch.ops.higher_order.cond,
                     exir_while,
                     torch.ops.map_impl,
                     executorch_call_delegate,
@@ -551,7 +550,7 @@ def get_algo(algo_name: str) -> Callable[..., List[int]]:
 
 def get_cond_nodes(graph_module: torch.fx.GraphModule) -> Iterable[Node]:
     for nd in graph_module.graph.nodes:
-        if nd.target is control_flow.cond:
+        if nd.target is torch.ops.higher_order.cond:
             yield nd
 
 


### PR DESCRIPTION
Summary:
In D48769108, the core cond operator was moved to
torch.ops.higher_order.cond, making control_flow.cond contain only the wrapper
for cond, and torch.ops.higher_order.cond is the actual operator in the graph.

Reviewed By: ydwu4

Differential Revision: D49077093


