### PR TITLE
ETDump FlatCC Python Schema

### DIFF
--- a/sdk/etdump/TARGETS
+++ b/sdk/etdump/TARGETS
@@ -16,6 +16,16 @@ python_library(
 )
 
 python_library(
+    name = "schema_flatcc",
+    srcs = [
+        "schema_flatcc.py",
+    ],
+    deps = [
+        "//executorch/exir:scalar_type",
+    ],
+)
+
+python_library(
     name = "serialize",
     srcs = [
         "serialize.py",
@@ -23,10 +33,12 @@ python_library(
     resources = {
         "//executorch/schema:scalar_type.fbs": "scalar_type.fbs",
         "//executorch/sdk/etdump:etdump_schema.fbs": "etdump_schema.fbs",
+        "//executorch/sdk/etdump:etdump_schema_flatcc.fbs": "etdump_schema_flatcc.fbs",
     },
     deps = [
         "fbsource//third-party/pypi/setuptools:setuptools",
         ":schema",
+        ":schema_flatcc",
         "//executorch/exir/_serialize:_bindings",
         "//executorch/exir/_serialize:lib",
     ],

--- a/sdk/etdump/etdump_schema_flatcc.fbs
+++ b/sdk/etdump/etdump_schema_flatcc.fbs
@@ -33,7 +33,6 @@ table String {
 }
 
 enum ValueType : byte { Null, Int, Bool, Double, Tensor, String,}
-enum EventType : byte { ProfileEvent, AllocationEvent, DebugEvent }
 
 // This table is only necessary because flatbuffer can't support a list of
 // union elements directly, they need to be wrapped in a table.
@@ -103,9 +102,9 @@ table ProfileEvent {
 // Since we can only keep one vector open at a time when building the flatbuffer, using a
 // generic Event type (as opposed to separate arrays for each type) allows us to add
 // different events as they occur.
+//
+// Exactly one of these fields must be non-null, and the rest must be set to null.
 table Event {
-  event_type : EventType;
-
   profile_event: ProfileEvent;
 
   allocation_event: AllocationEvent;

--- a/sdk/etdump/schema_flatcc.py
+++ b/sdk/etdump/schema_flatcc.py
@@ -1,0 +1,128 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+"""
+This file is the python representation of the schema contained in
+executorch/sdk/etdump/etdump_schema.fbs. Any changes made to that
+flatbuffer schema should accordingly be reflected here also.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional
+
+from executorch.exir.scalar_type import ScalarType
+
+
+@dataclass
+class Tensor:
+    scalar_type: ScalarType
+    sizes: List[int]
+    strides: List[int]
+    data: bytes
+
+
+@dataclass
+class Null:
+    pass
+
+
+@dataclass
+class Int:
+    int_val: int
+
+
+@dataclass
+class Bool:
+    bool_val: bool
+
+
+@dataclass
+class Double:
+    double_val: float
+
+
+@dataclass
+class String:
+    string_val: str
+
+
+@dataclass
+class ContainerMetadata:
+    encoded_inp_str: str
+    encoded_out_str: str
+
+
+@dataclass
+class ValueType(Enum):
+    NULL = "Null"
+    INT = "Int"
+    BOOL = "Bool"
+    DOUBLE = "Double"
+    TENSOR = "Tensor"
+    STRING = "String"
+
+
+@dataclass
+class Value:
+    val: str  # Member of ValueType
+    offset: int
+
+
+@dataclass
+class DebugEvent:
+    chain_idx: int
+    debug_handle: int
+    debug_entries: List[Value]
+
+
+# Note the differing value style is a result of ETDump string
+class PROFILE_EVENT_ENUM(Enum):
+    RUN_MODEL = "Method::execute"
+    OPERATOR_CALL = "OPERATOR_CALL"
+    DELEGATE_CALL = "DELEGATE_CALL"
+    LOAD_MODEL = "Program::load_method"
+
+
+@dataclass
+class ProfileEvent:
+    name: str
+    chain_idx: int
+    debug_handle: int
+    start_time: int
+    end_time: int
+
+
+@dataclass
+class AllocationEvent:
+    allocator_id: int
+    allocation_size: int
+
+
+@dataclass
+class Allocator:
+    name: str
+
+
+# Must have one of profile_event, allocation_event, or debug_event
+@dataclass
+class Event:
+    profile_event: Optional[ProfileEvent]
+    allocation_event: Optional[AllocationEvent]
+    debug_event: Optional[DebugEvent]
+
+
+@dataclass
+class RunData:
+    allocators: List[Allocator]
+    events: List[Event]
+
+
+@dataclass
+class ETDumpFlatCC:
+    version: int
+    run_data: List[RunData]

--- a/sdk/etdump/serialize.py
+++ b/sdk/etdump/serialize.py
@@ -9,6 +9,7 @@
 import json
 import os
 import tempfile
+from typing import Union
 
 # pyre-ignore[21]: Could not find module `executorch.exir._serialize._bindings`.
 import executorch.exir._serialize._bindings as bindings  # @manual=//executorch/exir/_serialize:_bindings
@@ -17,9 +18,11 @@ import pkg_resources
 
 from executorch.exir._serialize._dataclass import _DataclassEncoder, _json_to_dataclass
 from executorch.sdk.etdump.schema import ETDump
+from executorch.sdk.etdump.schema_flatcc import ETDumpFlatCC
 
 # The prefix of schema files used for etdump
 ETDUMP_SCHEMA_NAME = "etdump_schema"
+ETDUMP_FLATCC_SCHEMA_NAME = "etdump_schema_flatcc"
 SCALAR_TYPE_SCHEMA_NAME = "scalar_type"
 
 
@@ -31,8 +34,8 @@ def _write_schema(d: str, schema_name: str) -> None:
         )
 
 
-def _serialize_from_etdump_to_json(etdump: ETDump) -> str:
-    return json.dumps(etdump, cls=_DataclassEncoder)
+def _serialize_from_etdump_to_json(etdump: Union[ETDump, ETDumpFlatCC]) -> str:
+    return json.dumps(etdump, cls=_DataclassEncoder, indent=4)
 
 
 # from json to etdump
@@ -99,3 +102,74 @@ def deserialize_from_etdump(data: bytes) -> ETDump:
         Deserialized ETDump python object.
     """
     return _deserialize_from_json_to_etdump(_convert_from_flatbuffer(data))
+
+
+"""
+ETDump FlatCC Schema Implementations
+"""
+
+
+# from json to etdump
+def _deserialize_from_json_to_etdump_flatcc(etdump_json: bytes) -> ETDumpFlatCC:
+    etdump_json = json.loads(etdump_json)
+    return _json_to_dataclass(etdump_json, ETDumpFlatCC)
+
+
+def _convert_to_flatcc(etdump_json: str) -> bytes:
+    with tempfile.TemporaryDirectory() as d:
+        # load given and common schema
+        _write_schema(d, ETDUMP_FLATCC_SCHEMA_NAME)
+        _write_schema(d, SCALAR_TYPE_SCHEMA_NAME)
+
+        schema_path = os.path.join(d, "{}.fbs".format(ETDUMP_FLATCC_SCHEMA_NAME))
+        json_path = os.path.join(d, "{}.json".format(ETDUMP_FLATCC_SCHEMA_NAME))
+        with open(json_path, "wb") as json_file:
+            json_file.write(etdump_json.encode("ascii"))
+
+        # pyre-ignore
+        bindings.flatc_compile(d, schema_path, json_path)
+        output_path = os.path.join(d, "{}.etdp".format(ETDUMP_FLATCC_SCHEMA_NAME))
+        with open(output_path, "rb") as output_file:
+            return output_file.read()
+
+
+def _convert_from_flatcc(etdump_flatbuffer: bytes) -> bytes:
+    with tempfile.TemporaryDirectory() as d:
+        _write_schema(d, ETDUMP_FLATCC_SCHEMA_NAME)
+        _write_schema(d, SCALAR_TYPE_SCHEMA_NAME)
+
+        schema_path = os.path.join(d, "{}.fbs".format(ETDUMP_FLATCC_SCHEMA_NAME))
+        bin_path = os.path.join(d, "schema.bin")
+        with open(bin_path, "wb") as bin_file:
+            bin_file.write(etdump_flatbuffer)
+        # pyre-ignore
+        bindings.flatc_decompile(d, schema_path, bin_path)
+        output_path = os.path.join(d, "schema.json")
+        with open(output_path, "rb") as output_file:
+            return output_file.read()
+
+
+def serialize_to_etdump_flatcc(
+    etdump: ETDumpFlatCC,
+) -> bytes:
+    """
+    Given an ETdump python object this function will return a serialized object
+    that can then be written to a file using the FlatCC schema.
+    Args:
+        etdump: ETDump python object that the user wants to serialize.
+    Returns:
+        Serialized etdump binary blob using the FlatCC schema
+    """
+    return _convert_to_flatcc(_serialize_from_etdump_to_json(etdump))
+
+
+def deserialize_from_etdump_flatcc(data: bytes) -> ETDumpFlatCC:
+    """
+    Given an etdump binary blob (constructed using the FlatCC schema) this function will deserialize
+    it and return the FlatCC python object representation of etdump.
+    Args:
+        data: Serialized etdump binary blob.
+    Returns:
+        Deserialized ETDump python object.
+    """
+    return _deserialize_from_json_to_etdump_flatcc(_convert_from_flatcc(data))

--- a/sdk/etdump/targets.bzl
+++ b/sdk/etdump/targets.bzl
@@ -131,6 +131,11 @@ def define_common_targets():
         ],
     )
 
+    export_file(
+        name = ETDUMP_SCHEMA_FLATCC,
+        visibility = ["//executorch/..."],
+    )
+
     generate_schema_header_flatcc(
         ETDUMP_GEN_RULE_NAME_FLATCC,
         [ETDUMP_SCHEMA_FLATCC, SCALAR_TYPE],

--- a/sdk/etdump/tests/TARGETS
+++ b/sdk/etdump/tests/TARGETS
@@ -9,7 +9,9 @@ python_unittest(
         "serialize_test.py",
     ],
     deps = [
+        "//executorch/exir/_serialize:lib",
         "//executorch/sdk/etdump:schema",
+        "//executorch/sdk/etdump:schema_flatcc",
         "//executorch/sdk/etdump:serialize",
     ],
 )


### PR DESCRIPTION
Summary:
Create a Python schema reflecting the ETDump FlatCC schema.
++ Deprecate the EventType field - we can determine the type of the event at parse time by seeing which one is not null.

Reviewed By: tarun292

Differential Revision: D49023411


