### PR TITLE
: Depend on lintrunner-adapters pypi instead

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -8,22 +8,22 @@ exclude_patterns = [
     '**/third-party/**',
 ]
 command = [
-    'python3',
-    'third-party/pytorch/tools/linter/adapters/flake8_linter.py',
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'flake8_linter',
     '--',
     '@{{PATHSFILE}}'
 ]
 init_command = [
-    'python3',
-    'third-party/pytorch/tools/linter/adapters/pip_init.py',
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'pip_init',
     '--dry-run={{DRYRUN}}',
-    'flake8==6.0.0',
-    'flake8-breakpoint==1.1.0',
-    'flake8-bugbear==23.6.5',
-    'flake8-comprehensions==3.12.0',
-    'flake8-pyi==23.5.0',
-    'mccabe==0.7.0',
-    'pycodestyle==2.10.0',
+    '--requirement=requirements-lintrunner.txt',
 ]
 
 # Black + usort
@@ -38,18 +38,22 @@ exclude_patterns = [
     '**/third-party/**',
 ]
 command = [
-    'python3',
-    'third-party/pytorch/tools/linter/adapters/ufmt_linter.py',
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'ufmt_linter',
     '--',
     '@{{PATHSFILE}}'
 ]
 init_command = [
-    'python3',
-    'third-party/pytorch/tools/linter/adapters/pip_init.py',
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'pip_init',
     '--dry-run={{DRYRUN}}',
     '--no-black-binary',
-    'black==22.12.0',
-    'ufmt==2.0.1',
-    'usort==1.0.5',
+    '--requirement=requirements-lintrunner.txt',
 ]
 is_formatter = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ the ExecuTorch code.
 You can see [lintrunner](https://pypi.org/project/lintrunner/) for making sure the code follows our standard. Here's how to set up `lintrunner`:
 
 ```
-pip install lintrunner
+pip install lintrunner==0.11.0
+pip install lintrunner-adapters==0.9.0
 lintrunner init
 ```
 

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -1,0 +1,13 @@
+# Flake 8 and its dependencies
+flake8==6.0.0
+flake8-breakpoint==1.1.0
+flake8-bugbear==23.6.5
+flake8-comprehensions==3.12.0
+flake8-pyi==23.5.0
+mccabe==0.7.0
+pycodestyle==2.10.0
+
+# UFMT
+black==22.12.0
+ufmt==2.0.1
+usort==1.0.5


### PR DESCRIPTION
Summary:
Currently we are calling third-party/pytorch/tools/

But the adapters are already in pypi. Let's just depend on that.

That way, we don't have to do sketchy things like download arbitrary binary from s3 for clang formatter.

Differential Revision: D49098183


