### PR TITLE
Fix CI breakage

### DIFF
--- a/examples/recipes/xnnpack_optimization/models.py
+++ b/examples/recipes/xnnpack_optimization/models.py
@@ -19,5 +19,7 @@ MODEL_NAME_TO_OPTIONS = {
     "add_mul": OptimizationOptions(True, True),
     "mv2": OptimizationOptions(True, True),
     "mv3": OptimizationOptions(False, True),
-    "ic4": OptimizationOptions(True, False),
+    "ic4": OptimizationOptions(
+        False, False
+    ),  # TODO[T163161310]: takes a long time to export to exec prog and save inception_v4 quantized model
 }


### PR DESCRIPTION
Summary:
In #203 we exclude ic4 from quantization examples, this is breaking OSS CI jobs:

https://github.com/pytorch/executorch/actions/runs/6124801722/job/16625571056?fbclid=IwAR3PM3KY0rPzPigM__onBDAClVcbNICIaCh61llcxb_KM4CYfJMwDn_G_uM

Reviewed By: JacobSzwejbka

Differential Revision: D49106938


