### PR TITLE
Add init context

### DIFF
--- a/runtime/backend/backend_init_context.h
+++ b/runtime/backend/backend_init_context.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <executorch/runtime/core/memory_allocator.h>
+
+namespace torch {
+namespace executor {
+
+/**
+ * BackendInitContext will be used to inject runtime info for to initialize
+ * delegate.
+ */
+class BackendInitContext final {
+ public:
+  BackendInitContext(MemoryAllocator* runtime_allocator)
+      : runtime_allocator_(runtime_allocator) {}
+
+  /** Get the runtime allocator passed from Method. It's the same runtime
+   * executor used by the standard executor runtime and the life span is the
+   * same as the model.
+   */
+  MemoryAllocator* get_runtime_allocator() {
+    return runtime_allocator_;
+  }
+
+ private:
+  MemoryAllocator* runtime_allocator_;
+};
+
+} // namespace executor
+} // namespace torch

--- a/runtime/backend/targets.bzl
+++ b/runtime/backend/targets.bzl
@@ -16,6 +16,7 @@ def define_common_targets():
             ],
             exported_headers = [
                 "backend_execution_context.h",
+                "backend_init_context.h",
                 "backend_registry.h",
             ],
             preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],


### PR DESCRIPTION
Summary: Similar to other places we use context to inject runtime related information. The `BackendInitContext` will wrap `runtime_allocator` for `backend.init`.

Reviewed By: dbort

Differential Revision: D48872101


