### PR TITLE
rangeAnalysis based upper bound memory planning.

### DIFF
--- a/exir/capture/TARGETS
+++ b/exir/capture/TARGETS
@@ -37,5 +37,6 @@ python_library(
         "//executorch/exir:pass_manager",
         "//executorch/exir:tracer",
         "//executorch/exir/passes:lib",
+        "//executorch/exir/passes:sym_shape_eval_pass",
     ],
 )

--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from executorch.exir.dynamic_shape import DynamicMemoryPlanningMode
 from executorch.exir.pass_manager import PassType
 from executorch.exir.passes import MemoryPlanningPass, ToOutVarPass
+from executorch.exir.passes.sym_shape_eval_pass import HintBasedSymShapeEvalPass
 from executorch.exir.tracer import ExirDynamoConfig
 from torch.fx._compatibility import compatibility
 
@@ -63,3 +64,4 @@ class ExecutorchBackendConfig:
     # If provided, the minimum alignment of delegate data in the program. Must
     # be a power of 2. If not provided, uses the value in the schema file.
     delegate_alignment: Optional[int] = None
+    sym_shape_eval_pass: PassType = HintBasedSymShapeEvalPass()

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -21,6 +21,7 @@ from executorch.exir.backend.backend_details import BackendDetails, PreprocessRe
 from executorch.exir.emit import emit_program  # noqa
 from executorch.exir.error import InternalError
 from executorch.exir.passes.const_prop_pass import ConstPropPass
+from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
 from executorch.exir.print_program import pretty_print, print_program  # noqa
 from executorch.exir.schema import (
     Bool,
@@ -45,6 +46,8 @@ from executorch.extension.pybindings.portable_lib import (
 )
 from functorch.experimental import control_flow
 from torch import nn
+
+from torch.export import dynamic_dim
 
 
 class TestEmit(unittest.TestCase):
@@ -1049,6 +1052,41 @@ class TestEmit(unittest.TestCase):
         self.assertEqual(
             merged_program2.execution_plan[2], merged_program.execution_plan[2]
         )
+
+    def test_upper_bound_memory_planning_respect_input_constraints(self) -> None:
+        def func(k: torch.Tensor) -> torch.Tensor:
+            k = torch.cat((k, torch.ones(1, 4)))
+            return k
+
+        k = torch.rand(2, 4)
+        constraints = [
+            dynamic_dim(k, 0) <= 3,
+        ]
+        captured = exir.capture(
+            func,
+            (k,),
+            exir.CaptureConfig(pt2_mode=True, enable_aot=True),
+            constraints=constraints,  # enable_aot=False works
+        )
+        edge = captured.to_edge()
+        from executorch.exir.passes import MemoryPlanningPass
+
+        config = exir.ExecutorchBackendConfig(
+            sym_shape_eval_pass=ConstraintBasedSymShapeEvalPass(),
+            memory_planning_pass=MemoryPlanningPass(
+                memory_planning_algo="greedy",
+                # allow_lifetime_and_storage_overlap: bool = False,
+                alloc_graph_input=True,
+                alloc_graph_output=False,
+            ),
+        )
+
+        exe_prog = edge.to_executorch(config)
+        program = exe_prog.program
+        exir.print_program.pretty_print(exe_prog.program.execution_plan)
+        execution_plan = program.execution_plan[0]
+        self.check_tensor_buffer_loc(0, execution_plan.values, 0, 1, 0)
+        self.check_tensor_buffer_loc(1, execution_plan.values, 0, 1, 48)
 
     def test_emit_prims(self) -> None:
         class Simple(torch.nn.Module):

--- a/exir/passes/__init__.py
+++ b/exir/passes/__init__.py
@@ -51,7 +51,7 @@ from executorch.exir.passes.replace_edge_with_backend_pass import EdgeToBackendO
 from executorch.exir.passes.replace_sym_size_op_pass import ReplaceSymSizeOpPass
 from executorch.exir.passes.scalar_to_tensor_pass import ScalarToTensorPass
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
-from executorch.exir.passes.sym_shape_eval_pass import SymShapeEvalPass
+from executorch.exir.passes.sym_shape_eval_pass import HintBasedSymShapeEvalPass
 from executorch.exir.passes.sym_to_tensor_pass import SymToTensorPass
 from torch import fx
 from torch._subclasses import FakeTensor
@@ -65,7 +65,7 @@ __all__ = [
     "OpReplacePass",
     "EdgeToBackendOpsPass",
     "MemoryFormatOpsPass",
-    "SymShapeEvalPass",
+    "HintBasedSymShapeEvalPass",
 ]
 
 Argument = Optional[
@@ -510,5 +510,5 @@ def propagate_dynamic_shape(
     """
     return [
         SpecPropPass(),
-        SymShapeEvalPass(),
+        HintBasedSymShapeEvalPass(),
     ]

--- a/exir/passes/sym_shape_eval_pass.py
+++ b/exir/passes/sym_shape_eval_pass.py
@@ -10,7 +10,7 @@ import torch
 import torch.utils._pytree as pytree
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import PassBase, PassResult
-from executorch.exir.sym_util import eval_expr, eval_shape
+from executorch.exir.sym_util import eval_expr, eval_shape, eval_upper_bound
 from executorch.exir.tensor import TensorSpec
 from sympy import Integer
 from torch.fx import GraphModule
@@ -95,4 +95,39 @@ class HintBasedSymShapeEvalPass(PassBase):
                         )
                         spec.shape = concrete_shape
                         spec.stride = concrete_spec
+        return PassResult(graph_module, True)
+
+
+class ConstraintBasedSymShapeEvalPass(PassBase):
+    """
+    If we enable dynamic shape tracing, a tensor's shape may become a symbolic
+    formula. We should convert those symbolic formula to concrete value for
+    static/upperbound tensors so we can properly do memory planning for them.
+
+    Not inherit from ExportPass since we simply need a way to iterate thru
+    every node's output. PassBase is easier for that purpose.
+    """
+
+    def call(self, graph_module: GraphModule):
+        for subgm in graph_module.modules():
+            if not isinstance(subgm, GraphModule):
+                continue
+            for node in subgm.graph.nodes:
+                for spec in pytree.tree_flatten(node.meta.get("spec", []))[0]:
+                    # Node for function like aten.sym_size does not have spec
+                    if isinstance(spec, TensorSpec):
+                        concrete_shape = [eval_upper_bound(s) for s in spec.shape]
+                        concrete_stride = [eval_upper_bound(s) for s in spec.stride]
+                        if any(not isinstance(s, int) for s in concrete_shape) or any(
+                            not isinstance(s, int) for s in concrete_stride
+                        ):
+                            raise RuntimeError(
+                                f"Cannot evalute the shape upper bound of a dynamic-shaped tensor to a concrete bounded integer. Got tensor spec: {spec}."
+                                f"The upper bound shape we get {concrete_shape}, the upper bound stride we get {concrete_stride}"
+                                "This tensor could either be from 1. a data-dependent operation such as nonzero. Or 2. an input, whose don't have a constraint for the upper bound."
+                                "Please use export's constrain_as_size() or constrain_as_value() apis and set a concrete upper bound to resolve this."
+                            )
+
+                        spec.shape = concrete_shape  # pyre-ignore[8]: Attribute `stride` declared in class `TensorSpec` has type `Tuple[int]` but is used as type `List[Optional[int]]`
+                        spec.stride = concrete_stride  # pyre-ignore[8]: Attribute `stride` declared in class `TensorSpec` has type `Tuple[int]` but is used as type `List[Optional[int]]`
         return PassResult(graph_module, True)

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -19,8 +19,8 @@ from executorch.exir.pass_manager import PassType
 from executorch.exir.passes import (
     aten_to_edge_passes,
     EdgeToBackendOpsPass,
+    HintBasedSymShapeEvalPass,
     OpReplacePass,
-    SymShapeEvalPass,
 )
 from executorch.exir.passes.remove_assert_async_pass import RemoveAssertAsyncPass
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
@@ -309,7 +309,7 @@ def edge_to_executorch_passes(config: ExecutorchBackendConfig) -> List[PassType]
         SpecPropPass(),
         EdgeToBackendOpsPass(),
         RemoveAssertAsyncPass(),
-        SymShapeEvalPass(),
+        HintBasedSymShapeEvalPass(),
         config.to_out_var_pass,
         config.memory_planning_pass,
     ]

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -19,7 +19,6 @@ from executorch.exir.pass_manager import PassType
 from executorch.exir.passes import (
     aten_to_edge_passes,
     EdgeToBackendOpsPass,
-    HintBasedSymShapeEvalPass,
     OpReplacePass,
 )
 from executorch.exir.passes.remove_assert_async_pass import RemoveAssertAsyncPass
@@ -309,7 +308,7 @@ def edge_to_executorch_passes(config: ExecutorchBackendConfig) -> List[PassType]
         SpecPropPass(),
         EdgeToBackendOpsPass(),
         RemoveAssertAsyncPass(),
-        HintBasedSymShapeEvalPass(),
+        config.sym_shape_eval_pass,
         config.to_out_var_pass,
         config.memory_planning_pass,
     ]

--- a/exir/sym_util.py
+++ b/exir/sym_util.py
@@ -4,11 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, Set, Union
+from typing import List, Optional, Set, Union
 
 import sympy
 
 import torch
+from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
 
 
 def eval_expr(symint: Union[int, torch.SymInt]) -> Optional[int]:
@@ -28,6 +29,32 @@ def eval_expr(symint: Union[int, torch.SymInt]) -> Optional[int]:
     return int(output)
 
 
+def eval_upper_bound(maybe_symint: Union[int, torch.SymInt]) -> Optional[int]:
+    """
+    Evaluate a symint to its uppper bound value. Returns None if symint's symoblic expr's
+    upper bound can not be evaluated to valid integer according to the constraints in shape_env.
+    """
+    if isinstance(maybe_symint, int):
+        return maybe_symint
+    node = maybe_symint.node
+    shape_env = node.shape_env
+    expr = node.expr
+    var_range: ValueRanges = bound_sympy(expr, shape_env.var_to_range)
+    upper_bound = var_range.upper
+    if isinstance(upper_bound, sympy.Integer):
+        concrete_upper = int(var_range.upper)  # pyre-ignore
+        assert isinstance(
+            concrete_upper, int
+        ), f"Expect upper bound to be a concrete int but got {concrete_upper}"
+        return concrete_upper
+    elif isinstance(upper_bound, sympy.oo):
+        return None
+    else:
+        raise RuntimeError(
+            f"Expect upper bound to be sympy.Integer or sympy.oo. but got {upper_bound}"
+        )
+
+
 def eval_shape(shape):
     """
     Shape maybe immutable so we return a new shape. Return None for
@@ -36,6 +63,13 @@ def eval_shape(shape):
     new_shape = []
     for _, s in enumerate(shape):
         new_shape.append(eval_expr(s))
+    return new_shape
+
+
+def eval_shape_upper_bound(shape) -> List[int]:
+    new_shape = []
+    for _, s in enumerate(shape):
+        new_shape.append(eval_upper_bound(s))
     return new_shape
 
 

--- a/exir/tests/test_dynamic_shape_propagation.py
+++ b/exir/tests/test_dynamic_shape_propagation.py
@@ -7,7 +7,7 @@
 from unittest import TestCase
 
 from executorch import exir
-from executorch.exir.passes import DebugPass, SpecPropPass, SymShapeEvalPass
+from executorch.exir.passes import DebugPass, HintBasedSymShapeEvalPass, SpecPropPass
 from executorch.exir.tests.models import Repeat
 
 
@@ -23,7 +23,7 @@ class TestDynamicShapeProp(TestCase):
             exir.CaptureConfig(enable_dynamic_shape=True),
         ).to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
 
-        new_prog = prog.transform(SpecPropPass(), SymShapeEvalPass())
+        new_prog = prog.transform(SpecPropPass(), HintBasedSymShapeEvalPass())
 
         gm = new_prog.exported_program.graph_module
 

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -24,11 +24,11 @@ from executorch.exir.pass_base import ExportPass, PassResult
 from executorch.exir.passes import (
     dead_code_elimination_pass,
     DebugPass,
+    HintBasedSymShapeEvalPass,
     MemoryPlanningPass,
     propagate_dynamic_shape,
     RemoveNoopPass,
     ReplaceSymSizeOpPass,
-    SymShapeEvalPass,
     ToOutVarPass,
 )
 from executorch.exir.passes.const_prop_pass import ConstPropPass
@@ -586,7 +586,7 @@ class TestPasses(unittest.TestCase):
         ).to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
         passes = [
             SpecPropPass(),
-            SymShapeEvalPass(),
+            HintBasedSymShapeEvalPass(),
             ToOutVarPass(),
             MemoryPlanningPass("greedy"),
         ]


### PR DESCRIPTION
Summary:
Before this PR, we treat inputs that passed in for tracing as the upper bound tensor itself. We use their shape as the uppper bound. However, 1. this approach doesn't respect user provided constraints. 2.  this approach cannot handle certain data-dependent op such as tensor.item() because we don't know the exact value at export time.

This PR makes the upper bound memory planning respect the user provided shape constraints by using the rangeAnalysis infra. This change has several implications. User must provide a concrete interger as upper bound for

1. dynamic input tensors.

2. outputs of data dependent operations (e.g. nonzero, .item()).

Otherwise, upper bound memory planning cannot proceed because by default the uppper bound is infinity.

Differential Revision: D49158290


