### PR TITLE
Initial gtest bringup for executorch c++ tests

### DIFF
--- a/shim/xplat/executorch/build/env_interface.bzl
+++ b/shim/xplat/executorch/build/env_interface.bzl
@@ -29,7 +29,7 @@ _EXTERNAL_DEPS = {
     "gen-oplist-lib": "//third-party:gen_oplist_lib",
     # Commandline flags library
     "gflags": "//third-party:gflags",
-    "gmock": [],  # TODO(larryliu0820): Add support
+    "gmock": "//third-party:gmock",
     "gtest": "//third-party:gtest",
     "libtorch": "//third-party:libtorch",
     "prettytable": "//third-party:prettytable",

--- a/shim/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim/xplat/executorch/build/runtime_wrapper.bzl
@@ -115,8 +115,17 @@ def _patch_test_compiler_flags(kwargs):
     if "compiler_flags" not in kwargs:
         kwargs["compiler_flags"] = []
 
+    # Required globally by all c++ tests.
+    kwargs["compiler_flags"].extend([
+        "-std=c++17",
+    ])
+
     # Relaxing some constraints for tests
-    kwargs["compiler_flags"].extend(["-Wno-missing-prototypes", "-Wno-unused-variable", "-Wno-error"])
+    kwargs["compiler_flags"].extend([
+        "-Wno-missing-prototypes",
+        "-Wno-unused-variable",
+        "-Wno-error",
+    ])
     return kwargs
 
 def _external_dep_location(name):

--- a/test/utils/UnitTestMain.cpp
+++ b/test/utils/UnitTestMain.cpp
@@ -9,12 +9,10 @@
 /**
  * @file
  * Custom main function for unit test executables.
- * Based on `fbcode//common/gtest/LightMain.cpp`
  */
 
 #include <executorch/runtime/platform/compiler.h>
 #include <executorch/runtime/platform/runtime.h>
-#include <folly/init/Init.h>
 #include <gtest/gtest.h>
 
 // Define main as a weak symbol to allow trivial overriding.
@@ -22,7 +20,6 @@ int main(int argc, char** argv) __ET_WEAK;
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv);
   torch::executor::runtime_init();
   return RUN_ALL_TESTS();
 }

--- a/test/utils/targets.bzl
+++ b/test/utils/targets.bzl
@@ -24,13 +24,9 @@ def define_common_targets():
             "//executorch/runtime/platform:platform",
             "//executorch/runtime/core:core",
         ],
-        fbcode_exported_deps = [
-            "//common/init:init",
-            "//common/gtest:gtest",
-        ],
-        xplat_exported_deps = [
-            "//xplat/folly:init_init",
-            "//xplat/third-party/gmock:gmock",
+        exported_external_deps = [
+            "gtest",
+            "gmock",
         ],
     )
 


### PR DESCRIPTION
Summary: Buck build and run executorch c++ tests on OSS with `gtest`

Differential Revision: D49171169


