### PR TITLE
Add aten::squeeze and aten::unsqueeze to functionalization

### DIFF
--- a/exir/passes/replace_broken_ops_with_function_ops_pass.py
+++ b/exir/passes/replace_broken_ops_with_function_ops_pass.py
@@ -20,6 +20,8 @@ _NON_FUNCTIONAL_OPS_TO_FUNCTIONAL_OPS: Dict[OpOverload, OpOverload] = {
     torch.ops.aten.view.default: torch.ops.aten.view_copy.default,
     torch.ops.aten.expand.default: torch.ops.aten.expand_copy.default,
     torch.ops.aten.permute.default: torch.ops.aten.permute_copy.default,
+    torch.ops.aten.squeeze.default: torch.ops.aten.squeeze_copy.default,
+    torch.ops.aten.unsqueeze.default: torch.ops.aten.unsqueeze_copy.default,
     torch.ops.aten.slice.Tensor: torch.ops.aten.slice_copy.Tensor,
 }
 


### PR DESCRIPTION
Summary:
`aten::squeeze` and `aten::unsqueeze` only have out variants defined for the functional
variants: `squeeze_copy` and `unsqueeze_copy`.

Add these to a conversion pass similar to permute and transpose.

Differential Revision: D49171160


