### PR TITLE
Apply lintrunner --all-files -a

### DIFF
--- a/backends/transforms/TARGETS
+++ b/backends/transforms/TARGETS
@@ -20,5 +20,6 @@ python_library(
     deps = [
         "//caffe2:torch",
         "//executorch/exir:sym_util",
+        "//executorch/exir/dialects:lib",
     ],
 )

--- a/backends/transforms/__init__.py
+++ b/backends/transforms/__init__.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from executorch.backends.transforms.addmm_mm_to_linear import (
+from executorch.backends.transforms.addmm_mm_to_linear import (  # noqa: F401
     apply_addmm_mm_to_linear_transform,
     get_shape,
 )

--- a/backends/vulkan/serialization/vulkan_graph_schema.py
+++ b/backends/vulkan/serialization/vulkan_graph_schema.py
@@ -12,7 +12,7 @@ Please refer to fbcode/caffe2/executorch/backends/vulkan/serialization/schema/sc
 
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import List, Union
+from typing import List
 
 
 class VkDatatype(IntEnum):

--- a/backends/xnnpack/partition/xnnpack_partitioner.py
+++ b/backends/xnnpack/partition/xnnpack_partitioner.py
@@ -347,7 +347,7 @@ class XnnpackFloatingPointPartitioner(Partitioner):
         Disqualify the whole module if one of the nodes fails to satisfy.
         """
         return all(
-            [XnnpackOperatorSupport.check_constraint(node) for node in input_nodes]
+            XnnpackOperatorSupport.check_constraint(node) for node in input_nodes
         )
 
     def get_module_partitions(

--- a/backends/xnnpack/passes/TARGETS
+++ b/backends/xnnpack/passes/TARGETS
@@ -21,6 +21,5 @@ python_library(
         "//executorch/exir:pass_base",
         "//executorch/exir/dialects:lib",
         "//executorch/exir/passes:const_prop_pass",
-        "//executorch/exir/passes:lib",
     ],
 )

--- a/backends/xnnpack/passes/channels_last_tagged_reshape_pass.py
+++ b/backends/xnnpack/passes/channels_last_tagged_reshape_pass.py
@@ -344,7 +344,7 @@ class ChannelsLastTaggedReshapePass(XNNPACKPass):
             target_node=target_node,
         )
 
-    def call(self, graph_module: torch.fx.GraphModule):
+    def call(self, graph_module: torch.fx.GraphModule):  # noqa: C901
         graph = graph_module.graph
         original_nodes = list(graph.nodes)
         for node in original_nodes:

--- a/backends/xnnpack/test/TARGETS
+++ b/backends/xnnpack/test/TARGETS
@@ -25,7 +25,6 @@ python_unittest(
         "//executorch/bundled_program:core",
         "//executorch/bundled_program/serialize:lib",
         "//executorch/exir:lib",
-        "//executorch/exir:tracer",
         "//executorch/exir/backend:backend_api",
         "//executorch/exir/passes:spec_prop_pass",
         "//executorch/extension/pybindings:portable_lib",  # @manual
@@ -54,7 +53,6 @@ python_unittest(
         "//executorch/bundled_program:core",
         "//executorch/bundled_program/serialize:lib",
         "//executorch/exir:lib",
-        "//executorch/exir:tracer",
         "//executorch/exir/backend:backend_api",
         "//executorch/exir/dialects:lib",
         "//executorch/exir/passes:spec_prop_pass",
@@ -84,7 +82,6 @@ python_unittest(
         "//executorch/bundled_program:core",
         "//executorch/bundled_program/serialize:lib",
         "//executorch/exir:lib",
-        "//executorch/exir:tracer",
         "//executorch/exir/backend:backend_api",
         "//executorch/exir/passes:spec_prop_pass",
         "//executorch/extension/pybindings:portable_lib",  # @manual

--- a/backends/xnnpack/test/test_xnnpack_quantized.py
+++ b/backends/xnnpack/test/test_xnnpack_quantized.py
@@ -46,18 +46,17 @@ class TestXNNPACKQuantized(TestXNNPACK):
         self.lower_module_and_test_output(just_quant, sample_input)
 
     def test_xnnpack_qmax_pool_2d(self):
+        class maxpool(torch.nn.Module):
+            def __init__(self, maxpool_params):
+                super().__init__()
+                self.max = torch.nn.MaxPool2d(*maxpool_params)
+
+            def forward(self, x):
+                return self.max(x)
+
         for maxpool_params in [(4,), (4, 2), (4, 2, 2)]:
-
-            class maxpool(torch.nn.Module):
-                def __init__(self):
-                    super().__init__()
-                    self.max = torch.nn.MaxPool2d(*maxpool_params)
-
-                def forward(self, x):
-                    return self.max(x)
-
             example_input = (torch.ones(1, 2, 8, 8),)
-            self.quantize_and_test_model(maxpool(), example_input)
+            self.quantize_and_test_model(maxpool(maxpool_params), example_input)
 
     def test_xnnpack_qadd(self):
         class Add(torch.nn.Module):

--- a/backends/xnnpack/test/test_xnnpack_utils.py
+++ b/backends/xnnpack/test/test_xnnpack_utils.py
@@ -35,7 +35,6 @@ from executorch.exir import ExecutorchProgram, ExirExportedProgram
 from executorch.exir.backend.backend_api import to_backend, validation_disabled
 
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
-from executorch.exir.tracer import _default_decomposition_table
 
 from executorch.extension.pybindings.portable_lib import (  # @manual
     _load_for_executorch_from_buffer,

--- a/backends/xnnpack/test/tester/tester.py
+++ b/backends/xnnpack/test/tester/tester.py
@@ -290,7 +290,7 @@ class Tester:
             self._stage_name(Serialize): [],
         }
         assert all(
-            [stage in self.pipeline for stage in self.stages]
+            stage in self.pipeline for stage in self.stages
         ), "Invalid Tester internal state!"
 
         # Current stage name

--- a/codegen/tools/test/test_gen_all_oplist.py
+++ b/codegen/tools/test/test_gen_all_oplist.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 import tempfile
 import unittest
 from unittest.mock import NonCallableMock, patch

--- a/examples/export/test/test_export.py
+++ b/examples/export/test/test_export.py
@@ -33,7 +33,6 @@ class ExportTest(unittest.TestCase):
         takes the eager mode output and ET output, and returns True if they
         match.
         """
-
         eager_model = eager_model.eval()
         model = export.capture_pre_autograd_graph(eager_model, example_inputs)
         edge_model = export_to_edge(model, example_inputs)

--- a/exir/TARGETS
+++ b/exir/TARGETS
@@ -232,7 +232,6 @@ python_library(
         ":error",
         ":memory",
         "//caffe2:torch",
-        "//caffe2/functorch:functorch_src",
         "//executorch/exir/dialects/edge:lib",
     ],
 )

--- a/exir/capture/_capture.py
+++ b/exir/capture/_capture.py
@@ -15,10 +15,7 @@ import torch._export
 from executorch.exir.capture._config import CaptureConfig
 from executorch.exir.error import ExportError, ExportErrorType, InternalError
 from executorch.exir.program import ExirExportedProgram, MultiMethodExirExportedProgram
-from executorch.exir.program._program import (
-    HackedUpExportedProgramDONOTUSE,
-    transform_exported_program,
-)
+from executorch.exir.program._program import HackedUpExportedProgramDONOTUSE
 from executorch.exir.tracer import (
     _default_decomposition_table,
     dispatch_trace,
@@ -56,6 +53,7 @@ def _capture_legacy_do_not_use(f, args) -> ExirExportedProgram:
         "This function is now deprecated, please use `capture` instead. "
         "See https://github.com/pytorch/functorch for more details.",
         DeprecationWarning,
+        stacklevel=1,
     )
 
     graph_module = dispatch_trace(f, args)
@@ -87,7 +85,7 @@ def _capture_legacy_do_not_use(f, args) -> ExirExportedProgram:
 
 
 @compatibility(is_backward_compatible=False)
-def capture(
+def capture(  # noqa: C901
     f: Callable[..., Any],
     args: Tuple[Value, ...],
     config: Optional[CaptureConfig] = None,

--- a/exir/control_flow.py
+++ b/exir/control_flow.py
@@ -135,7 +135,7 @@ def while_loop(
     until cond_fn returns False.
     """
     flattened_inputs, _ = pytree.tree_flatten(init_val)
-    if not all([isinstance(i, torch.Tensor) for i in flattened_inputs]):
+    if not all(isinstance(i, torch.Tensor) for i in flattened_inputs):
         raise ExportError(
             ExportErrorType.INVALID_INPUT_TYPE,
             f"control_flow.while_loop() expects all inputs values to be tensors, actual inputs: {init_val}",
@@ -147,7 +147,7 @@ def while_loop(
             val = body_fn(*val)
 
     flattened_outputs, _ = pytree.tree_flatten(val)
-    if not all([isinstance(o, torch.Tensor) for o in flattened_outputs]):
+    if not all(isinstance(o, torch.Tensor) for o in flattened_outputs):
         raise ExportError(
             ExportErrorType.INVALID_OUTPUT_TYPE,
             f"control_flow.while_loop() expects all returned values to be tensors, actual outputs: {val}",

--- a/exir/delegate.py
+++ b/exir/delegate.py
@@ -86,7 +86,7 @@ def call_delegate_autograd(lowered_module, *args):
     # TODO: support autograd
     flat_operands, _ = tree_flatten([lowered_module, *args])
     requires_grad = any(
-        [f.requires_grad for f in flat_operands if isinstance(f, torch.Tensor)]
+        f.requires_grad for f in flat_operands if isinstance(f, torch.Tensor)
     )
 
     with torch._C._ExcludeDispatchKeyGuard(
@@ -95,10 +95,6 @@ def call_delegate_autograd(lowered_module, *args):
         res = executorch_call_delegate(lowered_module, *args)
 
         if requires_grad:
-            err_fn = torch._C._functions.DelayedError(
-                b"NYI: call_delegate doesn't support autograd",
-                1,
-            )
             # Create aliases of the output that has requires_grad=True. We need
             # at least one of the inputs to err_fn to require grad so that the
             # output will have a grad_fn.

--- a/exir/dialects/_ops.py
+++ b/exir/dialects/_ops.py
@@ -62,7 +62,7 @@ def bind_pattern_to_op(library: Library, schema_or_name: str):
             DispatchKey.CompositeImplicitAutograd,
             DispatchKey.Meta,
         ]
-        if not any([torch_op.has_kernel_for_dispatch_key(k) for k in keys]):
+        if not any(torch_op.has_kernel_for_dispatch_key(k) for k in keys):
             library.impl(opname, f, "CompositeImplicitAutograd")
         op = getattr(getattr(getattr(ops.backend, library.ns), name), overload_name)
         op._equivalent_callable = f

--- a/exir/dialects/edge/spec/gen.py
+++ b/exir/dialects/edge/spec/gen.py
@@ -278,10 +278,8 @@ class EdgeOpYamlInfo:
         self.custom = custom
 
         assert all(
-            [
-                len(self.tensor_variable_names) == len(type_combination)
-                for type_combination in allowed_types
-            ]
+            len(self.tensor_variable_names) == len(type_combination)
+            for type_combination in allowed_types
         ), "{}'s tensor_variable_names length must be the same as number of allowed types, but got {} vs {}: {}.".format(
             self.inherits,
             self.tensor_variable_names,

--- a/exir/emit/TARGETS
+++ b/exir/emit/TARGETS
@@ -19,7 +19,6 @@ python_library(
     deps = [
         "fbsource//third-party/pypi/typing-extensions:typing-extensions",
         "//caffe2:torch",
-        "//caffe2/functorch:functorch_src",
         "//executorch/exir:common",
         "//executorch/exir:delegate",
         "//executorch/exir:error",

--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -89,7 +89,6 @@ from executorch.exir.tensor import (
     TensorSpec,
 )
 from executorch.exir.types import LeafValueSpec, ValueSpec
-from functorch.experimental import control_flow
 from torch._export.exported_program import ExportedProgram
 from torch.utils import _pytree as pytree
 
@@ -449,7 +448,7 @@ class _Emitter(torch.fx.Interpreter):
         # For constant tensors, allocation_info = None.
         return EValue(make_tensor_value(buffer_idx, None, spec))
 
-    def _constant_to_evalue(
+    def _constant_to_evalue(  # noqa: C901
         self,
         val: _Argument,
         val_type: Optional[_SchemaType],
@@ -979,7 +978,7 @@ class _Emitter(torch.fx.Interpreter):
         self.emitter_state.operator_cache[key] = op_index
         return op_index, operator
 
-    def _emit_operator(
+    def _emit_operator(  # noqa: C901
         self, target: _Target, args: Tuple[_Argument, ...], kwargs: Dict[str, _Argument]
     ) -> _EmitterValue:
         """Emits an operator (aten or custom), directly translates to a call_kernel instruction."""

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -238,11 +238,11 @@ class TestEmit(unittest.TestCase):
         program = edge.to_executorch().program
         for opname in removed_ops:
             self.assertTrue(
-                all([op.name != opname for op in program.execution_plan[0].operators])
+                all(op.name != opname for op in program.execution_plan[0].operators)
             )
         for opname in expected_ops:
             self.assertTrue(
-                any([op.name == opname for op in program.execution_plan[0].operators])
+                any(op.name == opname for op in program.execution_plan[0].operators)
             )
 
     def test_operators_unique(self) -> None:

--- a/exir/graph.py
+++ b/exir/graph.py
@@ -64,7 +64,7 @@ class ExportGraph:
             try:
                 submod: torch.nn.Module = mod.get_submodule(module_path)
             except AttributeError:
-                warnings.warn(f"Failed to fetch module {module_path}!")
+                warnings.warn(f"Failed to fetch module {module_path}!", stacklevel=1)
                 return None
 
             # See if the value is a buffer

--- a/exir/memory_planning.py
+++ b/exir/memory_planning.py
@@ -271,7 +271,7 @@ def get_graph_output_tensors(nodes: Iterable[Node]) -> Set[TensorSpec]:
     return graph_output_tensors
 
 
-def collect_specs_from_nodes(
+def collect_specs_from_nodes(  # noqa: C901
     nodes: Iterable[Node],
     ignore_graph_input: bool = False,
     ignore_graph_output: bool = False,

--- a/exir/operator/manip.py
+++ b/exir/operator/manip.py
@@ -10,7 +10,7 @@
 This module contains APIs to manipulate ops.
 """
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict
 
 import torch
 from executorch.exir.tensor import TensorSpec

--- a/exir/pass_base.py
+++ b/exir/pass_base.py
@@ -6,36 +6,27 @@
 
 # pyre-strict
 
-import logging
 import operator
-import typing
-from contextlib import nullcontext
 from typing import (
     Any,
     Callable,
     Dict,
     List,
     MutableMapping,
-    Optional,
     Protocol,
     runtime_checkable,
     Tuple,
-    Type,
     TypeVar,
-    Union,
 )
 
 import torch
-from executorch.exir import error, memory
+from executorch.exir import memory
 
 from executorch.exir.delegate import executorch_call_delegate, is_lowered_module
 
 from executorch.exir.dialects.edge._ops import EdgeOpOverload
 from executorch.exir.error import ExportError, ExportErrorType
-from functorch.experimental import control_flow
-from functorch.experimental._map import _unstack_pytree
 from torch import fx
-from torch._dispatch.python import enable_python_dispatcher
 from torch._export.pass_base import (  # noqa
     _ExportPassBase,
     Argument,
@@ -44,13 +35,6 @@ from torch._export.pass_base import (  # noqa
     PassResult,
     ProxyValue,
 )
-from torch._subclasses import FakeTensor, UnsupportedFakeTensorException
-from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.fx import traceback as fx_traceback
-from torch.fx.experimental.proxy_tensor import PythonKeyTracer
-from torch.fx.graph import CodeGen
-from torch.fx.passes.shape_prop import _extract_tensor_metadata, TensorMetadata
-from torch.utils import _pytree as pytree
 from torch.utils._pytree import PyTree
 
 Fn = Callable[..., Any]  # pyre-ignore

--- a/exir/passes/__init__.py
+++ b/exir/passes/__init__.py
@@ -310,7 +310,7 @@ class ToOutVarPass(PassBase):
         if (not self.ignore_to_out_var_failure) and len(self.missing_out_vars) > 0:
             raise RuntimeError(f"Missing out variants: {self.missing_out_vars}")
 
-    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:  # noqa: C901
         """
         Converts all of the functions to contain an out variant if it does not exist
         """

--- a/exir/passes/dynamic_shape_prop_pass.py
+++ b/exir/passes/dynamic_shape_prop_pass.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 

--- a/exir/passes/memory_planning_pass.py
+++ b/exir/passes/memory_planning_pass.py
@@ -66,7 +66,8 @@ class MemoryPlanningPass(PassBase):
                         out_alloc_node = node.kwargs[out_arg]
                         if out_alloc_node is None:
                             warnings.warn(
-                                f"Function {node.target}'s {out_arg} kwarg value is None"
+                                f"Function {node.target}'s {out_arg} kwarg value is None",
+                                stacklevel=1,
                             )
                             continue
                         internal_assert(

--- a/exir/passes/pass_registry.py
+++ b/exir/passes/pass_registry.py
@@ -60,7 +60,8 @@ class PassRegistry:
 
         if pass_name in cls.registry:
             warnings.warn(
-                f"Pass {pass_name} already exists inside of the PassRegistry. Will ignore."
+                f"Pass {pass_name} already exists inside of the PassRegistry. Will ignore.",
+                stacklevel=1,
             )
             return
 

--- a/exir/passes/quant_fusion_pass.py
+++ b/exir/passes/quant_fusion_pass.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 from torch.fx import GraphModule, subgraph_rewriter

--- a/exir/passes/remove_mixed_type_operators.py
+++ b/exir/passes/remove_mixed_type_operators.py
@@ -15,7 +15,7 @@ from torch.utils._pytree import PyTree
 
 class RemoveMixedTypeOperators(ExportPass):
     # pyre-ignore
-    def call_operator(self, op, args, kwargs, meta: NodeMetadata):
+    def call_operator(self, op, args, kwargs, meta: NodeMetadata):  # noqa: C901
         if len(args) <= 1:
             # Unary Operators are not mixed type
             return super().call_operator(op, args, kwargs, meta)

--- a/exir/passes/sym_shape_eval_pass.py
+++ b/exir/passes/sym_shape_eval_pass.py
@@ -52,8 +52,8 @@ class SymShapeEvalPass(PassBase):
                     if isinstance(spec, TensorSpec):
                         concrete_shape = eval_shape(spec.shape)
                         concrete_spec = eval_shape(spec.stride)
-                        if any([s is None for s in concrete_shape]) or any(
-                            [s is None for s in concrete_spec]
+                        if any(s is None for s in concrete_shape) or any(
+                            s is None for s in concrete_spec
                         ):
 
                             def get_val(arg):
@@ -79,9 +79,9 @@ class SymShapeEvalPass(PassBase):
                             # we cached the map between symbols and the concrete upper bounds. Can directly eval here.
                             concrete_spec = eval_shape(spec.stride)
 
-                        assert all(
-                            [isinstance(s, int) for s in concrete_shape]
-                        ) and all([isinstance(s, int) for s in concrete_spec])
+                        assert all(isinstance(s, int) for s in concrete_shape) and all(
+                            isinstance(s, int) for s in concrete_spec
+                        )
                         spec.shape = concrete_shape
                         spec.stride = concrete_spec
         return PassResult(graph_module, True)

--- a/exir/print_program.py
+++ b/exir/print_program.py
@@ -70,7 +70,7 @@ def _is_dynamic_shape_tensor(tensor: Tensor) -> bool:
     return tensor.shape_dynamism != TensorShapeDynamism.STATIC
 
 
-def _format_evalue(
+def _format_evalue(  # noqa: C901
     evalue: EValue, show_meminfo: bool, mark_dynamic_shape_tensor: bool
 ) -> str:
     evstr = "\033[34m"
@@ -140,7 +140,7 @@ def _format_evalue(
     return evstr
 
 
-def print_program(
+def print_program(  # noqa: C901
     program: Program, show_meminfo: bool = True, mark_dynamic_shape_tensor: bool = False
 ) -> None:
     """

--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -98,7 +98,7 @@ def calculate_aligned_num_bytes(num: int, alignment: int) -> int:
 
 
 def determine_tensor_dynanism(shape: torch.Size) -> TensorShapeDynamism:
-    if all([isinstance(s, int) for s in shape]):
+    if all(isinstance(s, int) for s in shape):
         return TensorShapeDynamism.STATIC
     else:
         try:

--- a/exir/tests/TARGETS
+++ b/exir/tests/TARGETS
@@ -118,7 +118,6 @@ python_unittest(
     ],
     deps = [
         "//caffe2:torch",
-        "//executorch/exir:lib",
         "//executorch/exir:schema",
         "//executorch/exir:tensor",
     ],
@@ -183,9 +182,7 @@ python_unittest(
         "test_experimental.py",
     ],
     deps = [
-        ":models",
         "//caffe2:torch",
-        "//caffe2/functorch:functorch_src",
         "//executorch/exir:error",
         "//executorch/exir:lib",
         "//executorch/exir/experimental:export_pt2",
@@ -210,7 +207,6 @@ python_unittest(
         "//executorch/exir:memory",
         "//executorch/exir:memory_planning",
         "//executorch/exir:pass_base",
-        "//executorch/exir:pass_manager",
         "//executorch/exir:tensor",
         "//executorch/exir/dialects:lib",
         "//executorch/exir/dialects/edge:lib",

--- a/exir/tests/test_experimental.py
+++ b/exir/tests/test_experimental.py
@@ -6,20 +6,15 @@
 
 # pyre-strict
 
-import copy
 import unittest
 from typing import Optional
 
 import executorch.exir as exir
-import executorch.exir.tests.models as models
 
 import torch
 from executorch.exir import CaptureConfig
 from executorch.exir.error import ExportError
-from executorch.exir.experimental import (
-    add_assertions,
-    convert_fake_tensor_to_tensor_meta,
-)
+from executorch.exir.experimental import add_assertions
 from executorch.exir.experimental.export_pt2 import (
     ExportSession,
     Guard,
@@ -28,8 +23,6 @@ from executorch.exir.experimental.export_pt2 import (
     Trace,
     trace,
 )
-from functorch.experimental import control_flow
-from torch._subclasses.fake_tensor import FakeTensor
 
 
 class TestExperimental(unittest.TestCase):

--- a/exir/tests/test_memory_planning.py
+++ b/exir/tests/test_memory_planning.py
@@ -93,11 +93,11 @@ class ModelWithDifferentTensorSizes(torch.nn.Module):
 
     def forward(self, i: torch.Tensor) -> torch.Tensor:
         o1 = i
-        for l in self.linears:
-            o1 = l(o1)
+        for linear in self.linears:
+            o1 = linear(o1)
         o2 = i
-        for l in self.linears:
-            o2 = l(o2)
+        for linear in self.linears:
+            o2 = linear(o2)
         return o1 + o2
 
     def get_random_inputs(self) -> Tuple[torch.Tensor, ...]:

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-None
 import os
 import tempfile
 import unittest
@@ -22,12 +21,10 @@ from executorch.exir.dialects.edge._ops import EdgeOpOverload
 from executorch.exir.emit import emit_program
 from executorch.exir.graph_module import get_control_flow_submodules
 from executorch.exir.pass_base import ExportPass, PassResult
-from executorch.exir.pass_manager import PassManager
 from executorch.exir.passes import (
     dead_code_elimination_pass,
     DebugPass,
     MemoryPlanningPass,
-    NormalizeTransposePass,
     propagate_dynamic_shape,
     RemoveNoopPass,
     ReplaceSymSizeOpPass,

--- a/exir/tests/test_quantization.py
+++ b/exir/tests/test_quantization.py
@@ -16,10 +16,10 @@ from executorch.exir import EdgeCompileConfig
 from executorch.exir.passes.quant_fusion_pass import QuantFusionPass
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
 from torch.ao.ns.fx.utils import compute_sqnr
-from torch.ao.quantization import get_default_qconfig, QConfigMapping  # @manual
+from torch.ao.quantization import QConfigMapping  # @manual
 from torch.ao.quantization.backend_config import get_executorch_backend_config
 from torch.ao.quantization.qconfig import default_per_channel_symmetric_qnnpack_qconfig
-from torch.ao.quantization.quantize_fx import convert_to_reference_fx, prepare_fx
+from torch.ao.quantization.quantize_fx import prepare_fx
 from torch.ao.quantization.quantize_pt2e import (
     _convert_to_reference_decomposed_fx,
     convert_pt2e,
@@ -31,7 +31,6 @@ from torch.ao.quantization.quantizer.xnnpack_quantizer import (
     XNNPACKQuantizer,
 )
 from torch.testing import FileCheck
-from torch.testing._internal.common_quantization import skipIfNoQNNPACK
 from torch.testing._internal.common_quantized import override_quantized_engine
 
 # load executorch out variant ops

--- a/exir/tests/test_serde.py
+++ b/exir/tests/test_serde.py
@@ -12,7 +12,6 @@ from typing import Tuple
 import executorch.exir as exir
 
 import torch
-from executorch.exir import EdgeCompileConfig
 from executorch.exir.backend.backend_api import CompileSpec, to_backend
 from executorch.exir.backend.test.backend_with_compiler_demo import (
     BackendWithCompilerDemo,

--- a/exir/tests/test_tensor.py
+++ b/exir/tests/test_tensor.py
@@ -11,8 +11,6 @@ import unittest
 
 from typing import List, Optional
 
-import executorch.exir as exir
-
 import executorch.exir.schema as schema
 
 import torch

--- a/exir/tests/test_tracer.py
+++ b/exir/tests/test_tracer.py
@@ -96,10 +96,10 @@ class TestTorchDispatchFXTracer(unittest.TestCase):
         )
         # Check that stacktrace is populated and retained (by checking twice)
         self.assertTrue(
-            any([node.meta.get("stack_trace", None) for node in traced_f.graph.nodes])
+            any(node.meta.get("stack_trace", None) for node in traced_f.graph.nodes)
         )
         self.assertTrue(
-            any([node.meta.get("stack_trace", None) for node in traced_f.graph.nodes])
+            any(node.meta.get("stack_trace", None) for node in traced_f.graph.nodes)
         )
 
     def test_possible_input_mutation(self) -> None:

--- a/exir/tracer.py
+++ b/exir/tracer.py
@@ -291,7 +291,7 @@ class PythonTensor(torch.Tensor):
             return func(*args, **kwargs)
 
     @classmethod
-    def __torch_dispatch__(
+    def __torch_dispatch__(  # noqa: C901
         cls,
         func_overload: torch._ops.OpOverload,
         # pyre-ignore: Missing parameter annotation [2]
@@ -324,13 +324,6 @@ class PythonTensor(torch.Tensor):
                             out_arg_name, format_schema_name(func_overload._schema)
                         )
                     )
-
-        tensor_args = [
-            x
-            # pyre-fixme[16]: Module `pytree` has no attribute `tree_flatten`.
-            for x in ex_pytree.tree_flatten(args)[0] + ex_pytree.tree_flatten(kwargs)[0]
-            if isinstance(x, torch.Tensor)
-        ]
 
         # pyre-fixme[16]: Module `pytree` has no attribute `tree_map`.
         proxy_args = ex_pytree.tree_map(unwrap_proxy, args)
@@ -438,7 +431,7 @@ class DispatchTracer(fx.Tracer):
             return attr_val
         return attr_val
 
-    def create_arg(self, a: Value) -> torch.fx.Node:
+    def create_arg(self, a: Value) -> torch.fx.Node:  # noqa: C901
         if isinstance(a, torch.nn.Parameter):
             for n, p in self.root.named_parameters():
                 if a is p:

--- a/exir/verification/arg_validator.py
+++ b/exir/verification/arg_validator.py
@@ -62,7 +62,7 @@ class EdgeOpArgValidator(torch.fx.Interpreter):
 
         return kernel_arg
 
-    def call_function(
+    def call_function(  # noqa: C901
         self, target: _Target, args: Tuple[_Argument, ...], kwargs: Dict[str, _Argument]
     ) -> Any:
         """

--- a/kernels/test/gen_supported_features.py
+++ b/kernels/test/gen_supported_features.py
@@ -68,7 +68,7 @@ def generate_definition(d: dict):
 
 def generate_definition_entry(d: dict):
     if not d:
-        return []
+        return []  # noqa: B901
     for entry in d:
         namespace = entry["namespace"]
         for feature, value in entry.items():

--- a/kernels/test/summarize_supported_features.py
+++ b/kernels/test/summarize_supported_features.py
@@ -18,7 +18,7 @@ definitions_yaml = "fbcode/executorch/kernels/test/supported_features.yaml"
 
 
 def gen_overriden_values():
-    overriden_values = dict()
+    overriden_values = {}
     for name, path in kernels.items():
         with open(path) as f:
             overrides = yaml.full_load(f)

--- a/profiler/parse_profiler_results.py
+++ b/profiler/parse_profiler_results.py
@@ -9,8 +9,7 @@ import struct
 from collections import OrderedDict
 from enum import Enum
 
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from prettytable import PrettyTable
 

--- a/sdk/edir/et_schema.py
+++ b/sdk/edir/et_schema.py
@@ -222,7 +222,7 @@ class OperatorGraphWithStats(OperatorGraph):
         return header_row + data_rows
 
     # Generate summary stats grouped by operator type
-    def _gen_op_summary_stats(self) -> List[Any]:
+    def _gen_op_summary_stats(self) -> List[Any]:  # noqa: C901
         grouped_ops = {}
 
         def gen_stats(node):
@@ -472,7 +472,7 @@ class FXOperatorGraph(OperatorGraphWithStats):
             module_mapping[(source_fn[0], module_type)].append(node)
 
     @staticmethod
-    def _parse_args(
+    def _parse_args(  # noqa: C901
         node: torch.fx.Node,
         nodes: Dict[str, Node],
         const_count: int,
@@ -543,7 +543,9 @@ class FXOperatorGraph(OperatorGraphWithStats):
             ):
                 continue
             else:
-                warnings.warn(f"Unsupported kwarg encountered: {name}, {kwargs}")
+                warnings.warn(
+                    f"Unsupported kwarg encountered: {name}, {kwargs}", stacklevel=1
+                )
 
         return inputs, const_count
 


### PR DESCRIPTION
Pretty big bang fix for all existing linter issues captured by https://github.com/pytorch/executorch/pull/266.  They are:

* F401 imported but unused
* B028 No explicit stacklevel argument found
* C901 too complex (ignored with `# noqa: C901`)
* C419 Unnecessary list comprehension
* F841 local variable is assigned to but never used
* B023 Function definition does not bind loop variable (only once in `backends/xnnpack/test/test_xnnpack_quantized.py`)
* EXE001 Shebang is present but the file is not executable

### Testing

All tests pass on CI and `lintrunner --all-files -a` passes locally.