### PR TITLE
Add backend init context to backend.init

### DIFF
--- a/backends/qnnpack/QNNPackBackend.cpp
+++ b/backends/qnnpack/QNNPackBackend.cpp
@@ -112,9 +112,10 @@ class QnnpackBackend final : public PyTorchBackendInterface {
   }
 
   Result<DelegateHandle*> init(
+      BackendInitContext& context,
       FreeableBuffer* processed,
-      ArrayRef<CompileSpec> compile_specs,
-      MemoryAllocator* runtime_allocator) const override {
+      ArrayRef<CompileSpec> compile_specs) const override {
+    MemoryAllocator* runtime_allocator = context.get_runtime_allocator();
     auto dynamic_linear = fb_qnnpack::GetQNNDynamicLinear(processed->data());
     auto bias = dynamic_linear->bias();
 

--- a/backends/vulkan/VulkanBackend.cpp
+++ b/backends/vulkan/VulkanBackend.cpp
@@ -245,9 +245,9 @@ class VulkanBackend final : public PyTorchBackendInterface {
   }
 
   Result<DelegateHandle*> init(
+      BackendInitContext& context,
       FreeableBuffer* processed,
-      ArrayRef<CompileSpec>,
-      MemoryAllocator* runtime_allocator) const override {
+      ArrayRef<CompileSpec>) const override {
     ET_CHECK_OR_RETURN_ERROR(
         at::vulkan::delegate::VkGraphBufferHasIdentifier(processed->data()),
         DelegateInvalidCompatibility,
@@ -257,7 +257,7 @@ class VulkanBackend final : public PyTorchBackendInterface {
 
     at::native::vulkan::ComputeGraph* compute_graph =
         ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(
-            runtime_allocator, at::native::vulkan::ComputeGraph);
+            context.get_runtime_allocator(), at::native::vulkan::ComputeGraph);
 
     new (compute_graph) at::native::vulkan::ComputeGraph(generate_config());
 

--- a/exir/backend/test/demos/rpc/ExecutorBackend.cpp
+++ b/exir/backend/test/demos/rpc/ExecutorBackend.cpp
@@ -44,11 +44,12 @@ class ExecutorBackend final : public PyTorchBackendInterface {
   }
 
   Result<DelegateHandle*> init(
+      BackendInitContext& context,
       FreeableBuffer* processed,
-      __ET_UNUSED ArrayRef<CompileSpec> compile_specs,
-      MemoryAllocator* runtime_allocator) const override {
+      __ET_UNUSED ArrayRef<CompileSpec> compile_specs) const override {
     // `processed` contains an executorch program. Wrap it in a DataLoader that
     // will return the data directly without copying it.
+    MemoryAllocator* runtime_allocator = context.get_runtime_allocator();
     auto loader = ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(
         runtime_allocator, util::BufferDataLoader);
     new (loader) util::BufferDataLoader(processed->data(), processed->size());

--- a/runtime/backend/backend_registry.h
+++ b/runtime/backend/backend_registry.h
@@ -11,6 +11,7 @@
 #include <cstring>
 
 #include <executorch/runtime/backend/backend_execution_context.h>
+#include <executorch/runtime/backend/backend_init_context.h>
 #include <executorch/runtime/core/array_ref.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/evalue.h>
@@ -75,9 +76,9 @@ class PyTorchBackendInterface {
    * @returns On error, a value other than Error:Ok.
    */
   __ET_NODISCARD virtual Result<DelegateHandle*> init(
+      BackendInitContext& context,
       FreeableBuffer* processed,
-      ArrayRef<CompileSpec> compile_specs,
-      MemoryAllocator* memory_allocator) const = 0;
+      ArrayRef<CompileSpec> compile_specs) const = 0;
 
   /**
    * Responsible for executing the given method’s handle, as it was produced

--- a/runtime/executor/test/backend_integration_test.cpp
+++ b/runtime/executor/test/backend_integration_test.cpp
@@ -30,6 +30,7 @@
 using namespace ::testing;
 using exec_aten::ArrayRef;
 using torch::executor::BackendExecutionContext;
+using torch::executor::BackendInitContext;
 using torch::executor::CompileSpec;
 using torch::executor::DataLoader;
 using torch::executor::DelegateHandle;
@@ -78,11 +79,12 @@ class StubBackend final : public PyTorchBackendInterface {
   }
 
   Result<DelegateHandle*> init(
+      BackendInitContext& context,
       FreeableBuffer* processed,
-      ArrayRef<CompileSpec> compile_specs,
-      MemoryAllocator* runtime_allocator) const override {
+      ArrayRef<CompileSpec> compile_specs) const override {
     if (init_fn_) {
-      return init_fn_.value()(processed, compile_specs, runtime_allocator);
+      return init_fn_.value()(
+          processed, compile_specs, context.get_runtime_allocator());
     }
     // Return a benign value otherwise.
     return nullptr;

--- a/runtime/executor/test/test_backend_compiler_lib.cpp
+++ b/runtime/executor/test/test_backend_compiler_lib.cpp
@@ -94,9 +94,10 @@ class BackendWithCompiler final : public PyTorchBackendInterface {
   }
 
   Result<DelegateHandle*> init(
+      BackendInitContext& context,
       FreeableBuffer* processed,
-      ArrayRef<CompileSpec> compile_specs,
-      MemoryAllocator* runtime_allocator) const override {
+      ArrayRef<CompileSpec> compile_specs) const override {
+    MemoryAllocator* runtime_allocator = context.get_runtime_allocator();
     int shape = *(int*)(compile_specs.at(0).value.buffer);
     ET_CHECK_OR_RETURN_ERROR(
         shape <= max_shape,

--- a/runtime/executor/test/test_backend_with_delegate_mapping.cpp
+++ b/runtime/executor/test/test_backend_with_delegate_mapping.cpp
@@ -77,9 +77,10 @@ class BackendWithDelegateMapping final : public PyTorchBackendInterface {
   }
 
   Result<DelegateHandle*> init(
+      BackendInitContext& context,
       FreeableBuffer* processed,
-      ArrayRef<CompileSpec> compile_specs,
-      MemoryAllocator* runtime_allocator) const override {
+      ArrayRef<CompileSpec> compile_specs) const override {
+    MemoryAllocator* runtime_allocator = context.get_runtime_allocator();
     (void)compile_specs;
     const char* kSignLiteral = "#";
     // The first number is the number of total instruction


### PR DESCRIPTION
Summary: Create `BackendInitContext` to wrap the runtime allocator. We may inject `EventTracer` to `BackendInitContext` to profile init time later

Reviewed By: dbort

Differential Revision: D48872105


