### PR TITLE
Allow each model to choose its own runner

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -16,6 +16,11 @@ BUILD_TOOLS = [
     "buck2",
     "cmake",
 ]
+DEFAULT_RUNNER = "linux.2xlarge"
+RUNNERS = {
+    # This one runs OOM on smaller runner, the root cause is unclear (T163016365)
+    "w2l": "linux.12xlarge"
+}
 
 
 def set_output(name: str, val: Any) -> None:
@@ -53,6 +58,7 @@ def export_models_for_ci() -> None:
                     "model": name,
                     "quantization": quantization,
                     "xnnpack_delegation": xnnpack_delegation,
+                    "runner": RUNNERS.get(name, DEFAULT_RUNNER),
                 }
             )
     set_output("models", json.dumps(models))

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -43,7 +43,7 @@ jobs:
       matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
       fail-fast: false
     with:
-      runner: linux.2xlarge
+      runner: ${{ matrix.runner }}
       docker-image: executorch-ubuntu-22.04-clang12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -100,7 +100,7 @@ jobs:
           - build-tool: cmake
       fail-fast: false
     with:
-      runner: linux.2xlarge
+      runner: ${{ matrix.runner }}
       docker-image: executorch-ubuntu-22.04-clang12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -150,7 +150,7 @@ jobs:
           - build-tool: cmake
       fail-fast: false
     with:
-      runner: linux.2xlarge
+      runner: ${{ matrix.runner }}
       docker-image: executorch-ubuntu-22.04-clang12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
It's a good idea to allow each model to choose its own runner.  This also help unblock https://github.com/pytorch/executorch/pull/212 until we know the root cause of why it runs OOM.