### PR TITLE
remove the supportive for attachment/metadata

### DIFF
--- a/bundled_program/TARGETS
+++ b/bundled_program/TARGETS
@@ -26,7 +26,6 @@ python_library(
     deps = [
         "fbsource//third-party/pypi/typing-extensions:typing-extensions",
         "//caffe2:torch",
-        "//executorch/bundled_program:schema",
         "//executorch/extension/pytree:pylib",
     ],
 )

--- a/bundled_program/core.py
+++ b/bundled_program/core.py
@@ -282,16 +282,13 @@ def create_bundled_program(
                 BundledIOSet(inputs=inputs, expected_outputs=expected_outputs)
             )
 
-        # emit meta data of each execution plan test, and emit the whole execution plan test
-        execution_plan_tests.append(
-            BundledExecutionPlanTest(test_sets=test_sets, metadata=plan_test.metadata)
-        )
+        # emit the whole execution plan test
+        execution_plan_tests.append(BundledExecutionPlanTest(test_sets=test_sets))
 
     program_bytes: bytes = _serialize_pte_binary(program)
 
     return BundledProgram(
         version=BUNDLED_PROGRAM_SCHEMA_VERSION,
-        attachments=bundled_config.attachments,
         execution_plan_tests=execution_plan_tests,
         program=program_bytes,
     )

--- a/bundled_program/schema.py
+++ b/bundled_program/schema.py
@@ -70,50 +70,11 @@ class BundledIOSet:
 
 
 @dataclass
-class BundledString:
-    string_value: str
-
-
-@dataclass
-class BundledBytes:
-    bytes_value: bytes
-
-
-BundledAttachmentValueUnion = Union[
-    BundledBytes,
-    BundledInt,
-    BundledDouble,
-    BundledBool,
-    BundledString,
-]
-
-
-@dataclass
-class BundledAttachmentValue:
-    """Abstraction for BundledAttachment values"""
-
-    val: "BundledAttachmentValueUnion"
-
-
-@dataclass
-class BundledAttachment:
-    """Extra data or files need to be recorded in BundledProgram
-    for executing and verifying.
-    """
-
-    key: str
-    val: BundledAttachmentValue
-
-
-@dataclass
 class BundledExecutionPlanTest:
     """Context for testing and verifying an exceution plan."""
 
     # Sets of input/outputs to test with.
     test_sets: List[BundledIOSet]
-
-    # Optional extra data used for verification.
-    metadata: List[BundledAttachment]
 
 
 @dataclass
@@ -122,9 +83,6 @@ class BundledProgram:
 
     # Schema version.
     version: int
-
-    # Extra files or other data attached by user to verify the whole program.
-    attachments: List[BundledAttachment]
 
     # Test sets and other meta datas to verify the whole program.
     # Each BundledExecutionPlanTest should be used for the execution plan of program sharing same index.

--- a/bundled_program/tests/TARGETS
+++ b/bundled_program/tests/TARGETS
@@ -55,7 +55,6 @@ python_unittest(
         ":lib",
         "//caffe2:torch",
         "//executorch/bundled_program:config",
-        "//executorch/bundled_program:schema",
         "//executorch/extension/pytree:pylib",
     ],
 )

--- a/bundled_program/tests/common.py
+++ b/bundled_program/tests/common.py
@@ -5,8 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-import random
-from typing import Any, Dict, List, Tuple, Union
+from typing import List, Tuple, Union
 
 import executorch.exir as exir
 import torch
@@ -97,32 +96,6 @@ def get_rand_output_values(
     ]
 
 
-def get_rand_attachement(n_kv_pairs: int = -1) -> Dict[str, Any]:
-    """Helper function to generate random bundled attachments."""
-
-    if n_kv_pairs == -1:
-        n_kv_pairs = random.randint(0, 10)
-
-    # This list cotains differnet possible values for generated random attachment.
-    # They are in differnet types on purpose, which demonstrate bundle program
-    # supports multiple types of attachment values. It is worth noting that it is
-    # just a hacky method to generate random bundled attachments. It does not mean
-    # bundled program can only support listed values.
-
-    rand_attachment_vals = [
-        b"BUNDLED_VALUE_IN_BYTES",  # random bytes array
-        "BUNDLED_VALUE_IN_STR",  # random strinåg
-        1.2345,  # random float
-        True,  # random bool
-        1,  # random int
-    ]
-
-    return {
-        "BUNDLED_ATTACHMENT_KEY_{}".format(i): random.choice(rand_attachment_vals)
-        for i in range(n_kv_pairs)
-    }
-
-
 # TODO(T143955558): make n_int and metadatas as its input;
 def get_random_config(
     n_model_inputs: int,
@@ -132,13 +105,7 @@ def get_random_config(
     dtype: torch.dtype,
     n_sets_per_plan_test: int,
     n_execution_plan_tests: int,
-) -> Tuple[
-    List[List[InputValues]],
-    List[List[OutputValues]],
-    List[Dict[str, Any]],
-    Dict[str, Any],
-    BundledConfig,
-]:
+) -> Tuple[List[List[InputValues]], List[List[OutputValues]], BundledConfig,]:
     """Helper function to generate config filled with random inputs and expected outputs.
 
     The return type of rand inputs is a List[List[InputValues]]. The inner list of
@@ -166,18 +133,10 @@ def get_random_config(
         n_execution_plan_tests=n_execution_plan_tests,
     )
 
-    rand_metadatas = [get_rand_attachement() for _ in range(n_execution_plan_tests)]
-
-    rand_attachment = get_rand_attachement()
-
     return (
         rand_inputs,
         rand_expected_outputs,
-        rand_metadatas,
-        rand_attachment,
-        BundledConfig(
-            rand_inputs, rand_expected_outputs, rand_metadatas, **rand_attachment
-        ),
+        BundledConfig(rand_inputs, rand_expected_outputs),
     )
 
 
@@ -212,11 +171,7 @@ def get_random_config_with_eager_model(
         [[eager_model(*x)] for x in inputs[i]] for i in range(n_execution_plan_tests)
     ]
 
-    metadatas = [get_rand_attachement() for _ in range(n_execution_plan_tests)]
-
-    attachment = get_rand_attachement()
-
-    return inputs, BundledConfig(inputs, expected_outputs, metadatas, **attachment)
+    return inputs, BundledConfig(inputs, expected_outputs)
 
 
 def get_common_program() -> Tuple[Program, BundledConfig]:

--- a/bundled_program/tests/test_bundle_data.py
+++ b/bundled_program/tests/test_bundle_data.py
@@ -13,7 +13,6 @@ import torch
 from executorch.bundled_program.config import ConfigValue
 from executorch.bundled_program.core import create_bundled_program
 from executorch.bundled_program.schema import (
-    BundledAttachment,
     BundledBool,
     BundledDouble,
     BundledInt,
@@ -46,18 +45,6 @@ class TestBundle(unittest.TestCase):
             elif type(program_element.val) == BundledBool:
                 self.assertEqual(program_element.val.bool_val, config_element)
 
-    def assertAttachmentEqual(
-        self,
-        config_attachments: List[BundledAttachment],
-        bundled_attachments: List[BundledAttachment],
-    ) -> None:
-        self.assertEqual(len(config_attachments), len(bundled_attachments))
-        for config_attachment, bundled_attachment in zip(
-            config_attachments, bundled_attachments
-        ):
-            self.assertEqual(config_attachment.key, bundled_attachment.key)
-            self.assertEqual(config_attachment.val, bundled_attachment.val)
-
     def test_bundled_program(self) -> None:
         program, bundled_config = get_common_program()
 
@@ -79,11 +66,5 @@ class TestBundle(unittest.TestCase):
                     bundled_program_ioset.expected_outputs,
                     bundled_config_ioset.expected_outputs,
                 )
-            self.assertAttachmentEqual(
-                bundled_plan_test.metadata, config_plan_test.metadata
-            )
 
         self.assertEqual(bundled_program.program, _serialize_pte_binary(program))
-        self.assertAttachmentEqual(
-            bundled_program.attachments, bundled_config.attachments
-        )

--- a/bundled_program/tests/test_config.py
+++ b/bundled_program/tests/test_config.py
@@ -6,13 +6,11 @@
 
 # pyre-strict
 
-import typing
 import unittest
-from typing import Any, get_args, List, Union
+from typing import get_args, List, Union
 
 import torch
-from executorch.bundled_program.config import BundledConfig, DataContainer
-from executorch.bundled_program.schema import BundledAttachment
+from executorch.bundled_program.config import DataContainer
 
 from executorch.bundled_program.tests.common import (
     get_random_config,
@@ -41,30 +39,11 @@ class TestConfig(unittest.TestCase):
             else:
                 self.assertTrue(t1 == t2)
 
-    def assertAttachmentDictEqual(
-        self,
-        attachments: List[BundledAttachment],
-        kwargs: typing.Dict[str, Any],
-    ) -> None:
-        self.assertEqual(len(attachments), len(kwargs))
-        for attachment, k in zip(attachments, kwargs):
-            self.assertEqual(attachment.key, k)
-            self.assertEqual(
-                attachment.val,
-                BundledConfig.convert_prim_val_to_attachement_val(kwargs[k]),
-            )
-
     def test_create_config(self) -> None:
         n_sets_per_plan_test = 10
         n_execution_plan_tests = 5
 
-        (
-            rand_inputs,
-            rand_expected_outpus,
-            metadatas,
-            attachment,
-            bundled_config,
-        ) = get_random_config(
+        (rand_inputs, rand_expected_outpus, bundled_config,) = get_random_config(
             n_model_inputs=2,
             model_input_sizes=[[2, 2], [2, 2]],
             n_model_outputs=1,
@@ -95,12 +74,6 @@ class TestConfig(unittest.TestCase):
                     .test_sets[testset_idx]
                     .expected_outputs,
                 )
-            self.assertAttachmentDictEqual(
-                bundled_config.execution_plan_tests[plan_test_idx].metadata,
-                metadatas[plan_test_idx],
-            )
-
-        self.assertAttachmentDictEqual(bundled_config.attachments, attachment)
 
     def test_create_config_from_eager_model(self) -> None:
         n_sets_per_plan_test = 10

--- a/schema/bundled_program_schema.fbs
+++ b/schema/bundled_program_schema.fbs
@@ -10,7 +10,7 @@ include "scalar_type.fbs";
 namespace executorch_flatbuffer;
 
 // Identifier of a valid bundled program schema.
-file_identifier "BP04";
+file_identifier "BP05";
 // Extension of written files.
 file_extension "bp";
 
@@ -63,52 +63,17 @@ table BundledIOSet {
 }
 
 
-table BundledString {
-  string_value: string;
-}
-
-table BundledBytes {
-  bytes_value: [ubyte];
-}
-
-union BundledAttachmentValueUnion {
-  BundledBytes,
-  BundledInt,
-  BundledDouble,
-  BundledBool,
-  BundledString,
-}
-
-// Abstraction for BundledAttachment values
-table BundledAttachmentValue {
-  val: BundledAttachmentValueUnion;
-}
-
-// Extra data or files need to be recorded in BundledProgram
-// for executing and verifying.
-table BundledAttachment {
-  key: string;
-  val: BundledAttachmentValue;
-}
-
-
 // Context for testing and verifying an exceution plan.
 table BundledExecutionPlanTest {
 
   // Sets of input/outputs to test with.
   test_sets: [BundledIOSet];
-
-  // Optional extra data used for verification.
-  metadata: [BundledAttachment];
 }
 
 // Executorch program bunlded with data for verification.
 table BundledProgram {
   // Schema version.
   version:uint;
-
-  // Extra files or other data attached by user for verification
-  attachments: [BundledAttachment];
 
   // Test sets and other meta datas to verify the whole program.
   // Each BundledExecutionPlanTest should be used for the execution plan of program sharing same index.

--- a/test/models/generate_linear_out_bundled_program.py
+++ b/test/models/generate_linear_out_bundled_program.py
@@ -65,30 +65,12 @@ def main() -> None:
         for _ in range(len(program.execution_plan))
     ]
 
-    arbitrary_attachments = {
-        "PROGRAM_ATTACHMENT_A_KEY": b"PROGRAM_ATTACHEMENT_A_VALUE",
-        "PROGRAM_ATTACHMENT_B_KEY": b"PROGRAM_ATTACHEMENT_B_VALUE",
-    }
-
-    metadatas = [
-        {
-            "metadata_{}_A_KEY_BYTES_VAL".format(i): b"metadata_A_VALUE",
-            "metadata_{}_B_KEY_INT_VAL".format(i): 1,
-            "metadata_{}_C_KEY_FLOAT_VAL".format(i): 1.0,
-            "metadata_{}_D_KEY_BOOL_VAL".format(i): False,
-            "metadata_{}_E_KEY_STR_VAL".format(i): "metadata_E_VALUE",
-        }
-        for i in range(len(program.execution_plan))
-    ]
-
     bundled_expected_outputs = [
         [[model(*x)] for x in bundled_inputs[i]]
         for i in range(len(program.execution_plan))
     ]
 
-    bundled_config = BundledConfig(
-        bundled_inputs, bundled_expected_outputs, metadatas, **arbitrary_attachments
-    )
+    bundled_config = BundledConfig(bundled_inputs, bundled_expected_outputs)
 
     bundled_program = create_bundled_program(program, bundled_config)
     pretty_print(bundled_program)


### PR DESCRIPTION
Summary: we do not support attachment/metadata for BP (bundled program) anymore. This diff removes such supportive.

Differential Revision: D49165742


