### PR TITLE
Fix emitter bug which doesn't allow input lists to delegates

### DIFF
--- a/exir/emit/test/TARGETS
+++ b/exir/emit/test/TARGETS
@@ -13,6 +13,7 @@ python_unittest(
         "//executorch/exir:lib",
         "//executorch/exir:print_program",
         "//executorch/exir:schema",
+        "//executorch/exir/backend:backend_api",
         "//executorch/exir/emit:lib",
         "//executorch/exir/passes:const_prop_pass",
         "//executorch/exir/tests:lib",


### PR DESCRIPTION
Summary:
As the delegate op doesn't have a schema we pass in `None` here when emitting the delegate arguments.

https://www.internalfb.com/code/fbsource/[4c61670ae0bd654ca630c2288f685d3a4dfa8ece]/fbcode/executorch/exir/emit/_emitter.py?lines=954

`emit_list` expects a `val_type` to be passed in though and triggers an assert when `None` is passed in.

https://www.internalfb.com/code/fbsource/[4c61670ae0bd654ca630c2288f685d3a4dfa8ece]/fbcode/executorch/exir/emit/_emitter.py?lines=471

To handle this we try to infer the `JitType` for lists using the newly added function `_get_list_jit_type`.

Differential Revision: D49180438


