### PR TITLE
Support torch.int32 as a dtype for quantize and dequantize

### DIFF
--- a/kernels/quantized/cpu/op_dequantize.cpp
+++ b/kernels/quantized/cpu/op_dequantize.cpp
@@ -37,7 +37,9 @@ void check_dequantize_per_tensor_args(
     Tensor& out) {
   ET_CHECK_MSG(
       input.scalar_type() == ScalarType::Byte ||
-          input.scalar_type() == ScalarType::Char,
+          input.scalar_type() == ScalarType::Char ||
+          input.scalar_type() == ScalarType::Short ||
+          input.scalar_type() == ScalarType::Int,
       "input.scalar_type() %hdd is not supported:",
       input.scalar_type());
 

--- a/kernels/quantized/cpu/op_quantize.cpp
+++ b/kernels/quantized/cpu/op_quantize.cpp
@@ -56,6 +56,12 @@ void check_quantize_per_tensor_args(
         static_cast<int32_t>(std::numeric_limits<int8_t>::min());
     quant_max_upper_bound =
         static_cast<int32_t>(std::numeric_limits<int8_t>::max());
+  } else if (dtype == ScalarType::Short) {
+    quant_min_lower_bound = std::numeric_limits<int16_t>::min();
+    quant_max_upper_bound = std::numeric_limits<int16_t>::max();
+  } else if (dtype == ScalarType::Int) {
+    quant_min_lower_bound = std::numeric_limits<int32_t>::min();
+    quant_max_upper_bound = std::numeric_limits<int32_t>::max();
   } else {
     ET_CHECK_MSG(false, "Unsupported dtype: %hdd", out_dtype);
   }


### PR DESCRIPTION
Summary:
The ops like `quantized_decomposed.quantize_per_tensor.default` did not support
an int32 quantized type. Add support for these to the portable and aten runtimes.

This is important for Turing which uses int32 to represent uint16 (as the latter is not a valid
pytorch dtype).

Differential Revision: D49202048

