### PR TITLE
Use sample input for edge ops

### DIFF
--- a/exir/dialects/edge/_ops.py
+++ b/exir/dialects/edge/_ops.py
@@ -87,15 +87,15 @@ class FunctionDtypeConstraint:
             alias: AllowedDtypeSet(set(types)) for alias, types in type_alias.items()
         }
         self.type_constraint: List[Dict[str, str]] = type_constraint
-        # type_constraint's non return entries should be same as all tensor args.
+        # type_constraint's non return entries should include all tensor-like arguments.
         for t_constraint in self.type_constraint:
             type_constraint_names = set(t_constraint)
             all_tensor_arg_names = set(
                 self.essential_tensor_io_names + self.optional_tensor_io_names
             )
-            if type_constraint_names != all_tensor_arg_names:
+            if not all_tensor_arg_names.issubset(type_constraint_names):
                 raise RuntimeError(
-                    "Each input entry of type_constraint must be tensor-like,"
+                    "Input entries of type_constraint must contain all tensor-like arguments, "
                     + f"but get {type_constraint_names} and {all_tensor_arg_names}"
                 )
 

--- a/exir/dialects/edge/arg/model.py
+++ b/exir/dialects/edge/arg/model.py
@@ -362,8 +362,3 @@ class Return(BaseKwarg):
             value=self.value,
             deps=self.deps,
         )
-
-
-def get_callable(name):
-    main, suffix = name.split(".")
-    return getattr(getattr(torch.ops.aten, main), suffix)

--- a/exir/dialects/edge/dtype/TARGETS
+++ b/exir/dialects/edge/dtype/TARGETS
@@ -7,9 +7,11 @@ python_library(
     srcs = [
         "runner.py",
         "supported.py",
+        "utils.py",
     ],
     deps = [
         "//caffe2:torch",
         "//executorch/exir/dialects/edge/arg:lib",
+        "//executorch/exir/dialects/edge/op:lib",
     ],
 )

--- a/exir/dialects/edge/dtype/utils.py
+++ b/exir/dialects/edge/dtype/utils.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import collections
+from typing import Any, List
+
+import torch
+from executorch.exir.dialects.edge.arg.model import BaseArg
+
+from executorch.exir.dialects.edge.arg.type import ArgType
+
+
+def extract_return_dtype(
+    returns: Any, sample_returns: List[BaseArg]
+) -> List[torch.dtype]:
+    """Extract the dtype from a return value."""
+    if not isinstance(returns, collections.abc.Sequence):
+        returns = [returns]
+    result = []
+    for ret, sample in zip(returns, sample_returns):
+        if sample.type == ArgType.TensorList or sample.type == ArgType.TensorOptList:
+            # Assuming all tensors in tensor list has the same dtype, and we only add 1 dtype to result.
+            assert (
+                ret is not None
+            ), f"Expecting non-None return value for {sample} but got None"
+            result.append(ret.dtype)
+            break
+        elif sample.type == ArgType.Tensor or sample.type == ArgType.TensorOpt:
+            assert (
+                ret is not None
+            ), f"Expecting non-None return value for {sample} but got None"
+            result.append(ret.dtype)
+    return result

--- a/exir/dialects/edge/edge.yaml
+++ b/exir/dialects/edge/edge.yaml
@@ -35,67 +35,2106 @@
     T7: [Long]
     T8: [Short]
   type_constraint:
-  - self: T0
-    __ret_0: T1
   - self: T1
+    dtype: T0
     __ret_0: T0
   - self: T1
+    dtype: T2
     __ret_0: T2
   - self: T1
+    dtype: T3
     __ret_0: T3
   - self: T1
+    dtype: T4
     __ret_0: T4
   - self: T1
+    dtype: T5
     __ret_0: T5
   - self: T1
+    dtype: T6
     __ret_0: T6
   - self: T1
+    dtype: T7
     __ret_0: T7
   - self: T1
+    dtype: T8
     __ret_0: T8
-  - self: T2
+
+- func: aten::abs
+  namespace: edge
+  inherits: aten::abs
+  type_alias:
+    T0: [Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::acos
+  namespace: edge
+  inherits: aten::acos
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
     __ret_0: T1
-  - self: T3
+
+- func: aten::acosh
+  namespace: edge
+  inherits: aten::acosh
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
     __ret_0: T1
+
+- func: aten::add.Scalar
+  namespace: edge
+  inherits: aten::add.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Float, Int, Long, Short]
+    T2: [Bool, Float, Int]
+    T3: [Bool, Int]
+    T4: [Bool, Long]
+    T5: [Byte]
+    T6: [Char]
+    T7: [Double]
+    T8: [Float]
+    T9: [Float, Int]
+    T10: [Int]
+    T11: [Long]
+    T12: [Short]
+  type_constraint:
+  - self: T0
+    other: T0
+    alpha: T3
+    __ret_0: T0
+  - self: T0
+    other: T8
+    alpha: T9
+    __ret_0: T8
+  - self: T1
+    other: T8
+    alpha: T8
+    __ret_0: T8
+  - self: T1
+    other: T8
+    alpha: T10
+    __ret_0: T8
   - self: T4
-    __ret_0: T1
+    other: T10
+    alpha: T10
+    __ret_0: T11
   - self: T5
-    __ret_0: T1
+    other: T3
+    alpha: T10
+    __ret_0: T5
+  - self: T5
+    other: T8
+    alpha: T9
+    __ret_0: T8
   - self: T6
-    __ret_0: T1
+    other: T3
+    alpha: T10
+    __ret_0: T6
+  - self: T6
+    other: T8
+    alpha: T9
+    __ret_0: T8
   - self: T7
-    __ret_0: T1
+    other: T0
+    alpha: T9
+    __ret_0: T7
+  - self: T7
+    other: T2
+    alpha: T8
+    __ret_0: T7
+  - self: T7
+    other: T2
+    alpha: T10
+    __ret_0: T7
+  - self: T7
+    other: T8
+    alpha: T9
+    __ret_0: T7
+  - self: T7
+    other: T10
+    alpha: T9
+    __ret_0: T7
   - self: T8
-    __ret_0: T1
+    other: T0
+    alpha: T9
+    __ret_0: T8
+  - self: T8
+    other: T2
+    alpha: T8
+    __ret_0: T8
+  - self: T8
+    other: T2
+    alpha: T10
+    __ret_0: T8
+  - self: T8
+    other: T8
+    alpha: T9
+    __ret_0: T8
+  - self: T8
+    other: T10
+    alpha: T9
+    __ret_0: T8
+  - self: T10
+    other: T3
+    alpha: T10
+    __ret_0: T10
+  - self: T10
+    other: T8
+    alpha: T9
+    __ret_0: T8
+  - self: T11
+    other: T3
+    alpha: T10
+    __ret_0: T11
+  - self: T11
+    other: T8
+    alpha: T9
+    __ret_0: T8
+  - self: T12
+    other: T3
+    alpha: T10
+    __ret_0: T12
+  - self: T12
+    other: T8
+    alpha: T9
+    __ret_0: T8
 
 - func: aten::add.Tensor
   namespace: edge
   inherits: aten::add.Tensor
   type_alias:
-    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T0: [Bool]
+    T1: [Bool, Byte]
+    T2: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T3: [Bool, Byte, Char, Float, Int, Long, Short]
+    T4: [Bool, Byte, Char, Int, Long, Short]
+    T5: [Bool, Byte, Char, Int, Short]
+    T6: [Bool, Byte, Char, Short]
+    T7: [Bool, Char]
+    T8: [Bool, Int]
+    T9: [Byte]
+    T10: [Byte, Short]
+    T11: [Char]
+    T12: [Char, Short]
+    T13: [Double]
+    T14: [Float]
+    T15: [Float, Int]
+    T16: [Int]
+    T17: [Long]
+    T18: [Short]
   type_constraint:
   - self: T0
     other: T0
+    alpha: T8
     __ret_0: T0
+  - self: T0
+    other: T13
+    alpha: T15
+    __ret_0: T13
+  - self: T0
+    other: T14
+    alpha: T15
+    __ret_0: T14
+  - self: T1
+    other: T9
+    alpha: T16
+    __ret_0: T9
+  - self: T2
+    other: T13
+    alpha: T14
+    __ret_0: T13
+  - self: T2
+    other: T13
+    alpha: T16
+    __ret_0: T13
+  - self: T3
+    other: T14
+    alpha: T14
+    __ret_0: T14
+  - self: T3
+    other: T14
+    alpha: T16
+    __ret_0: T14
+  - self: T4
+    other: T17
+    alpha: T16
+    __ret_0: T17
+  - self: T5
+    other: T16
+    alpha: T16
+    __ret_0: T16
+  - self: T6
+    other: T18
+    alpha: T16
+    __ret_0: T18
+  - self: T7
+    other: T11
+    alpha: T16
+    __ret_0: T11
+  - self: T9
+    other: T1
+    alpha: T16
+    __ret_0: T9
+  - self: T9
+    other: T12
+    alpha: T16
+    __ret_0: T18
+  - self: T9
+    other: T13
+    alpha: T15
+    __ret_0: T13
+  - self: T9
+    other: T14
+    alpha: T15
+    __ret_0: T14
+  - self: T10
+    other: T11
+    alpha: T16
+    __ret_0: T18
+  - self: T11
+    other: T7
+    alpha: T16
+    __ret_0: T11
+  - self: T11
+    other: T10
+    alpha: T16
+    __ret_0: T18
+  - self: T11
+    other: T13
+    alpha: T15
+    __ret_0: T13
+  - self: T11
+    other: T14
+    alpha: T15
+    __ret_0: T14
+  - self: T12
+    other: T9
+    alpha: T16
+    __ret_0: T18
+  - self: T13
+    other: T0
+    alpha: T15
+    __ret_0: T13
+  - self: T13
+    other: T2
+    alpha: T14
+    __ret_0: T13
+  - self: T13
+    other: T2
+    alpha: T16
+    __ret_0: T13
+  - self: T13
+    other: T9
+    alpha: T15
+    __ret_0: T13
+  - self: T13
+    other: T11
+    alpha: T15
+    __ret_0: T13
+  - self: T13
+    other: T13
+    alpha: T15
+    __ret_0: T13
+  - self: T13
+    other: T14
+    alpha: T15
+    __ret_0: T13
+  - self: T13
+    other: T16
+    alpha: T15
+    __ret_0: T13
+  - self: T13
+    other: T17
+    alpha: T15
+    __ret_0: T13
+  - self: T13
+    other: T18
+    alpha: T15
+    __ret_0: T13
+  - self: T14
+    other: T0
+    alpha: T15
+    __ret_0: T14
+  - self: T14
+    other: T3
+    alpha: T14
+    __ret_0: T14
+  - self: T14
+    other: T3
+    alpha: T16
+    __ret_0: T14
+  - self: T14
+    other: T9
+    alpha: T15
+    __ret_0: T14
+  - self: T14
+    other: T11
+    alpha: T15
+    __ret_0: T14
+  - self: T14
+    other: T13
+    alpha: T15
+    __ret_0: T13
+  - self: T14
+    other: T14
+    alpha: T15
+    __ret_0: T14
+  - self: T14
+    other: T16
+    alpha: T15
+    __ret_0: T14
+  - self: T14
+    other: T17
+    alpha: T15
+    __ret_0: T14
+  - self: T14
+    other: T18
+    alpha: T15
+    __ret_0: T14
+  - self: T16
+    other: T5
+    alpha: T16
+    __ret_0: T16
+  - self: T16
+    other: T13
+    alpha: T15
+    __ret_0: T13
+  - self: T16
+    other: T14
+    alpha: T15
+    __ret_0: T14
+  - self: T17
+    other: T4
+    alpha: T16
+    __ret_0: T17
+  - self: T17
+    other: T13
+    alpha: T15
+    __ret_0: T13
+  - self: T17
+    other: T14
+    alpha: T15
+    __ret_0: T14
+  - self: T18
+    other: T6
+    alpha: T16
+    __ret_0: T18
+  - self: T18
+    other: T13
+    alpha: T15
+    __ret_0: T13
+  - self: T18
+    other: T14
+    alpha: T15
+    __ret_0: T14
 
 - func: aten::addmm
   namespace: edge
   inherits: aten::addmm
   type_alias:
-    T0: [Byte, Char, Double, Float, Int, Long, Short]
+    T0: [Bool]
+    T1: [Bool, Float, Int]
+    T2: [Bool, Int]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Double]
+    T6: [Float]
+    T7: [Int]
+    T8: [Long]
+    T9: [Short]
+  type_constraint:
+  - self: T3
+    mat1: T3
+    mat2: T3
+    beta: T0
+    alpha: T1
+    __ret_0: T3
+  - self: T3
+    mat1: T3
+    mat2: T3
+    beta: T1
+    alpha: T6
+    __ret_0: T3
+  - self: T3
+    mat1: T3
+    mat2: T3
+    beta: T2
+    alpha: T0
+    __ret_0: T3
+  - self: T3
+    mat1: T3
+    mat2: T3
+    beta: T2
+    alpha: T7
+    __ret_0: T3
+  - self: T3
+    mat1: T3
+    mat2: T3
+    beta: T7
+    alpha: T1
+    __ret_0: T3
+  - self: T4
+    mat1: T4
+    mat2: T4
+    beta: T0
+    alpha: T1
+    __ret_0: T4
+  - self: T4
+    mat1: T4
+    mat2: T4
+    beta: T1
+    alpha: T0
+    __ret_0: T4
+  - self: T4
+    mat1: T4
+    mat2: T4
+    beta: T1
+    alpha: T6
+    __ret_0: T4
+  - self: T4
+    mat1: T4
+    mat2: T4
+    beta: T1
+    alpha: T7
+    __ret_0: T4
+  - self: T4
+    mat1: T4
+    mat2: T4
+    beta: T6
+    alpha: T1
+    __ret_0: T4
+  - self: T4
+    mat1: T4
+    mat2: T4
+    beta: T7
+    alpha: T1
+    __ret_0: T4
+  - self: T5
+    mat1: T5
+    mat2: T5
+    beta: T0
+    alpha: T1
+    __ret_0: T5
+  - self: T5
+    mat1: T5
+    mat2: T5
+    beta: T1
+    alpha: T0
+    __ret_0: T5
+  - self: T5
+    mat1: T5
+    mat2: T5
+    beta: T1
+    alpha: T6
+    __ret_0: T5
+  - self: T5
+    mat1: T5
+    mat2: T5
+    beta: T1
+    alpha: T7
+    __ret_0: T5
+  - self: T5
+    mat1: T5
+    mat2: T5
+    beta: T6
+    alpha: T1
+    __ret_0: T5
+  - self: T5
+    mat1: T5
+    mat2: T5
+    beta: T7
+    alpha: T1
+    __ret_0: T5
+  - self: T6
+    mat1: T6
+    mat2: T6
+    beta: T0
+    alpha: T1
+    __ret_0: T6
+  - self: T6
+    mat1: T6
+    mat2: T6
+    beta: T1
+    alpha: T0
+    __ret_0: T6
+  - self: T6
+    mat1: T6
+    mat2: T6
+    beta: T1
+    alpha: T6
+    __ret_0: T6
+  - self: T6
+    mat1: T6
+    mat2: T6
+    beta: T1
+    alpha: T7
+    __ret_0: T6
+  - self: T6
+    mat1: T6
+    mat2: T6
+    beta: T6
+    alpha: T1
+    __ret_0: T6
+  - self: T6
+    mat1: T6
+    mat2: T6
+    beta: T7
+    alpha: T1
+    __ret_0: T6
+  - self: T7
+    mat1: T7
+    mat2: T7
+    beta: T0
+    alpha: T1
+    __ret_0: T7
+  - self: T7
+    mat1: T7
+    mat2: T7
+    beta: T1
+    alpha: T0
+    __ret_0: T7
+  - self: T7
+    mat1: T7
+    mat2: T7
+    beta: T1
+    alpha: T6
+    __ret_0: T7
+  - self: T7
+    mat1: T7
+    mat2: T7
+    beta: T1
+    alpha: T7
+    __ret_0: T7
+  - self: T7
+    mat1: T7
+    mat2: T7
+    beta: T6
+    alpha: T1
+    __ret_0: T7
+  - self: T7
+    mat1: T7
+    mat2: T7
+    beta: T7
+    alpha: T1
+    __ret_0: T7
+  - self: T8
+    mat1: T8
+    mat2: T8
+    beta: T0
+    alpha: T1
+    __ret_0: T8
+  - self: T8
+    mat1: T8
+    mat2: T8
+    beta: T1
+    alpha: T0
+    __ret_0: T8
+  - self: T8
+    mat1: T8
+    mat2: T8
+    beta: T1
+    alpha: T6
+    __ret_0: T8
+  - self: T8
+    mat1: T8
+    mat2: T8
+    beta: T1
+    alpha: T7
+    __ret_0: T8
+  - self: T8
+    mat1: T8
+    mat2: T8
+    beta: T6
+    alpha: T1
+    __ret_0: T8
+  - self: T8
+    mat1: T8
+    mat2: T8
+    beta: T7
+    alpha: T1
+    __ret_0: T8
+  - self: T9
+    mat1: T9
+    mat2: T9
+    beta: T0
+    alpha: T1
+    __ret_0: T9
+  - self: T9
+    mat1: T9
+    mat2: T9
+    beta: T1
+    alpha: T0
+    __ret_0: T9
+  - self: T9
+    mat1: T9
+    mat2: T9
+    beta: T1
+    alpha: T6
+    __ret_0: T9
+  - self: T9
+    mat1: T9
+    mat2: T9
+    beta: T1
+    alpha: T7
+    __ret_0: T9
+  - self: T9
+    mat1: T9
+    mat2: T9
+    beta: T6
+    alpha: T1
+    __ret_0: T9
+  - self: T9
+    mat1: T9
+    mat2: T9
+    beta: T7
+    alpha: T1
+    __ret_0: T9
+
+- func: aten::alias_copy
+  namespace: edge
+  inherits: aten::alias_copy
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
   type_constraint:
   - self: T0
-    mat1: T0
-    mat2: T0
     __ret_0: T0
+
+- func: aten::amax
+  namespace: edge
+  inherits: aten::amax
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::amin
+  namespace: edge
+  inherits: aten::amin
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::any
+  namespace: edge
+  inherits: aten::any
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+  type_constraint:
+  - self: T1
+    __ret_0: T0
+  - self: T2
+    __ret_0: T2
+
+- func: aten::arange
+  namespace: edge
+  inherits: aten::arange
+  type_alias:
+    T0: [Bool, Float, Int]
+    T1: [Byte]
+    T2: [Char]
+    T3: [Double]
+    T4: [Float]
+    T5: [Int]
+    T6: [Long]
+    T7: [Short]
+  type_constraint:
+  - end: T0
+    dtype: T1
+    __ret_0: T1
+  - end: T0
+    dtype: T2
+    __ret_0: T2
+  - end: T0
+    dtype: T3
+    __ret_0: T3
+  - end: T0
+    dtype: T4
+    __ret_0: T4
+  - end: T0
+    dtype: T5
+    __ret_0: T5
+  - end: T0
+    dtype: T6
+    __ret_0: T6
+  - end: T0
+    dtype: T7
+    __ret_0: T7
 
 - func: aten::arange.start_step
   namespace: edge
   inherits: aten::arange.start_step
   type_alias:
-    T0: [Byte, Char, Double, Float, Int, Long, Short]
+    T0: [Bool]
+    T1: [Bool, Float, Int]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
   type_constraint:
-  - __ret_0: T0
+  - start: T0
+    end: T0
+    step: T1
+    dtype: T2
+    __ret_0: T2
+  - start: T0
+    end: T0
+    step: T1
+    dtype: T3
+    __ret_0: T3
+  - start: T0
+    end: T0
+    step: T1
+    dtype: T4
+    __ret_0: T4
+  - start: T0
+    end: T0
+    step: T1
+    dtype: T5
+    __ret_0: T5
+  - start: T0
+    end: T0
+    step: T1
+    dtype: T6
+    __ret_0: T6
+  - start: T0
+    end: T0
+    step: T1
+    dtype: T7
+    __ret_0: T7
+  - start: T0
+    end: T0
+    step: T1
+    dtype: T8
+    __ret_0: T8
+  - start: T0
+    end: T1
+    step: T0
+    dtype: T2
+    __ret_0: T2
+  - start: T0
+    end: T1
+    step: T0
+    dtype: T3
+    __ret_0: T3
+  - start: T0
+    end: T1
+    step: T0
+    dtype: T4
+    __ret_0: T4
+  - start: T0
+    end: T1
+    step: T0
+    dtype: T5
+    __ret_0: T5
+  - start: T0
+    end: T1
+    step: T0
+    dtype: T6
+    __ret_0: T6
+  - start: T0
+    end: T1
+    step: T0
+    dtype: T7
+    __ret_0: T7
+  - start: T0
+    end: T1
+    step: T0
+    dtype: T8
+    __ret_0: T8
+  - start: T0
+    end: T1
+    step: T5
+    dtype: T2
+    __ret_0: T2
+  - start: T0
+    end: T1
+    step: T5
+    dtype: T3
+    __ret_0: T3
+  - start: T0
+    end: T1
+    step: T5
+    dtype: T4
+    __ret_0: T4
+  - start: T0
+    end: T1
+    step: T5
+    dtype: T5
+    __ret_0: T5
+  - start: T0
+    end: T1
+    step: T5
+    dtype: T6
+    __ret_0: T6
+  - start: T0
+    end: T1
+    step: T5
+    dtype: T7
+    __ret_0: T7
+  - start: T0
+    end: T1
+    step: T5
+    dtype: T8
+    __ret_0: T8
+  - start: T0
+    end: T1
+    step: T6
+    dtype: T2
+    __ret_0: T2
+  - start: T0
+    end: T1
+    step: T6
+    dtype: T3
+    __ret_0: T3
+  - start: T0
+    end: T1
+    step: T6
+    dtype: T4
+    __ret_0: T4
+  - start: T0
+    end: T1
+    step: T6
+    dtype: T5
+    __ret_0: T5
+  - start: T0
+    end: T1
+    step: T6
+    dtype: T6
+    __ret_0: T6
+  - start: T0
+    end: T1
+    step: T6
+    dtype: T7
+    __ret_0: T7
+  - start: T0
+    end: T1
+    step: T6
+    dtype: T8
+    __ret_0: T8
+  - start: T0
+    end: T5
+    step: T1
+    dtype: T2
+    __ret_0: T2
+  - start: T0
+    end: T5
+    step: T1
+    dtype: T3
+    __ret_0: T3
+  - start: T0
+    end: T5
+    step: T1
+    dtype: T4
+    __ret_0: T4
+  - start: T0
+    end: T5
+    step: T1
+    dtype: T5
+    __ret_0: T5
+  - start: T0
+    end: T5
+    step: T1
+    dtype: T6
+    __ret_0: T6
+  - start: T0
+    end: T5
+    step: T1
+    dtype: T7
+    __ret_0: T7
+  - start: T0
+    end: T5
+    step: T1
+    dtype: T8
+    __ret_0: T8
+  - start: T0
+    end: T6
+    step: T1
+    dtype: T2
+    __ret_0: T2
+  - start: T0
+    end: T6
+    step: T1
+    dtype: T3
+    __ret_0: T3
+  - start: T0
+    end: T6
+    step: T1
+    dtype: T4
+    __ret_0: T4
+  - start: T0
+    end: T6
+    step: T1
+    dtype: T5
+    __ret_0: T5
+  - start: T0
+    end: T6
+    step: T1
+    dtype: T6
+    __ret_0: T6
+  - start: T0
+    end: T6
+    step: T1
+    dtype: T7
+    __ret_0: T7
+  - start: T0
+    end: T6
+    step: T1
+    dtype: T8
+    __ret_0: T8
+  - start: T1
+    end: T0
+    step: T0
+    dtype: T2
+    __ret_0: T2
+  - start: T1
+    end: T0
+    step: T0
+    dtype: T3
+    __ret_0: T3
+  - start: T1
+    end: T0
+    step: T0
+    dtype: T4
+    __ret_0: T4
+  - start: T1
+    end: T0
+    step: T0
+    dtype: T5
+    __ret_0: T5
+  - start: T1
+    end: T0
+    step: T0
+    dtype: T6
+    __ret_0: T6
+  - start: T1
+    end: T0
+    step: T0
+    dtype: T7
+    __ret_0: T7
+  - start: T1
+    end: T0
+    step: T0
+    dtype: T8
+    __ret_0: T8
+  - start: T1
+    end: T0
+    step: T5
+    dtype: T2
+    __ret_0: T2
+  - start: T1
+    end: T0
+    step: T5
+    dtype: T3
+    __ret_0: T3
+  - start: T1
+    end: T0
+    step: T5
+    dtype: T4
+    __ret_0: T4
+  - start: T1
+    end: T0
+    step: T5
+    dtype: T5
+    __ret_0: T5
+  - start: T1
+    end: T0
+    step: T5
+    dtype: T6
+    __ret_0: T6
+  - start: T1
+    end: T0
+    step: T5
+    dtype: T7
+    __ret_0: T7
+  - start: T1
+    end: T0
+    step: T5
+    dtype: T8
+    __ret_0: T8
+  - start: T1
+    end: T0
+    step: T6
+    dtype: T2
+    __ret_0: T2
+  - start: T1
+    end: T0
+    step: T6
+    dtype: T3
+    __ret_0: T3
+  - start: T1
+    end: T0
+    step: T6
+    dtype: T4
+    __ret_0: T4
+  - start: T1
+    end: T0
+    step: T6
+    dtype: T5
+    __ret_0: T5
+  - start: T1
+    end: T0
+    step: T6
+    dtype: T6
+    __ret_0: T6
+  - start: T1
+    end: T0
+    step: T6
+    dtype: T7
+    __ret_0: T7
+  - start: T1
+    end: T0
+    step: T6
+    dtype: T8
+    __ret_0: T8
+  - start: T1
+    end: T5
+    step: T0
+    dtype: T2
+    __ret_0: T2
+  - start: T1
+    end: T5
+    step: T0
+    dtype: T3
+    __ret_0: T3
+  - start: T1
+    end: T5
+    step: T0
+    dtype: T4
+    __ret_0: T4
+  - start: T1
+    end: T5
+    step: T0
+    dtype: T5
+    __ret_0: T5
+  - start: T1
+    end: T5
+    step: T0
+    dtype: T6
+    __ret_0: T6
+  - start: T1
+    end: T5
+    step: T0
+    dtype: T7
+    __ret_0: T7
+  - start: T1
+    end: T5
+    step: T0
+    dtype: T8
+    __ret_0: T8
+  - start: T1
+    end: T5
+    step: T5
+    dtype: T2
+    __ret_0: T2
+  - start: T1
+    end: T5
+    step: T5
+    dtype: T3
+    __ret_0: T3
+  - start: T1
+    end: T5
+    step: T5
+    dtype: T4
+    __ret_0: T4
+  - start: T1
+    end: T5
+    step: T5
+    dtype: T5
+    __ret_0: T5
+  - start: T1
+    end: T5
+    step: T5
+    dtype: T6
+    __ret_0: T6
+  - start: T1
+    end: T5
+    step: T5
+    dtype: T7
+    __ret_0: T7
+  - start: T1
+    end: T5
+    step: T5
+    dtype: T8
+    __ret_0: T8
+  - start: T1
+    end: T5
+    step: T6
+    dtype: T2
+    __ret_0: T2
+  - start: T1
+    end: T5
+    step: T6
+    dtype: T3
+    __ret_0: T3
+  - start: T1
+    end: T5
+    step: T6
+    dtype: T4
+    __ret_0: T4
+  - start: T1
+    end: T5
+    step: T6
+    dtype: T5
+    __ret_0: T5
+  - start: T1
+    end: T5
+    step: T6
+    dtype: T6
+    __ret_0: T6
+  - start: T1
+    end: T5
+    step: T6
+    dtype: T7
+    __ret_0: T7
+  - start: T1
+    end: T5
+    step: T6
+    dtype: T8
+    __ret_0: T8
+  - start: T1
+    end: T6
+    step: T0
+    dtype: T2
+    __ret_0: T2
+  - start: T1
+    end: T6
+    step: T0
+    dtype: T3
+    __ret_0: T3
+  - start: T1
+    end: T6
+    step: T0
+    dtype: T4
+    __ret_0: T4
+  - start: T1
+    end: T6
+    step: T0
+    dtype: T5
+    __ret_0: T5
+  - start: T1
+    end: T6
+    step: T0
+    dtype: T6
+    __ret_0: T6
+  - start: T1
+    end: T6
+    step: T0
+    dtype: T7
+    __ret_0: T7
+  - start: T1
+    end: T6
+    step: T0
+    dtype: T8
+    __ret_0: T8
+  - start: T1
+    end: T6
+    step: T5
+    dtype: T2
+    __ret_0: T2
+  - start: T1
+    end: T6
+    step: T5
+    dtype: T3
+    __ret_0: T3
+  - start: T1
+    end: T6
+    step: T5
+    dtype: T4
+    __ret_0: T4
+  - start: T1
+    end: T6
+    step: T5
+    dtype: T5
+    __ret_0: T5
+  - start: T1
+    end: T6
+    step: T5
+    dtype: T6
+    __ret_0: T6
+  - start: T1
+    end: T6
+    step: T5
+    dtype: T7
+    __ret_0: T7
+  - start: T1
+    end: T6
+    step: T5
+    dtype: T8
+    __ret_0: T8
+  - start: T1
+    end: T6
+    step: T6
+    dtype: T2
+    __ret_0: T2
+  - start: T1
+    end: T6
+    step: T6
+    dtype: T3
+    __ret_0: T3
+  - start: T1
+    end: T6
+    step: T6
+    dtype: T4
+    __ret_0: T4
+  - start: T1
+    end: T6
+    step: T6
+    dtype: T5
+    __ret_0: T5
+  - start: T1
+    end: T6
+    step: T6
+    dtype: T6
+    __ret_0: T6
+  - start: T1
+    end: T6
+    step: T6
+    dtype: T7
+    __ret_0: T7
+  - start: T1
+    end: T6
+    step: T6
+    dtype: T8
+    __ret_0: T8
+  - start: T5
+    end: T0
+    step: T1
+    dtype: T2
+    __ret_0: T2
+  - start: T5
+    end: T0
+    step: T1
+    dtype: T3
+    __ret_0: T3
+  - start: T5
+    end: T0
+    step: T1
+    dtype: T4
+    __ret_0: T4
+  - start: T5
+    end: T0
+    step: T1
+    dtype: T5
+    __ret_0: T5
+  - start: T5
+    end: T0
+    step: T1
+    dtype: T6
+    __ret_0: T6
+  - start: T5
+    end: T0
+    step: T1
+    dtype: T7
+    __ret_0: T7
+  - start: T5
+    end: T0
+    step: T1
+    dtype: T8
+    __ret_0: T8
+  - start: T5
+    end: T1
+    step: T0
+    dtype: T2
+    __ret_0: T2
+  - start: T5
+    end: T1
+    step: T0
+    dtype: T3
+    __ret_0: T3
+  - start: T5
+    end: T1
+    step: T0
+    dtype: T4
+    __ret_0: T4
+  - start: T5
+    end: T1
+    step: T0
+    dtype: T5
+    __ret_0: T5
+  - start: T5
+    end: T1
+    step: T0
+    dtype: T6
+    __ret_0: T6
+  - start: T5
+    end: T1
+    step: T0
+    dtype: T7
+    __ret_0: T7
+  - start: T5
+    end: T1
+    step: T0
+    dtype: T8
+    __ret_0: T8
+  - start: T5
+    end: T1
+    step: T5
+    dtype: T2
+    __ret_0: T2
+  - start: T5
+    end: T1
+    step: T5
+    dtype: T3
+    __ret_0: T3
+  - start: T5
+    end: T1
+    step: T5
+    dtype: T4
+    __ret_0: T4
+  - start: T5
+    end: T1
+    step: T5
+    dtype: T5
+    __ret_0: T5
+  - start: T5
+    end: T1
+    step: T5
+    dtype: T6
+    __ret_0: T6
+  - start: T5
+    end: T1
+    step: T5
+    dtype: T7
+    __ret_0: T7
+  - start: T5
+    end: T1
+    step: T5
+    dtype: T8
+    __ret_0: T8
+  - start: T5
+    end: T1
+    step: T6
+    dtype: T2
+    __ret_0: T2
+  - start: T5
+    end: T1
+    step: T6
+    dtype: T3
+    __ret_0: T3
+  - start: T5
+    end: T1
+    step: T6
+    dtype: T4
+    __ret_0: T4
+  - start: T5
+    end: T1
+    step: T6
+    dtype: T5
+    __ret_0: T5
+  - start: T5
+    end: T1
+    step: T6
+    dtype: T6
+    __ret_0: T6
+  - start: T5
+    end: T1
+    step: T6
+    dtype: T7
+    __ret_0: T7
+  - start: T5
+    end: T1
+    step: T6
+    dtype: T8
+    __ret_0: T8
+  - start: T5
+    end: T5
+    step: T1
+    dtype: T2
+    __ret_0: T2
+  - start: T5
+    end: T5
+    step: T1
+    dtype: T3
+    __ret_0: T3
+  - start: T5
+    end: T5
+    step: T1
+    dtype: T4
+    __ret_0: T4
+  - start: T5
+    end: T5
+    step: T1
+    dtype: T5
+    __ret_0: T5
+  - start: T5
+    end: T5
+    step: T1
+    dtype: T6
+    __ret_0: T6
+  - start: T5
+    end: T5
+    step: T1
+    dtype: T7
+    __ret_0: T7
+  - start: T5
+    end: T5
+    step: T1
+    dtype: T8
+    __ret_0: T8
+  - start: T5
+    end: T6
+    step: T1
+    dtype: T2
+    __ret_0: T2
+  - start: T5
+    end: T6
+    step: T1
+    dtype: T3
+    __ret_0: T3
+  - start: T5
+    end: T6
+    step: T1
+    dtype: T4
+    __ret_0: T4
+  - start: T5
+    end: T6
+    step: T1
+    dtype: T5
+    __ret_0: T5
+  - start: T5
+    end: T6
+    step: T1
+    dtype: T6
+    __ret_0: T6
+  - start: T5
+    end: T6
+    step: T1
+    dtype: T7
+    __ret_0: T7
+  - start: T5
+    end: T6
+    step: T1
+    dtype: T8
+    __ret_0: T8
+  - start: T6
+    end: T0
+    step: T1
+    dtype: T2
+    __ret_0: T2
+  - start: T6
+    end: T0
+    step: T1
+    dtype: T3
+    __ret_0: T3
+  - start: T6
+    end: T0
+    step: T1
+    dtype: T4
+    __ret_0: T4
+  - start: T6
+    end: T0
+    step: T1
+    dtype: T5
+    __ret_0: T5
+  - start: T6
+    end: T0
+    step: T1
+    dtype: T6
+    __ret_0: T6
+  - start: T6
+    end: T0
+    step: T1
+    dtype: T7
+    __ret_0: T7
+  - start: T6
+    end: T0
+    step: T1
+    dtype: T8
+    __ret_0: T8
+  - start: T6
+    end: T1
+    step: T0
+    dtype: T2
+    __ret_0: T2
+  - start: T6
+    end: T1
+    step: T0
+    dtype: T3
+    __ret_0: T3
+  - start: T6
+    end: T1
+    step: T0
+    dtype: T4
+    __ret_0: T4
+  - start: T6
+    end: T1
+    step: T0
+    dtype: T5
+    __ret_0: T5
+  - start: T6
+    end: T1
+    step: T0
+    dtype: T6
+    __ret_0: T6
+  - start: T6
+    end: T1
+    step: T0
+    dtype: T7
+    __ret_0: T7
+  - start: T6
+    end: T1
+    step: T0
+    dtype: T8
+    __ret_0: T8
+  - start: T6
+    end: T1
+    step: T5
+    dtype: T2
+    __ret_0: T2
+  - start: T6
+    end: T1
+    step: T5
+    dtype: T3
+    __ret_0: T3
+  - start: T6
+    end: T1
+    step: T5
+    dtype: T4
+    __ret_0: T4
+  - start: T6
+    end: T1
+    step: T5
+    dtype: T5
+    __ret_0: T5
+  - start: T6
+    end: T1
+    step: T5
+    dtype: T6
+    __ret_0: T6
+  - start: T6
+    end: T1
+    step: T5
+    dtype: T7
+    __ret_0: T7
+  - start: T6
+    end: T1
+    step: T5
+    dtype: T8
+    __ret_0: T8
+  - start: T6
+    end: T1
+    step: T6
+    dtype: T2
+    __ret_0: T2
+  - start: T6
+    end: T1
+    step: T6
+    dtype: T3
+    __ret_0: T3
+  - start: T6
+    end: T1
+    step: T6
+    dtype: T4
+    __ret_0: T4
+  - start: T6
+    end: T1
+    step: T6
+    dtype: T5
+    __ret_0: T5
+  - start: T6
+    end: T1
+    step: T6
+    dtype: T6
+    __ret_0: T6
+  - start: T6
+    end: T1
+    step: T6
+    dtype: T7
+    __ret_0: T7
+  - start: T6
+    end: T1
+    step: T6
+    dtype: T8
+    __ret_0: T8
+  - start: T6
+    end: T5
+    step: T1
+    dtype: T2
+    __ret_0: T2
+  - start: T6
+    end: T5
+    step: T1
+    dtype: T3
+    __ret_0: T3
+  - start: T6
+    end: T5
+    step: T1
+    dtype: T4
+    __ret_0: T4
+  - start: T6
+    end: T5
+    step: T1
+    dtype: T5
+    __ret_0: T5
+  - start: T6
+    end: T5
+    step: T1
+    dtype: T6
+    __ret_0: T6
+  - start: T6
+    end: T5
+    step: T1
+    dtype: T7
+    __ret_0: T7
+  - start: T6
+    end: T5
+    step: T1
+    dtype: T8
+    __ret_0: T8
+  - start: T6
+    end: T6
+    step: T1
+    dtype: T2
+    __ret_0: T2
+  - start: T6
+    end: T6
+    step: T1
+    dtype: T3
+    __ret_0: T3
+  - start: T6
+    end: T6
+    step: T1
+    dtype: T4
+    __ret_0: T4
+  - start: T6
+    end: T6
+    step: T1
+    dtype: T5
+    __ret_0: T5
+  - start: T6
+    end: T6
+    step: T1
+    dtype: T6
+    __ret_0: T6
+  - start: T6
+    end: T6
+    step: T1
+    dtype: T7
+    __ret_0: T7
+  - start: T6
+    end: T6
+    step: T1
+    dtype: T8
+    __ret_0: T8
+
+- func: aten::argmax
+  namespace: edge
+  inherits: aten::argmax
+  type_alias:
+    T0: [Byte, Char, Double, Float, Int, Long, Short]
+    T1: [Long]
+  type_constraint:
+  - self: T0
+    __ret_0: T1
+
+- func: aten::argmin
+  namespace: edge
+  inherits: aten::argmin
+  type_alias:
+    T0: [Byte, Char, Double, Float, Int, Long, Short]
+    T1: [Long]
+  type_constraint:
+  - self: T0
+    __ret_0: T1
+
+- func: aten::as_strided_copy
+  namespace: edge
+  inherits: aten::as_strided_copy
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::asin
+  namespace: edge
+  inherits: aten::asin
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::asinh
+  namespace: edge
+  inherits: aten::asinh
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::atan
+  namespace: edge
+  inherits: aten::atan
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::atanh
+  namespace: edge
+  inherits: aten::atanh
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::avg_pool2d
+  namespace: edge
+  inherits: aten::avg_pool2d
+  type_alias:
+    T0: [Double, Float, Long]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::bitwise_and.Scalar
+  namespace: edge
+  inherits: aten::bitwise_and.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Int]
+    T2: [Bool, Long]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Int]
+    T6: [Long]
+    T7: [Short]
+  type_constraint:
+  - self: T0
+    other: T0
+    __ret_0: T0
+  - self: T2
+    other: T5
+    __ret_0: T6
+  - self: T3
+    other: T1
+    __ret_0: T3
+  - self: T4
+    other: T1
+    __ret_0: T4
+  - self: T5
+    other: T1
+    __ret_0: T5
+  - self: T6
+    other: T1
+    __ret_0: T6
+  - self: T7
+    other: T1
+    __ret_0: T7
+
+- func: aten::bitwise_and.Tensor
+  namespace: edge
+  inherits: aten::bitwise_and.Tensor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte]
+    T2: [Bool, Byte, Char, Int, Long, Short]
+    T3: [Bool, Byte, Char, Int, Short]
+    T4: [Bool, Byte, Char, Short]
+    T5: [Bool, Char]
+    T6: [Byte]
+    T7: [Byte, Short]
+    T8: [Char]
+    T9: [Char, Short]
+    T10: [Int]
+    T11: [Long]
+    T12: [Short]
+  type_constraint:
+  - self: T0
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T6
+  - self: T2
+    other: T11
+    __ret_0: T11
+  - self: T3
+    other: T10
+    __ret_0: T10
+  - self: T4
+    other: T12
+    __ret_0: T12
+  - self: T5
+    other: T8
+    __ret_0: T8
+  - self: T6
+    other: T1
+    __ret_0: T6
+  - self: T6
+    other: T9
+    __ret_0: T12
+  - self: T7
+    other: T8
+    __ret_0: T12
+  - self: T8
+    other: T5
+    __ret_0: T8
+  - self: T8
+    other: T7
+    __ret_0: T12
+  - self: T9
+    other: T6
+    __ret_0: T12
+  - self: T10
+    other: T3
+    __ret_0: T10
+  - self: T11
+    other: T2
+    __ret_0: T11
+  - self: T12
+    other: T4
+    __ret_0: T12
+
+- func: aten::bitwise_not
+  namespace: edge
+  inherits: aten::bitwise_not
+  type_alias:
+    T0: [Bool, Byte, Char, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::bitwise_or.Scalar
+  namespace: edge
+  inherits: aten::bitwise_or.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Int]
+    T2: [Bool, Long]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Int]
+    T6: [Long]
+    T7: [Short]
+  type_constraint:
+  - self: T0
+    other: T0
+    __ret_0: T0
+  - self: T2
+    other: T5
+    __ret_0: T6
+  - self: T3
+    other: T1
+    __ret_0: T3
+  - self: T4
+    other: T1
+    __ret_0: T4
+  - self: T5
+    other: T1
+    __ret_0: T5
+  - self: T6
+    other: T1
+    __ret_0: T6
+  - self: T7
+    other: T1
+    __ret_0: T7
+
+- func: aten::bitwise_or.Tensor
+  namespace: edge
+  inherits: aten::bitwise_or.Tensor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte]
+    T2: [Bool, Byte, Char, Int, Long, Short]
+    T3: [Bool, Byte, Char, Int, Short]
+    T4: [Bool, Byte, Char, Short]
+    T5: [Bool, Char]
+    T6: [Byte]
+    T7: [Byte, Short]
+    T8: [Char]
+    T9: [Char, Short]
+    T10: [Int]
+    T11: [Long]
+    T12: [Short]
+  type_constraint:
+  - self: T0
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T6
+  - self: T2
+    other: T11
+    __ret_0: T11
+  - self: T3
+    other: T10
+    __ret_0: T10
+  - self: T4
+    other: T12
+    __ret_0: T12
+  - self: T5
+    other: T8
+    __ret_0: T8
+  - self: T6
+    other: T1
+    __ret_0: T6
+  - self: T6
+    other: T9
+    __ret_0: T12
+  - self: T7
+    other: T8
+    __ret_0: T12
+  - self: T8
+    other: T5
+    __ret_0: T8
+  - self: T8
+    other: T7
+    __ret_0: T12
+  - self: T9
+    other: T6
+    __ret_0: T12
+  - self: T10
+    other: T3
+    __ret_0: T10
+  - self: T11
+    other: T2
+    __ret_0: T11
+  - self: T12
+    other: T4
+    __ret_0: T12
+
+- func: aten::bitwise_xor.Scalar
+  namespace: edge
+  inherits: aten::bitwise_xor.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Int]
+    T2: [Bool, Long]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Int]
+    T6: [Long]
+    T7: [Short]
+  type_constraint:
+  - self: T0
+    other: T0
+    __ret_0: T0
+  - self: T2
+    other: T5
+    __ret_0: T6
+  - self: T3
+    other: T1
+    __ret_0: T3
+  - self: T4
+    other: T1
+    __ret_0: T4
+  - self: T5
+    other: T1
+    __ret_0: T5
+  - self: T6
+    other: T1
+    __ret_0: T6
+  - self: T7
+    other: T1
+    __ret_0: T7
+
+- func: aten::bitwise_xor.Tensor
+  namespace: edge
+  inherits: aten::bitwise_xor.Tensor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte]
+    T2: [Bool, Byte, Char, Int, Long, Short]
+    T3: [Bool, Byte, Char, Int, Short]
+    T4: [Bool, Byte, Char, Short]
+    T5: [Bool, Char]
+    T6: [Byte]
+    T7: [Byte, Short]
+    T8: [Char]
+    T9: [Char, Short]
+    T10: [Int]
+    T11: [Long]
+    T12: [Short]
+  type_constraint:
+  - self: T0
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T6
+  - self: T2
+    other: T11
+    __ret_0: T11
+  - self: T3
+    other: T10
+    __ret_0: T10
+  - self: T4
+    other: T12
+    __ret_0: T12
+  - self: T5
+    other: T8
+    __ret_0: T8
+  - self: T6
+    other: T1
+    __ret_0: T6
+  - self: T6
+    other: T9
+    __ret_0: T12
+  - self: T7
+    other: T8
+    __ret_0: T12
+  - self: T8
+    other: T5
+    __ret_0: T8
+  - self: T8
+    other: T7
+    __ret_0: T12
+  - self: T9
+    other: T6
+    __ret_0: T12
+  - self: T10
+    other: T3
+    __ret_0: T10
+  - self: T11
+    other: T2
+    __ret_0: T11
+  - self: T12
+    other: T4
+    __ret_0: T12
 
 - func: aten::bmm
   namespace: edge
@@ -116,18 +2155,248 @@
   - tensors: T0
     __ret_0: T0
 
+- func: aten::ceil
+  namespace: edge
+  inherits: aten::ceil
+  type_alias:
+    T0: [Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
 - func: aten::clamp
   namespace: edge
   inherits: aten::clamp
   type_alias:
-    T0: [Bool, Long]
-    T1: [Byte, Char, Double, Float, Int, Short]
-    T2: [Long]
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Float, Int, Long, Short]
+    T2: [Bool, Float, Int]
+    T3: [Bool, Int]
+    T4: [Bool, Long]
+    T5: [Byte]
+    T6: [Char]
+    T7: [Double]
+    T8: [Float]
+    T9: [Int]
+    T10: [Long]
+    T11: [Short]
   type_constraint:
   - self: T0
-    __ret_0: T2
+    min: T2
+    max: T8
+    __ret_0: T8
+  - self: T0
+    min: T3
+    max: T9
+    __ret_0: T10
+  - self: T0
+    min: T8
+    max: T2
+    __ret_0: T8
+  - self: T0
+    min: T9
+    max: T3
+    __ret_0: T10
   - self: T1
-    __ret_0: T1
+    min: T0
+    max: T8
+    __ret_0: T8
+  - self: T1
+    min: T8
+    max: T0
+    __ret_0: T8
+  - self: T1
+    min: T8
+    max: T8
+    __ret_0: T8
+  - self: T1
+    min: T8
+    max: T9
+    __ret_0: T8
+  - self: T1
+    min: T9
+    max: T8
+    __ret_0: T8
+  - self: T4
+    min: T0
+    max: T9
+    __ret_0: T10
+  - self: T4
+    min: T9
+    max: T0
+    __ret_0: T10
+  - self: T4
+    min: T9
+    max: T9
+    __ret_0: T10
+  - self: T5
+    min: T0
+    max: T3
+    __ret_0: T5
+  - self: T5
+    min: T2
+    max: T8
+    __ret_0: T8
+  - self: T5
+    min: T3
+    max: T0
+    __ret_0: T5
+  - self: T5
+    min: T3
+    max: T9
+    __ret_0: T5
+  - self: T5
+    min: T8
+    max: T2
+    __ret_0: T8
+  - self: T5
+    min: T9
+    max: T3
+    __ret_0: T5
+  - self: T6
+    min: T0
+    max: T3
+    __ret_0: T6
+  - self: T6
+    min: T2
+    max: T8
+    __ret_0: T8
+  - self: T6
+    min: T3
+    max: T0
+    __ret_0: T6
+  - self: T6
+    min: T3
+    max: T9
+    __ret_0: T6
+  - self: T6
+    min: T8
+    max: T2
+    __ret_0: T8
+  - self: T6
+    min: T9
+    max: T3
+    __ret_0: T6
+  - self: T7
+    min: T0
+    max: T2
+    __ret_0: T7
+  - self: T7
+    min: T2
+    max: T0
+    __ret_0: T7
+  - self: T7
+    min: T2
+    max: T8
+    __ret_0: T7
+  - self: T7
+    min: T2
+    max: T9
+    __ret_0: T7
+  - self: T7
+    min: T8
+    max: T2
+    __ret_0: T7
+  - self: T7
+    min: T9
+    max: T2
+    __ret_0: T7
+  - self: T8
+    min: T0
+    max: T2
+    __ret_0: T8
+  - self: T8
+    min: T2
+    max: T0
+    __ret_0: T8
+  - self: T8
+    min: T2
+    max: T8
+    __ret_0: T8
+  - self: T8
+    min: T2
+    max: T9
+    __ret_0: T8
+  - self: T8
+    min: T8
+    max: T2
+    __ret_0: T8
+  - self: T8
+    min: T9
+    max: T2
+    __ret_0: T8
+  - self: T9
+    min: T0
+    max: T3
+    __ret_0: T9
+  - self: T9
+    min: T2
+    max: T8
+    __ret_0: T8
+  - self: T9
+    min: T3
+    max: T0
+    __ret_0: T9
+  - self: T9
+    min: T3
+    max: T9
+    __ret_0: T9
+  - self: T9
+    min: T8
+    max: T2
+    __ret_0: T8
+  - self: T9
+    min: T9
+    max: T3
+    __ret_0: T9
+  - self: T10
+    min: T0
+    max: T3
+    __ret_0: T10
+  - self: T10
+    min: T2
+    max: T8
+    __ret_0: T8
+  - self: T10
+    min: T3
+    max: T0
+    __ret_0: T10
+  - self: T10
+    min: T3
+    max: T9
+    __ret_0: T10
+  - self: T10
+    min: T8
+    max: T2
+    __ret_0: T8
+  - self: T10
+    min: T9
+    max: T3
+    __ret_0: T10
+  - self: T11
+    min: T0
+    max: T3
+    __ret_0: T11
+  - self: T11
+    min: T2
+    max: T8
+    __ret_0: T8
+  - self: T11
+    min: T3
+    max: T0
+    __ret_0: T11
+  - self: T11
+    min: T3
+    max: T9
+    __ret_0: T11
+  - self: T11
+    min: T8
+    max: T2
+    __ret_0: T8
+  - self: T11
+    min: T9
+    max: T3
+    __ret_0: T11
 
 - func: aten::clone
   namespace: edge
@@ -138,16 +2407,308 @@
   - self: T0
     __ret_0: T0
 
+- func: aten::constant_pad_nd
+  namespace: edge
+  inherits: aten::constant_pad_nd
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Float, Int]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    value: T1
+    __ret_0: T0
+  - self: T2
+    value: T1
+    __ret_0: T2
+  - self: T3
+    value: T1
+    __ret_0: T3
+  - self: T4
+    value: T1
+    __ret_0: T4
+  - self: T5
+    value: T1
+    __ret_0: T5
+  - self: T6
+    value: T1
+    __ret_0: T6
+  - self: T7
+    value: T1
+    __ret_0: T7
+  - self: T8
+    value: T1
+    __ret_0: T8
+
 - func: aten::convolution
   namespace: edge
   inherits: aten::convolution
   type_alias:
-    T0: [Double, Float, Long]
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T1: [Byte]
+    T2: [Char]
+    T3: [Double]
+    T4: [Float]
+    T5: [Int]
+    T6: [Long]
+    T7: [Short]
   type_constraint:
-  - input: T0
-    weight: T0
+  - input: T1
+    weight: T1
     bias: T0
+    __ret_0: T1
+  - input: T2
+    weight: T2
+    bias: T0
+    __ret_0: T2
+  - input: T3
+    weight: T3
+    bias: T0
+    __ret_0: T3
+  - input: T4
+    weight: T4
+    bias: T0
+    __ret_0: T4
+  - input: T5
+    weight: T5
+    bias: T0
+    __ret_0: T5
+  - input: T6
+    weight: T6
+    bias: T0
+    __ret_0: T6
+  - input: T7
+    weight: T7
+    bias: T0
+    __ret_0: T7
+
+- func: aten::copy
+  namespace: edge
+  inherits: aten::copy
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    src: T1
     __ret_0: T0
+  - self: T2
+    src: T1
+    __ret_0: T2
+  - self: T3
+    src: T1
+    __ret_0: T3
+  - self: T4
+    src: T1
+    __ret_0: T4
+  - self: T5
+    src: T1
+    __ret_0: T5
+  - self: T6
+    src: T1
+    __ret_0: T6
+  - self: T7
+    src: T1
+    __ret_0: T7
+  - self: T8
+    src: T1
+    __ret_0: T8
+
+- func: aten::cos
+  namespace: edge
+  inherits: aten::cos
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::cosh
+  namespace: edge
+  inherits: aten::cosh
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::cumsum
+  namespace: edge
+  inherits: aten::cumsum
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T1: [Byte]
+    T2: [Char]
+    T3: [Double]
+    T4: [Float]
+    T5: [Int]
+    T6: [Long]
+    T7: [Short]
+  type_constraint:
+  - self: T0
+    dtype: T1
+    __ret_0: T1
+  - self: T0
+    dtype: T2
+    __ret_0: T2
+  - self: T0
+    dtype: T3
+    __ret_0: T3
+  - self: T0
+    dtype: T4
+    __ret_0: T4
+  - self: T0
+    dtype: T5
+    __ret_0: T5
+  - self: T0
+    dtype: T6
+    __ret_0: T6
+  - self: T0
+    dtype: T7
+    __ret_0: T7
+
+- func: aten::detach_copy
+  namespace: edge
+  inherits: aten::detach_copy
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::div.Scalar
+  namespace: edge
+  inherits: aten::div.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Float, Int, Long, Short]
+    T2: [Bool, Float, Int]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Double]
+    T6: [Float]
+    T7: [Int]
+    T8: [Long]
+    T9: [Short]
+  type_constraint:
+  - self: T0
+    other: T2
+    __ret_0: T6
+  - self: T1
+    other: T0
+    __ret_0: T6
+  - self: T1
+    other: T6
+    __ret_0: T6
+  - self: T1
+    other: T7
+    __ret_0: T6
+  - self: T3
+    other: T2
+    __ret_0: T6
+  - self: T4
+    other: T2
+    __ret_0: T6
+  - self: T5
+    other: T2
+    __ret_0: T5
+  - self: T6
+    other: T2
+    __ret_0: T6
+  - self: T7
+    other: T2
+    __ret_0: T6
+  - self: T8
+    other: T2
+    __ret_0: T6
+  - self: T9
+    other: T2
+    __ret_0: T6
+
+- func: aten::div.Tensor
+  namespace: edge
+  inherits: aten::div.Tensor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Bool, Byte, Char, Float, Int, Long, Short]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Double]
+    T6: [Float]
+    T7: [Int]
+    T8: [Long]
+    T9: [Short]
+  type_constraint:
+  - self: T0
+    other: T2
+    __ret_0: T6
+  - self: T1
+    other: T5
+    __ret_0: T5
+  - self: T2
+    other: T0
+    __ret_0: T6
+  - self: T2
+    other: T3
+    __ret_0: T6
+  - self: T2
+    other: T4
+    __ret_0: T6
+  - self: T2
+    other: T6
+    __ret_0: T6
+  - self: T2
+    other: T7
+    __ret_0: T6
+  - self: T2
+    other: T8
+    __ret_0: T6
+  - self: T2
+    other: T9
+    __ret_0: T6
+  - self: T3
+    other: T2
+    __ret_0: T6
+  - self: T4
+    other: T2
+    __ret_0: T6
+  - self: T5
+    other: T1
+    __ret_0: T5
+  - self: T6
+    other: T2
+    __ret_0: T6
+  - self: T7
+    other: T2
+    __ret_0: T6
+  - self: T8
+    other: T2
+    __ret_0: T6
+  - self: T9
+    other: T2
+    __ret_0: T6
 
 - func: aten::embedding
   namespace: edge
@@ -159,8 +2720,9 @@
     T3: [Double]
     T4: [Float]
     T5: [Int]
-    T6: [Long]
-    T7: [Short]
+    T6: [Int, Long]
+    T7: [Long]
+    T8: [Short]
   type_constraint:
   - weight: T0
     indices: T6
@@ -180,30 +2742,907 @@
   - weight: T5
     indices: T6
     __ret_0: T5
-  - weight: T6
-    indices: T6
-    __ret_0: T6
   - weight: T7
     indices: T6
     __ret_0: T7
+  - weight: T8
+    indices: T6
+    __ret_0: T8
+
+- func: aten::empty.memory_format
+  namespace: edge
+  inherits: aten::empty.memory_format
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - dtype: T0
+    __ret_0: T0
+
+- func: aten::eq.Scalar
+  namespace: edge
+  inherits: aten::eq.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Bool, Float, Int]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Double]
+    T6: [Float]
+    T7: [Int]
+    T8: [Long]
+    T9: [Short]
+  type_constraint:
+  - self: T0
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T3
+    other: T2
+    __ret_0: T0
+  - self: T4
+    other: T2
+    __ret_0: T0
+  - self: T5
+    other: T2
+    __ret_0: T0
+  - self: T6
+    other: T2
+    __ret_0: T0
+  - self: T7
+    other: T2
+    __ret_0: T0
+  - self: T8
+    other: T2
+    __ret_0: T0
+  - self: T9
+    other: T2
+    __ret_0: T0
+
+- func: aten::erf
+  namespace: edge
+  inherits: aten::erf
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::exp
+  namespace: edge
+  inherits: aten::exp
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::expand_copy
+  namespace: edge
+  inherits: aten::expand_copy
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::fill.Scalar
+  namespace: edge
+  inherits: aten::fill.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Float, Int]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    value: T1
+    __ret_0: T0
+  - self: T2
+    value: T1
+    __ret_0: T2
+  - self: T3
+    value: T1
+    __ret_0: T3
+  - self: T4
+    value: T1
+    __ret_0: T4
+  - self: T5
+    value: T1
+    __ret_0: T5
+  - self: T6
+    value: T1
+    __ret_0: T6
+  - self: T7
+    value: T1
+    __ret_0: T7
+  - self: T8
+    value: T1
+    __ret_0: T8
+
+- func: aten::fill.Tensor
+  namespace: edge
+  inherits: aten::fill.Tensor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    value: T1
+    __ret_0: T0
+  - self: T2
+    value: T1
+    __ret_0: T2
+  - self: T3
+    value: T1
+    __ret_0: T3
+  - self: T4
+    value: T1
+    __ret_0: T4
+  - self: T5
+    value: T1
+    __ret_0: T5
+  - self: T6
+    value: T1
+    __ret_0: T6
+  - self: T7
+    value: T1
+    __ret_0: T7
+  - self: T8
+    value: T1
+    __ret_0: T8
+
+- func: aten::floor
+  namespace: edge
+  inherits: aten::floor
+  type_alias:
+    T0: [Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
 
 - func: aten::floor_divide
   namespace: edge
   inherits: aten::floor_divide
   type_alias:
-    T0: [Byte, Char, Double, Float, Int, Long, Short]
+    T0: [Bool, Byte]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Bool, Byte, Char, Float, Int, Long, Short]
+    T3: [Bool, Byte, Char, Int, Long, Short]
+    T4: [Bool, Byte, Char, Int, Short]
+    T5: [Bool, Byte, Char, Short]
+    T6: [Bool, Char]
+    T7: [Byte]
+    T8: [Byte, Short]
+    T9: [Char]
+    T10: [Char, Short]
+    T11: [Double]
+    T12: [Float]
+    T13: [Int]
+    T14: [Long]
+    T15: [Short]
   type_constraint:
   - self: T0
+    other: T7
+    __ret_0: T7
+  - self: T1
+    other: T11
+    __ret_0: T11
+  - self: T2
+    other: T12
+    __ret_0: T12
+  - self: T3
+    other: T14
+    __ret_0: T14
+  - self: T4
+    other: T13
+    __ret_0: T13
+  - self: T5
+    other: T15
+    __ret_0: T15
+  - self: T6
+    other: T9
+    __ret_0: T9
+  - self: T7
     other: T0
-    __ret_0: T0
+    __ret_0: T7
+  - self: T7
+    other: T10
+    __ret_0: T15
+  - self: T8
+    other: T9
+    __ret_0: T15
+  - self: T9
+    other: T6
+    __ret_0: T9
+  - self: T9
+    other: T8
+    __ret_0: T15
+  - self: T10
+    other: T7
+    __ret_0: T15
+  - self: T11
+    other: T1
+    __ret_0: T11
+  - self: T12
+    other: T2
+    __ret_0: T12
+  - self: T13
+    other: T4
+    __ret_0: T13
+  - self: T14
+    other: T3
+    __ret_0: T14
+  - self: T15
+    other: T5
+    __ret_0: T15
+
+- func: aten::fmod.Scalar
+  namespace: edge
+  inherits: aten::fmod.Scalar
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Bool, Float, Int]
+    T2: [Bool, Int]
+    T3: [Bool, Long]
+    T4: [Byte]
+    T5: [Char]
+    T6: [Double]
+    T7: [Float]
+    T8: [Int]
+    T9: [Long]
+    T10: [Short]
+  type_constraint:
+  - self: T0
+    other: T7
+    __ret_0: T7
+  - self: T3
+    other: T8
+    __ret_0: T9
+  - self: T4
+    other: T2
+    __ret_0: T4
+  - self: T5
+    other: T2
+    __ret_0: T5
+  - self: T6
+    other: T1
+    __ret_0: T6
+  - self: T7
+    other: T1
+    __ret_0: T7
+  - self: T8
+    other: T2
+    __ret_0: T8
+  - self: T9
+    other: T2
+    __ret_0: T9
+  - self: T10
+    other: T2
+    __ret_0: T10
+
+- func: aten::fmod.Tensor
+  namespace: edge
+  inherits: aten::fmod.Tensor
+  type_alias:
+    T0: [Bool, Byte]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Bool, Byte, Char, Float, Int, Long, Short]
+    T3: [Bool, Byte, Char, Int, Long, Short]
+    T4: [Bool, Byte, Char, Int, Short]
+    T5: [Bool, Byte, Char, Short]
+    T6: [Bool, Char]
+    T7: [Byte]
+    T8: [Byte, Short]
+    T9: [Char]
+    T10: [Char, Short]
+    T11: [Double]
+    T12: [Float]
+    T13: [Int]
+    T14: [Long]
+    T15: [Short]
+  type_constraint:
+  - self: T0
+    other: T7
+    __ret_0: T7
+  - self: T1
+    other: T11
+    __ret_0: T11
+  - self: T2
+    other: T12
+    __ret_0: T12
+  - self: T3
+    other: T14
+    __ret_0: T14
+  - self: T4
+    other: T13
+    __ret_0: T13
+  - self: T5
+    other: T15
+    __ret_0: T15
+  - self: T6
+    other: T9
+    __ret_0: T9
+  - self: T7
+    other: T0
+    __ret_0: T7
+  - self: T7
+    other: T10
+    __ret_0: T15
+  - self: T8
+    other: T9
+    __ret_0: T15
+  - self: T9
+    other: T6
+    __ret_0: T9
+  - self: T9
+    other: T8
+    __ret_0: T15
+  - self: T10
+    other: T7
+    __ret_0: T15
+  - self: T11
+    other: T1
+    __ret_0: T11
+  - self: T12
+    other: T2
+    __ret_0: T12
+  - self: T13
+    other: T4
+    __ret_0: T13
+  - self: T14
+    other: T3
+    __ret_0: T14
+  - self: T15
+    other: T5
+    __ret_0: T15
 
 - func: aten::full
   namespace: edge
   inherits: aten::full
   type_alias:
-    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T0: [Bool]
+    T1: [Bool, Float, Int]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
   type_constraint:
-  - __ret_0: T0
+  - fill_value: T1
+    dtype: T0
+    __ret_0: T0
+  - fill_value: T1
+    dtype: T2
+    __ret_0: T2
+  - fill_value: T1
+    dtype: T3
+    __ret_0: T3
+  - fill_value: T1
+    dtype: T4
+    __ret_0: T4
+  - fill_value: T1
+    dtype: T5
+    __ret_0: T5
+  - fill_value: T1
+    dtype: T6
+    __ret_0: T6
+  - fill_value: T1
+    dtype: T7
+    __ret_0: T7
+  - fill_value: T1
+    dtype: T8
+    __ret_0: T8
+
+- func: aten::full_like
+  namespace: edge
+  inherits: aten::full_like
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Bool, Float, Int]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Double]
+    T6: [Float]
+    T7: [Int]
+    T8: [Long]
+    T9: [Short]
+  type_constraint:
+  - self: T0
+    fill_value: T2
+    dtype: T0
+    __ret_0: T0
+  - self: T0
+    fill_value: T2
+    dtype: T3
+    __ret_0: T3
+  - self: T0
+    fill_value: T2
+    dtype: T4
+    __ret_0: T4
+  - self: T0
+    fill_value: T2
+    dtype: T5
+    __ret_0: T5
+  - self: T0
+    fill_value: T2
+    dtype: T6
+    __ret_0: T6
+  - self: T0
+    fill_value: T2
+    dtype: T7
+    __ret_0: T7
+  - self: T0
+    fill_value: T2
+    dtype: T8
+    __ret_0: T8
+  - self: T0
+    fill_value: T2
+    dtype: T9
+    __ret_0: T9
+  - self: T1
+    fill_value: T0
+    dtype: T0
+    __ret_0: T0
+  - self: T1
+    fill_value: T0
+    dtype: T3
+    __ret_0: T3
+  - self: T1
+    fill_value: T0
+    dtype: T4
+    __ret_0: T4
+  - self: T1
+    fill_value: T0
+    dtype: T5
+    __ret_0: T5
+  - self: T1
+    fill_value: T0
+    dtype: T6
+    __ret_0: T6
+  - self: T1
+    fill_value: T0
+    dtype: T7
+    __ret_0: T7
+  - self: T1
+    fill_value: T0
+    dtype: T8
+    __ret_0: T8
+  - self: T1
+    fill_value: T0
+    dtype: T9
+    __ret_0: T9
+  - self: T1
+    fill_value: T6
+    dtype: T0
+    __ret_0: T0
+  - self: T1
+    fill_value: T6
+    dtype: T3
+    __ret_0: T3
+  - self: T1
+    fill_value: T6
+    dtype: T4
+    __ret_0: T4
+  - self: T1
+    fill_value: T6
+    dtype: T5
+    __ret_0: T5
+  - self: T1
+    fill_value: T6
+    dtype: T6
+    __ret_0: T6
+  - self: T1
+    fill_value: T6
+    dtype: T7
+    __ret_0: T7
+  - self: T1
+    fill_value: T6
+    dtype: T8
+    __ret_0: T8
+  - self: T1
+    fill_value: T6
+    dtype: T9
+    __ret_0: T9
+  - self: T1
+    fill_value: T7
+    dtype: T0
+    __ret_0: T0
+  - self: T1
+    fill_value: T7
+    dtype: T3
+    __ret_0: T3
+  - self: T1
+    fill_value: T7
+    dtype: T4
+    __ret_0: T4
+  - self: T1
+    fill_value: T7
+    dtype: T5
+    __ret_0: T5
+  - self: T1
+    fill_value: T7
+    dtype: T6
+    __ret_0: T6
+  - self: T1
+    fill_value: T7
+    dtype: T7
+    __ret_0: T7
+  - self: T1
+    fill_value: T7
+    dtype: T8
+    __ret_0: T8
+  - self: T1
+    fill_value: T7
+    dtype: T9
+    __ret_0: T9
+  - self: T3
+    fill_value: T2
+    dtype: T0
+    __ret_0: T0
+  - self: T3
+    fill_value: T2
+    dtype: T3
+    __ret_0: T3
+  - self: T3
+    fill_value: T2
+    dtype: T4
+    __ret_0: T4
+  - self: T3
+    fill_value: T2
+    dtype: T5
+    __ret_0: T5
+  - self: T3
+    fill_value: T2
+    dtype: T6
+    __ret_0: T6
+  - self: T3
+    fill_value: T2
+    dtype: T7
+    __ret_0: T7
+  - self: T3
+    fill_value: T2
+    dtype: T8
+    __ret_0: T8
+  - self: T3
+    fill_value: T2
+    dtype: T9
+    __ret_0: T9
+  - self: T4
+    fill_value: T2
+    dtype: T0
+    __ret_0: T0
+  - self: T4
+    fill_value: T2
+    dtype: T3
+    __ret_0: T3
+  - self: T4
+    fill_value: T2
+    dtype: T4
+    __ret_0: T4
+  - self: T4
+    fill_value: T2
+    dtype: T5
+    __ret_0: T5
+  - self: T4
+    fill_value: T2
+    dtype: T6
+    __ret_0: T6
+  - self: T4
+    fill_value: T2
+    dtype: T7
+    __ret_0: T7
+  - self: T4
+    fill_value: T2
+    dtype: T8
+    __ret_0: T8
+  - self: T4
+    fill_value: T2
+    dtype: T9
+    __ret_0: T9
+  - self: T5
+    fill_value: T2
+    dtype: T0
+    __ret_0: T0
+  - self: T5
+    fill_value: T2
+    dtype: T3
+    __ret_0: T3
+  - self: T5
+    fill_value: T2
+    dtype: T4
+    __ret_0: T4
+  - self: T5
+    fill_value: T2
+    dtype: T5
+    __ret_0: T5
+  - self: T5
+    fill_value: T2
+    dtype: T6
+    __ret_0: T6
+  - self: T5
+    fill_value: T2
+    dtype: T7
+    __ret_0: T7
+  - self: T5
+    fill_value: T2
+    dtype: T8
+    __ret_0: T8
+  - self: T5
+    fill_value: T2
+    dtype: T9
+    __ret_0: T9
+  - self: T6
+    fill_value: T2
+    dtype: T0
+    __ret_0: T0
+  - self: T6
+    fill_value: T2
+    dtype: T3
+    __ret_0: T3
+  - self: T6
+    fill_value: T2
+    dtype: T4
+    __ret_0: T4
+  - self: T6
+    fill_value: T2
+    dtype: T5
+    __ret_0: T5
+  - self: T6
+    fill_value: T2
+    dtype: T6
+    __ret_0: T6
+  - self: T6
+    fill_value: T2
+    dtype: T7
+    __ret_0: T7
+  - self: T6
+    fill_value: T2
+    dtype: T8
+    __ret_0: T8
+  - self: T6
+    fill_value: T2
+    dtype: T9
+    __ret_0: T9
+  - self: T7
+    fill_value: T2
+    dtype: T0
+    __ret_0: T0
+  - self: T7
+    fill_value: T2
+    dtype: T3
+    __ret_0: T3
+  - self: T7
+    fill_value: T2
+    dtype: T4
+    __ret_0: T4
+  - self: T7
+    fill_value: T2
+    dtype: T5
+    __ret_0: T5
+  - self: T7
+    fill_value: T2
+    dtype: T6
+    __ret_0: T6
+  - self: T7
+    fill_value: T2
+    dtype: T7
+    __ret_0: T7
+  - self: T7
+    fill_value: T2
+    dtype: T8
+    __ret_0: T8
+  - self: T7
+    fill_value: T2
+    dtype: T9
+    __ret_0: T9
+  - self: T8
+    fill_value: T2
+    dtype: T0
+    __ret_0: T0
+  - self: T8
+    fill_value: T2
+    dtype: T3
+    __ret_0: T3
+  - self: T8
+    fill_value: T2
+    dtype: T4
+    __ret_0: T4
+  - self: T8
+    fill_value: T2
+    dtype: T5
+    __ret_0: T5
+  - self: T8
+    fill_value: T2
+    dtype: T6
+    __ret_0: T6
+  - self: T8
+    fill_value: T2
+    dtype: T7
+    __ret_0: T7
+  - self: T8
+    fill_value: T2
+    dtype: T8
+    __ret_0: T8
+  - self: T8
+    fill_value: T2
+    dtype: T9
+    __ret_0: T9
+  - self: T9
+    fill_value: T2
+    dtype: T0
+    __ret_0: T0
+  - self: T9
+    fill_value: T2
+    dtype: T3
+    __ret_0: T3
+  - self: T9
+    fill_value: T2
+    dtype: T4
+    __ret_0: T4
+  - self: T9
+    fill_value: T2
+    dtype: T5
+    __ret_0: T5
+  - self: T9
+    fill_value: T2
+    dtype: T6
+    __ret_0: T6
+  - self: T9
+    fill_value: T2
+    dtype: T7
+    __ret_0: T7
+  - self: T9
+    fill_value: T2
+    dtype: T8
+    __ret_0: T8
+  - self: T9
+    fill_value: T2
+    dtype: T9
+    __ret_0: T9
+
+- func: aten::ge.Scalar
+  namespace: edge
+  inherits: aten::ge.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Bool, Float, Int]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Double]
+    T6: [Float]
+    T7: [Int]
+    T8: [Long]
+    T9: [Short]
+  type_constraint:
+  - self: T0
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T3
+    other: T2
+    __ret_0: T0
+  - self: T4
+    other: T2
+    __ret_0: T0
+  - self: T5
+    other: T2
+    __ret_0: T0
+  - self: T6
+    other: T2
+    __ret_0: T0
+  - self: T7
+    other: T2
+    __ret_0: T0
+  - self: T8
+    other: T2
+    __ret_0: T0
+  - self: T9
+    other: T2
+    __ret_0: T0
+
+- func: aten::ge.Tensor
+  namespace: edge
+  inherits: aten::ge.Tensor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    other: T1
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T3
+    __ret_0: T0
+  - self: T1
+    other: T4
+    __ret_0: T0
+  - self: T1
+    other: T5
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T1
+    other: T8
+    __ret_0: T0
+  - self: T2
+    other: T1
+    __ret_0: T0
+  - self: T3
+    other: T1
+    __ret_0: T0
+  - self: T4
+    other: T1
+    __ret_0: T0
+  - self: T5
+    other: T1
+    __ret_0: T0
+  - self: T6
+    other: T1
+    __ret_0: T0
+  - self: T7
+    other: T1
+    __ret_0: T0
+  - self: T8
+    other: T1
+    __ret_0: T0
 
 - func: aten::gelu
   namespace: edge
@@ -213,6 +3652,396 @@
   type_constraint:
   - self: T0
     __ret_0: T0
+
+- func: aten::glu
+  namespace: edge
+  inherits: aten::glu
+  type_alias:
+    T0: [Double, Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::gt.Scalar
+  namespace: edge
+  inherits: aten::gt.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Bool, Float, Int]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Double]
+    T6: [Float]
+    T7: [Int]
+    T8: [Long]
+    T9: [Short]
+  type_constraint:
+  - self: T0
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T3
+    other: T2
+    __ret_0: T0
+  - self: T4
+    other: T2
+    __ret_0: T0
+  - self: T5
+    other: T2
+    __ret_0: T0
+  - self: T6
+    other: T2
+    __ret_0: T0
+  - self: T7
+    other: T2
+    __ret_0: T0
+  - self: T8
+    other: T2
+    __ret_0: T0
+  - self: T9
+    other: T2
+    __ret_0: T0
+
+- func: aten::gt.Tensor
+  namespace: edge
+  inherits: aten::gt.Tensor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    other: T1
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T3
+    __ret_0: T0
+  - self: T1
+    other: T4
+    __ret_0: T0
+  - self: T1
+    other: T5
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T1
+    other: T8
+    __ret_0: T0
+  - self: T2
+    other: T1
+    __ret_0: T0
+  - self: T3
+    other: T1
+    __ret_0: T0
+  - self: T4
+    other: T1
+    __ret_0: T0
+  - self: T5
+    other: T1
+    __ret_0: T0
+  - self: T6
+    other: T1
+    __ret_0: T0
+  - self: T7
+    other: T1
+    __ret_0: T0
+  - self: T8
+    other: T1
+    __ret_0: T0
+
+- func: aten::hardtanh
+  namespace: edge
+  inherits: aten::hardtanh
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Float, Int]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T2
+    min_val: T0
+    max_val: T1
+    __ret_0: T2
+  - self: T2
+    min_val: T1
+    max_val: T0
+    __ret_0: T2
+  - self: T2
+    min_val: T1
+    max_val: T5
+    __ret_0: T2
+  - self: T2
+    min_val: T1
+    max_val: T6
+    __ret_0: T2
+  - self: T2
+    min_val: T5
+    max_val: T1
+    __ret_0: T2
+  - self: T2
+    min_val: T6
+    max_val: T1
+    __ret_0: T2
+  - self: T3
+    min_val: T0
+    max_val: T1
+    __ret_0: T3
+  - self: T3
+    min_val: T1
+    max_val: T0
+    __ret_0: T3
+  - self: T3
+    min_val: T1
+    max_val: T5
+    __ret_0: T3
+  - self: T3
+    min_val: T1
+    max_val: T6
+    __ret_0: T3
+  - self: T3
+    min_val: T5
+    max_val: T1
+    __ret_0: T3
+  - self: T3
+    min_val: T6
+    max_val: T1
+    __ret_0: T3
+  - self: T4
+    min_val: T0
+    max_val: T1
+    __ret_0: T4
+  - self: T4
+    min_val: T1
+    max_val: T0
+    __ret_0: T4
+  - self: T4
+    min_val: T1
+    max_val: T5
+    __ret_0: T4
+  - self: T4
+    min_val: T1
+    max_val: T6
+    __ret_0: T4
+  - self: T4
+    min_val: T5
+    max_val: T1
+    __ret_0: T4
+  - self: T4
+    min_val: T6
+    max_val: T1
+    __ret_0: T4
+  - self: T5
+    min_val: T0
+    max_val: T1
+    __ret_0: T5
+  - self: T5
+    min_val: T1
+    max_val: T0
+    __ret_0: T5
+  - self: T5
+    min_val: T1
+    max_val: T5
+    __ret_0: T5
+  - self: T5
+    min_val: T1
+    max_val: T6
+    __ret_0: T5
+  - self: T5
+    min_val: T5
+    max_val: T1
+    __ret_0: T5
+  - self: T5
+    min_val: T6
+    max_val: T1
+    __ret_0: T5
+  - self: T6
+    min_val: T0
+    max_val: T1
+    __ret_0: T6
+  - self: T6
+    min_val: T1
+    max_val: T0
+    __ret_0: T6
+  - self: T6
+    min_val: T1
+    max_val: T5
+    __ret_0: T6
+  - self: T6
+    min_val: T1
+    max_val: T6
+    __ret_0: T6
+  - self: T6
+    min_val: T5
+    max_val: T1
+    __ret_0: T6
+  - self: T6
+    min_val: T6
+    max_val: T1
+    __ret_0: T6
+  - self: T7
+    min_val: T0
+    max_val: T1
+    __ret_0: T7
+  - self: T7
+    min_val: T1
+    max_val: T0
+    __ret_0: T7
+  - self: T7
+    min_val: T1
+    max_val: T5
+    __ret_0: T7
+  - self: T7
+    min_val: T1
+    max_val: T6
+    __ret_0: T7
+  - self: T7
+    min_val: T5
+    max_val: T1
+    __ret_0: T7
+  - self: T7
+    min_val: T6
+    max_val: T1
+    __ret_0: T7
+  - self: T8
+    min_val: T0
+    max_val: T1
+    __ret_0: T8
+  - self: T8
+    min_val: T1
+    max_val: T0
+    __ret_0: T8
+  - self: T8
+    min_val: T1
+    max_val: T5
+    __ret_0: T8
+  - self: T8
+    min_val: T1
+    max_val: T6
+    __ret_0: T8
+  - self: T8
+    min_val: T5
+    max_val: T1
+    __ret_0: T8
+  - self: T8
+    min_val: T6
+    max_val: T1
+    __ret_0: T8
+
+- func: aten::index.Tensor
+  namespace: edge
+  inherits: aten::index.Tensor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Int, Long]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    indices: T1
+    __ret_0: T0
+  - self: T2
+    indices: T1
+    __ret_0: T2
+  - self: T3
+    indices: T1
+    __ret_0: T3
+  - self: T4
+    indices: T1
+    __ret_0: T4
+  - self: T5
+    indices: T1
+    __ret_0: T5
+  - self: T6
+    indices: T1
+    __ret_0: T6
+  - self: T7
+    indices: T1
+    __ret_0: T7
+  - self: T8
+    indices: T1
+    __ret_0: T8
+
+- func: aten::index_put
+  namespace: edge
+  inherits: aten::index_put
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Int, Long]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    indices: T1
+    values: T0
+    __ret_0: T0
+  - self: T2
+    indices: T1
+    values: T2
+    __ret_0: T2
+  - self: T3
+    indices: T1
+    values: T3
+    __ret_0: T3
+  - self: T4
+    indices: T1
+    values: T4
+    __ret_0: T4
+  - self: T5
+    indices: T1
+    values: T5
+    __ret_0: T5
+  - self: T6
+    indices: T1
+    values: T6
+    __ret_0: T6
+  - self: T7
+    indices: T1
+    values: T7
+    __ret_0: T7
+  - self: T8
+    indices: T1
+    values: T8
+    __ret_0: T8
 
 - func: aten::index_select
   namespace: edge
@@ -224,8 +4053,9 @@
     T3: [Double]
     T4: [Float]
     T5: [Int]
-    T6: [Long]
-    T7: [Short]
+    T6: [Int, Long]
+    T7: [Long]
+    T8: [Short]
   type_constraint:
   - self: T0
     index: T6
@@ -245,12 +4075,757 @@
   - self: T5
     index: T6
     __ret_0: T5
-  - self: T6
-    index: T6
-    __ret_0: T6
   - self: T7
     index: T6
     __ret_0: T7
+  - self: T8
+    index: T6
+    __ret_0: T8
+
+- func: aten::isinf
+  namespace: edge
+  inherits: aten::isinf
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T1
+    __ret_0: T0
+
+- func: aten::isnan
+  namespace: edge
+  inherits: aten::isnan
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T1
+    __ret_0: T0
+
+- func: aten::le.Scalar
+  namespace: edge
+  inherits: aten::le.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Bool, Float, Int]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Double]
+    T6: [Float]
+    T7: [Int]
+    T8: [Long]
+    T9: [Short]
+  type_constraint:
+  - self: T0
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T3
+    other: T2
+    __ret_0: T0
+  - self: T4
+    other: T2
+    __ret_0: T0
+  - self: T5
+    other: T2
+    __ret_0: T0
+  - self: T6
+    other: T2
+    __ret_0: T0
+  - self: T7
+    other: T2
+    __ret_0: T0
+  - self: T8
+    other: T2
+    __ret_0: T0
+  - self: T9
+    other: T2
+    __ret_0: T0
+
+- func: aten::le.Tensor
+  namespace: edge
+  inherits: aten::le.Tensor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    other: T1
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T3
+    __ret_0: T0
+  - self: T1
+    other: T4
+    __ret_0: T0
+  - self: T1
+    other: T5
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T1
+    other: T8
+    __ret_0: T0
+  - self: T2
+    other: T1
+    __ret_0: T0
+  - self: T3
+    other: T1
+    __ret_0: T0
+  - self: T4
+    other: T1
+    __ret_0: T0
+  - self: T5
+    other: T1
+    __ret_0: T0
+  - self: T6
+    other: T1
+    __ret_0: T0
+  - self: T7
+    other: T1
+    __ret_0: T0
+  - self: T8
+    other: T1
+    __ret_0: T0
+
+- func: aten::leaky_relu
+  namespace: edge
+  inherits: aten::leaky_relu
+  type_alias:
+    T0: [Bool, Float, Int]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T1
+    negative_slope: T0
+    __ret_0: T1
+  - self: T2
+    negative_slope: T0
+    __ret_0: T2
+
+- func: aten::lift_fresh_copy
+  namespace: edge
+  inherits: aten::lift_fresh_copy
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::log
+  namespace: edge
+  inherits: aten::log
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::logical_and
+  namespace: edge
+  inherits: aten::logical_and
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    other: T1
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T3
+    __ret_0: T0
+  - self: T1
+    other: T4
+    __ret_0: T0
+  - self: T1
+    other: T5
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T1
+    other: T8
+    __ret_0: T0
+  - self: T2
+    other: T1
+    __ret_0: T0
+  - self: T3
+    other: T1
+    __ret_0: T0
+  - self: T4
+    other: T1
+    __ret_0: T0
+  - self: T5
+    other: T1
+    __ret_0: T0
+  - self: T6
+    other: T1
+    __ret_0: T0
+  - self: T7
+    other: T1
+    __ret_0: T0
+  - self: T8
+    other: T1
+    __ret_0: T0
+
+- func: aten::logical_not
+  namespace: edge
+  inherits: aten::logical_not
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T1
+    __ret_0: T0
+
+- func: aten::logical_or
+  namespace: edge
+  inherits: aten::logical_or
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    other: T1
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T3
+    __ret_0: T0
+  - self: T1
+    other: T4
+    __ret_0: T0
+  - self: T1
+    other: T5
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T1
+    other: T8
+    __ret_0: T0
+  - self: T2
+    other: T1
+    __ret_0: T0
+  - self: T3
+    other: T1
+    __ret_0: T0
+  - self: T4
+    other: T1
+    __ret_0: T0
+  - self: T5
+    other: T1
+    __ret_0: T0
+  - self: T6
+    other: T1
+    __ret_0: T0
+  - self: T7
+    other: T1
+    __ret_0: T0
+  - self: T8
+    other: T1
+    __ret_0: T0
+
+- func: aten::logical_xor
+  namespace: edge
+  inherits: aten::logical_xor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    other: T1
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T3
+    __ret_0: T0
+  - self: T1
+    other: T4
+    __ret_0: T0
+  - self: T1
+    other: T5
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T1
+    other: T8
+    __ret_0: T0
+  - self: T2
+    other: T1
+    __ret_0: T0
+  - self: T3
+    other: T1
+    __ret_0: T0
+  - self: T4
+    other: T1
+    __ret_0: T0
+  - self: T5
+    other: T1
+    __ret_0: T0
+  - self: T6
+    other: T1
+    __ret_0: T0
+  - self: T7
+    other: T1
+    __ret_0: T0
+  - self: T8
+    other: T1
+    __ret_0: T0
+
+- func: aten::logit
+  namespace: edge
+  inherits: aten::logit
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::lt.Scalar
+  namespace: edge
+  inherits: aten::lt.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Bool, Float, Int]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Double]
+    T6: [Float]
+    T7: [Int]
+    T8: [Long]
+    T9: [Short]
+  type_constraint:
+  - self: T0
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T3
+    other: T2
+    __ret_0: T0
+  - self: T4
+    other: T2
+    __ret_0: T0
+  - self: T5
+    other: T2
+    __ret_0: T0
+  - self: T6
+    other: T2
+    __ret_0: T0
+  - self: T7
+    other: T2
+    __ret_0: T0
+  - self: T8
+    other: T2
+    __ret_0: T0
+  - self: T9
+    other: T2
+    __ret_0: T0
+
+- func: aten::lt.Tensor
+  namespace: edge
+  inherits: aten::lt.Tensor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    other: T1
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T3
+    __ret_0: T0
+  - self: T1
+    other: T4
+    __ret_0: T0
+  - self: T1
+    other: T5
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T1
+    other: T8
+    __ret_0: T0
+  - self: T2
+    other: T1
+    __ret_0: T0
+  - self: T3
+    other: T1
+    __ret_0: T0
+  - self: T4
+    other: T1
+    __ret_0: T0
+  - self: T5
+    other: T1
+    __ret_0: T0
+  - self: T6
+    other: T1
+    __ret_0: T0
+  - self: T7
+    other: T1
+    __ret_0: T0
+  - self: T8
+    other: T1
+    __ret_0: T0
+
+- func: aten::masked_fill.Scalar
+  namespace: edge
+  inherits: aten::masked_fill.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Float, Int]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    mask: T0
+    value: T1
+    __ret_0: T0
+  - self: T2
+    mask: T0
+    value: T1
+    __ret_0: T2
+  - self: T3
+    mask: T0
+    value: T1
+    __ret_0: T3
+  - self: T4
+    mask: T0
+    value: T1
+    __ret_0: T4
+  - self: T5
+    mask: T0
+    value: T1
+    __ret_0: T5
+  - self: T6
+    mask: T0
+    value: T1
+    __ret_0: T6
+  - self: T7
+    mask: T0
+    value: T1
+    __ret_0: T7
+  - self: T8
+    mask: T0
+    value: T1
+    __ret_0: T8
+
+- func: aten::max.dim
+  namespace: edge
+  inherits: aten::max.dim
+  type_alias:
+    T0: [Bool]
+    T1: [Byte]
+    T2: [Char]
+    T3: [Double]
+    T4: [Float]
+    T5: [Int]
+    T6: [Long]
+    T7: [Short]
+  type_constraint:
+  - self: T0
+    values: T0
+    indices: T6
+  - self: T1
+    values: T1
+    indices: T6
+  - self: T2
+    values: T2
+    indices: T6
+  - self: T3
+    values: T3
+    indices: T6
+  - self: T4
+    values: T4
+    indices: T6
+  - self: T5
+    values: T5
+    indices: T6
+  - self: T6
+    values: T6
+    indices: T6
+  - self: T7
+    values: T7
+    indices: T6
+
+- func: aten::max_pool2d_with_indices
+  namespace: edge
+  inherits: aten::max_pool2d_with_indices
+  type_alias:
+    T0: [Byte]
+    T1: [Char]
+    T2: [Double]
+    T3: [Float]
+    T4: [Int]
+    T5: [Long]
+    T6: [Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+    __ret_1: T5
+  - self: T1
+    __ret_0: T1
+    __ret_1: T5
+  - self: T2
+    __ret_0: T2
+    __ret_1: T5
+  - self: T3
+    __ret_0: T3
+    __ret_1: T5
+  - self: T4
+    __ret_0: T4
+    __ret_1: T5
+  - self: T5
+    __ret_0: T5
+    __ret_1: T5
+  - self: T6
+    __ret_0: T6
+    __ret_1: T5
+
+- func: aten::mean.dim
+  namespace: edge
+  inherits: aten::mean.dim
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    dtype: T1
+    __ret_0: T1
+  - self: T0
+    dtype: T2
+    __ret_0: T2
+
+- func: aten::min.dim
+  namespace: edge
+  inherits: aten::min.dim
+  type_alias:
+    T0: [Bool]
+    T1: [Byte]
+    T2: [Char]
+    T3: [Double]
+    T4: [Float]
+    T5: [Int]
+    T6: [Long]
+    T7: [Short]
+  type_constraint:
+  - self: T0
+    values: T0
+    indices: T6
+  - self: T1
+    values: T1
+    indices: T6
+  - self: T2
+    values: T2
+    indices: T6
+  - self: T3
+    values: T3
+    indices: T6
+  - self: T4
+    values: T4
+    indices: T6
+  - self: T5
+    values: T5
+    indices: T6
+  - self: T6
+    values: T6
+    indices: T6
+  - self: T7
+    values: T7
+    indices: T6
+
+- func: aten::minimum
+  namespace: edge
+  inherits: aten::minimum
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte]
+    T2: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T3: [Bool, Byte, Char, Float, Int, Long, Short]
+    T4: [Bool, Byte, Char, Int, Long, Short]
+    T5: [Bool, Byte, Char, Int, Short]
+    T6: [Bool, Byte, Char, Short]
+    T7: [Bool, Char]
+    T8: [Byte]
+    T9: [Byte, Short]
+    T10: [Char]
+    T11: [Char, Short]
+    T12: [Double]
+    T13: [Float]
+    T14: [Int]
+    T15: [Long]
+    T16: [Short]
+  type_constraint:
+  - self: T0
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T8
+    __ret_0: T8
+  - self: T2
+    other: T12
+    __ret_0: T12
+  - self: T3
+    other: T13
+    __ret_0: T13
+  - self: T4
+    other: T15
+    __ret_0: T15
+  - self: T5
+    other: T14
+    __ret_0: T14
+  - self: T6
+    other: T16
+    __ret_0: T16
+  - self: T7
+    other: T10
+    __ret_0: T10
+  - self: T8
+    other: T1
+    __ret_0: T8
+  - self: T8
+    other: T11
+    __ret_0: T16
+  - self: T9
+    other: T10
+    __ret_0: T16
+  - self: T10
+    other: T7
+    __ret_0: T10
+  - self: T10
+    other: T9
+    __ret_0: T16
+  - self: T11
+    other: T8
+    __ret_0: T16
+  - self: T12
+    other: T2
+    __ret_0: T12
+  - self: T13
+    other: T3
+    __ret_0: T13
+  - self: T14
+    other: T5
+    __ret_0: T14
+  - self: T15
+    other: T4
+    __ret_0: T15
+  - self: T16
+    other: T6
+    __ret_0: T16
 
 - func: aten::mm
   namespace: edge
@@ -262,15 +4837,133 @@
     mat2: T0
     __ret_0: T0
 
-- func: aten::mul.Tensor
+- func: aten::mul.Scalar
   namespace: edge
-  inherits: aten::mul.Tensor
+  inherits: aten::mul.Scalar
   type_alias:
-    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Float, Int, Long, Short]
+    T2: [Bool, Float, Int]
+    T3: [Bool, Int]
+    T4: [Bool, Long]
+    T5: [Byte]
+    T6: [Char]
+    T7: [Double]
+    T8: [Float]
+    T9: [Int]
+    T10: [Long]
+    T11: [Short]
   type_constraint:
   - self: T0
     other: T0
     __ret_0: T0
+  - self: T1
+    other: T8
+    __ret_0: T8
+  - self: T4
+    other: T9
+    __ret_0: T10
+  - self: T5
+    other: T3
+    __ret_0: T5
+  - self: T6
+    other: T3
+    __ret_0: T6
+  - self: T7
+    other: T2
+    __ret_0: T7
+  - self: T8
+    other: T2
+    __ret_0: T8
+  - self: T9
+    other: T3
+    __ret_0: T9
+  - self: T10
+    other: T3
+    __ret_0: T10
+  - self: T11
+    other: T3
+    __ret_0: T11
+
+- func: aten::mul.Tensor
+  namespace: edge
+  inherits: aten::mul.Tensor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte]
+    T2: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T3: [Bool, Byte, Char, Float, Int, Long, Short]
+    T4: [Bool, Byte, Char, Int, Long, Short]
+    T5: [Bool, Byte, Char, Int, Short]
+    T6: [Bool, Byte, Char, Short]
+    T7: [Bool, Char]
+    T8: [Byte]
+    T9: [Byte, Short]
+    T10: [Char]
+    T11: [Char, Short]
+    T12: [Double]
+    T13: [Float]
+    T14: [Int]
+    T15: [Long]
+    T16: [Short]
+  type_constraint:
+  - self: T0
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T8
+    __ret_0: T8
+  - self: T2
+    other: T12
+    __ret_0: T12
+  - self: T3
+    other: T13
+    __ret_0: T13
+  - self: T4
+    other: T15
+    __ret_0: T15
+  - self: T5
+    other: T14
+    __ret_0: T14
+  - self: T6
+    other: T16
+    __ret_0: T16
+  - self: T7
+    other: T10
+    __ret_0: T10
+  - self: T8
+    other: T1
+    __ret_0: T8
+  - self: T8
+    other: T11
+    __ret_0: T16
+  - self: T9
+    other: T10
+    __ret_0: T16
+  - self: T10
+    other: T7
+    __ret_0: T10
+  - self: T10
+    other: T9
+    __ret_0: T16
+  - self: T11
+    other: T8
+    __ret_0: T16
+  - self: T12
+    other: T2
+    __ret_0: T12
+  - self: T13
+    other: T3
+    __ret_0: T13
+  - self: T14
+    other: T5
+    __ret_0: T14
+  - self: T15
+    other: T4
+    __ret_0: T15
+  - self: T16
+    other: T6
+    __ret_0: T16
 
 - func: aten::native_layer_norm
   namespace: edge
@@ -285,6 +4978,146 @@
     __ret_1: T0
     __ret_2: T0
 
+- func: aten::ne.Scalar
+  namespace: edge
+  inherits: aten::ne.Scalar
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Bool, Float, Int]
+    T3: [Byte]
+    T4: [Char]
+    T5: [Double]
+    T6: [Float]
+    T7: [Int]
+    T8: [Long]
+    T9: [Short]
+  type_constraint:
+  - self: T0
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T3
+    other: T2
+    __ret_0: T0
+  - self: T4
+    other: T2
+    __ret_0: T0
+  - self: T5
+    other: T2
+    __ret_0: T0
+  - self: T6
+    other: T2
+    __ret_0: T0
+  - self: T7
+    other: T2
+    __ret_0: T0
+  - self: T8
+    other: T2
+    __ret_0: T0
+  - self: T9
+    other: T2
+    __ret_0: T0
+
+- func: aten::ne.Tensor
+  namespace: edge
+  inherits: aten::ne.Tensor
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    other: T1
+    __ret_0: T0
+  - self: T1
+    other: T0
+    __ret_0: T0
+  - self: T1
+    other: T2
+    __ret_0: T0
+  - self: T1
+    other: T3
+    __ret_0: T0
+  - self: T1
+    other: T4
+    __ret_0: T0
+  - self: T1
+    other: T5
+    __ret_0: T0
+  - self: T1
+    other: T6
+    __ret_0: T0
+  - self: T1
+    other: T7
+    __ret_0: T0
+  - self: T1
+    other: T8
+    __ret_0: T0
+  - self: T2
+    other: T1
+    __ret_0: T0
+  - self: T3
+    other: T1
+    __ret_0: T0
+  - self: T4
+    other: T1
+    __ret_0: T0
+  - self: T5
+    other: T1
+    __ret_0: T0
+  - self: T6
+    other: T1
+    __ret_0: T0
+  - self: T7
+    other: T1
+    __ret_0: T0
+  - self: T8
+    other: T1
+    __ret_0: T0
+
+- func: aten::neg
+  namespace: edge
+  inherits: aten::neg
+  type_alias:
+    T0: [Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::nonzero
+  namespace: edge
+  inherits: aten::nonzero
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T1: [Long]
+  type_constraint:
+  - self: T0
+    __ret_0: T1
+
+- func: aten::ones
+  namespace: edge
+  inherits: aten::ones
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - dtype: T0
+    __ret_0: T0
+
 - func: aten::permute_copy
   namespace: edge
   inherits: aten::permute_copy
@@ -293,6 +5126,139 @@
   type_constraint:
   - self: T0
     __ret_0: T0
+
+- func: aten::pow.Tensor_Scalar
+  namespace: edge
+  inherits: aten::pow.Tensor_Scalar
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Bool, Float, Int]
+    T2: [Bool, Int]
+    T3: [Bool, Long]
+    T4: [Byte]
+    T5: [Char]
+    T6: [Double]
+    T7: [Float]
+    T8: [Int]
+    T9: [Long]
+    T10: [Short]
+  type_constraint:
+  - self: T0
+    exponent: T7
+    __ret_0: T7
+  - self: T3
+    exponent: T8
+    __ret_0: T9
+  - self: T4
+    exponent: T2
+    __ret_0: T4
+  - self: T5
+    exponent: T2
+    __ret_0: T5
+  - self: T6
+    exponent: T1
+    __ret_0: T6
+  - self: T7
+    exponent: T1
+    __ret_0: T7
+  - self: T8
+    exponent: T2
+    __ret_0: T8
+  - self: T9
+    exponent: T2
+    __ret_0: T9
+  - self: T10
+    exponent: T2
+    __ret_0: T10
+
+- func: aten::pow.Tensor_Tensor
+  namespace: edge
+  inherits: aten::pow.Tensor_Tensor
+  type_alias:
+    T0: [Bool, Byte]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Bool, Byte, Char, Float, Int, Long, Short]
+    T3: [Bool, Byte, Char, Int, Long, Short]
+    T4: [Bool, Byte, Char, Int, Short]
+    T5: [Bool, Byte, Char, Short]
+    T6: [Bool, Char]
+    T7: [Byte]
+    T8: [Byte, Short]
+    T9: [Char]
+    T10: [Char, Short]
+    T11: [Double]
+    T12: [Float]
+    T13: [Int]
+    T14: [Long]
+    T15: [Short]
+  type_constraint:
+  - self: T0
+    exponent: T7
+    __ret_0: T7
+  - self: T1
+    exponent: T11
+    __ret_0: T11
+  - self: T2
+    exponent: T12
+    __ret_0: T12
+  - self: T3
+    exponent: T14
+    __ret_0: T14
+  - self: T4
+    exponent: T13
+    __ret_0: T13
+  - self: T5
+    exponent: T15
+    __ret_0: T15
+  - self: T6
+    exponent: T9
+    __ret_0: T9
+  - self: T7
+    exponent: T0
+    __ret_0: T7
+  - self: T7
+    exponent: T10
+    __ret_0: T15
+  - self: T8
+    exponent: T9
+    __ret_0: T15
+  - self: T9
+    exponent: T6
+    __ret_0: T9
+  - self: T9
+    exponent: T8
+    __ret_0: T15
+  - self: T10
+    exponent: T7
+    __ret_0: T15
+  - self: T11
+    exponent: T1
+    __ret_0: T11
+  - self: T12
+    exponent: T2
+    __ret_0: T12
+  - self: T13
+    exponent: T4
+    __ret_0: T13
+  - self: T14
+    exponent: T3
+    __ret_0: T14
+  - self: T15
+    exponent: T5
+    __ret_0: T15
+
+- func: aten::reciprocal
+  namespace: edge
+  inherits: aten::reciprocal
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
 
 - func: aten::relu
   namespace: edge
@@ -303,6 +5269,126 @@
   - self: T0
     __ret_0: T0
 
+- func: aten::remainder.Scalar
+  namespace: edge
+  inherits: aten::remainder.Scalar
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Bool, Float, Int]
+    T2: [Bool, Int]
+    T3: [Bool, Long]
+    T4: [Byte]
+    T5: [Char]
+    T6: [Double]
+    T7: [Float]
+    T8: [Int]
+    T9: [Long]
+    T10: [Short]
+  type_constraint:
+  - self: T0
+    other: T7
+    __ret_0: T7
+  - self: T3
+    other: T8
+    __ret_0: T9
+  - self: T4
+    other: T2
+    __ret_0: T4
+  - self: T5
+    other: T2
+    __ret_0: T5
+  - self: T6
+    other: T1
+    __ret_0: T6
+  - self: T7
+    other: T1
+    __ret_0: T7
+  - self: T8
+    other: T2
+    __ret_0: T8
+  - self: T9
+    other: T2
+    __ret_0: T9
+  - self: T10
+    other: T2
+    __ret_0: T10
+
+- func: aten::remainder.Tensor
+  namespace: edge
+  inherits: aten::remainder.Tensor
+  type_alias:
+    T0: [Bool, Byte]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Bool, Byte, Char, Float, Int, Long, Short]
+    T3: [Bool, Byte, Char, Int, Long, Short]
+    T4: [Bool, Byte, Char, Int, Short]
+    T5: [Bool, Byte, Char, Short]
+    T6: [Bool, Char]
+    T7: [Byte]
+    T8: [Byte, Short]
+    T9: [Char]
+    T10: [Char, Short]
+    T11: [Double]
+    T12: [Float]
+    T13: [Int]
+    T14: [Long]
+    T15: [Short]
+  type_constraint:
+  - self: T0
+    other: T7
+    __ret_0: T7
+  - self: T1
+    other: T11
+    __ret_0: T11
+  - self: T2
+    other: T12
+    __ret_0: T12
+  - self: T3
+    other: T14
+    __ret_0: T14
+  - self: T4
+    other: T13
+    __ret_0: T13
+  - self: T5
+    other: T15
+    __ret_0: T15
+  - self: T6
+    other: T9
+    __ret_0: T9
+  - self: T7
+    other: T0
+    __ret_0: T7
+  - self: T7
+    other: T10
+    __ret_0: T15
+  - self: T8
+    other: T9
+    __ret_0: T15
+  - self: T9
+    other: T6
+    __ret_0: T9
+  - self: T9
+    other: T8
+    __ret_0: T15
+  - self: T10
+    other: T7
+    __ret_0: T15
+  - self: T11
+    other: T1
+    __ret_0: T11
+  - self: T12
+    other: T2
+    __ret_0: T12
+  - self: T13
+    other: T4
+    __ret_0: T13
+  - self: T14
+    other: T3
+    __ret_0: T14
+  - self: T15
+    other: T5
+    __ret_0: T15
+
 - func: aten::repeat
   namespace: edge
   inherits: aten::repeat
@@ -312,17 +5398,294 @@
   - self: T0
     __ret_0: T0
 
+- func: aten::round
+  namespace: edge
+  inherits: aten::round
+  type_alias:
+    T0: [Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::rsqrt
+  namespace: edge
+  inherits: aten::rsqrt
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::rsub.Scalar
+  namespace: edge
+  inherits: aten::rsub.Scalar
+  type_alias:
+    T0: [Byte]
+    T1: [Byte, Char, Float, Int, Long, Short]
+    T2: [Char]
+    T3: [Double]
+    T4: [Float]
+    T5: [Float, Int]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    other: T4
+    alpha: T5
+    __ret_0: T4
+  - self: T0
+    other: T6
+    alpha: T6
+    __ret_0: T0
+  - self: T1
+    other: T4
+    alpha: T4
+    __ret_0: T4
+  - self: T1
+    other: T4
+    alpha: T6
+    __ret_0: T4
+  - self: T2
+    other: T4
+    alpha: T5
+    __ret_0: T4
+  - self: T2
+    other: T6
+    alpha: T6
+    __ret_0: T2
+  - self: T3
+    other: T4
+    alpha: T5
+    __ret_0: T3
+  - self: T3
+    other: T5
+    alpha: T4
+    __ret_0: T3
+  - self: T3
+    other: T5
+    alpha: T6
+    __ret_0: T3
+  - self: T3
+    other: T6
+    alpha: T5
+    __ret_0: T3
+  - self: T4
+    other: T4
+    alpha: T5
+    __ret_0: T4
+  - self: T4
+    other: T5
+    alpha: T4
+    __ret_0: T4
+  - self: T4
+    other: T5
+    alpha: T6
+    __ret_0: T4
+  - self: T4
+    other: T6
+    alpha: T5
+    __ret_0: T4
+  - self: T6
+    other: T4
+    alpha: T5
+    __ret_0: T4
+  - self: T6
+    other: T6
+    alpha: T6
+    __ret_0: T6
+  - self: T7
+    other: T4
+    alpha: T5
+    __ret_0: T4
+  - self: T7
+    other: T6
+    alpha: T6
+    __ret_0: T7
+  - self: T8
+    other: T4
+    alpha: T5
+    __ret_0: T4
+  - self: T8
+    other: T6
+    alpha: T6
+    __ret_0: T8
+
 - func: aten::scalar_tensor
   namespace: edge
   inherits: aten::scalar_tensor
   type_alias:
+    T0: [Bool]
+    T1: [Bool, Float, Int]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - s: T1
+    dtype: T0
+    __ret_0: T0
+  - s: T1
+    dtype: T2
+    __ret_0: T2
+  - s: T1
+    dtype: T3
+    __ret_0: T3
+  - s: T1
+    dtype: T4
+    __ret_0: T4
+  - s: T1
+    dtype: T5
+    __ret_0: T5
+  - s: T1
+    dtype: T6
+    __ret_0: T6
+  - s: T1
+    dtype: T7
+    __ret_0: T7
+  - s: T1
+    dtype: T8
+    __ret_0: T8
+
+- func: aten::scatter_add
+  namespace: edge
+  inherits: aten::scatter_add
+  type_alias:
+    T0: [Bool]
+    T1: [Byte]
+    T2: [Char]
+    T3: [Double]
+    T4: [Float]
+    T5: [Int]
+    T6: [Long]
+    T7: [Short]
+  type_constraint:
+  - self: T0
+    index: T6
+    src: T0
+    __ret_0: T0
+  - self: T1
+    index: T6
+    src: T1
+    __ret_0: T1
+  - self: T2
+    index: T6
+    src: T2
+    __ret_0: T2
+  - self: T3
+    index: T6
+    src: T3
+    __ret_0: T3
+  - self: T4
+    index: T6
+    src: T4
+    __ret_0: T4
+  - self: T5
+    index: T6
+    src: T5
+    __ret_0: T5
+  - self: T6
+    index: T6
+    src: T6
+    __ret_0: T6
+  - self: T7
+    index: T6
+    src: T7
+    __ret_0: T7
+
+- func: aten::select_copy.int
+  namespace: edge
+  inherits: aten::select_copy.int
+  type_alias:
     T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
   type_constraint:
-  - __ret_0: T0
+  - self: T0
+    __ret_0: T0
+
+- func: aten::select_scatter
+  namespace: edge
+  inherits: aten::select_scatter
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    src: T1
+    __ret_0: T0
+  - self: T2
+    src: T1
+    __ret_0: T2
+  - self: T3
+    src: T1
+    __ret_0: T3
+  - self: T4
+    src: T1
+    __ret_0: T4
+  - self: T5
+    src: T1
+    __ret_0: T5
+  - self: T6
+    src: T1
+    __ret_0: T6
+  - self: T7
+    src: T1
+    __ret_0: T7
+  - self: T8
+    src: T1
+    __ret_0: T8
 
 - func: aten::sigmoid
   namespace: edge
   inherits: aten::sigmoid
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::sign
+  namespace: edge
+  inherits: aten::sign
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::sin
+  namespace: edge
+  inherits: aten::sin
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::sinh
+  namespace: edge
+  inherits: aten::sinh
   type_alias:
     T0: [Bool, Byte, Char, Float, Int, Long, Short]
     T1: [Double]
@@ -342,6 +5705,45 @@
   - self: T0
     __ret_0: T0
 
+- func: aten::slice_scatter
+  namespace: edge
+  inherits: aten::slice_scatter
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    src: T1
+    __ret_0: T0
+  - self: T2
+    src: T1
+    __ret_0: T2
+  - self: T3
+    src: T1
+    __ret_0: T3
+  - self: T4
+    src: T1
+    __ret_0: T4
+  - self: T5
+    src: T1
+    __ret_0: T5
+  - self: T6
+    src: T1
+    __ret_0: T6
+  - self: T7
+    src: T1
+    __ret_0: T7
+  - self: T8
+    src: T1
+    __ret_0: T8
+
 - func: aten::split_copy.Tensor
   namespace: edge
   inherits: aten::split_copy.Tensor
@@ -351,31 +5753,389 @@
   - self: T0
     __ret_0: T0
 
+- func: aten::sqrt
+  namespace: edge
+  inherits: aten::sqrt
+  type_alias:
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
+
+- func: aten::squeeze_copy.dim
+  namespace: edge
+  inherits: aten::squeeze_copy.dim
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::stack
+  namespace: edge
+  inherits: aten::stack
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - tensors: T0
+    __ret_0: T0
+
+- func: aten::sub.Scalar
+  namespace: edge
+  inherits: aten::sub.Scalar
+  type_alias:
+    T0: [Byte]
+    T1: [Byte, Char, Float, Int, Long, Short]
+    T2: [Char]
+    T3: [Double]
+    T4: [Float]
+    T5: [Float, Int]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T0
+    other: T4
+    alpha: T5
+    __ret_0: T4
+  - self: T0
+    other: T6
+    alpha: T6
+    __ret_0: T0
+  - self: T1
+    other: T4
+    alpha: T4
+    __ret_0: T4
+  - self: T1
+    other: T4
+    alpha: T6
+    __ret_0: T4
+  - self: T2
+    other: T4
+    alpha: T5
+    __ret_0: T4
+  - self: T2
+    other: T6
+    alpha: T6
+    __ret_0: T2
+  - self: T3
+    other: T4
+    alpha: T5
+    __ret_0: T3
+  - self: T3
+    other: T5
+    alpha: T4
+    __ret_0: T3
+  - self: T3
+    other: T5
+    alpha: T6
+    __ret_0: T3
+  - self: T3
+    other: T6
+    alpha: T5
+    __ret_0: T3
+  - self: T4
+    other: T4
+    alpha: T5
+    __ret_0: T4
+  - self: T4
+    other: T5
+    alpha: T4
+    __ret_0: T4
+  - self: T4
+    other: T5
+    alpha: T6
+    __ret_0: T4
+  - self: T4
+    other: T6
+    alpha: T5
+    __ret_0: T4
+  - self: T6
+    other: T4
+    alpha: T5
+    __ret_0: T4
+  - self: T6
+    other: T6
+    alpha: T6
+    __ret_0: T6
+  - self: T7
+    other: T4
+    alpha: T5
+    __ret_0: T4
+  - self: T7
+    other: T6
+    alpha: T6
+    __ret_0: T7
+  - self: T8
+    other: T4
+    alpha: T5
+    __ret_0: T4
+  - self: T8
+    other: T6
+    alpha: T6
+    __ret_0: T8
+
 - func: aten::sub.Tensor
   namespace: edge
   inherits: aten::sub.Tensor
   type_alias:
-    T0: [Byte, Char, Double, Float, Int, Long, Short]
+    T0: [Byte]
+    T1: [Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte, Char, Float, Int, Long, Short]
+    T3: [Byte, Char, Int, Long, Short]
+    T4: [Byte, Char, Int, Short]
+    T5: [Byte, Char, Short]
+    T6: [Byte, Short]
+    T7: [Char]
+    T8: [Char, Short]
+    T9: [Double]
+    T10: [Float]
+    T11: [Float, Int]
+    T12: [Int]
+    T13: [Long]
+    T14: [Short]
   type_constraint:
   - self: T0
     other: T0
+    alpha: T12
+    __ret_0: T0
+  - self: T0
+    other: T8
+    alpha: T12
+    __ret_0: T14
+  - self: T0
+    other: T9
+    alpha: T11
+    __ret_0: T9
+  - self: T0
+    other: T10
+    alpha: T11
+    __ret_0: T10
+  - self: T1
+    other: T9
+    alpha: T10
+    __ret_0: T9
+  - self: T1
+    other: T9
+    alpha: T12
+    __ret_0: T9
+  - self: T2
+    other: T10
+    alpha: T10
+    __ret_0: T10
+  - self: T2
+    other: T10
+    alpha: T12
+    __ret_0: T10
+  - self: T3
+    other: T13
+    alpha: T12
+    __ret_0: T13
+  - self: T4
+    other: T12
+    alpha: T12
+    __ret_0: T12
+  - self: T5
+    other: T14
+    alpha: T12
+    __ret_0: T14
+  - self: T6
+    other: T7
+    alpha: T12
+    __ret_0: T14
+  - self: T7
+    other: T6
+    alpha: T12
+    __ret_0: T14
+  - self: T7
+    other: T7
+    alpha: T12
+    __ret_0: T7
+  - self: T7
+    other: T9
+    alpha: T11
+    __ret_0: T9
+  - self: T7
+    other: T10
+    alpha: T11
+    __ret_0: T10
+  - self: T8
+    other: T0
+    alpha: T12
+    __ret_0: T14
+  - self: T9
+    other: T0
+    alpha: T11
+    __ret_0: T9
+  - self: T9
+    other: T1
+    alpha: T10
+    __ret_0: T9
+  - self: T9
+    other: T1
+    alpha: T12
+    __ret_0: T9
+  - self: T9
+    other: T7
+    alpha: T11
+    __ret_0: T9
+  - self: T9
+    other: T9
+    alpha: T11
+    __ret_0: T9
+  - self: T9
+    other: T10
+    alpha: T11
+    __ret_0: T9
+  - self: T9
+    other: T12
+    alpha: T11
+    __ret_0: T9
+  - self: T9
+    other: T13
+    alpha: T11
+    __ret_0: T9
+  - self: T9
+    other: T14
+    alpha: T11
+    __ret_0: T9
+  - self: T10
+    other: T0
+    alpha: T11
+    __ret_0: T10
+  - self: T10
+    other: T2
+    alpha: T10
+    __ret_0: T10
+  - self: T10
+    other: T2
+    alpha: T12
+    __ret_0: T10
+  - self: T10
+    other: T7
+    alpha: T11
+    __ret_0: T10
+  - self: T10
+    other: T9
+    alpha: T11
+    __ret_0: T9
+  - self: T10
+    other: T10
+    alpha: T11
+    __ret_0: T10
+  - self: T10
+    other: T12
+    alpha: T11
+    __ret_0: T10
+  - self: T10
+    other: T13
+    alpha: T11
+    __ret_0: T10
+  - self: T10
+    other: T14
+    alpha: T11
+    __ret_0: T10
+  - self: T12
+    other: T4
+    alpha: T12
+    __ret_0: T12
+  - self: T12
+    other: T9
+    alpha: T11
+    __ret_0: T9
+  - self: T12
+    other: T10
+    alpha: T11
+    __ret_0: T10
+  - self: T13
+    other: T3
+    alpha: T12
+    __ret_0: T13
+  - self: T13
+    other: T9
+    alpha: T11
+    __ret_0: T9
+  - self: T13
+    other: T10
+    alpha: T11
+    __ret_0: T10
+  - self: T14
+    other: T5
+    alpha: T12
+    __ret_0: T14
+  - self: T14
+    other: T9
+    alpha: T11
+    __ret_0: T9
+  - self: T14
+    other: T10
+    alpha: T11
+    __ret_0: T10
+
+- func: aten::sum.dim_IntList
+  namespace: edge
+  inherits: aten::sum.dim_IntList
+  type_alias:
+    T0: [Bool]
+    T1: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T2: [Byte]
+    T3: [Char]
+    T4: [Double]
+    T5: [Float]
+    T6: [Int]
+    T7: [Long]
+    T8: [Short]
+  type_constraint:
+  - self: T1
+    dtype: T0
+    __ret_0: T0
+  - self: T1
+    dtype: T2
+    __ret_0: T2
+  - self: T1
+    dtype: T3
+    __ret_0: T3
+  - self: T1
+    dtype: T4
+    __ret_0: T4
+  - self: T1
+    dtype: T5
+    __ret_0: T5
+  - self: T1
+    dtype: T6
+    __ret_0: T6
+  - self: T1
+    dtype: T7
+    __ret_0: T7
+  - self: T1
+    dtype: T8
+    __ret_0: T8
+
+- func: aten::t_copy
+  namespace: edge
+  inherits: aten::t_copy
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
     __ret_0: T0
 
-- func: aten::sym_numel
+- func: aten::tan
   namespace: edge
-  inherits: aten::sym_numel
+  inherits: aten::tan
   type_alias:
-    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T0: [Bool, Byte, Char, Float, Int, Long, Short]
+    T1: [Double]
+    T2: [Float]
   type_constraint:
   - self: T0
-
-- func: aten::sym_size.int
-  namespace: edge
-  inherits: aten::sym_size.int
-  type_alias:
-    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
-  type_constraint:
-  - self: T0
+    __ret_0: T2
+  - self: T1
+    __ret_0: T1
 
 - func: aten::tanh
   namespace: edge
@@ -389,6 +6149,24 @@
     __ret_0: T2
   - self: T1
     __ret_0: T1
+
+- func: aten::transpose_copy.int
+  namespace: edge
+  inherits: aten::transpose_copy.int
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
+- func: aten::tril
+  namespace: edge
+  inherits: aten::tril
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
 
 - func: aten::unbind_copy.int
   namespace: edge
@@ -408,6 +6186,15 @@
   - self: T0
     __ret_0: T0
 
+- func: aten::var.dim
+  namespace: edge
+  inherits: aten::var.dim
+  type_alias:
+    T0: [Double, Float]
+  type_constraint:
+  - self: T0
+    __ret_0: T0
+
 - func: aten::view_copy
   namespace: edge
   inherits: aten::view_copy
@@ -422,13 +6209,429 @@
   inherits: aten::where.self
   type_alias:
     T0: [Bool]
-    T1: [Byte]
+    T1: [Bool, Byte]
+    T2: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+    T3: [Bool, Byte, Char, Float, Int, Long, Short]
+    T4: [Bool, Byte, Char, Int, Long, Short]
+    T5: [Bool, Byte, Char, Int, Short]
+    T6: [Bool, Byte, Char, Short]
+    T7: [Bool, Char]
+    T8: [Byte]
+    T9: [Byte, Short]
+    T10: [Char]
+    T11: [Char, Short]
+    T12: [Double]
+    T13: [Float]
+    T14: [Int]
+    T15: [Long]
+    T16: [Short]
   type_constraint:
   - condition: T0
+    self: T1
+    other: T8
+    __ret_0: T8
+  - condition: T0
+    self: T2
+    other: T12
+    __ret_0: T12
+  - condition: T0
+    self: T3
+    other: T13
+    __ret_0: T13
+  - condition: T0
+    self: T4
+    other: T15
+    __ret_0: T15
+  - condition: T0
+    self: T5
+    other: T14
+    __ret_0: T14
+  - condition: T0
+    self: T6
+    other: T16
+    __ret_0: T16
+  - condition: T0
+    self: T7
+    other: T10
+    __ret_0: T10
+  - condition: T0
+    self: T8
+    other: T1
+    __ret_0: T8
+  - condition: T0
+    self: T8
+    other: T11
+    __ret_0: T16
+  - condition: T0
+    self: T9
+    other: T10
+    __ret_0: T16
+  - condition: T0
+    self: T10
+    other: T7
+    __ret_0: T10
+  - condition: T0
+    self: T10
+    other: T9
+    __ret_0: T16
+  - condition: T0
+    self: T11
+    other: T8
+    __ret_0: T16
+  - condition: T0
+    self: T12
+    other: T2
+    __ret_0: T12
+  - condition: T0
+    self: T13
+    other: T3
+    __ret_0: T13
+  - condition: T0
+    self: T14
+    other: T5
+    __ret_0: T14
+  - condition: T0
+    self: T15
+    other: T4
+    __ret_0: T15
+  - condition: T0
+    self: T16
+    other: T6
+    __ret_0: T16
+  - condition: T1
     self: T0
     other: T0
     __ret_0: T0
   - condition: T1
     self: T0
+    other: T8
+    __ret_0: T8
+  - condition: T1
+    self: T0
+    other: T10
+    __ret_0: T10
+  - condition: T1
+    self: T0
+    other: T12
+    __ret_0: T12
+  - condition: T1
+    self: T0
+    other: T13
+    __ret_0: T13
+  - condition: T1
+    self: T0
+    other: T14
+    __ret_0: T14
+  - condition: T1
+    self: T0
+    other: T15
+    __ret_0: T15
+  - condition: T1
+    self: T0
+    other: T16
+    __ret_0: T16
+  - condition: T1
+    self: T8
+    other: T0
+    __ret_0: T8
+  - condition: T1
+    self: T8
+    other: T8
+    __ret_0: T8
+  - condition: T1
+    self: T8
+    other: T10
+    __ret_0: T16
+  - condition: T1
+    self: T8
+    other: T12
+    __ret_0: T12
+  - condition: T1
+    self: T8
+    other: T13
+    __ret_0: T13
+  - condition: T1
+    self: T8
+    other: T14
+    __ret_0: T14
+  - condition: T1
+    self: T8
+    other: T15
+    __ret_0: T15
+  - condition: T1
+    self: T8
+    other: T16
+    __ret_0: T16
+  - condition: T1
+    self: T10
+    other: T0
+    __ret_0: T10
+  - condition: T1
+    self: T10
+    other: T8
+    __ret_0: T16
+  - condition: T1
+    self: T10
+    other: T10
+    __ret_0: T10
+  - condition: T1
+    self: T10
+    other: T12
+    __ret_0: T12
+  - condition: T1
+    self: T10
+    other: T13
+    __ret_0: T13
+  - condition: T1
+    self: T10
+    other: T14
+    __ret_0: T14
+  - condition: T1
+    self: T10
+    other: T15
+    __ret_0: T15
+  - condition: T1
+    self: T10
+    other: T16
+    __ret_0: T16
+  - condition: T1
+    self: T12
+    other: T0
+    __ret_0: T12
+  - condition: T1
+    self: T12
+    other: T8
+    __ret_0: T12
+  - condition: T1
+    self: T12
+    other: T10
+    __ret_0: T12
+  - condition: T1
+    self: T12
+    other: T12
+    __ret_0: T12
+  - condition: T1
+    self: T12
+    other: T13
+    __ret_0: T12
+  - condition: T1
+    self: T12
+    other: T14
+    __ret_0: T12
+  - condition: T1
+    self: T12
+    other: T15
+    __ret_0: T12
+  - condition: T1
+    self: T12
+    other: T16
+    __ret_0: T12
+  - condition: T1
+    self: T13
+    other: T0
+    __ret_0: T13
+  - condition: T1
+    self: T13
+    other: T8
+    __ret_0: T13
+  - condition: T1
+    self: T13
+    other: T10
+    __ret_0: T13
+  - condition: T1
+    self: T13
+    other: T12
+    __ret_0: T12
+  - condition: T1
+    self: T13
+    other: T13
+    __ret_0: T13
+  - condition: T1
+    self: T13
+    other: T14
+    __ret_0: T13
+  - condition: T1
+    self: T13
+    other: T15
+    __ret_0: T13
+  - condition: T1
+    self: T13
+    other: T16
+    __ret_0: T13
+  - condition: T1
+    self: T14
+    other: T0
+    __ret_0: T14
+  - condition: T1
+    self: T14
+    other: T8
+    __ret_0: T14
+  - condition: T1
+    self: T14
+    other: T10
+    __ret_0: T14
+  - condition: T1
+    self: T14
+    other: T12
+    __ret_0: T12
+  - condition: T1
+    self: T14
+    other: T13
+    __ret_0: T13
+  - condition: T1
+    self: T14
+    other: T14
+    __ret_0: T14
+  - condition: T1
+    self: T14
+    other: T15
+    __ret_0: T15
+  - condition: T1
+    self: T14
+    other: T16
+    __ret_0: T14
+  - condition: T1
+    self: T15
+    other: T0
+    __ret_0: T15
+  - condition: T1
+    self: T15
+    other: T8
+    __ret_0: T15
+  - condition: T1
+    self: T15
+    other: T10
+    __ret_0: T15
+  - condition: T1
+    self: T15
+    other: T12
+    __ret_0: T12
+  - condition: T1
+    self: T15
+    other: T13
+    __ret_0: T13
+  - condition: T1
+    self: T15
+    other: T14
+    __ret_0: T15
+  - condition: T1
+    self: T15
+    other: T15
+    __ret_0: T15
+  - condition: T1
+    self: T15
+    other: T16
+    __ret_0: T15
+  - condition: T1
+    self: T16
+    other: T0
+    __ret_0: T16
+  - condition: T1
+    self: T16
+    other: T8
+    __ret_0: T16
+  - condition: T1
+    self: T16
+    other: T10
+    __ret_0: T16
+  - condition: T1
+    self: T16
+    other: T12
+    __ret_0: T12
+  - condition: T1
+    self: T16
+    other: T13
+    __ret_0: T13
+  - condition: T1
+    self: T16
+    other: T14
+    __ret_0: T14
+  - condition: T1
+    self: T16
+    other: T15
+    __ret_0: T15
+  - condition: T1
+    self: T16
+    other: T16
+    __ret_0: T16
+  - condition: T8
+    self: T1
+    other: T8
+    __ret_0: T8
+  - condition: T8
+    self: T2
+    other: T12
+    __ret_0: T12
+  - condition: T8
+    self: T3
+    other: T13
+    __ret_0: T13
+  - condition: T8
+    self: T4
+    other: T15
+    __ret_0: T15
+  - condition: T8
+    self: T5
+    other: T14
+    __ret_0: T14
+  - condition: T8
+    self: T6
+    other: T16
+    __ret_0: T16
+  - condition: T8
+    self: T7
+    other: T10
+    __ret_0: T10
+  - condition: T8
+    self: T8
     other: T1
-    __ret_0: T1
+    __ret_0: T8
+  - condition: T8
+    self: T8
+    other: T11
+    __ret_0: T16
+  - condition: T8
+    self: T9
+    other: T10
+    __ret_0: T16
+  - condition: T8
+    self: T10
+    other: T7
+    __ret_0: T10
+  - condition: T8
+    self: T10
+    other: T9
+    __ret_0: T16
+  - condition: T8
+    self: T11
+    other: T8
+    __ret_0: T16
+  - condition: T8
+    self: T12
+    other: T2
+    __ret_0: T12
+  - condition: T8
+    self: T13
+    other: T3
+    __ret_0: T13
+  - condition: T8
+    self: T14
+    other: T5
+    __ret_0: T14
+  - condition: T8
+    self: T15
+    other: T4
+    __ret_0: T15
+  - condition: T8
+    self: T16
+    other: T6
+    __ret_0: T16
+
+- func: aten::zeros
+  namespace: edge
+  inherits: aten::zeros
+  type_alias:
+    T0: [Bool, Byte, Char, Double, Float, Int, Long, Short]
+  type_constraint:
+  - dtype: T0
+    __ret_0: T0

--- a/exir/dialects/edge/op/api.py
+++ b/exir/dialects/edge/op/api.py
@@ -28,7 +28,7 @@ def get_torch_op_overload(
         return packet.default
 
 
-def get_callable(name):
+def get_callable(name) -> torch._ops.OpOverload:
     main, suffix = name.split(".")
     return get_torch_op_overload("aten", main, suffix)
 

--- a/exir/dialects/edge/spec/TARGETS
+++ b/exir/dialects/edge/spec/TARGETS
@@ -12,7 +12,9 @@ python_library(
     deps = [
         "fbsource//third-party/pypi/ruamel-yaml:ruamel-yaml",
         "//caffe2:torch",
+        "//executorch/exir/dialects/edge/arg:lib",
         "//executorch/exir/dialects/edge/dtype:lib",
+        "//executorch/exir/dialects/edge/op:lib",
     ],
 )
 

--- a/exir/dialects/edge/test/test_edge_yaml.py
+++ b/exir/dialects/edge/test/test_edge_yaml.py
@@ -155,7 +155,7 @@ class TestEdgeYaml(unittest.TestCase):
 
     def test_optional_tensor_supported(self) -> None:
         # Two of three tensor inputs of native_layer_norm are in optional tensor type.
-        ret = gen_op_yaml("aten::native_layer_norm")
+        ret = gen_op_yaml("native_layer_norm.default")
         self.assertTrue(ret is not None)
         self.assertEqual(ret.func_name, "aten::native_layer_norm")
         self.assertEqual(ret.inherits, "aten::native_layer_norm")
@@ -169,7 +169,7 @@ class TestEdgeYaml(unittest.TestCase):
 
     def test_tensor_list_supported(self) -> None:
         # Input of cat is tensor list.
-        ret = gen_op_yaml("aten::cat")
+        ret = gen_op_yaml("cat.default")
         self.assertTrue(ret is not None)
         self.assertEqual(ret.func_name, "aten::cat")
         self.assertEqual(ret.inherits, "aten::cat")

--- a/exir/tests/test_quant_lowering_custom_backend_pass.py
+++ b/exir/tests/test_quant_lowering_custom_backend_pass.py
@@ -11,6 +11,7 @@ import logging
 import unittest
 
 from typing import Callable, Dict, final, List, Tuple
+from unittest import skip
 
 import executorch.exir as exir
 
@@ -499,6 +500,7 @@ class TestQuantLoweringCustomBackendPass(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
+    @skip("This doesn't work in OSS")
     @torch.inference_mode()  # TODO Use  for capturing.
     def test(self) -> None:
         mod = TestModel(


### PR DESCRIPTION
Summary:
Use sample inputs to generate dtype constraints for edge ops.

This is depending on diff stack D49088856. The purpose of the whole stack is to increase edge ops dtype constraints coverage.

This diff uses the sample input generator DtypeRunner to generate all possible dtype arguments and get back valid ones for each operator.

Differential Revision: D49182359


