### PR TITLE
fix lint warning

### DIFF
--- a/backends/example/example_backend_delegate_passes/permute_memory_formats_pass.py
+++ b/backends/example/example_backend_delegate_passes/permute_memory_formats_pass.py
@@ -28,7 +28,9 @@ class PermuteMemoryFormatsPass(ExportPass):
         after pass: x -> to_dim(channel_last) -> conv -> to_dim_(contiguous) -> to_dim(channel_last) -> linear -> to_dim_(contiguous) -> out
     """
 
-    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+    def call(  # noqa: suprress function is too complex (13)
+        self, graph_module: torch.fx.GraphModule
+    ) -> PassResult:
         for pattern in list(module_to_annotator.keys()):
             pattern_op = module_to_annotator[pattern]
             if pattern_op.permuate_memory_format:


### PR DESCRIPTION
Summary: the function is too complext and lint runner shows warning. Suppress it for now and will refactor later

Differential Revision: D49213042


