### PR TITLE
Add TorchFix linter

### DIFF
--- a/.ci/docker/requirements-lintrunner.txt
+++ b/.ci/docker/requirements-lintrunner.txt
@@ -10,6 +10,7 @@ flake8-comprehensions==3.12.0
 flake8-pyi==23.5.0
 mccabe==0.7.0
 pycodestyle==2.10.0
+torchfix==0.0.2
 
 # UFMT
 black==22.12.0

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-select = B,C,E,F,P,W,B9
+select = B,C,E,F,P,W,B9,TOR0,TOR1,TOR2
 max-line-length = 80
 ignore =
     # Black conflicts and overlaps.

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -635,12 +635,8 @@ class TestEmit(unittest.TestCase):
 
     def test_optional_float_list(self) -> None:
         class M(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.upsample = torch.nn.UpsamplingNearest2d(scale_factor=2)
-
             def forward(self, x):
-                return self.upsample(x)
+                return torch.nn.functional.interpolate(x, scale_factor=2)
 
         x = (torch.randn(1, 1, 2, 2),)
         program = (


### PR DESCRIPTION
Besides adding to the CI, updated exir/emit/test/test_emit.py to fix TOR101 "Use of deprecated function torch.nn.UpsamplingNearest2d"

Lint error "Advice (FLAKE8) C901 'PermuteMemoryFormatsPass.call' is too complex (13)" is pre-existing.