### PR TITLE
fix mv2/3 input shape

### DIFF
--- a/backends/xnnpack/test/models/mobilenet_v2.py
+++ b/backends/xnnpack/test/models/mobilenet_v2.py
@@ -20,7 +20,7 @@ from torchvision.models.mobilenetv2 import MobileNet_V2_Weights
 class TestMobileNetV2(unittest.TestCase):
     mv2 = models.mobilenetv2.mobilenet_v2(weights=MobileNet_V2_Weights)
     mv2 = mv2.eval()
-    model_inputs = (torch.ones(1, 3, 224, 244),)
+    model_inputs = (torch.ones(1, 3, 224, 224),)
 
     all_operators = {
         "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",

--- a/backends/xnnpack/test/models/mobilenet_v2.py
+++ b/backends/xnnpack/test/models/mobilenet_v2.py
@@ -17,7 +17,7 @@ from executorch.exir import CaptureConfig
 from torchvision.models.mobilenetv2 import MobileNet_V2_Weights
 
 
-class TestXNNPACKMobileNetV2(unittest.TestCase):
+class TestMobileNetV2(unittest.TestCase):
     mv2 = models.mobilenetv2.mobilenet_v2(weights=MobileNet_V2_Weights)
     mv2 = mv2.eval()
     model_inputs = (torch.ones(1, 3, 224, 244),)
@@ -32,7 +32,7 @@ class TestXNNPACKMobileNetV2(unittest.TestCase):
         "executorch_exir_dialects_edge__ops_aten_convolution_default",
     }
 
-    def test_mv2_fp32(self):
+    def test_fp32_mv2(self):
 
         (
             Tester(self.mv2, self.model_inputs)
@@ -48,7 +48,7 @@ class TestXNNPACKMobileNetV2(unittest.TestCase):
             .compare_outputs()
         )
 
-    def test_mv2_qs8_pt2e(self):
+    def test_qs8_mv2(self):
         # Quantization fuses away batchnorm, so it is no longer in the graph
         ops_after_quantization = self.all_operators - {
             "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
@@ -56,7 +56,7 @@ class TestXNNPACKMobileNetV2(unittest.TestCase):
 
         (
             Tester(self.mv2, self.model_inputs)
-            .quantize2()
+            .quantize()
             .export(Export(CaptureConfig(enable_aot=True)))
             .to_edge()
             .check(list(ops_after_quantization))

--- a/backends/xnnpack/test/models/mobilenet_v3.py
+++ b/backends/xnnpack/test/models/mobilenet_v3.py
@@ -16,7 +16,7 @@ from executorch.backends.xnnpack.test.tester.tester import Export
 from executorch.exir import CaptureConfig
 
 
-class TestXNNPACKMobileNetV3(unittest.TestCase):
+class TestMobileNetV3(unittest.TestCase):
     mv3 = models.mobilenetv3.mobilenet_v3_small(pretrained=True)
     mv3 = mv3.eval()
     model_inputs = (torch.ones(1, 3, 224, 244),)
@@ -35,7 +35,7 @@ class TestXNNPACKMobileNetV3(unittest.TestCase):
         "executorch_exir_dialects_edge__ops_aten_mean_dim",
     }
 
-    def test_mv3_fp32(self):
+    def test_fp32_mv3(self):
         (
             Tester(self.mv3, self.model_inputs)
             .export(Export(CaptureConfig(enable_aot=True)))
@@ -50,7 +50,7 @@ class TestXNNPACKMobileNetV3(unittest.TestCase):
             .compare_outputs()
         )
 
-    def test_mv3_qs8_pt2e(self):
+    def test_qs8_mv3(self):
         ops_after_quantization = self.all_operators - {
             "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
         }
@@ -66,7 +66,7 @@ class TestXNNPACKMobileNetV3(unittest.TestCase):
 
         (
             Tester(self.mv3, self.model_inputs)
-            .quantize2()
+            .quantize()
             .export(Export(CaptureConfig(enable_aot=True)))
             .to_edge()
             .check(list(ops_after_quantization))

--- a/backends/xnnpack/test/models/mobilenet_v3.py
+++ b/backends/xnnpack/test/models/mobilenet_v3.py
@@ -19,7 +19,7 @@ from executorch.exir import CaptureConfig
 class TestMobileNetV3(unittest.TestCase):
     mv3 = models.mobilenetv3.mobilenet_v3_small(pretrained=True)
     mv3 = mv3.eval()
-    model_inputs = (torch.ones(1, 3, 224, 244),)
+    model_inputs = (torch.ones(1, 3, 224, 224),)
 
     all_operators = {
         "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",

--- a/backends/xnnpack/test/ops/add.py
+++ b/backends/xnnpack/test/ops/add.py
@@ -46,7 +46,7 @@ class TestAdd(unittest.TestCase):
         inputs = (torch.ones(1), torch.ones(1))
         (
             Tester(self.Add(), inputs)
-            .quantize2()
+            .quantize()
             .export()
             .check_count({"torch.ops.aten.add.Tensor": 4})
             .check(["torch.ops.quantized_decomposed"])
@@ -91,7 +91,7 @@ class TestAdd(unittest.TestCase):
         inputs = (torch.randn(1, 1, 4, 4), torch.randn(1, 1, 4, 4))
         (
             Tester(self.AddRelu(), inputs)
-            .quantize2()
+            .quantize()
             .export()
             .check_count({"torch.ops.aten.add.Tensor": 1})
             .check_count({"torch.ops.aten.relu.default": 1})


### PR DESCRIPTION
Summary: typo for shape info in MV2/MV3 shapes

Reviewed By: kirklandsign

Differential Revision: D48761859

