### PR TITLE
Fix missing runner in Linux selective build and custom ops jobs

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -99,7 +99,7 @@ jobs:
           - build-tool: cmake
       fail-fast: false
     with:
-      runner: ${{ matrix.runner }}
+      runner: linux.2xlarge
       docker-image: executorch-ubuntu-22.04-clang12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -148,7 +148,7 @@ jobs:
           - build-tool: cmake
       fail-fast: false
     with:
-      runner: ${{ matrix.runner }}
+      runner: linux.2xlarge
       docker-image: executorch-ubuntu-22.04-clang12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
I mistakenly replace this in https://github.com/pytorch/executorch/pull/277.  The runner is not set here, and causes syntax error, for example https://github.com/pytorch/executorch/actions/runs/6167285165.  The workflow still works because the default `linux.2xlarge` is used (same runner type)

### Testing

The annotation error is gone now https://github.com/pytorch/executorch/actions/runs/6175961826