### PR TITLE
Delete deprecated non_const_buffer methods from Program

### DIFF
--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -208,33 +208,6 @@ Result<const void*> Program::get_constant_buffer_data(
       constant_buffer[buffer_index]->storage()->data());
 }
 
-Result<int64_t> Program::get_non_const_buffer_size(
-    size_t buffer_index,
-    const char* method_name) const {
-  auto plan = get_execution_plan(internal_program_, method_name);
-  if (!plan.ok()) {
-    return plan.error();
-  }
-  auto non_const_buffer_sizes = plan.get()->non_const_buffer_sizes();
-  if (buffer_index >= non_const_buffer_sizes->size()) {
-    ET_LOG(
-        Error,
-        "invalid buffer index %zu for size %zu",
-        buffer_index,
-        (size_t)non_const_buffer_sizes->size());
-    return Error::InvalidArgument;
-  }
-  return (*(plan.get()->non_const_buffer_sizes()))[buffer_index];
-}
-
-Result<size_t> Program::num_non_const_buffers(const char* method_name) const {
-  auto plan = get_execution_plan(internal_program_, method_name);
-  if (!plan.ok()) {
-    return plan.error();
-  }
-  return plan.get()->non_const_buffer_sizes()->size();
-}
-
 Result<const char*> Program::get_output_flattening_encoding(
     const char* method_name) const {
   auto plan = get_execution_plan(internal_program_, method_name);

--- a/runtime/executor/program.h
+++ b/runtime/executor/program.h
@@ -134,36 +134,6 @@ class Program final {
   Result<MethodMeta> method_meta(const char* method_name) const;
 
   /**
-   * DEPRECATED: Use MethodMeta instead.
-   *
-   * Get the size of the buffer with index buffer_index. Note that this function
-   * does not return the correct value for index 0 which denotes constant
-   * memory. Only index >= 1 should be used to retrieve the size of
-   * non-constant pools.
-   * @param[in] buffer_index the index of the buffer in the non_const_buffer
-   * list
-   * @param[in] method_name The name of the method to retrieve buffer
-   * information from.
-   * @return The size of the non_constant buffer corresponding to buffer_index,
-   * or Error if it cannot be retrieved.
-   */
-  __ET_DEPRECATED Result<int64_t> get_non_const_buffer_size(
-      size_t buffer_index,
-      const char* method_name = "forward") const;
-
-  /**
-   * DEPRECATED: Use MethodMeta instead.
-   *
-   * Get the number of non_constant buffers.
-   * @param[in] method_name The name of the method to get the buffer amounts
-   * for.
-   * @return The number of non_constant buffers, or Error if it cannot be
-   * retrieved.
-   */
-  __ET_DEPRECATED Result<size_t> num_non_const_buffers(
-      const char* method_name = "forward") const;
-
-  /**
    * DEPRECATED: Get the pytree encoding string for the output. Deprecated as
    * this functionality will eventually move out of the core program into a
    * higher level structure, but that does not exist at this time.


### PR DESCRIPTION
Summary: `MethodMeta` is the new way to get this information.

Differential Revision: D49208547

