### PR TITLE
Remove Inspector API usage from lib.py

### DIFF
--- a/sdk/TARGETS
+++ b/sdk/TARGETS
@@ -12,7 +12,6 @@ python_library(
     deps = [
         "//executorch/sdk/edir:et_schema",
         "//executorch/sdk/etdb:etdb",
-        "//executorch/sdk/etdb:inspector",
         "//executorch/sdk/etrecord:etrecord",
     ],
 )
@@ -24,7 +23,6 @@ python_binary(
     deps = [
         "//executorch/sdk/edir:et_schema",
         "//executorch/sdk/etdb:etdb",
-        "//executorch/sdk/etdb:inspector",
         "//executorch/sdk/etrecord:etrecord",
     ],
 )

--- a/sdk/lib.py
+++ b/sdk/lib.py
@@ -7,7 +7,7 @@
 import argparse
 import asyncio
 import os
-from typing import Mapping, Optional, Union
+from typing import Mapping, Optional
 
 from executorch.sdk.edir.et_schema import (
     FXOperatorGraph,
@@ -15,7 +15,6 @@ from executorch.sdk.edir.et_schema import (
     OperatorGraphWithStats,
 )
 from executorch.sdk.etdb.etdb import debug_graphs
-from executorch.sdk.etdb.inspector import Inspector
 from executorch.sdk.etrecord import ETRecord, parse_etrecord
 
 """
@@ -87,30 +86,6 @@ def debug_etrecord_path(
     debug_etrecord(parse_etrecord(etrecord_path), et_dump_path, verbose)
 
 
-def gen_inspector_from_etrecord(
-    etrecord: Union[str, ETRecord],
-    etdump_path: Optional[str] = None,
-    show_stack_trace: Optional[bool] = False,
-    verbose: Optional[bool] = False,
-) -> Inspector:
-    """
-    API that creates an Inspector instance based on a file path to an ETRecord instance
-    or an ETRecord instance and optional parameters including a file path to an ETDump
-    """
-    if isinstance(etrecord, str):
-        etrecord = parse_etrecord(etrecord_path=str(etrecord))
-
-    op_graph_dict: Mapping[str, OperatorGraphWithStats] = _gen_graphs_from_etrecord(
-        etrecord=etrecord
-    )
-    if etdump_path is not None:
-        _gen_and_attach_metadata(op_graph_dict=op_graph_dict, et_dump_path=etdump_path)
-
-    return Inspector(
-        op_graph_dict=op_graph_dict, show_stack_trace=show_stack_trace, verbose=verbose
-    )
-
-
 """
 SDK Binary
 """
@@ -125,10 +100,6 @@ def parse_args():
         action="store_true",
         help="Whether the terminal should display in verbose mode",
     )
-    parser.add_argument(
-        "--show_stack_trace",
-        help="Whether to show stack trace in the output tables",
-    )
     return parser.parse_args()
 
 
@@ -139,13 +110,7 @@ async def main() -> int:
     Only required argument is an et_record path
     """
     args = parse_args()
-    et_inspector = gen_inspector_from_etrecord(
-        etrecord=args.et_record,
-        etdump_path=args.et_dump,
-        show_stack_trace=args.show_stack_trace,
-        verbose=args.verbose,
-    )
-    et_inspector.cli_flow()
+    debug_etrecord_path(args.et_record, args.et_dump, args.verbose)
     return 0
 
 


### PR DESCRIPTION
Summary:
Revert what I did to lib.py in D48456830. Reasoning:

1. We redesigned the Inspector interface in D49099840, so the Inspector won't work with the lib.py on master anymore;
2. We initially wanted to invoke Inspector from lib.py, but then later decided to have the user interact with Inspector directly.

Users will be able to enter a CLI debugging flow from the Inspector directly. Once that's implemented and landed, we can then work on removing duplicated CLI features from lib.py.

Differential Revision: D49249836


