### PR TITLE
Adding support for delegate map in emitter

### DIFF
--- a/exir/program/TARGETS
+++ b/exir/program/TARGETS
@@ -22,6 +22,7 @@ python_library(
         "//executorch/exir:schema",
         "//executorch/exir/_serialize:lib",
         "//executorch/exir/capture:config",
+        "//executorch/exir/emit:emit",
         "//executorch/exir/emit:lib",
         "//executorch/exir/passes:lib",
         "//executorch/exir/passes:remove_assert_async_pass",

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -13,6 +13,7 @@ import torch._export
 from executorch.exir._serialize import _serialize_pte_binary
 from executorch.exir.capture._config import EdgeCompileConfig, ExecutorchBackendConfig
 from executorch.exir.emit import emit_program, EmitterOutput
+from executorch.exir.emit._emitter import _DelegateDebugIdentifierMap
 from executorch.exir.error import ExportError
 from executorch.exir.pass_manager import PassType
 from executorch.exir.passes import (
@@ -249,6 +250,14 @@ class ExecutorchProgram:
     def debug_handle_map(self) -> Dict[int, Union[int, List[int]]]:
         if self._emitter_output:
             return self._emitter_output.debug_handle_map
+        return {}
+
+    @property
+    def delegate_map(
+        self,
+    ) -> Dict[str, Dict[int, Dict[str, Union[str, _DelegateDebugIdentifierMap]]]]:
+        if self._emitter_output:
+            return self._emitter_output.method_to_delegate_debug_id_map
         return {}
 
     @property
@@ -497,6 +506,14 @@ class MultiMethodExecutorchProgram:
     @property
     def debug_handle_map(self) -> Dict[int, Union[int, List[int]]]:
         return self._emitter_output.debug_handle_map
+
+    @property
+    def delegate_map(
+        self,
+    ) -> Dict[str, Dict[int, Dict[str, Union[str, _DelegateDebugIdentifierMap]]]]:
+        if self._emitter_output:
+            return self._emitter_output.method_to_delegate_debug_id_map
+        return {}
 
     # TODO(ycao): This doesn't make sense any more, remove/change later.
     def dump_graph_module(self) -> torch.fx.GraphModule:


### PR DESCRIPTION
Summary:
LoweredBackendModules might optionally have a delegate debug handle map embedded in them if `preprocess` returned a result with a map inside it.

The emitter internally generates a mapping which is:
```
{'instruction_id' : {'name':delegate_name, 'debug_handle_map': delegate_identifier_map}
```
and returns this in the `EmitterOutput` object which is then subsequently copied over into the `ExecutorchProgram` object returned by `to_executorch()`. This enables us to serialize this map into etrecord which we can then use later for mapping back delegate internal operations to the original node in the graph.

Differential Revision: D49173918

