### PR TITLE
Add etdump_gen to generate flatbuffer containing profiling/debug events

### DIFF
--- a/sdk/etdump/etdump_flatcc.cpp
+++ b/sdk/etdump/etdump_flatcc.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "executorch/sdk/etdump/etdump_flatcc.h"
+#include <string.h>
+#include "executorch/runtime/platform/assert.h"
+
+namespace torch {
+namespace executor {
+
+// Constructor implementation
+ETDumpGen::ETDumpGen(void* buffer, size_t buf_size) {
+  // Initialize the flatcc builder using the buffer and buffer size
+  flatcc_builder_init(&builder);
+  flatbuffers_buffer_start(&builder, etdump_ETDump_file_identifier);
+  etdump_ETDump_start(&builder);
+  etdump_ETDump_version_add(&builder, ETDUMP_VERSION);
+  etdump_ETDump_run_data_start(&builder);
+  etdump_ETDump_run_data_push_start(&builder);
+}
+
+ETDumpGen::~ETDumpGen() {
+  flatcc_builder_clear(&builder);
+}
+
+void ETDumpGen::clear_builder() {
+  flatcc_builder_clear(&builder);
+}
+
+void ETDumpGen::create_event_block(const char* name) {
+  if (etdump_gen_state == ETDumpGen_Adding_Events) {
+    etdump_RunData_events_end(&builder);
+  }
+  if (num_blocks > 0) {
+    etdump_ETDump_run_data_push_end(&builder);
+    etdump_ETDump_run_data_push_start(&builder);
+  }
+  ++num_blocks;
+  etdump_RunData_name_create_strn(&builder, name, strlen(name));
+  etdump_gen_state = ETDumpGen_Block_Created;
+}
+
+int64_t ETDumpGen::create_string_entry(const char* name) {
+  return flatbuffers_string_create_str(&builder, name);
+}
+
+void ETDumpGen::check_ready_to_add_events() {
+  if (etdump_gen_state != ETDumpGen_Adding_Events) {
+    ET_CHECK_MSG(
+        (etdump_gen_state == ETDumpGen_Adding_Allocators ||
+         etdump_gen_state == ETDumpGen_Block_Created),
+        "ETDumpGen in an invalid state. Cannot add new events now.");
+    if (etdump_gen_state == ETDumpGen_Adding_Allocators) {
+      etdump_RunData_allocators_end(&builder);
+    }
+    etdump_RunData_events_start(&builder);
+    etdump_gen_state = ETDumpGen_Adding_Events;
+  }
+}
+
+EventTracerEntry ETDumpGen::start_profiling(
+    const char* name,
+    ChainID chain_id,
+    DebugHandle debug_handle) {
+  EventTracerEntry prof_entry;
+  prof_entry.event_id = create_string_entry(name);
+
+  if (chain_id == -1 && debug_handle == 0) {
+    prof_entry.chain_id = chain_id_;
+    prof_entry.debug_handle = debug_handle_;
+
+  } else {
+    prof_entry.chain_id = chain_id;
+    prof_entry.debug_handle = debug_handle;
+  }
+  prof_entry.start_time = et_pal_current_ticks();
+  return prof_entry;
+}
+
+// TODO: Update all occurrences of the ProfileEvent calls once the
+// EventTracerEntry struct is updated.
+void ETDumpGen::end_profiling(EventTracerEntry prof_entry) {
+  et_timestamp_t end_time = et_pal_current_ticks();
+  check_ready_to_add_events();
+  etdump_RunData_events_push_start(&builder);
+
+  etdump_Event_profile_event_create(
+      &builder,
+      prof_entry.event_id, // see todo - change to prof_entry.name
+      prof_entry.chain_id,
+      -1, // see todo - change to prof_entry.instruction_id
+      prof_entry.debug_handle, // see todo - change to
+                               // prof_entry.delegate_debug_id_int
+      flatbuffers_string_create_str(
+          &builder, ""), // see todo - change to prof_entry.dlegate_debug_id_str
+      prof_entry.start_time,
+      end_time);
+  etdump_RunData_events_push_end(&builder);
+}
+
+AllocatorID ETDumpGen::track_allocator(const char* name) {
+  ET_CHECK_MSG(
+      (etdump_gen_state == ETDumpGen_Block_Created ||
+       etdump_gen_state == ETDumpGen_Adding_Allocators),
+      "Allocators can only be added immediately after a new block is created and before any events are added.");
+  if (etdump_gen_state != ETDumpGen_Adding_Allocators) {
+    etdump_RunData_allocators_start(&builder);
+    etdump_gen_state = ETDumpGen_Adding_Allocators;
+  }
+  flatbuffers_string_ref_t ref = create_string_entry(name);
+  etdump_RunData_allocators_push_create(&builder, ref);
+  return etdump_RunData_allocators_reserved_len(&builder);
+}
+
+void ETDumpGen::track_allocation(
+    AllocatorID allocator_id,
+    size_t allocation_size) {
+  check_ready_to_add_events();
+
+  // etdump_AllocationEvent_ref_t alloc_event_ref =
+  //     etdump_AllocationEvent_create(&builder, allocator_id, allocation_size);
+  etdump_RunData_events_push_start(&builder);
+  etdump_Event_allocation_event_create(&builder, allocator_id, allocation_size);
+  etdump_RunData_events_push_end(&builder);
+}
+
+etdump_result ETDumpGen::get_etdump_data() {
+  etdump_result result;
+  if (etdump_gen_state == ETDumpGen_Adding_Events) {
+    etdump_RunData_events_end(&builder);
+  } else if (etdump_gen_state == ETDumpGen_Adding_Allocators) {
+    etdump_RunData_allocators_end(&builder);
+  }
+  etdump_ETDump_run_data_push_end(&builder);
+  etdump_ETDump_run_data_end(&builder);
+  etdump_ETDump_ref_t root = etdump_ETDump_end(&builder);
+  flatbuffers_buffer_end(&builder, root);
+  if (num_blocks == 0) {
+    result = {nullptr, 0};
+  } else {
+    result.buf = flatcc_builder_finalize_aligned_buffer(&builder, &result.size);
+  }
+  return result;
+}
+
+size_t ETDumpGen::get_num_blocks() {
+  return num_blocks;
+}
+} // namespace executor
+} // namespace torch

--- a/sdk/etdump/etdump_flatcc.h
+++ b/sdk/etdump/etdump_flatcc.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/sdk/etdump/etdump_schema_flatcc_builder.h>
+#include <executorch/sdk/etdump/etdump_schema_flatcc_reader.h>
+#include "executorch/runtime/core/event_tracer.h"
+#include "executorch/runtime/platform/platform.h"
+
+#define ETDUMP_VERSION 0
+
+namespace torch {
+namespace executor {
+
+enum ETDumpGen_State {
+  ETDumpGen_Init,
+  ETDumpGen_Block_Created,
+  ETDumpGen_Adding_Allocators,
+  ETDumpGen_Adding_Events,
+};
+
+struct etdump_result {
+  void* buf;
+  size_t size;
+};
+
+class ETDumpGen : public EventTracer {
+ public:
+  ETDumpGen(void* buffer, size_t buf_size);
+
+  ~ETDumpGen() override;
+  void clear_builder();
+
+  void create_event_block(const char* name) override;
+  virtual EventTracerEntry start_profiling(
+      const char* name,
+      ChainID chain_id = -1,
+      DebugHandle debug_handle = 0) override;
+  virtual void end_profiling(EventTracerEntry prof_entry) override;
+  virtual void track_allocation(AllocatorID id, size_t size) override;
+  virtual AllocatorID track_allocator(const char* name) override;
+  etdump_result get_etdump_data();
+  size_t get_num_blocks();
+
+ private:
+  flatcc_builder_t builder;
+  size_t num_blocks = 0;
+  ETDumpGen_State etdump_gen_state = ETDumpGen_Init;
+
+  void check_ready_to_add_events();
+  int64_t create_string_entry(const char* name);
+};
+
+} // namespace executor
+} // namespace torch

--- a/sdk/etdump/targets.bzl
+++ b/sdk/etdump/targets.bzl
@@ -174,3 +174,21 @@ def define_common_targets():
             "fbsource//arvr/third-party/flatcc:flatcc",
         ],
     )
+
+    runtime.cxx_library(
+        name = "etdump_flatcc",
+        srcs = [
+            "etdump_flatcc.cpp",
+        ],
+        headers = [
+            "etdump_flatcc.h",
+        ],
+        deps = [
+            "//executorch/runtime/platform:platform",
+        ],
+        exported_deps = [
+            ":etdump_schema_flatcc",
+            "//executorch/runtime/core:core",
+        ],
+        visibility = ["//executorch/..."],
+    )

--- a/sdk/etdump/tests/etdump_test.cpp
+++ b/sdk/etdump/tests/etdump_test.cpp
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <executorch/runtime/platform/runtime.h>
+#include <executorch/sdk/etdump/etdump_flatcc.h>
+#include <executorch/test/utils/DeathTest.h>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+
+namespace torch {
+namespace executor {
+
+class ProfilerETDumpTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    torch::executor::runtime_init();
+    const size_t buf_size = 8192;
+    buf = static_cast<uint8_t*>(malloc(buf_size * sizeof(uint8_t)));
+
+    etdump_gen = new ETDumpGen(buf, buf_size);
+  }
+
+  void TearDown() override {
+    free(buf);
+    delete etdump_gen;
+  }
+
+  ETDumpGen* etdump_gen;
+  uint8_t* buf = nullptr;
+};
+
+TEST_F(ProfilerETDumpTest, SingleProfileEvent) {
+  etdump_gen->create_event_block("test_block");
+  EventTracerEntry entry = etdump_gen->start_profiling("test_event", 0, 1);
+  etdump_gen->end_profiling(entry);
+
+  etdump_result result = etdump_gen->get_etdump_data();
+  ASSERT_TRUE(result.buf != nullptr);
+  ASSERT_TRUE(result.size != 0);
+
+  etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+      result.buf, etdump_ETDump_file_identifier);
+
+  ASSERT_NE(etdump, nullptr);
+  EXPECT_EQ(etdump_ETDump_version(etdump), ETDUMP_VERSION);
+
+  etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+  EXPECT_EQ(etdump_gen->get_num_blocks(), etdump_RunData_vec_len(run_data_vec));
+
+  etdump_RunData_table_t run_data_single_prof =
+      etdump_RunData_vec_at(run_data_vec, 0);
+  EXPECT_EQ(
+      std::string(
+          etdump_RunData_name(run_data_single_prof),
+          strlen(etdump_RunData_name(run_data_single_prof))),
+      "test_block");
+
+  free(result.buf);
+}
+
+TEST_F(ProfilerETDumpTest, MultipleProfileEvent) {
+  etdump_gen->create_event_block("test_block");
+
+  // Create the profile events and then add the actual profile events in
+  // reverse.
+  EventTracerEntry entry_1 = etdump_gen->start_profiling("test_event_1", 0, 1);
+  EventTracerEntry entry_2 = etdump_gen->start_profiling("test_event_2", 0, 2);
+
+  etdump_gen->end_profiling(entry_2);
+  etdump_gen->end_profiling(entry_1);
+}
+
+TEST_F(ProfilerETDumpTest, EmptyBlocks) {
+  etdump_gen->create_event_block("test_block");
+  etdump_gen->create_event_block("test_block_1");
+  etdump_gen->create_event_block("test_block_2");
+
+  EventTracerEntry entry = etdump_gen->start_profiling("test_event_1", 0, 1);
+  etdump_gen->end_profiling(entry);
+
+  etdump_result result = etdump_gen->get_etdump_data();
+  ASSERT_TRUE(result.buf != nullptr);
+  ASSERT_TRUE(result.size != 0);
+
+  etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+      result.buf, etdump_ETDump_file_identifier);
+
+  etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+  ASSERT_EQ(etdump_RunData_vec_len(run_data_vec), 3);
+  ASSERT_EQ(
+      etdump_Event_vec_len(
+          etdump_RunData_events(etdump_RunData_vec_at(run_data_vec, 0))),
+      0);
+
+  free(result.buf);
+}
+
+TEST_F(ProfilerETDumpTest, AddAllocators) {
+  etdump_gen->create_event_block("test_block");
+  AllocatorID allocator_id = etdump_gen->track_allocator("test_allocator");
+  EXPECT_EQ(allocator_id, 1);
+  allocator_id = etdump_gen->track_allocator("test_allocator_1");
+  EXPECT_EQ(allocator_id, 2);
+
+  // Add a profiling event and then try to add an allocator which should fail.
+  EventTracerEntry entry = etdump_gen->start_profiling("test_event", 0, 1);
+  etdump_gen->end_profiling(entry);
+  ET_EXPECT_DEATH(etdump_gen->track_allocator("test_allocator"), "");
+}
+
+TEST_F(ProfilerETDumpTest, AllocationEvents) {
+  etdump_gen->create_event_block("test_block");
+
+  // Add allocation events.
+  etdump_gen->track_allocation(1, 64);
+  etdump_gen->track_allocation(2, 128);
+
+  // Add a mix of performance and memory events.
+  etdump_gen->track_allocation(1, 64);
+  EventTracerEntry entry = etdump_gen->start_profiling("test_event", 0, 1);
+  etdump_gen->end_profiling(entry);
+  etdump_gen->track_allocation(2, 128);
+}
+
+TEST_F(ProfilerETDumpTest, MultipleBlocksWithEvents) {
+  etdump_gen->create_event_block("test_block");
+
+  AllocatorID allocator_id_0 = etdump_gen->track_allocator("test_allocator_0");
+  AllocatorID allocator_id_1 = etdump_gen->track_allocator("test_allocator_1");
+  etdump_gen->track_allocation(allocator_id_0, 64);
+  etdump_gen->track_allocation(allocator_id_1, 128);
+
+  EventTracerEntry entry = etdump_gen->start_profiling("test_event", 0, 1);
+  etdump_gen->end_profiling(entry);
+  etdump_gen->create_event_block("test_block_1");
+  allocator_id_0 = etdump_gen->track_allocator("test_allocator_0");
+  allocator_id_1 = etdump_gen->track_allocator("test_allocator_1");
+  etdump_gen->track_allocation(allocator_id_0, 64);
+  etdump_gen->track_allocation(allocator_id_0, 128);
+
+  entry = etdump_gen->start_profiling("test_event", 0, 1);
+  etdump_gen->end_profiling(entry);
+
+  etdump_result result = etdump_gen->get_etdump_data();
+  ASSERT_TRUE(result.buf != nullptr);
+  ASSERT_TRUE(result.size != 0);
+
+  etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+      result.buf, etdump_ETDump_file_identifier);
+
+  ASSERT_NE(etdump, nullptr);
+  EXPECT_EQ(etdump_ETDump_version(etdump), ETDUMP_VERSION);
+
+  etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+  ASSERT_EQ(etdump_gen->get_num_blocks(), etdump_RunData_vec_len(run_data_vec));
+
+  etdump_RunData_table_t run_data_0 = etdump_RunData_vec_at(run_data_vec, 0);
+  EXPECT_EQ(
+      std::string(
+          etdump_RunData_name(run_data_0),
+          strlen(etdump_RunData_name(run_data_0))),
+      "test_block");
+
+  etdump_Allocator_vec_t allocator_vec_0 =
+      etdump_RunData_allocators(run_data_0);
+  ASSERT_EQ(etdump_Allocator_vec_len(allocator_vec_0), 2);
+
+  etdump_Allocator_table_t allocator_0 =
+      etdump_Allocator_vec_at(allocator_vec_0, 0);
+  EXPECT_EQ(
+      std::string(
+          etdump_Allocator_name(allocator_0),
+          strlen(etdump_Allocator_name(allocator_0))),
+      "test_allocator_0");
+
+  etdump_Event_vec_t event_vec = etdump_RunData_events(run_data_0);
+  ASSERT_EQ(etdump_Event_vec_len(event_vec), 3);
+
+  etdump_Event_table_t event_0 = etdump_Event_vec_at(event_vec, 0);
+  EXPECT_EQ(
+      etdump_AllocationEvent_allocation_size(
+          etdump_Event_allocation_event(event_0)),
+      64);
+
+  etdump_Event_table_t event_2 = etdump_Event_vec_at(event_vec, 2);
+  flatbuffers_string_t event_2_name =
+      etdump_ProfileEvent_name(etdump_Event_profile_event(event_2));
+  EXPECT_EQ(std::string(event_2_name, strlen(event_2_name)), "test_event");
+
+  free(result.buf);
+}
+
+TEST_F(ProfilerETDumpTest, VerifyData) {
+  etdump_gen->create_event_block("test_block");
+
+  etdump_gen->track_allocator("single prof allocator");
+
+  EventTracerEntry entry = etdump_gen->start_profiling("test_event", 0, 1);
+  etdump_gen->end_profiling(entry);
+  entry = etdump_gen->start_profiling("test_event2", 0, 1);
+  etdump_gen->end_profiling(entry);
+
+  etdump_result result = etdump_gen->get_etdump_data();
+  ASSERT_TRUE(result.buf != nullptr);
+  ASSERT_TRUE(result.size != 0);
+
+  etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+      result.buf, etdump_ETDump_file_identifier);
+
+  ASSERT_NE(etdump, nullptr);
+  EXPECT_EQ(etdump_ETDump_version(etdump), ETDUMP_VERSION);
+
+  etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+  EXPECT_EQ(etdump_gen->get_num_blocks(), etdump_RunData_vec_len(run_data_vec));
+
+  etdump_RunData_table_t run_data_single_prof =
+      etdump_RunData_vec_at(run_data_vec, 0);
+  EXPECT_EQ(
+      std::string(
+          etdump_RunData_name(run_data_single_prof),
+          strlen(etdump_RunData_name(run_data_single_prof))),
+      "test_block");
+
+  etdump_Allocator_vec_t allocator_vec =
+      etdump_RunData_allocators(run_data_single_prof);
+
+  etdump_Event_table_t single_event =
+      etdump_Event_vec_at(etdump_RunData_events(run_data_single_prof), 0);
+
+  etdump_ProfileEvent_table_t single_prof_event =
+      etdump_Event_profile_event(single_event);
+
+  EXPECT_EQ(
+      std::string(
+          etdump_ProfileEvent_name(single_prof_event),
+          strlen(etdump_ProfileEvent_name(single_prof_event))),
+      "test_event");
+  EXPECT_EQ(etdump_ProfileEvent_chain_id(single_prof_event), 0);
+
+  flatbuffers_string_t allocator_name =
+      etdump_Allocator_name(etdump_Allocator_vec_at(allocator_vec, 0));
+  EXPECT_EQ(
+      std::string(allocator_name, strlen(allocator_name)),
+      "single prof allocator");
+
+  free(result.buf);
+}
+
+} // namespace executor
+} // namespace torch

--- a/sdk/etdump/tests/targets.bzl
+++ b/sdk/etdump/tests/targets.bzl
@@ -18,3 +18,15 @@ def define_common_targets():
         ],
         preprocessor_flags = ["-DPROFILING_ENABLED"],
     )
+
+    runtime.cxx_test(
+        name = "etdump_test",
+        srcs = [
+            "etdump_test.cpp",
+        ],
+        deps = [
+            "//executorch/sdk/etdump:etdump_flatcc",
+            "//executorch/sdk/etdump:etdump_schema_flatcc",
+            "//executorch/runtime/platform:platform",
+        ],
+    )


### PR DESCRIPTION
Summary:
1. generate etdump
2. deserialize & verify the values
3. check for edge cases

There is a TODO in here once the `EventTracerEntry` struct has been modified to include the updates to the etdump flatbuffer schema or devise a way to evaluate the necessary information from the existing struct.

Differential Revision: D48743211


