### PR TITLE
Change partition function to take exported program

### DIFF
--- a/backends/qnnpack/partition/qnnpack_partitioner.py
+++ b/backends/qnnpack/partition/qnnpack_partitioner.py
@@ -24,6 +24,7 @@ from executorch.exir.backend.partitioner import (
     Partitioner,
     PartitionResult,
 )
+from torch.export import ExportedProgram
 from torch.fx.passes.utils.matcher_utils import SubgraphMatcher
 
 logging.basicConfig(level=logging.INFO)
@@ -51,9 +52,11 @@ class _BasePartitioner(Partitioner):
         else:
             log.info(f"Found {pl} subgraphs to be partitioned.")
 
-    def partition(self, graph_module: torch.fx.GraphModule) -> PartitionResult:
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
         raise NotImplementedError("This is not meant to be used directly.")
-        return PartitionResult(tagged_graph=graph_module, partition_tags={})
+        return PartitionResult(
+            tagged_exported_program=exported_program, partition_tags={}
+        )
 
 
 class _SingleOpDelegatePartitioner(_BasePartitioner):
@@ -75,16 +78,18 @@ class _SingleOpDelegatePartitioner(_BasePartitioner):
         self.transforms = transforms
 
     # override
-    def partition(self, graph_module: torch.fx.GraphModule) -> PartitionResult:
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
         # TODO delete this since we are not allowed to do this
         if self.transforms is not None:
             for transform in self.transforms:  # pyre-ignore
-                graph_module.graph = transform(graph_module.graph)
+                exported_program = exported_program._transform(transform)
 
         matches = [
             match
             for matches in (
-                SubgraphMatcher(pattern, ignore_literals=True).match(graph_module.graph)
+                SubgraphMatcher(pattern, ignore_literals=True).match(
+                    exported_program.graph
+                )
                 for pattern in self.patterns
             )
             for match in matches
@@ -130,7 +135,9 @@ class _SingleOpDelegatePartitioner(_BasePartitioner):
             partition_tags[delegation_tag] = self.delegation_spec
             tag_mapping[delegation_tag] = match_set
 
-        return PartitionResult(tagged_graph=graph_module, partition_tags=partition_tags)
+        return PartitionResult(
+            tagged_exported_program=exported_program, partition_tags=partition_tags
+        )
 
 
 class QnnpackPartitioner(_SingleOpDelegatePartitioner):

--- a/docs/website/docs/tutorials/backend_delegate.md
+++ b/docs/website/docs/tutorials/backend_delegate.md
@@ -373,7 +373,7 @@ class Backend_1_2_Partitioner(Partitioner):
         self.delegation_spec_2 = DelegationSpec("Backend2", [])
 
     def partition(
-        self, edge_graph_module: torch.fx.GraphModule
+        self, exported_program: ExportedProgram
     ) -> PartitionResult:
         partition_tags: Dict[str, DelegationSpec] = {}
         # Tag all nodes in the first partiton to backend 1
@@ -388,7 +388,7 @@ class Backend_1_2_Partitioner(Partitioner):
         node.meta["delegation_tag"] = delegation_tag
         partition_tags[delegation_tag] = self.delegation_spec_2
         return PartitionResult(
-            tagged_graph=edge_graph_module, partition_tags=partition_tags
+            tagged_exported_program=exported_program, partition_tags=partition_tags
         )
 ```
 

--- a/exir/backend/partitioner.py
+++ b/exir/backend/partitioner.py
@@ -8,10 +8,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Dict, List, NamedTuple, TypeVar
 
-import torch.fx as fx
-
 from executorch.exir.backend.backend_details import enforcedmethod
 from executorch.exir.backend.compile_spec_schema import CompileSpec
+from torch.export import ExportedProgram
 
 
 class DelegationSpec(NamedTuple):
@@ -22,20 +21,20 @@ class DelegationSpec(NamedTuple):
 @dataclass
 class PartitionResult:
     """
-    tagged_graph: the graph with nodes that intend to be delegated containing a "DelegationSpec" metadata
+    tagged_exported_program: the graph with nodes that intend to be delegated containing a "DelegationSpec" metadata
     partition_tags: A dictionary that will be used to keep track of the tags and it's corresponding DelegationSpec. The tag is defined by users and used
     in the node.meta.
     """
 
-    tagged_graph: fx.GraphModule
+    tagged_exported_program: ExportedProgram
     partition_tags: Dict[str, DelegationSpec]
 
 
 class Partitioner(ABC):
     """
-    Defines a callable interface for partitioning an exported module (i.e. a program) for
+    Defines a callable interface for partitioning an exported program for
     backend delegation.
-    A partitioner implementation would receive an exported module, determine what portions of
+    A partitioner implementation would receive an exported program, determine what portions of
     the it can be delegated to certain backend (though a partitioner can target multiple
     backends as well), and return the PartitionResult including:
     - the same input module with specific nodes in the input graph tagged for delegation
@@ -51,31 +50,31 @@ class Partitioner(ABC):
     the same format.
 
     Args:
-        edge_graph_module: A module in Edge dialect to be partitioned for backend delegation.
+        exported_program: An ExportedProgram in Edge dialect to be partitioned for backend delegation.
     """
 
-    def __call__(self, edge_graph_module: fx.GraphModule) -> PartitionResult:
-        return self.partition(edge_graph_module)
+    def __call__(self, exported_program: ExportedProgram) -> PartitionResult:
+        return self.partition(exported_program)
 
     @enforcedmethod
     @abstractmethod
-    def partition(self, edge_graph_module: fx.GraphModule) -> PartitionResult:
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
         """
         Returns the input exported program with newly created sub-Modules encapsulating
         specific portions of the input "tagged" for delegation.
 
         The specific implementation is free to decide how existing computation in the
-        input Module should be delegated to one or even more than one specific
+        input exported program should be delegated to one or even more than one specific
         backends.
 
         The contract is stringent in that:
         * Each node that is intended to be delegated must be tagged
-        * No change in the original input Module (GraphModule) representation can take
+        * No change in the original input exported program (ExportedProgram) representation can take
         place other than adding sub-Modules for encapsulating existing portions of the
-        input Module and the associated metadata for tagging.
+        input exported program and the associated metadata for tagging.
 
         Args:
-            edge_graph_module: A module in Edge dialect to be partitioned for backend delegation.
+            exported_program: An ExportedProgram in Edge dialect to be partitioned for backend delegation.
 
         Returns:
             PartitionResult: includes the tagged graph and the delegation spec to indicate what backend_id and compile_spec is used for each node and the tag created by the backend developers.
@@ -84,5 +83,5 @@ class Partitioner(ABC):
 
 
 # Define Type variables to allow instantiate an instance a subclass of Partitioner
-# in to_backend(edge_graph_module: torch.fx.GraphModule, partitioner: Type[TPartitioner])
+# in to_backend(edge_exported_program: ExportedProgram, partitioner: Type[TPartitioner])
 TPartitioner = TypeVar("TPartitioner", bound=Partitioner)

--- a/exir/backend/test/demos/rpc/executor_backend_partitioner.py
+++ b/exir/backend/test/demos/rpc/executor_backend_partitioner.py
@@ -19,6 +19,7 @@ from executorch.exir.backend.partitioner import (
 from executorch.exir.backend.test.backend_with_compiler_demo import (
     BackendWithCompilerDemo,
 )
+from torch.export import ExportedProgram
 from torch.fx.passes.operator_support import any_chain, OperatorSupportBase
 
 
@@ -49,10 +50,10 @@ class ExecutorBackendPartitioner(Partitioner):
         self.op_support = any_chain(AnyOperatorSupport(), AnyDelegateSupport())
         self.delegation_spec = DelegationSpec("ExecutorBackend", [])
 
-    def partition(self, edge_graph_module: torch.fx.GraphModule) -> PartitionResult:
+    def partition(self, edge_exported_program: ExportedProgram) -> PartitionResult:
         partition_tags = {}
         partition_list = generate_pattern_op_partitions(
-            edge_graph_module, op_support=self.op_support
+            edge_exported_program.graph_module, op_support=self.op_support
         )
         for partition in partition_list:
             for node in partition.nodes:
@@ -67,5 +68,6 @@ class ExecutorBackendPartitioner(Partitioner):
                     node.args[0].meta["delegation_tag"] = delegation_tag
 
         return PartitionResult(
-            tagged_graph=edge_graph_module, partition_tags=partition_tags
+            tagged_exported_program=edge_exported_program,
+            partition_tags=partition_tags,
         )

--- a/exir/backend/test/hta_partitioner_demo.py
+++ b/exir/backend/test/hta_partitioner_demo.py
@@ -19,7 +19,7 @@ from executorch.exir.backend.partitioner import (
     PartitionResult,
 )
 from executorch.exir.backend.test.qnn_backend_demo import QnnBackend
-from torch.fx import GraphModule
+from torch.export import ExportedProgram
 from torch.fx.passes.infra.partitioner import Partition
 
 
@@ -191,15 +191,17 @@ class HTAPartitionerMultiplePatternsDemo(Partitioner):
 
         return flat_proposed_partitions_with_unique_id
 
-    def partition(self, graph_module: GraphModule) -> PartitionResult:
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
         partition_tags = {}
-        partition_list = self.generate_partition_list(graph_module)
+        partition_list = self.generate_partition_list(exported_program.graph_module)
         for partition in partition_list:
             for node in partition.nodes:
                 delegation_tag = f"tag{partition.id}"
                 node.meta["delegation_tag"] = delegation_tag
                 partition_tags[delegation_tag] = self.delegation_spec
-        return PartitionResult(tagged_graph=graph_module, partition_tags=partition_tags)
+        return PartitionResult(
+            tagged_exported_program=exported_program, partition_tags=partition_tags
+        )
 
 
 @final
@@ -268,10 +270,10 @@ class HTAPartitionerOnePatternDemo(Partitioner):
         backend_id = QnnBackend.__name__
         self.delegation_spec = DelegationSpec(backend_id, [])
 
-    def partition(self, edge_graph_module: torch.fx.GraphModule) -> PartitionResult:
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
         partition_tags = {}
         partition_list = generate_pattern_op_partitions(
-            edge_graph_module, patterns=self.patterns
+            exported_program.graph_module, patterns=self.patterns
         )
         for partition in partition_list:
             for node in partition.nodes:
@@ -279,5 +281,5 @@ class HTAPartitionerOnePatternDemo(Partitioner):
                 node.meta["delegation_tag"] = delegation_tag
                 partition_tags[delegation_tag] = self.delegation_spec
         return PartitionResult(
-            tagged_graph=edge_graph_module, partition_tags=partition_tags
+            tagged_exported_program=exported_program, partition_tags=partition_tags
         )

--- a/exir/backend/test/op_partitioner_demo.py
+++ b/exir/backend/test/op_partitioner_demo.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import final
+from typing import Dict, final
 
 import torch
 from executorch.exir.backend.canonical_partitioners.pattern_op_partitioner import (
@@ -22,6 +22,7 @@ from executorch.exir.backend.test.backend_with_compiler_demo import (
 )
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.graph_module import get_control_flow_submodules
+from torch.export import ExportedProgram
 from torch.fx.passes.operator_support import any_chain, OperatorSupportBase
 
 
@@ -52,10 +53,13 @@ class AddMulPartitionerDemo(Partitioner):
             [CompileSpec("max_value", bytes([4]))],
         )
 
-    def partition(self, edge_graph_module: torch.fx.GraphModule) -> PartitionResult:
-        partition_tags = {}
+    def _partition_graph_module(
+        self,
+        graph_module: torch.fx.GraphModule,
+    ) -> Dict[str, DelegationSpec]:
+        partition_tags: Dict[str, DelegationSpec] = {}
         partition_list = generate_pattern_op_partitions(
-            edge_graph_module, op_support=self.op_support
+            graph_module, op_support=self.op_support
         )
         for partition in partition_list:
             for node in partition.nodes:
@@ -63,11 +67,15 @@ class AddMulPartitionerDemo(Partitioner):
                 node.meta["delegation_tag"] = delegation_tag
                 partition_tags[delegation_tag] = self.delegation_spec
 
-        for _, submodule, _ in get_control_flow_submodules(edge_graph_module):
-            partition_result = self.partition(submodule)
-            partition_tags.update(partition_result.partition_tags)
+        for _, submodule, _ in get_control_flow_submodules(graph_module):
+            ret_partition_tags = self._partition_graph_module(submodule)
+            partition_tags.update(ret_partition_tags)
+        return partition_tags
+
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
+        partition_tags = self._partition_graph_module(exported_program.graph_module)
         return PartitionResult(
-            tagged_graph=edge_graph_module, partition_tags=partition_tags
+            tagged_exported_program=exported_program, partition_tags=partition_tags
         )
 
 
@@ -82,10 +90,10 @@ class AddAttributePartitionerDemo(Partitioner):
 
         self.delegation_spec = DelegationSpec(BackendWithCompilerDemo.__name__, [])
 
-    def partition(self, edge_graph_module: torch.fx.GraphModule) -> PartitionResult:
+    def partition(self, edge_exported_program: ExportedProgram) -> PartitionResult:
         partition_tags = {}
         partition_list = generate_pattern_op_partitions(
-            edge_graph_module, op_support=self.op_support
+            edge_exported_program.graph_module, op_support=self.op_support
         )
         for partition in partition_list:
             for node in partition.nodes:
@@ -102,5 +110,5 @@ class AddAttributePartitionerDemo(Partitioner):
                         arg.meta["delegation_tag"] = delegation_tag
 
         return PartitionResult(
-            tagged_graph=edge_graph_module, partition_tags=partition_tags
+            tagged_exported_program=edge_exported_program, partition_tags=partition_tags
         )

--- a/exir/backend/test/test_utils.py
+++ b/exir/backend/test/test_utils.py
@@ -30,6 +30,7 @@ from torch.ao.quantization.quantize_fx import (
     _convert_to_reference_decomposed_fx,
     prepare_fx,
 )
+from torch.export import ExportedProgram
 from torch.fx import symbolic_trace
 from torch.fx.passes.utils.fuser_utils import legalize_graph
 from torch.fx.passes.utils.matcher_utils import SubgraphMatcher
@@ -256,10 +257,10 @@ class TestPartitioners(unittest.TestCase):
                 self.test = "a"
 
             def partition(
-                self, edge_graph_module: torch.fx.GraphModule
+                self, edge_exported_program: ExportedProgram
             ) -> PartitionResult:
                 return PartitionResult(
-                    tagged_graph=edge_graph_module, partition_tags=None
+                    tagged_exported_program=edge_exported_program, partition_tags=None
                 )
 
         exported_program = exir.capture(


### PR DESCRIPTION
Summary:
right now to_backend takes `ExportedProgram` and for partitioner sometimes it'll need to access parameters/buffers to decide how to partition.

this change is needed for partition to take graph with lifted params

Differential Revision: D49171496


