### PR TITLE
support multimethod by method name on AOT

### DIFF
--- a/bundled_program/core.py
+++ b/bundled_program/core.py
@@ -136,32 +136,56 @@ def assert_valid_bundle(
 
     """
 
-    # Check the number of execution plan tests
-    assert len(bundled_config.execution_plan_tests) == len(
-        program.execution_plan
-    ), "The length of execution_plan_tests in config should match the length of execution_plan in program, but get {} and {}.".format(
-        len(bundled_config.execution_plan_tests), len(program.execution_plan)
-    )
+    program_plan_id = 0
+    bp_plan_id = 0
+
+    method_name_of_program = {e.name for e in program.execution_plan}
+    method_name_of_test_suites = {
+        t.method_name for t in bundled_config.execution_plan_tests
+    }
+
+    assert method_name_of_test_suites.issubset(
+        method_name_of_program
+    ), f"All methods in method_test_suites should be found in program.execution_plan, \
+         but {str(method_name_of_test_suites - method_name_of_program)} does not include."
+
+    # check if method_tesdt_suites has been sorted in ascending alphabetical order of method name.
+    for bp_plan_id in range(1, len(bundled_config.execution_plan_tests)):
+        assert (
+            bundled_config.execution_plan_tests[bp_plan_id - 1].method_name
+            <= bundled_config.execution_plan_tests[bp_plan_id].method_name
+        ), f"The method name of test suite should be sorted in ascending alphabetical \
+            order of method name, but {bp_plan_id-1}-th and {bp_plan_id}-th method_test_suite aren't."
 
     # Check if the inputs' type meet Program's requirement
-    for plan_id in range(len(program.execution_plan)):
-        plan_test: ConfigExecutionPlanTest = bundled_config.execution_plan_tests[
-            plan_id
-        ]
+    while bp_plan_id < len(bundled_config.execution_plan_tests):
 
-        plan: ExecutionPlan = program.execution_plan[plan_id]
+        plan_test: ConfigExecutionPlanTest = bundled_config.execution_plan_tests[
+            bp_plan_id
+        ]
+        plan: ExecutionPlan = program.execution_plan[program_plan_id]
+
+        # User does not provide testcases for current plan, skip it
+        if plan_test.method_name > plan.name:
+            program_plan_id += 1
+            continue
+
+        # Check if the method name in user provided test matches the one in the original program
+        assert (
+            plan_test.method_name == plan.name
+        ), f"BundledConfig has testcases for method {plan_test.method_name}, but can not find it in the given program. All method names in the program are {', '.join([p.name for p in program.execution_plan])}."
 
         # Check if the type of Program's input is supported
         for index in range(len(plan.inputs)):
             assert (
-                type(get_program_input(program, plan_id, index))
+                type(get_program_input(program, program_plan_id, index))
                 in supported_program_type_table
             ), "The type of program's input isn't supported."
 
         # Check if the type of Program's output is supported
         for index in range(len(plan.outputs)):
             assert (
-                type(get_program_output(program, plan_id, index)) == Tensor
+                type(get_program_output(program, program_plan_id, index)) == Tensor
             ), "Only supports program with output in Tensor type."
 
         # Check if the I/O sets of each execution plan test match program's requirement.
@@ -181,14 +205,14 @@ def assert_valid_bundle(
                 assert (
                     type(cur_plan_test_inputs[j])
                     == supported_program_type_table[
-                        type(get_program_input(program, plan_id, j))
+                        type(get_program_input(program, program_plan_id, j))
                     ]
                 ), "The type {}-th input in {}-th test set of {}-th execution plan does not meet Program's requirement: expected {} but get {}".format(
                     j,
                     i,
-                    plan_id,
+                    program_plan_id,
                     supported_program_type_table[
-                        type(get_program_input(program, plan_id, j))
+                        type(get_program_input(program, program_plan_id, j))
                     ],
                     type(cur_plan_test_inputs[j]),
                 )
@@ -198,10 +222,10 @@ def assert_valid_bundle(
                     # pyre-fixme[16]: Undefined attribute [16]: Item `bool` of `typing.Union[bool, float, int, torch._tensor.Tensor]`
                     # has no attribute `dtype`.
                     assert cur_plan_test_inputs[j].dtype == get_input_dtype(
-                        program, plan_id, j
+                        program, program_plan_id, j
                     ), "The input tensor {} dtype shall be {}, but now is {}".format(
                         cur_plan_test_inputs[j],
-                        get_input_dtype(program, plan_id, j),
+                        get_input_dtype(program, program_plan_id, j),
                         cur_plan_test_inputs[j].dtype,
                     )
                 elif type(cur_plan_test_inputs[j]) in (
@@ -210,9 +234,9 @@ def assert_valid_bundle(
                     float,
                 ):
                     assert type(cur_plan_test_inputs[j]) == get_input_type(
-                        program, plan_id, j
+                        program, program_plan_id, j
                     ), "The input primitive dtype shall be {}, but now is {}".format(
-                        get_input_type(program, plan_id, j),
+                        get_input_type(program, program_plan_id, j),
                         type(cur_plan_test_inputs[j]),
                     )
 
@@ -221,12 +245,15 @@ def assert_valid_bundle(
                 # pyre-fixme[16]: Undefined attribute [16]: Item `bool` of `typing.Union[bool, float, int, torch._tensor.Tensor]`
                 # has no attribute `dtype`.
                 assert cur_plan_test_expected_outputs[j].dtype == get_output_dtype(
-                    program, plan_id, j
+                    program, program_plan_id, j
                 ), "The label tensor {} dtype shall be {}, but now is {}".format(
                     cur_plan_test_expected_outputs[j],
-                    get_output_dtype(program, plan_id, j),
+                    get_output_dtype(program, program_plan_id, j),
                     cur_plan_test_expected_outputs[j].dtype,
                 )
+
+        program_plan_id += 1
+        bp_plan_id += 1
 
 
 def create_bundled_program(
@@ -245,10 +272,7 @@ def create_bundled_program(
     execution_plan_tests: List[BundledExecutionPlanTest] = []
 
     # Emit data and metadata of bundled tensor
-    for plan_id in range(len(program.execution_plan)):
-        plan_test: ConfigExecutionPlanTest = bundled_config.execution_plan_tests[
-            plan_id
-        ]
+    for plan_test in bundled_config.execution_plan_tests:
         test_sets: List[BundledIOSet] = []
 
         # emit I/O sets for each execution plan test
@@ -283,7 +307,11 @@ def create_bundled_program(
             )
 
         # emit the whole execution plan test
-        execution_plan_tests.append(BundledExecutionPlanTest(test_sets=test_sets))
+        execution_plan_tests.append(
+            BundledExecutionPlanTest(
+                method_name=plan_test.method_name, test_sets=test_sets
+            )
+        )
 
     program_bytes: bytes = _serialize_pte_binary(program)
 

--- a/bundled_program/schema.py
+++ b/bundled_program/schema.py
@@ -73,6 +73,11 @@ class BundledIOSet:
 class BundledExecutionPlanTest:
     """Context for testing and verifying an exceution plan."""
 
+    # The name of the method to test; e.g., "forward" for the forward() method
+    # of an nn.Module. This name match a method defined by the ExecuTorch
+    # program.
+    method_name: str
+
     # Sets of input/outputs to test with.
     test_sets: List[BundledIOSet]
 

--- a/bundled_program/tests/test_bundle_data.py
+++ b/bundled_program/tests/test_bundle_data.py
@@ -53,6 +53,7 @@ class TestBundle(unittest.TestCase):
         for plan_id in range(len(program.execution_plan)):
             bundled_plan_test = bundled_program.execution_plan_tests[plan_id]
             config_plan_test = bundled_config.execution_plan_tests[plan_id]
+
             self.assertEqual(
                 len(bundled_plan_test.test_sets), len(config_plan_test.test_sets)
             )
@@ -68,3 +69,19 @@ class TestBundle(unittest.TestCase):
                 )
 
         self.assertEqual(bundled_program.program, _serialize_pte_binary(program))
+
+    def test_bundled_miss_methods(self) -> None:
+        program, bundled_config = get_common_program()
+
+        # only keep the testcases for the first method to mimic the case that user only creates testcases for the first method.
+        bundled_config.execution_plan_tests = bundled_config.execution_plan_tests[:1]
+
+        _ = create_bundled_program(program, bundled_config)
+
+    def test_bundled_wrong_method_name(self) -> None:
+        program, bundled_config = get_common_program()
+
+        bundled_config.execution_plan_tests[-1].method_name = "wrong_method_name"
+        self.assertRaises(
+            AssertionError, create_bundled_program, program, bundled_config
+        )

--- a/schema/bundled_program_schema.fbs
+++ b/schema/bundled_program_schema.fbs
@@ -10,7 +10,7 @@ include "scalar_type.fbs";
 namespace executorch_flatbuffer;
 
 // Identifier of a valid bundled program schema.
-file_identifier "BP05";
+file_identifier "BP06";
 // Extension of written files.
 file_extension "bp";
 
@@ -65,6 +65,11 @@ table BundledIOSet {
 
 // Context for testing and verifying an exceution plan.
 table BundledExecutionPlanTest {
+
+  // The name of the method to test; e.g., "forward" for the forward() method
+  // of an nn.Module. This name match a method defined by the ExecuTorch
+  // program.
+  method_name: string;
 
   // Sets of input/outputs to test with.
   test_sets: [BundledIOSet];

--- a/test/end2end/test_end2end.py
+++ b/test/end2end/test_end2end.py
@@ -594,6 +594,9 @@ def maketest(
             ]
             bundled_config = BundledConfig(
                 [
+                    method,
+                ],
+                [
                     inputs_list,
                 ],
                 expected_outputs_list,

--- a/test/models/generate_linear_out_bundled_program.py
+++ b/test/models/generate_linear_out_bundled_program.py
@@ -70,7 +70,9 @@ def main() -> None:
         for i in range(len(program.execution_plan))
     ]
 
-    bundled_config = BundledConfig(bundled_inputs, bundled_expected_outputs)
+    bundled_config = BundledConfig(
+        ["forward"], bundled_inputs, bundled_expected_outputs
+    )
 
     bundled_program = create_bundled_program(program, bundled_config)
     pretty_print(bundled_program)


### PR DESCRIPTION
Summary: Update AOT api and schema to support multimethod by method name instead of method idx.

Differential Revision: D49246787


