### PR TITLE
event_tracer logging inside method.cpp and program.cpp

### DIFF
--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <executorch/runtime/core/event_tracer_hooks.h>
 #include <executorch/runtime/executor/memory_manager.h>
 #include <executorch/runtime/executor/method.h>
 #include <executorch/runtime/platform/profiler.h>
@@ -170,6 +171,9 @@ Result<Method> Program::load_method(
     MemoryManager* memory_manager,
     EventTracer* event_tracer) const {
   EXECUTORCH_SCOPE_PROF("Program::load_method");
+  internal::event_tracer_create_event_block(event_tracer, "Default");
+  internal::EventTracerProfileScope event_tracer_scope =
+      internal::EventTracerProfileScope(event_tracer, "Program::load_method");
   auto plan = get_execution_plan(internal_program_, method_name);
   if (!plan.ok()) {
     return plan.error();


### PR DESCRIPTION
Summary:
Adding event_tracer logging inside method.cpp and program.cpp.

Similar to D48975975 calls to both `internal::ET_EVENT_TRACER_SCOPE_PROF` and `EXECUTORCH_SCOPE_PROF` are present in `method.cpp` and `program.cpp`. Calls to `event_tracer_*` are a no-op for now and `EXECUTORCH_SCOPE_PROF` will be deprecated soon.

Differential Revision: D49220572

