### PR TITLE
Addmm is supported op

### DIFF
--- a/backends/qnnpack/partition/qnnpack_partitioner.py
+++ b/backends/qnnpack/partition/qnnpack_partitioner.py
@@ -5,9 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Callable, Dict, List, Optional, Union
-
-import torch
+from typing import Dict, List, Optional, Union
 
 from executorch.backends.qnnpack.partition.support_patterns import (
     get_dynamic_quant_addmm_with_view_copy_graph,
@@ -16,15 +14,14 @@ from executorch.backends.qnnpack.partition.support_patterns import (
     get_dynamic_quant_mm_without_view_copy_graph,
 )
 from executorch.backends.qnnpack.qnnpack_preprocess import QnnpackBackend
-from executorch.backends.transforms.addmm_mm_to_linear import (
-    apply_addmm_mm_to_linear_transform,
-)
+from executorch.backends.transforms.addmm_mm_to_linear import AddmmToLinearTransform
 from executorch.exir.backend.partitioner import (
     DelegationSpec,
     Partitioner,
     PartitionResult,
 )
 from torch._export.exported_program import ExportedProgram
+from torch._export.pass_base import PassType
 from torch.fx.passes.utils.matcher_utils import SubgraphMatcher
 
 logging.basicConfig(level=logging.INFO)
@@ -69,7 +66,7 @@ class _SingleOpDelegatePartitioner(_BasePartitioner):
         self,
         delegate_name,
         patterns,
-        transforms: Optional[List[Callable[[torch.fx.Graph], torch.fx.Graph]]] = None,
+        transforms: Optional[List[PassType]] = None,
     ):
         """
         @param transforms: Optional list of transforms that will be applied to the graph before running the partitioner.
@@ -157,5 +154,5 @@ class QnnpackPartitioner(_SingleOpDelegatePartitioner):
             get_dynamic_quant_mm_without_view_copy_graph(dynamic_shape=True),
         ]
         super().__init__(
-            QnnpackBackend.__name__, qnnp_patterns, [apply_addmm_mm_to_linear_transform]
+            QnnpackBackend.__name__, qnnp_patterns, [AddmmToLinearTransform()]
         )

--- a/backends/qnnpack/test/test_qnnpack.py
+++ b/backends/qnnpack/test/test_qnnpack.py
@@ -51,8 +51,7 @@ EXECUTORCH_BACKEND_CONFIG = exir.ExecutorchBackendConfig(
 
 EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(_check_ir_validity=False)
 
-# TODO(T158653285)
-@unittest.expectedFailure
+
 class TestQnnbackends(unittest.TestCase):
     k_dim = 5
     input_dims = (1, 4, k_dim)
@@ -89,7 +88,7 @@ class TestQnnbackends(unittest.TestCase):
         ).check(
             "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_tensor"
         ).check(
-            "executorch_exir_dialects_edge__ops_aten_t_copy_default"
+            "executorch_exir_dialects_edge__ops_aten_permute_copy_default"
         ).check(
             "executorch_exir_dialects_edge__ops_aten_mm"
         ).run(
@@ -170,7 +169,7 @@ class TestQnnbackends(unittest.TestCase):
         ).check(
             "aten_view_copy_default"
         ).check(
-            "aten_t_copy_default"
+            "aten_permute_copy_default"
         ).check(
             "aten_addmm_default"
         ).check(
@@ -245,7 +244,7 @@ class TestQnnbackends(unittest.TestCase):
         ).check(
             "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_tensor"
         ).check(
-            "executorch_exir_dialects_edge__ops_aten_t_copy_default"
+            "executorch_exir_dialects_edge__ops_aten_permute_copy_default"
         ).check(
             "executorch_exir_dialects_edge__ops_aten_mm"
         ).run(
@@ -326,7 +325,7 @@ class TestQnnbackends(unittest.TestCase):
         ).check(
             "aten_view_copy_default"
         ).check(
-            "aten_t_copy_default"
+            "aten_permute_copy_default"
         ).check(
             "aten_addmm_default"
         ).check(
@@ -400,7 +399,7 @@ class TestQnnbackends(unittest.TestCase):
         ).check(
             "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_tensor"
         ).check(
-            "executorch_exir_dialects_edge__ops_aten_t_copy_default"
+            "executorch_exir_dialects_edge__ops_aten_permute_copy_default"
         ).check(
             "executorch_exir_dialects_edge__ops_aten_mm"
         ).run(
@@ -482,7 +481,7 @@ class TestQnnbackends(unittest.TestCase):
         ).check(
             "aten_view_copy_default"
         ).check(
-            "aten_t_copy_default"
+            "aten_permute_copy_default"
         ).check(
             "aten_addmm_default"
         ).check(

--- a/backends/qnnpack/test/test_qnnpack_partitioner.py
+++ b/backends/qnnpack/test/test_qnnpack_partitioner.py
@@ -66,8 +66,6 @@ def get_actual_dyanmic_quantized_graph(
     return dynamic_quantized_exir_graph.graph
 
 
-# TODO(T158653285)
-@unittest.expectedFailure
 class TestQnnbackends(unittest.TestCase):
     def test_dynamic_quantize_addmm_with_view_copy_partitioner(self):
         example_inputs = (torch.rand(5, 1, 256),)

--- a/backends/transforms/TARGETS
+++ b/backends/transforms/TARGETS
@@ -19,6 +19,7 @@ python_library(
     srcs = ["addmm_mm_to_linear.py"],
     deps = [
         "//caffe2:torch",
+        "//executorch/exir:pass_base",
         "//executorch/exir:sym_util",
         "//executorch/exir/dialects:lib",
     ],

--- a/backends/xnnpack/operators/node_visitor.py
+++ b/backends/xnnpack/operators/node_visitor.py
@@ -289,12 +289,6 @@ class NodeVisitor:
 
         # convert tensor shape must reflect memory format, default is contiguous, so
         # only permute shape if we are converting the tensor to nhwc format
-        if tensor.target in (
-            exir_ops.edge.aten.permute_copy.default,
-            exir_ops.edge.aten.t_copy.default,
-        ):
-            # We ignore transpose nodes and reverse the dims to before it
-            dims = dims[::-1]
         if swap_nc_for_depthwise_weights:
             dims = [dims[1], dims[0]] + dims[2:]
         if convert_to_nhwc:

--- a/backends/xnnpack/operators/op_addmm.py
+++ b/backends/xnnpack/operators/op_addmm.py
@@ -22,7 +22,6 @@ from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
 from executorch.backends.xnnpack.utils.xnnpack_constants import (
     XNN_FLAG_TRANSPOSE_WEIGHTS,
 )
-from executorch.exir.dialects._ops import ops as exir_ops
 
 
 @register_node_visitor
@@ -56,15 +55,7 @@ class AddmmVisitor(NodeVisitor):
         # output
         output_id = vals_to_ids[node]
 
-        flag = (
-            0
-            if get_input_node(node, 2).target
-            in (
-                exir_ops.edge.aten.permute_copy.default,
-                exir_ops.edge.aten.t_copy.default,
-            )
-            else XNN_FLAG_TRANSPOSE_WEIGHTS
-        )
+        flag = XNN_FLAG_TRANSPOSE_WEIGHTS
 
         ser_node = XNode(
             xnode_union=XNNFullyConnected(

--- a/backends/xnnpack/partition/configs.py
+++ b/backends/xnnpack/partition/configs.py
@@ -62,6 +62,7 @@ SUPPORTED_OPS = [
     exir_ops.edge.aten.elu.default,
     exir_ops.edge.aten.avg_pool2d.default,
     exir_ops.edge.aten.leaky_relu.default,
+    exir_ops.edge.aten.addmm.default,  # TODO(T163877189) add constraint for addmm
 ]
 
 SUPPORTED_MODULES = [

--- a/backends/xnnpack/partition/xnnpack_partitioner.py
+++ b/backends/xnnpack/partition/xnnpack_partitioner.py
@@ -109,6 +109,11 @@ class XnnpackOperatorSupport(OperatorSupportBase):
         return _OP_SUPPORT_CONSTRAINTS.get(node.target, lambda node, ep: True)(node, ep)
 
     def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
+        # Parameters are supported if any of there users are supported
+        if is_param_node(self.ep, node):
+            return any(
+                self.is_node_supported(submodules, user) for user in node.users.keys()
+            )
         # TODO - other ops?
         if node.op != "call_function":
             return False

--- a/backends/xnnpack/partition/xnnpack_partitioner.py
+++ b/backends/xnnpack/partition/xnnpack_partitioner.py
@@ -32,6 +32,7 @@ from executorch.exir.backend.partitioner import (
     PartitionResult,
 )
 from executorch.exir.dialects._ops import ops as exir_ops
+from torch._export.exported_program import ExportedProgram
 from torch.fx.passes.infra.partitioner import Partition
 from torch.fx.passes.operator_support import OperatorSupportBase
 
@@ -403,16 +404,18 @@ class XnnpackFloatingPointPartitioner(Partitioner):
         return partition_tags
 
     # override
-    def partition(self, graph_module: torch.fx.GraphModule) -> PartitionResult:
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
         """
         Run the partitioner on the given graph module, then tag each partition
         with its delegation tag (and partition id)
         """
-        partitions = self.generate_partitions(graph_module)
+        partitions = self.generate_partitions(exported_program.graph_module)
         partition_tags: Dict[str, DelegationSpec] = {}
         if self.check_partitions(partitions):
             partition_tags = self.tag_nodes(partitions)
-        return PartitionResult(tagged_graph=graph_module, partition_tags=partition_tags)
+        return PartitionResult(
+            tagged_exported_program=exported_program, partition_tags=partition_tags
+        )
 
 
 # TODO: Merge XnnpackQuantizedPartitioner and XnnpackFloatingPointPartitioner
@@ -788,20 +791,22 @@ class XnnpackPartitioner(Partitioner):
 
     # override
     def _partition(
-        self, graph_module: torch.fx.GraphModule, quant: Optional[bool]
+        self, exported_program: ExportedProgram, quant: Optional[bool]
     ) -> PartitionResult:
         """
         Run the partitioner on the given graph module, then tag each partition
         with its delegation tag (and partition id)
         """
-        partitions = self.generate_partitions(graph_module, quant)
+        partitions = self.generate_partitions(exported_program.graph_module, quant)
         partition_tags: Dict[str, DelegationSpec] = {}
         if self.check_partitions(partitions):
             partition_tags = self.tag_nodes(partitions)
-        return PartitionResult(tagged_graph=graph_module, partition_tags=partition_tags)
+        return PartitionResult(
+            tagged_exported_program=exported_program, partition_tags=partition_tags
+        )
 
-    def partition(self, graph_module: torch.fx.GraphModule) -> PartitionResult:
-        ret: PartitionResult = self._partition(graph_module, self.quant)
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
+        ret: PartitionResult = self._partition(exported_program, self.quant)
         return ret
 
 
@@ -814,7 +819,7 @@ class XnnpackDynamicallyQuantizedPartitioner(XnnpackQuantizedPartitioner):
         super().__init__(supported_modules, supported_ops)
 
     # override
-    def partition(self, graph_module: torch.fx.GraphModule) -> PartitionResult:
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
         """
         Run the partitioner on the given graph module, then tag each partition with its delegegation tag (and partition id)
 
@@ -826,10 +831,12 @@ class XnnpackDynamicallyQuantizedPartitioner(XnnpackQuantizedPartitioner):
                 id=next(partition_id),
                 nodes=set(match),
             )
-            for match in self.get_module_partitions(graph_module)
+            for match in self.get_module_partitions(exported_program.graph_module)
         ]
         partition_tags: Dict[str, DelegationSpec] = {}
 
         if self.check_partitions(partitions):
             partition_tags = self.tag_nodes(partitions)
-        return PartitionResult(tagged_graph=graph_module, partition_tags=partition_tags)
+        return PartitionResult(
+            tagged_exported_program=exported_program, partition_tags=partition_tags
+        )

--- a/backends/xnnpack/partition/xnnpack_partitioner.py
+++ b/backends/xnnpack/partition/xnnpack_partitioner.py
@@ -19,7 +19,7 @@ from executorch.backends.xnnpack.partition.configs import (
     SUPPORTED_QUANT_OPS,
     UNSUPPORTED_QUANT_MODULES,
 )
-from executorch.backends.xnnpack.utils.utils import get_input_node
+from executorch.backends.xnnpack.utils.utils import get_input_node, is_param_node
 from executorch.backends.xnnpack.xnnpack_preprocess import XnnpackBackend
 
 from executorch.exir.backend.canonical_partitioners.pattern_op_partitioner import (
@@ -74,6 +74,7 @@ _OP_SUPPORT_CONSTRAINTS = {}
 class XnnpackOperatorSupport(OperatorSupportBase):
     def __init__(
         self,
+        ep: ExportedProgram,
         constraints_dict: Dict[
             Any, Callable[[torch.fx.Node], bool]
         ] = _OP_SUPPORT_CONSTRAINTS,
@@ -89,6 +90,7 @@ class XnnpackOperatorSupport(OperatorSupportBase):
         self.unsupported_modules = unsupported_modules
         self.supported_ops = supported_ops
         self.constraints = constraints_dict
+        self.ep = ep
         assert len(self.constraints)
 
     def check_common_constraints(self, node) -> bool:
@@ -98,13 +100,13 @@ class XnnpackOperatorSupport(OperatorSupportBase):
         return True
 
     @staticmethod
-    def check_constraint(node) -> bool:
+    def check_constraint(node, ep) -> bool:
         """
         This node is from a partitioned subgraph by one of the partitioners so
         should be a valid node otherwise, let's make sure the constraint is met
         if specified
         """
-        return _OP_SUPPORT_CONSTRAINTS.get(node.target, lambda _: True)(node)
+        return _OP_SUPPORT_CONSTRAINTS.get(node.target, lambda node, ep: True)(node, ep)
 
     def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
         # TODO - other ops?
@@ -115,14 +117,16 @@ class XnnpackOperatorSupport(OperatorSupportBase):
         if self.supported_ops and node.target not in self.supported_ops:
             return False
 
-        return self.check_constraint(node) and self.check_common_constraints(node)
+        return self.check_constraint(node, self.ep) and self.check_common_constraints(
+            node
+        )
 
     def _constraint(target):  # noqa
         """
         Decorator to register a constraint fn for a node
         """
 
-        def register(func: Callable[[torch.fx.Node], bool]):
+        def register(func: Callable[[torch.fx.Node, ExportedProgram], bool]):
             """
             Pass through registration for the constraint fn
             """
@@ -144,7 +148,7 @@ class XnnpackOperatorSupport(OperatorSupportBase):
     """
 
     @_constraint(exir_ops.edge.aten.mean.dim)
-    def mean_dim(node: torch.fx.Node) -> bool:  # noqa
+    def mean_dim(node: torch.fx.Node, ep: ExportedProgram) -> bool:  # noqa
         """
         Only select 2d cases are supported by XNNPACK
         """
@@ -152,7 +156,9 @@ class XnnpackOperatorSupport(OperatorSupportBase):
         return dims in ([-2, -1], [-1, -2])
 
     @_constraint(exir_ops.edge.aten.max_pool2d_with_indices.default)
-    def maxpool2d_with_indices(node: torch.fx.Node) -> bool:  # noqa
+    def maxpool2d_with_indices(
+        node: torch.fx.Node, ep: ExportedProgram  # noqa
+    ) -> bool:
         """
         Only if the first output value is consumed in the graph
         """
@@ -166,53 +172,61 @@ class XnnpackOperatorSupport(OperatorSupportBase):
         )
 
     @_constraint(exir_ops.edge.quantized_decomposed.quantize_per_tensor.default)
-    def quant_per_tensor_default(q: torch.fx.Node) -> bool:  # noqa
+    def quant_per_tensor_default(q: torch.fx.Node, ep: ExportedProgram) -> bool:  # noqa
         """
         Decide if we want to pull this q node or not in the partition.
         Given, op1 -> q -> dq -> op2
         For node q, if op1 or op2 is good, q should be good
         TODO: q -> op -> dq, real q not handled right now
         """
-        first = XnnpackOperatorSupport.check_constraint(q.args[0])
+        first = XnnpackOperatorSupport.check_constraint(q.args[0], ep)
         dq = list(q.users.keys())[0]
         op2 = list(dq.users.keys())[0]
-        return first or XnnpackOperatorSupport.check_constraint(op2)
+        return first or XnnpackOperatorSupport.check_constraint(op2, ep)
 
     @_constraint(exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default)
-    def dequant_per_tensor_default(dq: torch.fx.Node) -> bool:  # noqa
+    def dequant_per_tensor_default(
+        dq: torch.fx.Node, ep: ExportedProgram  # noqa
+    ) -> bool:
         """
         Decide if we want to pull this dq node or not.
         """
-        return XnnpackOperatorSupport.check_constraint(dq.args[0])
+        return XnnpackOperatorSupport.check_constraint(dq.args[0], ep)
 
     @_constraint(exir_ops.edge.quantized_decomposed.quantize_per_channel.default)
-    def quant_per_channel_default(q: torch.fx.Node) -> bool:  # noqa
-        return XnnpackOperatorSupport.quant_per_tensor_default(q)
+    def quant_per_channel_default(
+        q: torch.fx.Node, ep: ExportedProgram  # noqa
+    ) -> bool:
+        return XnnpackOperatorSupport.quant_per_tensor_default(q, ep)
 
     @_constraint(exir_ops.edge.quantized_decomposed.dequantize_per_channel.default)
-    def dequant_per_channel_default(dq: torch.fx.Node) -> bool:  # noqa
-        return XnnpackOperatorSupport.dequant_per_tensor_default(dq)
+    def dequant_per_channel_default(
+        dq: torch.fx.Node, ep: ExportedProgram  # noqa
+    ) -> bool:
+        return XnnpackOperatorSupport.dequant_per_tensor_default(dq, ep)
 
     @_constraint(exir_ops.edge.quantized_decomposed.quantize_per_tensor.tensor)
-    def quant_per_tensor_tensor(q: torch.fx.Node) -> bool:  # noqa
-        return XnnpackOperatorSupport.quant_per_tensor_default(q)
+    def quant_per_tensor_tensor(q: torch.fx.Node, ep: ExportedProgram) -> bool:  # noqa
+        return XnnpackOperatorSupport.quant_per_tensor_default(q, ep)
 
     @_constraint(exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor)
-    def dequant_per_tensor_tensor(dq: torch.fx.Node) -> bool:  # noqa
-        return XnnpackOperatorSupport.dequant_per_tensor_default(dq)
+    def dequant_per_tensor_tensor(
+        dq: torch.fx.Node, ep: ExportedProgram  # noqa
+    ) -> bool:
+        return XnnpackOperatorSupport.dequant_per_tensor_default(dq, ep)
 
     @_constraint(exir_ops.edge.quantized_decomposed.choose_qparams.tensor)
-    def choose_qparams_tensor(cqp: torch.fx.Node) -> bool:  # noqa
+    def choose_qparams_tensor(cqp: torch.fx.Node, ep: ExportedProgram) -> bool:  # noqa
         """
         Given, cqp -> getitem -> q -> dq -> op2
         Just check q, because it will check op2
         """
         getitem0 = list(cqp.users.keys())[0]
         q = list(getitem0.users.keys())[0]
-        return XnnpackOperatorSupport.check_constraint(q)
+        return XnnpackOperatorSupport.check_constraint(q, ep)
 
     @_constraint(exir_ops.edge.aten.pow.Tensor_Scalar)
-    def pow_tensor_scalar(node: torch.fx.Node) -> bool:  # noqa
+    def pow_tensor_scalar(node: torch.fx.Node, ep: ExportedProgram) -> bool:  # noqa
         """
         Only supports square, when args_2 = 2
         """
@@ -220,7 +234,7 @@ class XnnpackOperatorSupport(OperatorSupportBase):
         return isinstance(power, int) and power == 2
 
     @_constraint(exir_ops.edge.aten.avg_pool2d.default)
-    def avg_pool_2d(node: torch.fx.Node) -> bool:  # noqa
+    def avg_pool_2d(node: torch.fx.Node, ep: ExportedProgram) -> bool:  # noqa
         """
         Arguments to avg_pool2d.default node are as follows:
             - input,
@@ -255,7 +269,7 @@ class XnnpackOperatorSupport(OperatorSupportBase):
         )
 
     @_constraint(exir_ops.edge.aten._prelu_kernel.default)
-    def prelu(node: torch.fx.Node) -> bool:  # noqa
+    def prelu(node: torch.fx.Node, ep: ExportedProgram) -> bool:  # noqa
         """
         Input and Weight must be 4-dimensional
         """
@@ -264,7 +278,7 @@ class XnnpackOperatorSupport(OperatorSupportBase):
         return input_dim == 4 and weight_dim == 4
 
     @_constraint(exir_ops.edge.aten.cat.default)
-    def cat(node: torch.fx.Node) -> bool:  # noqa
+    def cat(node: torch.fx.Node, ep: ExportedProgram) -> bool:  # noqa
         """
         Only support concatenation of 2 - 4 tensors
         """
@@ -272,7 +286,7 @@ class XnnpackOperatorSupport(OperatorSupportBase):
         return num_tensors >= 2 and num_tensors <= 4
 
     @_constraint(exir_ops.edge.aten.slice_copy.Tensor)
-    def slice_copy(node: torch.fx.Node) -> bool:  # noqa
+    def slice_copy(node: torch.fx.Node, ep: ExportedProgram) -> bool:  # noqa
         """
         Support slicing with stride = 1, no zero-dim tensors
         """
@@ -334,7 +348,9 @@ class XnnpackFloatingPointPartitioner(Partitioner):
             log.info(f"Found {pl} subgraphs to be partitioned.")
         return pl != 0
 
-    def get_nodes(self, src_partition: SourcePartition) -> List[torch.fx.Node]:
+    def get_nodes(
+        self, src_partition: SourcePartition, ep: ExportedProgram
+    ) -> List[torch.fx.Node]:
         """
         Return nodes from the source partition.
 
@@ -343,7 +359,9 @@ class XnnpackFloatingPointPartitioner(Partitioner):
         """
         return src_partition.nodes
 
-    def qualify_nodes(self, input_nodes: List[torch.fx.Node]) -> bool:
+    def qualify_nodes(
+        self, input_nodes: List[torch.fx.Node], ep: ExportedProgram
+    ) -> bool:
         """
         Each node in the module (post decomposition) must satisfy the
         constraints specified for XNNPACK.
@@ -351,16 +369,15 @@ class XnnpackFloatingPointPartitioner(Partitioner):
         Disqualify the whole module if one of the nodes fails to satisfy.
         """
         return all(
-            XnnpackOperatorSupport.check_constraint(node) for node in input_nodes
+            XnnpackOperatorSupport.check_constraint(node, ep) for node in input_nodes
         )
 
-    def get_module_partitions(
-        self, graph_module: torch.fx.GraphModule
-    ) -> List[List[torch.fx.Node]]:
+    def get_module_partitions(self, ep: ExportedProgram) -> List[List[torch.fx.Node]]:
         """
         Get all partitions in the torch.fx.GraphModule for the supported
         modules.
         """
+        graph_module = ep.graph_module
         src_partition_dict = get_source_partitions(
             graph_module.graph, self.supported_modules
         )
@@ -369,22 +386,24 @@ class XnnpackFloatingPointPartitioner(Partitioner):
         module_partitions = []
         for src_partitions in all_partitions:
             for src_partition in src_partitions:
-                partition_nodes = self.get_nodes(src_partition)
-                if self.qualify_nodes(partition_nodes):
+                partition_nodes = self.get_nodes(src_partition, ep)
+                if self.qualify_nodes(partition_nodes, ep):
                     module_partitions.append(partition_nodes)
 
         return module_partitions
 
-    def generate_partitions(self, graph_module: torch.fx.GraphModule) -> List[Any]:
+    def generate_partitions(self, ep: ExportedProgram) -> List[Any]:
         """
         Generate a list of partitions for an torch.fx.GraphModule.
         Also pass the supported ops to match.
         """
-        matched_module_nodes = self.get_module_partitions(graph_module)
+        graph_module = ep.graph_module
+        matched_module_nodes = self.get_module_partitions(ep)
         return generate_partitions_from_list_of_nodes(
             graph_module,
             matched_module_nodes,
             XnnpackOperatorSupport(
+                ep=ep,
                 supported_ops=self.supported_ops,
                 unsupported_modules=self.unsupported_modules,
             ),
@@ -409,7 +428,7 @@ class XnnpackFloatingPointPartitioner(Partitioner):
         Run the partitioner on the given graph module, then tag each partition
         with its delegation tag (and partition id)
         """
-        partitions = self.generate_partitions(exported_program.graph_module)
+        partitions = self.generate_partitions(exported_program)
         partition_tags: Dict[str, DelegationSpec] = {}
         if self.check_partitions(partitions):
             partition_tags = self.tag_nodes(partitions)
@@ -456,7 +475,7 @@ class XnnpackQuantizedPartitioner(XnnpackFloatingPointPartitioner):
     # TODO Refactor this
     # TODO Don't be greedy when pulling q->dq pairs for a given op, add convert tracker pass
     def get_input_deps(  # noqa
-        self, input_nodes: List[torch.fx.Node]
+        self, input_nodes: List[torch.fx.Node], ep: ExportedProgram
     ) -> List[torch.fx.Node]:
         """
         For each input node, walk up and pull necessary quant/attr nodes in the partition
@@ -470,7 +489,7 @@ class XnnpackQuantizedPartitioner(XnnpackFloatingPointPartitioner):
                 # possible per_channel scale/zp for the dequant node args{1, 2}
                 for i in [1, 2]:
                     node = inp.args[i]
-                    if isinstance(node, torch.fx.Node) and node.op == "get_attr":
+                    if isinstance(node, torch.fx.Node) and is_param_node(ep, node):
                         nodes.add(node)
 
                 # quant node
@@ -482,7 +501,7 @@ class XnnpackQuantizedPartitioner(XnnpackFloatingPointPartitioner):
 
                 # possible weight for the quant node arg{0}
                 node = q_prod.args[0]
-                if isinstance(node, torch.fx.Node) and node.op == "get_attr":
+                if isinstance(node, torch.fx.Node) and is_param_node(ep, node):
                     nodes.add(node)
 
                 # possible nodes for quant node args{1, 2}
@@ -504,11 +523,13 @@ class XnnpackQuantizedPartitioner(XnnpackFloatingPointPartitioner):
                             nodes.add(parent)
 
                     # possible per_channel scale/zp for the quant node
-                    elif isinstance(node, torch.fx.Node) and node.op == "get_attr":
+                    elif isinstance(node, torch.fx.Node) and is_param_node(ep, node):
                         nodes.add(node)
         return list(nodes)
 
-    def get_output_deps(self, output_nodes: List[torch.fx.Node]) -> List[torch.fx.Node]:
+    def get_output_deps(
+        self, output_nodes: List[torch.fx.Node], exported_program
+    ) -> List[torch.fx.Node]:
         """
         For each output node, check all the users and insert them into the partition if needed
         """
@@ -526,14 +547,16 @@ class XnnpackQuantizedPartitioner(XnnpackFloatingPointPartitioner):
         return nodes
 
     # override
-    def get_nodes(self, src_partition: SourcePartition) -> List[torch.fx.Node]:  # noqa
+    def get_nodes(
+        self, src_partition: SourcePartition, ep: ExportedProgram
+    ) -> List[torch.fx.Node]:  # noqa
         """
         Insert quantization ops into src_partition by following the input, output node.
         """
         return (
             src_partition.nodes
-            + self.get_input_deps(src_partition.input_nodes)
-            + self.get_output_deps(src_partition.output_nodes)
+            + self.get_input_deps(src_partition.input_nodes, ep)
+            + self.get_output_deps(src_partition.output_nodes, ep)
         )
 
 
@@ -621,7 +644,7 @@ class XnnpackPartitioner(Partitioner):
         return pl != 0
 
     def get_input_deps(  # noqa
-        self, input_nodes: List[torch.fx.Node]
+        self, input_nodes: List[torch.fx.Node], ep: ExportedProgram
     ) -> List[torch.fx.Node]:
         """
         For each input node, walk up and pull necessary quant/attr nodes in the partition
@@ -635,7 +658,7 @@ class XnnpackPartitioner(Partitioner):
                 # possible per_channel scale/zp for the dequant node args{1, 2}
                 for i in [1, 2]:
                     node = inp.args[i]
-                    if isinstance(node, torch.fx.Node) and node.op == "get_attr":
+                    if isinstance(node, torch.fx.Node) and is_param_node(ep, node):
                         nodes.add(node)
 
                 # quant node
@@ -647,7 +670,7 @@ class XnnpackPartitioner(Partitioner):
 
                 # possible weight for the quant node arg{0}
                 node = q_prod.args[0]
-                if isinstance(node, torch.fx.Node) and node.op == "get_attr":
+                if isinstance(node, torch.fx.Node) and is_param_node(ep, node):
                     nodes.add(node)
 
                 # possible nodes for quant node args{1, 2}
@@ -669,11 +692,13 @@ class XnnpackPartitioner(Partitioner):
                             nodes.add(parent)
 
                     # possible per_channel scale/zp for the quant node
-                    elif isinstance(node, torch.fx.Node) and node.op == "get_attr":
+                    elif isinstance(node, torch.fx.Node) and is_param_node(ep, node):
                         nodes.add(node)
         return list(nodes)
 
-    def get_output_deps(self, output_nodes: List[torch.fx.Node]) -> List[torch.fx.Node]:
+    def get_output_deps(
+        self, output_nodes: List[torch.fx.Node], ep: ExportedProgram
+    ) -> List[torch.fx.Node]:
         """
         For each output node, check all the users and insert them into the partition if needed
         """
@@ -691,7 +716,7 @@ class XnnpackPartitioner(Partitioner):
         return nodes
 
     def get_nodes(
-        self, src_partition: SourcePartition, quant: bool
+        self, src_partition: SourcePartition, ep: ExportedProgram, quant: bool
     ) -> List[torch.fx.Node]:
         """
         Return nodes from the source partition.
@@ -700,13 +725,15 @@ class XnnpackPartitioner(Partitioner):
             # Insert quantization ops into src_partition by following the input, output node.
             return (
                 src_partition.nodes
-                + self.get_input_deps(src_partition.input_nodes)
-                + self.get_output_deps(src_partition.output_nodes)
+                + self.get_input_deps(src_partition.input_nodes, ep)
+                + self.get_output_deps(src_partition.output_nodes, ep)
             )
         else:
             return src_partition.nodes
 
-    def qualify_nodes(self, input_nodes: List[torch.fx.Node]) -> bool:
+    def qualify_nodes(
+        self, input_nodes: List[torch.fx.Node], ep: ExportedProgram
+    ) -> bool:
         """
         Each node in the module (post decomposition) must satisfy the
         constraints specified for XNNPACK.
@@ -714,23 +741,25 @@ class XnnpackPartitioner(Partitioner):
         Disqualify the whole module if one of the nodes fails to satisfy.
         """
         return all(
-            XnnpackOperatorSupport.check_constraint(node) for node in input_nodes
+            XnnpackOperatorSupport.check_constraint(node, ep) for node in input_nodes
         )
 
     def get_module_partitions(
-        self, graph_module: torch.fx.GraphModule, quant: Optional[bool]
+        self,
+        ep: ExportedProgram,
+        quant: Optional[bool],
     ) -> List[List[torch.fx.Node]]:
         """
         Get all partitions in the torch.fx.GraphModule for the supported
         modules.
         """
-
+        graph_module = ep.graph_module
         if quant is None:
-            module_partitions = self.get_module_partitions(graph_module, True)
+            module_partitions = self.get_module_partitions(ep, True)
             for node_list in module_partitions:
                 for node in node_list:
                     node.meta["quant_match"] = True
-            fp32_module_partitions = self.get_module_partitions(graph_module, False)
+            fp32_module_partitions = self.get_module_partitions(ep, False)
             for node_list in fp32_module_partitions:
                 for node in node_list:
                     if node.meta.get("quant_match", False):
@@ -750,24 +779,27 @@ class XnnpackPartitioner(Partitioner):
         module_partitions = []
         for src_partitions in all_partitions:
             for src_partition in src_partitions:
-                partition_nodes = self.get_nodes(src_partition, quant)
-                if self.qualify_nodes(partition_nodes):
+                partition_nodes = self.get_nodes(src_partition, ep, quant)
+                if self.qualify_nodes(partition_nodes, ep):
                     module_partitions.append(partition_nodes)
 
         return module_partitions
 
     def generate_partitions(
-        self, graph_module: torch.fx.GraphModule, quant: Optional[bool]
+        self, ep: ExportedProgram, quant: Optional[bool]
     ) -> List[Any]:
         """
         Generate a list of partitions for an torch.fx.GraphModule.
         Also pass the supported ops to match.
         """
-        matched_module_nodes = self.get_module_partitions(graph_module, quant)
+        graph_module = ep.graph_module
+        matched_module_nodes = self.get_module_partitions(ep, quant)
         return generate_partitions_from_list_of_nodes(
             graph_module,
             matched_module_nodes,
-            XnnpackOperatorSupport(supported_ops=list(self.get_supported_ops(quant))),
+            XnnpackOperatorSupport(
+                ep=ep, supported_ops=list(self.get_supported_ops(quant))
+            ),
         )
 
     def tag_nodes(self, partitions: List[Partition]) -> Dict[str, DelegationSpec]:
@@ -797,7 +829,7 @@ class XnnpackPartitioner(Partitioner):
         Run the partitioner on the given graph module, then tag each partition
         with its delegation tag (and partition id)
         """
-        partitions = self.generate_partitions(exported_program.graph_module, quant)
+        partitions = self.generate_partitions(exported_program, quant)
         partition_tags: Dict[str, DelegationSpec] = {}
         if self.check_partitions(partitions):
             partition_tags = self.tag_nodes(partitions)

--- a/backends/xnnpack/passes/TARGETS
+++ b/backends/xnnpack/passes/TARGETS
@@ -15,6 +15,7 @@ python_library(
     ],
     deps = [
         "//caffe2:torch",
+        "//executorch/backends/transforms:addmm_mm_to_linear",
         "//executorch/backends/transforms:lib",
         "//executorch/backends/xnnpack/partition:configs",
         "//executorch/backends/xnnpack/utils:xnnpack_utils",

--- a/docs/website/docs/tutorials/backend_delegate.md
+++ b/docs/website/docs/tutorials/backend_delegate.md
@@ -373,7 +373,7 @@ class Backend_1_2_Partitioner(Partitioner):
         self.delegation_spec_2 = DelegationSpec("Backend2", [])
 
     def partition(
-        self, edge_graph_module: torch.fx.GraphModule
+        self, exported_program: ExportedProgram
     ) -> PartitionResult:
         partition_tags: Dict[str, DelegationSpec] = {}
         # Tag all nodes in the first partiton to backend 1
@@ -388,7 +388,7 @@ class Backend_1_2_Partitioner(Partitioner):
         node.meta["delegation_tag"] = delegation_tag
         partition_tags[delegation_tag] = self.delegation_spec_2
         return PartitionResult(
-            tagged_graph=edge_graph_module, partition_tags=partition_tags
+            tagged_exported_program=exported_program, partition_tags=partition_tags
         )
 ```
 

--- a/exir/backend/backend_api.py
+++ b/exir/backend/backend_api.py
@@ -281,18 +281,17 @@ def _(
     Returns:
         ExportedProgram: The input program, with some portions targeted for delegation.
     """
-    edge_graph_module = edge_program.graph_module
-    copied_graph_module = copy.deepcopy(edge_graph_module)
+    copied_edge_program = copy.deepcopy(edge_program)
     # Call the partitioner on the given graph module
     partitioner_instance: Partitioner = partitioner()
-    partitioner_result = partitioner_instance(copied_graph_module)
-    tagged_graph_module = partitioner_result.tagged_graph
+    partitioner_result = partitioner_instance(copied_edge_program)
+    tagged_exported_program = partitioner_result.tagged_exported_program
 
     # Check that the partitioner did not modify the original graph
     if _ENABLE_VALIDATION:
         assert is_identical_graph(
-            tagged_graph_module,
-            edge_graph_module,
+            tagged_exported_program.graph_module,
+            edge_program.graph_module,
         ), f"The partitioner {partitioner} should not modify the graph module"
     else:
         logging.warning("Disabled validating the partitioner.")
@@ -302,7 +301,7 @@ def _(
     ), f"Partitioner {partitioner} needs a `partition_tags` field containing a mapping of tags to delegate spec"
 
     tagged_graph_module = _partition_and_lower(
-        tagged_graph_module, partitioner_result, edge_program
+        tagged_exported_program.graph_module, partitioner_result, edge_program
     )
 
     # TODO(angelayi): Update this signature in a less manual way (maybe through

--- a/exir/backend/test/demos/rpc/executor_backend_partitioner.py
+++ b/exir/backend/test/demos/rpc/executor_backend_partitioner.py
@@ -19,6 +19,7 @@ from executorch.exir.backend.partitioner import (
 from executorch.exir.backend.test.backend_with_compiler_demo import (
     BackendWithCompilerDemo,
 )
+from torch._export.exported_program import ExportedProgram
 from torch.fx.passes.operator_support import any_chain, OperatorSupportBase
 
 
@@ -49,10 +50,10 @@ class ExecutorBackendPartitioner(Partitioner):
         self.op_support = any_chain(AnyOperatorSupport(), AnyDelegateSupport())
         self.delegation_spec = DelegationSpec("ExecutorBackend", [])
 
-    def partition(self, edge_graph_module: torch.fx.GraphModule) -> PartitionResult:
+    def partition(self, edge_exported_program: ExportedProgram) -> PartitionResult:
         partition_tags = {}
         partition_list = generate_pattern_op_partitions(
-            edge_graph_module, op_support=self.op_support
+            edge_exported_program.graph_module, op_support=self.op_support
         )
         for partition in partition_list:
             for node in partition.nodes:
@@ -67,5 +68,6 @@ class ExecutorBackendPartitioner(Partitioner):
                     node.args[0].meta["delegation_tag"] = delegation_tag
 
         return PartitionResult(
-            tagged_graph=edge_graph_module, partition_tags=partition_tags
+            tagged_exported_program=edge_exported_program,
+            partition_tags=partition_tags,
         )

--- a/exir/backend/test/test_backends_lifted.py
+++ b/exir/backend/test/test_backends_lifted.py
@@ -59,6 +59,7 @@ from executorch.extension.pybindings.portable_lib import (  # @manual
 from executorch.extension.pytree import tree_flatten
 
 from functorch.experimental import control_flow
+from torch._export.exported_program import ExportedProgram
 from torch.ao.quantization import get_default_qconfig_mapping  # @manual
 from torch.ao.quantization.backend_config.executorch import (
     get_executorch_backend_config,
@@ -952,17 +953,18 @@ class TestBackends(unittest.TestCase):
         class BadPartitioner(Partitioner):
             partition_tags = {"tag1": DelegationSpec("BackendWithCompilerDemo", [])}
 
-            def partition(self, edge_graph_module):
+            def partition(self, exported_program: ExportedProgram) -> PartitionResult:
                 # Partitioner should not modify the given graph module
                 partition_tags: Dict[str, DelegationSpec] = {}
-                for node in edge_graph_module.graph.nodes:
+                for node in exported_program.graph.nodes:
                     if (
                         node.op == "call_function"
                         and node.target == exir_ops.edge.aten.add.Tensor
                     ):
                         node.target = exir_ops.edge.aten.mul.Tensor
                 return PartitionResult(
-                    tagged_graph=edge_graph_module, partition_tags=partition_tags
+                    tagged_exported_program=exported_program,
+                    partition_tags=partition_tags,
                 )
 
         ep = exir.capture(Model(), inputs, get_testing_capture_config()).to_edge()

--- a/exir/backend/test/test_utils.py
+++ b/exir/backend/test/test_utils.py
@@ -18,6 +18,7 @@ from executorch.exir.backend.utils import (
 )
 
 from executorch.exir.dialects._ops import bind_pattern_to_op, ops as exir_ops
+from torch._export.exported_program import ExportedProgram
 from torch.ao.quantization import get_default_qconfig  # @manual
 from torch.ao.quantization.backend_config.executorch import (
     get_executorch_backend_config,
@@ -256,10 +257,10 @@ class TestPartitioners(unittest.TestCase):
                 self.test = "a"
 
             def partition(
-                self, edge_graph_module: torch.fx.GraphModule
+                self, edge_exported_program: ExportedProgram
             ) -> PartitionResult:
                 return PartitionResult(
-                    tagged_graph=edge_graph_module, partition_tags=None
+                    tagged_exported_program=edge_exported_program, partition_tags=None
                 )
 
         exported_program = exir.capture(

--- a/exir/tests/test_quant_lowering_custom_backend_pass.py
+++ b/exir/tests/test_quant_lowering_custom_backend_pass.py
@@ -480,10 +480,10 @@ class QuantizedConvAddOpPartitioner(Partitioner):
 
         self.delegation_spec = DelegationSpec(ConvAddBackendDemo.__name__, [])
 
-    def partition(self, edge_graph_module: torch.fx.GraphModule) -> PartitionResult:
+    def partition(self, edge_exported_program: ExportedProgram) -> PartitionResult:
         partition_tags: Dict[str, DelegationSpec] = {}
         partition_list = generate_pattern_op_partitions(
-            edge_graph_module, patterns=self.patterns
+            edge_exported_program.graph_module, patterns=self.patterns
         )
         logging.debug(partition_list)
         for partition in partition_list:
@@ -492,7 +492,8 @@ class QuantizedConvAddOpPartitioner(Partitioner):
                 node.meta["delegation_tag"] = delegation_tag
                 partition_tags[delegation_tag] = self.delegation_spec
         return PartitionResult(
-            tagged_graph=edge_graph_module, partition_tags=partition_tags
+            tagged_exported_program=edge_exported_program.graph_module,
+            partition_tags=partition_tags,
         )
 
 


### PR DESCRIPTION
Summary:
This is required for VIT.

addmm is not delegateable if it is not derived from torch.nn.linear. There are some addmms in ViT which are derived from MultiHeadAttention. As a result to improve performance we need to partition addmms in the operator list rather than by module.

Reviewed By: kirklandsign

Differential Revision: D49129703

