### PR TITLE
Add lift constant tensors passes after aten_to_edge

### DIFF
--- a/exir/backend/test/test_backends_lifted.py
+++ b/exir/backend/test/test_backends_lifted.py
@@ -647,7 +647,7 @@ class TestBackends(unittest.TestCase):
             config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
         )
 
-        new_res = program_with_delegates.dump_graph_module()(*inputs)
+        new_res = program_with_delegates.dump_exported_program()(*inputs)
         for t1, t2 in zip(new_res, orig_res, strict=True):
             self.assertTrue(torch.allclose(t1, t2, atol=1e-03, rtol=1e-03))
 
@@ -780,7 +780,7 @@ class TestBackends(unittest.TestCase):
         #     config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
         # )
 
-        new_res = program_with_delegates.dump_graph_module()(*inputs)
+        new_res = program_with_delegates.dump_exported_program()(*inputs)
         for t1, t2 in zip(new_res, orig_res, strict=True):
             self.assertTrue(torch.allclose(t1, t2, atol=1e-03, rtol=1e-03))
 

--- a/exir/capture/_capture.py
+++ b/exir/capture/_capture.py
@@ -245,6 +245,7 @@ def capture(  # noqa: C901
         {},
         [],
         [],
+        dialect="OLD_EXIR_ATEN",
     )
     return ExirExportedProgram(ep, False)
 

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -46,6 +46,7 @@ from executorch.exir.tests.models import MLP, Mul
 from functorch.experimental import control_flow
 
 from torch import nn
+from torch._export.passes.lift_constant_tensor_pass import lift_constant_tensor_pass
 from torch.fx import GraphModule, subgraph_rewriter
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.library import impl, Library
@@ -463,6 +464,53 @@ class TestPasses(unittest.TestCase):
             if node.op == "call_function":
                 for arg in node.args + tuple(node.kwargs.values()):
                     self.assertFalse(isinstance(arg, float))
+
+    def test_lift_scalar_tensor(self) -> None:
+        class FooWithBuffer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("buffer", torch.zeros(42))
+
+            def forward(self, x):
+                return x.cos() + self.buffer.sum() + torch.tensor(4) + 4
+
+        ep = exir.capture(
+            FooWithBuffer(), (torch.ones(6, 2),), exir.CaptureConfig(enable_aot=True)
+        )
+        new_ep = ep.transform(ScalarToTensorPass()).exported_program
+        self.assertTrue(
+            len([node for node in new_ep.graph.nodes if node.op == "get_attr"])
+        )
+        lifted_exported_program = lift_constant_tensor_pass(new_ep)
+
+        self.assertEqual(
+            len(
+                [
+                    node
+                    for node in lifted_exported_program.graph.nodes
+                    if node.op == "placeholder"
+                ]
+            ),
+            4,
+        )
+        for node in lifted_exported_program.graph.nodes:
+            self.assertTrue(node.op != "get_attr")
+
+        edge_ep = exir.capture(
+            FooWithBuffer(), (torch.ones(6, 2),), exir.CaptureConfig(enable_aot=True)
+        ).to_edge()
+        self.assertEqual(
+            len(
+                [
+                    node
+                    for node in edge_ep.exported_program.graph.nodes
+                    if node.op == "placeholder"
+                ]
+            ),
+            4,
+        )
+        for node in edge_ep.exported_program.graph.nodes:
+            self.assertTrue(node.op != "get_attr")
 
     def test_remove_mixed_types_symfloats(self) -> None:
         def f(x: torch.Tensor) -> torch.Tensor:

--- a/exir/tests/test_tracer.py
+++ b/exir/tests/test_tracer.py
@@ -398,9 +398,8 @@ class TestTorchDispatchFXTracer(unittest.TestCase):
                 return x.cos() + self.buffer.sum()
 
         capture_config = exir.CaptureConfig(enable_aot=True)
-        captured_gm = exir.capture(
-            FooWithBuffer(), (torch.ones(6, 2),), capture_config
-        ).exported_program.graph_module
+        captured_ep = exir.capture(FooWithBuffer(), (torch.ones(6, 2),), capture_config)
+        captured_gm = captured_ep.exported_program.graph_module
 
         placeholder_nodes = set()
         print(captured_gm.graph)
@@ -420,6 +419,7 @@ class TestTorchDispatchFXTracer(unittest.TestCase):
                 )
 
         self.assertEqual(len(placeholder_nodes), 2)
+        captured_ep.to_edge()
 
     def test_export_unlift(self) -> None:
         class Foo(torch.nn.Module):


### PR DESCRIPTION
Summary:
When exporting using enable_aot (through the torch.export path), we want to lift all constant tensors as buffers to the exported program. The ScalarToTensor pass in EXIR's aten_to_edge passes will create some constant tensors in the graph, so we will need to run a lift_constant_tensors pass afterwards.

Note that this only needs to be applied when exporting using the torch.export path because in the original path, nothing is lifted.

Differential Revision: D49207492


