### PR TITLE
Fix Debug Handle Map Typing

### DIFF
--- a/exir/backend/backend_details.py
+++ b/exir/backend/backend_details.py
@@ -22,7 +22,7 @@ def enforcedmethod(func):
 class PreprocessResult:
     processed_bytes: bytes = bytes()
     debug_handle_map: Optional[
-        Union[Dict[int, Tuple[int]], Dict[int, Tuple[int]]]
+        Union[Dict[int, Tuple[int]], Dict[str, Tuple[int]]]
     ] = None
 
 

--- a/exir/backend/test/backend_with_delegate_mapping_demo.py
+++ b/exir/backend/test/backend_with_delegate_mapping_demo.py
@@ -153,7 +153,6 @@ class BackendWithDelegateMappingDemo(BackendDetails):
             processed_bytes=bytes(
                 str(number_of_instruction) + "#" + processed_bytes, encoding="utf8"
             ),
-            # pyre-ignore
             debug_handle_map=delegate_builder.get_delegate_mapping(),
         )
 


### PR DESCRIPTION
Summary:
The intended typing for PreprocessResult.debug_handle_map was
```
Dict[int, Tuple[int, ...]] || Dict[str, Tuple[int, ...]]
```
Since the delegate identifier can be either a string or int and maps to a Int Tuple of variable length

This fixes the type and gets rid of the pyre ignore

Reviewed By: digantdesai, cccclai

Differential Revision: D49300700


