### PR TITLE
Add an option to specify an existing flatbuffers compiler for cmake build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,12 +87,15 @@ option(EXECUTORCH_BUILD_XNNPACK
        "Build xnn_executor_runner which depends on XNNPACK" OFF)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
+
 if(NOT BUCK2)
   set(BUCK2 buck2)
 endif()
+
 if(NOT PYTHON_EXECUTABLE)
   set(PYTHON_EXECUTABLE python3)
 endif()
@@ -126,12 +129,15 @@ include(${EXECUTORCH_SRCS_FILE})
 # flatc: Flatbuffer commandline tool to generate .h files from .fbs files
 #
 
-option(FLATBUFFERS_BUILD_FLATC "" ON)
-option(FLATBUFFERS_BUILD_FLATHASH "" OFF)
-option(FLATBUFFERS_BUILD_FLATLIB "" OFF)
-option(FLATBUFFERS_BUILD_TESTS "" OFF)
-option(FLATBUFFERS_INSTALL "" OFF)
-add_subdirectory(third-party/flatbuffers)
+if(NOT FLATC_EXECUTABLE)
+  set(FLATC_EXECUTABLE flatc)
+  option(FLATBUFFERS_BUILD_FLATC "" ON)
+  option(FLATBUFFERS_BUILD_FLATHASH "" OFF)
+  option(FLATBUFFERS_BUILD_FLATLIB "" OFF)
+  option(FLATBUFFERS_BUILD_TESTS "" OFF)
+  option(FLATBUFFERS_INSTALL "" OFF)
+  add_subdirectory(third-party/flatbuffers)
+endif()
 
 #
 # gflags: Commandline flag libgrary

--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -12,6 +12,7 @@
 cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
@@ -19,6 +20,11 @@ endif()
 if(NOT PYTHON_EXECUTABLE)
   set(PYTHON_EXECUTABLE python3)
 endif()
+
+if(NOT FLATC_EXECUTABLE)
+  set(FLATC_EXECUTABLE flatc)
+endif()
+
 # Source root directory for executorch.
 if(NOT EXECUTORCH_ROOT)
   set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
@@ -43,7 +49,7 @@ endforeach()
 add_custom_command(
   OUTPUT ${_xnnpack_schema__outputs}
   COMMAND
-    flatc --cpp --cpp-std c++11 --scoped-enums -o
+    ${FLATC_EXECUTABLE} --cpp --cpp-std c++11 --scoped-enums -o
     "${_xnnpack_schema__include_dir}/executorch/backends/xnnpack"
     ${_xnnpack_schema__srcs}
   WORKING_DIRECTORY ${EXECUTORCH_ROOT}

--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -18,6 +18,8 @@ function(executorch_print_configuration_summary)
   message(STATUS "  CMAKE_CXX_STANDARD            : ${CMAKE_CXX_STANDARD}")
   message(STATUS "  CMAKE_CXX_COMPILER_ID         : ${CMAKE_CXX_COMPILER_ID}")
   message(STATUS "  CMAKE_TOOLCHAIN_FILE          : ${CMAKE_TOOLCHAIN_FILE}")
+  message(STATUS "  PYTHON_EXECUTABLE             : ${PYTHON_EXECUTABLE}")
+  message(STATUS "  FLATC_EXECUTABLE              : ${FLATC_EXECUTABLE}")
   message(STATUS "  FLATBUFFERS_BUILD_FLATC       : ${FLATBUFFERS_BUILD_FLATC}")
   message(
     STATUS "  FLATBUFFERS_BUILD_FLATHASH    : ${FLATBUFFERS_BUILD_FLATHASH}")

--- a/schema/CMakeLists.txt
+++ b/schema/CMakeLists.txt
@@ -9,6 +9,10 @@
 # cmake-format --first-comment-is-literal=True CMakeLists.txt
 # ~~~
 
+if(NOT FLATC_EXECUTABLE)
+  set(FLATC_EXECUTABLE flatc)
+endif()
+
 # The include directory that will contain the generated schema headers.
 set(_program_schema__include_dir "${CMAKE_BINARY_DIR}/schema/include")
 
@@ -31,13 +35,13 @@ endforeach()
 add_custom_command(
   OUTPUT ${_program_schema__outputs}
   COMMAND
-    flatc --cpp --cpp-std c++11 --gen-mutable --scoped-enums
+    ${FLATC_EXECUTABLE} --cpp --cpp-std c++11 --gen-mutable --scoped-enums
     # Add a subdirectory to the include dir so the files can be included as
     # <executorch/schema/x_generated.h>
     -o "${_program_schema__include_dir}/executorch/schema"
     ${_program_schema__srcs}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  DEPENDS flatc ${_program_schema__srcs}
+  DEPENDS ${FLATC_EXECUTABLE} ${_program_schema__srcs}
   COMMENT "Generating program_schema headers"
   VERBATIM)
 


### PR DESCRIPTION
Summary: Cmake Xcode genrator creates an Xcode project for Executorch where some targets that require codegen steps become Run script build phases in Xcode, and some of them use `flatc` directly assuming it's available via $PATH, whereas it's not installed on MacOS by default. We can't use the one we build as a dependency either because there's no clear way to point to it for such Run script build phase (e.g. $<TARGET_FILE:flatc> provides a path that includes an Xcode own env var ${EFFECTIVE_PLATFORM_NAME} which is not possible to set when we generate the project with cmake). So here we'll follow the same approach as we already have for $PYTHON_EXCUTABLE and just pass a path to `flatc` binary too as one of the arguments to cmake.

Differential Revision: D49324851


