### PR TITLE
Fix test_end2end.py

### DIFF
--- a/test/end2end/TARGETS
+++ b/test/end2end/TARGETS
@@ -35,6 +35,7 @@ python_unittest(
     srcs = [
         "test_end2end.py",
     ],
+    preload_deps = ["//executorch/kernels/portable:custom_ops_generated_lib"],
     deps = [
         ":exported_module",
         ":register_scratch_meta_fns",
@@ -66,6 +67,7 @@ python_unittest(
     srcs = [
         "test_end2end.py",
     ],
+    preload_deps = ["//executorch/kernels/portable:custom_ops_generated_lib"],
     deps = [
         ":exported_module",
         ":register_scratch_meta_fns",


### PR DESCRIPTION
Summary:
A bunch of fixes including cleaning up imports, changing the style we
define test methods so that they can be discovered by unittest loader, fixing
small issues related to result comparing and disabling some tests that are not
easy to fix.

Reviewed By: Gasoonjia

Differential Revision: D49328465

