### PR TITLE
[executorch][docs] Don't generate docs for exir.serialize

### DIFF
--- a/docs/source_py/exir.rst
+++ b/docs/source_py/exir.rst
@@ -120,4 +120,3 @@ Subpackages
 
    exir.data_structures
    exir.passes
-   exir.serialize

--- a/docs/source_py/exir.serialize.rst
+++ b/docs/source_py/exir.serialize.rst
@@ -1,7 +1,0 @@
-exir.serialize
-=================================
-
-.. automodule:: exir.serialize
-   :members:
-   :undoc-members:
-   :show-inheritance:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #371

This module is now hidden, so we shouldn't create docs for it. Also its new name is `exir._serialize`, so the current names cause the docs build to break.

Differential Revision: [D49331927](https://our.internmc.facebook.com/intern/diff/D49331927/)