### PR TITLE
add long running tag to e2e model tests

### DIFF
--- a/backends/xnnpack/test/TARGETS
+++ b/backends/xnnpack/test/TARGETS
@@ -125,11 +125,10 @@ python_unittest(
     srcs = glob([
         "models/*.py",
     ]),
+    tags = ["long_running"],
     deps = [
         "//caffe2:torch",
-        "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
         "//executorch/backends/xnnpack/test/tester:tester",
-        "//executorch/exir:lib",
         "//pytorch/vision:torchvision",
     ],
 )


### PR DESCRIPTION
Summary:
Models take longer to capture especially without dev-nosan mode. So in testing xnnpack models, a lot of these end to end tests time out and end up ommitted.

Since models generally take longer, we can add the long running tag to keep them from timing out on CI

Reviewed By: cccclai

Differential Revision: D49279457


