### PR TITLE
Move SymShapeEvalPass as part of memory planning pass

### DIFF
--- a/exir/passes/TARGETS
+++ b/exir/passes/TARGETS
@@ -118,6 +118,7 @@ python_library(
         "memory_planning_pass.py",
     ],
     deps = [
+        ":lib",
         "//caffe2:torch",
         "//executorch/exir:error",
         "//executorch/exir:memory",

--- a/exir/passes/memory_planning_pass.py
+++ b/exir/passes/memory_planning_pass.py
@@ -19,6 +19,7 @@ from executorch.exir.memory_planning import (
 )
 from executorch.exir.operator.convert import get_out_args_from_opoverload
 from executorch.exir.pass_base import PassBase, PassResult
+from executorch.exir.passes import SymShapeEvalPass
 from executorch.exir.tensor import ALIGNMENT
 
 
@@ -42,6 +43,7 @@ class MemoryPlanningPass(PassBase):
         self.alloc_graph_input = alloc_graph_input
         self.alloc_graph_output = alloc_graph_output
         self.alignment = alignment
+        self.sym_shape_eval_fn = SymShapeEvalPass()
 
     def _set_alloc_node_spec(self, graph_module: torch.fx.GraphModule) -> None:
         """
@@ -88,6 +90,8 @@ class MemoryPlanningPass(PassBase):
         """
         self._set_alloc_node_spec(graph_module)
         algo = get_algo(self.memory_planning_algo)
+
+        self.sym_shape_eval_fn(graph_module)
 
         # TODO(shunting) if people have concern of adding a field to GraphModule
         # directly, we should define a GraphModule subclass that we can add our

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -309,7 +309,6 @@ def edge_to_executorch_passes(config: ExecutorchBackendConfig) -> List[PassType]
         SpecPropPass(),
         EdgeToBackendOpsPass(),
         RemoveAssertAsyncPass(),
-        SymShapeEvalPass(),
         config.to_out_var_pass,
         config.memory_planning_pass,
     ]


### PR DESCRIPTION
Summary: Before this PR, SymShapeEvalPass and memory planning pass are seperate passes in edge_to_executorch_passes. However, the only user of SymShapeEvalPass is memory planning. This PR moves it into memory planning pass to emphasize this fact. This also makes it easier to configure the way of evaluating the symbols: right now it's hint based but we'll need the ValueRange based upper bound evaluation to respect user's input constraints.

Differential Revision: D49334995


