### PR TITLE
Add a test for building executor_runner with no ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,10 @@ endif()
 # -Os: Optimize for size -ffunction-sections -fdata-sections: breaks function
 # and data into sections so they can be properly gc'd -s: strip symbols
 set(CMAKE_CXX_FLAGS_RELEASE
-    "-Os -ffunction-sections -fdata-sections -s -fno-exceptions -fno-rtti")
+    "-Os -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti")
+if(NOT APPLE)
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+endif()
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 
 # Option to register custom operator `my_ops::mul3` or `my_ops::mul4` or no
@@ -70,6 +73,9 @@ option(REGISTER_QUANTIZED_OPS
 
 option(BUILD_SELECTIVE_BUILD_TEST
        "Whether to build binary for demo selective build" OFF)
+
+option(EXECUTORCH_BUILD_SIZE_TEST
+       "Whether to build size test" OFF)
 
 if(BUILD_SELECTIVE_BUILD_TEST)
   option(SELECT_ALL_OPS
@@ -207,6 +213,11 @@ endif()
 # Add selective build subdirectory
 if(BUILD_SELECTIVE_BUILD_TEST)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples/selective_build)
+endif()
+
+# Add size test subdirectory
+if(EXECUTORCH_BUILD_SIZE_TEST)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/test)
 endif()
 # Print all summary
 executorch_print_configuration_summary()

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -25,6 +25,7 @@ function(gen_selected_ops ops_schema_yaml root_ops include_all_ops)
   if(include_all_ops)
     list(APPEND _gen_oplist_command --include_all_operators)
   endif()
+
   message("Command - ${_gen_oplist_command}")
   add_custom_command(
     COMMENT "Generating selected_operators.yaml for custom ops"
@@ -113,7 +114,9 @@ function(gen_operators_lib lib_name kernel_lib deps)
       ${CMAKE_CURRENT_BINARY_DIR}/Functions.h
       ${CMAKE_CURRENT_BINARY_DIR}/NativeFunctions.h)
   target_link_libraries(${lib_name} PRIVATE ${deps})
-  target_link_libraries(${lib_name} INTERFACE ${kernel_lib})
+  if(kernel_lib)
+    target_link_libraries(${lib_name} INTERFACE ${kernel_lib})
+  endif()
 
   target_link_options_shared_lib(${lib_name})
 endfunction()

--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -63,6 +63,20 @@ deps = [
   "portable_kernels",
 ]
 
+[targets.size_test]
+buck_targets = [
+  "//test:size_test",
+]
+filters = [
+  ".cpp$",
+]
+excludes = [
+  "^codegen",
+]
+deps = [
+  "executorch",
+]
+
 [targets.xnnpack_schema]
 buck_targets = [
   "//backends/xnnpack:xnnpack_schema"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# Simple CMake build system for size_test demo.
+#
+# ### Editing this file ###
+#
+# This file should be formatted with
+# ~~~
+# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# ~~~
+# It should also be cmake-lint clean.
+#
+
+cmake_minimum_required(VERSION 3.19)
+set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+# Since extract_sources.py is not returning absolute values, we need to patch
+# the source paths. TODO(larryliu0820): Fix this
+set(_updated_size_test__srcs)
+foreach(_src ${_size_test__srcs})
+  list(APPEND _updated_size_test__srcs "${EXECUTORCH_ROOT}/${_src}")
+endforeach()
+
+#
+# size_test: minimal binary with no ops and no delegate backend
+#
+# TODO(larryliu0820): Add EXECUTORCH_BUILD_EXECUTABLES to not build executable
+# when we cross compile to ios
+add_executable(size_test ${_updated_size_test__srcs})
+target_link_libraries(size_test executorch)
+if(CMAKE_BUILD_TYPE EQUAL "Release")
+  target_link_options(size_test PRIVATE "LINKER:--gc-sections")
+endif()
+
+# Print all summary
+executorch_print_configuration_summary()

--- a/test/build_size_test.sh
+++ b/test/build_size_test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Build size_test and show the size of it
+set -e
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/../.ci/scripts/utils.sh"
+
+test_cmake_size_test() {
+    (rm -rf cmake-out \
+        && mkdir cmake-out \
+        && cd cmake-out \
+        && retry cmake -DBUCK2="$BUCK2" \
+            -DBUILD_SIZE_TEST=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
+
+    echo "Build selective build test"
+    cmake --build cmake-out -j9 --config Release
+
+    echo 'Size of the binary:'
+    ls -al cmake-out/test/size_test
+}
+
+if [[ -z $BUCK2 ]]; then
+  BUCK2=buck2
+fi
+
+if [[ -z $PYTHON_EXECUTABLE ]]; then
+  PYTHON_EXECUTABLE=python3
+fi
+
+test_cmake_size_test


### PR DESCRIPTION
Summary: As titled, adding a new example in selective_build, for selecting no ops.

Repro:
```
cmake -DBUCK2=/tmp/buck2 -DBUILD_SIZE_TEST=ON -DCMAKE_BUILD_TYPE=Release ..
```

Differential Revision: D49336922


