### PR TITLE
[executorch] Rename FileDataLoader::From to ::from

### DIFF
--- a/extension/data_loader/file_data_loader.cpp
+++ b/extension/data_loader/file_data_loader.cpp
@@ -59,7 +59,7 @@ FileDataLoader::~FileDataLoader() {
   ::close(fd_);
 }
 
-Result<FileDataLoader> FileDataLoader::From(
+Result<FileDataLoader> FileDataLoader::from(
     const char* file_name,
     size_t alignment) {
   ET_CHECK_OR_RETURN_ERROR(

--- a/extension/data_loader/file_data_loader.h
+++ b/extension/data_loader/file_data_loader.h
@@ -40,9 +40,16 @@ class FileDataLoader : public DataLoader {
    *     could not be found.
    * @retval Error::MemoryAllocationFailed Internal memory allocation failure.
    */
-  static Result<FileDataLoader> From(
+  static Result<FileDataLoader> from(
       const char* file_name,
       size_t alignment = alignof(std::max_align_t));
+
+  /// DEPRECATED: Use the lowercase `from()` instead.
+  __ET_DEPRECATED static Result<FileDataLoader> From(
+      const char* file_name,
+      size_t alignment = alignof(std::max_align_t)) {
+    return from(file_name, alignment);
+  }
 
   // Movable to be compatible with Result.
   FileDataLoader(FileDataLoader&& rhs) noexcept


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #383
* #382
* __->__ #381

This is a commonly-used method that violates our style guide.

Differential Revision: [D49351745](https://our.internmc.facebook.com/intern/diff/D49351745/)