### PR TITLE
[executorch] Rename MmapDataLoader::From to ::from

### DIFF
--- a/extension/data_loader/mmap_data_loader.cpp
+++ b/extension/data_loader/mmap_data_loader.cpp
@@ -35,7 +35,7 @@ MmapDataLoader::~MmapDataLoader() {
   ::close(fd_);
 }
 
-Result<MmapDataLoader> MmapDataLoader::From(
+Result<MmapDataLoader> MmapDataLoader::from(
     const char* file_name,
     MmapDataLoader::MlockConfig mlock_config) {
   // Cache the page size.

--- a/extension/data_loader/mmap_data_loader.h
+++ b/extension/data_loader/mmap_data_loader.h
@@ -51,16 +51,23 @@ class MmapDataLoader : public DataLoader {
    * @param[in] mlock_config How and whether to lock loaded pages with
    *     `mlock()`.
    */
-  static Result<MmapDataLoader> From(
+  static Result<MmapDataLoader> from(
       const char* file_name,
       MlockConfig mlock_config = MlockConfig::UseMlock);
 
-  /// DEPRECATED: Use the version of `From()` that takes an MlockConfig.
+  /// DEPRECATED: Use the lowercase `from()` instead.
+  __ET_DEPRECATED static Result<MmapDataLoader> From(
+      const char* file_name,
+      MlockConfig mlock_config = MlockConfig::UseMlock) {
+    return from(file_name, mlock_config);
+  }
+
+  /// DEPRECATED: Use the version of `from()` that takes an MlockConfig.
   __ET_DEPRECATED
   static Result<MmapDataLoader> From(const char* file_name, bool use_mlock) {
     MlockConfig mlock_config =
         use_mlock ? MlockConfig::UseMlock : MlockConfig::NoMlock;
-    return From(file_name, mlock_config);
+    return from(file_name, mlock_config);
   }
 
   // Movable to be compatible with Result.

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -244,7 +244,7 @@ inline std::unique_ptr<Module> load_from_buffer(
 inline std::unique_ptr<Module> load_from_file(const std::string& path) {
   EXECUTORCH_SCOPE_PROF("load_from_file");
 
-  Result<MmapDataLoader> res = MmapDataLoader::From(
+  Result<MmapDataLoader> res = MmapDataLoader::from(
       path.c_str(), MmapDataLoader::MlockConfig::UseMlockIgnoreErrors);
   THROW_IF_ERROR(
       res.error(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #383
* #382
* #381

This is a commonly-used method that violates our style guide.

Also update pybindings.cpp, the one place under //executorch that uses this.

Differential Revision: [D49351780](https://our.internmc.facebook.com/intern/diff/D49351780/)