### PR TITLE
[executorch] Split out HierarchicalAllocator tests

### DIFF
--- a/runtime/core/test/hierarchical_allocator_test.cpp
+++ b/runtime/core/test/hierarchical_allocator_test.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <array>
+#include <vector>
+
+#include <executorch/runtime/core/hierarchical_allocator.h>
+#include <executorch/runtime/core/memory_allocator.h>
+#include <executorch/runtime/platform/runtime.h>
+#include <executorch/test/utils/alignment.h>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using torch::executor::Error;
+using torch::executor::HierarchicalAllocator;
+using torch::executor::MemoryAllocator;
+using torch::executor::Result;
+
+class HierarchicalAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Since these tests cause ET_LOG to be called, the PAL must be initialized
+    // first.
+    torch::executor::runtime_init();
+  }
+};
+
+TEST_F(HierarchicalAllocatorTest, Smoke) {
+  constexpr size_t n_allocators = 2;
+  constexpr size_t size0 = 4;
+  constexpr size_t size1 = 8;
+  uint8_t mem0[size0];
+  uint8_t mem1[size1];
+  MemoryAllocator allocators[n_allocators]{
+      MemoryAllocator(size0, mem0), MemoryAllocator(size1, mem1)};
+
+  HierarchicalAllocator allocator(n_allocators, allocators);
+
+  // get_offset_address() success cases
+  {
+    // Total size is 4, so off=0 + size=2 fits.
+    Result<void*> address = allocator.get_offset_address(
+        /*memory_id=*/0, /*offset_bytes=*/0, /*size_bytes=*/2);
+    ASSERT_EQ(address.error(), Error::Ok);
+    ASSERT_NE(address.get(), nullptr);
+    ASSERT_EQ(address.get(), mem0);
+  }
+  {
+    // Total size is 8, so off=4 + size=4 fits exactly.
+    Result<void*> address = allocator.get_offset_address(
+        /*memory_id=*/1, /*offset_bytes=*/4, /*size_bytes=*/4);
+    ASSERT_EQ(address.error(), Error::Ok);
+    ASSERT_NE(address.get(), nullptr);
+    ASSERT_EQ(address.get(), mem1 + 4);
+  }
+
+  // get_offset_address() failure cases
+  {
+    // Total size is 4, so off=0 + size=5 is too large.
+    Result<void*> address = allocator.get_offset_address(
+        /*memory_id=*/0, /*offset_bytes=*/4, /*size_bytes=*/5);
+    ASSERT_FALSE(address.ok());
+    ASSERT_NE(address.error(), Error::Ok);
+  }
+  {
+    // Total size is 4, so off=8 + size=0 is off the end.
+    Result<void*> address = allocator.get_offset_address(
+        /*memory_id=*/0, /*offset_bytes=*/8, /*size_bytes=*/0);
+    ASSERT_FALSE(address.ok());
+    ASSERT_NE(address.error(), Error::Ok);
+  }
+  {
+    // ID too large; only two zero-indexed entries in the allocator.
+    Result<void*> address = allocator.get_offset_address(
+        /*memory_id=*/2, /*offset_bytes=*/0, /*size_bytes=*/2);
+    ASSERT_FALSE(address.ok());
+    ASSERT_NE(address.error(), Error::Ok);
+  }
+}

--- a/runtime/core/test/hierarchical_allocator_test.cpp
+++ b/runtime/core/test/hierarchical_allocator_test.cpp
@@ -6,9 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <array>
-#include <vector>
-
 #include <executorch/runtime/core/hierarchical_allocator.h>
 #include <executorch/runtime/core/memory_allocator.h>
 #include <executorch/runtime/platform/runtime.h>

--- a/runtime/core/test/targets.bzl
+++ b/runtime/core/test/targets.bzl
@@ -74,6 +74,16 @@ def define_common_targets():
     )
 
     runtime.cxx_test(
+        name = "hierarchical_allocator_test",
+        srcs = [
+            "hierarchical_allocator_test.cpp",
+        ],
+        deps = [
+            "//executorch/runtime/core:memory_allocator",
+        ],
+    )
+
+    runtime.cxx_test(
         name = "tensor_shape_dynamism_test_aten",
         srcs = ["tensor_shape_dynamism_test_aten.cpp"],
         deps = [

--- a/runtime/executor/test/targets.bzl
+++ b/runtime/executor/test/targets.bzl
@@ -63,17 +63,15 @@ def define_common_targets(is_fbcode = False):
             "executor_test.cpp",
         ],
         deps = [
-            "//executorch/runtime/core/exec_aten:lib",
-            "//executorch/runtime/core:evalue",
-            "//executorch/runtime/core:core",
-            "//executorch/runtime/platform:platform",
-            "//executorch/runtime/kernel:operator_registry",
-            "//executorch/runtime/executor:executor",
-            "//executorch/kernels/portable:generated_lib",
-            "//executorch/runtime/kernel:kernel_runtime_context",
             "//executorch/extension/pytree:pytree",
+            "//executorch/kernels/portable:generated_lib",  # @manual
+            "//executorch/runtime/core:core",
+            "//executorch/runtime/core:evalue",
+            "//executorch/runtime/core/exec_aten:lib",
+            "//executorch/runtime/kernel:kernel_runtime_context",
+            "//executorch/runtime/kernel:operator_registry",
+            "//executorch/runtime/platform:platform",
             "//executorch/test/utils:utils",
-            "//executorch/util:test_memory_config",
         ],
     )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #403
* #402
* #391
* #390
* #389
* #388
* #387
* __->__ #386

A following diff will modify HierarchicalAllocator and add more tests.

Clean up the headers and deps of `executor_test` while I'm here.

Differential Revision: [D49344930](https://our.internmc.facebook.com/intern/diff/D49344930/)