### PR TITLE
[executorch] Migrate runner-like targets to use the new HierarchicalAllocator span ctor

### DIFF
--- a/examples/bundled_executor_runner/bundled_executor_runner.cpp
+++ b/examples/bundled_executor_runner/bundled_executor_runner.cpp
@@ -154,26 +154,27 @@ int main(int argc, char** argv) {
       MemoryAllocator(kRuntimeMemorySize, runtime_pool)};
   runtime_allocator.enable_profiling("runtime allocator");
 
-  // The non-const allocator is used to provide the memory-planned buffers that
-  // back mutable tensors. Since it was planned ahead of time, the Program knows
-  // how big each of the allocators needs to be.
+  // The non-const buffers will back the mutable tensors used by the method. The
+  // sizes of these buffers were determined ahead of time during the
+  // memory-planning pasees.
   //
-  // These buffers correspond to different hardware memory banks. Most mobile
-  // environments will only have a single buffer. Some embedded environments may
-  // have more than one for, e.g., slow/large DRAM and fast/small SRAM.
+  // Each buffer typically corresponds to a different hardware memory bank. Most
+  // mobile environments will only have a single buffer. Some embedded
+  // environments may have more than one for, e.g., slow/large DRAM and
+  // fast/small SRAM, or for memory associated with particular cores.
   std::vector<std::unique_ptr<uint8_t[]>> non_const_buffers;
-  std::vector<MemoryAllocator> non_const_allocators;
+  std::vector<Span<uint8_t>> non_const_spans;
   size_t num_non_const_buffers = method_meta->num_non_const_buffers();
   for (size_t id = 0; id < num_non_const_buffers; ++id) {
-    size_t buffer_size = method_meta->non_const_buffer_size(id).get();
+    // .get() will always succeed because id < num_non_const_buffers.
+    size_t buffer_size =
+        static_cast<size_t>(method_meta->non_const_buffer_size(id).get());
     ET_LOG(Info, "Setting up non-const buffer %zu, size %zu.", id, buffer_size);
     non_const_buffers.push_back(std::make_unique<uint8_t[]>(buffer_size));
-    non_const_allocators.push_back(
-        MemoryAllocator(buffer_size, non_const_buffers.back().get()));
-    non_const_allocators.back().enable_profiling("non_const_allocators");
+    non_const_spans.push_back({non_const_buffers.back().get(), buffer_size});
   }
   HierarchicalAllocator non_const_allocator(
-      non_const_allocators.size(), non_const_allocators.data());
+      {non_const_spans.data(), non_const_spans.size()});
 
   // Allocator for bundled input.
   MemoryAllocator bundled_input_allocator{

--- a/sdk/runners/executor_runner.cpp
+++ b/sdk/runners/executor_runner.cpp
@@ -264,26 +264,27 @@ int main(int argc, char** argv) {
       MemoryAllocator(kRuntimeMemorySize, runtime_pool)};
   runtime_allocator.enable_profiling("runtime allocator");
 
-  // The non-const allocator is used to provide the memory-planned buffers that
-  // back mutable tensors. Since it was planned ahead of time, the Program knows
-  // how big each of the allocators needs to be.
+  // The non-const buffers will back the mutable tensors used by the method. The
+  // sizes of these buffers were determined ahead of time during the
+  // memory-planning pasees.
   //
-  // These buffers correspond to different hardware memory banks. Most mobile
-  // environments will only have a single buffer. Some embedded environments may
-  // have more than one for, e.g., slow/large DRAM and fast/small SRAM.
+  // Each buffer typically corresponds to a different hardware memory bank. Most
+  // mobile environments will only have a single buffer. Some embedded
+  // environments may have more than one for, e.g., slow/large DRAM and
+  // fast/small SRAM, or for memory associated with particular cores.
   std::vector<std::unique_ptr<uint8_t[]>> non_const_buffers;
-  std::vector<MemoryAllocator> non_const_allocators;
+  std::vector<Span<uint8_t>> non_const_spans;
   size_t num_non_const_buffers = method_meta->num_non_const_buffers();
   for (size_t id = 0; id < num_non_const_buffers; ++id) {
-    size_t buffer_size = method_meta->non_const_buffer_size(id).get();
+    // .get() will always succeed because id < num_non_const_buffers.
+    size_t buffer_size =
+        static_cast<size_t>(method_meta->non_const_buffer_size(id).get());
     ET_LOG(Info, "Setting up non-const buffer %zu, size %zu.", id, buffer_size);
     non_const_buffers.push_back(std::make_unique<uint8_t[]>(buffer_size));
-    non_const_allocators.push_back(
-        MemoryAllocator(buffer_size, non_const_buffers.back().get()));
-    non_const_allocators.back().enable_profiling("non_const_allocators");
+    non_const_spans.push_back({non_const_buffers.back().get(), buffer_size});
   }
   HierarchicalAllocator non_const_allocator(
-      non_const_allocators.size(), non_const_allocators.data());
+      {non_const_spans.data(), non_const_spans.size()});
 
   // The constant allocator is not currently used. Please initialize with a
   // zero-sized allocator.

--- a/test/size_test.cpp
+++ b/test/size_test.cpp
@@ -39,12 +39,8 @@ int main(int argc, char** argv) {
   MemoryAllocator temp_allocator{MemoryAllocator(0, nullptr)};
   temp_allocator.enable_profiling("temp allocator");
 
-  MemoryAllocator non_const_allocators[1]{
-      MemoryAllocator(kMemoryAmount, activation_pool)};
-  non_const_allocators[0].enable_profiling("non_const_allocators");
-
-  HierarchicalAllocator non_const_allocator{
-      HierarchicalAllocator(1, non_const_allocators)};
+  Span<uint8_t> non_const_buffers[1]{{activation_pool, kMemoryAmount}};
+  HierarchicalAllocator non_const_allocator({non_const_buffers, 1});
 
   MemoryManager memory_manager{MemoryManager(
       &const_allocator,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #403
* #402
* #391
* #390
* #389
* __->__ #388
* #387
* #386

Stop using the deprecated HierarchicalAllocator ctor.

Differential Revision: [D49344926](https://our.internmc.facebook.com/intern/diff/D49344926/)