### PR TITLE
[executorch] Migrate ExecutorchModule.mm to use the new HierarchicalAllocator span ctor

### DIFF
--- a/examples/ios_demo_apps/ExecutorchMobileNet/ExecutorchMobileNet/ExecutorchMobileNet/ExecutorchModule.mm
+++ b/examples/ios_demo_apps/ExecutorchMobileNet/ExecutorchMobileNet/ExecutorchMobileNet/ExecutorchModule.mm
@@ -162,12 +162,8 @@ std::vector<std::string> get_image_net_classes() {
   MemoryAllocator temp_allocator{MemoryAllocator(0, nullptr)};
   temp_allocator.enable_profiling("temp allocator");
 
-  MemoryAllocator non_const_allocators[1]{
-      MemoryAllocator(kMemoryAmount, activation_pool)};
-  non_const_allocators[0].enable_profiling("non_const_allocators");
-
-  HierarchicalAllocator non_const_allocator{
-      HierarchicalAllocator(1, non_const_allocators)};
+  Span<uint8_t> non_const_buffers[1]{{activation_pool, kMemoryAmount}};
+  HierarchicalAllocator non_const_allocator({non_const_buffers, 1});
 
   MemoryManager memory_manager{MemoryManager(
       &const_allocator,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #403
* #402
* __->__ #391
* #390
* #389
* #388
* #387
* #386

Stop using the deprecated HierarchicalAllocator ctor.

Differential Revision: [D49344927](https://our.internmc.facebook.com/intern/diff/D49344927/)