### PR TITLE
fix nonzero upper bound

### DIFF
--- a/exir/passes/sym_shape_eval_pass.py
+++ b/exir/passes/sym_shape_eval_pass.py
@@ -29,7 +29,7 @@ def register_upper_bound_inference(fn):
 @register_upper_bound_inference(exir_ops.edge.aten.nonzero.default)
 @register_upper_bound_inference(torch.ops.aten.nonzero.default)
 def nonzero(args, kwargs) -> List[Optional[int]]:
-    return [eval_expr(args[0].shape[0]), len(args[0].shape)]
+    return [eval_expr(args[0].numel()), len(args[0].shape)]
 
 
 class HintBasedSymShapeEvalPass(PassBase):


### PR DESCRIPTION
Summary: If nonzero's input has `n` dimensions, then the resulting output tensor is of size `(z, n)`, where `z` is the total number of non-zero elements in the input tensor. Therefore, an upper bound for out's shape is [input.numel(), input.dim()]

Reviewed By: ydwu4

Differential Revision: D49342476


