### PR TITLE
support multimethod by method name runtime

### DIFF
--- a/bundled_program/schema.py
+++ b/bundled_program/schema.py
@@ -73,6 +73,11 @@ class BundledIOSet:
 class BundledExecutionPlanTest:
     """Context for testing and verifying an exceution plan."""
 
+    # The name of the method to test; e.g., "forward" for the forward() method
+    # of an nn.Module. This name match a method defined by the ExecuTorch
+    # program.
+    method_name: str
+
     # Sets of input/outputs to test with.
     test_sets: List[BundledIOSet]
 

--- a/bundled_program/tests/common.py
+++ b/bundled_program/tests/common.py
@@ -12,7 +12,6 @@ from typing import List, Tuple, Union
 import executorch.exir as exir
 import torch
 from executorch.bundled_program.config import BundledConfig
-from executorch.exir import CaptureConfig
 from executorch.exir.schema import Program
 
 # @manual=fbsource//third-party/pypi/typing-extensions:typing-extensions

--- a/bundled_program/tests/test_bundle_data.py
+++ b/bundled_program/tests/test_bundle_data.py
@@ -53,6 +53,7 @@ class TestBundle(unittest.TestCase):
         for plan_id in range(len(program.execution_plan)):
             bundled_plan_test = bundled_program.execution_plan_tests[plan_id]
             config_plan_test = bundled_config.execution_plan_tests[plan_id]
+
             self.assertEqual(
                 len(bundled_plan_test.test_sets), len(config_plan_test.test_sets)
             )
@@ -68,3 +69,19 @@ class TestBundle(unittest.TestCase):
                 )
 
         self.assertEqual(bundled_program.program, _serialize_pte_binary(program))
+
+    def test_bundled_miss_methods(self) -> None:
+        program, bundled_config = get_common_program()
+
+        # only keep the testcases for the first method to mimic the case that user only creates testcases for the first method.
+        bundled_config.execution_plan_tests = bundled_config.execution_plan_tests[:1]
+
+        _ = create_bundled_program(program, bundled_config)
+
+    def test_bundled_wrong_method_name(self) -> None:
+        program, bundled_config = get_common_program()
+
+        bundled_config.execution_plan_tests[-1].method_name = "wrong_method_name"
+        self.assertRaises(
+            AssertionError, create_bundled_program, program, bundled_config
+        )

--- a/schema/bundled_program_schema.fbs
+++ b/schema/bundled_program_schema.fbs
@@ -10,7 +10,7 @@ include "scalar_type.fbs";
 namespace executorch_flatbuffer;
 
 // Identifier of a valid bundled program schema.
-file_identifier "BP05";
+file_identifier "BP06";
 // Extension of written files.
 file_extension "bp";
 
@@ -65,6 +65,11 @@ table BundledIOSet {
 
 // Context for testing and verifying an exceution plan.
 table BundledExecutionPlanTest {
+
+  // The name of the method to test; e.g., "forward" for the forward() method
+  // of an nn.Module. This name match a method defined by the ExecuTorch
+  // program.
+  method_name: string;
 
   // Sets of input/outputs to test with.
   test_sets: [BundledIOSet];

--- a/sdk/runners/executor_runner.cpp
+++ b/sdk/runners/executor_runner.cpp
@@ -75,6 +75,11 @@ DEFINE_string(
 
 DEFINE_int32(num_threads, 1, "Number of threads to use.");
 
+DEFINE_string(
+    method_name,
+    "forward",
+    "Name of method to run. Only used by bundled program mode.");
+
 DEFINE_int32(
     testset_idx,
     0,
@@ -347,7 +352,7 @@ int main(int argc, char** argv) {
           *method,
           program_data.bundled_program_data(),
           &bundled_input_allocator,
-          method_index,
+          method_name,
           FLAGS_testset_idx);
       ET_CHECK_MSG(
           status == Error::Ok,
@@ -376,7 +381,7 @@ int main(int argc, char** argv) {
           *method,
           program_data.bundled_program_data(),
           &bundled_input_allocator,
-          method_index,
+          method_name,
           FLAGS_testset_idx,
           FLAGS_rtol,
           FLAGS_atol);

--- a/test/end2end/test_end2end.py
+++ b/test/end2end/test_end2end.py
@@ -594,6 +594,9 @@ def maketest(
             ]
             bundled_config = BundledConfig(
                 [
+                    method,
+                ],
+                [
                     inputs_list,
                 ],
                 expected_outputs_list,

--- a/test/models/generate_linear_out_bundled_program.py
+++ b/test/models/generate_linear_out_bundled_program.py
@@ -70,7 +70,9 @@ def main() -> None:
         for i in range(len(program.execution_plan))
     ]
 
-    bundled_config = BundledConfig(bundled_inputs, bundled_expected_outputs)
+    bundled_config = BundledConfig(
+        ["forward"], bundled_inputs, bundled_expected_outputs
+    )
 
     bundled_program = create_bundled_program(program, bundled_config)
     pretty_print(bundled_program)

--- a/util/bundled_program_verification.h
+++ b/util/bundled_program_verification.h
@@ -26,7 +26,7 @@ using serialized_bundled_program = const void;
  *
  * @param[in] method The Method to verify.
  * @param[in] bundled_program_ptr The bundled program contains expected output.
- * @param[in] method_idx  The index of the Method being verified.
+ * @param[in] method_name  The name of the Method being verified.
  * @param[in] testset_idx  The index of input needs to be set into given Method.
  *
  * @returns Return Error::Ok if load successfully, or the error happens during
@@ -36,7 +36,7 @@ __ET_NODISCARD Error LoadBundledInput(
     Method& method,
     serialized_bundled_program* bundled_program_ptr,
     MemoryAllocator* memory_allocator,
-    size_t method_idx,
+    const char* method_name,
     size_t testset_idx);
 
 /**
@@ -45,7 +45,7 @@ __ET_NODISCARD Error LoadBundledInput(
  *
  * @param[in] method The Method to extract outputs from.
  * @param[in] bundled_program_ptr The bundled program contains expected output.
- * @param[in] method_idx  The index of the Method being verified.
+ * @param[in] method_name  The name of the Method being verified.
  * @param[in] testset_idx  The index of expected output needs to be compared.
  * @param[in] rtol Relative tolerance used for data comparsion.
  * @param[in] atol Absolute tolerance used for data comparsion.
@@ -57,7 +57,7 @@ __ET_NODISCARD Error VerifyResultWithBundledExpectedOutput(
     Method& method,
     serialized_bundled_program* bundled_program_ptr,
     MemoryAllocator* memory_allocator,
-    size_t method_idx,
+    const char* method_name,
     size_t testset_idx,
     double rtol = 1e-5,
     double atol = 1e-8);


### PR DESCRIPTION
Summary:
Update runtime apis to support multimethod based on method name instead of method index
Since the following diffs will reformat the AOT apis, this diff doesn't pay much effort on documentation stuff.

Differential Revision: D49335926

