### PR TITLE
end2end test for bundled program

### DIFF
--- a/bundled_program/core.py
+++ b/bundled_program/core.py
@@ -136,32 +136,56 @@ def assert_valid_bundle(
 
     """
 
-    # Check the number of execution plan tests
-    assert len(bundled_config.execution_plan_tests) == len(
-        program.execution_plan
-    ), "The length of execution_plan_tests in config should match the length of execution_plan in program, but get {} and {}.".format(
-        len(bundled_config.execution_plan_tests), len(program.execution_plan)
-    )
+    program_plan_id = 0
+    bp_plan_id = 0
+
+    method_name_of_program = {e.name for e in program.execution_plan}
+    method_name_of_test_suites = {
+        t.method_name for t in bundled_config.execution_plan_tests
+    }
+
+    assert method_name_of_test_suites.issubset(
+        method_name_of_program
+    ), f"All methods in method_test_suites should be found in program.execution_plan, \
+         but {str(method_name_of_test_suites - method_name_of_program)} does not include."
+
+    # check if method_tesdt_suites has been sorted in ascending alphabetical order of method name.
+    for bp_plan_id in range(1, len(bundled_config.execution_plan_tests)):
+        assert (
+            bundled_config.execution_plan_tests[bp_plan_id - 1].method_name
+            <= bundled_config.execution_plan_tests[bp_plan_id].method_name
+        ), f"The method name of test suite should be sorted in ascending alphabetical \
+            order of method name, but {bp_plan_id-1}-th and {bp_plan_id}-th method_test_suite aren't."
 
     # Check if the inputs' type meet Program's requirement
-    for plan_id in range(len(program.execution_plan)):
-        plan_test: ConfigExecutionPlanTest = bundled_config.execution_plan_tests[
-            plan_id
-        ]
+    while bp_plan_id < len(bundled_config.execution_plan_tests):
 
-        plan: ExecutionPlan = program.execution_plan[plan_id]
+        plan_test: ConfigExecutionPlanTest = bundled_config.execution_plan_tests[
+            bp_plan_id
+        ]
+        plan: ExecutionPlan = program.execution_plan[program_plan_id]
+
+        # User does not provide testcases for current plan, skip it
+        if plan_test.method_name > plan.name:
+            program_plan_id += 1
+            continue
+
+        # Check if the method name in user provided test matches the one in the original program
+        assert (
+            plan_test.method_name == plan.name
+        ), f"BundledConfig has testcases for method {plan_test.method_name}, but can not find it in the given program. All method names in the program are {', '.join([p.name for p in program.execution_plan])}."
 
         # Check if the type of Program's input is supported
         for index in range(len(plan.inputs)):
             assert (
-                type(get_program_input(program, plan_id, index))
+                type(get_program_input(program, program_plan_id, index))
                 in supported_program_type_table
             ), "The type of program's input isn't supported."
 
         # Check if the type of Program's output is supported
         for index in range(len(plan.outputs)):
             assert (
-                type(get_program_output(program, plan_id, index)) == Tensor
+                type(get_program_output(program, program_plan_id, index)) == Tensor
             ), "Only supports program with output in Tensor type."
 
         # Check if the I/O sets of each execution plan test match program's requirement.
@@ -181,14 +205,14 @@ def assert_valid_bundle(
                 assert (
                     type(cur_plan_test_inputs[j])
                     == supported_program_type_table[
-                        type(get_program_input(program, plan_id, j))
+                        type(get_program_input(program, program_plan_id, j))
                     ]
                 ), "The type {}-th input in {}-th test set of {}-th execution plan does not meet Program's requirement: expected {} but get {}".format(
                     j,
                     i,
-                    plan_id,
+                    program_plan_id,
                     supported_program_type_table[
-                        type(get_program_input(program, plan_id, j))
+                        type(get_program_input(program, program_plan_id, j))
                     ],
                     type(cur_plan_test_inputs[j]),
                 )
@@ -198,10 +222,10 @@ def assert_valid_bundle(
                     # pyre-fixme[16]: Undefined attribute [16]: Item `bool` of `typing.Union[bool, float, int, torch._tensor.Tensor]`
                     # has no attribute `dtype`.
                     assert cur_plan_test_inputs[j].dtype == get_input_dtype(
-                        program, plan_id, j
+                        program, program_plan_id, j
                     ), "The input tensor {} dtype shall be {}, but now is {}".format(
                         cur_plan_test_inputs[j],
-                        get_input_dtype(program, plan_id, j),
+                        get_input_dtype(program, program_plan_id, j),
                         cur_plan_test_inputs[j].dtype,
                     )
                 elif type(cur_plan_test_inputs[j]) in (
@@ -210,9 +234,9 @@ def assert_valid_bundle(
                     float,
                 ):
                     assert type(cur_plan_test_inputs[j]) == get_input_type(
-                        program, plan_id, j
+                        program, program_plan_id, j
                     ), "The input primitive dtype shall be {}, but now is {}".format(
-                        get_input_type(program, plan_id, j),
+                        get_input_type(program, program_plan_id, j),
                         type(cur_plan_test_inputs[j]),
                     )
 
@@ -221,12 +245,15 @@ def assert_valid_bundle(
                 # pyre-fixme[16]: Undefined attribute [16]: Item `bool` of `typing.Union[bool, float, int, torch._tensor.Tensor]`
                 # has no attribute `dtype`.
                 assert cur_plan_test_expected_outputs[j].dtype == get_output_dtype(
-                    program, plan_id, j
+                    program, program_plan_id, j
                 ), "The label tensor {} dtype shall be {}, but now is {}".format(
                     cur_plan_test_expected_outputs[j],
-                    get_output_dtype(program, plan_id, j),
+                    get_output_dtype(program, program_plan_id, j),
                     cur_plan_test_expected_outputs[j].dtype,
                 )
+
+        program_plan_id += 1
+        bp_plan_id += 1
 
 
 def create_bundled_program(
@@ -245,10 +272,7 @@ def create_bundled_program(
     execution_plan_tests: List[BundledExecutionPlanTest] = []
 
     # Emit data and metadata of bundled tensor
-    for plan_id in range(len(program.execution_plan)):
-        plan_test: ConfigExecutionPlanTest = bundled_config.execution_plan_tests[
-            plan_id
-        ]
+    for plan_test in bundled_config.execution_plan_tests:
         test_sets: List[BundledIOSet] = []
 
         # emit I/O sets for each execution plan test
@@ -283,7 +307,11 @@ def create_bundled_program(
             )
 
         # emit the whole execution plan test
-        execution_plan_tests.append(BundledExecutionPlanTest(test_sets=test_sets))
+        execution_plan_tests.append(
+            BundledExecutionPlanTest(
+                method_name=plan_test.method_name, test_sets=test_sets
+            )
+        )
 
     program_bytes: bytes = _serialize_pte_binary(program)
 

--- a/bundled_program/schema.py
+++ b/bundled_program/schema.py
@@ -73,6 +73,11 @@ class BundledIOSet:
 class BundledExecutionPlanTest:
     """Context for testing and verifying an exceution plan."""
 
+    # The name of the method to test; e.g., "forward" for the forward() method
+    # of an nn.Module. This name match a method defined by the ExecuTorch
+    # program.
+    method_name: str
+
     # Sets of input/outputs to test with.
     test_sets: List[BundledIOSet]
 

--- a/bundled_program/tests/TARGETS
+++ b/bundled_program/tests/TARGETS
@@ -1,3 +1,5 @@
+# @noautodeps
+
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 
@@ -56,5 +58,35 @@ python_unittest(
         "//caffe2:torch",
         "//executorch/bundled_program:config",
         "//executorch/extension/pytree:pylib",
+    ],
+)
+
+python_unittest(
+    name = "end2end",
+    srcs = [
+        "test_end2end.py",
+    ],
+    deps = [
+        ":lib",
+        "//caffe2:torch",
+        "//executorch/bundled_program:config",
+        "//executorch/bundled_program:core",
+        "//executorch/bundled_program/serialize:lib",
+        "//executorch/exir:dynamic_shape",
+        "//executorch/exir:lib",
+        "//executorch/exir:memory",
+        "//executorch/exir:pass_manager",
+        "//executorch/exir:print_program",
+        "//executorch/exir:tensor",
+        "//executorch/exir/_serialize:lib",
+        "//executorch/exir/emit:lib",
+        "//executorch/exir/passes:lib",
+        "//executorch/exir/tests:control_flow_models",
+        "//executorch/exir/tests:dynamic_shape_models",
+        "//executorch/exir/tests:models",
+        "//executorch/exir/tests:transformer",
+        "//executorch/extension/pybindings:portable_lib",
+        "//executorch/extension/pytree:pybindings",
+        "//executorch/kernels/portable:custom_ops_generated_lib",
     ],
 )

--- a/bundled_program/tests/common.py
+++ b/bundled_program/tests/common.py
@@ -12,7 +12,6 @@ from typing import List, Tuple, Union
 import executorch.exir as exir
 import torch
 from executorch.bundled_program.config import BundledConfig
-from executorch.exir import CaptureConfig
 from executorch.exir.schema import Program
 
 # @manual=fbsource//third-party/pypi/typing-extensions:typing-extensions

--- a/bundled_program/tests/test_bundle_data.py
+++ b/bundled_program/tests/test_bundle_data.py
@@ -53,6 +53,7 @@ class TestBundle(unittest.TestCase):
         for plan_id in range(len(program.execution_plan)):
             bundled_plan_test = bundled_program.execution_plan_tests[plan_id]
             config_plan_test = bundled_config.execution_plan_tests[plan_id]
+
             self.assertEqual(
                 len(bundled_plan_test.test_sets), len(config_plan_test.test_sets)
             )
@@ -68,3 +69,19 @@ class TestBundle(unittest.TestCase):
                 )
 
         self.assertEqual(bundled_program.program, _serialize_pte_binary(program))
+
+    def test_bundled_miss_methods(self) -> None:
+        program, bundled_config = get_common_program()
+
+        # only keep the testcases for the first method to mimic the case that user only creates testcases for the first method.
+        bundled_config.execution_plan_tests = bundled_config.execution_plan_tests[:1]
+
+        _ = create_bundled_program(program, bundled_config)
+
+    def test_bundled_wrong_method_name(self) -> None:
+        program, bundled_config = get_common_program()
+
+        bundled_config.execution_plan_tests[-1].method_name = "wrong_method_name"
+        self.assertRaises(
+            AssertionError, create_bundled_program, program, bundled_config
+        )

--- a/bundled_program/tests/test_end2end.py
+++ b/bundled_program/tests/test_end2end.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# flake8: noqa: F401
+import functools
+import inspect
+import os
+import random
+import unittest
+from typing import Callable, Dict, Optional, Tuple, Type
+
+import executorch.exir as exir
+
+import executorch.exir.control_flow as control_flow
+
+# @manual=//executorch/extension/pytree:pybindings
+import executorch.extension.pytree as pytree
+
+import torch
+from executorch.bundled_program.config import BundledConfig
+
+from executorch.bundled_program.core import create_bundled_program
+from executorch.bundled_program.serialize import (
+    serialize_from_bundled_program_to_flatbuffer,
+)
+
+from executorch.bundled_program.tests.common import get_common_program, SampleModel
+
+kernel_mode = None  # either aten mode or lean mode
+try:
+    # pyre-ignore[21]
+    from executorch.extension.pybindings.portable_lib import (
+        _load_bundled_program_from_buffer,
+        _load_for_executorch_from_buffer,
+        _load_for_executorch_from_bundled_program,
+    )
+
+    kernel_mode = "lean"
+except ImportError as e:
+    print(e)
+    pass
+
+try:
+    # pyre-ignore[21]
+    from executorch.extension.pybindings.aten_lib import (
+        _load_bundled_program_from_buffer,
+        _load_for_executorch_from_buffer,
+        _load_for_executorch_from_bundled_program,
+    )
+
+    assert kernel_mode is None
+    kernel_mode = "aten"
+except ImportError as e:
+    print(e)
+    pass
+
+assert kernel_mode is not None
+
+
+class BundledProgramE2ETest(unittest.TestCase):
+    def test_sample_model_e2e(self):
+        program, bundled_config = get_common_program()
+        eager_model = SampleModel()
+
+        bundled_program = create_bundled_program(program, bundled_config)
+
+        bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
+            bundled_program
+        )
+
+        executorch_bundled_program = _load_bundled_program_from_buffer(
+            bundled_program_buffer
+        )
+
+        executorch_module = _load_for_executorch_from_bundled_program(
+            executorch_bundled_program
+        )
+
+        for method_name in eager_model.method_names:
+            executorch_module.load_bundled_input(
+                executorch_bundled_program,
+                method_name,
+                0,
+            )
+            executorch_module.plan_execute(method_name)
+            executorch_module.verify_result_with_bundled_expected_output(
+                executorch_bundled_program,
+                method_name,
+                0,
+            )

--- a/schema/bundled_program_schema.fbs
+++ b/schema/bundled_program_schema.fbs
@@ -10,7 +10,7 @@ include "scalar_type.fbs";
 namespace executorch_flatbuffer;
 
 // Identifier of a valid bundled program schema.
-file_identifier "BP05";
+file_identifier "BP06";
 // Extension of written files.
 file_extension "bp";
 
@@ -65,6 +65,11 @@ table BundledIOSet {
 
 // Context for testing and verifying an exceution plan.
 table BundledExecutionPlanTest {
+
+  // The name of the method to test; e.g., "forward" for the forward() method
+  // of an nn.Module. This name match a method defined by the ExecuTorch
+  // program.
+  method_name: string;
 
   // Sets of input/outputs to test with.
   test_sets: [BundledIOSet];

--- a/sdk/runners/executor_runner.cpp
+++ b/sdk/runners/executor_runner.cpp
@@ -75,6 +75,11 @@ DEFINE_string(
 
 DEFINE_int32(num_threads, 1, "Number of threads to use.");
 
+DEFINE_string(
+    method_name,
+    "forward",
+    "Name of method to run. Only used by bundled program mode.");
+
 DEFINE_int32(
     testset_idx,
     0,
@@ -347,7 +352,7 @@ int main(int argc, char** argv) {
           *method,
           program_data.bundled_program_data(),
           &bundled_input_allocator,
-          method_index,
+          method_name,
           FLAGS_testset_idx);
       ET_CHECK_MSG(
           status == Error::Ok,
@@ -376,7 +381,7 @@ int main(int argc, char** argv) {
           *method,
           program_data.bundled_program_data(),
           &bundled_input_allocator,
-          method_index,
+          method_name,
           FLAGS_testset_idx,
           FLAGS_rtol,
           FLAGS_atol);

--- a/test/end2end/test_end2end.py
+++ b/test/end2end/test_end2end.py
@@ -594,6 +594,9 @@ def maketest(
             ]
             bundled_config = BundledConfig(
                 [
+                    method,
+                ],
+                [
                     inputs_list,
                 ],
                 expected_outputs_list,

--- a/test/models/generate_linear_out_bundled_program.py
+++ b/test/models/generate_linear_out_bundled_program.py
@@ -70,7 +70,9 @@ def main() -> None:
         for i in range(len(program.execution_plan))
     ]
 
-    bundled_config = BundledConfig(bundled_inputs, bundled_expected_outputs)
+    bundled_config = BundledConfig(
+        ["forward"], bundled_inputs, bundled_expected_outputs
+    )
 
     bundled_program = create_bundled_program(program, bundled_config)
     pretty_print(bundled_program)

--- a/util/bundled_program_verification.h
+++ b/util/bundled_program_verification.h
@@ -26,7 +26,7 @@ using serialized_bundled_program = const void;
  *
  * @param[in] method The Method to verify.
  * @param[in] bundled_program_ptr The bundled program contains expected output.
- * @param[in] method_idx  The index of the Method being verified.
+ * @param[in] method_name  The name of the Method being verified.
  * @param[in] testset_idx  The index of input needs to be set into given Method.
  *
  * @returns Return Error::Ok if load successfully, or the error happens during
@@ -36,7 +36,7 @@ __ET_NODISCARD Error LoadBundledInput(
     Method& method,
     serialized_bundled_program* bundled_program_ptr,
     MemoryAllocator* memory_allocator,
-    size_t method_idx,
+    const char* method_name,
     size_t testset_idx);
 
 /**
@@ -45,7 +45,7 @@ __ET_NODISCARD Error LoadBundledInput(
  *
  * @param[in] method The Method to extract outputs from.
  * @param[in] bundled_program_ptr The bundled program contains expected output.
- * @param[in] method_idx  The index of the Method being verified.
+ * @param[in] method_name  The name of the Method being verified.
  * @param[in] testset_idx  The index of expected output needs to be compared.
  * @param[in] rtol Relative tolerance used for data comparsion.
  * @param[in] atol Absolute tolerance used for data comparsion.
@@ -57,7 +57,7 @@ __ET_NODISCARD Error VerifyResultWithBundledExpectedOutput(
     Method& method,
     serialized_bundled_program* bundled_program_ptr,
     MemoryAllocator* memory_allocator,
-    size_t method_idx,
+    const char* method_name,
     size_t testset_idx,
     double rtol = 1e-5,
     double atol = 1e-8);


### PR DESCRIPTION
Summary:
Update pybinding functions to support bundled program (bp) APIs with method name. Split the end2end test for bp into a single test file.

The reasonsfor spliting are:
1. Current overall end2end test does not support multiple methods, but we need to test bp on multiple methods.
2. Bp does not need to be tested on several different kinds of program.
3. Decompose the test for core ET and Bp.

Differential Revision: D49336485

