### PR TITLE
Add event_tracer pointer to delegate backend context

### DIFF
--- a/runtime/backend/backend_execution_context.h
+++ b/runtime/backend/backend_execution_context.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <executorch/runtime/core/event_tracer.h>
+
 namespace torch {
 namespace executor {
 
@@ -16,7 +18,23 @@ namespace executor {
  * The current plan is to add temp allocator and event tracer (for profiling) as
  * part of the runtime context.
  */
-class BackendExecutionContext final {};
+class BackendExecutionContext final {
+ public:
+  BackendExecutionContext(EventTracer* event_tracer = nullptr)
+      : event_tracer_(event_tracer) {}
+
+  /**
+   * Returns a pointer to an instance of EventTracer to do profiling/debugging
+   * logging inside the delegate backend. Users will need access to this pointer
+   * to use any of the event tracer APIs.
+   */
+  EventTracer* event_tracer() {
+    return event_tracer_;
+  }
+
+ private:
+  EventTracer* event_tracer_ = nullptr;
+};
 
 } // namespace executor
 } // namespace torch

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -952,7 +952,7 @@ Error Method::execute_instruction() {
           delegate_idx,
           n_delegate_,
           step_state_.instr_idx);
-      BackendExecutionContext backend_execution_context;
+      BackendExecutionContext backend_execution_context(event_tracer_);
       Error err = delegates_[delegate_idx].Execute(
           backend_execution_context,
           chain.argument_lists_[step_state_.instr_idx].data());

--- a/runtime/kernel/kernel_runtime_context.h
+++ b/runtime/kernel/kernel_runtime_context.h
@@ -65,7 +65,7 @@ class KernelRuntimeContext {
   // TODO(T147221312): Add a way to resize a tensor.
 
  private:
-  EventTracer* event_tracer_;
+  EventTracer* event_tracer_ = nullptr;
   Error failure_state_ = Error::Ok;
 };
 


### PR DESCRIPTION
Summary: Adding `event_tracer` pointer to delegate backend context which backend authors can access for logging/profiling in their backend.

Reviewed By: cccclai

Differential Revision: D49422536

