### PR TITLE
enable vit quantization

### DIFF
--- a/examples/recipes/xnnpack_optimization/models.py
+++ b/examples/recipes/xnnpack_optimization/models.py
@@ -24,4 +24,5 @@ MODEL_NAME_TO_OPTIONS = {
     ),  # TODO[T163161310]: takes a long time to export to exec prog and save inception_v4 quantized model
     "w2l": OptimizationOptions(False, True),
     "dl3": OptimizationOptions(True, False),
+    "vit": OptimizationOptions(True, False),
 }


### PR DESCRIPTION
Summary: After 0919 nightly of pytorch vit linear layers should be quantized

Differential Revision: D49438891


