### PR TITLE
[executorch] Make docs build less flaky

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -45,6 +45,10 @@ jobs:
         cd ..
 
         cp -rf docs/_build/html/* "${RUNNER_DOCS_DIR}"
+
+        # Sometimes the artifact directory already contains an "html" subdir.
+        rm -rf "${RUNNER_ARTIFACT_DIR}/html"
+
         mv docs/_build/html "${RUNNER_ARTIFACT_DIR}"
 
 # Enable preview later. Previews are available publicly


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #420

The docs build sometimes fails with an error like

```
mv docs/_build/html /artifacts
mv: inter-device move failed: 'docs/_build/html' to '/artifacts/html'; unable to remove target: Directory not empty
```
(from https://github.com/pytorch/executorch/actions/runs/6251991315/job/16974762713#step:11:209)

Update the script to force-remove any existing `/artifacts/html` directory before copying, which should avoid this error.

Differential Revision: [D49466514](https://our.internmc.facebook.com/intern/diff/D49466514/)