### PR TITLE
Fix broken unit tests and timeout for deeplabv3

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -47,7 +47,7 @@ jobs:
       docker-image: executorch-ubuntu-22.04-clang12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      timeout: 60
+      timeout: 90
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
@@ -73,7 +73,7 @@ jobs:
       runner: macos-m1-12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      timeout: 60
+      timeout: 90
       script: |
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,9 @@ exir/_serialize/program.fbs
 bundled_program/serialize/bundled_program_schema.fbs
 bundled_program/serialize/scalar_type.fbs
 
-# Any exported models
+# Any exported models and profiling outputs
 *.pte
+*.bin
 
 # Editor temporaries
 *.swa

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,7 +32,7 @@ addopts =
     exir/tests/test_tensor.py
     exir/tests/test_quant_lowering_custom_backend_pass.py
     # kernels/
-    kernels/prim_ops/test/test_prim_ops.py
+    kernels/prim_ops/test/prim_ops_test.py
     kernels/test/test_case_gen.py
     # backends/tosa
     backends/tosa/test


### PR DESCRIPTION
Some fixes to make trunk green again:

* https://github.com/pytorch/executorch/pull/349 rename a test. This is the quick mitigation, we will need a better test discovery mechanism here
* Increase the timeout from 60m to 90m for deeplabv3.  Again, this is also a quick fix.  As this model will be the long pole on OSS CI.  There are more powerful runner to use if that helps.