### PR TITLE
Enable quantization for inception_v3

### DIFF
--- a/examples/recipes/xnnpack_optimization/models.py
+++ b/examples/recipes/xnnpack_optimization/models.py
@@ -19,6 +19,7 @@ MODEL_NAME_TO_OPTIONS = {
     "add_mul": OptimizationOptions(True, True),
     "mv2": OptimizationOptions(True, True),
     "mv3": OptimizationOptions(False, True),
+    "ic3": OptimizationOptions(True, False),
     "ic4": OptimizationOptions(
         True, False
     ),  # TODO[T163161310]: takes a long time to export to exec prog and save inception_v4 quantized model


### PR DESCRIPTION
Summary:
quantized model: https://www.internalfb.com/intern/everpaste/?handle=GFU5kxapMcFIxvgCAN39FPLWemAibsIXAAAB

Note: this diverges from fx quant since we quantize mul op with Scalar inputs in different ways, and xnnpack quantizer won't align with the old flow

xnnpack: differnt input and output qparams
qnnpack in fx: same input and output qparams

Differential Revision: D49474108


