### PR TITLE
The number of inputs given to exported program should be 2 not 3.

### DIFF
--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -284,7 +284,7 @@ class TestProgramManagers(unittest.TestCase):
 
         forward_program = delegate_manager.exported_program("forward")
         self.assertEqual(
-            forward_program(torch.ones(1), torch.ones(1), torch.ones(1)),
+            forward_program(torch.ones(1), torch.ones(1)),
             torch.ones(1) + 1,  # x * y + x
         )
 


### PR DESCRIPTION
Summary: as title. The forward method only takes 2 inputs but we give 3 inputs to it during testing.

Reviewed By: angelayi

Differential Revision: D49501277


