### PR TITLE
Remove QNNPack dependency in OSS executor_runner

### DIFF
--- a/sdk/runners/executor_runner.cpp
+++ b/sdk/runners/executor_runner.cpp
@@ -19,13 +19,12 @@
 #include <executorch/sdk/etdump/etdump_flatcc.h>
 #include <executorch/util/bundled_program_verification.h>
 #include <executorch/util/util.h>
-#ifdef USE_ATEN_LIB
-#include <c10/core/impl/LocalDispatchKeySet.h>
-#endif
 
-#if !defined(USE_ATEN_LIB)
+#ifndef USE_ATEN_LIB
 #include <executorch/backends/xnnpack/threadpool/fb/threadpool_use_n_threads.h>
 #include <executorch/backends/xnnpack/threadpool/threadpool.h>
+#else
+#include <c10/core/impl/LocalDispatchKeySet.h>
 #endif
 
 // This tool includes all of the headers necessary to execute a model.
@@ -327,9 +326,7 @@ int main(int argc, char** argv) {
   // production environment, given that in xplat we are depending on a library
   // that enables C10_MOBILE (`torch_mobile_core`).
   c10::impl::ExcludeDispatchKeyGuard no_autograd(c10::autograd_dispatch_keyset);
-#endif
-
-#if !defined(USE_ATEN_LIB)
+#else
   // To enable intra-op parallelism
   // This sets the # of threads to use for running executorch model
   // to num_threads. Applicable to lean mode.

--- a/shim/xplat/executorch/backends/backends.bzl
+++ b/shim/xplat/executorch/backends/backends.bzl
@@ -6,7 +6,6 @@ def get_all_cpu_backend_targets():
     """
     return [
         "//executorch/backends/xnnpack:xnnpack_backend",
-        "//executorch/backends/qnnpack:qnnpack_backend",
     ]
 
 def get_all_cpu_aot_and_backend_targets():
@@ -18,6 +17,4 @@ def get_all_cpu_aot_and_backend_targets():
     return [
         "//executorch/backends/xnnpack:xnnpack_preprocess",
         "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
-        "//executorch/backends/qnnpack:qnnpack_preprocess",
-        "//executorch/backends/qnnpack/partition:qnnpack_partitioner",
     ] + get_all_cpu_backend_targets()


### PR DESCRIPTION
Summary: As title - QNNPack should not be included in OSS targets.

Differential Revision: D49509300


