### PR TITLE
remove redundant inner header from delegate authors section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,6 @@ must work with threading**
 
 ## For Delegate Authors
 
-### Dependencies Management for a Delegate
-
 * Use [this](/docs/website/docs/contributors/delegates.md)
 guide when integrating your delegate with Executorch.
 


### PR DESCRIPTION
Summary:
as Title

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: kirklandsign

Differential Revision: D49514413


