### PR TITLE
Enable quantization for wav2letter

### DIFF
--- a/examples/recipes/xnnpack_optimization/models.py
+++ b/examples/recipes/xnnpack_optimization/models.py
@@ -25,7 +25,7 @@ MODEL_NAME_TO_OPTIONS = {
     "resnet18": OptimizationOptions(True, True),
     "resnet50": OptimizationOptions(True, True),
     "vit": OptimizationOptions(False, True),
-    "w2l": OptimizationOptions(False, True),
+    "w2l": OptimizationOptions(True, True),
     "edsr": OptimizationOptions(True, False),
     "mobilebert": OptimizationOptions(True, False),
 }


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/109830

Also added annotation support for conv1d_relu and conv1d in XNNPACKQuantizer, the quantized results still
matches fx quant path (didn't quantize conv1d) so tests are not disabled

Differential Revision: D49479546


