### PR TITLE
Work around spec violation in executorch program unit test.

### DIFF
--- a/exir/tests/test_serde.py
+++ b/exir/tests/test_serde.py
@@ -56,7 +56,8 @@ class TestSerde(unittest.TestCase):
 
         executorch = edge.to_executorch().dump_exported_program()
         executorch_new = deserialize(*serialize(executorch))
-        self.check_ep(executorch, executorch_new, inputs)
+        with torch.no_grad():
+            self.check_ep(executorch, executorch_new, inputs)
 
     def test_basic(self) -> None:
         class MyModule(torch.nn.Module):


### PR DESCRIPTION
Summary: In theory, we shouldn't serialize an executorch program with default serializer because there is a spec violation with out variant graph.

Reviewed By: angelayi

Differential Revision: D49548576


