### PR TITLE
Enable quantization for EDSR

### DIFF
--- a/examples/quantization/example.py
+++ b/examples/quantization/example.py
@@ -43,6 +43,15 @@ logging.basicConfig(level=logging.INFO, format=FORMAT)
 def verify_xnnpack_quantizer_matching_fx_quant_model(model_name, model, example_inputs):
     """This is a verification against fx graph mode quantization flow as a sanity check"""
 
+    if model_name == "edsr":
+        # EDSR has control flows that are not traceable in symbolic_trace
+        return
+    if model_name == "ic3":
+        # we don't want to compare results of inception_v3 with fx, since mul op with Scalar
+        # input is quantized differently in fx, and we don't want to replicate the behavior
+        # in XNNPACKQuantizer
+        return
+
     model.eval()
     m_copy = copy.deepcopy(model)
     m = model
@@ -72,11 +81,6 @@ def verify_xnnpack_quantizer_matching_fx_quant_model(model_name, model, example_
     after_quant_result_fx = m_fx(*example_inputs)
 
     # 3. compare results
-    if model_name == "ic3":
-        # we don't want to compare results of inception_v3 with fx, since mul op with Scalar
-        # input is quantized differently in fx, and we don't want to replicate the behavior
-        # in XNNPACKQuantizer
-        return
     if model_name == "dl3":
         # dl3 output format: {"out": a, "aux": b}
         after_prepare_result = after_prepare_result["out"]

--- a/examples/recipes/xnnpack_optimization/models.py
+++ b/examples/recipes/xnnpack_optimization/models.py
@@ -26,4 +26,5 @@ MODEL_NAME_TO_OPTIONS = {
     "resnet50": OptimizationOptions(True, True),
     "vit": OptimizationOptions(False, True),
     "w2l": OptimizationOptions(False, True),
+    "edsr": OptimizationOptions(True, False),
 }


### PR DESCRIPTION
Summary:
printed quantized model: https://www.internalfb.com/phabricator/paste/view/P834732421
can't verify against fx since symbolic_trace can't capture control flows

Reviewed By: kimishpatel, guangy10

Differential Revision: D49524934


