### PR TITLE
Set model tests with cmake to release build

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -42,6 +42,7 @@ build_cmake_executor_runner() {
     && mkdir ${CMAKE_OUTPUT_DIR} \
     && cd ${CMAKE_OUTPUT_DIR} \
     && retry cmake -DBUCK2=buck2 \
+      -DCMAKE_BUILD_TYPE=Release \
       -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
 
   cmake --build ${CMAKE_OUTPUT_DIR} -j4
@@ -73,6 +74,7 @@ build_cmake_xnn_executor_runner() {
     && mkdir ${CMAKE_OUTPUT_DIR} \
     && cd ${CMAKE_OUTPUT_DIR} \
     && retry cmake -DBUCK2=buck2 \
+      -DCMAKE_BUILD_TYPE=Release \
       -DEXECUTORCH_BUILD_XNNPACK=ON \
       -DREGISTER_QUANTIZED_OPS=ON \
       -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -62,7 +62,9 @@ build_executorch_runner_cmake() {
   pushd "${CMAKE_OUTPUT_DIR}" || return
   # This command uses buck2 to gather source files and buck2 could crash flakily
   # on MacOS
-  retry cmake -DBUCK2=buck2 -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" ..
+  retry cmake -DBUCK2=buck2 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" ..
   popd || return
 
   if [ "$(uname)" == "Darwin" ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 # -Os: Optimize for size -ffunction-sections -fdata-sections: breaks function
 # and data into sections so they can be properly gc'd -s: strip symbols
 set(CMAKE_CXX_FLAGS_RELEASE
-    "-Os -ffunction-sections -fdata-sections -s -fno-exceptions -fno-rtti")
+    "-Os -ffunction-sections -fdata-sections -s -fno-exceptions")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 
 # Option to register custom operator `my_ops::mul3` or `my_ops::mul4` or no

--- a/examples/quantization/test_quantize.sh
+++ b/examples/quantization/test_quantize.sh
@@ -51,6 +51,7 @@ test_cmake_quantization() {
     && mkdir cmake-out \
     && cd cmake-out \
     && retry cmake -DBUCK2="$BUCK" \
+      -DCMAKE_BUILD_TYPE=Release \
       -DEXECUTORCH_BUILD_XNNPACK="$EXECUTORCH_BUILD_XNNPACK" \
       -DREGISTER_QUANTIZED_OPS=ON \
       -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \


### PR DESCRIPTION
Summary: Our ci is bleeding with debug build (default). We should start using release build for long running e2e tests. Release or opt model for buck2 is not ready, we can start enabling release build with cmake first.

Differential Revision: D49553397


