### PR TITLE
Fix build breaks from llvm-17

### DIFF
--- a/backends/xnnpack/runtime/utils/utils.cpp
+++ b/backends/xnnpack/runtime/utils/utils.cpp
@@ -171,7 +171,7 @@ std::pair<float, float> GetMinMax(const Tensor& ft) {
   ET_CHECK_MSG(
       ft.scalar_type() == ScalarType::Float,
       "Expected float tensor but got %hhd",
-      ft.scalar_type());
+      static_cast<int8_t>(ft.scalar_type()));
   const float* d = ft.const_data_ptr<float>();
   for (int i = 0; i < ft.numel(); ++i) {
     min = (d[i] < min) ? d[i] : min;

--- a/kernels/optimized/cpu/op_bmm.cpp
+++ b/kernels/optimized/cpu/op_bmm.cpp
@@ -148,7 +148,8 @@ Tensor& opt_bmm_out(
   switch (scalar_type) {
     ET_FORALL_REAL_TYPES(BMM_TENSOR)
     default:
-      ET_CHECK_MSG(false, "Unhandled dtype %hhd", scalar_type);
+      ET_CHECK_MSG(
+          false, "Unhandled dtype %hhd", static_cast<int8_t>(scalar_type));
   }
 #undef BMM_TENSOR
 

--- a/kernels/optimized/cpu/op_gelu.cpp
+++ b/kernels/optimized/cpu/op_gelu.cpp
@@ -120,7 +120,10 @@ Tensor& opt_gelu_out(
     // TODO support Double as well
     GELU(float, Float)
     default:
-      ET_CHECK_MSG(false, "Unhandled dtype %hhd", input.scalar_type());
+      ET_CHECK_MSG(
+          false,
+          "Unhandled dtype %hhd",
+          static_cast<int8_t>(input.scalar_type()));
   }
 #undef GELU
 

--- a/kernels/optimized/cpu/op_log_softmax.cpp
+++ b/kernels/optimized/cpu/op_log_softmax.cpp
@@ -108,7 +108,10 @@ void log_softmax_wrapper(const Tensor& X, int64_t dim, Tensor& out) {
       log_softmax_kernel<float, OUT_T>(X, dim, out);
       break;
     default:
-      ET_CHECK_MSG(false, "Unhandled input dtype %hhd", input_scalar_type);
+      ET_CHECK_MSG(
+          false,
+          "Unhandled input dtype %hhd",
+          static_cast<int8_t>(input_scalar_type));
   }
 }
 } // namespace
@@ -138,12 +141,12 @@ void opt_log_soft_max_check_preconditions(
   ET_CHECK_MSG(
       out_scalar_type == ScalarType::Float,
       "out.scalar_type() %hhd is not Float",
-      out_scalar_type);
+      static_cast<int8_t>(out_scalar_type));
   auto input_scalar_type = self.scalar_type();
   ET_CHECK_MSG(
       input_scalar_type == ScalarType::Float,
       "self.scalar_type() %hhd is not Float",
-      input_scalar_type);
+      static_cast<int8_t>(input_scalar_type));
 }
 
 // _log_softmax.out(Tensor self, int dim, bool half_to_float, *, Tensor(a!) out)
@@ -172,7 +175,10 @@ Tensor& opt_log_softmax_out(
       log_softmax_wrapper<float>(self, dim, out);
       break;
     default:
-      ET_CHECK_MSG(false, "Unhandled out dtype %hhd", out_scalar_type);
+      ET_CHECK_MSG(
+          false,
+          "Unhandled out dtype %hhd",
+          static_cast<int8_t>(out_scalar_type));
   }
   return out;
 }

--- a/kernels/optimized/cpu/op_native_layer_norm.cpp
+++ b/kernels/optimized/cpu/op_native_layer_norm.cpp
@@ -160,7 +160,10 @@ std::tuple<Tensor&, Tensor&, Tensor&> opt_native_layer_norm_out(
     // TODO support bfloat16
     ET_FORALL_FLOAT_TYPES(LAYER_NORM)
     default:
-      ET_CHECK_MSG(false, "Unhandled dtype %hhd", input.scalar_type());
+      ET_CHECK_MSG(
+          false,
+          "Unhandled dtype %hhd",
+          static_cast<int8_t>(input.scalar_type()));
   }
 #undef LAYER_NORM
   return {out, mean_out, rstd_out};

--- a/kernels/portable/cpu/op_allclose.cpp
+++ b/kernels/portable/cpu/op_allclose.cpp
@@ -103,7 +103,7 @@ Tensor& allclose_out(
   ET_CHECK_MSG(
       out.scalar_type() == ScalarType::Bool,
       "Out tensor must be type Bool; saw type %hhd",
-      out.scalar_type());
+      static_cast<int8_t>(out.scalar_type()));
   ET_CHECK_MSG(
       out.numel() == 1,
       "Out tensor must be a single element; saw %zu elements",

--- a/kernels/portable/cpu/op_argmax.cpp
+++ b/kernels/portable/cpu/op_argmax.cpp
@@ -40,7 +40,7 @@ void check_preconditions(
   ET_CHECK_MSG(
       out.scalar_type() == ScalarType::Long,
       "Expected out tensor to have dtype Long, but got %hhd instead",
-      out.scalar_type());
+      static_cast<int8_t>(out.scalar_type()));
   ET_CHECK_MSG(
       out.dim() == compute_reduced_out_dim(in, dim, keepdim),
       "Number of dims of out tensor is not compatible with inputs and params");

--- a/kernels/portable/cpu/op_argmin.cpp
+++ b/kernels/portable/cpu/op_argmin.cpp
@@ -40,7 +40,7 @@ void check_preconditions(
   ET_CHECK_MSG(
       out.scalar_type() == ScalarType::Long,
       "Expected out tensor to have dtype Long, but got %hhd instead",
-      out.scalar_type());
+      static_cast<int8_t>(out.scalar_type()));
   ET_CHECK_MSG(
       out.dim() == compute_reduced_out_dim(in, dim, keepdim),
       "Number of dims of out tensor is not compatible with inputs and params");

--- a/kernels/portable/cpu/op_as_strided_copy.cpp
+++ b/kernels/portable/cpu/op_as_strided_copy.cpp
@@ -145,7 +145,10 @@ Tensor& as_strided_copy_out(
   switch (self.scalar_type()) {
     ET_FORALL_SCALAR_TYPES(AS_STRIDED_COPY_TENSOR)
     default:
-      ET_CHECK_MSG(false, "Unhandled dtype %hhd", self.scalar_type());
+      ET_CHECK_MSG(
+          false,
+          "Unhandled dtype %hhd",
+          static_cast<int8_t>(self.scalar_type()));
   }
 #undef AS_STRIDED_COPY_TENSOR
   return out;

--- a/kernels/portable/cpu/op_bitwise_not.cpp
+++ b/kernels/portable/cpu/op_bitwise_not.cpp
@@ -44,7 +44,10 @@ Tensor& bitwise_not_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
           in.numel());
     });
   } else {
-    ET_CHECK_MSG(false, "Unsupported input dtype %hhd", in.scalar_type());
+    ET_CHECK_MSG(
+        false,
+        "Unsupported input dtype %hhd",
+        static_cast<int8_t>(in.scalar_type()));
   }
 
   return out;

--- a/kernels/portable/cpu/op_cumsum.cpp
+++ b/kernels/portable/cpu/op_cumsum.cpp
@@ -116,19 +116,25 @@ Tensor& cumsum_out(
     cumsum_tensors<SELF_CTYPE, OUT_CTYPE>(self, dim, out); \
     break;
 
-#define CUMSUM_TENSORS(SELF_CTYPE, self_dtype)                                 \
-  case ScalarType::self_dtype:                                                 \
-    switch (out.scalar_type()) {                                               \
-      ET_FORALL_REAL_TYPES_WITH(SELF_CTYPE, CUMSUM_IMPL)                       \
-      default:                                                                 \
-        ET_CHECK_MSG(false, "Unhandled output dtype %hhd", out.scalar_type()); \
-    }                                                                          \
+#define CUMSUM_TENSORS(SELF_CTYPE, self_dtype)           \
+  case ScalarType::self_dtype:                           \
+    switch (out.scalar_type()) {                         \
+      ET_FORALL_REAL_TYPES_WITH(SELF_CTYPE, CUMSUM_IMPL) \
+      default:                                           \
+        ET_CHECK_MSG(                                    \
+            false,                                       \
+            "Unhandled output dtype %hhd",               \
+            static_cast<int8_t>(out.scalar_type()));     \
+    }                                                    \
     break;
 
   switch (self.scalar_type()) {
     ET_FORALL_REAL_TYPES_AND(Bool, CUMSUM_TENSORS)
     default:
-      ET_CHECK_MSG(false, "Unhandled input dtype %hhd", self.scalar_type());
+      ET_CHECK_MSG(
+          false,
+          "Unhandled input dtype %hhd",
+          static_cast<int8_t>(self.scalar_type()));
   }
 
 #undef CUMSUM_TENSORS

--- a/kernels/portable/cpu/op_glu.cpp
+++ b/kernels/portable/cpu/op_glu.cpp
@@ -207,7 +207,8 @@ glu_out(RuntimeContext& ctx, const Tensor& self, int64_t dim, Tensor& out) {
   switch (in_dtype) {
     ET_FORALL_FLOAT_TYPES(GLU_TENSOR)
     default:
-      ET_CHECK_MSG(false, "Unhandled dtype %hhd", in_dtype);
+      ET_CHECK_MSG(
+          false, "Unhandled dtype %hhd", static_cast<int8_t>(in_dtype));
   }
 #undef GLU_TENSOR
   return out;

--- a/kernels/portable/cpu/op_nonzero.cpp
+++ b/kernels/portable/cpu/op_nonzero.cpp
@@ -39,7 +39,7 @@ void check_preconditions(const Tensor& input, const Tensor& output) {
   ET_CHECK_MSG(
       output.scalar_type() == ScalarType::Long,
       "Expected out to be a Long tensor but received %hdd",
-      output.scalar_type());
+      static_cast<short>(output.scalar_type()));
   ET_CHECK_MSG(
       output.dim() == 2,
       "Expected out to be a 2d tensor received %zd",

--- a/kernels/portable/cpu/op_ones.cpp
+++ b/kernels/portable/cpu/op_ones.cpp
@@ -66,7 +66,7 @@ Tensor& ones_out(RuntimeContext& ctx, IntArrayRef size, Tensor& out) {
       ET_CHECK_MSG(
           false,
           "out tensor should be a real or bool dtype, but got %hhd",
-          out.scalar_type());
+          static_cast<int8_t>(out.scalar_type()));
   }
 #undef ONES_OUT
 

--- a/kernels/portable/cpu/op_split_copy.cpp
+++ b/kernels/portable/cpu/op_split_copy.cpp
@@ -92,8 +92,8 @@ void check_args(
         out[i].scalar_type() == out[0].scalar_type(),
         "out[%zu] dtype %hhd != out[0] dtype %hhd",
         i,
-        out[i].scalar_type(),
-        out[0].scalar_type());
+        static_cast<int8_t>(out[i].scalar_type()),
+        static_cast<int8_t>(out[0].scalar_type()));
 
     // All outputs must have the same number of dimensions as the input.
     ET_CHECK_MSG(

--- a/kernels/portable/cpu/op_t_copy.cpp
+++ b/kernels/portable/cpu/op_t_copy.cpp
@@ -62,7 +62,8 @@ Tensor& t_copy_out(RuntimeContext& ctx, const Tensor& a, Tensor& out) {
   switch (a.scalar_type()) {
     ET_FORALL_SCALAR_TYPES(TRANSPOSE_TENSORS)
     default:
-      ET_CHECK_MSG(false, "Unhandled dtype %hhd", a.scalar_type());
+      ET_CHECK_MSG(
+          false, "Unhandled dtype %hhd", static_cast<int8_t>(a.scalar_type()));
   }
 
 #undef TRANSPOSE_TENSORS

--- a/kernels/portable/cpu/op_to_copy.cpp
+++ b/kernels/portable/cpu/op_to_copy.cpp
@@ -54,19 +54,25 @@ Tensor& to_copy_out(
     _to_impl<SELF_CTYPE, OUT_CTYPE>(self, out);   \
     break;
 
-#define CASE_TENSOR_DTYPE(SELF_CTYPE, self_dtype)                              \
-  case ScalarType::self_dtype:                                                 \
-    switch (out.scalar_type()) {                                               \
-      ET_FORALL_REAL_TYPES_AND_WITH(Bool, SELF_CTYPE, TO_IMPL)                 \
-      default:                                                                 \
-        ET_CHECK_MSG(false, "Unhandled output dtype %hhd", out.scalar_type()); \
-    }                                                                          \
+#define CASE_TENSOR_DTYPE(SELF_CTYPE, self_dtype)              \
+  case ScalarType::self_dtype:                                 \
+    switch (out.scalar_type()) {                               \
+      ET_FORALL_REAL_TYPES_AND_WITH(Bool, SELF_CTYPE, TO_IMPL) \
+      default:                                                 \
+        ET_CHECK_MSG(                                          \
+            false,                                             \
+            "Unhandled output dtype %hhd",                     \
+            static_cast<int8_t>(out.scalar_type()));           \
+    }                                                          \
     break;
 
   switch (self.scalar_type()) {
     ET_FORALL_REAL_TYPES_AND(Bool, CASE_TENSOR_DTYPE);
     default:
-      ET_CHECK_MSG(false, "Unhandled input dtype %hhd", self.scalar_type());
+      ET_CHECK_MSG(
+          false,
+          "Unhandled input dtype %hhd",
+          static_cast<int8_t>(self.scalar_type()));
   }
 
 #undef CASE_TENSOR_DTYPE

--- a/kernels/portable/cpu/op_transpose_copy.cpp
+++ b/kernels/portable/cpu/op_transpose_copy.cpp
@@ -90,7 +90,8 @@ Tensor& transpose_copy_int_out(
   switch (a.scalar_type()) {
     ET_FORALL_SCALAR_TYPES(TRANSPOSE_TENSORS)
     default:
-      ET_CHECK_MSG(false, "Unhandled dtype %hhd", a.scalar_type());
+      ET_CHECK_MSG(
+          false, "Unhandled dtype %hhd", static_cast<int8_t>(a.scalar_type()));
   }
 
 #undef TRANSPOSE_TENSORS

--- a/kernels/portable/cpu/op_tril.cpp
+++ b/kernels/portable/cpu/op_tril.cpp
@@ -151,7 +151,7 @@ Tensor& tril_out(
       ET_CHECK_MSG(
           false,
           "out tensor should be a real or bool dtype, but got %hhd",
-          out.scalar_type());
+          static_cast<int8_t>(out.scalar_type()));
   }
 #undef TRIL_OUT
 

--- a/kernels/portable/cpu/op_unbind_copy.cpp
+++ b/kernels/portable/cpu/op_unbind_copy.cpp
@@ -46,8 +46,8 @@ void check_args(const Tensor& input, int64_t dim, TensorList out) {
         out[i].scalar_type() == out[0].scalar_type(),
         "out[%zu] dtype %hhd != out[0] dtype %hhd",
         i,
-        out[i].scalar_type(),
-        out[0].scalar_type());
+        static_cast<int8_t>(out[i].scalar_type()),
+        static_cast<int8_t>(out[0].scalar_type()));
 
     // output tensor must have # of dims = input.dim() -1
     ET_CHECK_MSG(

--- a/kernels/portable/cpu/pattern/unary_ufunc_realb_to_bool.cpp
+++ b/kernels/portable/cpu/pattern/unary_ufunc_realb_to_bool.cpp
@@ -30,7 +30,7 @@ Tensor& unary_ufunc_realb_to_bool(
   ET_CHECK_MSG(
       out.scalar_type() == exec_aten::ScalarType::Bool,
       "Expected out tensor to have dtype Bool, but got %hhd instead.",
-      out.scalar_type());
+      static_cast<int8_t>(out.scalar_type()));
 
   const auto in_type = in.scalar_type();
 

--- a/kernels/portable/cpu/util/index_util.cpp
+++ b/kernels/portable/cpu/util/index_util.cpp
@@ -122,7 +122,7 @@ bool indices_list_is_valid(
       ET_LOG_MSG_AND_RETURN_IF_FALSE(
           false,
           "%hhd scalar type is not supported for indices",
-          index.scalar_type());
+          static_cast<int8_t>(index.scalar_type()));
     }
   }
   return true;

--- a/kernels/quantized/cpu/op_add.cpp
+++ b/kernels/quantized/cpu/op_add.cpp
@@ -151,7 +151,8 @@ Tensor& quantized_add_out(
   switch (a.scalar_type()) {
     ET_FORALL_INT_TYPES(ADD_TENSORS)
     default:
-      ET_CHECK_MSG(false, "Unhandled dtype %hhd", a.scalar_type());
+      ET_CHECK_MSG(
+          false, "Unhandled dtype %hhd", static_cast<int8_t>(a.scalar_type()));
   }
 
 #undef ADD_TENSORS

--- a/kernels/quantized/cpu/op_choose_qparams.cpp
+++ b/kernels/quantized/cpu/op_choose_qparams.cpp
@@ -47,15 +47,15 @@ void check_quantize_per_tensor_args(
   ET_CHECK_MSG(
       input.scalar_type() == ScalarType::Float,
       "Expected input to be Float tensor received: %hdd",
-      input.scalar_type());
+      static_cast<short>(input.scalar_type()));
   ET_CHECK_MSG(
       scale_out.scalar_type() == ScalarType::Double,
       "Expected scale to be Double tensor received: %hdd",
-      scale_out.scalar_type());
+      static_cast<short>(scale_out.scalar_type()));
   ET_CHECK_MSG(
       zero_point_out.scalar_type() == ScalarType::Long,
       "Expected scale to be Long tensor received: %hdd",
-      zero_point_out.scalar_type());
+      static_cast<short>(zero_point_out.scalar_type()));
   ET_CHECK_MSG(
       scale_out.numel() == 1,
       "Exepcted scale to only have one element received: %zd",

--- a/kernels/quantized/cpu/op_dequantize.cpp
+++ b/kernels/quantized/cpu/op_dequantize.cpp
@@ -41,17 +41,17 @@ void check_dequantize_per_tensor_args(
           input.scalar_type() == ScalarType::Short ||
           input.scalar_type() == ScalarType::Int,
       "input.scalar_type() %hdd is not supported:",
-      input.scalar_type());
+      static_cast<short>(input.scalar_type()));
 
   ET_CHECK_MSG(
       input.scalar_type() == dtype,
       "input.scalar_type() %hdd is not matching dtype argumenta:",
-      input.scalar_type());
+      static_cast<short>(input.scalar_type()));
 
   ET_CHECK_MSG(
       out.scalar_type() == ScalarType::Float,
       "out.scalar_type() %hdd is not supported:",
-      out.scalar_type());
+      static_cast<short>(out.scalar_type()));
 
   ET_CHECK_MSG(
       quant_min <= quant_max,
@@ -100,19 +100,25 @@ Tensor& dequantize_per_tensor_out(
           static_cast<float>(scale));                                          \
     }                                                                          \
     break;
-#define CALCULATE_INT_TYPE(IN_CTYPE, in_dtype)                                 \
-  case ScalarType::in_dtype:                                                   \
-    switch (out.scalar_type()) {                                               \
-      ET_FORALL_FLOAT_TYPES_WITH(IN_CTYPE, DEQUANTIZE_IMPL);                   \
-      default:                                                                 \
-        ET_CHECK_MSG(false, "Unhandled output dtype %hhd", out.scalar_type()); \
-    }                                                                          \
+#define CALCULATE_INT_TYPE(IN_CTYPE, in_dtype)               \
+  case ScalarType::in_dtype:                                 \
+    switch (out.scalar_type()) {                             \
+      ET_FORALL_FLOAT_TYPES_WITH(IN_CTYPE, DEQUANTIZE_IMPL); \
+      default:                                               \
+        ET_CHECK_MSG(                                        \
+            false,                                           \
+            "Unhandled output dtype %hhd",                   \
+            static_cast<int8_t>(out.scalar_type()));         \
+    }                                                        \
     break;
 
   switch (input.scalar_type()) {
     ET_FORALL_INT_TYPES(CALCULATE_INT_TYPE);
     default:
-      ET_CHECK_MSG(false, "Unhandled input dtype %hhd", input.scalar_type());
+      ET_CHECK_MSG(
+          false,
+          "Unhandled input dtype %hhd",
+          static_cast<int8_t>(input.scalar_type()));
   }
 
 #undef CALCULATE_FLOAT_TYPE
@@ -131,11 +137,11 @@ Tensor& dequantize_per_tensor_tensor_args_out(
   ET_CHECK_MSG(
       scale.scalar_type() == ScalarType::Double,
       "Expected scale to be Double tensor received: %hdd",
-      scale.scalar_type());
+      static_cast<short>(scale.scalar_type()));
   ET_CHECK_MSG(
       zero_point.scalar_type() == ScalarType::Long,
       "Expected scale to be Long tensor received: %hdd",
-      zero_point.scalar_type());
+      static_cast<short>(zero_point.scalar_type()));
   ET_CHECK_MSG(
       scale.numel() == 1,
       "Exepcted scale to only have one element received: %zd",

--- a/kernels/quantized/cpu/op_embedding.cpp
+++ b/kernels/quantized/cpu/op_embedding.cpp
@@ -36,27 +36,27 @@ void check_embedding_byte_args(
       weight.scalar_type() == ScalarType::Byte ||
           weight.scalar_type() == ScalarType::Char,
       "weight.scalar_type() %hdd is not supported:",
-      weight.scalar_type());
+      static_cast<short>(weight.scalar_type()));
 
   ET_CHECK_MSG(
       weight_scales.scalar_type() == ScalarType::Float,
       "weight_scales.scalar_type() %hdd is not float only float is supported:",
-      weight_scales.scalar_type());
+      static_cast<short>(weight_scales.scalar_type()));
 
   ET_CHECK_MSG(
       weight_zero_points.scalar_type() == ScalarType::Float,
       "weight_zero_points.scalar_type() %hdd is not Float only Float is supported for embedding:",
-      weight_zero_points.scalar_type());
+      static_cast<short>(weight_zero_points.scalar_type()));
 
   ET_CHECK_MSG(
       indices.scalar_type() == ScalarType::Long,
       "indices.scalar_type() %hdd is not Long only Long is supported:",
-      indices.scalar_type());
+      static_cast<short>(indices.scalar_type()));
 
   ET_CHECK_MSG(
       out.scalar_type() == ScalarType::Float,
       "out.scalar_type() %hdd is not supported:",
-      out.scalar_type());
+      static_cast<short>(out.scalar_type()));
 
   ET_CHECK_MSG(
       weight_quant_min <= weight_quant_max,
@@ -158,14 +158,17 @@ Tensor& quantized_embedding_byte_out(
       indices,
       out);
 
-#define FETCH_EMBEDDINGS(WEIGHT_CTYPE)                                       \
-  switch (out.scalar_type()) {                                               \
-    case ScalarType::Float:                                                  \
-      embedding_byte_per_channel<WEIGHT_CTYPE, float>(                       \
-          weight, weight_scales, weight_zero_points, indices, out);          \
-      break;                                                                 \
-    default:                                                                 \
-      ET_CHECK_MSG(false, "Unhandled output dtype %hhd", out.scalar_type()); \
+#define FETCH_EMBEDDINGS(WEIGHT_CTYPE)                              \
+  switch (out.scalar_type()) {                                      \
+    case ScalarType::Float:                                         \
+      embedding_byte_per_channel<WEIGHT_CTYPE, float>(              \
+          weight, weight_scales, weight_zero_points, indices, out); \
+      break;                                                        \
+    default:                                                        \
+      ET_CHECK_MSG(                                                 \
+          false,                                                    \
+          "Unhandled output dtype %hhd",                            \
+          static_cast<int8_t>(out.scalar_type()));                  \
   }
 
   switch (weight.scalar_type()) {
@@ -176,7 +179,10 @@ Tensor& quantized_embedding_byte_out(
       FETCH_EMBEDDINGS(int8_t)
       break;
     default:
-      ET_CHECK_MSG(false, "Unhandled weight dtype %hhd", weight.scalar_type());
+      ET_CHECK_MSG(
+          false,
+          "Unhandled weight dtype %hhd",
+          static_cast<int8_t>(weight.scalar_type()));
   }
 #undef CALCULATE_OUT_DTYPE
 

--- a/kernels/quantized/cpu/op_quantize.cpp
+++ b/kernels/quantized/cpu/op_quantize.cpp
@@ -37,15 +37,15 @@ void check_quantize_per_tensor_args(
   ET_CHECK_MSG(
       torch::executor::isFloatingType(input.scalar_type()),
       "input.scalar_type() %hdd is not floating type",
-      input.scalar_type());
+      static_cast<short>(input.scalar_type()));
 
   int32_t quant_min_lower_bound = 0, quant_max_upper_bound = 0;
   ScalarType out_dtype = out.scalar_type();
   ET_CHECK_MSG(
       out_dtype == dtype,
       "out.scalar_type() %hdd is not matching dtype argument %hdd",
-      out_dtype,
-      dtype);
+      static_cast<short>(out_dtype),
+      static_cast<short>(dtype));
   if (out_dtype == ScalarType::Byte) {
     quant_min_lower_bound =
         static_cast<int32_t>(std::numeric_limits<uint8_t>::min());
@@ -63,7 +63,8 @@ void check_quantize_per_tensor_args(
     quant_min_lower_bound = std::numeric_limits<int32_t>::min();
     quant_max_upper_bound = std::numeric_limits<int32_t>::max();
   } else {
-    ET_CHECK_MSG(false, "Unsupported dtype: %hdd", out_dtype);
+    ET_CHECK_MSG(
+        false, "Unsupported dtype: %hdd", static_cast<short>(out_dtype));
   }
   ET_CHECK_MSG(
       quant_min >= quant_min_lower_bound,
@@ -123,19 +124,25 @@ Tensor& quantize_per_tensor_out(
           scale, zero_point, value, quant_min, quant_max);              \
     }                                                                   \
     break;
-#define CALCULATE_FLOAT_TYPE(IN_CTYPE, in_dtype)                               \
-  case ScalarType::in_dtype:                                                   \
-    switch (out.scalar_type()) {                                               \
-      ET_FORALL_INT_TYPES_WITH(IN_CTYPE, QUANTIZE_IMPL);                       \
-      default:                                                                 \
-        ET_CHECK_MSG(false, "Unhandled output dtype %hhd", out.scalar_type()); \
-    }                                                                          \
+#define CALCULATE_FLOAT_TYPE(IN_CTYPE, in_dtype)         \
+  case ScalarType::in_dtype:                             \
+    switch (out.scalar_type()) {                         \
+      ET_FORALL_INT_TYPES_WITH(IN_CTYPE, QUANTIZE_IMPL); \
+      default:                                           \
+        ET_CHECK_MSG(                                    \
+            false,                                       \
+            "Unhandled output dtype %hhd",               \
+            static_cast<int8_t>(out.scalar_type()));     \
+    }                                                    \
     break;
 
   switch (input.scalar_type()) {
     ET_FORALL_FLOAT_TYPES(CALCULATE_FLOAT_TYPE);
     default:
-      ET_CHECK_MSG(false, "Unhandled input dtype %hhd", input.scalar_type());
+      ET_CHECK_MSG(
+          false,
+          "Unhandled input dtype %hhd",
+          static_cast<int8_t>(input.scalar_type()));
   }
 #undef CALCULATE_FLOAT_TYPE
 #undef QUANTIZE_IMPL
@@ -153,11 +160,11 @@ Tensor& quantize_per_tensor_tensor_args_out(
   ET_CHECK_MSG(
       scale.scalar_type() == ScalarType::Double,
       "Expected scale to be Double tensor received: %hdd",
-      scale.scalar_type());
+      static_cast<short>(scale.scalar_type()));
   ET_CHECK_MSG(
       zero_point.scalar_type() == ScalarType::Long,
       "Expected zero_point to be Long tensor received: %hdd",
-      zero_point.scalar_type());
+      static_cast<short>(zero_point.scalar_type()));
   ET_CHECK_MSG(
       scale.numel() == 1,
       "Exepcted scale to only have one element received: %zd",

--- a/runtime/core/exec_aten/util/scalar_type_util.h
+++ b/runtime/core/exec_aten/util/scalar_type_util.h
@@ -289,7 +289,7 @@ inline size_t elementSize(exec_aten::ScalarType t) {
   switch (t) {
     ET_FORALL_SCALAR_TYPES(CASE_ELEMENTSIZE_CASE)
     default:
-      ET_CHECK_MSG(false, "Unknown ScalarType %hhd", t);
+      ET_CHECK_MSG(false, "Unknown ScalarType %" PRId8, static_cast<int8_t>(t));
   }
 #undef CASE_ELEMENTSIZE_CASE
 }
@@ -552,8 +552,8 @@ inline size_t sizeof_scalar_type(exec_aten::ScalarType type) {
           type != exec_aten::ScalarType::ComplexDouble &&
           type != exec_aten::ScalarType::BFloat16 &&
           type != exec_aten::ScalarType::Undefined,
-      "Invalid or unsupported ScalarType %hhd",
-      type);
+      "Invalid or unsupported ScalarType %" PRId8,
+      static_cast<int8_t>(type));
 
   size_t type_size = 0;
 #define SCALAR_TYPE_SIZE(ctype, dtype) \
@@ -564,7 +564,8 @@ inline size_t sizeof_scalar_type(exec_aten::ScalarType type) {
   switch (type) {
     ET_FORALL_SCALAR_TYPES(SCALAR_TYPE_SIZE)
     default:
-      ET_CHECK_MSG(false, "Invalid input ScalarType %hhd", type);
+      ET_CHECK_MSG(
+          false, "Invalid input ScalarType %" PRId8, static_cast<int8_t>(type));
   }
 #undef SCALAR_TYPE_SIZE
 

--- a/runtime/core/exec_aten/util/tensor_util.h
+++ b/runtime/core/exec_aten/util/tensor_util.h
@@ -129,8 +129,8 @@
     ET_CHECK_MSG(                                                 \
         a_type__ == b_type__,                                     \
         ET_TENSOR_CHECK_PREFIX__ ": dtype={%hhd, %hhd}",          \
-        a_type__,                                                 \
-        b_type__);                                                \
+        static_cast<int8_t>(a_type__),                            \
+        static_cast<int8_t>(b_type__));                           \
   })
 
 #define ET_CHECK_SAME_DTYPE3(a__, b__, c__)                       \
@@ -141,9 +141,9 @@
     ET_CHECK_MSG(                                                 \
         a_type__ == b_type__ && b_type__ == c_type__,             \
         ET_TENSOR_CHECK_PREFIX__ ": dtype={%hhd, %hhd, %hhd}",    \
-        a_type__,                                                 \
-        b_type__,                                                 \
-        c_type__);                                                \
+        static_cast<int8_t>(a_type__),                            \
+        static_cast<int8_t>(b_type__),                            \
+        static_cast<int8_t>(c_type__));                           \
   })
 
 /**
@@ -171,8 +171,8 @@
         b_numel__,                                                        \
         a_dim__,                                                          \
         b_dim__,                                                          \
-        a_type__,                                                         \
-        b_type__);                                                        \
+        static_cast<int8_t>(a_type__),                                    \
+        static_cast<int8_t>(b_type__));                                   \
     for (size_t dim__ = 0; dim__ < ET_MIN2(a_dim__, b_dim__); ++dim__) {  \
       size_t a_size__ = (a__).size(dim__);                                \
       size_t b_size__ = (b__).size(dim__);                                \
@@ -211,9 +211,9 @@
         a_dim__,                                                       \
         b_dim__,                                                       \
         c_dim__,                                                       \
-        a_type__,                                                      \
-        b_type__,                                                      \
-        c_type__);                                                     \
+        static_cast<int8_t>(a_type__),                                 \
+        static_cast<int8_t>(b_type__),                                 \
+        static_cast<int8_t>(c_type__));                                \
     for (size_t dim__ = 0; dim__ < ET_MIN3(a_dim__, b_dim__, c_dim__); \
          ++dim__) {                                                    \
       size_t a_size__ = (a__).size(dim__);                             \

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -102,7 +102,7 @@ class BackendDelegate final {
           Error,
           "Init failed for backend %s: %" PRIu32,
           backend_id,
-          handle.error());
+          static_cast<uint32_t>(handle.error()));
       out->segment_.Free();
       return handle.error();
     }
@@ -241,8 +241,8 @@ bool parse_cond_value(const EValue& cond_value) {
     ET_CHECK_MSG(
         ScalarType::Bool == cond_val.scalar_type(),
         "Expected dtype of %hhd got %hhd",
-        ScalarType::Bool,
-        cond_val.scalar_type());
+        static_cast<int8_t>(ScalarType::Bool),
+        static_cast<int8_t>(cond_val.scalar_type()));
 
     const bool* cond_data = cond_val.const_data_ptr<bool>();
     for (size_t i = 0; i < cond_val.numel(); i++) {
@@ -342,7 +342,7 @@ Error Method::parse_values() {
               Error,
               "Failed parsing tensor at index %zu: %" PRIu32,
               i,
-              t.error());
+              static_cast<uint32_t>(t.error()));
           return t.error();
         }
         new (&values_[i]) EValue(t.get());
@@ -359,7 +359,7 @@ Error Method::parse_values() {
               Error,
               "Failed parsing tensor list at index %zu: %" PRIu32,
               i,
-              tensors.error());
+              static_cast<uint32_t>(tensors.error()));
           return tensors.error();
         }
         new (&values_[i]) EValue(tensors.get());
@@ -376,7 +376,7 @@ Error Method::parse_values() {
               Error,
               "Failed parsing optional tensor list at index %zu: %" PRIu32,
               i,
-              tensors.error());
+              static_cast<uint32_t>(tensors.error()));
           return tensors.error();
         }
         new (&values_[i]) EValue(tensors.get());
@@ -472,7 +472,7 @@ Error Method::resolve_operator(
           InvalidArgument,
           "Error setting dim_order %zu: 0x%" PRIx32,
           i,
-          err);
+          static_cast<uint32_t>(err));
       meta[count].dim_order_ =
           ArrayRef<exec_aten::DimOrderType>(dim_order_ptr, size);
       count++;
@@ -686,14 +686,14 @@ Method::set_input(const EValue& input_evalue, size_t input_idx) {
       InvalidArgument,
       "The %zu-th input in method is expected Tensor or prim, but received %u",
       input_idx,
-      e.tag);
+      static_cast<uint32_t>(e.tag));
 
   ET_CHECK_OR_RETURN_ERROR(
       e.tag == input_evalue.tag,
       InvalidArgument,
       "The %zu-th input of method should have the same type as the input_evalue, but get tag %u and tag %u",
       input_idx,
-      e.tag,
+      static_cast<uint32_t>(e.tag),
       (unsigned int)input_evalue.tag);
 
   if (e.isTensor()) {
@@ -703,8 +703,8 @@ Method::set_input(const EValue& input_evalue, size_t input_idx) {
         t_dst.scalar_type() == t_src.scalar_type(),
         InvalidArgument,
         "The input tensor's scalartype does not meet requirement: found %hhd but expected %hhd",
-        t_src.scalar_type(),
-        t_dst.scalar_type());
+        static_cast<int8_t>(t_src.scalar_type()),
+        static_cast<int8_t>(t_dst.scalar_type()));
     // Reset the shape for the Method's input as the size of forwarded input
     // tensor for shape dynamism. Also is a safety check if need memcpy.
     Error err = resize_tensor(t_dst, t_src.sizes());
@@ -713,7 +713,7 @@ Method::set_input(const EValue& input_evalue, size_t input_idx) {
         InvalidArgument,
         "Error setting input %zu: 0x%" PRIx32,
         input_idx,
-        err);
+        static_cast<uint32_t>(err));
     Error error;
     if (pre_allocated_input_) {
       error = internal::copy_tensor_data(t_dst, t_src);
@@ -725,7 +725,7 @@ Method::set_input(const EValue& input_evalue, size_t input_idx) {
         InvalidArgument,
         "Error setting data_ptr %zu: 0x%" PRIx32,
         input_idx,
-        error);
+        static_cast<uint32_t>(error));
     // Prims have to be the same as what was traced
   } else if (e.isInt()) {
     ET_CHECK_OR_RETURN_ERROR(
@@ -954,7 +954,7 @@ Error Method::execute_instruction() {
             Error,
             "CALL_DELEGATE execute failed at instruction %zu: %" PRIu32,
             step_state_.instr_idx,
-            err);
+            static_cast<uint32_t>(err));
         return err;
       }
     } break;
@@ -982,7 +982,7 @@ Error Method::execute_instruction() {
       ET_CHECK_MSG(
           false,
           "Instruction is not supported. %hhu",
-          instruction->instr_args_type());
+          static_cast<uint8_t>(instruction->instr_args_type()));
   }
   step_state_.instr_idx += 1;
   return Error::Ok;

--- a/runtime/executor/tensor_parser_portable.cpp
+++ b/runtime/executor/tensor_parser_portable.cpp
@@ -105,7 +105,10 @@ Result<torch::executor::Tensor> parseTensor(
       tensor_impl->nbytes(),
       memory_manager->planned_memory());
   if (!data_ptr.ok()) {
-    ET_LOG(Error, "getTensorDataPtr() failed: 0x%" PRIx32, data_ptr.error());
+    ET_LOG(
+        Error,
+        "getTensorDataPtr() failed: 0x%" PRIx32,
+        static_cast<uint32_t>(data_ptr.error()));
     return data_ptr.error();
   }
   tensor_impl->set_data(data_ptr.get());

--- a/runtime/kernel/operator_registry.cpp
+++ b/runtime/kernel/operator_registry.cpp
@@ -30,7 +30,7 @@ Error register_kernels(const ArrayRef<Kernel>& kernels) {
         false,
         "Kernel registration failed with error %" PRIu32
         ", see error log for details.",
-        success);
+        static_cast<uint32_t>(success));
   }
   return success;
 }


### PR DESCRIPTION
Summary:
Clang-17 is stricter around format strings and ambiguous headers.
* Cast the enums to the right format type
* Namespace `format_to` methods with `fmt` since libc++ 17 introduces its own std::format

Differential Revision: D49556599


