### PR TITLE
Upgrade flatbuffers version to 23.5.26

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -32,7 +32,7 @@ install_miniconda() {
 install_python() {
   pushd /opt/conda
   # Install the correct Python version
-  as_ci_user conda create -n "py_${PYTHON_VERSION}" -y --file /opt/conda/conda-env-ci.txt -c conda-forge python="${PYTHON_VERSION}"
+  as_ci_user conda create -n "py_${PYTHON_VERSION}" -y --file /opt/conda/conda-env-ci.txt python="${PYTHON_VERSION}"
   popd
 }
 

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -32,7 +32,7 @@ install_miniconda() {
 install_python() {
   pushd /opt/conda
   # Install the correct Python version
-  as_ci_user conda create -n "py_${PYTHON_VERSION}" -y --file /opt/conda/conda-env-ci.txt python="${PYTHON_VERSION}"
+  as_ci_user conda create -n "py_${PYTHON_VERSION}" -y --file /opt/conda/conda-env-ci.txt -c conda-forge python="${PYTHON_VERSION}"
   popd
 }
 

--- a/.ci/docker/conda-env-ci.txt
+++ b/.ci/docker/conda-env-ci.txt
@@ -1,9 +1,1 @@
-# NB: Install flatbuffers 23.5.6 from conda-forge. This matches the version of
-# in fbcode/executorch/third-party/flatbuffers.submodule.txt. Otherwise, we'll
-# need to build it from source
-conda-forge::flatbuffers=23.5.26
 cmake=3.22.1
-
-# NB: This is to avoid pulling in rhash 1.4.4 from conda-forge, which doesn't
-# work with cmake on MacOS
-rhash=1.4.3

--- a/.ci/docker/conda-env-ci.txt
+++ b/.ci/docker/conda-env-ci.txt
@@ -3,3 +3,7 @@
 # need to build it from source
 conda-forge::flatbuffers=23.5.26
 cmake=3.22.1
+
+# NB: This is to avoid pulling in rhash 1.4.4 from conda-forge, which doesn't
+# work with cmake on MacOS
+rhash=1.4.3

--- a/.ci/docker/conda-env-ci.txt
+++ b/.ci/docker/conda-env-ci.txt
@@ -1,5 +1,5 @@
 # NB: Install flatbuffers 23.5.6 from conda-forge. This matches the version of
 # in fbcode/executorch/third-party/flatbuffers.submodule.txt. Otherwise, we'll
 # need to build it from source
-flatbuffers=23.5.26
-cmake=3.26.4
+conda-forge::flatbuffers=23.5.26
+cmake=3.22.1

--- a/.ci/docker/conda-env-ci.txt
+++ b/.ci/docker/conda-env-ci.txt
@@ -1,4 +1,5 @@
-# TODO: We might need to update this to install flatbuffers from the pinned commit
-# in fbcode/executorch/third-party/flatbuffers.submodule.txt
-flatbuffers=2.0.0
+# NB: Install flatbuffers 23.5.6 from conda-forge. This matches the version of
+# in fbcode/executorch/third-party/flatbuffers.submodule.txt. Otherwise, we'll
+# need to build it from source
+flatbuffers=23.5.26
 cmake=3.22.1

--- a/.ci/docker/conda-env-ci.txt
+++ b/.ci/docker/conda-env-ci.txt
@@ -2,4 +2,4 @@
 # in fbcode/executorch/third-party/flatbuffers.submodule.txt. Otherwise, we'll
 # need to build it from source
 flatbuffers=23.5.26
-cmake=3.22.1
+cmake=3.26.4

--- a/.ci/scripts/setup-linux.sh
+++ b/.ci/scripts/setup-linux.sh
@@ -20,5 +20,6 @@ fi
 
 # As Linux job is running inside a Docker container, all of its dependencies
 # have already been installed
+install_flatc_from_source
 install_executorch
 build_executorch_runner "${BUILD_TOOL}"

--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -80,5 +80,6 @@ install_buck
 install_conda
 install_pip_dependencies
 print_cmake_info
+install_flatc_from_source
 install_executorch
 build_executorch_runner "${BUILD_TOOL}"

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -27,7 +27,7 @@ install_executorch() {
 install_conda() {
   pushd .ci/docker || return
   # Install conda dependencies like flatbuffer
-  conda install -y --file conda-env-ci.txt -c conda-forge
+  conda install -y --file conda-env-ci.txt
   popd || return
 }
 

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -62,7 +62,7 @@ install_flatc_from_source() {
   cmake --build . -j "${CMAKE_JOBS}"
 
   # Copy the flatc binary to conda path
-  EXEC_PATH="$(dirname $(which python))"
+  EXEC_PATH=$(dirname "$(which python)")
   cp flatc "${EXEC_PATH}"
 
   popd || return

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -27,7 +27,7 @@ install_executorch() {
 install_conda() {
   pushd .ci/docker || return
   # Install conda dependencies like flatbuffer
-  conda install --file conda-env-ci.txt
+  conda install -y --file conda-env-ci.txt -c conda-forge
   popd || return
 }
 
@@ -46,6 +46,21 @@ install_pip_dependencies() {
     torchaudio=="${TORCHAUDIO_VERSION}.${NIGHTLY}" \
     torchvision=="${TORCHVISION_VERSION}.${NIGHTLY}" \
     --index-url https://download.pytorch.org/whl/nightly/cpu
+  popd || return
+}
+
+install_flatc_from_source() {
+  # NB: This function could be used to install flatbuffer from source
+  pushd third-party/flatbuffers || return
+
+  cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
+  if [ "$(uname)" == "Darwin" ]; then
+    CMAKE_JOBS=$(( $(sysctl -n hw.ncpu) - 1 ))
+  else
+    CMAKE_JOBS=$(( $(nproc) - 1 ))
+  fi
+  cmake --build . -j "${CMAKE_JOBS}"
+
   popd || return
 }
 

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -61,6 +61,10 @@ install_flatc_from_source() {
   fi
   cmake --build . -j "${CMAKE_JOBS}"
 
+  # Copy the flatc binary to conda path
+  EXEC_PATH=$(dirname $(which python))
+  cp flatc "${EXEC_PATH}"
+
   popd || return
 }
 

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -62,7 +62,7 @@ install_flatc_from_source() {
   cmake --build . -j "${CMAKE_JOBS}"
 
   # Copy the flatc binary to conda path
-  EXEC_PATH=$(dirname $(which python))
+  EXEC_PATH="$(dirname $(which python))"
   cp flatc "${EXEC_PATH}"
 
   popd || return

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -28,8 +28,11 @@ jobs:
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
         conda activate "${CONDA_ENV}"
 
+        source .ci/scripts/utils.sh
         # Just need to install executorch, everything else has been setup
-        pip install .
+        install_flatc_from_source
+        install_executorch
+
         # Run pytest with coverage
         pytest -n auto --cov=./ --cov-report=xml
 
@@ -54,7 +57,9 @@ jobs:
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
 
         # Just need to install executorch, everything else has been setup
-        pip install .
+        install_flatc_from_source
+        install_executorch
+
         # Run pytest with coverage
         pytest -n auto --cov=./ --cov-report=xml
         # Run gtest

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -15,6 +15,10 @@ on:
 jobs:
   linux:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    strategy:
+      matrix:
+        include:
+          - build-tool: buck2
     with:
       runner: linux.2xlarge
       docker-image: ${{ inputs.docker-image }}
@@ -28,10 +32,9 @@ jobs:
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
         conda activate "${CONDA_ENV}"
 
-        source .ci/scripts/utils.sh
-        # Just need to install executorch, everything else has been setup
-        install_flatc_from_source
-        install_executorch
+        BUILD_TOOL=${{ matrix.build-tool }}
+        # Setup MacOS dependencies as there is no Docker support on MacOS atm
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
 
         # Run pytest with coverage
         pytest -n auto --cov=./ --cov-report=xml
@@ -55,10 +58,6 @@ jobs:
         BUILD_TOOL=${{ matrix.build-tool }}
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
-
-        # Just need to install executorch, everything else has been setup
-        install_flatc_from_source
-        install_executorch
 
         # Run pytest with coverage
         pytest -n auto --cov=./ --cov-report=xml

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -37,87 +37,83 @@ jobs:
 
           PYTHONPATH="${PWD}" python .ci/scripts/gather_test_models.py
 
-#  test-models-linux:
-#    name: test-models-linux
-#    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-#    needs: gather-models
-#    strategy:
-#      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
-#      fail-fast: false
-#    with:
-#      runner: ${{ matrix.runner }}
-#      docker-image: executorch-ubuntu-22.04-clang12
-#      submodules: 'true'
-#      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-#      timeout: 90
-#      script: |
-#        # The generic Linux job chooses to use base env, not the one setup by the image
-#        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-#        conda activate "${CONDA_ENV}"
-#
-#        MODEL_NAME=${{ matrix.model }}
-#        BUILD_TOOL=${{ matrix.build-tool }}
-#        QUANTIZATION=${{ matrix.quantization }}
-#        XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
-#
-#        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
-#        # Build and test Executorch
-#        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${QUANTIZATION}" "${XNNPACK_DELEGATION}"
-#
-#  test-models-macos:
-#    name: test-models-macos
-#    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
-#    needs: gather-models
-#    strategy:
-#      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
-#      fail-fast: false
-#    with:
-#      runner: macos-m1-12
-#      submodules: 'true'
-#      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-#      timeout: 90
-#      script: |
-#        #PYTHON_VERSION="3.10"
-#        #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
-#        #conda activate executorch
-#
-#        WORKSPACE=$(pwd)
-#        pushd "${WORKSPACE}/pytorch/executorch"
-#
-#        MODEL_NAME=${{ matrix.model }}
-#        BUILD_TOOL=${{ matrix.build-tool }}
-#        QUANTIZATION=${{ matrix.quantization }}
-#        XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
-#
-#        # Setup MacOS dependencies as there is no Docker support on MacOS atm
-#        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
-#        # Build and test Executorch
-#        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${QUANTIZATION}" "${XNNPACK_DELEGATION}"
-#        popd
+  test-models-linux:
+    name: test-models-linux
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    needs: gather-models
+    strategy:
+      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
+      fail-fast: false
+    with:
+      runner: ${{ matrix.runner }}
+      docker-image: executorch-ubuntu-22.04-clang12
+      submodules: 'true'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 90
+      script: |
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
 
-#  test-custom-ops-linux:
-#    name: test-custom-ops-linux
-#    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-#    strategy:
-#      matrix:
-#        include:
-#          - build-tool: buck2
-#          - build-tool: cmake
-#      fail-fast: false
-#    with:
-#      runner: linux.2xlarge
-#      docker-image: executorch-ubuntu-22.04-clang12
-#      submodules: 'true'
-#      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-#      script: |
-#        # The generic Linux job chooses to use base env, not the one setup by the image
-#        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-#        conda activate "${CONDA_ENV}"
-#
-#        BUILD_TOOL=${{ matrix.build-tool }}
-#        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
-#        # Test custom ops
-#        PYTHON_EXECUTABLE=python bash examples/custom_ops/test_custom_ops.sh "${BUILD_TOOL}"
+        MODEL_NAME=${{ matrix.model }}
+        BUILD_TOOL=${{ matrix.build-tool }}
+        QUANTIZATION=${{ matrix.quantization }}
+        XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
+
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+        # Build and test Executorch
+        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${QUANTIZATION}" "${XNNPACK_DELEGATION}"
+
+  test-models-macos:
+    name: test-models-macos
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    needs: gather-models
+    strategy:
+      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
+      fail-fast: false
+    with:
+      runner: macos-m1-12
+      submodules: 'true'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 90
+      script: |
+        WORKSPACE=$(pwd)
+        pushd "${WORKSPACE}/pytorch/executorch"
+
+        MODEL_NAME=${{ matrix.model }}
+        BUILD_TOOL=${{ matrix.build-tool }}
+        QUANTIZATION=${{ matrix.quantization }}
+        XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
+
+        # Setup MacOS dependencies as there is no Docker support on MacOS atm
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+        # Build and test Executorch
+        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${QUANTIZATION}" "${XNNPACK_DELEGATION}"
+        popd
+
+  test-custom-ops-linux:
+    name: test-custom-ops-linux
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    strategy:
+      matrix:
+        include:
+          - build-tool: buck2
+          - build-tool: cmake
+      fail-fast: false
+    with:
+      runner: linux.2xlarge
+      docker-image: executorch-ubuntu-22.04-clang12
+      submodules: 'true'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      script: |
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        BUILD_TOOL=${{ matrix.build-tool }}
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+        # Test custom ops
+        PYTHON_EXECUTABLE=python bash examples/custom_ops/test_custom_ops.sh "${BUILD_TOOL}"
 
   test-custom-ops-macos:
     name: test-custom-ops-macos
@@ -133,11 +129,6 @@ jobs:
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
-        #PYTHON_VERSION="3.10"
-        #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
-        #conda activate executorch
-        conda env list
-
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"
 
@@ -149,29 +140,29 @@ jobs:
         PYTHON_EXECUTABLE=python bash examples/custom_ops/test_custom_ops.sh "${BUILD_TOOL}"
         popd
 
-#  test-selective-build-linux:
-#    name: test-selective-build-linux
-#    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-#    strategy:
-#      matrix:
-#        include:
-#          - build-tool: buck2
-#          - build-tool: cmake
-#      fail-fast: false
-#    with:
-#      runner: linux.2xlarge
-#      docker-image: executorch-ubuntu-22.04-clang12
-#      submodules: 'true'
-#      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-#      script: |
-#        # The generic Linux job chooses to use base env, not the one setup by the image
-#        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-#        conda activate "${CONDA_ENV}"
-#
-#        BUILD_TOOL=${{ matrix.build-tool }}
-#        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
-#        # Test selective build
-#        PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
+  test-selective-build-linux:
+    name: test-selective-build-linux
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    strategy:
+      matrix:
+        include:
+          - build-tool: buck2
+          - build-tool: cmake
+      fail-fast: false
+    with:
+      runner: linux.2xlarge
+      docker-image: executorch-ubuntu-22.04-clang12
+      submodules: 'true'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      script: |
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        BUILD_TOOL=${{ matrix.build-tool }}
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+        # Test selective build
+        PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
 
   test-selective-build-macos:
     name: test-selective-build-macos
@@ -187,12 +178,6 @@ jobs:
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
-        #PYTHON_VERSION="3.10"
-        #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
-        #conda activate executorch
-        conda env list
-        sleep 3600
-
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"
 

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -77,6 +77,10 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 90
       script: |
+        PYTHON_VERSION="3.10"
+        conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
+        conda activate executorch
+
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"
 
@@ -129,8 +133,11 @@ jobs:
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
-        WORKSPACE=$(pwd)
+        PYTHON_VERSION="3.10"
+        conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
+        conda activate executorch
 
+        WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"
 
         BUILD_TOOL=${{ matrix.build-tool }}
@@ -178,8 +185,11 @@ jobs:
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
-        WORKSPACE=$(pwd)
+        PYTHON_VERSION="3.10"
+        conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
+        conda activate executorch
 
+        WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"
 
         BUILD_TOOL=${{ matrix.build-tool }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -137,7 +137,6 @@ jobs:
         #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
         #conda activate executorch
         conda env list
-        sleep 3600
 
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -77,9 +77,9 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 90
       script: |
-        PYTHON_VERSION="3.10"
-        conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
-        conda activate executorch
+        #PYTHON_VERSION="3.10"
+        #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
+        #conda activate executorch
 
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"
@@ -133,9 +133,9 @@ jobs:
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
-        PYTHON_VERSION="3.10"
-        conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
-        conda activate executorch
+        #PYTHON_VERSION="3.10"
+        #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
+        #conda activate executorch
 
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"
@@ -143,6 +143,8 @@ jobs:
         BUILD_TOOL=${{ matrix.build-tool }}
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+
+        sleep 3600
         # Build and test custom ops
         PYTHON_EXECUTABLE=python bash examples/custom_ops/test_custom_ops.sh "${BUILD_TOOL}"
         popd
@@ -185,9 +187,9 @@ jobs:
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
-        PYTHON_VERSION="3.10"
-        conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
-        conda activate executorch
+        #PYTHON_VERSION="3.10"
+        #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
+        #conda activate executorch
 
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"
@@ -195,6 +197,8 @@ jobs:
         BUILD_TOOL=${{ matrix.build-tool }}
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+
+        sleep 3600
         # Build and test selective build
         PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
         popd

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -37,87 +37,87 @@ jobs:
 
           PYTHONPATH="${PWD}" python .ci/scripts/gather_test_models.py
 
-  test-models-linux:
-    name: test-models-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-    needs: gather-models
-    strategy:
-      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
-      fail-fast: false
-    with:
-      runner: ${{ matrix.runner }}
-      docker-image: executorch-ubuntu-22.04-clang12
-      submodules: 'true'
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      timeout: 90
-      script: |
-        # The generic Linux job chooses to use base env, not the one setup by the image
-        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-        conda activate "${CONDA_ENV}"
+          #  test-models-linux:
+          #    name: test-models-linux
+          #    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+          #    needs: gather-models
+          #    strategy:
+          #      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
+          #      fail-fast: false
+          #    with:
+          #      runner: ${{ matrix.runner }}
+          #      docker-image: executorch-ubuntu-22.04-clang12
+          #      submodules: 'true'
+          #      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          #      timeout: 90
+          #      script: |
+          #        # The generic Linux job chooses to use base env, not the one setup by the image
+          #        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+          #        conda activate "${CONDA_ENV}"
+          #
+          #        MODEL_NAME=${{ matrix.model }}
+          #        BUILD_TOOL=${{ matrix.build-tool }}
+          #        QUANTIZATION=${{ matrix.quantization }}
+          #        XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
+          #
+          #        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+          #        # Build and test Executorch
+          #        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${QUANTIZATION}" "${XNNPACK_DELEGATION}"
+          #
+          #  test-models-macos:
+          #    name: test-models-macos
+          #    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+          #    needs: gather-models
+          #    strategy:
+          #      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
+          #      fail-fast: false
+          #    with:
+          #      runner: macos-m1-12
+          #      submodules: 'true'
+          #      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          #      timeout: 90
+          #      script: |
+          #        #PYTHON_VERSION="3.10"
+          #        #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
+          #        #conda activate executorch
+          #
+          #        WORKSPACE=$(pwd)
+          #        pushd "${WORKSPACE}/pytorch/executorch"
+          #
+          #        MODEL_NAME=${{ matrix.model }}
+          #        BUILD_TOOL=${{ matrix.build-tool }}
+          #        QUANTIZATION=${{ matrix.quantization }}
+          #        XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
+          #
+          #        # Setup MacOS dependencies as there is no Docker support on MacOS atm
+          #        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+          #        # Build and test Executorch
+          #        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${QUANTIZATION}" "${XNNPACK_DELEGATION}"
+          #        popd
 
-        MODEL_NAME=${{ matrix.model }}
-        BUILD_TOOL=${{ matrix.build-tool }}
-        QUANTIZATION=${{ matrix.quantization }}
-        XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
-
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
-        # Build and test Executorch
-        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${QUANTIZATION}" "${XNNPACK_DELEGATION}"
-
-  test-models-macos:
-    name: test-models-macos
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
-    needs: gather-models
-    strategy:
-      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
-      fail-fast: false
-    with:
-      runner: macos-m1-12
-      submodules: 'true'
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      timeout: 90
-      script: |
-        #PYTHON_VERSION="3.10"
-        #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
-        #conda activate executorch
-
-        WORKSPACE=$(pwd)
-        pushd "${WORKSPACE}/pytorch/executorch"
-
-        MODEL_NAME=${{ matrix.model }}
-        BUILD_TOOL=${{ matrix.build-tool }}
-        QUANTIZATION=${{ matrix.quantization }}
-        XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
-
-        # Setup MacOS dependencies as there is no Docker support on MacOS atm
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
-        # Build and test Executorch
-        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${QUANTIZATION}" "${XNNPACK_DELEGATION}"
-        popd
-
-  test-custom-ops-linux:
-    name: test-custom-ops-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-    strategy:
-      matrix:
-        include:
-          - build-tool: buck2
-          - build-tool: cmake
-      fail-fast: false
-    with:
-      runner: linux.2xlarge
-      docker-image: executorch-ubuntu-22.04-clang12
-      submodules: 'true'
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      script: |
-        # The generic Linux job chooses to use base env, not the one setup by the image
-        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-        conda activate "${CONDA_ENV}"
-
-        BUILD_TOOL=${{ matrix.build-tool }}
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
-        # Test custom ops
-        PYTHON_EXECUTABLE=python bash examples/custom_ops/test_custom_ops.sh "${BUILD_TOOL}"
+          #  test-custom-ops-linux:
+          #    name: test-custom-ops-linux
+          #    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+          #    strategy:
+          #      matrix:
+          #        include:
+          #          - build-tool: buck2
+          #          - build-tool: cmake
+          #      fail-fast: false
+          #    with:
+          #      runner: linux.2xlarge
+          #      docker-image: executorch-ubuntu-22.04-clang12
+          #      submodules: 'true'
+          #      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          #      script: |
+          #        # The generic Linux job chooses to use base env, not the one setup by the image
+          #        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+          #        conda activate "${CONDA_ENV}"
+          #
+          #        BUILD_TOOL=${{ matrix.build-tool }}
+          #        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+          #        # Test custom ops
+          #        PYTHON_EXECUTABLE=python bash examples/custom_ops/test_custom_ops.sh "${BUILD_TOOL}"
 
   test-custom-ops-macos:
     name: test-custom-ops-macos

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -37,87 +37,87 @@ jobs:
 
           PYTHONPATH="${PWD}" python .ci/scripts/gather_test_models.py
 
-          #  test-models-linux:
-          #    name: test-models-linux
-          #    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-          #    needs: gather-models
-          #    strategy:
-          #      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
-          #      fail-fast: false
-          #    with:
-          #      runner: ${{ matrix.runner }}
-          #      docker-image: executorch-ubuntu-22.04-clang12
-          #      submodules: 'true'
-          #      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          #      timeout: 90
-          #      script: |
-          #        # The generic Linux job chooses to use base env, not the one setup by the image
-          #        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-          #        conda activate "${CONDA_ENV}"
-          #
-          #        MODEL_NAME=${{ matrix.model }}
-          #        BUILD_TOOL=${{ matrix.build-tool }}
-          #        QUANTIZATION=${{ matrix.quantization }}
-          #        XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
-          #
-          #        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
-          #        # Build and test Executorch
-          #        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${QUANTIZATION}" "${XNNPACK_DELEGATION}"
-          #
-          #  test-models-macos:
-          #    name: test-models-macos
-          #    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
-          #    needs: gather-models
-          #    strategy:
-          #      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
-          #      fail-fast: false
-          #    with:
-          #      runner: macos-m1-12
-          #      submodules: 'true'
-          #      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          #      timeout: 90
-          #      script: |
-          #        #PYTHON_VERSION="3.10"
-          #        #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
-          #        #conda activate executorch
-          #
-          #        WORKSPACE=$(pwd)
-          #        pushd "${WORKSPACE}/pytorch/executorch"
-          #
-          #        MODEL_NAME=${{ matrix.model }}
-          #        BUILD_TOOL=${{ matrix.build-tool }}
-          #        QUANTIZATION=${{ matrix.quantization }}
-          #        XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
-          #
-          #        # Setup MacOS dependencies as there is no Docker support on MacOS atm
-          #        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
-          #        # Build and test Executorch
-          #        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${QUANTIZATION}" "${XNNPACK_DELEGATION}"
-          #        popd
+#  test-models-linux:
+#    name: test-models-linux
+#    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+#    needs: gather-models
+#    strategy:
+#      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
+#      fail-fast: false
+#    with:
+#      runner: ${{ matrix.runner }}
+#      docker-image: executorch-ubuntu-22.04-clang12
+#      submodules: 'true'
+#      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+#      timeout: 90
+#      script: |
+#        # The generic Linux job chooses to use base env, not the one setup by the image
+#        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+#        conda activate "${CONDA_ENV}"
+#
+#        MODEL_NAME=${{ matrix.model }}
+#        BUILD_TOOL=${{ matrix.build-tool }}
+#        QUANTIZATION=${{ matrix.quantization }}
+#        XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
+#
+#        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+#        # Build and test Executorch
+#        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${QUANTIZATION}" "${XNNPACK_DELEGATION}"
+#
+#  test-models-macos:
+#    name: test-models-macos
+#    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+#    needs: gather-models
+#    strategy:
+#      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
+#      fail-fast: false
+#    with:
+#      runner: macos-m1-12
+#      submodules: 'true'
+#      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+#      timeout: 90
+#      script: |
+#        #PYTHON_VERSION="3.10"
+#        #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
+#        #conda activate executorch
+#
+#        WORKSPACE=$(pwd)
+#        pushd "${WORKSPACE}/pytorch/executorch"
+#
+#        MODEL_NAME=${{ matrix.model }}
+#        BUILD_TOOL=${{ matrix.build-tool }}
+#        QUANTIZATION=${{ matrix.quantization }}
+#        XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
+#
+#        # Setup MacOS dependencies as there is no Docker support on MacOS atm
+#        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+#        # Build and test Executorch
+#        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${QUANTIZATION}" "${XNNPACK_DELEGATION}"
+#        popd
 
-          #  test-custom-ops-linux:
-          #    name: test-custom-ops-linux
-          #    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-          #    strategy:
-          #      matrix:
-          #        include:
-          #          - build-tool: buck2
-          #          - build-tool: cmake
-          #      fail-fast: false
-          #    with:
-          #      runner: linux.2xlarge
-          #      docker-image: executorch-ubuntu-22.04-clang12
-          #      submodules: 'true'
-          #      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          #      script: |
-          #        # The generic Linux job chooses to use base env, not the one setup by the image
-          #        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-          #        conda activate "${CONDA_ENV}"
-          #
-          #        BUILD_TOOL=${{ matrix.build-tool }}
-          #        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
-          #        # Test custom ops
-          #        PYTHON_EXECUTABLE=python bash examples/custom_ops/test_custom_ops.sh "${BUILD_TOOL}"
+#  test-custom-ops-linux:
+#    name: test-custom-ops-linux
+#    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+#    strategy:
+#      matrix:
+#        include:
+#          - build-tool: buck2
+#          - build-tool: cmake
+#      fail-fast: false
+#    with:
+#      runner: linux.2xlarge
+#      docker-image: executorch-ubuntu-22.04-clang12
+#      submodules: 'true'
+#      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+#      script: |
+#        # The generic Linux job chooses to use base env, not the one setup by the image
+#        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+#        conda activate "${CONDA_ENV}"
+#
+#        BUILD_TOOL=${{ matrix.build-tool }}
+#        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+#        # Test custom ops
+#        PYTHON_EXECUTABLE=python bash examples/custom_ops/test_custom_ops.sh "${BUILD_TOOL}"
 
   test-custom-ops-macos:
     name: test-custom-ops-macos
@@ -136,6 +136,7 @@ jobs:
         #PYTHON_VERSION="3.10"
         #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
         #conda activate executorch
+        sleep 3600
 
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"
@@ -144,34 +145,33 @@ jobs:
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
 
-        sleep 3600
         # Build and test custom ops
         PYTHON_EXECUTABLE=python bash examples/custom_ops/test_custom_ops.sh "${BUILD_TOOL}"
         popd
 
-  test-selective-build-linux:
-    name: test-selective-build-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-    strategy:
-      matrix:
-        include:
-          - build-tool: buck2
-          - build-tool: cmake
-      fail-fast: false
-    with:
-      runner: linux.2xlarge
-      docker-image: executorch-ubuntu-22.04-clang12
-      submodules: 'true'
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      script: |
-        # The generic Linux job chooses to use base env, not the one setup by the image
-        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-        conda activate "${CONDA_ENV}"
-
-        BUILD_TOOL=${{ matrix.build-tool }}
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
-        # Test selective build
-        PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
+#  test-selective-build-linux:
+#    name: test-selective-build-linux
+#    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+#    strategy:
+#      matrix:
+#        include:
+#          - build-tool: buck2
+#          - build-tool: cmake
+#      fail-fast: false
+#    with:
+#      runner: linux.2xlarge
+#      docker-image: executorch-ubuntu-22.04-clang12
+#      submodules: 'true'
+#      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+#      script: |
+#        # The generic Linux job chooses to use base env, not the one setup by the image
+#        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+#        conda activate "${CONDA_ENV}"
+#
+#        BUILD_TOOL=${{ matrix.build-tool }}
+#        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+#        # Test selective build
+#        PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
 
   test-selective-build-macos:
     name: test-selective-build-macos
@@ -190,6 +190,7 @@ jobs:
         #PYTHON_VERSION="3.10"
         #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
         #conda activate executorch
+        sleep 3600
 
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"
@@ -198,7 +199,6 @@ jobs:
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
 
-        sleep 3600
         # Build and test selective build
         PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
         popd

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -136,6 +136,7 @@ jobs:
         #PYTHON_VERSION="3.10"
         #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
         #conda activate executorch
+        conda env list
         sleep 3600
 
         WORKSPACE=$(pwd)
@@ -190,6 +191,7 @@ jobs:
         #PYTHON_VERSION="3.10"
         #conda create --yes --quiet -n executorch python="${PYTHON_VERSION}"
         #conda activate executorch
+        conda env list
         sleep 3600
 
         WORKSPACE=$(pwd)


### PR DESCRIPTION
`23.5.26` from conda-forge https://anaconda.org/conda-forge/flatbuffers matches the third-party commit.  This is to avoid compilation issue when the version of `flatbuffers` from conda (used by CI) is different than the third-party commit (used when compiling).