### PR TITLE
Install Executorch when building docs

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -74,13 +74,12 @@ jobs:
         name: docs
     - name: Upload docs
       run: |
+
         set -x
         git config user.name 'pytorchbot'
         git config user.email 'soumith+bot@pytorch.org'
-
         rm -rf main
         mv html main
-
         git add --all main || true
         git commit -m "Auto-generating sphinx docs" || true
         git push -f

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -20,15 +20,18 @@ jobs:
       job-name: Build doc
       runner: linux.2xlarge
       docker-image: executorch-ubuntu-22.04-clang12
-      fetch-depth: 0
       submodules: 'true'
       repository: pytorch/executorch
       upload-artifact: docs
-
       script: |
-        # Set up Environment Variables
-        PYTHON_VERSION=3.10
-        export PATH="/opt/conda/envs/py_${PYTHON_VERSION}/bin:${PATH}"
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        source .ci/scripts/utils.sh
+        # This is a simple Python script but as it tries to import executorch.examples.models,
+        # it requires a whole bunch of Executorch dependencies on the Docker image
+        install_executorch
 
         if [[(${GITHUB_EVENT_NAME} = 'pull_request' && (${GITHUB_BASE_REF} = 'release'*)) || (${GITHUB_REF} = 'refs/heads/release'*) ]]; then
           export CHANNEL=test
@@ -36,8 +39,7 @@ jobs:
           export CHANNEL=nightly
         fi
 
-        set -ex
-        set +u
+        set -eux
 
         # Build docset:
         cd docs
@@ -48,7 +50,6 @@ jobs:
 
         # Sometimes the artifact directory already contains an "html" subdir.
         rm -rf "${RUNNER_ARTIFACT_DIR}/html"
-
         mv docs/_build/html "${RUNNER_ARTIFACT_DIR}"
 
 # Enable preview later. Previews are available publicly
@@ -73,12 +74,13 @@ jobs:
         name: docs
     - name: Upload docs
       run: |
-
         set -x
         git config user.name 'pytorchbot'
         git config user.email 'soumith+bot@pytorch.org'
+
         rm -rf main
         mv html main
+
         git add --all main || true
         git commit -m "Auto-generating sphinx docs" || true
         git push -f


### PR DESCRIPTION
This should fix the missing executorch module in https://github.com/pytorch/executorch/actions/runs/6267937461/job/17021962867?pr=437#step:11:254.  Note that all the docs build dependencies are pre-installed in the Docker image with the exception of Executorch, which needs to be installed when the CI runs to get the latest code from the change.