### PR TITLE
Fix %hhd format specifiers as PRId8

### DIFF
--- a/backends/xnnpack/runtime/utils/utils.cpp
+++ b/backends/xnnpack/runtime/utils/utils.cpp
@@ -8,6 +8,7 @@
 
 #include <executorch/backends/xnnpack/runtime/utils/utils.h>
 #include <executorch/runtime/platform/assert.h>
+#include <cinttypes>
 
 namespace torch {
 namespace executor {
@@ -170,7 +171,7 @@ std::pair<float, float> GetMinMax(const Tensor& ft) {
   float max = -std::numeric_limits<float>::max();
   ET_CHECK_MSG(
       ft.scalar_type() == ScalarType::Float,
-      "Expected float tensor but got %hhd",
+      "Expected float tensor but got %" PRId8,
       static_cast<int8_t>(ft.scalar_type()));
   const float* d = ft.const_data_ptr<float>();
   for (int i = 0; i < ft.numel(); ++i) {

--- a/kernels/optimized/cpu/op_bmm.cpp
+++ b/kernels/optimized/cpu/op_bmm.cpp
@@ -149,7 +149,7 @@ Tensor& opt_bmm_out(
     ET_FORALL_REAL_TYPES(BMM_TENSOR)
     default:
       ET_CHECK_MSG(
-          false, "Unhandled dtype %hhd", static_cast<int8_t>(scalar_type));
+          false, "Unhandled dtype %" PRId8, static_cast<int8_t>(scalar_type));
   }
 #undef BMM_TENSOR
 

--- a/kernels/optimized/cpu/op_gelu.cpp
+++ b/kernels/optimized/cpu/op_gelu.cpp
@@ -122,7 +122,7 @@ Tensor& opt_gelu_out(
     default:
       ET_CHECK_MSG(
           false,
-          "Unhandled dtype %hhd",
+          "Unhandled dtype %" PRId8,
           static_cast<int8_t>(input.scalar_type()));
   }
 #undef GELU

--- a/kernels/optimized/cpu/op_log_softmax.cpp
+++ b/kernels/optimized/cpu/op_log_softmax.cpp
@@ -110,7 +110,7 @@ void log_softmax_wrapper(const Tensor& X, int64_t dim, Tensor& out) {
     default:
       ET_CHECK_MSG(
           false,
-          "Unhandled input dtype %hhd",
+          "Unhandled input dtype %" PRId8,
           static_cast<int8_t>(input_scalar_type));
   }
 }
@@ -140,12 +140,12 @@ void opt_log_soft_max_check_preconditions(
   auto out_scalar_type = out.scalar_type();
   ET_CHECK_MSG(
       out_scalar_type == ScalarType::Float,
-      "out.scalar_type() %hhd is not Float",
+      "out.scalar_type() %" PRId8 " is not Float",
       static_cast<int8_t>(out_scalar_type));
   auto input_scalar_type = self.scalar_type();
   ET_CHECK_MSG(
       input_scalar_type == ScalarType::Float,
-      "self.scalar_type() %hhd is not Float",
+      "self.scalar_type() %" PRId8 " is not Float",
       static_cast<int8_t>(input_scalar_type));
 }
 
@@ -177,7 +177,7 @@ Tensor& opt_log_softmax_out(
     default:
       ET_CHECK_MSG(
           false,
-          "Unhandled out dtype %hhd",
+          "Unhandled out dtype %" PRId8,
           static_cast<int8_t>(out_scalar_type));
   }
   return out;

--- a/kernels/optimized/cpu/op_native_layer_norm.cpp
+++ b/kernels/optimized/cpu/op_native_layer_norm.cpp
@@ -162,7 +162,7 @@ std::tuple<Tensor&, Tensor&, Tensor&> opt_native_layer_norm_out(
     default:
       ET_CHECK_MSG(
           false,
-          "Unhandled dtype %hhd",
+          "Unhandled dtype %" PRId8,
           static_cast<int8_t>(input.scalar_type()));
   }
 #undef LAYER_NORM

--- a/kernels/portable/cpu/op_allclose.cpp
+++ b/kernels/portable/cpu/op_allclose.cpp
@@ -102,7 +102,7 @@ Tensor& allclose_out(
   ET_CHECK_SAME_SHAPE_AND_DTYPE2(self, other);
   ET_CHECK_MSG(
       out.scalar_type() == ScalarType::Bool,
-      "Out tensor must be type Bool; saw type %hhd",
+      "Out tensor must be type Bool; saw type %" PRId8,
       static_cast<int8_t>(out.scalar_type()));
   ET_CHECK_MSG(
       out.numel() == 1,

--- a/kernels/portable/cpu/op_argmax.cpp
+++ b/kernels/portable/cpu/op_argmax.cpp
@@ -39,7 +39,7 @@ void check_preconditions(
   }
   ET_CHECK_MSG(
       out.scalar_type() == ScalarType::Long,
-      "Expected out tensor to have dtype Long, but got %hhd instead",
+      "Expected out tensor to have dtype Long, but got %" PRId8 " instead",
       static_cast<int8_t>(out.scalar_type()));
   ET_CHECK_MSG(
       out.dim() == compute_reduced_out_dim(in, dim, keepdim),

--- a/kernels/portable/cpu/op_argmin.cpp
+++ b/kernels/portable/cpu/op_argmin.cpp
@@ -39,7 +39,7 @@ void check_preconditions(
   }
   ET_CHECK_MSG(
       out.scalar_type() == ScalarType::Long,
-      "Expected out tensor to have dtype Long, but got %hhd instead",
+      "Expected out tensor to have dtype Long, but got %" PRId8 " instead",
       static_cast<int8_t>(out.scalar_type()));
   ET_CHECK_MSG(
       out.dim() == compute_reduced_out_dim(in, dim, keepdim),

--- a/kernels/portable/cpu/op_as_strided_copy.cpp
+++ b/kernels/portable/cpu/op_as_strided_copy.cpp
@@ -147,7 +147,7 @@ Tensor& as_strided_copy_out(
     default:
       ET_CHECK_MSG(
           false,
-          "Unhandled dtype %hhd",
+          "Unhandled dtype %" PRId8,
           static_cast<int8_t>(self.scalar_type()));
   }
 #undef AS_STRIDED_COPY_TENSOR

--- a/kernels/portable/cpu/op_bitwise_not.cpp
+++ b/kernels/portable/cpu/op_bitwise_not.cpp
@@ -46,7 +46,7 @@ Tensor& bitwise_not_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   } else {
     ET_CHECK_MSG(
         false,
-        "Unsupported input dtype %hhd",
+        "Unsupported input dtype %" PRId8,
         static_cast<int8_t>(in.scalar_type()));
   }
 

--- a/kernels/portable/cpu/op_cumsum.cpp
+++ b/kernels/portable/cpu/op_cumsum.cpp
@@ -123,7 +123,7 @@ Tensor& cumsum_out(
       default:                                           \
         ET_CHECK_MSG(                                    \
             false,                                       \
-            "Unhandled output dtype %hhd",               \
+            "Unhandled output dtype %" PRId8,            \
             static_cast<int8_t>(out.scalar_type()));     \
     }                                                    \
     break;
@@ -133,7 +133,7 @@ Tensor& cumsum_out(
     default:
       ET_CHECK_MSG(
           false,
-          "Unhandled input dtype %hhd",
+          "Unhandled input dtype %" PRId8,
           static_cast<int8_t>(self.scalar_type()));
   }
 

--- a/kernels/portable/cpu/op_glu.cpp
+++ b/kernels/portable/cpu/op_glu.cpp
@@ -208,7 +208,7 @@ glu_out(RuntimeContext& ctx, const Tensor& self, int64_t dim, Tensor& out) {
     ET_FORALL_FLOAT_TYPES(GLU_TENSOR)
     default:
       ET_CHECK_MSG(
-          false, "Unhandled dtype %hhd", static_cast<int8_t>(in_dtype));
+          false, "Unhandled dtype %" PRId8, static_cast<int8_t>(in_dtype));
   }
 #undef GLU_TENSOR
   return out;

--- a/kernels/portable/cpu/op_nonzero.cpp
+++ b/kernels/portable/cpu/op_nonzero.cpp
@@ -38,8 +38,8 @@ void check_preconditions(const Tensor& input, const Tensor& output) {
 
   ET_CHECK_MSG(
       output.scalar_type() == ScalarType::Long,
-      "Expected out to be a Long tensor but received %hdd",
-      static_cast<short>(output.scalar_type()));
+      "Expected out to be a Long tensor but received %" PRId8,
+      static_cast<int8_t>(output.scalar_type()));
   ET_CHECK_MSG(
       output.dim() == 2,
       "Expected out to be a 2d tensor received %zd",

--- a/kernels/portable/cpu/op_ones.cpp
+++ b/kernels/portable/cpu/op_ones.cpp
@@ -65,7 +65,7 @@ Tensor& ones_out(RuntimeContext& ctx, IntArrayRef size, Tensor& out) {
     default:
       ET_CHECK_MSG(
           false,
-          "out tensor should be a real or bool dtype, but got %hhd",
+          "out tensor should be a real or bool dtype, but got %" PRId8,
           static_cast<int8_t>(out.scalar_type()));
   }
 #undef ONES_OUT

--- a/kernels/portable/cpu/op_split_copy.cpp
+++ b/kernels/portable/cpu/op_split_copy.cpp
@@ -90,7 +90,7 @@ void check_args(
     // All output dtypes must be the same.
     ET_CHECK_MSG(
         out[i].scalar_type() == out[0].scalar_type(),
-        "out[%zu] dtype %hhd != out[0] dtype %hhd",
+        "out[%zu] dtype %" PRId8 " != out[0] dtype %" PRId8,
         i,
         static_cast<int8_t>(out[i].scalar_type()),
         static_cast<int8_t>(out[0].scalar_type()));

--- a/kernels/portable/cpu/op_t_copy.cpp
+++ b/kernels/portable/cpu/op_t_copy.cpp
@@ -63,7 +63,9 @@ Tensor& t_copy_out(RuntimeContext& ctx, const Tensor& a, Tensor& out) {
     ET_FORALL_SCALAR_TYPES(TRANSPOSE_TENSORS)
     default:
       ET_CHECK_MSG(
-          false, "Unhandled dtype %hhd", static_cast<int8_t>(a.scalar_type()));
+          false,
+          "Unhandled dtype %" PRId8,
+          static_cast<int8_t>(a.scalar_type()));
   }
 
 #undef TRANSPOSE_TENSORS

--- a/kernels/portable/cpu/op_to_copy.cpp
+++ b/kernels/portable/cpu/op_to_copy.cpp
@@ -61,7 +61,7 @@ Tensor& to_copy_out(
       default:                                                 \
         ET_CHECK_MSG(                                          \
             false,                                             \
-            "Unhandled output dtype %hhd",                     \
+            "Unhandled output dtype %" PRId8,                  \
             static_cast<int8_t>(out.scalar_type()));           \
     }                                                          \
     break;
@@ -71,7 +71,7 @@ Tensor& to_copy_out(
     default:
       ET_CHECK_MSG(
           false,
-          "Unhandled input dtype %hhd",
+          "Unhandled input dtype %" PRId8,
           static_cast<int8_t>(self.scalar_type()));
   }
 

--- a/kernels/portable/cpu/op_transpose_copy.cpp
+++ b/kernels/portable/cpu/op_transpose_copy.cpp
@@ -91,7 +91,9 @@ Tensor& transpose_copy_int_out(
     ET_FORALL_SCALAR_TYPES(TRANSPOSE_TENSORS)
     default:
       ET_CHECK_MSG(
-          false, "Unhandled dtype %hhd", static_cast<int8_t>(a.scalar_type()));
+          false,
+          "Unhandled dtype %" PRId8,
+          static_cast<int8_t>(a.scalar_type()));
   }
 
 #undef TRANSPOSE_TENSORS

--- a/kernels/portable/cpu/op_tril.cpp
+++ b/kernels/portable/cpu/op_tril.cpp
@@ -150,7 +150,7 @@ Tensor& tril_out(
     default:
       ET_CHECK_MSG(
           false,
-          "out tensor should be a real or bool dtype, but got %hhd",
+          "out tensor should be a real or bool dtype, but got %" PRId8,
           static_cast<int8_t>(out.scalar_type()));
   }
 #undef TRIL_OUT

--- a/kernels/portable/cpu/op_unbind_copy.cpp
+++ b/kernels/portable/cpu/op_unbind_copy.cpp
@@ -44,7 +44,7 @@ void check_args(const Tensor& input, int64_t dim, TensorList out) {
     // All output dtypes must be the same.
     ET_CHECK_MSG(
         out[i].scalar_type() == out[0].scalar_type(),
-        "out[%zu] dtype %hhd != out[0] dtype %hhd",
+        "out[%zu] dtype %" PRId8 " != out[0] dtype %" PRId8,
         i,
         static_cast<int8_t>(out[i].scalar_type()),
         static_cast<int8_t>(out[0].scalar_type()));

--- a/kernels/portable/cpu/pattern/unary_ufunc_realb_to_bool.cpp
+++ b/kernels/portable/cpu/pattern/unary_ufunc_realb_to_bool.cpp
@@ -29,7 +29,7 @@ Tensor& unary_ufunc_realb_to_bool(
 
   ET_CHECK_MSG(
       out.scalar_type() == exec_aten::ScalarType::Bool,
-      "Expected out tensor to have dtype Bool, but got %hhd instead.",
+      "Expected out tensor to have dtype Bool, but got %" PRId8 " instead.",
       static_cast<int8_t>(out.scalar_type()));
 
   const auto in_type = in.scalar_type();

--- a/kernels/portable/cpu/util/index_util.cpp
+++ b/kernels/portable/cpu/util/index_util.cpp
@@ -121,7 +121,7 @@ bool indices_list_is_valid(
     } else {
       ET_LOG_MSG_AND_RETURN_IF_FALSE(
           false,
-          "%hhd scalar type is not supported for indices",
+          "%" PRId8 " scalar type is not supported for indices",
           static_cast<int8_t>(index.scalar_type()));
     }
   }

--- a/kernels/quantized/cpu/op_add.cpp
+++ b/kernels/quantized/cpu/op_add.cpp
@@ -152,7 +152,9 @@ Tensor& quantized_add_out(
     ET_FORALL_INT_TYPES(ADD_TENSORS)
     default:
       ET_CHECK_MSG(
-          false, "Unhandled dtype %hhd", static_cast<int8_t>(a.scalar_type()));
+          false,
+          "Unhandled dtype %" PRId8,
+          static_cast<int8_t>(a.scalar_type()));
   }
 
 #undef ADD_TENSORS

--- a/kernels/quantized/cpu/op_choose_qparams.cpp
+++ b/kernels/quantized/cpu/op_choose_qparams.cpp
@@ -46,16 +46,16 @@ void check_quantize_per_tensor_args(
       qmax);
   ET_CHECK_MSG(
       input.scalar_type() == ScalarType::Float,
-      "Expected input to be Float tensor received: %hdd",
-      static_cast<short>(input.scalar_type()));
+      "Expected input to be Float tensor received: %" PRId8,
+      static_cast<int8_t>(input.scalar_type()));
   ET_CHECK_MSG(
       scale_out.scalar_type() == ScalarType::Double,
-      "Expected scale to be Double tensor received: %hdd",
-      static_cast<short>(scale_out.scalar_type()));
+      "Expected scale to be Double tensor received: %" PRId8,
+      static_cast<int8_t>(scale_out.scalar_type()));
   ET_CHECK_MSG(
       zero_point_out.scalar_type() == ScalarType::Long,
-      "Expected scale to be Long tensor received: %hdd",
-      static_cast<short>(zero_point_out.scalar_type()));
+      "Expected scale to be Long tensor received: %" PRId8,
+      static_cast<int8_t>(zero_point_out.scalar_type()));
   ET_CHECK_MSG(
       scale_out.numel() == 1,
       "Exepcted scale to only have one element received: %zd",

--- a/kernels/quantized/cpu/op_dequantize.cpp
+++ b/kernels/quantized/cpu/op_dequantize.cpp
@@ -40,18 +40,18 @@ void check_dequantize_per_tensor_args(
           input.scalar_type() == ScalarType::Char ||
           input.scalar_type() == ScalarType::Short ||
           input.scalar_type() == ScalarType::Int,
-      "input.scalar_type() %hdd is not supported:",
-      static_cast<short>(input.scalar_type()));
+      "input.scalar_type() %" PRId8 " is not supported:",
+      static_cast<int8_t>(input.scalar_type()));
 
   ET_CHECK_MSG(
       input.scalar_type() == dtype,
-      "input.scalar_type() %hdd is not matching dtype argumenta:",
-      static_cast<short>(input.scalar_type()));
+      "input.scalar_type() %" PRId8 " is not matching dtype argumenta:",
+      static_cast<int8_t>(input.scalar_type()));
 
   ET_CHECK_MSG(
       out.scalar_type() == ScalarType::Float,
-      "out.scalar_type() %hdd is not supported:",
-      static_cast<short>(out.scalar_type()));
+      "out.scalar_type() %" PRId8 " is not supported:",
+      static_cast<int8_t>(out.scalar_type()));
 
   ET_CHECK_MSG(
       quant_min <= quant_max,
@@ -107,7 +107,7 @@ Tensor& dequantize_per_tensor_out(
       default:                                               \
         ET_CHECK_MSG(                                        \
             false,                                           \
-            "Unhandled output dtype %hhd",                   \
+            "Unhandled output dtype %" PRId8,                \
             static_cast<int8_t>(out.scalar_type()));         \
     }                                                        \
     break;
@@ -117,7 +117,7 @@ Tensor& dequantize_per_tensor_out(
     default:
       ET_CHECK_MSG(
           false,
-          "Unhandled input dtype %hhd",
+          "Unhandled input dtype %" PRId8,
           static_cast<int8_t>(input.scalar_type()));
   }
 
@@ -136,12 +136,12 @@ Tensor& dequantize_per_tensor_tensor_args_out(
     Tensor& out) {
   ET_CHECK_MSG(
       scale.scalar_type() == ScalarType::Double,
-      "Expected scale to be Double tensor received: %hdd",
-      static_cast<short>(scale.scalar_type()));
+      "Expected scale to be Double tensor received: %" PRId8,
+      static_cast<int8_t>(scale.scalar_type()));
   ET_CHECK_MSG(
       zero_point.scalar_type() == ScalarType::Long,
-      "Expected scale to be Long tensor received: %hdd",
-      static_cast<short>(zero_point.scalar_type()));
+      "Expected scale to be Long tensor received: %" PRId8,
+      static_cast<int8_t>(zero_point.scalar_type()));
   ET_CHECK_MSG(
       scale.numel() == 1,
       "Exepcted scale to only have one element received: %zd",

--- a/kernels/quantized/cpu/op_embedding.cpp
+++ b/kernels/quantized/cpu/op_embedding.cpp
@@ -35,28 +35,30 @@ void check_embedding_byte_args(
   ET_CHECK_MSG(
       weight.scalar_type() == ScalarType::Byte ||
           weight.scalar_type() == ScalarType::Char,
-      "weight.scalar_type() %hdd is not supported:",
-      static_cast<short>(weight.scalar_type()));
+      "weight.scalar_type() %" PRId8 " is not supported:",
+      static_cast<int8_t>(weight.scalar_type()));
 
   ET_CHECK_MSG(
       weight_scales.scalar_type() == ScalarType::Float,
-      "weight_scales.scalar_type() %hdd is not float only float is supported:",
-      static_cast<short>(weight_scales.scalar_type()));
+      "weight_scales.scalar_type() %" PRId8
+      " is not float only float is supported:",
+      static_cast<int8_t>(weight_scales.scalar_type()));
 
   ET_CHECK_MSG(
       weight_zero_points.scalar_type() == ScalarType::Float,
-      "weight_zero_points.scalar_type() %hdd is not Float only Float is supported for embedding:",
-      static_cast<short>(weight_zero_points.scalar_type()));
+      "weight_zero_points.scalar_type() %" PRId8
+      " is not Float only Float is supported for embedding:",
+      static_cast<int8_t>(weight_zero_points.scalar_type()));
 
   ET_CHECK_MSG(
       indices.scalar_type() == ScalarType::Long,
-      "indices.scalar_type() %hdd is not Long only Long is supported:",
-      static_cast<short>(indices.scalar_type()));
+      "indices.scalar_type() %" PRId8 " is not Long only Long is supported:",
+      static_cast<int8_t>(indices.scalar_type()));
 
   ET_CHECK_MSG(
       out.scalar_type() == ScalarType::Float,
-      "out.scalar_type() %hdd is not supported:",
-      static_cast<short>(out.scalar_type()));
+      "out.scalar_type() %" PRId8 " is not supported:",
+      static_cast<int8_t>(out.scalar_type()));
 
   ET_CHECK_MSG(
       weight_quant_min <= weight_quant_max,
@@ -167,7 +169,7 @@ Tensor& quantized_embedding_byte_out(
     default:                                                        \
       ET_CHECK_MSG(                                                 \
           false,                                                    \
-          "Unhandled output dtype %hhd",                            \
+          "Unhandled output dtype %" PRId8,                         \
           static_cast<int8_t>(out.scalar_type()));                  \
   }
 
@@ -181,7 +183,7 @@ Tensor& quantized_embedding_byte_out(
     default:
       ET_CHECK_MSG(
           false,
-          "Unhandled weight dtype %hhd",
+          "Unhandled weight dtype %" PRId8,
           static_cast<int8_t>(weight.scalar_type()));
   }
 #undef CALCULATE_OUT_DTYPE

--- a/kernels/quantized/cpu/op_quantize.cpp
+++ b/kernels/quantized/cpu/op_quantize.cpp
@@ -36,16 +36,16 @@ void check_quantize_per_tensor_args(
   // Ensure self and out has the same shape
   ET_CHECK_MSG(
       torch::executor::isFloatingType(input.scalar_type()),
-      "input.scalar_type() %hdd is not floating type",
-      static_cast<short>(input.scalar_type()));
+      "input.scalar_type() %" PRId8 " is not floating type",
+      static_cast<int8_t>(input.scalar_type()));
 
   int32_t quant_min_lower_bound = 0, quant_max_upper_bound = 0;
   ScalarType out_dtype = out.scalar_type();
   ET_CHECK_MSG(
       out_dtype == dtype,
-      "out.scalar_type() %hdd is not matching dtype argument %hdd",
-      static_cast<short>(out_dtype),
-      static_cast<short>(dtype));
+      "out.scalar_type() %" PRId8 " is not matching dtype argument %" PRId8,
+      static_cast<int8_t>(out_dtype),
+      static_cast<int8_t>(dtype));
   if (out_dtype == ScalarType::Byte) {
     quant_min_lower_bound =
         static_cast<int32_t>(std::numeric_limits<uint8_t>::min());
@@ -64,7 +64,7 @@ void check_quantize_per_tensor_args(
     quant_max_upper_bound = std::numeric_limits<int32_t>::max();
   } else {
     ET_CHECK_MSG(
-        false, "Unsupported dtype: %hdd", static_cast<short>(out_dtype));
+        false, "Unsupported dtype: %" PRId8, static_cast<int8_t>(out_dtype));
   }
   ET_CHECK_MSG(
       quant_min >= quant_min_lower_bound,
@@ -131,7 +131,7 @@ Tensor& quantize_per_tensor_out(
       default:                                           \
         ET_CHECK_MSG(                                    \
             false,                                       \
-            "Unhandled output dtype %hhd",               \
+            "Unhandled output dtype %" PRId8,            \
             static_cast<int8_t>(out.scalar_type()));     \
     }                                                    \
     break;
@@ -141,7 +141,7 @@ Tensor& quantize_per_tensor_out(
     default:
       ET_CHECK_MSG(
           false,
-          "Unhandled input dtype %hhd",
+          "Unhandled input dtype %" PRId8,
           static_cast<int8_t>(input.scalar_type()));
   }
 #undef CALCULATE_FLOAT_TYPE
@@ -159,12 +159,12 @@ Tensor& quantize_per_tensor_tensor_args_out(
     Tensor& out) {
   ET_CHECK_MSG(
       scale.scalar_type() == ScalarType::Double,
-      "Expected scale to be Double tensor received: %hdd",
-      static_cast<short>(scale.scalar_type()));
+      "Expected scale to be Double tensor received: %" PRId8,
+      static_cast<int8_t>(scale.scalar_type()));
   ET_CHECK_MSG(
       zero_point.scalar_type() == ScalarType::Long,
-      "Expected zero_point to be Long tensor received: %hdd",
-      static_cast<short>(zero_point.scalar_type()));
+      "Expected zero_point to be Long tensor received: %" PRId8,
+      static_cast<int8_t>(zero_point.scalar_type()));
   ET_CHECK_MSG(
       scale.numel() == 1,
       "Exepcted scale to only have one element received: %zd",

--- a/runtime/core/exec_aten/util/tensor_util.h
+++ b/runtime/core/exec_aten/util/tensor_util.h
@@ -122,28 +122,29 @@
   })
 
 /// Asserts that all tensors have the same dtype.
-#define ET_CHECK_SAME_DTYPE2(a__, b__)                            \
-  ({                                                              \
-    const ::exec_aten::ScalarType a_type__ = (a__).scalar_type(); \
-    const ::exec_aten::ScalarType b_type__ = (b__).scalar_type(); \
-    ET_CHECK_MSG(                                                 \
-        a_type__ == b_type__,                                     \
-        ET_TENSOR_CHECK_PREFIX__ ": dtype={%hhd, %hhd}",          \
-        static_cast<int8_t>(a_type__),                            \
-        static_cast<int8_t>(b_type__));                           \
+#define ET_CHECK_SAME_DTYPE2(a__, b__)                               \
+  ({                                                                 \
+    const ::exec_aten::ScalarType a_type__ = (a__).scalar_type();    \
+    const ::exec_aten::ScalarType b_type__ = (b__).scalar_type();    \
+    ET_CHECK_MSG(                                                    \
+        a_type__ == b_type__,                                        \
+        ET_TENSOR_CHECK_PREFIX__ ": dtype={%" PRId8 ", %" PRId8 "}", \
+        static_cast<int8_t>(a_type__),                               \
+        static_cast<int8_t>(b_type__));                              \
   })
 
-#define ET_CHECK_SAME_DTYPE3(a__, b__, c__)                       \
-  ({                                                              \
-    const ::exec_aten::ScalarType a_type__ = (a__).scalar_type(); \
-    const ::exec_aten::ScalarType b_type__ = (b__).scalar_type(); \
-    const ::exec_aten::ScalarType c_type__ = (c__).scalar_type(); \
-    ET_CHECK_MSG(                                                 \
-        a_type__ == b_type__ && b_type__ == c_type__,             \
-        ET_TENSOR_CHECK_PREFIX__ ": dtype={%hhd, %hhd, %hhd}",    \
-        static_cast<int8_t>(a_type__),                            \
-        static_cast<int8_t>(b_type__),                            \
-        static_cast<int8_t>(c_type__));                           \
+#define ET_CHECK_SAME_DTYPE3(a__, b__, c__)                                 \
+  ({                                                                        \
+    const ::exec_aten::ScalarType a_type__ = (a__).scalar_type();           \
+    const ::exec_aten::ScalarType b_type__ = (b__).scalar_type();           \
+    const ::exec_aten::ScalarType c_type__ = (c__).scalar_type();           \
+    ET_CHECK_MSG(                                                           \
+        a_type__ == b_type__ && b_type__ == c_type__,                       \
+        ET_TENSOR_CHECK_PREFIX__ ": dtype={%" PRId8 ", %" PRId8 ", %" PRId8 \
+                                 "}",                                       \
+        static_cast<int8_t>(a_type__),                                      \
+        static_cast<int8_t>(b_type__),                                      \
+        static_cast<int8_t>(c_type__));                                     \
   })
 
 /**
@@ -152,37 +153,37 @@
  * This macro should produce less code/data than calling the SHAPE and DTYPE
  * macros independently, because it only calls ET_CHECK_MSG once.
  */
-#define ET_CHECK_SAME_SHAPE_AND_DTYPE2(a__, b__)                          \
-  ({                                                                      \
-    const size_t a_numel__ = (a__).numel();                               \
-    const size_t b_numel__ = (b__).numel();                               \
-    const size_t a_dim__ = (a__).dim();                                   \
-    const size_t b_dim__ = (b__).dim();                                   \
-    const ::exec_aten::ScalarType a_type__ = (a__).scalar_type();         \
-    const ::exec_aten::ScalarType b_type__ = (b__).scalar_type();         \
-                                                                          \
-    ET_CHECK_MSG(                                                         \
-        a_numel__ == b_numel__ &&                                         \
-            ((a_numel__ == 1 && b_numel__ == 1) || a_dim__ == b_dim__) && \
-            a_type__ == b_type__,                                         \
-        ET_TENSOR_CHECK_PREFIX__                                          \
-        ": numel={%zu, %zu}, dim={%zu, %zu}, dtype={%hhd, %hhd}",         \
-        a_numel__,                                                        \
-        b_numel__,                                                        \
-        a_dim__,                                                          \
-        b_dim__,                                                          \
-        static_cast<int8_t>(a_type__),                                    \
-        static_cast<int8_t>(b_type__));                                   \
-    for (size_t dim__ = 0; dim__ < ET_MIN2(a_dim__, b_dim__); ++dim__) {  \
-      size_t a_size__ = (a__).size(dim__);                                \
-      size_t b_size__ = (b__).size(dim__);                                \
-      ET_CHECK_MSG(                                                       \
-          a_size__ == b_size__,                                           \
-          ET_TENSOR_CHECK_PREFIX__ " at size(%zu): {%zu, %zu}",           \
-          dim__,                                                          \
-          a_size__,                                                       \
-          b_size__);                                                      \
-    }                                                                     \
+#define ET_CHECK_SAME_SHAPE_AND_DTYPE2(a__, b__)                              \
+  ({                                                                          \
+    const size_t a_numel__ = (a__).numel();                                   \
+    const size_t b_numel__ = (b__).numel();                                   \
+    const size_t a_dim__ = (a__).dim();                                       \
+    const size_t b_dim__ = (b__).dim();                                       \
+    const ::exec_aten::ScalarType a_type__ = (a__).scalar_type();             \
+    const ::exec_aten::ScalarType b_type__ = (b__).scalar_type();             \
+                                                                              \
+    ET_CHECK_MSG(                                                             \
+        a_numel__ == b_numel__ &&                                             \
+            ((a_numel__ == 1 && b_numel__ == 1) || a_dim__ == b_dim__) &&     \
+            a_type__ == b_type__,                                             \
+        ET_TENSOR_CHECK_PREFIX__                                              \
+        ": numel={%zu, %zu}, dim={%zu, %zu}, dtype={%" PRId8 ", %" PRId8 "}", \
+        a_numel__,                                                            \
+        b_numel__,                                                            \
+        a_dim__,                                                              \
+        b_dim__,                                                              \
+        static_cast<int8_t>(a_type__),                                        \
+        static_cast<int8_t>(b_type__));                                       \
+    for (size_t dim__ = 0; dim__ < ET_MIN2(a_dim__, b_dim__); ++dim__) {      \
+      size_t a_size__ = (a__).size(dim__);                                    \
+      size_t b_size__ = (b__).size(dim__);                                    \
+      ET_CHECK_MSG(                                                           \
+          a_size__ == b_size__,                                               \
+          ET_TENSOR_CHECK_PREFIX__ " at size(%zu): {%zu, %zu}",               \
+          dim__,                                                              \
+          a_size__,                                                           \
+          b_size__);                                                          \
+    }                                                                         \
   })
 
 #define ET_CHECK_SAME_SHAPE_AND_DTYPE3(a__, b__, c__)                  \
@@ -204,7 +205,7 @@
             a_type__ == b_type__ && b_type__ == c_type__,              \
         ET_TENSOR_CHECK_PREFIX__                                       \
         ": numel={%zu, %zu, %zu}, dim={%zu, %zu, %zu}, "               \
-        "dtype={%hhd, %hhd, %hhd}",                                    \
+        "dtype={%" PRId8 ", %" PRId8 ", %" PRId8 "}",                  \
         a_numel__,                                                     \
         b_numel__,                                                     \
         c_numel__,                                                     \

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -241,7 +241,7 @@ bool parse_cond_value(const EValue& cond_value) {
     // and we should exit.
     ET_CHECK_MSG(
         ScalarType::Bool == cond_val.scalar_type(),
-        "Expected dtype of %hhd got %hhd",
+        "Expected dtype of %" PRId8 " got %" PRId8,
         static_cast<int8_t>(ScalarType::Bool),
         static_cast<int8_t>(cond_val.scalar_type()));
 
@@ -705,7 +705,8 @@ Method::set_input(const EValue& input_evalue, size_t input_idx) {
     ET_CHECK_OR_RETURN_ERROR(
         t_dst.scalar_type() == t_src.scalar_type(),
         InvalidArgument,
-        "The input tensor's scalartype does not meet requirement: found %hhd but expected %hhd",
+        "The input tensor's scalartype does not meet requirement: found %" PRId8
+        " but expected %" PRId8,
         static_cast<int8_t>(t_src.scalar_type()),
         static_cast<int8_t>(t_dst.scalar_type()));
     // Reset the shape for the Method's input as the size of forwarded input


### PR DESCRIPTION
Summary: `PRId8` should be used with `int8_t` instead of `%hhd`. Additionally, fix `%hdd` to `%hhd`. `%hdd` is an invalid format and was being interpreted as `short` when it should also be `int8_t`.

Differential Revision: D49568420


