### PR TITLE
[executorch] Implement operator<<() for EValue

### DIFF
--- a/extension/evalue_util/TARGETS
+++ b/extension/evalue_util/TARGETS
@@ -1,0 +1,8 @@
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/extension/evalue_util/print_evalue.cpp
+++ b/extension/evalue_util/print_evalue.cpp
@@ -166,35 +166,48 @@ void print_list_optional_tensor(
 } // namespace
 
 std::ostream& operator<<(std::ostream& os, const EValue& value) {
-  if (value.isNone()) {
-    os << "None";
-  } else if (value.isBool()) {
-    if (value.toBool()) {
-      os << "True";
-    } else {
-      os << "False";
-    }
-  } else if (value.isInt()) {
-    os << value.toInt();
-  } else if (value.isDouble()) {
-    print_double(os, value.toDouble());
-  } else if (value.isString()) {
-    auto str = value.toString();
-    os << std::quoted(std::string(str.data(), str.size()));
-  } else if (value.isTensor()) {
-    print_tensor(os, value.toTensor());
-  } else if (value.isBoolList()) {
-    print_scalar_list(os, value.toBoolList());
-  } else if (value.isIntList()) {
-    print_scalar_list(os, value.toIntList());
-  } else if (value.isDoubleList()) {
-    print_scalar_list(os, value.toDoubleList());
-  } else if (value.isTensorList()) {
-    print_tensor_list(os, value.toTensorList());
-  } else if (value.isListOptionalTensor()) {
-    print_list_optional_tensor(os, value.toListOptionalTensor());
-  } else {
-    os << "<Unknown EValue tag " << static_cast<int>(value.tag) << ">";
+  switch (value.tag) {
+    case Tag::None:
+      os << "None";
+      break;
+    case Tag::Bool:
+      if (value.toBool()) {
+        os << "True";
+      } else {
+        os << "False";
+      }
+      break;
+    case Tag::Int:
+      os << value.toInt();
+      break;
+    case Tag::Double:
+      print_double(os, value.toDouble());
+      break;
+    case Tag::String: {
+      auto str = value.toString();
+      os << std::quoted(std::string(str.data(), str.size()));
+    } break;
+    case Tag::Tensor:
+      print_tensor(os, value.toTensor());
+      break;
+    case Tag::ListBool:
+      print_scalar_list(os, value.toBoolList());
+      break;
+    case Tag::ListInt:
+      print_scalar_list(os, value.toIntList());
+      break;
+    case Tag::ListDouble:
+      print_scalar_list(os, value.toDoubleList());
+      break;
+    case Tag::ListTensor:
+      print_tensor_list(os, value.toTensorList());
+      break;
+    case Tag::ListOptionalTensor:
+      print_list_optional_tensor(os, value.toListOptionalTensor());
+      break;
+    default:
+      os << "<Unknown EValue tag " << static_cast<int>(value.tag) << ">";
+      break;
   }
   return os;
 }

--- a/extension/evalue_util/print_evalue.h
+++ b/extension/evalue_util/print_evalue.h
@@ -57,12 +57,12 @@ class evalue_edge_items final {
   friend std::ostream& operator<<(
       std::ostream& os,
       const evalue_edge_items& e) {
-    os.iword(xalloc_index()) = e.edge_items_;
+    set_edge_items(os, e.edge_items_);
     return os;
   }
 
  private:
-  static long xalloc_index();
+  static void set_edge_items(std::ostream& os, long edge_items);
 
   const long edge_items_;
 };

--- a/extension/evalue_util/print_evalue.h
+++ b/extension/evalue_util/print_evalue.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ostream>
+
+#include <executorch/runtime/core/evalue.h>
+
+namespace torch {
+namespace executor {
+
+/**
+ * Prints an Evalue to a stream.
+ */
+std::ostream& operator<<(std::ostream& os, const EValue& value);
+// Note that this must be declared in the same namespace as EValue.
+
+namespace util {
+
+/**
+ * Sets the number of "edge items" when printing EValue lists to a stream.
+ *
+ * The edge item count is used to elide inner elements from large lists, and
+ * like core PyTorch defaults to 3.
+ *
+ * For example,
+ * ```
+ * os << torch::executor::util::evalue_edge_items(3) << evalue_int_list << "\n";
+ * os << torch::executor::util::evalue_edge_items(1) << evalue_int_list << "\n";
+ * ```
+ * will print the same list with three edge items, then with only one edge item:
+ * ```
+ * [0, 1, 2,  ..., 6, 7, 8]
+ * [0,  ..., 8]
+ * ```
+ * This setting is sticky, and will affect all subsequent evalues printed to the
+ * affected stream until the value is changed again.
+ *
+ * @param[in] os The stream to modify.
+ * @param[in] edge_items The number of "edge items" to print at the beginning
+ *     and end of a list before eliding inner elements. If zero or negative,
+ *     uses the default number of edge items.
+ */
+class evalue_edge_items final {
+  // See https://stackoverflow.com/a/29337924 for other examples of stream
+  // manipulators like this.
+ public:
+  explicit evalue_edge_items(long edge_items)
+      : edge_items_(edge_items < 0 ? 0 : edge_items) {}
+
+  friend std::ostream& operator<<(
+      std::ostream& os,
+      const evalue_edge_items& e) {
+    os.iword(xalloc_index()) = e.edge_items_;
+    return os;
+  }
+
+ private:
+  static long xalloc_index();
+
+  const long edge_items_;
+};
+
+} // namespace util
+} // namespace executor
+} // namespace torch

--- a/extension/evalue_util/targets.bzl
+++ b/extension/evalue_util/targets.bzl
@@ -1,0 +1,24 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    for aten_mode in (True, False):
+        aten_suffix = ("_aten" if aten_mode else "")
+
+        runtime.cxx_library(
+            name = "print_evalue" + aten_suffix,
+            srcs = ["print_evalue.cpp"],
+            exported_headers = ["print_evalue.h"],
+            visibility = ["@EXECUTORCH_CLIENTS"],
+            exported_deps = [
+                "//executorch/runtime/core:evalue" + aten_suffix,
+            ],
+            deps = [
+                "//executorch/runtime/core/exec_aten/util:scalar_type_util" + aten_suffix,
+            ],
+        )

--- a/extension/evalue_util/test/TARGETS
+++ b/extension/evalue_util/test/TARGETS
@@ -1,0 +1,6 @@
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+define_common_targets()

--- a/extension/evalue_util/test/print_evalue_test.cpp
+++ b/extension/evalue_util/test/print_evalue_test.cpp
@@ -1,0 +1,713 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/evalue_util/print_evalue.h>
+
+#include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
+
+#include <array>
+#include <cmath>
+#include <memory>
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using exec_aten::ArrayRef;
+using exec_aten::Scalar;
+using exec_aten::ScalarType;
+using torch::executor::BoxedEvalueList;
+using torch::executor::EValue;
+using torch::executor::testing::TensorFactory;
+
+void expect_output(const EValue& value, const char* expected) {
+  std::ostringstream os;
+  os << value;
+  EXPECT_STREQ(expected, os.str().c_str());
+}
+
+TEST(PrintEvalueTest, None) {
+  EValue value;
+  expect_output(value, "None");
+}
+
+//
+// Bool
+//
+
+TEST(PrintEvalueTest, TrueBool) {
+  EValue value(exec_aten::Scalar(true));
+  expect_output(value, "True");
+}
+
+TEST(PrintEvalueTest, FalseBool) {
+  EValue value(exec_aten::Scalar(false));
+  expect_output(value, "False");
+}
+
+//
+// Int
+//
+
+TEST(PrintEvalueTest, ZeroInt) {
+  EValue value(exec_aten::Scalar(0));
+  expect_output(value, "0");
+}
+
+TEST(PrintEvalueTest, PositiveInt) {
+  EValue value(exec_aten::Scalar(10));
+  expect_output(value, "10");
+}
+
+TEST(PrintEvalueTest, NegativeInt) {
+  EValue value(exec_aten::Scalar(-10));
+  expect_output(value, "-10");
+}
+
+TEST(PrintEvalueTest, LargePositiveInt) {
+  // A value that can't fit in 32 bits.
+  EValue value(exec_aten::Scalar(1152921504606846976));
+  expect_output(value, "1152921504606846976");
+}
+
+TEST(PrintEvalueTest, LargeNegativeInt) {
+  // A value that can't fit in 32 bits.
+  EValue value(exec_aten::Scalar(-1152921504606846976));
+  expect_output(value, "-1152921504606846976");
+}
+
+//
+// Double
+//
+
+TEST(PrintEvalueTest, ZeroDouble) {
+  EValue value(exec_aten::Scalar(0.0));
+  expect_output(value, "0.");
+}
+
+TEST(PrintEvalueTest, PositiveZeroDouble) {
+  EValue value(exec_aten::Scalar(+0.0));
+  expect_output(value, "0.");
+}
+
+TEST(PrintEvalueTest, NegativeZeroDouble) {
+  EValue value(exec_aten::Scalar(-0.0));
+  expect_output(value, "-0.");
+}
+
+TEST(PrintEvalueTest, PositiveIntegralDouble) {
+  EValue value(exec_aten::Scalar(10.0));
+  expect_output(value, "10.");
+}
+
+TEST(PrintEvalueTest, PositiveFractionalDouble) {
+  EValue value(exec_aten::Scalar(10.1));
+  expect_output(value, "10.1");
+}
+
+TEST(PrintEvalueTest, NegativeIntegralDouble) {
+  EValue value(exec_aten::Scalar(-10.0));
+  expect_output(value, "-10.");
+}
+
+TEST(PrintEvalueTest, NegativeFractionalDouble) {
+  EValue value(exec_aten::Scalar(-10.1));
+  expect_output(value, "-10.1");
+}
+
+TEST(PrintEvalueTest, PositiveInfinityDouble) {
+  EValue value((exec_aten::Scalar(INFINITY)));
+  expect_output(value, "inf");
+}
+
+TEST(PrintEvalueTest, NegativeInfinityDouble) {
+  EValue value((exec_aten::Scalar(-INFINITY)));
+  expect_output(value, "-inf");
+}
+
+TEST(PrintEvalueTest, NaNDouble) {
+  EValue value((exec_aten::Scalar(NAN)));
+  expect_output(value, "nan");
+}
+
+// Don't test exponents or values with larger numbers of truncated decimal
+// digits since their formatting may be system-dependent.
+
+//
+// String
+//
+
+TEST(PrintEvalueTest, EmptyString) {
+  std::string str = "";
+  EValue value(str.c_str(), str.size());
+  expect_output(value, "\"\"");
+}
+
+TEST(PrintEvalueTest, BasicString) {
+  // No escaping required.
+  std::string str = "Test Data";
+  EValue value(str.c_str(), str.size());
+  expect_output(value, "\"Test Data\"");
+}
+
+TEST(PrintEvalueTest, EscapedString) {
+  // Contains characters that need to be escaped.
+  std::string str = "double quote: \" backslash: \\";
+  EValue value(str.c_str(), str.size());
+  expect_output(value, "\"double quote: \\\" backslash: \\\\\"");
+}
+
+//
+// Tensor
+//
+
+TEST(PrintEvalueTest, BoolTensor) {
+  TensorFactory<ScalarType::Bool> tf;
+  {
+    // Unelided
+    EValue value(tf.make({2, 2}, {true, false, true, false}));
+    expect_output(value, "tensor(sizes=[2, 2], [True, False, True, False])");
+  }
+  {
+    // Elided
+    EValue value(tf.make(
+        {5, 2},
+        {true, false, true, false, true, false, true, false, true, false}));
+    expect_output(
+        value,
+        "tensor(sizes=[5, 2], [True, False, True, ..., False, True, False])");
+  }
+}
+
+template <ScalarType DTYPE>
+void test_print_integer_tensor() {
+  TensorFactory<DTYPE> tf;
+  {
+    // Unelided
+    EValue value(tf.make({2, 2}, {1, 2, 3, 4}));
+    expect_output(value, "tensor(sizes=[2, 2], [1, 2, 3, 4])");
+  }
+  {
+    // Elided
+    EValue value(tf.make({5, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
+    expect_output(value, "tensor(sizes=[5, 2], [1, 2, 3, ..., 8, 9, 10])");
+  }
+}
+
+TEST(PrintEvalueTest, ByteTensor) {
+  test_print_integer_tensor<ScalarType::Byte>();
+}
+
+TEST(PrintEvalueTest, CharTensor) {
+  test_print_integer_tensor<ScalarType::Char>();
+}
+
+TEST(PrintEvalueTest, ShortTensor) {
+  test_print_integer_tensor<ScalarType::Short>();
+}
+
+TEST(PrintEvalueTest, IntTensor) {
+  test_print_integer_tensor<ScalarType::Int>();
+}
+
+TEST(PrintEvalueTest, LongTensor) {
+  test_print_integer_tensor<ScalarType::Long>();
+}
+
+template <ScalarType DTYPE>
+void test_print_float_tensor() {
+  TensorFactory<DTYPE> tf;
+  {
+    // Unelided
+    EValue value(tf.make({2, 2}, {1.0, 2.2, 3.3, 4.0}));
+    expect_output(value, "tensor(sizes=[2, 2], [1., 2.2, 3.3, 4.])");
+  }
+  {
+    // Elided
+    EValue value(
+        tf.make({5, 2}, {1.0, 2.2, 3.3, 4.0, 5.5, 6.6, 7.0, 8.8, 9.0, 10.1}));
+    expect_output(
+        value, "tensor(sizes=[5, 2], [1., 2.2, 3.3, ..., 8.8, 9., 10.1])");
+  }
+}
+
+TEST(PrintEvalueTest, FloatTensor) {
+  test_print_float_tensor<ScalarType::Float>();
+}
+
+TEST(PrintEvalueTest, DoubleTensor) {
+  test_print_float_tensor<ScalarType::Double>();
+}
+
+//
+// BoolList
+//
+
+TEST(PrintEvalueTest, UnelidedBoolLists) {
+  // Default edge items is 3, so the longest unelided list length is 6.
+  std::array<bool, 6> list = {true, false, true, false, true, false};
+
+  // Important to test the cases where the length is less than or equal to the
+  // number of edge items (3 by default). Use bool as a proxy for this edge
+  // case; the other scalar types use the same underlying code, so they don't
+  // need to test this again.
+  {
+    EValue value(ArrayRef<bool>(list.data(), 0ul));
+    expect_output(value, "(len=0)[]");
+  }
+  {
+    EValue value(ArrayRef<bool>(list.data(), 1));
+    expect_output(value, "(len=1)[True]");
+  }
+  {
+    EValue value(ArrayRef<bool>(list.data(), 2));
+    expect_output(value, "(len=2)[True, False]");
+  }
+  {
+    EValue value(ArrayRef<bool>(list.data(), 3));
+    expect_output(value, "(len=3)[True, False, True]");
+  }
+  {
+    EValue value(ArrayRef<bool>(list.data(), 4));
+    expect_output(value, "(len=4)[True, False, True, False]");
+  }
+  {
+    EValue value(ArrayRef<bool>(list.data(), 5));
+    expect_output(value, "(len=5)[True, False, True, False, True]");
+  }
+  {
+    EValue value(ArrayRef<bool>(list.data(), 6));
+    expect_output(value, "(len=6)[True, False, True, False, True, False]");
+  }
+}
+
+TEST(PrintEvalueTest, ElidedBoolLists) {
+  std::array<bool, 10> list = {
+      true, false, true, false, true, false, true, false, true, false};
+
+  {
+    // Default edge items is 3, so the shortest elided list length is 7.
+    EValue value(ArrayRef<bool>(list.data(), 7));
+    expect_output(value, "(len=7)[True, False, True, ..., True, False, True]");
+  }
+  {
+    EValue value(ArrayRef<bool>(list.data(), 8));
+    expect_output(value, "(len=8)[True, False, True, ..., False, True, False]");
+  }
+  {
+    // Multi-digit length.
+    EValue value(ArrayRef<bool>(list.data(), 10));
+    expect_output(
+        value, "(len=10)[True, False, True, ..., False, True, False]");
+  }
+}
+
+//
+// IntList
+//
+
+TEST(PrintEvalueTest, UnelidedIntLists) {
+  // Default edge items is 3, so the longest unelided list length is 6. EValue
+  // treats int lists specially, and must be constructed from a BoxedEvalueList
+  // instead of from an ArrayRef.
+  std::array<EValue, 6> values = {
+      Scalar(-2), Scalar(-1), Scalar(0), Scalar(1), Scalar(2), Scalar(3)};
+  std::array<EValue*, values.size()> wrapped_values = {
+      &values[0],
+      &values[1],
+      &values[2],
+      &values[3],
+      &values[4],
+      &values[5],
+  };
+  // Memory that BoxedEvalueList will use to unpack wrapped_values into an
+  // ArrayRef.
+  std::array<int64_t, wrapped_values.size()> unwrapped_values;
+
+  {
+    BoxedEvalueList<int64_t> list(
+        wrapped_values.data(), unwrapped_values.data(), 0);
+    EValue value(list);
+    expect_output(value, "(len=0)[]");
+  }
+  {
+    BoxedEvalueList<int64_t> list(
+        wrapped_values.data(), unwrapped_values.data(), 3);
+    EValue value(list);
+    expect_output(value, "(len=3)[-2, -1, 0]");
+  }
+  {
+    BoxedEvalueList<int64_t> list(
+        wrapped_values.data(), unwrapped_values.data(), 6);
+    EValue value(list);
+    expect_output(value, "(len=6)[-2, -1, 0, 1, 2, 3]");
+  }
+}
+
+TEST(PrintEvalueTest, ElidedIntLists) {
+  std::array<EValue, 10> values = {
+      Scalar(-4),
+      Scalar(-3),
+      Scalar(-2),
+      Scalar(-1),
+      Scalar(0),
+      Scalar(1),
+      Scalar(2),
+      Scalar(3),
+      Scalar(4),
+      Scalar(5),
+  };
+  std::array<EValue*, values.size()> wrapped_values = {
+      &values[0],
+      &values[1],
+      &values[2],
+      &values[3],
+      &values[4],
+      &values[5],
+      &values[6],
+      &values[7],
+      &values[8],
+      &values[9],
+  };
+  // Memory that BoxedEvalueList will use to unpack wrapped_values into an
+  // ArrayRef.
+  std::array<int64_t, wrapped_values.size()> unwrapped_values;
+
+  {
+    // Default edge items is 3, so the shortest elided list length is 7.
+    BoxedEvalueList<int64_t> list(
+        wrapped_values.data(), unwrapped_values.data(), 7);
+    EValue value(list);
+    expect_output(value, "(len=7)[-4, -3, -2, ..., 0, 1, 2]");
+  }
+  {
+    BoxedEvalueList<int64_t> list(
+        wrapped_values.data(), unwrapped_values.data(), 8);
+    EValue value(list);
+    expect_output(value, "(len=8)[-4, -3, -2, ..., 1, 2, 3]");
+  }
+  {
+    // Multi-digit length.
+    BoxedEvalueList<int64_t> list(
+        wrapped_values.data(), unwrapped_values.data(), 10);
+    EValue value(list);
+    expect_output(value, "(len=10)[-4, -3, -2, ..., 3, 4, 5]");
+  }
+}
+
+//
+// DoubleList
+//
+
+TEST(PrintEvalueTest, UnelidedDoubleLists) {
+  // Default edge items is 3, so the longest unelided list length is 6.
+  std::array<double, 6> list = {-2.2, -1, 0, INFINITY, NAN, 3.3};
+
+  {
+    EValue value(ArrayRef<double>(list.data(), 0ul));
+    expect_output(value, "(len=0)[]");
+  }
+  {
+    EValue value(ArrayRef<double>(list.data(), 3));
+    expect_output(value, "(len=3)[-2.2, -1., 0.]");
+  }
+  {
+    EValue value(ArrayRef<double>(list.data(), 6));
+    expect_output(value, "(len=6)[-2.2, -1., 0., inf, nan, 3.3]");
+  }
+}
+
+TEST(PrintEvalueTest, ElidedDoubleLists) {
+  std::array<double, 10> list = {
+      -4.4, -3.0, -2.2, -1, 0, INFINITY, NAN, 3.3, 4.0, 5.5};
+
+  {
+    // Default edge items is 3, so the shortest elided list length is 7.
+    EValue value(ArrayRef<double>(list.data(), 7));
+    expect_output(value, "(len=7)[-4.4, -3., -2.2, ..., 0., inf, nan]");
+  }
+  {
+    EValue value(ArrayRef<double>(list.data(), 8));
+    expect_output(value, "(len=8)[-4.4, -3., -2.2, ..., inf, nan, 3.3]");
+  }
+  {
+    // Multi-digit length.
+    EValue value(ArrayRef<double>(list.data(), 10));
+    expect_output(value, "(len=10)[-4.4, -3., -2.2, ..., 3.3, 4., 5.5]");
+  }
+}
+
+//
+// TensorList
+//
+
+void expect_tensor_list_output(size_t num_tensors, const char* expected) {
+  TensorFactory<ScalarType::Float> tf;
+
+  std::array<EValue, 10> values = {
+      tf.make({2, 2}, {0, 0, 0, 0}),
+      tf.make({2, 2}, {1, 1, 1, 1}),
+      tf.make({2, 2}, {2, 2, 2, 2}),
+      tf.make({2, 2}, {3, 3, 3, 3}),
+      tf.make({2, 2}, {4, 4, 4, 4}),
+      tf.make({2, 2}, {5, 5, 5, 5}),
+      tf.make({2, 2}, {6, 6, 6, 6}),
+      tf.make({2, 2}, {7, 7, 7, 7}),
+      tf.make({2, 2}, {8, 8, 8, 8}),
+      tf.make({2, 2}, {9, 9, 9, 9}),
+  };
+  std::array<EValue*, values.size()> wrapped_values = {
+      &values[0],
+      &values[1],
+      &values[2],
+      &values[3],
+      &values[4],
+      &values[5],
+      &values[6],
+      &values[7],
+      &values[8],
+      &values[9],
+  };
+  // Memory that BoxedEvalueList will use to assemble a contiguous array of
+  // Tensor entries. It's important not to destroy these entries, because the
+  // values list will own the underlying Tensors.
+  auto unwrapped_values_memory = std::make_unique<uint8_t[]>(
+      sizeof(exec_aten::Tensor) * wrapped_values.size());
+  exec_aten::Tensor* unwrapped_values =
+      reinterpret_cast<exec_aten::Tensor*>(unwrapped_values_memory.get());
+#if USE_ATEN_LIB
+  // Must be initialized because BoxedEvalueList will use operator=() on each
+  // entry. But we can't do this in non-ATen mode because
+  // torch::executor::Tensor doesn't have a default constructor.
+  for (int i = 0; i < wrapped_values.size(); ++i) {
+    new (&unwrapped_values[i]) at::Tensor();
+  }
+#endif
+
+  ASSERT_LE(num_tensors, wrapped_values.size());
+  BoxedEvalueList<exec_aten::Tensor> list(
+      wrapped_values.data(), unwrapped_values, num_tensors);
+  EValue value(list);
+  expect_output(value, expected);
+}
+
+TEST(PrintEvalueTest, EmptyTensorListIsOnOneLine) {
+  expect_tensor_list_output(0, "(len=0)[]");
+}
+
+TEST(PrintEvalueTest, SingleTensorListIsOnOneLine) {
+  expect_tensor_list_output(
+      1, "(len=1)[tensor(sizes=[2, 2], [0., 0., 0., 0.])]");
+}
+
+TEST(PrintEvalueTest, AllTensorListEntriesArePrinted) {
+  expect_tensor_list_output(
+      10,
+      "(len=10)[\n"
+      "  [0]: tensor(sizes=[2, 2], [0., 0., 0., 0.]),\n"
+      "  [1]: tensor(sizes=[2, 2], [1., 1., 1., 1.]),\n"
+      "  [2]: tensor(sizes=[2, 2], [2., 2., 2., 2.]),\n"
+      // Inner entries are never elided.
+      "  [3]: tensor(sizes=[2, 2], [3., 3., 3., 3.]),\n"
+      "  [4]: tensor(sizes=[2, 2], [4., 4., 4., 4.]),\n"
+      "  [5]: tensor(sizes=[2, 2], [5., 5., 5., 5.]),\n"
+      "  [6]: tensor(sizes=[2, 2], [6., 6., 6., 6.]),\n"
+      "  [7]: tensor(sizes=[2, 2], [7., 7., 7., 7.]),\n"
+      "  [8]: tensor(sizes=[2, 2], [8., 8., 8., 8.]),\n"
+      "  [9]: tensor(sizes=[2, 2], [9., 9., 9., 9.]),\n"
+      "]");
+}
+
+//
+// ListOptionalTensor
+//
+
+void expect_list_optional_tensor_output(
+    size_t num_tensors,
+    const char* expected) {
+  TensorFactory<ScalarType::Float> tf;
+
+  std::array<EValue, 5> values = {
+      tf.make({2, 2}, {0, 0, 0, 0}),
+      tf.make({2, 2}, {2, 2, 2, 2}),
+      tf.make({2, 2}, {4, 4, 4, 4}),
+      tf.make({2, 2}, {6, 6, 6, 6}),
+      tf.make({2, 2}, {8, 8, 8, 8}),
+  };
+  std::array<EValue*, 10> wrapped_values = {
+      nullptr, // None is represented by a nullptr in the wrapped array.
+      &values[0],
+      nullptr,
+      &values[1],
+      nullptr,
+      &values[2],
+      nullptr,
+      &values[3],
+      nullptr,
+      &values[4],
+  };
+  // Memory that BoxedEvalueList will use to assemble a contiguous array of
+  // optional<Tensor> entries. It's important not to destroy these entries,
+  // because the values list will own the underlying Tensors.
+  auto unwrapped_values_memory = std::make_unique<uint8_t[]>(
+      sizeof(exec_aten::optional<exec_aten::Tensor>) * wrapped_values.size());
+  exec_aten::optional<exec_aten::Tensor>* unwrapped_values =
+      reinterpret_cast<exec_aten::optional<exec_aten::Tensor>*>(
+          unwrapped_values_memory.get());
+  // Must be initialized because BoxedEvalueList will use operator=() on each
+  // entry.
+  for (int i = 0; i < wrapped_values.size(); ++i) {
+    new (&unwrapped_values[i]) exec_aten::optional<exec_aten::Tensor>();
+  }
+
+  ASSERT_LE(num_tensors, wrapped_values.size());
+  BoxedEvalueList<exec_aten::optional<exec_aten::Tensor>> list(
+      wrapped_values.data(), unwrapped_values, num_tensors);
+  EValue value(list);
+  expect_output(value, expected);
+}
+
+TEST(PrintEvalueTest, EmptyListOptionalTensorIsOnOneLine) {
+  expect_list_optional_tensor_output(0, "(len=0)[]");
+}
+
+TEST(PrintEvalueTest, SingleListOptionalTensorIsOnOneLine) {
+  expect_list_optional_tensor_output(1, "(len=1)[None]");
+}
+
+TEST(PrintEvalueTest, AllListOptionalTensorEntriesArePrinted) {
+  expect_list_optional_tensor_output(
+      10,
+      "(len=10)[\n"
+      "  [0]: None,\n"
+      "  [1]: tensor(sizes=[2, 2], [0., 0., 0., 0.]),\n"
+      "  [2]: None,\n"
+      // Inner entries are never elided.
+      "  [3]: tensor(sizes=[2, 2], [2., 2., 2., 2.]),\n"
+      "  [4]: None,\n"
+      "  [5]: tensor(sizes=[2, 2], [4., 4., 4., 4.]),\n"
+      "  [6]: None,\n"
+      "  [7]: tensor(sizes=[2, 2], [6., 6., 6., 6.]),\n"
+      "  [8]: None,\n"
+      "  [9]: tensor(sizes=[2, 2], [8., 8., 8., 8.]),\n"
+      "]");
+}
+
+//
+// evalue_edge_items
+//
+// Use double as a proxy for testing the edge_items logic; the other scalar
+// types use the same underlying code, so they don't need to test this again.
+//
+
+TEST(PrintEvalueTest, EdgeItemsOverride) {
+  std::array<double, 7> list = {-3.0, -2.2, -1, 0, 3.3, 4.0, 5.5};
+  EValue value(ArrayRef<double>(list.data(), 7));
+
+  {
+    // Default edge items is 3, so this should elide.
+    std::ostringstream os;
+    os << value;
+    EXPECT_STREQ(
+        os.str().c_str(), "(len=7)[-3., -2.2, -1., ..., 3.3, 4., 5.5]");
+  }
+  {
+    // Override to one edge item.
+    std::ostringstream os;
+    os << torch::executor::util::evalue_edge_items(1) << value;
+    EXPECT_STREQ(os.str().c_str(), "(len=7)[-3., ..., 5.5]");
+  }
+  {
+    // Override to more edge items than the list contains, removing the elision.
+    std::ostringstream os;
+    os << torch::executor::util::evalue_edge_items(20) << value;
+    EXPECT_STREQ(os.str().c_str(), "(len=7)[-3., -2.2, -1., 0., 3.3, 4., 5.5]");
+  }
+}
+
+TEST(PrintEvalueTest, EdgeItemsDefaults) {
+  std::array<double, 7> list = {-3.0, -2.2, -1, 0, 3.3, 4.0, 5.5};
+  EValue value(ArrayRef<double>(list.data(), 7));
+
+  {
+    // Default edge items is 3, so this should elide.
+    std::ostringstream os;
+    os << value;
+    EXPECT_STREQ(
+        os.str().c_str(), "(len=7)[-3., -2.2, -1., ..., 3.3, 4., 5.5]");
+  }
+  {
+    // A value of zero should be the same as the default.
+    std::ostringstream os;
+    os << torch::executor::util::evalue_edge_items(0) << value;
+    EXPECT_STREQ(
+        os.str().c_str(), "(len=7)[-3., -2.2, -1., ..., 3.3, 4., 5.5]");
+  }
+  {
+    // A negative should be the same as the default.
+    std::ostringstream os;
+    os << torch::executor::util::evalue_edge_items(-5) << value;
+    EXPECT_STREQ(
+        os.str().c_str(), "(len=7)[-3., -2.2, -1., ..., 3.3, 4., 5.5]");
+  }
+}
+
+TEST(PrintEvalueTest, EdgeItemsSingleStream) {
+  std::array<double, 7> list = {-3.0, -2.2, -1, 0, 3.3, 4.0, 5.5};
+  EValue value(ArrayRef<double>(list.data(), 7));
+  std::ostringstream os_before;
+
+  // Print to the same stream multiple times, showing that evalue_edge_items
+  // can be changed, and is sticky.
+  std::ostringstream os;
+  os << "default: " << value << "\n";
+  os << "      1: " << torch::executor::util::evalue_edge_items(1) << value
+     << "\n";
+  os << "still 1: " << value << "\n";
+  os << "default: " << torch::executor::util::evalue_edge_items(0) << value
+     << "\n";
+  os << "     20: " << torch::executor::util::evalue_edge_items(20) << value
+     << "\n";
+  EXPECT_STREQ(
+      os.str().c_str(),
+      "default: (len=7)[-3., -2.2, -1., ..., 3.3, 4., 5.5]\n"
+      "      1: (len=7)[-3., ..., 5.5]\n"
+      "still 1: (len=7)[-3., ..., 5.5]\n"
+      "default: (len=7)[-3., -2.2, -1., ..., 3.3, 4., 5.5]\n"
+      "     20: (len=7)[-3., -2.2, -1., 0., 3.3, 4., 5.5]\n");
+
+  // The final value of 20 does not affect other streams, whether they were
+  // created before or after the modified stream.
+  os_before << value;
+  EXPECT_STREQ(
+      os_before.str().c_str(), "(len=7)[-3., -2.2, -1., ..., 3.3, 4., 5.5]");
+
+  std::ostringstream os_after;
+  os_after << value;
+  EXPECT_STREQ(
+      os_after.str().c_str(), "(len=7)[-3., -2.2, -1., ..., 3.3, 4., 5.5]");
+}
+
+// Demonstrate the evalue_edge_items affects the data lists inside tensors.
+TEST(PrintEvalueTest, EdgeItemsAffectsTensorData) {
+  TensorFactory<ScalarType::Double> tf;
+  EValue value(tf.make(
+      {5, 1, 1, 2}, {1.0, 2.2, 3.3, 4.0, 5.5, 6.6, 7.0, 8.8, 9.0, 10.1}));
+
+  std::ostringstream os;
+  os << value << "\n";
+  os << torch::executor::util::evalue_edge_items(1) << value << "\n";
+  EXPECT_STREQ(
+      os.str().c_str(),
+      "tensor(sizes=[5, 1, 1, 2], [1., 2.2, 3.3, ..., 8.8, 9., 10.1])\n"
+      // Notice that it doesn't affect the sizes list, which is always printed
+      // in full.
+      "tensor(sizes=[5, 1, 1, 2], [1., ..., 10.1])\n");
+}

--- a/extension/evalue_util/test/print_evalue_test.cpp
+++ b/extension/evalue_util/test/print_evalue_test.cpp
@@ -76,14 +76,18 @@ TEST(PrintEvalueTest, NegativeInt) {
 }
 
 TEST(PrintEvalueTest, LargePositiveInt) {
-  // A value that can't fit in 32 bits.
-  EValue value(exec_aten::Scalar(1152921504606846976));
+  // A value that can't fit in 32 bits. Saying Scalar(<literal-long-long>) is
+  // ambiguous with c10::Scalar, so use a non-literal value.
+  constexpr int64_t i = 1152921504606846976;
+  EValue value = {exec_aten::Scalar(i)};
   expect_output(value, "1152921504606846976");
 }
 
 TEST(PrintEvalueTest, LargeNegativeInt) {
-  // A value that can't fit in 32 bits.
-  EValue value(exec_aten::Scalar(-1152921504606846976));
+  // A value that can't fit in 32 bits. Saying Scalar(<literal-long-long>) is
+  // ambiguous with c10::Scalar, so use a non-literal value.
+  constexpr int64_t i = -1152921504606846976;
+  EValue value = {exec_aten::Scalar(i)};
   expect_output(value, "-1152921504606846976");
 }
 

--- a/extension/evalue_util/test/print_evalue_test.cpp
+++ b/extension/evalue_util/test/print_evalue_test.cpp
@@ -33,6 +33,10 @@ void expect_output(const EValue& value, const char* expected) {
   EXPECT_STREQ(expected, os.str().c_str());
 }
 
+//
+// None
+//
+
 TEST(PrintEvalueTest, None) {
   EValue value;
   expect_output(value, "None");
@@ -598,6 +602,16 @@ TEST(PrintEvalueTest, AllListOptionalTensorEntriesArePrinted) {
       "  [8]: None,\n"
       "  [9]: tensor(sizes=[2, 2], [8., 8., 8., 8.]),\n"
       "]");
+}
+
+//
+// Unknown tag
+//
+
+TEST(PrintEvalueTest, UnknownTag) {
+  EValue value;
+  value.tag = static_cast<torch::executor::Tag>(5555);
+  expect_output(value, "<Unknown EValue tag 5555>");
 }
 
 //

--- a/extension/evalue_util/test/targets.bzl
+++ b/extension/evalue_util/test/targets.bzl
@@ -1,0 +1,22 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    for aten_mode in (True, False):
+        aten_suffix = "_aten" if aten_mode else ""
+
+        runtime.cxx_test(
+            name = "print_evalue_test" + aten_suffix,
+            srcs = [
+                "print_evalue_test.cpp",
+            ],
+            deps = [
+                "//executorch/extension/evalue_util:print_evalue" + aten_suffix,
+                "//executorch/runtime/core/exec_aten/testing_util:tensor_util" + aten_suffix,
+            ],
+        )

--- a/runtime/core/evalue.h
+++ b/runtime/core/evalue.h
@@ -247,7 +247,7 @@ struct EValue {
   }
 
   exec_aten::Tensor& toTensor() & {
-    ET_CHECK_MSG(isTensor(), "EValue is not a Tensor: tag is %d.", (int)tag);
+    ET_CHECK_MSG(isTensor(), "EValue is not a Tensor.");
     return payload.as_tensor;
   }
 

--- a/runtime/core/evalue.h
+++ b/runtime/core/evalue.h
@@ -247,7 +247,7 @@ struct EValue {
   }
 
   exec_aten::Tensor& toTensor() & {
-    ET_CHECK_MSG(isTensor(), "EValue is not a Tensor.");
+    ET_CHECK_MSG(isTensor(), "EValue is not a Tensor: tag is %d.", (int)tag);
     return payload.as_tensor;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #481
* #480
* __->__ #479

Add a helper utility to print `EValue`s. Doesn't format multidimensional data like PyTorch does, but we can improve that in the future if we want to.

Differential Revision: [D49574853](https://our.internmc.facebook.com/intern/diff/D49574853/)