### PR TITLE
Fix missing flatc in doc build

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -16,6 +16,10 @@ on:
 jobs:
   build:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    strategy:
+      matrix:
+        include:
+          - build-tool: buck2
     with:
       job-name: Build doc
       runner: linux.2xlarge
@@ -28,10 +32,9 @@ jobs:
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
         conda activate "${CONDA_ENV}"
 
-        source .ci/scripts/utils.sh
-        # This is a simple Python script but as it tries to import executorch.examples.models,
-        # it requires a whole bunch of Executorch dependencies on the Docker image
-        install_executorch
+        BUILD_TOOL=${{ matrix.build-tool }}
+        # Setup MacOS dependencies as there is no Docker support on MacOS atm
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
 
         if [[(${GITHUB_EVENT_NAME} = 'pull_request' && (${GITHUB_BASE_REF} = 'release'*)) || (${GITHUB_REF} = 'refs/heads/release'*) ]]; then
           export CHANNEL=test

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -181,8 +181,8 @@ ExecuTorch tutorials.
    :tags: Template
 
 .. customcarditem::
-   :header: Exporting to Executorch Tutorial
-   :card_description: A tutorial for exporting a model and lowering a it to be runnable on the Executorch runtime.
+   :header: Exporting to ExecuTorch Tutorial
+   :card_description: A tutorial for exporting a model and lowering a it to be runnable on the ExecuTorch runtime.
    :image: _static/img/generic-pytorch-logo.png
    :link: tutorials/export-to-executorch.html
    :tags: Export,Delegation,Quantization


### PR DESCRIPTION
I missed the step to install flatc in doc build workflow after https://github.com/pytorch/executorch/pull/465.  And this also fixes 2 minor leftover typos in `docs/source/index.rst` (from https://hud.pytorch.org/pytorch/executorch/commit/c3a6a6af054c346331fb6c76a3472571168bb50f)