### PR TITLE
Summary: Make xnnpack_backend depend on executorch in the CMake map `cmake_deps.toml` to avoid symbol duplications when the two link together.

### DIFF
--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -86,6 +86,9 @@ buck_targets = [
 filters = [
   ".cpp$",
 ]
+deps = [
+  "executorch",
+]
 
 [targets.xnn_executor_runner]
 buck_targets = [


### PR DESCRIPTION
Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D49624543

