### PR TITLE
Allow kernel manual registration

### DIFF
--- a/codegen/templates/RegisterKernels.cpp
+++ b/codegen/templates/RegisterKernels.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// ${generated_comment}
+// This implements register_all_kernels() API that is declared in
+// RegisterKernels.h
+#include "RegisterKernels.h"
+#include "${fn_header}" // Generated Function import headers
+
+namespace torch {
+namespace executor {
+
+Error register_all_kernels() {
+  Kernel kernels_to_register[] = {
+      ${unboxed_kernels} // Generated kernels
+  };
+  Error success_with_kernel_reg = register_kernels(kernels_to_register);
+  if (success_with_kernel_reg != Error::Ok) {
+    ET_LOG(Error, "Failed register all kernels");
+    return success_with_kernel_reg;
+  }
+  return Error::Ok;
+}
+
+} // namespace executor
+} // namespace torch

--- a/codegen/templates/RegisterKernels.h
+++ b/codegen/templates/RegisterKernels.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// ${generated_comment}
+// Exposing an API for registering all kernels at once.
+#include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/kernel/operator_registry.h>
+#include <executorch/runtime/platform/profiler.h>
+
+namespace torch {
+namespace executor {
+
+Error register_all_kernels();
+
+} // namespace executor
+} // namespace torch

--- a/runtime/kernel/test/targets.bzl
+++ b/runtime/kernel/test/targets.bzl
@@ -75,6 +75,30 @@ def define_common_targets():
         ],
     )
 
+    executorch_generated_lib(
+        name = "test_manual_registration_lib",
+        deps = [
+            ":executorch_all_ops",
+            "//executorch/kernels/portable:operators",
+        ],
+        functions_yaml_target = "//executorch/kernels/portable:functions.yaml",
+        manual_registration = True,
+        visibility = [
+            "//executorch/...",
+        ],
+    )
+
+    runtime.cxx_test(
+        name = "test_kernel_manual_registration",
+        srcs = [
+            "test_kernel_manual_registration.cpp",
+        ],
+        deps = [
+            "//executorch/runtime/kernel:operator_registry",
+            ":test_manual_registration_lib",
+        ],
+    )
+
     for aten_mode in (True, False):
         aten_suffix = "_aten" if aten_mode else ""
 

--- a/runtime/kernel/test/test_kernel_manual_registration.cpp
+++ b/runtime/kernel/test/test_kernel_manual_registration.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Include RegisterKernels.h and call register_all_kernels().
+#include <gtest/gtest.h>
+
+#include <executorch/runtime/kernel/operator_registry.h>
+#include <executorch/runtime/kernel/test/RegisterKernels.h>
+#include <executorch/runtime/platform/runtime.h>
+
+using namespace ::testing;
+
+namespace torch {
+namespace executor {
+
+class KernelManualRegistrationTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    torch::executor::runtime_init();
+  }
+};
+
+TEST_F(KernelManualRegistrationTest, ManualRegister) {
+  Error result = register_all_kernels();
+  // Check that we can find the kernel for foo.
+  EXPECT_EQ(result, Error::Ok);
+  EXPECT_FALSE(hasOpsFn("fpp"));
+  EXPECT_TRUE(hasOpsFn("aten::add.out"));
+}
+
+} // namespace executor
+} // namespace torch


### PR DESCRIPTION
Summary:
Exposing a codegen mode for generating a hook for user to register their kernels.

If we pass `--manual-registration` flag to `gen_executorch.py`, we will generate the following files:
1. RegisterKernels.h which declares a `register_all_kernels()` API inside `torch::executor` namespace.
2. RegisterKernelsEverything.cpp which implements `register_all_kernels()` by defining an array of generated kernels.

This way user can depend on the library declared by `executorch_generated_lib` macro (with `manual_registration=True`) and be able to include `RegisterKernels.h`. Then they can manually call `register_all_kernels()` instead of relying on C++ static initialization mechanism which is not available in some embedded systems.

Reviewed By: cccclai

Differential Revision: D49439673


