### PR TITLE
Re-enable ir validation for example models

### DIFF
--- a/examples/export/utils.py
+++ b/examples/export/utils.py
@@ -17,7 +17,7 @@ from executorch.exir.tracer import Value
 
 
 _EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(
-    _check_ir_validity=False,
+    _check_ir_validity=True,
 )
 
 


### PR DESCRIPTION
Summary: As titled. Decomp fixes are synced so we can re-enable the check

Differential Revision: D49647305


