### PR TITLE
Fix the key used for extraction of delegate debug handle map in emitter

### DIFF
--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -950,7 +950,7 @@ class _Emitter(torch.fx.Interpreter):
         """
         delegate_map = {}
         if hasattr(lowered_module, "meta"):
-            delegate_map = lowered_module.meta.get("delegate_map", {})
+            delegate_map = lowered_module.meta.get("debug_handle_map", {})
 
         self.instr_id_to_delegate_debug_id_map[delegate_instruction_id] = {
             "name": lowered_module.backend_id,

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -1324,4 +1324,16 @@ class TestEmit(unittest.TestCase):
             .to_edge()
             .to_executorch()
         )
+        # Reading the program triggers the call to emit_program underneath which
+        # we need to be done for our test to succeed.
+        exec_prog.program
         self.assertIsNotNone(exec_prog.delegate_map)
+        self.assertIsNotNone(exec_prog.delegate_map.get("forward"))
+        self.assertIsNotNone(exec_prog.delegate_map.get("forward").get(0))
+        self.assertEqual(
+            exec_prog.delegate_map.get("forward").get(0).get("name"),
+            "BackendWithCompilerDemo",
+        )
+        self.assertTrue(
+            len(exec_prog.delegate_map.get("forward").get(0).get("delegate_map")) != 0
+        )

--- a/runtime/core/event_tracer_hooks.h
+++ b/runtime/core/event_tracer_hooks.h
@@ -37,18 +37,22 @@ namespace internal {
 class EventTracerProfileScope final {
  public:
   EventTracerProfileScope(EventTracer* event_tracer, const char* name) {
+#ifdef ET_EVENT_TRACER_ENABLED
     event_tracer_ = event_tracer;
     if (event_tracer_ == nullptr) {
       return;
     }
     event_entry_ = event_tracer->start_profiling(name);
+#endif
   }
 
   ~EventTracerProfileScope() {
+#ifdef ET_EVENT_TRACER_ENABLED
     if (event_tracer_ == nullptr) {
       return;
     }
     event_tracer_->end_profiling(event_entry_);
+#endif
   }
 
  private:
@@ -70,18 +74,22 @@ class EventTracerProfileInstructionScope final {
       EventTracer* event_tracer,
       ChainID chain_idx,
       DebugHandle debug_handle) {
+#ifdef ET_EVENT_TRACER_ENABLED
     event_tracer_ = event_tracer;
     if (event_tracer_ == nullptr) {
       return;
     }
     event_tracer_->set_chain_debug_handle(chain_idx, debug_handle);
+#endif
   }
 
   ~EventTracerProfileInstructionScope() {
+#ifdef ET_EVENT_TRACER_ENABLED
     if (event_tracer_ == nullptr) {
       return;
     }
     event_tracer_->set_chain_debug_handle(kUnsetChainId, kUnsetDebugHandle);
+#endif
   }
 
  private:

--- a/sdk/etdump/etdump_flatcc.cpp
+++ b/sdk/etdump/etdump_flatcc.cpp
@@ -15,7 +15,7 @@ namespace torch {
 namespace executor {
 
 // Constructor implementation
-ETDumpGen::ETDumpGen(void* buffer, size_t buf_size) {
+ETDumpGen::ETDumpGen() {
   // Initialize the flatcc builder using the buffer and buffer size
   flatcc_builder_init(&builder);
   flatbuffers_buffer_start(&builder, etdump_ETDump_file_identifier);

--- a/sdk/etdump/etdump_flatcc.h
+++ b/sdk/etdump/etdump_flatcc.h
@@ -43,22 +43,20 @@ class ETDumpGen : public EventTracer {
       ChainID chain_id = -1,
       DebugHandle debug_handle = 0) override;
   virtual void end_profiling(EventTracerEntry prof_entry) override;
-  virtual void track_allocation(AllocatorID id, size_t size) override;
-  virtual AllocatorID track_allocator(const char* name) override;
   virtual EventTracerEntry start_profiling_delegate(
       const char* name,
-      DebugHandle delegate_debug_index) override {
-    return EventTracerEntry();
-  };
+      DebugHandle delegate_debug_index) override;
   virtual void end_profiling_delegate(
-      EventTracerEntry event_tracer_entry,
-      const char* metadata = nullptr) override{};
+      EventTracerEntry prof_entry,
+      const char* metadata) override;
   virtual void log_profiling_delegate(
       const char* name,
       DebugHandle delegate_debug_index,
       et_timestamp_t start_time,
       et_timestamp_t end_time,
-      const char* metadata = nullptr) override{};
+      const char* metadata) override;
+  virtual void track_allocation(AllocatorID id, size_t size) override;
+  virtual AllocatorID track_allocator(const char* name) override;
   etdump_result get_etdump_data();
   size_t get_num_blocks();
 

--- a/sdk/etdump/etdump_flatcc.h
+++ b/sdk/etdump/etdump_flatcc.h
@@ -32,7 +32,7 @@ struct etdump_result {
 
 class ETDumpGen : public EventTracer {
  public:
-  ETDumpGen(void* buffer, size_t buf_size);
+  ETDumpGen();
 
   ~ETDumpGen() override;
   void clear_builder();

--- a/sdk/etdump/etdump_schema_flatcc.fbs
+++ b/sdk/etdump/etdump_schema_flatcc.fbs
@@ -97,6 +97,9 @@ table ProfileEvent {
   // String based delegate debug identifier.
   delegate_debug_id_str:string;
 
+  // Delegate debug metadata free form string.
+  delegate_debug_metadata:string;
+
   // Time at which this event started. Could be in units of time or CPU cycles.
   start_time:ulong;
 

--- a/sdk/etdump/schema_flatcc.py
+++ b/sdk/etdump/schema_flatcc.py
@@ -90,11 +90,12 @@ class PROFILE_EVENT_ENUM(Enum):
 
 @dataclass
 class ProfileEvent:
-    name: str
+    name: Optional[str]
     chain_id: int
     instruction_id: int
-    delegate_debug_id_int: int
-    delegate_debug_id_str: str
+    delegate_debug_id_int: Optional[int]
+    delegate_debug_id_str: Optional[str]
+    delegate_debug_metadata: Optional[str]
     start_time: int
     end_time: int
 

--- a/sdk/runners/targets.bzl
+++ b/sdk/runners/targets.bzl
@@ -48,6 +48,7 @@ def define_common_targets():
                 "//executorch/runtime/executor/test:test_backend_with_delegate_mapping" + aten_suffix,
                 "//executorch/runtime/executor:program" + aten_suffix,
                 "//executorch/sdk/etdump:etdump",
+                "//executorch/sdk/etdump:etdump_flatcc",
                 "//executorch/util:bundled_program_verification" + aten_suffix,
                 "//executorch/extension/data_loader:buffer_data_loader",
                 "//executorch/extension/data_loader:file_data_loader",


### PR DESCRIPTION
Summary: In D49173918 while looking for the delegate map in the lowered_module metadata i ended up using the wrong key. It should be `debug_handle_map` and not `delegate_map`.

Reviewed By: Jack-Khuu

Differential Revision: D49620440

