### PR TITLE
Add support for using ETDumpGen (flatcc) in sdk/executor_runner

### DIFF
--- a/runtime/core/event_tracer_hooks.h
+++ b/runtime/core/event_tracer_hooks.h
@@ -37,23 +37,32 @@ namespace internal {
 class EventTracerProfileScope final {
  public:
   EventTracerProfileScope(EventTracer* event_tracer, const char* name) {
+#ifdef ET_EVENT_TRACER_ENABLED
     event_tracer_ = event_tracer;
     if (event_tracer_ == nullptr) {
       return;
     }
     event_entry_ = event_tracer->start_profiling(name);
+#else //! ET_EVENT_TRACER_ENABLED
+    (void)event_tracer;
+    (void)name;
+#endif
   }
 
   ~EventTracerProfileScope() {
+#ifdef ET_EVENT_TRACER_ENABLED
     if (event_tracer_ == nullptr) {
       return;
     }
     event_tracer_->end_profiling(event_entry_);
+#endif
   }
 
  private:
+#ifdef ET_EVENT_TRACER_ENABLED
   EventTracer* event_tracer_;
   EventTracerEntry event_entry_;
+#endif
 };
 
 /**
@@ -70,22 +79,32 @@ class EventTracerProfileInstructionScope final {
       EventTracer* event_tracer,
       ChainID chain_idx,
       DebugHandle debug_handle) {
+#ifdef ET_EVENT_TRACER_ENABLED
     event_tracer_ = event_tracer;
     if (event_tracer_ == nullptr) {
       return;
     }
     event_tracer_->set_chain_debug_handle(chain_idx, debug_handle);
+#else //! ET_EVENT_TRACER_ENABLED
+    (void)event_tracer;
+    (void)chain_idx;
+    (void)debug_handle;
+#endif
   }
 
   ~EventTracerProfileInstructionScope() {
+#ifdef ET_EVENT_TRACER_ENABLED
     if (event_tracer_ == nullptr) {
       return;
     }
     event_tracer_->set_chain_debug_handle(kUnsetChainId, kUnsetDebugHandle);
+#endif
   }
 
  private:
+#ifdef ET_EVENT_TRACER_ENABLED
   EventTracer* event_tracer_;
+#endif
 };
 
 /**

--- a/sdk/etdump/etdump_flatcc.cpp
+++ b/sdk/etdump/etdump_flatcc.cpp
@@ -15,7 +15,7 @@ namespace torch {
 namespace executor {
 
 // Constructor implementation
-ETDumpGen::ETDumpGen(void* buffer, size_t buf_size) {
+ETDumpGen::ETDumpGen() {
   // Initialize the flatcc builder using the buffer and buffer size
   flatcc_builder_init(&builder);
   flatbuffers_buffer_start(&builder, etdump_ETDump_file_identifier);
@@ -241,6 +241,10 @@ etdump_result ETDumpGen::get_etdump_data() {
     etdump_RunData_events_end(&builder);
   } else if (etdump_gen_state == ETDumpGen_Adding_Allocators) {
     etdump_RunData_allocators_end(&builder);
+  } else if (etdump_gen_state == ETDumpGen_Init) {
+    result.buf = nullptr;
+    result.size = 0;
+    return result;
   }
   etdump_ETDump_run_data_push_end(&builder);
   etdump_ETDump_run_data_end(&builder);

--- a/sdk/etdump/etdump_flatcc.h
+++ b/sdk/etdump/etdump_flatcc.h
@@ -32,7 +32,7 @@ struct etdump_result {
 
 class ETDumpGen : public EventTracer {
  public:
-  ETDumpGen(void* buffer, size_t buf_size);
+  ETDumpGen();
 
   ~ETDumpGen() override;
   void clear_builder();

--- a/sdk/etdump/targets.bzl
+++ b/sdk/etdump/targets.bzl
@@ -180,7 +180,7 @@ def define_common_targets():
         srcs = [
             "etdump_flatcc.cpp",
         ],
-        headers = [
+        exported_headers = [
             "etdump_flatcc.h",
         ],
         deps = [

--- a/sdk/etdump/tests/etdump_test.cpp
+++ b/sdk/etdump/tests/etdump_test.cpp
@@ -25,7 +25,7 @@ class ProfilerETDumpTest : public ::testing::Test {
     const size_t buf_size = 8192;
     buf = static_cast<uint8_t*>(malloc(buf_size * sizeof(uint8_t)));
 
-    etdump_gen = new ETDumpGen(buf, buf_size);
+    etdump_gen = new ETDumpGen();
   }
 
   void TearDown() override {

--- a/sdk/runners/targets.bzl
+++ b/sdk/runners/targets.bzl
@@ -48,6 +48,7 @@ def define_common_targets():
                 "//executorch/runtime/executor/test:test_backend_with_delegate_mapping" + aten_suffix,
                 "//executorch/runtime/executor:program" + aten_suffix,
                 "//executorch/sdk/etdump:etdump",
+                "//executorch/sdk/etdump:etdump_flatcc",
                 "//executorch/util:bundled_program_verification" + aten_suffix,
                 "//executorch/extension/data_loader:buffer_data_loader",
                 "//executorch/extension/data_loader:file_data_loader",


### PR DESCRIPTION
Summary: Adding support to output etdump (flatcc) in sdk/executor_runner.

Reviewed By: vmpuri

Differential Revision: D48975977

