### PR TITLE
ETRecord change to make edge dialect program a first class citizen

### DIFF
--- a/docs/website/docs/sdk/01_generating_etrecord.md
+++ b/docs/website/docs/sdk/01_generating_etrecord.md
@@ -13,7 +13,8 @@ There are two important API's users must be aware of when dealing with ETrecord:
 ```python
 generate_etrecord(
     etrecord_path: str,
-    program: Optional[Union[ExecutorchProgram, MultiMethodExecutorchProgram]] = None,
+    edge_dialect_program: ExirExportedProgram
+    executorch_program: Union[ExecutorchProgram, MultiMethodExecutorchProgram],
     export_modules: Optional[
         Dict[
             str, Union[MultiMethodExirExportedProgram, ExirExportedProgram]
@@ -23,13 +24,15 @@ generate_etrecord(
 ```
 
 Generates an ETRecord from the given objects and saves it to the given path.
-The objects that will be serialized to an ETRecord are all the graph modules present in the export_modules dict and also the graph module present in the program object, which is the closest graph module representation of what is eventually run on the device.
+The objects that will be serialized to an ETRecord are all the graph modules present in the export_modules dict, the graph module present in the edge dialect program object,
+and also the graph module present in the executorch program object, which is the closest graph module representation of what is eventually run on the device.
 
 In addition to all the graph modules we also serialize the program buffer which the users can provide to the ExecuTorch runtime to run the model.
 
 #### Parameters:
 - `etrecord_path` : Path to where the ETRecord file will be saved to.
-- `program`: ExecutorchProgram or MultiMethodExecutorchProgram for this model returned by the call to to_executorch()
+- `edge_dialect_program`: ExirExportedProgram for this model returned by the call to to_edge()
+- `executorch_program`: ExecutorchProgram or MultiMethodExecutorchProgram for this model returned by the call to to_executorch()
 - `export_modules`: Dictionary of graph modules with the key being the user provided name and the value is the corresponding exported module. The exported graph modules can be either the output of capture() or to_edge().
 
 #### Returns:

--- a/sdk/etdb/_inspector_utils.py
+++ b/sdk/etdb/_inspector_utils.py
@@ -16,16 +16,24 @@ from executorch.sdk.etdump.schema_flatcc import ETDumpFlatCC
 from executorch.sdk.etdump.serialize import deserialize_from_etdump_flatcc
 from executorch.sdk.etrecord import ETRecord, parse_etrecord
 
+EDGE_DIALECT_GRAPH_KEY = "edge_dialect_graph_module"
+
 
 def gen_graphs_from_etrecord(
     etrecord: ETRecord,
 ) -> Mapping[str, OperatorGraphWithStats]:
-    if etrecord.graph_map is None:
-        return {}
-    return {
-        name: FXOperatorGraph.gen_operator_graph(exported_program.graph_module)
-        for name, exported_program in etrecord.graph_map.items()
-    }
+    op_graph_map = {}
+    if etrecord.graph_map is not None:
+        op_graph_map = {
+            name: FXOperatorGraph.gen_operator_graph(exported_program.graph_module)
+            for name, exported_program in etrecord.graph_map.items()
+        }
+    if etrecord.edge_dialect_program is not None:
+        op_graph_map[EDGE_DIALECT_GRAPH_KEY] = FXOperatorGraph.gen_operator_graph(
+            etrecord.edge_dialect_program.graph_module
+        )
+
+    return op_graph_map
 
 
 # TODO: use anonymous function to avoid passing the dict around

--- a/sdk/etdb/inspector.py
+++ b/sdk/etdb/inspector.py
@@ -28,6 +28,7 @@ from executorch.exir import ExportedProgram
 from executorch.sdk.edir.et_schema import OperatorGraphWithStats, OperatorNode
 from executorch.sdk.etdb._inspector_utils import (
     create_debug_handle_to_op_node_mapping,
+    EDGE_DIALECT_GRAPH_KEY,
     gen_etdump_object,
     gen_etrecord_object,
     gen_graphs_from_etrecord,
@@ -71,7 +72,7 @@ class ProfileEventSignature:
         The Signature will convert these back to the intended None value
         """
         return ProfileEventSignature(
-            event.name,
+            event.name or "",
             event.instruction_id if event.instruction_id != -1 else None,
             event.delegate_debug_id_int if event.delegate_debug_id_int != -1 else None,
             event.delegate_debug_id_str if event.delegate_debug_id_str != "" else None,
@@ -346,9 +347,6 @@ class EventBlock:
                 )
 
 
-EDGE_DIALECT_GRAPH_KEY = "edge_dialect_output/forward"
-
-
 class Inspector:
     """
     APIs for examining model architecture and performance stats.
@@ -455,13 +453,13 @@ class Inspector:
         # TODO: implement
         pass
 
-    def get_exported_program(
-        self, graph: Optional[str] = EDGE_DIALECT_GRAPH_KEY
-    ) -> ExportedProgram:
+    def get_exported_program(self, graph: Optional[str] = None) -> ExportedProgram:
         """
         Access helper for ETRecord, defaults to returning Edge Dialect Program
 
         Args:
-            graph: Name of the graph to access, defaults to "edge_dialect_output/forward"
+            graph: Name of the graph to access. If None, returns the Edge Dialect Program.
         """
+        if graph is None:
+            return self._etrecord.edge_dialect_program
         return self._etrecord.graph_map.get(graph)

--- a/sdk/etdb/tests/inspector_test.py
+++ b/sdk/etdb/tests/inspector_test.py
@@ -197,6 +197,8 @@ class TestInspector(unittest.TestCase):
             EventBlock, "_gen_from_etdump"
         ), patch.object(
             inspector, "gen_graphs_from_etrecord"
+        ), patch.object(
+            inspector, "create_debug_handle_to_op_node_mapping"
         ):
             # Call the constructor of Inspector
             inspector_instance = Inspector(
@@ -209,10 +211,10 @@ class TestInspector(unittest.TestCase):
             with tempfile.TemporaryDirectory() as tmpdirname:
                 generate_etrecord(
                     tmpdirname + "/etrecord.bin",
+                    edge_output,
                     et_output,
                     {
                         "aten_dialect_output": captured_output,
-                        "edge_dialect_output": edge_output,
                     },
                 )
 

--- a/sdk/etdb/tests/inspector_utils_test.py
+++ b/sdk/etdb/tests/inspector_utils_test.py
@@ -16,6 +16,7 @@ from executorch.sdk.edir.et_schema import (
 )
 from executorch.sdk.etdb._inspector_utils import (
     create_debug_handle_to_op_node_mapping,
+    EDGE_DIALECT_GRAPH_KEY,
     gen_graphs_from_etrecord,
 )
 from executorch.sdk.etrecord import generate_etrecord, parse_etrecord
@@ -29,10 +30,10 @@ class TestInspectorUtils(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             generate_etrecord(
                 tmpdirname + "/etrecord.bin",
+                edge_output,
                 et_output,
                 {
                     "aten_dialect_output": captured_output,
-                    "edge_dialect_output": edge_output,
                 },
             )
 
@@ -42,7 +43,7 @@ class TestInspectorUtils(unittest.TestCase):
 
             self.assertTrue("aten_dialect_output/forward" in graphs)
             self.assertTrue("et_dialect_graph_module/forward" in graphs)
-            self.assertTrue("edge_dialect_output/forward" in graphs)
+            self.assertTrue(EDGE_DIALECT_GRAPH_KEY in graphs)
 
             self.assertTrue(
                 isinstance(graphs["aten_dialect_output/forward"], FXOperatorGraph)
@@ -50,9 +51,7 @@ class TestInspectorUtils(unittest.TestCase):
             self.assertTrue(
                 isinstance(graphs["et_dialect_graph_module/forward"], FXOperatorGraph)
             )
-            self.assertTrue(
-                isinstance(graphs["edge_dialect_output/forward"], FXOperatorGraph)
-            )
+            self.assertTrue(isinstance(graphs[EDGE_DIALECT_GRAPH_KEY], FXOperatorGraph))
 
     def test_create_debug_handle_to_op_node_mapping(self):
         debug_handle_to_op_node_map = {}

--- a/sdk/etrecord/tests/etrecord_test.py
+++ b/sdk/etrecord/tests/etrecord_test.py
@@ -51,10 +51,10 @@ class TestETRecord(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             generate_etrecord(
                 tmpdirname + "/etrecord.bin",
+                edge_output,
                 et_output,
                 {
                     "aten_dialect_output": captured_output,
-                    "edge_dialect_output": edge_output,
                 },
             )
 
@@ -64,7 +64,7 @@ class TestETRecord(unittest.TestCase):
                 captured_output.exported_program.graph_module,
             )
             self.check_graph_closeness(
-                etrecord.graph_map["edge_dialect_output/forward"],
+                etrecord.edge_dialect_program,
                 edge_output.exported_program.graph_module,
             )
             self.check_graph_closeness(
@@ -82,7 +82,10 @@ class TestETRecord(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             with self.assertRaises(RuntimeError):
                 generate_etrecord(
-                    tmpdirname + "/etrecord.bin", {"fail_test_case": et_output}
+                    tmpdirname + "/etrecord.bin",
+                    edge_output,
+                    et_output,
+                    {"fail_test_case": et_output},
                 )
 
     def test_etrecord_reserved_name(self):
@@ -92,5 +95,7 @@ class TestETRecord(unittest.TestCase):
                 with self.assertRaises(RuntimeError):
                     generate_etrecord(
                         tmpdirname + "/etrecord.bin",
+                        edge_output,
+                        et_output,
                         {reserved_name: captured_output.exported_program.graph_module},
                     )


### PR DESCRIPTION
Summary: As building out the Inspector APIs, we realized that we want to make edge dialect program a first class citizen of ETRecord, and also require executorch program when constructing an ETRecord (used to be optional).

Differential Revision: D49436040


