### PR TITLE
flag a bunch of method functions as deprecated

### DIFF
--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -1100,6 +1100,17 @@ Error Method::execute() {
   return experimental_reset_execution();
 }
 
+MethodMeta Method::method_meta() const {
+  auto name = serialization_plan_->name()->c_str();
+  auto method_meta = program_->method_meta(name);
+  ET_CHECK_MSG(
+      method_meta.ok(),
+      "Internal error: method_meta(%s) returned 0x%" PRIx32,
+      name,
+      static_cast<uint32_t>(method_meta.error()));
+  return method_meta.get();
+}
+
 size_t Method::values_size() const {
   return n_value_;
 }

--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -12,6 +12,7 @@
 #include <executorch/runtime/core/event_tracer.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/executor/memory_manager.h>
+#include <executorch/runtime/executor/method_meta.h>
 #include <executorch/runtime/platform/compiler.h>
 
 // Forward declare flatbuffer types. This is a public header and must not
@@ -196,17 +197,43 @@ class Method final {
    */
   __ET_NODISCARD Error experimental_reset_execution();
 
-  size_t values_size() const;
-  const EValue& get_value(size_t i) const;
-  EValue& mutable_value(size_t i);
+  /**
+   * Returns the MethodMeta that corresponds to the calling Method.
+   */
+  MethodMeta method_meta() const;
+
+  /**
+   * Returns the number of inputs the Method expects.
+   */
   size_t inputs_size() const;
-  size_t get_input_index(size_t i) const;
-  const EValue& get_input(size_t i) const;
-  EValue& mutable_input(size_t i);
+
+  /**
+   * Returns the number of outputs the Method returns.
+   */
   size_t outputs_size() const;
-  size_t get_output_index(size_t i) const;
+
+  /**
+   * Retrieves the output at the specified index.
+   */
   const EValue& get_output(size_t i) const;
-  EValue& mutable_output(size_t i);
+
+  __ET_DEPRECATED size_t values_size() const;
+  __ET_DEPRECATED const EValue& get_value(size_t i) const;
+  __ET_DEPRECATED EValue& mutable_value(size_t i);
+  /// DEPRECATED: Use MethodMeta instead to access metadata, and set_input to
+  /// update Method inputs.
+  __ET_DEPRECATED size_t get_input_index(size_t i) const;
+  /// DEPRECATED: Use MethodMeta instead to access metadata, and set_input to
+  /// update Method inputs.
+  __ET_DEPRECATED const EValue& get_input(size_t i) const;
+  /// DEPRECATED: Use MethodMeta instead to access metadata, and set_input to
+  /// update Method inputs.
+  __ET_DEPRECATED EValue& mutable_input(size_t i);
+  __ET_DEPRECATED size_t get_output_index(size_t i) const;
+  /// DEPRECATED: Use MethodMeta instead to access metadata, and get_output to
+  /// retrieve Method outputs.
+  __ET_DEPRECATED EValue& mutable_output(size_t i);
+
   ~Method();
 
  private:

--- a/runtime/executor/test/method_test.cpp
+++ b/runtime/executor/test/method_test.cpp
@@ -116,6 +116,17 @@ TEST_F(MethodTest, SetPrimInputTest) {
   torch::executor::util::FreeInputs(inputs);
 }
 
+TEST_F(MethodTest, MethodMetaTest) {
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
+  ASSERT_EQ(method.error(), Error::Ok);
+
+  auto method_meta = method->method_meta();
+
+  EXPECT_EQ(method_meta.num_inputs(), method->inputs_size());
+  EXPECT_EQ(method_meta.num_outputs(), method->outputs_size());
+}
+
 TEST_F(MethodTest, AliasedIOTest) {
   // TODO(T163238401)
   ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);


### PR DESCRIPTION
Summary: None of these should exist in the public API, but we are out of time before MVP so just deprecating

Differential Revision: D49747135


