### PR TITLE
Fix lint warning introduced in D49715284

### DIFF
--- a/exir/common.py
+++ b/exir/common.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-import copy
 import logging
 import re
 import sys


### PR DESCRIPTION
Summary: D49715284 removed some code from this file but didn't remove an import that's no longer needed. This triggered a lint error in OSS CI.

Reviewed By: angelayi

Differential Revision: D49755124


