### PR TITLE
[executorch] Work around an old GCC bug in memory_manager.h

### DIFF
--- a/runtime/executor/memory_manager.h
+++ b/runtime/executor/memory_manager.h
@@ -63,7 +63,11 @@ class MemoryManager final {
    * TODO(T162089316): Remove this once all users migrate to the new ctor.
    */
   __ET_DEPRECATED MemoryManager(
-      __ET_UNUSED MemoryAllocator* constant_allocator,
+      // We would normally use __ET_UNUSED here, but GCC older than 9.3 has a
+      // bug that triggers a syntax error when using [[maybe_unused]] on the
+      // first parameter of a constructor:
+      // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81429
+      __attribute__((unused)) MemoryAllocator* constant_allocator,
       HierarchicalAllocator* non_constant_allocator,
       MemoryAllocator* runtime_allocator,
       MemoryAllocator* kernel_temporary_allocator)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #529

We were hitting https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81429 "maybe_unused attribute triggers syntax error when used on first argument to a constructor" when building with older versions of GCC, like v8.5.0 on our devvms.

Rather than changing things everywhere by modifying compiler.h to avoid using `[[maybe_unused]]`, patch this one spot. It's deprecated anyway, and should go away soon.

Differential Revision: [D49759354](https://our.internmc.facebook.com/intern/diff/D49759354/)