### PR TITLE
fix resizing scalar tensor with empty sizes

### DIFF
--- a/runtime/core/exec_aten/util/test/tensor_util_test.cpp
+++ b/runtime/core/exec_aten/util/test/tensor_util_test.cpp
@@ -543,3 +543,11 @@ TEST_F(TensorUtilTest, TensorIsContiguous) {
   EXPECT_TRUE(tensor_is_contiguous(c));
   EXPECT_TRUE(tensor_is_contiguous(d));
 }
+
+TEST_F(TensorUtilTest, ResizeZeroDimTensor) {
+  using namespace torch::executor;
+  Tensor a = tf_float_.ones({});
+
+  EXPECT_EQ(resize_tensor(a, {}), Error::Ok);
+  EXPECT_EQ(a.dim(), 0);
+}

--- a/runtime/core/portable_type/test/tensor_impl_test.cpp
+++ b/runtime/core/portable_type/test/tensor_impl_test.cpp
@@ -181,6 +181,30 @@ TEST_F(TensorImplTest, TestSetSizesContigUpperBounded) {
   ET_EXPECT_DEATH(t.set_sizes_contiguous({new_sizes_4, 1}), "");
 }
 
+TEST_F(TensorImplTest, TestZeroDimSetEmptySizesContig) {
+  SizesType sizes[0] = {};
+  DimOrderType dim_order[0] = {};
+  StridesType strides[0] = {};
+  float data[1] = {1.0};
+  TensorImpl t(
+      ScalarType::Float,
+      0,
+      sizes,
+      data,
+      dim_order,
+      strides,
+      TensorShapeDynamism::DYNAMIC_BOUND);
+
+  ArrayRef<SizesType> new_sizes_empty{};
+  // Can resize with empty sizes
+  t.set_sizes_contiguous(new_sizes_empty);
+  EXPECT_EQ(t.dim(), 0);
+
+  SizesType new_sizes_1[1] = {1};
+  // Can't change rank of tensor
+  ET_EXPECT_DEATH(t.set_sizes_contiguous({new_sizes_1, 1}), "");
+}
+
 TEST_F(TensorImplTest, TestWriteRead) {
   SizesType sizes[1] = {1};
   DimOrderType dim_order[1] = {0};


### PR DESCRIPTION
Summary: Resizing scalar tensor providing empty sizes should run successfully. Resizing logic assumed the sizes were non-empty, resulting in a crash

Reviewed By: JacobSzwejbka

Differential Revision: D49789758


