### PR TITLE
Add int types header

### DIFF
--- a/kernels/portable/cpu/vec_ops.h
+++ b/kernels/portable/cpu/vec_ops.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cinttypes>
 #include <cmath>
 #include <cstring>
 #include <numeric>


### PR DESCRIPTION
Summary: Fixing some compile-time failures when cross crompiling using arm-none-eabi-gcc

Reviewed By: JacobSzwejbka

Differential Revision: D49780125


