### PR TITLE
[executorch] Fix the docs build by using unique titles

### DIFF
--- a/docs/source/sdk-bundled-io.md
+++ b/docs/source/sdk-bundled-io.md
@@ -101,7 +101,7 @@ __Returns:__
 __Return type:__
 - `BundledProgram`
 
-### Example
+### Emit Example
 
 Here is a flow highlighting how to generate a `BundledProgram` given a PyTorch model and the representative inputs we want to test it along with.
 
@@ -334,7 +334,7 @@ __Returns:__
  execution.
 
 
-### Example
+### Runtime Example
 
 Here we provide an example about how to run the bundled program step by step. Most of the code is borrowed from [executor_runner](https://github.com/pytorch/executorch/blob/main/sdk/runners/executor_runner.cpp), and please review that file if you need more info and context:
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #561

Based on the failure message at https://github.com/pytorch/executorch/actions/runs/6358969960/job/17271725544#step:11:514, it looks like titles need to be unique within a document. I'm guessing it's because they're used to create `#anchor` IDs for section URLs.

Differential Revision: [D49831895](https://our.internmc.facebook.com/intern/diff/D49831895/)