### PR TITLE
Pass flatc executable path via env var for exir serializer.

### DIFF
--- a/exir/_serialize/_flatbuffer.py
+++ b/exir/_serialize/_flatbuffer.py
@@ -186,8 +186,9 @@ def _run_flatc(args: Sequence[str]) -> None:
         with importlib.resources.path(__package__, _FLATC_RESOURCE_NAME) as flatc_path:
             subprocess.run([flatc_path] + list(args), check=True)
     else:
-        # Expect the `flatc` tool to be on the system path.
-        subprocess.run(["flatc"] + list(args), check=True)
+        # Expect the `flatc` tool to be on the system path or set as an env var.
+        flatc_path = os.getenv("FLATC_EXECUTABLE", "flatc")
+        subprocess.run([flatc_path] + list(args), check=True)
 
 
 def _flatc_compile(output_dir: str, schema_path: str, json_path: str) -> None:


### PR DESCRIPTION
Pre-flight:

- Clone executorch repo
- Install the recommended buck2 binary version at /tmp/buck2
- cd path/to/executorch
- Sync and update git submodules
- Make sure you have Python 3.11+ installed (standard on Ventura+) and `pip` pointing to it
- Run ./install_requirements.sh to install PyTorch dependencies

```
# Build flatbuffers compiler

cd third-party/flatbuffers && rm -rf cmake-out && mkdir cmake-out && cd cmake-out

cmake .. && cmake --build . --target flatc

cd ../../..

# Configure executorch

rm -rf cmake-out && mkdir cmake-out && cd cmake-out

cmake .. -G Xcode -DCMAKE_TOOLCHAIN_FILE=../third-party/pytorch/cmake/iOS.cmake -DBUCK2=/tmp/buck2 -DPYTHON_EXECUTABLE=$(which python3) -DFLATC_EXECUTABLE=$(realpath ../third-party/flatbuffers/cmake-out/flatc) -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(pwd) -DEXECUTORCH_BUILD_XNNPACK=ON -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=<YOUR_TEAM_ID>  # -DPLATFORM=SIMULATOR

# Build executorch

cmake --build . --config Release

# Copy executorch libs

cd Release

mkdir -p ../../examples/ios_demo_apps/ExecuTorchDemo/ExecuTorchDemo/Frameworks/executorch/

cp libclog.a libcpuinfo.a libexecutorch.a libextension_data_loader.a libportable_kernels.a libportable_ops_lib.a libpthreadpool.a libxnnpack_backend.a libXNNPACK.a ../../examples/ios_demo_apps/ExecuTorchDemo/ExecuTorchDemo/Frameworks/executorch/

# Export a MobileNet v3 model backed with XNNPACK delegate and copy it over to bundle with the app

export FLATC_EXECUTABLE=$(realpath third-party/flatbuffers/cmake-out/flatc)

python3 -m examples.export.export_example --model_name="mv3"
python3 -m examples.backend.xnnpack_examples --model_name="mv3" --delegate

cp mv3.pte mv3_xnnpack_fp32.pte examples/ios_demo_apps/ExecuTorchDemo/ExecuTorchDemo/Resources/Models/MobileNet/

```

Post-flight:

- Open executorch/examples/ios_demo_apps/ExecuTorchDemo/ExecuTorchDemo.xcodeproj
- Set the header search path for MobileNetClassifier target pointing to the dir containing the executorch repo
- Run the app and tests

Differential Revision: D49843232


