### PR TITLE
Add buck config to remove ET_LOG

### DIFF
--- a/runtime/platform/targets.bzl
+++ b/runtime/platform/targets.bzl
@@ -57,6 +57,9 @@ def define_common_targets():
         force_static = True,
     )
 
+    # Enable or disable ET_LOGs
+    enable_et_log = native.read_config("executorch", "enable_et_log", None)
+
     # Interfaces for executorch users
     runtime.cxx_library(
         name = "platform",
@@ -73,7 +76,7 @@ def define_common_targets():
             "profiler.cpp",
             "runtime.cpp",
         ],
-        exported_preprocessor_flags = get_profiling_flags(),
+        exported_preprocessor_flags = get_profiling_flags() + (["-DET_LOG_ENABLED=0"] if enable_et_log else []),
         exported_deps = [
             "//executorch/runtime/platform:pal_interface",
             ":compiler",

--- a/test/targets.bzl
+++ b/test/targets.bzl
@@ -24,6 +24,7 @@ def define_common_targets():
     #
     # It's also best to build this with `-c executorch.enable_program_verification=false`
     # to remove ~30kB of optional flatbuffer verification code from the binary.
+    # Building with `-c executorch.enable_et_log=0` removes ~15kB from the binary.
     runtime.cxx_binary(
         name = "size_test",
         srcs = SIZE_TEST_SOURCES,


### PR DESCRIPTION
Summary:
|**build, stripped** | **x86_64 (devserver)** | **arm64 (macbook)** |
|With ET_LOG, verification | 82576 | 122376 |
|Without ET_LOG | 67576 | 105720 |
|Without ET_LOG, verification | 48584 |  89280|

Differential Revision: D49709986


