### PR TITLE
Make etrecord path optional

### DIFF
--- a/sdk/inspector/TARGETS
+++ b/sdk/inspector/TARGETS
@@ -16,8 +16,9 @@ python_library(
         ":inspector_utils",
         "//caffe2:torch",
         "//executorch/exir:lib",
-        "//executorch/sdk/edir:base_schema",
+        "//executorch/sdk/edir:et_schema",
         "//executorch/sdk/etdump:schema_flatcc",
+        "//executorch/sdk/etrecord:etrecord",
     ],
 )
 

--- a/sdk/inspector/_inspector_utils.py
+++ b/sdk/inspector/_inspector_utils.py
@@ -12,7 +12,7 @@ from executorch.sdk.edir.et_schema import FXOperatorGraph, OperatorGraph
 from executorch.sdk.etdump.schema_flatcc import ETDumpFlatCC
 
 from executorch.sdk.etdump.serialize import deserialize_from_etdump_flatcc
-from executorch.sdk.etrecord import ETRecord, parse_etrecord
+from executorch.sdk.etrecord import ETRecord
 
 EDGE_DIALECT_GRAPH_KEY = "edge_dialect_graph_module"
 
@@ -59,13 +59,6 @@ def create_debug_handle_to_op_node_mapping(
                         "No two op nodes of the same graph should have the same debug handle."
                     )
                 debug_handle_to_op_node_map[debug_handle] = element
-
-
-def gen_etrecord_object(etrecord_path: Optional[str] = None) -> ETRecord:
-    # Gen op graphs from etrecord
-    if etrecord_path is None:
-        raise ValueError("Etrecord_path must be specified.")
-    return parse_etrecord(etrecord_path=etrecord_path)
 
 
 def gen_etdump_object(etdump_path: Optional[str] = None) -> ETDumpFlatCC:

--- a/sdk/inspector/tests/inspector_test.py
+++ b/sdk/inspector/tests/inspector_test.py
@@ -54,8 +54,8 @@ class TestInspector(unittest.TestCase):
     def test_inspector_constructor(self):
         # Create a context manager to patch functions called by Inspector.__init__
         with patch.object(
-            inspector, "gen_etrecord_object", return_value=None
-        ) as mock_gen_etrecord, patch.object(
+            inspector, "parse_etrecord", return_value=None
+        ) as mock_parse_etrecord, patch.object(
             inspector, "gen_etdump_object", return_value=None
         ) as mock_gen_etdump, patch.object(
             EventBlock, "_gen_from_etdump"
@@ -69,20 +69,17 @@ class TestInspector(unittest.TestCase):
             )
 
             # Assert that expected functions are called
-            mock_gen_etrecord.assert_called_once_with(etrecord_path=ETRECORD_PATH)
+            mock_parse_etrecord.assert_called_once_with(etrecord_path=ETRECORD_PATH)
             mock_gen_etdump.assert_called_once_with(etdump_path=ETDUMP_PATH)
             mock_gen_from_etdump.assert_called_once()
-            mock_gen_graphs_from_etrecord.assert_called_once()
+            # Because we mocked parse_etrecord() to return None, this method shouldn't be called
+            mock_gen_graphs_from_etrecord.assert_not_called()
 
     def test_inspector_get_event_blocks_and_print_data_tabular(self):
         # Create a context manager to patch functions called by Inspector.__init__
-        with patch.object(
-            inspector, "gen_etrecord_object", return_value=None
-        ), patch.object(
+        with patch.object(inspector, "parse_etrecord", return_value=None), patch.object(
             inspector, "gen_etdump_object", return_value=None
-        ), patch.object(
-            EventBlock, "_gen_from_etdump"
-        ), patch.object(
+        ), patch.object(EventBlock, "_gen_from_etdump"), patch.object(
             inspector, "gen_graphs_from_etrecord"
         ):
             # Call the constructor of Inspector
@@ -189,13 +186,9 @@ class TestInspector(unittest.TestCase):
 
     def test_inspector_get_exported_program(self):
         # Create a context manager to patch functions called by Inspector.__init__
-        with patch.object(
-            inspector, "gen_etrecord_object", return_value=None
-        ), patch.object(
+        with patch.object(inspector, "parse_etrecord", return_value=None), patch.object(
             inspector, "gen_etdump_object", return_value=None
-        ), patch.object(
-            EventBlock, "_gen_from_etdump"
-        ), patch.object(
+        ), patch.object(EventBlock, "_gen_from_etdump"), patch.object(
             inspector, "gen_graphs_from_etrecord"
         ), patch.object(
             inspector, "create_debug_handle_to_op_node_mapping"


### PR DESCRIPTION
Summary: Before this diff, when an etrecord is not given, we throw a ValueError. We want user to still be able to use the Inspector without etrecord, thus this diff.

Reviewed By: tarun292

Differential Revision: D49844340


