### PR TITLE
fix quantized ic3/ic4/edsr examples

### DIFF
--- a/examples/xnnpack/__init__.py
+++ b/examples/xnnpack/__init__.py
@@ -18,15 +18,15 @@ MODEL_NAME_TO_OPTIONS = {
     "add": XNNPackOptions(True, True),
     "add_mul": XNNPackOptions(True, True),
     "dl3": XNNPackOptions(True, True),
-    "ic3": XNNPackOptions(True, False),
-    "ic4": XNNPackOptions(True, False),
+    "ic3": XNNPackOptions(True, True),
+    "ic4": XNNPackOptions(True, True),
     "mv2": XNNPackOptions(True, True),
     "mv3": XNNPackOptions(True, True),
     "resnet18": XNNPackOptions(True, True),
     "resnet50": XNNPackOptions(True, True),
     "vit": XNNPackOptions(False, True),
     "w2l": XNNPackOptions(False, True),
-    "edsr": XNNPackOptions(True, False),
+    "edsr": XNNPackOptions(True, True),
     "mobilebert": XNNPackOptions(True, False),
 }
 

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -13,6 +13,9 @@ import torch._export as export
 
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
 from executorch.exir import EdgeCompileConfig
+from torch.ao.quantization.quantizer.xnnpack_quantizer_utils import (
+    convert_scalars_to_attrs,
+)
 
 from ..models import MODEL_NAME_TO_MODEL
 from ..models.model_factory import EagerModelFactory
@@ -75,6 +78,8 @@ if __name__ == "__main__":
 
     if args.quantize:
         logging.info("Quantizing Model...")
+        # TODO(T165162973): This pass shall eventually be folded into quantizer
+        model = convert_scalars_to_attrs(model)
         model = quantize(model, example_inputs)
 
     edge = export_to_edge(


### PR DESCRIPTION
Summary:
The fix for quantized ic3/ic4/edsr requires runnign the pass

`convert_scalars_to_attrs` after capturing_pre_autograd_graph and before preparing and converting

We add using this pass in the examples to fix the quantized ic3/ic4/edsr

Differential Revision: D49850155

