### PR TITLE
Remove getter for event_blocks

### DIFF
--- a/sdk/inspector/TARGETS
+++ b/sdk/inspector/TARGETS
@@ -16,8 +16,9 @@ python_library(
         ":inspector_utils",
         "//caffe2:torch",
         "//executorch/exir:lib",
-        "//executorch/sdk/edir:base_schema",
+        "//executorch/sdk/edir:et_schema",
         "//executorch/sdk/etdump:schema_flatcc",
+        "//executorch/sdk/etrecord:etrecord",
     ],
 )
 

--- a/sdk/inspector/_inspector_utils.py
+++ b/sdk/inspector/_inspector_utils.py
@@ -12,7 +12,7 @@ from executorch.sdk.edir.et_schema import FXOperatorGraph, OperatorGraph
 from executorch.sdk.etdump.schema_flatcc import ETDumpFlatCC
 
 from executorch.sdk.etdump.serialize import deserialize_from_etdump_flatcc
-from executorch.sdk.etrecord import ETRecord, parse_etrecord
+from executorch.sdk.etrecord import ETRecord
 
 EDGE_DIALECT_GRAPH_KEY = "edge_dialect_graph_module"
 
@@ -59,13 +59,6 @@ def create_debug_handle_to_op_node_mapping(
                         "No two op nodes of the same graph should have the same debug handle."
                     )
                 debug_handle_to_op_node_map[debug_handle] = element
-
-
-def gen_etrecord_object(etrecord_path: Optional[str] = None) -> ETRecord:
-    # Gen op graphs from etrecord
-    if etrecord_path is None:
-        raise ValueError("Etrecord_path must be specified.")
-    return parse_etrecord(etrecord_path=etrecord_path)
 
 
 def gen_etdump_object(etdump_path: Optional[str] = None) -> ETDumpFlatCC:

--- a/sdk/inspector/inspector.py
+++ b/sdk/inspector/inspector.py
@@ -364,7 +364,7 @@ class Inspector:
     APIs for examining model architecture and performance stats.
 
     Public Attributes:
-        event_blocks: List["EventBlocks"]. Structured data accessible through Inspector for analysis.
+        event_blocks: List["EventBlocks"]. Structured data from ETDump (correlated with ETRecord if provided).
 
     Private Attributes:
         _etrecord: Optional[ETRecord]. File under etrecord_path deserialized into an object.
@@ -460,12 +460,6 @@ class Inspector:
                         total += event.perf_data.avg
                         break
         return total
-
-    def get_event_blocks(self) -> List[EventBlock]:
-        """
-        Returns EventBlocks containing contents from ETDump (correlated to ETRecord if provided)
-        """
-        return self.event_blocks
 
     def get_op_list(
         self, event_block: str, show_delegated_ops: Optional[bool] = True

--- a/sdk/inspector/tests/inspector_test.py
+++ b/sdk/inspector/tests/inspector_test.py
@@ -75,7 +75,7 @@ class TestInspector(unittest.TestCase):
             # Because we mocked parse_etrecord() to return None, this method shouldn't be called
             mock_gen_graphs_from_etrecord.assert_not_called()
 
-    def test_inspector_get_event_blocks_and_print_data_tabular(self):
+    def test_inspector_print_data_tabular(self):
         # Create a context manager to patch functions called by Inspector.__init__
         with patch.object(inspector, "parse_etrecord", return_value=None), patch.object(
             inspector, "gen_etdump_object", return_value=None
@@ -88,14 +88,11 @@ class TestInspector(unittest.TestCase):
                 etrecord_path=ETRECORD_PATH,
             )
 
-            # Test get_event_blocks() method. The mock inspector instance should start with having an empty event blocks list
-            event_block_list = [
+            # The mock inspector instance starts with having an empty event blocks list.
+            # Add non-empty event blocks to test print_data_tabular().
+            inspector_instance.event_blocks = [
                 EventBlock(name=EVENT_BLOCK_NAME, events=self._gen_random_events())
             ]
-            # Add non-empty event blocks to test get_event_blocks() and print_data_tabular()
-            inspector_instance.event_blocks = event_block_list
-            self.assertEqual(inspector_instance.get_event_blocks(), event_block_list)
-
             # Call print_data_tabular(), make sure it doesn't crash
             with redirect_stdout(None):
                 inspector_instance.print_data_tabular()

--- a/sdk/inspector/tests/inspector_test.py
+++ b/sdk/inspector/tests/inspector_test.py
@@ -54,8 +54,8 @@ class TestInspector(unittest.TestCase):
     def test_inspector_constructor(self):
         # Create a context manager to patch functions called by Inspector.__init__
         with patch.object(
-            inspector, "gen_etrecord_object", return_value=None
-        ) as mock_gen_etrecord, patch.object(
+            inspector, "parse_etrecord", return_value=None
+        ) as mock_parse_etrecord, patch.object(
             inspector, "gen_etdump_object", return_value=None
         ) as mock_gen_etdump, patch.object(
             EventBlock, "_gen_from_etdump"
@@ -69,20 +69,17 @@ class TestInspector(unittest.TestCase):
             )
 
             # Assert that expected functions are called
-            mock_gen_etrecord.assert_called_once_with(etrecord_path=ETRECORD_PATH)
+            mock_parse_etrecord.assert_called_once_with(etrecord_path=ETRECORD_PATH)
             mock_gen_etdump.assert_called_once_with(etdump_path=ETDUMP_PATH)
             mock_gen_from_etdump.assert_called_once()
-            mock_gen_graphs_from_etrecord.assert_called_once()
+            # Because we mocked parse_etrecord() to return None, this method shouldn't be called
+            mock_gen_graphs_from_etrecord.assert_not_called()
 
     def test_inspector_get_event_blocks_and_print_data_tabular(self):
         # Create a context manager to patch functions called by Inspector.__init__
-        with patch.object(
-            inspector, "gen_etrecord_object", return_value=None
-        ), patch.object(
+        with patch.object(inspector, "parse_etrecord", return_value=None), patch.object(
             inspector, "gen_etdump_object", return_value=None
-        ), patch.object(
-            EventBlock, "_gen_from_etdump"
-        ), patch.object(
+        ), patch.object(EventBlock, "_gen_from_etdump"), patch.object(
             inspector, "gen_graphs_from_etrecord"
         ):
             # Call the constructor of Inspector
@@ -189,13 +186,9 @@ class TestInspector(unittest.TestCase):
 
     def test_inspector_get_exported_program(self):
         # Create a context manager to patch functions called by Inspector.__init__
-        with patch.object(
-            inspector, "gen_etrecord_object", return_value=None
-        ), patch.object(
+        with patch.object(inspector, "parse_etrecord", return_value=None), patch.object(
             inspector, "gen_etdump_object", return_value=None
-        ), patch.object(
-            EventBlock, "_gen_from_etdump"
-        ), patch.object(
+        ), patch.object(EventBlock, "_gen_from_etdump"), patch.object(
             inspector, "gen_graphs_from_etrecord"
         ), patch.object(
             inspector, "create_debug_handle_to_op_node_mapping"


### PR DESCRIPTION
Summary: Remove the getter function because it's more Pythonic to just access the attributes (I read this [article](https://realpython.com/python-getter-setter/#:~:text=In%20OOP%2C%20the%20getter%20and,use%20getter%20and%20setter%20methods.) says so).

Differential Revision: D49853351

