### PR TITLE
Amend toolchain file matching in CMakeLists to avoid building executables for iOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ include(${EXECUTORCH_SRCS_FILE})
 # _default_build_host_targets: The default value for the
 # EXECUTORCH_BUILD_HOST_TARGETS option.
 set(_default_build_host_targets ON)
-if(CMAKE_TOOLCHAIN_FILE MATCHES ".*ios\.toolchain\.cmake$")
+if(CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
   # TODO(dbort): Refactor toolchain-specific matching. Ideally this file would
   # not know about specific targets, and work with more abstract concepts like
   # "is cross compiling".

--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -91,7 +91,7 @@ target_link_options_shared_lib(xnnpack_backend)
 list(APPEND xnn_executor_runner_libs xnnpack_backend)
 
 # ios can only build library but not binary
-if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*ios\.toolchain\.cmake$")
+if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
   #
   # xnn_executor_runner: Like executor_runner but with XNNPACK, the binary will
   # be at ${CMAKE_BINARY_DIR}/backends/xnnpack


### PR DESCRIPTION
Summary: .

Differential Revision: D49864956


