### PR TITLE
Add "Loader=..." to yaml.load callsites

### DIFF
--- a/kernels/test/gen_supported_features_test.py
+++ b/kernels/test/gen_supported_features_test.py
@@ -30,7 +30,8 @@ class TestGenSupportedFeatures(unittest.TestCase):
   dtype_double:
     type: bool
     default: true
-"""
+""",
+            Loader=yaml.FullLoader,
         )
         result = generate_header(y)
         self.assertTrue("bool is_aten = false;" in result)
@@ -45,7 +46,8 @@ class TestGenSupportedFeatures(unittest.TestCase):
 
 - namespace: op_gelu
   dtype_double: true
-"""
+""",
+            Loader=yaml.FullLoader,
         )
         result = generate_definition(y)
         self.assertTrue(".output_resize = true," in result)


### PR DESCRIPTION
Summary: Calling `yaml.load` without `Loader=` is deprecated and will throw in `pyyaml` 6.x. [The behavior in 5.x is to use `Loader=yaml.FullLoader`](https://github.com/yaml/pyyaml/blob/5.4.1.1/lib/yaml/__init__.py#L110), so we retain that semantic.

Differential Revision: D49670999


