### PR TITLE
replace deprecated functions

### DIFF
--- a/kernels/prim_ops/et_copy_index.cpp
+++ b/kernels/prim_ops/et_copy_index.cpp
@@ -95,17 +95,17 @@ void et_copy_index(RuntimeContext& context, EValue** stack) {
   }
 
   if (copy_to.sizes()[0] != expected_output_size[0]) {
-    void* data_ptr = copy_to.data_ptr();
+    const void* data_ptr = copy_to.const_data_ptr();
     Error err =
         resize_tensor(copy_to, {expected_output_size, copy_to.sizes().size()});
     ET_CHECK(err == Error::Ok);
     ET_CHECK_MSG(
-        data_ptr == copy_to.data_ptr(),
+        data_ptr == copy_to.const_data_ptr(),
         "Data ptr of copy_to tensor changed after resize which isn't allowed for static/upper-bounded tensors");
   }
 
-  auto copy_to_ptr = copy_to.data_ptr();
-  auto copy_from_ptr = copy_from.data_ptr();
+  auto copy_to_ptr = copy_to.const_data_ptr();
+  auto copy_from_ptr = copy_from.const_data_ptr();
 
   // If we've reached here, it means the copy_to tensor has been
   // successfully resized so we can now copy over the data from

--- a/runtime/core/exec_aten/util/tensor_util_portable.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_portable.cpp
@@ -90,7 +90,7 @@ Error share_tensor_data(
       InvalidArgument,
       "Source tensor should have data_ptr not being nullptr.");
   // Assign internal data_ptr as the one in forwarded tensor
-  t_dst.set_data(t_src.mutable_data_ptr());
+  t_dst.unsafeGetTensorImpl()->set_data(t_src.mutable_data_ptr());
 
   return Error::Ok;
 }
@@ -132,7 +132,7 @@ __ET_NODISCARD Error set_tensor_data(
 
 void reset_data_ptr(const torch::executor::Tensor& tensor) {
   // Lean mode doesn't deallocate the tensor data_ptr in the allocator
-  tensor.set_data(nullptr);
+  tensor.unsafeGetTensorImpl()->set_data(nullptr);
 }
 
 class TensorResizerFriend final {

--- a/runtime/executor/method_meta.cpp
+++ b/runtime/executor/method_meta.cpp
@@ -180,7 +180,7 @@ size_t MethodMeta::num_memory_planned_buffers() const {
 }
 
 Result<int64_t> MethodMeta::memory_planned_buffer_size(size_t index) const {
-  auto num_buffers = this->num_non_const_buffers();
+  auto num_buffers = this->num_memory_planned_buffers();
   ET_CHECK_OR_RETURN_ERROR(
       index >= 0 && index < num_buffers,
       InvalidArgument,


### PR DESCRIPTION
Summary:
to run internal size test locally (macbook arm)

|**build, stripped** | **x86_64 (devserver)** | **arm64 (macbook)** |
|With ET_LOG, verification | 82576 | 122376 |
|Without ET_LOG | 67576 | 105720 |
|Without ET_LOG, verification | 48584 |  89280|

Reviewed By: larryliu0820

Differential Revision: D49742299


