### PR TITLE
Cast to float in nearbyint function for quantize and choose_qparams ops

### DIFF
--- a/kernels/quantized/cpu/op_choose_qparams.cpp
+++ b/kernels/quantized/cpu/op_choose_qparams.cpp
@@ -141,7 +141,7 @@ void choose_qparams(
   } else if (initial_zero_point > qmax) {
     nudged_zero_point = qmax;
   } else {
-    nudged_zero_point = nearbyint(initial_zero_point);
+    nudged_zero_point = nearbyint(static_cast<float>(initial_zero_point));
   }
 
   scale_out.data_ptr<double>()[0] = scale;

--- a/kernels/quantized/cpu/op_quantize.cpp
+++ b/kernels/quantized/cpu/op_quantize.cpp
@@ -93,7 +93,8 @@ T quantize_val(
   int64_t qvalue;
   float inv_scale = 1.0f / static_cast<float>(scale);
   qvalue = static_cast<int64_t>(
-      static_cast<int32_t>(zero_point) + std::nearbyint(inv_scale * value));
+      static_cast<int32_t>(zero_point) +
+      std::nearbyint(static_cast<float>(inv_scale * value)));
 
   qvalue = std::max<int64_t>(qvalue, quant_min);
   qvalue = std::min<int64_t>(qvalue, quant_max);


### PR DESCRIPTION
Summary:
Casting to float prevents calling the `double` overload of the function, which does not exist in the libc of some embedded backends.
Note that we will ask Cadence about this and if/when it gets fixed on their side, we can revert this change.

Differential Revision: D49878712


