### PR TITLE
Back out "[executorch] update set_tensor_data to use MethodMeta and set_input"

### DIFF
--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -89,18 +89,17 @@ class Method final {
   }
 
   /**
-   * Sets the internal input value to be equivalent to the to the provided
-   * value.
+   * Sets a specific method input to the provided value.
    *
-   * @param[in] input_evalue The evalue to copy into the method input. If the
-   *     evalue is a tensor, the data is copied in most cases, so the tensor
-   *     passed in here does not always need to outlive this call. But there is
-   *     a case where the Method will keep a pointer to the tensor's data.
-   *     Based on the memory plan of the method, the inputs may not have
-   *     buffer space pre-allocated for them. In this case the executor will
-   *     alias the memory of the tensors provided as inputs here rather then
-   *     deepcopy the input into the memory planned arena.
+   * NOTE: Based on the memory plan of the method, the inputs may not have
+   * buffer space pre-allocated for them, in this case the executor will alias
+   * the memory of the tensors provided as inputs here, so the user should take
+   * care that the life span of this memory outlasts the executor forward.
    *
+   * @param[in] input_evalue The value to set the input to. The type of this
+   *     must match the type of the corresponding input. If this value is a
+   *     tensor, attempts to allow dynamic shape, but the dtype must always
+   *     agree.
    * @param[in] input_idx Zero-based index of the input to set. Must be less
    *     than the value returned by inputs_size().
    *
@@ -111,7 +110,7 @@ class Method final {
   /**
    * Sets the values of all method inputs.
    *
-   * See set_input() for a more detailed description of the behavior.
+   * See NOTE on set_input().
    *
    * @param[in] input_evalues The new values for all of the method inputs. The
    *     type of each element must match the type of corresponding input. If the

--- a/test/size_test.cpp
+++ b/test/size_test.cpp
@@ -12,6 +12,7 @@
 #include <executorch/runtime/platform/log.h>
 #include <executorch/runtime/platform/profiler.h>
 #include <executorch/runtime/platform/runtime.h>
+#include <executorch/util/util.h>
 #include <stdio.h>
 
 using namespace torch::executor;
@@ -64,13 +65,7 @@ int main(int argc, char** argv) {
 
   // Prepare for inputs
   // It assumes the input is one tensor.
-  float data[] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
-  Tensor::SizesType sizes[] = {6};
-  Tensor::DimOrderType dim_order[] = {0};
-  TensorImpl impl(ScalarType::Float, 1, sizes, data, dim_order);
-  Tensor t(&impl);
-  Error set_input_error = method->set_input(t, 0);
-  ET_CHECK(set_input_error == Error::Ok);
+  auto inputs = torch::executor::util::PrepareInputTensors(*method);
 
   ET_LOG(Info, "Inputs prepared.");
 
@@ -95,6 +90,7 @@ int main(int argc, char** argv) {
       ET_LOG(Info, "%f", data_output[j]);
     }
   }
+  torch::executor::util::FreeInputs(inputs);
   prof_result_t prof_result;
   EXECUTORCH_DUMP_PROFILE_RESULTS(&prof_result);
   if (prof_result.num_bytes != 0) {

--- a/test/targets.bzl
+++ b/test/targets.bzl
@@ -7,6 +7,7 @@ SIZE_TEST_SOURCES = [
 SIZE_TEST_DEPS = [
     "//executorch/runtime/executor:program",
     "//executorch/extension/data_loader:file_data_loader",
+    "//executorch/util:util",
 ]
 
 def define_common_targets():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #603

Looks like D49747239 broke emformer_predict: https://github.com/pytorch/executorch/actions/runs/6399287832/job/17371212118#step:11:17554. Back it out for now.

Differential Revision: [D49893949](https://our.internmc.facebook.com/intern/diff/D49893949/)