### PR TITLE
fix handling of optional inputs

### DIFF
--- a/runtime/executor/method_meta.cpp
+++ b/runtime/executor/method_meta.cpp
@@ -24,6 +24,9 @@ Result<Tag> get_tag(
         return_type serialization_value,
     size_t index) {
   switch (serialization_value->val_type()) {
+    case executorch_flatbuffer::KernelTypes::Null: {
+      return Tag::None;
+    } break;
     case executorch_flatbuffer::KernelTypes::Int: {
       return Tag::Int;
     } break;
@@ -42,7 +45,7 @@ Result<Tag> get_tag(
     default:
       ET_LOG(
           Error,
-          "Invalid tag: %zu input: %zu",
+          "Invalid tag: %zu input idx: %zu",
           (size_t)serialization_value->val_type(),
           index);
       return Error::Internal;


### PR DESCRIPTION
Summary: I think emformer_predict takes an optional as an arg in python, so then when captured that arg isnt present so its flagged as Null.

Differential Revision: D49894385


