### PR TITLE
Move MacOS jobs to trunk to reduce its load

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -31,7 +31,7 @@ jobs:
 
           source .ci/scripts/utils.sh
           # This is a simple Python script but as it tries to import executorch.examples.models,
-          # it requires a whole bunch of Executorch dependencies on the Docker image
+          # it requires a whole bunch of ExecuTorch dependencies on the Docker image
           install_pip_dependencies
           install_executorch
 
@@ -62,7 +62,7 @@ jobs:
         DEMO_BACKEND_DELEGATION=${{ matrix.demo_backend_delegation }}
 
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
-        # Build and test Executorch
+        # Build and test ExecuTorch
         PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${XNNPACK_QUANTIZATION}" "${XNNPACK_DELEGATION}" "${DEMO_BACKEND_DELEGATION}"
 
   test-custom-ops-linux:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -1,7 +1,6 @@
-name: pull
+name: trunk
 
 on:
-  pull_request:
   push:
     branches:
       - main
@@ -37,23 +36,21 @@ jobs:
 
           PYTHONPATH="${PWD}" python .ci/scripts/gather_test_models.py
 
-  test-models-linux:
-    name: test-models-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+  test-models-macos:
+    name: test-models-macos
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     needs: gather-models
     strategy:
       matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
       fail-fast: false
     with:
-      runner: ${{ matrix.runner }}
-      docker-image: executorch-ubuntu-22.04-clang12
+      runner: macos-m1-12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 90
       script: |
-        # The generic Linux job chooses to use base env, not the one setup by the image
-        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-        conda activate "${CONDA_ENV}"
+        WORKSPACE=$(pwd)
+        pushd "${WORKSPACE}/pytorch/executorch"
 
         MODEL_NAME=${{ matrix.model }}
         BUILD_TOOL=${{ matrix.build-tool }}
@@ -61,13 +58,15 @@ jobs:
         XNNPACK_DELEGATION=${{ matrix.xnnpack_delegation }}
         DEMO_BACKEND_DELEGATION=${{ matrix.demo_backend_delegation }}
 
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+        # Setup MacOS dependencies as there is no Docker support on MacOS atm
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
         # Build and test Executorch
         PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${XNNPACK_QUANTIZATION}" "${XNNPACK_DELEGATION}" "${DEMO_BACKEND_DELEGATION}"
+        popd
 
-  test-custom-ops-linux:
-    name: test-custom-ops-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+  test-custom-ops-macos:
+    name: test-custom-ops-macos
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     strategy:
       matrix:
         include:
@@ -75,23 +74,24 @@ jobs:
           - build-tool: cmake
       fail-fast: false
     with:
-      runner: linux.2xlarge
-      docker-image: executorch-ubuntu-22.04-clang12
+      runner: macos-m1-12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
-        # The generic Linux job chooses to use base env, not the one setup by the image
-        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-        conda activate "${CONDA_ENV}"
+        WORKSPACE=$(pwd)
+        pushd "${WORKSPACE}/pytorch/executorch"
 
         BUILD_TOOL=${{ matrix.build-tool }}
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
-        # Test custom ops
+        # Setup MacOS dependencies as there is no Docker support on MacOS atm
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+
+        # Build and test custom ops
         PYTHON_EXECUTABLE=python bash examples/custom_ops/test_custom_ops.sh "${BUILD_TOOL}"
+        popd
 
-  test-selective-build-linux:
-    name: test-selective-build-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+  test-selective-build-macos:
+    name: test-selective-build-macos
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     strategy:
       matrix:
         include:
@@ -99,21 +99,17 @@ jobs:
           - build-tool: cmake
       fail-fast: false
     with:
-      runner: linux.2xlarge
-      docker-image: executorch-ubuntu-22.04-clang12
+      runner: macos-m1-12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
-        # The generic Linux job chooses to use base env, not the one setup by the image
-        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-        conda activate "${CONDA_ENV}"
+        WORKSPACE=$(pwd)
+        pushd "${WORKSPACE}/pytorch/executorch"
 
         BUILD_TOOL=${{ matrix.build-tool }}
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
-        # Test selective build
-        PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
+        # Setup MacOS dependencies as there is no Docker support on MacOS atm
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
 
-  unittest:
-    uses: ./.github/workflows/_unittest.yml
-    with:
-      docker-image: executorch-ubuntu-22.04-clang12
+        # Build and test selective build
+        PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
+        popd

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -30,7 +30,7 @@ jobs:
 
           source .ci/scripts/utils.sh
           # This is a simple Python script but as it tries to import executorch.examples.models,
-          # it requires a whole bunch of Executorch dependencies on the Docker image
+          # it requires a whole bunch of ExecuTorch dependencies on the Docker image
           install_pip_dependencies
           install_executorch
 
@@ -60,7 +60,7 @@ jobs:
 
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
-        # Build and test Executorch
+        # Build and test xecutorch
         PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${XNNPACK_QUANTIZATION}" "${XNNPACK_DELEGATION}" "${DEMO_BACKEND_DELEGATION}"
         popd
 

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -68,6 +68,8 @@ include_patterns = [
 exclude_patterns = [
     'third-party/**',
     '**/third-party/**',
+    # NB: Objective-C is not supported
+    'examples/apple/**',
     'examples/ios_demo_apps/**',
 ]
 command = [

--- a/examples/apple/ios/README.md
+++ b/examples/apple/ios/README.md
@@ -1,7 +1,7 @@
-# iOS Demo App: Executorch Setup
+# iOS Demo App: ExecuTorch Setup
 
-This guide explains how to setup Executorch for iOS using a demo app. The app
-employs a MobileNet v3 model (exported to Executorch) to process live camera
+This guide explains how to setup ExecuTorch for iOS using a demo app. The app
+employs a MobileNet v3 model (exported to ExecuTorch) to process live camera
 images.
 
 ## Pre-setup
@@ -27,7 +27,7 @@ images.
    ln -s /Applications/CMake.app/Contents/bin/cmake /usr/bin/cmake
    ```
 
-4. Clone Executorch repository and update submodules:
+4. Clone ExecuTorch repository and update submodules:
 
    ```bash
    git clone https://github.com/pytorch/executorch.git
@@ -60,7 +60,7 @@ cmake .. && cmake --build . --target flatc
 cd ../../..
 ```
 
-## Executorch Configuration
+## ExecuTorch Configuration
 
 Configure the libraries for iOS:
 


### PR DESCRIPTION
As ET is using more MacOS runners causing a long queue there https://hud.pytorch.org/metrics, an immediate mitigation step would be to move MacOS jobs to trunk to reduce its load.  I'll start working on T165554710 to consolidate MacOS jobs.