### PR TITLE
Add example script to run on cpu

### DIFF
--- a/examples/arm/README.md
+++ b/examples/arm/README.md
@@ -1,0 +1,31 @@
+## ExecuTorch on ARM Cortex-M55 + Ethos-U55
+
+This dir contains scripts to help you prepare setup needed to run a PyTorch
+model on a ARM Corstone-300 platform via ExecuTorch. Corstone-300 platform
+contains the Cortex-M55 CPU and Ethos-U55 NPU.
+
+We will start from a PyTorch model in python, export it, convert it to a `.pte`
+file - A binary format adopted by ExecuTorch. Then we will take the `.pte`
+model file and embed that with a baremetal application executor_runner. We will
+then take the executor_runner file, which contains not only the `.pte` file but
+also necessary software component to run standalone on a baremetal system.
+Lastly, we will run the executor_runner binary on a Corstone-300 FVP Simulator
+platform.
+
+### Example workflow
+
+There are two main scripts, setup.sh and run.sh. Each takes one optional,
+positional argument. It is a path to a scratch dir to download and generate
+build artifacts. If supplied, the same argument must be supplied to both the scripts.
+
+run.sh also takes a second optional positional arg to specify a buck2 command.
+
+To run these scripts. On a Linux system, in a terminal, with a working internet connection,
+```
+# Step [1] - setup necessary tools
+$ ./setup.sh
+
+# Step [2] - build + run ExecuTorch and executor_runner baremetal application
+# suited for Corstone300 to run a simple PyTorch model.
+$ ./run.sh
+```

--- a/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake
+++ b/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake
@@ -1,0 +1,105 @@
+#
+# Copyright (c) 2020-2022 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Copied this file from core_platform/cmake/toolchain/arm-non-eabi-gcc.cmake
+# And modified to align better with cs300 platform
+
+set(TARGET_CPU "cortex-m55" CACHE STRING "Target CPU")
+string(TOLOWER ${TARGET_CPU} CMAKE_SYSTEM_PROCESSOR)
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_C_COMPILER "arm-none-eabi-gcc")
+set(CMAKE_CXX_COMPILER "arm-none-eabi-g++")
+set(CMAKE_ASM_COMPILER "arm-none-eabi-gcc")
+set(CMAKE_LINKER "arm-none-eabi-ld")
+
+set(CMAKE_EXECUTABLE_SUFFIX ".elf")
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Select C/C++ version
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
+
+set(GCC_CPU ${CMAKE_SYSTEM_PROCESSOR})
+string(REPLACE "cortex-m85" "cortex-m55" GCC_CPU ${GCC_CPU})
+
+# Compile options
+add_compile_options(
+    -mcpu=${GCC_CPU}
+    -mthumb
+    "$<$<CONFIG:DEBUG>:-gdwarf-3>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-fno-unwind-tables;-fno-rtti;-fno-exceptions>"
+    -fdata-sections
+    -ffunction-sections)
+
+# Compile defines
+add_compile_definitions(
+    "$<$<NOT:$<CONFIG:DEBUG>>:NDEBUG>")
+
+# Link options
+add_link_options(
+    -mcpu=${GCC_CPU}
+    -mthumb
+    --specs=nosys.specs)
+
+# Set floating point unit
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "\\+fp")
+    set(FLOAT hard)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "\\+nofp")
+    set(FLOAT soft)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m33(\\+|$)" OR
+       CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m55(\\+|$)" OR
+       CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m85(\\+|$)")
+    set(FLOAT hard)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m4(\\+|$)" OR
+       CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m7(\\+|$)")
+    set(FLOAT hard)
+    set(FPU_CONFIG "fpv4-sp-d16")
+    add_compile_options(-mfpu=${FPU_CONFIG})
+    add_link_options(-mfpu=${FPU_CONFIG})
+else()
+    set(FLOAT soft)
+endif()
+
+if(FLOAT)
+    add_compile_options(-mfloat-abi=${FLOAT})
+    add_link_options(-mfloat-abi=${FLOAT})
+endif()
+
+add_link_options(LINKER:--nmagic,--gc-sections)
+
+# Compilation warnings
+add_compile_options(
+    # -Wall
+    # -Wextra
+    # -Wcast-align
+    # -Wdouble-promotion
+    # -Wformat
+    # -Wmissing-field-initializers
+    # -Wnull-dereference
+    # -Wredundant-decls
+    # -Wshadow
+    # -Wswitch
+    # -Wswitch-default
+    # -Wunused
+    # -Wno-redundant-decls
+    # -Wno-psabi
+)

--- a/examples/arm/ethos-u-setup/core_platform/patches/0001-Executorch-Add-README.patch
+++ b/examples/arm/ethos-u-setup/core_platform/patches/0001-Executorch-Add-README.patch
@@ -1,0 +1,35 @@
+From 48a99f4b00e504c13cd74ca44a5ce7128f719cba Mon Sep 17 00:00:00 2001
+From: Digant Desai <digantdesai@meta.com>
+Date: Tue, 3 Oct 2023 21:20:21 -0700
+Subject: [PATCH 1/6] [Executorch] Add README
+
+---
+ applications/executorch_tests/README.md | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+ create mode 100644 applications/executorch_tests/README.md
+
+diff --git a/applications/executorch_tests/README.md b/applications/executorch_tests/README.md
+new file mode 100644
+index 0000000..f2dfb05
+--- /dev/null
++++ b/applications/executorch_tests/README.md
+@@ -0,0 +1,16 @@
++## ExecuTorch
++A unified ML software stack within the PyTorch platform for edge devices. It
++defines new compiler entry points as well as a state-of-art runtime.
++
++Home: https://github.com/pytorch/executorch/
++
++### executor_runner
++
++This test is a simple wrapper around ExecuTorch runtime, capable of running
++`.pte` model files compatible with ExecuTorch.
++
++If configured correctly with `ET_*` CMake variables pointing to the ExecuTorch
++project build, then this test bin executes `model.pte.h` file converted from
++`model.pte` using `pte_to_header.py`, from the ExecuTorch project root dir,
++containing an ExecuTorch compatible PyTorch model on the Costrone 300 FVP using
++ExecuTorch runtime.
+-- 
+2.39.3
+

--- a/examples/arm/ethos-u-setup/core_platform/patches/0002-Executorch-local-patch-regress-cmake-version-from-3..patch
+++ b/examples/arm/ethos-u-setup/core_platform/patches/0002-Executorch-local-patch-regress-cmake-version-from-3..patch
@@ -1,0 +1,26 @@
+From 3359f94fc57ac76b3f5995d4453975251b56ae71 Mon Sep 17 00:00:00 2001
+From: Digant Desai <digantdesai@meta.com>
+Date: Thu, 28 Sep 2023 18:05:03 -0700
+Subject: [PATCH 2/6] [Executorch][local-patch] regress cmake version from 3.21
+ --> 3.20
+
+---
+ targets/corstone-300/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/targets/corstone-300/CMakeLists.txt b/targets/corstone-300/CMakeLists.txt
+index 62205bb..7dda8a1 100644
+--- a/targets/corstone-300/CMakeLists.txt
++++ b/targets/corstone-300/CMakeLists.txt
+@@ -42,7 +42,7 @@ set(MEMORY_ARENA "dram" CACHE STRING "Memory config for arena")
+ # Project
+ #############################################################################
+ 
+-cmake_minimum_required(VERSION 3.21)
++cmake_minimum_required(VERSION 3.20)
+ 
+ project(ethos-u-corstone-300 VERSION 0.0.1)
+ 
+-- 
+2.39.3
+

--- a/examples/arm/ethos-u-setup/core_platform/patches/0003-Executorch-local-patch-Disable-warnings-to-reduce-ve.patch
+++ b/examples/arm/ethos-u-setup/core_platform/patches/0003-Executorch-local-patch-Disable-warnings-to-reduce-ve.patch
@@ -1,0 +1,53 @@
+From b13de10ad4920da069d44efb99eceb86f6169a32 Mon Sep 17 00:00:00 2001
+From: Digant Desai <digantdesai@meta.com>
+Date: Thu, 28 Sep 2023 18:05:30 -0700
+Subject: [PATCH 3/6] [Executorch][local-patch] Disable warnings to reduce
+ verbosity
+
+---
+ cmake/toolchain/arm-none-eabi-gcc.cmake | 28 ++++++++++++-------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/cmake/toolchain/arm-none-eabi-gcc.cmake b/cmake/toolchain/arm-none-eabi-gcc.cmake
+index 093005e..0e6a2ed 100644
+--- a/cmake/toolchain/arm-none-eabi-gcc.cmake
++++ b/cmake/toolchain/arm-none-eabi-gcc.cmake
+@@ -85,21 +85,21 @@ add_link_options(LINKER:--nmagic,--gc-sections)
+ 
+ # Compilation warnings
+ add_compile_options(
+-    -Wall
+-    -Wextra
++    # -Wall
++    # -Wextra
+ 
+-    -Wcast-align
+-    -Wdouble-promotion
+-    -Wformat
+-    -Wmissing-field-initializers
+-    -Wnull-dereference
+-    -Wredundant-decls
+-    -Wshadow
+-    -Wswitch
+-    -Wswitch-default
+-    -Wunused
++    # -Wcast-align
++    # -Wdouble-promotion
++    # -Wformat
++    # -Wmissing-field-initializers
++    # -Wnull-dereference
++    # -Wredundant-decls
++    # -Wshadow
++    # -Wswitch
++    # -Wswitch-default
++    # -Wunused
+ 
+-    -Wno-redundant-decls
++    # -Wno-redundant-decls
+ 
+-    -Wno-psabi
++    # -Wno-psabi
+ )
+-- 
+2.39.3
+

--- a/examples/arm/ethos-u-setup/core_platform/patches/0004-Executorch-local-patch-New-phdr-for-.data-section.patch
+++ b/examples/arm/ethos-u-setup/core_platform/patches/0004-Executorch-local-patch-New-phdr-for-.data-section.patch
@@ -1,0 +1,33 @@
+From 5423ef7ec31e4260ec79f2f6e60deddc1640f3e4 Mon Sep 17 00:00:00 2001
+From: Digant Desai <digantdesai@meta.com>
+Date: Mon, 2 Oct 2023 20:39:39 -0700
+Subject: [PATCH 4/6] [Executorch][local-patch] New phdr for .data section
+
+---
+ targets/corstone-300/platform.ld | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/targets/corstone-300/platform.ld b/targets/corstone-300/platform.ld
+index 8d77329..8de77c4 100644
+--- a/targets/corstone-300/platform.ld
++++ b/targets/corstone-300/platform.ld
+@@ -94,6 +94,7 @@ PHDRS
+ {
+     rom_exec PT_LOAD;
+     rom_dram PT_LOAD;
++    data     PT_LOAD; /* HACK: New prog header for .data (and friends) going in DTCM */
+     null     PT_NULL;
+ }
+ 
+@@ -247,7 +248,7 @@ SECTIONS
+     /* All data end */
+     __data_end__ = .;
+ 
+-  } > DTCM :rom_exec
++  } > DTCM :data
+ 
+   .sram.bss :
+   {
+-- 
+2.39.3
+

--- a/examples/arm/ethos-u-setup/core_platform/patches/0005-Executorch-Add-pte-to-header-script.patch
+++ b/examples/arm/ethos-u-setup/core_platform/patches/0005-Executorch-Add-pte-to-header-script.patch
@@ -1,0 +1,84 @@
+From dcf2e249d7f96f521e19c556d7529757aa94a0f5 Mon Sep 17 00:00:00 2001
+From: Digant Desai <digantdesai@meta.com>
+Date: Tue, 3 Oct 2023 21:20:07 -0700
+Subject: [PATCH 5/6] [Executorch] Add pte to header script
+
+---
+ .../executorch_tests/pte_to_header.py         | 65 +++++++++++++++++++
+ 1 file changed, 65 insertions(+)
+ create mode 100644 applications/executorch_tests/pte_to_header.py
+
+diff --git a/applications/executorch_tests/pte_to_header.py b/applications/executorch_tests/pte_to_header.py
+new file mode 100644
+index 0000000..37d88aa
+--- /dev/null
++++ b/applications/executorch_tests/pte_to_header.py
+@@ -0,0 +1,65 @@
++# Copyright (c) Meta Platforms, Inc. and affiliates.
++# All rights reserved.
++#
++# This source code is licensed under the BSD-style license found in the
++# LICENSE file in the root directory of this source tree.
++
++import binascii
++import os
++from argparse import ArgumentParser, ArgumentTypeError
++
++# Also see: https://git.mlplatform.org/ml/ethos-u/ml-embedded-evaluation-kit.git/tree/scripts/py/gen_model_cpp.py
++
++bytes_per_line = 32
++hex_digits_per_line = bytes_per_line * 2
++
++
++def input_file_path(path):
++    if os.path.exists(path):
++        return path
++    else:
++        raise ArgumentTypeError(f"input filepath:{path} does not exist")
++
++
++parser = ArgumentParser()
++parser.add_argument(
++    "--pte",
++    help="ExecuTorch .pte model file",
++    type=input_file_path,
++    required=True,
++)
++parser.add_argument(
++    "--outdir",
++    help="Output dir for model_pte.h",
++    type=str,
++    required=False,
++    default=".",
++)
++parser.add_argument(
++    "--section",
++    help="Section attribute for the data array",
++    type=str,
++    required=False,
++    default=".sram.data",
++)
++args = parser.parse_args()
++outfile = os.path.join(args.outdir, "model_pte.h")
++attr = f'__attribute__((section("{args.section}"), aligned(16))) char '
++
++with open(args.pte, "rb") as fr, open(
++    outfile, "w"
++) as fw:
++    data = fr.read()
++    hexstream = binascii.hexlify(data).decode("utf-8")
++    hexstring = attr + "model_pte[] = {"
++
++    for i in range(0, len(hexstream), 2):
++        if 0 == (i % hex_digits_per_line):
++            hexstring += "\n"
++        hexstring += "0x" + hexstream[i : i + 2] + ", "
++
++    hexstring += "};\n"
++    fw.write(hexstring)
++    print(
++        f"Input: {args.pte} with {len(data)} bytes. Output: {outfile} with {len(hexstring)} bytes. Section: {args.section}."
++    )
+-- 
+2.39.3
+

--- a/examples/arm/ethos-u-setup/core_platform/patches/0006-Executorch-Add-executorch_runner-test.patch
+++ b/examples/arm/ethos-u-setup/core_platform/patches/0006-Executorch-Add-executorch_runner-test.patch
@@ -1,0 +1,283 @@
+From 0c91f25a52d32d7f4b6ec787a40633a92af7f885 Mon Sep 17 00:00:00 2001
+From: Digant Desai <digantdesai@meta.com>
+Date: Thu, 28 Sep 2023 19:07:51 -0700
+Subject: [PATCH 6/6] [Executorch] Add executorch_runner test
+
+---
+ applications/CMakeLists.txt                  |   2 +
+ applications/executorch_tests/CMakeLists.txt |  76 +++++++++++
+ applications/executorch_tests/runner.cpp     | 133 +++++++++++++++++++
+ cmake/helpers.cmake                          |  13 +-
+ 4 files changed, 222 insertions(+), 2 deletions(-)
+ create mode 100644 applications/executorch_tests/CMakeLists.txt
+ create mode 100644 applications/executorch_tests/runner.cpp
+
+diff --git a/applications/CMakeLists.txt b/applications/CMakeLists.txt
+index 1fa2b2e..68e5427 100644
+--- a/applications/CMakeLists.txt
++++ b/applications/CMakeLists.txt
+@@ -28,6 +28,8 @@ add_subdirectory(threadx_demo)
+ 
+ add_subdirectory(message_handler_openamp)
+ 
++add_subdirectory(executorch_tests)
++
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "ARMClang")
+     # Only armclang supported for now
+     add_subdirectory(trustzone_inference)
+diff --git a/applications/executorch_tests/CMakeLists.txt b/applications/executorch_tests/CMakeLists.txt
+new file mode 100644
+index 0000000..c95d53e
+--- /dev/null
++++ b/applications/executorch_tests/CMakeLists.txt
+@@ -0,0 +1,76 @@
++#
++# Copyright (c) 2021 Arm Limited. All rights reserved.
++#
++# SPDX-License-Identifier: Apache-2.0
++#
++# Licensed under the Apache License, Version 2.0 (the License); you may
++# not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++# www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an AS IS BASIS, WITHOUT
++# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++#
++
++if (NOT TARGET ethosu_core_driver)
++  return()
++endif()
++
++####
++#### ExecuTorch demo app/test
++####
++
++set(ET_DIR_PATH "<..>/executorch" CACHE PATH "Path to ExecuTorch dir")
++set(ET_BUILD_DIR_PATH "${ET_DIR_PATH}/cmake-out" CACHE PATH "Path to ExecuTorch build dir")
++set(ET_INCLUDE_PATH "${ET_DIR_PATH}/.." CACHE PATH "Path to ExecuTorch headers")
++set(ET_PTE_FILE_PATH "${ET_PTE_FILE_PATH}" CACHE PATH "Path to ExecuTorch model pte")
++
++get_filename_component(ET_BUILD_DIR_PATH ${ET_BUILD_DIR_PATH} REALPATH)
++get_filename_component(ET_DIR_PATH ${ET_DIR_PATH} REALPATH)
++get_filename_component(ET_INCLUDE_PATH ${ET_INCLUDE_PATH} REALPATH)
++get_filename_component(ET_PTE_FILE_PATH ${ET_PTE_FILE_PATH} REALPATH)
++
++message("**********************")
++message("ExecuTorch dir      (ET_DIR_PATH)       : ${ET_DIR_PATH}")
++message("ExecuTorch build dir(ET_BUILD_DIR_PATH) : ${ET_BUILD_DIR_PATH}")
++message("ExecuTorch headers  (ET_INCUDE_PATH)    : ${ET_INCLUDE_PATH}")
++message("ExecuTorch pte file (ET_PTE_FILE_PATH)  : ${ET_PTE_FILE_PATH}")
++message("**********************")
++
++set(LIB_ET_RUNTIME "${ET_BUILD_DIR_PATH}/libexecutorch.a")
++set(LIB_ET_OP_REGISTRATION "${ET_BUILD_DIR_PATH}/kernels/portable/libportable_ops_lib.a")
++set(LIB_ET_OP_KERNELS "${ET_BUILD_DIR_PATH}/kernels/portable/libportable_kernels.a")
++
++add_custom_target(
++    gen_model_header ALL
++    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/fake_dep
++)
++
++add_custom_command(
++    OUTPUT
++        ${CMAKE_CURRENT_BINARY_DIR}/fake_dep
++        ${CMAKE_CURRENT_BINARY_DIR}/model_pte.h
++    COMMAND ${PYTHON_EXECUTABLE} ./pte_to_header.py --pte ${ET_PTE_FILE_PATH}
++    --out ${CMAKE_CURRENT_BINARY_DIR}
++    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
++    )
++
++ethosu_add_executable_test(executor_runner PRIVATE
++    WHOLE_ARCHIVE TRUE
++    SOURCES runner.cpp
++    LIBRARIES
++    ${LIB_ET_RUNTIME}
++    ${LIB_ET_OP_REGISTRATION}
++    ${LIB_ET_OP_KERNELS})
++
++add_dependencies(executor_runner gen_model_header)
++
++target_include_directories(executor_runner PRIVATE
++${ET_INCLUDE_PATH}
++${CMAKE_CURRENT_BINARY_DIR})
++
++# TODO Memory setup
+diff --git a/applications/executorch_tests/runner.cpp b/applications/executorch_tests/runner.cpp
+new file mode 100644
+index 0000000..7ef920d
+--- /dev/null
++++ b/applications/executorch_tests/runner.cpp
+@@ -0,0 +1,133 @@
++/* Copyright (c) Meta Platforms, Inc. and affiliates.
++ * All rights reserved.
++ *
++ * This source code is licensed under the BSD-style license found in the
++ * LICENSE file in the root directory of this source tree.
++ */
++
++#include <stdio.h>
++#include <vector>
++#include <memory>
++
++#include <executorch/extension/data_loader/buffer_data_loader.h>
++#include <executorch/runtime/executor/program.h>
++#include <executorch/runtime/platform/log.h>
++#include <executorch/runtime/platform/platform.h>
++#include <executorch/runtime/platform/runtime.h>
++#include <executorch/util/util.h>
++
++// Model file - TODO make this configurable through CMake
++#include "model_pte.h"
++
++using namespace std;
++using torch::executor::Result;
++using torch::executor::Error;
++
++__attribute__((section(".sram.data"), aligned(16))) uint8_t method_allocator_pool[4 * 1024U];
++
++void et_pal_init(void) {}
++
++__ET_NORETURN void et_pal_abort(void) {
++  __builtin_trap();
++}
++
++et_timestamp_t et_pal_current_ticks(void) {
++ // libc.a - warning: _gettimeofday is not implemented and will always fail
++ return 11223344;
++}
++
++/**
++ * Emit a log message via platform output (serial port, console, etc).
++ */
++void et_pal_emit_log_message(
++    __ET_UNUSED et_timestamp_t timestamp,
++    et_pal_log_level_t level,
++    const char* filename,
++    __ET_UNUSED const char* function,
++    size_t line,
++    const char* message,
++    __ET_UNUSED size_t length) {
++  fprintf(
++      stderr,
++      "%c executorch:%s:%zu] %s\n",
++      level,
++      filename,
++      line,
++      message);
++}
++
++int main() {
++    torch::executor::runtime_init();
++
++    auto loader = torch::executor::util::BufferDataLoader(model_pte, sizeof(model_pte));
++    ET_LOG(Info, "Model PTE file loaded. Size: %lu bytes.", sizeof(model_pte));
++    Result<torch::executor::Program> program = torch::executor::Program::load(&loader);
++    if(!program.ok()) {
++       ET_LOG(Info,"Program loading failed @ 0x%p: 0x%" PRIx32, model_pte, program.error());
++    }
++
++    ET_LOG(Info,"Model buffer loaded, has %lu methods", program->num_methods());
++
++    const char* method_name = nullptr;
++    {
++      const auto method_name_result = program->get_method_name(0);
++      ET_CHECK_MSG(method_name_result.ok(), "Program has no methods");
++      method_name = *method_name_result;
++    }
++    ET_LOG(Info,"Running method %s", method_name);
++
++    Result<torch::executor::MethodMeta> method_meta = program->method_meta(method_name);
++    if (!method_meta.ok()) {
++        ET_LOG(Info,"Failed to get method_meta for %s: 0x%x",
++                method_name, (unsigned int)method_meta.error());
++    }
++
++    torch::executor::MemoryAllocator method_allocator{
++        torch::executor::MemoryAllocator(sizeof(method_allocator_pool), method_allocator_pool)};
++
++    std::vector<std::unique_ptr<uint8_t[]>> planned_buffers; // Owns the memory
++    std::vector<torch::executor::Span<uint8_t>> planned_spans; // Passed to the allocator
++    size_t num_memory_planned_buffers = method_meta->num_memory_planned_buffers();
++
++    for (size_t id = 0; id < num_memory_planned_buffers; ++id) {
++        size_t buffer_size = static_cast<size_t>(method_meta->memory_planned_buffer_size(id).get());
++        ET_LOG(Info,"Setting up planned buffer %zu, size %zu.", id, buffer_size);
++
++        planned_buffers.push_back(std::make_unique<uint8_t[]>(buffer_size));
++        planned_spans.push_back({planned_buffers.back().get(), buffer_size});
++    }
++
++    torch::executor::HierarchicalAllocator planned_memory(
++      {planned_spans.data(), planned_spans.size()});
++
++    torch::executor::MemoryManager memory_manager(&method_allocator, &planned_memory);
++
++    Result<torch::executor::Method> method = program->load_method(method_name, &memory_manager);
++    if(!method.ok()) {
++        ET_LOG(Info,"Loading of method %s failed with status 0x%" PRIx32, method_name, method.error());
++    }
++    ET_LOG(Info,"Method loaded.");
++
++    ET_LOG(Info,"Preparing inputs...");
++    auto inputs = torch::executor::util::PrepareInputTensors(*method);
++    ET_LOG(Info,"Input prepared.");
++
++    ET_LOG(Info,"Starting the model execution...");
++    Error status = method->execute();
++    if(status != Error::Ok){
++        ET_LOG(Info,"Execution of method %s failed with status 0x%" PRIx32, method_name, status);
++    } else {
++        ET_LOG(Info,"Model executed successfully.");
++    }
++
++    std::vector<torch::executor::EValue> outputs(method->outputs_size());
++    ET_LOG(Info, "%zu outputs: ", outputs.size());
++    status = method->get_outputs(outputs.data(), outputs.size());
++    ET_CHECK(status == Error::Ok);
++    for (int i = 0; i < outputs.size(); ++i) {
++       for (int j = 0; j < outputs[i].toTensor().numel(); ++j) {
++          printf("Output[%d][%d]: %f\n", i, j, outputs[i].toTensor().const_data_ptr<float>()[j]);
++       }
++    }
++    return 0;
++}
+diff --git a/cmake/helpers.cmake b/cmake/helpers.cmake
+index a21d9f0..036f189 100644
+--- a/cmake/helpers.cmake
++++ b/cmake/helpers.cmake
+@@ -85,7 +85,7 @@ endfunction()
+ #############################################################################
+ 
+ function(ethosu_add_executable target)
+-    cmake_parse_arguments(ARGS "" "TARGET_LIBRARY" "SOURCES;LIBRARIES" ${ARGN})
++    cmake_parse_arguments(ARGS "WHOLE_ARCHIVE" "TARGET_LIBRARY" "SOURCES;LIBRARIES" ${ARGN})
+     add_executable(${target})
+ 
+     target_sources(${target} PRIVATE
+@@ -95,8 +95,17 @@ function(ethosu_add_executable target)
+         set(ARGS_TARGET_LIBRARY ethosu_target_init)
+     endif()
+ 
++    if (ARGS_WHOLE_ARCHIVE)
++        set(PRE_LINKER_FLAGS "-Wl,--whole-archive")
++        set(POST_LINKER_FLAGS "-Wl,--no-whole-archive")
++    endif()
++
+     target_link_libraries(${target} PRIVATE
+-        ${ARGS_TARGET_LIBRARY} ${ARGS_LIBRARIES})
++        ${PRE_LINKER_FLAGS}
++        ${ARGS_TARGET_LIBRARY} 
++        ${ARGS_LIBRARIES}
++        ${POST_LINKER_FLAGS}
++        )
+ 
+     ethosu_eval_link_options(${target})
+ 
+-- 
+2.39.3
+

--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eu
+
+if [[ "${1}" == "-h" ]]; then
+    echo "Usage: $(basename $0) [path-to-a-scratch-dir] [buck2 binary]"
+    exit 0
+fi
+
+########
+### Hardcoded constants
+########
+script_dir=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# Ethos-u
+root_dir=${1:-"$(realpath ${script_dir}/ethos-u-scratch)"}
+buck2=${2:-"/tmp/buck2"}
+ethos_u_root_dir="$(cd ${root_dir}/ethos-u && pwd)"
+ethos_u_build_dir=${ethos_u_root_dir}/core_platform/build
+setup_path_script=${root_dir}/setup_path.sh
+
+# Executorch
+et_root_dir=$(cd ${script_dir}/../.. && pwd)
+et_build_dir=${root_dir}/executorch-cmake-out
+
+fvp_model=FVP_Corstone_SSE-300_Ethos-U55
+toolchain_cmake=${script_dir}/ethos-u-setup/arm-none-eabi-gcc.cmake
+_setup_msg="please refer to ${script_dir}/ethos-u-setup/setup.sh to properly install necessary tools."
+
+
+# Generate the PTE file
+function generate_pte_file() {
+    cd $et_root_dir
+    python3 -m examples.export.export_example --model_name="softmax"
+    local pte_file
+    pte_file="$(realpath ./softmax.pte)"
+    [[ -f ${pte_file} ]] || { echo "Failed to generate a pte file - ${pte_file}"; exit 1; }
+    echo "${pte_file}"
+}
+
+# build ExecuTorch Libraries
+function build_executorch() {
+    [[ -d "${et_build_dir}" ]] \
+        && echo "[${FUNCNAME[0]}] Warn: using already existing build-dir for executorch: ${et_build_dir}!!"
+    mkdir -p "${et_build_dir}"
+    
+    cd "${et_build_dir}"
+    cmake                                                 \
+        -DBUCK2=${buck2}                                  \
+        -DEXECUTORCH_BUILD_XNNPACK=OFF                    \
+        -DEXECUTORCH_BUILD_GFLAGS=OFF                     \
+        -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF            \
+        -DEXECUTORCH_BUILD_HOST_TARGETS=OFF               \
+        -DCMAKE_BUILD_TYPE=Release                        \
+        -DEXECUTORCH_ENABLE_LOGGING=ON                    \
+        -DEXECUTORCH_SELECT_OPS_LIST="aten::_softmax.out" \
+        -DFLATC_EXECUTABLE="$(which flatc)"               \
+        -DCMAKE_TOOLCHAIN_FILE="${toolchain_cmake}"       \
+        "${et_root_dir}"
+
+    echo "[${FUNCNAME[0]}] Configured CMAKE"
+
+    n=$(nproc)
+    cmake --build . -j"$((n - 5))" -- VERBOSE=1
+    echo "[${FUNCNAME[0]}] Generated static libraries for ExecuTorch:"
+    find . -name "*.a" -exec ls -al {} \;
+}
+
+# build Arm Baremetal executor_runner
+function build_executorch_runner() {
+    [[ $# -ne 1 ]] && { echo "[${FUNCNAME[0]}]" "Expecting pte file as an argument got, $*"; exit 1; }
+    local pte=${1}
+    cd "${ethos_u_root_dir}"/core_platform
+    cmake                                         \
+        -DCMAKE_TOOLCHAIN_FILE=${toolchain_cmake} \
+        -B build targets/corstone-300             \
+        -DET_DIR_PATH:PATH=${et_root_dir}         \
+        -DET_BUILD_DIR_PATH:PATH=${et_build_dir}  \
+        -DET_PTE_FILE_PATH:PATH="${pte}"          \
+        -DPYTHON_EXECUTABLE=$(which python3)
+    echo "[${FUNCNAME[0]}] Configured CMAKE"
+
+    n=$(nproc)
+    cmake --build build -- -j"$((n - 5))" executor_runner VERBOSE=1
+    echo "[${FUNCNAME[0]}] Generated baremetal elf file:"
+    find . -name "executor_runner.elf"
+}
+
+# Execute the executor_runner on FVP Simulator
+function run_fvp() {
+    elf=$(find ${ethos_u_build_dir} -name "executor_runner.elf")
+    [[ ! -f $elf ]] && { echo "[${FUNCNAME[0]}]: Unable to find executor_runner elf: ${elf}"; exit 1; }
+    FVP_Corstone_SSE-300_Ethos-U55                          \
+        -C ethosu.num_macs=128                              \
+        -C mps3_board.visualisation.disable-visualisation=1 \
+        -C mps3_board.telnetterminal0.start_telnet=0        \
+        -C mps3_board.uart0.out_file='-'                    \
+        -a "${elf}"                                         \
+        --timelimit 10 # seconds
+    echo "[${FUNCNAME[0]} Simulation complete, $?"
+}
+
+#######
+### Main
+#######
+# Source the tools
+# This should be prepared by the setup.sh
+[[ -f ${setup_path_script} ]] \
+    || { echo "Missing ${setup_path_script}. ${_setup_msg}"; exit 1; }
+source ${root_dir}/setup_path.sh
+
+# basic checks before we get started
+hash ${fvp_model} \
+    || { echo "Could not find ${fvp_model} on PATH, ${_setup_msg}"; exit 1; }
+
+hash arm-none-eabi-gcc \
+    || { echo "Could not find arm baremetal toolchain on PATH, ${_setup_msg}"; exit 1; }
+
+[[ -f ${toolchain_cmake} ]] \
+    || { echo "Could not find ${toolchain_cmake} file, ${_setup_msg}"; exit 1; }
+
+[[ -f ${et_root_dir}/CMakeLists.txt ]] \
+    || { echo "Executorch repo doesn't contain CMakeLists.txt file at root level"; exit 1; }
+
+type ${buck2} 2>&1 > /dev/null \
+    || { echo "Need a functioning buck2. Got ${buck2}."; exit 1; }
+
+# get the pte
+pte=$(generate_pte_file)
+
+# build et
+build_executorch
+
+# build the et baremetal app
+build_executorch_runner "${pte}"
+
+# run the app
+run_fvp
+
+exit 0

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eu
+
+if [[ "${1}" == "-h" ]]; then
+    echo "Usage: $(basename $0) [path-to-a-scratch-dir]"
+    exit 0
+fi
+
+########
+### Hardcoded constants
+########
+script_dir=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# FVP
+fvp_url="https://developer.arm.com/-/media/Arm%20Developer%20Community/Downloads/OSS/FVP/Corstone-300/FVP_Corstone_SSE-300_11.22_20_Linux64.tgz?rev=018659bd574f4e7b95fa647e7836ccf4&hash=22A79103C6FA5FFA7AFF3BE0447F3FF9"
+fvp_model_dir="Linux64_GCC-9.3"
+fvp_md5_checksum="98e93b949d0fbac977292d8668d34523"
+
+# toochain
+toolchain_url="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz"
+toolchain_dir="arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi"
+toolchain_md5_checksum="00ebb1b70b1f88906c61206457eacb61"
+
+# ethos-u
+ethos_u_repo_url="https://review.mlplatform.org/ml/ethos-u/ethos-u"
+ethos_u_base_rev="0995223100e3da8011700f58e491f1bf59511e3c"
+
+########
+### Optional user args
+########
+root_dir=${1:-"$(realpath ${script_dir}/ethos-u-scratch)"}
+
+########
+### Functions
+########
+function get_os_name() {
+    # Returns the name of the system i.e. Linux or Darwin
+    uname -s
+}
+
+function get_cpu_arch() {
+    # Returns the cpu architecture like arm64 or x86-64
+    uname -m
+}
+
+function verify_md5() {
+    [[ $# -ne 2 ]]  \
+        && { echo "[${FUNCNAME[0]}] Invalid number of args, expecting 2, but got $#"; exit 1; }
+    local ref_checksum="${1}"
+    local file="${2}"
+
+    local file_checksum="$(md5sum $file | awk '{print $1}')"
+    if [[ ${ref_checksum} != ${file_checksum} ]]; then
+        echo "Mismatched MD5 checksum for file: ${file}. Expecting ${ref_checksum} but got ${file_checksum}. Exiting."
+        exit 1
+    fi
+}
+
+function setup_fvp() {
+    # Download and install the Corstone 300 FVP simulator platform
+    cd "${root_dir}"
+    if [[ ! -e FVP_cs300.tgz ]]; then
+        echo "[${FUNCNAME[0]}] Downloading FVP ..."
+        curl --output FVP_cs300.tgz "${fvp_url}"
+        verify_md5 ${fvp_md5_checksum} FVP_cs300.tgz
+    fi
+
+    echo "[${FUNCNAME[0]}] Installing FVP ..."
+    rm -rf FVP
+    mkdir -p FVP
+    cd FVP
+    tar xf ../FVP_cs300.tgz
+    ./FVP_Corstone_SSE-300.sh --i-agree-to-the-contained-eula --force --destination ./ --quiet --no-interactive
+
+    fvp_bin_path="$(cd models/${fvp_model_dir} && pwd)"
+    export PATH=${PATH}:${fvp_bin_path}
+
+    hash FVP_Corstone_SSE-300_Ethos-U55
+    echo "export PATH=\${PATH}:${fvp_bin_path}" >> ${setup_path_script}
+
+}
+
+function setup_toolchain() {
+    # Download and install the arm-none-eabi toolchain
+    cd "${root_dir}"
+    if [[ ! -e gcc.tar.xz ]]; then
+        echo "[${FUNCNAME[0]}] Downloading toolchain ..."
+        curl --output gcc.tar.xz "${toolchain_url}"
+        verify_md5 ${toolchain_md5_checksum} gcc.tar.xz
+    fi
+
+    echo "[${FUNCNAME[0]}] Installing toolchain ..."
+    rm -rf "${toolchain_dir}"
+    tar xf gcc.tar.xz
+    toolchain_bin_path="$(cd ${toolchain_dir}/bin && pwd)"
+    export PATH=${PATH}:${toolchain_bin_path}
+    hash arm-none-eabi-gcc
+    echo "export PATH=\${PATH}:${toolchain_bin_path}" >> ${setup_path_script}
+}
+
+function setup_ethos_u() {
+    # This is the main dir which will pull more repos to do baremetal software dev for cs300
+    echo "[${FUNCNAME[0]}] Setting up the repo"
+    cd "${root_dir}"
+    [[ ! -d ethos-u ]] && \
+        git clone ${ethos_u_repo_url}
+    cd ethos-u
+    git reset --hard ${ethos_u_base_rev}
+    ./fetch_externals.py fetch
+    pip install pyelftools
+    echo "[${FUNCNAME[0]}] Done @ $(git describe --all --long 3> /dev/null) in ${root_dir}/ethos-u dir."
+}
+
+function patch_repo() {
+    # This is a temporary hack until it finds a better home in one for the ARM Ml repos
+    echo -e "[${FUNCNAME[0]}] Preparing ${name}..."
+    local repo_dir="${root_dir}/ethos-u/${name}"
+    cd $repo_dir
+
+    git reset --hard ${base_rev}
+
+    patch_dir=${script_dir}/ethos-u-setup/${name}/patches/
+    [[ -e ${patch_dir} && $(ls -A ${patch_dir}) ]] && \
+        git am -3 ${patch_dir}/*.patch
+
+    echo -e "[${FUNCNAME[0]}] Patched ${name} @ $(git describe --all --long 2> /dev/null) in ${repo_dir} dir.\n"
+}
+
+########
+### main
+########
+# do basic checks
+# Make sure we are on a supported platform
+# Linux ARM64 is a supported platform - adding it here is a WIP
+[[ "$(get_cpu_arch)" != "x86_64" ]] \
+    && { echo "[main] Error: only x86-64 architecture is supported for now!"; exit 1; }
+
+# No OSx support for FVP
+[[ "$(get_os_name)" != "Linux" ]] \
+    && { echo "[main] Error: only Linux os is supported for now!"; exit 1; }
+
+cd "${script_dir}"
+
+# Setup the root dir
+mkdir -p "${root_dir}"
+cd "${root_dir}"
+echo "[main] Using root dir ${root_dir}"
+
+setup_path_script="${root_dir}/setup_path.sh"
+echo "" > "${setup_path_script}"
+
+# Setup FVP
+setup_fvp
+
+# Setup toolchain
+setup_toolchain
+
+# Setup the ethos-u dev environment
+setup_ethos_u
+
+# Patch the ethos-u dev environment to include executorch application
+name="core_platform"
+base_rev=204210b1074071532627da9dc69950d058a809f4
+patch_repo
+
+echo "[main] update path by doing 'source ${setup_path_script}'"
+echo "[main] sucecss!"
+exit 0

--- a/examples/models/__init__.py
+++ b/examples/models/__init__.py
@@ -11,6 +11,7 @@ MODEL_NAME_TO_MODEL = {
     "linear": ("toy_model", "LinearModule"),
     "add": ("toy_model", "AddModule"),
     "add_mul": ("toy_model", "AddMulModule"),
+    "softmax": ("toy_model", "SoftmaxModule"),
     "dl3": ("deeplab_v3", "DeepLabV3ResNet50Model"),
     "edsr": ("edsr", "EdsrModel"),
     "emformer_transcribe": ("emformer_rnnt", "EmformerRnntTranscriberModel"),

--- a/examples/models/toy_model/__init__.py
+++ b/examples/models/toy_model/__init__.py
@@ -4,11 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .model import AddModule, AddMulModule, LinearModule, MulModule
+from .model import AddModule, AddMulModule, LinearModule, MulModule, SoftmaxModule
 
 __all__ = [
     AddModule,
     AddMulModule,
     LinearModule,
     MulModule,
+    SoftmaxModule,
 ]

--- a/examples/models/toy_model/model.py
+++ b/examples/models/toy_model/model.py
@@ -75,3 +75,19 @@ class AddMulModule(torch.nn.Module, EagerModelBase):
     def get_compile_spec(self):
         max_value = self.get_example_inputs()[0].shape[0]
         return [CompileSpec("max_value", bytes([max_value]))]
+
+
+class SoftmaxModule(torch.nn.Module, EagerModelBase):
+    def __init__(self):
+        super().__init__()
+        self.softmax = torch.nn.Softmax()
+
+    def forward(self, x):
+        z = self.softmax(x)
+        return z
+
+    def get_eager_model(self) -> torch.nn.Module:
+        return self
+
+    def get_example_inputs(self):
+        return (torch.ones(2, 2),)


### PR DESCRIPTION
Summary: An example script to build and run executor_runner baremetal version on ARM M-class CPUs

Differential Revision: D49900956

```
cd executorch
rm -rf cmake-out # optional
cd examples/arm/
./setup.sh [scratch_dir]
./run.sh [scratch_dir]
```



