### PR TITLE
Properly introduce selective build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,15 +94,19 @@ option(BUILD_SELECTIVE_BUILD_TEST
 
 option(EXECUTORCH_BUILD_SIZE_TEST "Whether to build size test" OFF)
 
-if(BUILD_SELECTIVE_BUILD_TEST)
-  option(SELECT_ALL_OPS
-         "Whether to register all ops defined in portable kernel library." OFF)
+# Selective build options.
+option(EXECUTORCH_SELECT_ALL_OPS
+      "Whether to register all ops defined in portable kernel library." ON)
 
-  # Option to register op list
-  option(SELECT_OPS_LIST "Register the following list of ops" OFF)
+# Option to register op list
+option(EXECUTORCH_SELECT_OPS_LIST "Register the following list of ops" OFF)
 
-  # Option to register ops from yaml file
-  option(SELECT_OPS_YAML "Register all the ops from a given yaml file" OFF)
+# Option to register ops from yaml file
+option(EXECUTORCH_SELECT_OPS_YAML
+      "Register all the ops from a given yaml file" OFF)
+# Do not enable select all ops if any of the other select options is on.
+if(EXECUTORCH_SELECT_OPS_LIST OR EXECUTORCH_SELECT_OPS_YAML)
+  set(EXECUTORCH_SELECT_ALL_OPS OFF)
 endif()
 
 # Build xnn_executor_runner which depends on XNNPACK

--- a/examples/selective_build/CMakeLists.txt
+++ b/examples/selective_build/CMakeLists.txt
@@ -27,13 +27,7 @@ include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
 # library
 #
 set(_kernel_lib)
-if(SELECT_ALL_OPS)
-  gen_selected_ops("" "" "${SELECT_ALL_OPS}")
-  list(APPEND _kernel_lib portable_kernels)
-elseif(SELECT_OPS_LIST)
-  gen_selected_ops("" "${SELECT_OPS_LIST}" "")
-  list(APPEND _kernel_lib portable_kernels)
-elseif(SELECT_OPS_YAML)
+if(EXECUTORCH_SELECT_OPS_YAML)
   set(_custom_ops_yaml ${EXECUTORCH_ROOT}/examples/custom_ops/custom_ops.yaml)
   gen_selected_ops("${_custom_ops_yaml}" "" "")
   set(kernel_sources
@@ -47,7 +41,15 @@ elseif(SELECT_OPS_YAML)
   target_compile_options(custom_kernels PUBLIC ${_common_compile_options})
 
   list(APPEND _kernel_lib custom_kernels)
+else()
+  list(APPEND _kernel_lib portable_kernels)
 endif()
+
+gen_selected_ops(
+  "${_custom_ops_yaml}"
+  "${EXECUTORCH_SELECT_OPS_LIST}"
+  "${EXECUTORCH_SELECT_ALL_OPS}")
+
 generate_bindings_for_kernels(${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
                               "${_custom_ops_yaml}")
 gen_operators_lib("select_build_lib" ${_kernel_lib} executorch)

--- a/examples/selective_build/test_selective_build.sh
+++ b/examples/selective_build/test_selective_build.sh
@@ -63,7 +63,7 @@ test_cmake_select_all_ops() {
         && retry cmake -DBUCK2="$BUCK" \
             -DBUILD_SELECTIVE_BUILD_TEST=ON \
             -DCMAKE_BUILD_TYPE=Release \
-            -DSELECT_ALL_OPS=ON \
+            -DEXECUTORCH_SELECT_ALL_OPS=ON \
             -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
 
     echo "Build selective build test"
@@ -88,7 +88,7 @@ test_cmake_select_ops_in_list() {
             -DMAX_KERNEL_NUM=17 \
             -DBUILD_SELECTIVE_BUILD_TEST=ON \
             -DCMAKE_BUILD_TYPE=Release \
-            -DSELECT_OPS_LIST="aten::convolution.out,\
+            -DEXECUTORCH_SELECT_OPS_LIST="aten::convolution.out,\
 aten::_native_batch_norm_legit_no_training.out,aten::hardtanh.out,aten::add.out,\
 aten::mean.out,aten::view_copy.out,aten::permute_copy.out,aten::addmm.out,\
 aten,aten::clone.out" \
@@ -114,7 +114,7 @@ test_cmake_select_ops_in_yaml() {
         && retry cmake -DBUCK2="$BUCK" \
             -DBUILD_SELECTIVE_BUILD_TEST=ON \
             -DCMAKE_BUILD_TYPE=Release \
-            -DSELECT_OPS_YAML=ON \
+            -DEXECUTORCH_SELECT_OPS_YAML=ON \
             -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
 
     echo "Build selective build test"

--- a/kernels/portable/CMakeLists.txt
+++ b/kernels/portable/CMakeLists.txt
@@ -39,7 +39,11 @@ list(FILTER _portable_kernels__srcs EXCLUDE REGEX "test/*.cpp")
 list(FILTER _portable_kernels__srcs EXCLUDE REGEX "codegen")
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in functions.yaml
-gen_selected_ops("${CMAKE_CURRENT_LIST_DIR}/functions.yaml" "" "")
+if(EXECUTORCH_SELECT_OPS_YAML)
+  set(_yaml "${CMAKE_CURRENT_LIST_DIR}/functions.yaml")
+endif()
+gen_selected_ops(
+  "${_yaml}" "${EXECUTORCH_SELECT_OPS_LIST}" "${EXECUTORCH_SELECT_ALL_OPS}")
 # Expect gen_selected_ops output file to be selected_operators.yaml
 generate_bindings_for_kernels(${CMAKE_CURRENT_SOURCE_DIR}/functions.yaml "")
 message("Generated files ${gen_command_sources}")


### PR DESCRIPTION
Summary:
Refactor options to do selective build.
* `EXECUTORCH_SELECT_ALL_OPS` by default `ON`, will be set to `OFF` if any of the other options is on.
* `EXECUTORCH_SELECT_OPS_LIST` by default `OFF`
* `EXECUTORCH_SELECT_OPS_YAML` by default `OFF`.

This allows these options to be used outside of selective build examples.

Differential Revision: D49935141


