### PR TITLE
Check if dl library is available and only then link it in for executorch in CMake. (#579)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,7 +239,12 @@ add_subdirectory(schema)
 
 add_library(executorch ${_executorch__srcs})
 target_link_libraries(executorch PRIVATE program_schema)
-target_link_libraries(executorch PRIVATE dl) # For dladdr()
+# Check if dl exists for this toolchain and only then link it.
+find_library(DL_LIBRARY_EXISTS NAMES dl)
+# Check if the library was found
+if(DL_LIBRARY_EXISTS)
+  target_link_libraries(executorch PRIVATE dl) # For dladdr()
+endif()
 target_include_directories(executorch PUBLIC ${_common_include_directories})
 target_compile_options(executorch PUBLIC ${_common_compile_options})
 if(MAX_KERNEL_NUM)


### PR DESCRIPTION
Summary:
The dl library might not be available on embedded platforms. Before we link it in for executorch core lib we check if it exists for the toolchain we are using and then link it in if it does.


Differential Revision: D50001473


