### PR TITLE
Replace GitHub link with the link to pytorch/executorch

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,55 +1,88 @@
 {% extends "!layout.html" %}
 
 {% block extrahead %}
-    {% if 'getting-started-setup' in pagename%}
-    <link rel="stylesheet" href="_static/css/progress-bar.css">
-    <script src="_static/js/progress-bar.js" defer></script>
-    {% elif 'compiler-delegate-and-partitioner' in pagename%}
-    <link rel="stylesheet" href="../_static/css/progress-bar.css">
-    <script src="../_static/js/progress-bar.js" defer></script>
-    {% elif 'xtensa' in pagename%}
-    <link rel="stylesheet" href="../_static/css/progress-bar.css">
-    <script src="../_static/js/progress-bar.js" defer></script>
-    {% endif %}
-    {{ super() }}
+{% if 'getting-started-setup' in pagename%}
+<link rel="stylesheet" href="_static/css/progress-bar.css">
+<script src="_static/js/progress-bar.js" defer></script>
+{% elif 'compiler-delegate-and-partitioner' in pagename%}
+<link rel="stylesheet" href="../_static/css/progress-bar.css">
+<script src="../_static/js/progress-bar.js" defer></script>
+{% elif 'xtensa' in pagename%}
+<link rel="stylesheet" href="../_static/css/progress-bar.css">
+<script src="../_static/js/progress-bar.js" defer></script>
+{% endif %}
+{{ super() }}
 {% endblock %}
 
 
 {% block sidebartitle %}
-    {% include "searchbox.html" %}
+{% include "searchbox.html" %}
 {% endblock %}
 
 {%- block content %}
-    {% if 'tutorials' in pagename %}
+{% if 'tutorials' in pagename %}
 
-    <div class="pytorch-call-to-action-links">
-      <div id="tutorial-type">{{ pagename }}</div>
+<div class="pytorch-call-to-action-links">
+  <div id="tutorial-type">{{ pagename }}</div>
 
-      <div id="google-colab-link">
-        <img class="call-to-action-img" src="{{ pathto('_static/images/pytorch-colab.svg', 1) }}"/>
-        <div class="call-to-action-desktop-view">Run in Google Colab</div>
-        <div class="call-to-action-mobile-view">Colab</div>
-      </div>
-      <div id="download-notebook-link">
-        <img class="call-to-action-notebook-img" src="{{ pathto('_static/images/pytorch-download.svg', 1) }}"/>
-        <div class="call-to-action-desktop-view">Download Notebook</div>
-        <div class="call-to-action-mobile-view">Notebook</div>
-      </div>
-      <div id="github-view-link">
-        <img class="call-to-action-img" src="{{ pathto('_static/images/pytorch-github.svg', 1) }}"/>
-        <div class="call-to-action-desktop-view">View on GitHub</div>
-        <div class="call-to-action-mobile-view">GitHub</div>
-      </div>
-    </div>
+  <div id="google-colab-link">
+    <img class="call-to-action-img" src="{{ pathto('_static/images/pytorch-colab.svg', 1) }}" />
+    <div class="call-to-action-desktop-view">Run in Google Colab</div>
+    <div class="call-to-action-mobile-view">Colab</div>
+  </div>
+  <div id="download-notebook-link">
+    <img class="call-to-action-notebook-img" src="{{ pathto('_static/images/pytorch-download.svg', 1) }}" />
+    <div class="call-to-action-desktop-view">Download Notebook</div>
+    <div class="call-to-action-mobile-view">Notebook</div>
+  </div>
+  <div id="github-view-link">
+    <img class="call-to-action-img" src="{{ pathto('_static/images/pytorch-github.svg', 1) }}" />
+    <div class="call-to-action-desktop-view">View on GitHub</div>
+    <div class="call-to-action-mobile-view">GitHub</div>
+  </div>
+</div>
 
-    {% endif %}
-    {{ super() }}
+{% endif %}
+{{ super() }}
 
 {% endblock %}
 
 {% block footer %}
 {{ super() }}
 <script script type="text/javascript">
-    var collapsedSections = ['Introduction', 'Getting Started', 'Exporting to ExecuTorch', 'API Reference', 'IR Specification', 'Compiler Entry Points', 'Runtime', 'Quantization', 'Kernel Library', 'SDK', 'Tutorials']
+  var collapsedSections = ['Introduction', 'Getting Started', 'Exporting to ExecuTorch', 'API Reference', 'IR Specification', 'Compiler Entry Points', 'Runtime', 'Quantization', 'Kernel Library', 'SDK', 'Tutorials']
+</script>
+
+{{ super() }}
+// Patch up links to point to ExecuTorch URLs instead of to
+// pytorch/pytorch URLs.
+<script type="text/javascript">
+  $(document).ready(function () {
+    // Patch links on interactive tutorial pages to point
+    // to the correct ExecuTorch URLs.
+    var downloadNote = $(".sphx-glr-download-link-note.admonition.note");
+    if (downloadNote.length >= 1) {
+      var tutorialUrl = $("#tutorial-type").text().substring($("#tutorial-type").text().indexOf("tutorials/") + 9); // 9 is the length of "tutorials/"
+      var githubLink = "https://github.com/pytorch/executorch/blob/main/docs/source/tutorials_source" + tutorialUrl + ".py",
+        notebookLink = $(".reference.download")[1].href,
+        notebookDownloadPath = notebookLink.split('_downloads')[1],
+        colabLink = "https://colab.research.google.com/github/pytorch/executorch/blob/gh-pages/main/_downloads" + notebookDownloadPath;
+
+      $(".pytorch-call-to-action-links a[data-response='Run in Google Colab']").attr("href", colabLink);
+      $(".pytorch-call-to-action-links a[data-response='View on Github']").attr("href", githubLink);
+    }
+
+    // Patch the "GitHub" link at the top of the page
+    // to point to the ExecuTorch repo.
+    var overwrite = function (_) {
+      if ($(this).length > 0) {
+        $(this)[0].href = "https://github.com/pytorch/executorch"
+      }
+    }
+    // PC
+    $(".main-menu a:contains('GitHub')").each(overwrite);
+    // Mobile
+    $(".mobile-menu a:contains('Github')").each(overwrite);
+  });
 </script>
 {% endblock %}


### PR DESCRIPTION
Summary:
* Replace GitHub link with the link to pytorch/executorch
* Also, make sure to use the correct links in the Google Colab downloads. For now downloads from main only.
* Inspired by pytorch/audio: https://github.com/pytorch/audio/blob/main/docs/source/_templates/layout.html#L61

Differential Revision: D50038777


