### PR TITLE
Fix lint errors

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -70,7 +70,7 @@ exclude_patterns = [
     '**/third-party/**',
     # NB: Objective-C is not supported
     'examples/apple/**',
-    'examples/ios_demo_apps/**',
+    'examples/demo-apps/apple_ios/**',
 ]
 command = [
     'python',

--- a/examples/demo-apps/android/jni/CMakeLists.txt
+++ b/examples/demo-apps/android/jni/CMakeLists.txt
@@ -7,7 +7,9 @@
 
 cmake_minimum_required(VERSION 3.19)
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/fbjni ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni)
+add_subdirectory(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/fbjni
+  ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni)
 
 
 if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*ios\.toolchain\.cmake$")


### PR DESCRIPTION
Summary:

Fixed two lint errors:

- CMake (more than 80 characters per line)
- Ignoring objective C in examples (didn't update due to refactoring_

Test Plan: lintrunner --all-files