### PR TITLE
[ET][Portable] Fix op constant_pad_nd

### DIFF
--- a/kernels/portable/cpu/op_constant_pad_nd.cpp
+++ b/kernels/portable/cpu/op_constant_pad_nd.cpp
@@ -145,6 +145,11 @@ void constant_pad_nd_out_impl(
 
   size_t ndim = self.dim();
 
+  if (ndim == 0) {
+    out_data[0] = self_data[0];
+    return;
+  }
+
   int64_t self_sizes[kTensorDimensionLimit];
   int64_t self_strides[kTensorDimensionLimit];
   int64_t out_sizes[kTensorDimensionLimit];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #712
* #711
* #710
* #709
* __->__ #708
* #707
* #706
* #705
* #704
* #703
* #702
* #701
* #700
* #699
* #698
* #697
* #696
* #695
* #694
* #693

Fix for zero rank tensor

Differential Revision: [D49849625](https://our.internmc.facebook.com/intern/diff/D49849625/)