### PR TITLE
[ET][Portable] Simplify op copy

### DIFF
--- a/kernels/portable/cpu/op_copy.cpp
+++ b/kernels/portable/cpu/op_copy.cpp
@@ -33,25 +33,11 @@ Tensor& copy_out(
 
   ET_KERNEL_CHECK(ctx, tensors_have_same_dtype(in, out), InvalidArgument, out);
 
-  Tensor::SizesType expected_output_size[kTensorDimensionLimit];
-  size_t expected_output_dim = 0;
-
   ET_KERNEL_CHECK(
       ctx, tensor_is_broadcastable_to(src, in), InvalidArgument, src);
 
-  get_broadcast_target_size(
-      in,
-      src,
-      expected_output_size,
-      kTensorDimensionLimit,
-      &expected_output_dim);
-
   ET_KERNEL_CHECK(
-      ctx,
-      resize_tensor(out, {expected_output_size, expected_output_dim}) ==
-          Error::Ok,
-      InvalidArgument,
-      out);
+      ctx, resize_tensor(out, in.sizes()) == Error::Ok, InvalidArgument, out);
 
   ScalarType in_type = in.scalar_type();
   ScalarType src_type = src.scalar_type();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #726
* #725
* #724
* #723
* #712
* __->__ #711
* #710
* #709
* #708
* #707
* #706
* #705
* #704
* #703
* #702
* #701
* #700
* #699
* #698
* #697
* #696
* #695
* #694
* #693

The fact that `src` must broadcast to `in` implies that the result of broadcasting `in` and `src` has shape equal to `in`. Therefore `out` must have the same shape than `in`. Hence, we can avoid calling `get_broadcast_target_size` and simply resize `out` to `in.sizes()`

Differential Revision: [D49979519](https://our.internmc.facebook.com/intern/diff/D49979519/)