### PR TITLE
Add GA tag

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -134,6 +134,7 @@ html_theme_options = {
     "navigation_depth": 4,
     "includehidden": True,
     "titles_only": False,
+    "analytics_id": "GTM-T8XT4PS",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Summary: Add Google Analytics tag to track metrics on the site.

Reviewed By: mergennachin

Differential Revision: D50027516


