### PR TITLE
Add initial lowering of aten depthwise convolution to tosa.depthwise_conv2d

### DIFF
--- a/backends/arm/operators/__init__.py
+++ b/backends/arm/operators/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2023 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from . import op_conv2d  # noqa

--- a/backends/arm/operators/op_conv2d.py
+++ b/backends/arm/operators/op_conv2d.py
@@ -1,0 +1,167 @@
+# Copyright 2023 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# Main implementation of AoT flow to partition and preprocess for Arm target
+# backends. Converts via TOSA as an intermediate form supported by AoT and
+# JIT compiler flows.
+#
+
+import serializer.tosa_serializer as ts
+
+from executorch.backends.arm import tosa_quant_utils
+from executorch.exir.dialects._ops import ops as exir_ops
+from serializer.tosa_serializer import TosaOp
+
+from . import op_utils
+
+
+def tosaLowerAtenConvolution(tosa_fb, node, inputs, is_quant, outp):
+    if node.target != exir_ops.edge.aten.convolution.default:
+        raise AssertionError("not a convolution operation")
+
+    input, weight, bias, stride, pad, dilation, _, _, group = inputs
+
+    # Currently only int8 is supported in quantized types.
+    actual_out_type = ts.DType.INT8 if is_quant else outp.dtype
+
+    ## Transpose input tensor to NHWC_Order for TOSA
+    NHWC_Order = [0, 2, 3, 1]
+    input_transposed = op_utils.buildTranspose(
+        tosa_fb, input.name, input.shape, NHWC_Order, actual_out_type
+    )
+
+    # Get the attributes of convolution.
+    attr = ts.TosaSerializerAttribute()
+    pad_attr = [val for val in pad.special for _ in (0, 1)]
+    stride_attr = stride.special
+    dilation_attr = dilation.special
+    attr.ConvAttribute(pad_attr, stride_attr, dilation_attr, 0, 0)
+
+    # Non-bias case.
+    if len(node.all_input_nodes) == 2:
+        # Create a zero bias tensor if not presented
+        out_channels = weight.shape[0]
+        bias_name = "bias" + node.name.split("default", 1)[1]
+        bias = tosa_fb.addConst(
+            [out_channels],
+            ts.DType.INT32 if is_quant else outp.dtype,
+            [0] * out_channels,
+            name=bias_name,
+        )
+
+    if group.number > 1:
+        """Depthwise convolution case"""
+        # Given input.shape is (N, Ci, H, W), and weight.shape is (Co, Ci/G, H, W)
+        in_channels = input.shape[1]
+        out_channels = weight.shape[0]
+
+        # Reshape torch shape format of weight tensor to tosa required format.
+        # https://www.mlplatform.org/tosa/tosa_spec.html#_depthwise_conv2d
+        m_length = int(round(out_channels / in_channels))
+        weight_post_shape = (
+            in_channels,
+            m_length,
+            weight.shape[2],
+            weight.shape[3],
+        )
+
+        weight_reshaped = tosa_fb.addIntermediate(
+            weight_post_shape,
+            ts.DType.INT8 if is_quant else weight.dtype,
+        )
+
+        op_utils.buildReshape(
+            tosa_fb, weight.name, weight_post_shape, weight_reshaped.name
+        )
+
+        # Transpose weight to [KH, KW, C, M]
+        weight_HWCM_Order = [2, 3, 0, 1]
+        weight_transposed = op_utils.buildTranspose(
+            tosa_fb,
+            weight_reshaped.name,
+            weight_post_shape,
+            weight_HWCM_Order,
+            ts.DType.INT8 if is_quant else weight.dtype,
+        )
+
+        ## TOSA output shape is [N, H, W, C*M]
+        NHWO_Order = [0, 2, 3, 1]
+        out_shape_TOSA_Depthwise_CONV2D = [outp.shape[i] for i in NHWO_Order]
+
+        conv2d_res = tosa_fb.addIntermediate(
+            out_shape_TOSA_Depthwise_CONV2D,
+            ts.DType.INT32 if is_quant else outp.dtype,
+        )
+        tosa_fb.addOperator(
+            TosaOp.Op().DEPTHWISE_CONV2D,
+            [
+                input_transposed.name,
+                weight_transposed.name,
+                bias.name,
+            ],
+            [conv2d_res.name],
+            attr,
+        )
+    else:
+        """Regular convolution case"""
+        # Transpose weight to [OC, H, W, IC]
+        weight_CHWC_Order = [0, 2, 3, 1]
+        weight_transposed = op_utils.buildTranspose(
+            tosa_fb,
+            weight.name,
+            weight.shape,
+            weight_CHWC_Order,
+            actual_out_type,
+        )
+
+        ## TOSA output shape is [NHWO]
+        NHWO_Order = [0, 2, 3, 1]
+        out_shape_TOSA_CONV2D = [outp.shape[i] for i in NHWO_Order]
+
+        # The output type is int32 when input type is int8.
+        conv2d_res = tosa_fb.addIntermediate(
+            out_shape_TOSA_CONV2D,
+            ts.DType.INT32 if is_quant else outp.dtype,
+        )
+        tosa_fb.addOperator(
+            TosaOp.Op().CONV2D,
+            [
+                input_transposed.name,
+                weight_transposed.name,
+                bias.name,
+            ],
+            [conv2d_res.name],
+            attr,
+        )
+
+    ## Torch output shape is [NOHW]
+    NOHW_Order = [0, 3, 1, 2]
+    attr_output_transpose = ts.TosaSerializerAttribute()
+    attr_output_transpose.TransposeAttribute(NOHW_Order)
+
+    # For quantized convolution, rescale the output value back to the same
+    # integer value domain of the next op. Otherwise return float32 output.
+    if is_quant:
+        # Get scale_factor from input, weight, and output.
+        _, input_scale, _, _, _, _ = op_utils.getNodeArgs(node.args[0])
+        _, weight_scale, _, _, _, _ = op_utils.getNodeArgs(node.args[1])
+        _, output_scale, _, _, _, _ = op_utils.getNodeArgs(list(node.users)[0])
+
+        conv2d_res = tosa_quant_utils.buildRescaleOpConvOutput(
+            tosa_fb,
+            conv2d_res,
+            actual_out_type,
+            input_scale,
+            weight_scale,
+            output_scale,
+        )
+
+    tosa_fb.addOperator(
+        TosaOp.Op().TRANSPOSE,
+        [conv2d_res.name],
+        [outp.name],
+        attr_output_transpose,
+    )

--- a/backends/arm/operators/op_utils.py
+++ b/backends/arm/operators/op_utils.py
@@ -1,0 +1,49 @@
+import serializer.tosa_serializer as ts
+from executorch.backends.arm import tosa_mapping
+
+from serializer.tosa_serializer import TosaOp
+
+
+def getNodeArgs(node):
+    return [tosa_mapping.TosaArg(arg) for arg in node.args]
+
+
+"""
+Helper transpose function to match TOSA's shape requirements
+ E.g., TOSA 0.80.0 specification - 2.3.3 CONV2D shapes:
+ https://www.mlplatform.org/tosa/tosa_spec.html#_conv2d
+"""
+
+
+def buildTranspose(tosa_fb, input_name, input_shape, new_order, out_dtype):
+    # Check new_order's length is equal to input rank
+    assert len(input_shape) == len(new_order), "Wrong shape order length"
+
+    # Check no duplications
+    assert len(set(new_order)) == len(new_order), "Contain duplicated dim numbers"
+
+    # Check all dims are valid
+    for idx in new_order:
+        if idx < 0:
+            assert True, "Negative dim number"
+        elif idx >= len(input_shape):
+            assert True, "Dim is greater than input rank"
+
+    input_shape_transpoed = [input_shape[i] for i in new_order]
+    attr = ts.TosaSerializerAttribute()
+    attr.TransposeAttribute(new_order)
+    input_transposed = tosa_fb.addIntermediate(input_shape_transpoed, out_dtype)
+    tosa_fb.addOperator(
+        TosaOp.Op().TRANSPOSE, [input_name], [input_transposed.name], attr
+    )
+    return input_transposed
+
+
+""" TOSA reshape returns a tensor with the same type/values as the input.
+    No data conversion happens during a reshape operation. """
+
+
+def buildReshape(tosa_fb, input_name, new_shape, output_name):
+    attr = ts.TosaSerializerAttribute()
+    attr.ReshapeAttribute(new_shape)
+    tosa_fb.addOperator(TosaOp.Op().RESHAPE, [input_name], [output_name], attr)

--- a/backends/arm/test/test_models.py
+++ b/backends/arm/test/test_models.py
@@ -34,6 +34,10 @@ class TosaProfile(Enum):
     BI_INT = 3  # integer only BI subset tests (for test graphs)
 
 
+def rand_test_integers(low, high, size):
+    return torch.from_numpy(np.float32(rng.integers(low, high, size)))
+
+
 class TorchBuilder:
     """The member functions build the PyTorch operators into small networks
     for our tests"""
@@ -335,20 +339,138 @@ class TorchBuilder:
             x = self.conv2d_2(x)
             return x
 
-    # @register_test
-    class simple_depthwise_conv2d(torch.nn.Module):
+    @register_test
+    class simple_depthwise_conv2d_3x3x3_1x3x256x256_group3_stride1(torch.nn.Module):
+        data = torch.ones(1, 3, 256, 256)
         inputs = {
-            TosaProfile.MI: (torch.ones(1, 3, 256, 256),),
+            TosaProfile.BI: (data,),
+            TosaProfile.MI: (data,),
         }
 
         def __init__(self):
             super().__init__()
-            self.conv2d = torch.nn.Conv2d(
+            """ in_channels == out_channels """
+            self.depthwise_conv2d = torch.nn.Conv2d(
                 in_channels=3, out_channels=3, kernel_size=3, stride=1, groups=3
             )
+            with torch.no_grad():
+                self.depthwise_conv2d.weight.copy_(
+                    rand_test_integers(low=100, high=130, size=(3, 1, 3, 3))
+                )
+                self.depthwise_conv2d.bias.copy_(torch.ones(3))
 
         def forward(self, x):
-            x = self.conv2d(x)
+            x = self.depthwise_conv2d(x)
+            return x
+
+    @register_test
+    class simple_depthwise_conv2d_8x4x3x3_1x4x256x256_group4_stride1(torch.nn.Module):
+        data = torch.ones(1, 4, 256, 256)
+        inputs = {
+            TosaProfile.BI: (data,),
+            TosaProfile.MI: (data,),
+        }
+
+        def __init__(self):
+            super().__init__()
+            """ in_channels * k == out_channels, where k = 2 """
+            self.depthwise_conv2d = torch.nn.Conv2d(
+                in_channels=4, out_channels=8, kernel_size=3, stride=1, groups=4
+            )
+            with torch.no_grad():
+                self.depthwise_conv2d.weight.copy_(
+                    rand_test_integers(low=21, high=25, size=(8, 1, 3, 3))
+                )
+                self.depthwise_conv2d.bias.copy_(
+                    rand_test_integers(low=1, high=4, size=(8))
+                )
+
+        def forward(self, x):
+            x = self.depthwise_conv2d(x)
+            return x
+
+    @register_test
+    class simple_depthwise_conv2d_8x16x3_2x8x198x198_group8_stride3(torch.nn.Module):
+        data = torch.ones(2, 8, 198, 198)
+        inputs = {
+            TosaProfile.BI: (data,),
+            TosaProfile.MI: (data,),
+        }
+
+        def __init__(self):
+            super().__init__()
+            self.depthwise_conv2d = torch.nn.Conv2d(
+                in_channels=8, out_channels=16, kernel_size=3, stride=3, groups=8
+            )
+            with torch.no_grad():
+                self.depthwise_conv2d.weight.copy_(
+                    rand_test_integers(low=80, high=110, size=(16, 1, 3, 3))
+                )
+                self.depthwise_conv2d.bias.copy_(
+                    rand_test_integers(low=1, high=4, size=(16))
+                )
+
+        def forward(self, x):
+            x = self.depthwise_conv2d(x)
+            return x
+
+    @register_test
+    class simple_depthwise_conv2d_3x3_1x4x256x256_group4_non_bias(torch.nn.Module):
+        data = torch.ones(1, 4, 256, 256)
+        inputs = {
+            TosaProfile.BI: (data,),
+            TosaProfile.MI: (data,),
+        }
+
+        def __init__(self):
+            super().__init__()
+            self.depthwise_conv2d = torch.nn.Conv2d(
+                in_channels=4,
+                out_channels=8,
+                kernel_size=3,
+                stride=1,
+                groups=4,
+                bias=False,
+            )
+            with torch.no_grad():
+                self.depthwise_conv2d.weight.copy_(
+                    rand_test_integers(low=30, high=50, size=(8, 1, 3, 3))
+                )
+
+        def forward(self, x):
+            x = self.depthwise_conv2d(x)
+            return x
+
+    @register_test
+    class block_two_depthwise_conv2d(torch.nn.Module):
+        data = rand_test_integers(low=10, high=20, size=(2, 4, 64, 64))
+
+        inputs = {
+            TosaProfile.BI: (data,),
+            TosaProfile.MI: (data,),
+        }
+
+        def __init__(self):
+            super().__init__()
+            self.depthwise_conv2d = torch.nn.Conv2d(
+                in_channels=4, out_channels=8, kernel_size=3, stride=1, groups=4
+            )
+            self.depthwise_conv2d_2 = torch.nn.Conv2d(
+                in_channels=8, out_channels=24, kernel_size=3, stride=1, groups=8
+            )
+            with torch.no_grad():
+                self.depthwise_conv2d.weight.copy_(
+                    rand_test_integers(low=11, high=14, size=(8, 1, 3, 3))
+                )
+                self.depthwise_conv2d.bias.copy_(torch.ones(8))
+                self.depthwise_conv2d_2.weight.copy_(
+                    rand_test_integers(low=11, high=14, size=(24, 1, 3, 3))
+                )
+                self.depthwise_conv2d.bias.copy_(torch.ones(8))
+
+        def forward(self, x):
+            x = self.depthwise_conv2d(x)
+            x = self.depthwise_conv2d_2(x)
             return x
 
     @register_test

--- a/examples/arm/arm_tosa_e2e.py
+++ b/examples/arm/arm_tosa_e2e.py
@@ -46,8 +46,13 @@ SUPPORTED_BI_TEST_LIST = [
     "simple_conv2d_2x2_1x1x14x14_stride2",
     "simple_conv2d_5x5_3x2x128x128_stride1",
     "simple_conv2d_2x2_3x1x40x40_non_bias",
+    "simple_depthwise_conv2d_3x3x3_1x3x256x256_group3_stride1",
+    "simple_depthwise_conv2d_8x4x3x3_1x4x256x256_group4_stride1",
+    "simple_depthwise_conv2d_3x3_1x4x256x256_group4_non_bias",
+    "simple_depthwise_conv2d_8x16x3_2x8x198x198_group8_stride3",
     "block_two_conv2d",
     "block_two_conv2d_non_bias",
+    "block_two_depthwise_conv2d",
 ]
 
 


### PR DESCRIPTION
aten.convolution is known as depthwise convolution when groups == in_channels and out_channels == K * in_channels. Lower this operation type to tosa.depthwise_conv2d