### PR TITLE
Update the Setting Up tutorial.

### DIFF
--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -55,15 +55,9 @@ the required dependencies.
 
 Follow these steps:
 
-1. If you do not have it already, install conda on your machine by following
-the steps in the [conda installation guide](https://conda.io/projects/conda/en/latest/user-guide/install/index.html).
-
-1. Create and activate your conda environment:
-
-   ```bash
-   conda create -yn executorch python=3.10.0
-   conda activate executorch
-   ```
+1. If you do not have it already, install conda on your machine by following the
+   steps in the
+   [conda installation guide](https://conda.io/projects/conda/en/latest/user-guide/install/index.html).
 
 1. Clone the `executorch` repository:
 
@@ -79,11 +73,45 @@ the steps in the [conda installation guide](https://conda.io/projects/conda/en/l
    git submodule update --init
    ```
 
+1. Create and activate your conda environment:
+
+   ```bash
+   conda create -yn executorch python=3.10.0
+   conda activate executorch
+   ```
+
+   Or alternatively use a Python virtual environment:
+
+   ```bash
+   python3 -m venv .executorch
+   source .executorch/bin/activate
+   ```
+
+1. Install [Cmake](https://cmake.org/download)
+
+   ```bash
+   conda install cmake
+   ```
+
+   Alternatively:
+
+   ```bash
+   pip install cmake
+   ```
+
 1. Install ExecuTorch and dependencies:
 
    ```bash
-   bash ./install_requirements.sh
+   ./install_requirements.sh
    ```
+
+1. Expose FlatBuffers compiler:
+
+   ExecuTorch uses `flatc` to export models and builds it from sources at
+   `third-party/flatbuffers`. Make it's available by referring in `$PATH`,
+   as prompted by the previous step, or exporting as `$FLATC_EXECUTABLE`
+   enironment variable.
+   Run `./build/install_flatc.sh` to make sure `flatc` is installed correctly.
 
 You have successfully set up your environment to work with ExecuTorch. The next
 step is to generate a sample ExecuTorch program.
@@ -178,18 +206,25 @@ Complete the following steps:
    git submodule update --init
    ```
 
-2. Configure Buck2 by decompressing with the following command (filename depends
+1. Install ExecuTorch and dependencies:
+
+   ```bash
+   ./install_requirements.sh
+   ```
+
+1. Configure Buck2 by decompressing with the following command (filename depends
    on your system):
 
    ```bash
-   # For example, buck2-x86_64-unknown-linux-musl.zst
+   # For example, buck2-x86_64-unknown-linux-musl.zst or buck2-aarch64-apple-darwin.zst
    zstd -cdq buck2-DOWNLOADED_FILENAME.zst > /tmp/buck2 && chmod +x /tmp/buck2
    ```
 
    You may want to copy the `buck2` binary into your `$PATH` so you can run it
    as `buck2`.
 
-3. Build a binary:
+1. Build a binary:
+
    ```bash
    /tmp/buck2 build //examples/portable/executor_runner:executor_runner --show-output
    ```

--- a/docs/website/docs/tutorials/00_setting_up_executorch.md
+++ b/docs/website/docs/tutorials/00_setting_up_executorch.md
@@ -2,35 +2,25 @@
 
 # Setting up ExecuTorch
 
-This is a tutorial for building and installing ExecuTorch from the GitHub repository.
+This is a tutorial for building and installing ExecuTorch from the GitHub
+repository.
 
-## AOT Setup [(Open on Google Colab)](https://colab.research.google.com/drive/1m8iU4y7CRVelnnolK3ThS2l2gBo7QnAP#scrollTo=1o2t3LlYJQY5)
+## Ahead-of-Time Setup [(Open on Google Colab)](https://colab.research.google.com/drive/1m8iU4y7CRVelnnolK3ThS2l2gBo7QnAP#scrollTo=1o2t3LlYJQY5)
 
 This will install an `executorch` pip package to your conda environment and
 allow you to export your PyTorch model to a flatbuffer file using ExecuTorch.
 
-### Step 1: Set up a dev environment
-
-To install conda, you can look at the
-[conda installation guide](https://conda.io/projects/conda/en/latest/user-guide/install/index.html).
-
-```bash
-conda create -yn executorch python=3.10.0
-conda activate executorch
-
-conda install cmake
-conda install -c conda-forge flatbuffers
-```
-
-### Step 2: Clone the `executorch` repo
+### Step 1: Clone the ExecuTorch repo
 
 ```bash
 # Do one of these, depending on how your auth is set up
 git clone https://github.com/pytorch/executorch.git
 git clone git@github.com:pytorch/executorch.git
 ```
-Ensure that git has fetched and updated the submodules. This is necessary anytime
-commit hash of any of the submodules changes. Thus it is safe and necessary at times to apply this step after you pull changes from upstream.
+
+Ensure that git has fetched and updated the submodules. This is necessary
+anytime commit hash of any of the submodules changes. Thus it is safe and
+necessary at times to apply this step after you pull changes from upstream.
 
 ```bash
 cd executorch
@@ -38,14 +28,44 @@ git submodule sync
 git submodule update --init
 ```
 
-### Step 3: Install `executorch` pip package and dependencies
+### Step 2: Set up a dev environment
+
+Install
+[Conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
+and activate a new virtual environment:
+
+```bash
+conda create -yn executorch python=3.10.0
+conda activate executorch
+```
+
+Or alternatively, activate a new Python virtual environment:
+
+```bash
+python3 -m venv .executorch
+source .executorch/bin/activate
+```
+
+### Step 3: Install [Cmake](https://cmake.org/download)
+
+```bash
+conda install cmake
+```
+
+Alternatively:
+
+```bash
+pip install cmake
+```
+
+### Step 4: Install `executorch` pip package and dependencies
 
 Install all required python dependencies and PyTorch dependencies.
+
 ```bash
-cd executorch
 # Note: if you are behind a firewall an appropriate proxy server must be setup
 # for all subsequent steps.
-bash ./install_requirements.sh
+./install_requirements.sh
 ```
 
 When getting a new version of the executorch repo (via clone, fetch, or pull),
@@ -53,9 +73,18 @@ you may need to re-install a new version the PyTorch nightly pip package. The
 `TORCH_VERSION` value in this document will be the correct version for the
 corresponsing version of the repo.
 
-### Step 4: Generate a program file from an `nn.Module`
+### Step 5: Expose FlatBuffers compiler
 
-Via python script:
+ExecuTorch uses `flatc` to export models and builds it from sources at
+`third-party/flatbuffers`. Make it's available by referring in `$PATH`,
+as prompted by the previous step, or exporting as `$FLATC_EXECUTABLE`
+enironment variable.
+Run `./build/install_flatc.sh` to make sure `flatc` is installed correctly.
+
+## Testing Model Export
+
+Generate a test program file from an `nn.Module` via Python script:
+
 ```bash
 # Creates the file `add.pte`
 python3 -m examples.portable.scripts.export --model_name="add"
@@ -64,7 +93,8 @@ python3 -m examples.portable.scripts.export --model_name="add"
 python3 -m examples.portable.scripts.export_and_delegate --option "composite"
 ```
 
-Or via python interpreter:
+Or via Python interpreter:
+
 ```python
 $ python3
 >>> import executorch.exir as exir
@@ -74,11 +104,14 @@ $ python3
 >>> open("mul.pte", "wb").write(exir.capture(m, m.get_random_inputs()).to_edge().to_executorch().buffer)
 ```
 
-Please refer to the [More Examples](./00_setting_up_executorch.md#more-examples) section for running with more popular models.
+Please refer to the [More Examples](./00_setting_up_executorch.md#more-examples)
+section for running with more popular models.
 
 ## Runtime Setup
 
-Follow [AOT Setup: Step 2](./00_setting_up_executorch.md#step-2-clone-the-executorch-repo) above to clone the `executorch` repo if you haven't already.
+Follow
+[Ahead-of-Time Setup: Step 1](./00_setting_up_executorch.md#step-1-clone-the-executorch-repo)
+above to clone the `executorch` repo if you haven't already.
 
 ### Step 1: Install buck2
 
@@ -87,7 +120,7 @@ Follow [AOT Setup: Step 2](./00_setting_up_executorch.md#step-2-clone-the-execut
 - Decompress with the following command (filename depends on your system)
 
 ```bash
-# For example, buck2-x86_64-unknown-linux-musl.zst
+# For example, buck2-x86_64-unknown-linux-musl.zst or buck2-aarch64-apple-darwin.zst
 zstd -cdq buck2-DOWNLOADED_FILENAME.zst > /tmp/buck2 && chmod +x /tmp/buck2
 ```
 


### PR DESCRIPTION
Summary: Swap repo checkout and dev env setup, use vanilla Python venvs and leave Conda as an alternative, etc. to make the steps friendlier on macOS.

Differential Revision: D50090516

