### PR TITLE
make GetProgramData only for bp

### DIFF
--- a/docs/source/sdk-bundled-io.md
+++ b/docs/source/sdk-bundled-io.md
@@ -236,14 +236,11 @@ Error GetProgramData(
     size_t* out_program_data_len);
 ```
 
- Finds the serialized ExecuTorch program data in the provided file data.
+ Finds the serialized ExecuTorch program data in the provided bundled program
+ file data.
 
  The returned buffer is appropriate for constructing a
  torch::executor::Program.
-
- Calling this is only necessary if the file could be a bundled program. If the
- file will only contain an unwrapped ExecuTorch program, callers can construct
- torch::executor::Program with file_data directly.
 
 __Parameters:__
  - @param[in] file_data The contents of an ExecuTorch program or bundled program
@@ -253,9 +250,9 @@ __Parameters:__
  - @param[out] out_program_data_len The length of out_program_data, in bytes.
 
 #### Returns
- - Error::Ok if the program was found, and
-     out_program_data/out_program_data_len point to the data. Other values
-     on failure.
+ - Error::Ok if the given file is bundled program, a program was found
+in it, and out_program_data/out_program_data_len point to the data. Other
+values on failure.
 
 Here's an example of how to use the `GetProgramData` API:
 ```c++

--- a/schema/targets.bzl
+++ b/schema/targets.bzl
@@ -97,7 +97,6 @@ def define_common_targets():
             # //executorch/runtime/executor/...
             "//executorch/codegen/tools/...",
             "//executorch/runtime/executor/...",
-            "//executorch/util/...",  # bundled_program_verification
         ],
         exported_headers = {
             OUTPUT_PROGRAM_HEADER: ":{}[{}]".format(PROGRAM_GEN_RULE_NAME, OUTPUT_PROGRAM_HEADER),

--- a/util/bundled_program_verification.cpp
+++ b/util/bundled_program_verification.cpp
@@ -21,7 +21,6 @@
 #include <executorch/runtime/executor/method.h>
 #include <executorch/runtime/platform/log.h>
 #include <executorch/schema/bundled_program_schema_generated.h>
-#include <executorch/schema/program_generated.h>
 
 namespace torch {
 namespace executor {
@@ -345,18 +344,14 @@ __ET_NODISCARD Error GetProgramData(
     size_t file_data_len,
     const void** out_program_data,
     size_t* out_program_data_len) {
-  if (executorch_flatbuffer::ProgramBufferHasIdentifier(file_data)) {
-    *out_program_data = file_data;
-    *out_program_data_len = file_data_len;
-  } else if (executorch_flatbuffer::BundledProgramBufferHasIdentifier(
-                 file_data)) {
+  if (executorch_flatbuffer::BundledProgramBufferHasIdentifier(file_data)) {
     auto program_bundled = executorch_flatbuffer::GetBundledProgram(file_data);
     *out_program_data = program_bundled->program()->data();
     *out_program_data_len = program_bundled->program()->size();
   } else {
     ET_LOG(
         Error,
-        "Unrecognized flatbuffer identifier '%.4s'",
+        "Unrecognized bundled program flatbuffer identifier '%.4s'",
         flatbuffers::GetBufferIdentifier(file_data));
     return Error::NotSupported;
   }

--- a/util/bundled_program_verification.h
+++ b/util/bundled_program_verification.h
@@ -63,14 +63,11 @@ __ET_NODISCARD Error VerifyResultWithBundledExpectedOutput(
     double atol = 1e-8);
 
 /**
- * Finds the serialized ExecuTorch program data in the provided file data.
+ * Finds the serialized ExecuTorch program data in the provided bundled program
+ * file data.
  *
  * The returned buffer is appropriate for constructing a
  * torch::executor::Program.
- *
- * Calling this is only necessary if the file could be a bundled program. If the
- * file will only contain an unwrapped ExecuTorch program, callers can construct
- * torch::executor::Program with file_data directly.
  *
  * @param[in] file_data The contents of an ExecuTorch program or bundled program
  *                      file.
@@ -78,9 +75,9 @@ __ET_NODISCARD Error VerifyResultWithBundledExpectedOutput(
  * @param[out] out_program_data The serialized Program data, if found.
  * @param[out] out_program_data_len The length of out_program_data, in bytes.
  *
- * @returns Error::Ok if the program was found, and
- *     out_program_data/out_program_data_len point to the data. Other values
- *     on failure.
+ * @returns Error::Ok if the given file is bundled program, a program was found
+ * in it, and out_program_data/out_program_data_len point to the data. Other
+ * values on failure.
  */
 __ET_NODISCARD Error GetProgramData(
     void* file_data,

--- a/util/targets.bzl
+++ b/util/targets.bzl
@@ -34,7 +34,6 @@ def define_common_targets():
             deps = [
                 "//executorch/runtime/core/exec_aten/util:dim_order_util" + aten_suffix,
                 "//executorch/schema:bundled_program_schema",
-                "//executorch/schema:program",
             ],
             exported_deps = [
                 "//executorch/runtime/core:memory_allocator",


### PR DESCRIPTION
Summary:
This diff update the GetProgramData function, its comments and doc, to make it only for bundled program data, rather than .bp and .pte. The reasons are:

1. loading .pte file should not use this function; instead we should use Loader + Program api. Remove the support to avoid misusing
2. after update, GetProgramData Api can be a sanity checker for bundled_program_runner and other places executing .bp files to make sure the loaded file is .bp.

In the future the GetProgramData will be deprecated. BundleProgram will follow the similar pattern like ET program to load file.

Reviewed By: dbort

Differential Revision: D50090162


