### PR TITLE
fix the instruction issue

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,8 +40,6 @@ To build the documentation locally:
 
 1. Clone the ExecuTorch repo to your machine.
 
-1. Switch to the `docs/` directory.
-
 1. If you don't have it already, start a conda environment:
 
    ```{note}


### PR DESCRIPTION
Summary:
the following command will run from the `executorch` root instead of `doc`
```
pip3 install -r ./.ci/docker/requirements-ci.txt
bash install_requirements.sh
```

Reviewed By: tarun292

Differential Revision: D49979270


