### PR TITLE
Clarify that buck2 version is important

### DIFF
--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -158,9 +158,13 @@ all the operators and backends.
 
 You will need the following prerequisits for this section:
 
-* **Zstandard**, or `zstd`, command line tool — install by running `pip3 install zstd`.
+* The `zstd` command line tool — install by running `pip3 install zstd`.
 
-* A prebuilt Buck2 archive for your system from [the Buck2 repo](https://github.com/facebook/buck2/releases/tag/2023-07-18).
+* Version `2023-07-18` of the `buck2` commandline tool — you can download a
+  prebuilt archive for your system from [the Buck2
+  repo](https://github.com/facebook/buck2/releases/tag/2023-07-18). Note that
+  the version is important, and newer or older versions may not work with the
+  version of the buck2 prelude used by the ExecuTorch repo.
 
 Complete the following steps:
 

--- a/docs/website/docs/tutorials/00_setting_up_executorch.md
+++ b/docs/website/docs/tutorials/00_setting_up_executorch.md
@@ -83,7 +83,7 @@ Follow [AOT Setup: Step 2](./00_setting_up_executorch.md#step-2-clone-the-execut
 ### Step 1: Install buck2
 
 - If you don't have the `zstd` commandline tool, install it with `pip install zstd`
-- Download a prebuilt buck2 archive for your system from https://github.com/facebook/buck2/releases/tag/2023-07-18
+- Download a prebuilt buck2 archive for your system from the https://github.com/facebook/buck2/releases/tag/2023-07-18 release page. Note that the version is important, and newer or older versions may not work with the version of the buck2 prelude used by the ExecuTorch repo.
 - Decompress with the following command (filename depends on your system)
 
 ```bash


### PR DESCRIPTION
Summary: The buck2 commandline tool version must be compatible with the buck2 prelude version. Make it clear that users must grab a specific version of buck2.

Differential Revision: D50093420


