### PR TITLE
Reorder the pages, renamed etrecord and etdump titles

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -172,12 +172,12 @@ Topics in this section will help you get started with ExecuTorch.
    :hidden:
 
    sdk-overview
+   sdk-etrecord
+   sdk-etdump
    sdk-profiling
+   sdk-inspector
    sdk-bundled-io
    sdk-delegate-integration
-   sdk-etdump
-   sdk-inspector
-   sdk-etrecord
 
 .. toctree::
    :glob:

--- a/docs/source/sdk-etdump.md
+++ b/docs/source/sdk-etdump.md
@@ -1,4 +1,4 @@
-# ETDump - ExecuTorch Dump
+# Prerequisite | ETDump - ExecuTorch Dump
 
 ETDump (ExecuTorch Dump) is one of the core components of the ExecuTorch SDK experience. It is the mechanism through which all forms of profiling and debugging data is extracted from the runtime. Users can't parse ETDump directly; instead, they should pass it into the Inspector API, which deserializes the data, offering interfaces for flexible analysis and debugging.
 

--- a/docs/source/sdk-etrecord.rst
+++ b/docs/source/sdk-etrecord.rst
@@ -1,5 +1,5 @@
-ETRecord
-========
+Prerequisite | ETRecord - ExecuTorch Record
+===========================================
 
 Overview
 --------


### PR DESCRIPTION
Summary:
1. We want to reorder the SDK pages according to TOC in https://docs.google.com/document/d/1JS5tcMZCsmNJyYHU_tVtf1fFvwif0nuW5wJqq0JtH3Q/edit?usp=sharing
2. Discussed the changed titles with Tarun

Differential Revision: D50097864


