### PR TITLE
update types for bundled input and expected output

### DIFF
--- a/bundled_program/config.py
+++ b/bundled_program/config.py
@@ -26,6 +26,16 @@ ConfigValue: TypeAlias = Union[
 ]
 
 """
+The data type of the input for method single execution.
+"""
+MethodInputType: TypeAlias = List[ConfigValue]
+
+"""
+The data type of the output for method single execution.
+"""
+MethodOutputType: TypeAlias = List[torch.Tensor]
+
+"""
 All supported types for input/expected output of test set.
 
 Namedtuple is also supported and listed implicity since it is a subclass of tuple.
@@ -62,10 +72,8 @@ class BundledConfig:
     def __init__(
         self,
         method_names: List[str],
-        # pyre-ignore
-        inputs: List[List[Any]],
-        # pyre-ignore
-        expected_outputs: List[List[Any]],
+        inputs: List[List[MethodInputType]],
+        expected_outputs: List[List[MethodOutputType]],
     ) -> None:
         """Contruct the config given inputs and expected outputs
 
@@ -76,6 +84,10 @@ class BundledConfig:
                     program with corresponding method name. Each set of any `inputs` element should
                     contain all inputs required by eager_model with the same inference function
                     as corresponding execution plan for one-time execution.
+
+                    It is worth mentioning that, although both bundled program and ET runtime apis support setting input
+                    other than torch.tensor type, only the input in torch.tensor type will be actually updated in
+                    the method, and the rest of the inputs will just do a sanity check if they match the default value in method.
 
             expected_outputs: Expected outputs for inputs sharing same index. The size of
                     expected_outputs should be the same as the size of inputs and provided method_names.
@@ -148,10 +160,8 @@ class BundledConfig:
     @staticmethod
     def _gen_execution_plan_tests(
         method_names: List[str],
-        # pyre-ignore
-        inputs: List[List[Any]],
-        # pyre-ignore
-        expected_outputs: List[List[Any]],
+        inputs: List[List[MethodInputType]],
+        expected_outputs: List[List[MethodOutputType]],
     ) -> List[ConfigExecutionPlanTest]:
         """Generate execution plan test given inputs, expected outputs for verifying each execution plan"""
 

--- a/bundled_program/core.py
+++ b/bundled_program/core.py
@@ -149,7 +149,7 @@ def assert_valid_bundle(
     ), f"All method names in bundled config should be found in program.execution_plan, \
          but {str(method_name_of_bundled_config - method_name_of_program)} does not include."
 
-    # check if  has been sorted in ascending alphabetical order of method name.
+    # check if execution_plan_tests has been sorted in ascending alphabetical order of method name.
     for bp_plan_id in range(1, len(bundled_config.execution_plan_tests)):
         assert (
             bundled_config.execution_plan_tests[bp_plan_id - 1].method_name
@@ -242,6 +242,12 @@ def assert_valid_bundle(
 
             # Check if bundled expected output in the current exeution plan test share same type as output in Program
             for j in range(len(cur_plan_test_expected_outputs)):
+                assert (
+                    type(cur_plan_test_expected_outputs[j]) == torch.Tensor
+                ), "The {}-th expected output shall be a tensor, but now is {}".format(
+                    j, type(cur_plan_test_expected_outputs[j])
+                )
+
                 # pyre-fixme[16]: Undefined attribute [16]: Item `bool` of `typing.Union[bool, float, int, torch._tensor.Tensor]`
                 # has no attribute `dtype`.
                 assert cur_plan_test_expected_outputs[j].dtype == get_output_dtype(

--- a/bundled_program/tests/common.py
+++ b/bundled_program/tests/common.py
@@ -162,6 +162,7 @@ def get_random_config(
         rand_method_names,
         rand_inputs,
         rand_expected_outputs,
+        # pyre-ignore[6]: Expected Union[Tensor, int, float, bool] for each element in 2nd positional argument, but got Union[Tensor, int]
         BundledConfig(rand_method_names, rand_inputs, rand_expected_outputs),
     )
 
@@ -192,6 +193,7 @@ def get_random_config_with_eager_model(
         for i, m_name in enumerate(method_names)
     ]
 
+    # pyre-ignore[6]: Expected Union[Tensor, int, float, bool] for each element in 2nd positional argument, but got Union[Tensor, int]
     return inputs, BundledConfig(method_names, inputs, expected_outputs)
 
 

--- a/bundled_program/tests/test_bundle_data.py
+++ b/bundled_program/tests/test_bundle_data.py
@@ -70,7 +70,7 @@ class TestBundle(unittest.TestCase):
 
         self.assertEqual(bundled_program.program, _serialize_pte_binary(program))
 
-    def test_bundled_miss_methods(self) -> None:
+    def test_bundle_miss_methods(self) -> None:
         program, bundled_config = get_common_program()
 
         # only keep the testcases for the first method to mimic the case that user only creates testcases for the first method.
@@ -78,10 +78,31 @@ class TestBundle(unittest.TestCase):
 
         _ = create_bundled_program(program, bundled_config)
 
-    def test_bundled_wrong_method_name(self) -> None:
+    def test_bundle_wrong_method_name(self) -> None:
         program, bundled_config = get_common_program()
 
         bundled_config.execution_plan_tests[-1].method_name = "wrong_method_name"
+        self.assertRaises(
+            AssertionError, create_bundled_program, program, bundled_config
+        )
+
+    def test_bundle_wrong_input_type(self) -> None:
+        program, bundled_config = get_common_program()
+
+        # pyre-ignore[8]: Use a wrong type on purpose. Should raise an error when creating a bundled program using bundled_config.
+        bundled_config.execution_plan_tests[-1].test_sets[-1].inputs = [
+            "WRONG INPUT TYPE"
+        ]
+        self.assertRaises(
+            AssertionError, create_bundled_program, program, bundled_config
+        )
+
+    def test_bundle_wrong_output_type(self) -> None:
+        program, bundled_config = get_common_program()
+
+        bundled_config.execution_plan_tests[-1].test_sets[-1].expected_outputs = [
+            0, 0.0
+        ]
         self.assertRaises(
             AssertionError, create_bundled_program, program, bundled_config
         )

--- a/docs/source/sdk-bundled-io.md
+++ b/docs/source/sdk-bundled-io.md
@@ -30,11 +30,15 @@ class BundledConfig (method_names, inputs, expected_outputs)
 
 __Parameters:__
 - method_names (_List[str]_): All names of Methods to be verified in the program.
-- inputs (_List[List[Any]]_): All sets of input to be tested on for all methods. Each list
+- inputs (_List[List[List[Union[torch.Tensor, int, float, bool]]]]_): All sets of input to be tested on for all methods. Each list
         of `inputs` is all sets which will be run on the method in the
         program with corresponding method name. Each set of any `inputs` element should contain all inputs required by Method with the same inference method name in ExecuTorch program for one-time execution.
 
-- expected_outputs (_List[List[Any]]_): Expected outputs for inputs sharing same index. The size of
+        It is worth mentioning that, although both bundled program and ET runtime apis support setting input
+        other than torch.tensor type, only the input in torch.tensor type will be actually updated in
+        the program, and the rest of the inputs will just do a sanity check if they match the default value in method.
+
+- expected_outputs (_List[List[List[torch.Tensor]]]_): Expected outputs for inputs sharing same index. The size of
         expected_outputs should be the same as the size of inputs and provided method_names.
 
 __Returns:__

--- a/examples/sdk/scripts/export_bundled_program.py
+++ b/examples/sdk/scripts/export_bundled_program.py
@@ -25,11 +25,11 @@ from ...portable.utils import export_to_exec_prog
 def save_bundled_program(
     method_names,
     inputs,
-    exec_prog: ExecutorchProgramManager,
-    graph_module: torch.nn.Module,
-    output_path: str,
-) -> None:
-    # Here inputs is List[Tuple[Union[torch.tenor, int, bool]]]. Each tuple is one input test
+    exec_prog,
+    graph_module,
+    output_path,
+):
+    # Here inputs is List[Tuple[Union[torch.tenor, int, float, bool]]]. Each tuple is one input test
     # set for the model. If we wish to test the model with multiple inputs then they can be
     # appended to this list. len(inputs) == number of test sets we want to run.
     #
@@ -45,7 +45,11 @@ def save_bundled_program(
         [[graph_module(*x)] for x in inputs] for i in range(len(method_names))
     ]
 
-    bundled_config = BundledConfig(method_names, bundled_inputs, expected_outputs)
+    bundled_config = BundledConfig(
+        method_names=method_names,
+        inputs=bundled_inputs,
+        expected_outputs=expected_outputs,
+    )
 
     bundled_program = create_bundled_program(
         exec_prog.executorch_program, bundled_config
@@ -63,7 +67,7 @@ def export_to_bundled_program(model_name, model, method_names, example_inputs):
 
     # Just as an example to show how multiple input sets can be bundled along, here we
     # create a list with the example_inputs tuple used twice. Each instance of example_inputs
-    # is a Tuple[Union[torch.tenor, int, bool]] which represents one test set for the model.
+    # is a Tuple[Union[torch.tenor, int, float, bool]] which represents one test set for the model.
     bundled_inputs = [example_inputs, example_inputs]
     print(f"Saving exported program to {model_name}_bundled.bp")
     save_bundled_program(

--- a/test/models/generate_linear_out_bundled_program.py
+++ b/test/models/generate_linear_out_bundled_program.py
@@ -71,7 +71,10 @@ def main() -> None:
     ]
 
     bundled_config = BundledConfig(
-        ["forward"], bundled_inputs, bundled_expected_outputs
+        method_names=["forward"],
+        # pyre-ignore
+        inputs=bundled_inputs,
+        expected_outputs=bundled_expected_outputs,
     )
 
     bundled_program = create_bundled_program(program, bundled_config)


### PR DESCRIPTION
Summary:
this diff updates comments, docs and annotations related to I/O types of bundled program, to make users clearer to know:
1. what kind of type of input can be bundled
2. what kind of type of input can actually be used in the ET method.

Differential Revision: D50100273


