### PR TITLE
Remove inception model part

### DIFF
--- a/examples/demo-apps/android/ExecuTorchDemo/README.md
+++ b/examples/demo-apps/android/ExecuTorchDemo/README.md
@@ -101,8 +101,7 @@ cd ..
 
 > **Note**: Please refer to [XNNPACK backend](../../../backend/README.md) and [Qualcomm backend](../../../../backends/qualcomm/README.md) for the full export tutorial on backends.
 
-1. Export a DeepLab v3 model and Inception v4 model backed with XNNPACK delegate and bundle it with
-   the app:
+1. Export a DeepLab v3 model backed with XNNPACK delegate and bundle it with the app:
 
 ```bash
 export FLATC_EXECUTABLE=$(realpath third-party/flatbuffers/cmake-out/flatc)


### PR DESCRIPTION
Summary: Inception/IC3/IC4/classification are no longer used.

Reviewed By: mergennachin

Differential Revision: D50110242


