### PR TITLE
Fix remaining internal lint errors: Part 2/N

### DIFF
--- a/bundled_program/tests/test_bundle_data.py
+++ b/bundled_program/tests/test_bundle_data.py
@@ -101,7 +101,8 @@ class TestBundle(unittest.TestCase):
         program, bundled_config = get_common_program()
 
         bundled_config.execution_plan_tests[-1].test_sets[-1].expected_outputs = [
-            0, 0.0
+            0,
+            0.0,
         ]
         self.assertRaises(
             AssertionError, create_bundled_program, program, bundled_config

--- a/examples/demo-apps/android/ExecuTorchDemo/.gitignore
+++ b/examples/demo-apps/android/ExecuTorchDemo/.gitignore
@@ -9,4 +9,3 @@
 .cxx
 local.properties
 *.so
-

--- a/examples/demo-apps/android/ExecuTorchDemo/app/build.gradle.kts
+++ b/examples/demo-apps/android/ExecuTorchDemo/app/build.gradle.kts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 plugins {
   id("com.android.application")
   id("org.jetbrains.kotlin.android")

--- a/examples/demo-apps/android/ExecuTorchDemo/settings.gradle.kts
+++ b/examples/demo-apps/android/ExecuTorchDemo/settings.gradle.kts
@@ -14,7 +14,6 @@ pluginManagement {
   }
 }
 
-
 dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {
@@ -24,6 +23,5 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "ExecuTorch Demo"
-
 
 include(":app")

--- a/examples/sdk/scripts/export_bundled_program.py
+++ b/examples/sdk/scripts/export_bundled_program.py
@@ -7,12 +7,16 @@
 # Example script for exporting simple models to flatbuffer
 
 import argparse
+import os
 
 from typing import List
 
 import torch
-import os
-from executorch.bundled_program.config import BundledConfig, MethodInputType, MethodOutputType
+from executorch.bundled_program.config import (
+    BundledConfig,
+    MethodInputType,
+    MethodOutputType,
+)
 from executorch.bundled_program.core import create_bundled_program
 from executorch.bundled_program.serialize import (
     serialize_from_bundled_program_to_flatbuffer,
@@ -71,7 +75,6 @@ def export_to_bundled_program(
         example_inputs: An example input for model's all method for single execution.
                         To simplify, here we assume that all inference methods have the same inputs.
     """
-
 
     print("Exporting ET program...")
 

--- a/kernels/prim_ops/test/TARGETS
+++ b/kernels/prim_ops/test/TARGETS
@@ -32,6 +32,6 @@ cpp_unittest(
         "//executorch/runtime/kernel:kernel_runtime_context",  # @manual
         "//executorch/runtime/kernel:operator_registry",
         "//executorch/runtime/platform:platform",
-        "//executorch/test/utils:utils",
+        "//executorch/test/utils:utils_aten",
     ],
 )

--- a/kernels/test/gen_supported_features.py
+++ b/kernels/test/gen_supported_features.py
@@ -93,7 +93,7 @@ def main(args: List[Any]) -> None:
     """
     This binary generates the supported_features.h from supported_features.yaml
     from this (//executorch/kernels/test) directory. Then for a specific kernel,
-    we need to supply the overriden supported_features_def.yaml for the kernel.
+    we need to supply the overridden supported_features_def.yaml for the kernel.
     """
     with open(args[0]) as f:
         y = yaml.full_load(f)

--- a/kernels/test/supported_features_summary.md
+++ b/kernels/test/supported_features_summary.md
@@ -18,4 +18,3 @@ Each kernel can have its own overrides, which are defined in
 ('portable', 'fbcode/executorch/kernels/portable/test/supported_features_def.yaml')
 ('quantized', 'fbcode/executorch/kernels/quantized/test/supported_features_def.yaml')
 ('custom_kernel_example', 'fbcode/executorch/kernels/test/custom_kernel_example/supported_features_def.yaml')
-


### PR DESCRIPTION
Summary:
All existing formattable lints

`arc lint --apply-patches --paths-cmd 'hg files executorch'`

Differential Revision: D50134275

