### PR TITLE
use headers in concepts for anchor links

### DIFF
--- a/docs/source/concepts.md
+++ b/docs/source/concepts.md
@@ -1,90 +1,102 @@
 # ExecuTorch Concepts
 This page provides an overview of key concepts and terms used throughout the ExecuTorch documentation. It is intended to help readers understand the terminology and concepts used in PyTorch Edge and ExecuTorch.
 
-[**AOT (Ahead of Time)**](./getting-started-architecture.md#program-preparation)
+### [AOT (Ahead of Time)](./getting-started-architecture.md#program-preparation)
 
 AOT generally refers to the program preparation that occurs before execution. On a high level, ExecuTorch workflow is split into an AOT compilation and a runtime. The AOT steps involve compilation into an Intermediate Representation (IR), along with optional transformations and optimizations.
 
-[**ATen**]((https://pytorch.org/cppdocs/#aten))
+### [ATen](https://pytorch.org/cppdocs/#aten)
 
 Fundamentally, it is a tensor library on top of which almost all other Python and C++ interfaces in PyTorch are built. It provides a core Tensor class, on which many hundreds of operations are defined.
 
-[**ATen Dialect**](./ir-exir.md#aten-dialect)
+### [ATen Dialect](./ir-exir.md#aten-dialect)
 
-ATen dialect is the result of exporting an eager module to a graph representation. It is the entry point of the ExecuTorch compilation pipeline; after exporting to ATen dialect, subsequent passes can then lower to Edge dialect. ATen dialect is a valid EXIR (Export Intermediate Representation) with additional properties. The goal of ATen dialect is to capture users’ programs as faithfully as possible.
+ATen dialect is the result of exporting an eager module to a graph representation. It is the entry point of the ExecuTorch compilation pipeline; after exporting to ATen dialect, subsequent passes can lower to Core ATen dialect and Edge dialect.
 
-**ATen mode**
+ATen dialect is a valid Export IR with additional properties. It consists of functional ATen operators, higher order operators (like control flow operators) and registered custom operators.
+
+The goal of ATen dialect is to capture users’ programs as faithfully as possible.
+
+### ATen mode
 
 ATen mode uses the ATen implementation of Tensor (`at::Tensor`) and related types, such as `ScalarType`, from the PyTorch core. This is in contrast to portable mode, which uses ExecuTorch’s smaller implementation of tensor (`torch::executor::Tensor`) and related types, such as `torch::executor::ScalarType`.
 - ATen kernels that rely on the full `at::Tensor` API are usable in this configuration.
 - ATen kernels tend to do dynamic memory allocation and often have extra flexibility (and thus overhead) to handle cases not needed by mobile/embedded clients. e.g.,  CUDA support, sparse tensor support, and dtype promotion.
 - Note: ATen mode is currently a WIP.
 
-**Backend**
+### Autograd safe ATen Dialect
+
+Autograd safe ATen dialect contains the autograd safe ATen operators, along with higher order operators (control flow ops) and registered custom operators.
+
+### Backend
 
 A specific hardware (like GPU, NPU) or a software stack (like XNNPACK) that consumes a graph or part of it, with performance and efficiency benefits.
 
-[**Backend Dialect**](./ir-exir.md#backend-dialect)
+### [Backend Dialect](./ir-exir.md#backend-dialect)
 
 Backend dialect is the result of exporting Edge dialect to specific backend. It’s target-aware, and may contain operators or submodules that are only meaningful to the target backend. This dialect allows the introduction of target-specific operators that do not conform to the schema defined in the Core ATen Operator Set and are not shown in ATen or Edge Dialect.
 
-[**Backend Specific Operator**](./compiler-kernel-fusion-pass.md)
+### [Backend Specific Operator](./compiler-kernel-fusion-pass.md)
 
 These are operators that are not part of ATen dialect or Edge dialect. Backend specific operators are only introduced by passes that happen after Edge dialect (see Backend dialect). These operators are specific to the target backend and will generally execute faster.
 
-[**Buck2**](https://buck2.build/)
+### [Buck2](https://buck2.build/)
 
 An open-source, large scale build system. Used to build ExecuTorch.
 
-[**CMake**](https://cmake.org/)
+### [CMake](https://cmake.org/)
 
 An open-source, cross-platform family of tools designed to build, test and package software. Used to build ExecuTorch.
 
-[**Core ATen operators / Canonical ATen operator set**](./ir-ops-set-definition.md)
+### Core ATen Dialect
+
+Core ATen dialect contains the core ATen operators along with higher order operators (control flow) and registered custom operators.
+
+### [Core ATen operators / Canonical ATen operator set](./ir-ops-set-definition.md)
 
 A select subset of the PyTorch ATen operator library. Core ATen operators will not be decomposed when exported with the core ATen decomposition table. They serve as a reference for the baseline ATen ops that a backend or compiler should expect from upstream.
 
-**Core ATen Decomposition Table**
+### Core ATen Decomposition Table
 
 Decomposing an operator involves expressing it as a combination of other operators. During the export process, a default list of decompositions are used; this is known as the Core ATen Decomposition Table.
 
-[**Core ATen IR**](https://pytorch.org/docs/stable/torch.compiler_ir.html#irs)
+### [Core ATen IR](https://pytorch.org/docs/stable/torch.compiler_ir.html#irs)
 
 Contains only the core ATen operators and registered custom operators. Registered custom operators are registered into the current PyTorch eager mode runtime, usually with a `TORCH_LIBRARY` call.
 
-[**Custom operator**](./compiler-kernel-fusion-pass.md)
+### [Custom operator](https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit?fbclid=IwAR1qLTrChO4wRokhh_wHgdbX1SZwsU-DUv1XE2xFq0tIKsZSdDLAe6prTxg#heading=h.ahugy69p2jmz)
 
 These are operators that aren't part of the ATen library, but which appear in eager mode. They are most likely associated with a specific target model or hardware platform. For example, [torchvision::roi_align](https://pytorch.org/vision/main/generated/torchvision.ops.roi_align.html) is a custom operator widely used by torchvision (doesn't target a specific hardware).
 
-**DataLoader**
+### DataLoader
 
 An interface that enables the ExecuTorch runtime to read from a file or other data source without directly depending on operating system concepts like files or memory allocation.
 
-[**Delegation**](./compiler-delegate-and-partitioner.md)
+### [Delegation](./compiler-delegate-and-partitioner.md)
 
 To run parts (or all) of a program on a specific backend (eg. XNNPACK) while the rest of the program (if any) runs on the basic ExecuTorch runtime. Delegation enables us to leverage the performance and efficiency benefits of specialized backends and hardware.
 
-**DSP (Digital Signal Processor)**
+### DSP (Digital Signal Processor)
 
 Specialized microprocessor chip with architecture optimized for digital signal processing.
 
-**dtype**
+### dtype
 
 Data type, the type of data (eg. float, integer, etc.) in a tensor.
 
-[**Dynamic Quantization**](https://pytorch.org/docs/main/quantization.html#general-quantization-flow)
+### [Dynamic Quantization](https://pytorch.org/docs/main/quantization.html#general-quantization-flow)
 
 A method of quantizing wherein tensors are quantized on the fly during inference. This is in contrast to static quantization, where tensors are quantized before inference.
 
-**Dynamic shapes**
+### Dynamic shapes
 
 Refers to the ability of a model to accept inputs with varying shapes during inference. For example, the ATen op [unique_consecutive](https://pytorch.org/docs/stable/generated/torch.unique_consecutive.html) and the custom op [MaskRCNN](https://pytorch.org/vision/main/models/mask_rcnn.html) have data dependent output shapes. Such operators are difficult to do memory planning on, as each invocation may produce a different output shape even for the same input shape. To support dynamic shapes in ExecuTorch, kernels can allocate tensor data using the `MemoryAllocator` provided by the client.
 
-**Eager mode**
+### Eager mode
 
 Python execution environment where operators in a model are immediately executed as they are encountered. e.g. Jupyter / Colab notebooks are run in eager mode. This is in contrast to graph mode, where operators are first synthesized into a graph which is then compiled and executed.
 
-[**Edge Dialect**](./ir-exir.md#edge-dialect)
+### [Edge Dialect](./ir-exir.md#edge-dialect)
 
 A dialect of EXIR with the following properties:
 - All operators are from a predefined operator set, called 'Edge Operators' or are registered custom operators.
@@ -92,83 +104,83 @@ A dialect of EXIR with the following properties:
 
 Edge dialect introduces specializations that are useful for Edge devices, but not necessarily for general (server) export. However, Edge dialect does not contain specializations for specific hardware besides those already present in the original Python program.
 
-**Edge operator**
+### Edge operator
 
 An ATen operator with a dtype specialization.
 
-[**ExecuTorch**](https://github.com/pytorch/executorch)
+### [ExecuTorch](https://github.com/pytorch/executorch)
 
 A unified ML software stack within the PyTorch Edge platform designed for efficient on-device inference. ExecuTorch defines a workflow to prepare (export and transform) and execute a PyTorch program on Edge devices such as mobile, wearables, and embedded devices.
 
-**ExecuTorch Method**
+### ExecuTorch Method
 
 The executable equivalent of an `nn.Module` Python method. For example, the `forward()` Python method would compile into an ExecuTorch `Method`.
 
-**ExecuTorch Program**
+### ExecuTorch Program
 
 An ExecuTorch `Program` maps string names like `forward` to specific ExecuTorch `Method` entries.
 
-**executor_runner**
+### executor_runner
 
 The ExecuTorch runtime that executes the exported PyTorch model on-device.
 
-[**EXIR**](./ir-exir.md)
+### [EXIR](./ir-exir.md)
 
 The **EX**port **I**ntermediate **R**epresentation (IR) from `torch.export`. Contains the computational graph of the model. All EXIR graphs are valid [FX graphs](https://pytorch.org/docs/stable/fx.html#torch.fx.Graph).
 
-[**flatbuffer**](https://github.com/google/flatbuffers)
+### [flatbuffer](https://github.com/google/flatbuffers)
 
 Memory efficient, cross platform serialization library. In the context of ExecuTorch, eager mode Pytorch models are exported to flatbuffer, which is the format consumed by the ExecuTorch runtime.
 
-**Framework tax**
+### Framework tax
 
 The cost of various loading and initialization tasks (not inference). For example; loading a program, initializing executor, kernel and backend-delegate dispatch, and runtime memory utilization.
 
-[**Graph**](./ir-exir.md)
+### [Graph](./ir-exir.md)
 
 An EXIR Graph is a PyTorch program represented in the form of a DAG (directed acyclic graph). Each node in the graph represents a particular computation or operation, and edges of this graph consist of references between nodes. Note: all EXIR graphs are valid [FX graphs](https://pytorch.org/docs/stable/fx.html#torch.fx.Graph).
 
-**Graph mode**
+### Graph mode
 
 In graph mode, operators are first synthesized into a graph, which will then be compiled and executed as a whole. This is in contrast to eager mode, where operators are executed as they are encountered. Graph mode typically delivers higher performance as it allows optimizations such as operator fusion.
 
-**Hybrid Quantization**
+### Hybrid Quantization
 
 A quantization technique where different parts of the model are quantized with different techniques based on computational complexity and sensitivity to accuracy loss. Some parts of the model may not be quantized to retain accuracy.
 
-**Intermediate Representation (IR)**
+### Intermediate Representation (IR)
 
 A representation of a program between the source and target languages. Generally, it is a data structure used internally by a compiler or virtual machine to represent source code.
 
-**Kernel**
+### Kernel
 
 An implementation of an operator. There can be multiple implementations of an operator for different backends/inputs/etc.
 
-**Lowering**
+### Lowering
 
 The process of transforming a model to run on various backends. It is called 'lowering' as it is moving code closer to the hardware. In ExecuTorch, lowering is performed as part of backend delegation.
 
-[**Memory planning**](./tutorials/export-to-executorch-tutorial#running-user-defined-passes-and-memory-planning)
+### [Memory planning](./compiler-memory-planning.md)
 
 The process of allocating and managing memory for a model. In ExecuTorch, a memory planning pass is run before the graph is saved to flatbuffer. This assigns a memory ID to each tensor and an offset in the buffer, marking where storage for the tensor starts.
 
-[**Node**](./ir-exir.md)
+### [Node](./ir-exir.md)
 
 A node in an EXIR graph represents a particular computation or operation, and is represented in Python using [torch.fx.Node](https://pytorch.org/docs/stable/fx.html#torch.fx.Node) class.
 
-**Operator**
+### Operator
 
 Function on tensors. This is the abstraction; kernels are the implementation. There can be varying implementations for different backends/inputs/etc.
 
-**Operator fusion**
+### Operator fusion
 
 Operator fusion is the process of combining multiple operators into a single compound operator, resulting in faster computation due to fewer kernel launches and fewer memory read/writes. This is a performance advantage of graph mode vs eager mode.
 
-**Operator registration**
+### Operator registration
 
 Operators need to be registered with the ExecuTorch runtime. This allows the compiler to resolve references to the operator in code.
 
-[**PAL (Platform Abstraction Layer)**](./runtime-platform-abstraction-layer.md)
+### [PAL (Platform Abstraction Layer)](./runtime-platform-abstraction-layer.md)
 
 Provides a way for execution environments to override operations such as;
 - Getting the current time.
@@ -176,22 +188,21 @@ Provides a way for execution environments to override operations such as;
 - Panicking the process/system.
 The default PAL implementation can be overridden if it doesn’t work for a particular client system.
 
-**Partial kernels**
+### Partial kernels
 
 Kernels that support a subset of tensor dtypes and/or dim orders.
 
-**Partitioner**
+### Partitioner
 
 Parts of a model may be delegated to run on an optimized backend. The partitioner splits the graph into the appropriate sub-networks and tags them for delegation.
 
-
-**Portable mode (lean mode)**
+### Portable mode (lean mode)
 
 Portable mode uses ExecuTorch’s smaller implementation of tensor (`torch::executor::Tensor`) along with related types (`torch::executor::ScalarType`, etc.). This is in contrast to ATen mode, which uses the ATen implementation of Tensor (`at::Tensor`) and related types (`ScalarType`, etc.)
 - `torch::executor::Tensor`, also known as ETensor, is a source-compatible subset of `at::Tensor`. Code written against ETensor can build against `at::Tensor`.
 - ETensor does not own or allocate memory on its own. To support dynamic shapes, kernels can allocate Tensor data using the MemoryAllocator provided by the client.
 
-**Portable kernels**
+### Portable kernels
 
 Portable kernels are operator implementations that are written to be compatible with ETensor. As ETensor is compatible with `at::Tensor`, portable kernels can be built against `at::Tensor` and used in the same model as ATen kernels. Portable kernels are:
 - Compatible with ATen operator signatures
@@ -200,42 +211,42 @@ Portable kernels are operator implementations that are written to be compatible 
 - Generally smaller in size than ATen kernels
 - Written to avoid dynamically allocating memory using new/malloc.
 
-**Program**
+### Program
 
 The set of codes and data to describe an ML model.
 
-**Program source code**
+### Program source code
 
 The Python source code to describe the program. It can be a Python function, or a method in PyTorch’s eager mode `nn.Module`.
 
-[**PTQ (Post Training Quantization)**](https://pytorch.org/tutorials/prototype/pt2e_quant_ptq.html)
+### [PTQ (Post Training Quantization)](https://pytorch.org/tutorials/prototype/pt2e_quant_ptq.html)
 
 A quantization technique where the model is quantized after it has been trained (usually for performance benefits). PTQ applies the quantization flow after training, in contrast to QAT which applies it during training.
 
-[**QAT (Quantization Aware Training)**](https://pytorch.org/tutorials/prototype/pt2e_quant_qat.html)
+### [QAT (Quantization Aware Training)](https://pytorch.org/tutorials/prototype/pt2e_quant_qat.html)
 
 Models may lose accuracy after quantization. QAT enables higher accuracy compared to eg. PTQ, by modeling the effects of quantization while training. During training, all weights and activations are ‘fake quantized’; float values are rounded to mimic int8 values, but all computations are still done with floating point numbers. Thus, all weight adjustments during training are made ‘aware’ that the model will ultimately be quantized. QAT applies the quantization flow during training, in contrast to PTQ which applies it afterwards.
 
-**Quantization**
+### Quantization
 
 Techniques for performing computations and memory accesses on tensors with lower precision data, usually `int8`. Quantization improves model performance by lowering the memory usage and (usually) decreasing computational latency; depending on the hardware, computation done in lower precision will typically be faster, e.g. `int8` matmul vs `fp32` matmul. Often, quantization comes at the cost of model accuracy.
 
-**Runtime**
+### Runtime
 
 The ExecuTorch runtime executes models on edge devices. It is responsible for program initialization, program execution and, optionally, destruction (releasing backend owned resources).
 
-[**SDK**](./sdk-overview.md)
+### [SDK](./sdk-overview.md)
 
 Software Development Kit. The tooling users need to profile, debug and visualize programs that are running with ExecuTorch.
 
-[**Selective build**](./selective_build.md)
+### [Selective build](./kernel-library-selective_build.md)
 
 An API used to build a leaner runtime by linking only to kernels used by the program. This provides significant binary size savings.
 
-[**Static Quantization**](https://pytorch.org/docs/main/quantization.html#general-quantization-flow)
+### [Static Quantization](https://pytorch.org/docs/main/quantization.html#general-quantization-flow)
 
 A method of quantizing wherein tensors are statically quantized. That is, floats are converted to a reduced-precision data type before inference.
 
-[**XNNPACK**](https://github.com/google/XNNPACK)
+### [XNNPACK](https://github.com/google/XNNPACK)
 
 An optimized library of neural network interface operators for ARM, x86, WebAssembly, and RISC-V platforms. It is an open-source project and used by PyTorch and ExecuTorch. It is a successor to the QNNPack library. The operators support both floating point and quantized values.


### PR DESCRIPTION
Summary:
so we can link to concepts from other docs.

Also add definition for 'Core ATen dialect'

Differential Revision: D50140641


