### PR TITLE
Update more examples to use long-term export APIs

### DIFF
--- a/examples/xtensa/aot/export_example.py
+++ b/examples/xtensa/aot/export_example.py
@@ -7,18 +7,15 @@
 # Example script for exporting simple models to flatbuffer
 
 import logging
-from typing import Tuple
 
 from .meta_registrations import *  # noqa
 
 import torch
-import torch._export as export
-
-from executorch import exir
-from executorch.exir import ExirExportedProgram
-from executorch.exir.tracer import Value
+from executorch.exir import EdgeCompileConfig
 from torch._export import capture_pre_autograd_graph
 from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
+
+from ...portable.utils import export_to_edge, save_pte_program
 
 from .quantizer import (
     QuantFusion,
@@ -30,53 +27,6 @@ from .quantizer import (
 
 FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
 logging.basicConfig(level=logging.INFO, format=FORMAT)
-
-
-_EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(
-    _check_ir_validity=False,
-)
-
-
-def _to_core_aten(
-    model: torch.fx.GraphModule,
-    example_inputs: Tuple[Value, ...],
-) -> ExirExportedProgram:
-    # post autograd export. eventually this will become .to_core_aten
-    if not isinstance(model, torch.fx.GraphModule):
-        raise ValueError(
-            f"Expected passed in model to be an instance of fx.GraphModule, got {type(model)}"
-        )
-    core_aten_exir_ep = exir.capture(
-        model, example_inputs, exir.CaptureConfig(enable_aot=True)
-    )
-    return core_aten_exir_ep
-
-
-def _core_aten_to_edge(
-    core_aten_exir_ep: ExirExportedProgram,
-    edge_compile_config=_EDGE_COMPILE_CONFIG,
-) -> ExirExportedProgram:
-    edge = core_aten_exir_ep.to_edge(edge_compile_config)
-    return edge
-
-
-def export_to_edge(
-    model: torch.fx.GraphModule,
-    example_inputs: Tuple[Value, ...],
-    edge_compile_config=_EDGE_COMPILE_CONFIG,
-) -> ExirExportedProgram:
-    core_aten_exir_ep = _to_core_aten(model, example_inputs)
-    return _core_aten_to_edge(core_aten_exir_ep, edge_compile_config)
-
-
-def save_pte_program(buffer, model_name):
-    filename = f"{model_name}.pte"
-    try:
-        with open(filename, "wb") as file:
-            file.write(buffer)
-            logging.info(f"Saved exported program to {filename}")
-    except Exception as e:
-        logging.error(f"Error while saving to {filename}: {e}")
 
 
 if __name__ == "__main__":
@@ -117,24 +67,27 @@ if __name__ == "__main__":
     QuantFusion(patterns)(converted_model)
 
     # pre-autograd export. eventually this will become torch.export
-    converted_model_exp = export.capture_pre_autograd_graph(
-        converted_model, example_inputs
-    )
+    converted_model_exp = capture_pre_autograd_graph(converted_model, example_inputs)
 
     converted_model_exp = torch.ao.quantization.move_exported_model_to_eval(
         converted_model_exp
     )
 
-    core_aten_exir_ep = _to_core_aten(converted_model_exp, example_inputs)
+    exec_prog = (
+        export_to_edge(
+            converted_model_exp,
+            example_inputs,
+            EdgeCompileConfig(
+                _check_ir_validity=False,
+            ),
+        )
+        .transform(
+            [ReplacePT2QuantWithXtensaQuant(), ReplacePT2DequantWithXtensaDequant()]
+        )
+        .to_executorch()
+    )
 
-    edge_m = _core_aten_to_edge(core_aten_exir_ep, _EDGE_COMPILE_CONFIG)
-
-    # Replace quant/dequant ops with custom xtensa versions
-    edge_m.transform(ReplacePT2QuantWithXtensaQuant())
-    edge_m.transform(ReplacePT2DequantWithXtensaDequant())
-
-    # Get executorch program
-    exec_prog = edge_m.to_executorch(None)
+    logging.info(f"Final exported graph:\n{exec_prog.exported_program().graph}")
 
     # Save the program as XtensaDemoModel.pte
     save_pte_program(exec_prog.buffer, "XtensaDemoModel")


### PR DESCRIPTION
Summary: As titled, `exir.capture()` is removed. It looks like those examples are landed after D49972005.

Differential Revision: D50145301


