### PR TITLE
index.rst: Remove "release status"; add compile/export links

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,28 +19,11 @@ iOS and Android mobile deployments. One of the main
 goals for ExecuTorch is to enable wider customization and deployment
 capabilities of the PyTorch programs.
 
-ExecuTorch heavily relies on such PyTorch technologies as TorchDynamo
-and torch.export. If you are not familiar with these APIs, you might want
-to read about them in the PyTorch documentation before diving into
-the ExecuTorch documentation.
-
-Features described in this documentation are classified by release status:
-
-  *Stable:*  These features will be maintained long-term and there should
-  generally be no major performance limitations or gaps in documentation.
-  We also expect to maintain backwards compatibility (although
-  breaking changes can happen and notice will be given one release ahead
-  of time).
-
-  *Beta:*  These features are tagged as Beta because the API may change based on
-  user feedback, because the performance needs to improve, or because
-  coverage across operators is not yet complete. For Beta features, we are
-  committing to seeing the feature through to the Stable classification.
-  We are not, however, committing to backwards compatibility.
-
-  *Prototype:*  These features are typically not available as part of
-  binary distributions like PyPI or Conda, except sometimes behind run-time
-  flags, and are at an early stage for feedback and testing.
+ExecuTorch heavily relies on such PyTorch technologies as `torch.compile
+<https://pytorch.org/docs/stable/torch.compiler.html>`__ and `torch.export
+<https://pytorch.org/docs/main/export.html>`__. If you are not familiar with
+these APIs, you might want to read about them in the PyTorch documentation
+before diving into the ExecuTorch documentation.
 
 Getting Started
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Summary:
We don't use the terms "stable/beta/prototype" -- at this point everything in ET is "prototype". Remove them to avoid confusion.

Also, add some links to the docs that the text suggests that people read.

Differential Revision: D50150314


