### PR TITLE
Remove the temp for xtensa lint

### DIFF
--- a/examples/xtensa/kernels/kernels.cpp
+++ b/examples/xtensa/kernels/kernels.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "kernels.h"
 #include "NatureDSP_Signal.h"
 #include "NatureDSP_Signal_vector.h"

--- a/examples/xtensa/kernels/kernels.h
+++ b/examples/xtensa/kernels/kernels.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include "inttypes.h"

--- a/examples/xtensa/ops/dequantize_per_tensor.cpp
+++ b/examples/xtensa/ops/dequantize_per_tensor.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include <executorch/runtime/kernel/kernel_includes.h>
 #include "kernels.h"
 

--- a/examples/xtensa/ops/op_add.cpp
+++ b/examples/xtensa/ops/op_add.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>

--- a/examples/xtensa/ops/quantize_per_tensor.cpp
+++ b/examples/xtensa/ops/quantize_per_tensor.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include <executorch/runtime/kernel/kernel_includes.h>
 #include "kernels.h"
 

--- a/examples/xtensa/ops/quantized_linear_out.cpp
+++ b/examples/xtensa/ops/quantized_linear_out.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "kernels.h"
 
 #include <executorch/runtime/kernel/kernel_includes.h>


### PR DESCRIPTION
Summary: Now D50135341 is merged, we can enable back internal linter

Reviewed By: mcremon-meta

Differential Revision: D50157118


