### PR TITLE
Fix graph signature data model to list of specs.

### DIFF
--- a/exir/backend/test/test_backends.py
+++ b/exir/backend/test/test_backends.py
@@ -35,7 +35,10 @@ from executorch.exir.backend.test.qnn_backend_demo import QnnBackend
 from executorch.exir.delegate import executorch_call_delegate
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.graph_module import get_control_flow_submodules
-from executorch.exir.lowered_backend_module import get_lowered_submodules
+from executorch.exir.lowered_backend_module import (
+    _get_new_signature,
+    get_lowered_submodules,
+)
 from executorch.exir.print_program import print_program
 from executorch.exir.schema import (
     BackendDelegate,
@@ -60,6 +63,7 @@ from torch.ao.quantization.quantize_fx import (
     prepare_fx,
 )
 from torch.export import ExportedProgram
+from torch.export.exported_program import OutputKind, TensorArgument
 from torch.testing import FileCheck
 
 
@@ -1229,3 +1233,21 @@ class TestBackends(unittest.TestCase):
 
         gm = exir.capture(ComposedM(), inputs, exir.CaptureConfig()).to_edge()
         gm(*inputs)
+
+    def test_get_new_signature(self):
+        class MyModule(torch.nn.Module):
+            def forward(self, x, y, z):
+                return x + y, y - z, z * x
+
+        ep = torch.export.export(
+            MyModule(), (torch.randn(3, 2), torch.randn(3, 2), torch.randn(3, 2))
+        )
+        sig, *_ = _get_new_signature(ep, ep.graph_module)
+        output_names = set()
+        self.assertEqual(len(sig.output_specs), 3)
+        for s in sig.output_specs:
+            self.assertEqual(s.kind, OutputKind.USER_OUTPUT)
+            self.assertIsInstance(s.arg, TensorArgument)
+            name = s.arg.name
+            self.assertNotIn(name, output_names)
+            output_names.add(name)

--- a/exir/capture/_capture.py
+++ b/exir/capture/_capture.py
@@ -28,6 +28,13 @@ from torch._dynamo.eval_frame import Constraint
 from torch._export import CallSpec, export, ExportedProgram, ExportGraphSignature
 from torch._export.passes import ReplaceViewOpsWithViewCopyOpsPass
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+from torch.export.exported_program import (
+    InputKind,
+    InputSpec,
+    OutputKind,
+    OutputSpec,
+    TensorArgument,
+)
 from torch.func import functionalize
 from torch.fx._compatibility import compatibility
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -72,7 +79,20 @@ def _capture_legacy_do_not_use(f, args) -> ExirExportedProgram:
     ep = HackedUpExportedProgramDONOTUSE(
         graph_module,
         graph_module.graph,
-        ExportGraphSignature([], [], user_inputs, user_outputs, {}, {}, {}, None),
+        ExportGraphSignature(
+            input_specs=[
+                InputSpec(
+                    kind=InputKind.USER_INPUT, arg=TensorArgument(name=i), target=None
+                )
+                for i in user_inputs
+            ],
+            output_specs=[
+                OutputSpec(
+                    kind=OutputKind.USER_OUTPUT, arg=TensorArgument(name=o), target=None
+                )
+                for o in user_outputs
+            ],
+        ),
         CallSpec(in_spec, out_spec),
         {},
         {},
@@ -233,16 +253,25 @@ def capture(  # noqa: C901
     graph_module._apply(torch.Tensor.contiguous)
 
     user_inputs = [
-        node.name for node in graph_module.graph.nodes if node.op == "placeholder"
+        InputSpec(
+            kind=InputKind.USER_INPUT, arg=TensorArgument(name=node.name), target=None
+        )
+        for node in graph_module.graph.nodes
+        if node.op == "placeholder"
     ]
     output_node = list(graph_module.graph.nodes)[-1]
     assert output_node.op == "output"
-    user_outputs = [arg.name for arg in output_node.args[0]]
+    user_outputs = [
+        OutputSpec(
+            kind=OutputKind.USER_OUTPUT, arg=TensorArgument(name=arg.name), target=None
+        )
+        for arg in output_node.args[0]
+    ]
 
     ep = ExportedProgram(
         graph_module,
         graph_module.graph,
-        ExportGraphSignature([], [], user_inputs, user_outputs, {}, {}, {}, None),
+        ExportGraphSignature(user_inputs, user_outputs),
         CallSpec(in_spec, out_spec),
         {},
         {},

--- a/exir/lowered_backend_module.py
+++ b/exir/lowered_backend_module.py
@@ -25,12 +25,16 @@ from executorch.exir.schema import Program
 
 from executorch.exir.tracer import Value
 
-from torch._export.exported_program import (
-    CallSpec,
-    ExportedProgram,
-    ExportGraphSignature,
-)
+from torch._export.exported_program import CallSpec, ExportedProgram
 from torch._subclasses import FakeTensor
+from torch.export.exported_program import (
+    ExportGraphSignature,
+    InputKind,
+    InputSpec,
+    OutputKind,
+    OutputSpec,
+    TensorArgument,
+)
 from torch.fx.passes.utils.fuser_utils import (
     erase_nodes,
     fuse_as_graphmodule,
@@ -209,30 +213,37 @@ class LoweredBackendModule(torch.nn.Module):
         lowered_exported_program.graph.lint()
 
         # Users output will be the get items nodes instead
-        lowered_exported_program.graph_signature.user_outputs = [
-            getitem_node.name for getitem_node in getitem_nodes
+        output_specs = [
+            OutputSpec(
+                kind=OutputKind.USER_OUTPUT,
+                arg=TensorArgument(name=getitem_node.name),
+                target=None,
+            )
+            for getitem_node in getitem_nodes
         ]
         # All data are consumed by the delegates so they should be removed from the state dict.
         inputs_to_parameters = (
             lowered_exported_program.graph_signature.inputs_to_parameters
         )
         inputs_to_buffers = lowered_exported_program.graph_signature.inputs_to_buffers
-        lowered_exported_program.graph_signature.user_inputs = [
-            user_input
+        input_specs = [
+            InputSpec(
+                kind=InputKind.USER_INPUT,
+                arg=TensorArgument(name=node.name),
+                target=None,
+            )
             for user_input in lowered_exported_program.graph_signature.user_inputs
             if user_input not in inputs_to_parameters
             and user_input not in inputs_to_buffers
         ]
-        lowered_exported_program.graph_signature.buffers = {}
-        lowered_exported_program.graph_signature.parameters = {}
-        lowered_exported_program.graph_signature.inputs_to_parameters = {}
-        lowered_exported_program.graph_signature.inputs_to_buffers = {}
 
         # Double check the ExportedProgram data(especially everything except graph) is good
         exported_program = ExportedProgram(
             root=lowered_exported_program.graph_module,
             graph=lowered_exported_program.graph,
-            graph_signature=lowered_exported_program.graph_signature,
+            graph_signature=ExportGraphSignature(
+                input_specs=input_specs, output_specs=output_specs
+            ),
             # TODO: May need to set lowered_exported_program.call_spec = CallSpec(None, None)
             # somewhere as we should pass it a list of tensors to the lowered module and output a
             # list of tensors. Putting call_spec=lowered_exported_program.call_spec is correct here as the
@@ -347,20 +358,16 @@ def arrange_graph_placeholders(
     return gm
 
 
+# TODO Don't regenerate new signature manually.
 def _get_new_signature(
     original_program: ExportedProgram, gm: torch.fx.GraphModule
 ) -> Tuple[ExportGraphSignature, Dict[str, Union[torch.Tensor, torch.nn.Parameter]]]:
     old_signature = original_program.graph_signature
 
+    input_specs = []
+    output_specs = []
     new_signature = ExportGraphSignature(
-        parameters=[],
-        buffers=[],
-        user_inputs=[],
-        user_outputs=[],
-        inputs_to_parameters={},
-        inputs_to_buffers={},
-        buffers_to_mutate={},
-        backward_signature=None,
+        input_specs=input_specs, output_specs=output_specs
     )
     new_state_dict = {}
 
@@ -369,8 +376,13 @@ def _get_new_signature(
             if node.name in old_signature.inputs_to_parameters:
                 parameter_name = old_signature.inputs_to_parameters[node.name]
                 # add param to graph signature
-                new_signature.parameters.append(parameter_name)
-                new_signature.inputs_to_parameters[node.name] = parameter_name
+                input_specs.append(
+                    InputSpec(
+                        kind=InputKind.PARAMETER,
+                        arg=TensorArgument(name=node.name),
+                        target=parameter_name,
+                    )
+                )
 
                 # add param to state_dict
                 new_state_dict[parameter_name] = original_program.state_dict[
@@ -379,17 +391,34 @@ def _get_new_signature(
             elif node.name in old_signature.inputs_to_buffers:
                 buffer_name = old_signature.inputs_to_buffers[node.name]
                 # add buffer to graph signature
-                new_signature.buffers.append(buffer_name)
-                new_signature.inputs_to_buffers[node.name] = buffer_name
+                input_specs.append(
+                    InputSpec(
+                        kind=InputKind.BUFFER,
+                        arg=TensorArgument(name=node.name),
+                        target=buffer_name,
+                    )
+                )
 
                 # add param to new_state_dict
                 new_state_dict[buffer_name] = original_program.state_dict[buffer_name]
             else:
                 # not param or buffer then user input
-                new_signature.user_inputs.append(node.name)
+                input_specs.append(
+                    InputSpec(
+                        kind=InputKind.USER_INPUT,
+                        arg=TensorArgument(name=node.name),
+                        target=None,
+                    )
+                )
         if node.op == "output":
             for output in node.all_input_nodes:
-                new_signature.user_outputs.append(output.name)
+                output_specs.append(
+                    OutputSpec(
+                        kind=OutputKind.USER_OUTPUT,
+                        arg=TensorArgument(name=output.name),
+                        target=None,
+                    )
+                )
 
     return new_signature, new_state_dict
 

--- a/exir/serde/serialize.py
+++ b/exir/serde/serialize.py
@@ -34,6 +34,7 @@ from executorch.exir.serde.schema import (
     CompileSpec,
     LoweredBackendModule as SerdeLoweredBackendModule,
 )
+from torch._export.serde.schema import Argument, GraphSignature
 from torch._export.serde.serialize import SerializeError
 from torch.fx.experimental import symbolic_shapes
 
@@ -346,6 +347,11 @@ class GraphModuleDeserializer(export_serialize.GraphModuleDeserializer):
     def __init__(self, state_dict: Dict[str, torch.Tensor]) -> None:
         super().__init__()
         self.state_dict: Dict[str, Any] = state_dict  # TODO(T157676982)
+
+    def deserialize_signature(
+        self, sig: GraphSignature, inputs: List[Argument], outputs: List[Argument]
+    ) -> ep.ExportGraphSignature:
+        return ep.ExportGraphSignature(input_specs=[], output_specs=[])
 
     def deserialize_operator(self, serialized_target: str) -> str:
         def find_operator(module: _DialectNamespace, serialized_target: str) -> str:

--- a/exir/tests/test_quant_fusion_pass.py
+++ b/exir/tests/test_quant_fusion_pass.py
@@ -294,7 +294,7 @@ class TestQuantFusionPass(unittest.TestCase):
             )
             m = exir.capture(m, example_inputs).to_edge(config=compile_config)
             # QuantFusionPass should be part of to_executorch() config, separating it out so that we can check the graph.
-            m = m.transform(QuantFusionPass())
+            m = m.transform(QuantFusionPass(_fix_node_meta_val=True))
             # check that we are using functional variant of q/dq/cat
             FileCheck().check(
                 "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_channel_default",
@@ -350,7 +350,7 @@ class TestQuantFusionPass(unittest.TestCase):
             )
             m = exir.capture(m, example_inputs).to_edge(config=compile_config)
             # QuantFusionPass should be part of to_executorch() config, separating it out so that we can check the graph.
-            m = m.transform(QuantFusionPass())
+            m = m.transform(QuantFusionPass(_fix_node_meta_val=True))
             m(*example_inputs)
             # check that we are using functional variant of q/dq/cat
             FileCheck().check(

--- a/exir/wrap.py
+++ b/exir/wrap.py
@@ -27,6 +27,6 @@ def update_with_proxy(t: torch.Tensor, proxy: torch.fx.Proxy) -> torch.Tensor:
     unwrapped = unwrap_functional(t)
     assert isinstance(unwrapped, PythonTensor)
     unwrapped.update_proxy(proxy)
-    if is_functionaltensor(t):
+    if is_functionaltensor(t):  # type: ignore
         _assert_wrapped_functional(unwrapped, t)
     return t


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/111017

Previously we design the GraphSignature format as a bunch of inputs and outputs node names. After a discussion in the design meeting we decide to change the format to make signature more self-contained. Now the signature format look like the following:
```
[
InputSpec(
   kind=InputKind.USER_INPUT,
   arg=TensorArgument(name="arg0_1"),
   target=None,
),
...
]
```

Reviewed By: angelayi

Differential Revision: D49876258


