### PR TITLE
Get export APIs ready for PTC (reland) (#835)

### DIFF
--- a/exir/capture/_capture.py
+++ b/exir/capture/_capture.py
@@ -8,7 +8,6 @@ import copy
 import warnings
 from collections import namedtuple
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
-from unittest.mock import patch
 
 import torch
 import torch._export
@@ -125,9 +124,8 @@ def capture(  # noqa: C901
                     "Functionalization is required for enable_aot.",
                 )
 
-            # TODO remove this later
-            with patch("torch._export.DECOMP_TABLE", _default_decomposition_table()):
-                ep = export(f, args, constraints=constraints)
+            ep = export(f, args, constraints=constraints)
+            ep = ep.run_decompositions(_default_decomposition_table())  # pyre-ignore[6]
             ep = ep._transform(ReplaceViewOpsWithViewCopyOpsPass())
             if not config._unlift:
                 return ExirExportedProgram(ep, False)

--- a/exir/program/TARGETS
+++ b/exir/program/TARGETS
@@ -21,6 +21,7 @@ python_library(
         "//executorch/exir:pass_manager",
         "//executorch/exir:print_program",
         "//executorch/exir:schema",
+        "//executorch/exir:tracer",
         "//executorch/exir/_serialize:lib",
         "//executorch/exir/backend:backend_api",
         "//executorch/exir/backend:partitioner",

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -27,6 +27,7 @@ from executorch.exir.passes.remove_assert_async_pass import RemoveAssertAsyncPas
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
 from executorch.exir.print_program import pretty_print, print_program
 from executorch.exir.schema import Program
+from executorch.exir.tracer import _default_decomposition_table
 from executorch.exir.verification.verifier import (
     EXIRATenDialectVerifier,
     EXIREdgeDialectVerifier,
@@ -589,6 +590,11 @@ def to_edge(
 
     edge_programs: Dict[str, ExportedProgram] = {}
     for name, program in aten_programs.items():
+        # Decompose to Core ATen
+        program = program.run_decompositions(
+            _default_decomposition_table()  # pyre-ignore[6]
+        )
+
         if config._check_ir_validity:
             try:
                 EXIRATenDialectVerifier()(program.graph_module)

--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -44,11 +44,11 @@ def get_exported_programs() -> Dict[str, ExportedProgram]:
             torch.ones(1),
             torch.zeros(1),
         ),
-    )
+    ).run_decompositions()
     programs["foo"] = export(
         foo,
         (torch.ones(1),),
-    )
+    ).run_decompositions()
     return programs
 
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/executorch/pull/835

https://docs.google.com/document/d/1QJJEGnj2nHGPODlw38BEG3KLLCOTfdOVjPrNQbz_LM8/edit#bookmark=id.lp80wfshq130 Changes:
* `torch.export` will return a functional ATen graph but not lowered to core aten decompositions (CompositeImplicitAutograd decomps still run)
* `exported_program.run_decompositions(decomposition_table)` will optionally take a decomposition table, and run decompositions on the exported program, returning a new exported program. By default we will run the Core ATen decomposition table.

Calling convention for Executorch stays the same:
```
pre_autograd_graph = capture_pre_autograd_graph(f, args, ...)
aten_graph_no_decomps = torch.export.export(pre_autograd_graph, args, ...)
# Within to_edge we decompose to core aten and then convert to edge
edge_graph = exir.to_edge(aten_graph_no_decomps)
```
bypass-github-export-checks

Reviewed By: ydwu4

Differential Revision: D50172210

fbshipit-source-id: 753819e28f5e350bb0d5fa89d4ac2d8ccbf88f21