### PR TITLE
Add a workflow trigger to release branches (#853)

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - release/*
   schedule:
     - cron: 1 3 * * 3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - main
       - release/*
-      - landchecks/*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - release/*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Summary:
So that release only or cherry pick changes like https://github.com/pytorch/executorch/pull/849 is run when pushing to `release/*` branch.

Commits from an arbitrary branch can be shown on HUD by changing the branch name, for example https://hud.pytorch.org/hud/pytorch/executorch/release%2F0.1