### PR TITLE
Support unlift=false for per_channel qparams

### DIFF
--- a/backends/xnnpack/operators/node_visitor.py
+++ b/backends/xnnpack/operators/node_visitor.py
@@ -458,7 +458,9 @@ class NodeVisitor:
             )
             # Define Weight Node
             weight_node = get_input_node(node, input_type_map.node_weight)
-            weight_quant_params = QuantParams.from_weights(weight_node)
+            weight_quant_params = QuantParams.from_weights(
+                weight_node, self._exported_program
+            )
             self.define_tensor(
                 weight_node,
                 xnn_graph,

--- a/backends/xnnpack/operators/op_conv2d.py
+++ b/backends/xnnpack/operators/op_conv2d.py
@@ -73,7 +73,9 @@ class Conv2d(NodeVisitor):
         # shape for xnnpack convolution is (oc, height, width, inc/groups), to convert
         # to the proper shape, this is essentially a NCHW to NHWC conversion
         weight_node = get_input_node(node, 1)
-        weight_quant_params = QuantParams.from_weights(weight_node)
+        weight_quant_params = QuantParams.from_weights(
+            weight_node, self._exported_program
+        )
         self.define_tensor(
             weight_node,
             xnn_graph,

--- a/backends/xnnpack/test/TARGETS
+++ b/backends/xnnpack/test/TARGETS
@@ -112,6 +112,7 @@ python_unittest(
     srcs = [
         "ops/add.py",
         "ops/conv1d.py",
+        "ops/conv2d.py",
     ],
     deps = [
         "//caffe2:torch",

--- a/backends/xnnpack/test/ops/conv2d.py
+++ b/backends/xnnpack/test/ops/conv2d.py
@@ -1,0 +1,96 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Optional
+
+import torch
+
+from executorch.backends.xnnpack.test.tester import Quantize, Tester
+from torch.ao.quantization.quantizer.xnnpack_quantizer import (
+    get_symmetric_quantization_config,
+)
+from torch.ao.quantization.quantizer.xnnpack_quantizer_utils import QuantizationConfig
+
+
+class Conv2d(torch.nn.Module):
+    def __init__(
+        self,
+        in_channels=2,
+        out_channels=1,
+        kernel_size=(3, 3),
+        stride=(2, 2),
+        padding=(1, 1),
+        dilation=(1, 1),
+        groups=1,
+        bias=True,
+        padding_mode="zeros",
+        batches=1,
+        width=8,
+        height=8,
+    ):
+        super().__init__()
+        self.batches = batches
+        self.width = width
+        self.height = height
+        self.in_channels = in_channels
+
+        self.conv = torch.nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            bias=bias,
+            padding_mode=padding_mode,
+        )
+
+    def forward(self, x):
+        return self.conv(x)
+
+    def get_inputs(self):
+        return (torch.randn(self.batches, self.in_channels, self.height, self.width),)
+
+
+class TestConv2d(unittest.TestCase):
+    def _test(
+        self, m: torch.nn.Module, quant_config: Optional[QuantizationConfig] = None
+    ):
+        tester = Tester(m.eval(), m.get_inputs())
+
+        if quant_config is not None:
+            tester = tester.quantize(Quantize(quantization_config=quant_config))
+            tester.check(["torch.ops.quantized_decomposed"])
+
+        (
+            tester.export()
+            .check_count({"torch.ops.aten.convolution.default": 1})
+            .to_edge()
+            .check_count(
+                {"executorch_exir_dialects_edge__ops_aten_convolution_default": 1}
+            )
+            .partition()
+            .check_not(["executorch_exir_dialects_edge__ops_aten_convolution_default"])
+            .check_count({"torch.ops.executorch_call_delegate": 1})
+            .to_executorch()
+            .serialize()
+            .run_method()
+            .compare_outputs()
+        )
+
+    def test_conv2d(self) -> None:
+        self._test(Conv2d())
+
+    def test_qconv2d(self) -> None:
+        self._test(Conv2d(), quant_config=get_symmetric_quantization_config())
+
+    def test_qconv2d_per_channel(self) -> None:
+        self._test(
+            Conv2d(),
+            quant_config=get_symmetric_quantization_config(is_per_channel=True),
+        )

--- a/backends/xnnpack/test/test_xnnpack_quantized.py
+++ b/backends/xnnpack/test/test_xnnpack_quantized.py
@@ -393,7 +393,12 @@ class TestXNNPACKQuantized(TestXNNPACK):
 
         model = ModelConvReLU().eval()
         example_inputs = (torch.randn(batches, in_channels, height, width) * 11,)
-        self.quantize_and_test_model(model, example_inputs)
+        for per_channel_quant in (True, False):
+            self.quantize_and_test_model(
+                model,
+                example_inputs,
+                per_channel_quant=per_channel_quant,
+            )
 
     def test_xnnpack_qconv_relu_sequence(self):
         model = torch.nn.Sequential(


### PR DESCRIPTION
Summary: This was a TODO, is now needed to support Saliency model with `unlift=False`

Differential Revision: D50197184

