### PR TITLE
Fix time scale conversion in inspector

### DIFF
--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -10,6 +10,6 @@ from executorch.sdk.etrecord._etrecord import (
     parse_etrecord,
 )
 
-from executorch.sdk.inspector.inspector import Inspector
+from executorch.sdk.inspector.inspector import Inspector, TimeScale
 
-__all__ = ["ETRecord", "generate_etrecord", "parse_etrecord", "Inspector"]
+__all__ = ["ETRecord", "generate_etrecord", "parse_etrecord", "Inspector", "TimeScale"]

--- a/sdk/inspector/tests/event_blocks_test.py
+++ b/sdk/inspector/tests/event_blocks_test.py
@@ -128,7 +128,7 @@ class TestEventBlock(unittest.TestCase):
         - Correct number of Events and Raw Data values (iterations)
         """
         etdump: ETDumpFlatCC = TestEventBlock._get_sample_etdump_flatcc()
-        blocks: List[EventBlock] = EventBlock._gen_from_etdump(etdump, 1000)
+        blocks: List[EventBlock] = EventBlock._gen_from_etdump(etdump)
 
         self.assertEqual(len(blocks), 2, f"Expected 2 runs, got {len(blocks)}")
 


### PR DESCRIPTION
Summary:
The current time scale provided to Inspector API can result in buggy time outputs as the assumptions of the time scale might be wrong. This is problematic as users might be looking at the completely wrong time scales in their profiling results. In order to fix this we add a source_time_scale and target_time_scale which makes sure there are no hidden assumptions.

As we have no external users yet using this API it's a low risk change.

Pull Request resolved: https://github.com/pytorch/executorch/pull/860

Test Plan: CI

Reviewed By: Jack-Khuu

Differential Revision: D50208476

Pulled By: tarun292

fbshipit-source-id: 2aa505211ec723ba49a202d2229b4e188a4bbe85