### PR TITLE
Cherry-pick docs-only commits from main onto release/0.1

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -82,8 +82,17 @@
     }
     // PC
     $(".main-menu a:contains('GitHub')").each(overwrite);
+    // Overwrite link to Tutorials and Get Started top navigation. If these sections are moved
+    // this overrides need to be updated.
+    $(".main-menu a:contains('Tutorials')").attr("href", "/index.html#tutorials-and-examples");
+    $(".main-menu a:contains('Get Started')").attr("href", "/getting-started-setup.html");
     // Mobile
     $(".mobile-menu a:contains('Github')").each(overwrite);
+    // Overwrite link to Tutorials and Get Started top navigation. If these sections are moved
+    // this overrides need to be updated.
+    $(".mobile-menu a:contains('Tutorials')").attr("href", "/index.html#tutorials-and-examples");
+    $(".mobile-menu a:contains('Get Started')").attr("href", "/getting-started-setup.html");
+
   });
 </script>
 {% endblock %}

--- a/examples/models/llama2/README.md
+++ b/examples/models/llama2/README.md
@@ -1,7 +1,16 @@
 # Summary
-This example demonstrates how to Export a Llama 2 model in ExecuTorch.
+This example demonstrates how to Export a [Llama 2](https://ai.meta.com/llama/) model in ExecuTorch such that it can be used in a mobile environment.
 For Llama2, please refer to [the llama's github page](https://github.com/facebookresearch/llama) for details.
 Pretrained parameters are not included in this repo. Users are suggested to download them through [the llama's download page](https://ai.meta.com/resources/models-and-libraries/llama-downloads/).
+
+# What is Llama 2?
+Llama is a family of large language models that uses publicly available data for training. These models are based on the transformer architecture, which allows it to process input sequences of arbitrary length and generate output sequences of variable length. One of the key features of Llama models is its ability to generate coherent and contextually relevant text. This is achieved through the use of attention mechanisms, which allow the model to focus on different parts of the input sequence as it generates output. Additionally, Llama models use a technique called “masked language modeling” to pre-train the model on a large corpus of text, which helps it learn to predict missing words in a sentence. 
+
+Llama models have shown to perform well on a variety of natural language processing tasks, including language translation, question answering, and text summarization and are also capable of generating human-like text, making Llama models a useful tool for creative writing and other applications where natural language generation is important. 
+
+Overall, Llama models are powerful and versatile language models that can be used for a wide range of natural language processing tasks. The model’s ability to generate coherent and contextually relevant text makes it particularly useful for applications such as chatbots, virtual assistants, and language translation. 
+
+Please note that the models are subject to the [acceptable use policy](https://github.com/facebookresearch/llama/blob/main/USE_POLICY.md) and the provided [responsible use guide](https://ai.meta.com/static-resource/responsible-use-guide/).
 
 # Notes
 1. This example is to show the feasibility of exporting a Llama2 model in ExecuTorch. There is no guarantee for performance.


### PR DESCRIPTION
Using the new tool from https://github.com/pytorch/executorch/pull/863

```
$ pick_doc_commits.py --release=origin/release/0.1

Commits on 'origin/main' that have already been cherry-picked into
    'origin/release/0.1':
- 3ff6a0b6 Remove etrecord parse_etrecord API from doc (#805)
- b5d56999 Re-word misleading delegate doc (#826)
- 66505007 fix a couple todos (#842)
- bc17c52d move tutorials higher in left pane (#844)
- 9833feb3 Get export APIs ready for PTC (reland) (#835)
- e9c06644 Fix Sphinx build warnings (#840)
- 102ec0ac fix typo "buck2_oss" -> "buck2" in integrate tutorial (#847)
- 67d4c6b0 Fix documentation frontpage. (#848)
- dc0be34e Fix xtensa demo tree structure and format (#852)
- 7baf02cc Add android app screenshot (#850)
- d61c9bc0 Fix unnecessary text in tutorial (#832)
- 6e12632f Add a workflow trigger to release branches (#853)
- 15d80d32 Fix link (#858)
- 18dac767 Link Fixes (#857)
- 26f55620 Fix ExecuTorch SDK tutorial home page card (#856)

Will not pick these commits on 'origin/main' that touch non-documentation
    files:
- ed0e858d add __ET_NODISCARD to backend.is_available (#838)
- ed16f667 Add MPS delegate (#754)
- 3748b008 Update more examples to use long-term export APIs (#810)
- 14715f67 Change default memory planning algorithm to greedy. (#830)
- 52a95b7e Update job to strip from "v" and patches. (#854)
- ca89995d Fix graph signature data model to list of specs. (#836)
- 92f2d7ba Revert D49876258: Fix graph signature data model to list of specs.
- 3f181de8 Fix doc-build job (#861)
- 790239f1 Fix time scale conversion in inspector (#860)

Remaining 'origin/main' commits that touch only documentation files; will be
    cherry-picked into 'origin/release/0.1':
- cb54dcc3 Redirect top nav to ET resources (#855)
- 506ecc58 Update README.md (#851)
```