### PR TITLE
Update runners for better illustrations.

### DIFF
--- a/bundled_program/TARGETS
+++ b/bundled_program/TARGETS
@@ -26,7 +26,6 @@ python_library(
     deps = [
         "fbsource//third-party/pypi/typing-extensions:typing-extensions",
         "//caffe2:torch",
-        "//executorch/extension/pytree:pylib",
     ],
 )
 

--- a/bundled_program/config.py
+++ b/bundled_program/config.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from typing import Any, get_args, List, Union
 
 import torch
-from executorch.extension.pytree import tree_flatten
+from torch.utils._pytree import tree_flatten
 
 from typing_extensions import TypeAlias
 
@@ -126,7 +126,6 @@ class BundledConfig:
         Returns:
             flatten_data: Flatten data with legal type.
         """
-        # pyre-fixme[16]: Module `pytree` has no attribute `tree_flatten`.
         flatten_data, _ = tree_flatten(unflatten_data)
 
         for data in flatten_data:

--- a/examples/portable/executor_runner/executor_runner.cpp
+++ b/examples/portable/executor_runner/executor_runner.cpp
@@ -27,7 +27,6 @@
 #include <executorch/runtime/executor/method.h>
 #include <executorch/runtime/executor/program.h>
 #include <executorch/runtime/platform/log.h>
-#include <executorch/runtime/platform/profiler.h>
 #include <executorch/runtime/platform/runtime.h>
 #include <executorch/util/util.h>
 
@@ -37,10 +36,6 @@ DEFINE_string(
     model_path,
     "model.pte",
     "Model serialized in flatbuffer format.");
-DEFINE_string(
-    prof_result_path,
-    "prof_result.bin",
-    "ExecuTorch profiler output path.");
 
 using namespace torch::executor;
 using torch::executor::util::FileDataLoader;
@@ -113,7 +108,6 @@ int main(int argc, char** argv) {
   // In this example we use a statically allocated memory pool.
   MemoryAllocator method_allocator{
       MemoryAllocator(sizeof(method_allocator_pool), method_allocator_pool)};
-  method_allocator.enable_profiling("method allocator");
 
   // The memory-planned buffers will back the mutable tensors used by the
   // method. The sizes of these buffers were determined ahead of time during the
@@ -178,15 +172,6 @@ int main(int argc, char** argv) {
   std::cout << torch::executor::util::evalue_edge_items(100);
   for (int i = 0; i < outputs.size(); ++i) {
     std::cout << "Output " << i << ": " << outputs[i] << std::endl;
-  }
-
-  // Dump the profiling data to the specified file.
-  torch::executor::prof_result_t prof_result;
-  EXECUTORCH_DUMP_PROFILE_RESULTS(&prof_result);
-  if (prof_result.num_bytes != 0) {
-    FILE* ptr = fopen(FLAGS_prof_result_path.c_str(), "w+");
-    fwrite(prof_result.prof_data, 1, prof_result.num_bytes, ptr);
-    fclose(ptr);
   }
 
   util::FreeInputs(inputs);


### PR DESCRIPTION
Summary:
1. Remove deprecated profiler stuffs.
2. Add print_output flag for sdk_example_runners. Printing output each scalar per line is sometimes pretty verbose, especially some outputs have thousands or even millions of scalars. Make the print as optional in this diff.

Differential Revision: D50246087


