### PR TITLE
use flat_tree from core instead of executorch

### DIFF
--- a/bundled_program/TARGETS
+++ b/bundled_program/TARGETS
@@ -26,7 +26,6 @@ python_library(
     deps = [
         "fbsource//third-party/pypi/typing-extensions:typing-extensions",
         "//caffe2:torch",
-        "//executorch/extension/pytree:pylib",
     ],
 )
 

--- a/bundled_program/config.py
+++ b/bundled_program/config.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from typing import Any, get_args, List, Union
 
 import torch
-from executorch.extension.pytree import tree_flatten
+from torch.utils._pytree import tree_flatten
 
 from typing_extensions import TypeAlias
 
@@ -126,7 +126,6 @@ class BundledConfig:
         Returns:
             flatten_data: Flatten data with legal type.
         """
-        # pyre-fixme[16]: Module `pytree` has no attribute `tree_flatten`.
         flatten_data, _ = tree_flatten(unflatten_data)
 
         for data in flatten_data:


### PR DESCRIPTION
Summary: Update the source of flatten_tree functino from executorch.extension to torch core to support OrderedDict type.

Reviewed By: tarun292

Differential Revision: D50245226


