### PR TITLE
Remove profiling hook from method_meta

### DIFF
--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -182,7 +182,6 @@ Result<Method> Program::load_method(
 }
 
 Result<MethodMeta> Program::method_meta(const char* method_name) const {
-  EXECUTORCH_SCOPE_PROF("Program::method_meta");
   auto plan = get_execution_plan(internal_program_, method_name);
   if (!plan.ok()) {
     return plan.error();


### PR DESCRIPTION
Summary: This hook causes issues in the post-profiling step as we try to consolidate the data across multiple runs. Removing it for now.

Differential Revision: D50250670


