### PR TITLE
Fix per_channel quant axis for depthwise conv2d weights and bias

### DIFF
--- a/backends/xnnpack/test/test_xnnpack_quantized.py
+++ b/backends/xnnpack/test/test_xnnpack_quantized.py
@@ -393,7 +393,12 @@ class TestXNNPACKQuantized(TestXNNPACK):
 
         model = ModelConvReLU().eval()
         example_inputs = (torch.randn(batches, in_channels, height, width) * 11,)
-        self.quantize_and_test_model(model, example_inputs)
+        for per_channel_quant in (True, False):
+            self.quantize_and_test_model(
+                model,
+                example_inputs,
+                per_channel_quant=per_channel_quant,
+            )
 
     def test_xnnpack_qconv_relu_sequence(self):
         model = torch.nn.Sequential(


### PR DESCRIPTION
Summary:
Rationale,
* PyTorch, weights = [out_channels, in_channels/group, kernel_h, kernel_w], per_channel quant axis = 0
* XNNPACK, weights = [in_channels/group, kernel_h, kernel_w, out_channels], per_channel quant axis = 3

This diff fixes the axis value (i.e. weight dim) and convert from 0 --> 3 before passing it on to XNNPACK just like we do weights already

Reviewed By: kimishpatel

Differential Revision: D50195930

