### PR TITLE
[release/0.1] Update clone commands to use the v0.1.0 tag

### DIFF
--- a/build/test_ios.sh
+++ b/build/test_ios.sh
@@ -52,7 +52,7 @@ say() {
 say "Cloning the Code"
 
 pushd . > /dev/null
-git clone https://github.com/pytorch/executorch.git "$OUTPUT"
+git clone --branch v0.1.0 https://github.com/pytorch/executorch.git "$OUTPUT"
 cd "$OUTPUT"
 
 say "Updating the Submodules"

--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -86,7 +86,7 @@ Follow these steps:
 1. Clone the `executorch` repository:
 
    ```bash
-   git clone git@github.com:pytorch/executorch.git
+   git clone --branch v0.1.0 git@github.com:pytorch/executorch.git
    ```
 
 1. Update the submodules:

--- a/docs/source/tutorials_source/export-to-executorch-tutorial.py
+++ b/docs/source/tutorials_source/export-to-executorch-tutorial.py
@@ -45,7 +45,7 @@ Exporting to ExecuTorch Tutorial
 # Install ExecuTorch from source. If cloning is failing on Google Colab, make
 # sure Colab -> Setting -> Github -> Access Private Repo is checked::
 #
-#       !git clone https://{github_username}:{token}@github.com/pytorch/executorch.git
+#       !git clone --branch v0.1.0 https://{github_username}:{token}@github.com/pytorch/executorch.git
 #       !cd executorch && bash ./install_requirements.sh
 
 ######################################################################

--- a/docs/source/tutorials_source/sdk-integration-tutorial.py
+++ b/docs/source/tutorials_source/sdk-integration-tutorial.py
@@ -42,7 +42,7 @@ SDK Integration Tutorial
 # Install ExecuTorch from source. If cloning is failing on Google Colab, make
 # sure Colab -> Setting -> Github -> Access Private Repo is checked::
 #
-#       !git clone https://{github_username}:{token}@github.com/pytorch/executorch.git
+#       !git clone --branch v0.1.0 https://{github_username}:{token}@github.com/pytorch/executorch.git
 #       !cd executorch && bash ./install_requirements.sh
 
 ######################################################################

--- a/docs/website/docs/tutorials/00_setting_up_executorch.md
+++ b/docs/website/docs/tutorials/00_setting_up_executorch.md
@@ -14,8 +14,8 @@ allow you to export your PyTorch model to a flatbuffer file using ExecuTorch.
 
 ```bash
 # Do one of these, depending on how your auth is set up
-git clone https://github.com/pytorch/executorch.git
-git clone git@github.com:pytorch/executorch.git
+git clone --branch v0.1.0 https://github.com/pytorch/executorch.git
+git clone --branch v0.1.0 git@github.com:pytorch/executorch.git
 ```
 
 Ensure that git has fetched and updated the submodules. This is necessary


### PR DESCRIPTION
This commit is on the release/0.1 branch. Any docs here should recommend using the v0.1.0 tag that we will create to point to the final release next week.

Modifying only this branch means that the docs on the `main` branch will default to cloning with the `main` branch, which is the right behavior.

This tag doesn't exist yet, so I tested with a tag that does:
```
$ git clone --branch v0.1.0-rc1 git@github.com:pytorch/executorch.git
$ cd executorch
$ git log
commit 61a79678edc0f7301768c8c186a50dd75675d367 (HEAD, tag: v0.1.0-rc1, origin/orig/release/0.1)
```