### PR TITLE
Remove "TBA" runtime docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ and feedback about ExecuTorch using the tag **#executorch** and
 our [GitHub repository](https://github.com/pytorch/executorch/issues)
 for bug reporting.
 
+The ExecuTorch code and APIs are still changing quickly, and there are not yet
+any guarantees about forward/backward source compatibility. We recommend using
+the latest `v#.#.#` release tag from the
+[Releases](https://github.com/pytorch/executorch/releases) page when
+experimenting with this preview release.
+
 ## Directory Structure [WIP]
 
 ```

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -143,8 +143,6 @@ Topics in this section will help you get started with ExecuTorch.
 
    runtime-overview
    runtime-backend-delegate-implementation-and-linking
-   runtime-custom-memory-allocator
-   runtime-error-handling
    runtime-platform-abstraction-layer
 
 .. toctree::

--- a/docs/source/runtime-custom-memory-allocator.md
+++ b/docs/source/runtime-custom-memory-allocator.md
@@ -1,3 +1,0 @@
-# Custom Memory Allocator
-
-TBA

--- a/docs/source/runtime-error-handling.md
+++ b/docs/source/runtime-error-handling.md
@@ -1,3 +1,0 @@
-# Runtime Error Handling
-
-TBA

--- a/docs/source/runtime-overview.md
+++ b/docs/source/runtime-overview.md
@@ -159,8 +159,6 @@ For more details about the ExecuTorch runtime, please see:
 * [Runtime API Tutorial](running-a-model-cpp-tutorial.md)
 * [Runtime Build and Cross Compilation](runtime-build-and-cross-compilation.md)
 * [Runtime Platform Abstraction Layer](runtime-platform-abstraction-layer.md)
-* [Custom Memory Allocation](runtime-custom-memory-allocator.md)
-* [Runtime Error Handling](runtime-error-handling.md)
 * [Runtime Profiling](sdk-profiling.md)
 * [Backends and Delegates](compiler-delegate-and-partitioner.md)
 * [Backend Delegate Implementation](runtime-backend-delegate-implementation-and-linking.md)


### PR DESCRIPTION
Summary: Didn't have a chance to write these before MVP. Remove and unlink them for now.

Reviewed By: larryliu0820

Differential Revision: D50290060

