### PR TITLE
Add MPS delegate (#754)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,10 @@ option(EXECUTORCH_BUILD_EXAMPLES "Build the ExecuTorch examples.")
 option(EXECUTORCH_BUILD_XTENSA_EXAMPLE
        "Build the example targeted for the Xtensa Hifi4 DSP" OFF)
 
+# Build mps_executor_runner which depends on MPSGraph framework
+option(EXECUTORCH_BUILD_MPS
+       "Build mps_executor_runner which depends on MPS" OFF)
+
 if(NOT BUCK2)
   set(BUCK2 buck2)
 endif()
@@ -334,6 +338,12 @@ option(EXECUTORCH_BUILD_ARM_BAREMETAL
        "Build the Arm Baremetal flow for Cortex-M and Ethos-U" OFF)
 if(EXECUTORCH_BUILD_ARM_BAREMETAL)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backends/arm)
+endif()
+
+option(EXECUTORCH_BUILD_MPS "Build the backends/apple/mps directory" OFF)
+if(EXECUTORCH_BUILD_MPS)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backends/apple/mps)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples/apple/mps)
 endif()
 
 # Add selective build subdirectory

--- a/backends/apple/mps/.clang-format
+++ b/backends/apple/mps/.clang-format
@@ -1,0 +1,9 @@
+---
+Language: ObjC
+ColumnLimit: 120
+AlignAfterOpenBracket: Align
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false

--- a/backends/apple/mps/CMakeLists.txt
+++ b/backends/apple/mps/CMakeLists.txt
@@ -1,0 +1,30 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+cmake_minimum_required(VERSION 3.19)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(NOT PYTHON_EXECUTABLE)
+  set(PYTHON_EXECUTABLE python3)
+endif()
+
+# Source root directory for executorch.
+if(NOT EXECUTORCH_ROOT)
+  set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+endif()
+
+set(_common_compile_options -Wno-deprecated-declarations)
+set(_common_include_directories ${EXECUTORCH_ROOT}/..)
+
+list(TRANSFORM _mps_backend__srcs PREPEND "${EXECUTORCH_ROOT}/")
+add_library(mpsdelegate ${_mps_backend__srcs})
+target_link_libraries(mpsdelegate PRIVATE ${_executor_runner_libs})
+target_include_directories(mpsdelegate
+                           PUBLIC ${_common_include_directories})

--- a/backends/apple/mps/TARGETS
+++ b/backends/apple/mps/TARGETS
@@ -1,0 +1,8 @@
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/backends/apple/mps/install_requirements.sh
+++ b/backends/apple/mps/install_requirements.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+# Install required python dependencies for using the MPS Backend
+pip install --force-reinstall ninja

--- a/backends/apple/mps/mps_preprocess.py
+++ b/backends/apple/mps/mps_preprocess.py
@@ -1,0 +1,784 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+from typing import Any, Dict, final, List, Optional, Union
+
+import torch
+
+from executorch.backends.apple.mps.utils.graph_bindings import graph_bindings
+from executorch.backends.apple.mps.utils.mps_utils import get_mps_data_type
+
+from executorch.exir.backend.backend_details import (
+    BackendDetails,
+    CompileSpec,
+    PreprocessResult,
+)
+
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch._export.exported_program import ExportedProgram
+from torch._subclasses import FakeTensor
+
+
+def get_param_from_node(
+    node: torch.fx.Node, edge_program: ExportedProgram
+) -> Optional[torch.nn.Parameter]:
+    """
+    Returns the parameter associated with the given node in the edge program.
+    Returns None if the node is not a parameter within the edge_program
+    """
+    if node.name in edge_program.graph_signature.inputs_to_parameters:
+        parameter_name = edge_program.graph_signature.inputs_to_parameters[node.name]
+        return edge_program.state_dict[parameter_name]
+    elif node.name in edge_program.graph_signature.inputs_to_buffers:
+        buffer_name = edge_program.graph_signature.inputs_to_buffers[node.name]
+        return edge_program.state_dict[buffer_name]
+    return None
+
+
+def create_mpsgraph_constant_tensor(tensor: torch.Tensor, mpsGraph):
+    if tensor.dim() == 0:
+        return mpsGraph.constant(tensor.item(), get_mps_data_type(tensor.dtype))
+    else:
+        return mpsGraph.constantTensor(tensor, get_mps_data_type(tensor.dtype))
+
+
+@final
+class MPSBackend(BackendDetails):
+    @staticmethod
+    def fetch_attr(node: torch.fx.Node, edge_program: ExportedProgram):
+        attr_itr = edge_program
+
+        attr_itr = getattr(node.graph.owning_module, node.target)
+        return attr_itr
+
+    @staticmethod
+    def eval_shape(node):
+        def eval_expr(symint: Union[int, torch.SymInt, FakeTensor]) -> Optional[int]:
+            if isinstance(symint, int):
+                return symint
+
+            return None
+
+        """
+      Evaluate the shape of a node.
+
+      symint can of of type `SymInt`, `FakeTensor`, a `List[Union[FakeTensor, SymInt]]`, or `None`
+      """
+        if isinstance(node, FakeTensor):
+            return node.shape
+
+        new_shape = []
+        for _, s in enumerate(node):
+            new_shape.append(eval_expr(s))
+        return new_shape
+
+    @staticmethod
+    def preprocess(  # noqa: C901
+        edge_program: ExportedProgram,
+        compile_specs: List[CompileSpec],
+    ) -> bytes:
+        # C++ MPSGraph bindings.
+        mpsGraph = graph_bindings.MPSGraphModule()
+
+        unaryOps = {
+            exir_ops.edge.aten.exp.default: mpsGraph.exp,
+            exir_ops.edge.aten.exp2.default: mpsGraph.exp2,
+            exir_ops.edge.aten.reciprocal.default: mpsGraph.reciprocal,
+            exir_ops.edge.aten.sqrt.default: mpsGraph.sqrt,
+            exir_ops.edge.aten.neg.default: mpsGraph.neg,
+            exir_ops.edge.aten.log.default: mpsGraph.log,
+            exir_ops.edge.aten.log10.default: mpsGraph.log10,
+            exir_ops.edge.aten.log2.default: mpsGraph.log2,
+            exir_ops.edge.aten.erf.default: mpsGraph.erf,
+            exir_ops.edge.aten.floor.default: mpsGraph.floor,
+            exir_ops.edge.aten.ceil.default: mpsGraph.ceil,
+            exir_ops.edge.aten.rsqrt.default: mpsGraph.rsqrt,
+            exir_ops.edge.aten.sigmoid.default: mpsGraph.sigmoid,
+            exir_ops.edge.aten.sin.default: mpsGraph.sin,
+            exir_ops.edge.aten.sign.default: mpsGraph.sign,
+            exir_ops.edge.aten.cos.default: mpsGraph.cos,
+            exir_ops.edge.aten.tan.default: mpsGraph.tan,
+            exir_ops.edge.aten.abs.default: mpsGraph.abs,
+            exir_ops.edge.aten.asin.default: mpsGraph.asin,
+            exir_ops.edge.aten.acos.default: mpsGraph.acos,
+            exir_ops.edge.aten.atan.default: mpsGraph.atan,
+            exir_ops.edge.aten.sinh.default: mpsGraph.sinh,
+            exir_ops.edge.aten.cosh.default: mpsGraph.cosh,
+            exir_ops.edge.aten.tanh.default: mpsGraph.tanh,
+            exir_ops.edge.aten.asinh.default: mpsGraph.asinh,
+            exir_ops.edge.aten.acosh.default: mpsGraph.acosh,
+            exir_ops.edge.aten.atanh.default: mpsGraph.atanh,
+            exir_ops.edge.aten.bitwise_not.default: mpsGraph.bitwise_not,
+            exir_ops.edge.aten.isnan.default: mpsGraph.isnan,
+            exir_ops.edge.aten.isinf.default: mpsGraph.isinf,
+            exir_ops.edge.aten.round.default: mpsGraph.round,
+        }
+
+        binaryOps = {
+            exir_ops.edge.aten.mm.default: mpsGraph.mm,
+            exir_ops.edge.aten.bmm.default: mpsGraph.bmm,
+            exir_ops.edge.aten.mul.Tensor: mpsGraph.mul,
+            exir_ops.edge.aten.div.Tensor: mpsGraph.div,
+            exir_ops.edge.aten.div.Tensor_mode: mpsGraph.div,
+            exir_ops.edge.aten.floor_divide.default: mpsGraph.floor_divide,
+            exir_ops.edge.aten.fmod.Tensor: mpsGraph.fmod,
+            exir_ops.edge.aten.remainder.Tensor: mpsGraph.remainder,
+            exir_ops.edge.aten.bitwise_and.Tensor: mpsGraph.bitwise_and,
+            exir_ops.edge.aten.bitwise_or.Tensor: mpsGraph.bitwise_or,
+            exir_ops.edge.aten.bitwise_xor.Tensor: mpsGraph.bitwise_xor,
+            exir_ops.edge.aten.eq.Tensor: mpsGraph.eq,
+            exir_ops.edge.aten.ne.Tensor: mpsGraph.ne,
+            exir_ops.edge.aten.ge.Tensor: mpsGraph.ge,
+            exir_ops.edge.aten.gt.Tensor: mpsGraph.gt,
+            exir_ops.edge.aten.le.Tensor: mpsGraph.le,
+            exir_ops.edge.aten.lt.Tensor: mpsGraph.lt,
+            exir_ops.edge.aten.pow.Tensor_Tensor: mpsGraph.pow,
+            exir_ops.edge.aten.minimum.default: mpsGraph.minimum,
+        }
+
+        binaryOpsWithScalar = {
+            exir_ops.edge.aten.mul.Scalar: mpsGraph.mulWithScalar,
+            exir_ops.edge.aten.remainder.Scalar: mpsGraph.remainder,
+            exir_ops.edge.aten.eq.Scalar: mpsGraph.eq,
+            exir_ops.edge.aten.ne.Scalar: mpsGraph.ne,
+            exir_ops.edge.aten.ge.Scalar: mpsGraph.ge,
+            exir_ops.edge.aten.gt.Scalar: mpsGraph.gt,
+            exir_ops.edge.aten.le.Scalar: mpsGraph.le,
+            exir_ops.edge.aten.lt.Scalar: mpsGraph.lt,
+            exir_ops.edge.aten.bitwise_and.Scalar: mpsGraph.bitwise_and,
+            exir_ops.edge.aten.bitwise_or.Scalar: mpsGraph.bitwise_or,
+            exir_ops.edge.aten.bitwise_xor.Scalar: mpsGraph.bitwise_xor,
+            exir_ops.edge.aten.pow.Tensor_Scalar: mpsGraph.pow,
+        }
+
+        # `graph_nodes` dictionary is made out of <key> : <MPSGraphTensor*>
+        graphNodes: Dict[str, Any] = {}
+
+        for node in edge_program.graph.nodes:
+            if node.op == "get_attr":
+                attr = MPSBackend.fetch_attr(node, edge_program)
+                graphNodes[node.name] = create_mpsgraph_constant_tensor(
+                    tensor=attr, mpsGraph=mpsGraph
+                )
+
+            # Handle inputs to the graph.
+            elif node.op == "placeholder":
+                # Check if this is a lifted parameter / buffer
+                # If so, bundle the constants in the graph instead of creating placeholders
+                lifted_param_or_buffer = get_param_from_node(node, edge_program)
+                if lifted_param_or_buffer is not None:
+                    graphNodes[node.name] = create_mpsgraph_constant_tensor(
+                        tensor=lifted_param_or_buffer, mpsGraph=mpsGraph
+                    )
+                else:
+                    if node.meta["val"] is None:
+                        continue
+                    shape = MPSBackend.eval_shape(node.meta["val"])
+                    if shape is None:
+                        graphNodes[node.name] = mpsGraph.mpsGraphUnrankedPlaceHolder(
+                            get_mps_data_type(node.meta["val"].dtype)
+                        )
+                    else:
+                        graphNodes[node.name] = mpsGraph.mpsGraphRankedPlaceHolder(
+                            get_mps_data_type(node.meta["val"].dtype), shape
+                        )
+
+            # Handle `call_function` calls.
+            elif node.op == "call_function":
+                if node.target == exir_ops.edge.aten.mm.default:
+                    graphNodes[node.name] = mpsGraph.mm(
+                        graphNodes[node.args[0].name], graphNodes[node.args[1].name]
+                    )
+                elif node.target == exir_ops.edge.aten.bmm.default:
+                    graphNodes[node.name] = mpsGraph.bmm(
+                        graphNodes[node.args[0].name], graphNodes[node.args[1].name]
+                    )
+                elif node.target == exir_ops.edge.aten.add.Tensor:
+                    alpha = 1.0
+                    if node.kwargs and node.kwargs["alpha"] is not None:
+                        alpha = node.kwargs["alpha"]
+                    graphNodes[node.name] = mpsGraph.add(
+                        graphNodes[node.args[0].name],
+                        graphNodes[node.args[1].name],
+                        alpha,
+                    )
+                elif node.target == exir_ops.edge.aten.add.Scalar:
+                    graphNodes[node.name] = mpsGraph.add(
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+                elif node.target == exir_ops.edge.aten.sub.Tensor:
+                    alpha = 1.0
+                    if node.kwargs and node.kwargs["alpha"] is not None:
+                        alpha = node.kwargs["alpha"]
+                    graphNodes[node.name] = mpsGraph.sub(
+                        graphNodes[node.args[0].name],
+                        graphNodes[node.args[1].name],
+                        alpha,
+                    )
+                elif node.target == exir_ops.edge.aten.sub.Scalar:
+                    graphNodes[node.name] = mpsGraph.sub(
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+                elif node.target == exir_ops.edge.aten.mul.Tensor:
+                    graphNodes[node.name] = mpsGraph.mul(
+                        graphNodes[node.args[0].name], graphNodes[node.args[1].name]
+                    )
+                elif node.target == exir_ops.edge.aten.mul.Scalar:
+                    graphNodes[node.name] = mpsGraph.mulWithScalar(
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+                elif node.target in binaryOps:
+                    graphNodes[node.name] = binaryOps[node.target](
+                        graphNodes[node.args[0].name], graphNodes[node.args[1].name]
+                    )
+                elif node.target in binaryOpsWithScalar:
+                    graphNodes[node.name] = binaryOpsWithScalar[node.target](
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+
+                elif node.target == exir_ops.edge.aten.full.default:
+                    if len(node.args) < 2:
+                        raise AssertionError(
+                            "Full op requires at least size & fill_value args"
+                        )
+                    dtype = get_mps_data_type(torch.float32)
+                    if len(node.args) >= 3:
+                        dtype = get_mps_data_type(node.args[2])
+                    if len(node.args) >= 4:
+                        raise AssertionError("Unexpected number of input parameters")
+                    graphNodes[node.name] = mpsGraph.full(
+                        node.args[0], node.args[1], dtype
+                    )
+
+                elif node.target == exir_ops.edge.aten.full_like.default:
+                    if len(node.args) < 2:
+                        raise AssertionError("Too few input parameters")
+                    graphNodes[node.name] = mpsGraph.full_like(
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+
+                elif node.target == exir_ops.edge.aten.convolution.default:
+                    from typing import cast
+
+                    input_node = cast(torch.fx.Node, node.args[0]).meta["val"]
+                    sizes = input_node.size()
+                    dim0 = sizes[0]
+                    dim1 = sizes[1]
+                    groups = int(node.args[8])
+                    group_in_channels = dim1
+                    group_out_channels = int(dim0 / groups)
+
+                    # Convolution is depthwise if groups = input channels and output channel
+                    # is a positive multiple of input channels
+                    is_depthwise_conv = (group_in_channels == 1) and (
+                        group_out_channels % group_in_channels == 0
+                    )
+
+                    if node.args[2] is None:
+                        graphNodes[node.name] = mpsGraph.conv2D(
+                            graphNodes[node.args[0].name],
+                            graphNodes[node.args[1].name],
+                            None,
+                            node.args[3],
+                            node.args[4],
+                            node.args[5],
+                            node.args[6],
+                            node.args[7],
+                            node.args[8],
+                            is_depthwise_conv,
+                        )
+                    else:
+                        graphNodes[node.name] = mpsGraph.conv2D(
+                            graphNodes[node.args[0].name],
+                            graphNodes[node.args[1].name],
+                            graphNodes[node.args[2].name],
+                            node.args[3],
+                            node.args[4],
+                            node.args[5],
+                            node.args[6],
+                            node.args[7],
+                            node.args[8],
+                            is_depthwise_conv,
+                        )
+
+                elif node.target == exir_ops.edge.aten.max_pool2d_with_indices.default:
+                    n_args = len(node.args)
+                    if n_args > 6:
+                        raise AssertionError("Unexpected number of input parameters")
+
+                    padding = [0, 0]
+                    dilation = [1, 1]
+                    ceil_mode = False
+                    if n_args >= 4:
+                        padding = node.args[3]
+                    if n_args >= 5:
+                        dilation = node.args[4]
+                    if n_args == 6:
+                        ceil_mode = node.args[5]
+
+                    graphNodes[node.name] = mpsGraph.maxPool2DWithIndices(
+                        graphNodes[node.args[0].name],
+                        node.args[1],
+                        node.args[2],
+                        padding,
+                        dilation,
+                        ceil_mode,
+                    )
+
+                elif node.target == exir_ops.edge.aten.avg_pool2d.default:
+                    stride = node.args[1]
+                    padding = [0, 0]
+                    ceil_mode = False
+                    count_include_pad = True
+                    divisor_override = None
+
+                    n_args = len(node.args)
+                    if n_args >= 3:
+                        stride = node.args[2]
+                    if n_args >= 4:
+                        padding = node.args[3]
+                    if n_args >= 5:
+                        ceil_mode = node.args[4]
+                    if n_args >= 6:
+                        count_include_pad = node.args[5]
+                    if n_args == 7:
+                        divisor_override = node.args[6]
+                    if n_args > 7:
+                        raise AssertionError("Unexpected number of arguments")
+
+                    graphNodes[node.name] = mpsGraph.avgPool2D(
+                        graphNodes[node.args[0].name],
+                        node.args[1],
+                        stride,
+                        padding,
+                        ceil_mode,
+                        count_include_pad,
+                        divisor_override,
+                    )
+
+                elif (
+                    node.target
+                    == exir_ops.edge.aten._native_batch_norm_legit_no_training.default
+                ):
+                    graphNodes[node.name] = mpsGraph.batchNorm(
+                        graphNodes[node.args[0].name],
+                        graphNodes[node.args[1].name],
+                        graphNodes[node.args[2].name],
+                        graphNodes[node.args[3].name],
+                        graphNodes[node.args[4].name],
+                        node.args[5],
+                        node.args[6],
+                    )
+
+                elif node.target == exir_ops.edge.aten.native_layer_norm.default:
+                    graphNodes[node.name] = mpsGraph.layerNorm(
+                        graphNodes[node.args[0].name],
+                        node.args[1],
+                        graphNodes[node.args[2].name],
+                        graphNodes[node.args[3].name],
+                        node.args[4],
+                    )
+
+                elif node.target == exir_ops.edge.aten.hardtanh.default:
+                    graphNodes[node.name] = mpsGraph.hardTanh(
+                        graphNodes[node.args[0].name], node.args[1], node.args[2]
+                    )
+
+                elif node.target == exir_ops.edge.aten.relu.default:
+                    graphNodes[node.name] = mpsGraph.relu(graphNodes[node.args[0].name])
+
+                elif node.target == exir_ops.edge.aten.leaky_relu.default:
+                    n_args = len(node.args)
+                    if n_args > 2:
+                        raise AssertionError("Unexpected number of input parameters")
+
+                    negative_slope = 0.01
+                    if n_args == 2:
+                        negative_slope = node.args[1]
+                    graphNodes[node.name] = mpsGraph.leaky_relu(
+                        graphNodes[node.args[0].name], negative_slope
+                    )
+
+                elif node.target == exir_ops.edge.aten.gelu.default:
+                    approximate = "none"
+                    if len(node.args) > 1:
+                        approximate = node.args[1]
+                    graphNodes[node.name] = mpsGraph.gelu(
+                        graphNodes[node.args[0].name], approximate
+                    )
+
+                elif node.target == exir_ops.edge.aten.glu.default:
+                    dim = -1
+                    if len(node.args) > 1:
+                        dim = node.args[1]
+                    graphNodes[node.name] = mpsGraph.glu(
+                        graphNodes[node.args[0].name], dim
+                    )
+
+                elif node.target == exir_ops.edge.aten.index_select.default:
+                    dim = node.args[1]
+                    index = graphNodes[node.args[2].name]
+                    graphNodes[node.name] = mpsGraph.index_select(
+                        graphNodes[node.args[0].name], dim, index
+                    )
+
+                elif node.target == exir_ops.edge.aten._softmax.default:
+                    graphNodes[node.name] = mpsGraph.softmax(
+                        graphNodes[node.args[0].name], node.args[1], node.args[2]
+                    )
+
+                elif node.target == exir_ops.edge.aten._log_softmax.default:
+                    graphNodes[node.name] = mpsGraph.log_softmax(
+                        graphNodes[node.args[0].name], node.args[1], node.args[2]
+                    )
+
+                elif node.target == exir_ops.edge.aten._to_copy.default:
+                    graphNodes[node.name] = mpsGraph.identity(
+                        graphNodes[node.args[0].name]
+                    )
+
+                elif node.target == exir_ops.edge.aten.min.dim:
+                    keep_dim = False
+                    if len(node.args) == 3:
+                        keep_dim = node.args[2]
+                    graphNodes[node.name] = mpsGraph.minDim(
+                        graphNodes[node.args[0].name], node.args[1], keep_dim
+                    )
+
+                elif node.target == exir_ops.edge.aten.max.dim:
+                    keep_dim = False
+                    if len(node.args) == 3:
+                        keep_dim = node.args[2]
+                    graphNodes[node.name] = mpsGraph.maxDim(
+                        graphNodes[node.args[0].name], node.args[1], keep_dim
+                    )
+
+                elif node.target == exir_ops.edge.aten.amax.default:
+                    if len(node.args) == 2:
+                        graphNodes[node.name] = mpsGraph.amax(
+                            graphNodes[node.args[0].name], node.args[1], False
+                        )
+                    elif len(node.args) == 3:
+                        graphNodes[node.name] = mpsGraph.amax(
+                            graphNodes[node.args[0].name], node.args[1], node.args[2]
+                        )
+                    else:
+                        raise AssertionError("Unexpected number of input parameters")
+
+                elif node.target == exir_ops.edge.aten.amin.default:
+                    if len(node.args) == 2:
+                        graphNodes[node.name] = mpsGraph.amin(
+                            graphNodes[node.args[0].name], node.args[1], False
+                        )
+                    elif len(node.args) == 3:
+                        graphNodes[node.name] = mpsGraph.amin(
+                            graphNodes[node.args[0].name], node.args[1], node.args[2]
+                        )
+                    else:
+                        raise AssertionError("Unexpected number of input parameters")
+
+                elif node.target == exir_ops.edge.aten.argmax.default:
+                    n_args = len(node.args)
+                    if n_args == 1:
+                        graphNodes[node.name] = mpsGraph.argmax(
+                            graphNodes[node.args[0].name], 0, False, True
+                        )
+                    elif len(node.args) == 2:
+                        graphNodes[node.name] = mpsGraph.argmax(
+                            graphNodes[node.args[0].name], node.args[1], False, False
+                        )
+                    elif len(node.args) == 3:
+                        graphNodes[node.name] = mpsGraph.argmax(
+                            graphNodes[node.args[0].name],
+                            node.args[1],
+                            node.args[2],
+                            False,
+                        )
+                    else:
+                        raise AssertionError("Unexpected number of input parameters")
+
+                elif node.target == exir_ops.edge.aten.argmin.default:
+                    n_args = len(node.args)
+                    if n_args == 1:
+                        graphNodes[node.name] = mpsGraph.argmin(
+                            graphNodes[node.args[0].name], 0, False, True
+                        )
+                    elif len(node.args) == 2:
+                        graphNodes[node.name] = mpsGraph.argmin(
+                            graphNodes[node.args[0].name], node.args[1], False, False
+                        )
+                    elif len(node.args) == 3:
+                        graphNodes[node.name] = mpsGraph.argmin(
+                            graphNodes[node.args[0].name],
+                            node.args[1],
+                            node.args[2],
+                            False,
+                        )
+                    else:
+                        raise AssertionError("Unexpected number of input parameters")
+
+                elif node.target == exir_ops.edge.aten.mean.dim:
+                    if len(node.args) == 2:
+                        graphNodes[node.name] = mpsGraph.mean(
+                            graphNodes[node.args[0].name], node.args[1], False
+                        )
+                    elif len(node.args) == 3:
+                        graphNodes[node.name] = mpsGraph.mean(
+                            graphNodes[node.args[0].name], node.args[1], node.args[2]
+                        )
+                    else:
+                        raise AssertionError("Unexpected number of input parameters")
+
+                elif node.target == exir_ops.edge.aten.pixel_shuffle.default:
+                    torch._assert(
+                        len(node.args) == 2, "Unexpected number of input parameters"
+                    )
+                    graphNodes[node.name] = mpsGraph.pixel_shuffle(
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+
+                elif node.target == exir_ops.edge.aten.split_with_sizes_copy.default:
+                    dim = 0
+                    torch._assert(
+                        len(node.args) >= 2, "Unexpected number of input parameters"
+                    )
+                    split_sizes = node.args[1]
+                    if len(node.args) >= 2:
+                        dim = node.args[2]
+                    graphNodes[node.name] = mpsGraph.split_size(
+                        graphNodes[node.args[0].name], split_sizes, dim
+                    )
+
+                elif node.target == exir_ops.edge.aten.split_copy.Tensor:
+                    dim = 0
+                    torch._assert(
+                        len(node.args) >= 2, "Unexpected number of input parameters"
+                    )
+                    split_sizes = node.args[1]
+                    if len(node.args) >= 3:
+                        dim = node.args[2]
+                    graphNodes[node.name] = mpsGraph.split(
+                        graphNodes[node.args[0].name], split_sizes, dim
+                    )
+
+                elif node.target == exir_ops.edge.aten.unbind_copy.int:
+                    dim = 0
+                    if len(node.args) >= 2:
+                        dim = node.args[1]
+                    graphNodes[node.name] = mpsGraph.unbind(
+                        graphNodes[node.args[0].name], dim
+                    )
+
+                elif node.target == exir_ops.edge.aten.stack.default:
+                    stackTensors = []
+                    dim = 0
+                    if len(node.args) > 1:
+                        dim = node.args[1]
+                    for inputTensor in node.args[0]:
+                        stackTensors.append(graphNodes[inputTensor.name])
+                    graphNodes[node.name] = mpsGraph.stack(dim, *stackTensors)
+
+                elif node.target == exir_ops.edge.aten.cat.default:
+                    catTensors = []
+                    dim = 0
+                    if len(node.args) > 1:
+                        dim = node.args[1]
+                    for inputTensor in node.args[0]:
+                        catTensors.append(graphNodes[inputTensor.name])
+                    graphNodes[node.name] = mpsGraph.cat(dim, *catTensors)
+
+                elif node.target == exir_ops.edge.aten.slice_copy.Tensor:
+                    dim = 0
+                    step = 1
+                    start = None
+                    end = None
+                    if len(node.args) >= 2:
+                        dim = node.args[1]
+                    if len(node.args) >= 4:
+                        end = node.args[3]
+                        start = node.args[2]
+                    if len(node.args) >= 5:
+                        step = node.args[4]
+                    graphNodes[node.name] = mpsGraph.slice(
+                        graphNodes[node.args[0].name], dim, start, end, step
+                    )
+
+                elif node.target == exir_ops.edge.aten.expand_copy.default:
+                    graphNodes[node.name] = mpsGraph.expand(
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+
+                elif node.target == exir_ops.edge.aten.view_copy.default:
+                    graphNodes[node.name] = mpsGraph.view(
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+
+                elif node.target == exir_ops.edge.aten.clone.default:
+                    # Per exir documentation the executorch memory format and layout is still WIP
+                    # So we'll assume the memory layout option of clone is to be ignored
+                    # TODO: adjust once the memory format and layout have been finalized
+                    graphNodes[node.name] = mpsGraph.identity(
+                        graphNodes[node.args[0].name]
+                    )
+
+                elif node.target == exir_ops.edge.aten.select_copy.int:
+                    idx = torch.sym_int(node.args[2])
+                    graphNodes[node.name] = mpsGraph.select(
+                        graphNodes[node.args[0].name], node.args[1], idx
+                    )
+
+                elif node.target == exir_ops.edge.aten.permute_copy.default:
+                    graphNodes[node.name] = mpsGraph.permute(
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+
+                elif node.target == exir_ops.edge.aten.squeeze_copy.default:
+                    graphNodes[node.name] = mpsGraph.squeeze(
+                        graphNodes[node.args[0].name]
+                    )
+
+                elif node.target == exir_ops.edge.aten.squeeze_copy.dim:
+                    graphNodes[node.name] = mpsGraph.squeeze(
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+
+                elif node.target == exir_ops.edge.aten.squeeze_copy.dims:
+                    graphNodes[node.name] = mpsGraph.squeeze(
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+
+                elif node.target == exir_ops.edge.aten.unsqueeze_copy.default:
+                    graphNodes[node.name] = mpsGraph.unsqueeze(
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+
+                elif node.target == exir_ops.edge.aten.constant_pad_nd.default:
+                    padding = node.args[1]
+                    c_value = node.args[2]
+                    graphNodes[node.name] = mpsGraph.constant_pad_nd(
+                        graphNodes[node.args[0].name], padding, c_value
+                    )
+
+                elif node.target == exir_ops.edge.aten.addmm.default:
+                    beta = 1.0
+                    alpha = 1.0
+                    if len(node.args) == 4:
+                        beta = node.args[3]
+                    if len(node.args) == 5:
+                        alpha = node.args[4]
+                    graphNodes[node.name] = mpsGraph.addmm(
+                        graphNodes[node.args[0].name],
+                        graphNodes[node.args[1].name],
+                        graphNodes[node.args[2].name],
+                        beta,
+                        alpha,
+                    )
+                elif node.target == exir_ops.edge.aten.clamp.default:
+                    min_value = 0.0
+                    use_min = False
+                    if len(node.args) >= 2 and node.args[1] is not None:
+                        min_value = node.args[1]
+                        use_min = True
+
+                    max_value = 1.0
+                    use_max = False
+                    if len(node.args) >= 3 and node.args[2] is not None:
+                        max_value = node.args[2]
+                        use_max = True
+                    graphNodes[node.name] = mpsGraph.clamp(
+                        graphNodes[node.args[0].name],
+                        min_value,
+                        max_value,
+                        use_min,
+                        use_max,
+                    )
+
+                elif node.target == exir_ops.edge.aten.cumsum.default:
+                    if len(node.args) != 2:
+                        raise AssertionError("Unexpected number of input parameters")
+                    graphNodes[node.name] = mpsGraph.cumsum(
+                        graphNodes[node.args[0].name], node.args[1]
+                    )
+
+                elif node.target in unaryOps:
+                    graphNodes[node.name] = unaryOps[node.target](
+                        graphNodes[node.args[0].name]
+                    )
+
+                elif node.target == exir_ops.edge.aten.arange.start_step:
+                    step = 1
+                    if len(node.args) > 2 and node.args[2] is not None:
+                        step = node.args[2]
+                    dtype = get_mps_data_type(node.meta["val"].dtype)
+                    shape = node.meta["val"].shape[0]
+                    graphNodes[node.name] = mpsGraph.arange(
+                        node.args[0], node.args[1], step, dtype, shape
+                    )
+
+                elif node.target == exir_ops.edge.aten.where.self:
+                    graphNodes[node.name] = mpsGraph.where(
+                        graphNodes[node.args[0].name],
+                        graphNodes[node.args[1].name],
+                        graphNodes[node.args[2].name],
+                    )
+                elif node.target == exir_ops.edge.aten.scalar_tensor.default:
+                    graphNodes[node.name] = mpsGraph.scalar_out(
+                        node.args[0], get_mps_data_type(node.meta["val"].dtype)
+                    )
+
+                elif node.target == exir_ops.edge.aten.empty.memory_format:
+                    dtype = get_mps_data_type(torch.float32)
+                    if len(node.args) >= 2:
+                        dtype = get_mps_data_type(node.args[1])
+                    graphNodes[node.name] = mpsGraph.empty(node.args[0], dtype)
+                elif node.target == exir_ops.edge.aten.embedding.default:
+                    if len(node.args) == 2:
+                        graphNodes[node.name] = mpsGraph.index_select(
+                            graphNodes[node.args[0].name],
+                            0,
+                            graphNodes[node.args[1].name],
+                        )
+                    elif len(node.args) > 2 and node.args[2] is not None:
+                        r1 = mpsGraph.unsqueeze(
+                            mpsGraph.ne(graphNodes[node.args[1].name], node.args[2]), -1
+                        )
+                        r2 = mpsGraph.index_select(
+                            graphNodes[node.args[0].name],
+                            0,
+                            graphNodes[node.args[1].name],
+                        )
+                        graphNodes[node.name] = mpsGraph.where(
+                            r1, r2, mpsGraph.full_like(r2, 0)
+                        )
+                # Cant check for target with getitem
+                # Arg[0] target node, arg[1] target index
+                elif "getitem" in node.name:
+                    graphNodes[node.name] = graphNodes[node.args[0].name][node.args[1]]
+                else:
+                    raise AssertionError(f"Unknown op: {node.target}")
+
+            # Handle `call_method` calls.
+            elif node.op == "call_method":
+                raise AssertionError("Not yet implemented")
+
+            # Handle `call_method` calls.
+            elif node.op == "call_module":
+                raise AssertionError("Not yet implemented")
+
+            # Handle output nodes in the graph.
+            elif node.op == "output":
+                output_nodes = []
+                for i in range(len(node.args)):
+                    for j in range(len(node.args[i])):
+                        output_nodes.append(graphNodes[node.args[i][j].name])
+                mpsGraph.set_outputs(*output_nodes)
+            else:
+                torch._assert(
+                    False,
+                    f"Unsupported operator: {node.op}, {node.name}, {node.target}",
+                )
+
+        mpsGraphExecutableBytes = mpsGraph.serialize()
+        return PreprocessResult(processed_bytes=bytes(mpsGraphExecutableBytes))

--- a/backends/apple/mps/operations/ActivationOps.mm
+++ b/backends/apple/mps/operations/ActivationOps.mm
@@ -1,0 +1,165 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+
+namespace mps {
+using namespace torch;
+
+PyMPSGraphTensor*
+MPSGraphModule::relu(MPSGraphTensor* inputTensor) {
+  return [mpsGraph reLUWithTensor:inputTensor
+                             name:@"relu"];
+
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::leaky_relu(MPSGraphTensor* inputTensor, float negative_slope) {
+  return [mpsGraph leakyReLUWithTensor:inputTensor
+                                 alpha:negative_slope
+                                  name:@"leaky_relu"];
+
+}
+
+MPSGraphTensor* tanh(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
+  auto dataType = [inputTensor dataType];
+  constexpr float kBeta =  M_SQRT2 * M_2_SQRTPI * 0.5;
+  constexpr float kKappa = 0.044715f;
+  MPSGraphTensor *betaf = [mpsGraph constantWithScalar: kBeta
+                                                 shape: @[@1]
+                                              dataType: dataType];
+  MPSGraphTensor *kappaf = [mpsGraph constantWithScalar: kKappa
+                                                  shape: @[@1]
+                                               dataType: dataType];
+  MPSGraphTensor *onef = [mpsGraph constantWithScalar: 1.0f
+                                                shape: @[@1]
+                                            dataType: dataType];
+  MPSGraphTensor *halff = [mpsGraph constantWithScalar: 0.5f
+                                                  shape: @[@1]
+                                              dataType: dataType];
+  MPSGraphTensor *erfTensor = [mpsGraph multiplicationWithPrimaryTensor: inputTensor
+                                                        secondaryTensor: inputTensor
+                                                                  name : nil];
+  erfTensor = [mpsGraph multiplicationWithPrimaryTensor: erfTensor
+                                        secondaryTensor: inputTensor
+                                                  name : nil];
+  erfTensor = [mpsGraph multiplicationWithPrimaryTensor: erfTensor
+                                        secondaryTensor: kappaf
+                                                  name : nil];
+  erfTensor = [mpsGraph additionWithPrimaryTensor: erfTensor
+                                  secondaryTensor: inputTensor
+                                            name : nil];
+  erfTensor = [mpsGraph multiplicationWithPrimaryTensor: erfTensor
+                                        secondaryTensor: betaf
+                                                  name : nil];
+  erfTensor = [mpsGraph tanhWithTensor: erfTensor
+                                 name : nil];
+  erfTensor = [mpsGraph additionWithPrimaryTensor: erfTensor
+                                  secondaryTensor: onef
+                                            name : nil];
+  erfTensor = [mpsGraph multiplicationWithPrimaryTensor: erfTensor
+                                        secondaryTensor: halff
+                                                  name : nil];
+  return erfTensor;
+}
+
+MPSGraphTensor* normcdf(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
+  auto dataType = [inputTensor dataType];
+  const float SQRT1_2 = 0.707106781186547524400844362104849039f;
+  MPSGraphTensor *sqrt1_2 = [mpsGraph constantWithScalar: SQRT1_2
+                                                      shape: @[@1]
+                                                   dataType: dataType];
+  MPSGraphTensor *onef = [mpsGraph constantWithScalar: 1.0f
+                                                shape: @[@1]
+                                            dataType: dataType];
+  MPSGraphTensor *halff = [mpsGraph constantWithScalar: 0.5f
+                                                  shape: @[@1]
+                                              dataType: dataType];
+
+  MPSGraphTensor *erfTensor = [mpsGraph multiplicationWithPrimaryTensor: inputTensor
+                                                        secondaryTensor: sqrt1_2
+                                                                name : nil];
+  erfTensor = [mpsGraph erfWithTensor: erfTensor name : nil];
+  erfTensor = [mpsGraph additionWithPrimaryTensor: erfTensor
+                                    secondaryTensor: onef
+                                                name : nil];
+  erfTensor = [mpsGraph multiplicationWithPrimaryTensor: erfTensor
+                                      secondaryTensor: halff
+                                                  name : nil];
+
+  return  erfTensor;
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::gelu(MPSGraphTensor* inputTensor,
+                      const std::string &approximation=nil) {
+  MPSGraphTensor* result;
+  if (approximation == "tanh") {
+    result = tanh(mpsGraph, inputTensor);
+  } else {
+    result = normcdf(mpsGraph, inputTensor);
+  }
+  return [mpsGraph multiplicationWithPrimaryTensor:result
+                                    secondaryTensor:inputTensor
+                                              name:nil];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::softmax(MPSGraphTensor* inputTensor, const int dim, const bool half_to_float) {
+  TORCH_CHECK(!half_to_float, "softmax with half to float conversion is not supported on MPS");
+  return [mpsGraph softMaxWithTensor:inputTensor
+                                axis:dim
+                                name:@"softmax"];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::log_softmax(MPSGraphTensor* inputTensor, const int dim, const bool half_to_float) {
+  TORCH_CHECK(!half_to_float, "softmax with half to float conversion is not supported on MPS");
+  MPSGraphTensor* softmaxTensor = [mpsGraph softMaxWithTensor:inputTensor
+                                                   axis:dim
+                                                   name:@"softmax"];
+  return [mpsGraph logarithmWithTensor:softmaxTensor
+                                name:@"log_softmax"];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::hardTanh(MPSGraphTensor* inputTensor,
+                         float min_value,
+                         float max_value) {
+  MPSDataType inputType = [inputTensor dataType];
+  MPSShape* inputShape = [inputTensor shape];
+  MPSGraphTensor* minTensor = [mpsGraph constantWithScalar:min_value shape:inputShape dataType:inputType];
+  MPSGraphTensor* maxTensor = [mpsGraph constantWithScalar:max_value shape:inputShape dataType:inputType];
+  MPSGraphTensor* lessThanMinPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
+                                                                   secondaryTensor:minTensor
+                                                                              name:@"LessThanPredicate"];
+  MPSGraphTensor* greaterThanMaxPredicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
+                                                                      secondaryTensor:maxTensor
+                                                                                 name:@"MoreThanPredicate"];
+
+  MPSGraphTensor* temp = [mpsGraph selectWithPredicateTensor:lessThanMinPredicateTensor
+                                              truePredicateTensor:minTensor
+                                              falsePredicateTensor:inputTensor
+                                              name:@"minOutput"];
+  MPSGraphTensor* result = [mpsGraph selectWithPredicateTensor:greaterThanMaxPredicateTensor
+                                              truePredicateTensor:maxTensor
+                                              falsePredicateTensor:temp
+                                              name:@"hardTanh"];
+  return result;
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::glu(MPSGraphTensor* inputTensor, int64_t dim) {
+  auto wrap_dim = maybe_wrap_dim(dim, inputTensor.shape.count);
+  auto splitTensors = [mpsGraph splitTensor:inputTensor
+                                  numSplits:2
+                                       axis:wrap_dim
+                                       name:nil];
+  return [mpsGraph multiplicationWithPrimaryTensor:splitTensors[0]
+                                   secondaryTensor:[mpsGraph sigmoidWithTensor:splitTensors[1] name:nil]
+                                              name:nil];
+}
+
+}//namespace mps

--- a/backends/apple/mps/operations/BinaryOps.h
+++ b/backends/apple/mps/operations/BinaryOps.h
@@ -1,0 +1,70 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+// clang-format off
+#pragma once
+
+#define REGISTER_PYBIND11_MPS_BINARY_OP(py11_export_name, graph_op)                                    \
+.def(py11_export_name, [](MPSGraphModule& self, PyMPSGraphTensor* input, PyMPSGraphTensor* other) {    \
+return self.binaryOpTensor(                                                                            \
+  static_cast<MPSGraphTensor*>(input), static_cast<MPSGraphTensor*>(other), py11_export_name,          \
+  [&](MPSGraphTensor* primaryCastTensor, MPSGraphTensor* secondaryCastTensor) -> MPSGraphTensor* {     \
+    return [self.getMPSGraph() graph_op##WithPrimaryTensor:primaryCastTensor                           \
+                                           secondaryTensor:secondaryCastTensor                         \
+                                                      name:nil];                                       \
+  });                                                                                                  \
+})                                                                                                     \
+.def(py11_export_name, [](MPSGraphModule& self, PyMPSGraphTensor* input, float sc) {                   \
+return self.binaryOpWithScalar(                                                                        \
+  static_cast<MPSGraphTensor*>(input), sc, py11_export_name,                                           \
+  [&](MPSGraphTensor* primaryCastTensor, MPSGraphTensor* secondaryCastTensor) -> MPSGraphTensor* {     \
+    MPSDataType mpsInputDataType = [primaryCastTensor dataType];                                       \
+    return [self.getMPSGraph() graph_op##WithPrimaryTensor:primaryCastTensor                           \
+                                           secondaryTensor:secondaryCastTensor                         \
+                                                      name:nil];                                       \
+  });                                                                                                  \
+})                                                                                                     \
+.def(py11_export_name, [](MPSGraphModule& self, PyMPSGraphTensor* input, int sc) {                     \
+return self.binaryOpWithScalar(                                                                        \
+  static_cast<MPSGraphTensor*>(input), sc, py11_export_name,                                           \
+  [&](MPSGraphTensor* primaryCastTensor, MPSGraphTensor* secondaryCastTensor) -> MPSGraphTensor* {     \
+    MPSDataType mpsInputDataType = [primaryCastTensor dataType];                                       \
+    return [self.getMPSGraph() graph_op##WithPrimaryTensor:primaryCastTensor                           \
+                                           secondaryTensor:secondaryCastTensor                         \
+                                                      name:nil];                                       \
+  });                                                                                                  \
+})                                                                                                     \
+
+#define REGISTER_PYBIND11_MPS_BITWISE_BINARY_OP(py11_export_name, graph_op)                            \
+.def(py11_export_name, [](MPSGraphModule& self, PyMPSGraphTensor* input, PyMPSGraphTensor* other) {    \
+return self.binaryOpTensor(                                                                            \
+  static_cast<MPSGraphTensor*>(input), static_cast<MPSGraphTensor*>(other), py11_export_name,          \
+  [&](MPSGraphTensor* primaryCastTensor, MPSGraphTensor* secondaryCastTensor) -> MPSGraphTensor* {     \
+    MPSDataType mpsInputDataType = [primaryCastTensor dataType];                                       \
+    if (getScalarType(mpsInputDataType) == ScalarType::Bool) {                                         \
+      return [self.getMPSGraph() logical##graph_op##WithPrimaryTensor:primaryCastTensor                \
+                                           secondaryTensor:secondaryCastTensor                         \
+                                                      name:nil];                                       \
+    }                                                                                                  \
+    return [self.getMPSGraph() bitwise##graph_op##WithPrimaryTensor:primaryCastTensor                  \
+                                           secondaryTensor:secondaryCastTensor                         \
+                                                      name:nil];                                       \
+  });                                                                                                  \
+})                                                                                                     \
+.def(py11_export_name, [](MPSGraphModule& self, PyMPSGraphTensor* input, int sc) {                     \
+return self.binaryOpWithScalar(                                                                        \
+  static_cast<MPSGraphTensor*>(input), sc, py11_export_name,                                           \
+  [&](MPSGraphTensor* primaryCastTensor, MPSGraphTensor* secondaryCastTensor) -> MPSGraphTensor* {     \
+    MPSDataType mpsInputDataType = [primaryCastTensor dataType];                                       \
+    if (getScalarType(mpsInputDataType) == ScalarType::Bool) {                                         \
+      return [self.getMPSGraph() logical##graph_op##WithPrimaryTensor:primaryCastTensor                \
+                                           secondaryTensor:secondaryCastTensor                         \
+                                                      name:nil];                                       \
+    }                                                                                                  \
+    return [self.getMPSGraph() bitwise##graph_op##WithPrimaryTensor:primaryCastTensor                  \
+                                           secondaryTensor:secondaryCastTensor                         \
+                                                      name:nil];                                       \
+  });                                                                                                  \
+})                                                                                                     \
+// clang-format on

--- a/backends/apple/mps/operations/BinaryOps.mm
+++ b/backends/apple/mps/operations/BinaryOps.mm
@@ -1,0 +1,222 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+
+#include "BinaryOps.h"
+
+namespace mps {
+using namespace torch;
+
+PyMPSGraphTensor*
+MPSGraphModule::binaryOpTensor(
+  MPSGraphTensor* primaryTensor,
+  MPSGraphTensor* secondaryTensor,
+  const std::string& op_name,
+  std::function<MPSGraphTensor*(MPSGraphTensor*, MPSGraphTensor*)> binaryOpFunction) {
+  MPSDataType mpsInputDataType = [primaryTensor dataType];
+  MPSDataType mpsOtherDataType = [secondaryTensor dataType];
+
+  ScalarType inputDataType = getScalarType(mpsInputDataType);
+  ScalarType otherDataType = getScalarType(mpsOtherDataType);
+
+  MPSGraphTensor* primaryCastTensor = primaryTensor;
+  MPSGraphTensor* secondaryCastTensor = secondaryTensor;
+  ScalarType common_dtype = c10::promoteTypes(inputDataType, otherDataType);
+  if (inputDataType != common_dtype) {
+    primaryCastTensor = castMPSTensor(mpsGraph, primaryTensor, common_dtype);
+  }
+  if (otherDataType != common_dtype) {
+    secondaryCastTensor = castMPSTensor(mpsGraph, secondaryTensor, common_dtype);
+  }
+
+  return binaryOpFunction(primaryCastTensor, secondaryCastTensor);
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::additionWithTensor(MPSGraphTensor* primaryTensor,
+                                   MPSGraphTensor* secondaryTensor,
+                                   Scalar alpha) {
+  MPSGraphTensor* primaryCastTensor = primaryTensor;
+  MPSGraphTensor* secondaryCastTensor = secondaryTensor;
+  auto _alpha = alpha.isFloatingPoint() ? alpha.to<float>() : alpha.to<int>();
+
+  ScalarType primaryDataType = getScalarType(primaryCastTensor.dataType);
+  ScalarType secondaryDataType = getScalarType(secondaryCastTensor.dataType);
+
+  MPSDataType commonDataType = getMPSDataType(c10::promoteTypes(primaryDataType, secondaryDataType));
+
+  if(primaryCastTensor.dataType != commonDataType) {
+    primaryCastTensor = [mpsGraph castTensor:primaryCastTensor
+                                      toType:commonDataType
+                                        name:nil];
+  }
+
+  if(secondaryCastTensor.dataType != commonDataType) {
+    secondaryCastTensor = [mpsGraph castTensor:secondaryCastTensor
+                                      toType:commonDataType
+                                        name:nil];
+  }
+
+  if(_alpha!=1.0) {
+    MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:_alpha
+                                                         shape:@[@1]
+                                                      dataType:primaryCastTensor.dataType];
+    secondaryCastTensor = [mpsGraph multiplicationWithPrimaryTensor:secondaryCastTensor
+                                             secondaryTensor:alphaTensor
+                                                        name:nil];
+  }
+  MPSGraphTensor* resultTensor = [mpsGraph additionWithPrimaryTensor:primaryCastTensor
+                                                     secondaryTensor:secondaryCastTensor
+                                                                name:nil];
+  return resultTensor;
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::subtractionWithTensor(MPSGraphTensor* primaryTensor,
+                                   MPSGraphTensor* secondaryTensor,
+                                   Scalar alpha) {
+  MPSGraphTensor* primaryCastTensor = primaryTensor;
+  MPSGraphTensor* secondaryCastTensor = secondaryTensor;
+  auto _alpha = alpha.isFloatingPoint() ? alpha.to<float>() : alpha.to<int>();
+
+  ScalarType primaryDataType = getScalarType(primaryCastTensor.dataType);
+  ScalarType secondaryDataType = getScalarType(secondaryCastTensor.dataType);
+
+  MPSDataType commonDataType = getMPSDataType(c10::promoteTypes(primaryDataType, secondaryDataType));
+
+  if(primaryCastTensor.dataType != commonDataType) {
+    primaryCastTensor = [mpsGraph castTensor:primaryCastTensor
+                                      toType:commonDataType
+                                        name:nil];
+  }
+
+  if(secondaryCastTensor.dataType != commonDataType) {
+    secondaryCastTensor = [mpsGraph castTensor:secondaryCastTensor
+                                      toType:commonDataType
+                                        name:nil];
+  }
+
+  if(_alpha!=1.0) {
+    MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:_alpha
+                                                         shape:@[@1]
+                                                      dataType:primaryCastTensor.dataType];
+    secondaryCastTensor = [mpsGraph multiplicationWithPrimaryTensor:secondaryCastTensor
+                                             secondaryTensor:alphaTensor
+                                                        name:nil];
+  }
+  MPSGraphTensor* resultTensor = [mpsGraph subtractionWithPrimaryTensor:primaryCastTensor
+                                                     secondaryTensor:secondaryCastTensor
+                                                                name:nil];
+  return resultTensor;
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::multiplicationWithScalar(MPSGraphTensor* inputTensor, Scalar scalar) {
+  auto value = scalar.isFloatingPoint() ? scalar.to<float>() : scalar.to<int>();
+  MPSGraphTensor* constantTensor = [mpsGraph constantWithScalar:value
+                                                          shape:@[@1]
+                                                       dataType:inputTensor.dataType];
+  MPSGraphTensor* resultTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
+                                                     secondaryTensor:constantTensor
+                                                                name:nil];
+  return resultTensor;
+}
+
+MPSGraphTensor*
+MPSGraphModule::trunc_tensor(MPSGraphTensor* inputTensor) {
+  // Rounding is a no-op for integral types, and also a reasonable workaround
+  // For MPSGraph bug on Apple Silicon, that throws `Function floorOp_i64 was not found in the library`
+  // See https://github.com/pytorch/pytorch/issues/84995
+  bool isFloatInput = ([inputTensor dataType] & MPSDataTypeFloatBit) != 0;
+  if (!isFloatInput) {
+    return inputTensor;
+  }
+
+  return [mpsGraph truncateWithTensor:inputTensor
+                                  name:nil];
+};
+
+PyMPSGraphTensor*
+MPSGraphModule::div_mode_template(
+  MPSGraphTensor* primaryTensor,
+  MPSGraphTensor* secondaryTensor,
+  c10::optional<c10::string_view> rounding_mode,
+  const string& op_name) {
+  MPSDataType mpsInputDataType = [primaryTensor dataType];
+  MPSDataType mpsOtherDataType = [secondaryTensor dataType];
+
+  ScalarType inputDataType = getScalarType(mpsInputDataType);
+  ScalarType otherDataType = getScalarType(mpsOtherDataType);
+
+  if(rounding_mode.has_value() && *rounding_mode == "trunc"){
+    TORCH_CHECK(inputDataType != ScalarType::Half,
+                "MPS: does not support trunc_divide op with float16 input");
+  }
+
+  auto divOpFunc = [&](MPSGraphTensor* primaryCastTensor,
+                      MPSGraphTensor* secondaryCastTensor) -> MPSGraphTensor* {
+    bool isFloatInput = ([primaryCastTensor dataType] & MPSDataTypeFloatBit) != 0;
+    if(!isFloatInput && rounding_mode.has_value() && (*rounding_mode == "floor" || *rounding_mode == "trunc")) {
+      primaryCastTensor = [mpsGraph castTensor:primaryCastTensor
+                                        toType:MPSDataTypeFloat32
+                                          name:@"primaryCastTensor"];
+      secondaryCastTensor = [mpsGraph castTensor:secondaryCastTensor
+                                          toType:MPSDataTypeFloat32
+                                            name:@"secondaryCastTensor"];
+    }
+    MPSGraphTensor* divTensor =  [mpsGraph divisionWithPrimaryTensor:primaryCastTensor
+                                                      secondaryTensor:secondaryCastTensor
+                                                                name:nil];
+
+    // Rounding is a no-op for integral types, and also a reasonable workaround
+    // For MPSGraph bug on Apple Silicon, that throws `Function floorOp_i64 was not found in the library`
+    // See https://github.com/pytorch/pytorch/issues/84995
+    bool isFloatOutput = ([divTensor dataType] & MPSDataTypeFloatBit) != 0;
+    if (!rounding_mode.has_value() || !isFloatOutput) {
+      return divTensor;
+    } else if (*rounding_mode == "trunc") {
+      auto truncTensor =  trunc_tensor(divTensor);
+      if (op_name == "fmod_mps_out") {
+        auto mulTensor = [mpsGraph multiplicationWithPrimaryTensor:truncTensor
+                                                    secondaryTensor:secondaryCastTensor
+                                                              name:nil];
+        return [mpsGraph subtractionWithPrimaryTensor:primaryCastTensor
+                                      secondaryTensor:mulTensor
+                                                  name:nil];
+      }
+      return truncTensor;
+    } else if (*rounding_mode == "floor") {
+      MPSGraphTensor* floorTensor = [mpsGraph floorWithTensor:divTensor name:nil];
+      if (op_name == "remainder_out_mps") {
+        auto mulTensor = [mpsGraph multiplicationWithPrimaryTensor:floorTensor
+                                                    secondaryTensor:secondaryCastTensor
+                                                              name:nil];
+        return [mpsGraph subtractionWithPrimaryTensor:primaryCastTensor
+                                      secondaryTensor:mulTensor
+                                                  name:nil];
+      }
+      return floorTensor;
+    } else {
+      assert(0 && "Invalid rounding mode\n");
+    }
+    return nullptr;
+  };
+  return binaryOpTensor(primaryTensor, secondaryTensor, op_name, divOpFunc);
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::binaryOpWithScalar(MPSGraphTensor *inputTensor, Scalar scalar,
+  const std::string &op_name,
+  std::function<MPSGraphTensor*(MPSGraphTensor*, MPSGraphTensor*)> binaryOpFunction) {
+  auto value = scalar.isFloatingPoint() ? scalar.to<float>() : scalar.to<int>();
+  MPSGraphTensor* constantTensor = [mpsGraph constantWithScalar:value
+                                                          shape:@[@1]
+                                                       dataType:inputTensor.dataType];
+  return binaryOpTensor(inputTensor, constantTensor, op_name, binaryOpFunction);
+}
+
+} // namespace mps
+

--- a/backends/apple/mps/operations/BitwiseOps.mm
+++ b/backends/apple/mps/operations/BitwiseOps.mm
@@ -1,0 +1,19 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+
+namespace mps {
+using namespace torch;
+
+PyMPSGraphTensor *MPSGraphModule::bitwiseNotTensor(MPSGraphTensor *inputTensor,
+                                                   const std::string &op_name) {
+  MPSDataType mpsInputDataType = [inputTensor dataType];
+  if (getScalarType(mpsInputDataType) == ScalarType::Bool) {
+    return [getMPSGraph() notWithTensor:inputTensor name:nil];
+  }
+  return [getMPSGraph() bitwiseNOTWithTensor:inputTensor name:nil];
+}
+} // namespace mps

--- a/backends/apple/mps/operations/ClampOps.mm
+++ b/backends/apple/mps/operations/ClampOps.mm
@@ -1,0 +1,58 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+
+namespace mps {
+using namespace torch;
+
+PyMPSGraphTensor*
+MPSGraphModule::clamp(MPSGraphTensor* inputTensor, float min, float max, bool use_min, bool use_max) {
+  if(use_min && use_max) {
+    MPSGraphTensor* minTensor = [mpsGraph constantWithScalar:min
+                                                       shape:inputTensor.shape
+                                                    dataType:inputTensor.dataType];
+    MPSGraphTensor* maxTensor = [mpsGraph constantWithScalar:max
+                                                       shape:inputTensor.shape
+                                                    dataType:inputTensor.dataType];
+    return [mpsGraph clampWithTensor:inputTensor
+                      minValueTensor:minTensor
+                      maxValueTensor:maxTensor
+                                name:@"clamp"];
+  } else if(use_min && !use_max) {
+    MPSGraphTensor* minTensor = [mpsGraph constantWithScalar:min
+                                                       shape:inputTensor.shape
+                                                    dataType:inputTensor.dataType];
+    return [mpsGraph maximumWithPrimaryTensor:inputTensor
+                                                secondaryTensor:minTensor
+                                                          name:nil];
+  } else if(!use_min && use_max) {
+    MPSGraphTensor* maxTensor = [mpsGraph constantWithScalar:max
+                                                    shape:inputTensor.shape
+                                                dataType:inputTensor.dataType];
+    return [mpsGraph minimumWithPrimaryTensor:inputTensor
+                                                    secondaryTensor:maxTensor
+                                                               name:nil];
+  }
+
+  //For the case that neither min nor max is given? Nothing in the documentation forbids this.
+  return inputTensor;
+}
+
+PyMPSGraphTensor* MPSGraphModule::where(MPSGraphTensor* condition,
+    MPSGraphTensor* input, MPSGraphTensor* other) {
+  if ([condition dataType] != MPSDataTypeBool) {
+    condition = [mpsGraph castTensor:condition
+                              toType:MPSDataTypeBool
+                              name:@"condition"];
+  }
+  MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:condition
+                                                     truePredicateTensor:input
+                                                    falsePredicateTensor:other
+                                                                    name:nil];
+  return outputTensor;
+}
+
+}//namespace mps

--- a/backends/apple/mps/operations/ConstantOps.mm
+++ b/backends/apple/mps/operations/ConstantOps.mm
@@ -1,0 +1,55 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+
+namespace mps {
+using namespace torch;
+
+PyMPSGraphTensor*
+MPSGraphModule::constantWithScalar(MPSDataType dataType, const IntArrayRef& sizes, double scalar) {
+  TORCH_CHECK(!sizes.empty(), "No sizes passed to create a constant with scalar");
+  if (sizes.back() == 0) {
+    // Cannot create a zero-sized dimension through mpsGraph
+    return nil;
+  }
+  return [mpsGraph constantWithScalar:scalar
+                                shape:getMPSShape(sizes)
+                             dataType:dataType];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::full(IntArrayRef size, double scalar, MPSDataType dataType) {
+  if (size.back() == 0) {
+    // Cannot create a zero-sized dimension through mpsGraph
+    return nil;
+  }
+  return [mpsGraph constantWithScalar:scalar
+                                shape:getMPSShape(size)
+                             dataType:dataType];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::full_like(MPSGraphTensor* inputTensor, double scalar) {
+  return [mpsGraph constantWithScalar:scalar
+                                shape:inputTensor.shape
+                             dataType:inputTensor.dataType];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::constant(double scalar, MPSDataType dataType) {
+  return [mpsGraph constantWithScalar:scalar
+                             dataType:dataType];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::constantTensor(Tensor constant_tensor, MPSDataType dataType) {
+  NSData* dataBuffer = [[NSData alloc] initWithBytes:constant_tensor.data_ptr()
+                            length:constant_tensor.nbytes()];
+  return [mpsGraph constantWithData:dataBuffer
+                              shape:getMPSShape(constant_tensor)
+                           dataType:dataType];
+}
+}//namespace mps

--- a/backends/apple/mps/operations/ConvolutionOps.mm
+++ b/backends/apple/mps/operations/ConvolutionOps.mm
@@ -1,0 +1,80 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+
+namespace mps {
+using namespace torch;
+
+PyMPSGraphTensor*
+MPSGraphModule::conv2D(MPSGraphTensor* primaryTensor, MPSGraphTensor* secondaryTensor,
+                       MPSGraphTensor* biasTensor, IntArrayRef stride,
+                       IntArrayRef padding, IntArrayRef dilation, bool transpose,
+                       IntArrayRef outputPadding, int64_t groups, bool is_depthwise) {
+
+  if(is_depthwise){
+    MPSGraphDepthwiseConvolution2DOpDescriptor* desc = [MPSGraphDepthwiseConvolution2DOpDescriptor
+                                    descriptorWithStrideInX:stride[0]
+                                                  strideInY:stride[1]
+                                            dilationRateInX:dilation[0]
+                                            dilationRateInY:dilation[1]
+                                                paddingLeft:padding[1]
+                                               paddingRight:padding[1]
+                                                 paddingTop:padding[0]
+                                              paddingBottom:padding[0]
+                                               paddingStyle:MPSGraphPaddingStyleExplicit
+                                                 dataLayout:MPSGraphTensorNamedDataLayoutNCHW
+                                              weightsLayout:MPSGraphTensorNamedDataLayoutOIHW];
+
+    MPSGraphTensor* depthwiseConv2DTensor = [mpsGraph depthwiseConvolution2DWithSourceTensor:primaryTensor
+                                                                               weightsTensor:secondaryTensor
+                                                                                  descriptor:desc
+                                                                                        name:@"depthwiseConv2D"];
+    //Can be a nullptr
+    if(biasTensor){
+        //Need to add correct dimension to bias to avoid broadcasting issues
+        biasTensor = [mpsGraph expandDimsOfTensor:biasTensor
+                                          axes:@[@0, @2, @3]
+                                          name:nil];
+        depthwiseConv2DTensor = [mpsGraph additionWithPrimaryTensor:depthwiseConv2DTensor
+                                                    secondaryTensor:biasTensor
+                                                               name:@"depthwiseConv2DWithBiasAdd"];
+    }
+
+    return depthwiseConv2DTensor;
+  } else {
+    MPSGraphConvolution2DOpDescriptor* desc = [MPSGraphConvolution2DOpDescriptor
+                                    descriptorWithStrideInX:stride[0]
+                                                  strideInY:stride[1]
+                                            dilationRateInX:dilation[0]
+                                            dilationRateInY:dilation[1]
+                                                     groups:groups
+                                                paddingLeft:padding[1]
+                                               paddingRight:padding[1]
+                                                 paddingTop:padding[0]
+                                              paddingBottom:padding[0]
+                                               paddingStyle:MPSGraphPaddingStyleExplicit
+                                                 dataLayout:MPSGraphTensorNamedDataLayoutNCHW
+                                              weightsLayout:MPSGraphTensorNamedDataLayoutOIHW];
+
+    MPSGraphTensor* conv2DTensor = [mpsGraph convolution2DWithSourceTensor:primaryTensor
+                                                             weightsTensor:secondaryTensor
+                                                                descriptor:desc
+                                                                      name:@"conv2D"];
+
+    //Can be a nullptr
+    if(biasTensor){
+        //Need to add correct dimension to bias to avoid broadcasting issues
+        biasTensor = [mpsGraph expandDimsOfTensor:biasTensor
+                                              axes:@[@0,@2,@3]
+                                              name:nil];
+        conv2DTensor = [mpsGraph additionWithPrimaryTensor:conv2DTensor
+                                           secondaryTensor:biasTensor
+                                                      name:@"conv2DWithBiasAdd"];
+    }
+    return conv2DTensor;
+  }
+}
+} //namespace mps

--- a/backends/apple/mps/operations/Indexing.mm
+++ b/backends/apple/mps/operations/Indexing.mm
@@ -1,0 +1,30 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+
+namespace mps {
+using namespace torch;
+
+PyMPSGraphTensor*
+MPSGraphModule::index_select(MPSGraphTensor* inputTensor, int64_t dim, MPSGraphTensor* indexTensor) {
+  dim = maybe_wrap_dim(dim, inputTensor.shape.count);
+
+  MPSGraphTensor* castIndexTensor = indexTensor;
+  if(castIndexTensor.dataType != MPSDataTypeInt32) {
+    castIndexTensor = [mpsGraph castTensor:indexTensor
+                                    toType:MPSDataTypeInt32
+                                      name:nil];
+  }
+
+  MPSGraphTensor* outputTensor = [mpsGraph gatherWithUpdatesTensor: inputTensor
+                                                     indicesTensor: castIndexTensor
+                                                              axis: dim
+                                                   batchDimensions: 0
+                                                              name: nil];
+  return outputTensor;
+}
+
+} // namespace at::native

--- a/backends/apple/mps/operations/LinearAlgebraOps.mm
+++ b/backends/apple/mps/operations/LinearAlgebraOps.mm
@@ -1,0 +1,48 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+
+namespace mps {
+using namespace torch;
+
+PyMPSGraphTensor*
+MPSGraphModule::addmm(MPSGraphTensor* biasTensor,
+                      MPSGraphTensor* inputTensor,
+                      MPSGraphTensor* weightTensor,
+                      const float beta,
+                      const float alpha) {
+
+  MPSGraphTensor* betaTensor = [mpsGraph constantWithScalar:beta
+                                              dataType:inputTensor.dataType];
+  MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha
+                                              dataType:inputTensor.dataType];
+
+  if(inputTensor.shape == weightTensor.shape) {
+    weightTensor = [mpsGraph transposeTensor:weightTensor
+                                      dimension:0
+                                      withDimension:1
+                                      name:@"addmm/transposedWeightTensor"];
+  }
+
+  MPSGraphTensor* multiplyTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:inputTensor
+                                                                   secondaryTensor:weightTensor
+                                                                   name:@"addmm/matmul"];
+  MPSGraphTensor* alphaTimesMultiply = [mpsGraph multiplicationWithPrimaryTensor:multiplyTensor
+                                                              secondaryTensor:alphaTensor
+                                                              name:@"addmm/alpha*matmul"];
+  MPSGraphTensor* betaBiasTensor = biasTensor;
+  if(beta!=0.0) {
+    betaBiasTensor = [mpsGraph multiplicationWithPrimaryTensor:biasTensor
+                                                  secondaryTensor:betaTensor
+                                                  name:@"addmm/beta*bias"];
+  }
+  MPSGraphTensor* outputTensor = [mpsGraph additionWithPrimaryTensor:alphaTimesMultiply
+                                                        secondaryTensor:betaBiasTensor
+                                                        name:@"addmm/beta*bias*alpha*matmul"];
+
+  return outputTensor;
+}
+}//namespace

--- a/backends/apple/mps/operations/NormalizationOps.mm
+++ b/backends/apple/mps/operations/NormalizationOps.mm
@@ -1,0 +1,93 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+
+namespace mps {
+using namespace torch;
+
+std::tuple<PyMPSGraphTensor*, PyMPSGraphTensor*, PyMPSGraphTensor*>
+MPSGraphModule::batchNorm(MPSGraphTensor* inputTensor,
+                           MPSGraphTensor* meanTensor,
+                           MPSGraphTensor* varTensor,
+                           MPSGraphTensor* weightTensor,
+                           MPSGraphTensor* biasTensor,
+                           float momentum,
+                           float epsilon) {
+
+
+  //Shapes are NCHW so the input parameters to normalization are 1xCx1x1
+  NSMutableArray<NSNumber*>* newShape = [NSMutableArray array];
+  [newShape addObject:[NSNumber numberWithInt:1]];
+  [newShape addObject:inputTensor.shape[1]];
+  for(int i = 2; i<[inputTensor.shape count]; ++i) {
+    [newShape addObject:[NSNumber numberWithInt:1]];
+  }
+  //No need for momentum since we are not training for now since not training?
+  MPSGraphTensor* reshapedMeanTensor = [mpsGraph reshapeTensor:meanTensor
+                             withShape:newShape
+                                  name:nil];
+  MPSGraphTensor* reshapedVarTensor = [mpsGraph reshapeTensor:varTensor
+                             withShape:newShape
+                                  name:nil];
+  MPSGraphTensor* reshapedWeightTensor = [mpsGraph reshapeTensor:weightTensor
+                               withShape:newShape
+                                    name:nil];
+  MPSGraphTensor* reshapedBiasTensor = [mpsGraph reshapeTensor:biasTensor
+                               withShape:newShape
+                                    name:nil];
+
+  MPSGraphTensor* result = [mpsGraph normalizationWithTensor:inputTensor
+                                meanTensor:reshapedMeanTensor
+                            varianceTensor:reshapedVarTensor
+                               gammaTensor:reshapedWeightTensor
+                                betaTensor:reshapedBiasTensor
+                                   epsilon:epsilon
+                                      name:@"batch_norm"];
+  MPSGraphTensor* saveVarTensor = [mpsGraph identityWithTensor:varTensor name:nil];
+  MPSGraphTensor* saveMeanTensor = [mpsGraph identityWithTensor:meanTensor name:nil];
+
+  //For now just return meanTensor and varTensor assuming this isn't training
+  auto out_tuple =  std::make_tuple<PyMPSGraphTensor*>(result, saveMeanTensor, saveVarTensor);
+  return out_tuple;
+}
+
+//Normalizes over the last ndim=normalized_shape.size() dimensions scaling
+//with weight and bias tensors if they are non-nil
+std::tuple<PyMPSGraphTensor*, PyMPSGraphTensor*, PyMPSGraphTensor*>
+MPSGraphModule::layerNorm(MPSGraphTensor* inputTensor,
+                          IntArrayRef normalized_shape,
+                          MPSGraphTensor* weightTensor,
+                          MPSGraphTensor* biasTensor,
+                          float eps) {
+
+  const int input_ndim = [inputTensor.shape count];
+  const int normalized_shape_ndim = normalized_shape.size();
+  const int ndim_to_normalize = input_ndim-normalized_shape_ndim;
+
+  NSMutableArray<NSNumber*>* axesArray = [NSMutableArray arrayWithCapacity:normalized_shape_ndim];
+  for (const auto idx : c10::irange(ndim_to_normalize, input_ndim)) {
+    [axesArray addObject:[NSNumber numberWithInt:idx]];
+  }
+
+  MPSGraphTensor* meanTensor = [mpsGraph meanOfTensor:inputTensor
+                                                 axes:axesArray
+                                                 name:@"LayerNorm/MeanTensor"];
+
+  MPSGraphTensor* varianceTensor = [mpsGraph varianceOfTensor:inputTensor
+                                                    meanTensor:meanTensor
+                                                          axes:axesArray
+                                                          name:@"LayerNorm/varianceTensor"];
+  MPSGraphTensor* normalizedTensor = [mpsGraph normalizationWithTensor:inputTensor
+                                                              meanTensor:meanTensor
+                                                              varianceTensor:varianceTensor
+                                                              gammaTensor:weightTensor
+                                                              betaTensor:biasTensor
+                                                              epsilon:eps
+                                                              name:@"LayerNorm/resultTensor"];
+
+  return std::make_tuple<PyMPSGraphTensor*>(normalizedTensor, meanTensor, varianceTensor);
+}
+}//namespace mps

--- a/backends/apple/mps/operations/PadOps.mm
+++ b/backends/apple/mps/operations/PadOps.mm
@@ -1,0 +1,132 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+#include <ATen/native/mps/OperationUtils.h>
+
+namespace mps {
+using namespace torch;
+
+// Pad operations (1D/2D/3D forward)
+static PyMPSGraphTensor*
+pad_out_template(MPSGraph* mpsGraph,
+                 MPSGraphTensor* input, IntArrayRef padding,
+                 MPSGraphPaddingMode mode, double constantValue)
+{
+  const int padding_size = (int) padding.size();
+  int padding_dim = padding_size / 2; // either 1D, 2D, or 3D
+
+  TORCH_CHECK(padding_size == 2 || padding_size == 4 || padding_size == 6,
+              "invalid padding argument of size ", padding_size);
+
+  auto input_sizes = getMPSShapeVec(input.shape);
+  int64_t nbatch = 1;
+  int64_t ndims = input_sizes.size();
+
+  TORCH_CHECK(ndims >= (int64_t)padding_dim, "Length of pad should be no more than twice the number of "
+              "dimensions of the input. Pad length is ", padding_size, "while the input has ", ndims, "dimensions.");
+
+  // number of input dims with ConstantPad could be less than 2
+  int dim_w = padding_dim;
+  int dim_h = padding_dim - 1;
+  int dim_d = padding_dim - 2;
+  int dim_slices = 0;
+
+  if (mode != MPSGraphPaddingModeConstant && ndims > padding_dim) {
+    bool valid_dims = input_sizes[1] != 0 && input_sizes[padding_dim] != 0;
+    TORCH_CHECK((ndims == 1 + padding_dim && valid_dims) ||
+                (ndims == 2 + padding_dim && valid_dims && input_sizes[1 + padding_dim] != 0),
+                "3D or 4D (batch mode) tensor expected for input, but got: ", input);
+  }
+
+  if (ndims == padding_dim) {
+    dim_w--;
+    dim_h--;
+    dim_d--;
+  } else if (ndims > padding_dim + 1) {
+    const int dim_diff = (int)ndims - padding_dim - 1;
+    // this virtually inflates the padding with zeros if ndims > padding_dim + 2
+    padding_dim += dim_diff - 1;
+    dim_w += dim_diff;
+    dim_h += dim_diff;
+    dim_d += dim_diff;
+    dim_slices++;
+    nbatch = input_sizes[0];
+  }
+
+  int64_t pad_l = padding[0];
+  int64_t pad_r = padding[1];
+  int64_t pad_t = padding_size > 2 ? padding[2] : 0;
+  int64_t pad_b = padding_size > 2 ? padding[3] : 0;
+  int64_t pad_front = padding_size > 4 ? padding[4] : 0;
+  int64_t pad_back  = padding_size > 4 ? padding[5] : 0;
+
+  int64_t nplane = input_sizes[dim_slices];
+  int64_t input_w = input_sizes[dim_w];
+  int64_t output_w  = input_w + pad_l + pad_r;
+  int64_t input_h = padding_dim > 1 ? input_sizes[dim_h] : 0;
+  int64_t output_h = padding_dim > 1 ? input_h + pad_t + pad_b : 0;
+  int64_t input_d = padding_dim > 2 ? input_sizes[dim_d] : 0;
+  int64_t output_d = padding_dim > 2 ? input_d + pad_front + pad_back : 0;
+
+  TORCH_CHECK(output_w >= 1 || output_h >= padding_dim - 1,
+    "input (H: ", input_h, ", W: ", input_w, ") is too small. Calculated "
+    "output H: ", output_h, " W: ", output_w);
+
+  // these checks are only relevant for reflection padding (code taken from ReflectionPad.cpp)
+  if (mode == MPSGraphPaddingModeReflect) {
+    TORCH_CHECK(pad_l < input_w && pad_r < input_w,
+      "Argument #4: Padding size should be less than the corresponding "
+      "input dimension, but got: padding (", pad_l, ", ", pad_r,
+      ") at dimension ", dim_w, " of input ", ndims);
+
+    if (padding_dim > 1) {
+      TORCH_CHECK(pad_t < input_h && pad_b < input_h,
+        "Argument #6: Padding size should be less than the corresponding "
+        "input dimension, but got: padding (", pad_t, ", ", pad_b,
+        ") at dimension ", dim_h, " of input ", ndims);
+    }
+    if (padding_dim > 2) {
+      TORCH_CHECK(pad_front < input_d && pad_back < input_d,
+        "Argument #8: Padding size should be less than the corresponding "
+        "input dimension, but got: padding (", pad_front, ", ", pad_back,
+        ") at dimension ", dim_d, " of input ", ndims);
+    }
+  }
+
+  std::vector<NSNumber*> leftPadVec(ndims, @(0));
+  std::vector<NSNumber*> rightPadVec(ndims, @(0));
+
+  for (int64_t pdim = 0; pdim < padding_size / 2; pdim++) {
+    const int64_t leftIdx  = pdim * 2;
+    const int64_t rightIdx = pdim * 2 + 1;
+    const int64_t padIdx = ndims - pdim - 1;
+
+    leftPadVec [padIdx] = @(padding[leftIdx]);
+    rightPadVec[padIdx] = @(padding[rightIdx]);
+  }
+  MPSShape *leftPadding  = [NSArray arrayWithObjects:leftPadVec.data() count:ndims];
+  MPSShape *rightPadding = [NSArray arrayWithObjects:rightPadVec.data() count:ndims];
+
+  // TODO: check if Bool type works with Constant padding (asserts on pytorch)
+  MPSGraphTensor *padTensor = [mpsGraph padTensor: input
+                                  withPaddingMode: mode
+                                      leftPadding: leftPadding
+                                     rightPadding: rightPadding
+                                    constantValue: constantValue
+                                             name: nil];
+
+  return padTensor;
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::constant_pad_nd(
+    MPSGraphTensor* input,
+    IntArrayRef pad,
+    const double value) {
+  return pad_out_template(mpsGraph, input, pad, MPSGraphPaddingModeConstant, value);
+}
+
+} // namespace at::native

--- a/backends/apple/mps/operations/PoolingOps.mm
+++ b/backends/apple/mps/operations/PoolingOps.mm
@@ -1,0 +1,109 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+#include <ATen/native/mps/OperationUtils.h>
+
+namespace mps {
+using namespace torch;
+
+std::tuple<PyMPSGraphTensor*, PyMPSGraphTensor*>
+MPSGraphModule::maxPool2DWithIndices(MPSGraphTensor* inputTensor,
+                                     IntArrayRef kernel_size,
+                                     IntArrayRef stride,
+                                     IntArrayRef padding,
+                                     IntArrayRef dilation,
+                                     bool ceil_mode) {
+
+  int padH = padding[0];
+  int padW = padding.size() == 1 ? padH : padding[1];
+  const int kH = kernel_size[0];
+  const int kW = kernel_size.size() == 1 ? kH : kernel_size[1];
+  const int dH = stride.empty() ? kH : stride[0];
+  const int dW = stride.empty() ? kW : stride.size() == 1 ? dH : stride[1];
+  const int dilationH = dilation[0];
+  const int dilationW = dilation.size() == 1 ? dilationH : dilation[1];
+
+  MPSGraphPooling2DOpDescriptor* desc = [MPSGraphPooling2DOpDescriptor
+      descriptorWithKernelWidth:kW
+                   kernelHeight:kH
+                      strideInX:dW
+                      strideInY:dH
+                dilationRateInX:dilationW
+                dilationRateInY:dilationH
+                    paddingLeft:padW
+                   paddingRight:ceil_mode ? padW * dW : padW
+                     paddingTop:padH
+                  paddingBottom:ceil_mode ? padH * dH : padH
+                   paddingStyle:MPSGraphPaddingStyleExplicit
+                     dataLayout:MPSGraphTensorNamedDataLayoutNCHW];
+  desc.ceilMode = (padW == 0 && padH == 0) ? ceil_mode : false;
+  desc.returnIndicesMode = MPSGraphPoolingReturnIndicesGlobalFlatten2D;
+  desc.returnIndicesDataType = MPSDataTypeInt32;
+
+  NSArray<MPSGraphTensor*>* outputs = [mpsGraph maxPooling2DReturnIndicesWithSourceTensor:inputTensor
+                                                                 descriptor:desc
+                                                                       name:@"MaxPool2DWithIndices"];
+
+
+  return std::make_tuple(outputs[0], outputs[1]);
+}
+
+
+PyMPSGraphTensor*
+MPSGraphModule::avgPool2D(MPSGraphTensor* inputTensor,
+                                     IntArrayRef kernel_size,
+                                     IntArrayRef stride,
+                                     IntArrayRef padding,
+                                     bool ceil_mode,
+                                     bool count_include_pad,
+                                     c10::optional<int> divisor_override) {
+  int padH = padding[0];
+  int padW = padding.size() == 1 ? padH : padding[1];
+  const int kH = kernel_size[0];
+  const int kW = kernel_size.size() == 1 ? kH : kernel_size[1];
+  const int dH = stride.empty() ? kH : stride[0];
+  const int dW = stride.empty() ? kW : stride.size() == 1 ? dH : stride[1];
+  const int dilationH = 1;
+  const int dilationW = 1;
+
+  MPSGraphPooling2DOpDescriptor* desc = [MPSGraphPooling2DOpDescriptor
+      descriptorWithKernelWidth:kW
+                   kernelHeight:kH
+                      strideInX:dW
+                      strideInY:dH
+                dilationRateInX:dilationW
+                dilationRateInY:dilationH
+                    paddingLeft:padW
+                   paddingRight:ceil_mode ? padW * dW : padW
+                     paddingTop:padH
+                  paddingBottom:ceil_mode ? padH * dH : padH
+                   paddingStyle:MPSGraphPaddingStyleExplicit
+                     dataLayout:MPSGraphTensorNamedDataLayoutNCHW];
+
+  const bool use_divisor = divisor_override.has_value() && divisor_override.value() != 0;
+
+  //if overriding divisor, zeroPads must be included to the average for correct behavior
+  desc.includeZeroPadToAverage = use_divisor ? true : count_include_pad;
+
+  MPSGraphTensor* avgPoolTensor = [mpsGraph avgPooling2DWithSourceTensor:inputTensor
+                                                              descriptor:desc
+                                                                    name:@"AvgPool2DTensor"];
+  if(use_divisor) {
+    //here we rescale the average due to MPSGraph not supporting custom divisor directly
+    const float divisor = float(kH * kW) / (float)divisor_override.value();
+    MPSGraphTensor* constantTensor = [mpsGraph constantWithScalar:divisor
+                                                            shape:@[@1]
+                                                         dataType:MPSDataTypeFloat32];
+    avgPoolTensor = [mpsGraph multiplicationWithPrimaryTensor:avgPoolTensor
+                                              secondaryTensor:constantTensor
+                                                         name:@"AvgPool2DTensor/divisor_override"];
+
+  }
+
+  return avgPoolTensor;
+
+}
+} //namespace

--- a/backends/apple/mps/operations/RangeOps.mm
+++ b/backends/apple/mps/operations/RangeOps.mm
@@ -1,0 +1,31 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+
+namespace mps {
+using namespace torch;
+
+PyMPSGraphTensor*
+MPSGraphModule::arange(Scalar start, Scalar end, Scalar step, MPSDataType dataType, const int numEle) {
+    auto shapeTensor = [mpsGraph constantWithData:[NSData dataWithBytes:&numEle length:sizeof(int32_t)]
+                                            shape:@[ @1 ]
+                                         dataType:MPSDataTypeInt32];
+    auto startScalar = start.isFloatingPoint() ? start.to<float>() : start.to<int>();
+    auto stepScalar = step.isFloatingPoint() ? step.to<float>() : step.to<int>();
+    auto coordsTensor = [mpsGraph coordinateAlongAxis:0 withShapeTensor:shapeTensor name:nil];
+    coordsTensor = [mpsGraph castTensor:coordsTensor toType:dataType name:@"coords"];
+
+    auto startTensor = [mpsGraph constantWithScalar:startScalar
+                             dataType:dataType];
+    auto multiplyTensor = [mpsGraph constantWithScalar:stepScalar
+                             dataType:dataType];
+    auto scaledCoords = [mpsGraph multiplicationWithPrimaryTensor:coordsTensor
+                                                secondaryTensor:multiplyTensor
+                                                            name:nil];
+    auto outputTensor = [mpsGraph additionWithPrimaryTensor:scaledCoords secondaryTensor:startTensor name:nil];
+    return outputTensor;
+}
+} // namespace mps

--- a/backends/apple/mps/operations/ReduceOps.mm
+++ b/backends/apple/mps/operations/ReduceOps.mm
@@ -1,0 +1,238 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+
+namespace mps {
+using namespace torch;
+
+std::tuple<PyMPSGraphTensor*, PyMPSGraphTensor*>
+MPSGraphModule::minDim(MPSGraphTensor* inputTensor,
+                     int dim,
+                     bool keep_dims) {
+
+  const int input_dims = inputTensor.shape.count;
+  int wrapped_dim = torch::maybe_wrap_dim(dim, input_dims);
+
+  MPSGraphTensor* minTensor =  [mpsGraph reductionMinimumWithTensor:inputTensor
+                                                               axis:wrapped_dim
+                                                               name:@"minTensor"];
+
+  MPSGraphTensor* indicesTensor = [mpsGraph reductionArgMinimumWithTensor:inputTensor
+                                              axis:wrapped_dim
+                                              name:@"argminTensor"];
+
+  if ([indicesTensor dataType] != MPSDataTypeInt64) {
+    indicesTensor = [mpsGraph castTensor:indicesTensor
+                                  toType:MPSDataTypeInt64
+                                    name:@"argminTensor/cast"];
+  }
+
+  if(!keep_dims) {
+    minTensor = [mpsGraph squeezeTensor:minTensor
+                                    axis:wrapped_dim
+                                    name:@"minTensor/squeezed"];
+    indicesTensor = [mpsGraph squeezeTensor:indicesTensor
+                                    axis:wrapped_dim
+                                    name:@"argminTensor/squeezed"];
+  }
+
+  return std::make_tuple(minTensor, indicesTensor);
+}
+
+std::tuple<PyMPSGraphTensor*, PyMPSGraphTensor*>
+MPSGraphModule::maxDim(MPSGraphTensor* inputTensor,
+                     int dim,
+                     bool keep_dims) {
+
+  const int input_dims = inputTensor.shape.count;
+  int wrapped_dim = torch::maybe_wrap_dim(dim, input_dims);
+
+  MPSGraphTensor* maxTensor =  [mpsGraph reductionMaximumWithTensor:inputTensor
+                                                               axis:wrapped_dim
+                                                               name:@"maxTensor"];
+
+  MPSGraphTensor* indicesTensor = [mpsGraph reductionArgMaximumWithTensor:inputTensor
+                                              axis:wrapped_dim
+                                              name:@"argmaxTensor"];
+
+  if ([indicesTensor dataType] != MPSDataTypeInt64) {
+    indicesTensor = [mpsGraph castTensor:indicesTensor
+                                  toType:MPSDataTypeInt64
+                                    name:@"argmaxTensor/cast"];
+  }
+
+  if(!keep_dims) {
+    maxTensor = [mpsGraph squeezeTensor:maxTensor
+                                    axis:wrapped_dim
+                                    name:@"minTensor/squeezed"];
+    indicesTensor = [mpsGraph squeezeTensor:indicesTensor
+                                    axis:wrapped_dim
+                                    name:@"argminTensor/squeezed"];
+  }
+
+  return std::make_tuple(maxTensor, indicesTensor);
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::amax(MPSGraphTensor* inputTensor,
+                     IntArrayRef dims,
+                     bool keep_dims) {
+
+  const int input_dims = inputTensor.shape.count;
+  NSMutableArray<NSNumber*>* dimArray = [NSMutableArray array];
+  for(int dim: dims) {
+    int wrapped_dim = torch::maybe_wrap_dim(dim, input_dims);
+    [dimArray addObject:[NSNumber numberWithInt:wrapped_dim]];
+  }
+
+  MPSGraphTensor* amaxTensor = [mpsGraph reductionMaximumWithTensor:inputTensor
+                                                               axes:dimArray
+                                                               name:@"AmaxTensor"];
+  if(!keep_dims) {
+    amaxTensor = [mpsGraph squeezeTensor:amaxTensor
+                                    axes:dimArray
+                                    name:@"AmaxTensor/squeezed"];
+  }
+
+  return amaxTensor;
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::amin(MPSGraphTensor* inputTensor,
+                     IntArrayRef dims,
+                     bool keep_dims) {
+
+  const int input_dims = inputTensor.shape.count;
+  NSMutableArray<NSNumber*>* dimArray = [NSMutableArray array];
+  for(int dim: dims) {
+    int wrapped_dim = torch::maybe_wrap_dim(dim, input_dims);
+    [dimArray addObject:[NSNumber numberWithInt:wrapped_dim]];
+  }
+
+  MPSGraphTensor* aminTensor = [mpsGraph reductionMinimumWithTensor:inputTensor
+                                                               axes:dimArray
+                                                               name:@"AminTensor"];
+  if(!keep_dims) {
+    aminTensor = [mpsGraph squeezeTensor:aminTensor
+                                    axes:dimArray
+                                    name:@"AminTensor/squeezed"];
+  }
+
+  return aminTensor;
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::argmax(MPSGraphTensor* inputTensor,
+                     int64_t dim,
+                     bool keep_dims,
+                     bool flatten) {
+
+  auto dim_ = maybe_wrap_dim(dim, inputTensor.shape.count);
+
+  MPSGraphTensor* output = inputTensor;
+  //In case the dimension is not specified, expectation is to return index
+  //of entry in flattened input tensor
+  if(flatten) {
+    NSInteger nElems = 0;
+    for (NSNumber *num in inputTensor.shape) {
+      nElems *= [num intValue];
+    }
+    dim_ = 0;
+    output =  [mpsGraph reshapeTensor:inputTensor
+                            withShape:@[@-1]
+                            name:nil];
+  }
+
+  output = [mpsGraph reductionArgMaximumWithTensor:output
+                                              axis:dim_
+                                              name:@"ArgmaxTensor"];
+  if(!keep_dims && !flatten) {
+    output = [mpsGraph squeezeTensor:output
+                                axis:dim_
+                                name:@"ArgmaxTensor/squeezed"];
+  }
+
+  if ([output dataType] != MPSDataTypeInt64) {
+    output = [mpsGraph castTensor:output
+                        toType:MPSDataTypeInt64
+                        name:@"ArgmaxTensor/cast"];
+  }
+
+  return output;
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::argmin(MPSGraphTensor* inputTensor,
+                     int64_t dim,
+                     bool keep_dims,
+                     bool flatten) {
+
+  auto dim_ = maybe_wrap_dim(dim, inputTensor.shape.count);
+
+  MPSGraphTensor* output = inputTensor;
+  //In case the dimension is not specified, expectation is to return index
+  //of entry in flattened input tensor
+  if(flatten) {
+    NSInteger nElems = 0;
+    for (NSNumber *num in inputTensor.shape) {
+      nElems *= [num intValue];
+    }
+    dim_ = 0;
+    output =  [mpsGraph reshapeTensor:inputTensor
+                            withShape:@[@-1]
+                            name:nil];
+  }
+
+  output = [mpsGraph reductionArgMinimumWithTensor:output
+                                              axis:dim_
+                                              name:@"ArgminTensor"];
+  if(!keep_dims && !flatten) {
+    output = [mpsGraph squeezeTensor:output
+                                axis:dim_
+                                name:@"ArgminTensor/squeezed"];
+  }
+
+  if ([output dataType] != MPSDataTypeInt64) {
+    output = [mpsGraph castTensor:output
+                        toType:MPSDataTypeInt64
+                        name:@"ArgminTensor/cast"];
+  }
+
+  return output;
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::mean(MPSGraphTensor* inputTensor,
+                     IntArrayRef dims,
+                     bool keep_dims) {
+
+  //MPSGraph wants negative axes to be converted to positive
+  const int input_dims = [inputTensor.shape count];
+  NSMutableArray<NSNumber*>* dimArray = [NSMutableArray array];
+  for(int i = 0; i<dims.size(); i++) {
+    int dim = dims[i];
+    if(dim<0) {
+      dim = input_dims + dim;
+    }
+    [dimArray addObject:[NSNumber numberWithInt:dim]];
+  }
+  //Reverting back to get the ordering back to slowest axis first as MPSGraph expects
+  dimArray = [[[dimArray reverseObjectEnumerator] allObjects] mutableCopy];
+
+  MPSGraphTensor* meanTensor = [mpsGraph meanOfTensor:inputTensor
+                          axes:dimArray
+                          name:@"Mean"];
+  if(!keep_dims) {
+    meanTensor = [mpsGraph squeezeTensor:meanTensor
+                                    axes:dimArray
+                                    name:@"Mean/squeezed"];
+  }
+
+  return meanTensor;
+
+}
+}//namespace mps
+

--- a/backends/apple/mps/operations/ShapeOps.mm
+++ b/backends/apple/mps/operations/ShapeOps.mm
@@ -1,0 +1,260 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+
+namespace mps {
+using namespace torch;
+
+PyMPSGraphTensor*
+MPSGraphModule::pixel_shuffle(MPSGraphTensor* inputTensor, int upscale_factor) {
+
+  const int ndims = inputTensor.shape.count;
+  TORCH_CHECK(ndims >= 3, "pixel_shuffle requires tensor with at least 3 dimensions.");
+  if (upscale_factor == 1) {
+    return inputTensor;
+  }
+  TORCH_CHECK(inputTensor.shape[ndims - 3].intValue % (upscale_factor * upscale_factor) == 0, 
+                "pixel_shuffle channels must be divisible by upscale factor squared.");
+
+  return [mpsGraph depthToSpace2DTensor:inputTensor
+                              widthAxis:ndims - 1
+                             heightAxis:ndims - 2
+                              depthAxis:ndims - 3
+                              blockSize:upscale_factor
+                   usePixelShuffleOrder:true
+                                   name:@"pixel_shuffle"];
+
+}
+
+std::vector<PyMPSGraphTensor*>
+MPSGraphModule::split_size(MPSGraphTensor* inputTensor, IntArrayRef split_sizes, int dim) {
+
+  TORCH_CHECK(dim >=0 && dim < inputTensor.shape.count, 
+              "split_copy: dim ", dim, " out of range for input tensor with ", inputTensor.shape.count, " dimensions");
+
+  std::vector<PyMPSGraphTensor*> splitResults;
+  NSArray<MPSGraphTensor*>* mpsGraphResults;
+
+  mpsGraphResults = [mpsGraph splitTensor:inputTensor
+                               splitSizes:getMPSShape(split_sizes)
+                                     axis:dim
+                                     name:@"split_size"];
+                                     
+  for (MPSGraphTensor* splitTensor in mpsGraphResults) {
+    splitResults.push_back(splitTensor);
+  }
+  return splitResults;
+}
+
+std::vector<PyMPSGraphTensor*>
+MPSGraphModule::split(MPSGraphTensor* inputTensor, int split_size, int dim) {
+
+  TORCH_CHECK(dim >=0 && dim < inputTensor.shape.count, 
+              "split_copy: dim ", dim, " out of range for input tensor with ", inputTensor.shape.count, " dimensions");
+  TORCH_CHECK(split_size > 0 && split_size <= inputTensor.shape[dim].intValue,
+              "split_copy: split_size ", split_size, " invalid for inputTensor dimension ", dim, " with length ", inputTensor.shape[dim].intValue);
+
+  NSMutableArray* splits = [NSMutableArray array];
+  NSNumber* splitSize = [NSNumber numberWithInt:split_size];
+  int i = 1;
+
+  while(split_size * i < inputTensor.shape[dim].intValue) {
+    [splits addObject:splitSize];
+    i++;
+  }
+
+  int splits_adjust = inputTensor.shape[dim].intValue - (split_size * i);
+  if (splits_adjust < 0) {
+    splits[i - 1] = [NSNumber numberWithInt:(split_size + splits_adjust)];
+  }
+
+  std::vector<PyMPSGraphTensor*> splitResults;
+  NSArray<MPSGraphTensor*>* mpsGraphResults;
+
+  mpsGraphResults = [mpsGraph splitTensor:inputTensor
+                               splitSizes:splits
+                                     axis:dim
+                                     name:@"split"];
+  
+  for (MPSGraphTensor* splitTensor in mpsGraphResults) {
+    splitResults.push_back(splitTensor);
+  }
+  return splitResults;
+}
+
+std::vector<PyMPSGraphTensor*>
+MPSGraphModule::unbind(MPSGraphTensor* inputTensor, int dim) {
+
+  std::vector<PyMPSGraphTensor*> unbindResults;
+
+  for (int i = 0; i < inputTensor.shape[dim].intValue; i++) {
+    unbindResults.push_back(
+      [mpsGraph sliceTensor:inputTensor
+                  dimension:dim
+                      start:i
+                     length:1
+                       name:@"unbind"]
+    );
+  }
+  return unbindResults;
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::slice(MPSGraphTensor* inputTensor,
+                        int64_t dim,
+                        c10::optional<int64_t> start,
+                        c10::optional<int64_t> end,
+                        int64_t step) {
+
+  int64_t dim_len = inputTensor.shape[dim].intValue;
+  // Unwrap optional values
+  int64_t start_val = start.has_value() ? start.value() : 0;
+  int64_t end_val = end.has_value() ? end.value() : dim_len;
+  // Convert python style indices to compatible values
+  start_val = start_val < 0 ? start_val + dim_len : start_val;
+  end_val = end_val < 0 ? end_val + dim_len : end_val;
+  start_val = start_val < 0 ? 0 : start_val;
+  end_val = end_val < 0 ? 0 : end_val;
+  start_val = start_val > dim_len ? dim_len : start_val;
+  end_val = end_val > dim_len ? dim_len : end_val;
+
+  // Define input arrays as required by MPSGraph api
+  NSMutableArray<NSNumber*>* start_arr = [NSMutableArray arrayWithCapacity: inputTensor.shape.count];
+  NSMutableArray<NSNumber*>* end_arr = [NSMutableArray arrayWithCapacity: inputTensor.shape.count];
+  NSMutableArray<NSNumber*>* step_arr = [NSMutableArray arrayWithCapacity: inputTensor.shape.count];
+  // Step needs to be set to one for all other dims
+  for (int i = 0; i < inputTensor.shape.count; i++) {
+    step_arr[i] = @1;
+    end_arr[i] = inputTensor.shape[i];
+    start_arr[i] = @0;
+  }
+
+  start_arr[dim] = [NSNumber numberWithInteger:start_val];
+  end_arr[dim] = [NSNumber numberWithInteger:end_val];
+  step_arr[dim] = [NSNumber numberWithInteger:step];
+
+  return [mpsGraph sliceTensor:inputTensor
+                        starts:start_arr
+                          ends:end_arr
+                       strides:step_arr
+                          name:@"strided_slice"];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::cat(int dim, py::args catTensors) {
+  NSMutableArray<MPSGraphTensor*>* inputTensors = [NSMutableArray array];
+  for (const auto i: c10::irange(catTensors.size())) {
+    MPSGraphTensor* catTensor = static_cast<MPSGraphTensor*>(pybind11::cast<void*>(catTensors[i]));
+    if (catTensor != nil)
+      [inputTensors addObject:static_cast<MPSGraphTensor*>(pybind11::cast<void*>(catTensors[i]))];
+  }
+  return [mpsGraph concatTensors:inputTensors
+                       dimension:dim
+                            name:@"cat"];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::stack(int dim, py::args stackTensors) {
+  NSMutableArray<MPSGraphTensor*>* inputTensors = [NSMutableArray array];
+  for (const auto i: c10::irange(stackTensors.size())) {
+    [inputTensors addObject:static_cast<MPSGraphTensor*>(pybind11::cast<void*>(stackTensors[i]))];
+  }
+  return [mpsGraph stackTensors:inputTensors
+                           axis:dim
+                           name:@"stack"];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::expand(MPSGraphTensor* inputTensor,
+                                IntArrayRef sizes) {
+  // In torch, -1 is passed for dimensions which are to stay the same size
+  NSMutableArray<NSNumber*>* mpsSizes = [NSMutableArray array];
+  [mpsSizes addObjectsFromArray:getMPSShape(sizes)];
+  for (int64_t i = 0; i < mpsSizes.count; i++) {
+    if ([mpsSizes[i] isEqualToNumber:[NSNumber numberWithInt:-1]]) {
+      mpsSizes[i] = inputTensor.shape[i];
+    }
+  }
+  return [mpsGraph broadcastTensor:inputTensor
+                           toShape:mpsSizes
+                              name:@"expand_copy"];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::select(MPSGraphTensor* inputTensor, int dim, int index) {
+  // Support python-style negative indexing
+  // MPSGraph already handles negative indexing for start param
+  if (dim < 0) {
+    dim += inputTensor.shape.count;
+  }
+  MPSGraphTensor* slicedTensor =  [mpsGraph sliceTensor:inputTensor
+                                              dimension:dim
+                                                  start:index
+                                                 length:1
+                                                   name:@"slice"];
+  slicedTensor = [mpsGraph squeezeTensor:slicedTensor
+                                    axis:dim
+                                    name:@"slice/squeezed"];
+  return slicedTensor;
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::view(MPSGraphTensor* inputTensor,
+                          IntArrayRef shape) {
+  // MPS_TODO: Implement view functionality instead of just copying & reshaping
+  return [mpsGraph reshapeTensor:inputTensor
+                       withShape:getMPSShape(shape)
+                            name:@"view_copy"];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::permute(MPSGraphTensor* inputTensor,
+                        IntArrayRef axes) {
+  NSMutableArray<NSNumber*>* permutation = [NSMutableArray array];
+  for(int64_t i = 0; i<axes.size(); i++) {
+    [permutation addObject:[NSNumber numberWithInteger:axes[i]]];
+  }
+  return [mpsGraph transposeTensor:inputTensor
+                       permutation:permutation
+                              name:@"permutation"];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::squeeze(MPSGraphTensor* inputTensor) {
+  return [mpsGraph squeezeTensor:inputTensor
+                            name:@"squeeze"];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::squeeze(MPSGraphTensor* inputTensor, int dimension) {
+  dimension = torch::maybe_wrap_dim(dimension, inputTensor.shape.count);
+  TORCH_CHECK([inputTensor.shape[dimension] intValue] == 1, "Dimension must be size 1");
+  return [mpsGraph squeezeTensor:inputTensor
+                            axis:dimension
+                            name:@"squeeze"];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::squeeze(MPSGraphTensor* inputTensor, IntArrayRef axes) {
+  NSMutableArray<NSNumber*>* wrappedAxes = [NSMutableArray array];
+  for(int64_t i = 0; i<axes.size(); i++) {
+    int dimension = torch::maybe_wrap_dim(axes[i], inputTensor.shape.count);
+    TORCH_CHECK([inputTensor.shape[dimension] intValue] == 1, "Dimension must be size 1");
+    [wrappedAxes addObject:[NSNumber numberWithInteger:dimension]];
+  }
+  return [mpsGraph squeezeTensor:inputTensor
+                            axes:wrappedAxes
+                            name:@"squeeze"];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::unsqueeze(MPSGraphTensor* inputTensor, int dimension) {
+  return [mpsGraph expandDimsOfTensor:inputTensor
+                            axis:dimension
+                            name:@"unsqueeze"];
+}
+
+}//namespace mps

--- a/backends/apple/mps/operations/UnaryOps.h
+++ b/backends/apple/mps/operations/UnaryOps.h
@@ -1,0 +1,17 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+// clang-format off
+#pragma once
+
+#define REGISTER_PYBIND11_MPS_UNARY_OP(py11_export_name, graph_op)                                    \
+.def(py11_export_name, [](MPSGraphModule& self, PyMPSGraphTensor* input) {                            \
+return self.unaryOpTensor(                                                                            \
+    static_cast<MPSGraphTensor*>(input), py11_export_name,                                            \
+    [&](MPSGraphTensor* inputTensor) -> MPSGraphTensor* {                                             \
+      return [self.getMPSGraph() graph_op##WithTensor:inputTensor                                     \
+                                                        name:nil];                                    \
+    });                                                                                               \
+})
+// clang-format on

--- a/backends/apple/mps/operations/UnaryOps.mm
+++ b/backends/apple/mps/operations/UnaryOps.mm
@@ -1,0 +1,30 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "utils/MPSGraphInterface.h"
+#include "UnaryOps.h"
+
+namespace mps {
+using namespace torch;
+
+PyMPSGraphTensor*
+MPSGraphModule::unaryOpTensor(
+  MPSGraphTensor* inputTensor,
+  const std::string& op_name,
+  std::function<MPSGraphTensor*(MPSGraphTensor*)> unaryOpFunction) {
+    return unaryOpFunction(inputTensor);
+  }
+
+PyMPSGraphTensor*
+MPSGraphModule::cumsum(
+  MPSGraphTensor* inputTensor,
+  int dim
+) {
+  return [mpsGraph cumulativeSumWithTensor:inputTensor
+                                      axis:dim
+                                      name:@"cumsum"];
+}
+
+}//namespace

--- a/backends/apple/mps/partition/mps_partitioner.py
+++ b/backends/apple/mps/partition/mps_partitioner.py
@@ -1,0 +1,66 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+import logging
+
+import torch
+from executorch.exir.backend.partitioner import (
+    DelegationSpec,
+    Partitioner,
+    PartitionResult,
+)
+
+from torch._export.exported_program import ExportedProgram
+from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
+from torch.fx.passes.operator_support import OperatorSupportBase
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
+
+
+class OperatorsSupportedForMpsBackend(OperatorSupportBase):
+    def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
+        supported_mps_ops = [
+            torch.ops.aten.add.Tensor,
+            torch.ops.aten.mm.default,
+            torch.ops.aten.div.default,
+        ]
+        ret_val = (
+            (node.op == "call_function" and node.target in supported_mps_ops)
+            or node.op == "get_attr"
+            or node.op == "output"
+        )
+        return ret_val
+
+
+# TODO MPSPartitioner is work in progress currently.
+# Use whole graph delegation instead when lowering to MPS.
+class MPSPartitioner(Partitioner):
+    compile_spec = []
+
+    def __init__(self) -> None:
+        self.delegation_spec = DelegationSpec("MPSBackend", self.compile_spec)
+
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
+        # Run the CapabilityBasedPartitioner to return the largest possible
+        # subgraphs containing the nodes with the tags
+        logger.info("MpsPartitioner::partition")
+        partition_tags = {}
+
+        capability_partitioner = CapabilityBasedPartitioner(
+            exported_program.graph_module,
+            OperatorsSupportedForMpsBackend(),
+            allows_single_node_partition=True,
+        )
+        partition_list = capability_partitioner.propose_partitions()
+        for partition in partition_list:
+            for node in partition.nodes:
+                tag = f"tag{partition.id}"
+                node.meta["delegation_tag"] = tag
+                partition_tags[tag] = self.delegation_spec
+
+        return PartitionResult(
+            tagged_exported_program=exported_program, partition_tags=partition_tags
+        )

--- a/backends/apple/mps/runtime/MPSBackend.mm
+++ b/backends/apple/mps/runtime/MPSBackend.mm
@@ -1,0 +1,122 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#import <Foundation/Foundation.h>
+
+#include "MPSCompiler.h"
+#include <executorch/runtime/backend/interface.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/platform/profiler.h>
+#include <cstdio>
+#include <cstdlib> /* strtol */
+#include <memory>
+#include <string>
+#include <iostream>
+
+namespace torch {
+namespace executor {
+
+class MPSBackend final : public PyTorchBackendInterface {
+ public:
+  ~MPSBackend() = default;
+
+  bool is_available() const override {
+    return true;
+  }
+
+  Result<DelegateHandle*> init(
+      BackendInitContext& context,
+      FreeableBuffer* processed,
+      ArrayRef<CompileSpec> compile_specs) const override {
+    auto executor = ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(
+        context.get_runtime_allocator(), mps::delegate::MPSExecutor);
+    // NOTE: Since we use placement new and since this type is not trivially
+    // destructible, we must call the destructor manually in destroy().
+    new (executor) mps::delegate::MPSExecutor;
+    Error err = mps::delegate::MPSCompiler::compileModel(
+        processed->data(), processed->size(), executor, context.get_runtime_allocator(), compile_specs);
+    ET_CHECK_OR_RETURN_ERROR(
+      err == Error::Ok,
+      Internal,
+      "Failed to initialize the MPS delegate");
+
+    // Free the flatbuffer.
+    processed->Free();
+
+    return executor;
+  }
+
+  // Function that actually executes the model in the backend.
+  Error execute(
+    __ET_UNUSED BackendExecutionContext& context,
+    DelegateHandle* handle,
+    EValue** args) const override {
+    auto executor = static_cast<mps::delegate::MPSExecutor*>(handle);
+    std::vector<const Tensor*> input_pointers;
+    std::vector<const Tensor*> output_pointers;
+
+    Error err = Error::Ok;
+
+    int i = 0;
+    int total_placeholders = executor->getNumInputs() + executor->getNumOutputs();
+    while ((input_pointers.size() != executor->getNumInputs()    ||
+           output_pointers.size() != executor->getNumOutputs())  &&
+           (i < total_placeholders)) {
+      ET_CHECK_OR_RETURN_ERROR(
+        args[i] != nullptr,
+        Internal,
+        "Nullptr tensor received during graph execution");
+
+      if (args[i]->isTensor()) {
+        if (input_pointers.size() < executor->getNumInputs()) {
+          input_pointers.push_back(&args[i]->toTensor());
+        } else {
+          output_pointers.push_back(&args[i]->toTensor());
+        }
+      } else if (args[i]->isTensorList()) {
+        const exec_aten::ArrayRef<exec_aten::Tensor>& tensorList = args[i]->toTensorList();
+        for (auto& tensor_ : tensorList) {
+          if (input_pointers.size() < executor->getNumInputs()) {
+            input_pointers.push_back(&tensor_);
+          } else {
+            output_pointers.push_back(&tensor_);
+          }
+        }
+      } else {
+        ET_CHECK_OR_RETURN_ERROR(
+          false,
+          Internal,
+          "Unhandled tag during execution of the graph");
+      }
+      i++;
+    }
+
+    err = executor->set_inputs_outputs(input_pointers, output_pointers);
+    if (err != Error::Ok) {
+      return err;
+    }
+
+    err = executor->forward(output_pointers);
+    return err;
+  }
+
+  void destroy(DelegateHandle* handle) const override {
+    if (handle != nullptr) {
+      auto executor = static_cast<mps::delegate::MPSExecutor*>(handle);
+      // manually in init(), we must destroy it manually here.
+      executor->~MPSExecutor();
+    }
+  }
+};
+
+namespace {
+auto cls = MPSBackend();
+Backend backend{"MPSBackend", &cls};
+static auto success_with_compiler = register_backend(backend);
+} // namespace
+
+} // namespace executor
+} // namespace torch

--- a/backends/apple/mps/runtime/MPSCompiler.h
+++ b/backends/apple/mps/runtime/MPSCompiler.h
@@ -1,0 +1,36 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#pragma once
+
+#include <executorch/runtime/backend/interface.h>
+#include <executorch/runtime/core/memory_allocator.h>
+#include <executorch/runtime/platform/compiler.h>
+#include <memory>
+#include <vector>
+#include "MPSExecutor.h"
+
+namespace torch {
+namespace executor {
+namespace mps {
+namespace delegate {
+
+class MPSCompiler {
+ public:
+  // Takes Flatbuffer Serialized MPS Model and rebuilds the MPSGraphExecutable
+  // returns an executor object that holds the MPS runtime object which we
+  // can then use to set inputs and run inference using the MPSGraphExecutable.
+  __ET_NODISCARD static Error compileModel(
+      const void* buffer_pointer,
+      size_t num_bytes,
+      MPSExecutor* executor,
+      MemoryAllocator* runtime_allocator,
+      ArrayRef<CompileSpec> compile_specs);
+};
+
+} // namespace delegate
+} // namespace mps
+} // namespace executor
+} // namespace torch

--- a/backends/apple/mps/runtime/MPSCompiler.mm
+++ b/backends/apple/mps/runtime/MPSCompiler.mm
@@ -1,0 +1,111 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#import <Foundation/Foundation.h>
+#import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+#import <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+#include "MPSCompiler.h"
+#include <executorch/backends/apple/mps/utils/MPSGraphPackageExport.h>
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
+#include <unordered_map>
+#include <string>
+
+#define MPS_UNUSED(x) ( (void)(x) )
+
+@interface MPSGraphExecutable()
+-(NSArray<MPSGraphShapedType *> *) getInputShapes;
+-(NSArray<MPSGraphShapedType *> *) getOutputShapes;
+@end
+
+namespace torch {
+namespace executor {
+namespace mps {
+namespace delegate {
+
+void printLoadedGraph(MPSGraphExecutable* executable) {
+  NSLog(@"Loaded graph: %@", [executable debugDescription]);
+}
+
+MPSGraphExecutable* loadExecutable(
+  const void* buffer_pointer,
+  size_t num_bytes) {
+  ExirMPSGraphPackage* exirMPSGraphPackage = (ExirMPSGraphPackage*)buffer_pointer;
+  NSData *new_manifest_plist_data = [NSData dataWithBytes:exirMPSGraphPackage->data length:exirMPSGraphPackage->model_0_offset];
+  NSData *new_model_0_data = [NSData dataWithBytes:exirMPSGraphPackage->data + exirMPSGraphPackage->model_0_offset length:exirMPSGraphPackage->model_1_offset - exirMPSGraphPackage->model_0_offset];
+  NSData *new_model_1_data = [NSData dataWithBytes:exirMPSGraphPackage->data + exirMPSGraphPackage->model_1_offset length:exirMPSGraphPackage->total_bytes - sizeof(ExirMPSGraphPackage) - exirMPSGraphPackage->model_1_offset];
+
+  NSError* error = nil;
+  NSString* packageName = [NSString stringWithUTF8String:(
+      std::string("%@/mpsgraphmodule_") + std::to_string(arc4random_uniform(INT_MAX)) + ".mpsgraphpackage").c_str()];
+#if TARGET_OS_IPHONE
+  NSArray *paths = NSSearchPathForDirectoriesInDomains
+      (NSDocumentDirectory, NSUserDomainMask, YES);
+  NSString *documentsDirectory = [paths objectAtIndex:0];
+#else
+  NSString *documentsDirectory = @"/tmp";
+#endif
+
+  NSString *dataFileNSStr = [NSString stringWithFormat:packageName,
+                                                        documentsDirectory];
+
+  NSString* manifestFileStr = [NSString stringWithFormat:@"%@/manifest.plist", dataFileNSStr];
+  NSString* model0FileStr = [NSString stringWithFormat:@"%@/model_0.mpsgraph", dataFileNSStr];
+  NSString* model1FileStr = [NSString stringWithFormat:@"%@/model_1.mpsgraph", dataFileNSStr];
+
+  NSFileManager *fileManager= [NSFileManager defaultManager];
+  [fileManager createDirectoryAtPath:dataFileNSStr withIntermediateDirectories:NO attributes:nil error:&error];
+
+  [new_manifest_plist_data writeToFile:manifestFileStr options:NSDataWritingAtomic error:&error];
+  [new_model_0_data writeToFile:model0FileStr options:NSDataWritingAtomic error:&error];
+  [new_model_1_data writeToFile:model1FileStr options:NSDataWritingAtomic error:&error];
+
+  NSURL *bundleURL = [NSURL fileURLWithPath:dataFileNSStr];
+  MPSGraphCompilationDescriptor *compilationDescriptor = [MPSGraphCompilationDescriptor new];
+  MPSGraphExecutable *newExec = [[MPSGraphExecutable new] initWithMPSGraphPackageAtURL:bundleURL compilationDescriptor:compilationDescriptor];
+
+  return newExec;
+}
+
+/*
+Builds the mps runtime object using the buffer pointer. The buffer pointer
+must be a valid pointer to the serialized mps object.
+*/
+__ET_NODISCARD Error MPSCompiler::compileModel(
+  const void* buffer_pointer,
+  size_t num_bytes,
+  MPSExecutor* executor,
+  MemoryAllocator* runtime_allocator,
+  ArrayRef<CompileSpec> compile_specs) {
+  MPS_UNUSED(compile_specs);
+
+  Error err = Error::Ok;
+
+  id mpsCD = NSClassFromString(@"MPSGraph");
+  static bool _macos_14_0_plus = [mpsCD instancesRespondToSelector:@selector(imToColWithSourceTensor:descriptor:name:)] == YES;
+  ET_CHECK_OR_RETURN_ERROR(
+      _macos_14_0_plus,
+      NotSupported,
+      "MPS Executorch runtime is supported only from macOS 14.0 and above.");
+
+  MPSGraphExecutable* executable = loadExecutable(buffer_pointer, num_bytes);
+  ET_CHECK_OR_RETURN_ERROR(
+      executable != nil,
+      InvalidProgram,
+      "Invalid flatbuffer contents - could not deserialize MPSGraphExecutable");
+
+  executor->inputShapes_ = [[executable getInputShapes] retain];
+  executor->outputShapes_ = [[executable getOutputShapes] retain];
+
+  ET_LOG(Info, "Num inputs: %lu", [executor->inputShapes_ count]);
+  ET_LOG(Info, "Num outputs: %lu", [executor->outputShapes_ count]);
+
+  executor->executable_ = executable;
+  return err;
+}
+
+} // namespace delegate
+} // namespace mps
+} // namespace executor
+} // namespace torch

--- a/backends/apple/mps/runtime/MPSDevice.h
+++ b/backends/apple/mps/runtime/MPSDevice.h
@@ -1,0 +1,51 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#pragma once
+
+#include <Foundation/Foundation.h>
+#include <Metal/Metal.h>
+#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
+
+#define MB(x) (x * 1048576UL)
+
+namespace torch {
+namespace executor {
+namespace mps {
+namespace delegate {
+
+class MPSDevice {
+ public:
+  /**
+   * MPSDevice should not be cloneable.
+   */
+  MPSDevice(MPSDevice& other) = delete;
+  /**
+   * MPSDevice should not be assignable.
+   */
+  void operator=(const MPSDevice&) = delete;
+  /**
+   * Gets single instance of the Device.
+   */
+  static MPSDevice* getInstance();
+  /**
+   * Returns the single device.
+   */
+  id<MTLDevice> device() {
+    return _mtl_device;
+  }
+
+  ~MPSDevice();
+
+ private:
+  static MPSDevice* _device;
+  id<MTLDevice> _mtl_device;
+  MPSDevice();
+};
+
+} // namespace delegate
+} // namespace mps
+} // namespace executor
+} // namespace torch

--- a/backends/apple/mps/runtime/MPSDevice.mm
+++ b/backends/apple/mps/runtime/MPSDevice.mm
@@ -1,0 +1,53 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "MPSDevice.h"
+#include <executorch/runtime/platform/assert.h>
+#include <memory>
+#include <mutex>
+
+namespace torch {
+namespace executor {
+namespace mps {
+namespace delegate {
+
+static std::unique_ptr<MPSDevice> mps_device;
+static std::once_flag mpsdev_init;
+
+MPSDevice::~MPSDevice() {
+  [_mtl_device release];
+  _mtl_device = nil;
+}
+
+MPSDevice::MPSDevice(): _mtl_device(nil) {
+  @autoreleasepool {
+#if TARGET_OS_IPHONE
+    _mtl_device = MTLCreateSystemDefaultDevice();
+#else
+    NSArray* devices = MTLCopyAllDevices();
+    for (unsigned long i = 0 ; i < [devices count] ; i++) {
+      id<MTLDevice>  device = devices[i];
+      if(![device isLowPower]) { // exclude Intel GPUs
+        _mtl_device = [device retain];
+        break;
+      }
+    }
+#endif
+  }
+  // MPS TODO: Replace with `ET_CHECK_OR_RETURN_ERROR` and propagate back the error.
+  ET_CHECK(_mtl_device != nil);
+}
+
+MPSDevice* MPSDevice::getInstance() {
+  std::call_once(mpsdev_init, [] {
+      mps_device = std::unique_ptr<MPSDevice>(new MPSDevice());
+  });
+  return mps_device.get();
+}
+
+} // namespace delegate
+} // namespace mps
+} // namespace executor
+} // namespace torch

--- a/backends/apple/mps/runtime/MPSExecutor.h
+++ b/backends/apple/mps/runtime/MPSExecutor.h
@@ -1,0 +1,67 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+// clang-format off
+#pragma once
+
+#import <Foundation/Foundation.h>
+#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
+#include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
+
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace torch {
+namespace executor {
+namespace mps {
+namespace delegate {
+
+class MPSExecutor {
+ private:
+  MPSGraphExecutable* executable_;
+  NSArray<MPSGraphShapedType *> * inputShapes_;
+  NSArray<MPSGraphShapedType *> * outputShapes_;
+
+  NSMutableArray<MPSGraphTensorData *>* inputsArray_;
+  NSMutableArray<MPSGraphTensorData *>* outputsArray_;
+#if TARGET_OS_SIMULATOR
+  NSMutableArray<id<MTLBuffer>>* output_buffers_;
+#endif
+
+ public:
+  MPSExecutor() = default;
+  ~MPSExecutor() {
+    [inputsArray_ release];
+    [outputsArray_ release];
+  }
+
+  inline size_t getNumInputs() {
+    return [inputShapes_ count];
+  }
+
+  inline size_t getNumOutputs() {
+    return [outputShapes_ count];
+  }
+
+  inline MPSGraphExecutable* getMPSGraphExecutable() {
+    return executable_;
+  }
+
+  __ET_NODISCARD Error forward(std::vector<const Tensor*>& outputs);
+
+  __ET_NODISCARD Error
+  set_inputs_outputs(std::vector<const Tensor*>& inputs, std::vector<const Tensor*>& outputs);
+
+  friend class MPSCompiler;
+};
+
+} // namespace delegate
+} // namespace mps
+} // namespace executor
+} // namespace torch
+// clang-format on

--- a/backends/apple/mps/runtime/MPSExecutor.mm
+++ b/backends/apple/mps/runtime/MPSExecutor.mm
@@ -1,0 +1,104 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#define EXIR_MPS_DELEGATE 1
+
+#include <executorch/runtime/kernel/kernel_includes.h>
+#include <executorch/backends/apple/mps/runtime/MPSStream.h>
+#include <executorch/backends/apple/mps/utils/OperationUtils.h>
+
+#include "MPSExecutor.h"
+
+@interface MPSNDArray ()
+-(nonnull instancetype) initWithBuffer:(id<MTLBuffer> _Nonnull) buffer
+                            descriptor:(MPSNDArrayDescriptor * _Nonnull) descriptor;
+@end
+
+@interface MPSNDArrayDescriptor ()
+@property (readwrite, nonatomic) BOOL preferPackedRows;
+@end
+
+
+namespace torch {
+namespace executor {
+namespace mps {
+namespace delegate {
+
+__ET_NODISCARD Error
+MPSExecutor::set_inputs_outputs(std::vector<const Tensor*>& inputs, std::vector<const Tensor*>& outputs) {
+  ET_CHECK_OR_RETURN_ERROR(inputs.size() == getNumInputs(), Internal, "Inputs mismatch");
+  ET_CHECK_OR_RETURN_ERROR(outputs.size() == getNumOutputs(), Internal, "Outputs mismatch");
+
+#if !TARGET_OS_SIMULATOR
+  if (outputsArray_ != nil) {
+    return Error::Ok;
+  }
+#endif
+
+  inputsArray_ = [[NSMutableArray<MPSGraphTensorData *> alloc] init];
+  outputsArray_ = [[NSMutableArray<MPSGraphTensorData *> alloc] init];
+
+#if TARGET_OS_SIMULATOR
+  output_buffers_ = [[NSMutableArray<id<MTLBuffer>> alloc] init];
+#endif
+
+  for (int i = 0; i < inputs.size(); i++) {
+    MPSNDArrayDescriptor *tensorDesc = [MPSNDArrayDescriptor descriptorWithDataType:[inputShapes_[i] dataType]
+                                                                              shape:[inputShapes_[i] shape]];
+    tensorDesc.preferPackedRows = YES;
+    id<MTLBuffer> inputBuffer = ::mps::getMTLBufferStorage(*inputs[i]);
+    MPSNDArray *ndArrayData = [[MPSNDArray alloc] initWithBuffer:inputBuffer descriptor:tensorDesc];
+    MPSGraphTensorData* tensorData = [[MPSGraphTensorData alloc] initWithMPSNDArray:ndArrayData];
+    [inputsArray_ addObject:tensorData];
+  }
+
+  for (int i = 0; i < outputs.size(); i++) {
+    MPSNDArrayDescriptor *tensorDesc = [MPSNDArrayDescriptor descriptorWithDataType:[outputShapes_[i] dataType]
+                                                                              shape:[outputShapes_[i] shape]];
+    tensorDesc.preferPackedRows = YES;
+    id<MTLBuffer> outputBuffer = ::mps::getMTLBufferStorage(*outputs[i]);
+    MPSNDArray *ndArrayData = [[MPSNDArray alloc] initWithBuffer:outputBuffer descriptor:tensorDesc];
+    MPSGraphTensorData* tensorData = [[MPSGraphTensorData alloc] initWithMPSNDArray:ndArrayData];
+    [outputsArray_ addObject:tensorData];
+#if TARGET_OS_SIMULATOR
+    [output_buffers_ addObject:[outputBuffer retain]];
+#endif
+  }
+
+  return Error::Ok;
+}
+
+__ET_NODISCARD Error MPSExecutor::forward(std::vector<const Tensor*>& outputs) {
+  Error err = Error::Ok;
+  MPSStream* mpsStream = getDefaultMPSStream();
+  id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
+  [executable_ encodeToCommandBuffer:commandBuffer
+                        inputsArray:inputsArray_
+                        resultsArray:outputsArray_
+                executionDescriptor:nil];
+  if (mps::delegate::getDefaultMPSStream()->commitAndContinueEnabled()) {
+    err = mpsStream->synchronize(SyncType::COMMIT_AND_CONTINUE);
+  } else {
+    err = mpsStream->synchronize(SyncType::COMMIT_AND_WAIT);
+#if TARGET_OS_SIMULATOR
+  for (int i = 0; i < outputs.size(); i++) {
+    uint8_t* data = outputs[i]->mutable_data_ptr<uint8_t>();
+    memcpy(data, [output_buffers_[i] contents], [output_buffers_[i] length]);
+  }
+#endif
+  }
+
+  ET_CHECK_OR_RETURN_ERROR(
+    err == Error::Ok,
+    Internal,
+    "Could not synchronize on the MPSStream");
+
+  return Error::Ok;
+}
+
+} // namespace delegate
+} // namespace mps
+} // namespace executor
+} // namespace torch

--- a/backends/apple/mps/runtime/MPSStream.h
+++ b/backends/apple/mps/runtime/MPSStream.h
@@ -1,0 +1,101 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include <Foundation/Foundation.h>
+#include <Metal/Metal.h>
+#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
+#include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+#include <executorch/runtime/core/error.h>
+#include <map>
+#include "MPSDevice.h"
+
+namespace torch {
+namespace executor {
+namespace mps {
+namespace delegate {
+
+enum class SyncType {
+  NONE, // no commit to command buffer
+  COMMIT, // commit and flush the command buffer
+  COMMIT_AND_WAIT, // flush and wait for command buffer execution to finish
+  COMMIT_AND_CONTINUE, // commit and continue with a new underlying command
+                       // buffer
+  COMMIT_ADAPTIVE, // commit adaptively based on available memory
+};
+
+class MPSStream {
+ public:
+  MPSStream();
+
+  ~MPSStream();
+  id<MTLCommandQueue> commandQueue() const {
+    return _commandQueue;
+  };
+  dispatch_queue_t queue() const {
+    return _serialQueue;
+  }
+
+  MPSCommandBuffer* commandBuffer();
+  id<MTLComputeCommandEncoder> commandEncoder();
+  void endKernelCoalescing();
+  __ET_NODISCARD Error synchronize(SyncType syncType);
+  // void commitAdaptive(const TensorList& inputTensors, const TensorList&
+  // outputTensors, void* profilerHandle);
+  bool commitAndContinueEnabled();
+
+ private:
+  id<MTLCommandQueue> _commandQueue = nil;
+  MPSCommandBuffer* _commandBuffer = nil;
+  MPSCommandBuffer* _prevCommandBuffer = nil;
+  id<MTLComputeCommandEncoder> _commandEncoder = nil;
+  MPSGraphExecutionDescriptor* _executionDescriptor = nil;
+  MPSGraphExecutableExecutionDescriptor* _executableExecutionDescriptor = nil;
+  MPSGraphCompilationDescriptor* _compilationDescriptor = nil;
+  dispatch_queue_t _serialQueue = nullptr;
+  // CommitAndContinue is disabled by default
+  bool _enableCommitAndContinue = false;
+  // accumulated sizes of resources encoded on command buffer
+  size_t _commandBufferResourceSize = 0;
+  // unfortunately, there's no way to get the underlying buffer from
+  // an MPSGraphTensorData. so we need to keep a mapping of them here
+  std::unordered_map<MPSGraphTensorData*, void*> _activeResources{};
+
+  // use synchronize() to access any of these commit functions outside MPSStream
+  void commit();
+  void commitAndWait();
+  void commitAndContinue();
+  void flush();
+};
+
+/**
+ * Get the current MPS stream
+ */
+MPSStream* getCurrentMPSStream();
+
+/**
+ * Get the default MPS stream
+ */
+MPSStream* getDefaultMPSStream();
+
+//-----------------------------------------------------------------
+//  MPSStreamImpl
+//-----------------------------------------------------------------
+
+class MPSStreamImpl {
+ public:
+  /**
+   * Gets single instance of the MPSStream.
+   */
+  static MPSStream* getInstance();
+
+ private:
+  static MPSStream* _stream;
+  MPSStreamImpl();
+};
+
+} // namespace delegate
+} // namespace mps
+} // namespace executor
+} // namespace torch

--- a/backends/apple/mps/runtime/MPSStream.mm
+++ b/backends/apple/mps/runtime/MPSStream.mm
@@ -1,0 +1,186 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "MPSStream.h"
+#include <executorch/runtime/platform/assert.h>
+
+@interface MPSGraphExecutionDescriptor ()
+@property (readwrite, atomic) BOOL enableCommitAndContinue;
+@end
+
+namespace torch {
+namespace executor {
+namespace mps {
+namespace delegate {
+
+// threshold to perform adaptive commit if the accumulated size
+// of resources encoded on the command buffer exceeds that.
+static const size_t kCmdBufAdaptiveCommitThreshold = MB(64);
+
+//-----------------------------------------------------------------
+//  MPSStream
+//-----------------------------------------------------------------
+
+MPSStream::MPSStream() {
+  _commandQueue = [MPSDevice::getInstance()->device() newCommandQueue];
+  _serialQueue = dispatch_queue_create("metal gpu stream", nullptr);
+  _executionDescriptor = [MPSGraphExecutionDescriptor new];
+  _executableExecutionDescriptor = [MPSGraphExecutableExecutionDescriptor new];
+  _compilationDescriptor = [MPSGraphCompilationDescriptor new];
+
+  // internal CommitAndContinue heuristic of MPSGraph is disabled, and we
+  // control it via Adaptive Commit in Executorch-side
+  _executionDescriptor.enableCommitAndContinue = false;
+
+  // Choose level which optimizes for GPU
+  _compilationDescriptor.optimizationLevel = MPSGraphOptimizationLevel0;
+  _executionDescriptor.compilationDescriptor =  _compilationDescriptor;
+}
+
+MPSStream::~MPSStream() {
+  [_commandQueue release];
+  _commandQueue = nil;
+  [_executionDescriptor release];
+  [_compilationDescriptor release];
+  [_executableExecutionDescriptor release];
+
+  _executionDescriptor = nil;
+  _compilationDescriptor = nil;
+  _executableExecutionDescriptor = nil;
+
+  assert(_commandBuffer == nil);
+}
+
+MPSCommandBuffer* MPSStream::commandBuffer() {
+  if (!_commandBuffer) {
+    _commandBuffer = [MPSCommandBuffer commandBufferFromCommandQueue:_commandQueue].retain;
+  }
+
+  return _commandBuffer;
+}
+
+id<MTLComputeCommandEncoder> MPSStream::commandEncoder() {
+  if (!_commandEncoder) {
+    _commandEncoder = [commandBuffer() computeCommandEncoder].retain;
+  }
+
+  return _commandEncoder;
+}
+
+__ET_NODISCARD
+Error MPSStream::synchronize(SyncType syncType) {
+  endKernelCoalescing();
+  switch(syncType) {
+    case SyncType::COMMIT:
+      commit();
+      break;
+    case SyncType::COMMIT_AND_WAIT:
+      commitAndWait();
+      break;
+    case SyncType::COMMIT_AND_CONTINUE:
+      ET_CHECK_OR_RETURN_ERROR(
+        _enableCommitAndContinue == true,
+        Internal,
+        "CommitAndContinue is called but it is disabled globally!");
+      commitAndContinue();
+      break;
+    default:
+      ET_CHECK_OR_RETURN_ERROR(
+        false,
+        Internal,
+        "Unhandled syncType type");
+  }
+
+  return Error::Ok;
+}
+
+bool MPSStream::commitAndContinueEnabled() {
+  return _enableCommitAndContinue;
+}
+
+void MPSStream::commitAndContinue() {
+  assert(_commandBuffer);
+  [_commandBuffer commitAndContinue];
+}
+
+void MPSStream::endKernelCoalescing() {
+  if (_commandEncoder) {
+    [_commandEncoder endEncoding];
+    [_commandEncoder release];
+    _commandEncoder = nil;
+  }
+}
+
+void MPSStream::commitAndWait() {
+  if (_prevCommandBuffer) {
+    // the previous command buffer (if exists) has already been committed,
+    // so we just wait until it's completed and then dispose it.
+    [_prevCommandBuffer waitUntilCompleted];
+    [_prevCommandBuffer release];
+    _prevCommandBuffer = nil;
+  }
+
+  if (_commandBuffer) {
+    [_commandBuffer commit];
+    [_commandBuffer waitUntilCompleted];
+    [_commandBuffer release];
+    _commandBuffer = nil;
+    // reset the accumulated resource sizes for command buffer
+    _commandBufferResourceSize = 0;
+  }
+}
+
+void MPSStream::commit() {
+  if (_enableCommitAndContinue) {
+    [commandBuffer() commitAndContinue];
+  } else {
+    flush();
+  }
+  // reset the accumulated resource sizes for command buffer
+  _commandBufferResourceSize = 0;
+}
+
+void MPSStream::flush() {
+  if (_commandBuffer) {
+    [_commandBuffer commit];
+    // if commitAndContinue is disabled (e.g., for Profiler), we keep the command
+    // buffer so we could wait on it later, if required.
+    if (!_enableCommitAndContinue) {
+      _prevCommandBuffer = _commandBuffer;
+    } else {
+      [_commandBuffer release];
+    }
+    _commandBuffer = nil;
+  }
+}
+
+//-----------------------------------------------------------------
+//  MPSStreamImpl
+//-----------------------------------------------------------------
+
+MPSStream* MPSStreamImpl::_stream = nullptr;
+
+MPSStream* MPSStreamImpl::getInstance() {
+  if (_stream == nullptr) {
+    _stream =
+        new MPSStream();
+  }
+  return _stream;
+}
+
+MPSStreamImpl::MPSStreamImpl() {}
+
+MPSStream* getCurrentMPSStream() {
+  return getDefaultMPSStream();
+}
+
+MPSStream* getDefaultMPSStream() {
+  return MPSStreamImpl::getInstance();
+}
+
+} // namespace delegate
+} // namespace mps
+} // namespace executor
+} // namespace torch

--- a/backends/apple/mps/runtime/TARGETS
+++ b/backends/apple/mps/runtime/TARGETS
@@ -1,0 +1,11 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+
+load(":targets.bzl", "define_common_targets")
+define_common_targets(is_fbcode = True)

--- a/backends/apple/mps/runtime/targets.bzl
+++ b/backends/apple/mps/runtime/targets.bzl
@@ -1,0 +1,47 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets(is_fbcode = False):
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+    if runtime.is_oss:
+        runtime.cxx_library(
+            name = "MPSBackend",
+            srcs = [
+              "MPSExecutor.mm",
+              "MPSCompiler.mm",
+              "MPSBackend.mm",
+              "MPSStream.mm",
+              "MPSDevice.mm",
+            ] + native.glob(["utils/OperationUtils.mm"]),
+            # lang_preprocessor_flags = 'objective-c++'
+            visibility = [
+                "//executorch/exir/backend:backend_lib",
+                "//executorch/backends/apple/...",
+                "//executorch/runtime/backend/...",
+                "//executorch/extension/pybindings/...",
+                "//executorch/sdk/runners/...",
+                "//executorch/test/...",
+                "//executorch/examples/...",
+                "@EXECUTORCH_CLIENTS",
+            ],
+            headers = native.glob([
+              "runtime/*.h",
+            ]),
+            # registration of backends is done through a static global
+            compiler_flags = ["-Wno-global-constructors"],
+            external_deps = [
+            "gflags",
+            ],
+            exported_deps = [
+                "//executorch/runtime/backend:interface",
+            ],
+            link_whole = True,
+        )

--- a/backends/apple/mps/setup.md
+++ b/backends/apple/mps/setup.md
@@ -1,0 +1,145 @@
+<!---- DO NOT MODIFY Progress Bar Start --->
+
+<div class="progress-bar-wrapper">
+   <div class="progress-bar-item">
+     <div class="step-number" id="step-1">1</div>
+     <span class="step-caption" id="caption-1"></span>
+   </div>
+   <div class="progress-bar-item">
+     <div class="step-number" id="step-2">2</div>
+     <span class="step-caption" id="caption-2"></span>
+   </div>
+   <div class="progress-bar-item">
+     <div class="step-number" id="step-3">3</div>
+     <span class="step-caption" id="caption-3"></span>
+   </div>
+   <div class="progress-bar-item">
+     <div class="step-number" id="step-4">4</div>
+     <span class="step-caption" id="caption-4"></span>
+   </div>
+   <div class="progress-bar-item">
+     <div class="step-number" id="step-5">5</div>
+     <span class="step-caption" id="caption-5"></span>
+   </div>
+</div>
+
+<!---- DO NOT MODIFY Progress Bar End--->
+
+# Building and Running ExecuTorch on MPS Backend
+
+In this tutorial we will walk you through the process of getting setup to build the MPS backend for ExecuTorch and running a simple model on it.
+
+The MPS backend device maps machine learning computational graphs and primitives on the [MPS Graph](https://developer.apple.com/documentation/metalperformanceshadersgraph/mpsgraph?language=objc) framework and tuned kernels provided by [MPS](https://developer.apple.com/documentation/metalperformanceshaders?language=objc).
+
+::::{grid} 2
+:::{grid-item-card}  What you will learn in this tutorial:
+:class-card: card-prerequisites
+* In this tutorial you will learn how to export [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model to the MPS delegate.
+* You will also learn how to compile and deploy the ExecuTorch runtime with the MPS delegate on macOS and iOS.
+:::
+:::{grid-item-card}  Tutorials we recommend you complete before this:
+:class-card: card-prerequisites
+* [Introduction to ExecuTorch](intro-how-it-works.md)
+* [Setting up ExecuTorch](getting-started-setup.md)
+* [Building ExecuTorch with CMake](runtime-build-and-cross-compilation.md)
+:::
+::::
+
+
+## Prerequisites (Hardware and Software)
+
+In order to be able to successfully build and run a model using the MPS backend for ExecuTorch, you'll need the following hardware and software components.
+
+### Hardware
+- [Apple Silicon](https://support.apple.com/en-us/HT211814)
+
+### Software
+- [macOS Sonoma](https://www.apple.com/macos/sonoma/) (for lowering to MPS delegate)
+- [iOS 17](https://www.apple.com/ios/ios-17/) / [iPadOS 17](https://www.apple.com/ipados/ipados-17/) (for running on device)
+
+
+## Setting up Developer Environment
+
+***Step 1.*** Please finish tutorial [Setting up executorch](../../../docs/website/docs/tutorials/00_setting_up_executorch.md).
+
+***Step 2.*** Install dependencies needed to lower MPS delegate:
+
+  ```bash
+  bash ./backends/apple/mps/install_requirements.sh
+  ```
+
+## Build
+
+### AOT (Ahead-of-time) Components
+
+**Compiling model for MPS delegate**:
+- In this step, you will generate a simple ExecuTorch program that lowers MobileNetV3 model to the MPS delegate. You'll then pass this Program(the `.pte` file) during the runtime to run it using the MPS backend.
+
+```bash
+cd executorch
+python3 -m unittest backends.apple.mps.test.test_mps --verbose -k mv3
+```
+
+### Runtime
+
+**Building the MPS executor runner**
+- In this step, you'll be building the `mps_executor_runner` that is able to run MPS lowered modules.
+
+***Step 1***. Run the CMake build.
+
+```bash
+# Build the mps_executor_runner
+rm -rf cmake-out && mkdir cmake-out && cd cmake-out && cmake -DEXECUTORCH_BUILD_MPS=1 -DBUCK2=/tmp/buck2 —trace .. && cmake --build . && cd ..
+```
+
+***Step 2***. Run the model using the `mps_executor_runner`.
+```bash
+./cmake-out/examples/apple/mps/mps_executor_runner --model_path mv3.pte --bundled_program
+```
+
+You should see the following results. Note that no output file will be generated in this example:
+```
+./cmake-out/examples/apple/mps/mps_executor_runner --model_path mv3.pte --bundled_program
+I 00:00:00.003290 executorch:mps_executor_runner.mm:286] Model file mv3.pte is loaded.
+I 00:00:00.003306 executorch:mps_executor_runner.mm:292] Program methods: 1
+I 00:00:00.003308 executorch:mps_executor_runner.mm:294] Running method forward
+I 00:00:00.003311 executorch:mps_executor_runner.mm:349] Setting up non-const buffer 1, size 606112.
+I 00:00:00.003374 executorch:mps_executor_runner.mm:376] Setting up memory manager
+I 00:00:00.003376 executorch:mps_executor_runner.mm:392] Loading method name from plan
+I 00:00:00.018942 executorch:mps_executor_runner.mm:399] Method loaded.
+I 00:00:00.018944 executorch:mps_executor_runner.mm:404] Loading bundled program...
+I 00:00:00.018980 executorch:mps_executor_runner.mm:421] Inputs prepared.
+I 00:00:00.118731 executorch:mps_executor_runner.mm:438] Model executed successfully.
+I 00:00:00.122615 executorch:mps_executor_runner.mm:501] Model verified successfully.
+```
+
+## Deploying and Running on Device
+
+***Step 1***. Create the ExecuTorch core and MPS delegate frameworks to link on iOS
+```bash
+cd executorch
+./build/build_apple_frameworks.sh --Release --mps
+```
+
+`mps_delegate.xcframework` will be in `cmake-out` folder, along with `executorch.xcframework` and `portable_delegate.xcframework`:
+```bash
+cd cmake-out && ls
+```
+
+***Step 2***. Link the frameworks into your XCode project:
+Go to project Target’s  `Build Phases`  -  `Link Binaries With Libraries`, click the **+** sign and add the frameworks: files located in  `Release` folder.
+- `executorch.xcframework`
+- `portable_delegate.xcframework`
+- `mps_delegate.xcframework`
+
+From the same page, include the needed libraries for the MPS delegate:
+- `MetalPerformanceShaders.framework`
+- `MetalPerformanceShadersGraph.framework`
+- `Metal.framework`
+
+In this tutorial, you have learned how to lower a model to the MPS delegate, build the mps_executor_runner and run a lowered model through the MPS delegate, or directly on device using the MPS delegate static library.
+
+
+## Frequently encountered errors and resolution.
+
+If you encountered any bugs or issues following this tutorial please file a bug/issue on the ExecuTorch repository, with hashtag **#mps**.

--- a/backends/apple/mps/targets.bzl
+++ b/backends/apple/mps/targets.bzl
@@ -1,0 +1,27 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "get_oss_build_kwargs", "runtime")
+
+def define_common_targets():
+    if runtime.is_oss:
+      runtime.cxx_library(
+          name = "mps_backend",
+          srcs = native.glob([
+              "runtime/*.mm",
+          ]),
+          headers = native.glob([
+              "runtime/*.h",
+          ]),
+          visibility = [
+              "//executorch/exir/backend:backend_lib",
+              "//executorch/exir/backend/test/...",
+              "//executorch/backends/apple/mps/test/...",
+              "//executorch/extension/pybindings/...",
+              "@EXECUTORCH_CLIENTS",
+          ],
+          deps = [
+              "//executorch/backends/apple/mps/runtime:MPSBackend",
+              "//executorch/runtime/backend:interface",
+              "//executorch/runtime/core/exec_aten/util:tensor_util",
+          ],
+          define_static_target = True,
+          link_whole = True,
+      )

--- a/backends/apple/mps/test/test_mps.py
+++ b/backends/apple/mps/test/test_mps.py
@@ -1,0 +1,2425 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+import inspect
+import logging
+import random
+import unittest
+from enum import Enum
+
+import executorch.exir as exir
+import torch
+import torch._export as export
+from examples.models import MODEL_NAME_TO_MODEL
+from examples.models.model_factory import EagerModelFactory
+from executorch.backends.apple.mps.mps_preprocess import MPSBackend
+from executorch.backends.apple.mps.test.test_mps_models import MPS_MODEL_NAME_TO_MODEL
+from executorch.backends.apple.mps.test.test_mps_utils import (
+    _CAPTURE_CONFIG,
+    _EDGE_COMPILE_CONFIG,
+    dump_executorch_program_info,
+    OpSequencesAddConv2d,
+    randomize_bn,
+    TestMPS,
+)
+
+from executorch.bundled_program.config import BundledConfig
+from executorch.bundled_program.core import create_bundled_program
+from executorch.bundled_program.serialize import (
+    serialize_from_bundled_program_to_flatbuffer,
+)
+from executorch.exir import ExirExportedProgram
+from executorch.exir.backend.backend_api import to_backend
+from executorch.exir.tests.models import (
+    BasicSinMax,
+    CompositeDelegateModule,
+    ElementwiseAdd,
+    Emformer,
+    MLP,
+    ModelWithUnusedArg,
+    Mul,
+    Repeat,
+)
+
+
+class MODEL_TYPE(Enum):
+    EXIR_DEFAULT_MODEL = 0
+    EXIR_TEST_MODEL = 1
+    MPS_TEST_MODEL = 2
+
+
+EXIR_MODEL_NAME_TO_MODEL = {
+    "repeat": lambda: (Repeat(), Repeat().get_random_inputs()),
+    "model_with_unused_arg": lambda: (
+        ModelWithUnusedArg(),
+        ModelWithUnusedArg().get_random_inputs(),
+    ),
+    "mlp": lambda: (MLP(), MLP().get_random_inputs()),
+    "mul_2": lambda: (Mul(), Mul().get_random_inputs()),
+    "element_wise_add": lambda: (
+        ElementwiseAdd(),
+        ElementwiseAdd().get_random_inputs(),
+    ),
+    "basic_sin_max": lambda: (BasicSinMax(), BasicSinMax().get_random_inputs()),
+    "composite_delegate_module": lambda: (
+        CompositeDelegateModule(),
+        CompositeDelegateModule().get_random_inputs(),
+    ),
+    "emformer": lambda: (Emformer(), Emformer().get_random_inputs()),
+}
+
+
+def run_model(
+    model: str,
+    model_type: MODEL_TYPE = MODEL_TYPE.EXIR_DEFAULT_MODEL,
+    dump_non_lowered_module: bool = False,
+    dump_lowered_module: bool = False,
+):
+    logging.info(f"Step 1: Retrieving model: {model}...")
+    if model_type == MODEL_TYPE.EXIR_DEFAULT_MODEL:
+        m, m_inputs = EagerModelFactory.create_model(*MODEL_NAME_TO_MODEL[model])
+    elif model_type == MODEL_TYPE.EXIR_TEST_MODEL:
+        m, m_inputs = EXIR_MODEL_NAME_TO_MODEL.get(model)()
+    elif model_type == MODEL_TYPE.MPS_TEST_MODEL:
+        m, m_inputs = MPS_MODEL_NAME_TO_MODEL.get(model)()
+
+    m = m.eval()
+
+    m = export.capture_pre_autograd_graph(m, m_inputs)
+
+    logging.info("Step 2: EXIR capturing of original module...")
+    edge = exir.capture(m, m_inputs, _CAPTURE_CONFIG).to_edge(_EDGE_COMPILE_CONFIG)
+
+    if dump_non_lowered_module:
+        dump_executorch_program_info(edge=edge, module_info="Non-lowered")
+
+    # Step 3: Lower to MPSGraph
+    logging.info("Step 3: Lowering to MPSGraph...")
+    lowered_module = to_backend(MPSBackend.__name__, edge.exported_program, [])
+
+    logging.info("Step 4: Capturing executorch program with lowered module...")
+
+    # Step 4: Create a new composite module with our lowered MPS module
+    # This composite module calls into the lowered module
+    class WrappedModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mps_module = lowered_module
+
+        def forward(self, *args):
+            return self.mps_module(*args)
+
+    executorch_program = (
+        exir.capture(WrappedModule(), m_inputs, _CAPTURE_CONFIG)
+        .to_edge(_EDGE_COMPILE_CONFIG)
+        .to_executorch()
+    )
+
+    if dump_lowered_module:
+        tmp_exported_program: ExirExportedProgram = exir.capture(
+            lowered_module, m_inputs, _CAPTURE_CONFIG
+        ).to_edge(_EDGE_COMPILE_CONFIG)
+        dump_executorch_program_info(edge=tmp_exported_program, module_info="Lowered")
+
+    logging.info("Step 5: Generating bundled program... ")
+
+    logging.info(
+        f"  -> Number of execution plans: {len(executorch_program.program.execution_plan)}"
+    )
+
+    bundled_inputs = [
+        [m_inputs] for _ in range(len(executorch_program.program.execution_plan))
+    ]
+    logging.info("  -> Bundled inputs generated successfully")
+
+    output = m(*m_inputs)
+    expected_outputs = [
+        [[output]] for _ in range(len(executorch_program.program.execution_plan))
+    ]
+    logging.info("  -> Bundled outputs generated successfully")
+
+    bundled_config = BundledConfig(["forward"], bundled_inputs, expected_outputs)
+    logging.info("  -> Bundled config generated successfully")
+
+    bundled_program = create_bundled_program(executorch_program.program, bundled_config)
+    logging.info("  -> Bundled program generated successfully")
+
+    bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
+        bundled_program
+    )
+    logging.info("  -> Bundled program serialized successfully to flatbuffer")
+
+    filename = f"{model}.pte"
+    logging.info(f"Step 6: Saving exported program to {filename}...")
+    with open(filename, "wb") as file:
+        file.write(bundled_program_buffer)
+
+
+class TestMPSBackend_ExampleModels(unittest.TestCase):
+    def test_mul(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_linear(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_add(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_add_mul(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_emformer_transcribe(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_emformer_join(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_mobilebert(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_mv2(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_mv3(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_vit(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_ic3(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_ic4(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_resnet18(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_resnet50(self):
+        run_model(inspect.stack()[0].function[5:])
+
+    def test_edsr(self):
+        run_model(inspect.stack()[0].function[5:])
+
+
+class TestMPSBackendExirModels(unittest.TestCase):
+    def test_model_with_unused_arg(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.EXIR_TEST_MODEL)
+
+    def test_mlp(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.EXIR_TEST_MODEL)
+
+    def test_mul_2(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.EXIR_TEST_MODEL)
+
+    def test_element_wise_add(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.EXIR_TEST_MODEL)
+
+    def test_emformer(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.EXIR_TEST_MODEL)
+
+
+class TestMPSBackendMPSModels(unittest.TestCase):
+    def test_conv2D(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.MPS_TEST_MODEL)
+
+    def test_norm(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.MPS_TEST_MODEL)
+
+    def test_module_add(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.MPS_TEST_MODEL)
+
+    def test_toy_model_for_mem_planning(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.MPS_TEST_MODEL)
+
+    def test_mem_planning_with_scratch_tensor(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.MPS_TEST_MODEL)
+
+    def test_module_ops_return_tensor_list(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.MPS_TEST_MODEL)
+
+    def test_module_contiguous_tensor(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.MPS_TEST_MODEL)
+
+    def test_module_input_dynamic_shape(self):
+        run_model(inspect.stack()[0].function[5:], MODEL_TYPE.MPS_TEST_MODEL)
+
+
+class TestMPSUnitOpTesting(TestMPS):
+    def test_mps_backend_split_copy(self):
+        class SplitCopy(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.split(x, 2, 1)
+
+        example_inputs = (torch.randn(3, 5, 4, 7),)
+        self.lower_and_test_with_partitioner(
+            SplitCopy(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_unbind_copy(self):
+        class UnbindCopy(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.unbind(x, 1)
+
+        example_inputs = (torch.randn(3, 5, 4, 7),)
+        self.lower_and_test_with_partitioner(
+            UnbindCopy(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_pixel_shuffle(self):
+        class PixelShuffle(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.pixel_shuffle(x, 2)
+
+        example_inputs = (torch.randn(3, 8, 4, 7),)
+        self.lower_and_test_with_partitioner(
+            PixelShuffle(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_cumsum(self):
+        class CumulativeSum(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, *x):
+                return torch.cumsum(x[0], dim=0)
+
+        example_inputs = (torch.randn(3, 5, 4, 7),)
+        self.lower_and_test_with_partitioner(
+            CumulativeSum(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_stack(self):
+        class Stack(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, *x):
+                return torch.stack((x), 0)
+
+        example_inputs = (
+            torch.randn(1, 5, 1, 8),
+            torch.randn(1, 5, 1, 8),
+        )
+        self.lower_and_test_with_partitioner(
+            Stack(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_cat(self):
+        class Cat(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, *x):
+                return torch.cat((x), 1)
+
+        example_inputs = (
+            torch.randn(1, 5, 1, 8),
+            torch.randn(1, 5, 1, 8),
+        )
+        self.lower_and_test_with_partitioner(
+            Cat(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_expand_copy(self):
+        class ExpandCopy(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.example_inputs = [7, 5, 4, 8]
+
+            def forward(self, x):
+                return x.expand(self.example_inputs)
+
+        example_inputs = (torch.randn(1, 5, 1, 8),)
+        self.lower_and_test_with_partitioner(
+            ExpandCopy(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_select(self):
+        class Select(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.select(x, 3, 2)
+
+        example_inputs = (torch.randn(3, 5, 4, 7),)
+        self.lower_and_test_with_partitioner(
+            Select(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_view_copy(self):
+        class ViewCopy(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.example_inputs = [2, 10, 2, 4]
+
+            def forward(self, x):
+                return x.view(self.example_inputs)
+
+        example_inputs = (torch.randn(1, 5, 4, 8),)
+        self.lower_and_test_with_partitioner(
+            ViewCopy(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_mean_dim_2(self):
+        class Mean(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.mean(x, (-1, -2), keepdim=True)
+
+        example_inputs = (torch.randn(1, 5, 4, 4),)
+        self.lower_and_test_with_partitioner(
+            Mean(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_squeeze_dim_1(self):
+        class Squeeze(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.squeeze(x, 2)
+
+        example_inputs = (torch.randn(1, 5, 1, 4),)
+        self.lower_and_test_with_partitioner(
+            Squeeze(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_mean_dim_no_keepdim(self):
+        class Mean(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.mean(x, (-1, -2), keepdim=False)
+
+        example_inputs = (torch.randn(1, 5, 4, 4),)
+        self.lower_and_test_with_partitioner(
+            Mean(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_mean_dim_unsupported(self):
+        class Mean(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.mean(x, (3), keepdim=True)
+
+        example_inputs = (torch.randn(1, 5, 4, 4),)
+        self.lower_and_test_with_partitioner(
+            Mean(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_static_transpose(self):
+        class PermuteModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.nchw_to_nhwc = [0, 2, 3, 1]
+
+            def forward(self, x):
+                return torch.permute(x, self.nchw_to_nhwc)
+
+        example_inputs = (torch.randn(1, 1, 4, 4),)
+        self.lower_module_and_test_output(
+            PermuteModule(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_sequential_conv2d(self):
+        class TwoConv(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.first = torch.nn.Conv2d(
+                    in_channels=1,
+                    out_channels=3,
+                    kernel_size=(3, 3),
+                    padding=1,
+                    bias=False,
+                )
+                self.second = torch.nn.Conv2d(
+                    in_channels=3,
+                    out_channels=2,
+                    kernel_size=(3, 3),
+                    padding=1,
+                    bias=False,
+                )
+
+            def forward(self, x):
+                return self.second(self.first(x))
+
+        example_inputs = (torch.randn(1, 1, 3, 3),)
+        self.lower_and_test_with_partitioner(
+            TwoConv(), example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_conv2d_bn(self):
+        class ModelConvBN(torch.nn.Module):
+            def __init__(self, in_features: int, out_features: int, kernel_size):
+                super().__init__()
+                self.conv2d = torch.nn.Conv2d(in_features, out_features, kernel_size)
+                self.bn = randomize_bn(out_features)
+
+            def forward(self, x):
+                y = self.conv2d(x)
+                y = self.bn(y)
+                return y
+
+        model = ModelConvBN(2, 2, (2, 2)).eval()
+
+        self.lower_and_test_with_partitioner(
+            model, (torch.randn(2, 2, 4, 4),), func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_conv2d(self):
+        groups = 1
+        stride = [2, 2]
+        padding = [1, 1]
+        dilation = [1, 1]
+        in_channels = 2
+        out_channels = 1
+        width = 8
+        height = 8
+        batches = 1
+        example_inputs = (torch.randn(batches, in_channels, height, width),)
+        conv = torch.nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=(3, 3),
+            stride=stride,
+            padding=padding,
+            groups=groups,
+            dilation=dilation,
+            bias=True,
+        )
+        conv.eval()
+        self.lower_and_test_with_partitioner(
+            conv, example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_conv2d_single_int_params(self):
+        groups = 1
+        stride = 2
+        padding = "valid"
+        dilation = 1
+        in_channels = 2
+        out_channels = 1
+        width = 8
+        height = 8
+        batches = 1
+        example_inputs = (torch.randn(batches, in_channels, height, width),)
+        conv = torch.nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            stride=stride,
+            padding=padding,
+            groups=groups,
+            dilation=dilation,
+            bias=True,
+        )
+        conv.eval()
+        self.lower_and_test_with_partitioner(
+            conv, example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_conv2d_dw(self):
+        # Depthwise Convolution Requirements:
+        # - Groups must equal In Channels
+        # - Out Channels must be a positive multiple of In Channels
+        groups = 2
+        stride = [2, 2]
+        padding = [1, 1]
+        dilation = [1, 1]
+        in_channels = groups
+        out_channels = 3 * in_channels
+        width = 8
+        height = 8
+        batches = 1
+        example_inputs = (torch.randn(batches, in_channels, height, width),)
+        conv = torch.nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=(3, 3),
+            stride=stride,
+            padding=padding,
+            groups=groups,
+            dilation=dilation,
+            bias=True,
+        )
+        conv.eval()
+        self.lower_and_test_with_partitioner(
+            conv, example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_mm(self):
+        in_sizes = [1, 4, 4]
+        input_sizes = [4, 37, 17]
+        output_sizes = [4, 17, 37]
+        for i, _ in enumerate(in_sizes):
+            in_size = int(in_sizes[i])
+            input_size = int(input_sizes[i])
+            output_size = int(output_sizes[i])
+            linear = torch.nn.Linear(input_size, output_size, bias=False).eval()
+            example_input = (torch.randn(in_size, input_size),)
+
+            self.lower_and_test_with_partitioner(
+                linear, example_input, func_name=inspect.stack()[0].function[5:]
+            )
+
+    def test_mps_backend_addmm(self):
+        in_sizes = [1, 4, 4]
+        input_sizes = [4, 37, 17]
+        output_sizes = [4, 17, 37]
+        for i, _ in enumerate(in_sizes):
+            in_size = int(in_sizes[i])
+            input_size = int(input_sizes[i])
+            output_size = int(output_sizes[i])
+            linear = torch.nn.Linear(input_size, output_size, bias=True).eval()
+            example_input = (torch.randn(in_size, input_size),)
+
+            self.lower_and_test_with_partitioner(
+                linear, example_input, func_name=inspect.stack()[0].function[5:]
+            )
+
+    def test_mps_backend_full_ones_default(self):
+        class Ones(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self):
+                size = (4, 37, 17)
+                return torch.ones(size)
+
+        self.lower_and_test_with_partitioner(
+            Ones(), (), func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_full_zeros_default(self):
+        class Zeros(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self):
+                size = (4, 37, 17)
+                return torch.zeros(size=size)
+
+        self.lower_and_test_with_partitioner(
+            Zeros(), (), func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_full_default(self):
+        class Full(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self):
+                size = (4, 37, 17)
+                return torch.full(size=size, fill_value=2.0)
+
+        self.lower_and_test_with_partitioner(
+            Full(), (), func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_full_like(self):
+        class Full_Like(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.full_like(x, fill_value=2.0)
+
+        const_module = Full_Like()
+        model_inputs = (torch.randn(4, 37, 17),)
+
+        self.lower_and_test_with_partitioner(
+            const_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_constant_add(self):
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._constant = torch.ones(4, 4, 4)
+
+            def forward(self, x):
+                out1 = x + self._constant
+                out2 = x + self._constant + self._constant
+                return out1, out2
+
+        const_module = Module()
+        model_inputs = (torch.randn(4, 4, 4),)
+
+        self.lower_and_test_with_partitioner(
+            const_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_mul_scalar_float(self):
+        class MulScalarModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._scalar = 3.14
+
+            def forward(self, x):
+                out1 = torch.ops.aten.mul.Scalar(x, self._scalar)
+                return out1
+
+        mul_scalar_module = MulScalarModule()
+        model_inputs = (torch.randn(4, 4, 4),)
+
+        self.lower_and_test_with_partitioner(
+            mul_scalar_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_mul_scalar_int(self):
+        class MulScalarModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._scalar = 3
+
+            def forward(self, x):
+                out1 = torch.ops.aten.mul.Scalar(x, self._scalar)
+                return out1
+
+        mul_scalar_module = MulScalarModule()
+        model_inputs = (torch.randint(11, (4, 4, 4)),)
+
+        self.lower_and_test_with_partitioner(
+            mul_scalar_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_add_1(self):
+        class AddModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                z = torch.add(x, y, alpha=0.1)
+                return z
+
+        add_module = AddModule()
+        model_inputs = (torch.randn(1), torch.randn(1))
+
+        self.lower_and_test_with_partitioner(
+            add_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_add_2(self):
+        class AddModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                z = torch.ops.aten.add.Scalar(x, 2.0)
+                return z
+
+        add_module = AddModule()
+        model_inputs = (torch.randn(2, 5),)
+
+        self.lower_and_test_with_partitioner(
+            add_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_add_3(self):
+        class AddModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                z = torch.add(x, y)
+                return z
+
+        add_module = AddModule()
+        model_inputs = (torch.randn(1), torch.randn(1))
+
+        self.lower_and_test_with_partitioner(
+            add_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_sub_1(self):
+        class SubModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                z = torch.sub(x, y, alpha=0.1)
+                return z
+
+        sub_module = SubModule()
+        model_inputs = (torch.randn(1), torch.randn(1))
+
+        self.lower_and_test_with_partitioner(
+            sub_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_sub_2(self):
+        class SubModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                z = torch.ops.aten.sub.Scalar(x, 2.0)
+                return z
+
+        sub_module = SubModule()
+        model_inputs = (torch.randn(2, 5),)
+
+        self.lower_and_test_with_partitioner(
+            sub_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_sub_3(self):
+        class SubModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                z = torch.sub(x, y)
+                return z
+
+        sub_module = SubModule()
+        model_inputs = (torch.randn(1), torch.randn(1))
+
+        self.lower_and_test_with_partitioner(
+            sub_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_add_scalar_float(self):
+        class AddScalarModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._scalar_float = 3.14
+
+            def forward(self, x):
+                out = torch.ops.aten.add.Scalar(x, self._scalar_float)
+                return out
+
+        add_scalar_module = AddScalarModule()
+        model_inputs = (torch.randn(4, 4, 4),)
+
+        self.lower_and_test_with_partitioner(
+            add_scalar_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_add_scalar_int(self):
+        class AddScalarModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._scalar_int = 3
+
+            def forward(self, x):
+                out1 = torch.ops.aten.add.Scalar(x, self._scalar_int)
+                return out1
+
+        add_scalar_module = AddScalarModule()
+        model_inputs = (torch.randint(11, (4, 4, 4), dtype=torch.int32),)
+
+        self.lower_and_test_with_partitioner(
+            add_scalar_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_logit_1(self):
+        class LogitModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                z = torch.ops.aten.logit.default(x)
+                return z
+
+        logit_module = LogitModule()
+        model_inputs = (torch.rand(5),)
+
+        self.lower_and_test_with_partitioner(
+            logit_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_logit_2(self):
+        class LogitModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                z = torch.ops.aten.logit.default(x, eps=1e-6)
+                return z
+
+        logit_module = LogitModule()
+        model_inputs = (torch.rand(5),)
+
+        self.lower_and_test_with_partitioner(
+            logit_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_div(self):
+        class DivModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                z = x / y
+                return z
+
+        div_module = DivModule()
+        model_inputs = (torch.ones(1), torch.ones(1))
+
+        self.lower_and_test_with_partitioner(
+            div_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_round(self):
+        class RoundModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out = torch.round(x)
+                return out
+
+        module = RoundModule()
+        model_inputs = (torch.randn(5, 2),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_fmod(self):
+        class FModModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                return torch.fmod(x, y)
+
+        module = FModModule()
+        model_inputs = (torch.randn(2, 3, 4), torch.randn(2, 3, 4))
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_floor_divide(self):
+        class FloorDivideModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                return torch.floor_divide(x, y)
+
+        module = FloorDivideModule()
+        model_inputs = (torch.randn(2, 3, 4), torch.randn(2, 3, 4))
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_amax(self):
+        class AmaxModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out = torch.amax(x, 1)
+                return out
+
+        module = AmaxModule()
+        model_inputs = (torch.randn(2, 3, 4),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_amin(self):
+        class AminModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out = torch.amin(x, 1)
+                return out
+
+        module = AminModule()
+        model_inputs = (torch.randn(2, 3, 4),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_min_dim(self):
+        class MinModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out = torch.min(x, 1)
+                return out
+
+        module = MinModule()
+        model_inputs = (torch.randn(2, 3, 4),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_argmax_1(self):
+        class ArgmaxModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out1 = torch.argmax(x, 1)
+                return out1
+
+        module = ArgmaxModule()
+        model_inputs = (torch.randn(5, 10),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_argmax_2(self):
+        class ArgmaxModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out1 = torch.argmax(x)
+                return out1
+
+        module = ArgmaxModule()
+        model_inputs = (torch.randn(5, 10),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_argmin_1(self):
+        class ArgminModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out1 = torch.argmin(x, 1)
+                return out1
+
+        module = ArgminModule()
+        model_inputs = (torch.randn(5, 10),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_argmin_2(self):
+        class ArgminModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out1 = torch.argmin(x)
+                return out1
+
+        module = ArgminModule()
+        model_inputs = (torch.randn(5, 10),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_minimum(self):
+        class MinimumModule(torch.nn.Module):
+            def __init__(
+                self,
+            ):
+                super().__init__()
+                self.minimum_module = torch.minimum
+
+            def forward(self, x, y):
+                return self.minimum_module(x, y)
+
+        module = MinimumModule()
+        model_inputs = (
+            torch.randn(1, 3, 6),
+            torch.randn(1, 3, 6),
+        )
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_eq_tensor_1(self):
+        class EqModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                out = torch.eq(x, y)
+                return out
+
+        module = EqModule()
+        model_inputs = (
+            torch.randn(2, 3, 4),
+            torch.randn(2, 3, 4),
+        )
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_eq_tensor_2(self):
+        class EqModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                out = torch.eq(x, y)
+                return out
+
+        module = EqModule()
+        input_tensor = torch.randn(2, 3, 4)
+        model_inputs = (input_tensor, input_tensor)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_eq_scalar(self):
+        class EqModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out = torch.eq(x, 1.0)
+                return out
+
+        module = EqModule()
+        model_inputs = (torch.randn(2, 3, 4),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_ne_tensor_1(self):
+        class NeModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                out = torch.ne(x, y)
+                return out
+
+        module = NeModule()
+        model_inputs = (
+            torch.randn(2, 3, 4),
+            torch.randn(2, 3, 4),
+        )
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_ne_tensor_2(self):
+        class NeModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                out = torch.ne(x, y)
+                return out
+
+        module = NeModule()
+        input_tensor = torch.randn(2, 3, 4)
+        model_inputs = (input_tensor, input_tensor)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_ne_scalar(self):
+        class NeModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out = torch.ne(x, 1.0)
+                return out
+
+        module = NeModule()
+        model_inputs = (torch.randn(2, 3, 4),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_ge_tensor_1(self):
+        class GeModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                out = torch.ge(x, y)
+                return out
+
+        module = GeModule()
+        model_inputs = (torch.randn(2, 3, 4), torch.randn(2, 3, 4))
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_ge_tensor_2(self):
+        class GeModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                out = torch.ge(x, y)
+                return out
+
+        module = GeModule()
+
+        input_tensor = torch.randn(2, 3, 4)
+        model_inputs = (input_tensor, input_tensor)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_ge_scalar(self):
+        class GeModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out = torch.ge(x, 1.0)
+                return out
+
+        module = GeModule()
+        model_inputs = (torch.randn(2, 3, 4),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_gt_tensor_1(self):
+        class GtModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                out = torch.gt(x, y)
+                return out
+
+        module = GtModule()
+        model_inputs = (torch.randn(2, 3, 4), torch.randn(2, 3, 4))
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_gt_tensor_2(self):
+        class GtModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                out = torch.gt(x, y)
+                return out
+
+        module = GtModule()
+        input_tensor = torch.randn(2, 3, 4)
+        model_inputs = (input_tensor, input_tensor)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_gt_scalar(self):
+        class GtModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out = torch.gt(x, 1.0)
+                return out
+
+        module = GtModule()
+        model_inputs = (torch.randn(2, 3, 4),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_isnan(self):
+        class IsNanModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.isnan(x)
+
+        module = IsNanModule()
+        model_inputs = (
+            torch.randn(8, 3, 4, 5).index_put_(
+                indices=[torch.tensor([random.randrange(0, 8)])],
+                values=torch.tensor(float("nan")),
+            ),
+        )
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_isinf(self):
+        class IsInfModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.isinf(x)
+
+        module = IsInfModule()
+        model_inputs = (
+            torch.randn(8, 3, 4, 5).index_put_(
+                indices=[torch.tensor([random.randrange(0, 8)])],
+                values=torch.tensor(float("inf")),
+            ),
+        )
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_le_tensor_1(self):
+        class LeModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                out = torch.le(x, y)
+                return out
+
+        module = LeModule()
+        model_inputs = (torch.randn(2, 3, 4), torch.randn(2, 3, 4))
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_le_tensor_2(self):
+        class LeModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                out = torch.le(x, y)
+                return out
+
+        module = LeModule()
+        input_tensor = torch.randn(2, 3, 4)
+        model_inputs = (input_tensor, input_tensor)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_le_scalar(self):
+        class LeModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out = torch.le(x, 1.0)
+                return out
+
+        module = LeModule()
+        model_inputs = (torch.randn(2, 3, 4),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_lt_tensor_1(self):
+        class LtModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                out = torch.lt(x, y)
+                return out
+
+        module = LtModule()
+        model_inputs = (torch.randn(2, 3, 4), torch.randn(2, 3, 4))
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_lt_tensor_2(self):
+        class LtModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                out = torch.le(x, y)
+                return out
+
+        module = LtModule()
+        input_tensor = torch.randn(2, 3, 4)
+        model_inputs = (input_tensor, input_tensor)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_lt_scalar(self):
+        class LtModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                out = torch.lt(x, 1.0)
+                return out
+
+        module = LtModule()
+        model_inputs = (torch.randn(2, 3, 4),)
+
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    @torch.inference_mode()  # TODO Use  for capturing.
+    def test_mps_backend_linear(self):
+        in_size = 2
+        input_size = 3
+        output_size = 4
+        linear = torch.nn.Linear(input_size, output_size).eval()
+        example_input = (torch.randn(in_size, input_size),)
+
+        self.lower_and_test_with_partitioner(
+            linear, example_input, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_glu(self):
+        class GLUModule(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.glu = torch.nn.GLU(dim=dim)
+
+            def forward(self, x):
+                return self.glu(x)
+
+        shape = (4, 2)
+        for dim in list(range(len(shape))) + [-1]:
+            model_inputs = (torch.rand(shape),)
+            glu_module = GLUModule(dim)
+            self.lower_and_test_with_partitioner(
+                glu_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+            )
+
+    def test_mps_backend_softmax(self):
+        class SoftMaxModule(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.softmax = torch.nn.Softmax(dim=dim)
+
+            def forward(self, x):
+                return self.softmax(x)
+
+        shape = (3, 5, 7)
+        for dim in list(range(len(shape))) + [-1]:
+            model_inputs = (torch.rand(shape),)
+            softmax_module = SoftMaxModule(dim)
+            self.lower_and_test_with_partitioner(
+                softmax_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+            )
+
+    def test_mps_backend_log_softmax(self):
+        class LogSoftMaxModule(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.logsoftmax = torch.nn.LogSoftmax(dim=dim)
+
+            def forward(self, x):
+                return self.logsoftmax(x)
+
+        shape = (3, 5, 7)
+        for dim in list(range(len(shape))) + [-1]:
+            model_inputs = (torch.rand(shape),)
+            logsoftmax_module = LogSoftMaxModule(dim)
+
+            self.lower_and_test_with_partitioner(
+                logsoftmax_module,
+                model_inputs,
+                func_name=inspect.stack()[0].function[5:],
+            )
+
+    def test_mps_backend_hardtanh(self):
+        class HardTanhModule(torch.nn.Module):
+            def __init__(self, min_val=-1.0, max_val=1.0):
+                super().__init__()
+                self.hardtanh = torch.nn.Hardtanh(min_val, max_val)
+
+            def forward(self, x):
+                return self.hardtanh(x)
+
+        inputs = [torch.randn(2, 3, 4), torch.randn(7, 5, 2), torch.randn(2, 9)]
+        for test_input in inputs:
+            hardtanh_model = HardTanhModule()
+            self.lower_and_test_with_partitioner(
+                hardtanh_model, (test_input,), func_name=inspect.stack()[0].function[5:]
+            )
+
+        for test_input in inputs:
+            hardtanh_model = HardTanhModule(-2, 2)
+            self.lower_and_test_with_partitioner(
+                hardtanh_model, (test_input,), func_name=inspect.stack()[0].function[5:]
+            )
+
+    def test_mps_backend_Relu(self):
+        class ReluModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                return self.relu(x)
+
+        example_input = torch.randn(2, 3, 4)
+        self.lower_and_test_with_partitioner(
+            ReluModule(), (example_input,), func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_leaky_Relu(self):
+        class LeakyReluModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.leaky_relu = torch.nn.LeakyReLU()
+                self.leaky_relu_2 = torch.nn.LeakyReLU(1.0)
+
+            def forward(self, x):
+                out = self.leaky_relu(x)
+                out = self.leaky_relu_2(out)
+                return out
+
+        example_input = torch.randn(2, 3, 4)
+        self.lower_and_test_with_partitioner(
+            LeakyReluModule(),
+            (example_input,),
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    def test_mps_backend_sigmoid(self):
+        class SigmoidModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.sigmoid = torch.nn.Sigmoid()
+
+            def forward(self, x):
+                return self.sigmoid(x)
+
+        model_inputs = (torch.rand(7, 5, 3),)
+        sigmoid_module = SigmoidModule()
+        self.lower_and_test_with_partitioner(
+            sigmoid_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_constant_pad_nd(self):
+        class PadModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.constant_pad = torch.nn.ConstantPad2d((1, 2), 0)
+
+            def forward(self, x):
+                return self.constant_pad(x)
+
+        model_inputs = (torch.rand(1, 2, 3, 4),)
+        pad_module = PadModule()
+        self.lower_and_test_with_partitioner(
+            pad_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_index_select(self):
+        class IndexSelectModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input, index):
+                return torch.index_select(input, dim=2, index=index)
+
+        model_inputs = (torch.rand(2, 8, 4, 5), torch.tensor([3, 0, 1]))
+        module = IndexSelectModule()
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_empty(self):
+        class EmptyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self):
+                return torch.empty((3, 4, 5), dtype=torch.float32)
+
+        self.lower_and_test_with_partitioner(
+            EmptyModule(), (), func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_static_constant_pad(self):
+        class StaticConstantPadModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y, z):
+                pad_6 = (1, 2, 3, 4, 5, 6)
+                pad_4 = (1, 2, 3, 4)
+                pad_2 = (1, 2)
+                a = torch.nn.functional.pad(
+                    input=x,
+                    pad=pad_6,
+                    mode="constant",
+                    value=2.3,
+                )
+                b = torch.nn.functional.pad(
+                    input=x,
+                    pad=pad_4,
+                    mode="constant",
+                    value=1.3,
+                )
+                c = torch.nn.functional.pad(
+                    input=x,
+                    pad=pad_2,
+                    mode="constant",
+                    value=2.1,
+                )
+                d = torch.nn.functional.pad(
+                    input=y,
+                    pad=pad_6,
+                    mode="constant",
+                    value=2.7,
+                )
+                e = torch.nn.functional.pad(
+                    input=y,
+                    pad=pad_4,
+                    mode="constant",
+                    value=1.9,
+                )
+                f = torch.nn.functional.pad(
+                    input=y,
+                    pad=pad_2,
+                    mode="constant",
+                    value=3.1,
+                )
+                g = torch.nn.functional.pad(
+                    input=z,
+                    pad=pad_4,
+                    mode="constant",
+                    value=2.9,
+                )
+                h = torch.nn.functional.pad(
+                    input=z,
+                    pad=pad_2,
+                    mode="constant",
+                    value=1.2,
+                )
+                return (a, b, c, d, e, f, g, h)
+
+        example_inputs = (
+            torch.randn(size=(5, 4, 3, 2)),
+            torch.randn(size=(5, 3, 2)),
+            torch.randn(size=(4, 3)),
+        )
+        self.lower_and_test_with_partitioner(
+            StaticConstantPadModule(),
+            example_inputs,
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    def test_mps_clamp(self):
+        class Clamp(torch.nn.Module):
+            def __init__(self, min_val, max_val):
+                super().__init__()
+                self.clamp = torch.clamp
+                self.min_val = min_val
+                self.max_val = max_val
+
+            def forward(self, x):
+                return self.clamp(x, min=self.min_val, max=self.max_val)
+
+        model_inputs = (torch.randn(1, 4, 122, 122) * 2,)
+        module = Clamp(-0.5, 0.5)
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_maxpool2d_default(self):
+        class MaxPool2dModule(torch.nn.Module):
+            def __init__(
+                self,
+                kernel_size=3,
+                stride=1,
+                padding=3,
+                dilation=1,
+            ):
+                super().__init__()
+                self.max_pool2d_module = torch.nn.MaxPool2d(
+                    kernel_size=kernel_size,
+                    stride=stride,
+                    padding=padding,
+                    dilation=dilation,
+                )
+
+            def forward(self, x):
+                return self.max_pool2d_module(x)
+
+        maxpool2d_module = MaxPool2dModule(3, 1, 0, 1)
+        model_inputs = (torch.randn(4, 3, 24, 24),)
+
+        self.lower_and_test_with_partitioner(
+            maxpool2d_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_maxpool2d_unsupported(self):
+        class MaxPool2dModule(torch.nn.Module):
+            def __init__(
+                self,
+                kernel_size=3,
+                stride=1,
+                padding=0,
+                dilation=1,
+            ):
+                super().__init__()
+                self.max_pool2d_module = torch.nn.MaxPool2d(
+                    kernel_size=kernel_size,
+                    stride=stride,
+                    padding=padding,
+                    dilation=dilation,
+                    return_indices=True,
+                )
+
+            def forward(self, x):
+                return self.max_pool2d_module(x)[1]
+
+        maxpool2d_module = MaxPool2dModule(3, 1, 0, 1)
+        model_inputs = (torch.randn(4, 3, 24, 24),)
+
+        self.lower_and_test_with_partitioner(
+            maxpool2d_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_max_dim_vals(self):
+        class MaxModule(torch.nn.Module):
+            def __init__(
+                self,
+            ):
+                super().__init__()
+
+            def forward(self, x):
+                max_vals, _ = torch.max(x, dim=3, keepdim=True)
+                return max_vals
+
+        model_inputs = (torch.randn(16, 3, 12, 12),)
+        max_dim_module = MaxModule()
+
+        self.lower_and_test_with_partitioner(
+            max_dim_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_max_dim(self):
+        class MaxModule(torch.nn.Module):
+            def __init__(
+                self,
+            ):
+                super().__init__()
+
+            def forward(self, x):
+                x = torch.add(x, x)
+                max_values_1, max_indices_1 = torch.max(x, dim=2, keepdim=True)
+                max_values_2, max_indices_2 = torch.max(x, dim=3, keepdim=True)
+                return (max_values_1, max_indices_1, max_values_2, max_indices_2)
+
+        model_inputs = (torch.randn(16, 3, 12, 12),)
+        max_dim_module = MaxModule()
+
+        self.lower_and_test_with_partitioner(
+            max_dim_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_multiply(self):
+        class MulModule(torch.nn.Module):
+            def __init__(
+                self,
+            ):
+                super().__init__()
+                self.mul = torch.mul
+
+            def forward(self, x, y):
+                return self.mul(x, y)
+
+        mul_module = MulModule()
+        model_inputs = (
+            torch.randn((1, 8)),
+            torch.randn((8, 1)),
+        )
+
+        self.lower_and_test_with_partitioner(
+            mul_module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_sub(self):
+        class Sub(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.sub = torch.sub
+
+            def forward(self, x, y):
+                return self.sub(x, y)
+
+        module = Sub()
+        M = torch.randn(2, 3)
+        N = torch.randn(2, 3)
+        model_inputs = (
+            M,
+            N,
+        )
+        self.lower_and_test_with_partitioner(
+            module, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_clone(self):
+        model_inputs = (torch.randn(1, 3, 3),)
+        self.lower_and_test_with_partitioner(
+            torch.clone, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_floor(self):
+        model_inputs = (torch.randn(1, 3, 3),)
+        self.lower_and_test_with_partitioner(
+            torch.floor, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_sqrt(self):
+        model_inputs = (torch.randn(1, 3, 3).abs(),)
+        self.lower_and_test_with_partitioner(
+            torch.sqrt, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_ceil(self):
+        model_inputs = (torch.randn(1, 3, 3),)
+        self.lower_and_test_with_partitioner(
+            torch.ceil, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_hardswish(self):
+        model_inputs = (torch.randn(1, 3, 3),)
+
+        class HardswishModule(torch.nn.Module):
+            def __init__(self):
+                super(HardswishModule, self).__init__()
+                self.hardswish_out_of_place = torch.nn.Hardswish()
+                self.hardswish_in_place = torch.nn.Hardswish(inplace=True)
+                self.hardswish_functional = torch.nn.functional.hardswish
+
+            def forward(self, x):
+                a = self.hardswish_out_of_place(x)
+                a = self.hardswish_in_place(a)
+                a = self.hardswish_functional(a)
+                return a
+
+        # TODO(T158969708)
+        self.lower_and_test_with_partitioner(
+            HardswishModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_leaky_relu(self):
+        model_inputs = (torch.randn(1, 3, 3),)
+
+        class LeakyReLUModule(torch.nn.Module):
+            def __init__(self):
+                super(LeakyReLUModule, self).__init__()
+                self.leaky_relu_out_of_place = torch.nn.LeakyReLU(negative_slope=0.2)
+                self.leaky_relu_in_place = torch.nn.LeakyReLU(
+                    negative_slope=0.08, inplace=True
+                )
+                self.leaky_relu_functional_default = torch.nn.functional.leaky_relu
+
+            def forward(self, x):
+                a = self.leaky_relu_out_of_place(x)
+                a = self.leaky_relu_in_place(a)
+                a = self.leaky_relu_functional_default(a)
+                return a
+
+        self.lower_and_test_with_partitioner(
+            LeakyReLUModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_channels_last_tagged_reshape_pass_output(self):
+        op_sequences = OpSequencesAddConv2d(2, 2)
+        op_sequences.eval()
+
+        example_inputs = (torch.ones(1, 1, 6, 6),)
+
+        self.lower_and_test_with_partitioner(
+            op_sequences, example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_conv2d_bn_hardtanh_mean_sequence(self):
+        """
+        This test makes sure that we can fuse batchnorm and hardtanh
+        even with inserting copy nodes at some spots in the graph to change
+        memory format
+        """
+        groups = 1
+        stride = [2, 2]
+        padding = [1, 1]
+        dilation = [1, 1]
+        in_channels = 2
+        out_channels = 1
+        width = 8
+        height = 8
+        batches = 1
+        example_inputs = (torch.randn(batches, in_channels, height, width),)
+
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super(TestModule, self).__init__()
+                self.conv = torch.nn.Conv2d(
+                    in_channels=in_channels,
+                    out_channels=out_channels,
+                    kernel_size=(3, 3),
+                    stride=stride,
+                    padding=padding,
+                    groups=groups,
+                    dilation=dilation,
+                    bias=True,
+                )
+                self.native_batchnorm = torch.nn.BatchNorm2d(out_channels)
+                self.hardtanh = torch.nn.Hardtanh(min_val=0, max_val=6)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = self.native_batchnorm(x)
+                x = self.hardtanh(x)
+                x = torch.mean(x, (-1, -2), keepdim=True)
+                return x
+
+        test_module = TestModule()
+        test_module.eval()
+        self.lower_and_test_with_partitioner(
+            test_module, example_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    @unittest.expectedFailure
+    def test_mps_backend_maximum_no_broadcast(self):
+        model_inputs_no_broadcast = (torch.randn(2, 3, 4), torch.randn(2, 3, 4))
+
+        self.lower_and_test_with_partitioner(
+            torch.maximum,
+            model_inputs_no_broadcast,
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    @unittest.expectedFailure
+    def test_mps_backend_maximum_broadcast(self):
+        model_inputs_broadcast = (torch.randn(2, 3, 4), torch.randn(2, 1, 4))
+
+        self.lower_and_test_with_partitioner(
+            torch.maximum,
+            model_inputs_broadcast,
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    def test_mps_backend_negative(self):
+        model_inputs = (torch.randn(1, 3, 3),)
+
+        class NegModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.neg(x)
+
+        self.lower_and_test_with_partitioner(
+            NegModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_remainder_1(self):
+        model_inputs = (torch.randn(1, 3, 3), torch.randn(1, 3, 3))
+
+        class RemainderModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                return torch.remainder(x, y)
+
+        self.lower_and_test_with_partitioner(
+            RemainderModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_remainder_2(self):
+        model_inputs = (torch.randn(1, 3, 3),)
+
+        class RemainderModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.remainder(x, 0.5)
+
+        self.lower_and_test_with_partitioner(
+            RemainderModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_square(self):
+        model_inputs = (torch.randn(1, 3, 3),)
+
+        class SquareModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.square(x)
+
+        self.lower_and_test_with_partitioner(
+            SquareModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_pow_1(self):
+        model_inputs = (torch.randn(1, 3, 3),)
+
+        class PowModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.pow(x, 4)
+
+        self.lower_and_test_with_partitioner(
+            PowModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_pow_2(self):
+        model_inputs = (torch.randn(1, 3, 3), torch.tensor(4))
+
+        class PowModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                return torch.pow(x, y)
+
+        self.lower_and_test_with_partitioner(
+            PowModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_elu(self):
+        model_inputs = (torch.randn(1, 3, 3),)
+
+        class ELUModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.square(x)
+
+        self.lower_and_test_with_partitioner(
+            ELUModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_avg_pool_2d_1(self):
+        model_inputs = (torch.randn(1, 1, 10, 10),)
+
+        class AvgPoolModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.avgPool = torch.nn.AvgPool2d(
+                    kernel_size=(2, 2),
+                    padding=(1, 1),
+                    stride=(2, 2),
+                    count_include_pad=False,
+                )
+
+            def forward(self, x):
+                return self.avgPool(x)
+
+        self.lower_and_test_with_partitioner(
+            AvgPoolModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_avg_pool_2d_2(self):
+        model_inputs = (torch.randn(1, 1, 10, 10),)
+
+        class AvgPoolModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.avgPool = torch.nn.AvgPool2d(
+                    kernel_size=(2, 2),
+                    padding=(1, 1),
+                    stride=(2, 2),
+                    count_include_pad=True,
+                )
+
+            def forward(self, x):
+                return self.avgPool(x)
+
+        self.lower_and_test_with_partitioner(
+            AvgPoolModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_avg_pool_2d_3(self):
+        model_inputs = (torch.randn(1, 1, 10, 10),)
+
+        class AvgPoolModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.avgPool = torch.nn.AvgPool2d(
+                    kernel_size=(2, 2),
+                    padding=(1, 1),
+                    stride=(2, 2),
+                    count_include_pad=False,
+                    ceil_mode=True,
+                    divisor_override=4,
+                )
+
+            def forward(self, x):
+                return self.avgPool(x)
+
+        self.lower_and_test_with_partitioner(
+            AvgPoolModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_abs(self):
+        model_inputs = (torch.randn(1, 3, 3),)
+
+        class AbsModule(torch.nn.Module):
+            def forward(self, x):
+                return torch.abs(x)
+
+        self.lower_and_test_with_partitioner(
+            AbsModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_sign(self):
+        model_inputs = (torch.randn(1, 3, 3),)
+
+        class SignModule(torch.nn.Module):
+            def forward(self, x):
+                return torch.sign(x)
+
+        self.lower_and_test_with_partitioner(
+            SignModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_rsqrt(self):
+        model_inputs = (torch.randn(1, 3, 3).abs(),)
+
+        class RsqrtModule(torch.nn.Module):
+            def forward(self, x):
+                return torch.rsqrt(x)
+
+        self.lower_and_test_with_partitioner(
+            RsqrtModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_prelu(self):
+        num_channels = 5
+        model_inputs = (torch.randn(1, num_channels, 3, 2),)
+
+        class PReLUModule(torch.nn.Module):
+            def __init__(self):
+                super(PReLUModule, self).__init__()
+                self.prelu = torch.nn.PReLU()
+                self.prelu_non_default = torch.nn.PReLU(
+                    num_parameters=num_channels, init=0.2
+                )
+
+            def forward(self, x):
+                a = self.prelu(x)
+                a = self.prelu_non_default(a)
+                return a
+
+        self.lower_and_test_with_partitioner(
+            PReLUModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+        # Should fail to be partitioned since constraint (input dim) is violated
+        self.assertRaises(
+            Exception,
+            self.lower_and_test_with_partitioner,
+            torch.nn.PReLU(),
+            (torch.randn(1, 2),),
+        )
+
+    def test_mps_backend_concatenate2(self):
+        class Concat(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.cat((y, x), 0)
+
+        self.lower_and_test_with_partitioner(
+            Concat(),
+            (torch.ones(4, 2, 3), torch.randn(1, 2, 3)),
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    def test_mps_backend_concatenate3(self):
+        class Concat(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.concat((y, y, x), 0)
+
+        self.lower_and_test_with_partitioner(
+            Concat(),
+            (torch.ones(4, 2, 3), torch.randn(1, 2, 3)),
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    def test_mps_backend_concatenate4(self):
+        class Concat(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.concatenate((y, x, y, x), 2)
+
+        self.lower_and_test_with_partitioner(
+            Concat(),
+            (torch.randn(1, 2, 3), torch.randn(1, 2, 5)),
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    def test_mps_backend_concatenate_nhwc(self):
+        class Concat(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(
+                    in_channels=1,
+                    out_channels=3,
+                    kernel_size=(3, 3),
+                    padding=1,
+                    bias=False,
+                )
+
+            def forward(self, x, y):
+                x = self.conv(x)
+                return torch.concatenate((y, x, y, x), 1)
+
+        self.lower_and_test_with_partitioner(
+            Concat(),
+            (torch.randn(1, 1, 3, 3), torch.randn(1, 1, 3, 3)),
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    def test_mps_backend_concatenate_nhwc2(self):
+        class Concat(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(
+                    in_channels=1,
+                    out_channels=3,
+                    kernel_size=(3, 3),
+                    padding=1,
+                    bias=False,
+                )
+
+            def forward(self, x, y):
+                x = self.conv(x)
+                y = self.conv(y)
+                return torch.concatenate((y, x, y, x), 3)
+
+        self.lower_and_test_with_partitioner(
+            Concat(),
+            (torch.randn(1, 1, 3, 3), torch.randn(1, 1, 3, 3)),
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    def test_mps_backend_slice_copy(self):
+        class Slice(torch.nn.Module):
+            def forward(self, x):
+                return x[1:3, -2:, :-1]
+
+        self.lower_and_test_with_partitioner(
+            Slice(), (torch.randn(5, 5, 5),), func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_slice_copy_stride_non_1(self):
+        class Slice(torch.nn.Module):
+            def forward(self, x):
+                return x[:3:-1, 2:, :3]
+
+        self.assertRaises(
+            Exception,
+            self.lower_and_test_with_partitioner,
+            Slice(),
+            (torch.randn(5, 5, 5),),
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    def test_mps_backend_slice_copy_dim_0(self):
+        class Slice(torch.nn.Module):
+            def forward(self, x):
+                return x[-1:3, 2:, 3:3]
+
+        self.lower_module_and_test_output(
+            Slice(),
+            (torch.randn(5, 5, 5),),
+            use_partitioner=False,
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    def test_mps_backend_slice_copy_memory_format(self):
+        class ConvSlice(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(
+                    in_channels=1,
+                    out_channels=3,
+                    kernel_size=(3, 3),
+                    padding=1,
+                    bias=False,
+                )
+
+            def forward(self, x):
+                y = self.conv(x)
+                return y[:, :, 2:3, -2:]
+
+        self.lower_and_test_with_partitioner(
+            ConvSlice(),
+            (torch.randn(1, 1, 3, 3),),
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    def test_mps_backend_bitwise_and(self):
+        model_inputs = (
+            torch.tensor([-1, -2, 3], dtype=torch.int8),
+            torch.tensor([1, 0, 3], dtype=torch.int8),
+        )
+        self.lower_and_test_with_partitioner(
+            torch.bitwise_and, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_bitwise_or(self):
+        model_inputs = (
+            torch.tensor([-1, -2, 3], dtype=torch.int8),
+            torch.tensor([1, 0, 3], dtype=torch.int8),
+        )
+        self.lower_and_test_with_partitioner(
+            torch.bitwise_or, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_bitwise_xor(self):
+        model_inputs = (
+            torch.tensor([True, True, False]),
+            torch.tensor([False, True, False]),
+        )
+        self.lower_and_test_with_partitioner(
+            torch.bitwise_xor, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_bitwise_not(self):
+        model_inputs = (torch.tensor([-1, -2, 3], dtype=torch.int8),)
+        self.lower_and_test_with_partitioner(
+            torch.bitwise_not, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_bitwise_not_with_bool(self):
+        model_inputs = (torch.tensor([True, True, False]),)
+        self.lower_and_test_with_partitioner(
+            torch.bitwise_not, model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_bitwise_with_scalar(self):
+        class BitwiseScalarModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._scalar = 3
+
+            def forward(self, x):
+                out1 = torch.ops.aten.bitwise_and.Scalar(x, self._scalar)
+                return out1
+
+        model_inputs = (torch.tensor([-1, -2, 3], dtype=torch.int8),)
+        self.lower_and_test_with_partitioner(
+            BitwiseScalarModule(),
+            model_inputs,
+            func_name=inspect.stack()[0].function[5:],
+        )
+
+    def test_mps_backend_arange(self):
+        class ArangeModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._begin = 2.5
+                self._end = 5
+                self._step = 0.5
+
+            def forward(self):
+                out1 = torch.arange(end=self._end)
+                out2 = torch.arange(start=self._begin, end=self._end, step=self._step)
+                return out1 + out2
+
+        self.lower_and_test_with_partitioner(
+            ArangeModule(), (), func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_where(self):
+        x = torch.randn(3, 2)
+        y = torch.ones(3, 2)
+        cond = x > 0
+        module_inputs = (cond, x, y)
+        self.lower_and_test_with_partitioner(
+            torch.where, module_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_scalar_tensor(self):
+        class ScalarTensorModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._scalar = 3.0
+                self._bool = True
+
+            def forward(self):
+                out1 = torch.ops.aten.scalar_tensor(self._scalar)
+                out2 = torch.ops.aten.scalar_tensor(self._scalar, dtype=torch.int32)
+                out3 = torch.ops.aten.scalar_tensor(self._bool, dtype=torch.bool)
+                return out1 + out2 + out3
+
+        self.lower_and_test_with_partitioner(
+            ScalarTensorModule(), (), func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_tril(self):
+        class TrilModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._k = 1
+                self._negK = -1
+
+            def forward(self, x):
+                out1 = torch.tril(x, diagonal=self._k)
+                out2 = torch.tril(x, diagonal=self._negK)
+                return out1 + out2
+
+        model_inputs = (torch.randn(4, 6),)
+        self.lower_and_test_with_partitioner(
+            TrilModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def test_mps_backend_embedding(self):
+        class EmbeddingModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._embedding = torch.nn.Embedding(10, 3)
+                self._embedding_with_padding = torch.nn.Embedding(10, 3, padding_idx=2)
+
+            def forward(self, x):
+                return self._embedding(x) + self._embedding_with_padding(x)
+
+        model_inputs = (torch.tensor([[1, 2, 4, 5], [4, 3, 2, 9]]),)
+        self.lower_and_test_with_partitioner(
+            EmbeddingModule(), model_inputs, func_name=inspect.stack()[0].function[5:]
+        )

--- a/backends/apple/mps/test/test_mps_models.py
+++ b/backends/apple/mps/test/test_mps_models.py
@@ -1,0 +1,416 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+import random
+
+import executorch.exir.control_flow as control_flow
+import torch
+from functorch.experimental.control_flow import cond
+from torch import nn
+
+
+class LayerNormModule(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.norm = torch.nn.LayerNorm([5, 10, 10])
+
+    def forward(self, arg):
+        return self.norm(arg)
+
+    @staticmethod
+    def get_example_inputs():
+        return (torch.randn(20, 5, 10, 10),)
+
+
+class Conv2DModule(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(1, 3, 3, stride=1)
+
+    def forward(self, arg):
+        return self.conv(arg)
+
+    @staticmethod
+    def get_example_inputs():
+        return (torch.randn(1, 1, 3, 3),)
+
+
+class ModuleBasic(torch.nn.Module):
+    def __init__(self):
+        super(ModuleBasic, self).__init__()
+
+    def forward(self, x):
+        return torch.sin(x).max()
+
+    def get_random_inputs(self):
+        return (torch.randn(100),)
+
+
+class ModuleOpsReturnMulti(torch.nn.Module):
+    def __init__(self):
+        super(ModuleOpsReturnMulti, self).__init__()
+
+    def forward(self, a, b):
+        x, y = torch.topk(a, 3)
+        return x * 2 + b
+
+    def get_random_inputs(self):
+        return (torch.randn(10), torch.randn(3))
+
+
+class ModuleAdd(torch.nn.Module):
+    def __init__(self):
+        super(ModuleAdd, self).__init__()
+
+    def forward(self, x, y):
+        return torch.add(x, y)
+
+    def get_random_inputs(self):
+        return (torch.randn(2, 2), torch.randn(2, 2))
+
+
+class ModuleFloatAddWithAlpha(torch.nn.Module):
+    def __init__(self):
+        super(ModuleFloatAddWithAlpha, self).__init__()
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor, c: float):
+        return torch.add(x, y, alpha=c)
+
+    def get_random_inputs(self):
+        return (torch.randn(2, 2), torch.randn(2, 2), random.random())
+
+
+class ModuleIntAddWithAlpha(torch.nn.Module):
+    def __init__(self):
+        super(ModuleIntAddWithAlpha, self).__init__()
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor, c: int):
+        return torch.add(x, y, alpha=c)
+
+    def get_random_inputs(self):
+        return (
+            torch.randint(0, 10, (2, 2)),
+            torch.randint(0, 10, (2, 2)),
+            random.randint(0, 10),
+        )
+
+
+class ModuleContainers(torch.nn.Module):
+    def __init__(self):
+        super(ModuleContainers, self).__init__()
+
+    def forward(self, d):
+        a = d["a"]
+        b = d["b"]
+        return {"inputs": (a, b), "c": torch.add(a, b)}
+
+    def get_random_inputs(self):
+        return ({"a": torch.randn(2, 2), "b": torch.randn(2, 2)},)
+
+
+class ToyModelForMemPlanning(torch.nn.Module):
+    def __init__(self):
+        super(ToyModelForMemPlanning, self).__init__()
+
+    def forward(self, a, b):
+        o = a
+        for _ in range(3):
+            o = o * a
+            o = o + b
+        return o
+
+    def get_random_inputs(self):
+        return (
+            torch.randn(10),
+            torch.randn(10),
+        )
+
+
+class MemPlanningWithScratchTensor(torch.nn.Module):
+    def __init__(self):
+        super(MemPlanningWithScratchTensor, self).__init__()
+        self.linear1 = torch.nn.Linear(4, 2)
+        self.linear2 = torch.nn.Linear(4, 2)
+
+    def forward(self, a, b):
+        o1 = self.linear1(a)
+        o2 = self.linear2(b)
+        return o1 + o2
+
+    def get_random_inputs(self):
+        return (
+            torch.randn(10, 4),
+            torch.randn(10, 4),
+        )
+
+
+class ModuleOpsReturnTensorList(torch.nn.Module):
+    def __init__(self):
+        super(ModuleOpsReturnTensorList, self).__init__()
+
+    def forward(self, x):
+        split = torch.ops.aten.tensor_split.sections(x, 3)
+        return split[0]
+
+    def get_random_inputs(self):
+        return (torch.randn(100),)
+
+
+class ModuleReturnInput(torch.nn.Module):
+    def __init__(self):
+        super(ModuleReturnInput, self).__init__()
+
+    def forward(self, x):
+        return (x, x, {"x": x, "y": x}, [x, x, x])
+
+    def get_random_inputs(self):
+        return (torch.randn(1),)
+
+
+class ModuleIfElse(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, c, x):
+        x = x * x
+
+        def addloop(x, n):
+            out = x
+            for _ in range(n - 1):
+                out = out + x
+            return out
+
+        def true_branch(c, x):
+            return addloop(x, 3)
+
+        def false_branch(c, x):
+            return addloop(x, 4)
+
+        y = cond(c, true_branch, false_branch, (c, x))
+        return y * y
+
+    def get_random_inputs(self):
+        return (torch.randint(2, [1]) == 0, torch.randn(10))
+
+
+class ModuleIfElseWithBoolInput(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, c: bool, x: torch.Tensor):
+        x = x * x
+
+        def addloop(x, n):
+            out = x
+            for _ in range(n - 1):
+                out = out + x
+            return out
+
+        def true_branch(c, x):
+            return addloop(x, 3)
+
+        def false_branch(c, x):
+            return addloop(x, 4)
+
+        y = cond(c, true_branch, false_branch, (c, x))
+
+        return y * y
+
+    def get_random_inputs(self):
+        return (random.randint(0, 1) == 0, torch.randn(10))
+
+
+class ModuleWhileIf(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, accum, cnt):
+        @control_flow.tracing_context(
+            inputs=(torch.zeros([1]).to(dtype=torch.long), torch.randint(10, 100, [1]))
+        )
+        def loop_cond(accum, cnt):
+            return cnt != torch.zeros([1]).to(dtype=torch.long)
+
+        @control_flow.tracing_context(
+            inputs=(torch.zeros([1]).to(dtype=torch.long), torch.randint(10, 100, [1]))
+        )
+        def loop_body(accum, cnt):
+            # return accum + cnt, cnt - torch.ones([1]).to(dtype=torch.long)
+            @control_flow.tracing_context(
+                inputs=(torch.zeros([1]).to(dtype=torch.long),)
+            )
+            def true_branch(cnt):
+                return cnt
+
+            @control_flow.tracing_context(
+                inputs=(torch.zeros([1]).to(dtype=torch.long),)
+            )
+            def false_branch(cnt):
+                return torch.zeros([1], dtype=torch.long)
+
+            accum = accum + cond(
+                torch.BoolTensor([True]), true_branch, false_branch, (cnt,)
+            )
+            # 'cnt - 1' does not work yet since the runtime does not expect
+            # tensor to be mixed with scalar for sub op.
+            return accum, cnt - torch.ones([1]).to(dtype=torch.long)
+
+        y, _ = control_flow.while_loop(
+            loop_cond,
+            loop_body,
+            (accum, cnt),
+        )
+        return y
+
+    def get_random_inputs(self):
+        return (torch.zeros([1]).to(dtype=torch.long), torch.randint(10, 100, [1]))
+
+
+class ModuleIfWhile(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, accum, cnt):
+        @control_flow.tracing_context(
+            inputs=(torch.zeros([1]).to(dtype=torch.long), torch.randint(10, 100, [1]))
+        )
+        def true_branch(accum, cnt):
+            @control_flow.tracing_context(
+                inputs=(
+                    torch.zeros([1]).to(dtype=torch.long),
+                    torch.randint(10, 100, [1]),
+                )
+            )
+            def loop_cond(accum, cnt):
+                return cnt != torch.zeros([1]).to(dtype=torch.long)
+
+            @control_flow.tracing_context(
+                inputs=(
+                    torch.zeros([1]).to(dtype=torch.long),
+                    torch.randint(10, 100, [1]),
+                )
+            )
+            def loop_body(accum, cnt):
+                return accum + cnt, cnt - torch.ones([1]).to(dtype=torch.long)
+
+            return control_flow.while_loop(loop_cond, loop_body, (accum, cnt))
+
+        @control_flow.tracing_context(
+            inputs=(torch.zeros([1]).to(dtype=torch.long), torch.randint(10, 100, [1]))
+        )
+        def false_branch(accum, cnt):
+            return accum, cnt
+
+        return cond(torch.BoolTensor([True]), true_branch, false_branch, (accum, cnt))[
+            0
+        ]
+
+    def get_random_inputs(self):
+        return (torch.zeros([1]).to(dtype=torch.long), torch.randint(10, 100, [1]))
+
+
+class ModuleContiguousTensor(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(8, 32)
+
+    def forward(self, arg):
+        return self.linear(arg)
+
+    def get_random_inputs(self):
+        return (torch.randn(3, 8),)
+
+
+class ModuleInputDynamicShape(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        for _ in range(4):
+            x = x + x
+            x = x * x
+        return x
+
+    def get_upper_bound_inputs(self):
+        return (torch.randn(10),)
+
+    def get_random_inputs(self):
+        n = random.randint(1, 10)
+        return (torch.randn(n),)
+
+
+class ModuleIntermediateDynamicShape(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        x = x * x
+
+        # We should use x[torch.nonzero(x)] ideally, but index op is not supported
+        # in the runtime so far.
+        x = torch.nonzero(x)
+        return x + x
+
+    def get_random_inputs(self):
+        return (torch.randint(0, 2, (10,), dtype=torch.float),)
+
+
+MPS_MODEL_NAME_TO_MODEL = {
+    "conv2D": lambda: (Conv2DModule(), Conv2DModule.get_example_inputs()),
+    "norm": lambda: (LayerNormModule(), LayerNormModule.get_example_inputs()),
+    "module_basic": lambda: (ModuleBasic(), ModuleBasic().get_random_inputs()),
+    "module_ops_return_multi": lambda: (
+        ModuleOpsReturnMulti(),
+        ModuleOpsReturnMulti().get_random_inputs(),
+    ),
+    "module_add": lambda: (ModuleAdd(), ModuleAdd().get_random_inputs()),
+    "module_float_add_with_alpha": lambda: (
+        ModuleFloatAddWithAlpha(),
+        ModuleFloatAddWithAlpha().get_random_inputs(),
+    ),
+    "module_int_add_with_alpha": lambda: (
+        ModuleIntAddWithAlpha(),
+        ModuleIntAddWithAlpha().get_random_inputs(),
+    ),
+    "module_containers": lambda: (
+        ModuleContainers(),
+        ModuleContainers().get_random_inputs(),
+    ),
+    "toy_model_for_mem_planning": lambda: (
+        ToyModelForMemPlanning(),
+        ToyModelForMemPlanning().get_random_inputs(),
+    ),
+    "mem_planning_with_scratch_tensor": lambda: (
+        MemPlanningWithScratchTensor(),
+        MemPlanningWithScratchTensor().get_random_inputs(),
+    ),
+    "module_ops_return_tensor_list": lambda: (
+        ModuleOpsReturnTensorList(),
+        ModuleOpsReturnTensorList().get_random_inputs(),
+    ),
+    "module_return_input": lambda: (
+        ModuleReturnInput(),
+        ModuleReturnInput().get_random_inputs(),
+    ),
+    "module_if_else": lambda: (ModuleIfElse(), ModuleIfElse().get_random_inputs()),
+    "module_if_else_with_bool_input": lambda: (
+        ModuleIfElseWithBoolInput(),
+        ModuleIfElseWithBoolInput().get_random_inputs(),
+    ),
+    "module_while_if": lambda: (ModuleWhileIf(), ModuleWhileIf().get_random_inputs()),
+    "module_if_while": lambda: (ModuleIfWhile(), ModuleIfWhile().get_random_inputs()),
+    "module_contiguous_tensor": lambda: (
+        ModuleContiguousTensor(),
+        ModuleContiguousTensor().get_random_inputs(),
+    ),
+    "module_input_dynamic_shape": lambda: (
+        ModuleInputDynamicShape(),
+        ModuleInputDynamicShape().get_random_inputs(),
+    ),
+    "module_intermediate_dynamic_shape": lambda: (
+        ModuleIntermediateDynamicShape(),
+        ModuleIntermediateDynamicShape().get_random_inputs(),
+    ),
+}

--- a/backends/apple/mps/test/test_mps_utils.py
+++ b/backends/apple/mps/test/test_mps_utils.py
@@ -1,0 +1,231 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+import logging
+import unittest
+
+from typing import Any, Tuple
+
+import executorch.exir as exir
+
+import torch
+from executorch.backends.apple.mps.mps_preprocess import MPSBackend
+from executorch.bundled_program.config import BundledConfig
+from executorch.bundled_program.core import create_bundled_program
+from executorch.bundled_program.serialize import (
+    serialize_from_bundled_program_to_flatbuffer,
+)
+from executorch.exir import ExecutorchProgram, ExirExportedProgram
+from executorch.exir.backend.backend_api import to_backend, validation_disabled
+
+from executorch.exir.print_program import print_program
+
+# Config for Capturing the weights, will be moved in the future
+_CAPTURE_CONFIG = exir.CaptureConfig(enable_aot=True, _unlift=True)
+_EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(_check_ir_validity=False)
+
+
+class ansi_colors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+
+def dump_executorch_program_info(
+    edge: ExirExportedProgram, module_info: str = "Lowered"
+):
+    module_info = f"\033[92m{module_info}\033[0m"
+
+    logging.info("-----------------------------------")
+    logging.info(f"{module_info} exported edge graph:\n", edge.exported_program.graph)
+    executorch_program = edge.to_executorch()
+    program = executorch_program.program
+    logging.info("-----------------------------------")
+    logging.info(f"{module_info} flatbuffer representation:")
+    exir.print_program.pretty_print(program)
+    logging.info("-----------------------------------")
+    logging.info(f"{module_info} instruction list:")
+    print_program(program=program, show_meminfo=True, mark_dynamic_shape_tensor=True)
+    logging.info("-----------------------------------")
+    logging.info(f"{module_info} executorch program:")
+    logging.info(executorch_program.dump_exported_program())
+    logging.info("-----------------------------------")
+
+
+class OpSequencesAddConv2d(torch.nn.Module):
+    """
+    Module which include sequences of Memory Format sensitive ops. forward runs
+    [num_sequences] sequences of [ops_per_sequences] ops. Each sequence is
+    followed by an add to separate the sequences
+    """
+
+    def __init__(self, num_sequences, ops_per_sequence):
+        super().__init__()
+        self.num_ops = num_sequences * ops_per_sequence
+        self.num_sequences = num_sequences
+        self.op_sequence = [[] for _ in range(num_sequences)]
+        for seq in range(num_sequences):
+            for _ in range(ops_per_sequence):
+                self.op_sequence[seq].append(
+                    torch.nn.Conv2d(
+                        in_channels=1,
+                        out_channels=1,
+                        kernel_size=(3, 3),
+                        padding=1,
+                        bias=False,
+                    )
+                )
+
+    def forward(self, x):
+        for seq in self.op_sequence:
+            for op in seq:
+                x = op(x)
+            x = x + x
+        return x + x
+
+
+def randomize_bn(num_features: int, dimensionality: int = 2) -> torch.nn.Module:
+    if dimensionality == 1:
+        bn = torch.nn.BatchNorm1d(num_features)
+        input_size = (1, num_features, 5)
+    elif dimensionality == 2:
+        bn = torch.nn.BatchNorm2d(num_features)
+        input_size = (1, num_features, 5, 5)
+    else:
+        raise AssertionError(
+            f"Only dimensionality 1 or 2 supported in randomize_bn, got {dimensionality}"
+        )
+
+    bn.weight = torch.nn.Parameter(torch.randn(num_features))
+    bn.bias = torch.nn.Parameter(torch.randn(num_features))
+
+    for _ in range(5):
+        bn(torch.randn(size=input_size))
+
+    return bn
+
+
+class TestMPS(unittest.TestCase):
+    def lower_module_and_test_output(
+        self,
+        module: Any,
+        sample_inputs: Tuple[torch.Tensor],
+        func_name: str,
+        use_partitioner: bool = False,
+        dump_non_lowered_module: bool = False,
+        dump_lowered_module: bool = False,
+    ) -> ExirExportedProgram:
+        """
+        Helper testing function that takes a torch.nn.Module and lowers it to XNNPACK with
+        the given sample inputs. It then runs the lowered module and compares its
+        outputs with the outputs of the eager module.
+        """
+
+        logging.info("Step 1: EXIR capturing of original module...")
+
+        class WrappedModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.one_module = module
+
+            def forward(self, *args):
+                return self.one_module(*args)
+
+        edge_program = exir.capture(
+            WrappedModule(), sample_inputs, _CAPTURE_CONFIG
+        ).to_edge(_EDGE_COMPILE_CONFIG)
+
+        if dump_non_lowered_module:
+            dump_executorch_program_info(edge=edge_program, module_info="Non-lowered")
+
+        logging.info("Step 2: Lowering to MPSGraph...")
+        if use_partitioner:
+            with validation_disabled():
+                None
+        else:
+            delegated_program = to_backend(
+                "MPSBackend", edge_program.exported_program, []
+            )
+
+        logging.info("Step 3: Capturing executorch program with lowered module...")
+
+        class WrappedModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mps_module = delegated_program
+
+            def forward(self, *args):
+                return self.mps_module(*args)
+
+        exported_program: ExirExportedProgram = exir.capture(
+            WrappedModule(), sample_inputs, _CAPTURE_CONFIG
+        ).to_edge(_EDGE_COMPILE_CONFIG)
+
+        if dump_lowered_module:
+            tmp_exported_program: ExirExportedProgram = exir.capture(
+                delegated_program, sample_inputs, _CAPTURE_CONFIG
+            ).to_edge(_EDGE_COMPILE_CONFIG)
+            dump_executorch_program_info(
+                edge=tmp_exported_program, module_info="Lowered"
+            )
+
+        executorch_program: ExecutorchProgram = exported_program.to_executorch()
+
+        # Assert the backend name is mps
+        self.assertEqual(
+            executorch_program.program.execution_plan[0].delegates[0].id,
+            MPSBackend.__name__,
+        )
+
+        logging.info("Step 4: Generating bundled program...")
+        logging.info(
+            "  -> Number of execution plans: {len(executorch_program.program.execution_plan)}"
+        )
+        bundled_inputs = [
+            [sample_inputs]
+            for _ in range(len(executorch_program.program.execution_plan))
+        ]
+        logging.info("  -> Bundled inputs generated successfully")
+
+        output = module(*sample_inputs)
+        expected_outputs = [
+            [[output]] for _ in range(len(executorch_program.program.execution_plan))
+        ]
+        logging.info("  -> Bundled outputs generated successfully")
+
+        method_names = ["forward"]
+        bundled_config = BundledConfig(method_names, bundled_inputs, expected_outputs)
+        bundled_program = create_bundled_program(
+            executorch_program.program, bundled_config
+        )
+        bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
+            bundled_program
+        )
+
+        filename = f"{func_name}.pte"
+        logging.info(f"Step 5: Saving bundled program to {filename}...")
+        with open(filename, "wb") as file:
+            file.write(bundled_program_buffer)
+
+    def lower_and_test_with_partitioner(
+        self,
+        graph_module,
+        example_inputs,
+        func_name: str,
+    ):
+        logging.info(func_name)
+        # MPS TODO: partitioner support
+        self.lower_module_and_test_output(
+            graph_module,
+            example_inputs,
+            use_partitioner=False,
+            func_name=func_name,
+        )

--- a/backends/apple/mps/utils/Bindings.mm
+++ b/backends/apple/mps/utils/Bindings.mm
@@ -1,0 +1,345 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "MPSGraphInterface.h"
+
+namespace mps {
+namespace {
+using namespace torch;
+// Create Python bindings for the Objective-C++ code.
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  // Main class to interface with MPSGraph.
+  py::class_<MPSGraphModule>(m, "MPSGraphModule")
+    // MPSGraphModule constructor.
+    .def(py::init<>())
+
+    //
+    // Graph placeholders.
+    //
+    .def("mpsGraphUnrankedPlaceHolder", &MPSGraphModule::mpsGraphUnrankedPlaceHolder)
+    .def("mpsGraphRankedPlaceHolder",   &MPSGraphModule::mpsGraphRankedPlaceHolder)
+    .def("mpsGraphScalarPlaceHolder",   &MPSGraphModule::mpsGraphScalarPlaceHolder)
+    .def("set_outputs",  &MPSGraphModule::set_outputs)
+
+    //
+    // Graph operators
+    //
+    .def("constant", &MPSGraphModule::constant)
+    .def("constantTensor", &MPSGraphModule::constantTensor)
+    .def("full", &MPSGraphModule::full)
+    .def("full_like", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, double scalar) {
+      return  self.full_like(static_cast<MPSGraphTensor*>(inputTensor), scalar);
+    })
+    .def("mm", [](MPSGraphModule& self, PyMPSGraphTensor* primaryTensor, PyMPSGraphTensor* secondaryTensor) {
+      return  self.mm(static_cast<MPSGraphTensor*>(primaryTensor), static_cast<MPSGraphTensor*>(secondaryTensor));
+    })
+    .def("conv2D", [](MPSGraphModule& self, PyMPSGraphTensor* primaryTensor, PyMPSGraphTensor* secondaryTensor,
+                      std::optional<PyMPSGraphTensor*> biasTensor, IntArrayRef stride, IntArrayRef padding, IntArrayRef dilation,
+                      bool transposed, IntArrayRef outputPadding, int64_t groups, bool is_depthwise) {
+      MPSGraphTensor *optionalBias = nullptr;
+      MPSGraphTensor *inputTensor = static_cast<MPSGraphTensor*>(primaryTensor);
+      if(biasTensor.has_value()){
+        optionalBias = static_cast<MPSGraphTensor*>(*biasTensor);
+      }
+      return self.conv2D(static_cast<MPSGraphTensor*>(primaryTensor), static_cast<MPSGraphTensor*>(secondaryTensor),
+                          optionalBias, stride, padding, dilation, transposed, outputPadding, groups, is_depthwise);
+    })
+    .def("maxPool2DWithIndices", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, IntArrayRef kernel_size,
+                                    IntArrayRef stride, IntArrayRef padding, IntArrayRef dilation, bool ceil_mode) {
+      return self.maxPool2DWithIndices(static_cast<MPSGraphTensor*>(inputTensor), kernel_size, stride, padding,
+                                      dilation, ceil_mode);
+    })
+    .def("avgPool2D", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, IntArrayRef kernel_size,
+                                    IntArrayRef stride, IntArrayRef padding, bool ceil_mode, bool count_include_pad,
+                                    c10::optional<int> divisor_override) {
+      return self.avgPool2D(static_cast<MPSGraphTensor*>(inputTensor), kernel_size, stride, padding,
+                                      ceil_mode, count_include_pad, divisor_override);
+
+    })
+    .def("batchNorm", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, PyMPSGraphTensor* weightTensor,
+                          PyMPSGraphTensor* biasTensor, PyMPSGraphTensor* meanTensor, PyMPSGraphTensor* varTensor,
+                          float momentum, float epsilon) {
+      std::tuple<PyMPSGraphTensor*, PyMPSGraphTensor*, PyMPSGraphTensor*> result = self.batchNorm(
+                            static_cast<MPSGraphTensor*>(inputTensor),
+                            static_cast<MPSGraphTensor*>(meanTensor),
+                            static_cast<MPSGraphTensor*>(varTensor),
+                            static_cast<MPSGraphTensor*>(weightTensor),
+                            static_cast<MPSGraphTensor*>(biasTensor),
+                            momentum, epsilon);
+      return result;
+
+    })
+    .def("layerNorm", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, IntArrayRef normalized_shape,
+                          c10::optional<PyMPSGraphTensor*> weightTensor_opt, c10::optional<PyMPSGraphTensor*> biasTensor_opt,
+                          float epsilon) {
+
+      MPSGraphTensor* weightTensor = nil;
+      MPSGraphTensor* biasTensor = nil;
+      if(weightTensor_opt.has_value()){
+        weightTensor = static_cast<MPSGraphTensor*>(*weightTensor_opt);
+      }
+      if(biasTensor_opt.has_value()){
+        biasTensor = static_cast<MPSGraphTensor*>(*biasTensor_opt);
+      }
+
+      std::tuple<PyMPSGraphTensor*, PyMPSGraphTensor*, PyMPSGraphTensor*> result = self.layerNorm(
+        static_cast<MPSGraphTensor*>(inputTensor), normalized_shape,
+        weightTensor, biasTensor, epsilon);
+
+      return result;
+    })
+    .def("hardTanh", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, float min_value, float max_value) {
+      return self.hardTanh(static_cast<MPSGraphTensor*>(inputTensor), min_value, max_value);
+    })
+    .def("mean", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, IntArrayRef dims, bool keep_dims) {
+      return self.mean(static_cast<MPSGraphTensor*>(inputTensor), dims, keep_dims);
+    })
+    .def("minDim", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int dim, bool keep_dims) {
+      return self.minDim(static_cast<MPSGraphTensor*>(inputTensor), dim, keep_dims);
+    })
+    .def("maxDim", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int dim, bool keep_dims) {
+      return self.maxDim(static_cast<MPSGraphTensor*>(inputTensor), dim, keep_dims);
+    })
+    .def("amax", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, IntArrayRef dims, bool keep_dims) {
+      return self.amax(static_cast<MPSGraphTensor*>(inputTensor), dims, keep_dims);
+    })
+    .def("amin", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, IntArrayRef dims, bool keep_dims) {
+      return self.amin(static_cast<MPSGraphTensor*>(inputTensor), dims, keep_dims);
+    })
+    .def("argmax", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int64_t dim, bool keep_dims, bool flatten) {
+      return self.argmax(static_cast<MPSGraphTensor*>(inputTensor), dim, keep_dims, flatten);
+    })
+    .def("argmin", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int64_t dim, bool keep_dims, bool flatten) {
+      return self.argmin(static_cast<MPSGraphTensor*>(inputTensor), dim, keep_dims, flatten);
+    })
+    .def("identity", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor) {
+      return self.identity(static_cast<MPSGraphTensor*>(inputTensor));
+    })
+    .def("clamp", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, float min, float max, bool use_min, bool use_max) {
+      return self.clamp(static_cast<MPSGraphTensor*>(inputTensor), min, max, use_min, use_max);
+    })
+    .def("relu", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor) {
+      return self.relu(static_cast<MPSGraphTensor*>(inputTensor));
+    })
+    .def("leaky_relu", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, float negative_slope) {
+      return self.leaky_relu(static_cast<MPSGraphTensor*>(inputTensor), negative_slope);
+    })
+    .def("softmax", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int dim, bool half_to_float) {
+      return self.softmax(static_cast<MPSGraphTensor*>(inputTensor), dim, half_to_float);
+    })
+    .def("log_softmax", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int dim, bool half_to_float) {
+      return self.log_softmax(static_cast<MPSGraphTensor*>(inputTensor), dim, half_to_float);
+    })
+    .def("squeeze", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor) {
+      return self.squeeze(static_cast<MPSGraphTensor*>(inputTensor));
+    })
+    .def("squeeze", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int dim) {
+      return self.squeeze(static_cast<MPSGraphTensor*>(inputTensor), dim);
+    })
+    .def("squeeze", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, IntArrayRef dims) {
+      return self.squeeze(static_cast<MPSGraphTensor*>(inputTensor), dims);
+    })
+    .def("unsqueeze", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int dimension) {
+      return self.unsqueeze(static_cast<MPSGraphTensor*>(inputTensor), dimension);
+    })
+    .def("gelu", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, const std::string &approximation) {
+      return self.gelu(static_cast<MPSGraphTensor*>(inputTensor), approximation);
+    })
+    .def("glu", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int64_t dim) {
+      return self.glu(static_cast<MPSGraphTensor*>(inputTensor), dim);
+    })
+    .def("pixel_shuffle", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int upscale_factor) {
+      return self.pixel_shuffle(static_cast<MPSGraphTensor*>(inputTensor), upscale_factor);
+    })
+    .def("split_size", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, IntArrayRef split_sizes, int dim) {
+      return self.split_size(static_cast<MPSGraphTensor*>(inputTensor), split_sizes, dim);
+    })
+    .def("split", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int split_size, int dim) {
+      return self.split(static_cast<MPSGraphTensor*>(inputTensor), split_size, dim);
+    })
+    .def("unbind", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int dim) {
+      return self.unbind(static_cast<MPSGraphTensor*>(inputTensor), dim);
+    })
+    .def("cat", [](MPSGraphModule& self,int dim, py::args catTensors) {
+      return self.cat(dim, catTensors);
+    })
+    .def("stack", [](MPSGraphModule& self,int dim, py::args stackTensors) {
+      return self.stack(dim, stackTensors);
+    })
+    .def("slice", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int64_t dim, c10::optional<int64_t> start, c10::optional<int64_t> end, int64_t step) {
+      return self.slice(static_cast<MPSGraphTensor*>(inputTensor), dim, start, end, step);
+    })
+    .def("expand", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, IntArrayRef sizes){
+      return self.expand(static_cast<MPSGraphTensor*>(inputTensor), sizes);
+    })
+    .def("select", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int dim, int index) {
+      return self.select(static_cast<MPSGraphTensor*>(inputTensor), dim, index);
+    })
+    .def("view", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, IntArrayRef shape){
+      return self.view(static_cast<MPSGraphTensor*>(inputTensor), shape);
+    })
+    .def("permute", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, IntArrayRef axes) {
+      return self.permute(static_cast<MPSGraphTensor*>(inputTensor), axes);
+    })
+    .def("cumsum", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int dim) {
+      return self.cumsum(static_cast<MPSGraphTensor*>(inputTensor), dim);
+    })
+    .def("addmm", [](MPSGraphModule& self, PyMPSGraphTensor* biasTensor,
+                    PyMPSGraphTensor* inputTensor, PyMPSGraphTensor* weightTensor,
+                    float beta, float alpha) {
+      return self.addmm(static_cast<MPSGraphTensor*>(biasTensor),
+                        static_cast<MPSGraphTensor*>(inputTensor),
+                        static_cast<MPSGraphTensor*>(weightTensor),
+                        beta, alpha);
+    })
+    .def("constant_pad_nd", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, IntArrayRef pad, const double value) {
+      return self.constant_pad_nd(static_cast<MPSGraphTensor*>(inputTensor), pad, value);
+    })
+    .def("add", [](MPSGraphModule& self, PyMPSGraphTensor* primaryTensor, PyMPSGraphTensor* secondaryTensor, float alpha) {
+      return self.additionWithTensor(static_cast<MPSGraphTensor*>(primaryTensor), static_cast<MPSGraphTensor*>(secondaryTensor), alpha);
+    })
+    .def("add", [](MPSGraphModule& self, PyMPSGraphTensor* primaryTensor, PyMPSGraphTensor* secondaryTensor, int alpha) {
+      return self.additionWithTensor(static_cast<MPSGraphTensor*>(primaryTensor), static_cast<MPSGraphTensor*>(secondaryTensor), alpha);
+    })
+    .def("sub", [](MPSGraphModule& self, PyMPSGraphTensor* primaryTensor, PyMPSGraphTensor* secondaryTensor, float alpha) {
+      return self.subtractionWithTensor(static_cast<MPSGraphTensor*>(primaryTensor), static_cast<MPSGraphTensor*>(secondaryTensor), alpha);
+    })
+    .def("sub", [](MPSGraphModule& self, PyMPSGraphTensor* primaryTensor, PyMPSGraphTensor* secondaryTensor, int alpha) {
+      return self.subtractionWithTensor(static_cast<MPSGraphTensor*>(primaryTensor), static_cast<MPSGraphTensor*>(secondaryTensor), alpha);
+    })
+    .def("mulWithScalar", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, float scalar) {
+      return self.multiplicationWithScalar(static_cast<MPSGraphTensor*>(inputTensor), scalar);
+    })
+    .def("mulWithScalar", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int scalar) {
+      return self.multiplicationWithScalar(static_cast<MPSGraphTensor*>(inputTensor), scalar);
+    })
+    .def("arange", [](MPSGraphModule& self, int64_t start, int64_t end, int64_t step,
+      MPSDataType dtype, int numOfElements) {
+      return self.arange(start, end, step, dtype, numOfElements);
+    })
+    .def("arange", [](MPSGraphModule& self, float start, float end, float step,
+      MPSDataType dtype, int numOfElements) {
+      return self.arange(start, end, step, dtype, numOfElements);
+    })
+    .def("where", [](MPSGraphModule& self, PyMPSGraphTensor* cond, PyMPSGraphTensor* input,
+       PyMPSGraphTensor* other) {
+      return self.where(static_cast<MPSGraphTensor*>(cond), static_cast<MPSGraphTensor*>(input),
+       static_cast<MPSGraphTensor*>(other));
+    })
+    .def("scalar_out", [](MPSGraphModule& self, double scalar, MPSDataType dtype) {
+      return self.constant(scalar, dtype);
+    })
+    .def("index_select", [](MPSGraphModule& self, PyMPSGraphTensor* inputTensor, int64_t dim, PyMPSGraphTensor* indexTensor) {
+      return self.index_select(static_cast<MPSGraphTensor*>(inputTensor), dim, static_cast<MPSGraphTensor*>(indexTensor));
+    })
+    .def("empty", [](MPSGraphModule& self, IntArrayRef sizes, MPSDataType dtype) {
+      return self.constantWithScalar(dtype, sizes, 0);
+    })
+    // Arithmetic Binary Ops
+    REGISTER_PYBIND11_MPS_BINARY_OP("add", addition)
+    REGISTER_PYBIND11_MPS_BINARY_OP("sub", subtraction)
+    REGISTER_PYBIND11_MPS_BINARY_OP("mul", multiplication)
+    REGISTER_PYBIND11_MPS_BINARY_OP("min", minimum)
+    REGISTER_PYBIND11_MPS_BINARY_OP("max", maximum)
+    REGISTER_PYBIND11_MPS_BINARY_OP("pow", power)
+    REGISTER_PYBIND11_MPS_BINARY_OP("remainder", modulo)
+    REGISTER_PYBIND11_MPS_BINARY_OP("atan2", atan2)
+    REGISTER_PYBIND11_MPS_BINARY_OP("bmm", matrixMultiplication)
+    REGISTER_PYBIND11_MPS_BINARY_OP("minimum", minimum)
+
+    // Comparison Ops
+    REGISTER_PYBIND11_MPS_BINARY_OP("eq", equal)
+    REGISTER_PYBIND11_MPS_BINARY_OP("ne", notEqual)
+    REGISTER_PYBIND11_MPS_BINARY_OP("ge", greaterThanOrEqualTo)
+    REGISTER_PYBIND11_MPS_BINARY_OP("gt", greaterThan)
+    REGISTER_PYBIND11_MPS_BINARY_OP("le", lessThanOrEqualTo)
+    REGISTER_PYBIND11_MPS_BINARY_OP("lt", lessThan)
+
+    // Bitwise Ops
+    REGISTER_PYBIND11_MPS_BITWISE_BINARY_OP("bitwise_and", AND)
+    REGISTER_PYBIND11_MPS_BITWISE_BINARY_OP("bitwise_or", OR)
+    REGISTER_PYBIND11_MPS_BITWISE_BINARY_OP("bitwise_xor", XOR)
+
+    .def("bitwise_not", [](MPSGraphModule& self, PyMPSGraphTensor* input) {
+      return self.bitwiseNotTensor(static_cast<MPSGraphTensor*>(input), "bitwise_not");
+    })
+
+    // Boolean Binary Ops
+    REGISTER_PYBIND11_MPS_BINARY_OP("eq", equal)
+    REGISTER_PYBIND11_MPS_BINARY_OP("ne", notEqual)
+    REGISTER_PYBIND11_MPS_BINARY_OP("le", lessThanOrEqualTo)
+    REGISTER_PYBIND11_MPS_BINARY_OP("lt", lessThan)
+    REGISTER_PYBIND11_MPS_BINARY_OP("ge", greaterThanOrEqualTo)
+    REGISTER_PYBIND11_MPS_BINARY_OP("gt", greaterThan)
+
+    // Unary Ops
+
+    REGISTER_PYBIND11_MPS_UNARY_OP("abs", absolute)
+    REGISTER_PYBIND11_MPS_UNARY_OP("exp", exponent)
+    REGISTER_PYBIND11_MPS_UNARY_OP("exp2", exponentBase2)
+    REGISTER_PYBIND11_MPS_UNARY_OP("reciprocal", reciprocal)
+    REGISTER_PYBIND11_MPS_UNARY_OP("sqrt", squareRoot)
+    REGISTER_PYBIND11_MPS_UNARY_OP("neg", negative)
+    REGISTER_PYBIND11_MPS_UNARY_OP("log", logarithm)
+    REGISTER_PYBIND11_MPS_UNARY_OP("log10", logarithmBase10)
+    REGISTER_PYBIND11_MPS_UNARY_OP("log2", logarithmBase2)
+    REGISTER_PYBIND11_MPS_UNARY_OP("erf", erf)
+    REGISTER_PYBIND11_MPS_UNARY_OP("floor", floor)
+    REGISTER_PYBIND11_MPS_UNARY_OP("ceil", ceil)
+    REGISTER_PYBIND11_MPS_UNARY_OP("rsqrt", reverseSquareRoot)
+    REGISTER_PYBIND11_MPS_UNARY_OP("sin", sin)
+    REGISTER_PYBIND11_MPS_UNARY_OP("sign", sign)
+    REGISTER_PYBIND11_MPS_UNARY_OP("sigmoid", sigmoid)
+    REGISTER_PYBIND11_MPS_UNARY_OP("cos", cos)
+    REGISTER_PYBIND11_MPS_UNARY_OP("tan", tan)
+    REGISTER_PYBIND11_MPS_UNARY_OP("asin", asin)
+    REGISTER_PYBIND11_MPS_UNARY_OP("acos", acos)
+    REGISTER_PYBIND11_MPS_UNARY_OP("atan", atan)
+    REGISTER_PYBIND11_MPS_UNARY_OP("sinh", sinh)
+    REGISTER_PYBIND11_MPS_UNARY_OP("cosh", cosh)
+    REGISTER_PYBIND11_MPS_UNARY_OP("tanh", tanh)
+    REGISTER_PYBIND11_MPS_UNARY_OP("asinh", asinh)
+    REGISTER_PYBIND11_MPS_UNARY_OP("acosh", acosh)
+    REGISTER_PYBIND11_MPS_UNARY_OP("atanh", atanh)
+    REGISTER_PYBIND11_MPS_UNARY_OP("isinf", isInfinite)
+    REGISTER_PYBIND11_MPS_UNARY_OP("isnan", isNaN)
+    REGISTER_PYBIND11_MPS_UNARY_OP("round", round)
+
+    .def("div", [](MPSGraphModule& self, PyMPSGraphTensor* primaryTensor, PyMPSGraphTensor* secondaryTensor) {
+      return self.div_mode_template(static_cast<MPSGraphTensor*>(primaryTensor), static_cast<MPSGraphTensor*>(secondaryTensor), c10::nullopt, "div");
+    })
+    .def("fmod", [](MPSGraphModule& self, PyMPSGraphTensor* primaryTensor, PyMPSGraphTensor* secondaryTensor) {
+      return self.div_mode_template(static_cast<MPSGraphTensor*>(primaryTensor), static_cast<MPSGraphTensor*>(secondaryTensor), "trunc", "fmod_mps_out");
+    })
+    .def("floor_divide", [](MPSGraphModule& self, PyMPSGraphTensor* primaryTensor, PyMPSGraphTensor* secondaryTensor) {
+      return self.div_mode_template(static_cast<MPSGraphTensor*>(primaryTensor), static_cast<MPSGraphTensor*>(secondaryTensor), "floor", "floor_divide");
+    })
+
+    //
+    // Graph debug methods.
+    //
+    .def("printGraph", &MPSGraphModule::printGraph)
+
+    //
+    // Serialization / deserialization methods.
+    //
+    .def("serialize", &MPSGraphModule::serialize);
+
+  // Export `MPSDataType` Objective-C enum to python.
+  py::enum_<MPSDataType>(m, "MPSDataType")
+    .value("MPSDataTypeTypeInvalid", MPSDataType::MPSDataTypeFloatBit)
+    .value("MPSDataTypeFloat32",     MPSDataType::MPSDataTypeFloat32)
+    .value("MPSDataTypeFloat16",     MPSDataType::MPSDataTypeFloat16)
+    .value("MPSDataTypeInt32",       MPSDataType::MPSDataTypeInt32)
+    .value("MPSDataTypeInt64",       MPSDataType::MPSDataTypeInt64)
+    .value("MPSDataTypeInt16",       MPSDataType::MPSDataTypeInt16)
+    .value("MPSDataTypeInt8",        MPSDataType::MPSDataTypeInt8)
+    .value("MPSDataTypeUInt8",       MPSDataType::MPSDataTypeUInt8)
+    .value("MPSDataTypeBool",        MPSDataType::MPSDataTypeBool)
+    .export_values();
+}
+
+} // namespace
+} // namespace mps

--- a/backends/apple/mps/utils/MPSGraphInterface.h
+++ b/backends/apple/mps/utils/MPSGraphInterface.h
@@ -1,0 +1,259 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#pragma once
+
+#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
+#include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+#include <torch/torch.h>
+#include "OperationUtils.h"
+#include "operations/BinaryOps.h"
+#include "operations/UnaryOps.h"
+
+// Workaround for PyBind custom class return type.
+// We need a type caster
+// (https://pybind11.readthedocs.io/en/stable/advanced/cast/custom.html) for
+// MPSGraphTensor. Return `void*` for now instead of `MPSGraphTensor*`.
+typedef void PyMPSGraphTensor;
+
+namespace mps {
+
+using namespace torch;
+
+// ExecuTorch is supported only from macOS 14.0 and above
+// Previous macOS version don't have support to generate .mpsgraphpackage
+enum class MacOSVersion : uint32_t {
+  MACOS_VER_14_0_PLUS = 0,
+};
+
+class MPSGraphModule {
+ public:
+  MPSGraphModule();
+  ~MPSGraphModule();
+
+  // Graph placeholders.
+  PyMPSGraphTensor* mpsGraphUnrankedPlaceHolder(MPSDataType dataType);
+  PyMPSGraphTensor* mpsGraphRankedPlaceHolder(
+      MPSDataType dataType,
+      const IntArrayRef& shape);
+  PyMPSGraphTensor* mpsGraphScalarPlaceHolder(MPSDataType dataType);
+  void set_outputs(py::args args);
+
+  // Graph operators.
+  PyMPSGraphTensor* constant(double scalar, MPSDataType dataType);
+  PyMPSGraphTensor* constantTensor(
+      Tensor constant_tensor,
+      MPSDataType dataType);
+  PyMPSGraphTensor* constantWithScalar(
+      MPSDataType dtype,
+      const IntArrayRef& sizes,
+      double scalar);
+  PyMPSGraphTensor* full(IntArrayRef size, double scalar, MPSDataType dataType);
+  PyMPSGraphTensor* full_like(MPSGraphTensor* inputTensor, double scalar);
+  std::tuple<PyMPSGraphTensor*, PyMPSGraphTensor*, PyMPSGraphTensor*> batchNorm(
+      MPSGraphTensor* inputTensor,
+      MPSGraphTensor* meanTensor,
+      MPSGraphTensor* varTensor,
+      MPSGraphTensor* weightTensor,
+      MPSGraphTensor* biasTensor,
+      float momentum,
+      float epsilon);
+  std::tuple<PyMPSGraphTensor*, PyMPSGraphTensor*, PyMPSGraphTensor*> layerNorm(
+      MPSGraphTensor* inputTensor,
+      IntArrayRef normalized_shape,
+      MPSGraphTensor* weightTensor,
+      MPSGraphTensor* biasTensor,
+      float epsilon);
+  PyMPSGraphTensor* conv2D(
+      MPSGraphTensor* primaryTensor,
+      MPSGraphTensor* secondaryTensor,
+      MPSGraphTensor* bias,
+      IntArrayRef stride,
+      IntArrayRef padding,
+      IntArrayRef dilation,
+      bool transpose,
+      IntArrayRef outputPadding,
+      int64_t groups,
+      bool is_depthwise);
+  std::tuple<PyMPSGraphTensor*, PyMPSGraphTensor*> maxPool2DWithIndices(
+      MPSGraphTensor* inputTensor,
+      IntArrayRef kernel_size,
+      IntArrayRef stride,
+      IntArrayRef padding,
+      IntArrayRef dilation,
+      bool ceil_mode);
+  PyMPSGraphTensor* avgPool2D(
+      MPSGraphTensor* inputTensor,
+      IntArrayRef kernel_size,
+      IntArrayRef stride,
+      IntArrayRef padding,
+      bool ceil_mode,
+      bool count_include_pad,
+      c10::optional<int> divisor_override);
+  PyMPSGraphTensor*
+  hardTanh(MPSGraphTensor* inputTensor, float min_val, float max_val);
+  PyMPSGraphTensor*
+  mean(MPSGraphTensor* inputTensor, IntArrayRef dims, bool keep_dims);
+  std::tuple<PyMPSGraphTensor*, PyMPSGraphTensor*>
+  minDim(MPSGraphTensor* inputTensor, int dim, bool keep_dims);
+  std::tuple<PyMPSGraphTensor*, PyMPSGraphTensor*>
+  maxDim(MPSGraphTensor* inputTensor, int dim, bool keep_dims);
+  PyMPSGraphTensor*
+  amax(MPSGraphTensor* inputTensor, IntArrayRef dims, bool keep_dims);
+  PyMPSGraphTensor*
+  amin(MPSGraphTensor* inputTensor, IntArrayRef dims, bool keep_dims);
+  PyMPSGraphTensor* argmax(
+      MPSGraphTensor* inputTensor,
+      int64_t dim,
+      bool keep_dims,
+      bool flatten);
+  PyMPSGraphTensor* argmin(
+      MPSGraphTensor* inputTensor,
+      int64_t dim,
+      bool keep_dims,
+      bool flatten);
+  PyMPSGraphTensor* mm(
+      MPSGraphTensor* primaryTensor,
+      MPSGraphTensor* secondaryTensor);
+  PyMPSGraphTensor* identity(MPSGraphTensor* inputTensor);
+  PyMPSGraphTensor* clamp(
+      MPSGraphTensor* inputTensor,
+      float min,
+      float max,
+      bool use_min,
+      bool use_max);
+  PyMPSGraphTensor* relu(MPSGraphTensor* inputTensor);
+  PyMPSGraphTensor* leaky_relu(
+      MPSGraphTensor* inputTensor,
+      float negative_slope);
+  PyMPSGraphTensor*
+  softmax(MPSGraphTensor* inputTensor, int dim, bool half_to_float);
+  PyMPSGraphTensor*
+  log_softmax(MPSGraphTensor* inputTensor, int dim, bool half_to_float);
+  PyMPSGraphTensor* squeeze(MPSGraphTensor* inputTensor);
+  PyMPSGraphTensor* squeeze(MPSGraphTensor* inputTensor, int dim);
+  PyMPSGraphTensor* squeeze(MPSGraphTensor* inputTensor, IntArrayRef dim);
+  PyMPSGraphTensor* unsqueeze(MPSGraphTensor* inputTensor, int dimension);
+  PyMPSGraphTensor* gelu(
+      MPSGraphTensor* inputTensor,
+      const std::string& approximation);
+  PyMPSGraphTensor* glu(MPSGraphTensor* inputTensor, int64_t dim);
+  PyMPSGraphTensor* cat(int dim, py::args catTensors);
+  PyMPSGraphTensor* pixel_shuffle(
+      MPSGraphTensor* inputTensor,
+      int upscale_factor);
+  std::vector<PyMPSGraphTensor*>
+  split(MPSGraphTensor* inputTensor, int split_size, int dim);
+  std::vector<PyMPSGraphTensor*>
+  split_size(MPSGraphTensor* inputTensor, IntArrayRef split_sizes, int dim);
+  std::vector<PyMPSGraphTensor*> unbind(MPSGraphTensor* inputTensor, int dim);
+  PyMPSGraphTensor* stack(int dim, py::args stackTensors);
+  PyMPSGraphTensor* slice(
+      MPSGraphTensor* inputTensor,
+      int64_t dim,
+      c10::optional<int64_t> start,
+      c10::optional<int64_t> end,
+      int64_t step);
+  PyMPSGraphTensor* expand(MPSGraphTensor* inputTensor, IntArrayRef sizes);
+  PyMPSGraphTensor* select(MPSGraphTensor* inputTensor, int dim, int index);
+  PyMPSGraphTensor* view(MPSGraphTensor* inputTensor, IntArrayRef shape);
+  PyMPSGraphTensor* permute(MPSGraphTensor* inputTensor, IntArrayRef axes);
+  PyMPSGraphTensor* cumsum(MPSGraphTensor* inputTensor, int dim);
+  PyMPSGraphTensor* addmm(
+      MPSGraphTensor* biasTensor,
+      MPSGraphTensor* inputTensor,
+      MPSGraphTensor* weightTensor,
+      float beta,
+      float alpha);
+  MPSGraphTensor* trunc_tensor(MPSGraphTensor* inputTensor);
+
+  // Binary Ops
+  PyMPSGraphTensor* div_mode_template(
+      MPSGraphTensor* primaryTensor,
+      MPSGraphTensor* secondaryTensor,
+      c10::optional<c10::string_view> rounding_mode,
+      const string& op_name);
+  PyMPSGraphTensor* binaryOpTensor(
+      MPSGraphTensor* primaryTensor,
+      MPSGraphTensor* secondaryTensor,
+      const std::string& op_name,
+      std::function<MPSGraphTensor*(MPSGraphTensor*, MPSGraphTensor*)>
+          binaryOpFunction);
+
+  PyMPSGraphTensor* binaryOpWithScalar(
+      MPSGraphTensor* inputTensor,
+      Scalar scalar,
+      const std::string& op_name,
+      std::function<MPSGraphTensor*(MPSGraphTensor*, MPSGraphTensor*)>
+          binaryOpFunction);
+
+  // Unary Ops
+  PyMPSGraphTensor* unaryOpTensor(
+      MPSGraphTensor* inputTensor,
+      const std::string& op_name,
+      std::function<MPSGraphTensor*(MPSGraphTensor*)> unaryOpFunction);
+
+  PyMPSGraphTensor* additionWithTensor(
+      MPSGraphTensor* primaryTensor,
+      MPSGraphTensor* secondaryTensor,
+      Scalar alpha);
+  PyMPSGraphTensor* subtractionWithTensor(
+      MPSGraphTensor* primaryTensor,
+      MPSGraphTensor* secondaryTensor,
+      Scalar alpha);
+  PyMPSGraphTensor* multiplicationWithScalar(
+      MPSGraphTensor* inputTensor,
+      Scalar scalar);
+
+  // bitwise Ops
+  PyMPSGraphTensor* bitwiseNotTensor(
+      MPSGraphTensor* inputTensor,
+      const std::string& op_name);
+
+  // Pad Ops
+  PyMPSGraphTensor*
+  constant_pad_nd(MPSGraphTensor* input, IntArrayRef pad, const double value);
+
+  // range Ops
+  PyMPSGraphTensor* arange(
+      Scalar start,
+      Scalar end,
+      Scalar step,
+      MPSDataType dataType,
+      const int numEle);
+
+  // trinary Ops
+  PyMPSGraphTensor*
+  where(MPSGraphTensor* cond, MPSGraphTensor* input, MPSGraphTensor* other);
+
+  // Indexing Ops
+  PyMPSGraphTensor* index_select(
+      MPSGraphTensor* inputTensor,
+      int64_t dim,
+      MPSGraphTensor* indexTensor);
+
+  MPSGraph* getMPSGraph() {
+    return mpsGraph;
+  }
+
+  // Graph debug methods.
+  void printGraph();
+  bool macos_version_or_newer(
+      MacOSVersion version = MacOSVersion::MACOS_VER_14_0_PLUS);
+
+  MPSGraphExecutable* compileMPSGraphExecutable();
+  std::vector<uint8_t> serialize();
+
+ private:
+  MPSGraph* mpsGraph;
+  std::vector<MPSGraphTensor*> outputTensors_;
+  std::vector<MPSGraphTensor*> inputTensors_;
+  MPSGraphExecutable* executable_;
+
+  id<MTLDevice> device_;
+  id<MTLCommandQueue> commandQueue_;
+};
+
+} // namespace mps

--- a/backends/apple/mps/utils/MPSGraphInterface.mm
+++ b/backends/apple/mps/utils/MPSGraphInterface.mm
@@ -1,0 +1,154 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "MPSGraphInterface.h"
+#include "MPSGraphPackageExport.h"
+
+namespace mps {
+
+using namespace torch;
+MPSGraphModule::MPSGraphModule() {
+  TORCH_CHECK(macos_version_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS),
+  "MPS Executorch backend is supported only from macOS 14.0 and above.");
+
+  mpsGraph = [MPSGraph new];
+  device_ = MTLCreateSystemDefaultDevice();
+  commandQueue_ = [device_ newCommandQueue];
+}
+
+MPSGraphModule::~MPSGraphModule() {
+  [mpsGraph release];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::mpsGraphUnrankedPlaceHolder(MPSDataType dataType) {
+  inputTensors_.push_back([mpsGraph placeholderWithShape:nil
+                                                dataType:dataType
+                                                    name:nil]);
+  return inputTensors_.back();
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::mpsGraphRankedPlaceHolder(MPSDataType dataType, const at::IntArrayRef& shape) {
+  inputTensors_.push_back([mpsGraph placeholderWithShape:getMPSShape(shape)
+                                                dataType:dataType
+                                                    name:nil]);
+  return inputTensors_.back();
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::mpsGraphScalarPlaceHolder(MPSDataType dataType) {
+  inputTensors_.push_back([mpsGraph placeholderWithShape:@[@1]
+                                                dataType:dataType
+                                                    name:nil]);
+  return inputTensors_.back();
+}
+
+void
+MPSGraphModule::set_outputs(py::args args) {
+  for (const auto i: c10::irange(args.size())) {
+    MPSGraphTensor* outputTensor = static_cast<MPSGraphTensor*>(pybind11::cast<void*>(args[i]));
+    outputTensors_.push_back(outputTensor);
+  }
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::mm(MPSGraphTensor* primaryTensor, MPSGraphTensor* secondaryTensor) {
+  return [mpsGraph matrixMultiplicationWithPrimaryTensor:primaryTensor
+                                         secondaryTensor:secondaryTensor
+                                                    name:nil];
+}
+
+PyMPSGraphTensor*
+MPSGraphModule::identity(MPSGraphTensor* inputTensor) {
+  return [mpsGraph identityWithTensor:inputTensor
+                                 name:nil];
+}
+
+bool MPSGraphModule::macos_version_or_newer(MacOSVersion version) {
+  id mpsCD = NSClassFromString(@"MPSGraph");
+  static auto compileOptions = [[[MTLCompileOptions alloc] init] autorelease];
+
+  static bool _macos_14_0_plus = [mpsCD instancesRespondToSelector:@selector(imToColWithSourceTensor:descriptor:name:)] == YES;
+
+  switch (version) {
+    case MacOSVersion::MACOS_VER_14_0_PLUS:  return _macos_14_0_plus;
+    default: return false;
+  }
+}
+
+void MPSGraphModule::printGraph() {
+  NSLog(@"%@", [mpsGraph debugDescription]);
+}
+
+MPSGraphExecutable*
+MPSGraphModule::compileMPSGraphExecutable() {
+  NSMutableDictionary<MPSGraphTensor*, MPSGraphShapedType *> *feeds = [NSMutableDictionary dictionary];
+  for (const auto i: c10::irange(inputTensors_.size())) {
+    feeds[inputTensors_[i]] = [[MPSGraphShapedType alloc] initWithShape:[inputTensors_[i] shape] dataType:[inputTensors_[i] dataType]];
+  }
+
+  NSMutableArray<MPSGraphTensor*> *targetTensors = [NSMutableArray new];
+  std::for_each(outputTensors_.begin(), outputTensors_.end(), ^(MPSGraphTensor* outputTensor) {
+    [targetTensors addObject:outputTensor];
+  });
+
+  MPSGraphExecutable *exec = [mpsGraph compileWithDevice:[MPSGraphDevice deviceWithMTLDevice:device_]
+                                                   feeds:feeds
+                                           targetTensors:targetTensors
+                                        targetOperations:nil
+                                   compilationDescriptor:nil];
+
+  return exec;
+}
+
+std::vector<uint8_t> MPSGraphModule::serialize() {
+  MPSGraphExecutable* exec = compileMPSGraphExecutable();
+
+  std::string dataFolder = "/tmp/";
+
+  std::string name = "mpsgraphmodule_" + std::to_string(arc4random_uniform(INT_MAX));
+  std::string mpsgraphpackagePath = dataFolder + name + ".mpsgraphpackage";
+
+  NSString *mpsgraphpackageFileStr = [NSString stringWithUTF8String:mpsgraphpackagePath.c_str()];
+  NSURL *bundleURL = [NSURL fileURLWithPath:mpsgraphpackageFileStr];
+
+  MPSGraphExecutableSerializationDescriptor *serializationDescriptor = [MPSGraphExecutableSerializationDescriptor new];
+  serializationDescriptor.deploymentPlatform = MPSGraphDeploymentPlatformMacOS;
+  serializationDescriptor.minimumDeploymentTarget = @"14.0.0";
+  [exec serializeToMPSGraphPackageAtURL:bundleURL descriptor:serializationDescriptor];
+
+  NSString* mpsgraphpackage_manifest_file = [NSString stringWithUTF8String:(mpsgraphpackagePath + "/manifest.plist").c_str()];
+  NSString* mpsgraphpackage_model_0_file = [NSString stringWithUTF8String:(mpsgraphpackagePath + "/model_0.mpsgraph").c_str()];
+  NSString* mpsgraphpackage_model_1_file = [NSString stringWithUTF8String:(mpsgraphpackagePath + "/model_1.mpsgraph").c_str()];
+
+  NSURL* manifestPlistURL = [NSURL fileURLWithPath:mpsgraphpackage_manifest_file];
+  NSURL* model0URL = [NSURL fileURLWithPath:mpsgraphpackage_model_0_file];
+  NSURL* model1URL = [NSURL fileURLWithPath:mpsgraphpackage_model_1_file];
+
+  NSData* manifest_plist_data = [NSData dataWithContentsOfURL:manifestPlistURL];
+  NSData* model_0_data = [NSData dataWithContentsOfURL:model0URL];
+  NSData* model_1_data = [NSData dataWithContentsOfURL:model1URL];
+
+  int64_t total_package_size = sizeof(ExirMPSGraphPackage) + [manifest_plist_data length] + [model_0_data length] + [model_1_data length];
+  ExirMPSGraphPackage *exirMPSGraphPackage = (ExirMPSGraphPackage*)malloc(total_package_size);
+  assert(exirMPSGraphPackage != nil);
+
+  exirMPSGraphPackage->manifest_plist_offset = 0;
+  exirMPSGraphPackage->model_0_offset = [manifest_plist_data length];
+  exirMPSGraphPackage->model_1_offset = exirMPSGraphPackage->model_0_offset + [model_0_data length];
+  exirMPSGraphPackage->total_bytes = total_package_size;
+
+  memcpy(exirMPSGraphPackage->data, [manifest_plist_data bytes], [manifest_plist_data length]);
+  memcpy(exirMPSGraphPackage->data + exirMPSGraphPackage->model_0_offset, [model_0_data bytes], [model_0_data length]);
+  memcpy(exirMPSGraphPackage->data + exirMPSGraphPackage->model_1_offset, [model_1_data bytes], [model_1_data length]);
+
+  std::vector<uint8_t> data((uint8_t*)exirMPSGraphPackage, (uint8_t*)exirMPSGraphPackage + total_package_size);
+  free(exirMPSGraphPackage);
+
+  return data;
+}
+
+} // namespace mps

--- a/backends/apple/mps/utils/MPSGraphPackageExport.h
+++ b/backends/apple/mps/utils/MPSGraphPackageExport.h
@@ -1,0 +1,16 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#pragma once
+
+// Export the contents of the MPSGraphPackage directly as a list of bytes.
+// Any changes to this structure will break previous exported models.
+struct ExirMPSGraphPackage {
+  int64_t manifest_plist_offset;
+  int64_t model_0_offset;
+  int64_t model_1_offset;
+  int64_t total_bytes;
+  uint8_t data[];
+};

--- a/backends/apple/mps/utils/OperationUtils.h
+++ b/backends/apple/mps/utils/OperationUtils.h
@@ -1,0 +1,100 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#pragma once
+
+#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
+#include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+#if !EXIR_MPS_DELEGATE
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <torch/torch.h>
+#else
+#include <executorch/backends/apple/mps/runtime/MPSDevice.h>
+#endif
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+namespace mps {
+
+#if EXIR_MPS_DELEGATE
+using torch::executor::mps::delegate::MPSDevice;
+#endif
+
+#if EXIR_MPS_DELEGATE
+using namespace exec_aten;
+#else
+using namespace torch;
+#endif
+
+MPSDataType getMPSDataType(ScalarType scalar_type);
+MPSDataType getMPSScalarType(ScalarType scalar_type);
+ScalarType getScalarType(MPSDataType mpsDataType);
+MPSGraphTensor*
+castMPSTensor(MPSGraph* mpsGraph, MPSGraphTensor* tensor, ScalarType toType);
+MPSGraphTensor*
+castMPSTensor(MPSGraph* mpsGraph, MPSGraphTensor* tensor, MPSDataType toType);
+
+// The MPSShape could vary based on memory format
+MPSShape* getMPSShape(
+    const Tensor& t,
+    MemoryFormat memory_format = MemoryFormat::Contiguous);
+MPSShape* getMPSShape(
+    const IntArrayRef& sizes,
+    MemoryFormat memory_format = MemoryFormat::Contiguous);
+std::vector<int64_t> getMPSShapeVec(const MPSShape* shape);
+
+static inline id<MTLBuffer> getMTLBufferStorage(const Tensor& tensor) {
+#if EXIR_MPS_DELEGATE
+#if TARGET_OS_SIMULATOR
+  // Simulator crashes in newBufferWithBytesNoCopy, so we're making a copy of
+  // the data.
+  uint8_t* data = tensor.mutable_data_ptr<uint8_t>();
+  return [MPSDevice::getInstance()->device() newBufferWithBytes:data
+                                                         length:tensor.nbytes()
+                                                        options:0];
+#else
+  uint8_t* data = tensor.mutable_data_ptr<uint8_t>();
+  return [MPSDevice::getInstance()->device()
+      newBufferWithBytesNoCopy:data
+                        length:tensor.nbytes()
+                       options:0
+                   deallocator:nil];
+#endif // TARGET_OS_SIMULATOR
+#else
+  return __builtin_bit_cast(id<MTLBuffer>, tensor.storage().data());
+#endif // EXIR_MPS_DELEGATE
+}
+
+class Placeholder {
+ public:
+  Placeholder()
+      : _placeholder(nullptr), _value(nullptr), _tensor(Tensor(nullptr)) {}
+  Placeholder(MPSGraphTensor* mpsGraphTensor)
+      : _placeholder(mpsGraphTensor),
+        _value(nullptr),
+        _tensor(Tensor(nullptr)) {}
+  Placeholder(
+      MPSGraphTensor* mpsGraphTensor,
+      const Tensor& self,
+      MPSShape* mpsShape = nullptr,
+      MPSDataType dataType = MPSDataTypeInvalid);
+  MPSGraphTensor* getMPSGraphTensor() {
+    return _placeholder;
+  }
+  MPSGraphTensorData* getMPSGraphTensorData() {
+    return _value;
+  }
+  bool isIntermediate() {
+    return _value == nullptr;
+  }
+
+ private:
+  MPSGraphTensor* _placeholder;
+  MPSGraphTensorData* _value;
+  Tensor _tensor;
+};
+
+} // namespace mps

--- a/backends/apple/mps/utils/OperationUtils.mm
+++ b/backends/apple/mps/utils/OperationUtils.mm
@@ -1,0 +1,144 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "OperationUtils.h"
+
+namespace mps {
+
+MPSShape* getMPSShape(const Tensor& t, MemoryFormat memory_format) {
+  return getMPSShape(t.sizes(), memory_format);
+}
+
+MPSShape* getMPSShape(const IntArrayRef& sizes, MemoryFormat memory_format) {
+  if (memory_format == MemoryFormat::ChannelsLast) {
+    TORCH_INTERNAL_ASSERT(sizes.size() == 4, "ChannelsLast memory format must have 4 dimensions!");
+    const NSUInteger N = sizes[0];
+    const NSUInteger C = sizes[1];
+    const NSUInteger H = sizes[2];
+    const NSUInteger W = sizes[3];
+    return @[@(N), @(H), @(W), @(C)];
+  }
+  const int sz = sizes.size();
+  const int sz_ = (sz > 0) ? sz : 1;
+
+  std::vector<NSNumber*> numbers(sz_);
+
+  for (int i = 0; i < sz_; i++) {
+    NSInteger sz_i = (i < sz) ? sizes[i] : 1;
+    NSNumber* number = [NSNumber numberWithInteger:sz_i];
+    numbers[i] = number;
+  }
+  return [NSArray arrayWithObjects:numbers.data() count:numbers.size()];
+}
+
+std::vector<int64_t> getMPSShapeVec(const MPSShape* shape) {
+  __block std::vector<int64_t> shapeVec;
+  shapeVec.reserve([shape count]);
+  [shape enumerateObjectsUsingBlock:^(NSNumber * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+      shapeVec.push_back(obj.intValue);
+  }];
+  return shapeVec;
+}
+
+MPSDataType getMPSScalarType(ScalarType scalar_type) {
+  switch (scalar_type) {
+    // This is an intentional fallthrough supporting Double for Scalar
+    // types as they are casted to Float32 currently.
+    case ScalarType::Double:
+    case ScalarType::Float:
+      return MPSDataTypeFloat32;
+    case ScalarType::Half:  return MPSDataTypeFloat16;
+    case ScalarType::Int:   return MPSDataTypeInt32;
+    case ScalarType::Long:  return MPSDataTypeInt64;
+    case ScalarType::Short: return MPSDataTypeInt16;
+    case ScalarType::Char:
+    case ScalarType::QInt8:
+      return MPSDataTypeInt8;
+    case ScalarType::Byte:
+    case ScalarType::QUInt8:
+      return MPSDataTypeUInt8;
+    case ScalarType::Bool: return MPSDataTypeBool;
+    default:
+      TORCH_CHECK_TYPE(false, "Trying to convert ", scalar_type, " to the MPS backend but it does not have support for that dtype.")
+  }
+}
+
+MPSDataType getMPSDataType(ScalarType scalar_type) {
+  switch (scalar_type) {
+    case ScalarType::Float: return MPSDataTypeFloat32;
+    case ScalarType::Half:  return MPSDataTypeFloat16;
+    case ScalarType::Int:   return MPSDataTypeInt32;
+    case ScalarType::Long:  return MPSDataTypeInt64;
+    case ScalarType::Short: return MPSDataTypeInt16;
+    case ScalarType::Char:
+    case ScalarType::QInt8:
+      return MPSDataTypeInt8;
+    case ScalarType::Byte:
+    case ScalarType::QUInt8: return MPSDataTypeUInt8;
+    case ScalarType::Bool:   return MPSDataTypeBool;
+    case ScalarType::Double:
+      TORCH_CHECK_TYPE(false, "Cannot convert a float64 Tensor to MPS as the MPS framework doesn't support float64. "
+                       "Please use float32 instead.")
+    default:
+      TORCH_CHECK_TYPE(false, "Trying to convert ", scalar_type, " to the MPS backend but it does not have support for that dtype.")
+  }
+}
+
+ScalarType getScalarType(MPSDataType mps_data_type) {
+ switch (mps_data_type) {
+    case MPSDataTypeFloat32: return ScalarType::Float;
+    case MPSDataTypeFloat16: return ScalarType::Half;
+    case MPSDataTypeInt32:   return ScalarType::Int;
+    case MPSDataTypeInt64:   return ScalarType::Long;
+    case MPSDataTypeInt16:   return ScalarType::Short;
+    case MPSDataTypeInt8:    return ScalarType::Char;
+    case MPSDataTypeUInt8:   return ScalarType::Byte;
+    case MPSDataTypeBool:    return ScalarType::Bool;
+    default:
+      TORCH_CHECK_TYPE(false, "Couldn't convert MPS data type ", mps_data_type, " to PyTorch data type");
+  }
+}
+
+MPSGraphTensor* castMPSTensor(MPSGraph *mpsGraph, MPSGraphTensor* tensor, MPSDataType toType) {
+  return [mpsGraph castTensor:tensor toType:toType name:@"castTensor"];
+}
+
+MPSGraphTensor* castMPSTensor(MPSGraph *mpsGraph, MPSGraphTensor* tensor, ScalarType toType) {
+  return [mpsGraph castTensor:tensor toType:getMPSScalarType(toType) name:@"castTensor"];
+}
+
+MPSGraphTensorData* allocMPSGraphTensorData(id<MTLBuffer> buffer,
+                                            MPSShape* mpsShape,
+                                            MPSDataType mpsDataType) {
+  MPSGraphTensorData *tensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer:buffer
+                                                                            shape:mpsShape
+                                                                         dataType:mpsDataType] autorelease];
+  TORCH_INTERNAL_ASSERT(tensorData);
+  return tensorData;
+}
+
+Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor, const Tensor& src, MPSShape *mpsShape, MPSDataType dataType) : _tensor(src) {
+  TORCH_CHECK(src.is_mps(), "Placeholder storage has not been allocated on MPS device!");
+  // extract the pointer to MTLBuffer from the Tensor's storage
+  id<MTLBuffer> srcBuf = getMTLBufferStorage(src);
+
+  // tensor.numel() could be zero, but tensor is valid as long as the buffer size is non-zero.
+  // if buffer size is zero in here, it's not a user error. It could be a missing check for
+  // tensor.numel() == 0 in our internal implementations of ops.
+  TORCH_INTERNAL_ASSERT([srcBuf length] > 0, "Placeholder tensor is empty!");
+  const MPSDataType mpsDataType = dataType != MPSDataTypeInvalid ? dataType :
+                      _tensor.dim() == 0 ? getMPSScalarType(_tensor.scalar_type()) : getMPSDataType(_tensor.scalar_type());
+
+  if (!mpsShape) {
+    mpsShape = getMPSShape(_tensor);
+  }
+
+  _value = allocMPSGraphTensorData(srcBuf, mpsShape, mpsDataType);
+  TORCH_INTERNAL_ASSERT(_value);
+
+  _placeholder = mpsGraphTensor;
+}
+
+} // namespace mps

--- a/backends/apple/mps/utils/graph_bindings.py
+++ b/backends/apple/mps/utils/graph_bindings.py
@@ -1,0 +1,42 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+import torch.utils.cpp_extension
+
+sources = [
+    "MPSGraphInterface.mm",
+    "OperationUtils.mm",
+    "Bindings.mm",
+]
+
+ops = [
+    "ConvolutionOps.mm",
+    "NormalizationOps.mm",
+    "ActivationOps.mm",
+    "ReduceOps.mm",
+    "ConstantOps.mm",
+    "UnaryOps.mm",
+    "BinaryOps.mm",
+    "ClampOps.mm",
+    "ShapeOps.mm",
+    "LinearAlgebraOps.mm",
+    "BitwiseOps.mm",
+    "PoolingOps.mm",
+    "PadOps.mm",
+    "RangeOps.mm",
+    "Indexing.mm",
+]
+
+SOURCES_PATH = "backends/apple/mps/"
+final_sources = [SOURCES_PATH + "utils/" + source for source in sources] + [
+    SOURCES_PATH + "operations/" + op for op in ops
+]
+
+graph_bindings = torch.utils.cpp_extension.load(
+    name="MPSGraphBindings",
+    sources=final_sources,
+    extra_include_paths=[SOURCES_PATH],
+    verbose=False,
+)

--- a/backends/apple/mps/utils/mps_utils.py
+++ b/backends/apple/mps/utils/mps_utils.py
@@ -1,0 +1,37 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+import torch
+from executorch.backends.apple.mps.utils.graph_bindings import graph_bindings
+
+
+def get_mps_data_type(dtype):
+    scalar_type_to_mps_dtype = {
+        "torch.float32": graph_bindings.MPSDataTypeFloat32,
+        "torch.float16": graph_bindings.MPSDataTypeFloat16,
+        "torch.int32": graph_bindings.MPSDataTypeInt32,
+        "torch.int64": graph_bindings.MPSDataTypeInt64,
+        "torch.int16": graph_bindings.MPSDataTypeInt16,
+        "torch.int8": graph_bindings.MPSDataTypeInt8,
+        "torch.qint8": graph_bindings.MPSDataTypeInt8,
+        "torch.uint8": graph_bindings.MPSDataTypeUInt8,
+        "torch.quint8": graph_bindings.MPSDataTypeUInt8,
+        "torch.bool": graph_bindings.MPSDataTypeBool,
+        torch.float32: graph_bindings.MPSDataTypeFloat32,
+        torch.float16: graph_bindings.MPSDataTypeFloat16,
+        torch.int32: graph_bindings.MPSDataTypeInt32,
+        torch.int64: graph_bindings.MPSDataTypeInt64,
+        torch.int16: graph_bindings.MPSDataTypeInt16,
+        torch.int8: graph_bindings.MPSDataTypeInt8,
+        torch.qint8: graph_bindings.MPSDataTypeInt8,
+        torch.uint8: graph_bindings.MPSDataTypeUInt8,
+        torch.quint8: graph_bindings.MPSDataTypeUInt8,
+        torch.bool: graph_bindings.MPSDataTypeBool,
+    }
+
+    try:
+        return scalar_type_to_mps_dtype[dtype]
+    except KeyError:
+        raise AssertionError(f"Invalid data type: {dtype}")

--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -47,6 +47,7 @@ function(executorch_print_configuration_summary)
   message(STATUS "  EXECUTORCH_BUILD_EXTENSION_DATA_LOADER : "
                  "${EXECUTORCH_BUILD_EXTENSION_DATA_LOADER}")
   message(STATUS "  EXECUTORCH_BUILD_XNNPACK : ${EXECUTORCH_BUILD_XNNPACK}")
+  message(STATUS "  EXECUTORCH_BUILD_MPS     : ${EXECUTORCH_BUILD_MPS}")
 endfunction()
 
 # This is the funtion to use -Wl, --whole-archive to link static library NB:

--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -102,6 +102,32 @@ deps = [
   "executorch",
 ]
 
+[targets.mps_executor_runner]
+buck_targets = [
+  "//examples/apple/mps/executor_runner:mps_executor_runner",
+]
+filters = [
+  "(.mm|.cpp)$",
+]
+excludes = [
+  "^codegen",
+]
+deps = [
+  "executorch",
+  "portable_kernels",
+]
+
+[targets.mps_backend]
+buck_targets = [
+  "//backends/apple/mps:mps_backend",
+]
+filters = [
+  "(.mm|.cpp)$",
+]
+deps = [
+  "executorch",
+]
+
 [targets.xnn_executor_runner]
 buck_targets = [
   "//examples/xnnpack:xnn_executor_runner",

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -13,6 +13,9 @@
 {% elif 'qualcomm-ai-engine-direct-backend' in pagename%}
 <link rel="stylesheet" href="../_static/css/progress-bar.css">
 <script src="../_static/js/progress-bar.js" defer></script>
+{% elif 'mps' in pagename%}
+<link rel="stylesheet" href="../_static/css/progress-bar.css">
+<script src="../_static/js/progress-bar.js" defer></script>
 {% endif %}
 {{ super() }}
 {% endblock %}

--- a/docs/source/build-run-mps.md
+++ b/docs/source/build-run-mps.md
@@ -1,0 +1,1 @@
+```{include} ../../backends/apple/mps/setup.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,6 +93,7 @@ Topics in this section will help you get started with ExecuTorch.
    demo-apps-android
    build-run-xtensa
    build-run-qualcomm-ai-engine-direct-backend
+   build-run-mps
    tutorials/sdk-integration-tutorial
    executorch-arm-delegate-tutorial
    tutorial-xnnpack-delegate-lowering

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,8 @@ ExecuTorch's extensive support spans from simple modules like "Add" to comprehen
 ## Directory structure
 ```
 examples
+├── apple
+|   ├── mps                           # Contains end-to-end demos of MPS backend
 ├── models                            # Contains a set of popular and representative PyTorch models
 ├── portable                          # Contains end-to-end demos for ExecuTorch in portable mode
 ├── xnnpack                           # Contains end-to-end ExecuTorch demos with first-party optimization using XNNPACK

--- a/examples/apple/mps/CMakeLists.txt
+++ b/examples/apple/mps/CMakeLists.txt
@@ -1,0 +1,53 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+#
+# mps_executor_runner: Host tool that demonstrates program
+#                      execution using MPSBackend.
+#
+
+cmake_minimum_required(VERSION 3.19)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(NOT PYTHON_EXECUTABLE)
+  set(PYTHON_EXECUTABLE python3)
+endif()
+
+if(NOT FLATC_EXECUTABLE)
+  set(FLATC_EXECUTABLE flatc)
+endif()
+
+# Source root directory for executorch.
+if(NOT EXECUTORCH_ROOT)
+  set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+endif()
+
+include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+
+# ios can only build library but not binary
+if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
+  #
+  # mps_executor_runner: Like executor_runner but with MPS, the binary will
+  # be at ${CMAKE_BINARY_DIR}/examples/apple/executor_runner/mps
+  #
+set(mps_executor_runner_libs "-framework Foundation"
+                              "-weak_framework MetalPerformanceShaders"
+                              "-weak_framework MetalPerformanceShadersGraph"
+                              "-weak_framework Metal")
+list(TRANSFORM _mps_executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
+add_executable(mps_executor_runner ${_mps_executor_runner__srcs})
+target_include_directories(
+  mps_executor_runner INTERFACE ${CMAKE_BINARY_DIR}/schema/include/
+                          ${EXECUTORCH_ROOT}/third-party/flatbuffers/include)
+target_link_libraries(mps_executor_runner program_schema
+                                          ${_executor_runner_libs}
+                                          ${mps_executor_runner_libs})
+target_compile_options(mps_executor_runner PUBLIC ${_common_compile_options})
+endif()

--- a/examples/apple/mps/README.md
+++ b/examples/apple/mps/README.md
@@ -1,0 +1,52 @@
+This README gives some examples on backend-specific model workflow.
+
+# MPS Backend
+
+[MPS](https://developer.apple.com/documentation/metalperformanceshaders) is a framework of highly optimized compute and graphics shaders, specially tuned to take advantage of the unique hardware characteristics of each GPU family to ensure optimal performance.
+**MPS** backend takes advantage of [MPSGraph](https://developer.apple.com/documentation/metalperformanceshadersgraph/mpsgraph?language=objc) to build, compile, and execute customized multidimensional graphs from the edge dialect ops.
+
+## Prerequisite
+
+Please finish the following tutorials:
+- [Setting up executorch](../../../docs/website/docs/tutorials/00_setting_up_executorch.md).
+- [Setting up MPS backend](../../../backends/apple/mps/setup.md).
+
+## Delegation to MPS backend
+
+The following command will lower the EdgeIR to MPS delegate:
+
+```bash
+# For MobileNet V2
+python3 -m examples.apple.mps.scripts.mps_example --model_name="mv2" --bundled
+```
+To see all the options when exporting a model to MPS delegate, use the following command:
+```
+python3 -m examples.apple.mps.scripts.mps_example --help
+```
+
+Once we have the model binary file, then let's run it with the ExecuTorch runtime using the `mps_executor_runner`.
+
+```bash
+# Build the mps_executor_runner
+(rm -rf cmake-out && mkdir cmake-out && cd cmake-out && cmake -DEXECUTORCH_BUILD_MPS=1 -DBUCK2=/tmp/buck2 —trace .. && cd ..)
+cmake --build cmake-out -j9
+
+# Run the mv2 generated model using the mps_executor_runner
+./cmake-out/examples/apple/mps/mps_executor_runner --model_path mv2_mps_bundled.pte --bundled_program
+```
+
+## Profiling
+
+The following arguments can be used alongside the mps_executor_runner to benchmark a model:
+- `--num-runs`: Number of total iterations.
+- `--profile`: Show execution time for each iteration.
+- `--bundled_program`: Load the inputs and outputs from the bundled program (note that during export, `--bundled` flag must be passed)
+
+For example:
+```bash
+./cmake-out/examples/apple/mps/mps_executor_runner --model_path mv2_mps_bundled.pte --profile --num_runs 10
+```
+
+## Limitation
+
+1. MPS backend is currently supported from iOS 17 and macOS Sonoma and newer.

--- a/examples/apple/mps/executor_runner/TARGETS
+++ b/examples/apple/mps/executor_runner/TARGETS
@@ -1,0 +1,8 @@
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/examples/apple/mps/executor_runner/mps_executor_runner.mm
+++ b/examples/apple/mps/executor_runner/mps_executor_runner.mm
@@ -1,0 +1,506 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+/**
+ * @file
+ *
+ * This tool can run Executorch model files that use operators that
+ * are covered by the MPSDelegate or the portable kernels.
+ *
+ * It uses the original bundled input data from the flatbuffer file.
+ */
+
+#import <Foundation/Foundation.h>
+#import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+#import <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+
+#include <memory>
+
+#include <gflags/gflags.h>
+
+#include <executorch/extension/data_loader/file_data_loader.h>
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/program.h>
+#include <executorch/runtime/platform/log.h>
+#include <executorch/runtime/platform/profiler.h>
+#include <executorch/runtime/platform/runtime.h>
+#include <executorch/util/util.h>
+#include <executorch/util/bundled_program_verification.h>
+#include <executorch/extension/data_loader/buffer_data_loader.h>
+#include <executorch/runtime/core/result.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include <chrono>
+using namespace std::chrono;
+
+static constexpr size_t kRuntimeMemorySize = 4 * 1024U * 1024U; // 4 MB
+static uint8_t runtime_pool[kRuntimeMemorySize];
+static constexpr size_t kBundledAllocatorPoolSize = 16 * 1024U;
+static uint8_t bundled_allocator_pool[kBundledAllocatorPoolSize];
+
+DEFINE_string(model_path, "model.ff", "Model serialized in flatbuffer format.");
+DEFINE_string(
+    prof_result_path,
+    "prof_result.bin",
+    "Executorch profiler output path.");
+
+DEFINE_bool(
+    bundled_program,
+    false,
+    "True for running bundled program, false for executorch_flatbuffer::program");
+
+DEFINE_int32(
+    testset_idx,
+    0,
+    "Index of bundled verification set to be run "
+    "by bundled model for verification");
+
+DEFINE_int32(
+    num_runs,
+    1,
+    "Number of total runs");
+
+DEFINE_bool(
+    profile,
+    false,
+    "True for showing profile data (e.g execution time)");
+
+using namespace torch::executor;
+using torch::executor::util::FileDataLoader;
+
+/**
+ * Helps handle bundled and non-bundled program inputs.
+ */
+class ProgramData {
+ public:
+  /**
+   * Tries loading the named file as a plain Program or a bundled program,
+   * failing with an ET_CHECK on any failure.
+   */
+  static ProgramData load_or_die(std::string& filename) {
+    // Create a DataLoader that wraps the input file. It may be a plain Program,
+    // or it may be a BundledProgram that contains a Program.
+    Result<util::FileDataLoader> loader =
+        util::FileDataLoader::From(filename.c_str());
+    ET_CHECK_MSG(
+        loader.ok(),
+        "Could not create loader for file '%s': 0x%x",
+        filename.c_str(),
+        (unsigned int)loader.error());
+
+    // Figure out the file type. Create a scope to destroy the header after the
+    // check.
+    {
+      Result<FreeableBuffer> header =
+          loader->Load(/*offset=*/0, Program::kMinHeadBytes);
+      ET_CHECK_MSG(
+          header.ok(),
+          "Could not load header of file '%s': 0x%x",
+          filename.c_str(),
+          (unsigned int)loader.error());
+      Program::HeaderStatus hs =
+          Program::check_header(header->data(), header->size());
+      if (hs == Program::HeaderStatus::CompatibleVersion) {
+        // It's a plain Program. We can use the existing loader, and there is no
+        // bundled program data.
+        return ProgramData(
+            new util::FileDataLoader(std::move(*loader)),
+            /*bundled_program_data=*/FreeableBuffer());
+      }
+    }
+
+    // Read in the entire file.
+    Result<FreeableBuffer> file_data = loader->Load(0, loader->size().get());
+    ET_CHECK_MSG(
+        file_data.ok(),
+        "Could not load contents of file '%s': 0x%x",
+        filename.c_str(),
+        (unsigned int)file_data.error());
+
+    // Find the offset to the embedded Program.
+    const void* program_data;
+    size_t program_data_len;
+    Error status = torch::executor::util::GetProgramData(
+        const_cast<void*>(file_data->data()),
+        file_data->size(),
+        &program_data,
+        &program_data_len);
+    ET_CHECK_MSG(
+        status == Error::Ok,
+        "GetProgramData() failed on file '%s': 0x%x",
+        filename.c_str(),
+        (unsigned int)status);
+
+    // Wrap the Program in a loader, and pass on the FreeableBuffer that
+    // contains the full bundled program data.
+    return ProgramData(
+        new util::BufferDataLoader(program_data, program_data_len),
+        std::move(*file_data));
+  }
+
+  /**
+   * Returns the loader for the plain Program. May or may not be inside a
+   * bundled program wrapper.
+   */
+  DataLoader* program_loader() {
+    return loader_.get();
+  }
+
+  /**
+   * If the file was a bundled program, returns a pointer to the file data.
+   * Otherwise returns nullptr.
+   */
+  const void* bundled_program_data() const {
+    if (bundled_program_data_.size() > 0) {
+      return bundled_program_data_.data();
+    } else {
+      return nullptr;
+    }
+  }
+
+ private:
+  /// Takes ownership of both params.
+  ProgramData(DataLoader* loader, FreeableBuffer&& bundled_program_data)
+      : loader_(loader),
+        bundled_program_data_(std::move(bundled_program_data)) {}
+
+  std::unique_ptr<DataLoader> loader_;
+  FreeableBuffer bundled_program_data_;
+};
+
+struct TensorData {
+  std::vector<uint8_t> data;
+  ssize_t numel;
+  size_t nbytes;
+  ScalarType scalar_type;
+};
+
+template <typename T>
+bool data_is_close_(
+    const T* a,
+    const T* b,
+    size_t numel,
+    double rtol,
+    double atol) {
+  for (size_t i = 0; i < numel; i++) {
+    if (rtol == 0 && atol == 0) {
+      // Exact comparison; avoid unnecessary math.
+      if (a[i] != b[i]) {
+        return false;
+      }
+    } else {
+      auto allowed_error = atol + fabs(rtol * b[i]);
+      auto actual_error = fabs(a[i] - b[i]);
+      if (!isfinite(actual_error) || actual_error > allowed_error) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+static
+bool tensors_are_close_(
+    ScalarType scalar_type,
+    ssize_t numel,
+    size_t nbytes,
+    void* a_data_ptr,
+    void* b_data_ptr,
+    double rtol = 1e-05,
+    double atol = 1e-08) {
+  if (scalar_type == ScalarType::Float) {
+    return data_is_close_<float>(
+        (float*)a_data_ptr,
+        (float*)b_data_ptr,
+        numel,
+        rtol,
+        atol);
+  } else if (scalar_type == ScalarType::Double) {
+    return data_is_close_<double>(
+        (double*)a_data_ptr,
+        (double*)b_data_ptr,
+        numel,
+        rtol,
+        atol);
+  } else {
+    // Non-floating-point types can be compared bitwise.
+    return memcmp(a_data_ptr, b_data_ptr, nbytes) == 0;
+  }
+}
+
+int main(int argc, char** argv) {
+  runtime_init();
+
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  if (argc != 1) {
+    std::string msg = "Extra commandline args:";
+    for (int i = 1 /* skip argv[0] (program name) */; i < argc; i++) {
+      msg += std::string(" ") + argv[i];
+    }
+    ET_LOG(Error, "%s", msg.c_str());
+    return 1;
+  }
+
+  // Create a loader to get the data of the program file. There are other
+  // DataLoaders that use mmap() or point to data that's already in memory, and
+  // users can create their own DataLoaders to load from arbitrary sources.
+  const char* model_path = FLAGS_model_path.c_str();
+  Result<FileDataLoader> loader = FileDataLoader::From(model_path);
+  ET_CHECK_MSG(
+      loader.ok(), "FileDataLoader::From() failed: 0x%" PRIx32, loader.error());
+
+  // Read in the entire file.
+  Result<FreeableBuffer> file_data = loader->Load(0, loader->size().get());
+  ET_CHECK_MSG(
+      file_data.ok(),
+      "Could not load contents of file '%s': 0x%x",
+      model_path,
+      (unsigned int)file_data.error());
+
+  // Find the offset to the embedded Program.
+  const void* program_data;
+  size_t program_data_len;
+  Error status = torch::executor::util::GetProgramData(
+      const_cast<void*>(file_data->data()),
+      file_data->size(),
+      &program_data,
+      &program_data_len);
+  ET_CHECK_MSG(
+      status == Error::Ok,
+      "GetProgramData() failed on file '%s': 0x%x",
+      model_path,
+      (unsigned int)status);
+
+  auto buffer_data_loader =
+      util::BufferDataLoader(program_data, program_data_len);
+
+  // Parse the program file. This is immutable, and can also be reused
+  // between multiple execution invocations across multiple threads.
+  Result<Program> program = Program::Load(&buffer_data_loader);
+  if (!program.ok()) {
+    ET_LOG(Error, "Failed to parse model file %s", model_path);
+    return 1;
+  }
+  ET_LOG(Info, "Model file %s is loaded.", model_path);
+
+  // Use the first method in the program.
+  const auto method_name_result = program->get_method_name(0);
+  ET_CHECK_MSG(method_name_result.ok(), "Program has no methods");
+  const char* method_name = *method_name_result;
+  ET_LOG(Info, "Program methods: %zu", program->num_methods());
+
+  ET_LOG(Info, "Running method %s", method_name);
+
+  //
+  // The runtime does not use malloc/new; it allocates all memory using the
+  // MemoryManger provided by the client. Clients are responsible for allocating
+  // the memory ahead of time, or providing MemoryAllocator subclasses that can
+  // do it dynamically.
+  //
+
+  // The runtime allocator is used to allocate all dynamic C++ metadata/objects
+  // used to represent the loaded program. This allocator is only used during
+  // loading a method of the program, which will return an error if there was
+  // not enough memory.
+  //
+  // The amount of memory required depends on the loaded program and the runtime
+  // code itself. The amount of memory here is usually determined by running the
+  // program and seeing how much memory is actually used, though it's possible
+  // to subclass MemoryAllocator so that it calls malloc() under the hood.
+
+  // In this example we using statically allocated gloabl runtime_pool of
+  // size kRuntimeMemorySize
+  MemoryAllocator runtime_allocator{
+      MemoryAllocator(kRuntimeMemorySize, runtime_pool)};
+  runtime_allocator.enable_profiling("runtime allocator");
+
+  // The non-const allocator is used to provide the memory-planned buffers that
+  // back mutable tensors. Since it was planned ahead of time, the Program knows
+  // how big each of the allocators needs to be.
+  //
+  // These buffers correspond to different hardware memory banks. Most mobile
+  // environments will only have a single buffer. Some embedded environments may
+  // have more than one for, e.g., slow/large DRAM and fast/small SRAM.
+  std::vector<std::unique_ptr<uint8_t[]>> non_const_buffers;
+  std::vector<MemoryAllocator> non_const_allocators;
+  size_t num_non_const_buffers = 0;
+  {
+    auto result = program->num_non_const_buffers(method_name);
+    ET_CHECK_MSG(
+        result.ok(),
+        "Failed to get number of non-const buffers for method %s: 0x%x",
+        method_name,
+        (unsigned int)result.error());
+    num_non_const_buffers = *result;
+  }
+  // Note that this loop starts at ID 1, because ID 0 is reserved. But, the
+  // HierarchicalAllocator indices are zero-based, so it's later adjusted by -1.
+  for (size_t id = 1; id < num_non_const_buffers; ++id) {
+    auto buffer_size = program->get_non_const_buffer_size(id, method_name);
+    ET_CHECK_MSG(
+        buffer_size.ok(),
+        "Failed to get size of non-const buffer %zu for method %s: 0x%x",
+        id,
+        method_name,
+        (unsigned int)buffer_size.error());
+    ET_LOG(
+        Info, "Setting up non-const buffer %zu, size %lld.", id, *buffer_size);
+    non_const_buffers.push_back(std::make_unique<uint8_t[]>(*buffer_size));
+    // Since the list of allocators began empty, buffer ID N will live at index
+    // N-1.
+    non_const_allocators.push_back(
+        MemoryAllocator(*buffer_size, non_const_buffers.back().get()));
+    non_const_allocators.back().enable_profiling("non_const_allocators");
+  }
+
+  HierarchicalAllocator non_const_allocator(
+      non_const_allocators.size(), non_const_allocators.data());
+
+  // Allocator for bundled input.
+  MemoryAllocator bundled_input_allocator{
+      MemoryAllocator(kBundledAllocatorPoolSize, bundled_allocator_pool)};
+
+  // The constant allocator is not currently used. Please initialize with a
+  // zero-sized allocator.
+  MemoryAllocator const_allocator{MemoryAllocator(0, nullptr)};
+  const_allocator.enable_profiling("const allocator");
+
+  // The kernel temporary allocator is not currently used. Please initialize
+  // with a zero-sized allocator.
+  MemoryAllocator temp_allocator{MemoryAllocator(0, nullptr)};
+  temp_allocator.enable_profiling("temp allocator");
+
+  ET_LOG(
+      Info, "Setting up memory manager");
+  // Assemble all of the allocators into the MemoryManager that the Executor
+  // will use.
+  MemoryManager memory_manager(
+      &const_allocator,
+      &non_const_allocator,
+      &runtime_allocator,
+      &temp_allocator);
+
+  //
+  // Load method from the program, using the provided
+  // allocators. Running the method can mutate allocated non_const buffers,
+  // so should only be used by a single thread at at time, but it can be reused.
+  //
+
+  ET_LOG(
+      Info, "Loading method name from plan");
+  Result<Method> method = program->load_method(method_name, &memory_manager);
+  ET_CHECK_MSG(
+      method.ok(),
+      "Loading of method %s failed with status 0x%" PRIx32,
+      method_name,
+      method.error());
+  ET_LOG(Info, "Method loaded.");
+
+  // Prepare the inputs.
+  exec_aten::ArrayRef<void*> inputs;
+  if (FLAGS_bundled_program) {
+    ET_LOG(Info, "Loading bundled program...\n");
+    // Use the inputs embedded in the bundled program.
+    status = torch::executor::util::LoadBundledInput(
+        *method,
+        file_data->data(),
+        &bundled_input_allocator,
+        method_name,
+        FLAGS_testset_idx);
+    ET_CHECK_MSG(
+        status == Error::Ok,
+        "LoadBundledInput failed with status 0x%" PRIx32,
+        status);
+  } else {
+    ET_LOG(Info, "Loading non-bundled program...\n");
+    // Use ones-initialized inputs.
+    inputs = torch::executor::util::PrepareInputTensors(*method);
+  }
+  ET_LOG(Info, "Inputs prepared.");
+
+  for (int i = 0; i < FLAGS_num_runs; i++) {
+    auto start_exec_time = high_resolution_clock::now();
+    // Run the model.
+    Error status = method->execute();
+    auto end_exec_time = high_resolution_clock::now();
+    auto duration = duration_cast<milliseconds>(end_exec_time - start_exec_time);
+    if (FLAGS_profile) {
+      ET_LOG(Info, "[Run %d] Inference time: %lld milliseconds", i, duration.count());
+    }
+    ET_CHECK_MSG(
+        status == Error::Ok,
+        "Execution of method %s failed with status 0x%" PRIx32,
+        method_name,
+        status);
+  }
+  ET_LOG(Info, "Model executed successfully.");
+
+  auto output_list =
+      runtime_allocator.allocateList<EValue>(method->outputs_size());
+  status = method->get_outputs(output_list, method->outputs_size());
+  ET_CHECK(status == Error::Ok);
+
+  // Print the outputs.
+  std::vector<EValue> outputs(method->outputs_size());
+  status = method->get_outputs(outputs.data(), outputs.size());
+  ET_CHECK(status == Error::Ok);
+  for (EValue& output : outputs) {
+    // TODO(T159700776): This assumes that all outputs are fp32 tensors. Add
+    // support for other EValues and Tensor dtypes, and print tensors in a more
+    // readable way.
+    auto output_tensor = output.toTensor();
+    auto data_output = output_tensor.const_data_ptr<float>();
+    for (size_t j = 0; j < output_tensor.numel(); ++j) {
+      ET_LOG(Info, "%f", data_output[j]);
+    }
+  }
+
+  // Dump the profiling data to the specified file.
+  torch::executor::prof_result_t prof_result;
+  EXECUTORCH_DUMP_PROFILE_RESULTS(&prof_result);
+  if (prof_result.num_bytes != 0) {
+    FILE* ptr = fopen(FLAGS_prof_result_path.c_str(), "w+");
+    fwrite(prof_result.prof_data, 1, prof_result.num_bytes, ptr);
+    fclose(ptr);
+  }
+
+  // Handle the outputs.
+  if (FLAGS_bundled_program) {
+    double rtol = 1e-05;
+    double atol = 1e-08;
+
+    if (strstr(model_path, "mv3")                  ||
+        strstr(model_path, "mv2")                  ||
+        strstr(model_path, "vit")                  ||
+        strstr(model_path, "resnet18")             ||
+        strstr(model_path, "resnet50")             ||
+        strstr(model_path, "mobilebert")           ||
+        strstr(model_path, "emformer")             ||
+        strstr(model_path, "emformer_transcribe")  ||
+        strstr(model_path, "emformer_join")        ||
+        strstr(model_path, "edsr")                 ||
+        strstr(model_path, "ic3")                  ||
+        strstr(model_path, "ic4")) {
+        atol = 1e-04;
+      }
+    status = torch::executor::util::VerifyResultWithBundledExpectedOutput(
+        *method,
+        file_data->data(),
+        &bundled_input_allocator,
+        method_name,
+        FLAGS_testset_idx,
+        rtol,
+        atol
+    );
+    ET_CHECK_MSG(
+        status == Error::Ok,
+        "Bundle verification failed with status 0x%" PRIx32,
+        status);
+    ET_LOG(Info, "Model verified successfully.");
+  } else {
+    util::FreeInputs(inputs);
+  }
+  return 0;
+}

--- a/examples/apple/mps/executor_runner/targets.bzl
+++ b/examples/apple/mps/executor_runner/targets.bzl
@@ -1,0 +1,28 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "get_oss_build_kwargs", "runtime")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    # executor_runner for MPS Backend and portable kernels.
+    if runtime.is_oss:
+        runtime.cxx_binary(
+            name = "mps_executor_runner",
+            srcs = ["mps_executor_runner.mm"],
+            deps = [
+                "//executorch/backends/apple/mps/runtime:MPSBackend",
+                "//executorch/runtime/executor:program",
+                "//executorch/extension/data_loader:file_data_loader",
+                "//executorch/kernels/portable:generated_lib_all_ops",
+                "//executorch/extension/data_loader:file_data_loader",
+                "//executorch/extension/data_loader:buffer_data_loader",
+                "//executorch/util:util",
+                "//executorch/util:bundled_program_verification",
+                "//executorch/util:util",
+            ],
+            define_static_target = True,
+            **get_oss_build_kwargs()
+        )

--- a/examples/apple/mps/scripts/mps_example.py
+++ b/examples/apple/mps/scripts/mps_example.py
@@ -1,0 +1,116 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+# Example script for exporting simple models to flatbuffer
+
+import argparse
+import logging
+
+import torch
+
+import torch._export as export
+from executorch import exir
+from executorch.backends.apple.mps.mps_preprocess import MPSBackend
+from executorch.bundled_program.config import BundledConfig
+from executorch.bundled_program.core import create_bundled_program
+from executorch.bundled_program.serialize import (
+    serialize_from_bundled_program_to_flatbuffer,
+)
+
+from executorch.exir.backend.backend_api import to_backend
+
+from ....models import MODEL_NAME_TO_MODEL
+from ....models.model_factory import EagerModelFactory
+
+from ....portable.utils import save_pte_program
+
+FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-m",
+        "--model_name",
+        required=True,
+        help=f"Provide model name. Valid ones: {list(MODEL_NAME_TO_MODEL.keys())}",
+    )
+
+    parser.add_argument(
+        "-b",
+        "--bundled",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Flag for bundling inputs and outputs in the final flatbuffer program",
+    )
+    args = parser.parse_args()
+
+    if args.model_name not in MODEL_NAME_TO_MODEL:
+        raise RuntimeError(f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}.")
+
+    model, example_inputs = EagerModelFactory.create_model(
+        *MODEL_NAME_TO_MODEL[args.model_name]
+    )
+
+    model = model.eval()
+
+    # pre-autograd export. eventually this will become torch.export
+    model = export.capture_pre_autograd_graph(model, example_inputs)
+
+    edge = exir.capture(
+        model, example_inputs, exir.CaptureConfig(enable_aot=True, _unlift=True)
+    ).to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
+    logging.info(f"Exported graph:\n{edge.exported_program.graph}")
+
+    lowered_module = to_backend(MPSBackend.__name__, edge.exported_program, [])
+
+    logging.info(f"Lowered graph:\n{edge.exported_program.graph}")
+
+    class WrappedModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mps_module = lowered_module
+
+        def forward(self, input_args):
+            return self.mps_module(input_args)
+
+    executorch_program = (
+        exir.capture(
+            WrappedModule(),
+            example_inputs,
+            exir.CaptureConfig(enable_aot=True, _unlift=True),
+        )
+        .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
+        .to_executorch()
+    )
+
+    model_name = f"{args.model_name}_mps"
+
+    if args.bundled:
+        bundled_inputs = [
+            [example_inputs]
+            for _ in range(len(executorch_program.program.execution_plan))
+        ]
+
+        output = model(*example_inputs)
+        expected_outputs = [
+            [[output]] for _ in range(len(executorch_program.program.execution_plan))
+        ]
+
+        bundled_config = BundledConfig(["forward"], bundled_inputs, expected_outputs)
+        bundled_program = create_bundled_program(
+            executorch_program.program, bundled_config
+        )
+        bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
+            bundled_program
+        )
+        model_name = f"{model_name}_bundled"
+        program_buffer = bundled_program_buffer
+    else:
+        program_buffer = executorch_program.buffer
+
+    save_pte_program(program_buffer, model_name)


### PR DESCRIPTION
Summary:
This PR adds MPS Delegate support for ExecuTorch:

To use the MPS delegate, follow the following steps:

* (AOT) Generate an MPSGraph lowered module

```
python3 -m examples.apple.mps.scripts.mps_example --model_name="mv2" --bundled
```

* (RUNTIME) Once the model binary file is generated, use the mps_executor_runner to run the model:

```bash
# Build the mps_executor_runner
rm -rf cmake-out && mkdir cmake-out && cd cmake-out && cmake -DEXECUTORCH_BUILD_MPS=1 -DBUCK2=/tmp/buck2 —trace .. && cmake --build . && cd ..

# Run the bundled program
./cmake-out/examples/apple/mps/mps_executor_runner --model_path mv2_mps_bundled.pte --bundled_program

```

To see more verbose logging on the runtime, you can enable set -DCMAKE_BUILD_TYPE=Debug while building the runner.

An example tutorial can be found under examples/apple/mps/README.md. iOS instructions to run using the MPSDelegate have been updated in examples/demo-apps/apple_ios/README.md

Note that the mps_executor_runner can be used with any testcase from test_mps.py and is not limited to examples.apple.mps.scripts.mps_example. For example

```
python3 -m unittest backends.apple.mps.test.test_mps --verbose -k test_mps_backend_cumsum
```

Fix MPS delegate through simulator.

Pull Request resolved: https://github.com/pytorch/executorch/pull/754

Reviewed By: iseeyuan, guangy10

Differential Revision: D50110623

Pulled By: kimishpatel

fbshipit-source-id: 800a1d90776206dfac82fba8d9d2a0b83daf8c31