### PR TITLE
[MPS] Fix variable number of inputs in mps_example.py

### DIFF
--- a/examples/apple/mps/executor_runner/mps_executor_runner.mm
+++ b/examples/apple/mps/executor_runner/mps_executor_runner.mm
@@ -481,10 +481,11 @@ int main(int argc, char** argv) {
         strstr(model_path, "emformer_transcribe")  ||
         strstr(model_path, "emformer_join")        ||
         strstr(model_path, "edsr")                 ||
+        strstr(model_path, "llama2")               ||
         strstr(model_path, "ic3")                  ||
         strstr(model_path, "ic4")) {
         atol = 1e-04;
-      }
+    }
     status = torch::executor::util::VerifyResultWithBundledExpectedOutput(
         *method,
         file_data->data(),

--- a/examples/apple/mps/scripts/mps_example.py
+++ b/examples/apple/mps/scripts/mps_example.py
@@ -75,8 +75,8 @@ if __name__ == "__main__":
             super().__init__()
             self.mps_module = lowered_module
 
-        def forward(self, input_args):
-            return self.mps_module(input_args)
+        def forward(self, *input_args):
+            return self.mps_module(*input_args)
 
     executorch_program = (
         exir.capture(


### PR DESCRIPTION
Summary:
- fix models with variable number of inputs (>1). Needed for the models `add`, `linear`, `add_mul` where the inputs array is usually made out of 2/3 tensors.
- llama2 is also working correctly through MPS delegate. Set the `atol` to 1e-4 when doing the bundled program comparison check with the eager output from CPU.