### PR TITLE
CoreML backend changes.

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -114,6 +114,34 @@ jobs:
         # Test selective build
         PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
 
+  test-coreml-delegate:
+    name: test-coreml-delegate
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    secrets: inherit
+    strategy:
+      matrix:
+        include:
+          - build-tool: cmake
+      fail-fast: false
+    with:
+      runner: macos-13-xlarge
+      submodules: 'true'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 60
+      secrets-env: TOKEN_COREML_PRIVATE_REPO
+      script: |
+        WORKSPACE=$(pwd)
+        pushd "${WORKSPACE}/pytorch/executorch"
+        BUILD_TOOL=${{ matrix.build-tool }}
+        # Setup MacOS dependencies as there is no Docker support on MacOS atm
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+
+        # Build and test coreml delegate
+        PYTHON_EXECUTABLE=python sh backends/apple/coreml/scripts/install_requirements_internal.sh
+        PYTHON_EXECUTABLE=python sh backends/apple/coreml/scripts/build_tests.sh
+        PYTHON_EXECUTABLE=python sh backends/apple/coreml/scripts/run_tests.sh
+        popd
+
   unittest:
     uses: ./.github/workflows/_unittest.yml
     with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,6 +346,19 @@ if(EXECUTORCH_BUILD_MPS)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples/apple/mps)
 endif()
 
+# Build CoreML backend
+option(EXECUTORCH_BUILD_COREML "Build the backends/apple/coreml directory" OFF)
+if(EXECUTORCH_BUILD_COREML)
+  # CoreML delegate library can only be built with iOS toolchain
+  if(CMAKE_TOOLCHAIN_FILE MATCHES ".*(iOS\.)|(ios\.toolchain\.)cmake$")
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backends/apple/coreml)
+  else()
+    message(
+      FATAL_ERROR "executorch: Building CoreML delegate requires iOS toolchain"
+    )
+  endif()
+endif()
+
 # Add selective build subdirectory
 if(BUILD_SELECTIVE_BUILD_TEST)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples/selective_build)

--- a/backends/apple/coreml/.clang-format
+++ b/backends/apple/coreml/.clang-format
@@ -1,0 +1,29 @@
+BasedOnStyle: WebKit
+BreakBeforeBraces: Attach
+AllowShortIfStatementsOnASingleLine: false
+BreakBeforeBinaryOperators: None
+BreakConstructorInitializers: BeforeColon
+IndentCaseLabels: true
+SortIncludes: true
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceBeforeParens: ControlStatements
+AlignAfterOpenBracket: Align
+NamespaceIndentation: None
+MaxEmptyLinesToKeep: 2
+#AlignConsecutiveAssignments: true
+
+ColumnLimit: 120
+
+# When breaking up parameter/argument lists across multiple lines,
+# put only one per line instead of packing as many as possible.
+BinPackArguments: false
+BinPackParameters: false
+
+# Control of individual brace wrapping cases.
+BreakBeforeBraces: Custom
+BraceWrapping:
+  BeforeCatch: true
+
+# Options for aligning backslashes in escaped newlines.
+AlignEscapedNewlines: Left
+

--- a/backends/apple/coreml/.gitignore
+++ b/backends/apple/coreml/.gitignore
@@ -1,0 +1,25 @@
+# Mac OS X
+*.DS_Store
+
+cmake-out/
+
+
+# Xcode
+*.pbxuser
+*.mode1v3
+*.mode2v3
+*.perspectivev3
+*.xcuserstate
+project.xcworkspace/
+xcuserdata/
+
+
+runtime/runner/build/
+runtime/libraries/
+runtime/inmemoryfs/build/
+runtime/test/models/
+third-party/
+
+xcode-build/
+
+*.egg-info

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -1,0 +1,109 @@
+# Copyright © 2023 Apple Inc. All rights reserved.
+
+cmake_minimum_required(VERSION 3.19)
+
+project(executorch_coreml_backend)
+
+enable_language(CXX)
+enable_language(OBJC)
+
+# Source root directory for executorch.
+if(NOT EXECUTORCH_ROOT)
+  set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+endif()
+
+# inmemoryfs sources
+set(INMEMORYFS_SOURCES
+  runtime/inmemoryfs/inmemory_filesystem.cpp
+  runtime/inmemoryfs/memory_buffer.cpp
+  runtime/inmemoryfs/memory_stream.cpp
+  runtime/inmemoryfs/reversed_memory_stream.cpp
+)
+
+# kvstore sources
+set(KVSTORE_SOURCES
+  runtime/kvstore/database.cpp
+  runtime/kvstore/sqlite_error.cpp
+  runtime/kvstore/key_value_store.cpp
+  runtime/kvstore/statement.cpp
+)
+
+# delegate sources
+set(DELEGATE_SOURCES
+  runtime/delegate/asset.mm
+  runtime/delegate/backend_delegate.mm
+  runtime/delegate/coreml_backend_delegate.mm
+  runtime/delegate/ETCoreMLAsset.mm
+  runtime/delegate/ETCoreMLAssetManager.mm
+  runtime/delegate/ETCoreMLLogging.mm
+  runtime/delegate/ETCoreMLModel.mm
+  runtime/delegate/ETCoreMLModelManager.mm
+  runtime/delegate/ETCoreMLStrings.mm
+  runtime/delegate/MLModel_Prewarm.mm
+  runtime/delegate/MLMultiArray_Copy.mm
+  runtime/delegate/multiarray.mm
+  runtime/delegate/serde_json.mm
+)
+
+# Define the delegate library
+add_library(coremldelegate)
+target_sources(
+  coremldelegate PRIVATE
+  ${INMEMORYFS_SOURCES}
+  ${KVSTORE_SOURCES}
+  ${DELEGATE_SOURCES}
+)
+target_include_directories(
+  coremldelegate PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/runtime/include
+)
+target_include_directories(
+  coremldelegate PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/runtime/kvstore
+)
+target_include_directories(
+  coremldelegate PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/runtime/inmemoryfs
+)
+target_include_directories(
+  coremldelegate PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/runtime/delegate
+)
+target_include_directories(
+  coremldelegate PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/third-party/nlohmann_json/single_include/nlohmann
+)
+target_include_directories(
+  coremldelegate PRIVATE
+  ${EXECUTORCH_ROOT}/..
+)
+
+target_link_libraries(
+  coremldelegate PRIVATE
+  executorch
+)
+
+target_compile_options(coremldelegate PRIVATE "-fobjc-arc")
+target_compile_options(coremldelegate PRIVATE "-fno-exceptions")
+target_compile_options(coremldelegate PRIVATE "-fno-rtti")
+target_compile_definitions(coremldelegate PRIVATE JSON_NOEXCEPTION=1)
+
+set(
+  TARGET coremldelegate
+  APPEND_STRING PROPERTY COMPILE_FLAGS "-x objective-c++"
+)
+
+set(
+  TARGET coremldelegate
+  APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-null-character"
+)
+
+set(
+  TARGET coremldelegate
+  APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-receiver-expr"
+)
+
+set_property(
+  TARGET coremldelegate
+  PROPERTY CXX_STANDARD 17
+)

--- a/backends/apple/coreml/README.md
+++ b/backends/apple/coreml/README.md
@@ -1,0 +1,59 @@
+# ExecuTorch CoreML Delegate
+
+
+This subtree contains the CoreML Delegate implementation for ExecuTorch.
+CoreML is an optimized framework for running machine learning models on Apple devices. The delegate is the mechanism for leveraging the CoreML framework to accelerate operators when running on Apple devices.
+
+## Layout
+- `compiler/` : Lowers a module to CoreML backend.
+- `scripts/` : Scripts for installing dependencies and running tests.
+- `runtime/`: CoreML delegate runtime implementation.
+    - `inmemoryfs`: InMemory filesystem implementation used to serialize/de-serialize AOT blob.
+    - `kvstore`: Persistent Key-Value store implementation.
+    - `delegate`: Runtime implementation.
+    - `include` : Public headers.
+    - `tests` :  Tests for CoreML delegate.
+    - `workspace` : Xcode workspace for tests.
+- `third-party/`: External dependencies.
+
+## Help & Improvements
+If you have problems or questions or have suggestions for ways to make
+implementation and testing better, please create an issue on [github](https://www.github.com/pytorch/executorch/issues).
+
+## Delegation
+
+For delegating the Program to the **CoreML** backend, the client must be responsible for calling `to_backend` with the **CoreMLBackend** tag.
+
+```python
+import executorch.exir as exir
+import torch
+
+from executorch.exir.backend.backend_api import to_backend
+
+from executorch.backends.coreml.compiler import CoreMLBackend
+
+class LowerableSubModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return torch.sin(x)
+
+# Convert the lowerable module to Edge IR Representation
+to_be_lowered = LowerableSubModel()
+example_input = (torch.ones(1), )
+to_be_lowered_exir_submodule = exir.capture(to_be_lowered, example_input).to_edge()
+
+# Lower to CoreML backend
+lowered_module = to_backend('CoreMLBackend', to_be_lowered_exir_submodule, [])
+```
+
+Currently, the **CoreML** backend delegates the whole module to **CoreML**. If a specific op is not supported by the **CoreML** backend then the `to_backend` call would throw an exception. We will be adding a **CoreML Partitioner** to resolve the issue.
+
+The `to_backend` implementation is a thin wrapper over `coremltools`, `coremltools` is responsible for converting an **ExportedProgram** to a **MLModel**. The converted **MLModel** data is saved, flattened, and returned as bytes to **ExecuTorch**.
+
+## Runtime
+
+To execute a **CoreML** delegated **Program**, the client must link to the `coremldelegate` library. Once linked there are no additional steps required, **ExecuTorch** when running the **Program** would call the **CoreML** runtime to execute the **CoreML** delegated part of the **Program**.
+
+Please follow the instructions described in the [CoreML setup](/backends/apple/coreml/setup.md) to link the `coremldelegate` library.

--- a/backends/apple/coreml/compiler/__init__.py
+++ b/backends/apple/coreml/compiler/__init__.py
@@ -1,0 +1,9 @@
+# Copyright © 2023 Apple Inc. All rights reserved.
+#
+# Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+from .coreml_preprocess import CoreMLBackend
+
+__all__ = [
+    CoreMLBackend,
+]

--- a/backends/apple/coreml/compiler/coreml_preprocess.py
+++ b/backends/apple/coreml/compiler/coreml_preprocess.py
@@ -1,0 +1,76 @@
+#  Copyright © 2023 Apple Inc. All rights reserved.
+
+# CoreML backend for delegating a EdgeProgram to CoreML.
+
+import json
+import shutil
+import uuid
+
+from pathlib import Path
+
+from typing import final, List
+
+import coremltools as ct
+import executorchcoreml
+
+from executorch.exir.backend.backend_details import (
+    BackendDetails,
+    ExportedProgram,
+    PreprocessResult,
+)
+from executorch.exir.backend.compile_spec_schema import CompileSpec
+
+
+@final
+class CoreMLBackend(BackendDetails):
+    @staticmethod
+    def to_bytes(mlmodel):
+        dir_path = Path("tmp")
+        model_dir_path = dir_path / "lowered_module"
+        Path(model_dir_path).mkdir(parents=True, exist_ok=True)
+        model_path = model_dir_path / "model.mlpackage"
+        mlmodel.save(model_path)
+
+        # save model metdata
+        spec = mlmodel.get_spec()
+        input_names = [input.name for input in spec.description.input]
+        output_names = [output.name for output in spec.description.output]
+        identifier = uuid.uuid4()
+
+        model_metadata = {
+            "inputNames": input_names,
+            "outputNames": output_names,
+            "identifier": str(identifier),
+        }
+
+        # store metadata
+        model_metadata_path = Path(model_dir_path) / "metadata.json"
+        json_object = json.dumps(model_metadata)
+        with open(model_metadata_path, "w") as outfile:
+            outfile.write(json_object)
+
+        # flatten directory contents and convert it to bytes
+        flattened_bytes = executorchcoreml.flatten_directory_contents(
+            str(model_dir_path.resolve())
+        )
+        shutil.rmtree(str(model_dir_path.resolve()))
+        return flattened_bytes
+
+    @classmethod
+    # pyre-ignore
+    def preprocess(
+        cls,
+        edge_program: ExportedProgram,
+        module_compile_spec: List[CompileSpec],
+    ) -> PreprocessResult:
+        mlmodel = ct.convert(
+            model=edge_program,
+            source="pytorch",
+            convert_to="mlprogram",
+            pass_pipeline=ct.PassPipeline.DEFAULT,
+            skip_model_load=True,
+        )
+        flattened_bytes = CoreMLBackend.to_bytes(mlmodel)
+        return PreprocessResult(
+            processed_bytes=flattened_bytes,
+        )

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLAsset.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLAsset.h
@@ -1,0 +1,59 @@
+//
+// ETCoreMLAsset.h
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <Foundation/Foundation.h>
+
+#import <asset.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Represents an asset on the filesystem. An asset is merely a directory with a unique identifier.
+@interface ETCoreMLAsset : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Constructs an `ETCoreMLAsset` instance from `ModelAsset`
+///
+/// @param backingAsset The cpp asset.
+- (instancetype)initWithBackingAsset:(const executorchcoreml::Asset&)backingAsset NS_DESIGNATED_INITIALIZER;
+
+/// The unique identifier.
+@property (copy, readonly, nonatomic) NSString* identifier;
+
+/// The absolute URL of the asset.
+@property (copy, readonly, nonatomic) NSURL* contentURL;
+
+/// The total size of the directory in bytes.
+@property (assign, readonly, nonatomic) NSUInteger totalSizeInBytes;
+
+/// Returns `YES` is the asset is valid otherwise `NO`.
+@property (assign, readonly, nonatomic) BOOL isValid;
+
+/// Returns `YES` is the asset is alive otherwise `NO`.
+@property (assign, readonly, nonatomic) BOOL isAlive;
+
+/// Keeps the asset alive by opening and hanging on to the file handles in the asset.
+/// The file handles are closed when `close` is called or at the time of deallocation.
+///
+/// @param error   On failure, error is filled with the failure information.
+/// @retval `YES` is the file handles could be opened otherwise `NO`.
+- (BOOL)keepAliveAndReturnError:(NSError* __autoreleasing*)error;
+
+/// Pre-warms the asset by doing an advisory async read to all the content files.
+///
+/// @param error   On failure, error is filled with the failure information.
+/// @retval `YES` is the advisory read to all the files succeeded otherwise`NO`.
+- (BOOL)prewarmAndReturnError:(NSError* __autoreleasing*)error;
+
+/// Closes all the opened file handles by the `keepAliveAndReturnError` call.
+- (void)close;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLAsset.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLAsset.mm
@@ -1,0 +1,181 @@
+//
+// ETCoreMLAsset.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <ETCoreMLAsset.h>
+
+#import <fcntl.h>
+#import <os/lock.h>
+#import <stdio.h>
+#import <system_error>
+
+namespace  {
+
+using namespace executorchcoreml;
+
+inline id check_class(id obj, Class cls) {
+    return [obj isKindOfClass:cls] ? obj : nil;
+}
+
+#define SAFE_CAST(Object, Type) ((Type *)check_class(Object, [Type class]))
+
+NSDate * _Nullable get_content_modification_date(NSURL *url, NSError * __autoreleasing *error) {
+    NSDate *result = nil;
+    if (![url getResourceValue:&result forKey:NSURLContentModificationDateKey error:error]) {
+        return nil;
+    }
+    
+    return SAFE_CAST(result, NSDate);
+}
+
+bool is_asset_valid(const Asset& asset) {
+    NSURL *asset_url = [NSURL fileURLWithPath:@(asset.path.c_str())];
+    for (const auto& file_info : asset.package_info.file_infos) {
+        NSError *local_error = nil;
+        const std::string& relative_path = file_info.relative_path;
+        NSURL *file_url = [asset_url URLByAppendingPathComponent:@(relative_path.c_str())];
+        
+        NSDate *last_modification_date = get_content_modification_date(file_url, &local_error);
+        if (!last_modification_date) {
+            return false;
+        }
+        
+        int64_t last_modification_time_interval = static_cast<int64_t>(last_modification_date.timeIntervalSince1970 * 1000);
+        if (last_modification_time_interval != file_info.last_modification_time_interval) {
+            return false;
+        }
+    }
+    
+    return true;
+}
+
+void set_error_from_error_code(const std::error_code& cppError, NSError * __autoreleasing *error) {
+    if (!error || !cppError) {
+        return;
+    }
+    
+    NSString *message = @(cppError.message().c_str());
+    NSString *domain =  @(cppError.category().name());
+    NSInteger code = cppError.value();
+    NSError *localError = [NSError errorWithDomain:domain code:code userInfo:@{NSLocalizedDescriptionKey : message}];
+    *error = localError;
+}
+} //namespace
+
+@implementation ETCoreMLAsset {
+    executorchcoreml::Asset _backingAsset;
+    std::vector<std::unique_ptr<FILE, decltype(&fclose)>> _openFiles;
+    os_unfair_lock _lock;
+}
+
+- (instancetype)initWithBackingAsset:(const executorchcoreml::Asset&)backingAsset {
+    self = [super init];
+    if (self) {
+        _backingAsset = backingAsset;
+        _isValid = static_cast<BOOL>(is_asset_valid(backingAsset));
+        _identifier = @(backingAsset.identifier.c_str());
+        _contentURL = [NSURL fileURLWithPath:@(backingAsset.path.c_str())];
+        _totalSizeInBytes = backingAsset.total_size_in_bytes();
+    }
+    
+    return self;
+}
+
+- (void)dealloc {
+    [self close];
+}
+
+- (BOOL)_keepAliveAndReturnError:(NSError * __autoreleasing *)error {
+    if (!_isValid) {
+        return NO;
+    }
+    
+    const auto& fileInfos = _backingAsset.package_info.file_infos;
+    if (_openFiles.size() == fileInfos.size()) {
+        return YES;
+    }
+    
+    std::vector<std::unique_ptr<FILE, decltype(&fclose)>> openFiles;
+    for (const auto& fileInfo : fileInfos) {
+        NSURL *fileURL = [NSURL fileURLWithPath:@(fileInfo.relative_path.c_str()) relativeToURL:self.contentURL];
+        std::unique_ptr<FILE, decltype(&fclose)> file(fopen(fileURL.path.UTF8String, "rb"), fclose);
+        if (file == nullptr) {
+            ::set_error_from_error_code(std::error_code(errno, std::generic_category()), error);
+            break;
+        }
+        openFiles.emplace_back(std::move(file));
+    }
+    
+    BOOL success = (openFiles.size() == fileInfos.size());
+    if (success) {
+        _openFiles = std::move(openFiles);
+    }
+    
+    return success;
+}
+
+- (BOOL)isAlive {
+    BOOL result = NO;
+    {
+        os_unfair_lock_lock(&_lock);
+        const auto& fileInfos = _backingAsset.package_info.file_infos;
+        result = (_openFiles.size() == fileInfos.size());
+        os_unfair_lock_unlock(&_lock);
+    }
+    
+    return result;
+}
+
+- (BOOL)keepAliveAndReturnError:(NSError * __autoreleasing *)error {
+    BOOL result = NO;
+    {
+        os_unfair_lock_lock(&_lock);
+        result = [self _keepAliveAndReturnError:error];
+        os_unfair_lock_unlock(&_lock);
+    }
+    
+    return result;
+}
+
+- (BOOL)prewarmAndReturnError:(NSError * __autoreleasing *)error {
+    std::vector<int> fds;
+    {
+        os_unfair_lock_lock(&_lock);
+        if ([self _keepAliveAndReturnError:error]) {
+            for (const auto& file : _openFiles) {
+                fds.emplace_back(fileno(file.get()));
+            }
+        }
+        os_unfair_lock_unlock(&_lock);
+    }
+    
+    const auto& fileInfos = _backingAsset.package_info.file_infos;
+    if (fds.size() != fileInfos.size()) {
+        return NO;
+    }
+    
+    for (size_t i = 0; i < fileInfos.size(); i++) {
+        const auto& fileInfo = fileInfos[i];
+        size_t sizeInBytes = fileInfo.size_in_bytes;
+        struct radvisory advisory = { .ra_offset = 0, .ra_count = (int)sizeInBytes };
+        int fd = fds[i];
+        int status = fcntl(fd, F_RDADVISE, &advisory);
+        if (status == -1) {
+            ::set_error_from_error_code(std::error_code(errno, std::system_category()), error);
+            return NO;
+        }
+    }
+    
+    return YES;
+}
+
+- (void)close {
+    os_unfair_lock_lock(&_lock);
+    _openFiles.clear();
+    os_unfair_lock_unlock(&_lock);
+}
+
+@end

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLAssetManager.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLAssetManager.h
@@ -1,0 +1,122 @@
+//
+// ETCoreMLAssetManager.h
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <Foundation/Foundation.h>
+
+#import <database.hpp>
+
+@class ETCoreMLAsset;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A class responsible for managing the assets created by the delegate.
+@interface ETCoreMLAssetManager : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Constructs an `ETCoreMLAssetManager` instance.
+///
+/// @param database The sqlite database that will be used to keep track of assets.
+/// @param assetsDirectoryURL The directory URL where the assets will be stored.
+/// @param trashDirectoryURL   The directory URL where the assets will be moved before deletion.
+/// @param maxAssetsSizeInBytes   The maximum assets size in bytes.
+/// @param error   On failure, error is filled with the failure information.
+- (nullable instancetype)initWithDatabase:(const std::shared_ptr<executorchcoreml::sqlite::Database>&)database
+                       assetsDirectoryURL:(NSURL*)assetsDirectoryURL
+                        trashDirectoryURL:(NSURL*)trashDirectoryURL
+                     maxAssetsSizeInBytes:(NSInteger)maxAssetsSizeInBytes
+                                    error:(NSError* __autoreleasing*)error NS_DESIGNATED_INITIALIZER;
+
+/// Constructs an `ETCoreMLAssetManager` instance.
+///
+/// @param databaseURL The URL to the database that will be used to keep track of assets.
+/// @param assetsDirectoryURL The directory URL where the assets will be stored.
+/// @param trashDirectoryURL   The directory URL where the assets will be moved before deletion.
+/// @param maxAssetsSizeInBytes   The maximum assets size in bytes.
+/// @param error   On failure, error is filled with the failure information.
+- (nullable instancetype)initWithDatabaseURL:(NSURL*)databaseURL
+                          assetsDirectoryURL:(NSURL*)assetsDirectoryURL
+                           trashDirectoryURL:(NSURL*)trashDirectoryURL
+                        maxAssetsSizeInBytes:(NSInteger)maxAssetsSizeInBytes
+                                       error:(NSError* __autoreleasing*)error;
+
+/// Stores an asset at the url. The contents of the url are moved to the assets directory and it's
+/// lifecycle is managed by the`ETCoreMLAssetManager`.
+///
+/// @param url The URL to the directory.
+/// @param identifier An unique identifier to associate the asset with.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval The `ETCoreMLAsset` instance representing the asset if the store was successful
+/// otherwise `nil`.
+- (nullable ETCoreMLAsset*)storeAssetAtURL:(NSURL*)url
+                            withIdentifier:(NSString*)identifier
+                                     error:(NSError* __autoreleasing*)error;
+
+/// Returns the asset associated with the identifier.
+///
+/// @param identifier The asset identifier.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval The `ETCoreMLAsset` instance representing the asset if the retrieval was successful
+/// otherwise `nil`.
+- (nullable ETCoreMLAsset*)assetWithIdentifier:(NSString*)identifier error:(NSError* __autoreleasing*)error;
+
+/// Removes an asset associated with the identifier.
+///
+/// @param identifier The asset identifier.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval `YES` is the asset was removed or didn't exist otherwise `NO`.
+- (BOOL)removeAssetWithIdentifier:(NSString*)identifier error:(NSError* __autoreleasing*)error;
+
+/// Checks if the asset associated with the identifier exists.
+///
+/// @param identifier The asset identifier.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval `YES` is the asset exists otherwise `NO`.
+- (BOOL)hasAssetWithIdentifier:(NSString*)identifier error:(NSError* __autoreleasing*)error;
+
+/// Returns an array of most recently used assets. Assets are sorted in descending order by their
+/// access time and the first `maxCount` assets are returned. The access time of an asset is updated
+/// when the asset is stored or retrieved.
+///
+/// @param maxCount The max count of assets to return.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval An array of most recently used assets
+- (nullable NSArray<ETCoreMLAsset*>*)mostRecentlyUsedAssetsWithMaxCount:(NSUInteger)maxCount
+                                                                  error:(NSError* __autoreleasing*)error;
+
+/// Compacts the assets storage. The assets are moved to the trash directory and are asynchronously
+/// deleted.
+///
+/// @param sizeInBytes The maximum size of the assets storage that the compaction should achieve.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval The size of the assets store after the compaction.
+- (NSUInteger)compact:(NSUInteger)sizeInBytes error:(NSError* __autoreleasing*)error;
+
+
+/// Purges the assets storage. The assets are moved to the trash directory and are asynchronously
+/// deleted.
+///
+/// @param error   On failure, error is filled with the failure information.
+/// @retval `YES` is the assets are purged otherwise `NO`.
+- (BOOL)purge:(NSError* __autoreleasing*)error;
+
+/// The estimated size of the assets store. The returned value might not correct if the asset
+/// directory is tampered externally.
+@property (assign, readonly, atomic) NSInteger estimatedSizeInBytes;
+
+/// The maximum size of the assets store.
+@property (assign, readonly, nonatomic) NSInteger maxAssetsSizeInBytes;
+
+/// The trash directory URL, the assets before removal are moved to this directory. The directory
+/// contents are deleted asynchronously.
+@property (copy, readonly, nonatomic) NSURL* trashDirectoryURL;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLAssetManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLAssetManager.mm
@@ -1,0 +1,761 @@
+//
+// ETCoreMLAssetManager.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import "ETCoreMLAssetManager.h"
+
+#import <iostream>
+#import <sstream>
+
+#import <database.hpp>
+#import <json_key_value_store.hpp>
+#import <serde_json.h>
+
+#import <ETCoreMLAsset.h>
+#import <ETCoreMLLogging.h>
+
+namespace  {
+
+using namespace executorchcoreml;
+using namespace executorchcoreml::sqlite;
+using json = nlohmann::json;
+
+constexpr size_t kBusyTimeIntervalInMS = 100;
+
+constexpr std::string_view kModelAssetsStoreName = "MODEL_ASSETS_STORE";
+constexpr std::string_view kModelAssetsMetaStoreName = "MODEL_ASSETS_STORE_META";
+
+class ModelAssetsStore {
+public:
+    using StoreType = JSONKeyValueStore<std::string, Asset>;
+    
+    ModelAssetsStore(std::unique_ptr<StoreType> impl) noexcept
+    :impl_(std::move(impl))
+    {}
+    
+    ModelAssetsStore() noexcept
+    :impl_(nullptr)
+    {}
+    
+    ModelAssetsStore(const ModelAssetsStore &) = delete;
+    ModelAssetsStore &operator=(const ModelAssetsStore &) = delete;
+    
+    ModelAssetsStore& operator=(ModelAssetsStore&& rhs) noexcept {
+        rhs.impl_.swap(impl_);
+        return *this;
+    }
+    
+    ModelAssetsStore(ModelAssetsStore&& rhs) noexcept
+    :impl_(std::move(rhs.impl_))
+    {}
+    
+    inline StoreType *impl() {
+        return impl_.get();
+    }
+    
+private:
+    std::unique_ptr<StoreType> impl_;
+};
+
+class ModelAssetsMetaStore {
+public:
+    using StoreType = KeyValueStore<std::string, size_t>;
+    
+    ModelAssetsMetaStore() noexcept
+    :impl_(nullptr)
+    {}
+    
+    ModelAssetsMetaStore(std::unique_ptr<StoreType> impl) noexcept
+    :impl_(std::move(impl))
+    {}
+    
+    ModelAssetsMetaStore(const ModelAssetsMetaStore &) = delete;
+    ModelAssetsMetaStore &operator=(const ModelAssetsMetaStore &) = delete;
+    
+    ModelAssetsMetaStore& operator=(ModelAssetsMetaStore&& rhs) noexcept {
+        rhs.impl_.swap(impl_);
+        return *this;
+    }
+    
+    ModelAssetsMetaStore(ModelAssetsMetaStore&& rhs) noexcept
+    :impl_(std::move(rhs.impl_))
+    {}
+    
+    inline StoreType *impl() {
+        return impl_.get();
+    }
+    
+private:
+    std::unique_ptr<StoreType> impl_;
+};
+
+void set_error_from_error_code(const std::error_code& cppError, NSError * __autoreleasing *error) {
+    if (!error || !cppError) {
+        return;
+    }
+    
+    NSString *message = @(cppError.message().c_str());
+    NSString *domain =  @(cppError.category().name());
+    NSInteger code = cppError.value();
+    NSError *localError = [NSError errorWithDomain:domain code:code userInfo:@{NSLocalizedDescriptionKey : message}];
+    *error = localError;
+}
+
+std::shared_ptr<Database> make_database(NSURL *database_url,
+                                        NSTimeInterval busy_time_interval,
+                                        NSError * __autoreleasing *error) {
+    Database::OpenOptions options;
+    options.set_read_write_option(true);
+    options.set_create_option(true);
+    
+    std::error_code ec;
+    auto database = Database::make(database_url.path.UTF8String,
+                                   options,
+                                   Database::SynchronousMode::Normal,
+                                   busy_time_interval,
+                                   ec);
+    if (!database) {
+        ::set_error_from_error_code(ec, error);
+        return nullptr;
+    }
+    
+    return database;
+}
+
+ModelAssetsStore make_assets_store(const std::shared_ptr<Database>& database,
+                                   NSError * __autoreleasing *error) {
+    std::error_code ec;
+    auto store = ModelAssetsStore::StoreType::make(std::move(database), std::string(kModelAssetsStoreName), ec);
+    if (!store) {
+        ::set_error_from_error_code(ec, error);
+        return ModelAssetsStore(nullptr);
+    }
+    
+    return ModelAssetsStore(std::move(store));
+}
+
+ModelAssetsMetaStore make_assets_meta_store(const std::shared_ptr<Database>& database,
+                                            NSError * __autoreleasing *error) {
+    std::error_code ec;
+    auto store = ModelAssetsMetaStore::StoreType::make(std::move(database), std::string(kModelAssetsMetaStoreName), ec);
+    if (!store) {
+        ::set_error_from_error_code(ec, error);
+        return ModelAssetsMetaStore(nullptr);
+    }
+    
+    return ModelAssetsMetaStore(std::move(store));
+}
+
+std::optional<size_t> get_total_assets_size(ModelAssetsMetaStore& store,
+                                            std::error_code& ec) {
+    std::string name = std::string(kModelAssetsStoreName);
+    auto total_size = store.impl()->get(name, ec);
+    
+    if (!total_size && !store.impl()->put(name, size_t(0), ec)) {
+        return std::nullopt;
+    }
+    
+    size_t result = total_size.has_value() ? total_size.value() : size_t(0);
+    return result;
+}
+
+bool set_total_assets_size(size_t total_size,
+                           ModelAssetsMetaStore& store,
+                           std::error_code& ec) {
+    if (!store.impl()->put(std::string(kModelAssetsStoreName), total_size, ec)) {
+        return false;
+    }
+    
+    return true;
+}
+
+bool exclude_item_from_backup(NSURL *url, NSError * __autoreleasing *error) {
+    return [url setResourceValue:@(YES) forKey:NSURLIsExcludedFromBackupKey error:error];
+}
+
+NSURL * _Nullable create_directory_if_needed(NSURL *url,
+                                             NSString *name,
+                                             NSFileManager *fm,
+                                             NSError * __autoreleasing *error) {
+    NSURL *directory_url = [url URLByAppendingPathComponent:name];
+    if (![fm fileExistsAtPath:directory_url.path] &&
+        ![fm createDirectoryAtURL:directory_url withIntermediateDirectories:NO attributes:@{} error:error]) {
+        return nil;
+    }
+    
+    ::exclude_item_from_backup(directory_url, nil);
+    
+    return directory_url;
+}
+
+bool is_directory_empty(NSURL *url, NSFileManager *fm, NSError * __autoreleasing *error) {
+    BOOL is_directory = NO;
+    if (![fm fileExistsAtPath:url.path isDirectory:&is_directory] && !is_directory) {
+        return true;
+    }
+    
+    __block NSError *local_error = nil;
+    BOOL (^errorHandler)(NSURL *url, NSError *error) = ^BOOL(NSURL *url, NSError *enumeration_error) {
+        local_error = enumeration_error;
+        return NO;
+    };
+    
+    NSDirectoryEnumerator *enumerator = [fm enumeratorAtURL:url
+                                 includingPropertiesForKeys:@[]
+                                                    options:NSDirectoryEnumerationProducesRelativePathURLs
+                                               errorHandler:errorHandler];
+    if (local_error && error) {
+        *error = local_error;
+    }
+    
+    return [enumerator nextObject] == nil;
+}
+
+NSURL * _Nullable get_asset_url(const Asset& asset) {
+    return [NSURL fileURLWithPath:@(asset.path.c_str())];
+}
+
+BOOL is_asset_alive(NSMapTable<NSString *, ETCoreMLAsset *> *assets_in_use_map, NSString *identifier) {
+    ETCoreMLAsset *asset = [assets_in_use_map objectForKey:identifier];
+    return asset && asset.isAlive;
+}
+
+std::vector<executorchcoreml::Asset>
+get_assets_to_remove(ModelAssetsStore& store,
+                     ssize_t bytes_to_remove,
+                     NSMapTable<NSString *, ETCoreMLAsset *> *assets_in_use_map,
+                     std::error_code &error) {
+    std::vector<Asset> assets;
+    store.impl()->get_keys_sorted_by_access_count([store = store.impl(),
+                                                   &bytes_to_remove,
+                                                   &assets,
+                                                   assets_in_use_map,
+                                                   &error](const std::string& key) {
+        if (bytes_to_remove <= 0) {
+            return false;
+        }
+        
+        NSString *identifier = @(key.c_str());
+        // Asset is in use, we can't remove it
+        if (::is_asset_alive(assets_in_use_map, identifier)) {
+            return true;
+        }
+        
+        auto asset = store->get(key, error);
+        if (asset) {
+            auto& asset_value = asset.value();
+            bytes_to_remove -= static_cast<ssize_t>(asset_value.total_size_in_bytes());
+            assets.emplace_back(std::move(asset_value));
+        }
+        
+        return true;
+    }, SortOrder::Ascending, error);
+    
+    return assets;
+}
+} //namespace
+
+@interface ETCoreMLAssetManager () <NSFileManagerDelegate> {
+    ModelAssetsStore _assetsStore;
+    ModelAssetsMetaStore _assetsMetaStore;
+}
+
+@property (assign, readwrite, atomic) NSInteger estimatedSizeInBytes;
+@property (copy, readonly, nonatomic) NSURL *assetsDirectoryURL;
+@property (strong, readonly, nonatomic) NSFileManager *fileManager;
+@property (strong, readonly, nonatomic) dispatch_queue_t syncQueue;
+@property (strong, readonly, nonatomic) dispatch_queue_t trashQueue;
+@property (strong, readonly, nonatomic) NSMapTable<NSString *, ETCoreMLAsset *> *assetsInUseMap;
+
+@end
+
+@implementation ETCoreMLAssetManager
+
+- (nullable instancetype)initWithDatabase:(const std::shared_ptr<Database>&)database
+                       assetsDirectoryURL:(NSURL *)assetsDirectoryURL
+                        trashDirectoryURL:(NSURL *)trashDirectoryURL
+                     maxAssetsSizeInBytes:(NSInteger)maxAssetsSizeInBytes
+                                    error:(NSError * __autoreleasing *)error {
+    
+    auto assetsStore = ::make_assets_store(database, error);
+    if (assetsStore.impl() == nullptr) {
+        return nil;
+    }
+    
+    auto assetsMetaStore = ::make_assets_meta_store(database, error);
+    if (assetsMetaStore.impl() == nullptr) {
+        return nil;
+    }
+    
+    std::error_code ec;
+    auto sizeInBytes = ::get_total_assets_size(assetsMetaStore, ec);
+    if (!sizeInBytes) {
+        ::set_error_from_error_code(ec, error);
+        return nil;
+    }
+    
+    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    NSURL *managedAssetsDirectoryURL = ::create_directory_if_needed(assetsDirectoryURL, @"models", fileManager, error);
+    if (!managedAssetsDirectoryURL) {
+        return nil;
+    }
+    
+    NSURL *managedTrashDirectoryURL = ::create_directory_if_needed(trashDirectoryURL, @"models", fileManager, error);
+    if (!managedTrashDirectoryURL) {
+        return nil;
+    }
+    
+    // If directory is empty then purge the stores
+    if (::is_directory_empty(managedAssetsDirectoryURL, fileManager, nil)) {
+        assetsMetaStore.impl()->purge(ec);
+        assetsStore.impl()->purge(ec);
+    }
+    
+    if (self = [super init]) {
+        _assetsStore = std::move(assetsStore);
+        _assetsMetaStore = std::move(assetsMetaStore);
+        _assetsDirectoryURL = managedAssetsDirectoryURL;
+        _trashDirectoryURL = managedTrashDirectoryURL;
+        _estimatedSizeInBytes = sizeInBytes.value();
+        _maxAssetsSizeInBytes = maxAssetsSizeInBytes;
+        
+        _fileManager = fileManager;
+        _trashQueue = dispatch_queue_create("com.executorchcoreml.assetmanager.trash", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+        _syncQueue = dispatch_queue_create("com.executorchcoreml.assetmanager.sync", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+        _assetsInUseMap = [NSMapTable strongToWeakObjectsMapTable];
+    }
+    
+    [self triggerCompaction];
+    return self;
+}
+
+- (nullable instancetype)initWithDatabaseURL:(NSURL *)databaseURL
+                          assetsDirectoryURL:(NSURL *)assetsDirectoryURL
+                           trashDirectoryURL:(NSURL *)trashDirectoryURL
+                        maxAssetsSizeInBytes:(NSInteger)maxAssetsSizeInBytes
+                                       error:(NSError * __autoreleasing *)error {
+    auto database = make_database(databaseURL, kBusyTimeIntervalInMS, error);
+    if (!database) {
+        return nil;
+    }
+    
+    return [self initWithDatabase:database
+               assetsDirectoryURL:assetsDirectoryURL
+                trashDirectoryURL:trashDirectoryURL
+             maxAssetsSizeInBytes:maxAssetsSizeInBytes
+                            error:error];
+}
+
+- (nullable NSURL *)moveURL:(NSURL *)url
+     toUniqueURLInDirectory:(NSURL *)directoryURL
+                      error:(NSError * __autoreleasing *)error {
+    NSURL *dstURL = [directoryURL URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+    if (![self.fileManager moveItemAtURL:url toURL:dstURL error:error]) {
+        return nil;
+    }
+    
+    return dstURL;
+}
+
+- (void)cleanupAssetIfNeeded:(ETCoreMLAsset *)asset {
+    if (!asset || asset.isValid) {
+        return;
+    }
+    
+    NSString *identifier = asset.identifier;
+    dispatch_async(self.syncQueue, ^{
+        NSError *cleanupError = nil;
+        if (![self _removeAssetWithIdentifier:asset.identifier error:&cleanupError]) {
+            ETCoreMLLogError(cleanupError,
+                             "%@: Failed to remove asset with identifier = %@",
+                             NSStringFromClass(ETCoreMLAssetManager.class),
+                             identifier);
+        }
+    });
+}
+
+- (nullable ETCoreMLAsset *)_storeAssetAtURL:(NSURL *)srcURL
+                              withIdentifier:(NSString *)identifier
+                                       error:(NSError * __autoreleasing *)error {
+    dispatch_assert_queue(self.syncQueue);
+    NSString *extension = srcURL.lastPathComponent.pathExtension;
+    NSURL *dstURL = [self.assetsDirectoryURL URLByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", identifier, extension]];
+    auto asset = Asset::make(srcURL, identifier, self.fileManager, error);
+    if (!asset) {
+        return nil;
+    }
+    
+    auto& assetValue = asset.value();
+    size_t assetSizeInBytes = assetValue.total_size_in_bytes();
+    std::error_code ec;
+    // Update the stores inside a transaction, if anything fails it will automatically rollback to the previous state.
+    bool status = _assetsStore.impl()->transaction([self, &assetValue, assetSizeInBytes, srcURL, dstURL, &ec, error]() {
+        const std::string& assetIdentifier = assetValue.identifier;
+        // If an asset exists with the same identifier then remove it.
+        if (![self _removeAssetWithIdentifier:@(assetIdentifier.c_str()) error:error]) {
+            return false;
+        }
+        
+        // Update asset path.
+        assetValue.path = dstURL.path.UTF8String;
+        // Store the asset.
+        if (!_assetsStore.impl()->put(assetIdentifier, assetValue, ec)) {
+            return false;
+        }
+        
+        // Update the size of the store.
+        if (!::set_total_assets_size(_estimatedSizeInBytes + assetSizeInBytes, _assetsMetaStore, ec)) {
+            return false;
+        }
+        
+        // If an asset exists move it
+        [self moveURL:dstURL toUniqueURLInDirectory:self.trashDirectoryURL error:nil];
+        
+        // Move the asset to assets directory.
+        if (![self.fileManager moveItemAtURL:srcURL toURL:dstURL error:error]) {
+            return false;
+        }
+        
+        return true;
+    }, Database::TransactionBehavior::Immediate, ec);
+    
+    // Update the estimated size if the transaction succeeded.
+    _estimatedSizeInBytes += status ? assetSizeInBytes : 0;
+    ::set_error_from_error_code(ec, error);
+    
+    ETCoreMLAsset *result = status ? [[ETCoreMLAsset alloc] initWithBackingAsset:assetValue] : nil;
+    if ([result keepAliveAndReturnError:error]) {
+        [self.assetsInUseMap setObject:result forKey:identifier];
+    } else {
+        [self cleanupAssetIfNeeded:result];
+    }
+    
+    return result;
+}
+
+- (void)triggerCompaction {
+    if (self.estimatedSizeInBytes < self.maxAssetsSizeInBytes) {
+        return;
+    }
+    
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(self.syncQueue, ^{
+        NSError *localError = nil;
+        if (![weakSelf _compact:self.maxAssetsSizeInBytes error:&localError]) {
+            ETCoreMLLogError(localError,
+                             "%@: Failed to compact asset store.",
+                             NSStringFromClass(ETCoreMLAssetManager.class));
+        }
+    });
+}
+
+- (nullable ETCoreMLAsset *)storeAssetAtURL:(NSURL *)url
+                             withIdentifier:(NSString *)identifier
+                                      error:(NSError * __autoreleasing *)error {
+    __block ETCoreMLAsset *result = nil;
+    dispatch_sync(self.syncQueue, ^{
+        result = [self _storeAssetAtURL:url withIdentifier:identifier error:error];
+    });
+    
+    [self triggerCompaction];
+    return result;
+}
+
+- (nullable ETCoreMLAsset *)_assetWithIdentifier:(NSString *)identifier
+                                           error:(NSError * __autoreleasing *)error {
+    dispatch_assert_queue(self.syncQueue);
+    std::string assetIdentifier(identifier.UTF8String);
+    std::error_code ec;
+    auto asset = _assetsStore.impl()->get(assetIdentifier, ec);
+    if (!asset) {
+        ::set_error_from_error_code(ec, error);
+        return nil;
+    }
+    
+    const auto& assetValue = asset.value();
+    ETCoreMLAsset *modelAsset = [[ETCoreMLAsset alloc] initWithBackingAsset:assetValue];
+    [self.assetsInUseMap setObject:modelAsset forKey:identifier];
+    
+    return modelAsset;
+}
+
+- (nullable ETCoreMLAsset *)assetWithIdentifier:(NSString *)identifier
+                                          error:(NSError * __autoreleasing *)error {
+    __block ETCoreMLAsset *result = nil;
+    dispatch_sync(self.syncQueue, ^{
+        result = [self _assetWithIdentifier:identifier error:error];
+    });
+    
+    if ([result keepAliveAndReturnError:error]) {
+        [self.assetsInUseMap setObject:result forKey:identifier];
+    } else {
+        [self cleanupAssetIfNeeded:result];
+    }
+    
+    return result;
+}
+
+- (BOOL)_containsAssetWithIdentifier:(NSString *)identifier
+                               error:(NSError * __autoreleasing *)error {
+    dispatch_assert_queue(self.syncQueue);
+    std::error_code ec;
+    BOOL result = static_cast<BOOL>(_assetsStore.impl()->exists(std::string(identifier.UTF8String), ec));
+    ::set_error_from_error_code(ec, error);
+    
+    return result;
+}
+
+- (BOOL)hasAssetWithIdentifier:(NSString *)identifier
+                         error:(NSError * __autoreleasing *)error {
+    __block BOOL result = NO;
+    dispatch_sync(self.syncQueue, ^{
+        result = [self _containsAssetWithIdentifier:identifier error:error];
+    });
+    
+    return result;
+}
+
+- (BOOL)_removeAssetWithIdentifier:(NSString *)identifier
+                             error:(NSError * __autoreleasing *)error {
+    dispatch_assert_queue(self.syncQueue);
+    // Asset is alive we can't delete it.
+    if (is_asset_alive(self.assetsInUseMap, identifier)) {
+        return NO;
+    }
+    
+    std::error_code ec;
+    std::string assetIdentifier(identifier.UTF8String);
+    auto asset = _assetsStore.impl()->get(assetIdentifier, ec);
+    // If it's an error then we can't proceed.
+    if (ec) {
+        ::set_error_from_error_code(ec, error);
+        return NO;
+    }
+    
+    // Asset doesn't exists, we are good.
+    if (!asset) {
+        return YES;
+    }
+    
+    const auto& assetValue = asset.value();
+    size_t assetSizeInBytes = std::min(_estimatedSizeInBytes, static_cast<NSInteger>(assetValue.total_size_in_bytes()));
+    // Update the stores inside a transaction, if anything fails it will automatically rollback to the previous state.
+    bool status = _assetsStore.impl()->transaction([self, &assetValue, assetSizeInBytes, &ec, error]() {
+        if (!self->_assetsStore.impl()->remove(assetValue.identifier, ec)) {
+            return false;
+        }
+        
+        if (!::set_total_assets_size(_estimatedSizeInBytes - assetSizeInBytes, _assetsMetaStore, ec)) {
+            return false;
+        }
+        
+        NSURL *assetURL = ::get_asset_url(assetValue);
+        if ([self.fileManager fileExistsAtPath:assetURL.path] &&
+            ![self moveURL:assetURL toUniqueURLInDirectory:self.trashDirectoryURL error:error]) {
+            return false;
+        }
+        
+        return true;
+    }, Database::TransactionBehavior::Immediate, ec);
+    
+    // Update the estimated size if the transaction succeeded.
+    _estimatedSizeInBytes -= status ? assetSizeInBytes : 0;
+    ::set_error_from_error_code(ec, error);
+    return static_cast<BOOL>(status);
+}
+
+- (BOOL)removeAssetWithIdentifier:(NSString *)identifier
+                            error:(NSError * __autoreleasing *)error {
+    __block BOOL result = NO;
+    dispatch_sync(self.syncQueue, ^{
+        result = [self _removeAssetWithIdentifier:identifier error:error];
+    });
+    
+    return result;
+}
+
+- (nullable NSArray<ETCoreMLAsset *> *)_recentlyUsedAssetsWithMaxCount:(NSUInteger)maxCount
+                                                                 error:(NSError * __autoreleasing *)error {
+    dispatch_assert_queue(self.syncQueue);
+    
+    NSMutableArray<ETCoreMLAsset *> *assets = [NSMutableArray arrayWithCapacity:maxCount];
+    std::error_code ec;
+    bool status = _assetsStore.impl()->get_keys_sorted_by_access_time([self, maxCount, assets](const std::string& key) {
+        NSError *localError = nil;
+        NSString *identifier = @(key.c_str());
+        ETCoreMLAsset *asset = [self _assetWithIdentifier:identifier error:&localError];
+        
+        if (asset) {
+            [assets addObject:asset];
+        } else if (localError) {
+            ETCoreMLLogError(localError,
+                             "%@: Failed to retrieve asset with identifier = %@",
+                             NSStringFromClass(ETCoreMLAssetManager.class),
+                             identifier);
+        }
+        
+        return assets.count < maxCount;
+    }, SortOrder::Descending, ec);
+    
+    ::set_error_from_error_code(ec, error);
+    return status ? assets : nil;
+}
+
+- (nullable NSArray<ETCoreMLAsset *> *)mostRecentlyUsedAssetsWithMaxCount:(NSUInteger)maxCount
+                                                                    error:(NSError * __autoreleasing *)error {
+    __block NSArray<ETCoreMLAsset *> *result = nil;
+    dispatch_sync(self.syncQueue, ^{
+        result = [self _recentlyUsedAssetsWithMaxCount:maxCount error:error];
+    });
+    
+    return result;
+}
+
+- (BOOL)_canPurgeStore {
+    dispatch_assert_queue(self.syncQueue);
+    
+    NSEnumerator *keyEnumerator = self.assetsInUseMap.keyEnumerator;
+    for (NSString *identifier in keyEnumerator) {
+        if (is_asset_alive(self.assetsInUseMap, identifier)) {
+            return NO;
+        }
+    }
+    
+    return YES;
+}
+
+- (NSUInteger)_compact:(NSUInteger)sizeInBytes error:(NSError * __autoreleasing *)error {
+    dispatch_assert_queue(self.syncQueue);
+    
+    if (sizeInBytes == 0 && [self _canPurgeStore]) {
+        return [self _purge:error] ? 0 : _estimatedSizeInBytes;
+    }
+    
+    if (_estimatedSizeInBytes <= sizeInBytes) {
+        return YES;
+    }
+    
+    std::error_code ec;
+    ssize_t bytesToRemove = _estimatedSizeInBytes - sizeInBytes;
+    const auto& assets = ::get_assets_to_remove(_assetsStore, bytesToRemove, self.assetsInUseMap, ec);
+    
+    if (ec) {
+        ::set_error_from_error_code(ec, error);
+        return _estimatedSizeInBytes;
+    }
+    
+    for (const auto& asset : assets) {
+        NSError *cleanupError = nil;
+        NSString *identifier = @(asset.identifier.c_str());
+        if (![self _removeAssetWithIdentifier:identifier error:&cleanupError] && cleanupError) {
+            ETCoreMLLogError(cleanupError,
+                             "%@: Failed to remove asset with identifier = %@",
+                             NSStringFromClass(ETCoreMLAssetManager.class),
+                             identifier);
+        }
+    }
+    
+    // Trigger cleanup.
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(self.trashQueue, ^{
+        [weakSelf removeFilesInTrashDirectory];
+    });
+    
+    return _estimatedSizeInBytes;
+}
+
+- (NSUInteger)compact:(NSUInteger)sizeInBytes error:(NSError * __autoreleasing *)error {
+    __block NSUInteger result = 0;
+    dispatch_sync(self.syncQueue, ^{
+        result = [self _compact:sizeInBytes error:error];
+    });
+    
+    return result;
+}
+
+- (void)removeFilesInTrashDirectory {
+    dispatch_assert_queue(self.trashQueue);
+    
+    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    fileManager.delegate = self;
+    __block NSError *localError = nil;
+    BOOL (^errorHandler)(NSURL *url, NSError *error) = ^BOOL(NSURL *url, NSError *enumerationError) {
+        localError = enumerationError;
+        return YES;
+    };
+    
+    NSDirectoryEnumerator *enumerator = [fileManager enumeratorAtURL:self.trashDirectoryURL
+                                          includingPropertiesForKeys:@[]
+                                                             options:NSDirectoryEnumerationSkipsSubdirectoryDescendants
+                                                        errorHandler:errorHandler];
+    for (NSURL *itemURL in enumerator) {
+        if (![fileManager removeItemAtURL:itemURL error:&localError]) {
+            ETCoreMLLogError(localError,
+                             "%@: Failed to remove item in trash directory with name = %@",
+                             NSStringFromClass(ETCoreMLAssetManager.class),
+                             itemURL.lastPathComponent);
+        }
+    }
+}
+
+- (BOOL)_purge:(NSError * __autoreleasing *)error {
+    dispatch_assert_queue(self.syncQueue);
+    
+    std::error_code ec;
+    bool status = _assetsStore.impl()->transaction([self, &ec, error]() {
+        // Purge the assets store.
+        if (!self->_assetsStore.impl()->purge(ec)) {
+            return false;
+        }
+        
+        // Purge the assets size store.
+        if (!self->_assetsMetaStore.impl()->purge(ec)) {
+            return false;
+        }
+        
+        // Move the the whole assets directory to the temp directory.
+        if (![self moveURL:self.assetsDirectoryURL toUniqueURLInDirectory:self.trashDirectoryURL error:error]) {
+            return false;
+        }
+        
+        self->_estimatedSizeInBytes = 0;
+        NSError *localError = nil;
+        // Create the assets directory, if we fail here it's okay.
+        if (![self.fileManager createDirectoryAtURL:self.assetsDirectoryURL withIntermediateDirectories:NO attributes:@{} error:&localError]) {
+            ETCoreMLLogError(localError,
+                             "%@: Failed to create assets directory",
+                             NSStringFromClass(ETCoreMLAssetManager.class));
+        }
+        
+        return true;
+    }, Database::TransactionBehavior::Immediate, ec);
+    
+    ::set_error_from_error_code(ec, error);
+    // Trigger cleanup
+    if (status) {
+        __weak __typeof(self) weakSelf = self;
+        dispatch_async(self.trashQueue, ^{
+            [weakSelf removeFilesInTrashDirectory];
+        });
+    }
+    
+    return static_cast<BOOL>(status);
+}
+
+- (BOOL)purge:(NSError * __autoreleasing *)error {
+    __block BOOL result = 0;
+    dispatch_sync(self.syncQueue, ^{
+        result = [self _purge:error];
+    });
+    
+    return result;
+}
+
+- (BOOL)fileManager:(NSFileManager *)fileManager shouldProceedAfterError:(NSError *)error removingItemAtURL:(NSURL *)URL {
+    return YES;
+}
+
+@end

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.h
@@ -1,0 +1,80 @@
+//
+// ETCoreMLLogging.h
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <Foundation/Foundation.h>
+
+#import <os/log.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// The error domain for the delegate error.
+extern NSErrorDomain const ETCoreMLErrorDomain;
+
+/// The error codes that are exposed publicly.
+typedef NS_ERROR_ENUM(ETCoreMLErrorDomain, ETCoreMLError) {
+    ETCoreMLErrorCorruptedData = 1, // AOT blob can't be parsed.
+    ETCoreMLErrorCorruptedMetadata, // AOT blob has incorrect or missing metadata.
+    ETCoreMLErrorCorruptedModel, // AOT blob has incorrect or missing CoreML model.
+    ETCoreMLErrorBrokenModel, // CoreML model doesn't match the input and output specification.
+    ETCoreMLErrorCompilationFailed, // CoreML model failed to compile.
+    ETCoreMLErrorModelSaveFailed, // Failed to save CoreML model to disk.
+    ETCoreMLErrorModelCacheCreationFailed // Failed to create model cache.
+};
+
+@interface ETCoreMLErrorUtils : NSObject
+
++ (NSError*)errorWithCode:(ETCoreMLError)code
+          underlyingError:(nullable NSError*)underlyingError
+                   format:(nullable NSString*)description, ... NS_FORMAT_FUNCTION(3, 4);
+
++ (NSError*)errorWithIntegerCode:(NSInteger)code
+                 underlyingError:(nullable NSError*)underlyingError
+                          format:(nullable NSString*)format
+                            args:(va_list)args;
+
+@property (class, strong, readonly, nonatomic, nullable) os_log_t loggingChannel;
+
+@end
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+
+/// Record the error with `os_log_error` and fills `*errorOut` with `NSError`.
+#define ETCoreMLLogErrorAndSetNSError(errorOut, errorCode, formatString, ...)                                        \
+    os_log_error(ETCoreMLErrorUtils.loggingChannel, formatString, ##__VA_ARGS__);                                    \
+    if (errorOut) {                                                                                                  \
+        *errorOut =                                                                                                  \
+            [NSError errorWithDomain:ETCoreMLErrorDomain                                                             \
+                                code:errorCode                                                                       \
+                            userInfo:@{                                                                              \
+                                NSLocalizedDescriptionKey : [NSString stringWithFormat:@formatString, ##__VA_ARGS__] \
+                            }];                                                                                      \
+    }
+
+/// Record the error and its underlying error with `os_log_error` and fills
+/// `*errorOut` with NSError.
+#define ETCoreMLLogUnderlyingErrorAndSetNSError(errorOut, errorCode, underlyingNSError, formatString, ...) \
+    os_log_error(ETCoreMLErrorUtils.loggingChannel,                                                        \
+                 formatString " (Underlying error: %@)",                                                   \
+                 ##__VA_ARGS__,                                                                            \
+                 (underlyingNSError).localizedDescription);                                                \
+    if (errorOut) {                                                                                        \
+        *errorOut = [ETCoreMLErrorUtils errorWithCode:errorCode                                            \
+                                      underlyingError:underlyingNSError                                    \
+                                               format:@formatString, ##__VA_ARGS__];                       \
+    }
+
+#define ETCoreMLLogError(error, formatString, ...)       \
+    os_log_error(ETCoreMLErrorUtils.loggingChannel,      \
+                 formatString " (Underlying error: %@)", \
+                 ##__VA_ARGS__,                          \
+                 (error).localizedDescription);
+
+
+#pragma clang diagnostic pop
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.mm
@@ -1,0 +1,73 @@
+//
+// ETCoreMLLogging.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <ETCoreMLLogging.h>
+
+#import <ETCoreMLStrings.h>
+
+const NSErrorDomain ETCoreMLErrorDomain = @"com.apple.executorchcoreml";
+
+static os_log_t LoggingChannel() {
+    static dispatch_once_t onceToken;
+    static os_log_t coreChannel;
+    dispatch_once(&onceToken, ^{
+        coreChannel = os_log_create(ETCoreMLStrings.productIdentifier.UTF8String, ETCoreMLStrings.productName.UTF8String);
+        if (!coreChannel) {
+            os_log_error(OS_LOG_DEFAULT, "Failed to create os_log_t coreChannel");
+        }
+    });
+    return coreChannel;
+}
+
+
+@implementation ETCoreMLErrorUtils
+
++ (NSError *)errorWithIntegerCode:(NSInteger)code
+                  underlyingError:(nullable NSError *)underlyingError
+                           format:(nullable NSString *)format
+                             args:(va_list)args {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
+    NSString *description = format ? [[NSString alloc] initWithFormat:format arguments:args] : nil;
+#pragma clang diagnostic pop
+    
+    NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    if (description) {
+        userInfo[NSLocalizedDescriptionKey] =  description;
+    }
+    if (underlyingError) {
+        userInfo[NSUnderlyingErrorKey] = underlyingError;
+    }
+    
+    return [NSError errorWithDomain:ETCoreMLErrorDomain
+                               code:code
+                           userInfo:userInfo];
+}
+
++ (NSError *)errorWithCode:(ETCoreMLError)code
+           underlyingError:(nullable NSError *)underlyingError
+                    format:(nullable NSString *)format
+                      args:(va_list)args {
+    return [self errorWithIntegerCode:code underlyingError:underlyingError format:format args:args];
+}
+
++ (NSError *)errorWithCode:(ETCoreMLError)type
+           underlyingError:(nullable NSError *)underlyingError
+                    format:(nullable NSString *)description, ... {
+    va_list args;
+    va_start(args, description);
+    NSError *error = [self errorWithCode:type underlyingError:underlyingError format:description args:args];
+    va_end(args);
+    return error;
+}
+
++ (os_log_t)loggingChannel {
+    return LoggingChannel();
+}
+
+@end

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModel.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModel.h
@@ -1,0 +1,51 @@
+//
+// ETCoreMLModel.h
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <CoreML/CoreML.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class ETCoreMLAsset;
+
+/// Represents a ML model, the class is a thin wrapper over `MLModel` with additional properties.
+@interface ETCoreMLModel : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Constructs an `ETCoreMLModel` instance.
+///
+/// @param asset The asset from which the model is loaded.
+/// @param configuration The model configuration.
+/// @param orderedInputNames   The ordered input names of the model.
+/// @param orderedOutputNames   The ordered output names of the model.
+/// @param error   On failure, error is filled with the failure information.
+- (nullable instancetype)initWithAsset:(ETCoreMLAsset*)asset
+                         configuration:(MLModelConfiguration*)configuration
+                     orderedInputNames:(NSOrderedSet<NSString*>*)orderedInputNames
+                    orderedOutputNames:(NSOrderedSet<NSString*>*)orderedOutputNames
+                                 error:(NSError* __autoreleasing*)error NS_DESIGNATED_INITIALIZER;
+
+/// The underlying MLModel.
+@property (strong, readonly, nonatomic) MLModel* mlModel;
+
+/// The asset from which the model is loaded.
+@property (strong, readonly, nonatomic) ETCoreMLAsset* asset;
+
+/// The asset identifier.
+@property (strong, readonly, nonatomic) NSString* identifier;
+
+/// The ordered input names of the model.
+@property (copy, readonly, nonatomic) NSOrderedSet<NSString*>* orderedInputNames;
+
+/// The ordered output names of the model.
+@property (copy, readonly, nonatomic) NSOrderedSet<NSString*>* orderedOutputNames;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModel.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModel.mm
@@ -1,0 +1,45 @@
+//
+// ETCoreMLModel.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <ETCoreMLModel.h>
+
+#import <ETCoreMLAsset.h>
+
+@implementation ETCoreMLModel
+
+- (nullable instancetype)initWithAsset:(ETCoreMLAsset *)asset
+                         configuration:(MLModelConfiguration *)configuration
+                     orderedInputNames:(NSOrderedSet<NSString *> *)orderedInputNames
+                    orderedOutputNames:(NSOrderedSet<NSString *> *)orderedOutputNames
+                                 error:(NSError * __autoreleasing *)error {
+    if (![asset keepAliveAndReturnError:error]) {
+        return nil;
+    }
+    
+    MLModel *mlModel = [MLModel modelWithContentsOfURL:asset.contentURL
+                                         configuration:configuration
+                                                 error:error];
+    if (!mlModel) {
+        return nil;
+    }
+    
+    self = [super init];
+    if (self) {
+        _mlModel = mlModel;
+        _asset = asset;
+        _orderedInputNames = [orderedInputNames copy];
+        _orderedOutputNames = [orderedOutputNames copy];
+    }
+
+    return self;
+}
+
+- (NSString *)identifier {
+    return self.asset.identifier;
+}
+
+@end

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.h
@@ -1,0 +1,87 @@
+//
+// ETCoreMLModelManager.h
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+
+#import <CoreML/CoreML.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class ETCoreMLModel;
+@class ETCoreMLAssetManager;
+
+typedef void ModelHandle;
+
+/// A class responsible for managing the models loaded by the delegate.
+@interface ETCoreMLModelManager : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Constructs an `ETCoreMLModelManager` instance.
+///
+/// @param assetManager The asset manager that will be used to store the compiled models.
+- (instancetype)initWithAssetManager:(ETCoreMLAssetManager*)assetManager NS_DESIGNATED_INITIALIZER;
+
+/// Loads the model from the AOT  data.
+///
+/// The data is the AOT blob stored in the executorch Program. The method first parses the model
+/// metadata stored in the blob and extracts the identifier. If the asset store contains an asset
+/// with the same identifier then the model is directly loaded from the asset otherwise the model is
+/// saved to the filesystem, compiled, moved to the assets store, and then loaded from there.
+///
+/// @param data The AOT blob data.
+/// @param configuration The model configuration that will be used to load the model.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval An opaque handle that points to the loaded model.
+- (ModelHandle*)loadModelFromAOTData:(NSData*)data
+                       configuration:(MLModelConfiguration*)configuration
+                               error:(NSError* __autoreleasing*)error;
+
+/// Executes the loaded model.
+///
+/// @param handle The handle to the loaded model.
+/// @param args The arguments to the model.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval `YES` if the execution succeeded otherwise `NO`.
+- (BOOL)executeModelWithHandle:(ModelHandle*)handle
+                          args:(NSArray<MLMultiArray*>*)args
+                         error:(NSError* __autoreleasing*)error;
+
+/// Unloads the loaded model.
+///
+/// @param handle The handle to the loaded model.
+/// @retval `YES` if the model is unloaded otherwise `NO`.
+- (BOOL)unloadModelWithHandle:(ModelHandle*)handle;
+
+/// Returns the loaded model associated with the handle.
+///
+/// @param handle The handle to the loaded model.
+/// @retval The loaded model.
+- (nullable ETCoreMLModel*)modelWithHandle:(ModelHandle*)handle;
+
+/// Pre-warms most recently used assets. This does an advisory read ahead of the asset (compiled
+/// model) files and could potentially improve the read time if the data is already available in the
+/// system cache.
+///
+/// @param maxCount The maximum count of assets to be pre-warmed.
+- (void)prewarmRecentlyUsedAssetsWithMaxCount:(NSUInteger)maxCount;
+
+/// Pre-warms the model associated with the handle. This could potentially improve the model
+/// execution time.
+///
+/// @param handle The handle to the loaded model.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval `YES` if the model was pre-warmed otherwise `NO`.
+- (BOOL)prewarmModelWithHandle:(ModelHandle*)handle error:(NSError* __autoreleasing*)error;
+
+/// The `ETCoreMLAssetManager` instance used to manage models cache.
+@property (strong, readonly, nonatomic) ETCoreMLAssetManager* assetManager;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
@@ -1,0 +1,567 @@
+//
+// ETCoreMLModelManager.mm
+//
+//  Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import "ETCoreMLModelManager.h"
+
+#import <filesystem>
+#import <memory>
+#import <optional>
+#import <string>
+#import <system_error>
+#import <vector>
+#import <iostream>
+
+#import <os/lock.h>
+
+#import <inmemory_filesystem.hpp>
+#import <metadata.h>
+#import <serde_json.h>
+
+#import <ETCoreMLLogging.h>
+#import <ETCoreMLAsset.h>
+#import <ETCoreMLAssetManager.h>
+#import <ETCoreMLModel.h>
+#import <ETCoreMLStrings.h>
+#import <MLMultiArray_Copy.h>
+#import <MLModel_Prewarm.h>
+
+namespace {
+
+using json = nlohmann::json;
+using namespace executorchcoreml;
+
+std::vector<std::string> canonical_path(NSString *path) {
+    NSArray<NSString *> *components = path.pathComponents;
+    std::vector<std::string> result;
+    result.reserve(components.count);
+    for (NSString *component in components) {
+        result.emplace_back(component.UTF8String);
+    }
+    
+    return result;
+}
+
+id<MLFeatureProvider> _Nullable get_feature_provider(NSArray<MLMultiArray *> *inputs,
+                                                     NSOrderedSet<NSString *> *input_names,
+                                                     NSError * __autoreleasing *error) {
+    NSEnumerator<NSString *> *enumerator = [input_names objectEnumerator];
+    NSMutableDictionary<NSString *, MLFeatureValue *> *features = [NSMutableDictionary dictionaryWithCapacity:inputs.count];
+    for (MLMultiArray *input in inputs) {
+        NSString *input_name = [enumerator nextObject];
+        features[input_name] = [MLFeatureValue featureValueWithMultiArray:input];
+    }
+    
+    return [[MLDictionaryFeatureProvider alloc] initWithDictionary:features error:error];
+}
+
+BOOL is_backed_by_same_buffer(MLMultiArray *array1, MLMultiArray *array2) {
+    __block BOOL result = NO;
+    [array1 getBytesWithHandler:^(const void *bytes1, NSInteger __unused size1){
+        [array2 getBytesWithHandler:^(const void *bytes2, NSInteger __unused size2) {
+            result = (bytes1 == bytes2);
+        }];
+    }];
+    
+    return result;
+}
+
+MLPredictionOptions *get_prediction_options(NSArray<MLMultiArray *> *outputs,
+                                            NSOrderedSet<NSString *> *output_names,
+                                            NSError * __autoreleasing *error) {
+    MLPredictionOptions *options = [MLPredictionOptions new];
+    NSMutableDictionary<NSString *, id> *output_backings = [NSMutableDictionary new];
+    NSEnumerator<NSString *> *enumerator = [output_names objectEnumerator];
+    for (MLMultiArray *output in outputs) {
+        NSString *output_name = [enumerator nextObject];
+        if (output_name.length == 0) {
+            ETCoreMLLogErrorAndSetNSError(error, 0, "%@: Model is broken.", NSStringFromClass(ETCoreMLModelManager.class));
+            return nil;
+        }
+        output_backings[output_name] = output;
+    }
+    options.outputBackings = output_backings;
+    
+    return options;
+}
+
+BOOL copy(MLMultiArray *src, MLMultiArray *dst, NSError * __autoreleasing *error) {
+    if (![src.shape isEqualToArray:dst.shape]) {
+        ETCoreMLLogErrorAndSetNSError(error, 0, "%@: Model is broken", NSStringFromClass(ETCoreMLModelManager.class));
+        return NO;
+    }
+    if (::is_backed_by_same_buffer(src, dst)) {
+        return YES;
+    }
+    @autoreleasepool {
+        [src copyInto:dst];
+    }
+    return YES;
+}
+
+BOOL set_outputs(NSArray<MLMultiArray *> *outputs,
+                 id<MLFeatureProvider> feature_provider,
+                 NSOrderedSet<NSString *> *output_names,
+                 NSError * __autoreleasing *error) {
+    NSEnumerator<NSString *> *enumerator = [output_names objectEnumerator];
+    for (MLMultiArray *output in outputs) {
+        NSString *name = [enumerator nextObject];
+        MLFeatureValue *featureValue = [feature_provider featureValueForName:name];
+        MLMultiArray *result = featureValue.multiArrayValue;
+        if (!::copy(result, output, error)) {
+            return NO;
+        }
+    }
+    
+    return YES;
+}
+
+std::optional<ModelMetadata> get_model_metadata(const inmemoryfs::InMemoryFileSystem& inMemoryFS) {
+    std::error_code error;
+    const auto& file_path = ::canonical_path(ETCoreMLStrings.metadataFileRelativePath);
+    auto buffer = inMemoryFS.get_file_content(file_path, error);
+    if (!buffer) {
+        return std::nullopt;
+    }
+    
+    char *ptr = static_cast<char *>(buffer->data());
+    auto json = json::parse(ptr, ptr + buffer->size());
+    ModelMetadata metadata;
+    from_json(json, metadata);
+    if (metadata.isValid()) {
+        return metadata;
+    }
+    
+    return std::nullopt;
+}
+
+NSOrderedSet<NSString *> *get_ordered_set(const std::vector<std::string>& values) {
+    NSMutableOrderedSet<NSString *> *result = [NSMutableOrderedSet orderedSetWithCapacity:values.size()];
+    for (const auto& value : values) {
+        [result addObject:@(value.c_str())];
+    }
+    
+    return result;
+}
+
+NSURL * _Nullable compile_model(NSURL *model_url, NSError * __autoreleasing *error) {
+    __block NSError *local_error = nil;
+    __block NSURL *result = nil;
+    
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    [MLModel compileModelAtURL:model_url completionHandler:^(NSURL * _Nullable temp_url, NSError * _Nullable compilation_error) {
+        result = [temp_url copy];
+        local_error = compilation_error;
+        dispatch_semaphore_signal(sema);
+    }];
+    
+    long status = dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * 60 * NSEC_PER_SEC)));
+    if (status != 0) {
+        ETCoreMLLogUnderlyingErrorAndSetNSError(error,
+                                                ETCoreMLErrorCompilationFailed,
+                                                local_error,
+                                                "%@: Failed to compile model.",
+                                                NSStringFromClass(ETCoreMLModelManager.class));
+        return nil;
+    }
+    return result;
+}
+
+NSURL * _Nullable write_model_files(NSURL *dst_url,
+                                    NSFileManager *fm,
+                                    NSString *identifier,
+                                    const inmemoryfs::InMemoryFileSystem& inmemory_fs,
+                                    NSError * __autoreleasing *error) {
+    NSError *local_error = nil;
+    if (![fm createDirectoryAtURL:dst_url withIntermediateDirectories:NO attributes:@{} error:error]) {
+        ETCoreMLLogUnderlyingErrorAndSetNSError(error,
+                                                ETCoreMLErrorModelSaveFailed,
+                                                local_error,
+                                                "%@: Failed to create directory when saving model with identifier = %@.",
+                                                NSStringFromClass(ETCoreMLModelManager.class),
+                                                identifier);
+        return nil;
+    }
+    
+    std::filesystem::path model_path(dst_url.fileSystemRepresentation);
+    std::error_code ec;
+    const auto& file_path = canonical_path(ETCoreMLStrings.modelFileRelativePath);
+    if (!inmemory_fs.write_item_to_disk(file_path, model_path, true, ec)) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      ETCoreMLErrorModelSaveFailed,
+                                      "%@: Failed to write model files to disk when saving model with identifier = %@.",
+                                      NSStringFromClass(ETCoreMLModelManager.class),
+                                      identifier);
+        return nil;
+    }
+    
+    return [dst_url URLByAppendingPathComponent:[NSString stringWithFormat:@"model.%@", ETCoreMLStrings.modelExtensionName]];
+}
+
+ETCoreMLModel * _Nullable get_model_from_asset(ETCoreMLAsset *asset,
+                                               MLModelConfiguration *configuration,
+                                               const ModelMetadata& metadata,
+                                               NSError * __autoreleasing *error) {
+    NSOrderedSet<NSString *> *orderedInputNames = ::get_ordered_set(metadata.input_names);
+    NSOrderedSet<NSString *> *orderedOutputNames = ::get_ordered_set(metadata.output_names);
+    ETCoreMLModel *model = [[ETCoreMLModel alloc] initWithAsset:asset
+                                                  configuration:configuration
+                                              orderedInputNames:orderedInputNames
+                                             orderedOutputNames:orderedOutputNames
+                                                          error:error];
+    return model;
+}
+
+ETCoreMLModel * _Nullable load_model_from_url(NSURL *compiled_url,
+                                              MLModelConfiguration *configuration,
+                                              const ModelMetadata& metadata,
+                                              ETCoreMLAssetManager *asset_manager,
+                                              NSFileManager *fm,
+                                              NSError * __autoreleasing *error) {
+    NSError *local_error = nil;
+    NSString *identifier = @(metadata.identifier.c_str());
+    ETCoreMLAsset *asset = [asset_manager storeAssetAtURL:compiled_url withIdentifier:identifier error:&local_error];
+    ETCoreMLModel *model = (asset != nil) ? get_model_from_asset(asset, configuration, metadata, &local_error) : nil;
+    if (model) {
+        return model;
+    }
+    
+    if (local_error) {
+        ETCoreMLLogError(local_error,
+                         "%@: Failed to load model from asset with identifier = %@",
+                         NSStringFromClass(ETCoreMLModelManager.class),
+                         identifier);
+    }
+    
+    // If store failed then we will load the model from compiledURL.
+    auto backing_asset = Asset::make(compiled_url, identifier, fm, error);
+    if (!backing_asset) {
+        return nil;
+    }
+    
+    asset = [[ETCoreMLAsset alloc] initWithBackingAsset:backing_asset.value()];
+    return get_model_from_asset(asset, configuration, metadata, error);
+}
+
+std::string to_string(MLComputeUnits compute_units) {
+    switch (compute_units) {
+        case MLComputeUnitsAll: {
+            return ETCoreMLStrings.allComputeUnitsName.UTF8String;
+        }
+        case MLComputeUnitsCPUOnly: {
+            return ETCoreMLStrings.cpuComputeUnitName.UTF8String;
+        }
+        case MLComputeUnitsCPUAndGPU: {
+            return ETCoreMLStrings.cpuAndGpuComputeUnitsName.UTF8String;
+        }
+        case MLComputeUnitsCPUAndNeuralEngine: {
+            return ETCoreMLStrings.cpuAndNeuralEngineComputeUnitsName.UTF8String;
+        }
+        default: {
+            return ETCoreMLStrings.allComputeUnitsName.UTF8String;
+        }
+    }
+}
+
+void add_compute_unit(std::string& identifier, MLComputeUnits compute_units) {
+    identifier.append("_");
+    identifier.append(to_string(compute_units));
+}
+} //namespace
+
+@interface ETCoreMLModelManager () {
+    os_unfair_lock _lock;
+}
+
+@property (nonatomic, readonly, strong) NSFileManager *fileManager;
+
+@property (nonatomic, readonly, strong) NSMutableDictionary<NSValue *, ETCoreMLModel *> *handleToModelMap;
+@property (nonatomic, readonly, strong) NSMapTable<NSString *, dispatch_queue_t> *modelIdentifierToLoadingQueueMap;
+@property (nonatomic, readonly, strong) NSMutableDictionary<NSString *, ETCoreMLAsset *> *modelIdentifierToPrewarmedAssetMap;
+
+@property (nonatomic, readonly, strong) dispatch_queue_t prewarmQueue;
+
+@end
+
+@implementation ETCoreMLModelManager
+
+- (instancetype)initWithAssetManager:(ETCoreMLAssetManager *)assetManager {
+    self = [super init];
+    if (self) {
+        _assetManager = assetManager;
+        _lock = OS_UNFAIR_LOCK_INIT;
+        _handleToModelMap = [NSMutableDictionary dictionary];
+        _modelIdentifierToLoadingQueueMap = [NSMapTable strongToWeakObjectsMapTable];
+        _modelIdentifierToPrewarmedAssetMap = [NSMutableDictionary dictionary];
+        _fileManager = [[NSFileManager alloc] init];
+        dispatch_queue_attr_t attr = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_DEFAULT, -1);
+        _prewarmQueue = dispatch_queue_create("com.executorchcoreml.modelmanager.prewarm", attr);
+    }
+    
+    return self;
+}
+
+- (nullable ETCoreMLModel *)modelWithHandle:(ModelHandle *)handle {
+    ETCoreMLModel *model = nil;
+    NSValue *key = [NSValue valueWithPointer:handle];
+    {
+        os_unfair_lock_lock(&_lock);
+        model = self.handleToModelMap[key];
+        os_unfair_lock_unlock(&_lock);
+    }
+    
+    return model;
+}
+
+- (nullable ETCoreMLAsset *)assetWithIdentifier:(NSString *)identifier {
+    ETCoreMLAsset *modelAsset = nil;
+    {
+        os_unfair_lock_lock(&_lock);
+        modelAsset = self.modelIdentifierToPrewarmedAssetMap[identifier];
+        os_unfair_lock_unlock(&_lock);
+    }
+    
+    if (modelAsset) {
+        return modelAsset;
+    }
+    
+    NSError *localError = nil;
+    modelAsset = [self.assetManager assetWithIdentifier:identifier error:&localError];
+    if (localError) {
+        ETCoreMLLogError(localError,
+                         "%@: Failed to retrieve asset with identifier = %@",
+                         NSStringFromClass(self.assetManager.class),
+                         identifier);
+    }
+    
+    return modelAsset;
+}
+
+- (nullable ETCoreMLModel *)loadModelUsingMetadata:(const ModelMetadata&)metadata
+                                        inMemoryFS:(const inmemoryfs::InMemoryFileSystem *)inMemoryFS
+                                     configuration:(MLModelConfiguration *)configuration
+                                             error:(NSError * __autoreleasing *)error {
+    NSString *identifier = @(metadata.identifier.c_str());
+    // Otherwise try to retrieve the compiled asset.
+    ETCoreMLAsset *asset = [self assetWithIdentifier:identifier];
+    ETCoreMLModel *model = asset ? get_model_from_asset(asset, configuration, metadata, error) : nil;
+    if (model) {
+        return model;
+    }
+    
+    // Create a unique directory for writing model files.
+    NSURL *dstURL = [self.assetManager.trashDirectoryURL URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+    // Write the model files for on-device compilation.
+    NSURL *modelURL = ::write_model_files(dstURL, self.fileManager, identifier, *inMemoryFS, error);
+    if (!modelURL) {
+        return nil;
+    }
+    
+    // Compile the model.
+    NSURL *compiledModelURL = ::compile_model(modelURL, error);
+    if (!compiledModelURL) {
+        return nil;
+    }
+    
+    model = ::load_model_from_url(compiledModelURL,
+                                  configuration,
+                                  metadata,
+                                  self.assetManager,
+                                  self.fileManager,
+                                  error);
+    return model;
+}
+
+- (nullable ETCoreMLModel *)loadModelFromData:(NSData *)data
+                                configuration:(MLModelConfiguration *)configuration
+                                        error:(NSError * __autoreleasing *)error {
+    using namespace inmemoryfs;
+    
+    auto buffer = MemoryBuffer::make_unowned(const_cast<void *>(data.bytes), data.length);
+    std::unique_ptr<InMemoryFileSystem> inMemoryFS = InMemoryFileSystem::make(buffer);
+    if (!inMemoryFS) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      ETCoreMLErrorCorruptedModel,
+                                      "%@: Model data is corrupted.",
+                                      NSStringFromClass(ETCoreMLModelManager.class));
+        return nil;
+    }
+    
+    std::optional<ModelMetadata> metadata = ::get_model_metadata(*inMemoryFS);
+    if (!metadata) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      ETCoreMLErrorCorruptedMetadata,
+                                      "%@: Metadata is invalid or missing.",
+                                      NSStringFromClass(ETCoreMLModelManager.class));
+        return nil;
+    }
+    
+    auto metadataValue = metadata.value();
+    add_compute_unit(metadataValue.identifier, configuration.computeUnits);
+    NSString *identifier = @(metadataValue.identifier.c_str());
+    // If there are multiple calls to load the same model, we only want to compile it once.
+    __block ETCoreMLModel *model = nil;
+    dispatch_queue_t loadingQueue = [self queueForLoadingModelWithIdentifier:identifier];
+    auto inMemoryFSPtr = inMemoryFS.get();
+    dispatch_sync(loadingQueue, ^{
+        model = [self loadModelUsingMetadata:metadataValue
+                                  inMemoryFS:inMemoryFSPtr
+                               configuration:configuration
+                                       error:error];
+    });
+    
+    return model;
+}
+
+- (dispatch_queue_t)queueForLoadingModelWithIdentifier:(NSString *)identifier {
+    os_unfair_lock_lock(&_lock);
+    dispatch_queue_t queue = [self.modelIdentifierToLoadingQueueMap objectForKey:identifier];
+    if (!queue) {
+        queue = dispatch_queue_create("com.executorchcoreml.modelmanager.loader", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+        [self.modelIdentifierToLoadingQueueMap setObject:queue forKey:identifier];
+    }
+    os_unfair_lock_unlock(&_lock);
+    
+    return queue;
+}
+
+- (ModelHandle *)loadModelFromAOTData:(NSData *)data
+                        configuration:(MLModelConfiguration *)configuration
+                                error:(NSError * __autoreleasing *)error {
+    ETCoreMLModel *model = [self loadModelFromData:data configuration:configuration error:error];
+    {
+        os_unfair_lock_lock(&_lock);
+        if (model) {
+            NSValue *key = [NSValue valueWithPointer:(__bridge void *)model];
+            self.handleToModelMap[key] = model;
+        }
+        os_unfair_lock_unlock(&_lock);
+    }
+    
+    return (__bridge ModelHandle *)model;
+}
+
+- (BOOL)prewarmModelWithHandle:(ModelHandle *)handle
+                         error:(NSError * __autoreleasing *)error {
+    ETCoreMLModel *model = [self modelWithHandle:handle];
+    if (!model) {
+        return NO;
+    }
+    
+    NSError *localError = nil;
+    BOOL result = [model.mlModel prewarmAndReturnError:&localError];
+    if (!result) {
+        ETCoreMLLogError(localError,
+                         "%@: Failed to prewarm model with identifier = %@",
+                         NSStringFromClass(self.assetManager.class),
+                         model.identifier);
+    }
+    
+    if (error) {
+        *error = localError;
+    }
+    
+    return result;
+}
+
+- (void)prewarmRecentlyUsedAssetsWithMaxCount:(NSUInteger)maxCount {
+    NSError *localError = nil;
+    NSArray<ETCoreMLAsset *> *assets = [self.assetManager mostRecentlyUsedAssetsWithMaxCount:maxCount error:&localError];
+    
+    if (localError) {
+        ETCoreMLLogError(localError,
+                         "%@: Failed to retrieve recently used assets.",
+                         NSStringFromClass(self.assetManager.class));
+    }
+    
+    if (assets.count == 0) {
+        return;
+    }
+    
+    for (ETCoreMLAsset *asset in assets) {
+        __weak __typeof(self) weakSelf = self;
+        dispatch_async(self.prewarmQueue, ^{
+            __strong __typeof(self) strongSelf = weakSelf;
+            if (!strongSelf) {
+                return;
+            }
+            
+            NSError *prewarmError = nil;
+            if (![asset prewarmAndReturnError:&prewarmError]) {
+                ETCoreMLLogError(localError,
+                                 "%@: Failed to prewarm asset with identifier = %@",
+                                 NSStringFromClass(self.assetManager.class),
+                                 asset.identifier);
+                return;
+            }
+            
+            [strongSelf addPrewarmedAsset:asset];
+        });
+    }
+}
+
+- (void)addPrewarmedAsset:(ETCoreMLAsset *)asset {
+    os_unfair_lock_lock(&_lock);
+    [self.modelIdentifierToPrewarmedAssetMap setObject:asset forKey:asset.identifier];
+    os_unfair_lock_unlock(&_lock);
+}
+
+- (BOOL)executeModelWithHandle:(ModelHandle *)handle
+                          args:(NSArray<MLMultiArray *> *)args
+                         error:(NSError * __autoreleasing *)error {
+    ETCoreMLModel *model = [self modelWithHandle:handle];
+    if (!model) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      0,
+                                      "%@: Model is already unloaded.",
+                                      NSStringFromClass(self.class));
+        return NO;
+    }
+    
+    if (args.count != model.orderedInputNames.count + model.orderedOutputNames.count) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      ETCoreMLErrorCorruptedModel,
+                                      "%@: Model is invalid.",
+                                      NSStringFromClass(self.class));
+        return NO;
+    }
+    
+    NSArray<MLMultiArray *> *inputs = [args subarrayWithRange:NSMakeRange(0, model.orderedInputNames.count)];
+    NSArray<MLMultiArray *> *outputs = [args subarrayWithRange:NSMakeRange(model.orderedInputNames.count, args.count - model.orderedInputNames.count)];
+    id<MLFeatureProvider> inputFeatures = ::get_feature_provider(inputs, model.orderedInputNames, error);
+    if (!inputFeatures) {
+        return NO;
+    }
+    
+    MLPredictionOptions *predictionOptions = ::get_prediction_options(outputs, model.orderedOutputNames, error);
+    if (!predictionOptions) {
+        return NO;
+    }
+    
+    id<MLFeatureProvider> outputFeatures = [model.mlModel predictionFromFeatures:inputFeatures
+                                                                         options:predictionOptions
+                                                                           error:error];
+    if (!outputFeatures) {
+        return NO;
+    }
+    
+    return ::set_outputs(outputs, outputFeatures, model.orderedOutputNames, error);
+}
+
+- (BOOL)unloadModelWithHandle:(ModelHandle *)handle {
+    BOOL result = NO;
+    @autoreleasepool {
+        NSValue *key = [NSValue valueWithPointer:handle];
+        os_unfair_lock_lock(&_lock);
+        result = (self.handleToModelMap[key] != nil);
+        [self.handleToModelMap removeObjectForKey:key];
+        os_unfair_lock_unlock(&_lock);
+    }
+    
+    return result;
+}
+
+@end

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLStrings.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLStrings.h
@@ -1,0 +1,65 @@
+//
+// ETCoreMLStrings.h
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A class to query all the constants in the system.
+@interface ETCoreMLStrings : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// The product name.
+@property (class, copy, readonly, nonatomic) NSString* productName;
+/// The product identifier.
+@property (class, copy, readonly, nonatomic) NSString* productIdentifier;
+
+/// The identifier that's used to register the delegate.
+@property (class, copy, readonly, nonatomic) NSString* delegateIdentifier;
+
+/// The delegate plist config name.
+@property (class, copy, readonly, nonatomic) NSString* configPlistName;
+
+/// The key name for compute units.
+@property (class, copy, readonly, nonatomic) NSString* computeUnitsKeyName;
+
+/// The compiled model package extension name.
+@property (class, copy, readonly, nonatomic) NSString* compiledModelExtensionName;
+
+/// The model package extension name.
+@property (class, copy, readonly, nonatomic) NSString* modelExtensionName;
+
+/// The model metadata relative path in the AOT blob.
+@property (class, copy, readonly, nonatomic) NSString* metadataFileRelativePath;
+/// The model package relative path in the AOT blob.
+@property (class, copy, readonly, nonatomic) NSString* modelFileRelativePath;
+
+/// The default assets directory path.
+@property (class, copy, readonly, nonatomic, nullable) NSString* assetsDirectoryPath;
+/// The default trash directory path.
+@property (class, copy, readonly, nonatomic, nullable) NSString* trashDirectoryPath;
+
+/// The default database directory path.
+@property (class, copy, readonly, nonatomic, nullable) NSString* databaseDirectoryPath;
+/// The default database name.
+@property (class, copy, readonly, nonatomic) NSString* databaseName;
+
+/// CPU compute unit name.
+@property (class, copy, readonly, nonatomic) NSString* cpuComputeUnitName;
+/// GPU compute unit name.
+@property (class, copy, readonly, nonatomic) NSString* cpuAndGpuComputeUnitsName;
+/// NeuralEngine compute unit name.
+@property (class, copy, readonly, nonatomic) NSString* cpuAndNeuralEngineComputeUnitsName;
+/// All compute units name.
+@property (class, copy, readonly, nonatomic) NSString* allComputeUnitsName;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLStrings.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLStrings.mm
@@ -1,0 +1,120 @@
+//
+// ETCoreMLStrings.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+
+#import "ETCoreMLStrings.h"
+
+@implementation ETCoreMLStrings
+
++ (NSString *)productName {
+    static NSString * const ETCoreMLProductName = @"executorchcoreml";
+    return ETCoreMLProductName;
+}
+
++ (NSString *)productIdentifier {
+    static NSString * const ETCoreMLProductIdentifier = @"com.apple.executorchcoreml";
+    return ETCoreMLProductIdentifier;
+}
+
++ (NSString *)delegateIdentifier {
+    static NSString * const ETCoreMLDelegateIdentifier = @"CoreMLBackend";
+    return ETCoreMLDelegateIdentifier;
+}
+
++ (NSString *)configPlistName {
+    static NSString * const ETCoreMLDelegateConfigPlistName = @"com.apple.executorchcoreml_config";
+    return ETCoreMLDelegateConfigPlistName;
+}
+
++ (NSString *)computeUnitsKeyName {
+    static NSString * const ETCoreMLComputeUnitsName = @"compute_units";
+    return ETCoreMLComputeUnitsName;
+}
+
++ (NSString *)compiledModelExtensionName {
+    static NSString * const ETCoreMLCompiledModelExtensionName = @"mlmodelc";
+    return ETCoreMLCompiledModelExtensionName;
+}
+
++ (NSString *)modelExtensionName {
+    static NSString * const ETCoreMLModelExtensionName = @"mlpackage";
+    return ETCoreMLModelExtensionName;
+}
+
++ (NSString *)metadataFileRelativePath {
+    static NSString * const ETCoreMLMetadataFileRelativePath = @"metadata.json";
+    return ETCoreMLMetadataFileRelativePath;
+}
+
++ (NSString *)modelFileRelativePath {
+    static NSString * const ETCoreMLModelFileRelativePath = @"model.mlpackage";
+    return ETCoreMLModelFileRelativePath;
+}
+
++ (NSString *)cpuComputeUnitName {
+    static NSString * const ETCoreMLCPUComputeUnitName = @"cpu_only";
+    return ETCoreMLCPUComputeUnitName;
+}
+
++ (NSString *)cpuAndGpuComputeUnitsName {
+    static NSString * const ETCoreMLCPUAndGPUComputeUnitsName = @"cpu_and_gpu";
+    return ETCoreMLCPUAndGPUComputeUnitsName;
+}
+
++ (NSString *)cpuAndNeuralEngineComputeUnitsName {
+    static NSString * const ETCoreMLCPUAndNeuralEngineComputeUnitsName = @"cpu_and_ane";
+    return ETCoreMLCPUAndNeuralEngineComputeUnitsName;
+}
+
++ (NSString *)allComputeUnitsName {
+    static NSString * const ETCoreMLAllComputeUnitsName = @"all";
+    return ETCoreMLAllComputeUnitsName;
+}
+
++ (NSString *)databaseName {
+    static NSString * const ETCoreMLDatabaseName = @"assets.db";
+    return ETCoreMLDatabaseName;
+}
+
++ (nullable NSString *)assetsDirectoryPath {
+    static dispatch_once_t onceToken;
+    static NSString *result = nil;
+    dispatch_once(&onceToken, ^{
+        NSArray<NSString *> *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+        if (paths.count > 0) {
+            result = [paths.lastObject stringByAppendingPathComponent:self.productName];
+        }
+    });
+    
+    return result;
+}
+
++ (nullable NSString *)trashDirectoryPath {
+    static dispatch_once_t onceToken;
+    static NSString *result = nil;
+    dispatch_once(&onceToken, ^{
+        result = [NSTemporaryDirectory() stringByAppendingPathComponent:self.productName];
+    });
+    
+    return result;
+}
+
++ (nullable NSString *)databaseDirectoryPath {
+    static dispatch_once_t onceToken;
+    static NSString *result = nil;
+    dispatch_once(&onceToken, ^{
+        NSArray<NSString *> *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+        if (paths.count > 0) {
+            result = [paths.lastObject stringByAppendingPathComponent:self.productName];
+        }
+    });
+    
+    return result;
+}
+
+
+@end

--- a/backends/apple/coreml/runtime/delegate/MLModel_Prewarm.h
+++ b/backends/apple/coreml/runtime/delegate/MLModel_Prewarm.h
@@ -1,0 +1,24 @@
+//
+// MLModel+Prewarm.h
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+
+#import <CoreML/CoreML.h>
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MLModel (Prewarm)
+
+/// Pre-warms the model by running a prediction with zeroed-out inputs.
+///
+/// @param error   On failure, error is filled with the failure information.
+/// @retval `YES` if the prediction succeeded otherwise `NO`.
+- (BOOL)prewarmAndReturnError:(NSError* __autoreleasing*)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/MLModel_Prewarm.mm
+++ b/backends/apple/coreml/runtime/delegate/MLModel_Prewarm.mm
@@ -1,0 +1,84 @@
+//
+// MLModel+Prewarm.m
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <MLModel_Prewarm.h>
+
+#import <algorithm>
+
+@interface MLMultiArray (PreHeat)
+
++ (nullable MLMultiArray *)zeroedMultiArrayWithShape:(NSArray<NSNumber *> *)shape
+                                            dataType:(MLMultiArrayDataType)dataType
+                                               error:(NSError * __autoreleasing *)error;
+
+@end
+
+
+@implementation MLMultiArray (PreHeat)
+
++ (MLMultiArray *)zeroedMultiArrayWithShape:(NSArray<NSNumber *> *)shape
+                                   dataType:(MLMultiArrayDataType)dataType
+                                      error:(NSError * __autoreleasing *)error {
+    MLMultiArray *multiArray = [[MLMultiArray alloc] initWithShape:shape dataType:dataType error:error];
+    if (!multiArray) {
+        return nil;
+    }
+    
+    [multiArray getMutableBytesWithHandler:^(void *mutableBytes, NSInteger size, NSArray<NSNumber *> * __unused strides) {
+        uint8_t *start = reinterpret_cast<uint8_t *>(mutableBytes);
+        uint8_t *end = start + size;
+        std::fill(start, end, uint8_t(0));
+    }];
+    
+    return multiArray;
+}
+
+@end
+
+namespace {
+
+id<MLFeatureProvider> _Nullable get_zeroed_inputs(MLModel *model, NSError * __autoreleasing *error) {
+    NSMutableDictionary<NSString *, MLFeatureValue *> *inputs = [NSMutableDictionary dictionary];
+    for (MLFeatureDescription *feature_desc in model.modelDescription.inputDescriptionsByName.allValues) {
+        switch (feature_desc.type) {
+            case MLFeatureTypeMultiArray: {
+                MLMultiArrayConstraint *constraint = feature_desc.multiArrayConstraint;
+                MLMultiArray *array = [MLMultiArray zeroedMultiArrayWithShape:constraint.shape dataType:constraint.dataType error:error];
+                MLFeatureValue *feature = (array != nil) ? [MLFeatureValue featureValueWithMultiArray:array] : nil;
+                if (!feature) {
+                    return nil;
+                }
+                inputs[feature_desc.name] = feature;
+                break;
+            }
+                
+            default: {
+                return nil;
+            }
+        }
+    }
+    
+    return [[MLDictionaryFeatureProvider alloc] initWithDictionary:inputs error:error];
+}
+
+} //namespace
+
+@implementation MLModel (Prewarm)
+
+- (BOOL)prewarmAndReturnError:(NSError * __autoreleasing *)error {
+    @autoreleasepool {
+        id<MLFeatureProvider> inputs = ::get_zeroed_inputs(self, error);
+        if (!inputs) {
+            return NO;
+        }
+        
+        id<MLFeatureProvider> outputs = [self predictionFromFeatures:inputs error:error];
+        return outputs != nil;
+    }
+}
+
+@end

--- a/backends/apple/coreml/runtime/delegate/MLMultiArray_Copy.h
+++ b/backends/apple/coreml/runtime/delegate/MLMultiArray_Copy.h
@@ -1,0 +1,21 @@
+//
+// MLMultiArray+Copy.h
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <CoreML/CoreML.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MLMultiArray (Copy)
+
+/// Copies this into another `MLMutiArray`.
+///
+/// @param dstMultiArray The destination `MLMutiArray`.
+- (void)copyInto:(MLMultiArray*)dstMultiArray;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/MLMultiArray_Copy.mm
+++ b/backends/apple/coreml/runtime/delegate/MLMultiArray_Copy.mm
@@ -1,0 +1,77 @@
+//
+// MLMultiArray+Copy.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <MLMultiArray_Copy.h>
+
+#import <multiarray.h>
+
+namespace {
+using namespace executorchcoreml;
+
+template<typename T>
+T toValue(NSNumber *value);
+
+template<> size_t toValue(NSNumber *value) {
+    return value.unsignedLongValue;
+}
+
+template<> ssize_t toValue(NSNumber *value) {
+    return value.longLongValue;
+}
+
+template<typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
+std::vector<T> to_vector(NSArray<NSNumber *> *numbers) {
+    std::vector<T> result;
+    result.reserve(numbers.count);
+    for (NSNumber *number in numbers) {
+        result.emplace_back(toValue<T>(number));
+    }
+    
+    return result;
+}
+
+MultiArray::DataType to_multi_array_data_type(MLMultiArrayDataType data_type) {
+    switch (data_type) {
+        case MLMultiArrayDataTypeInt32: {
+            return MultiArray::DataType::Int;
+        }
+        case MLMultiArrayDataTypeFloat: {
+            return MultiArray::DataType::Float;
+        }
+        case MLMultiArrayDataTypeFloat16: {
+            return MultiArray::DataType::Float16;
+        }
+        case MLMultiArrayDataTypeDouble: {
+            return MultiArray::DataType::Double;
+        }
+    }
+}
+
+MultiArray to_multi_array(void *data,
+                          MLMultiArrayDataType dataType,
+                          NSArray<NSNumber *> *shape,
+                          NSArray<NSNumber *> *strides) {
+    auto layout = MultiArray::MemoryLayout(to_multi_array_data_type(dataType),
+                                           to_vector<size_t>(shape),
+                                           to_vector<ssize_t>(strides));
+    return MultiArray(data, std::move(layout));
+}
+} //namespace
+
+@implementation MLMultiArray (Copy)
+
+- (void)copyInto:(MLMultiArray *)dstMultiArray {
+    [self getBytesWithHandler:^(const void *srcBytes, __unused NSInteger srcSize) {
+        [dstMultiArray getMutableBytesWithHandler:^(void *dstBytes, __unused NSInteger size, NSArray<NSNumber *> * strides) {
+            auto src = ::to_multi_array(const_cast<void *>(srcBytes), self.dataType, self.shape, self.strides);
+            auto dst = ::to_multi_array(dstBytes, dstMultiArray.dataType, dstMultiArray.shape, strides);
+            src.copy(dst);
+        }];
+    }];
+}
+
+@end

--- a/backends/apple/coreml/runtime/delegate/asset.h
+++ b/backends/apple/coreml/runtime/delegate/asset.h
@@ -1,0 +1,61 @@
+//
+// ModelAsset.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <Foundation/Foundation.h>
+
+#import <numeric>
+#import <string>
+#import <vector>
+
+namespace executorchcoreml {
+
+/// A struct containing the file info.
+struct FileInfo {
+    /// The last modification time interval of the file since 1970 in milliseconds.
+    int64_t last_modification_time_interval = 0;
+    /// The file size in bytes.
+    size_t size_in_bytes = 0;
+    /// The relative file path from the containing package.
+    std::string relative_path;
+};
+
+/// A struct containing the package info.
+struct PackageInfo {
+    /// The package name.
+    std::string name;
+    /// The file infos for the files inside the package.
+    std::vector<FileInfo> file_infos;
+
+    /// Returns the total size in bytes.
+    inline size_t total_size_in_bytes() const noexcept {
+        return std::accumulate(file_infos.begin(), file_infos.end(), size_t(0), [](size_t acc, const auto& info) {
+            return acc + info.size_in_bytes;
+        });
+    }
+};
+
+/// A struct containing the asset info.
+struct Asset {
+    inline Asset(std::string identifier, std::string path, PackageInfo info) noexcept
+        : identifier(std::move(identifier)), path(std::move(path)), package_info(info) { }
+
+    inline Asset() noexcept { }
+
+    /// Returns the total size in bytes.
+    inline const size_t total_size_in_bytes() const noexcept { return package_info.total_size_in_bytes(); }
+
+    /// The unique identifier.
+    std::string identifier;
+    /// The absolute file path for the asset.
+    std::string path;
+    /// The package info.
+    PackageInfo package_info;
+
+    static std::optional<Asset>
+    make(NSURL* srcURL, NSString* identifier, NSFileManager* fm, NSError* __autoreleasing* error);
+};
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/delegate/asset.mm
+++ b/backends/apple/coreml/runtime/delegate/asset.mm
@@ -1,0 +1,137 @@
+//
+// ModelAsset.cpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+
+#import <asset.h>
+
+#import <optional>
+
+namespace  {
+
+inline id check_class(id obj, Class cls) {
+    return [obj isKindOfClass:cls] ? obj : nil;
+}
+
+#define SAFE_CAST(Object, Type) ((Type *)check_class(Object, [Type class]))
+
+NSNumber * _Nullable is_regular_file(NSURL *url, NSError * __autoreleasing *error) {
+    NSNumber *result = nil;
+    if (![url getResourceValue:&result forKey:NSURLIsRegularFileKey error:error]) {
+        return nil;
+    }
+    
+    return SAFE_CAST(result, NSNumber);
+}
+
+NSNumber * _Nullable get_total_allocated_file_size(NSURL *url, NSError * __autoreleasing *error) {
+    NSNumber *result = nil;
+    if (![url getResourceValue:&result forKey:NSURLTotalFileAllocatedSizeKey error:error]) {
+        return nil;
+    }
+    
+    return SAFE_CAST(result, NSNumber);
+}
+
+NSNumber * _Nullable get_allocated_file_size(NSURL *url, NSError * __autoreleasing *error) {
+    NSNumber *result = nil;
+    if (![url getResourceValue:&result forKey:NSURLFileAllocatedSizeKey error:error]) {
+        return nil;
+    }
+    
+    return SAFE_CAST(result, NSNumber);
+}
+
+NSDate * _Nullable get_modification_date(NSURL *url, NSError * __autoreleasing *error) {
+    NSDate *result = nil;
+    if (![url getResourceValue:&result forKey:NSURLContentModificationDateKey error:error]) {
+        return nil;
+    }
+    
+    return SAFE_CAST(result, NSDate);
+}
+
+void set_error_from_local_error( NSError * __autoreleasing *error, NSError *local_error) {
+    if (local_error && error) {
+        *error = local_error;
+    }
+}
+
+std::optional<executorchcoreml::PackageInfo>
+get_package_info(NSURL *directory_url, NSFileManager *fm, NSError * __autoreleasing *error) {
+    NSArray<NSString *> *properties = @[NSURLIsRegularFileKey, NSURLFileAllocatedSizeKey, NSURLTotalFileAllocatedSizeKey];
+    
+    __block NSError *local_error = nil;
+    BOOL (^errorHandler)(NSURL *url, NSError *error) = ^BOOL(NSURL *url, NSError *enumeration_error) {
+        local_error = enumeration_error;
+        return NO;
+    };
+    
+    NSDirectoryEnumerator *enumerator = [fm enumeratorAtURL:directory_url
+                                 includingPropertiesForKeys:properties
+                                                    options:NSDirectoryEnumerationProducesRelativePathURLs
+                                               errorHandler:errorHandler];
+    
+    auto result = executorchcoreml::PackageInfo {.name = directory_url.lastPathComponent.UTF8String};
+    for (NSURL *item_url in enumerator) {
+        if (local_error != nil) {
+            set_error_from_local_error(error, local_error);
+            return std::nullopt;
+        }
+        
+        NSURL *file_url = [NSURL fileURLWithPath:item_url.path relativeToURL:directory_url];
+        if (!file_url) {
+            continue;
+        }
+        
+        if (!is_regular_file(file_url, &local_error).boolValue) {
+            continue;
+        }
+        
+        NSNumber *size = get_total_allocated_file_size(file_url, &local_error) ?: get_allocated_file_size(file_url, &local_error);
+        if (!size) {
+            break;
+        }
+        
+        NSDate *last_modification_date = get_modification_date(file_url, &local_error);
+        if (!last_modification_date) {
+            break;
+        }
+        
+        int64_t last_modification_time_interval = static_cast<int64_t>(last_modification_date.timeIntervalSince1970 * 1000);
+        auto fileInfo = executorchcoreml::FileInfo {
+            .relative_path = std::string(item_url.relativePath.UTF8String),
+            .size_in_bytes = size.unsignedLongLongValue,
+            .last_modification_time_interval = last_modification_time_interval
+        };
+        
+        result.file_infos.emplace_back(std::move(fileInfo));
+    }
+    
+    if (local_error) {
+        set_error_from_local_error(error, local_error);
+        return std::nullopt;
+    }
+    
+    return result;
+}
+
+}
+
+namespace executorchcoreml {
+
+std::optional<Asset> Asset::make(NSURL *url,
+                                 NSString *identifier,
+                                 NSFileManager *fm,
+                                 NSError * __autoreleasing *error) {
+    auto package_info = get_package_info(url, fm, error);
+    if (!package_info) {
+        return std::nullopt;
+    }
+    
+    return Asset(identifier.UTF8String, url.path.UTF8String, std::move(package_info.value()));
+}
+}

--- a/backends/apple/coreml/runtime/delegate/backend_delegate.h
+++ b/backends/apple/coreml/runtime/delegate/backend_delegate.h
@@ -1,0 +1,141 @@
+//
+// backend_delegate.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#include <system_error>
+#include <vector>
+
+namespace executorchcoreml {
+
+class MultiArray;
+class Buffer;
+
+/// An abstract class for a CoreML delegate to implement.
+class BackendDelegate {
+public:
+    /// The model handle.
+    using Handle = void;
+
+    struct Config {
+        // Max models cache size in bytes.
+        size_t max_models_cache_size = 2 * size_t(1024) * size_t(1024) * size_t(1024);
+        // If set to `true`, delegate pre-warms the most recently used asset.
+        bool should_prewarm_asset = true;
+        // If set to `true`, delegate pre-warms the model in `init`.
+        bool should_prewarm_model = true;
+    };
+
+    /// The error codes for the `BackendDelegate`.
+    enum class ErrorCode : int8_t {
+        CorruptedData = 1, // AOT blob can't be parsed.
+        CorruptedMetadata, // AOT blob has incorrect or missing metadata.
+        CorruptedModel, // AOT blob has incorrect or missing CoreML model.
+        BrokenModel, // Model doesn't match the input and output specifications.
+        CompilationFailed, // Model failed to compile.
+        ModelSaveFailed, // Failed to save Model to disk.
+        ModelCacheCreationFailed // Failed to create models cache.
+    };
+
+    /// The error category for `BackendDelegate` errors.
+    struct ErrorCategory final : public std::error_category {
+    public:
+        /// Returns the name of the category.
+        inline const char* name() const noexcept override { return "CoreMLBackend"; }
+
+        /// Returns a message from the error code.
+        std::string message(int code) const override;
+    };
+
+    inline BackendDelegate() noexcept { }
+    virtual ~BackendDelegate() noexcept = default;
+
+    BackendDelegate(BackendDelegate const&) = delete;
+    BackendDelegate& operator=(BackendDelegate const&) = delete;
+
+    BackendDelegate(BackendDelegate&&) = default;
+    BackendDelegate& operator=(BackendDelegate&&) = default;
+
+    /// Must initialize a CoreML model.
+    ///
+    /// The method receives the AOT blob that's embedded in the executorch
+    /// Program. The implementation must initialize the model and prepare it for
+    /// execution.
+    ///
+    /// @param processed The AOT blob.
+    /// @param specs The specs at the time of compilation.
+    /// @retval An opaque handle to the initialized blob or `nullptr` if the
+    /// initialization failed.
+    virtual Handle* init(Buffer processed, const std::unordered_map<std::string, Buffer>& specs) const noexcept = 0;
+
+    /// Must execute the CoreML model with the specified handle.
+    ///
+    /// The `args` are inputs and outputs combined. It's the responsibility of the
+    /// implementation to find the inputs and the outputs from `args`. The
+    /// implementation must execute the model with the inputs and must populate
+    /// the outputs from the model prediction outputs.
+    ///
+    /// @param handle The model handle.
+    /// @param args The inputs and outputs to the model.
+    /// @param error   On failure, error is filled with the failure information.
+    /// @retval `true` if the execution succeeded otherwise `false`.
+    virtual bool
+    execute(Handle* handle, const std::vector<MultiArray>& args, std::error_code& error) const noexcept = 0;
+
+    /// Must return `true` if the delegate is available for execution otherwise
+    /// `false`.
+    virtual bool is_available() const noexcept = 0;
+
+    /// Must returns the number of inputs and the number of outputs for the
+    /// specified handle.
+    ///
+    /// The returned pair's first value is the number of inputs and the second
+    /// value is the number of outputs.
+    ///
+    /// @param handle The model handle.
+    /// @retval A pair with the number of inputs and the number of outputs.
+    virtual std::pair<size_t, size_t> get_num_arguments(Handle* handle) const noexcept = 0;
+
+    /// Checks if the model handle is valid.
+    ///
+    /// @param handle The model handle.
+    /// @retval `true` if the model handle is valid otherwise `false`.
+    virtual bool is_valid_handle(Handle* handle) const noexcept = 0;
+
+    /// Must unload the CoreML model with the specified handle.
+    ///
+    /// The returned pair's first value is the number of inputs and the second
+    /// value is the number of outputs.
+    ///
+    /// @param handle The model handle.
+    virtual void destroy(Handle* handle) const noexcept = 0;
+
+    /// Purges the models cache.
+    ///
+    /// Compiled models are stored on-disk to improve the model load time. The
+    /// method tries to remove all the models that are not currently in-use.
+    virtual bool purge_models_cache() const noexcept = 0;
+
+    /// Returns a delegate implementation with the specified config.
+    ///
+    /// @param config The delegate config.
+    /// @retval A delegate implementation.
+    static std::shared_ptr<BackendDelegate> make(const Config& config);
+};
+
+/// Constructs a `std::error_code` from  a`BackendDelegate::ErrorCode`.
+///
+/// @param code The backend error code.
+/// @retval A `std::error_code` constructed from
+/// the`BackendDelegate::ErrorCode`.
+inline std::error_code make_error_code(BackendDelegate::ErrorCode code) {
+    static BackendDelegate::ErrorCategory errorCategory;
+    return { static_cast<int>(code), errorCategory };
+}
+} // namespace executorchcoreml
+
+namespace std {
+template <> struct is_error_code_enum<executorchcoreml::BackendDelegate::ErrorCode> : true_type { };
+} // namespace std

--- a/backends/apple/coreml/runtime/delegate/backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/backend_delegate.mm
@@ -1,0 +1,243 @@
+//
+// backend_delegate.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import "backend_delegate.h"
+
+#import <atomic>
+
+#import <multiarray.h>
+
+#import <ETCoreMLModel.h>
+#import <ETCoreMLAssetManager.h>
+#import <ETCoreMLModelManager.h>
+#import <ETCoreMLStrings.h>
+
+namespace  {
+using namespace executorchcoreml;
+
+MLComputeUnits get_compute_units(const Buffer& buffer) {
+    std::string value(reinterpret_cast<const char *>(buffer.data()), buffer.size());
+    if (value == std::string(ETCoreMLStrings.cpuComputeUnitName.UTF8String)) {
+        return MLComputeUnitsCPUOnly;
+    } else if (value == std::string(ETCoreMLStrings.cpuAndGpuComputeUnitsName.UTF8String)) {
+        return MLComputeUnitsCPUAndGPU;
+    } else if (value == std::string(ETCoreMLStrings.cpuAndNeuralEngineComputeUnitsName.UTF8String)) {
+        return MLComputeUnitsCPUAndNeuralEngine;
+    } else {
+        return MLComputeUnitsAll;
+    }
+}
+
+MLModelConfiguration *get_model_configuration(const std::unordered_map<std::string, Buffer>& specs) {
+    std::string key_name(ETCoreMLStrings.computeUnitsKeyName.UTF8String);
+    MLModelConfiguration *configuration = [[MLModelConfiguration alloc] init];
+    for (const auto& [key, buffer] : specs) {
+        if (key == key_name) {
+            configuration.computeUnits = get_compute_units(buffer);
+            break;
+        }
+    }
+    
+    return configuration;
+}
+
+template<typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
+NSArray<NSNumber *> *to_array(const std::vector<T>& array) {
+    NSMutableArray<NSNumber *> *result = [NSMutableArray arrayWithCapacity:array.size()];
+    for (T value : array) {
+        [result addObject:@(value)];
+    }
+    
+    return result;
+}
+
+MLMultiArrayDataType get_data_type(MultiArray::DataType dataType) {
+    switch (dataType) {
+        case MultiArray::DataType::Float16: {
+            return MLMultiArrayDataTypeFloat16;
+        }
+        case MultiArray::DataType::Float: {
+            return MLMultiArrayDataTypeFloat32;
+        }
+        case MultiArray::DataType::Double: {
+            return MLMultiArrayDataTypeFloat64;
+        }
+        case MultiArray::DataType::Int: {
+            return MLMultiArrayDataTypeInt32;
+        }
+    }
+}
+
+MLMultiArray * _Nullable to_ml_multiarray(const MultiArray& array, NSError * __autoreleasing *error) {
+    const auto& layout = array.layout();
+    MLMultiArray *result = [[MLMultiArray alloc] initWithDataPointer:array.data()
+                                                               shape:to_array(layout.shape())
+                                                            dataType:get_data_type(layout.dataType())
+                                                             strides:to_array(layout.strides())
+                                                         deallocator:^(void * _Nonnull bytes) {}
+                                                               error:error];
+    return result;
+}
+
+NSURL * _Nullable create_directory_if_needed(NSURL *url,
+                                             NSFileManager *fileManager,
+                                             NSError * __autoreleasing *error) {
+    if (![fileManager fileExistsAtPath:url.path] &&
+        ![fileManager createDirectoryAtURL:url withIntermediateDirectories:YES attributes:@{} error:error]) {
+        return nil;
+    }
+    
+    return url;
+}
+
+ETCoreMLAssetManager * _Nullable create_asset_manager(NSString *assets_directory_path,
+                                                      NSString *trash_directory_path,
+                                                      NSString *database_directory_path,
+                                                      NSString *database_name,
+                                                      NSInteger max_assets_size_in_bytes,
+                                                      NSError * __autoreleasing *error) {
+    NSFileManager *fm  = [[NSFileManager alloc] init];
+    
+    NSURL *assets_directory_url = [NSURL fileURLWithPath:assets_directory_path];
+    if (!create_directory_if_needed(assets_directory_url, fm, error)) {
+        return nil;
+    }
+    
+    NSURL *trash_directory_url = [NSURL fileURLWithPath:trash_directory_path];
+    if (!create_directory_if_needed(trash_directory_url, fm, error)) {
+        return nil;
+    }
+    
+    NSURL *database_directory_url = [NSURL fileURLWithPath:database_directory_path];
+    if (!create_directory_if_needed(database_directory_url, fm, error)) {
+        return nil;
+    }
+    
+    NSURL *database_url = [database_directory_url URLByAppendingPathComponent:database_name];
+    ETCoreMLAssetManager *manager = [[ETCoreMLAssetManager alloc] initWithDatabaseURL:database_url
+                                                                   assetsDirectoryURL:assets_directory_url
+                                                                    trashDirectoryURL:trash_directory_url
+                                                                 maxAssetsSizeInBytes:max_assets_size_in_bytes
+                                                                                error:error];
+    return manager;
+}
+} //namespace
+
+namespace executorchcoreml {
+
+std::string BackendDelegate::ErrorCategory::message(int code) const {
+    switch (static_cast<ErrorCode>(code)) {
+        case ErrorCode::CorruptedData:
+            return "AOT blob can't be parsed";
+        case ErrorCode::CorruptedMetadata:
+            return "AOT blob has incorrect or missing metadata.";
+        case ErrorCode::CorruptedModel:
+            return "AOT blob has incorrect or missing CoreML model.";
+        case ErrorCode::BrokenModel:
+            return "CoreML model doesn't match the input and output specifications";
+        case ErrorCode::CompilationFailed:
+            return "CoreML model failed to compile";
+        case ErrorCode::ModelSaveFailed:
+            return "Failed to save CoreML model to disk";
+        case ErrorCode::ModelCacheCreationFailed:
+            return "Failed to create model cache";
+        default:
+            return "Unexpected error";
+    }
+}
+
+class BackendDelegateImpl: public BackendDelegate {
+public:
+    explicit BackendDelegateImpl(const Config& config) noexcept
+    :BackendDelegate(), config_(config) {
+        NSError *localError = nil;
+        ETCoreMLAssetManager *asset_manager = create_asset_manager(ETCoreMLStrings.assetsDirectoryPath,
+                                                                   ETCoreMLStrings.trashDirectoryPath,
+                                                                   ETCoreMLStrings.databaseDirectoryPath,
+                                                                   ETCoreMLStrings.databaseName,
+                                                                   config.max_models_cache_size,
+                                                                   &localError);
+        
+        model_manager_ = (asset_manager != nil) ? [[ETCoreMLModelManager alloc] initWithAssetManager:asset_manager] : nil;
+        if (model_manager_ != nil && config_.should_prewarm_asset) {
+            [model_manager_ prewarmRecentlyUsedAssetsWithMaxCount:1];
+        }
+        available_.store(model_manager_ != nil, std::memory_order_seq_cst);
+    }
+    
+    BackendDelegateImpl(BackendDelegateImpl const&) = delete;
+    BackendDelegateImpl& operator=(BackendDelegateImpl const&) = delete;
+    
+    Handle *init(Buffer processed,const std::unordered_map<std::string, Buffer>& specs) const noexcept override {
+        NSError *localError = nil;
+        MLModelConfiguration *configuration = get_model_configuration(specs);
+        NSData *data = [NSData dataWithBytesNoCopy:const_cast<void *>(processed.data())
+                                            length:processed.size()
+                                      freeWhenDone:NO];
+        ModelHandle *modelHandle = [model_manager_ loadModelFromAOTData:data
+                                                          configuration:configuration
+                                                                  error:&localError];
+        if (modelHandle && config_.should_prewarm_model) {
+            NSError *localError = nil;
+            [model_manager_ prewarmModelWithHandle:modelHandle error:&localError];
+        }
+        
+        return modelHandle;
+    }
+    
+    bool execute(Handle* handle, const std::vector<MultiArray>& args, std::error_code& ec) const noexcept override {
+        NSError *error = nil;
+        NSMutableArray<MLMultiArray *> *model_args = [NSMutableArray arrayWithCapacity:args.size()];
+        for (const auto& arg : args) {
+            MLMultiArray *multi_array = to_ml_multiarray(arg, &error);
+            if (!multi_array) {
+                return false;
+            }
+            [model_args addObject:multi_array];
+        }
+        
+        if (![model_manager_ executeModelWithHandle:handle args:model_args error:&error]) {
+            ec = static_cast<ErrorCode>(error.code);
+            return false;
+        }
+        
+        return true;
+    }
+    
+    bool is_valid_handle(Handle* handle) const noexcept override {
+        return [model_manager_ modelWithHandle:handle] != nil;
+    }
+    
+    bool is_available() const noexcept override {
+        return available_.load(std::memory_order_acquire);
+    }
+    
+    std::pair<size_t, size_t> get_num_arguments(Handle* handle) const noexcept override {
+        ETCoreMLModel *model = [model_manager_ modelWithHandle:handle];
+        return {model.orderedInputNames.count, model.orderedOutputNames.count};
+    }
+    
+    void destroy(Handle* handle) const noexcept override {
+        [model_manager_ unloadModelWithHandle:handle];
+    }
+    
+    bool purge_models_cache() const noexcept override {
+        NSError *localError = nil;
+        bool result = static_cast<bool>([model_manager_.assetManager purge:&localError]);
+        return result;
+    }
+    
+    ETCoreMLModelManager *model_manager_;
+    std::atomic<bool> available_;
+    Config config_;
+};
+
+std::shared_ptr<BackendDelegate> BackendDelegate::make(const Config& config) {
+    return std::make_shared<BackendDelegateImpl>(config);
+}
+} //namespace executorchcoreml
+

--- a/backends/apple/coreml/runtime/delegate/com.apple.executorchcoreml_config.plist
+++ b/backends/apple/coreml/runtime/delegate/com.apple.executorchcoreml_config.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>shouldPrewarmAsset</key>
+	<true/>
+	<key>shouldPrewarmModel</key>
+	<true/>
+	<key>maxAssetsSizeInBytes</key>
+	<integer>2147483648</integer>
+</dict>
+</plist>

--- a/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
@@ -1,0 +1,209 @@
+//
+// coreml_backend_delegate.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <coreml_backend/delegate.h>
+
+#import <backend_delegate.h>
+#import <memory>
+#import <unordered_map>
+#import <vector>
+
+#import <multiarray.h>
+
+#import <ETCoreMLLogging.h>
+#import <ETCoreMLModel.h>
+#import <ETCoreMLStrings.h>
+
+#import <executorch/runtime/core/evalue.h>
+
+namespace {
+using namespace torch::executor;
+using namespace executorchcoreml;
+
+inline id check_class(id obj, Class cls) {
+    return [obj isKindOfClass:cls] ? obj : nil;
+}
+
+#define SAFE_CAST(Object, Type) ((Type *)check_class(Object, [Type class]))
+
+std::optional<MultiArray::DataType> get_data_type(ScalarType scalar_type) {
+    if (scalar_type == ScalarType::Float) {
+        return MultiArray::DataType::Float;
+    } else if (scalar_type == ScalarType::Double) {
+        return MultiArray::DataType::Double;
+    } else if (scalar_type == ScalarType::Half) {
+        return MultiArray::DataType::Float16;
+    } else if (scalar_type == ScalarType::Int) {
+        return MultiArray::DataType::Int;
+    } else {
+        return std::nullopt;
+    }
+}
+
+enum class ArgType: uint8_t {
+    Input,
+    Output
+};
+
+std::optional<MultiArray> get_multi_array(EValue *eValue, ArgType argType) {
+    if (!eValue->isTensor()) {
+        return std::nullopt;
+    }
+    
+    auto tensor = eValue->toTensor();
+    auto dataType = get_data_type(tensor.scalar_type());
+    if (!dataType.has_value()) {
+        return std::nullopt;
+    }
+    
+    std::vector<ssize_t> strides(tensor.strides().begin(), tensor.strides().end());
+    std::vector<size_t> shape(tensor.sizes().begin(), tensor.sizes().end());
+    MultiArray::MemoryLayout layout(dataType.value(), std::move(shape), std::move(strides));
+    switch (argType) {
+        case ArgType::Input: {
+            return MultiArray(const_cast<void *>(tensor.const_data_ptr()), layout);
+        }
+        case ArgType::Output: {
+            return MultiArray(tensor.mutable_data_ptr(), layout);
+        }
+    }
+}
+
+std::optional<BackendDelegate::Config> parse_config(NSURL *plistURL) {
+    NSDictionary<NSString *, id> *dict = [NSDictionary dictionaryWithContentsOfURL:plistURL];
+    if (!dict) {
+        return std::nullopt;
+    }
+    
+    BackendDelegate::Config config;
+    {
+        NSNumber *should_prewarm_model = SAFE_CAST(dict[@"shouldPrewarmModel"], NSNumber);
+        if (should_prewarm_model) {
+            config.should_prewarm_model = static_cast<bool>(should_prewarm_model.boolValue);
+        }
+    }
+    
+    {
+        NSNumber *should_prewarm_asset = SAFE_CAST(dict[@"shouldPrewarmAsset"], NSNumber);
+        if (should_prewarm_asset) {
+            config.should_prewarm_asset = static_cast<bool>(should_prewarm_asset.boolValue);
+        }
+    }
+    
+    {
+        NSNumber *max_models_cache_size_in_bytes = SAFE_CAST(dict[@"maxModelsCacheSizeInBytes"], NSNumber);
+        if (max_models_cache_size_in_bytes) {
+            config.max_models_cache_size = max_models_cache_size_in_bytes.unsignedLongLongValue;
+        }
+    }
+    
+    return config;
+}
+
+BackendDelegate::Config get_delegate_config(NSString *config_name) {
+    NSURL *config_url = [[NSBundle mainBundle] URLForResource:config_name withExtension:@"plist"];
+    config_url = config_url ?: [[NSBundle bundleForClass:ETCoreMLModel.class] URLForResource:config_name withExtension:@"plist"];
+    auto config = parse_config(config_url);
+    return config.has_value() ? config.value() : BackendDelegate::Config();
+}
+} //namespace
+
+namespace torch {
+namespace executor {
+
+using namespace executorchcoreml;
+
+CoreMLBackendDelegate::CoreMLBackendDelegate() noexcept
+:impl_(BackendDelegate::make(get_delegate_config(ETCoreMLStrings.configPlistName)))
+{}
+
+Result<DelegateHandle *>
+CoreMLBackendDelegate::init(BackendInitContext& context,
+                            FreeableBuffer* processed,
+                            ArrayRef<CompileSpec> specs) const {
+    ET_LOG(Debug, "%s: init called.", ETCoreMLStrings.delegateIdentifier.UTF8String);
+    std::unordered_map<std::string, Buffer> specs_map;
+    specs_map.reserve(specs.size());
+    for (auto it = specs.cbegin(); it != specs.cend(); ++it) {
+        auto& spec = *(it);
+        auto buffer = Buffer(spec.value.buffer, spec.value.nbytes);
+        specs_map.emplace(spec.key, std::move(buffer));
+    }
+    
+    auto buffer = Buffer(processed->data(), processed->size());
+    std::error_code error;
+    auto handle = impl_->init(std::move(buffer), specs_map);
+    ET_CHECK_OR_RETURN_ERROR(handle != nullptr,
+                             InvalidProgram,
+                             "%s: Failed to init the model.", ETCoreMLStrings.delegateIdentifier.UTF8String);
+    
+    return handle;
+}
+
+Error CoreMLBackendDelegate::execute(BackendExecutionContext& context,
+                                     DelegateHandle* handle,
+                                     EValue** args) const {
+    const auto& nArgs = impl_->get_num_arguments(handle);
+    std::vector<MultiArray> delegate_args;
+    size_t nInputs = nArgs.first;
+    size_t nOutputs = nArgs.second;
+    delegate_args.reserve(nInputs + nOutputs);
+    
+    // inputs
+    for (size_t i = 0; i < nInputs; i++) {
+        auto multi_array = get_multi_array(args[i], ArgType::Input);
+        ET_CHECK_OR_RETURN_ERROR(multi_array.has_value(),
+                                 Internal,
+                                 "%s: Expected tensor at args[%zu]", ETCoreMLStrings.delegateIdentifier.UTF8String, i);
+        delegate_args.emplace_back(std::move(multi_array.value()));
+    }
+    
+    // outputs
+    for (size_t i = nInputs; i < nInputs + nOutputs; i++) {
+        auto multi_array = get_multi_array(args[i], ArgType::Output);
+        ET_CHECK_OR_RETURN_ERROR(multi_array.has_value(),
+                                 Internal,
+                                 "%s: Expected tensor at args[%zu]", ETCoreMLStrings.delegateIdentifier.UTF8String, i);
+        delegate_args.emplace_back(std::move(multi_array.value()));
+    }
+    
+    std::error_code ec;
+    ET_CHECK_OR_RETURN_ERROR(impl_->execute(handle, delegate_args, ec),
+                             DelegateInvalidHandle,
+                             "%s: Failed to run the model.",
+                             ETCoreMLStrings.delegateIdentifier.UTF8String);
+    return Error::Ok;
+}
+
+bool CoreMLBackendDelegate::is_available() const {
+    ET_LOG(Debug, "%s: is_available called.", ETCoreMLStrings.delegateIdentifier.UTF8String);
+    return impl_->is_available();
+}
+
+void CoreMLBackendDelegate::destroy(DelegateHandle* handle) const {
+    ET_LOG(Debug, "%s: destroy called.", ETCoreMLStrings.delegateIdentifier.UTF8String);
+    impl_->destroy(handle);
+}
+
+bool CoreMLBackendDelegate::purge_models_cache() const noexcept {
+    ET_LOG(Debug, "%s: purge_models_cache called.", ETCoreMLStrings.delegateIdentifier.UTF8String);
+    return impl_->purge_models_cache();
+}
+
+CoreMLBackendDelegate *CoreMLBackendDelegate::get_registered_delegate() noexcept {
+    return static_cast<CoreMLBackendDelegate *>(get_backend_class(ETCoreMLStrings.delegateIdentifier.UTF8String));
+}
+
+namespace {
+auto cls = CoreMLBackendDelegate();
+Backend backend{ETCoreMLStrings.delegateIdentifier.UTF8String, &cls};
+static auto success_with_compiler = register_backend(backend);
+}
+
+} // namespace executor
+} // namespace torch
+

--- a/backends/apple/coreml/runtime/delegate/metadata.h
+++ b/backends/apple/coreml/runtime/delegate/metadata.h
@@ -1,0 +1,42 @@
+//
+// metadata.h
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#import <string>
+#import <vector>
+
+namespace executorchcoreml {
+
+/// A class representing a model's metadata.
+struct ModelMetadata {
+    /// Constructs a `ModelMetada` instance.
+    /// @param identifier The unique identifier.
+    /// @param input_names The input names for the model.
+    /// @param output_names   The output names for the model.
+    inline ModelMetadata(std::string identifier,
+                         std::vector<std::string> input_names,
+                         std::vector<std::string> output_names) noexcept
+        : identifier(std::move(identifier)), input_names(std::move(input_names)),
+          output_names(std::move(output_names)) { }
+
+    inline ModelMetadata() noexcept { }
+
+    /// Returns `true` if the metadata is valid otherwise `false`.
+    inline bool isValid() const noexcept {
+        return !identifier.empty() && !input_names.empty() && !output_names.empty();
+    }
+
+    /// Unique identifier.
+    std::string identifier;
+    /// Input names of the model.
+    std::vector<std::string> input_names;
+    /// Output names of the model.
+    std::vector<std::string> output_names;
+};
+
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/delegate/multiarray.h
+++ b/backends/apple/coreml/runtime/delegate/multiarray.h
@@ -1,0 +1,88 @@
+//
+// multiarray.h
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#import <vector>
+
+namespace executorchcoreml {
+
+/// A class representing an unowned buffer.
+class Buffer {
+public:
+    /// Constructs a buffer from data and size.
+    explicit Buffer(const void* data, size_t size) noexcept : data_(data), size_(size) { }
+
+    /// Returns the data pointer.
+    inline const void* data() const noexcept { return data_; }
+
+    /// Returns the size of the buffer.
+    inline size_t size() const noexcept { return size_; }
+
+private:
+    const void* data_;
+    size_t size_;
+};
+
+/// A class representing a MultiArray.
+class MultiArray {
+public:
+    /// The MultiArray datatype.
+    enum class DataType : uint8_t { Int = 0, Double, Float, Float16 };
+
+    /// A class describing the memory layout of a MultiArray.
+    class MemoryLayout {
+    public:
+        MemoryLayout(DataType dataType, std::vector<size_t> shape, std::vector<ssize_t> strides)
+            : dataType_(dataType), shape_(std::move(shape)), strides_(std::move(strides)) { }
+
+        /// Returns the datatype of the MultiArray.
+        inline DataType dataType() const noexcept { return dataType_; }
+
+        /// Returns the shape of the MultiArray.
+        inline const std::vector<size_t>& shape() const noexcept { return shape_; }
+
+        /// Returns the strides of the MultiArray.
+        inline const std::vector<ssize_t>& strides() const noexcept { return strides_; }
+
+        /// Returns the MultiArray rank.
+        inline size_t rank() const noexcept { return shape_.size(); }
+
+        /// Returns the number of elements in the MultiArray.
+        size_t get_num_elements() const noexcept;
+
+        /// Returns `true` if the memory layout is packed otherwise `false`.
+        bool is_packed() const noexcept;
+
+    private:
+        DataType dataType_;
+        std::vector<size_t> shape_;
+        std::vector<ssize_t> strides_;
+    };
+
+    /// Constructs a `MultiArray` from data and it's memory layout.
+    ///
+    /// The data is not owned by the `MultiArray`.
+    MultiArray(void* data, MemoryLayout layout) : data_(data), layout_(std::move(layout)) { }
+
+    /// Returns the data pointer.
+    inline void* data() const noexcept { return data_; }
+
+    /// Returns the layout of the MultiArray.
+    inline const MemoryLayout& layout() const noexcept { return layout_; }
+
+    /// Copies this into another `MultiArray`.
+    ///
+    /// @param dst The destination `MultiArray`.
+    bool copy(MultiArray& dst) const noexcept;
+
+private:
+    void* data_;
+    MemoryLayout layout_;
+};
+
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/delegate/multiarray.mm
+++ b/backends/apple/coreml/runtime/delegate/multiarray.mm
@@ -1,0 +1,584 @@
+//
+//  multiarray.mm
+//  coremlexecutorch
+//
+//  Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <multiarray.h>
+
+#import <Accelerate/Accelerate.h>
+#import <CoreML/CoreML.h>
+
+#import <functional>
+#import <numeric>
+#import <vector>
+
+namespace  {
+using namespace executorchcoreml;
+
+template<typename T>
+struct TypedMultiArray {
+    explicit TypedMultiArray(T *data, MultiArray::MemoryLayout layout) noexcept
+    :data(data), layout(std::move(layout))
+    {}
+    
+    T *data;
+    MultiArray::MemoryLayout layout;
+};
+
+#pragma mark - BNNS
+
+template<typename T1, typename T2>
+struct BNNSCopier {
+    static bool supported() noexcept {
+        return false;
+    }
+    
+    static void copy(BNNSNDArrayDescriptor *src_bnns_desc, BNNSNDArrayDescriptor *dstNNSDesc) noexcept {}
+};
+
+// float -> _Float16
+template<>
+struct BNNSCopier<float, _Float16> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(BNNSNDArrayDescriptor *src_bnns_desc, BNNSNDArrayDescriptor *dst_bnns_desc) noexcept {
+        src_bnns_desc->data_type = BNNSDataTypeFloat32;
+        dst_bnns_desc->data_type = BNNSDataTypeFloat16;
+        BNNSCopy(src_bnns_desc, dst_bnns_desc, NULL);
+    }
+};
+
+// float -> int32_t
+template<>
+struct BNNSCopier<float, int32_t> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(BNNSNDArrayDescriptor *src_bnns_desc, BNNSNDArrayDescriptor *dst_bnns_desc) noexcept {
+        src_bnns_desc->data_type = BNNSDataTypeFloat32;
+        dst_bnns_desc->data_type = BNNSDataTypeInt32;
+        BNNSCopy(src_bnns_desc, dst_bnns_desc, NULL);
+    }
+};
+
+// _Float16 -> float
+template<>
+struct BNNSCopier<_Float16, float> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(BNNSNDArrayDescriptor *src_bnns_desc, BNNSNDArrayDescriptor *dst_bnns_desc) noexcept {
+        src_bnns_desc->data_type = BNNSDataTypeFloat16;
+        dst_bnns_desc->data_type = BNNSDataTypeFloat32;
+        BNNSCopy(src_bnns_desc, dst_bnns_desc, NULL);
+    }
+};
+
+// _Float16 -> int32_t
+template<>
+struct BNNSCopier<_Float16, int32_t> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(BNNSNDArrayDescriptor *src_bnns_desc, BNNSNDArrayDescriptor *dst_bnns_desc) noexcept {
+        src_bnns_desc->data_type = BNNSDataTypeFloat16;
+        dst_bnns_desc->data_type = BNNSDataTypeInt32;
+        BNNSCopy(src_bnns_desc, dst_bnns_desc, NULL);
+    }
+};
+
+// int32_t -> _Float16
+template<>
+struct BNNSCopier<int32_t, _Float16> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(BNNSNDArrayDescriptor *src_bnns_desc, BNNSNDArrayDescriptor *dst_bnns_desc) noexcept {
+        src_bnns_desc->data_type = BNNSDataTypeInt32;
+        dst_bnns_desc->data_type = BNNSDataTypeFloat16;
+        BNNSCopy(src_bnns_desc, dst_bnns_desc, NULL);
+    }
+};
+
+// int32_t -> float
+template<>
+struct BNNSCopier<int32_t, float> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(BNNSNDArrayDescriptor *src_bnns_desc, BNNSNDArrayDescriptor *dst_bnns_desc) noexcept {
+        src_bnns_desc->data_type = BNNSDataTypeInt32;
+        dst_bnns_desc->data_type = BNNSDataTypeFloat32;
+        BNNSCopy(src_bnns_desc, dst_bnns_desc, NULL);
+    }
+};
+
+/// Returns BNNSDataLayout and sets strides from the multi-array strides.
+///
+/// BNNS requires strides to be non-decreasing order;
+/// `bnns_strides[i] <= bnns_strides[i + 1]`. BNNSDataLayout defines
+/// how each dimension is mapped to the stride.
+///
+/// @param multi_array_strides  The multiarray strides.
+/// @param bnns_strides   The bnns strides.
+/// @retval The `BNNSDataLayout`.
+BNNSDataLayout get_bnns_data_layout(const std::vector<ssize_t>& multi_array_strides, size_t *bnns_strides) {
+    uint32_t firstMajorFlag = 1;
+    uint32_t rank = static_cast<uint32_t>(multi_array_strides.size());
+    if (rank > BNNS_MAX_TENSOR_DIMENSION) {
+        return (BNNSDataLayout)-1;
+    }
+    
+    if (std::is_sorted(multi_array_strides.begin(), multi_array_strides.end(), std::less())) {
+        firstMajorFlag = 0;
+        std::copy(multi_array_strides.begin(), multi_array_strides.end(), bnns_strides);
+    } else if (std::is_sorted(multi_array_strides.begin(), multi_array_strides.end(), std::greater()) ) {
+        firstMajorFlag = 1;
+        std::copy(multi_array_strides.rbegin(), multi_array_strides.rend(), bnns_strides);
+    } else {
+        return (BNNSDataLayout)-1;
+    }
+    
+    // See BNNSDataLayout's raw value how this bitwise-or makes sense.
+    return (BNNSDataLayout)((rank << 16) | (8 << 12) | firstMajorFlag);
+}
+
+/// Initializes BNNSNDArrayDescriptor for the shape and strides.
+///
+/// @param layout  The memory layout.
+/// @param desc   The ``BNNSNDArrayDescriptor`  to be initialized.
+/// @retval `true` if the initialization succeeded otherwise `false`.
+bool init_bnns_array_descriptor(const MultiArray::MemoryLayout& layout, BNNSNDArrayDescriptor *desc) {
+    BNNSDataLayout bnns_layout = get_bnns_data_layout(layout.strides(), desc->stride);
+    if (bnns_layout == (BNNSDataLayout)-1) {
+        return false;
+    }
+    
+    std::memset(desc, 0, sizeof(*desc));
+    const auto& shape = layout.shape();
+    std::copy(shape.begin(), shape.end(), desc->size);
+    desc->layout = bnns_layout;
+    desc->data_scale = 1.0f;
+    desc->data_bias = 0.0f;
+    
+    return true;
+}
+
+template<typename T1, typename T2>
+struct MultiArrayBNNSCopier {
+    static bool copy(TypedMultiArray<T1>& src, TypedMultiArray<T2>& dst) {
+        if (!BNNSCopier<T1, T2>::supported()) {
+            return false;
+        }
+        
+        BNNSNDArrayDescriptor src_bnns_array;
+        BNNSNDArrayDescriptor dst_bnns_array;
+        if (!init_bnns_array_descriptor(src.layout, &src_bnns_array) || !init_bnns_array_descriptor(dst.layout, &dst_bnns_array)) {
+            return false;
+        }
+        
+        BNNSCopier<T1, T2>::copy(&src_bnns_array, &dst_bnns_array);
+        return true;
+    }
+};
+
+#pragma mark - VImageCopier
+
+bool init_vi_Buffer(const MultiArray::MemoryLayout& layout, vImage_Buffer *viBuf, size_t bytesPerScalar) {
+    size_t rank = layout.rank();
+    const auto& shape = layout.shape();
+    const auto& strides = layout.strides();
+    
+    if (rank < 2) {
+        // vImage path requires at least two dimensions.
+        return false;
+    }
+    
+    // vImage blitter requires first major and every dimension except row (shape[rank - 2]) is contiguous.
+    if (!std::is_sorted(strides.begin(), strides.end(), std::greater())) {
+        return false;
+    }
+    
+    if (strides[rank - 1] != 1) {
+        return false;
+    }
+    
+    size_t height = std::accumulate(shape.begin(), shape.end() - 1, size_t(1), std::multiplies<size_t>());
+    if (height * strides[rank - 2] != strides[0] * shape[0]) {
+        return false;
+    }
+    
+    size_t width = shape[rank - 1];
+    size_t rowBytes = strides[rank - 2] * bytesPerScalar;
+    
+    viBuf->data = NULL;
+    viBuf->height = height;
+    viBuf->width = width;
+    viBuf->rowBytes = rowBytes;
+    
+    return true;
+}
+
+template<typename T1, typename T2>
+struct VImageCopier {
+    static bool supported() noexcept {
+        return false;
+    }
+    
+    static void copy(vImage_Buffer *src_vi_buffer, vImage_Buffer *dst_vi_buffer) noexcept {}
+};
+
+template<typename T>
+struct VImageCopier<T, T> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(vImage_Buffer *src_vi_buffer, vImage_Buffer *dst_vi_buffer) noexcept {
+        vImageCopyBuffer(src_vi_buffer, dst_vi_buffer, sizeof(T), kvImageDoNotTile);
+    }
+};
+
+// float -> _Float16
+template <>
+struct VImageCopier<float, _Float16> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(vImage_Buffer *src_vi_buffer, vImage_Buffer *dst_vi_buffer) noexcept {
+        vImageConvert_PlanarFtoPlanar16F(src_vi_buffer, dst_vi_buffer, kvImageDoNotTile);
+    }
+};
+
+// _Float16 -> float
+template <>
+struct VImageCopier<_Float16, float> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(vImage_Buffer *src_vi_buffer, vImage_Buffer *dst_vi_buffer) noexcept {
+        vImageConvert_Planar16FtoPlanarF(src_vi_buffer, dst_vi_buffer, kvImageDoNotTile);
+    }
+};
+
+template<typename T1, typename T2>
+struct MultiArrayVImageCopier {
+    static bool copy(TypedMultiArray<T1>& src, TypedMultiArray<T2>& dst) {
+        if (!VImageCopier<T1, T2>::supported()) {
+            return false;
+        }
+        
+        vImage_Buffer src_vi_buffer;
+        vImage_Buffer dst_vi_buffer;
+        if (!init_vi_Buffer(src.layout, &src_vi_buffer, sizeof(T1))) {
+            return false;
+        }
+        
+        if (!init_vi_Buffer(dst.layout, &dst_vi_buffer, sizeof(T2))) {
+            return false;
+        }
+        
+        VImageCopier<T1, T2>::copy(&src_vi_buffer, &dst_vi_buffer);
+        return true;
+    }
+};
+
+#pragma mark - VDSPCopier
+
+template<typename T1, typename T2>
+struct VDSPCopier {
+    static bool supported() noexcept {
+        return false;
+    }
+    
+    static void copy(const T1 *src_data, T2 *dst_data, size_t num_elements) noexcept {}
+};
+
+// Double -> Float
+template<>
+struct VDSPCopier<double, float> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(const double *src_data, float *dst_data, size_t num_elements) noexcept {
+        vDSP_vdpsp(src_data, 1, dst_data, 1, num_elements);
+    }
+};
+
+// Float -> Double
+template<>
+struct VDSPCopier<float, double> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(const float *src_data, double *dst_data, size_t num_elements) noexcept {
+        vDSP_vspdp(src_data, 1, dst_data, 1, num_elements);
+    }
+};
+
+// Float -> Int32
+template<>
+struct VDSPCopier<float, int32_t> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(const float *src_data, int32_t *dst_data, size_t num_elements) noexcept {
+        vDSP_vfix32(src_data, 1, dst_data, 1, num_elements);
+    }
+};
+
+// Int32 -> Double
+template<>
+struct VDSPCopier<int32_t, double> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(const int32_t *src_data, double *dst_data, size_t num_elements) noexcept {
+        vDSP_vflt32D(src_data, 1, dst_data, 1, num_elements);
+    }
+};
+
+// Int32 -> Float
+template<>
+struct VDSPCopier<int32_t, float> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(const int32_t *src_data, float *dst_data, size_t num_elements) noexcept {
+        vDSP_vflt32(src_data, 1, dst_data, 1, num_elements);
+    }
+};
+
+template<typename T1, typename T2>
+struct MultiArrayVDSPCopier {
+    static bool copy(TypedMultiArray<T1>& src, TypedMultiArray<T2>& dst) {
+        if (!VDSPCopier<T1, T2>::supported()) {
+            return false;
+        }
+        
+        if (!src.layout.is_packed() || !dst.layout.is_packed()) {
+            return false;
+        }
+        
+        VDSPCopier<T1, T2>::copy(src.data, dst.data, src.layout.get_num_elements());
+        return true;
+    }
+};
+
+#pragma mark - MemCopy
+
+template<typename T1, typename T2>
+struct MemCopier {
+    static bool supported() noexcept {
+        return false;
+    }
+    
+    static void copy(const T1 *src_data, T2 *dst_data, size_t num_elements) noexcept {}
+};
+
+template<typename T>
+struct MemCopier<T, T> {
+    static bool supported() noexcept {
+        return true;
+    }
+    
+    static void copy(const T *src_data, T *dst_data, size_t num_elements) noexcept {
+        std::memcpy(dst_data, src_data, num_elements);
+    }
+};
+
+template<typename T1, typename T2>
+struct MultiArrayMemCopier {
+    static bool copy(TypedMultiArray<T1>& src, TypedMultiArray<T2>& dst) {
+        if (!MemCopier<T1, T2>::supported()) {
+            return false;
+        }
+        
+        if (!src.layout.is_packed() || !dst.layout.is_packed()) {
+            return false;
+        }
+        
+        MemCopier<T1, T2>::copy(src.data, dst.data, src.layout.get_num_elements());
+        return true;
+    }
+};
+
+#pragma mark - MultiArrayIterator
+/// TODO - remove recursion and coalesce contiguous dimensions.
+template <typename T1, typename T2>
+struct MultiArrayIterator {
+    explicit MultiArrayIterator(TypedMultiArray<T1>& array1, TypedMultiArray<T2>& array2)
+    :array1(array1), array2(array2)
+    {}
+    
+    template<typename FN>
+    void loop(FN&& fn, T1 *data1, T2 *data2, size_t dim) {
+        const size_t index = dim - 1;
+        const auto& layout1 = array1.layout;
+        const auto& layout2 = array2.layout;
+        const ssize_t stride1 = layout1.strides()[index];
+        const ssize_t stride2 = layout2.strides()[index];
+        const size_t bound = layout1.shape()[index];
+        
+        if (index == 0) {
+            for (size_t i = 0; i < bound; i++) {
+                if (fn(data1 + stride1 * i, data2 + stride2 * i)) {
+                    break;
+                }
+            }
+            return;
+        }
+        
+        for (size_t i = 0; i < bound; i++) {
+            loop(fn, data1 + stride1 * i, data2 + stride2 * i, dim - 1);
+        }
+    }
+    
+    template<typename FN>
+    void loop(FN&& fn) {
+        loop(fn, array1.data, array2.data, array1.layout.rank());
+    }
+    
+    TypedMultiArray<T1> array1;
+    TypedMultiArray<T2> array2;
+};
+
+template<typename T1, typename T2>
+struct MultiArrayLoopingCopier {
+    static bool copy(TypedMultiArray<T1>& src, TypedMultiArray<T2>& dst) {
+        auto looper  = MultiArrayIterator<T1, T2>(src, dst);
+        looper.loop([](T1 *src, T2 *dst){
+            *dst = static_cast<T2>(*src);
+            return true;
+        });
+        
+        return true;
+    }
+};
+
+template <typename T1, typename T2>
+struct MultiArrayCopier {
+    static bool copy(TypedMultiArray<T1>& src, TypedMultiArray<T2>& dst) {
+        if (src.layout.shape() != dst.layout.shape()) {
+            return false;
+        }
+        
+        if (src.layout.get_num_elements() == 0) {
+            return true;
+        }
+        
+        if (MultiArrayBNNSCopier<T1, T2>::copy(src, dst)) {
+            return true;
+        }
+        
+        if (MultiArrayVImageCopier<T1, T2>::copy(src, dst)) {
+            return true;
+        }
+        
+        if (MultiArrayVDSPCopier<T1, T2>::copy(src, dst)) {
+            return true;
+        }
+        
+        if (MultiArrayMemCopier<T1, T2>::copy(src, dst)) {
+            return true;
+        }
+        
+        return MultiArrayLoopingCopier<T1, T2>::copy(src, dst);
+    }
+};
+
+template <typename T>
+bool copy(TypedMultiArray<T>& src, MultiArray& dst) {
+    const auto& dstLayout = dst.layout();
+    switch (dstLayout.dataType()) {
+        case MultiArray::DataType::Int: {
+            auto dst_array = TypedMultiArray<int32_t>(reinterpret_cast<int32_t *>(dst.data()), dstLayout);
+            return MultiArrayCopier<T, int32_t>::copy(src, dst_array);
+        }
+            
+        case MultiArray::DataType::Float16: {
+            auto dst_array = TypedMultiArray<_Float16>(reinterpret_cast<_Float16 *>(dst.data()), dstLayout);
+            return MultiArrayCopier<T, _Float16>::copy(src, dst_array);
+        }
+            
+        case MultiArray::DataType::Float: {
+            auto dst_array = TypedMultiArray<float>(reinterpret_cast<float *>(dst.data()), dstLayout);
+            return MultiArrayCopier<T, float>::copy(src, dst_array);
+        }
+            
+        case MultiArray::DataType::Double: {
+            auto dst_array = TypedMultiArray<double>(reinterpret_cast<double *>(dst.data()), dstLayout);
+            return MultiArrayCopier<T, double>::copy(src, dst_array);
+        }
+    }
+}
+} //namespace
+
+namespace executorchcoreml {
+
+size_t MultiArray::MemoryLayout::get_num_elements() const noexcept {
+    if (shape_.size() == 0) {
+        return 0;
+    }
+    
+    return std::accumulate(shape_.begin(), shape_.end(), size_t(1), std::multiplies<size_t>());
+}
+
+bool MultiArray::MemoryLayout::is_packed() const noexcept {
+    if (strides_.size() < 2) {
+        return true;
+    }
+    
+    ssize_t expectedStride = 1;
+    auto stridesIt = strides_.crbegin();
+    for (auto shapeIt = shape_.crbegin(); shapeIt!= shape_.crend(); shapeIt++) {
+        if (*stridesIt != expectedStride) {
+            return false;
+        }
+        expectedStride = expectedStride * (*shapeIt);
+    }
+    
+    return true;
+}
+
+bool MultiArray::copy(MultiArray& dst) const noexcept {
+    switch (layout().dataType()) {
+        case MultiArray::DataType::Int: {
+            auto src = TypedMultiArray<int32_t>(reinterpret_cast<int32_t *>(data()), layout());
+            return ::copy(src, dst);
+        }
+            
+        case MultiArray::DataType::Float16: {
+            auto src = TypedMultiArray<_Float16>(reinterpret_cast<_Float16 *>(data()), layout());
+            return ::copy(src, dst);
+        }
+            
+        case MultiArray::DataType::Float: {
+            auto src = TypedMultiArray<float>(reinterpret_cast<float *>(data()), layout());
+            return ::copy(src, dst);
+        }
+            
+        case MultiArray::DataType::Double: {
+            auto src = TypedMultiArray<double>(reinterpret_cast<double *>(data()), layout());
+            return ::copy(src, dst);
+        }
+    }
+}
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/delegate/serde_json.h
+++ b/backends/apple/coreml/runtime/delegate/serde_json.h
@@ -1,0 +1,44 @@
+//
+// Serdes.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#import <string>
+#import <vector>
+
+#import <json.hpp>
+
+#import <asset.h>
+#import <metadata.h>
+
+namespace executorchcoreml {
+
+/// Populates `nlohmann::json` from `ModelAsset`.
+///
+/// @param json The json value to be populated from the asset value.
+/// @param asset The asset value.
+void to_json(nlohmann::json& json, const Asset& asset);
+
+/// Populates `ModelAsset` from `nlohmann::json`.
+///
+/// @param json The json value.
+/// @param asset The asset value to be populated from the json value.
+void from_json(const nlohmann::json& json, Asset& asset);
+
+/// Populates nlohmann::json`from `ModelMetadata`.
+///
+/// @param json The json value to be populated from the metadata value.
+/// @param metadata The metadata value.
+void to_json(nlohmann::json& json, const ModelMetadata& metadata);
+
+/// Populates `ModelMetadata` from `nlohmann::json`.
+///
+/// @param json The json value.
+/// @param metadata The metadata value to be populated from the json value.
+void from_json(const nlohmann::json& json, ModelMetadata& metadata);
+
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/delegate/serde_json.mm
+++ b/backends/apple/coreml/runtime/delegate/serde_json.mm
@@ -1,0 +1,116 @@
+//
+// serde_json.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <serde_json.h>
+
+namespace  {
+
+struct FileInfoKeys {
+    constexpr static std::string_view kRelativePath = "relativePath";
+    constexpr static std::string_view kSizeKey = "sizeInBytes";
+    constexpr static std::string_view kLastModificationTimeIntervalKey = "lastModificationTimeInterval";
+};
+
+struct PackageInfoKeys {
+    constexpr static std::string_view kNameKey = "name";
+    constexpr static std::string_view kFileInfosKey = "fileInfos";
+};
+
+struct ModelAssetKeys {
+    constexpr static std::string_view kIdentifierKey = "identifier";
+    constexpr static std::string_view kPathKey = "path";
+    constexpr static std::string_view kPackageInfoKey = "packageInfo";
+};
+
+struct ModelMetadataKeys {
+    constexpr static std::string_view kIdentifierKey = "identifier";
+    constexpr static std::string_view kInputNamesKey = "inputNames";
+    constexpr static std::string_view kOutputNamesKey = "outputNames";
+};
+} //namespace
+
+namespace executorchcoreml {
+
+using json = nlohmann::json;
+
+void to_json(json& j, const FileInfo& info) {
+    j = json{
+        {FileInfoKeys::kRelativePath, info.relative_path},
+        {FileInfoKeys::kSizeKey, info.size_in_bytes},
+        {FileInfoKeys::kLastModificationTimeIntervalKey, info.last_modification_time_interval},
+    };
+}
+
+void from_json(const json& j, FileInfo& info) {
+    if (j.contains(FileInfoKeys::kRelativePath)) {
+        j.at(FileInfoKeys::kRelativePath).get_to(info.relative_path);
+    }
+    if (j.contains(FileInfoKeys::kSizeKey)) {
+        j.at(FileInfoKeys::kSizeKey).get_to(info.size_in_bytes);
+    }
+    if (j.contains(FileInfoKeys::kLastModificationTimeIntervalKey)) {
+        j.at(FileInfoKeys::kLastModificationTimeIntervalKey).get_to(info.last_modification_time_interval);
+    }
+}
+
+void to_json(json& j, const PackageInfo& info) {
+    j = json{
+        {PackageInfoKeys::kNameKey, info.name},
+        {PackageInfoKeys::kFileInfosKey, info.file_infos}
+    };
+}
+
+void from_json(const json& j, PackageInfo& info) {
+    if (j.contains(PackageInfoKeys::kNameKey)) {
+        j.at(PackageInfoKeys::kNameKey).get_to(info.name);
+    }
+    if (j.contains(PackageInfoKeys::kFileInfosKey)) {
+        j.at(PackageInfoKeys::kFileInfosKey).get_to(info.file_infos);
+    }
+}
+
+void to_json(json& j, const Asset& asset) {
+    j = json{
+        {ModelAssetKeys::kIdentifierKey, asset.identifier},
+        {ModelAssetKeys::kPathKey, asset.path},
+        {ModelAssetKeys::kPackageInfoKey, asset.package_info}
+    };
+}
+
+void from_json(const json& j, Asset& asset) {
+    if (j.contains(ModelAssetKeys::kIdentifierKey)) {
+        j.at(ModelAssetKeys::kIdentifierKey).get_to(asset.identifier);
+    }
+    if (j.contains(ModelAssetKeys::kPathKey)) {
+        j.at(ModelAssetKeys::kPathKey).get_to(asset.path);
+    }
+    if (j.contains(ModelAssetKeys::kPackageInfoKey)) {
+        j.at(ModelAssetKeys::kPackageInfoKey).get_to(asset.package_info);
+    }
+}
+
+void to_json(json& j, const ModelMetadata& metadata) {
+    j = json{
+        {ModelMetadataKeys::kIdentifierKey, metadata.identifier},
+        {ModelMetadataKeys::kInputNamesKey, metadata.input_names},
+        {ModelMetadataKeys::kOutputNamesKey, metadata.output_names}
+    };
+}
+
+void from_json(const json& j, ModelMetadata& metadata) {
+    if (j.contains(ModelMetadataKeys::kIdentifierKey)) {
+        j.at(ModelMetadataKeys::kIdentifierKey).get_to(metadata.identifier);
+    }
+    if (j.contains(ModelMetadataKeys::kInputNamesKey)) {
+        j.at(ModelMetadataKeys::kInputNamesKey).get_to(metadata.input_names);
+    }
+    if (j.contains(ModelMetadataKeys::kOutputNamesKey)) {
+        j.at(ModelMetadataKeys::kOutputNamesKey).get_to(metadata.output_names);
+    }
+}
+
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/include/coreml_backend/delegate.h
+++ b/backends/apple/coreml/runtime/include/coreml_backend/delegate.h
@@ -1,0 +1,69 @@
+//
+// delegate.h
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <executorch/runtime/backend/interface.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/evalue.h>
+
+#include <memory>
+
+namespace executorchcoreml {
+class BackendDelegate;
+}
+
+namespace torch {
+namespace executor {
+
+class CoreMLBackendDelegate final : public PyTorchBackendInterface {
+public:
+    CoreMLBackendDelegate() noexcept;
+    ~CoreMLBackendDelegate() = default;
+
+    /// Loads a CoreML model from AOT blob.
+    ///
+    /// @param context An init context specific to the CoreML backend.
+    /// @param processed The AOT blob that was produced by a call to CoreML's
+    /// backend `preprocess` method.
+    /// @param compileSpecs The exact same compiler specification that was used to
+    /// produce `processed`.
+    /// @retval On success, an opaque handle representing the loaded model
+    /// otherwise  an`Error` case.
+    Result<DelegateHandle*>
+    init(BackendInitContext& context, FreeableBuffer* processed, ArrayRef<CompileSpec> compileSpecs) const override;
+
+    /// Executes the loaded model.
+    ///
+    /// @param context An execution context specific to the CoreML backend.
+    /// @param handle The handle returned by an earlier call to `init`.
+    /// @param args The models inputs and outputs.
+    /// @retval On success, `Error::Ok` otherwise any other `Error` case.
+    Error execute(BackendExecutionContext& context, DelegateHandle* handle, EValue** args) const override;
+
+    /// Returns `true` if the delegate is available otherwise `false`.
+    bool is_available() const override;
+
+    /// Unloads the loaded CoreML model with the  specified handle.
+    ///
+    /// @param handle The handle returned by an earlier call to `init`.
+    void destroy(DelegateHandle* handle) const override;
+
+    /// Returns the registered `CoreMLBackendDelegate` instance.
+    static CoreMLBackendDelegate* get_registered_delegate() noexcept;
+
+    /// Purges the models cache.
+    ///
+    /// The cached models are moved to a temporary directory and are
+    /// asynchronously deleted.
+    bool purge_models_cache() const noexcept;
+
+private:
+    std::shared_ptr<executorchcoreml::BackendDelegate> impl_;
+};
+} // namespace executor
+} // namespace torch

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.cpp
@@ -1,0 +1,786 @@
+//
+// inmemory_filesystem.cpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#include "inmemory_filesystem.hpp"
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace std {
+namespace filesystem = std::experimental::filesystem;
+}
+#endif
+
+#include <json.hpp>
+#include <reversed_memory_stream.hpp>
+
+namespace {
+using namespace inmemoryfs;
+
+class InMemoryFileNode : public InMemoryFileSystem::InMemoryNode {
+public:
+    InMemoryFileNode(std::string name,
+                     InMemoryFileSystem::Attributes attributes,
+                     std::shared_ptr<MemoryBuffer> buffer) noexcept
+        : InMemoryNode(std::move(name), std::move(attributes), InMemoryNode::Kind::File), buffer_(std::move(buffer)) { }
+
+    InMemoryFileNode(InMemoryFileNode const&) = delete;
+    InMemoryFileNode& operator=(InMemoryFileNode const&) = delete;
+
+    inline std::shared_ptr<MemoryBuffer> getBuffer() const noexcept { return buffer_; }
+
+private:
+    const std::shared_ptr<MemoryBuffer> buffer_;
+};
+
+class InMemoryDirectoryNode : public InMemoryFileSystem::InMemoryNode {
+public:
+    using ItemsType = std::unordered_map<std::string, std::unique_ptr<InMemoryNode>>;
+
+    InMemoryDirectoryNode(std::string name, InMemoryFileSystem::Attributes attributes, ItemsType items) noexcept
+        : InMemoryNode(std::move(name), std::move(attributes), InMemoryNode::Kind::Directory),
+          items_(std::move(items)) { }
+
+    InMemoryDirectoryNode(std::string name, InMemoryFileSystem::Attributes attributes) noexcept
+        : InMemoryNode(std::move(name), std::move(attributes), InMemoryNode::Kind::Directory), items_(ItemsType()) { }
+
+    InMemoryDirectoryNode(InMemoryDirectoryNode const&) = delete;
+    InMemoryDirectoryNode& operator=(InMemoryDirectoryNode const&) = delete;
+
+    inline void add_item(const std::string& name, std::unique_ptr<InMemoryNode> node) noexcept {
+        items_[name] = std::move(node);
+    }
+
+    inline void remove_item(const std::string& name) noexcept { items_.erase(name); }
+
+    inline const ItemsType& get_items() const noexcept { return items_; }
+
+    inline bool contains(const std::string& key) const noexcept { return items_.find(key) != items_.end(); }
+
+    InMemoryNode* get_item(const std::string& key) noexcept {
+        auto it = items_.find(key);
+        if (it == items_.end()) {
+            return nullptr;
+        }
+
+        return it->second.get();
+    }
+
+private:
+    ItemsType items_;
+};
+
+template <typename Iter, typename Container> inline bool is_last(Iter it, const Container& container) {
+    return (it != container.end()) && (next(it) == container.end());
+}
+
+inline size_t align(size_t length, size_t alignment) { return ((length + (alignment - 1)) / alignment) * alignment; }
+
+InMemoryFileSystem::InMemoryNode* get_node(InMemoryFileSystem::InMemoryNode* node,
+                                           std::vector<std::string>::const_iterator path_start,
+                                           std::vector<std::string>::const_iterator path_end) {
+    for (auto it = path_start; it != path_end; ++it) {
+        if (!node) {
+            return nullptr;
+        }
+        const std::string& component = *it;
+        InMemoryDirectoryNode* directory_node = static_cast<InMemoryDirectoryNode*>(node);
+        node = directory_node->get_item(component);
+    }
+
+    return node;
+}
+
+std::string toString(time_t time) {
+    constexpr auto format = "%Y-%m-%dT%TZ";
+    std::stringstream stream;
+    stream << std::put_time(gmtime(&time), format);
+    return stream.str();
+}
+
+time_t toTime(const std::string& str) {
+    constexpr auto format = "%Y-%m-%dT%TZ";
+    time_t time = (time_t)(-1);
+    std::stringstream stream(str);
+    stream >> std::get_time(gmtime(&time), format);
+    return time;
+}
+
+template <typename TP> std::time_t toTime(TP tp) {
+    using namespace std::chrono;
+    auto sctp = time_point_cast<system_clock::duration>(tp - TP::clock::now() + system_clock::now());
+    return system_clock::to_time_t(sctp);
+}
+
+InMemoryFileSystem::Attributes get_file_attributes(const std::filesystem::path& path) {
+    auto attributes = InMemoryFileSystem::Attributes();
+    auto modificationTime = toTime(std::filesystem::last_write_time(path));
+    attributes.modificationTime = modificationTime;
+
+    return attributes;
+}
+
+std::unique_ptr<InMemoryFileSystem::InMemoryNode> make_file_node(const std::filesystem::path& path,
+                                                                 std::error_code& error) {
+    error.clear();
+    auto name = path.filename().string();
+    auto file_path = path.string();
+    auto buffer = MemoryBuffer::read_file_content(file_path, MemoryBuffer::ReadOption::Any, error);
+    if (error) {
+        return nullptr;
+    }
+
+    auto attributes = get_file_attributes(path);
+    return std::make_unique<InMemoryFileNode>(std::move(name), std::move(attributes), std::move(buffer));
+}
+
+std::unique_ptr<InMemoryFileSystem::InMemoryNode> make_directory_node(const std::filesystem::path& path,
+                                                                      std::error_code& error) {
+    auto name = path.filename();
+    std::unordered_map<std::string, std::unique_ptr<InMemoryFileSystem::InMemoryNode>> items = {};
+    for (const std::filesystem::directory_entry& entry: std::filesystem::directory_iterator(path)) {
+        if (!entry.exists()) {
+            continue;
+        }
+
+        auto itemPath = std::filesystem::canonical(entry.path());
+        auto itemName = itemPath.filename().string();
+        std::unique_ptr<InMemoryFileSystem::InMemoryNode> node;
+        if (entry.is_directory()) {
+            node = make_directory_node(itemPath, error);
+        } else if (!entry.is_directory()) {
+            node = make_file_node(itemPath, error);
+        }
+
+        if (node) {
+            items[itemName] = std::move(node);
+        }
+    }
+    auto attributes = get_file_attributes(path);
+    return std::make_unique<InMemoryDirectoryNode>(std::move(name), std::move(attributes), std::move(items));
+}
+
+std::unique_ptr<InMemoryFileSystem::InMemoryNode> make_node(const std::filesystem::path& path, std::error_code& error) {
+    error.clear();
+    auto status = std::filesystem::exists(path, error);
+    if (!status || error) {
+        return nullptr;
+    }
+
+    auto name = path.filename();
+    bool isDirectory = std::filesystem::is_directory(path, error);
+    if (error) {
+        return nullptr;
+    }
+
+    if (isDirectory) {
+        return make_directory_node(path, error);
+    }
+
+    return make_file_node(path, error);
+}
+
+bool write_node(InMemoryFileSystem::InMemoryNode* node,
+                const std::filesystem::path& dst_path,
+                bool recursive,
+                std::error_code& error);
+
+bool write_file_node(InMemoryFileNode* node, const std::filesystem::path& dst_path, std::error_code& error) {
+    error.clear();
+    std::filesystem::path file_path = dst_path;
+    file_path.append(node->name());
+    std::ofstream stream;
+    stream.open(file_path, std::ofstream::out);
+    if (!stream.good()) {
+        error = std::error_code(errno, std::system_category());
+        return false;
+    }
+    auto buffer = node->getBuffer().get();
+    if (buffer->size() > 0) {
+        char* bufferPtr = static_cast<char*>(buffer->data());
+        stream.write(bufferPtr, static_cast<std::streamsize>(buffer->size()));
+    }
+    if (!stream.good()) {
+        error = std::error_code(errno, std::system_category());
+    }
+    stream.close();
+
+    return !error;
+}
+
+bool write_directory_node(InMemoryDirectoryNode* node,
+                          const std::filesystem::path& dst_path,
+                          bool recursive,
+                          std::error_code& error) {
+    error.clear();
+    std::filesystem::path dir_path = dst_path;
+    dir_path.append(node->name());
+    if (!std::filesystem::create_directory(dir_path, error)) {
+        return false;
+    }
+
+    for (const auto& [_, node]: node->get_items()) {
+        if (node.get()->isDirectory() && !recursive) {
+            continue;
+        }
+        if (!write_node(node.get(), dir_path, recursive, error)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool write_node(InMemoryFileSystem::InMemoryNode* node,
+                const std::filesystem::path& dst_path,
+                bool recursive,
+                std::error_code& error) {
+    switch (node->kind()) {
+        case InMemoryFileSystem::InMemoryNode::Kind::Directory:
+            return write_directory_node(static_cast<InMemoryDirectoryNode*>(node), dst_path, recursive, error);
+
+        case InMemoryFileSystem::InMemoryNode::Kind::File:
+            return write_file_node(static_cast<InMemoryFileNode*>(node), dst_path, error);
+    }
+}
+} // namespace
+
+namespace inmemoryfs {
+using json = nlohmann::json;
+
+void to_json(json& j, const MemoryRegion& region) { j = json { { "offset", region.offset }, { "size", region.size } }; }
+
+void from_json(const json& j, MemoryRegion& region) {
+    j.at("offset").get_to(region.offset);
+    j.at("size").get_to(region.size);
+}
+
+void to_json(json& j, const InMemoryFileSystem::Attributes& attributes) {
+    j = json { { "modificationTime", toString(attributes.modificationTime) } };
+}
+
+void from_json(const json& j, InMemoryFileSystem::Attributes& attributes) {
+    const std::string& modificationTime = j.at("modificationTime");
+    attributes.modificationTime = toTime(modificationTime);
+}
+
+struct Attributes {
+    time_t creation_time;
+    time_t modification_time;
+
+    inline Attributes() noexcept : creation_time(time(0)), modification_time(time(0)) { }
+};
+} // namespace inmemoryfs
+
+namespace serdes {
+using json = nlohmann::json;
+
+struct FlattenedInMemoryNodeKeys {
+    constexpr static std::string_view kName = "name";
+    constexpr static std::string_view kDataRegion = "dataRegion";
+    constexpr static std::string_view kChildren = "children";
+    constexpr static std::string_view kKind = "kind";
+};
+
+struct FlattenedInMemoryNode {
+    std::string name;
+    InMemoryFileSystem::InMemoryNode::Kind kind;
+    InMemoryFileSystem::Attributes attributes;
+    std::unordered_map<std::string, size_t> children;
+    MemoryRegion data_region;
+    InMemoryFileNode* file_node = nullptr;
+
+    static std::vector<FlattenedInMemoryNode> flatten(InMemoryFileSystem::InMemoryNode* node,
+                                                      size_t alignment) noexcept;
+
+    static std::unique_ptr<InMemoryFileSystem::InMemoryNode>
+    unflatten(const std::vector<FlattenedInMemoryNode>& nodes, const std::shared_ptr<MemoryBuffer>& data) noexcept;
+
+private:
+    static void populate(InMemoryFileSystem::InMemoryNode* node,
+                         std::unordered_map<InMemoryFileSystem::InMemoryNode*, size_t>& node_to_index_map,
+                         size_t alignment,
+                         std::vector<FlattenedInMemoryNode>& result) noexcept;
+
+    static size_t get_next_offset(const std::vector<FlattenedInMemoryNode>& nodes) noexcept;
+};
+
+size_t FlattenedInMemoryNode::get_next_offset(const std::vector<FlattenedInMemoryNode>& nodes) noexcept {
+    for (auto it = nodes.rbegin(); it != nodes.rend(); ++it) {
+        if (it->kind == InMemoryFileSystem::InMemoryNode::Kind::File) {
+            return it->data_region.get_length() + 1;
+        }
+    }
+
+    return 0;
+}
+
+void FlattenedInMemoryNode::populate(InMemoryFileSystem::InMemoryNode* node,
+                                     std::unordered_map<InMemoryFileSystem::InMemoryNode*, size_t>& node_to_index_map,
+                                     size_t alignment,
+                                     std::vector<FlattenedInMemoryNode>& result) noexcept {
+    FlattenedInMemoryNode flattened_node;
+    flattened_node.name = node->name();
+    flattened_node.kind = node->kind();
+    switch (node->kind()) {
+        case InMemoryFileSystem::InMemoryNode::Kind::File: {
+            size_t index = result.size();
+            InMemoryFileNode* file_node = static_cast<InMemoryFileNode*>(node);
+            size_t offset = align(FlattenedInMemoryNode::get_next_offset(result), alignment);
+            auto buffer = file_node->getBuffer();
+            size_t size = buffer->size();
+            flattened_node.data_region = MemoryRegion(offset, size);
+            flattened_node.file_node = file_node;
+            result.emplace_back(std::move(flattened_node));
+            node_to_index_map[node] = index;
+            break;
+        }
+        case InMemoryFileSystem::InMemoryNode::Kind::Directory: {
+            InMemoryDirectoryNode* directory_node = static_cast<InMemoryDirectoryNode*>(node);
+            for (const auto& [key, item]: directory_node->get_items()) {
+                populate(item.get(), node_to_index_map, alignment, result);
+                flattened_node.children[key] = node_to_index_map[item.get()];
+            }
+            node_to_index_map[node] = result.size();
+            result.emplace_back(std::move(flattened_node));
+            break;
+        }
+    }
+}
+
+std::vector<FlattenedInMemoryNode> FlattenedInMemoryNode::flatten(InMemoryFileSystem::InMemoryNode* node,
+                                                                  size_t alignment) noexcept {
+    std::unordered_map<InMemoryFileSystem::InMemoryNode*, size_t> node_to_index_map;
+    std::vector<FlattenedInMemoryNode> result;
+    populate(node, node_to_index_map, alignment, result);
+
+    return result;
+}
+
+std::unique_ptr<InMemoryFileSystem::InMemoryNode>
+FlattenedInMemoryNode::unflatten(const std::vector<FlattenedInMemoryNode>& flattened_nodes,
+                                 const std::shared_ptr<MemoryBuffer>& buffer) noexcept {
+    if (flattened_nodes.size() == 0) {
+        return nullptr;
+    }
+
+    std::vector<std::unique_ptr<InMemoryFileSystem::InMemoryNode>> nodes;
+    nodes.reserve(flattened_nodes.size());
+    for (size_t index = 0; index < flattened_nodes.size(); index++) {
+        const FlattenedInMemoryNode& flattened_node = flattened_nodes[index];
+        auto name = flattened_node.name;
+        auto attributes = flattened_node.attributes;
+        switch (flattened_node.kind) {
+            case InMemoryFileSystem::InMemoryNode::Kind::File: {
+                auto region = flattened_node.data_region;
+                std::shared_ptr sliced_buffer = buffer->slice(region);
+                if (!sliced_buffer) {
+                    return nullptr;
+                }
+                auto file_node = std::make_unique<InMemoryFileNode>(
+                    std::move(name), std::move(attributes), std::move(sliced_buffer));
+                nodes.emplace_back(std::move(file_node));
+                break;
+            }
+            case InMemoryFileSystem::InMemoryNode::Kind::Directory: {
+                std::unordered_map<std::string, std::unique_ptr<InMemoryFileSystem::InMemoryNode>> items;
+                items.reserve(flattened_node.children.size());
+                for (const auto& [name, index]: flattened_node.children) {
+                    auto moveIt = std::make_move_iterator(nodes.begin() + index);
+                    items[name] = *moveIt;
+                }
+                auto directory_node =
+                    std::make_unique<InMemoryDirectoryNode>(std::move(name), std::move(attributes), std::move(items));
+                nodes.emplace_back(std::move(directory_node));
+                break;
+            }
+        }
+    }
+
+    return std::move(nodes.back());
+}
+
+void to_json(json& j, const FlattenedInMemoryNode& flattened_node) {
+    j = json { { FlattenedInMemoryNodeKeys::kName, flattened_node.name },
+               { FlattenedInMemoryNodeKeys::kDataRegion, flattened_node.data_region },
+               { FlattenedInMemoryNodeKeys::kChildren, flattened_node.children },
+               { FlattenedInMemoryNodeKeys::kKind, static_cast<int>(flattened_node.kind) } };
+}
+
+void from_json(const json& j, FlattenedInMemoryNode& flattened_node) {
+    if (j.contains(FlattenedInMemoryNodeKeys::kName)) {
+        j.at(FlattenedInMemoryNodeKeys::kName).get_to(flattened_node.name);
+    }
+    if (j.contains(FlattenedInMemoryNodeKeys::kDataRegion)) {
+        j.at(FlattenedInMemoryNodeKeys::kDataRegion).get_to(flattened_node.data_region);
+    }
+    if (j.contains(FlattenedInMemoryNodeKeys::kChildren)) {
+        j.at(FlattenedInMemoryNodeKeys::kChildren).get_to(flattened_node.children);
+    }
+    if (j.contains(FlattenedInMemoryNodeKeys::kKind)) {
+        j.at(FlattenedInMemoryNodeKeys::kKind).get_to(flattened_node.kind);
+    }
+}
+
+struct InMemoryNodeMetaDataKeys {
+    constexpr static std::string_view kNodes = "nodes";
+};
+
+struct InMemoryNodeMetaData {
+    std::vector<FlattenedInMemoryNode> nodes;
+
+    std::string json_string();
+    void writeToStream(std::ostream& ostream);
+};
+
+void to_json(json& j, const InMemoryNodeMetaData& metadata) {
+    j = json { { InMemoryNodeMetaDataKeys::kNodes, metadata.nodes } };
+}
+
+void from_json(const json& j, InMemoryNodeMetaData& metadata) {
+    if (j.contains(InMemoryNodeMetaDataKeys::kNodes)) {
+        j.at(InMemoryNodeMetaDataKeys::kNodes).get_to(metadata.nodes);
+    }
+}
+
+std::string InMemoryNodeMetaData::json_string() {
+    json value;
+    to_json(value, *this);
+    std::stringstream ss;
+    ss << value;
+    std::string metadataStr = ss.str();
+    return metadataStr;
+}
+
+void InMemoryNodeMetaData::writeToStream(std::ostream& ostream) {
+    std::string jsonStr = json_string();
+    // reverse it for writing
+    std::reverse(jsonStr.begin(), jsonStr.end());
+    ostream << jsonStr;
+}
+} // namespace serdes
+
+namespace inmemoryfs {
+
+std::string InMemoryFileSystem::ErrorCategory::message(int code) const {
+    switch (static_cast<ErrorCode>(code)) {
+        case ErrorCode::DirectoryExists:
+            return "The item at the path is a directory.";
+        case ErrorCode::ItemNotFound:
+            return "Path does not exist.";
+        case ErrorCode::ItemExists:
+            return "Item already exists at the path.";
+        case ErrorCode::DirectoryExpected:
+            return "The item at the path is not a directory";
+        case ErrorCode::FileExpected:
+            return "The item at the path is not a file";
+    }
+}
+
+InMemoryFileSystem::InMemoryFileSystem(std::string name) noexcept
+    : root_(std::make_unique<InMemoryDirectoryNode>(std::move(name), Attributes())) { }
+
+bool InMemoryFileSystem::is_directory(const std::vector<std::string>& canonical_path) noexcept {
+    auto node = get_node(root(), canonical_path.begin(), canonical_path.end());
+    return node && node->isDirectory();
+}
+
+bool InMemoryFileSystem::is_file(const std::vector<std::string>& canonical_path) noexcept {
+    auto node = get_node(root_.get(), canonical_path.begin(), canonical_path.end());
+    return node && node->isFile();
+}
+
+bool InMemoryFileSystem::exists(const std::vector<std::string>& canonical_path) noexcept {
+    auto node = get_node(root_.get(), canonical_path.begin(), canonical_path.end());
+    return node != nullptr;
+}
+
+std::vector<std::vector<std::string>> InMemoryFileSystem::get_item_paths(const std::vector<std::string>& canonical_path,
+                                                                         std::error_code& error) const noexcept {
+    auto node = get_node(root(), canonical_path.begin(), canonical_path.end());
+    if (node == nullptr) {
+        error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+        return {};
+    }
+
+    if (node->isFile()) {
+        error = InMemoryFileSystem::ErrorCode::DirectoryExpected;
+        return {};
+    }
+
+    auto directory_node = static_cast<InMemoryDirectoryNode*>(node);
+    const auto& items = directory_node->get_items();
+    std::vector<std::vector<std::string>> result;
+    result.reserve(items.size());
+    for (const auto& [component, _]: items) {
+        auto components = canonical_path;
+        components.emplace_back(component);
+        result.emplace_back(std::move(components));
+    }
+
+    return result;
+}
+
+std::optional<InMemoryFileSystem::Attributes>
+InMemoryFileSystem::get_attributes(const std::vector<std::string>& canonical_path,
+                                   std::error_code& error) const noexcept {
+    auto node = get_node(root(), canonical_path.begin(), canonical_path.end());
+    if (node == nullptr) {
+        error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+        return std::nullopt;
+    }
+
+    return node->attributes();
+}
+
+std::shared_ptr<MemoryBuffer> InMemoryFileSystem::get_file_content(const std::vector<std::string>& canonical_path,
+                                                                   std::error_code& error) const noexcept {
+    auto node = get_node(root(), canonical_path.begin(), canonical_path.end());
+    if (node == nullptr) {
+        error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+        return nullptr;
+    }
+    if (node->isDirectory()) {
+        error = InMemoryFileSystem::ErrorCode::FileExpected;
+        return nullptr;
+    }
+
+    InMemoryFileNode* file_node = static_cast<InMemoryFileNode*>(node);
+    return file_node->getBuffer();
+}
+
+bool InMemoryFileSystem::make_directory(const std::vector<std::string>& canonical_path,
+                                        Attributes attributes,
+                                        bool create_intermediate_directories,
+                                        std::error_code& error) noexcept {
+    if (canonical_path.size() == 0) {
+        error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+        return false;
+    }
+
+    auto directory_node = static_cast<InMemoryDirectoryNode*>(root());
+    for (auto it = canonical_path.begin(); it != canonical_path.end(); ++it) {
+        auto node = directory_node->get_item(*it);
+        bool createDirectory = create_intermediate_directories || is_last(it, canonical_path);
+        if (node == nullptr && createDirectory) {
+            auto child_directory_node = std::make_unique<InMemoryDirectoryNode>(*it, attributes);
+            directory_node->add_item(*it, std::move(child_directory_node));
+            directory_node = static_cast<InMemoryDirectoryNode*>(directory_node->get_item(*it));
+        } else if (node != nullptr && node->isDirectory()) {
+            directory_node = static_cast<InMemoryDirectoryNode*>(node);
+        } else {
+            if (node == nullptr) {
+                error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+            } else if (node->isFile()) {
+                error = InMemoryFileSystem::ErrorCode::DirectoryExpected;
+            }
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool InMemoryFileSystem::make_file(const std::vector<std::string>& canonical_path,
+                                   std::shared_ptr<MemoryBuffer> buffer,
+                                   Attributes attributes,
+                                   bool overwrite,
+                                   std::error_code& error) noexcept {
+    if (canonical_path.size() == 0) {
+        error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+        return false;
+    }
+
+    auto node = get_node(root(), canonical_path.begin(), std::prev(canonical_path.end()));
+    if (!node) {
+        error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+        return false;
+    }
+
+    if (!node->isDirectory()) {
+        error = InMemoryFileSystem::ErrorCode::DirectoryExpected;
+        return false;
+    }
+
+    InMemoryDirectoryNode* directory_node = static_cast<InMemoryDirectoryNode*>(node);
+    if (directory_node->contains(canonical_path.back()) && !overwrite) {
+        error = InMemoryFileSystem::ErrorCode::ItemExists;
+        return false;
+    }
+
+    auto name = canonical_path.back();
+    auto file_node = std::make_unique<InMemoryFileNode>(std::move(name), std::move(attributes), std::move(buffer));
+    directory_node->add_item(canonical_path.back(), std::move(file_node));
+
+    return true;
+}
+
+bool InMemoryFileSystem::remove_item(const std::vector<std::string>& canonical_path, std::error_code& error) noexcept {
+    if (canonical_path.size() == 0) {
+        error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+        return false;
+    }
+
+    auto node = get_node(root(), canonical_path.begin(), std::prev(canonical_path.end()));
+    if (!node->isDirectory()) {
+        error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+        return false;
+    }
+
+    InMemoryDirectoryNode* directory_node = static_cast<InMemoryDirectoryNode*>(node);
+    if (!directory_node->contains(canonical_path.back())) {
+        error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+        return false;
+    }
+    directory_node->remove_item(canonical_path.back());
+
+    return true;
+}
+
+bool InMemoryFileSystem::set_attributes(const std::vector<std::string>& canonical_path,
+                                        Attributes attributes,
+                                        std::error_code& error) noexcept {
+    if (canonical_path.size() == 0) {
+        error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+        return false;
+    }
+
+    auto node = get_node(root(), canonical_path.begin(), canonical_path.end());
+    if (!node) {
+        error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+        return false;
+    }
+
+    node->setAttributes(std::move(attributes));
+    return true;
+}
+
+bool InMemoryFileSystem::write_item_to_disk(const std::vector<std::string>& canonical_path,
+                                            const std::string& dst_path,
+                                            bool recursive,
+                                            std::error_code& error) const noexcept {
+    std::filesystem::path dst_file_path(dst_path);
+    auto status = std::filesystem::exists(dst_file_path, error);
+    if (!status || error) {
+        return false;
+    }
+
+    auto node = get_node(root(), canonical_path.begin(), canonical_path.end());
+    if (!node) {
+        error = InMemoryFileSystem::ErrorCode::ItemNotFound;
+        return false;
+    }
+
+    bool result = write_node(node, dst_file_path, recursive, error);
+    if (!result) {
+        auto rootPath = dst_path;
+        rootPath.append(root()->name());
+        std::filesystem::remove_all(rootPath, error);
+    }
+
+    return result;
+}
+
+std::unique_ptr<InMemoryFileSystem> InMemoryFileSystem::make(const std::string& path, std::error_code& error) {
+    std::filesystem::path file_path(path);
+    auto status = std::filesystem::exists(file_path, error);
+    if (!status || error) {
+        return nullptr;
+    }
+
+    auto node = make_node(file_path, error);
+    if (!node) {
+        return nullptr;
+    }
+
+    switch (node->kind()) {
+        case InMemoryFileSystem::InMemoryNode::Kind::Directory: {
+            auto fs = std::make_unique<InMemoryFileSystem>(std::move(node));
+            return fs;
+        }
+        case InMemoryFileSystem::InMemoryNode::Kind::File: {
+            auto fs = std::make_unique<InMemoryFileSystem>();
+            auto rootNode = static_cast<InMemoryDirectoryNode*>(fs->root());
+            rootNode->add_item(file_path.filename().string(), std::move(node));
+            return fs;
+        }
+    }
+}
+
+void InMemoryFileSystem::serialize(const std::vector<std::string>& canonical_path,
+                                   size_t alignment,
+                                   std::ostream& stream) {
+    using namespace serdes;
+    auto node = get_node(root(), canonical_path.begin(), canonical_path.end());
+    if (!node) {
+        return;
+    }
+
+    auto nodes = FlattenedInMemoryNode::flatten(node, alignment);
+    for (const auto& node: nodes) {
+        if (node.file_node == nullptr) {
+            continue;
+        }
+        auto region = node.data_region;
+        auto buffer = node.file_node->getBuffer();
+        auto start = static_cast<char*>(buffer->data());
+        stream.seekp(region.offset);
+        stream.write(start, region.size);
+    }
+
+    auto metadata = InMemoryNodeMetaData { .nodes = std::move(nodes) };
+    metadata.writeToStream(stream);
+}
+
+size_t InMemoryFileSystem::get_serialization_size(const std::vector<std::string>& canonical_path, size_t alignment) {
+    using namespace serdes;
+
+    auto node = get_node(root(), canonical_path.begin(), canonical_path.end());
+    if (!node) {
+        return 0;
+    }
+
+    auto nodes = FlattenedInMemoryNode::flatten(node, alignment);
+    size_t length = 0;
+    for (const auto& node: nodes) {
+        auto region = node.data_region;
+        length = std::max(region.get_length(), length);
+    }
+    auto metadata = InMemoryNodeMetaData { .nodes = std::move(nodes) };
+    const auto& str = metadata.json_string();
+    length += str.length();
+
+    return length;
+}
+
+std::unique_ptr<InMemoryFileSystem> InMemoryFileSystem::make(const std::shared_ptr<MemoryBuffer>& buffer) {
+    using namespace serdes;
+
+    // read metadata from the end of the stream
+    auto istream = ReversedIMemoryStream(buffer);
+    json metadata_json;
+    nlohmann::detail::json_sax_dom_parser<json> sdp(metadata_json, true);
+    if (!json::sax_parse(istream, &sdp, nlohmann::detail::input_format_t::json, false)) {
+        return nullptr;
+    }
+
+    InMemoryNodeMetaData metadata;
+    from_json(metadata_json, metadata);
+    auto rootNode = FlattenedInMemoryNode::unflatten(metadata.nodes, buffer);
+    if (!rootNode) {
+        return nullptr;
+    }
+
+    return std::make_unique<InMemoryFileSystem>(std::move(rootNode));
+}
+
+} // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.hpp
@@ -1,0 +1,292 @@
+//
+// inmemory_filesystem.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <optional>
+#include <memory>
+#include <stdio.h>
+#include <string>
+#include <system_error>
+
+#include "memory_buffer.hpp"
+
+namespace inmemoryfs {
+
+/// A class representing an in-memory file system.
+class InMemoryFileSystem final {
+public:
+    /// Error codes for `InMemoryFileSystem`.
+    enum class ErrorCode: int8_t {
+        DirectoryExists = 1,   // If the path already exists.
+        ItemNotFound,          // If the path does not exist.
+        ItemExists,            // If an item at the path already exists.
+        DirectoryExpected,     // If path is not a directory.
+        FileExpected,          // If the path is not a file.
+    };
+    
+    /// The error category for `InMemoryFileSystem`.
+    struct ErrorCategory final: public std::error_category {
+    public:
+        inline const char* name() const noexcept override {
+            return "InMemoryFileSystem";
+        }
+        
+        std::string message(int code) const override;
+    };
+    
+    struct Attributes {
+        time_t modificationTime;
+        
+        inline Attributes() noexcept:
+        modificationTime(time(0))
+        {}
+    };
+    
+    /// A class representing an in-memory node. This could either be a file node or a directory node.
+    class InMemoryNode {
+    public:
+        /// The node kind.
+        enum class Kind: uint8_t {
+            File = 0,   /// Node is a File.
+            Directory   /// Node is a Directory.
+        };
+        
+        /// Constructs an in-memory node instance.
+        ///
+        /// @param name The name of the Node. It must be unique in the enclosing Directory.
+        /// @param attributes   The node attributes.
+        /// @param kind   The node kind.
+        inline InMemoryNode(std::string name, Attributes attributes, Kind kind) noexcept:
+        name_(std::move(name)),
+        attributes_(std::move(attributes)),
+        kind_(kind)
+        {}
+        
+        InMemoryNode(InMemoryNode const&) = delete;
+        InMemoryNode& operator=(InMemoryNode const&) = delete;
+        
+        inline virtual ~InMemoryNode() {}
+        
+        /// Returns the node attributes.
+        inline Attributes attributes() const noexcept {
+            return attributes_;
+        }
+        
+        /// Sets the node attributes.
+        ///
+        /// @param attributes The node attributes.
+        inline void setAttributes(Attributes attributes) noexcept {
+            attributes_ = std::move(attributes);
+        }
+        
+        /// Returns the node kind, possible values are `File` and `Directory`.
+        inline Kind kind() const noexcept {
+            return kind_;
+        }
+        
+        /// Returns the name of the node.
+        inline const std::string& name() const noexcept {
+            return name_;
+        }
+        
+        /// Returns `true` if the node is a directory otherwise `false`.
+        inline bool isDirectory() const noexcept {
+            switch (kind_) {
+                case InMemoryFileSystem::InMemoryNode::Kind::Directory:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+        
+        /// Returns `true` if the node is a file otherwise `false`.
+        inline bool isFile() const noexcept {
+            return !isDirectory();
+        }
+        
+    private:
+        const std::string name_;
+        InMemoryFileSystem::Attributes attributes_;
+        const Kind kind_;
+    };
+    
+    /// Constructs an`InMemoryFileSystem` instance with an empty root with the specified name.
+    ///
+    /// @param rootName The name of the root node.
+    explicit InMemoryFileSystem(std::string rootName = "root") noexcept;
+    
+    /// Constructs an`InMemoryFileSystem` instance with the specified root.
+    ///
+    /// @param root The root node.
+    explicit InMemoryFileSystem(std::unique_ptr<InMemoryNode> root) noexcept
+    :root_(std::move(root))
+    {}
+    
+    InMemoryFileSystem(InMemoryFileSystem const&) = delete;
+    InMemoryFileSystem& operator=(InMemoryFileSystem const&) = delete;
+    
+    virtual ~InMemoryFileSystem() {}
+    
+    /// Returns the root.
+    InMemoryNode *root() const noexcept {
+        return root_.get();
+    }
+    
+    /// Checks if the node at the specified path is a directory.
+    ///
+    /// @param canonical_path   The path components from the root.
+    /// @retval `true` if the node at the specified path is a directory otherwise `false`.
+    bool is_directory(const std::vector<std::string>& canonical_path) noexcept;
+    
+    /// Checks if the node at the specified path is a file.
+    ///
+    /// @param canonical_path   The path components from the root.
+    /// @retval `true` if the node at the specified path is a file otherwise `false`.
+    bool is_file(const std::vector<std::string>& canonical_path) noexcept;
+    
+    /// Checks if the node at the specified path exists.
+    ///
+    /// @param canonical_path   The path components from the root.
+    /// @retval `true` if the node at the specified path exists.
+    bool exists(const std::vector<std::string>& canonical_path) noexcept;
+    
+    /// Retrieves the canonical path of all the child nodes at the specified path. The node
+    /// at the specified path must be a directory otherwise it returns an empty vector with the `error`
+    /// populated.
+    ///
+    /// @param canonical_path  The path components from the root.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval paths to all the items at the specified path.
+    std::vector<std::vector<std::string>> get_item_paths(const std::vector<std::string>& canonical_path,
+                                                         std::error_code& error) const noexcept;
+    
+    /// Retrieves the attributes of the item at the specified path.
+    ///
+    /// @param canonical_path  The path components from the root.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval The item attributes at the specified path.
+    std::optional<Attributes> get_attributes(const std::vector<std::string>& canonical_path,
+                                             std::error_code& error) const noexcept;
+    
+    /// Retrieves the contents of the file at the specified path.
+    ///
+    /// @param canonical_path  The path components from the root.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval The file contents or `nullptr` if the item at the specified path is not a file.
+    std::shared_ptr<MemoryBuffer> get_file_content(const std::vector<std::string>& canonical_path,
+                                                   std::error_code& error) const noexcept;
+    
+    /// Creates an in-memory directory at the specified path.
+    ///
+    /// @param canonical_path  The path components from the root.
+    /// @param attributes  The directory attributes.
+    /// @param create_intermediate_directories   If this is `true` then the method will also create intermediate directories if not present.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the directory is created otherwise `false`.
+    bool make_directory(const std::vector<std::string>& canonical_path,
+                        Attributes attributes,
+                        bool create_intermediate_directories,
+                        std::error_code& error) noexcept;
+    
+    /// Creates an in-memory file at the specified path.
+    ///
+    /// @param canonical_path  The path components from the root.
+    /// @param buffer  The file contents.
+    /// @param attributes  The file attributes.
+    /// @param overwrite   If this is `true` then the the method will overwrite the contents at the specified path.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the file is created otherwise `false`.
+    bool make_file(const std::vector<std::string>& canonical_path,
+                   std::shared_ptr<MemoryBuffer> buffer,
+                   Attributes attributes,
+                   bool overwrite,
+                   std::error_code& error) noexcept;
+    
+    /// Removes the item at the specified path.
+    ///
+    /// @param canonical_path  The path components from the root.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the item is removed otherwise `false`.
+    bool remove_item(const std::vector<std::string>& canonical_path,
+                     std::error_code& error) noexcept;
+    
+    /// Sets the attributes at the specified path.
+    ///
+    /// @param canonical_path  The path components from the root.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the attributes are updated otherwise `false`.
+    bool set_attributes(const std::vector<std::string>& canonical_path,
+                        Attributes attributes,
+                        std::error_code& error) noexcept;
+    
+    /// Writes the item at the specified path to the filesystem.
+    ///
+    /// @param canonical_path  The path components from the root.
+    /// @param dst_path  The filesystem path where the item contents will be saved.
+    /// @param recursive   If this is `true` then the the method will recursively write the contents of nested directory items.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the write succeeded otherwise `false`.
+    bool write_item_to_disk(const std::vector<std::string>& canonical_path,
+                            const std::string& dst_path,
+                            bool recursive,
+                            std::error_code& error) const noexcept;
+    
+    /// Creates  an`InMemoryFileSystem` from the filesystem path.
+    ///
+    /// The structure of the `InMemoryFileSystem` is identical to the structure of the filesystem at the
+    /// specified path.
+    ///
+    /// @param path  The filesystem path.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval The `InMemoryFileSystem` instance if the construction succeeded otherwise `nullptr`.
+    static std::unique_ptr<InMemoryFileSystem> make(const std::string& path,
+                                                    std::error_code& error);
+    
+    /// Serializes the item at the specified path and writes it to the stream.
+    ///
+    /// The structure of the `InMemoryFileSystem` is identical to the structure of the filesystem at the
+    /// specified path.
+    ///
+    /// @param canonical_path  The path components from the root.
+    /// @param alignment  The offset alignment where an item is written to the stream.
+    /// @param ostream   The output stream.
+    void serialize(const std::vector<std::string>& canonical_path,
+                   size_t alignment,
+                   std::ostream& ostream);
+    
+    /// Computes the size of the buffer that would be needed to serialized the item at the specified path.
+    ///
+    /// @param canonical_path  The path components from the root.
+    /// @param alignment  The offset alignment where an item is written to the stream.
+    /// @retval The size of the buffer that will be needed to write the item at the specified path.
+    size_t get_serialization_size(const std::vector<std::string>& canonical_path,
+                                  size_t alignment);
+    
+    /// Constructs an `InMemoryFileSystem` instance from the buffer contents.
+    ///
+    /// @param buffer  The memory buffer.
+    /// @retval The constructed `InMemoryFileSystem` or `nullptr` if the deserialization failed.
+    static std::unique_ptr<InMemoryFileSystem> make(const std::shared_ptr<MemoryBuffer>& buffer);
+    
+private:
+    const std::unique_ptr<InMemoryNode> root_;
+};
+
+/// Constructs an `error_code` from a `InMemoryFileSystem::ErrorCode`.
+inline std::error_code make_error_code(InMemoryFileSystem::ErrorCode code) {
+    static InMemoryFileSystem::ErrorCategory errorCategory;
+    return {static_cast<int>(code), errorCategory};
+}
+
+}; // namespace inmemoryfs
+
+namespace std {
+
+template <> struct is_error_code_enum<inmemoryfs::InMemoryFileSystem::ErrorCode> : true_type {};
+
+} // namespace std

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_py.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_py.cpp
@@ -1,0 +1,63 @@
+//
+// inmemory_filesystem_py.cpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#include <memory>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <string>
+#include <system_error>
+
+#include "inmemory_filesystem.hpp"
+#include "memory_buffer.hpp"
+#include "memory_stream.hpp"
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace std {
+namespace filesystem = std::experimental::filesystem;
+}
+#endif
+
+using namespace inmemoryfs;
+
+namespace executorchcoreml {
+
+/// Flattens the directory contents at the specified path.
+///
+/// @param path  The directory path
+/// @retval The flattened directory contents.
+pybind11::bytes flatten_directory_contents(const std::string& path) {
+    std::filesystem::path fs_path(path);
+    std::error_code error;
+    auto canonical_path = std::filesystem::canonical(fs_path);
+
+    if (error) {
+        throw std::system_error(error.value(), error.category(), error.message());
+    }
+
+    auto inMemoryfs = InMemoryFileSystem::make(canonical_path, error);
+    if (error) {
+        throw std::system_error(error.value(), error.category(), error.message());
+    }
+
+    size_t length = inMemoryfs->get_serialization_size({}, 1);
+    auto bytes = PyBytes_FromStringAndSize(NULL, length);
+    void* data = static_cast<void*>(PyBytes_AsString(bytes));
+    auto buffer = MemoryBuffer::make_unowned(data, length);
+    auto memstream = MemoryOStream(buffer);
+    inMemoryfs->serialize({}, 1, memstream);
+
+    return pybind11::reinterpret_steal<pybind11::bytes>((PyObject*)bytes);
+}
+
+} // namespace executorchcoreml
+
+PYBIND11_MODULE(executorchcoreml, mod) {
+    mod.def("flatten_directory_contents", &executorchcoreml::flatten_directory_contents);
+}

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.cpp
@@ -1,0 +1,184 @@
+//
+// memory_buffer.cpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#include <memory_buffer.hpp>
+
+#include <iostream>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+namespace {
+using namespace inmemoryfs;
+
+class MMappedBuffer : public MemoryBuffer {
+public:
+    explicit MMappedBuffer(std::shared_ptr<void> buffer, size_t size) noexcept
+        : MemoryBuffer(reinterpret_cast<uint8_t*>(buffer.get()), size, MemoryBuffer::Kind::MMap),
+          buffer_(std::move(buffer)) { }
+
+    MMappedBuffer(const MemoryBuffer&) = delete;
+    MMappedBuffer& operator=(const MemoryBuffer&) = delete;
+
+    ~MMappedBuffer() { }
+
+private:
+    const std::shared_ptr<void> buffer_;
+};
+
+class MallocedBuffer : public MemoryBuffer {
+public:
+    explicit MallocedBuffer(std::vector<uint8_t> buffer) noexcept
+        : MemoryBuffer(buffer.data(), buffer.size(), MemoryBuffer::Kind::Malloc), buffer_(std::move(buffer)) { }
+
+    MallocedBuffer(const MallocedBuffer&) = delete;
+    MallocedBuffer& operator=(const MallocedBuffer&) = delete;
+
+    ~MallocedBuffer() { }
+
+private:
+    const std::vector<uint8_t> buffer_;
+};
+
+std::unique_ptr<void, std::function<void(void*)>> mmap_file_region(FILE* file, MemoryRegion region) {
+    auto ptr = mmap(nullptr, region.size, PROT_READ, MAP_PRIVATE, fileno(file), region.offset);
+    return std::unique_ptr<void, std::function<void(void*)>>(
+        ptr, [size = region.size](void* bufferPtr) mutable { munmap(bufferPtr, size); });
+}
+
+size_t get_file_length(const std::string& file_path, std::error_code& error) {
+    struct stat fileInfo;
+    if (stat(file_path.c_str(), &fileInfo) != 0) {
+        error = std::error_code(errno, std::generic_category());
+        return 0;
+    }
+
+    return static_cast<size_t>(fileInfo.st_size);
+}
+
+std::unique_ptr<FILE, decltype(&fclose)> open_file(const std::string& file_path, std::error_code& error) {
+    std::unique_ptr<FILE, decltype(&fclose)> file(fopen(file_path.c_str(), "rb"), fclose);
+    if (!file) {
+        error = std::error_code(errno, std::generic_category());
+    }
+    return file;
+}
+
+std::unique_ptr<MemoryBuffer> mmap_buffer_from_file(FILE* file, MemoryRegion region, std::error_code& error) {
+    error.clear();
+    auto ptr = mmap_file_region(file, region);
+    if (!ptr || (reinterpret_cast<int*>(ptr.get()) == MAP_FAILED)) {
+        error = std::error_code(errno, std::generic_category());
+        return {};
+    }
+
+    return std::make_unique<MMappedBuffer>(std::move(ptr), region.size);
+}
+
+std::unique_ptr<MemoryBuffer> malloced_buffer_from_file(FILE* file, MemoryRegion region, std::error_code& error) {
+    error.clear();
+    size_t offset = region.offset;
+    if (std::fseek(file, offset, SEEK_SET) != 0) {
+        error = std::error_code(errno, std::generic_category());
+        return nullptr;
+    }
+
+    std::vector<uint8_t> buffer(region.size, 0);
+    if (std::fread(buffer.data(), 1, buffer.size(), file) != region.size) {
+        error = std::error_code(errno, std::generic_category());
+        return nullptr;
+    }
+
+    return std::make_unique<MallocedBuffer>(std::move(buffer));
+}
+
+std::unique_ptr<MemoryBuffer>
+read_file_content(FILE* file, MemoryRegion region, MMappedBuffer::ReadOption option, std::error_code& error) {
+    switch (option) {
+        case MemoryBuffer::ReadOption::MMap: {
+            return mmap_buffer_from_file(file, region, error);
+        }
+
+        case MemoryBuffer::ReadOption::Malloc: {
+            return malloced_buffer_from_file(file, region, error);
+        }
+
+        case MemoryBuffer::ReadOption::Any: {
+            auto buffer = mmap_buffer_from_file(file, region, error);
+            if (!buffer) {
+                buffer = malloced_buffer_from_file(file, region, error);
+            }
+            return buffer;
+        }
+    }
+}
+} // namespace
+
+namespace inmemoryfs {
+std::shared_ptr<MemoryBuffer> MemoryBuffer::slice(MemoryRegion region) noexcept {
+    if (region.get_length() > size()) {
+        return nullptr;
+    }
+
+    auto start = static_cast<void*>(static_cast<uint8_t*>(data()) + region.offset);
+    return std::make_shared<MemoryBuffer>(start, region.size, kind(), shared_from_this());
+}
+
+std::vector<std::shared_ptr<MemoryBuffer>> MemoryBuffer::read_file_content(const std::string& file_path,
+                                                                           const std::vector<MemoryRegion>& regions,
+                                                                           ReadOption option,
+                                                                           std::error_code& error) {
+    auto file = open_file(file_path, error);
+    if (!file) {
+        return {};
+    }
+
+    std::vector<std::shared_ptr<MemoryBuffer>> result;
+    result.reserve(regions.size());
+    for (const auto& region: regions) {
+        auto buffer = ::read_file_content(file.get(), region, option, error);
+        if (!buffer) {
+            return {};
+        }
+        result.emplace_back(std::move(buffer));
+    }
+
+    return result;
+}
+
+std::shared_ptr<MemoryBuffer>
+MemoryBuffer::read_file_content(const std::string& file_path, ReadOption option, std::error_code& error) {
+    const size_t length = ::get_file_length(file_path, error);
+    if (length == 0) {
+        return {};
+    }
+
+    auto file = open_file(file_path, error);
+    if (!file) {
+        return {};
+    }
+
+    auto buffer = ::read_file_content(file.get(), MemoryRegion(0, length), option, error);
+    return buffer;
+}
+
+std::shared_ptr<MemoryBuffer> MemoryBuffer::make(const void* data, size_t size) {
+    std::vector<uint8_t> bytes;
+    bytes.resize(size);
+    std::memcpy(bytes.data(), data, size);
+    return std::make_unique<MallocedBuffer>(std::move(bytes));
+}
+
+std::shared_ptr<MemoryBuffer> MemoryBuffer::make(std::vector<uint8_t> bytes) {
+    return std::make_unique<MallocedBuffer>(std::move(bytes));
+}
+
+std::shared_ptr<MemoryBuffer> MemoryBuffer::make_unowned(void* data, size_t size) {
+    return std::make_unique<MemoryBuffer>(data, size);
+}
+
+} // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
@@ -1,0 +1,135 @@
+//
+// memory_buffer.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <stdio.h>
+#include <string>
+#include <memory>
+
+#include <system_error>
+
+namespace inmemoryfs {
+
+/// A struct representing a memory region.
+struct MemoryRegion {
+    inline MemoryRegion(size_t offset, size_t size) noexcept:
+    offset(offset), size(size)
+    {}
+    
+    inline MemoryRegion() noexcept:
+    offset(0), size(0)
+    {}
+    
+    /// Returns the length of the region.
+    inline size_t get_length() const noexcept {
+        return offset + size;
+    }
+    
+    size_t offset = 0;
+    size_t size = 0;
+};
+
+/// A class representing a memory buffer.
+class MemoryBuffer: public std::enable_shared_from_this<MemoryBuffer> {
+public:
+    /// The kind of buffer.
+    enum class Kind: uint8_t {
+        MMap = 0,  // If the buffer is memory mapped.
+        Malloc ,   // If the buffer is heap allocated.
+    };
+    
+    enum class ReadOption: uint8_t {
+        MMap = 0,
+        Malloc,
+        Any
+    };
+    
+    inline MemoryBuffer(void *data,
+                        size_t size,
+                        Kind kind = Kind::Malloc,
+                        std::shared_ptr<MemoryBuffer> parent = nullptr) noexcept:
+    data_(data), size_(size), kind_(kind), parent_(parent)
+    {}
+    
+    MemoryBuffer(const MemoryBuffer &) = delete;
+    MemoryBuffer &operator=(const MemoryBuffer &) = delete;
+    
+    virtual ~MemoryBuffer() noexcept {}
+    
+    /// Returns the underlying data.
+    inline void *data() const noexcept {
+        return data_;
+    }
+    
+    /// Returns the size of the buffer.
+    inline const size_t size() const noexcept {
+        return size_;
+    }
+    
+    /// Returns the kind of the buffer.
+    inline const Kind kind() const noexcept {
+        return kind_;
+    }
+    
+    /// Slices a buffer.
+    ///
+    /// @param region The memory region.
+    /// @retval The sliced buffer if the region is inside the buffer otherwise `nullptr`.
+    virtual std::shared_ptr<MemoryBuffer> slice(MemoryRegion region) noexcept;
+    
+    /// Reads the file content at the specified path.
+    ///
+    /// @param file_path The file path.
+    /// @param regions The regions to be read.
+    /// @param option The read option.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval The read buffers or an empty vector if the read failed.
+    static std::vector<std::shared_ptr<MemoryBuffer>>
+    read_file_content(const std::string& file_path,
+                      const std::vector<MemoryRegion>& regions,
+                      ReadOption option,
+                      std::error_code& error);
+    
+    /// Reads the whole file content at the specified path.
+    ///
+    /// @param file_path The file path.
+    /// @param option The read option.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval The read buffer or `nullptr` if the read failed.
+    static std::shared_ptr<MemoryBuffer>
+    read_file_content(const std::string& file_path,
+                      ReadOption option,
+                      std::error_code& error);
+    
+    /// Constructs a `MemoryBuffer` by copying data.
+    ///
+    /// @param data The data pointer.
+    /// @param size The size of the buffer.
+    static std::shared_ptr<MemoryBuffer>
+    make(const void *data, size_t size);
+    
+    /// Constructs a `MemoryBuffer` from a bytes vector.
+    ///
+    /// @param bytes A bytes vector.
+    static std::shared_ptr<MemoryBuffer>
+    make(std::vector<uint8_t> bytes);
+    
+    /// Constructs a `MemoryBuffer` without copying data.
+    ///
+    /// @param data The data pointer.
+    /// @param size The size of the buffer.
+    static std::shared_ptr<MemoryBuffer>
+    make_unowned(void *data, size_t size);
+    
+private:
+    void *data_;
+    const size_t size_;
+    Kind kind_;
+    const std::shared_ptr<MemoryBuffer> parent_;
+};
+}

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_stream.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_stream.cpp
@@ -1,0 +1,170 @@
+//
+// memory_stream.cpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#include <memory_stream.hpp>
+
+namespace inmemoryfs {
+
+MemoryStreamBuf::MemoryStreamBuf(const std::shared_ptr<MemoryBuffer>& buffer) noexcept : buffer_(buffer) {
+    auto start = static_cast<char*>(buffer->data());
+    auto end = start + buffer->size();
+    setg(start, start, end);
+    setp(start, end);
+}
+
+std::streambuf::pos_type MemoryStreamBuf::iseekoff(std::streambuf::off_type offset, std::ios_base::seekdir dir) {
+    std::streambuf::off_type next = -1;
+    const std::ptrdiff_t size = std::ptrdiff_t(egptr() - eback());
+    switch (dir) {
+        case std::ios_base::beg: {
+            next = offset;
+            break;
+        }
+        case std::ios_base::cur: {
+            next = std::streambuf::off_type(std::ptrdiff_t(gptr() - eback())) + offset;
+            break;
+        }
+        case std::ios_base::end: {
+            next = std::streambuf::off_type(size) + offset;
+            break;
+        }
+        default:
+            break;
+    }
+
+    if (next < 0 || next >= std::streambuf::off_type(size)) {
+        return std::streambuf::pos_type(std::streambuf::off_type(-1));
+    }
+
+    setg(eback(), eback() + next, egptr());
+    return gptr() - eback();
+}
+
+std::streambuf::pos_type MemoryStreamBuf::oseekoff(std::streambuf::off_type offset, std::ios_base::seekdir dir) {
+    std::streambuf::off_type next = -1;
+    const std::ptrdiff_t size = std::ptrdiff_t(epptr() - pbase());
+    switch (dir) {
+        case std::ios_base::beg: {
+            next = offset;
+            break;
+        }
+        case std::ios_base::cur: {
+            next = std::streambuf::off_type(std::ptrdiff_t(pptr() - pbase())) + offset;
+            break;
+        }
+        case std::ios_base::end: {
+            next = std::streambuf::off_type(size) + offset;
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+
+    if (next < 0 || next > std::streambuf::off_type(size)) {
+        return std::streambuf::pos_type(std::streambuf::off_type(-1));
+    }
+
+    setp(pbase(), epptr());
+    pbump(static_cast<int>(next));
+    return pptr() - pbase();
+}
+
+std::streambuf::pos_type
+MemoryStreamBuf::seekoff(std::streambuf::off_type offset, std::ios_base::seekdir dir, std::ios_base::openmode which) {
+    if (which & std::ios_base::out) {
+        return oseekoff(offset, dir);
+    } else if (which & std::ios_base::in) {
+        return iseekoff(offset, dir);
+    } else {
+        return std::streambuf::pos_type(std::streambuf::off_type(-1));
+    }
+}
+
+std::streambuf::pos_type MemoryStreamBuf::seekpos(std::streambuf::pos_type pos, std::ios_base::openmode which) {
+    return seekoff(pos - std::streambuf::pos_type(std::streambuf::off_type(0)), std::ios::beg, which);
+}
+
+std::streamsize MemoryStreamBuf::showmanyc() {
+    std::ptrdiff_t n = egptr() - gptr();
+    std::streamsize max = std::numeric_limits<std::streamsize>::max();
+    return (n <= max ? std::streamsize(n) : max);
+}
+
+std::streambuf::int_type MemoryStreamBuf::pbackfail(std::streambuf::int_type ch) {
+    if (eback() == gptr() || (ch != traits_type::eof() && ch != gptr()[-1])) {
+        return traits_type::eof();
+    }
+    gbump(-1);
+    return ch;
+}
+
+std::streambuf::int_type MemoryStreamBuf::underflow() {
+    if (gptr() == egptr()) {
+        return traits_type::eof();
+    }
+    return traits_type::to_int_type(*gptr());
+}
+
+std::streambuf::int_type MemoryStreamBuf::uflow() {
+    if (gptr() == egptr()) {
+        return traits_type::eof();
+    }
+    const std::streambuf::char_type ch = *gptr();
+    gbump(1);
+    return traits_type::to_int_type(ch);
+}
+
+std::streambuf::int_type MemoryStreamBuf::overflow(std::streambuf::int_type ch) {
+    if (ch == traits_type::eof()) {
+        return ch;
+    }
+    const std::streambuf::char_type c = traits_type::to_char_type(ch);
+    xsputn(&c, 1);
+    return ch;
+}
+
+std::streamsize MemoryStreamBuf::xsgetn(char* s, std::streamsize n) {
+    const ptrdiff_t remaining = egptr() - gptr();
+    n = std::min(n, remaining);
+    if (n <= 0) {
+        return std::streamsize(0);
+    }
+    auto current = epptr();
+    for (std::streamsize i = 0; i < n; i++) {
+        *(s + i) = *(current + i);
+    }
+    setg(eback(), current + n, egptr());
+    return n;
+}
+
+std::streamsize MemoryStreamBuf::xsputn(const char* s, std::streamsize n) {
+    const ptrdiff_t remaining = epptr() - pptr();
+    n = std::min(n, remaining);
+    if (n <= 0) {
+        return std::streamsize(0);
+    }
+    auto current = pptr();
+    for (std::streamsize i = 0; i < n; i++) {
+        *(current + i) = *(s + i);
+    }
+
+    pbump(static_cast<int>(n));
+    return n;
+}
+
+MemoryIStream::MemoryIStream(const std::shared_ptr<MemoryBuffer>& buffer) noexcept
+    : std::istream(nullptr), streambuf(buffer) {
+    rdbuf(&streambuf);
+}
+
+MemoryOStream::MemoryOStream(const std::shared_ptr<MemoryBuffer>& buffer) noexcept
+    : std::ostream(nullptr), streambuf(buffer) {
+    rdbuf(&streambuf);
+}
+
+} // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_stream.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_stream.hpp
@@ -1,0 +1,126 @@
+//
+//  Stream.hpp
+//  inmemoryfs
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <memory_buffer.hpp>
+
+#include <istream>
+#include <ostream>
+
+namespace inmemoryfs {
+
+/// A class representing an in-memory stream buffer.
+class MemoryStreamBuf: public std::streambuf {
+public:
+    ~MemoryStreamBuf() = default;
+    
+    /// Constructs a `MemoryStreamBuf` from a `MemoryBuffer`.
+    ///
+    /// @param buffer  The memory buffer.
+    explicit MemoryStreamBuf(const std::shared_ptr<MemoryBuffer>& buffer) noexcept;
+
+protected:
+    /// Called by `seekof` if the `openmode` is input.
+    ///
+    /// @param offset  The offset  value relative to the `dir`.
+    /// @param dir  The seek direction.
+    /// @retval The stream position.
+    pos_type iseekoff(off_type offset, std::ios_base::seekdir dir);
+    
+    /// Called by `seekof` if the `openmode` is output.
+    ///
+    /// @param offset  The offset  value relative to the `dir`.
+    /// @param dir  The seek direction.
+    /// @retval The stream position.
+    pos_type oseekoff(off_type offset, std::ios_base::seekdir dir);
+
+    /// Called by other member functions to alter the stream position of the controlled input sequence.
+    ///
+    /// @param which  The open mode.
+    /// @retval The stream position.
+    pos_type seekpos(pos_type pos, std::ios_base::openmode which) override;
+    
+    /// Called by the public member function `pubseekoff` to alter the stream position.
+    ///
+    /// @param offset  The offset  value relative to the `dir`.
+    /// @param dir  The seek direction.
+    /// @param which  The open mode.
+    /// @retval The stream position.
+    std::streambuf::pos_type seekoff(std::streambuf::off_type offset,
+                                     std::ios_base::seekdir dir,
+                                     std::ios_base::openmode which) override;
+
+    /// Called by other member functions to get an estimate on the number of characters available in controlled input sequence.
+    ///
+    /// Returns number of characters available in controlled input sequence.
+    std::streamsize showmanyc() override;
+
+    /// Called by other member functions to put a character back into the controlled input sequence and decrease the position indicator.
+    ///
+    /// Returns the value of the character put back, converted to a value of type int.
+    int_type pbackfail(int_type ch) override;
+
+    /// Called by other member functions to get the current character in the controlled input sequence without changing the current position.
+    ///
+    /// Returns the value of the current character, converted to a value of type int.
+    std::streambuf::int_type underflow() override;
+
+    /// Called by other member functions to get the current character in the controlled input sequence and advances the current position.
+    ///
+    /// Returns the value of the current character, converted to a value of type int.
+    std::streambuf::int_type uflow() override;
+    
+    /// Called by other member functions to put a character into the controlled output sequence.
+    ///
+    /// Returns the value of the character that's put into the stream, converted to a value of type int.
+    int_type overflow(int_type ch) override;
+    
+    /// Retrieves characters from the controlled input sequence and stores them in the array pointed by s,
+    /// until either n characters have been extracted or the end of the sequence is reached.
+    ///
+    /// Returns the number of characters copied.
+    std::streamsize xsgetn(char *s, std::streamsize n) override;
+    
+    /// Writes characters from the array pointed to by s into the controlled output sequence,
+    /// until either n characters have been written or the end of the output sequence is reached.
+    ///
+    /// Returns the number of characters that's written.
+    std::streamsize xsputn(const char *s, std::streamsize n) override;
+
+private:
+    /// Reads the character at the specified position.
+    std::streambuf::int_type read(char *pos);
+
+    const std::shared_ptr<MemoryBuffer> buffer_;
+};
+
+/// A class representing an in-memory input stream.
+class MemoryIStream final : public std::istream  {
+public:
+    MemoryIStream(const std::shared_ptr<MemoryBuffer>& buffer) noexcept;
+
+    ~MemoryIStream() = default;
+
+private:
+    MemoryStreamBuf streambuf;
+};
+
+/// A class representing an in-memory output stream.
+class MemoryOStream final : public std::ostream  {
+public:
+    MemoryOStream(const std::shared_ptr<MemoryBuffer>& buffer) noexcept;
+
+    ~MemoryOStream() = default;
+
+private:
+    MemoryStreamBuf streambuf;
+};
+
+}
+

--- a/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.cpp
@@ -1,0 +1,117 @@
+//
+// reversed_memory_stream.cpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#include <reversed_memory_stream.hpp>
+
+namespace inmemoryfs {
+
+ReversedIMemoryStreamBuf::ReversedIMemoryStreamBuf(std::shared_ptr<MemoryBuffer> buffer) noexcept
+    : buffer_(buffer), start_(static_cast<char*>(buffer->data())), current_(start_), end_(start_ + buffer->size()) {
+    // we are intentionally setting `gptr` to the buffer end, this makes sure
+    // that `underflow` and `uflow` methods are always called.
+    setg(start_, start_, start_);
+}
+
+std::streambuf::pos_type ReversedIMemoryStreamBuf::iseekoff(std::streambuf::off_type offset,
+                                                            std::ios_base::seekdir dir) {
+    std::streambuf::off_type next = std::streambuf::off_type(-1);
+    const std::ptrdiff_t size = std::ptrdiff_t(buffer_->size());
+    switch (dir) {
+        case std::ios_base::beg: {
+            next = offset;
+            break;
+        }
+        case std::ios_base::cur: {
+            next = std::streambuf::off_type(std::ptrdiff_t(current_ - start_)) + offset;
+            break;
+        }
+        case std::ios_base::end: {
+            next = std::streambuf::off_type(size) + offset;
+            break;
+        }
+        default:
+            break;
+    }
+    if (next < 0 || next >= std::streambuf::off_type(size)) {
+        return std::streambuf::pos_type(std::streambuf::off_type(-1));
+    }
+    current_ = start_ + offset;
+    setg(start_, current_, current_);
+    return std::streambuf::pos_type(current_ - start_);
+}
+
+std::streambuf::pos_type ReversedIMemoryStreamBuf::seekpos(std::streambuf::pos_type pos,
+                                                           std::ios_base::openmode which) {
+    if ((which & std::ios_base::in) == 0) {
+        return std::streambuf::pos_type(std::streambuf::off_type(-1));
+    }
+    return iseekoff(pos - std::streambuf::pos_type(std::streambuf::off_type(0)), std::ios::beg);
+}
+
+std::streamsize ReversedIMemoryStreamBuf::showmanyc() {
+    std::ptrdiff_t n = end_ - current_;
+    std::streamsize max = std::numeric_limits<std::streamsize>::max();
+    return (n <= max ? std::streamsize(n) : max);
+}
+
+std::streambuf::int_type ReversedIMemoryStreamBuf::read(char* pos) {
+    std::ptrdiff_t offset = pos - start_;
+    // offset from the end
+    std::ptrdiff_t offsetFromEnd = buffer_->size() - offset - 1;
+    return traits_type::to_int_type(start_[offsetFromEnd]);
+}
+
+std::streambuf::int_type ReversedIMemoryStreamBuf::pbackfail(std::streambuf::int_type ch) {
+    if (current_ == end_ || (ch != traits_type::eof() && ch != read(current_ - 1))) {
+        return traits_type::eof();
+    }
+    --current_;
+    setg(start_, current_, current_);
+    return ch;
+}
+
+std::streambuf::int_type ReversedIMemoryStreamBuf::underflow() {
+    if (current_ == end_) {
+        return traits_type::eof();
+    }
+    return traits_type::to_int_type(read(current_));
+}
+
+std::streambuf::int_type ReversedIMemoryStreamBuf::uflow() {
+    if (current_ == end_) {
+        return traits_type::eof();
+    }
+    auto ch = read(current_);
+    ++current_;
+    setg(start_, current_, current_);
+    return ch;
+}
+
+std::streamsize ReversedIMemoryStreamBuf::xsgetn(char* s, std::streamsize n) {
+    const ptrdiff_t remaining = (static_cast<char*>(buffer_->data()) + buffer_->size()) - current_;
+    n = std::min(n, remaining);
+    if (n <= 0) {
+        return std::streamsize(0);
+    }
+    std::ptrdiff_t offset = current_ - start_;
+    for (std::streamsize i = 0; i < n; i++) {
+        offset = offset + i;
+        // offset from the end
+        std::ptrdiff_t offsetFromEnd = buffer_->size() - offset - 1;
+        s[i] = start_[offsetFromEnd];
+    }
+    current_ += n;
+    setg(start_, current_, current_);
+    return n;
+}
+
+ReversedIMemoryStream::ReversedIMemoryStream(const std::shared_ptr<MemoryBuffer>& buffer) noexcept
+    : std::istream(nullptr), streambuf(buffer) {
+    rdbuf(&streambuf);
+}
+
+} // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.hpp
@@ -1,0 +1,86 @@
+//
+// Stream.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <memory_buffer.hpp>
+
+#include <istream>
+#include <ostream>
+
+namespace inmemoryfs {
+
+/// A class for reading an in-memory stream buffer in reverse.
+class ReversedIMemoryStreamBuf: public std::streambuf {
+public:
+    ~ReversedIMemoryStreamBuf() = default;
+    
+    /// Constructs a `ReversedIMemoryStreamBuf` from a `MemoryBuffer`.
+    ///
+    /// @param buffer  The memory buffer.
+    explicit ReversedIMemoryStreamBuf(std::shared_ptr<MemoryBuffer> buffer) noexcept;
+
+protected:
+    /// Called by seekof if the openmode is input.
+    pos_type iseekoff(off_type off, std::ios_base::seekdir dir);
+
+    /// Called by other member functions to alter the stream position of the controlled input sequence.
+    pos_type seekpos(pos_type pos, std::ios_base::openmode which) override;
+
+    /// Called by other member functions to get an estimate on the number of characters available in controlled input sequence.
+    ///
+    /// Returns number of characters available in controlled input sequence.
+    std::streamsize showmanyc() override;
+
+    /// Called by other member functions to put a character back into the controlled input sequence and decrease the position indicator.
+    ///
+    /// Returns the value of the character put back, converted to a value of type int.
+    int_type pbackfail(int_type ch) override;
+
+    /// Called by other member functions to get the current character in the controlled input sequence without changing the current position.
+    ///
+    /// Returns the value of the current character, converted to a value of type int.
+    std::streambuf::int_type underflow() override;
+
+    /// Called by other member functions to get the current character in the controlled input sequence and advances the current position.
+    ///
+    /// Returns the value of the current character, converted to a value of type int.
+    std::streambuf::int_type uflow() override;
+    
+    /// Retrieves characters from the controlled input sequence and stores them in the array pointed by s,
+    /// until either n characters have been extracted or the end of the sequence is reached.
+    ///
+    /// Returns the number of characters copied.
+    std::streamsize xsgetn(char *s, std::streamsize n) override;
+
+private:
+    /// Reads the character at the specified position.
+    std::streambuf::int_type read(char *pos);
+    
+    const std::shared_ptr<MemoryBuffer> buffer_;
+    char *start_;
+    char *current_;
+    char *end_;
+};
+
+/// A class for reading an in-memory buffer in reverse.
+class ReversedIMemoryStream final : public std::istream  {
+public:
+    
+    /// Constructs a `ReversedIMemoryStream` from a `MemoryBuffer`.
+    ///
+    /// @param buffer  The memory buffer.
+    ReversedIMemoryStream(const std::shared_ptr<MemoryBuffer>& buffer) noexcept;
+
+    ~ReversedIMemoryStream() = default;
+
+private:
+    ReversedIMemoryStreamBuf streambuf;
+};
+
+}
+

--- a/backends/apple/coreml/runtime/inmemoryfs/setup.py
+++ b/backends/apple/coreml/runtime/inmemoryfs/setup.py
@@ -1,0 +1,49 @@
+import os
+
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent.parent.parent.parent
+PYBIND11_DIR_PATH = REPO_ROOT / "third-party" / "pybind11"
+sys.path.append(str(PYBIND11_DIR_PATH.absolute()))
+
+from pybind11.setup_helpers import build_ext, Pybind11Extension
+from setuptools import setup
+
+__version__ = "0.0.1"
+
+cxx_std = int(os.environ.get("CMAKE_CXX_STANDARD", "17"))
+
+ext_modules = [
+    Pybind11Extension(
+        "executorchcoreml",
+        [
+            "inmemory_filesystem.cpp",
+            "inmemory_filesystem_py.cpp",
+            "memory_buffer.cpp",
+            "memory_stream.cpp",
+            "reversed_memory_stream.cpp",
+        ],
+        define_macros=[("VERSION_INFO", __version__)],
+        cxx_std=cxx_std,
+        extra_compile_args=["-mmacosx-version-min=10.15"],
+        include_dirs=[
+            "../../third-party/nlohmann_json/single_include/nlohmann",
+            ".",
+        ],
+    ),
+]
+
+setup(
+    name="executorchcoreml",
+    version=__version__,
+    description="CoreML extension for executorch",
+    long_description="",
+    author="Apple Inc.",
+    ext_modules=ext_modules,
+    extras_require={"test": "pytest"},
+    cmdclass={"build_ext": build_ext},
+    include_package_data=True,
+    zip_safe=False,
+    python_requires=">=3.9",
+)

--- a/backends/apple/coreml/runtime/kvstore/database.cpp
+++ b/backends/apple/coreml/runtime/kvstore/database.cpp
@@ -1,0 +1,261 @@
+//
+//  database.cpp
+//  kvstore
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#include <database.hpp>
+
+#include <sqlite_error.hpp>
+
+namespace {
+using namespace executorchcoreml::sqlite;
+
+sqlite3_stmt* getPreparedStatement(sqlite3* database, const std::string& statement, std::error_code& error) {
+    sqlite3_stmt* handle = nullptr;
+    const int status = sqlite3_prepare_v2(database, statement.c_str(), -1, &handle, nullptr);
+    if (!process_sqlite_status(status, error)) {
+        return nullptr;
+    }
+
+    return handle;
+}
+
+/// Returns the sqlite pragma from
+std::string toString(Database::SynchronousMode mode) {
+    switch (mode) {
+        case Database::SynchronousMode::Full: {
+            return "FULL";
+        }
+        case Database::SynchronousMode::Extra: {
+            return "EXTRA";
+        }
+        case Database::SynchronousMode::Normal: {
+            return "NORMAL";
+        }
+        case Database::SynchronousMode::Off: {
+            return "OFF";
+        }
+    }
+}
+
+/// Returns the sqlite statement for a specified transaction behavior.
+std::string getTransactionStatement(Database::TransactionBehavior behavior) {
+    switch (behavior) {
+        case Database::TransactionBehavior::Deferred: {
+            return "BEGIN DEFERRED";
+        }
+        case Database::TransactionBehavior::Immediate: {
+            return "BEGIN IMMEDIATE";
+        }
+        case Database::TransactionBehavior::Exclusive: {
+            return "BEGIN EXCLUSIVE";
+        }
+    }
+}
+} // namespace
+
+namespace executorchcoreml {
+namespace sqlite {
+
+int Database::OpenOptions::get_sqlite_flags() const noexcept {
+    int flags = 0;
+    if (is_read_only_option_enabled()) {
+        flags |= SQLITE_OPEN_READONLY;
+    }
+
+    if (is_read_write_option_enabled()) {
+        flags |= SQLITE_OPEN_READWRITE;
+    }
+
+    if (is_create_option_enabled()) {
+        flags |= SQLITE_OPEN_CREATE;
+    }
+
+    if (is_memory_option_enabled()) {
+        flags |= SQLITE_OPEN_MEMORY;
+    }
+
+    if (is_no_mutex_option_enabled()) {
+        flags |= SQLITE_OPEN_NOMUTEX;
+    }
+
+    if (is_full_mutex_option_enabled()) {
+        flags |= SQLITE_OPEN_FULLMUTEX;
+    }
+
+    if (is_shared_cache_option_enabled()) {
+        flags |= SQLITE_OPEN_SHAREDCACHE;
+    }
+
+    if (is_shared_cache_option_enabled()) {
+        flags |= SQLITE_OPEN_SHAREDCACHE;
+    }
+
+    if (is_uri_option_enabled()) {
+        flags |= SQLITE_OPEN_URI;
+    }
+
+    return flags;
+}
+
+bool Database::open(OpenOptions options, SynchronousMode mode, int busy_timeout_ms, std::error_code& error) noexcept {
+    sqlite3* handle = nullptr;
+    const int status = sqlite3_open_v2(file_path_.c_str(), &handle, options.get_sqlite_flags(), nullptr);
+    sqlite_database_.reset(handle);
+    if (!process_sqlite_status(status, error)) {
+        return false;
+    }
+
+    if (!set_busy_timeout(busy_timeout_ms, error)) {
+        return false;
+    }
+
+    if (!execute("pragma journal_mode = WAL", error)) {
+        return false;
+    }
+
+    if (!execute("pragma auto_vacuum = FULL", error)) {
+        return false;
+    }
+
+    if (!execute("pragma synchronous = " + toString(mode), error)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool Database::is_open() const noexcept { return sqlite_database_ != nullptr; }
+
+bool Database::table_exists(const std::string& tableName, std::error_code& error) const noexcept {
+    auto statement = prepare_statement("SELECT COUNT(*) FROM sqlite_master WHERE TYPE='table' AND NAME=?", error);
+    if (!statement) {
+        return false;
+    }
+
+    if (!statement->bind(1, UnOwnedString(tableName), error)) {
+        return false;
+    }
+
+    if (!statement->step(error)) {
+        return false;
+    }
+
+    auto value = statement->get_column_value(0, error);
+    if (error) {
+        return false;
+    }
+
+    return (std::get<int64_t>(value) == 1);
+}
+
+bool Database::drop_table(const std::string& tableName, std::error_code& error) const noexcept {
+    std::string statement = "DROP TABLE IF EXISTS " + tableName;
+    return execute(statement, error);
+}
+
+int64_t Database::get_row_count(const std::string& tableName, std::error_code& error) const noexcept {
+    auto statement = prepare_statement("SELECT COUNT(*) FROM " + tableName, error);
+    if (!statement) {
+        return -1;
+    }
+
+    if (!statement->step(error)) {
+        return -1;
+    }
+
+    auto value = statement->get_column_value(0, error);
+    return std::get<int64_t>(value);
+}
+
+bool Database::set_busy_timeout(int busy_timeout_ms, std::error_code& error) const noexcept {
+    const int status = sqlite3_busy_timeout(get_underlying_database(), busy_timeout_ms);
+    return process_sqlite_status(status, error);
+}
+
+bool Database::execute(const std::string& statements, std::error_code& error) const noexcept {
+    const int status = sqlite3_exec(get_underlying_database(), statements.c_str(), nullptr, nullptr, nullptr);
+    return process_sqlite_status(status, error);
+}
+
+int Database::get_updated_row_count() const noexcept { return sqlite3_changes(get_underlying_database()); }
+
+std::string Database::get_last_error_message() const noexcept { return sqlite3_errmsg(get_underlying_database()); }
+
+std::unique_ptr<PreparedStatement> Database::prepare_statement(const std::string& statement,
+                                                               std::error_code& error) const noexcept {
+    sqlite3_stmt* handle = getPreparedStatement(get_underlying_database(), statement, error);
+    return std::make_unique<PreparedStatement>(std::unique_ptr<sqlite3_stmt, StatementDeleter>(handle));
+}
+
+int64_t Database::get_last_inserted_row_id() const noexcept {
+    return sqlite3_last_insert_rowid(get_underlying_database());
+}
+
+std::error_code Database::get_last_error_code() const noexcept {
+    int code = sqlite3_errcode(get_underlying_database());
+    return static_cast<ErrorCode>(code);
+}
+
+std::error_code Database::get_last_extended_error_code() const noexcept {
+    int code = sqlite3_extended_errcode(get_underlying_database());
+    return static_cast<ErrorCode>(code);
+}
+
+bool Database::begin_transaction(TransactionBehavior behavior, std::error_code& error) const noexcept {
+    return execute(getTransactionStatement(behavior), error);
+}
+
+bool Database::commit_transaction(std::error_code& error) const noexcept {
+    return execute("COMMIT TRANSACTION", error);
+}
+
+bool Database::rollback_transaction(std::error_code& error) const noexcept {
+    return execute("ROLLBACK TRANSACTION", error);
+}
+
+bool Database::transaction(const std::function<bool(void)>& fn,
+                           TransactionBehavior behavior,
+                           std::error_code& error) noexcept {
+    if (!begin_transaction(behavior, error)) {
+        return false;
+    }
+
+    bool status = fn();
+    if (status) {
+        return commit_transaction(error);
+    } else {
+        rollback_transaction(error);
+        return false;
+    }
+}
+
+std::shared_ptr<Database> Database::make_inmemory(SynchronousMode mode, int busy_timeout_ms, std::error_code& error) {
+    auto database = std::make_shared<Database>(":memory:");
+    OpenOptions options;
+    options.set_read_write_option(true);
+    if (database->open(options, mode, busy_timeout_ms, error)) {
+        return database;
+    }
+
+    return nullptr;
+}
+
+std::shared_ptr<Database> Database::make(const std::string& filePath,
+                                         OpenOptions options,
+                                         SynchronousMode mode,
+                                         int busy_timeout_ms,
+                                         std::error_code& error) {
+    auto database = std::make_shared<Database>(filePath);
+    if (database->open(options, mode, busy_timeout_ms, error)) {
+        return database;
+    }
+
+    return nullptr;
+}
+
+} // namespace sqlite
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/kvstore/database.hpp
+++ b/backends/apple/coreml/runtime/kvstore/database.hpp
@@ -1,0 +1,279 @@
+//
+// database.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <bitset>
+#include <memory>
+#include <string>
+#include <system_error>
+
+#include <sqlite3.h>
+
+#include <statement.hpp>
+
+namespace executorchcoreml {
+namespace sqlite {
+
+/// The deleter for a sqlite database, closes the database at the time of deallocation.
+struct DatabaseDeleter {
+    inline void operator()(sqlite3* handle) {
+        if (handle) {
+            sqlite3_close(handle);
+        }
+    }
+};
+
+/// Database represents a sqlite database.
+class Database {
+public:
+    /// OpenOptions lists all the options that can be used to open a sqlite database.
+    ///
+    /// The caller is responsible for setting and passing a valid option when opening the database.
+    class OpenOptions {
+    public:
+        /// Corresponds to `SQLITE_OPEN_READONLY` flag, when set the database will be opened in read-only mode.
+        inline void set_read_only_option(bool enable) noexcept {
+            flags_[0] = enable;
+        }
+        
+        /// Returns `true` if read-only option is enabled otherwise `false`.
+        inline bool is_read_only_option_enabled() const noexcept {
+            return flags_[0];
+        }
+        
+        /// Corresponds to `SQLITE_OPEN_READWRITE` flag, when set the database will be opened in read and write mode.
+        inline void set_read_write_option(bool enable) noexcept {
+            flags_[1] = enable;
+        }
+        
+        /// Returns `true` if read and write option is enabled otherwise `false`.
+        inline bool is_read_write_option_enabled() const noexcept {
+            return flags_[1];
+        }
+        
+        /// Corresponds to `SQLITE_OPEN_CREATE` flag, when set the database will be created if it does not exist.
+        inline void set_create_option(bool enable) noexcept {
+            flags_[2] = enable;
+        }
+        
+        /// Returns `true` if create option is enabled otherwise `false`.
+        inline bool is_create_option_enabled() const noexcept {
+            return flags_[2];
+        }
+        
+        /// Corresponds to `SQLITE_OPEN_MEMORY` flag, when set the database will be opened as in-memory database.
+        inline void set_memory_option(bool enable) noexcept {
+            flags_[3] = enable;
+        }
+        
+        /// Returns `true` if memory option is enabled otherwise `false`.
+        inline bool is_memory_option_enabled() const noexcept {
+            return flags_[3];
+        }
+        
+        /// Corresponds to `SQLITE_OPEN_NOMUTEX` flag, when set the database connection will use the "multi-thread" threading mode.
+        inline void set_no_mutex_option(bool enable) noexcept {
+            flags_[4] = enable;
+        }
+        
+        /// Returns `true` if no mutex option is enabled otherwise `false`.
+        inline bool is_no_mutex_option_enabled() const noexcept {
+            return flags_[4];
+        }
+        
+        /// Corresponds to `SQLITE_OPEN_FULLMUTEX` flag, when set the database connection will use the "serialized" threading mode.
+        inline void set_full_mutex_option(bool enable) noexcept {
+            flags_[5] = enable;
+        }
+        
+        /// Returns `true` if full mutex option is enabled otherwise `false`.
+        inline bool is_full_mutex_option_enabled() const noexcept {
+            return flags_[5];
+        }
+        
+        /// Corresponds to `SQLITE_OPEN_SHAREDCACHE` flag, when set the database will be opened with shared cache enabled.
+        inline void set_shared_cache_option(bool enable) noexcept {
+            flags_[6] = enable;
+        }
+        
+        /// Returns `true` if shared cache option is enabled otherwise `false`.
+        inline bool is_shared_cache_option_enabled() const noexcept {
+            return flags_[6];
+        }
+        
+        /// Corresponds to `SQLITE_OPEN_URI` flag, when set the filename can be interpreted as a URI.
+        inline void set_uri_option(bool enable) noexcept {
+            flags_[7] = enable;
+        }
+        
+        /// Returns `true` if URI option is enabled otherwise `false`.
+        inline bool is_uri_option_enabled() const noexcept {
+            return flags_[7];
+        }
+        
+        /// Returns the sqlite flags that can be used to open a sqlite database from the set options.
+        int get_sqlite_flags() const noexcept;
+        
+    private:
+        std::bitset<8> flags_;
+    };
+    
+    /// Represents sqlite synchronous flag.
+    enum class SynchronousMode: uint8_t {
+        Extra = 0,
+        Full,
+        Normal,
+        Off,
+    };
+    
+    /// Represents the behavior of a sqlite transaction
+    enum class TransactionBehavior: uint8_t {
+        Deferred = 0,
+        Immediate,
+        Exclusive,
+    };
+    
+    /// Constructs a database from a file path.
+    Database(const std::string& filePath) noexcept
+    :file_path_(filePath)
+    {}
+    
+    Database(Database const&) = delete;
+    Database& operator=(Database const&) = delete;
+    
+    /// Opens a database
+    ///
+    /// @param options The options for opening the database.
+    /// @param mode   The synchronous mode for the database connection.
+    /// @param busy_timeout_ms   The busy timeout interval in milliseconds.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the database is opened otherwise `false`.
+    bool open(OpenOptions options,
+              SynchronousMode mode,
+              int busy_timeout_ms,
+              std::error_code& error) noexcept;
+    
+    /// Returns `true` is the database is opened otherwise `false`.
+    bool is_open() const noexcept;
+    
+    /// Check if a table exists with the specified name.
+    ///
+    /// @param tableName The table name.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the table exists otherwise `false`.
+    bool table_exists(const std::string& tableName, std::error_code& error) const noexcept;
+    
+    /// Drops a table with the specified name.
+    ///
+    /// @param tableName The table name.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the table is dropped otherwise `false`.
+    bool drop_table(const std::string& tableName, std::error_code& error) const noexcept;
+    
+    /// Returns the number of rows in the table.
+    ///
+    /// @param tableName The table name.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval The number of rows in the table.
+    int64_t get_row_count(const std::string& tableName, std::error_code& error) const noexcept;
+    
+    /// Executes the provided statements.
+    ///
+    /// @param statements The statements to execute.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the execution succeeded otherwise `false`.
+    bool execute(const std::string& statements, std::error_code& error) const noexcept;
+    
+    /// Returns the number of rows updated by the last statement.
+    int get_updated_row_count() const noexcept;
+    
+    /// Returns the error message of the last failed sqlite call.
+    std::string get_last_error_message() const noexcept;
+    
+    /// Returns the error code of the last failed sqlite call.
+    std::error_code get_last_error_code() const noexcept;
+    
+    /// Returns the extended error code of the last failed sqlite call.
+    std::error_code get_last_extended_error_code() const noexcept;
+    
+    /// Returns the value of the last inserted row id.
+    int64_t get_last_inserted_row_id() const noexcept;
+    
+    /// Returns the file path that was used to create the database.
+    std::string_view file_path() const noexcept {
+        return file_path_;
+    }
+    
+    /// Compiles the provided statement and returns it.
+    ///
+    /// @param statement The statement to be compiled.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval The compiled statement.
+    std::unique_ptr<PreparedStatement>
+    prepare_statement(const std::string& statement, std::error_code& error) const noexcept;
+    
+    /// Executes the provided function inside a transaction.
+    ///
+    /// The transaction is committed only if the provided function returns `true` otherwise the transaction is rolled-back.
+    ///
+    /// @param fn The function that will  be executed inside a transaction.
+    /// @param behavior   The transaction behavior.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the transaction is committed otherwise `false`.
+    bool transaction(const std::function<bool(void)>& fn,
+                     TransactionBehavior behavior,
+                     std::error_code& error) noexcept;
+    
+    /// Opens an in-memory database.
+    ///
+    /// @param mode The synchronous mode.
+    /// @param busy_timeout_ms   The total busy timeout duration, in milliseconds.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval The opened in-memory database.
+    static std::shared_ptr<Database> make_inmemory(SynchronousMode mode,
+                                                   int busy_timeout_ms,
+                                                   std::error_code& error);
+    
+    /// Creates and opens a  database at the specified path.
+    ///
+    /// @param filePath The file path of the database.
+    /// @param options   The open options.
+    /// @param mode   The synchronous mode.
+    /// @param busy_timeout_ms The total busy timeout duration, in milliseconds.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval The opened database.
+    static std::shared_ptr<Database> make(const std::string& filePath,
+                                          OpenOptions options,
+                                          SynchronousMode mode,
+                                          int busy_timeout_ms,
+                                          std::error_code& error);
+    
+private:
+    /// Returns the internal sqlite database.
+    inline sqlite3 *get_underlying_database() const noexcept {
+        return sqlite_database_.get();
+    }
+    
+    /// Registers an internal busy handler that keeps attempting to acquire a busy lock until the total specified time has passed.
+    bool set_busy_timeout(int busy_timeout_ms, std::error_code& error) const noexcept;
+    
+    /// Begins an explicit transaction with the specified behavior.
+    bool begin_transaction(TransactionBehavior behavior, std::error_code& error) const noexcept;
+    
+    /// Commits the last open transaction.
+    bool commit_transaction(std::error_code& error) const noexcept;
+    
+    /// Rollbacks the last open transaction.
+    bool rollback_transaction(std::error_code& error) const noexcept;
+    
+    std::string file_path_;
+    std::unique_ptr<sqlite3, DatabaseDeleter> sqlite_database_;
+};
+
+} // namespace sqlite
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/kvstore/json_key_value_store.hpp
+++ b/backends/apple/coreml/runtime/kvstore/json_key_value_store.hpp
@@ -1,0 +1,55 @@
+//
+// JSONKeyValueStore.h
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <key_value_store.hpp>
+
+#include <iostream>
+#include <sstream>
+
+#include <json.hpp>
+
+namespace executorchcoreml {
+namespace sqlite {
+
+using json = nlohmann::json;
+
+/// JSON converter for a type `T`.
+template <typename T>
+struct JSONConverter {
+    static constexpr StorageType storage_type = StorageType::Text;
+    
+    /// Converts a value of type `T` to a `sqlite::Value`.
+    inline static sqlite::Value to_sqlite_value(const T& value) {
+        json j;
+        to_json(j, value);
+        std::stringstream ss;
+        ss << j;
+        return ss.str();
+    }
+    
+    /// Converts a `sqlite::UnOwnedValue` to a value of type `T`.
+    inline static T from_sqlite_value(const sqlite::UnOwnedValue& value) {
+        auto text = std::get<sqlite::UnOwnedString>(value);
+        json j = json::parse(text.data, text.data + text.size);
+        T result;
+        from_json(j, result);
+        return result;
+    }
+};
+
+/// Type representing a JSON KeyValue store, the `Value` type uses a JSON converter.
+///
+/// The `Value` type must implement `to_json(nlohmann::json& j, const T& value)` to convert
+/// the value to json and `from_json(const nlohmann::json& j, T& value)` to convert the value from json.
+/// The functions should be in the same namespace where the value is defined.
+template<typename Key, typename Value, typename KeyConverter = Converter<Key>>
+using JSONKeyValueStore = KeyValueStore<Key, Value, JSONConverter<Value>, KeyConverter>;
+
+} // namespace sqlite
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/kvstore/key_value_store.cpp
+++ b/backends/apple/coreml/runtime/kvstore/key_value_store.cpp
@@ -1,0 +1,337 @@
+//
+// KeyValueStore.cpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#include "key_value_store.hpp"
+
+#include <iostream>
+#include <sstream>
+
+namespace {
+using namespace executorchcoreml::sqlite;
+
+constexpr std::string_view kAccessCountColumnName = "ENTRY_ACCESS_COUNT";
+constexpr std::string_view kAccessTimeColumnName = "ENTRY_ACCESS_TIME";
+
+std::string to_string(StorageType storage_type) {
+    switch (storage_type) {
+        case StorageType::Text: {
+            return "TEXT";
+        }
+        case StorageType::Integer: {
+            return "INTEGER";
+        }
+        case StorageType::Double: {
+            return "REAL";
+        }
+        case StorageType::Blob: {
+            return "BLOB";
+        }
+        case StorageType::Null: {
+            return "NULL";
+        }
+    }
+}
+
+std::string
+get_create_store_statement(std::string_view store_name, StorageType key_storage_type, StorageType value_storage_type) {
+    std::stringstream ss;
+    ss << "CREATE TABLE IF NOT EXISTS ";
+    ss << store_name << " ";
+    ss << "(";
+    ss << "ENTRY_KEY " << to_string(key_storage_type) << "PRIMARY KEY UNIQUE, ";
+    ss << "ENTRY_VALUE " << to_string(value_storage_type) << ", ";
+    ss << "ENTRY_ACCESS_COUNT " << to_string(StorageType::Integer) << ", ";
+    ss << "ENTRY_ACCESS_TIME " << to_string(StorageType::Integer);
+    ss << ")";
+
+    return ss.str();
+}
+
+std::string get_create_index_statement(std::string_view store_name, std::string_view column_name) {
+    std::stringstream ss;
+    ss << "CREATE INDEX IF NOT EXISTS " << column_name << "_INDEX"
+       << " ON " << store_name << "(" << column_name << ")";
+
+    return ss.str();
+}
+
+std::string get_insert_or_replace_statement(std::string_view store_name) {
+    std::stringstream ss;
+    ss << "INSERT OR REPLACE INTO " << store_name
+       << "(ENTRY_KEY, ENTRY_VALUE, ENTRY_ACCESS_COUNT, ENTRY_ACCESS_TIME) VALUES (?, ?, ?, ?)";
+
+    return ss.str();
+}
+
+std::string get_remove_statement(std::string_view store_name) {
+    std::stringstream ss;
+    ss << "DELETE FROM " << store_name << " WHERE ENTRY_KEY = ?";
+
+    return ss.str();
+}
+
+std::string getQueryStatement(std::string_view store_name) {
+    std::stringstream ss;
+    ss << "SELECT ENTRY_VALUE, ENTRY_ACCESS_COUNT FROM " << store_name << " WHERE ENTRY_KEY = ?";
+
+    return ss.str();
+}
+
+std::string get_key_count_statement(std::string_view store_name) {
+    std::stringstream ss;
+    ss << "SELECT COUNT(*) FROM " << store_name << " WHERE ENTRY_KEY = ?";
+
+    return ss.str();
+}
+
+std::string get_update_entry_access_statement(std::string_view store_name) {
+    std::stringstream ss;
+    ss << "UPDATE " << store_name << " SET ENTRY_ACCESS_COUNT = ?, ENTRY_ACCESS_TIME = ? WHERE ENTRY_KEY = ?";
+
+    return ss.str();
+}
+
+std::string to_string(SortOrder order) {
+    switch (order) {
+        case SortOrder::Ascending: {
+            return "ASC";
+        }
+        case SortOrder::Descending: {
+            return "DESC";
+        }
+    }
+}
+
+std::string
+get_keys_sorted_by_column_statement(std::string_view storeName, std::string_view columnName, SortOrder order) {
+    std::stringstream ss;
+    ss << "SELECT ENTRY_KEY, ENTRY_ACCESS_COUNT, ENTRY_ACCESS_TIME FROM " << storeName << " ORDER BY " << columnName
+       << " ";
+    ss << to_string(order);
+
+    return ss.str();
+}
+
+bool bind_value(
+    PreparedStatement* statement, StorageType type, const Value& value, size_t index, std::error_code& error) {
+    switch (type) {
+        case StorageType::Text: {
+            return statement->bind(index, std::get<std::string>(value), error);
+        }
+        case StorageType::Integer: {
+            return statement->bind(index, std::get<int64_t>(value), error);
+        }
+        case StorageType::Double: {
+            return statement->bind(index, std::get<double>(value), error);
+        }
+        case StorageType::Blob: {
+            return statement->bind(index, std::get<Blob>(value).toUnOwned(), error);
+        }
+        default: {
+            return false;
+        }
+    }
+}
+
+bool execute(Database* database,
+             const std::string& query,
+             size_t columnIndex,
+             const std::function<bool(const UnOwnedValue&)>& fn,
+             std::error_code& error) {
+    auto statement = database->prepare_statement(query, error);
+    if (!statement) {
+        return false;
+    }
+
+    while (statement->step(error)) {
+        auto columnValue = statement->get_column_value_no_copy(columnIndex, error);
+        if (error || !fn(columnValue)) {
+            break;
+        }
+    }
+
+    return !(error.operator bool());
+}
+
+int64_t get_last_access_time(Database* database, std::string_view storeName, std::error_code& error) {
+    int64_t latestAccessTime = 0;
+    auto statement = get_keys_sorted_by_column_statement(storeName, kAccessTimeColumnName, SortOrder::Descending);
+    std::function<bool(const UnOwnedValue&)> fn = [&latestAccessTime](const UnOwnedValue& value) {
+        latestAccessTime = std::get<int64_t>(value);
+        return false;
+    };
+
+    return execute(database, statement, 1, fn, error);
+}
+
+} // namespace
+
+namespace executorchcoreml {
+namespace sqlite {
+
+bool KeyValueStoreImpl::init(std::error_code& error) noexcept {
+    if (!database_->execute(get_create_store_statement(name_, get_key_storage_type_, get_value_storage_type_), error)) {
+        return false;
+    }
+
+    if (!database_->execute(get_create_index_statement(name_, kAccessCountColumnName), error)) {
+        return false;
+    }
+
+    if (!database_->execute(get_create_index_statement(name_, kAccessTimeColumnName), error)) {
+        return false;
+    }
+
+    int64_t lastAccessTime = get_last_access_time(database_.get(), name_, error);
+    if (error) {
+        return false;
+    }
+
+    lastAccessTime_.store(lastAccessTime, std::memory_order_seq_cst);
+    return true;
+}
+
+bool KeyValueStoreImpl::exists(const Value& key, std::error_code& error) noexcept {
+    if (error) {
+        return false;
+    }
+
+    auto query = database_->prepare_statement(get_key_count_statement(name_), error);
+    if (!query) {
+        return false;
+    }
+
+    if (!bind_value(query.get(), get_key_storage_type(), key, 1, error)) {
+        return false;
+    }
+
+    if (!query->step(error)) {
+        return false;
+    }
+
+    return std::get<int64_t>(query->get_column_value(0, error)) > 0;
+}
+
+bool KeyValueStoreImpl::updateValueAccessCountAndTime(const Value& key,
+                                                      int64_t accessCount,
+                                                      std::error_code& error) noexcept {
+    auto update = database_->prepare_statement(get_update_entry_access_statement(name_), error);
+    if (!update) {
+        return false;
+    }
+
+    if (!bind_value(update.get(), StorageType::Integer, accessCount + 1, 1, error)) {
+        return false;
+    }
+
+    if (!bind_value(update.get(), StorageType::Integer, lastAccessTime_, 2, error)) {
+        return false;
+    }
+
+    if (!bind_value(update.get(), get_key_storage_type(), key, 3, error)) {
+        return false;
+    }
+
+    bool result = update->execute(error);
+    if (result) {
+        lastAccessTime_ += 1;
+    }
+    return result;
+}
+
+bool KeyValueStoreImpl::get(const Value& key,
+                            const std::function<void(const UnOwnedValue&)>& fn,
+                            std::error_code& error,
+                            bool updateAccessStatistics) noexcept {
+    auto query = database_->prepare_statement(getQueryStatement(name_), error);
+    if (!query) {
+        return false;
+    }
+
+    if (!bind_value(query.get(), get_key_storage_type(), key, 1, error)) {
+        return false;
+    }
+
+    if (!query->step(error)) {
+        return false;
+    }
+
+    auto value = query->get_column_value_no_copy(0, error);
+    fn(value);
+
+    if (updateAccessStatistics) {
+        int64_t accessCount = std::get<int64_t>(query->get_column_value(1, error));
+        return updateValueAccessCountAndTime(key, accessCount, error);
+    }
+
+    return true;
+}
+
+bool KeyValueStoreImpl::put(const Value& key, const Value& value, std::error_code& error) noexcept {
+    auto statement = database_->prepare_statement(get_insert_or_replace_statement(name_), error);
+    if (!statement) {
+        return false;
+    }
+
+    if (!bind_value(statement.get(), get_key_storage_type(), key, 1, error)) {
+        return false;
+    }
+
+    if (!bind_value(statement.get(), get_value_storage_type(), value, 2, error)) {
+        return false;
+    }
+
+    if (!bind_value(statement.get(), StorageType::Integer, int64_t(1), 3, error)) {
+        return false;
+    }
+
+    if (!bind_value(statement.get(), StorageType::Integer, lastAccessTime_.load(std::memory_order_acquire), 4, error)) {
+        return false;
+    }
+
+    lastAccessTime_ += 1;
+    return statement->execute(error);
+}
+
+bool KeyValueStoreImpl::remove(const Value& key, std::error_code& error) noexcept {
+    auto statement = database_->prepare_statement(get_remove_statement(name_), error);
+    if (!bind_value(statement.get(), get_key_storage_type(), key, 1, error)) {
+        return false;
+    }
+
+    return statement->execute(error);
+}
+
+bool KeyValueStoreImpl::get_keys_sorted_by_access_count(const std::function<bool(const UnOwnedValue&)>& fn,
+                                                        SortOrder order,
+                                                        std::error_code& error) noexcept {
+    auto statement = get_keys_sorted_by_column_statement(name(), kAccessCountColumnName, order);
+    return execute(database_.get(), statement, 0, fn, error);
+}
+
+bool KeyValueStoreImpl::get_keys_sorted_by_access_time(const std::function<bool(const UnOwnedValue&)>& fn,
+                                                       SortOrder order,
+                                                       std::error_code& error) noexcept {
+    auto statement = get_keys_sorted_by_column_statement(name(), kAccessTimeColumnName, order);
+    return execute(database_.get(), statement, 0, fn, error);
+}
+
+std::optional<size_t> KeyValueStoreImpl::size(std::error_code& error) noexcept {
+    int64_t count = database_->get_row_count(name_, error);
+    return count < 0 ? std::nullopt : std::optional<size_t>(count);
+}
+
+bool KeyValueStoreImpl::purge(std::error_code& error) noexcept {
+    if (!database_->drop_table(name_, error)) {
+        return false;
+    }
+
+    return init(error);
+}
+
+} // namespace sqlite
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/kvstore/key_value_store.hpp
+++ b/backends/apple/coreml/runtime/kvstore/key_value_store.hpp
@@ -1,0 +1,417 @@
+//
+// key_value_store.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <optional>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <type_traits>
+
+#include <database.hpp>
+#include <types.hpp>
+
+namespace executorchcoreml {
+namespace sqlite {
+
+/// A class to convert a type `T` from `sqlite::Value` and vice-versa.
+///
+/// This is used by the KeyValueStore to read and write values to and from the backing sqlite table.
+///
+template<typename T>
+struct Converter {
+    static constexpr StorageType storage_type = StorageType::Null;
+    
+    template<typename FROM>
+    static sqlite::Value to_sqlite_value(FROM&& value);
+    
+    static T from_sqlite_value(const sqlite::UnOwnedValue& value);
+};
+
+/// Converter for `int64_t` type.
+template<>
+struct Converter<int64_t> {
+    static constexpr StorageType storage_type = StorageType::Integer;
+    
+    static inline Value to_sqlite_value(int value) {
+        return value;
+    }
+    
+    static inline int64_t from_sqlite_value(const sqlite::UnOwnedValue& value) {
+        return std::get<int64_t>(value);
+    }
+};
+
+/// Converter for `int` type.
+template<>
+struct Converter<int> {
+    static constexpr StorageType storage_type = StorageType::Integer;
+    
+    static inline Value to_sqlite_value(int value) {
+        return static_cast<int>(value);
+    }
+    
+    static  inline int from_sqlite_value(const sqlite::UnOwnedValue& value) {
+        return static_cast<int>(std::get<int64_t>(value));
+    }
+};
+
+/// Converter for `size_t` type.
+template<>
+struct Converter<size_t> {
+    static constexpr StorageType storage_type = StorageType::Integer;
+    
+    static inline Value to_sqlite_value(size_t value) {
+        return static_cast<int>(value);
+    }
+    
+    static inline size_t from_sqlite_value(const sqlite::UnOwnedValue& value) {
+        return static_cast<size_t>(std::get<int64_t>(value));
+    }
+};
+
+/// Converter for `double` type.
+template<>
+struct Converter<double> {
+    static constexpr StorageType storage_type = StorageType::Double;
+    
+    static inline Value to_sqlite_value(double value) {
+        return value;
+    }
+    
+    static inline int from_sqlite_value(const UnOwnedValue& value) {
+        return std::get<double>(value);
+    }
+};
+
+/// Converter for `std::string` type.
+template<>
+struct Converter<std::string> {
+    static constexpr sqlite::StorageType storage_type = StorageType::Text;
+    
+    static inline sqlite::Value to_sqlite_value(const std::string& value) {
+        return value;
+    }
+    
+    static inline std::string from_sqlite_value(const UnOwnedValue& value) {
+        return std::string(std::get<sqlite::UnOwnedString>(value).data);
+    }
+};
+
+/// Represents the sort order.
+enum class SortOrder: uint8_t {
+    Ascending = 0,
+    Descending
+};
+
+/// Represents a type-erased KeyValue store, the store is backed by a sqlite table.
+class KeyValueStoreImpl {
+public:
+    /// Constructs a type-erased KeyValue store.
+    ///
+    /// The backing table is created with the key column type set to the `get_key_storage_type` and the
+    /// value column type set to the `get_value_storage_type`.
+    ///
+    /// @param database The opened database.
+    /// @param name   The name of the store.
+    /// @param get_key_storage_type   The key storage type.
+    /// @param get_value_storage_type  The value storage type.
+    inline KeyValueStoreImpl(const std::shared_ptr<Database>& database,
+                             const std::string& name,
+                             StorageType get_key_storage_type,
+                             StorageType get_value_storage_type) noexcept
+    :name_(name),
+    get_key_storage_type_(get_key_storage_type),
+    get_value_storage_type_(get_value_storage_type),
+    database_(std::move(database))
+    {}
+    
+    KeyValueStoreImpl(KeyValueStoreImpl const&) noexcept = delete;
+    KeyValueStoreImpl& operator=(KeyValueStoreImpl const&) noexcept = delete;
+    
+    /// Returns the name of the store.
+    inline std::string_view name() const noexcept {
+        return name_;
+    }
+    
+    /// Returns the key storage type.
+    inline StorageType get_key_storage_type() const noexcept {
+        return get_key_storage_type_;
+    }
+    
+    /// Returns the value storage type.
+    inline StorageType get_value_storage_type() const noexcept {
+        return get_value_storage_type_;
+    }
+    
+    /// Returns the sqlite database.
+    inline Database *database() const noexcept {
+        return database_.get();
+    }
+    
+    /// Returns the value for the specified key. If the key doesn't exists in the store or for some reason the operation failed
+    /// then `nullopt` is returned.
+    ///
+    /// @param key The key for which the value is retrieved.
+    /// @param fn   The function that will be invoked with the retrieved value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @param update_access_statistics   If it is `true` then the access statistics (access time and count) are updated otherwise not.
+    /// @retval The associated value for the key.
+    bool get(const Value& key,
+             const std::function<void(const UnOwnedValue&)>& fn,
+             std::error_code& error,
+             bool update_access_statistics) noexcept;
+    
+    /// Returns `true` if the key exists in the store otherwise `false`.
+    ///
+    /// @param key The key.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the key exists in the store otherwise `false`.
+    bool exists(const Value& key,
+                std::error_code& error) noexcept;
+    
+    /// Sorts the keys by the access count and calls the `std::function` on each key value. The sort order
+    /// is specified by the `order` parameter. The caller can stop the iteration by returning `false`
+    /// from the lambda, to continue the iteration the caller must return `true`.
+    ///
+    /// @param fn The `std::function` that gets called for each key after its sorted.
+    /// @param order The sort order.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the operation succeeded otherwise `false`.
+    bool get_keys_sorted_by_access_count(const std::function<bool(const UnOwnedValue&)>& fn,
+                                         SortOrder order,
+                                         std::error_code& error) noexcept;
+    
+    /// Sorts the keys by the access time and calls the `std::function` on each key value. The sort order
+    /// is specified by the `order` parameter. The caller can stop the iteration by returning `false`
+    /// from the lambda, to continue the iteration the caller must return `true`.
+    ///
+    /// @param fn The `std::function` that gets called for each key after its sorted.
+    /// @param order The sort order.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the operation succeeded otherwise `false`.
+    bool get_keys_sorted_by_access_time(const std::function<bool(const UnOwnedValue&)>& fn,
+                                        SortOrder order,
+                                        std::error_code& error) noexcept;
+    
+    /// Stores a key and a value in the store, the old value is overwritten.
+    ///
+    /// @param key The key.
+    /// @param value The value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the operation succeeded otherwise `false`.
+    bool put(const Value& key, const Value& value, std::error_code& error) noexcept;
+    
+    /// Removes the specified key and the associated value from the store.
+    ///
+    /// @param key The key.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the operation succeeded otherwise `false`.
+    bool remove(const Value& key, std::error_code& error) noexcept;
+    
+    /// Purges the store. The backing table is dropped and re-created.
+    bool purge(std::error_code& error)  noexcept;
+    
+    /// Returns the size of the store.
+    std::optional<size_t> size(std::error_code& error) noexcept;
+    
+    /// Initializes the store.
+    ///
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the operation succeeded otherwise `false`.
+    bool init(std::error_code& error) noexcept;
+    
+private:
+    bool updateValueAccessCountAndTime(const Value& key,
+                                       int64_t accessCount,
+                                       std::error_code& error) noexcept;
+    
+    std::string name_;
+    StorageType get_key_storage_type_;
+    StorageType get_value_storage_type_;
+    std::shared_ptr<Database> database_;
+    std::atomic<int64_t> lastAccessTime_;
+};
+
+/// Represents a KeyValue store, the store is backed by a sqlite table.
+template <typename Key, typename Value, typename ValueConverter = Converter<Value>, typename KeyConverter = Converter<Key>>
+class KeyValueStore final {
+public:
+    template<typename T> using same_key = std::is_same<typename std::decay_t<T>, Key>;
+    template<typename T> using same_value = std::is_same<typename std::decay_t<T>, Value>;
+    
+    virtual ~KeyValueStore() = default;
+    
+    KeyValueStore(KeyValueStore const&) noexcept = delete;
+    KeyValueStore& operator=(KeyValueStore const&) noexcept = delete;
+    
+    inline KeyValueStore(std::unique_ptr<KeyValueStoreImpl> impl) noexcept
+    :impl_(std::move(impl))
+    {}
+    
+    /// Executes the provided lambda inside a transaction. The lambda must return `true` if the transaction is to
+    /// be committed otherwise `false`.
+    ///
+    /// The transaction is only committed if the lambda returns `true` otherwise the transaction is rolled-back.
+    ///
+    /// @param fn The lambda that will  be executed inside a transaction.
+    /// @param behavior   The transaction behavior.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the transaction is committed otherwise `false`.
+    template<typename FN>
+    bool transaction(FN&& fn, Database::TransactionBehavior behavior, std::error_code& error) noexcept {
+        return impl_->database()->transaction([&fn](){
+            return fn();
+        }, behavior, error);
+    }
+    
+    
+    /// Returns the value for the specified key. If the key doesn't exists in the store or the operation failed
+    /// then `nullopt` is returned.
+    ///
+    /// @param key The key for which the value is retrieved.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @param update_access_statistics   If it is `true` then the access statistics (access time and access count) are updated otherwise not.
+    /// @retval The associated value for the key.
+    template<typename T>
+    inline std::optional<Value> get(T&& key, std::error_code& error, bool update_access_statistics = true) noexcept {
+        static_assert(same_key<T>::value, "Key type is not supported.");
+        
+        Value result;
+        std::function<void(const UnOwnedValue&)> fn = [&result](const UnOwnedValue& value) {
+            result = ValueConverter::from_sqlite_value(value);
+        };
+        
+        if (!impl_->get(KeyConverter::to_sqlite_value(std::forward<T>(key)), fn, error, update_access_statistics)) {
+            return std::nullopt;
+        }
+        
+        return result;
+    }
+    
+    /// Returns `true` if the key exists in the store otherwise `false`.
+    ///
+    /// @param key The key.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the key exists in the store otherwise `false`.
+    template<typename T>
+    inline bool exists(T&& key, std::error_code& error) noexcept {
+        static_assert(same_key<T>::value, "Key type is not supported.");
+        
+        return impl_->exists(KeyConverter::to_sqlite_value(std::forward<T>(key)), error);
+    }
+    
+    /// Stores a key and its associated value in the store, the old value is overwritten.
+    ///
+    /// @param key The key.
+    /// @param value The value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the operation succeeded otherwise `false`.
+    template<typename T, typename U>
+    inline bool put(T&& key, U&& value, std::error_code& error) const noexcept {
+        static_assert(same_key<T>::value, "Key type is not supported.");
+        static_assert(same_value<U>::value, "Value type is not supported.");
+        
+        return impl_->put(KeyConverter::to_sqlite_value(std::forward<T>(key)),
+                          ValueConverter::to_sqlite_value(std::forward<U>(value)),
+                          error);
+    }
+    
+    /// Sorts the keys by the access count and calls the lambda on each key value. The sort order
+    /// is specified by the `order` parameter. The caller can stop the iteration by returning `false`
+    /// from the lambda, to continue the iteration the caller must return `true`.
+    ///
+    /// @param fn The lambda that gets called for each key after its sorted.
+    /// @param order The sort order.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the operation succeeded otherwise `false`.
+    template<typename FN>
+    bool get_keys_sorted_by_access_count(FN&& fn,
+                                         SortOrder order,
+                                         std::error_code& error) noexcept {
+        std::function<bool(const UnOwnedValue&)> wrappedFn = [&fn](const UnOwnedValue& value) {
+            return fn(KeyConverter::from_sqlite_value(value));
+        };
+        
+        return impl_->get_keys_sorted_by_access_count(wrappedFn, order, error);
+    }
+    
+    /// Sorts the keys by the access time and calls the lambda on each key value. The sort order
+    /// is specified by the `order` parameter. The caller can stop the iteration by returning `false`
+    /// from the lambda, to continue the iteration the caller must return `true`.
+    ///
+    /// @param fn The lambda that gets called for each key after its sorted.
+    /// @param order The sort order.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the operation succeeded otherwise `false`.
+    template<typename FN>
+    bool get_keys_sorted_by_access_time(FN&& fn,
+                                        SortOrder order,
+                                        std::error_code& error) noexcept {
+        std::function<bool(const UnOwnedValue&)> wrappedFn = [&fn](const UnOwnedValue& value) {
+            return fn(KeyConverter::from_sqlite_value(value));
+        };
+        
+        return impl_->get_keys_sorted_by_access_time(wrappedFn, order, error);
+    }
+    
+    /// Removes the specified key and its associated value from the store.
+    ///
+    /// @param key The key.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the operation succeeded otherwise `false`.
+    template<typename T>
+    inline bool remove(T&& key, std::error_code& error) noexcept {
+        static_assert(same_key<T>::value, "Key type is not supported");
+        return impl_->remove(Converter<Key>::to_sqlite_value(std::forward<T>(key)), error);
+    }
+    
+    /// Returns the name of the store.
+    inline std::string_view name() const noexcept {
+        return impl_->name();
+    }
+    
+    /// Returns the size of the store.
+    inline std::optional<size_t> size(std::error_code& error) const noexcept {
+        return impl_->size(error);
+    }
+    
+    /// Purges the store. The backing table is dropped and re-created.
+    inline bool purge(std::error_code& error) noexcept {
+        return impl_->purge(error);
+    }
+    
+    /// Creates a typed KeyValue store.
+    ///
+    /// The returned store's key type is `KeyType` and the value type is `ValueType`.  The store
+    /// uses the `KeyConverter` type to convert a value of `KeyType` to a `sqlite::Value` and
+    /// the `ValueConverter` to convert a value of `ValueType` to a `sqlite::Value`.
+    ///
+    /// @param database The sqlite database used for persisting.
+    /// @param name  The name of the store.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval the `unique_ptr` to the created store or `nullptr` if the creation failed.
+    static inline std::unique_ptr<KeyValueStore<Key, Value, ValueConverter, KeyConverter>>
+    make(const std::shared_ptr<Database>& database, const std::string& name, std::error_code& error) noexcept {
+        auto impl = std::make_unique<KeyValueStoreImpl>(database,
+                                                        name,
+                                                        KeyConverter::storage_type,
+                                                        ValueConverter::storage_type);
+        if (!impl->init(error)) {
+            return nullptr;
+        }
+        
+        return std::make_unique<KeyValueStore<Key, Value, ValueConverter, KeyConverter>>(std::move(impl));
+    }
+    
+private:
+    std::unique_ptr<KeyValueStoreImpl> impl_;
+};
+
+} // namespace sqlite
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/kvstore/sqlite_error.cpp
+++ b/backends/apple/coreml/runtime/kvstore/sqlite_error.cpp
@@ -1,0 +1,156 @@
+//
+// sqlite_error.cpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+//
+
+#include <sqlite_error.hpp>
+
+#include <sqlite3.h>
+
+namespace executorchcoreml {
+namespace sqlite {
+
+bool ErrorCategory::equivalent(const std::error_code& code, int condition) const noexcept {
+    switch (static_cast<Status>(condition)) {
+        case Status::success: {
+            return !code || (code == ErrorCode::OK_LOAD_PERMANENTLY) || (code == ErrorCode::ROW) ||
+                (code == ErrorCode::DONE);
+        }
+        case Status::error: {
+            return (code == ErrorCode::ERROR);
+        }
+        case Status::internal: {
+            return (code == ErrorCode::INTERNAL);
+        }
+        case Status::perm: {
+            return (code == ErrorCode::PERM);
+        }
+        case Status::abort: {
+            return (code == ErrorCode::ABORT) || (code == ErrorCode::ABORT_ROLLBACK);
+        }
+        case Status::busy: {
+            return (code == ErrorCode::BUSY) || (code == ErrorCode::BUSY_RECOVERY) ||
+                (code == ErrorCode::BUSY_SNAPSHOT);
+        }
+        case Status::locked: {
+            return (code == ErrorCode::LOCKED) || (code == ErrorCode::LOCKED_SHAREDCACHE);
+        }
+        case Status::nomem: {
+            return (code == ErrorCode::NOMEM);
+        }
+        case Status::readonly: {
+            return (code == ErrorCode::READONLY) || (code == ErrorCode::READONLY_CANTLOCK) ||
+                (code == ErrorCode::READONLY_DBMOVED) || (code == ErrorCode::READONLY_RECOVERY) ||
+                (code == ErrorCode::READONLY_ROLLBACK);
+        }
+        case Status::interrupt: {
+            return (code == ErrorCode::INTERRUPT);
+        }
+        case Status::ioerr: {
+            return (code == ErrorCode::IOERR) || (code == ErrorCode::IOERR_ACCESS) ||
+                (code == ErrorCode::IOERR_BLOCKED) || (code == ErrorCode::IOERR_CHECKRESERVEDLOCK) ||
+                (code == ErrorCode::IOERR_CLOSE) || (code == ErrorCode::IOERR_CONVPATH) ||
+                (code == ErrorCode::IOERR_DELETE) || (code == ErrorCode::IOERR_DELETE_NOENT) ||
+                (code == ErrorCode::IOERR_DIR_CLOSE) || (code == ErrorCode::IOERR_DIR_FSYNC) ||
+                (code == ErrorCode::IOERR_FSTAT) || (code == ErrorCode::IOERR_FSYNC) ||
+                (code == ErrorCode::IOERR_GETTEMPPATH) || (code == ErrorCode::IOERR_LOCK) ||
+                (code == ErrorCode::IOERR_MMAP) || (code == ErrorCode::IOERR_NOMEM) ||
+                (code == ErrorCode::IOERR_RDLOCK) || (code == ErrorCode::IOERR_READ) ||
+                (code == ErrorCode::IOERR_SEEK) || (code == ErrorCode::IOERR_SHMLOCK) ||
+                (code == ErrorCode::IOERR_SHMMAP) || (code == ErrorCode::IOERR_SHMOPEN) ||
+                (code == ErrorCode::IOERR_SHMSIZE) || (code == ErrorCode::IOERR_SHORT_READ) ||
+                (code == ErrorCode::IOERR_TRUNCATE) || (code == ErrorCode::IOERR_UNLOCK) ||
+                (code == ErrorCode::IOERR_WRITE);
+        }
+        case Status::corrupt: {
+            return (code == ErrorCode::CORRUPT) || (code == ErrorCode::CORRUPT_VTAB);
+        }
+        case Status::notfound: {
+            return (code == ErrorCode::NOTFOUND);
+        }
+        case Status::full: {
+            return (code == ErrorCode::FULL);
+        }
+        case Status::cantopen: {
+            return (code == ErrorCode::CANTOPEN) || (code == ErrorCode::CANTOPEN_CONVPATH) ||
+                (code == ErrorCode::CANTOPEN_FULLPATH) || (code == ErrorCode::CANTOPEN_ISDIR) ||
+                (code == ErrorCode::CANTOPEN_NOTEMPDIR);
+        }
+        case Status::protocol: {
+            return (code == ErrorCode::PROTOCOL);
+        }
+        case Status::empty: {
+            return (code == ErrorCode::EMPTY);
+        }
+        case Status::schema: {
+            return (code == ErrorCode::SCHEMA);
+        }
+        case Status::toobig: {
+            return (code == ErrorCode::TOOBIG);
+        }
+        case Status::constraint: {
+            return (code == ErrorCode::CONSTRAINT) || (code == ErrorCode::CONSTRAINT_CHECK) ||
+                (code == ErrorCode::CONSTRAINT_COMMITHOOK) || (code == ErrorCode::CONSTRAINT_FOREIGNKEY) ||
+                (code == ErrorCode::CONSTRAINT_FUNCTION) || (code == ErrorCode::CONSTRAINT_NOTNULL) ||
+                (code == ErrorCode::CONSTRAINT_PRIMARYKEY) || (code == ErrorCode::CONSTRAINT_ROWID) ||
+                (code == ErrorCode::CONSTRAINT_TRIGGER) || (code == ErrorCode::CONSTRAINT_UNIQUE) ||
+                (code == ErrorCode::CONSTRAINT_VTAB);
+        }
+        case Status::mismatch: {
+            return (code == ErrorCode::MISMATCH);
+        }
+        case Status::misuse: {
+            return (code == ErrorCode::MISUSE);
+        }
+        case Status::nolfs: {
+            return (code == ErrorCode::NOLFS);
+        }
+        case Status::auth: {
+            return (code == ErrorCode::AUTH);
+        }
+        case Status::format: {
+            return (code == ErrorCode::FORMAT);
+        }
+        case Status::range: {
+            return (code == ErrorCode::RANGE);
+        }
+        case Status::notadb: {
+            return (code == ErrorCode::NOTADB);
+        }
+        case Status::notice: {
+            return (code == ErrorCode::NOTICE) || (code == ErrorCode::NOTICE_RECOVER_ROLLBACK) ||
+                (code == ErrorCode::NOTICE_RECOVER_WAL);
+        }
+        case Status::warning: {
+            return (code == ErrorCode::WARNING) || (code == ErrorCode::WARNING_AUTOINDEX);
+        }
+        case Status::row: {
+            return (code == ErrorCode::ROW);
+        }
+        case Status::done: {
+            return (code == ErrorCode::DONE);
+        }
+        default: {
+            return false;
+        }
+    }
+}
+
+bool is_status_ok(int status) {
+    return (status == SQLITE_OK || status == SQLITE_DONE || status == SQLITE_OK_LOAD_PERMANENTLY ||
+            status == SQLITE_ROW);
+}
+
+bool process_sqlite_status(int status, std::error_code& code) {
+    if (is_status_ok(status)) {
+        return true;
+    }
+    code = std::error_code(status, ErrorCategory::instance());
+    return false;
+}
+
+} // namespace sqlite
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/kvstore/sqlite_error.hpp
+++ b/backends/apple/coreml/runtime/kvstore/sqlite_error.hpp
@@ -1,0 +1,185 @@
+//
+// sqlite_error.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+
+#include <types.hpp>
+
+#include <sqlite3.h>
+
+namespace executorchcoreml {
+namespace sqlite {
+
+/// The error codes representing sqlite error codes.
+enum class ErrorCode: int32_t {
+    ERROR = SQLITE_ERROR,
+    INTERNAL = SQLITE_INTERNAL,
+    PERM = SQLITE_PERM,
+    ABORT = SQLITE_ABORT,
+    BUSY = SQLITE_BUSY,
+    LOCKED = SQLITE_LOCKED,
+    NOMEM = SQLITE_NOMEM,
+    READONLY = SQLITE_READONLY,
+    INTERRUPT = SQLITE_INTERRUPT,
+    IOERR = SQLITE_IOERR,
+    CORRUPT = SQLITE_CORRUPT,
+    NOTFOUND = SQLITE_NOTFOUND,
+    FULL = SQLITE_FULL,
+    CANTOPEN = SQLITE_CANTOPEN,
+    PROTOCOL = SQLITE_PROTOCOL,
+    EMPTY = SQLITE_EMPTY,
+    SCHEMA = SQLITE_SCHEMA,
+    TOOBIG = SQLITE_TOOBIG,
+    CONSTRAINT = SQLITE_CONSTRAINT,
+    MISMATCH = SQLITE_MISMATCH,
+    MISUSE = SQLITE_MISUSE,
+    NOLFS = SQLITE_NOLFS,
+    AUTH = SQLITE_AUTH,
+    FORMAT = SQLITE_FORMAT,
+    RANGE = SQLITE_RANGE,
+    NOTADB = SQLITE_NOTADB,
+    NOTICE = SQLITE_NOTICE,
+    WARNING = SQLITE_WARNING,
+    ROW = SQLITE_ROW,
+    DONE = SQLITE_DONE,
+    
+    // Extended
+    ABORT_ROLLBACK = SQLITE_ABORT_ROLLBACK,
+    BUSY_RECOVERY = SQLITE_BUSY_RECOVERY,
+    BUSY_SNAPSHOT = SQLITE_BUSY_SNAPSHOT,
+    CANTOPEN_CONVPATH = SQLITE_CANTOPEN_CONVPATH,
+    CANTOPEN_FULLPATH = SQLITE_CANTOPEN_FULLPATH,
+    CANTOPEN_ISDIR = SQLITE_CANTOPEN_ISDIR,
+    CANTOPEN_NOTEMPDIR = SQLITE_CANTOPEN_NOTEMPDIR,
+    CONSTRAINT_CHECK = SQLITE_CONSTRAINT_CHECK,
+    CONSTRAINT_COMMITHOOK = SQLITE_CONSTRAINT_COMMITHOOK,
+    CONSTRAINT_FOREIGNKEY = SQLITE_CONSTRAINT_FOREIGNKEY,
+    CONSTRAINT_FUNCTION = SQLITE_CONSTRAINT_FUNCTION,
+    CONSTRAINT_NOTNULL = SQLITE_CONSTRAINT_NOTNULL,
+    CONSTRAINT_PRIMARYKEY = SQLITE_CONSTRAINT_PRIMARYKEY,
+    CONSTRAINT_ROWID = SQLITE_CONSTRAINT_ROWID,
+    CONSTRAINT_TRIGGER = SQLITE_CONSTRAINT_TRIGGER,
+    CONSTRAINT_UNIQUE = SQLITE_CONSTRAINT_UNIQUE,
+    CONSTRAINT_VTAB = SQLITE_CONSTRAINT_VTAB,
+    CORRUPT_VTAB = SQLITE_CORRUPT_VTAB,
+    IOERR_ACCESS = SQLITE_IOERR_ACCESS,
+    IOERR_BLOCKED = SQLITE_IOERR_BLOCKED,
+    IOERR_CHECKRESERVEDLOCK = SQLITE_IOERR_CHECKRESERVEDLOCK,
+    IOERR_CLOSE = SQLITE_IOERR_CLOSE,
+    IOERR_CONVPATH = SQLITE_IOERR_CONVPATH,
+    IOERR_DELETE = SQLITE_IOERR_DELETE,
+    IOERR_DELETE_NOENT = SQLITE_IOERR_DELETE_NOENT,
+    IOERR_DIR_CLOSE = SQLITE_IOERR_DIR_CLOSE,
+    IOERR_DIR_FSYNC = SQLITE_IOERR_DIR_FSYNC,
+    IOERR_FSTAT = SQLITE_IOERR_FSTAT,
+    IOERR_FSYNC = SQLITE_IOERR_FSYNC,
+    IOERR_GETTEMPPATH = SQLITE_IOERR_GETTEMPPATH,
+    IOERR_LOCK = SQLITE_IOERR_LOCK,
+    IOERR_MMAP = SQLITE_IOERR_MMAP,
+    IOERR_NOMEM = SQLITE_IOERR_NOMEM,
+    IOERR_RDLOCK = SQLITE_IOERR_RDLOCK,
+    IOERR_READ = SQLITE_IOERR_READ,
+    IOERR_SEEK = SQLITE_IOERR_SEEK,
+    IOERR_SHMLOCK = SQLITE_IOERR_SHMLOCK,
+    IOERR_SHMMAP = SQLITE_IOERR_SHMMAP,
+    IOERR_SHMOPEN = SQLITE_IOERR_SHMOPEN,
+    IOERR_SHMSIZE = SQLITE_IOERR_SHMSIZE,
+    IOERR_SHORT_READ = SQLITE_IOERR_SHORT_READ,
+    IOERR_TRUNCATE = SQLITE_IOERR_TRUNCATE,
+    IOERR_UNLOCK = SQLITE_IOERR_UNLOCK,
+    IOERR_WRITE = SQLITE_IOERR_WRITE,
+    LOCKED_SHAREDCACHE = SQLITE_LOCKED_SHAREDCACHE,
+    NOTICE_RECOVER_ROLLBACK = SQLITE_NOTICE_RECOVER_ROLLBACK,
+    NOTICE_RECOVER_WAL = SQLITE_NOTICE_RECOVER_WAL,
+    OK_LOAD_PERMANENTLY = SQLITE_OK_LOAD_PERMANENTLY,
+    READONLY_CANTLOCK = SQLITE_READONLY_CANTLOCK,
+    READONLY_DBMOVED = SQLITE_READONLY_DBMOVED,
+    READONLY_RECOVERY = SQLITE_READONLY_RECOVERY,
+    READONLY_ROLLBACK = SQLITE_READONLY_ROLLBACK,
+    WARNING_AUTOINDEX = SQLITE_WARNING_AUTOINDEX
+};
+
+enum class Status {
+    success = 1,
+    error,
+    internal,
+    perm,
+    abort,
+    busy,
+    locked,
+    nomem,
+    readonly,
+    interrupt,
+    ioerr,
+    corrupt,
+    notfound,
+    full,
+    cantopen,
+    protocol,
+    empty,
+    schema,
+    toobig,
+    constraint,
+    mismatch,
+    misuse,
+    nolfs,
+    auth,
+    format,
+    range,
+    notadb,
+    notice,
+    warning,
+    row,
+    done
+};
+
+/// The category for a sqlite error.
+struct ErrorCategory final : std::error_category {
+    inline const char* name() const noexcept override {
+        return "sqlite";
+    }
+    
+    inline std::string message(int v) const override {
+        return std::string(sqlite3_errstr(v));
+    }
+    
+    static inline ErrorCategory& instance() {
+        static ErrorCategory c;
+        return c;
+    }
+    
+    bool equivalent(const std::error_code& ec, int condition) const noexcept override;
+};
+
+
+inline std::error_code make_error_code(ErrorCode code) {
+    return {static_cast<int>(code), ErrorCategory::instance()};
+}
+
+/// Checks if the sqlite status is not an error.
+///
+/// @param status The sqlite status.
+/// @retval `true` if the status is not an error otherwise `false`.
+bool is_status_ok(int status);
+
+/// Processes sqlite return status.
+///
+/// @param status The sqlite status.
+/// @param error   if the sqlite status is an error then it is converted to `error_code` and is assigned to `error`.
+/// @retval `true` if the status is not an error otherwise `false`.
+bool process_sqlite_status(int status, std::error_code& error);
+
+} // namespace sqlite
+} // namespace executorchcoreml
+
+namespace std {
+
+template <>
+struct is_error_code_enum<executorchcoreml::sqlite::ErrorCode> : true_type {};
+
+}  // namespace std

--- a/backends/apple/coreml/runtime/kvstore/statement.cpp
+++ b/backends/apple/coreml/runtime/kvstore/statement.cpp
@@ -1,0 +1,284 @@
+//
+// Statement.cpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#include "statement.hpp"
+
+#include <string_view>
+
+#include <sqlite_error.hpp>
+
+namespace {
+
+using namespace executorchcoreml::sqlite;
+
+size_t get_column_count(sqlite3_stmt* stmt) { return static_cast<size_t>(sqlite3_column_count(stmt)); }
+
+std::vector<std::string> get_column_names(sqlite3_stmt* stmt, size_t column_count) {
+    std::vector<std::string> result;
+    result.reserve(static_cast<size_t>(column_count));
+    for (int i = 0; i < column_count; i++) {
+        const char* name = sqlite3_column_name(stmt, i);
+        if (!name) {
+            return {};
+        }
+        result.emplace_back(name);
+    }
+
+    return result;
+}
+
+int get_parameter_index(sqlite3_stmt* stmt, const std::string& name) {
+    return sqlite3_bind_parameter_index(stmt, name.c_str());
+}
+
+bool bind_unowned_string(sqlite3_stmt* stmt, size_t index, UnOwnedString value, bool copy, std::error_code& error) {
+    if (error) {
+        return false;
+    }
+    auto destructor = copy ? SQLITE_TRANSIENT : SQLITE_STATIC;
+    const int status =
+        sqlite3_bind_text(stmt, static_cast<int>(index), value.data, static_cast<int>(value.size), destructor);
+    return process_sqlite_status(status, error);
+}
+
+bool bind_blob(sqlite3_stmt* stmt, size_t index, const UnOwnedBlob& value, bool copy, std::error_code& error) {
+    if (error) {
+        return false;
+    }
+    auto destructor = copy ? SQLITE_TRANSIENT : SQLITE_STATIC;
+    const int status =
+        sqlite3_bind_blob(stmt, static_cast<int>(index), value.data, static_cast<int>(value.size), destructor);
+    return process_sqlite_status(status, error);
+}
+
+StorageType get_column_storage_type(sqlite3_stmt* stmt, int index) {
+    switch (sqlite3_column_type(stmt, index)) {
+        case SQLITE_INTEGER: {
+            return StorageType::Integer;
+        }
+        case SQLITE_FLOAT: {
+            return StorageType::Double;
+        }
+        case SQLITE_TEXT: {
+            return StorageType::Text;
+        }
+        case SQLITE_BLOB: {
+            return StorageType::Blob;
+        }
+        case SQLITE_NULL: {
+            return StorageType::Null;
+        }
+        default: {
+            return StorageType::Null;
+        }
+    }
+}
+
+std::vector<StorageType> get_column_storage_types(sqlite3_stmt* stmt, size_t columnCount) {
+    std::vector<StorageType> result;
+    result.reserve(static_cast<size_t>(columnCount));
+    for (int i = 0; i < columnCount; i++) {
+        result.emplace_back(get_column_storage_type(stmt, i));
+    }
+
+    return result;
+}
+
+int64_t get_int64_value(sqlite3_stmt* stmt, size_t index) {
+    return sqlite3_column_int64(stmt, static_cast<int>(index));
+}
+
+int64_t get_double_value(sqlite3_stmt* stmt, size_t index) {
+    return sqlite3_column_double(stmt, static_cast<int>(index));
+}
+
+std::string get_string_value(sqlite3_stmt* stmt, size_t index) {
+    auto data = static_cast<const char*>(sqlite3_column_blob(stmt, static_cast<int>(index)));
+    return std::string(data, sqlite3_column_bytes(stmt, static_cast<int>(index)));
+}
+
+UnOwnedString get_unowned_string_value(sqlite3_stmt* stmt, size_t index) {
+    auto data = static_cast<const char*>(sqlite3_column_blob(stmt, static_cast<int>(index)));
+    return UnOwnedString(data, sqlite3_column_bytes(stmt, static_cast<int>(index)));
+}
+
+std::pair<const void*, size_t> get_stored_blob_value(sqlite3_stmt* stmt, size_t index) {
+    const void* data = sqlite3_column_blob(stmt, static_cast<int>(index));
+    int n = sqlite3_column_bytes(stmt, static_cast<int>(index));
+    return { data, static_cast<size_t>(n) };
+}
+
+Blob get_blob_value(sqlite3_stmt* stmt, size_t index) {
+    const auto& pair = get_stored_blob_value(stmt, index);
+    return Blob(pair.first, pair.second);
+}
+
+UnOwnedBlob get_unowned_blob_value(sqlite3_stmt* stmt, size_t index) {
+    const auto& pair = get_stored_blob_value(stmt, index);
+    return UnOwnedBlob(pair.first, pair.second);
+}
+} // namespace
+
+namespace executorchcoreml {
+namespace sqlite {
+
+PreparedStatement::PreparedStatement(std::unique_ptr<sqlite3_stmt, StatementDeleter> prepared_statement) noexcept
+    : column_count_(::get_column_count(prepared_statement.get())),
+      column_names_(::get_column_names(prepared_statement.get(), column_count_)),
+      prepared_statement_(std::move(prepared_statement)) { }
+
+bool PreparedStatement::bind(size_t index, int64_t value, std::error_code& error) const noexcept {
+    if (error) {
+        return false;
+    }
+    const int status = sqlite3_bind_int64(get_underlying_statement(), static_cast<int>(index), value);
+    return process_sqlite_status(status, error);
+}
+
+bool PreparedStatement::bind_name(const std::string& name, int64_t value, std::error_code& error) const noexcept {
+    return bind(get_parameter_index(get_underlying_statement(), name), value, error);
+}
+
+bool PreparedStatement::bind(size_t index, double value, std::error_code& error) const noexcept {
+    if (error) {
+        return false;
+    }
+    const int status = sqlite3_bind_double(get_underlying_statement(), static_cast<int>(index), value);
+    return process_sqlite_status(status, error);
+}
+
+bool PreparedStatement::bind(size_t index, UnOwnedString value, std::error_code& error) const noexcept {
+    return bind_unowned_string(get_underlying_statement(), index, value, true, error);
+}
+
+bool PreparedStatement::bind_no_copy(size_t index, UnOwnedString value, std::error_code& error) const noexcept {
+    return bind_unowned_string(get_underlying_statement(), index, value, false, error);
+}
+
+bool PreparedStatement::bind_name(const std::string& name, UnOwnedString value, std::error_code& error) const noexcept {
+    size_t index = get_parameter_index(get_underlying_statement(), name);
+    return bind_unowned_string(get_underlying_statement(), index, value, true, error);
+}
+
+bool PreparedStatement::bind_name_no_copy(const std::string& name,
+                                          UnOwnedString value,
+                                          std::error_code& error) const noexcept {
+    size_t index = get_parameter_index(get_underlying_statement(), name);
+    return bind_unowned_string(get_underlying_statement(), index, value, false, error);
+}
+
+bool PreparedStatement::bind(size_t index, const UnOwnedBlob& value, std::error_code& error) const noexcept {
+    return bind_blob(get_underlying_statement(), index, value, true, error);
+}
+
+bool PreparedStatement::bind_name(const std::string& name,
+                                  const UnOwnedBlob& value,
+                                  std::error_code& error) const noexcept {
+    size_t index = get_parameter_index(get_underlying_statement(), name);
+    return bind_blob(get_underlying_statement(), index, value, true, error);
+}
+
+bool PreparedStatement::bind_no_copy(size_t index, const UnOwnedBlob& value, std::error_code& error) const noexcept {
+    return bind_blob(get_underlying_statement(), index, value, false, error);
+}
+
+bool PreparedStatement::bind_name_no_copy(const std::string& name,
+                                          const UnOwnedBlob& value,
+                                          std::error_code& error) const noexcept {
+    size_t index = get_parameter_index(get_underlying_statement(), name);
+    return bind_blob(get_underlying_statement(), index, value, false, error);
+}
+
+bool PreparedStatement::reset(std::error_code& error) const noexcept {
+    if (error) {
+        return false;
+    }
+    const int status = sqlite3_reset(get_underlying_statement());
+    return process_sqlite_status(status, error);
+}
+
+bool PreparedStatement::step(std::error_code& error) const noexcept {
+    if (error) {
+        return false;
+    }
+    const int status = sqlite3_step(get_underlying_statement());
+    if (status == SQLITE_ROW) {
+        return true;
+    } else if (status == SQLITE_DONE) {
+        return false;
+    } else {
+        return process_sqlite_status(status, error);
+    }
+}
+
+const std::vector<StorageType>& PreparedStatement::get_column_storage_types() noexcept {
+    if (column_storage_types_.empty()) {
+        column_storage_types_ = ::get_column_storage_types(get_underlying_statement(), get_column_count());
+    }
+    return column_storage_types_;
+}
+
+Value PreparedStatement::get_column_value(size_t index, std::error_code& error) noexcept {
+    if (error) {
+        return Null();
+    }
+    switch (get_column_storage_type(index)) {
+        case StorageType::Integer: {
+            return get_int64_value(get_underlying_statement(), index);
+        }
+        case StorageType::Double: {
+            return get_double_value(get_underlying_statement(), index);
+        }
+        case StorageType::Text: {
+            return get_string_value(get_underlying_statement(), index);
+        }
+        case StorageType::Blob: {
+            return get_blob_value(get_underlying_statement(), index);
+        }
+        case StorageType::Null: {
+            return Null();
+        }
+    }
+}
+
+UnOwnedValue PreparedStatement::get_column_value_no_copy(size_t index, std::error_code& error) noexcept {
+    if (error) {
+        return Null();
+    }
+    switch (get_column_storage_type(index)) {
+        case StorageType::Integer: {
+            return get_int64_value(get_underlying_statement(), index);
+        }
+        case StorageType::Double: {
+            return get_double_value(get_underlying_statement(), index);
+        }
+        case StorageType::Text: {
+            return get_unowned_string_value(get_underlying_statement(), index);
+        }
+        case StorageType::Blob: {
+            return get_unowned_blob_value(get_underlying_statement(), index);
+        }
+        case StorageType::Null: {
+            return Null();
+        }
+    }
+}
+
+bool PreparedStatement::execute(std::error_code& error) const noexcept {
+    if (error) {
+        return false;
+    }
+    const int status = sqlite3_step(get_underlying_statement());
+    if (status == SQLITE_DONE) {
+        return true;
+    } else {
+        return process_sqlite_status(status, error);
+    }
+}
+
+} // namespace sqlite
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/kvstore/statement.hpp
+++ b/backends/apple/coreml/runtime/kvstore/statement.hpp
@@ -1,0 +1,197 @@
+//
+// database.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <string>
+#include <system_error>
+#include <sqlite3.h>
+
+#include <types.hpp>
+
+namespace executorchcoreml {
+namespace sqlite {
+
+/// The deleter for a sqlite statement, finalizes the statement at the time of deallocation.
+struct StatementDeleter {
+    inline void operator()(sqlite3_stmt* stmt) {
+        if (stmt) {
+            sqlite3_finalize(stmt);
+        }
+    }
+};
+
+/// A class representing a compiled sqlite statement.
+class PreparedStatement {
+public:
+    virtual ~PreparedStatement() = default;
+    
+    explicit PreparedStatement(std::unique_ptr<sqlite3_stmt, StatementDeleter> preparedStatement) noexcept;
+    
+    PreparedStatement(PreparedStatement const&) = delete;
+    PreparedStatement& operator=(PreparedStatement const&) = delete;
+    
+    /// Binds an int64_t value to a parameter at the specified index.
+    ///
+    /// @param index The column index.
+    /// @param value   The column value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool bind(size_t index, int64_t value, std::error_code& error) const noexcept;
+    
+    /// Binds an int64_t value to a parameter with the specified name.
+    ///
+    /// @param name The column name.
+    /// @param value   The column value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool bind_name(const std::string& name, int64_t value, std::error_code& error) const noexcept;
+    
+    /// Binds a double value to a parameter at the specified index.
+    ///
+    /// @param index The column index.
+    /// @param value   The column value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool bind(size_t index, double value, std::error_code& error) const noexcept;
+    
+    /// Binds a double value to a parameter with the specified name.
+    ///
+    /// @param name The column name.
+    /// @param value   The column value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool bind_name(const std::string& name, double value, std::error_code& error) const noexcept;
+    
+    /// Binds a string value to a parameter at the specified index.
+    ///
+    /// @param index The column index.
+    /// @param value   The column value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool bind(size_t index, UnOwnedString value, std::error_code& error) const noexcept;
+    
+    /// Binds a string value to a parameter at the specified index without copying.
+    ///
+    /// @param index The column index.
+    /// @param value   The column value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool bind_no_copy(size_t index, UnOwnedString value, std::error_code& error) const noexcept;
+    
+    /// Binds a string value to a parameter with the specified name.
+    ///
+    /// @param name The column name.
+    /// @param value   The column value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool bind_name(const std::string& name, UnOwnedString value, std::error_code& error) const noexcept;
+    
+    /// Binds a string value to a parameter with the specified name without copying.
+    ///
+    /// @param name The column name.
+    /// @param value   The column value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool bind_name_no_copy(const std::string& name, UnOwnedString value, std::error_code& error) const noexcept;
+    
+    /// Binds a blob value to a parameter at the specified index.
+    ///
+    /// @param index The column index.
+    /// @param value   The column value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool bind(size_t index, const UnOwnedBlob& value, std::error_code& error) const noexcept;
+    
+    /// Binds a blob value to a parameter at the specified index without copying.
+    ///
+    /// @param index The column index.
+    /// @param value   The column value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool bind_no_copy(size_t index, const UnOwnedBlob& value, std::error_code& error) const noexcept;
+    
+    /// Binds a blob value to a parameter with the specified name.
+    ///
+    /// @param name The column name.
+    /// @param value   The column value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool bind_name(const std::string& name, const UnOwnedBlob& value, std::error_code& error) const noexcept;
+    
+    /// Binds a blob value to a parameter with the specified name without copying.
+    ///
+    /// @param name The column name.
+    /// @param value   The column value.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool bind_name_no_copy(const std::string& name, const UnOwnedBlob& value, std::error_code& error) const noexcept;
+    
+    /// Resets the statement. The statement can be used again after calling this method but the column values needs to be rebound.
+    ///
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the value was bound otherwise `false`.
+    bool reset(std::error_code& error) const noexcept;
+    
+    /// Returns the underlying sqlite statement.
+    inline sqlite3_stmt *get_underlying_statement() const noexcept {
+        return prepared_statement_.get();
+    }
+    
+    /// Returns the column storage type.
+    inline StorageType get_column_storage_type(size_t index) noexcept {
+        return get_column_storage_types()[index];
+    }
+    
+    /// Returns the column value at the specified index.
+    ///
+    /// @param index The column index.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval The column value at the specified index.
+    Value get_column_value(size_t index, std::error_code& error) noexcept;
+    
+    /// Returns the column value without copy at the specified index. It's the caller's responsibility to copy the value.
+    ///
+    /// @param index The column index.
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval The column value at the specified index.
+    UnOwnedValue get_column_value_no_copy(size_t index, std::error_code& error) noexcept;
+    
+    /// Returns the column storage types.
+    const std::vector<StorageType>& get_column_storage_types() noexcept;
+    
+    /// Returns the column count.
+    inline size_t get_column_count() const noexcept {
+        return column_count_;
+    }
+    
+    /// Returns the column names.
+    inline const std::vector<std::string>& get_column_names() const noexcept {
+        return column_names_;
+    }
+    
+    /// Executes the statement.
+    ///
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if the statement executed successfully `false`.
+    bool execute(std::error_code& error) const noexcept;
+    
+    /// Retrieves next row.
+    ///
+    /// @param error   On failure, error is populated with the failure reason.
+    /// @retval `true` if there is a next row to step to otherwise false.
+    bool step(std::error_code& error) const noexcept;
+    
+private:
+    size_t column_count_;
+    std::vector<std::string> column_names_;
+    std::vector<StorageType> column_storage_types_;
+    std::unique_ptr<sqlite3_stmt, StatementDeleter> prepared_statement_;
+};
+
+} // namespace sqlite
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/kvstore/types.hpp
+++ b/backends/apple/coreml/runtime/kvstore/types.hpp
@@ -1,0 +1,101 @@
+//
+// types.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <string>
+#include <system_error>
+#include <variant>
+#include <vector>
+
+namespace executorchcoreml {
+namespace sqlite {
+
+struct Null {};
+
+struct UnOwnedBlob {
+    inline explicit UnOwnedBlob(const void *data, size_t size)
+    :data(data), size(size)
+    {}
+    
+    const void *data;
+    size_t size;
+};
+
+struct UnOwnedString {
+    inline UnOwnedString(const char *data, size_t size)
+    :data(data), size(size)
+    {}
+    
+    inline UnOwnedString(const std::string& string)
+    :data(string.c_str()), size(string.size())
+    {}
+    
+    inline bool empty() const noexcept {
+        return size == 0;
+    }
+    
+    inline std::string toString() const noexcept {
+        return std::string(data);
+    }
+    
+    const char *data;
+    size_t size;
+};
+
+struct Blob {
+    static inline void *copy_data(const void *data, size_t size) {
+        void *result = ::operator new(size);
+        std::memcpy(result, data, size);
+        return result;
+    }
+    
+    inline Blob(const void *data, size_t size)
+    :data(copy_data(data, size)), size(size)
+    {}
+    
+    Blob(Blob const&) noexcept = delete;
+    Blob& operator=(Blob const&) noexcept = delete;
+    
+    inline Blob(Blob&& other) noexcept
+    :data(std::exchange(other.data, nullptr)),
+    size(std::exchange(other.size, 0))
+    {}
+    
+    inline Blob& operator=(Blob&& other) noexcept {
+        std::swap(data, other.data);
+        std::swap(size, other.size);
+        return *this;
+    }
+    
+    inline ~Blob() {
+        if (data) {
+            ::operator delete(data);
+        }
+    }
+    
+    inline UnOwnedBlob toUnOwned() const noexcept {
+        return UnOwnedBlob(data, size);
+    }
+    
+    void *data = nullptr;
+    size_t size = 0;
+};
+
+enum class StorageType: uint8_t {
+    Null,
+    Blob,
+    Text,
+    Double,
+    Integer
+};
+
+using Value = std::variant<int64_t, double, std::string, Blob, Null>;
+using UnOwnedValue = std::variant<int64_t, double, UnOwnedString, UnOwnedBlob, Null>;
+
+} // namespace sqlite
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/test/BackendDelegateTests.mm
+++ b/backends/apple/coreml/runtime/test/BackendDelegateTests.mm
@@ -1,0 +1,231 @@
+//
+// BackendDelegateTests.m
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <XCTest/XCTest.h>
+
+#import <CoreML/CoreML.h>
+
+#import <backend_delegate.h>
+#import <coreml_backend/delegate.h>
+#import <multiarray.h>
+
+#import <ETCoreMLModel.h>
+#import <ETCoreMLStrings.h>
+
+#import "ETCoreMLTestUtils.h"
+
+using namespace executorchcoreml;
+
+namespace {
+template<typename T>
+T toValue(NSNumber *value);
+
+template<>
+size_t toValue(NSNumber *value) {
+    return value.unsignedLongLongValue;
+}
+
+template<>
+ssize_t toValue(NSNumber *value) {
+    return value.longLongValue;
+}
+
+template<typename T>
+std::vector<T> toVector(NSArray<NSNumber *> *values) {
+    std::vector<T> result;
+    result.reserve(values.count);
+    for (NSNumber *value in values) {
+        result.emplace_back(toValue<T>(value));
+    }
+    
+    return result;
+}
+
+MultiArray::DataType toDataType(MLMultiArrayDataType dataType) {
+    switch (dataType) {
+        case MLMultiArrayDataTypeFloat: {
+            return MultiArray::DataType::Float;
+        }
+        case MLMultiArrayDataTypeFloat16: {
+            return MultiArray::DataType::Float16;
+        }
+        case MLMultiArrayDataTypeDouble: {
+            return MultiArray::DataType::Double;
+        }
+        case MLMultiArrayDataTypeInt32: {
+            return MultiArray::DataType::Int;
+        }
+    }
+}
+
+MultiArray toMultiArray(MLMultiArray *mlMultiArray) {
+    auto shape = toVector<size_t>(mlMultiArray.shape);
+    auto strides = toVector<ssize_t>(mlMultiArray.strides);
+    auto layout = MultiArray::MemoryLayout(toDataType(mlMultiArray.dataType), std::move(shape), std::move(strides));
+    __block void *bytes = nullptr;
+    [mlMultiArray getMutableBytesWithHandler:^(void *mutableBytes, __unused NSInteger size, __unused NSArray<NSNumber *> *strides) {
+        bytes = mutableBytes;
+    }];
+    
+    return MultiArray(bytes, std::move(layout));
+}
+
+std::vector<MultiArray> toMultiArrays(NSArray<MLMultiArray *> *mlMultiArrays) {
+    std::vector<MultiArray> result;
+    result.reserve(mlMultiArrays.count);
+    
+    for (MLMultiArray *mlMultiArray in mlMultiArrays) {
+        result.emplace_back(toMultiArray(mlMultiArray));
+    }
+    return result;
+}
+}
+
+@interface BackendDelegateTests : XCTestCase
+
+@end
+
+@implementation BackendDelegateTests {
+    std::shared_ptr<BackendDelegate> _delegate;
+}
+
++ (nullable NSURL *)bundledResourceWithName:(NSString *)name extension:(NSString *)extension {
+    NSBundle *bundle = [NSBundle bundleForClass:BackendDelegateTests.class];
+    return [bundle URLForResource:name withExtension:extension];
+}
+
+- (void)setUp {
+    @autoreleasepool {
+        _delegate = BackendDelegate::make(BackendDelegate::Config());
+    }
+}
+
+- (void)tearDown {
+    @autoreleasepool {
+        _delegate.reset();
+    }
+}
+
+- (void)testDelegateAvailability {
+    XCTAssertTrue(_delegate->is_available());
+}
+
+- (void)testDelegateInit {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"add_coreml_all" extension:@"bin"];
+    XCTAssertNotNil(modelURL);
+    NSData *data = [NSData dataWithContentsOfURL:modelURL];
+    BackendDelegate::Handle *handle = _delegate->init(Buffer(data.bytes, data.length), {});
+    XCTAssert(handle != nullptr);
+}
+
+- (void)testCompileSpecs {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"add_coreml_all" extension:@"bin"];
+    XCTAssertNotNil(modelURL);
+    NSData *data = [NSData dataWithContentsOfURL:modelURL];
+    std::string computeUnitsKey(ETCoreMLStrings.computeUnitsKeyName.UTF8String);
+    {
+        std::unordered_map<std::string, Buffer> compileSpecs;
+        NSData *specData = [@"cpu_only" dataUsingEncoding:NSUTF8StringEncoding];
+        compileSpecs.emplace(computeUnitsKey, Buffer(specData.bytes, specData.length));
+        BackendDelegate::Handle *handle = _delegate->init(Buffer(data.bytes, data.length), compileSpecs);
+        ETCoreMLModel *model = (__bridge ETCoreMLModel *)handle;
+        XCTAssert(model.mlModel.configuration.computeUnits == MLComputeUnitsCPUOnly);
+        _delegate->destroy(handle);
+    }
+    
+    {
+        std::unordered_map<std::string, Buffer> compileSpecs;
+        NSData *specData = [@"cpu_and_gpu" dataUsingEncoding:NSUTF8StringEncoding];
+        compileSpecs.emplace(computeUnitsKey, Buffer(specData.bytes, specData.length));
+        BackendDelegate::Handle *handle = _delegate->init(Buffer(data.bytes, data.length), compileSpecs);
+        ETCoreMLModel *model = (__bridge ETCoreMLModel *)handle;
+        XCTAssert(model.mlModel.configuration.computeUnits == MLComputeUnitsCPUAndGPU);
+        _delegate->destroy(handle);
+    }
+    
+    {
+        std::unordered_map<std::string, Buffer> compileSpecs;
+        NSData *specData = [@"cpu_and_ane" dataUsingEncoding:NSUTF8StringEncoding];
+        compileSpecs.emplace(computeUnitsKey, Buffer(specData.bytes, specData.length));
+        BackendDelegate::Handle *handle = _delegate->init(Buffer(data.bytes, data.length), compileSpecs);
+        ETCoreMLModel *model = (__bridge ETCoreMLModel *)handle;
+        XCTAssert(model.mlModel.configuration.computeUnits == MLComputeUnitsCPUAndNeuralEngine);
+        _delegate->destroy(handle);
+    }
+}
+
+- (void)testDelegateDestroy {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"add_coreml_all" extension:@"bin"];
+    XCTAssertNotNil(modelURL);
+    NSData *data = [NSData dataWithContentsOfURL:modelURL];
+    BackendDelegate::Handle *handle = _delegate->init(Buffer(data.bytes, data.length), {});
+    XCTAssert(handle != nullptr);
+    XCTAssertTrue(_delegate->is_valid_handle(handle));
+    _delegate->destroy(handle);
+    XCTAssertFalse(_delegate->is_valid_handle(handle));
+}
+
+- (void)testDelegateNumArgs {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"add_coreml_all" extension:@"bin"];
+    XCTAssertNotNil(modelURL);
+    NSData *data = [NSData dataWithContentsOfURL:modelURL];
+    BackendDelegate::Handle *handle = _delegate->init(Buffer(data.bytes, data.length), {});
+    ETCoreMLModel *model = (__bridge ETCoreMLModel *)handle;
+    auto pair = _delegate->get_num_arguments(handle);
+    XCTAssertEqual(model.orderedInputNames.count, pair.first);
+    XCTAssertEqual(model.orderedOutputNames.count, pair.second);
+}
+
+- (void)testAddModelExecution {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"add_coreml_all" extension:@"bin"];
+    XCTAssertNotNil(modelURL);
+    NSError *localError = nil;
+    NSData *data = [NSData dataWithContentsOfURL:modelURL];
+    BackendDelegate::Handle *handle = _delegate->init(Buffer(data.bytes, data.length), {});
+    ETCoreMLModel *model = (__bridge ETCoreMLModel *)handle;
+    int x = 20;
+    int y = 50;
+    // add_coreml_all does the following operations.
+    int z = x + y;
+    z = z + x;
+    z = z + x;
+    z = z + z;
+    
+    NSArray<MLMultiArray *> *inputs = [ETCoreMLTestUtils inputsForModel:model repeatedValues:@[@(x), @(y)] error:&localError];
+    XCTAssertNotNil(inputs);
+    MLMultiArray *output = [ETCoreMLTestUtils filledMultiArrayWithShape:inputs[0].shape dataType:inputs[0].dataType repeatedValue:@(0) error:&localError];
+    NSArray<MLMultiArray *> *args = [inputs arrayByAddingObject:output];
+    std::error_code errorCode;
+    XCTAssertTrue(_delegate->execute(handle, toMultiArrays(args), errorCode));
+    for (NSUInteger i = 0; i < output.count; i++) {
+        NSNumber *value = [output objectAtIndexedSubscript:i];
+        XCTAssertEqual(value.integerValue, z);
+    }
+}
+
+- (void)testMulModelExecution {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"mul_coreml_all" extension:@"bin"];
+    XCTAssertNotNil(modelURL);
+    NSError *localError = nil;
+    NSData *data = [NSData dataWithContentsOfURL:modelURL];
+    BackendDelegate::Handle *handle = _delegate->init(Buffer(data.bytes, data.length), {});
+    ETCoreMLModel *model = (__bridge ETCoreMLModel *)handle;
+    int x = 20;
+    int y = 50;
+    NSArray<MLMultiArray *> *inputs = [ETCoreMLTestUtils inputsForModel:model repeatedValues:@[@(x), @(y)] error:&localError];
+    XCTAssertNotNil(inputs);
+    MLMultiArray *output = [ETCoreMLTestUtils filledMultiArrayWithShape:inputs[0].shape dataType:inputs[0].dataType repeatedValue:@(0) error:&localError];
+    NSArray<MLMultiArray *> *args = [inputs arrayByAddingObject:output];
+    std::error_code errorCode;
+    XCTAssertTrue(_delegate->execute(handle, toMultiArrays(args), errorCode));
+    for (NSUInteger i = 0; i < output.count; i++) {
+        NSNumber *value = [output objectAtIndexedSubscript:i];
+        XCTAssertEqual(value.integerValue, x * y);
+    }
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/CoreMLBackendDelegateTests.mm
+++ b/backends/apple/coreml/runtime/test/CoreMLBackendDelegateTests.mm
@@ -1,0 +1,213 @@
+//
+// CoreMLBackendDelegateTests.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <XCTest/XCTest.h>
+
+#import <string>
+
+#import <executorch/runtime/core/data_loader.h>
+#import <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
+#import <executorch/runtime/executor/method.h>
+#import <executorch/runtime/executor/program.h>
+#import <executorch/runtime/platform/runtime.h>
+#import <executorch/util/util.h>
+
+static constexpr size_t kRuntimeMemorySize = 10 * 1024U * 1024U; // 10 MB
+
+using namespace torch::executor;
+using torch::executor::testing::TensorFactory;
+
+namespace {
+// TODO: Move the following methods to a utility class, so that it can be shared with `executor_runner.main.mm`
+NSData * _Nullable read_data(const std::string& filePath) {
+    NSURL *url = [NSURL fileURLWithPath:@(filePath.c_str())];
+    return [NSData dataWithContentsOfURL:url];
+}
+    
+class DataLoaderImpl: public DataLoader {
+public:
+    DataLoaderImpl(std::string filePath)
+    :data_(read_data(filePath))
+    {}
+    
+    Result<FreeableBuffer> Load(size_t offset, size_t size) override {
+        NSData *subdata = [data_ subdataWithRange:NSMakeRange(offset, size)];
+        return FreeableBuffer(subdata.bytes, size, nullptr);
+    }
+    
+    Result<size_t> size() const override {
+        return data_.length;
+    }
+     
+private:
+   NSData *data_;
+};
+    
+using Buffer = std::vector<uint8_t>;
+
+std::unique_ptr<Program> get_program(NSURL *url) {
+    DataLoaderImpl dataLoader(url.path.UTF8String);
+    auto program = Program::load(&dataLoader);
+    if (!program.ok()) {
+        return nullptr;
+    }
+    
+    return std::make_unique<Program>(std::move(program.get()));
+}
+    
+Result<std::string> get_method_name(Program *program) {
+    const auto method_name = program->get_method_name(0);
+    if (!method_name.ok()) {
+        return Error::InvalidProgram;
+    }
+    
+    return std::string(method_name.get());
+}
+
+Result<std::vector<Buffer>>
+get_planned_buffers(const std::string& method_name, Program *program) {
+    auto method_meta = program->method_meta(method_name.c_str());
+    if (!method_meta.ok()) {
+        return Error::InvalidProgram;
+    }
+    
+    std::vector<std::vector<uint8_t>> buffers;
+    buffers.reserve(method_meta->num_memory_planned_buffers());
+    for (size_t bufferID = 0; bufferID < method_meta->num_memory_planned_buffers(); ++bufferID) {
+        auto buffer_size = method_meta->memory_planned_buffer_size(bufferID);
+        std::vector<uint8_t> data(buffer_size.get(), 0);
+        buffers.emplace_back(std::move(data));
+    }
+    
+    return buffers;
+}
+   
+std::vector<Span<uint8_t>> to_spans(std::vector<Buffer>& buffers) {
+    std::vector<Span<uint8_t>> result;
+    result.reserve(buffers.size());
+    for (auto& buffer : buffers) {
+        result.emplace_back(buffer.data(), buffer.size());
+    }
+    
+    return result;
+}
+}
+
+@interface CoreMLBackendDelegateTests : XCTestCase
+
+@end
+
+@implementation CoreMLBackendDelegateTests
+
++ (void)setUp {
+    runtime_init();
+}
+
++ (nullable NSURL *)bundledResourceWithName:(NSString *)name extension:(NSString *)extension {
+    NSBundle *bundle = [NSBundle bundleForClass:CoreMLBackendDelegateTests.class];
+    return [bundle URLForResource:name withExtension:extension];
+}
+
+- (void)testProgramLoad {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"add_coreml_all" extension:@"pte"];
+    XCTAssertNotNil(modelURL);
+    auto program = get_program(modelURL);
+    XCTAssert(program != nullptr);
+    auto methodName = get_method_name(program.get());
+    XCTAssert(methodName.ok());
+    auto plannedBuffers = get_planned_buffers(methodName.get(), program.get());
+    XCTAssert(plannedBuffers.ok());
+    Buffer methodBuffer(kRuntimeMemorySize, 0);
+    MemoryAllocator methodAllocator(static_cast<int32_t>(methodBuffer.size()), methodBuffer.data());
+    auto spans = to_spans(plannedBuffers.get());
+    HierarchicalAllocator plannedAllocator({spans.data(), spans.size()});
+    MemoryManager memoryManger(&methodAllocator, &plannedAllocator);
+    auto method = program->load_method(methodName.get().c_str(), &memoryManger);
+    XCTAssert(method.ok());
+}
+
+- (void)executeModelAtURL:(NSURL *)modelURL nTimes:(NSUInteger)nTimes {
+    for (NSUInteger i = 0; i < nTimes; i++) {
+        auto program = get_program(modelURL);
+        XCTAssert(program != nullptr);
+        auto methodName = get_method_name(program.get());
+        XCTAssert(methodName.ok());
+        auto plannedBuffers = get_planned_buffers(methodName.get(), program.get());
+        XCTAssert(plannedBuffers.ok());
+        Buffer methodBuffer(kRuntimeMemorySize, 0);
+        MemoryAllocator methodAllocator(static_cast<int32_t>(methodBuffer.size()), methodBuffer.data());
+        auto spans = to_spans(plannedBuffers.get());
+        HierarchicalAllocator plannedAllocator({spans.data(), spans.size()});
+        MemoryManager memoryManger(&methodAllocator, &plannedAllocator);
+        auto method = program->load_method(methodName.get().c_str(), &memoryManger);
+        XCTAssert(method.ok());
+        auto inputs = util::PrepareInputTensors(method.get());
+        
+        auto status = method->execute();
+        XCTAssertEqual(status, Error::Ok);
+        auto outputs = methodAllocator.allocateList<EValue>(method->outputs_size());
+        status = method->get_outputs(outputs, method->outputs_size());
+        XCTAssertEqual(status, Error::Ok);
+        
+        util::FreeInputs(inputs);
+    }
+}
+
+- (void)testAddProgramExecute {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"add_coreml_all" extension:@"pte"];
+    XCTAssertNotNil(modelURL);
+    [self executeModelAtURL:modelURL nTimes:10];
+}
+
+- (void)testMulProgramExecute {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"mul_coreml_all" extension:@"pte"];
+    XCTAssertNotNil(modelURL);
+    [self executeModelAtURL:modelURL nTimes:10];
+}
+
+- (void)testMV3ProgramExecute {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"mv3_coreml_all" extension:@"pte"];
+    XCTAssertNotNil(modelURL);
+    [self executeModelAtURL:modelURL nTimes:10];
+}
+
+- (void)executeMultipleModelsConcurrently:(NSArray<NSURL *> *)modelURLs
+                                   nTimes:(NSUInteger)nTimes
+                                  timeout:(NSTimeInterval)timeout {
+    NSMutableArray<XCTestExpectation *> *expectations = [NSMutableArray arrayWithCapacity:modelURLs.count];
+    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    for (NSURL *modelURL in modelURLs) {
+        NSString *description = [NSString stringWithFormat:@"%@ must execute successfully", modelURL.lastPathComponent];
+        XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:description];
+        [expectations addObject:expectation];
+        dispatch_async(queue, ^{
+            [self executeModelAtURL:modelURL nTimes:nTimes];
+            [expectation fulfill];
+        });
+    }
+    
+    [self waitForExpectations:expectations timeout:timeout];
+}
+
+- (void)testMultipleModelExecutionConcurrently {
+    NSURL *modelURL1 = [[self class] bundledResourceWithName:@"add_coreml_all" extension:@"pte"];
+    NSURL *modelURL2 = [[self class] bundledResourceWithName:@"mul_coreml_all" extension:@"pte"];
+    NSURL *modelURL3 = [[self class] bundledResourceWithName:@"mv3_coreml_all" extension:@"pte"];
+    [self executeMultipleModelsConcurrently:@[modelURL1, modelURL2, modelURL3]
+                                     nTimes:10
+                                    timeout:5 * 60];
+}
+
+- (void)testSameModelExecutionConcurrently {
+    NSURL *modelURL1 = [[self class] bundledResourceWithName:@"mv3_coreml_all" extension:@"pte"];
+    NSURL *modelURL2 = [[self class] bundledResourceWithName:@"mv3_coreml_all" extension:@"pte"];
+    [self executeMultipleModelsConcurrently:@[modelURL1, modelURL2]
+                                     nTimes:10
+                                    timeout:5 * 60];
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/DatabaseTests.mm
+++ b/backends/apple/coreml/runtime/test/DatabaseTests.mm
@@ -1,0 +1,134 @@
+//
+// DatabaseTests.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <XCTest/XCTest.h>
+
+#import <database.hpp>
+#import <json.hpp>
+
+@interface DatabaseTests : XCTestCase
+
+@end
+
+@implementation DatabaseTests
+
+using namespace executorchcoreml::sqlite;
+
+- (void)testDatabaseOpen {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    XCTAssert(database != nullptr);
+}
+
+- (void)testTableCreation {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    XCTAssert(database != nullptr);
+    XCTAssertTrue(database->execute("CREATE TABLE IF NOT EXISTS TEST (id INTEGER PRIMARY KEY, value TEXT)", error));
+    XCTAssertTrue(database->table_exists("TEST", error));
+    XCTAssertTrue(database->drop_table("TEST", error));
+    XCTAssertFalse(database->table_exists("TEST", error));
+}
+
+- (void)testDatabaseExecute {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    XCTAssert(database != nullptr);
+    XCTAssertTrue(database->execute("CREATE TABLE IF NOT EXISTS TEST (key TEXT PRIMARY KEY, value TEXT)", error));
+    auto insertStatement = database->prepare_statement("INSERT INTO TEST (key, value) VALUES ($key, $value)", error);
+    XCTAssertTrue(insertStatement != nullptr);
+    XCTAssertTrue(insertStatement->bind_name("$key", std::string("1"), error));
+    XCTAssertTrue(insertStatement->bind_name("$value", std::string("1"), error));
+    XCTAssertTrue(insertStatement->execute(error));
+    XCTAssertTrue(database->get_row_count("TEST", error) == 1);
+}
+
+- (void)testDatabaseQuery {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    XCTAssert(database != nullptr);
+    XCTAssertTrue(database->execute("CREATE TABLE IF NOT EXISTS TEST (key TEXT PRIMARY KEY, value TEXT)", error));
+    auto insertStatement = database->prepare_statement("INSERT INTO TEST (key, value) VALUES ($key, $value)", error);
+    XCTAssertTrue(insertStatement != nullptr);
+    XCTAssertTrue(insertStatement->bind_name("$key", std::string("1"), error));
+    XCTAssertTrue(insertStatement->bind_name("$value", std::string("1"), error));
+    XCTAssertTrue(insertStatement->execute(error));
+    XCTAssertTrue(database->get_row_count("TEST", error) == 1);
+    
+    auto query = database->prepare_statement("SELECT * FROM TEST", error);
+    XCTAssertTrue(query != nullptr);
+    XCTAssertTrue(query->step(error));
+    auto key = query->get_column_value_no_copy(0, error);
+    XCTAssertFalse(std::get<UnOwnedString>(key).empty());
+    auto value = query->get_column_value_no_copy(1, error);
+    XCTAssertFalse(std::get<UnOwnedString>(value).empty());
+    XCTAssertFalse(query->step(error));
+}
+
+- (void)testDatabaseTransactionCommit {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    XCTAssert(database != nullptr);
+    XCTAssertTrue(database->execute("CREATE TABLE IF NOT EXISTS TEST (key TEXT PRIMARY KEY, value TEXT)", error));
+    // Insert a row inside a transaction.
+    XCTAssertTrue(database->transaction([database = database.get()]() {
+        std::error_code transactionError;
+        auto insertStatement = database->prepare_statement("INSERT INTO TEST (key, value) VALUES ($key, $value)", transactionError);
+        XCTAssertTrue(insertStatement != nullptr);
+        XCTAssertTrue(insertStatement->bind_name("$key", std::string("1"), transactionError));
+        XCTAssertTrue(insertStatement->bind_name("$value", std::string("1"), transactionError));
+        XCTAssertTrue(insertStatement->execute(transactionError));
+        XCTAssertTrue(database->get_row_count("TEST", transactionError) == 1);
+        // Returns true to commit the transaction.
+        return true;
+    }, Database::TransactionBehavior::Immediate, error));
+    // The row must exist because the transaction was committed.
+    XCTAssertTrue(database->get_row_count("TEST", error) == 1);
+}
+
+- (void)testDatabaseTransactionRollback {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    XCTAssert(database != nullptr);
+    XCTAssertTrue(database->execute("CREATE TABLE IF NOT EXISTS TEST (key TEXT PRIMARY KEY, value TEXT)", error));
+    // Insert a row inside a transaction.
+    XCTAssertFalse(database->transaction([database = database.get()]() {
+        std::error_code transactionError;
+        auto insertStatement = database->prepare_statement("INSERT INTO TEST (key, value) VALUES ($key, $value)", transactionError);
+        XCTAssertTrue(insertStatement != nullptr);
+        XCTAssertTrue(insertStatement->bind_name("$key", std::string("1"), transactionError));
+        XCTAssertTrue(insertStatement->bind_name("$value", std::string("1"), transactionError));
+        XCTAssertTrue(insertStatement->execute(transactionError));
+        XCTAssertTrue(database->get_row_count("TEST", transactionError) == 1);
+        // Returns false to rollback the transaction.
+        return false;
+    }, Database::TransactionBehavior::Immediate, error));
+    // The row must exist because the transaction was rollbacked.
+    XCTAssertTrue(database->get_row_count("TEST", error) == 0);
+}
+
+- (void)testDatabaseLastError {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    XCTAssert(database != nullptr);
+    XCTAssertTrue(database->execute("CREATE TABLE IF NOT EXISTS TEST (key TEXT PRIMARY KEY, value TEXT)", error));
+    auto insertStatement = database->prepare_statement("INSERT INTO TEST (key, value) VALUES ($key, $value)", error);
+    XCTAssertTrue(insertStatement->bind_name("$key", std::string("1"), error));
+    XCTAssertTrue(insertStatement->bind_name("$value", std::string("1"), error));
+    XCTAssertTrue(insertStatement->execute(error));
+    // Reset the insert statement.
+    XCTAssertTrue(insertStatement->reset(error));
+    // Insert the same key, this is a constraint violation.
+    XCTAssertTrue(insertStatement->bind_name("$key", std::string("1"), error));
+    XCTAssertTrue(insertStatement->bind_name("$value", std::string("1"), error));
+    XCTAssertFalse(insertStatement->execute(error));
+    XCTAssertEqual(database->get_last_error_code().value(), SQLITE_CONSTRAINT);
+    XCTAssertEqual(database->get_last_extended_error_code().value(), SQLITE_CONSTRAINT_PRIMARYKEY);
+    XCTAssertFalse(database->get_last_error_message().empty());
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/ETCoreMLAssetManagerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLAssetManagerTests.mm
@@ -1,0 +1,151 @@
+//
+// ETCoreMLAssetManagerTests.mm
+//
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <XCTest/XCTest.h>
+
+#import <ETCoreMLAsset.h>
+#import <ETCoreMLAssetManager.h>
+
+#import "ETCoreMLTestUtils.h"
+
+@interface ETCoreMLAssetManagerTests : XCTestCase
+
+@property (strong, nonatomic, nullable) ETCoreMLAssetManager *assetManager;
+@property (strong, nonatomic, nullable) NSFileManager *fileManager;
+@property (copy, nonatomic) NSURL *testDirectoryURL;
+
+@end
+
+@implementation ETCoreMLAssetManagerTests
+
+- (void)setUp {
+    @autoreleasepool {
+        NSError *localError = nil;
+        self.fileManager = [[NSFileManager alloc] init];
+        self.testDirectoryURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:[NSUUID UUID].UUIDString]];
+        self.assetManager = [ETCoreMLTestUtils createAssetManagerWithURL:self.testDirectoryURL error:&localError];
+        XCTAssertNotNil(self.assetManager);
+    }
+}
+
+- (void)tearDown {
+    @autoreleasepool {
+        NSError *localError = nil;
+        self.assetManager = nil;
+        [self.fileManager removeItemAtURL:self.testDirectoryURL error:&localError];
+        self.fileManager = nil;
+    }
+}
+
+- (void)testAssetManagerCreation {
+    XCTAssertNotNil(self.assetManager);
+}
+
+- (void)testPutAsset {
+    NSUInteger n = 5;
+    NSError *localError = nil;
+    for (NSUInteger i = 0; i < n; i++) {
+        NSString *identifier = [NSUUID UUID].UUIDString;
+        NSURL *assetURL = [ETCoreMLTestUtils createUniqueAssetInDirectoryAtURL:self.testDirectoryURL withContent:@"testing" fileManager:self.fileManager error:&localError];
+        XCTAssertNotNil(assetURL);
+        XCTAssertTrue([self.assetManager storeAssetAtURL:assetURL withIdentifier:identifier error:&localError]);
+        XCTAssertTrue([self.assetManager hasAssetWithIdentifier:identifier error:&localError]);
+    }
+}
+
+- (void)testGetAsset {
+    NSUInteger n = 5;
+    NSError *localError = nil;
+    for (NSUInteger i = 0; i < n; i++) {
+        NSString *identifier = [NSUUID UUID].UUIDString;
+        NSURL *assetURL = [ETCoreMLTestUtils createUniqueAssetInDirectoryAtURL:self.testDirectoryURL withContent:@"testing" fileManager:self.fileManager error:&localError];
+        XCTAssertNotNil(assetURL);
+        XCTAssertTrue([self.assetManager storeAssetAtURL:assetURL withIdentifier:identifier error:&localError]);
+        XCTAssertTrue([[self.assetManager assetWithIdentifier:identifier error:&localError].identifier isEqualToString:identifier]);
+    }
+}
+
+- (void)testRemoveAsset {
+    NSUInteger n = 5;
+    NSError *localError = nil;
+    NSMutableArray<NSString *> *identifiers = [NSMutableArray arrayWithCapacity:n];
+    @autoreleasepool {
+        for (NSUInteger i = 0; i < n; i++) {
+            NSString *identifier = [NSUUID UUID].UUIDString;
+            NSURL *assetURL = [ETCoreMLTestUtils createUniqueAssetInDirectoryAtURL:self.testDirectoryURL withContent:@"testing" fileManager:self.fileManager error:&localError];
+            XCTAssertNotNil(assetURL);
+            ETCoreMLAsset *asset = [self.assetManager storeAssetAtURL:assetURL withIdentifier:identifier error:&localError];
+            (void)asset;
+            // The asset is alive, it must not be removed.
+            XCTAssertFalse([self.assetManager removeAssetWithIdentifier:identifier error:&localError]);
+            [identifiers addObject:identifier];
+        }
+    }
+    
+    // The asset will only be removed if it's not in use.
+    for (NSString *identifier in identifiers) {
+        XCTAssertTrue([self.assetManager hasAssetWithIdentifier:identifier error:&localError]);
+        XCTAssertTrue([self.assetManager removeAssetWithIdentifier:identifier error:&localError]);
+        XCTAssertFalse([self.assetManager hasAssetWithIdentifier:identifier error:&localError]);
+    }
+}
+
+- (void)testEstimatedSizeInBytes {
+    NSUInteger n = 5;
+    NSError *localError = nil;
+    for (NSUInteger i = 0; i < n; i++) {
+        NSString *identifier = [NSUUID UUID].UUIDString;
+        NSURL *assetURL = [ETCoreMLTestUtils createUniqueAssetInDirectoryAtURL:self.testDirectoryURL withContent:@"testing" fileManager:self.fileManager error:&localError];
+        XCTAssertNotNil(assetURL);
+        XCTAssertNotNil([self.assetManager storeAssetAtURL:assetURL withIdentifier:identifier error:&localError]);
+        XCTAssertTrue(self.assetManager.estimatedSizeInBytes > 0);
+    }
+
+    for (NSUInteger i = 0; i < n; i++) {
+        NSString *identifier = [NSUUID UUID].UUIDString;
+        NSURL *assetURL = [ETCoreMLTestUtils createUniqueAssetInDirectoryAtURL:self.testDirectoryURL withContent:@"testing" fileManager:self.fileManager error:&localError];
+        XCTAssertNotNil(assetURL);
+        NSInteger oldSize = self.assetManager.estimatedSizeInBytes;
+        ETCoreMLAsset *asset = [self.assetManager storeAssetAtURL:assetURL withIdentifier:identifier error:&localError];
+        NSInteger newSize = asset.totalSizeInBytes + oldSize;
+        XCTAssertEqual(newSize, self.assetManager.estimatedSizeInBytes);
+        [asset close];
+        XCTAssertTrue([self.assetManager removeAssetWithIdentifier:identifier error:&localError]);
+        XCTAssertEqual(oldSize, self.assetManager.estimatedSizeInBytes);
+    }
+}
+
+- (void)testCompaction {
+    NSUInteger n = 5;
+    NSError *localError = nil;
+    for (NSUInteger i = 0; i < n; i++) {
+        NSString *identifier = [NSUUID UUID].UUIDString;
+        NSURL *assetURL = [ETCoreMLTestUtils createUniqueAssetInDirectoryAtURL:self.testDirectoryURL withContent:@"testing" fileManager:self.fileManager error:&localError];
+        XCTAssertNotNil(assetURL);
+        ETCoreMLAsset *asset = [self.assetManager storeAssetAtURL:assetURL withIdentifier:identifier error:&localError];
+        // Close the asset so that it could be deleted.
+        [asset close];
+    }
+    XCTAssertEqual([self.assetManager compact:100 error:&localError], 0);
+}
+
+- (void)testPurge {
+    NSUInteger n = 5;
+    NSError *localError = nil;
+    for (NSUInteger i = 0; i < n; i++) {
+        NSString *identifier = [NSUUID UUID].UUIDString;
+        NSURL *assetURL = [ETCoreMLTestUtils createUniqueAssetInDirectoryAtURL:self.testDirectoryURL withContent:@"testing" fileManager:self.fileManager error:&localError];
+        XCTAssertNotNil(assetURL);
+        ETCoreMLAsset *asset = [self.assetManager storeAssetAtURL:assetURL withIdentifier:identifier error:&localError];
+        // Close the asset so that it could be deleted.
+        [asset close];
+    }
+    XCTAssertTrue([self.assetManager purge:&localError]);
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/ETCoreMLAssetTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLAssetTests.mm
@@ -1,0 +1,129 @@
+//
+// ETCoreMLAssetTests.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <XCTest/XCTest.h>
+
+#import <ETCoreMLAsset.h>
+
+@interface ETCoreMLAssetTests : XCTestCase
+
+@property (copy, nonatomic, nullable) NSURL *assetURL;
+@property (strong, nonatomic, nullable) NSFileManager *fileManager;
+
+@end
+
+@implementation ETCoreMLAssetTests
+
+using namespace executorchcoreml;
+
+- (void)setUp {
+    NSURL *assetURL = [[NSURL fileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    NSError *localError = nil;
+    XCTAssertTrue([fileManager createDirectoryAtURL:assetURL withIntermediateDirectories:NO attributes:@{} error:&localError]);
+    // Write dir1
+    {
+        NSURL *dirURL = [assetURL URLByAppendingPathComponent:@"dir1"];
+        XCTAssertTrue([fileManager createDirectoryAtURL:dirURL withIntermediateDirectories:NO attributes:@{} error:&localError]);
+        NSURL *fileURL = [dirURL URLByAppendingPathComponent:@"content.txt"];
+        NSString *testData = @"data1";
+        NSData* data = [testData dataUsingEncoding:NSUTF8StringEncoding];
+        XCTAssertTrue([data writeToURL:fileURL atomically:YES]);
+    }
+    // Write dir2
+    {
+        NSURL *dirURL = [assetURL URLByAppendingPathComponent:@"dir2"];
+        XCTAssertTrue([fileManager createDirectoryAtURL:dirURL withIntermediateDirectories:NO attributes:@{} error:&localError]);
+        NSURL *fileURL = [dirURL URLByAppendingPathComponent:@"content.txt"];
+        NSString *testData = @"data2";
+        NSData* data = [testData dataUsingEncoding:NSUTF8StringEncoding];
+        XCTAssertTrue([data writeToURL:fileURL atomically:YES]);
+    }
+    
+    self.assetURL = assetURL;
+    self.fileManager = fileManager;
+}
+
+- (void)tearDown {
+    NSError *localError = nil;
+    XCTAssertTrue([self.fileManager removeItemAtURL:self.assetURL error:&localError]);
+    self.assetURL = nil;
+    self.fileManager = nil;
+}
+
+- (void)testAssetCreation {
+    NSString *identifier = [NSUUID UUID].UUIDString;
+    NSError *localError = nil;
+    auto backingAsset = Asset::make(self.assetURL, identifier, self.fileManager, &localError);
+    XCTAssertTrue(backingAsset.has_value());
+    const auto& packageInfo = backingAsset.value().package_info;
+    XCTAssertEqual(packageInfo.file_infos.size(), 2);
+    const auto& fileInfos = packageInfo.file_infos;
+    XCTAssert(std::find_if(fileInfos.begin(), fileInfos.end(), [](const auto& fileInfo) {
+        return fileInfo.relative_path == "dir1/content.txt";
+    }) != packageInfo.file_infos.end());
+    
+    XCTAssert(std::find_if(fileInfos.begin(), fileInfos.end(), [](const auto& fileInfo) {
+        return fileInfo.relative_path == "dir2/content.txt";
+    }) != packageInfo.file_infos.end());
+
+    ETCoreMLAsset *asset = [[ETCoreMLAsset alloc] initWithBackingAsset:backingAsset.value()];
+    XCTAssertTrue([asset.identifier isEqualToString:identifier]);
+}
+
+- (void)testAssetValidity {
+    NSString *identifier = [NSUUID UUID].UUIDString;
+    NSError *localError = nil;
+    auto backingAsset = Asset::make(self.assetURL, identifier, self.fileManager, &localError);
+    const auto& backingAssetValue = backingAsset.value();
+    {
+        ETCoreMLAsset *asset = [[ETCoreMLAsset alloc] initWithBackingAsset:backingAsset.value()];
+        XCTAssertTrue(asset.isValid);
+    }
+    {
+        const auto& packageInfo = backingAssetValue.package_info;
+        const auto& fileInfos = packageInfo.file_infos;
+        NSURL *dirURL = [NSURL fileURLWithPath:@(backingAssetValue.path.c_str())];
+        NSURL *fileURL = [dirURL URLByAppendingPathComponent:@(fileInfos[0].relative_path.c_str())];
+        // Delete a file, asset must not be valid.
+        XCTAssert([self.fileManager removeItemAtURL:fileURL error:&localError]);
+        ETCoreMLAsset *asset = [[ETCoreMLAsset alloc] initWithBackingAsset:backingAsset.value()];
+        XCTAssertFalse(asset.isValid);
+    }
+}
+
+- (void)testKeepAlive {
+    NSString *identifier = [NSUUID UUID].UUIDString;
+    NSError *localError = nil;
+    auto backingAsset = Asset::make(self.assetURL, identifier, self.fileManager, &localError);
+    XCTAssertTrue(backingAsset.has_value());
+    ETCoreMLAsset *asset = [[ETCoreMLAsset alloc] initWithBackingAsset:backingAsset.value()];
+    XCTAssertTrue([asset keepAliveAndReturnError:&localError]);
+}
+
+- (void)testPewarm {
+    NSString *identifier = [NSUUID UUID].UUIDString;
+    NSError *localError = nil;
+    auto backingAsset = Asset::make(self.assetURL, identifier, self.fileManager, &localError);
+    XCTAssertTrue(backingAsset.has_value());
+    ETCoreMLAsset *asset = [[ETCoreMLAsset alloc] initWithBackingAsset:backingAsset.value()];
+    XCTAssertTrue([asset prewarmAndReturnError:&localError]);
+}
+
+- (void)testClose {
+    NSString *identifier = [NSUUID UUID].UUIDString;
+    NSError *localError = nil;
+    auto backingAsset = Asset::make(self.assetURL, identifier, self.fileManager, &localError);
+    XCTAssertTrue(backingAsset.has_value());
+    ETCoreMLAsset *asset = [[ETCoreMLAsset alloc] initWithBackingAsset:backingAsset.value()];
+    XCTAssertTrue([asset keepAliveAndReturnError:&localError]);
+    XCTAssertTrue(asset.isAlive);
+    [asset close];
+    XCTAssertFalse(asset.isAlive);
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/ETCoreMLModelManagerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLModelManagerTests.mm
@@ -1,0 +1,146 @@
+//
+// ETCoreMLModelManagerTests.m
+//
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <XCTest/XCTest.h>
+
+#import <ETCoreMLModelManager.h>
+
+#import <ETCoreMLAsset.h>
+#import <ETCoreMLAssetManager.h>
+#import <ETCoreMLModel.h>
+#import <MLModel_Prewarm.h>
+
+#import "ETCoreMLTestUtils.h"
+
+@interface ETCoreMLModelManagerTests : XCTestCase
+
+@property (strong, nonatomic, nullable) ETCoreMLModelManager *modelManager;
+@property (strong, nonatomic, nullable) NSFileManager *fileManager;
+@property (copy, nonatomic) NSURL *testDirectoryURL;
+
+@end
+
+@implementation ETCoreMLModelManagerTests
+
++ (nullable NSURL *)bundledResourceWithName:(NSString *)name extension:(NSString *)extension {
+    NSBundle *bundle = [NSBundle bundleForClass:ETCoreMLModelManagerTests.class];
+    return [bundle URLForResource:name withExtension:extension];
+}
+
+- (void)setUp {
+    @autoreleasepool {
+        NSError *localError = nil;
+        self.fileManager = [[NSFileManager alloc] init];
+        self.testDirectoryURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:[NSUUID UUID].UUIDString]];
+        [self.fileManager removeItemAtURL:self.testDirectoryURL error:&localError];
+        ETCoreMLAssetManager *assetManager = [ETCoreMLTestUtils createAssetManagerWithURL:self.testDirectoryURL error:&localError];
+        XCTAssertNotNil(assetManager);
+        self.modelManager = [[ETCoreMLModelManager alloc] initWithAssetManager:assetManager];
+    }
+}
+
+- (void)tearDown {
+    @autoreleasepool {
+        NSError *localError = nil;
+        self.modelManager = nil;
+        XCTAssertTrue([self.fileManager removeItemAtURL:self.testDirectoryURL error:&localError]);
+        self.fileManager = nil;
+    }
+}
+
+- (void)testModelLoadAndUnload {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"add_coreml_all" extension:@"bin"];
+    NSError *localError = nil;
+    XCTAssertNotNil(modelURL);
+    NSData *data = [NSData dataWithContentsOfURL:modelURL];
+    MLModelConfiguration *configuration = [[MLModelConfiguration alloc] init];
+    configuration.computeUnits = MLComputeUnitsAll;
+    ModelHandle *handle = [self.modelManager loadModelFromAOTData:data configuration:configuration error:&localError];
+    XCTAssertTrue([self.modelManager unloadModelWithHandle:handle]);
+    XCTAssertFalse([self.modelManager unloadModelWithHandle:handle]);
+}
+
+- (void)testModelHandle {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"add_coreml_all" extension:@"bin"];
+    NSError *localError = nil;
+    XCTAssertNotNil(modelURL);
+    NSData *data = [NSData dataWithContentsOfURL:modelURL];
+    MLModelConfiguration *configuration = [[MLModelConfiguration alloc] init];
+    configuration.computeUnits = MLComputeUnitsAll;
+    ModelHandle *handle = [self.modelManager loadModelFromAOTData:data configuration:configuration error:&localError];
+    ETCoreMLModel *model = [self.modelManager modelWithHandle:handle];
+    XCTAssertNotNil(model.mlModel);
+    XCTAssertTrue(model.identifier.length > 0);
+    XCTAssertEqual(model.orderedInputNames.count, 2);
+    XCTAssertEqual(model.orderedOutputNames.count, 1);
+}
+
+- (void)testModelPrewarm {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"add_coreml_all" extension:@"bin"];
+    NSError *localError = nil;
+    XCTAssertNotNil(modelURL);
+    NSData *data = [NSData dataWithContentsOfURL:modelURL];
+    MLModelConfiguration *configuration = [[MLModelConfiguration alloc] init];
+    configuration.computeUnits = MLComputeUnitsAll;
+    ModelHandle *handle = [self.modelManager loadModelFromAOTData:data configuration:configuration error:&localError];
+    XCTAssertTrue([self.modelManager prewarmModelWithHandle:handle error:&localError]);
+}
+
+- (void)testAddModelExecution {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"add_coreml_all" extension:@"bin"];
+    XCTAssertNotNil(modelURL);
+    
+    NSError *localError = nil;
+    NSData *data = [NSData dataWithContentsOfURL:modelURL];
+    MLModelConfiguration *configuration = [[MLModelConfiguration alloc] init];
+    configuration.computeUnits = MLComputeUnitsAll;
+    ModelHandle *handle = [self.modelManager loadModelFromAOTData:data configuration:configuration error:&localError];
+    ETCoreMLModel *model = [self.modelManager modelWithHandle:handle];
+    int x = 20;
+    int y = 50;
+    // add_coreml_all does the following operations.
+    int z = x + y;
+    z = z + x;
+    z = z + x;
+    z = z + z;
+    
+    NSArray<MLMultiArray *> *inputs = [ETCoreMLTestUtils inputsForModel:model repeatedValues:@[@(x), @(y)] error:&localError];
+    XCTAssertNotNil(inputs);
+    MLMultiArray *output = [ETCoreMLTestUtils filledMultiArrayWithShape:inputs[0].shape dataType:inputs[0].dataType repeatedValue:@(0) error:&localError];
+    NSArray<MLMultiArray *> *args = [inputs arrayByAddingObject:output];
+    XCTAssertTrue([self.modelManager executeModelWithHandle:handle args:args error:&localError]);
+    for (NSUInteger i = 0; i < output.count; i++) {
+        NSNumber *value = [output objectAtIndexedSubscript:i];
+        XCTAssertEqual(value.integerValue, z);
+    }
+}
+
+- (void)testMulModelExecution {
+    NSURL *modelURL = [[self class] bundledResourceWithName:@"mul_coreml_all" extension:@"bin"];
+    XCTAssertNotNil(modelURL);
+    
+    NSError *localError = nil;
+    NSData *data = [NSData dataWithContentsOfURL:modelURL];
+    MLModelConfiguration *configuration = [[MLModelConfiguration alloc] init];
+    configuration.computeUnits = MLComputeUnitsAll;
+    ModelHandle *handle = [self.modelManager loadModelFromAOTData:data configuration:configuration error:&localError];
+    ETCoreMLModel *model = [self.modelManager modelWithHandle:handle];
+    int x = 20;
+    int y = 50;
+    NSArray<MLMultiArray *> *inputs = [ETCoreMLTestUtils inputsForModel:model repeatedValues:@[@(x), @(y)] error:&localError];
+    XCTAssertNotNil(inputs);
+    MLMultiArray *output = [ETCoreMLTestUtils filledMultiArrayWithShape:inputs[0].shape dataType:inputs[0].dataType repeatedValue:@(0) error:&localError];
+    NSArray<MLMultiArray *> *args = [inputs arrayByAddingObject:output];
+    XCTAssertTrue([self.modelManager executeModelWithHandle:handle args:args error:&localError]);
+    for (NSUInteger i = 0; i < output.count; i++) {
+        NSNumber *value = [output objectAtIndexedSubscript:i];
+        XCTAssertEqual(value.integerValue, x * y);
+    }
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/ETCoreMLTestUtils.h
+++ b/backends/apple/coreml/runtime/test/ETCoreMLTestUtils.h
@@ -1,0 +1,79 @@
+//
+// ETCoreMLTestUtils.h
+//
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <CoreML/CoreML.h>
+
+#import <ETCoreMLAssetManager.h>
+#import <ETCoreMLModel.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ETCoreMLTestUtils : NSObject
+
+/// Creates a unique directory inside the specified directory.
+///
+/// The created directory contains a nested directory named 'folder' and a 'content.txt' file inside
+/// 'folder' directory with the specified content.
+///
+/// @param directoryURL The url of the directory.
+/// @param content   The content of 'content.txt' file.
+/// @param fileManager The file manager.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval The directory URL if the creation succeeded otherwise `nil`.
++ (nullable NSURL*)createUniqueAssetInDirectoryAtURL:(NSURL*)directoryURL
+                                         withContent:(NSString*)content
+                                         fileManager:(NSFileManager*)fileManager
+                                               error:(NSError* __autoreleasing*)error;
+
+
+/// Creates a `ETCoreMLAssetManager` for testing.
+///
+///
+/// @param directoryURL The url of the directory.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval An `ETCoreMLAssetManager` instance if the creation succeeded otherwise `nil`.
++ (nullable ETCoreMLAssetManager*)createAssetManagerWithURL:(NSURL*)directoryURL error:(NSError* __autoreleasing*)error;
+
+
+/// Creates a `MLMultiArray` instance with a repeated value.
+///
+/// @param constraint The MLMultiArray constraint.
+/// @param value The value to be repeated.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval A  filled `MLMultiArray` instance.
++ (nullable MLMultiArray*)filledMultiArrayWithConstraint:(MLMultiArrayConstraint*)constraint
+                                           repeatedValue:(NSNumber*)value
+                                                   error:(NSError* __autoreleasing*)error;
+
+
+/// Creates a `MLMultiArray` instance with a repeated value.
+///
+/// @param shape The MLMultiArray shape.
+/// @param dataType The MLMultiArray data type.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval A  filled `MLMultiArray` instance.
++ (nullable MLMultiArray*)filledMultiArrayWithShape:(NSArray<NSNumber*>*)shape
+                                           dataType:(MLMultiArrayDataType)dataType
+                                      repeatedValue:(NSNumber*)value
+                                              error:(NSError* __autoreleasing*)error;
+
+
+/// Creates inputs with repeated values for a `ETCoreMLModel`.
+///
+/// @param model The model.
+/// @param repeatedValues An array of values, the size of the array must be equal to the inputs
+/// count.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval Model inputs with repeated values.
++ (nullable NSArray<MLMultiArray*>*)inputsForModel:(ETCoreMLModel*)model
+                                    repeatedValues:(NSArray<NSNumber*>*)repeatedValues
+                                             error:(NSError* __autoreleasing*)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/test/ETCoreMLTestUtils.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLTestUtils.mm
@@ -1,0 +1,183 @@
+//
+// ETCoreMLTestUtils.mm
+//
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import "ETCoreMLTestUtils.h"
+
+#import <ETCoreMLAsset.h>
+
+namespace {
+NSURL * _Nullable create_directory_if_needed(NSURL *url,
+                                             NSFileManager *fm,
+                                             NSError * __autoreleasing *error) {
+    if (![fm fileExistsAtPath:url.path] && ![fm createDirectoryAtURL:url withIntermediateDirectories:YES attributes:@{} error:error]) {
+        return nil;
+    }
+    
+    return url;
+}
+
+ETCoreMLAssetManager * _Nullable create_asset_manager(NSString *assets_directory_path,
+                                                      NSString *trash_directory_path,
+                                                      NSString *database_directory_path,
+                                                      NSString *database_name,
+                                                      NSError * __autoreleasing *error) {
+    NSFileManager *fm  = [[NSFileManager alloc] init];
+    
+    NSURL *assets_directory_url = [NSURL fileURLWithPath:assets_directory_path];
+    if (!create_directory_if_needed(assets_directory_url, fm, error)) {
+        return nil;
+    }
+    
+    NSURL *trash_directory_url = [NSURL fileURLWithPath:trash_directory_path];
+    if (!create_directory_if_needed(trash_directory_url, fm, error)) {
+        return nil;
+    }
+    
+    NSURL *database_directory_url = [NSURL fileURLWithPath:database_directory_path];
+    if (!create_directory_if_needed(database_directory_url, fm, error)) {
+        return nil;
+    }
+    
+    NSURL *database_url = [database_directory_url URLByAppendingPathComponent:database_name];
+    ETCoreMLAssetManager *manager = [[ETCoreMLAssetManager alloc] initWithDatabaseURL:database_url
+                                                                   assetsDirectoryURL:assets_directory_url
+                                                                    trashDirectoryURL:trash_directory_url
+                                                                 maxAssetsSizeInBytes:2 * 1024 * 1024 // 2 mb
+                                                                                error:error];
+    return manager;
+}
+    
+template<typename T>
+T toValue(NSNumber *value);
+
+template<>
+int32_t toValue(NSNumber *value) {
+    return value.intValue;
+}
+    
+template<>
+double toValue(NSNumber *value) {
+    return value.doubleValue;
+}
+    
+template<>
+float toValue(NSNumber *value) {
+    return value.floatValue;
+}
+    
+template<>
+_Float16 toValue(NSNumber *value) {
+    return static_cast<_Float16>(value.floatValue);
+}
+
+template <typename T>
+void fillBytesWithValue(void *mutableBytes, NSInteger size, NSNumber *value) {
+    T *start = reinterpret_cast<T *>(mutableBytes);
+    T *end = start + size;
+    T fillValue = toValue<T>(value);
+    std::fill(start, end, fillValue);
+}
+}
+
+@implementation ETCoreMLTestUtils
+
++ (nullable NSURL *)createUniqueAssetInDirectoryAtURL:(NSURL *)directoryURL
+                                          withContent:(NSString *)content
+                                          fileManager:(NSFileManager *)fileManager
+                                                error:(NSError * __autoreleasing *)error {
+    NSURL *assetURL = [directoryURL URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+    if (![fileManager createDirectoryAtURL:assetURL withIntermediateDirectories:NO attributes:@{} error:error]) {
+        return nil;
+    }
+    
+    NSURL *dirURL = [assetURL URLByAppendingPathComponent:@"folder"];
+    if (![fileManager createDirectoryAtURL:dirURL withIntermediateDirectories:NO attributes:@{} error:error]) {
+        return nil;
+    }
+    
+    NSURL *fileURL = [dirURL URLByAppendingPathComponent:@"content.txt"];
+    NSData* data = [content dataUsingEncoding:NSUTF8StringEncoding];
+    if (![data writeToURL:fileURL options:NSDataWritingAtomic error:error]) {
+        return nil;
+    }
+    
+    return assetURL;
+}
+
++ (nullable ETCoreMLAssetManager *)createAssetManagerWithURL:(NSURL *)directoryURL
+                                                       error:(NSError * __autoreleasing *)error {
+    NSString *assetDirectoryPath = [directoryURL.path stringByAppendingPathComponent:@"assets"];
+    NSString *trashDirectoryPath = [directoryURL.path stringByAppendingPathComponent:@"trash"];
+    NSString *databaseDirectoryPath = directoryURL.path;
+    return create_asset_manager(assetDirectoryPath, trashDirectoryPath, databaseDirectoryPath, @"main.db", error);
+}
+
++ (nullable MLMultiArray *)filledMultiArrayWithShape:(NSArray<NSNumber *> *)shape
+                                            dataType:(MLMultiArrayDataType)dataType
+                                       repeatedValue:(NSNumber *)value
+                                               error:(NSError * __autoreleasing *)error {
+    MLMultiArray *multiArray = [[MLMultiArray alloc] initWithShape:shape dataType:dataType error:error];
+    if (!multiArray) {
+        return nil;
+    }
+    
+    [multiArray getMutableBytesWithHandler:^(void *mutableBytes, NSInteger __unused size, NSArray<NSNumber *> * __unused strides) {
+        switch (multiArray.dataType) {
+            case MLMultiArrayDataTypeFloat16: {
+                fillBytesWithValue<_Float16>(mutableBytes, multiArray.count, value);
+                break;
+            }
+            case MLMultiArrayDataTypeFloat: {
+                fillBytesWithValue<float>(mutableBytes, multiArray.count, value);
+                break;
+            }
+            case MLMultiArrayDataTypeDouble: {
+                fillBytesWithValue<double>(mutableBytes, multiArray.count, value);
+                break;
+            }
+            
+            case MLMultiArrayDataTypeInt32: {
+                fillBytesWithValue<int>(mutableBytes, multiArray.count, value);
+                break;
+            }
+                
+            default:
+                break;
+        }
+    }];
+    
+    return multiArray;
+    
+}
+
++ (nullable MLMultiArray *)filledMultiArrayWithConstraint:(MLMultiArrayConstraint *)constraint
+                                            repeatedValue:(NSNumber *)value
+                                                    error:(NSError * __autoreleasing *)error {
+    return [self filledMultiArrayWithShape:constraint.shape dataType:constraint.dataType repeatedValue:value error:error];
+}
+
++ (nullable NSArray<MLMultiArray *> *)inputsForModel:(ETCoreMLModel *)model
+                                      repeatedValues:(NSArray<NSNumber *> *)repeatedValues
+                                               error:(NSError * __autoreleasing *)error {
+    NSDictionary<NSString *, MLFeatureDescription *> *inputDescriptionsByName = [model.mlModel.modelDescription inputDescriptionsByName];
+    NSMutableArray<MLMultiArray *> *inputs = [NSMutableArray arrayWithCapacity:inputDescriptionsByName.count];
+    NSEnumerator<NSNumber *> *enumerator = [repeatedValues objectEnumerator];
+    for (NSString *inputName in model.orderedInputNames) {
+        MLMultiArrayConstraint *constraint = inputDescriptionsByName[inputName].multiArrayConstraint;
+        MLMultiArray *multiArray = [ETCoreMLTestUtils filledMultiArrayWithConstraint:constraint repeatedValue:[enumerator nextObject] error:error];
+        if (!multiArray) {
+            return nil;
+        }
+        
+        [inputs addObject:multiArray];
+    }
+    
+    return inputs;
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/InMemoryFileSystemTests.mm
+++ b/backends/apple/coreml/runtime/test/InMemoryFileSystemTests.mm
@@ -1,0 +1,243 @@
+//
+// InMemoryFileSystemTests.mm
+//
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <XCTest/XCTest.h>
+
+#import <iostream>
+#import <sstream>
+
+#import <inmemory_filesystem.hpp>
+#import <memory_stream.hpp>
+#import <json.hpp>
+
+namespace {
+using json = nlohmann::json;
+using namespace inmemoryfs;
+
+struct Content {
+    inline Content(std::string identifier, std::string value) noexcept
+    :identifier(std::move(identifier)), value(std::move(value))
+    {}
+    
+    inline Content() noexcept
+    :identifier(""), value("")
+    {}
+    
+    std::string identifier;
+    std::string value;
+};
+
+bool operator==(const Content& lhs, const Content& rhs) {
+    return lhs.identifier == rhs.identifier && lhs.value == rhs.value;
+}
+
+void to_json(json& j, const Content& content) {
+    j = json{
+        {"identifier", content.identifier},
+        {"value", content.value}
+    };
+}
+
+void from_json(const json& j, Content& content) {
+    j.at("identifier").get_to(content.identifier);
+    j.at("value").get_to(content.value);
+}
+
+template <typename T>
+std::shared_ptr<MemoryBuffer> toMemoryBuffer(const T& value) {
+    std::stringstream ss;
+    json j;
+    to_json(j, value);
+    ss << j;
+    auto text = ss.str();
+    return MemoryBuffer::make(static_cast<void *>(text.data()), text.size());
+}
+
+template <typename T>
+T fromMemoryBuffer(const std::shared_ptr<MemoryBuffer>& buffer) {
+    T result;
+    MemoryIStream memstream(buffer);
+    json j;
+    memstream >> j;
+    from_json(j, result);
+    return result;
+}
+
+}
+
+@interface InMemoryFileSystemTests : XCTestCase
+
+@end
+
+@implementation InMemoryFileSystemTests
+
+using namespace inmemoryfs;
+
+- (void)testCreation {
+    auto fs = InMemoryFileSystem("test");
+    XCTAssert(fs.root()->name() == "test");
+}
+
+- (void)testMakeFileAtPath {
+    auto fs = InMemoryFileSystem("test");
+    Content content("abc", "xyz");
+    std::shared_ptr<MemoryBuffer> buffer = toMemoryBuffer(content);
+    std::error_code error;
+    XCTAssertTrue(fs.make_file({"content.json"}, buffer, InMemoryFileSystem::Attributes(), false  /*overwrite*/, error));
+    // This must fail if we try to overwrite the file at the same path but with the `overwrite` parameter set to true.
+    XCTAssertFalse(fs.make_file({"content.json"}, buffer, InMemoryFileSystem::Attributes(), false /*overwrite*/, error));
+    // This must pass if we try to overwrite the file at the same path but with the `overwrite` parameter set to true.
+    XCTAssertTrue(fs.make_file({"content.json"}, buffer, InMemoryFileSystem::Attributes(), true /*overwrite*/, error));
+}
+
+- (void)testMakeDirectoryAtPath {
+    auto fs = InMemoryFileSystem("test");
+    std::error_code error;
+    XCTAssertTrue(fs.make_directory({"dir1"}, InMemoryFileSystem::Attributes(), false, error));
+    // This must fail, `dir2` doesn't exists and `create_intermediate_directories` is `false`.
+    XCTAssertFalse(fs.make_directory({"dir1", "dir2", "dir3"}, InMemoryFileSystem::Attributes(), false /*create_intermediate_directories*/, error));
+    // This must pass, `dir2` doesn't exists but `create_intermediate_directories` is `true`.
+    XCTAssertTrue(fs.make_directory({"dir1", "dir2", "dir3"}, InMemoryFileSystem::Attributes(), true /*create_intermediate_directories*/, error));
+}
+
+- (void)testIsDirectory {
+    auto fs = InMemoryFileSystem("test");
+    std::error_code error;
+    XCTAssertTrue(fs.make_directory({"dir1"}, InMemoryFileSystem::Attributes(), false, error));
+    XCTAssertTrue(fs.is_directory({"dir1"}));
+    Content content("abc", "xyz");
+    std::shared_ptr<MemoryBuffer> buffer = toMemoryBuffer(content);
+    XCTAssertTrue(fs.make_file({"dir1", "content.json"}, buffer, InMemoryFileSystem::Attributes(), false  /*overwrite*/, error));
+    XCTAssertFalse(fs.is_directory({"dir1", "content.json"}));
+}
+
+- (void)testIsFile {
+    auto fs = InMemoryFileSystem("test");
+    std::error_code error;
+    XCTAssertTrue(fs.make_directory({"dir1"}, InMemoryFileSystem::Attributes(), false, error));
+    Content content("abc", "xyz");
+    std::shared_ptr<MemoryBuffer> buffer = toMemoryBuffer(content);
+    XCTAssertTrue(fs.make_file({"dir1", "content.json"}, buffer, InMemoryFileSystem::Attributes(), false  /*overwrite*/, error));
+    XCTAssertTrue(fs.is_file({"dir1", "content.json"}));
+    XCTAssertFalse(fs.is_file({"dir1"}));
+}
+
+- (void)testFileContentAtPath {
+    auto fs = InMemoryFileSystem("test");
+    std::error_code error;
+    XCTAssertTrue(fs.make_directory({"dir1"}, InMemoryFileSystem::Attributes(), false, error));
+    Content content("abc", "xyz");
+    std::shared_ptr<MemoryBuffer> buffer = toMemoryBuffer(content);
+    XCTAssertTrue(fs.make_file({"dir1", "content.json"}, buffer, InMemoryFileSystem::Attributes(), false  /*overwrite*/, error));
+    auto contents = fs.get_file_content({"dir1", "content.json"}, error);
+    XCTAssert(contents != nullptr);
+}
+
+- (void)testRemoveItemAtPath {
+    auto fs = InMemoryFileSystem("test");
+    std::error_code error;
+    XCTAssertTrue(fs.make_directory({"dir1"}, InMemoryFileSystem::Attributes(), false, error));
+    Content content("abc", "xyz");
+    std::shared_ptr<MemoryBuffer> buffer = toMemoryBuffer(content);
+    XCTAssertTrue(fs.make_file({"dir1", "content.json"}, buffer, InMemoryFileSystem::Attributes(), false  /*overwrite*/, error));
+    XCTAssertTrue(fs.remove_item({"dir1", "content.json"}, error));
+    XCTAssertFalse(fs.exists({"dir1", "content.json"}));
+    XCTAssertTrue(fs.remove_item({"dir1"}, error));
+    XCTAssertFalse(fs.exists({"dir1"}));
+}
+
+- (void)testWriteItemAtPath {
+    auto fs = InMemoryFileSystem("test");
+    Content content("abc", "xyz");
+    std::shared_ptr<MemoryBuffer> buffer = toMemoryBuffer(content);
+    std::error_code error;
+    
+    XCTAssertTrue(fs.make_directory({"dir1"}, InMemoryFileSystem::Attributes(), false, error));
+    XCTAssertTrue(fs.make_file({"dir1", "content.json"}, buffer, InMemoryFileSystem::Attributes(), false  /*overwrite*/, error));
+    XCTAssertTrue(fs.make_directory({"dir1", "dir2"}, InMemoryFileSystem::Attributes(), false, error));
+    XCTAssertTrue(fs.make_file({"dir1", "dir2", "content.json"}, buffer, InMemoryFileSystem::Attributes(), false  /*overwrite*/, error));
+    
+    NSURL *dirURL = [[NSURL fileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSError *localError = nil;
+    XCTAssertTrue([fm createDirectoryAtURL:dirURL withIntermediateDirectories:NO attributes:@{} error:&localError]);
+    // Only write dir2
+    XCTAssertTrue(fs.write_item_to_disk({"dir1", "dir2"}, dirURL.path.UTF8String, true, error));
+    {
+        NSData *data = [NSData dataWithContentsOfURL:[dirURL URLByAppendingPathComponent:@"dir2/content.json"]];
+        XCTAssert(data.length > 0);
+    }
+    // Dump the whole thing
+    XCTAssertTrue(fs.write_item_to_disk({}, dirURL.path.UTF8String, true, error));
+    {
+        NSData *data = [NSData dataWithContentsOfURL:[dirURL URLByAppendingPathComponent:@"test/dir1/content.json"]];
+        XCTAssert(data.length > 0);
+        data = [NSData dataWithContentsOfURL:[dirURL URLByAppendingPathComponent:@"test/dir1/dir2/content.json"]];
+        XCTAssert(data.length > 0);
+    }
+    XCTAssertTrue([fm removeItemAtURL:dirURL error:&localError]);
+}
+
+- (void)testCreationFromFileSystem {
+    Content content("abc", "xyz");
+    std::shared_ptr<MemoryBuffer> buffer = toMemoryBuffer(content);
+    NSURL *dirURL = [[NSURL fileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSError *localError = nil;
+    XCTAssertTrue([fm createDirectoryAtURL:dirURL withIntermediateDirectories:NO attributes:@{} error:&localError]);
+    // create dir1
+    XCTAssertTrue([fm createDirectoryAtURL:[dirURL URLByAppendingPathComponent:@"dir1"] withIntermediateDirectories:NO attributes:@{} error:&localError]);
+    // create dir2
+    XCTAssertTrue([fm createDirectoryAtURL:[dirURL URLByAppendingPathComponent:@"dir2"] withIntermediateDirectories:NO attributes:@{} error:&localError]);
+    // write content
+    NSData *data = [NSData dataWithBytesNoCopy:buffer->data() length:buffer->size() freeWhenDone:NO];
+    XCTAssertTrue([data writeToURL:[dirURL URLByAppendingPathComponent:@"dir1/content.json"] atomically:YES]);
+    XCTAssertTrue([data writeToURL:[dirURL URLByAppendingPathComponent:@"dir2/content.json"] atomically:YES]);
+    
+    std::filesystem::path dirPath(dirURL.path.UTF8String);
+    std::error_code error;
+    auto fs = InMemoryFileSystem::make(dirPath, error);
+    XCTAssertTrue(fs->is_directory({"dir1"}));
+    XCTAssertTrue(fs->is_file({"dir1", "content.json"}));
+    XCTAssertTrue(fs->is_directory({"dir2"}));
+    XCTAssertTrue(fs->is_file({"dir2", "content.json"}));
+    XCTAssertTrue([fm removeItemAtURL:dirURL error:&localError]);
+}
+
+- (void)testSerdes {
+    std::error_code error;
+    std::shared_ptr<MemoryBuffer> serializedBuffer = nullptr;
+    Content content1("id1", "value1");
+    Content content2("id2", "value2");
+    {
+        auto fs = InMemoryFileSystem("test");
+        XCTAssertTrue(fs.make_directory({"dir1"}, InMemoryFileSystem::Attributes(), false, error));
+        std::shared_ptr<MemoryBuffer> buffer1 = toMemoryBuffer(content1);
+        XCTAssertTrue(fs.make_file({"dir1", "content.json"}, buffer1, InMemoryFileSystem::Attributes(), false /*overwrite*/, error));
+        XCTAssertTrue(fs.make_directory({"dir2"}, InMemoryFileSystem::Attributes(), false, error));
+        std::shared_ptr<MemoryBuffer> buffer2 = toMemoryBuffer(content2);
+        XCTAssertTrue(fs.make_file({"dir2", "content.json"}, buffer2, InMemoryFileSystem::Attributes(), false /*overwrite*/, error));
+        size_t length = fs.get_serialization_size({}, 1);
+        std::vector<uint8_t> bytes;
+        bytes.resize(length);
+        serializedBuffer = MemoryBuffer::make(std::move(bytes));
+        auto memstream = MemoryOStream(serializedBuffer);
+        fs.serialize({}, 1, memstream);
+    }
+    
+    {
+        std::error_code error;
+        auto fs = InMemoryFileSystem::make(serializedBuffer);
+        XCTAssertTrue(fs->is_directory({"dir1"}));
+        XCTAssertTrue(fs->is_directory({"dir2"}));
+        XCTAssertEqual(fromMemoryBuffer<Content>(fs->get_file_content({"dir1", "content.json"}, error)), content1);
+        XCTAssertEqual(fromMemoryBuffer<Content>(fs->get_file_content({"dir2", "content.json"}, error)), content2);
+    }
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/KeyValueStoreTests.mm
+++ b/backends/apple/coreml/runtime/test/KeyValueStoreTests.mm
@@ -1,0 +1,217 @@
+//
+// KeyValueStoreTests.m
+//
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <XCTest/XCTest.h>
+
+#import <json_key_value_store.hpp>
+#import <json.hpp>
+
+namespace {
+using json = nlohmann::json;
+
+struct Entry {
+    inline Entry(std::string identifier, size_t count) noexcept
+    :identifier(std::move(identifier)), count(count)
+    {}
+    
+    inline Entry() noexcept
+    :identifier(""), count(0)
+    {}
+    
+    std::string identifier;
+    size_t count;
+};
+
+void to_json(json& j, const Entry& entry) {
+    j = json{
+        {"identifier", entry.identifier},
+        {"count", entry.count}
+    };
+}
+
+void from_json(const json& j, Entry& entry) {
+    j.at("identifier").get_to(entry.identifier);
+    j.at("count").get_to(entry.count);
+}
+}
+
+@interface KeyValueStoreTests : XCTestCase
+
+@end
+
+@implementation KeyValueStoreTests
+
+using namespace executorchcoreml::sqlite;
+
+- (void)testKVStorePut {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    auto store = KeyValueStore<int, double>::make(std::move(database), "test", error);
+    XCTAssertTrue(store->put(1, 2.0, error));
+    XCTAssertTrue(store->size(error) == 1);
+    XCTAssertTrue(store->put(1, 3.0, error));
+    XCTAssertTrue(store->size(error) == 1);
+}
+
+- (void)testKVStoreGet {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    auto store = KeyValueStore<std::string, int>::make(std::move(database), "test", error);
+    XCTAssertTrue(store->put(std::string("1"), 1, error));
+    XCTAssertTrue(store->size(error) == 1);
+    XCTAssertTrue(store->get(std::string("1"), error).value() == 1);
+    XCTAssertFalse(store->get(std::string("2"), error).has_value());
+}
+
+- (void)testKVStoreRemove {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    auto store = KeyValueStore<std::string, int>::make(std::move(database), "test", error);
+    XCTAssertTrue(store->put(std::string("1"), 1, error));
+    XCTAssertTrue(store->size(error) == 1);
+    XCTAssertTrue(store->remove(std::string("1"), error));
+    XCTAssertTrue(store->size(error) == 0);
+}
+
+- (void)testKVStoreExists {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    auto store = KeyValueStore<std::string, int>::make(std::move(database), "test", error);
+    XCTAssertTrue(store->put(std::string("1"), 1, error));
+    XCTAssertTrue(store->exists(std::string("1"), error));
+    XCTAssertFalse(store->exists(std::string("2"), error));
+}
+
+- (void)testJSONKeyValueStore {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    auto store = JSONKeyValueStore<int, Entry>::make(std::move(database), "test", error);
+    
+    XCTAssertTrue(store->put(1, Entry("1", 1), error));
+    auto entry1 = store->get(1, error);
+    XCTAssertTrue(entry1.value().count == 1);
+    XCTAssertTrue(entry1.value().identifier == "1");
+    
+    XCTAssertTrue(store->put(2, Entry("2", 2), error));
+    auto entry2 = store->get(2, error);
+    XCTAssertTrue(entry2.value().count == 2);
+    XCTAssertTrue(entry2.value().identifier == "2");
+}
+
+- (void)testKVStoreTransactionCommit {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    auto store = KeyValueStore<int, std::string>::make(std::move(database), "test", error);
+    XCTAssertTrue(store->transaction([store = store.get(), &error]() {
+        XCTAssertTrue(store->put(1, std::string("abc"), error));
+        XCTAssertTrue(store->put(2, std::string("def"), error));
+        XCTAssertTrue(store->get(2, error).value() == "def");
+        XCTAssertTrue(store->size(error) == 2);
+        // Commit the transaction.
+        return true;
+    }, Database::TransactionBehavior::Immediate, error));
+    
+    XCTAssertTrue(store->size(error) == 2);
+}
+
+- (void)testKVStoreTransactionRollback {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    auto store = KeyValueStore<int, std::string>::make(std::move(database), "test", error);
+    XCTAssertFalse(store->transaction([store = store.get(), &error]() {
+        XCTAssertTrue(store->put(1, std::string("abc"), error));
+        XCTAssertTrue(store->put(2, std::string("def"), error));
+        XCTAssertTrue(store->get(2, error).value() == "def");
+        XCTAssertTrue(store->size(error) == 2);
+        // Rollback the transaction.
+        return false;
+    }, Database::TransactionBehavior::Immediate, error));
+    
+    XCTAssertTrue(store->size(error) == 0);
+}
+
+- (void)testKVStoreGetKeysSortedByAccessTime {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    auto store = KeyValueStore<int, std::string>::make(std::move(database), "test", error);
+    XCTAssertTrue(store->put(1, std::string("1"), error));
+    XCTAssertTrue(store->put(2, std::string("2"), error));
+    XCTAssertTrue(store->put(3, std::string("3"), error));
+    XCTAssertTrue(store->get(1, error).has_value());
+    XCTAssertTrue(store->get(2, error).has_value());
+    XCTAssertTrue(store->get(3, error).has_value());
+    {
+        std::vector<int> keys;
+        XCTAssertTrue(store->get_keys_sorted_by_access_time([&keys](int key) {
+            keys.push_back(key);
+            return true;
+        }, SortOrder::Ascending, error));
+        // 1 is accessed first then 2 and then 3
+        XCTAssertTrue(keys == (std::vector<int>{1, 2, 3}));
+    }
+    
+    {
+        std::vector<int> keys;
+        XCTAssertTrue(store->get_keys_sorted_by_access_time([&keys](int key) {
+            keys.push_back(key);
+            return true;
+        }, SortOrder::Descending, error));
+        // 1 is accessed first then 2 and then 3
+        XCTAssertTrue(keys == (std::vector<int>{3, 2, 1}));
+    }
+}
+
+- (void)testKVStoreGetKeysSortedByAccessCount {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    auto store = KeyValueStore<int, std::string>::make(std::move(database), "test", error);
+    XCTAssertTrue(store->put(1, std::string("1"), error));
+    XCTAssertTrue(store->put(2, std::string("2"), error));
+    XCTAssertTrue(store->put(3, std::string("3"), error));
+    // 1 is accessed 3 times.
+    XCTAssertTrue(store->get(1, error).has_value());
+    XCTAssertTrue(store->get(1, error).has_value());
+    XCTAssertTrue(store->get(1, error).has_value());
+    // 2 is accessed 2 times.
+    XCTAssertTrue(store->get(2, error).has_value());
+    XCTAssertTrue(store->get(2, error).has_value());
+    // 3 is accessed 1 times.
+    XCTAssertTrue(store->get(3, error).has_value());
+    {
+        std::vector<int> keys;
+        XCTAssertTrue(store->get_keys_sorted_by_access_count([&keys](int key) {
+            keys.push_back(key);
+            return true;
+        }, SortOrder::Ascending, error));
+        // 3 is accessed 1 time, 2 is accessed 2 times, and 1 is accessed 3 times.
+        XCTAssertTrue(keys == (std::vector<int>{3, 2, 1}));
+    }
+    
+    {
+        std::vector<int> keys;
+        XCTAssertTrue(store->get_keys_sorted_by_access_count([&keys](int key) {
+            keys.push_back(key);
+            return true;
+        }, SortOrder::Descending, error));
+        // 3 is accessed 1 time, 2 is accessed 2 times, and 1 is accessed 3 times.
+        XCTAssertTrue(keys == (std::vector<int>{1, 2, 3}));
+    }
+}
+
+- (void)testKVStorePurge {
+    std::error_code error;
+    auto database = Database::make_inmemory(Database::SynchronousMode::Normal, 100, error);
+    auto store = KeyValueStore<int, std::string>::make(std::move(database), "test", error);
+    XCTAssertTrue(store->put(1, std::string("1"), error));
+    XCTAssertTrue(store->put(2, std::string("2"), error));
+    XCTAssertTrue(store->size(error) == 2);
+    XCTAssertTrue(store->purge(error));
+    XCTAssertTrue(store->size(error) == 0);
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/setup.md
+++ b/backends/apple/coreml/runtime/test/setup.md
@@ -1,0 +1,65 @@
+## CoreML delegate tests set up
+
+This is a tutorial for setting up tests for the **CoreML** backend.
+
+## Running tests
+
+1. Follow the instructions described in [Setting Up ExecuTorch](/docs/source/getting-started-setup.md) to set up ExecuTorch environment.
+
+2. Run `install_requirements.sh` to install dependencies required by the **CoreML** backend.
+
+```bash
+cd executorch
+
+sh backends/apple/coreml/scripts/install_requirements.sh   
+
+``` 
+
+3. Follow the instructions described in [Building with CMake](/docs/source/runtime-build-and-cross-compilation.md#building-with-cmake) to set up CMake build system.
+
+4. Install [Xcode](https://developer.apple.com/xcode/).
+
+5. Install Xcode Command Line Tools.
+
+6. Run `build_tests.sh` to build tests.
+
+```bash
+cd executorch
+
+# Builds macOS universal test bundle. 
+
+sh backends/apple/coreml/srcipts/build_tests.sh
+
+```
+
+7. Run `run_tests.sh` to execute the tests.
+
+```
+cd executorch
+
+sh backends/apple/coreml/srcipts/run_tests.sh
+
+```
+ 
+## Updating tests
+
+1. Open the Xcode workspace.
+
+```bash
+cd executorch
+
+# Builds macOS universal test bundle. 
+
+open backends/apple/coreml/runtime/workspace/executorchcoreml.xcworkspace
+
+```
+
+2. The runtime tests are in the `test` folder, after updating the tests you can use the Xcode tests navigator to run the tests or use the command line.
+
+```bash
+cd executorch
+
+# There is no need to build the tests.
+sh backends/apple/coreml/srcipts/run_tests.sh
+
+```

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
@@ -1,0 +1,606 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		C94BC6492AD5EB400067A63B /* coreml_backend_delegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = C94BC6482AD5EB400067A63B /* coreml_backend_delegate.mm */; };
+		C94D50D92ABD7B2400AF47FD /* CoreML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C96560922AABF992005F8126 /* CoreML.framework */; };
+		C94D50DA2ABD7B6600AF47FD /* libexecutorch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C965608D2AABF72A005F8126 /* libexecutorch.a */; };
+		C94D50E52ABDF80A00AF47FD /* database.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DF062A9FD16F001CC178 /* database.cpp */; };
+		C94D50E72ABDF80D00AF47FD /* sqlite_error.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DF092A9FD16F001CC178 /* sqlite_error.cpp */; };
+		C94D50E82ABDF81100AF47FD /* key_value_store.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DF052A9FD16E001CC178 /* key_value_store.cpp */; };
+		C94D50EA2ABDF81400AF47FD /* statement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DF072A9FD16F001CC178 /* statement.cpp */; };
+		C94D50ED2ABDF81900AF47FD /* inmemory_filesystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C95266452A7E06760016283E /* inmemory_filesystem.cpp */; };
+		C94D50EE2ABDF81B00AF47FD /* memory_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C95266472A7E06760016283E /* memory_buffer.cpp */; };
+		C94D50F02ABDF81F00AF47FD /* memory_stream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C95266412A7E06760016283E /* memory_stream.cpp */; };
+		C94D50F22ABDF82200AF47FD /* reversed_memory_stream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C95266422A7E06760016283E /* reversed_memory_stream.cpp */; };
+		C94D50F42ABDF82500AF47FD /* asset.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DFBC2AA84FC6001CC178 /* asset.mm */; };
+		C94D50F62ABDF82900AF47FD /* backend_delegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = C952664F2A7F818A0016283E /* backend_delegate.mm */; };
+		C94D50FA2ABDF83200AF47FD /* multiarray.mm in Sources */ = {isa = PBXBuildFile; fileRef = C96560B12AAF7CC2005F8126 /* multiarray.mm */; };
+		C94D50FC2ABDF83500AF47FD /* ETCoreMLAsset.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DFB62AA183BC001CC178 /* ETCoreMLAsset.mm */; };
+		C94D50FE2ABDF83800AF47FD /* ETCoreMLModel.mm in Sources */ = {isa = PBXBuildFile; fileRef = C95266362A7E06460016283E /* ETCoreMLModel.mm */; };
+		C94D51002ABDF83C00AF47FD /* ETCoreMLAssetManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DED52A9FCFC4001CC178 /* ETCoreMLAssetManager.mm */; };
+		C94D51022ABDF83E00AF47FD /* ETCoreMLModelManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = C95266372A7E06460016283E /* ETCoreMLModelManager.mm */; };
+		C94D51042ABDF84100AF47FD /* ETCoreMLStrings.mm in Sources */ = {isa = PBXBuildFile; fileRef = C952665E2A8012400016283E /* ETCoreMLStrings.mm */; };
+		C94D51062ABDF84400AF47FD /* ETCoreMLLogging.mm in Sources */ = {isa = PBXBuildFile; fileRef = C95266392A7E06460016283E /* ETCoreMLLogging.mm */; };
+		C94D51082ABDF84800AF47FD /* MLModel_Prewarm.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DFC32AA9109F001CC178 /* MLModel_Prewarm.mm */; };
+		C94D510A2ABDF84B00AF47FD /* MLMultiArray_Copy.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9670FFA2A82F0C800E7D441 /* MLMultiArray_Copy.mm */; };
+		C94D510C2ABDF84F00AF47FD /* serde_json.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DFB02AA123E9001CC178 /* serde_json.mm */; };
+		C94D510E2ABDF86800AF47FD /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C96560942AABFDCE005F8126 /* libsqlite3.tbd */; };
+		C94D510F2ABDF87500AF47FD /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C96560902AABF982005F8126 /* Accelerate.framework */; };
+		C985519E2AD2542D009143F9 /* mv3_coreml_all.pte in Resources */ = {isa = PBXBuildFile; fileRef = C98551982AD2542D009143F9 /* mv3_coreml_all.pte */; };
+		C985519F2AD2542D009143F9 /* mul_coreml_all.bin in Resources */ = {isa = PBXBuildFile; fileRef = C98551992AD2542D009143F9 /* mul_coreml_all.bin */; };
+		C98551A02AD2542D009143F9 /* add_coreml_all.bin in Resources */ = {isa = PBXBuildFile; fileRef = C985519A2AD2542D009143F9 /* add_coreml_all.bin */; };
+		C98551A12AD2542D009143F9 /* mv3_coreml_all.bin in Resources */ = {isa = PBXBuildFile; fileRef = C985519B2AD2542D009143F9 /* mv3_coreml_all.bin */; };
+		C98551A22AD2542D009143F9 /* mul_coreml_all.pte in Resources */ = {isa = PBXBuildFile; fileRef = C985519C2AD2542D009143F9 /* mul_coreml_all.pte */; };
+		C98551A32AD2542D009143F9 /* add_coreml_all.pte in Resources */ = {isa = PBXBuildFile; fileRef = C985519D2AD2542D009143F9 /* add_coreml_all.pte */; };
+		C9E7D78F2AB3F9BF00CCAE5D /* ETCoreMLTestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D7862AB3F9BF00CCAE5D /* ETCoreMLTestUtils.mm */; };
+		C9E7D7902AB3F9BF00CCAE5D /* InMemoryFileSystemTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D7882AB3F9BF00CCAE5D /* InMemoryFileSystemTests.mm */; };
+		C9E7D7912AB3F9BF00CCAE5D /* ETCoreMLAssetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D7892AB3F9BF00CCAE5D /* ETCoreMLAssetTests.mm */; };
+		C9E7D7922AB3F9BF00CCAE5D /* DatabaseTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D78A2AB3F9BF00CCAE5D /* DatabaseTests.mm */; };
+		C9E7D7932AB3F9BF00CCAE5D /* ETCoreMLAssetManagerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D78B2AB3F9BF00CCAE5D /* ETCoreMLAssetManagerTests.mm */; };
+		C9E7D7942AB3F9BF00CCAE5D /* BackendDelegateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D78C2AB3F9BF00CCAE5D /* BackendDelegateTests.mm */; };
+		C9E7D7952AB3F9BF00CCAE5D /* ETCoreMLModelManagerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D78D2AB3F9BF00CCAE5D /* ETCoreMLModelManagerTests.mm */; };
+		C9E7D7962AB3F9BF00CCAE5D /* KeyValueStoreTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D78E2AB3F9BF00CCAE5D /* KeyValueStoreTests.mm */; };
+		C9E7D7A22AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D7A12AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		C96560EC2AB24D62005F8126 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		C94BC6482AD5EB400067A63B /* coreml_backend_delegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = coreml_backend_delegate.mm; path = ../delegate/coreml_backend_delegate.mm; sourceTree = "<group>"; };
+		C95266352A7E06460016283E /* ETCoreMLModelManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelManager.h; path = ../delegate/ETCoreMLModelManager.h; sourceTree = "<group>"; };
+		C95266362A7E06460016283E /* ETCoreMLModel.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModel.mm; path = ../delegate/ETCoreMLModel.mm; sourceTree = "<group>"; };
+		C95266372A7E06460016283E /* ETCoreMLModelManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelManager.mm; path = ../delegate/ETCoreMLModelManager.mm; sourceTree = "<group>"; };
+		C95266382A7E06460016283E /* ETCoreMLLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLLogging.h; path = ../delegate/ETCoreMLLogging.h; sourceTree = "<group>"; };
+		C95266392A7E06460016283E /* ETCoreMLLogging.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLLogging.mm; path = ../delegate/ETCoreMLLogging.mm; sourceTree = "<group>"; };
+		C952663A2A7E06460016283E /* ETCoreMLModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModel.h; path = ../delegate/ETCoreMLModel.h; sourceTree = "<group>"; };
+		C95266402A7E06760016283E /* memory_buffer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = memory_buffer.hpp; path = ../inmemoryfs/memory_buffer.hpp; sourceTree = "<group>"; };
+		C95266412A7E06760016283E /* memory_stream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = memory_stream.cpp; path = ../inmemoryfs/memory_stream.cpp; sourceTree = "<group>"; };
+		C95266422A7E06760016283E /* reversed_memory_stream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = reversed_memory_stream.cpp; path = ../inmemoryfs/reversed_memory_stream.cpp; sourceTree = "<group>"; };
+		C95266432A7E06760016283E /* memory_stream.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = memory_stream.hpp; path = ../inmemoryfs/memory_stream.hpp; sourceTree = "<group>"; };
+		C95266442A7E06760016283E /* inmemory_filesystem.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = inmemory_filesystem.hpp; path = ../inmemoryfs/inmemory_filesystem.hpp; sourceTree = "<group>"; };
+		C95266452A7E06760016283E /* inmemory_filesystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = inmemory_filesystem.cpp; path = ../inmemoryfs/inmemory_filesystem.cpp; sourceTree = "<group>"; };
+		C95266462A7E06760016283E /* reversed_memory_stream.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = reversed_memory_stream.hpp; path = ../inmemoryfs/reversed_memory_stream.hpp; sourceTree = "<group>"; };
+		C95266472A7E06760016283E /* memory_buffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = memory_buffer.cpp; path = ../inmemoryfs/memory_buffer.cpp; sourceTree = "<group>"; };
+		C952664F2A7F818A0016283E /* backend_delegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = backend_delegate.mm; path = ../delegate/backend_delegate.mm; sourceTree = "<group>"; };
+		C95266502A7F818A0016283E /* backend_delegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = backend_delegate.h; path = ../delegate/backend_delegate.h; sourceTree = "<group>"; };
+		C952665D2A8012400016283E /* ETCoreMLStrings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ETCoreMLStrings.h; path = ../delegate/ETCoreMLStrings.h; sourceTree = "<group>"; };
+		C952665E2A8012400016283E /* ETCoreMLStrings.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLStrings.mm; path = ../delegate/ETCoreMLStrings.mm; sourceTree = "<group>"; };
+		C96560792AABD1DF005F8126 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk/System/Library/Frameworks/Accelerate.framework; sourceTree = DEVELOPER_DIR; };
+		C965607B2AABD1E5005F8126 /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk/System/Library/Frameworks/CoreML.framework; sourceTree = DEVELOPER_DIR; };
+		C965607D2AABD1EA005F8126 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
+		C965608D2AABF72A005F8126 /* libexecutorch.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libexecutorch.a; path = ../libraries/libexecutorch.a; sourceTree = "<group>"; };
+		C96560902AABF982005F8126 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/Accelerate.framework; sourceTree = DEVELOPER_DIR; };
+		C96560922AABF992005F8126 /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/CoreML.framework; sourceTree = DEVELOPER_DIR; };
+		C96560942AABFDCE005F8126 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
+		C96560982AAC0075005F8126 /* libgflags_nothreads_debug.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgflags_nothreads_debug.a; path = ../libraries/libgflags_nothreads_debug.a; sourceTree = "<group>"; };
+		C96560A32AAC0DCF005F8126 /* executorchcoreml_tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = executorchcoreml_tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C96560B12AAF7CC2005F8126 /* multiarray.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = multiarray.mm; path = ../delegate/multiarray.mm; sourceTree = "<group>"; };
+		C96560B22AAF9EA7005F8126 /* inmemory_filesystem_py.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = inmemory_filesystem_py.cpp; path = ../inmemoryfs/inmemory_filesystem_py.cpp; sourceTree = "<group>"; };
+		C9670FF92A82F0C800E7D441 /* MLMultiArray_Copy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MLMultiArray_Copy.h; path = ../delegate/MLMultiArray_Copy.h; sourceTree = "<group>"; };
+		C9670FFA2A82F0C800E7D441 /* MLMultiArray_Copy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MLMultiArray_Copy.mm; path = ../delegate/MLMultiArray_Copy.mm; sourceTree = "<group>"; };
+		C98551982AD2542D009143F9 /* mv3_coreml_all.pte */ = {isa = PBXFileReference; lastKnownFileType = file; name = mv3_coreml_all.pte; path = ../test/models/mv3_coreml_all.pte; sourceTree = "<group>"; };
+		C98551992AD2542D009143F9 /* mul_coreml_all.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = mul_coreml_all.bin; path = ../test/models/mul_coreml_all.bin; sourceTree = "<group>"; };
+		C985519A2AD2542D009143F9 /* add_coreml_all.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = add_coreml_all.bin; path = ../test/models/add_coreml_all.bin; sourceTree = "<group>"; };
+		C985519B2AD2542D009143F9 /* mv3_coreml_all.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = mv3_coreml_all.bin; path = ../test/models/mv3_coreml_all.bin; sourceTree = "<group>"; };
+		C985519C2AD2542D009143F9 /* mul_coreml_all.pte */ = {isa = PBXFileReference; lastKnownFileType = file; name = mul_coreml_all.pte; path = ../test/models/mul_coreml_all.pte; sourceTree = "<group>"; };
+		C985519D2AD2542D009143F9 /* add_coreml_all.pte */ = {isa = PBXFileReference; lastKnownFileType = file; name = add_coreml_all.pte; path = ../test/models/add_coreml_all.pte; sourceTree = "<group>"; };
+		C9D3DED52A9FCFC4001CC178 /* ETCoreMLAssetManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLAssetManager.mm; path = ../delegate/ETCoreMLAssetManager.mm; sourceTree = "<group>"; };
+		C9D3DED62A9FCFC4001CC178 /* ETCoreMLAssetManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLAssetManager.h; path = ../delegate/ETCoreMLAssetManager.h; sourceTree = "<group>"; };
+		C9D3DF002A9FD16E001CC178 /* statement.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = statement.hpp; path = ../kvstore/statement.hpp; sourceTree = "<group>"; };
+		C9D3DF012A9FD16E001CC178 /* types.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = types.hpp; path = ../kvstore/types.hpp; sourceTree = "<group>"; };
+		C9D3DF022A9FD16E001CC178 /* sqlite_error.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = sqlite_error.hpp; path = ../kvstore/sqlite_error.hpp; sourceTree = "<group>"; };
+		C9D3DF032A9FD16E001CC178 /* database.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = database.hpp; path = ../kvstore/database.hpp; sourceTree = "<group>"; };
+		C9D3DF042A9FD16E001CC178 /* json_key_value_store.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = json_key_value_store.hpp; path = ../kvstore/json_key_value_store.hpp; sourceTree = "<group>"; };
+		C9D3DF052A9FD16E001CC178 /* key_value_store.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = key_value_store.cpp; path = ../kvstore/key_value_store.cpp; sourceTree = "<group>"; };
+		C9D3DF062A9FD16F001CC178 /* database.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = database.cpp; path = ../kvstore/database.cpp; sourceTree = "<group>"; };
+		C9D3DF072A9FD16F001CC178 /* statement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = statement.cpp; path = ../kvstore/statement.cpp; sourceTree = "<group>"; };
+		C9D3DF082A9FD16F001CC178 /* key_value_store.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = key_value_store.hpp; path = ../kvstore/key_value_store.hpp; sourceTree = "<group>"; };
+		C9D3DF092A9FD16F001CC178 /* sqlite_error.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sqlite_error.cpp; path = ../kvstore/sqlite_error.cpp; sourceTree = "<group>"; };
+		C9D3DF812A9FF394001CC178 /* multiarray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = multiarray.h; path = ../delegate/multiarray.h; sourceTree = "<group>"; };
+		C9D3DFAF2AA12097001CC178 /* asset.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = asset.h; path = ../delegate/asset.h; sourceTree = "<group>"; };
+		C9D3DFB02AA123E9001CC178 /* serde_json.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = serde_json.mm; path = ../delegate/serde_json.mm; sourceTree = "<group>"; };
+		C9D3DFB12AA123E9001CC178 /* serde_json.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = serde_json.h; path = ../delegate/serde_json.h; sourceTree = "<group>"; };
+		C9D3DFB22AA12683001CC178 /* metadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = metadata.h; path = ../delegate/metadata.h; sourceTree = "<group>"; };
+		C9D3DFB52AA183BC001CC178 /* ETCoreMLAsset.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ETCoreMLAsset.h; path = ../delegate/ETCoreMLAsset.h; sourceTree = "<group>"; };
+		C9D3DFB62AA183BC001CC178 /* ETCoreMLAsset.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLAsset.mm; path = ../delegate/ETCoreMLAsset.mm; sourceTree = "<group>"; };
+		C9D3DFBC2AA84FC6001CC178 /* asset.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = asset.mm; path = ../delegate/asset.mm; sourceTree = "<group>"; };
+		C9D3DFC22AA9109F001CC178 /* MLModel_Prewarm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MLModel_Prewarm.h; path = ../delegate/MLModel_Prewarm.h; sourceTree = "<group>"; };
+		C9D3DFC32AA9109F001CC178 /* MLModel_Prewarm.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MLModel_Prewarm.mm; path = ../delegate/MLModel_Prewarm.mm; sourceTree = "<group>"; };
+		C9E7D7862AB3F9BF00CCAE5D /* ETCoreMLTestUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLTestUtils.mm; path = ../test/ETCoreMLTestUtils.mm; sourceTree = "<group>"; };
+		C9E7D7872AB3F9BF00CCAE5D /* ETCoreMLTestUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLTestUtils.h; path = ../test/ETCoreMLTestUtils.h; sourceTree = "<group>"; };
+		C9E7D7882AB3F9BF00CCAE5D /* InMemoryFileSystemTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = InMemoryFileSystemTests.mm; path = ../test/InMemoryFileSystemTests.mm; sourceTree = "<group>"; };
+		C9E7D7892AB3F9BF00CCAE5D /* ETCoreMLAssetTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLAssetTests.mm; path = ../test/ETCoreMLAssetTests.mm; sourceTree = "<group>"; };
+		C9E7D78A2AB3F9BF00CCAE5D /* DatabaseTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = DatabaseTests.mm; path = ../test/DatabaseTests.mm; sourceTree = "<group>"; };
+		C9E7D78B2AB3F9BF00CCAE5D /* ETCoreMLAssetManagerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLAssetManagerTests.mm; path = ../test/ETCoreMLAssetManagerTests.mm; sourceTree = "<group>"; };
+		C9E7D78C2AB3F9BF00CCAE5D /* BackendDelegateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = BackendDelegateTests.mm; path = ../test/BackendDelegateTests.mm; sourceTree = "<group>"; };
+		C9E7D78D2AB3F9BF00CCAE5D /* ETCoreMLModelManagerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelManagerTests.mm; path = ../test/ETCoreMLModelManagerTests.mm; sourceTree = "<group>"; };
+		C9E7D78E2AB3F9BF00CCAE5D /* KeyValueStoreTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = KeyValueStoreTests.mm; path = ../test/KeyValueStoreTests.mm; sourceTree = "<group>"; };
+		C9E7D7A12AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = CoreMLBackendDelegateTests.mm; path = ../test/CoreMLBackendDelegateTests.mm; sourceTree = "<group>"; };
+		C9E7D7A92AB5081600CCAE5D /* libgflags_nothreads.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgflags_nothreads.a; path = ../libraries/libgflags_nothreads.a; sourceTree = "<group>"; };
+		C9E7D7AB2AB55AC100CCAE5D /* com.apple.executorchcoreml_config.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = com.apple.executorchcoreml_config.plist; path = ../delegate/com.apple.executorchcoreml_config.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C96560A02AAC0DCF005F8126 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C94D510F2ABDF87500AF47FD /* Accelerate.framework in Frameworks */,
+				C94D510E2ABDF86800AF47FD /* libsqlite3.tbd in Frameworks */,
+				C94D50D92ABD7B2400AF47FD /* CoreML.framework in Frameworks */,
+				C94D50DA2ABD7B6600AF47FD /* libexecutorch.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C95266222A7E05FB0016283E = {
+			isa = PBXGroup;
+			children = (
+				C9E7D7AE2AB6C0C000CCAE5D /* models */,
+				C9E7D7852AB3F99A00CCAE5D /* test */,
+				C9D3DEFF2A9FD150001CC178 /* kvstore */,
+				C952663F2A7E065F0016283E /* inmemoryfs */,
+				C952663E2A7E06510016283E /* delegate */,
+				C952662C2A7E05FB0016283E /* Products */,
+				C952664C2A7E06B50016283E /* Frameworks */,
+				C965609E2AAC0C17005F8126 /* Recovered References */,
+			);
+			sourceTree = "<group>";
+		};
+		C952662C2A7E05FB0016283E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C96560A32AAC0DCF005F8126 /* executorchcoreml_tests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C952663E2A7E06510016283E /* delegate */ = {
+			isa = PBXGroup;
+			children = (
+				C9E7D7AB2AB55AC100CCAE5D /* com.apple.executorchcoreml_config.plist */,
+				C9D3DFAF2AA12097001CC178 /* asset.h */,
+				C9D3DFBC2AA84FC6001CC178 /* asset.mm */,
+				C94BC6482AD5EB400067A63B /* coreml_backend_delegate.mm */,
+				C95266502A7F818A0016283E /* backend_delegate.h */,
+				C952664F2A7F818A0016283E /* backend_delegate.mm */,
+				C9D3DF812A9FF394001CC178 /* multiarray.h */,
+				C96560B12AAF7CC2005F8126 /* multiarray.mm */,
+				C9D3DFB22AA12683001CC178 /* metadata.h */,
+				C9D3DFB52AA183BC001CC178 /* ETCoreMLAsset.h */,
+				C9D3DFB62AA183BC001CC178 /* ETCoreMLAsset.mm */,
+				C952663A2A7E06460016283E /* ETCoreMLModel.h */,
+				C95266362A7E06460016283E /* ETCoreMLModel.mm */,
+				C9D3DED62A9FCFC4001CC178 /* ETCoreMLAssetManager.h */,
+				C9D3DED52A9FCFC4001CC178 /* ETCoreMLAssetManager.mm */,
+				C95266352A7E06460016283E /* ETCoreMLModelManager.h */,
+				C95266372A7E06460016283E /* ETCoreMLModelManager.mm */,
+				C952665D2A8012400016283E /* ETCoreMLStrings.h */,
+				C952665E2A8012400016283E /* ETCoreMLStrings.mm */,
+				C95266382A7E06460016283E /* ETCoreMLLogging.h */,
+				C95266392A7E06460016283E /* ETCoreMLLogging.mm */,
+				C9D3DFC22AA9109F001CC178 /* MLModel_Prewarm.h */,
+				C9D3DFC32AA9109F001CC178 /* MLModel_Prewarm.mm */,
+				C9670FF92A82F0C800E7D441 /* MLMultiArray_Copy.h */,
+				C9670FFA2A82F0C800E7D441 /* MLMultiArray_Copy.mm */,
+				C9D3DFB12AA123E9001CC178 /* serde_json.h */,
+				C9D3DFB02AA123E9001CC178 /* serde_json.mm */,
+			);
+			name = delegate;
+			sourceTree = "<group>";
+		};
+		C952663F2A7E065F0016283E /* inmemoryfs */ = {
+			isa = PBXGroup;
+			children = (
+				C95266442A7E06760016283E /* inmemory_filesystem.hpp */,
+				C95266452A7E06760016283E /* inmemory_filesystem.cpp */,
+				C96560B22AAF9EA7005F8126 /* inmemory_filesystem_py.cpp */,
+				C95266402A7E06760016283E /* memory_buffer.hpp */,
+				C95266472A7E06760016283E /* memory_buffer.cpp */,
+				C95266432A7E06760016283E /* memory_stream.hpp */,
+				C95266412A7E06760016283E /* memory_stream.cpp */,
+				C95266462A7E06760016283E /* reversed_memory_stream.hpp */,
+				C95266422A7E06760016283E /* reversed_memory_stream.cpp */,
+			);
+			name = inmemoryfs;
+			sourceTree = "<group>";
+		};
+		C952664C2A7E06B50016283E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C9E7D7A92AB5081600CCAE5D /* libgflags_nothreads.a */,
+				C965607D2AABD1EA005F8126 /* libsqlite3.tbd */,
+				C965607B2AABD1E5005F8126 /* CoreML.framework */,
+				C96560792AABD1DF005F8126 /* Accelerate.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C965609E2AAC0C17005F8126 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				C96560942AABFDCE005F8126 /* libsqlite3.tbd */,
+				C96560922AABF992005F8126 /* CoreML.framework */,
+				C96560982AAC0075005F8126 /* libgflags_nothreads_debug.a */,
+				C96560902AABF982005F8126 /* Accelerate.framework */,
+				C965608D2AABF72A005F8126 /* libexecutorch.a */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		C9D3DEFF2A9FD150001CC178 /* kvstore */ = {
+			isa = PBXGroup;
+			children = (
+				C9D3DF062A9FD16F001CC178 /* database.cpp */,
+				C9D3DF032A9FD16E001CC178 /* database.hpp */,
+				C9D3DF092A9FD16F001CC178 /* sqlite_error.cpp */,
+				C9D3DF022A9FD16E001CC178 /* sqlite_error.hpp */,
+				C9D3DF042A9FD16E001CC178 /* json_key_value_store.hpp */,
+				C9D3DF082A9FD16F001CC178 /* key_value_store.hpp */,
+				C9D3DF052A9FD16E001CC178 /* key_value_store.cpp */,
+				C9D3DF002A9FD16E001CC178 /* statement.hpp */,
+				C9D3DF072A9FD16F001CC178 /* statement.cpp */,
+				C9D3DF012A9FD16E001CC178 /* types.hpp */,
+			);
+			name = kvstore;
+			sourceTree = "<group>";
+		};
+		C9E7D7852AB3F99A00CCAE5D /* test */ = {
+			isa = PBXGroup;
+			children = (
+				C9E7D78C2AB3F9BF00CCAE5D /* BackendDelegateTests.mm */,
+				C9E7D7A12AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm */,
+				C9E7D78A2AB3F9BF00CCAE5D /* DatabaseTests.mm */,
+				C9E7D78B2AB3F9BF00CCAE5D /* ETCoreMLAssetManagerTests.mm */,
+				C9E7D7892AB3F9BF00CCAE5D /* ETCoreMLAssetTests.mm */,
+				C9E7D78D2AB3F9BF00CCAE5D /* ETCoreMLModelManagerTests.mm */,
+				C9E7D7872AB3F9BF00CCAE5D /* ETCoreMLTestUtils.h */,
+				C9E7D7862AB3F9BF00CCAE5D /* ETCoreMLTestUtils.mm */,
+				C9E7D7882AB3F9BF00CCAE5D /* InMemoryFileSystemTests.mm */,
+				C9E7D78E2AB3F9BF00CCAE5D /* KeyValueStoreTests.mm */,
+			);
+			name = test;
+			sourceTree = "<group>";
+		};
+		C9E7D7AE2AB6C0C000CCAE5D /* models */ = {
+			isa = PBXGroup;
+			children = (
+				C985519A2AD2542D009143F9 /* add_coreml_all.bin */,
+				C985519D2AD2542D009143F9 /* add_coreml_all.pte */,
+				C98551992AD2542D009143F9 /* mul_coreml_all.bin */,
+				C985519C2AD2542D009143F9 /* mul_coreml_all.pte */,
+				C985519B2AD2542D009143F9 /* mv3_coreml_all.bin */,
+				C98551982AD2542D009143F9 /* mv3_coreml_all.pte */,
+			);
+			name = models;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C96560A22AAC0DCF005F8126 /* executorchcoreml_tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C96560AA2AAC0DCF005F8126 /* Build configuration list for PBXNativeTarget "executorchcoreml_tests" */;
+			buildPhases = (
+				C965609F2AAC0DCF005F8126 /* Sources */,
+				C96560A02AAC0DCF005F8126 /* Frameworks */,
+				C96560A12AAC0DCF005F8126 /* Resources */,
+				C96560EC2AB24D62005F8126 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = executorchcoreml_tests;
+			productName = ETCoreMLDelegateTests;
+			productReference = C96560A32AAC0DCF005F8126 /* executorchcoreml_tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C95266232A7E05FB0016283E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					C96560A22AAC0DCF005F8126 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = C95266262A7E05FB0016283E /* Build configuration list for PBXProject "executorchcoreml" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = C95266222A7E05FB0016283E;
+			productRefGroup = C952662C2A7E05FB0016283E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C96560A22AAC0DCF005F8126 /* executorchcoreml_tests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C96560A12AAC0DCF005F8126 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C98551A12AD2542D009143F9 /* mv3_coreml_all.bin in Resources */,
+				C985519F2AD2542D009143F9 /* mul_coreml_all.bin in Resources */,
+				C985519E2AD2542D009143F9 /* mv3_coreml_all.pte in Resources */,
+				C98551A02AD2542D009143F9 /* add_coreml_all.bin in Resources */,
+				C98551A22AD2542D009143F9 /* mul_coreml_all.pte in Resources */,
+				C98551A32AD2542D009143F9 /* add_coreml_all.pte in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C965609F2AAC0DCF005F8126 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C94D50E72ABDF80D00AF47FD /* sqlite_error.cpp in Sources */,
+				C94D50FC2ABDF83500AF47FD /* ETCoreMLAsset.mm in Sources */,
+				C94D51062ABDF84400AF47FD /* ETCoreMLLogging.mm in Sources */,
+				C94D50F22ABDF82200AF47FD /* reversed_memory_stream.cpp in Sources */,
+				C94D51022ABDF83E00AF47FD /* ETCoreMLModelManager.mm in Sources */,
+				C94D50F42ABDF82500AF47FD /* asset.mm in Sources */,
+				C94D51042ABDF84100AF47FD /* ETCoreMLStrings.mm in Sources */,
+				C9E7D7932AB3F9BF00CCAE5D /* ETCoreMLAssetManagerTests.mm in Sources */,
+				C9E7D7922AB3F9BF00CCAE5D /* DatabaseTests.mm in Sources */,
+				C9E7D7902AB3F9BF00CCAE5D /* InMemoryFileSystemTests.mm in Sources */,
+				C9E7D7962AB3F9BF00CCAE5D /* KeyValueStoreTests.mm in Sources */,
+				C94D50E52ABDF80A00AF47FD /* database.cpp in Sources */,
+				C94D51082ABDF84800AF47FD /* MLModel_Prewarm.mm in Sources */,
+				C94D50F02ABDF81F00AF47FD /* memory_stream.cpp in Sources */,
+				C9E7D7A22AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm in Sources */,
+				C94BC6492AD5EB400067A63B /* coreml_backend_delegate.mm in Sources */,
+				C9E7D78F2AB3F9BF00CCAE5D /* ETCoreMLTestUtils.mm in Sources */,
+				C94D51002ABDF83C00AF47FD /* ETCoreMLAssetManager.mm in Sources */,
+				C94D50EE2ABDF81B00AF47FD /* memory_buffer.cpp in Sources */,
+				C94D50FE2ABDF83800AF47FD /* ETCoreMLModel.mm in Sources */,
+				C94D510A2ABDF84B00AF47FD /* MLMultiArray_Copy.mm in Sources */,
+				C94D510C2ABDF84F00AF47FD /* serde_json.mm in Sources */,
+				C9E7D7912AB3F9BF00CCAE5D /* ETCoreMLAssetTests.mm in Sources */,
+				C94D50E82ABDF81100AF47FD /* key_value_store.cpp in Sources */,
+				C9E7D7942AB3F9BF00CCAE5D /* BackendDelegateTests.mm in Sources */,
+				C94D50F62ABDF82900AF47FD /* backend_delegate.mm in Sources */,
+				C94D50EA2ABDF81400AF47FD /* statement.cpp in Sources */,
+				C94D50ED2ABDF81900AF47FD /* inmemory_filesystem.cpp in Sources */,
+				C94D50FA2ABDF83200AF47FD /* multiarray.mm in Sources */,
+				C9E7D7952AB3F9BF00CCAE5D /* ETCoreMLModelManagerTests.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		C95266302A7E05FB0016283E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LIBRARY_SEARCH_PATHS = "../../cmake-ios-out/build/**";
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		C95266312A7E05FB0016283E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LIBRARY_SEARCH_PATHS = "../../cmake-ios-out/build/**";
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		C96560AB2AAC0DCF005F8126 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../../../../",
+					"$(SRCROOT)/../delegate",
+					"$(SRCROOT)/../kvstore",
+					"$(SRCROOT)/../inmemoryfs",
+					"$(SRCROOT)/../../third-party/nlohmann_json/single_include/nlohmann",
+					"$(SRCROOT)/../include",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../libraries";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-all_load";
+				PRODUCT_BUNDLE_IDENTIFIER = apple.executorchcoreml.com;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+			};
+			name = Debug;
+		};
+		C96560AC2AAC0DCF005F8126 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../../../../",
+					"$(SRCROOT)/../delegate",
+					"$(SRCROOT)/../kvstore",
+					"$(SRCROOT)/../inmemoryfs",
+					"$(SRCROOT)/../../third-party/nlohmann_json/single_include/nlohmann",
+					"$(SRCROOT)/../include",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../libraries";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-all_load";
+				PRODUCT_BUNDLE_IDENTIFIER = apple.executorchcoreml.com;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C95266262A7E05FB0016283E /* Build configuration list for PBXProject "executorchcoreml" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C95266302A7E05FB0016283E /* Debug */,
+				C95266312A7E05FB0016283E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C96560AA2AAC0DCF005F8126 /* Build configuration list for PBXNativeTarget "executorchcoreml_tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C96560AB2AAC0DCF005F8126 /* Debug */,
+				C96560AC2AAC0DCF005F8126 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C95266232A7E05FB0016283E /* Project object */;
+}

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/xcshareddata/xcschemes/executorchcoreml_runner.xcscheme
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/xcshareddata/xcschemes/executorchcoreml_runner.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C952662A2A7E05FB0016283E"
+               BuildableName = "executorchcoreml_runner"
+               BlueprintName = "executorchcoreml_runner"
+               ReferencedContainer = "container:executorchcoreml.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C952662A2A7E05FB0016283E"
+            BuildableName = "executorchcoreml_runner"
+            BlueprintName = "executorchcoreml_runner"
+            ReferencedContainer = "container:executorchcoreml.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--model_path mv2_all.pte --iterations 10"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C952662A2A7E05FB0016283E"
+            BuildableName = "executorchcoreml_runner"
+            BlueprintName = "executorchcoreml_runner"
+            ReferencedContainer = "container:executorchcoreml.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/xcshareddata/xcschemes/executorchcoreml_tests.xcscheme
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/xcshareddata/xcschemes/executorchcoreml_tests.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C96560A22AAC0DCF005F8126"
+               BuildableName = "executorchcoreml_tests.xctest"
+               BlueprintName = "executorchcoreml_tests"
+               ReferencedContainer = "container:executorchcoreml.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "DYLD_INSERT_LIBRARIES"
+            value = "/usr/lib/libgmalloc.dylib"
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "PrefersMallocStackLoggingLite"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "MallocGuardEdges"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcworkspace/contents.xcworkspacedata
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:executorchcoreml.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/backends/apple/coreml/scripts/build_all.sh
+++ b/backends/apple/coreml/scripts/build_all.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2023 Apple Inc. All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Run this script to sanity check CoreML backend.
+
+SCRIPT_DIR_PATH="$(
+    cd -- "$(dirname "$0")" >/dev/null 2>&1
+    pwd -P
+)"
+
+EXECUTORCH_ROOT_PATH="$SCRIPT_DIR_PATH/../../../../"
+COREML_DIR_PATH="$EXECUTORCH_ROOT_PATH/backends/apple/coreml"
+COREML_EXAMPLES_DIR_PATH="$EXECUTORCH_ROOT_PATH/examples/apple/coreml"
+TEST_ENV_NAME=".coreml-test-env"
+TEST_MODEL_PATH="$COREML_DIR_PATH/runtime/test/models/mv3_coreml_all.pte"
+
+red=`tput setaf 1`
+green=`tput setaf 2`
+
+cd "$EXECUTORCH_ROOT_PATH"
+
+echo "${green}ExecuTorch: Updating git submmodules"
+git submodule sync
+git submodule update --init
+
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to update git submodules."
+    exit 1
+fi
+
+echo "${green}ExecuTorch: Creating virtual environment."
+
+function cleanup {
+    echo "${green}ExecuTorch: Deactivating virtual environment"
+    deactivate
+    rm -rf "$TEST_ENV_NAME"
+}
+
+python3 -m venv "$TEST_ENV_NAME"
+source "$TEST_ENV_NAME/bin/activate"
+trap cleanup EXIT
+
+STATUS=$?
+if [ ${STATUS} -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to create virtual environment."
+    exit 1
+fi
+
+FLATBUFFERS_PATH="$EXECUTORCH_ROOT_PATH/third-party/flatbuffers/cmake-out"
+export PATH="${FLATBUFFERS_PATH}:${PATH}"
+
+echo "${green}ExecuTorch: Installing ExecuTorch requirements"
+source "$EXECUTORCH_ROOT_PATH/install_requirements.sh"
+
+echo "${green}ExecuTorch: Installing CoreML requirements"
+source "$COREML_DIR_PATH/scripts/install_requirements_internal.sh"
+STATUS=$?
+if [ ${STATUS} -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to install dependencies required by CoreML backend."
+    exit 1
+fi
+
+cd "$EXECUTORCH_ROOT_PATH"
+
+# Build CoreML tests
+echo "${green}ExecuTorch: Building CoreML tests"
+source "$COREML_DIR_PATH/scripts/build_tests.sh"
+STATUS=$?
+if [ ${STATUS} -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to build CoreML tests."
+    exit 1
+fi
+
+# Run CoreML tests
+echo "${green}ExecuTorch: Running CoreML tests"
+source "$COREML_DIR_PATH/scripts/run_tests.sh"
+STATUS=$?
+if [ ${STATUS} -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to run CoreML tests."
+    exit 1
+fi
+
+# Build CoreML runner, this also builds the CoreML delegate
+echo "${green}ExecuTorch: Building CoreML executor."
+cd "$EXECUTORCH_ROOT_PATH"
+source "$COREML_EXAMPLES_DIR_PATH/scripts/build_executor_runner.sh"
+STATUS=$?
+if [ ${STATUS} -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to build executor."
+    exit 1
+fi
+
+# Run CoreML runner
+echo "${green}ExecuTorch: Verifying mv3 model"
+$("$EXECUTORCH_ROOT_PATH"/coreml_executor_runner --model_path "$TEST_MODEL_PATH")
+STATUS=$?
+if [ ${STATUS} -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to run runner."
+    exit 1
+fi

--- a/backends/apple/coreml/scripts/build_tests.sh
+++ b/backends/apple/coreml/scripts/build_tests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2023 Apple Inc. All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+SCRIPT_DIR_PATH="$(
+    cd -- "$(dirname "$0")" >/dev/null 2>&1
+    pwd -P
+)"
+
+EXECUTORCH_ROOT_PATH="$SCRIPT_DIR_PATH/../../../../"
+COREML_DIR_PATH="$EXECUTORCH_ROOT_PATH/backends/apple/coreml"
+IOS_TOOLCHAIN_PATH="$COREML_DIR_PATH/third-party/ios-cmake/ios.toolchain.cmake"
+CMAKE_BUILD_DIR_PATH="$COREML_DIR_PATH/cmake-out"
+LIBRARIES_DIR_PATH="$COREML_DIR_PATH/runtime/libraries"
+
+echo "ExecuTorch: Building Tests"
+
+echo "ExecuTorch: Removing build directory $CMAKE_BUILD_DIR"
+rm -rf "$CMAKE_BUILD_DIR_PATH"
+
+# Build executorch
+echo "ExecuTorch: Building executorch"
+cmake "$EXECUTORCH_ROOT_PATH" -B"$CMAKE_BUILD_DIR_PATH" \
+-DCMAKE_TOOLCHAIN_FILE="$IOS_TOOLCHAIN_PATH" \
+-DPLATFORM=MAC_UNIVERSAL \
+-DDEPLOYMENT_TARGET=13.0 \
+-DFLATC_EXECUTABLE="$(which flatc)" \
+-DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF \
+-DEXECUTORCH_BUILD_XNNPACK=OFF \
+-DEXECUTORCH_BUILD_GFLAGS=OFF
+
+cmake --build "$CMAKE_BUILD_DIR_PATH"  -j9 -t executorch
+
+# Copy required libraries
+echo "ExecuTorch: Copying libraries"
+mkdir "$LIBRARIES_DIR_PATH"
+cp -f "$CMAKE_BUILD_DIR_PATH/libexecutorch.a" "$LIBRARIES_DIR_PATH"
+
+source "$SCRIPT_DIR_PATH/generate_test_models.sh"

--- a/backends/apple/coreml/scripts/generate_test_models.sh
+++ b/backends/apple/coreml/scripts/generate_test_models.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2023 Apple Inc. All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+SCRIPT_DIR_PATH="$(
+    cd -- "$(dirname "$0")" >/dev/null 2>&1
+    pwd -P
+)"
+
+EXECUTORCH_ROOT_PATH="$SCRIPT_DIR_PATH/../../../../"
+COREML_DIR_PATH="$EXECUTORCH_ROOT_PATH/backends/apple/coreml"
+
+mkdir "$COREML_DIR_PATH/runtime/test/models/"
+#Generate models
+echo "Executorch: Generating test models"
+cd "$EXECUTORCH_ROOT_PATH"
+
+MODELS=("add" "mul" "mv3")
+for MODEL in "${MODELS[@]}"
+do
+  # TODO: Don't use the script in examples directory. 
+  python3 -m examples.apple.coreml.scripts.export_and_delegate --model_name "$MODEL" --save_processed_bytes
+  mv -f "$MODEL""_coreml_all.pte" "$COREML_DIR_PATH/runtime/test/models"
+  mv -f "$MODEL""_coreml_all.bin" "$COREML_DIR_PATH/runtime/test/models"
+done

--- a/backends/apple/coreml/scripts/install_requirements.sh
+++ b/backends/apple/coreml/scripts/install_requirements.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2023 Apple Inc. All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+SCRIPT_DIR_PATH="$(
+    cd -- "$(dirname "$0")" >/dev/null 2>&1
+    pwd -P
+)"
+
+red=`tput setaf 1`
+green=`tput setaf 2`
+
+EXECUTORCH_ROOT_PATH="$SCRIPT_DIR_PATH/../../../../"
+COREML_DIR_PATH="$EXECUTORCH_ROOT_PATH/backends/apple/coreml"
+
+# clone and install coremltools
+if [ -d "/tmp/coremltools" ]; then
+    rm -rf "/tmp/coremltools"
+fi
+
+echo "${green}ExecuTorch: Cloning coremltools."
+git clone git@github.com:apple/coremltools.git /tmp/coremltools
+cd /tmp/coremltools
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to clone coremltools."
+    exit 1
+fi
+
+echo "${green}ExecuTorch: Installing coremltools dependencies."
+pip install -r /tmp/coremltools/reqs/build.pip
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to install coremltools dependencies."
+    exit 1
+fi
+
+echo "${green}ExecuTorch: Checking out 'executorch_integration' branch in coremltools repo."
+git checkout executorch_integration
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to checkout 'executorch_integration' branch in coremltools repo."
+    exit 1
+fi
+
+mkdir /tmp/coremltools/build
+cmake -S /tmp/coremltools/ -B /tmp/coremltools/build
+cmake --build /tmp/coremltools/build --parallel
+
+echo "${green}ExecuTorch: Installing coremltools."
+pip install /tmp/coremltools
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to install coremltools."
+    exit 1
+fi
+
+cd "$EXECUTORCH_ROOT_PATH"
+
+rm -rf "$COREML_DIR_PATH/third-party"
+mkdir "$COREML_DIR_PATH/third-party"
+
+echo "${green}ExecuTorch: Cloning ios-cmake."
+git clone https://github.com/leetal/ios-cmake.git "$COREML_DIR_PATH/third-party/ios-cmake"
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to clone ios-cmake."
+    exit 1
+fi
+
+echo "${green}ExecuTorch: Cloning nlohmann."
+git clone https://github.com/nlohmann/json.git "$COREML_DIR_PATH/third-party/nlohmann_json"
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to clone nlohmann."
+    exit 1
+fi
+
+echo "${green}ExecuTorch: Installing inmemoryfs extension."
+pip install "$COREML_DIR_PATH/runtime/inmemoryfs"
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to install inmemoryfs extension."
+    exit 1
+fi

--- a/backends/apple/coreml/scripts/install_requirements_internal.sh
+++ b/backends/apple/coreml/scripts/install_requirements_internal.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2023 Apple Inc. All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+SCRIPT_DIR_PATH="$(
+    cd -- "$(dirname "$0")" >/dev/null 2>&1
+    pwd -P
+)"
+
+red=`tput setaf 1`
+green=`tput setaf 2`
+
+EXECUTORCH_ROOT_PATH="$SCRIPT_DIR_PATH/../../../../"
+COREML_DIR_PATH="$EXECUTORCH_ROOT_PATH/backends/apple/coreml"
+
+# clone and install coremltools
+if [ -d "/tmp/coremltools" ]; then
+    rm -rf "/tmp/coremltools"
+fi
+
+if [ -n "${SECRET_TOKEN_COREML_PRIVATE_REPO}" ]; then
+    git clone "https://${SECRET_TOKEN_COREML_PRIVATE_REPO}@github.com/DawerG/coremltools.git" /tmp/coremltools
+else
+    git clone "https://github.com/DawerG/coremltools.git" /tmp/coremltools
+fi
+
+cd /tmp/coremltools
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to clone coremltools."
+    exit 1
+fi
+
+echo "${green}ExecuTorch: Installing coremltools dependencies."
+pip install -r /tmp/coremltools/reqs/build.pip
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to install coremltools dependencies."
+    exit 1
+fi
+
+echo "${green}ExecuTorch: Checking out 'executorch_integration' branch in coremltools repo."
+git checkout executorch_integration
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to checkout 'executorch_integration' branch in coremltools repo."
+    exit 1
+fi
+
+mkdir /tmp/coremltools/build
+cmake -S /tmp/coremltools/ -B /tmp/coremltools/build
+cmake --build /tmp/coremltools/build --parallel
+
+echo "${green}ExecuTorch: Installing coremltools."
+pip install /tmp/coremltools
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to install coremltools."
+    exit 1
+fi
+
+cd "$EXECUTORCH_ROOT_PATH"
+
+rm -rf "$COREML_DIR_PATH/third-party"
+mkdir "$COREML_DIR_PATH/third-party"
+
+echo "${green}ExecuTorch: Cloning ios-cmake."
+git clone https://github.com/leetal/ios-cmake.git "$COREML_DIR_PATH/third-party/ios-cmake"
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to clone ios-cmake."
+    exit 1
+fi
+
+echo "${green}ExecuTorch: Cloning nlohmann."
+git clone https://github.com/nlohmann/json.git "$COREML_DIR_PATH/third-party/nlohmann_json"
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to clone nlohmann."
+    exit 1
+fi
+
+echo "${green}ExecuTorch: Installing inmemoryfs extension."
+pip install "$COREML_DIR_PATH/runtime/inmemoryfs"
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to install inmemoryfs extension."
+    exit 1
+fi

--- a/backends/apple/coreml/scripts/run_tests.sh
+++ b/backends/apple/coreml/scripts/run_tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2023 Apple Inc. All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+SCRIPT_DIR_PATH="$(
+    cd -- "$(dirname "$0")" >/dev/null 2>&1
+    pwd -P
+)"
+
+EXECUTORCH_ROOT_PATH="$SCRIPT_DIR_PATH/../../../../"
+COREML_DIR_PATH="$EXECUTORCH_ROOT_PATH/backends/apple/coreml"
+
+# Run the test
+echo "ExecuTorch: Running executorchcoreml_tests"
+XCODE_WORKSPACE_DIR_PATH="$COREML_DIR_PATH/runtime/workspace"
+XCODE_BUILD_DIR_PATH="$COREML_DIR_PATH/xcode-build"
+
+xcodebuild test -workspace "$XCODE_WORKSPACE_DIR_PATH/executorchcoreml.xcworkspace" -scheme executorchcoreml_tests BUILD_DIR="$XCODE_BUILD_DIR_PATH"

--- a/backends/apple/coreml/setup.md
+++ b/backends/apple/coreml/setup.md
@@ -1,0 +1,71 @@
+# Setting up CoreML backend
+
+This is a tutorial for setting up the CoreML backend.
+
+## AOT Setup
+
+1. Follow the instructions described in [Setting Up ExecuTorch](/docs/source/getting-started-setup.md) to set up ExecuTorch environment.
+
+2. Run `install_requirements.sh` to install dependencies required by the **CoreML** backend.
+
+```
+cd executorch
+
+sh backends/apple/coreml/scripts/install_requirements.sh   
+
+``` 
+
+3. Run the example script to validate that the **CoreML** backend is set up correctly. 
+
+```
+cd executorch
+
+# Saves add_coreml_all.pte in the current directory if successful.
+
+python3 -m examples.apple.coreml.scripts.export_and_delegate --model_name add 
+
+```
+
+4. You can now integrate the **CoreML** backend in code.
+
+```python
+# Lower to CoreML backend
+lowered_module = to_backend('CoreMLBackend', to_be_lowered_exir_submodule, [])
+```
+
+
+## Integrating CoreML delegate into runtime.
+
+1. Follow the instructions described in [Building with CMake](/docs/source/runtime-build-and-cross-compilation.md#building-with-cmake) to set up CMake build system.
+
+2. Install [Xcode](https://developer.apple.com/xcode/).
+
+3. Install Xcode Command Line Tools.
+
+```bash
+xcode-select --install
+```
+
+2. Build **CoreML** delegate. The following will create a `executorch.xcframework` in `cmake-out` directory.
+
+```bash
+cd executorch
+./build/build_apple_frameworks.sh --Release --coreml
+```
+3. Open the project in Xcode, and drag the `executorch.xcframework` generated from Step 2 to Frameworks.
+
+4. Go to project Target’s Build Phases -  Link Binaries With Libraries, click the + sign, and add the following frameworks:
+
+```
+executorch.xcframework
+coreml_backend.xcframework
+```
+
+5. Go to project Target’s Build Phases -  Link Binaries With Libraries, click the + sign, and add the following frameworks.
+```
+- Accelerate.framework
+- CoreML.framework
+- libsqlite3.tbd
+``` 
+
+6. The target could now run a **CoreML** delegated **Program**. 

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -13,6 +13,9 @@
 {% elif 'qualcomm-ai-engine-direct-backend' in pagename%}
 <link rel="stylesheet" href="../_static/css/progress-bar.css">
 <script src="../_static/js/progress-bar.js" defer></script>
+{% elif 'coreml' in pagename%}
+<link rel="stylesheet" href="../_static/css/progress-bar.css">
+<script src="../_static/js/progress-bar.js" defer></script>
 {% elif 'mps' in pagename%}
 <link rel="stylesheet" href="../_static/css/progress-bar.css">
 <script src="../_static/js/progress-bar.js" defer></script>

--- a/docs/source/build-run-coreml.md
+++ b/docs/source/build-run-coreml.md
@@ -1,0 +1,162 @@
+<!---- To make this progress bar work users will need to modify source/_templates/layout.html >
+<!---- To make this page show up in the tutorials section users will need to add an entry in source/index.rst under the Tutorials section>
+
+<!---- DO NOT MODIFY Progress Bar Start --->
+
+<div class="progress-bar-wrapper">
+   <div class="progress-bar-item">
+     <div class="step-number" id="step-1">1</div>
+     <span class="step-caption" id="caption-1"></span>
+   </div>
+   <div class="progress-bar-item">
+     <div class="step-number" id="step-2">2</div>
+     <span class="step-caption" id="caption-2"></span>
+   </div>
+   <div class="progress-bar-item">
+     <div class="step-number" id="step-3">3</div>
+     <span class="step-caption" id="caption-3"></span>
+   </div>
+   <div class="progress-bar-item">
+     <div class="step-number" id="step-4">4</div>
+     <span class="step-caption" id="caption-4"></span>
+   </div>
+</div>
+
+<!---- DO NOT MODIFY Progress Bar End--->
+
+# Building and Running ExecuTorch on CoreML Backend
+
+CoreML delegate uses CoreML apis to enable running neural networks via Apple's hardware acceleration. For more about coreml you can read [here](https://developer.apple.com/documentation/coreml). In this tutorial we will walk through steps of lowering a PyTorch model to CoreML delegate
+
+
+::::{grid} 2
+:::{grid-item-card}  What you will learn in this tutorial:
+:class-card: card-prerequisites
+* In this tutorial you will learn how to export [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model so that it runs on CoreML backend.
+* You will also learn how to deploy and run the exported model on a supported Apple device.
+:::
+:::{grid-item-card}  Tutorials we recommend you complete before this:
+:class-card: card-prerequisites
+* [Introduction to ExecuTorch](intro-how-it-works.md)
+* [Setting up ExecuTorch](getting-started-setup.md)
+* [Building ExecuTorch with CMake](runtime-build-and-cross-compilation.md)
+* [ExecuTorch iOS Demo App](demo-apps-ios.md)
+:::
+::::
+
+
+## Prerequisites (Hardware and Software)
+
+In order to be able to successfully build and run the ExecuTorch's CoreML backend you'll need the following hardware and software components.
+
+### Hardware:
+- A [mac](https://www.apple.com/mac/]) system for building.
+- A [mac](https://www.apple.com/mac/]) or [iPhone](https://www.apple.com/iphone/) or [iPad](https://www.apple.com/ipad/) or [Apple TV](https://www.apple.com/tv-home/) device for running the model.
+
+### Software:
+
+- [Xcode](https://developer.apple.com/documentation/xcode) >= 14.1, [macOS](https://developer.apple.com/macos) >= 13.0 for building.
+- [macOS](https://developer.apple.com/macos) >= 13.0, [iOS](https://developer.apple.com/ios/) >= 16.0, [iPadOS](https://developer.apple.com/ipados/) >= 16.0, and [tvOS](https://developer.apple.com/tvos/) >= 16.0 for running the model.
+
+## Setting up your developer environment
+
+1. Make sure that you have completed the ExecuTorch setup tutorials linked to at the top of this page and setup the environment.
+2. Run `install_requirements.sh` to install dependencies required by the **CoreML** backend.
+
+```bash
+cd executorch
+sh backends/apple/coreml/scripts/install_requirements.sh
+```
+3. Install [Xcode](https://developer.apple.com/xcode/).
+4. Install Xcode Command Line Tools.
+
+```bash
+xcode-select --install
+```
+
+## Build
+
+### AOT (Ahead-of-time) components:
+
+
+**Exporting a CoreML delegated Program**:
+- In this step, you will lower the [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model to the CoreML backend and export the ExecuTorch program. You'll then deploy and run the exported program on a supported Apple device using CoreML backend.
+```bash
+cd executorch
+
+# Generates ./mv3_coreml_all.pte file.
+python3 -m examples.apple.coreml.scripts.export_and_delegate --model_name mv3
+```
+
+- CoreML backend uses [coremltools](https://apple.github.io/coremltools/docs-guides/source/overview-coremltools.html) to lower [Edge dialect](ir-exir.md#edge-dialect) to CoreML format and then bundles it in the `.pte` file.
+
+
+### Runtime:
+
+**Running the CoreML delegated Program**:
+1. Build the runner.
+```bash
+cd executorch
+
+# Generates ./coreml_executor_runner.
+sh examples/apple/coreml/scripts/build_executor_runner.sh
+```
+2. Run the exported program.
+```bash
+cd executorch
+
+# Runs the exported mv3 model on the CoreML backend.
+./coreml_executor_runner --model_path mv3_coreml_all.pte
+```
+
+## Deploying and running on a device
+
+**Running the CoreML delegated Program using the Demo iOS App**:
+1. Please follow the [Export Model](demo-apps-ios.md#models-and-labels) step of the tutorial to bundle the exported [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) program. You only need to do the CoreML part.
+
+2. Complete the [Build Runtime and Backends](demo-apps-ios.md#build-runtime-and-backends) section of the tutorial. When building the frameworks you only need the `coreml` option.
+
+3. Complete the [Final Steps](demo-apps-ios.md#final-steps) section of the tutorial to build and run the demo app.
+
+<br>**Running the CoreML delegated Program using your own App**
+1. Build **CoreML** delegate. The following will create a `executorch.xcframework` in the `cmake-out` directory.
+```bash
+cd executorch
+./build/build_apple_frameworks.sh --Release --coreml
+```
+2. Create a new [Xcode project](https://developer.apple.com/documentation/xcode/creating-an-xcode-project-for-an-app#) or open an existing project.
+
+3. Drag the `executorch.xcframework` generated from Step 2 to Frameworks.
+
+4. Go to the project's [Build Phases](https://developer.apple.com/documentation/xcode/customizing-the-build-phases-of-a-target) -  Link Binaries With Libraries, click the + sign, and add the following frameworks:
+```
+- executorch.xcframework
+- coreml_backend.xcframework
+- Accelerate.framework
+- CoreML.framework
+- libsqlite3.tbd
+```
+5. Add the exported program to the [Copy Bundle Phase](https://developer.apple.com/documentation/xcode/customizing-the-build-phases-of-a-target#Copy-files-to-the-finished-product) of your Xcode target.
+
+6. Please follow the [running a model](running-a-model-cpp-tutorial.md) tutorial to integrate the code for loading a ExecuTorch program.
+
+7. Update the code to load the program from the Application's bundle.
+``` objective-c
+using namespace torch::executor;
+
+NSURL *model_url = [NBundle.mainBundle URLForResource:@"mv3_coreml_all" extension:@"pte"];
+
+Result<util::FileDataLoader> loader =
+        util::FileDataLoader::from(model_url.path.UTF8String);
+
+```
+
+8. Use [Xcode](https://developer.apple.com/documentation/xcode/building-and-running-an-app#Build-run-and-debug-your-app) to deploy the application on the device.
+
+9. The application can now run the [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model on the CoreML backend.
+
+<br>In this tutorial, you have learned how to lower the [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model to the CoreML backend, deploy, and run it on an Apple device.
+
+## Frequently encountered errors and resolution.
+
+If you encountered any bugs or issues following this tutorial please file a bug/issue [here](https://github.com/pytorch/executorch/issues) with tag #coreml.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -94,6 +94,7 @@ Topics in this section will help you get started with ExecuTorch.
    build-run-xtensa
    build-run-qualcomm-ai-engine-direct-backend
    build-run-mps
+   build-run-coreml
    tutorials/sdk-integration-tutorial
    executorch-arm-delegate-tutorial
    tutorial-xnnpack-delegate-lowering

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,8 @@ examples
 ├── arm                               # Contains demos of the Arm TOSA and Ethos-U NPU flows
 ├── qualcomm                          # Contains demos of Qualcomm QNN backend
 ├── xtensa                            # Contains demos of exporting and running a simple model on Xtensa Hifi4 DSP
+├── apple
+|   └── coreml                        # Contains demos of Apple's CoreML backend
 ├── demo-apps                         # Contains demo apps for Android and iOS
 ├── third-party                       # Third-party libraries required for working on the demos
 └── README.md                         # This file
@@ -58,6 +60,9 @@ You will find demos of [ExecuTorch QNN Backend](./qualcomm) in the [`qualcomm/`]
 
 The [`xtensa/`](./xtensa) directory hosts a demo that showcases the process of exporting and executing a model on Xtensa Hifi4 DSP. You can utilize [this tutorial](../docs/source/build-run-xtensa.md) to guide you in configuring the demo and running it.
 
+## Demo of ExecuTorch Apple Backend
+
+You will find demos of [ExecuTorch CoreML Backend](./apple/coreml/) in the [`apple/coreml/`](./apple/coreml) directory.
 
 ## Dependencies
 

--- a/examples/apple/coreml/.gitignore
+++ b/examples/apple/coreml/.gitignore
@@ -1,0 +1,19 @@
+# Mac OS X
+*.DS_Store
+
+cmake-out/
+
+
+# Xcode
+*.pbxuser
+*.mode1v3
+*.mode2v3
+*.perspectivev3
+*.xcuserstate
+project.xcworkspace/
+xcuserdata
+
+executor_runner/include/
+executor_runner/libraries/
+
+xcode-build/

--- a/examples/apple/coreml/README.md
+++ b/examples/apple/coreml/README.md
@@ -1,0 +1,72 @@
+# Examples
+
+This directory contains scripts and other helper utilities to illustrate an end-to-end workflow to run a **CoreML** delegated `torch.nn.module` with the **ExecuTorch** runtime.
+
+
+## Directory structure
+```bash
+coreml
+├── scripts             # Scripts to build the runner.
+├── executor_runner     # The runner implementation.
+└── README.md           # This file.
+```
+
+## Using the examples
+
+We will walk through an example model to generate a **CoreML** delegated binary file from a python `torch.nn.module` then we will use the `coreml/executor_runner` to run the exported binary file.
+
+1. Following the setup guide in [Setting Up ExecuTorch](/docs/source/getting-started-setup.md)
+you should be able to get the basic development environment for ExecuTorch working.
+
+2. Run `install_requirements.sh` to install dependencies required by the **CoreML** backend.
+
+```bash
+cd executorch
+
+sh backends/apple/coreml/scripts/install_requirements.sh
+
+```
+
+3. Run the export script to generate a **CoreML** delegated binary file.
+
+```bash
+cd executorch
+
+# To get a list of example models
+python3 -m examples.portable.scripts.export -h
+
+# Generates ./add_coreml_all.pte file if successful.
+python3 -m examples.apple.coreml.scripts.export_and_delegate --model_name add
+```
+
+4. Once we have the **CoreML** delegated model binary (pte) file, then let's run it with the **ExecuTorch** runtime using the `coreml_executor_runner`.
+
+```bash
+cd executorch
+
+# Builds the CoreML executor runner. Generates ./coreml_executor_runner if successful.
+sh examples/apple/coreml/scripts/build_executor_runner.sh
+
+# Run the CoreML delegate model.
+./coreml_executor_runner --model_path add_coreml_all.pte
+```
+
+## Frequently encountered errors and resolution.
+- The `examples.apple.coreml.scripts.export_and_delegate` could fail if the model is not supported by the **CoreML** backend. The following models from the examples models list (` python3 -m examples.portable.scripts.export -h`)are currently supported by the **CoreML** backend.
+
+```
+add
+add_mul
+ic4
+linear
+mul
+mv2
+mv3
+resnet18
+resnet50
+softmax
+vit
+w2l
+```
+
+- If you encountered any bugs or issues following this tutorial please file a bug/issue [here](https://github.com/pytorch/executorch/issues) with tag #coreml.

--- a/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.pbxproj
+++ b/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.pbxproj
@@ -1,0 +1,334 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		C94D51592ACF4BFC00AF47FD /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = C94D51582ACF4BFC00AF47FD /* main.mm */; };
+		C94D515E2ACFCBA000AF47FD /* libexecutorch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D515C2ACFCBA000AF47FD /* libexecutorch.a */; };
+		C94D51622ACFCBBA00AF47FD /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51612ACFCBBA00AF47FD /* libsqlite3.tbd */; };
+		C94D51642ACFCBC500AF47FD /* CoreML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51632ACFCBC500AF47FD /* CoreML.framework */; };
+		C94D51662ACFCBCB00AF47FD /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51652ACFCBCB00AF47FD /* Accelerate.framework */; };
+		C94D51682ACFCC7100AF47FD /* libcoremldelegate.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51672ACFCC7100AF47FD /* libcoremldelegate.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		C94D514C2ACF4B9300AF47FD /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		C94D514E2ACF4B9300AF47FD /* coreml_executor_runner */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = coreml_executor_runner; sourceTree = BUILT_PRODUCTS_DIR; };
+		C94D51582ACF4BFC00AF47FD /* main.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
+		C94D515C2ACFCBA000AF47FD /* libexecutorch.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libexecutorch.a; path = libraries/libexecutorch.a; sourceTree = "<group>"; };
+		C94D515D2ACFCBA000AF47FD /* libgflags_nothreads_debug.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgflags_nothreads_debug.a; path = libraries/libgflags_nothreads_debug.a; sourceTree = "<group>"; };
+		C94D51612ACFCBBA00AF47FD /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
+		C94D51632ACFCBC500AF47FD /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = System/Library/Frameworks/CoreML.framework; sourceTree = SDKROOT; };
+		C94D51652ACFCBCB00AF47FD /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		C94D51672ACFCC7100AF47FD /* libcoremldelegate.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcoremldelegate.a; path = libraries/libcoremldelegate.a; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C94D514B2ACF4B9300AF47FD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C94D51682ACFCC7100AF47FD /* libcoremldelegate.a in Frameworks */,
+				C94D51662ACFCBCB00AF47FD /* Accelerate.framework in Frameworks */,
+				C94D51642ACFCBC500AF47FD /* CoreML.framework in Frameworks */,
+				C94D51622ACFCBBA00AF47FD /* libsqlite3.tbd in Frameworks */,
+				C94D515E2ACFCBA000AF47FD /* libexecutorch.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C94D51452ACF4B9300AF47FD = {
+			isa = PBXGroup;
+			children = (
+				C94D51582ACF4BFC00AF47FD /* main.mm */,
+				C94D514F2ACF4B9300AF47FD /* Products */,
+				C94D51602ACFCBBA00AF47FD /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		C94D514F2ACF4B9300AF47FD /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C94D514E2ACF4B9300AF47FD /* coreml_executor_runner */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C94D51602ACFCBBA00AF47FD /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C94D51652ACFCBCB00AF47FD /* Accelerate.framework */,
+				C94D51632ACFCBC500AF47FD /* CoreML.framework */,
+				C94D515C2ACFCBA000AF47FD /* libexecutorch.a */,
+				C94D515D2ACFCBA000AF47FD /* libgflags_nothreads_debug.a */,
+				C94D51612ACFCBBA00AF47FD /* libsqlite3.tbd */,
+				C94D51672ACFCC7100AF47FD /* libcoremldelegate.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C94D514D2ACF4B9300AF47FD /* coreml_executor_runner */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C94D51552ACF4B9300AF47FD /* Build configuration list for PBXNativeTarget "coreml_executor_runner" */;
+			buildPhases = (
+				C94D514A2ACF4B9300AF47FD /* Sources */,
+				C94D514B2ACF4B9300AF47FD /* Frameworks */,
+				C94D514C2ACF4B9300AF47FD /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = coreml_executor_runner;
+			productName = executorch_runner;
+			productReference = C94D514E2ACF4B9300AF47FD /* coreml_executor_runner */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C94D51462ACF4B9300AF47FD /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					C94D514D2ACF4B9300AF47FD = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = C94D51492ACF4B9300AF47FD /* Build configuration list for PBXProject "coreml_executor_runner" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = C94D51452ACF4B9300AF47FD;
+			productRefGroup = C94D514F2ACF4B9300AF47FD /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C94D514D2ACF4B9300AF47FD /* coreml_executor_runner */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C94D514A2ACF4B9300AF47FD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C94D51592ACF4BFC00AF47FD /* main.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		C94D51532ACF4B9300AF47FD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		C94D51542ACF4B9300AF47FD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		C94D51562ACF4B9300AF47FD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../../../../",
+					"$(SRCROOT)/include",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(SRCROOT)/libraries",
+					"$(PROJECT_DIR)/libraries",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				OTHER_LDFLAGS = "-all_load";
+				PRODUCT_BUNDLE_IDENTIFIER = apple.executorchcoreml.com;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		C94D51572ACF4B9300AF47FD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../../../../",
+					"$(SRCROOT)/include",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(SRCROOT)/libraries",
+					"$(PROJECT_DIR)/libraries",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				OTHER_LDFLAGS = "-all_load";
+				PRODUCT_BUNDLE_IDENTIFIER = apple.executorchcoreml.com;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C94D51492ACF4B9300AF47FD /* Build configuration list for PBXProject "coreml_executor_runner" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C94D51532ACF4B9300AF47FD /* Debug */,
+				C94D51542ACF4B9300AF47FD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C94D51552ACF4B9300AF47FD /* Build configuration list for PBXNativeTarget "coreml_executor_runner" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C94D51562ACF4B9300AF47FD /* Debug */,
+				C94D51572ACF4B9300AF47FD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C94D51462ACF4B9300AF47FD /* Project object */;
+}

--- a/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/apple/coreml/executor_runner/coreml_executor_runner.xcworkspace/contents.xcworkspacedata
+++ b/examples/apple/coreml/executor_runner/coreml_executor_runner.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:coreml_executor_runner.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/apple/coreml/executor_runner/coreml_executor_runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/apple/coreml/executor_runner/coreml_executor_runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/apple/coreml/executor_runner/main.mm
+++ b/examples/apple/coreml/executor_runner/main.mm
@@ -1,0 +1,283 @@
+//
+// main.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <Foundation/Foundation.h>
+
+#import <chrono>
+#import <memory>
+#import <numeric>
+#import <string>
+
+#import <executorch/extension/data_loader/file_data_loader.h>
+#import <executorch/runtime/executor/method.h>
+#import <executorch/runtime/executor/program.h>
+#import <executorch/runtime/platform/log.h>
+#import <executorch/runtime/platform/profiler.h>
+#import <executorch/runtime/platform/runtime.h>
+#import <executorch/util/util.h>
+
+#import <coreml_backend/delegate.h>
+
+static inline id check_class(id obj, Class cls) {
+    return [obj isKindOfClass:cls] ? obj : nil;
+}
+
+#define SAFE_CAST(Object, Type) ((Type *)check_class(Object, [Type class]))
+
+using namespace torch::executor;
+using torch::executor::util::FileDataLoader;
+
+static constexpr size_t kRuntimeMemorySize = 16 * 1024U * 1024U; // 16 MB
+
+namespace {
+
+struct Args {
+    std::string model_path;
+    std::string prof_result_path = "prof_result.bin";
+    size_t iterations = 1;
+    bool purge_models_cache = false;
+
+    Args(NSDictionary<NSString *, NSString *> *params) {
+        {
+            NSString *value = SAFE_CAST(params[@"--model_path"], NSString);
+            if (value.length > 0) {
+                model_path = value.UTF8String;
+            }
+        }
+        {
+            NSString *value = SAFE_CAST(params[@"--prof_result_path"], NSString);
+            if (value.length > 0) {
+                prof_result_path = value.UTF8String;
+            }
+        }
+        {
+            NSString *value = SAFE_CAST(params[@"--iterations"], NSString);
+            if (value.length > 0) {
+                iterations = value.integerValue;
+            }
+        }
+        {
+            NSString *value = SAFE_CAST(params[@"--purge_models_cache"], NSString);
+            if (value.length > 0) {
+                purge_models_cache = value.boolValue;
+            }
+        }
+    }
+};
+
+NSString *clean_string(NSString *value) {
+    return [value stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+}
+
+NSSet<NSString *> *all_keys() {
+    return [NSSet setWithObjects:@"--model_path", @"--iterations", @"--purge_models_cache", @"--prof_result_path", nil];
+}
+
+Args parse_command_line_args(NSArray<NSString *> *args) {
+    NSMutableDictionary<NSString *, NSString *> *params = [[NSMutableDictionary alloc] initWithCapacity:args.count];
+    NSMutableSet<NSString *> *keys = [all_keys() mutableCopy];
+    NSMutableString *values = [NSMutableString string];
+    NSString *key = @"";
+    for (NSString *arg in args) {
+        NSString *value = clean_string(arg);
+        if (![keys containsObject:value]) {
+            if (value.length == 0) {
+                continue;
+            }
+            if (values.length > 0) {
+                [values appendString:@"\t"];
+            }
+            [values appendString:value];
+            continue;
+        }
+        [keys removeObject:value];
+        params[key] = values;
+        key = value;
+        values = [NSMutableString string];
+    }
+
+    if (key.length > 0) {
+        params[key] = values.length > 0 ? clean_string(values.copy) : @"";
+    }
+
+    return Args(params);
+}
+
+NSData * _Nullable read_data(const std::string& file_path) {
+    NSError *localError = nil;
+    NSURL *url = [NSURL fileURLWithPath:@(file_path.c_str())];
+    NSData *data = [NSData dataWithContentsOfURL:url options:NSDataReadingMappedIfSafe error:&localError];
+    ET_CHECK_MSG(data != nil, "Failed to read data from path=%s", file_path.c_str());
+    return data;
+}
+
+class DataLoaderImpl: public DataLoader {
+public:
+    DataLoaderImpl(const std::string& filePath)
+    :data_(read_data(filePath))
+    {}
+
+    Result<FreeableBuffer> Load(size_t offset, size_t size) override {
+        NSData *subdata = [data_ subdataWithRange:NSMakeRange(offset, size)];
+        return FreeableBuffer(subdata.bytes, size, nullptr);
+    }
+
+    Result<size_t> size() const override {
+        return data_.length;
+    }
+
+private:
+   NSData *data_;
+};
+
+using Buffer = std::vector<uint8_t>;
+
+std::unique_ptr<Program> get_program(NSURL *url) {
+    DataLoaderImpl dataLoader(url.path.UTF8String);
+    auto program = Program::load(&dataLoader);
+    if (!program.ok()) {
+        return nullptr;
+    }
+
+    return std::make_unique<Program>(std::move(program.get()));
+}
+
+Result<std::string> get_method_name(Program *program) {
+    const auto methodName = program->get_method_name(0);
+    if (!methodName.ok()) {
+        return Error::InvalidProgram;
+    }
+
+    return std::string(methodName.get());
+}
+
+Result<std::vector<Buffer>>
+get_planned_buffers(const std::string& method_name, Program *program) {
+    auto method_meta = program->method_meta(method_name.c_str());
+    if (!method_meta.ok()) {
+        return Error::InvalidProgram;
+    }
+
+    std::vector<std::vector<uint8_t>> buffers;
+    buffers.reserve(method_meta->num_memory_planned_buffers());
+    for (size_t bufferID = 0; bufferID < method_meta->num_memory_planned_buffers(); ++bufferID) {
+        auto buffer_size = method_meta->memory_planned_buffer_size(bufferID);
+        std::vector<uint8_t> data(buffer_size.get(), 0);
+        buffers.emplace_back(std::move(data));
+    }
+
+    return buffers;
+}
+
+std::vector<Span<uint8_t>> to_spans(std::vector<Buffer>& buffers) {
+    std::vector<Span<uint8_t>> result;
+    result.reserve(buffers.size());
+    for (auto& buffer : buffers) {
+        result.emplace_back(buffer.data(), buffer.size());
+    }
+
+    return result;
+}
+
+double calculate_mean(const std::vector<double>& durations) {
+    if (durations.size() == 0) {
+        return 0.0;
+    }
+
+    return std::accumulate(durations.begin(), durations.end(), 0.0)/durations.size();
+}
+
+void dump_profile_data(const std::string& prof_result_path) {
+    // Dump the profiling data to the specified file.
+    torch::executor::prof_result_t prof_result;
+    EXECUTORCH_DUMP_PROFILE_RESULTS(&prof_result);
+    if (prof_result.num_bytes != 0) {
+      FILE* ptr = fopen(prof_result_path.c_str(), "w+");
+      fwrite(prof_result.prof_data, 1, prof_result.num_bytes, ptr);
+      fclose(ptr);
+    }
+}
+
+Error execute_method(Method *method, size_t n, std::vector<double>& durations) {
+    Error status = Error::Ok;
+    durations.reserve(static_cast<size_t>(n));
+    for (int i = 0; i < n; i++) {
+        auto start_time = std::chrono::steady_clock::now();
+        status = method->execute();
+        auto current_time = std::chrono::steady_clock::now();
+        if (status != Error::Ok) {
+            break;
+        }
+        auto diff = current_time - start_time;
+        durations.emplace_back(std::chrono::duration<double, std::milli>(diff).count());
+    }
+
+    return status;
+}
+}
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        runtime_init();
+
+        auto args = parse_command_line_args([[NSProcessInfo processInfo] arguments]);
+        if (args.purge_models_cache) {
+            ET_LOG(Info, "Purging models cache");
+            auto delegate = CoreMLBackendDelegate::get_registered_delegate();
+            delegate->purge_models_cache();
+        }
+
+        if (args.model_path.empty()) {
+            ET_LOG(Error, "Model path is empty.");
+            return EXIT_FAILURE;
+        }
+
+        NSURL *model_url = [NSURL fileURLWithPath:@(args.model_path.c_str())];
+        ET_CHECK_MSG(model_url != nil, "Model path=%s is invalid", args.model_path.c_str());
+
+        auto program = get_program(model_url);
+        ET_CHECK_MSG(program != nil, "Failed to load program from path=%s", args.model_path.c_str());
+
+        auto method_name = get_method_name(program.get());
+        ET_CHECK_MSG(method_name.ok(), "Failed to get method name from program=%p", program.get());
+
+        auto plannedBuffers = get_planned_buffers(method_name.get(), program.get());
+        Buffer method_buffer(kRuntimeMemorySize, 0);
+        MemoryAllocator method_allocator(static_cast<int32_t>(method_buffer.size()), method_buffer.data());
+        auto spans = to_spans(plannedBuffers.get());
+        HierarchicalAllocator planned_allocator(Span<Span<uint8_t>>(reinterpret_cast<Span<uint8_t> *>(spans.data()), spans.size()));
+        MemoryManager memory_manager(&method_allocator, &planned_allocator);
+
+        auto load_start_time = std::chrono::steady_clock::now();
+        auto method = program->load_method(method_name.get().c_str(), &memory_manager);
+        auto load_duration = std::chrono::steady_clock::now() - load_start_time;
+        ET_LOG(Info, "Load duration = %f",std::chrono::duration<double, std::milli>(load_duration).count());
+
+        ET_CHECK_MSG(method_name.ok(), "Failed to load method with name=%s from program=%p", method_name.get().c_str(), program.get());
+        ET_LOG(Info, "Running method = %s", method_name.get().c_str());
+
+        auto inputs = util::PrepareInputTensors(*method);
+        ET_LOG(Info, "Inputs prepared.");
+
+        // Run the model.
+        std::vector<double> durations;
+        Error status = execute_method(&method.get(), args.iterations, durations);
+        ET_CHECK_MSG(status == Error::Ok, "Execution of method %s failed with status 0x%" PRIx32, method_name.get().c_str(), status);
+        ET_LOG(Info, "Model executed successfully.");
+
+        double mean = calculate_mean(durations);
+        ET_LOG(Info, "Inference latency=%.2fms.", mean);
+
+        auto outputs = method_allocator.allocateList<EValue>(method->outputs_size());
+        status = method->get_outputs(outputs, method->outputs_size());
+        ET_CHECK(status == Error::Ok);
+
+        dump_profile_data(args.prof_result_path);
+        util::FreeInputs(inputs);
+        return 0;
+    }
+}

--- a/examples/apple/coreml/scripts/build_executor_runner.sh
+++ b/examples/apple/coreml/scripts/build_executor_runner.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2023 Apple Inc. All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+SCRIPT_DIR_PATH="$(
+    cd -- "$(dirname "$0")" >/dev/null 2>&1
+    pwd -P
+)"
+
+EXECUTORCH_ROOT_PATH="$SCRIPT_DIR_PATH/../../../../"
+COREML_DIR_PATH="$EXECUTORCH_ROOT_PATH/backends/apple/coreml"
+EXAMPLES_COREML_DIR_PATH="$EXECUTORCH_ROOT_PATH/examples/apple/coreml"
+IOS_TOOLCHAIN_PATH="$COREML_DIR_PATH/third-party/ios-cmake/ios.toolchain.cmake"
+CMAKE_BUILD_DIR_PATH="$EXAMPLES_COREML_DIR_PATH/cmake-out"
+LIBRARIES_DIR_PATH="$EXAMPLES_COREML_DIR_PATH/executor_runner/libraries"
+INCLUDE_DIR_PATH="$EXAMPLES_COREML_DIR_PATH/executor_runner/include"
+
+echo "ExecuTorch: Building executor_runner"
+
+echo "ExecuTorch: Removing build directory $CMAKE_BUILD_DIR"
+rm -rf "$CMAKE_BUILD_DIR_PATH"
+
+# Build executorch
+echo "ExecuTorch: Building executorch"
+cmake "$EXECUTORCH_ROOT_PATH" -B"$CMAKE_BUILD_DIR_PATH" \
+-DCMAKE_TOOLCHAIN_FILE="$IOS_TOOLCHAIN_PATH" \
+-DPLATFORM=MAC_UNIVERSAL \
+-DDEPLOYMENT_TARGET=13.0 \
+-DFLATC_EXECUTABLE="$(which flatc)" \
+-DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF \
+-DEXECUTORCH_BUILD_XNNPACK=OFF \
+-DEXECUTORCH_BUILD_COREML=ON
+
+cmake --build "$CMAKE_BUILD_DIR_PATH" -j9 -t coremldelegate -t gflags_nothreads_static
+
+# Copy include headers
+echo "ExecuTorch: Copying headers"
+mkdir "$INCLUDE_DIR_PATH"
+cp -rf "$COREML_DIR_PATH/runtime/include/" "$INCLUDE_DIR_PATH"
+
+# Copy required libraries
+echo "ExecuTorch: Copying libraries"
+mkdir "$LIBRARIES_DIR_PATH"
+cp -f "$CMAKE_BUILD_DIR_PATH/libexecutorch.a" "$LIBRARIES_DIR_PATH"
+cp -f "$CMAKE_BUILD_DIR_PATH/backends/apple/coreml/libcoremldelegate.a" "$LIBRARIES_DIR_PATH"
+
+# Build the runner
+echo "ExecuTorch: Building runner"
+XCODE_WORKSPACE_DIR_PATH="$EXAMPLES_COREML_DIR_PATH/executor_runner"
+XCODE_BUILD_DIR_PATH="$EXAMPLES_COREML_DIR_PATH/xcode-build"
+
+xcodebuild build -workspace "$XCODE_WORKSPACE_DIR_PATH/coreml_executor_runner.xcworkspace" -scheme coreml_executor_runner BUILD_DIR="$XCODE_BUILD_DIR_PATH"
+mv -f "$XCODE_BUILD_DIR_PATH/DEBUG/coreml_executor_runner" "$PWD"

--- a/examples/apple/coreml/scripts/export_and_delegate.py
+++ b/examples/apple/coreml/scripts/export_and_delegate.py
@@ -1,0 +1,140 @@
+# Copyright © 2023 Apple Inc. All rights reserved.
+#
+# Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+import argparse
+
+import pathlib
+import sys
+
+import executorch.exir as exir
+import torch
+
+from executorch.backends.apple.coreml.compiler import CoreMLBackend
+
+from executorch.exir.backend.backend_api import to_backend
+from executorch.exir.backend.compile_spec_schema import CompileSpec
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent.parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples"
+sys.path.append(str(EXAMPLES_DIR.absolute()))
+
+from models import MODEL_NAME_TO_MODEL
+from models.model_factory import EagerModelFactory
+
+# Script to export a model with coreml delegation.
+
+_CAPTURE_CONFIG = exir.CaptureConfig(enable_aot=True, _unlift=False)
+_EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(
+    _check_ir_validity=False,
+)
+
+
+def lower_module_to_coreml(module, compute_units):
+    module = module.eval()
+    edge = exir.capture(module, example_inputs, _CAPTURE_CONFIG).to_edge(
+        _EDGE_COMPILE_CONFIG
+    )
+
+    lowered_module = to_backend(
+        CoreMLBackend.__name__,
+        edge.exported_program,
+        [CompileSpec("compute_units", bytes(compute_units, "utf-8"))],
+    )
+
+    return lowered_module
+
+
+def export_lowered_module_to_executorch_program(lowered_module, example_inputs):
+    class CompositeModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lowered_module = lowered_module
+
+        def forward(self, *args):
+            return self.lowered_module(*args)
+
+    composite_model = CompositeModule()
+    composite_model(*example_inputs)
+
+    exec_prog = (
+        exir.capture(composite_model, example_inputs, _CAPTURE_CONFIG)
+        .to_edge(_EDGE_COMPILE_CONFIG)
+        .to_executorch()
+    )
+
+    return exec_prog
+
+
+def save_executorch_program(exec_prog, model_name, compute_units):
+    buffer = exec_prog.buffer
+    filename = f"{model_name}_coreml_{compute_units}.pte"
+    print(f"Saving exported program to {filename}")
+    with open(filename, "wb") as file:
+        file.write(buffer)
+    return
+
+
+def save_processed_bytes(processed_bytes, model_name, compute_units):
+    filename = f"{model_name}_coreml_{compute_units}.bin"
+    print(f"Saving processed bytes to {filename}")
+    with open(filename, "wb") as file:
+        file.write(processed_bytes)
+    return
+
+
+compute_units = ["cpu_only", "cpu_and_gpu", "cpu_and_ane", "all"]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-m",
+        "--model_name",
+        required=True,
+        help=f"Provide model name. Valid ones: {list(MODEL_NAME_TO_MODEL.keys())}",
+    )
+
+    parser.add_argument(
+        "-c",
+        "--compute_units",
+        required=False,
+        default="all",
+        help=f"Provide compute units. Valid ones: {compute_units}",
+    )
+
+    parser.add_argument("--save_processed_bytes", action=argparse.BooleanOptionalAction)
+
+    args = parser.parse_args()
+
+    if args.model_name not in MODEL_NAME_TO_MODEL:
+        raise RuntimeError(
+            f"Model {args.model_name} is not a valid name. "
+            f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}."
+        )
+
+    if args.compute_units not in compute_units:
+        raise RuntimeError(
+            f"{args.compute_units} is invalid. "
+            f"Valid compute units are {compute_units}."
+        )
+
+    model, example_inputs = EagerModelFactory.create_model(
+        *MODEL_NAME_TO_MODEL[args.model_name]
+    )
+
+    lowered_module = lower_module_to_coreml(
+        model,
+        args.compute_units,
+    )
+
+    exec_program = export_lowered_module_to_executorch_program(
+        lowered_module,
+        example_inputs,
+    )
+
+    save_executorch_program(exec_program, args.model_name, args.compute_units)
+
+    if args.save_processed_bytes:
+        save_processed_bytes(
+            lowered_module.processed_bytes, args.model_name, args.compute_units
+        )


### PR DESCRIPTION
- CoreML backend related files are in the backends/coreml directory. Please refer to the setup.md files for the setup instructions.
- There is an `examples/export/coreml_export_and_delegate.py` file that's used for delegating the Program to CoreML backend.
- We added `ios-cmake` as a dependency for building the library  but it should probably be added as a git submodule. Please let us know.
- We added `.clang-format` for `Objective-C` files.
- The root `CMakeLists.txt` file has the selective build option for building `coremldelegate` library.