### PR TITLE
Tutorial title consistency

### DIFF
--- a/backends/apple/mps/setup.md
+++ b/backends/apple/mps/setup.md
@@ -25,7 +25,7 @@
 
 <!---- DO NOT MODIFY Progress Bar End--->
 
-# Building and Running ExecuTorch on MPS Backend
+# Building and Running ExecuTorch with MPS Backend
 
 In this tutorial we will walk you through the process of getting setup to build the MPS backend for ExecuTorch and running a simple model on it.
 

--- a/docs/source/build-run-coreml.md
+++ b/docs/source/build-run-coreml.md
@@ -24,7 +24,7 @@
 
 <!---- DO NOT MODIFY Progress Bar End--->
 
-# Building and Running ExecuTorch on CoreML Backend
+# Building and Running ExecuTorch with CoreML Backend
 
 CoreML delegate uses CoreML apis to enable running neural networks via Apple's hardware acceleration. For more about coreml you can read [here](https://developer.apple.com/documentation/coreml). In this tutorial we will walk through steps of lowering a PyTorch model to CoreML delegate
 

--- a/docs/source/build-run-qualcomm-ai-engine-direct-backend.md
+++ b/docs/source/build-run-qualcomm-ai-engine-direct-backend.md
@@ -25,7 +25,7 @@
 
 <!---- DO NOT MODIFY Progress Bar End--->
 
-# Building and Running ExecuTorch on Qualcomm AI Engine Direct
+# Building and Running ExecuTorch with Qualcomm AI Engine Direct Backend
 
 In this tutorial we will walk you through the process of getting setup to
 build ExecuTorch for Qualcomm AI Engine Direct and running a model on it.
@@ -261,4 +261,3 @@ An Android demo-app using Qualcomm AI Engine Direct Backend can be found in
 
 If you encounter any issues while reproducing the tutorial, please file a github
 issue on ExecuTorch repo and tag use `#qcom_aisw` tag
-

--- a/docs/source/examples-end-to-end-to-lower-model-to-delegate.md
+++ b/docs/source/examples-end-to-end-to-lower-model-to-delegate.md
@@ -1,4 +1,4 @@
-# An end-to-end example to lower a model as a delegate
+# Lowering a Model as a Delegate
 
 Audience: ML Engineers, who are interested in applying delegates to accelerate their program in runtime
 

--- a/docs/source/executorch-arm-delegate-tutorial.md
+++ b/docs/source/executorch-arm-delegate-tutorial.md
@@ -1,5 +1,5 @@
 <!---- Name is a WIP - this reflects better what it can do today ----->
-# ExecuTorch Arm Ethos-U Delegate
+# Building and Running ExecuTorch with ARM Ethos-U Backend
 
 <!----This will show a grid card on the page----->
 ::::{grid} 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -269,7 +269,7 @@ ExecuTorch tutorials.
    :tags: Export,Backend,Delegation,CoreML
 
 .. customcarditem::
-   :header: Building and Running ExecuTorch with MPSGraph Backend
+   :header: Building and Running ExecuTorch with MPS Backend
    :card_description: A tutorial that walks you through the process of building ExecuTorch with MPSGraph Backend
    :image: _static/img/generic-pytorch-logo.png
    :link: build-run-mps.html

--- a/docs/source/tutorial-xnnpack-delegate-lowering.md
+++ b/docs/source/tutorial-xnnpack-delegate-lowering.md
@@ -1,4 +1,4 @@
-# XNNPACK Backend Delegate Lowering Tutorial
+# Building and Running ExecuTorch with XNNPACK Backend
 
 The following tutorial will familiarize you with leveraging the ExecuTorch XNNPACK Delegate for accelerating your ML Models using CPU hardware. It will go over exporting and serializing a model to a binary file, targeting the XNNPACK Delegate Backend and running the model on a supported target  platform. To get started quickly, use the script in the ExecuTorch repository with instructions on exporting and generating  a binary file for a few sample models demonstrating the flow.
 

--- a/docs/source/tutorials_source/sdk-integration-tutorial.py
+++ b/docs/source/tutorials_source/sdk-integration-tutorial.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-SDK Integration Tutorial
+Using the ExecuTorch SDK to Profile a Model
 ========================
 
 **Author:** `Jack Khuu <https://github.com/Jack-Khuu>`__

--- a/examples/demo-apps/android/ExecuTorchDemo/README.md
+++ b/examples/demo-apps/android/ExecuTorchDemo/README.md
@@ -17,7 +17,7 @@ This guide explains how to setup ExecuTorch for Android using a demo app. The ap
 * Refer to [Setting up ExecuTorch](getting-started-setup.md) to set up the repo and dev environment.
 * Download and install [Android Studio and SDK](https://developer.android.com/studio).
 * Supported Host OS: CentOS, macOS Ventura (M1/x86_64). See below for Qualcomm HTP specific requirements.
-* *Qualcomm HTP Only[^1]:* To build and run on Qualcomm's AI Engine Direct, please follow [Building and Running ExecuTorch on Qualcomm AI Engine Direct](build-run-qualcomm-ai-engine-direct-backend.md) for hardware and software pre-requisites.
+* *Qualcomm HTP Only[^1]:* To build and run on Qualcomm's AI Engine Direct, please follow [Building and Running ExecuTorch with Qualcomm AI Engine Direct Backend](build-run-qualcomm-ai-engine-direct-backend.md) for hardware and software pre-requisites.
 :::
 ::::
 

--- a/examples/demo-apps/apple_ios/README.md
+++ b/examples/demo-apps/apple_ios/README.md
@@ -1,4 +1,4 @@
-# ExecuTorch iOS Demo App Tutorial
+# Building an ExecuTorch iOS Demo App
 
 Welcome to the tutorial on setting up the ExecuTorch iOS Demo App!
 


### PR DESCRIPTION
Summary:
On the left hand side, the tutorial titles are not consistent with tutorial cards.

I like dbort change D50302244. Let's just make sure the titles are also consistent across the board. Both on left hand nav as well as the actual pages.

Reviewed By: dbort

Differential Revision: D50302650


