### PR TITLE
Remove "WIP" from top-level README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ the latest `v#.#.#` release tag from the
 [Releases](https://github.com/pytorch/executorch/releases) page when
 experimenting with this preview release.
 
-## Directory Structure [WIP]
+## Directory Structure
 
 ```
 executorch


### PR DESCRIPTION
Summary: Let's remove it. Having WIP on the top README file just looks sloppy right away.

Reviewed By: dbort

Differential Revision: D50308053


