### PR TITLE
Add README for old folders

### DIFF
--- a/docs/website/docs/contributors/design_docs.md
+++ b/docs/website/docs/contributors/design_docs.md
@@ -1,5 +1,0 @@
-# Design Docs
-
-ExecuTorch stack diagram: https://docs.google.com/drawings/d/1bBIbG6YDIjdx8emS_6K23YM6WyRkKVpPt-26nznxroU/edit
-
-High-level design doc: https://docs.google.com/document/d/1Z12w6-KtwoFDh781LQAbfwUdEZw9cwTCmz5BmKuS6U8/edit#

--- a/docs/website/docs/export/README.md
+++ b/docs/website/docs/export/README.md
@@ -1,0 +1,4 @@
+# Deprecated folder
+
+This folder is deprecated. For up-to-date comprehensive technical overview of ExecuTorch and step-by-step tutorials,
+please visit our [documentation website](https://pytorch.org/executorch). For export tutorial, please visit [`torch.export()`](https://pytorch.org/docs/main/export.html).

--- a/docs/website/docs/ir_spec/README.md
+++ b/docs/website/docs/ir_spec/README.md
@@ -1,0 +1,4 @@
+# Deprecated folder
+
+This folder is deprecated. For up-to-date comprehensive technical overview of ExecuTorch and step-by-step tutorials,
+please visit our [documentation website](https://pytorch.org/executorch).

--- a/docs/website/docs/sdk/README.md
+++ b/docs/website/docs/sdk/README.md
@@ -1,0 +1,4 @@
+# Deprecated folder
+
+This folder is deprecated. For up-to-date comprehensive technical overview of ExecuTorch and step-by-step tutorials,
+please visit our [documentation website](https://pytorch.org/executorch).

--- a/docs/website/docs/tutorials/README.md
+++ b/docs/website/docs/tutorials/README.md
@@ -1,0 +1,4 @@
+# Deprecated folder
+
+This folder is deprecated. For up-to-date comprehensive technical overview of ExecuTorch and step-by-step tutorials,
+please visit our [documentation website](https://pytorch.org/executorch).


### PR DESCRIPTION
Summary:
There are a bunch of folders that are not relevant anymore, all of them are revamped in the new documentation webpage.

Let's just create a warning README for now before consolidating.

This will hopefully reduce confusion for readers who are just exploring the codebase.

Reviewed By: dbort

Differential Revision: D50307968


