### PR TITLE
Fix broken link in QNN tutorial card

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -279,7 +279,7 @@ ExecuTorch tutorials.
    :header: Building and Running ExecuTorch with Qualcomm AI Engine Direct Backend
    :card_description: A tutorial that walks you through the process of building ExecuTorch with Qualcomm AI Engine Direct Backend
    :image: _static/img/generic-pytorch-logo.png
-   :link: build-run-build-run-qualcomm-ai-engine-direct-backend.html
+   :link: build-run-qualcomm-ai-engine-direct-backend.html
    :tags: Export,Backend,Delegation,QNN
 
 .. customcarditem::


### PR DESCRIPTION
Summary: An extra "build-run-" got in there.

Differential Revision: D50309707


