### PR TITLE
Update mps docs (#974)

### DIFF
--- a/backends/apple/mps/setup.md
+++ b/backends/apple/mps/setup.md
@@ -56,16 +56,16 @@ In order to be able to successfully build and run a model using the MPS backend 
 ### Software
 - [macOS Sonoma](https://www.apple.com/macos/sonoma/) (for lowering to MPS delegate)
 - [iOS 17](https://www.apple.com/ios/ios-17/) / [iPadOS 17](https://www.apple.com/ipados/ipados-17/) (for running on device)
-
+- [Xcode 15](https://developer.apple.com/xcode/) (for building the [AOT](#aot-ahead-of-time-components) and [runtime](#runtime))
 
 ## Setting up Developer Environment
 
-***Step 1.*** Please finish tutorial [Setting up executorch](../../../docs/website/docs/tutorials/00_setting_up_executorch.md).
+***Step 1.*** Please finish tutorial [Setting up executorch](getting-started-setup.md).
 
 ***Step 2.*** Install dependencies needed to lower MPS delegate:
 
   ```bash
-  bash ./backends/apple/mps/install_requirements.sh
+  ./backends/apple/mps/install_requirements.sh
   ```
 
 ## Build


### PR DESCRIPTION
Summary:
Summary of changes:
- Update MPS docs to include Xcode15 as prerequisite software
- Fix anchor links for executorch tutorial

Pull Request resolved: https://github.com/pytorch/executorch/pull/974

Reviewed By: cccclai

Differential Revision: D50347558

Pulled By: shoumikhin

fbshipit-source-id: 1950dfbbcce179cb0e3c0f820f8cb5eafc39c34c