### PR TITLE
Fix printf for enum class

### DIFF
--- a/util/util.h
+++ b/util/util.h
@@ -126,7 +126,7 @@ inline exec_aten::ArrayRef<void*> PrepareInputTensors(Method& method) {
     ET_CHECK_MSG(
         error == Error::Ok,
         "Error: 0x%" PRIx32 " setting input %zu.",
-        error,
+        static_cast<uint32_t>(error),
         i);
 #ifndef USE_ATEN_LIB // Portable Tensor
     free(sizes);


### PR DESCRIPTION
Summary:
It's always been undefined behavior to use printf directly with an enum
class member (without casting it). Clang 16 and below incorrectly
permitted it, but Clang 17 makes it an error, so we need to explicitly
cast to the underlying enum type and use appropriate format specifiers.

Reviewed By: JacobSzwejbka

Differential Revision: D50353351

