### PR TITLE
Fix "Tutorials" and "Getting Started" top-nav links

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -93,14 +93,14 @@
     $(".main-menu a:contains('GitHub')").each(overwrite);
     // Overwrite link to Tutorials and Get Started top navigation. If these sections are moved
     // this overrides need to be updated.
-    $(".main-menu a:contains('Tutorials')").attr("href", "/index.html#tutorials-and-examples");
-    $(".main-menu a:contains('Get Started')").attr("href", "/getting-started-setup.html");
+    $(".main-menu a:contains('Tutorials')").attr("href", "https://pytorch.org/executorch/stable/index.html#tutorials-and-examples");
+    $(".main-menu a:contains('Get Started')").attr("href", "https://pytorch.org/executorch/stable/getting-started-setup.html");
     // Mobile
     $(".mobile-menu a:contains('Github')").each(overwrite);
     // Overwrite link to Tutorials and Get Started top navigation. If these sections are moved
     // this overrides need to be updated.
-    $(".mobile-menu a:contains('Tutorials')").attr("href", "/index.html#tutorials-and-examples");
-    $(".mobile-menu a:contains('Get Started')").attr("href", "/getting-started-setup.html");
+    $(".mobile-menu a:contains('Tutorials')").attr("href", "https://pytorch.org/executorch/stable/index.html#tutorials-and-examples");
+    $(".mobile-menu a:contains('Get Started')").attr("href", "https://pytorch.org/executorch/stable/getting-started-setup.html");
 
   });
 </script>


### PR DESCRIPTION
These absolute paths worked when we were using the standalone netlify preview site, but break when serving from pytorch.org/executorch. The absolute links try pointing to pages directly under pytorch.org instead of under the executorch/stable subtree.