### PR TITLE
Prepare for chaning the name space of map_impl.

### DIFF
--- a/exir/TARGETS
+++ b/exir/TARGETS
@@ -35,6 +35,7 @@ python_library(
     ],
     deps = [
         "//caffe2:torch",
+        "//caffe2/functorch:functorch_src",
     ],
 )
 
@@ -158,6 +159,7 @@ python_library(
         ":schema",
         ":tensor",
         "//caffe2:torch",
+        "//caffe2/functorch:functorch_src",
         "//executorch/exir/operator:convert",
     ],
 )

--- a/exir/emit/TARGETS
+++ b/exir/emit/TARGETS
@@ -19,6 +19,7 @@ python_library(
     deps = [
         "fbsource//third-party/pypi/typing-extensions:typing-extensions",
         "//caffe2:torch",
+        "//caffe2/functorch:functorch_src",
         "//executorch/exir:delegate",
         "//executorch/exir:error",
         "//executorch/exir:memory",

--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -85,6 +85,8 @@ from executorch.exir.tensor import (
     TensorSpec,
 )
 from executorch.exir.types import LeafValueSpec, ValueSpec
+
+from functorch.experimental._map import map_impl
 from torch._export.exported_program import ExportedProgram
 from torch.utils import _pytree as pytree
 
@@ -862,7 +864,7 @@ class _Emitter(torch.fx.Interpreter):
 
         if target is torch.ops.higher_order.cond:
             return self._emit_cond(args, subemitter_binding_output_values)
-        elif target is torch.ops.map_impl:
+        elif target is map_impl:
             return self._emit_map(args, subemitter_binding_output_values)
         else:
             raise InternalError(
@@ -1233,7 +1235,7 @@ class _Emitter(torch.fx.Interpreter):
         elif target is torch.ops.higher_order.cond:
             return self._emit_control_flow(target, args, kwargs)
 
-        elif target is torch.ops.map_impl:
+        elif target is map_impl:
             return self._emit_control_flow(target, args, kwargs)
 
         elif target == executorch_call_delegate:

--- a/exir/graph_module.py
+++ b/exir/graph_module.py
@@ -11,6 +11,8 @@ from typing import Dict, List, Tuple, Union
 
 import torch
 
+from functorch.experimental._map import map_impl
+
 
 LeafValue = Union[
     torch.Tensor,
@@ -64,7 +66,7 @@ def get_control_flow_submodules(
         if node.target is torch.ops.higher_order.cond:
             control_flow_submodules.append(_get_submodule(graph_module, node, 1))
             control_flow_submodules.append(_get_submodule(graph_module, node, 2))
-        if node.target is torch.ops.map_impl:
+        if node.target is map_impl:
             control_flow_submodules.append(_get_submodule(graph_module, node, 0))
 
     return control_flow_submodules

--- a/exir/memory_planning.py
+++ b/exir/memory_planning.py
@@ -27,6 +27,8 @@ from executorch.exir.error import (
 from executorch.exir.operator.convert import is_out_variant
 from executorch.exir.schema import TensorShapeDynamism
 from executorch.exir.tensor import TensorSpec
+
+from functorch.experimental._map import map_impl
 from torch import fx
 from torch.fx import Node
 from torch.utils._pytree import tree_flatten
@@ -321,7 +323,7 @@ def collect_specs_from_nodes(  # noqa: C901
                     operator.getitem,
                     torch.ops.higher_order.cond,
                     exir_while,
-                    torch.ops.map_impl,
+                    map_impl,
                     executorch_call_delegate,
                 ],
                 f"Unexpected op {node.op}, target {node.target}",
@@ -567,7 +569,7 @@ def get_while_nodes(graph_module: torch.fx.GraphModule) -> Iterable[Node]:
 
 def get_map_nodes(graph_module: torch.fx.GraphModule) -> Iterable[Node]:
     for nd in graph_module.graph.nodes:
-        if nd.target is torch.ops.map_impl:
+        if nd.target is map_impl:
             yield nd
 
 

--- a/exir/passes/TARGETS
+++ b/exir/passes/TARGETS
@@ -27,6 +27,7 @@ python_library(
         ":sym_shape_eval_pass",
         ":sym_to_tensor_pass",
         "//caffe2:torch",
+        "//caffe2/functorch:functorch_src",
         "//executorch/exir:common",
         "//executorch/exir:control_flow",
         "//executorch/exir:delegate",

--- a/exir/passes/__init__.py
+++ b/exir/passes/__init__.py
@@ -53,6 +53,8 @@ from executorch.exir.passes.scalar_to_tensor_pass import ScalarToTensorPass
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
 from executorch.exir.passes.sym_shape_eval_pass import HintBasedSymShapeEvalPass
 from executorch.exir.passes.sym_to_tensor_pass import SymToTensorPass
+
+from functorch.experimental._map import map_impl
 from torch import fx
 from torch._subclasses import FakeTensor
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
@@ -328,7 +330,7 @@ class ToOutVarPass(PassBase):
                 self.call(get_submodule(node.args[1]))
                 self.call(get_submodule(node.args[2]))
                 continue
-            if target == torch.ops.map_impl:
+            if target == map_impl:
                 self.call(get_submodule(node.args[0]))
                 continue
             elif target == control_flow.while_loop:


### PR DESCRIPTION
Summary: We plan to move the namespace of map_impl from torch.ops.map_impl to torch.ops.higher_order.map_impl. To avoid the change breaking executorch CI, this pr removes all usage of torch.ops.map_impl.  After the PyTorch PR is landed D50347324, will submit a new pr to change all usage to torch.ops.higher_order.map_impl.

Differential Revision: D50370232


