### PR TITLE
Correcting usage of Core ML

### DIFF
--- a/backends/apple/coreml/README.md
+++ b/backends/apple/coreml/README.md
@@ -1,18 +1,18 @@
-# ExecuTorch CoreML Delegate
+# ExecuTorch Core ML Delegate
 
 
-This subtree contains the CoreML Delegate implementation for ExecuTorch.
-CoreML is an optimized framework for running machine learning models on Apple devices. The delegate is the mechanism for leveraging the CoreML framework to accelerate operators when running on Apple devices.
+This subtree contains the Core ML Delegate implementation for ExecuTorch.
+Core ML is an optimized framework for running machine learning models on Apple devices. The delegate is the mechanism for leveraging the Core ML framework to accelerate operators when running on Apple devices.
 
 ## Layout
-- `compiler/` : Lowers a module to CoreML backend.
+- `compiler/` : Lowers a module to Core ML backend.
 - `scripts/` : Scripts for installing dependencies and running tests.
-- `runtime/`: CoreML delegate runtime implementation.
+- `runtime/`: Core ML delegate runtime implementation.
     - `inmemoryfs`: InMemory filesystem implementation used to serialize/de-serialize AOT blob.
     - `kvstore`: Persistent Key-Value store implementation.
     - `delegate`: Runtime implementation.
     - `include` : Public headers.
-    - `tests` :  Tests for CoreML delegate.
+    - `tests` :  Tests for Core ML delegate.
     - `workspace` : Xcode workspace for tests.
 - `third-party/`: External dependencies.
 
@@ -22,7 +22,7 @@ implementation and testing better, please create an issue on [github](https://ww
 
 ## Delegation
 
-For delegating the Program to the **CoreML** backend, the client must be responsible for calling `to_backend` with the **CoreMLBackend** tag.
+For delegating the Program to the **Core ML** backend, the client must be responsible for calling `to_backend` with the **CoreMLBackend** tag.
 
 ```python
 import executorch.exir as exir
@@ -44,16 +44,16 @@ to_be_lowered = LowerableSubModel()
 example_input = (torch.ones(1), )
 to_be_lowered_exir_submodule = exir.capture(to_be_lowered, example_input).to_edge()
 
-# Lower to CoreML backend
+# Lower to Core ML backend
 lowered_module = to_backend('CoreMLBackend', to_be_lowered_exir_submodule, [])
 ```
 
-Currently, the **CoreML** backend delegates the whole module to **CoreML**. If a specific op is not supported by the **CoreML** backend then the `to_backend` call would throw an exception. We will be adding a **CoreML Partitioner** to resolve the issue.
+Currently, the **Core ML** backend delegates the whole module to **Core ML**. If a specific op is not supported by the **Core ML** backend then the `to_backend` call would throw an exception. We will be adding a **Core ML Partitioner** to resolve the issue.
 
 The `to_backend` implementation is a thin wrapper over `coremltools`, `coremltools` is responsible for converting an **ExportedProgram** to a **MLModel**. The converted **MLModel** data is saved, flattened, and returned as bytes to **ExecuTorch**.
 
 ## Runtime
 
-To execute a **CoreML** delegated **Program**, the client must link to the `coremldelegate` library. Once linked there are no additional steps required, **ExecuTorch** when running the **Program** would call the **CoreML** runtime to execute the **CoreML** delegated part of the **Program**.
+To execute a **Core ML** delegated **Program**, the client must link to the `coremldelegate` library. Once linked there are no additional steps required, **ExecuTorch** when running the **Program** would call the **Core ML** runtime to execute the **Core ML** delegated part of the **Program**.
 
-Please follow the instructions described in the [CoreML setup](/backends/apple/coreml/setup.md) to link the `coremldelegate` library.
+Please follow the instructions described in the [Core ML setup](/backends/apple/coreml/setup.md) to link the `coremldelegate` library.

--- a/backends/apple/coreml/runtime/test/setup.md
+++ b/backends/apple/coreml/runtime/test/setup.md
@@ -1,12 +1,12 @@
-## CoreML delegate tests set up
+## Core ML delegate tests set up
 
-This is a tutorial for setting up tests for the **CoreML** backend.
+This is a tutorial for setting up tests for the **Core ML** backend.
 
 ## Running tests
 
 1. Follow the instructions described in [Setting Up ExecuTorch](/docs/source/getting-started-setup.md) to set up ExecuTorch environment.
 
-2. Run `install_requirements.sh` to install dependencies required by the **CoreML** backend.
+2. Run `install_requirements.sh` to install dependencies required by the **Core ML** backend.
 
 ```bash
 cd executorch

--- a/backends/apple/coreml/setup.md
+++ b/backends/apple/coreml/setup.md
@@ -1,12 +1,12 @@
-# Setting up CoreML backend
+# Setting up Core ML backend
 
-This is a tutorial for setting up the CoreML backend.
+This is a tutorial for setting up the Core ML backend.
 
 ## AOT Setup
 
 1. Follow the instructions described in [Setting Up ExecuTorch](/docs/source/getting-started-setup.md) to set up ExecuTorch environment.
 
-2. Run `install_requirements.sh` to install dependencies required by the **CoreML** backend.
+2. Run `install_requirements.sh` to install dependencies required by the **Core ML** backend.
 
 ```
 cd executorch
@@ -15,7 +15,7 @@ cd executorch
 
 ``` 
 
-3. Run the example script to validate that the **CoreML** backend is set up correctly. 
+3. Run the example script to validate that the **Core ML** backend is set up correctly. 
 
 ```
 cd executorch
@@ -26,15 +26,15 @@ python3 -m examples.apple.coreml.scripts.export_and_delegate --model_name add
 
 ```
 
-4. You can now integrate the **CoreML** backend in code.
+4. You can now integrate the **Core ML** backend in code.
 
 ```python
-# Lower to CoreML backend
+# Lower to Core ML backend
 lowered_module = to_backend('CoreMLBackend', to_be_lowered_exir_submodule, [])
 ```
 
 
-## Integrating CoreML delegate into runtime.
+## Integrating Core ML delegate into runtime.
 
 1. Follow the instructions described in [Building with CMake](/docs/source/runtime-build-and-cross-compilation.md#building-with-cmake) to set up CMake build system.
 
@@ -46,7 +46,7 @@ lowered_module = to_backend('CoreMLBackend', to_be_lowered_exir_submodule, [])
 xcode-select --install
 ```
 
-2. Build **CoreML** delegate. The following will create a `executorch.xcframework` in `cmake-out` directory.
+2. Build **Core ML** delegate. The following will create a `executorch.xcframework` in `cmake-out` directory.
 
 ```bash
 cd executorch
@@ -68,4 +68,4 @@ coreml_backend.xcframework
 - libsqlite3.tbd
 ``` 
 
-6. The target could now run a **CoreML** delegated **Program**. 
+6. The target could now run a **Core ML** delegated **Program**. 

--- a/docs/source/build-run-coreml.md
+++ b/docs/source/build-run-coreml.md
@@ -24,15 +24,15 @@
 
 <!---- DO NOT MODIFY Progress Bar End--->
 
-# Building and Running ExecuTorch with CoreML Backend
+# Building and Running ExecuTorch with Core ML Backend
 
-CoreML delegate uses CoreML apis to enable running neural networks via Apple's hardware acceleration. For more about coreml you can read [here](https://developer.apple.com/documentation/coreml). In this tutorial we will walk through steps of lowering a PyTorch model to CoreML delegate
+Core ML delegate uses Core ML apis to enable running neural networks via Apple's hardware acceleration. For more about coreml you can read [here](https://developer.apple.com/documentation/coreml). In this tutorial we will walk through steps of lowering a PyTorch model to Core ML delegate
 
 
 ::::{grid} 2
 :::{grid-item-card}  What you will learn in this tutorial:
 :class-card: card-prerequisites
-* In this tutorial you will learn how to export [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model so that it runs on CoreML backend.
+* In this tutorial you will learn how to export [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model so that it runs on Core ML backend.
 * You will also learn how to deploy and run the exported model on a supported Apple device.
 :::
 :::{grid-item-card}  Tutorials we recommend you complete before this:
@@ -47,7 +47,7 @@ CoreML delegate uses CoreML apis to enable running neural networks via Apple's h
 
 ## Prerequisites (Hardware and Software)
 
-In order to be able to successfully build and run the ExecuTorch's CoreML backend you'll need the following hardware and software components.
+In order to be able to successfully build and run the ExecuTorch's Core ML backend you'll need the following hardware and software components.
 
 ### Hardware:
 - A [mac](https://www.apple.com/mac/]) system for building.
@@ -61,7 +61,7 @@ In order to be able to successfully build and run the ExecuTorch's CoreML backen
 ## Setting up your developer environment
 
 1. Make sure that you have completed the ExecuTorch setup tutorials linked to at the top of this page and setup the environment.
-2. Run `install_requirements.sh` to install dependencies required by the **CoreML** backend.
+2. Run `install_requirements.sh` to install dependencies required by the **Core ML** backend.
 
 ```bash
 cd executorch
@@ -79,8 +79,8 @@ xcode-select --install
 ### AOT (Ahead-of-time) components:
 
 
-**Exporting a CoreML delegated Program**:
-- In this step, you will lower the [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model to the CoreML backend and export the ExecuTorch program. You'll then deploy and run the exported program on a supported Apple device using CoreML backend.
+**Exporting a Core ML delegated Program**:
+- In this step, you will lower the [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model to the Core ML backend and export the ExecuTorch program. You'll then deploy and run the exported program on a supported Apple device using Core ML backend.
 ```bash
 cd executorch
 
@@ -88,12 +88,12 @@ cd executorch
 python3 -m examples.apple.coreml.scripts.export_and_delegate --model_name mv3
 ```
 
-- CoreML backend uses [coremltools](https://apple.github.io/coremltools/docs-guides/source/overview-coremltools.html) to lower [Edge dialect](ir-exir.md#edge-dialect) to CoreML format and then bundles it in the `.pte` file.
+- Core ML backend uses [coremltools](https://apple.github.io/coremltools/docs-guides/source/overview-coremltools.html) to lower [Edge dialect](ir-exir.md#edge-dialect) to Core ML format and then bundles it in the `.pte` file.
 
 
 ### Runtime:
 
-**Running the CoreML delegated Program**:
+**Running the Core ML delegated Program**:
 1. Build the runner.
 ```bash
 cd executorch
@@ -105,21 +105,21 @@ cd executorch
 ```bash
 cd executorch
 
-# Runs the exported mv3 model on the CoreML backend.
+# Runs the exported mv3 model on the Core ML backend.
 ./coreml_executor_runner --model_path mv3_coreml_all.pte
 ```
 
 ## Deploying and running on a device
 
-**Running the CoreML delegated Program in the Demo iOS App**:
-1. Please follow the [Export Model](demo-apps-ios.md#models-and-labels) step of the tutorial to bundle the exported [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) program. You only need to do the CoreML part.
+**Running the Core ML delegated Program in the Demo iOS App**:
+1. Please follow the [Export Model](demo-apps-ios.md#models-and-labels) step of the tutorial to bundle the exported [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) program. You only need to do the Core ML part.
 
 2. Complete the [Build Runtime and Backends](demo-apps-ios.md#build-runtime-and-backends) section of the tutorial. When building the frameworks you only need the `coreml` option.
 
 3. Complete the [Final Steps](demo-apps-ios.md#final-steps) section of the tutorial to build and run the demo app.
 
-<br>**Running the CoreML delegated Program in your own App**
-1. Build **CoreML** delegate. The following will create a `executorch.xcframework` in the `cmake-out` directory.
+<br>**Running the Core ML delegated Program in your own App**
+1. Build **Core ML** delegate. The following will create a `executorch.xcframework` in the `cmake-out` directory.
 ```bash
 cd executorch
 ./build/build_apple_frameworks.sh --Release --coreml
@@ -153,9 +153,9 @@ Result<util::FileDataLoader> loader =
 
 8. Use [Xcode](https://developer.apple.com/documentation/xcode/building-and-running-an-app#Build-run-and-debug-your-app) to deploy the application on the device.
 
-9. The application can now run the [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model on the CoreML backend.
+9. The application can now run the [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model on the Core ML backend.
 
-<br>In this tutorial, you have learned how to lower the [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model to the CoreML backend, deploy, and run it on an Apple device.
+<br>In this tutorial, you have learned how to lower the [MobileNet V3](https://pytorch.org/vision/main/models/mobilenetv3.html) model to the Core ML backend, deploy, and run it on an Apple device.
 
 ## Frequently encountered errors and resolution.
 

--- a/docs/source/getting-started-architecture.md
+++ b/docs/source/getting-started-architecture.md
@@ -54,7 +54,7 @@ The Export process discussed above operates on a graph that is agnostic to the e
 
 * _[Edge Dialect](./ir-exir.md#edge-dialect)_. All operators are either compliant with ATen operators with dtype plus memory layout information (represented as `dim_order`) or registered custom operators. Scalars are converted to Tensors. Those specifications allow following steps focusing on a smaller Edge domain. In addition, it enables the selective build which is based on specific dtypes and memory layouts.
 
-With the Edge dialect, there are two target-aware ways to further lower the graph to the _[Backend Dialect](./compiler-backend-dialect.md)_. At this point, delegates for specific hardware can perform many operations. For example, CoreML on iOS, QNN on Qualcomm, or TOSA on Arm can rewrite the graph. The options at this level are:
+With the Edge dialect, there are two target-aware ways to further lower the graph to the _[Backend Dialect](./compiler-backend-dialect.md)_. At this point, delegates for specific hardware can perform many operations. For example, Core ML on iOS, QNN on Qualcomm, or TOSA on Arm can rewrite the graph. The options at this level are:
 
 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ examples
 ├── demo-apps                         # Contains demo apps for Android and iOS
 ├── xnnpack                           # Contains end-to-end ExecuTorch demos with first-party optimization using XNNPACK
 ├── apple
-|   |── coreml                        # Contains demos of Apple's CoreML backend
+|   |── coreml                        # Contains demos of Apple's Core ML backend
 |   └── mps                           # Contains end-to-end demos of MPS backend
 ├── arm                               # Contains demos of the Arm TOSA and Ethos-U NPU flows
 ├── qualcomm                          # Contains demos of Qualcomm QNN backend
@@ -49,7 +49,7 @@ The demos in the [`xnnpack/`](./xnnpack) directory provide valuable insights int
 
 ## Demo of ExecuTorch Apple Backend
 
-You will find demos of [ExecuTorch CoreML Backend](./apple/coreml/) in the [`apple/coreml/`](./apple/coreml) directory and [MPS Backend](./apple/mps/) in the [`apple/mps/`](./apple/mps) directory.
+You will find demos of [ExecuTorch Core ML Backend](./apple/coreml/) in the [`apple/coreml/`](./apple/coreml) directory and [MPS Backend](./apple/mps/) in the [`apple/mps/`](./apple/mps) directory.
 
 ## Demo of ExecuTorch on ARM Cortex-M55 + Ethos-U55
 

--- a/examples/apple/coreml/README.md
+++ b/examples/apple/coreml/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-This directory contains scripts and other helper utilities to illustrate an end-to-end workflow to run a **CoreML** delegated `torch.nn.module` with the **ExecuTorch** runtime.
+This directory contains scripts and other helper utilities to illustrate an end-to-end workflow to run a **Core ML** delegated `torch.nn.module` with the **ExecuTorch** runtime.
 
 
 ## Directory structure
@@ -13,12 +13,12 @@ coreml
 
 ## Using the examples
 
-We will walk through an example model to generate a **CoreML** delegated binary file from a python `torch.nn.module` then we will use the `coreml/executor_runner` to run the exported binary file.
+We will walk through an example model to generate a **Core ML** delegated binary file from a python `torch.nn.module` then we will use the `coreml/executor_runner` to run the exported binary file.
 
 1. Following the setup guide in [Setting Up ExecuTorch](https://pytorch.org/executorch/stable/getting-started-setup)
 you should be able to get the basic development environment for ExecuTorch working.
 
-2. Run `install_requirements.sh` to install dependencies required by the **CoreML** backend.
+2. Run `install_requirements.sh` to install dependencies required by the **Core ML** backend.
 
 ```bash
 cd executorch
@@ -27,7 +27,7 @@ cd executorch
 
 ```
 
-3. Run the export script to generate a **CoreML** delegated binary file.
+3. Run the export script to generate a **Core ML** delegated binary file.
 
 ```bash
 cd executorch
@@ -39,20 +39,20 @@ python3 -m examples.portable.scripts.export -h
 python3 -m examples.apple.coreml.scripts.export_and_delegate --model_name add
 ```
 
-4. Once we have the **CoreML** delegated model binary (pte) file, then let's run it with the **ExecuTorch** runtime using the `coreml_executor_runner`.
+4. Once we have the **Core ML** delegated model binary (pte) file, then let's run it with the **ExecuTorch** runtime using the `coreml_executor_runner`.
 
 ```bash
 cd executorch
 
-# Builds the CoreML executor runner. Generates ./coreml_executor_runner if successful.
+# Builds the Core ML executor runner. Generates ./coreml_executor_runner if successful.
 ./examples/apple/coreml/scripts/build_executor_runner.sh
 
-# Run the CoreML delegate model.
+# Run the Core ML delegate model.
 ./coreml_executor_runner --model_path add_coreml_all.pte
 ```
 
 ## Frequently encountered errors and resolution.
-- The `examples.apple.coreml.scripts.export_and_delegate` could fail if the model is not supported by the **CoreML** backend. The following models from the examples models list (` python3 -m examples.portable.scripts.export -h`)are currently supported by the **CoreML** backend.
+- The `examples.apple.coreml.scripts.export_and_delegate` could fail if the model is not supported by the **Core ML** backend. The following models from the examples models list (` python3 -m examples.portable.scripts.export -h`)are currently supported by the **Core ML** backend.
 
 ```
 add

--- a/examples/demo-apps/apple_ios/README.md
+++ b/examples/demo-apps/apple_ios/README.md
@@ -62,7 +62,7 @@ Now let's move on to exporting and bundling the MobileNet v3 model.
 
 ### 1. Export Model
 
-Export the MobileNet v3 model with CoreML, MPS and XNNPACK delegates, and move
+Export the MobileNet v3 model with Core ML, MPS and XNNPACK delegates, and move
 the exported model to a specific location where the Demo App will pick them up:
 
 ```bash


### PR DESCRIPTION
This PR changes all instances of `CoreML` with `Core ML` in readme and setup files. 