### PR TITLE
Remove Progress bar from tutorials where it's not loading (#988)

### DIFF
--- a/backends/apple/mps/setup.md
+++ b/backends/apple/mps/setup.md
@@ -1,30 +1,3 @@
-<!---- DO NOT MODIFY Progress Bar Start --->
-
-<div class="progress-bar-wrapper">
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-1">1</div>
-     <span class="step-caption" id="caption-1"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-2">2</div>
-     <span class="step-caption" id="caption-2"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-3">3</div>
-     <span class="step-caption" id="caption-3"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-4">4</div>
-     <span class="step-caption" id="caption-4"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-5">5</div>
-     <span class="step-caption" id="caption-5"></span>
-   </div>
-</div>
-
-<!---- DO NOT MODIFY Progress Bar End--->
-
 # Building and Running ExecuTorch with MPS Backend
 
 In this tutorial we will walk you through the process of getting setup to build the MPS backend for ExecuTorch and running a simple model on it.

--- a/docs/source/build-run-coreml.md
+++ b/docs/source/build-run-coreml.md
@@ -1,29 +1,3 @@
-<!---- To make this progress bar work users will need to modify source/_templates/layout.html >
-<!---- To make this page show up in the tutorials section users will need to add an entry in source/index.rst under the Tutorials section>
-
-<!---- DO NOT MODIFY Progress Bar Start --->
-
-<div class="progress-bar-wrapper">
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-1">1</div>
-     <span class="step-caption" id="caption-1"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-2">2</div>
-     <span class="step-caption" id="caption-2"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-3">3</div>
-     <span class="step-caption" id="caption-3"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-4">4</div>
-     <span class="step-caption" id="caption-4"></span>
-   </div>
-</div>
-
-<!---- DO NOT MODIFY Progress Bar End--->
-
 # Building and Running ExecuTorch with Core ML Backend
 
 Core ML delegate uses Core ML apis to enable running neural networks via Apple's hardware acceleration. For more about coreml you can read [here](https://developer.apple.com/documentation/coreml). In this tutorial we will walk through steps of lowering a PyTorch model to Core ML delegate

--- a/docs/source/build-run-qualcomm-ai-engine-direct-backend.md
+++ b/docs/source/build-run-qualcomm-ai-engine-direct-backend.md
@@ -1,30 +1,3 @@
-<!---- DO NOT MODIFY Progress Bar Start --->
-
-<div class="progress-bar-wrapper">
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-1">1</div>
-     <span class="step-caption" id="caption-1"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-2">2</div>
-     <span class="step-caption" id="caption-2"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-3">3</div>
-     <span class="step-caption" id="caption-3"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-4">4</div>
-     <span class="step-caption" id="caption-4"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-5">5</div>
-     <span class="step-caption" id="caption-5"></span>
-   </div>
-</div>
-
-<!---- DO NOT MODIFY Progress Bar End--->
-
 # Building and Running ExecuTorch with Qualcomm AI Engine Direct Backend
 
 In this tutorial we will walk you through the process of getting setup to

--- a/docs/source/build-run-xtensa.md
+++ b/docs/source/build-run-xtensa.md
@@ -1,34 +1,3 @@
-<!---- DO NOT MODIFY Progress Bar Start --->
-
-<div class="progress-bar-wrapper">
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-1">1</div>
-     <span class="step-caption" id="caption-1"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-2">2</div>
-     <span class="step-caption" id="caption-2"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-3">3</div>
-     <span class="step-caption" id="caption-3"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-4">4</div>
-     <span class="step-caption" id="caption-4"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-5">5</div>
-     <span class="step-caption" id="caption-5"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-6">6</div>
-     <span class="step-caption" id="caption-6"></span>
-   </div>
-</div>
-
-<!---- DO NOT MODIFY Progress Bar End--->
-
 # Building and Running ExecuTorch on Xtensa HiFi4 DSP
 
 

--- a/docs/source/tutorial-template.md
+++ b/docs/source/tutorial-template.md
@@ -1,29 +1,3 @@
-<!---- To make this progress bar work users will need to modify source/_templates/layout.html >
-<!---- To make this page show up in the tutorials section users will need to add an entry in source/index.rst under the Tutorials section>
-
-<!---- DO NOT MODIFY Progress Bar Start --->
-
-<div class="progress-bar-wrapper">
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-1">1</div>
-     <span class="step-caption" id="caption-1"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-2">2</div>
-     <span class="step-caption" id="caption-2"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-3">3</div>
-     <span class="step-caption" id="caption-3"></span>
-   </div>
-   <div class="progress-bar-item">
-     <div class="step-number" id="step-4">4</div>
-     <span class="step-caption" id="caption-4"></span>
-   </div>
-</div>
-
-<!---- DO NOT MODIFY Progress Bar End--->
-
 # TITLE
 
 <!----This will show a grid card on the page----->


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/executorch/pull/988

Remove progress bar where it's not loading

Reviewed By: dbort, kirklandsign

Differential Revision: D50377828

fbshipit-source-id: 417a6a370f2a661adab2e27589049c5bf1c58007