### PR TITLE
Write program_buffer during ETRecord Generation

### DIFF
--- a/sdk/etrecord/_etrecord.py
+++ b/sdk/etrecord/_etrecord.py
@@ -163,6 +163,13 @@ def generate_etrecord(
                 )
             _handle_export_module(etrecord_zip, export_module, module_name)
 
+            if isinstance(
+                executorch_program, (ExecutorchProgram, ExecutorchProgramManager)
+            ):
+                etrecord_zip.writestr(
+                    ETRecordReservedFileNames.PROGRAM_BUFFER, executorch_program.buffer
+                )
+
     if isinstance(
         edge_dialect_program,
         (EdgeProgramManager, exir.program._program.EdgeProgramManager),


### PR DESCRIPTION
Summary:
D50129349 removed writing the program_buffer during ETRecord generation, causing tests looking for a buffer to fail (namely AIBench API tests).

Inaccurate bisect blamed Yanan's diff. T166884022

Add this back.

Differential Revision: D50400104


