### PR TITLE
Move iOS app build to a separate workflow

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -1,0 +1,40 @@
+name: Build ExecuTorch demo apps
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+    paths:
+      - .github/workflows/app-build.yml
+      - build/test_ios_ci.sh
+      - examples/demo-apps/**
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+jobs:
+  test-demo-ios:
+    name: test-demo-ios
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    strategy:
+      matrix:
+        include:
+          - build-tool: cmake
+      fail-fast: false
+    with:
+      runner: macos-latest-xlarge
+      submodules: 'true'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 60
+      script: |
+        WORKSPACE=$(pwd)
+        pushd "${WORKSPACE}/pytorch/executorch"
+        BUILD_TOOL=${{ matrix.build-tool }}
+        # Setup MacOS dependencies as there is no Docker support on MacOS atm
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+        # Build and test iOS Demo App
+        PYTHON_EXECUTABLE=python sh build/test_ios_ci.sh
+        popd

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - release/*
+  pull_request:
     paths:
       - .github/workflows/app-build.yml
       - build/test_ios_ci.sh

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -114,29 +114,6 @@ jobs:
         # Test selective build
         PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
 
-  test-demo-ios:
-    name: test-demo-ios
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
-    strategy:
-      matrix:
-        include:
-          - build-tool: cmake
-      fail-fast: false
-    with:
-      runner: macos-latest-xlarge
-      submodules: 'true'
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      timeout: 60
-      script: |
-        WORKSPACE=$(pwd)
-        pushd "${WORKSPACE}/pytorch/executorch"
-        BUILD_TOOL=${{ matrix.build-tool }}
-        # Setup MacOS dependencies as there is no Docker support on MacOS atm
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
-        # Build and test iOS Demo App
-        PYTHON_EXECUTABLE=python sh build/test_ios_ci.sh
-        popd
-
   test-coreml-delegate:
     name: test-coreml-delegate
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main


### PR DESCRIPTION
This achieves 2 goals:

* To avoid building and testing iOS app on GitHub runner on every pull request, which is very expensive ($$$)
* This would also help @shoumikhin when he want to add the release part here next after building and testing the app

Note that the workflow would still be run if the pull request updates the content of the app itself via `examples/demo-apps/**`.  This is probably the desired behavior to run this job only when it's needed.

```
on:
  push:
    branches:
      - main
      - release/*
  pull_request:
    paths:
      - .github/workflows/app-build.yml
      - build/test_ios_ci.sh
      - examples/demo-apps/**
```