### PR TITLE
Propagate version number in the doc build.

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -41,6 +41,19 @@ jobs:
           export CHANNEL=nightly
         fi
 
+        # Get the version of ExecuTorch from REF_NAME and save as ET_VERSION_DOCS
+        # ET_VERSION_DOCS will be pulled during the doc build to add to the version dropdown
+        # on the website. See docs/source/conf.py for details
+
+        REF_TYPE=${{ github.ref_type }}
+        REF_NAME=${{ github.ref_name }}
+
+        echo "$REF_TYPE"
+        echo "$REF_NAME"
+
+        ET_VERSION_DOCS="${REF_NAME}"
+        echo "$ET_VERSION_DOCS"
+
         set -eux
 
         # Build docset:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,6 +73,42 @@ doxygen_xml_dir = os.path.join(
 )
 
 html_favicon = "_static/img/ExecuTorch-Logo-cropped.svg"
+
+# Get ET_VERSION_DOCS during the build.
+et_version_docs = os.environ.get("ET_VERSION_DOCS", None)
+
+
+# The code below will cut version displayed in the dropdown like this:
+# tags like v0.1.0 = > 0.1
+# branch like release/0.1 => 0.1
+# main will remain main
+# if not set will fail back to main
+# the version varible is used in layout.html: https://github.com/pytorch/executorch/blob/main/docs/source/_templates/layout.html#L29
+if et_version_docs:
+    # Check if starts with release/ and set the version to the number after slash
+    if et_version_docs.startswith("release/"):
+        version = et_version_docs.split("/")[-1]
+    else:
+        # Remove "v" prefix if present
+        if et_version_docs.startswith("v"):
+            et_version_docs = et_version_docs[1:]
+        # Split to major, minor, and patch
+        version_components = et_version_docs.split(".")
+
+        # Combine the major and minor version components:
+        if len(version_components) >= 2:
+            version = release = ".".join(version_components[:2])
+        else:
+            # If there are not enough components, use the full version
+            version = release = et_version_docs
+
+    html_title = " ".join((project, version, "documentation"))
+# IF ET_VERSION_DOCS not set, set version to main.
+# This can be updated to nightly and so on.
+else:
+    version = "main"
+    release = "main"
+
 breathe_projects = {"ExecuTorch": "../build/xml/"}
 breathe_default_project = "ExecuTorch"
 


### PR DESCRIPTION
Summary: - We need to dynamically get the version number from the project.toml file so that it is displayed directly in the version dropdown on the website.

Differential Revision: D50464418


