### PR TITLE
Update portable op names to match functions.yaml

### DIFF
--- a/kernels/portable/README.md
+++ b/kernels/portable/README.md
@@ -53,7 +53,7 @@ in other cases we can consider adding the missing features.
 
 ### Do your initial work in fbcode (skip this if in OSS)
 
-Althouth ExecuTorch is mapped into both `xplat` and `fbcode`, we recommend
+Although ExecuTorch is mapped into both `xplat` and `fbcode`, we recommend
 setting up the initial targets while working from `fbcode`. Once everything's in
 place, you should be able to build from either spot.
 

--- a/kernels/portable/cpu/op_abs.cpp
+++ b/kernels/portable/cpu/op_abs.cpp
@@ -24,7 +24,7 @@ Tensor& abs_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
   ET_CHECK_SAME_SHAPE_AND_DTYPE2(in, out);
 
-  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "abs", CTYPE, [&] {
+  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "abs.out", CTYPE, [&] {
     apply_unary_map_fn(
         [](const CTYPE val_in) {
           if (val_in < 0) {

--- a/kernels/portable/cpu/op_add.cpp
+++ b/kernels/portable/cpu/op_add.cpp
@@ -33,26 +33,28 @@ Tensor& add_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "add", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "add", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "add", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "add", CTYPE_OUT, [&]() {
-          CTYPE_IN alpha_val;
-          ET_EXTRACT_SCALAR(alpha, alpha_val);
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "add.out", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "add.out", CTYPE_B, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, common_type, ctx, "add.out", CTYPE_IN, [&]() {
+            ET_SWITCH_REAL_TYPES_AND(
+                Bool, out_type, ctx, "add.out", CTYPE_OUT, [&]() {
+                  CTYPE_IN alpha_val;
+                  ET_EXTRACT_SCALAR(alpha, alpha_val);
 
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [alpha_val](const CTYPE_A val_a, const CTYPE_B val_b) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                CTYPE_IN value = a_casted + alpha_val * b_casted;
+                  apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
+                      [alpha_val](const CTYPE_A val_a, const CTYPE_B val_b) {
+                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                        CTYPE_IN value = a_casted + alpha_val * b_casted;
 
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
-        });
-      });
+                        return static_cast<CTYPE_OUT>(value);
+                      },
+                      a,
+                      b,
+                      out);
+                });
+          });
     });
   });
 
@@ -78,27 +80,29 @@ Tensor& add_scalar_out(
 
   ET_CHECK(common_type == out_type);
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "add", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "add", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "add", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "add", CTYPE_OUT, [&]() {
-          CTYPE_B b_val;
-          ET_EXTRACT_SCALAR(b, b_val);
-          CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
-          CTYPE_IN alpha_val;
-          ET_EXTRACT_SCALAR(alpha, alpha_val);
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "add.Scalar_out", CTYPE_A, [&]() {
+    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "add.Scalar_out", CTYPE_B, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, common_type, ctx, "add.Scalar_out", CTYPE_IN, [&]() {
+            ET_SWITCH_REAL_TYPES_AND(
+                Bool, out_type, ctx, "add.Scalar_out", CTYPE_OUT, [&]() {
+                  CTYPE_B b_val;
+                  ET_EXTRACT_SCALAR(b, b_val);
+                  CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
+                  CTYPE_IN alpha_val;
+                  ET_EXTRACT_SCALAR(alpha, alpha_val);
 
-          apply_unary_map_fn(
-              [b_casted, alpha_val](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN value = a_casted + alpha_val * b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
+                  apply_unary_map_fn(
+                      [b_casted, alpha_val](const CTYPE_A val_a) {
+                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                        CTYPE_IN value = a_casted + alpha_val * b_casted;
+                        return static_cast<CTYPE_OUT>(value);
+                      },
+                      a.const_data_ptr<CTYPE_A>(),
+                      out.mutable_data_ptr<CTYPE_OUT>(),
+                      out.numel());
+                });
+          });
     });
   });
 

--- a/kernels/portable/cpu/op_addmm.cpp
+++ b/kernels/portable/cpu/op_addmm.cpp
@@ -47,9 +47,9 @@ Tensor& addmm_out(
 
   ScalarType alpha_dtype = utils::get_scalar_dtype(alpha);
   ScalarType beta_dtype = utils::get_scalar_dtype(beta);
-  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "addmm", CTYPE, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(alpha_dtype, ctx, "addmm", ALPHA_T, [&]() {
-      ET_SWITCH_SCALAR_OBJ_TYPES(beta_dtype, ctx, "addmm", BETA_T, [&]() {
+  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "addmm.out", CTYPE, [&]() {
+    ET_SWITCH_SCALAR_OBJ_TYPES(alpha_dtype, ctx, "addmm.out", ALPHA_T, [&]() {
+      ET_SWITCH_SCALAR_OBJ_TYPES(beta_dtype, ctx, "addmm.out", BETA_T, [&]() {
         size_t m = mat1.size(0);
         size_t n = mat1.size(1);
         size_t p = mat2.size(1);

--- a/kernels/portable/cpu/op_amax.cpp
+++ b/kernels/portable/cpu/op_amax.cpp
@@ -55,18 +55,19 @@ Tensor& amax_out(
   Error e = resize_reduction_out(in, dim_list, keepdim, out);
   ET_CHECK_MSG(e == Error::Ok, "Failed to resize out tensor in amax_out");
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in.scalar_type(), ctx, "amax", CTYPE, [&]() {
-    CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
-    for (size_t out_ix = 0; out_ix < out.numel(); ++out_ix) {
-      out_data[out_ix] = reduce_over_dim_list<CTYPE>(
-          [](CTYPE v, CTYPE max_v) {
-            return std::isnan(v) || v > max_v ? v : max_v;
-          },
-          in,
-          dim_list,
-          out_ix);
-    }
-  });
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in.scalar_type(), ctx, "amax.out", CTYPE, [&]() {
+        CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
+        for (size_t out_ix = 0; out_ix < out.numel(); ++out_ix) {
+          out_data[out_ix] = reduce_over_dim_list<CTYPE>(
+              [](CTYPE v, CTYPE max_v) {
+                return std::isnan(v) || v > max_v ? v : max_v;
+              },
+              in,
+              dim_list,
+              out_ix);
+        }
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_amin.cpp
+++ b/kernels/portable/cpu/op_amin.cpp
@@ -55,18 +55,19 @@ Tensor& amin_out(
   Error e = resize_reduction_out(in, dim_list, keepdim, out);
   ET_CHECK_MSG(e == Error::Ok, "Failed to resize out tensor in amin_out");
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in.scalar_type(), ctx, "amin", CTYPE, [&]() {
-    CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
-    for (size_t out_ix = 0; out_ix < out.numel(); ++out_ix) {
-      out_data[out_ix] = reduce_over_dim_list<CTYPE>(
-          [](CTYPE v, CTYPE min_v) {
-            return std::isnan(v) || v < min_v ? v : min_v;
-          },
-          in,
-          dim_list,
-          out_ix);
-    }
-  });
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in.scalar_type(), ctx, "amin.out", CTYPE, [&]() {
+        CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
+        for (size_t out_ix = 0; out_ix < out.numel(); ++out_ix) {
+          out_data[out_ix] = reduce_over_dim_list<CTYPE>(
+              [](CTYPE v, CTYPE min_v) {
+                return std::isnan(v) || v < min_v ? v : min_v;
+              },
+              in,
+              dim_list,
+              out_ix);
+        }
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_any.cpp
+++ b/kernels/portable/cpu/op_any.cpp
@@ -24,18 +24,19 @@ Tensor& any_all_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   ScalarType in_type = in.scalar_type();
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE_IN, [&] {
-    ET_SWITCH_TWO_TYPES(Bool, Byte, out_type, ctx, __func__, CTYPE_OUT, [&] {
-      const auto data_in = in.const_data_ptr<CTYPE_IN>();
-      auto data_out = out.mutable_data_ptr<CTYPE_OUT>();
-      data_out[0] = static_cast<CTYPE_OUT>(false);
-      for (auto i = 0; i < in.numel(); ++i) {
-        if (static_cast<CTYPE_OUT>(data_in[i])) {
-          data_out[0] = static_cast<CTYPE_OUT>(true);
-          break;
-        }
-      }
-    });
+  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "any.all_out", CTYPE_IN, [&] {
+    ET_SWITCH_TWO_TYPES(
+        Bool, Byte, out_type, ctx, "any.all_out", CTYPE_OUT, [&] {
+          const auto data_in = in.const_data_ptr<CTYPE_IN>();
+          auto data_out = out.mutable_data_ptr<CTYPE_OUT>();
+          data_out[0] = static_cast<CTYPE_OUT>(false);
+          for (auto i = 0; i < in.numel(); ++i) {
+            if (static_cast<CTYPE_OUT>(data_in[i])) {
+              data_out[0] = static_cast<CTYPE_OUT>(true);
+              break;
+            }
+          }
+        });
   });
 
   return out;

--- a/kernels/portable/cpu/op_arange.cpp
+++ b/kernels/portable/cpu/op_arange.cpp
@@ -30,7 +30,7 @@ Tensor& arange_out(RuntimeContext& ctx, const Scalar& end, Tensor& out) {
   ScalarType end_type = utils::get_scalar_dtype(end);
 
   double end_val = 0;
-  ET_SWITCH_SCALAR_OBJ_TYPES(end_type, ctx, __func__, CTYPE_END, [&]() {
+  ET_SWITCH_SCALAR_OBJ_TYPES(end_type, ctx, "arange.out", CTYPE_END, [&]() {
     CTYPE_END end_v;
     ET_EXTRACT_SCALAR(end, end_v);
     ET_KERNEL_CHECK_MSG(
@@ -49,7 +49,7 @@ Tensor& arange_out(RuntimeContext& ctx, const Scalar& end, Tensor& out) {
   ET_KERNEL_CHECK_MSG(
       ctx, status == Error::Ok, InvalidArgument, out, "resize_tensor fails");
 
-  ET_SWITCH_REAL_TYPES(out.scalar_type(), ctx, __func__, CTYPE, [&]() {
+  ET_SWITCH_REAL_TYPES(out.scalar_type(), ctx, "arange.out", CTYPE, [&]() {
     auto out_data = out.mutable_data_ptr<CTYPE>();
     for (size_t i = 0; i < size; i++) {
       out_data[i] = static_cast<CTYPE>(i);
@@ -72,25 +72,28 @@ Tensor& arange_start_out(
   ScalarType step_type = utils::get_scalar_dtype(step);
 
   double d_start = 0;
-  ET_SWITCH_SCALAR_OBJ_TYPES(start_type, ctx, __func__, CTYPE_END, [&]() {
-    CTYPE_END start_v;
-    ET_EXTRACT_SCALAR(start, start_v);
-    d_start = static_cast<double>(start_v);
-  });
+  ET_SWITCH_SCALAR_OBJ_TYPES(
+      start_type, ctx, "arange.start_out", CTYPE_END, [&]() {
+        CTYPE_END start_v;
+        ET_EXTRACT_SCALAR(start, start_v);
+        d_start = static_cast<double>(start_v);
+      });
 
   double d_end = 0;
-  ET_SWITCH_SCALAR_OBJ_TYPES(end_type, ctx, __func__, CTYPE_END, [&]() {
-    CTYPE_END end_v;
-    ET_EXTRACT_SCALAR(end, end_v);
-    d_end = static_cast<double>(end_v);
-  });
+  ET_SWITCH_SCALAR_OBJ_TYPES(
+      end_type, ctx, "arange.start_out", CTYPE_END, [&]() {
+        CTYPE_END end_v;
+        ET_EXTRACT_SCALAR(end, end_v);
+        d_end = static_cast<double>(end_v);
+      });
 
   double d_step = 0;
-  ET_SWITCH_SCALAR_OBJ_TYPES(step_type, ctx, __func__, CTYPE_END, [&]() {
-    CTYPE_END step_v;
-    ET_EXTRACT_SCALAR(step, step_v);
-    d_step = static_cast<double>(step_v);
-  });
+  ET_SWITCH_SCALAR_OBJ_TYPES(
+      step_type, ctx, "arange.start_out", CTYPE_END, [&]() {
+        CTYPE_END step_v;
+        ET_EXTRACT_SCALAR(step, step_v);
+        d_step = static_cast<double>(step_v);
+      });
 
   ET_KERNEL_CHECK_MSG(
       ctx,
@@ -107,12 +110,13 @@ Tensor& arange_start_out(
   ET_KERNEL_CHECK_MSG(
       ctx, status == Error::Ok, InvalidArgument, out, "resize_tensor fails");
 
-  ET_SWITCH_REAL_TYPES(out.scalar_type(), ctx, __func__, CTYPE, [&]() {
-    auto out_data = out.mutable_data_ptr<CTYPE>();
-    for (size_t i = 0; i < size; i++) {
-      out_data[i] = convert<CTYPE, double>(d_start + i * d_step);
-    }
-  });
+  ET_SWITCH_REAL_TYPES(
+      out.scalar_type(), ctx, "arange.start_out", CTYPE, [&]() {
+        auto out_data = out.mutable_data_ptr<CTYPE>();
+        for (size_t i = 0; i < size; i++) {
+          out_data[i] = convert<CTYPE, double>(d_start + i * d_step);
+        }
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_argmax.cpp
+++ b/kernels/portable/cpu/op_argmax.cpp
@@ -63,7 +63,7 @@ Tensor& argmax_out(
   Error error = resize_reduction_out(in, dim, keepdim, out);
   ET_CHECK_MSG(error == Error::Ok, "Failed to resize out tensor in argmax_out");
 
-  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "argmax", CTYPE, [&] {
+  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "argmax.out", CTYPE, [&] {
     long* out_data = out.mutable_data_ptr<long>();
 
     for (size_t out_ix = 0; out_ix < out.numel(); ++out_ix) {

--- a/kernels/portable/cpu/op_argmin.cpp
+++ b/kernels/portable/cpu/op_argmin.cpp
@@ -63,7 +63,7 @@ Tensor& argmin_out(
   Error error = resize_reduction_out(in, dim, keepdim, out);
   ET_CHECK_MSG(error == Error::Ok, "Failed to resize out tensor in argmin_out");
 
-  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "argmin", CTYPE, [&] {
+  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "argmin.out", CTYPE, [&] {
     long* out_data = out.mutable_data_ptr<long>();
 
     for (size_t out_ix = 0; out_ix < out.numel(); ++out_ix) {

--- a/kernels/portable/cpu/op_avg_pool2d.cpp
+++ b/kernels/portable/cpu/op_avg_pool2d.cpp
@@ -62,7 +62,7 @@ Tensor& avg_pool2d_out(
       out);
 
   ScalarType in_type = in.scalar_type();
-  ET_SWITCH_FLOAT_TYPES_AND(Long, in_type, ctx, __func__, CTYPE, [&]() {
+  ET_SWITCH_FLOAT_TYPES_AND(Long, in_type, ctx, "avg_pool2d.out", CTYPE, [&]() {
     if (divisor_override.has_value()) {
       int64_t divisor = divisor_override.value();
       // If divisor_override is specified, then we don't need to use `count` in

--- a/kernels/portable/cpu/op_bitwise_and.cpp
+++ b/kernels/portable/cpu/op_bitwise_and.cpp
@@ -50,27 +50,45 @@ Tensor& bitwise_and_Tensor_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_INT_TYPES_AND(Bool, a_type, ctx, "bitwise_and", CTYPE_A, [&]() {
-    ET_SWITCH_INT_TYPES_AND(Bool, b_type, ctx, "bitwise_and", CTYPE_B, [&]() {
-      ET_SWITCH_INT_TYPES_AND(
-          Bool, common_type, ctx, "bitwise_and", CTYPE_IN, [&]() {
-            ET_SWITCH_REAL_TYPES_AND(
-                Bool, out_type, ctx, "bitwise_and", CTYPE_OUT, [&]() {
-                  apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                      [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                        CTYPE_IN value = bitwise_and(a_casted, b_casted);
+  ET_SWITCH_INT_TYPES_AND(
+      Bool, a_type, ctx, "bitwise_and.Tensor_out", CTYPE_A, [&]() {
+        ET_SWITCH_INT_TYPES_AND(
+            Bool, b_type, ctx, "bitwise_and.Tensor_out", CTYPE_B, [&]() {
+              ET_SWITCH_INT_TYPES_AND(
+                  Bool,
+                  common_type,
+                  ctx,
+                  "bitwise_and.Tensor_out",
+                  CTYPE_IN,
+                  [&]() {
+                    ET_SWITCH_REAL_TYPES_AND(
+                        Bool,
+                        out_type,
+                        ctx,
+                        "bitwise_and.Tensor_out",
+                        CTYPE_OUT,
+                        [&]() {
+                          apply_binary_elementwise_fn<
+                              CTYPE_A,
+                              CTYPE_B,
+                              CTYPE_OUT>(
+                              [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value =
+                                    bitwise_and(a_casted, b_casted);
 
-                        return static_cast<CTYPE_OUT>(value);
-                      },
-                      a,
-                      b,
-                      out);
-                });
-          });
-    });
-  });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a,
+                              b,
+                              out);
+                        });
+                  });
+            });
+      });
 
   return out;
 }
@@ -92,29 +110,44 @@ Tensor& bitwise_and_Scalar_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_INT_TYPES_AND(Bool, a_type, ctx, "bitwise_and", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_INTB_TYPES(b_type, ctx, "bitwise_and", CTYPE_B, [&]() {
-      CTYPE_B val_b = 0;
-      ET_EXTRACT_SCALAR(b, val_b);
-      ET_SWITCH_INT_TYPES_AND(
-          Bool, common_type, ctx, "bitwise_and", CTYPE_IN, [&]() {
-            ET_SWITCH_REAL_TYPES_AND(
-                Bool, out_type, ctx, "bitwise_and", CTYPE_OUT, [&]() {
-                  apply_unary_map_fn(
-                      [val_b](const CTYPE_A val_a) {
-                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                        CTYPE_IN value = bitwise_and(a_casted, b_casted);
+  ET_SWITCH_INT_TYPES_AND(
+      Bool, a_type, ctx, "bitwise_and.Scalar_out", CTYPE_A, [&]() {
+        ET_SWITCH_SCALAR_OBJ_INTB_TYPES(
+            b_type, ctx, "bitwise_and.Scalar_out", CTYPE_B, [&]() {
+              CTYPE_B val_b = 0;
+              ET_EXTRACT_SCALAR(b, val_b);
+              ET_SWITCH_INT_TYPES_AND(
+                  Bool,
+                  common_type,
+                  ctx,
+                  "bitwise_and.Scalar_out",
+                  CTYPE_IN,
+                  [&]() {
+                    ET_SWITCH_REAL_TYPES_AND(
+                        Bool,
+                        out_type,
+                        ctx,
+                        "bitwise_and.Scalar_out",
+                        CTYPE_OUT,
+                        [&]() {
+                          apply_unary_map_fn(
+                              [val_b](const CTYPE_A val_a) {
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value =
+                                    bitwise_and(a_casted, b_casted);
 
-                        return static_cast<CTYPE_OUT>(value);
-                      },
-                      a.const_data_ptr<CTYPE_A>(),
-                      out.mutable_data_ptr<CTYPE_OUT>(),
-                      out.numel());
-                });
-          });
-    });
-  });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a.const_data_ptr<CTYPE_A>(),
+                              out.mutable_data_ptr<CTYPE_OUT>(),
+                              out.numel());
+                        });
+                  });
+            });
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_bitwise_not.cpp
+++ b/kernels/portable/cpu/op_bitwise_not.cpp
@@ -36,7 +36,7 @@ Tensor& bitwise_not_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
         out.mutable_data_ptr<bool>(),
         in.numel());
   } else if (isIntegralType(in.scalar_type(), /*includeBool=*/false)) {
-    ET_SWITCH_INT_TYPES(in.scalar_type(), ctx, "bitwise_not", CTYPE, [&] {
+    ET_SWITCH_INT_TYPES(in.scalar_type(), ctx, "bitwise_not.out", CTYPE, [&] {
       apply_unary_map_fn(
           [](const CTYPE val_in) { return ~val_in; },
           in.const_data_ptr<CTYPE>(),

--- a/kernels/portable/cpu/op_bitwise_or.cpp
+++ b/kernels/portable/cpu/op_bitwise_or.cpp
@@ -50,27 +50,44 @@ Tensor& bitwise_or_Tensor_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_INT_TYPES_AND(Bool, a_type, ctx, "bitwise_or", CTYPE_A, [&]() {
-    ET_SWITCH_INT_TYPES_AND(Bool, b_type, ctx, "bitwise_or", CTYPE_B, [&]() {
-      ET_SWITCH_INT_TYPES_AND(
-          Bool, common_type, ctx, "bitwise_or", CTYPE_IN, [&]() {
-            ET_SWITCH_REAL_TYPES_AND(
-                Bool, out_type, ctx, "bitwise_or", CTYPE_OUT, [&]() {
-                  apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                      [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                        CTYPE_IN value = bitwise_or(a_casted, b_casted);
+  ET_SWITCH_INT_TYPES_AND(
+      Bool, a_type, ctx, "bitwise_or.Tensor_out", CTYPE_A, [&]() {
+        ET_SWITCH_INT_TYPES_AND(
+            Bool, b_type, ctx, "bitwise_or.Tensor_out", CTYPE_B, [&]() {
+              ET_SWITCH_INT_TYPES_AND(
+                  Bool,
+                  common_type,
+                  ctx,
+                  "bitwise_or.Tensor_out",
+                  CTYPE_IN,
+                  [&]() {
+                    ET_SWITCH_REAL_TYPES_AND(
+                        Bool,
+                        out_type,
+                        ctx,
+                        "bitwise_or.Tensor_out",
+                        CTYPE_OUT,
+                        [&]() {
+                          apply_binary_elementwise_fn<
+                              CTYPE_A,
+                              CTYPE_B,
+                              CTYPE_OUT>(
+                              [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value = bitwise_or(a_casted, b_casted);
 
-                        return static_cast<CTYPE_OUT>(value);
-                      },
-                      a,
-                      b,
-                      out);
-                });
-          });
-    });
-  });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a,
+                              b,
+                              out);
+                        });
+                  });
+            });
+      });
 
   return out;
 }
@@ -92,29 +109,43 @@ Tensor& bitwise_or_Scalar_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_INT_TYPES_AND(Bool, a_type, ctx, "bitwise_or", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_INTB_TYPES(b_type, ctx, "bitwise_or", CTYPE_B, [&]() {
-      CTYPE_B val_b = 0;
-      ET_EXTRACT_SCALAR(b, val_b);
-      ET_SWITCH_INT_TYPES_AND(
-          Bool, common_type, ctx, "bitwise_or", CTYPE_IN, [&]() {
-            ET_SWITCH_REAL_TYPES_AND(
-                Bool, out_type, ctx, "bitwise_or", CTYPE_OUT, [&]() {
-                  apply_unary_map_fn(
-                      [val_b](const CTYPE_A val_a) {
-                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                        CTYPE_IN value = bitwise_or(a_casted, b_casted);
+  ET_SWITCH_INT_TYPES_AND(
+      Bool, a_type, ctx, "bitwise_or.Scalar_out", CTYPE_A, [&]() {
+        ET_SWITCH_SCALAR_OBJ_INTB_TYPES(
+            b_type, ctx, "bitwise_or.Scalar_out", CTYPE_B, [&]() {
+              CTYPE_B val_b = 0;
+              ET_EXTRACT_SCALAR(b, val_b);
+              ET_SWITCH_INT_TYPES_AND(
+                  Bool,
+                  common_type,
+                  ctx,
+                  "bitwise_or.Scalar_out",
+                  CTYPE_IN,
+                  [&]() {
+                    ET_SWITCH_REAL_TYPES_AND(
+                        Bool,
+                        out_type,
+                        ctx,
+                        "bitwise_or.Scalar_out",
+                        CTYPE_OUT,
+                        [&]() {
+                          apply_unary_map_fn(
+                              [val_b](const CTYPE_A val_a) {
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value = bitwise_or(a_casted, b_casted);
 
-                        return static_cast<CTYPE_OUT>(value);
-                      },
-                      a.const_data_ptr<CTYPE_A>(),
-                      out.mutable_data_ptr<CTYPE_OUT>(),
-                      out.numel());
-                });
-          });
-    });
-  });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a.const_data_ptr<CTYPE_A>(),
+                              out.mutable_data_ptr<CTYPE_OUT>(),
+                              out.numel());
+                        });
+                  });
+            });
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_bitwise_xor.cpp
+++ b/kernels/portable/cpu/op_bitwise_xor.cpp
@@ -50,27 +50,45 @@ Tensor& bitwise_xor_Tensor_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_INT_TYPES_AND(Bool, a_type, ctx, "bitwise_xor", CTYPE_A, [&]() {
-    ET_SWITCH_INT_TYPES_AND(Bool, b_type, ctx, "bitwise_xor", CTYPE_B, [&]() {
-      ET_SWITCH_INT_TYPES_AND(
-          Bool, common_type, ctx, "bitwise_xor", CTYPE_IN, [&]() {
-            ET_SWITCH_REAL_TYPES_AND(
-                Bool, out_type, ctx, "bitwise_xor", CTYPE_OUT, [&]() {
-                  apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                      [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                        CTYPE_IN value = bitwise_xor(a_casted, b_casted);
+  ET_SWITCH_INT_TYPES_AND(
+      Bool, a_type, ctx, "bitwise_xor.Tensor_out", CTYPE_A, [&]() {
+        ET_SWITCH_INT_TYPES_AND(
+            Bool, b_type, ctx, "bitwise_xor.Tensor_out", CTYPE_B, [&]() {
+              ET_SWITCH_INT_TYPES_AND(
+                  Bool,
+                  common_type,
+                  ctx,
+                  "bitwise_xor.Tensor_out",
+                  CTYPE_IN,
+                  [&]() {
+                    ET_SWITCH_REAL_TYPES_AND(
+                        Bool,
+                        out_type,
+                        ctx,
+                        "bitwise_xor.Tensor_out",
+                        CTYPE_OUT,
+                        [&]() {
+                          apply_binary_elementwise_fn<
+                              CTYPE_A,
+                              CTYPE_B,
+                              CTYPE_OUT>(
+                              [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value =
+                                    bitwise_xor(a_casted, b_casted);
 
-                        return static_cast<CTYPE_OUT>(value);
-                      },
-                      a,
-                      b,
-                      out);
-                });
-          });
-    });
-  });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a,
+                              b,
+                              out);
+                        });
+                  });
+            });
+      });
 
   return out;
 }
@@ -92,29 +110,44 @@ Tensor& bitwise_xor_Scalar_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_INT_TYPES_AND(Bool, a_type, ctx, "bitwise_xor", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_INTB_TYPES(b_type, ctx, "bitwise_xor", CTYPE_B, [&]() {
-      CTYPE_B val_b = 0;
-      ET_EXTRACT_SCALAR(b, val_b);
-      ET_SWITCH_INT_TYPES_AND(
-          Bool, common_type, ctx, "bitwise_xor", CTYPE_IN, [&]() {
-            ET_SWITCH_REAL_TYPES_AND(
-                Bool, out_type, ctx, "bitwise_xor", CTYPE_OUT, [&]() {
-                  apply_unary_map_fn(
-                      [val_b](const CTYPE_A val_a) {
-                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                        CTYPE_IN value = bitwise_xor(a_casted, b_casted);
+  ET_SWITCH_INT_TYPES_AND(
+      Bool, a_type, ctx, "bitwise_xor.Scalar_out", CTYPE_A, [&]() {
+        ET_SWITCH_SCALAR_OBJ_INTB_TYPES(
+            b_type, ctx, "bitwise_xor.Scalar_out", CTYPE_B, [&]() {
+              CTYPE_B val_b = 0;
+              ET_EXTRACT_SCALAR(b, val_b);
+              ET_SWITCH_INT_TYPES_AND(
+                  Bool,
+                  common_type,
+                  ctx,
+                  "bitwise_xor.Scalar_out",
+                  CTYPE_IN,
+                  [&]() {
+                    ET_SWITCH_REAL_TYPES_AND(
+                        Bool,
+                        out_type,
+                        ctx,
+                        "bitwise_xor.Scalar_out",
+                        CTYPE_OUT,
+                        [&]() {
+                          apply_unary_map_fn(
+                              [val_b](const CTYPE_A val_a) {
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value =
+                                    bitwise_xor(a_casted, b_casted);
 
-                        return static_cast<CTYPE_OUT>(value);
-                      },
-                      a.const_data_ptr<CTYPE_A>(),
-                      out.mutable_data_ptr<CTYPE_OUT>(),
-                      out.numel());
-                });
-          });
-    });
-  });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a.const_data_ptr<CTYPE_A>(),
+                              out.mutable_data_ptr<CTYPE_OUT>(),
+                              out.numel());
+                        });
+                  });
+            });
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_bmm.cpp
+++ b/kernels/portable/cpu/op_bmm.cpp
@@ -32,7 +32,7 @@ Tensor& bmm_out(
       InvalidArgument,
       out);
 
-  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "bmm", CTYPE, [&]() {
+  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "bmm.out", CTYPE, [&]() {
     const CTYPE* in_data = in.const_data_ptr<CTYPE>();
     const CTYPE* mat2_data = mat2.const_data_ptr<CTYPE>();
     CTYPE* out_data = out.mutable_data_ptr<CTYPE>();

--- a/kernels/portable/cpu/op_cat.cpp
+++ b/kernels/portable/cpu/op_cat.cpp
@@ -52,12 +52,12 @@ Tensor& cat_out(
   const size_t ninputs = tensors.size();
 
   const auto out_type = out.scalar_type();
-  ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "cat", CTYPE_OUT, [&] {
+  ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "cat.out", CTYPE_OUT, [&] {
     CTYPE_OUT* out_ptr = out.mutable_data_ptr<CTYPE_OUT>();
     for (size_t i = 0; i < outer; ++i) {
       for (size_t j = 0; j < ninputs; ++j) {
         const auto in_type = tensors[j].scalar_type();
-        ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "cat", CTYPE_IN, [&] {
+        ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "cat.out", CTYPE_IN, [&] {
           if (tensors[j].numel() == 0) {
             return;
           }

--- a/kernels/portable/cpu/op_clamp.cpp
+++ b/kernels/portable/cpu/op_clamp.cpp
@@ -90,11 +90,11 @@ void check_bounds(
     const torch::executor::native::ScalarType& val_type,
     const torch::executor::native::ScalarType& out_type,
     const char* val_name) {
-  ET_SWITCH_SCALAR_OBJ_TYPES(val_type, ctx, "clamp", CTYPE_VAL, [&]() {
+  ET_SWITCH_SCALAR_OBJ_TYPES(val_type, ctx, "clamp.out", CTYPE_VAL, [&]() {
     CTYPE_VAL val = 0;
     ET_EXTRACT_SCALAR(val_scalar, val);
     if (isIntegralType(out_type, /*includeBool=*/false)) {
-      ET_SWITCH_INT_TYPES(out_type, ctx, "clamp", CTYPE_OUT, [&]() {
+      ET_SWITCH_INT_TYPES(out_type, ctx, "clamp.out", CTYPE_OUT, [&]() {
         if (is_out_of_bounds<CTYPE_VAL, CTYPE_OUT, long>(val)) {
           ET_CHECK_MSG(false, "%s value out of bounds", val_name);
         }

--- a/kernels/portable/cpu/op_constant_pad_nd.cpp
+++ b/kernels/portable/cpu/op_constant_pad_nd.cpp
@@ -215,15 +215,17 @@ Tensor& constant_pad_nd_out(
 
   ET_CHECK(in_type == out_type);
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE, [&]() {
-    CTYPE value_v;
-    ET_SWITCH_SCALAR_OBJ_TYPES(value_type, ctx, __func__, CTYPE_VALUE, [&]() {
-      CTYPE_VALUE val;
-      ET_EXTRACT_SCALAR(value, val);
-      value_v = static_cast<CTYPE>(val);
-    });
-    constant_pad_nd_out_impl<CTYPE>(in, pad, value_v, out);
-  });
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in_type, ctx, "constant_pad_nd.out", CTYPE, [&]() {
+        CTYPE value_v;
+        ET_SWITCH_SCALAR_OBJ_TYPES(
+            value_type, ctx, "constant_pad_nd.out", CTYPE_VALUE, [&]() {
+              CTYPE_VALUE val;
+              ET_EXTRACT_SCALAR(value, val);
+              value_v = static_cast<CTYPE>(val);
+            });
+        constant_pad_nd_out_impl<CTYPE>(in, pad, value_v, out);
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_convolution.cpp
+++ b/kernels/portable/cpu/op_convolution.cpp
@@ -320,11 +320,12 @@ Tensor& convolution_out(
   if (bias.has_value()) {
     bias_type = bias.value().scalar_type();
   }
-  ET_SWITCH_REAL_TYPES(in_type, ctx, __func__, CTYPE, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, bias_type, ctx, __func__, CTYPE_BIAS, [&]() {
-      convolution_wrapper<CTYPE, CTYPE_BIAS>(
-          in, weight, bias, stride, padding, dilation, groups, out);
-    });
+  ET_SWITCH_REAL_TYPES(in_type, ctx, "convolution.out", CTYPE, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(
+        Bool, bias_type, ctx, "convolution.out", CTYPE_BIAS, [&]() {
+          convolution_wrapper<CTYPE, CTYPE_BIAS>(
+              in, weight, bias, stride, padding, dilation, groups, out);
+        });
   });
 
   return out;

--- a/kernels/portable/cpu/op_copy.cpp
+++ b/kernels/portable/cpu/op_copy.cpp
@@ -42,8 +42,8 @@ Tensor& copy_out(
   ScalarType in_type = in.scalar_type();
   ScalarType src_type = src.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, src_type, ctx, __func__, CTYPE_SRC, [&]() {
+  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "copy.out", CTYPE, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(Bool, src_type, ctx, "copy.out", CTYPE_SRC, [&]() {
       apply_binary_elementwise_fn<CTYPE, CTYPE_SRC, CTYPE>(
           [](const CTYPE val_in, const CTYPE_SRC val_src) {
             return convert<CTYPE, CTYPE_SRC>(val_src);

--- a/kernels/portable/cpu/op_div.cpp
+++ b/kernels/portable/cpu/op_div.cpp
@@ -50,10 +50,10 @@ div_out(RuntimeContext& ctx, const Tensor& a, const Tensor& b, Tensor& out) {
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "div", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "div", CTYPE_B, [&]() {
-      ET_SWITCH_FLOAT_TYPES(common_type, ctx, "div", CTYPE_IN, [&]() {
-        ET_SWITCH_FLOAT_TYPES(out_type, ctx, "div", CTYPE_OUT, [&]() {
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "div.out", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "div.out", CTYPE_B, [&]() {
+      ET_SWITCH_FLOAT_TYPES(common_type, ctx, "div.out", CTYPE_IN, [&]() {
+        ET_SWITCH_FLOAT_TYPES(out_type, ctx, "div.out", CTYPE_OUT, [&]() {
           apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
               [](const CTYPE_A val_a, const CTYPE_B val_b) {
                 CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
@@ -92,10 +92,10 @@ Tensor& div_out_mode(
   // non-bool -> bool is still disallowed
   ET_CHECK(!(common_type != ScalarType::Bool && out_type == ScalarType::Bool));
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "div", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "div", CTYPE_B, [&]() {
-      ET_SWITCH_FLOAT_TYPES(common_type, ctx, "div", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES(out_type, ctx, "div", CTYPE_OUT, [&]() {
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "div.out_mode", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "div.out_mode", CTYPE_B, [&]() {
+      ET_SWITCH_FLOAT_TYPES(common_type, ctx, "div.out_mode", CTYPE_IN, [&]() {
+        ET_SWITCH_REAL_TYPES(out_type, ctx, "div.out_mode", CTYPE_OUT, [&]() {
           apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
               [mode](const CTYPE_A val_a, const CTYPE_B val_b) {
                 CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
@@ -137,25 +137,27 @@ Tensor& div_scalar_out(
 
   ET_CHECK(common_type == out_type);
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "div", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "div", CTYPE_B, [&]() {
-      ET_SWITCH_FLOAT_TYPES(common_type, ctx, "div", CTYPE_IN, [&]() {
-        ET_SWITCH_FLOAT_TYPES(out_type, ctx, "div", CTYPE_OUT, [&]() {
-          CTYPE_B b_val;
-          ET_EXTRACT_SCALAR(b, b_val);
-          CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "div.Scalar_out", CTYPE_A, [&]() {
+    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "div.Scalar_out", CTYPE_B, [&]() {
+      ET_SWITCH_FLOAT_TYPES(
+          common_type, ctx, "div.Scalar_out", CTYPE_IN, [&]() {
+            ET_SWITCH_FLOAT_TYPES(
+                out_type, ctx, "div.Scalar_out", CTYPE_OUT, [&]() {
+                  CTYPE_B b_val;
+                  ET_EXTRACT_SCALAR(b, b_val);
+                  CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
 
-          apply_unary_map_fn(
-              [b_casted](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN value = a_casted / b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
+                  apply_unary_map_fn(
+                      [b_casted](const CTYPE_A val_a) {
+                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                        CTYPE_IN value = a_casted / b_casted;
+                        return static_cast<CTYPE_OUT>(value);
+                      },
+                      a.const_data_ptr<CTYPE_A>(),
+                      out.mutable_data_ptr<CTYPE_OUT>(),
+                      out.numel());
+                });
+          });
     });
   });
 

--- a/kernels/portable/cpu/op_embedding.cpp
+++ b/kernels/portable/cpu/op_embedding.cpp
@@ -132,9 +132,10 @@ Tensor& embedding_out(
       ix_type == ScalarType::Long || ix_type == ScalarType::Int,
       "Expected indices tensor to have Long or Int scalar types");
 
-  ET_SWITCH_TWO_TYPES(Long, Int, ix_type, ctx, __func__, CTYPE, [&]() {
-    embedding_kernel<CTYPE>(weight, indices, out);
-  });
+  ET_SWITCH_TWO_TYPES(
+      Long, Int, ix_type, ctx, "op_embedding.out", CTYPE, [&]() {
+        embedding_kernel<CTYPE>(weight, indices, out);
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_eq.cpp
+++ b/kernels/portable/cpu/op_eq.cpp
@@ -34,23 +34,26 @@ Tensor& eq_tensor_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "eq", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "eq", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "eq", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "eq", CTYPE_OUT, [&]() {
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted == b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "eq.Scalar_out", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(
+        Bool, b_type, ctx, "eq.Scalar_out", CTYPE_B, [&]() {
+          ET_SWITCH_REAL_TYPES_AND(
+              Bool, common_type, ctx, "eq.Scalar_out", CTYPE_IN, [&]() {
+                ET_SWITCH_REAL_TYPES_AND(
+                    Bool, out_type, ctx, "eq.Scalar_out", CTYPE_OUT, [&]() {
+                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
+                          [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                            bool value = a_casted == b_casted;
+                            return static_cast<CTYPE_OUT>(value);
+                          },
+                          a,
+                          b,
+                          out);
+                    });
+              });
         });
-      });
-    });
   });
 
   return out;
@@ -72,24 +75,26 @@ Tensor& eq_scalar_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "eq", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "eq", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "eq", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "eq", CTYPE_OUT, [&]() {
-          CTYPE_B val_b = 0;
-          ET_EXTRACT_SCALAR(b, val_b);
-          apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted == b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "eq.Scalar_out", CTYPE_A, [&]() {
+    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "eq.Scalar_out", CTYPE_B, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, common_type, ctx, "eq.Scalar_out", CTYPE_IN, [&]() {
+            ET_SWITCH_REAL_TYPES_AND(
+                Bool, out_type, ctx, "eq.Scalar_out", CTYPE_OUT, [&]() {
+                  CTYPE_B val_b = 0;
+                  ET_EXTRACT_SCALAR(b, val_b);
+                  apply_unary_map_fn(
+                      [val_b](const CTYPE_A val_a) {
+                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                        bool value = a_casted == b_casted;
+                        return static_cast<CTYPE_OUT>(value);
+                      },
+                      a.const_data_ptr<CTYPE_A>(),
+                      out.mutable_data_ptr<CTYPE_OUT>(),
+                      out.numel());
+                });
+          });
     });
   });
 

--- a/kernels/portable/cpu/op_fill.cpp
+++ b/kernels/portable/cpu/op_fill.cpp
@@ -35,9 +35,9 @@ Tensor& fill_scalar_out(
   auto error = resize_tensor(out, a.sizes());
   ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "fill", CTYPE_A, [&] {
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "fill.Scalar_out", CTYPE_A, [&] {
     CTYPE_A b_casted;
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "fill", CTYPE_B, [&] {
+    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "fill.Scalar_out", CTYPE_B, [&] {
       CTYPE_B b_val;
       ET_EXTRACT_SCALAR(b, b_val);
       b_casted = static_cast<CTYPE_A>(b_val);
@@ -73,13 +73,14 @@ Tensor& fill_tensor_out(
   auto error = resize_tensor(out, a.sizes());
   ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "fill", CTYPE_A, [&] {
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "fill.Tensor_out", CTYPE_A, [&] {
     CTYPE_A b_casted;
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "fill", CTYPE_B, [&] {
-      CTYPE_B b_val;
-      ET_EXTRACT_SCALAR_TENSOR(b, b_val);
-      b_casted = static_cast<CTYPE_A>(b_val);
-    });
+    ET_SWITCH_REAL_TYPES_AND(
+        Bool, b_type, ctx, "fill.Tensor_out", CTYPE_B, [&] {
+          CTYPE_B b_val;
+          ET_EXTRACT_SCALAR_TENSOR(b, b_val);
+          b_casted = static_cast<CTYPE_A>(b_val);
+        });
 
     apply_unary_map_fn(
         [b_casted](const CTYPE_A val_a) { return b_casted; },

--- a/kernels/portable/cpu/op_floor_divide.cpp
+++ b/kernels/portable/cpu/op_floor_divide.cpp
@@ -72,28 +72,40 @@ Tensor& floor_divide_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "floor_divide", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "floor_divide", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES(common_type, ctx, "floor_divide", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES(out_type, ctx, "floor_divide", CTYPE_OUT, [&]() {
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [common_type](const CTYPE_A val_a, const CTYPE_B val_b) {
-                if (isIntegralType(common_type, /*includeBool=*/true)) {
-                  ET_CHECK(val_b != 0);
-                }
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                CTYPE_IN value = floor_divide<CTYPE_IN>(a_casted, b_casted);
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, a_type, ctx, "floor_divide.out", CTYPE_A, [&]() {
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, b_type, ctx, "floor_divide.out", CTYPE_B, [&]() {
+              ET_SWITCH_REAL_TYPES(
+                  common_type, ctx, "floor_divide.out", CTYPE_IN, [&]() {
+                    ET_SWITCH_REAL_TYPES(
+                        out_type, ctx, "floor_divide.out", CTYPE_OUT, [&]() {
+                          apply_binary_elementwise_fn<
+                              CTYPE_A,
+                              CTYPE_B,
+                              CTYPE_OUT>(
+                              [common_type](
+                                  const CTYPE_A val_a, const CTYPE_B val_b) {
+                                if (isIntegralType(
+                                        common_type, /*includeBool=*/true)) {
+                                  ET_CHECK(val_b != 0);
+                                }
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value =
+                                    floor_divide<CTYPE_IN>(a_casted, b_casted);
 
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
-        });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a,
+                              b,
+                              out);
+                        });
+                  });
+            });
       });
-    });
-  });
 
   return out;
 }

--- a/kernels/portable/cpu/op_fmod.cpp
+++ b/kernels/portable/cpu/op_fmod.cpp
@@ -36,28 +36,39 @@ Tensor& fmod_Tensor_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "fmod", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "fmod", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES(common_type, ctx, "fmod", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES(out_type, ctx, "fmod", CTYPE_OUT, [&]() {
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [common_type](const CTYPE_A val_a, const CTYPE_B val_b) {
-                if (isIntegralType(common_type, /*includeBool=*/true)) {
-                  ET_CHECK(val_b != 0);
-                }
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                CTYPE_IN value = std::fmod(a_casted, b_casted);
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, a_type, ctx, "fmod.Tensor_out", CTYPE_A, [&]() {
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, b_type, ctx, "fmod.Tensor_out", CTYPE_B, [&]() {
+              ET_SWITCH_REAL_TYPES(
+                  common_type, ctx, "fmod.Tensor_out", CTYPE_IN, [&]() {
+                    ET_SWITCH_REAL_TYPES(
+                        out_type, ctx, "fmod.Tensor_out", CTYPE_OUT, [&]() {
+                          apply_binary_elementwise_fn<
+                              CTYPE_A,
+                              CTYPE_B,
+                              CTYPE_OUT>(
+                              [common_type](
+                                  const CTYPE_A val_a, const CTYPE_B val_b) {
+                                if (isIntegralType(
+                                        common_type, /*includeBool=*/true)) {
+                                  ET_CHECK(val_b != 0);
+                                }
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value = std::fmod(a_casted, b_casted);
 
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
-        });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a,
+                              b,
+                              out);
+                        });
+                  });
+            });
       });
-    });
-  });
 
   return out;
 }
@@ -79,30 +90,36 @@ Tensor& fmod_Scalar_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "fmod", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "fmod", CTYPE_B, [&]() {
-      CTYPE_B val_b = 0;
-      ET_EXTRACT_SCALAR(b, val_b);
-      ET_SWITCH_REAL_TYPES(common_type, ctx, "fmod", CTYPE_IN, [&]() {
-        if (isIntegralType(common_type, /*includeBool=*/true)) {
-          ET_CHECK(val_b != 0);
-        }
-        ET_SWITCH_REAL_TYPES(out_type, ctx, "fmod", CTYPE_OUT, [&]() {
-          apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                CTYPE_IN value = std::fmod(a_casted, b_casted);
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, a_type, ctx, "fmod.Scalar_out", CTYPE_A, [&]() {
+        ET_SWITCH_SCALAR_OBJ_TYPES(
+            b_type, ctx, "fmod.Scalar_out", CTYPE_B, [&]() {
+              CTYPE_B val_b = 0;
+              ET_EXTRACT_SCALAR(b, val_b);
+              ET_SWITCH_REAL_TYPES(
+                  common_type, ctx, "fmod.Scalar_out", CTYPE_IN, [&]() {
+                    if (isIntegralType(common_type, /*includeBool=*/true)) {
+                      ET_CHECK(val_b != 0);
+                    }
+                    ET_SWITCH_REAL_TYPES(
+                        out_type, ctx, "fmod.Scalar_out", CTYPE_OUT, [&]() {
+                          apply_unary_map_fn(
+                              [val_b](const CTYPE_A val_a) {
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value = std::fmod(a_casted, b_casted);
 
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a.const_data_ptr<CTYPE_A>(),
+                              out.mutable_data_ptr<CTYPE_OUT>(),
+                              out.numel());
+                        });
+                  });
+            });
       });
-    });
-  });
 
   return out;
 }

--- a/kernels/portable/cpu/op_full.cpp
+++ b/kernels/portable/cpu/op_full.cpp
@@ -29,11 +29,11 @@ Tensor& full_out(
   Error err = resize_tensor(out, sizes);
   ET_CHECK_MSG(err == Error::Ok, "Could not resize out");
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, val_type, ctx, "full", CTYPE_VAL, [&] {
+  ET_SWITCH_REAL_TYPES_AND(Bool, val_type, ctx, "full.out", CTYPE_VAL, [&] {
     CTYPE_VAL val;
     ET_EXTRACT_SCALAR(fill_value, val);
 
-    ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "full", CTYPE_OUT, [&] {
+    ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "full.out", CTYPE_OUT, [&] {
       CTYPE_OUT val_casted = static_cast<CTYPE_OUT>(val);
       auto data_out = out.mutable_data_ptr<CTYPE_OUT>();
       for (size_t i = 0; i < out.numel(); ++i) {

--- a/kernels/portable/cpu/op_full_like.cpp
+++ b/kernels/portable/cpu/op_full_like.cpp
@@ -37,18 +37,20 @@ Tensor& full_like_out(
   ScalarType val_type = utils::get_scalar_dtype(fill_value);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, val_type, ctx, "full_like", CTYPE_VAL, [&] {
-    CTYPE_VAL val;
-    ET_EXTRACT_SCALAR(fill_value, val);
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, val_type, ctx, "full_like.out", CTYPE_VAL, [&] {
+        CTYPE_VAL val;
+        ET_EXTRACT_SCALAR(fill_value, val);
 
-    ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "full_like", CTYPE_OUT, [&] {
-      CTYPE_OUT val_casted = static_cast<CTYPE_OUT>(val);
-      auto data_out = out.mutable_data_ptr<CTYPE_OUT>();
-      for (size_t i = 0; i < out.numel(); ++i) {
-        data_out[i] = val_casted;
-      }
-    });
-  });
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, out_type, ctx, "full_like.out", CTYPE_OUT, [&] {
+              CTYPE_OUT val_casted = static_cast<CTYPE_OUT>(val);
+              auto data_out = out.mutable_data_ptr<CTYPE_OUT>();
+              for (size_t i = 0; i < out.numel(); ++i) {
+                data_out[i] = val_casted;
+              }
+            });
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_ge.cpp
+++ b/kernels/portable/cpu/op_ge.cpp
@@ -34,23 +34,26 @@ Tensor& ge_tensor_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "ge", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "ge", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "ge", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "ge", CTYPE_OUT, [&]() {
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted >= b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "ge.Tensor_out", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(
+        Bool, b_type, ctx, "ge.Tensor_out", CTYPE_B, [&]() {
+          ET_SWITCH_REAL_TYPES_AND(
+              Bool, common_type, ctx, "ge.Tensor_out", CTYPE_IN, [&]() {
+                ET_SWITCH_REAL_TYPES_AND(
+                    Bool, out_type, ctx, "ge.Tensor_out", CTYPE_OUT, [&]() {
+                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
+                          [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                            bool value = a_casted >= b_casted;
+                            return static_cast<CTYPE_OUT>(value);
+                          },
+                          a,
+                          b,
+                          out);
+                    });
+              });
         });
-      });
-    });
   });
 
   return out;
@@ -72,24 +75,26 @@ Tensor& ge_scalar_out(
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "ge", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "ge", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "ge", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "ge", CTYPE_OUT, [&]() {
-          CTYPE_B val_b = 0;
-          ET_EXTRACT_SCALAR(b, val_b);
-          apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted >= b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "ge.Scalar_out", CTYPE_A, [&]() {
+    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "ge.Scalar_out", CTYPE_B, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, common_type, ctx, "ge.Scalar_out", CTYPE_IN, [&]() {
+            ET_SWITCH_REAL_TYPES_AND(
+                Bool, out_type, ctx, "ge.Scalar_out", CTYPE_OUT, [&]() {
+                  CTYPE_B val_b = 0;
+                  ET_EXTRACT_SCALAR(b, val_b);
+                  apply_unary_map_fn(
+                      [val_b](const CTYPE_A val_a) {
+                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                        bool value = a_casted >= b_casted;
+                        return static_cast<CTYPE_OUT>(value);
+                      },
+                      a.const_data_ptr<CTYPE_A>(),
+                      out.mutable_data_ptr<CTYPE_OUT>(),
+                      out.numel());
+                });
+          });
     });
   });
 

--- a/kernels/portable/cpu/op_gelu.cpp
+++ b/kernels/portable/cpu/op_gelu.cpp
@@ -34,7 +34,7 @@ Tensor& gelu_out(
   ET_KERNEL_CHECK(
       ctx, resize_tensor(out, in.sizes()) == Error::Ok, InvalidArgument, out);
 
-  ET_SWITCH_FLOAT_TYPES(in.scalar_type(), ctx, "gelu", CTYPE, [&]() {
+  ET_SWITCH_FLOAT_TYPES(in.scalar_type(), ctx, "gelu.out", CTYPE, [&]() {
     if (approximate == "tanh") {
       apply_unary_map_fn(
           [](const CTYPE x) {

--- a/kernels/portable/cpu/op_gt.cpp
+++ b/kernels/portable/cpu/op_gt.cpp
@@ -34,23 +34,26 @@ Tensor& gt_tensor_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "gt", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "gt", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "gt", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "gt", CTYPE_OUT, [&]() {
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted > b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "gt.Tensor_out", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(
+        Bool, b_type, ctx, "gt.Tensor_out", CTYPE_B, [&]() {
+          ET_SWITCH_REAL_TYPES_AND(
+              Bool, common_type, ctx, "gt.Tensor_out", CTYPE_IN, [&]() {
+                ET_SWITCH_REAL_TYPES_AND(
+                    Bool, out_type, ctx, "gt.Tensor_out", CTYPE_OUT, [&]() {
+                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
+                          [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                            bool value = a_casted > b_casted;
+                            return static_cast<CTYPE_OUT>(value);
+                          },
+                          a,
+                          b,
+                          out);
+                    });
+              });
         });
-      });
-    });
   });
 
   return out;
@@ -72,24 +75,26 @@ Tensor& gt_scalar_out(
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "gt", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "gt", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "gt", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "gt", CTYPE_OUT, [&]() {
-          CTYPE_B val_b = 0;
-          ET_EXTRACT_SCALAR(b, val_b);
-          apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted > b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "gt.Scalar_out", CTYPE_A, [&]() {
+    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "gt.Scalar_out", CTYPE_B, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, common_type, ctx, "gt.Scalar_out", CTYPE_IN, [&]() {
+            ET_SWITCH_REAL_TYPES_AND(
+                Bool, out_type, ctx, "gt.Scalar_out", CTYPE_OUT, [&]() {
+                  CTYPE_B val_b = 0;
+                  ET_EXTRACT_SCALAR(b, val_b);
+                  apply_unary_map_fn(
+                      [val_b](const CTYPE_A val_a) {
+                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                        bool value = a_casted > b_casted;
+                        return static_cast<CTYPE_OUT>(value);
+                      },
+                      a.const_data_ptr<CTYPE_A>(),
+                      out.mutable_data_ptr<CTYPE_OUT>(),
+                      out.numel());
+                });
+          });
     });
   });
 

--- a/kernels/portable/cpu/op_hardtanh.cpp
+++ b/kernels/portable/cpu/op_hardtanh.cpp
@@ -87,16 +87,16 @@ Tensor& hardtanh_out(
 
   ET_CHECK(in_type == out_type);
 
-  ET_SWITCH_REAL_TYPES(in_type, ctx, "hardtanh", CTYPE, [&]() {
+  ET_SWITCH_REAL_TYPES(in_type, ctx, "hardtanh.out", CTYPE, [&]() {
     CTYPE min_casted;
-    ET_SWITCH_SCALAR_OBJ_TYPES(min_type, ctx, "hardtanh", CTYPE_MIN, [&]() {
+    ET_SWITCH_SCALAR_OBJ_TYPES(min_type, ctx, "hardtanh.out", CTYPE_MIN, [&]() {
       CTYPE_MIN min_val;
       ET_EXTRACT_SCALAR(min, min_val);
       min_casted = static_cast<CTYPE>(min_val);
     });
 
     CTYPE max_casted;
-    ET_SWITCH_SCALAR_OBJ_TYPES(max_type, ctx, "hardtanh", CTYPE_MAX, [&]() {
+    ET_SWITCH_SCALAR_OBJ_TYPES(max_type, ctx, "hardtanh.out", CTYPE_MAX, [&]() {
       CTYPE_MAX max_val;
       ET_EXTRACT_SCALAR(max, max_val);
       max_casted = static_cast<CTYPE>(max_val);

--- a/kernels/portable/cpu/op_index.cpp
+++ b/kernels/portable/cpu/op_index.cpp
@@ -40,11 +40,12 @@ Tensor& index_Tensor_out(
   if (block_count == 0) {
     ET_KERNEL_CHECK(
         ctx, resize_tensor(out, in.sizes()) == Error::Ok, InvalidArgument, out);
-    ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE, [&]() {
-      const CTYPE* const in_data = in.const_data_ptr<CTYPE>();
-      CTYPE* const out_data = out.mutable_data_ptr<CTYPE>();
-      memcpy(out_data, in_data, in.nbytes());
-    });
+    ET_SWITCH_REAL_TYPES_AND(
+        Bool, in_type, ctx, "index.Tensor_out", CTYPE, [&]() {
+          const CTYPE* const in_data = in.const_data_ptr<CTYPE>();
+          CTYPE* const out_data = out.mutable_data_ptr<CTYPE>();
+          memcpy(out_data, in_data, in.nbytes());
+        });
     return out;
   }
 
@@ -84,19 +85,20 @@ Tensor& index_Tensor_out(
   compute_dim_map(in, indices, dim_map, block_count == 1);
   compute_index_map(in, indices, ix_map);
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE, [&]() {
-    const CTYPE* const in_data = in.const_data_ptr<CTYPE>();
-    CTYPE* const out_data = out.mutable_data_ptr<CTYPE>();
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in_type, ctx, "index.Tensor_out", CTYPE, [&]() {
+        const CTYPE* const in_data = in.const_data_ptr<CTYPE>();
+        CTYPE* const out_data = out.mutable_data_ptr<CTYPE>();
 
-    for (auto out_ix = 0; out_ix < out.numel(); out_ix++) {
-      size_t in_ix = 0;
-      bool success = true;
-      std::tie(in_ix, success) =
-          get_in_ix(in, indices, out, out_ix, start, xdim, dim_map, ix_map);
-      ET_KERNEL_CHECK(ctx, success, InvalidArgument, out);
-      out_data[out_ix] = in_data[in_ix];
-    }
-  });
+        for (auto out_ix = 0; out_ix < out.numel(); out_ix++) {
+          size_t in_ix = 0;
+          bool success = true;
+          std::tie(in_ix, success) =
+              get_in_ix(in, indices, out, out_ix, start, xdim, dim_map, ix_map);
+          ET_KERNEL_CHECK(ctx, success, InvalidArgument, out);
+          out_data[out_ix] = in_data[in_ix];
+        }
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_index_put.cpp
+++ b/kernels/portable/cpu/op_index_put.cpp
@@ -48,7 +48,7 @@ Tensor& index_put_out(
     ET_KERNEL_CHECK(
         ctx, tensor_is_broadcastable_to(values, out), InvalidArgument, out);
 
-    ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "index_put.out", CTYPE, [&]() {
       apply_binary_elementwise_fn<CTYPE, CTYPE, CTYPE>(
           [accumulate](const CTYPE val_in, const CTYPE val) {
             return accumulate ? val_in + val : val;
@@ -115,7 +115,7 @@ Tensor& index_put_out(
     x_numel *= x_sizes[i];
   }
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE, [&]() {
+  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "index_put.out", CTYPE, [&]() {
     const CTYPE* const values_data = values.const_data_ptr<CTYPE>();
     CTYPE* const out_data = out.mutable_data_ptr<CTYPE>();
 

--- a/kernels/portable/cpu/op_index_select.cpp
+++ b/kernels/portable/cpu/op_index_select.cpp
@@ -65,18 +65,19 @@ Tensor& index_select_out(
 
   ScalarType ix_type = index.scalar_type();
 
-  ET_SWITCH_TWO_TYPES(Long, Int, ix_type, ctx, __func__, CTYPE, [&]() {
-    const CTYPE* const index_arr = index.mutable_data_ptr<CTYPE>();
-    for (int i = 0; i < leading_dims; i++) {
-      const char* src = input_data + i * in_dim_length * length_per_step;
-      char* dest = out_data + i * out_dim_length * length_per_step;
-      for (auto j = 0; j < out_dim_length; j++) {
-        const char* copy_src = src + index_arr[j] * length_per_step;
-        memcpy(dest, copy_src, length_per_step);
-        dest += length_per_step;
-      }
-    }
-  });
+  ET_SWITCH_TWO_TYPES(
+      Long, Int, ix_type, ctx, "index_select.out", CTYPE, [&]() {
+        const CTYPE* const index_arr = index.mutable_data_ptr<CTYPE>();
+        for (int i = 0; i < leading_dims; i++) {
+          const char* src = input_data + i * in_dim_length * length_per_step;
+          char* dest = out_data + i * out_dim_length * length_per_step;
+          for (auto j = 0; j < out_dim_length; j++) {
+            const char* copy_src = src + index_arr[j] * length_per_step;
+            memcpy(dest, copy_src, length_per_step);
+            dest += length_per_step;
+          }
+        }
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_le.cpp
+++ b/kernels/portable/cpu/op_le.cpp
@@ -34,23 +34,26 @@ Tensor& le_tensor_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "le", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "le", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "le", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "le", CTYPE_OUT, [&]() {
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted <= b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "le.Tensor_out", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(
+        Bool, b_type, ctx, "le.Tensor_out", CTYPE_B, [&]() {
+          ET_SWITCH_REAL_TYPES_AND(
+              Bool, common_type, ctx, "le.Tensor_out", CTYPE_IN, [&]() {
+                ET_SWITCH_REAL_TYPES_AND(
+                    Bool, out_type, ctx, "le.Tensor_out", CTYPE_OUT, [&]() {
+                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
+                          [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                            bool value = a_casted <= b_casted;
+                            return static_cast<CTYPE_OUT>(value);
+                          },
+                          a,
+                          b,
+                          out);
+                    });
+              });
         });
-      });
-    });
   });
 
   return out;
@@ -72,24 +75,26 @@ Tensor& le_scalar_out(
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "le", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "le", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "le", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "le", CTYPE_OUT, [&]() {
-          CTYPE_B val_b = 0;
-          ET_EXTRACT_SCALAR(b, val_b);
-          apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted <= b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "le.Scalar_out", CTYPE_A, [&]() {
+    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "le.Scalar_out", CTYPE_B, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, common_type, ctx, "le.Scalar_out", CTYPE_IN, [&]() {
+            ET_SWITCH_REAL_TYPES_AND(
+                Bool, out_type, ctx, "le.Scalar_out", CTYPE_OUT, [&]() {
+                  CTYPE_B val_b = 0;
+                  ET_EXTRACT_SCALAR(b, val_b);
+                  apply_unary_map_fn(
+                      [val_b](const CTYPE_A val_a) {
+                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                        bool value = a_casted <= b_casted;
+                        return static_cast<CTYPE_OUT>(value);
+                      },
+                      a.const_data_ptr<CTYPE_A>(),
+                      out.mutable_data_ptr<CTYPE_OUT>(),
+                      out.numel());
+                });
+          });
     });
   });
 

--- a/kernels/portable/cpu/op_leaky_relu.cpp
+++ b/kernels/portable/cpu/op_leaky_relu.cpp
@@ -36,13 +36,14 @@ Tensor& leaky_relu_out(
 
   ET_CHECK(in_type == out_type);
 
-  ET_SWITCH_FLOAT_TYPES(in_type, ctx, "leaky_relu", CTYPE, [&]() {
+  ET_SWITCH_FLOAT_TYPES(in_type, ctx, "leaky_relu.out", CTYPE, [&]() {
     CTYPE negative_slope_casted;
-    ET_SWITCH_SCALAR_OBJ_TYPES(sc_type, ctx, "leaky_relu", CTYPE_MIN, [&]() {
-      CTYPE_MIN negative_slope_val;
-      ET_EXTRACT_SCALAR(negative_slope, negative_slope_val);
-      negative_slope_casted = static_cast<CTYPE>(negative_slope_val);
-    });
+    ET_SWITCH_SCALAR_OBJ_TYPES(
+        sc_type, ctx, "leaky_relu.out", CTYPE_MIN, [&]() {
+          CTYPE_MIN negative_slope_val;
+          ET_EXTRACT_SCALAR(negative_slope, negative_slope_val);
+          negative_slope_casted = static_cast<CTYPE>(negative_slope_val);
+        });
 
     apply_unary_map_fn(
         [negative_slope_casted](const CTYPE val_in) {

--- a/kernels/portable/cpu/op_logical_not.cpp
+++ b/kernels/portable/cpu/op_logical_not.cpp
@@ -25,9 +25,9 @@ Tensor& logical_not_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   ET_CHECK_SAME_SHAPE2(in, out);
 
   ET_SWITCH_REAL_TYPES_AND(
-      Bool, in.scalar_type(), ctx, "logical_not", CTYPE_IN, [&] {
+      Bool, in.scalar_type(), ctx, "logical_not.out", CTYPE_IN, [&] {
         ET_SWITCH_REAL_TYPES_AND(
-            Bool, out.scalar_type(), ctx, "logical_not", CTYPE_OUT, [&] {
+            Bool, out.scalar_type(), ctx, "logical_not.out", CTYPE_OUT, [&] {
               apply_unary_map_fn(
                   [](const CTYPE_IN val_in) {
                     return static_cast<CTYPE_OUT>(!static_cast<bool>(val_in));

--- a/kernels/portable/cpu/op_logit.cpp
+++ b/kernels/portable/cpu/op_logit.cpp
@@ -30,8 +30,8 @@ Tensor& logit_out(
 
   ScalarType in_type = in.scalar_type();
   ScalarType out_type = out.scalar_type();
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE_IN, [&] {
-    ET_SWITCH_FLOAT_TYPES(out_type, ctx, __func__, CTYPE_OUT, [&] {
+  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "logit.out", CTYPE_IN, [&] {
+    ET_SWITCH_FLOAT_TYPES(out_type, ctx, "logit.out", CTYPE_OUT, [&] {
       apply_unary_map_fn(
           [eps](const CTYPE_IN val_in) {
             CTYPE_OUT xi = static_cast<CTYPE_OUT>(val_in);

--- a/kernels/portable/cpu/op_lt.cpp
+++ b/kernels/portable/cpu/op_lt.cpp
@@ -34,23 +34,26 @@ Tensor& lt_tensor_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "lt", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "lt", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "lt", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "lt", CTYPE_OUT, [&]() {
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted < b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "lt.Tensor_out", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(
+        Bool, b_type, ctx, "lt.Tensor_out", CTYPE_B, [&]() {
+          ET_SWITCH_REAL_TYPES_AND(
+              Bool, common_type, ctx, "lt.Tensor_out", CTYPE_IN, [&]() {
+                ET_SWITCH_REAL_TYPES_AND(
+                    Bool, out_type, ctx, "lt.Tensor_out", CTYPE_OUT, [&]() {
+                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
+                          [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                            bool value = a_casted < b_casted;
+                            return static_cast<CTYPE_OUT>(value);
+                          },
+                          a,
+                          b,
+                          out);
+                    });
+              });
         });
-      });
-    });
   });
 
   return out;
@@ -72,24 +75,26 @@ Tensor& lt_scalar_out(
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "lt", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "lt", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "lt", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "lt", CTYPE_OUT, [&]() {
-          CTYPE_B val_b = 0;
-          ET_EXTRACT_SCALAR(b, val_b);
-          apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted < b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "lt.Scalar_out", CTYPE_A, [&]() {
+    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "lt.Scalar_out", CTYPE_B, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, common_type, ctx, "lt.Scalar_out", CTYPE_IN, [&]() {
+            ET_SWITCH_REAL_TYPES_AND(
+                Bool, out_type, ctx, "lt.Scalar_out", CTYPE_OUT, [&]() {
+                  CTYPE_B val_b = 0;
+                  ET_EXTRACT_SCALAR(b, val_b);
+                  apply_unary_map_fn(
+                      [val_b](const CTYPE_A val_a) {
+                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                        bool value = a_casted < b_casted;
+                        return static_cast<CTYPE_OUT>(value);
+                      },
+                      a.const_data_ptr<CTYPE_A>(),
+                      out.mutable_data_ptr<CTYPE_OUT>(),
+                      out.numel());
+                });
+          });
     });
   });
 

--- a/kernels/portable/cpu/op_masked_fill.cpp
+++ b/kernels/portable/cpu/op_masked_fill.cpp
@@ -36,21 +36,23 @@ Tensor& masked_fill_scalar_out(
 
   resize_to_broadcast_target_size(in, mask, out);
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, val_type, ctx, __func__, CTYPE_VAL, [&]() {
-      CTYPE_VAL value_v;
-      ET_EXTRACT_SCALAR(value, value_v);
-      CTYPE val = static_cast<CTYPE>(value_v);
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in_type, ctx, "masked_fill.Scalar_out", CTYPE, [&]() {
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, val_type, ctx, "masked_fill.Scalar_out", CTYPE_VAL, [&]() {
+              CTYPE_VAL value_v;
+              ET_EXTRACT_SCALAR(value, value_v);
+              CTYPE val = static_cast<CTYPE>(value_v);
 
-      apply_binary_elementwise_fn<CTYPE, bool, CTYPE>(
-          [val](const CTYPE val_in, const bool val_mask) {
-            return val_mask ? val : val_in;
-          },
-          in,
-          mask,
-          out);
-    });
-  });
+              apply_binary_elementwise_fn<CTYPE, bool, CTYPE>(
+                  [val](const CTYPE val_in, const bool val_mask) {
+                    return val_mask ? val : val_in;
+                  },
+                  in,
+                  mask,
+                  out);
+            });
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_max_pool2d_with_indices.cpp
+++ b/kernels/portable/cpu/op_max_pool2d_with_indices.cpp
@@ -70,28 +70,29 @@ std::tuple<Tensor&, Tensor&> max_pool2d_with_indices_out(
       ret_val);
 
   ScalarType in_type = in.scalar_type();
-  ET_SWITCH_REAL_TYPES(in_type, ctx, __func__, CTYPE, [&]() {
-    apply_kernel_2d_reduce_then_map_fn<CTYPE>(
-        [](const CTYPE in_val,
-           const int64_t in_idx,
-           const CTYPE accum,
-           const int64_t accum_idx) {
-          if (in_val > accum) {
-            return std::tuple<CTYPE, int64_t>(in_val, in_idx);
-          }
-          return std::tuple<CTYPE, int64_t>(accum, accum_idx);
-        },
-        // Max pooling does not need to post-process the accumulated output
-        [](const int64_t count, const CTYPE accum) { return accum; },
-        /*include_pad=*/false,
-        in,
-        kernel_size,
-        stride,
-        padding,
-        dilation,
-        out,
-        {indices});
-  });
+  ET_SWITCH_REAL_TYPES(
+      in_type, ctx, "max_pool2d_with_indices.out", CTYPE, [&]() {
+        apply_kernel_2d_reduce_then_map_fn<CTYPE>(
+            [](const CTYPE in_val,
+               const int64_t in_idx,
+               const CTYPE accum,
+               const int64_t accum_idx) {
+              if (in_val > accum) {
+                return std::tuple<CTYPE, int64_t>(in_val, in_idx);
+              }
+              return std::tuple<CTYPE, int64_t>(accum, accum_idx);
+            },
+            // Max pooling does not need to post-process the accumulated output
+            [](const int64_t count, const CTYPE accum) { return accum; },
+            /*include_pad=*/false,
+            in,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            out,
+            {indices});
+      });
 
   return ret_val;
 }

--- a/kernels/portable/cpu/op_mean.cpp
+++ b/kernels/portable/cpu/op_mean.cpp
@@ -67,24 +67,26 @@ Tensor& mean_dim_out(
   Error e = resize_reduction_out(in, dim_list, keepdim, out);
   ET_CHECK_MSG(e == Error::Ok, "Failed to resize out tensor in mean_dim_out");
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in.scalar_type(), ctx, "mean", CTYPE_IN, [&] {
-    ET_SWITCH_FLOAT_TYPES(out.scalar_type(), ctx, "mean", CTYPE_OUT, [&] {
-      CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
-      const size_t num = get_reduced_dim_product(in, dim_list);
-      for (size_t out_ix = 0; out_ix < out.numel(); ++out_ix) {
-        CTYPE_OUT sum = 0;
-        if (in.numel() > 0) {
-          sum = map_reduce_over_dim_list<CTYPE_IN, CTYPE_OUT>(
-              [](CTYPE_IN v) { return static_cast<CTYPE_OUT>(v); },
-              [](CTYPE_OUT outv, CTYPE_OUT acc) { return acc + outv; },
-              in,
-              dim_list,
-              out_ix);
-        }
-        out_data[out_ix] = sum / num;
-      }
-    });
-  });
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in.scalar_type(), ctx, "mean.out", CTYPE_IN, [&] {
+        ET_SWITCH_FLOAT_TYPES(
+            out.scalar_type(), ctx, "mean.out", CTYPE_OUT, [&] {
+              CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
+              const size_t num = get_reduced_dim_product(in, dim_list);
+              for (size_t out_ix = 0; out_ix < out.numel(); ++out_ix) {
+                CTYPE_OUT sum = 0;
+                if (in.numel() > 0) {
+                  sum = map_reduce_over_dim_list<CTYPE_IN, CTYPE_OUT>(
+                      [](CTYPE_IN v) { return static_cast<CTYPE_OUT>(v); },
+                      [](CTYPE_OUT outv, CTYPE_OUT acc) { return acc + outv; },
+                      in,
+                      dim_list,
+                      out_ix);
+                }
+                out_data[out_ix] = sum / num;
+              }
+            });
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_min.cpp
+++ b/kernels/portable/cpu/op_min.cpp
@@ -75,26 +75,28 @@ std::tuple<Tensor&, Tensor&> min_out(
 
   dim = dim < 0 ? dim + in.dim() : dim;
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in.scalar_type(), ctx, "min", CTYPE, [&]() {
-    CTYPE* min_data = min.mutable_data_ptr<CTYPE>();
-    long* min_indices_data = min_indices.mutable_data_ptr<long>();
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in.scalar_type(), ctx, "min.dim_min", CTYPE, [&]() {
+        CTYPE* min_data = min.mutable_data_ptr<CTYPE>();
+        long* min_indices_data = min_indices.mutable_data_ptr<long>();
 
-    for (size_t out_ix = 0; out_ix < min.numel(); ++out_ix) {
-      std::tuple<CTYPE, long> acc = reduce_over_dim<CTYPE>(
-          [](CTYPE v, long ix, CTYPE acc_val, long acc_ix) {
-            if (!std::isnan(acc_val) && (std::isnan(v) || v < acc_val)) {
-              acc_val = v;
-              acc_ix = ix;
-            }
-            return std::tuple<CTYPE, long>{acc_val, acc_ix};
-          },
-          in,
-          dim,
-          out_ix);
-      min_data[out_ix] = std::get<0>(acc);
-      min_indices_data[out_ix] = std::get<1>(acc);
-    }
-  });
+        for (size_t out_ix = 0; out_ix < min.numel(); ++out_ix) {
+          std::tuple<CTYPE, long> acc = reduce_over_dim<CTYPE>(
+              [](CTYPE v, long ix, CTYPE acc_val, long acc_ix) {
+                if (!std::isnan(acc_val) && (std::isnan(v) || v < acc_val)) {
+                  acc_val = v;
+                  acc_ix = ix;
+                }
+                return std::tuple<CTYPE, long>{acc_val, acc_ix};
+              },
+              in,
+              dim,
+              out_ix);
+          min_data[out_ix] = std::get<0>(acc);
+          min_indices_data[out_ix] = std::get<1>(acc);
+        }
+      });
+
   return {min, min_indices};
 }
 

--- a/kernels/portable/cpu/op_minimum.cpp
+++ b/kernels/portable/cpu/op_minimum.cpp
@@ -38,12 +38,12 @@ Tensor& minimum_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "minimum", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "minimum", CTYPE_B, [&]() {
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "minimum.out", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "minimum.out", CTYPE_B, [&]() {
       ET_SWITCH_REAL_TYPES_AND(
-          Bool, common_type, ctx, "minimum", CTYPE_IN, [&]() {
+          Bool, common_type, ctx, "minimum.out", CTYPE_IN, [&]() {
             ET_SWITCH_REAL_TYPES_AND(
-                Bool, out_type, ctx, "minimum", CTYPE_OUT, [&]() {
+                Bool, out_type, ctx, "minimum.out", CTYPE_OUT, [&]() {
                   apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
                       [](const CTYPE_A val_a, const CTYPE_B val_b) {
                         CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);

--- a/kernels/portable/cpu/op_mm.cpp
+++ b/kernels/portable/cpu/op_mm.cpp
@@ -29,7 +29,7 @@ mm_out(RuntimeContext& ctx, const Tensor& in, const Tensor& mat2, Tensor& out) {
       InvalidArgument,
       out);
 
-  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "mm", CTYPE, [&]() {
+  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "mm.out", CTYPE, [&]() {
     size_t m = in.size(0);
     size_t n = in.size(1);
     size_t p = mat2.size(1);

--- a/kernels/portable/cpu/op_mul.cpp
+++ b/kernels/portable/cpu/op_mul.cpp
@@ -29,23 +29,25 @@ mul_out(RuntimeContext& ctx, const Tensor& a, const Tensor& b, Tensor& out) {
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "mul", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "mul", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "mul", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "mul", CTYPE_OUT, [&]() {
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                CTYPE_IN value = a_casted * b_casted;
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "mul.out", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "mul.out", CTYPE_B, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, common_type, ctx, "mul.out", CTYPE_IN, [&]() {
+            ET_SWITCH_REAL_TYPES_AND(
+                Bool, out_type, ctx, "mul.out", CTYPE_OUT, [&]() {
+                  apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
+                      [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                        CTYPE_IN value = a_casted * b_casted;
 
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
-        });
-      });
+                        return static_cast<CTYPE_OUT>(value);
+                      },
+                      a,
+                      b,
+                      out);
+                });
+          });
     });
   });
 
@@ -70,25 +72,27 @@ Tensor& mul_scalar_out(
 
   ET_CHECK(common_type == out_type);
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "mul", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "mul", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "mul", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "mul", CTYPE_OUT, [&]() {
-          CTYPE_B b_val;
-          ET_EXTRACT_SCALAR(b, b_val);
-          CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "mul.Scalar_out", CTYPE_A, [&]() {
+    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "mul.Scalar_out", CTYPE_B, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, common_type, ctx, "mul.Scalar_out", CTYPE_IN, [&]() {
+            ET_SWITCH_REAL_TYPES_AND(
+                Bool, out_type, ctx, "mul.Scalar_out", CTYPE_OUT, [&]() {
+                  CTYPE_B b_val;
+                  ET_EXTRACT_SCALAR(b, b_val);
+                  CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
 
-          apply_unary_map_fn(
-              [b_casted](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN value = a_casted * b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
+                  apply_unary_map_fn(
+                      [b_casted](const CTYPE_A val_a) {
+                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                        CTYPE_IN value = a_casted * b_casted;
+                        return static_cast<CTYPE_OUT>(value);
+                      },
+                      a.const_data_ptr<CTYPE_A>(),
+                      out.mutable_data_ptr<CTYPE_OUT>(),
+                      out.numel());
+                });
+          });
     });
   });
 

--- a/kernels/portable/cpu/op_native_batch_norm.cpp
+++ b/kernels/portable/cpu/op_native_batch_norm.cpp
@@ -76,7 +76,11 @@ std::tuple<Tensor&, Tensor&, Tensor&> _native_batch_norm_legit_no_training_out(
   size_t inner = getTrailingDims(in, C_dim);
 
   ET_SWITCH_FLOAT_TYPES(
-      in.scalar_type(), ctx, "native_batch_norm_legit_no_training", CTYPE, [&] {
+      in.scalar_type(),
+      ctx,
+      "native_batch_norm_legit_no_training.out",
+      CTYPE,
+      [&] {
         const CTYPE* in_data = in.const_data_ptr<CTYPE>();
         CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
 

--- a/kernels/portable/cpu/op_native_layer_norm.cpp
+++ b/kernels/portable/cpu/op_native_layer_norm.cpp
@@ -140,10 +140,18 @@ std::tuple<Tensor&, Tensor&, Tensor&> native_layer_norm_out(
       InvalidArgument,
       ret_val);
 
-  ET_SWITCH_FLOAT_TYPES(input.scalar_type(), ctx, __func__, CTYPE, [&]() {
-    layer_norm<CTYPE>(
-        input, normalized_shape, weight, bias, eps, out, mean_out, rstd_out);
-  });
+  ET_SWITCH_FLOAT_TYPES(
+      input.scalar_type(), ctx, "native_layer_norm.out", CTYPE, [&]() {
+        layer_norm<CTYPE>(
+            input,
+            normalized_shape,
+            weight,
+            bias,
+            eps,
+            out,
+            mean_out,
+            rstd_out);
+      });
 
   return ret_val;
 }

--- a/kernels/portable/cpu/op_ne.cpp
+++ b/kernels/portable/cpu/op_ne.cpp
@@ -34,23 +34,26 @@ Tensor& ne_tensor_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "ne", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "ne", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "ne", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "ne", CTYPE_OUT, [&]() {
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted != b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "ne.Tensor_out", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(
+        Bool, b_type, ctx, "ne.Tensor_out", CTYPE_B, [&]() {
+          ET_SWITCH_REAL_TYPES_AND(
+              Bool, common_type, ctx, "ne.Tensor_out", CTYPE_IN, [&]() {
+                ET_SWITCH_REAL_TYPES_AND(
+                    Bool, out_type, ctx, "ne.Tensor_out", CTYPE_OUT, [&]() {
+                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
+                          [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                            bool value = a_casted != b_casted;
+                            return static_cast<CTYPE_OUT>(value);
+                          },
+                          a,
+                          b,
+                          out);
+                    });
+              });
         });
-      });
-    });
   });
 
   return out;
@@ -72,24 +75,26 @@ Tensor& ne_scalar_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "ne", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "ne", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, "ne", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "ne", CTYPE_OUT, [&]() {
-          CTYPE_B val_b = 0;
-          ET_EXTRACT_SCALAR(b, val_b);
-          apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted != b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "ne.Scalar_out", CTYPE_A, [&]() {
+    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "ne.Scalar_out", CTYPE_B, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, common_type, ctx, "ne.Scalar_out", CTYPE_IN, [&]() {
+            ET_SWITCH_REAL_TYPES_AND(
+                Bool, out_type, ctx, "ne.Scalar_out", CTYPE_OUT, [&]() {
+                  CTYPE_B val_b = 0;
+                  ET_EXTRACT_SCALAR(b, val_b);
+                  apply_unary_map_fn(
+                      [val_b](const CTYPE_A val_a) {
+                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                        bool value = a_casted != b_casted;
+                        return static_cast<CTYPE_OUT>(value);
+                      },
+                      a.const_data_ptr<CTYPE_A>(),
+                      out.mutable_data_ptr<CTYPE_OUT>(),
+                      out.numel());
+                });
+          });
     });
   });
 

--- a/kernels/portable/cpu/op_neg.cpp
+++ b/kernels/portable/cpu/op_neg.cpp
@@ -24,7 +24,7 @@ Tensor& neg_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
   ET_CHECK_SAME_SHAPE_AND_DTYPE2(in, out);
 
-  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "neg", CTYPE, [&] {
+  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "neg.out", CTYPE, [&] {
     apply_unary_map_fn(
         [](const CTYPE val_in) { return static_cast<CTYPE>(-val_in); },
         in.const_data_ptr<CTYPE>(),

--- a/kernels/portable/cpu/op_nonzero.cpp
+++ b/kernels/portable/cpu/op_nonzero.cpp
@@ -96,9 +96,10 @@ Tensor& nonzero_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
 
   check_preconditions(in, out);
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in.scalar_type(), ctx, "nonzero", CTYPE, [&] {
-    nonzero<CTYPE>(in, out);
-  });
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in.scalar_type(), ctx, "nonzero.out", CTYPE, [&] {
+        nonzero<CTYPE>(in, out);
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_permute_copy.cpp
+++ b/kernels/portable/cpu/op_permute_copy.cpp
@@ -58,7 +58,7 @@ Tensor& permute_copy_out(
 
   const auto in_type = out.scalar_type();
   // in and out must be the same dtype
-  ET_SWITCH_ALL_TYPES(in_type, ctx, "permute_copy", CTYPE, [&] {
+  ET_SWITCH_ALL_TYPES(in_type, ctx, "permute_copy.out", CTYPE, [&] {
     const CTYPE* const in_data = in.const_data_ptr<CTYPE>();
     CTYPE* const out_data = out.mutable_data_ptr<CTYPE>();
 

--- a/kernels/portable/cpu/op_pixel_shuffle.cpp
+++ b/kernels/portable/cpu/op_pixel_shuffle.cpp
@@ -51,7 +51,7 @@ Tensor& pixel_shuffle_out(
   ET_SWITCH_ALL_TYPES(
       in_type,
       ctx,
-      __func__,
+      "pixel_shuffle.out",
       CTYPE,
       [leading_dims, channels, height, width, upscale_factor, &in, &out] {
         const CTYPE* const in_data = in.const_data_ptr<CTYPE>();

--- a/kernels/portable/cpu/op_pow.cpp
+++ b/kernels/portable/cpu/op_pow.cpp
@@ -36,25 +36,38 @@ Tensor& pow_Tensor_Tensor_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "pow", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "pow", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES(common_type, ctx, "pow", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES(out_type, ctx, "pow", CTYPE_OUT, [&]() {
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                CTYPE_IN value = std::pow(a_casted, b_casted);
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, a_type, ctx, "pow.Tensor_Tensor_out", CTYPE_A, [&]() {
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, b_type, ctx, "pow.Tensor_Tensor_out", CTYPE_B, [&]() {
+              ET_SWITCH_REAL_TYPES(
+                  common_type, ctx, "pow.Tensor_Tensor_out", CTYPE_IN, [&]() {
+                    ET_SWITCH_REAL_TYPES(
+                        out_type,
+                        ctx,
+                        "pow.Tensor_Tensor_out",
+                        CTYPE_OUT,
+                        [&]() {
+                          apply_binary_elementwise_fn<
+                              CTYPE_A,
+                              CTYPE_B,
+                              CTYPE_OUT>(
+                              [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value = std::pow(a_casted, b_casted);
 
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
-        });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a,
+                              b,
+                              out);
+                        });
+                  });
+            });
       });
-    });
-  });
 
   return out;
 }
@@ -76,27 +89,37 @@ Tensor& pow_Tensor_Scalar_out(
 
   ET_CHECK(common_type == out_type);
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "pow", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "pow", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES(common_type, ctx, "pow", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES(out_type, ctx, "pow", CTYPE_OUT, [&]() {
-          CTYPE_B val_b = 0;
-          ET_EXTRACT_SCALAR(b, val_b);
-          apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                CTYPE_IN value = std::pow(a_casted, b_casted);
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, a_type, ctx, "pow.Tensor_Scalar_out", CTYPE_A, [&]() {
+        ET_SWITCH_SCALAR_OBJ_TYPES(
+            b_type, ctx, "pow.Tensor_Scalar_out", CTYPE_B, [&]() {
+              ET_SWITCH_REAL_TYPES(
+                  common_type, ctx, "pow.Tensor_Scalar_out", CTYPE_IN, [&]() {
+                    ET_SWITCH_REAL_TYPES(
+                        out_type,
+                        ctx,
+                        "pow.Tensor_Scalar_out",
+                        CTYPE_OUT,
+                        [&]() {
+                          CTYPE_B val_b = 0;
+                          ET_EXTRACT_SCALAR(b, val_b);
+                          apply_unary_map_fn(
+                              [val_b](const CTYPE_A val_a) {
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value = std::pow(a_casted, b_casted);
 
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a.const_data_ptr<CTYPE_A>(),
+                              out.mutable_data_ptr<CTYPE_OUT>(),
+                              out.numel());
+                        });
+                  });
+            });
       });
-    });
-  });
 
   return out;
 }

--- a/kernels/portable/cpu/op_relu.cpp
+++ b/kernels/portable/cpu/op_relu.cpp
@@ -27,7 +27,7 @@ Tensor& relu_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
 
   ET_CHECK_SAME_SHAPE_AND_DTYPE2(in, out);
 
-  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "relu", CTYPE, [&]() {
+  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "relu.out", CTYPE, [&]() {
     apply_unary_map_fn(
         [](const CTYPE val_in) {
           return (std::isnan(val_in) || val_in >= CTYPE(0)) ? val_in : CTYPE(0);

--- a/kernels/portable/cpu/op_remainder.cpp
+++ b/kernels/portable/cpu/op_remainder.cpp
@@ -59,25 +59,39 @@ Tensor& remainder_Tensor_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "remainder", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "remainder", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES(common_type, ctx, "remainder", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES(out_type, ctx, "remainder", CTYPE_OUT, [&]() {
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                CTYPE_IN value = remainder_override(a_casted, b_casted);
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, a_type, ctx, "remainder.Tensor_out", CTYPE_A, [&]() {
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, b_type, ctx, "remainder.Tensor_out", CTYPE_B, [&]() {
+              ET_SWITCH_REAL_TYPES(
+                  common_type, ctx, "remainder.Tensor_out", CTYPE_IN, [&]() {
+                    ET_SWITCH_REAL_TYPES(
+                        out_type,
+                        ctx,
+                        "remainder.Tensor_out",
+                        CTYPE_OUT,
+                        [&]() {
+                          apply_binary_elementwise_fn<
+                              CTYPE_A,
+                              CTYPE_B,
+                              CTYPE_OUT>(
+                              [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value =
+                                    remainder_override(a_casted, b_casted);
 
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
-        });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a,
+                              b,
+                              out);
+                        });
+                  });
+            });
       });
-    });
-  });
 
   return out;
 }
@@ -99,27 +113,38 @@ Tensor& remainder_Scalar_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "remainder", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "remainder", CTYPE_B, [&]() {
-      CTYPE_B val_b = 0;
-      ET_EXTRACT_SCALAR(b, val_b);
-      ET_SWITCH_REAL_TYPES(common_type, ctx, "remainder", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES(out_type, ctx, "remainder", CTYPE_OUT, [&]() {
-          apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                CTYPE_IN value = remainder_override(a_casted, b_casted);
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, a_type, ctx, "remainder.Scalar_out", CTYPE_A, [&]() {
+        ET_SWITCH_SCALAR_OBJ_TYPES(
+            b_type, ctx, "remainder.Scalar_out", CTYPE_B, [&]() {
+              CTYPE_B val_b = 0;
+              ET_EXTRACT_SCALAR(b, val_b);
+              ET_SWITCH_REAL_TYPES(
+                  common_type, ctx, "remainder.Scalar_out", CTYPE_IN, [&]() {
+                    ET_SWITCH_REAL_TYPES(
+                        out_type,
+                        ctx,
+                        "remainder.Scalar_out",
+                        CTYPE_OUT,
+                        [&]() {
+                          apply_unary_map_fn(
+                              [val_b](const CTYPE_A val_a) {
+                                CTYPE_IN a_casted =
+                                    static_cast<CTYPE_IN>(val_a);
+                                CTYPE_IN b_casted =
+                                    static_cast<CTYPE_IN>(val_b);
+                                CTYPE_IN value =
+                                    remainder_override(a_casted, b_casted);
 
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
+                                return static_cast<CTYPE_OUT>(value);
+                              },
+                              a.const_data_ptr<CTYPE_A>(),
+                              out.mutable_data_ptr<CTYPE_OUT>(),
+                              out.numel());
+                        });
+                  });
+            });
       });
-    });
-  });
 
   return out;
 }

--- a/kernels/portable/cpu/op_round.cpp
+++ b/kernels/portable/cpu/op_round.cpp
@@ -40,7 +40,7 @@ Tensor& round_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
 
   auto in_scalar_type = in.scalar_type();
 
-  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "round", CTYPE, [&] {
+  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "round.out", CTYPE, [&] {
     apply_unary_map_fn(
         [in_scalar_type](const CTYPE val_in) {
           if (isIntegralType(in_scalar_type, /*includeBool=*/false)) {

--- a/kernels/portable/cpu/op_rsub.cpp
+++ b/kernels/portable/cpu/op_rsub.cpp
@@ -33,28 +33,31 @@ Tensor& rsub_scalar_out(
 
   ET_CHECK(common_type == out_type);
 
-  ET_SWITCH_REAL_TYPES(a_type, ctx, "rsub", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_REAL_TYPES(b_type, ctx, "rsub", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES(common_type, ctx, "rsub", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES(out_type, ctx, "rsub", CTYPE_OUT, [&]() {
-          CTYPE_B b_val;
-          ET_EXTRACT_SCALAR(b, b_val);
-          CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
-          CTYPE_IN alpha_val;
-          ET_EXTRACT_SCALAR(alpha, alpha_val);
+  ET_SWITCH_REAL_TYPES(a_type, ctx, "rsub.Scalar_out", CTYPE_A, [&]() {
+    ET_SWITCH_SCALAR_OBJ_REAL_TYPES(
+        b_type, ctx, "rsub.Scalar_out", CTYPE_B, [&]() {
+          ET_SWITCH_REAL_TYPES(
+              common_type, ctx, "rsub.Scalar_out", CTYPE_IN, [&]() {
+                ET_SWITCH_REAL_TYPES(
+                    out_type, ctx, "rsub.Scalar_out", CTYPE_OUT, [&]() {
+                      CTYPE_B b_val;
+                      ET_EXTRACT_SCALAR(b, b_val);
+                      CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
+                      CTYPE_IN alpha_val;
+                      ET_EXTRACT_SCALAR(alpha, alpha_val);
 
-          apply_unary_map_fn(
-              [b_casted, alpha_val](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN value = b_casted - alpha_val * a_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
+                      apply_unary_map_fn(
+                          [b_casted, alpha_val](const CTYPE_A val_a) {
+                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                            CTYPE_IN value = b_casted - alpha_val * a_casted;
+                            return static_cast<CTYPE_OUT>(value);
+                          },
+                          a.const_data_ptr<CTYPE_A>(),
+                          out.mutable_data_ptr<CTYPE_OUT>(),
+                          out.numel());
+                    });
+              });
         });
-      });
-    });
   });
 
   return out;

--- a/kernels/portable/cpu/op_scalar_tensor.cpp
+++ b/kernels/portable/cpu/op_scalar_tensor.cpp
@@ -22,13 +22,15 @@ Tensor& scalar_tensor_out(RuntimeContext& ctx, const Scalar& s, Tensor& out) {
   ScalarType s_type = utils::get_scalar_dtype(s);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, __func__, CTYPE, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(s_type, ctx, __func__, CTYPE_S, [&]() {
-      CTYPE_S val_s;
-      ET_EXTRACT_SCALAR(s, val_s);
-      out.mutable_data_ptr<CTYPE>()[0] = convert<CTYPE, CTYPE_S>(val_s);
-    });
-  });
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, out_type, ctx, "scalar_tensor.out", CTYPE, [&]() {
+        ET_SWITCH_SCALAR_OBJ_TYPES(
+            s_type, ctx, "scalar_tensor.out", CTYPE_S, [&]() {
+              CTYPE_S val_s;
+              ET_EXTRACT_SCALAR(s, val_s);
+              out.mutable_data_ptr<CTYPE>()[0] = convert<CTYPE, CTYPE_S>(val_s);
+            });
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_scatter_add.cpp
+++ b/kernels/portable/cpu/op_scatter_add.cpp
@@ -77,23 +77,24 @@ Tensor& scatter_add_out(
 
   ScalarType self_type = self.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, self_type, ctx, __func__, CTYPE, [&]() {
-    const CTYPE* self_data = self.const_data_ptr<CTYPE>();
-    const long* index_data = index.const_data_ptr<long>();
-    const CTYPE* src_data = src.const_data_ptr<CTYPE>();
-    CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, self_type, ctx, "scatter_add.out", CTYPE, [&]() {
+        const CTYPE* self_data = self.const_data_ptr<CTYPE>();
+        const long* index_data = index.const_data_ptr<long>();
+        const CTYPE* src_data = src.const_data_ptr<CTYPE>();
+        CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
 
-    memcpy(out_data, self_data, self.nbytes());
+        memcpy(out_data, self_data, self.nbytes());
 
-    if (index.numel() != 0) {
-      if (self.dim() == 0) {
-        out_data[0] += nonempty_size(index, 0) * src_data[0];
-      } else {
-        scatter_add_helper<CTYPE>(
-            src_data, index_data, out_data, src, index, out, dim);
-      }
-    }
-  });
+        if (index.numel() != 0) {
+          if (self.dim() == 0) {
+            out_data[0] += nonempty_size(index, 0) * src_data[0];
+          } else {
+            scatter_add_helper<CTYPE>(
+                src_data, index_data, out_data, src, index, out, dim);
+          }
+        }
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_select_scatter.cpp
+++ b/kernels/portable/cpu/op_select_scatter.cpp
@@ -135,19 +135,22 @@ Tensor& select_scatter_out(
   ScalarType in_type = in.scalar_type();
   ScalarType src_type = src.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, src_type, ctx, __func__, CTYPE_SRC, [&]() {
-      CTYPE* const out_data = out.mutable_data_ptr<CTYPE>();
-      const CTYPE_SRC* const src_data = src.const_data_ptr<CTYPE_SRC>();
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in_type, ctx, "select_scatter.out", CTYPE, [&]() {
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, src_type, ctx, "select_scatter.out", CTYPE_SRC, [&]() {
+              CTYPE* const out_data = out.mutable_data_ptr<CTYPE>();
+              const CTYPE_SRC* const src_data = src.const_data_ptr<CTYPE_SRC>();
 
-      for (size_t i = 0; i < leading_dims; ++i) {
-        for (size_t j = 0; j < trailing_stride; ++j) {
-          out_data[start_offset + i * out_step + j] =
-              convert<CTYPE, CTYPE_SRC>(src_data[i * trailing_stride + j]);
-        }
-      }
-    });
-  });
+              for (size_t i = 0; i < leading_dims; ++i) {
+                for (size_t j = 0; j < trailing_stride; ++j) {
+                  out_data[start_offset + i * out_step + j] =
+                      convert<CTYPE, CTYPE_SRC>(
+                          src_data[i * trailing_stride + j]);
+                }
+              }
+            });
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_sigmoid.cpp
+++ b/kernels/portable/cpu/op_sigmoid.cpp
@@ -25,8 +25,8 @@ Tensor& sigmoid_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
 
   ScalarType in_type = in.scalar_type();
   ScalarType out_type = out.scalar_type();
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "sigmoid", CTYPE_IN, [&]() {
-    ET_SWITCH_FLOAT_TYPES(out_type, ctx, "sigmoid", CTYPE_OUT, [&]() {
+  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "sigmoid.out", CTYPE_IN, [&]() {
+    ET_SWITCH_FLOAT_TYPES(out_type, ctx, "sigmoid.out", CTYPE_OUT, [&]() {
       apply_unary_map_fn(
           [](const CTYPE_IN val_in) {
             // perform math in double to preserve precision

--- a/kernels/portable/cpu/op_sign.cpp
+++ b/kernels/portable/cpu/op_sign.cpp
@@ -30,7 +30,7 @@ Tensor& sign_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   if (in.scalar_type() == exec_aten::ScalarType::Bool) {
     memcpy(out.mutable_data_ptr(), in.const_data_ptr(), in.nbytes());
   } else {
-    ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "sign", CTYPE, [&] {
+    ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "sign.out", CTYPE, [&] {
       apply_unary_map_fn(
           [](const CTYPE val_in) {
             if (std::isnan(val_in)) {

--- a/kernels/portable/cpu/op_slice_scatter.cpp
+++ b/kernels/portable/cpu/op_slice_scatter.cpp
@@ -171,26 +171,28 @@ Tensor& slice_scatter_out(
   ScalarType in_type = input.scalar_type();
   ScalarType src_type = src.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, src_type, ctx, __func__, CTYPE_SRC, [&]() {
-      CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
-      const CTYPE_SRC* src_data = src.const_data_ptr<CTYPE_SRC>();
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in_type, ctx, "slice_scatter.out", CTYPE, [&]() {
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, src_type, ctx, "slice_scatter.out", CTYPE_SRC, [&]() {
+              CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
+              const CTYPE_SRC* src_data = src.const_data_ptr<CTYPE_SRC>();
 
-      size_t src_offset = 0;
+              size_t src_offset = 0;
 
-      for (int i = 0; i < leading_dims; i++) {
-        size_t out_offset = (i * dim_length + start) * trailing_dims;
-        for (int j = 0; j < num_values; j++) {
-          for (size_t k = 0; k < trailing_dims; ++k) {
-            out_data[out_offset + k] =
-                convert<CTYPE, CTYPE_SRC>(src_data[src_offset + k]);
-          }
-          src_offset += trailing_dims;
-          out_offset += step * trailing_dims;
-        }
-      }
-    });
-  });
+              for (int i = 0; i < leading_dims; i++) {
+                size_t out_offset = (i * dim_length + start) * trailing_dims;
+                for (int j = 0; j < num_values; j++) {
+                  for (size_t k = 0; k < trailing_dims; ++k) {
+                    out_data[out_offset + k] =
+                        convert<CTYPE, CTYPE_SRC>(src_data[src_offset + k]);
+                  }
+                  src_offset += trailing_dims;
+                  out_offset += step * trailing_dims;
+                }
+              }
+            });
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_softmax.cpp
+++ b/kernels/portable/cpu/op_softmax.cpp
@@ -35,7 +35,7 @@ Tensor& softmax_out(
   // Adjust for negative dim
   dim = dim < 0 ? dim + nonzero_dim(in) : dim;
 
-  ET_SWITCH_FLOAT_TYPES(in.scalar_type(), ctx, "softmax", CTYPE, [&]() {
+  ET_SWITCH_FLOAT_TYPES(in.scalar_type(), ctx, "_softmax.out", CTYPE, [&]() {
     const CTYPE* const in_data = in.const_data_ptr<CTYPE>();
     CTYPE* const out_data = out.mutable_data_ptr<CTYPE>();
 

--- a/kernels/portable/cpu/op_split_copy.cpp
+++ b/kernels/portable/cpu/op_split_copy.cpp
@@ -175,27 +175,29 @@ void split_copy_Tensor_out(
   ScalarType in_type = input.scalar_type();
   ScalarType out_type = out[0].scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE_IN, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, __func__, CTYPE_OUT, [&]() {
-      const CTYPE_IN* input_data = input.const_data_ptr<CTYPE_IN>();
-      for (size_t i = 0, e = out.size(); i < e; ++i) {
-        size_t out_step = out[i].size(dim) * trailing_dims;
-        if (out_step == 0) {
-          continue;
-        }
-        const CTYPE_IN* src = input_data;
-        CTYPE_OUT* dest = out[i].mutable_data_ptr<CTYPE_OUT>();
-        for (size_t j = 0; j < leading_dims; ++j) {
-          for (size_t k = 0; k < out_step; ++k) {
-            dest[k] = convert<CTYPE_OUT, CTYPE_IN>(src[k]);
-          }
-          src += step;
-          dest += out_step;
-        }
-        input_data += out_step;
-      }
-    });
-  });
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in_type, ctx, "split_copy.Tensor_out", CTYPE_IN, [&]() {
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, out_type, ctx, "split_copy.Tensor_out", CTYPE_OUT, [&]() {
+              const CTYPE_IN* input_data = input.const_data_ptr<CTYPE_IN>();
+              for (size_t i = 0, e = out.size(); i < e; ++i) {
+                size_t out_step = out[i].size(dim) * trailing_dims;
+                if (out_step == 0) {
+                  continue;
+                }
+                const CTYPE_IN* src = input_data;
+                CTYPE_OUT* dest = out[i].mutable_data_ptr<CTYPE_OUT>();
+                for (size_t j = 0; j < leading_dims; ++j) {
+                  for (size_t k = 0; k < out_step; ++k) {
+                    dest[k] = convert<CTYPE_OUT, CTYPE_IN>(src[k]);
+                  }
+                  src += step;
+                  dest += out_step;
+                }
+                input_data += out_step;
+              }
+            });
+      });
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_stack.cpp
+++ b/kernels/portable/cpu/op_stack.cpp
@@ -45,20 +45,21 @@ Tensor& stack_out(
   const size_t ninputs = tensors.size();
 
   const auto out_type = out.scalar_type();
-  ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "stack", CTYPE_OUT, [&] {
+  ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "stack.out", CTYPE_OUT, [&] {
     CTYPE_OUT* out_ptr = out.mutable_data_ptr<CTYPE_OUT>();
     for (size_t i = 0; i < outer; ++i) {
       for (size_t j = 0; j < ninputs; ++j) {
         const auto in_type = tensors[j].scalar_type();
-        ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "stack", CTYPE_IN, [&] {
-          const CTYPE_IN* const in_ptr =
-              tensors[j].const_data_ptr<CTYPE_IN>() + i * inner;
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, in_type, ctx, "stack.out", CTYPE_IN, [&] {
+              const CTYPE_IN* const in_ptr =
+                  tensors[j].const_data_ptr<CTYPE_IN>() + i * inner;
 
-          for (size_t k = 0; k < inner; ++k) {
-            out_ptr[k] = static_cast<CTYPE_OUT>(in_ptr[k]);
-          }
-          out_ptr += inner;
-        });
+              for (size_t k = 0; k < inner; ++k) {
+                out_ptr[k] = static_cast<CTYPE_OUT>(in_ptr[k]);
+              }
+              out_ptr += inner;
+            });
       }
     }
   });

--- a/kernels/portable/cpu/op_sub.cpp
+++ b/kernels/portable/cpu/op_sub.cpp
@@ -33,10 +33,10 @@ Tensor& sub_out(
 
   ET_CHECK(canCast(common_type, out_type));
 
-  ET_SWITCH_REAL_TYPES(a_type, ctx, "sub", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES(b_type, ctx, "sub", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES(common_type, ctx, "sub", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES(out_type, ctx, "sub", CTYPE_OUT, [&]() {
+  ET_SWITCH_REAL_TYPES(a_type, ctx, "sub.out", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES(b_type, ctx, "sub.out", CTYPE_B, [&]() {
+      ET_SWITCH_REAL_TYPES(common_type, ctx, "sub.out", CTYPE_IN, [&]() {
+        ET_SWITCH_REAL_TYPES(out_type, ctx, "sub.out", CTYPE_OUT, [&]() {
           CTYPE_IN alpha_val;
           ET_EXTRACT_SCALAR(alpha, alpha_val);
 
@@ -78,28 +78,31 @@ Tensor& sub_scalar_out(
 
   ET_CHECK(common_type == out_type);
 
-  ET_SWITCH_REAL_TYPES(a_type, ctx, "sub", CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_REAL_TYPES(b_type, ctx, "sub", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES(common_type, ctx, "sub", CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES(out_type, ctx, "sub", CTYPE_OUT, [&]() {
-          CTYPE_B b_val;
-          ET_EXTRACT_SCALAR(b, b_val);
-          CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
-          CTYPE_IN alpha_val;
-          ET_EXTRACT_SCALAR(alpha, alpha_val);
+  ET_SWITCH_REAL_TYPES(a_type, ctx, "sub.Scalar_out", CTYPE_A, [&]() {
+    ET_SWITCH_SCALAR_OBJ_REAL_TYPES(
+        b_type, ctx, "sub.Scalar_out", CTYPE_B, [&]() {
+          ET_SWITCH_REAL_TYPES(
+              common_type, ctx, "sub.Scalar_out", CTYPE_IN, [&]() {
+                ET_SWITCH_REAL_TYPES(
+                    out_type, ctx, "sub.Scalar_out", CTYPE_OUT, [&]() {
+                      CTYPE_B b_val;
+                      ET_EXTRACT_SCALAR(b, b_val);
+                      CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
+                      CTYPE_IN alpha_val;
+                      ET_EXTRACT_SCALAR(alpha, alpha_val);
 
-          apply_unary_map_fn(
-              [b_casted, alpha_val](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN value = a_casted - alpha_val * b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
+                      apply_unary_map_fn(
+                          [b_casted, alpha_val](const CTYPE_A val_a) {
+                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                            CTYPE_IN value = a_casted - alpha_val * b_casted;
+                            return static_cast<CTYPE_OUT>(value);
+                          },
+                          a.const_data_ptr<CTYPE_A>(),
+                          out.mutable_data_ptr<CTYPE_OUT>(),
+                          out.numel());
+                    });
+              });
         });
-      });
-    });
   });
 
   return out;

--- a/kernels/portable/cpu/op_sum.cpp
+++ b/kernels/portable/cpu/op_sum.cpp
@@ -54,24 +54,25 @@ Tensor& sum_dim_out(
   Error e = resize_reduction_out(in, dim_list, keepdim, out);
   ET_CHECK_MSG(e == Error::Ok, "Failed to resize out tensor in sum_dim_out");
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in.scalar_type(), ctx, "sum", CTYPE_IN, [&] {
-    ET_SWITCH_REAL_TYPES_AND(
-        Bool, out.scalar_type(), ctx, "sum", CTYPE_OUT, [&] {
-          CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
-          for (size_t out_ix = 0; out_ix < out.numel(); ++out_ix) {
-            CTYPE_OUT sum = 0;
-            if (in.numel() > 0) {
-              sum = map_reduce_over_dim_list<CTYPE_IN, CTYPE_OUT>(
-                  [](CTYPE_IN v) { return static_cast<CTYPE_OUT>(v); },
-                  [](CTYPE_OUT outv, CTYPE_OUT acc) { return acc + outv; },
-                  in,
-                  dim_list,
-                  out_ix);
-            }
-            out_data[out_ix] = sum;
-          }
-        });
-  });
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in.scalar_type(), ctx, "sum.IntList_out", CTYPE_IN, [&] {
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, out.scalar_type(), ctx, "sum.IntList_out", CTYPE_OUT, [&] {
+              CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
+              for (size_t out_ix = 0; out_ix < out.numel(); ++out_ix) {
+                CTYPE_OUT sum = 0;
+                if (in.numel() > 0) {
+                  sum = map_reduce_over_dim_list<CTYPE_IN, CTYPE_OUT>(
+                      [](CTYPE_IN v) { return static_cast<CTYPE_OUT>(v); },
+                      [](CTYPE_OUT outv, CTYPE_OUT acc) { return acc + outv; },
+                      in,
+                      dim_list,
+                      out_ix);
+                }
+                out_data[out_ix] = sum;
+              }
+            });
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_unbind_copy.cpp
+++ b/kernels/portable/cpu/op_unbind_copy.cpp
@@ -102,24 +102,27 @@ void unbind_copy_int_out(
   ScalarType in_type = input.scalar_type();
   ScalarType out_type = out[0].scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE_IN, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, __func__, CTYPE_OUT, [&]() {
-      const CTYPE_IN* const input_data = input.const_data_ptr<CTYPE_IN>();
-      for (size_t i = 0, e = out.size(); i < e; ++i) {
-        size_t input_offset = i * trailing_dims;
-        CTYPE_OUT* const dest = out[i].mutable_data_ptr<CTYPE_OUT>();
-        size_t dest_offset = 0;
-        for (size_t j = 0; j < leading_dims; ++j) {
-          for (size_t k = 0; k < trailing_dims; ++k) {
-            dest[dest_offset + k] =
-                convert<CTYPE_OUT, CTYPE_IN>(input_data[input_offset + k]);
-          }
-          input_offset += step;
-          dest_offset += trailing_dims;
-        }
-      }
-    });
-  });
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in_type, ctx, "unbind_copy.int_out", CTYPE_IN, [&]() {
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, out_type, ctx, "unbind_copy.int_out", CTYPE_OUT, [&]() {
+              const CTYPE_IN* const input_data =
+                  input.const_data_ptr<CTYPE_IN>();
+              for (size_t i = 0, e = out.size(); i < e; ++i) {
+                size_t input_offset = i * trailing_dims;
+                CTYPE_OUT* const dest = out[i].mutable_data_ptr<CTYPE_OUT>();
+                size_t dest_offset = 0;
+                for (size_t j = 0; j < leading_dims; ++j) {
+                  for (size_t k = 0; k < trailing_dims; ++k) {
+                    dest[dest_offset + k] = convert<CTYPE_OUT, CTYPE_IN>(
+                        input_data[input_offset + k]);
+                  }
+                  input_offset += step;
+                  dest_offset += trailing_dims;
+                }
+              }
+            });
+      });
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_var.cpp
+++ b/kernels/portable/cpu/op_var.cpp
@@ -50,8 +50,8 @@ Tensor& var_out(
   Error e = resize_reduction_out(in, dim_list, keepdim, out);
   ET_CHECK_MSG(e == Error::Ok, "Failed to resize out tensor in var_out");
 
-  ET_SWITCH_FLOAT_TYPES(in.scalar_type(), ctx, "var", CTYPE_IN, [&] {
-    ET_SWITCH_FLOAT_TYPES(out.scalar_type(), ctx, "var", CTYPE_OUT, [&] {
+  ET_SWITCH_FLOAT_TYPES(in.scalar_type(), ctx, "var.out", CTYPE_IN, [&] {
+    ET_SWITCH_FLOAT_TYPES(out.scalar_type(), ctx, "var.out", CTYPE_OUT, [&] {
       CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
       const size_t num = get_reduced_dim_product(in, dim_list);
       const size_t denominator = unbiased ? num - 1 : num;

--- a/kernels/portable/cpu/op_where.cpp
+++ b/kernels/portable/cpu/op_where.cpp
@@ -33,31 +33,41 @@ Tensor& where_out(
   // Determine output size and resize for dynamic shapes
   resize_to_broadcast_target_size(a, b, cond, out);
 
-  ET_SWITCH_TWO_TYPES(Bool, Byte, cond_type, ctx, "where", CTYPE_COND, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "where", CTYPE_A, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "where", CTYPE_B, [&]() {
+  ET_SWITCH_TWO_TYPES(
+      Bool, Byte, cond_type, ctx, "where.self_out", CTYPE_COND, [&]() {
         ET_SWITCH_REAL_TYPES_AND(
-            Bool, out_type, ctx, "where", CTYPE_OUT, [&]() {
-              apply_ternary_elementwise_fn<
-                  CTYPE_A,
-                  CTYPE_B,
-                  CTYPE_COND,
-                  CTYPE_OUT>(
-                  [](const CTYPE_A val_a,
-                     const CTYPE_B val_b,
-                     const CTYPE_COND val_c) {
-                    CTYPE_OUT a_casted = static_cast<CTYPE_OUT>(val_a);
-                    CTYPE_OUT b_casted = static_cast<CTYPE_OUT>(val_b);
-                    return val_c ? a_casted : b_casted;
-                  },
-                  a,
-                  b,
-                  cond,
-                  out);
+            Bool, a_type, ctx, "where.self_out", CTYPE_A, [&]() {
+              ET_SWITCH_REAL_TYPES_AND(
+                  Bool, b_type, ctx, "where.self_out", CTYPE_B, [&]() {
+                    ET_SWITCH_REAL_TYPES_AND(
+                        Bool,
+                        out_type,
+                        ctx,
+                        "where.self_out",
+                        CTYPE_OUT,
+                        [&]() {
+                          apply_ternary_elementwise_fn<
+                              CTYPE_A,
+                              CTYPE_B,
+                              CTYPE_COND,
+                              CTYPE_OUT>(
+                              [](const CTYPE_A val_a,
+                                 const CTYPE_B val_b,
+                                 const CTYPE_COND val_c) {
+                                CTYPE_OUT a_casted =
+                                    static_cast<CTYPE_OUT>(val_a);
+                                CTYPE_OUT b_casted =
+                                    static_cast<CTYPE_OUT>(val_b);
+                                return val_c ? a_casted : b_casted;
+                              },
+                              a,
+                              b,
+                              cond,
+                              out);
+                        });
+                  });
             });
       });
-    });
-  });
 
   return out;
 }


### PR DESCRIPTION
Summary:
- selected_op.yaml; contains *op_names* collected from the model
- dtype selective build; for each *op_name*, generate kernel code only if the dtype is used in the model

- this diff: make sure op_names in op_<op>.cpp file match the op name collected by selected_op.yaml. This is the op name from [functions.yaml](https://fburl.com/code/uok7njmb)

Note: the op names are not used for anything besides selective build, so this change should not break anything.

Reviewed By: manuelcandales

Differential Revision: D50425923

