### PR TITLE
Update front-page docs to point to the new forum category

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ please visit our [documentation website](https://pytorch.org/executorch).
 
 ## Important: This is a preview release
 
-This is a preview version of ExecuTorch and should be used for testing and evaluation purposes only.
-It is not recommended for use in production settings. We welcome any feedback, suggestions, and bug
-reports from the community to help us improve the technology.
-Please use the [PyTorch Forums](https://discuss.pytorch.org/) for discussion
-and feedback about ExecuTorch using the tag **#executorch** and
-our [GitHub repository](https://github.com/pytorch/executorch/issues)
-for bug reporting.
+This is a preview version of ExecuTorch and should be used for testing and
+evaluation purposes only. It is not recommended for use in production settings.
+We welcome any feedback, suggestions, and bug reports from the community to help
+us improve the technology. Please use the [PyTorch
+Forums](https://discuss.pytorch.org/c/executorch) for discussion and feedback
+about ExecuTorch using the **ExecuTorch** category, and our [GitHub
+repository](https://github.com/pytorch/executorch/issues) for bug reporting.
 
 The ExecuTorch code and APIs are still changing quickly, and there are not yet
 any guarantees about forward/backward source compatibility. We recommend using

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,13 +4,13 @@ Welcome to the ExecuTorch Documentation
 =======================================
 
 .. important::
-   This is a preview version of ExecuTorch and should be used for testing and
-   evaluation purposes only. It is not recommended for use in production
+   This is a preview version of ExecuTorch and should be used for testing
+   and evaluation purposes only. It is not recommended for use in production
    settings. We welcome any feedback, suggestions, and bug reports from the
-   community to help us improve the technology. Please use the
-   `PyTorch Forums <https://discuss.pytorch.org/>`__ for discussion and feedback
-   about ExecuTorch using the tag **#executorch** and our
-   `GitHub repository <https://github.com/pytorch/executorch/issues>`__ for bug
+   community to help us improve the technology. Please use the `PyTorch
+   Forums <https://discuss.pytorch.org/c/executorch>`__ for discussion and
+   feedback about ExecuTorch using the **ExecuTorch** category, and our `GitHub
+   repository <https://github.com/pytorch/executorch/issues>`__ for bug
    reporting.
 
 .. raw:: html
@@ -21,6 +21,8 @@ Welcome to the ExecuTorch Documentation
      <div class="et-page-column2"><img src="_static/img/ExecuTorch-Logo-cropped.svg" alt="ExecuTorch logo" title="ExecuTorch logo"></div>
    </div>
 
+The ExecuTorch source is hosted on GitHub at
+https://github.com/pytorch/executorch.
 
 Getting Started
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Summary:
The forums don't use hashtags, they use categories. We now have the `ExecuTorch` category, so point to it.

Also, while I'm modifying the main docs page, explicitly point to the github repo to address T167412145.

Differential Revision: D50510494


