### PR TITLE
Onboard ExecuTorch to ciflow bot

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,0 +1,3 @@
+# The schema is from https://github.com/pytorch/pytorch/blob/main/.github/pytorch-probot.yml
+ciflow_push_tags:
+- ciflow/trunk

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - release/*
+    tags:
+      - ciflow/trunk/*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This would allow folks to add `ciflow/trunk` on their PR to run trunk jobs.

Fixes https://github.com/pytorch/test-infra/issues/4663