### PR TITLE
Simplify gather_models step

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: 'true'
+          submodules: 'false'
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -30,12 +30,6 @@ jobs:
         run: |
           set -eux
 
-          source .ci/scripts/utils.sh
-          # This is a simple Python script but as it tries to import executorch.examples.models,
-          # it requires a whole bunch of ExecuTorch dependencies on the Docker image
-          install_pip_dependencies
-          install_executorch
-
           PYTHONPATH="${PWD}" python .ci/scripts/gather_test_models.py --event "${GITHUB_EVENT_NAME}"
 
   test-models-linux:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-          cache: pip
       - name: Extract the list of models to test
         id: gather-models
         run: |

--- a/examples/models/__init__.py
+++ b/examples/models/__init__.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .model_factory import EagerModelFactory
-
 MODEL_NAME_TO_MODEL = {
     "mul": ("toy_model", "MulModule"),
     "linear": ("toy_model", "LinearModule"),
@@ -30,6 +28,5 @@ MODEL_NAME_TO_MODEL = {
 }
 
 __all__ = [
-    "EagerModelFactory",
     "MODEL_NAME_TO_MODEL",
 ]


### PR DESCRIPTION
We don't need to install the full ExecuTorch package