### PR TITLE
Clarify that the python example isn't exactly the same

### DIFF
--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -179,16 +179,17 @@ To generate a sample program, complete the following steps:
   ```
   :::
 
-  This command has created a `add.pte` file that contains your sample program.
+  This command has created a `add.pte` file that contains your sample program,
+  which adds its inputs multiple times.
 
-Alternatively, you can use a Python Interpreter to perform the same action:
+Alternatively, you can use a Python interpreter to perform similar steps, this
+time creating a `mul.pte` program file that multiplies its inputs:
 
 ```python
->>> import executorch.exir as exir
->>> from executorch.exir.tests.models import Mul
->>> m = Mul()
->>> print(exir.capture(m, m.get_random_inputs()).to_edge())
->>> open("mul.pte", "wb").write(exir.capture(m, m.get_random_inputs()).to_edge().to_executorch().buffer)
+import executorch.exir as exir
+from executorch.exir.tests.models import Mul
+m = Mul()
+open("mul.pte", "wb").write(exir.capture(m, m.get_random_inputs()).to_edge().to_executorch().buffer)
 ```
 
 In this step, you learned how you can export your PyTorch program to an ExecuTorch


### PR DESCRIPTION
Summary:
When reading this, "perform the same action" made it sound like these steps would also create an `add.pte` file, but that's not true.

I looked into adding the code that would actually perform the exact same action, but the AddModule isn't in exir.tests. So, instead just call out that it's not literally the same action.

While I'm here:
- Remove the `>>>` so that users can copy and paste all of the lines at once
- Remove the `print`, which just printed something like `<executorch.exir.program._program.ExirExportedProgram object at 0x102f1ae00>`

Differential Revision: D50578857


