### PR TITLE
XNNPACK workflow don't stop on one run error

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -154,22 +154,22 @@ else
   set +e
   if [[ "${BACKEND}" == *"quantization"* ]]; then
     echo "::group::Testing ${MODEL_NAME} with XNNPACK quantization only..."
-    test_model_with_xnnpack true false || Q_ERROR=1
+    test_model_with_xnnpack true false || Q_ERROR="q8 run error"
     echo "::endgroup::"
   fi
   if [[ "${BACKEND}" == *"delegation"* ]]; then
     echo "::group::Testing ${MODEL_NAME} with XNNPACK delegation only..."
-    test_model_with_xnnpack false true || D_ERROR=1
+    test_model_with_xnnpack false true || D_ERROR="Delegation fp32 run error"
     echo "::endgroup::"
   fi
   if [[ "${BACKEND}" == *"quantization"* ]] && [[ "${BACKEND}" == *"delegation"* ]]; then
     echo "::group::Testing ${MODEL_NAME} with XNNPACK quantization and delegation..."
-    test_model_with_xnnpack true true || Q_D_ERROR=1
+    test_model_with_xnnpack true true || Q_D_ERROR="Delegation q8 run error"
     echo "::endgroup::"
   fi
   set -e
   if [[ -z "${Q_ERROR:-}" ]] || [[ -z "${D_ERROR:-}" ]] || [[ -z "${Q_D_ERROR:-}" ]]; then
-    echo "${Q_ERROR}" "${D_ERROR}" "${Q_D_ERROR}"
+    echo "${Q_ERROR:-q8 ok}" "${D_ERROR:-delegation fp32 ok}" "${Q_D_ERROR:- delegation q8 ok}"
     exit 1
   fi
 fi

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -168,7 +168,7 @@ else
     echo "::endgroup::"
   fi
   set -e
-  if [[ -z "${Q_ERROR:-}" ]] || [[ -z "${D_ERROR:-}" ]] || [[ -z "${Q_D_ERROR:-}" ]]; then
+  if [[ -n "${Q_ERROR:-}" ]] || [[ -n "${D_ERROR:-}" ]] || [[ -n "${Q_D_ERROR:-}" ]]; then
     echo "Portable q8 ${Q_ERROR:-ok}," "Delegation fp32 ${D_ERROR:-ok}," "Delegation q8 ${Q_D_ERROR:-ok}"
     exit 1
   fi

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -154,22 +154,22 @@ else
   set +e
   if [[ "${BACKEND}" == *"quantization"* ]]; then
     echo "::group::Testing ${MODEL_NAME} with XNNPACK quantization only..."
-    test_model_with_xnnpack true false || Q_ERROR="q8 run error"
+    test_model_with_xnnpack true false || Q_ERROR="error"
     echo "::endgroup::"
   fi
   if [[ "${BACKEND}" == *"delegation"* ]]; then
     echo "::group::Testing ${MODEL_NAME} with XNNPACK delegation only..."
-    test_model_with_xnnpack false true || D_ERROR="Delegation fp32 run error"
+    test_model_with_xnnpack false true || D_ERROR="error"
     echo "::endgroup::"
   fi
   if [[ "${BACKEND}" == *"quantization"* ]] && [[ "${BACKEND}" == *"delegation"* ]]; then
     echo "::group::Testing ${MODEL_NAME} with XNNPACK quantization and delegation..."
-    test_model_with_xnnpack true true || Q_D_ERROR="Delegation q8 run error"
+    test_model_with_xnnpack true true || Q_D_ERROR="error"
     echo "::endgroup::"
   fi
   set -e
   if [[ -z "${Q_ERROR:-}" ]] || [[ -z "${D_ERROR:-}" ]] || [[ -z "${Q_D_ERROR:-}" ]]; then
-    echo "${Q_ERROR:-q8 ok}" "${D_ERROR:-delegation fp32 ok}" "${Q_D_ERROR:- delegation q8 ok}"
+    echo "Portable q8 ${Q_ERROR:-ok}," "Delegation fp32 ${D_ERROR:-ok}," "Delegation q8 ${Q_D_ERROR:-ok}"
     exit 1
   fi
 fi

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -151,20 +151,26 @@ if [[ "${BACKEND}" == "portable" ]]; then
   echo "Testing ${MODEL_NAME} with portable kernels..."
   test_model
 else
+  set +e
   if [[ "${BACKEND}" == *"quantization"* ]]; then
     echo "::group::Testing ${MODEL_NAME} with XNNPACK quantization only..."
-    test_model_with_xnnpack true false
+    test_model_with_xnnpack true false || Q_ERROR=1
     echo "::endgroup::"
   fi
   if [[ "${BACKEND}" == *"delegation"* ]]; then
     echo "::group::Testing ${MODEL_NAME} with XNNPACK delegation only..."
-    test_model_with_xnnpack false true
+    test_model_with_xnnpack false true || D_ERROR=1
     echo "::endgroup::"
   fi
   if [[ "${BACKEND}" == *"quantization"* ]] && [[ "${BACKEND}" == *"delegation"* ]]; then
     echo "::group::Testing ${MODEL_NAME} with XNNPACK quantization and delegation..."
-    test_model_with_xnnpack true true
+    test_model_with_xnnpack true true || Q_D_ERROR=1
     echo "::endgroup::"
+  fi
+  set -e
+  if [[ -z "${Q_ERROR:-}" ]] || [[ -z "${D_ERROR:-}" ]] || [[ -z "${Q_D_ERROR:-}" ]]; then
+    echo "${Q_ERROR}" "${D_ERROR}" "${Q_D_ERROR}"
+    exit 1
   fi
 fi
 

--- a/backends/xnnpack/runtime/XNNStatus.h
+++ b/backends/xnnpack/runtime/XNNStatus.h
@@ -10,7 +10,7 @@
 
 #include <assert.h>
 #include <xnnpack.h>
-123
+
 namespace torch {
 namespace executor {
 namespace xnnpack {

--- a/backends/xnnpack/runtime/XNNStatus.h
+++ b/backends/xnnpack/runtime/XNNStatus.h
@@ -10,7 +10,7 @@
 
 #include <assert.h>
 #include <xnnpack.h>
-
+123
 namespace torch {
 namespace executor {
 namespace xnnpack {


### PR DESCRIPTION
Instead, need to wait for all options (quantization/delegation) and report error in the end.

See https://github.com/pytorch/executorch/actions/runs/6631014744/job/18013650086?pr=1077, now we run all models, and see useful info like `Portable q8 ok, Delegation fp32 error, Delegation q8 error`