### PR TITLE
Move portable_programming.md into the new docs tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,7 @@ modifications to the Google C++ style guide.
 
 ### C++ Portability Guidelines
 
-See also
-[Portable Programming](https://github.com/pytorch/executorch/blob/main/docs/website/docs/contributors/portable_programming.md)
+See also [Portable C++ Programming](/docs/source/portable-cpp-programming.md)
 for detailed advice.
 
 #### C++ language version

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -147,6 +147,7 @@ Topics in this section will help you get started with ExecuTorch.
    runtime-overview
    runtime-backend-delegate-implementation-and-linking
    runtime-platform-abstraction-layer
+   portable-cpp-programming
 
 .. toctree::
    :glob:


### PR DESCRIPTION
Summary: Move portable_programming.md into the new docs tree. Also update the one reference to it.

Differential Revision: D50609267


