### PR TITLE
Move program_file_format.md into the new docs tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,7 @@ modifications to the Google C++ style guide.
 
 ### C++ Portability Guidelines
 
-See also
-[Portable Programming](https://github.com/pytorch/executorch/blob/main/docs/website/docs/contributors/portable_programming.md)
+See also [Portable C++ Programming](/docs/source/portable-cpp-programming.md)
 for detailed advice.
 
 #### C++ language version

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -147,6 +147,7 @@ Topics in this section will help you get started with ExecuTorch.
    runtime-overview
    runtime-backend-delegate-implementation-and-linking
    runtime-platform-abstraction-layer
+   portable-cpp-programming
 
 .. toctree::
    :glob:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -148,6 +148,7 @@ Topics in this section will help you get started with ExecuTorch.
    runtime-backend-delegate-implementation-and-linking
    runtime-platform-abstraction-layer
    portable-cpp-programming
+   pte-file-format
 
 .. toctree::
    :glob:

--- a/docs/source/pte-file-format.md
+++ b/docs/source/pte-file-format.md
@@ -1,12 +1,13 @@
-# Program file format
+# `.pte` file format
 
-ExecuTorch programs are serialized as modified binary flatbuffer files.
+ExecuTorch `.pte` program files are serialized as modified binary flatbuffer
+files with optional data segments appended.
 
 ```
              ┌───────────────────────────────────┐
              │Standard flatbuffer header         │
              ├───────────────────────────────────┤
-             │Optional ExecuTorch extended header│
+Optional ──> │ExecuTorch extended header         │
              ├───────────────────────────────────┤
              │Flatbuffer-serialized program data │
              │                                   │

--- a/schema/extended_header.h
+++ b/schema/extended_header.h
@@ -17,8 +17,7 @@ namespace executor {
  * An extended, ExecuTorch-specific header that may be embedded in the
  * serialized Program data header.
  *
- * For details see
- * //executorch/docs/website/docs/contributors/program_file_format.md
+ * For details see //executorch/docs/source/pte-file-format.md
  */
 struct ExtendedHeader {
   /**


### PR DESCRIPTION
Summary: Move program_file_format.md into the new docs tree. Also update the one reference to it.

Differential Revision: D50609710


