### PR TITLE
Update optimized op names to match optimized.yaml

### DIFF
--- a/kernels/optimized/cpu/op_div.cpp
+++ b/kernels/optimized/cpu/op_div.cpp
@@ -53,7 +53,7 @@ Tensor& opt_div_out(
     auto error = resize_tensor(out, a.sizes());
     ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
 
-    ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "div", CTYPE, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "div.out", CTYPE, [&]() {
       using Vec = executorch::vec::Vectorized<CTYPE>;
       executorch::vec::map2<CTYPE>(
           [](Vec x, Vec y) { return x / y; },
@@ -68,12 +68,12 @@ Tensor& opt_div_out(
 
     resize_to_broadcast_target_size(a, b, out);
 
-    ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "div", CTYPE_A, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "div", CTYPE_B, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "div.out", CTYPE_A, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "div.out", CTYPE_B, [&]() {
         ET_SWITCH_REAL_TYPES_AND(
-            Bool, common_type, ctx, "div", CTYPE_IN, [&]() {
+            Bool, common_type, ctx, "div.out", CTYPE_IN, [&]() {
               ET_SWITCH_REAL_TYPES_AND(
-                  Bool, out_type, ctx, "div", CTYPE_OUT, [&]() {
+                  Bool, out_type, ctx, "div.out", CTYPE_OUT, [&]() {
                     apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
                         [](const CTYPE_A val_a, const CTYPE_B val_b) {
                           CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
@@ -113,40 +113,46 @@ Tensor& opt_div_scalar_out(
   ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
 
   if (a_type == common_type && a_type == out_type) {
-    ET_SWITCH_REAL_TYPES(a_type, ctx, "div", CTYPE, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "div", CTYPE_B, [&]() {
-        CTYPE_B b_val;
-        ET_EXTRACT_SCALAR(b, b_val);
-        CTYPE b_casted = static_cast<CTYPE>(b_val);
-
-        using Vec = executorch::vec::Vectorized<CTYPE>;
-        executorch::vec::map<CTYPE>(
-            [b_casted](Vec x) { return x / Vec(b_casted); },
-            out.mutable_data_ptr<CTYPE>(),
-            a.const_data_ptr<CTYPE>(),
-            out.numel());
-      });
-    });
-  } else {
-    ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "div", CTYPE_A, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "div", CTYPE_B, [&]() {
-        ET_SWITCH_REAL_TYPES(common_type, ctx, "div", CTYPE_IN, [&]() {
-          ET_SWITCH_REAL_TYPES(out_type, ctx, "div", CTYPE_OUT, [&]() {
+    ET_SWITCH_REAL_TYPES(a_type, ctx, "div.Scalar_out", CTYPE, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, b_type, ctx, "div.Scalar_out", CTYPE_B, [&]() {
             CTYPE_B b_val;
             ET_EXTRACT_SCALAR(b, b_val);
-            CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
+            CTYPE b_casted = static_cast<CTYPE>(b_val);
 
-            const size_t n = a.numel();
-            const CTYPE_A* a_data = a.const_data_ptr<CTYPE_A>();
-            CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
-            for (auto i = 0; i < n; ++i) {
-              out_data[i] = static_cast<CTYPE_OUT>(
-                  static_cast<CTYPE_IN>(a_data[i]) / b_casted);
-            }
+            using Vec = executorch::vec::Vectorized<CTYPE>;
+            executorch::vec::map<CTYPE>(
+                [b_casted](Vec x) { return x / Vec(b_casted); },
+                out.mutable_data_ptr<CTYPE>(),
+                a.const_data_ptr<CTYPE>(),
+                out.numel());
           });
-        });
-      });
     });
+  } else {
+    ET_SWITCH_REAL_TYPES_AND(
+        Bool, a_type, ctx, "div.Scalar_out", CTYPE_A, [&]() {
+          ET_SWITCH_REAL_TYPES_AND(
+              Bool, b_type, ctx, "div.Scalar_out", CTYPE_B, [&]() {
+                ET_SWITCH_REAL_TYPES(
+                    common_type, ctx, "div.Scalar_out", CTYPE_IN, [&]() {
+                      ET_SWITCH_REAL_TYPES(
+                          out_type, ctx, "div.Scalar_out", CTYPE_OUT, [&]() {
+                            CTYPE_B b_val;
+                            ET_EXTRACT_SCALAR(b, b_val);
+                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
+
+                            const size_t n = a.numel();
+                            const CTYPE_A* a_data = a.const_data_ptr<CTYPE_A>();
+                            CTYPE_OUT* out_data =
+                                out.mutable_data_ptr<CTYPE_OUT>();
+                            for (auto i = 0; i < n; ++i) {
+                              out_data[i] = static_cast<CTYPE_OUT>(
+                                  static_cast<CTYPE_IN>(a_data[i]) / b_casted);
+                            }
+                          });
+                    });
+              });
+        });
   }
 
   return out;

--- a/kernels/optimized/cpu/op_exp.cpp
+++ b/kernels/optimized/cpu/op_exp.cpp
@@ -63,14 +63,16 @@ Tensor& opt_exp_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   auto error = resize_tensor(out, in.sizes());
   ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in.scalar_type(), ctx, "exp", CTYPE_IN, [&] {
-    ET_SWITCH_FLOAT_TYPES(out.scalar_type(), ctx, "exp", CTYPE_OUT, [&] {
-      exp_data<CTYPE_IN, CTYPE_OUT>(
-          in.const_data_ptr<CTYPE_IN>(),
-          in.numel(),
-          out.mutable_data_ptr<CTYPE_OUT>());
-    });
-  });
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, in.scalar_type(), ctx, "exp.out", CTYPE_IN, [&] {
+        ET_SWITCH_FLOAT_TYPES(
+            out.scalar_type(), ctx, "exp.out", CTYPE_OUT, [&] {
+              exp_data<CTYPE_IN, CTYPE_OUT>(
+                  in.const_data_ptr<CTYPE_IN>(),
+                  in.numel(),
+                  out.mutable_data_ptr<CTYPE_OUT>());
+            });
+      });
 
   return out;
 }

--- a/kernels/optimized/cpu/op_mul.cpp
+++ b/kernels/optimized/cpu/op_mul.cpp
@@ -36,7 +36,7 @@ Tensor& opt_mul_out(
     auto error = resize_tensor(out, a.sizes());
     ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
 
-    ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "mul", CTYPE, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "mul.out", CTYPE, [&]() {
       using Vec = executorch::vec::Vectorized<CTYPE>;
       executorch::vec::map2<CTYPE>(
           [](Vec x, Vec y) { return x * y; },
@@ -51,12 +51,12 @@ Tensor& opt_mul_out(
 
     resize_to_broadcast_target_size(a, b, out);
 
-    ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "mul", CTYPE_A, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "mul", CTYPE_B, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "mul.out", CTYPE_A, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "mul.out", CTYPE_B, [&]() {
         ET_SWITCH_REAL_TYPES_AND(
-            Bool, common_type, ctx, "mul", CTYPE_IN, [&]() {
+            Bool, common_type, ctx, "mul.out", CTYPE_IN, [&]() {
               ET_SWITCH_REAL_TYPES_AND(
-                  Bool, out_type, ctx, "mul", CTYPE_OUT, [&]() {
+                  Bool, out_type, ctx, "mul.out", CTYPE_OUT, [&]() {
                     apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
                         [](const CTYPE_A val_a, const CTYPE_B val_b) {
                           CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
@@ -96,42 +96,51 @@ Tensor& opt_mul_scalar_out(
   ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
 
   if (a_type == common_type && a_type == out_type) {
-    ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "mul", CTYPE, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "mul", CTYPE_B, [&]() {
-        CTYPE_B b_val;
-        ET_EXTRACT_SCALAR(b, b_val);
-        CTYPE b_casted = static_cast<CTYPE>(b_val);
+    ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "mul.Scalar_out", CTYPE, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, b_type, ctx, "mul.Scalar_out", CTYPE_B, [&]() {
+            CTYPE_B b_val;
+            ET_EXTRACT_SCALAR(b, b_val);
+            CTYPE b_casted = static_cast<CTYPE>(b_val);
 
-        using Vec = executorch::vec::Vectorized<CTYPE>;
-        executorch::vec::map<CTYPE>(
-            [b_casted](Vec x) { return x * Vec(b_casted); },
-            out.mutable_data_ptr<CTYPE>(),
-            a.const_data_ptr<CTYPE>(),
-            out.numel());
-      });
+            using Vec = executorch::vec::Vectorized<CTYPE>;
+            executorch::vec::map<CTYPE>(
+                [b_casted](Vec x) { return x * Vec(b_casted); },
+                out.mutable_data_ptr<CTYPE>(),
+                a.const_data_ptr<CTYPE>(),
+                out.numel());
+          });
     });
   } else {
-    ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "mul", CTYPE_A, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "mul", CTYPE_B, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(
-            Bool, common_type, ctx, "mul", CTYPE_IN, [&]() {
-              ET_SWITCH_REAL_TYPES_AND(
-                  Bool, out_type, ctx, "mul", CTYPE_OUT, [&]() {
-                    CTYPE_B b_val;
-                    ET_EXTRACT_SCALAR(b, b_val);
-                    CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
+    ET_SWITCH_REAL_TYPES_AND(
+        Bool, a_type, ctx, "mul.Scalar_out", CTYPE_A, [&]() {
+          ET_SWITCH_REAL_TYPES_AND(
+              Bool, b_type, ctx, "mul.Scalar_out", CTYPE_B, [&]() {
+                ET_SWITCH_REAL_TYPES_AND(
+                    Bool, common_type, ctx, "mul.Scalar_out", CTYPE_IN, [&]() {
+                      ET_SWITCH_REAL_TYPES_AND(
+                          Bool,
+                          out_type,
+                          ctx,
+                          "mul.Scalar_out",
+                          CTYPE_OUT,
+                          [&]() {
+                            CTYPE_B b_val;
+                            ET_EXTRACT_SCALAR(b, b_val);
+                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
 
-                    const size_t n = a.numel();
-                    const CTYPE_A* a_data = a.const_data_ptr<CTYPE_A>();
-                    CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
-                    for (auto i = 0; i < n; ++i) {
-                      out_data[i] = static_cast<CTYPE_OUT>(
-                          static_cast<CTYPE_IN>(a_data[i]) * b_casted);
-                    }
-                  });
-            });
-      });
-    });
+                            const size_t n = a.numel();
+                            const CTYPE_A* a_data = a.const_data_ptr<CTYPE_A>();
+                            CTYPE_OUT* out_data =
+                                out.mutable_data_ptr<CTYPE_OUT>();
+                            for (auto i = 0; i < n; ++i) {
+                              out_data[i] = static_cast<CTYPE_OUT>(
+                                  static_cast<CTYPE_IN>(a_data[i]) * b_casted);
+                            }
+                          });
+                    });
+              });
+        });
   }
 
   return out;

--- a/kernels/optimized/cpu/op_native_layer_norm.cpp
+++ b/kernels/optimized/cpu/op_native_layer_norm.cpp
@@ -155,10 +155,18 @@ std::tuple<Tensor&, Tensor&, Tensor&> opt_native_layer_norm_out(
       InvalidArgument,
       ret_val);
 
-  ET_SWITCH_FLOAT_TYPES(input.scalar_type(), ctx, __func__, CTYPE, [&]() {
-    layer_norm<CTYPE>(
-        input, normalized_shape, weight, bias, eps, out, mean_out, rstd_out);
-  });
+  ET_SWITCH_FLOAT_TYPES(
+      input.scalar_type(), ctx, "native_layer_norm.out", CTYPE, [&]() {
+        layer_norm<CTYPE>(
+            input,
+            normalized_shape,
+            weight,
+            bias,
+            eps,
+            out,
+            mean_out,
+            rstd_out);
+      });
 
   return ret_val;
 }

--- a/kernels/optimized/cpu/op_neg.cpp
+++ b/kernels/optimized/cpu/op_neg.cpp
@@ -21,7 +21,7 @@ Tensor& opt_neg_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   auto error = resize_tensor(out, in.sizes());
   ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
 
-  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "neg", CTYPE, [&] {
+  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "neg.out", CTYPE, [&] {
     using Vec = executorch::vec::Vectorized<CTYPE>;
     executorch::vec::map<CTYPE>(
         [](Vec x) { return x.neg(); },

--- a/kernels/optimized/cpu/op_sub.cpp
+++ b/kernels/optimized/cpu/op_sub.cpp
@@ -37,7 +37,7 @@ Tensor& opt_sub_out(
     auto error = resize_tensor(out, a.sizes());
     ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
 
-    ET_SWITCH_REAL_TYPES(out_type, ctx, "sub", CTYPE, [&]() {
+    ET_SWITCH_REAL_TYPES(out_type, ctx, "sub.out", CTYPE, [&]() {
       CTYPE alpha_val;
       ET_EXTRACT_SCALAR(alpha, alpha_val);
 
@@ -55,10 +55,10 @@ Tensor& opt_sub_out(
 
     resize_to_broadcast_target_size(a, b, out);
 
-    ET_SWITCH_REAL_TYPES(a_type, ctx, "sub", CTYPE_A, [&]() {
-      ET_SWITCH_REAL_TYPES(b_type, ctx, "sub", CTYPE_B, [&]() {
-        ET_SWITCH_REAL_TYPES(common_type, ctx, "sub", CTYPE_IN, [&]() {
-          ET_SWITCH_REAL_TYPES(out_type, ctx, "sub", CTYPE_OUT, [&]() {
+    ET_SWITCH_REAL_TYPES(a_type, ctx, "sub.out", CTYPE_A, [&]() {
+      ET_SWITCH_REAL_TYPES(b_type, ctx, "sub.out", CTYPE_B, [&]() {
+        ET_SWITCH_REAL_TYPES(common_type, ctx, "sub.out", CTYPE_IN, [&]() {
+          ET_SWITCH_REAL_TYPES(out_type, ctx, "sub.out", CTYPE_OUT, [&]() {
             CTYPE_IN alpha_val;
             ET_EXTRACT_SCALAR(alpha, alpha_val);
 
@@ -102,8 +102,8 @@ Tensor& opt_sub_scalar_out(
   ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
 
   if (a_type == common_type && a_type == out_type) {
-    ET_SWITCH_REAL_TYPES(a_type, ctx, "sub", CTYPE, [&]() {
-      ET_SWITCH_REAL_TYPES(b_type, ctx, "sub", CTYPE_B, [&]() {
+    ET_SWITCH_REAL_TYPES(a_type, ctx, "sub.Scalar_out", CTYPE, [&]() {
+      ET_SWITCH_REAL_TYPES(b_type, ctx, "sub.Scalar_out", CTYPE_B, [&]() {
         CTYPE_B b_val;
         ET_EXTRACT_SCALAR(b, b_val);
         CTYPE b_casted = static_cast<CTYPE>(b_val);
@@ -121,25 +121,28 @@ Tensor& opt_sub_scalar_out(
       });
     });
   } else {
-    ET_SWITCH_REAL_TYPES(a_type, ctx, "sub", CTYPE_A, [&]() {
-      ET_SWITCH_REAL_TYPES(b_type, ctx, "sub", CTYPE_B, [&]() {
-        ET_SWITCH_REAL_TYPES(common_type, ctx, "sub", CTYPE_IN, [&]() {
-          ET_SWITCH_REAL_TYPES(out_type, ctx, "sub", CTYPE_OUT, [&]() {
-            CTYPE_B b_val;
-            ET_EXTRACT_SCALAR(b, b_val);
-            CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
-            CTYPE_IN alpha_val;
-            ET_EXTRACT_SCALAR(alpha, alpha_val);
+    ET_SWITCH_REAL_TYPES(a_type, ctx, "sub.Scalar_out", CTYPE_A, [&]() {
+      ET_SWITCH_REAL_TYPES(b_type, ctx, "sub.Scalar_out", CTYPE_B, [&]() {
+        ET_SWITCH_REAL_TYPES(
+            common_type, ctx, "sub.Scalar_out", CTYPE_IN, [&]() {
+              ET_SWITCH_REAL_TYPES(
+                  out_type, ctx, "sub.Scalar_out", CTYPE_OUT, [&]() {
+                    CTYPE_B b_val;
+                    ET_EXTRACT_SCALAR(b, b_val);
+                    CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
+                    CTYPE_IN alpha_val;
+                    ET_EXTRACT_SCALAR(alpha, alpha_val);
 
-            const size_t n = a.numel();
-            const CTYPE_A* a_data = a.const_data_ptr<CTYPE_A>();
-            CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
-            for (auto i = 0; i < n; ++i) {
-              out_data[i] = static_cast<CTYPE_OUT>(
-                  static_cast<CTYPE_IN>(a_data[i]) - alpha_val * b_casted);
-            }
-          });
-        });
+                    const size_t n = a.numel();
+                    const CTYPE_A* a_data = a.const_data_ptr<CTYPE_A>();
+                    CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
+                    for (auto i = 0; i < n; ++i) {
+                      out_data[i] = static_cast<CTYPE_OUT>(
+                          static_cast<CTYPE_IN>(a_data[i]) -
+                          alpha_val * b_casted);
+                    }
+                  });
+            });
       });
     });
   }

--- a/kernels/portable/README.md
+++ b/kernels/portable/README.md
@@ -183,6 +183,10 @@ E.g., these operator overloads all have a base name of `add`:
 So, if you were implementing `add.out` then your operator base name would be
 `add`, and you would replace `<name>` with `add` everywhere below.
 
+### Selective build
+
+When using macros that require a `NAME` argument, eg. `#define ET_SWITCH_REAL_TYPES_AND(ADDITIONAL, TYPE, CONTEXT, NAME, CTYPE_ALIAS, ...)`, make sure to pass in the same operator name defined in `functions.yaml`. This is the base name + variant, eg. `add.out`, `add.Scalar_out`. The function name is required for dtype selective build, which matches against the operator names and dtypes present in a model.
+
 ### Overview of files and targets
 
 For the operator base name `<name>`, you should work with these files and Buck


### PR DESCRIPTION
Summary:
Same as D50561135, for the optimized ops.

For dtype selective build, make sure op names passed to macros matches the op names scraped into selected_operators.yaml.

Add section in README as well.

Differential Revision: D50621838


