### PR TITLE
fix D50422563 oss broken

### DIFF
--- a/backends/apple/mps/test/test_mps_utils.py
+++ b/backends/apple/mps/test/test_mps_utils.py
@@ -191,9 +191,14 @@ class TestMPS(unittest.TestCase):
         )
 
         method_test_suites = [
-            MethodTestSuite(method_name="forward", test_cases=[
-                MethodTestCase(input=sample_inputs, expected_outputs=module(*sample_inputs))
-            ])
+            MethodTestSuite(
+                method_name="forward",
+                test_cases=[
+                    MethodTestCase(
+                        input=sample_inputs, expected_outputs=module(*sample_inputs)
+                    )
+                ],
+            )
         ]
 
         logging.info("  -> Test suites generated successfully")

--- a/bundled_program/config.py
+++ b/bundled_program/config.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 from dataclasses import dataclass
-from typing import Any, get_args, List, Optional, Sequence, Union
+from typing import get_args, List, Optional, Sequence, Union
 
 import torch
 from torch.utils._pytree import tree_flatten

--- a/docs/source/tutorials_source/sdk-integration-tutorial.py
+++ b/docs/source/tutorials_source/sdk-integration-tutorial.py
@@ -150,7 +150,7 @@ method_test_suites = [
     MethodTestSuite(
         method_name=m_name,
         test_cases=[
-            MethodTestCase(inputs=inp, outputs=getattr(model, m_name)(*inp))
+            MethodTestCase(inputs=inp, expected_outputs=getattr(model, m_name)(*inp))
             for inp in inputs
         ],
     )

--- a/examples/apple/mps/scripts/mps_example.py
+++ b/examples/apple/mps/scripts/mps_example.py
@@ -13,13 +13,13 @@ import torch
 import torch._export as export
 from executorch import exir
 from executorch.backends.apple.mps.mps_preprocess import MPSBackend
-
-from executorch.exir.backend.backend_api import to_backend
 from executorch.bundled_program.config import MethodTestCase, MethodTestSuite
 from executorch.bundled_program.core import create_bundled_program
 from executorch.bundled_program.serialize import (
     serialize_from_bundled_program_to_flatbuffer,
 )
+
+from executorch.exir.backend.backend_api import to_backend
 
 from ....models import MODEL_NAME_TO_MODEL
 from ....models.model_factory import EagerModelFactory

--- a/schema/bundled_program_schema.fbs
+++ b/schema/bundled_program_schema.fbs
@@ -9,7 +9,7 @@ include "scalar_type.fbs";
 namespace bundled_program_flatbuffer;
 
 // Identifier of a valid bundled program schema.
-file_identifier "BP07";
+file_identifier "BP08";
 // Extension of written files.
 file_extension "bpte";
 
@@ -90,8 +90,8 @@ table BundledProgram {
   // executorch program keeps the same alignment as original no matter how
   // the program schema changes, we need to make the force_align here the max
   // one around all kinds of force_align in the current and future program
-  // schema, so we use the 4096 as the force_align here.
-  program: [ubyte] (force_align: 4096);
+  // schema, so we use the 32 as the force_align here.
+  program: [ubyte] (force_align: 32);
 }
 
 root_type BundledProgram;


### PR DESCRIPTION
Summary:
previous force_align is too large for oss package, which broke the oss ci (https://github.com/pytorch/executorch/actions/runs/6632940387/job/18019709741#step:11:533).
Shrink it to oss maximum value (32) to sove the issue.

Differential Revision: D50631705


