### PR TITLE
OSS CI skip if xnnpack is not used

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -108,13 +108,12 @@ def export_models_for_ci() -> dict[str, dict]:
             continue
 
         if backend == "xnnpack":
-            if (
-                name in MODEL_NAME_TO_OPTIONS
-                and MODEL_NAME_TO_OPTIONS[name].quantization
-            ):
+            if name not in MODEL_NAME_TO_OPTIONS:
+                continue
+            if MODEL_NAME_TO_OPTIONS[name].quantization:
                 backend += "-quantization"
 
-            if name in MODEL_NAME_TO_OPTIONS and MODEL_NAME_TO_OPTIONS[name].delegation:
+            if MODEL_NAME_TO_OPTIONS[name].delegation:
                 backend += "-delegation"
 
         record = {


### PR DESCRIPTION
When we check for a model, we don't want jobs like test-models-macos (cmake, emformer_join, xnnpack, macos-m1-12) / macos-job which does nothing (non delegated nor quantized).