### PR TITLE
[CI] Fix selective build CI job

### DIFF
--- a/examples/selective_build/CMakeLists.txt
+++ b/examples/selective_build/CMakeLists.txt
@@ -27,6 +27,11 @@ set(TORCH_ROOT ${EXECUTORCH_ROOT}/third-party/pytorch)
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  # Can't set to 11 due to executor_runner.cpp make_unique
+endif()
+
 set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 
 # Let files say "include <executorch/path/to/header.h>".


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1128

Summary: Add C++17 support. There are several use cases of C++17
features in executor_runner.cpp so we can't do C++11 only.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D50909027](https://our.internmc.facebook.com/intern/diff/D50909027)