### PR TITLE
Migrate the visualizer to use Inspector for etrecord and etdump parsing

### DIFF
--- a/docs/source/sdk-inspector.rst
+++ b/docs/source/sdk-inspector.rst
@@ -34,7 +34,7 @@ Constructor
 
     from executorch.sdk import Inspector
 
-    inspector = Inspector(etdump_path="/path/to/etdump.etdp", etrecord_path="/path/to/etrecord.bin")
+    inspector = Inspector(etdump_path="/path/to/etdump.etdp", etrecord="/path/to/etrecord.bin")
 
 
 print_data_tabular

--- a/docs/source/tutorials_source/sdk-integration-tutorial.py
+++ b/docs/source/tutorials_source/sdk-integration-tutorial.py
@@ -210,7 +210,7 @@ inspector_patch.start()
 inspector_patch_print.start()
 # sphinx_gallery_end_ignore
 etdump_path = "etdump.etdp"
-inspector = Inspector(etdump_path=etdump_path, etrecord_path=etrecord_path)
+inspector = Inspector(etdump_path=etdump_path, etrecord=etrecord_path)
 # sphinx_gallery_start_ignore
 inspector.event_blocks = []
 # sphinx_gallery_end_ignore

--- a/sdk/inspector/TARGETS
+++ b/sdk/inspector/TARGETS
@@ -25,7 +25,9 @@ python_library(
 python_binary(
     name = "inspector_cli",
     main_src = "inspector_cli.py",
-    deps = [":inspector"],
+    deps = [
+        ":inspector",
+    ],
 )
 
 python_library(

--- a/sdk/inspector/inspector_cli.py
+++ b/sdk/inspector/inspector_cli.py
@@ -23,7 +23,5 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    inspector = Inspector(
-        etdump_path=args.etdump_path, etrecord_path=args.etrecord_path
-    )
+    inspector = Inspector(etdump_path=args.etdump_path, etrecord=args.etrecord_path)
     inspector.print_data_tabular()

--- a/sdk/inspector/tests/inspector_test.py
+++ b/sdk/inspector/tests/inspector_test.py
@@ -65,7 +65,7 @@ class TestInspector(unittest.TestCase):
             # Call the constructor of Inspector
             Inspector(
                 etdump_path=ETDUMP_PATH,
-                etrecord_path=ETRECORD_PATH,
+                etrecord=ETRECORD_PATH,
             )
 
             # Assert that expected functions are called
@@ -85,7 +85,7 @@ class TestInspector(unittest.TestCase):
             # Call the constructor of Inspector
             inspector_instance = Inspector(
                 etdump_path=ETDUMP_PATH,
-                etrecord_path=ETRECORD_PATH,
+                etrecord=ETRECORD_PATH,
             )
 
             # The mock inspector instance starts with having an empty event blocks list.
@@ -193,7 +193,7 @@ class TestInspector(unittest.TestCase):
             # Call the constructor of Inspector
             inspector_instance = Inspector(
                 etdump_path=ETDUMP_PATH,
-                etrecord_path=ETRECORD_PATH,
+                etrecord=ETRECORD_PATH,
             )
 
             # Gen a mock etrecord


### PR DESCRIPTION
Summary:
As titled. I'll make another diff to remove the et_schema module completely.

Upcoming diffs:
* Attach op level runtime data to graph
* Put run level runtime data in TB Text tab
* [refactor] Delete et_schema.py

Differential Revision: D50544122


