### PR TITLE
Add a note to help with missing `ld`

### DIFF
--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -273,6 +273,13 @@ Complete the following steps:
 
    The `--show-output` flag prints the path to the executable if you want to run it directly.
 
+   If you run into `Stderr: clang-14: error: invalid linker name in argument
+   '-fuse-ld=lld'`, `lld` is not available on your system. Try installing it
+   with `conda` or with your system's package manager.
+   ```bash
+   conda install -c conda-forge lld
+   ```
+
 Now that you have built our sample programs, you can proceed to
 run them.
 


### PR DESCRIPTION
Summary:
This note was in the old doc at https://github.com/pytorch/executorch/blob/3a74a1f06ce13a1953b530b9066ee1fc3e75b563/docs/website/docs/tutorials/00_setting_up_executorch.md?plain=1#L139-L142 but didn't make it to the new doc.

Fixes https://github.com/pytorch/executorch/issues/1142

Differential Revision: D50991455


