### PR TITLE
[coreml] Remove nlohmann json dependency from runtime

### DIFF
--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 # inmemoryfs sources
 set(INMEMORYFS_SOURCES
   runtime/inmemoryfs/inmemory_filesystem.cpp
+  runtime/inmemoryfs/inmemory_filesystem_utils.mm
   runtime/inmemoryfs/memory_buffer.cpp
   runtime/inmemoryfs/memory_stream.cpp
   runtime/inmemoryfs/reversed_memory_stream.cpp
@@ -20,6 +21,7 @@ set(INMEMORYFS_SOURCES
 # kvstore sources
 set(KVSTORE_SOURCES
   runtime/kvstore/database.cpp
+  runtime/kvstore/json_key_value_store.cpp
   runtime/kvstore/sqlite_error.cpp
   runtime/kvstore/key_value_store.cpp
   runtime/kvstore/statement.cpp
@@ -42,6 +44,12 @@ set(DELEGATE_SOURCES
   runtime/delegate/serde_json.mm
 )
 
+# util sources
+set(UTIL_SOURCES
+  runtime/util/json_util.cpp
+  runtime/util/objc_json_serde.mm
+)
+
 # Define the delegate library
 add_library(coremldelegate)
 target_sources(
@@ -49,6 +57,7 @@ target_sources(
   ${INMEMORYFS_SOURCES}
   ${KVSTORE_SOURCES}
   ${DELEGATE_SOURCES}
+  ${UTIL_SOURCES}
 )
 target_include_directories(
   coremldelegate PRIVATE
@@ -68,7 +77,7 @@ target_include_directories(
 )
 target_include_directories(
   coremldelegate PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/third-party/nlohmann_json/single_include/nlohmann
+  ${CMAKE_CURRENT_SOURCE_DIR}/runtime/util
 )
 target_include_directories(
   coremldelegate PRIVATE
@@ -83,7 +92,6 @@ target_link_libraries(
 target_compile_options(coremldelegate PRIVATE "-fobjc-arc")
 target_compile_options(coremldelegate PRIVATE "-fno-exceptions")
 target_compile_options(coremldelegate PRIVATE "-fno-rtti")
-target_compile_definitions(coremldelegate PRIVATE JSON_NOEXCEPTION=1)
 
 set(
   TARGET coremldelegate

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLAsset.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLAsset.mm
@@ -12,15 +12,10 @@
 #import <stdio.h>
 #import <system_error>
 
+#import <objc_safe_cast.h>
+
 namespace  {
-
 using namespace executorchcoreml;
-
-inline id check_class(id obj, Class cls) {
-    return [obj isKindOfClass:cls] ? obj : nil;
-}
-
-#define SAFE_CAST(Object, Type) ((Type *)check_class(Object, [Type class]))
 
 NSDate * _Nullable get_content_modification_date(NSURL *url, NSError * __autoreleasing *error) {
     NSDate *result = nil;

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLAssetManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLAssetManager.mm
@@ -21,7 +21,6 @@ namespace  {
 
 using namespace executorchcoreml;
 using namespace executorchcoreml::sqlite;
-using json = nlohmann::json;
 
 constexpr size_t kBusyTimeIntervalInMS = 100;
 

--- a/backends/apple/coreml/runtime/delegate/asset.h
+++ b/backends/apple/coreml/runtime/delegate/asset.h
@@ -11,6 +11,8 @@
 #import <string>
 #import <vector>
 
+#import <serde_json.h>
+
 namespace executorchcoreml {
 
 /// A struct containing the file info.
@@ -54,6 +56,12 @@ struct Asset {
     std::string path;
     /// The package info.
     PackageInfo package_info;
+
+    inline std::string to_json_string() const noexcept { return serde::json::to_json_string(*this); }
+
+    inline void from_json_string(std::string json_string) noexcept {
+        serde::json::from_json_string(json_string, *this);
+    }
 
     static std::optional<Asset>
     make(NSURL* srcURL, NSString* identifier, NSFileManager* fm, NSError* __autoreleasing* error);

--- a/backends/apple/coreml/runtime/delegate/asset.mm
+++ b/backends/apple/coreml/runtime/delegate/asset.mm
@@ -10,13 +10,9 @@
 
 #import <optional>
 
+#import <objc_safe_cast.h>
+
 namespace  {
-
-inline id check_class(id obj, Class cls) {
-    return [obj isKindOfClass:cls] ? obj : nil;
-}
-
-#define SAFE_CAST(Object, Type) ((Type *)check_class(Object, [Type class]))
 
 NSNumber * _Nullable is_regular_file(NSURL *url, NSError * __autoreleasing *error) {
     NSNumber *result = nil;

--- a/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
@@ -12,6 +12,7 @@
 #import <unordered_map>
 #import <vector>
 
+#import <objc_safe_cast.h>
 #import <multiarray.h>
 
 #import <ETCoreMLLogging.h>
@@ -23,12 +24,6 @@
 namespace {
 using namespace torch::executor;
 using namespace executorchcoreml;
-
-inline id check_class(id obj, Class cls) {
-    return [obj isKindOfClass:cls] ? obj : nil;
-}
-
-#define SAFE_CAST(Object, Type) ((Type *)check_class(Object, [Type class]))
 
 std::optional<MultiArray::DataType> get_data_type(ScalarType scalar_type) {
     if (scalar_type == ScalarType::Float) {

--- a/backends/apple/coreml/runtime/delegate/metadata.h
+++ b/backends/apple/coreml/runtime/delegate/metadata.h
@@ -10,6 +10,8 @@
 #import <string>
 #import <vector>
 
+#import <serde_json.h>
+
 namespace executorchcoreml {
 
 /// A class representing a model's metadata.
@@ -29,6 +31,12 @@ struct ModelMetadata {
     /// Returns `true` if the metadata is valid otherwise `false`.
     inline bool isValid() const noexcept {
         return !identifier.empty() && !input_names.empty() && !output_names.empty();
+    }
+
+    inline std::string to_json_string() const noexcept { return executorchcoreml::serde::json::to_json_string(*this); }
+
+    inline void from_json_string(std::string json_string) noexcept {
+        executorchcoreml::serde::json::from_json_string(json_string, *this);
     }
 
     /// Unique identifier.

--- a/backends/apple/coreml/runtime/delegate/serde_json.h
+++ b/backends/apple/coreml/runtime/delegate/serde_json.h
@@ -8,37 +8,38 @@
 #pragma once
 
 #import <string>
-#import <vector>
-
-#import <json.hpp>
-
-#import <asset.h>
-#import <metadata.h>
 
 namespace executorchcoreml {
+struct Asset;
+struct ModelMetadata;
 
-/// Populates `nlohmann::json` from `ModelAsset`.
+namespace serde {
+namespace json {
+
+/// Serializes `Asset` to json.
 ///
-/// @param json The json value to be populated from the asset value.
 /// @param asset The asset value.
-void to_json(nlohmann::json& json, const Asset& asset);
+/// @retval Serialized json.
+std::string to_json_string(const executorchcoreml::Asset& asset);
 
-/// Populates `ModelAsset` from `nlohmann::json`.
+/// Populates `Asset` from serialized json.
 ///
-/// @param json The json value.
-/// @param asset The asset value to be populated from the json value.
-void from_json(const nlohmann::json& json, Asset& asset);
+/// @param json_string  A json string.
+/// @param asset The asset value to be populated from the json string.
+void from_json_string(const std::string& json_string, executorchcoreml::Asset& asset);
 
-/// Populates nlohmann::json`from `ModelMetadata`.
+/// Serializes `ModelMetadata` to json.
 ///
-/// @param json The json value to be populated from the metadata value.
-/// @param metadata The metadata value.
-void to_json(nlohmann::json& json, const ModelMetadata& metadata);
+/// @param metdata The metadata value.
+/// @retval Serialized json.
+std::string to_json_string(const executorchcoreml::ModelMetadata& metdata);
 
-/// Populates `ModelMetadata` from `nlohmann::json`.
+/// Populates `ModelMetadata` from serialized json.
 ///
-/// @param json The json value.
-/// @param metadata The metadata value to be populated from the json value.
-void from_json(const nlohmann::json& json, ModelMetadata& metadata);
+/// @param json_string  A json string.
+/// @param metadata The metadata value to be populated from the json string.
+void from_json_string(const std::string& json_string, executorchcoreml::ModelMetadata& metadata);
 
+} // namespace json
+} // namespace serde
 } // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata.hpp
@@ -1,0 +1,30 @@
+//
+// inmemory_filesystem_metadata.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <memory_buffer.hpp>
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+namespace inmemoryfs {
+
+struct InMemoryNodeMetadata {
+    std::string name;
+    size_t kind;
+    MemoryRegion data_region;
+    std::unordered_map<std::string, size_t> child_name_to_indices_map;
+};
+
+struct InMemoryFileSystemMetadata {
+    std::vector<InMemoryNodeMetadata> nodes;
+};
+
+} // namespace inmemoryfs
+

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata_keys.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata_keys.hpp
@@ -1,0 +1,31 @@
+//
+// metadata_keys.hpp
+// inmemoryfs
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <string>
+
+namespace inmemoryfs {
+
+struct InMemoryNodeMetadataKeys {
+    constexpr static std::string_view kName = "name";
+    constexpr static std::string_view kDataRegion = "dataRegion";
+    constexpr static std::string_view kChildIndices = "children";
+    constexpr static std::string_view kKind = "kind";
+};
+
+struct InMemoryFileSystemMetadataKeys {
+    constexpr static std::string_view kNodes = "nodes";
+};
+
+struct MemoryRegionKeys {
+    constexpr static std::string_view kOffset = "offset";
+    constexpr static std::string_view kSize = "size";
+};
+
+} // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.cpp
@@ -1,0 +1,115 @@
+//
+// inmemory_filesystem_utils.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#include "inmemory_filesystem_utils.hpp"
+
+#include <iostream>
+#include <json.hpp>
+#include <sstream>
+
+#include <inmemory_filesystem_metadata.hpp>
+#include <inmemory_filesystem_metadata_keys.hpp>
+
+namespace inmemoryfs {
+
+using json = nlohmann::json;
+
+void to_json(json& j, const MemoryRegion& region) {
+    j = json { { MemoryRegionKeys::kOffset, region.offset }, { MemoryRegionKeys::kSize, region.size } };
+}
+
+void from_json(const json& j, MemoryRegion& region) {
+    if (j.contains(MemoryRegionKeys::kOffset)) {
+        j.at(MemoryRegionKeys::kOffset).get_to(region.offset);
+    }
+    if (j.contains(MemoryRegionKeys::kSize)) {
+        j.at(MemoryRegionKeys::kSize).get_to(region.size);
+    }
+}
+
+void to_json(json& j, const InMemoryNodeMetadata& node) {
+    j = json { { InMemoryNodeMetadataKeys::kName, node.name },
+               { InMemoryNodeMetadataKeys::kDataRegion, node.data_region },
+               { InMemoryNodeMetadataKeys::kChildIndices, node.child_name_to_indices_map },
+               { InMemoryNodeMetadataKeys::kKind, static_cast<int>(node.kind) } };
+}
+
+void from_json(const json& j, InMemoryNodeMetadata& node) {
+    if (j.contains(InMemoryNodeMetadataKeys::kName)) {
+        j.at(InMemoryNodeMetadataKeys::kName).get_to(node.name);
+    }
+    if (j.contains(InMemoryNodeMetadataKeys::kDataRegion)) {
+        j.at(InMemoryNodeMetadataKeys::kDataRegion).get_to(node.data_region);
+    }
+    if (j.contains(InMemoryNodeMetadataKeys::kChildIndices)) {
+        j.at(InMemoryNodeMetadataKeys::kChildIndices).get_to(node.child_name_to_indices_map);
+    }
+    if (j.contains(InMemoryNodeMetadataKeys::kKind)) {
+        j.at(InMemoryNodeMetadataKeys::kKind).get_to(node.kind);
+    }
+}
+
+void to_json(json& j, const InMemoryFileSystemMetadata& fs) {
+    j = json { { InMemoryFileSystemMetadataKeys::kNodes, fs.nodes } };
+}
+
+void from_json(const json& j, InMemoryFileSystemMetadata& fs) {
+    if (j.contains(InMemoryFileSystemMetadataKeys::kNodes)) {
+        j.at(InMemoryFileSystemMetadataKeys::kNodes).get_to(fs.nodes);
+    }
+}
+
+static void write_metadata_to_stream(const InMemoryFileSystemMetadata& fs_metadata, std::ostream& stream) {
+    std::stringstream ss;
+    json value;
+    to_json(value, fs_metadata);
+    ss << value;
+    std::string metadata_json = ss.str();
+    // reverse it for writing
+    std::reverse(metadata_json.begin(), metadata_json.end());
+    stream << metadata_json;
+}
+
+void serialize(const InMemoryFileSystem& file_system,
+               const std::vector<std::string>& canonical_path,
+               size_t alignment,
+               std::ostream& ostream) noexcept {
+    InMemoryFileSystem::MetadataReader metadata_writer = [](const InMemoryFileSystemMetadata& fs_metadata,
+                                                            std::ostream& stream) {
+        write_metadata_to_stream(fs_metadata, stream);
+    };
+
+    file_system.serialize(canonical_path, alignment, metadata_writer, ostream);
+}
+
+size_t get_serialization_size(const InMemoryFileSystem& file_system,
+                              const std::vector<std::string>& canonical_path,
+                              size_t alignment) noexcept {
+    InMemoryFileSystem::MetadataReader metadata_writer = [](const InMemoryFileSystemMetadata& fs_metadata,
+                                                            std::ostream& stream) {
+        write_metadata_to_stream(fs_metadata, stream);
+    };
+
+    return file_system.get_serialization_size(canonical_path, alignment, metadata_writer);
+}
+
+std::unique_ptr<InMemoryFileSystem> make(const std::shared_ptr<MemoryBuffer>& buffer) noexcept {
+    InMemoryFileSystem::MetadataWriter metadata_reader = [](std::istream& stream) {
+        json metadata_json;
+        nlohmann::detail::json_sax_dom_parser<json> sdp(metadata_json, true);
+        if (!json::sax_parse(stream, &sdp, nlohmann::detail::input_format_t::json, false)) {
+            return std::optional<InMemoryFileSystemMetadata>();
+        }
+
+        InMemoryFileSystemMetadata metadata;
+        from_json(metadata_json, metadata);
+        return std::optional<InMemoryFileSystemMetadata>(std::move(metadata));
+    };
+
+    return InMemoryFileSystem::make(buffer, metadata_reader);
+}
+} // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.hpp
@@ -1,0 +1,45 @@
+//
+// inmemory_filesystem_utils.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include "inmemory_filesystem.hpp"
+
+namespace inmemoryfs {
+
+/// Serializes the item at the specified path and writes it to the stream.
+///
+/// The structure of the `InMemoryFileSystem` is identical to the structure of the filesystem at the
+/// specified path.
+///
+/// @param fs  The in-memory filesystem.
+/// @param canonical_path  The path components from the root.
+/// @param alignment  The offset alignment where an item is written to the stream.
+/// @param ostream   The output stream.
+void serialize(const InMemoryFileSystem& fs,
+               const std::vector<std::string>& canonical_path,
+               size_t alignment,
+               std::ostream& ostream) noexcept;
+
+/// Computes the size of the buffer that would be needed to serialized the item at the specified path.
+///
+/// @param fs  The in-memory filesystem.
+/// @param canonical_path  The path components from the root.
+/// @param alignment  The offset alignment where an item is written to the stream.
+/// @retval The size of the buffer that will be needed to write the item at the specified path.
+size_t get_serialization_size(const InMemoryFileSystem& fs,
+                              const std::vector<std::string>& canonical_path,
+                              size_t alignment) noexcept;
+
+/// Constructs an `InMemoryFileSystem` instance from the buffer contents.
+///
+/// @param buffer  The memory buffer.
+/// @retval The constructed `InMemoryFileSystem` or `nullptr` if the deserialization fail
+std::unique_ptr<InMemoryFileSystem> make(const std::shared_ptr<MemoryBuffer>& buffer) noexcept;
+
+
+} // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.mm
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.mm
@@ -1,0 +1,150 @@
+//
+// inmemory_filesystem_utils.mm
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <Foundation/Foundation.h>
+
+#import "inmemory_filesystem_utils.hpp"
+
+#import <iostream>
+#import <sstream>
+#import <unordered_map>
+
+#import <inmemory_filesystem_metadata.hpp>
+#import <inmemory_filesystem_metadata_keys.hpp>
+
+#import <objc_json_serde.h>
+#import <json_util.hpp>
+
+namespace executorchcoreml {
+namespace serde {
+namespace json {
+
+using namespace inmemoryfs;
+
+template <>
+struct JSONSerde<MemoryRegion> {
+    static id to_json(const MemoryRegion& region) {
+        return @{
+            to_string(MemoryRegionKeys::kOffset) : to_json_value(region.offset),
+            to_string(MemoryRegionKeys::kSize) : to_json_value(region.size)
+        };
+    }
+    
+    static void from_json(id json, MemoryRegion& region) {
+        NSDictionary<NSString *, id> *json_dict = SAFE_CAST(json, NSDictionary);
+        if (!json_dict) {
+            return;
+        }
+        
+        from_json_value(json_dict[to_string(MemoryRegionKeys::kOffset)], region.offset);
+        from_json_value(json_dict[to_string(MemoryRegionKeys::kSize)], region.size);
+    }
+};
+
+template <>
+struct JSONSerde<InMemoryNodeMetadata> {
+    static id to_json(const InMemoryNodeMetadata& node) {
+        return @{
+            to_string(InMemoryNodeMetadataKeys::kName) : to_json_value(node.name),
+            to_string(InMemoryNodeMetadataKeys::kDataRegion) : to_json_value(node.data_region),
+            to_string(InMemoryNodeMetadataKeys::kChildIndices) : to_json_value(node.child_name_to_indices_map),
+            to_string(InMemoryNodeMetadataKeys::kKind) : to_json_value(node.kind)
+        };
+    }
+    
+    static void from_json(id json, InMemoryNodeMetadata& node) {
+        NSDictionary<NSString *, id> *json_dict = SAFE_CAST(json, NSDictionary);
+        if (!json_dict) {
+            return;
+        }
+        
+        from_json_value(json_dict[to_string(InMemoryNodeMetadataKeys::kName)], node.name);
+        from_json_value(json_dict[to_string(InMemoryNodeMetadataKeys::kDataRegion)], node.data_region);
+        from_json_value(json_dict[to_string(InMemoryNodeMetadataKeys::kChildIndices)], node.child_name_to_indices_map);
+        from_json_value(json_dict[to_string(InMemoryNodeMetadataKeys::kKind)], node.kind);
+    }
+};
+
+template <>
+struct JSONSerde<InMemoryFileSystemMetadata> {
+    static id to_json(const InMemoryFileSystemMetadata& fs) {
+        return @{
+            to_string(InMemoryFileSystemMetadataKeys::kNodes) : to_json_value(fs.nodes)
+        };
+    }
+    
+    static void from_json(id json, InMemoryFileSystemMetadata& fs) {
+        NSDictionary<NSString *, id> *json_dict = SAFE_CAST(json, NSDictionary);
+        if (!json_dict) {
+            return;
+        }
+        
+        from_json_value(json_dict[to_string(InMemoryFileSystemMetadataKeys::kNodes)], fs.nodes);
+    }
+};
+
+} // namespace json
+} // namespace serde
+} // namespace executorchcoreml
+
+namespace {
+using namespace::inmemoryfs;
+
+void write_metadata_to_stream(const InMemoryFileSystemMetadata& metadata, std::ostream& stream) {
+    using namespace executorchcoreml::serde::json;
+    std::string json_string = to_json_string(JSONSerde<InMemoryFileSystemMetadata>::to_json(metadata));
+    std::reverse(json_string.begin(), json_string.end());
+    stream << json_string;
+}
+
+std::optional<InMemoryFileSystemMetadata> read_metadata_from_stream(std::istream& stream) {
+    using namespace executorchcoreml::serde::json;
+    auto json_object = executorchcoreml::json::read_object_from_stream(stream);
+    if (!json_object) {
+        return std::optional<InMemoryFileSystemMetadata>();
+    }
+    
+    InMemoryFileSystemMetadata metadata;
+    JSONSerde<InMemoryFileSystemMetadata>::from_json(to_json_object(json_object.value()), metadata);
+    return metadata;
+}
+
+} // namespace
+
+namespace inmemoryfs {
+
+void serialize(const InMemoryFileSystem& file_system,
+               const std::vector<std::string>& canonical_path,
+               size_t alignment,
+               std::ostream& ostream) noexcept {
+    InMemoryFileSystem::MetadataReader metadata_writer = [](const InMemoryFileSystemMetadata& fs_metadata,
+                                                            std::ostream& stream) {
+        ::write_metadata_to_stream(fs_metadata, stream);
+    };
+    
+    file_system.serialize(canonical_path, alignment, metadata_writer, ostream);
+}
+
+size_t get_serialization_size(const InMemoryFileSystem& file_system,
+                              const std::vector<std::string>& canonical_path,
+                              size_t alignment) noexcept {
+    InMemoryFileSystem::MetadataReader metadata_writer = [](const InMemoryFileSystemMetadata& fs_metadata,
+                                                            std::ostream& stream) {
+        ::write_metadata_to_stream(fs_metadata, stream);
+    };
+    
+    return file_system.get_serialization_size(canonical_path, alignment, metadata_writer);
+}
+
+std::unique_ptr<InMemoryFileSystem> make(const std::shared_ptr<MemoryBuffer>& buffer) noexcept {
+    InMemoryFileSystem::MetadataWriter metadata_reader = [](std::istream& stream) {
+        return ::read_metadata_from_stream(stream);
+    };
+    
+    return InMemoryFileSystem::make(buffer, metadata_reader);
+}
+} // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.cpp
@@ -98,11 +98,9 @@ std::streamsize ReversedIMemoryStreamBuf::xsgetn(char* s, std::streamsize n) {
         return std::streamsize(0);
     }
     std::ptrdiff_t offset = current_ - start_;
+    std::ptrdiff_t pos = buffer_->size() - 1 - offset;
     for (std::streamsize i = 0; i < n; i++) {
-        offset = offset + i;
-        // offset from the end
-        std::ptrdiff_t offsetFromEnd = buffer_->size() - offset - 1;
-        s[i] = start_[offsetFromEnd];
+        s[i] = start_[pos - i];
     }
     current_ += n;
     setg(start_, current_, current_);

--- a/backends/apple/coreml/runtime/inmemoryfs/setup.py
+++ b/backends/apple/coreml/runtime/inmemoryfs/setup.py
@@ -18,8 +18,10 @@ ext_modules = [
     Pybind11Extension(
         "executorchcoreml",
         [
+            "../util/json_util.cpp",
             "inmemory_filesystem.cpp",
             "inmemory_filesystem_py.cpp",
+            "inmemory_filesystem_utils.cpp",
             "memory_buffer.cpp",
             "memory_stream.cpp",
             "reversed_memory_stream.cpp",
@@ -30,6 +32,7 @@ ext_modules = [
         include_dirs=[
             "../../third-party/nlohmann_json/single_include/nlohmann",
             ".",
+            "../util",
         ],
     ),
 ]

--- a/backends/apple/coreml/runtime/kvstore/json_key_value_store.cpp
+++ b/backends/apple/coreml/runtime/kvstore/json_key_value_store.cpp
@@ -1,0 +1,22 @@
+//
+//  json_key_value_store.cpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#include <json_key_value_store.hpp>
+
+namespace executorchcoreml {
+namespace sqlite {
+
+std::string string_from_unowned_value(const sqlite::UnOwnedValue& value) {
+    auto unowned_string = std::get<sqlite::UnOwnedString>(value);
+    std::string result;
+    result.assign(unowned_string.data, unowned_string.size);
+    return result;
+}
+
+
+} // namespace sqlite
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/kvstore/key_value_store.hpp
+++ b/backends/apple/coreml/runtime/kvstore/key_value_store.hpp
@@ -278,10 +278,8 @@ public:
     /// @param error   On failure, error is populated with the failure reason.
     /// @param update_access_statistics   If it is `true` then the access statistics (access time and access count) are updated otherwise not.
     /// @retval The associated value for the key.
-    template<typename T>
+    template<typename T = Key>
     inline std::optional<Value> get(T&& key, std::error_code& error, bool update_access_statistics = true) noexcept {
-        static_assert(same_key<T>::value, "Key type is not supported.");
-        
         Value result;
         std::function<void(const UnOwnedValue&)> fn = [&result](const UnOwnedValue& value) {
             result = ValueConverter::from_sqlite_value(value);
@@ -299,10 +297,8 @@ public:
     /// @param key The key.
     /// @param error   On failure, error is populated with the failure reason.
     /// @retval `true` if the key exists in the store otherwise `false`.
-    template<typename T>
+    template<typename T = Key>
     inline bool exists(T&& key, std::error_code& error) noexcept {
-        static_assert(same_key<T>::value, "Key type is not supported.");
-        
         return impl_->exists(KeyConverter::to_sqlite_value(std::forward<T>(key)), error);
     }
     
@@ -312,11 +308,8 @@ public:
     /// @param value The value.
     /// @param error   On failure, error is populated with the failure reason.
     /// @retval `true` if the operation succeeded otherwise `false`.
-    template<typename T, typename U>
+    template<typename T = Key, typename U = Value>
     inline bool put(T&& key, U&& value, std::error_code& error) const noexcept {
-        static_assert(same_key<T>::value, "Key type is not supported.");
-        static_assert(same_value<U>::value, "Value type is not supported.");
-        
         return impl_->put(KeyConverter::to_sqlite_value(std::forward<T>(key)),
                           ValueConverter::to_sqlite_value(std::forward<U>(value)),
                           error);
@@ -365,9 +358,8 @@ public:
     /// @param key The key.
     /// @param error   On failure, error is populated with the failure reason.
     /// @retval `true` if the operation succeeded otherwise `false`.
-    template<typename T>
+    template<typename T = Key>
     inline bool remove(T&& key, std::error_code& error) noexcept {
-        static_assert(same_key<T>::value, "Key type is not supported");
         return impl_->remove(Converter<Key>::to_sqlite_value(std::forward<T>(key)), error);
     }
     

--- a/backends/apple/coreml/runtime/test/KeyValueStoreTests.mm
+++ b/backends/apple/coreml/runtime/test/KeyValueStoreTests.mm
@@ -14,6 +14,12 @@
 namespace {
 using json = nlohmann::json;
 
+struct Entry;
+
+void to_json(json& j, const Entry& entry) noexcept;
+
+void from_json(const json& j, Entry& entry) noexcept;
+
 struct Entry {
     inline Entry(std::string identifier, size_t count) noexcept
     :identifier(std::move(identifier)), count(count)
@@ -23,18 +29,31 @@ struct Entry {
     :identifier(""), count(0)
     {}
     
+    inline std::string to_json_string() const noexcept {
+        json j;
+        to_json(j, *this);
+        std::stringstream ss;
+        ss << j;
+        return ss.str();
+    }
+    
+    inline void from_json_string(const std::string& json_string) noexcept {
+        auto j = json::parse(json_string);
+        from_json(j, *this);
+    }
+    
     std::string identifier;
     size_t count;
 };
 
-void to_json(json& j, const Entry& entry) {
+void to_json(json& j, const Entry& entry) noexcept {
     j = json{
         {"identifier", entry.identifier},
         {"count", entry.count}
     };
 }
 
-void from_json(const json& j, Entry& entry) {
+void from_json(const json& j, Entry& entry) noexcept {
     j.at("identifier").get_to(entry.identifier);
     j.at("count").get_to(entry.count);
 }

--- a/backends/apple/coreml/runtime/util/json_util.cpp
+++ b/backends/apple/coreml/runtime/util/json_util.cpp
@@ -1,0 +1,90 @@
+//
+//  json_util.cpp
+//  util
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#include <json_util.hpp>
+
+namespace {
+
+struct JSONParseState {
+    int n_open_braces = 0;
+    std::string json_object;
+    bool reading_string = false;
+};
+
+bool is_quote_escaped(const std::vector<char>& buffer, size_t offset) {
+    return offset >= 1 && buffer[offset - 1] == '\\';
+}
+
+void process_quotes(const std::vector<char>& buffer, JSONParseState& state, size_t offset) {
+    // If we are reading a string and the quote is escaped then we don't mark it as the end of string.
+    if (state.reading_string && is_quote_escaped(buffer, offset)) {
+        return;
+    }
+    state.reading_string = !state.reading_string;
+}
+
+// Foundation has no streaming parser, so we try to read the top json object.
+// At this stage we don't care about the validity of json, the parser would
+// anyways fail if the json object is not valid.
+void read_object_from_buffer(std::vector<char>& buffer, JSONParseState& state) {
+    size_t offset = 0;
+    for (; offset < buffer.size() && state.n_open_braces > 0; offset++) {
+        switch (buffer[offset]) {
+            case '}': {
+                // If the close brace is inside a string then then ignore it.
+                state.n_open_braces -= (state.reading_string ? 0 : 1);
+                break;
+            }
+            case '{': {
+                // If the open brace is inside a string then ignore it.
+                state.n_open_braces += (state.reading_string ? 0 : 1);
+                break;
+            }
+            case '"': {
+                process_quotes(buffer, state, offset);
+                break;
+            }
+            default: {
+                break;
+            }
+        }
+    }
+
+    if (offset > 0) {
+        state.json_object.append(buffer.begin(), buffer.begin() + offset);
+    }
+}
+}
+
+namespace executorchcoreml {
+namespace json {
+
+std::optional<std::string> read_object_from_stream(std::istream& stream, size_t max_bytes_to_read) {
+    static constexpr size_t buffer_size = 512;
+    JSONParseState state;
+    char ch;
+    // The first character must be an opening brace.
+    if (!(stream >> ch) || ch != '{') {
+        return std::optional<std::string>();
+    }
+    state.json_object += ch;
+    state.n_open_braces = 1;
+
+    std::vector<char> buffer;
+    while (stream.good() && state.n_open_braces > 0 && state.json_object.size() < max_bytes_to_read) {
+        buffer.resize(buffer_size, '\0');
+        stream.read(buffer.data(), buffer_size);
+        read_object_from_buffer(buffer, state);
+        buffer.clear();
+    }
+
+    return state.n_open_braces == 0 ? state.json_object : std::optional<std::string>();
+}
+
+} // namespace json
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/util/json_util.hpp
+++ b/backends/apple/coreml/runtime/util/json_util.hpp
@@ -1,0 +1,30 @@
+//
+//  json_util.hpp
+//  util
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <iostream>
+#include <optional>
+#include <sstream>
+
+namespace executorchcoreml {
+namespace json {
+/// Reads and returns the first json object from the stream.
+///
+/// The returned string is not guaranteed to be a valid json object, the caller must
+/// use a JSON parser to parse the returned string into a json object.
+///
+///
+/// @param stream  The stream to read from.
+/// @param max_bytes_to_read  The maximum bytes that can be read from the stream.
+/// @retval The json object string or `nullopt` if there is no json object in the stream.
+std::optional<std::string> read_object_from_stream(std::istream& stream,
+                                                   size_t max_bytes_to_read = 10 * 1024 * 1024);
+
+} // namespace json
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/util/objc_json_serde.h
+++ b/backends/apple/coreml/runtime/util/objc_json_serde.h
@@ -1,0 +1,131 @@
+//
+//  objc_json_serde.h
+//  util
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+#import <map>
+#import <string>
+#import <unordered_map>
+#import <vector>
+
+#import <objc_safe_cast.h>
+
+namespace executorchcoreml {
+namespace serde {
+namespace json {
+
+inline NSString* to_string(std::string_view view) { return @(std::string(view).c_str()); }
+
+template <typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
+T to_scalar(NSNumber* value);
+
+template <> inline size_t to_scalar(NSNumber* value) { return value.unsignedLongLongValue; }
+
+template <> inline int64_t to_scalar(NSNumber* value) { return value.longLongValue; }
+
+id to_json_object(const std::string& json_string);
+
+std::string to_json_string(id json_object);
+
+template <typename T, typename Enable = void> struct JSONSerde { };
+
+template <typename T>
+using is_vector =
+    std::is_same<std::decay_t<T>,
+                 std::vector<typename std::decay_t<T>::value_type, typename std::decay_t<T>::allocator_type>>;
+
+template <typename T>
+using is_unordered_map = std::is_same<std::decay_t<T>,
+                                      std::unordered_map<typename std::decay_t<T>::key_type,
+                                                         typename std::decay_t<T>::mapped_type,
+                                                         typename std::decay_t<T>::hasher,
+                                                         typename std::decay_t<T>::key_equal,
+                                                         typename std::decay_t<T>::allocator_type>>;
+
+template <typename T> struct JSONSerde<T, typename std::enable_if<std::is_arithmetic_v<T>>::type> {
+    template <typename U = T> static id to_json(U&& value) { return @(value); }
+
+    static void from_json(id json_value, T& value) {
+        NSNumber* json_number = SAFE_CAST(json_value, NSNumber);
+        if (json_number) {
+            value = to_scalar<T>(json_number);
+        }
+    }
+};
+
+template <typename T> struct JSONSerde<T, typename std::enable_if<std::is_same_v<T, std::string>>::type> {
+    template <typename U = T> static id to_json(U&& value) { return @(value.c_str()); }
+
+    static void from_json(id json_value, T& value) {
+        NSString* json_string = SAFE_CAST(json_value, NSString);
+        if (json_string) {
+            value = json_string.UTF8String;
+        }
+    }
+};
+
+template <typename T> struct JSONSerde<T, typename std::enable_if<is_vector<T>::value>::type> {
+    using value_type = typename T::value_type;
+
+    template <typename U = T> static id to_json(U&& values) {
+        NSMutableArray<id>* result = [NSMutableArray arrayWithCapacity:values.size()];
+        for (auto it = values.begin(); it != values.end(); ++it) {
+            [result addObject:JSONSerde<value_type>::to_json(*it)];
+        }
+
+        return result;
+    }
+
+    static void from_json(id json_value, T& values) {
+        NSArray<id>* json_values = SAFE_CAST(json_value, NSArray);
+        for (id json_object in json_values) {
+            value_type value;
+            JSONSerde<value_type>::from_json(json_object, value);
+            values.emplace_back(std::move(value));
+        }
+    }
+};
+
+template <typename T> struct JSONSerde<T, std::enable_if_t<is_unordered_map<T>::value>> {
+    using value_type = typename T::mapped_type;
+    using key_type = typename T::key_type;
+
+    static_assert(std::is_same<key_type, std::string>::value, "key_type must be string");
+
+    template <typename U = T> static id to_json(U&& values) {
+        NSMutableDictionary<NSString*, id>* result = [NSMutableDictionary dictionaryWithCapacity:values.size()];
+        for (auto it = values.begin(); it != values.end(); ++it) {
+            result[@(it->first.c_str())] = JSONSerde<value_type>::to_json(it->second);
+        }
+
+        return result;
+    }
+
+    static void from_json(id json_value, T& values) {
+        NSDictionary<NSString*, id>* json_values = SAFE_CAST(json_value, NSDictionary);
+        for (NSString* key in json_values) {
+            value_type value;
+            JSONSerde<value_type>::from_json(json_values[key], value);
+            values.emplace(std::string(key.UTF8String), std::move(value));
+        }
+    }
+};
+
+template <typename T> inline id to_json_value(T&& value) {
+    return JSONSerde<typename std::decay_t<T>>::to_json(std::forward<T>(value));
+}
+
+template <typename T> void from_json_value(id json_value, T& value) {
+    return JSONSerde<T>::from_json(json_value, value);
+}
+
+} // namespace serde
+} // namespace json
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/util/objc_json_serde.mm
+++ b/backends/apple/coreml/runtime/util/objc_json_serde.mm
@@ -1,0 +1,38 @@
+//
+//  objc_json_serde.mm
+//  util
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+
+#import <objc_json_serde.h>
+
+namespace executorchcoreml {
+namespace serde {
+namespace json {
+
+id to_json_object(const std::string& json_string) {
+    auto bytes = const_cast<void *>(reinterpret_cast<const void *>(json_string.c_str()));
+    NSData *data = [[NSData alloc] initWithBytesNoCopy:bytes length:json_string.size() freeWhenDone:NO];
+    NSError *local_error = nil;
+    id object = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:&local_error];
+    NSCAssert(object != nil, @"Failed to deserialize json string=&@, error=%@", @(json_string.c_str()), local_error);
+    return object;
+}
+
+std::string to_json_string(id json_object) {
+    NSError *local_error = nil;
+    NSData *data = [NSJSONSerialization dataWithJSONObject:json_object options:(NSJSONWritingOptions)0 error:&local_error];
+    NSCAssert(data != nil, @"Failed to serialize json object=&@, error=%@", json_object, local_error);
+    NSString *json_string = [[NSString alloc] initWithBytesNoCopy:const_cast<void *>(data.bytes)
+                                                           length:data.length
+                                                         encoding:NSUTF8StringEncoding
+                                                     freeWhenDone:NO];
+    return json_string.UTF8String;
+}
+
+} // namespace json
+} // namespace serde
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/util/objc_safe_cast.h
+++ b/backends/apple/coreml/runtime/util/objc_safe_cast.h
@@ -1,0 +1,15 @@
+//
+//  objc_safe_cast.h
+//  util
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+inline id check_class(id obj, Class cls) { return [obj isKindOfClass:cls] ? obj : nil; }
+
+#define SAFE_CAST(Object, Type) ((Type*)check_class(Object, [Type class]))

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
@@ -32,6 +32,10 @@
 		C94D510C2ABDF84F00AF47FD /* serde_json.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DFB02AA123E9001CC178 /* serde_json.mm */; };
 		C94D510E2ABDF86800AF47FD /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C96560942AABFDCE005F8126 /* libsqlite3.tbd */; };
 		C94D510F2ABDF87500AF47FD /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C96560902AABF982005F8126 /* Accelerate.framework */; };
+		C97716B52AEA21B600FC0DAC /* inmemory_filesystem_utils.mm in Sources */ = {isa = PBXBuildFile; fileRef = C97716B32AEA1F9900FC0DAC /* inmemory_filesystem_utils.mm */; };
+		C97716D52AF41B2E00FC0DAC /* json_key_value_store.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C97716D42AF41B2E00FC0DAC /* json_key_value_store.cpp */; };
+		C97716DA2AF44CFA00FC0DAC /* json_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C97716D82AF44CFA00FC0DAC /* json_util.cpp */; };
+		C97716DD2AF44E7B00FC0DAC /* objc_json_serde.mm in Sources */ = {isa = PBXBuildFile; fileRef = C97716DC2AF44E7B00FC0DAC /* objc_json_serde.mm */; };
 		C985519E2AD2542D009143F9 /* mv3_coreml_all.pte in Resources */ = {isa = PBXBuildFile; fileRef = C98551982AD2542D009143F9 /* mv3_coreml_all.pte */; };
 		C985519F2AD2542D009143F9 /* mul_coreml_all.bin in Resources */ = {isa = PBXBuildFile; fileRef = C98551992AD2542D009143F9 /* mul_coreml_all.bin */; };
 		C98551A02AD2542D009143F9 /* add_coreml_all.bin in Resources */ = {isa = PBXBuildFile; fileRef = C985519A2AD2542D009143F9 /* add_coreml_all.bin */; };
@@ -88,12 +92,22 @@
 		C96560902AABF982005F8126 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/Accelerate.framework; sourceTree = DEVELOPER_DIR; };
 		C96560922AABF992005F8126 /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/CoreML.framework; sourceTree = DEVELOPER_DIR; };
 		C96560942AABFDCE005F8126 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
-		C96560982AAC0075005F8126 /* libgflags_nothreads_debug.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgflags_nothreads_debug.a; path = ../libraries/libgflags_nothreads_debug.a; sourceTree = "<group>"; };
 		C96560A32AAC0DCF005F8126 /* executorchcoreml_tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = executorchcoreml_tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C96560B12AAF7CC2005F8126 /* multiarray.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = multiarray.mm; path = ../delegate/multiarray.mm; sourceTree = "<group>"; };
 		C96560B22AAF9EA7005F8126 /* inmemory_filesystem_py.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = inmemory_filesystem_py.cpp; path = ../inmemoryfs/inmemory_filesystem_py.cpp; sourceTree = "<group>"; };
 		C9670FF92A82F0C800E7D441 /* MLMultiArray_Copy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MLMultiArray_Copy.h; path = ../delegate/MLMultiArray_Copy.h; sourceTree = "<group>"; };
 		C9670FFA2A82F0C800E7D441 /* MLMultiArray_Copy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MLMultiArray_Copy.mm; path = ../delegate/MLMultiArray_Copy.mm; sourceTree = "<group>"; };
+		C97716A82AE857C900FC0DAC /* inmemory_filesystem_metadata.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = inmemory_filesystem_metadata.hpp; path = ../inmemoryfs/inmemory_filesystem_metadata.hpp; sourceTree = "<group>"; };
+		C97716AA2AE85D4700FC0DAC /* inmemory_filesystem_metadata_keys.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = inmemory_filesystem_metadata_keys.hpp; path = ../inmemoryfs/inmemory_filesystem_metadata_keys.hpp; sourceTree = "<group>"; };
+		C97716B02AE9BBBA00FC0DAC /* inmemory_filesystem_utils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = inmemory_filesystem_utils.cpp; path = ../inmemoryfs/inmemory_filesystem_utils.cpp; sourceTree = "<group>"; };
+		C97716B12AE9BBBA00FC0DAC /* inmemory_filesystem_utils.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = inmemory_filesystem_utils.hpp; path = ../inmemoryfs/inmemory_filesystem_utils.hpp; sourceTree = "<group>"; };
+		C97716B32AEA1F9900FC0DAC /* inmemory_filesystem_utils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = inmemory_filesystem_utils.mm; path = ../inmemoryfs/inmemory_filesystem_utils.mm; sourceTree = "<group>"; };
+		C97716D42AF41B2E00FC0DAC /* json_key_value_store.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = json_key_value_store.cpp; path = ../kvstore/json_key_value_store.cpp; sourceTree = "<group>"; };
+		C97716D82AF44CFA00FC0DAC /* json_util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = json_util.cpp; path = ../util/json_util.cpp; sourceTree = "<group>"; };
+		C97716D92AF44CFA00FC0DAC /* json_util.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = json_util.hpp; path = ../util/json_util.hpp; sourceTree = "<group>"; };
+		C97716DB2AF44D9A00FC0DAC /* objc_json_serde.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = objc_json_serde.h; path = ../util/objc_json_serde.h; sourceTree = "<group>"; };
+		C97716DC2AF44E7B00FC0DAC /* objc_json_serde.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = objc_json_serde.mm; path = ../util/objc_json_serde.mm; sourceTree = "<group>"; };
+		C97716DE2AF44FC400FC0DAC /* objc_safe_cast.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = objc_safe_cast.h; path = ../util/objc_safe_cast.h; sourceTree = "<group>"; };
 		C98551982AD2542D009143F9 /* mv3_coreml_all.pte */ = {isa = PBXFileReference; lastKnownFileType = file; name = mv3_coreml_all.pte; path = ../test/models/mv3_coreml_all.pte; sourceTree = "<group>"; };
 		C98551992AD2542D009143F9 /* mul_coreml_all.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = mul_coreml_all.bin; path = ../test/models/mul_coreml_all.bin; sourceTree = "<group>"; };
 		C985519A2AD2542D009143F9 /* add_coreml_all.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = add_coreml_all.bin; path = ../test/models/add_coreml_all.bin; sourceTree = "<group>"; };
@@ -154,6 +168,7 @@
 		C95266222A7E05FB0016283E = {
 			isa = PBXGroup;
 			children = (
+				C97716D72AF44BCA00FC0DAC /* util */,
 				C9E7D7AE2AB6C0C000CCAE5D /* models */,
 				C9E7D7852AB3F99A00CCAE5D /* test */,
 				C9D3DEFF2A9FD150001CC178 /* kvstore */,
@@ -212,6 +227,9 @@
 			children = (
 				C95266442A7E06760016283E /* inmemory_filesystem.hpp */,
 				C95266452A7E06760016283E /* inmemory_filesystem.cpp */,
+				C97716B12AE9BBBA00FC0DAC /* inmemory_filesystem_utils.hpp */,
+				C97716B02AE9BBBA00FC0DAC /* inmemory_filesystem_utils.cpp */,
+				C97716B32AEA1F9900FC0DAC /* inmemory_filesystem_utils.mm */,
 				C96560B22AAF9EA7005F8126 /* inmemory_filesystem_py.cpp */,
 				C95266402A7E06760016283E /* memory_buffer.hpp */,
 				C95266472A7E06760016283E /* memory_buffer.cpp */,
@@ -219,6 +237,8 @@
 				C95266412A7E06760016283E /* memory_stream.cpp */,
 				C95266462A7E06760016283E /* reversed_memory_stream.hpp */,
 				C95266422A7E06760016283E /* reversed_memory_stream.cpp */,
+				C97716A82AE857C900FC0DAC /* inmemory_filesystem_metadata.hpp */,
+				C97716AA2AE85D4700FC0DAC /* inmemory_filesystem_metadata_keys.hpp */,
 			);
 			name = inmemoryfs;
 			sourceTree = "<group>";
@@ -239,11 +259,22 @@
 			children = (
 				C96560942AABFDCE005F8126 /* libsqlite3.tbd */,
 				C96560922AABF992005F8126 /* CoreML.framework */,
-				C96560982AAC0075005F8126 /* libgflags_nothreads_debug.a */,
 				C96560902AABF982005F8126 /* Accelerate.framework */,
 				C965608D2AABF72A005F8126 /* libexecutorch.a */,
 			);
 			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		C97716D72AF44BCA00FC0DAC /* util */ = {
+			isa = PBXGroup;
+			children = (
+				C97716D92AF44CFA00FC0DAC /* json_util.hpp */,
+				C97716D82AF44CFA00FC0DAC /* json_util.cpp */,
+				C97716DB2AF44D9A00FC0DAC /* objc_json_serde.h */,
+				C97716DC2AF44E7B00FC0DAC /* objc_json_serde.mm */,
+				C97716DE2AF44FC400FC0DAC /* objc_safe_cast.h */,
+			);
+			name = util;
 			sourceTree = "<group>";
 		};
 		C9D3DEFF2A9FD150001CC178 /* kvstore */ = {
@@ -254,6 +285,7 @@
 				C9D3DF092A9FD16F001CC178 /* sqlite_error.cpp */,
 				C9D3DF022A9FD16E001CC178 /* sqlite_error.hpp */,
 				C9D3DF042A9FD16E001CC178 /* json_key_value_store.hpp */,
+				C97716D42AF41B2E00FC0DAC /* json_key_value_store.cpp */,
 				C9D3DF082A9FD16F001CC178 /* key_value_store.hpp */,
 				C9D3DF052A9FD16E001CC178 /* key_value_store.cpp */,
 				C9D3DF002A9FD16E001CC178 /* statement.hpp */,
@@ -371,15 +403,19 @@
 				C94D50E72ABDF80D00AF47FD /* sqlite_error.cpp in Sources */,
 				C94D50FC2ABDF83500AF47FD /* ETCoreMLAsset.mm in Sources */,
 				C94D51062ABDF84400AF47FD /* ETCoreMLLogging.mm in Sources */,
+				C97716D52AF41B2E00FC0DAC /* json_key_value_store.cpp in Sources */,
 				C94D50F22ABDF82200AF47FD /* reversed_memory_stream.cpp in Sources */,
 				C94D51022ABDF83E00AF47FD /* ETCoreMLModelManager.mm in Sources */,
 				C94D50F42ABDF82500AF47FD /* asset.mm in Sources */,
+				C97716DA2AF44CFA00FC0DAC /* json_util.cpp in Sources */,
 				C94D51042ABDF84100AF47FD /* ETCoreMLStrings.mm in Sources */,
 				C9E7D7932AB3F9BF00CCAE5D /* ETCoreMLAssetManagerTests.mm in Sources */,
+				C97716B52AEA21B600FC0DAC /* inmemory_filesystem_utils.mm in Sources */,
 				C9E7D7922AB3F9BF00CCAE5D /* DatabaseTests.mm in Sources */,
 				C9E7D7902AB3F9BF00CCAE5D /* InMemoryFileSystemTests.mm in Sources */,
 				C9E7D7962AB3F9BF00CCAE5D /* KeyValueStoreTests.mm in Sources */,
 				C94D50E52ABDF80A00AF47FD /* database.cpp in Sources */,
+				C97716DD2AF44E7B00FC0DAC /* objc_json_serde.mm in Sources */,
 				C94D51082ABDF84800AF47FD /* MLModel_Prewarm.mm in Sources */,
 				C94D50F02ABDF81F00AF47FD /* memory_stream.cpp in Sources */,
 				C9E7D7A22AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm in Sources */,
@@ -532,8 +568,9 @@
 					"$(SRCROOT)/../delegate",
 					"$(SRCROOT)/../kvstore",
 					"$(SRCROOT)/../inmemoryfs",
-					"$(SRCROOT)/../../third-party/nlohmann_json/single_include/nlohmann",
 					"$(SRCROOT)/../include",
+					"$(SRCROOT)/../util",
+					"$(SRCROOT)/../../third-party/nlohmann_json/single_include/nlohmann",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../libraries";
@@ -560,8 +597,9 @@
 					"$(SRCROOT)/../delegate",
 					"$(SRCROOT)/../kvstore",
 					"$(SRCROOT)/../inmemoryfs",
-					"$(SRCROOT)/../../third-party/nlohmann_json/single_include/nlohmann",
 					"$(SRCROOT)/../include",
+					"$(SRCROOT)/../util",
+					"$(SRCROOT)/../../third-party/nlohmann_json/single_include/nlohmann",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../libraries";


### PR DESCRIPTION
The runtime uses` nlohmann` library for serializing and deserializing JSON but it increases the binary size of the CoreML runtime. 

- The changes remove the dependency and use Foundation for serializing and deserializing JSON.