### PR TITLE
Update Explicit __init__ for SDK and propagate import paths

### DIFF
--- a/examples/sdk/scripts/gen_sample_etrecord.py
+++ b/examples/sdk/scripts/gen_sample_etrecord.py
@@ -17,7 +17,7 @@ from executorch.exir import (
     ExportedProgram,
     to_edge,
 )
-from executorch.sdk.etrecord import generate_etrecord
+from executorch.sdk import generate_etrecord
 from torch.export import export
 
 from ...models import MODEL_NAME_TO_MODEL

--- a/sdk/TARGETS
+++ b/sdk/TARGETS
@@ -7,6 +7,6 @@ python_library(
     srcs = ["__init__.py"],
     deps = [
         "//executorch/sdk/etrecord:etrecord",
-        "//executorch/sdk/inspector:inspector",
+        "//executorch/sdk/inspector:lib",
     ],
 )

--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -4,12 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from executorch.sdk.etrecord._etrecord import (
-    ETRecord,
-    generate_etrecord,
-    parse_etrecord,
-)
+import executorch.sdk.inspector as inspector
+from executorch.sdk.etrecord import ETRecord, generate_etrecord, parse_etrecord
+from executorch.sdk.inspector import Inspector
 
-from executorch.sdk.inspector.inspector import Inspector, TimeScale
-
-__all__ = ["ETRecord", "generate_etrecord", "parse_etrecord", "Inspector", "TimeScale"]
+__all__ = ["ETRecord", "Inspector", "generate_etrecord", "parse_etrecord", "inspector"]

--- a/sdk/inspector/TARGETS
+++ b/sdk/inspector/TARGETS
@@ -6,7 +6,7 @@ oncall("executorch")
 python_library(
     name = "inspector",
     srcs = [
-        "inspector.py",
+        "_inspector.py",
     ],
     deps = [
         "fbsource//third-party/pypi/ipython:ipython",
@@ -26,7 +26,7 @@ python_binary(
     name = "inspector_cli",
     main_src = "inspector_cli.py",
     deps = [
-        ":inspector",
+        "//executorch/sdk:lib",
     ],
 )
 
@@ -41,5 +41,13 @@ python_library(
         "//executorch/sdk/etdump:schema_flatcc",
         "//executorch/sdk/etdump:serialize",
         "//executorch/sdk/etrecord:etrecord",
+    ],
+)
+
+python_library(
+    name = "lib",
+    srcs = ["__init__.py"],
+    deps = [
+        ":inspector",
     ],
 )

--- a/sdk/inspector/__init__.py
+++ b/sdk/inspector/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from executorch.sdk.inspector._inspector import (
+    Event,
+    EventBlock,
+    Inspector,
+    PerfData,
+    TimeScale,
+)
+
+__all__ = ["Event", "EventBlock", "Inspector", "PerfData", "TimeScale"]

--- a/sdk/inspector/_inspector.py
+++ b/sdk/inspector/_inspector.py
@@ -10,7 +10,6 @@ from collections import defaultdict, OrderedDict
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
-    Any,
     Dict,
     List,
     Mapping,

--- a/sdk/inspector/inspector_cli.py
+++ b/sdk/inspector/inspector_cli.py
@@ -6,7 +6,7 @@
 
 import argparse
 
-from executorch.sdk.inspector.inspector import Inspector
+from executorch.sdk import Inspector
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/sdk/inspector/tests/TARGETS
+++ b/sdk/inspector/tests/TARGETS
@@ -7,10 +7,11 @@ python_unittest(
     srcs = ["inspector_test.py"],
     deps = [
         "//executorch/exir:lib",
+        "//executorch/sdk:lib",
         "//executorch/sdk/debug_format:et_schema",
-        "//executorch/sdk/etrecord:etrecord",
         "//executorch/sdk/etrecord/tests:etrecord_test_library",
         "//executorch/sdk/inspector:inspector",
+        "//executorch/sdk/inspector:lib",
     ],
 )
 
@@ -20,6 +21,7 @@ python_unittest(
     deps = [
         "//executorch/sdk/etdump:schema_flatcc",
         "//executorch/sdk/inspector:inspector",
+        "//executorch/sdk/inspector:lib",
     ],
 )
 
@@ -27,9 +29,9 @@ python_unittest(
     name = "inspector_utils_test",
     srcs = ["inspector_utils_test.py"],
     deps = [
+        "//executorch/sdk:lib",
         "//executorch/sdk/debug_format:base_schema",
         "//executorch/sdk/debug_format:et_schema",
-        "//executorch/sdk/etrecord:etrecord",
         "//executorch/sdk/etrecord/tests:etrecord_test_library",
         "//executorch/sdk/inspector:inspector_utils",
     ],

--- a/sdk/inspector/tests/event_blocks_test.py
+++ b/sdk/inspector/tests/event_blocks_test.py
@@ -10,13 +10,8 @@ from typing import List, Optional, Tuple, Union
 
 import executorch.sdk.etdump.schema_flatcc as flatcc
 from executorch.sdk.etdump.schema_flatcc import ETDumpFlatCC, ProfileEvent
-from executorch.sdk.inspector.inspector import (
-    DelegateMetadata,
-    Event,
-    EventBlock,
-    PerfData,
-    ProfileEventSignature,
-)
+from executorch.sdk.inspector import Event, EventBlock, PerfData
+from executorch.sdk.inspector._inspector import DelegateMetadata, ProfileEventSignature
 
 
 class TestEventBlock(unittest.TestCase):

--- a/sdk/inspector/tests/inspector_test.py
+++ b/sdk/inspector/tests/inspector_test.py
@@ -15,13 +15,11 @@ from typing import List
 from unittest.mock import patch
 
 from executorch.exir import ExportedProgram
+from executorch.sdk import generate_etrecord, parse_etrecord
 from executorch.sdk.debug_format.et_schema import OperatorNode
-from executorch.sdk.etrecord import generate_etrecord, parse_etrecord
 from executorch.sdk.etrecord.tests.etrecord_test import TestETRecord
 
-from executorch.sdk.inspector import inspector
-
-from executorch.sdk.inspector.inspector import Event, EventBlock, Inspector, PerfData
+from executorch.sdk.inspector import _inspector, Event, EventBlock, Inspector, PerfData
 
 
 OP_TYPE = "aten::add"
@@ -54,13 +52,13 @@ class TestInspector(unittest.TestCase):
     def test_inspector_constructor(self):
         # Create a context manager to patch functions called by Inspector.__init__
         with patch.object(
-            inspector, "parse_etrecord", return_value=None
+            _inspector, "parse_etrecord", return_value=None
         ) as mock_parse_etrecord, patch.object(
-            inspector, "gen_etdump_object", return_value=None
+            _inspector, "gen_etdump_object", return_value=None
         ) as mock_gen_etdump, patch.object(
             EventBlock, "_gen_from_etdump"
         ) as mock_gen_from_etdump, patch.object(
-            inspector, "gen_graphs_from_etrecord"
+            _inspector, "gen_graphs_from_etrecord"
         ) as mock_gen_graphs_from_etrecord:
             # Call the constructor of Inspector
             Inspector(
@@ -77,10 +75,14 @@ class TestInspector(unittest.TestCase):
 
     def test_inspector_print_data_tabular(self):
         # Create a context manager to patch functions called by Inspector.__init__
-        with patch.object(inspector, "parse_etrecord", return_value=None), patch.object(
-            inspector, "gen_etdump_object", return_value=None
-        ), patch.object(EventBlock, "_gen_from_etdump"), patch.object(
-            inspector, "gen_graphs_from_etrecord"
+        with patch.object(
+            _inspector, "parse_etrecord", return_value=None
+        ), patch.object(
+            _inspector, "gen_etdump_object", return_value=None
+        ), patch.object(
+            EventBlock, "_gen_from_etdump"
+        ), patch.object(
+            _inspector, "gen_graphs_from_etrecord"
         ):
             # Call the constructor of Inspector
             inspector_instance = Inspector(
@@ -183,12 +185,16 @@ class TestInspector(unittest.TestCase):
 
     def test_inspector_get_exported_program(self):
         # Create a context manager to patch functions called by Inspector.__init__
-        with patch.object(inspector, "parse_etrecord", return_value=None), patch.object(
-            inspector, "gen_etdump_object", return_value=None
-        ), patch.object(EventBlock, "_gen_from_etdump"), patch.object(
-            inspector, "gen_graphs_from_etrecord"
+        with patch.object(
+            _inspector, "parse_etrecord", return_value=None
         ), patch.object(
-            inspector, "create_debug_handle_to_op_node_mapping"
+            _inspector, "gen_etdump_object", return_value=None
+        ), patch.object(
+            EventBlock, "_gen_from_etdump"
+        ), patch.object(
+            _inspector, "gen_graphs_from_etrecord"
+        ), patch.object(
+            _inspector, "create_debug_handle_to_op_node_mapping"
         ):
             # Call the constructor of Inspector
             inspector_instance = Inspector(

--- a/sdk/inspector/tests/inspector_utils_test.py
+++ b/sdk/inspector/tests/inspector_utils_test.py
@@ -8,6 +8,8 @@ import tempfile
 import unittest
 from typing import Dict, Tuple
 
+from executorch.sdk import generate_etrecord, parse_etrecord
+
 from executorch.sdk.debug_format.base_schema import (
     OperatorGraph,
     OperatorNode,
@@ -15,7 +17,6 @@ from executorch.sdk.debug_format.base_schema import (
 )
 
 from executorch.sdk.debug_format.et_schema import FXOperatorGraph
-from executorch.sdk.etrecord import generate_etrecord, parse_etrecord
 
 from executorch.sdk.etrecord.tests.etrecord_test import TestETRecord
 from executorch.sdk.inspector._inspector_utils import (

--- a/sdk/size_analysis_tool/TARGETS
+++ b/sdk/size_analysis_tool/TARGETS
@@ -12,7 +12,7 @@ python_library(
         "//caffe2:torch",
         "//executorch/exir:lib",
         "//executorch/exir/backend:backend_api",
-        "//executorch/sdk/etrecord:etrecord",
+        "//executorch/sdk:lib",
     ],
 )
 
@@ -27,7 +27,7 @@ python_binary(
         "//caffe2:torch",
         "//executorch/exir:lib",
         "//executorch/exir/backend:backend_api",
-        "//executorch/sdk/etrecord:etrecord",
+        "//executorch/sdk:lib",
     ],
 )
 
@@ -44,6 +44,6 @@ python_unittest(
         "//executorch/exir:lib",
         "//executorch/exir/backend:backend_api",
         "//executorch/exir/passes:spec_prop_pass",
-        "//executorch/sdk/etrecord:etrecord",
+        "//executorch/sdk:lib",
     ],
 )

--- a/sdk/size_analysis_tool/size_analysis_tool.py
+++ b/sdk/size_analysis_tool/size_analysis_tool.py
@@ -12,7 +12,7 @@ import torch
 
 from executorch.exir import ExportedProgram
 from executorch.exir.backend.backend_api import LoweredBackendModule
-from executorch.sdk.etrecord import parse_etrecord
+from executorch.sdk import parse_etrecord
 
 
 def _get_tensor_data(node: torch.fx.Node, tensor: torch.Tensor) -> Dict[str, Any]:


### PR DESCRIPTION
Summary:
Based on the design linked below, this diff updates the `__init__.py` of SDK and Inspector to provide clear import paths for users

In addition, it renames `inspector.py` -> `_inspector.py` to deter manual access
  - With exception of tests

---

Note:
- Outside of the ETRecord folders, no one should be using `from executorch.sdk.etrecord import ...`
- Updating SDK file names to deter import ("_") will be done in separate diffs

---

Design: https://docs.google.com/document/d/1ugPAPmKzc0oOeL9Vjssgx1UvQP6KxdDJK06wFRHtgAU/edit

Reviewed By: tarun292

Differential Revision: D50943994


