### PR TITLE
Move timescale validation earlier in Inspector Constructor

### DIFF
--- a/sdk/inspector/TARGETS
+++ b/sdk/inspector/TARGETS
@@ -49,5 +49,6 @@ python_library(
     srcs = ["__init__.py"],
     deps = [
         ":inspector",
+        ":inspector_utils",
     ],
 )

--- a/sdk/inspector/__init__.py
+++ b/sdk/inspector/__init__.py
@@ -4,12 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from executorch.sdk.inspector._inspector import (
-    Event,
-    EventBlock,
-    Inspector,
-    PerfData,
-    TimeScale,
-)
+from executorch.sdk.inspector._inspector import Event, EventBlock, Inspector, PerfData
+from executorch.sdk.inspector._inspector_utils import TimeScale
 
 __all__ = ["Event", "EventBlock", "Inspector", "PerfData", "TimeScale"]

--- a/sdk/inspector/_inspector.py
+++ b/sdk/inspector/_inspector.py
@@ -427,6 +427,15 @@ class Inspector:
             None
         """
 
+        if (source_time_scale == TimeScale.CYCLES) ^ (
+            target_time_scale == TimeScale.CYCLES
+        ):
+            raise RuntimeError(
+                "For TimeScale in cycles both the source and target time scale have to be in cycles."
+            )
+        self._source_time_scale = source_time_scale
+        self._target_time_scale = target_time_scale
+
         if etrecord is None:
             self._etrecord = None
         elif isinstance(etrecord, ETRecord):
@@ -437,15 +446,6 @@ class Inspector:
             raise TypeError("Unsupported ETRecord type")
 
         etdump = gen_etdump_object(etdump_path=etdump_path)
-        if (source_time_scale == TimeScale.CYCLES) ^ (
-            target_time_scale == TimeScale.CYCLES
-        ):
-            raise RuntimeError(
-                "For TimeScale in cycles both the source and target time scale have to be in cycles."
-            )
-
-        self._source_time_scale = source_time_scale
-        self._target_time_scale = target_time_scale
         self.event_blocks = EventBlock._gen_from_etdump(
             etdump, self._source_time_scale, self._target_time_scale
         )

--- a/sdk/inspector/_inspector.py
+++ b/sdk/inspector/_inspector.py
@@ -8,7 +8,6 @@ import dataclasses
 import logging
 from collections import defaultdict, OrderedDict
 from dataclasses import dataclass
-from enum import Enum
 from typing import (
     Dict,
     List,
@@ -32,26 +31,17 @@ from executorch.sdk.etrecord import ETRecord, parse_etrecord
 from executorch.sdk.inspector._inspector_utils import (
     create_debug_handle_to_op_node_mapping,
     EDGE_DIALECT_GRAPH_KEY,
+    EXCLUDED_COLUMNS_WHEN_PRINTING,
+    EXCLUDED_EVENTS_WHEN_PRINTING,
+    FORWARD,
     gen_etdump_object,
     gen_graphs_from_etrecord,
+    RESERVED_FRAMEWORK_EVENT_NAMES,
+    TIME_SCALE_DICT,
+    TimeScale,
 )
 
 from tabulate import tabulate
-
-FORWARD = "forward"
-RESERVED_FRAMEWORK_EVENT_NAMES = [
-    "Method::init",
-    "Program::load_method",
-    "Method::execute",
-]
-EXCLUDED_COLUMNS_WHEN_PRINTING = [
-    "raw",
-    "delegate_debug_identifier",
-    "stack_traces",
-    "module_hierarchy",
-    "debug_data",
-]
-EXCLUDED_EVENTS_WHEN_PRINTING = {"OPERATOR_CALL"}
 
 
 log: logging.Logger = logging.getLogger(__name__)
@@ -94,23 +84,6 @@ DelegateMetadata = TypedDict(
     "DelegateMetadata",
     {"name": str, "delegate_map": DelegateIdentifierDebugHandleMap},
 )
-
-
-class TimeScale(Enum):
-    NS = "ns"
-    US = "us"
-    MS = "ms"
-    S = "s"
-    CYCLES = "cycles"
-
-
-time_scale_dict = {
-    TimeScale.NS: 1000000000,
-    TimeScale.US: 1000000,
-    TimeScale.MS: 1000,
-    TimeScale.S: 1,
-    TimeScale.CYCLES: 1,
-}
 
 
 @dataclass
@@ -352,7 +325,7 @@ class EventBlock:
                 run_signature_events.setdefault(event_signature, []).append(event)
 
         scale_factor = (
-            time_scale_dict[source_time_scale] / time_scale_dict[target_time_scale]
+            TIME_SCALE_DICT[source_time_scale] / TIME_SCALE_DICT[target_time_scale]
         )
         # Create EventBlocks from the Profile Run Groups
         return [

--- a/sdk/inspector/_inspector_utils.py
+++ b/sdk/inspector/_inspector_utils.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from enum import Enum
 from typing import Dict, Mapping, Optional
 
 from executorch.sdk.debug_format.base_schema import OperatorNode
@@ -14,7 +15,39 @@ from executorch.sdk.etdump.schema_flatcc import ETDumpFlatCC
 from executorch.sdk.etdump.serialize import deserialize_from_etdump_flatcc
 from executorch.sdk.etrecord import ETRecord
 
+FORWARD = "forward"
 EDGE_DIALECT_GRAPH_KEY = "edge_dialect_graph_module"
+
+RESERVED_FRAMEWORK_EVENT_NAMES = [
+    "Method::init",
+    "Program::load_method",
+    "Method::execute",
+]
+EXCLUDED_COLUMNS_WHEN_PRINTING = [
+    "raw",
+    "delegate_debug_identifier",
+    "stack_traces",
+    "module_hierarchy",
+    "debug_data",
+]
+EXCLUDED_EVENTS_WHEN_PRINTING = {"OPERATOR_CALL"}
+
+
+class TimeScale(Enum):
+    NS = "ns"
+    US = "us"
+    MS = "ms"
+    S = "s"
+    CYCLES = "cycles"
+
+
+TIME_SCALE_DICT = {
+    TimeScale.NS: 1000000000,
+    TimeScale.US: 1000000,
+    TimeScale.MS: 1000,
+    TimeScale.S: 1,
+    TimeScale.CYCLES: 1,
+}
 
 
 def gen_graphs_from_etrecord(


### PR DESCRIPTION
Summary: Moved to fail faster, cheap sanity checks should be done prior to expensive sanity checks that require parsing

Reviewed By: Olivia-liu

Differential Revision: D51042483


