### PR TITLE
enforce dtype in partitioner

### DIFF
--- a/backends/xnnpack/test/test_xnnpack.py
+++ b/backends/xnnpack/test/test_xnnpack.py
@@ -570,6 +570,7 @@ class TestXNNPACKFloatingPoint(TestXNNPACK):
 
         self.lower_and_test_with_partitioner(maxpool2d_module, model_inputs)
 
+    @unittest.expectedFailure
     def test_xnnpack_backend_max_dim_vals(self):
         class MaxModule(torch.nn.Module):
             def __init__(


### PR DESCRIPTION
Summary:
Filter nodes based on dtype for partitioner. We add a common constraint for nodes in our partitioner that forces filters out nodes with incoming and outgoing edges with dtypes that do not fall in the following set:

{torch.float32, torch.float16, torch.int8, torch.qint8, torch.quint8, torch.qint32}

This constraint fails to partition max pool with indices since the output of the indicies tensors is int64. We will temporarily remove this from being enabled

Differential Revision: D50996209


