### PR TITLE
Add temp allocator to backend.execute

### DIFF
--- a/runtime/backend/backend_execution_context.h
+++ b/runtime/backend/backend_execution_context.h
@@ -9,19 +9,20 @@
 #pragma once
 
 #include <executorch/runtime/core/event_tracer.h>
+#include <executorch/runtime/core/memory_allocator.h>
 
 namespace torch {
 namespace executor {
 
 /**
  * BackendExecutionContext will be used to inject run time context.
- * The current plan is to add temp allocator and event tracer (for profiling) as
- * part of the runtime context.
  */
 class BackendExecutionContext final {
  public:
-  BackendExecutionContext(EventTracer* event_tracer = nullptr)
-      : event_tracer_(event_tracer) {}
+  BackendExecutionContext(
+      EventTracer* event_tracer = nullptr,
+      MemoryAllocator* temp_allocator = nullptr)
+      : event_tracer_(event_tracer), temp_allocator_(temp_allocator) {}
 
   /**
    * Returns a pointer to an instance of EventTracer to do profiling/debugging
@@ -32,8 +33,21 @@ class BackendExecutionContext final {
     return event_tracer_;
   }
 
+  /**
+   * Returns a pointer to the address allocated by temp allocator. This
+   * allocator will be reset after every delegate call during execution.
+   */
+  void* allocate(
+      size_t size,
+      size_t alignment = MemoryAllocator::kDefaultAlignment) {
+    // TODO(chenlai): depends on the need, we may expose more functionality for
+    // memory allocation.
+    return temp_allocator_->allocate(size, alignment);
+  }
+
  private:
   EventTracer* event_tracer_ = nullptr;
+  MemoryAllocator* temp_allocator_ = nullptr;
 };
 
 } // namespace executor

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -975,7 +975,6 @@ Error Method::execute_instruction() {
       bool jf_result = parse_cond_value(values_[jf_call->cond_value_index()]);
       if (!jf_result) {
         next_instr_idx = jf_call->destination_instruction();
-        // return Error::Ok;
       }
     } break;
     case executorch_flatbuffer::InstructionArguments::MoveCall: {
@@ -998,6 +997,10 @@ Error Method::execute_instruction() {
           false,
           "Instruction is not supported. %hhu",
           static_cast<uint8_t>(instruction->instr_args_type()));
+  }
+  // Reset the temp allocator for every instruction.
+  if (memory_manager_->temp_allocator() != nullptr) {
+    memory_manager_->temp_allocator()->reset();
   }
   if (err == Error::Ok) {
     step_state_.instr_idx = next_instr_idx;


### PR DESCRIPTION
Summary: As plan, we're adding temp allocator to the `BackendExecutionContext`.

Differential Revision: D51178938


