### PR TITLE
Fix lint error in examples/xnnpack/quantization:example

### DIFF
--- a/examples/xnnpack/quantization/example.py
+++ b/examples/xnnpack/quantization/example.py
@@ -136,7 +136,7 @@ def main() -> None:
     # See if we have quantized op out variants registered
     has_out_ops = True
     try:
-        op = torch.ops.quantized_decomposed.add.out
+        torch.ops.quantized_decomposed.add.out
     except AttributeError:
         logging.info("No registered quantized ops")
         has_out_ops = False


### PR DESCRIPTION
Summary: "local variable 'op' is assigned to but never used"

Differential Revision: D51204688


