### PR TITLE
Ignore licenselint for llama2 example in Executorch

### DIFF
--- a/backends/xnnpack/test/tester/tester.py
+++ b/backends/xnnpack/test/tester/tester.py
@@ -261,7 +261,7 @@ class ToExecutorch(Stage):
 
     def dump_artifact(self, path_to_dump: Optional[str]):
         """
-        dump_artifact is overriden to dump the serialized program
+        dump_artifact is overridden to dump the serialized program
         """
         original_stdout = sys.stdout
 

--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -1,3 +1,4 @@
+# @lint-ignore-every LICENSELINT
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #


### PR DESCRIPTION
Summary:
llama2 as its own specific license. Will ignore the fbcode-wide licenselint for that file.

https://www.internalfb.com/code/fbsource/[def2f612b7200f78b46041779e8ee7f13b76e247]/fbcode/executorch/examples/models/llama2/model.py

Reviewed By: zertosh

Differential Revision: D51164249


