### PR TITLE
Fix lint error

### DIFF
--- a/examples/xnnpack/quantization/example.py
+++ b/examples/xnnpack/quantization/example.py
@@ -136,7 +136,7 @@ def main() -> None:
     # See if we have quantized op out variants registered
     has_out_ops = True
     try:
-        _op = torch.ops.quantized_decomposed.add.out
+        _ = torch.ops.quantized_decomposed.add.out
     except AttributeError:
         logging.info("No registered quantized ops")
         has_out_ops = False

--- a/examples/xnnpack/quantization/example.py
+++ b/examples/xnnpack/quantization/example.py
@@ -136,7 +136,7 @@ def main() -> None:
     # See if we have quantized op out variants registered
     has_out_ops = True
     try:
-        op = torch.ops.quantized_decomposed.add.out
+        _op = torch.ops.quantized_decomposed.add.out
     except AttributeError:
         logging.info("No registered quantized ops")
         has_out_ops = False


### PR DESCRIPTION
Fix "local variable 'op' is assigned to but never used".