### PR TITLE
Add oncall for targets owned by executorch

### DIFF
--- a/exir/TARGETS
+++ b/exir/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
+oncall("executorch")
+
 python_library(
     name = "tracer",
     srcs = [

--- a/extension/pybindings/TARGETS
+++ b/extension/pybindings/TARGETS
@@ -5,6 +5,8 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbsource//xplat/executorch/extension/pybindings:pybindings.bzl", "ATEN_MODULE_DEPS", "MODELS_ATEN_OPS_ATEN_MODE_GENERATED_LIB", "MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB", "PORTABLE_MODULE_DEPS", "executorch_pybindings")
 
+oncall("executorch")
+
 # Export this so the internal fb/ subdir can create pybindings with custom internal deps
 # without forking the pybinding source.
 runtime.export_file(

--- a/extension/pytree/TARGETS
+++ b/extension/pytree/TARGETS
@@ -6,6 +6,8 @@ load("@fbcode_macros//build_defs:cpp_python_extension.bzl", "cpp_python_extensio
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()
 
 cpp_python_extension(

--- a/profiler/test/TARGETS
+++ b/profiler/test/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
 
+oncall("executorch")
+
 # Ideally this should be a python_unittest but we cannot do that as
 # we have to run this python test with a buck config flag which is
 # -c executorch.prof_enabled=true. So we instead define this as a

--- a/runtime/executor/test/TARGETS
+++ b/runtime/executor/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets(is_fbcode = True)

--- a/test/end2end/TARGETS
+++ b/test/end2end/TARGETS
@@ -3,6 +3,8 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 
+oncall("executorch")
+
 python_library(
     name = "exported_module",
     srcs = [

--- a/test/models/TARGETS
+++ b/test/models/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()


### PR DESCRIPTION
Summary: Defines in executorch_* contbuild configs

Reviewed By: JacobSzwejbka, pcerl017

Differential Revision: D51213792


