### PR TITLE
Slight refactor of ETRecord Consumption

### DIFF
--- a/sdk/inspector/tests/inspector_utils_test.py
+++ b/sdk/inspector/tests/inspector_utils_test.py
@@ -52,9 +52,8 @@ class TestInspectorUtils(unittest.TestCase):
             self.assertTrue(isinstance(graphs[EDGE_DIALECT_GRAPH_KEY], FXOperatorGraph))
 
     def test_create_debug_handle_to_op_node_mapping(self):
-        debug_handle_to_op_node_map = {}
         graph, expected_mapping = gen_mock_operator_graph_with_expected_map()
-        create_debug_handle_to_op_node_mapping(graph, debug_handle_to_op_node_map)
+        debug_handle_to_op_node_map = create_debug_handle_to_op_node_mapping(graph)
 
         self.assertEqual(debug_handle_to_op_node_map, expected_mapping)
 


### PR DESCRIPTION
Summary:
This diff makes 2 main changes:
- Updates `create_debug_handle_to_op_node_mapping` to construct the dictionary internally
- Moves ETRecord related logic in `Inspector's` constructor into a separate function

Reviewed By: Olivia-liu

Differential Revision: D51135613


