### PR TITLE
[Executorch][EXIR] Few fixes to export to enable exporting sam

### DIFF
--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -28,6 +28,26 @@ from executorch.extension.pybindings.portable_lib import (
 )
 from torch.export import export, ExportedProgram
 
+from torch.library import impl, Library
+
+lib = Library("test_op", "DEF")
+
+# Fake a operator for testing.
+# This operator takes two tensors as input and returns the first one.
+lib.define("foo(Tensor self, Tensor other) -> Tensor")
+
+
+@impl(lib, "foo", "CPU")
+def foo(a, b):
+    # do nothing and return a.
+    return a + b
+
+
+@impl(lib, "foo", "Meta")
+def foo_meta(a, b):
+    # do nothing and return a.
+    return torch.empty_like(a)
+
 
 def get_exported_programs() -> Dict[str, ExportedProgram]:
     def forward(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
@@ -299,3 +319,31 @@ class TestProgramManagers(unittest.TestCase):
             get_exported_programs(), get_config_methods()
         )
         self.assertTrue(edge_manager.exported_program().dialect == "EDGE")
+
+    def _test_edge_dialect_verifier(self, callable, validate_ir=True):
+        from executorch.exir import EdgeCompileConfig
+
+        edge_compile_config = EdgeCompileConfig(
+            _check_ir_validity=validate_ir,
+        )
+        # pre-autograd export. eventually this will become torch.export
+        one = torch.ones(1, dtype=torch.float)
+        two = torch.ones(1, dtype=torch.int32)
+        inputs = (
+            one,
+            two,
+        )
+        exported_foo = export(callable, inputs)
+        _ = to_edge(exported_foo, compile_config=edge_compile_config)
+
+    def test_edge_dialect_custom_op(self):
+        def _use_foo_add(a: torch.Tensor, b: torch.Tensor):
+            return torch.ops.test_op.foo(a, b)
+
+        from torch._export.verifier import SpecViolationError
+
+        with self.assertRaises(SpecViolationError) as cm:
+            self._test_edge_dialect_verifier(_use_foo_add)
+
+        # This should not raise error
+        self._test_edge_dialect_verifier(_use_foo_add, False)

--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -342,7 +342,7 @@ class TestProgramManagers(unittest.TestCase):
 
         from torch._export.verifier import SpecViolationError
 
-        with self.assertRaises(SpecViolationError) as cm:
+        with self.assertRaises(SpecViolationError):
             self._test_edge_dialect_verifier(_use_foo_add)
 
         # This should not raise error

--- a/exir/verification/verifier.py
+++ b/exir/verification/verifier.py
@@ -173,6 +173,8 @@ def EXIREdgeDialectVerifier(  # noqa: C901
                         op.__module__, op.__name__
                     )
                 )
+            if isinstance(op, EdgeOpOverload):
+                self.check_valid_aten_op(op._op)
             if isinstance(op, types.FunctionType):
                 assert op.__name__ in ("alloc",)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1205
* __->__ #1204

Spec violation happens when exporting SAM model where mixed dtype on aten op
triggers spec violation.

In the process I realized that turning off ir_validity does not fully work.
So in this diff, I first made changes that respect check_ir_validity flag and
added tests for the same.

Next PR will address mixed dtype

Differential Revision: [D51293091](https://our.internmc.facebook.com/intern/diff/D51293091/)