### PR TITLE
[Executorch][EXIR] Remove constraint on having all the input arg dtypes to be
same

### DIFF
--- a/exir/verification/verifier.py
+++ b/exir/verification/verifier.py
@@ -199,25 +199,6 @@ def EXIREdgeDialectVerifier(  # noqa: C901
                 _check_tensors_are_contiguous(gm)
                 _check_tensor_args_matching_op_allowed_dtype(gm)
 
-            # Additionally, edge dialect's operator must have same input dtype
-            for n in gm.graph.nodes:
-                if n.op == "call_function" and isinstance(n.target, OpOverload):
-                    _check_has_fake_tensor(n)
-                    dtypes = set()
-                    for arg in n.args:
-                        if isinstance(arg, torch.Tensor):
-                            dtypes.add(arg.dtype)
-                        if isinstance(arg, torch.fx.Node):
-                            if arg.meta.get("val", None) is None:
-                                raise SpecViolationError(
-                                    f"No metadata 'val' for node {arg}"
-                                )
-                            dtypes.add(arg.meta["val"].dtype)
-                    if len(dtypes) > 1:
-                        raise SpecViolationError(
-                            "Operators of Edge dialect in should work on tensors of same dtype"
-                        )
-
         def is_valid(self, gm: GraphModule) -> bool:
             try:
                 self(gm)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1205
* #1204

same

This seems like not the right constraint

Differential Revision: [D51293090](https://our.internmc.facebook.com/intern/diff/D51293090/)