### PR TITLE
new AOT BundledProgram class to store ExecutorchProgram instead of Program

### DIFF
--- a/backends/apple/mps/test/test_mps.py
+++ b/backends/apple/mps/test/test_mps.py
@@ -141,9 +141,7 @@ def run_model(
 
     logging.info("  -> Test suites generated successfully")
 
-    bundled_program = create_bundled_program(
-        executorch_program.program, method_test_suites
-    )
+    bundled_program = create_bundled_program(executorch_program, method_test_suites)
     logging.info("  -> Bundled program generated successfully")
 
     bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(

--- a/backends/apple/mps/test/test_mps_utils.py
+++ b/backends/apple/mps/test/test_mps_utils.py
@@ -203,9 +203,7 @@ class TestMPS(unittest.TestCase):
 
         logging.info("  -> Test suites generated successfully")
 
-        bundled_program = create_bundled_program(
-            executorch_program.program, method_test_suites
-        )
+        bundled_program = create_bundled_program(executorch_program, method_test_suites)
         bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
             bundled_program
         )

--- a/backends/xnnpack/test/test_xnnpack_utils.py
+++ b/backends/xnnpack/test/test_xnnpack_utils.py
@@ -97,7 +97,9 @@ def randomize_bn(num_features: int, dimensionality: int = 2) -> torch.nn.Module:
     return bn
 
 
-def save_bundled_program(representative_inputs, program, ref_output, output_path):
+def save_bundled_program(
+    representative_inputs, executorch_program, ref_output, output_path
+):
     niter = 1
 
     print("generating bundled program inputs / outputs")
@@ -116,7 +118,7 @@ def save_bundled_program(representative_inputs, program, ref_output, output_path
     ]
 
     print("creating bundled program...")
-    bundled_program = create_bundled_program(program, method_test_suites)
+    bundled_program = create_bundled_program(executorch_program, method_test_suites)
 
     print("serializing bundled program...")
     bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
@@ -230,7 +232,7 @@ class TestXNNPACK(unittest.TestCase):
         if dump_bundled_program:
             save_bundled_program(
                 representative_inputs=sample_inputs,
-                program=executorch_program.program,
+                executorch_program=executorch_program,
                 ref_output=ref_output,
                 output_path=f"/tmp/xnnpack_test_{randint(1, 99999)}",
             )
@@ -442,7 +444,7 @@ class TestXNNPACK(unittest.TestCase):
 
             save_bundled_program(
                 representative_inputs=example_inputs,
-                program=executorch_program.program,
+                executorch_program=executorch_program,
                 ref_output=ref_output,
                 output_path=filename,
             )

--- a/docs/source/tutorials_source/sdk-integration-tutorial.py
+++ b/docs/source/tutorials_source/sdk-integration-tutorial.py
@@ -157,8 +157,8 @@ method_test_suites = [
 ]
 
 # Step 3: Generate BundledProgram
-program = to_edge(method_graphs).to_executorch().executorch_program
-bundled_program = create_bundled_program(program, method_test_suites)
+executorch_program = to_edge(method_graphs).to_executorch()
+bundled_program = create_bundled_program(executorch_program, method_test_suites)
 
 # Step 4: Serialize BundledProgram to flatbuffer.
 serialized_bundled_program = serialize_from_bundled_program_to_flatbuffer(

--- a/examples/apple/mps/scripts/mps_example.py
+++ b/examples/apple/mps/scripts/mps_example.py
@@ -102,9 +102,7 @@ if __name__ == "__main__":
             )
         ]
 
-        bundled_program = create_bundled_program(
-            executorch_program.program, method_test_suites
-        )
+        bundled_program = create_bundled_program(executorch_program, method_test_suites)
         bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
             bundled_program
         )

--- a/sdk/bundled_program/config.py
+++ b/sdk/bundled_program/config.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import get_args, List, Optional, Sequence, Union
 
 import torch
+
 from torch.utils._pytree import tree_flatten
 
 from typing_extensions import TypeAlias

--- a/sdk/bundled_program/core.py
+++ b/sdk/bundled_program/core.py
@@ -6,7 +6,8 @@
 
 import ctypes
 import typing
-from typing import Dict, List, Sequence, Type
+from dataclasses import dataclass
+from typing import Dict, List, Sequence, Type, Union
 
 import executorch.exir.schema as core_schema
 
@@ -14,8 +15,13 @@ import executorch.sdk.bundled_program.schema as bp_schema
 
 import torch
 import torch.fx
-from executorch.exir._serialize import _serialize_pte_binary
 
+from executorch.exir import (
+    ExecutorchProgram,
+    ExecutorchProgramManager,
+    MultiMethodExecutorchProgram,
+)
+from executorch.exir._serialize import _serialize_pte_binary
 from executorch.exir.tensor import get_scalar_type, scalar_type_enum, TensorSpec
 from executorch.sdk.bundled_program.config import ConfigValue, MethodTestSuite
 
@@ -28,6 +34,29 @@ supported_program_type_table: Dict[Type[core_schema.KernelTypes], ConfigValue] =
     core_schema.Double: float,
     core_schema.Bool: bool,
 }
+
+
+@dataclass
+class BundledProgram:
+    """
+    User should not create an instance of BundledProgram directly. Instead, use `create_bundled_program` API.
+
+    Bundled program contains all information needed to execute and verify the program on device.
+
+    Attributes:
+        method_test_suites: All test suites for verifying methods.
+        executorch_program: ExecutorchProgram-like variable for the program to be verified, including
+                            ExecutorchProgram, MultiMethodExecutorchProgram or ExecutorchProgramManager.
+        _bundled_program: information will be serialized into a binary format.
+    """
+
+    executorch_program: Union[
+        ExecutorchProgram,
+        MultiMethodExecutorchProgram,
+        ExecutorchProgramManager,
+    ]
+    method_test_suites: Sequence[MethodTestSuite]
+    _bundled_program: bp_schema.BundledProgram
 
 
 def emit_bundled_tensor(
@@ -254,9 +283,13 @@ def assert_valid_bundle(
 
 
 def create_bundled_program(
-    program: core_schema.Program,
+    executorch_program: Union[
+        ExecutorchProgram,
+        MultiMethodExecutorchProgram,
+        ExecutorchProgramManager,
+    ],
     method_test_suites: Sequence[MethodTestSuite],
-) -> bp_schema.BundledProgram:
+) -> BundledProgram:
     """Create bp_schema.BundledProgram by bundling the given program and method_test_suites together.
 
     Args:
@@ -266,6 +299,13 @@ def create_bundled_program(
     Returns:
         The `BundledProgram` variable contains given ExecuTorch program and test cases.
     """
+    if isinstance(executorch_program, ExecutorchProgramManager):
+        program = executorch_program.executorch_program
+    elif isinstance(executorch_program, ExecutorchProgram):
+        program = executorch_program.program
+    else:
+        assert isinstance(executorch_program, MultiMethodExecutorchProgram)
+        program = executorch_program.program
 
     method_test_suites = sorted(method_test_suites, key=lambda x: x.method_name)
 
@@ -321,8 +361,12 @@ def create_bundled_program(
 
     program_bytes: bytes = _serialize_pte_binary(program)
 
-    return bp_schema.BundledProgram(
-        version=BUNDLED_PROGRAM_SCHEMA_VERSION,
-        method_test_suites=bundled_method_test_suites,
-        program=program_bytes,
+    return BundledProgram(
+        executorch_program=executorch_program,
+        method_test_suites=method_test_suites,
+        _bundled_program=bp_schema.BundledProgram(
+            version=BUNDLED_PROGRAM_SCHEMA_VERSION,
+            method_test_suites=bundled_method_test_suites,
+            program=program_bytes,
+        ),
     )

--- a/sdk/bundled_program/serialize/test/test_serialize.py
+++ b/sdk/bundled_program/serialize/test/test_serialize.py
@@ -8,32 +8,28 @@
 
 import unittest
 
-from executorch.exir.print_program import pretty_print
-
 from executorch.sdk.bundled_program.core import create_bundled_program
 
 from executorch.sdk.bundled_program.serialize import (
     deserialize_from_flatbuffer_to_bundled_program,
     serialize_from_bundled_program_to_flatbuffer,
 )
-from executorch.sdk.bundled_program.util.test_util import get_common_program
+from executorch.sdk.bundled_program.util.test_util import get_common_executorch_program
 
 
 class TestSerialize(unittest.TestCase):
     def test_bundled_program_serialization(self) -> None:
-        program, method_test_suites = get_common_program()
+        executorch_program, method_test_suites = get_common_executorch_program()
 
-        bundled_program = create_bundled_program(program, method_test_suites)
-        pretty_print(bundled_program)
+        bundled_program = create_bundled_program(executorch_program, method_test_suites)
         flat_buffer_bundled_program = serialize_from_bundled_program_to_flatbuffer(
             bundled_program
         )
-        regenerate_bundled_program = deserialize_from_flatbuffer_to_bundled_program(
-            flat_buffer_bundled_program
+        regenerate_bundled_program_in_schema = (
+            deserialize_from_flatbuffer_to_bundled_program(flat_buffer_bundled_program)
         )
-        pretty_print(regenerate_bundled_program)
         self.assertEqual(
-            bundled_program,
-            regenerate_bundled_program,
+            bundled_program._bundled_program,
+            regenerate_bundled_program_in_schema,
             "Regenerated bundled program mismatches original one",
         )

--- a/sdk/bundled_program/test/test_bundle_data.py
+++ b/sdk/bundled_program/test/test_bundle_data.py
@@ -15,7 +15,7 @@ import torch
 from executorch.exir._serialize import _serialize_pte_binary
 from executorch.sdk.bundled_program.config import ConfigValue
 from executorch.sdk.bundled_program.core import create_bundled_program
-from executorch.sdk.bundled_program.util.test_util import get_common_program
+from executorch.sdk.bundled_program.util.test_util import get_common_executorch_program
 
 
 class TestBundle(unittest.TestCase):
@@ -33,22 +33,24 @@ class TestBundle(unittest.TestCase):
                 self.assertTrue(isinstance(config_element, torch.Tensor))
                 self.assertEqual(program_element.val.sizes, list(config_element.size()))
                 # TODO(gasoonjia): Check the inner data.
-            elif type(program_element.val) == bp_schema.Int:
+            elif type(program_element.val) is bp_schema.Int:
                 self.assertEqual(program_element.val.int_val, config_element)
-            elif type(program_element.val) == bp_schema.Double:
+            elif type(program_element.val) is bp_schema.Double:
                 self.assertEqual(program_element.val.double_val, config_element)
-            elif type(program_element.val) == bp_schema.Bool:
+            elif type(program_element.val) is bp_schema.Bool:
                 self.assertEqual(program_element.val.bool_val, config_element)
 
     def test_bundled_program(self) -> None:
-        program, method_test_suites = get_common_program()
+        executorch_program, method_test_suites = get_common_executorch_program()
 
-        bundled_program = create_bundled_program(program, method_test_suites)
+        bundled_program = create_bundled_program(executorch_program, method_test_suites)
 
         method_test_suites = sorted(method_test_suites, key=lambda t: t.method_name)
 
-        for plan_id in range(len(program.execution_plan)):
-            bundled_plan_test = bundled_program.method_test_suites[plan_id]
+        for plan_id in range(len(executorch_program.executorch_program.execution_plan)):
+            bundled_plan_test = bundled_program._bundled_program.method_test_suites[
+                plan_id
+            ]
             method_test_suite = method_test_suites[plan_id]
 
             self.assertEqual(
@@ -65,40 +67,52 @@ class TestBundle(unittest.TestCase):
                     method_test_case.expected_outputs,
                 )
 
-        self.assertEqual(bundled_program.program, _serialize_pte_binary(program))
+        self.assertEqual(
+            bundled_program._bundled_program.program,
+            _serialize_pte_binary(executorch_program.executorch_program),
+        )
 
     def test_bundled_miss_methods(self) -> None:
-        program, method_test_suites = get_common_program()
+        executorch_program, method_test_suites = get_common_executorch_program()
 
         # only keep the testcases for the first method to mimic the case that user only creates testcases for the first method.
         method_test_suites = method_test_suites[:1]
 
-        _ = create_bundled_program(program, method_test_suites)
+        _ = create_bundled_program(executorch_program, method_test_suites)
 
     def test_bundled_wrong_method_name(self) -> None:
-        program, method_test_suites = get_common_program()
+        executorch_program, method_test_suites = get_common_executorch_program()
 
         method_test_suites[-1].method_name = "wrong_method_name"
         self.assertRaises(
-            AssertionError, create_bundled_program, program, method_test_suites
+            AssertionError,
+            create_bundled_program,
+            executorch_program,
+            method_test_suites,
         )
 
     def test_bundle_wrong_input_type(self) -> None:
-        program, method_test_suites = get_common_program()
+        executorch_program, method_test_suites = get_common_executorch_program()
 
         # pyre-ignore[8]: Use a wrong type on purpose. Should raise an error when creating a bundled program using method_test_suites.
         method_test_suites[0].test_cases[-1].inputs = ["WRONG INPUT TYPE"]
         self.assertRaises(
-            AssertionError, create_bundled_program, program, method_test_suites
+            AssertionError,
+            create_bundled_program,
+            executorch_program,
+            method_test_suites,
         )
 
     def test_bundle_wrong_output_type(self) -> None:
-        program, method_test_suites = get_common_program()
+        executorch_program, method_test_suites = get_common_executorch_program()
 
         method_test_suites[0].test_cases[-1].expected_outputs = [
             0,
             0.0,
         ]
         self.assertRaises(
-            AssertionError, create_bundled_program, program, method_test_suites
+            AssertionError,
+            create_bundled_program,
+            executorch_program,
+            method_test_suites,
         )

--- a/sdk/bundled_program/test/test_end2end.py
+++ b/sdk/bundled_program/test/test_end2end.py
@@ -27,7 +27,7 @@ from executorch.sdk.bundled_program.serialize import (
 )
 
 from executorch.sdk.bundled_program.util.test_util import (
-    get_common_program,
+    get_common_executorch_program,
     SampleModel,
 )
 
@@ -64,10 +64,10 @@ assert kernel_mode is not None
 
 class BundledProgramE2ETest(unittest.TestCase):
     def test_sample_model_e2e(self):
-        program, method_test_suites = get_common_program()
+        executorch_program, method_test_suites = get_common_executorch_program()
         eager_model = SampleModel()
 
-        bundled_program = create_bundled_program(program, method_test_suites)
+        bundled_program = create_bundled_program(executorch_program, method_test_suites)
 
         bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
             bundled_program

--- a/sdk/bundled_program/util/test_util.py
+++ b/sdk/bundled_program/util/test_util.py
@@ -11,8 +11,7 @@ from typing import List, Tuple
 
 import torch
 
-from executorch.exir import to_edge
-from executorch.exir.schema import Program
+from executorch.exir import ExecutorchProgramManager, to_edge
 from executorch.sdk.bundled_program.config import (
     MethodInputType,
     MethodOutputType,
@@ -229,7 +228,9 @@ def get_random_test_suites_with_eager_model(
     return inputs_per_program, method_test_suites
 
 
-def get_common_program() -> Tuple[Program, List[MethodTestSuite]]:
+def get_common_executorch_program() -> Tuple[
+    ExecutorchProgramManager, List[MethodTestSuite]
+]:
     """Helper function to generate a sample BundledProgram with its config."""
     eager_model = SampleModel()
     # Trace to FX Graph.
@@ -248,7 +249,7 @@ def get_common_program() -> Tuple[Program, List[MethodTestSuite]]:
         for m_name in eager_model.method_names
     }
 
-    program = to_edge(method_graphs).to_executorch().executorch_program
+    executorch_program = to_edge(method_graphs).to_executorch()
 
     _, method_test_suites = get_random_test_suites_with_eager_model(
         eager_model=eager_model,
@@ -258,4 +259,4 @@ def get_common_program() -> Tuple[Program, List[MethodTestSuite]]:
         dtype=torch.int32,
         n_sets_per_plan_test=10,
     )
-    return program, method_test_suites
+    return executorch_program, method_test_suites

--- a/test/models/generate_linear_out_bundled_program.py
+++ b/test/models/generate_linear_out_bundled_program.py
@@ -48,13 +48,10 @@ def main() -> None:
         )
     )
     # Emit in-memory representation.
-    program = exec_prog.program
-
-    # Emit in-memory representation.
-    pretty_print(program)
+    pretty_print(exec_prog.program)
 
     # Serialize to flatbuffer.
-    program.version = 0
+    exec_prog.program.version = 0
 
     # Create test sets
     method_test_cases: List[MethodTestCase] = []
@@ -67,7 +64,7 @@ def main() -> None:
         MethodTestSuite(method_name="forward", test_cases=method_test_cases)
     ]
 
-    bundled_program = create_bundled_program(program, method_test_suites)
+    bundled_program = create_bundled_program(exec_prog, method_test_suites)
     pretty_print(bundled_program)
 
     bundled_program_flatbuffer = serialize_from_bundled_program_to_flatbuffer(


### PR DESCRIPTION
Summary:
This diff updates bundled program aot to contain ExecutorchProgram-like object (`ExecutorchProgram`,`MultiMethodExecutorchProgram` or `ExecutorchProgramManager`) to unblock sdk usage.

To achieve that, we create a new class, also called `BundledProgram`, but under `bundled_program/core`, to make bunded program contains `ExecutorchProgram` information while still only serialize the `Program` object in the given `ExecutorchProgram`. The new `BundledProgram` object will be the only `BundledProgram` users interact with, and in the future we will add more apis to make it more user friendly.

This diff only focuses on BundledProgram info update to unblock SDK asap. Other parts, like the class structure, documentation, serialization apis, etc, still needs to be updated.

Differential Revision: D51126519


