### PR TITLE
Create XNNPACK __init__.py file

### DIFF
--- a/backends/xnnpack/TARGETS
+++ b/backends/xnnpack/TARGETS
@@ -25,3 +25,19 @@ runtime.python_library(
         "//executorch/exir/backend:backend_details",
     ],
 )
+
+runtime.python_library(
+    name = "xnnpack_delegate",
+    srcs = [
+        "__init__.py",
+    ],
+    visibility = [
+        "//executorch/...",
+        "@EXECUTORCH_CLIENTS",
+    ],
+    deps = [
+        ":xnnpack_preprocess",
+        "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
+        "//executorch/backends/xnnpack/utils:xnnpack_utils",
+    ],
+)

--- a/backends/xnnpack/__init__.py
+++ b/backends/xnnpack/__init__.py
@@ -1,0 +1,35 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Exposed Partitioners in XNNPACK Package
+from .partition.xnnpack_partitioner import (
+    XnnpackDynamicallyQuantizedPartitioner,
+    XnnpackPartitioner,
+)
+
+# Exposed Configs in XNNPACK Package
+from .utils.configs import (
+    get_xnnpack_capture_config,
+    get_xnnpack_edge_compile_config,
+    get_xnnpack_executorch_backend_config,
+)
+
+# Easy util functions
+from .utils.utils import capture_graph_for_xnnpack
+
+# XNNPACK Backend
+from .xnnpack_preprocess import XnnpackBackend
+
+
+__all__ = [
+    "XnnpackDynamicallyQuantizedPartitioner",
+    "XnnpackPartitioner",
+    "XnnpackBackend",
+    "capture_graph_for_xnnpack",
+    "get_xnnpack_capture_config",
+    "get_xnnpack_edge_compile_config",
+    "get_xnnpack_executorch_backend_config",
+]


### PR DESCRIPTION
Summary:
Users of XNNPACK Delegate shouldn't have to know where partitioners and configs are within package submodules. So we can bring the only things that users need into the `__init__` file.

This allows us to import partitioners, configs and anything else straight from

`executorch.backends.xnnpack`

Reviewed By: JacobSzwejbka

Differential Revision: D46538935


