### PR TITLE
change build mode to release

### DIFF
--- a/build/install_flatc.sh
+++ b/build/install_flatc.sh
@@ -68,7 +68,7 @@ main() {
         # Build the tool if not already built.
         echo "Building flatc under ${FLATBUFFERS_PATH}..."
         # Generate cache.
-        (rm -rf "${BUILD_DIR}" && mkdir "${BUILD_DIR}" && cd "${BUILD_DIR}" && cmake ..)
+        (rm -rf "${BUILD_DIR}" && mkdir "${BUILD_DIR}" && cd "${BUILD_DIR}" && cmake -DCMAKE_BUILD_TYPE=Release ..)
         # Build.
         (cd "${FLATBUFFERS_PATH}" && cmake --build "${BUILD_DIR}" --target flatc -j9)
 


### PR DESCRIPTION
Summary:
It seems by default it maybe building with release mode. This results in much
slower flatbuffer serialization.

Before:
MV3: 37s
SAM (local changes): ~7m

After:
MV3: 31s
SAM (local changes): ~4m

Reviewed By: kirklandsign

Differential Revision: D51310857


