### PR TITLE
remove _deprecated_global_ns

### DIFF
--- a/exir/tests/control_flow_models.py
+++ b/exir/tests/control_flow_models.py
@@ -87,7 +87,7 @@ class FTMapBasic(Module):
         def f(x, y):
             return x + y
 
-        return torch.ops.map(f, xs, y) + xs
+        return torch.ops.higher_order.map(f, xs, y) + xs
 
     def get_random_inputs(self):
         return torch.rand(2, 4), torch.rand(4)
@@ -101,7 +101,7 @@ class FTMapDynShape(Module):
         def f(x, y):
             return x + y
 
-        return torch.ops.map(f, xs, y) + xs
+        return torch.ops.higher_order.map(f, xs, y) + xs
 
     def get_upper_bound_inputs(self):
         return torch.rand(4, 4), torch.rand(4)


### PR DESCRIPTION
Summary:
This is a reland of https://github.com/pytorch/pytorch/issues/112757. Cannot land internally because internal diff is not in sync with OSS due to issues in dealing with two export repos (executorch and pytorch) for the ghimport-ghexport approach.

Will try the web UI of import and export instead of ghimport and ghexport flow.

X-link: https://github.com/pytorch/pytorch/pull/113813

Reviewed By: angelayi

Differential Revision: D51373556

Pulled By: ydwu4


