### PR TITLE
[Executorch][XNNPACK] Fix broken xnnpack build

### DIFF
--- a/backends/xnnpack/xnnpack_preprocess.py
+++ b/backends/xnnpack/xnnpack_preprocess.py
@@ -37,7 +37,9 @@ from executorch.exir.backend.backend_details import (
     CompileSpec,
     PreprocessResult,
 )
+from executorch.exir.verification.verifier import EXIREdgeDialectVerifier
 from torch._export.exported_program import ExportedProgram
+from torch._export.verifier import Verifier
 
 XNN_VALUE_FLAG_NON_EXTERNAL = 0
 XNN_VALUE_FLAG_EXTERNAL_INPUT = 1
@@ -180,7 +182,6 @@ def generate_node_to_external_map(
                     )
     return node_to_external_map
 
-
 @final
 class XnnpackBackend(BackendDetails):
     @staticmethod
@@ -189,6 +190,26 @@ class XnnpackBackend(BackendDetails):
         compile_specs: List[CompileSpec],
     ) -> PreprocessResult:
         ep = copy.deepcopy(edge_program)
+        # Need to wrap EP here because xnnpack does addmm to linear
+        # transforms. This makes resulting graph not aten comliant
+        # as aten.linear is not a core aten op.
+        # Ideal fix would be to have XNNPACK verifier that bypass
+        # most checks but the base Verifier itself has some strict changes
+        # and to bypass those, we would basicallyy copy what EdgeDialectVerifier
+        # does. So for now instead of copy pasting that, just instantiate
+        # EdgeDialectVerifier, but disable it.
+        # TODO (task link) to implement NullVerifier or something similar
+        ep = ExportedProgram(
+            ep.graph_module,
+            ep.graph,
+            ep.graph_signature,
+            ep.state_dict,
+            ep.range_constraints,
+            ep.equality_constraints,
+            copy.deepcopy(ep.module_call_graph),
+            ep.example_inputs,
+            verifier=EXIREdgeDialectVerifier(check_edge_ops=False, enable=False, class_only=True),
+        )
 
         # XNNPACK Delegate Specific Passes
         ep = XNNPACKPassManager(ep).transform()

--- a/backends/xnnpack/xnnpack_preprocess.py
+++ b/backends/xnnpack/xnnpack_preprocess.py
@@ -39,7 +39,6 @@ from executorch.exir.backend.backend_details import (
 )
 from executorch.exir.verification.verifier import EXIREdgeDialectVerifier
 from torch._export.exported_program import ExportedProgram
-from torch._export.verifier import Verifier
 
 XNN_VALUE_FLAG_NON_EXTERNAL = 0
 XNN_VALUE_FLAG_EXTERNAL_INPUT = 1
@@ -182,6 +181,7 @@ def generate_node_to_external_map(
                     )
     return node_to_external_map
 
+
 @final
 class XnnpackBackend(BackendDetails):
     @staticmethod
@@ -208,7 +208,9 @@ class XnnpackBackend(BackendDetails):
             ep.equality_constraints,
             copy.deepcopy(ep.module_call_graph),
             ep.example_inputs,
-            verifier=EXIREdgeDialectVerifier(check_edge_ops=False, enable=False, class_only=True),
+            verifier=EXIREdgeDialectVerifier(
+                check_edge_ops=False, enable=False, class_only=True
+            ),
         )
 
         # XNNPACK Delegate Specific Passes


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1229

Summary:
Recent change to edge dialect verifier enables checking if the graph
contains only aten ops. This broke XNNPACK delegate because linear
transform converts addmm and friends to linear.

This fix just works around it.

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D51406090](https://our.internmc.facebook.com/intern/diff/D51406090)