### PR TITLE
Don't link against libclog.a for xnnpack backend anymore.

### DIFF
--- a/build/build_apple_frameworks.sh
+++ b/build/build_apple_frameworks.sh
@@ -25,7 +25,7 @@ EXECUTORCH_FRAMEWORK="executorch:libexecutorch.a,libextension_data_loader.a:$HEA
 PORTABLE_FRAMEWORK="portable_backend:libportable_kernels.a,libportable_ops_lib.a:"
 COREML_FRAMEWORK="coreml_backend:libcoremldelegate.a:"
 MPS_FRAMEWORK="mps_backend:libmpsdelegate.a:"
-XNNPACK_FRAMEWORK="xnnpack_backend:libXNNPACK.a,libclog.a,libcpuinfo.a,libpthreadpool.a,libxnnpack_backend.a:"
+XNNPACK_FRAMEWORK="xnnpack_backend:libXNNPACK.a,libcpuinfo.a,libpthreadpool.a,libxnnpack_backend.a:"
 
 usage() {
   echo "Usage: $0 [SOURCE_ROOT_DIR] [OPTIONS]"


### PR DESCRIPTION
Summary: Recent xnnpack upgrade doesn't require it anymore.

Differential Revision: D51440195


