### PR TITLE
Add div op-level test for xnnpack backend

### DIFF
--- a/backends/xnnpack/test/ops/div.py
+++ b/backends/xnnpack/test/ops/div.py
@@ -1,0 +1,62 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack.test.tester import Tester
+
+
+class TestDiv(unittest.TestCase):
+    class Div(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x, y):
+            z = x / y
+            return z
+
+    class DivSingleInput(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            z = x / x
+            return z
+
+    def test_fp32_div(self):
+        inputs = (torch.ones(1), torch.ones(1))
+        (
+            Tester(self.Div(), inputs)
+            .export()
+            .check_count({"torch.ops.aten.div.Tensor": 1})
+            .to_edge()
+            .check_count({"executorch_exir_dialects_edge__ops_aten_div_Tensor": 1})
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .check_not(["executorch_exir_dialects_edge__ops_aten_div_Tensor"])
+            .to_executorch()
+            .serialize()
+            .run_method()
+            .compare_outputs()
+        )
+
+    def test_fp32_div_single_input(self):
+        inputs = (torch.ones(1),)
+        (
+            Tester(self.DivSingleInput(), inputs)
+            .export()
+            .check_count({"torch.ops.aten.div.Tensor": 1})
+            .to_edge()
+            .check_count({"executorch_exir_dialects_edge__ops_aten_div_Tensor": 1})
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .check_not(["executorch_exir_dialects_edge__ops_aten_div_Tensor"])
+            .to_executorch()
+            .serialize()
+            .run_method()
+            .compare_outputs()
+        )


### PR DESCRIPTION
Summary:
Add an operator-level test for the tensor division operator in the XNNPack backend.

Note that as per the XNNPack delegate code (https://www.internalfb.com/code/fbsource/[5ac008e86389c2b383476edbfa09c1d4bba1ddbd]/fbcode/executorch/backends/xnnpack/partition/configs.py?lines=82-102), the XNNPack delegate does not support quantization for the div operator.

Similarly, as per the operator logic (https://www.internalfb.com/code/fbsource/[5ac008e86389c2b383476edbfa09c1d4bba1ddbd]/fbcode/executorch/backends/xnnpack/operators/op_div.py), there are no fused variants.

As such, this change only includes one new test - test_fp32_div. This test verifies that the aten div.Tensor operator is converted to the relevant EXIR op, the delegate is invoked, and that the results of tensor division are as expected.

Reviewed By: digantdesai, mcr229

Differential Revision: D51323792


