### PR TITLE
Save reference outputs (sourced from BundledProgram) in ETRecord

### DIFF
--- a/sdk/bundled_program/schema/TARGETS
+++ b/sdk/bundled_program/schema/TARGETS
@@ -14,6 +14,7 @@ runtime.python_library(
     ],
     visibility = [
         "//executorch/sdk/bundled_program/...",
+        "//executorch/sdk/etrecord/...",
     ],
     deps = [
         "//executorch/exir:scalar_type",

--- a/sdk/etrecord/TARGETS
+++ b/sdk/etrecord/TARGETS
@@ -10,5 +10,7 @@ python_library(
         "//executorch/exir:lib",
         "//executorch/exir/emit:emit",
         "//executorch/exir/serde:serialize",
+        "//executorch/sdk/bundled_program:core",
+        "//executorch/sdk/bundled_program/schema:bundled_program_schema_py",
     ],
 )

--- a/sdk/etrecord/tests/TARGETS
+++ b/sdk/etrecord/tests/TARGETS
@@ -10,6 +10,8 @@ python_unittest(
         "//caffe2:torch",
         "//executorch/exir:lib",
         "//executorch/exir/tests:models",
+        "//executorch/sdk/bundled_program:config",
+        "//executorch/sdk/bundled_program:core",
         "//executorch/sdk/etrecord:etrecord",
     ],
 )
@@ -21,6 +23,8 @@ python_library(
         "//caffe2:torch",
         "//executorch/exir:lib",
         "//executorch/exir/tests:models",
+        "//executorch/sdk/bundled_program:config",
+        "//executorch/sdk/bundled_program:core",
         "//executorch/sdk/etrecord:etrecord",
     ],
 )


### PR DESCRIPTION
Summary: ETRecord schema change to store reference outputs

Differential Revision: D51039462


