### PR TITLE
update test_emit to use export

### DIFF
--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -15,11 +15,10 @@ import executorch.exir as exir
 import executorch.exir.schema as schema
 import executorch.exir.tests.models as models
 import torch
-from executorch.exir import CaptureConfig, EdgeCompileConfig, ExecutorchProgram
+from executorch.exir import EdgeCompileConfig, ExecutorchProgramManager, to_edge
 from executorch.exir.backend.backend_api import to_backend
 from executorch.exir.backend.backend_details import BackendDetails, PreprocessResult
 from executorch.exir.emit import emit_program  # noqa
-from executorch.exir.error import InternalError
 from executorch.exir.passes.const_prop_pass import ConstPropPass
 from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
 from executorch.exir.print_program import pretty_print, print_program  # noqa
@@ -39,15 +38,11 @@ from executorch.exir.schema import (
     Tensor,
 )
 from executorch.exir.tests.common import register_additional_test_aten_ops
-from executorch.exir.tests.models import MLP, Mul
-
-from executorch.extension.pybindings.portable_lib import (
-    _load_for_executorch_from_buffer,
-)
+from executorch.exir.tests.models import Mul
 from functorch.experimental import control_flow
 from torch import nn
 
-from torch.export import dynamic_dim
+from torch.export import dynamic_dim, export
 
 
 class TestEmit(unittest.TestCase):
@@ -109,14 +104,14 @@ class TestEmit(unittest.TestCase):
             return x * y + x
 
         program = (
-            exir.capture(
-                f,
-                (torch.ones(3, 2), torch.zeros(3, 2)),
-                exir.CaptureConfig(),
+            to_edge(
+                export(
+                    f,
+                    (torch.ones(3, 2), torch.zeros(3, 2)),
+                )
             )
-            .to_edge()
             .to_executorch()
-            .program
+            .executorch_program
         )
         exec_plan = program.execution_plan[0]
         ops = exec_plan.operators
@@ -135,10 +130,7 @@ class TestEmit(unittest.TestCase):
     def test_basic_end_to_end(self) -> None:
         f = models.BasicSinMax()
         program = (
-            exir.capture(f, f.get_random_inputs(), exir.CaptureConfig())
-            .to_edge()
-            .to_executorch()
-            .program
+            to_edge(export(f, f.get_random_inputs())).to_executorch().executorch_program
         )
         exec_plan = program.execution_plan[0]
         ops = exec_plan.operators
@@ -162,9 +154,7 @@ class TestEmit(unittest.TestCase):
             )
 
         x = (torch.randn(100),)
-        program = (
-            exir.capture(f, x, exir.CaptureConfig()).to_edge().to_executorch().program
-        )
+        program = to_edge(export(f, x)).to_executorch().executorch_program
         exec_plan = program.execution_plan[0]
         self.assertEqual(len(exec_plan.outputs), 4)
         self.assertEqual(len(exec_plan.inputs), 1)
@@ -184,11 +174,14 @@ class TestEmit(unittest.TestCase):
             return torch.ones(100) + x + (torch.ones(100) * 2)
 
         program = (
-            exir.capture(f, (torch.randn(100),), exir.CaptureConfig())
-            .to_edge()
-            .transform(ConstPropPass())
+            to_edge(export(f, (torch.randn(100),)))
+            .transform(
+                [
+                    ConstPropPass(),
+                ]
+            )
             .to_executorch()
-            .program
+            .executorch_program
         )
         self.assertEqual(len(program.constant_buffer), 3)
         instructions = program.execution_plan[0].chains[0].instructions
@@ -196,27 +189,27 @@ class TestEmit(unittest.TestCase):
 
         # first arg to first torch_add is a constant tensor
         self.check_tensor_buffer_loc(
-            instructions[0].instr_args.args[0], values, 1, None, None
+            instructions[0].instr_args.args[0], values, 1, None, None  # pyre-ignore[16]
         )
         # second arg to first torch_add is an input tensor
         self.check_tensor_buffer_loc(
-            instructions[0].instr_args.args[1], values, 0, 1, 0
+            instructions[0].instr_args.args[1], values, 0, 1, 0  # pyre-ignore[16]
         )
         # output of first torch_add is a dynamic tensor
         self.check_tensor_buffer_loc(
-            instructions[0].instr_args.args[3], values, 0, 1, 400
+            instructions[0].instr_args.args[3], values, 0, 1, 400  # pyre-ignore[16]
         )
         # first arg to second torch_add is a dynamic tensor
         self.check_tensor_buffer_loc(
-            instructions[1].instr_args.args[0], values, 0, 1, 400
+            instructions[1].instr_args.args[0], values, 0, 1, 400  # pyre-ignore[16]
         )
         # second arg to second torch_add is a constant tensor
         self.check_tensor_buffer_loc(
-            instructions[1].instr_args.args[1], values, 2, None, None
+            instructions[1].instr_args.args[1], values, 2, None, None  # pyre-ignore[16]
         )
         # output of second torch_add is a dynamic tensor
         self.check_tensor_buffer_loc(
-            instructions[1].instr_args.args[3], values, 0, 1, 0
+            instructions[1].instr_args.args[3], values, 0, 1, 0  # pyre-ignore[16]
         )
 
     def test_inplace_ops(self) -> None:
@@ -227,21 +220,21 @@ class TestEmit(unittest.TestCase):
             return z.max()
 
         inputs = (torch.ones((10, 10)),)
-        edge = exir.capture(f, inputs, exir.CaptureConfig()).to_edge()
+        edge = to_edge(export(f, inputs))
 
         removed_ops = ["aten::relu_", "aten::view"]
         expected_ops = ["aten::sin", "aten::relu", "aten::max", "aten::view_copy"]
 
         for opname in removed_ops:
             self.assertEqual(
-                self.count_node(edge.exported_program.graph_module, opname), 0
+                self.count_node(edge.exported_program().graph_module, opname), 0
             )
         for opname in expected_ops:
             self.assertTrue(
-                self.count_node(edge.exported_program.graph_module, opname) >= 1
+                self.count_node(edge.exported_program().graph_module, opname) >= 1
             )
 
-        program = edge.to_executorch().program
+        program = edge.to_executorch().executorch_program
         for opname in removed_ops:
             self.assertTrue(
                 all(op.name != opname for op in program.execution_plan[0].operators)
@@ -268,12 +261,7 @@ class TestEmit(unittest.TestCase):
 
         inputs = (torch.ones(2, 2),)
 
-        program = (
-            exir.capture(model, inputs, exir.CaptureConfig())
-            .to_edge()
-            .to_executorch()
-            .program
-        )
+        program = to_edge(export(model, inputs)).to_executorch().executorch_program
 
         self.assertEqual(len(program.execution_plan[0].operators), 2)
 
@@ -284,16 +272,15 @@ class TestEmit(unittest.TestCase):
             return torch.permute(x, (2, 0, 1))
 
         program = (
-            exir.capture(f, (torch.randn(2, 3, 5),), exir.CaptureConfig())
-            .to_edge()
+            to_edge(export(f, (torch.randn(2, 3, 5),)))
             .to_executorch()
-            .program
+            .executorch_program
         )
         exir.print_program.pretty_print(program)
 
         deboxed_int_list = []
-        for item in program.execution_plan[0].values[5].val.items:
-            deboxed_int_list.append(program.execution_plan[0].values[item].val.int_val)
+        for item in program.execution_plan[0].values[5].val.items:  # pyre-ignore[16]
+            deboxed_int_list.append(program.execution_plan[0].values[item].val.int_val)  # pyre-ignore[16]
 
         self.assertEqual(IntList(deboxed_int_list), IntList([2, 0, 1]))
 
@@ -308,10 +295,7 @@ class TestEmit(unittest.TestCase):
             return torch.addbmm(x, batch1, batch2, alpha=2, beta=3)
 
         program = (
-            exir.capture(f, (torch.randn(3, 5),), exir.CaptureConfig())
-            .to_edge()
-            .to_executorch()
-            .program
+            to_edge(export(f, (torch.randn(3, 5),))).to_executorch().executorch_program
         )
         # The value for beta should appear before alpha
         self.assertEqual(program.execution_plan[0].values[12].val, Int(3))
@@ -327,105 +311,12 @@ class TestEmit(unittest.TestCase):
             return torch.searchsorted(x, values, side="right", right=True)
 
         x, _ = torch.sort(torch.randn(3, 4))
-        program = (
-            exir.capture(f, (x,), exir.CaptureConfig())
-            .to_edge()
-            .to_executorch()
-            .program
-        )
+        program = to_edge(export(f, (x,))).to_executorch().executorch_program
         # The value for right should appear before side
         self.assertEqual(program.execution_plan[0].values[6].val, Bool(False))
         self.assertEqual(program.execution_plan[0].values[7].val, Bool(True))
         self.assertEqual(program.execution_plan[0].values[8].val, String("right"))
         self.assertEqual(program.execution_plan[0].values[9].val, Null())
-
-    def test_no_input(self) -> None:
-        capture_config = CaptureConfig(
-            enable_functionalization=True,
-            enable_dynamic_shape=False,
-        )
-
-        class SimpleDict(torch.nn.Module):
-            def __init__(self, x):
-                super().__init__()
-                self.x = x
-
-            def forward(self):
-                return self.x
-
-        model = SimpleDict(torch.ones(1, dtype=torch.int64))
-        example_inputs = ()
-        program = (
-            exir.capture(model.forward, example_inputs, capture_config)
-            .to_edge()
-            .to_executorch()
-            .program
-        )
-        self.assertEqual(len(program.execution_plan[0].inputs), 0)
-        self.assertEqual(len(program.execution_plan[0].outputs), 1)
-        self.assertEqual(len(program.execution_plan[0].chains[0].instructions), 0)
-
-    def test_kwargs_memory_format(self) -> None:
-        def f_1(x: torch.Tensor) -> torch.Tensor:
-            y = x.to(dtype=torch.double)
-            return y
-
-        def f_2(x: torch.Tensor, mem_format: torch.memory_format) -> torch.Tensor:
-            y = x.to(dtype=torch.double, memory_format=mem_format)
-            return y
-
-        program_supported_without_mem_format = (
-            exir.capture(f_1, (torch.ones([4, 4, 4, 4]),), exir.CaptureConfig())
-            .to_edge()
-            .to_executorch()
-            .program
-        )
-        program_supported_with_mem_format = (
-            exir.capture(
-                f_2,
-                (torch.ones([4, 4, 4, 4]), torch.contiguous_format),
-                exir.CaptureConfig(),
-            )
-            .to_edge()
-            .to_executorch()
-            .program
-        )
-
-        with self.assertRaisesRegex(
-            InternalError, "Non contiguous tensors are not supported in ExecuTorch"
-        ):
-            exir.capture(
-                f_2,
-                (torch.ones([4, 4, 4, 4]), torch.channels_last),
-                exir.CaptureConfig(),
-            ).to_edge().to_executorch().program
-
-        # Get the indexes at which the memory_format values are present in the values list
-        mem_format_arg_1 = (
-            program_supported_with_mem_format.execution_plan[0]
-            .chains[0]
-            .instructions[0]
-            .instr_args.args[-3]
-        )
-        mem_format_arg_2 = (
-            program_supported_without_mem_format.execution_plan[0]
-            .chains[0]
-            .instructions[0]
-            .instr_args.args[-3]
-        )
-        # Assert that the values in the memory_format arg are as expected.
-        self.assertEqual(
-            program_supported_with_mem_format.execution_plan[0]
-            .values[mem_format_arg_1]
-            .val,
-            Int(0),
-        )
-        self.assertEqual(
-            program_supported_without_mem_format.execution_plan[0]
-            .values[mem_format_arg_2]
-            .val,
-            Null(),
-        )
 
     def test_out(self) -> None:
         def f(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
@@ -433,15 +324,14 @@ class TestEmit(unittest.TestCase):
             return torch.mul(x, y, out=z)
 
         program = (
-            exir.capture(f, (torch.ones(3), torch.ones(3)), exir.CaptureConfig())
-            .to_edge()
+            to_edge(export(f, (torch.ones(3), torch.ones(3))))
             .to_executorch()
-            .program
+            .executorch_program
         )
 
         self.assertEqual(len(program.execution_plan[0].chains[0].instructions), 1)
         self.assertEqual(
-            len(program.execution_plan[0].chains[0].instructions[0].instr_args.args), 4
+            len(program.execution_plan[0].chains[0].instructions[0].instr_args.args), 4  # pyre-ignore[16]
         )
 
     def test_model_out(self) -> None:
@@ -463,19 +353,14 @@ class TestEmit(unittest.TestCase):
         inputs = (torch.ones(2, 2, dtype=torch.int32),)
 
         # Trace to FX Graph.
-        program = (
-            exir.capture(model_out, inputs, exir.CaptureConfig())
-            .to_edge()
-            .to_executorch()
-            .program
-        )
+        program = to_edge(export(model_out, inputs)).to_executorch().executorch_program
 
         self.assertEqual(len(program.execution_plan[0].chains[0].instructions), 2)
         self.assertEqual(
-            len(program.execution_plan[0].chains[0].instructions[0].instr_args.args), 4
+            len(program.execution_plan[0].chains[0].instructions[0].instr_args.args), 4  # pyre-ignore[16]
         )
         self.assertEqual(
-            len(program.execution_plan[0].chains[0].instructions[1].instr_args.args), 5
+            len(program.execution_plan[0].chains[0].instructions[1].instr_args.args), 5  # pyre-ignore[16]
         )
 
     def test_stacktrace(self) -> None:
@@ -489,17 +374,15 @@ class TestEmit(unittest.TestCase):
             return torch.add(g(x), torch.randn(3, 2))
 
         x = (torch.randn(3, 2),)
-        exec_prog = (
-            exir.capture(h, x, exir.CaptureConfig())
-            .to_edge()
-            .to_executorch(exir.ExecutorchBackendConfig(emit_stacktrace=True))
+        exec_prog = to_edge(export(h, x)).to_executorch(
+            exir.ExecutorchBackendConfig(emit_stacktrace=True)
         )
-        program = exec_prog.program
+        program = exec_prog.executorch_program
 
         # Check the mul operator's stack trace contains f -> g -> h
         self.assertTrue(
             "return torch.mul(x, torch.randn(3, 2))"
-            in program.execution_plan[0].chains[0].stacktrace[1].items[-1].context
+            in program.execution_plan[0].chains[0].stacktrace[1].items[-1].context  # pyre-ignore[16]
         )
         self.assertEqual(
             program.execution_plan[0].chains[0].stacktrace[1].items[-1].name, "f"
@@ -530,9 +413,7 @@ class TestEmit(unittest.TestCase):
             return torch.add(g(x), torch.randn(3, 2))
 
         x = (torch.randn(3, 2),)
-        program = (
-            exir.capture(h, x, exir.CaptureConfig()).to_edge().to_executorch().program
-        )
+        program = to_edge(export(h, x)).to_executorch().executorch_program
 
         # Check the stacktrace is None since we did not specify to get the stacktrace
         self.assertTrue(program.execution_plan[0].chains[0].stacktrace is None)
@@ -544,61 +425,24 @@ class TestEmit(unittest.TestCase):
 
         x = torch.randn(3, 2)
         program = (
-            exir.capture(f, (x, x), exir.CaptureConfig())
-            .to_edge(self.compile_config)  # TODO(larryliu): fix cat
-            .to_executorch()
-            .program
+            to_edge(export(f, (x, x)))
+            # .to_edge(self.compile_config)  # TODO(larryliu): fix cat
+            .to_executorch().executorch_program
         )
 
         self.assertEqual(len(program.execution_plan[0].chains[0].instructions), 1)
         self.assertEqual(
-            len(program.execution_plan[0].chains[0].instructions[0].instr_args.args), 4
+            len(program.execution_plan[0].chains[0].instructions[0].instr_args.args), 4  # pyre-ignore[16]
         )
-
-    def test_lifted(self) -> None:
-        def test_model(eager_module):
-            inputs = eager_module.get_random_inputs()
-            eager_output = eager_module.forward(*inputs)
-            capture_config = exir.CaptureConfig(
-                enable_functionalization=True,
-                enable_aot=True,
-                _unlift=False,
-            )
-
-            aten_dialect = exir.capture(
-                eager_module,
-                eager_module.get_random_inputs(),
-                capture_config,
-            )
-
-            edge_dialect = aten_dialect.to_edge()
-
-            executorch_dialect = edge_dialect.to_executorch()
-
-            pretty_print(executorch_dialect.program)
-
-            executorch_module = _load_for_executorch_from_buffer(
-                executorch_dialect.buffer
-            )
-            et_output = executorch_module.forward(inputs)
-            self.assertTrue(torch.allclose(eager_output, et_output[0], atol=1e-04))
-
-        test_model(MLP())
-        # test_model(Emformer()) cannot run without bernoulli.out being added
 
     def test_emit_multiple_out(self) -> None:
         def f(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
             return torch.topk(x, 5)
 
         x = (torch.randn(10),)
-        program = (
-            exir.capture(f, x, exir.CaptureConfig())
-            .to_edge(self.compile_config)  # TODO(larryliu): fix topk
-            .to_executorch()
-            .program
-        )
+        program = to_edge(export(f, x)).to_executorch().executorch_program
         self.assertEqual(
-            len(program.execution_plan[0].chains[0].instructions[0].instr_args.args), 8
+            len(program.execution_plan[0].chains[0].instructions[0].instr_args.args), 8  # pyre-ignore[16]
         )
 
     # Non contiguous tensors are not supported in ExecuTorch
@@ -608,9 +452,7 @@ class TestEmit(unittest.TestCase):
             return torch.ones_like(x)
 
         x = (torch.randn(3, 2),)
-        program = (
-            exir.capture(f, x, exir.CaptureConfig()).to_edge().to_executorch().program
-        )
+        program = to_edge(export(f, x)).to_executorch().executorch_program
 
         vals = program.execution_plan[0].values
         for val in vals:
@@ -625,14 +467,20 @@ class TestEmit(unittest.TestCase):
             return b
 
         x = (torch.randn(3, 2),)
-        config = CaptureConfig(enable_dynamic_shape=True)
-        program = exir.capture(f, x, config=config).to_edge().to_executorch().program
+        program = (
+            to_edge(
+                export(f, x),
+                compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+            )
+            .to_executorch()
+            .executorch_program
+        )
 
         self.assertEqual(
-            len(program.execution_plan[0].chains[0].instructions[0].instr_args.args), 3
+            len(program.execution_plan[0].chains[0].instructions[0].instr_args.args), 3  # pyre-ignore[16]
         )
         self.assertEqual(
-            len(program.execution_plan[0].chains[0].instructions[1].instr_args.args), 4
+            len(program.execution_plan[0].chains[0].instructions[1].instr_args.args), 4  # pyre-ignore[16]
         )
 
     def test_optional_float_list(self) -> None:
@@ -642,11 +490,10 @@ class TestEmit(unittest.TestCase):
 
         x = (torch.randn(1, 1, 2, 2),)
         program = (
-            exir.capture(M(), x, exir.CaptureConfig())
-            .to_edge()
-            .transform(ConstPropPass())
+            to_edge(export(M(), x))
+            .transform([ConstPropPass()])
             .to_executorch()
-            .program
+            .executorch_program
         )
         self.assertIsInstance(
             program.execution_plan[0].values[4].val, schema.OptionalTensorList
@@ -669,10 +516,8 @@ class TestEmit(unittest.TestCase):
                 ret = control_flow.cond(pred, true_fn, false_fn, [x])
                 return ret
 
-        module = exir.capture(M(), (torch.tensor(True), torch.ones(2, 2))).to_edge(
-            exir.EdgeCompileConfig(_check_ir_validity=False)
-        )
-        program = module.to_executorch().program
+        module = to_edge(export(M(), (torch.tensor(True), torch.ones(2, 2))))
+        program = module.to_executorch().executorch_program
 
         num_mm = 0
         num_add = 0
@@ -681,7 +526,7 @@ class TestEmit(unittest.TestCase):
             if not isinstance(inst.instr_args, KernelCall):
                 continue
 
-            op = program.execution_plan[0].operators[inst.instr_args.op_index].name
+            op = program.execution_plan[0].operators[inst.instr_args.op_index].name  # pyre-ignore[16]
 
             if "mm" in op:
                 num_mm += 1
@@ -701,15 +546,12 @@ class TestEmit(unittest.TestCase):
 
             return control_flow.map(map_fn, x, y)
 
-        capture_config = CaptureConfig(
-            enable_functionalization=False,
-            enable_dynamic_shape=True,
-        )
         inputs = (torch.ones(4, 4), torch.ones(4))
-        module = exir.capture(f, inputs, capture_config).to_edge(
-            exir.EdgeCompileConfig(_check_ir_validity=False)
+        module = to_edge(
+            export(f, inputs),
+            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
         )
-        program = module.to_executorch().program
+        program = module.to_executorch().executorch_program
 
         op_table = program.execution_plan[0].operators
         # The first two operators at the beginning of a map program should be sym_size
@@ -718,13 +560,13 @@ class TestEmit(unittest.TestCase):
         # generate the tensor on which this iteration will operate on.
         self.assertEqual(
             op_table[
-                program.execution_plan[0].chains[0].instructions[0].instr_args.op_index
+                program.execution_plan[0].chains[0].instructions[0].instr_args.op_index  # pyre-ignore[16]
             ].name,
             "aten::sym_size",
         )
         self.assertEqual(
             op_table[
-                program.execution_plan[0].chains[0].instructions[1].instr_args.op_index
+                program.execution_plan[0].chains[0].instructions[1].instr_args.op_index  # pyre-ignore[16]
             ].name,
             "aten::select_copy",
         )
@@ -736,19 +578,19 @@ class TestEmit(unittest.TestCase):
         # We check here that both of these have been generated.
         self.assertEqual(
             op_table[
-                program.execution_plan[0].chains[0].instructions[-5].instr_args.op_index
+                program.execution_plan[0].chains[0].instructions[-5].instr_args.op_index  # pyre-ignore[16]
             ].name,
             "executorch_prim::et_copy_index",
         )
         self.assertEqual(
             op_table[
-                program.execution_plan[0].chains[0].instructions[-4].instr_args.op_index
+                program.execution_plan[0].chains[0].instructions[-4].instr_args.op_index  # pyre-ignore[16]
             ].name,
             "executorch_prim::add",
         )
         self.assertEqual(
             op_table[
-                program.execution_plan[0].chains[0].instructions[-3].instr_args.op_index
+                program.execution_plan[0].chains[0].instructions[-3].instr_args.op_index  # pyre-ignore[16]
             ].name,
             "executorch_prim::eq",
         )
@@ -762,7 +604,7 @@ class TestEmit(unittest.TestCase):
         )
         self.assertEqual(
             op_table[
-                program.execution_plan[0].chains[0].instructions[-1].instr_args.op_index
+                program.execution_plan[0].chains[0].instructions[-1].instr_args.op_index  # pyre-ignore[16]
             ].name,
             "executorch_prim::sub",
         )
@@ -778,14 +620,13 @@ class TestEmit(unittest.TestCase):
 
         model = SimpleLinear()
         inputs = (torch.ones(10, 5),)
-        capture_config = CaptureConfig(
-            enable_dynamic_shape=True,
-        )
         program = (
-            exir.capture(model, inputs, capture_config)
-            .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
+            to_edge(
+                export(model, inputs),
+                compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+            )
             .to_executorch()
-            .program
+            .executorch_program
         )
 
         addmm_found = False
@@ -881,22 +722,17 @@ class TestEmit(unittest.TestCase):
 
         model = SimpleLinear()
         inputs = (torch.ones(10, 5),)
-        capture_config = CaptureConfig(
-            enable_dynamic_shape=True,
-        )
-        program_relu = (
-            exir.capture(model.forward_relu, inputs, capture_config)
-            .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
-            .to_executorch()
-        )
-        program_sigmoid = (
-            exir.capture(model.forward_sigmoid, inputs, capture_config)
-            .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
-            .to_executorch()
-        )
+        program_relu = to_edge(
+            export(model.forward_relu, inputs),
+            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+        ).to_executorch()
+        program_sigmoid = to_edge(
+            export(model.forward_sigmoid, inputs),
+            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+        ).to_executorch()
         exir_input = {
-            "forward_relu": program_relu.dump_exported_program(),
-            "forward_sigmoid": program_sigmoid.dump_exported_program(),
+            "forward_relu": program_relu.exported_program(),
+            "forward_sigmoid": program_sigmoid.exported_program(),
         }
         merged_program = emit_program(exir_input, False).program
         self.assertEqual(len(merged_program.execution_plan), 2)
@@ -911,26 +747,28 @@ class TestEmit(unittest.TestCase):
         )
         # reserved spot, weight, bias
         self.assertEqual(
-            len(program_sigmoid.program.constant_buffer),
+            len(program_sigmoid._emitter_output.program.constant_buffer),
             3,
         )
         self.assertEqual(
-            len(program_relu.program.constant_buffer),
+            len(program_relu._emitter_output.program.constant_buffer),
             3,
         )
         # sum of the entry points minus 1 because we only have one reserved spot still
         self.assertEqual(
             len(merged_program.constant_buffer),
-            len(program_sigmoid.program.constant_buffer)
-            + len(program_relu.program.constant_buffer)
+            len(program_sigmoid._emitter_output.program.constant_buffer)
+            + len(program_relu._emitter_output.program.constant_buffer)
             - 1,
         )
 
         self._compare_execution_plans(
-            merged_program.execution_plan[0], program_relu.program.execution_plan[0]
+            merged_program.execution_plan[0],
+            program_relu._emitter_output.program.execution_plan[0],
         )
         self._compare_execution_plans(
-            merged_program.execution_plan[1], program_sigmoid.program.execution_plan[0]
+            merged_program.execution_plan[1],
+            program_sigmoid._emitter_output.program.execution_plan[0],
         )
 
     def test_emit_weight_deduplication(self) -> None:
@@ -947,43 +785,34 @@ class TestEmit(unittest.TestCase):
 
         model = SimpleLinear()
         inputs = (torch.ones(10, 5),)
-        capture_config = CaptureConfig(
-            enable_dynamic_shape=True,
-        )
-        program_relu = (
-            exir.capture(model.forward_relu, inputs, capture_config)
-            .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
-            .to_executorch()
-        )
-        program_sigmoid = (
-            exir.capture(model.forward_sigmoid, inputs, capture_config)
-            .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
-            .to_executorch()
-        )
+        program_relu = to_edge(export(model.forward_relu, inputs)).to_executorch()
+        program_sigmoid = to_edge(export(model.forward_sigmoid, inputs)).to_executorch()
         exir_input = {
-            "forward_relu": program_relu.dump_exported_program(),
-            "forward_sigmoid": program_sigmoid.dump_exported_program(),
+            "forward_relu": program_relu.exported_program(),
+            "forward_sigmoid": program_sigmoid.exported_program(),
         }
         merged_program = emit_program(exir_input, False).program
         self.assertEqual(len(merged_program.execution_plan), 2)
 
         # reserved spot, weight, bias
         self.assertEqual(
-            len(program_sigmoid.program.constant_buffer),
+            len(program_sigmoid._emitter_output.program.constant_buffer),
             3,
         )
         self.assertEqual(
-            len(program_relu.program.constant_buffer),
+            len(program_relu._emitter_output.program.constant_buffer),
             3,
         )
         # weights are shared between entry points so the merged one should deduplicate everything
         self.assertEqual(len(merged_program.constant_buffer), 3)
 
         self._compare_execution_plans(
-            merged_program.execution_plan[0], program_relu.program.execution_plan[0]
+            merged_program.execution_plan[0],
+            program_relu._emitter_output.program.execution_plan[0],
         )
         self._compare_execution_plans(
-            merged_program.execution_plan[1], program_sigmoid.program.execution_plan[0]
+            merged_program.execution_plan[1],
+            program_sigmoid._emitter_output.program.execution_plan[0],
         )
 
     def test_emit_execution_plans_sorted(self) -> None:
@@ -1006,27 +835,22 @@ class TestEmit(unittest.TestCase):
         def make_program(
             fn,
             inputs,
-        ) -> ExecutorchProgram:
-            return (
-                exir.capture(
+        ) -> "ExecutorchProgramManager":
+            return to_edge(
+                export(
                     fn,
                     inputs,
-                    CaptureConfig(
-                        enable_dynamic_shape=True,
-                    ),
                 )
-                .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
-                .to_executorch()
-            )
+            ).to_executorch()
 
         program_a = make_program(model.a, inputs)
         program_b = make_program(model.b, inputs)
         program_c = make_program(model.c, inputs)
 
         exir_input = {
-            "b": program_b.dump_exported_program(),
-            "c": program_c.dump_exported_program(),
-            "a": program_a.dump_exported_program(),
+            "b": program_b.exported_program(),
+            "c": program_c.exported_program(),
+            "a": program_a.exported_program(),
         }
         merged_program = emit_program(exir_input, False).program
         self.assertEqual(len(merged_program.execution_plan), 3)
@@ -1037,9 +861,9 @@ class TestEmit(unittest.TestCase):
         # Create a second program equivalent to the first, but the input is in a different order.
         # python dicts are instertion ordered
         exir_input2 = {
-            "a": program_b.dump_exported_program(),
-            "b": program_c.dump_exported_program(),
-            "c": program_a.dump_exported_program(),
+            "a": program_b.exported_program(),
+            "b": program_c.exported_program(),
+            "c": program_a.exported_program(),
         }
         merged_program2 = emit_program(exir_input2, False).program
         self.assertEqual(
@@ -1061,13 +885,12 @@ class TestEmit(unittest.TestCase):
         constraints = [
             dynamic_dim(k, 0) <= 3,
         ]
-        captured = exir.capture(
+        captured = export(
             func,
             (k,),
-            exir.CaptureConfig(pt2_mode=True, enable_aot=True),
-            constraints=constraints,  # enable_aot=False works
+            constraints=constraints,
         )
-        edge = captured.to_edge()
+        edge = to_edge(captured)
         from executorch.exir.passes import MemoryPlanningPass
 
         config = exir.ExecutorchBackendConfig(
@@ -1081,8 +904,8 @@ class TestEmit(unittest.TestCase):
         )
 
         exe_prog = edge.to_executorch(config)
-        program = exe_prog.program
-        exir.print_program.pretty_print(exe_prog.program.execution_plan)
+        program = exe_prog._emitter_output.program
+        exir.print_program.pretty_print(exe_prog._emitter_output.program.execution_plan)
         execution_plan = program.execution_plan[0]
         self.check_tensor_buffer_loc(0, execution_plan.values, 0, 1, 0)
         self.check_tensor_buffer_loc(1, execution_plan.values, 0, 1, 48)
@@ -1106,16 +929,9 @@ class TestEmit(unittest.TestCase):
 
         model = Simple()
         inputs = (torch.ones(10, 5),)
-        capture_config = CaptureConfig(
-            enable_dynamic_shape=True,
-        )
-        program = (
-            exir.capture(model.forward, inputs, capture_config)
-            .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
-            .to_executorch()
-        )
+        program = to_edge(export(model.forward, inputs)).to_executorch()
         exir_input = {
-            "forward": program.dump_exported_program(),
+            "forward": program.exported_program(),
         }
         getters = {}
         getters["get_ints"] = model.get_ints()
@@ -1174,17 +990,14 @@ class TestEmit(unittest.TestCase):
 
     def test_emit_debug_handle_map(self) -> None:
         mul_model = Mul()
-        program_mul = (
-            exir.capture(
+        program_mul = to_edge(
+            export(
                 mul_model,
                 mul_model.get_random_inputs(),
-                CaptureConfig(),
             )
-            .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
-            .to_executorch()
-        )
+        ).to_executorch()
         # this triggers the actual emission of the graph
-        program_mul.program
+        program_mul._emitter_output.program
         self.assertIsNotNone(program_mul.debug_handle_map)
 
     def test_final_graph_module_update_debug_handle(self) -> None:
@@ -1197,23 +1010,20 @@ class TestEmit(unittest.TestCase):
                 return a * 2
 
         mul_model = SimpleAddMul()
-        program_mul = (
-            exir.capture(
+        program_mul = to_edge(
+            export(
                 mul_model,
                 (torch.ones(2, 2),),
-                CaptureConfig(),
             )
-            .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
-            .to_executorch()
-        )
+        ).to_executorch()
 
         # this triggers the actual emission of the graph
-        program = program_mul.program
+        program = program_mul._emitter_output.program
         node = None
-        program.execution_plan[0].chains[0].instructions[0].instr_args.op_index
+        program.execution_plan[0].chains[0].instructions[0].instr_args.op_index  # pyre-ignore[16]
 
         # Find the multiplication node in the graph that was emitted.
-        for node in program_mul.dump_exported_program().graph.nodes:
+        for node in program_mul.exported_program().graph.nodes:
             if node.target == torch.ops.aten.mul.out:
                 break
         self.assertIsNotNone(node)
@@ -1222,7 +1032,7 @@ class TestEmit(unittest.TestCase):
         # Find the multiplication instruction in the program that was emitted.
         for idx in range(len(program.execution_plan[0].chains[0].instructions)):
             instruction = program.execution_plan[0].chains[0].instructions[idx]
-            op_index = instruction.instr_args.op_index
+            op_index = instruction.instr_args.op_index  # pyre-ignore[16]
             if "mul" in program.execution_plan[0].operators[op_index].name:
                 break
 
@@ -1255,11 +1065,9 @@ class TestEmit(unittest.TestCase):
 
         inputs = ([torch.ones(2, 2), torch.ones(2, 2)],)
         model = TestModel()
-        edgeir_m = exir.capture(model, inputs, exir.CaptureConfig()).to_edge(
-            exir.EdgeCompileConfig(_check_ir_validity=False)
-        )
+        edgeir_m = to_edge(export(model, inputs))
         lowered_module = to_backend(
-            "BackendWithCompilerDemo", edgeir_m.exported_program, None
+            "BackendWithCompilerDemo", edgeir_m.exported_program(), []
         )
 
         class CompositeModule(torch.nn.Module):
@@ -1271,11 +1079,9 @@ class TestEmit(unittest.TestCase):
                 return self.lowered_module(list_a)
 
         composite_model = CompositeModule()
-        exec_prog = (
-            exir.capture(composite_model, inputs, exir.CaptureConfig())
-            .to_edge()
-            .to_executorch()
-        )
+        exec_prog = to_edge(
+            export(composite_model, inputs),
+        ).to_executorch()
         exec_prog.buffer
 
     def test_delegate_with_input_tuple(self) -> None:
@@ -1301,11 +1107,9 @@ class TestEmit(unittest.TestCase):
 
         model_inputs = ((torch.ones(2, 2), 2 * torch.ones(2, 2), 3 * torch.ones(2, 2)),)
         model = AddMulModule()
-        edgeir_m = exir.capture(model, model_inputs, exir.CaptureConfig()).to_edge(
-            exir.EdgeCompileConfig(_check_ir_validity=False)
-        )
+        edgeir_m = to_edge(export(model, model_inputs))
         lowered_module = to_backend(
-            "BackendWithCompilerDemo", edgeir_m.exported_program, None
+            "BackendWithCompilerDemo", edgeir_m.exported_program(), []
         )
 
         class CompositeModule(torch.nn.Module):
@@ -1317,11 +1121,9 @@ class TestEmit(unittest.TestCase):
                 return self.lowered_module(list_a)
 
         composite_model = CompositeModule()
-        exec_prog = (
-            exir.capture(composite_model, model_inputs, exir.CaptureConfig())
-            .to_edge()
-            .to_executorch()
-        )
+        exec_prog = to_edge(
+            export(composite_model, model_inputs),
+        ).to_executorch()
         exec_prog.buffer
 
     def test_delegate_mapping(self) -> None:
@@ -1347,11 +1149,9 @@ class TestEmit(unittest.TestCase):
 
         inputs = (torch.ones(2, 2), torch.ones(2, 2))
         model = TestModel()
-        edgeir_m = exir.capture(model, inputs, exir.CaptureConfig()).to_edge(
-            exir.EdgeCompileConfig(_check_ir_validity=False)
-        )
+        edgeir_m = to_edge(export(model, inputs))
         lowered_module = to_backend(
-            "BackendWithCompilerDemo", edgeir_m.exported_program, None
+            "BackendWithCompilerDemo", edgeir_m.exported_program(), []
         )
 
         class CompositeModule(torch.nn.Module):
@@ -1363,17 +1163,15 @@ class TestEmit(unittest.TestCase):
                 return self.lowered_module(x, y)
 
         composite_model = CompositeModule()
-        exec_prog = (
-            exir.capture(composite_model, inputs, exir.CaptureConfig())
-            .to_edge()
-            .to_executorch()
-        )
+        exec_prog = to_edge(
+            export(composite_model, inputs),
+        ).to_executorch()
         # Reading the program triggers the call to emit_program underneath which
         # we need to be done for our test to succeed.
-        exec_prog.program
+        exec_prog._emitter_output.program
         self.assertIsNotNone(exec_prog.delegate_map)
         self.assertIsNotNone(exec_prog.delegate_map.get("forward"))
-        self.assertIsNotNone(exec_prog.delegate_map.get("forward").get(0))
+        self.assertIsNotNone(exec_prog.delegate_map.get("forward").get(0))  # pyre-ignore[16]
         self.assertEqual(
             exec_prog.delegate_map.get("forward").get(0).get("name"),
             "BackendWithCompilerDemo",


### PR DESCRIPTION
Summary: exir.capture is deprecated. Switch to blessed path

Differential Revision: D51503120


