### PR TITLE
[ci] Fix unittest ci

### DIFF
--- a/exir/tests/test_memory_format_ops_pass.py
+++ b/exir/tests/test_memory_format_ops_pass.py
@@ -55,11 +55,11 @@ class TestMemoryFormatOpsPass(unittest.TestCase):
             ).run(before.exported_program.graph_module.code)
 
             ep = before.to_edge(
-                config=EdgeCompileConfig(_use_edge_ops=True)
+                config=EdgeCompileConfig(_check_ir_validity=False)
             )  # Only replacing edge_ops
 
             # Run the pass - TODO move this in to_edge passes
-            after = ep.transform([MemoryFormatOpsPass()], check_ir_validity=False)
+            after = ep.transform(MemoryFormatOpsPass())
 
             # check op strings
             FileCheck().check_not(aten_op_str).check_count(

--- a/exir/tests/test_memory_format_ops_pass.py
+++ b/exir/tests/test_memory_format_ops_pass.py
@@ -59,7 +59,7 @@ class TestMemoryFormatOpsPass(unittest.TestCase):
             )  # Only replacing edge_ops
 
             # Run the pass - TODO move this in to_edge passes
-            after = ep.transform(MemoryFormatOpsPass())
+            after = ep.transform([MemoryFormatOpsPass()], check_ir_validity=False)
 
             # check op strings
             FileCheck().check_not(aten_op_str).check_count(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1260

Disable check_ir_validity check in transform().

This fixes the following error:

```
torch._export.verifier.SpecViolationError: Operator torch._ops.dim_order_ops._to_dim_order_copy.default is not Aten Canonical.
```

Differential Revision: [D51506923](https://our.internmc.facebook.com/intern/diff/D51506923)