### PR TITLE
update test_backends_lifted.py to use export

### DIFF
--- a/exir/backend/test/test_backends_lifted.py
+++ b/exir/backend/test/test_backends_lifted.py
@@ -9,6 +9,7 @@ from typing import Dict, List
 
 import executorch.exir as exir
 import torch
+from executorch.exir import to_edge
 from executorch.exir.backend.backend_api import LoweredBackendModule, to_backend
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.backend.partitioner import (
@@ -61,12 +62,8 @@ from torch.ao.quantization.quantize_fx import (
     _convert_to_reference_decomposed_fx,
     prepare_fx,
 )
-from torch.export import ExportedProgram
+from torch.export import export, ExportedProgram
 from torch.testing import FileCheck
-
-
-def get_testing_capture_config():
-    return exir.CaptureConfig(enable_aot=True, _unlift=False)
 
 
 def vary_segments(test_method):
@@ -132,19 +129,17 @@ class TestBackends(unittest.TestCase):
         sin_module = SinModule()
         model_inputs = (torch.ones(1),)
         expected_res = sin_module(*model_inputs)
-        edgeir_m = exir.capture(
-            sin_module, model_inputs, get_testing_capture_config()
-        ).to_edge()
+        edgeir_m = to_edge(export(sin_module, model_inputs))
 
         lowered_sin_module = to_backend(
-            "BackendWithCompilerDemo", edgeir_m.exported_program, []
+            "BackendWithCompilerDemo", edgeir_m.exported_program(), []
         )
         new_res = lowered_sin_module(*model_inputs)
 
         self.assertTrue(torch.allclose(new_res, expected_res))
 
         # TODO(tkaruturi): emitting single LoweredBackendModule
-        # program = exir.capture(graph_module).to_edge().to_exectorch().program
+        # program = to_edge(export(graph_module)).to_exectorch()._emitter_output.program
 
     @vary_segments
     def test_backend_with_compiler(self, extract_segments: bool):
@@ -159,13 +154,11 @@ class TestBackends(unittest.TestCase):
 
         sin_module = SinModule()
         model_inputs = (torch.ones(1),)
-        edgeir_m = exir.capture(
-            sin_module, model_inputs, get_testing_capture_config()
-        ).to_edge()
+        edgeir_m = to_edge(export(sin_module, model_inputs))
         max_value = model_inputs[0].shape[0]
         compile_specs = [CompileSpec("max_value", bytes([max_value]))]
         lowered_sin_module = to_backend(
-            "BackendWithCompilerDemo", edgeir_m.exported_program, compile_specs
+            "BackendWithCompilerDemo", edgeir_m.exported_program(), compile_specs
         )
 
         class CompositeModule(torch.nn.Module):
@@ -181,14 +174,10 @@ class TestBackends(unittest.TestCase):
 
         composite_model(*model_inputs)
 
-        exec_prog = (
-            exir.capture(composite_model, model_inputs, get_testing_capture_config())
-            .to_edge()
-            .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments)
-            )
+        exec_prog = to_edge(export(composite_model, model_inputs)).to_executorch(
+            config=exir.ExecutorchBackendConfig(extract_segments=extract_segments)
         )
-        graph_module = exec_prog.dump_graph_module()
+        graph_module = exec_prog.exported_program().graph_module
 
         # Check that there is not an aten.sin node.
         self.assertTrue(
@@ -209,7 +198,7 @@ class TestBackends(unittest.TestCase):
                 # Check that first arg is lowered_module_{unique_id}
                 self.assertEqual(node.args[0].target, "lowered_module_0")
 
-        program = exec_prog.program
+        program = exec_prog._emitter_output.program
 
         # Check the program can be printed
         print_program(program)
@@ -257,13 +246,13 @@ class TestBackends(unittest.TestCase):
 
         add_mul_module = AddMulModule()
         model_inputs = (torch.ones(2, 2), 2 * torch.ones(2, 2), 3 * torch.ones(2, 2))
-        edge_graph_module = exir.capture(
-            add_mul_module, model_inputs, get_testing_capture_config()
-        ).to_edge()
+        edge_graph_module = to_edge(export(add_mul_module, model_inputs))
         max_value = model_inputs[0].shape[0]
         compile_specs = [CompileSpec("max_value", bytes([max_value]))]
         lowered_add_mul = to_backend(
-            "BackendWithCompilerDemo", edge_graph_module.exported_program, compile_specs
+            "BackendWithCompilerDemo",
+            edge_graph_module.exported_program(),
+            compile_specs,
         )
 
         class CompositeModule(torch.nn.Module):
@@ -278,14 +267,8 @@ class TestBackends(unittest.TestCase):
 
         composite_model(*model_inputs)
 
-        exec_prog = (
-            exir.capture(composite_model, model_inputs, get_testing_capture_config())
-            .to_edge(
-                exir.EdgeCompileConfig(_use_edge_ops=True, _check_ir_validity=True)
-            )
-            .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments)
-            )
+        exec_prog = to_edge(export(composite_model, model_inputs)).to_executorch(
+            config=exir.ExecutorchBackendConfig(extract_segments=extract_segments)
         )
         buff = exec_prog.buffer
 
@@ -311,13 +294,11 @@ class TestBackends(unittest.TestCase):
         sin_module = SinModule()
         # the backend only  accepts shape <= 4
         model_inputs = (torch.ones(6),)
-        edgeir_m = exir.capture(
-            sin_module, model_inputs, get_testing_capture_config()
-        ).to_edge()
+        edgeir_m = to_edge(export(sin_module, model_inputs))
         max_value = model_inputs[0].shape[0]
         compile_specs = [CompileSpec("max_value", bytes([max_value]))]
         lowered_sin_module = to_backend(
-            "BackendWithCompilerDemo", edgeir_m.exported_program, compile_specs
+            "BackendWithCompilerDemo", edgeir_m.exported_program(), compile_specs
         )
 
         class CompositeModule(torch.nn.Module):
@@ -333,12 +314,8 @@ class TestBackends(unittest.TestCase):
 
         composite_model(*model_inputs)
 
-        exec_prog = (
-            exir.capture(composite_model, model_inputs, get_testing_capture_config())
-            .to_edge()
-            .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
-            )
+        exec_prog = to_edge(export(composite_model, model_inputs)).to_executorch(
+            config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
         )
 
         buff = exec_prog.buffer
@@ -374,13 +351,11 @@ class TestBackends(unittest.TestCase):
 
         sin_module = SinModule()
         model_inputs = (torch.ones(1),)
-        edgeir_m = exir.capture(
-            sin_module, model_inputs, get_testing_capture_config()
-        ).to_edge()
+        edgeir_m = to_edge(export(sin_module, model_inputs))
         max_value = model_inputs[0].shape[0]
         compile_specs = [CompileSpec("max_value", bytes([max_value]))]
         lowered_sin_module = to_backend(
-            "BackendWithCompilerDemo", edgeir_m.exported_program, compile_specs
+            "BackendWithCompilerDemo", edgeir_m.exported_program(), compile_specs
         )
 
         class CompositeModule(torch.nn.Module):
@@ -398,15 +373,11 @@ class TestBackends(unittest.TestCase):
 
         composite_model(*model_inputs)
 
-        exec_prog = (
-            exir.capture(composite_model, model_inputs, get_testing_capture_config())
-            .to_edge()
-            .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
-            )
+        exec_prog = to_edge(export(composite_model, model_inputs)).to_executorch(
+            config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
         )
-        graph_module = exec_prog.dump_graph_module()
-        program = exec_prog.program
+        graph_module = exec_prog.exported_program().graph_module
+        program = exec_prog._emitter_output.program
         buff = exec_prog.buffer
 
         # Check that there is not an aten.sin node.
@@ -469,16 +440,14 @@ class TestBackends(unittest.TestCase):
 
         sin_module = SinModule()
         model_inputs = (torch.ones(1),)
-        edgeir_m = exir.capture(
-            sin_module, model_inputs, get_testing_capture_config()
-        ).to_edge()
+        edgeir_m = to_edge(export(sin_module, model_inputs))
         error_msg = r"call_function aten.cos.default is not supported in backend BackendWithCompilerDemo"
 
         with self.assertRaisesRegex(
             RuntimeError,
             error_msg,
         ):
-            _ = to_backend("BackendWithCompilerDemo", edgeir_m.exported_program, [])
+            _ = to_backend("BackendWithCompilerDemo", edgeir_m.exported_program(), [])
 
     def test_backend_with_compiler_backend_not_found_exception(self):
         class SinModule(torch.nn.Module):
@@ -492,16 +461,16 @@ class TestBackends(unittest.TestCase):
 
         sin_module = SinModule()
         model_inputs = (torch.ones(1),)
-        edgeir_m = exir.capture(
-            sin_module, model_inputs, get_testing_capture_config()
-        ).to_edge()
+        edgeir_m = to_edge(export(sin_module, model_inputs))
         error_msg = r"Backend FakeBackendWithCompilerDemo was not found."
 
         with self.assertRaisesRegex(
             NotImplementedError,
             error_msg,
         ):
-            _ = to_backend("FakeBackendWithCompilerDemo", edgeir_m.exported_program, [])
+            _ = to_backend(
+                "FakeBackendWithCompilerDemo", edgeir_m.exported_program(), []
+            )
 
     @vary_segments
     def test_backend_with_compiler_delegate_and_operator_with_two_modules(
@@ -518,15 +487,13 @@ class TestBackends(unittest.TestCase):
         # sin_module is an nn.Module
         to_be_lowered = LowerableSubModel()
         example_input = (torch.ones(1),)
-        to_be_lowered_exir_submodule = exir.capture(
-            to_be_lowered, example_input, get_testing_capture_config()
-        ).to_edge()
+        to_be_lowered_exir_submodule = to_edge(export(to_be_lowered, example_input))
 
         max_value = example_input[0].shape[0]
         compile_specs = [CompileSpec("max_value", bytes([max_value]))]
         lowered_module = to_backend(
             "BackendWithCompilerDemo",
-            to_be_lowered_exir_submodule.exported_program,
+            to_be_lowered_exir_submodule.exported_program(),
             compile_specs,
         )
 
@@ -559,12 +526,8 @@ class TestBackends(unittest.TestCase):
         # Verify the input works with eager module
         composite_model(*model_inputs)
 
-        exec_prog = (
-            exir.capture(composite_model, model_inputs, get_testing_capture_config())
-            .to_edge()
-            .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
-            )
+        exec_prog = to_edge(export(composite_model, model_inputs)).to_executorch(
+            config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
         )
         flatbuffer = exec_prog.buffer
 
@@ -620,39 +583,41 @@ class TestBackends(unittest.TestCase):
         composite_m = CompositeModel(3)
         orig_res = composite_m(*inputs)
 
-        traced = exir.capture(
-            composite_m, inputs, get_testing_capture_config()
-        ).to_edge(exir.EdgeCompileConfig(_check_ir_validity=False, _use_edge_ops=True))
+        traced = to_edge(
+            export(composite_m, inputs),
+            compile_config=exir.EdgeCompileConfig(
+                _check_ir_validity=False, _use_edge_ops=True
+            ),
+        )
 
-        program_without_delegates = (
-            exir.capture(CompositeModel(3), inputs)
-            .to_edge(
-                exir.EdgeCompileConfig(
-                    _check_ir_validity=False,
-                )
-            )
-            .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
-            )
+        program_without_delegates = to_edge(
+            export(CompositeModel(3), inputs),
+            compile_config=exir.EdgeCompileConfig(
+                _check_ir_validity=False,
+            ),
+        ).to_executorch(
+            config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
         )
         # after this step, part of the graph will be lowered to backend, depending on
         # HTAPartitionerDemo's rule.
         program_with_delegates = traced
-        program_with_delegates.exported_program = to_backend(
-            traced.exported_program, HTAPartitionerMultiplePatternsDemo()
+        program_with_delegates = program_with_delegates.to_backend(
+            HTAPartitionerMultiplePatternsDemo()
         )
         program_with_delegates = program_with_delegates.to_executorch(
             config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
         )
 
-        new_res = program_with_delegates.dump_exported_program()(*inputs)
+        new_res = program_with_delegates.exported_program()(*inputs)
         for t1, t2 in zip(new_res, orig_res, strict=True):
             self.assertTrue(torch.allclose(t1, t2, atol=1e-03, rtol=1e-03))
 
         # Check the backend delegate
         self.check_backend_delegate(
-            program=program_with_delegates.program,
-            delegate=program_with_delegates.program.execution_plan[0].delegates[0],
+            program=program_with_delegates._emitter_output.program,
+            delegate=program_with_delegates._emitter_output.program.execution_plan[
+                0
+            ].delegates[0],
             expected_id=QnnBackend.__name__,
             expected_processed=b"imqnncompiled",
         )
@@ -663,7 +628,9 @@ class TestBackends(unittest.TestCase):
             len(
                 [
                     op
-                    for op in program_with_delegates.program.execution_plan[0].operators
+                    for op in program_with_delegates._emitter_output.program.execution_plan[
+                        0
+                    ].operators
                     if op.name == "aten::sub"
                 ]
             ),
@@ -675,7 +642,9 @@ class TestBackends(unittest.TestCase):
             len(
                 [
                     op
-                    for op in program_with_delegates.program.execution_plan[0].operators
+                    for op in program_with_delegates._emitter_output.program.execution_plan[
+                        0
+                    ].operators
                     if op.name == "aten::convolution"
                 ]
             ),
@@ -687,7 +656,7 @@ class TestBackends(unittest.TestCase):
             len(
                 [
                     op
-                    for op in program_without_delegates.program.execution_plan[
+                    for op in program_without_delegates._emitter_output.program.execution_plan[
                         0
                     ].operators
                     if op.name == "aten::convolution"
@@ -729,35 +698,32 @@ class TestBackends(unittest.TestCase):
         composite_m = CompositeModel(3)
         orig_res = composite_m(*inputs)
 
-        traced = exir.capture(
-            composite_m,
-            inputs,
-            get_testing_capture_config(),
-        ).to_edge(exir.EdgeCompileConfig(_check_ir_validity=False, _use_edge_ops=True))
+        traced = to_edge(
+            export(composite_m, inputs),
+            compile_config=exir.EdgeCompileConfig(
+                _check_ir_validity=False, _use_edge_ops=True
+            ),
+        )
 
-        program_without_delegates = (
-            exir.capture(
+        program_without_delegates = to_edge(
+            export(
                 CompositeModel(3),
                 (input_x, input_h, input_c),
-                get_testing_capture_config(),
-            )
-            .to_edge(
-                exir.EdgeCompileConfig(
-                    _check_ir_validity=False,
-                )
-            )
-            .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
-            )
+            ),
+            compile_config=exir.EdgeCompileConfig(
+                _check_ir_validity=False,
+            ),
+        ).to_executorch(
+            config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
         )
         # after this step, part of the graph will be lowered to backend, depending on
         # HTAPartitionerDemo's rule.
         traced_with_delegate = traced
-        traced_with_delegate.exported_program = to_backend(
-            traced.exported_program, HTAPartitionerOnePatternDemo()
+        traced_with_delegate = traced_with_delegate.to_backend(
+            HTAPartitionerOnePatternDemo()
         )
 
-        new_res = traced_with_delegate(*inputs)
+        new_res = traced_with_delegate.exported_program()(*inputs)
         for t1, t2 in zip(new_res, orig_res, strict=True):
             self.assertTrue(torch.allclose(t1, t2, atol=1e-03, rtol=1e-03))
 
@@ -768,24 +734,26 @@ class TestBackends(unittest.TestCase):
         # TODO(T143084047): Currently not retraceable
         # Retracing is not needed, but keeping this here to make sure the result
         # of to_backend is retraceable
-        # graph_module_with_delegate = exir.capture(
+        # graph_module_with_delegate = to_edge(export(
         #     traced_with_delegate,
         #     (input_x, input_h, input_c),
-        #     get_testing_capture_config(),
-        # ).to_edge()
+        #
+        # ))
 
         # program_with_delegates = graph_module_with_delegate.to_executorch(
         #     config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
         # )
 
-        new_res = program_with_delegates.dump_exported_program()(*inputs)
+        new_res = program_with_delegates.exported_program()(*inputs)
         for t1, t2 in zip(new_res, orig_res, strict=True):
             self.assertTrue(torch.allclose(t1, t2, atol=1e-03, rtol=1e-03))
 
         # Check the backend delegate
         self.check_backend_delegate(
-            program=program_with_delegates.program,
-            delegate=program_with_delegates.program.execution_plan[0].delegates[0],
+            program=program_with_delegates._emitter_output.program,
+            delegate=program_with_delegates._emitter_output.program.execution_plan[
+                0
+            ].delegates[0],
             expected_id=QnnBackend.__name__,
             expected_processed=b"imqnncompiled",
         )
@@ -796,7 +764,9 @@ class TestBackends(unittest.TestCase):
             len(
                 [
                     op
-                    for op in program_with_delegates.program.execution_plan[0].operators
+                    for op in program_with_delegates._emitter_output.program.execution_plan[
+                        0
+                    ].operators
                     if op.name == "aten::sub"
                 ]
             ),
@@ -808,7 +778,9 @@ class TestBackends(unittest.TestCase):
             len(
                 [
                     op
-                    for op in program_with_delegates.program.execution_plan[0].operators
+                    for op in program_with_delegates._emitter_output.program.execution_plan[
+                        0
+                    ].operators
                     if op.name == "aten::convolution"
                 ]
             ),
@@ -820,7 +792,7 @@ class TestBackends(unittest.TestCase):
             len(
                 [
                     op
-                    for op in program_without_delegates.program.execution_plan[
+                    for op in program_without_delegates._emitter_output.program.execution_plan[
                         0
                     ].operators
                     if op.name == "aten::convolution"
@@ -846,20 +818,18 @@ class TestBackends(unittest.TestCase):
         inputs = (torch.randn(2, 2), torch.randn(2, 2), torch.randn(2, 2))
         orig_res = m(*inputs)
 
-        ep = exir.capture(m, inputs, get_testing_capture_config()).to_edge()
+        ep = to_edge(export(m, inputs))
         executorch_prog = ep
-        executorch_prog.exported_program = to_backend(
-            ep.exported_program, AddMulPartitionerDemo()
-        )
+        executorch_prog = executorch_prog.to_backend(AddMulPartitionerDemo())
         executorch_prog = executorch_prog.to_executorch(
             config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
         )
 
-        new_res = executorch_prog.dump_graph_module()(*inputs)
+        new_res = executorch_prog.exported_program().graph_module(*inputs)
         self.assertTrue(torch.allclose(new_res[0], orig_res))
 
         counter = 0
-        for node in executorch_prog.dump_graph_module().graph.nodes:
+        for node in executorch_prog.exported_program().graph_module.graph.nodes:
             if node.op == "get_attr":
                 self.assertEqual(node.target, f"lowered_module_{counter}")
                 counter += 1
@@ -902,18 +872,16 @@ class TestBackends(unittest.TestCase):
 
         inputs = (torch.randn(1, 3), torch.randn(1, 3))
         orig_res = Model()(*inputs)
-        ep = exir.capture(Model(), inputs, get_testing_capture_config()).to_edge()
+        ep = to_edge(export(Model(), inputs))
         executorch_prog = ep
-        executorch_prog.exported_program = to_backend(
-            ep.exported_program, AddAttributePartitionerDemo()
-        )
+        executorch_prog = executorch_prog.to_backend(AddAttributePartitionerDemo())
         executorch_prog = executorch_prog.to_executorch(
             config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
         )
 
         # Check the delegated submodules
         lowered_backends = get_lowered_backend_modules(
-            executorch_prog.dump_graph_module()
+            executorch_prog.exported_program().graph_module
         )
         self.assertEqual(len(lowered_backends), 2)
         for backend in lowered_backends:
@@ -925,7 +893,7 @@ class TestBackends(unittest.TestCase):
 
         executorch_prog.buffer
 
-        new_res = executorch_prog.dump_graph_module()(*inputs)
+        new_res = executorch_prog.exported_program().graph_module(*inputs)
         self.assertTrue(torch.allclose(orig_res, new_res[0]))
 
     def test_bad_partitioner(self):
@@ -965,9 +933,9 @@ class TestBackends(unittest.TestCase):
                     partition_tags=partition_tags,
                 )
 
-        ep = exir.capture(Model(), inputs, get_testing_capture_config()).to_edge()
+        ep = to_edge(export(Model(), inputs))
         with self.assertRaises(AssertionError):
-            _ = to_backend(ep.exported_program, BadPartitioner())
+            _ = ep.to_backend(BadPartitioner())
 
     def test_quantized_with_delegate(self) -> None:
         torch.ops.load_library(
@@ -990,20 +958,17 @@ class TestBackends(unittest.TestCase):
         )
 
         # fails to trace here
-        converted_linear_gm = exir.capture(
-            converted_linear,
-            example_inputs,
-            exir.CaptureConfig(
-                enable_aot=True,
-                _unlift=True,
+        converted_linear_gm = to_edge(
+            export(
+                converted_linear,
+                example_inputs,
             ),
-        ).to_edge(
-            exir.EdgeCompileConfig(
+            compile_config=exir.EdgeCompileConfig(
                 _check_ir_validity=False,
-            )
+            ),
         )
         FileCheck().check_count("quantize_per_tensor_default", 3).check("addmm").run(
-            converted_linear_gm.exported_program.graph_module.code
+            converted_linear_gm.exported_program().graph_module.code
         )
 
     def test_partition_with_control_flow(self) -> None:
@@ -1027,21 +992,20 @@ class TestBackends(unittest.TestCase):
 
         inputs = (torch.ones(2, 2), torch.ones(2, 2))
         orig_res = f(*inputs)
-        orig = exir.capture(
-            f,
-            inputs,
-            get_testing_capture_config(),
-        ).to_edge()
-        partitioned = orig
-        partitioned.exported_program = to_backend(
-            orig.exported_program, AddMulPartitionerDemo()
+        orig = to_edge(
+            export(
+                f,
+                inputs,
+            )
         )
+        partitioned = orig
+        partitioned = partitioned.to_backend(AddMulPartitionerDemo())
 
-        new_res = partitioned(*inputs)
+        new_res = partitioned.exported_program()(*inputs)
         self.assertTrue(torch.allclose(orig_res, new_res[0]))
 
         toplevel_lowered = get_lowered_submodules(
-            partitioned.exported_program.graph_module
+            partitioned.exported_program().graph_module
         )
         self.assertEqual(len(toplevel_lowered), 1)
         FileCheck().check("executorch_exir_dialects_edge__ops_aten_add_Tensor").run(
@@ -1050,7 +1014,7 @@ class TestBackends(unittest.TestCase):
 
         # Toplevel module only has the cond submodules
         partitioned_submodules = get_control_flow_submodules(
-            partitioned.exported_program.graph_module
+            partitioned.exported_program().graph_module
         )
         self.assertEqual(len(partitioned_submodules), 2)
 
@@ -1080,18 +1044,17 @@ class TestBackends(unittest.TestCase):
 
         inputs = (torch.ones(2, 2), torch.ones(2, 2))
         orig_res = f(*inputs)
-        orig = exir.capture(
-            f,
-            inputs,
-            get_testing_capture_config(),
-        ).to_edge()
-        partitioned = orig
-        partitioned.exported_program = to_backend(
-            orig.exported_program, AddMulPartitionerDemo()
+        orig = to_edge(
+            export(
+                f,
+                inputs,
+            )
         )
+        partitioned = orig
+        partitioned = partitioned.to_backend(AddMulPartitionerDemo())
 
         toplevel_lowered = get_lowered_submodules(
-            partitioned.exported_program.graph_module
+            partitioned.exported_program().graph_module
         )
         self.assertEqual(len(toplevel_lowered), 1)
         FileCheck().check("executorch_exir_dialects_edge__ops_aten_mm_default").run(
@@ -1100,7 +1063,7 @@ class TestBackends(unittest.TestCase):
 
         # Toplevel module only has the map submodule
         partitioned_submodules = get_control_flow_submodules(
-            partitioned.exported_program.graph_module
+            partitioned.exported_program().graph_module
         )
         self.assertEqual(len(partitioned_submodules), 1)
 
@@ -1111,7 +1074,7 @@ class TestBackends(unittest.TestCase):
             map_fn_lowered[0][1].original_module.graph_module.code
         )
 
-        new_res = partitioned(*inputs)
+        new_res = partitioned.exported_program()(*inputs)
 
         self.assertTrue(torch.allclose(orig_res, new_res[0]))
 
@@ -1153,21 +1116,20 @@ class TestBackends(unittest.TestCase):
         )
 
         orig_res = f(*inputs)
-        orig = exir.capture(
-            f,
-            inputs,
-            get_testing_capture_config(),
-        ).to_edge()
-        partitioned = orig
-        partitioned.exported_program = to_backend(
-            orig.exported_program, AddMulPartitionerDemo()
+        orig = to_edge(
+            export(
+                f,
+                inputs,
+            )
         )
+        partitioned = orig
+        partitioned = partitioned.to_backend(AddMulPartitionerDemo())
 
-        new_res = partitioned(*inputs)
+        new_res = partitioned.exported_program()(*inputs)
         self.assertTrue(torch.allclose(orig_res, new_res[0]))
 
         toplevel_lowered = get_lowered_submodules(
-            partitioned.exported_program.graph_module
+            partitioned.exported_program().graph_module
         )
         self.assertEqual(len(toplevel_lowered), 1)
         FileCheck().check("executorch_exir_dialects_edge__ops_aten_mm_default").run(
@@ -1176,7 +1138,7 @@ class TestBackends(unittest.TestCase):
 
         # Toplevel module only has the map submodule
         partitioned_submodules = get_control_flow_submodules(
-            partitioned.exported_program.graph_module
+            partitioned.exported_program().graph_module
         )
         self.assertEqual(len(partitioned_submodules), 1)
 
@@ -1220,9 +1182,9 @@ class TestBackends(unittest.TestCase):
             return y
 
         inputs = ([torch.randn(2, 2), torch.randn(2, 2)],)
-        edge_prog = exir.capture(f, inputs, get_testing_capture_config()).to_edge()
+        edge_prog = to_edge(export(f, inputs))
         lowered_gm = to_backend(
-            BackendWithCompilerDemo.__name__, edge_prog.exported_program, []
+            BackendWithCompilerDemo.__name__, edge_prog.exported_program(), []
         )
 
         class ComposedM(torch.nn.Module):
@@ -1233,8 +1195,8 @@ class TestBackends(unittest.TestCase):
             def forward(self, x: List[torch.Tensor]):
                 return self.lowered(x)
 
-        gm = exir.capture(ComposedM(), inputs, get_testing_capture_config()).to_edge()
-        gm(*inputs)
+        gm = to_edge(export(ComposedM(), inputs))
+        gm.exported_program()(*inputs)
 
     def test_dict_input(self):
         def f(x: Dict[str, torch.Tensor]):
@@ -1242,9 +1204,9 @@ class TestBackends(unittest.TestCase):
             return y
 
         inputs = ({"a": torch.randn(2, 2), "b": torch.randn(2, 2)},)
-        edge_prog = exir.capture(f, inputs, get_testing_capture_config()).to_edge()
+        edge_prog = to_edge(export(f, inputs))
         lowered_gm = to_backend(
-            BackendWithCompilerDemo.__name__, edge_prog.exported_program, []
+            BackendWithCompilerDemo.__name__, edge_prog.exported_program(), []
         )
 
         class ComposedM(torch.nn.Module):
@@ -1255,5 +1217,5 @@ class TestBackends(unittest.TestCase):
             def forward(self, x: List[torch.Tensor]):
                 return self.lowered(x)
 
-        gm = exir.capture(ComposedM(), inputs, get_testing_capture_config()).to_edge()
-        gm(*inputs)
+        gm = to_edge(export(ComposedM(), inputs))
+        gm.exported_program()(*inputs)


### PR DESCRIPTION
Summary: exir.capture is deprecated. Updated to use export instead.

Differential Revision: D51508366


