### PR TITLE
Migrate tests for additional ops

### DIFF
--- a/backends/xnnpack/test/ops/add.py
+++ b/backends/xnnpack/test/ops/add.py
@@ -25,6 +25,16 @@ class TestAdd(unittest.TestCase):
             z = z + z
             return z
 
+    class AddConstant(torch.nn.Module):
+        def __init__(self, constant):
+            super().__init__()
+            self._constant = constant
+
+        def forward(self, x):
+            out1 = x + self._constant
+            out2 = x + self._constant + self._constant
+            return out1, out2
+
     def test_fp32_add(self):
         inputs = (torch.ones(1), torch.ones(1))
         (
@@ -33,6 +43,23 @@ class TestAdd(unittest.TestCase):
             .check_count({"torch.ops.aten.add.Tensor": 4})
             .to_edge()
             .check_count({"executorch_exir_dialects_edge__ops_aten_add_Tensor": 4})
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .check_not(["executorch_exir_dialects_edge__ops_aten_add_Tensor"])
+            .to_executorch()
+            .serialize()
+            .run_method()
+            .compare_outputs()
+        )
+
+    def test_fp32_add_constant(self):
+        inputs = (torch.randn(4, 4, 4),)
+        (
+            Tester(self.AddConstant(torch.ones(4, 4, 4)), inputs)
+            .export()
+            .check_count({"torch.ops.aten.add.Tensor": 3})
+            .to_edge()
+            .check_count({"executorch_exir_dialects_edge__ops_aten_add_Tensor": 3})
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .check_not(["executorch_exir_dialects_edge__ops_aten_add_Tensor"])

--- a/backends/xnnpack/test/ops/hardtanh.py
+++ b/backends/xnnpack/test/ops/hardtanh.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack.test.tester import Tester
+
+
+class TestHardTanh(unittest.TestCase):
+    class HardTanh(torch.nn.Module):
+        def __init__(self, min_val=-1.0, max_val=1.0):
+            super().__init__()
+            self.min_val = min_val
+            self.max_val = max_val
+
+        def forward(self, x):
+            return torch.nn.Hardtanh(self.min_val, self.max_val)(x)
+
+    def test_fp32_hardtanh(self):
+        inputs_sets = [torch.randn(2, 3, 4), torch.randn(7, 5, 2), torch.randn(2, 9)]
+        for input in inputs_sets:
+            (
+                Tester(self.HardTanh(), (input,))
+                .export()
+                .check_count({"torch.ops.aten.hardtanh.default": 1})
+                .to_edge()
+                .check_count(
+                    {"executorch_exir_dialects_edge__ops_aten_hardtanh_default": 1}
+                )
+                .partition()
+                .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+                .check_not(["executorch_exir_dialects_edge__ops_aten_hardtanh_default"])
+                .to_executorch()
+                .serialize()
+                .run_method()
+                .compare_outputs()
+            )
+
+    def test_fp32_hardtanh_bound(self):
+        inputs_sets = [torch.randn(2, 3, 4), torch.randn(7, 5, 2), torch.randn(2, 9)]
+        for input in inputs_sets:
+            (
+                Tester(self.HardTanh(-2.0, 2.0), (input,))
+                .export()
+                .check_count({"torch.ops.aten.hardtanh.default": 1})
+                .to_edge()
+                .check_count(
+                    {"executorch_exir_dialects_edge__ops_aten_hardtanh_default": 1}
+                )
+                .partition()
+                .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+                .check_not(["executorch_exir_dialects_edge__ops_aten_hardtanh_default"])
+                .to_executorch()
+                .serialize()
+                .run_method()
+                .compare_outputs()
+            )

--- a/backends/xnnpack/test/ops/maximum.py
+++ b/backends/xnnpack/test/ops/maximum.py
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack.test.tester import Tester
+
+
+class TestMaximum(unittest.TestCase):
+    class Maximum(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x, y):
+            return torch.maximum(x, y)
+
+    def test_fp32_maximum(self):
+        inputs = (
+            torch.randn(2, 3, 4),
+            torch.randn(2, 3, 4),
+        )
+        (
+            Tester(self.Maximum(), inputs)
+            .export()
+            .check_count({"torch.ops.aten.maximum.default": 1})
+            .to_edge()
+            .check_count({"executorch_exir_dialects_edge__ops_aten_maximum_default": 1})
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .check_not(["executorch_exir_dialects_edge__ops_aten_maximum_default"])
+            .to_executorch()
+            .serialize()
+            .run_method()
+            .compare_outputs()
+        )
+
+    def test_fp32_maximum_broadcast(self):
+        inputs = (
+            torch.randn(2, 3, 4),
+            torch.randn(2, 1, 4),
+        )
+        (
+            Tester(self.Maximum(), inputs)
+            .export()
+            .check_count({"torch.ops.aten.maximum.default": 1})
+            .to_edge()
+            .check_count({"executorch_exir_dialects_edge__ops_aten_maximum_default": 1})
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .check_not(["executorch_exir_dialects_edge__ops_aten_maximum_default"])
+            .to_executorch()
+            .serialize()
+            .run_method()
+            .compare_outputs()
+        )

--- a/backends/xnnpack/test/ops/mean_dim.py
+++ b/backends/xnnpack/test/ops/mean_dim.py
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack.test.tester import Tester
+
+
+class TestMeanDim(unittest.TestCase):
+    class MeanDim(torch.nn.Module):
+        def __init__(self, dims):
+            super().__init__()
+            self.dims = dims
+
+        def forward(self, x):
+            return torch.mean(x, self.dims, keepdim=True)
+
+    def test_fp32_mean_dim(self):
+        inputs = (torch.randn(1, 5, 4, 4),)
+        (
+            Tester(self.MeanDim((-1, -2)), inputs)
+            .export()
+            .check_count({"torch.ops.aten.mean.dim": 1})
+            .to_edge()
+            .check_count({"executorch_exir_dialects_edge__ops_aten_mean_dim": 1})
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .check_not(["executorch_exir_dialects_edge__ops_aten_mean_dim"])
+            .to_executorch()
+            .serialize()
+            .run_method()
+            .compare_outputs()
+        )
+
+    def test_fp32_mean_dim_unsupported(self):
+        """
+        XNNPack mean.dim implementation only supports innermost two dimensions. As such,
+        we expect it to fail to partition when dim=(3).
+        """
+        inputs = (torch.randn(1, 5, 4, 4),)
+        (
+            Tester(self.MeanDim((3)), inputs)
+            .export()
+            .check_count({"torch.ops.aten.mean.dim": 1})
+            .to_edge()
+            .check_count({"executorch_exir_dialects_edge__ops_aten_mean_dim": 1})
+            .partition()
+            .check_count({"executorch_exir_dialects_edge__ops_aten_mean_dim": 1})
+        )

--- a/backends/xnnpack/test/ops/minimum.py
+++ b/backends/xnnpack/test/ops/minimum.py
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack.test.tester import Tester
+
+
+class TestMinimum(unittest.TestCase):
+    class Minimum(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x, y):
+            return torch.minimum(x, y)
+
+    def test_fp32_minimum(self):
+        inputs = (
+            torch.randn(1, 3, 6),
+            torch.randn(1, 3, 6),
+        )
+        (
+            Tester(self.Minimum(), inputs)
+            .export()
+            .check_count({"torch.ops.aten.minimum.default": 1})
+            .to_edge()
+            .check_count({"executorch_exir_dialects_edge__ops_aten_minimum_default": 1})
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .check_not(["executorch_exir_dialects_edge__ops_aten_minimum_default"])
+            .to_executorch()
+            .serialize()
+            .run_method()
+            .compare_outputs()
+        )

--- a/backends/xnnpack/test/ops/permute.py
+++ b/backends/xnnpack/test/ops/permute.py
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack.test.tester import Tester
+
+
+class TestPermute(unittest.TestCase):
+    class Permute(torch.nn.Module):
+        def __init__(self, dims):
+            self.dims = dims
+            super().__init__()
+
+        def forward(self, x):
+            return torch.permute(x, self.dims)
+
+    def test_fp32_permute(self):
+        inputs = (torch.randn(1, 1, 4, 4),)
+        (
+            Tester(self.Permute([0, 2, 3, 1]), inputs)
+            .export()
+            .check_count({"torch.ops.aten.permute_copy.default": 1})
+            .to_edge()
+            .check_count(
+                {"executorch_exir_dialects_edge__ops_aten_permute_copy_default": 1}
+            )
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .check_not(["executorch_exir_dialects_edge__ops_aten_permute_copy_default"])
+            .to_executorch()
+            .serialize()
+            .run_method()
+            .compare_outputs()
+        )

--- a/backends/xnnpack/test/ops/softmax.py
+++ b/backends/xnnpack/test/ops/softmax.py
@@ -1,0 +1,68 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack.test.tester import Tester
+
+
+class TestSoftmax(unittest.TestCase):
+    class Softmax(torch.nn.Module):
+        def __init__(self, dim):
+            super().__init__()
+            self.dim = dim
+
+        def forward(self, x):
+            return torch.nn.Softmax(dim=self.dim)(x)
+
+    def test_fp32_softmax(self):
+        inputs = (torch.rand((3, 5, 7)),)
+
+        # Dim can be either the last dimension index or -1 (last dimension),
+        # as xnnpack only supports softmax on the last dimension.
+        valid_dims = [len(inputs[0]) - 1, -1]
+
+        for dim in valid_dims:
+            (
+                Tester(self.Softmax(dim), inputs)
+                .export()
+                .check_count({"torch.ops.aten._softmax.default": 1})
+                .to_edge()
+                .check_count(
+                    {"executorch_exir_dialects_edge__ops_aten__softmax_default": 1}
+                )
+                .partition()
+                .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+                .check_not(["executorch_exir_dialects_edge__ops_aten__softmax_default"])
+                .to_executorch()
+                .serialize()
+                .run_method()
+                .compare_outputs()
+            )
+
+    def test_fp32_softmax_unsupported(self):
+        inputs = (torch.rand((3, 5, 7)),)
+
+        # Dim can be either the last dimension index or -1 (last dimension),
+        # as xnnpack only supports softmax on the last dimension.
+        # This test validates the delegate does not attempt to delegate softmax
+        # on any other dimension.
+        invalid_dims = range(len(inputs) - 1)
+
+        for dim in invalid_dims:
+            (
+                Tester(self.Softmax(dim), inputs)
+                .export()
+                .check_count({"torch.ops.aten._softmax.default": 1})
+                .to_edge()
+                .check_count(
+                    {"executorch_exir_dialects_edge__ops_aten__softmax_default": 1}
+                )
+                .partition()
+                # Should not be delegated
+                .check(["executorch_exir_dialects_edge__ops_aten__softmax_default"])
+            )


### PR DESCRIPTION
Summary: Migrate tests for hardtanh, maximum, mean_dim, minimum, permute, and softmax from test_xnnpack.py to ops/ directory. Update test logic to use new XNNPACK test harness.

Reviewed By: mcr229

Differential Revision: D51512379


