### PR TITLE
Adding logging for program outputs and delegates

### DIFF
--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -218,6 +218,8 @@ class Method final {
    */
   const EValue& get_output(size_t i) const;
 
+  EventTracer* get_event_tracer();
+
   __ET_DEPRECATED size_t values_size() const;
   __ET_DEPRECATED const EValue& get_value(size_t i) const;
   __ET_DEPRECATED EValue& mutable_value(size_t i);
@@ -333,6 +335,8 @@ class Method final {
       size_t kernel_index,
       InstructionArgs args,
       size_t n_args);
+
+  void log_outputs();
 };
 
 } // namespace executor


### PR DESCRIPTION
Summary:
This diff uses the newly added evalue logging API's for two things:
- Logging the args to the delegate call (we can't differentiate between inputs and outputs currently so we log everything, in the future we'd only like to log the outputs)
- Logging the program level outputs after inference is done.

This is essentially a no-op when the `ET_EVENT_TRACER_ENABLED` compilation flag is disabled.

Reviewed By: JacobSzwejbka

Differential Revision: D51534579


