### PR TITLE
Use python 3.11 and the correct conda env on MacOS runners

### DIFF
--- a/.ci/scripts/setup-conda.sh
+++ b/.ci/scripts/setup-conda.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -ex
+
+install_conda() {
+  pushd .ci/docker || return
+  ${CONDA_INSTALL} -y --file conda-env-ci.txt
+  popd || return
+}
+
+install_conda

--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -77,7 +77,6 @@ print_cmake_info() {
 # NB: we need buck2 in all cases because cmake build also depends on calling
 # buck2 atm
 install_buck
-install_conda
 install_pip_dependencies
 print_cmake_info
 install_flatc_from_source

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -24,13 +24,6 @@ install_executorch() {
   pip list
 }
 
-install_conda() {
-  pushd .ci/docker || return
-  # Install conda dependencies like flatbuffer
-  conda install -y --file conda-env-ci.txt
-  popd || return
-}
-
 install_pip_dependencies() {
   pushd .ci/docker || return
   # Install all Python dependencies, including PyTorch

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -80,7 +80,7 @@ jobs:
 
         # Build //extension/pybindings:portable_lib. Example path:
         # buck-out/v2/gen/root/524f8da68ea2a374/extension/pybindings/__portable_lib__/portable_lib.dylib
-        SO_LIB_DIR=$(buck2 build //extension/pybindings:portable_lib --show-output | cut -d' ' -f2 | xargs dirname)
+        SO_LIB_DIR=$(${CONDA_RUN} buck2 build //extension/pybindings:portable_lib --show-output | cut -d' ' -f2 | xargs dirname)
 
         # Let LD_LIBRARY_PATH include libtorch_python directory
         PYTHON_LIB_DIR=$(${CONDA_RUN} python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')
@@ -97,6 +97,6 @@ jobs:
         # Run pytest with coverage
         ${CONDA_RUN} pytest -n auto --cov=./ --cov-report=xml
         # Run gtest
-        buck2 test runtime/core/... runtime/platform/...
+        ${CONDA_RUN} buck2 test runtime/core/... runtime/platform/...
 
         popd

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -63,6 +63,7 @@ jobs:
           - build-tool: buck2
     with:
       runner: macos-m1-12
+      python-version: '3.11'
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
@@ -72,15 +73,17 @@ jobs:
         pushd "${WORKSPACE}/pytorch/executorch"
 
         BUILD_TOOL=${{ matrix.build-tool }}
+
+        bash .ci/scripts/setup-conda.sh
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
 
         # Build //extension/pybindings:portable_lib. Example path:
         # buck-out/v2/gen/root/524f8da68ea2a374/extension/pybindings/__portable_lib__/portable_lib.dylib
         SO_LIB_DIR=$(buck2 build //extension/pybindings:portable_lib --show-output | cut -d' ' -f2 | xargs dirname)
 
         # Let LD_LIBRARY_PATH include libtorch_python directory
-        PYTHON_LIB_DIR=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')
+        PYTHON_LIB_DIR=$(${CONDA_RUN} python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')
         export LD_LIBRARY_PATH="${PYTHON_LIB_DIR}/torch/lib"
 
         # Let PYTHONPATH include the output directory so that portable_lib.dylib can be loaded into Python.
@@ -92,7 +95,7 @@ jobs:
         echo "from portable_lib import _load_for_executorch_from_buffer,_load_bundled_program_from_buffer,_load_for_executorch_from_bundled_program" > ${SHIM_PY}
 
         # Run pytest with coverage
-        pytest -n auto --cov=./ --cov-report=xml
+        ${CONDA_RUN} pytest -n auto --cov=./ --cov-report=xml
         # Run gtest
         buck2 test runtime/core/... runtime/platform/...
 

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -32,8 +32,10 @@ jobs:
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"
         BUILD_TOOL=cmake
+
+        bash .ci/scripts/setup-conda.sh
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
         # Build and test iOS Demo App
-        PYTHON_EXECUTABLE=python sh build/test_ios_ci.sh
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash build/test_ios_ci.sh
         popd

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -53,10 +53,11 @@ jobs:
         BACKEND=${{ matrix.backend }}
         DEMO_BACKEND_DELEGATION=${{ matrix.demo_backend_delegation }}
 
+        bash .ci/scripts/setup-conda.sh
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
         # Build and test xecutorch
-        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${BACKEND}" "${DEMO_BACKEND_DELEGATION}"
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/test.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${BACKEND}" "${DEMO_BACKEND_DELEGATION}"
         popd
 
   test-custom-ops-macos:
@@ -76,11 +77,13 @@ jobs:
         pushd "${WORKSPACE}/pytorch/executorch"
 
         BUILD_TOOL=${{ matrix.build-tool }}
+
+        bash .ci/scripts/setup-conda.sh
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
 
         # Build and test custom ops
-        PYTHON_EXECUTABLE=python bash examples/portable/custom_ops/test_custom_ops.sh "${BUILD_TOOL}"
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash examples/portable/custom_ops/test_custom_ops.sh "${BUILD_TOOL}"
         popd
 
   test-selective-build-macos:
@@ -100,11 +103,13 @@ jobs:
         pushd "${WORKSPACE}/pytorch/executorch"
 
         BUILD_TOOL=${{ matrix.build-tool }}
+
+        bash .ci/scripts/setup-conda.sh
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
 
         # Build and test selective build
-        PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
         popd
 
   test-demo-backend-delegation:
@@ -163,9 +168,11 @@ jobs:
         WORKSPACE=$(pwd)
         pushd "${WORKSPACE}/pytorch/executorch"
         BUILD_TOOL=cmake
+
+        bash .ci/scripts/setup-conda.sh
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
 
         # Build and test coreml delegate
-        PYTHON_EXECUTABLE=python bash backends/apple/coreml/scripts/build_all.sh
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash backends/apple/coreml/scripts/build_all.sh
         popd


### PR DESCRIPTION
While working on https://github.com/pytorch/executorch/pull/1247, I discover an issue where MacOS jobs don't use the correct temporary conda environment and try to install packages directly into the runner base conda setup.  Because the base env is persisted across jobs, this could lead to cryptic issues elsewhere like mismatched PyTorch version.  Also, using a temp environment allows MacOS jobs to use any python it needs instead of the default 3.9 from the base env.

This fixes the root cause of some MacOS flaky issues:
* https://github.com/pytorch/executorch/actions/runs/7000671520/job/19041660402
* https://github.com/pytorch/executorch/actions/runs/6962965183/job/18947693161