### PR TITLE
ETDump cpp changes for intermediate logging

### DIFF
--- a/sdk/etdump/etdump_flatcc.h
+++ b/sdk/etdump/etdump_flatcc.h
@@ -8,8 +8,10 @@
 
 #pragma once
 
+#include <executorch/runtime/core/span.h>
 #include <executorch/sdk/etdump/etdump_schema_flatcc_builder.h>
 #include <executorch/sdk/etdump/etdump_schema_flatcc_reader.h>
+#include <cstdint>
 #include "executorch/runtime/core/event_tracer.h"
 #include "executorch/runtime/platform/platform.h"
 
@@ -61,16 +63,21 @@ class ETDumpGen : public EventTracer {
       const EValue& evalue,
       LoggedEValueType evalue_type =
           LoggedEValueType::kIntermediateOutput) override;
+  void set_debug_buffer(Span<uint8_t> buffer);
   etdump_result get_etdump_data();
   size_t get_num_blocks();
 
  private:
   flatcc_builder_t builder;
   size_t num_blocks = 0;
+  Span<uint8_t> debug_buffer;
+  size_t debug_buffer_offset = 0;
+  int bundled_input_index = -1;
   ETDumpGen_State etdump_gen_state = ETDumpGen_Init;
 
   void check_ready_to_add_events();
   int64_t create_string_entry(const char* name);
+  size_t copy_tensor_to_debug_buffer(exec_aten::Tensor tensor);
 };
 
 } // namespace executor

--- a/sdk/etdump/etdump_schema_flatcc.fbs
+++ b/sdk/etdump/etdump_schema_flatcc.fbs
@@ -11,8 +11,8 @@ table Null {}
 
 table Tensor {
   scalar_type:executorch_flatbuffer.ScalarType;
-  sizes:[int];
-  strides:[int];
+  sizes:[long];
+  strides:[long];
   offset:long;
 }
 

--- a/sdk/etdump/targets.bzl
+++ b/sdk/etdump/targets.bzl
@@ -103,6 +103,7 @@ def define_common_targets():
             exported_deps = [
                 ":etdump_schema_flatcc",
                 "//executorch/runtime/core:event_tracer" + aten_suffix,
+                "//executorch/runtime/core/exec_aten/util:scalar_type_util" + aten_suffix,
             ],
             visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
         )

--- a/sdk/etdump/tests/targets.bzl
+++ b/sdk/etdump/tests/targets.bzl
@@ -16,5 +16,6 @@ def define_common_targets():
             "//executorch/sdk/etdump:etdump_flatcc",
             "//executorch/sdk/etdump:etdump_schema_flatcc",
             "//executorch/runtime/platform:platform",
+            "//executorch/runtime/core/exec_aten/testing_util:tensor_util",
         ],
     )


### PR DESCRIPTION
Summary: All the ETDump changes needed for intermediate tensor logging. There is an additional method in `etdump_gen` now called `set_debug_buffer` that sets the debug buffer to which all intermediate and output tensors are logged to. This combined along with ETDump will need to be provided to the inspector API to analyze outputs/intermediate outputs.

Differential Revision: D51402553


