### PR TITLE
Qualcomm AI Engine Direct - enable per-tensor dump mechanism

### DIFF
--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -139,6 +139,7 @@ add_library(qnn_backend STATIC)
 add_library(qnn_factory STATIC)
 add_library(qnn_header INTERFACE)
 add_library(wrappers STATIC)
+add_library(utils STATIC)
 
 #
 # declare dependency
@@ -228,6 +229,7 @@ target_link_libraries(qnn_manager
     qnn_factory
     wrappers
     qnn_schema
+    utils
 )
 target_link_libraries(qnn_executorch_backend
     PRIVATE
@@ -236,6 +238,10 @@ target_link_libraries(qnn_executorch_backend
     qnn_manager
     executorch
     qcir_utils
+)
+target_link_libraries(utils
+    PRIVATE
+    qnn_executorch_logging
 )
 
 #

--- a/backends/qualcomm/aot/python/PyQnnManagerAdaptor.cpp
+++ b/backends/qualcomm/aot/python/PyQnnManagerAdaptor.cpp
@@ -30,7 +30,8 @@ PYBIND11_MODULE(PyQnnManagerAdaptor, m) {
       .def("IsNodeSupportedByBackend", &PyQnnManager::IsNodeSupportedByBackend)
       .def("Compile", &PyQnnManager::Compile)
       .def("Destroy", &PyQnnManager::Destroy)
-      .def("IsAvailable", &PyQnnManager::IsAvailable);
+      .def("IsAvailable", &PyQnnManager::IsAvailable)
+      .def("IsTensorDump", &PyQnnManager::IsTensorDump);
 }
 } // namespace qnn
 } // namespace executor

--- a/backends/qualcomm/aot/python/PyQnnManagerAdaptor.h
+++ b/backends/qualcomm/aot/python/PyQnnManagerAdaptor.h
@@ -137,6 +137,10 @@ class PyQnnManager {
     return qnn_manager_->IsAvailable();
   }
 
+  bool IsTensorDump() {
+    return qnn_manager_->IsTensorDump();
+  }
+
  private:
   // Store the bytes object instead of a raw pointer so that this module will
   // keep the bytes alive.

--- a/backends/qualcomm/aot/wrappers/TensorWrapper.cpp
+++ b/backends/qualcomm/aot/wrappers/TensorWrapper.cpp
@@ -121,6 +121,19 @@ Error TensorWrapper::FillDataBuffer(const void* data, bool copy_data) {
   return Error::Ok;
 }
 
+Error TensorWrapper::AllocateDataBuffer() {
+  char* static_data_buffer = new (std::nothrow) char[bytes_]; // NOLINT
+  if (static_data_buffer == nullptr) {
+    return Error::Internal;
+  }
+  owned_data_ = std::unique_ptr<char[]>(static_data_buffer);
+  QNN_VER_PTR(tensor_)->memType = QNN_TENSORMEMTYPE_RAW;
+  QNN_VER_PTR(tensor_)->clientBuf.dataSize = bytes_;
+  QNN_VER_PTR(tensor_)->clientBuf.data = owned_data_.get();
+
+  return Error::Ok;
+}
+
 void TensorWrapper::UpdateQnnTensorMeta(const Qnn_Tensor_t& tensor_src) {
   QNN_VER_PTR(tensor_)->id = QNN_VER_PTR(tensor_src)->id;
 }

--- a/backends/qualcomm/aot/wrappers/TensorWrapper.h
+++ b/backends/qualcomm/aot/wrappers/TensorWrapper.h
@@ -35,6 +35,8 @@ class TensorWrapper {
 
   Error FillDataBuffer(const void* data, bool copy_data = false);
 
+  Error AllocateDataBuffer();
+
   // update qnn tensor meta
   // this function is used to recover metadata from QNN context binary.
   void UpdateQnnTensorMeta(const Qnn_Tensor_t& tensor_src);

--- a/backends/qualcomm/qnn_preprocess.py
+++ b/backends/qualcomm/qnn_preprocess.py
@@ -53,8 +53,11 @@ class QnnBackend(BackendDetails):
         pass_result = qnn_compiler_passes(edge_program.graph_module)
         assert pass_result is not None
 
+        enable_tensor_dump = qnn_manager.IsTensorDump()
         nodes_to_wrappers = {}
-        node_visitors = get_node_visitors(edge_program)
+        node_visitors = get_node_visitors(
+            edge_program, enable_tensor_dump=enable_tensor_dump
+        )
         py_op_wrapper_list = []
         for node in pass_result.graph_module.graph.nodes:
             if node.op == "call_function":

--- a/backends/qualcomm/runtime/CMakeLists.txt
+++ b/backends/qualcomm/runtime/CMakeLists.txt
@@ -39,3 +39,11 @@ target_sources(qnn_executorch_logging
     PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/Logging.cpp
 )
+
+# utils
+target_sources(utils
+    PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/Utils.h
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp
+)

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
@@ -194,13 +194,16 @@ Error QnnExecuTorchBackend::execute(
     input_tensor_structs.push_back(input_tensors[i]->CloneTensorStruct());
   }
 
-  for (int i = input_tensors.size();
-       i < input_tensors.size() + output_tensors.size();
-       ++i) {
-    output_tensors[i - input_tensors.size()]->FillDataBuffer(
-        args[i]->toTensor().mutable_data_ptr(), false /* copy_data */);
-    output_tensor_structs.push_back(
-        output_tensors[i - input_tensors.size()]->CloneTensorStruct());
+  int output_index = input_tensors.size();
+  for (const auto& output_tensor : output_tensors) {
+    // pos=0 limits the search to the prefix
+    if (output_tensor->GetName().rfind("output_", 0) == 0) {
+      output_tensor->FillDataBuffer(
+          args[output_index]->toTensor().mutable_data_ptr(),
+          false /* copy_data */);
+      output_index++;
+    }
+    output_tensor_structs.push_back(output_tensor->CloneTensorStruct());
   }
 
   ET_CHECK_OR_RETURN_ERROR(

--- a/backends/qualcomm/runtime/QnnManager.h
+++ b/backends/qualcomm/runtime/QnnManager.h
@@ -42,6 +42,10 @@ class QnnManager {
 
   bool IsAvailable();
 
+  bool IsTensorDump() {
+    return !tensor_dump_output_path_.empty();
+  }
+
   bool IsOnlinePrepare();
 
   bool IsNodeSupportedByBackend(
@@ -68,6 +72,7 @@ class QnnManager {
   QnnExecuTorchBackendType backend_type_;
   std::string library_path_;
   std::string skel_library_dir_;
+  std::string tensor_dump_output_path_;
   std::string graph_name_;
   const SocInfo* soc_info_;
   const QnnExecuTorchHtpBackendOptions* htp_options_;

--- a/backends/qualcomm/runtime/Utils.cpp
+++ b/backends/qualcomm/runtime/Utils.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <executorch/backends/qualcomm/runtime/Logging.h>
+#include <executorch/backends/qualcomm/runtime/Utils.h>
+#include <sys/stat.h>
+namespace torch {
+namespace executor {
+namespace qnn {
+
+void CreateDirectory(const std::string& path) {
+  // Create any recursive directory
+  if (path.empty()) {
+    QNN_EXECUTORCH_LOG_ERROR("Create folder shouldn't be empty");
+    return;
+  }
+  std::size_t pos = path.find_last_of('/');
+  std::string subdir = (std::string::npos == pos) ? "" : path.substr(0, pos);
+  if (subdir.empty() || subdir == "." || subdir == "..") {
+    return;
+  }
+  CreateDirectory(subdir);
+  int mkdir_err = mkdir(subdir.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
+  if (mkdir_err != 0 && errno != EEXIST) {
+    std::string err_msg = "Failed to create " + subdir + " folder\n";
+    QNN_EXECUTORCH_LOG_ERROR(err_msg.c_str());
+  }
+}
+
+} // namespace qnn
+} // namespace executor
+} // namespace torch

--- a/backends/qualcomm/runtime/Utils.h
+++ b/backends/qualcomm/runtime/Utils.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <string>
+
+namespace torch {
+namespace executor {
+namespace qnn {
+// Create Directory
+void CreateDirectory(const std::string& path);
+
+} // namespace qnn
+} // namespace executor
+} // namespace torch

--- a/backends/qualcomm/serialization/qnn_compile_spec_schema.py
+++ b/backends/qualcomm/serialization/qnn_compile_spec_schema.py
@@ -114,3 +114,4 @@ class QnnExecuTorchOptions:
     htp_options: QnnExecuTorchHtpBackendOptions = QnnExecuTorchHtpBackendOptions()
     soc_info: SocInfo = SocInfo()
     online_prepare: bool = False
+    tensor_dump_output_path: str = ""

--- a/backends/qualcomm/serialization/schema.fbs
+++ b/backends/qualcomm/serialization/schema.fbs
@@ -140,6 +140,12 @@ table QnnExecuTorchOptions {
 
   /// Check if on-device graph construction. Default is false.
   online_prepare:bool;
+
+  /// Tensor dump output path. If a path is given, Delegate would write
+  /// outputs of each OP there.
+  /// In ALL cases, we don't recommend to set this option.
+  /// This option exist just for debugging some accuracy issues.
+  tensor_dump_output_path:string;
 }
 
 root_type QnnExecuTorchOptions;

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -44,6 +44,7 @@ class TestQNNFloatingPointOperator(TestQNN):
             debug=False,
             saver=False,
             online_prepare=TestQNN.online_prepare,
+            tensor_dump_output_path="",
         )
 
     def test_qnn_backend_arange(self):
@@ -373,6 +374,7 @@ class TestQNNFloatingPointModel(TestQNN):
             debug=False,
             saver=False,
             online_prepare=TestQNN.online_prepare,
+            tensor_dump_output_path="",
         )
 
     def test_qnn_backend_conv1d_relu_log_softmax(self):
@@ -464,6 +466,7 @@ class TestQNNQuantizedOperator(TestQNN):
             debug=False,
             saver=False,
             online_prepare=TestQNN.online_prepare,
+            tensor_dump_output_path="",
         )
 
     def test_qnn_backend_arange(self):
@@ -840,6 +843,7 @@ class TestQNNQuantizedModel(TestQNN):
             debug=False,
             saver=False,
             online_prepare=TestQNN.online_prepare,
+            tensor_dump_output_path="",
         )
 
     def test_qnn_backend_conv1d_relu_log_softmax(self):

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -122,6 +122,7 @@ def generate_qnn_executorch_compiler_spec(
     debug: bool = False,
     saver: bool = False,
     online_prepare: bool = False,
+    tensor_dump_output_path: str = "",
 ) -> List[CompileSpec]:
     """
     Helper function generating compiler specs for Qualcomm AI Engine Direct
@@ -142,6 +143,10 @@ def generate_qnn_executorch_compiler_spec(
         saver: Instead of compiling the model, run QNN Saver. Please check
             documents of Qualcomm AI Engine Direct SDK. This feature is usually
             for debugging purpose.
+        tensor_dump_output_path: If a path is given, Delegate would write
+            outputs of each OP there in runtime. In ALL cases,
+            we don't recommend to set this option. This option exist just
+            for debugging some accuracy issues.
 
     Returns:
         List[CompileSpec]: Compiler specs for Qualcomm AI Engine Direct.
@@ -186,6 +191,9 @@ def generate_qnn_executorch_compiler_spec(
 
     if saver:
         qnn_executorch_options.library_path = "libQnnSaver.so"
+
+    if len(tensor_dump_output_path.strip()) != 0:
+        qnn_executorch_options.tensor_dump_output_path = tensor_dump_output_path
 
     if online_prepare:
         qnn_executorch_options.online_prepare = True


### PR DESCRIPTION
- Add "tensor_dump_output_path" option into compiler spec
- Add "output_" for output tensors in the AOT phase. In the runtime, we fill in the output tensor based on the order of the output tensor in the context cache.

If tensor_dump_output_path is given, Delegate would write outputs of each OP there in runtime. 
In ALL cases, we don't recommend setting this option. This option exists just for debugging some accuracy issues.