### PR TITLE
Add support for statically allocated buffer in etdump

### DIFF
--- a/sdk/etdump/emitter.cpp
+++ b/sdk/etdump/emitter.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <stdio.h>
+#include <cstdint>
+
+#include "executorch/runtime/platform/assert.h"
+#include "executorch/sdk/etdump/emitter.h"
+
+namespace torch {
+namespace executor {
+
+static int _allocator_fn(
+    void* alloc_context,
+    flatcc_iovec_t* b,
+    size_t request,
+    int zero_fill,
+    int hint) {
+  void* p;
+  size_t n;
+
+  struct etdump_static_allocator* state =
+      (struct etdump_static_allocator*)alloc_context;
+
+  // This allocator doesn't support freeing memory.
+  if (request == 0) {
+    if (b->iov_base) {
+      b->iov_base = nullptr;
+      b->iov_len = 0;
+    }
+    return 0;
+  }
+
+  switch (hint) {
+    case flatcc_builder_alloc_ds:
+      n = 256;
+      break;
+    case flatcc_builder_alloc_ht:
+      /* Should be exact size, or space size is just wasted. */
+      n = request;
+      break;
+    case flatcc_builder_alloc_fs:
+      n = sizeof(__flatcc_builder_frame_t) * 8;
+      break;
+    case flatcc_builder_alloc_us:
+      n = 64;
+      break;
+    case flatcc_builder_alloc_vd:
+      n = 64;
+      break;
+    default:
+      /*
+       * We have many small structures - vs stack for tables with few
+       * elements, and few offset fields in patch log. No need to
+       * overallocate in case of busy small messages.
+       */
+      n = 32;
+      break;
+  }
+
+  while (n < request) {
+    n *= 2;
+  }
+
+  if (b->iov_base != nullptr) {
+    if (request > b->iov_len) {
+      // We don't support reallocating larger buffers.
+      if (((uintptr_t)b->iov_base + b->iov_len) ==
+          (uintptr_t)&state->data[state->allocated]) {
+        if ((state->allocated + n - b->iov_len) > state->data_size) {
+          return -1;
+        }
+        state->allocated += n - b->iov_len;
+      } else {
+        if ((state->allocated + n) > state->data_size) {
+          return -1;
+        }
+        memcpy((void*)&state->data[state->allocated], b->iov_base, b->iov_len);
+        b->iov_base = &state->data[state->allocated];
+        state->allocated += n;
+      }
+      if (zero_fill) {
+        memset((uint8_t*)b->iov_base + b->iov_len, 0, n - b->iov_len);
+      }
+      b->iov_len = n;
+    }
+
+    // Ignore request to resize buffers down.
+    return 0;
+  }
+
+  if ((state->allocated + n) > state->data_size) {
+    return -1;
+  }
+
+  p = &state->data[state->allocated];
+  state->allocated += n;
+
+  if (zero_fill) {
+    memset((void*)p, 0, n);
+  }
+
+  b->iov_base = p;
+  b->iov_len = n;
+
+  return 0;
+}
+
+// This emitter implementation emits to a fixed size buffer and will fail if it
+// runs out of room on either end.
+static int _emitter_fn(
+    void* emit_context,
+    const flatcc_iovec_t* iov,
+    int iov_count,
+    flatbuffers_soffset_t offset,
+    size_t len) {
+  struct etdump_static_allocator* E =
+      (struct etdump_static_allocator*)emit_context;
+  uint8_t* p;
+
+  if (offset < 0) {
+    if (len > E->front_left) {
+      return -1;
+    }
+    E->front_cursor -= len;
+    E->front_left -= len;
+    p = E->front_cursor;
+  } else {
+    ET_CHECK_MSG(
+        0, "Moving the back pointer is currently not supported in ETDump.");
+  }
+
+  while (iov_count--) {
+    memcpy(p, iov->iov_base, iov->iov_len);
+    p += iov->iov_len;
+    ++iov;
+  }
+
+  return 0;
+}
+
+/*******************************************************************************
+ * Public Functions
+ ******************************************************************************/
+
+int etdump_static_allocator_builder_init(
+    flatcc_builder_t* builder,
+    struct etdump_static_allocator* alloc) {
+  ET_CHECK(builder != nullptr);
+  ET_CHECK(alloc != nullptr);
+
+  // Ensure data size is multiple of 32 (minimum allocation size).
+  ET_CHECK((alloc->data_size & 0x1F) == 0);
+  // Ensure out_size is divisable by 2 to ensure front/back sizes are equal for
+  // emitter..
+  ET_CHECK((alloc->out_size & 0x1) == 0);
+
+  return flatcc_builder_custom_init(
+      builder, _emitter_fn, alloc, _allocator_fn, alloc);
+}
+
+void etdump_static_allocator_reset(struct etdump_static_allocator* alloc) {
+  ET_CHECK(alloc != nullptr);
+  alloc->allocated = 0;
+  size_t n = alloc->out_size / 2;
+  alloc->front_cursor = &alloc->data[alloc->data_size + n];
+  alloc->front_left = n;
+}
+
+int et_flatcc_custom_init(
+    flatcc_builder_t* builder,
+    struct etdump_static_allocator* alloc) {
+  return flatcc_builder_custom_init(
+      builder, _emitter_fn, alloc, _allocator_fn, alloc);
+}
+
+} // namespace executor
+} // namespace torch

--- a/sdk/etdump/emitter.h
+++ b/sdk/etdump/emitter.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <flatcc/flatcc_builder.h>
+
+#pragma once
+
+namespace torch {
+namespace executor {
+
+struct etdump_static_allocator {
+  etdump_static_allocator(
+      uint8_t* buffer,
+      size_t total_buf_size,
+      size_t alloc_buf_size)
+      : data{buffer},
+        data_size{alloc_buf_size},
+        allocated{0},
+        out_size{total_buf_size - alloc_buf_size},
+        front_cursor{&buffer[alloc_buf_size]},
+        front_left{out_size / 2} {}
+  // Pointer to backing buffer to allocate from.
+  uint8_t* data{nullptr};
+
+  // Size of backing buffer.
+  size_t data_size{0};
+
+  // Current allocation offset.
+  size_t allocated{0};
+
+  // Size of build buffer.
+  size_t out_size{0};
+
+  // Pointer to front of build buffer.
+  uint8_t* front_cursor{nullptr};
+
+  // Bytes left in front of front_cursor.
+  size_t front_left{0};
+};
+
+int et_flatcc_custom_init(
+    flatcc_builder_t* builder,
+    struct etdump_static_allocator* alloc);
+
+} // namespace executor
+} // namespace torch

--- a/sdk/etdump/etdump_flatcc.h
+++ b/sdk/etdump/etdump_flatcc.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include "executorch/runtime/core/event_tracer.h"
 #include "executorch/runtime/platform/platform.h"
+#include "executorch/sdk/etdump/emitter.h"
 
 #define ETDUMP_VERSION 0
 
@@ -34,8 +35,7 @@ struct etdump_result {
 
 class ETDumpGen : public EventTracer {
  public:
-  ETDumpGen();
-
+  ETDumpGen(Span<uint8_t> buffer = {nullptr, (size_t)0});
   ~ETDumpGen() override;
   void clear_builder();
 
@@ -66,6 +66,7 @@ class ETDumpGen : public EventTracer {
   void set_debug_buffer(Span<uint8_t> buffer);
   etdump_result get_etdump_data();
   size_t get_num_blocks();
+  bool is_static_etdump();
 
  private:
   flatcc_builder_t builder;
@@ -74,6 +75,7 @@ class ETDumpGen : public EventTracer {
   size_t debug_buffer_offset = 0;
   int bundled_input_index = -1;
   ETDumpGen_State etdump_gen_state = ETDumpGen_Init;
+  struct etdump_static_allocator alloc;
 
   void check_ready_to_add_events();
   int64_t create_string_entry(const char* name);

--- a/sdk/etdump/targets.bzl
+++ b/sdk/etdump/targets.bzl
@@ -87,6 +87,20 @@ def define_common_targets():
         exported_external_deps = ["flatccrt"],
     )
 
+    runtime.cxx_library(
+        name = "etdump_emitter",
+        srcs = [
+            "emitter.cpp",
+        ],
+        deps = [
+            "//executorch/runtime/core:core",
+        ],
+        exported_headers = [
+            "emitter.h",
+        ],
+        exported_external_deps = ["flatccrt"],
+    )
+
     for aten_mode in (True, False):
         aten_suffix = "_aten" if aten_mode else ""
         runtime.cxx_library(
@@ -102,8 +116,12 @@ def define_common_targets():
             ],
             exported_deps = [
                 ":etdump_schema_flatcc",
+                ":etdump_emitter",
                 "//executorch/runtime/core:event_tracer" + aten_suffix,
                 "//executorch/runtime/core/exec_aten/util:scalar_type_util" + aten_suffix,
             ],
-            visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
+            visibility = [
+                "//executorch/...",
+                "@EXECUTORCH_CLIENTS",
+            ],
         )

--- a/sdk/etdump/tests/etdump_test.cpp
+++ b/sdk/etdump/tests/etdump_test.cpp
@@ -24,435 +24,476 @@ class ProfilerETDumpTest : public ::testing::Test {
  protected:
   void SetUp() override {
     torch::executor::runtime_init();
-    const size_t buf_size = 8192;
-    buf = static_cast<uint8_t*>(malloc(buf_size * sizeof(uint8_t)));
-
-    etdump_gen = new ETDumpGen();
+    etdump_gen[0] = new ETDumpGen();
+    const size_t buf_size = 1024 * 1024;
+    buf = (uint8_t*)malloc(buf_size * sizeof(uint8_t));
+    etdump_gen[1] = new ETDumpGen(Span<uint8_t>(buf, buf_size));
   }
 
   void TearDown() override {
+    delete etdump_gen[0];
+    delete etdump_gen[1];
     free(buf);
-    delete etdump_gen;
   }
 
-  ETDumpGen* etdump_gen;
+  ETDumpGen* etdump_gen[2];
   uint8_t* buf = nullptr;
 };
 
 TEST_F(ProfilerETDumpTest, SingleProfileEvent) {
-  etdump_gen->create_event_block("test_block");
-  EventTracerEntry entry = etdump_gen->start_profiling("test_event", 0, 1);
-  etdump_gen->end_profiling(entry);
+  for (size_t i = 0; i < 2; i++) {
+    etdump_gen[i]->create_event_block("test_block");
+    EventTracerEntry entry = etdump_gen[i]->start_profiling("test_event", 0, 1);
+    etdump_gen[i]->end_profiling(entry);
 
-  etdump_result result = etdump_gen->get_etdump_data();
-  ASSERT_TRUE(result.buf != nullptr);
-  ASSERT_TRUE(result.size != 0);
+    etdump_result result = etdump_gen[i]->get_etdump_data();
+    ASSERT_TRUE(result.buf != nullptr);
+    ASSERT_TRUE(result.size != 0);
 
-  size_t size = 0;
-  void* buf = flatbuffers_read_size_prefix(result.buf, &size);
-  etdump_ETDump_table_t etdump =
-      etdump_ETDump_as_root_with_identifier(buf, etdump_ETDump_file_identifier);
+    size_t size = 0;
+    void* buf = flatbuffers_read_size_prefix(result.buf, &size);
+    etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+        buf, etdump_ETDump_file_identifier);
 
-  ASSERT_NE(etdump, nullptr);
-  EXPECT_EQ(etdump_ETDump_version(etdump), ETDUMP_VERSION);
+    ASSERT_NE(etdump, nullptr);
+    EXPECT_EQ(etdump_ETDump_version(etdump), ETDUMP_VERSION);
 
-  etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
-  EXPECT_EQ(etdump_gen->get_num_blocks(), etdump_RunData_vec_len(run_data_vec));
+    etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+    EXPECT_EQ(
+        etdump_gen[i]->get_num_blocks(), etdump_RunData_vec_len(run_data_vec));
 
-  etdump_RunData_table_t run_data_single_prof =
-      etdump_RunData_vec_at(run_data_vec, 0);
-  EXPECT_EQ(
-      std::string(
-          etdump_RunData_name(run_data_single_prof),
-          strlen(etdump_RunData_name(run_data_single_prof))),
-      "test_block");
+    etdump_RunData_table_t run_data_single_prof =
+        etdump_RunData_vec_at(run_data_vec, 0);
+    EXPECT_EQ(
+        std::string(
+            etdump_RunData_name(run_data_single_prof),
+            strlen(etdump_RunData_name(run_data_single_prof))),
+        "test_block");
 
-  free(result.buf);
+    if (!etdump_gen[i]->is_static_etdump()) {
+      free(result.buf);
+    }
+  }
 }
 
 TEST_F(ProfilerETDumpTest, MultipleProfileEvent) {
-  etdump_gen->create_event_block("test_block");
+  for (size_t i = 0; i < 2; i++) {
+    etdump_gen[i]->create_event_block("test_block");
 
-  // Create the profile events and then add the actual profile events in
-  // reverse.
-  EventTracerEntry entry_1 = etdump_gen->start_profiling("test_event_1", 0, 1);
-  EventTracerEntry entry_2 = etdump_gen->start_profiling("test_event_2", 0, 2);
+    // Create the profile events and then add the actual profile events in
+    // reverse.
+    EventTracerEntry entry_1 =
+        etdump_gen[i]->start_profiling("test_event_1", 0, 1);
+    EventTracerEntry entry_2 =
+        etdump_gen[i]->start_profiling("test_event_2", 0, 2);
 
-  etdump_gen->end_profiling(entry_2);
-  etdump_gen->end_profiling(entry_1);
+    etdump_gen[i]->end_profiling(entry_2);
+    etdump_gen[i]->end_profiling(entry_1);
+  }
 }
 
 TEST_F(ProfilerETDumpTest, EmptyBlocks) {
-  etdump_gen->create_event_block("test_block");
-  etdump_gen->create_event_block("test_block_1");
-  etdump_gen->create_event_block("test_block_2");
+  for (size_t i = 0; i < 2; i++) {
+    etdump_gen[i]->create_event_block("test_block");
+    etdump_gen[i]->create_event_block("test_block_1");
+    etdump_gen[i]->create_event_block("test_block_2");
 
-  EventTracerEntry entry = etdump_gen->start_profiling("test_event_1", 0, 1);
-  etdump_gen->end_profiling(entry);
+    EventTracerEntry entry =
+        etdump_gen[i]->start_profiling("test_event_1", 0, 1);
+    etdump_gen[i]->end_profiling(entry);
 
-  etdump_result result = etdump_gen->get_etdump_data();
-  ASSERT_TRUE(result.buf != nullptr);
-  ASSERT_TRUE(result.size != 0);
+    etdump_result result = etdump_gen[i]->get_etdump_data();
+    ASSERT_TRUE(result.buf != nullptr);
+    ASSERT_TRUE(result.size != 0);
 
-  size_t size = 0;
-  void* buf = flatbuffers_read_size_prefix(result.buf, &size);
-  etdump_ETDump_table_t etdump =
-      etdump_ETDump_as_root_with_identifier(buf, etdump_ETDump_file_identifier);
+    size_t size = 0;
+    void* buf = flatbuffers_read_size_prefix(result.buf, &size);
+    etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+        buf, etdump_ETDump_file_identifier);
 
-  etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
-  ASSERT_EQ(etdump_RunData_vec_len(run_data_vec), 3);
-  ASSERT_EQ(
-      etdump_Event_vec_len(
-          etdump_RunData_events(etdump_RunData_vec_at(run_data_vec, 0))),
-      0);
+    etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+    ASSERT_EQ(etdump_RunData_vec_len(run_data_vec), 3);
+    ASSERT_EQ(
+        etdump_Event_vec_len(
+            etdump_RunData_events(etdump_RunData_vec_at(run_data_vec, 0))),
+        0);
 
-  free(result.buf);
+    if (!etdump_gen[i]->is_static_etdump()) {
+      free(result.buf);
+    }
+  }
 }
 
 TEST_F(ProfilerETDumpTest, AddAllocators) {
-  etdump_gen->create_event_block("test_block");
-  AllocatorID allocator_id = etdump_gen->track_allocator("test_allocator");
-  EXPECT_EQ(allocator_id, 1);
-  allocator_id = etdump_gen->track_allocator("test_allocator_1");
-  EXPECT_EQ(allocator_id, 2);
+  for (size_t i = 0; i < 2; i++) {
+    etdump_gen[i]->create_event_block("test_block");
+    AllocatorID allocator_id = etdump_gen[i]->track_allocator("test_allocator");
+    EXPECT_EQ(allocator_id, 1);
+    allocator_id = etdump_gen[i]->track_allocator("test_allocator_1");
+    EXPECT_EQ(allocator_id, 2);
 
-  // Add a profiling event and then try to add an allocator which should fail.
-  EventTracerEntry entry = etdump_gen->start_profiling("test_event", 0, 1);
-  etdump_gen->end_profiling(entry);
-  ET_EXPECT_DEATH(etdump_gen->track_allocator("test_allocator"), "");
+    // Add a profiling event and then try to add an allocator which should fail.
+    EventTracerEntry entry = etdump_gen[i]->start_profiling("test_event", 0, 1);
+    etdump_gen[i]->end_profiling(entry);
+    ET_EXPECT_DEATH(etdump_gen[i]->track_allocator("test_allocator"), "");
+  }
 }
 
 TEST_F(ProfilerETDumpTest, AllocationEvents) {
-  etdump_gen->create_event_block("test_block");
+  for (size_t i = 0; i < 2; i++) {
+    etdump_gen[i]->create_event_block("test_block");
 
-  // Add allocation events.
-  etdump_gen->track_allocation(1, 64);
-  etdump_gen->track_allocation(2, 128);
+    // Add allocation events.
+    etdump_gen[i]->track_allocation(1, 64);
+    etdump_gen[i]->track_allocation(2, 128);
 
-  // Add a mix of performance and memory events.
-  etdump_gen->track_allocation(1, 64);
-  EventTracerEntry entry = etdump_gen->start_profiling("test_event", 0, 1);
-  etdump_gen->end_profiling(entry);
-  etdump_gen->track_allocation(2, 128);
+    // Add a mix of performance and memory events.
+    etdump_gen[i]->track_allocation(1, 64);
+    EventTracerEntry entry = etdump_gen[i]->start_profiling("test_event", 0, 1);
+    etdump_gen[i]->end_profiling(entry);
+    etdump_gen[i]->track_allocation(2, 128);
+  }
 }
 
 TEST_F(ProfilerETDumpTest, DebugEvent) {
-  testing::TensorFactory<ScalarType::Float> tf;
-  EValue evalue(tf.ones({3, 2}));
+  for (size_t i = 0; i < 2; i++) {
+    testing::TensorFactory<ScalarType::Float> tf;
+    EValue evalue(tf.ones({3, 2}));
 
-  etdump_gen->create_event_block("test_block");
+    etdump_gen[i]->create_event_block("test_block");
 
-  void* ptr = malloc(2048);
-  Span<uint8_t> buffer((uint8_t*)ptr, 2048);
+    void* ptr = malloc(2048);
+    Span<uint8_t> buffer((uint8_t*)ptr, 2048);
 
-  etdump_gen->set_debug_buffer(buffer);
-  etdump_gen->log_evalue(evalue);
-  etdump_gen->log_evalue(evalue, LoggedEValueType::kProgramOutput);
+    etdump_gen[i]->set_debug_buffer(buffer);
+    etdump_gen[i]->log_evalue(evalue);
+    etdump_gen[i]->log_evalue(evalue, LoggedEValueType::kProgramOutput);
 
-  EValue evalue_int((int64_t)5);
-  etdump_gen->log_evalue(evalue_int);
+    EValue evalue_int((int64_t)5);
+    etdump_gen[i]->log_evalue(evalue_int);
 
-  EValue evalue_double((double)1.5);
-  etdump_gen->log_evalue(evalue_double);
+    EValue evalue_double((double)1.5);
+    etdump_gen[i]->log_evalue(evalue_double);
 
-  EValue evalue_bool(true);
-  etdump_gen->log_evalue(evalue_bool);
+    EValue evalue_bool(true);
+    etdump_gen[i]->log_evalue(evalue_bool);
 
-  etdump_gen->log_evalue(evalue_bool);
+    etdump_gen[i]->log_evalue(evalue_bool);
 
-  free(ptr);
+    free(ptr);
+  }
 }
 
 TEST_F(ProfilerETDumpTest, VerifyLogging) {
   testing::TensorFactory<ScalarType::Float> tf;
   EValue evalue(tf.ones({3, 2}));
 
-  etdump_gen->create_event_block("test_block");
+  for (size_t i = 0; i < 2; i++) {
+    etdump_gen[i]->create_event_block("test_block");
 
-  void* ptr = malloc(2048);
-  Span<uint8_t> buffer((uint8_t*)ptr, 2048);
+    void* ptr = malloc(2048);
+    Span<uint8_t> buffer((uint8_t*)ptr, 2048);
 
-  etdump_gen->set_debug_buffer(buffer);
-  etdump_gen->log_evalue(evalue);
-  etdump_gen->log_evalue(evalue, LoggedEValueType::kProgramOutput);
+    etdump_gen[i]->set_debug_buffer(buffer);
+    etdump_gen[i]->log_evalue(evalue);
+    etdump_gen[i]->log_evalue(evalue, LoggedEValueType::kProgramOutput);
 
-  etdump_result result = etdump_gen->get_etdump_data();
-  ASSERT_TRUE(result.buf != nullptr);
-  ASSERT_TRUE(result.size != 0);
+    etdump_result result = etdump_gen[i]->get_etdump_data();
+    ASSERT_TRUE(result.buf != nullptr);
+    ASSERT_TRUE(result.size != 0);
 
-  size_t size = 0;
-  void* buf = flatbuffers_read_size_prefix(result.buf, &size);
-  etdump_ETDump_table_t etdump =
-      etdump_ETDump_as_root_with_identifier(buf, etdump_ETDump_file_identifier);
+    size_t size = 0;
+    void* buf = flatbuffers_read_size_prefix(result.buf, &size);
+    etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+        buf, etdump_ETDump_file_identifier);
 
-  etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
-  ASSERT_EQ(etdump_RunData_vec_len(run_data_vec), 1);
+    etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+    ASSERT_EQ(etdump_RunData_vec_len(run_data_vec), 1);
 
-  etdump_Event_vec_t events =
-      etdump_RunData_events(etdump_RunData_vec_at(run_data_vec, 0));
-  ASSERT_EQ(etdump_Event_vec_len(events), 2);
+    etdump_Event_vec_t events =
+        etdump_RunData_events(etdump_RunData_vec_at(run_data_vec, 0));
+    ASSERT_EQ(etdump_Event_vec_len(events), 2);
 
-  etdump_Event_table_t event = etdump_Event_vec_at(events, 0);
+    etdump_Event_table_t event = etdump_Event_vec_at(events, 0);
 
-  etdump_DebugEvent_table_t single_debug_event =
-      etdump_Event_debug_event(event);
-  etdump_Value_table_t value =
-      etdump_DebugEvent_debug_entry(single_debug_event);
-  ASSERT_EQ(etdump_Value_tensor_is_present(value), true);
-  ASSERT_EQ(etdump_Value_output_is_present(value), false);
+    etdump_DebugEvent_table_t single_debug_event =
+        etdump_Event_debug_event(event);
+    etdump_Value_table_t value =
+        etdump_DebugEvent_debug_entry(single_debug_event);
+    ASSERT_EQ(etdump_Value_tensor_is_present(value), true);
+    ASSERT_EQ(etdump_Value_output_is_present(value), false);
 
-  etdump_Tensor_table_t tensor = etdump_Value_tensor(value);
-  executorch_flatbuffer_ScalarType_enum_t scalar_enum =
-      etdump_Tensor_scalar_type(tensor);
-  ASSERT_EQ(scalar_enum, executorch_flatbuffer_ScalarType_FLOAT);
-  flatbuffers_int64_vec_t sizes = etdump_Tensor_sizes(tensor);
-  ASSERT_EQ(flatbuffers_int64_vec_len(sizes), 2);
-  ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 0), 3);
-  ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 1), 2);
+    etdump_Tensor_table_t tensor = etdump_Value_tensor(value);
+    executorch_flatbuffer_ScalarType_enum_t scalar_enum =
+        etdump_Tensor_scalar_type(tensor);
+    ASSERT_EQ(scalar_enum, executorch_flatbuffer_ScalarType_FLOAT);
+    flatbuffers_int64_vec_t sizes = etdump_Tensor_sizes(tensor);
+    ASSERT_EQ(flatbuffers_int64_vec_len(sizes), 2);
+    ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 0), 3);
+    ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 1), 2);
 
-  event = etdump_Event_vec_at(events, 1);
-  single_debug_event = etdump_Event_debug_event(event);
-  value = etdump_DebugEvent_debug_entry(single_debug_event);
-  ASSERT_EQ(etdump_Value_tensor_is_present(value), true);
-  ASSERT_EQ(etdump_Value_output_is_present(value), true);
-  etdump_Bool_table_t bool_val = etdump_Value_output_get(value);
-  bool bool_val_from_table = etdump_Bool_bool_val(bool_val);
-  ASSERT_EQ(bool_val_from_table, true);
+    event = etdump_Event_vec_at(events, 1);
+    single_debug_event = etdump_Event_debug_event(event);
+    value = etdump_DebugEvent_debug_entry(single_debug_event);
+    ASSERT_EQ(etdump_Value_tensor_is_present(value), true);
+    ASSERT_EQ(etdump_Value_output_is_present(value), true);
+    etdump_Bool_table_t bool_val = etdump_Value_output_get(value);
+    bool bool_val_from_table = etdump_Bool_bool_val(bool_val);
+    ASSERT_EQ(bool_val_from_table, true);
 
-  free(ptr);
-  free(result.buf);
+    free(ptr);
+    if (!etdump_gen[i]->is_static_etdump()) {
+      free(result.buf);
+    }
+  }
 }
 
 TEST_F(ProfilerETDumpTest, MultipleBlocksWithEvents) {
-  etdump_gen->create_event_block("test_block");
+  for (size_t i = 0; i < 2; i++) {
+    etdump_gen[i]->create_event_block("test_block");
 
-  AllocatorID allocator_id_0 = etdump_gen->track_allocator("test_allocator_0");
-  AllocatorID allocator_id_1 = etdump_gen->track_allocator("test_allocator_1");
-  etdump_gen->track_allocation(allocator_id_0, 64);
-  etdump_gen->track_allocation(allocator_id_1, 128);
+    AllocatorID allocator_id_0 =
+        etdump_gen[i]->track_allocator("test_allocator_0");
+    AllocatorID allocator_id_1 =
+        etdump_gen[i]->track_allocator("test_allocator_1");
+    etdump_gen[i]->track_allocation(allocator_id_0, 64);
+    etdump_gen[i]->track_allocation(allocator_id_1, 128);
 
-  EventTracerEntry entry = etdump_gen->start_profiling("test_event", 0, 1);
-  etdump_gen->end_profiling(entry);
-  etdump_gen->create_event_block("test_block_1");
-  allocator_id_0 = etdump_gen->track_allocator("test_allocator_0");
-  allocator_id_1 = etdump_gen->track_allocator("test_allocator_1");
-  etdump_gen->track_allocation(allocator_id_0, 64);
-  etdump_gen->track_allocation(allocator_id_0, 128);
+    EventTracerEntry entry = etdump_gen[i]->start_profiling("test_event", 0, 1);
+    etdump_gen[i]->end_profiling(entry);
+    etdump_gen[i]->create_event_block("test_block_1");
+    allocator_id_0 = etdump_gen[i]->track_allocator("test_allocator_0");
+    allocator_id_1 = etdump_gen[i]->track_allocator("test_allocator_1");
+    etdump_gen[i]->track_allocation(allocator_id_0, 64);
+    etdump_gen[i]->track_allocation(allocator_id_0, 128);
 
-  entry = etdump_gen->start_profiling("test_event", 0, 1);
-  etdump_gen->end_profiling(entry);
+    entry = etdump_gen[i]->start_profiling("test_event", 0, 1);
+    etdump_gen[i]->end_profiling(entry);
 
-  etdump_result result = etdump_gen->get_etdump_data();
-  ASSERT_TRUE(result.buf != nullptr);
-  ASSERT_TRUE(result.size != 0);
+    etdump_result result = etdump_gen[i]->get_etdump_data();
+    ASSERT_TRUE(result.buf != nullptr);
+    ASSERT_TRUE(result.size != 0);
 
-  size_t size = 0;
-  void* buf = flatbuffers_read_size_prefix(result.buf, &size);
-  etdump_ETDump_table_t etdump =
-      etdump_ETDump_as_root_with_identifier(buf, etdump_ETDump_file_identifier);
+    size_t size = 0;
+    void* buf = flatbuffers_read_size_prefix(result.buf, &size);
+    etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+        buf, etdump_ETDump_file_identifier);
 
-  ASSERT_NE(etdump, nullptr);
-  EXPECT_EQ(etdump_ETDump_version(etdump), ETDUMP_VERSION);
+    ASSERT_NE(etdump, nullptr);
+    EXPECT_EQ(etdump_ETDump_version(etdump), ETDUMP_VERSION);
 
-  etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
-  ASSERT_EQ(etdump_gen->get_num_blocks(), etdump_RunData_vec_len(run_data_vec));
+    etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+    ASSERT_EQ(
+        etdump_gen[i]->get_num_blocks(), etdump_RunData_vec_len(run_data_vec));
 
-  etdump_RunData_table_t run_data_0 = etdump_RunData_vec_at(run_data_vec, 0);
-  EXPECT_EQ(
-      std::string(
-          etdump_RunData_name(run_data_0),
-          strlen(etdump_RunData_name(run_data_0))),
-      "test_block");
+    etdump_RunData_table_t run_data_0 = etdump_RunData_vec_at(run_data_vec, 0);
+    EXPECT_EQ(
+        std::string(
+            etdump_RunData_name(run_data_0),
+            strlen(etdump_RunData_name(run_data_0))),
+        "test_block");
 
-  etdump_Allocator_vec_t allocator_vec_0 =
-      etdump_RunData_allocators(run_data_0);
-  ASSERT_EQ(etdump_Allocator_vec_len(allocator_vec_0), 2);
+    etdump_Allocator_vec_t allocator_vec_0 =
+        etdump_RunData_allocators(run_data_0);
+    ASSERT_EQ(etdump_Allocator_vec_len(allocator_vec_0), 2);
 
-  etdump_Allocator_table_t allocator_0 =
-      etdump_Allocator_vec_at(allocator_vec_0, 0);
-  EXPECT_EQ(
-      std::string(
-          etdump_Allocator_name(allocator_0),
-          strlen(etdump_Allocator_name(allocator_0))),
-      "test_allocator_0");
+    etdump_Allocator_table_t allocator_0 =
+        etdump_Allocator_vec_at(allocator_vec_0, 0);
+    EXPECT_EQ(
+        std::string(
+            etdump_Allocator_name(allocator_0),
+            strlen(etdump_Allocator_name(allocator_0))),
+        "test_allocator_0");
 
-  etdump_Event_vec_t event_vec = etdump_RunData_events(run_data_0);
-  ASSERT_EQ(etdump_Event_vec_len(event_vec), 3);
+    etdump_Event_vec_t event_vec = etdump_RunData_events(run_data_0);
+    ASSERT_EQ(etdump_Event_vec_len(event_vec), 3);
 
-  etdump_Event_table_t event_0 = etdump_Event_vec_at(event_vec, 0);
-  EXPECT_EQ(
-      etdump_AllocationEvent_allocation_size(
-          etdump_Event_allocation_event(event_0)),
-      64);
+    etdump_Event_table_t event_0 = etdump_Event_vec_at(event_vec, 0);
+    EXPECT_EQ(
+        etdump_AllocationEvent_allocation_size(
+            etdump_Event_allocation_event(event_0)),
+        64);
 
-  etdump_Event_table_t event_2 = etdump_Event_vec_at(event_vec, 2);
-  flatbuffers_string_t event_2_name =
-      etdump_ProfileEvent_name(etdump_Event_profile_event(event_2));
-  EXPECT_EQ(std::string(event_2_name, strlen(event_2_name)), "test_event");
+    etdump_Event_table_t event_2 = etdump_Event_vec_at(event_vec, 2);
+    flatbuffers_string_t event_2_name =
+        etdump_ProfileEvent_name(etdump_Event_profile_event(event_2));
+    EXPECT_EQ(std::string(event_2_name, strlen(event_2_name)), "test_event");
 
-  free(result.buf);
+    if (!etdump_gen[i]->is_static_etdump()) {
+      free(result.buf);
+    }
+  }
 }
 
 TEST_F(ProfilerETDumpTest, VerifyData) {
-  etdump_gen->create_event_block("test_block");
+  for (size_t i = 0; i < 2; i++) {
+    etdump_gen[i]->create_event_block("test_block");
 
-  etdump_gen->track_allocator("single prof allocator");
+    etdump_gen[i]->track_allocator("single prof allocator");
 
-  EventTracerEntry entry = etdump_gen->start_profiling("test_event", 0, 1);
-  etdump_gen->end_profiling(entry);
-  entry = etdump_gen->start_profiling("test_event2", 0, 1);
-  etdump_gen->end_profiling(entry);
+    EventTracerEntry entry = etdump_gen[i]->start_profiling("test_event", 0, 1);
+    etdump_gen[i]->end_profiling(entry);
+    entry = etdump_gen[i]->start_profiling("test_event2", 0, 1);
+    etdump_gen[i]->end_profiling(entry);
 
-  etdump_result result = etdump_gen->get_etdump_data();
-  ASSERT_TRUE(result.buf != nullptr);
-  ASSERT_TRUE(result.size != 0);
+    etdump_result result = etdump_gen[i]->get_etdump_data();
+    ASSERT_TRUE(result.buf != nullptr);
+    ASSERT_TRUE(result.size != 0);
 
-  size_t size = 0;
-  void* buf = flatbuffers_read_size_prefix(result.buf, &size);
-  etdump_ETDump_table_t etdump =
-      etdump_ETDump_as_root_with_identifier(buf, etdump_ETDump_file_identifier);
+    size_t size = 0;
+    void* buf = flatbuffers_read_size_prefix(result.buf, &size);
+    etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+        buf, etdump_ETDump_file_identifier);
 
-  ASSERT_NE(etdump, nullptr);
-  EXPECT_EQ(etdump_ETDump_version(etdump), ETDUMP_VERSION);
+    ASSERT_NE(etdump, nullptr);
+    EXPECT_EQ(etdump_ETDump_version(etdump), ETDUMP_VERSION);
 
-  etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
-  EXPECT_EQ(etdump_gen->get_num_blocks(), etdump_RunData_vec_len(run_data_vec));
+    etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+    EXPECT_EQ(
+        etdump_gen[i]->get_num_blocks(), etdump_RunData_vec_len(run_data_vec));
 
-  etdump_RunData_table_t run_data_single_prof =
-      etdump_RunData_vec_at(run_data_vec, 0);
-  EXPECT_EQ(
-      std::string(
-          etdump_RunData_name(run_data_single_prof),
-          strlen(etdump_RunData_name(run_data_single_prof))),
-      "test_block");
+    etdump_RunData_table_t run_data_single_prof =
+        etdump_RunData_vec_at(run_data_vec, 0);
+    EXPECT_EQ(
+        std::string(
+            etdump_RunData_name(run_data_single_prof),
+            strlen(etdump_RunData_name(run_data_single_prof))),
+        "test_block");
 
-  etdump_Allocator_vec_t allocator_vec =
-      etdump_RunData_allocators(run_data_single_prof);
+    etdump_Allocator_vec_t allocator_vec =
+        etdump_RunData_allocators(run_data_single_prof);
 
-  etdump_Event_table_t single_event =
-      etdump_Event_vec_at(etdump_RunData_events(run_data_single_prof), 0);
+    etdump_Event_table_t single_event =
+        etdump_Event_vec_at(etdump_RunData_events(run_data_single_prof), 0);
 
-  etdump_ProfileEvent_table_t single_prof_event =
-      etdump_Event_profile_event(single_event);
+    etdump_ProfileEvent_table_t single_prof_event =
+        etdump_Event_profile_event(single_event);
 
-  EXPECT_EQ(
-      std::string(
-          etdump_ProfileEvent_name(single_prof_event),
-          strlen(etdump_ProfileEvent_name(single_prof_event))),
-      "test_event");
-  EXPECT_EQ(etdump_ProfileEvent_chain_index(single_prof_event), 0);
+    EXPECT_EQ(
+        std::string(
+            etdump_ProfileEvent_name(single_prof_event),
+            strlen(etdump_ProfileEvent_name(single_prof_event))),
+        "test_event");
+    EXPECT_EQ(etdump_ProfileEvent_chain_index(single_prof_event), 0);
 
-  flatbuffers_string_t allocator_name =
-      etdump_Allocator_name(etdump_Allocator_vec_at(allocator_vec, 0));
-  EXPECT_EQ(
-      std::string(allocator_name, strlen(allocator_name)),
-      "single prof allocator");
+    flatbuffers_string_t allocator_name =
+        etdump_Allocator_name(etdump_Allocator_vec_at(allocator_vec, 0));
+    EXPECT_EQ(
+        std::string(allocator_name, strlen(allocator_name)),
+        "single prof allocator");
 
-  free(result.buf);
+    if (!etdump_gen[i]->is_static_etdump()) {
+      free(result.buf);
+    }
+  }
 }
 
 TEST_F(ProfilerETDumpTest, LogDelegateEvents) {
-  etdump_gen->create_event_block("test_block");
+  for (size_t i = 0; i < 2; i++) {
+    etdump_gen[i]->create_event_block("test_block");
 
-  // Event 0
-  etdump_gen->log_profiling_delegate(nullptr, 276, 1, 2, nullptr);
-  // Event 1
-  etdump_gen->log_profiling_delegate(nullptr, 278, 1, 2, "test_metadata");
-  EventTracerEntry entry = etdump_gen->start_profiling_delegate(
-      "test_event", static_cast<torch::executor::DebugHandle>(-1));
-  EXPECT_NE(entry.delegate_event_id_type, DelegateDebugIdType::kNone);
-  // Event 2
-  etdump_gen->end_profiling_delegate(entry, "test_metadata");
-  // Event 3
-  etdump_gen->log_profiling_delegate(
-      "test_event",
-      static_cast<torch::executor::DebugHandle>(-1),
-      1,
-      2,
-      nullptr);
-  // Event 4
-  etdump_gen->log_profiling_delegate(
-      "test_event",
-      static_cast<torch::executor::DebugHandle>(-1),
-      1,
-      2,
-      "test_metadata");
+    // Event 0
+    etdump_gen[i]->log_profiling_delegate(nullptr, 276, 1, 2, nullptr);
+    // Event 1
+    etdump_gen[i]->log_profiling_delegate(nullptr, 278, 1, 2, "test_metadata");
+    EventTracerEntry entry = etdump_gen[i]->start_profiling_delegate(
+        "test_event", static_cast<torch::executor::DebugHandle>(-1));
+    EXPECT_NE(entry.delegate_event_id_type, DelegateDebugIdType::kNone);
+    // Event 2
+    etdump_gen[i]->end_profiling_delegate(entry, "test_metadata");
+    // Event 3
+    etdump_gen[i]->log_profiling_delegate(
+        "test_event",
+        static_cast<torch::executor::DebugHandle>(-1),
+        1,
+        2,
+        nullptr);
+    // Event 4
+    etdump_gen[i]->log_profiling_delegate(
+        "test_event",
+        static_cast<torch::executor::DebugHandle>(-1),
+        1,
+        2,
+        "test_metadata");
 
-  // Only a valid name or delegate debug index should be passed in. If valid
-  // entries are passed in for both then the test should assert out.
-  ET_EXPECT_DEATH(
-      etdump_gen->start_profiling_delegate("test_event", 1),
-      "Only name or delegate_debug_index can be valid. Check DelegateMappingBuilder documentation for more details.");
-  ET_EXPECT_DEATH(
-      etdump_gen->log_profiling_delegate("test_event", 1, 1, 2, nullptr),
-      "Only name or delegate_debug_index can be valid. Check DelegateMappingBuilder documentation for more details.");
-  ET_EXPECT_DEATH(
-      etdump_gen->end_profiling(entry),
-      "Delegate events must use end_profiling_delegate to mark the end of a delegate profiling event.");
+    // Only a valid name or delegate debug index should be passed in. If valid
+    // entries are passed in for both then the test should assert out.
+    ET_EXPECT_DEATH(
+        etdump_gen[i]->start_profiling_delegate("test_event", 1),
+        "Only name or delegate_debug_index can be valid. Check DelegateMappingBuilder documentation for more details.");
+    ET_EXPECT_DEATH(
+        etdump_gen[i]->log_profiling_delegate("test_event", 1, 1, 2, nullptr),
+        "Only name or delegate_debug_index can be valid. Check DelegateMappingBuilder documentation for more details.");
+    ET_EXPECT_DEATH(
+        etdump_gen[i]->end_profiling(entry),
+        "Delegate events must use end_profiling_delegate to mark the end of a delegate profiling event.");
 
-  etdump_result result = etdump_gen->get_etdump_data();
-  ASSERT_TRUE(result.buf != nullptr);
-  ASSERT_TRUE(result.size != 0);
+    etdump_result result = etdump_gen[i]->get_etdump_data();
+    ASSERT_TRUE(result.buf != nullptr);
+    ASSERT_TRUE(result.size != 0);
 
-  // Run verification tests on the data that was just serialized.
-  size_t size = 0;
-  void* buf = flatbuffers_read_size_prefix(result.buf, &size);
-  etdump_ETDump_table_t etdump =
-      etdump_ETDump_as_root_with_identifier(buf, etdump_ETDump_file_identifier);
-  etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+    // Run verification tests on the data that was just serialized.
+    size_t size = 0;
+    void* buf = flatbuffers_read_size_prefix(result.buf, &size);
+    etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+        buf, etdump_ETDump_file_identifier);
+    etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
 
-  // Event 0
-  etdump_RunData_table_t run_data_0 = etdump_RunData_vec_at(run_data_vec, 0);
-  etdump_Event_vec_t event_vec = etdump_RunData_events(run_data_0);
-  ASSERT_EQ(etdump_Event_vec_len(event_vec), 5);
-  etdump_Event_table_t event = etdump_Event_vec_at(event_vec, 0);
+    // Event 0
+    etdump_RunData_table_t run_data_0 = etdump_RunData_vec_at(run_data_vec, 0);
+    etdump_Event_vec_t event_vec = etdump_RunData_events(run_data_0);
+    ASSERT_EQ(etdump_Event_vec_len(event_vec), 5);
+    etdump_Event_table_t event = etdump_Event_vec_at(event_vec, 0);
 
-  flatbuffers_string_t delegate_debug_id_name =
-      etdump_ProfileEvent_delegate_debug_id_str(
-          etdump_Event_profile_event(event));
+    flatbuffers_string_t delegate_debug_id_name =
+        etdump_ProfileEvent_delegate_debug_id_str(
+            etdump_Event_profile_event(event));
 
-  // Event 0 should have a empty delegate_debug_id_str
-  EXPECT_EQ(delegate_debug_id_name, nullptr);
-  // Check for the correct delegate_debug_id_int
-  EXPECT_EQ(
-      etdump_ProfileEvent_delegate_debug_id_int(
-          etdump_Event_profile_event(event)),
-      276);
-  flatbuffers_string_t debug_metadata_name =
-      etdump_ProfileEvent_delegate_debug_metadata(
-          etdump_Event_profile_event(event));
-  // Event 0 should have an empty delegate_debug_metadata string.
-  EXPECT_EQ(debug_metadata_name, nullptr);
+    // Event 0 should have a empty delegate_debug_id_str
+    EXPECT_EQ(delegate_debug_id_name, nullptr);
+    // Check for the correct delegate_debug_id_int
+    EXPECT_EQ(
+        etdump_ProfileEvent_delegate_debug_id_int(
+            etdump_Event_profile_event(event)),
+        276);
+    flatbuffers_string_t debug_metadata_name =
+        etdump_ProfileEvent_delegate_debug_metadata(
+            etdump_Event_profile_event(event));
+    // Event 0 should have an empty delegate_debug_metadata string.
+    EXPECT_EQ(debug_metadata_name, nullptr);
 
-  // Event 1
-  event = etdump_Event_vec_at(event_vec, 1);
-  // Check for the correct delegate_debug_id_int
-  EXPECT_EQ(
-      etdump_ProfileEvent_delegate_debug_id_int(
-          etdump_Event_profile_event(event)),
-      278);
-  debug_metadata_name = etdump_ProfileEvent_delegate_debug_metadata(
-      etdump_Event_profile_event(event));
-  // Check for the correct delegate_debug_metadata string
-  EXPECT_EQ(
-      std::string(debug_metadata_name, strlen(debug_metadata_name)),
-      "test_metadata");
+    // Event 1
+    event = etdump_Event_vec_at(event_vec, 1);
+    // Check for the correct delegate_debug_id_int
+    EXPECT_EQ(
+        etdump_ProfileEvent_delegate_debug_id_int(
+            etdump_Event_profile_event(event)),
+        278);
+    debug_metadata_name = etdump_ProfileEvent_delegate_debug_metadata(
+        etdump_Event_profile_event(event));
+    // Check for the correct delegate_debug_metadata string
+    EXPECT_EQ(
+        std::string(debug_metadata_name, strlen(debug_metadata_name)),
+        "test_metadata");
 
-  // Event 2
-  event = etdump_Event_vec_at(event_vec, 2);
-  delegate_debug_id_name = etdump_ProfileEvent_delegate_debug_id_str(
-      etdump_Event_profile_event(event));
-  // Check for the correct delegate_debug_id_str string.
-  EXPECT_EQ(
-      std::string(delegate_debug_id_name, strlen(delegate_debug_id_name)),
-      "test_event");
-  // Event 2 used a string delegate debug identifier, so delegate_debug_id_int
-  // should be -1.
-  EXPECT_EQ(
-      etdump_ProfileEvent_delegate_debug_id_int(
-          etdump_Event_profile_event(event)),
-      -1);
-  free(result.buf);
+    // Event 2
+    event = etdump_Event_vec_at(event_vec, 2);
+    delegate_debug_id_name = etdump_ProfileEvent_delegate_debug_id_str(
+        etdump_Event_profile_event(event));
+    // Check for the correct delegate_debug_id_str string.
+    EXPECT_EQ(
+        std::string(delegate_debug_id_name, strlen(delegate_debug_id_name)),
+        "test_event");
+    // Event 2 used a string delegate debug identifier, so delegate_debug_id_int
+    // should be -1.
+    EXPECT_EQ(
+        etdump_ProfileEvent_delegate_debug_id_int(
+            etdump_Event_profile_event(event)),
+        -1);
+    if (!etdump_gen[i]->is_static_etdump()) {
+      free(result.buf);
+    }
+  }
 }
 
 } // namespace executor


### PR DESCRIPTION
Summary:
This diff adds support for generating etdump in a statically allocated buffer that is passed in by the user. In many embedded use cases users want fine grained control on where etdump is placed and want to avoid any dynamic memory allocations.

All that the user's need to do is pass in a Span into the `ETDumpGen` constructor. This Span needs to contain the pointer to the statically allocated buffer and its size.

Differential Revision: D50854912


