### PR TITLE
[Executorch][Exir] Fix bug in memory planning

### DIFF
--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -928,6 +928,18 @@ class EdgeProgramManager:
                 new_gm_res = p(new_gm)
                 assert new_gm_res is not None
                 new_gm = new_gm_res.graph_module
+                if isinstance(p, SpecPropPass):
+                    # Note that this is a hacky way to get around the fact that
+                    # placeholder nodes corresponding to the parameters of the graph module
+                    # shall not participate in memory planning. It increases runtime memory
+                    # footprint.
+                    # Proper way would be to have ExportPass work with ExportedProgram
+                    # instead of GraphModule. This is because ExportPass should work
+                    # on top of the export artifact of torch.export whichi s ExportedProgram.
+                    # Working with GraphModule does not provide all the information contained
+                    # in the ExportedProgram
+                    # TODO(who?)
+                    p.update_placeholder_tensor_specs(program, new_gm)
             new_prog = copy.deepcopy(program)
             _copy_module(new_prog.graph_module, new_gm)
             execution_programs[name] = new_prog


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1301
* __->__ #1300

Summary:
This diff fixes bug in memory planning where const tensors are also
memory planned for.

A proper fix should be a done a bit differently as mentioned int he
comment.

Test Plan:
Validated on MV3.
Before this diff 20 MB non const buffer
Before this diff 9 MB non const buffer

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D51625496](https://our.internmc.facebook.com/intern/diff/D51625496)