### PR TITLE
Remove noautodeps from files inc executorch/extension/pybindings/TARGETS

### DIFF
--- a/extension/pybindings/TARGETS
+++ b/extension/pybindings/TARGETS
@@ -1,4 +1,3 @@
-# @noautodeps
 # Any targets that should be shared between fbcode and xplat must be defined in
 # targets.bzl. This file can contain fbcode-only targets.
 


### PR DESCRIPTION
Summary:
autodeps automatically adds and removes dependencies from targets. Removing dependencies reduces build times, build sizes, and error surfaces. Adding dependencies gives your code the things it needs to work.

This diff removes **noautodeps** from one or more TARGETS files, opting them into autodeps.

This changes **should be low risk** because:
* We have verified that `autodeps` runs correctly on the modified files
* The TARGETS files in this diff contain _only additions_ and no removals of dependencies. Additions rarely break code.
* We have verified that the additions do not create circular dependencies, which are the most common problem when dependencies are added.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D51492505


