### PR TITLE
Add constant_segment to schema

### DIFF
--- a/exir/_serialize/test/test_program.py
+++ b/exir/_serialize/test/test_program.py
@@ -31,6 +31,7 @@ from executorch.exir.schema import (
     DataSegment,
     ExecutionPlan,
     Program,
+    SubsegmentOffsets,
 )
 from executorch.exir.tests.common import get_test_program
 
@@ -188,6 +189,7 @@ class TestProgram(unittest.TestCase):
                 BackendDelegateInlineData(data=b"AA delegate [0,0] data"),
             ],
             segments=[],
+            constant_segment=SubsegmentOffsets(segment_index=0, offsets=[]),
         )
 
         # Demonstrate which data each delegate points to.

--- a/exir/emit/_emit_program.py
+++ b/exir/emit/_emit_program.py
@@ -28,6 +28,7 @@ from executorch.exir.schema import (
     Int,
     Program,
     String,
+    SubsegmentOffsets,
 )
 from executorch.exir.tensor import layout_enum, scalar_type_enum
 from executorch.exir.version import EXECUTORCH_SCHEMA_VERSION
@@ -204,5 +205,7 @@ def emit_program(
             backend_delegate_data=program_state.backend_delegate_data,
             # Segments may be added at serialization time.
             segments=[],
+            # Subsegment offsets may be added at serialization time.
+            constant_segment=SubsegmentOffsets(segment_index=0, offsets=[]),
         ),
     )

--- a/exir/schema.py
+++ b/exir/schema.py
@@ -245,9 +245,16 @@ class DataSegment:
 
 
 @dataclass
+class SubsegmentOffsets:
+    segment_index: int
+    offsets: List[int]
+
+
+@dataclass
 class Program:
     version: int
     execution_plan: List[ExecutionPlan]
     constant_buffer: List[Buffer]
     backend_delegate_data: List[BackendDelegateInlineData]
     segments: List[DataSegment]
+    constant_segment: SubsegmentOffsets

--- a/exir/tests/common.py
+++ b/exir/tests/common.py
@@ -27,6 +27,7 @@ from executorch.exir.schema import (
     Program,
     ScalarType,
     String,
+    SubsegmentOffsets,
     Tensor,
     TensorShapeDynamism,
 )
@@ -80,6 +81,7 @@ def get_test_program() -> Program:
         constant_buffer=[Buffer(storage=b"")],
         backend_delegate_data=[],
         segments=[],
+        constant_segment=SubsegmentOffsets(segment_index=0, offsets=[]),
     )
 
 

--- a/exir/tests/fixtures/basic_sin_max.txt
+++ b/exir/tests/fixtures/basic_sin_max.txt
@@ -109,5 +109,11 @@
   ],
   "segments": [
 
-  ]
+  ],
+  "constant_segment": {
+    "segment_index": 0,
+    "offsets": [
+
+    ]
+  }
 }

--- a/exir/tests/fixtures/composite_delegate.txt
+++ b/exir/tests/fixtures/composite_delegate.txt
@@ -224,5 +224,11 @@
   ],
   "segments": [
 
-  ]
+  ],
+  "constant_segment": {
+    "segment_index": 0,
+    "offsets": [
+
+    ]
+  }
 }

--- a/schema/program.fbs
+++ b/schema/program.fbs
@@ -357,6 +357,16 @@ table DataSegment {
   size: uint64;
 }
 
+// Describes data offsets into a particular segment
+table SubsegmentOffsets {
+  // Index of the segment in Program.segments
+  segment_index: uint;
+
+  // Each element is an offset in bytes into the data of the segment pointed to
+  // by segment_index. Offsets must be aligned to @executorch-tensor-alignment.
+  offsets: [uint64];
+}
+
 table Program {
   // Schema version.
   version:uint;
@@ -367,7 +377,8 @@ table Program {
 
   // Tables of constant data, used for constant Values (e.g.data field of weight tensors).
   // Each constant is assigned an index into the table which are each individually aligned.
-  // 0 index is reserved to be pointed to by non-constant Tensors
+  // 0 index is reserved to be pointed to by non-constant Tensors.
+  // If this field is non-empty, constant_segment.offsets must be empty.
   constant_buffer:[Buffer];
 
   // List of delegate data. Pointed to by BackendDelegateDataReference.
@@ -376,6 +387,12 @@ table Program {
   // List of data segments that follow the Program data in this file, sorted by
   // offset. Elements in this schema can refer to these segments by index.
   segments:[DataSegment];
+
+  // Describes the offsets of each constant tensor, relative to the segment
+  // offset. If constant_segment.offsets field is non-empty, constant_buffer
+  // must be empty. constant_segment.offsets[0] is reserved to be pointed to by
+  // non-constant Tensors.
+  constant_segment: SubsegmentOffsets;
 }
 
 root_type Program;


### PR DESCRIPTION
Summary:
Add `constant_segment`, `SubsegmentOffsets` to flatbuffer schema and tests. Used in subsequent diffs.

Generate fixtures with `buck2 run fbcode//executorch/exir/tests:generate_fixtures`

Issue/design: https://github.com/pytorch/executorch/issues/885

Differential Revision: D51595437


