### PR TITLE
SDK example runner changes to suppport intermediate tensor logging

### DIFF
--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -1035,7 +1035,7 @@ Error Method::experimental_reset_execution() {
 void Method::log_outputs() {
 #ifdef ET_EVENT_TRACER_ENABLED
   if (event_tracer_ != nullptr) {
-    if (event_tracer->event_tracer_debug_level() >=
+    if (event_tracer_->event_tracer_debug_level() >=
         EventTracerDebugLogLevel::kProgramOutputs) {
       for (size_t i = 0; i < outputs_size(); i++) {
         internal::event_tracer_log_evalue_output(event_tracer_, get_output(i));

--- a/sdk/bundled_program/bundled_program.cpp
+++ b/sdk/bundled_program/bundled_program.cpp
@@ -16,6 +16,7 @@
 #include <ATen/ATen.h>
 #endif // USE_ATEN_LIB
 
+#include <executorch/runtime/core/event_tracer_hooks.h>
 #include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 #include <executorch/runtime/core/memory_allocator.h>
 #include <executorch/runtime/executor/method.h>
@@ -292,6 +293,9 @@ __ET_NODISCARD Error LoadBundledInput(
         "set_input failed during load bundled inputs with status %" PRIu32,
         status);
   }
+
+  internal::event_tracer_set_bundled_input_index(
+      method.get_event_tracer(), testset_idx);
 
   return Error::Ok;
 }


### PR DESCRIPTION
Summary: This diff adds support to the `sdk_example_runner` to take in command line parameters to enable intermediate/program output logging to etdump. Along with that we take in additional parameters for debug_buffer path and debug_buffer size. The debug_buffer is where the tensor and scalar data is stored (just the raw data not the metadata).

Reviewed By: Jack-Khuu

Differential Revision: D51599690


