### PR TITLE
[MPS] Don't specialize the executable for the current device

### DIFF
--- a/backends/apple/mps/runtime/MPSCompiler.mm
+++ b/backends/apple/mps/runtime/MPSCompiler.mm
@@ -33,8 +33,7 @@ MPSGraphExecutable* loadExecutable(
   size_t num_bytes) {
   ExirMPSGraphPackage* exirMPSGraphPackage = (ExirMPSGraphPackage*)buffer_pointer;
   NSData *new_manifest_plist_data = [NSData dataWithBytes:exirMPSGraphPackage->data length:exirMPSGraphPackage->model_0_offset];
-  NSData *new_model_0_data = [NSData dataWithBytes:exirMPSGraphPackage->data + exirMPSGraphPackage->model_0_offset length:exirMPSGraphPackage->model_1_offset - exirMPSGraphPackage->model_0_offset];
-  NSData *new_model_1_data = [NSData dataWithBytes:exirMPSGraphPackage->data + exirMPSGraphPackage->model_1_offset length:exirMPSGraphPackage->total_bytes - sizeof(ExirMPSGraphPackage) - exirMPSGraphPackage->model_1_offset];
+  NSData *new_model_0_data = [NSData dataWithBytes:exirMPSGraphPackage->data + exirMPSGraphPackage->model_0_offset length:exirMPSGraphPackage->total_bytes - sizeof(ExirMPSGraphPackage) - exirMPSGraphPackage->model_0_offset];
 
   NSError* error = nil;
   NSString* packageName = [NSString stringWithUTF8String:(
@@ -52,14 +51,12 @@ MPSGraphExecutable* loadExecutable(
 
   NSString* manifestFileStr = [NSString stringWithFormat:@"%@/manifest.plist", dataFileNSStr];
   NSString* model0FileStr = [NSString stringWithFormat:@"%@/model_0.mpsgraph", dataFileNSStr];
-  NSString* model1FileStr = [NSString stringWithFormat:@"%@/model_1.mpsgraph", dataFileNSStr];
 
   NSFileManager *fileManager= [NSFileManager defaultManager];
   [fileManager createDirectoryAtPath:dataFileNSStr withIntermediateDirectories:NO attributes:nil error:&error];
 
   [new_manifest_plist_data writeToFile:manifestFileStr options:NSDataWritingAtomic error:&error];
   [new_model_0_data writeToFile:model0FileStr options:NSDataWritingAtomic error:&error];
-  [new_model_1_data writeToFile:model1FileStr options:NSDataWritingAtomic error:&error];
 
   NSURL *bundleURL = [NSURL fileURLWithPath:dataFileNSStr];
   MPSGraphCompilationDescriptor *compilationDescriptor = [MPSGraphCompilationDescriptor new];

--- a/backends/apple/mps/utils/MPSGraphInterface.h
+++ b/backends/apple/mps/utils/MPSGraphInterface.h
@@ -251,9 +251,6 @@ class MPSGraphModule {
   std::vector<MPSGraphTensor*> outputTensors_;
   std::vector<MPSGraphTensor*> inputTensors_;
   MPSGraphExecutable* executable_;
-
-  id<MTLDevice> device_;
-  id<MTLCommandQueue> commandQueue_;
 };
 
 } // namespace mps

--- a/backends/apple/mps/utils/MPSGraphPackageExport.h
+++ b/backends/apple/mps/utils/MPSGraphPackageExport.h
@@ -10,7 +10,6 @@
 struct ExirMPSGraphPackage {
   int64_t manifest_plist_offset;
   int64_t model_0_offset;
-  int64_t model_1_offset;
   int64_t total_bytes;
   uint8_t data[];
 };


### PR DESCRIPTION
Summary of changes: 
- Remove the specialization of the executable for the current device. This reduces the size of the final generated package and increases the tracing speed for AOT, as the weights will be stored only once instead of duplicating them.

cc @georgepaw