### PR TITLE
Fix emitter build for Apple

### DIFF
--- a/sdk/etdump/emitter.h
+++ b/sdk/etdump/emitter.h
@@ -50,5 +50,11 @@ int et_flatcc_custom_init(
     flatcc_builder_t* builder,
     struct etdump_static_allocator* alloc);
 
+int etdump_static_allocator_builder_init(
+    flatcc_builder_t* builder,
+    struct etdump_static_allocator* alloc);
+
+void etdump_static_allocator_reset(struct etdump_static_allocator* alloc);
+
 } // namespace executor
 } // namespace torch

--- a/sdk/etdump/etdump_flatcc.h
+++ b/sdk/etdump/etdump_flatcc.h
@@ -82,5 +82,8 @@ class ETDumpGen : public EventTracer {
   size_t copy_tensor_to_debug_buffer(exec_aten::Tensor tensor);
 };
 
+executorch_flatbuffer_ScalarType_enum_t get_flatbuffer_scalar_type(
+    exec_aten::ScalarType tensor_scalar_type);
+
 } // namespace executor
 } // namespace torch


### PR DESCRIPTION
Summary:
Building etdump emitter + flatcc for Apple results in errors
```
buck2 build fbsource//xplat/executorch/sdk/etdump:etdump_emitterApple
File changed: fbsource//xplat/executorch/sdk/etdump/emitter.cpp
Action failed: fbsource//xplat/executorch/sdk/etdump:etdump_emitterApple (cxx_compile emitter.cpp (pic))
Remote command returned non-zero exit code 1
Reproduce locally: `frecli cas download-action a01a5504e1ed37075b4eef867b83ef7323cb03bee79d9ba17fccb2426c7258da:145`
stdout:
stderr:
xplat/executorch/sdk/etdump/emitter.cpp:167:6: error: no previous prototype for function 'etdump_static_allocator_reset' [-Werror,-Wmissing-prototypes]
void etdump_static_allocator_reset(struct etdump_static_allocator* alloc) {
     ^
xplat/executorch/sdk/etdump/emitter.cpp:167:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
void etdump_static_allocator_reset(struct etdump_static_allocator* alloc) {
^
static
1 error generated.
Buck UI: https://www.internalfb.com/buck2/10cdbd8c-deaf-4a17-8888-707a42c0e01a
Network: Up: 4.4KiB  Down: 0B  (reSessionID-b60f2a3d-fc97-430a-84a3-52ab6d42a01c)
Jobs completed: 4. Time elapsed: 14.6s.
Cache hits: 0%. Commands: 1 (cached: 0, remote: 1, local: 0)
BUILD FAILED
Failed to build 'fbsource//xplat/executorch/sdk/etdump:etdump_emitterApple (ovr_config//platform/iphoneos:iphonesimulator-x86_64-local#6bc77c42b644050f)'
```

```
buck2 build fbsource//xplat/executorch/sdk/etdump:etdump_flatccApple
Action failed: fbsource//xplat/executorch/sdk/etdump:etdump_flatccApple (cxx_compile etdump_flatcc.cpp (pic))
Remote command returned non-zero exit code 1
Reproduce locally: `frecli cas download-action 224e62e6f94b27cbc1a9e8f6f56cf524e09017b030ad56c07593db3ba3a96a3b:145`
stdout:
stderr:
xplat/executorch/sdk/etdump/etdump_flatcc.cpp:283:41: error: no previous prototype for function 'get_flatbuffer_scalar_type' [-Werror,-Wmissing-prototypes]
executorch_flatbuffer_ScalarType_enum_t get_flatbuffer_scalar_type(
                                        ^
xplat/executorch/sdk/etdump/etdump_flatcc.cpp:283:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
executorch_flatbuffer_ScalarType_enum_t get_flatbuffer_scalar_type(
^
static
1 error generated.
Buck UI: https://www.internalfb.com/buck2/fe8dd46c-a8d1-4ae4-9971-68e591c8e4ad
Network: Up: 174B  Down: 0B  (reSessionID-bbc28771-18a8-47d7-a699-9c2257ddc73e)
Jobs completed: 4. Time elapsed: 10.8s.
Cache hits: 0%. Commands: 1 (cached: 0, remote: 1, local: 0)
BUILD FAILED
Failed to build 'fbsource//xplat/executorch/sdk/etdump:etdump_flatccApple (ovr_config//platform/iphoneos:iphonesimulator-x86_64-local#6bc77c42b644050f)'
```

Add prototypes in emitter.h and etdump_flatcc.h

Reviewed By: tarun292, kirklandsign

Differential Revision: D51716663


