### PR TITLE
Add Executor runner benchmark to iOS PyTorch Benchmark app

### DIFF
--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -12,6 +12,9 @@
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 #include <unordered_map>
 
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wglobal-constructors"
+
 namespace torch {
 namespace executor {
 namespace xnnpack {

--- a/backends/xnnpack/runtime/XNNPACKBackend.cpp
+++ b/backends/xnnpack/runtime/XNNPACKBackend.cpp
@@ -13,6 +13,8 @@
 #include <executorch/runtime/platform/profiler.h>
 #include <memory>
 
+#pragma clang diagnostic ignored "-Wglobal-constructors"
+
 namespace torch {
 namespace executor {
 

--- a/schema/extended_header.cpp
+++ b/schema/extended_header.cpp
@@ -14,6 +14,8 @@
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/result.h>
 
+#pragma clang diagnostic ignored "-Wdeprecated"
+
 namespace torch {
 namespace executor {
 


### PR DESCRIPTION
Summary:
Currently, executor_runner cannot be deployed to iOS device sbecause it needs to be wrapped in an app. This change allows us to set a flag to trigger the `executor_runner` instead of the `lite_predictor_benechmark` without maintaining a separate app.

Add D51386920 changes

Reviewed By: kirklandsign

Differential Revision: D51013939


