### PR TITLE
add memory manager test target back

### DIFF
--- a/runtime/executor/test/targets.bzl
+++ b/runtime/executor/test/targets.bzl
@@ -200,3 +200,14 @@ def define_common_targets(is_fbcode = False):
                 "ET_MODULE_ADD_MUL_PATH": "$(location fbcode//executorch/test/models:exported_delegated_programs[ModuleAddMul.pte])",
             },
         )
+
+        runtime.cxx_test(
+            name = "memory_manager_test",
+            srcs = [
+                "memory_manager_test.cpp",
+            ],
+            deps = [
+                "//executorch/runtime/core:memory_allocator",
+                "//executorch/runtime/executor:memory_manager",
+            ],
+        )


### PR DESCRIPTION
Summary: Seems like accidently deleted in D49279973, fortunately it still passes..

Differential Revision: D51762695


