### PR TITLE
[TOSA] Replace Linear lowering of using Matmul with Conv2d

### DIFF
--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -19,7 +19,11 @@ from executorch.backends.arm.operators.node_visitor import get_node_visitors
 from executorch.backends.arm.operators.op_placeholder import process_placeholder
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_quant_utils import isQuantNode
-from executorch.backends.arm.tosa_utils import dbg_fail, dbg_tosa_dump
+from executorch.backends.arm.tosa_utils import (
+    dbg_fail,
+    dbg_tosa_dump,
+    is_permute_node_before_addmm,
+)
 from executorch.exir.backend.backend_details import BackendDetails, PreprocessResult
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from torch._export.exported_program import ExportedProgram
@@ -74,7 +78,9 @@ class ArmBackend(BackendDetails):
                 # Add output to TOSA graph
                 tosa_graph.currRegion.currBasicBlock.addTensor(
                     output.name,
-                    output.shape,
+                    inputs[0].shape
+                    if is_permute_node_before_addmm(node)
+                    else output.shape,
                     ts.DType.INT8 if is_quant_node else output.dtype,
                 )
 

--- a/backends/arm/operators/op_addmm.py
+++ b/backends/arm/operators/op_addmm.py
@@ -16,7 +16,9 @@ from executorch.backends.arm.tosa_quant_utils import (
     computeMultiplierAndShift,
     getQuantNodeArgs,
 )
-from executorch.backends.arm.tosa_utils import promote_shape
+
+from executorch.backends.arm.tosa_utils import buildReshape
+from executorch.exir.dialects._ops import ops as exir_ops
 from serializer.tosa_serializer import TosaOp
 
 
@@ -37,68 +39,88 @@ class AddmmVisitor(NodeVisitor):
     ) -> None:
         bias, input, weight = inputs
 
-        output_dtype = ts.DType.INT8 if is_quant_node else output.dtype
+        N = input.shape[0]
+        input_channels = input.shape[1]
+        output_channels = weight.shape[1]
 
-        # Reshape input, weight, bias tensors
-        input_reshape_res = promote_shape(
-            tosa_graph, input, (1,) + input.shape, output_dtype
-        )
-        weight_reshape_res = promote_shape(
-            tosa_graph, weight, (1,) + weight.shape, output_dtype
-        )
-
-        bias_dtype = ts.DType.INT32 if is_quant_node else output.dtype
-        bias_reshape_res = promote_shape(
-            tosa_graph,
-            bias,
-            (
-                1,
-                1,
-            )
-            + bias.shape,
-            bias_dtype,
+        input_new_shape = (N, 1, 1, input_channels)
+        input_reshaped = tosa_graph.addIntermediate(
+            input_new_shape,
+            ts.DType.INT8 if is_quant_node else input.dtype,
         )
 
-        # Add dummy batch 1 to mm_shape
-        mm_shape = (1, input.shape[0], weight.shape[1])
-        # Define Intermediate tensor for MatMul res
-        mm_res = tosa_graph.addIntermediate(
-            mm_shape, ts.DType.INT32 if is_quant_node else output_dtype
+        buildReshape(tosa_graph, input.name, input_new_shape, input_reshaped.name)
+
+        weight_new_shape = (output_channels, 1, 1, input_channels)
+        weight_reshaped = tosa_graph.addIntermediate(
+            weight_new_shape,
+            ts.DType.INT8 if is_quant_node else weight.dtype,
         )
 
-        # Add MatMulOp
-        attr_matmul = ts.TosaSerializerAttribute()
-        a_zp, b_zp = (-128, 0) if is_quant_node else (0, 0)
-        attr_matmul.MatMulAttribute(a_zp, b_zp)
+        buildReshape(tosa_graph, weight.name, weight_new_shape, weight_reshaped.name)
+
+        # Get the attributes of convolution.
+        attr = ts.TosaSerializerAttribute()
+        pad_attr = [0, 0, 0, 0]
+        stride_attr = [1, 1]
+        dilation_attr = [1, 1]
+
+        input_zp = -128 if is_quant_node else 0
+        attr.ConvAttribute(
+            pad=pad_attr,
+            stride=stride_attr,
+            dilation=dilation_attr,
+            input_zp=input_zp,
+            weight_zp=0,
+            local_bound=False,
+        )
+
+        conv2d_output_shape = (N, 1, 1, output_channels)
+        conv2d_res = tosa_graph.addIntermediate(
+            conv2d_output_shape,
+            ts.DType.INT32 if is_quant_node else output.dtype,
+        )
+
+        # U55 doesn't support tosa.matmul and tosa.fully_connected will be deprecated
+        # TOSA Conv2d input is NHWC and weights are in OHWI
         tosa_graph.addOperator(
-            TosaOp.Op().MATMUL,
-            [input_reshape_res.name, weight_reshape_res.name],
-            [mm_res.name],
-            attr_matmul,
+            TosaOp.Op().CONV2D,
+            [
+                input_reshaped.name,
+                weight_reshaped.name,
+                bias.name,
+            ],
+            [conv2d_res.name],
+            attr,
         )
 
-        # Add AddOp
-        add_res = tosa_graph.addIntermediate(
-            mm_shape, ts.DType.INT32 if is_quant_node else output_dtype
-        )
-
-        tosa_graph.addOperator(
-            TosaOp.Op().ADD,
-            [bias_reshape_res.name, mm_res.name],
-            [add_res.name],
-            None,
-        )
+        result_shape = (N, output_channels)
 
         if is_quant_node:
             # Read inputs' parent nodes
-            #
             _, input_node, weight_node = node.all_input_nodes
-            input_scale, _ = getQuantNodeArgs(input_node)
+
+            # rank > 2 linear layer
+            if input_node.target == exir_ops.edge.aten.view_copy.default:
+                quant_node = input_node.all_input_nodes[0]
+                input_scale, _ = getQuantNodeArgs(quant_node)
+                consumer_node = list(node.users)[0]
+                consumer_consumer_node = list(consumer_node.users)[0]
+                (
+                    consumer_node_scale,
+                    consumer_node_node_zp,
+                ) = getQuantNodeArgs(consumer_consumer_node)
+
+            else:
+                input_scale, _ = getQuantNodeArgs(input_node)
+                consumer_node = list(node.users)[0]
+                (
+                    consumer_node_scale,
+                    consumer_node_node_zp,
+                ) = getQuantNodeArgs(consumer_node)
+
             weight_node_q_node = weight_node.all_input_nodes[0]
             weight_scale, _ = getQuantNodeArgs(weight_node_q_node)
-
-            consumer_node = list(node.users)[0]
-            consumer_node_scale, consumer_node_node_zp = getQuantNodeArgs(consumer_node)
 
             output_rescale_scale = (input_scale * weight_scale) / consumer_node_scale
             (
@@ -115,20 +137,20 @@ class AddmmVisitor(NodeVisitor):
                 scale32=True,
                 double_round=True,
                 per_channel=False,
+                input_unsigned=False,
+                output_unsigned=False,
             )
-            add_res_int8 = tosa_graph.addIntermediate(mm_shape, ts.DType.INT8)
+
+            reshaped_res = tosa_graph.addIntermediate(result_shape, ts.DType.INT32)
+            buildReshape(tosa_graph, conv2d_res.name, result_shape, reshaped_res.name)
+
             tosa_graph.addOperator(
                 TosaOp.Op().RESCALE,
-                [add_res.name],
-                [add_res_int8.name],
+                [reshaped_res.name],
+                [output.name],
                 attr_rescale_output,
             )
-        # Reshape final result to original shape
-        attr_out = ts.TosaSerializerAttribute()
-        attr_out.ReshapeAttribute(output.shape)
-        tosa_graph.addOperator(
-            TosaOp.Op().RESHAPE,
-            [add_res_int8.name if is_quant_node else add_res.name],
-            [output.name],
-            attr_out,
-        )
+
+        else:
+            # non-quantized case
+            buildReshape(tosa_graph, conv2d_res.name, result_shape, output.name)

--- a/backends/arm/operators/op_conv2d.py
+++ b/backends/arm/operators/op_conv2d.py
@@ -52,7 +52,14 @@ class Conv2dVisitor(NodeVisitor):
         pad_attr = [val for val in pad.special for _ in (0, 1)]
         stride_attr = stride.special
         dilation_attr = dilation.special
-        attr.ConvAttribute(pad_attr, stride_attr, dilation_attr, 0, 0)
+        attr.ConvAttribute(
+            pad=pad_attr,
+            stride=stride_attr,
+            dilation=dilation_attr,
+            input_zp=0,
+            weight_zp=0,
+            local_bound=False,
+        )
 
         # Non-bias case.
         if len(node.all_input_nodes) == 2:

--- a/backends/arm/operators/op_permute.py
+++ b/backends/arm/operators/op_permute.py
@@ -12,6 +12,7 @@ from executorch.backends.arm.operators.node_visitor import (
     register_node_visitor,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
+from executorch.backends.arm.tosa_utils import is_permute_node_before_addmm
 from serializer.tosa_serializer import TosaOp
 
 
@@ -30,6 +31,13 @@ class PermuteVisitor(NodeVisitor):
         output: TosaArg,
         is_quant_node: bool,
     ) -> None:
+        if is_permute_node_before_addmm(node):
+            ## Simply add an identityOp
+            tosa_graph.addOperator(
+                TosaOp.Op().IDENTITY, [inputs[0].name], [output.name]
+            )
+            return
+
         attr = ts.TosaSerializerAttribute()
         attr.TransposeAttribute(inputs[1].special)
         tosa_graph.addOperator(

--- a/backends/arm/test/test_models.py
+++ b/backends/arm/test/test_models.py
@@ -128,13 +128,29 @@ class TorchBuilder:
     @register_test
     class simple_linear(torch.nn.Module):
         inputs = {
-            TosaProfile.BI: (torch.ones(100, 20),),
-            TosaProfile.MI: (torch.ones(100, 20),),
+            TosaProfile.BI: (torch.rand(1, 2),),
+            TosaProfile.MI: (torch.rand(1, 2),),
         }
 
         def __init__(self):
             super().__init__()
             torch.manual_seed(seed)
+            self.fc = torch.nn.Linear(2, 3)
+
+        def forward(self, x):
+            x = self.fc(x)
+            return x
+
+    @register_test
+    class simple_linear_rank4(torch.nn.Module):
+        inputs = {
+            TosaProfile.BI: (torch.rand(5, 10, 25, 20),),
+            TosaProfile.MI: (torch.rand(5, 10, 25, 20),),
+        }
+
+        def __init__(self):
+            super().__init__()
+            torch.manual_seed(42)
             self.fc = torch.nn.Linear(20, 30)
 
         def forward(self, x):

--- a/examples/arm/arm_tosa_e2e.py
+++ b/examples/arm/arm_tosa_e2e.py
@@ -16,9 +16,6 @@ from executorch.backends.arm.test.test_models import TestList, TosaProfile
 from executorch.backends.arm.test.test_tosa import prepare_model_and_ref
 from executorch.exir import to_edge
 
-from executorch.exir.backend.canonical_partitioners.duplicate_dequant_node_pass import (
-    DuplicateDequantNodePass,
-)
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -41,6 +38,7 @@ SUPPORTED_BI_TEST_LIST = [
     "simple_add",
     "simple_add_broadcast",
     "simple_linear",
+    "simple_linear_rank4",
     "simple_conv2d_3x3_1x3x256x256_stride1",
     "simple_conv2d_1x1_1x2x128x128_stride1",
     "simple_conv2d_2x2_1x1x14x14_stride2",
@@ -173,6 +171,7 @@ def tosa_run_test(op, profile=TosaProfile.MI):  # noqa: C901
     # Export model
     model_capture = export(model, inputs)
     model_edge = to_edge(model_capture, compile_config=_EDGE_COMPILE_CONFIG)
+
     ArmPartitioner.compile_spec = compile_spec
 
     if profile == TosaProfile.BI:
@@ -185,7 +184,6 @@ def tosa_run_test(op, profile=TosaProfile.MI):  # noqa: C901
             output_quantization_zp,
         ) = get_output_quantization_param(model_edge)
 
-    model_edge = model_edge.transform((DuplicateDequantNodePass(),))
     model_edge = model_edge.to_backend(ArmPartitioner())
     exec_prog = model_edge.to_executorch()
 


### PR DESCRIPTION
- The existing Vela compiler doesn't support Matmul and TOSA.Fully_Connected will be deprecated
- Also add support for linear layers with rank>2 + tests

