### PR TITLE
Refactor extract_segments -> extract_delegate_segments

### DIFF
--- a/backends/xnnpack/utils/configs.py
+++ b/backends/xnnpack/utils/configs.py
@@ -32,7 +32,7 @@ def get_xnnpack_executorch_backend_config(
     additional_passes = additional_passes if additional_passes else []
     return exir.ExecutorchBackendConfig(
         passes=additional_passes,
-        extract_segments=True,
+        extract_delegate_segments=True,
     )
 
 

--- a/exir/_serialize/_program.py
+++ b/exir/_serialize/_program.py
@@ -237,7 +237,7 @@ def _get_extended_header(program_data: bytes) -> Optional[_ExtendedHeader]:
     return None
 
 
-def _extract_segments(
+def _extract_delegate_segments(
     program: Program, segment_alignment: int
 ) -> Tuple[Program, List[bytes]]:
     """Moves data from the Program into a list of segments.
@@ -420,7 +420,7 @@ def _append_segments(
 def serialize_pte_binary(
     program: Program,
     *,
-    extract_segments: bool = False,
+    extract_delegate_segments: bool = False,
     segment_alignment: int = 4096,
     constant_tensor_alignment: Optional[int] = None,
     delegate_alignment: Optional[int] = None,
@@ -429,9 +429,9 @@ def serialize_pte_binary(
 
     Args:
         program: The Program to serialize.
-        extract_segments: Whether to move certain data blobs from the Program
-            into separate segments, rather than encoding those blobs in the
-            flatbuffer data. When true, will also:
+        extract_delegate_segments: Whether to move delegate data blobs from the
+            Program into separate segments, rather than encoding those blobs
+            in the flatbuffer data. When true, will also:
             - Add an extended header to the output, containing the program size
               and the starting segment offset.
             - Update the Program.segments field with the offsets and lengths
@@ -449,9 +449,9 @@ def serialize_pte_binary(
     """
     # Segment data to be written to the file following the flatbuffer data.
     segments: List[bytes] = []
-    if extract_segments:
+    if extract_delegate_segments:
         # May return a copy of the program to avoid modifying the input.
-        program, segments = _extract_segments(
+        program, segments = _extract_delegate_segments(
             program=program, segment_alignment=segment_alignment
         )
 
@@ -461,7 +461,7 @@ def serialize_pte_binary(
         constant_tensor_alignment=constant_tensor_alignment,
         delegate_alignment=delegate_alignment,
     )
-    if not extract_segments:
+    if not extract_delegate_segments:
         return result.data
 
     # Size of the header to insert. Its size is padded to the largest

--- a/exir/_serialize/test/test_program.py
+++ b/exir/_serialize/test/test_program.py
@@ -282,7 +282,7 @@ class TestProgram(unittest.TestCase):
         deserializing, even when it contains an extended header.
         """
         program = get_test_program()
-        pte_data = serialize_pte_binary(program, extract_segments=True)
+        pte_data = serialize_pte_binary(program, extract_delegate_segments=True)
         self.assertGreater(len(pte_data), 16)
 
         # File magic should be present at the expected offset.
@@ -329,7 +329,7 @@ class TestProgram(unittest.TestCase):
 
         # Extract the blobs into segments during serialization.
         pte_data = serialize_pte_binary(
-            program, extract_segments=True, segment_alignment=SEGMENT_ALIGNMENT
+            program, extract_delegate_segments=True, segment_alignment=SEGMENT_ALIGNMENT
         )
 
         # The input Program should not have been modified.
@@ -443,7 +443,7 @@ class TestProgram(unittest.TestCase):
 
         # Extract the blobs into segments should succeeed.
         pte_data = serialize_pte_binary(
-            program, extract_segments=True, segment_alignment=SEGMENT_ALIGNMENT
+            program, extract_delegate_segments=True, segment_alignment=SEGMENT_ALIGNMENT
         )
         self.assertGreater(len(pte_data), 16)
 
@@ -455,7 +455,9 @@ class TestProgram(unittest.TestCase):
         # Should cause serialization to fail.
         with self.assertRaises(ValueError):
             serialize_pte_binary(
-                program, extract_segments=True, segment_alignment=SEGMENT_ALIGNMENT
+                program,
+                extract_delegate_segments=True,
+                segment_alignment=SEGMENT_ALIGNMENT,
             )
 
 

--- a/exir/backend/test/test_backends.py
+++ b/exir/backend/test/test_backends.py
@@ -68,14 +68,14 @@ from torch.testing import FileCheck
 
 
 def vary_segments(test_method):
-    """A decorator that calls the test method with `extract_segments` set to
+    """A decorator that calls the test method with `extract_delegate_segments` set to
     True and False.
 
     Decorated test methods must expect a boolean parameter named
-    `extract_segments`, and they should pass that value to to_executorch() like:
+    `extract_delegate_segments`, and they should pass that value to to_executorch() like:
 
         m.to_executorch(
-            config=exir.ExecutorchBackendConfig(extract_segments=extract_segments)
+            config=exir.ExecutorchBackendConfig(extract_delegate_segments=extract_delegate_segments)
         )
 
     This will cause the delegate data blobs to be extracted from the program and
@@ -84,12 +84,12 @@ def vary_segments(test_method):
     """
 
     def wrapper(self):
-        for extract_segments in [False, True]:
+        for extract_delegate_segments in [False, True]:
             # subTest will create a different top-level test entry for each
             # value, whose full names have a suffix like
-            # "(extract_segments=True)".
-            with self.subTest(extract_segments=extract_segments):
-                test_method(self, extract_segments=extract_segments)
+            # "(extract_delegate_segments=True)".
+            with self.subTest(extract_delegate_segments=extract_delegate_segments):
+                test_method(self, extract_delegate_segments=extract_delegate_segments)
 
     return wrapper
 
@@ -120,7 +120,7 @@ class TestBackends(unittest.TestCase):
         )
 
     @vary_segments
-    def test_backend_with_compiler(self, extract_segments: bool):
+    def test_backend_with_compiler(self, extract_delegate_segments: bool):
         class SinModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -158,7 +158,9 @@ class TestBackends(unittest.TestCase):
             exir.capture(composite_model, model_inputs, exir.CaptureConfig())
             .to_edge()
             .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments)
+                config=exir.ExecutorchBackendConfig(
+                    extract_delegate_segments=extract_delegate_segments
+                )
             )
         )
         graph_module = exec_prog.dump_graph_module()
@@ -218,7 +220,7 @@ class TestBackends(unittest.TestCase):
         )
 
     @vary_segments
-    def test_lowered_add_mul(self, extract_segments: bool):
+    def test_lowered_add_mul(self, extract_delegate_segments: bool):
         class AddMulModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -255,7 +257,9 @@ class TestBackends(unittest.TestCase):
             exir.capture(composite_model, model_inputs, exir.CaptureConfig())
             .to_edge()
             .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments)
+                config=exir.ExecutorchBackendConfig(
+                    extract_delegate_segments=extract_delegate_segments
+                )
             )
         )
         buff = exec_prog.buffer
@@ -271,7 +275,7 @@ class TestBackends(unittest.TestCase):
             torch.allclose(model_output[0], ref_output, atol=1e-03, rtol=1e-03)
         )
 
-    def run_model_in_unsupported_backend(self, extract_segments: bool):
+    def run_model_in_unsupported_backend(self, extract_delegate_segments: bool):
         class SinModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -308,7 +312,9 @@ class TestBackends(unittest.TestCase):
             exir.capture(composite_model, model_inputs, exir.CaptureConfig())
             .to_edge()
             .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
+                config=exir.ExecutorchBackendConfig(
+                    extract_delegate_segments=extract_delegate_segments
+                ),
             )
         )
 
@@ -319,15 +325,19 @@ class TestBackends(unittest.TestCase):
         _load_for_executorch_from_buffer(buff)
 
     @vary_segments
-    def test_backend_with_compiler_out_of_range(self, extract_segments: bool):
+    def test_backend_with_compiler_out_of_range(self, extract_delegate_segments: bool):
         with self.assertRaisesRegex(
             RuntimeError,
             "loading method forward failed with error 0x12",
         ):
-            self.run_model_in_unsupported_backend(extract_segments=extract_segments)
+            self.run_model_in_unsupported_backend(
+                extract_delegate_segments=extract_delegate_segments
+            )
 
     @vary_segments
-    def test_backend_with_compiler_delegate_and_operator(self, extract_segments: bool):
+    def test_backend_with_compiler_delegate_and_operator(
+        self, extract_delegate_segments: bool
+    ):
         # Test includes both delegates and operator
         # import the backend implementation
         from executorch.exir.backend.test.backend_with_compiler_demo import (
@@ -373,7 +383,9 @@ class TestBackends(unittest.TestCase):
             exir.capture(composite_model, model_inputs, exir.CaptureConfig())
             .to_edge()
             .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
+                config=exir.ExecutorchBackendConfig(
+                    extract_delegate_segments=extract_delegate_segments
+                ),
             )
         )
         graph_module = exec_prog.dump_graph_module()
@@ -476,7 +488,7 @@ class TestBackends(unittest.TestCase):
 
     @vary_segments
     def test_backend_with_compiler_delegate_and_operator_with_two_modules(
-        self, extract_segments: bool
+        self, extract_delegate_segments: bool
     ):
         # the submodule runs in a specific backend. In this example, `BackendWithCompilerDemo` backend
         class LowerableSubModel(torch.nn.Module):
@@ -534,7 +546,9 @@ class TestBackends(unittest.TestCase):
             exir.capture(composite_model, model_inputs, exir.CaptureConfig())
             .to_edge()
             .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
+                config=exir.ExecutorchBackendConfig(
+                    extract_delegate_segments=extract_delegate_segments
+                ),
             )
         )
         flatbuffer = exec_prog.buffer
@@ -557,7 +571,7 @@ class TestBackends(unittest.TestCase):
 
     @vary_segments
     def test_partition_delegate_graph_with_multiple_patterns(
-        self, extract_segments: bool
+        self, extract_delegate_segments: bool
     ):
         class CompositeModel(torch.nn.Module):
             def __init__(self, _weight):
@@ -603,7 +617,9 @@ class TestBackends(unittest.TestCase):
                 exir.EdgeCompileConfig(_check_ir_validity=False)
             )
             .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
+                config=exir.ExecutorchBackendConfig(
+                    extract_delegate_segments=extract_delegate_segments
+                ),
             )
         )
         # after this step, part of the graph will be lowered to backend, depending on
@@ -613,7 +629,9 @@ class TestBackends(unittest.TestCase):
             traced.exported_program, HTAPartitionerMultiplePatternsDemo()
         )
         program_with_delegates = program_with_delegates.to_executorch(
-            config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
+            config=exir.ExecutorchBackendConfig(
+                extract_delegate_segments=extract_delegate_segments
+            ),
         )
 
         new_res = program_with_delegates.dump_graph_module()(*inputs)
@@ -667,7 +685,9 @@ class TestBackends(unittest.TestCase):
         )
 
     @vary_segments
-    def test_partition_delegate_graph_with_one_patterns(self, extract_segments: bool):
+    def test_partition_delegate_graph_with_one_patterns(
+        self, extract_delegate_segments: bool
+    ):
         class CompositeModel(torch.nn.Module):
             def __init__(self, _weight):
                 super().__init__()
@@ -716,7 +736,9 @@ class TestBackends(unittest.TestCase):
                 exir.EdgeCompileConfig(_check_ir_validity=False)
             )
             .to_executorch(
-                config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
+                config=exir.ExecutorchBackendConfig(
+                    extract_delegate_segments=extract_delegate_segments
+                ),
             )
         )
         # after this step, part of the graph will be lowered to backend, depending on
@@ -731,7 +753,9 @@ class TestBackends(unittest.TestCase):
             self.assertTrue(torch.allclose(t1, t2, atol=1e-03, rtol=1e-03))
 
         program_with_delegates = traced_with_delegate.to_executorch(
-            config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
+            config=exir.ExecutorchBackendConfig(
+                extract_delegate_segments=extract_delegate_segments
+            ),
         )
 
         # TODO(T143084047): Currently not retraceable
@@ -744,7 +768,7 @@ class TestBackends(unittest.TestCase):
         # ).to_edge()
 
         # program_with_delegates = graph_module_with_delegate.to_executorch(
-        #     config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
+        #     config=exir.ExecutorchBackendConfig(extract_delegate_segments=extract_delegate_segments),
         # )
 
         new_res = program_with_delegates.dump_graph_module()(*inputs)
@@ -798,7 +822,7 @@ class TestBackends(unittest.TestCase):
         )
 
     @vary_segments
-    def test_add_mul_partitioner(self, extract_segments: bool):
+    def test_add_mul_partitioner(self, extract_delegate_segments: bool):
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -831,7 +855,9 @@ class TestBackends(unittest.TestCase):
                     self.assertTrue(user.meta.get("nn_module_stack", None) is None)
 
         executorch_prog = executorch_prog.to_executorch(
-            config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
+            config=exir.ExecutorchBackendConfig(
+                extract_delegate_segments=extract_delegate_segments
+            ),
         )
 
         new_res = executorch_prog.dump_graph_module()(*inputs)
@@ -856,7 +882,7 @@ class TestBackends(unittest.TestCase):
         )
 
     @vary_segments
-    def test_partitioner_with_attributes(self, extract_segments: bool):
+    def test_partitioner_with_attributes(self, extract_delegate_segments: bool):
         """
         Check that if we tag the getattr nodes, the attributes will be added to
         the lowered submodule rather than being passed into the delegate as
@@ -898,7 +924,9 @@ class TestBackends(unittest.TestCase):
                     self.assertTrue(user.meta.get("nn_module_stack", None) is None)
 
         executorch_prog = executorch_prog.to_executorch(
-            config=exir.ExecutorchBackendConfig(extract_segments=extract_segments),
+            config=exir.ExecutorchBackendConfig(
+                extract_delegate_segments=extract_delegate_segments
+            ),
         )
 
         # Check the delegated submodules

--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -47,10 +47,10 @@ class ExecutorchBackendConfig:
     )
     emit_stacktrace: bool = False
 
-    # Whether to move certain data blobs from the Program into separate
+    # Whether to move delegate data blobs from the Program into separate
     # segments, rather than encoding those blobs in the flatbuffer data.
     # This makes it possible to free those blobs at runtime.
-    extract_segments: bool = False
+    extract_delegate_segments: bool = False
 
     # When extracting segments, the starting offset of each segment will be
     # aligned to this value (in bytes). When using mmap() to load segments, this

--- a/exir/lowered_backend_module.py
+++ b/exir/lowered_backend_module.py
@@ -102,7 +102,7 @@ class LoweredBackendModule(torch.nn.Module):
     # TODO(chenlai): consolidate the seriailization config with serialize_to_flatbuffer api
     def buffer(
         self,
-        extract_segments: bool = False,
+        extract_delegate_segments: bool = False,
         segment_alignment: int = 4096,
         constant_tensor_alignment: Optional[int] = None,
         delegate_alignment: Optional[int] = None,
@@ -112,7 +112,7 @@ class LoweredBackendModule(torch.nn.Module):
         """
         out = _serialize_pte_binary(
             program=self.program(),
-            extract_segments=extract_segments,
+            extract_delegate_segments=extract_delegate_segments,
             segment_alignment=segment_alignment,
             constant_tensor_alignment=constant_tensor_alignment,
             delegate_alignment=delegate_alignment,

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -270,7 +270,7 @@ class ExirExportedProgram:
         executorch_prog = ExecutorchProgram(
             new_prog,
             emit_stacktrace=config.emit_stacktrace,
-            extract_segments=config.extract_segments,
+            extract_delegate_segments=config.extract_delegate_segments,
             segment_alignment=config.segment_alignment,
             constant_tensor_alignment=config.constant_tensor_alignment,
             delegate_alignment=config.delegate_alignment,
@@ -298,7 +298,7 @@ class ExecutorchProgram:
         self,
         exir_exported_program: ExirExportedProgram,
         emit_stacktrace: bool,
-        extract_segments: bool,
+        extract_delegate_segments: bool,
         segment_alignment: int,
         constant_tensor_alignment: Optional[int] = None,
         delegate_alignment: Optional[int] = None,
@@ -311,7 +311,7 @@ class ExecutorchProgram:
         self._buffer: Optional[bytes] = None
         self._emitter_output: Optional[EmitterOutput] = None
         self._emit_stacktrace: bool = emit_stacktrace
-        self._extract_segments: bool = extract_segments
+        self._extract_delegate_segments: bool = extract_delegate_segments
         self._segment_alignment: int = segment_alignment
         self._constant_tensor_alignment: Optional[int] = constant_tensor_alignment
         self._delegate_alignment: Optional[int] = delegate_alignment
@@ -321,7 +321,7 @@ class ExecutorchProgram:
         if self._buffer is None:
             self._buffer = _serialize_pte_binary(
                 program=self.program,
-                extract_segments=self._extract_segments,
+                extract_delegate_segments=self._extract_delegate_segments,
                 segment_alignment=self._segment_alignment,
                 constant_tensor_alignment=self._constant_tensor_alignment,
                 delegate_alignment=self._delegate_alignment,
@@ -593,7 +593,7 @@ class MultiMethodExecutorchProgram:
         self,
         executorch_dialect_program: "MultiMethodExirExportedProgram",
         emit_stacktrace: bool,
-        extract_segments: bool,
+        extract_delegate_segments: bool,
         segment_alignment: int,
         constant_tensor_alignment: Optional[int] = None,
         delegate_alignment: Optional[int] = None,
@@ -609,7 +609,7 @@ class MultiMethodExecutorchProgram:
             executorch_dialect_program.prim_getters(),
         )
         self._executorch_dialect_ir_program = executorch_dialect_program
-        self._extract_segments: bool = extract_segments
+        self._extract_delegate_segments: bool = extract_delegate_segments
         self._segment_alignment: int = segment_alignment
         self._constant_tensor_alignment: Optional[int] = constant_tensor_alignment
         self._delegate_alignment: Optional[int] = delegate_alignment
@@ -620,7 +620,7 @@ class MultiMethodExecutorchProgram:
         if self._buffer is None:
             self._buffer = _serialize_pte_binary(
                 program=self._emitter_output.program,
-                extract_segments=self._extract_segments,
+                extract_delegate_segments=self._extract_delegate_segments,
                 segment_alignment=self._segment_alignment,
                 constant_tensor_alignment=self._constant_tensor_alignment,
                 delegate_alignment=self._delegate_alignment,
@@ -671,7 +671,7 @@ def multi_method_program_to_executorch(
     return MultiMethodExecutorchProgram(
         executorch_dialect_program=MultiMethodExirExportedProgram(res),
         emit_stacktrace=config.emit_stacktrace,
-        extract_segments=config.extract_segments,
+        extract_delegate_segments=config.extract_delegate_segments,
         segment_alignment=config.segment_alignment,
         constant_tensor_alignment=config.constant_tensor_alignment,
         delegate_alignment=config.delegate_alignment,
@@ -998,7 +998,7 @@ class ExecutorchProgramManager:
         # Serialize emitter output to a buffer
         self._buffer: bytes = _serialize_pte_binary(
             program=self._emitter_output.program,
-            extract_segments=backend_config.extract_segments,
+            extract_delegate_segments=backend_config.extract_delegate_segments,
             segment_alignment=backend_config.segment_alignment,
             constant_tensor_alignment=backend_config.constant_tensor_alignment,
             delegate_alignment=backend_config.delegate_alignment,

--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -244,7 +244,7 @@ class TestProgramManagers(unittest.TestCase):
         self.assertEqual(
             len(
                 delegate_manager.to_executorch(
-                    ExecutorchBackendConfig(extract_segments=True)
+                    ExecutorchBackendConfig(extract_delegate_segments=True)
                 )
                 ._emitter_output.program.execution_plan[0]
                 .delegates
@@ -254,7 +254,7 @@ class TestProgramManagers(unittest.TestCase):
         self.assertEqual(
             len(
                 delegate_manager.to_executorch(
-                    ExecutorchBackendConfig(extract_segments=True)
+                    ExecutorchBackendConfig(extract_delegate_segments=True)
                 )
                 ._emitter_output.program.execution_plan[1]
                 .delegates

--- a/test/models/export_delegated_program.py
+++ b/test/models/export_delegated_program.py
@@ -73,7 +73,7 @@ def export_module_to_program(
     module_class: Type[nn.Module],
     *,
     backend_id: str,
-    extract_segments: bool,
+    extract_delegate_segments: bool,
     constant_tensor_alignemnt: Optional[int] = None,
     delegate_alignment: Optional[int] = None,
     method: str = "forward",
@@ -112,7 +112,7 @@ def export_module_to_program(
         .to_edge()
         .to_executorch(
             config=exir.ExecutorchBackendConfig(
-                extract_segments=extract_segments,
+                extract_delegate_segments=extract_delegate_segments,
                 constant_tensor_alignment=constant_tensor_alignemnt,
                 delegate_alignment=delegate_alignment,
             )
@@ -169,8 +169,8 @@ def main() -> None:
     # Export and write to the output files.
     os.makedirs(args.outdir, exist_ok=True)
     for module_name, module_class in module_names_to_classes.items():
-        for extract_segments in (True, False):
-            suffix = "" if extract_segments else "-nosegments"
+        for extract_delegate_segments in (True, False):
+            suffix = "" if extract_delegate_segments else "-nosegments"
             # Create files with the default alignment, and a large alignment.
             # This alignment should be so large that it's extremely unlikely for
             # the data to accidentally be aligned to it in the default case.
@@ -182,7 +182,7 @@ def main() -> None:
                         export_module_to_program(
                             module_class,
                             backend_id=args.backend_id,
-                            extract_segments=extract_segments,
+                            extract_delegate_segments=extract_delegate_segments,
                             delegate_alignment=delegate_alignment,
                         )
                     )


### PR DESCRIPTION
Summary: In D51596390 we introduce `extract_constant_segment`. This refactor updates `extract_segments` to specifically `extract_delegate_segments` now that we have different segments being extracted.

Differential Revision: D51725073


