### PR TITLE
block temp allocator == method allocator

### DIFF
--- a/runtime/executor/memory_manager.h
+++ b/runtime/executor/memory_manager.h
@@ -55,7 +55,11 @@ class MemoryManager final {
       MemoryAllocator* temp_allocator = nullptr)
       : method_allocator_(method_allocator),
         planned_memory_(planned_memory),
-        temp_allocator_(temp_allocator) {}
+        temp_allocator_(temp_allocator) {
+    ET_CHECK_MSG(
+        method_allocator != temp_allocator,
+        "method allocator cannot be the same as temp allocator");
+  }
 
   /**
    * DEPRECATED: Use the constructor without `constant_allocator` instead.

--- a/runtime/executor/test/memory_manager_test.cpp
+++ b/runtime/executor/test/memory_manager_test.cpp
@@ -10,6 +10,7 @@
 
 #include <executorch/runtime/core/memory_allocator.h>
 
+#include <executorch/test/utils/DeathTest.h>
 #include <gtest/gtest.h>
 
 using namespace ::testing;
@@ -65,6 +66,31 @@ TEST(MemoryManagerTest, DEPRECATEDCtor) {
   EXPECT_EQ(mm.method_allocator(), &method_allocator);
   EXPECT_EQ(mm.planned_memory(), &planned_memory);
   EXPECT_EQ(mm.temp_allocator(), &temp_allocator);
+}
+
+TEST(MemoryManagerTest, DeprecatedCtorWithSameAllocator) {
+  MemoryAllocator method_allocator(0, nullptr);
+  HierarchicalAllocator planned_memory({});
+  MemoryAllocator const_allocator(0, nullptr);
+  ET_EXPECT_DEATH(
+      MemoryManager(
+          /*constant_allocator=*/&const_allocator,
+          /*non_constant_allocator=*/&planned_memory,
+          /*runtime_allocator=*/&method_allocator,
+          /*kernel_temporary_allocator=*/&method_allocator),
+      "");
+}
+
+TEST(MemoryManagerTest, CtorWithSameAllocator) {
+  MemoryAllocator method_allocator(0, nullptr);
+  HierarchicalAllocator planned_memory({});
+  MemoryAllocator const_allocator(0, nullptr);
+  ET_EXPECT_DEATH(
+      MemoryManager(
+          /*runtime_allocator=*/&method_allocator,
+          /*non_constant_allocator=*/&planned_memory,
+          /*temp_allocator=*/&method_allocator),
+      "");
 }
 
 } // namespace executor


### PR DESCRIPTION
Summary: As title, context is that we find out quite a few clients' code reusing runtime allocator for temp allocator in D51234032

Reviewed By: dbort

Differential Revision: D51732836


