### PR TITLE
Move constants to constant_segment

### DIFF
--- a/exir/_serialize/_program.py
+++ b/exir/_serialize/_program.py
@@ -23,9 +23,11 @@ from executorch.exir._serialize._flatbuffer import (
 from executorch.exir.schema import (
     BackendDelegateDataReference,
     BackendDelegateInlineData,
+    Buffer,
     DataLocation,
     DataSegment,
     Program,
+    SubsegmentOffsets,
 )
 
 
@@ -238,32 +240,16 @@ def _get_extended_header(program_data: bytes) -> Optional[_ExtendedHeader]:
 
 
 def _extract_delegate_segments(
-    program: Program, segment_alignment: int
-) -> Tuple[Program, List[bytes]]:
-    """Moves data from the Program into a list of segments.
-
-    The returned program is a copy of `program`. Program.segments parallels the
-    returned list of buffers.
+    program: Program, segments: List[bytes], segment_alignment: int
+) -> None:
+    """The input program and segments list are modified in place.
 
     Args:
-        program: The program to extract segments from.
+        program: The program to extract segments from. Modified in-place.
+        segments: A list to which extracted segments will be appended. Modified in-place.
         segment_alignment: Alignment in bytes. The starting offset of each
             segment will be aligned to this value.
-    Returns:
-        A tuple of (modified program, list of segment data).
     """
-    if program.segments:
-        raise ValueError(
-            f"Program already has {len(program.segments)} segments: "
-            + f"{repr(program.segments)}"
-        )
-
-    # Don't modify the original program.
-    # TODO(T144120904): Could avoid yet more huge copies with a more shallow
-    # copy, reusing the actual data blobs.
-    program = copy.deepcopy(program)
-
-    segments: List[bytes] = []
     remaining_inline: List[BackendDelegateInlineData] = []
     inline_indices_seen: set[int] = set()
     for plan in program.execution_plan:
@@ -331,7 +317,39 @@ def _extract_delegate_segments(
     # Preserve any entries that were not moved into segments.
     program.backend_delegate_data = remaining_inline
 
-    return (program, segments)
+
+def _extract_constant_segment(
+    constant_buffer: List[Buffer],
+    tensor_alignment: int,
+) -> Tuple[bytes, List[int]]:
+    """Copies the tensors from the provided list into a single buffer and tracks the offsets
+    of each tensor.
+
+        constant_buffer: list of Buffers from which to extract constants from. Not modified.
+        tensor_alignment: Alignment in bytes. The starting offset of each tensor in the
+            constant segment will be aligned to this value. Default to 16.
+
+    Returns:
+        A tuple of (constant segment, list of offsets for each tensor in the segment)
+    """
+    constant_segment_data: bytearray = bytearray()
+    constant_segment_offsets: List[int] = []
+    current_offset: int = 0
+    for i in range(len(constant_buffer)):
+        buffer = constant_buffer[i]
+        buffer_length = len(buffer.storage)
+        pad_length = _padding_required(buffer_length, tensor_alignment)
+
+        # Append each constant buffer to the constant segment.
+        constant_segment_data += buffer.storage
+        # Add padding for all but the last tensor.
+        if i < len(constant_buffer) - 1:
+            constant_segment_data += b"\x00" * pad_length
+
+        # Append constant data offset.
+        constant_segment_offsets.append(current_offset)
+        current_offset += buffer_length + pad_length
+    return bytes(constant_segment_data), constant_segment_offsets
 
 
 def _append_segments(
@@ -421,6 +439,7 @@ def serialize_pte_binary(
     program: Program,
     *,
     extract_delegate_segments: bool = False,
+    extract_constant_segment: bool = False,
     segment_alignment: int = 4096,
     constant_tensor_alignment: Optional[int] = None,
     delegate_alignment: Optional[int] = None,
@@ -436,6 +455,8 @@ def serialize_pte_binary(
               and the starting segment offset.
             - Update the Program.segments field with the offsets and lengths
               of each segment.
+        extract_constant_segment: Whether to move the constant data from the Program
+            into a separate segment.
         segment_alignment: Alignment in bytes. The starting offset of each
             segment will be aligned to this value in the output data.
         constant_tensor_alignment: If provided, the minimum alignment of tensor
@@ -447,13 +468,51 @@ def serialize_pte_binary(
     Returns:
         The serialized form of the Program, ready for execution by the runtime.
     """
+    # Default tensor alignment.
+    if constant_tensor_alignment is None:
+        constant_tensor_alignment = 16
+
     # Segment data to be written to the file following the flatbuffer data.
     segments: List[bytes] = []
-    if extract_delegate_segments:
-        # May return a copy of the program to avoid modifying the input.
-        program, segments = _extract_delegate_segments(
-            program=program, segment_alignment=segment_alignment
-        )
+    extract_segments = extract_constant_segment or extract_delegate_segments
+    if extract_segments:
+        if program.segments:
+            raise ValueError(
+                f"Program already has {len(program.segments)} segments: "
+                + f"{repr(program.segments)}"
+            )
+
+        # Don't modify the original program.
+        # TODO(T144120904): Could avoid yet more huge copies with a more shallow
+        # copy, reusing the actual data blobs.
+        program = copy.deepcopy(program)
+
+        if extract_constant_segment:
+            constant_segment_data, constant_segment_offsets = _extract_constant_segment(
+                program.constant_buffer, tensor_alignment=constant_tensor_alignment
+            )
+
+            if constant_segment_data:
+                # Append constant_segment to the list of segments if non-empty.
+                segments.append(constant_segment_data)
+                # Append constant_segment offset to the list of DataSegments. Added as the
+                # first segment here, but it's not mandatory that the constant segment be
+                # the first one in the file.
+                program.segments.append(
+                    DataSegment(offset=0, size=len(constant_segment_data))
+                )
+
+                # Fill in constant_segment offsets and clear the constant buffer; only one of
+                # constant_segment and constant_buffer should be non-empty.
+                program.constant_segment = SubsegmentOffsets(
+                    segment_index=0, offsets=constant_segment_offsets
+                )
+                program.constant_buffer = []
+
+        if extract_delegate_segments:
+            _extract_delegate_segments(
+                program, segments=segments, segment_alignment=segment_alignment
+            )
 
     # Convert to a standard flatbuffer binary.
     result: _FlatbufferResult = _program_json_to_flatbuffer(
@@ -461,7 +520,8 @@ def serialize_pte_binary(
         constant_tensor_alignment=constant_tensor_alignment,
         delegate_alignment=delegate_alignment,
     )
-    if not extract_delegate_segments:
+
+    if not extract_segments:
         return result.data
 
     # Size of the header to insert. Its size is padded to the largest

--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -52,6 +52,12 @@ class ExecutorchBackendConfig:
     # This makes it possible to free those blobs at runtime.
     extract_delegate_segments: bool = False
 
+    # Whether to extract constants from the Program into separate segments,
+    # rather than encoding those constants in the flatbuffer data.
+    # This reduces the memory overhead of creating the .pte file for models with
+    # large constant data.
+    extract_constant_segment: bool = False
+
     # When extracting segments, the starting offset of each segment will be
     # aligned to this value (in bytes). When using mmap() to load segments, this
     # should be a multiple of the OS page size.


### PR DESCRIPTION
Summary:
* Add `extract_constant_segment` field, defaults to `False`, add `_extract_constant_segment(..)` to move constants to segment
* Segments are extracted twice (delegates, constants), so we create a copy of the program inside `serialize_pte_binary` to use for modification.

Potential future refactor: rename extract_segments -> extract_delegate_segments

Reviewed By: dbort

Differential Revision: D51596390

