### PR TITLE
etrecord error message to use f-string

### DIFF
--- a/sdk/etrecord/_etrecord.py
+++ b/sdk/etrecord/_etrecord.py
@@ -308,7 +308,7 @@ def parse_etrecord(etrecord_path: str) -> ETRecord:
         serialized_state_dict_file = f"{serialized_file}_state_dict"
         assert (
             serialized_state_dict_file in serialized_state_dict_files
-        ), "Could not find corresponding state dict file for {serialized_file}."
+        ), f"Could not find corresponding state dict file for {serialized_file}."
         graph_map[serialized_file] = deserialize(
             etrecord_zip.read(serialized_file),
             etrecord_zip.read(serialized_state_dict_file),


### PR DESCRIPTION
Summary: Pretty sure the intention was to get the value of `serialized_file` so should use f-string

Differential Revision: D51819282


