### PR TITLE
Parsing reference outputs from etrecord and save in inspector and event block

### DIFF
--- a/sdk/inspector/_inspector_utils.py
+++ b/sdk/inspector/_inspector_utils.py
@@ -65,6 +65,7 @@ TIME_SCALE_DICT = {
 
 # Model Debug Output
 InferenceOutput: TypeAlias = Union[torch.Tensor, int, float, str, bool, None]
+ProgramOutput: TypeAlias = List[InferenceOutput]
 
 
 def inflate_runtime_output(
@@ -150,7 +151,7 @@ def find_populated_event(event: flatcc.Event) -> Union[ProfileEvent, DebugEvent]
 
 # TODO: Optimize by verifying prior to inflating the tensors
 def verify_debug_data_equivalence(
-    existing_data: List[InferenceOutput], new_data: List[InferenceOutput]
+    existing_data: ProgramOutput, new_data: ProgramOutput
 ) -> None:
     """
     Verify that the lists of inference_outputs are equivalent


### PR DESCRIPTION
Summary:
The inspector instance would hold all reference outputs in a dict, keyed by method name. We assume there's only the "forward" key for now. Each event block instance would just hold the one output that's indexed by `event_block.bundled_input_index`.

Also did a small refactoring because I introduced a new type alias ProgramOutput.

Differential Revision: D51290998


