### PR TITLE
Add support to BoltNN executorch app for ETDump

### DIFF
--- a/sdk/etdump/targets.bzl
+++ b/sdk/etdump/targets.bzl
@@ -35,7 +35,7 @@ def generate_schema_header_flatcc(rule_name, srcs, headers, default_headers):
             "-o ${OUT}",
             "${SRCS}",
             # Let our infra know that the file was generated.
-            " ".join(["&& echo '// @''generated' >> ${OUT}/" + header for header in headers]),
+            " ".join(["&& echo // @" + "generated >> ${OUT}/" + header for header in headers]),
         ]),
     )
 


### PR DESCRIPTION
Summary:
Getting rid of the old etdump library which is deprecated now and moving the BoltNN example app to use the new etdump library (which is flatcc based). This also adds a bunch of configs to enable the generation of etdump along with the debug buffer containing intermediate outputs/model outputs.

In order for any of the etdump related stuff to work the high level control is:
`--generate_etdump 1 --etdump_path  <path_to_where_etdump_should_be_placed>`

This will only ensure though that profiling data is collected in etdump. In order to enable intermediate outputs collections these additional configs will need to be passed in:
`--dump_intermediate_outputs 1 --debug_buffer_path <path_to_where_the_debug_buffer_should_be_placed>`

If the user is only interested in collecting the model level outputs and not the intermediate outputs then the flags should be:
`--dump_outputs 1 --debug_buffer_path <path_to_where_the_debug_buffer_should_be_placed>`

After generating those files, to look at the data the command to run is:
`buck2 run fbcode//executorch/sdk/inspector:inspector_cli -- --etdump_path etdump.etdp --etrecord_path <optional_etrecord> --buffer_path <optional_debug_buffer>`

Differential Revision: D51611697


