### PR TITLE
Enable sleef, BLAS for executor_runner_optimized

### DIFF
--- a/kernels/optimized/blas/CPUBlas.cpp
+++ b/kernels/optimized/blas/CPUBlas.cpp
@@ -8,15 +8,37 @@
 
 #include <executorch/kernels/optimized/blas/CPUBlas.h>
 
+#include <limits.h>
+
 #ifdef ET_BUILD_WITH_BLAS
+#ifdef ET_BUILD_FOR_APPLE
+#include <Accelerate/Accelerate.h>
+#else
 // clang-format off
 extern "C" void dgemm_(char *transa, char *transb, int *m, int *n, int *k, double *alpha, const double *a, int *lda, const double *b, int *ldb, double *beta, double *c, int *ldc);
 extern "C" void sgemm_(char *transa, char *transb, int *m, int *n, int *k, float *alpha, const float *a, int *lda, const float *b, int *ldb, float *beta, float *c, int *ldc);
 // clang-format on
-#endif
+#endif // ET_BUILD_FOR_APPLE
+#endif // ET_BUILD_WITH_BLAS
 
 namespace executorch {
 namespace cpublas {
+#ifdef ET_BUILD_WITH_BLAS
+#ifdef ET_BUILD_FOR_APPLE
+inline CBLAS_TRANSPOSE to_cblas_transpose(TransposeType trans) {
+  switch (trans) {
+    case TransposeType::Transpose:
+      return CblasTrans;
+    case TransposeType::NoTranspose:
+      return CblasNoTrans;
+    case TransposeType::ConjTranspose:
+      return CblasConjTrans;
+  }
+  // Assume no transpose by default
+  return CblasNoTrans;
+}
+#endif // ET_BUILD_FOR_APPLE
+#endif // ET_BUILD_WITH_BLAS
 
 // clang-format off
 void normalize_last_dims(
@@ -56,6 +78,9 @@ void gemm(
     double *c, int64_t ldc) {
   normalize_last_dims(transa, transb, m, n, k, &lda, &ldb, &ldc);
 #ifdef ET_BUILD_WITH_BLAS
+#ifdef ET_BUILD_FOR_APPLE
+  cblas_dgemm(CblasColMajor, to_cblas_transpose(transa), to_cblas_transpose(transb), m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+#else
   int m_ = m, n_ = n, k_ = k, lda_ = lda, ldb_ = ldb, ldc_ = ldc;
   double alpha_ = alpha, beta_ = beta;
   char transa_ = to_blas(transa), transb_ = to_blas(transb);
@@ -67,6 +92,7 @@ void gemm(
       b, &ldb_,
       &beta_,
       c, &ldc_);
+#endif // ET_BUILD_FOR_APPLE
 #else
   using acc_type = utils::compute_dtype<float>;
   gemm_impl(
@@ -92,6 +118,9 @@ void gemm(
     float *c, int64_t ldc) {
   normalize_last_dims(transa, transb, m, n, k, &lda, &ldb, &ldc);
 #ifdef ET_BUILD_WITH_BLAS
+#ifdef ET_BUILD_FOR_APPLE
+  cblas_sgemm(CblasColMajor, to_cblas_transpose(transa), to_cblas_transpose(transb), m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+#else
   int m_ = m, n_ = n, k_ = k, lda_ = lda, ldb_ = ldb, ldc_ = ldc;
   float alpha_ = alpha, beta_ = beta;
   char transa_ = to_blas(transa), transb_ = to_blas(transb);
@@ -103,6 +132,8 @@ void gemm(
       b, &ldb_,
       &beta_,
       c, &ldc_);
+#endif // ET_BUILD_FOR_APPLE
+
 #else
   using acc_type = utils::compute_dtype<float>;
   gemm_impl(

--- a/kernels/optimized/cpu/op_log_softmax.cpp
+++ b/kernels/optimized/cpu/op_log_softmax.cpp
@@ -93,9 +93,9 @@ void log_softmax_kernel(const Tensor& input, int64_t dim, Tensor& out) {
 
       temp_sum = std::log(temp_sum);
 
-      for (auto d = 0; d < dim_size; ++d) {
-        output_data[d * dim_stride] =
-            input_data[d * dim_stride] - max_input - temp_sum;
+      for (auto dd = 0; dd < dim_size; ++dd) {
+        output_data[dd * dim_stride] =
+            input_data[dd * dim_stride] - max_input - temp_sum;
       }
     }
   }

--- a/kernels/optimized/cpu/targets.bzl
+++ b/kernels/optimized/cpu/targets.bzl
@@ -27,7 +27,7 @@ _OPTIMIZED_ATEN_OPS = (
         name = "op_gelu",
         deps = select({
             "DEFAULT": [],
-            "ovr_config//runtime:fbcode-arm64": [
+            "ovr_config//cpu:arm64": [
                 "fbsource//third-party/sleef:sleef_arm",
             ],
         }),
@@ -44,7 +44,7 @@ _OPTIMIZED_ATEN_OPS = (
             "DEFAULT": [
                 "//executorch/kernels/portable/cpu/util:activation_ops_util",
             ],
-            "ovr_config//runtime:fbcode-arm64": [
+            "ovr_config//cpu:arm64": [
                 "//executorch/kernels/portable/cpu/util:activation_ops_util",
                 "fbsource//third-party/sleef:sleef_arm",
             ],

--- a/kernels/optimized/lib_defs.bzl
+++ b/kernels/optimized/lib_defs.bzl
@@ -112,7 +112,6 @@ def define_libs():
             "//executorch/...",
             "@EXECUTORCH_CLIENTS",
         ],
-        # TODO(ssjia): Link with Accelerate for Apple builds
         fbandroid_platform_preprocessor_flags = [
             (
                 "^android-arm64.*$",
@@ -128,6 +127,13 @@ def define_libs():
                     "fbsource//third-party/openblas:openblas",
                 ],
             ),
+        ],
+        fbobjc_exported_preprocessor_flags = [
+            "-DET_BUILD_WITH_BLAS",
+            "-DET_BUILD_FOR_APPLE",
+        ],
+        fbobjc_frameworks = [
+            "Accelerate",
         ],
         exported_deps = [
             "//executorch/kernels/optimized:libutils",


### PR DESCRIPTION
Summary:
This library will prefer optimized kernel, and use portable kernel as a fallback kernel.

For ios, we can also use sleef and blas library, with minor modifications.

Then we can deploy the runner library with executor_runner_optimized for ios. This improves ViT performance.

Reviewed By: kimishpatel

Differential Revision: D51748530


