### PR TITLE
Fix lint in test code

### DIFF
--- a/backends/xnnpack/test/test_xnnpack.py
+++ b/backends/xnnpack/test/test_xnnpack.py
@@ -7,10 +7,7 @@
 import unittest
 
 import torch
-from executorch.backends.xnnpack.test.test_xnnpack_utils import (
-    randomize_bn,
-    TestXNNPACK,
-)
+from executorch.backends.xnnpack.test.test_xnnpack_utils import TestXNNPACK
 
 from executorch.backends.xnnpack.test.test_xnnpack_utils_classes import (
     OpSequencesAddConv2d,


### PR DESCRIPTION
Summary: Lint issue is causing CI job to fail. This fixes the lint.

Reviewed By: digantdesai, kirklandsign

Differential Revision: D51861334


