### PR TITLE
Remove explicit supports_static_listing key

### DIFF
--- a/extension/pytree/test/TARGETS
+++ b/extension/pytree/test/TARGETS
@@ -7,14 +7,12 @@ oncall("executorch")
 cpp_unittest(
     name = "cpptest",
     srcs = ["test_pytree.cpp"],
-    supports_static_listing = True,
     deps = ["//executorch/extension/pytree:pytree"],
 )
 
 cpp_unittest(
     name = "function_ref_test",
     srcs = ["function_ref_test.cpp"],
-    supports_static_listing = True,
     deps = ["//executorch/extension/pytree:pytree"],
 )
 

--- a/kernels/prim_ops/test/TARGETS
+++ b/kernels/prim_ops/test/TARGETS
@@ -22,7 +22,6 @@ cpp_unittest(
     srcs = [
         "prim_ops_test.cpp",
     ],
-    supports_static_listing = True,
     deps = [
         "//executorch/kernels/prim_ops:prim_ops_registry",  # @manual
         "//executorch/runtime/core:evalue",  # @manual


### PR DESCRIPTION
Summary: supports_static_listing is True by default after we rolled out it to everywhere. Removing explicit True value from cpp unittests

Reviewed By: jbardini

Differential Revision: D51848076


