### PR TITLE
Mass update arvr/third-party/pybind11 to point to third-party/pybind11

### DIFF
--- a/exir/_serialize/TARGETS
+++ b/exir/_serialize/TARGETS
@@ -18,7 +18,7 @@ cpp_python_extension(
         "//executorch/sdk/etdump/...",
     ],
     deps = [
-        "fbsource//arvr/third-party/pybind11:pybind11",
+        "fbsource//third-party/pybind11/2.6.2:pybind11",
         "fbsource//third-party/flatbuffers:flatc_library",
     ],
 )

--- a/exir/_serialize/bindings.cpp
+++ b/exir/_serialize/bindings.cpp
@@ -8,8 +8,8 @@
 
 #include <flatbuffers/flatc.h> // @manual=fbsource//third-party/flatbuffers:flatc_library
 #include <flatbuffers/idl.h> // @manual=fbsource//third-party/flatbuffers:flatc_library
-#include <pybind11/pybind11.h> // @manual=fbsource//arvr/third-party/pybind11:pybind11
-#include <pybind11/stl.h> // @manual=fbsource//arvr/third-party/pybind11:pybind11
+#include <pybind11/pybind11.h> // @manual=fbsource//third-party/pybind11/2.6.2:pybind11
+#include <pybind11/stl.h> // @manual=fbsource//third-party/pybind11/2.6.2:pybind11
 
 namespace exir {
 namespace {


### PR DESCRIPTION
Summary: Moving away from arvr/third-party/pybind11 to it's new location in fbsource/third-party

Reviewed By: macat, itamaro

Differential Revision: D51566630


