### PR TITLE
executor_runner on iOS fixes

### DIFF
--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -27,6 +27,8 @@
 #define ET_ENABLE_PROGRAM_VERIFICATION 1
 #endif
 
+#pragma clang diagnostic ignored "-Wshadow"
+
 namespace torch {
 namespace executor {
 


### PR DESCRIPTION
Summary:
A few fixes to the iOS benchmark
1. Ignore `-wShadow` since this was failing due to EXECUTORCH_SCOPE_PROF in the profiler/event tracer
2. Platform-specific headers in iOS build. Defining `IOS_BENCHMARK` in the `PyTorchBenchmark` build rule does not propagate to dependencies, so the `executor_runner_lib` was building without this definition
3. Remove deprecated `generate_etdump` flag from controlling program flow
4. Add build options to `PyTorchBenchmark` build config

Reviewed By: kirklandsign

Differential Revision: D51825112


