### PR TITLE
Offset calculation fix for etdump

### DIFF
--- a/sdk/etdump/etdump_flatcc.cpp
+++ b/sdk/etdump/etdump_flatcc.cpp
@@ -320,12 +320,11 @@ size_t ETDumpGen::copy_tensor_to_debug_buffer(exec_aten::Tensor tensor) {
   }
   uint8_t* offset_ptr =
       alignPointer(debug_buffer.data() + debug_buffer_offset, 64);
+  debug_buffer_offset = (offset_ptr - debug_buffer.data()) + tensor.nbytes();
   ET_CHECK_MSG(
-      (((size_t)(offset_ptr - debug_buffer.data()) + tensor.nbytes()) <=
-       debug_buffer.size()),
+      debug_buffer_offset <= debug_buffer.size(),
       "Ran out of space to store intermediate outputs.");
   memcpy(offset_ptr, tensor.const_data_ptr(), tensor.nbytes());
-  debug_buffer_offset += tensor.nbytes();
   return (size_t)(offset_ptr - debug_buffer.data());
 }
 

--- a/sdk/inspector/_inspector.py
+++ b/sdk/inspector/_inspector.py
@@ -773,7 +773,7 @@ class Inspector:
         etrecord: Optional[Union[ETRecord, str]] = None,
         source_time_scale: TimeScale = TimeScale.NS,
         target_time_scale: TimeScale = TimeScale.MS,
-        buffer_path: Optional[str] = None,
+        debug_buffer_path: Optional[str] = None,
     ) -> None:
         r"""
         Initialize an `Inspector` instance with the underlying `EventBlock`\ s populated with data from the provided ETDump path
@@ -784,7 +784,7 @@ class Inspector:
             etrecord: Optional ETRecord object or path to the ETRecord file.
             source_time_scale: The time scale of the performance data retrieved from the runtime. The default time hook implentation in the runtime returns NS.
             target_time_scale: The target time scale to which the users want their performance data converted to. Defaults to MS.
-            buffer_path: Buffer file path referenced by ETDump
+            debug_buffer_path: Debug buffer file path that contains the debug data referenced by ETDump for intermediate and program outputs.
 
         Returns:
             None
@@ -810,8 +810,8 @@ class Inspector:
 
         # Create EventBlocks from ETDump
         etdump = gen_etdump_object(etdump_path=etdump_path)
-        if buffer_path is not None:
-            with open(buffer_path, "rb") as f:
+        if debug_buffer_path is not None:
+            with open(debug_buffer_path, "rb") as f:
                 output_buffer = f.read()
         else:
             output_buffer = None


### PR DESCRIPTION
Summary:
Caught a bug in the offset calculation while integrating etdump into the Xtensa workflows. This only shows up when the base address itself is not 64 bytes aligned.

Also changed the name of `buffer_path` to `debug_buffer_path` in inspector.py

Differential Revision: D51913391


