### PR TITLE
Getting delegate sdk integration documentation up to date

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -189,6 +189,7 @@ Topics in this section will help you get started with ExecuTorch.
    sdk-etrecord
    sdk-etdump
    sdk-profiling
+   sdk-debugging
    sdk-inspector
    sdk-delegate-integration
    sdk-tutorial

--- a/docs/source/sdk-debugging.md
+++ b/docs/source/sdk-debugging.md
@@ -1,0 +1,82 @@
+# Debugging Models in ExecuTorch
+
+With the ExecuTorch SDK, users can debug their models for numerical inaccurcies and extract model outputs from their device to do quality analysis (such as Signal-to-Noise, Mean square error etc.).
+
+Currently, ExecuTorch supports the following debugging flows:
+- Extraction of model level outputs via ETDump.
+- Extraction of intermediate outputs (outside of delegates) via ETDump:
+  - Linking of these intermediate outputs back to the eager model python code.
+
+
+## Steps to debug a model in ExecuTorch
+
+### Runtime
+For a real example reflecting the steps below, please refer to [sdk_example_runner.cpp](https://github.com/pytorch/executorch/blob/main/examples/sdk/sdk_example_runner/sdk_example_runner.cpp).
+
+1. [Optional] Generate an [ETRecord](./sdk-etrecord.rst) while exporting your model. When provided, this enables users to link profiling information back to the eager model source code (with stack traces and module hierarchy).
+2. Integrate [ETDump generation](./sdk-etdump.md) into the runtime and set the debugging level by configuring the `ETDumpGen` object. Then, provide an additional buffer to which intermediate outputs and program outputs will be written. Currently we support two levels of debugging:
+    - Program level outputs
+    ```C++
+    Span<uint8_t> buffer((uint8_t*)debug_buffer, debug_buffer_size);
+    etdump_gen.set_debug_buffer(buffer);
+    etdump_gen.set_event_tracer_debug_level(
+        EventTracerDebugLogLevel::kIntermediateOutputs);
+    ```
+
+    - Intermediate outputs of executed (non-delegated) operations (will include the program level outputs too)
+    ```C++
+    Span<uint8_t> buffer((uint8_t*)debug_buffer, debug_buffer_size);
+    etdump_gen.set_debug_buffer(buffer);
+    etdump_gen.set_event_tracer_debug_level(
+        EventTracerDebugLogLevel::kProgramOutputs);
+    ```
+3. Build the runtime with the pre-processor flag that enables tracking of debug events. Instructions are in the [ETDump documentation](./sdk-etdump.md).
+4. Run your model and dump out the ETDump buffer as described [here](./sdk-etdump.md). (Do so similarly for the debug buffer if configured above)
+
+
+### Accessing the debug outputs post run using the Inspector API's
+Once a model has been run, using the generated ETDump and debug buffers, users can leverage the [Inspector API's](./sdk-inspector.rst) to inspect these debug outputs.
+
+```python
+from executorch.sdk import Inspector
+
+# Create an Inspector instance with etdump and the debug buffer.
+inspector = Inspector(etdump_path=etdump_path,
+            buffer_path = buffer_path,
+            # etrecord is optional, if provided it'll link back
+            # the runtime events to the eager model python source code.
+            etrecord = etrecord_path)
+
+# Accessing program outputs is as simple as this:
+for event_block in inspector.event_blocks:
+    if event_block.name == "Execute":
+        print(event_blocks.run_output)
+
+# Accessing intermediate outputs from each event (an event here is essentially an instruction that executed in the runtime).
+for event_block in inspector.event_blocks:
+    if event_block.name == "Execute":
+        for event in event_block.events:
+            print(event.debug_data)
+            # If an ETRecord was provided by the user during Inspector initialization, users
+            # can print the stacktraces and module hierarchy of these events.
+            print(event.stack_traces)
+            print(event.module_hierarchy)
+```
+
+We've also provided a simple set of utilities that let users perform quality analysis of their model outputs with respect to a set of reference outputs (possibly from the eager mode model).
+
+
+```python
+from executorch.sdk.inspector._inspector_utils import compare_results
+
+# Run a simple quality analysis between the model outputs sourced from the
+# runtime and a set of reference outputs.
+#
+# Setting plot to True will result in the quality metrics being graphed
+# and displayed (when run from a notebook) and will be written out to the
+# filesystem. A dictionary will always be returned which will contain the
+# results.
+for event_block in inspector.event_blocks:
+    if event_block.name == "Execute":
+        compare_results(event_blocks.run_output, ref_outputs, plot = True)
+```

--- a/docs/source/sdk-etdump.md
+++ b/docs/source/sdk-etdump.md
@@ -34,7 +34,7 @@ if (result.buf != nullptr && result.size > 0) {
   }
 ```
 
-4. ***Compile*** your binary with the `ET_EVENT_TRACER_ENABLED` flag to enable events to be traced and logged into ETDump inside the ExecuTorch runtime.
+4. ***Compile*** your binary with the `ET_EVENT_TRACER_ENABLED` pre-processor flag to enable events to be traced and logged into ETDump inside the ExecuTorch runtime.
 
     i). ***Buck***
 

--- a/docs/source/sdk-profiling.md
+++ b/docs/source/sdk-profiling.md
@@ -15,7 +15,7 @@ We provide access to all the profiling data via the Python [Inspector API](./sdk
 
 1. [Optional] Generate an [ETRecord](./sdk-etrecord.rst) while you're exporting your model. If provided this will enable users to link back profiling details to eager model source code (with stack traces and module hierarchy).
 2.  Build the runtime with the pre-processor flags that enable profiling. Detailed in the [ETDump documentation](./sdk-etdump.md).
-3.  Run your Program on the ExecuTorch runtime and generate an [ETDump](./sdk-etdump.md).
+3. Run your Program on the ExecuTorch runtime and generate an [ETDump](./sdk-etdump.md).
 4. Create an instance of the [Inspector API](./sdk-inspector.rst) by passing in the ETDump you have sourced from the runtime along with the optionally generated ETRecord from step 1.
     - Through the Inspector API, users can do a wide range of analysis varying from printing out performance details to doing more finer granular calculation on module level.
 

--- a/sdk/inspector/_inspector.py
+++ b/sdk/inspector/_inspector.py
@@ -867,7 +867,8 @@ class Inspector:
             source_time_scale: The time scale of the performance data retrieved from the runtime. The default time hook implentation in the runtime returns NS.
             target_time_scale: The target time scale to which the users want their performance data converted to. Defaults to MS.
             debug_buffer_path: Debug buffer file path that contains the debug data referenced by ETDump for intermediate and program outputs.
-            delegate_metadata_parser: Optional function to parse delegate metadata from an Profiling Event
+            delegate_metadata_parser: Optional function to parse delegate metadata from an Profiling Event. Expected signature of the function is:
+                    (delegate_metadata_list: List[bytes]) -> Union[List[str], Dict[str, Any]]
 
         Returns:
             None


### PR DESCRIPTION
Summary: Getting the delegate SDK documentation up to date to reflect the recent changes we've been making.

Differential Revision: D51929676

