### PR TITLE
Rewrite backend passes w/o ExportPass

### DIFF
--- a/exir/passes/replace_edge_with_backend_pass.py
+++ b/exir/passes/replace_edge_with_backend_pass.py
@@ -8,43 +8,43 @@
 
 import torch
 from executorch.exir.dialects._ops import ops
-from executorch.exir.pass_base import ExportPass
 from executorch.exir.passes.executorch_prim_ops_registry import (
     _PYTHON_SYM_OPS_TO_EXECUTORCH_SYM_OPS,
 )
+from torch.fx.passes.infra.pass_base import PassBase, PassResult
 
 
-class EdgeToBackendOpsPass(ExportPass):
+class EdgeToBackendOpsPass(PassBase):
     """
     Converts
     1. symbolic int ops to the executorch_prims namespaced ops
     2. other backend ops from torch._ops.OpOverload to BackendOpOverload
     """
 
-    # pyre-ignore
-    def call_sym(self, target, args, meta):
-        if target in _PYTHON_SYM_OPS_TO_EXECUTORCH_SYM_OPS:
-            return super().call_operator(
-                _PYTHON_SYM_OPS_TO_EXECUTORCH_SYM_OPS[target],
-                args,
-                {},
-                meta,
-            )
-        return super().call_sym(target, args, meta)
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        for module in graph_module.modules():
+            if not isinstance(module, torch.fx.GraphModule):
+                continue
 
-    # pyre-ignore
-    def call_operator(self, op, args, kwargs, meta):
-        # replace torch.ops.OpOverload with its corresponding backend ops.
-        # Looking op name up from _dir in _DialectNamespace, _OpNamespace
-        # and BackendOpOverloadPacket
-        if isinstance(op, torch._ops.OpOverload):
-            namespace = op.namespace
-            name = op._schema.name.split("::")[1]
-            overload_name = op._overloadname
-            obj = ops.backend
-            for key in [namespace, name, overload_name]:
-                if key not in obj._dir:
-                    return super().call_operator(op, args, kwargs, meta)
-                obj = getattr(obj, key)
-            return super().call_operator(obj, args, kwargs, meta)
-        return super().call_operator(op, args, kwargs, meta)
+            for node in module.graph.nodes:
+                if node.op == "call_function":
+                    if node.target in _PYTHON_SYM_OPS_TO_EXECUTORCH_SYM_OPS:
+                        node.target = _PYTHON_SYM_OPS_TO_EXECUTORCH_SYM_OPS[node.target]
+
+                    elif isinstance(node.target, torch._ops.OpOverload):
+                        # replace torch.ops.OpOverload with its corresponding backend ops.
+                        # Looking op name up from _dir in _DialectNamespace, _OpNamespace
+                        # and BackendOpOverloadPacketb
+                        namespace = node.target.namespace
+                        name = node.target._schema.name.split("::")[1]
+                        overload_name = node.target._overloadname
+                        obj = ops.backend
+                        for key in [namespace, name, overload_name]:
+                            if key not in obj._dir:
+                                break
+                            obj = getattr(obj, key)
+                        node.target = obj
+
+            module.recompile()
+
+        return PassResult(graph_module, True)

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -437,6 +437,9 @@ def edge_to_executorch_passes(config: ExecutorchBackendConfig) -> List[PassType]
     passes: List[PassType] = [
         *config.passes,
         SpecPropPass(),
+        # ExecuTorch backend ops are unable to handle unbacked symints. So after
+        # this pass, passes cannot be Interpreter-based, because it will fail if
+        # there exists an unbacked symint operation.
         EdgeToBackendOpsPass(),
         RemoveAssertAsyncPass(),
         config.sym_shape_eval_pass,


### PR DESCRIPTION
Summary:
The core problem can be reproduced in D51686224. The issue is that the executorch sym operation is unable to handle unbacked symints, and we run the graph with fake inputs + symints whenever we do an Interpreter-based pass. So, the solution we have here is to rewrite the passes to not use the Interpreter-based passes.

This is ok because we (Executorch) is in control of all the passes after EdgeToBackendOpPass, so we just need to make sure that those passes do not use Interpreter-based passes.

Context for this pass:
> At a high level heres whats going on:
> Export produces a graph with nodes like "operator.ge". These are not aten operators and they operate on SymInts/Bools/Floats. Executorch would really like these to be operators so we can target them easier in the backend. To do that we have a pass that replaces all of these with executorch operators that attempt to mimic the behavior of whatever operator.ge etc do. This has historically caused problems where the executorch python definition does not match the operator.ge behavior preventing us from performing future passes or running the model before final lowering. In cpp theres no issues because the concept of sym is gone and everything is concrete.

Reviewed By: larryliu0820

Differential Revision: D51924408


