### PR TITLE
Abstracting away flatcc from any users of etdump

### DIFF
--- a/sdk/etdump/emitter.h
+++ b/sdk/etdump/emitter.h
@@ -9,42 +9,13 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <executorch/sdk/etdump/etdump_flatcc.h>
 #include <flatcc/flatcc_builder.h>
 
 #pragma once
 
 namespace torch {
 namespace executor {
-
-struct etdump_static_allocator {
-  etdump_static_allocator(
-      uint8_t* buffer,
-      size_t total_buf_size,
-      size_t alloc_buf_size)
-      : data{buffer},
-        data_size{alloc_buf_size},
-        allocated{0},
-        out_size{total_buf_size - alloc_buf_size},
-        front_cursor{&buffer[alloc_buf_size]},
-        front_left{out_size / 2} {}
-  // Pointer to backing buffer to allocate from.
-  uint8_t* data{nullptr};
-
-  // Size of backing buffer.
-  size_t data_size{0};
-
-  // Current allocation offset.
-  size_t allocated{0};
-
-  // Size of build buffer.
-  size_t out_size{0};
-
-  // Pointer to front of build buffer.
-  uint8_t* front_cursor{nullptr};
-
-  // Bytes left in front of front_cursor.
-  size_t front_left{0};
-};
 
 int et_flatcc_custom_init(
     flatcc_builder_t* builder,

--- a/sdk/etdump/etdump_flatcc.cpp
+++ b/sdk/etdump/etdump_flatcc.cpp
@@ -7,63 +7,117 @@
  */
 
 #include "executorch/sdk/etdump/etdump_flatcc.h"
+#include <executorch/sdk/etdump/etdump_schema_flatcc_builder.h>
+#include <executorch/sdk/etdump/etdump_schema_flatcc_reader.h>
 #include <flatcc/flatcc_types.h>
 #include <stdio.h>
 #include <string.h>
 #include "executorch/runtime/core/exec_aten/util/scalar_type_util.h"
 #include "executorch/runtime/platform/assert.h"
+#include "executorch/sdk/etdump/emitter.h"
 
 namespace torch {
 namespace executor {
 
+namespace {
+executorch_flatbuffer_ScalarType_enum_t get_flatbuffer_scalar_type(
+    exec_aten::ScalarType tensor_scalar_type) {
+  switch (tensor_scalar_type) {
+    case exec_aten::ScalarType::Byte:
+      return executorch_flatbuffer_ScalarType_BYTE;
+    case exec_aten::ScalarType::Char:
+      return executorch_flatbuffer_ScalarType_CHAR;
+    case exec_aten::ScalarType::Short:
+      return executorch_flatbuffer_ScalarType_SHORT;
+    case exec_aten::ScalarType::Float:
+      return executorch_flatbuffer_ScalarType_FLOAT;
+    case exec_aten::ScalarType::Int:
+      return executorch_flatbuffer_ScalarType_INT;
+    case exec_aten::ScalarType::Long:
+      return executorch_flatbuffer_ScalarType_LONG;
+    case exec_aten::ScalarType::Double:
+      return executorch_flatbuffer_ScalarType_DOUBLE;
+    case exec_aten::ScalarType::Bool:
+      return executorch_flatbuffer_ScalarType_BOOL;
+    default:
+      ET_CHECK_MSG(
+          0,
+          "This ScalarType = %hhd is not yet supported in ETDump",
+          tensor_scalar_type);
+  }
+}
+
+static uint8_t* alignPointer(void* ptr, size_t alignment) {
+  intptr_t addr = reinterpret_cast<intptr_t>(ptr);
+  if ((addr & (alignment - 1)) == 0) {
+    // Already aligned.
+    return reinterpret_cast<uint8_t*>(ptr);
+  }
+  addr = (addr | (alignment - 1)) + 1;
+  return reinterpret_cast<uint8_t*>(addr);
+}
+
+} // namespace
+
 constexpr size_t max_alloc_buf_size = 128 * 1024;
 
 // Constructor implementation
-ETDumpGen::ETDumpGen(Span<uint8_t> buffer)
-    : alloc{
-          buffer.data(),
-          buffer.size(),
-          (size_t)((buffer.size() / 4 > max_alloc_buf_size) ? max_alloc_buf_size : buffer.size() / 4),
-      } {
+ETDumpGen::ETDumpGen(Span<uint8_t> buffer) {
   // Initialize the flatcc builder using the buffer and buffer size.
+
   if (buffer.data() != nullptr) {
-    et_flatcc_custom_init(&builder, &alloc);
+    builder = (struct flatcc_builder*)alignPointer(buffer.data(), 64);
+    uintptr_t buffer_with_builder =
+        (uintptr_t)alignPointer(builder + sizeof(struct flatcc_builder), 64);
+    size_t buffer_size = buffer.size() -
+        (size_t)(buffer_with_builder - (uintptr_t)buffer.data());
+    alloc.set_buffer(
+        (uint8_t*)buffer_with_builder,
+        buffer_size,
+        (size_t)((buffer_size / 4 > max_alloc_buf_size) ? max_alloc_buf_size : buffer_size / 4));
+    et_flatcc_custom_init(builder, &alloc);
   } else {
-    flatcc_builder_init(&builder);
+    builder = (struct flatcc_builder*)malloc(sizeof(struct flatcc_builder));
+    ET_CHECK_MSG(
+        builder != nullptr, "Failed to allocate memory for flatcc builder.");
+    flatcc_builder_init(builder);
   }
-  flatbuffers_buffer_start(&builder, etdump_ETDump_file_identifier);
-  etdump_ETDump_start_as_root_with_size(&builder);
-  etdump_ETDump_version_add(&builder, ETDUMP_VERSION);
-  etdump_ETDump_run_data_start(&builder);
-  etdump_ETDump_run_data_push_start(&builder);
+  flatbuffers_buffer_start(builder, etdump_ETDump_file_identifier);
+  etdump_ETDump_start_as_root_with_size(builder);
+  etdump_ETDump_version_add(builder, ETDUMP_VERSION);
+  etdump_ETDump_run_data_start(builder);
+  etdump_ETDump_run_data_push_start(builder);
 }
 
 ETDumpGen::~ETDumpGen() {
-  flatcc_builder_clear(&builder);
+  flatcc_builder_clear(builder);
+  if (!is_static_etdump()) {
+    free(builder);
+  }
 }
 
 void ETDumpGen::clear_builder() {
-  flatcc_builder_clear(&builder);
+  flatcc_builder_clear(builder);
 }
 
 void ETDumpGen::create_event_block(const char* name) {
   if (etdump_gen_state == ETDumpGen_Adding_Events) {
-    etdump_RunData_events_end(&builder);
+    etdump_RunData_events_end(builder);
   }
   if (num_blocks > 0) {
-    etdump_ETDump_run_data_push_end(&builder);
-    etdump_ETDump_run_data_push_start(&builder);
+    etdump_ETDump_run_data_push_end(builder);
+    etdump_ETDump_run_data_push_start(builder);
   }
   ++num_blocks;
-  etdump_RunData_name_create_strn(&builder, name, strlen(name));
+  etdump_RunData_name_create_strn(builder, name, strlen(name));
   if (bundled_input_index != -1) {
-    etdump_RunData_bundled_input_index_add(&builder, bundled_input_index);
+    etdump_RunData_bundled_input_index_add(builder, bundled_input_index);
   }
   etdump_gen_state = ETDumpGen_Block_Created;
 }
 
 int64_t ETDumpGen::create_string_entry(const char* name) {
-  return flatbuffers_string_create_str(&builder, name);
+  return flatbuffers_string_create_str(builder, name);
 }
 
 // ETDumpGen has the following possible states, ETDumpGen_Init,
@@ -86,9 +140,9 @@ void ETDumpGen::check_ready_to_add_events() {
          etdump_gen_state == ETDumpGen_Block_Created),
         "ETDumpGen in an invalid state. Cannot add new events now.");
     if (etdump_gen_state == ETDumpGen_Adding_Allocators) {
-      etdump_RunData_allocators_end(&builder);
+      etdump_RunData_allocators_end(builder);
     }
-    etdump_RunData_events_start(&builder);
+    etdump_RunData_events_start(builder);
     etdump_gen_state = ETDumpGen_Adding_Events;
   }
 }
@@ -142,29 +196,29 @@ void ETDumpGen::end_profiling_delegate(
   check_ready_to_add_events();
 
   // Start building the ProfileEvent entry.
-  etdump_ProfileEvent_start(&builder);
-  etdump_ProfileEvent_start_time_add(&builder, event_tracer_entry.start_time);
-  etdump_ProfileEvent_end_time_add(&builder, end_time);
-  etdump_ProfileEvent_chain_index_add(&builder, chain_id_);
-  etdump_ProfileEvent_instruction_id_add(&builder, debug_handle_);
+  etdump_ProfileEvent_start(builder);
+  etdump_ProfileEvent_start_time_add(builder, event_tracer_entry.start_time);
+  etdump_ProfileEvent_end_time_add(builder, end_time);
+  etdump_ProfileEvent_chain_index_add(builder, chain_id_);
+  etdump_ProfileEvent_instruction_id_add(builder, debug_handle_);
   // Delegate debug identifier can either be of a string type or an integer
   // type. If it's a string type then it's a value of type
   // flatbuffers_string_ref_t type, whereas if it's an integer type then we
   // write the integer value directly.
   if (event_tracer_entry.delegate_event_id_type == DelegateDebugIdType::kInt) {
     etdump_ProfileEvent_delegate_debug_id_int_add(
-        &builder, event_tracer_entry.event_id);
+        builder, event_tracer_entry.event_id);
   } else {
     etdump_ProfileEvent_delegate_debug_id_str_add(
-        &builder, event_tracer_entry.event_id);
+        builder, event_tracer_entry.event_id);
   }
   flatbuffers_uint8_vec_ref_t vec_ref = flatbuffers_uint8_vec_create_pe(
-      &builder, (const uint8_t*)metadata, metadata_len);
-  etdump_ProfileEvent_delegate_debug_metadata_add(&builder, vec_ref);
-  etdump_ProfileEvent_ref_t id = etdump_ProfileEvent_end(&builder);
-  etdump_RunData_events_push_start(&builder);
-  etdump_Event_profile_event_add(&builder, id);
-  etdump_RunData_events_push_end(&builder);
+      builder, (const uint8_t*)metadata, metadata_len);
+  etdump_ProfileEvent_delegate_debug_metadata_add(builder, vec_ref);
+  etdump_ProfileEvent_ref_t id = etdump_ProfileEvent_end(builder);
+  etdump_RunData_events_push_start(builder);
+  etdump_Event_profile_event_add(builder, id);
+  etdump_RunData_events_push_end(builder);
 }
 
 void ETDumpGen::log_profiling_delegate(
@@ -179,24 +233,24 @@ void ETDumpGen::log_profiling_delegate(
       "Only name or delegate_debug_index can be valid. Check DelegateMappingBuilder documentation for more details.");
   check_ready_to_add_events();
   int64_t string_id = name != nullptr ? create_string_entry(name) : -1;
-  etdump_ProfileEvent_start(&builder);
-  etdump_ProfileEvent_start_time_add(&builder, start_time);
-  etdump_ProfileEvent_end_time_add(&builder, end_time);
-  etdump_ProfileEvent_chain_index_add(&builder, chain_id_);
-  etdump_ProfileEvent_instruction_id_add(&builder, debug_handle_);
+  etdump_ProfileEvent_start(builder);
+  etdump_ProfileEvent_start_time_add(builder, start_time);
+  etdump_ProfileEvent_end_time_add(builder, end_time);
+  etdump_ProfileEvent_chain_index_add(builder, chain_id_);
+  etdump_ProfileEvent_instruction_id_add(builder, debug_handle_);
   if (string_id == -1) {
     etdump_ProfileEvent_delegate_debug_id_int_add(
-        &builder, delegate_debug_index);
+        builder, delegate_debug_index);
   } else {
-    etdump_ProfileEvent_delegate_debug_id_str_add(&builder, string_id);
+    etdump_ProfileEvent_delegate_debug_id_str_add(builder, string_id);
   }
   flatbuffers_uint8_vec_ref_t vec_ref = flatbuffers_uint8_vec_create_pe(
-      &builder, (const uint8_t*)metadata, metadata_len);
-  etdump_ProfileEvent_delegate_debug_metadata_add(&builder, vec_ref);
-  etdump_ProfileEvent_ref_t id = etdump_ProfileEvent_end(&builder);
-  etdump_RunData_events_push_start(&builder);
-  etdump_Event_profile_event_add(&builder, id);
-  etdump_RunData_events_push_end(&builder);
+      builder, (const uint8_t*)metadata, metadata_len);
+  etdump_ProfileEvent_delegate_debug_metadata_add(builder, vec_ref);
+  etdump_ProfileEvent_ref_t id = etdump_ProfileEvent_end(builder);
+  etdump_RunData_events_push_start(builder);
+  etdump_Event_profile_event_add(builder, id);
+  etdump_RunData_events_push_end(builder);
 }
 
 void ETDumpGen::end_profiling(EventTracerEntry prof_entry) {
@@ -206,18 +260,18 @@ void ETDumpGen::end_profiling(EventTracerEntry prof_entry) {
       "Delegate events must use end_profiling_delegate to mark the end of a delegate profiling event.");
   check_ready_to_add_events();
 
-  etdump_ProfileEvent_start(&builder);
-  etdump_ProfileEvent_start_time_add(&builder, prof_entry.start_time);
-  etdump_ProfileEvent_end_time_add(&builder, end_time);
-  etdump_ProfileEvent_chain_index_add(&builder, prof_entry.chain_id);
-  etdump_ProfileEvent_instruction_id_add(&builder, prof_entry.debug_handle);
+  etdump_ProfileEvent_start(builder);
+  etdump_ProfileEvent_start_time_add(builder, prof_entry.start_time);
+  etdump_ProfileEvent_end_time_add(builder, end_time);
+  etdump_ProfileEvent_chain_index_add(builder, prof_entry.chain_id);
+  etdump_ProfileEvent_instruction_id_add(builder, prof_entry.debug_handle);
   if (prof_entry.event_id != -1) {
-    etdump_ProfileEvent_name_add(&builder, prof_entry.event_id);
+    etdump_ProfileEvent_name_add(builder, prof_entry.event_id);
   }
-  etdump_ProfileEvent_ref_t id = etdump_ProfileEvent_end(&builder);
-  etdump_RunData_events_push_start(&builder);
-  etdump_Event_profile_event_add(&builder, id);
-  etdump_RunData_events_push_end(&builder);
+  etdump_ProfileEvent_ref_t id = etdump_ProfileEvent_end(builder);
+  etdump_RunData_events_push_start(builder);
+  etdump_Event_profile_event_add(builder, id);
+  etdump_RunData_events_push_end(builder);
 }
 
 AllocatorID ETDumpGen::track_allocator(const char* name) {
@@ -226,12 +280,12 @@ AllocatorID ETDumpGen::track_allocator(const char* name) {
        etdump_gen_state == ETDumpGen_Adding_Allocators),
       "Allocators can only be added immediately after a new block is created and before any events are added.");
   if (etdump_gen_state != ETDumpGen_Adding_Allocators) {
-    etdump_RunData_allocators_start(&builder);
+    etdump_RunData_allocators_start(builder);
     etdump_gen_state = ETDumpGen_Adding_Allocators;
   }
   flatbuffers_string_ref_t ref = create_string_entry(name);
-  etdump_RunData_allocators_push_create(&builder, ref);
-  return etdump_RunData_allocators_reserved_len(&builder);
+  etdump_RunData_allocators_push_create(builder, ref);
+  return etdump_RunData_allocators_reserved_len(builder);
 }
 
 void ETDumpGen::track_allocation(
@@ -239,26 +293,26 @@ void ETDumpGen::track_allocation(
     size_t allocation_size) {
   check_ready_to_add_events();
 
-  etdump_RunData_events_push_start(&builder);
-  etdump_Event_allocation_event_create(&builder, allocator_id, allocation_size);
-  etdump_RunData_events_push_end(&builder);
+  etdump_RunData_events_push_start(builder);
+  etdump_Event_allocation_event_create(builder, allocator_id, allocation_size);
+  etdump_RunData_events_push_end(builder);
 }
 
 etdump_result ETDumpGen::get_etdump_data() {
   etdump_result result;
   if (etdump_gen_state == ETDumpGen_Adding_Events) {
-    etdump_RunData_events_end(&builder);
+    etdump_RunData_events_end(builder);
   } else if (etdump_gen_state == ETDumpGen_Adding_Allocators) {
-    etdump_RunData_allocators_end(&builder);
+    etdump_RunData_allocators_end(builder);
   } else if (etdump_gen_state == ETDumpGen_Init) {
     result.buf = nullptr;
     result.size = 0;
     return result;
   }
-  etdump_ETDump_run_data_push_end(&builder);
-  etdump_ETDump_run_data_end(&builder);
-  etdump_ETDump_ref_t root = etdump_ETDump_end(&builder);
-  flatbuffers_buffer_end(&builder, root);
+  etdump_ETDump_run_data_push_end(builder);
+  etdump_ETDump_run_data_end(builder);
+  etdump_ETDump_ref_t root = etdump_ETDump_end(builder);
+  flatbuffers_buffer_end(builder, root);
   if (num_blocks == 0) {
     result = {nullptr, 0};
   } else {
@@ -267,51 +321,14 @@ etdump_result ETDumpGen::get_etdump_data() {
       result.size = alloc.out_size - alloc.front_left;
     } else {
       result.buf =
-          flatcc_builder_finalize_aligned_buffer(&builder, &result.size);
+          flatcc_builder_finalize_aligned_buffer(builder, &result.size);
     }
   }
   return result;
 }
 
-executorch_flatbuffer_ScalarType_enum_t get_flatbuffer_scalar_type(
-    exec_aten::ScalarType tensor_scalar_type) {
-  switch (tensor_scalar_type) {
-    case exec_aten::ScalarType::Byte:
-      return executorch_flatbuffer_ScalarType_BYTE;
-    case exec_aten::ScalarType::Char:
-      return executorch_flatbuffer_ScalarType_CHAR;
-    case exec_aten::ScalarType::Short:
-      return executorch_flatbuffer_ScalarType_SHORT;
-    case exec_aten::ScalarType::Float:
-      return executorch_flatbuffer_ScalarType_FLOAT;
-    case exec_aten::ScalarType::Int:
-      return executorch_flatbuffer_ScalarType_INT;
-    case exec_aten::ScalarType::Long:
-      return executorch_flatbuffer_ScalarType_LONG;
-    case exec_aten::ScalarType::Double:
-      return executorch_flatbuffer_ScalarType_DOUBLE;
-    case exec_aten::ScalarType::Bool:
-      return executorch_flatbuffer_ScalarType_BOOL;
-    default:
-      ET_CHECK_MSG(
-          0,
-          "This ScalarType = %hhd is not yet supported in ETDump",
-          tensor_scalar_type);
-  }
-}
-
 void ETDumpGen::set_debug_buffer(Span<uint8_t> buffer) {
   debug_buffer = buffer;
-}
-
-static uint8_t* alignPointer(void* ptr, size_t alignment) {
-  intptr_t addr = reinterpret_cast<intptr_t>(ptr);
-  if ((addr & (alignment - 1)) == 0) {
-    // Already aligned.
-    return reinterpret_cast<uint8_t*>(ptr);
-  }
-  addr = (addr | (alignment - 1)) + 1;
-  return reinterpret_cast<uint8_t*>(addr);
 }
 
 size_t ETDumpGen::copy_tensor_to_debug_buffer(exec_aten::Tensor tensor) {
@@ -335,74 +352,74 @@ void ETDumpGen::log_evalue(const EValue& evalue, LoggedEValueType evalue_type) {
 
   check_ready_to_add_events();
 
-  etdump_DebugEvent_start(&builder);
+  etdump_DebugEvent_start(builder);
 
-  etdump_DebugEvent_chain_index_add(&builder, chain_id_);
-  etdump_DebugEvent_instruction_id_add(&builder, debug_handle_);
+  etdump_DebugEvent_chain_index_add(builder, chain_id_);
+  etdump_DebugEvent_instruction_id_add(builder, debug_handle_);
 
   switch (evalue.tag) {
     case Tag::Tensor: {
       exec_aten::Tensor tensor = evalue.toTensor();
       long offset = copy_tensor_to_debug_buffer(tensor);
 
-      etdump_Tensor_start(&builder);
+      etdump_Tensor_start(builder);
 
       etdump_Tensor_scalar_type_add(
-          &builder, get_flatbuffer_scalar_type(tensor.scalar_type()));
-      etdump_Tensor_sizes_start(&builder);
+          builder, get_flatbuffer_scalar_type(tensor.scalar_type()));
+      etdump_Tensor_sizes_start(builder);
 
       for (auto dim : tensor.sizes()) {
         int64_t cast_dim = static_cast<int64_t>(dim);
-        etdump_Tensor_sizes_push(&builder, &cast_dim);
+        etdump_Tensor_sizes_push(builder, &cast_dim);
       }
-      etdump_Tensor_sizes_end(&builder);
+      etdump_Tensor_sizes_end(builder);
 
-      etdump_Tensor_strides_start(&builder);
+      etdump_Tensor_strides_start(builder);
       for (auto dim : tensor.strides()) {
         int64_t cast_dim = static_cast<int64_t>(dim);
-        etdump_Tensor_strides_push(&builder, &cast_dim);
+        etdump_Tensor_strides_push(builder, &cast_dim);
       }
-      etdump_Tensor_strides_end(&builder);
-      etdump_Tensor_offset_add(&builder, offset);
+      etdump_Tensor_strides_end(builder);
+      etdump_Tensor_offset_add(builder, offset);
 
-      etdump_Tensor_ref_t tensor_ref = etdump_Tensor_end(&builder);
+      etdump_Tensor_ref_t tensor_ref = etdump_Tensor_end(builder);
 
-      etdump_Value_start(&builder);
-      etdump_Value_val_add(&builder, etdump_ValueType_Tensor);
-      etdump_Value_tensor_add(&builder, tensor_ref);
+      etdump_Value_start(builder);
+      etdump_Value_val_add(builder, etdump_ValueType_Tensor);
+      etdump_Value_tensor_add(builder, tensor_ref);
       if (evalue_type == LoggedEValueType::kProgramOutput) {
-        auto bool_ref = etdump_Bool_create(&builder, FLATBUFFERS_TRUE);
-        etdump_Value_output_add(&builder, bool_ref);
+        auto bool_ref = etdump_Bool_create(builder, FLATBUFFERS_TRUE);
+        etdump_Value_output_add(builder, bool_ref);
       }
-      auto value_ref = etdump_Value_end(&builder);
+      auto value_ref = etdump_Value_end(builder);
 
-      etdump_DebugEvent_debug_entry_add(&builder, value_ref);
+      etdump_DebugEvent_debug_entry_add(builder, value_ref);
 
       break;
     }
 
     case Tag::Int: {
       int64_t val = evalue.toInt();
-      auto int_ref = etdump_Int_create(&builder, val);
+      auto int_ref = etdump_Int_create(builder, val);
 
-      etdump_Value_start(&builder);
-      etdump_Value_val_add(&builder, etdump_ValueType_Int);
-      etdump_Value_int_value_add(&builder, int_ref);
-      auto value_ref = etdump_Value_end(&builder);
-      etdump_DebugEvent_debug_entry_add(&builder, value_ref);
+      etdump_Value_start(builder);
+      etdump_Value_val_add(builder, etdump_ValueType_Int);
+      etdump_Value_int_value_add(builder, int_ref);
+      auto value_ref = etdump_Value_end(builder);
+      etdump_DebugEvent_debug_entry_add(builder, value_ref);
 
       break;
     }
 
     case Tag::Double: {
       double val = evalue.toDouble();
-      auto double_ref = etdump_Double_create(&builder, val);
+      auto double_ref = etdump_Double_create(builder, val);
 
-      etdump_Value_start(&builder);
-      etdump_Value_double_value_add(&builder, double_ref);
-      etdump_Value_val_add(&builder, etdump_ValueType_Double);
-      auto value_ref = etdump_Value_end(&builder);
-      etdump_DebugEvent_debug_entry_add(&builder, value_ref);
+      etdump_Value_start(builder);
+      etdump_Value_double_value_add(builder, double_ref);
+      etdump_Value_val_add(builder, etdump_ValueType_Double);
+      auto value_ref = etdump_Value_end(builder);
+      etdump_DebugEvent_debug_entry_add(builder, value_ref);
 
       break;
     }
@@ -410,13 +427,13 @@ void ETDumpGen::log_evalue(const EValue& evalue, LoggedEValueType evalue_type) {
     case Tag::Bool: {
       flatbuffers_bool_t flatbuffer_bool_val =
           evalue.toBool() ? FLATBUFFERS_TRUE : FLATBUFFERS_FALSE;
-      auto bool_ref = etdump_Bool_create(&builder, flatbuffer_bool_val);
+      auto bool_ref = etdump_Bool_create(builder, flatbuffer_bool_val);
 
-      etdump_Value_start(&builder);
-      etdump_Value_bool_value_add(&builder, bool_ref);
-      etdump_Value_val_add(&builder, etdump_ValueType_Bool);
-      auto value_ref = etdump_Value_end(&builder);
-      etdump_DebugEvent_debug_entry_add(&builder, value_ref);
+      etdump_Value_start(builder);
+      etdump_Value_bool_value_add(builder, bool_ref);
+      etdump_Value_val_add(builder, etdump_ValueType_Bool);
+      auto value_ref = etdump_Value_end(builder);
+      etdump_DebugEvent_debug_entry_add(builder, value_ref);
 
       break;
     }
@@ -429,11 +446,11 @@ void ETDumpGen::log_evalue(const EValue& evalue, LoggedEValueType evalue_type) {
       break;
   }
 
-  etdump_DebugEvent_ref_t debug_event = etdump_DebugEvent_end(&builder);
+  etdump_DebugEvent_ref_t debug_event = etdump_DebugEvent_end(builder);
 
-  etdump_RunData_events_push_start(&builder);
-  etdump_Event_debug_event_add(&builder, debug_event);
-  etdump_RunData_events_push_end(&builder);
+  etdump_RunData_events_push_start(builder);
+  etdump_Event_debug_event_add(builder, debug_event);
+  etdump_RunData_events_push_end(builder);
 }
 
 size_t ETDumpGen::get_num_blocks() {

--- a/sdk/etdump/targets.bzl
+++ b/sdk/etdump/targets.bzl
@@ -87,40 +87,23 @@ def define_common_targets():
         exported_external_deps = ["flatccrt"],
     )
 
-    runtime.cxx_library(
-        name = "etdump_emitter",
-        srcs = [
-            "emitter.cpp",
-        ],
-        deps = [
-            "//executorch/runtime/core:core",
-        ],
-        exported_headers = [
-            "emitter.h",
-        ],
-        exported_external_deps = ["flatccrt"],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
-    )
-
     for aten_mode in (True, False):
         aten_suffix = "_aten" if aten_mode else ""
         runtime.cxx_library(
             name = "etdump_flatcc" + aten_suffix,
             srcs = [
                 "etdump_flatcc.cpp",
+                "emitter.cpp",
             ],
             exported_headers = [
                 "etdump_flatcc.h",
+                "emitter.h",
             ],
             deps = [
                 "//executorch/runtime/platform:platform",
             ],
             exported_deps = [
                 ":etdump_schema_flatcc",
-                ":etdump_emitter",
                 "//executorch/runtime/core:event_tracer" + aten_suffix,
                 "//executorch/runtime/core/exec_aten/util:scalar_type_util" + aten_suffix,
             ],

--- a/sdk/etdump/tests/etdump_test.cpp
+++ b/sdk/etdump/tests/etdump_test.cpp
@@ -12,6 +12,8 @@
 #include <executorch/runtime/core/span.h>
 #include <executorch/runtime/platform/runtime.h>
 #include <executorch/sdk/etdump/etdump_flatcc.h>
+#include <executorch/sdk/etdump/etdump_schema_flatcc_builder.h>
+#include <executorch/sdk/etdump/etdump_schema_flatcc_reader.h>
 #include <executorch/test/utils/DeathTest.h>
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
Summary:
This diff hides away all the flatcc types and isolates them `etdump_flatcc.cpp` so that any user who includes `etdump_flatcc.h` doesn't need to access any of the flatcc namespace variables.

Most of these issues surfaced while integrating etdump into coreml_executor_runner.

Differential Revision: D51966334


