### PR TITLE
update Meta-internal googletest references

### DIFF
--- a/kernels/test/targets.bzl
+++ b/kernels/test/targets.bzl
@@ -53,7 +53,7 @@ def define_common_targets(is_fbcode = False):
             ],
             xplat_exported_deps = [
                 "//xplat/folly:init_init",
-                "//xplat/third-party/gmock:gtest",
+                "//third-party/googletest:gtest_main",
             ],
         )
 


### PR DESCRIPTION
Summary: Update test dependencies to point to the new internal googletest location.

Differential Revision: D51957233


