### PR TITLE
Adding ETDump integration to coreml_executor_runner

### DIFF
--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -83,6 +83,8 @@ target_include_directories(
   coremldelegate PRIVATE
   ${EXECUTORCH_ROOT}/..
 )
+target_compile_options(executorch PUBLIC -DET_EVENT_TRACER_ENABLED)
+
 
 target_link_libraries(
   coremldelegate PRIVATE

--- a/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.pbxproj
+++ b/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		38626BB42B225A560059413D /* libflatccrt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 38626BB32B225A560059413D /* libflatccrt.a */; };
+		38626BB52B225A890059413D /* libetdump.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 38626BAF2B21C98F0059413D /* libetdump.a */; };
 		C94D51592ACF4BFC00AF47FD /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = C94D51582ACF4BFC00AF47FD /* main.mm */; };
 		C94D515E2ACFCBA000AF47FD /* libexecutorch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D515C2ACFCBA000AF47FD /* libexecutorch.a */; };
 		C94D51622ACFCBBA00AF47FD /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51612ACFCBBA00AF47FD /* libsqlite3.tbd */; };
@@ -28,6 +30,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		38626BAF2B21C98F0059413D /* libetdump.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libetdump.a; path = libraries/libetdump.a; sourceTree = "<group>"; };
+		38626BB32B225A560059413D /* libflatccrt.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libflatccrt.a; path = "../../../../third-party/flatcc/lib/libflatccrt.a"; sourceTree = "<group>"; };
 		C94D514E2ACF4B9300AF47FD /* coreml_executor_runner */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = coreml_executor_runner; sourceTree = BUILT_PRODUCTS_DIR; };
 		C94D51582ACF4BFC00AF47FD /* main.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
 		C94D515C2ACFCBA000AF47FD /* libexecutorch.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libexecutorch.a; path = libraries/libexecutorch.a; sourceTree = "<group>"; };
@@ -42,6 +46,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				38626BB52B225A890059413D /* libetdump.a in Frameworks */,
+				38626BB42B225A560059413D /* libflatccrt.a in Frameworks */,
 				C94D51682ACFCC7100AF47FD /* libcoremldelegate.a in Frameworks */,
 				C94D51662ACFCBCB00AF47FD /* Accelerate.framework in Frameworks */,
 				C94D51642ACFCBC500AF47FD /* CoreML.framework in Frameworks */,
@@ -73,6 +79,8 @@
 		C94D51602ACFCBBA00AF47FD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				38626BB32B225A560059413D /* libflatccrt.a */,
+				38626BAF2B21C98F0059413D /* libetdump.a */,
 				C94D51652ACFCBCB00AF47FD /* Accelerate.framework */,
 				C94D51632ACFCBC500AF47FD /* CoreML.framework */,
 				C94D515C2ACFCBA000AF47FD /* libexecutorch.a */,

--- a/examples/apple/coreml/scripts/build_executor_runner.sh
+++ b/examples/apple/coreml/scripts/build_executor_runner.sh
@@ -35,12 +35,15 @@ cmake "$EXECUTORCH_ROOT_PATH" -B"$CMAKE_BUILD_DIR_PATH" \
 -DFLATC_EXECUTABLE="$(which flatc)" \
 -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF \
 -DEXECUTORCH_BUILD_XNNPACK=OFF \
+-DEXECUTORCH_BUILD_SDK=ON \
 -DEXECUTORCH_BUILD_COREML=ON
 
 cmake --build "$CMAKE_BUILD_DIR_PATH" -j9 -t coremldelegate -t gflags_nothreads_static
+cmake --build "$CMAKE_BUILD_DIR_PATH" -j9 -t etdump -t flatccrt
 
 # Copy CoreML delegate headers
 echo "ExecuTorch: Copying headers"
+echo $EXECUTORCH_INCLUDE_DIR_PATH
 rm -rf "$INCLUDE_DIR_PATH"
 mkdir "$INCLUDE_DIR_PATH"
 cp -rf "$COREML_DIR_PATH/runtime/include/" "$INCLUDE_DIR_PATH"
@@ -49,12 +52,15 @@ mkdir -p "$EXECUTORCH_INCLUDE_DIR_PATH"
 find extension \( -name "*.h" -o -name "*.hpp" \) -exec rsync -R '{}' "$EXECUTORCH_INCLUDE_DIR_PATH" \;
 find runtime \( -name "*.h" -o -name "*.hpp" \) -exec rsync -R '{}' "$EXECUTORCH_INCLUDE_DIR_PATH" \;
 find util \( -name "*.h" -o -name "*.hpp" \) -exec rsync -R '{}' "$EXECUTORCH_INCLUDE_DIR_PATH" \;
+find sdk \( -name "*.h" -o -name "*.hpp" \) -exec rsync -R '{}' "$EXECUTORCH_INCLUDE_DIR_PATH" \;
 
 # Copy required libraries
 echo "ExecuTorch: Copying libraries"
 mkdir "$LIBRARIES_DIR_PATH"
 cp -f "$CMAKE_BUILD_DIR_PATH/libexecutorch.a" "$LIBRARIES_DIR_PATH"
+cp -f "$CMAKE_BUILD_DIR_PATH/sdk/libetdump.a" "$LIBRARIES_DIR_PATH"
 cp -f "$CMAKE_BUILD_DIR_PATH/backends/apple/coreml/libcoremldelegate.a" "$LIBRARIES_DIR_PATH"
+cp -f "$EXECUTORCH_ROOT_PATH/third-party/flatcc/lib/libflatccrt.a" "$LIBRARIES_DIR_PATH"
 
 # Build the runner
 echo "ExecuTorch: Building runner"

--- a/examples/apple/coreml/scripts/export_and_delegate.py
+++ b/examples/apple/coreml/scripts/export_and_delegate.py
@@ -3,6 +3,7 @@
 # Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
 import argparse
+import copy
 
 import pathlib
 import sys
@@ -13,6 +14,7 @@ from executorch.backends.apple.coreml.compiler import CoreMLBackend
 
 from executorch.exir.backend.backend_api import to_backend
 from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.sdk.etrecord import generate_etrecord
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent.parent.parent
 EXAMPLES_DIR = REPO_ROOT / "examples"
@@ -34,6 +36,11 @@ def lower_module_to_coreml(module, compute_units):
     edge = exir.capture(module, example_inputs, _CAPTURE_CONFIG).to_edge(
         _EDGE_COMPILE_CONFIG
     )
+    # All of the subsequent calls on the edge_dialect_graph generated above (such as delegation or
+    # to_executorch()) are done in place and the graph is also modified in place. For debugging purposes
+    # we would like to keep a copy of the original edge dialect graph and hence we create a deepcopy of
+    # it here that will later then be serialized into a etrecord.
+    edge_copy = copy.deepcopy(edge)
 
     lowered_module = to_backend(
         CoreMLBackend.__name__,
@@ -41,7 +48,7 @@ def lower_module_to_coreml(module, compute_units):
         [CompileSpec("compute_units", bytes(compute_units, "utf-8"))],
     )
 
-    return lowered_module
+    return lowered_module, edge_copy
 
 
 def export_lowered_module_to_executorch_program(lowered_module, example_inputs):
@@ -91,6 +98,8 @@ if __name__ == "__main__":
         help=f"Provide compute units. Valid ones: {compute_units}",
     )
 
+    parser.add_argument("--generate_etrecord", action=argparse.BooleanOptionalAction)
+
     parser.add_argument("--save_processed_bytes", action=argparse.BooleanOptionalAction)
 
     args = parser.parse_args()
@@ -111,7 +120,7 @@ if __name__ == "__main__":
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 
-    lowered_module = lower_module_to_coreml(
+    lowered_module, edge_copy = lower_module_to_coreml(
         model,
         args.compute_units,
     )
@@ -122,6 +131,7 @@ if __name__ == "__main__":
     )
 
     save_executorch_program(exec_program, args.model_name, args.compute_units)
+    generate_etrecord(f"{args.model_name}_coreml_etrecord.bin", edge_copy, exec_program)
 
     if args.save_processed_bytes:
         save_processed_bytes(


### PR DESCRIPTION
Differential Revision: D51990610

```bash
# Should see mv3_coreml_etrecord.bin generated after this command.
python3 -m examples.apple.coreml.scripts.export_and_delegate --model_name mv3 --generate_etrecord
# Build coreml runner
sh examples/apple/coreml/scripts/build_executor_runner.sh
# Should see etdump.etdp generated in this folder after running this command.
./coreml_executor_runner --model_path mv3_coreml_all.pte
# Run the inspector cli tool to print the profiling results
python3 -m sdk.inspector.inspector_cli --etdump_path etdump.etdp --etrecord_path mv3_coreml.bin 
╒════╤════════════════════╤══════════════════════╤════════════╤════════════╤════════════╤════════════╤════════════╤════════════╤════════════╤═══════════════════╤═════════════════════════╕
│    │ event_block_name   │ event_name           │   p10 (ms) │   p50 (ms) │   p90 (ms) │   avg (ms) │   min (ms) │   max (ms) │ op_types   │ is_delegated_op   │ delegate_backend_name   │
╞════╪════════════════════╪══════════════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪═══════════════════╪═════════════════════════╡
│  0 │ Default            │ Method::init         │  87.4569   │  87.4569   │  87.4569   │  87.4569   │  87.4569   │  87.4569   │ []         │ False             │                         │
├────┼────────────────────┼──────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼───────────────────┼─────────────────────────┤
│  1 │ Default            │ Program::load_method │  87.4654   │  87.4654   │  87.4654   │  87.4654   │  87.4654   │  87.4654   │ []         │ False             │                         │
├────┼────────────────────┼──────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼───────────────────┼─────────────────────────┤
│  2 │ Execute            │ DELEGATE_CALL        │   0.893667 │   0.893667 │   0.893667 │   0.893667 │   0.893667 │   0.893667 │ []         │ False             │                         │
├────┼────────────────────┼──────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼───────────────────┼─────────────────────────┤
│  3 │ Execute            │ Method::execute      │   0.895833 │   0.895833 │   0.895833 │   0.895833 │   0.895833 │   0.895833 │ []         │ False             │                         │
╘════╧════════════════════╧══════════════════════╧════════════╧════════════╧════════════╧════════════╧════════════╧════════════╧════════════╧═══════════════════╧═════════════════════════╛
```

