### PR TITLE
[flatbuffer] Pass extract_constant_segment through

### DIFF
--- a/examples/portable/scripts/export.py
+++ b/examples/portable/scripts/export.py
@@ -12,6 +12,7 @@ import logging
 from ...models import MODEL_NAME_TO_MODEL
 from ...models.model_factory import EagerModelFactory
 from ..utils import export_to_exec_prog, save_pte_program
+from executorch.exir.capture._config import ExecutorchBackendConfig
 
 
 FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
@@ -40,7 +41,9 @@ def main() -> None:
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 
-    prog = export_to_exec_prog(model, example_inputs)
+    #prog = export_to_exec_prog(model, example_inputs)
+    prog = export_to_exec_prog(model, example_inputs, backend_config=ExecutorchBackendConfig(extract_constant_segment=True))
+
     save_pte_program(prog.buffer, args.model_name, args.output_dir)
 
 

--- a/exir/_serialize/_program.py
+++ b/exir/_serialize/_program.py
@@ -611,6 +611,7 @@ def serialize_pte_binary(
             base_offset=segment_base_offset,
         )
 
+    print(f"serialize_pte_binary: segments {segments}, program.segments {program.segments}")
     return program_data
 
 

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -271,6 +271,7 @@ class ExirExportedProgram:
             new_prog,
             emit_stacktrace=config.emit_stacktrace,
             extract_delegate_segments=config.extract_delegate_segments,
+            extract_constant_segment=config.extract_constant_segment,
             segment_alignment=config.segment_alignment,
             constant_tensor_alignment=config.constant_tensor_alignment,
             delegate_alignment=config.delegate_alignment,
@@ -602,6 +603,7 @@ class MultiMethodExecutorchProgram:
         executorch_dialect_program: "MultiMethodExirExportedProgram",
         emit_stacktrace: bool,
         extract_delegate_segments: bool,
+        extract_constant_segment: bool,
         segment_alignment: int,
         constant_tensor_alignment: Optional[int] = None,
         delegate_alignment: Optional[int] = None,
@@ -618,6 +620,7 @@ class MultiMethodExecutorchProgram:
         )
         self._executorch_dialect_ir_program = executorch_dialect_program
         self._extract_delegate_segments: bool = extract_delegate_segments
+        self._extract_constant_segment: bool = extract_constant_segment
         self._segment_alignment: int = segment_alignment
         self._constant_tensor_alignment: Optional[int] = constant_tensor_alignment
         self._delegate_alignment: Optional[int] = delegate_alignment
@@ -629,6 +632,7 @@ class MultiMethodExecutorchProgram:
             self._buffer = _serialize_pte_binary(
                 program=self._emitter_output.program,
                 extract_delegate_segments=self._extract_delegate_segments,
+                extract_constant_segment=self._extract_constant_segment,
                 segment_alignment=self._segment_alignment,
                 constant_tensor_alignment=self._constant_tensor_alignment,
                 delegate_alignment=self._delegate_alignment,
@@ -680,6 +684,7 @@ def multi_method_program_to_executorch(
         executorch_dialect_program=MultiMethodExirExportedProgram(res),
         emit_stacktrace=config.emit_stacktrace,
         extract_delegate_segments=config.extract_delegate_segments,
+        extract_constant_segment=config.extract_constant_segment,
         segment_alignment=config.segment_alignment,
         constant_tensor_alignment=config.constant_tensor_alignment,
         delegate_alignment=config.delegate_alignment,

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -299,6 +299,7 @@ class ExecutorchProgram:
         exir_exported_program: ExirExportedProgram,
         emit_stacktrace: bool,
         extract_delegate_segments: bool,
+        extract_constant_segment: bool,
         segment_alignment: int,
         constant_tensor_alignment: Optional[int] = None,
         delegate_alignment: Optional[int] = None,
@@ -312,6 +313,7 @@ class ExecutorchProgram:
         self._emitter_output: Optional[EmitterOutput] = None
         self._emit_stacktrace: bool = emit_stacktrace
         self._extract_delegate_segments: bool = extract_delegate_segments
+        self._extract_constant_segment: bool = extract_constant_segment
         self._segment_alignment: int = segment_alignment
         self._constant_tensor_alignment: Optional[int] = constant_tensor_alignment
         self._delegate_alignment: Optional[int] = delegate_alignment
@@ -322,6 +324,7 @@ class ExecutorchProgram:
             self._buffer = _serialize_pte_binary(
                 program=self.program,
                 extract_delegate_segments=self._extract_delegate_segments,
+                extract_constant_segment=self._extract_constant_segment,
                 segment_alignment=self._segment_alignment,
                 constant_tensor_alignment=self._constant_tensor_alignment,
                 delegate_alignment=self._delegate_alignment,
@@ -924,7 +927,6 @@ class EdgeProgramManager:
             after it has been transformed to the ExecuTorch backend.
         """
         config = config if config else ExecutorchBackendConfig()
-
         execution_programs: Dict[str, ExportedProgram] = {}
         for name, program in self._edge_programs.items():
             new_gm = program.graph_module
@@ -1005,6 +1007,7 @@ class ExecutorchProgramManager:
         self._buffer: bytes = _serialize_pte_binary(
             program=self._emitter_output.program,
             extract_delegate_segments=backend_config.extract_delegate_segments,
+            extract_constant_segment=backend_config.extract_constant_segment,
             segment_alignment=backend_config.segment_alignment,
             constant_tensor_alignment=backend_config.constant_tensor_alignment,
             delegate_alignment=backend_config.delegate_alignment,


### PR DESCRIPTION
Enable using `extract_constant_segment` in `ExecutorchBackendConfig`

Test: pip install . && python -m examples.portable.scripts.export --model_name="llama2"