### PR TITLE
Attempt to fix flaky cmake missing libzstd issue on MacOS

### DIFF
--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -125,8 +125,8 @@ if [[ -z "${GITHUB_RUNNER:-}" ]]; then
   install_sccache
 fi
 
-install_pytorch_and_domains
 print_cmake_info
+install_pytorch_and_domains
 install_flatc_from_source
 install_executorch
 build_executorch_runner "${BUILD_TOOL}"


### PR DESCRIPTION
A minor tweak to apply the cmake fix I have in `print_cmake_info` before building PyTorch and domains from source.  I suspect that this helps address the flaky cmake missing libzstd issue on MacOS, i.e. https://github.com/pytorch/executorch/actions/runs/7150273250/job/19473394440