### PR TITLE
[cmake] Build xtensa example runner separately

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,9 +118,6 @@ option(EXECUTORCH_BUILD_XNNPACK
 option(EXECUTORCH_BUILD_SDK
        "Build the ExecuTorch SDK library and the SDK example runner.")
 
-option(EXECUTORCH_BUILD_XTENSA_EXAMPLE
-       "Build the example targeted for the Xtensa Hifi4 DSP" OFF)
-
 # Build mps_executor_runner which depends on MPSGraph framework
 option(EXECUTORCH_BUILD_MPS "Build mps_executor_runner which depends on MPS"
        OFF)
@@ -353,10 +350,6 @@ endif()
 # Add size test subdirectory
 if(EXECUTORCH_BUILD_SIZE_TEST)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/test)
-endif()
-
-if(EXECUTORCH_BUILD_XTENSA_EXAMPLE)
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples/xtensa)
 endif()
 
 # Print all summary

--- a/docs/source/build-run-xtensa.md
+++ b/docs/source/build-run-xtensa.md
@@ -133,11 +133,26 @@ In order to run the CMake build, you need the path to the following:
 
 ```bash
 cd executorch
-mkdir cmake-xt
-cd cmake-xt
-cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../examples/xtensa/xtensa.cmake -DMODEL_PATH=<path_to_program_file_generated_in_previous_step> -DNXP_SDK_ROOT_DIR=<path_to_nxp_sdk_root> -DEXECUTORCH_BUILD_FLATC=0 -DFLATC_EXECUTABLE="$(which flatc)" -DEXECUTORCH_BUILD_XTENSA_EXAMPLE=1 -DNN_LIB_BASE_DIR=<path_to_nnlib_cloned_in_step_2>  ..
-cd ..
-cmake --build cmake-xt -j8 -t xtensa_executorch_example
+rm -rf cmake-out
+# prebuild and install executorch library
+cmake -DBUCK2=buck2 \
+    -DCMAKE_INSTALL_PREFIX=cmake-out \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DPYTHON_EXECUTABLE=python3 \
+    -Bcmake-out .
+
+cmake --build cmake-out -j8 --target install --config Debug
+# build xtensa runner
+cmake -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_TOOLCHAIN_FILE=../examples/xtensa/xtensa.cmake \
+    -DMODEL_PATH=<path_to_program_file_generated_in_previous_step> \
+    -DNXP_SDK_ROOT_DIR=<path_to_nxp_sdk_root> -DEXECUTORCH_BUILD_FLATC=0 \
+    -DFLATC_EXECUTABLE="$(which flatc)" \
+    -DNN_LIB_BASE_DIR=<path_to_nnlib_cloned_in_step_2> \
+    -Bcmake-out/examples/xtensa \
+    examples/xtensa
+
+cmake --build cmake-out/examples/xtensa -j8 -t xtensa_executorch_example
 ```
 
 After having succesfully run the above step you should see two binary files in their CMake output directory.

--- a/examples/xtensa/CMakeLists.txt
+++ b/examples/xtensa/CMakeLists.txt
@@ -19,6 +19,9 @@ if(NOT EXECUTORCH_ROOT)
   set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 endif()
 
+# Find prebuilt executorch lib
+find_package(executorch CONFIG REQUIRED)
+
 add_compile_options(
   -DSDK_DEBUGCONSOLE=1
   -DSERIAL_PORT_TYPE_UART=1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1403
* #1402
* #1395
* __->__ #1394
* #1393
* #1392
* #1381
* #1380

Summary: Remove xtensa example option from root level CMakeLists.txt

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D52055858](https://our.internmc.facebook.com/intern/diff/D52055858)