### PR TITLE
error out when tag input/output node

### DIFF
--- a/exir/backend/test/test_partitioner.py
+++ b/exir/backend/test/test_partitioner.py
@@ -29,6 +29,7 @@ from executorch.exir.backend.utils import get_delegates
 
 from executorch.exir.tests.models import MLP
 from torch._export import capture_pre_autograd_graph
+from torch._export.utils import is_buffer, is_param
 from torch.export import export
 from torch.fx.passes.operator_support import any_chain
 
@@ -98,3 +99,79 @@ class TestPartitioner(unittest.TestCase):
             "can't set attribute 'spec'",
         ):
             my_partitioner.spec = {"new_key": "new_value"}
+
+    def test_bad_partitioner_tagged_output(self):
+        # Create a bad partitioner to tag output, which is not allowed.
+        class PartitionerTagOutput(Partitioner):
+            def __init__(self) -> None:
+                super().__init__()
+                self.delegation_spec = DelegationSpec(
+                    ExecutorBackend.__name__,
+                    [CompileSpec(key, value) for key, value in self.spec.items()],
+                )
+
+            def partition(
+                self, edge_exported_program: ExportedProgram
+            ) -> PartitionResult:
+                partition_tags = {}
+                for node in edge_exported_program.graph.nodes:
+                    if node.op == "output":
+                        delegation_tag = "tag0"
+                        node.meta["delegation_tag"] = delegation_tag
+                        partition_tags[delegation_tag] = self.delegation_spec
+
+                return PartitionResult(
+                    tagged_exported_program=edge_exported_program,
+                    partition_tags=partition_tags,
+                )
+
+        mlp = MLP()
+        example_inputs = mlp.get_random_inputs()
+        model = capture_pre_autograd_graph(mlp, example_inputs)
+        aten = export(model, example_inputs)
+        edge = exir.to_edge(aten)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "output node output should not be tagged",
+        ):
+            _ = edge.to_backend(PartitionerTagOutput())
+
+    def test_bad_partitioner_tagged_model_input(self):
+        # Create a bad partitioner to tag an input that is neither params nor buffer, which is not allowed.
+        class PartitionerTagInput(Partitioner):
+            def __init__(self) -> None:
+                super().__init__()
+                self.delegation_spec = DelegationSpec(
+                    ExecutorBackend.__name__,
+                    [CompileSpec(key, value) for key, value in self.spec.items()],
+                )
+
+            def partition(
+                self, edge_exported_program: ExportedProgram
+            ) -> PartitionResult:
+                partition_tags = {}
+                for node in edge_exported_program.graph.nodes:
+                    if node.op == "placeholder":
+                        if not is_param(edge_exported_program, node) and not is_buffer(
+                            edge_exported_program, node
+                        ):
+                            delegation_tag = "tag_" + str(node.meta["debug_handle"])
+                            node.meta["delegation_tag"] = delegation_tag
+                            partition_tags[delegation_tag] = self.delegation_spec
+
+                return PartitionResult(
+                    tagged_exported_program=edge_exported_program,
+                    partition_tags=partition_tags,
+                )
+
+        mlp = MLP()
+        example_inputs = mlp.get_random_inputs()
+        model = capture_pre_autograd_graph(mlp, example_inputs)
+        edge = exir.to_edge(export(model, example_inputs))
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "placeholder node for non-params and non-buffer should not be tagged",
+        ):
+            _ = edge.to_backend(PartitionerTagInput())


### PR DESCRIPTION
Summary: coreml is working on adding partitioner and they accidently tag output node. The stack trace is not straightforward to read. We can add an assertion early to point user what goes wrong.

Reviewed By: tarun292

Differential Revision: D52060445


