### PR TITLE
Update memory plan default to use ConstraintBased instead of HintBased

### DIFF
--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 from executorch.exir.dynamic_shape import DynamicMemoryPlanningMode
 from executorch.exir.pass_manager import PassType
 from executorch.exir.passes import MemoryPlanningPass, ToOutVarPass
-from executorch.exir.passes.sym_shape_eval_pass import HintBasedSymShapeEvalPass
+from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
 from executorch.exir.tracer import ExirDynamoConfig
 from torch.fx._compatibility import compatibility
 
@@ -70,4 +70,4 @@ class ExecutorchBackendConfig:
     # If provided, the minimum alignment of delegate data in the program. Must
     # be a power of 2. If not provided, uses the value in the schema file.
     delegate_alignment: Optional[int] = None
-    sym_shape_eval_pass: PassType = HintBasedSymShapeEvalPass()
+    sym_shape_eval_pass: PassType = ConstraintBasedSymShapeEvalPass()

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -489,14 +489,9 @@ class TestEmit(unittest.TestCase):
                 return torch.nn.functional.interpolate(x, scale_factor=2)
 
         x = (torch.randn(1, 1, 2, 2),)
-        program = (
-            to_edge(export(M(), x))
-            .transform([ConstPropPass()])
-            .to_executorch()
-            .executorch_program
-        )
+        program = to_edge(export(M(), x)).to_executorch().executorch_program
         self.assertIsInstance(
-            program.execution_plan[0].values[4].val, schema.OptionalTensorList
+            program.execution_plan[0].values[28].val, schema.OptionalTensorList
         )
 
     def test_emit_cond(self) -> None:

--- a/test/end2end/exported_module.py
+++ b/test/end2end/exported_module.py
@@ -16,6 +16,7 @@ from executorch.exir.dynamic_shape import DynamicMemoryPlanningMode
 from executorch.exir.pass_manager import PassManager
 from executorch.exir.passes import (
     DebugPass,
+    HintBasedSymShapeEvalPass,
     MemoryPlanningPass,
     to_scratch_op_pass,
     ToOutVarPass,
@@ -163,6 +164,7 @@ class ExportedModule:
                         ),
                         to_scratch_op_pass,
                     ],
+                    sym_shape_eval_pass=HintBasedSymShapeEvalPass(),
                     dynamic_memory_planning_mode=dynamic_memory_planning_mode,
                     memory_planning_pass=memory_planning_pass,
                     to_out_var_pass=ToOutVarPass(ignore_to_out_var_failure),


### PR DESCRIPTION
Summary:
Hintbased uses whatever the inputs were while constraint based uses the constraints present in the program. Hint based doesnt seem to work for data dependent, and is a legacy pass before the constrain api was added.

There should only be one method to pass shape information about your program and that should be whatever export uses, executorch shouldnt have this concrete shape back door of hint based.

Reviewed By: tarun292

Differential Revision: D51905989


