### PR TITLE
Migrate pass tests

### DIFF
--- a/backends/xnnpack/test/passes/test_convert_to_linear.py
+++ b/backends/xnnpack/test/passes/test_convert_to_linear.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack.passes.convert_to_linear import ConvertToLinearPass
+from executorch.backends.xnnpack.test.tester import RunPasses, Tester
+
+
+class TestConvertToLinear(unittest.TestCase):
+    PassStage = RunPasses([ConvertToLinearPass])
+
+    def test_fp32_convert_to_linear(self):
+        in_sizes = [1, 4, 4]
+        input_sizes = [4, 37, 17]
+        output_sizes = [4, 17, 37]
+        bias_vals = [True, True, False]
+
+        for i, _ in enumerate(in_sizes):
+            in_size = int(in_sizes[i])
+            input_size = int(input_sizes[i])
+            output_size = int(output_sizes[i])
+            linear = torch.nn.Linear(input_size, output_size, bias=bias_vals[i])
+            inputs = (torch.randn(in_size, input_size),)
+
+            (
+                Tester(linear, inputs)
+                .export()
+                .to_edge()
+                .run_passes(self.PassStage)
+                .check_count(
+                    {"executorch_exir_dialects_edge__ops_aten_linear_default": 1}
+                )
+                .run_method()
+                .compare_outputs()
+            )

--- a/backends/xnnpack/test/passes/test_tag_implicit_q_dq_pass.py
+++ b/backends/xnnpack/test/passes/test_tag_implicit_q_dq_pass.py
@@ -1,0 +1,81 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack.passes.tag_implicit_q_dq_pass import TagImplicitQDqPass
+from executorch.backends.xnnpack.test.tester import RunPasses, Tester
+from executorch.exir.backend.canonical_partitioners.duplicate_dequant_node_pass import (
+    DuplicateDequantNodePass,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+class TestTagImplicitQDq(unittest.TestCase):
+    PassStage = RunPasses([DuplicateDequantNodePass, TagImplicitQDqPass])
+
+    class QDqModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            qparams = [0.12345, 0, -127, 127, torch.int8]
+            x = exir_ops.edge.quantized_decomposed.quantize_per_tensor.default(
+                x, *qparams
+            )
+            x = exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default(
+                x, *qparams
+            )
+            x = torch.add(x, x)
+            x = exir_ops.edge.quantized_decomposed.quantize_per_tensor.default(
+                x, *qparams
+            )
+            x = exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default(
+                x, *qparams
+            )
+            x = torch.mul(x, x)
+            x = exir_ops.edge.quantized_decomposed.quantize_per_tensor.default(
+                x, *qparams
+            )
+            x = exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default(
+                x, *qparams
+            )
+            x = torch.add(x, x)
+            x = torch.mul(x, x)
+            return x
+
+    def test_tag_implicit_q_dq_test(self):
+        inputs = (torch.randn(2, 3),)
+        artifact = (
+            Tester(self.QDqModule(), inputs)
+            .export()
+            .to_edge()
+            .run_passes(self.PassStage)
+            .run_method()
+            .compare_outputs()
+            .get_artifact(Tester.stage_name(self.PassStage))
+        )
+
+        for node in artifact.exported_program().module().graph.nodes:
+            print(
+                f"{node}: {node.meta.get(TagImplicitQDqPass.IS_IMPLICIT_Q_DQ_TAG, False)}"
+            )
+
+        # The six tagged nodes are:
+        # 1) The dq of the first add input
+        # 2) The dq of the second add input
+        # 3) The q of the add output
+        # 4) The dq of the first mul input
+        # 5) The dq of the second mul input
+        # 6) The q of the mul output
+        self.assertEqual(
+            sum(
+                node.meta.get(TagImplicitQDqPass.IS_IMPLICIT_Q_DQ_TAG, False)
+                for node in artifact.exported_program().module().graph.nodes
+            ),
+            6,
+        )

--- a/backends/xnnpack/test/tester/tester.py
+++ b/backends/xnnpack/test/tester/tester.py
@@ -320,19 +320,19 @@ class Tester:
         self.inputs = inputs
         self.stages: Dict[str, Stage] = OrderedDict.fromkeys(list(_stages_.keys()))
         self.pipeline = {
-            self._stage_name(Quantize): [self._stage_name(Export)],
-            self._stage_name(Export): [
-                self._stage_name(ToEdge),
+            self.stage_name(Quantize): [self.stage_name(Export)],
+            self.stage_name(Export): [
+                self.stage_name(ToEdge),
             ],
-            self._stage_name(ToEdge): [
-                self._stage_name(Partition),
-                self._stage_name(RunPasses),
+            self.stage_name(ToEdge): [
+                self.stage_name(Partition),
+                self.stage_name(RunPasses),
             ],
-            self._stage_name(RunPasses): [self._stage_name(Partition)],
+            self.stage_name(RunPasses): [self.stage_name(Partition)],
             # TODO Make this Stage optional
-            self._stage_name(Partition): [self._stage_name(ToExecutorch)],
-            self._stage_name(ToExecutorch): [self._stage_name(Serialize)],
-            self._stage_name(Serialize): [],
+            self.stage_name(Partition): [self.stage_name(ToExecutorch)],
+            self.stage_name(ToExecutorch): [self.stage_name(Serialize)],
+            self.stage_name(Serialize): [],
         }
         assert all(
             stage in self.pipeline for stage in self.stages
@@ -348,12 +348,12 @@ class Tester:
         self.stage_output = None
 
     @staticmethod
-    def _stage_name(stage) -> str:
+    def stage_name(stage) -> str:
         t = stage if isinstance(stage, type) else type(stage)
         return t.__qualname__
 
     def _pre(self, stage):
-        name: str = self._stage_name(stage)
+        name: str = self.stage_name(stage)
         assert isinstance(name, str) and name in self.stages and not self.stages[name]
 
         last_artifact = self.original_module
@@ -366,7 +366,7 @@ class Tester:
         return last_artifact
 
     def _post(self, stage):
-        name = self._stage_name(stage)
+        name = self.stage_name(stage)
         assert name in self.stages
         self.stages[name] = stage
 
@@ -432,7 +432,7 @@ class Tester:
     ):
         inputs_to_run = inputs or self.inputs
         # Reference Output
-        self.reference_output = self.stages[self._stage_name(Export)].run_artifact(
+        self.reference_output = self.stages[self.stage_name(Export)].run_artifact(
             inputs_to_run
         )
 


### PR DESCRIPTION
Summary: Migrate XNNPACK pass tests to use new test harness and move to test/passes/ directory.

Reviewed By: digantdesai

Differential Revision: D52082130


