### PR TITLE
Remove extra semi colon from executorch/extension/pytree/pytree.h

### DIFF
--- a/extension/pytree/pytree.h
+++ b/extension/pytree/pytree.h
@@ -664,12 +664,12 @@ ContainerHandle<T, Aux> unflatten(const TreeSpec<Aux>& spec, T* leaves) {
     refresh_leaves_num(spec);
   }
   return clone(spec, leaves);
-};
+}
 
 template <typename T, typename Aux = Empty>
 ContainerHandle<T, Aux> unflatten(const StrTreeSpec& spec, T* leaves) {
   return unflatten(from_str<Aux>(spec), leaves);
-};
+}
 
 template <typename T, typename Aux>
 void flatten_internal(const ContainerHandle<T, Aux>& tree, const T** leaves) {

--- a/runtime/backend/interface.cpp
+++ b/runtime/backend/interface.cpp
@@ -12,7 +12,7 @@
 namespace torch {
 namespace executor {
 
-PyTorchBackendInterface::~PyTorchBackendInterface(){};
+PyTorchBackendInterface::~PyTorchBackendInterface() {}
 
 // Task t128866626: Remove global static variables.
 // We want to be able to run multiple Executor instances


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51995014


