### PR TITLE
add oncall annotation for TARGETS files in fbcode based on contbuild information - /data/users/bayarmunkh/target_oncalls_11_pytorch

### DIFF
--- a/profiler/TARGETS
+++ b/profiler/TARGETS
@@ -3,6 +3,8 @@
 
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 runtime.python_library(
     name = "parse_profiler_library",
     srcs = [

--- a/schema/TARGETS
+++ b/schema/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/util/TARGETS
+++ b/util/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()


### PR DESCRIPTION
Summary:
This diff adds oncall to Buck TARGETS files in fbcode repository based on their contbuild information.
This diff was generated by this command:
  ./fbcode/ownership/coverage/submit_diff_with_file_oncall_mapping.sh /data/users/bayarmunkh/target_oncalls_14
see more context here: https://fb.workplace.com/groups/fbcode/posts/6551897871513663 and https://fb.workplace.com/groups/fbcode.devx/permalink/3149549092006627/
drop_conflicts

Differential Revision: D52122373


