### PR TITLE
Fix Dynamic QLinear with new XNNPACK Version

### DIFF
--- a/backends/xnnpack/runtime/XNNExecutor.cpp
+++ b/backends/xnnpack/runtime/XNNExecutor.cpp
@@ -7,80 +7,40 @@
  */
 
 #include <executorch/backends/xnnpack/runtime/XNNExecutor.h>
-#ifdef ENABLE_DYNAMIC_QUANTIZATION
-#include <executorch/backends/xnnpack/runtime/utils/utils.h>
-#endif
 
 namespace torch {
 namespace executor {
 namespace xnnpack {
 namespace delegate {
 
-Error XNNExecutor::set_external_input(uint32_t id, Tensor* input) {
-  auto qinput_pair = qinputs_.find(id);
-  if (qinput_pair != qinputs_.end()) {
-#ifdef ENABLE_DYNAMIC_QUANTIZATION
-    auto qinput = qinput_pair->second;
-    // dq the input and copy it in to qinput
-    float input_min, input_max;
-    std::tie(input_min, input_max) = qnnpack_utils::GetMinMax(*input);
-
-    qnnpack_utils::QuantizationParams input_qparam;
-
-    int8_t qmin = std::numeric_limits<int8_t>::min();
-    int8_t qmax = std::numeric_limits<int8_t>::max();
-    Error e = qnnpack_utils::ChooseQuantizationParams(
-        input_min,
-        input_max,
-        qmin,
-        qmax,
-        input_qparam,
-        false, /* preserve_sparsity */
-        false, /* force_scale_power_of_two */
-        false /* reduce_range */
-    );
-    ET_CHECK_OR_RETURN_ERROR(
-        e == Error::Ok, Internal, "ChooseQuantizationParams() failed");
-
-    ET_CHECK_OR_RETURN_ERROR(
-        input_qparam.zero_point <= qmax && input_qparam.zero_point >= qmin,
-        Internal,
-        "ChooseQuantizationParams() selected invalid input_zero_point: %d",
-        input_qparam.zero_point);
-
-    e = qnnpack_utils::QuantizePerTensor<int8_t>(
-        *input, qinput, input_qparam.scale, input_qparam.zero_point);
-
-    size_t batch_size = 1;
-    for (int i = 0; i < input->dim() - 1; i++) {
-      batch_size *= input->size(i);
+Error XNNExecutor::set_external_input(
+    uint32_t id,
+    Tensor* input,
+    struct XNNShape* shape) {
+  // TODO(T165403530): Test insure accuracy for int64 --> float32 conversion
+  if (input->scalar_type() == ScalarType::Long) {
+    // Input data type is int64. However, XNNPACK doesn't support
+    // int64. This means that the data needs to be casted to float
+    // In order for XNNPACK to properly use it.
+    const int64_t* data_64 = input->const_data_ptr<int64_t>();
+    float* data_f32 = input->mutable_data_ptr<float>();
+    for (int j = 0; j < input->numel(); j++) {
+      data_f32[j] = data_64[j];
     }
-    ET_CHECK_OR_RETURN_ERROR(
-        e == Error::Ok, Internal, "QuantizePerTensor() failed");
-    externals_.emplace_back(xnn_external_value{
-        id,
-        qinput.mutable_data_ptr(),
-        {static_cast<float>(input_qparam.scale),
-         static_cast<int8_t>(input_qparam.zero_point)},
-        batch_size});
-#else
-    ET_LOG(Error, "Dynamic Quantization is not supported");
-    return Error::NotSupported;
-#endif
-  } else {
-    // TODO(T165403530): Test insure accuracy for int64 --> float32 conversion
-    if (input->scalar_type() == ScalarType::Long) {
-      // Input data type is int64. However, XNNPACK doesn't support
-      // int64. This means that the data needs to be casted to float
-      // In order for XNNPACK to properly use it.
-      const int64_t* data_64 = input->const_data_ptr<int64_t>();
-      float* data_f32 = input->mutable_data_ptr<float>();
-      for (int j = 0; j < input->numel(); j++) {
-        data_f32[j] = data_64[j];
-      }
-    }
-    externals_.emplace_back(xnn_external_value{id, input->mutable_data_ptr()});
   }
+  if (input->dim() != shape->num_dims) {
+    ET_LOG(Error, "Input dim mismatch between tensor and shape struct");
+  }
+
+#ifdef ENABLE_DYNAMIC_QUANTIZATION
+  externals_.emplace_back(xnn_external_value{
+      id,
+      input->mutable_data_ptr(),
+      static_cast<size_t>(shape->num_dims),
+      shape->dim});
+#else
+  externals_.emplace_back(xnn_external_value{id, input->mutable_data_ptr()});
+#endif
   return Error::Ok;
 }
 

--- a/backends/xnnpack/test/test_xnnpack_quantized.py
+++ b/backends/xnnpack/test/test_xnnpack_quantized.py
@@ -601,11 +601,13 @@ class TestXNNPACKQuantized(TestXNNPACK):
             example_inputs,
         )
 
+    @unittest.skip("Dynamic Per Tensor Quantization is not supported yet")
     def test_xnnpack_dqlinear_mm_per_tensor(self):
         self._test_xnnpack_dqlinear(
             weight_qconfig=weight_observer_range_neg_127_to_127, use_bias=False
         )
 
+    @unittest.skip("Dynamic Per Tensor Quantization is not supported yet")
     def test_xnnpack_dqlinear_addmm_per_tensor(self):
         self._test_xnnpack_dqlinear(
             weight_qconfig=weight_observer_range_neg_127_to_127, use_bias=True
@@ -623,11 +625,13 @@ class TestXNNPACKQuantized(TestXNNPACK):
             use_bias=True,
         )
 
+    @unittest.skip("Dynamic Per Tensor Quantization is not supported yet")
     def test_xnnpack_dqlinear_partitioner_mm_per_tensor(self):
         self._test_xnnpack_dqlinear_with_partitioner(
             weight_qconfig=weight_observer_range_neg_127_to_127, use_bias=False
         )
 
+    @unittest.skip("Dynamic Per Tensor Quantization is not supported yet")
     def test_xnnpack_dqlinear_partitioner_addmm_per_tensor(self):
         self._test_xnnpack_dqlinear_with_partitioner(
             weight_qconfig=weight_observer_range_neg_127_to_127, use_bias=True

--- a/backends/xnnpack/test/test_xnnpack_utils.py
+++ b/backends/xnnpack/test/test_xnnpack_utils.py
@@ -461,7 +461,7 @@ class TestXNNPACK(unittest.TestCase):
 
         # Compare the result from executor and eager mode directly
         self.assertTrue(
-            torch.allclose(model_output[0], ref_output, atol=1e-03, rtol=1e-03)
+            torch.allclose(model_output[0], ref_output, atol=4e-03, rtol=1e-03)
         )
 
     def _get_dqlinear_graph_module(self, weight_qconfig, linear, example_inputs):
@@ -518,7 +518,7 @@ class TestXNNPACK(unittest.TestCase):
         self, LinearModule, example_inputs
     ):
         linear = LinearModule()
-        weight_qconfig = weight_observer_range_neg_127_to_127
+        weight_qconfig = per_channel_weight_observer_range_neg_127_to_127
         converted_dqlinear = self._get_dqlinear_graph_module(
             weight_qconfig, linear, example_inputs
         )


### PR DESCRIPTION
Summary:
Without Digants patches due to new xnnpack commit, we need to rewire XNNPACK delegate to support old DQ Linear path. which is from dq-datatype.
The diff stack this contains is from D51878934 to D51927294. Those diffs are seperated for the sake of reviewability, but all changes are required in order
for CI to properly pass. This diff should actually be merged with the diff preceding it, but because ghexport does not work on both PyTorch and ExecuTorch
repo and the diff is too large to get the phabricator button, seperate in order to export for ExecuTorch and for PyTorch

allow-large-files

Reviewed By: digantdesai

Differential Revision: D52099774

