### PR TITLE
[llama] Custom Llama2 export script

### DIFF
--- a/examples/models/llama2/README.md
+++ b/examples/models/llama2/README.md
@@ -14,8 +14,8 @@ Please note that the models are subject to the [acceptable use policy](https://g
 
 # Notes
 1. This example is to show the feasibility of exporting a Llama2 model in ExecuTorch. There is no guarantee for performance.
-2. It's targeted to a reasonable size for edge devices. Depending on the model size, the memory usage of exporting the model can be high. Please see [GitHub issue: Improve memory usage in EXIR emitter](https://github.com/pytorch/executorch/issues/885).
-3. The provided check point, demo_rand_params.pth is a dummy checkpoint with random parameters. It does not provide meaningful results. It's only for the purpose of demonstration and fast iterations.
+2. The provided checkpoint, demo_rand_params.pth is a dummy checkpoint with random parameters. It does not provide meaningful results. It's only for the purpose of demonstration and fast iterations.  Use the options `--checkpoint <checkpoint>` and `--params <params>` for custom checkpoints.
+
 
 # Limitations
 This example tries to reuse the Python code, with modifications to make it compatible with current ExecuTorch:
@@ -29,4 +29,5 @@ This example tries to reuse the Python code, with modifications to make it compa
 1. Follow the [tutorial](https://pytorch.org/executorch/stable/getting-started-setup) to set up ExecuTorch
 2. `cd examples/third-party/llama`
 3. `pip install -e .`
-4. Go back to `executorch` root, run `python3 -m examples.portable.scripts.export --model_name="llama2"`. The exported program, llama2.pte would be saved in current directory
+4. Go back to `executorch` root, run `python3 -m examples.models.llama2.export_llama`. The exported program, llama2.pte would be saved in current directory using the dummy checkpoint.
+5. Llama2 pretrained parameters can be downloaded [here](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and run with `python3 -m examples.models.llama2.export_llama --checkpoint <checkpoint.pth> --params <params.json>`.

--- a/examples/models/llama2/export_llama.py
+++ b/examples/models/llama2/export_llama.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Example script for exporting Llama2 to flatbuffer
+
+import argparse
+import logging
+
+from executorch.exir.capture._config import ExecutorchBackendConfig
+
+from ...portable.utils import export_to_exec_prog, save_pte_program
+
+from ..model_factory import EagerModelFactory
+
+
+FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-o", "--output_dir", default=".", help="output directory")
+    parser.add_argument(
+        "-c", "--checkpoint", default="demo_rand_params.pth", help="checkpoint.pth"
+    )
+    parser.add_argument(
+        "-p", "--params", default="demo_config.json", help="config.json"
+    )
+
+    args = parser.parse_args()
+
+    model, example_inputs = EagerModelFactory.create_model(
+        "llama2", "Llama2Model", checkpoint=args.checkpoint, params=args.params
+    )
+
+    prog = export_to_exec_prog(
+        model,
+        example_inputs,
+        backend_config=ExecutorchBackendConfig(extract_constant_segment=True),
+    )
+
+    save_pte_program(prog.buffer, "llama2", args.output_dir)
+
+
+if __name__ == "__main__":
+    main()  # pragma: no cover

--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -193,15 +193,15 @@ class Transformer(nn.Module):
 
 
 class Llama2Model(EagerModelBase):
-    def __init__(self):
+    def __init__(self, **kwargs):
         ckpt_dir = Path(__file__).absolute().parent
         # The example is using a dummy small model with random weights for demo purpose only.
         # Follow the instruction in https://github.com/facebookresearch/llama to download the model
         device = "cpu"
         checkpoint = torch.load(
-            Path(ckpt_dir) / "demo_rand_params.pth", map_location=device
+            Path(ckpt_dir) / kwargs["checkpoint"], map_location=device
         )
-        with open(Path(ckpt_dir) / "demo_config.json", "r") as f:
+        with open(Path(ckpt_dir) / kwargs["params"], "r") as f:
             params = json.loads(f.read())
         max_seq_len = 128
         max_batch_size = 1

--- a/examples/models/model_factory.py
+++ b/examples/models/model_factory.py
@@ -17,7 +17,9 @@ class EagerModelFactory:
     """
 
     @staticmethod
-    def create_model(module_name, model_class_name) -> Tuple[torch.nn.Module, Any]:
+    def create_model(
+        module_name, model_class_name, **kwargs
+    ) -> Tuple[torch.nn.Module, Any]:
         """
         Create an instance of a model class that implements EagerModelBase and retrieve related data.
 
@@ -38,7 +40,7 @@ class EagerModelFactory:
 
         if hasattr(module, model_class_name):
             model_class = getattr(module, model_class_name)
-            model = model_class()
+            model = model_class(**kwargs)
             return model.get_eager_model(), model.get_example_inputs()
 
         raise ValueError(


### PR DESCRIPTION
Enable llama export with custom weights (.pth) and config (.json)

Run with `python3 -m examples.models.llama2.export_llama --checkpoint "demo_rand_params.pth" --params "demo_config.json"`
