### PR TITLE
[Core ML] Add a Rudimentary Core ML Partitioner

### DIFF
--- a/backends/apple/coreml/partition/coreml_partitioner.py
+++ b/backends/apple/coreml/partition/coreml_partitioner.py
@@ -1,0 +1,70 @@
+# Copyright © 2023 Apple Inc. All rights reserved.
+#
+# Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+import logging
+from typing import List
+
+import torch
+from torch._export.exported_program import ExportedProgram
+from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
+from torch.fx.passes.operator_support import OperatorSupportBase
+
+from executorch.exir.backend.partitioner import (
+    DelegationSpec,
+    Partitioner,
+    PartitionResult,
+)
+from executorch.backends.apple.coreml.compiler.coreml_preprocess import CoreMLBackend
+
+from coremltools.converters.mil.frontend.torch.torch_op_registry import is_torch_fx_node_supported
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
+
+
+class OperatorsSupportedForCoreMLBackend(OperatorSupportBase):
+    def __init__(self, skip_ops: List[str] = []) -> None:
+        super().__init__()
+        self.skip_ops = skip_ops
+
+    def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
+        # get_attr node can always be supported on any backend
+        if node.op == "get_attr":
+            return True
+        # check if the PyTorch op get called is supported in Core ML
+        elif node.op == "call_function":
+            return is_torch_fx_node_supported(node, self.skip_ops)
+        # cowardly refuse to support all other types of node
+        else:
+            return False
+
+
+class CoreMLPartitioner(Partitioner):
+    compile_spec = []
+
+    def __init__(self, skip_ops: List[str] = []) -> None:
+        self.skip_ops = skip_ops
+        self.delegation_spec = DelegationSpec("CoreMLBackend", self.compile_spec)
+
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
+        # Run the CapabilityBasedPartitioner to return the largest possible
+        # subgraphs containing the nodes with the tags
+        logger.info("CoreMLPartitioner::partition")
+        partition_tags = {}
+
+        capability_partitioner = CapabilityBasedPartitioner(
+            exported_program.graph_module,
+            OperatorsSupportedForCoreMLBackend(self.skip_ops),
+            allows_single_node_partition=True,
+        )
+        partition_list = capability_partitioner.propose_partitions()
+        for partition in partition_list:
+            for node in partition.nodes:
+                tag = f"tag{partition.id}"
+                node.meta["delegation_tag"] = tag
+                partition_tags[tag] = self.delegation_spec
+
+        return PartitionResult(
+            tagged_exported_program=exported_program, partition_tags=partition_tags
+        )

--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -38,7 +38,7 @@ class TestCoreMLPartitioner(unittest.TestCase):
 
         exported_to_coreml = to_backend(
             exported_program,
-            CoreMLPartitioner(skip_ops=["mm.default"]),
+            CoreMLPartitioner(skip_ops_for_coreml_delegation=["aten.mm.default"]),
         )
 
         assert [

--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -1,0 +1,53 @@
+# Copyright © 2023 Apple Inc. All rights reserved.
+#
+# Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+import unittest
+
+import torch
+
+import executorch.exir as exir
+from executorch.exir.backend.backend_api import to_backend
+
+from executorch.backends.apple.coreml.partition.coreml_partitioner import CoreMLPartitioner
+
+
+class TestCoreMLPartitioner(unittest.TestCase):
+    def test_partition_add_mul(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, a, x, b):
+                y = torch.mm(a, x)
+                z = y + b
+                a = z - a
+                y = torch.mm(a, x)
+                z = y + b
+                return z
+
+        model = Model()
+        inputs = (torch.randn(2, 2), torch.randn(2, 2), torch.randn(2, 2))
+        exported_program = exir.capture(model, inputs, exir.CaptureConfig()).to_edge().exported_program
+
+        assert [
+            node.target.__name__ for node in exported_program.graph.nodes if node.op == "call_function"
+        ] == [
+            "aten.mm.default", "aten.add.Tensor", "aten.sub.Tensor", "aten.mm.default", "aten.add.Tensor"
+        ]
+
+        exported_to_coreml = to_backend(
+            exported_program,
+            CoreMLPartitioner(skip_ops=["mm.default"]),
+        )
+
+        assert [
+            node.target.__name__ for node in exported_to_coreml.graph.nodes if node.op == "call_function"
+        ] == [
+            "aten.mm.default", "executorch_call_delegate", "getitem", "aten.mm.default", "executorch_call_delegate", "getitem"
+        ]
+
+
+if __name__ == "__main__":
+    test_runner = TestCoreMLPartitioner()
+    test_runner.test_partition_add_mul()


### PR DESCRIPTION
In this PR, we add a rudimentary Core ML partitioner based on `CapabilityBasedPartitioner`, which proposes possible partitions based on whether a PyTorch op can run on the specified backend, in our case, Core ML.

Any insights on potential ways to implement the Core ML partitioner are welcomed :pray:

The unit test has to be run with [this coremltools branch](https://github.com/apple/coremltools/pull/2081)