### PR TITLE
add oncall annotation for TARGETS files in fbcode based on contbuild information - /data/users/bayarmunkh/target_oncalls_26

### DIFF
--- a/backends/example/TARGETS
+++ b/backends/example/TARGETS
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 
+oncall("executorch")
+
 python_library(
     name = "example_quantizer",
     srcs = [

--- a/backends/example/example_backend_delegate_passes/TARGETS
+++ b/backends/example/example_backend_delegate_passes/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
+oncall("executorch")
+
 python_library(
     name = "lib",
     srcs = [

--- a/backends/example/example_operators/TARGETS
+++ b/backends/example/example_operators/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
+oncall("executorch")
+
 python_library(
     name = "example_operators_lib",
     srcs = [

--- a/backends/transforms/TARGETS
+++ b/backends/transforms/TARGETS
@@ -1,5 +1,7 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 runtime.python_library(
     name = "lib",
     srcs = [

--- a/backends/vulkan/TARGETS
+++ b/backends/vulkan/TARGETS
@@ -1,5 +1,7 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 runtime.cxx_library(
     name = "vulkan_backend_lib",
     srcs = [

--- a/backends/xnnpack/TARGETS
+++ b/backends/xnnpack/TARGETS
@@ -1,6 +1,8 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()
 
 runtime.python_library(

--- a/backends/xnnpack/operators/TARGETS
+++ b/backends/xnnpack/operators/TARGETS
@@ -1,5 +1,7 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 runtime.python_library(
     name = "operators",
     srcs = glob(["*.py"]),

--- a/backends/xnnpack/partition/TARGETS
+++ b/backends/xnnpack/partition/TARGETS
@@ -1,5 +1,7 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 runtime.python_library(
     name = "xnnpack_partitioner",
     srcs = [

--- a/backends/xnnpack/passes/TARGETS
+++ b/backends/xnnpack/passes/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
+oncall("executorch")
+
 python_library(
     name = "xnnpack_passes",
     srcs = [

--- a/backends/xnnpack/test/tester/TARGETS
+++ b/backends/xnnpack/test/tester/TARGETS
@@ -1,5 +1,7 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 runtime.python_library(
     name = "tester",
     srcs = [

--- a/backends/xnnpack/threadpool/TARGETS
+++ b/backends/xnnpack/threadpool/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/backends/xnnpack/utils/TARGETS
+++ b/backends/xnnpack/utils/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
+oncall("executorch")
+
 python_library(
     name = "xnnpack_utils",
     srcs = glob(["*.py"]),

--- a/exir/_serialize/test/TARGETS
+++ b/exir/_serialize/test/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 
+oncall("executorch")
+
 python_unittest(
     name = "program",
     srcs = [

--- a/exir/backend/TARGETS
+++ b/exir/backend/TARGETS
@@ -5,6 +5,8 @@ load("@fbsource//xplat/executorch/backends:backends.bzl", "get_all_cpu_aot_and_b
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()
 
 # Use runtime.python_library instead of the one defined in python_library.bzl,

--- a/exir/backend/canonical_partitioners/TARGETS
+++ b/exir/backend/canonical_partitioners/TARGETS
@@ -1,5 +1,7 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 runtime.python_library(
     name = "canonical_partitioner_lib",
     srcs = [

--- a/exir/capture/TARGETS
+++ b/exir/capture/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
+oncall("executorch")
+
 python_library(
     name = "lib",
     srcs = [

--- a/exir/dialects/TARGETS
+++ b/exir/dialects/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
+oncall("executorch")
+
 python_library(
     name = "lib",
     srcs = [

--- a/exir/dialects/backend/TARGETS
+++ b/exir/dialects/backend/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
+oncall("executorch")
+
 python_library(
     name = "lib",
     srcs = [

--- a/exir/dialects/test/TARGETS
+++ b/exir/dialects/test/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 
+oncall("executorch")
+
 python_unittest(
     name = "test_exir_dialect_ops",
     srcs = [

--- a/exir/emit/TARGETS
+++ b/exir/emit/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
+oncall("executorch")
+
 python_library(
     name = "lib",
     srcs = [

--- a/exir/emit/test/TARGETS
+++ b/exir/emit/test/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 
+oncall("executorch")
+
 python_unittest(
     # @autodeps-skip pybindings don't work well with autodeps
     name = "emit",

--- a/exir/experimental/TARGETS
+++ b/exir/experimental/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
+oncall("executorch")
+
 python_library(
     name = "export_pt2",
     srcs = ["export_pt2.py"],

--- a/exir/program/TARGETS
+++ b/exir/program/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
+oncall("executorch")
+
 python_library(
     name = "lib",
     srcs = [

--- a/exir/program/test/TARGETS
+++ b/exir/program/test/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 
+oncall("executorch")
+
 python_unittest(
     # @autodeps-skip pybindings don't work well with autodeps
     name = "test_program",

--- a/extension/aten_util/TARGETS
+++ b/extension/aten_util/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/extension/aten_util/test/TARGETS
+++ b/extension/aten_util/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/extension/data_loader/TARGETS
+++ b/extension/data_loader/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/extension/data_loader/test/TARGETS
+++ b/extension/data_loader/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/extension/evalue_util/test/TARGETS
+++ b/extension/evalue_util/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/extension/memory_allocator/TARGETS
+++ b/extension/memory_allocator/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/extension/pytree/aten_util/TARGETS
+++ b/extension/pytree/aten_util/TARGETS
@@ -2,4 +2,6 @@
 # targets.bzl. This file can contain fbcode-only targets.
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/extension/pytree/aten_util/test/TARGETS
+++ b/extension/pytree/aten_util/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/extension/testing_util/TARGETS
+++ b/extension/testing_util/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/extension/testing_util/test/TARGETS
+++ b/extension/testing_util/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/kernels/aten/test/TARGETS
+++ b/kernels/aten/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/kernels/optimized/test/TARGETS
+++ b/kernels/optimized/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/kernels/portable/TARGETS
+++ b/kernels/portable/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/kernels/portable/cpu/TARGETS
+++ b/kernels/portable/cpu/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets(is_fbcode = True)

--- a/kernels/portable/cpu/pattern/TARGETS
+++ b/kernels/portable/cpu/pattern/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/kernels/portable/cpu/test/TARGETS
+++ b/kernels/portable/cpu/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/kernels/portable/cpu/util/TARGETS
+++ b/kernels/portable/cpu/util/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/kernels/portable/cpu/util/test/TARGETS
+++ b/kernels/portable/cpu/util/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/kernels/portable/test/TARGETS
+++ b/kernels/portable/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/runtime/core/TARGETS
+++ b/runtime/core/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/runtime/core/exec_aten/TARGETS
+++ b/runtime/core/exec_aten/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/runtime/core/exec_aten/testing_util/TARGETS
+++ b/runtime/core/exec_aten/testing_util/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/runtime/core/exec_aten/testing_util/test/TARGETS
+++ b/runtime/core/exec_aten/testing_util/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/runtime/core/exec_aten/util/TARGETS
+++ b/runtime/core/exec_aten/util/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/runtime/core/exec_aten/util/test/TARGETS
+++ b/runtime/core/exec_aten/util/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/runtime/core/portable_type/TARGETS
+++ b/runtime/core/portable_type/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/runtime/core/portable_type/test/TARGETS
+++ b/runtime/core/portable_type/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/runtime/executor/TARGETS
+++ b/runtime/executor/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/runtime/platform/TARGETS
+++ b/runtime/platform/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/runtime/platform/test/TARGETS
+++ b/runtime/platform/test/TARGETS
@@ -3,4 +3,6 @@
 
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/sdk/bundled_program/schema/TARGETS
+++ b/sdk/bundled_program/schema/TARGETS
@@ -4,6 +4,8 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()
 
 runtime.python_library(

--- a/sdk/etdump/tests/TARGETS
+++ b/sdk/etdump/tests/TARGETS
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()
 
 python_unittest(

--- a/sdk/etrecord/TARGETS
+++ b/sdk/etrecord/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
+oncall("executorch")
+
 python_library(
     name = "etrecord",
     srcs = [

--- a/sdk/size_analysis_tool/TARGETS
+++ b/sdk/size_analysis_tool/TARGETS
@@ -2,6 +2,8 @@ load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 
+oncall("executorch")
+
 python_library(
     name = "size_analysis_tool_lib",
     srcs = [


### PR DESCRIPTION
Summary:
This diff adds oncall to Buck TARGETS files in fbcode repository based on their contbuild information.

This diff was generated by this command:
    ./fbcode/ownership/coverage/submit_diff_with_file_oncall_mapping.sh /data/users/bayarmunkh/target_oncalls_26

see more context here: https://fb.workplace.com/groups/fbcode/posts/6551897871513663 and https://fb.workplace.com/groups/fbcode.devx/permalink/3149549092006627/

drop_conflicts

Differential Revision: D52150100

