### PR TITLE
Skip Tensor Debug Output population if no buffer is provided

### DIFF
--- a/sdk/inspector/_inspector.py
+++ b/sdk/inspector/_inspector.py
@@ -7,6 +7,7 @@
 import dataclasses
 import logging
 import sys
+import warnings
 from collections import defaultdict, OrderedDict
 from dataclasses import dataclass
 from functools import cached_property
@@ -899,6 +900,10 @@ class Inspector:
                 output_buffer = f.read()
         else:
             output_buffer = None
+            warnings.warn(
+                "Output Buffer not found. Tensor Debug Data will not be available.",
+                stacklevel=1,
+            )
 
         self.event_blocks = EventBlock._gen_from_etdump(
             etdump,

--- a/sdk/inspector/_inspector_utils.py
+++ b/sdk/inspector/_inspector_utils.py
@@ -97,12 +97,15 @@ def inflate_runtime_output(
 
     # Given a ETDump Tensor object and offset, extract into a torch.Tensor
     def parse_tensor_value(tensor: Optional[Tensor]) -> torch.Tensor:
-        if output_buffer is None:
-            raise ValueError("Empty buffer provided. Cannot deserialize tensors.")
         if tensor is None or tensor.offset is None:
             raise ValueError("Tensor cannot be None")
 
         torch_dtype, dtype_size = get_scalar_type_size(tensor.scalar_type)
+
+        if output_buffer is None:
+            # Empty buffer provided. Cannot deserialize tensors.
+            return torch.zeros(tensor.sizes, dtype=torch_dtype)
+
         tensor_bytes_size = math.prod(tensor.sizes) * dtype_size
 
         if tensor.offset is None:


### PR DESCRIPTION
Summary:
Check for Debug Buffer prior to populating

Previously, would error out if debug events were found and debug buffer was not provided

Differential Revision: D52138655


