### PR TITLE
ETDump changes to support tensor lists

### DIFF
--- a/runtime/core/evalue.h
+++ b/runtime/core/evalue.h
@@ -7,7 +7,6 @@
  */
 
 #pragma once
-
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/tag.h>
 #include <executorch/runtime/platform/assert.h>

--- a/sdk/etdump/etdump_schema_flatcc.fbs
+++ b/sdk/etdump/etdump_schema_flatcc.fbs
@@ -36,13 +36,18 @@ table String {
   string_val:string;
 }
 
-enum ValueType : byte { Null, Int, Bool, Float, Double, Tensor, String,}
+table TensorList {
+  tensors:[Tensor];
+}
+
+enum ValueType : byte { Null, Int, Bool, Float, Double, Tensor, TensorList, String,}
 
 // This table is only necessary because flatbuffer can't support a list of
 // union elements directly, they need to be wrapped in a table.
 table Value {
     val:ValueType;
     tensor:Tensor;
+    tensor_list:TensorList;
     int_value:Int;
     float_value:Float;
     double_value:Double;

--- a/sdk/etdump/schema_flatcc.py
+++ b/sdk/etdump/schema_flatcc.py
@@ -27,6 +27,11 @@ class Tensor:
 
 
 @dataclass
+class TensorList:
+    tensors: List[Tensor]
+
+
+@dataclass
 class Null:
     pass
 
@@ -70,6 +75,7 @@ class ValueType(Enum):
     FLOAT = "Float"
     DOUBLE = "Double"
     TENSOR = "Tensor"
+    TENSOR_LIST = "TensorList"
     STRING = "String"
 
 
@@ -77,6 +83,7 @@ class ValueType(Enum):
 class Value:
     val: str  # Member of ValueType
     tensor: Optional[Tensor]
+    tensor_list: Optional[TensorList]
     int_value: Optional[Int]
     float_value: Optional[Float]
     double_value: Optional[Double]

--- a/sdk/etdump/tests/etdump_test.cpp
+++ b/sdk/etdump/tests/etdump_test.cpp
@@ -186,6 +186,30 @@ TEST_F(ProfilerETDumpTest, DebugEvent) {
   }
 }
 
+TEST_F(ProfilerETDumpTest, DebugEventTensorList) {
+  for (size_t i = 0; i < 2; i++) {
+    testing::TensorFactory<ScalarType::Int> tf;
+    exec_aten::Tensor storage[2] = {tf.ones({3, 2}), tf.ones({3, 2})};
+    EValue evalue_1(storage[0]);
+    EValue evalue_2(storage[1]);
+    EValue* values_p[2] = {&evalue_1, &evalue_2};
+
+    BoxedEvalueList<exec_aten::Tensor> a_box(values_p, storage, 2);
+    EValue evalue(a_box);
+    evalue.tag = Tag::ListTensor;
+
+    etdump_gen[i]->create_event_block("test_block");
+
+    void* ptr = malloc(2048);
+    Span<uint8_t> buffer((uint8_t*)ptr, 2048);
+
+    etdump_gen[i]->set_debug_buffer(buffer);
+    etdump_gen[i]->log_evalue(evalue);
+
+    free(ptr);
+  }
+}
+
 TEST_F(ProfilerETDumpTest, VerifyLogging) {
   testing::TensorFactory<ScalarType::Float> tf;
   EValue evalue(tf.ones({3, 2}));

--- a/sdk/etdump/tests/serialize_test.py
+++ b/sdk/etdump/tests/serialize_test.py
@@ -93,6 +93,16 @@ def get_sample_etdump_flatcc() -> flatcc.ETDumpFlatCC:
                                     strides=[1],
                                     offset=12345,
                                 ),
+                                tensor_list=flatcc.TensorList(
+                                    [
+                                        flatcc.Tensor(
+                                            scalar_type=flatcc.ScalarType.INT,
+                                            sizes=[1],
+                                            strides=[1],
+                                            offset=12345,
+                                        )
+                                    ]
+                                ),
                                 int_value=flatcc.Int(1),
                                 float_value=flatcc.Float(1.0),
                                 double_value=flatcc.Double(1.0),

--- a/sdk/inspector/_inspector_utils.py
+++ b/sdk/inspector/_inspector_utils.py
@@ -64,7 +64,9 @@ TIME_SCALE_DICT = {
 
 
 # Model Debug Output
-InferenceOutput: TypeAlias = Union[torch.Tensor, int, float, str, bool, None]
+InferenceOutput: TypeAlias = Union[
+    torch.Tensor, List[torch.Tensor], int, float, str, bool, None
+]
 ProgramOutput: TypeAlias = List[InferenceOutput]
 
 
@@ -135,6 +137,10 @@ def inflate_runtime_output(
             return value.double_value.double_val
         case ValueType.TENSOR.value:
             return parse_tensor_value(value.tensor)
+        case ValueType.TENSOR_LIST.value:
+            if value.tensor_list is None:
+                raise ValueError("Expected TensorList value, `None` provided")
+            return [parse_tensor_value(t) for t in value.tensor_list.tensors]
 
 
 def find_populated_event(event: flatcc.Event) -> Union[ProfileEvent, DebugEvent]:

--- a/sdk/inspector/tests/inspector_utils_test.py
+++ b/sdk/inspector/tests/inspector_utils_test.py
@@ -81,6 +81,18 @@ class TestInspectorUtils(unittest.TestCase):
                     strides=[1],
                     offset=12345,
                 ),
+                tensor_list=[
+                    flatcc.TensorList(
+                        tensors=[
+                            flatcc.Tensor(
+                                scalar_type=flatcc.ScalarType.INT,
+                                sizes=[1],
+                                strides=[1],
+                                offset=12345,
+                            )
+                        ]
+                    )
+                ],
                 int_value=flatcc.Int(1),
                 float_value=flatcc.Float(1.0),
                 double_value=flatcc.Double(1.0),


### PR DESCRIPTION
Summary: We don't support Tensor lists currently in ETDump and Inspector. Ran into a case in Jarvis where Tensor lists are needed to log intermediate outputs so adding support for that.

Reviewed By: Olivia-liu

Differential Revision: D52210043


