### PR TITLE
Add warning message about missing etdump data

### DIFF
--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -550,6 +550,12 @@ struct PyModule final {
       fwrite((uint8_t*)result.buf, 1, result.size, f);
       fclose(f);
       free(result.buf);
+    } else {
+      ET_LOG(
+          Info,
+          "No etdump data found, try rebuilding with "
+          "the CMake option EXECUTORCH_ENABLE_EVENT_TRACER or with "
+          "buck run --config executorch.event_tracer_enabled=true");
     }
   }
 


### PR DESCRIPTION
Summary:
When there's no data for ETDump to write out, make a warning
message for the user.

Info level was chosen because there is no warning level, just
Info and Error.

Differential Revision: D52221886


