### PR TITLE
fix lint error

### DIFF
--- a/backends/xnnpack/test/test_xnnpack_quantized.py
+++ b/backends/xnnpack/test/test_xnnpack_quantized.py
@@ -7,10 +7,7 @@
 import unittest
 
 import torch
-from executorch.backends.xnnpack.test.test_xnnpack_utils import (
-    randomize_bn,
-    TestXNNPACK,
-)
+from executorch.backends.xnnpack.test.test_xnnpack_utils import TestXNNPACK
 
 from executorch.exir.dialects._ops import ops as exir_ops
 

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -468,7 +468,7 @@ struct PyModule final {
 
     const auto& method = module_->get_method(method_name);
     const auto num_outputs = method.outputs_size();
-    // These output storages will not be used if the Executorch program already
+    // These output storages will not be used if the ExecuTorch program already
     // pre-allocated output space. That is represented by an error from
     // set_output_data_ptr.
     std::vector<std::unique_ptr<uint8_t[]>> output_storages(num_outputs);


### PR DESCRIPTION
Summary:
lint signal in oss is a bit more internal, forward fix here. Original message is
```
>>> Lint for backends/xnnpack/test/test_xnnpack_quantized.py:

  Warning (FLAKE8) F401
    'executorch.backends.xnnpack.test.test_xnnpack_utils.randomize_bn'
    imported but unused
    See https://www.flake8rules.com/rules/F401.html.

          7  |import unittest
          8  |
          9  |import torch
    >>>  10  |from executorch.backends.xnnpack.test.test_xnnpack_utils import (
         11  |    randomize_bn,
         12  |    TestXNNPACK,
         13  |)



>>> Lint for extension/pybindings/pybindings.cpp:

  Error (ExecuTorchCapitalization) Incorrect capitalization for ExecuTorch

        Please use ExecuTorch with capital T for consistency.
        https://fburl.com/workplace/nsx6hib2


        468  |
        469  |    const auto& method = module_->get_method(method_name);
        470  |    const auto num_outputs = method.outputs_size();
    >>> 471  |    // These output storages will not be used if the Executorch program already
        472  |    // pre-allocated output space. That is represented by an error from
        473  |    // set_output_data_ptr.
        474  |    std::vector<std::unique_ptr<uint8_t[]>> output_storages(num_outputs);

```

Differential Revision: D52305648


