### PR TITLE
Add hacky per-tensor quant support

### DIFF
--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -219,7 +219,7 @@ Error defineTensor(
               /*subgraph=*/subgraph_ptr,
               /*datatype=*/xnn_datatype_qdint8,
               /*num_dims=*/tensor_value->num_dims(),
-              /*num_nonbatch_dims=*/1, // This is always for fully connected
+              /*num_nonbatch_dims=*/dims_data.size(), // = per tensor dq
               /*dims=*/dims_data.data(),
               /*external_id=*/XNN_INVALID_VALUE_ID, // always internal value id
               /*flags=*/0, // this is netiher external input or output


### PR DESCRIPTION
Summary: This is a hacky support, effectively disabling per_batch in favor of per_tensor quant.

Reviewed By: mcr229

Differential Revision: D52021616


