### PR TITLE
allow passing dynamic shape information in examples dir

### DIFF
--- a/examples/models/model_factory.py
+++ b/examples/models/model_factory.py
@@ -19,7 +19,7 @@ class EagerModelFactory:
     @staticmethod
     def create_model(
         module_name, model_class_name, **kwargs
-    ) -> Tuple[torch.nn.Module, Any]:
+    ) -> Tuple[torch.nn.Module, Any, Any]:
         """
         Create an instance of a model class that implements EagerModelBase and retrieve related data.
 
@@ -41,7 +41,14 @@ class EagerModelFactory:
         if hasattr(module, model_class_name):
             model_class = getattr(module, model_class_name)
             model = model_class(**kwargs)
-            return model.get_eager_model(), model.get_example_inputs()
+            if hasattr(model, "get_dynamic_shapes"):
+                return (
+                    model.get_eager_model(),
+                    model.get_example_inputs(),
+                    model.get_dynamic_shapes(),
+                )
+            else:
+                return model.get_eager_model(), model.get_example_inputs(), None
 
         raise ValueError(
             f"Model class '{model_class_name}' not found in module '{module_name}'."

--- a/examples/portable/scripts/export.py
+++ b/examples/portable/scripts/export.py
@@ -9,6 +9,9 @@
 import argparse
 import logging
 
+from executorch.examples.portable.utils import export_to_edge
+from executorch.exir.capture import EdgeCompileConfig
+
 from executorch.exir.capture._config import ExecutorchBackendConfig
 
 from ...models import MODEL_NAME_TO_MODEL
@@ -44,12 +47,29 @@ def main() -> None:
             f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}."
         )
 
-    model, example_inputs = EagerModelFactory.create_model(
+    model, example_inputs, dynamic_shapes = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 
     config = ExecutorchBackendConfig(extract_constant_segment=args.constant_segment)
-    prog = export_to_exec_prog(model, example_inputs, backend_config=config)
+    if (
+        dynamic_shapes is not None
+    ):  # capture_pre_autograd_graph does not work with dynamic shapes
+        edge_manager = export_to_edge(
+            model,
+            example_inputs,
+            dynamic_shapes=dynamic_shapes,
+            edge_compile_config=EdgeCompileConfig(
+                _check_ir_validity=False,
+            ),
+        )
+        prog = edge_manager.to_executorch(
+            ExecutorchBackendConfig(extract_constant_segment=True)
+        )
+    else:
+        prog = export_to_exec_prog(
+            model, example_inputs, dynamic_shapes=dynamic_shapes, backend_config=config
+        )
     save_pte_program(prog.buffer, args.model_name, args.output_dir)
 
 


### PR DESCRIPTION
Summary: Right now nothing under examples can have dynamic shape information. This change correctly forwards it along if the user implements "get_dynamic_shape"

Reviewed By: larryliu0820

Differential Revision: D52301732


