### PR TITLE
Remove equality_constraints

### DIFF
--- a/backends/xnnpack/xnnpack_preprocess.py
+++ b/backends/xnnpack/xnnpack_preprocess.py
@@ -200,14 +200,13 @@ class XnnpackBackend(BackendDetails):
         # EdgeDialectVerifier, but disable it.
         # TODO (task link) to implement NullVerifier or something similar
         ep = ExportedProgram(
-            ep.graph_module,
-            ep.graph,
-            ep.graph_signature,
-            ep.state_dict,
-            ep.range_constraints,
-            ep.equality_constraints,
-            copy.deepcopy(ep.module_call_graph),
-            ep.example_inputs,
+            root=ep.graph_module,
+            graph=ep.graph,
+            graph_signature=ep.graph_signature,
+            state_dict=ep.state_dict,
+            range_constraints=ep.range_constraints,
+            module_call_graph=copy.deepcopy(ep.module_call_graph),
+            example_inputs=ep.example_inputs,
             verifier=EXIREdgeDialectVerifier(
                 check_edge_ops=False, enable=False, class_only=True
             ),

--- a/exir/backend/backend_api.py
+++ b/exir/backend/backend_api.py
@@ -354,13 +354,12 @@ def _(
         edge_program, tagged_graph_module
     )
     return ExportedProgram(
-        tagged_graph_module,
-        tagged_graph_module.graph,
-        new_signature,
-        new_state_dict,
-        copy.deepcopy(edge_program.range_constraints),
-        copy.deepcopy(edge_program.equality_constraints),
-        copy.deepcopy(edge_program.module_call_graph),
-        None,
-        edge_program.verifier,
+        root=tagged_graph_module,
+        graph=tagged_graph_module.graph,
+        graph_signature=new_signature,
+        state_dict=new_state_dict,
+        range_constraints=copy.deepcopy(edge_program.range_constraints),
+        module_call_graph=copy.deepcopy(edge_program.module_call_graph),
+        example_inputs=None,
+        verifier=edge_program.verifier,
     )

--- a/exir/capture/_capture.py
+++ b/exir/capture/_capture.py
@@ -90,9 +90,9 @@ def _capture_legacy_do_not_use(f, args) -> ExirExportedProgram:
                 n.meta["val"] = None
 
     ep = HackedUpExportedProgramDONOTUSE(
-        graph_module,
-        graph_module.graph,
-        ExportGraphSignature(
+        root=graph_module,
+        graph=graph_module.graph,
+        graph_signature=ExportGraphSignature(
             input_specs=[
                 InputSpec(
                     kind=InputKind.USER_INPUT, arg=TensorArgument(name=i), target=None
@@ -106,11 +106,10 @@ def _capture_legacy_do_not_use(f, args) -> ExirExportedProgram:
                 for o in user_outputs
             ],
         ),
-        CallSpec(in_spec, out_spec),
-        {},
-        {},
-        [],
-        [
+        call_spec=CallSpec(in_spec, out_spec),
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[
             ModuleCallEntry(
                 fqn="",
                 signature=ModuleCallSignature(
@@ -121,8 +120,8 @@ def _capture_legacy_do_not_use(f, args) -> ExirExportedProgram:
                 ),
             )
         ],
-        None,
-        EXIRATenDialectVerifierBase,
+        example_inputs=None,
+        verifier=EXIRATenDialectVerifierBase,
     )
     return ExirExportedProgram(ep, False)
 
@@ -294,13 +293,12 @@ def capture(  # noqa: C901
 
     graph_module.graph.eliminate_dead_code()
     ep = ExportedProgram(
-        graph_module,
-        graph_module.graph,
-        ExportGraphSignature(user_inputs, user_outputs),
-        {},
-        {},
-        [],
-        [
+        root=graph_module,
+        graph=graph_module.graph,
+        graph_signature=ExportGraphSignature(user_inputs, user_outputs),
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[
             ModuleCallEntry(
                 fqn="",
                 signature=ModuleCallSignature(
@@ -311,8 +309,8 @@ def capture(  # noqa: C901
                 ),
             )
         ],
-        None,
-        EXIRATenDialectVerifierBase,
+        example_inputs=None,
+        verifier=EXIRATenDialectVerifierBase,
     )
     return ExirExportedProgram(ep, False)
 

--- a/exir/lowered_backend_module.py
+++ b/exir/lowered_backend_module.py
@@ -274,7 +274,6 @@ class LoweredBackendModule(torch.nn.Module):
             # inputs/outputs to the toplevel program will be in the format of the eager module.
             state_dict={},  # None because all data are consumed by delegate
             range_constraints=lowered_exported_program.range_constraints,
-            equality_constraints=lowered_exported_program.equality_constraints,
             module_call_graph=lowered_exported_program.module_call_graph,
             example_inputs=None,
             verifier=lowered_exported_program.verifier,
@@ -480,7 +479,6 @@ def create_exported_program_from_submodule(
         graph_signature=subgraph_signature,
         state_dict=subgraph_state_dict,
         range_constraints=copy.deepcopy(owning_program.range_constraints),
-        equality_constraints=[],
         module_call_graph=[],
         verifier=owning_program.verifier,
     )

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -114,16 +114,17 @@ def _transform(self, *passes: PassType) -> "ExportedProgram":
         return self
 
     transformed_ep = ExportedProgram(
-        transformed_gm,
-        transformed_gm.graph,
-        _get_updated_graph_signature(self.graph_signature, transformed_gm),
-        self.state_dict,
-        _get_updated_range_constraints(transformed_gm),
-        copy.deepcopy(self.equality_constraints),
-        copy.deepcopy(self._module_call_graph),
-        self.example_inputs,
-        self.verifier,
-        self.tensor_constants,
+        root=transformed_gm,
+        graph=transformed_gm.graph,
+        graph_signature=_get_updated_graph_signature(
+            self.graph_signature, transformed_gm
+        ),
+        state_dict=self.state_dict,
+        range_constraints=_get_updated_range_constraints(transformed_gm),
+        module_call_graph=copy.deepcopy(self._module_call_graph),
+        example_inputs=self.example_inputs,
+        verifier=self.verifier,
+        tensor_constants=self.tensor_constants,
     )
     transformed_ep.graph_module.meta.update(self.graph_module.meta)
     transformed_ep.graph_module.meta.update(res.graph_module.meta)
@@ -226,21 +227,19 @@ class HackedUpExportedProgramDONOTUSE(ExportedProgram):
         call_spec,
         state_dict,
         range_constraints,
-        equality_constraints,
         module_call_graph,
         example_inputs,
         verifier,
     ):
         super().__init__(
-            root,
-            graph,
-            graph_signature,
-            state_dict,
-            range_constraints,
-            equality_constraints,
-            module_call_graph,
-            example_inputs,
-            verifier,
+            root=root,
+            graph=graph,
+            graph_signature=graph_signature,
+            state_dict=state_dict,
+            range_constraints=range_constraints,
+            module_call_graph=module_call_graph,
+            example_inputs=example_inputs,
+            verifier=verifier,
         )
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
@@ -467,14 +466,13 @@ def _to_edge(ep, config: EdgeCompileConfig) -> "ExirExportedProgram":
     if dialect == "ATEN":
         ep = ExirExportedProgram(
             ExportedProgram(
-                ep.exported_program.graph_module,
-                ep.exported_program.graph_module.graph,
-                ep.exported_program.graph_signature,
-                ep.exported_program.state_dict,
-                ep.exported_program.range_constraints,
-                ep.exported_program.equality_constraints,
-                ep.exported_program.module_call_graph,
-                ep.exported_program.example_inputs,
+                root=ep.exported_program.graph_module,
+                graph=ep.exported_program.graph_module.graph,
+                graph_signature=ep.exported_program.graph_signature,
+                state_dict=ep.exported_program.state_dict,
+                range_constraints=ep.exported_program.range_constraints,
+                module_call_graph=ep.exported_program.module_call_graph,
+                example_inputs=ep.exported_program.example_inputs,
                 verifier=get_aten_verifier(enable=config._check_ir_validity),
                 tensor_constants=ep.exported_program.tensor_constants,
             ),
@@ -503,14 +501,15 @@ def _to_edge(ep, config: EdgeCompileConfig) -> "ExirExportedProgram":
         new_gm = new_gm_res.graph_module
 
     new_ep.exported_program = ExportedProgram(
-        new_gm,
-        new_gm.graph,
-        _get_updated_graph_signature(new_ep.exported_program.graph_signature, new_gm),
-        new_ep.exported_program.state_dict,
-        new_ep.exported_program.range_constraints,
-        new_ep.exported_program.equality_constraints,
-        new_ep.exported_program.module_call_graph,
-        new_ep.exported_program.example_inputs,
+        root=new_gm,
+        graph=new_gm.graph,
+        graph_signature=_get_updated_graph_signature(
+            new_ep.exported_program.graph_signature, new_gm
+        ),
+        state_dict=new_ep.exported_program.state_dict,
+        range_constraints=new_ep.exported_program.range_constraints,
+        module_call_graph=new_ep.exported_program.module_call_graph,
+        example_inputs=new_ep.exported_program.example_inputs,
         verifier=EXIREdgeDialectVerifier(
             check_edge_ops=config._use_edge_ops,
             enable=config._check_ir_validity,
@@ -846,7 +845,6 @@ def to_edge(
             ),
             state_dict=edge_program.state_dict,
             range_constraints=edge_program.range_constraints,
-            equality_constraints=edge_program.equality_constraints,
             module_call_graph=edge_program.module_call_graph,
             example_inputs=edge_program.example_inputs,
             verifier=EXIREdgeDialectVerifier(

--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -1733,15 +1733,16 @@ class ExportedProgramDeserializer:
         state_dict = deserialize_torch_artifact(serialized_artifact.state_dict)
 
         exported_program = ep.ExportedProgram(
-            res.graph_module,
-            res.graph_module.graph,
-            res.signature,
-            state_dict,  # type: ignore[arg-type]
-            range_constraints,
-            [],
-            res.module_call_graph,
-            None,
-            load_verifier(serialized_artifact.exported_program.dialect),  # pyre-ignore
+            root=res.graph_module,
+            graph=res.graph_module.graph,
+            graph_signature=res.signature,
+            state_dict=state_dict,  # type: ignore[arg-type]
+            range_constraints=range_constraints,
+            module_call_graph=res.module_call_graph,
+            example_inputs=None,
+            verifier=load_verifier(
+                serialized_artifact.exported_program.dialect  # pyre-ignore
+            ),
             tensor_constants=tensor_constants,
         )
         return upgrader.upgrade(exported_program)

--- a/exir/serde/serialize.py
+++ b/exir/serde/serialize.py
@@ -676,12 +676,11 @@ class ExportedProgramDeserializer(export_serialize.ExportedProgramDeserializer):
         dummy_g = torch.fx.Graph()
         dummy_g.output(())
         exported_program = exir.ExportedProgram(
-            state_dict,
-            dummy_g,
-            ep.ExportGraphSignature(input_specs=[], output_specs=[]),
-            {},  # TODO(T157676982)
-            range_constraints,
-            [],
+            root=state_dict,
+            graph=dummy_g,
+            graph_signature=ep.ExportGraphSignature(input_specs=[], output_specs=[]),
+            state_dict={},  # TODO(T157676982)
+            range_constraints=range_constraints,
             module_call_graph=module_call_graph,
             verifier=load_verifier(
                 serialized_artifact.exported_program.dialect  # pyre-ignore


### PR DESCRIPTION
Summary:
With improvements to the dynamic_shapes API, dynamic dimensions which
are equal (they are marked with the same named `Dim`) will have the same symint
assigned to them. So, we no longer need `equality_constraints` to tell us which
inputs dimensions are equal.

Differential Revision: D52314640


