### PR TITLE
Decompose print_data_tabular into another function that returns the raw dataframe.

### DIFF
--- a/docs/source/sdk-inspector.rst
+++ b/docs/source/sdk-inspector.rst
@@ -36,6 +36,11 @@ Constructor
 
     inspector = Inspector(etdump_path="/path/to/etdump.etdp", etrecord="/path/to/etrecord.bin")
 
+to_dataframe
+~~~~~~~~~~~~~~~~
+
+.. autofunction:: sdk.Inspector.to_dataframe
+
 
 print_data_tabular
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Summary: IMO if we're going through the trouble of generating a Pandas dataframe, we should give users the option to use it rather than just printing it. In theory, also improves code modularity.

Differential Revision: D52150960


