### PR TITLE
Consolidate memory ownership for runner.cpp

### DIFF
--- a/extension/runner/runner.h
+++ b/extension/runner/runner.h
@@ -34,18 +34,44 @@ class Runner {
   Error loadMethod(const std::string& methodName);
 
  private:
-  struct MethodHolder {
+  class Memory {
+   public:
+    explicit Memory(
+        std::vector<size_t> sizes,
+        std::shared_ptr<MemoryAllocator> memoryAllocator) {
+      plannedBuffers.resize(sizes.size());
+      plannedSpans.resize(sizes.size());
+      for (size_t i = 0; i < sizes.size(); ++i) {
+        plannedBuffers[i].resize(sizes[i]);
+        plannedSpans[i] = {plannedBuffers[i].data(), sizes[i]};
+      }
+      plannedMemory = std::make_unique<HierarchicalAllocator>(
+          Span(plannedSpans.data(), plannedSpans.size()));
+      memoryManager = std::make_unique<MemoryManager>(
+          memoryAllocator.get(), plannedMemory.get());
+    }
+    /// Returns a pointer to the internal memory manager, the Memory instance
+    /// must outlive this pointer.
+    std::shared_ptr<MemoryManager> inline getMemoryManager() {
+      return memoryManager;
+    }
+
+   private:
     std::vector<std::vector<uint8_t>> plannedBuffers;
     std::vector<Span<uint8_t>> plannedSpans;
     std::unique_ptr<HierarchicalAllocator> plannedMemory;
-    std::unique_ptr<MemoryManager> memoryManager;
-    std::unique_ptr<Method> method;
+    std::shared_ptr<MemoryManager> memoryManager;
+  };
+
+  struct MethodHolder {
+    std::unique_ptr<Memory> memory_;
+    std::unique_ptr<Method> method_;
   };
 
  private:
   std::unique_ptr<DataLoader> dataLoader_;
   std::unique_ptr<Program> program_;
-  std::unique_ptr<MemoryAllocator> memoryAllocator_;
+  std::shared_ptr<MemoryAllocator> memoryAllocator_;
   std::unordered_map<std::string, MethodHolder> methods_;
 };
 


### PR DESCRIPTION
Summary:
In current `runner.cpp` implementation, we reserve memory at `Runner::loadMethod()` through a local variable `std::vector<uint8_t>`:

https://www.internalfb.com/code/fbsource/[6156a9fd502c4e1e7ff4eb74737ac2498fa21ccf]/fbcode/executorch/extension/runner/runner.cpp?lines=65

This is dangerous because when this local variable goes out of scope of `Runner::loadMethod()`, the memory will be released and this is a undefined behavior.

This diff changes the logic, that a vector of buffer size will be passed into the `Memory` class constructor and inside it will reserve memory. This way `Memory` instance will own its memory.

Reviewed By: iseeyuan

Differential Revision: D52356196


