### PR TITLE
Fix unintentional indents in example export scripts

### DIFF
--- a/examples/apple/coreml/scripts/export_and_delegate.py
+++ b/examples/apple/coreml/scripts/export_and_delegate.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
             f"Valid compute units are {compute_units}."
         )
 
-        model, example_inputs, _ = EagerModelFactory.create_model(
+    model, example_inputs, _ = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 

--- a/examples/apple/mps/scripts/mps_example.py
+++ b/examples/apple/mps/scripts/mps_example.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     if args.model_name not in MODEL_NAME_TO_MODEL:
         raise RuntimeError(f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}.")
 
-        model, example_inputs, _ = EagerModelFactory.create_model(
+    model, example_inputs, _ = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 

--- a/examples/qualcomm/scripts/export_example.py
+++ b/examples/qualcomm/scripts/export_example.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
             f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}."
         )
 
-        model, example_inputs, _ = EagerModelFactory.create_model(
+    model, example_inputs, _ = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 


### PR DESCRIPTION
Summary:
D52301732 (https://github.com/pytorch/executorch/commit/344919c4ce9ebc67110d9db60e173e6a8989d0f0) unintentionally indented a few lines, making them conditional and effectively never-executed.

Note that that commit also broke scripts/export.py (failing import at https://github.com/pytorch/executorch/commit/344919c4ce9ebc67110d9db60e173e6a8989d0f0#diff-c554651d54754f1842eaeaf56543580a374b10322fa3cd9aafb9bbf93bcc9e09R12) but this commit does not fix that.

Differential Revision: D52417986


