### PR TITLE
Add constant segment to export_program for tests

### DIFF
--- a/test/end2end/exported_module.py
+++ b/test/end2end/exported_module.py
@@ -63,6 +63,7 @@ class ExportedModule:
         ignore_to_out_var_failure: bool = False,
         dynamic_memory_planning_mode: DynamicMemoryPlanningMode = DynamicMemoryPlanningMode.UPPER_BOUND,
         capture_config=None,
+        extract_constant_segment: bool = True,
     ) -> "ExportedModule":
         """
         Creates a new ExportedModule for the specified module class.
@@ -166,6 +167,7 @@ class ExportedModule:
                     dynamic_memory_planning_mode=dynamic_memory_planning_mode,
                     memory_planning_pass=memory_planning_pass,
                     to_out_var_pass=ToOutVarPass(ignore_to_out_var_failure),
+                    extract_constant_segment=extract_constant_segment,
                 )
             )
         )

--- a/test/models/targets.bzl
+++ b/test/models/targets.bzl
@@ -72,7 +72,11 @@ def define_common_targets():
     runtime.genrule(
         name = "exported_programs",
         cmd = "$(exe :export_program) --modules " + ",".join(MODULES_TO_EXPORT) + " --outdir $OUT",
-        outs = {fname + ".pte": [fname + ".pte"] for fname in MODULES_TO_EXPORT},
+        outs = {
+            fname + seg_suffix + ".pte": [fname + seg_suffix + ".pte"]
+            for fname in MODULES_TO_EXPORT
+            for seg_suffix in ["", "-no-constant-segment"]
+        },
         default_outs = ["."],
         visibility = [
             "//executorch/...",


### PR DESCRIPTION
Summary:
- add `extract_constant_segment` to export_program
- for each program, generate pte file with constants in segment, and constants in flatbuffer.

Differential Revision: D52434374


