### PR TITLE
[TOSA] Reformat function names to match pep 8 convention

### DIFF
--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Arm Limited and/or its affiliates.
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -18,7 +18,7 @@ from executorch.backends.arm.arm_vela import vela_compile
 from executorch.backends.arm.operators.node_visitor import get_node_visitors
 from executorch.backends.arm.operators.op_placeholder import process_placeholder
 from executorch.backends.arm.tosa_mapping import TosaArg
-from executorch.backends.arm.tosa_quant_utils import isQuantNode
+from executorch.backends.arm.tosa_quant_utils import is_quant_node
 from executorch.backends.arm.tosa_utils import (
     dbg_fail,
     dbg_tosa_dump,
@@ -70,9 +70,6 @@ class ArmBackend(BackendDetails):
                 for arg in node.args:
                     inputs.append(TosaArg(arg))
 
-                # Check it's a quantized graph or not
-                is_quant_node = isQuantNode(node)
-
                 # Convert output (this node itself)
                 output = TosaArg(node)
                 # Add output to TOSA graph
@@ -81,13 +78,13 @@ class ArmBackend(BackendDetails):
                     inputs[0].shape
                     if is_permute_node_before_addmm(node)
                     else output.shape,
-                    ts.DType.INT8 if is_quant_node else output.dtype,
+                    ts.DType.INT8 if is_quant_node(node) else output.dtype,
                 )
 
                 # Visiting each Node
                 if node.target.__name__ in node_visitors:
                     node_visitors[node.target.__name__].define_node(
-                        node, tosa_graph, inputs, output, is_quant_node
+                        node, tosa_graph, inputs, output, is_quant_node(node)
                     )
                 else:
                     raise RuntimeError(f"Unknown operator {node.target}")

--- a/backends/arm/operators/op_add.py
+++ b/backends/arm/operators/op_add.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Arm Limited and/or its affiliates.
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -13,10 +13,10 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_quant_utils import (
-    buildRescaleFromInt32,
-    buildRescaleToInt32,
+    build_rescale_from_int32,
+    build_rescale_to_int32,
 )
-from executorch.backends.arm.tosa_utils import broadcastShapes, getNodeArgs
+from executorch.backends.arm.tosa_utils import broadcast_shapes, getNodeArgs
 from serializer.tosa_serializer import TosaOp
 
 
@@ -51,14 +51,14 @@ class AddVisitor(NodeVisitor):
             inputA_rescale_scale = input_A_scale.number / max_scale_2x
             inputB_rescale_scale = input_B_scale.number / max_scale_2x
 
-            input_A_rescaled_to_int32 = buildRescaleToInt32(
+            input_A_rescaled_to_int32 = build_rescale_to_int32(
                 tosa_graph,
                 input_A,
                 input_A_zp.number,
                 inputA_rescale_scale,
             )
 
-            input_B_rescaled_to_int32 = buildRescaleToInt32(
+            input_B_rescaled_to_int32 = build_rescale_to_int32(
                 tosa_graph,
                 input_B,
                 input_B_zp.number,
@@ -66,7 +66,7 @@ class AddVisitor(NodeVisitor):
             )
 
             ## Do the INT32 Add
-            broadcasted_shape = broadcastShapes(input_A.shape, input_B.shape)
+            broadcasted_shape = broadcast_shapes(input_A.shape, input_B.shape)
             add_res = tosa_graph.addIntermediate(broadcasted_shape, ts.DType.INT32)
             tosa_graph.addOperator(
                 TosaOp.Op().ADD,
@@ -84,7 +84,7 @@ class AddVisitor(NodeVisitor):
             output_rescale_scale = max_scale_2x / (output_scale.number)
 
             # Rescale Back to INT8
-            buildRescaleFromInt32(
+            build_rescale_from_int32(
                 tosa_graph,
                 add_res.name,
                 output.name,

--- a/backends/arm/operators/op_addmm.py
+++ b/backends/arm/operators/op_addmm.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Arm Limited and/or its affiliates.
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -13,11 +13,11 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_quant_utils import (
-    computeMultiplierAndShift,
-    getQuantNodeArgs,
+    compute_multiplier_and_shift,
+    get_quant_node_args,
 )
 
-from executorch.backends.arm.tosa_utils import buildReshape
+from executorch.backends.arm.tosa_utils import build_reshape
 from executorch.exir.dialects._ops import ops as exir_ops
 from serializer.tosa_serializer import TosaOp
 
@@ -49,7 +49,7 @@ class AddmmVisitor(NodeVisitor):
             ts.DType.INT8 if is_quant_node else input.dtype,
         )
 
-        buildReshape(tosa_graph, input.name, input_new_shape, input_reshaped.name)
+        build_reshape(tosa_graph, input.name, input_new_shape, input_reshaped.name)
 
         weight_new_shape = (output_channels, 1, 1, input_channels)
         weight_reshaped = tosa_graph.addIntermediate(
@@ -57,7 +57,7 @@ class AddmmVisitor(NodeVisitor):
             ts.DType.INT8 if is_quant_node else weight.dtype,
         )
 
-        buildReshape(tosa_graph, weight.name, weight_new_shape, weight_reshaped.name)
+        build_reshape(tosa_graph, weight.name, weight_new_shape, weight_reshaped.name)
 
         # Get the attributes of convolution.
         attr = ts.TosaSerializerAttribute()
@@ -103,30 +103,30 @@ class AddmmVisitor(NodeVisitor):
             # rank > 2 linear layer
             if input_node.target == exir_ops.edge.aten.view_copy.default:
                 quant_node = input_node.all_input_nodes[0]
-                input_scale, _ = getQuantNodeArgs(quant_node)
+                input_scale, _ = get_quant_node_args(quant_node)
                 consumer_node = list(node.users)[0]
                 consumer_consumer_node = list(consumer_node.users)[0]
                 (
                     consumer_node_scale,
                     consumer_node_node_zp,
-                ) = getQuantNodeArgs(consumer_consumer_node)
+                ) = get_quant_node_args(consumer_consumer_node)
 
             else:
-                input_scale, _ = getQuantNodeArgs(input_node)
+                input_scale, _ = get_quant_node_args(input_node)
                 consumer_node = list(node.users)[0]
                 (
                     consumer_node_scale,
                     consumer_node_node_zp,
-                ) = getQuantNodeArgs(consumer_node)
+                ) = get_quant_node_args(consumer_node)
 
             weight_node_q_node = weight_node.all_input_nodes[0]
-            weight_scale, _ = getQuantNodeArgs(weight_node_q_node)
+            weight_scale, _ = get_quant_node_args(weight_node_q_node)
 
             output_rescale_scale = (input_scale * weight_scale) / consumer_node_scale
             (
                 multiplier_output,
                 shift_output,
-            ) = computeMultiplierAndShift(output_rescale_scale)
+            ) = compute_multiplier_and_shift(output_rescale_scale)
 
             attr_rescale_output = ts.TosaSerializerAttribute()
             attr_rescale_output.RescaleAttribute(
@@ -142,7 +142,7 @@ class AddmmVisitor(NodeVisitor):
             )
 
             reshaped_res = tosa_graph.addIntermediate(result_shape, ts.DType.INT32)
-            buildReshape(tosa_graph, conv2d_res.name, result_shape, reshaped_res.name)
+            build_reshape(tosa_graph, conv2d_res.name, result_shape, reshaped_res.name)
 
             tosa_graph.addOperator(
                 TosaOp.Op().RESCALE,
@@ -153,4 +153,4 @@ class AddmmVisitor(NodeVisitor):
 
         else:
             # non-quantized case
-            buildReshape(tosa_graph, conv2d_res.name, result_shape, output.name)
+            build_reshape(tosa_graph, conv2d_res.name, result_shape, output.name)

--- a/backends/arm/operators/op_conv2d.py
+++ b/backends/arm/operators/op_conv2d.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Arm Limited and/or its affiliates.
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -11,9 +11,9 @@ from executorch.backends.arm.operators.node_visitor import (
     register_node_visitor,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
-from executorch.backends.arm.tosa_quant_utils import buildRescaleOpConvOutput
+from executorch.backends.arm.tosa_quant_utils import build_rescale_conv_output
 from executorch.backends.arm.tosa_utils import (
-    buildReshape,
+    build_reshape,
     getNodeArgs,
     transpose_helper,
 )
@@ -94,7 +94,7 @@ class Conv2dVisitor(NodeVisitor):
                 ts.DType.INT8 if is_quant_node else weight.dtype,
             )
 
-            buildReshape(
+            build_reshape(
                 tosa_graph, weight.name, weight_post_shape, weight_reshaped.name
             )
 
@@ -169,7 +169,7 @@ class Conv2dVisitor(NodeVisitor):
             _, weight_scale, _, _, _, _ = getNodeArgs(node.args[1])
             _, output_scale, _, _, _, _ = getNodeArgs(list(node.users)[0])
 
-            conv2d_res = buildRescaleOpConvOutput(
+            conv2d_res = build_rescale_conv_output(
                 tosa_graph,
                 conv2d_res,
                 actual_out_type,

--- a/backends/arm/tosa_quant_utils.py
+++ b/backends/arm/tosa_quant_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Arm Limited and/or its affiliates.
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -17,7 +17,7 @@ dq_op = exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default
 dq_q_ops = [q_op, dq_op]
 
 
-def isQuantNode(node):
+def is_quant_node(node):
     consumer_node = list(node.users)[0]
     input = node.all_input_nodes[0]
 
@@ -36,19 +36,19 @@ def isQuantNode(node):
     )
 
 
-def isQuantArg(arg):
+def is_quant_arg(arg):
     consumer_node = list(arg.users)[0]
     return consumer_node.target == q_op
 
 
-def getQuantNodeArgs(node):
+def get_quant_node_args(node):
     quant_args = [TosaArg(arg) for arg in node.args]
     # Return the scale and zp
     return quant_args[1].number, quant_args[2].number
 
 
 # Check if scale32 mode is used for given output element type
-def isScale32(type):
+def is_scale32(type):
     return type == ts.DType.INT8
 
 
@@ -56,7 +56,7 @@ def isScale32(type):
 # The RESCALE operator is defined using an integer multiply, add, and shift.
 # This utility function is for calculating the multier and shift given a scale.
 # Ref: https://www.mlplatform.org/tosa/tosa_spec.html#_precision_scaling
-def computeMultiplierAndShift(scale, scaleWidth=32):
+def compute_multiplier_and_shift(scale, scaleWidth=32):
     if scaleWidth == 16:
         offset = 15
     elif scaleWidth == 32:
@@ -92,7 +92,7 @@ def computeMultiplierAndShift(scale, scaleWidth=32):
     return multiplier, shift
 
 
-def buildRescale(
+def build_rescale(
     tosa_fb,
     scale,
     input_node,
@@ -102,9 +102,8 @@ def buildRescale(
     output_zp,
     is_double_round,
 ):
-    is_scale32 = isScale32(output_type)
-    scale_width = 32 if is_scale32 else 16
-    multiplier, shift = computeMultiplierAndShift(scale, scale_width)
+    scale_width = 32 if is_scale32(output_type) else 16
+    multiplier, shift = compute_multiplier_and_shift(scale, scale_width)
 
     attr_rescale = ts.TosaSerializerAttribute()
     attr_rescale.RescaleAttribute(
@@ -112,7 +111,7 @@ def buildRescale(
         output_zp=output_zp,
         multiplier=[multiplier],
         shift=[shift],
-        scale32=is_scale32,
+        scale32=is_scale32(output_type),
         double_round=is_double_round,
         per_channel=False,
         input_unsigned=False,
@@ -127,10 +126,10 @@ def buildRescale(
     return rescale_out
 
 
-def buildRescaleToInt32(
+def build_rescale_to_int32(
     tosa_fb, input, input_zp, rescale_scale, is_scale32=True, is_double_round=True
 ) -> TosaSerializerTensor:
-    multiplier, shift = computeMultiplierAndShift(rescale_scale)
+    multiplier, shift = compute_multiplier_and_shift(rescale_scale)
     attr_rescale = ts.TosaSerializerAttribute()
     attr_rescale.RescaleAttribute(
         input_zp=input_zp,
@@ -154,7 +153,7 @@ def buildRescaleToInt32(
     return input_A_rescaled_to_int32
 
 
-def buildRescaleFromInt32(
+def build_rescale_from_int32(
     tosa_fb,
     input_name,
     output_name,
@@ -163,7 +162,7 @@ def buildRescaleFromInt32(
     is_scale32=True,
     is_double_round=True,
 ) -> TosaSerializerTensor:
-    multiplier, shift = computeMultiplierAndShift(rescale_scale)
+    multiplier, shift = compute_multiplier_and_shift(rescale_scale)
     attr_rescale_output = ts.TosaSerializerAttribute()
     attr_rescale_output.RescaleAttribute(
         input_zp=0,
@@ -187,17 +186,17 @@ def buildRescaleFromInt32(
 """ Creates a TOSA rescale op based on conv2d parameters. """
 
 
-def buildRescaleOpConvOutput(
+def build_rescale_conv_output(
     tosa_fb, op, output_type, input_scale, weight_scale, output_scale
 ):
     # Only use double round if we are doing 32 bit scaling
-    double_round = isScale32(output_type)
+    double_round = is_scale32(output_type)
 
     # TODO add check to verify if this is a Per-channel quantization.
     post_conv2d_scale = (input_scale.number * weight_scale.number) / output_scale.number
 
     # Since we assume the input tensor that is being rescaled is int32 date type, zero point must be 0.
-    rescale_op = buildRescale(
+    rescale_op = build_rescale(
         tosa_fb, post_conv2d_scale, op, output_type, op.shape, 0, 0, double_round
     )
     return rescale_op

--- a/backends/arm/tosa_utils.py
+++ b/backends/arm/tosa_utils.py
@@ -1,3 +1,8 @@
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import logging
 import os
 
@@ -104,8 +109,8 @@ def getNodeArgs(node):
 
 # Helper function to do broadcasting
 # Ref: https://www.mlplatform.org/tosa/tosa_spec.html#_broadcasting
-def broadcastShapes(shape1, shape2):
-    assert len(shape1) == len(shape2), "broadcastShape::shapes must have same ranks"
+def broadcast_shapes(shape1, shape2):
+    assert len(shape1) == len(shape2), "broadcast_shapes::shapes must have same ranks"
 
     need_broadcasting = False
     for val1, val2 in zip(shape1, shape2):
@@ -122,7 +127,7 @@ def broadcastShapes(shape1, shape2):
         else:
             assert not (
                 shape2[idx] != 1 and shape2[idx] != broadcasted_shape[idx]
-            ), "broadcastShape::broadcast shape mismatch"
+            ), "broadcast_shapes::broadcast shape mismatch"
 
     return broadcasted_shape
 
@@ -131,7 +136,7 @@ def broadcastShapes(shape1, shape2):
     No data conversion happens during a reshape operation. """
 
 
-def buildReshape(tosa_fb, input_name, new_shape, output_name):
+def build_reshape(tosa_fb, input_name, new_shape, output_name):
     attr = ts.TosaSerializerAttribute()
     attr.ReshapeAttribute(new_shape)
     tosa_fb.addOperator(TosaOp.Op().RESHAPE, [input_name], [output_name], attr)


### PR DESCRIPTION
- reformatted utility function signatures to match pep 8 convention

This PR is created to fix this issue https://github.com/pytorch/executorch/issues/1370