### PR TITLE
Cleanup EXIREdgeDialectVerifier to use the same logic to verify core

### DIFF
--- a/exir/verification/TARGETS
+++ b/exir/verification/TARGETS
@@ -1,5 +1,6 @@
 load("@fbcode_macros//build_defs:cpp_python_extension.bzl", "cpp_python_extension")
 load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
+load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 
 oncall("executorch")
 
@@ -55,5 +56,15 @@ python_library(
         "//executorch/exir:lowered_backend_module",
         "//executorch/exir/dialects/edge:lib",
         "//executorch/exir/emit:emit",
+    ],
+)
+
+python_unittest(
+    name = "test_verifier",
+    srcs = ["test/test_verifier.py"],
+    deps = [
+        ":verifier",
+        "//caffe2:torch",
+        "//executorch/exir/dialects:lib",
     ],
 )

--- a/exir/verification/test/test_verifier.py
+++ b/exir/verification/test/test_verifier.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from contextlib import contextmanager
+
+from executorch.exir.dialects._ops import ops
+from torch._export.verifier import SpecViolationError
+from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib  # noqa: F401
+
+from ..verifier import EXIREdgeDialectVerifier
+
+
+class TestEdgeDialectVerifier(unittest.TestCase):
+    @contextmanager
+    def assertNotRaises(self, exc_type):
+        try:
+            yield None
+        except exc_type:
+            raise self.failureException("{} raised".format(exc_type.__name__))
+
+    def test_edge_verifier_check_valid_op_succeed_given_custom_op(self) -> None:
+        edge_op = ops.edge.quantized_decomposed.quantize_per_tensor.default
+        verifier = EXIREdgeDialectVerifier(check_edge_ops=True)
+        with self.assertNotRaises(SpecViolationError):
+            verifier.check_valid_edge_op(edge_op)
+            verifier.check_valid_op(edge_op)

--- a/exir/verification/verifier.py
+++ b/exir/verification/verifier.py
@@ -144,6 +144,8 @@ def EXIREdgeDialectVerifier(  # noqa: C901
 
         def __init__(self) -> None:
             self.check_edge_ops = check_edge_ops
+            self.aten_op_verifier = EXIRATenDialectVerifier()
+            self.check_valid_aten_op = self.aten_op_verifier.check_valid_op
 
             if self.check_edge_ops:
                 self.check_valid_op = self.check_valid_edge_op
@@ -177,20 +179,6 @@ def EXIREdgeDialectVerifier(  # noqa: C901
                 self.check_valid_aten_op(op._op)
             if isinstance(op, types.FunctionType):
                 assert op.__name__ in ("alloc",)
-
-        def check_valid_aten_op(self, op) -> None:
-            if isinstance(op, OpOverload):
-                if (
-                    torch.Tag.core not in op.tags  # type: ignore[attr-defined]
-                    and torch.Tag.view_copy not in op.tags  # type: ignore[attr-defined]
-                ):
-                    # NOTE(qihan): whether view_copy operators are marked as canonical is still under
-                    #            discussion.
-                    raise SpecViolationError(
-                        "Operator {}.{} is not Aten Canonical.".format(
-                            op.__module__, op.__name__
-                        )
-                    )
 
         def check_additional(self, gm: GraphModule) -> None:
             if not enable:


### PR DESCRIPTION
Summary:
Making sure EXIREdgeDialectVerifier is able to verify core ATen ops
correctly. Getting rid of forked logic of `check_valid_aten_op`.

Differential Revision: D52492252


