### PR TITLE
Constant segment runtime tests

### DIFF
--- a/runtime/executor/test/method_test.cpp
+++ b/runtime/executor/test/method_test.cpp
@@ -55,6 +55,12 @@ class MethodTest : public ::testing::Test {
     load_program(std::getenv("ET_MODULE_INDEX_PATH"), "index");
     load_program(
         std::getenv("ET_MODULE_DYNAMIC_CAT_UNALLOCATED_IO_PATH"), "cat");
+    load_program(
+        std::getenv("ET_MODULE_LINEAR_CONSTANT_SEGMENT_PATH"),
+        "linear_constant_segment");
+    load_program(
+        std::getenv("ET_MODULE_LINEAR_CONSTANT_BUFFER_PATH"),
+        "linear_constant_buffer");
   }
 
  private:
@@ -194,6 +200,30 @@ TEST_F(MethodTest, AliasedIOTest) {
     EXPECT_FLOAT_EQ(
         output.toTensor().const_data_ptr<float>()[(2 * 4) + i], 1.f);
   }
+}
+
+TEST_F(MethodTest, ConstantSegmentTest) {
+  // Execute model with constants stored in segment.
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method =
+      programs_["linear_constant_segment"]->load_method("forward", &mmm.get());
+  ASSERT_EQ(method.error(), Error::Ok);
+
+  // Can execute the method.
+  Error err = method->execute();
+  ASSERT_EQ(err, Error::Ok);
+}
+
+TEST_F(MethodTest, ConstantBufferTest) {
+  // Execute model with constants stored in the program flatbuffer.
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method =
+      programs_["linear_constant_buffer"]->load_method("forward", &mmm.get());
+  ASSERT_EQ(method.error(), Error::Ok);
+
+  // Can execute the method.
+  Error err = method->execute();
+  ASSERT_EQ(err, Error::Ok);
 }
 
 // TODO(T161163608): Test is disabled due to a resize bug in tensor_index_out of

--- a/runtime/executor/test/targets.bzl
+++ b/runtime/executor/test/targets.bzl
@@ -85,6 +85,8 @@ def define_common_targets(is_fbcode = False):
             "ET_MODULE_ADD_PATH": "$(location fbcode//executorch/test/models:exported_programs[ModuleAdd.pte])",
             "ET_MODULE_DYNAMIC_CAT_UNALLOCATED_IO_PATH": "$(location fbcode//executorch/test/models:exported_programs[ModuleDynamicCatUnallocatedIO.pte])",
             "ET_MODULE_INDEX_PATH": "$(location fbcode//executorch/test/models:exported_programs[ModuleIndex.pte])",
+            "ET_MODULE_LINEAR_CONSTANT_BUFFER_PATH": "$(location fbcode//executorch/test/models:exported_programs[ModuleLinear-no-constant-segment.pte])",
+            "ET_MODULE_LINEAR_CONSTANT_SEGMENT_PATH": "$(location fbcode//executorch/test/models:exported_programs[ModuleLinear.pte])",
             "ET_MODULE_MULTI_ENTRY_PATH": "$(location fbcode//executorch/test/models:exported_programs[ModuleMultipleEntry.pte])",
         }
 
@@ -140,6 +142,7 @@ def define_common_targets(is_fbcode = False):
                 "//executorch/runtime/executor:program",
                 "//executorch/extension/data_loader:buffer_data_loader",
                 "//executorch/extension/data_loader:file_data_loader",
+                "//executorch/schema:program",
             ],
             env = modules_env,
         )


### PR DESCRIPTION
Summary:
- load segment when constants are in segment
- no segments when constants are in flatbuffer

Differential Revision: D52434413


