### PR TITLE
Check for missing method-related field before creating MethodMeta

### DIFF
--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -57,6 +57,8 @@ class BackendDelegate final {
       BackendInitContext& backend_init_context,
       BackendDelegate* out) {
     // Look up the backend.
+    ET_CHECK_OR_RETURN_ERROR(
+        delegate.id() != nullptr, InvalidProgram, "Missing backend id");
     const char* backend_id = delegate.id()->c_str();
     PyTorchBackendInterface* backend = get_backend_class(backend_id);
     ET_CHECK_OR_RETURN_ERROR(

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -602,6 +602,8 @@ Error Method::init(executorch_flatbuffer::ExecutionPlan* s_plan) {
           case executorch_flatbuffer::InstructionArguments::KernelCall: {
             const auto arg_idxs =
                 instruction->instr_args_as_KernelCall()->args();
+            ET_CHECK_OR_RETURN_ERROR(
+                arg_idxs != nullptr, InvalidProgram, "KernelCall args missing");
             auto res = gen_instruction_arguments(
                 method_allocator,
                 n_value_,
@@ -629,6 +631,10 @@ Error Method::init(executorch_flatbuffer::ExecutionPlan* s_plan) {
           case executorch_flatbuffer::InstructionArguments::DelegateCall: {
             const auto arg_idxs =
                 instruction->instr_args_as_DelegateCall()->args();
+            ET_CHECK_OR_RETURN_ERROR(
+                arg_idxs != nullptr,
+                InvalidProgram,
+                "DelegateCall args missing");
             auto res = gen_instruction_arguments(
                 method_allocator,
                 n_value_,

--- a/runtime/executor/tensor_parser_aten.cpp
+++ b/runtime/executor/tensor_parser_aten.cpp
@@ -51,8 +51,22 @@ Result<at::Tensor> parseTensor(
       static_cast<int8_t>(type));
   auto options = at::CPU(type).options();
 
-  // convert int32 in serialization to int64 for aten
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->sizes() != nullptr, InvalidProgram, "Missing sizes field");
   size_t ndim = s_tensor->sizes()->size();
+
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->dim_order() != nullptr,
+      InvalidProgram,
+      "Missing dim_order field");
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->dim_order()->size() == ndim,
+      InvalidProgram,
+      "dim_order size %" PRIu32 " != ndim %zu",
+      s_tensor->dim_order()->size(),
+      ndim);
+
+  // convert int32 in serialization to int64 for aten
   std::vector<int64_t> sizes(
       s_tensor->sizes()->begin(), s_tensor->sizes()->end());
   std::vector<int64_t> strides(ndim);

--- a/runtime/executor/tensor_parser_portable.cpp
+++ b/runtime/executor/tensor_parser_portable.cpp
@@ -56,11 +56,25 @@ Result<torch::executor::Tensor> parseTensor(
       NotSupported,
       "Fully dynamic tensor shapes not yet supported: T133200526");
 
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->sizes() != nullptr, InvalidProgram, "Missing sizes field");
+  const auto serialized_sizes = s_tensor->sizes()->data();
+  const auto dim = s_tensor->sizes()->size();
+
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->dim_order() != nullptr,
+      InvalidProgram,
+      "Missing dim_order field");
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->dim_order()->size() == dim,
+      InvalidProgram,
+      "dim_order size %" PRIu32 " != dim %" PRIu32,
+      s_tensor->dim_order()->size(),
+      dim);
+  const auto serialized_dim_order = s_tensor->dim_order()->data();
+
   exec_aten::SizesType* sizes = nullptr;
   exec_aten::DimOrderType* dim_order = nullptr;
-  const auto dim = s_tensor->sizes()->size();
-  const auto serialized_sizes = s_tensor->sizes()->data();
-  const auto serialized_dim_order = s_tensor->dim_order()->data();
   // For dynamic shape tensors, allocate local buffers to allow mutable sizes
   // and strides
   if (dynamism != TensorShapeDynamism::STATIC) {


### PR DESCRIPTION
Summary:
Some MethodMeta methods don't return Error, assuming that the underlying data is valid. Ensure that the underlying ExecutionPlan is valid for those fields before returning a MethodMeta.

For fields whose accessors do return Error or Result, we can check them at the time they're called and return non-fatally then.

Differential Revision: D52451736


