### PR TITLE
Avoid fatal checks in populate_operator_name

### DIFF
--- a/examples/portable/executor_runner/executor_runner.cpp
+++ b/examples/portable/executor_runner/executor_runner.cpp
@@ -59,7 +59,9 @@ int main(int argc, char** argv) {
   const char* model_path = FLAGS_model_path.c_str();
   Result<FileDataLoader> loader = FileDataLoader::from(model_path);
   ET_CHECK_MSG(
-      loader.ok(), "FileDataLoader::from() failed: 0x%" PRIx32, loader.error());
+      loader.ok(),
+      "FileDataLoader::from() failed: 0x%" PRIx32,
+      (uint32_t)loader.error());
 
   // Parse the program file. This is immutable, and can also be reused between
   // multiple execution invocations across multiple threads.
@@ -83,9 +85,9 @@ int main(int argc, char** argv) {
   Result<MethodMeta> method_meta = program->method_meta(method_name);
   ET_CHECK_MSG(
       method_meta.ok(),
-      "Failed to get method_meta for %s: 0x%x",
+      "Failed to get method_meta for %s: 0x%" PRIx32,
       method_name,
-      (unsigned int)method_meta.error());
+      (uint32_t)method_meta.error());
 
   //
   // The runtime does not use malloc/new; it allocates all memory using the
@@ -146,7 +148,7 @@ int main(int argc, char** argv) {
       method.ok(),
       "Loading of method %s failed with status 0x%" PRIx32,
       method_name,
-      method.error());
+      (uint32_t)method.error());
   ET_LOG(Info, "Method loaded.");
 
   // Prepare the inputs.
@@ -160,7 +162,7 @@ int main(int argc, char** argv) {
       status == Error::Ok,
       "Execution of method %s failed with status 0x%" PRIx32,
       method_name,
-      status);
+      (uint32_t)status);
   ET_LOG(Info, "Model executed successfully.");
 
   // Print the outputs.

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -57,6 +57,8 @@ class BackendDelegate final {
       BackendInitContext& backend_init_context,
       BackendDelegate* out) {
     // Look up the backend.
+    ET_CHECK_OR_RETURN_ERROR(
+        delegate.id() != nullptr, InvalidProgram, "Missing backend id");
     const char* backend_id = delegate.id()->c_str();
     PyTorchBackendInterface* backend = get_backend_class(backend_id);
     ET_CHECK_OR_RETURN_ERROR(

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -225,7 +225,6 @@ Result<InstructionArgs> gen_instruction_arguments(
       ET_ALLOCATE_LIST_OR_RETURN_ERROR(method_allocator, EValue*, num_args);
   for (size_t i = 0; i < num_args; ++i) {
     int32_t arg_idx = arg_idxs[i];
-    ET_LOG(Error, "Argument index %d vs num_values %zu", arg_idx, num_values);
     ET_CHECK_OR_RETURN_ERROR(
         arg_idx < num_values,
         InvalidProgram,

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -602,6 +602,8 @@ Error Method::init(executorch_flatbuffer::ExecutionPlan* s_plan) {
           case executorch_flatbuffer::InstructionArguments::KernelCall: {
             const auto arg_idxs =
                 instruction->instr_args_as_KernelCall()->args();
+            ET_CHECK_OR_RETURN_ERROR(
+                arg_idxs != nullptr, InvalidProgram, "KernelCall args missing");
             auto res = gen_instruction_arguments(
                 method_allocator,
                 n_value_,
@@ -629,6 +631,10 @@ Error Method::init(executorch_flatbuffer::ExecutionPlan* s_plan) {
           case executorch_flatbuffer::InstructionArguments::DelegateCall: {
             const auto arg_idxs =
                 instruction->instr_args_as_DelegateCall()->args();
+            ET_CHECK_OR_RETURN_ERROR(
+                arg_idxs != nullptr,
+                InvalidProgram,
+                "DelegateCall args missing");
             auto res = gen_instruction_arguments(
                 method_allocator,
                 n_value_,

--- a/runtime/executor/tensor_parser_aten.cpp
+++ b/runtime/executor/tensor_parser_aten.cpp
@@ -51,8 +51,22 @@ Result<at::Tensor> parseTensor(
       static_cast<int8_t>(type));
   auto options = at::CPU(type).options();
 
-  // convert int32 in serialization to int64 for aten
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->sizes() != nullptr, InvalidProgram, "Missing sizes field");
   size_t ndim = s_tensor->sizes()->size();
+
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->dim_order() != nullptr,
+      InvalidProgram,
+      "Missing dim_order field");
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->dim_order()->size() == ndim,
+      InvalidProgram,
+      "dim_order size %" PRIu32 " != ndim %zu",
+      s_tensor->dim_order()->size(),
+      ndim);
+
+  // convert int32 in serialization to int64 for aten
   std::vector<int64_t> sizes(
       s_tensor->sizes()->begin(), s_tensor->sizes()->end());
   std::vector<int64_t> strides(ndim);

--- a/runtime/executor/tensor_parser_portable.cpp
+++ b/runtime/executor/tensor_parser_portable.cpp
@@ -56,11 +56,25 @@ Result<torch::executor::Tensor> parseTensor(
       NotSupported,
       "Fully dynamic tensor shapes not yet supported: T133200526");
 
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->sizes() != nullptr, InvalidProgram, "Missing sizes field");
+  const auto serialized_sizes = s_tensor->sizes()->data();
+  const auto dim = s_tensor->sizes()->size();
+
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->dim_order() != nullptr,
+      InvalidProgram,
+      "Missing dim_order field");
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->dim_order()->size() == dim,
+      InvalidProgram,
+      "dim_order size %" PRIu32 " != dim %" PRIu32,
+      s_tensor->dim_order()->size(),
+      dim);
+  const auto serialized_dim_order = s_tensor->dim_order()->data();
+
   exec_aten::SizesType* sizes = nullptr;
   exec_aten::DimOrderType* dim_order = nullptr;
-  const auto dim = s_tensor->sizes()->size();
-  const auto serialized_sizes = s_tensor->sizes()->data();
-  const auto serialized_dim_order = s_tensor->dim_order()->data();
   // For dynamic shape tensors, allocate local buffers to allow mutable sizes
   // and strides
   if (dynamism != TensorShapeDynamism::STATIC) {


### PR DESCRIPTION
Summary: Make `populate_operator_name()` return an error so we can avoid crashing when there's a problem. Also ensure that the `overload` field is present before using it.

Differential Revision: D52451742


