### PR TITLE
Catch invalid scalar type when parsing tensors

### DIFF
--- a/runtime/core/exec_aten/util/scalar_type_util.h
+++ b/runtime/core/exec_aten/util/scalar_type_util.h
@@ -254,6 +254,16 @@ ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
 //
 
 /**
+ * Returns true if the parameter is one of the values covered by
+ * ET_FORALL_SCALAR_TYPES.
+ */
+inline bool isValid(exec_aten::ScalarType type) {
+  return static_cast<int8_t>(type) >= 0 &&
+      type < exec_aten::ScalarType::NumOptions &&
+      type != exec_aten::ScalarType::Undefined;
+}
+
+/**
  * Returns the name of a ScalarType as a C string.
  *
  * @param[in] t The type to get the name of.
@@ -539,38 +549,6 @@ inline exec_aten::ScalarType promoteTypes(
       };
 
   return _promoteTypesLookup[static_cast<int>(a)][static_cast<int>(b)];
-}
-
-/**
- * Return the size of corresponding ctype given ScalarType.
- */
-inline size_t sizeof_scalar_type(exec_aten::ScalarType type) {
-  // Reject types that are not yet supported or are out of bounds.
-  ET_CHECK_MSG(
-      type != exec_aten::ScalarType::Half &&
-          type != exec_aten::ScalarType::ComplexHalf &&
-          type != exec_aten::ScalarType::ComplexFloat &&
-          type != exec_aten::ScalarType::ComplexDouble &&
-          type != exec_aten::ScalarType::BFloat16 &&
-          type != exec_aten::ScalarType::Undefined,
-      "Invalid or unsupported ScalarType %" PRId8,
-      static_cast<int8_t>(type));
-
-  size_t type_size = 0;
-#define SCALAR_TYPE_SIZE(ctype, dtype) \
-  case exec_aten::ScalarType::dtype:   \
-    type_size = sizeof(ctype);         \
-    break;
-
-  switch (type) {
-    ET_FORALL_SCALAR_TYPES(SCALAR_TYPE_SIZE)
-    default:
-      ET_CHECK_MSG(
-          false, "Invalid input ScalarType %" PRId8, static_cast<int8_t>(type));
-  }
-#undef SCALAR_TYPE_SIZE
-
-  return type_size;
 }
 
 //

--- a/runtime/core/exec_aten/util/test/scalar_type_util_test.cpp
+++ b/runtime/core/exec_aten/util/test/scalar_type_util_test.cpp
@@ -70,6 +70,24 @@ TEST(ScalarTypeUtilTest, ElementSize) {
   }
 }
 
+TEST(ScalarTypeUtilTest, IsValid) {
+  // Some valid types.
+  EXPECT_TRUE(torch::executor::isValid(ScalarType::Byte));
+  EXPECT_TRUE(torch::executor::isValid(ScalarType::Float));
+  EXPECT_TRUE(torch::executor::isValid(ScalarType::ComplexFloat));
+  EXPECT_TRUE(torch::executor::isValid(ScalarType::Bits16));
+
+  // Undefined, which is sort of a special case since it's not part of the
+  // iteration macros but is still a part of the enum.
+  EXPECT_FALSE(torch::executor::isValid(ScalarType::Undefined));
+
+  // Some out-of-range types, also demonstrating that NumOptions is not really a
+  // scalar type.
+  EXPECT_FALSE(torch::executor::isValid(ScalarType::NumOptions));
+  EXPECT_FALSE(torch::executor::isValid(static_cast<ScalarType>(127)));
+  EXPECT_FALSE(torch::executor::isValid(static_cast<ScalarType>(-1)));
+}
+
 TEST(ScalarTypeUtilTest, UnknownTypeElementSizeDies) {
   // Undefined, which is sort of a special case since it's not part of the
   // iteration macros but is still a part of the enum.

--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -47,12 +47,12 @@ TensorImpl::TensorImpl(
       data_(data),
       dim_(dim),
       numel_(compute_numel(sizes, dim)),
-      capacity_(numel_ * sizeof_scalar_type(type)),
+      capacity_(numel_ * elementSize(type)),
       type_(type),
       shape_dynamism_(dynamism) {}
 
 size_t TensorImpl::nbytes() const {
-  return numel_ * sizeof_scalar_type(type_);
+  return numel_ * elementSize(type_);
 }
 
 ssize_t TensorImpl::size(ssize_t dim) const {
@@ -78,7 +78,7 @@ ScalarType TensorImpl::scalar_type() const {
 
 // Return the size of one element of the tensor
 ssize_t TensorImpl::element_size() const {
-  return sizeof_scalar_type(type_);
+  return elementSize(type_);
 }
 
 const ArrayRef<TensorImpl::SizesType> TensorImpl::sizes() const {
@@ -145,7 +145,7 @@ Error TensorImpl::internal_resize_contiguous(ArrayRef<SizesType> new_sizes) {
 
   // Upper bounded tensors can be reshaped but not beyond upper bound
   if (shape_dynamism_ == TensorShapeDynamism::DYNAMIC_BOUND) {
-    auto new_nbytes = new_numel * sizeof_scalar_type(type_);
+    auto new_nbytes = new_numel * elementSize(type_);
     ET_CHECK_OR_RETURN_ERROR(
         new_nbytes <= capacity_,
         NotSupported,

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -388,12 +388,11 @@ Error Method::parse_values() {
         // subtract one to keep the output in 0 based indexing for a
         // disgruntled debugger seeing this error message and checking
         // schema.fbs
-        ET_CHECK_MSG(
-            false,
-            "Enum KernelTypes type: %" PRIu32
-            " not supported. Please look in executorch/schema/program.fbs "
-            "to see which type this is.",
+        ET_LOG(
+            Error,
+            "Unknown KernelTypes value %" PRIu32,
             static_cast<uint32_t>(serialization_value->val_type()) - 1);
+        return Error::InvalidProgram;
     }
 
     // ~Method() will try to clean up n_value_ entries in the values_ array.

--- a/runtime/executor/method_meta.cpp
+++ b/runtime/executor/method_meta.cpp
@@ -59,7 +59,7 @@ size_t calculate_nbytes(
   for (ssize_t i = 0; i < sizes.size(); i++) {
     n *= sizes[i];
   }
-  return n * sizeof_scalar_type(scalar_type);
+  return n * torch::executor::elementSize(scalar_type);
 }
 
 } // namespace

--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -146,30 +146,33 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
 
   // Constant data may live inside the flatbuffer data (constant_buffer) or in a
   // separate segment (constant_segment). It should not be in both.
-  const auto& constant_buffer = flatbuffer_program->constant_buffer();
-  const auto& constant_segment = flatbuffer_program->constant_segment();
-
-  // Check if the constant data is inside a separate segment.
-  if (constant_segment != nullptr && constant_segment->offsets()->size() > 0) {
+  const auto* constant_segment = flatbuffer_program->constant_segment();
+  if (constant_segment != nullptr && constant_segment->offsets() != nullptr &&
+      constant_segment->offsets()->size() > 0) {
+    // The constant data is inside a separate segment.
+    const auto* constant_buffer = flatbuffer_program->constant_buffer();
     ET_CHECK_OR_RETURN_ERROR(
-        constant_buffer->size() == 0,
-        InvalidState,
-        "constant_buffer contains %u items, constant_segment.offsets contains %u items. Only one should be used.",
+        constant_buffer == nullptr || constant_buffer->size() == 0,
+        InvalidProgram,
+        "constant_buffer contains %u items, "
+        "constant_segment.offsets contains %u items. Only one should be used.",
         constant_buffer->size(),
         constant_segment->offsets()->size());
+    const auto* segments = flatbuffer_program->segments();
+    ET_CHECK_OR_RETURN_ERROR(
+        segments != nullptr, InvalidProgram, "No segments in program");
 
     // Load constant segment.
     // TODO(T171839323): Add test for segment_index > num available segments.
     ET_CHECK_OR_RETURN_ERROR(
-        constant_segment->segment_index() <
-            flatbuffer_program->segments()->size(),
-        InvalidArgument,
+        constant_segment->segment_index() < segments->size(),
+        InvalidProgram,
         "Constant segment index %d invalid for program segments range %d",
         constant_segment->segment_index(),
-        flatbuffer_program->segments()->size());
+        segments->size());
 
     const executorch_flatbuffer::DataSegment* data_segment =
-        flatbuffer_program->segments()->Get(constant_segment->segment_index());
+        segments->Get(constant_segment->segment_index());
     Result<FreeableBuffer> constant_segment_data = loader->Load(
         segment_base_offset + data_segment->offset(), data_segment->size());
     if (!constant_segment_data.ok()) {
@@ -199,7 +202,12 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
 size_t Program::num_methods() const {
   auto internal_program =
       static_cast<const executorch_flatbuffer::Program*>(internal_program_);
-  return internal_program->execution_plan()->size();
+  const auto execution_plan = internal_program->execution_plan();
+  if (execution_plan != nullptr) {
+    return execution_plan->size();
+  } else {
+    return 0;
+  }
 }
 
 Result<const char*> Program::get_method_name(size_t plan_index) const {

--- a/runtime/executor/tensor_parser_aten.cpp
+++ b/runtime/executor/tensor_parser_aten.cpp
@@ -9,6 +9,7 @@
 #include <executorch/runtime/executor/tensor_parser.h>
 
 #include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 #include <executorch/runtime/executor/memory_manager.h>
 #include <executorch/runtime/executor/program.h>
 #include <executorch/runtime/platform/profiler.h>
@@ -43,6 +44,11 @@ Result<at::Tensor> parseTensor(
 
   // get metadata
   at::ScalarType type = static_cast<at::ScalarType>(s_tensor->scalar_type());
+  ET_CHECK_OR_RETURN_ERROR(
+      isValid(type),
+      InvalidProgram,
+      "Invalid ScalarType %" PRId8,
+      static_cast<int8_t>(type));
   auto options = at::CPU(type).options();
 
   // convert int32 in serialization to int64 for aten


### PR DESCRIPTION
Summary:
Fail non-fatally when encountering an unknown/unhandled `ScalarType` in a `.pte` file. As part of this:
- Move the "types not supported yet" logic out of `scalar_type_util` and into `tensor_parser`, since that decision is an aspect of the runtime and not a fundamental aspect of `ScalarType`.
- Remove the now-duplicate `sizeof_scalar_type` function, which is the same as the exsting `elementSize` function. Before this diff, `sizeof_scalar_type` did the "unsupported" checks that have now moved.
- Add an `isValid()` function to let users of `ScalarType` know whether a given enum value is legit. This makes it possible to avoid the fatal error when calling `elementSize` on a bad value.
- Add unit tests for the new `isValid()`.

Differential Revision: D52451738


