### PR TITLE
Extract constants to segment by default

### DIFF
--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -56,7 +56,7 @@ class ExecutorchBackendConfig:
     # rather than encoding those constants in the flatbuffer data.
     # This reduces the memory overhead of creating the .pte file for models with
     # large constant data.
-    extract_constant_segment: bool = False
+    extract_constant_segment: bool = True
 
     # When extracting segments, the starting offset of each segment will be
     # aligned to this value (in bytes). When using mmap() to load segments, this


### PR DESCRIPTION
Summary: After this, set `ExecutorchBackendConfig(extract_constant_segment=False)` to use constant buffer instead of constant segment.

Differential Revision: D52451128


