### PR TITLE
Serialize fp16 llama

### DIFF
--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -310,6 +310,7 @@ class Llama2Model(EagerModelBase):
             max_batch_size=max_batch_size,
             **params,
         )
+        torch.set_default_tensor_type(torch.HalfTensor)
         self.model_ = Transformer(model_args)
         self.model_.load_state_dict(
             checkpoint, strict=False


### PR DESCRIPTION
Summary:
Set tensors to fp16 (instead of default fp32)

https://github.com/facebookresearch/llama/blob/1076b9c51c77ad06e9d7ba8a4c6df775741732bd/example.py#L47-L49

Differential Revision: D52496764


