### PR TITLE
Use scaled_dot_product_attention in llama model

### DIFF
--- a/extension/runner/module/module.cpp
+++ b/extension/runner/module/module.cpp
@@ -16,7 +16,9 @@ namespace torch::executor {
 Module::Module(const std::string& filePath)
     : Runner(
           ({
-            auto dataLoader = util::MmapDataLoader::from(filePath.c_str());
+            auto dataLoader = util::MmapDataLoader::from(
+                filePath.c_str(),
+                util::MmapDataLoader::MlockConfig::UseMlockIgnoreErrors);
             if (!dataLoader.ok()) {
               throw std::runtime_error("Failed to load file: " + filePath);
             }


### PR DESCRIPTION
Summary:
As titled. Use F.scaled_dot_product_attention in
examples/llama2/model.py

Reviewed By: digantdesai, iseeyuan

Differential Revision: D52499256


