### PR TITLE
squeeze mask for XNNPACK before SDPA

### DIFF
--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -216,6 +216,11 @@ class Attention(nn.Module):
             assert hasattr(self, "mask")
             mask = self.mask[:, :, :seqlen, :seqlen]
 
+            # This is needed to support XNNPACK which requires mask shape to be 2D.
+            # This is a temporary workaround. Once we update XNNPACK we should be able to handle this.
+            # Shape before: [1, 1, L, S], after: [L, S]
+            mask = torch.squeeze(self.mask[:, :, :seqlen, :seqlen])
+
         output = F.scaled_dot_product_attention(
             xq, keys, values, attn_mask=mask, dropout_p=0.0
         )


### PR DESCRIPTION
Summary: XNNPACK SDPA requires mask tensor to be 2D. Without the squeeze in the model, we have to insert a squeeze in XNNPACK which doesn't yet support the general squeeze of [1, 1, L, S] -> [L, S] for the mask. Newer XNNPACK supports it so this can be removed once we update XNNPACK.

Differential Revision: D52546184


