### PR TITLE
Handle XNNHeader in XNNPACK Runtime

### DIFF
--- a/backends/xnnpack/runtime/XNNHeader.cpp
+++ b/backends/xnnpack/runtime/XNNHeader.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/xnnpack/runtime/XNNHeader.h>
+
+#include <cstring>
+
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/result.h>
+
+#pragma clang diagnostic ignored "-Wdeprecated"
+
+namespace torch {
+namespace executor {
+namespace xnnpack {
+namespace delegate {
+
+namespace {
+/// Interprets the 8 bytes at `data` as a little-endian uint64_t.
+uint64_t GetUInt64LE(const uint8_t* data) {
+  return (uint64_t)data[0] | ((uint64_t)data[1] << 8) |
+      ((uint64_t)data[2] << 16) | ((uint64_t)data[3] << 24) |
+      ((uint64_t)data[4] << 32) | ((uint64_t)data[5] << 40) |
+      ((uint64_t)data[6] << 48) | ((uint64_t)data[7] << 56);
+}
+
+/// Interprets the 4 bytes at `data` as a little-endian uint32_t.
+uint32_t GetUInt32LE(const uint8_t* data) {
+  return (uint32_t)data[0] | ((uint32_t)data[1] << 8) |
+      ((uint32_t)data[2] << 16) | ((uint32_t)data[3] << 24);
+}
+
+} // namespace
+
+Result<XNNHeader> XNNHeader::Parse(const void* data, size_t size) {
+  const uint8_t* header_data = (const uint8_t*)data;
+
+  if (size < XNNHeader::kMinSize) {
+    return Error::InvalidArgument;
+  }
+
+  const uint8_t* magic_start = header_data + XNNHeader::kMagicOffset;
+  if (std::memcmp(magic_start, XNNHeader::kMagic, XNNHeader::kMagicSize) != 0) {
+    return Error::NotFound;
+  }
+
+  uint32_t flatbuffer_offset =
+      GetUInt32LE(header_data + XNNHeader::kFlatbufferDataOffsetOffset);
+
+  uint32_t flatbuffer_size =
+      GetUInt32LE(header_data + XNNHeader::kFlatbufferDataSizeOffset);
+
+  uint32_t constant_data_offset =
+      GetUInt32LE(header_data + XNNHeader::kConstantDataOffsetOffset);
+
+  uint64_t constant_data_size =
+      GetUInt64LE(header_data + XNNHeader::kConstantDataSizeOffset);
+
+  return XNNHeader{
+      flatbuffer_offset,
+      flatbuffer_size,
+      constant_data_offset,
+      constant_data_size};
+}
+
+// Define storage for the static.
+constexpr char XNNHeader::kMagic[kMagicSize];
+
+} // namespace delegate
+} // namespace xnnpack
+} // namespace executor
+} // namespace torch

--- a/backends/xnnpack/runtime/XNNHeader.h
+++ b/backends/xnnpack/runtime/XNNHeader.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/runtime/core/result.h>
+
+namespace torch {
+namespace executor {
+namespace xnnpack {
+namespace delegate {
+
+/**
+ * An extended XNNPACK-header that is embeded before the flatbuffer payload
+ *
+ */
+struct XNNHeader {
+  /**
+   * The minimum size of the XNNHeader. The caller should provide at least this
+   * many bytes of the head of the serialized XNNPACK Data
+   */
+  static constexpr size_t kMinSize = 30;
+
+  /**
+   * The magic offset. This offset is the same as the offset for flatbuffer
+   * header so we will be able to check if the header is is either the
+   * flatbuffer head or the wrapper header we introduce here
+   */
+  static constexpr size_t kMagicOffset = 4;
+
+  /**
+   * The magic bytes that identify the header.
+   *
+   * This is the canonical definition of the expected value. If the header
+   * layout ever changes in a compatibility-breaking way, increment the digits
+   * in the magic. But, doing so will prevent older binaries from recognizing
+   * the presence of the header. The compatibility-preserving way to make
+   * changes is to increase the header's length field and add new fields at the
+   * end.
+   */
+  static constexpr size_t kMagicSize = 4;
+  static constexpr char kMagic[kMagicSize] = {'X', 'H', '0', '0'};
+
+  /**
+   * The size in bytes of the header length. We store 2 bytes for the header
+   * length
+   */
+  static constexpr size_t kHeaderLengthSize = 2;
+
+  /**
+   * The expected location of the header length field relative to the beginning
+   * of the header.
+   */
+  static constexpr size_t kHeaderLengthOffset =
+      XNNHeader::kMagicOffset + XNNHeader::kMagicSize;
+
+  /**
+   * The expected location of the flatbuffer data offset field relative to the
+   * beginning of the header.
+   */
+  static constexpr size_t kFlatbufferDataOffsetOffset =
+      kHeaderLengthOffset + sizeof(uint16_t);
+
+  /**
+   * The expected location of the flatbuffer data size field relative to the
+   * beginning of the header.
+   */
+  static constexpr size_t kFlatbufferDataSizeOffset =
+      kFlatbufferDataOffsetOffset + sizeof(uint32_t);
+
+  /*
+   * The expected location of the constant data offset field relative to the
+   * beginning of the header.
+   */
+  static constexpr size_t kConstantDataOffsetOffset =
+      kFlatbufferDataSizeOffset + sizeof(uint32_t);
+
+  /*
+   * The expected location of the constant data size field relative to the
+   * beginning of the header.
+   */
+  static constexpr size_t kConstantDataSizeOffset =
+      kConstantDataOffsetOffset + sizeof(uint32_t);
+
+  /**
+   * Look for and parse an ExtendedHeader in the provided data.
+   *
+   * @param[in] data The contents of the beginning of the serialized binary
+   *     Program data, starting at offset 0 (i.e., the head of the file).
+   * @param[in] size Length of `data` in bytes.
+   *
+   * @returns an XNNHeader if the header was found and is valid. Returns an
+   *     error if size was too short, if the header was not found, or if the
+   *     header appeared to be corrupt.
+   */
+  static Result<XNNHeader> Parse(const void* data, size_t size);
+
+  /**
+   * The offset in bytes to the beginning of the flatbuffer data.
+   */
+  uint32_t flatbuffer_offset;
+  /**
+   * The size in bytes of the flatbuffer data.
+   */
+  uint32_t flatbuffer_size;
+
+  /**
+   * The offset in bytes to the beginning of the constant data.
+   */
+  uint32_t constant_data_offset;
+  /**
+   * The size in bytes of the constant data.
+   */
+  uint64_t constant_data_size;
+};
+
+} // namespace delegate
+} // namespace xnnpack
+} // namespace executor
+} // namespace torch

--- a/backends/xnnpack/serialization/schema.fbs
+++ b/backends/xnnpack/serialization/schema.fbs
@@ -281,6 +281,17 @@ table XNNLeakyReLU {
   flags: uint;
 }
 
+// Describes data offsets for constant data
+table ConstantDataOffset {
+  // Constant data offsets are relative to the constant data base offset provided
+  // in the XNNPACKHeader.
+  offset: uint64;
+
+  // The size in bytes of valid data starting at the offset. The constant data
+  // may be followed by padding before the next piece of constant data
+  size: uint64;
+}
+
 table XNNGraph {
   // Schema version.
   version:string;
@@ -299,11 +310,16 @@ table XNNGraph {
   // Tables of constant data, used for constant Values (e.g.
   // data field of weight tensors). Each constant is assigned an index into the table
   // which are each individually aligned. 0 index is reserved to be pointed to by non-constant
-  // Tensors
+  // Tensors. Exactly one of constant_buffer and constant_data must be non-empty
   constant_buffer:[Buffer];
 
   // the list index is memory buffer id, the value is the memory buffer size.
   mem_buffer_sizes: [uint];
+
+  // List of the constant data that follows the XNNGraph in this file. Each constant data is assigned an index into
+  // the table. 0 index is reserved to be pointed to by non-constant Tensor. Exactly one of constant_buffer and
+  // constant_data must be non-empty
+  constant_data:[ConstantDataOffset];
 }
 
 root_type XNNGraph;

--- a/backends/xnnpack/serialization/xnnpack_graph_schema.py
+++ b/backends/xnnpack/serialization/xnnpack_graph_schema.py
@@ -418,6 +418,12 @@ class Buffer:
 
 
 @dataclass
+class ConstantDataOffset:
+    offset: int
+    size: int
+
+
+@dataclass
 class XNNGraph:
     version: str
     xnodes: List[XNode]
@@ -429,3 +435,5 @@ class XNNGraph:
 
     constant_buffer: List[Buffer]
     mem_buffer_sizes: List[int]
+
+    constant_data: List[ConstantDataOffset]

--- a/backends/xnnpack/serialization/xnnpack_graph_serialize.py
+++ b/backends/xnnpack/serialization/xnnpack_graph_serialize.py
@@ -8,13 +8,19 @@ import json
 import os
 import tempfile
 
-from dataclasses import fields, is_dataclass
+from dataclasses import dataclass, fields, is_dataclass
+from typing import ClassVar, Literal
 
 import pkg_resources
 from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import XNNGraph
 from executorch.exir._serialize._dataclass import _DataclassEncoder
 
 from executorch.exir._serialize._flatbuffer import _flatc_compile
+
+# Byte order of numbers written to program headers. Always little-endian
+# regardless of the host system, since all commonly-used modern CPUs are little
+# endian.
+_HEADER_BYTEORDER: Literal["little"] = "little"
 
 
 def sanity_check_xnngraph_dataclass(table, name: str = ""):
@@ -66,6 +72,168 @@ def sanity_check_xnngraph_dataclass(table, name: str = ""):
                     check_for_sym(v, _name_field_i)
         else:
             check_for_sym(o, _name_field)
+
+
+@dataclass
+class XNNHeader:
+    # Class Constants
+    MAGIC_OFFSET: ClassVar[slice] = slice(4, 8)
+    HEADER_SIZE_OFFSET: ClassVar[slice] = slice(8, 10)
+    FLATBUFFER_OFFSET_OFFSET: ClassVar[slice] = slice(10, 14)
+    FLATBUFFER_SIZE_OFFSET: ClassVar[slice] = slice(14, 18)
+    CONSTANT_DATA_OFFSET_OFFSET: ClassVar[slice] = slice(18, 22)
+    CONSTANT_DATA_SIZE_OFFSET: ClassVar[slice] = slice(22, 30)
+
+    # magic bytes that should be at the beginning of the header
+    EXPECTED_MAGIC: ClassVar[bytes] = b"XH00"
+    # The length of the header in bytes.
+    EXPECTED_LENGTH: ClassVar[int] = (
+        # Zeros magic
+        # We offset the magic by 4 bytes so that it is in the same location
+        # as the flatbuffer payload's magic. This way we can dynamically
+        # choose between the XNNPACK Header and Flatbuffer Header
+        4
+        # Header magic
+        + 4
+        # Header Length
+        + 2
+        # Flatbuffer offset
+        + 4
+        # Flatbuffer size
+        + 4
+        # Constant Data offset
+        + 4
+        # Constant Data size
+        + 8
+    )
+
+    # Instance attributes. @dataclass will turn these into ctor args.
+
+    # offset to the flatbuffer data
+    flatbuffer_offset: int
+
+    # flatbuffer size
+    flatbuffer_size: int
+
+    # offset to the constant data
+    constant_data_offset: int
+
+    # constant data size
+    constant_data_size: int
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "XNNHeader":
+        """
+        Converts the given bytes into an XNNHeader object.
+
+        We check that the magic and length is valid, but do not check that the offset and
+        size values are valid. We ensure here that the XNNHeader metadata is valid (magic and length)
+        but not the offsets and sizes themselves. Callers should use is_valid() to validate the
+        header contents
+
+        Args:
+            data: Data to read from
+        Returns:
+            XNNHeader object that contains the parsed data
+        Raises:
+            ValueError: if not enough data is provided, or if parsed length/magic are invalid
+        """
+        if len(data) > XNNHeader.EXPECTED_LENGTH:
+            raise ValueError(
+                f"Invalid XNNHeader: expected no more than {XNNHeader.EXPECTED_LENGTH} bytes, got {len(data)}"
+            )
+
+        magic: bytes = data[XNNHeader.MAGIC_OFFSET]
+        length_bytes: bytes = data[XNNHeader.HEADER_SIZE_OFFSET]
+        flatbuffer_offset_bytes: bytes = data[XNNHeader.FLATBUFFER_OFFSET_OFFSET]
+        flatbuffer_size_bytes: bytes = data[XNNHeader.FLATBUFFER_SIZE_OFFSET]
+        constant_data_offset_bytes: bytes = data[XNNHeader.CONSTANT_DATA_OFFSET_OFFSET]
+        constant_data_size_bytes: bytes = data[XNNHeader.CONSTANT_DATA_SIZE_OFFSET]
+
+        length = int.from_bytes(length_bytes, byteorder=_HEADER_BYTEORDER)
+
+        if magic != XNNHeader.EXPECTED_MAGIC:
+            raise ValueError(
+                f"Invalid XNNHeader: invalid magic bytes {magic}, expected {XNNHeader.EXPECTED_MAGIC}"
+            )
+        if length != len(data):
+            raise ValueError(
+                f"Invalid XNNHeader: Invalid parsed length: data given was {len(data)} bytes, parsed length was {length} bytes"
+            )
+
+        return XNNHeader(
+            flatbuffer_offset=int.from_bytes(
+                flatbuffer_offset_bytes, byteorder=_HEADER_BYTEORDER
+            ),
+            flatbuffer_size=int.from_bytes(
+                flatbuffer_size_bytes, byteorder=_HEADER_BYTEORDER
+            ),
+            constant_data_offset=int.from_bytes(
+                constant_data_offset_bytes, byteorder=_HEADER_BYTEORDER
+            ),
+            constant_data_size=int.from_bytes(
+                constant_data_size_bytes, byteorder=_HEADER_BYTEORDER
+            ),
+        )
+
+    def is_valid(self) -> bool:
+        """
+        Sanity checks the the XNNHeader.
+
+        We check that the flatbuffer size is non_zero and that the constant data offset
+        is after the flatbuffer payload. We check that the constant data size is non-negative.
+
+        Returns:
+            True if the XNNHeader is valid, False otherwise
+        """
+        # flatbuffer payload must have a non-zero size
+        valid_flatbuffer_size = self.flatbuffer_size > 0
+        # constant data offset is after flatbuffer payload
+        valid_const_data_offset = (
+            self.constant_data_offset >= self.flatbuffer_offset + self.flatbuffer_size
+        )
+        valid_const_data_size = self.constant_data_size >= 0
+
+        return (
+            valid_flatbuffer_size and valid_const_data_offset and valid_const_data_size
+        )
+
+    def to_bytes(self) -> bytes:
+        """
+        Converts XNNHeader to bytes for serialization.
+
+        Returns:
+            Returns the binary representation of the XNNPACK Header.
+        """
+
+        # We expect the given offsets and sizes to be valid
+        if not self.is_valid():
+            raise ValueError("Invalid XNNHeader: header failed is_valid() check")
+
+        data: bytes = (
+            # Padding for magic bytes. This is so that header magic is in the same position
+            # as the flatbuffer magic, and allows consumer to detect whether the header is
+            # being used or not
+            b"\x00\x00\x00\x00"
+            # XNNPACK Header's magic. This allows consumer to detect whether or not the header
+            # is being used or the flatbuffer header is being used
+            + self.EXPECTED_MAGIC
+            # uint16_t: Size of this header. This makes it easier to add new fields to the header
+            # in the future.
+            + self.EXPECTED_LENGTH.to_bytes(2, byteorder=_HEADER_BYTEORDER)
+            # uint32_t: Offset to the start of the flatbuffer data
+            + self.flatbuffer_offset.to_bytes(4, byteorder=_HEADER_BYTEORDER)
+            # uint32_t: Size of the flatbuffer data payload
+            + self.flatbuffer_size.to_bytes(4, byteorder=_HEADER_BYTEORDER)
+            # uint32_t: Offset to the start of the constant data
+            + self.constant_data_offset.to_bytes(4, byteorder=_HEADER_BYTEORDER)
+            # uint64_t: Size of the constant data
+            + self.constant_data_size.to_bytes(8, byteorder=_HEADER_BYTEORDER)
+        )
+
+        assert len(data) == XNNHeader.EXPECTED_LENGTH
+
+        return data
 
 
 def convert_to_flatbuffer(xnnpack_graph: XNNGraph) -> bytes:

--- a/backends/xnnpack/test/TARGETS
+++ b/backends/xnnpack/test/TARGETS
@@ -1,6 +1,8 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()
 
 runtime.python_test(
@@ -58,5 +60,15 @@ runtime.python_test(
     ],
     external_deps = [
         "libtorch",
+    ],
+)
+
+runtime.python_test(
+    name = "test_xnnpack_serialization",
+    srcs = glob([
+        "serialization/*.py",
+    ]),
+    deps = [
+        "//executorch/backends/xnnpack:xnnpack_preprocess",
     ],
 )

--- a/backends/xnnpack/test/serialization/test_serialization.py
+++ b/backends/xnnpack/test/serialization/test_serialization.py
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import random
+import unittest
+from typing import List, Tuple
+
+from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
+    Buffer,
+    XNNGraph,
+)
+
+from executorch.backends.xnnpack.serialization.xnnpack_graph_serialize import (
+    _HEADER_BYTEORDER,
+    serialize_xnnpack_binary,
+    XNNHeader,
+)
+
+
+class TestSerialization(unittest.TestCase):
+    def _generate_random_const_buffers(
+        self, num_tensors: int
+    ) -> Tuple[List[Buffer], List[int]]:
+        """
+        Helper function to generate `num_tensor` buffers of random sizes and random contents,
+        we return a tuple of (list_of_buffers, list_of_mem_sizes),
+        """
+        buffers = []
+        mem_sizes = []
+        for _ in range(num_tensors):
+            buffer_size = random.randint(1, 1000)
+            buffer = bytearray(os.urandom(buffer_size))
+            buffers.append(Buffer(storage=bytes(buffer)))
+            mem_sizes.append(buffer_size)
+
+        return buffers, mem_sizes
+
+    def test_serialize_xnnpack_binary(self):
+        xnn_graph = XNNGraph(
+            version="0",
+            xnodes=[],
+            xvalues=[],
+            num_externs=0,
+            input_ids=[],
+            output_ids=[],
+            constant_buffer=[Buffer(storage=b"")],
+            mem_buffer_sizes=[0],
+            constant_data=[],
+        )
+        buffers, sizes = self._generate_random_const_buffers(5)
+        xnn_graph.constant_buffer.extend(buffers)
+        xnn_graph.mem_buffer_sizes.extend(sizes)
+        buffers = xnn_graph.constant_buffer
+
+        serialized_binary = serialize_xnnpack_binary(xnn_graph)
+        offsets = xnn_graph.constant_data
+
+        # Check header
+        self.assertEqual(serialized_binary[0:4], b"\x00\x00\x00\x00")
+        self.assertEqual(serialized_binary[XNNHeader.MAGIC_OFFSET], b"XH00")
+        flatbuffer_offset_bytes = serialized_binary[XNNHeader.FLATBUFFER_OFFSET_OFFSET]
+        constant_data_offset_bytes = serialized_binary[
+            XNNHeader.CONSTANT_DATA_OFFSET_OFFSET
+        ]
+
+        # Check flatbuffer is at flatbuffer offset
+        flatbuffer_offset = int.from_bytes(
+            flatbuffer_offset_bytes, byteorder=_HEADER_BYTEORDER
+        )
+        # Flatbuffer magic should be in the same spot as the Header's magic
+        self.assertEqual(
+            serialized_binary[flatbuffer_offset:][XNNHeader.MAGIC_OFFSET], b"XN00"
+        )
+
+        # Check constant data
+        # Check that constant buffers have been moved to constant data
+        self.assertEqual(len(offsets), len(buffers))
+        self.assertEqual(len(xnn_graph.constant_buffer), 0)
+
+        constant_data_offset = int.from_bytes(
+            constant_data_offset_bytes, byteorder=_HEADER_BYTEORDER
+        )
+        constant_data_payload = serialized_binary[constant_data_offset:]
+
+        # We check that constant data indexes stored in the xnn_graph correctly index
+        # into the correct buffer in the constant data section
+        for idx in range(1, len(offsets)):
+            offset = offsets[idx].offset
+            size = offsets[idx].size
+
+            constant_data_bytes = constant_data_payload[offset : offset + size]
+            constant_buffer_bytes = buffers[idx].storage
+
+            self.assertEqual(constant_data_bytes, constant_buffer_bytes)

--- a/backends/xnnpack/test/serialization/test_xnnheader.py
+++ b/backends/xnnpack/test/serialization/test_xnnheader.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from executorch.backends.xnnpack.serialization.xnnpack_graph_serialize import XNNHeader
+
+EXAMPLE_FLATBUFFER_OFFSET: int = 0x11223344
+EXAMPLE_FLATBUFFER_SIZE: int = 0x55667788
+EXAMPLE_CONSTANT_DATA_OFFSET: int = EXAMPLE_FLATBUFFER_OFFSET + EXAMPLE_FLATBUFFER_SIZE
+EXAMPLE_CONSTANT_DATA_SIZE: int = 0x99AABBCC99AABBCC
+
+# If header layout or magic changes, this test must change too.
+# The layout of the header is a contract, not an implementation detail
+EXAMPLE_HEADER_DATA: bytes = (
+    # zeros
+    b"\x00\x00\x00\x00"
+    # magic
+    + b"XH00"
+    # All Values below are littl Endian
+    # header length
+    + b"\x1E\x00"
+    # Flatbuffer Offset
+    + b"\x44\x33\x22\x11"
+    # Flatbuffer Size
+    + b"\x88\x77\x66\x55"
+    # Constant Data Offset
+    + b"\xCC\xAA\x88\x66"
+    # Constant Data Size
+    + b"\xCC\xBB\xAA\x99\xCC\xBB\xAA\x99"
+)
+
+
+class TestXNNHeader(unittest.TestCase):
+    def test_to_bytes(self) -> None:
+        header = XNNHeader(
+            EXAMPLE_FLATBUFFER_OFFSET,
+            EXAMPLE_FLATBUFFER_SIZE,
+            EXAMPLE_CONSTANT_DATA_OFFSET,
+            EXAMPLE_CONSTANT_DATA_SIZE,
+        )
+        self.assertEqual(header.to_bytes(), EXAMPLE_HEADER_DATA)
+        self.assertTrue(header.is_valid())
+
+    def test_from_bytes(self) -> None:
+        header = XNNHeader.from_bytes(EXAMPLE_HEADER_DATA)
+        self.assertEqual(header.flatbuffer_offset, EXAMPLE_FLATBUFFER_OFFSET)
+        self.assertEqual(header.flatbuffer_size, EXAMPLE_FLATBUFFER_SIZE)
+        self.assertEqual(header.constant_data_offset, EXAMPLE_CONSTANT_DATA_OFFSET)
+        self.assertEqual(header.constant_data_size, EXAMPLE_CONSTANT_DATA_SIZE)
+
+    def test_invalid_metadata(self) -> None:
+        WRONG_MAGIC_DATA = EXAMPLE_HEADER_DATA[0:4] + b"YT01" + EXAMPLE_HEADER_DATA[8:]
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid XNNHeader: invalid magic bytes b'YT01', expected b'XH00'",
+        ):
+            XNNHeader.from_bytes(WRONG_MAGIC_DATA)
+
+        WRONG_LENGTH_DATA = (
+            EXAMPLE_HEADER_DATA[0:8] + b"\x1D\x00" + EXAMPLE_HEADER_DATA[10:]
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid XNNHeader: Invalid parsed length: data given was 30 bytes, parsed length was 29 bytes",
+        ):
+            XNNHeader.from_bytes(WRONG_LENGTH_DATA)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid XNNHeader: expected no more than 30 bytes, got 31",
+        ):
+            XNNHeader.from_bytes(EXAMPLE_HEADER_DATA + b"\x00")
+
+    def test_invalid_flatbuffer_size(self) -> None:
+        header = XNNHeader(
+            EXAMPLE_FLATBUFFER_OFFSET,
+            0,
+            EXAMPLE_CONSTANT_DATA_OFFSET,
+            EXAMPLE_CONSTANT_DATA_SIZE,
+        )
+
+        with self.assertRaises(ValueError):
+            header.to_bytes()
+
+    def test_invalid_constant_data_offset(self) -> None:
+        header = XNNHeader(
+            EXAMPLE_FLATBUFFER_OFFSET,
+            EXAMPLE_FLATBUFFER_SIZE,
+            EXAMPLE_FLATBUFFER_OFFSET + EXAMPLE_FLATBUFFER_SIZE - 1,
+            EXAMPLE_CONSTANT_DATA_SIZE,
+        )
+
+        with self.assertRaises(ValueError):
+            header.to_bytes()
+
+    def test_to_bytes_same_as_from_bytes(self) -> None:
+        header = XNNHeader.from_bytes(EXAMPLE_HEADER_DATA)
+
+        to_bytes = header.to_bytes()
+        self.assertEquals(EXAMPLE_HEADER_DATA, to_bytes)

--- a/backends/xnnpack/xnnpack_preprocess.py
+++ b/backends/xnnpack/xnnpack_preprocess.py
@@ -231,6 +231,7 @@ class XnnpackBackend(BackendDetails):
             output_ids=[],
             constant_buffer=[Buffer(storage=b"")],
             mem_buffer_sizes=[0],
+            constant_data=[],
         )
 
         node_visitors = get_node_visitors(ep, node_to_external_map)


### PR DESCRIPTION
Summary:
We introduce XNNHeader on runtime side to handle the newly introduced XNNHeader ahead of time. XNNHeader manages the offsets and sizes of the flatbuffer payload and the constant data payload so that it is accessible by the XNNCompiler

It is important to note that on serialization side, we have not yet switched our serialization method to `serialize_xnnpack_binary` so this does not yet use the new serialization format. However, passing tests on this illustrates BC as old models will still be able to run on this new runtime.

Passing tests here show that the Header Magic correctly works in discerning between using the XNNHeader and the Flatbuffer header

Differential Revision: D52556131


