### PR TITLE
[Executorch][Portable] Fix cmake build for portable ops

### DIFF
--- a/.ci/scripts/test_quantized_aot_lib.sh
+++ b/.ci/scripts/test_quantized_aot_lib.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -exu
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
+
+which "${PYTHON_EXECUTABLE}"
+# Just set this variable here, it's cheap even if we use buck2
+CMAKE_OUTPUT_DIR=cmake-out
+
+build_cmake_quantized_aot_lib() {
+  echo "Building quantized aot lib"
+  SITE_PACKAGES="$(${PYTHON_EXECUTABLE} -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')"
+  CMAKE_PREFIX_PATH="${SITE_PACKAGES}/torch"
+  (rm -rf ${CMAKE_OUTPUT_DIR} \
+    && mkdir ${CMAKE_OUTPUT_DIR} \
+    && cd ${CMAKE_OUTPUT_DIR} \
+    && retry cmake -DBUCK2=buck2 \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
+      -DREGISTER_QUANTIZED_OPS=ON \
+      -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
+
+  cmake --build ${CMAKE_OUTPUT_DIR} -j4
+}
+
+build_cmake_quantized_aot_lib

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -108,6 +108,29 @@ jobs:
         # Test selective build
         PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
 
+  test-quantized-aot-lib-linux:
+    name: test-quantized-aot-lib-linux
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    strategy:
+      matrix:
+        include:
+          - build-tool: cmake
+      fail-fast: false
+    with:
+      runner: linux.2xlarge
+      docker-image: executorch-ubuntu-22.04-clang12
+      submodules: 'true'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 90
+      script: |
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        BUILD_TOOL=${{ matrix.build-tool }}
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+        PYTHON_EXECUTABLE=python bash .ci/scripts/test_quantized_aot_lib.sh
+
   unittest:
     uses: ./.github/workflows/_unittest.yml
     with:

--- a/kernels/portable/cpu/util/index_util.cpp
+++ b/kernels/portable/cpu/util/index_util.cpp
@@ -65,7 +65,7 @@ void get_index_select_out_target_size(
     const Tensor& in,
     int64_t dim,
     const Tensor& index,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim) {
   *out_ndim = in.dim();
   for (size_t i = 0; i < in.dim(); ++i) {

--- a/kernels/portable/cpu/util/index_util.h
+++ b/kernels/portable/cpu/util/index_util.h
@@ -24,7 +24,7 @@ void get_index_select_out_target_size(
     const Tensor& in,
     int64_t dim,
     const Tensor& index,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
 
 bool check_scatter_add_args(

--- a/kernels/portable/cpu/util/reduce_util.cpp
+++ b/kernels/portable/cpu/util/reduce_util.cpp
@@ -12,7 +12,7 @@
 #include <executorch/runtime/platform/assert.h>
 #include <cstring>
 
-#ifndef USE_ATEN_MODE
+#ifndef USE_ATEN_LIB
 #include <executorch/kernels/portable/cpu/util/index_util.h>
 #endif
 
@@ -321,7 +321,7 @@ Error resize_reduction_out(
   return resize_tensor(out, out_size);
 }
 
-#ifndef USE_ATEN_MODE
+#ifndef USE_ATEN_LIB
 
 /**
  * Check the validity of arguments for reduction operators.

--- a/kernels/portable/cpu/util/reduce_util.h
+++ b/kernels/portable/cpu/util/reduce_util.h
@@ -596,7 +596,7 @@ Error resize_reduction_out(
     bool keepdim,
     exec_aten::Tensor& out);
 
-#ifndef USE_ATEN_MODE
+#ifndef USE_ATEN_LIB
 bool check_reduction_args(
     const Tensor& in,
     const optional<ArrayRef<int64_t>>& dim_list,

--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -169,6 +169,6 @@ def define_common_targets():
                 "//executorch/runtime/core/exec_aten/util:tensor_util{}".format(suffix),
                 ":index_util",
             ],
-            exported_preprocessor_flags = ["-DUSE_ATEN_MODE"] if aten_mode else [],
+            exported_preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],
             visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/quantized/..."],
         )

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -47,6 +47,7 @@ set(_quantized_sources
     ${_quantized_kernels__srcs}
     ${EXECUTORCH_ROOT}/runtime/core/exec_aten/util/tensor_util_aten.cpp # This
     # is a hack
+    ${EXECUTORCH_ROOT}/kernels/portable/cpu/util/reduce_util.cpp
 )
 gen_custom_ops_aot_lib("quantized_ops_aot_lib" "${_quantized_sources}")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1553
* __->__ #1552

Summary:
When building quantized aot lib quantized ops build fails due to
- SizesType not using aliased namedspace
- Use of USE_ATEN_MODE vs USE_ATEN_LIB requires changing
  build/Utils.cmake

Also added quantized op lib cmake flow to CI

Test Plan:
(rm -rf cmake-out && mkdir cmake-out && cd cmake-out && cmake
-DBUCK2=/home/kimishpatel/buck2
-DCMAKE_PREFIX_PATH=/data/users/kimishpatel/anaconda3/envs/executorch/lib/python3.10/site-packages/torch/
-DREGISTER_QUANTIZED_OPS=ON ..)
cmake --build cmake-out -j16

Reviewers:

Subscribers:

Tasks:

Tags: