### PR TITLE
wrap dict in struct

### DIFF
--- a/shim/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim/xplat/executorch/build/runtime_wrapper.bzl
@@ -30,7 +30,7 @@ load(":env_interface.bzl", "env")
 load(":selects.bzl", "selects")
 
 def struct_to_json(x):
-    return env.struct_to_json(x)
+    return env.struct_to_json(struct(**x))
 
 def get_default_executorch_platforms():
     return env.default_platforms


### PR DESCRIPTION
Summary:
Seeing error: `Error: 'dict' value has no field or method 'to_json'`

This diff patches the error by wrapping the dict into a struct.

Differential Revision: D52610719


