### PR TITLE
Cleanup up copy-family ops

### DIFF
--- a/kernels/portable/cpu/op_arange.cpp
+++ b/kernels/portable/cpu/op_arange.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
+#include <executorch/kernels/portable/cpu/util/kernel_ops_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 #include <executorch/runtime/platform/assert.h>
 
@@ -19,35 +20,22 @@ namespace executor {
 namespace native {
 
 Tensor& arange_out(RuntimeContext& ctx, const Scalar& end, Tensor& out) {
-  ET_KERNEL_CHECK_MSG(
-      ctx,
-      out.dim() == 1,
-      InvalidArgument,
-      out,
-      "out should be a 1-d tensor, but got a %zu-d tensor",
-      out.dim());
-
-  ScalarType end_type = utils::get_scalar_dtype(end);
-
   double end_val = 0;
-  ET_SWITCH_SCALAR_OBJ_TYPES(end_type, ctx, "arange.out", CTYPE_END, [&]() {
-    CTYPE_END end_v;
-    ET_EXTRACT_SCALAR(end, end_v);
-    ET_KERNEL_CHECK_MSG(
-        ctx,
-        end_v >= 0,
-        InvalidArgument,
-        out,
-        "Input end should be non-negative.");
-    end_val = static_cast<double>(end_v);
-  });
+  ET_KERNEL_CHECK(
+      ctx, utils::extract_scalar(end, &end_val), InvalidArgument, out);
+
+  ET_KERNEL_CHECK(
+      ctx, check_arange_args(0.0, end_val, 1.0, out), InvalidArgument, out);
 
   size_t size = static_cast<size_t>(std::ceil(end_val));
 
   Tensor::SizesType out_length = static_cast<Tensor::SizesType>(size);
-  Error status = resize_tensor(out, {&out_length, 1});
-  ET_KERNEL_CHECK_MSG(
-      ctx, status == Error::Ok, InvalidArgument, out, "resize_tensor fails");
+
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, {&out_length, 1}) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ET_SWITCH_REAL_TYPES(out.scalar_type(), ctx, "arange.out", CTYPE, [&]() {
     auto out_data = out.mutable_data_ptr<CTYPE>();
@@ -67,48 +55,34 @@ Tensor& arange_start_out(
     Tensor& out) {
   (void)ctx;
 
-  ScalarType start_type = utils::get_scalar_dtype(start);
-  ScalarType end_type = utils::get_scalar_dtype(end);
-  ScalarType step_type = utils::get_scalar_dtype(step);
-
   double d_start = 0;
-  ET_SWITCH_SCALAR_OBJ_TYPES(
-      start_type, ctx, "arange.start_out", CTYPE_END, [&]() {
-        CTYPE_END start_v;
-        ET_EXTRACT_SCALAR(start, start_v);
-        d_start = static_cast<double>(start_v);
-      });
+  ET_KERNEL_CHECK(
+      ctx, utils::extract_scalar(start, &d_start), InvalidArgument, out);
 
   double d_end = 0;
-  ET_SWITCH_SCALAR_OBJ_TYPES(
-      end_type, ctx, "arange.start_out", CTYPE_END, [&]() {
-        CTYPE_END end_v;
-        ET_EXTRACT_SCALAR(end, end_v);
-        d_end = static_cast<double>(end_v);
-      });
+  ET_KERNEL_CHECK(
+      ctx, utils::extract_scalar(end, &d_end), InvalidArgument, out);
 
   double d_step = 0;
-  ET_SWITCH_SCALAR_OBJ_TYPES(
-      step_type, ctx, "arange.start_out", CTYPE_END, [&]() {
-        CTYPE_END step_v;
-        ET_EXTRACT_SCALAR(step, step_v);
-        d_step = static_cast<double>(step_v);
-      });
+  ET_KERNEL_CHECK(
+      ctx, utils::extract_scalar(step, &d_step), InvalidArgument, out);
 
-  ET_KERNEL_CHECK_MSG(
+  ET_KERNEL_CHECK(
       ctx,
-      (d_step > 0 && (d_end >= d_start)) || (d_step < 0 && (d_end <= d_start)),
+      check_arange_args(d_start, d_end, d_step, out),
       InvalidArgument,
-      out,
-      "upper bound and larger bound inconsistent with step sign");
+      out);
 
   double size_d = (d_end - d_start) / d_step;
   size_t size = static_cast<size_t>(std::ceil(size_d));
 
   Tensor::SizesType out_length = static_cast<Tensor::SizesType>(size);
-  Error status = resize_tensor(out, {&out_length, 1});
-  ET_KERNEL_CHECK_MSG(
-      ctx, status == Error::Ok, InvalidArgument, out, "resize_tensor fails");
+
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, {&out_length, 1}) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ET_SWITCH_REAL_TYPES(
       out.scalar_type(), ctx, "arange.start_out", CTYPE, [&]() {

--- a/kernels/portable/cpu/op_expand_copy.cpp
+++ b/kernels/portable/cpu/op_expand_copy.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
+#include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
 #include <executorch/kernels/portable/cpu/util/repeat_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 #include <sys/types.h>
@@ -25,44 +26,6 @@ using SizesType = exec_aten::SizesType;
 constexpr const size_t kTensorDimensionLimit{16};
 
 namespace {
-
-size_t calculate_output_sizes(
-    exec_aten::ArrayRef<SizesType> self_sizes,
-    exec_aten::ArrayRef<int64_t> expand_sizes,
-    SizesType* output_sizes) {
-  auto j{expand_sizes.size()};
-  for (size_t i{self_sizes.size()}; i > 0 && j > 0;) {
-    --i;
-    --j;
-
-    output_sizes[j] = expand_sizes[j];
-
-    if (expand_sizes[j] == -1) {
-      // -1 can use for replacing any corresponding dimension
-      output_sizes[j] = self_sizes[i];
-    } else if (self_sizes[i] != 1) {
-      ET_CHECK_MSG(
-          expand_sizes[j] == self_sizes[i],
-          "The expanded size of the tensor (%zu) must match the existing size (%zu) at non-singleton dimension %zu.",
-          (size_t)expand_sizes[j],
-          (size_t)self_sizes[i],
-          i);
-    }
-  }
-
-  // The leading expand_sizes cannot be negative
-  while (j > 0) {
-    --j;
-    output_sizes[j] = expand_sizes[j];
-    ET_CHECK_MSG(
-        expand_sizes[j] >= 0,
-        "The expanded size of the tensor (%zu) isn't allowed in a leading, non-existing dimension %zu",
-        (size_t)expand_sizes[j],
-        j);
-  }
-
-  return expand_sizes.size();
-}
 
 size_t map_expand_to_repeats(
     exec_aten::ArrayRef<SizesType> self_sizes,
@@ -88,31 +51,6 @@ size_t map_expand_to_repeats(
 
   return expand_sizes.size();
 }
-
-void check_output_tensor(
-    const Tensor& self,
-    exec_aten::ArrayRef<exec_aten::SizesType> output_sizes,
-    const Tensor& out) {
-  ET_CHECK_SAME_DTYPE2(self, out);
-
-  const auto& out_sizes = out.sizes();
-
-  ET_CHECK_MSG(
-      output_sizes.size() == out_sizes.size(),
-      "Number of output tensor sizes (%zu) must match the number of expanded output sizes (%zu)",
-      output_sizes.size(),
-      out_sizes.size());
-
-  // Make sure the output shape is correct
-  for (size_t i{0}; i < output_sizes.size(); i++) {
-    ET_CHECK_MSG(
-        output_sizes[i] == out_sizes[i],
-        "Size of output tensor (%d) must match size of expanded output (%d) at dimension (%zu)",
-        out_sizes[i],
-        output_sizes[i],
-        i);
-  }
-}
 } // namespace
 
 Tensor& expand_copy_out(
@@ -123,35 +61,29 @@ Tensor& expand_copy_out(
     Tensor& out) {
   (void)ctx;
 
-  ET_CHECK_MSG(
-      implicit == false,
-      "This operator is not implemented for when implicit == true.");
+  ET_KERNEL_CHECK(
+      ctx,
+      check_expand_copy_args(self, expand_sizes, implicit, out),
+      InvalidArgument,
+      out);
 
   const auto& self_sizes = self.sizes();
 
-  ET_CHECK_MSG(
-      expand_sizes.size() >= self_sizes.size(),
-      "The number of sizes provided (%zu) must at least be equal to the number of dimensions in the tensor (%zu)",
-      expand_sizes.size(),
-      self_sizes.size());
-
-  ET_CHECK_MSG(
-      expand_sizes.size() <= kTensorDimensionLimit,
-      "The number of expanded dims (%zu) exceeds the configured maximum (%zu). Increase this limit.",
-      expand_sizes.size(),
-      kTensorDimensionLimit);
-
   // Holds the result of converting -1 to the original dim sizes
   exec_aten::SizesType output_sizes[kTensorDimensionLimit];
-  const auto output_sizes_size{
-      calculate_output_sizes(self_sizes, expand_sizes, output_sizes)};
+  size_t output_rank = 0;
+  ET_KERNEL_CHECK(
+      ctx,
+      get_expand_copy_out_target_size(
+          self_sizes, expand_sizes, output_sizes, &output_rank),
+      InvalidArgument,
+      out);
 
-  auto error = resize_tensor(out, {output_sizes, output_sizes_size});
-  // TODO: Construct error message with requested output sizes.
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
-
-  // Check that the output tensor is the same shape as the mapped expand
-  check_output_tensor(self, {output_sizes, output_sizes_size}, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, {output_sizes, output_rank}) == Error::Ok,
+      InvalidArgument,
+      out);
 
   // Holds the result of expand_sizes converted to repeat sizes
   int64_t repeats[kTensorDimensionLimit];

--- a/kernels/portable/cpu/op_log_softmax.cpp
+++ b/kernels/portable/cpu/op_log_softmax.cpp
@@ -27,7 +27,11 @@ Tensor& log_softmax_out(
     Tensor& out) {
   (void)ctx;
 
-  check_log_softmax_args(in, dim, half_to_float, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      check_log_softmax_args(in, dim, half_to_float, out),
+      InvalidArgument,
+      out);
 
   ET_KERNEL_CHECK(
       ctx, resize_tensor(out, in.sizes()) == Error::Ok, InvalidArgument, out);

--- a/kernels/portable/cpu/op_split_copy.cpp
+++ b/kernels/portable/cpu/op_split_copy.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
@@ -17,133 +18,6 @@ namespace native {
 
 using Tensor = exec_aten::Tensor;
 using TensorList = exec_aten::TensorList;
-
-namespace {
-void check_args(
-    const Tensor& input,
-    int64_t split_size,
-    int64_t dim,
-    TensorList out) {
-  ET_CHECK_MSG(
-      input.dim() > 0,
-      "input must have at least one dimension; saw %zd",
-      input.dim());
-  ET_CHECK_MSG(
-      dim >= 0 && dim < input.dim(),
-      "dim %" PRId64 " out of range [0,%zd)",
-      dim,
-      input.dim());
-
-  const ssize_t dim_size = input.size(dim);
-  ET_CHECK_MSG(
-      split_size >= 0,
-      "split_size %" PRId64 " must be non-negative",
-      split_size);
-  ET_CHECK_MSG(
-      split_size > 0 || dim_size == 0,
-      "split_size is zero but input.size(%" PRId64 ") %zd is non-zero",
-      dim,
-      dim_size);
-
-  // Check the number of outputs.
-  //
-  // The specified dimension will be split into split_size-sized chunks, with
-  // the final chunk possibly being smaller. So, the expected output length is
-  // ceil(dim_size / split_size).
-  //
-  // E.g., splitting dim 0 of a [5,2] tensor with split_size 2 would produce
-  // three tensors with size [2,2], [2,2], [1,2].
-  int64_t remainder; // The size of the split dimension of the final out tensor.
-  if (split_size >= dim_size) {
-    // Note that this also handles the case where split_size == 0, avoiding a
-    // division by zero in the other branch. When dim_size == 0 && split_size ==
-    // 0, core PyTorch expects 1 output element.
-    ET_CHECK_MSG(
-        out.size() == 1,
-        "Unexpected out.size() %zu: should be 1 because split_size %" PRId64
-        " >= input.size(%" PRId64 ") %zd",
-        out.size(),
-        split_size,
-        dim,
-        dim_size);
-    remainder = dim_size;
-  } else {
-    int64_t expected_out_len = (dim_size + split_size - 1) / split_size;
-    ET_CHECK_MSG(
-        out.size() == expected_out_len,
-        "Unexpected out.size() %zu: ceil(input.size(%" PRId64
-        ")=%zd"
-        " / split_size=%" PRId64 ") is %" PRId64,
-        out.size(),
-        dim,
-        dim_size,
-        split_size,
-        expected_out_len);
-    remainder = dim_size % split_size;
-    if (remainder == 0) {
-      remainder = split_size;
-    }
-  }
-
-  // Validate each output.
-  for (size_t i = 0; i < out.size(); ++i) {
-    // All output dtypes must be the same.
-    ET_CHECK_MSG(
-        out[i].scalar_type() == out[0].scalar_type(),
-        "out[%zu] dtype %" PRId8 " != out[0] dtype %" PRId8,
-        i,
-        static_cast<int8_t>(out[i].scalar_type()),
-        static_cast<int8_t>(out[0].scalar_type()));
-
-    // All outputs must have the same number of dimensions as the input.
-    ET_CHECK_MSG(
-        out[i].dim() == input.dim(),
-        "out[%zu] dim %zd != input dim %zd",
-        i,
-        out[i].dim(),
-        input.dim());
-
-    // Check the shape of the output.
-    for (ssize_t d = 0; d < out[i].dim(); ++d) {
-      if (d == dim) {
-        // This is the split dimension, which may be different.
-        if (i < out.size() - 1) {
-          // All outputs except the final one: split dimension should be
-          // split_size.
-          ET_CHECK_MSG(
-              out[i].size(d) == split_size,
-              "out[%zu].size(%zd) %zd != split_size %" PRId64,
-              i,
-              d,
-              out[i].size(d),
-              split_size);
-        } else {
-          // The final output: split dimension should be the remainder of
-          // split_size.
-          ET_CHECK_MSG(
-              out[i].size(d) == remainder,
-              "out[%zu].size(%zd) %zd != remainder %" PRId64,
-              i,
-              d,
-              out[i].size(d),
-              remainder);
-        }
-      } else {
-        // Non-split output dimensions must be the same as the input dimension.
-        ET_CHECK_MSG(
-            out[i].size(d) == input.size(d),
-            "out[%zu].size(%zd) %zd != input.size(%zd) %zd",
-            i,
-            d,
-            out[i].size(d),
-            d,
-            input.size(d));
-      }
-    }
-  }
-}
-
-} // namespace
 
 /**
  * Splits the tensor into chunks of size `split_size` along the specified
@@ -166,7 +40,12 @@ void split_copy_Tensor_out(
   if (dim < 0) {
     dim += input.dim();
   }
-  check_args(input, split_size, dim, out);
+
+  ET_KERNEL_CHECK(
+      ctx,
+      check_split_copy_args(input, split_size, dim, out),
+      InvalidArgument,
+      out);
 
   const size_t leading_dims = getLeadingDims(input, dim);
   const size_t trailing_dims = getTrailingDims(input, dim);

--- a/kernels/portable/cpu/op_to_copy.cpp
+++ b/kernels/portable/cpu/op_to_copy.cpp
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
@@ -32,51 +34,25 @@ Tensor& to_copy_out(
     bool non_blocking,
     exec_aten::optional<exec_aten::MemoryFormat> memory_format,
     Tensor& out) {
-  // Right now we only support blocking data transfer
-  ET_CHECK(non_blocking == false);
+  ET_KERNEL_CHECK(
+      ctx,
+      check_to_copy_args(self, non_blocking, memory_format, out),
+      InvalidArgument,
+      out);
 
-  // Right now we only focus on contiguous memory, memory_format shall be
-  // exec::aten::MemoryFormat::Contiguous or none.
-  ET_CHECK(
-      !memory_format.has_value() ||
-      memory_format.value() == MemoryFormat::Contiguous);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, self.sizes()) == torch::executor::Error::Ok,
+      InvalidArgument,
+      out);
 
-  torch::executor::Error err = resize_tensor(out, self.sizes());
-  ET_CHECK_MSG(
-      err == torch::executor::Error::Ok,
-      "Failed to resize out Tensor in to_copy_out");
-
-  // self and out should be in same size.
-  ET_CHECK_SAME_SHAPE2(self, out);
-// Use a two layer switch to hanldle each possible data pairs
-#define TO_IMPL(SELF_CTYPE, OUT_CTYPE, out_dtype) \
-  case ScalarType::out_dtype:                     \
-    _to_impl<SELF_CTYPE, OUT_CTYPE>(self, out);   \
-    break;
-
-#define CASE_TENSOR_DTYPE(SELF_CTYPE, self_dtype)              \
-  case ScalarType::self_dtype:                                 \
-    switch (out.scalar_type()) {                               \
-      ET_FORALL_REAL_TYPES_AND_WITH(Bool, SELF_CTYPE, TO_IMPL) \
-      default:                                                 \
-        ET_CHECK_MSG(                                          \
-            false,                                             \
-            "Unhandled output dtype %" PRId8,                  \
-            static_cast<int8_t>(out.scalar_type()));           \
-    }                                                          \
-    break;
-
-  switch (self.scalar_type()) {
-    ET_FORALL_REAL_TYPES_AND(Bool, CASE_TENSOR_DTYPE);
-    default:
-      ET_CHECK_MSG(
-          false,
-          "Unhandled input dtype %" PRId8,
-          static_cast<int8_t>(self.scalar_type()));
-  }
-
-#undef CASE_TENSOR_DTYPE
-#undef TO_IMPL
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, self.scalar_type(), ctx, "to_copy", CTYPE_IN, [&] {
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, out.scalar_type(), ctx, "to_copy", CTYPE_OUT, [&] {
+              _to_impl<CTYPE_IN, CTYPE_OUT>(self, out);
+            });
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/targets.bzl
+++ b/kernels/portable/cpu/targets.bzl
@@ -711,6 +711,9 @@ _ATEN_OPS = (
     ),
     op_target(
         name = "op_split_copy",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        ],
     ),
     op_target(
         name = "op_split_with_sizes_copy",
@@ -771,6 +774,9 @@ _ATEN_OPS = (
     ),
     op_target(
         name = "op_to_copy",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        ],
     ),
     op_target(
         name = "op_transpose_copy",
@@ -784,9 +790,15 @@ _ATEN_OPS = (
     ),
     op_target(
         name = "op_unbind_copy",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        ],
     ),
     op_target(
         name = "op_unsqueeze_copy",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        ],
     ),
     op_target(
         name = "op_var",

--- a/kernels/portable/cpu/targets.bzl
+++ b/kernels/portable/cpu/targets.bzl
@@ -74,6 +74,7 @@ _ATEN_OPS = (
     op_target(
         name = "op_arange",
         deps = [
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
             "//executorch/runtime/core/exec_aten/util:scalar_type_util",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
             ":scalar_utils",
@@ -239,6 +240,7 @@ _ATEN_OPS = (
         deps = [
             "//executorch/runtime/core/exec_aten/util:scalar_type_util",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
         ],
     ),
     op_target(
@@ -286,6 +288,7 @@ _ATEN_OPS = (
         deps = [
             "//executorch/runtime/core/exec_aten/util:scalar_type_util",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
             "//executorch/kernels/portable/cpu/util:repeat_util",
             ":scalar_utils",
         ],
@@ -354,6 +357,7 @@ _ATEN_OPS = (
     op_target(
         name = "op_glu",
         deps = [
+            "//executorch/kernels/portable/cpu/util:activation_ops_util",
             "//executorch/runtime/core/exec_aten/util:scalar_type_util",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
         ],

--- a/kernels/portable/cpu/util/activation_ops_util.cpp
+++ b/kernels/portable/cpu/util/activation_ops_util.cpp
@@ -23,6 +23,35 @@ bool check_gelu_args(const Tensor& in, string_view approximate, Tensor& out) {
   return true;
 }
 
+bool check_glu_args(const Tensor& in, int64_t dim, Tensor& out) {
+  ET_LOG_AND_RETURN_IF_FALSE(dim_is_valid(dim, in.dim()));
+
+  const size_t non_negative_dim = dim < 0 ? dim + in.dim() : dim;
+  const size_t dim_size = in.size(non_negative_dim);
+
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      dim_size % 2 == 0,
+      "Halving dimension must be even, but dimension %zd is size %zd",
+      non_negative_dim,
+      dim_size);
+
+  ET_LOG_AND_RETURN_IF_FALSE(tensor_is_floating_type(out));
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_rank(in, out));
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      out.size(non_negative_dim) == dim_size / 2,
+      "output tensor must have half the size of the input tensor along the specified dimension.");
+
+  for (size_t i = 0; i < in.dim(); ++i) {
+    if (i != non_negative_dim) {
+      ET_LOG_MSG_AND_RETURN_IF_FALSE(
+          out.size(i) == in.size(i),
+          "output tensor must have the same size as the input tensor in all dimensions except for the specified dimension.");
+    }
+  }
+
+  return true;
+}
+
 bool check_log_softmax_args(
     const Tensor& in,
     int64_t dim,
@@ -43,6 +72,21 @@ bool check_softmax_args(
     bool half_to_float,
     Tensor& out) {
   return check_log_softmax_args(in, dim, half_to_float, out);
+}
+
+Error resize_glu_out(const Tensor& in, int64_t dim, Tensor& out) {
+  exec_aten::SizesType expected_output_size[kTensorDimensionLimit];
+
+  const size_t non_negative_dim = dim < 0 ? dim + in.dim() : dim;
+  for (size_t i = 0; i < in.dim(); i++) {
+    expected_output_size[i] =
+        (i == non_negative_dim) ? (in.size(i) / 2) : in.size(i);
+  }
+
+  ArrayRef<exec_aten::SizesType> output_size{
+      expected_output_size, static_cast<size_t>(out.dim())};
+
+  return resize_tensor(out, output_size);
 }
 
 } // namespace executor

--- a/kernels/portable/cpu/util/activation_ops_util.h
+++ b/kernels/portable/cpu/util/activation_ops_util.h
@@ -15,6 +15,8 @@ namespace executor {
 
 bool check_gelu_args(const Tensor& in, string_view approximate, Tensor& out);
 
+bool check_glu_args(const Tensor& in, int64_t dim, Tensor& out);
+
 bool check_log_softmax_args(
     const Tensor& in,
     int64_t dim,
@@ -26,6 +28,8 @@ bool check_softmax_args(
     int64_t dim,
     bool half_to_float,
     Tensor& out);
+
+Error resize_glu_out(const Tensor& in, int64_t dim, Tensor& out);
 
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/copy_ops_util.cpp
+++ b/kernels/portable/cpu/util/copy_ops_util.cpp
@@ -147,6 +147,32 @@ void get_cat_out_target_size(
   }
 }
 
+bool check_expand_copy_args(
+    const Tensor& input,
+    ArrayRef<int64_t> expand_sizes,
+    bool implicit,
+    Tensor& out) {
+  (void)out;
+
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      implicit == false,
+      "This operator is not implemented for when implicit == true.");
+
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      expand_sizes.size() >= input.sizes().size(),
+      "The number of sizes provided (%zu) must at least be equal to the number of dimensions in the tensor (%zu)",
+      expand_sizes.size(),
+      input.sizes().size());
+
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      expand_sizes.size() <= kTensorDimensionLimit,
+      "The number of expanded dims (%zu) exceeds the configured maximum (%zu). Increase this limit.",
+      expand_sizes.size(),
+      kTensorDimensionLimit);
+
+  return true;
+}
+
 bool check_permute_copy_args(const Tensor& in, IntArrayRef dims, Tensor& out) {
   ET_LOG_AND_RETURN_IF_FALSE(tensor_is_rank(in, dims.size()));
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, out));
@@ -170,6 +196,58 @@ bool check_permute_copy_args(const Tensor& in, IntArrayRef dims, Tensor& out) {
         dim_exist[dim] == false, "duplicate dims are not allowed.");
 
     dim_exist[dim] = true;
+  }
+
+  return true;
+}
+
+bool check_unbind_copy_args(const Tensor& in, int64_t dim, TensorList out) {
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      in.dim() > 0, "in must have at least one dimension; saw %zd", in.dim());
+
+  ET_LOG_AND_RETURN_IF_FALSE(dim_is_valid(dim, in.dim()));
+
+  const ssize_t dim_size = in.size(dim);
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      dim_size == out.size(),
+      "out tensorlist's length %zd must equal unbind dim %" PRId64
+      " size = %zd.",
+      out.size(),
+      dim,
+      dim_size);
+
+  // Validate each output.
+  for (size_t i = 0; i < out.size(); ++i) {
+    // All output dtypes must be the same.
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        out[i].scalar_type() == out[0].scalar_type(),
+        "out[%zu] dtype %" PRId8 " != out[0] dtype %" PRId8,
+        i,
+        static_cast<int8_t>(out[i].scalar_type()),
+        static_cast<int8_t>(out[0].scalar_type()));
+
+    // output tensor must have # of dims = in.dim() -1
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        out[i].dim() == (in.dim() - 1),
+        "out[%zu] dim %zd != in dim %zd",
+        i,
+        out[i].dim(),
+        in.dim() - 1);
+
+    // Check the shape of the output.
+    for (ssize_t d = 0, out_d = 0; d < in.dim(); ++d) {
+      if (d != dim) {
+        ET_LOG_MSG_AND_RETURN_IF_FALSE(
+            out[i].size(out_d) == in.size(d),
+            "out[%zu].size(%zd) %zd != in.size(%zd) %zd",
+            i,
+            d,
+            out[i].size(out_d),
+            d,
+            in.size(d));
+        out_d++;
+      }
+    }
   }
 
   return true;

--- a/kernels/portable/cpu/util/copy_ops_util.cpp
+++ b/kernels/portable/cpu/util/copy_ops_util.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 
 #include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
 
 namespace torch {
 namespace executor {
@@ -170,6 +171,50 @@ bool check_expand_copy_args(
       expand_sizes.size(),
       kTensorDimensionLimit);
 
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(input, out));
+
+  return true;
+}
+
+bool get_expand_copy_out_target_size(
+    exec_aten::ArrayRef<exec_aten::SizesType> self_sizes,
+    exec_aten::ArrayRef<int64_t> expand_sizes,
+    exec_aten::SizesType* output_sizes,
+    size_t* output_rank) {
+  auto j{expand_sizes.size()};
+  *output_rank = 0;
+
+  for (size_t i{self_sizes.size()}; i > 0 && j > 0;) {
+    --i;
+    --j;
+
+    output_sizes[j] = expand_sizes[j];
+
+    if (expand_sizes[j] == -1) {
+      // -1 can use for replacing any corresponding dimension
+      output_sizes[j] = self_sizes[i];
+    } else if (self_sizes[i] != 1) {
+      ET_LOG_MSG_AND_RETURN_IF_FALSE(
+          expand_sizes[j] == self_sizes[i],
+          "The expanded size of the tensor (%zu) must match the existing size (%zu) at non-singleton dimension %zu.",
+          (size_t)expand_sizes[j],
+          (size_t)self_sizes[i],
+          i);
+    }
+  }
+
+  // The leading expand_sizes cannot be negative
+  while (j > 0) {
+    --j;
+    output_sizes[j] = expand_sizes[j];
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        expand_sizes[j] >= 0,
+        "The expanded size of the tensor (%zu) isn't allowed in a leading, non-existing dimension %zu",
+        (size_t)expand_sizes[j],
+        j);
+  }
+
+  *output_rank = expand_sizes.size();
   return true;
 }
 
@@ -189,7 +234,7 @@ bool check_permute_copy_args(const Tensor& in, IntArrayRef dims, Tensor& out) {
     size_t dim = dims[i] >= 0 ? dims[i] : in.dim() + dims[i];
 
     // Internal check, since we have already validated this
-    ET_CHECK(dim < kTensorDimensionLimit && dim >= 0);
+    ET_LOG_AND_RETURN_IF_FALSE(dim < kTensorDimensionLimit && dim >= 0);
 
     // Check that the dimension hasn't been seen previously.
     ET_LOG_MSG_AND_RETURN_IF_FALSE(
@@ -545,6 +590,199 @@ void get_stack_out_target_size(
 bool check_tril_args(const Tensor& in, Tensor& out) {
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, out));
   ET_LOG_AND_RETURN_IF_FALSE(tensor_has_rank_greater_or_equal_to(in, 2));
+  return true;
+}
+
+bool check_split_copy_args(
+    const Tensor& input,
+    int64_t split_size,
+    int64_t dim,
+    TensorList out) {
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      input.dim() > 0,
+      "input must have at least one dimension; saw %zd",
+      input.dim());
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      dim >= 0 && dim < input.dim(),
+      "dim %" PRId64 " out of range [0,%zd)",
+      dim,
+      input.dim());
+
+  const ssize_t dim_size = input.size(dim);
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      split_size >= 0,
+      "split_size %" PRId64 " must be non-negative",
+      split_size);
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      split_size > 0 || dim_size == 0,
+      "split_size is zero but input.size(%" PRId64 ") %zd is non-zero",
+      dim,
+      dim_size);
+
+  // Check the number of outputs.
+  //
+  // The specified dimension will be split into split_size-sized chunks, with
+  // the final chunk possibly being smaller. So, the expected output length is
+  // ceil(dim_size / split_size).
+  //
+  // E.g., splitting dim 0 of a [5,2] tensor with split_size 2 would produce
+  // three tensors with size [2,2], [2,2], [1,2].
+  int64_t remainder; // The size of the split dimension of the final out tensor.
+  if (split_size >= dim_size) {
+    // Note that this also handles the case where split_size == 0, avoiding a
+    // division by zero in the other branch. When dim_size == 0 && split_size ==
+    // 0, core PyTorch expects 1 output element.
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        out.size() == 1,
+        "Unexpected out.size() %zu: should be 1 because split_size %" PRId64
+        " >= input.size(%" PRId64 ") %zd",
+        out.size(),
+        split_size,
+        dim,
+        dim_size);
+    remainder = dim_size;
+  } else {
+    int64_t expected_out_len = (dim_size + split_size - 1) / split_size;
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        out.size() == expected_out_len,
+        "Unexpected out.size() %zu: ceil(input.size(%" PRId64
+        ")=%zd"
+        " / split_size=%" PRId64 ") is %" PRId64,
+        out.size(),
+        dim,
+        dim_size,
+        split_size,
+        expected_out_len);
+    remainder = dim_size % split_size;
+    if (remainder == 0) {
+      remainder = split_size;
+    }
+  }
+
+  // Validate each output.
+  for (size_t i = 0; i < out.size(); ++i) {
+    // All output dtypes must be the same.
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        out[i].scalar_type() == out[0].scalar_type(),
+        "out[%zu] dtype %" PRId8 " != out[0] dtype %" PRId8,
+        i,
+        static_cast<int8_t>(out[i].scalar_type()),
+        static_cast<int8_t>(out[0].scalar_type()));
+
+    // All outputs must have the same number of dimensions as the input.
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        out[i].dim() == input.dim(),
+        "out[%zu] dim %zd != input dim %zd",
+        i,
+        out[i].dim(),
+        input.dim());
+
+    // Check the shape of the output.
+    for (ssize_t d = 0; d < out[i].dim(); ++d) {
+      if (d == dim) {
+        // This is the split dimension, which may be different.
+        if (i < out.size() - 1) {
+          // All outputs except the final one: split dimension should be
+          // split_size.
+          ET_LOG_MSG_AND_RETURN_IF_FALSE(
+              out[i].size(d) == split_size,
+              "out[%zu].size(%zd) %zd != split_size %" PRId64,
+              i,
+              d,
+              out[i].size(d),
+              split_size);
+        } else {
+          // The final output: split dimension should be the remainder of
+          // split_size.
+          ET_LOG_MSG_AND_RETURN_IF_FALSE(
+              out[i].size(d) == remainder,
+              "out[%zu].size(%zd) %zd != remainder %" PRId64,
+              i,
+              d,
+              out[i].size(d),
+              remainder);
+        }
+      } else {
+        // Non-split output dimensions must be the same as the input dimension.
+        ET_LOG_AND_RETURN_IF_FALSE(
+            tensors_have_same_size_at_dims(out[i], d, input, d));
+      }
+    }
+  }
+
+  return true;
+}
+
+bool check_to_copy_args(
+    const Tensor& input,
+    bool non_blocking,
+    exec_aten::optional<exec_aten::MemoryFormat> memory_format,
+    Tensor& out) {
+  (void)input;
+  (void)out;
+
+  // Right now we only support blocking data transfer
+  ET_LOG_AND_RETURN_IF_FALSE(non_blocking == false);
+
+  // Right now we only focus on contiguous memory, memory_format shall be
+  // exec::aten::MemoryFormat::Contiguous or none.
+  ET_LOG_AND_RETURN_IF_FALSE(
+      !memory_format.has_value() ||
+      memory_format.value() == MemoryFormat::Contiguous);
+
+  return true;
+}
+
+bool check_unsqueeze_copy_args(
+    const Tensor input,
+    int64_t dim,
+    const Tensor out) {
+  // The input and out shall share same dtype
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(input, out));
+
+  ET_LOG_AND_RETURN_IF_FALSE(tensor_has_dim(out, dim));
+
+  // The shape of input and out shall obey the relationship:
+  // 1. input.dim() == out.dim()-1
+  // 2. input.size(i) == out.size(i) for all i < dim
+  // 3. input.size(i-1) == out.size(i) for all i >= dim
+  // 4. out.size(dim) == 1
+  ET_LOG_AND_RETURN_IF_FALSE(input.dim() == out.dim() - 1);
+
+  for (size_t d = 0; d < out.dim(); d++) {
+    auto dim_normalized = dim;
+    if (dim_normalized < 0) {
+      dim_normalized += out.dim();
+    }
+
+    if (d < dim_normalized) {
+      ET_LOG_MSG_AND_RETURN_IF_FALSE(
+          input.size(d) == out.size(d),
+          "input.size(%zu) %zd != out.size(%zu) %zd | dim = %" PRId64,
+          d,
+          input.size(d),
+          d,
+          out.size(d),
+          dim);
+    } else if (d > dim_normalized) {
+      ET_LOG_MSG_AND_RETURN_IF_FALSE(
+          input.size(d - 1) == out.size(d),
+          "input.size(%zu) %zd != out.size(%zu) %zd | dim = %" PRId64,
+          d - 1,
+          input.size(d),
+          d,
+          out.size(d),
+          dim);
+    } else { // d == dim
+      ET_LOG_MSG_AND_RETURN_IF_FALSE(
+          out.size(d) == 1,
+          "out.size(%zu) %zd shall equal 1 | dim = %" PRId64,
+          d,
+          out.size(d),
+          dim);
+    }
+  }
+
   return true;
 }
 

--- a/kernels/portable/cpu/util/copy_ops_util.h
+++ b/kernels/portable/cpu/util/copy_ops_util.h
@@ -37,6 +37,12 @@ bool check_expand_copy_args(
     bool implicit,
     Tensor& out);
 
+bool get_expand_copy_out_target_size(
+    exec_aten::ArrayRef<exec_aten::SizesType> self_sizes,
+    exec_aten::ArrayRef<int64_t> expand_sizes,
+    exec_aten::SizesType* output_sizes,
+    size_t* output_rank);
+
 bool check_permute_copy_args(const Tensor& in, IntArrayRef dims, Tensor& out);
 
 bool check_unbind_copy_args(const Tensor& in, int64_t dim, TensorList out);
@@ -130,6 +136,23 @@ void get_stack_out_target_size(
     size_t* out_ndim);
 
 bool check_tril_args(const Tensor& in, Tensor& out);
+
+bool check_split_copy_args(
+    const Tensor& input,
+    int64_t split_size,
+    int64_t dim,
+    TensorList out);
+
+bool check_to_copy_args(
+    const Tensor& input,
+    bool non_blocking,
+    exec_aten::optional<exec_aten::MemoryFormat> memory_format,
+    Tensor& out);
+
+bool check_unsqueeze_copy_args(
+    const Tensor input,
+    int64_t dim,
+    const Tensor out);
 
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/copy_ops_util.h
+++ b/kernels/portable/cpu/util/copy_ops_util.h
@@ -31,7 +31,15 @@ void get_cat_out_target_size(
     Tensor::SizesType* out_sizes,
     size_t* out_ndim);
 
+bool check_expand_copy_args(
+    const Tensor& self,
+    ArrayRef<int64_t> expand_sizes,
+    bool implicit,
+    Tensor& out);
+
 bool check_permute_copy_args(const Tensor& in, IntArrayRef dims, Tensor& out);
+
+bool check_unbind_copy_args(const Tensor& in, int64_t dim, TensorList out);
 
 void get_permute_copy_out_target_size(
     const Tensor& in,

--- a/kernels/portable/cpu/util/index_util.h
+++ b/kernels/portable/cpu/util/index_util.h
@@ -34,5 +34,7 @@ bool check_scatter_add_args(
     const Tensor& src,
     Tensor& out);
 
+bool check_nonzero_args(const Tensor& in, const Tensor& out);
+
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/kernel_ops_util.h
+++ b/kernels/portable/cpu/util/kernel_ops_util.h
@@ -370,6 +370,8 @@ void apply_kernel_2d_reduce_then_map_fn(
 // Operator specific utility functions
 //
 
+bool check_arange_args(double start, double end, double step, Tensor& out);
+
 bool check_avg_pool2d_args(
     const Tensor& in,
     const IntArrayRef kernel_size,
@@ -409,6 +411,12 @@ void get_convolution_out_target_size(
     IntArrayRef dilation,
     exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
+
+bool check_cumsum_args(
+    const Tensor& self,
+    int64_t dim,
+    optional<ScalarType> enforced_dtype,
+    Tensor& out);
 
 bool check_max_pool2d_with_indices_args(
     const Tensor& in,

--- a/kernels/test/op_unsqueeze_copy_test.cpp
+++ b/kernels/test/op_unsqueeze_copy_test.cpp
@@ -67,6 +67,9 @@ void run_unsqueeze_test_cases(
     const std::vector<int64_t>& dims) {
   TensorFactory<DTYPE> tf;
 
+  // DEBUG
+  et_pal_init();
+
   for (int64_t dim : dims) {
     std::vector<int32_t> size_out = generate_size_out(input.sizes(), dim);
     Tensor out = tf.ones(size_out);

--- a/runtime/core/exec_aten/util/tensor_util.h
+++ b/runtime/core/exec_aten/util/tensor_util.h
@@ -824,6 +824,15 @@ inline bool tensor_is_contiguous(exec_aten::Tensor t) {
   return true;
 }
 
+inline bool tensors_have_same_rank(exec_aten::Tensor a, exec_aten::Tensor b) {
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      a.dim() == b.dim(),
+      ET_TENSOR_CHECK_PREFIX__ ": rank={%zd, %zd}",
+      ssize_t(a.dim()),
+      ssize_t(b.dim()));
+  return true;
+}
+
 /**
  * The expected output size may not be the existing size of any inputs and
  * outputs if the operator supports both broadcast and dynamic shape. Therefore


### PR DESCRIPTION
Summary:
Clean up and refactor dependency/arg checks for copy-family ops:

 - expand_copy
 - select_copy
 - split_copy
 - t_copy
 - to_copy
 - unsqueeze_copy

Differential Revision: D52550625


