### PR TITLE
[Executorch][portable] Fix portable kernel utils for aten mode

### DIFF
--- a/kernels/portable/cpu/util/index_util.cpp
+++ b/kernels/portable/cpu/util/index_util.cpp
@@ -129,18 +129,5 @@ bool check_scatter_add_args(
   return true;
 }
 
-bool check_index_out_args(
-    const Tensor& in,
-    const Tensor& out,
-    const Tensor& index_out) {
-  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, out));
-  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_shape(out, index_out));
-  ET_LOG_AND_RETURN_IF_FALSE(
-      tensor_is_default_or_channels_last_dim_order(index_out));
-  ET_LOG_AND_RETURN_IF_FALSE(index_out.scalar_type() == ScalarType::Long);
-
-  return true;
-}
-
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/index_util.h
+++ b/kernels/portable/cpu/util/index_util.h
@@ -34,10 +34,5 @@ bool check_scatter_add_args(
     const Tensor& src,
     Tensor& out);
 
-bool check_index_out_args(
-    const Tensor& in,
-    const Tensor& out,
-    const Tensor& index_out);
-
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/reduce_util.cpp
+++ b/kernels/portable/cpu/util/reduce_util.cpp
@@ -12,10 +12,6 @@
 #include <executorch/runtime/platform/assert.h>
 #include <cstring>
 
-#ifndef USE_ATEN_LIB
-#include <executorch/kernels/portable/cpu/util/index_util.h>
-#endif
-
 namespace torch {
 namespace executor {
 

--- a/kernels/portable/cpu/util/reduce_util.cpp
+++ b/kernels/portable/cpu/util/reduce_util.cpp
@@ -426,7 +426,12 @@ bool check_min_max_args(
     Tensor& max_indices) {
   ET_LOG_AND_RETURN_IF_FALSE(
       check_reduction_args_single_dim(in, dim, keepdim, max));
-  ET_LOG_AND_RETURN_IF_FALSE(check_index_out_args(in, max, max_indices));
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, max));
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_shape(max, max_indices));
+  ET_LOG_AND_RETURN_IF_FALSE(
+      tensor_is_default_or_channels_last_dim_order(max_indices));
+  ET_LOG_AND_RETURN_IF_FALSE(max_indices.scalar_type() == ScalarType::Long);
+
 
   return true;
 }

--- a/kernels/portable/cpu/util/reduce_util.cpp
+++ b/kernels/portable/cpu/util/reduce_util.cpp
@@ -428,7 +428,6 @@ bool check_min_max_args(
       tensor_is_default_or_channels_last_dim_order(max_indices));
   ET_LOG_AND_RETURN_IF_FALSE(max_indices.scalar_type() == ScalarType::Long);
 
-
   return true;
 }
 

--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -167,7 +167,6 @@ def define_common_targets():
             deps = [
                 "//executorch/runtime/kernel:kernel_includes{}".format(suffix),
                 "//executorch/runtime/core/exec_aten/util:tensor_util{}".format(suffix),
-                ":index_util",
             ],
             exported_preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],
             visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/quantized/..."],

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -33,8 +33,7 @@ include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
 # Quantized ops kernel sources TODO(larryliu0820): use buck2 to gather the
 # sources
-file(GLOB_RECURSE _quantized_kernels__srcs
-     "${CMAKE_CURRENT_SOURCE_DIR}/cpu/*.cpp")
+list(TRANSFORM _quantized_kernels__srcs PREPEND "${EXECUTORCH_ROOT}/")
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in quantized.yaml
 gen_selected_ops("${CMAKE_CURRENT_LIST_DIR}/quantized.yaml" "" "")
@@ -47,7 +46,6 @@ set(_quantized_sources
     ${_quantized_kernels__srcs}
     ${EXECUTORCH_ROOT}/runtime/core/exec_aten/util/tensor_util_aten.cpp # This
     # is a hack
-    ${EXECUTORCH_ROOT}/kernels/portable/cpu/util/reduce_util.cpp
 )
 gen_custom_ops_aot_lib("quantized_ops_aot_lib" "${_quantized_sources}")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1563
* #1562

In supporting build for aten mode, reduce_util has dependency on
index_util.cpp. Reduce util depends on index_util for a util function,
check_index_out_args
However this function is used only when not being built for aten mode.
When being built with aten mode, index_util.cpp ends up including
c10/ScalarType.h (via scalar_type_utils.h). Both c10/ScalartType.h and
scalar_type_utils.h define toString which results in compiler error.

We should really fix scalar_type_utils.h to allow for aten mode build,
but that needs more work.

In the mean time check_index_out_args is used only in reduce_util.cpp so there is no
need to really factor out index_util.cpp, so removin this refactor.

Differential Revision: [D52626505](https://our.internmc.facebook.com/intern/diff/D52626505/)