### PR TITLE
Bounds checks for values/inputs/outputs

### DIFF
--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -607,14 +607,11 @@ Error Method::init(executorch_flatbuffer::ExecutionPlan* s_plan) {
   {
     // Load chains
     const auto chains = serialization_plan_->chains();
-    if (chains == nullptr) {
-      n_chains_ = 0;
-      chains_ = nullptr;
-    } else {
-      n_chains_ = chains->size();
-      chains_ =
-          ET_ALLOCATE_LIST_OR_RETURN_ERROR(method_allocator, Chain, n_chains_);
-    }
+    ET_CHECK_OR_RETURN_ERROR(
+        chains != nullptr && chains->size() > 0, InvalidProgram, "No chains");
+    n_chains_ = chains->size();
+    chains_ =
+        ET_ALLOCATE_LIST_OR_RETURN_ERROR(method_allocator, Chain, n_chains_);
 
     // Try resolving all operators before failing, to make it easier to debug
     // multiple problems at once.
@@ -738,12 +735,6 @@ Error Method::init(executorch_flatbuffer::ExecutionPlan* s_plan) {
       break;
     }
   }
-
-  ET_CHECK_OR_RETURN_ERROR(
-      n_chains_ > 0,
-      Internal,
-      "Expected program to have at least one chain received %zu",
-      n_chains_);
 
   step_state_ = StepState{0, 0};
 

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -578,7 +578,8 @@ Error Method::init(executorch_flatbuffer::ExecutionPlan* s_plan) {
   {
     // Resolve delegates
     const auto delegates = serialization_plan_->delegates();
-    ET_CHECK(delegates != nullptr);
+    ET_CHECK_OR_RETURN_ERROR(
+        delegates != nullptr, InvalidProgram, "Missing delegates field");
     size_t n_delegate = delegates->size();
     delegates_ = ET_ALLOCATE_LIST_OR_RETURN_ERROR(
         method_allocator, BackendDelegate, n_delegate);

--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -216,7 +216,12 @@ Result<const char*> Program::get_method_name(size_t plan_index) const {
   }
   auto internal_program =
       static_cast<const executorch_flatbuffer::Program*>(internal_program_);
-  return internal_program->execution_plan()->Get(plan_index)->name()->c_str();
+  // We know that the execution plan exists because num_methods() returned > 0.
+  auto name = internal_program->execution_plan()->Get(plan_index)->name();
+  if (name == nullptr) {
+    return Error::InvalidProgram;
+  }
+  return name->c_str();
 }
 
 Result<Method> Program::load_method(

--- a/runtime/executor/test/method_test.cpp
+++ b/runtime/executor/test/method_test.cpp
@@ -15,6 +15,7 @@
 #include <executorch/runtime/executor/program.h>
 #include <executorch/runtime/executor/test/managed_memory_manager.h>
 #include <executorch/runtime/platform/runtime.h>
+#include <executorch/test/utils/DeathTest.h>
 #include <executorch/util/util.h>
 #include <gtest/gtest.h>
 
@@ -94,6 +95,142 @@ TEST_F(MethodTest, MoveTest) {
   ASSERT_EQ(err, Error::Ok);
 
   torch::executor::util::FreeInputs(inputs);
+}
+
+TEST_F(MethodTest, GetValueTests) {
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
+  ASSERT_EQ(method.error(), Error::Ok);
+
+  size_t num_values = method->values_size();
+  ASSERT_GT(num_values, 0);
+
+  // In-range values should succeed without aborting.
+  method->get_value(0);
+  method->get_value(num_values - 1);
+
+  // Out-of-range values should abort.
+  ET_EXPECT_DEATH(method->get_value(num_values), "");
+  ET_EXPECT_DEATH(method->get_value(num_values + 1), "");
+}
+
+TEST_F(MethodTest, MutableValueTests) {
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
+  ASSERT_EQ(method.error(), Error::Ok);
+
+  size_t num_values = method->values_size();
+  ASSERT_GT(num_values, 0);
+
+  // In-range values should succeed without aborting.
+  method->mutable_value(0);
+  method->mutable_value(num_values - 1);
+
+  // Out-of-range values should abort.
+  ET_EXPECT_DEATH(method->mutable_value(num_values), "");
+  ET_EXPECT_DEATH(method->mutable_value(num_values + 1), "");
+}
+
+TEST_F(MethodTest, GetInputTests) {
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
+  ASSERT_EQ(method.error(), Error::Ok);
+
+  size_t num_inputs = method->inputs_size();
+  ASSERT_GT(num_inputs, 0);
+
+  // In-range inputs should succeed without aborting.
+  method->get_input(0);
+  method->get_input(num_inputs - 1);
+
+  // Out-of-range inputs should abort.
+  ET_EXPECT_DEATH(method->get_input(num_inputs), "");
+  ET_EXPECT_DEATH(method->get_input(num_inputs + 1), "");
+}
+
+TEST_F(MethodTest, GetInputIndexTests) {
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
+  ASSERT_EQ(method.error(), Error::Ok);
+
+  size_t num_inputs = method->inputs_size();
+  ASSERT_GT(num_inputs, 0);
+
+  // In-range inputs should succeed without aborting.
+  method->get_input_index(0);
+  method->get_input_index(num_inputs - 1);
+
+  // Out-of-range inputs should abort.
+  ET_EXPECT_DEATH(method->get_input_index(num_inputs), "");
+  ET_EXPECT_DEATH(method->get_input_index(num_inputs + 1), "");
+}
+
+TEST_F(MethodTest, MutableInputTests) {
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
+  ASSERT_EQ(method.error(), Error::Ok);
+
+  size_t num_inputs = method->inputs_size();
+  ASSERT_GT(num_inputs, 0);
+
+  // In-range inputs should succeed without aborting.
+  method->mutable_input(0);
+  method->mutable_input(num_inputs - 1);
+
+  // Out-of-range inputs should abort.
+  ET_EXPECT_DEATH(method->mutable_input(num_inputs), "");
+  ET_EXPECT_DEATH(method->mutable_input(num_inputs + 1), "");
+}
+
+TEST_F(MethodTest, GetOutputTests) {
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
+  ASSERT_EQ(method.error(), Error::Ok);
+
+  size_t num_outputs = method->outputs_size();
+  ASSERT_GT(num_outputs, 0);
+
+  // In-range outputs should succeed without aborting.
+  method->get_output(0);
+  method->get_output(num_outputs - 1);
+
+  // Out-of-range outputs should abort.
+  ET_EXPECT_DEATH(method->get_output(num_outputs), "");
+  ET_EXPECT_DEATH(method->get_output(num_outputs + 1), "");
+}
+
+TEST_F(MethodTest, GetOutputIndexTests) {
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
+  ASSERT_EQ(method.error(), Error::Ok);
+
+  size_t num_outputs = method->outputs_size();
+  ASSERT_GT(num_outputs, 0);
+
+  // In-range outputs should succeed without aborting.
+  method->get_output_index(0);
+  method->get_output_index(num_outputs - 1);
+
+  // Out-of-range outputs should abort.
+  ET_EXPECT_DEATH(method->get_output_index(num_outputs), "");
+  ET_EXPECT_DEATH(method->get_output_index(num_outputs + 1), "");
+}
+
+TEST_F(MethodTest, MutableOutputTests) {
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
+  ASSERT_EQ(method.error(), Error::Ok);
+
+  size_t num_outputs = method->outputs_size();
+  ASSERT_GT(num_outputs, 0);
+
+  // In-range outputs should succeed without aborting.
+  method->mutable_output(0);
+  method->mutable_output(num_outputs - 1);
+
+  // Out-of-range outputs should abort.
+  ET_EXPECT_DEATH(method->mutable_output(num_outputs), "");
+  ET_EXPECT_DEATH(method->mutable_output(num_outputs + 1), "");
 }
 
 TEST_F(MethodTest, SetPrimInputTest) {


### PR DESCRIPTION
Summary:
Avoid buffer overruns of the `values_` table by checking indies.

Pre-check that inputs/outputs point to valid values so we can fail non-fatally.

Differential Revision: D52646899


