### PR TITLE
Additional op cleanup to use ET_KERNEL_CHECK

### DIFF
--- a/kernels/optimized/cpu/op_add.cpp
+++ b/kernels/optimized/cpu/op_add.cpp
@@ -53,7 +53,11 @@ Tensor& opt_add_out(
     ScalarType common_type = promoteTypes(a_type, b_type);
     ET_CHECK(canCast(common_type, out_type));
 
-    resize_to_broadcast_target_size(a, b, out);
+    ET_KERNEL_CHECK(
+        ctx,
+        resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+        InvalidArgument,
+        out);
 
     ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "add.out", CTYPE_A, [&]() {
       ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "add.out", CTYPE_B, [&]() {

--- a/kernels/optimized/cpu/op_div.cpp
+++ b/kernels/optimized/cpu/op_div.cpp
@@ -66,7 +66,11 @@ Tensor& opt_div_out(
     ScalarType common_type = get_compute_type(a_type, b_type);
     ET_CHECK(canCast(common_type, out_type));
 
-    resize_to_broadcast_target_size(a, b, out);
+    ET_KERNEL_CHECK(
+        ctx,
+        resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+        InvalidArgument,
+        out);
 
     ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "div.out", CTYPE_A, [&]() {
       ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "div.out", CTYPE_B, [&]() {

--- a/kernels/optimized/cpu/op_mul.cpp
+++ b/kernels/optimized/cpu/op_mul.cpp
@@ -49,7 +49,11 @@ Tensor& opt_mul_out(
     ScalarType common_type = promoteTypes(a_type, b_type);
     ET_CHECK(canCast(common_type, out_type));
 
-    resize_to_broadcast_target_size(a, b, out);
+    ET_KERNEL_CHECK(
+        ctx,
+        resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+        InvalidArgument,
+        out);
 
     ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "mul.out", CTYPE_A, [&]() {
       ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "mul.out", CTYPE_B, [&]() {

--- a/kernels/optimized/cpu/op_sub.cpp
+++ b/kernels/optimized/cpu/op_sub.cpp
@@ -53,7 +53,11 @@ Tensor& opt_sub_out(
     ScalarType common_type = promoteTypes(a_type, b_type);
     ET_CHECK(canCast(common_type, out_type));
 
-    resize_to_broadcast_target_size(a, b, out);
+    ET_KERNEL_CHECK(
+        ctx,
+        resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+        InvalidArgument,
+        out);
 
     ET_SWITCH_REAL_TYPES(a_type, ctx, "sub.out", CTYPE_A, [&]() {
       ET_SWITCH_REAL_TYPES(b_type, ctx, "sub.out", CTYPE_B, [&]() {

--- a/kernels/portable/cpu/op_abs.cpp
+++ b/kernels/portable/cpu/op_abs.cpp
@@ -20,9 +20,14 @@ Tensor& abs_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
-  ET_CHECK_SAME_SHAPE_AND_DTYPE2(in, out);
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(ctx, tensors_have_same_dtype(in, out), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "abs.out", CTYPE, [&] {
     apply_unary_map_fn(

--- a/kernels/portable/cpu/op_add.cpp
+++ b/kernels/portable/cpu/op_add.cpp
@@ -72,15 +72,19 @@ Tensor& add_scalar_out(
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(common_type == out_type);
+  ET_KERNEL_CHECK(ctx, common_type == out_type, InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "add.Scalar_out", CTYPE_A, [&]() {
     ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "add.Scalar_out", CTYPE_B, [&]() {

--- a/kernels/portable/cpu/op_add.cpp
+++ b/kernels/portable/cpu/op_add.cpp
@@ -33,7 +33,7 @@ Tensor& add_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "add.out", CTYPE_A, [&]() {
     ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "add.out", CTYPE_B, [&]() {

--- a/kernels/portable/cpu/op_add.cpp
+++ b/kernels/portable/cpu/op_add.cpp
@@ -22,9 +22,11 @@ Tensor& add_out(
     const Tensor& b,
     const Scalar& alpha,
     Tensor& out) {
-  (void)ctx;
-
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_alias_copy.cpp
+++ b/kernels/portable/cpu/op_alias_copy.cpp
@@ -19,8 +19,15 @@ using Tensor = exec_aten::Tensor;
 Tensor& alias_copy_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   (void)ctx;
 
-  ET_CHECK(resize_tensor(out, in.sizes()) == torch::executor::Error::Ok);
-  ET_CHECK_SAME_DTYPE2(in, out);
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(ctx, tensors_have_same_dtype(in, out), InvalidArgument, out);
 
   if (in.nbytes() > 0) {
     // Note that this check is important. It's valid for a tensor with numel 0

--- a/kernels/portable/cpu/op_arange.cpp
+++ b/kernels/portable/cpu/op_arange.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
+#include <executorch/kernels/portable/cpu/util/kernel_ops_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 #include <executorch/runtime/platform/assert.h>
 
@@ -19,35 +20,22 @@ namespace executor {
 namespace native {
 
 Tensor& arange_out(RuntimeContext& ctx, const Scalar& end, Tensor& out) {
-  ET_KERNEL_CHECK_MSG(
-      ctx,
-      out.dim() == 1,
-      InvalidArgument,
-      out,
-      "out should be a 1-d tensor, but got a %zu-d tensor",
-      out.dim());
-
-  ScalarType end_type = utils::get_scalar_dtype(end);
-
   double end_val = 0;
-  ET_SWITCH_SCALAR_OBJ_TYPES(end_type, ctx, "arange.out", CTYPE_END, [&]() {
-    CTYPE_END end_v;
-    ET_EXTRACT_SCALAR(end, end_v);
-    ET_KERNEL_CHECK_MSG(
-        ctx,
-        end_v >= 0,
-        InvalidArgument,
-        out,
-        "Input end should be non-negative.");
-    end_val = static_cast<double>(end_v);
-  });
+  ET_KERNEL_CHECK(
+      ctx, utils::extract_scalar(end, &end_val), InvalidArgument, out);
+
+  ET_KERNEL_CHECK(
+      ctx, check_arange_args(0.0, end_val, 1.0, out), InvalidArgument, out);
 
   size_t size = static_cast<size_t>(std::ceil(end_val));
 
   Tensor::SizesType out_length = static_cast<Tensor::SizesType>(size);
-  Error status = resize_tensor(out, {&out_length, 1});
-  ET_KERNEL_CHECK_MSG(
-      ctx, status == Error::Ok, InvalidArgument, out, "resize_tensor fails");
+
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, {&out_length, 1}) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ET_SWITCH_REAL_TYPES(out.scalar_type(), ctx, "arange.out", CTYPE, [&]() {
     auto out_data = out.mutable_data_ptr<CTYPE>();
@@ -67,48 +55,34 @@ Tensor& arange_start_out(
     Tensor& out) {
   (void)ctx;
 
-  ScalarType start_type = utils::get_scalar_dtype(start);
-  ScalarType end_type = utils::get_scalar_dtype(end);
-  ScalarType step_type = utils::get_scalar_dtype(step);
-
   double d_start = 0;
-  ET_SWITCH_SCALAR_OBJ_TYPES(
-      start_type, ctx, "arange.start_out", CTYPE_END, [&]() {
-        CTYPE_END start_v;
-        ET_EXTRACT_SCALAR(start, start_v);
-        d_start = static_cast<double>(start_v);
-      });
+  ET_KERNEL_CHECK(
+      ctx, utils::extract_scalar(start, &d_start), InvalidArgument, out);
 
   double d_end = 0;
-  ET_SWITCH_SCALAR_OBJ_TYPES(
-      end_type, ctx, "arange.start_out", CTYPE_END, [&]() {
-        CTYPE_END end_v;
-        ET_EXTRACT_SCALAR(end, end_v);
-        d_end = static_cast<double>(end_v);
-      });
+  ET_KERNEL_CHECK(
+      ctx, utils::extract_scalar(end, &d_end), InvalidArgument, out);
 
   double d_step = 0;
-  ET_SWITCH_SCALAR_OBJ_TYPES(
-      step_type, ctx, "arange.start_out", CTYPE_END, [&]() {
-        CTYPE_END step_v;
-        ET_EXTRACT_SCALAR(step, step_v);
-        d_step = static_cast<double>(step_v);
-      });
+  ET_KERNEL_CHECK(
+      ctx, utils::extract_scalar(step, &d_step), InvalidArgument, out);
 
-  ET_KERNEL_CHECK_MSG(
+  ET_KERNEL_CHECK(
       ctx,
-      (d_step > 0 && (d_end >= d_start)) || (d_step < 0 && (d_end <= d_start)),
+      check_arange_args(d_start, d_end, d_step, out),
       InvalidArgument,
-      out,
-      "upper bound and larger bound inconsistent with step sign");
+      out);
 
   double size_d = (d_end - d_start) / d_step;
   size_t size = static_cast<size_t>(std::ceil(size_d));
 
   Tensor::SizesType out_length = static_cast<Tensor::SizesType>(size);
-  Error status = resize_tensor(out, {&out_length, 1});
-  ET_KERNEL_CHECK_MSG(
-      ctx, status == Error::Ok, InvalidArgument, out, "resize_tensor fails");
+
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, {&out_length, 1}) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ET_SWITCH_REAL_TYPES(
       out.scalar_type(), ctx, "arange.start_out", CTYPE, [&]() {

--- a/kernels/portable/cpu/op_bitwise_and.cpp
+++ b/kernels/portable/cpu/op_bitwise_and.cpp
@@ -101,15 +101,20 @@ Tensor& bitwise_and_Scalar_out(
     Tensor& out) {
   (void)ctx;
 
-  // Determine output size and resize for dynamic shapes
-  ET_CHECK(resize_tensor(out, a.sizes()) == Error::Ok);
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_INT_TYPES_AND(
       Bool, a_type, ctx, "bitwise_and.Scalar_out", CTYPE_A, [&]() {

--- a/kernels/portable/cpu/op_bitwise_and.cpp
+++ b/kernels/portable/cpu/op_bitwise_and.cpp
@@ -49,7 +49,7 @@ Tensor& bitwise_and_Tensor_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_INT_TYPES_AND(
       Bool, a_type, ctx, "bitwise_and.Tensor_out", CTYPE_A, [&]() {

--- a/kernels/portable/cpu/op_bitwise_and.cpp
+++ b/kernels/portable/cpu/op_bitwise_and.cpp
@@ -38,10 +38,11 @@ Tensor& bitwise_and_Tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
-  // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_bitwise_not.cpp
+++ b/kernels/portable/cpu/op_bitwise_not.cpp
@@ -25,9 +25,14 @@ Tensor& bitwise_not_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
-  ET_CHECK_SAME_SHAPE_AND_DTYPE2(in, out);
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(ctx, tensors_have_same_dtype(in, out), InvalidArgument, out);
 
   if (in.scalar_type() == exec_aten::ScalarType::Bool) {
     apply_unary_map_fn(

--- a/kernels/portable/cpu/op_bitwise_or.cpp
+++ b/kernels/portable/cpu/op_bitwise_or.cpp
@@ -100,15 +100,20 @@ Tensor& bitwise_or_Scalar_out(
     Tensor& out) {
   (void)ctx;
 
-  // Determine output size and resize for dynamic shapes
-  ET_CHECK(resize_tensor(out, a.sizes()) == Error::Ok);
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_INT_TYPES_AND(
       Bool, a_type, ctx, "bitwise_or.Scalar_out", CTYPE_A, [&]() {

--- a/kernels/portable/cpu/op_bitwise_or.cpp
+++ b/kernels/portable/cpu/op_bitwise_or.cpp
@@ -49,7 +49,7 @@ Tensor& bitwise_or_Tensor_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_INT_TYPES_AND(
       Bool, a_type, ctx, "bitwise_or.Tensor_out", CTYPE_A, [&]() {

--- a/kernels/portable/cpu/op_bitwise_or.cpp
+++ b/kernels/portable/cpu/op_bitwise_or.cpp
@@ -38,10 +38,11 @@ Tensor& bitwise_or_Tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
-  // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_bitwise_xor.cpp
+++ b/kernels/portable/cpu/op_bitwise_xor.cpp
@@ -102,15 +102,20 @@ Tensor& bitwise_xor_Scalar_out(
     Tensor& out) {
   (void)ctx;
 
-  // Determine output size and resize for dynamic shapes
-  ET_CHECK(resize_tensor(out, a.sizes()) == Error::Ok);
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_INT_TYPES_AND(
       Bool, a_type, ctx, "bitwise_xor.Scalar_out", CTYPE_A, [&]() {

--- a/kernels/portable/cpu/op_bitwise_xor.cpp
+++ b/kernels/portable/cpu/op_bitwise_xor.cpp
@@ -38,10 +38,12 @@ Tensor& bitwise_xor_Tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
   // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_bitwise_xor.cpp
+++ b/kernels/portable/cpu/op_bitwise_xor.cpp
@@ -50,7 +50,7 @@ Tensor& bitwise_xor_Tensor_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_INT_TYPES_AND(
       Bool, a_type, ctx, "bitwise_xor.Tensor_out", CTYPE_A, [&]() {

--- a/kernels/portable/cpu/op_cat.cpp
+++ b/kernels/portable/cpu/op_cat.cpp
@@ -31,8 +31,12 @@ Tensor& cat_out(
   Tensor::SizesType expected_out_size[kTensorDimensionLimit];
   size_t expected_out_dim = 0;
   get_cat_out_target_size(tensors, dim, expected_out_size, &expected_out_dim);
-  ET_CHECK(
-      resize_tensor(out, {expected_out_size, expected_out_dim}) == Error::Ok);
+
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, {expected_out_size, expected_out_dim}) == Error::Ok,
+      InvalidArgument,
+      out);
 
   // Special handling when all inputs are 1D-empty tensors for aten consistency
   // In that case, just return an 1D-empty tensor without checking dim

--- a/kernels/portable/cpu/op_clamp.cpp
+++ b/kernels/portable/cpu/op_clamp.cpp
@@ -85,29 +85,35 @@ bool is_out_of_bounds(CTYPE_VAL val) {
       val_cast > std::numeric_limits<CTYPE_OUT>::max();
 }
 
-void check_bounds(
+[[nodiscard]] bool check_bounds(
     const Scalar& val_scalar,
     const torch::executor::native::ScalarType& val_type,
     const torch::executor::native::ScalarType& out_type,
     const char* val_name) {
+  auto is_valid = true;
+
   ET_SWITCH_SCALAR_OBJ_TYPES(val_type, ctx, "clamp.out", CTYPE_VAL, [&]() {
     CTYPE_VAL val = 0;
     ET_EXTRACT_SCALAR(val_scalar, val);
     if (isIntegralType(out_type, /*includeBool=*/false)) {
       ET_SWITCH_INT_TYPES(out_type, ctx, "clamp.out", CTYPE_OUT, [&]() {
         if (is_out_of_bounds<CTYPE_VAL, CTYPE_OUT, long>(val)) {
-          ET_CHECK_MSG(false, "%s value out of bounds", val_name);
+          ET_LOG(Error, "%s value out of bounds", val_name);
+          is_valid = false;
         }
       });
     } else if (isFloatingType(out_type)) {
       ET_SWITCH_FLOAT_TYPES(out_type, ctx, "clamp", CTYPE_OUT, [&]() {
         if (std::isfinite(val) &&
             is_out_of_bounds<CTYPE_VAL, CTYPE_OUT, double>(val)) {
-          ET_CHECK_MSG(false, "%s value out of bounds", val_name);
+          ET_LOG(Error, "%s value out of bounds", val_name);
+          is_valid = false;
         }
       });
     }
   });
+
+  return is_valid;
 }
 
 } // namespace
@@ -120,8 +126,12 @@ Tensor& clamp_out(
     Tensor& out) {
   (void)ctx;
 
-  Error err = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(err == Error::Ok, "Could not resize output");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType in_type = in.scalar_type();
   ScalarType min_type = in_type;
@@ -133,13 +143,21 @@ Tensor& clamp_out(
   if (has_min) {
     min_type = utils::get_scalar_dtype(min_opt.value());
     common_type = utils::promote_type_with_scalar(common_type, min_opt.value());
-    check_bounds(min_opt.value(), min_type, out_type, "minimum");
+    ET_KERNEL_CHECK(
+        ctx,
+        check_bounds(min_opt.value(), min_type, out_type, "minimum"),
+        InvalidArgument,
+        out);
   }
   bool has_max = max_opt.has_value();
   if (has_max) {
     max_type = utils::get_scalar_dtype(max_opt.value());
     common_type = utils::promote_type_with_scalar(common_type, max_opt.value());
-    check_bounds(max_opt.value(), max_type, out_type, "maximum");
+    ET_KERNEL_CHECK(
+        ctx,
+        check_bounds(max_opt.value(), max_type, out_type, "maximum"),
+        InvalidArgument,
+        out);
   }
 
   ET_CHECK_MSG(

--- a/kernels/portable/cpu/op_constant_pad_nd.cpp
+++ b/kernels/portable/cpu/op_constant_pad_nd.cpp
@@ -12,47 +12,13 @@
 #include <executorch/runtime/kernel/kernel_includes.h>
 
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
+#include <executorch/kernels/portable/cpu/util/kernel_ops_util.h>
 
 namespace torch {
 namespace executor {
 namespace native {
 
 namespace {
-
-void check_input_output(const Tensor& self, const Tensor& out) {
-  ET_CHECK_SAME_DTYPE2(self, out);
-  ET_CHECK_MSG(
-      self.dim() == out.dim(),
-      "self and out must have the same number of dims");
-}
-
-void check_padding_arg(const Tensor& self, IntArrayRef pad) {
-  ET_CHECK_MSG(pad.size() % 2 == 0, "Padding array must be a multiple of 2");
-
-  ET_CHECK_MSG(
-      pad.size() / 2 <= self.dim(), "Padding array contains too many elements");
-}
-
-Error resize_to_expected_out_size(
-    const Tensor& self,
-    IntArrayRef pad,
-    Tensor& out) {
-  Tensor::SizesType expected_output_size[kTensorDimensionLimit];
-
-  int pad_i = self.dim() - 1;
-  for (size_t i = 0; i < self.dim(); ++i, --pad_i) {
-    expected_output_size[i] = self.size(i);
-    if (pad_i >= 0 && pad_i < pad.size() / 2) {
-      expected_output_size[i] += pad[2 * pad_i] + pad[2 * pad_i + 1];
-    }
-  }
-
-  ArrayRef<Tensor::SizesType> output_size{
-      expected_output_size, static_cast<size_t>(self.dim())};
-  auto error = resize_tensor(out, output_size);
-
-  return error;
-}
 
 template <typename CTYPE>
 void set_all_to_value(CTYPE* out_data, size_t step_len, CTYPE value) {
@@ -201,19 +167,19 @@ Tensor& constant_pad_nd_out(
     Tensor& out) {
   (void)ctx;
 
-  check_input_output(in, out);
-  check_padding_arg(in, pad);
+  ET_KERNEL_CHECK(
+      ctx, check_constant_pad_args(in, pad, value, out), InvalidArgument, out);
 
   // resize out tensor for dynamic shapes
-  auto error = resize_to_expected_out_size(in, pad, out);
-  // TODO: Construct error message with requested output sizes.
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_constant_pad_output(in, pad, out) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType in_type = in.scalar_type();
   ScalarType value_type = utils::get_scalar_dtype(value);
-  ScalarType out_type = out.scalar_type();
-
-  ET_CHECK(in_type == out_type);
 
   ET_SWITCH_REAL_TYPES_AND(
       Bool, in_type, ctx, "constant_pad_nd.out", CTYPE, [&]() {

--- a/kernels/portable/cpu/op_detach_copy.cpp
+++ b/kernels/portable/cpu/op_detach_copy.cpp
@@ -25,12 +25,16 @@ namespace {} // namespace
 Tensor& detach_copy_out(RuntimeContext& ctx, const Tensor& self, Tensor& out) {
   (void)ctx;
 
-  torch::executor::Error err = resize_tensor(out, self.sizes());
-  ET_CHECK_MSG(
-      err == torch::executor::Error::Ok,
-      "Failed to resize out Tensor in detach_copy_out");
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, self.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
-  ET_CHECK_SAME_SHAPE_AND_DTYPE2(self, out);
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_shape_and_dtype(self, out), InvalidArgument, out);
 
   if (self.nbytes() > 0) {
     // Note that this check is important. It's valid for a tensor with numel 0

--- a/kernels/portable/cpu/op_div.cpp
+++ b/kernels/portable/cpu/op_div.cpp
@@ -39,9 +39,11 @@ ScalarType get_compute_type(ScalarType a_type, ScalarType b_type) {
 
 Tensor&
 div_out(RuntimeContext& ctx, const Tensor& a, const Tensor& b, Tensor& out) {
-  (void)ctx;
-
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();
@@ -79,9 +81,11 @@ Tensor& div_out_mode(
     const Tensor& b,
     exec_aten::optional<exec_aten::string_view> mode,
     Tensor& out) {
-  (void)ctx;
-
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_div.cpp
+++ b/kernels/portable/cpu/op_div.cpp
@@ -50,7 +50,7 @@ div_out(RuntimeContext& ctx, const Tensor& a, const Tensor& b, Tensor& out) {
   ScalarType common_type = get_compute_type(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "div.out", CTYPE_A, [&]() {
     ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "div.out", CTYPE_B, [&]() {

--- a/kernels/portable/cpu/op_empty.cpp
+++ b/kernels/portable/cpu/op_empty.cpp
@@ -30,7 +30,13 @@ Tensor& empty_out(
     Tensor& out) {
   (void)context;
 
-  ET_CHECK(resize_tensor(out, size) == torch::executor::Error::Ok);
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, size) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   return out;
 }

--- a/kernels/portable/cpu/op_eq.cpp
+++ b/kernels/portable/cpu/op_eq.cpp
@@ -24,10 +24,11 @@ Tensor& eq_tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
-  // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_expand_copy.cpp
+++ b/kernels/portable/cpu/op_expand_copy.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
+#include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
 #include <executorch/kernels/portable/cpu/util/repeat_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 #include <sys/types.h>
@@ -25,44 +26,6 @@ using SizesType = exec_aten::SizesType;
 constexpr const size_t kTensorDimensionLimit{16};
 
 namespace {
-
-size_t calculate_output_sizes(
-    exec_aten::ArrayRef<SizesType> self_sizes,
-    exec_aten::ArrayRef<int64_t> expand_sizes,
-    SizesType* output_sizes) {
-  auto j{expand_sizes.size()};
-  for (size_t i{self_sizes.size()}; i > 0 && j > 0;) {
-    --i;
-    --j;
-
-    output_sizes[j] = expand_sizes[j];
-
-    if (expand_sizes[j] == -1) {
-      // -1 can use for replacing any corresponding dimension
-      output_sizes[j] = self_sizes[i];
-    } else if (self_sizes[i] != 1) {
-      ET_CHECK_MSG(
-          expand_sizes[j] == self_sizes[i],
-          "The expanded size of the tensor (%zu) must match the existing size (%zu) at non-singleton dimension %zu.",
-          (size_t)expand_sizes[j],
-          (size_t)self_sizes[i],
-          i);
-    }
-  }
-
-  // The leading expand_sizes cannot be negative
-  while (j > 0) {
-    --j;
-    output_sizes[j] = expand_sizes[j];
-    ET_CHECK_MSG(
-        expand_sizes[j] >= 0,
-        "The expanded size of the tensor (%zu) isn't allowed in a leading, non-existing dimension %zu",
-        (size_t)expand_sizes[j],
-        j);
-  }
-
-  return expand_sizes.size();
-}
 
 size_t map_expand_to_repeats(
     exec_aten::ArrayRef<SizesType> self_sizes,
@@ -88,31 +51,6 @@ size_t map_expand_to_repeats(
 
   return expand_sizes.size();
 }
-
-void check_output_tensor(
-    const Tensor& self,
-    exec_aten::ArrayRef<exec_aten::SizesType> output_sizes,
-    const Tensor& out) {
-  ET_CHECK_SAME_DTYPE2(self, out);
-
-  const auto& out_sizes = out.sizes();
-
-  ET_CHECK_MSG(
-      output_sizes.size() == out_sizes.size(),
-      "Number of output tensor sizes (%zu) must match the number of expanded output sizes (%zu)",
-      output_sizes.size(),
-      out_sizes.size());
-
-  // Make sure the output shape is correct
-  for (size_t i{0}; i < output_sizes.size(); i++) {
-    ET_CHECK_MSG(
-        output_sizes[i] == out_sizes[i],
-        "Size of output tensor (%d) must match size of expanded output (%d) at dimension (%zu)",
-        out_sizes[i],
-        output_sizes[i],
-        i);
-  }
-}
 } // namespace
 
 Tensor& expand_copy_out(
@@ -123,35 +61,29 @@ Tensor& expand_copy_out(
     Tensor& out) {
   (void)ctx;
 
-  ET_CHECK_MSG(
-      implicit == false,
-      "This operator is not implemented for when implicit == true.");
+  ET_KERNEL_CHECK(
+      ctx,
+      check_expand_copy_args(self, expand_sizes, implicit, out),
+      InvalidArgument,
+      out);
 
   const auto& self_sizes = self.sizes();
 
-  ET_CHECK_MSG(
-      expand_sizes.size() >= self_sizes.size(),
-      "The number of sizes provided (%zu) must at least be equal to the number of dimensions in the tensor (%zu)",
-      expand_sizes.size(),
-      self_sizes.size());
-
-  ET_CHECK_MSG(
-      expand_sizes.size() <= kTensorDimensionLimit,
-      "The number of expanded dims (%zu) exceeds the configured maximum (%zu). Increase this limit.",
-      expand_sizes.size(),
-      kTensorDimensionLimit);
-
   // Holds the result of converting -1 to the original dim sizes
   exec_aten::SizesType output_sizes[kTensorDimensionLimit];
-  const auto output_sizes_size{
-      calculate_output_sizes(self_sizes, expand_sizes, output_sizes)};
+  size_t output_rank = 0;
+  ET_KERNEL_CHECK(
+      ctx,
+      get_expand_copy_out_target_size(
+          self_sizes, expand_sizes, output_sizes, &output_rank),
+      InvalidArgument,
+      out);
 
-  auto error = resize_tensor(out, {output_sizes, output_sizes_size});
-  // TODO: Construct error message with requested output sizes.
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
-
-  // Check that the output tensor is the same shape as the mapped expand
-  check_output_tensor(self, {output_sizes, output_sizes_size}, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, {output_sizes, output_rank}) == Error::Ok,
+      InvalidArgument,
+      out);
 
   // Holds the result of expand_sizes converted to repeat sizes
   int64_t repeats[kTensorDimensionLimit];

--- a/kernels/portable/cpu/op_fill.cpp
+++ b/kernels/portable/cpu/op_fill.cpp
@@ -29,11 +29,15 @@ Tensor& fill_scalar_out(
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(a_type == out_type);
+  ET_KERNEL_CHECK(ct, a_type == out_type, InvalidArgument, out);
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "fill.Scalar_out", CTYPE_A, [&] {
     CTYPE_A b_casted;

--- a/kernels/portable/cpu/op_fill.cpp
+++ b/kernels/portable/cpu/op_fill.cpp
@@ -74,8 +74,12 @@ Tensor& fill_tensor_out(
   ET_CHECK(a_type == out_type);
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "fill.Tensor_out", CTYPE_A, [&] {
     CTYPE_A b_casted;

--- a/kernels/portable/cpu/op_floor_divide.cpp
+++ b/kernels/portable/cpu/op_floor_divide.cpp
@@ -74,7 +74,7 @@ Tensor& floor_divide_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(
       Bool, a_type, ctx, "floor_divide.out", CTYPE_A, [&]() {

--- a/kernels/portable/cpu/op_floor_divide.cpp
+++ b/kernels/portable/cpu/op_floor_divide.cpp
@@ -63,7 +63,11 @@ Tensor& floor_divide_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_fmod.cpp
+++ b/kernels/portable/cpu/op_fmod.cpp
@@ -36,7 +36,7 @@ Tensor& fmod_Tensor_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(
       Bool, a_type, ctx, "fmod.Tensor_out", CTYPE_A, [&]() {

--- a/kernels/portable/cpu/op_fmod.cpp
+++ b/kernels/portable/cpu/op_fmod.cpp
@@ -24,10 +24,12 @@ Tensor& fmod_Tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
   // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_fmod.cpp
+++ b/kernels/portable/cpu/op_fmod.cpp
@@ -82,15 +82,20 @@ Tensor& fmod_Scalar_out(
     Tensor& out) {
   (void)ctx;
 
-  // Determine output size and resize for dynamic shapes
-  ET_CHECK(resize_tensor(out, a.sizes()) == Error::Ok);
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(
       Bool, a_type, ctx, "fmod.Scalar_out", CTYPE_A, [&]() {

--- a/kernels/portable/cpu/op_full.cpp
+++ b/kernels/portable/cpu/op_full.cpp
@@ -26,8 +26,13 @@ Tensor& full_out(
   ScalarType val_type = utils::get_scalar_dtype(fill_value);
   ScalarType out_type = out.scalar_type();
 
-  Error err = resize_tensor(out, sizes);
-  ET_CHECK_MSG(err == Error::Ok, "Could not resize out");
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, sizes) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ET_SWITCH_REAL_TYPES_AND(Bool, val_type, ctx, "full.out", CTYPE_VAL, [&] {
     CTYPE_VAL val;

--- a/kernels/portable/cpu/op_full_like.cpp
+++ b/kernels/portable/cpu/op_full_like.cpp
@@ -25,14 +25,21 @@ Tensor& full_like_out(
   (void)ctx;
 
   if (memory_format.has_value()) {
-    ET_CHECK_MSG(
+    ET_KERNEL_CHECK_MSG(
+        ctx,
         memory_format.value() == MemoryFormat::Contiguous,
+        InvalidArgument,
+        out,
         "memory_format must be contiguous");
   }
 
-  Error err = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(
-      err == Error::Ok, "Failed to resize out Tensor in full_like_out");
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType val_type = utils::get_scalar_dtype(fill_value);
   ScalarType out_type = out.scalar_type();

--- a/kernels/portable/cpu/op_ge.cpp
+++ b/kernels/portable/cpu/op_ge.cpp
@@ -69,8 +69,12 @@ Tensor& ge_scalar_out(
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);

--- a/kernels/portable/cpu/op_ge.cpp
+++ b/kernels/portable/cpu/op_ge.cpp
@@ -24,10 +24,12 @@ Tensor& ge_tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
   // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_gt.cpp
+++ b/kernels/portable/cpu/op_gt.cpp
@@ -24,10 +24,12 @@ Tensor& gt_tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
   // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_gt.cpp
+++ b/kernels/portable/cpu/op_gt.cpp
@@ -69,8 +69,12 @@ Tensor& gt_scalar_out(
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);

--- a/kernels/portable/cpu/op_hardtanh.cpp
+++ b/kernels/portable/cpu/op_hardtanh.cpp
@@ -85,7 +85,7 @@ Tensor& hardtanh_out(
   ScalarType max_type = utils::get_scalar_dtype(max);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(in_type == out_type);
+  ET_KERNEL_CHECK(ctx, in_type == out_type, InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES(in_type, ctx, "hardtanh.out", CTYPE, [&]() {
     CTYPE min_casted;

--- a/kernels/portable/cpu/op_hardtanh.cpp
+++ b/kernels/portable/cpu/op_hardtanh.cpp
@@ -77,8 +77,13 @@ Tensor& hardtanh_out(
     Tensor& out) {
   (void)ctx;
 
-  Error err = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(err == Error::Ok, "Could not resize output");
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType in_type = in.scalar_type();
   ScalarType min_type = utils::get_scalar_dtype(min);

--- a/kernels/portable/cpu/op_le.cpp
+++ b/kernels/portable/cpu/op_le.cpp
@@ -69,8 +69,12 @@ Tensor& le_scalar_out(
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);

--- a/kernels/portable/cpu/op_le.cpp
+++ b/kernels/portable/cpu/op_le.cpp
@@ -24,10 +24,12 @@ Tensor& le_tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
   // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_leaky_relu.cpp
+++ b/kernels/portable/cpu/op_leaky_relu.cpp
@@ -27,14 +27,19 @@ Tensor& leaky_relu_out(
     Tensor& out) {
   (void)ctx;
 
-  Error err = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(err == Error::Ok, "Could not resize output");
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType in_type = in.scalar_type();
   ScalarType sc_type = utils::get_scalar_dtype(negative_slope);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(in_type == out_type);
+  ET_KERNEL_CHECK(ctx, in_type == out_type, InvalidArgument, out);
 
   ET_SWITCH_FLOAT_TYPES(in_type, ctx, "leaky_relu.out", CTYPE, [&]() {
     CTYPE negative_slope_casted;

--- a/kernels/portable/cpu/op_linear_scratch_example.cpp
+++ b/kernels/portable/cpu/op_linear_scratch_example.cpp
@@ -103,7 +103,12 @@ Tensor& linear_scratch_example(
 
     // add the bias
     if (bias.has_value()) {
-      ET_CHECK_MSG(K == bias.value().numel(), "Unexpected numel for bias");
+      ET_KERNEL_CHECK_MSG(
+          ctx,
+          K == bias.value().numel(),
+          InvalidArgument,
+          out,
+          "Unexpected numel for bias");
       for (size_t i = 0; i < M; ++i) {
         for (size_t j = 0; j < K; ++j) {
           scalar_t* scratch_ptr =

--- a/kernels/portable/cpu/op_log_softmax.cpp
+++ b/kernels/portable/cpu/op_log_softmax.cpp
@@ -27,7 +27,11 @@ Tensor& log_softmax_out(
     Tensor& out) {
   (void)ctx;
 
-  check_log_softmax_args(in, dim, half_to_float, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      check_log_softmax_args(in, dim, half_to_float, out),
+      InvalidArgument,
+      out);
 
   ET_KERNEL_CHECK(
       ctx, resize_tensor(out, in.sizes()) == Error::Ok, InvalidArgument, out);

--- a/kernels/portable/cpu/op_logical_not.cpp
+++ b/kernels/portable/cpu/op_logical_not.cpp
@@ -20,9 +20,14 @@ Tensor& logical_not_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
-  ET_CHECK_SAME_SHAPE2(in, out);
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(ctx, tensors_have_same_shape(in, out), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(
       Bool, in.scalar_type(), ctx, "logical_not.out", CTYPE_IN, [&] {

--- a/kernels/portable/cpu/op_lt.cpp
+++ b/kernels/portable/cpu/op_lt.cpp
@@ -69,8 +69,12 @@ Tensor& lt_scalar_out(
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);

--- a/kernels/portable/cpu/op_lt.cpp
+++ b/kernels/portable/cpu/op_lt.cpp
@@ -24,10 +24,12 @@ Tensor& lt_tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
   // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_masked_fill.cpp
+++ b/kernels/portable/cpu/op_masked_fill.cpp
@@ -8,6 +8,7 @@
 
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
+#include <executorch/kernels/portable/cpu/util/kernel_ops_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
@@ -26,14 +27,13 @@ Tensor& masked_fill_scalar_out(
     Tensor& out) {
   (void)ctx;
 
-  ET_KERNEL_CHECK(ctx, tensors_have_same_dtype(in, out), InvalidArgument, out);
+  ET_KERNEL_CHECK(
+      ctx, check_masked_fill_args(in, mask, value, out), InvalidArgument, out);
 
   ScalarType in_type = in.scalar_type();
-  ScalarType mask_type = mask.scalar_type();
   ScalarType val_type = utils::get_scalar_dtype(value);
 
-  ET_KERNEL_CHECK(ctx, mask_type == ScalarType::Bool, InvalidArgument, out);
-
+  // TODO(gjcomer) Refactor with remaining resize_to_broadcast_ users.
   resize_to_broadcast_target_size(in, mask, out);
 
   ET_SWITCH_REAL_TYPES_AND(

--- a/kernels/portable/cpu/op_masked_fill.cpp
+++ b/kernels/portable/cpu/op_masked_fill.cpp
@@ -33,8 +33,11 @@ Tensor& masked_fill_scalar_out(
   ScalarType in_type = in.scalar_type();
   ScalarType val_type = utils::get_scalar_dtype(value);
 
-  // TODO(gjcomer) Refactor with remaining resize_to_broadcast_ users.
-  resize_to_broadcast_target_size(in, mask, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(in, mask, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ET_SWITCH_REAL_TYPES_AND(
       Bool, in_type, ctx, "masked_fill.Scalar_out", CTYPE, [&]() {

--- a/kernels/portable/cpu/op_minimum.cpp
+++ b/kernels/portable/cpu/op_minimum.cpp
@@ -27,9 +27,11 @@ Tensor& minimum_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_minimum.cpp
+++ b/kernels/portable/cpu/op_minimum.cpp
@@ -27,6 +27,8 @@ Tensor& minimum_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
+  (void)ctx;
+
   ET_KERNEL_CHECK(
       ctx,
       resize_to_broadcast_target_size(a, b, out) == Error::Ok,
@@ -38,7 +40,7 @@ Tensor& minimum_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "minimum.out", CTYPE_A, [&]() {
     ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "minimum.out", CTYPE_B, [&]() {

--- a/kernels/portable/cpu/op_mul.cpp
+++ b/kernels/portable/cpu/op_mul.cpp
@@ -64,15 +64,19 @@ Tensor& mul_scalar_out(
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(common_type == out_type);
+  ET_KERNEL_CHECK(ctx, common_type == out_type, InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "mul.Scalar_out", CTYPE_A, [&]() {
     ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "mul.Scalar_out", CTYPE_B, [&]() {

--- a/kernels/portable/cpu/op_mul.cpp
+++ b/kernels/portable/cpu/op_mul.cpp
@@ -29,7 +29,7 @@ mul_out(RuntimeContext& ctx, const Tensor& a, const Tensor& b, Tensor& out) {
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "mul.out", CTYPE_A, [&]() {
     ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "mul.out", CTYPE_B, [&]() {

--- a/kernels/portable/cpu/op_mul.cpp
+++ b/kernels/portable/cpu/op_mul.cpp
@@ -18,9 +18,11 @@ namespace native {
 
 Tensor&
 mul_out(RuntimeContext& ctx, const Tensor& a, const Tensor& b, Tensor& out) {
-  (void)ctx;
-
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_ne.cpp
+++ b/kernels/portable/cpu/op_ne.cpp
@@ -24,10 +24,11 @@ Tensor& ne_tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
-  // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_ne.cpp
+++ b/kernels/portable/cpu/op_ne.cpp
@@ -66,10 +66,13 @@ Tensor& ne_scalar_out(
     const Scalar& b,
     Tensor& out) {
   (void)ctx;
-
   // Resize for dynamic shape
-  auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);

--- a/kernels/portable/cpu/op_neg.cpp
+++ b/kernels/portable/cpu/op_neg.cpp
@@ -20,9 +20,15 @@ Tensor& neg_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
-  ET_CHECK_SAME_SHAPE_AND_DTYPE2(in, out);
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_shape_and_dtype(in, out), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "neg.out", CTYPE, [&] {
     apply_unary_map_fn(

--- a/kernels/portable/cpu/op_pow.cpp
+++ b/kernels/portable/cpu/op_pow.cpp
@@ -36,7 +36,7 @@ Tensor& pow_Tensor_Tensor_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(
       Bool, a_type, ctx, "pow.Tensor_Tensor_out", CTYPE_A, [&]() {

--- a/kernels/portable/cpu/op_pow.cpp
+++ b/kernels/portable/cpu/op_pow.cpp
@@ -24,10 +24,12 @@ Tensor& pow_Tensor_Tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
   // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_pow.cpp
+++ b/kernels/portable/cpu/op_pow.cpp
@@ -81,15 +81,20 @@ Tensor& pow_Tensor_Scalar_out(
     Tensor& out) {
   (void)ctx;
 
-  // Determine output size and resize for dynamic shapes
-  ET_CHECK(resize_tensor(out, a.sizes()) == Error::Ok);
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(common_type == out_type);
+  ET_KERNEL_CHECK(ctx, common_type == out_type, InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(
       Bool, a_type, ctx, "pow.Tensor_Scalar_out", CTYPE_A, [&]() {
@@ -133,15 +138,20 @@ Tensor& pow_Scalar_out(
     Tensor& out) {
   (void)ctx;
 
-  // Determine output size and resize for dynamic shapes
-  ET_CHECK(resize_tensor(out, b.sizes()) == Error::Ok);
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, b.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = utils::get_scalar_dtype(a);
   ScalarType b_type = b.scalar_type();
   ScalarType common_type = utils::promote_type_with_scalar(b_type, a);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(common_type == out_type);
+  ET_KERNEL_CHECK(ctx, common_type == out_type, InvalidArgument, out);
 
   ET_SWITCH_SCALAR_OBJ_TYPES(a_type, ctx, "pow.Scalar_out", CTYPE_A, [&]() {
     ET_SWITCH_REAL_TYPES_AND(

--- a/kernels/portable/cpu/op_relu.cpp
+++ b/kernels/portable/cpu/op_relu.cpp
@@ -22,10 +22,16 @@ using ScalarType = exec_aten::ScalarType;
 Tensor& relu_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   (void)ctx;
 
-  Error err = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(err == Error::Ok, "Could not resize output");
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
-  ET_CHECK_SAME_SHAPE_AND_DTYPE2(in, out);
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_shape_and_dtype(in, out), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "relu.out", CTYPE, [&]() {
     apply_unary_map_fn(

--- a/kernels/portable/cpu/op_remainder.cpp
+++ b/kernels/portable/cpu/op_remainder.cpp
@@ -61,7 +61,7 @@ Tensor& remainder_Tensor_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(
       Bool, a_type, ctx, "remainder.Tensor_out", CTYPE_A, [&]() {

--- a/kernels/portable/cpu/op_remainder.cpp
+++ b/kernels/portable/cpu/op_remainder.cpp
@@ -107,15 +107,20 @@ Tensor& remainder_Scalar_out(
     Tensor& out) {
   (void)ctx;
 
-  // Determine output size and resize for dynamic shapes
-  ET_CHECK(resize_tensor(out, a.sizes()) == Error::Ok);
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES_AND(
       Bool, a_type, ctx, "remainder.Scalar_out", CTYPE_A, [&]() {

--- a/kernels/portable/cpu/op_remainder.cpp
+++ b/kernels/portable/cpu/op_remainder.cpp
@@ -50,7 +50,11 @@ Tensor& remainder_Tensor_out(
   (void)ctx;
 
   // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_repeat.cpp
+++ b/kernels/portable/cpu/op_repeat.cpp
@@ -51,9 +51,15 @@ Tensor& repeat_out(
   (void)ctx;
   Tensor::SizesType expected_output_size[kTensorDimensionLimit];
   calculate_output_size(self.sizes(), repeats, expected_output_size);
-  auto error = resize_tensor(out, {expected_output_size, repeats.size()});
-  // TODO: Construct error message with requested output sizes.
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, {expected_output_size, repeats.size()}) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
   return repeat_tensor(self, repeats, out);
 }
 

--- a/kernels/portable/cpu/op_repeat.cpp
+++ b/kernels/portable/cpu/op_repeat.cpp
@@ -21,8 +21,11 @@ void calculate_output_size(
     const exec_aten::ArrayRef<exec_aten::SizesType>& self_sizes,
     const exec_aten::ArrayRef<int64_t>& repeats,
     Tensor::SizesType* out_sizes_ptr) {
-  ET_CHECK_MSG(
+  ET_KERNEL_CHECK_MSG(
+      ctx,
       repeats.size() >= self_sizes.size(),
+      InvalidArgument,
+      ,
       "Repeats vector size is %zu must be >= self_sizes %zu.",
       repeats.size(),
       self_sizes.size());

--- a/kernels/portable/cpu/op_round.cpp
+++ b/kernels/portable/cpu/op_round.cpp
@@ -34,9 +34,15 @@ Tensor& round_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
-  ET_CHECK_SAME_SHAPE_AND_DTYPE2(in, out);
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_shape_and_dtype(in, out), InvalidArgument, out);
 
   auto in_scalar_type = in.scalar_type();
 

--- a/kernels/portable/cpu/op_rsub.cpp
+++ b/kernels/portable/cpu/op_rsub.cpp
@@ -23,15 +23,19 @@ Tensor& rsub_scalar_out(
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(common_type == out_type);
+  ET_KERNEL_CHECK(ctx, common_type == out_type, InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES(a_type, ctx, "rsub.Scalar_out", CTYPE_A, [&]() {
     ET_SWITCH_SCALAR_OBJ_REAL_TYPES(

--- a/kernels/portable/cpu/op_select_scatter.cpp
+++ b/kernels/portable/cpu/op_select_scatter.cpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include <executorch/kernels/portable/cpu/util/index_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
@@ -17,78 +18,6 @@ namespace executor {
 namespace native {
 
 using Tensor = exec_aten::Tensor;
-
-namespace {
-
-/**
- * Assumptions for inputs:
- * 1. output size is the same as input size
- * 2. src size is the same as the selected slice from the input
- * 3. dim and index values are valid given the input tensor
- */
-void check_select_scatter_args(
-    const Tensor& in,
-    const Tensor& src,
-    int64_t dim,
-    int64_t index,
-    Tensor& output) {
-  // Support python-style negative indexing. E.g., for the shape {2, 3, 4},
-  // dim = -1 would refer to dim[2], dim = -2 would refer to dim[1], and so on.
-
-  // The dim planed to be selected on shall exist in input
-  ET_CHECK_MSG(
-      dim >= 0 && dim < in.dim(),
-      "dim %" PRId64 " out of range [-%zd,%zd)",
-      dim,
-      in.dim(),
-      in.dim());
-
-  // The index shall be valid in the given dimenson
-  ET_CHECK_MSG(
-      index >= 0 && index < in.size(dim),
-      "index %" PRId64 " out of range [-%zd,%zd) at in.size( %" PRId64 ")",
-      index,
-      in.size(dim),
-      in.size(dim),
-      dim);
-
-  // The src.dim() shall be one lower than in.dim() since src needs to fit
-  // into the selected data on one dim of input
-  // https://pytorch.org/docs/stable/generated/torch.select_scatter.html
-  ET_CHECK_MSG(
-      in.dim() == src.dim() + 1,
-      "in.dim() %zd != src.dim() + 1 %zd",
-      in.dim(),
-      src.dim() + 1);
-
-  // The size of src tensor should follow these rules:
-  // - src.size(i) shall equal to in.size(i) if i < dim,
-  // - src.size(i) shall equal to in.size(i+1) if i >= dim
-
-  for (ssize_t d = 0; d < in.dim() - 1; d++) {
-    if (d < dim) {
-      ET_CHECK_MSG(
-          in.size(d) == src.size(d),
-          "in.size(%zu) %zd != src.size(%zu) %zd | dim = %" PRId64 ")",
-          d,
-          in.size(d),
-          d,
-          src.size(d),
-          dim);
-    } else {
-      ET_CHECK_MSG(
-          in.size(d + 1) == src.size(d),
-          "in.size(%zu) %zd != src.size(%zu) %zd | dim = %" PRId64 ")",
-          d + 1,
-          in.size(d + 1),
-          d,
-          src.size(d),
-          dim);
-    }
-  }
-}
-
-} // namespace
 
 /// aten::select_scatter.out(Tensor self, Tensor src, int dim, SymInt index, *,
 /// Tensor(a!) out) -> Tensor(a!)
@@ -101,7 +30,6 @@ Tensor& select_scatter_out(
     Tensor& out) {
   (void)ctx;
 
-  ET_KERNEL_CHECK(ctx, tensors_have_same_dtype(in, out), InvalidArgument, out);
   ET_KERNEL_CHECK(
       ctx, resize_tensor(out, in.sizes()) == Error::Ok, InvalidArgument, out);
 
@@ -114,7 +42,11 @@ Tensor& select_scatter_out(
   }
 
   // Check args
-  check_select_scatter_args(in, src, dim, index, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      check_select_scatter_args(in, src, dim, index, out),
+      InvalidArgument,
+      out);
 
   // If the input is an empty tensor, no other operation could be done. We just
   // return the output.

--- a/kernels/portable/cpu/op_sigmoid.cpp
+++ b/kernels/portable/cpu/op_sigmoid.cpp
@@ -20,8 +20,13 @@ using Tensor = exec_aten::Tensor;
 Tensor& sigmoid_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   (void)ctx;
 
-  Error err = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(err == Error::Ok, "Could not resize output");
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType in_type = in.scalar_type();
   ScalarType out_type = out.scalar_type();

--- a/kernels/portable/cpu/op_sign.cpp
+++ b/kernels/portable/cpu/op_sign.cpp
@@ -23,9 +23,15 @@ Tensor& sign_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
-  ET_CHECK_SAME_SHAPE_AND_DTYPE2(in, out);
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_shape_and_dtype(in, out), InvalidArgument, out);
 
   if (in.scalar_type() == exec_aten::ScalarType::Bool) {
     memcpy(out.mutable_data_ptr(), in.const_data_ptr(), in.nbytes());

--- a/kernels/portable/cpu/op_slice_copy.cpp
+++ b/kernels/portable/cpu/op_slice_copy.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
+#include <executorch/kernels/portable/cpu/util/index_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 #include <cstring>
 
@@ -15,44 +16,6 @@ namespace executor {
 namespace native {
 
 using Tensor = exec_aten::Tensor;
-
-namespace {
-
-int64_t adjust_slice_indices(
-    int64_t dim_length,
-    int64_t* start,
-    int64_t* end,
-    int64_t step) {
-  int64_t num_values = 0;
-
-  // Update start and end index
-  // First convert it to c++ style from python style if needed.
-  // The start index is using python style E.g., for the shape {2, 3, 4},
-  // dim = -1 would refer to dim[2], dim = -2 would refer to dim[1], and so on.
-  *start = *start < 0 ? *start + dim_length : *start;
-  *end = *end < 0 ? *end + dim_length : *end;
-  // Second, if start or end still negative, which means user want to start or
-  // end slicing from very beginning, so set it to zero
-  *start = *start < 0 ? 0 : *start;
-  *end = *end < 0 ? 0 : *end;
-  // Last, if start or end larger than maximum value (dim_length - 1), indicates
-  // user want to start slicing after end or slicing until the end, so update it
-  // to dim_length
-  *start = *start > dim_length ? dim_length : *start;
-  *end = *end > dim_length ? dim_length : *end;
-
-  if (*start >= dim_length || *end <= 0 || *start >= *end) {
-    // Set num_values to 0 if interval [start, end) is non-exist or do not
-    // overlap with [0, dim_length)
-    num_values = 0;
-  } else {
-    // Update num_values to min(max_num_values, num_values)
-    num_values = (*end - 1 - *start) / step + 1;
-  }
-  return num_values;
-}
-
-} // namespace
 
 Tensor& slice_copy_Tensor_out(
     RuntimeContext& ctx,

--- a/kernels/portable/cpu/op_slice_scatter.cpp
+++ b/kernels/portable/cpu/op_slice_scatter.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include <executorch/kernels/portable/cpu/util/index_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
@@ -16,115 +17,6 @@ namespace executor {
 namespace native {
 
 using Tensor = exec_aten::Tensor;
-
-namespace {
-
-// TODO(gasoonjia): Move this to a common spot so all implementation of
-// this operator can share it. (e.g., DSP-specific)
-/// Asserts that the parameters are valid.
-void check_input_args(
-    const Tensor& input,
-    const Tensor& src,
-    int64_t dim,
-    int64_t num_values,
-    int64_t step,
-    Tensor output) {
-  // Check dim. The dim planed to be selected on shall exist in input
-  ET_CHECK_MSG(
-      dim >= 0 && dim < input.dim(),
-      "dim %" PRId64 " out of range [0,%zd)",
-      dim,
-      input.dim());
-
-  // Input and output tensors should be the same shape
-  ET_CHECK_SAME_SHAPE2(input, output);
-
-  // Input and output tensors should have the same shape
-  ET_CHECK_SAME_DTYPE2(input, output);
-
-  // The input.dim() shall equal to src.dim()
-  ET_CHECK_MSG(
-      input.dim() == src.dim(),
-      "input.dim() %zd != src.dim() %zd",
-      input.dim(),
-      src.dim());
-
-  // Check step. Step must be greater than zero
-  ET_CHECK_MSG(step > 0, "slice step must be greater than zero");
-
-  // The size of src tensor should follow these rules:
-  // - src.size(i) shall equal to input.size(i) if i != dim,
-  // - src.size(dim) shall equal to num_values
-  for (size_t d = 0; d < input.dim() - 1; d++) {
-    if (d != dim) {
-      ET_CHECK_MSG(
-          input.size(d) == src.size(d),
-          "input.size(%zu) %zd != src.size(%zu) %zd | dim = %" PRId64 ")",
-          d,
-          input.size(d),
-          d,
-          src.size(d),
-          dim);
-    } else {
-      ET_CHECK_MSG(
-          src.size(d) == num_values,
-          "input.size(%zu) %zd != num_values %" PRId64 " | dim = %" PRId64 ")",
-          d,
-          input.size(d),
-          num_values,
-          dim);
-    }
-  }
-}
-
-// Output tensor should be the same size as the input tensor
-Error resize_like_input(const Tensor& input, Tensor& out) {
-  Tensor::SizesType expected_output_size[kTensorDimensionLimit];
-  for (size_t i = 0; i < input.dim(); ++i) {
-    expected_output_size[i] = input.size(i);
-  }
-  ArrayRef<Tensor::SizesType> output_size{
-      expected_output_size, static_cast<size_t>(input.dim())};
-  auto error = resize_tensor(out, output_size);
-
-  return error;
-}
-
-int64_t adjust_slice_indices(
-    int64_t dim_length,
-    int64_t* start,
-    int64_t* end,
-    int64_t step) {
-  int64_t num_values = 0;
-
-  // Update start and end index
-  // First convert it to c++ style from python style if needed.
-  // The start index is using python style E.g., for the shape {2, 3, 4},
-  // dim = -1 would refer to dim[2], dim = -2 would refer to dim[1], and so on.
-  *start = *start < 0 ? *start + dim_length : *start;
-  *end = *end < 0 ? *end + dim_length : *end;
-  // Second, if start or end still negative, which means user want to start or
-  // end slicing from very beginning, so set it to zero
-  *start = *start < 0 ? 0 : *start;
-  *end = *end < 0 ? 0 : *end;
-  // Last, if start or end larger than maximum value (dim_length - 1), indicates
-  // user want to start slicing after end or slicing until the end, so update it
-  // to dim_length
-  *start = *start > dim_length ? dim_length : *start;
-  *end = *end > dim_length ? dim_length : *end;
-
-  if (*start >= dim_length || *end <= 0 || *start >= *end) {
-    // Set num_values to 0 if interval [start, end) is non-exist or do not
-    // overlap with [0, dim_length)
-    num_values = 0;
-  } else {
-    // Update num_values to min(max_num_values, num_values)
-    num_values = (*end - 1 - *start) / step + 1;
-  }
-  return num_values;
-}
-
-} // namespace
 
 Tensor& slice_scatter_out(
     RuntimeContext& ctx,
@@ -142,8 +34,11 @@ Tensor& slice_scatter_out(
   }
 
   // resize out tensor for dynamic shapes
-  auto error = resize_like_input(input, out);
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, input.sizes()) == Error::Ok,
+      InvalidArgument,
+      out);
 
   if (input.numel() == 0) {
     return out;
@@ -159,7 +54,11 @@ Tensor& slice_scatter_out(
   int64_t num_values =
       adjust_slice_indices(input.size(dim), &start, &end, step);
 
-  check_input_args(input, src, dim, num_values, step, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      check_slice_scatter_args(input, src, dim, num_values, step, out),
+      InvalidArgument,
+      out);
 
   size_t dim_length = input.size(dim);
   size_t leading_dims = getLeadingDims(input, dim);

--- a/kernels/portable/cpu/op_softmax.cpp
+++ b/kernels/portable/cpu/op_softmax.cpp
@@ -27,7 +27,11 @@ Tensor& softmax_out(
     Tensor& out) {
   (void)ctx;
 
-  check_softmax_args(in, dim, half_to_float, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      check_softmax_args(in, dim, half_to_float, out),
+      InvalidArgument,
+      out);
 
   ET_KERNEL_CHECK(
       ctx, resize_tensor(out, in.sizes()) == Error::Ok, InvalidArgument, out);

--- a/kernels/portable/cpu/op_split_copy.cpp
+++ b/kernels/portable/cpu/op_split_copy.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
@@ -17,133 +18,6 @@ namespace native {
 
 using Tensor = exec_aten::Tensor;
 using TensorList = exec_aten::TensorList;
-
-namespace {
-void check_args(
-    const Tensor& input,
-    int64_t split_size,
-    int64_t dim,
-    TensorList out) {
-  ET_CHECK_MSG(
-      input.dim() > 0,
-      "input must have at least one dimension; saw %zd",
-      input.dim());
-  ET_CHECK_MSG(
-      dim >= 0 && dim < input.dim(),
-      "dim %" PRId64 " out of range [0,%zd)",
-      dim,
-      input.dim());
-
-  const ssize_t dim_size = input.size(dim);
-  ET_CHECK_MSG(
-      split_size >= 0,
-      "split_size %" PRId64 " must be non-negative",
-      split_size);
-  ET_CHECK_MSG(
-      split_size > 0 || dim_size == 0,
-      "split_size is zero but input.size(%" PRId64 ") %zd is non-zero",
-      dim,
-      dim_size);
-
-  // Check the number of outputs.
-  //
-  // The specified dimension will be split into split_size-sized chunks, with
-  // the final chunk possibly being smaller. So, the expected output length is
-  // ceil(dim_size / split_size).
-  //
-  // E.g., splitting dim 0 of a [5,2] tensor with split_size 2 would produce
-  // three tensors with size [2,2], [2,2], [1,2].
-  int64_t remainder; // The size of the split dimension of the final out tensor.
-  if (split_size >= dim_size) {
-    // Note that this also handles the case where split_size == 0, avoiding a
-    // division by zero in the other branch. When dim_size == 0 && split_size ==
-    // 0, core PyTorch expects 1 output element.
-    ET_CHECK_MSG(
-        out.size() == 1,
-        "Unexpected out.size() %zu: should be 1 because split_size %" PRId64
-        " >= input.size(%" PRId64 ") %zd",
-        out.size(),
-        split_size,
-        dim,
-        dim_size);
-    remainder = dim_size;
-  } else {
-    int64_t expected_out_len = (dim_size + split_size - 1) / split_size;
-    ET_CHECK_MSG(
-        out.size() == expected_out_len,
-        "Unexpected out.size() %zu: ceil(input.size(%" PRId64
-        ")=%zd"
-        " / split_size=%" PRId64 ") is %" PRId64,
-        out.size(),
-        dim,
-        dim_size,
-        split_size,
-        expected_out_len);
-    remainder = dim_size % split_size;
-    if (remainder == 0) {
-      remainder = split_size;
-    }
-  }
-
-  // Validate each output.
-  for (size_t i = 0; i < out.size(); ++i) {
-    // All output dtypes must be the same.
-    ET_CHECK_MSG(
-        out[i].scalar_type() == out[0].scalar_type(),
-        "out[%zu] dtype %" PRId8 " != out[0] dtype %" PRId8,
-        i,
-        static_cast<int8_t>(out[i].scalar_type()),
-        static_cast<int8_t>(out[0].scalar_type()));
-
-    // All outputs must have the same number of dimensions as the input.
-    ET_CHECK_MSG(
-        out[i].dim() == input.dim(),
-        "out[%zu] dim %zd != input dim %zd",
-        i,
-        out[i].dim(),
-        input.dim());
-
-    // Check the shape of the output.
-    for (ssize_t d = 0; d < out[i].dim(); ++d) {
-      if (d == dim) {
-        // This is the split dimension, which may be different.
-        if (i < out.size() - 1) {
-          // All outputs except the final one: split dimension should be
-          // split_size.
-          ET_CHECK_MSG(
-              out[i].size(d) == split_size,
-              "out[%zu].size(%zd) %zd != split_size %" PRId64,
-              i,
-              d,
-              out[i].size(d),
-              split_size);
-        } else {
-          // The final output: split dimension should be the remainder of
-          // split_size.
-          ET_CHECK_MSG(
-              out[i].size(d) == remainder,
-              "out[%zu].size(%zd) %zd != remainder %" PRId64,
-              i,
-              d,
-              out[i].size(d),
-              remainder);
-        }
-      } else {
-        // Non-split output dimensions must be the same as the input dimension.
-        ET_CHECK_MSG(
-            out[i].size(d) == input.size(d),
-            "out[%zu].size(%zd) %zd != input.size(%zd) %zd",
-            i,
-            d,
-            out[i].size(d),
-            d,
-            input.size(d));
-      }
-    }
-  }
-}
-
-} // namespace
 
 /**
  * Splits the tensor into chunks of size `split_size` along the specified
@@ -166,7 +40,12 @@ void split_copy_Tensor_out(
   if (dim < 0) {
     dim += input.dim();
   }
-  check_args(input, split_size, dim, out);
+
+  ET_KERNEL_CHECK(
+      ctx,
+      check_split_copy_args(input, split_size, dim, out),
+      InvalidArgument,
+      out);
 
   const size_t leading_dims = getLeadingDims(input, dim);
   const size_t trailing_dims = getTrailingDims(input, dim);

--- a/kernels/portable/cpu/op_sub.cpp
+++ b/kernels/portable/cpu/op_sub.cpp
@@ -33,7 +33,7 @@ Tensor& sub_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(canCast(common_type, out_type));
+  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES(a_type, ctx, "sub.out", CTYPE_A, [&]() {
     ET_SWITCH_REAL_TYPES(b_type, ctx, "sub.out", CTYPE_B, [&]() {
@@ -70,15 +70,19 @@ Tensor& sub_scalar_out(
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, a.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(common_type == out_type);
+  ET_KERNEL_CHECK(ctx, common_type == out_type, InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES(a_type, ctx, "sub.Scalar_out", CTYPE_A, [&]() {
     ET_SWITCH_SCALAR_OBJ_REAL_TYPES(

--- a/kernels/portable/cpu/op_sub.cpp
+++ b/kernels/portable/cpu/op_sub.cpp
@@ -22,9 +22,11 @@ Tensor& sub_out(
     const Tensor& b,
     const Scalar& alpha,
     Tensor& out) {
-  (void)ctx;
-
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_to_copy.cpp
+++ b/kernels/portable/cpu/op_to_copy.cpp
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
@@ -32,51 +34,25 @@ Tensor& to_copy_out(
     bool non_blocking,
     exec_aten::optional<exec_aten::MemoryFormat> memory_format,
     Tensor& out) {
-  // Right now we only support blocking data transfer
-  ET_CHECK(non_blocking == false);
+  ET_KERNEL_CHECK(
+      ctx,
+      check_to_copy_args(self, non_blocking, memory_format, out),
+      InvalidArgument,
+      out);
 
-  // Right now we only focus on contiguous memory, memory_format shall be
-  // exec::aten::MemoryFormat::Contiguous or none.
-  ET_CHECK(
-      !memory_format.has_value() ||
-      memory_format.value() == MemoryFormat::Contiguous);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, self.sizes()) == torch::executor::Error::Ok,
+      InvalidArgument,
+      out);
 
-  torch::executor::Error err = resize_tensor(out, self.sizes());
-  ET_CHECK_MSG(
-      err == torch::executor::Error::Ok,
-      "Failed to resize out Tensor in to_copy_out");
-
-  // self and out should be in same size.
-  ET_CHECK_SAME_SHAPE2(self, out);
-// Use a two layer switch to hanldle each possible data pairs
-#define TO_IMPL(SELF_CTYPE, OUT_CTYPE, out_dtype) \
-  case ScalarType::out_dtype:                     \
-    _to_impl<SELF_CTYPE, OUT_CTYPE>(self, out);   \
-    break;
-
-#define CASE_TENSOR_DTYPE(SELF_CTYPE, self_dtype)              \
-  case ScalarType::self_dtype:                                 \
-    switch (out.scalar_type()) {                               \
-      ET_FORALL_REAL_TYPES_AND_WITH(Bool, SELF_CTYPE, TO_IMPL) \
-      default:                                                 \
-        ET_CHECK_MSG(                                          \
-            false,                                             \
-            "Unhandled output dtype %" PRId8,                  \
-            static_cast<int8_t>(out.scalar_type()));           \
-    }                                                          \
-    break;
-
-  switch (self.scalar_type()) {
-    ET_FORALL_REAL_TYPES_AND(Bool, CASE_TENSOR_DTYPE);
-    default:
-      ET_CHECK_MSG(
-          false,
-          "Unhandled input dtype %" PRId8,
-          static_cast<int8_t>(self.scalar_type()));
-  }
-
-#undef CASE_TENSOR_DTYPE
-#undef TO_IMPL
+  ET_SWITCH_REAL_TYPES_AND(
+      Bool, self.scalar_type(), ctx, "to_copy", CTYPE_IN, [&] {
+        ET_SWITCH_REAL_TYPES_AND(
+            Bool, out.scalar_type(), ctx, "to_copy", CTYPE_OUT, [&] {
+              _to_impl<CTYPE_IN, CTYPE_OUT>(self, out);
+            });
+      });
 
   return out;
 }

--- a/kernels/portable/cpu/op_view_copy.cpp
+++ b/kernels/portable/cpu/op_view_copy.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
@@ -17,24 +18,6 @@ namespace native {
 
 using Tensor = exec_aten::Tensor;
 
-namespace {
-void size_compare(
-    exec_aten::ArrayRef<int64_t> size_int64_t,
-    exec_aten::ArrayRef<int32_t> size_int32_t) {
-  bool size_inferred = false;
-  for (int i = 0; i < size_int64_t.size(); i++) {
-    // If this value is -1 it implies that this dimension is inferred.
-    if (size_int64_t[i] == -1) {
-      ET_CHECK_MSG(!size_inferred, "Multiple dimensions cannot be inferred.");
-      size_inferred = true;
-    }
-    ET_CHECK(
-        ((int64_t)size_int32_t[i] == size_int64_t[i]) ||
-        (size_int64_t[i] == -1));
-  }
-}
-} // namespace
-
 // view_copy.out(Tensor self, int[] size, *, Tensor(a!) out) -> Tensor(a!)
 Tensor& view_copy_out(
     RuntimeContext& ctx,
@@ -42,34 +25,27 @@ Tensor& view_copy_out(
     exec_aten::ArrayRef<int64_t> size_int64_t,
     Tensor& out) {
   (void)ctx;
-  ET_CHECK(size_int64_t.size() == out.sizes().size());
-  Tensor::SizesType expected_output_size[16];
-  size_t out_numels_without_minus_1 = 1;
-  int32_t minus_1_dim = -1;
-  for (size_t i = 0; i < out.dim(); ++i) {
-    if (size_int64_t[i] != -1) {
-      expected_output_size[i] = static_cast<Tensor::SizesType>(size_int64_t[i]);
-      out_numels_without_minus_1 = out_numels_without_minus_1 * size_int64_t[i];
-    } else {
-      // TODO(kimishpatel): Add test to hit this line
-      ET_CHECK_MSG(minus_1_dim == -1, "At most one view copy dim can be -1.");
-      minus_1_dim = i;
-    }
-  }
-  if (minus_1_dim >= 0) {
-    expected_output_size[minus_1_dim] =
-        self.numel() / out_numels_without_minus_1;
-  }
-  auto error = resize_tensor(
-      out, {expected_output_size, static_cast<size_t>(out.dim())});
-  // TODO: Construct error message with requested output sizes.
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
-  // The input and out shall share same dtype and numel
-  ET_CHECK(self.numel() == out.numel());
-  ET_CHECK_SAME_DTYPE2(self, out);
 
-  // The size of out should equal target size.
-  size_compare(size_int64_t, out.sizes());
+  Tensor::SizesType expected_output_size[16];
+  ET_KERNEL_CHECK(
+      ctx,
+      get_view_copy_target_size(
+          self, size_int64_t, out.dim(), expected_output_size),
+      InvalidArgument,
+      out);
+
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(
+          out, {expected_output_size, static_cast<size_t>(out.dim())}) ==
+          Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(
+      ctx, check_view_copy_args(self, size_int64_t, out), InvalidArgument, out);
 
   if (self.nbytes() > 0) {
     memcpy(out.mutable_data_ptr(), self.const_data_ptr(), self.nbytes());

--- a/kernels/portable/cpu/op_where.cpp
+++ b/kernels/portable/cpu/op_where.cpp
@@ -20,8 +20,6 @@ Tensor& where_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
   ScalarType cond_type = cond.scalar_type();
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();
@@ -31,7 +29,11 @@ Tensor& where_out(
   ET_CHECK(common_type == out_type);
 
   // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, cond, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, cond, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ET_SWITCH_TWO_TYPES(
       Bool, Byte, cond_type, ctx, "where.self_out", CTYPE_COND, [&]() {

--- a/kernels/portable/cpu/op_where.cpp
+++ b/kernels/portable/cpu/op_where.cpp
@@ -26,7 +26,7 @@ Tensor& where_out(
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
-  ET_CHECK(common_type == out_type);
+  ET_KERNEL_CHECK(ctx, common_type == out_type, InvalidArgument, out);
 
   // Determine output size and resize for dynamic shapes
   ET_KERNEL_CHECK(

--- a/kernels/portable/cpu/pattern/binary_ufunc_realb_realb_to_realb_logical.cpp
+++ b/kernels/portable/cpu/pattern/binary_ufunc_realb_realb_to_realb_logical.cpp
@@ -22,10 +22,11 @@ Tensor& binary_ufunc_realb_realb_to_realb_logical(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  (void)ctx;
-
-  // Determine output size and resize for dynamic shapes
-  resize_to_broadcast_target_size(a, b, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/pattern/unary_ufunc_real.cpp
+++ b/kernels/portable/cpu/pattern/unary_ufunc_real.cpp
@@ -24,9 +24,15 @@ Tensor& unary_ufunc_real(
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
-  ET_CHECK_SAME_SHAPE_AND_DTYPE2(in, out);
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_shape_and_dtype(in, out), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, __func__, CTYPE, [&] {
     apply_unary_map_fn(

--- a/kernels/portable/cpu/pattern/unary_ufunc_realb_to_bool.cpp
+++ b/kernels/portable/cpu/pattern/unary_ufunc_realb_to_bool.cpp
@@ -24,11 +24,18 @@ Tensor& unary_ufunc_realb_to_bool(
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
-  ET_CHECK_MSG(
+  ET_KERNEL_CHECK_MSG(
+      ctx,
       out.scalar_type() == exec_aten::ScalarType::Bool,
+      InvalidArgument,
+      out,
       "Expected out tensor to have dtype Bool, but got %" PRId8 " instead.",
       static_cast<int8_t>(out.scalar_type()));
 

--- a/kernels/portable/cpu/pattern/unary_ufunc_realb_to_float.cpp
+++ b/kernels/portable/cpu/pattern/unary_ufunc_realb_to_float.cpp
@@ -24,8 +24,12 @@ Tensor& unary_ufunc_realb_to_float(
   (void)ctx;
 
   // Resize for dynamic shape
-  auto error = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   const auto in_type = in.scalar_type();
   const auto out_type = out.scalar_type();

--- a/kernels/portable/cpu/targets.bzl
+++ b/kernels/portable/cpu/targets.bzl
@@ -262,6 +262,9 @@ _ATEN_OPS = (
     ),
     op_target(
         name = "op_embedding",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
+        ],
     ),
     op_target(
         name = "op_eq",
@@ -823,6 +826,9 @@ _ATEN_OPS = (
     ),
     op_target(
         name = "op_view_copy",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        ],
     ),
     op_target(
         name = "op_where",

--- a/kernels/portable/cpu/targets.bzl
+++ b/kernels/portable/cpu/targets.bzl
@@ -577,6 +577,8 @@ _ATEN_OPS = (
         name = "op_nonzero",
         deps = [
             ":scalar_utils",
+            "//executorch/kernels/portable/cpu/util:index_util",
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
         ],
     ),
     op_target(
@@ -663,8 +665,10 @@ _ATEN_OPS = (
     op_target(
         name = "op_select_scatter",
         deps = [
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
             "//executorch/runtime/core/exec_aten/util:scalar_type_util",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
+            "//executorch/kernels/portable/cpu/util:index_util",
         ],
     ),
     op_target(
@@ -695,10 +699,15 @@ _ATEN_OPS = (
         name = "op_slice_copy",
         deps = [
             "//executorch/kernels/portable/cpu/util:copy_ops_util",
+            "//executorch/kernels/portable/cpu/util:index_util",
         ],
     ),
     op_target(
         name = "op_slice_scatter",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:index_util",
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
+        ],
     ),
     op_target(
         name = "op_softmax",

--- a/kernels/portable/cpu/targets.bzl
+++ b/kernels/portable/cpu/targets.bzl
@@ -205,7 +205,10 @@ _ATEN_OPS = (
     ),
     op_target(
         name = "op_constant_pad_nd",
-        deps = [":scalar_utils"],
+        deps = [
+            ":scalar_utils",
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
+        ],
     ),
     op_target(
         name = "op_convolution",
@@ -488,6 +491,7 @@ _ATEN_OPS = (
         name = "op_masked_fill",
         deps = [
             "//executorch/kernels/portable/cpu/util:broadcast_util",
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
             ":scalar_utils",
         ],
     ),

--- a/kernels/portable/cpu/targets.bzl
+++ b/kernels/portable/cpu/targets.bzl
@@ -711,6 +711,9 @@ _ATEN_OPS = (
     ),
     op_target(
         name = "op_split_copy",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        ],
     ),
     op_target(
         name = "op_split_with_sizes_copy",
@@ -771,6 +774,9 @@ _ATEN_OPS = (
     ),
     op_target(
         name = "op_to_copy",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        ],
     ),
     op_target(
         name = "op_transpose_copy",
@@ -784,9 +790,15 @@ _ATEN_OPS = (
     ),
     op_target(
         name = "op_unbind_copy",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        ],
     ),
     op_target(
         name = "op_unsqueeze_copy",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        ],
     ),
     op_target(
         name = "op_var",

--- a/kernels/portable/cpu/targets.bzl
+++ b/kernels/portable/cpu/targets.bzl
@@ -74,6 +74,7 @@ _ATEN_OPS = (
     op_target(
         name = "op_arange",
         deps = [
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
             "//executorch/runtime/core/exec_aten/util:scalar_type_util",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
             ":scalar_utils",
@@ -239,6 +240,7 @@ _ATEN_OPS = (
         deps = [
             "//executorch/runtime/core/exec_aten/util:scalar_type_util",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
         ],
     ),
     op_target(
@@ -286,6 +288,7 @@ _ATEN_OPS = (
         deps = [
             "//executorch/runtime/core/exec_aten/util:scalar_type_util",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
             "//executorch/kernels/portable/cpu/util:repeat_util",
             ":scalar_utils",
         ],
@@ -354,6 +357,7 @@ _ATEN_OPS = (
     op_target(
         name = "op_glu",
         deps = [
+            "//executorch/kernels/portable/cpu/util:activation_ops_util",
             "//executorch/runtime/core/exec_aten/util:scalar_type_util",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
         ],

--- a/kernels/portable/cpu/util/activation_ops_util.cpp
+++ b/kernels/portable/cpu/util/activation_ops_util.cpp
@@ -23,6 +23,35 @@ bool check_gelu_args(const Tensor& in, string_view approximate, Tensor& out) {
   return true;
 }
 
+bool check_glu_args(const Tensor& in, int64_t dim, Tensor& out) {
+  ET_LOG_AND_RETURN_IF_FALSE(dim_is_valid(dim, in.dim()));
+
+  const size_t non_negative_dim = dim < 0 ? dim + in.dim() : dim;
+  const size_t dim_size = in.size(non_negative_dim);
+
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      dim_size % 2 == 0,
+      "Halving dimension must be even, but dimension %zd is size %zd",
+      non_negative_dim,
+      dim_size);
+
+  ET_LOG_AND_RETURN_IF_FALSE(tensor_is_floating_type(out));
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_rank(in, out));
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      out.size(non_negative_dim) == dim_size / 2,
+      "output tensor must have half the size of the input tensor along the specified dimension.");
+
+  for (size_t i = 0; i < in.dim(); ++i) {
+    if (i != non_negative_dim) {
+      ET_LOG_MSG_AND_RETURN_IF_FALSE(
+          out.size(i) == in.size(i),
+          "output tensor must have the same size as the input tensor in all dimensions except for the specified dimension.");
+    }
+  }
+
+  return true;
+}
+
 bool check_log_softmax_args(
     const Tensor& in,
     int64_t dim,
@@ -43,6 +72,21 @@ bool check_softmax_args(
     bool half_to_float,
     Tensor& out) {
   return check_log_softmax_args(in, dim, half_to_float, out);
+}
+
+Error resize_glu_out(const Tensor& in, int64_t dim, Tensor& out) {
+  exec_aten::SizesType expected_output_size[kTensorDimensionLimit];
+
+  const size_t non_negative_dim = dim < 0 ? dim + in.dim() : dim;
+  for (size_t i = 0; i < in.dim(); i++) {
+    expected_output_size[i] =
+        (i == non_negative_dim) ? (in.size(i) / 2) : in.size(i);
+  }
+
+  ArrayRef<exec_aten::SizesType> output_size{
+      expected_output_size, static_cast<size_t>(out.dim())};
+
+  return resize_tensor(out, output_size);
 }
 
 } // namespace executor

--- a/kernels/portable/cpu/util/activation_ops_util.h
+++ b/kernels/portable/cpu/util/activation_ops_util.h
@@ -15,6 +15,8 @@ namespace executor {
 
 bool check_gelu_args(const Tensor& in, string_view approximate, Tensor& out);
 
+bool check_glu_args(const Tensor& in, int64_t dim, Tensor& out);
+
 bool check_log_softmax_args(
     const Tensor& in,
     int64_t dim,
@@ -26,6 +28,8 @@ bool check_softmax_args(
     int64_t dim,
     bool half_to_float,
     Tensor& out);
+
+Error resize_glu_out(const Tensor& in, int64_t dim, Tensor& out);
 
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/broadcast_util.h
+++ b/kernels/portable/cpu/util/broadcast_util.h
@@ -130,15 +130,14 @@ void get_broadcast_target_size(
  * @param[in] b The second tensor going to be broadcasted.
  * @param[out] out The output tensor that will be resized.
  */
-inline void
+[[nodiscard]] inline Error
 resize_to_broadcast_target_size(const Tensor& a, const Tensor& b, Tensor& out) {
   Tensor::SizesType expected_output_size[kTensorDimensionLimit];
   size_t expected_output_dim = 0;
   get_broadcast_target_size(
       a, b, expected_output_size, kTensorDimensionLimit, &expected_output_dim);
 
-  Error err = resize_tensor(out, {expected_output_size, expected_output_dim});
-  ET_CHECK_MSG(err == Error::Ok, "Could not resize output");
+  return resize_tensor(out, {expected_output_size, expected_output_dim});
 }
 
 /**
@@ -150,7 +149,7 @@ resize_to_broadcast_target_size(const Tensor& a, const Tensor& b, Tensor& out) {
  * @param[in] c The third tensor going to be broadcasted.
  * @param[out] out The output tensor that will be resized.
  */
-inline void resize_to_broadcast_target_size(
+[[nodiscard]] inline Error resize_to_broadcast_target_size(
     const Tensor& a,
     const Tensor& b,
     const Tensor& c,
@@ -174,8 +173,7 @@ inline void resize_to_broadcast_target_size(
       kTensorDimensionLimit,
       &expected_output_dim);
 
-  Error err = resize_tensor(out, {expected_output_size, expected_output_dim});
-  ET_CHECK_MSG(err == Error::Ok, "Could not resize output");
+  return resize_tensor(out, {expected_output_size, expected_output_dim});
 }
 
 /**

--- a/kernels/portable/cpu/util/copy_ops_util.cpp
+++ b/kernels/portable/cpu/util/copy_ops_util.cpp
@@ -147,6 +147,32 @@ void get_cat_out_target_size(
   }
 }
 
+bool check_expand_copy_args(
+    const Tensor& input,
+    ArrayRef<int64_t> expand_sizes,
+    bool implicit,
+    Tensor& out) {
+  (void)out;
+
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      implicit == false,
+      "This operator is not implemented for when implicit == true.");
+
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      expand_sizes.size() >= input.sizes().size(),
+      "The number of sizes provided (%zu) must at least be equal to the number of dimensions in the tensor (%zu)",
+      expand_sizes.size(),
+      input.sizes().size());
+
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      expand_sizes.size() <= kTensorDimensionLimit,
+      "The number of expanded dims (%zu) exceeds the configured maximum (%zu). Increase this limit.",
+      expand_sizes.size(),
+      kTensorDimensionLimit);
+
+  return true;
+}
+
 bool check_permute_copy_args(const Tensor& in, IntArrayRef dims, Tensor& out) {
   ET_LOG_AND_RETURN_IF_FALSE(tensor_is_rank(in, dims.size()));
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, out));
@@ -170,6 +196,58 @@ bool check_permute_copy_args(const Tensor& in, IntArrayRef dims, Tensor& out) {
         dim_exist[dim] == false, "duplicate dims are not allowed.");
 
     dim_exist[dim] = true;
+  }
+
+  return true;
+}
+
+bool check_unbind_copy_args(const Tensor& in, int64_t dim, TensorList out) {
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      in.dim() > 0, "in must have at least one dimension; saw %zd", in.dim());
+
+  ET_LOG_AND_RETURN_IF_FALSE(dim_is_valid(dim, in.dim()));
+
+  const ssize_t dim_size = in.size(dim);
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      dim_size == out.size(),
+      "out tensorlist's length %zd must equal unbind dim %" PRId64
+      " size = %zd.",
+      out.size(),
+      dim,
+      dim_size);
+
+  // Validate each output.
+  for (size_t i = 0; i < out.size(); ++i) {
+    // All output dtypes must be the same.
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        out[i].scalar_type() == out[0].scalar_type(),
+        "out[%zu] dtype %" PRId8 " != out[0] dtype %" PRId8,
+        i,
+        static_cast<int8_t>(out[i].scalar_type()),
+        static_cast<int8_t>(out[0].scalar_type()));
+
+    // output tensor must have # of dims = in.dim() -1
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        out[i].dim() == (in.dim() - 1),
+        "out[%zu] dim %zd != in dim %zd",
+        i,
+        out[i].dim(),
+        in.dim() - 1);
+
+    // Check the shape of the output.
+    for (ssize_t d = 0, out_d = 0; d < in.dim(); ++d) {
+      if (d != dim) {
+        ET_LOG_MSG_AND_RETURN_IF_FALSE(
+            out[i].size(out_d) == in.size(d),
+            "out[%zu].size(%zd) %zd != in.size(%zd) %zd",
+            i,
+            d,
+            out[i].size(out_d),
+            d,
+            in.size(d));
+        out_d++;
+      }
+    }
   }
 
   return true;

--- a/kernels/portable/cpu/util/copy_ops_util.cpp
+++ b/kernels/portable/cpu/util/copy_ops_util.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 
 #include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
 
 namespace torch {
 namespace executor {
@@ -170,6 +171,50 @@ bool check_expand_copy_args(
       expand_sizes.size(),
       kTensorDimensionLimit);
 
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(input, out));
+
+  return true;
+}
+
+bool get_expand_copy_out_target_size(
+    exec_aten::ArrayRef<exec_aten::SizesType> self_sizes,
+    exec_aten::ArrayRef<int64_t> expand_sizes,
+    exec_aten::SizesType* output_sizes,
+    size_t* output_rank) {
+  auto j{expand_sizes.size()};
+  *output_rank = 0;
+
+  for (size_t i{self_sizes.size()}; i > 0 && j > 0;) {
+    --i;
+    --j;
+
+    output_sizes[j] = expand_sizes[j];
+
+    if (expand_sizes[j] == -1) {
+      // -1 can use for replacing any corresponding dimension
+      output_sizes[j] = self_sizes[i];
+    } else if (self_sizes[i] != 1) {
+      ET_LOG_MSG_AND_RETURN_IF_FALSE(
+          expand_sizes[j] == self_sizes[i],
+          "The expanded size of the tensor (%zu) must match the existing size (%zu) at non-singleton dimension %zu.",
+          (size_t)expand_sizes[j],
+          (size_t)self_sizes[i],
+          i);
+    }
+  }
+
+  // The leading expand_sizes cannot be negative
+  while (j > 0) {
+    --j;
+    output_sizes[j] = expand_sizes[j];
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        expand_sizes[j] >= 0,
+        "The expanded size of the tensor (%zu) isn't allowed in a leading, non-existing dimension %zu",
+        (size_t)expand_sizes[j],
+        j);
+  }
+
+  *output_rank = expand_sizes.size();
   return true;
 }
 
@@ -189,7 +234,7 @@ bool check_permute_copy_args(const Tensor& in, IntArrayRef dims, Tensor& out) {
     size_t dim = dims[i] >= 0 ? dims[i] : in.dim() + dims[i];
 
     // Internal check, since we have already validated this
-    ET_CHECK(dim < kTensorDimensionLimit && dim >= 0);
+    ET_LOG_AND_RETURN_IF_FALSE(dim < kTensorDimensionLimit && dim >= 0);
 
     // Check that the dimension hasn't been seen previously.
     ET_LOG_MSG_AND_RETURN_IF_FALSE(
@@ -545,6 +590,199 @@ void get_stack_out_target_size(
 bool check_tril_args(const Tensor& in, Tensor& out) {
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, out));
   ET_LOG_AND_RETURN_IF_FALSE(tensor_has_rank_greater_or_equal_to(in, 2));
+  return true;
+}
+
+bool check_split_copy_args(
+    const Tensor& input,
+    int64_t split_size,
+    int64_t dim,
+    TensorList out) {
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      input.dim() > 0,
+      "input must have at least one dimension; saw %zd",
+      input.dim());
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      dim >= 0 && dim < input.dim(),
+      "dim %" PRId64 " out of range [0,%zd)",
+      dim,
+      input.dim());
+
+  const ssize_t dim_size = input.size(dim);
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      split_size >= 0,
+      "split_size %" PRId64 " must be non-negative",
+      split_size);
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      split_size > 0 || dim_size == 0,
+      "split_size is zero but input.size(%" PRId64 ") %zd is non-zero",
+      dim,
+      dim_size);
+
+  // Check the number of outputs.
+  //
+  // The specified dimension will be split into split_size-sized chunks, with
+  // the final chunk possibly being smaller. So, the expected output length is
+  // ceil(dim_size / split_size).
+  //
+  // E.g., splitting dim 0 of a [5,2] tensor with split_size 2 would produce
+  // three tensors with size [2,2], [2,2], [1,2].
+  int64_t remainder; // The size of the split dimension of the final out tensor.
+  if (split_size >= dim_size) {
+    // Note that this also handles the case where split_size == 0, avoiding a
+    // division by zero in the other branch. When dim_size == 0 && split_size ==
+    // 0, core PyTorch expects 1 output element.
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        out.size() == 1,
+        "Unexpected out.size() %zu: should be 1 because split_size %" PRId64
+        " >= input.size(%" PRId64 ") %zd",
+        out.size(),
+        split_size,
+        dim,
+        dim_size);
+    remainder = dim_size;
+  } else {
+    int64_t expected_out_len = (dim_size + split_size - 1) / split_size;
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        out.size() == expected_out_len,
+        "Unexpected out.size() %zu: ceil(input.size(%" PRId64
+        ")=%zd"
+        " / split_size=%" PRId64 ") is %" PRId64,
+        out.size(),
+        dim,
+        dim_size,
+        split_size,
+        expected_out_len);
+    remainder = dim_size % split_size;
+    if (remainder == 0) {
+      remainder = split_size;
+    }
+  }
+
+  // Validate each output.
+  for (size_t i = 0; i < out.size(); ++i) {
+    // All output dtypes must be the same.
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        out[i].scalar_type() == out[0].scalar_type(),
+        "out[%zu] dtype %" PRId8 " != out[0] dtype %" PRId8,
+        i,
+        static_cast<int8_t>(out[i].scalar_type()),
+        static_cast<int8_t>(out[0].scalar_type()));
+
+    // All outputs must have the same number of dimensions as the input.
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
+        out[i].dim() == input.dim(),
+        "out[%zu] dim %zd != input dim %zd",
+        i,
+        out[i].dim(),
+        input.dim());
+
+    // Check the shape of the output.
+    for (ssize_t d = 0; d < out[i].dim(); ++d) {
+      if (d == dim) {
+        // This is the split dimension, which may be different.
+        if (i < out.size() - 1) {
+          // All outputs except the final one: split dimension should be
+          // split_size.
+          ET_LOG_MSG_AND_RETURN_IF_FALSE(
+              out[i].size(d) == split_size,
+              "out[%zu].size(%zd) %zd != split_size %" PRId64,
+              i,
+              d,
+              out[i].size(d),
+              split_size);
+        } else {
+          // The final output: split dimension should be the remainder of
+          // split_size.
+          ET_LOG_MSG_AND_RETURN_IF_FALSE(
+              out[i].size(d) == remainder,
+              "out[%zu].size(%zd) %zd != remainder %" PRId64,
+              i,
+              d,
+              out[i].size(d),
+              remainder);
+        }
+      } else {
+        // Non-split output dimensions must be the same as the input dimension.
+        ET_LOG_AND_RETURN_IF_FALSE(
+            tensors_have_same_size_at_dims(out[i], d, input, d));
+      }
+    }
+  }
+
+  return true;
+}
+
+bool check_to_copy_args(
+    const Tensor& input,
+    bool non_blocking,
+    exec_aten::optional<exec_aten::MemoryFormat> memory_format,
+    Tensor& out) {
+  (void)input;
+  (void)out;
+
+  // Right now we only support blocking data transfer
+  ET_LOG_AND_RETURN_IF_FALSE(non_blocking == false);
+
+  // Right now we only focus on contiguous memory, memory_format shall be
+  // exec::aten::MemoryFormat::Contiguous or none.
+  ET_LOG_AND_RETURN_IF_FALSE(
+      !memory_format.has_value() ||
+      memory_format.value() == MemoryFormat::Contiguous);
+
+  return true;
+}
+
+bool check_unsqueeze_copy_args(
+    const Tensor input,
+    int64_t dim,
+    const Tensor out) {
+  // The input and out shall share same dtype
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(input, out));
+
+  ET_LOG_AND_RETURN_IF_FALSE(tensor_has_dim(out, dim));
+
+  // The shape of input and out shall obey the relationship:
+  // 1. input.dim() == out.dim()-1
+  // 2. input.size(i) == out.size(i) for all i < dim
+  // 3. input.size(i-1) == out.size(i) for all i >= dim
+  // 4. out.size(dim) == 1
+  ET_LOG_AND_RETURN_IF_FALSE(input.dim() == out.dim() - 1);
+
+  for (size_t d = 0; d < out.dim(); d++) {
+    auto dim_normalized = dim;
+    if (dim_normalized < 0) {
+      dim_normalized += out.dim();
+    }
+
+    if (d < dim_normalized) {
+      ET_LOG_MSG_AND_RETURN_IF_FALSE(
+          input.size(d) == out.size(d),
+          "input.size(%zu) %zd != out.size(%zu) %zd | dim = %" PRId64,
+          d,
+          input.size(d),
+          d,
+          out.size(d),
+          dim);
+    } else if (d > dim_normalized) {
+      ET_LOG_MSG_AND_RETURN_IF_FALSE(
+          input.size(d - 1) == out.size(d),
+          "input.size(%zu) %zd != out.size(%zu) %zd | dim = %" PRId64,
+          d - 1,
+          input.size(d),
+          d,
+          out.size(d),
+          dim);
+    } else { // d == dim
+      ET_LOG_MSG_AND_RETURN_IF_FALSE(
+          out.size(d) == 1,
+          "out.size(%zu) %zd shall equal 1 | dim = %" PRId64,
+          d,
+          out.size(d),
+          dim);
+    }
+  }
+
   return true;
 }
 

--- a/kernels/portable/cpu/util/copy_ops_util.h
+++ b/kernels/portable/cpu/util/copy_ops_util.h
@@ -154,5 +154,16 @@ bool check_unsqueeze_copy_args(
     int64_t dim,
     const Tensor out);
 
+bool check_view_copy_args(
+    const Tensor& self,
+    exec_aten::ArrayRef<int64_t> size_int64_t,
+    Tensor& out);
+
+bool get_view_copy_target_size(
+    const Tensor input,
+    exec_aten::ArrayRef<int64_t> size_int64_t,
+    int64_t dim,
+    Tensor::SizesType* out_sizes);
+
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/copy_ops_util.h
+++ b/kernels/portable/cpu/util/copy_ops_util.h
@@ -37,6 +37,12 @@ bool check_expand_copy_args(
     bool implicit,
     Tensor& out);
 
+bool get_expand_copy_out_target_size(
+    exec_aten::ArrayRef<exec_aten::SizesType> self_sizes,
+    exec_aten::ArrayRef<int64_t> expand_sizes,
+    exec_aten::SizesType* output_sizes,
+    size_t* output_rank);
+
 bool check_permute_copy_args(const Tensor& in, IntArrayRef dims, Tensor& out);
 
 bool check_unbind_copy_args(const Tensor& in, int64_t dim, TensorList out);
@@ -130,6 +136,23 @@ void get_stack_out_target_size(
     size_t* out_ndim);
 
 bool check_tril_args(const Tensor& in, Tensor& out);
+
+bool check_split_copy_args(
+    const Tensor& input,
+    int64_t split_size,
+    int64_t dim,
+    TensorList out);
+
+bool check_to_copy_args(
+    const Tensor& input,
+    bool non_blocking,
+    exec_aten::optional<exec_aten::MemoryFormat> memory_format,
+    Tensor& out);
+
+bool check_unsqueeze_copy_args(
+    const Tensor input,
+    int64_t dim,
+    const Tensor out);
 
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/copy_ops_util.h
+++ b/kernels/portable/cpu/util/copy_ops_util.h
@@ -31,7 +31,15 @@ void get_cat_out_target_size(
     Tensor::SizesType* out_sizes,
     size_t* out_ndim);
 
+bool check_expand_copy_args(
+    const Tensor& self,
+    ArrayRef<int64_t> expand_sizes,
+    bool implicit,
+    Tensor& out);
+
 bool check_permute_copy_args(const Tensor& in, IntArrayRef dims, Tensor& out);
+
+bool check_unbind_copy_args(const Tensor& in, int64_t dim, TensorList out);
 
 void get_permute_copy_out_target_size(
     const Tensor& in,

--- a/kernels/portable/cpu/util/index_util.cpp
+++ b/kernels/portable/cpu/util/index_util.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/kernels/portable/cpu/util/index_util.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
 
 namespace torch {
 namespace executor {
@@ -127,6 +128,40 @@ bool check_scatter_add_args(
         nonempty_size(self, dim));
   }
   return true;
+}
+
+int64_t adjust_slice_indices(
+    int64_t dim_length,
+    int64_t* start,
+    int64_t* end,
+    int64_t step) {
+  int64_t num_values = 0;
+
+  // Update start and end index
+  // First convert it to c++ style from python style if needed.
+  // The start index is using python style E.g., for the shape {2, 3, 4},
+  // dim = -1 would refer to dim[2], dim = -2 would refer to dim[1], and so on.
+  *start = *start < 0 ? *start + dim_length : *start;
+  *end = *end < 0 ? *end + dim_length : *end;
+  // Second, if start or end still negative, which means user want to start or
+  // end slicing from very beginning, so set it to zero
+  *start = *start < 0 ? 0 : *start;
+  *end = *end < 0 ? 0 : *end;
+  // Last, if start or end larger than maximum value (dim_length - 1), indicates
+  // user want to start slicing after end or slicing until the end, so update it
+  // to dim_length
+  *start = *start > dim_length ? dim_length : *start;
+  *end = *end > dim_length ? dim_length : *end;
+
+  if (*start >= dim_length || *end <= 0 || *start >= *end) {
+    // Set num_values to 0 if interval [start, end) is non-exist or do not
+    // overlap with [0, dim_length)
+    num_values = 0;
+  } else {
+    // Update num_values to min(max_num_values, num_values)
+    num_values = (*end - 1 - *start) / step + 1;
+  }
+  return num_values;
 }
 
 } // namespace executor

--- a/kernels/portable/cpu/util/index_util.h
+++ b/kernels/portable/cpu/util/index_util.h
@@ -36,5 +36,26 @@ bool check_scatter_add_args(
 
 bool check_nonzero_args(const Tensor& in, const Tensor& out);
 
+bool check_slice_scatter_args(
+    const Tensor& input,
+    const Tensor& src,
+    int64_t dim,
+    int64_t num_values,
+    int64_t step,
+    Tensor output);
+
+int64_t adjust_slice_indices(
+    int64_t dim_length,
+    int64_t* start,
+    int64_t* end,
+    int64_t step);
+
+bool check_select_scatter_args(
+    const Tensor& in,
+    const Tensor& src,
+    int64_t dim,
+    int64_t index,
+    Tensor& output);
+
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/index_util.h
+++ b/kernels/portable/cpu/util/index_util.h
@@ -34,5 +34,7 @@ bool check_scatter_add_args(
     const Tensor& src,
     Tensor& out);
 
+bool check_nonzero_args(const Tensor& in, const Tensor& out);
+
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/kernel_ops_util.cpp
+++ b/kernels/portable/cpu/util/kernel_ops_util.cpp
@@ -564,5 +564,59 @@ bool check_nonzero_args(const Tensor& in, const Tensor& out) {
   return true;
 }
 
+bool check_masked_fill_args(
+    const Tensor& in,
+    const Tensor& mask,
+    const Scalar& value,
+    Tensor& out) {
+  (void)value;
+
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, out));
+  ET_LOG_AND_RETURN_IF_FALSE(mask.scalar_type() == ScalarType::Bool);
+
+  return true;
+}
+
+bool check_constant_pad_args(
+    const Tensor& in,
+    IntArrayRef pad,
+    const Scalar& value,
+    Tensor& out) {
+  (void)value;
+
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, out));
+
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_rank(in, out));
+
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      pad.size() % 2 == 0, "Padding array must be a multiple of 2");
+
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      pad.size() / 2 <= in.dim(), "Padding array contains too many elements");
+
+  return true;
+}
+
+Error resize_constant_pad_output(
+    const Tensor& in,
+    IntArrayRef pad,
+    Tensor& out) {
+  Tensor::SizesType expected_output_size[kTensorDimensionLimit];
+
+  int pad_i = in.dim() - 1;
+  for (size_t i = 0; i < in.dim(); ++i, --pad_i) {
+    expected_output_size[i] = in.size(i);
+    if (pad_i >= 0 && pad_i < pad.size() / 2) {
+      expected_output_size[i] += pad[2 * pad_i] + pad[2 * pad_i + 1];
+    }
+  }
+
+  ArrayRef<Tensor::SizesType> output_size{
+      expected_output_size, static_cast<size_t>(in.dim())};
+  auto error = resize_tensor(out, output_size);
+
+  return error;
+}
+
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/kernel_ops_util.cpp
+++ b/kernels/portable/cpu/util/kernel_ops_util.cpp
@@ -455,5 +455,114 @@ void get_max_pool2d_with_indices_out_target_size(
       in, 2, kernel_size, stride, padding, dilation, out_sizes, ceil_mode);
 }
 
+bool check_slice_scatter_args(
+    const Tensor& input,
+    const Tensor& src,
+    int64_t dim,
+    int64_t num_values,
+    int64_t step,
+    Tensor output) {
+  // Check dim. The dim planed to be selected on shall exist in input
+  ET_LOG_AND_RETURN_IF_FALSE(dim_is_valid(dim, input.dim()));
+
+  // Input and output tensors should be the same shape and dtype
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_shape_and_dtype(input, output));
+
+  // The input.dim() shall equal to src.dim()
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_rank(input, src));
+
+  // Check step. Step must be greater than zero
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      step > 0, "slice step must be greater than zero");
+
+  // The size of src tensor should follow these rules:
+  // - src.size(i) shall equal to input.size(i) if i != dim,
+  // - src.size(dim) shall equal to num_values
+  for (size_t d = 0; d < input.dim() - 1; d++) {
+    if (d != dim) {
+      ET_LOG_AND_RETURN_IF_FALSE(
+          tensors_have_same_size_at_dims(input, d, src, d));
+    } else {
+      ET_LOG_MSG_AND_RETURN_IF_FALSE(
+          src.size(d) == num_values,
+          "input.size(%zu) %zd != num_values %" PRId64 " | dim = %" PRId64 ")",
+          d,
+          input.size(d),
+          num_values,
+          dim);
+    }
+  }
+
+  return true;
+}
+
+bool check_select_scatter_args(
+    const Tensor& in,
+    const Tensor& src,
+    int64_t dim,
+    int64_t index,
+    Tensor& output) {
+  /**
+   * Assumptions for inputs:
+   * 1. output size is the same as input size
+   * 2. src size is the same as the selected slice from the input
+   * 3. dim and index values are valid given the input tensor
+   */
+
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, output));
+
+  // The dim planed to be selected on shall exist in input
+  ET_LOG_AND_RETURN_IF_FALSE(dim_is_valid(dim, in.dim()));
+
+  // The index shall be valid in the given dimenson
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      index >= 0 && index < in.size(dim),
+      "index %" PRId64 " out of range [-%zd,%zd) at in.size( %" PRId64 ")",
+      index,
+      in.size(dim),
+      in.size(dim),
+      dim);
+
+  // The src.dim() shall be one lower than in.dim() since src needs to fit
+  // into the selected data on one dim of input
+  // https://pytorch.org/docs/stable/generated/torch.select_scatter.html
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      in.dim() == src.dim() + 1,
+      "in.dim() %zd != src.dim() + 1 %zd",
+      in.dim(),
+      src.dim() + 1);
+
+  // The size of src tensor should follow these rules:
+  // - src.size(i) shall equal to in.size(i) if i < dim,
+  // - src.size(i) shall equal to in.size(i+1) if i >= dim
+
+  for (ssize_t d = 0; d < in.dim() - 1; d++) {
+    if (d < dim) {
+      ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_size_at_dims(in, d, src, d));
+    } else {
+      ET_LOG_AND_RETURN_IF_FALSE(
+          tensors_have_same_size_at_dims(in, d + 1, src, d));
+    }
+  }
+
+  return true;
+}
+
+bool check_nonzero_args(const Tensor& in, const Tensor& out) {
+  (void)in;
+
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      out.scalar_type() == ScalarType::Long,
+      "Expected out to be a Long tensor but received %" PRId8,
+      static_cast<int8_t>(out.scalar_type()));
+
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      out.dim() == 2,
+      "Expected out to be a 2d tensor received %zd",
+      ssize_t(out.dim()));
+
+  return true;
+}
+
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/kernel_ops_util.h
+++ b/kernels/portable/cpu/util/kernel_ops_util.h
@@ -370,6 +370,8 @@ void apply_kernel_2d_reduce_then_map_fn(
 // Operator specific utility functions
 //
 
+bool check_arange_args(double start, double end, double step, Tensor& out);
+
 bool check_avg_pool2d_args(
     const Tensor& in,
     const IntArrayRef kernel_size,
@@ -409,6 +411,12 @@ void get_convolution_out_target_size(
     IntArrayRef dilation,
     exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
+
+bool check_cumsum_args(
+    const Tensor& self,
+    int64_t dim,
+    optional<ScalarType> enforced_dtype,
+    Tensor& out);
 
 bool check_max_pool2d_with_indices_args(
     const Tensor& in,

--- a/kernels/portable/cpu/util/kernel_ops_util.h
+++ b/kernels/portable/cpu/util/kernel_ops_util.h
@@ -478,5 +478,15 @@ Error resize_constant_pad_output(
     IntArrayRef pad,
     Tensor& out);
 
+bool check_embedding_args(
+    const Tensor& weight,
+    const Tensor& indices,
+    const Tensor& out);
+
+Error resize_embedding_output(
+    const Tensor& weight,
+    const Tensor& indices,
+    const Tensor& out);
+
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/kernel_ops_util.h
+++ b/kernels/portable/cpu/util/kernel_ops_util.h
@@ -461,5 +461,22 @@ bool check_select_scatter_args(
     int64_t index,
     Tensor& output);
 
+bool check_masked_fill_args(
+    const Tensor& in,
+    const Tensor& mask,
+    const Scalar& value,
+    Tensor& out);
+
+bool check_constant_pad_args(
+    const Tensor& in,
+    IntArrayRef pad,
+    const Scalar& value,
+    Tensor& out);
+
+Error resize_constant_pad_output(
+    const Tensor& in,
+    IntArrayRef pad,
+    Tensor& out);
+
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/kernel_ops_util.h
+++ b/kernels/portable/cpu/util/kernel_ops_util.h
@@ -438,5 +438,28 @@ void get_max_pool2d_with_indices_out_target_size(
     exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
 
+bool check_nonzero_args(const Tensor& in, const Tensor& out);
+
+bool check_slice_scatter_args(
+    const Tensor& input,
+    const Tensor& src,
+    int64_t dim,
+    int64_t num_values,
+    int64_t step,
+    Tensor output);
+
+int64_t adjust_slice_indices(
+    int64_t dim_length,
+    int64_t* start,
+    int64_t* end,
+    int64_t step);
+
+bool check_select_scatter_args(
+    const Tensor& in,
+    const Tensor& src,
+    int64_t dim,
+    int64_t index,
+    Tensor& output);
+
 } // namespace executor
 } // namespace torch

--- a/kernels/test/op_unsqueeze_copy_test.cpp
+++ b/kernels/test/op_unsqueeze_copy_test.cpp
@@ -67,6 +67,9 @@ void run_unsqueeze_test_cases(
     const std::vector<int64_t>& dims) {
   TensorFactory<DTYPE> tf;
 
+  // DEBUG
+  et_pal_init();
+
   for (int64_t dim : dims) {
     std::vector<int32_t> size_out = generate_size_out(input.sizes(), dim);
     Tensor out = tf.ones(size_out);

--- a/runtime/core/exec_aten/util/tensor_util.h
+++ b/runtime/core/exec_aten/util/tensor_util.h
@@ -824,6 +824,15 @@ inline bool tensor_is_contiguous(exec_aten::Tensor t) {
   return true;
 }
 
+inline bool tensors_have_same_rank(exec_aten::Tensor a, exec_aten::Tensor b) {
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      a.dim() == b.dim(),
+      ET_TENSOR_CHECK_PREFIX__ ": rank={%zd, %zd}",
+      ssize_t(a.dim()),
+      ssize_t(b.dim()));
+  return true;
+}
+
 /**
  * The expected output size may not be the existing size of any inputs and
  * outputs if the operator supports both broadcast and dynamic shape. Therefore


### PR DESCRIPTION
Summary: Clean up more portable ops to use ET_KERNEL_CHECK in preparation for non-fatal kernels.

Differential Revision: D52622168

