### PR TITLE
change signature of map_impl

### DIFF
--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -647,12 +647,15 @@ class _Emitter(torch.fx.Interpreter):
             raise RuntimeError(
                 f"Multiple outputs are not supported. Got {len(subemitter_binding_output_values)}."
             )
-        f, num_mapped_args = args[:2]
+        f, mapped_args, inputs = args
+        assert isinstance(mapped_args, (list, tuple))
+        num_mapped_args: int = len(mapped_args)
         if num_mapped_args != 1:
             raise RuntimeError(
                 f"Emitting map with more than one mapped args is not supported. Got {num_mapped_args}."
             )
-        x, *inputs = args[2:]
+        x = mapped_args[0]
+
         assert isinstance(f, torch.fx.GraphModule)
 
         # Generate the EValue that we will use as our iterator index to keep track of which

--- a/exir/lowered_backend_module.py
+++ b/exir/lowered_backend_module.py
@@ -122,6 +122,9 @@ class LoweredBackendModule(torch.nn.Module):
     # TODO(chenlai): re-consider recapture instead of manually constructing the program because
     # the meta data construction is done manually.
     def program(self, emit_stacktrace: bool = False) -> Program:
+        # Fix autodpes introuces cyclic dependencies:
+        # program -> verifier -> lowered_backend_module -> program
+        # @manual
         from executorch.exir.program._program import (
             _get_updated_graph_signature,
             _transform,

--- a/exir/pass_base.py
+++ b/exir/pass_base.py
@@ -336,8 +336,8 @@ class _ExportPassBase(PassBase):
                 pred, true_fn, false_fn, inputs = args
                 return self.callback.call_cond(pred, true_fn, false_fn, inputs, meta)
             elif target == torch.ops.higher_order.map_impl:
-                f, num_args, *rest = args  # type: ignore[assignment]
-                return self.callback.call_map(f, num_args, list(rest), meta)
+                f, mapped_args, operands = args  # type: ignore[assignment]
+                return self.callback.call_map(f, mapped_args, operands, meta)
             # For other unregistered HigherOrderOps, just interpret them blindly
             elif isinstance(target, torch._ops.HigherOrderOperator):
                 return self.callback._fx(
@@ -495,18 +495,17 @@ class _ExportPassBase(PassBase):
     def call_map(
         self,
         f: torch.fx.GraphModule,
-        num_args: int,
-        args: List[ProxyValue],
+        mapped_args: List[ProxyValue],
+        operands: List[ProxyValue],
         meta: NodeMetadata,
     ) -> ProxyValue:
-        xs = _unstack_pytree([arg.data for arg in args[:num_args]])[0]
-        pos_args = args[num_args:]
-        f_branch = self.call_submodule(f, tuple(xs + [arg.data for arg in pos_args]))
+        xs = _unstack_pytree([arg.data for arg in mapped_args])[0]
+        f_branch = self.call_submodule(f, tuple(xs + [arg.data for arg in operands]))
         assert f_branch is not None
         return self._fx(
             "call_function",
             torch.ops.higher_order.map_impl,
-            (f_branch.graph_module, num_args, *args),
+            (f_branch.graph_module, mapped_args, operands),
             {},
             meta,
         )

--- a/exir/passes/spec_prop_pass.py
+++ b/exir/passes/spec_prop_pass.py
@@ -85,21 +85,20 @@ class SpecPropPass(ExportPass):
     def call_map(
         self,
         f: torch.fx.GraphModule,
-        num_args: int,
-        args: List[ProxyValue],
+        mapped_args: List[ProxyValue],
+        operands: List[ProxyValue],
         meta: NodeMetadata,
     ) -> ProxyValue:
-        args_data = pytree.tree_map_only(ProxyValue, lambda x: x.data, args)
-        xs_data = args_data[:num_args]
+        mapped_dim_size = [arg.data for arg in mapped_args][0].size(0)
         *_, body_out_node = f.graph.nodes
         body_out_node_fake_tensor = body_out_node.meta["val"]
         map_fake_tensor = pytree.tree_map_only(
             torch.Tensor,
-            lambda x: x.new_empty(xs_data[0].size(0), *x.shape),
+            lambda x: x.new_empty(mapped_dim_size, *x.shape),
             body_out_node_fake_tensor,
         )
         meta["spec"] = pytree.tree_map(make_spec, map_fake_tensor)
-        return super().call_map(f, num_args, args, meta)
+        return super().call_map(f, mapped_args, operands, meta)
 
     # pyre-ignore
     def call_delegate(self, lowered_module, args, kwargs, meta):


### PR DESCRIPTION
Summary: This PR changes the schema of map_impl from map_impl(f, num_mapped, *operands) to map_impl(f, mapped_args: Tuple, moperands: Tuple). This is to prepare for turning on dynamo for eager mode cond, where we want to get rid of the num_mapped scalar.

Differential Revision: D52495413


