### PR TITLE
Remove the redundant install_requirement script when test iOS on CI

### DIFF
--- a/build/test_ios_ci.sh
+++ b/build/test_ios_ci.sh
@@ -31,10 +31,6 @@ say() {
   echo -e "\033[1m\n\t** $1 **\n\033[0m"
 }
 
-say "Installing Requirements"
-
-./install_requirements.sh
-
 say "Installing CoreML Backend Requirements"
 
 ./backends/apple/coreml/scripts/install_requirements.sh


### PR DESCRIPTION
All the dependency has already been setup by https://github.com/pytorch/executorch/blob/main/.github/workflows/app-build.yml#L40.  Running the install script again here will overwrite the PyTorch version causing version mismatched failure, i.e. https://github.com/pytorch/executorch/actions/runs/7483610205/job/20369124052