### PR TITLE
Replace `c10::ScalarType` with native equivalent

### DIFF
--- a/backends/vulkan/VulkanBackend.cpp
+++ b/backends/vulkan/VulkanBackend.cpp
@@ -51,11 +51,11 @@ class VulkanBackend final : public PyTorchBackendInterface {
     }
   }
 
-  c10::ScalarType get_scalar_type(
+  at::native::vulkan::api::ScalarType get_scalar_type(
       const at::vulkan::delegate::VkDatatype& vk_datatype) const {
     switch (vk_datatype) {
       case (at::vulkan::delegate::VkDatatype::vk_datatype_fp32): {
-        return c10::kFloat;
+        return at::native::vulkan::api::kFloat;
       }
     }
   }
@@ -87,7 +87,7 @@ class VulkanBackend final : public PyTorchBackendInterface {
         "Only constant buffers are supported when adding tensors to compute graph (indicated by constant_buffer_idx == 0), but got constant_buffer_idx of %d",
         vk_tensor->constant_buffer_idx());
 
-    const c10::ScalarType& tensor_dtype =
+    const at::native::vulkan::api::ScalarType& tensor_dtype =
         get_scalar_type(vk_tensor->datatype());
 
     const flatbuffers_fbsource::Vector<uint32_t>* tensor_dims_fb =
@@ -177,7 +177,7 @@ class VulkanBackend final : public PyTorchBackendInterface {
           input_id,
           input_vk_tensor->constant_buffer_idx());
 
-      const c10::ScalarType& input_dtype =
+      const at::native::vulkan::api::ScalarType& input_dtype =
           get_scalar_type(input_vk_tensor->datatype());
 
       const flatbuffers_fbsource::Vector<uint32_t>* input_dims_fb =


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/117181

## Context

This change is part of a set of changes that removes all references to the `c10` library in the `api/`, `graph/`, and `impl/` folders of the PyTorch Vulkan codebase. This is to ensure that these components can be built as a standalone library such that they can be used as the foundations of a Android GPU delegate for ExecuTorch.

## Notes for Reviewers

This changeset introduces `api::ScalarType` in `api/Types.h`, which is intended to function the same as `c10::ScalarType`; thus `api/Types.h` is the primary file of interest. The rest of the changes are straightforward replacements of `c10::ScalarType` with `api::ScalarType`.
ghstack-source-id: 211869868
exported-using-ghexport

Reviewed By: yipjustin, liuk22

Differential Revision: D52662237


