### PR TITLE
[pybind] Add option to build python module portable_lib

### DIFF
--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -19,7 +19,7 @@ install_executorch() {
   which pip
   # Install executorch, this assumes that Executorch is checked out in the
   # current directory
-  pip install .
+  pip install . --no-build-isolation
   # Just print out the list of packages for debugging
   pip list
 }

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -34,23 +34,7 @@ jobs:
 
         BUILD_TOOL=${{ matrix.build-tool }}
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
-
-        # Build //extension/pybindings:portable_lib. Example path:
-        # buck-out/v2/gen/root/524f8da68ea2a374/extension/pybindings/__portable_lib__/portable_lib.so
-        SO_LIB_DIR=$(buck2 build //extension/pybindings:portable_lib --show-output | cut -d' ' -f2 | xargs dirname)
-
-        # Let LD_LIBRARY_PATH include libtorch_python directory
-        PYTHON_LIB_DIR=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')
-        export LD_LIBRARY_PATH="${PYTHON_LIB_DIR}/torch/lib"
-
-        # Let PYTHONPATH include the output directory so that portable_lib.so can be loaded into Python.
-        export PYTHONPATH="${SO_LIB_DIR}:${PYTHON_LIB_DIR}/torch/lib"
-
-        # Generate a shim file in extension/pybindings/portable_lib/
-        SHIM_PY="${PYTHON_LIB_DIR}/executorch/extension/pybindings/portable_lib.py"
-        touch ${SHIM_PY}
-        echo "from portable_lib import _load_for_executorch_from_buffer,_load_bundled_program_from_buffer,_load_for_executorch_from_bundled_program" > ${SHIM_PY}
+        PYTHON_EXECUTABLE=python EXECUTORCH_BUILD_PYBIND=ON bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
 
         # Run pytest with coverage
         pytest -n auto --cov=./ --cov-report=xml
@@ -76,23 +60,7 @@ jobs:
 
         bash .ci/scripts/setup-conda.sh
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
-        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
-
-        # Build //extension/pybindings:portable_lib. Example path:
-        # buck-out/v2/gen/root/524f8da68ea2a374/extension/pybindings/__portable_lib__/portable_lib.dylib
-        SO_LIB_DIR=$(${CONDA_RUN} buck2 build //extension/pybindings:portable_lib --show-output | cut -d' ' -f2 | xargs dirname)
-
-        # Let LD_LIBRARY_PATH include libtorch_python directory
-        PYTHON_LIB_DIR=$(${CONDA_RUN} python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')
-        export LD_LIBRARY_PATH="${PYTHON_LIB_DIR}/torch/lib"
-
-        # Let PYTHONPATH include the output directory so that portable_lib.dylib can be loaded into Python.
-        export PYTHONPATH="${SO_LIB_DIR}:${PYTHON_LIB_DIR}/torch/lib"
-
-        # Generate a shim file in extension/pybindings/portable_lib/
-        SHIM_PY="${PYTHON_LIB_DIR}/executorch/extension/pybindings/portable_lib.py"
-        touch ${SHIM_PY}
-        echo "from portable_lib import _load_for_executorch_from_buffer,_load_bundled_program_from_buffer,_load_for_executorch_from_bundled_program" > ${SHIM_PY}
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} EXECUTORCH_BUILD_PYBIND=ON bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
 
         # Run pytest with coverage
         ${CONDA_RUN} pytest -n auto --cov=./ --cov-report=xml

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -131,6 +131,32 @@ jobs:
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
         PYTHON_EXECUTABLE=python bash .ci/scripts/test_quantized_aot_lib.sh
 
+  test-pybind-build-linux:
+    name: test-pybind-build-linux
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    strategy:
+      matrix:
+        include:
+          - build-tool: cmake
+      fail-fast: false
+    with:
+      runner: linux.2xlarge
+      docker-image: executorch-ubuntu-22.04-clang12
+      submodules: 'true'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 90
+      script: |
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        # build module for executorch.extension.pybindings.portable_lib
+        BUILD_TOOL=${{ matrix.build-tool }}
+        PYTHON_EXECUTABLE=python EXECUTORCH_BUILD_PYBIND=ON bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+
+        # see if we can import the module successfully
+        python -c "from executorch.extension.pybindings import portable_lib; print('success!')"
+
   unittest:
     uses: ./.github/workflows/_unittest.yml
     with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,5 +355,53 @@ if(EXECUTORCH_BUILD_COREML)
   endif()
 endif()
 
+# Build pybind
+option(EXECUTORCH_BUILD_PYBIND "Build pybindings" OFF)
+if(EXECUTORCH_BUILD_PYBIND)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/pybind11)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/data_loader)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sdk)
+
+  # find pytorch lib, to allow pybind to take at::Tensor as input/output
+  find_package(Torch CONFIG REQUIRED)
+  find_library(TORCH_PYTHON_LIBRARY torch_python
+               PATHS "${TORCH_INSTALL_PREFIX}/lib")
+
+  # compile options for pybind
+
+  set(_pybind_compile_options -Wno-deprecated-declarations -fPIC -frtti
+                              -fexceptions)
+  # util lib
+  add_library(
+    util
+    ${CMAKE_CURRENT_SOURCE_DIR}/extension/evalue_util/print_evalue.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/extension/aten_util/aten_bridge.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/util/read_file.cpp
+  )
+  target_include_directories(util PUBLIC ${_common_include_directories}
+                                         ${TORCH_INCLUDE_DIRS})
+  target_compile_options(util PUBLIC ${_pybind_compile_options})
+  target_link_libraries(util PRIVATE torch c10 executorch)
+
+  # pybind portable_lib
+  pybind11_add_module(portable_lib extension/pybindings/pybindings.cpp)
+  target_compile_definitions(portable_lib
+                             PUBLIC EXECUTORCH_PYTHON_MODULE_NAME=portable_lib)
+  target_include_directories(portable_lib PRIVATE ${TORCH_INCLUDE_DIRS})
+  target_compile_options(portable_lib PUBLIC ${_pybind_compile_options})
+  target_link_libraries(
+    portable_lib
+    PUBLIC ${TORCH_PYTHON_LIBRARY}
+           portable_ops_lib
+           executorch
+           extension_data_loader
+           bundled_program
+           etdump
+           flatcc
+           util)
+
+  install(TARGETS portable_lib
+          LIBRARY DESTINATION executorch/extension/pybindings)
+endif()
 # Print all summary
 executorch_print_configuration_summary()

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -117,7 +117,7 @@ function(gen_operators_lib lib_name kernel_lib deps)
       ${CMAKE_CURRENT_BINARY_DIR}/NativeFunctions.h)
   target_link_libraries(${lib_name} PRIVATE ${deps})
   if(kernel_lib)
-    target_link_libraries(${lib_name} INTERFACE ${kernel_lib})
+    target_link_libraries(${lib_name} PRIVATE ${kernel_lib})
   endif()
 
   target_link_options_shared_lib(${lib_name})

--- a/extension/data_loader/CMakeLists.txt
+++ b/extension/data_loader/CMakeLists.txt
@@ -18,8 +18,9 @@ endif()
 
 list(TRANSFORM _extension_data_loader__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(extension_data_loader ${_extension_data_loader__srcs})
+target_link_libraries(extension_data_loader executorch)
 target_include_directories(extension_data_loader PUBLIC ${EXECUTORCH_ROOT}/..)
-
+target_compile_options(extension_data_loader PUBLIC ${_common_compile_options})
 
 # Install libraries
 install(

--- a/extension/pybindings/README.md
+++ b/extension/pybindings/README.md
@@ -1,0 +1,30 @@
+# ExecuTorch Python Module (WIP)
+This Python module, named `portable_lib`, provides a set of functions and classes for loading and executing bundled programs. To install it, run the fullowing command:
+
+```bash
+EXECUTORCH_BUILD_PYBIND=ON pip install . --no-build-isolation
+```
+
+## Functions
+- `_load_for_executorch(path: str, enable_etdump: bool = False)`: Load a module from a file.
+- `_load_for_executorch_from_buffer(buffer: str, enable_etdump: bool = False)`: Load a module from a buffer.
+- `_load_for_executorch_from_bundled_program(ptr: str, enable_etdump: bool = False)`: Load a module from a bundled program.
+- `_load_bundled_program_from_buffer(buffer: str, non_const_pool_size: int = kDEFAULT_BUNDLED_INPUT_POOL_SIZE)`: Load a bundled program from a buffer.
+- `_dump_profile_results()`: Dump profile results.
+- `_get_operator_names()`: Get operator names.
+- `_create_profile_block()`: Create a profile block.
+- `_reset_profile_results()`: Reset profile results.
+## Classes
+### ExecuTorchModule
+- `load_bundled_input()`: Load bundled input.
+- `verify_result_with_bundled_expected_output(bundle: str, method_name: str, testset_idx: int, rtol: float = 1e-5, atol: float = 1e-8)`: Verify result with bundled expected output.
+- `plan_execute()`: Plan and execute.
+- `run_method()`: Run method.
+- `forward()`: Forward. This takes a pytree-flattend PyTorch-tensor-based input.
+- `has_etdump()`: Check if etdump is available.
+- `write_etdump_result_to_file()`: Write etdump result to a file.
+- `__call__()`: Call method.
+### BundledModule
+This class is currently empty and serves as a placeholder for future methods and attributes.
+## Note
+All functions and methods are guarded by a call guard that redirects `cout` and `cerr` to the Python environment.

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -621,6 +621,17 @@ void create_profile_block(const std::string& name) {
   EXECUTORCH_PROFILE_CREATE_BLOCK(name.c_str());
 }
 
+py::list get_operator_names() {
+  ArrayRef<Kernel> kernels = get_kernels();
+  py::list res;
+  for (const Kernel& k : kernels) {
+    if (k.name_ != nullptr) {
+      res.append(py::cast(k.name_));
+    }
+  }
+  return res;
+}
+
 } // namespace
 
 PYBIND11_MODULE(EXECUTORCH_PYTHON_MODULE_NAME, m) {
@@ -661,13 +672,14 @@ PYBIND11_MODULE(EXECUTORCH_PYTHON_MODULE_NAME, m) {
             prof_result.num_bytes);
       },
       call_guard);
+  m.def("_get_operator_names", &get_operator_names);
   m.def("_create_profile_block", &create_profile_block, call_guard);
   m.def(
       "_reset_profile_results",
       []() { EXECUTORCH_RESET_PROFILE_RESULTS(); },
       call_guard);
 
-  py::class_<PyModule>(m, "ExecutorchModule")
+  py::class_<PyModule>(m, "ExecuTorchModule")
       .def("load_bundled_input", &PyModule::load_bundled_input, call_guard)
       .def(
           "verify_result_with_bundled_expected_output",

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -7,7 +7,15 @@
 
 # Install required python dependencies for developing
 # Dependencies are defined in .pyproject.toml
-pip install .
+if [[ -z $BUCK ]];
+then
+  BUCK=buck2
+fi
+
+if [[ -z $PYTHON_EXECUTABLE ]];
+then
+  PYTHON_EXECUTABLE=python3
+fi
 
 # Install pytorch dependencies
 #
@@ -36,6 +44,9 @@ pip install --force-reinstall --pre transformers==${TRANSFORMERS_VERSION}
 
 TORCHSR_VERSION=1.0.4
 pip install --pre torchsr==${TORCHSR_VERSION}
+
+# Install ExecuTorch after dependencies are installed.
+pip install . --no-build-isolation
 
 # Install flatc dependency
 bash build/install_flatc.sh

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -118,7 +118,7 @@ add_library(etdump ${CMAKE_CURRENT_SOURCE_DIR}/etdump/etdump_flatcc.cpp
 
 target_link_libraries(
   etdump
-  PUBLIC etdump_schema
+  PUBLIC etdump_schema flatcc
   PRIVATE executorch)
 
 add_custom_command(

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,180 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
-import shutil
+# Part of this code is from pybind11 cmake_example:
+# https://github.com/pybind/cmake_example/blob/master/setup.py so attach the
+# license below.
 
-from setuptools import setup
+# Copyright (c) 2016 The Pybind Development Team, All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# You are under no obligation whatsoever to provide any bug fixes, patches, or
+# upgrades to the features, functionality or performance of the source code
+# ("Enhancements") to anyone; however, if you choose to make your Enhancements
+# available either publicly, or directly to the author of this software, without
+# imposing a separate written license agreement for such Enhancements, then you
+# hereby grant the following license: a non-exclusive, royalty-free perpetual
+# license to install, use, modify, prepare derivative works, incorporate into
+# other computer software, distribute, and sublicense such enhancements or
+# derivative works thereof, in binary and source code form.
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from distutils.sysconfig import get_python_lib
+from pathlib import Path
+
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
 from setuptools.command.develop import develop
 from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
+
+# Convert distutils Windows platform specifiers to CMake -A arguments
+PLAT_TO_CMAKE = {
+    "win32": "Win32",
+    "win-amd64": "x64",
+    "win-arm32": "ARM",
+    "win-arm64": "ARM64",
+}
+
+
+# A CMakeExtension needs a sourcedir instead of a file list.
+# The name must be the _single_ output extension from the CMake build.
+# If you need multiple extensions, see scikit-build.
+class CMakeExtension(Extension):
+    def __init__(self, name: str, sourcedir: str = "") -> None:
+        super().__init__(name, sources=[])
+        self.sourcedir = os.fspath(Path(sourcedir).resolve())
+
+
+class CMakeBuild(build_ext):
+    def build_extension(self, ext: CMakeExtension) -> None:
+        # Must be in this form due to bug in .resolve() only fixed in Python 3.10+
+        ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)
+        extdir = ext_fullpath.parent.resolve()
+
+        # Using this requires trailing slash for auto-detection & inclusion of
+        # auxiliary "native" libs
+
+        debug = int(os.environ.get("DEBUG", 0)) if self.debug is None else self.debug
+        cfg = "Debug" if debug else "Release"
+
+        # CMake lets you override the generator - we need to check this.
+        # Can be set with Conda-Build, for example.
+        cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
+
+        # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
+        # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
+        # from Python.
+        buck = os.environ.get("BUCK", "buck2")
+        cmake_prefix_path = os.environ.get("CMAKE_PREFIX_PATH", get_python_lib())
+        cmake_args = [
+            "-DEXECUTORCH_BUILD_PYBIND=ON",
+            "-DBUILD_SHARED_LIBS=ON",  # For flatcc
+            f"-DBUCK2={buck}",
+            f"-DCMAKE_PREFIX_PATH={cmake_prefix_path}",
+            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
+            f"-DPYTHON_EXECUTABLE={sys.executable}",
+            f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
+        ]
+        build_args = []
+        # Adding CMake arguments set as environment variable
+        # (needed e.g. to build for ARM OSx on conda-forge)
+        if "CMAKE_ARGS" in os.environ:
+            cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
+
+        # In this example, we pass in the version to C++. You might not need to.
+        cmake_args += [f"-DEXAMPLE_VERSION_INFO={self.distribution.get_version()}"]
+
+        if self.compiler.compiler_type != "msvc":
+            # Using Ninja-build since it a) is available as a wheel and b)
+            # multithreads automatically. MSVC would require all variables be
+            # exported for Ninja to pick it up, which is a little tricky to do.
+            # Users can override the generator with CMAKE_GENERATOR in CMake
+            # 3.15+.
+            if not cmake_generator or cmake_generator == "Ninja":
+                try:
+                    import ninja
+
+                    ninja_executable_path = Path(ninja.BIN_DIR) / "ninja"
+                    cmake_args += [
+                        "-GNinja",
+                        f"-DCMAKE_MAKE_PROGRAM:FILEPATH={ninja_executable_path}",
+                    ]
+                except ImportError:
+                    pass
+
+        else:
+            # Single config generators are handled "normally"
+            single_config = any(x in cmake_generator for x in {"NMake", "Ninja"})
+
+            # CMake allows an arch-in-generator style for backward compatibility
+            contains_arch = any(x in cmake_generator for x in {"ARM", "Win64"})
+
+            # Specify the arch if using MSVC generator, but only if it doesn't
+            # contain a backward-compatibility arch spec already in the
+            # generator name.
+            if not single_config and not contains_arch:
+                cmake_args += ["-A", PLAT_TO_CMAKE[self.plat_name]]
+
+            # Multi-config generators have a different way to specify configs
+            if not single_config:
+                cmake_args += [
+                    f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}"
+                ]
+                build_args += ["--config", cfg]
+
+        if sys.platform.startswith("darwin"):
+            # Cross-compile support for macOS - respect ARCHFLAGS if set
+            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
+            if archs:
+                cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
+
+        # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
+        # across all generators.
+        parallel = self.parallel if hasattr(self, "parallel") and self.parallel else "1"
+        parallel = os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", parallel)
+        # self.parallel is a Python 3 only way to set parallel jobs by hand
+        # using -j in the build_ext call, not supported by pip or PyPA-build.
+        build_args += [f"-j{parallel}"]
+        print(self.build_temp)
+        build_temp = Path(self.build_temp) / ext.name
+        if not build_temp.exists():
+            build_temp.mkdir(parents=True)
+
+        subprocess.run(
+            ["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True
+        )
+        subprocess.run(
+            ["cmake", "--build", ".", *build_args], cwd=build_temp, check=True
+        )
 
 
 def custom_command():
@@ -55,6 +222,16 @@ class CustomEggInfoCommand(egg_info):
         egg_info.run(self)
 
 
+cmdclass = {
+    "install": CustomInstallCommand,
+    "develop": CustomDevelopCommand,
+    "egg_info": CustomEggInfoCommand,
+}
+ext_modules = None
+if os.environ.get("EXECUTORCH_BUILD_PYBIND", None):
+    cmdclass["build_ext"] = CMakeBuild
+    ext_modules = [CMakeExtension("executorch.extension.pybindings.portable_lib")]
+
 setup(
     package_dir={
         "executorch/backends": "backends",
@@ -67,9 +244,6 @@ setup(
         "tosa": "backends/arm/third-party/serialization_lib/python/tosa",
         "serializer": "backends/arm/third-party/serialization_lib/python/serializer",
     },
-    cmdclass={
-        "install": CustomInstallCommand,
-        "develop": CustomDevelopCommand,
-        "egg_info": CustomEggInfoCommand,
-    },
+    cmdclass=cmdclass,
+    ext_modules=ext_modules,
 )


### PR DESCRIPTION
This adds a new CMake build option `EXECUTORCH_BUILD_PYBIND`. Under the hood it builds a pybind11 shared library that uses portable kernels, which exposes a series of APIs in Python. This helps ExecuTorch users to quickly experiment on Google Colab or some other notebook platforms.