### PR TITLE
Make the ExecutorchProfiler ctor explicit

### DIFF
--- a/runtime/platform/profiler.h
+++ b/runtime/platform/profiler.h
@@ -143,7 +143,7 @@ void profiling_create_block(const char* name);
 // object goes out of scope.
 class ExecutorchProfiler {
  public:
-  ExecutorchProfiler(const char* name);
+  explicit ExecutorchProfiler(const char* name);
 
   ~ExecutorchProfiler();
 


### PR DESCRIPTION
Summary: `ExecutorchProfiler::ExecutorchProfiler()` has a single parameter, so it should be marked `explicit`.

Differential Revision: D52717684


