### PR TITLE
Hide internal-only Method methods

### DIFF
--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -1267,10 +1267,6 @@ MethodMeta Method::method_meta() const {
   return method_meta.get();
 }
 
-size_t Method::values_size() const {
-  return n_value_;
-}
-
 const EValue& Method::get_value(size_t i) const {
   ET_CHECK_MSG(i < n_value_, "%zu >= %zu", i, n_value_);
   return values_[i];

--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -220,19 +220,12 @@ class Method final {
 
   EventTracer* get_event_tracer();
 
-  __ET_DEPRECATED size_t values_size() const;
-  __ET_DEPRECATED const EValue& get_value(size_t i) const;
-  __ET_DEPRECATED EValue& mutable_value(size_t i);
-  /// DEPRECATED: Use MethodMeta instead to access metadata, and set_input to
-  /// update Method inputs.
-  __ET_DEPRECATED size_t get_input_index(size_t i) const;
   /// DEPRECATED: Use MethodMeta instead to access metadata, and set_input to
   /// update Method inputs.
   __ET_DEPRECATED const EValue& get_input(size_t i) const;
   /// DEPRECATED: Use MethodMeta instead to access metadata, and set_input to
   /// update Method inputs.
   __ET_DEPRECATED EValue& mutable_input(size_t i);
-  __ET_DEPRECATED size_t get_output_index(size_t i) const;
   /// DEPRECATED: Use MethodMeta instead to access metadata, and get_output to
   /// retrieve Method outputs.
   __ET_DEPRECATED EValue& mutable_output(size_t i);
@@ -299,6 +292,11 @@ class Method final {
   inline bool initialized() const {
     return init_state_ == InitializationState::Initialized;
   }
+
+  const EValue& get_value(size_t i) const;
+  EValue& mutable_value(size_t i);
+  size_t get_input_index(size_t i) const;
+  size_t get_output_index(size_t i) const;
 
   // Executes a single instruction using the state in step_state_
   __ET_NODISCARD Error execute_instruction();

--- a/runtime/executor/test/method_test.cpp
+++ b/runtime/executor/test/method_test.cpp
@@ -99,40 +99,6 @@ TEST_F(MethodTest, MoveTest) {
   torch::executor::util::FreeInputs(inputs);
 }
 
-TEST_F(MethodTest, GetValueTests) {
-  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
-  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
-  ASSERT_EQ(method.error(), Error::Ok);
-
-  size_t num_values = method->values_size();
-  ASSERT_GT(num_values, 0);
-
-  // In-range values should succeed without aborting.
-  method->get_value(0);
-  method->get_value(num_values - 1);
-
-  // Out-of-range values should abort.
-  ET_EXPECT_DEATH(method->get_value(num_values), "");
-  ET_EXPECT_DEATH(method->get_value(num_values + 1), "");
-}
-
-TEST_F(MethodTest, MutableValueTests) {
-  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
-  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
-  ASSERT_EQ(method.error(), Error::Ok);
-
-  size_t num_values = method->values_size();
-  ASSERT_GT(num_values, 0);
-
-  // In-range values should succeed without aborting.
-  method->mutable_value(0);
-  method->mutable_value(num_values - 1);
-
-  // Out-of-range values should abort.
-  ET_EXPECT_DEATH(method->mutable_value(num_values), "");
-  ET_EXPECT_DEATH(method->mutable_value(num_values + 1), "");
-}
-
 TEST_F(MethodTest, GetInputTests) {
   ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
   Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
@@ -148,23 +114,6 @@ TEST_F(MethodTest, GetInputTests) {
   // Out-of-range inputs should abort.
   ET_EXPECT_DEATH(method->get_input(num_inputs), "");
   ET_EXPECT_DEATH(method->get_input(num_inputs + 1), "");
-}
-
-TEST_F(MethodTest, GetInputIndexTests) {
-  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
-  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
-  ASSERT_EQ(method.error(), Error::Ok);
-
-  size_t num_inputs = method->inputs_size();
-  ASSERT_GT(num_inputs, 0);
-
-  // In-range inputs should succeed without aborting.
-  method->get_input_index(0);
-  method->get_input_index(num_inputs - 1);
-
-  // Out-of-range inputs should abort.
-  ET_EXPECT_DEATH(method->get_input_index(num_inputs), "");
-  ET_EXPECT_DEATH(method->get_input_index(num_inputs + 1), "");
 }
 
 TEST_F(MethodTest, MutableInputTests) {
@@ -199,23 +148,6 @@ TEST_F(MethodTest, GetOutputTests) {
   // Out-of-range outputs should abort.
   ET_EXPECT_DEATH(method->get_output(num_outputs), "");
   ET_EXPECT_DEATH(method->get_output(num_outputs + 1), "");
-}
-
-TEST_F(MethodTest, GetOutputIndexTests) {
-  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
-  Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
-  ASSERT_EQ(method.error(), Error::Ok);
-
-  size_t num_outputs = method->outputs_size();
-  ASSERT_GT(num_outputs, 0);
-
-  // In-range outputs should succeed without aborting.
-  method->get_output_index(0);
-  method->get_output_index(num_outputs - 1);
-
-  // Out-of-range outputs should abort.
-  ET_EXPECT_DEATH(method->get_output_index(num_outputs), "");
-  ET_EXPECT_DEATH(method->get_output_index(num_outputs + 1), "");
 }
 
 TEST_F(MethodTest, MutableOutputTests) {


### PR DESCRIPTION
Summary:
No one should be messing with Method values or value indices directly. Make these methods private instead of deprecated.

Remove the unused `values_size()` because the internal code compares against `n_value_` directly.

Differential Revision: D52717552

