### PR TITLE
Enable export_llama to read LLama-style checkpoints created with fairseq2

### DIFF
--- a/examples/models/llama2/export_llama.py
+++ b/examples/models/llama2/export_llama.py
@@ -64,6 +64,9 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    with open(args.params, "r") as params_file:
+        params_json = json.load(params_file)
+
     model, example_inputs, _ = EagerModelFactory.create_model(
         "llama2",
         "Llama2Model",

--- a/examples/models/llama2/export_llama.py
+++ b/examples/models/llama2/export_llama.py
@@ -56,6 +56,7 @@ def main() -> None:
     parser.add_argument(
         "-p", "--params", default=ckpt_dir / "demo_config.json", help="config.json"
     )
+    parser.add_argument("-2", "--fairseq2", action="store_true")
 
     parser.add_argument("-2", "--fairseq2", action="store_true")
     parser.add_argument("-H", "--half", action="store_true")
@@ -73,6 +74,7 @@ def main() -> None:
         checkpoint=args.checkpoint,
         params=args.params,
         use_kv_cache=args.use_kv_cache,
+        fairseq2=args.fairseq2,
     )
 
     if args.use_kv_cache:

--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -493,6 +493,9 @@ class Llama2Model(EagerModelBase):
             use_kv_cache=self.use_kv_cache,
             **params,
         )
+        if kwargs.get("fairseq2", False):
+            print("Using fairseq2 checkpoint")
+            checkpoint = create_llama_checkpoint(checkpoint=checkpoint)
         self.model_ = Transformer(model_args)
 
         if "int8" in str(checkpoint_path):

--- a/examples/portable/utils.py
+++ b/examples/portable/utils.py
@@ -42,7 +42,7 @@ def _to_core_aten(
 
 def _core_aten_to_edge(
     core_aten_exir_ep: ExportedProgram,
-    edge_constant_methods=None,
+    edge_constant_methods: Optional[Dict[str, Any]] = None,
     edge_compile_config=None,
 ) -> EdgeProgramManager:
     if not edge_compile_config:


### PR DESCRIPTION
Summary: Enable export_llama to read LLama-style checkpoints created with fairseq2

Differential Revision: D52699573


