### PR TITLE
Update callsites to specify extract_constant_segments=False

### DIFF
--- a/backends/arm/test/arm_tosa_reference.py
+++ b/backends/arm/test/arm_tosa_reference.py
@@ -14,9 +14,9 @@ import numpy as np
 from executorch.backends.arm.arm_partitioner import ArmPartitioner
 from executorch.backends.arm.test.test_models import TestList, TosaProfile
 from executorch.backends.arm.test.test_tosa import prepare_model_and_ref
-from executorch.exir import to_edge
 
 from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.exir.capture._config import ExecutorchBackendConfig, to_edge
 
 from executorch.exir.dialects._ops import ops as exir_ops
 
@@ -185,7 +185,9 @@ def tosa_run_test(op, profile=TosaProfile.MI):  # noqa: C901
         ) = get_output_quantization_param(model_edge)
 
     model_edge = model_edge.to_backend(ArmPartitioner())
-    exec_prog = model_edge.to_executorch()
+    exec_prog = model_edge.to_executorch(
+        config=ExecutorchBackendConfig(extract_constant_segment=False)
+    )
 
     # Save ground truth results to file
     with open(TORCH_OUT_PATH + "/torch_output.npy", "wb") as f:

--- a/examples/apple/coreml/scripts/export_and_delegate.py
+++ b/examples/apple/coreml/scripts/export_and_delegate.py
@@ -56,7 +56,9 @@ def export_lowered_module_to_executorch_program(lowered_module, example_inputs):
     exec_prog = (
         exir.capture(lowered_module, example_inputs, _CAPTURE_CONFIG)
         .to_edge(_EDGE_COMPILE_CONFIG)
-        .to_executorch()
+        .to_executorch(
+            config=exir.ExecutorchBackendConfig(extract_constant_segment=False)
+        )
     )
 
     return exec_prog

--- a/examples/apple/mps/scripts/mps_example.py
+++ b/examples/apple/mps/scripts/mps_example.py
@@ -13,6 +13,7 @@ from executorch import exir
 from executorch.backends.apple.mps.mps_preprocess import MPSBackend
 
 from executorch.exir.backend.backend_api import to_backend
+from executorch.exir.capture._config import ExecutorchBackendConfig
 from executorch.sdk.bundled_program.config import MethodTestCase, MethodTestSuite
 from executorch.sdk.bundled_program.core import create_bundled_program
 from executorch.sdk.bundled_program.serialize import (
@@ -75,7 +76,7 @@ if __name__ == "__main__":
             exir.CaptureConfig(enable_aot=True, _unlift=True),
         )
         .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
-        .to_executorch()
+        .to_executorch(config=ExecutorchBackendConfig(extract_constant_segment=False))
     )
 
     model_name = f"{args.model_name}_mps"

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -14,7 +14,7 @@ import torch
 import torch._export as export
 
 from executorch.backends.arm.arm_partitioner import ArmPartitioner
-from executorch.exir import EdgeCompileConfig
+from executorch.exir import EdgeCompileConfig, ExecutorchBackendConfig
 
 from ..portable.utils import export_to_edge, save_pte_program
 
@@ -136,7 +136,9 @@ if __name__ == "__main__":
         edge = edge.to_backend(ArmPartitioner())
         logging.info(f"Lowered graph:\n{edge.exported_program().graph}")
 
-    exec_prog = edge.to_executorch()
+    exec_prog = edge.to_executorch(
+        config=ExecutorchBackendConfig(extract_constant_segment=False)
+    )
 
     model_name = f"{args.model_name}" + (
         "_arm_delegate" if args.delegate is True else ""

--- a/examples/portable/scripts/export.py
+++ b/examples/portable/scripts/export.py
@@ -9,7 +9,7 @@
 import argparse
 import logging
 
-from executorch.exir.capture import EdgeCompileConfig
+from executorch.exir.capture import EdgeCompileConfig, ExecutorchBackendConfig
 
 from ...models import MODEL_NAME_TO_MODEL
 from ...models.model_factory import EagerModelFactory
@@ -53,7 +53,9 @@ def main() -> None:
                 _check_ir_validity=False,
             ),
         )
-        prog = edge_manager.to_executorch()
+        prog = edge_manager.to_executorch(
+            config=ExecutorchBackendConfig(extract_constant_segment=False)
+        )
     else:
         prog = export_to_exec_prog(model, example_inputs, dynamic_shapes=dynamic_shapes)
     save_pte_program(prog.buffer, args.model_name, args.output_dir)

--- a/examples/portable/scripts/export_and_delegate.py
+++ b/examples/portable/scripts/export_and_delegate.py
@@ -16,6 +16,7 @@ from executorch.exir.backend.test.backend_with_compiler_demo import (
     BackendWithCompilerDemo,
 )
 from executorch.exir.backend.test.op_partitioner_demo import AddMulPartitionerDemo
+from executorch.exir.capture._config import ExecutorchBackendConfig
 
 from ...models import MODEL_NAME_TO_MODEL
 from ...models.model_factory import EagerModelFactory
@@ -94,7 +95,9 @@ def export_composite_module_with_lower_graph():
 
     logging.info(f"Lowered graph:\n{composited_edge.exported_program().graph}")
 
-    exec_prog = composited_edge.to_executorch()
+    exec_prog = composited_edge.to_executorch(
+        config=ExecutorchBackendConfig(extract_constant_segment=False)
+    )
     buffer = exec_prog.buffer
 
     model_name = "composite_model"
@@ -145,7 +148,9 @@ def export_and_lower_partitioned_graph():
     edge = edge.to_backend(AddMulPartitionerDemo())
     logging.info(f"Lowered graph:\n{edge.exported_program().graph}")
 
-    exec_prog = edge.to_executorch()
+    exec_prog = edge.to_executorch(
+        config=ExecutorchBackendConfig(extract_constant_segment=False)
+    )
     buffer = exec_prog.buffer
 
     model_name = "partition_lowered_model"

--- a/examples/qualcomm/scripts/export_example.py
+++ b/examples/qualcomm/scripts/export_example.py
@@ -15,6 +15,7 @@ from executorch.examples.models import MODEL_NAME_TO_MODEL
 from executorch.examples.models.model_factory import EagerModelFactory
 from executorch.examples.portable.utils import save_pte_program
 from executorch.exir.backend.backend_api import to_backend, validation_disabled
+from executorch.exir.capture._config import ExecutorchBackendConfig
 
 from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
 
@@ -70,5 +71,7 @@ if __name__ == "__main__":
             edge_program.exported_program, qnn_partitioner
         )
 
-    executorch_program = delegated_program.to_executorch()
+    executorch_program = delegated_program.to_executorch(
+        config=ExecutorchBackendConfig(extract_constant_segment=False)
+    )
     save_pte_program(executorch_program.buffer, args.model_name)

--- a/examples/qualcomm/scripts/utils.py
+++ b/examples/qualcomm/scripts/utils.py
@@ -24,6 +24,7 @@ from executorch.backends.qualcomm.utils.utils import (
     SoCModel,
 )
 from executorch.exir.backend.backend_api import to_backend
+from executorch.exir.capture._config import ExecutorchBackendConfig
 from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
 
 
@@ -178,7 +179,9 @@ def build_executorch_binary(
     )
     edge_prog.exported_program = to_backend(edge_prog.exported_program, qnn_partitioner)
     edge_prog.exported_program.graph_module.graph.print_tabular()
-    exec_prog = edge_prog.to_executorch()
+    exec_prog = edge_prog.to_executorch(
+        config=ExecutorchBackendConfig(extract_constant_segment=False)
+    )
     with open(f"{file_name}.pte", "wb") as file:
         file.write(exec_prog.buffer)
 

--- a/examples/sdk/scripts/gen_sample_etrecord.py
+++ b/examples/sdk/scripts/gen_sample_etrecord.py
@@ -17,6 +17,7 @@ from executorch.exir import (
     ExportedProgram,
     to_edge,
 )
+from executorch.exir.capture._config import ExecutorchBackendConfig
 from executorch.sdk import generate_etrecord
 from torch.export import export
 
@@ -37,7 +38,9 @@ def gen_etrecord(model: torch.nn.Module, inputs: Any, output_path=None):
         aten_dialect, compile_config=EdgeCompileConfig(_check_ir_validity=True)
     )
     edge_program_copy = copy.deepcopy(edge_program)
-    et_program: ExecutorchProgramManager = edge_program_copy.to_executorch()
+    et_program: ExecutorchProgramManager = edge_program_copy.to_executorch(
+        config=ExecutorchBackendConfig(extract_constant_segment=False)
+    )
     generate_etrecord(
         (DEFAULT_OUTPUT_PATH if not output_path else output_path),
         edge_dialect_program=edge_program,

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -12,7 +12,7 @@ import logging
 import torch._export as export
 
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
-from executorch.exir import EdgeCompileConfig
+from executorch.exir import EdgeCompileConfig, ExecutorchBackendConfig
 
 from ..models import MODEL_NAME_TO_MODEL
 from ..models.model_factory import EagerModelFactory
@@ -90,7 +90,9 @@ if __name__ == "__main__":
     edge = edge.to_backend(XnnpackPartitioner())
     logging.info(f"Lowered graph:\n{edge.exported_program().graph}")
 
-    exec_prog = edge.to_executorch()
+    exec_prog = edge.to_executorch(
+        config=ExecutorchBackendConfig(extract_constant_segment=False)
+    )
 
     quant_tag = "q8" if args.quantize else "fp32"
     model_name = f"{args.model_name}_xnnpack_{quant_tag}"

--- a/examples/xnnpack/quantization/example.py
+++ b/examples/xnnpack/quantization/example.py
@@ -12,6 +12,7 @@ import time
 import torch
 import torch._export as export
 from executorch.exir import EdgeCompileConfig
+from executorch.exir.capture._config import ExecutorchBackendConfig
 from torch.ao.ns.fx.utils import compute_sqnr
 from torch.ao.quantization import (  # @manual
     default_per_channel_symmetric_qnnpack_qconfig,
@@ -190,7 +191,9 @@ def main() -> None:
     logging.info(f"Export time: {end - start}s")
 
     start = time.perf_counter()
-    prog = edge_m.to_executorch(None)
+    prog = edge_m.to_executorch(
+        config=ExecutorchBackendConfig(extract_constant_segment=False)
+    )
     save_pte_program(prog.buffer, f"{args.model_name}_quantized")
     end = time.perf_counter()
     logging.info(f"Save time: {end - start}s")

--- a/examples/xtensa/aot/export_example.py
+++ b/examples/xtensa/aot/export_example.py
@@ -11,7 +11,7 @@ import logging
 from .meta_registrations import *  # noqa
 
 import torch
-from executorch.exir import EdgeCompileConfig
+from executorch.exir import EdgeCompileConfig, ExecutorchBackendConfig
 from torch._export import capture_pre_autograd_graph
 from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
 
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         .transform(
             [ReplacePT2QuantWithXtensaQuant(), ReplacePT2DequantWithXtensaDequant()]
         )
-        .to_executorch()
+        .to_executorch(config=ExecutorchBackendConfig(extract_constant_segment=False))
     )
 
     logging.info(f"Final exported graph:\n{exec_prog.exported_program().graph}")

--- a/test/models/generate_linear_out_bundled_program.py
+++ b/test/models/generate_linear_out_bundled_program.py
@@ -20,6 +20,7 @@ import executorch.exir as exir
 
 import torch
 from executorch.exir import ExecutorchBackendConfig
+
 from executorch.exir.passes import MemoryPlanningPass, ToOutVarPass
 from executorch.exir.print_program import pretty_print
 from executorch.sdk.bundled_program.config import MethodTestCase, MethodTestSuite


### PR DESCRIPTION
Summary:
Updated all external callsites, and executorch/examples.

Did not update tests within executorch/ (these should work with `extract_constant_segment=True`)

To prepare for D52451128, which sets `extract_constant_segment=True` by default.

Reviewed By: larryliu0820

Differential Revision: D52613715


