### PR TITLE
remove directly access to internal schema-type bp

### DIFF
--- a/sdk/bundled_program/serialize/__init__.py
+++ b/sdk/bundled_program/serialize/__init__.py
@@ -34,8 +34,10 @@ def write_schema(d: str, schema_name: str) -> None:
         )
 
 
-def serialize_from_bundled_program_to_json(bundled_program: BundledProgram) -> str:
-    return json.dumps(bundled_program._bundled_program, cls=_DataclassEncoder)
+def serialize_from_bundled_program_to_json(
+    bundled_program: bp_schema.BundledProgram,
+) -> str:
+    return json.dumps(bundled_program, cls=_DataclassEncoder)
 
 
 def deserialize_from_json_to_bundled_program(
@@ -90,8 +92,10 @@ def serialize_from_bundled_program_to_flatbuffer(
         The serialized FlatBuffer binary data in bytes.
     """
 
+    bundled_program_in_schema = bundled_program.serialize_to_schema()
+
     return convert_to_flatbuffer(
-        serialize_from_bundled_program_to_json(bundled_program)
+        serialize_from_bundled_program_to_json(bundled_program_in_schema)
     )
 
 

--- a/sdk/bundled_program/serialize/test/test_serialize.py
+++ b/sdk/bundled_program/serialize/test/test_serialize.py
@@ -29,7 +29,7 @@ class TestSerialize(unittest.TestCase):
             deserialize_from_flatbuffer_to_bundled_program(flat_buffer_bundled_program)
         )
         self.assertEqual(
-            bundled_program._bundled_program,
+            bundled_program.serialize_to_schema(),
             regenerate_bundled_program_in_schema,
             "Regenerated bundled program mismatches original one",
         )

--- a/sdk/bundled_program/test/test_bundle_data.py
+++ b/sdk/bundled_program/test/test_bundle_data.py
@@ -48,9 +48,9 @@ class TestBundle(unittest.TestCase):
         method_test_suites = sorted(method_test_suites, key=lambda t: t.method_name)
 
         for plan_id in range(len(executorch_program.executorch_program.execution_plan)):
-            bundled_plan_test = bundled_program._bundled_program.method_test_suites[
-                plan_id
-            ]
+            bundled_plan_test = (
+                bundled_program.serialize_to_schema().method_test_suites[plan_id]
+            )
             method_test_suite = method_test_suites[plan_id]
 
             self.assertEqual(
@@ -68,7 +68,7 @@ class TestBundle(unittest.TestCase):
                 )
 
         self.assertEqual(
-            bundled_program._bundled_program.program,
+            bundled_program.serialize_to_schema().program,
             _serialize_pte_binary(executorch_program.executorch_program),
         )
 


### PR DESCRIPTION
Summary:
We have to bundled program class: one is under `bundled_program/core.py`, focusing on user interactive; the other is under `bundled_program/schema/bundled_program_schema.py`, is used for serialization, and we do not want to user to directly changing or updating it. 

Currently, we put the schema-type BP as a private 
member:
```
dataclass
class BundledProgram:
   ...
    _bundled_program: bp_schema.BundledProgram
```

And when we want to get it, we use:

```
bp = BundledProgram(...)

# Get the schema-type BP
... = bp.__bundled_program
```

However it has two drawbacks:
1. Confusing structure. Another `bundled_program` in BundledProgram class is pretty confusing.  
2. Directly get internal member variable outside. 

This diff creates a specific member function to serialized BundledProgram into its  schema-type, to avoid the confusing naming and  private member access outside.

Differential Revision: D52754026


