### PR TITLE
Fail when trying to resize DYNAMIC_UNBOUND tensors past their capacity

### DIFF
--- a/runtime/core/exec_aten/testing_util/test/tensor_factory_test.cpp
+++ b/runtime/core/exec_aten/testing_util/test/tensor_factory_test.cpp
@@ -65,7 +65,13 @@ void resize_tensor_to_assert_dynamic_unbound(Tensor&& t) {
   ASSERT_LT(t.numel(), 100 * 100)
       << "Need to resize to an 100x100 tensor, so the input size should be < 10000";
   EXPECT_EQ(resize_tensor(t, ArrayRef<SizesType>({1, 1})), Error::Ok);
+
+#ifdef USE_ATEN_LIB
   EXPECT_EQ(resize_tensor(t, ArrayRef<SizesType>({100, 100})), Error::Ok);
+#else
+  // TODO(T175194371): For now, we can't resize past the original capacity.
+  EXPECT_NE(resize_tensor(t, ArrayRef<SizesType>({100, 100})), Error::Ok);
+#endif
 }
 
 #ifndef USE_ATEN_LIB

--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -144,13 +144,17 @@ Error TensorImpl::internal_resize_contiguous(ArrayRef<SizesType> new_sizes) {
   auto new_numel = compute_numel(new_sizes.data(), dim_);
 
   // Upper bounded tensors can be reshaped but not beyond upper bound
-  if (shape_dynamism_ == TensorShapeDynamism::DYNAMIC_BOUND) {
+  if (shape_dynamism_ == TensorShapeDynamism::DYNAMIC_BOUND ||
+      // TODO(T175194371): Unbounded tensor resizing is not yet supported: treat
+      // them as upper-bounded.
+      shape_dynamism_ == TensorShapeDynamism::DYNAMIC_UNBOUND) {
     auto new_nbytes = new_numel * elementSize(type_);
     ET_CHECK_OR_RETURN_ERROR(
         new_nbytes <= capacity_,
         NotSupported,
-        "Attempted to resize an upper bounded tensor "
+        "Attempted to resize a tensor with dynamism %d "
         "to %zu which is beyond its capacity %zu",
+        (int)shape_dynamism_,
         new_nbytes,
         capacity_);
   }

--- a/runtime/core/portable_type/test/targets.bzl
+++ b/runtime/core/portable_type/test/targets.bzl
@@ -34,6 +34,7 @@ def define_common_targets():
         name = "tensor_impl_test",
         srcs = ["tensor_impl_test.cpp"],
         deps = [
+            "//executorch/runtime/core/exec_aten/util:tensor_util",
             "//executorch/runtime/core/portable_type:portable_type",
         ],
     )

--- a/runtime/executor/tensor_parser_portable.cpp
+++ b/runtime/executor/tensor_parser_portable.cpp
@@ -48,12 +48,12 @@ Result<torch::executor::Tensor> parseTensor(
 
   TensorShapeDynamism dynamism =
       static_cast<TensorShapeDynamism>(s_tensor->shape_dynamism());
-  // TODO(T133200526): Remove this check once fully dynamic shapes are
+  // TODO(T175194371): Remove this check once fully dynamic shapes are
   // supported.
   ET_CHECK_OR_RETURN_ERROR(
       dynamism != TensorShapeDynamism::DYNAMIC_UNBOUND,
       NotSupported,
-      "Fully dynamic tensor shapes not yet supported: T133200526");
+      "Fully dynamic tensor shapes not yet supported: T175194371");
 
   ET_CHECK_OR_RETURN_ERROR(
       s_tensor->sizes() != nullptr, InvalidProgram, "Missing sizes field");


### PR DESCRIPTION
Summary:
We don't yet support arbitrary resizing of DYNAMIC_UNBOUND tensors in lean mode. Make sure we check for this case, otherwise the resize operation will appear to succeed, and callers can overrun the buffer.

While I was working on this the linter yelled at me about `set_sizes_contiguous()` being deprecated, so also update `tensor_impl_test.cpp` to use the non-deprecated `resize_tensor_impl()`, which has the extra benefit of not failing fatally.

Differential Revision: D52809543


