### PR TITLE
Fix failing doc build on CI due to sphinx version

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -15,7 +15,7 @@ hypothesis==6.84.2
 parameterized==0.9.0
 
 # Doc build requirements
-sphinx==5.5.0
+sphinx==5.0.0
 sphinx-gallery
 breathe==4.35.0
 exhale==0.3.6

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -20,7 +20,7 @@ sphinx-gallery==0.14.0
 breathe==4.34.0
 exhale==0.2.3
 docutils==0.16
-matplotlib==3.5.3
+matplotlib==3.7.2
 # PyTorch Theme
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 myst-parser==0.18.1

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -15,7 +15,7 @@ hypothesis==6.84.2
 parameterized==0.9.0
 
 # Doc build requirements
-sphinx==4.5.0
+sphinx==5.5.0
 sphinx-gallery
 breathe==4.35.0
 exhale==0.3.6

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -14,15 +14,15 @@ expecttest==0.1.6
 hypothesis==6.84.2
 parameterized==0.9.0
 
-# Doc build requirements
-sphinx==5.0.0
-sphinx-gallery
-breathe==4.35.0
-exhale==0.3.6
+# Doc build requirements, same as https://github.com/pytorch/pytorch/blob/main/.ci/docker/requirements-docs.txt
+sphinx==5.3.0
+sphinx-gallery==0.14.0
+breathe==4.34.0
+exhale==0.2.3
 docutils==0.16
-matplotlib
+matplotlib==3.5.3
 # PyTorch Theme
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
-myst-parser
-sphinx_design
-sphinx-copybutton
+myst-parser==0.18.1
+sphinx_design==0.4.1
+sphinx-copybutton==0.5.0


### PR DESCRIPTION
By pinning all doc build dependencies like https://github.com/pytorch/pytorch/blob/main/.ci/docker/requirements-docs.txt