### PR TITLE
make bundled program as an integrate class

### DIFF
--- a/backends/apple/mps/test/test_mps.py
+++ b/backends/apple/mps/test/test_mps.py
@@ -39,7 +39,7 @@ from executorch.exir.tests.models import (
 )
 
 from executorch.sdk.bundled_program.config import MethodTestCase, MethodTestSuite
-from executorch.sdk.bundled_program.core import create_bundled_program
+from executorch.sdk import BundledProgram
 from executorch.sdk.bundled_program.serialize import (
     serialize_from_bundled_program_to_flatbuffer,
 )
@@ -141,7 +141,7 @@ def run_model(
 
     logging.info("  -> Test suites generated successfully")
 
-    bundled_program = create_bundled_program(executorch_program, method_test_suites)
+    bundled_program = BundledProgram(executorch_program, method_test_suites)
     logging.info("  -> Bundled program generated successfully")
 
     bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(

--- a/backends/apple/mps/test/test_mps_utils.py
+++ b/backends/apple/mps/test/test_mps_utils.py
@@ -17,7 +17,7 @@ from executorch.exir.backend.backend_api import to_backend, validation_disabled
 
 from executorch.exir.print_program import print_program
 from executorch.sdk.bundled_program.config import MethodTestCase, MethodTestSuite
-from executorch.sdk.bundled_program.core import create_bundled_program
+from executorch.sdk import BundledProgram
 from executorch.sdk.bundled_program.serialize import (
     serialize_from_bundled_program_to_flatbuffer,
 )
@@ -203,7 +203,7 @@ class TestMPS(unittest.TestCase):
 
         logging.info("  -> Test suites generated successfully")
 
-        bundled_program = create_bundled_program(executorch_program, method_test_suites)
+        bundled_program = BundledProgram(executorch_program, method_test_suites)
         bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
             bundled_program
         )

--- a/backends/xnnpack/test/TARGETS
+++ b/backends/xnnpack/test/TARGETS
@@ -36,8 +36,8 @@ runtime.python_test(
     deps = [
         "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
         "//executorch/backends/xnnpack/test/tester:tester",
+        "//executorch/sdk:lib",
         "//executorch/sdk/bundled_program:config",
-        "//executorch/sdk/bundled_program:core",
         "//executorch/sdk/bundled_program/serialize:lib",
     ],
     external_deps = [

--- a/backends/xnnpack/test/test_xnnpack_utils.py
+++ b/backends/xnnpack/test/test_xnnpack_utils.py
@@ -34,9 +34,9 @@ from executorch.extension.pybindings.portable_lib import (  # @manual
     _load_for_executorch_from_buffer,
 )
 from executorch.extension.pytree import tree_flatten
+from executorch.sdk import BundledProgram
 
 from executorch.sdk.bundled_program.config import MethodTestCase, MethodTestSuite
-from executorch.sdk.bundled_program.core import create_bundled_program
 from executorch.sdk.bundled_program.serialize import (
     serialize_from_bundled_program_to_flatbuffer,
 )
@@ -118,7 +118,7 @@ def save_bundled_program(
     ]
 
     print("creating bundled program...")
-    bundled_program = create_bundled_program(executorch_program, method_test_suites)
+    bundled_program = BundledProgram(executorch_program, method_test_suites)
 
     print("serializing bundled program...")
     bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(

--- a/docs/source/tutorials_source/sdk-integration-tutorial.py
+++ b/docs/source/tutorials_source/sdk-integration-tutorial.py
@@ -131,9 +131,9 @@ from unittest.mock import patch
 import torch
 
 from executorch.exir import to_edge
+from executorch.sdk import BundledProgram
 
 from executorch.sdk.bundled_program.config import MethodTestCase, MethodTestSuite
-from executorch.sdk.bundled_program.core import create_bundled_program
 from executorch.sdk.bundled_program.serialize import (
     serialize_from_bundled_program_to_flatbuffer,
 )
@@ -158,7 +158,7 @@ method_test_suites = [
 
 # Step 3: Generate BundledProgram
 executorch_program = to_edge(method_graphs).to_executorch()
-bundled_program = create_bundled_program(executorch_program, method_test_suites)
+bundled_program = BundledProgram(executorch_program, method_test_suites)
 
 # Step 4: Serialize BundledProgram to flatbuffer.
 serialized_bundled_program = serialize_from_bundled_program_to_flatbuffer(

--- a/examples/apple/mps/scripts/mps_example.py
+++ b/examples/apple/mps/scripts/mps_example.py
@@ -15,7 +15,7 @@ from executorch.backends.apple.mps.mps_preprocess import MPSBackend
 from executorch.exir.backend.backend_api import to_backend
 from executorch.exir.capture._config import ExecutorchBackendConfig
 from executorch.sdk.bundled_program.config import MethodTestCase, MethodTestSuite
-from executorch.sdk.bundled_program.core import create_bundled_program
+from executorch.sdk import BundledProgram
 from executorch.sdk.bundled_program.serialize import (
     serialize_from_bundled_program_to_flatbuffer,
 )
@@ -93,7 +93,7 @@ if __name__ == "__main__":
             )
         ]
 
-        bundled_program = create_bundled_program(executorch_program, method_test_suites)
+        bundled_program = BundledProgram(executorch_program, method_test_suites)
         bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
             bundled_program
         )

--- a/examples/sdk/scripts/export_bundled_program.py
+++ b/examples/sdk/scripts/export_bundled_program.py
@@ -17,12 +17,12 @@ from executorch.exir import (
     ExecutorchProgramManager,
     MultiMethodExecutorchProgram,
 )
+from executorch.sdk import BundledProgram
 from executorch.sdk.bundled_program.config import (
     MethodInputType,
     MethodTestCase,
     MethodTestSuite,
 )
-from executorch.sdk.bundled_program.core import create_bundled_program
 from executorch.sdk.bundled_program.serialize import (
     serialize_from_bundled_program_to_flatbuffer,
 )
@@ -50,7 +50,7 @@ def save_bundled_program(
         output_path: Path to save the bundled program.
     """
 
-    bundled_program = create_bundled_program(executorch_program, method_test_suites)
+    bundled_program = BundledProgram(executorch_program, method_test_suites)
     bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
         bundled_program
     )

--- a/exir/_serialize/TARGETS
+++ b/exir/_serialize/TARGETS
@@ -51,7 +51,7 @@ runtime.python_library(
         "//executorch/extension/pybindings/test:test",
         "//executorch/extension/pybindings/test:test-library",
         "//executorch/profiler/...",
-        "//executorch/sdk/bundled_program:core",
+        "//executorch/sdk:lib",
         "//executorch/sdk/bundled_program/serialize:lib",
         "//executorch/sdk/bundled_program/tests/...",
         "//executorch/sdk/experimental/...",

--- a/sdk/TARGETS
+++ b/sdk/TARGETS
@@ -6,6 +6,7 @@ python_library(
     name = "lib",
     srcs = ["__init__.py"],
     deps = [
+        "//executorch/sdk/bundled_program:core",
         "//executorch/sdk/etrecord:etrecord",
         "//executorch/sdk/inspector:lib",
     ],

--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -5,7 +5,15 @@
 # LICENSE file in the root directory of this source tree.
 
 import executorch.sdk.inspector as inspector
+from executorch.sdk.bundled_program.core import BundledProgram
 from executorch.sdk.etrecord import ETRecord, generate_etrecord, parse_etrecord
 from executorch.sdk.inspector import Inspector
 
-__all__ = ["ETRecord", "Inspector", "generate_etrecord", "parse_etrecord", "inspector"]
+__all__ = [
+    "ETRecord",
+    "Inspector",
+    "generate_etrecord",
+    "parse_etrecord",
+    "inspector",
+    "BundledProgram",
+]

--- a/sdk/bundled_program/core.py
+++ b/sdk/bundled_program/core.py
@@ -6,7 +6,6 @@
 
 import ctypes
 import typing
-from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Type, Union
 
 import executorch.exir.schema as core_schema
@@ -36,11 +35,8 @@ supported_program_type_table: Dict[Type[core_schema.KernelTypes], ConfigValue] =
 }
 
 
-@dataclass
 class BundledProgram:
     """
-    User should not create an instance of BundledProgram directly. Instead, use `create_bundled_program` API.
-
     Bundled program contains all information needed to execute and verify the program on device.
 
     Public Attributes:
@@ -49,16 +45,31 @@ class BundledProgram:
                             ExecutorchProgram, MultiMethodExecutorchProgram or ExecutorchProgramManager.
     """
 
-    executorch_program: Union[
-        ExecutorchProgram,
-        MultiMethodExecutorchProgram,
-        ExecutorchProgramManager,
-    ]
-    method_test_suites: Sequence[MethodTestSuite]
+    def __init__(
+        self,
+        executorch_program: Union[
+            ExecutorchProgram,
+            MultiMethodExecutorchProgram,
+            ExecutorchProgramManager,
+        ],
+        method_test_suites: Sequence[MethodTestSuite],
+    ):
+        """Create BundledProgram by bundling the given program and method_test_suites together.
 
-    # This is the cache for bundled program in schema type.
-    # User should not access this field directly. Please Use `serialize_to_schema` function instead.
-    _bundled_program_in_schema: Optional[bp_schema.BundledProgram] = None
+        Args:
+            executorch_program: The program to be bundled.
+            method_test_suites: The testcases for certain methods to be bundled.
+        """
+
+        method_test_suites = sorted(method_test_suites, key=lambda x: x.method_name)
+        self._assert_valid_bundle(executorch_program, method_test_suites)
+
+        self.executorch_program = executorch_program
+        self.method_test_suites = method_test_suites
+
+        # This is the cache for bundled program in schema type.
+        # User should not access this field directly. Please Use `serialize_to_schema` function instead.
+        self._bundled_program_in_schema: Optional[bp_schema.BundledProgram] = None
 
     def serialize_to_schema(self) -> bp_schema.BundledProgram:
         """Serialize the current Bundled Program into its schema format for further serialization.."""
@@ -66,7 +77,7 @@ class BundledProgram:
         if self._bundled_program_in_schema is not None:
             return self._bundled_program_in_schema
 
-        program = extract_program(self.executorch_program)
+        program = self._extract_program(self.executorch_program)
         bundled_method_test_suites: List[bp_schema.BundledMethodTestSuite] = []
 
         # Emit data and metadata of bundled tensor
@@ -85,12 +96,12 @@ class BundledProgram:
 
                 for input_val in cur_plan_test_inputs:
                     if type(input_val) is torch.Tensor:
-                        emit_bundled_tensor(
+                        self._emit_bundled_tensor(
                             TensorSpec.from_tensor(input_val, const=True),
                             inputs,
                         )
                     else:
-                        emit_prim(
+                        self._emit_prim(
                             input_val,
                             inputs,
                         )
@@ -98,7 +109,7 @@ class BundledProgram:
                     assert (
                         type(expected_output_tensor) is torch.Tensor
                     ), "Only tensor outputs are currently supported."
-                    emit_bundled_tensor(
+                    self._emit_bundled_tensor(
                         TensorSpec.from_tensor(expected_output_tensor, const=True),
                         expected_outputs,
                     )
@@ -124,274 +135,249 @@ class BundledProgram:
         )
         return self._bundled_program_in_schema
 
+    def _emit_bundled_tensor(
+        self, spec: TensorSpec, bundled_values: List[bp_schema.Value]
+    ) -> None:
+        # QuantizedSchema in tensor has deprecated and may not be used anymore.
+        # So here we don't emit it.
 
-def emit_bundled_tensor(
-    spec: TensorSpec, bundled_values: List[bp_schema.Value]
-) -> None:
-    # QuantizedSchema in tensor has deprecated and may not be used anymore.
-    # So here we don't emit it.
-
-    if spec.allocated_memory == 0:
-        tensor_data: bytes = b""
-    else:
-        array_type = (
-            ctypes.c_char * typing.cast(torch.UntypedStorage, spec.storage).nbytes()
-        )
-        spec_array = ctypes.cast(
-            typing.cast(torch.UntypedStorage, spec.storage).data_ptr(),
-            ctypes.POINTER(array_type),
-        ).contents
-        tensor_data: bytes = bytes(spec_array)
-
-    bundled_values.append(
-        bp_schema.Value(
-            val=bp_schema.Tensor(
-                scalar_type=scalar_type_enum(spec.dtype),
-                sizes=spec.shape,
-                data=tensor_data,
-                dim_order=list(spec.dim_order),
-            ),
-        )
-    )
-
-
-def emit_prim(val: ConfigValue, bundled_values: List[bp_schema.Value]):
-    if type(val) is int:
-        bundled_values.append(bp_schema.Value(val=bp_schema.Int(int_val=val)))
-    elif type(val) is bool:
-        bundled_values.append(bp_schema.Value(val=bp_schema.Bool(bool_val=val)))
-    elif type(val) is float:
-        bundled_values.append(bp_schema.Value(val=bp_schema.Double(double_val=val)))
-    else:
-        assert 0, "Unsupported primitive type received."
-
-
-def get_program_input(
-    program: core_schema.Program, plan_idx: int, input_idx: int
-) -> core_schema.KernelTypes:
-    return (
-        program.execution_plan[plan_idx]
-        .values[program.execution_plan[plan_idx].inputs[input_idx]]
-        .val
-    )
-
-
-def get_program_output(
-    program: core_schema.Program, plan_idx: int, output_idx: int
-) -> core_schema.KernelTypes:
-    return (
-        program.execution_plan[plan_idx]
-        .values[program.execution_plan[plan_idx].outputs[output_idx]]
-        .val
-    )
-
-
-def get_input_dtype(
-    program: core_schema.Program, plan_idx: int, input_idx: int
-) -> torch.dtype:
-    # pyre-fixme[16]: now assert all input and outputs is in tenor type. Support multuple datatypes in the future.
-    return get_scalar_type(get_program_input(program, plan_idx, input_idx).scalar_type)
-
-
-def get_input_type(program: core_schema.Program, plan_idx: int, input_idx: int) -> type:
-    type_lookup = {
-        core_schema.Int: int,
-        core_schema.Bool: bool,
-        core_schema.Double: float,
-    }
-    # pyre-fixme[6]: Incompatible parameter type [6]: In call `dict.__getitem__`, for 1st positional only parameter
-    # expected `Type[Union[core_schema.Bool, core_schema.Double, core_schema.Int]]` but got `Type[Union[core_schema.Bool, core_schema.Double, core_schema.Int, core_schema.Tensor, BoolList, DoubleList,
-    # IntList, Null, OptionalTensorList, String, TensorList]]`.
-    return type_lookup[type(get_program_input(program, plan_idx, input_idx))]
-
-
-def get_output_dtype(
-    program: core_schema.Program, plan_idx: int, output_idx: int
-) -> torch.dtype:
-    return get_scalar_type(
-        # pyre-ignore[16]: now assert all outputs is in tensor type.
-        get_program_output(program, plan_idx, output_idx).scalar_type
-    )
-
-
-def assert_valid_bundle(
-    program: core_schema.Program,
-    method_test_suites: Sequence[MethodTestSuite],
-) -> None:
-    """Check if the program and method_test_suites matches each other.
-
-    Other checks not related to correspondence are done in config.py
-
-    Args:
-        program: The program to be bundled.
-        method_test_suites: The testcases for specific methods to be bundled.
-
-    """
-
-    method_name_of_program = {e.name for e in program.execution_plan}
-    method_name_of_test_suites = {t.method_name for t in method_test_suites}
-
-    assert method_name_of_test_suites.issubset(
-        method_name_of_program
-    ), f"All method names in bundled config should be found in program.execution_plan, \
-         but {str(method_name_of_test_suites - method_name_of_program)} does not include."
-
-    # check if method_test_suites has been sorted in ascending alphabetical order of method name.
-    for test_suite_id in range(1, len(method_test_suites)):
-        assert (
-            method_test_suites[test_suite_id - 1].method_name
-            <= method_test_suites[test_suite_id].method_name
-        ), f"The method name of test suite should be sorted in ascending alphabetical \
-            order of method name, but {test_suite_id-1}-th and {test_suite_id}-th method_test_suite aren't."
-
-    # Check if the inputs' type meet Program's requirement
-    for method_test_suite in method_test_suites:
-
-        # Get the method with same method name as method_test_suite
-        program_plan_id = -1
-        for plan in program.execution_plan:
-            if plan.name == method_test_suite.method_name:
-                program_plan_id = program.execution_plan.index(plan)
-                break
-
-        # Raise Assertion Error if can not find the method with same method_name as method_test_suite in program.
-        assert (
-            program_plan_id != -1
-        ), f"method_test_suites has testcases for method {method_test_suite.method_name}, but can not find it in the given program. All method names in the program are {', '.join([p.name for p in program.execution_plan])}."
-
-        plan = program.execution_plan[program_plan_id]
-
-        # Check if the type of Program's input is supported
-        for index in range(len(plan.inputs)):
-            assert (
-                type(get_program_input(program, program_plan_id, index))
-                in supported_program_type_table
-            ), "The type of program's input isn't supported."
-
-        # Check if the type of Program's output is supported
-        for index in range(len(plan.outputs)):
-            assert (
-                type(get_program_output(program, program_plan_id, index))
-                == core_schema.Tensor
-            ), "Only supports program with output in Tensor type."
-
-        # Check if the I/O sets of each execution plan test match program's requirement.
-        for i in range(len(method_test_suite.test_cases)):
-            cur_plan_test_inputs = method_test_suite.test_cases[i].inputs
-            cur_plan_test_expected_outputs = method_test_suite.test_cases[
-                i
-            ].expected_outputs
-
-            assert len(plan.inputs) == len(
-                cur_plan_test_inputs
-            ), "The number of input in each bundled set and Program shall equal, but get {} and {}".format(
-                len(plan.inputs),
-                len(cur_plan_test_inputs),
+        if spec.allocated_memory == 0:
+            tensor_data: bytes = b""
+        else:
+            array_type = (
+                ctypes.c_char * typing.cast(torch.UntypedStorage, spec.storage).nbytes()
             )
+            spec_array = ctypes.cast(
+                typing.cast(torch.UntypedStorage, spec.storage).data_ptr(),
+                ctypes.POINTER(array_type),
+            ).contents
+            tensor_data: bytes = bytes(spec_array)
 
-            # Check if bundled input in the current exeution plan test share same type as input in Program
-            for j in range(len(cur_plan_test_inputs)):
+        bundled_values.append(
+            bp_schema.Value(
+                val=bp_schema.Tensor(
+                    scalar_type=scalar_type_enum(spec.dtype),
+                    sizes=spec.shape,
+                    data=tensor_data,
+                    dim_order=list(spec.dim_order),
+                ),
+            )
+        )
+
+    def _emit_prim(self, val: ConfigValue, bundled_values: List[bp_schema.Value]):
+        if type(val) is int:
+            bundled_values.append(bp_schema.Value(val=bp_schema.Int(int_val=val)))
+        elif type(val) is bool:
+            bundled_values.append(bp_schema.Value(val=bp_schema.Bool(bool_val=val)))
+        elif type(val) is float:
+            bundled_values.append(bp_schema.Value(val=bp_schema.Double(double_val=val)))
+        else:
+            assert 0, "Unsupported primitive type received."
+
+    def _get_program_input(
+        self, program: core_schema.Program, plan_idx: int, input_idx: int
+    ) -> core_schema.KernelTypes:
+        return (
+            program.execution_plan[plan_idx]
+            .values[program.execution_plan[plan_idx].inputs[input_idx]]
+            .val
+        )
+
+    def _get_program_output(
+        self, program: core_schema.Program, plan_idx: int, output_idx: int
+    ) -> core_schema.KernelTypes:
+        return (
+            program.execution_plan[plan_idx]
+            .values[program.execution_plan[plan_idx].outputs[output_idx]]
+            .val
+        )
+
+    def _get_input_dtype(
+        self, program: core_schema.Program, plan_idx: int, input_idx: int
+    ) -> torch.dtype:
+        return get_scalar_type(
+            # pyre-fixme[16]: now assert all input and outputs is in tenor type. Support multuple datatypes in the future.
+            self._get_program_input(program, plan_idx, input_idx).scalar_type
+        )
+
+    def _get_input_type(
+        self, program: core_schema.Program, plan_idx: int, input_idx: int
+    ) -> type:
+        type_lookup = {
+            core_schema.Int: int,
+            core_schema.Bool: bool,
+            core_schema.Double: float,
+        }
+        # pyre-fixme[6]: Incompatible parameter type [6]: In call `dict.__getitem__`, for 1st positional only parameter
+        # expected `Type[Union[core_schema.Bool, core_schema.Double, core_schema.Int]]` but got `Type[Union[core_schema.Bool, core_schema.Double, core_schema.Int, core_schema.Tensor, BoolList, DoubleList,
+        # IntList, Null, OptionalTensorList, String, TensorList]]`.
+        return type_lookup[type(self._get_program_input(program, plan_idx, input_idx))]
+
+    def _get_output_dtype(
+        self, program: core_schema.Program, plan_idx: int, output_idx: int
+    ) -> torch.dtype:
+        return get_scalar_type(
+            # pyre-ignore[16]: now assert all outputs is in tensor type.
+            self._get_program_output(program, plan_idx, output_idx).scalar_type
+        )
+
+    def _assert_valid_bundle(
+        self,
+        executorch_program: Union[
+            ExecutorchProgram,
+            MultiMethodExecutorchProgram,
+            ExecutorchProgramManager,
+        ],
+        method_test_suites: Sequence[MethodTestSuite],
+    ) -> None:
+        """Check if the program and method_test_suites matches each other.
+
+        Other checks not related to correspondence are done in config.py
+
+        Args:
+            program: The program to be bundled.
+            method_test_suites: The testcases for specific methods to be bundled.
+        """
+
+        program = self._extract_program(executorch_program)
+
+        method_name_of_program = {e.name for e in program.execution_plan}
+        method_name_of_test_suites = {t.method_name for t in method_test_suites}
+
+        assert method_name_of_test_suites.issubset(
+            method_name_of_program
+        ), f"All method names in bundled config should be found in program.execution_plan, \
+            but {str(method_name_of_test_suites - method_name_of_program)} does not include."
+
+        # check if method_test_suites has been sorted in ascending alphabetical order of method name.
+        for test_suite_id in range(1, len(method_test_suites)):
+            assert (
+                method_test_suites[test_suite_id - 1].method_name
+                <= method_test_suites[test_suite_id].method_name
+            ), f"The method name of test suite should be sorted in ascending alphabetical \
+                order of method name, but {test_suite_id-1}-th and {test_suite_id}-th method_test_suite aren't."
+
+        # Check if the inputs' type meet Program's requirement
+        for method_test_suite in method_test_suites:
+
+            # Get the method with same method name as method_test_suite
+            program_plan_id = -1
+            for plan in program.execution_plan:
+                if plan.name == method_test_suite.method_name:
+                    program_plan_id = program.execution_plan.index(plan)
+                    break
+
+            # Raise Assertion Error if can not find the method with same method_name as method_test_suite in program.
+            assert (
+                program_plan_id != -1
+            ), f"method_test_suites has testcases for method {method_test_suite.method_name}, but can not find it in the given program. All method names in the program are {', '.join([p.name for p in program.execution_plan])}."
+
+            plan = program.execution_plan[program_plan_id]
+
+            # Check if the type of Program's input is supported
+            for index in range(len(plan.inputs)):
                 assert (
-                    type(cur_plan_test_inputs[j])
-                    is supported_program_type_table[
-                        type(get_program_input(program, program_plan_id, j))
-                    ]
-                ), "The type {}-th input in {}-th test set of {}-th execution plan does not meet Program's requirement: expected {} but get {}".format(
-                    j,
-                    i,
-                    program_plan_id,
-                    supported_program_type_table[
-                        type(get_program_input(program, program_plan_id, j))
-                    ],
-                    type(cur_plan_test_inputs[j]),
+                    type(self._get_program_input(program, program_plan_id, index))
+                    in supported_program_type_table
+                ), "The type of program's input isn't supported."
+
+            # Check if the type of Program's output is supported
+            for index in range(len(plan.outputs)):
+                assert (
+                    type(self._get_program_output(program, program_plan_id, index))
+                    == core_schema.Tensor
+                ), "Only supports program with output in Tensor type."
+
+            # Check if the I/O sets of each execution plan test match program's requirement.
+            for i in range(len(method_test_suite.test_cases)):
+                cur_plan_test_inputs = method_test_suite.test_cases[i].inputs
+                cur_plan_test_expected_outputs = method_test_suite.test_cases[
+                    i
+                ].expected_outputs
+
+                assert len(plan.inputs) == len(
+                    cur_plan_test_inputs
+                ), "The number of input in each bundled set and Program shall equal, but get {} and {}".format(
+                    len(plan.inputs),
+                    len(cur_plan_test_inputs),
                 )
 
-                # type of tensor input should match execution plan
-                if type(cur_plan_test_inputs[j]) is torch.Tensor:
-                    # pyre-fixme[16]: Undefined attribute [16]: Item `bool` of `typing.Union[bool, float, int, torch._tensor.Tensor]`
-                    # has no attribute `dtype`.
-                    assert cur_plan_test_inputs[j].dtype == get_input_dtype(
-                        program, program_plan_id, j
-                    ), "The input tensor {} dtype shall be {}, but now is {}".format(
-                        cur_plan_test_inputs[j],
-                        get_input_dtype(program, program_plan_id, j),
-                        cur_plan_test_inputs[j].dtype,
-                    )
-                elif type(cur_plan_test_inputs[j]) in (
-                    int,
-                    bool,
-                    float,
-                ):
-                    assert type(cur_plan_test_inputs[j]) is get_input_type(
-                        program, program_plan_id, j
-                    ), "The input primitive dtype shall be {}, but now is {}".format(
-                        get_input_type(program, program_plan_id, j),
+                # Check if bundled input in the current exeution plan test share same type as input in Program
+                for j in range(len(cur_plan_test_inputs)):
+                    assert (
+                        type(cur_plan_test_inputs[j])
+                        is supported_program_type_table[
+                            type(self._get_program_input(program, program_plan_id, j))
+                        ]
+                    ), "The type {}-th input in {}-th test set of {}-th execution plan does not meet Program's requirement: expected {} but get {}".format(
+                        j,
+                        i,
+                        program_plan_id,
+                        supported_program_type_table[
+                            type(self._get_program_input(program, program_plan_id, j))
+                        ],
                         type(cur_plan_test_inputs[j]),
                     )
 
-            # Check if bundled expected output in the current exeution plan test share same type as output in Program
-            for j in range(len(cur_plan_test_expected_outputs)):
-                assert (
-                    type(cur_plan_test_expected_outputs[j]) is torch.Tensor
-                ), "The {}-th expected output shall be a tensor, but now is {}".format(
-                    j, type(cur_plan_test_expected_outputs[j])
-                )
+                    # type of tensor input should match execution plan
+                    if type(cur_plan_test_inputs[j]) is torch.Tensor:
+                        # pyre-fixme[16]: Undefined attribute [16]: Item `bool` of `typing.Union[bool, float, int, torch._tensor.Tensor]`
+                        # has no attribute `dtype`.
+                        assert cur_plan_test_inputs[j].dtype == self._get_input_dtype(
+                            program, program_plan_id, j
+                        ), "The input tensor {} dtype shall be {}, but now is {}".format(
+                            cur_plan_test_inputs[j],
+                            self._get_input_dtype(program, program_plan_id, j),
+                            cur_plan_test_inputs[j].dtype,
+                        )
+                    elif type(cur_plan_test_inputs[j]) in (
+                        int,
+                        bool,
+                        float,
+                    ):
+                        assert type(cur_plan_test_inputs[j]) is self._get_input_type(
+                            program, program_plan_id, j
+                        ), "The input primitive dtype shall be {}, but now is {}".format(
+                            self._get_input_type(program, program_plan_id, j),
+                            type(cur_plan_test_inputs[j]),
+                        )
 
-                # pyre-fixme[16]: Undefined attribute [16]: Item `bool` of `typing.Union[bool, float, int, torch._tensor.Tensor]`
-                # has no attribute `dtype`.
-                assert cur_plan_test_expected_outputs[j].dtype == get_output_dtype(
-                    program, program_plan_id, j
-                ), "The label tensor {} dtype shall be {}, but now is {}".format(
-                    cur_plan_test_expected_outputs[j],
-                    get_output_dtype(program, program_plan_id, j),
-                    cur_plan_test_expected_outputs[j].dtype,
-                )
+                # Check if bundled expected output in the current exeution plan test share same type as output in Program
+                for j in range(len(cur_plan_test_expected_outputs)):
+                    assert (
+                        type(cur_plan_test_expected_outputs[j]) is torch.Tensor
+                    ), "The {}-th expected output shall be a tensor, but now is {}".format(
+                        j, type(cur_plan_test_expected_outputs[j])
+                    )
 
+                    # pyre-fixme[16]: Undefined attribute [16]: Item `bool` of `typing.Union[bool, float, int, torch._tensor.Tensor]`
+                    # has no attribute `dtype`.
+                    assert cur_plan_test_expected_outputs[
+                        j
+                    ].dtype == self._get_output_dtype(
+                        program, program_plan_id, j
+                    ), "The label tensor {} dtype shall be {}, but now is {}".format(
+                        cur_plan_test_expected_outputs[j],
+                        self._get_output_dtype(program, program_plan_id, j),
+                        cur_plan_test_expected_outputs[j].dtype,
+                    )
 
-def extract_program(
-    executorch_program: Union[
-        ExecutorchProgram,
-        MultiMethodExecutorchProgram,
-        ExecutorchProgramManager,
-    ]
-):
-    if isinstance(executorch_program, ExecutorchProgramManager):
-        program = executorch_program.executorch_program
-    elif isinstance(executorch_program, ExecutorchProgram):
-        program = executorch_program.program
-    else:
-        assert isinstance(
-            executorch_program, MultiMethodExecutorchProgram
-        ), f"executorch_program should be in type ExecutorchProgram, MultiMethodExecutorchProgram or ExecutorchProgramManager, but got {type(executorch_program)}"
-        program = executorch_program.program
+    def _extract_program(
+        self,
+        executorch_program: Union[
+            ExecutorchProgram,
+            MultiMethodExecutorchProgram,
+            ExecutorchProgramManager,
+        ],
+    ):
+        if isinstance(executorch_program, ExecutorchProgramManager):
+            program = executorch_program.executorch_program
+        elif isinstance(executorch_program, ExecutorchProgram):
+            program = executorch_program.program
+        else:
+            assert isinstance(
+                executorch_program, MultiMethodExecutorchProgram
+            ), f"executorch_program should be in type ExecutorchProgram, MultiMethodExecutorchProgram or ExecutorchProgramManager, but got {type(executorch_program)}"
+            program = executorch_program.program
 
-    return program
-
-
-def create_bundled_program(
-    executorch_program: Union[
-        ExecutorchProgram,
-        MultiMethodExecutorchProgram,
-        ExecutorchProgramManager,
-    ],
-    method_test_suites: Sequence[MethodTestSuite],
-) -> BundledProgram:
-    """Create BundledProgram by bundling the given program and method_test_suites together.
-
-    Args:
-        executorch_program: ExecutorchProgram-like variable, containing the Program to be verified by method_test_suites, including
-                            ExecutorchProgram, MultiMethodExecutorchProgram and ExecutorchProgramManager.
-        method_test_suites: The testcases for certain methods to be bundled.
-
-    Returns:
-        The `BundledProgram` variable contains given ExecuTorch program and test cases.
-    """
-    program = extract_program(executorch_program)
-
-    method_test_suites = sorted(method_test_suites, key=lambda x: x.method_name)
-
-    assert_valid_bundle(program, method_test_suites)
-
-    return BundledProgram(
-        executorch_program=executorch_program, method_test_suites=method_test_suites
-    )
+        return program

--- a/sdk/bundled_program/serialize/test/test_serialize.py
+++ b/sdk/bundled_program/serialize/test/test_serialize.py
@@ -8,7 +8,7 @@
 
 import unittest
 
-from executorch.sdk.bundled_program.core import create_bundled_program
+from executorch.sdk.bundled_program.core import BundledProgram
 
 from executorch.sdk.bundled_program.serialize import (
     deserialize_from_flatbuffer_to_bundled_program,
@@ -21,7 +21,7 @@ class TestSerialize(unittest.TestCase):
     def test_bundled_program_serialization(self) -> None:
         executorch_program, method_test_suites = get_common_executorch_program()
 
-        bundled_program = create_bundled_program(executorch_program, method_test_suites)
+        bundled_program = BundledProgram(executorch_program, method_test_suites)
         flat_buffer_bundled_program = serialize_from_bundled_program_to_flatbuffer(
             bundled_program
         )

--- a/sdk/bundled_program/test/test_bundle_data.py
+++ b/sdk/bundled_program/test/test_bundle_data.py
@@ -14,7 +14,7 @@ import executorch.sdk.bundled_program.schema as bp_schema
 import torch
 from executorch.exir._serialize import _serialize_pte_binary
 from executorch.sdk.bundled_program.config import ConfigValue
-from executorch.sdk.bundled_program.core import create_bundled_program
+from executorch.sdk.bundled_program.core import BundledProgram
 from executorch.sdk.bundled_program.util.test_util import get_common_executorch_program
 
 
@@ -43,7 +43,7 @@ class TestBundle(unittest.TestCase):
     def test_bundled_program(self) -> None:
         executorch_program, method_test_suites = get_common_executorch_program()
 
-        bundled_program = create_bundled_program(executorch_program, method_test_suites)
+        bundled_program = BundledProgram(executorch_program, method_test_suites)
 
         method_test_suites = sorted(method_test_suites, key=lambda t: t.method_name)
 
@@ -78,7 +78,7 @@ class TestBundle(unittest.TestCase):
         # only keep the testcases for the first method to mimic the case that user only creates testcases for the first method.
         method_test_suites = method_test_suites[:1]
 
-        _ = create_bundled_program(executorch_program, method_test_suites)
+        _ = BundledProgram(executorch_program, method_test_suites)
 
     def test_bundled_wrong_method_name(self) -> None:
         executorch_program, method_test_suites = get_common_executorch_program()
@@ -86,7 +86,7 @@ class TestBundle(unittest.TestCase):
         method_test_suites[-1].method_name = "wrong_method_name"
         self.assertRaises(
             AssertionError,
-            create_bundled_program,
+            BundledProgram,
             executorch_program,
             method_test_suites,
         )
@@ -98,7 +98,7 @@ class TestBundle(unittest.TestCase):
         method_test_suites[0].test_cases[-1].inputs = ["WRONG INPUT TYPE"]
         self.assertRaises(
             AssertionError,
-            create_bundled_program,
+            BundledProgram,
             executorch_program,
             method_test_suites,
         )
@@ -112,7 +112,7 @@ class TestBundle(unittest.TestCase):
         ]
         self.assertRaises(
             AssertionError,
-            create_bundled_program,
+            BundledProgram,
             executorch_program,
             method_test_suites,
         )

--- a/sdk/bundled_program/test/test_end2end.py
+++ b/sdk/bundled_program/test/test_end2end.py
@@ -21,7 +21,7 @@ import executorch.extension.pytree as pytree
 
 import torch
 
-from executorch.sdk.bundled_program.core import create_bundled_program
+from executorch.sdk.bundled_program.core import BundledProgram
 from executorch.sdk.bundled_program.serialize import (
     serialize_from_bundled_program_to_flatbuffer,
 )
@@ -65,7 +65,7 @@ class BundledProgramE2ETest(unittest.TestCase):
         executorch_program, method_test_suites = get_common_executorch_program()
         eager_model = SampleModel()
 
-        bundled_program = create_bundled_program(executorch_program, method_test_suites)
+        bundled_program = BundledProgram(executorch_program, method_test_suites)
 
         bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
             bundled_program

--- a/sdk/etrecord/tests/etrecord_test.py
+++ b/sdk/etrecord/tests/etrecord_test.py
@@ -14,7 +14,7 @@ import torch
 from executorch import exir
 from executorch.exir import EdgeCompileConfig, EdgeProgramManager, to_edge
 from executorch.sdk.bundled_program.config import MethodTestCase, MethodTestSuite
-from executorch.sdk.bundled_program.core import create_bundled_program
+from executorch.sdk.bundled_program.core import BundledProgram
 from executorch.sdk.etrecord import generate_etrecord, parse_etrecord
 from executorch.sdk.etrecord._etrecord import (
     _get_reference_outputs,
@@ -62,7 +62,7 @@ class TestETRecord(unittest.TestCase):
         edge_output_copy = copy.deepcopy(edge_output)
         et_output = edge_output.to_executorch()
 
-        bundled_program = create_bundled_program(et_output, method_test_suites)
+        bundled_program = BundledProgram(et_output, method_test_suites)
         return (captured_output_copy, edge_output_copy, bundled_program)
 
     def get_test_model_with_manager(self):

--- a/test/end2end/TARGETS
+++ b/test/end2end/TARGETS
@@ -57,8 +57,8 @@ python_unittest(
         "//executorch/exir/tests:transformer",
         "//executorch/extension/pybindings:aten_lib",
         "//executorch/extension/pytree:pybindings",
+        "//executorch/sdk:lib",
         "//executorch/sdk/bundled_program:config",
-        "//executorch/sdk/bundled_program:core",
         "//executorch/sdk/bundled_program/serialize:lib",
     ],
 )
@@ -88,8 +88,8 @@ python_unittest(
         "//executorch/exir/tests:transformer",
         "//executorch/extension/pybindings:portable_lib",
         "//executorch/extension/pytree:pybindings",
+        "//executorch/sdk:lib",
         "//executorch/sdk/bundled_program:config",
-        "//executorch/sdk/bundled_program:core",
         "//executorch/sdk/bundled_program/serialize:lib",
     ],
 )

--- a/test/models/generate_linear_out_bundled_program.py
+++ b/test/models/generate_linear_out_bundled_program.py
@@ -23,8 +23,8 @@ from executorch.exir import ExecutorchBackendConfig
 
 from executorch.exir.passes import MemoryPlanningPass, ToOutVarPass
 from executorch.exir.print_program import pretty_print
+from executorch.sdk import BundledProgram
 from executorch.sdk.bundled_program.config import MethodTestCase, MethodTestSuite
-from executorch.sdk.bundled_program.core import create_bundled_program
 from executorch.sdk.bundled_program.serialize import (
     serialize_from_bundled_program_to_flatbuffer,
 )
@@ -65,7 +65,7 @@ def main() -> None:
         MethodTestSuite(method_name="forward", test_cases=method_test_cases)
     ]
 
-    bundled_program = create_bundled_program(exec_prog, method_test_suites)
+    bundled_program = BundledProgram(exec_prog, method_test_suites)
     pretty_print(bundled_program)
 
     bundled_program_flatbuffer = serialize_from_bundled_program_to_flatbuffer(

--- a/test/models/targets.bzl
+++ b/test/models/targets.bzl
@@ -23,7 +23,7 @@ def define_common_targets():
             ":linear_model",
             "//caffe2:torch",
             "//executorch/sdk/bundled_program:config",
-            "//executorch/sdk/bundled_program:core",
+            "//executorch/sdk:lib",
             "//executorch/sdk/bundled_program/serialize:lib",
             "//executorch/exir:lib",
             "//executorch/exir/_serialize:lib",


### PR DESCRIPTION
Summary:
Currently BundledProgram does not have its own ctor. To create a `BundledProgram`, we need to leverage `create_bundled_program` api.
To make the logic more concise, and integrate all bundled program AOT apis as an individual class (which for further api update), this diff removes `create_bundled_program`, and creates a ctor.

Differential Revision: D52832295

