### PR TITLE
Make sure runtime_init is run once.

### DIFF
--- a/runtime/platform/runtime.cpp
+++ b/runtime/platform/runtime.cpp
@@ -6,10 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <executorch/runtime/platform/profiler.h>
 #include <executorch/runtime/platform/runtime.h>
 
+#include <atomic>
+
 #include <executorch/runtime/platform/platform.h>
+#include <executorch/runtime/platform/profiler.h>
 
 namespace torch {
 namespace executor {
@@ -18,8 +20,11 @@ namespace executor {
  * Initialize the ExecuTorch global runtime.
  */
 void runtime_init() {
-  et_pal_init();
-  EXECUTORCH_PROFILE_CREATE_BLOCK("default");
+  static std::atomic_bool initialized{false};
+  if (!initialized.exchange(true)) {
+    et_pal_init();
+    EXECUTORCH_PROFILE_CREATE_BLOCK("default");
+  }
 }
 
 } // namespace executor


### PR DESCRIPTION
Summary: By using an atomic flag we can allow users call runtime_init() any time from any thread without running into race conditions.

Differential Revision: D52846712


