### PR TITLE
create target for serializer and schema

### DIFF
--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -39,7 +39,7 @@ set(_xnnpack_schema__include_dir "${CMAKE_BINARY_DIR}/schema/include")
 # Paths to headers generated from the .fbs files.
 set(_xnnpack_schema__outputs)
 foreach(fbs_file ${_xnnpack_schema__srcs})
-  string(REGEX REPLACE "serialization/([^/]+)[.]fbs$" "\\1_generated.h"
+  string(REGEX REPLACE "([^/]+)[.]fbs$" "\\1_generated.h"
                        generated "${fbs_file}")
   list(APPEND _xnnpack_schema__outputs
        "${_xnnpack_schema__include_dir}/executorch/${generated}")
@@ -50,7 +50,7 @@ add_custom_command(
   OUTPUT ${_xnnpack_schema__outputs}
   COMMAND
     ${FLATC_EXECUTABLE} --cpp --cpp-std c++11 --scoped-enums -o
-    "${_xnnpack_schema__include_dir}/executorch/backends/xnnpack"
+    "${_xnnpack_schema__include_dir}/executorch/backends/xnnpack/serialization"
     ${_xnnpack_schema__srcs}
   WORKING_DIRECTORY ${EXECUTORCH_ROOT}
   COMMENT "Generating xnnpack_schema headers"

--- a/backends/xnnpack/TARGETS
+++ b/backends/xnnpack/TARGETS
@@ -8,12 +8,7 @@ define_common_targets()
 runtime.python_library(
     name = "xnnpack_preprocess",
     srcs = [
-        "serialization/xnnpack_graph_schema.py",
-        "serialization/xnnpack_graph_serialize.py",
         "xnnpack_preprocess.py",
-    ],
-    resources = [
-        "serialization/schema.fbs",
     ],
     visibility = [
         "//executorch/...",
@@ -23,6 +18,7 @@ runtime.python_library(
         "//executorch/backends/transforms:lib",
         "//executorch/backends/xnnpack/operators:operators",
         "//executorch/backends/xnnpack/passes:xnnpack_passes",
+        "//executorch/backends/xnnpack/serialization:xnnpack_serializer",
         "//executorch/exir:graph_module",
         "//executorch/exir/backend:backend_details",
     ],

--- a/backends/xnnpack/operators/TARGETS
+++ b/backends/xnnpack/operators/TARGETS
@@ -12,8 +12,6 @@ runtime.python_library(
     deps = [
         "//executorch/backends/xnnpack/utils:xnnpack_utils",
         "//executorch/exir:graph_module",
-        "//executorch/exir/_serialize:_bindings",
-        "//executorch/exir/_serialize:lib",
         "//executorch/exir/backend:backend_details",
     ],
 )

--- a/backends/xnnpack/passes/TARGETS
+++ b/backends/xnnpack/passes/TARGETS
@@ -24,6 +24,7 @@ python_library(
         "//executorch/backends/xnnpack/partition:configs",
         "//executorch/backends/xnnpack/partition:partitioner_graphs",
         "//executorch/backends/xnnpack/utils:xnnpack_utils",
+        "//executorch/exir:lib",
         "//executorch/exir:pass_base",
         "//executorch/exir/dialects:lib",
         "//executorch/exir/passes:const_prop_pass",

--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -8,7 +8,7 @@
 
 #include <executorch/backends/xnnpack/runtime/XNNCompiler.h>
 #include <executorch/backends/xnnpack/runtime/XNNHeader.h>
-#include <executorch/backends/xnnpack/schema_generated.h>
+#include <executorch/backends/xnnpack/serialization/schema_generated.h>
 #include <executorch/backends/xnnpack/threadpool/threadpool.h>
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 #include <unordered_map>

--- a/backends/xnnpack/serialization/TARGETS
+++ b/backends/xnnpack/serialization/TARGETS
@@ -1,0 +1,35 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()
+
+runtime.python_library(
+    name = "xnnpack_schema",
+    srcs = [
+        "xnnpack_graph_schema.py",
+    ],
+    visibility = [
+        "//executorch/...",
+        "@EXECUTORCH_CLIENTS",
+    ],
+)
+
+runtime.python_library(
+    name = "xnnpack_serializer",
+    srcs = [
+        "xnnpack_graph_serialize.py",
+    ],
+    resources = [
+        "schema.fbs",
+    ],
+    visibility = [
+        "//executorch/...",
+        "@EXECUTORCH_CLIENTS",
+    ],
+    deps = [
+        ":xnnpack_schema",
+        "//executorch/exir/_serialize:lib",
+    ],
+)

--- a/backends/xnnpack/serialization/targets.bzl
+++ b/backends/xnnpack/serialization/targets.bzl
@@ -1,0 +1,37 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    runtime.genrule(
+        name = "gen_xnnpack_schema",
+        srcs = [
+            "schema.fbs",
+        ],
+        # We're only generating a single file, so it seems like we could use
+        # `out`, but `flatc` takes a directory as a parameter, not a single
+        # file. Use `outs` so that `${OUT}` is expanded as the containing
+        # directory instead of the file itself.
+        outs = {
+            "schema_generated.h": ["schema_generated.h"],
+        },
+        cmd = " ".join([
+            "$(exe {})".format(runtime.external_dep_location("flatc")),
+            "--cpp",
+            "--cpp-std c++11",
+            "--scoped-enums",
+            "-o ${OUT}",
+            "${SRCS}",
+        ]),
+        default_outs = ["."],
+    )
+
+    runtime.cxx_library(
+        name = "xnnpack_flatbuffer_header",
+        srcs = [],
+        visibility = [
+            "//executorch/backends/xnnpack/...",
+        ],
+        exported_headers = {
+            "schema_generated.h": ":gen_xnnpack_schema[schema_generated.h]",
+        },
+        exported_external_deps = ["flatbuffers-api"],
+    )

--- a/backends/xnnpack/targets.bzl
+++ b/backends/xnnpack/targets.bzl
@@ -18,38 +18,6 @@ def define_common_targets():
         ],
     )
 
-    runtime.genrule(
-        name = "gen_xnnpack_schema",
-        srcs = [
-            "serialization/schema.fbs",
-        ],
-        # We're only generating a single file, so it seems like we could use
-        # `out`, but `flatc` takes a directory as a parameter, not a single
-        # file. Use `outs` so that `${OUT}` is expanded as the containing
-        # directory instead of the file itself.
-        outs = {
-            "schema_generated.h": ["schema_generated.h"],
-        },
-        cmd = " ".join([
-            "$(exe {})".format(runtime.external_dep_location("flatc")),
-            "--cpp",
-            "--cpp-std c++11",
-            "--scoped-enums",
-            "-o ${OUT}",
-            "${SRCS}",
-        ]),
-        default_outs = ["."],
-    )
-
-    runtime.cxx_library(
-        name = "xnnpack_schema",
-        srcs = [],
-        exported_headers = {
-            "schema_generated.h": ":gen_xnnpack_schema[schema_generated.h]",
-        },
-        exported_external_deps = ["flatbuffers-api"],
-    )
-
     runtime.cxx_library(
         name = "xnnpack_backend",
         srcs = native.glob([
@@ -70,9 +38,9 @@ def define_common_targets():
         ] + ([] if runtime.is_oss else ["-DENABLE_DYNAMIC_QUANTIZATION"]),
         deps = [
             third_party_dep("XNNPACK"),
-            ":xnnpack_schema",
             ":dynamic_quant_utils",  # TODO Use (1) portable for choose_qparams(), (2) xnnpack for quantize_per_tensor(),
             "//executorch/runtime/backend:interface",
+            "//executorch/backends/xnnpack/serialization:xnnpack_flatbuffer_header",
             "//executorch/backends/xnnpack/threadpool:threadpool",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
         ],

--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -202,7 +202,7 @@ filters = [
 
 [targets.xnnpack_schema]
 buck_targets = [
-  "//backends/xnnpack:xnnpack_schema",
+  "//backends/xnnpack/serialization:xnnpack_flatbuffer_header",
 ]
 filters = [
   ".fbs$",


### PR DESCRIPTION
Summary: Creating new buck targets for serialization and schema. Want to split out Targets which explicitly use the schema (things like passes and node visitors use the dataclasses instantiated in the schema) and targets which are actually serializing, like xnnpack_preprocess

Differential Revision: D52809539


