### PR TITLE
Implement SDK profiler support in XNNPACK delegate

### DIFF
--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -1583,7 +1583,7 @@ __ET_NODISCARD Error XNNCompiler::compileModel(
   }
   uint32_t runtime_flags = 0;
 
-#ifdef ENABLE_XNNPACK_PROFILING
+#if defined(ENABLE_XNNPACK_PROFILING) || defined(ET_EVENT_TRACER_ENABLED)
   runtime_flags |= XNN_FLAG_BASIC_PROFILING;
 #endif
 
@@ -1599,13 +1599,8 @@ __ET_NODISCARD Error XNNCompiler::compileModel(
       "XNN Runtime creation failed with code: %s",
       xnn_status_to_string(status));
 
-  executor->runtime_ =
-      std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)>(
-          runtime_ptr, xnn_delete_runtime);
+  executor->initialize(runtime_ptr);
 
-#ifdef ENABLE_XNNPACK_PROFILING
-  executor->init_profiler();
-#endif
   // HACK FOR FC/BC this is only to support old dq_datatype
   if (executor->qinputs_.size() > 0) {
     // qinputs_ is only set when using the old dq linear path. At which point

--- a/backends/xnnpack/runtime/XNNCompiler.h
+++ b/backends/xnnpack/runtime/XNNCompiler.h
@@ -10,6 +10,7 @@
 
 #include <executorch/backends/xnnpack/runtime/XNNExecutor.h>
 #include <executorch/runtime/platform/compiler.h>
+
 #include <xnnpack.h>
 #include <memory>
 #include <vector>

--- a/backends/xnnpack/runtime/XNNExecutor.cpp
+++ b/backends/xnnpack/runtime/XNNExecutor.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/backends/xnnpack/runtime/XNNExecutor.h>
+#include <executorch/runtime/core/event_tracer_hooks_delegate.h>
 
 namespace torch {
 namespace executor {
@@ -17,7 +18,7 @@ Error XNNExecutor::set_external_input(
     uint32_t id,
     Tensor* input,
     struct XNNShape* shape) {
-  // TODO(T165403530): Test insure accuracy for int64 --> float32 conversion
+  // TODO(T165403530): Test ensure accuracy for int64 --> float32 conversion
   if (input->scalar_type() == ScalarType::Long) {
     // Input data type is int64. However, XNNPACK doesn't support
     // int64. This means that the data needs to be casted to float
@@ -44,91 +45,6 @@ Error XNNExecutor::set_external_input(
   return Error::Ok;
 }
 
-inline void XNNExecutor::get_runtime_operator_names(
-    std::vector<char>& operator_names) {
-  size_t required_size = 0;
-  // First call returns xnn_status_out_of_memory, but sets required_size to
-  // the correct size of the buffer to store the result
-  xnn_status status = xnn_get_runtime_profiling_info(
-      runtime_.get(), // runtime
-      xnn_profile_info_operator_name, // param_name
-      0, // param_value_size
-      nullptr, // param_value
-      &required_size // param_value_size_ret
-  );
-
-  if (status == xnn_status_out_of_memory) {
-    operator_names.resize(required_size);
-    status = xnn_get_runtime_profiling_info(
-        runtime_.get(),
-        xnn_profile_info_operator_name,
-        operator_names.size(),
-        operator_names.data(),
-        &required_size);
-  }
-  if (status != xnn_status_success) {
-    ET_LOG(Error, "Failed to get XNNPACK Operator Timings");
-  }
-}
-
-inline void XNNExecutor::get_runtime_num_operators(size_t& num_operators) {
-  size_t required_size = 0;
-  xnn_status status = xnn_get_runtime_profiling_info(
-      runtime_.get(),
-      xnn_profile_info_num_operators,
-      sizeof(num_operators),
-      &num_operators,
-      &required_size);
-  if (status != xnn_status_success) {
-    ET_LOG(Error, "Failed to get XNNPACK Operator Timings");
-  }
-}
-
-inline void XNNExecutor::get_runtime_operator_timings(
-    std::vector<uint64_t>& timing_stats) {
-  size_t required_size;
-  // Get number of runtime operators for timing_stats.size
-  timing_stats.resize(num_ops_);
-  xnn_status status = xnn_get_runtime_profiling_info(
-      runtime_.get(),
-      xnn_profile_info_operator_timing,
-      timing_stats.size() * sizeof(uint64_t),
-      timing_stats.data(),
-      &required_size);
-  if (status != xnn_status_success) {
-    ET_LOG(Error, "Failed to get XNNPACK Operator Timings");
-  }
-}
-
-void XNNExecutor::init_profiler() {
-  get_runtime_operator_names(op_names_);
-  get_runtime_num_operators(num_ops_);
-}
-
-void XNNExecutor::log_op_timings() {
-  std::vector<uint64_t> op_stats;
-  get_runtime_operator_timings(op_stats);
-  op_timings_.emplace_back(op_stats);
-}
-
-void XNNExecutor::print_avg_op_timings() {
-  size_t num_iterations = op_timings_.size();
-  size_t name_len = 0;
-  const char* op_name = nullptr;
-  float avg_total = 0;
-  for (size_t xnn_node_idx = 0; xnn_node_idx < num_ops_; xnn_node_idx++) {
-    op_name = &op_names_[name_len];
-    name_len += strlen(op_name) + 1;
-    float total_op_time = 0;
-    for (size_t it = 0; it < num_iterations; it++) {
-      total_op_time += op_timings_[it][xnn_node_idx];
-    }
-    float avg_op_time = total_op_time / static_cast<float>(num_iterations);
-    ET_LOG(Info, ">>, %s, %f", op_name, avg_op_time);
-    avg_total += avg_op_time;
-  }
-  ET_LOG(Info, ">>, Total Time, %f", avg_total);
-}
 } // namespace delegate
 } // namespace xnnpack
 } // namespace executor

--- a/backends/xnnpack/runtime/XNNPACKBackend.cpp
+++ b/backends/xnnpack/runtime/XNNPACKBackend.cpp
@@ -55,7 +55,7 @@ class XnnpackBackend final : public PyTorchBackendInterface {
   }
 
   Error execute(
-      __ET_UNUSED BackendExecutionContext& context,
+      BackendExecutionContext& context,
       DelegateHandle* handle,
       EValue** args) const override {
     auto executor = static_cast<xnnpack::delegate::XNNExecutor*>(handle);
@@ -111,11 +111,7 @@ class XnnpackBackend final : public PyTorchBackendInterface {
       return err;
     }
 
-    err = executor->forward();
-
-#ifdef ENABLE_XNNPACK_PROFILING
-    executor->log_op_timings(); // Log the op execution time.
-#endif
+    err = executor->forward(context);
 
     // Resize output tensors - should be a no-op for static models
     for (int i = 0; i < executor->getNumOutputs(); i++) {

--- a/backends/xnnpack/runtime/profiling/XNNProfiler.cpp
+++ b/backends/xnnpack/runtime/profiling/XNNProfiler.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/xnnpack/runtime/profiling/XNNProfiler.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/event_tracer.h>
+#include <executorch/runtime/platform/log.h>
+#include <executorch/runtime/platform/platform.h>
+#include <executorch/runtime/platform/types.h>
+
+#include <cinttypes>
+#include <cstring>
+#include <string>
+#include <unordered_map>
+
+namespace torch::executor::xnnpack::delegate::profiling {
+
+#if defined(ET_EVENT_TRACER_ENABLED) || defined(ENABLE_XNNPACK_PROFILING)
+XNNProfiler::XNNProfiler()
+    : run_count_(0), state_(XNNProfilerState::Uninitialized) {}
+
+Error XNNProfiler::initialize(xnn_runtime_t runtime) {
+  runtime_ = runtime;
+
+  // Fetch the runtime operator information from XNNPACK.
+  ET_CHECK_OK_OR_RETURN_ERROR(get_runtime_num_operators(op_count_));
+  ET_CHECK_OK_OR_RETURN_ERROR(get_runtime_operator_names(op_names_));
+
+  state_ = XNNProfilerState::Ready;
+
+  return Error::Ok;
+}
+
+Error XNNProfiler::start(EventTracer* event_tracer) {
+  // Validate profiler state.
+  if (state_ == XNNProfilerState::Uninitialized) {
+    ET_LOG(
+        Error,
+        "XNNProfiler must be initialized prior to calling begin_execution.");
+    return Error::InvalidState;
+  } else if (state_ == XNNProfilerState::Running) {
+    ET_LOG(
+        Error,
+        "XNNProfiler is already running. Call end_execution() before calling begin_execution().");
+    return Error::InvalidState;
+  }
+
+  event_tracer_ = event_tracer;
+  state_ = XNNProfilerState::Running;
+
+  // Log the start of execution timestamp.
+  start_time_ = et_pal_current_ticks();
+
+  return Error::Ok;
+}
+
+Error XNNProfiler::end() {
+  // Validate profiler state.
+  ET_CHECK_OR_RETURN_ERROR(
+      state_ == XNNProfilerState::Running,
+      InvalidState,
+      "XNNProfiler is not running. Ensure begin_execution() is called before end_execution().");
+  state_ = XNNProfilerState::Ready;
+
+  // Retrieve operator timing from XNNPACK.
+  ET_CHECK_OK_OR_RETURN_ERROR(get_runtime_operator_timings(op_timings_));
+
+  if (event_tracer_ != nullptr) {
+    submit_trace();
+  }
+
+  log_operator_timings();
+
+  return Error::Ok;
+}
+
+Error XNNProfiler::get_runtime_operator_names(
+    std::vector<char>& operator_names) {
+  size_t required_size = 0;
+
+  // First call returns xnn_status_out_of_memory, but sets required_size to
+  // the correct size of the buffer to store the result.
+  xnn_status status = xnn_get_runtime_profiling_info(
+      runtime_, // runtime
+      xnn_profile_info_operator_name, // param_name
+      0, // param_value_size
+      nullptr, // param_value
+      &required_size // param_value_size_ret
+  );
+
+  if (status == xnn_status_out_of_memory) {
+    operator_names.resize(required_size);
+    status = xnn_get_runtime_profiling_info(
+        runtime_,
+        xnn_profile_info_operator_name,
+        operator_names.size(),
+        operator_names.data(),
+        &required_size);
+  }
+
+  if (status != xnn_status_success) {
+    ET_LOG(Error, "Failed to get XNNPACK operator names: %d", status);
+    return Error::Internal;
+  }
+
+  return Error::Ok;
+}
+
+Error XNNProfiler::get_runtime_num_operators(size_t& num_operators) {
+  size_t required_size = 0;
+
+  xnn_status status = xnn_get_runtime_profiling_info(
+      runtime_,
+      xnn_profile_info_num_operators,
+      sizeof(num_operators),
+      &num_operators,
+      &required_size);
+
+  if (status != xnn_status_success) {
+    ET_LOG(Error, "Failed to get XNNPACK operator count: %d", status);
+    return Error::Internal;
+  }
+
+  return Error::Ok;
+}
+
+Error XNNProfiler::get_runtime_operator_timings(
+    std::vector<uint64_t>& timing_stats) {
+  size_t required_size;
+
+  // Get number of runtime operators for timing_stats.size
+  timing_stats.resize(op_count_);
+  xnn_status status = xnn_get_runtime_profiling_info(
+      runtime_,
+      xnn_profile_info_operator_timing,
+      timing_stats.size() * sizeof(uint64_t),
+      timing_stats.data(),
+      &required_size);
+
+  if (status != xnn_status_success) {
+    ET_LOG(Error, "Failed to get XNNPACK operator timing: %d", status);
+    return Error::Internal;
+  }
+
+  return Error::Ok;
+}
+
+void XNNProfiler::log_operator_timings() {
+#ifdef ENABLE_XNNPACK_PROFILING
+  // Update running average state and log average timing for each op.
+  run_count_++;
+  size_t name_len = 0;
+  const char* op_name = nullptr;
+  auto total_time = 0.0f;
+
+  if (op_timings_sum_.size() != op_count_) {
+    op_timings_sum_ = std::vector<uint64_t>(op_count_, 0);
+  }
+
+  for (size_t i = 0; i < op_count_; i++) {
+    op_name = &op_names_[name_len];
+    name_len += strlen(op_name) + 1;
+
+    op_timings_sum_[i] += op_timings_[i];
+    auto avg_op_time = op_timings_sum_[i] / static_cast<float>(run_count_);
+    total_time += avg_op_time;
+
+    ET_LOG(
+        Info, ">>, %s, %" PRId64 " (%f)", op_name, op_timings_[i], avg_op_time);
+  }
+  ET_LOG(Info, ">>, Total Time, %f", total_time);
+#endif
+}
+
+void XNNProfiler::submit_trace() {
+  // Retrieve the system tick rate (ratio between ticks and nanoseconds).
+  auto tick_ns_conv_multiplier = et_pal_ticks_to_ns_multiplier();
+
+  ET_CHECK(op_timings_.size() == op_count_);
+  size_t name_len = 0;
+  et_timestamp_t time = start_time_;
+  std::unordered_map<std::string, uint32_t> op_counts;
+
+  for (auto i = 0u; i < op_count_; i++) {
+    auto op_name = &op_names_[name_len];
+    name_len += strlen(op_name) + 1;
+
+    // Format the op name as {name} #{count}.
+    auto op_name_str = std::string(op_name);
+    op_counts[op_name_str]++;
+    auto name_formatted =
+        op_name_str + " #" + std::to_string(op_counts[op_name_str]);
+
+    // Convert from microseconds (XNNPACK) to PAL ticks (ET).
+    // The tick_ns_conv_ratio is ns / tick. We want ticks:
+    //  ticks = us * (ns / us) / conv_ratio
+    //        = us * 1000 * conv_ratio.denom / conv_ratio.num
+    auto interval_ticks = static_cast<et_timestamp_t>(
+        op_timings_[i] * 1000 * tick_ns_conv_multiplier.denominator /
+        tick_ns_conv_multiplier.numerator);
+
+    auto end_time = time + interval_ticks;
+
+    torch::executor::event_tracer_log_profiling_delegate(
+        event_tracer_,
+        name_formatted.c_str(),
+        /*delegate_debug_id=*/static_cast<torch::executor::DebugHandle>(-1),
+        time,
+        end_time);
+
+    // Assume that the next op starts immediately after the previous op.
+    // This may not be strictly true, but it should be close enough.
+    // Ideally, we'll get the start and end times from XNNPACK in the
+    // future.
+    time = end_time;
+  }
+}
+
+#else // defined(ET_EVENT_TRACER_ENABLED) || defined(ENABLE_XNNPACK_PROFILING)
+
+// Stub implementation for when profiling is disabled.
+XNNProfiler::XNNProfiler() {}
+
+Error XNNProfiler::initialize(xnn_runtime_t runtime) {
+  (void)runtime;
+  return Error::Ok;
+}
+
+Error XNNProfiler::start(EventTracer* event_tracer) {
+  (void)event_tracer;
+  return Error::Ok;
+}
+
+Error XNNProfiler::end() {
+  return Error::Ok;
+}
+
+#endif
+
+} // namespace torch::executor::xnnpack::delegate::profiling

--- a/backends/xnnpack/runtime/profiling/XNNProfiler.h
+++ b/backends/xnnpack/runtime/profiling/XNNProfiler.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/event_tracer_hooks_delegate.h>
+
+#include <xnnpack.h>
+#include <vector>
+
+namespace torch {
+namespace executor {
+namespace xnnpack {
+namespace delegate {
+namespace profiling {
+
+enum class XNNProfilerState { Uninitialized, Ready, Running };
+
+class XNNProfiler {
+ public:
+  XNNProfiler();
+
+  /**
+   * Initialize the profiler. This must be called after model is
+   * compiled and before calling begin_execution.
+   */
+  Error initialize(xnn_runtime_t runtime);
+
+  /**
+   * Start a new profiling session. This is typically invoked
+   * immediately before invoking the XNNPACK runtime as part
+   * of a forward pass.
+   */
+  Error start(EventTracer* event_tracer);
+
+  /**
+   * End a profiling session. This is typically invoked immediately
+   * after the XNNPACK runtime invocation completes.
+   */
+  Error end();
+
+  uint64_t run_count_ = 0;
+
+ private:
+#if defined(ET_EVENT_TRACER_ENABLED) || defined(ENABLE_XNNPACK_PROFILING)
+  EventTracer* event_tracer_;
+  xnn_runtime_t runtime_;
+  XNNProfilerState state_;
+
+  size_t op_count_;
+  std::vector<char> op_names_;
+  std::vector<uint64_t> op_timings_;
+  et_timestamp_t start_time_;
+
+#ifdef ENABLE_XNNPACK_PROFILING
+  // State needed to track average timing. Track the running sum of
+  // timing for each op, as well as the number of invocations. The
+  // running average can be found as sum / run_count.
+  std::vector<uint64_t> op_timings_sum_;
+#endif
+
+  Error get_runtime_operator_names(std::vector<char>& operator_names);
+  Error get_runtime_num_operators(size_t& num_operators);
+  Error get_runtime_operator_timings(std::vector<uint64_t>& timing_stats);
+
+  void log_operator_timings();
+
+  /**
+   * Submit the trace to the ET event tracer.
+   */
+  void submit_trace();
+#endif
+};
+
+} // namespace profiling
+} // namespace delegate
+} // namespace xnnpack
+} // namespace executor
+} // namespace torch

--- a/backends/xnnpack/targets.bzl
+++ b/backends/xnnpack/targets.bzl
@@ -22,9 +22,11 @@ def define_common_targets():
         name = "xnnpack_backend",
         srcs = native.glob([
             "runtime/*.cpp",
+            "runtime/profiling/*.cpp",
         ]),
         headers = native.glob([
             "runtime/*.h",
+            "runtime/profiling/*.h",
         ]),
         visibility = [
             "//executorch/exir/backend:backend_lib",

--- a/backends/xnnpack/xnnpack_preprocess.py
+++ b/backends/xnnpack/xnnpack_preprocess.py
@@ -258,5 +258,6 @@ class XnnpackBackend(BackendDetails):
                 continue
             else:
                 raise RuntimeError(f"{node.op} is not supported in XNNPACK")
-
-        return PreprocessResult(processed_bytes=serialize_xnnpack_binary(xnnpack_graph))
+        return PreprocessResult(
+            processed_bytes=serialize_xnnpack_binary(xnnpack_graph), debug_handle_map={}
+        )

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -7,12 +7,14 @@
 # Example script for exporting simple models to flatbuffer
 
 import argparse
+import copy
 import logging
 
 import torch._export as export
 
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
 from executorch.exir import EdgeCompileConfig, ExecutorchBackendConfig
+from executorch.sdk import generate_etrecord
 
 from ..models import MODEL_NAME_TO_MODEL
 from ..models.model_factory import EagerModelFactory
@@ -31,7 +33,7 @@ if __name__ == "__main__":
         "-m",
         "--model_name",
         required=True,
-        help=f"Provide model name. Valid ones: {list(MODEL_NAME_TO_OPTIONS.keys())}",
+        help=f"Model name. Valid ones: {list(MODEL_NAME_TO_OPTIONS.keys())}",
     )
     parser.add_argument(
         "-q",
@@ -39,7 +41,7 @@ if __name__ == "__main__":
         action="store_true",
         required=False,
         default=False,
-        help="Flag for producing quantized or floating-point model",
+        help="Produce an 8-bit quantized quantized model",
     )
     parser.add_argument(
         "-d",
@@ -47,7 +49,13 @@ if __name__ == "__main__":
         action="store_true",
         required=False,
         default=True,
-        help="Flag for producing XNNPACK delegated model",
+        help="Produce an XNNPACK delegated model",
+    )
+    parser.add_argument(
+        "-r",
+        "--etrecord",
+        required=False,
+        help="Generate and save an ETRecord to the given file location",
     )
 
     args = parser.parse_args()
@@ -87,12 +95,19 @@ if __name__ == "__main__":
     )
     logging.info(f"Exported graph:\n{edge.exported_program().graph}")
 
+    # this is needed for the ETRecord as lowering modifies the graph in-place
+    edge_copy = copy.deepcopy(edge)
+
     edge = edge.to_backend(XnnpackPartitioner())
     logging.info(f"Lowered graph:\n{edge.exported_program().graph}")
 
     exec_prog = edge.to_executorch(
         config=ExecutorchBackendConfig(extract_constant_segment=False)
     )
+
+    if args.etrecord is not None:
+        generate_etrecord(args.etrecord, edge_copy, exec_prog)
+        logging.info(f"Saved ETRecord to {args.etrecord}")
 
     quant_tag = "q8" if args.quantize else "fp32"
     model_name = f"{args.model_name}_xnnpack_{quant_tag}"


### PR DESCRIPTION
Initial implementation of SDK support in the XNNPACK delegate. Does not include support for mapping event blocks to edge graph node IDs yet, but does implement a baseline level of support by tracing XNNPACK profiler output.

Also update XNNPACK AOT and runner example scripts to support ETDump and ETRecord generation.
 Example AOT invocation: `python3 -m examples.xnnpack.aot_compiler --model_name="mv2" --delegate -r mv2_etrecord.bin`
 Example runner invocation: `buck2 run examples/xnnpack:xnn_executor_runner -c executorch.event_tracer_enabled=true -- --model_path ./mv2_xnnpack_fp32.pte --dump_path etdump.bin`

Example output (MV2 example model, `Inspector.print_data_tabular()`):
```
╒════╤════════════════════╤═══════════════════════════════════╤════════════╤════════════╤════════════╤════════════╤════════════╤════════════╤══════════════════════════════════════════════════╤═══════════════════╤═════════════════════════╕
│    │ event_block_name   │ event_name                        │   p10 (ms) │   p50 (ms) │   p90 (ms) │   avg (ms) │   min (ms) │   max (ms) │ op_types                                         │ is_delegated_op   │ delegate_backend_name   │
╞════╪════════════════════╪═══════════════════════════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪══════════════════════════════════════════════════╪═══════════════════╪═════════════════════════╡
│  0 │ Default            │ Method::init                      │   28.3858  │   28.3858  │   28.3858  │   28.3858  │   28.3858  │   28.3858  │ []                                               │ False             │                         │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│  1 │ Default            │ Program::load_method              │   28.3976  │   28.3976  │   28.3976  │   28.3976  │   28.3976  │   28.3976  │ []                                               │ False             │                         │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│  2 │ Execute            │ Transpose (ND, X32)               │    1       │    1       │    1       │    1       │    1       │    1       │ []                                               │ True              │ XnnpackBackend          │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│  3 │ Execute            │ Convolution (NHWC, F32) IGEMM     │  217       │  217       │  217       │  217       │  217       │  217       │ []                                               │ True              │ XnnpackBackend          │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│  4 │ Execute            │ Convolution (NHWC, F32) DWConv    │  105       │  105       │  105       │  105       │  105       │  105       │ []                                               │ True              │ XnnpackBackend          │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│  5 │ Execute            │ Convolution (NHWC, F32) GEMM      │  227       │  227       │  227       │  227       │  227       │  227       │ []                                               │ True              │ XnnpackBackend          │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│  6 │ Execute            │ Add (ND, F32)                     │    3       │    3       │    3       │    3       │    3       │    3       │ []                                               │ True              │ XnnpackBackend          │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│  7 │ Execute            │ Global Average Pooling (NWC, F32) │   15       │   15       │   15       │   15       │   15       │   15       │ []                                               │ True              │ XnnpackBackend          │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│  8 │ Execute            │ DELEGATE_CALL                     │   11.9553  │   11.9553  │   11.9553  │   11.9553  │   11.9553  │   11.9553  │ ['aten.view_copy.default', 'aten.clone.default'] │ False             │                         │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│  9 │ Execute            │ native_call_view_copy.out         │    0.01666 │    0.01666 │    0.01666 │    0.01666 │    0.01666 │    0.01666 │ ['aten.view_copy.default']                       │ False             │                         │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│ 11 │ Execute            │ native_call_clone.out             │    0.01319 │    0.01319 │    0.01319 │    0.01319 │    0.01319 │    0.01319 │ ['aten.clone.default']                           │ False             │                         │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│ 13 │ Execute            │ Fully Connected (NC, F32) GEMM    │  173       │  173       │  173       │  173       │  173       │  173       │ []                                               │ True              │ XnnpackBackend          │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│ 14 │ Execute            │ DELEGATE_CALL                     │    0.19363 │    0.19363 │    0.19363 │    0.19363 │    0.19363 │    0.19363 │ []                                               │ False             │                         │
├────┼────────────────────┼───────────────────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼──────────────────────────────────────────────────┼───────────────────┼─────────────────────────┤
│ 15 │ Execute            │ Method::execute                   │   12.195   │   12.195   │   12.195   │   12.195   │   12.195   │   12.195   │ []                                               │ False             │                         │
╘════╧════════════════════╧═══════════════════════════════════╧════════════╧════════════╧════════════╧════════════╧════════════╧════════════╧══════════════════════════════════════════════════╧═══════════════════╧═════════════════════════╛
```