### PR TITLE
Fix update-commit-hash env condition on nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   update-pytorch-commit-hash:
     runs-on: ubuntu-latest
-    environment: ${{ (github.event.ref == 'refs/heads/main') && 'update-commit-hash' || '' }}
+    environment: ${{ (github.event_name == 'schedule') && 'update-commit-hash' || '' }}
     steps:
       - name: update-pytorch-commit-hash
         uses: pytorch/test-infra/.github/actions/update-commit-hash@main


### PR DESCRIPTION
The `github.event.ref == 'refs/heads/main'` condition didn't work as I expected for a scheduled event.  Thus, the nightly job failed to find the necessary tokens to run https://github.com/pytorch/executorch/actions/runs/7564420559/job/20598490541#step:2:24.

Switching to `github.event_name == 'schedule'` should work because it's the same condition used below.  Testing on https://github.com/pytorch/executorch/actions/runs/7564420559 looks ok.  The PR is created at https://github.com/pytorch/executorch/pull/1613, which I will try to import and land.