### PR TITLE
Add tick rate API to PAL

### DIFF
--- a/docs/source/runtime-platform-abstraction-layer.md
+++ b/docs/source/runtime-platform-abstraction-layer.md
@@ -22,8 +22,10 @@ But, if they don't work for your system, you can override the default PAL by:
   in one of your application's `.c` or `.cpp` files.
 - Defining an implementation of one or more of the `et_pal_*()` functions.
 
-No build system changes necessary. The default PAL functions are weak symbols,
-so providing your own strong-symbol definition will override them at link time.
+The default PAL functions are weak symbols, so providing your own strong-symbol
+definition can override them at link time. To ensure that your definitions take
+precedence, you may need to ensure that the strong definitions precede the weak
+definitions in the link order.
 
 ## Minimal PAL
 

--- a/runtime/platform/clock.h
+++ b/runtime/platform/clock.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file
+ * Clock and timing related methods.
+ */
+
+#pragma once
+
+#include <executorch/runtime/platform/platform.h>
+
+namespace torch {
+namespace executor {
+
+/**
+ * Convert an interval from units of system ticks to nanoseconds.
+ * The conversion ratio is platform-dependent, and thus depends on
+ * the platform implementation of et_pal_ticks_to_ns_multiplier().
+ *
+ * @param[in] ticks The interval length in system ticks.
+ * @retval The interval length in nanoseconds.
+ */
+inline uint64_t ticks_to_ns(et_timestamp_t ticks) {
+  et_tick_ratio_t ratio = et_pal_ticks_to_ns_multiplier();
+  return static_cast<uint64_t>(ticks) * ratio.numerator / ratio.denominator;
+}
+
+} // namespace executor
+} // namespace torch

--- a/runtime/platform/platform.h
+++ b/runtime/platform/platform.h
@@ -38,6 +38,15 @@
 extern "C" {
 
 /**
+ * Represents the conversion ratio from system ticks to nanoseconds.
+ * To convert, use nanoseconds = ticks * numerator / denominator.
+ */
+typedef struct {
+  uint64_t numerator;
+  uint64_t denominator;
+} et_tick_ratio_t;
+
+/**
  * Initialize the platform abstraction layer.
  *
  * This function should be called before any other function provided by the PAL
@@ -57,6 +66,21 @@ __ET_NORETURN void et_pal_abort(void) ET_INTERNAL_PLATFORM_WEAKNESS;
  * @retval Timestamp value in system ticks.
  */
 et_timestamp_t et_pal_current_ticks(void) ET_INTERNAL_PLATFORM_WEAKNESS;
+
+/**
+ * Return the conversion rate from system ticks to nanoseconds as a fraction.
+ * To convert a system ticks to nanoseconds, multiply the tick count by the
+ * numerator and then divide by the denominator:
+ *   nanoseconds = ticks * numerator / denominator
+ *
+ * The utility method torch::executor::ticks_to_ns(et_timestamp_t) can also
+ * be used to perform the conversion for a given tick count.
+ * It is defined in torch/executor/runtime/platform/clock.h.
+ *
+ * @retval The ratio of nanoseconds to system ticks.
+ */
+et_tick_ratio_t et_pal_ticks_to_ns_multiplier(void)
+    ET_INTERNAL_PLATFORM_WEAKNESS;
 
 /**
  * Severity level of a log message. Values must map to printable 7-bit ASCII

--- a/runtime/platform/target/Minimal.cpp
+++ b/runtime/platform/target/Minimal.cpp
@@ -34,6 +34,11 @@ et_timestamp_t et_pal_current_ticks(void) {
   return 11223344;
 }
 
+et_tick_ratio_t et_pal_ticks_to_ns_multiplier(void) {
+  // Since we don't define a tick rate, return a conversion ratio of 1.
+  return {1, 1};
+}
+
 void et_pal_emit_log_message(
     __ET_UNUSED et_timestamp_t timestamp,
     __ET_UNUSED et_pal_log_level_t level,

--- a/runtime/platform/target/Posix.cpp
+++ b/runtime/platform/target/Posix.cpp
@@ -106,6 +106,19 @@ et_timestamp_t et_pal_current_ticks(void) {
 }
 
 /**
+ * Return the conversion rate from system ticks to nanoseconds, as a fraction.
+ * To convert an interval from system ticks to nanoseconds, multiply the tick
+ * count by the numerator and then divide by the denominator:
+ *   nanoseconds = ticks * numerator / denominator
+ *
+ * @retval The ratio of nanoseconds to system ticks.
+ */
+et_tick_ratio_t et_pal_ticks_to_ns_multiplier(void) {
+  // The system tick interval is 1 nanosecond, so the conversion factor is 1.
+  return {1, 1};
+}
+
+/**
  * Emit a log message via platform output (serial port, console, etc).
  *
  * @param[in] timestamp Timestamp of the log event in system ticks since boot.

--- a/runtime/platform/targets.bzl
+++ b/runtime/platform/targets.bzl
@@ -66,6 +66,7 @@ def define_common_targets():
         exported_headers = [
             "abort.h",
             "assert.h",
+            "clock.h",
             "log.h",
             "profiler.h",
             "runtime.h",

--- a/runtime/platform/test/clock_test.cpp
+++ b/runtime/platform/test/clock_test.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/platform/clock.h>
+
+#include <executorch/runtime/platform/test/stub_platform.h>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+class PalSpy : public PlatformIntercept {
+ public:
+  et_tick_ratio_t ticks_to_ns_multiplier() override {
+    return tick_ns_multiplier;
+  }
+
+  et_tick_ratio_t tick_ns_multiplier = {1, 1};
+};
+
+TEST(ClockTest, ConvertTicksToNsSanity) {
+  PalSpy spy;
+  InterceptWith iw(spy);
+
+  spy.tick_ns_multiplier = {3, 2};
+  auto ns = torch::executor::ticks_to_ns(10);
+  ASSERT_EQ(15, ns); // 10 ticks * 3/2 = 15 ns
+
+  spy.tick_ns_multiplier = {2, 7};
+  ns = torch::executor::ticks_to_ns(14);
+  ASSERT_EQ(4, ns); // 14 ticks * 2/7 = 4 ns
+}

--- a/runtime/platform/test/executor_pal_override_test.cpp
+++ b/runtime/platform/test/executor_pal_override_test.cpp
@@ -31,6 +31,10 @@ class PalSpy : public PlatformIntercept {
     return kTimestamp;
   }
 
+  et_tick_ratio_t ticks_to_ns_multiplier() override {
+    return tick_ns_multiplier;
+  }
+
   void emit_log_message(
       et_timestamp_t timestamp,
       et_pal_log_level_t level,
@@ -54,6 +58,7 @@ class PalSpy : public PlatformIntercept {
   size_t init_call_count = 0;
   size_t current_ticks_call_count = 0;
   size_t emit_log_message_call_count = 0;
+  et_tick_ratio_t tick_ns_multiplier = {1, 1};
 
   /// The args that were passed to the most recent call to emit_log_message().
   struct {
@@ -137,4 +142,19 @@ TEST(ExecutorPalOverrideTest, LogLevels) {
   ET_LOG(NumLevels, "Test log");
   EXPECT_EQ(args.level, et_pal_log_level_t::kUnknown);
 }
+
+TEST(ExecutorPalOverrideTest, TickToNsMultiplier) {
+  PalSpy spy;
+  InterceptWith iw(spy);
+
+  // Validate that tick to ns multipliers are overridden.
+  spy.tick_ns_multiplier = {2, 3};
+  EXPECT_EQ(et_pal_ticks_to_ns_multiplier().numerator, 2);
+  EXPECT_EQ(et_pal_ticks_to_ns_multiplier().denominator, 3);
+
+  spy.tick_ns_multiplier = {3, 1};
+  EXPECT_EQ(et_pal_ticks_to_ns_multiplier().numerator, 3);
+  EXPECT_EQ(et_pal_ticks_to_ns_multiplier().denominator, 1);
+}
+
 #endif

--- a/runtime/platform/test/executor_pal_test.cpp
+++ b/runtime/platform/test/executor_pal_test.cpp
@@ -27,3 +27,9 @@ TEST(ExecutorPalTest, TimestampCoherency) {
   et_timestamp_t time_b = et_pal_current_ticks();
   ASSERT_TRUE(time_b >= time_a);
 }
+
+TEST(ExecutorPalTest, TickRateRatioSanity) {
+  auto tick_ns_ratio = et_pal_ticks_to_ns_multiplier();
+  ASSERT_TRUE(tick_ns_ratio.numerator > 0);
+  ASSERT_TRUE(tick_ns_ratio.denominator > 0);
+}

--- a/runtime/platform/test/stub_platform.cpp
+++ b/runtime/platform/test/stub_platform.cpp
@@ -57,6 +57,11 @@ et_timestamp_t et_pal_current_ticks(void) {
   return platform_intercept->current_ticks();
 }
 
+et_tick_ratio_t et_pal_ticks_to_ns_multiplier(void) {
+  ASSERT_INTERCEPT_INSTALLED();
+  return platform_intercept->ticks_to_ns_multiplier();
+}
+
 void et_pal_emit_log_message(
     et_timestamp_t timestamp,
     et_pal_log_level_t level,

--- a/runtime/platform/test/stub_platform.h
+++ b/runtime/platform/test/stub_platform.h
@@ -31,6 +31,10 @@ class PlatformIntercept {
     return 0;
   }
 
+  virtual et_tick_ratio_t ticks_to_ns_multiplier() {
+    return {1, 1};
+  }
+
   /// Called when et_pal_emit_log_message() is called.
   virtual void emit_log_message(
       __ET_UNUSED et_timestamp_t timestamp,

--- a/runtime/platform/test/targets.bzl
+++ b/runtime/platform/test/targets.bzl
@@ -56,9 +56,12 @@ def define_common_targets():
             "executor_pal_override_test.cpp",
         ],
         deps = [
+            # This must come first to ensure that the weak platform
+            # calls are overriden.
+            # buildifier: do not sort
+            ":stub_platform",
             "//executorch/runtime/core:core",
             "//executorch/runtime/platform:platform",
-            ":stub_platform",
         ],
     )
 
@@ -73,5 +76,20 @@ def define_common_targets():
         compiler_flags = [
             # Turn on debug logging.
             "-DET_MIN_LOG_LEVEL=Debug",
+        ],
+    )
+
+    runtime.cxx_test(
+        name = "clock_test",
+        srcs = [
+            "clock_test.cpp",
+        ],
+        deps = [
+            # This must come first to ensure that the weak platform
+            # calls are overriden.
+            # buildifier: do not sort
+            ":stub_platform",
+            "//executorch/runtime/core:core",
+            "//executorch/runtime/platform:platform",
         ],
     )


### PR DESCRIPTION
Summary: Add a new PAL method to retrieve the conversion ratio between ticks and nanoseconds. This is needed to support conversion between ticks and fixed units, such as the microseconds returned by the XNNPACK profiling API.

Differential Revision: D52915789


