### PR TITLE
controller_tracking_evpr onboarding

### DIFF
--- a/exir/verification/verifier.py
+++ b/exir/verification/verifier.py
@@ -78,6 +78,8 @@ class EXIRATenDialectVerifier(EXIRATenDialectVerifierBase):
                 torch.ops.aten.quantize_per_tensor.default,
                 torch.ops.aten.dequantize.self,
                 torch.ops.aten.max.default,
+                torch.ops.aten._linalg_svd.default,
+                torch.ops.aten._linalg_det.default,
             ):
                 return
             if torch.Tag.core not in op.tags and torch.Tag.view_copy not in op.tags:


### PR DESCRIPTION
Summary: Onboarding ControllerTrackingEvpr model to et platform. Currently we only support aten ops due to the lack of portable kernels. Also makes two ops, `torch.ops.aten._linalg_svd.default` and `torch.ops.aten._linalg_det.default` as legal ops.

Differential Revision: D52265788


