### PR TITLE
Change the way tokenizer and model are being serialized

### DIFF
--- a/examples/models/llama2/llama_runner.cpp
+++ b/examples/models/llama2/llama_runner.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// A simple llama2 runner that includes preprocessing and post processing logic.
+// The module takes in a string as input and emits a string as output.
+
+#include <executorch/examples/models/llama2/llama_runner.h>
+#ifdef USE_ATEN_LIB
+#include <torch/torch.h>
+#endif
+
+namespace torch {
+namespace executor {
+
+LlamaRunner::LlamaRunner(const char* model_path, const char* tokenizer_path) {
+  // Constants definition
+  float temperature = 0.8f;
+  float topp = 0.9f;
+  unsigned long long rng_seed =
+      (unsigned int)time(nullptr); // seed rng with time by default
+  // Create module
+  module_ = std::make_unique<Module>(
+      model_path, Module::MlockConfig::UseMlockIgnoreErrors);
+
+  // Read out metadata: vocab_size (expected by the model), BOS, EOS, n_BOS,
+  // n_EOS max_seq_len from the model
+  ET_LOG(Info, "Reading metadata from model");
+  Result<std::vector<std::string>> method_names = module_->methodNames();
+  ET_CHECK_MSG(
+      method_names.ok(),
+      "Failed to read method names from model: %s",
+      model_path);
+  auto metadata = readMetadata(method_names.get());
+  vocab_size_ = metadata[0];
+  bos_id_ = metadata[1];
+  eos_id_ = metadata[2];
+  n_bos_ = metadata[3];
+  n_eos_ = metadata[4];
+  max_seq_len_ = metadata[5];
+
+  // Load tokenizer
+  tokenizer_ = std::make_unique<Tokenizer>(vocab_size_, bos_id_, eos_id_);
+  tokenizer_->load(tokenizer_path);
+  if (tokenizer_->bos_tok() != bos_id_) {
+    ET_LOG(
+        Error,
+        "Tokenizer's BOS id %d does not match model's BOS id %d, will override tokenizer's BOS.",
+        tokenizer_->bos_tok(),
+        bos_id_);
+  }
+  if (tokenizer_->eos_tok() != eos_id_) {
+    ET_LOG(
+        Error,
+        "Tokenizer's EOS id %d does not match model's EOS id %d, will override tokenizer's EOS.",
+        tokenizer_->eos_tok(),
+        eos_id_);
+  }
+  // Create sampler
+  sampler_ =
+      std::make_unique<Sampler>(vocab_size_, temperature, topp, rng_seed);
+}
+
+std::vector<int32_t> LlamaRunner::readMetadata(
+    std::vector<std::string> model_methods) {
+  std::vector<std::string> methods = {
+      "get_vocab_size",
+      "get_bos_id",
+      "get_eos_id",
+      "get_n_bos",
+      "get_n_eos",
+      "get_max_seq_len"};
+  std::vector<int32_t> default_values = {32000, 1, 2, 1, 1, 128};
+  std::vector<int32_t> result;
+  for (int i = 0; i < methods.size(); ++i) {
+    int32_t res = default_values[i];
+    if (std::find(model_methods.begin(), model_methods.end(), methods[i]) !=
+        model_methods.end()) {
+      Result<std::vector<EValue>> outputs = module_->execute(methods[i]);
+      if (outputs.ok()) {
+        std::vector<EValue> outs = outputs.get();
+        if (outs.size() > 0) {
+          res = outs[0].toInt();
+        }
+      }
+    } else {
+      ET_LOG(
+          Info,
+          "The model does not contain %s method, using default value %d",
+          methods[i].c_str(),
+          default_values[i]);
+    }
+    ET_LOG(Info, "%s: %d", methods[i].c_str(), res);
+    result.push_back(res);
+  }
+  return result;
+}
+
+void LlamaRunner::generate(const char* prompt) {
+  // Prepare the inputs.
+  // Use ones-initialized inputs.
+  ET_CHECK_MSG(prompt != nullptr, "Prompt cannot be null");
+
+  // encode the (string) prompt into tokens sequence
+  int num_prompt_tokens = 0;
+  // max # of prompt tokens: len(prompt) + '\0', ?BOS, ?EOS
+  int* prompt_tokens = new int[strlen(prompt) + 1 + n_bos_ + n_eos_];
+
+  tokenizer_->encode(prompt, n_bos_, n_eos_, prompt_tokens, &num_prompt_tokens);
+
+  ET_CHECK_MSG(num_prompt_tokens >= 1, "Expected at least 1 prompt token");
+
+  // start the main loop
+  long start =
+      0; // used to time our code, only initialized after first iteration
+  int next; // will store the next token in the sequence
+  int pos = 0; // position in the sequence
+  int token = prompt_tokens[pos]; // prefill starts from 0 to num_prompt_tokens
+  int eos_counter = 0; // counter to capture EOS
+  void* data =
+      malloc(max_seq_len_ * sizeof(long)); // allocate space for the tokens
+  // create a 1xN int tensor with next as value
+  exec_aten::SizesType sizes[2]{1, 1};
+  exec_aten::DimOrderType dim_order[2]{0, 1};
+
+  while (pos < max_seq_len_) {
+    // ET_LOG(Info, "Generating step %d...", pos);
+    // set the current token in the tensor
+    ((long*)data)[pos] = token;
+    sizes[1] = pos + 1;
+#ifdef USE_ATEN_LIB
+    exec_aten::Tensor tensor =
+        torch::from_blob(data, /*dim*/ sizes, torch::kLong);
+#else
+    exec_aten::TensorImpl tensor_impl(
+        ScalarType::Long, /*dim*/ 2, sizes, data, dim_order);
+    exec_aten::Tensor tensor(&tensor_impl);
+#endif
+    Result<std::vector<EValue>> outputs_res =
+        module_->forward({EValue(tensor)});
+    ET_CHECK_MSG(
+        outputs_res.ok(),
+        "Execution of method forward failed with status 0x%" PRIx32,
+        outputs_res.error());
+    // ET_LOG(Info, "Model executed successfully.");
+
+    std::vector<EValue> outputs = outputs_res.get();
+    // Check the outputs.
+    ET_CHECK_MSG(
+        outputs.size() > 0,
+        "Expecting output to have at least one evalue. Got %zu",
+        outputs.size());
+
+    float* logits = outputs[0].toTensor().mutable_data_ptr<float>();
+    // debug
+    // torch::Tensor t = torch::from_blob(
+    //     (void*)logits, {1, num_prompt_tokens, 32000}, torch::kFloat);
+
+    // Since the logits are for all tokens, get the last token probabilities
+    float* logits_last = logits + pos * tokenizer_->vocab_size();
+    // advance the state machine
+    if (pos < num_prompt_tokens - 1) {
+      // prefill, force the next token to be the next prompt token
+      next = prompt_tokens[pos + 1];
+    } else {
+      // otherwise sample the next token from the logits
+      next = sampler_->sample(logits_last);
+    }
+    // ET_LOG(Info, "Output saved, next = %d", next);
+    pos++;
+
+    // print the token as string, decode it with the Tokenizer object
+    auto piece_res = tokenizer_->decode(token, next);
+    ET_CHECK(piece_res.ok());
+    const char* piece = piece_res.get();
+
+    // same as printf("%s", piece), but skips "unsafe" bytes
+    util::safe_printf(piece);
+    fflush(stdout);
+
+    // data-dependent terminating condition: we have n_eos_ number of EOS
+    if (pos >= num_prompt_tokens && next == eos_id_) {
+      eos_counter++;
+      if (eos_counter == n_eos_) {
+        ET_LOG(Info, "Reached to the end of generation");
+        break;
+      }
+    } else {
+      eos_counter = 0;
+    }
+
+    token = next;
+
+    // init the timer here because the first iteration can be slower
+    if (start == 0) {
+      start = util::time_in_ms();
+    }
+  }
+  printf("\n");
+
+  if (pos == max_seq_len_) {
+    ET_LOG(Info, "Maximum sequence length reached!");
+  }
+  // report achieved tok/s (pos-1 because the timer starts after first
+  // iteration)
+  if (pos >= 1) {
+    long end = util::time_in_ms();
+    ET_LOG(
+        Info, "Achieved tok/s: %f\n", (pos - 1) / (double)(end - start) * 1000);
+  }
+
+  delete[] prompt_tokens;
+  free(data);
+}
+
+LlamaRunner::~LlamaRunner() {}
+} // namespace executor
+} // namespace torch
+
+DEFINE_string(
+    model_path,
+    "llama2.pte",
+    "Model serialized in flatbuffer format.");
+
+DEFINE_string(tokenizer_path, "tokenizer.bin", "Tokenizer stuff.");
+
+DEFINE_string(prompt, "The answer to the ultimate question is", "Prompt.");
+
+using namespace torch::executor;
+using torch::executor::util::MmapDataLoader;
+
+int32_t main(int32_t argc, char** argv) {
+  runtime_init();
+
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  // Create a loader to get the data of the program file. There are other
+  // DataLoaders that use mmap() or point32_t to data that's already in memory,
+  // and users can create their own DataLoaders to load from arbitrary sources.
+  const char* model_path = FLAGS_model_path.c_str();
+
+  const char* tokenizer_path = FLAGS_tokenizer_path.c_str();
+
+  const char* prompt = FLAGS_prompt.c_str();
+
+  // create llama runner
+  LlamaRunner llama_runner(model_path, tokenizer_path);
+
+  // generate
+  llama_runner.generate(prompt);
+  return 0;
+}

--- a/examples/models/llama2/llama_runner.h
+++ b/examples/models/llama2/llama_runner.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// A simple llama2 runner that includes preprocessing and post processing logic.
+// The module takes in a string as input and emits a string as output.
+#pragma once
+#include <memory>
+#include <unordered_map>
+
+#include <gflags/gflags.h>
+
+#include <executorch/examples/models/llama2/sampler/sampler.h>
+#include <executorch/examples/models/llama2/tokenizer/tokenizer.h>
+#include <executorch/examples/models/llama2/util.h>
+#include <executorch/extension/data_loader/mmap_data_loader.h>
+#include <executorch/extension/evalue_util/print_evalue.h>
+#include <executorch/extension/memory_allocator/malloc_memory_allocator.h>
+#include <executorch/extension/module/module.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/program.h>
+#include <executorch/runtime/platform/log.h>
+#include <executorch/runtime/platform/runtime.h>
+
+namespace torch {
+namespace executor {
+
+class LlamaRunner {
+ public:
+  explicit LlamaRunner(const char* model_path, const char* tokenizer_path);
+
+  void generate(const char* prompt);
+
+  ~LlamaRunner();
+
+ private:
+  std::vector<int32_t> readMetadata(std::vector<std::string> method_names);
+  // metadata
+  int32_t vocab_size_;
+  int32_t bos_id_;
+  int32_t eos_id_;
+  int32_t n_bos_;
+  int32_t n_eos_;
+  int32_t max_seq_len_;
+  // module
+  std::unique_ptr<Module> module_;
+  // tokenizer
+  std::unique_ptr<Tokenizer> tokenizer_;
+  // sampler
+  std::unique_ptr<Sampler> sampler_;
+};
+
+} // namespace executor
+} // namespace torch

--- a/examples/models/llama2/sampler/sampler.cpp
+++ b/examples/models/llama2/sampler/sampler.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// This is a modified version of https://github.com/karpathy/llama2.c.git
+// @lint-ignore-every LICENSELINT
+/**
+ * MIT License
+ *
+ * Copyright (c) 2023 Andrej
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <executorch/examples/models/llama2/sampler/sampler.h>
+
+namespace torch {
+namespace executor {
+
+// sampler stuff
+int32_t Sampler::sample_argmax(float* probabilities) {
+  // return the index that has the highest probability
+  int max_i = 0;
+  float max_p = probabilities[0];
+  for (int i = 1; i < vocab_size_; i++) {
+    if (probabilities[i] > max_p) {
+      max_i = i;
+      max_p = probabilities[i];
+    }
+  }
+  return max_i;
+}
+
+int32_t Sampler::sample_mult(float* probabilities, float coin) {
+  // sample index from probabilities (they must sum to 1!)
+  // coin is a random number in [0, 1), usually from random_f32()
+  float cdf = 0.0f;
+  for (int i = 0; i < vocab_size_; i++) {
+    cdf += probabilities[i];
+    if (coin < cdf) {
+      return i;
+    }
+  }
+  return vocab_size_ - 1; // in case of rounding errors
+}
+
+int32_t compare(const void* a, const void* b) {
+  ProbIndex* a_ = (ProbIndex*)a;
+  ProbIndex* b_ = (ProbIndex*)b;
+  if (a_->prob > b_->prob) {
+    return -1;
+  } else if (a_->prob < b_->prob) {
+    return 1;
+  }
+  return 0;
+}
+
+int32_t Sampler::sample_topp(float* probabilities, float coin) {
+  // top-p sampling (or "nucleus sampling") samples from the smallest set of
+  // tokens that exceed probability topp. This way we never sample tokens that
+  // have very low probabilities and are less likely to go "off the rails".
+  // coin is a random number in [0, 1), usually from random_f32()
+  int n = vocab_size_;
+  int n0 = 0;
+  // quicksort indices in descending order of probabilities
+  // values smaller than (1 - topp) / (n - 1) cannot be part of the result
+  // so for efficiency we crop these out as candidates before sorting
+  const float cutoff = (1.0f - topp_) / (n - 1);
+  for (int i = 0; i < n; i++) {
+    if (probabilities[i] >= cutoff) {
+      probindex_[n0].index = i;
+      probindex_[n0].prob = probabilities[i];
+      n0++;
+    }
+  }
+  qsort(probindex_.get(), n0, sizeof(ProbIndex), compare);
+
+  // truncate the list where cumulative probability exceeds topp
+  float cumulative_prob = 0.0f;
+  int last_idx = n0 - 1; // in case of rounding errors consider all elements
+  for (int i = 0; i < n0; i++) {
+    cumulative_prob += probindex_[i].prob;
+    if (cumulative_prob > topp_) {
+      last_idx = i;
+      break; // we've exceeded topp by including last_idx
+    }
+  }
+
+  // sample from the truncated list
+  float r = coin * cumulative_prob;
+  float cdf = 0.0f;
+  for (int i = 0; i <= last_idx; i++) {
+    cdf += probindex_[i].prob;
+    if (r < cdf) {
+      return probindex_[i].index;
+    }
+  }
+  return probindex_[last_idx].index; // in case of rounding errors
+}
+
+Sampler::Sampler(
+    int vocab_size,
+    float temperature,
+    float topp,
+    unsigned long long rng_seed)
+    : vocab_size_(vocab_size),
+      probindex_(std::make_unique<ProbIndex[]>(vocab_size)),
+      temperature_(temperature),
+      topp_(topp),
+      rng_state_(rng_seed) {}
+
+void softmax(float* x, int size) {
+  // find max value (for numerical stability)
+  float max_val = x[0];
+  for (int i = 1; i < size; i++) {
+    if (x[i] > max_val) {
+      max_val = x[i];
+    }
+  }
+  // exp and sum
+  float sum = 0.0f;
+  for (int i = 0; i < size; i++) {
+    x[i] = expf(x[i] - max_val);
+    sum += x[i];
+  }
+  // normalize
+  for (int i = 0; i < size; i++) {
+    x[i] /= sum;
+  }
+}
+
+unsigned int random_u32(unsigned long long* state) {
+  // xorshift rng: https://en.wikipedia.org/wiki/Xorshift#xorshift.2A
+  *state ^= *state >> 12;
+  *state ^= *state << 25;
+  *state ^= *state >> 27;
+  return (*state * 0x2545F4914F6CDD1Dull) >> 32;
+}
+
+float random_f32(unsigned long long* state) { // random float32 in [0,1)
+  return (random_u32(state) >> 8) / 16777216.0f;
+}
+
+int32_t Sampler::sample(float* logits) {
+  // sample the token given the logits and some hyperparameters
+  int next;
+  if (temperature_ == 0.0f) {
+    // greedy argmax sampling: take the token with the highest probability
+    next = sample_argmax(logits);
+  } else {
+    // apply the temperature to the logits
+    for (int q = 0; q < vocab_size_; q++) {
+      logits[q] /= temperature_;
+    }
+    // apply softmax to the logits to get the probabilities for next token
+    softmax(logits, vocab_size_);
+    // flip a (float) coin (this is our source of entropy for sampling)
+    float coin = random_f32(&rng_state_);
+    // we sample from this distribution to get the next token
+    if (topp_ <= 0 || topp_ >= 1) {
+      // simply sample from the predicted probability distribution
+      next = sample_mult(logits, coin);
+    } else {
+      // top-p (nucleus) sampling, clamping the least likely tokens to zero
+      next = sample_topp(logits, coin);
+    }
+  }
+  return next;
+}
+
+} // namespace executor
+} // namespace torch

--- a/examples/models/llama2/sampler/sampler.h
+++ b/examples/models/llama2/sampler/sampler.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <math.h>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+
+namespace torch {
+namespace executor {
+// A simple llama2 sampler.
+
+struct ProbIndex {
+  float prob;
+  int32_t index;
+}; // struct used when sorting probabilities during top-p sampling
+
+class Sampler {
+ public:
+  Sampler(
+      int32_t vocab_size,
+      float temperature,
+      float topp,
+      unsigned long long rng_seed);
+
+  int32_t sample(float* logits);
+
+ private:
+  int32_t sample_topp(float* probabilities, float coin);
+  int32_t sample_mult(float* probabilities, float coin);
+  int32_t sample_argmax(float* probabilities);
+
+ private:
+  int32_t vocab_size_;
+  std::unique_ptr<ProbIndex[]> probindex_; // buffer used in top-p sampling
+  float temperature_;
+  float topp_;
+  unsigned long long rng_state_;
+};
+
+} // namespace executor
+} // namespace torch

--- a/examples/models/llama2/sampler/targets.bzl
+++ b/examples/models/llama2/sampler/targets.bzl
@@ -1,0 +1,21 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    runtime.cxx_library(
+        name = "sampler",
+        exported_headers = ["sampler.h"],
+        srcs = ["sampler.cpp"],
+        visibility = [
+            "//executorch/...",
+        ],
+    )
+
+    runtime.cxx_test(
+        name = "test_sampler",
+        srcs = ["test/test_sampler.cpp"],
+        deps = [
+            ":sampler",
+            "//caffe2:torch-cpp",
+            "//executorch/runtime/platform:platform",
+        ],
+    )

--- a/examples/models/llama2/sampler/test/test_sampler.cpp
+++ b/examples/models/llama2/sampler/test/test_sampler.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/examples/models/llama2/sampler/sampler.h>
+#include <executorch/runtime/platform/runtime.h>
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+using namespace ::testing;
+
+namespace torch {
+namespace executor {
+
+class SamplerTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    torch::executor::runtime_init();
+  }
+};
+
+TEST_F(SamplerTest, TestArgMax) {
+  torch::executor::Sampler sampler{
+      /*vocab_size*/ 32000,
+      /*temperature*/ 0.0f,
+      /*topp*/ 0.9f,
+      /*rng_seed*/ 0};
+  // tensor([[[-12.9832,  -7.4133,  -0.4327,  ...,  -6.8297,  -8.0880,
+  // -7.5863]]])
+  torch::Tensor input = torch::rand({1, 1, 32000}, at::kFloat);
+  input[0][0][396] = 1.0f;
+  EXPECT_EQ(sampler.sample(input.data_ptr<float>()), 396);
+}
+
+} // namespace executor
+} // namespace torch

--- a/examples/models/llama2/tokenizer/tokenizer.cpp
+++ b/examples/models/llama2/tokenizer/tokenizer.cpp
@@ -21,9 +21,11 @@ static int compare_tokens(const void* a, const void* b) {
   return strcmp(((TokenIndex*)a)->str, ((TokenIndex*)b)->str);
 }
 
-Tokenizer::Tokenizer(int32_t vocab_size)
+Tokenizer::Tokenizer(int32_t vocab_size, int32_t bos_tok, int32_t eos_tok)
     : initialized_(false),
       vocab_size_(vocab_size),
+      bos_tok_(bos_tok),
+      eos_tok_(eos_tok),
       vocab_(std::make_unique<char*[]>(vocab_size)),
       vocab_scores_(std::make_unique<float[]>(vocab_size)),
       sorted_vocab_(std::make_unique<TokenIndex[]>(vocab_size)) {
@@ -54,8 +56,8 @@ Error Tokenizer::load(const char* tokenizer_path) {
     ET_LOG(Error, "couldn't load %s", tokenizer_path);
     return Error::InvalidArgument;
   }
-  int32_t metadata[4];
-  for (int i = 0; i < 4; i++) {
+  int32_t metadata[2];
+  for (int i = 0; i < 2; i++) {
     if (fread(metadata + i, sizeof(int32_t), 1, file) != 1) {
       ET_LOG(
           Error,
@@ -82,9 +84,7 @@ Error Tokenizer::load(const char* tokenizer_path) {
         vocab_size_);
   }
 
-  bos_tok_ = metadata[1];
-  eos_tok_ = metadata[2];
-  max_token_length_ = metadata[3];
+  max_token_length_ = metadata[1];
 
   // allocate space for the vocabulary
   vocab_ = std::make_unique<char*[]>(vocab_size_);

--- a/examples/models/llama2/tokenizer/tokenizer.h
+++ b/examples/models/llama2/tokenizer/tokenizer.h
@@ -28,7 +28,7 @@ struct TokenIndex {
 
 class Tokenizer {
  public:
-  explicit Tokenizer(int32_t vocab_size);
+  explicit Tokenizer(int32_t vocab_size, int32_t bos_tok, int32_t eos_tok);
   ~Tokenizer();
 
   Error load(const char* tokenizer_path);

--- a/examples/models/llama2/tokenizer/tokenizer.py
+++ b/examples/models/llama2/tokenizer/tokenizer.py
@@ -101,11 +101,7 @@ class Tokenizer:
         # write to a binary file
         with open(output_path, "wb") as f:
             # write the vocab size, bos/eos ids and max token length
-            f.write(
-                struct.pack(
-                    "IIII", self.n_words, self.bos_id, self.eos_id, max_token_length
-                )
-            )
+            f.write(struct.pack("II", self.n_words, max_token_length))
             for bytes, score in zip(tokens, scores):
                 f.write(struct.pack("fI", score, len(bytes)))
                 f.write(bytes)

--- a/examples/models/llama2/util.h
+++ b/examples/models/llama2/util.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <stdio.h>
+#include <time.h>
+#include <cctype>
+
+namespace torch {
+namespace executor {
+namespace util {
+
+void inline safe_printf(const char* piece) {
+  // piece might be a raw byte token, and we only want to print printable chars
+  // or whitespace because some of the other bytes can be various control codes,
+  // backspace, etc.
+  if (piece == nullptr) {
+    return;
+  }
+  if (piece[0] == '\0') {
+    return;
+  }
+  if (piece[1] == '\0') {
+    unsigned char byte_val = piece[0];
+    if (!(isprint(byte_val) || isspace(byte_val))) {
+      return; // bad byte, don't print it
+    }
+  }
+  printf("%s", piece);
+}
+
+// ----------------------------------------------------------------------------
+// utilities: time
+
+long inline time_in_ms() {
+  // return time in milliseconds, for benchmarking the model speed
+  struct timespec time;
+  clock_gettime(CLOCK_REALTIME, &time);
+  return time.tv_sec * 1000 + time.tv_nsec / 1000000;
+}
+
+} // namespace util
+} // namespace executor
+} // namespace torch


### PR DESCRIPTION
Summary:
In practice we seem to value the BOS and EOS from the model instead of tokenizer. For example `sentencepiece` tells me the tokenizer is having `BOS` being 1 and `EOS` being 2, but the model tells me the `BOS` should be 3 and `EOS` should be two 3s.

To avoid the confusion, only serialize `BOS` and `EOS` into pte file instead of the tokenizer.

Reviewed By: mikekgfb

Differential Revision: D52926490

