### PR TITLE
Add DQLinear with 4bit weights

### DIFF
--- a/backends/xnnpack/operators/quant_params.py
+++ b/backends/xnnpack/operators/quant_params.py
@@ -67,6 +67,13 @@ class QuantParams:
         self.is_output = is_output
         self.is_input = is_input
         self.is_dynamic = is_dynamic
+        self.is_qc4w = (
+            self.per_channel
+            and not self.is_dynamic
+            and self.qmin == -8
+            and self.qmax == 7
+            and self.dtype == torch.int8
+        )
 
     def quantize_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
         # Do nothing if already quantized by the Quantizer
@@ -77,6 +84,14 @@ class QuantParams:
             assert (
                 tensor.shape[self.axis] == cast(torch.Tensor, self.scale).shape[0]
             ), f"Invalid size of per channel quantization scales, axis: {self.axis}, scale size: {self.scale.shape}, tensor shape: {tensor.shape}"
+
+            assert (
+                tensor.shape[self.axis] == cast(torch.Tensor, self.zp).shape[0]
+            ), f"Invalid size of per channel quantization zero-points, axis: {self.axis}, zp size: {self.zp.shape}, tensor shape: {tensor.shape}"
+
+            # Assuming folded quant weights
+            # TODO Add support for unfolded weights
+            assert not self.is_qc4w, "Not expecting QC4W per channel tensor"
 
             return exir_ops.edge.quantized_decomposed.quantize_per_channel.default(
                 tensor, self.scale, self.zp, self.axis, self.qmin, self.qmax, self.dtype

--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -69,6 +69,8 @@ xnn_datatype getDataType(const DataType& data_type) {
       return xnn_datatype::xnn_datatype_qcint8;
     case DataType::xnn_datatype_qcint32:
       return xnn_datatype::xnn_datatype_qcint32;
+    case DataType::xnn_datatype_qcint4:
+      return xnn_datatype::xnn_datatype_qcint4;
     default:
       return xnn_datatype::xnn_datatype_invalid;
   }
@@ -81,6 +83,7 @@ bool isQuantizedDataType(const xnn_datatype data_type) {
     case xnn_datatype::xnn_datatype_qint32:
     case xnn_datatype::xnn_datatype_qcint8:
     case xnn_datatype::xnn_datatype_qcint32:
+    case xnn_datatype::xnn_datatype_qcint4:
       return true;
     default:
       return false;
@@ -310,15 +313,23 @@ Error defineTensor(
       }
       case fb_xnnpack::XNNQuantParams::PerChannelQuant: {
         auto qparams = qtensor_value->quant_params_as_PerChannelQuant();
+        enum xnn_datatype dtype = getDataType(tensor_value->datatype());
+        int32_t zero_point =
+            (dtype == xnn_datatype::xnn_datatype_qcint4 ? 8 : 0);
+
         ET_LOG(
             Debug,
-            "define quant tensor (per channel): buffer_ptr: %p, scale.numel(): %u, channel_dim: %u\n",
+            "define quant tensor (per channel): buffer_ptr: %p, scale.numel(): %u, channel_dim: %u, dtype: %u, zero_point: %d\n",
             buffer_ptr,
             qparams->scale()->size(),
-            qparams->channel_dim());
-        status = xnn_define_channelwise_quantized_tensor_value(
+            qparams->channel_dim(),
+            dtype,
+            zero_point);
+
+        status = xnn_define_channelwise_quantized_tensor_value_v2(
             /*subgraph=*/subgraph_ptr,
-            /*datatype=*/getDataType(tensor_value->datatype()),
+            /*datatype=*/dtype,
+            /*zero_point=*/zero_point,
             /*scale=*/qparams->scale()->data(),
             /*num_dims=*/tensor_value->num_dims(),
             /*channel_dim*/ qparams->channel_dim(),

--- a/backends/xnnpack/serialization/schema.fbs
+++ b/backends/xnnpack/serialization/schema.fbs
@@ -23,6 +23,8 @@ enum XNNDatatype : short {
   xnn_datatype_qcint8 = 6,
   /// Quantized 32-bit signed integer with shared per-channel quantization parameters.
   xnn_datatype_qcint32 = 7,
+  /// Quantized 4-bit signed integer with shared per-channel quantization parameters.
+  xnn_datatype_qcint4 = 8,
 }
 
 // type of quantization

--- a/backends/xnnpack/serialization/xnnpack_graph_schema.py
+++ b/backends/xnnpack/serialization/xnnpack_graph_schema.py
@@ -379,6 +379,7 @@ class XNNDatatype(IntEnum):
     xnn_datatype_qint32 = 5
     xnn_datatype_qcint8 = 6
     xnn_datatype_qcint32 = 7
+    xnn_datatype_qcint4 = 8
 
 
 @dataclass


### PR DESCRIPTION
Summary:
Add support for dqlinear with,
* fp32 actvations
* int4 per channel, symm quantized weights with [-8,7] quantized value range
* fp32 bias
* fp32 output

Differential Revision: D52938925


