### PR TITLE
[CoreML] Use CoreMLTools Main Branch

### DIFF
--- a/backends/apple/coreml/scripts/install_requirements.sh
+++ b/backends/apple/coreml/scripts/install_requirements.sh
@@ -40,14 +40,6 @@ if [ $STATUS -ne 0 ]; then
     exit 1
 fi
 
-echo "${green}ExecuTorch: Checking out 'executorch_integration' branch in coremltools repo."
-git checkout executorch_integration
-STATUS=$?
-if [ $STATUS -ne 0 ]; then
-    echo "${red}ExecuTorch: Failed to checkout 'executorch_integration' branch in coremltools repo."
-    exit 1
-fi
-
 mkdir /tmp/coremltools/build
 cmake -S /tmp/coremltools/ -B /tmp/coremltools/build
 cmake --build /tmp/coremltools/build --parallel


### PR DESCRIPTION
When we were prototyping the integration between ExecuTorch and CoreML, we were using the prototype branch `executorch_integration`
```
...
echo "${green}ExecuTorch: Checking out 'executorch_integration' branch in coremltools repo."
git checkout executorch_integration
...
```
in [backends/apple/coreml/scripts/install_requirements.sh](https://github.com/pytorch/executorch/blob/main/backends/apple/coreml/scripts/install_requirements.sh)

Now that we have a more mature integration and have all necessary functionalities in `main` branch, it's time to use `main` branch now

Fix issue [1665](https://github.com/pytorch/executorch/issues/1665)