### PR TITLE
Back out "Extract constants to segment by default"

### DIFF
--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -56,7 +56,7 @@ class ExecutorchBackendConfig:
     # rather than encoding those constants in the flatbuffer data.
     # This reduces the memory overhead of creating the .pte file for models with
     # large constant data.
-    extract_constant_segment: bool = True
+    extract_constant_segment: bool = False
 
     # When extracting segments, the starting offset of each segment will be
     # aligned to this value (in bytes). When using mmap() to load segments, this


### PR DESCRIPTION
Summary:
Original commit changeset: 715f76335abe

Original Phabricator Diff: D52451128

This change causes ios_test.sh to fail

Reviewed By: shoumikhin

Differential Revision: D52947486


