### PR TITLE
Fix linking flatcc library for debug builds

### DIFF
--- a/build/executorch-config.cmake
+++ b/build/executorch-config.cmake
@@ -35,8 +35,14 @@ set_target_properties(
 )
 target_include_directories(portable_kernels INTERFACE ${_root})
 
+if (CMAKE_BUILD_TYPE MATCHES "Debug")
+    set(FLATCC_LIB flatcc_d)
+else()
+    set(FLATCC_LIB flatcc)
+endif()
+
 set(lib_list
-    etdump bundled_program extension_data_loader flatcc mpsdelegate
+    etdump bundled_program extension_data_loader ${FLATCC_LIB} mpsdelegate
     qnn_executorch_backend
 )
 foreach(lib ${lib_list})


### PR DESCRIPTION
When building ExecuTorch with ETDump support and `Debug` flag  set (`-DCMAKE_BUILD_TYPE=Debug`), flatcc will be built with a `_d` appended (the final lib will be `cmake-out/lib/libflatcc_d.a`) . For more info see: [set(CMAKE_DEBUG_POSTFIX “_d”)](https://github.com/dvidelabs/flatcc/blob/eb5228f76d395bffe31a33398ff73e60dfba5914/CMakeLists.txt#L316C1-L316C30)


This change checks if the build type is debug, then look for `libflatcc_d.a`, otherwise look for `libflatcc` name.

Change needed in PR https://github.com/DenisVieriu97/executorch/pull/14.

cc @tarun292, @kimishpatel, @shoumikhin 