### PR TITLE
Remove extra semi colon from executorch/kernels/portable/cpu/op_zeros.cpp

### DIFF
--- a/kernels/portable/cpu/op_zeros.cpp
+++ b/kernels/portable/cpu/op_zeros.cpp
@@ -29,7 +29,7 @@ bool check_sizes(
   }
 
   return true;
-};
+}
 
 } // namespace
 


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: SS-JIA

Differential Revision: D52969036


