### PR TITLE
Replace `constraints` with `dynamic_shapes` in executorch

### DIFF
--- a/examples/models/llama2/export_llama.py
+++ b/examples/models/llama2/export_llama.py
@@ -9,7 +9,6 @@
 import argparse
 import json
 import logging
-import os
 import shlex
 from json import JSONDecodeError
 
@@ -22,7 +21,6 @@ import torch
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
 from executorch.exir.capture._config import EdgeCompileConfig, ExecutorchBackendConfig
 from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
-from libfb.py import parutil
 
 from ...portable.utils import export_to_edge, save_pte_program
 

--- a/examples/models/llama2/llama_test.py
+++ b/examples/models/llama2/llama_test.py
@@ -6,16 +6,12 @@
 
 import unittest
 
-import torch
-
-from executorch.extension.pybindings import aten_lib
-
 from .export_llama import build_model
 
 
 class LlamaTest(unittest.TestCase):
     def test_quantized_llama(self):
-        output_path = build_model(
+        output_path = build_model(  # noqa
             modelname="model",
             extra_opts="--fairseq2 -Q",
             par_local_output=True,
@@ -23,7 +19,7 @@ class LlamaTest(unittest.TestCase):
         )
 
     def test_half_llama(self):
-        output_path = build_model(
+        output_path = build_model(  # noqa
             modelname="model",
             extra_opts="--fairseq2 -H",
             par_local_output=True,

--- a/exir/capture/_capture.py
+++ b/exir/capture/_capture.py
@@ -25,10 +25,10 @@ from executorch.exir.tracer import (
 from executorch.exir.verification.verifier import EXIRATenDialectVerifierBase
 from torch import _guards
 from torch._dispatch.python import enable_python_dispatcher
-from torch._dynamo.eval_frame import Constraint
-from torch._export import CallSpec, export, ExportedProgram, ExportGraphSignature
+from torch._export import CallSpec, ExportedProgram, ExportGraphSignature
 from torch._export.passes import ReplaceViewOpsWithViewCopyOpsPass
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+from torch.export import export
 from torch.export.exported_program import (
     InputKind,
     InputSpec,
@@ -49,7 +49,7 @@ Val = Any
 
 
 CompileSpec = namedtuple(
-    "CompileSpec", ["method_name", "callable", "args", "constraints"]
+    "CompileSpec", ["method_name", "callable", "args", "dynamic_shapes"]
 )
 
 
@@ -131,7 +131,7 @@ def capture(  # noqa: C901
     f: Callable[..., Any],
     args: Tuple[Value, ...],
     config: Optional[CaptureConfig] = None,
-    constraints: Optional[List[Constraint]] = None,
+    dynamic_shapes: Optional[List[Any]] = None,
 ) -> ExirExportedProgram:
     warnings.warn(
         "This function is now deprecated, please use `torch.export and exir.to_edge` instead. ",
@@ -167,7 +167,13 @@ def capture(  # noqa: C901
                     "Functionalization is required for enable_aot.",
                 )
 
-            ep = export(f, args, constraints=constraints)
+            class _CaptureProgram(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.forward = f
+
+            _program = _CaptureProgram()
+            ep = export(_program, args, dynamic_shapes=dynamic_shapes)
             ep = ep.run_decompositions(_default_decomposition_table())
             ep = _transform(ep, ReplaceViewOpsWithViewCopyOpsPass())
             if not config._unlift:
@@ -181,7 +187,7 @@ def capture(  # noqa: C901
                 aten_graph=True,
                 tracing_mode="symbolic",
                 dynamo_config=config._dynamo_config,
-                constraints=constraints,
+                dynamic_shapes=dynamic_shapes,
                 _use_old_decomp_table=config._use_old_decomp_table,
             )
 
@@ -192,7 +198,7 @@ def capture(  # noqa: C901
                 aten_graph=True,
                 tracing_mode="fake",
                 dynamo_config=config._dynamo_config,
-                constraints=None,  # constraints make sense only when dynamic shapes is enabled
+                dynamic_shapes=None,
                 _use_old_decomp_table=config._use_old_decomp_table,
             )
 
@@ -321,7 +327,7 @@ def capture_multiple(
     args: Union[Dict[str, Tuple[Value, ...]], Tuple[Value, ...]],
     config: Optional[CaptureConfig] = None,
     prim_getters: Optional[Set[str]] = None,
-    constraints: Optional[Union[Dict[str, List[Constraint]], List[Constraint]]] = None,
+    dynamic_shapes: Optional[Union[Dict[str, Any], List[Any]]] = None,
 ):
     """
     capture_multiple traces either an nn.Module or just a callable with PyTorch
@@ -349,12 +355,12 @@ def capture_multiple(
 
         prim_getters: A set of primitive getter functions to capture the return values of
 
-        constraints: Input shape constraints.
+        dynamic_shapes: Input dynamic shapes.
 
-        When `m` is an nn.Module, `constraints` is a dictionary that maps names of method
-        to their input shape constraints.
+        When `m` is an nn.Module, `dynamic_shapes` is a dictionary that maps names of method
+        to their input dynamic shapes.
 
-        When `m` is a non-Module callable, `constraints` is a list of input shape constraints.
+        When `m` is a non-Module callable, `dynamic_shapes` is a list of input dynamic shapes.
 
     Returns:
         A MultiMethodExirExportedProgram.
@@ -370,7 +376,7 @@ def capture_multiple(
         on the given nn.Module.
     """
     warnings.warn(
-        "This function is now deprecated, please use `torch.export and exir.to_edge` instead. ",
+        "This function is now deprecated, please use `torch.export and exir.to_edge` instead.",
         DeprecationWarning,
         stacklevel=1,
     )
@@ -378,10 +384,10 @@ def capture_multiple(
     compile_specs = []
     prim_getter_cache: Optional[Dict[str, Any]] = None
     if isinstance(m, torch.nn.Module):
-        if constraints is not None:
+        if dynamic_shapes is not None:
             assert isinstance(
-                constraints, dict
-            ), f"Expected a dict for constraints, got {type(constraints)}"
+                dynamic_shapes, dict
+            ), f"Expected a dict for dynamic_shapes, got {type(dynamic_shapes)}"
 
         if isinstance(args, tuple):
             compile_specs.append(
@@ -389,8 +395,8 @@ def capture_multiple(
                     "forward",
                     m.forward,
                     args,
-                    constraints["forward"]
-                    if constraints and "forward" in constraints
+                    dynamic_shapes["forward"]
+                    if dynamic_shapes and "forward" in dynamic_shapes
                     else None,
                 )
             )
@@ -404,8 +410,8 @@ def capture_multiple(
                         method_name,
                         getattr(m, method_name),
                         method_args,
-                        constraints[method_name]
-                        if constraints and method_name in constraints
+                        dynamic_shapes[method_name]
+                        if dynamic_shapes and method_name in dynamic_shapes
                         else None,
                     )
                 )
@@ -424,16 +430,19 @@ def capture_multiple(
         assert (
             prim_getters is None
         ), "Caller should not specify primitive getter functions when only providing a callable as input"
-        if constraints is not None:
+        if dynamic_shapes is not None:
             assert isinstance(
-                constraints, list
-            ), f"Expected a list for constraints, got {type(constraints)}"
-        compile_specs.append(CompileSpec("forward", m, args, constraints))
+                dynamic_shapes, list
+            ), f"Expected a list for constraints, got {type(dynamic_shapes)}"
+        compile_specs.append(CompileSpec("forward", m, args, dynamic_shapes))
 
     method_name_to_prog = {}
     for compile_spec in compile_specs:
         method_name_to_prog[compile_spec.method_name] = capture(
-            compile_spec.callable, compile_spec.args, config, compile_spec.constraints
+            compile_spec.callable,
+            compile_spec.args,
+            config,
+            compile_spec.dynamic_shapes,
         )
 
     return MultiMethodExirExportedProgram(method_name_to_prog, prim_getter_cache)

--- a/exir/tracer.py
+++ b/exir/tracer.py
@@ -45,10 +45,9 @@ from executorch.exir.types import ValueSpec
 
 from torch._C import _EnableTorchFunction, DisableTorchFunctionSubclass  # @manual
 from torch._decomp import core_aten_decompositions, get_decompositions
-from torch._dynamo.eval_frame import Constraint
 from torch._dynamo.guards import Guard
-
 from torch._functorch.eager_transforms import _maybe_unwrap_functional_tensor
+from torch.export.dynamic_shapes import _process_dynamic_shapes
 from torch.func import functionalize
 from torch.fx.operator_schemas import normalize_function
 from torch.utils._pytree import TreeSpec
@@ -643,7 +642,7 @@ def dynamo_trace(
     aten_graph: bool,
     tracing_mode: str = "real",
     dynamo_config: Optional[ExirDynamoConfig] = None,
-    constraints: Optional[List[Constraint]] = None,
+    dynamic_shapes: Optional[List[Any]] = None,
     _use_old_decomp_table: bool = False,
 ) -> Tuple[torch.fx.GraphModule, Set[Guard]]:
     """
@@ -671,7 +670,9 @@ def dynamo_trace(
                 decomposition_table=_default_decomposition_table(_use_old_decomp_table)
                 if aten_graph
                 else None,
-                constraints=constraints,
+                constraints=_process_dynamic_shapes(
+                    f, args, dynamic_shapes=dynamic_shapes
+                ),
             )(
                 *copy.deepcopy(args),
             )

--- a/test/end2end/exported_module.py
+++ b/test/end2end/exported_module.py
@@ -131,26 +131,25 @@ class ExportedModule:
         for method in methods:
             method_name_to_args[method] = trace_inputs
 
-        method_name_to_constraints = None
-        if hasattr(eager_module, "get_constraints"):
+        method_name_to_dynamic_shapes = None
+        if hasattr(eager_module, "get_dynamic_shapes"):
             assert capture_config is not None
             assert capture_config.enable_aot is True
-            trace_constraints = eager_module.get_constraints()
-            method_name_to_constraints = {}
+            trace_dynamic_shapes = eager_module.get_dynamic_shapes()
+            method_name_to_dynamic_shapes = {}
             for method in methods:
-                method_name_to_constraints[method] = trace_constraints
+                method_name_to_dynamic_shapes[method] = trace_dynamic_shapes
 
         memory_planning_pass = MemoryPlanningPass("greedy")
         if hasattr(eager_module, "get_memory_planning_pass"):
             memory_planning_pass = eager_module.get_memory_planning_pass()
-
         # Capture an executorch program.
         executorch_program = (
             exir.capture_multiple(
                 eager_module,
                 method_name_to_args,
                 capture_config,
-                constraints=method_name_to_constraints,
+                dynamic_shapes=method_name_to_dynamic_shapes,
             )
             .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
             .to_executorch(

--- a/test/models/export_program.py
+++ b/test/models/export_program.py
@@ -15,7 +15,7 @@ from executorch.exir import CaptureConfig
 from executorch.exir.passes import MemoryPlanningPass
 from executorch.test.end2end.exported_module import ExportedModule
 from torch import nn
-from torch._export import dynamic_dim
+from torch.export import Dim
 
 """Traces and exports nn.Modules to ExecuTorch .pte program files.
 
@@ -98,10 +98,8 @@ class ModuleDynamicCatUnallocatedIO(nn.Module):
     def get_random_inputs(self):
         return self._inputs
 
-    def get_constraints(self):
-        return [
-            dynamic_dim(self._inputs[0], 0) <= 3,
-        ]
+    def get_dynamic_shapes(self):
+        return ({0: Dim("dim0_k", max=3)},)
 
     def get_memory_planning_pass(self):
         return MemoryPlanningPass(


### PR DESCRIPTION
Summary: `constraints` argument for `torch.export` has been deprecated in favor of the `dynamic_shapes` argument. This PR updates the use of the deprecated API in `pye` and `executorch`.

Differential Revision: D52985629


