### PR TITLE
Remove use of ET_EXTACT_SCALAR in portable kernels

### DIFF
--- a/kernels/portable/cpu/op_bitwise_and.cpp
+++ b/kernels/portable/cpu/op_bitwise_and.cpp
@@ -121,7 +121,7 @@ Tensor& bitwise_and_Scalar_out(
         ET_SWITCH_SCALAR_OBJ_INTB_TYPES(
             b_type, ctx, "bitwise_and.Scalar_out", CTYPE_B, [&]() {
               CTYPE_B val_b = 0;
-              ET_EXTRACT_SCALAR(b, val_b);
+              utils::extract_scalar(b, &val_b);
               ET_SWITCH_INT_TYPES_AND(
                   Bool,
                   common_type,

--- a/kernels/portable/cpu/op_bitwise_or.cpp
+++ b/kernels/portable/cpu/op_bitwise_or.cpp
@@ -120,7 +120,7 @@ Tensor& bitwise_or_Scalar_out(
         ET_SWITCH_SCALAR_OBJ_INTB_TYPES(
             b_type, ctx, "bitwise_or.Scalar_out", CTYPE_B, [&]() {
               CTYPE_B val_b = 0;
-              ET_EXTRACT_SCALAR(b, val_b);
+              utils::extract_scalar(b, &val_b);
               ET_SWITCH_INT_TYPES_AND(
                   Bool,
                   common_type,

--- a/kernels/portable/cpu/op_bitwise_xor.cpp
+++ b/kernels/portable/cpu/op_bitwise_xor.cpp
@@ -122,7 +122,7 @@ Tensor& bitwise_xor_Scalar_out(
         ET_SWITCH_SCALAR_OBJ_INTB_TYPES(
             b_type, ctx, "bitwise_xor.Scalar_out", CTYPE_B, [&]() {
               CTYPE_B val_b = 0;
-              ET_EXTRACT_SCALAR(b, val_b);
+              utils::extract_scalar(b, &val_b);
               ET_SWITCH_INT_TYPES_AND(
                   Bool,
                   common_type,

--- a/kernels/portable/cpu/op_clamp.cpp
+++ b/kernels/portable/cpu/op_clamp.cpp
@@ -94,7 +94,7 @@ bool is_out_of_bounds(CTYPE_VAL val) {
 
   ET_SWITCH_SCALAR_OBJ_TYPES(val_type, ctx, "clamp.out", CTYPE_VAL, [&]() {
     CTYPE_VAL val = 0;
-    ET_EXTRACT_SCALAR(val_scalar, val);
+    utils::extract_scalar(val_scalar, &val);
     if (isIntegralType(out_type, /*includeBool=*/false)) {
       ET_SWITCH_INT_TYPES(out_type, ctx, "clamp.out", CTYPE_OUT, [&]() {
         if (is_out_of_bounds<CTYPE_VAL, CTYPE_OUT, long>(val)) {
@@ -175,7 +175,7 @@ Tensor& clamp_out(
     if (has_min) {
       ET_SWITCH_SCALAR_OBJ_TYPES(min_type, ctx, "clamp", CTYPE_MIN, [&]() {
         CTYPE_MIN min_val = 0;
-        ET_EXTRACT_SCALAR(min_opt.value(), min_val);
+        utils::extract_scalar(min_opt.value(), &min_val);
         min = static_cast<CTYPE_OUT>(min_val);
       });
     }
@@ -185,7 +185,7 @@ Tensor& clamp_out(
     if (has_max) {
       ET_SWITCH_SCALAR_OBJ_TYPES(max_type, ctx, "clamp", CTYPE_MAX, [&]() {
         CTYPE_MAX max_val = 0;
-        ET_EXTRACT_SCALAR(max_opt.value(), max_val);
+        utils::extract_scalar(max_opt.value(), &max_val);
         max = static_cast<CTYPE_OUT>(max_val);
       });
     }

--- a/kernels/portable/cpu/op_constant_pad_nd.cpp
+++ b/kernels/portable/cpu/op_constant_pad_nd.cpp
@@ -187,7 +187,7 @@ Tensor& constant_pad_nd_out(
         ET_SWITCH_SCALAR_OBJ_TYPES(
             value_type, ctx, "constant_pad_nd.out", CTYPE_VALUE, [&]() {
               CTYPE_VALUE val;
-              ET_EXTRACT_SCALAR(value, val);
+              utils::extract_scalar(value, &val);
               value_v = static_cast<CTYPE>(val);
             });
         constant_pad_nd_out_impl<CTYPE>(in, pad, value_v, out);

--- a/kernels/portable/cpu/op_div.cpp
+++ b/kernels/portable/cpu/op_div.cpp
@@ -163,7 +163,7 @@ Tensor& div_scalar_out(
             ET_SWITCH_FLOAT_TYPES(
                 out_type, ctx, "div.Scalar_out", CTYPE_OUT, [&]() {
                   CTYPE_B b_val;
-                  ET_EXTRACT_SCALAR(b, b_val);
+                  utils::extract_scalar(b, &b_val);
                   CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
 
                   apply_unary_map_fn(

--- a/kernels/portable/cpu/op_eq.cpp
+++ b/kernels/portable/cpu/op_eq.cpp
@@ -87,7 +87,7 @@ Tensor& eq_scalar_out(
             ET_SWITCH_REAL_TYPES_AND(
                 Bool, out_type, ctx, "eq.Scalar_out", CTYPE_OUT, [&]() {
                   CTYPE_B val_b = 0;
-                  ET_EXTRACT_SCALAR(b, val_b);
+                  utils::extract_scalar(b, &val_b);
                   apply_unary_map_fn(
                       [val_b](const CTYPE_A val_a) {
                         CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);

--- a/kernels/portable/cpu/op_fill.cpp
+++ b/kernels/portable/cpu/op_fill.cpp
@@ -43,7 +43,7 @@ Tensor& fill_scalar_out(
     CTYPE_A b_casted;
     ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "fill.Scalar_out", CTYPE_B, [&] {
       CTYPE_B b_val;
-      ET_EXTRACT_SCALAR(b, b_val);
+      utils::extract_scalar(b, &b_val);
       b_casted = static_cast<CTYPE_A>(b_val);
     });
 
@@ -86,7 +86,7 @@ Tensor& fill_tensor_out(
     ET_SWITCH_REAL_TYPES_AND(
         Bool, b_type, ctx, "fill.Tensor_out", CTYPE_B, [&] {
           CTYPE_B b_val;
-          ET_EXTRACT_SCALAR_TENSOR(b, b_val);
+          extract_scalar_tensor(b, &b_val);
           b_casted = static_cast<CTYPE_A>(b_val);
         });
 

--- a/kernels/portable/cpu/op_fmod.cpp
+++ b/kernels/portable/cpu/op_fmod.cpp
@@ -115,7 +115,7 @@ Tensor& fmod_Scalar_out(
     ET_SWITCH_REAL_TYPES_AND(
         Bool, b_type, ctx, "fmod.Scalar_out", CTYPE_B, [&]() {
           CTYPE_B val_b = 0;
-          ET_EXTRACT_SCALAR(b, val_b);
+          utils::extract_scalar(b, &val_b);
           is_zero = (val_b == 0);
         });
 
@@ -132,7 +132,7 @@ Tensor& fmod_Scalar_out(
         ET_SWITCH_SCALAR_OBJ_TYPES(
             b_type, ctx, "fmod.Scalar_out", CTYPE_B, [&]() {
               CTYPE_B val_b = 0;
-              ET_EXTRACT_SCALAR(b, val_b);
+              utils::extract_scalar(b, &val_b);
               ET_SWITCH_REAL_TYPES(
                   common_type, ctx, "fmod.Scalar_out", CTYPE_IN, [&]() {
                     ET_SWITCH_REAL_TYPES(

--- a/kernels/portable/cpu/op_full.cpp
+++ b/kernels/portable/cpu/op_full.cpp
@@ -36,7 +36,7 @@ Tensor& full_out(
 
   ET_SWITCH_REAL_TYPES_AND(Bool, val_type, ctx, "full.out", CTYPE_VAL, [&] {
     CTYPE_VAL val;
-    ET_EXTRACT_SCALAR(fill_value, val);
+    utils::extract_scalar(fill_value, &val);
 
     ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "full.out", CTYPE_OUT, [&] {
       CTYPE_OUT val_casted = static_cast<CTYPE_OUT>(val);

--- a/kernels/portable/cpu/op_full_like.cpp
+++ b/kernels/portable/cpu/op_full_like.cpp
@@ -47,7 +47,7 @@ Tensor& full_like_out(
   ET_SWITCH_REAL_TYPES_AND(
       Bool, val_type, ctx, "full_like.out", CTYPE_VAL, [&] {
         CTYPE_VAL val;
-        ET_EXTRACT_SCALAR(fill_value, val);
+        utils::extract_scalar(fill_value, &val);
 
         ET_SWITCH_REAL_TYPES_AND(
             Bool, out_type, ctx, "full_like.out", CTYPE_OUT, [&] {

--- a/kernels/portable/cpu/op_ge.cpp
+++ b/kernels/portable/cpu/op_ge.cpp
@@ -88,7 +88,7 @@ Tensor& ge_scalar_out(
             ET_SWITCH_REAL_TYPES_AND(
                 Bool, out_type, ctx, "ge.Scalar_out", CTYPE_OUT, [&]() {
                   CTYPE_B val_b = 0;
-                  ET_EXTRACT_SCALAR(b, val_b);
+                  utils::extract_scalar(b, &val_b);
                   apply_unary_map_fn(
                       [val_b](const CTYPE_A val_a) {
                         CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);

--- a/kernels/portable/cpu/op_gt.cpp
+++ b/kernels/portable/cpu/op_gt.cpp
@@ -88,7 +88,7 @@ Tensor& gt_scalar_out(
             ET_SWITCH_REAL_TYPES_AND(
                 Bool, out_type, ctx, "gt.Scalar_out", CTYPE_OUT, [&]() {
                   CTYPE_B val_b = 0;
-                  ET_EXTRACT_SCALAR(b, val_b);
+                  utils::extract_scalar(b, &val_b);
                   apply_unary_map_fn(
                       [val_b](const CTYPE_A val_a) {
                         CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);

--- a/kernels/portable/cpu/op_hardtanh.cpp
+++ b/kernels/portable/cpu/op_hardtanh.cpp
@@ -96,14 +96,14 @@ Tensor& hardtanh_out(
     CTYPE min_casted;
     ET_SWITCH_SCALAR_OBJ_TYPES(min_type, ctx, "hardtanh.out", CTYPE_MIN, [&]() {
       CTYPE_MIN min_val;
-      ET_EXTRACT_SCALAR(min, min_val);
+      utils::extract_scalar(min, &min_val);
       min_casted = static_cast<CTYPE>(min_val);
     });
 
     CTYPE max_casted;
     ET_SWITCH_SCALAR_OBJ_TYPES(max_type, ctx, "hardtanh.out", CTYPE_MAX, [&]() {
       CTYPE_MAX max_val;
-      ET_EXTRACT_SCALAR(max, max_val);
+      utils::extract_scalar(max, &max_val);
       max_casted = static_cast<CTYPE>(max_val);
     });
 

--- a/kernels/portable/cpu/op_le.cpp
+++ b/kernels/portable/cpu/op_le.cpp
@@ -88,7 +88,7 @@ Tensor& le_scalar_out(
             ET_SWITCH_REAL_TYPES_AND(
                 Bool, out_type, ctx, "le.Scalar_out", CTYPE_OUT, [&]() {
                   CTYPE_B val_b = 0;
-                  ET_EXTRACT_SCALAR(b, val_b);
+                  utils::extract_scalar(b, &val_b);
                   apply_unary_map_fn(
                       [val_b](const CTYPE_A val_a) {
                         CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);

--- a/kernels/portable/cpu/op_leaky_relu.cpp
+++ b/kernels/portable/cpu/op_leaky_relu.cpp
@@ -46,7 +46,7 @@ Tensor& leaky_relu_out(
     ET_SWITCH_SCALAR_OBJ_TYPES(
         sc_type, ctx, "leaky_relu.out", CTYPE_MIN, [&]() {
           CTYPE_MIN negative_slope_val;
-          ET_EXTRACT_SCALAR(negative_slope, negative_slope_val);
+          utils::extract_scalar(negative_slope, &negative_slope_val);
           negative_slope_casted = static_cast<CTYPE>(negative_slope_val);
         });
 

--- a/kernels/portable/cpu/op_lt.cpp
+++ b/kernels/portable/cpu/op_lt.cpp
@@ -88,7 +88,7 @@ Tensor& lt_scalar_out(
             ET_SWITCH_REAL_TYPES_AND(
                 Bool, out_type, ctx, "lt.Scalar_out", CTYPE_OUT, [&]() {
                   CTYPE_B val_b = 0;
-                  ET_EXTRACT_SCALAR(b, val_b);
+                  utils::extract_scalar(b, &val_b);
                   apply_unary_map_fn(
                       [val_b](const CTYPE_A val_a) {
                         CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);

--- a/kernels/portable/cpu/op_masked_fill.cpp
+++ b/kernels/portable/cpu/op_masked_fill.cpp
@@ -44,7 +44,7 @@ Tensor& masked_fill_scalar_out(
         ET_SWITCH_REAL_TYPES_AND(
             Bool, val_type, ctx, "masked_fill.Scalar_out", CTYPE_VAL, [&]() {
               CTYPE_VAL value_v;
-              ET_EXTRACT_SCALAR(value, value_v);
+              utils::extract_scalar(value, &value_v);
               CTYPE val = static_cast<CTYPE>(value_v);
 
               apply_binary_elementwise_fn<CTYPE, bool, CTYPE>(

--- a/kernels/portable/cpu/op_mul.cpp
+++ b/kernels/portable/cpu/op_mul.cpp
@@ -85,7 +85,7 @@ Tensor& mul_scalar_out(
             ET_SWITCH_REAL_TYPES_AND(
                 Bool, out_type, ctx, "mul.Scalar_out", CTYPE_OUT, [&]() {
                   CTYPE_B b_val;
-                  ET_EXTRACT_SCALAR(b, b_val);
+                  utils::extract_scalar(b, &b_val);
                   CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
 
                   apply_unary_map_fn(

--- a/kernels/portable/cpu/op_ne.cpp
+++ b/kernels/portable/cpu/op_ne.cpp
@@ -86,7 +86,7 @@ Tensor& ne_scalar_out(
             ET_SWITCH_REAL_TYPES_AND(
                 Bool, out_type, ctx, "ne.Scalar_out", CTYPE_OUT, [&]() {
                   CTYPE_B val_b = 0;
-                  ET_EXTRACT_SCALAR(b, val_b);
+                  utils::extract_scalar(b, &val_b);
                   apply_unary_map_fn(
                       [val_b](const CTYPE_A val_a) {
                         CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);

--- a/kernels/portable/cpu/op_pow.cpp
+++ b/kernels/portable/cpu/op_pow.cpp
@@ -109,7 +109,7 @@ Tensor& pow_Tensor_Scalar_out(
                         CTYPE_OUT,
                         [&]() {
                           CTYPE_B val_b = 0;
-                          ET_EXTRACT_SCALAR(b, val_b);
+                          utils::extract_scalar(b, &val_b);
                           apply_unary_map_fn(
                               [val_b](const CTYPE_A val_a) {
                                 CTYPE_IN a_casted =
@@ -161,7 +161,7 @@ Tensor& pow_Scalar_out(
                 ET_SWITCH_REAL_TYPES(
                     out_type, ctx, "pow.Scalar_out", CTYPE_OUT, [&]() {
                       CTYPE_A val_a = 0;
-                      ET_EXTRACT_SCALAR(a, val_a);
+                      utils::extract_scalar(a, &val_a);
 
                       apply_unary_map_fn(
                           [val_a](const CTYPE_B val_b) {

--- a/kernels/portable/cpu/op_remainder.cpp
+++ b/kernels/portable/cpu/op_remainder.cpp
@@ -127,7 +127,7 @@ Tensor& remainder_Scalar_out(
         ET_SWITCH_SCALAR_OBJ_TYPES(
             b_type, ctx, "remainder.Scalar_out", CTYPE_B, [&]() {
               CTYPE_B val_b = 0;
-              ET_EXTRACT_SCALAR(b, val_b);
+              utils::extract_scalar(b, &val_b);
               ET_SWITCH_REAL_TYPES(
                   common_type, ctx, "remainder.Scalar_out", CTYPE_IN, [&]() {
                     ET_SWITCH_REAL_TYPES(

--- a/kernels/portable/cpu/op_scalar_tensor.cpp
+++ b/kernels/portable/cpu/op_scalar_tensor.cpp
@@ -27,7 +27,7 @@ Tensor& scalar_tensor_out(RuntimeContext& ctx, const Scalar& s, Tensor& out) {
         ET_SWITCH_SCALAR_OBJ_TYPES(
             s_type, ctx, "scalar_tensor.out", CTYPE_S, [&]() {
               CTYPE_S val_s;
-              ET_EXTRACT_SCALAR(s, val_s);
+              utils::extract_scalar(s, &val_s);
               out.mutable_data_ptr<CTYPE>()[0] = convert<CTYPE, CTYPE_S>(val_s);
             });
       });

--- a/kernels/portable/cpu/op_sub.cpp
+++ b/kernels/portable/cpu/op_sub.cpp
@@ -9,6 +9,7 @@
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
+#include <executorch/kernels/portable/cpu/util/kernel_ops_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 #include <executorch/runtime/platform/assert.h>
 
@@ -30,9 +31,12 @@ Tensor& sub_out(
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();
+  ScalarType alpha_type = utils::get_scalar_dtype(alpha);
   ScalarType common_type = promoteTypes(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
+  ET_KERNEL_CHECK(
+      ctx, check_alpha_type(alpha_type, common_type), InvalidArgument, out);
   ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES(a_type, ctx, "sub.out", CTYPE_A, [&]() {
@@ -40,7 +44,7 @@ Tensor& sub_out(
       ET_SWITCH_REAL_TYPES(common_type, ctx, "sub.out", CTYPE_IN, [&]() {
         ET_SWITCH_REAL_TYPES(out_type, ctx, "sub.out", CTYPE_OUT, [&]() {
           CTYPE_IN alpha_val;
-          ET_EXTRACT_SCALAR(alpha, alpha_val);
+          utils::extract_scalar(alpha, &alpha_val);
 
           apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
               [alpha_val](const CTYPE_A val_a, const CTYPE_B val_b) {
@@ -79,10 +83,12 @@ Tensor& sub_scalar_out(
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
+  ScalarType alpha_type = utils::get_scalar_dtype(b);
   ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
   ET_KERNEL_CHECK(ctx, common_type == out_type, InvalidArgument, out);
+  ET_KERNEL_CHECK(ctx, canCast(alpha_type, common_type), InvalidArgument, out);
 
   ET_SWITCH_REAL_TYPES(a_type, ctx, "sub.Scalar_out", CTYPE_A, [&]() {
     ET_SWITCH_SCALAR_OBJ_REAL_TYPES(
@@ -92,10 +98,10 @@ Tensor& sub_scalar_out(
                 ET_SWITCH_REAL_TYPES(
                     out_type, ctx, "sub.Scalar_out", CTYPE_OUT, [&]() {
                       CTYPE_B b_val;
-                      ET_EXTRACT_SCALAR(b, b_val);
+                      utils::extract_scalar(b, &b_val);
                       CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
                       CTYPE_IN alpha_val;
-                      ET_EXTRACT_SCALAR(alpha, alpha_val);
+                      utils::extract_scalar(alpha, &alpha_val);
 
                       apply_unary_map_fn(
                           [b_casted, alpha_val](const CTYPE_A val_a) {

--- a/kernels/portable/cpu/targets.bzl
+++ b/kernels/portable/cpu/targets.bzl
@@ -33,6 +33,7 @@ _ATEN_OPS = (
         deps = [
             "//executorch/kernels/portable/cpu/util:broadcast_util",
             "//executorch/kernels/portable/cpu/util:functional_util",
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
             ":scalar_utils",
         ],
     ),
@@ -649,6 +650,7 @@ _ATEN_OPS = (
         deps = [
             ":scalar_utils",
             "//executorch/kernels/portable/cpu/util:functional_util",
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
         ],
     ),
     op_target(
@@ -659,6 +661,7 @@ _ATEN_OPS = (
         name = "op_scatter_add",
         deps = [
             "//executorch/kernels/portable/cpu/util:index_util",
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
             "//executorch/runtime/core/exec_aten/util:scalar_type_util",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
         ],
@@ -762,6 +765,7 @@ _ATEN_OPS = (
             ":scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
             "//executorch/kernels/portable/cpu/util:functional_util",
+            "//executorch/kernels/portable/cpu/util:kernel_ops_util",
         ],
     ),
     op_target(

--- a/kernels/portable/cpu/util/kernel_ops_util.cpp
+++ b/kernels/portable/cpu/util/kernel_ops_util.cpp
@@ -658,5 +658,17 @@ Error resize_embedding_output(
   return resize_tensor(out, output_size);
 }
 
+bool check_alpha_type(
+    const ScalarType alpha_type,
+    const ScalarType common_type) {
+  // Verify that alpha type is compatible with common type,
+  // as used by ops such as add and sub.
+  ET_LOG_AND_RETURN_IF_FALSE(
+      canCast(alpha_type, common_type) ||
+      (common_type == ScalarType::Bool && isIntegralType(alpha_type, true)));
+
+  return true;
+}
+
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/kernel_ops_util.h
+++ b/kernels/portable/cpu/util/kernel_ops_util.h
@@ -488,5 +488,9 @@ Error resize_embedding_output(
     const Tensor& indices,
     const Tensor& out);
 
+bool check_alpha_type(
+    const ScalarType alpha_type,
+    const ScalarType common_type);
+
 } // namespace executor
 } // namespace torch

--- a/kernels/test/op_add_test.cpp
+++ b/kernels/test/op_add_test.cpp
@@ -147,6 +147,7 @@ TEST(OpAddOutKernelTest, BoolAndIntInputTensor) {
 }
 
 TEST(OpAddOutKernelTest, BoolAndBoolInputTensor) {
+  et_pal_init();
   TensorFactory<ScalarType::Bool> tf;
 
   const std::vector<int32_t> sizes = {2, 2};
@@ -387,6 +388,8 @@ TEST(OpAddOutKernelTest, MismatchedOutputShapesDies) {
 }
 
 TEST(OpAddOutKernelTest, SimpleGeneratedCase) {
+  et_pal_init();
+
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.make(


### PR DESCRIPTION
Summary: Ensure that dtypes are compatible in op checks, then replace uses of ET_EXTRACT_SCALAR with utils::extract_scalar.

Differential Revision: D53004484


