### PR TITLE
Fix emission of weights that are views

### DIFF
--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -377,6 +377,14 @@ class _Emitter(torch.fx.Interpreter):
             self.program_state.cached_spec_hash_values[hashed] = buffer_idx
             self.program_state.constant_buffer.append(buffer)
 
+        if spec.const and spec.nbytes() != len(buffer_data):
+            raise InternalError(
+                self._emit_node_specific_error(
+                    self.node,
+                    f"Tensor spec has buffer of size {len(buffer_data)}, but expected nbytes of {spec.nbytes()}",
+                )
+            )
+
         # For constant tensors, allocation_info = None.
         return EValue(make_tensor_value(buffer_idx, None, spec))
 

--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -148,6 +148,9 @@ class TensorSpec:
         self.alignment = new_alignment
         return self.allocated_memory
 
+    def nbytes(self) -> int:
+        return num_bytes_from_shape_and_dtype(self.shape, self.dtype)
+
     @classmethod
     def from_tensor(cls, tensor: torch.Tensor, const: bool = False) -> TensorSpec:
         if const:

--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -156,6 +156,9 @@ class TensorSpec:
         if const:
             # for non-contigous tensors, convert to a contiguous one
             tensor = tensor.contiguous()
+            # Weights cannot be views during emission or serialization
+            if tensor.nbytes != tensor.untyped_storage().nbytes():
+                tensor = tensor.clone()
 
         spec = cls(
             dtype=tensor.dtype,


### PR DESCRIPTION
Summary: If a weight was a view of some larger data blob we would get a disconnect between the logical nbytes and the actual serialized storage. Thats not great and was upsetting deserialization so the .clone() should prevent it. If anyone knows how to do to this without the overhead of clone (as in just getting a pointer to relevant block of storage) Id be happy to do that instead.

Reviewed By: zhxchen17

Differential Revision: D53010225


