### PR TITLE
Fix MPS build

### DIFF
--- a/backends/apple/mps/targets.bzl
+++ b/backends/apple/mps/targets.bzl
@@ -19,6 +19,7 @@ def define_common_targets(is_xplat = False, platforms = []):
             "-Wno-missing-prototypes",
             "-Wno-nullable-to-nonnull-conversion",
             "-Wno-unused-const-variable",
+            "-Wno-unused-variable",
             "-fno-objc-arc",
         ],
         "deps": [


### PR DESCRIPTION
Summary: Unused variable caused build failure. Unblock first and remove unused variables later.

Reviewed By: mergennachin

Differential Revision: D53021410


