### PR TITLE
Remove check for half dtype

### DIFF
--- a/runtime/executor/tensor_parser_portable.cpp
+++ b/runtime/executor/tensor_parser_portable.cpp
@@ -37,7 +37,6 @@ Result<torch::executor::Tensor> parseTensor(
   ET_CHECK_OR_RETURN_ERROR(
       isValid(scalar_type) &&
           // Types that do not yet have deserialization support.
-          scalar_type != exec_aten::ScalarType::Half &&
           scalar_type != exec_aten::ScalarType::ComplexHalf &&
           scalar_type != exec_aten::ScalarType::ComplexFloat &&
           scalar_type != exec_aten::ScalarType::ComplexDouble &&


### PR DESCRIPTION
Summary: Adding support for half dtype; error out in kernel implementation.

Reviewed By: JacobSzwejbka

Differential Revision: D53026838


