### PR TITLE
Add support for ScalarType::Half

### DIFF
--- a/kernels/optimized/cpu/op_add.cpp
+++ b/kernels/optimized/cpu/op_add.cpp
@@ -32,7 +32,8 @@ Tensor& opt_add_out(
   ScalarType b_type = b.scalar_type();
   ScalarType out_type = out.scalar_type();
 
-  if (a_type == b_type && a_type == out_type && a.sizes().equals(b.sizes())) {
+  if (a_type == b_type && a_type == out_type && a.sizes().equals(b.sizes()) &&
+      out_type != ScalarType::Half) {
     // Resize for dynamic shape
     auto error = resize_tensor(out, a.sizes());
     ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
@@ -50,7 +51,8 @@ Tensor& opt_add_out(
           out.numel());
     });
   } else {
-    ScalarType common_type = promoteTypes(a_type, b_type);
+    ScalarType common_type =
+        promoteTypes(a_type, b_type, /*half_to_float*/ true);
     ET_CHECK(canCast(common_type, out_type));
 
     ET_KERNEL_CHECK(
@@ -59,30 +61,45 @@ Tensor& opt_add_out(
         InvalidArgument,
         out);
 
-    ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "add.out", CTYPE_A, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "add.out", CTYPE_B, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(
-            Bool, common_type, ctx, "add.out", CTYPE_IN, [&]() {
-              ET_SWITCH_REAL_TYPES_AND(
-                  Bool, out_type, ctx, "add.out", CTYPE_OUT, [&]() {
-                    CTYPE_IN alpha_val;
-                    ET_EXTRACT_SCALAR(alpha, alpha_val);
+    ET_SWITCH_REAL_TYPES_AND2(
+        Bool, Half, a_type, ctx, "add.out", CTYPE_A, [&]() {
+          ET_SWITCH_REAL_TYPES_AND2(
+              Bool, Half, b_type, ctx, "add.out", CTYPE_B, [&]() {
+                ET_SWITCH_REAL_TYPES_AND(
+                    Bool, common_type, ctx, "add.out", CTYPE_IN, [&]() {
+                      ET_SWITCH_REAL_TYPES_AND2(
+                          Bool,
+                          Half,
+                          out_type,
+                          ctx,
+                          "add.out",
+                          CTYPE_OUT,
+                          [&]() {
+                            CTYPE_IN alpha_val;
+                            ET_EXTRACT_SCALAR(alpha, alpha_val);
 
-                    apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                        [alpha_val](const CTYPE_A val_a, const CTYPE_B val_b) {
-                          CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                          CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                          CTYPE_IN value = a_casted + alpha_val * b_casted;
+                            apply_binary_elementwise_fn<
+                                CTYPE_A,
+                                CTYPE_B,
+                                CTYPE_OUT>(
+                                [alpha_val](
+                                    const CTYPE_A val_a, const CTYPE_B val_b) {
+                                  CTYPE_IN a_casted =
+                                      static_cast<CTYPE_IN>(val_a);
+                                  CTYPE_IN b_casted =
+                                      static_cast<CTYPE_IN>(val_b);
+                                  CTYPE_IN value =
+                                      a_casted + alpha_val * b_casted;
 
-                          return static_cast<CTYPE_OUT>(value);
-                        },
-                        a,
-                        b,
-                        out);
-                  });
-            });
-      });
-    });
+                                  return static_cast<CTYPE_OUT>(value);
+                                },
+                                a,
+                                b,
+                                out);
+                          });
+                    });
+              });
+        });
   }
 
   return out;

--- a/kernels/portable/cpu/op_add.cpp
+++ b/kernels/portable/cpu/op_add.cpp
@@ -32,36 +32,38 @@ Tensor& add_out(
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();
   ScalarType alpha_type = utils::get_scalar_dtype(alpha);
-  ScalarType common_type = promoteTypes(a_type, b_type);
+  ScalarType common_type = promoteTypes(a_type, b_type, /*half_to_float*/ true);
   ScalarType out_type = out.scalar_type();
 
   ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
   ET_KERNEL_CHECK(
       ctx, check_alpha_type(alpha_type, common_type), InvalidArgument, out);
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "add.out", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, "add.out", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(
-          Bool, common_type, ctx, "add.out", CTYPE_IN, [&]() {
-            ET_SWITCH_REAL_TYPES_AND(
-                Bool, out_type, ctx, "add.out", CTYPE_OUT, [&]() {
-                  CTYPE_IN alpha_val;
-                  utils::extract_scalar(alpha, &alpha_val);
+  ET_SWITCH_REAL_TYPES_AND2(Bool, Half, a_type, ctx, "add.out", CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND2(
+        Bool, Half, b_type, ctx, "add.out", CTYPE_B, [&]() {
+          ET_SWITCH_REAL_TYPES_AND(
+              Bool, common_type, ctx, "add.out", CTYPE_IN, [&]() {
+                ET_SWITCH_REAL_TYPES_AND2(
+                    Bool, Half, out_type, ctx, "add.out", CTYPE_OUT, [&]() {
+                      CTYPE_IN alpha_val;
+                      utils::extract_scalar(alpha, &alpha_val);
 
-                  apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                      [alpha_val](const CTYPE_A val_a, const CTYPE_B val_b) {
-                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                        CTYPE_IN value = a_casted + alpha_val * b_casted;
+                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
+                          [alpha_val](
+                              const CTYPE_A val_a, const CTYPE_B val_b) {
+                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                            CTYPE_IN value = a_casted + alpha_val * b_casted;
 
-                        return static_cast<CTYPE_OUT>(value);
-                      },
-                      a,
-                      b,
-                      out);
-                });
-          });
-    });
+                            return static_cast<CTYPE_OUT>(value);
+                          },
+                          a,
+                          b,
+                          out);
+                    });
+              });
+        });
   });
 
   return out;

--- a/kernels/test/op_add_test.cpp
+++ b/kernels/test/op_add_test.cpp
@@ -66,6 +66,7 @@ void test_add() {
 
 template <ScalarType DTYPE_A, ScalarType DTYPE_B>
 void test_add_enumerate_out_types() {
+  test_add<DTYPE_A, DTYPE_B, ScalarType::Half>();
   test_add<DTYPE_A, DTYPE_B, ScalarType::Float>();
   test_add<DTYPE_A, DTYPE_B, ScalarType::Double>();
   // Integral out type is only allowed if both inputs are integral types
@@ -80,7 +81,7 @@ void test_add_enumerate_b_types() {
 #define ENUMERATE_TEST_ENTRY(ctype, dtype) \
   test_add_enumerate_out_types<DTYPE_A, ScalarType::dtype>();
 
-  ET_FORALL_REAL_TYPES(ENUMERATE_TEST_ENTRY)
+  ET_FORALL_REAL_TYPES_AND(Half, ENUMERATE_TEST_ENTRY)
 
 #undef ENUMERATE_TEST_ENTRY
 }
@@ -89,7 +90,7 @@ void test_add_enumerate_a_types() {
 #define ENUMERATE_TEST_ENTRY(ctype, dtype) \
   test_add_enumerate_b_types<ScalarType::dtype>();
 
-  ET_FORALL_REAL_TYPES(ENUMERATE_TEST_ENTRY)
+  ET_FORALL_REAL_TYPES_AND(Half, ENUMERATE_TEST_ENTRY)
 
 #undef ENUMERATE_TEST_ENTRY
 }

--- a/runtime/core/portable_type/half.h
+++ b/runtime/core/portable_type/half.h
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#include <math.h>
 #include <cstdint>
+#include <cstring>
 
 namespace torch {
 namespace executor {
@@ -19,7 +21,557 @@ namespace executor {
  */
 struct alignas(2) Half {
   uint16_t x;
+
+  struct from_bits_t {};
+  static constexpr from_bits_t from_bits() {
+    return from_bits_t();
+  }
+
+  Half() = default;
+
+  constexpr Half(uint16_t bits, from_bits_t) : x(bits) {}
+  /* implicit */ inline Half(float value);
+  inline operator float() const;
 };
+
+namespace internal {
+
+inline float fp32_from_bits(uint32_t w) {
+  static_assert(sizeof(float) == sizeof(uint32_t));
+  union {
+    uint32_t as_bits;
+    float as_value;
+  } fp32 = {w};
+  return fp32.as_value;
+}
+
+inline uint32_t fp32_to_bits(float f) {
+  static_assert(sizeof(float) == sizeof(uint32_t));
+  union {
+    float as_value;
+    uint32_t as_bits;
+  } fp32 = {f};
+  return fp32.as_bits;
+}
+
+/*
+ * Convert a 16-bit floating-point number in IEEE half-precision format, in bit
+ * representation, to a 32-bit floating-point number in IEEE single-precision
+ * format, in bit representation.
+ *
+ * @note The implementation doesn't use any floating-point operations.
+ */
+inline uint32_t fp16_ieee_to_fp32_bits(uint16_t h) {
+  /*
+   * Extend the half-precision floating-point number to 32 bits and shift to the
+   * upper part of the 32-bit word:
+   *      +---+-----+------------+-------------------+
+   *      | S |EEEEE|MM MMMM MMMM|0000 0000 0000 0000|
+   *      +---+-----+------------+-------------------+
+   * Bits  31  26-30    16-25            0-15
+   *
+   * S - sign bit, E - bits of the biased exponent, M - bits of the mantissa, 0
+   * - zero bits.
+   */
+  const uint32_t w = (uint32_t)h << 16;
+  /*
+   * Extract the sign of the input number into the high bit of the 32-bit word:
+   *
+   *      +---+----------------------------------+
+   *      | S |0000000 00000000 00000000 00000000|
+   *      +---+----------------------------------+
+   * Bits  31                 0-31
+   */
+  const uint32_t sign = w & UINT32_C(0x80000000);
+  /*
+   * Extract mantissa and biased exponent of the input number into the bits 0-30
+   * of the 32-bit word:
+   *
+   *      +---+-----+------------+-------------------+
+   *      | 0 |EEEEE|MM MMMM MMMM|0000 0000 0000 0000|
+   *      +---+-----+------------+-------------------+
+   * Bits  30  27-31     17-26            0-16
+   */
+  const uint32_t nonsign = w & UINT32_C(0x7FFFFFFF);
+  /*
+   * Renorm shift is the number of bits to shift mantissa left to make the
+   * half-precision number normalized. If the initial number is normalized, some
+   * of its high 6 bits (sign == 0 and 5-bit exponent) equals one. In this case
+   * renorm_shift == 0. If the number is denormalize, renorm_shift > 0. Note
+   * that if we shift denormalized nonsign by renorm_shift, the unit bit of
+   * mantissa will shift into exponent, turning the biased exponent into 1, and
+   * making mantissa normalized (i.e. without leading 1).
+   */
+#ifdef _MSC_VER
+  unsigned long nonsign_bsr;
+  _BitScanReverse(&nonsign_bsr, (unsigned long)nonsign);
+  uint32_t renorm_shift = (uint32_t)nonsign_bsr ^ 31;
+#else
+  uint32_t renorm_shift = __builtin_clz(nonsign);
+#endif
+  renorm_shift = renorm_shift > 5 ? renorm_shift - 5 : 0;
+  /*
+   * Iff half-precision number has exponent of 15, the addition overflows
+   * it into bit 31, and the subsequent shift turns the high 9 bits
+   * into 1. Thus inf_nan_mask == 0x7F800000 if the half-precision number
+   * had exponent of 15 (i.e. was NaN or infinity) 0x00000000 otherwise
+   */
+  const int32_t inf_nan_mask =
+      ((int32_t)(nonsign + 0x04000000) >> 8) & INT32_C(0x7F800000);
+  /*
+   * Iff nonsign is 0, it overflows into 0xFFFFFFFF, turning bit 31
+   * into 1. Otherwise, bit 31 remains 0. The signed shift right by 31
+   * broadcasts bit 31 into all bits of the zero_mask. Thus zero_mask ==
+   * 0xFFFFFFFF if the half-precision number was zero (+0.0h or -0.0h)
+   * 0x00000000 otherwise
+   */
+  const int32_t zero_mask = (int32_t)(nonsign - 1) >> 31;
+  /*
+   * 1. Shift nonsign left by renorm_shift to normalize it (if the input
+   * was denormal)
+   * 2. Shift nonsign right by 3 so the exponent (5 bits originally)
+   * becomes an 8-bit field and 10-bit mantissa shifts into the 10 high
+   * bits of the 23-bit mantissa of IEEE single-precision number.
+   * 3. Add 0x70 to the exponent (starting at bit 23) to compensate the
+   * different in exponent bias (0x7F for single-precision number less 0xF
+   * for half-precision number).
+   * 4. Subtract renorm_shift from the exponent (starting at bit 23) to
+   * account for renormalization. As renorm_shift is less than 0x70, this
+   * can be combined with step 3.
+   * 5. Binary OR with inf_nan_mask to turn the exponent into 0xFF if the
+   * input was NaN or infinity.
+   * 6. Binary ANDNOT with zero_mask to turn the mantissa and exponent
+   * into zero if the input was zero.
+   * 7. Combine with the sign of the input number.
+   */
+  return sign |
+      ((((nonsign << renorm_shift >> 3) + ((0x70 - renorm_shift) << 23)) |
+        inf_nan_mask) &
+       ~zero_mask);
+}
+
+/*
+ * Convert a 16-bit floating-point number in IEEE half-precision format, in bit
+ * representation, to a 32-bit floating-point number in IEEE single-precision
+ * format.
+ *
+ * @note The implementation relies on IEEE-like (no assumption about rounding
+ * mode and no operations on denormals) floating-point operations and bitcasts
+ * between integer and floating-point variables.
+ */
+inline float fp16_ieee_to_fp32_value(uint16_t h) {
+  /*
+   * Extend the half-precision floating-point number to 32 bits and shift to the
+   * upper part of the 32-bit word:
+   *      +---+-----+------------+-------------------+
+   *      | S |EEEEE|MM MMMM MMMM|0000 0000 0000 0000|
+   *      +---+-----+------------+-------------------+
+   * Bits  31  26-30    16-25            0-15
+   *
+   * S - sign bit, E - bits of the biased exponent, M - bits of the mantissa, 0
+   * - zero bits.
+   */
+  const uint32_t w = (uint32_t)h << 16;
+  /*
+   * Extract the sign of the input number into the high bit of the 32-bit word:
+   *
+   *      +---+----------------------------------+
+   *      | S |0000000 00000000 00000000 00000000|
+   *      +---+----------------------------------+
+   * Bits  31                 0-31
+   */
+  const uint32_t sign = w & UINT32_C(0x80000000);
+  /*
+   * Extract mantissa and biased exponent of the input number into the high bits
+   * of the 32-bit word:
+   *
+   *      +-----+------------+---------------------+
+   *      |EEEEE|MM MMMM MMMM|0 0000 0000 0000 0000|
+   *      +-----+------------+---------------------+
+   * Bits  27-31    17-26            0-16
+   */
+  const uint32_t two_w = w + w;
+
+  /*
+   * Shift mantissa and exponent into bits 23-28 and bits 13-22 so they become
+   * mantissa and exponent of a single-precision floating-point number:
+   *
+   *       S|Exponent |          Mantissa
+   *      +-+---+-----+------------+----------------+
+   *      |0|000|EEEEE|MM MMMM MMMM|0 0000 0000 0000|
+   *      +-+---+-----+------------+----------------+
+   * Bits   | 23-31   |           0-22
+   *
+   * Next, there are some adjustments to the exponent:
+   * - The exponent needs to be corrected by the difference in exponent bias
+   * between single-precision and half-precision formats (0x7F - 0xF = 0x70)
+   * - Inf and NaN values in the inputs should become Inf and NaN values after
+   * conversion to the single-precision number. Therefore, if the biased
+   * exponent of the half-precision input was 0x1F (max possible value), the
+   * biased exponent of the single-precision output must be 0xFF (max possible
+   * value). We do this correction in two steps:
+   *   - First, we adjust the exponent by (0xFF - 0x1F) = 0xE0 (see exp_offset
+   * below) rather than by 0x70 suggested by the difference in the exponent bias
+   * (see above).
+   *   - Then we multiply the single-precision result of exponent adjustment by
+   * 2**(-112) to reverse the effect of exponent adjustment by 0xE0 less the
+   * necessary exponent adjustment by 0x70 due to difference in exponent bias.
+   *     The floating-point multiplication hardware would ensure than Inf and
+   * NaN would retain their value on at least partially IEEE754-compliant
+   * implementations.
+   *
+   * Note that the above operations do not handle denormal inputs (where biased
+   * exponent == 0). However, they also do not operate on denormal inputs, and
+   * do not produce denormal results.
+   */
+  constexpr uint32_t exp_offset = UINT32_C(0xE0) << 23;
+  // const float exp_scale = 0x1.0p-112f;
+  constexpr uint32_t scale_bits = (uint32_t)15 << 23;
+  float exp_scale_val = 0;
+  std::memcpy(&exp_scale_val, &scale_bits, sizeof(exp_scale_val));
+  const float exp_scale = exp_scale_val;
+  const float normalized_value =
+      fp32_from_bits((two_w >> 4) + exp_offset) * exp_scale;
+
+  /*
+   * Convert denormalized half-precision inputs into single-precision results
+   * (always normalized). Zero inputs are also handled here.
+   *
+   * In a denormalized number the biased exponent is zero, and mantissa has
+   * on-zero bits. First, we shift mantissa into bits 0-9 of the 32-bit word.
+   *
+   *                  zeros           |  mantissa
+   *      +---------------------------+------------+
+   *      |0000 0000 0000 0000 0000 00|MM MMMM MMMM|
+   *      +---------------------------+------------+
+   * Bits             10-31                0-9
+   *
+   * Now, remember that denormalized half-precision numbers are represented as:
+   *    FP16 = mantissa * 2**(-24).
+   * The trick is to construct a normalized single-precision number with the
+   * same mantissa and thehalf-precision input and with an exponent which would
+   * scale the corresponding mantissa bits to 2**(-24). A normalized
+   * single-precision floating-point number is represented as: FP32 = (1 +
+   * mantissa * 2**(-23)) * 2**(exponent - 127) Therefore, when the biased
+   * exponent is 126, a unit change in the mantissa of the input denormalized
+   * half-precision number causes a change of the constructed single-precision
+   * number by 2**(-24), i.e. the same amount.
+   *
+   * The last step is to adjust the bias of the constructed single-precision
+   * number. When the input half-precision number is zero, the constructed
+   * single-precision number has the value of FP32 = 1 * 2**(126 - 127) =
+   * 2**(-1) = 0.5 Therefore, we need to subtract 0.5 from the constructed
+   * single-precision number to get the numerical equivalent of the input
+   * half-precision number.
+   */
+  constexpr uint32_t magic_mask = UINT32_C(126) << 23;
+  constexpr float magic_bias = 0.5f;
+  const float denormalized_value =
+      fp32_from_bits((two_w >> 17) | magic_mask) - magic_bias;
+
+  /*
+   * - Choose either results of conversion of input as a normalized number, or
+   * as a denormalized number, depending on the input exponent. The variable
+   * two_w contains input exponent in bits 27-31, therefore if its smaller than
+   * 2**27, the input is either a denormal number, or zero.
+   * - Combine the result of conversion of exponent and mantissa with the sign
+   * of the input number.
+   */
+  constexpr uint32_t denormalized_cutoff = UINT32_C(1) << 27;
+  const uint32_t result = sign |
+      (two_w < denormalized_cutoff ? fp32_to_bits(denormalized_value)
+                                   : fp32_to_bits(normalized_value));
+  return fp32_from_bits(result);
+}
+
+/*
+ * Convert a 32-bit floating-point number in IEEE single-precision format to a
+ * 16-bit floating-point number in IEEE half-precision format, in bit
+ * representation.
+ *
+ * @note The implementation relies on IEEE-like (no assumption about rounding
+ * mode and no operations on denormals) floating-point operations and bitcasts
+ * between integer and floating-point variables.
+ */
+inline uint16_t fp16_ieee_from_fp32_value(float f) {
+  // const float scale_to_inf = 0x1.0p+112f;
+  // const float scale_to_zero = 0x1.0p-110f;
+  constexpr uint32_t scale_to_inf_bits = (uint32_t)239 << 23;
+  constexpr uint32_t scale_to_zero_bits = (uint32_t)17 << 23;
+  float scale_to_inf_val = 0, scale_to_zero_val = 0;
+  std::memcpy(&scale_to_inf_val, &scale_to_inf_bits, sizeof(scale_to_inf_val));
+  std::memcpy(
+      &scale_to_zero_val, &scale_to_zero_bits, sizeof(scale_to_zero_val));
+  const float scale_to_inf = scale_to_inf_val;
+  const float scale_to_zero = scale_to_zero_val;
+
+#if defined(_MSC_VER) && _MSC_VER == 1916
+  float base = ((signbit(f) != 0 ? -f : f) * scale_to_inf) * scale_to_zero;
+#else
+  float base = (fabsf(f) * scale_to_inf) * scale_to_zero;
+#endif
+
+  const uint32_t w = fp32_to_bits(f);
+  const uint32_t shl1_w = w + w;
+  const uint32_t sign = w & UINT32_C(0x80000000);
+  uint32_t bias = shl1_w & UINT32_C(0xFF000000);
+  if (bias < UINT32_C(0x71000000)) {
+    bias = UINT32_C(0x71000000);
+  }
+
+  base = fp32_from_bits((bias >> 1) + UINT32_C(0x07800000)) + base;
+  const uint32_t bits = fp32_to_bits(base);
+  const uint32_t exp_bits = (bits >> 13) & UINT32_C(0x00007C00);
+  const uint32_t mantissa_bits = bits & UINT32_C(0x00000FFF);
+  const uint32_t nonsign = exp_bits + mantissa_bits;
+  return static_cast<uint16_t>(
+      (sign >> 16) |
+      (shl1_w > UINT32_C(0xFF000000) ? UINT16_C(0x7E00) : nonsign));
+}
+
+} // namespace internal
+
+/// Constructors
+
+inline Half::Half(float value)
+    : x(internal::fp16_ieee_from_fp32_value(value)) {}
+
+/// Implicit conversions
+
+inline Half::operator float() const {
+  return internal::fp16_ieee_to_fp32_value(x);
+}
+
+/// Arithmetic
+
+inline Half operator+(const Half& a, const Half& b) {
+  return static_cast<float>(a) + static_cast<float>(b);
+}
+
+inline Half operator-(const Half& a, const Half& b) {
+  return static_cast<float>(a) - static_cast<float>(b);
+}
+
+inline Half operator*(const Half& a, const Half& b) {
+  return static_cast<float>(a) * static_cast<float>(b);
+}
+
+inline Half operator/(const Half& a, const Half& b) {
+  return static_cast<float>(a) / static_cast<float>(b);
+}
+
+inline Half operator-(const Half& a) {
+  return -static_cast<float>(a);
+}
+
+inline Half& operator+=(Half& a, const Half& b) {
+  a = a + b;
+  return a;
+}
+
+inline Half& operator-=(Half& a, const Half& b) {
+  a = a - b;
+  return a;
+}
+
+inline Half& operator*=(Half& a, const Half& b) {
+  a = a * b;
+  return a;
+}
+
+inline Half& operator/=(Half& a, const Half& b) {
+  a = a / b;
+  return a;
+}
+
+/// Arithmetic with floats
+
+inline float operator+(Half a, float b) {
+  return static_cast<float>(a) + b;
+}
+inline float operator-(Half a, float b) {
+  return static_cast<float>(a) - b;
+}
+inline float operator*(Half a, float b) {
+  return static_cast<float>(a) * b;
+}
+inline float operator/(Half a, float b) {
+  return static_cast<float>(a) / b;
+}
+
+inline float operator+(float a, Half b) {
+  return a + static_cast<float>(b);
+}
+inline float operator-(float a, Half b) {
+  return a - static_cast<float>(b);
+}
+inline float operator*(float a, Half b) {
+  return a * static_cast<float>(b);
+}
+inline float operator/(float a, Half b) {
+  return a / static_cast<float>(b);
+}
+
+inline float& operator+=(float& a, const Half& b) {
+  return a += static_cast<float>(b);
+}
+inline float& operator-=(float& a, const Half& b) {
+  return a -= static_cast<float>(b);
+}
+inline float& operator*=(float& a, const Half& b) {
+  return a *= static_cast<float>(b);
+}
+inline float& operator/=(float& a, const Half& b) {
+  return a /= static_cast<float>(b);
+}
+
+/// Arithmetic with doubles
+
+inline double operator+(Half a, double b) {
+  return static_cast<double>(a) + b;
+}
+inline double operator-(Half a, double b) {
+  return static_cast<double>(a) - b;
+}
+inline double operator*(Half a, double b) {
+  return static_cast<double>(a) * b;
+}
+inline double operator/(Half a, double b) {
+  return static_cast<double>(a) / b;
+}
+
+inline double operator+(double a, Half b) {
+  return a + static_cast<double>(b);
+}
+inline double operator-(double a, Half b) {
+  return a - static_cast<double>(b);
+}
+inline double operator*(double a, Half b) {
+  return a * static_cast<double>(b);
+}
+inline double operator/(double a, Half b) {
+  return a / static_cast<double>(b);
+}
+
+/// Arithmetic with ints
+
+inline Half operator+(Half a, int32_t b) {
+  return a + static_cast<Half>(b);
+}
+inline Half operator-(Half a, int32_t b) {
+  return a - static_cast<Half>(b);
+}
+inline Half operator*(Half a, int32_t b) {
+  return a * static_cast<Half>(b);
+}
+inline Half operator/(Half a, int32_t b) {
+  return a / static_cast<Half>(b);
+}
+
+inline Half operator+(int32_t a, Half b) {
+  return static_cast<Half>(a) + b;
+}
+inline Half operator-(int32_t a, Half b) {
+  return static_cast<Half>(a) - b;
+}
+inline Half operator*(int32_t a, Half b) {
+  return static_cast<Half>(a) * b;
+}
+inline Half operator/(int32_t a, Half b) {
+  return static_cast<Half>(a) / b;
+}
+
+//// Arithmetic with int64_t
+
+inline Half operator+(Half a, int64_t b) {
+  return a + static_cast<Half>(b);
+}
+inline Half operator-(Half a, int64_t b) {
+  return a - static_cast<Half>(b);
+}
+inline Half operator*(Half a, int64_t b) {
+  return a * static_cast<Half>(b);
+}
+inline Half operator/(Half a, int64_t b) {
+  return a / static_cast<Half>(b);
+}
+
+inline Half operator+(int64_t a, Half b) {
+  return static_cast<Half>(a) + b;
+}
+inline Half operator-(int64_t a, Half b) {
+  return static_cast<Half>(a) - b;
+}
+inline Half operator*(int64_t a, Half b) {
+  return static_cast<Half>(a) * b;
+}
+inline Half operator/(int64_t a, Half b) {
+  return static_cast<Half>(a) / b;
+}
+
+/// NOTE: we do not define comparisons directly and instead rely on the implicit
+/// conversion Half to float.
 
 } // namespace executor
 } // namespace torch
+
+namespace std {
+
+template <>
+class numeric_limits<torch::executor::Half> {
+ public:
+  static constexpr bool is_specialized = true;
+  static constexpr bool is_signed = true;
+  static constexpr bool is_integer = false;
+  static constexpr bool is_exact = false;
+  static constexpr bool has_infinity = true;
+  static constexpr bool has_quiet_NaN = true;
+  static constexpr bool has_signaling_NaN = true;
+  static constexpr auto has_denorm = numeric_limits<float>::has_denorm;
+  static constexpr auto has_denorm_loss =
+      numeric_limits<float>::has_denorm_loss;
+  static constexpr auto round_style = numeric_limits<float>::round_style;
+  static constexpr bool is_iec559 = true;
+  static constexpr bool is_bounded = true;
+  static constexpr bool is_modulo = false;
+  static constexpr int digits = 11;
+  static constexpr int digits10 = 3;
+  static constexpr int max_digits10 = 5;
+  static constexpr int radix = 2;
+  static constexpr int min_exponent = -13;
+  static constexpr int min_exponent10 = -4;
+  static constexpr int max_exponent = 16;
+  static constexpr int max_exponent10 = 4;
+  static constexpr auto traps = numeric_limits<float>::traps;
+  static constexpr auto tinyness_before =
+      numeric_limits<float>::tinyness_before;
+  static constexpr torch::executor::Half min() {
+    return torch::executor::Half(0x0400, torch::executor::Half::from_bits());
+  }
+  static constexpr torch::executor::Half lowest() {
+    return torch::executor::Half(0xFBFF, torch::executor::Half::from_bits());
+  }
+  static constexpr torch::executor::Half max() {
+    return torch::executor::Half(0x7BFF, torch::executor::Half::from_bits());
+  }
+  static constexpr torch::executor::Half epsilon() {
+    return torch::executor::Half(0x1400, torch::executor::Half::from_bits());
+  }
+  static constexpr torch::executor::Half round_error() {
+    return torch::executor::Half(0x3800, torch::executor::Half::from_bits());
+  }
+  static constexpr torch::executor::Half infinity() {
+    return torch::executor::Half(0x7C00, torch::executor::Half::from_bits());
+  }
+  static constexpr torch::executor::Half quiet_NaN() {
+    return torch::executor::Half(0x7E00, torch::executor::Half::from_bits());
+  }
+  static constexpr torch::executor::Half signaling_NaN() {
+    return torch::executor::Half(0x7D00, torch::executor::Half::from_bits());
+  }
+  static constexpr torch::executor::Half denorm_min() {
+    return torch::executor::Half(0x0001, torch::executor::Half::from_bits());
+  }
+};
+
+} // namespace std

--- a/runtime/core/portable_type/test/half_test.cpp
+++ b/runtime/core/portable_type/test/half_test.cpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/core/portable_type/half.h>
+#include <executorch/test/utils/DeathTest.h>
+#include <gtest/gtest.h>
+#include <cmath>
+
+namespace torch {
+namespace executor {
+namespace {
+
+/**
+ * According to the precision limitations listed here:
+ * https://en.wikipedia.org/wiki/Half-precision_floating-point_format#Precision_limitations
+ * The max precision error for a half in the range [2^n, 2^(n+1)] is 2^(n-10)
+ */
+float toleranceFloat16(float f) {
+  return pow(2, static_cast<int>(log2(fabs(f))) - 10);
+}
+
+bool closeEnoughFloat16(float a, float b) {
+  return fabs(a - b) <= toleranceFloat16(fmax(fabs(a), fabs(b)));
+}
+
+} // namespace
+
+/// Arithmetic with Halfs
+
+TEST(HalfTest, ArithmeticHalfAdd) {
+  float af = 104.35;
+  Half ah(af);
+  float bf = 72.5;
+  Half bh(bf);
+  EXPECT_TRUE(closeEnoughFloat16(ah + bh, af + bf));
+  ah += bh;
+  af += bf;
+  EXPECT_TRUE(closeEnoughFloat16(ah, af));
+}
+
+TEST(HalfTest, ArithmeticHalfSub) {
+  float af = 31.4;
+  Half ah(af);
+  float bf = 20.5;
+  Half bh(bf);
+  EXPECT_TRUE(closeEnoughFloat16(ah - bh, af - bf));
+  ah -= bh;
+  af -= bf;
+  EXPECT_TRUE(closeEnoughFloat16(ah, af));
+}
+
+TEST(HalfTest, ArithmeticHalfMul) {
+  float af = 85.5;
+  Half ah(af);
+  float bf = 17.5;
+  Half bh(bf);
+  EXPECT_TRUE(closeEnoughFloat16(ah * bh, af * bf));
+  ah *= bh;
+  af *= bf;
+  EXPECT_TRUE(closeEnoughFloat16(ah, af));
+}
+
+TEST(HalfTest, ArithmeticHalfDiv) {
+  float af = 96.9;
+  Half ah(af);
+  float bf = 12.5;
+  Half bh(bf);
+  EXPECT_TRUE(closeEnoughFloat16(ah / bh, af / bf));
+  ah /= bh;
+  af /= bf;
+  EXPECT_TRUE(closeEnoughFloat16(ah, af));
+}
+
+/// Arithmetic with floats
+
+TEST(HalfTest, ArithmeticFloatAdd) {
+  float af = 104.35;
+  Half ah(af);
+  float b = 72.5;
+  EXPECT_TRUE(closeEnoughFloat16(ah + b, af + b));
+  EXPECT_TRUE(closeEnoughFloat16(b + ah, b + af));
+}
+
+TEST(HalfTest, ArithmeticFloatSub) {
+  float af = 31.4;
+  Half ah(af);
+  float b = 20.5;
+  EXPECT_TRUE(closeEnoughFloat16(ah - b, af - b));
+  EXPECT_TRUE(closeEnoughFloat16(b - ah, b - af));
+}
+
+TEST(HalfTest, ArithmeticFloatMul) {
+  float af = 85.5;
+  Half ah(af);
+  float b = 17.5;
+  EXPECT_TRUE(closeEnoughFloat16(ah * b, af * b));
+  EXPECT_TRUE(closeEnoughFloat16(b * ah, b * af));
+}
+
+TEST(HalfTest, ArithmeticFloatDiv) {
+  float af = 96.9;
+  Half ah(af);
+  float b = 12.5;
+  EXPECT_TRUE(closeEnoughFloat16(ah / b, af / b));
+  EXPECT_TRUE(closeEnoughFloat16(b / ah, b / af));
+}
+
+/// Arithmetic with doubles
+
+TEST(HalfTest, ArithmeticDoubleAdd) {
+  float af = 104.35;
+  Half ah(af);
+  double b = 72.5;
+  EXPECT_TRUE(closeEnoughFloat16(ah + b, af + b));
+  EXPECT_TRUE(closeEnoughFloat16(b + ah, b + af));
+}
+
+TEST(HalfTest, ArithmeticDoubleSub) {
+  float af = 31.4;
+  Half ah(af);
+  double b = 20.5;
+  EXPECT_TRUE(closeEnoughFloat16(ah - b, af - b));
+  EXPECT_TRUE(closeEnoughFloat16(b - ah, b - af));
+}
+
+TEST(HalfTest, ArithmeticDoubleMul) {
+  float af = 85.5;
+  Half ah(af);
+  double b = 17.5;
+  EXPECT_TRUE(closeEnoughFloat16(ah * b, af * b));
+  EXPECT_TRUE(closeEnoughFloat16(b * ah, b * af));
+}
+
+TEST(HalfTest, ArithmeticDoubleDiv) {
+  float af = 96.9;
+  Half ah(af);
+  double b = 12.5;
+  EXPECT_TRUE(closeEnoughFloat16(ah / b, af / b));
+  EXPECT_TRUE(closeEnoughFloat16(b / ah, b / af));
+}
+
+/// Arithmetic with ints
+
+TEST(HalfTest, ArithmeticInt32Add) {
+  float af = 104.35;
+  Half ah(af);
+  int32_t b = 72;
+  EXPECT_TRUE(closeEnoughFloat16(ah + b, af + b));
+  EXPECT_TRUE(closeEnoughFloat16(b + ah, b + af));
+}
+
+TEST(HalfTest, ArithmeticInt32Sub) {
+  float af = 31.4;
+  Half ah(af);
+  int32_t b = 20;
+  EXPECT_TRUE(closeEnoughFloat16(ah - b, af - b));
+  EXPECT_TRUE(closeEnoughFloat16(b - ah, b - af));
+}
+
+TEST(HalfTest, ArithmeticInt32Mul) {
+  float af = 85.5;
+  Half ah(af);
+  int32_t b = 17;
+  EXPECT_TRUE(closeEnoughFloat16(ah * b, af * b));
+  EXPECT_TRUE(closeEnoughFloat16(b * ah, b * af));
+}
+
+TEST(HalfTest, ArithmeticInt32Div) {
+  float af = 96.9;
+  Half ah(af);
+  int32_t b = 12;
+  EXPECT_TRUE(closeEnoughFloat16(ah / b, af / b));
+  EXPECT_TRUE(closeEnoughFloat16(b / ah, b / af));
+}
+
+//// Arithmetic with int64_t
+
+TEST(HalfTest, ArithmeticInt64Add) {
+  float af = 104.35;
+  Half ah(af);
+  int64_t b = 72;
+  EXPECT_TRUE(closeEnoughFloat16(ah + b, af + b));
+  EXPECT_TRUE(closeEnoughFloat16(b + ah, b + af));
+}
+
+TEST(HalfTest, ArithmeticInt64Sub) {
+  float af = 31.4;
+  Half ah(af);
+  int64_t b = 20;
+  EXPECT_TRUE(closeEnoughFloat16(ah - b, af - b));
+  EXPECT_TRUE(closeEnoughFloat16(b - ah, b - af));
+}
+
+TEST(HalfTest, ArithmeticInt64Mul) {
+  float af = 85.5;
+  Half ah(af);
+  int64_t b = 17;
+  EXPECT_TRUE(closeEnoughFloat16(ah * b, af * b));
+  EXPECT_TRUE(closeEnoughFloat16(b * ah, b * af));
+}
+
+TEST(HalfTest, ArithmeticInt64Div) {
+  float af = 96.9;
+  Half ah(af);
+  int64_t b = 12;
+  EXPECT_TRUE(closeEnoughFloat16(ah / b, af / b));
+  EXPECT_TRUE(closeEnoughFloat16(b / ah, b / af));
+}
+
+} // namespace executor
+} // namespace torch

--- a/runtime/core/portable_type/test/targets.bzl
+++ b/runtime/core/portable_type/test/targets.bzl
@@ -23,6 +23,14 @@ def define_common_targets():
     )
 
     runtime.cxx_test(
+        name = "half_test",
+        srcs = ["half_test.cpp"],
+        deps = [
+            "//executorch/runtime/core/portable_type:portable_type",
+        ],
+    )
+
+    runtime.cxx_test(
         name = "scalar_test",
         srcs = ["scalar_test.cpp"],
         deps = [


### PR DESCRIPTION
Summary:
Imported code from https://www.internalfb.com/code/fbsource/fbcode/caffe2/c10/util/Half-inl.h and https://www.internalfb.com/code/fbsource/fbcode/caffe2/c10/util/Half.h into Half.h to enable conversions and arithmetic operations with halfs

Introduced ET_INTERNAL_SWITCH_CASE_REAL_TYPES_AND2 macro, in order to switch over REAL TYPES + Bool + Half

Updated add op to support Half
Updated add tests to test Half support

Reviewed By: digantdesai

Differential Revision: D53027795


