### PR TITLE
Avoid type promotion pass for fp16 weights

### DIFF
--- a/examples/models/llama2/export_llama.py
+++ b/examples/models/llama2/export_llama.py
@@ -160,7 +160,10 @@ def export_llama(modelname, args) -> str:
         use_kv_cache=args.use_kv_cache,
         fairseq2=args.fairseq2,
     )
-
+    edge_config = EdgeCompileConfig(
+        _check_ir_validity=False,
+        _skip_type_promotion=bool(args.half),
+    )
     if args.use_kv_cache:
         # seq length is fixed to 1 with current kv cache impl
         dynamic_shapes = None
@@ -209,9 +212,7 @@ def export_llama(modelname, args) -> str:
             example_inputs,
             dynamic_shapes=dynamic_shapes,
             edge_constant_methods=metadata,
-            edge_compile_config=EdgeCompileConfig(
-                _check_ir_validity=False,
-            ),
+            edge_compile_config=edge_config,
         )
     if args.xnnpack:
         edge_manager = edge_manager.to_backend(XnnpackPartitioner())

--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -34,6 +34,7 @@ class EdgeCompileConfig:
     _check_ir_validity: bool = True
     # TODO(larryliu): remove this
     _use_edge_ops: bool = True
+    _skip_type_promotion: bool = False
 
 
 @compatibility(is_backward_compatible=False)

--- a/exir/passes/__init__.py
+++ b/exir/passes/__init__.py
@@ -37,11 +37,8 @@ from executorch.exir.passes.debug_handle_generator_pass import DebugHandleGenera
 
 from executorch.exir.passes.executorch_prim_ops_registry import _EXECUTORCH_SYM_OPS
 from executorch.exir.passes.memory_format_ops_pass import MemoryFormatOpsPass
-from executorch.exir.passes.memory_planning_pass import MemoryPlanningPass
 from executorch.exir.passes.normalize_transpose_pass import NormalizeTransposePass
-from executorch.exir.passes.pass_registry import PassRegistry
 from executorch.exir.passes.quant_fusion_pass import QuantFusionPass
-from executorch.exir.passes.remove_mixed_type_operators import RemoveMixedTypeOperators
 from executorch.exir.passes.remove_noop_pass import RemoveNoopPass
 from executorch.exir.passes.replace_aten_with_edge_pass import OpReplacePass
 from executorch.exir.passes.replace_broken_ops_with_function_ops_pass import (
@@ -464,7 +461,8 @@ def dead_code_elimination_pass(graph_module: torch.fx.GraphModule) -> PassResult
 
 
 # Passes to convert a graph module from ATen to Edge IR
-aten_to_edge_passes = PassManager(
+
+pre_op_replace_passes = PassManager(
     passes=[
         # ReplaceSymSizeOpPass need to be run before other passes which inherits
         # from ExportPass. ExportPass can not handle OpOverloadPacket in its
@@ -475,27 +473,16 @@ aten_to_edge_passes = PassManager(
         ReplaceBrokenOpsWithFunctionalOpsPass(),
         ScalarToTensorPass(),
         SymToTensorPass(),
-        RemoveMixedTypeOperators(),
         RemoveNoopPass(),
+    ]
+).passes
+
+post_op_replace_passes = PassManager(
+    passes=[
         dead_code_elimination_pass,
         DebugHandleGeneratorPass(),
     ]
-)
-
-
-def register_passes() -> None:
-    """
-    Register an aten-to-edge collection of passes, and instances of PassBase
-    subclasses declared in this file.
-    """
-
-    PassRegistry.register("aten_to_edge_passes")(aten_to_edge_passes)
-    PassRegistry.register("debug_pass")(DebugPass())
-    PassRegistry.register("memory_planning_pass")(MemoryPlanningPass())
-    PassRegistry.register("to_out_var_pass")(ToOutVarPass())
-
-
-register_passes()
+).passes
 
 
 def propagate_dynamic_shape(

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -20,11 +20,13 @@ from executorch.exir.emit._emitter import _DelegateDebugIdentifierMap
 from executorch.exir.error import ExportError
 from executorch.exir.pass_manager import PassType
 from executorch.exir.passes import (
-    aten_to_edge_passes,
     EdgeToBackendOpsPass,
     OpReplacePass,
+    post_op_replace_passes,
+    pre_op_replace_passes,
 )
 from executorch.exir.passes.remove_graph_asserts_pass import RemoveGraphAssertsPass
+from executorch.exir.passes.remove_mixed_type_operators import RemoveMixedTypeOperators
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
 from executorch.exir.print_program import pretty_print, print_program
 from executorch.exir.schema import Program
@@ -482,10 +484,11 @@ def _to_edge(ep, config: EdgeCompileConfig) -> "ExirExportedProgram":
     # use_edge_op it can be moved to aten_to_edge_passes before eliminated_dead_code pass. Also ExportPass doesn't play
     # well with node.meta, meaning after some passes permuting operators, we may lose some information in node.meta.
     # It might be regenerated in SpecPropPass so it may not be visiable. However debug handle will be lost.
-    pre_op_replace_passes = aten_to_edge_passes.passes[:-2]
-    post_op_replace_passes = aten_to_edge_passes.passes[-2:]
 
-    new_ep = copy.deepcopy(ep).transform(*pre_op_replace_passes)
+    passes = pre_op_replace_passes + (
+        [] if config._skip_type_promotion else [RemoveMixedTypeOperators()]
+    )
+    new_ep = copy.deepcopy(ep).transform(*passes)
     if dialect == "ATEN":
         new_ep.exported_program = lift_constant_tensor_pass(new_ep.exported_program)
 
@@ -824,16 +827,16 @@ def to_edge(
         passes.append(
             ReplaceViewOpsWithViewCopyOpsPass()
         )  # TODO move inside aten_to_edge passes after all users are migrated off v1 capture
-        passes.extend(aten_to_edge_passes.passes[:-2])
+        passes.extend(pre_op_replace_passes)
+        if not config._skip_type_promotion:
+            passes.append(RemoveMixedTypeOperators())
+        if config._use_edge_ops:
+            passes.append(OpReplacePass())
+
         gm = program.graph_module
         edge_program = program
         for p in passes:
             gm_res = p(gm)
-            assert gm_res is not None
-            gm = gm_res.graph_module
-
-        if config._use_edge_ops:
-            gm_res = OpReplacePass()(gm)
             assert gm_res is not None
             gm = gm_res.graph_module
 
@@ -854,9 +857,7 @@ def to_edge(
             ),
             tensor_constants=edge_program.tensor_constants,
         )
-        passes = []
-        passes.extend(aten_to_edge_passes.passes[-2:])
-        edge_program = _transform(edge_program, *passes)
+        edge_program = _transform(edge_program, *post_op_replace_passes)
         edge_programs[name] = edge_program
     return EdgeProgramManager(edge_programs, constant_methods, config)
 


### PR DESCRIPTION
Summary: We are inserting `_to_copy` ops to `mul` where we promote the dtypes of input tensors to fp32. This behavior is unwanted for fp16 models. Here I'm adding an option to `to_edge()` to disable this type promotion pass.

Differential Revision: D53033258


