### PR TITLE
Fix small issues on export and runner

### DIFF
--- a/examples/models/llama2/export_llama.py
+++ b/examples/models/llama2/export_llama.py
@@ -160,7 +160,10 @@ def export_llama(modelname, args) -> str:
         use_kv_cache=args.use_kv_cache,
         fairseq2=args.fairseq2,
     )
-
+    edge_config = EdgeCompileConfig(
+        _check_ir_validity=False,
+        _skip_type_promotion=bool(args.half),
+    )
     if args.use_kv_cache:
         # seq length is fixed to 1 with current kv cache impl
         dynamic_shapes = None
@@ -209,9 +212,7 @@ def export_llama(modelname, args) -> str:
             example_inputs,
             dynamic_shapes=dynamic_shapes,
             edge_constant_methods=metadata,
-            edge_compile_config=EdgeCompileConfig(
-                _check_ir_validity=False,
-            ),
+            edge_compile_config=edge_config,
         )
     if args.xnnpack:
         edge_manager = edge_manager.to_backend(XnnpackPartitioner())

--- a/examples/models/llama2/llama_runner.cpp
+++ b/examples/models/llama2/llama_runner.cpp
@@ -112,7 +112,7 @@ void LlamaRunner::generate(const char* prompt) {
   // max # of prompt tokens: len(prompt) + '\0', ?BOS, ?EOS
   int* prompt_tokens = new int[strlen(prompt) + 1 + n_bos_ + n_eos_];
 
-  tokenizer_->encode(prompt, n_bos_, n_eos_, prompt_tokens, &num_prompt_tokens);
+  tokenizer_->encode(prompt, n_bos_, 0, prompt_tokens, &num_prompt_tokens);
 
   ET_CHECK_MSG(num_prompt_tokens >= 1, "Expected at least 1 prompt token");
 

--- a/examples/models/llama2/llama_runner.cpp
+++ b/examples/models/llama2/llama_runner.cpp
@@ -157,20 +157,46 @@ void LlamaRunner::generate(const char* prompt) {
         "Expecting output to have at least one evalue. Got %zu",
         outputs.size());
 
-    float* logits = outputs[0].toTensor().mutable_data_ptr<float>();
+    int32_t next_tok;
+    switch (outputs[0].toTensor().scalar_type()) {
+      case ScalarType::Float: {
+        float* logits = outputs[0].toTensor().mutable_data_ptr<float>();
+
+        // Since the logits are for all tokens, get the last token probabilities
+        float* logits_last = logits + pos * tokenizer_->vocab_size();
+        next_tok = sampler_->sample(logits_last);
+        break;
+      }
+      case ScalarType::Half: {
+#ifdef USE_ATEN_LIB
+        // TODO:(larryliu) get rid of this check once we have Half support in
+        // portable kernels.
+
+        c10::Half* half_logits =
+            outputs[0].toTensor().mutable_data_ptr<c10::Half>();
+        c10::Half* logits_last = half_logits + pos * tokenizer_->vocab_size();
+        next_tok = sampler_->sample(logits_last);
+        break;
+#endif
+      }
+      default:
+        ET_CHECK_MSG(
+            false,
+            "Unsupported dtype output %hhd",
+            outputs[0].toTensor().scalar_type());
+    }
+
     // debug
     // torch::Tensor t = torch::from_blob(
     //     (void*)logits, {1, num_prompt_tokens, 32000}, torch::kFloat);
 
-    // Since the logits are for all tokens, get the last token probabilities
-    float* logits_last = logits + pos * tokenizer_->vocab_size();
     // advance the state machine
     if (pos < num_prompt_tokens - 1) {
       // prefill, force the next token to be the next prompt token
       next = prompt_tokens[pos + 1];
     } else {
       // otherwise sample the next token from the logits
-      next = sampler_->sample(logits_last);
+      next = next_tok;
     }
     // ET_LOG(Info, "Output saved, next = %d", next);
     pos++;

--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -483,6 +483,12 @@ class Llama2Model(EagerModelBase):
         device = "cpu"
         # flake8: noqa: TOR102
         checkpoint = torch.load(checkpoint_path, map_location=device)
+        if kwargs.get("fairseq2", False):
+            print("Using fairseq2 checkpoint")
+            checkpoint = convert_to_llama_checkpoint(checkpoint=checkpoint)
+        if "model" in checkpoint:
+            # NB: some checkpoint contains a "model" field, which is the actual weights dict
+            checkpoint = checkpoint["model"]
         with open(params_path, "r") as f:
             params = json.loads(f.read())
         max_seq_len = 128
@@ -493,9 +499,6 @@ class Llama2Model(EagerModelBase):
             use_kv_cache=self.use_kv_cache,
             **params,
         )
-        if kwargs.get("fairseq2", False):
-            print("Using fairseq2 checkpoint")
-            checkpoint = convert_to_llama_checkpoint(checkpoint=checkpoint)
         self.model_ = Transformer(model_args)
 
         if "int8" in str(checkpoint_path):

--- a/examples/models/llama2/sampler/sampler.cpp
+++ b/examples/models/llama2/sampler/sampler.cpp
@@ -38,10 +38,11 @@ namespace torch {
 namespace executor {
 
 // sampler stuff
-int32_t Sampler::sample_argmax(float* probabilities) {
+template <typename T>
+int32_t Sampler::sample_argmax(T* probabilities) {
   // return the index that has the highest probability
   int max_i = 0;
-  float max_p = probabilities[0];
+  T max_p = probabilities[0];
   for (int i = 1; i < vocab_size_; i++) {
     if (probabilities[i] > max_p) {
       max_i = i;
@@ -51,10 +52,11 @@ int32_t Sampler::sample_argmax(float* probabilities) {
   return max_i;
 }
 
-int32_t Sampler::sample_mult(float* probabilities, float coin) {
+template <typename T>
+int32_t Sampler::sample_mult(T* probabilities, float coin) {
   // sample index from probabilities (they must sum to 1!)
   // coin is a random number in [0, 1), usually from random_f32()
-  float cdf = 0.0f;
+  T cdf = 0.0;
   for (int i = 0; i < vocab_size_; i++) {
     cdf += probabilities[i];
     if (coin < cdf) {
@@ -64,9 +66,10 @@ int32_t Sampler::sample_mult(float* probabilities, float coin) {
   return vocab_size_ - 1; // in case of rounding errors
 }
 
+template <typename T>
 static int32_t compare(const void* a, const void* b) {
-  ProbIndex* a_ = (ProbIndex*)a;
-  ProbIndex* b_ = (ProbIndex*)b;
+  ProbIndex<T>* a_ = (ProbIndex<T>*)a;
+  ProbIndex<T>* b_ = (ProbIndex<T>*)b;
   if (a_->prob > b_->prob) {
     return -1;
   } else if (a_->prob < b_->prob) {
@@ -75,7 +78,8 @@ static int32_t compare(const void* a, const void* b) {
   return 0;
 }
 
-int32_t Sampler::sample_topp(float* probabilities, float coin) {
+template <typename T>
+int32_t Sampler::sample_topp(T* probabilities, float coin) {
   // top-p sampling (or "nucleus sampling") samples from the smallest set of
   // tokens that exceed probability topp. This way we never sample tokens that
   // have very low probabilities and are less likely to go "off the rails".
@@ -85,21 +89,24 @@ int32_t Sampler::sample_topp(float* probabilities, float coin) {
   // quicksort indices in descending order of probabilities
   // values smaller than (1 - topp) / (n - 1) cannot be part of the result
   // so for efficiency we crop these out as candidates before sorting
+  std::unique_ptr<ProbIndex<T>[]> probindex =
+      std::make_unique<ProbIndex<T>[]>(vocab_size_);
+
   const float cutoff = (1.0f - topp_) / (n - 1);
   for (int i = 0; i < n; i++) {
     if (probabilities[i] >= cutoff) {
-      probindex_[n0].index = i;
-      probindex_[n0].prob = probabilities[i];
+      probindex[n0].index = i;
+      probindex[n0].prob = probabilities[i];
       n0++;
     }
   }
-  qsort(probindex_.get(), n0, sizeof(ProbIndex), compare);
+  qsort(probindex.get(), n0, sizeof(ProbIndex<T>), compare<T>);
 
   // truncate the list where cumulative probability exceeds topp
-  float cumulative_prob = 0.0f;
+  T cumulative_prob = 0;
   int last_idx = n0 - 1; // in case of rounding errors consider all elements
   for (int i = 0; i < n0; i++) {
-    cumulative_prob += probindex_[i].prob;
+    cumulative_prob += probindex[i].prob;
     if (cumulative_prob > topp_) {
       last_idx = i;
       break; // we've exceeded topp by including last_idx
@@ -107,15 +114,15 @@ int32_t Sampler::sample_topp(float* probabilities, float coin) {
   }
 
   // sample from the truncated list
-  float r = coin * cumulative_prob;
-  float cdf = 0.0f;
+  T r = coin * cumulative_prob;
+  T cdf = 0;
   for (int i = 0; i <= last_idx; i++) {
-    cdf += probindex_[i].prob;
+    cdf += probindex[i].prob;
     if (r < cdf) {
-      return probindex_[i].index;
+      return probindex[i].index;
     }
   }
-  return probindex_[last_idx].index; // in case of rounding errors
+  return probindex[last_idx].index; // in case of rounding errors
 }
 
 Sampler::Sampler(
@@ -124,21 +131,21 @@ Sampler::Sampler(
     float topp,
     unsigned long long rng_seed)
     : vocab_size_(vocab_size),
-      probindex_(std::make_unique<ProbIndex[]>(vocab_size)),
       temperature_(temperature),
       topp_(topp),
       rng_state_(rng_seed) {}
 
-static void softmax(float* x, int size) {
+template <typename T>
+static void softmax(T* x, int size) {
   // find max value (for numerical stability)
-  float max_val = x[0];
+  T max_val = x[0];
   for (int i = 1; i < size; i++) {
     if (x[i] > max_val) {
       max_val = x[i];
     }
   }
   // exp and sum
-  float sum = 0.0f;
+  T sum = 0;
   for (int i = 0; i < size; i++) {
     x[i] = expf(x[i] - max_val);
     sum += x[i];
@@ -161,7 +168,8 @@ static float random_f32(unsigned long long* state) { // random float32 in [0,1)
   return (random_u32(state) >> 8) / 16777216.0f;
 }
 
-int32_t Sampler::sample(float* logits) {
+template <typename T>
+int32_t Sampler::sample(T* logits) {
   // sample the token given the logits and some hyperparameters
   int next;
   if (temperature_ == 0.0f) {
@@ -187,6 +195,11 @@ int32_t Sampler::sample(float* logits) {
   }
   return next;
 }
+
+template int32_t Sampler::sample<float>(float* logits);
+#ifdef USE_ATEN_LIB
+template int32_t Sampler::sample<c10::Half>(c10::Half* logits);
+#endif
 
 } // namespace executor
 } // namespace torch

--- a/examples/models/llama2/sampler/sampler.h
+++ b/examples/models/llama2/sampler/sampler.h
@@ -14,13 +14,17 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#ifdef USE_ATEN_LIB
+#include <torch/torch.h>
+#endif
 
 namespace torch {
 namespace executor {
 // A simple llama2 sampler.
 
+template <typename T>
 struct ProbIndex {
-  float prob;
+  T prob;
   int32_t index;
 }; // struct used when sorting probabilities during top-p sampling
 
@@ -32,16 +36,19 @@ class Sampler {
       float topp,
       unsigned long long rng_seed);
 
-  int32_t sample(float* logits);
+  template <typename T>
+  int32_t sample(T* logits);
 
  private:
-  int32_t sample_topp(float* probabilities, float coin);
-  int32_t sample_mult(float* probabilities, float coin);
-  int32_t sample_argmax(float* probabilities);
+  template <typename T>
+  int32_t sample_topp(T* probabilities, float coin);
+  template <typename T>
+  int32_t sample_mult(T* probabilities, float coin);
+  template <typename T>
+  int32_t sample_argmax(T* probabilities);
 
  private:
   int32_t vocab_size_;
-  std::unique_ptr<ProbIndex[]> probindex_; // buffer used in top-p sampling
   float temperature_;
   float topp_;
   unsigned long long rng_state_;

--- a/examples/models/llama2/sampler/targets.bzl
+++ b/examples/models/llama2/sampler/targets.bzl
@@ -1,16 +1,23 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 def define_common_targets():
-    runtime.cxx_library(
-        name = "sampler",
-        exported_headers = [
-            "sampler.h",
-        ],
-        srcs = [
-            "sampler.cpp",
-        ],
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-            "//executorch/...",
-        ],
-    )
+    for aten in (True, False):
+        aten_postfix = "_aten" if aten else ""
+        runtime.cxx_library(
+            name = "sampler" + aten_postfix,
+            exported_headers = [
+                "sampler.h",
+            ],
+            preprocessor_flags = [
+                "-DUSE_ATEN_LIB",
+            ] if aten else [],
+            srcs = [
+                "sampler.cpp",
+            ],
+            visibility = [
+                "//executorch/...",
+            ],
+            external_deps = [
+                "libtorch",
+            ] if aten else [],
+        )

--- a/examples/models/llama2/sampler/test/targets.bzl
+++ b/examples/models/llama2/sampler/test/targets.bzl
@@ -13,7 +13,7 @@ def define_common_targets():
             "test_sampler.cpp",
         ],
         deps = [
-            "//executorch/examples/models/llama2/sampler:sampler",
+            "//executorch/examples/models/llama2/sampler:sampler_aten",
         ],
         xplat_deps = [
             "//caffe2:torch_mobile_all_ops",

--- a/examples/models/llama2/sampler/test/test_sampler.cpp
+++ b/examples/models/llama2/sampler/test/test_sampler.cpp
@@ -31,5 +31,18 @@ TEST_F(SamplerTest, TestArgMax) {
   EXPECT_EQ(sampler.sample(input.data_ptr<float>()), 396);
 }
 
+TEST_F(SamplerTest, TestArgMaxWithFP16) {
+  torch::executor::Sampler sampler{
+      /*vocab_size*/ 32000,
+      /*temperature*/ 0.0f,
+      /*topp*/ 0.9f,
+      /*rng_seed*/ 0};
+  // tensor([[[-12.9832,  -7.4133,  -0.4327,  ...,  -6.8297,  -8.0880,
+  // -7.5863]]])
+  torch::Tensor input = torch::rand({1, 1, 32000}, at::kHalf);
+  input[0][0][396] = 1.0f;
+  EXPECT_EQ(sampler.sample(input.data_ptr<c10::Half>()), 396);
+}
+
 } // namespace executor
 } // namespace torch

--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -34,6 +34,7 @@ class EdgeCompileConfig:
     _check_ir_validity: bool = True
     # TODO(larryliu): remove this
     _use_edge_ops: bool = True
+    _skip_type_promotion: bool = False
 
 
 @compatibility(is_backward_compatible=False)

--- a/exir/passes/__init__.py
+++ b/exir/passes/__init__.py
@@ -464,7 +464,8 @@ def dead_code_elimination_pass(graph_module: torch.fx.GraphModule) -> PassResult
 
 
 # Passes to convert a graph module from ATen to Edge IR
-aten_to_edge_passes = PassManager(
+
+pre_op_replace_passes = PassManager(
     passes=[
         # ReplaceSymSizeOpPass need to be run before other passes which inherits
         # from ExportPass. ExportPass can not handle OpOverloadPacket in its
@@ -475,27 +476,16 @@ aten_to_edge_passes = PassManager(
         ReplaceBrokenOpsWithFunctionalOpsPass(),
         ScalarToTensorPass(),
         SymToTensorPass(),
-        RemoveMixedTypeOperators(),
         RemoveNoopPass(),
+    ]
+).passes
+
+post_op_replace_passes = PassManager(
+    passes=[
         dead_code_elimination_pass,
         DebugHandleGeneratorPass(),
     ]
-)
-
-
-def register_passes() -> None:
-    """
-    Register an aten-to-edge collection of passes, and instances of PassBase
-    subclasses declared in this file.
-    """
-
-    PassRegistry.register("aten_to_edge_passes")(aten_to_edge_passes)
-    PassRegistry.register("debug_pass")(DebugPass())
-    PassRegistry.register("memory_planning_pass")(MemoryPlanningPass())
-    PassRegistry.register("to_out_var_pass")(ToOutVarPass())
-
-
-register_passes()
+).passes
 
 
 def propagate_dynamic_shape(

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -20,11 +20,13 @@ from executorch.exir.emit._emitter import _DelegateDebugIdentifierMap
 from executorch.exir.error import ExportError
 from executorch.exir.pass_manager import PassType
 from executorch.exir.passes import (
-    aten_to_edge_passes,
     EdgeToBackendOpsPass,
     OpReplacePass,
+    post_op_replace_passes,
+    pre_op_replace_passes,
 )
 from executorch.exir.passes.remove_graph_asserts_pass import RemoveGraphAssertsPass
+from executorch.exir.passes.remove_mixed_type_operators import RemoveMixedTypeOperators
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
 from executorch.exir.print_program import pretty_print, print_program
 from executorch.exir.schema import Program
@@ -482,10 +484,11 @@ def _to_edge(ep, config: EdgeCompileConfig) -> "ExirExportedProgram":
     # use_edge_op it can be moved to aten_to_edge_passes before eliminated_dead_code pass. Also ExportPass doesn't play
     # well with node.meta, meaning after some passes permuting operators, we may lose some information in node.meta.
     # It might be regenerated in SpecPropPass so it may not be visiable. However debug handle will be lost.
-    pre_op_replace_passes = aten_to_edge_passes.passes[:-2]
-    post_op_replace_passes = aten_to_edge_passes.passes[-2:]
 
-    new_ep = copy.deepcopy(ep).transform(*pre_op_replace_passes)
+    passes = pre_op_replace_passes + (
+        [] if config._skip_type_promotion else [RemoveMixedTypeOperators()]
+    )
+    new_ep = copy.deepcopy(ep).transform(*passes)
     if dialect == "ATEN":
         new_ep.exported_program = lift_constant_tensor_pass(new_ep.exported_program)
 
@@ -824,16 +827,16 @@ def to_edge(
         passes.append(
             ReplaceViewOpsWithViewCopyOpsPass()
         )  # TODO move inside aten_to_edge passes after all users are migrated off v1 capture
-        passes.extend(aten_to_edge_passes.passes[:-2])
+        passes.extend(pre_op_replace_passes)
+        if not config._skip_type_promotion:
+            passes.append(RemoveMixedTypeOperators())
+        if config._use_edge_ops:
+            passes.append(OpReplacePass())
+
         gm = program.graph_module
         edge_program = program
         for p in passes:
             gm_res = p(gm)
-            assert gm_res is not None
-            gm = gm_res.graph_module
-
-        if config._use_edge_ops:
-            gm_res = OpReplacePass()(gm)
             assert gm_res is not None
             gm = gm_res.graph_module
 
@@ -854,9 +857,7 @@ def to_edge(
             ),
             tensor_constants=edge_program.tensor_constants,
         )
-        passes = []
-        passes.extend(aten_to_edge_passes.passes[-2:])
-        edge_program = _transform(edge_program, *passes)
+        edge_program = _transform(edge_program, *post_op_replace_passes)
         edge_programs[name] = edge_program
     return EdgeProgramManager(edge_programs, constant_methods, config)
 


### PR DESCRIPTION
Summary:
Some checkpoint contains a `model` field and then has weights dict under it. Some checkpoint only has the weights dict. This diff adds a check to see if there's a `model` field.

For text completion tasks, we don't append `EOS` token to the prompt so changing it to 0.

Differential Revision: D53060052


