### PR TITLE
[MPS] Fix buffer alignment for iOS15/16, macOS12/13

### DIFF
--- a/backends/apple/mps/operators/unary_ops.py
+++ b/backends/apple/mps/operators/unary_ops.py
@@ -1,3 +1,4 @@
+#
 #  Copyright (c) 2023 Apple Inc. All rights reserved.
 #  Provided subject to the LICENSE file in the top level directory.
 #

--- a/backends/apple/mps/runtime/MPSDevice.h
+++ b/backends/apple/mps/runtime/MPSDevice.h
@@ -16,6 +16,15 @@ namespace executor {
 namespace mps {
 namespace delegate {
 
+// Helper enum to check if a MPSGraph op is supported in a given macOS version
+enum class MacOSVersion : uint32_t {
+  MACOS_VER_13_0_PLUS = 0,
+  MACOS_VER_13_1_PLUS,
+  MACOS_VER_13_2_PLUS,
+  MACOS_VER_13_3_PLUS,
+  MACOS_VER_14_0_PLUS,
+};
+
 class MPSDevice {
  public:
   /**
@@ -37,6 +46,11 @@ class MPSDevice {
     return _mtl_device;
   }
 
+  /**
+   * Returns whether running on Ventura or newer
+   */
+  bool isMacOS13Plus(MacOSVersion version) const;
+
   ~MPSDevice();
 
  private:
@@ -44,6 +58,8 @@ class MPSDevice {
   id<MTLDevice> _mtl_device;
   MPSDevice();
 };
+
+bool isMacOS13OrNewer(MacOSVersion version = MacOSVersion::MACOS_VER_13_0_PLUS);
 
 } // namespace delegate
 } // namespace mps

--- a/backends/apple/mps/runtime/MPSDevice.mm
+++ b/backends/apple/mps/runtime/MPSDevice.mm
@@ -47,6 +47,42 @@ MPSDevice* MPSDevice::getInstance() {
   return mps_device.get();
 }
 
+bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
+  id mpsCD = NSClassFromString(@"MPSGraph");
+  static auto compileOptions = [[[MTLCompileOptions alloc] init] autorelease];
+  static bool _macos_13_0_plus = [mpsCD instancesRespondToSelector:@selector(cumulativeSumWithTensor:
+                                                                                                axis:name:)] == YES;
+  static bool _macos_13_1_plus =
+      [mpsCD instancesRespondToSelector:@selector
+             (sampleGridWithSourceTensor:
+                        coordinateTensor:layout:normalizeCoordinates:relativeCoordinates:alignCorners:paddingMode
+                                        :samplingMode:constantValue:name:)] == YES;
+  static bool _macos_13_2_plus =
+      [mpsCD instancesRespondToSelector:@selector(convolution3DWithSourceTensor:weightsTensor:descriptor:name:)] == YES;
+  static bool _macos_13_3_plus = [compileOptions respondsToSelector:@selector(maxTotalThreadsPerThreadgroup)] == YES;
+
+  static bool _macos_14_0_plus = [mpsCD instancesRespondToSelector:@selector(conjugateWithTensor:name:)] == YES;
+
+  switch (version) {
+    case MacOSVersion::MACOS_VER_13_0_PLUS:
+      return _macos_13_0_plus;
+    case MacOSVersion::MACOS_VER_13_1_PLUS:
+      return _macos_13_1_plus;
+    case MacOSVersion::MACOS_VER_13_2_PLUS:
+      return _macos_13_2_plus;
+    case MacOSVersion::MACOS_VER_13_3_PLUS:
+      return _macos_13_3_plus;
+    case MacOSVersion::MACOS_VER_14_0_PLUS:
+      return _macos_14_0_plus;
+    default:
+      return false;
+  }
+}
+
+bool isMacOS13OrNewer(MacOSVersion version) {
+  return MPSDevice::getInstance()->isMacOS13Plus(version);
+}
+
 } // namespace delegate
 } // namespace mps
 } // namespace executor

--- a/backends/apple/mps/runtime/MPSExecutor.h
+++ b/backends/apple/mps/runtime/MPSExecutor.h
@@ -23,39 +23,64 @@ namespace delegate {
 
 class MPSExecutor {
  private:
-  MPSGraphExecutable* executable_;
-  NSArray<MPSGraphShapedType *> * inputShapes_;
-  NSArray<MPSGraphShapedType *> * outputShapes_;
+  MPSGraphExecutable* _executable;
+  NSArray<MPSGraphShapedType *> * _inputShapes;
+  NSArray<MPSGraphShapedType *> * _outputShapes;
 
-  NSMutableArray<MPSGraphTensorData *>* inputsArray_;
-  NSMutableArray<MPSGraphTensorData *>* outputsArray_;
-#if TARGET_OS_SIMULATOR
-  NSMutableArray<id<MTLBuffer>>* output_buffers_;
-#endif
+  NSMutableArray<MPSGraphTensorData *>* _inputsArray;
+  NSMutableArray<MPSGraphTensorData *>* _outputsArray;
 
+  // Flag whatever to use shared memory or not
+  // Shared memory flag will be set as following (based on HW and target config):
+  //   - True: Apple Silicon and macOS15+/iOS17+/iPadOS17+
+  //   - False: Simulator or x86 or pre-macOS15/iOS17/iPadOS17
+  bool _use_shared_mem;
+  bool _buffers_initialized;
+
+  // Input/Output GPU buffer pointer
+  std::vector<id<MTLBuffer>> _inputGPUBuffers;
+  std::vector<id<MTLBuffer>> _outputGPUBuffers;
+
+  // Input/Output CPU buffer pointers
+  std::vector<CPUBufferWrapper> _inputCPUBuffers;
+  std::vector<CPUBufferWrapper> _outputCPUBuffers;
+
+  std::unordered_map<MPSGraphTensor*, int32_t> _mpsGraphTensorToId;
  public:
-  MPSExecutor() = default;
+  MPSExecutor();
   ~MPSExecutor() {
-    [inputsArray_ release];
-    [outputsArray_ release];
+    if (_inputsArray) {
+      [_inputsArray release];
+      _inputsArray = nil;
+    }
+    if (_outputsArray) {
+      [_outputsArray release];
+    }
+
+    _inputsArray = nil;
+    _outputsArray = nil;
   }
 
   inline size_t getNumInputs() {
-    return [inputShapes_ count];
+    return [_inputShapes count];
   }
 
   inline size_t getNumOutputs() {
-    return [outputShapes_ count];
+    return [_outputShapes count];
   }
 
   inline MPSGraphExecutable* getMPSGraphExecutable() {
-    return executable_;
+    return _executable;
   }
 
   __ET_NODISCARD Error forward(std::vector<const Tensor*>& outputs);
 
   __ET_NODISCARD Error
   set_inputs_outputs(std::vector<const Tensor*>& inputs, std::vector<const Tensor*>& outputs);
+
+  Error initDataBuffers();
+  Error updateDataBuffers(std::vector<const Tensor*>& inputs, std::vector<const Tensor*>& outputs);
+  Error syncOutputBuffers(std::vector<const Tensor*>& outputs);
 
   friend class MPSCompiler;
 };

--- a/backends/apple/mps/runtime/MPSExecutor.mm
+++ b/backends/apple/mps/runtime/MPSExecutor.mm
@@ -7,14 +7,13 @@
 #include <executorch/runtime/core/exec_aten/util/tensor_util.h>
 #include <executorch/backends/apple/mps/schema_generated.h>
 #include <executorch/backends/apple/mps/runtime/MPSExecutor.h>
+#import <Foundation/Foundation.h>
+#import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+#import <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
 
-@interface MPSNDArray ()
--(nonnull instancetype) initWithBuffer:(id<MTLBuffer> _Nonnull) buffer
-                            descriptor:(MPSNDArrayDescriptor * _Nonnull) descriptor;
-@end
-
-@interface MPSNDArrayDescriptor ()
-@property (readwrite, nonatomic) BOOL preferPackedRows;
+@interface MPSGraphExecutable()
+-(NSArray<MPSGraphShapedType *> *) getInputShapes;
+-(NSArray<MPSGraphShapedType *> *) getOutputShapes;
 @end
 
 
@@ -23,47 +22,52 @@ namespace executor {
 namespace mps {
 namespace delegate {
 
+MPSExecutor::MPSExecutor() {
+  _use_shared_mem = true;
+  _buffers_initialized = false;
+
+#if TARGET_OS_SIMULATOR or defined(__x86_64__)
+  _use_shared_mem = false;
+#endif
+  if (!isMacOS13OrNewer(MacOSVersion::MACOS_VER_14_0_PLUS)) {
+    _use_shared_mem = false;
+  }
+
+  _inputsArray = [[NSMutableArray<MPSGraphTensorData *> alloc] init];
+  _outputsArray = [[NSMutableArray<MPSGraphTensorData *> alloc] init];
+}
+
 __ET_NODISCARD Error
 MPSExecutor::set_inputs_outputs(std::vector<const Tensor*>& inputs, std::vector<const Tensor*>& outputs) {
   ET_CHECK_OR_RETURN_ERROR(inputs.size() == getNumInputs(), Internal, "Inputs mismatch");
   ET_CHECK_OR_RETURN_ERROR(outputs.size() == getNumOutputs(), Internal, "Outputs mismatch");
 
-#if !TARGET_OS_SIMULATOR
-  if (outputsArray_ != nil) {
-    return Error::Ok;
+  if (_buffers_initialized) {
+    // When using shared memory, there is no need to blit
+    // the contents of the CPU buffer to the GPU
+    // Once a CPU buffer has been wrapped around a GPU buffer,
+    // it can be reused across different multiple inference runs.
+    if (!_use_shared_mem) {
+      updateDataBuffers(inputs, outputs);
+    }
+  } else {
+    updateDataBuffers(inputs, outputs);
+    for (MPSGraphTensor *tensor in [_executable feedTensors]) {
+      int i = _mpsGraphTensorToId[tensor];
+      MPSGraphTensorData* tensorData = [[MPSGraphTensorData alloc]initWithMTLBuffer:_inputGPUBuffers[i]
+                                                                              shape:[_inputShapes[i] shape]
+                                                                           dataType:[_inputShapes[i] dataType]];
+      [_inputsArray addObject:tensorData];
+    }
+
+    for (int i = 0; i < outputs.size(); i++) {
+      MPSGraphTensorData* tensorData = [[MPSGraphTensorData alloc] initWithMTLBuffer:_outputGPUBuffers[i]
+                                                                               shape:[_outputShapes[i] shape]
+                                                                            dataType:[_outputShapes[i] dataType]];
+      [_outputsArray addObject:tensorData];
+    }
+
   }
-#endif
-
-  inputsArray_ = [[NSMutableArray<MPSGraphTensorData *> alloc] init];
-  outputsArray_ = [[NSMutableArray<MPSGraphTensorData *> alloc] init];
-
-#if TARGET_OS_SIMULATOR
-  output_buffers_ = [[NSMutableArray<id<MTLBuffer>> alloc] init];
-#endif
-
-  for (int i = 0; i < inputs.size(); i++) {
-    MPSNDArrayDescriptor *tensorDesc = [MPSNDArrayDescriptor descriptorWithDataType:[inputShapes_[i] dataType]
-                                                                              shape:[inputShapes_[i] shape]];
-    tensorDesc.preferPackedRows = YES;
-    id<MTLBuffer> inputBuffer = getMTLBufferStorage(*inputs[i]);
-    MPSNDArray *ndArrayData = [[MPSNDArray alloc] initWithBuffer:inputBuffer descriptor:tensorDesc];
-    MPSGraphTensorData* tensorData = [[MPSGraphTensorData alloc] initWithMPSNDArray:ndArrayData];
-    [inputsArray_ addObject:tensorData];
-  }
-
-  for (int i = 0; i < outputs.size(); i++) {
-    MPSNDArrayDescriptor *tensorDesc = [MPSNDArrayDescriptor descriptorWithDataType:[outputShapes_[i] dataType]
-                                                                              shape:[outputShapes_[i] shape]];
-    tensorDesc.preferPackedRows = YES;
-    id<MTLBuffer> outputBuffer = getMTLBufferStorage(*outputs[i]);
-    MPSNDArray *ndArrayData = [[MPSNDArray alloc] initWithBuffer:outputBuffer descriptor:tensorDesc];
-    MPSGraphTensorData* tensorData = [[MPSGraphTensorData alloc] initWithMPSNDArray:ndArrayData];
-    [outputsArray_ addObject:tensorData];
-#if TARGET_OS_SIMULATOR
-    [output_buffers_ addObject:[outputBuffer retain]];
-#endif
-  }
-
   return Error::Ok;
 }
 
@@ -72,36 +76,178 @@ __ET_NODISCARD Error MPSExecutor::forward(std::vector<const Tensor*>& outputs) {
   MPSStream* mpsStream = getDefaultMPSStream();
   if (mpsStream->commitAndContinueEnabled() || mpsStream->hasLiveCommandBuffer()) {
     id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
-    [executable_ encodeToCommandBuffer:commandBuffer
-                          inputsArray:inputsArray_
-                          resultsArray:outputsArray_
+    [_executable encodeToCommandBuffer:commandBuffer
+                          inputsArray:_inputsArray
+                          resultsArray:_outputsArray
                   executionDescriptor:nil];
   } else {
-    [executable_ runWithMTLCommandQueue:mpsStream->commandQueue()
-                            inputsArray:inputsArray_
-                           resultsArray:outputsArray_
+    [_executable runWithMTLCommandQueue:mpsStream->commandQueue()
+                            inputsArray:_inputsArray
+                           resultsArray:_outputsArray
                     executionDescriptor:nil];
   }
+  syncOutputBuffers(outputs);
 
+  // On simulator, the buffers are synchronized during `syncOutputBuffer`
+#if !TARGET_OS_SIMULATOR
   if (mpsStream->commitAndContinueEnabled()) {
     err = mpsStream->synchronize(SyncType::COMMIT_AND_CONTINUE);
   } else {
     err = mpsStream->synchronize(SyncType::COMMIT_AND_WAIT);
-#if TARGET_OS_SIMULATOR
-  for (int i = 0; i < outputs.size(); i++) {
-    uint8_t* data = outputs[i]->mutable_data_ptr<uint8_t>();
-    memcpy(data, [output_buffers_[i] contents], [output_buffers_[i] length]);
-  }
-#endif
   }
 
   ET_CHECK_OR_RETURN_ERROR(
     err == Error::Ok,
     Internal,
     "Could not synchronize on the MPSStream");
+#endif
 
   return Error::Ok;
 }
+
+Error
+MPSExecutor::initDataBuffers() {
+  Error error = Error::Ok;
+
+  _inputShapes = [[_executable getInputShapes] retain];
+  _outputShapes = [[_executable getOutputShapes] retain];
+
+  int nInputs = getNumInputs();
+  int nOutputs = getNumOutputs();
+
+  _inputGPUBuffers.resize(nInputs);
+  _outputGPUBuffers.resize(nOutputs);
+
+  if (!_use_shared_mem) {
+    _inputCPUBuffers.resize(nInputs);
+    _outputCPUBuffers.resize(nOutputs);
+  }
+
+  // In case of shared memory, the CPU raw buffer is used directly as an MTLBuffer.
+  // In case of not being able to use shared memory, initialize the data buffers once
+  // and keep reusing them across inference runs.
+  auto getDataBuffer = [] (MPSShape* shape, MPSDataType mpsDataType) {
+    __block int64_t length = 1;
+    [shape enumerateObjectsUsingBlock:^(NSNumber * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        length *= obj.intValue;
+    }];
+    // Get total size in bytes.
+    length *= ((mpsDataType & 0xFFFF) >> 3);
+    MTLResourceOptions options = MTLResourceCPUCacheModeDefaultCache | MTLResourceStorageModeShared;
+    return [MPSDevice::getInstance()->device() newBufferWithLength:length
+                                                            options:options];
+
+  };
+
+  // Preallocate at init time the GPU buffers used to run
+  // the model in case shared memory is not being used.
+  if (!_use_shared_mem) {
+    for (int i = 0; i < nInputs; i++) {
+      _inputGPUBuffers[i] = getDataBuffer([_inputShapes[i] shape], [_inputShapes[i] dataType]);
+    }
+    for (int i = 0; i < nOutputs; i++) {
+      _outputGPUBuffers[i] = getDataBuffer([_outputShapes[i] shape], [_outputShapes[i] dataType]);
+    }
+  }
+
+  return error;
+}
+
+Error
+MPSExecutor::updateDataBuffers(
+  std::vector<const Tensor*>& inputs, std::vector<const Tensor*>& outputs
+) {
+  if (!_buffers_initialized) {
+    for (int i = 0; i < inputs.size(); i++) {
+      const Tensor& tensor = *inputs[i];
+      void* host_src = tensor.mutable_data_ptr<void*>();
+      if (_use_shared_mem) {
+        // Use directly the CPU buffer when using shared memory.
+        _inputGPUBuffers[i] = getMTLBufferStorage(tensor);
+      } else {
+        _inputCPUBuffers[i].flags = 0;
+#if TARGET_OS_SIMULATOR
+        // Simulator crashes when using newBufferWithBytesNoCopy.
+        // Use memcpy directly instead of using blit to copy the CPU
+        // data into the GPU buffer.
+        _inputCPUBuffers[i].srcOffset = 0;
+        _inputCPUBuffers[i].srcBuffer = host_src;
+        _inputCPUBuffers[i].srcCpu = 1;
+#else
+        MTLResourceOptions options = MTLResourceCPUCacheModeDefaultCache | MTLResourceStorageModeShared;
+        NSUInteger alignedLength = 0;
+        void* alignedPtr = pageAlignedBlockPtr(host_src, (NSUInteger)tensor.nbytes(), &alignedLength);
+        _inputCPUBuffers[i].srcOffset = uintptr_t(host_src) - uintptr_t(alignedPtr);
+        _inputCPUBuffers[i].srcBuffer = [MPSDevice::getInstance()->device() newBufferWithBytesNoCopy:alignedPtr
+                                                          length:alignedLength
+                                                        options:options
+                                                    deallocator:nil];
+
+#endif
+        _inputCPUBuffers[i].dstBuffer = _inputGPUBuffers[i];
+        _inputCPUBuffers[i].dstOffset = 0;
+        _inputCPUBuffers[i].length = tensor.nbytes();
+      }
+    }
+
+    if (_use_shared_mem) {
+      for (int i = 0; i < outputs.size(); i++) {
+        _outputGPUBuffers[i] = getMTLBufferStorage(*outputs[i]);
+      }
+    }
+  }
+
+  if (!_use_shared_mem) {
+    MPSStream* mpsStream = getDefaultMPSStream();
+      mpsStream->copy_and_sync(
+        _inputCPUBuffers, /*non_blocking=*/true);
+  }
+
+  return Error::Ok;
+}
+
+Error
+MPSExecutor::syncOutputBuffers(
+  std::vector<const Tensor*>& outputs) {
+  if (!_use_shared_mem)  {
+    MTLResourceOptions options = MTLResourceCPUCacheModeDefaultCache | MTLResourceStorageModeShared;
+    NSUInteger alignedLength = 0;
+    MPSStream* mpsStream = getDefaultMPSStream();
+
+  if (!_buffers_initialized) {
+      for (int i = 0; i < outputs.size(); i++) {
+        const Tensor& tensor = *outputs[i];
+        void* host_dst = tensor.mutable_data_ptr<void*>();
+        _outputCPUBuffers[i].flags = 0;
+#if TARGET_OS_SIMULATOR
+        _outputCPUBuffers[i].dstOffset = 0;
+        _outputCPUBuffers[i].dstBuffer = host_dst;
+        _outputCPUBuffers[i].dstCpu = 1;
+#else
+        void* alignedPtr = pageAlignedBlockPtr(host_dst, (NSUInteger)tensor.nbytes(), &alignedLength);
+        _outputCPUBuffers[i].dstOffset = (uintptr_t(host_dst) - uintptr_t(alignedPtr));
+        // 4 bytes alignment required on MacOS for blits.
+        ET_CHECK_MSG(_outputCPUBuffers[i].dstOffset % 4 == 0, "Unaligned blit request");
+        _outputCPUBuffers[i].dstBuffer = [MPSDevice::getInstance()->device() newBufferWithBytesNoCopy:alignedPtr
+                                                              length:alignedLength
+                                                            options:options
+                                                        deallocator:nil];
+#endif
+        _outputCPUBuffers[i].srcBuffer = _outputGPUBuffers[i];
+        _outputCPUBuffers[i].srcOffset = 0;
+        _outputCPUBuffers[i].length = tensor.nbytes();
+      }
+    }
+
+    mpsStream->copy_and_sync(
+      _outputCPUBuffers, /*non_blocking=*/true
+    );
+  }
+
+  _buffers_initialized = true;
+  return Error::Ok;
+}
+
 
 } // namespace delegate
 } // namespace mps

--- a/backends/apple/mps/runtime/MPSGraphBuilder.h
+++ b/backends/apple/mps/runtime/MPSGraphBuilder.h
@@ -38,7 +38,7 @@ using NodePtr = const mpsgraph::MPSNode *;
  */
 class MPSGraphBuilder {
 public:
-  MPSGraphBuilder(const void *buffer_pointer);
+  MPSGraphBuilder(const void *buffer_pointer, std::unordered_map<MPSGraphTensor *, int32_t> &mpsGraphTensorToId);
   ~MPSGraphBuilder() = default;
 
   Error compileModel();
@@ -164,6 +164,7 @@ private:
   // produced, which will be stored in this structure. Other ops
   // can reference the saved tensor by the AOT id (1:1 mapping).
   std::vector<MPSGraphTensor *> _idToMPSGraphTensor;
+  std::unordered_map<MPSGraphTensor *, int32_t> &_mpsGraphTensorToId;
   // FlatBuffer serialized graph containing the nodes from the original model.
   const mpsgraph::MPSGraph *_flatBufferGraph;
   // FlatBuffer raw bytes of the serialized MPS model.

--- a/backends/apple/mps/runtime/operations/ConvolutionOps.mm
+++ b/backends/apple/mps/runtime/operations/ConvolutionOps.mm
@@ -108,10 +108,7 @@ MPSGraphBuilder::mpsConv2DOp(NodePtr nodePtr) {
                                                  dataLayout:MPSGraphTensorNamedDataLayoutNCHW
                                               weightsLayout:MPSGraphTensorNamedDataLayoutHWIO];
     // Convert weights from OIHW to HWIO.
-    MPSGraphTensor* weightTransposeTensor = [_mpsGraph transposeTensor:weightTensor
-                                                           permutation:@[@2, @3, @1, @0]
-                                                                 name:nil];
-
+    MPSGraphTensor* weightTransposeTensor = permuteTensor(_mpsGraph, weightTensor, @[@2, @3, @1, @0]);
     MPSGraphTensor* conv2DTensor = [_mpsGraph convolution2DWithSourceTensor:inputTensor
                                                              weightsTensor:weightTransposeTensor
                                                                 descriptor:desc

--- a/backends/apple/mps/runtime/operations/OperationUtils.h
+++ b/backends/apple/mps/runtime/operations/OperationUtils.h
@@ -33,20 +33,10 @@ template <typename T = size_t> std::vector<T> flatbufferDimsToVector(const flatb
   return dimsData;
 }
 
-static inline id<MTLBuffer> getMTLBufferStorage(const Tensor &tensor) {
-#if TARGET_OS_SIMULATOR
-  // Simulator crashes in newBufferWithBytesNoCopy, so we're making a copy of
-  // the data.
-  uint8_t *data = tensor.mutable_data_ptr<uint8_t>();
-  return [MPSDevice::getInstance()->device() newBufferWithBytes:data length:tensor.nbytes() options:0];
-#else
-  uint8_t *data = tensor.mutable_data_ptr<uint8_t>();
-  return [MPSDevice::getInstance()->device() newBufferWithBytesNoCopy:data
-                                                               length:tensor.nbytes()
-                                                              options:0
-                                                          deallocator:nil];
-#endif // TARGET_OS_SIMULATOR
-}
+id<MTLBuffer> getMTLBufferStorage(const Tensor &tensor);
+void *pageAlignedBlockPtr(const void *ptr, NSUInteger size, NSUInteger *alignedBlockSize);
+
+MPSGraphTensor *permuteTensor(MPSGraph *graph, MPSGraphTensor *inputTensor, NSArray *permuteOrder);
 
 } // namespace delegate
 } // namespace mps

--- a/backends/apple/mps/runtime/operations/OperationUtils.mm
+++ b/backends/apple/mps/runtime/operations/OperationUtils.mm
@@ -5,6 +5,11 @@
 //
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
+#include <numeric>
+
+#ifndef PAGE_SIZE
+#define PAGE_SIZE 4096
+#endif
 
 namespace torch {
 namespace executor {
@@ -276,6 +281,58 @@ std::vector<int64_t> getMPSShapeVec(const MPSShape* shape) {
   }];
   return shapeVec;
 }
+
+id<MTLBuffer> getMTLBufferStorage(const Tensor &tensor) {
+  uint8_t *data = tensor.mutable_data_ptr<uint8_t>();
+  return [MPSDevice::getInstance()->device() newBufferWithBytesNoCopy:data
+                                                               length:tensor.nbytes()
+                                                              options:0
+                                                          deallocator:nil];
+}
+
+void* pageAlignedBlockPtr(const void* ptr, NSUInteger size, NSUInteger* alignedBlockSize) {
+  uintptr_t address = (uintptr_t)ptr;
+  uintptr_t alignedAddress = address & ~(PAGE_SIZE - 1);
+  uintptr_t alignedEnd = ((address + size) + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1);
+  uint64_t alignedLength = alignedEnd - alignedAddress;
+
+  assert(address >= alignedAddress);
+  assert(address + size <= alignedAddress + alignedLength);
+
+  *alignedBlockSize = alignedLength;
+  return (void*)alignedAddress;
+}
+
+
+MPSGraphTensor* permuteTensor(MPSGraph* graph, MPSGraphTensor* inputTensor, NSArray* permuteOrder) {
+  if (isMacOS13OrNewer()) {
+   return [graph transposeTensor:inputTensor
+                     permutation:permuteOrder
+                            name:nil];
+  } else {
+    NSUInteger srcRank = [[inputTensor shape] count];
+    if (srcRank != [permuteOrder count]) {
+      return nil;
+    }
+
+    MPSGraphTensor* outputTensor = inputTensor;
+    std::vector<NSUInteger> dimensionOrder(srcRank);
+    std::iota(std::begin(dimensionOrder), std::end(dimensionOrder), 0);
+
+    for (int32_t i = 0; i < srcRank; i++) {
+      NSUInteger axis = [permuteOrder[i] integerValue];
+      auto axisIter = std::find(dimensionOrder.begin(), dimensionOrder.end(), axis);
+      NSUInteger axis1 = i;
+      NSUInteger axis2 = axisIter - dimensionOrder.begin();
+      iter_swap(dimensionOrder.begin() + i, axisIter);
+
+      outputTensor = [graph transposeTensor:outputTensor dimension:axis1 withDimension:axis2 name:nil];
+    }
+
+    return outputTensor;
+  }
+}
+
 
 } // namespace delegate
 } // namespace mps

--- a/backends/apple/mps/runtime/operations/ShapeOps.mm
+++ b/backends/apple/mps/runtime/operations/ShapeOps.mm
@@ -26,9 +26,10 @@ MPSGraphBuilder::mpsPermuteOp(NodePtr nodePtr) {
   for(int64_t i = 0; i < graphNode->num_dims(); i++) {
     [permutation addObject:[NSNumber numberWithInteger:graphNode->perm()->Get(i)]];
   }
-  _idToMPSGraphTensor[graphNode->output_id()] = [_mpsGraph transposeTensor:getMPSGraphTensor(graphNode->input1_id())
-                                                               permutation:permutation
-                                                                      name:@"permutation"];
+  MPSGraphTensor* outputTensor = permuteTensor(
+    _mpsGraph, getMPSGraphTensor(graphNode->input1_id()), permutation
+  );
+  _idToMPSGraphTensor[graphNode->output_id()] = outputTensor;
 
   return Error::Ok;
 }


### PR DESCRIPTION
Fix buffer alignment for iOS15/16, macOS12/13

Summary of changes:
- Fix `newBufferWithBytesNoCopy` alignment requirements from iOS15/16 and macOS12/13
- Preallocate a list of buffers to use during consecutive inference runs
- Fix missing selectors on older OS versions