### PR TITLE
Pin all TOSA components to v0.80

### DIFF
--- a/backends/arm/test/arm_tosa_reference.py
+++ b/backends/arm/test/arm_tosa_reference.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Arm Limited and/or its affiliates.
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -14,11 +14,12 @@ import numpy as np
 from executorch.backends.arm.arm_partitioner import ArmPartitioner
 from executorch.backends.arm.test.test_models import TestList, TosaProfile
 from executorch.backends.arm.test.test_tosa import prepare_model_and_ref
-
 from executorch.exir.backend.compile_spec_schema import CompileSpec
-from executorch.exir.capture._config import ExecutorchBackendConfig, to_edge
+from executorch.exir.capture._config import ExecutorchBackendConfig
 
 from executorch.exir.dialects._ops import ops as exir_ops
+
+from executorch.exir.program import to_edge
 
 from torch.export import export
 

--- a/examples/arm/ethos-u-setup/ethos-u-vela/patches/0002-Use-TOSA-0.80.1_new-12f0e94aca6c17d0c6dc9b463277ab38.patch
+++ b/examples/arm/ethos-u-setup/ethos-u-vela/patches/0002-Use-TOSA-0.80.1_new-12f0e94aca6c17d0c6dc9b463277ab38.patch
@@ -1,0 +1,26 @@
+From 394636ef2063e386f54abde094298bb0e40a2cb7 Mon Sep 17 00:00:00 2001
+From: Zingo Andersen <zingo.andersen@arm.com>
+Date: Sat, 20 Jan 2024 10:34:45 +0100
+Subject: [PATCH 2/2] Use TOSA 0.80.1
+
+Signed-off-by: Zingo Andersen <zingo.andersen@arm.com>
+---
+ ethosu/vela/tosa_reader.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ethosu/vela/tosa_reader.py b/ethosu/vela/tosa_reader.py
+index 56af59d..7cb2bf3 100644
+--- a/ethosu/vela/tosa_reader.py
++++ b/ethosu/vela/tosa_reader.py
+@@ -294,7 +294,7 @@ class TosaGraph:
+     def check_version(self, tosa_graph):
+         version = tosa_graph.Version()
+         version_str = f"{version._Major()}.{version._Minor()}.{version._Patch()}"
+-        if version_str != "0.80.0":
++        if version_str != "0.80.1":
+             print(f"Unsupported TOSA version: {version_str}")
+             assert False
+ 
+-- 
+2.25.1
+

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -167,7 +167,7 @@ function setup_tosa_reference_model() {
     # errors for the early codebase
     cd "${root_dir}"
     if [[ ! -e reference_model ]]; then
-        git clone https://review.mlplatform.org/tosa/reference_model -b main
+        git clone https://review.mlplatform.org/tosa/reference_model v0.80
         cd reference_model
         git submodule update --init --recursive
         cd ..


### PR DESCRIPTION
- Pin TOSA serialization_lib to `branch` v0.80
- Pin TOSA reference_model to `branch` v0.80
- Fix any affected changes

I accidentally changed the serialization_lib hash in this patch: https://github.com/pytorch/executorch/commit/99f912ac8475bbe9546b133ac26b06ed7a352757#diff-099ad350604656a18b4146f6f297241b6d294a0650882968029fb1f574267f0d

Pin all TOSA components to `branch` v0.80. Hope we can have a stable development setup for a certain period of time. 

Previously, serialization_lib was pinned to a `tag`, reference_model was pinned to a `branch`. There can be a debate about whether to use tag or branch but at least I think we should make them consistent. 

Serialization_lib: https://review.mlplatform.org/plugins/gitiles/tosa/serialization_lib/
Reference_model: https://review.mlplatform.org/plugins/gitiles/tosa/reference_model/