### PR TITLE
[ET][Util] Add convenience switch macros

### DIFF
--- a/kernels/portable/cpu/op_add.cpp
+++ b/kernels/portable/cpu/op_add.cpp
@@ -39,31 +39,27 @@ Tensor& add_out(
   ET_KERNEL_CHECK(
       ctx, check_alpha_type(alpha_type, common_type), InvalidArgument, out);
 
-  ET_SWITCH_REAL_TYPES_AND2(Bool, Half, a_type, ctx, "add.out", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND2(
-        Bool, Half, b_type, ctx, "add.out", CTYPE_B, [&]() {
-          ET_SWITCH_REAL_TYPES_AND(
-              Bool, common_type, ctx, "add.out", CTYPE_IN, [&]() {
-                ET_SWITCH_REAL_TYPES_AND2(
-                    Bool, Half, out_type, ctx, "add.out", CTYPE_OUT, [&]() {
-                      CTYPE_IN alpha_val;
-                      utils::extract_scalar(alpha, &alpha_val);
+  ET_SWITCH_REALHB_TYPES(a_type, ctx, "add.out", CTYPE_A, [&]() {
+    ET_SWITCH_REALHB_TYPES(b_type, ctx, "add.out", CTYPE_B, [&]() {
+      ET_SWITCH_REALB_TYPES(common_type, ctx, "add.out", CTYPE_IN, [&]() {
+        ET_SWITCH_REALHB_TYPES(out_type, ctx, "add.out", CTYPE_OUT, [&]() {
+          CTYPE_IN alpha_val;
+          utils::extract_scalar(alpha, &alpha_val);
 
-                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                          [alpha_val](
-                              const CTYPE_A val_a, const CTYPE_B val_b) {
-                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                            CTYPE_IN value = a_casted + alpha_val * b_casted;
+          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
+              [alpha_val](const CTYPE_A val_a, const CTYPE_B val_b) {
+                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                CTYPE_IN value = a_casted + alpha_val * b_casted;
 
-                            return static_cast<CTYPE_OUT>(value);
-                          },
-                          a,
-                          b,
-                          out);
-                    });
-              });
+                return static_cast<CTYPE_OUT>(value);
+              },
+              a,
+              b,
+              out);
         });
+      });
+    });
   });
 
   return out;

--- a/runtime/core/exec_aten/util/scalar_type_util.h
+++ b/runtime/core/exec_aten/util/scalar_type_util.h
@@ -813,6 +813,16 @@ inline exec_aten::ScalarType promoteTypes(
       ET_INTERNAL_SWITCH_CASE_REAL_TYPES_AND2(                       \
           ADDITIONAL1, ADDITIONAL2, CTYPE_ALIAS, __VA_ARGS__))
 
+#define ET_SWITCH_REALH_TYPES(TYPE, CONTEXT, NAME, CTYPE_ALIAS, ...) \
+  ET_SWITCH_REAL_TYPES_AND(Half, TYPE, CONTEXT, NAME, CTYPE_ALIAS, __VA_ARGS__)
+
+#define ET_SWITCH_REALB_TYPES(TYPE, CONTEXT, NAME, CTYPE_ALIAS, ...) \
+  ET_SWITCH_REAL_TYPES_AND(Bool, TYPE, CONTEXT, NAME, CTYPE_ALIAS, __VA_ARGS__)
+
+#define ET_SWITCH_REALHB_TYPES(TYPE, CONTEXT, NAME, CTYPE_ALIAS, ...) \
+  ET_SWITCH_REAL_TYPES_AND2(                                          \
+      Half, Bool, TYPE, CONTEXT, NAME, CTYPE_ALIAS, __VA_ARGS__)
+
 #define ET_SWITCH_INT_TYPES(TYPE, CONTEXT, NAME, CTYPE_ALIAS, ...) \
   ET_INTERNAL_SWITCH(                                              \
       TYPE,                                                        \
@@ -844,6 +854,9 @@ inline exec_aten::ScalarType promoteTypes(
       NAME,                                            \
       ET_INTERNAL_SWITCH_CASE_FLOAT_TYPES_AND(         \
           ADDITIONAL, CTYPE_ALIAS, __VA_ARGS__))
+
+#define ET_SWITCH_FLOATH_TYPES(TYPE, CONTEXT, NAME, CTYPE_ALIAS, ...) \
+  ET_SWITCH_FLOAT_TYPES_AND(Half, TYPE, CONTEXT, NAME, CTYPE_ALIAS, __VA_ARGS__)
 
 #define ET_SWITCH_QINT_TYPES(TYPE, CONTEXT, NAME, CTYPE_ALIAS, ...) \
   ET_INTERNAL_SWITCH(                                               \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1709
* #1708
* #1707
* #1705
* #1704
* #1703
* __->__ #1702

Added convenience switch macros for:
- FLOATH = Float + Half
- REALH = Real + Half
- REALB = Real + Bool
- REALHB = Real + Half + Bool

Updated add op in order to test macros

Differential Revision: [D53061770](https://our.internmc.facebook.com/intern/diff/D53061770/)