### PR TITLE
[ET][Portable] Half support: add.Scalar

### DIFF
--- a/kernels/optimized/cpu/op_add.cpp
+++ b/kernels/optimized/cpu/op_add.cpp
@@ -98,7 +98,8 @@ Tensor& opt_add_scalar_out(
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
-  ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
+  ScalarType common_type =
+      utils::promote_type_with_scalar(a_type, b, /*half_to_float*/ true);
   ScalarType out_type = out.scalar_type();
 
   ET_CHECK(common_type == out_type);
@@ -107,59 +108,51 @@ Tensor& opt_add_scalar_out(
   auto error = resize_tensor(out, a.sizes());
   ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
 
-  if (a_type == common_type && a_type == out_type) {
-    ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "add.Scalar_out", CTYPE, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(
-          Bool, b_type, ctx, "add.Scalar_out", CTYPE_B, [&]() {
-            CTYPE_B b_val;
-            ET_EXTRACT_SCALAR(b, b_val);
-            CTYPE b_casted = static_cast<CTYPE>(b_val);
-            CTYPE alpha_val;
-            ET_EXTRACT_SCALAR(alpha, alpha_val);
+  if (a_type == common_type && a_type == out_type &&
+      a_type != ScalarType::Half) {
+    ET_SWITCH_REALB_TYPES(a_type, ctx, "add.Scalar_out", CTYPE, [&]() {
+      ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "add.Scalar_out", CTYPE_B, [&]() {
+        CTYPE_B b_val;
+        ET_EXTRACT_SCALAR(b, b_val);
+        CTYPE b_casted = static_cast<CTYPE>(b_val);
+        CTYPE alpha_val;
+        ET_EXTRACT_SCALAR(alpha, alpha_val);
 
-            using Vec = executorch::vec::Vectorized<CTYPE>;
-            executorch::vec::map<CTYPE>(
-                [alpha_val, b_casted](Vec x) {
-                  return x + Vec(alpha_val * b_casted);
-                },
-                out.mutable_data_ptr<CTYPE>(),
-                a.const_data_ptr<CTYPE>(),
-                out.numel());
-          });
+        using Vec = executorch::vec::Vectorized<CTYPE>;
+        executorch::vec::map<CTYPE>(
+            [alpha_val, b_casted](Vec x) {
+              return x + Vec(alpha_val * b_casted);
+            },
+            out.mutable_data_ptr<CTYPE>(),
+            a.const_data_ptr<CTYPE>(),
+            out.numel());
+      });
     });
   } else {
-    ET_SWITCH_REAL_TYPES_AND(
-        Bool, a_type, ctx, "add.Scalar_out", CTYPE_A, [&]() {
-          ET_SWITCH_REAL_TYPES_AND(
-              Bool, b_type, ctx, "add.Scalar_out", CTYPE_B, [&]() {
-                ET_SWITCH_REAL_TYPES_AND(
-                    Bool, common_type, ctx, "add.Scalar_out", CTYPE_IN, [&]() {
-                      ET_SWITCH_REAL_TYPES_AND(
-                          Bool,
-                          out_type,
-                          ctx,
-                          "add.Scalar_out",
-                          CTYPE_OUT,
-                          [&]() {
-                            CTYPE_B b_val;
-                            ET_EXTRACT_SCALAR(b, b_val);
-                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
-                            CTYPE_IN alpha_val;
-                            ET_EXTRACT_SCALAR(alpha, alpha_val);
+    ET_SWITCH_REALHB_TYPES(a_type, ctx, "add.Scalar_out", CTYPE_A, [&]() {
+      ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "add.Scalar_out", CTYPE_B, [&]() {
+        ET_SWITCH_REALB_TYPES(
+            common_type, ctx, "add.Scalar_out", CTYPE_IN, [&]() {
+              ET_SWITCH_REALHB_TYPES(
+                  out_type, ctx, "add.Scalar_out", CTYPE_OUT, [&]() {
+                    CTYPE_B b_val;
+                    ET_EXTRACT_SCALAR(b, b_val);
+                    CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);
+                    CTYPE_IN alpha_val;
+                    ET_EXTRACT_SCALAR(alpha, alpha_val);
 
-                            const size_t n = a.numel();
-                            const CTYPE_A* a_data = a.const_data_ptr<CTYPE_A>();
-                            CTYPE_OUT* out_data =
-                                out.mutable_data_ptr<CTYPE_OUT>();
-                            for (auto i = 0; i < n; ++i) {
-                              out_data[i] = static_cast<CTYPE_OUT>(
-                                  static_cast<CTYPE_IN>(a_data[i]) +
-                                  alpha_val * b_casted);
-                            }
-                          });
-                    });
-              });
-        });
+                    const size_t n = a.numel();
+                    const CTYPE_A* a_data = a.const_data_ptr<CTYPE_A>();
+                    CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
+                    for (auto i = 0; i < n; ++i) {
+                      out_data[i] = static_cast<CTYPE_OUT>(
+                          static_cast<CTYPE_IN>(a_data[i]) +
+                          alpha_val * b_casted);
+                    }
+                  });
+            });
+      });
+    });
   }
 
   return out;

--- a/kernels/portable/cpu/op_add.cpp
+++ b/kernels/portable/cpu/op_add.cpp
@@ -84,18 +84,19 @@ Tensor& add_scalar_out(
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType alpha_type = utils::get_scalar_dtype(alpha);
-  ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
+  ScalarType common_type =
+      utils::promote_type_with_scalar(a_type, b, /*half_to_float*/ true);
   ScalarType out_type = out.scalar_type();
 
   ET_KERNEL_CHECK(ctx, common_type == out_type, InvalidArgument, out);
   ET_KERNEL_CHECK(ctx, canCast(alpha_type, common_type), InvalidArgument, out);
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "add.Scalar_out", CTYPE_A, [&]() {
+  ET_SWITCH_REALHB_TYPES(a_type, ctx, "add.Scalar_out", CTYPE_A, [&]() {
     ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, "add.Scalar_out", CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(
-          Bool, common_type, ctx, "add.Scalar_out", CTYPE_IN, [&]() {
-            ET_SWITCH_REAL_TYPES_AND(
-                Bool, out_type, ctx, "add.Scalar_out", CTYPE_OUT, [&]() {
+      ET_SWITCH_REALB_TYPES(
+          common_type, ctx, "add.Scalar_out", CTYPE_IN, [&]() {
+            ET_SWITCH_REALHB_TYPES(
+                out_type, ctx, "add.Scalar_out", CTYPE_OUT, [&]() {
                   CTYPE_B b_val;
                   utils::extract_scalar(b, &b_val);
                   CTYPE_IN b_casted = static_cast<CTYPE_IN>(b_val);

--- a/kernels/portable/cpu/scalar_utils.h
+++ b/kernels/portable/cpu/scalar_utils.h
@@ -89,7 +89,14 @@ inline bool scalars_have_same_dtype(Scalar a, Scalar b) {
  *
  * If t is a complex type, then it will be preserved.
  */
-inline ScalarType promote_type_with_scalar(ScalarType t, Scalar scalar) {
+inline ScalarType promote_type_with_scalar(
+    ScalarType t,
+    Scalar scalar,
+    bool half_to_float = false) {
+  if (half_to_float && t == ScalarType::Half) {
+    t = ScalarType::Float;
+  }
+
   // QInt, and Bits types not supported
   ET_CHECK(!isQIntType(t));
   ET_CHECK(!isBitsType(t));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1709
* #1708
* #1707
* #1705
* #1704
* __->__ #1703
* #1702

Add half_to_float flag to promote_type_with_scalar
Update add.Scalar (Portable & Optimized) to support ScalarType::Half

Differential Revision: [D53062845](https://our.internmc.facebook.com/intern/diff/D53062845/)