### PR TITLE
fix the mps graph builder

### DIFF
--- a/backends/apple/mps/runtime/MPSGraphBuilder.mm
+++ b/backends/apple/mps/runtime/MPSGraphBuilder.mm
@@ -11,7 +11,7 @@ namespace executor {
 namespace mps {
 namespace delegate {
 
-MPSGraphBuilder::MPSGraphBuilder(const void* buffer_pointer, std::unordered_map<MPSGraphTensor*, int32_t>& mpsGraphTensorToId) : _buffer_pointer(buffer_pointer), _mpsGraphTensorToId(mpsGraphTensorToId) {
+MPSGraphBuilder::MPSGraphBuilder(const void* buffer_pointer, std::unordered_map<MPSGraphTensor*, int32_t>& mpsGraphTensorToId) : _mpsGraphTensorToId(mpsGraphTensorToId), _buffer_pointer(buffer_pointer) {
   _mpsGraph = [MPSGraph new];
   _feeds = [NSMutableDictionary dictionary];
   _targetTensors = [NSMutableArray new];


### PR DESCRIPTION
Summary:
Fix the error

```
Step [Build] failed with xplat/executorch/backends/apple/mps/runtime/MPSGraphBuilder.mm:14:130: error: field '_buffer_pointer' will be initialized after field '_mpsGraphTensorToId' [-Werror,-Wreorder-ctor]
[CONTEXT] MPSGraphBuilder::MPSGraphBuilder(const void* buffer_pointer, std
Step [Failed pytorchbenchmark-device-iphoneos-profile-buck2] failed with Failed
```

Differential Revision: D53099087


