### PR TITLE
[ET][Portable] Half support: unary ops with realhb to floath pattern (18 ops)

### DIFF
--- a/kernels/portable/cpu/op_acos.cpp
+++ b/kernels/portable/cpu/op_acos.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& acos_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::acos, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::acos, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_acosh.cpp
+++ b/kernels/portable/cpu/op_acosh.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& acosh_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::acosh, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::acosh, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_asin.cpp
+++ b/kernels/portable/cpu/op_asin.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& asin_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::asin, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::asin, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_asinh.cpp
+++ b/kernels/portable/cpu/op_asinh.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& asinh_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::asinh, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::asinh, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_atan.cpp
+++ b/kernels/portable/cpu/op_atan.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& atan_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::atan, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::atan, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_atanh.cpp
+++ b/kernels/portable/cpu/op_atanh.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& atanh_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::atanh, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::atanh, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_cos.cpp
+++ b/kernels/portable/cpu/op_cos.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& cos_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::cos, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::cos, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_cosh.cpp
+++ b/kernels/portable/cpu/op_cosh.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& cosh_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::cosh, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::cosh, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_erf.cpp
+++ b/kernels/portable/cpu/op_erf.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& erf_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::erf, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::erf, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_exp.cpp
+++ b/kernels/portable/cpu/op_exp.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& exp_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::exp, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::exp, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_log.cpp
+++ b/kernels/portable/cpu/op_log.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& log_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::log, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::log, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_reciprocal.cpp
+++ b/kernels/portable/cpu/op_reciprocal.cpp
@@ -21,7 +21,7 @@ double reciprocal(double x) {
 } // namespace
 
 Tensor& reciprocal_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(reciprocal, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(reciprocal, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_rsqrt.cpp
+++ b/kernels/portable/cpu/op_rsqrt.cpp
@@ -21,7 +21,7 @@ double rsqrt(double x) {
 } // namespace
 
 Tensor& rsqrt_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(rsqrt, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(rsqrt, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_sin.cpp
+++ b/kernels/portable/cpu/op_sin.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& sin_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::sin, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::sin, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_sinh.cpp
+++ b/kernels/portable/cpu/op_sinh.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& sinh_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::sinh, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::sinh, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_sqrt.cpp
+++ b/kernels/portable/cpu/op_sqrt.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& sqrt_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::sqrt, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::sqrt, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_tan.cpp
+++ b/kernels/portable/cpu/op_tan.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& tan_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::tan, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::tan, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_tanh.cpp
+++ b/kernels/portable/cpu/op_tanh.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& tanh_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_float(std::tanh, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_floath(std::tanh, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/pattern/pattern.h
+++ b/kernels/portable/cpu/pattern/pattern.h
@@ -23,9 +23,12 @@ We currently support the following sets of dtypes:
  - int    {Byte, Char, Short, Int, Long}
  - intb   {Byte, Char, Short, Int, Long, Bool}
  - float  {Float, Double}
+ - floath {Half, Float, Double}
  - floatb {Float, Double, Bool}
  - real   {Byte, Char, Short, Int, Long, Float, Double}
  - realb  {Byte, Char, Short, Int, Long, Float, Double, Bool}
+ - realh  {Byte, Char, Short, Int, Long, Half, Float, Double}
+ - realhb {Byte, Char, Short, Int, Long, Half, Float, Double, Bool}
 
 Input types are separated from output types by the "to" word.
 Input types are separated by underscores. Output types as well, in the cases
@@ -77,11 +80,11 @@ Tensor& unary_ufunc_realb_to_bool(
 
 /**
  * Implements an op pattern for ops that take a single input tensor of any
- * realb dtye (real and boolean), no additional arguments, and outputs a
+ * realhb dtye (real, half and boolean), no additional arguments, and outputs a
  * floating point tensor of the same size. The function fn specifies the math
  * operation which is applied to the input tensor element-wise.
  */
-Tensor& unary_ufunc_realb_to_float(
+Tensor& unary_ufunc_realhb_to_floath(
     FunctionRef<double(double)> fn,
     RuntimeContext& ctx,
     const Tensor& in,

--- a/kernels/portable/cpu/pattern/targets.bzl
+++ b/kernels/portable/cpu/pattern/targets.bzl
@@ -10,9 +10,9 @@ def define_common_targets():
     runtime.cxx_library(
         name = "pattern",
         srcs = [
+            "unary_ufunc_realhb_to_floath.cpp",
             "binary_ufunc_realb_realb_to_realb_logical.cpp",
             "unary_ufunc_realb_to_bool.cpp",
-            "unary_ufunc_realb_to_float.cpp",
             "unary_ufunc_real.cpp",
         ],
         exported_headers = [

--- a/kernels/portable/cpu/pattern/unary_ufunc_realhb_to_floath.cpp
+++ b/kernels/portable/cpu/pattern/unary_ufunc_realhb_to_floath.cpp
@@ -16,7 +16,7 @@ namespace executor {
 namespace native {
 namespace internal {
 
-Tensor& unary_ufunc_realb_to_float(
+Tensor& unary_ufunc_realhb_to_floath(
     FunctionRef<double(double)> fn,
     RuntimeContext& ctx,
     const Tensor& in,
@@ -34,8 +34,8 @@ Tensor& unary_ufunc_realb_to_float(
   const auto in_type = in.scalar_type();
   const auto out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE_IN, [&] {
-    ET_SWITCH_FLOAT_TYPES(out_type, ctx, __func__, CTYPE_OUT, [&] {
+  ET_SWITCH_REALHB_TYPES(in_type, ctx, __func__, CTYPE_IN, [&] {
+    ET_SWITCH_FLOATH_TYPES(out_type, ctx, __func__, CTYPE_OUT, [&] {
       apply_unary_map_fn(
           [fn](const CTYPE_IN val_in) {
             CTYPE_OUT xi = static_cast<CTYPE_OUT>(val_in);

--- a/kernels/test/op_acos_test.cpp
+++ b/kernels/test/op_acos_test.cpp
@@ -60,6 +60,16 @@ void test_floating_point_acos_out(
   // clang-format on
 }
 
+TEST(OpAcosOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test_floating_point_acos_out<ScalarType::dtype, ScalarType::Half>();
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
 TEST(OpAcosOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_acos_out<ScalarType::dtype, ScalarType::Float>();
@@ -71,6 +81,17 @@ TEST(OpAcosOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_acos_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
+TEST(OpAcosOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype)                                     \
+  test_floating_point_acos_out<ScalarType::dtype, ScalarType::Half>( \
+      {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 

--- a/kernels/test/op_asin_test.cpp
+++ b/kernels/test/op_asin_test.cpp
@@ -60,6 +60,16 @@ void test_floating_point_asin_out(
   // clang-format on
 }
 
+TEST(OpAsinOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test_floating_point_asin_out<ScalarType::dtype, ScalarType::Float>();
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
 TEST(OpAsinOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_asin_out<ScalarType::dtype, ScalarType::Float>();
@@ -71,6 +81,17 @@ TEST(OpAsinOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_asin_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
+TEST(OpAsinOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype)                                      \
+  test_floating_point_asin_out<ScalarType::dtype, ScalarType::Float>( \
+      {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 

--- a/kernels/test/op_asinh_test.cpp
+++ b/kernels/test/op_asinh_test.cpp
@@ -60,6 +60,16 @@ void test_floating_point_asinh_out(
   // clang-format on
 }
 
+TEST(OpAsinhOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test_floating_point_asinh_out<ScalarType::dtype, ScalarType::Float>();
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
 TEST(OpAsinhOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_asinh_out<ScalarType::dtype, ScalarType::Float>();
@@ -71,6 +81,17 @@ TEST(OpAsinhOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_asinh_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
+TEST(OpAsinhOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype)                                       \
+  test_floating_point_asinh_out<ScalarType::dtype, ScalarType::Float>( \
+      {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 

--- a/kernels/test/op_atan_test.cpp
+++ b/kernels/test/op_atan_test.cpp
@@ -60,6 +60,16 @@ void test_floating_point_atan_out(
   // clang-format on
 }
 
+TEST(OpAtanOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test_floating_point_atan_out<ScalarType::dtype, ScalarType::Float>();
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
 TEST(OpAtanOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_atan_out<ScalarType::dtype, ScalarType::Float>();
@@ -71,6 +81,17 @@ TEST(OpAtanOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_atan_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
+TEST(OpAtanOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype)                                      \
+  test_floating_point_atan_out<ScalarType::dtype, ScalarType::Float>( \
+      {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 

--- a/kernels/test/op_atanh_test.cpp
+++ b/kernels/test/op_atanh_test.cpp
@@ -60,6 +60,16 @@ void test_floating_point_atanh_out(
   // clang-format on
 }
 
+TEST(OpAtanhOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test_floating_point_atanh_out<ScalarType::dtype, ScalarType::Float>();
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
 TEST(OpAtanhOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_atanh_out<ScalarType::dtype, ScalarType::Float>();
@@ -71,6 +81,17 @@ TEST(OpAtanhOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_atanh_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
+TEST(OpAtanhOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype)                                       \
+  test_floating_point_atanh_out<ScalarType::dtype, ScalarType::Float>( \
+      {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 

--- a/kernels/test/op_cos_test.cpp
+++ b/kernels/test/op_cos_test.cpp
@@ -60,6 +60,16 @@ void test_floating_point_cos_out(
   // clang-format on
 }
 
+TEST(OpCosOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test_floating_point_cos_out<ScalarType::dtype, ScalarType::Float>();
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
 TEST(OpCosOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_cos_out<ScalarType::dtype, ScalarType::Float>();
@@ -71,6 +81,17 @@ TEST(OpCosOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_cos_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
+TEST(OpCosOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype)                                     \
+  test_floating_point_cos_out<ScalarType::dtype, ScalarType::Float>( \
+      {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 

--- a/kernels/test/op_cosh_test.cpp
+++ b/kernels/test/op_cosh_test.cpp
@@ -60,6 +60,16 @@ void test_floating_point_cosh_out(
   // clang-format on
 }
 
+TEST(OpCoshOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test_floating_point_cosh_out<ScalarType::dtype, ScalarType::Float>();
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
 TEST(OpCoshOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_cosh_out<ScalarType::dtype, ScalarType::Float>();
@@ -71,6 +81,17 @@ TEST(OpCoshOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_cosh_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
+TEST(OpCoshOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype)                                      \
+  test_floating_point_cosh_out<ScalarType::dtype, ScalarType::Float>( \
+      {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 

--- a/kernels/test/op_erf_test.cpp
+++ b/kernels/test/op_erf_test.cpp
@@ -8,6 +8,7 @@
 
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
+#include <executorch/kernels/test/supported_features.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -48,6 +49,21 @@ TEST(OpErfTest, HandleBoolInput) {
   Tensor a = tf_bool.make(sizes, /*data=*/{false, true});
   Tensor out = tf_float.zeros(sizes);
   Tensor res = tf_float.make(sizes, /*data=*/{0.000000, 0.842701});
+
+  EXPECT_TENSOR_CLOSE(op_erf_out(a, out), res);
+}
+
+TEST(OpErfTest, HalfSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+  TensorFactory<ScalarType::Half> tf_half;
+
+  const std::vector<int32_t> sizes = {1, 2};
+
+  Tensor a = tf_half.make(sizes, /*data=*/{0.0, 1.0});
+  Tensor out = tf_half.zeros(sizes);
+  Tensor res = tf_half.make(sizes, /*data=*/{0.000000, 0.842701});
 
   EXPECT_TENSOR_CLOSE(op_erf_out(a, out), res);
 }

--- a/kernels/test/op_exp_test.cpp
+++ b/kernels/test/op_exp_test.cpp
@@ -92,6 +92,21 @@ TEST(OpExpOutKernelTest, HandleBoolInput) {
   EXPECT_TENSOR_CLOSE(op_exp_out(a, out), res);
 }
 
+TEST(OpExpOutKernelTest, HandleHalfInput) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+  TensorFactory<ScalarType::Half> tf_half;
+
+  const std::vector<int32_t> sizes = {1, 2};
+
+  Tensor a = tf_half.make(sizes, /*data=*/{-2.5, -3.0});
+  Tensor out = tf_half.zeros(sizes);
+  Tensor res = tf_half.make(sizes, /*data=*/{0.082085, 0.049787});
+
+  EXPECT_TENSOR_CLOSE(op_exp_out(a, out), res);
+}
+
 // Mismatched shape tests.
 TEST(OpExpOutKernelTest, MismatchedShapesDies) {
   if (SupportedFeatures::get()->is_aten) {

--- a/kernels/test/op_log_test.cpp
+++ b/kernels/test/op_log_test.cpp
@@ -43,6 +43,16 @@ void test__log_out() {
       out, tf_out.make(sizes, /*data=*/{-INFINITY, 0, 0.693147, 1.386294}));
 }
 
+TEST(OpLogOutKernelTest, AllRealInputHalfOutputSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test__log_out<ScalarType::dtype, ScalarType::Half>();
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
 TEST(OpLogOutKernelTest, AllRealInputFloatOutputSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test__log_out<ScalarType::dtype, ScalarType::Float>();

--- a/kernels/test/op_reciprocal_test.cpp
+++ b/kernels/test/op_reciprocal_test.cpp
@@ -8,6 +8,7 @@
 
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
+#include <executorch/kernels/test/supported_features.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -48,6 +49,21 @@ TEST(OpReciprocalTest, HandleBoolInput) {
   Tensor a = tf_bool.make(sizes, /*data=*/{false, true});
   Tensor out = tf_float.zeros(sizes);
   Tensor res = tf_float.make(sizes, /*data=*/{INFINITY, 1.0});
+
+  EXPECT_TENSOR_CLOSE(op_reciprocal_out(a, out), res);
+}
+
+TEST(OpReciprocalTest, HandleHalfInput) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+  TensorFactory<ScalarType::Half> tf_half;
+
+  const std::vector<int32_t> sizes = {1, 2};
+
+  Tensor a = tf_half.make(sizes, /*data=*/{5.0, -2.0});
+  Tensor out = tf_half.zeros(sizes);
+  Tensor res = tf_half.make(sizes, /*data=*/{0.2, -0.5});
 
   EXPECT_TENSOR_CLOSE(op_reciprocal_out(a, out), res);
 }

--- a/kernels/test/op_rsqrt_test.cpp
+++ b/kernels/test/op_rsqrt_test.cpp
@@ -8,6 +8,7 @@
 
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
+#include <executorch/kernels/test/supported_features.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -48,6 +49,21 @@ TEST(OpRsqrtTest, HandleBoolInput) {
   Tensor a = tf_bool.make(sizes, /*data=*/{false, true});
   Tensor out = tf_float.zeros(sizes);
   Tensor res = tf_float.make(sizes, /*data=*/{INFINITY, 1.0});
+
+  EXPECT_TENSOR_CLOSE(op_rsqrt_out(a, out), res);
+}
+
+TEST(OpRsqrtTest, HandleHalfInput) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+  TensorFactory<ScalarType::Half> tf_half;
+
+  const std::vector<int32_t> sizes = {1, 2};
+
+  Tensor a = tf_half.make(sizes, /*data=*/{3.5, 2.6});
+  Tensor out = tf_half.zeros(sizes);
+  Tensor res = tf_half.make(sizes, /*data=*/{0.53452248, 0.62017367});
 
   EXPECT_TENSOR_CLOSE(op_rsqrt_out(a, out), res);
 }

--- a/kernels/test/op_sin_test.cpp
+++ b/kernels/test/op_sin_test.cpp
@@ -60,6 +60,16 @@ void test_floating_point_sin_out(
   // clang-format on
 }
 
+TEST(OpSinOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test_floating_point_sin_out<ScalarType::dtype, ScalarType::Half>();
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
 TEST(OpSinOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_sin_out<ScalarType::dtype, ScalarType::Float>();
@@ -71,6 +81,17 @@ TEST(OpSinOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_sin_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
+TEST(OpSinOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype)                                    \
+  test_floating_point_sin_out<ScalarType::dtype, ScalarType::Half>( \
+      {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 

--- a/kernels/test/op_sinh_test.cpp
+++ b/kernels/test/op_sinh_test.cpp
@@ -60,6 +60,16 @@ void test_floating_point_sinh_out(
   // clang-format on
 }
 
+TEST(OpSinhOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test_floating_point_sinh_out<ScalarType::dtype, ScalarType::Half>();
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
 TEST(OpSinhOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_sinh_out<ScalarType::dtype, ScalarType::Float>();
@@ -71,6 +81,17 @@ TEST(OpSinhOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_sinh_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
+TEST(OpSinhOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype)                                     \
+  test_floating_point_sinh_out<ScalarType::dtype, ScalarType::Half>( \
+      {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 

--- a/kernels/test/op_sqrt_test.cpp
+++ b/kernels/test/op_sqrt_test.cpp
@@ -8,6 +8,7 @@
 
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
+#include <executorch/kernels/test/supported_features.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -48,6 +49,21 @@ TEST(OpSqrtTest, HandleBoolInput) {
   Tensor a = tf_bool.make(sizes, /*data=*/{false, true});
   Tensor out = tf_float.zeros(sizes);
   Tensor res = tf_float.make(sizes, /*data=*/{0.0, 1.0});
+
+  EXPECT_TENSOR_CLOSE(op_sqrt_out(a, out), res);
+}
+
+TEST(OpSqrtTest, HandleHalfInput) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+  TensorFactory<ScalarType::Half> tf_half;
+
+  const std::vector<int32_t> sizes = {1, 2};
+
+  Tensor a = tf_half.make(sizes, /*data=*/{4.0, 6.25});
+  Tensor out = tf_half.zeros(sizes);
+  Tensor res = tf_half.make(sizes, /*data=*/{2.0, 2.5});
 
   EXPECT_TENSOR_CLOSE(op_sqrt_out(a, out), res);
 }

--- a/kernels/test/op_tan_test.cpp
+++ b/kernels/test/op_tan_test.cpp
@@ -60,6 +60,16 @@ void test_floating_point_tan_out(
   // clang-format on
 }
 
+TEST(OpTanOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test_floating_point_tan_out<ScalarType::dtype, ScalarType::Half>();
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
 TEST(OpTanOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_tan_out<ScalarType::dtype, ScalarType::Float>();
@@ -71,6 +81,17 @@ TEST(OpTanOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_tan_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
+TEST(OpTanOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype)                                    \
+  test_floating_point_tan_out<ScalarType::dtype, ScalarType::Half>( \
+      {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 

--- a/kernels/test/op_tanh_test.cpp
+++ b/kernels/test/op_tanh_test.cpp
@@ -66,6 +66,16 @@ void test_floating_point_tanh_out() {
   // clang-format on
 }
 
+TEST(OpTanhOutKernelTest, AllRealInputHalfOutputSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test_floating_point_tanh_out<ScalarType::dtype, ScalarType::Half>();
+  ET_FORALL_REALH_TYPES(TEST_ENTRY);
+#undef TEST_ENTRY
+}
+
 TEST(OpTanhOutKernelTest, AllRealInputFloatOutputSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_tanh_out<ScalarType::dtype, ScalarType::Float>();

--- a/runtime/core/exec_aten/util/scalar_type_util.h
+++ b/runtime/core/exec_aten/util/scalar_type_util.h
@@ -133,6 +133,15 @@ ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
   _(float, Float)                \
   _(double, Double)
 
+#define ET_FORALL_FLOAT_TYPES_AND(SCALARTYPE, _)    \
+  _(float, Float)                                   \
+  _(double, Double)                                 \
+  _(::torch::executor::ScalarTypeToCppType<         \
+        ::exec_aten::ScalarType::SCALARTYPE>::type, \
+    SCALARTYPE)
+
+#define ET_FORALL_FLOATH_TYPES(_) ET_FORALL_FLOAT_TYPES_AND(Half, _)
+
 // Here `ANOTHER_INPUT` should be another variable to be forwarded to a given
 // function. Not to be confused with another scalar type as in
 // `ET_FORALL_FLOAT_TYPES_AND`.
@@ -189,6 +198,8 @@ ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
   _(::torch::executor::ScalarTypeToCppType<         \
         ::exec_aten::ScalarType::SCALARTYPE>::type, \
     SCALARTYPE)
+
+#define ET_FORALL_REALH_TYPES(_) ET_FORALL_REAL_TYPES_AND(Half, _)
 
 #define ET_FORALL_REAL_TYPES_AND_WITH(SCALARTYPE, ANOTHER_INPUT, _) \
   _(ANOTHER_INPUT, uint8_t, Byte)                                   \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1709
* #1708
* __->__ #1707
* #1705
* #1704
* #1703
* #1702

Updated the following 18 ops to support Half dtype:
- acos
- acosh
- asin
- asinh
- atan
- atanh
- cos
- cosh
- erf
- exp
- log
- reciprocal
- rsqrt
- sin
- sinh
- sqrt
- tan
- tanh

Differential Revision: [D53074199](https://our.internmc.facebook.com/intern/diff/D53074199/)