### PR TITLE
[ET][Portable] Half support: unary ops with realhb to bool pattern (2 ops)

### DIFF
--- a/kernels/portable/cpu/op_isinf.cpp
+++ b/kernels/portable/cpu/op_isinf.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& isinf_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_bool(std::isinf, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_bool(std::isinf, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_isnan.cpp
+++ b/kernels/portable/cpu/op_isnan.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& isnan_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realb_to_bool(std::isnan, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_bool(std::isnan, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/pattern/pattern.h
+++ b/kernels/portable/cpu/pattern/pattern.h
@@ -68,11 +68,11 @@ Tensor& unary_ufunc_real(
 
 /**
  * Implements an op pattern for ops that take a single input tensor of any
- * realb dtye (real and boolean), no additional arguments, and outputs a
+ * realhb dtye (real, half and boolean), no additional arguments, and outputs a
  * boolean tensor of the same size. The function fn specifies the math
  * operation which is applied to the input tensor element-wise.
  */
-Tensor& unary_ufunc_realb_to_bool(
+Tensor& unary_ufunc_realhb_to_bool(
     FunctionRef<bool(double)> fn,
     RuntimeContext& ctx,
     const Tensor& in,

--- a/kernels/portable/cpu/pattern/targets.bzl
+++ b/kernels/portable/cpu/pattern/targets.bzl
@@ -10,9 +10,9 @@ def define_common_targets():
     runtime.cxx_library(
         name = "pattern",
         srcs = [
+            "unary_ufunc_realhb_to_bool.cpp",
             "unary_ufunc_realhb_to_floath.cpp",
             "binary_ufunc_realb_realb_to_realb_logical.cpp",
-            "unary_ufunc_realb_to_bool.cpp",
             "unary_ufunc_real.cpp",
         ],
         exported_headers = [

--- a/kernels/portable/cpu/pattern/unary_ufunc_realhb_to_bool.cpp
+++ b/kernels/portable/cpu/pattern/unary_ufunc_realhb_to_bool.cpp
@@ -16,7 +16,7 @@ namespace executor {
 namespace native {
 namespace internal {
 
-Tensor& unary_ufunc_realb_to_bool(
+Tensor& unary_ufunc_realhb_to_bool(
     FunctionRef<bool(double)> fn,
     RuntimeContext& ctx,
     const Tensor& in,
@@ -41,7 +41,7 @@ Tensor& unary_ufunc_realb_to_bool(
 
   const auto in_type = in.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, __func__, CTYPE_IN, [&] {
+  ET_SWITCH_REALHB_TYPES(in_type, ctx, __func__, CTYPE_IN, [&] {
     apply_unary_map_fn(
         [fn](const CTYPE_IN val_in) { return fn(val_in); },
         in.const_data_ptr<CTYPE_IN>(),

--- a/kernels/test/op_isinf_test.cpp
+++ b/kernels/test/op_isinf_test.cpp
@@ -8,6 +8,7 @@
 
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
+#include <executorch/kernels/test/supported_features.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -26,6 +27,24 @@ Tensor& op_isinf_out(const Tensor& self, Tensor& out) {
 
 TEST(OpIsInfTest, SanityCheckFloat) {
   TensorFactory<ScalarType::Float> tf;
+  TensorFactory<ScalarType::Bool> tfb;
+
+  Tensor in = tf.make(
+      {1, 5}, {-1.0, 0.0, 1.0, NAN, std::numeric_limits<float>::infinity()});
+  Tensor out = tfb.zeros({1, 5});
+  Tensor expected = tfb.make({1, 5}, {false, false, false, false, true});
+
+  Tensor ret = op_isinf_out(in, out);
+
+  EXPECT_TENSOR_EQ(out, ret);
+  EXPECT_TENSOR_EQ(out, expected);
+}
+
+TEST(OpIsInfTest, SanityCheckHalf) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+  TensorFactory<ScalarType::Half> tf;
   TensorFactory<ScalarType::Bool> tfb;
 
   Tensor in = tf.make(

--- a/kernels/test/op_isnan_test.cpp
+++ b/kernels/test/op_isnan_test.cpp
@@ -8,6 +8,7 @@
 
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
+#include <executorch/kernels/test/supported_features.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -25,6 +26,24 @@ Tensor& op_isnan_out(const Tensor& self, Tensor& out) {
 }
 
 TEST(OpIsNanTest, SanityCheckFloat) {
+  TensorFactory<ScalarType::Float> tf;
+  TensorFactory<ScalarType::Bool> tfb;
+
+  Tensor in = tf.make(
+      {1, 5}, {-1.0, 0.0, 1.0, NAN, std::numeric_limits<float>::infinity()});
+  Tensor out = tfb.zeros({1, 5});
+  Tensor expected = tfb.make({1, 5}, {false, false, false, true, false});
+
+  Tensor ret = op_isnan_out(in, out);
+
+  EXPECT_TENSOR_EQ(out, ret);
+  EXPECT_TENSOR_EQ(out, expected);
+}
+
+TEST(OpIsNanTest, SanityCheckHalf) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
   TensorFactory<ScalarType::Float> tf;
   TensorFactory<ScalarType::Bool> tfb;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1709
* __->__ #1708
* #1707
* #1705
* #1704
* #1703
* #1702

Updated the following 2 ops to support Half dtype:
- isinf
- isnan

Differential Revision: [D53074458](https://our.internmc.facebook.com/intern/diff/D53074458/)