### PR TITLE
[ET][Portable] Half support: unary ops with realh pattern

### DIFF
--- a/kernels/portable/cpu/op_ceil.cpp
+++ b/kernels/portable/cpu/op_ceil.cpp
@@ -17,7 +17,7 @@ namespace native {
 using exec_aten::Tensor;
 
 Tensor& ceil_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_real(std::ceil, ctx, in, out);
+  return internal::unary_ufunc_realh(std::ceil, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_floor.cpp
+++ b/kernels/portable/cpu/op_floor.cpp
@@ -17,7 +17,7 @@ namespace native {
 using exec_aten::Tensor;
 
 Tensor& floor_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_real(std::floor, ctx, in, out);
+  return internal::unary_ufunc_realh(std::floor, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/pattern/pattern.h
+++ b/kernels/portable/cpu/pattern/pattern.h
@@ -56,11 +56,11 @@ namespace internal {
 
 /**
  * Implements an op pattern for ops that take a single input tensor of any
- * real dtye, no additional arguments, and outputs a tensor of the same size
+ * realh dtye, no additional arguments, and outputs a tensor of the same size
  * and dtype. The function fn specifies the math operation which is applied to
  * the input tensor element-wise.
  */
-Tensor& unary_ufunc_real(
+Tensor& unary_ufunc_realh(
     FunctionRef<double(double)> fn,
     RuntimeContext& ctx,
     const Tensor& in,

--- a/kernels/portable/cpu/pattern/targets.bzl
+++ b/kernels/portable/cpu/pattern/targets.bzl
@@ -12,8 +12,8 @@ def define_common_targets():
         srcs = [
             "unary_ufunc_realhb_to_bool.cpp",
             "unary_ufunc_realhb_to_floath.cpp",
+            "unary_ufunc_realh.cpp",
             "binary_ufunc_realb_realb_to_realb_logical.cpp",
-            "unary_ufunc_real.cpp",
         ],
         exported_headers = [
             "pattern.h",

--- a/kernels/portable/cpu/pattern/unary_ufunc_realh.cpp
+++ b/kernels/portable/cpu/pattern/unary_ufunc_realh.cpp
@@ -16,7 +16,7 @@ namespace executor {
 namespace native {
 namespace internal {
 
-Tensor& unary_ufunc_real(
+Tensor& unary_ufunc_realh(
     FunctionRef<double(double)> fn,
     RuntimeContext& ctx,
     const Tensor& in,
@@ -34,7 +34,7 @@ Tensor& unary_ufunc_real(
   ET_KERNEL_CHECK(
       ctx, tensors_have_same_shape_and_dtype(in, out), InvalidArgument, out);
 
-  ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, __func__, CTYPE, [&] {
+  ET_SWITCH_REALH_TYPES(in.scalar_type(), ctx, __func__, CTYPE, [&] {
     apply_unary_map_fn(
         [fn](const CTYPE val_in) { return static_cast<CTYPE>(fn(val_in)); },
         in.const_data_ptr<CTYPE>(),

--- a/kernels/test/op_ceil_test.cpp
+++ b/kernels/test/op_ceil_test.cpp
@@ -8,6 +8,7 @@
 
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
+#include <executorch/kernels/test/supported_features.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -26,6 +27,22 @@ Tensor& op_ceil_out(const Tensor& self, Tensor& out) {
 
 TEST(OpCeilTest, SanityCheck) {
   TensorFactory<ScalarType::Float> tf;
+
+  Tensor in = tf.make({1, 7}, {-3.0, -2.99, -1.01, 0.0, 1.01, 2.99, 3.0});
+  Tensor out = tf.zeros({1, 7});
+  Tensor expected = tf.make({1, 7}, {-3.0, -2.0, -1.0, 0.0, 2.0, 3.0, 3.0});
+
+  Tensor ret = op_ceil_out(in, out);
+
+  EXPECT_TENSOR_EQ(out, ret);
+  EXPECT_TENSOR_EQ(out, expected);
+}
+
+TEST(OpCeilTest, HalfSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+  TensorFactory<ScalarType::Half> tf;
 
   Tensor in = tf.make({1, 7}, {-3.0, -2.99, -1.01, 0.0, 1.01, 2.99, 3.0});
   Tensor out = tf.zeros({1, 7});

--- a/kernels/test/op_floor_test.cpp
+++ b/kernels/test/op_floor_test.cpp
@@ -8,6 +8,7 @@
 
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
+#include <executorch/kernels/test/supported_features.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -26,6 +27,22 @@ Tensor& op_floor_out(const Tensor& self, Tensor& out) {
 
 TEST(OpFloorTest, SanityCheck) {
   TensorFactory<ScalarType::Float> tf;
+
+  Tensor in = tf.make({1, 7}, {-3.0, -2.99, -1.01, 0.0, 1.01, 2.99, 3.0});
+  Tensor out = tf.zeros({1, 7});
+  Tensor expected = tf.make({1, 7}, {-3.0, -3.0, -2.0, 0.0, 1.0, 2.0, 3.0});
+
+  Tensor ret = op_floor_out(in, out);
+
+  EXPECT_TENSOR_EQ(out, ret);
+  EXPECT_TENSOR_EQ(out, expected);
+}
+
+TEST(OpFloorTest, HalfSupport) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
+  }
+  TensorFactory<ScalarType::Half> tf;
 
   Tensor in = tf.make({1, 7}, {-3.0, -2.99, -1.01, 0.0, 1.01, 2.99, 3.0});
   Tensor out = tf.zeros({1, 7});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1709
* #1708
* #1707
* #1705
* #1704
* #1703
* #1702

Updated the following 2 ops to support Half dtype:
- ceil
- floor

Differential Revision: [D53074613](https://our.internmc.facebook.com/intern/diff/D53074613/)