### PR TITLE
Make executor_runner use the new prepare_input_tensors

### DIFF
--- a/examples/portable/executor_runner/executor_runner.cpp
+++ b/examples/portable/executor_runner/executor_runner.cpp
@@ -24,11 +24,11 @@
 
 #include <executorch/extension/data_loader/file_data_loader.h>
 #include <executorch/extension/evalue_util/print_evalue.h>
+#include <executorch/extension/runner_util/inputs.h>
 #include <executorch/runtime/executor/method.h>
 #include <executorch/runtime/executor/program.h>
 #include <executorch/runtime/platform/log.h>
 #include <executorch/runtime/platform/runtime.h>
-#include <executorch/util/util.h>
 
 static uint8_t method_allocator_pool[4 * 1024U * 1024U]; // 4 MB
 
@@ -151,9 +151,14 @@ int main(int argc, char** argv) {
       (uint32_t)method.error());
   ET_LOG(Info, "Method loaded.");
 
-  // Prepare the inputs.
-  // Use ones-initialized inputs.
-  auto inputs = util::PrepareInputTensors(*method);
+  // Allocate input tensors and set all of their elements to 1. The `inputs`
+  // variable owns the allocated memory and must live past the last call to
+  // `execute()`.
+  auto inputs = util::prepare_input_tensors(*method);
+  ET_CHECK_MSG(
+      inputs.ok(),
+      "Could not prepare inputs: 0x%" PRIx32,
+      (uint32_t)inputs.error());
   ET_LOG(Info, "Inputs prepared.");
 
   // Run the model.
@@ -176,6 +181,5 @@ int main(int argc, char** argv) {
     std::cout << "Output " << i << ": " << outputs[i] << std::endl;
   }
 
-  util::FreeInputs(inputs);
   return 0;
 }

--- a/examples/portable/executor_runner/targets.bzl
+++ b/examples/portable/executor_runner/targets.bzl
@@ -16,7 +16,7 @@ def define_common_targets():
             "//executorch/runtime/executor:program",
             "//executorch/extension/data_loader:file_data_loader",
             "//executorch/extension/evalue_util:print_evalue",
-            "//executorch/util:util",
+            "//executorch/extension/runner_util:inputs",
         ],
         external_deps = [
             "gflags",

--- a/extension/runner_util/TARGETS
+++ b/extension/runner_util/TARGETS
@@ -1,0 +1,8 @@
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain xplat-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/extension/runner_util/inputs.cpp
+++ b/extension/runner_util/inputs.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/runner_util/inputs.h>
+
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/method_meta.h>
+#include <executorch/runtime/platform/log.h>
+
+namespace torch {
+namespace executor {
+namespace util {
+
+Result<BufferCleanup> prepare_input_tensors(Method& method) {
+  MethodMeta method_meta = method.method_meta();
+  size_t num_inputs = method_meta.num_inputs();
+  size_t num_allocated = 0;
+  void** inputs = (void**)malloc(num_inputs * sizeof(void*));
+
+  for (size_t i = 0; i < num_inputs; i++) {
+    Result<TensorInfo> tensor_meta = method_meta.input_tensor_meta(i);
+    if (!tensor_meta.ok()) {
+      ET_LOG(Info, "Skipping non-tensor input %zu", i);
+      continue;
+    }
+    // This input is a tensor. Allocate a buffer for it.
+    void* data_ptr = malloc(tensor_meta->nbytes());
+    inputs[num_allocated++] = data_ptr;
+
+    // Create the tensor and set it as the input.
+    Error err =
+        internal::fill_and_set_input(method, tensor_meta.get(), i, data_ptr);
+    if (err != Error::Ok) {
+      ET_LOG(
+          Error, "Failed to prepare input %zu: 0x%" PRIx32, i, (uint32_t)err);
+      // The BufferCleanup will free the inputs when it goes out of scope.
+      BufferCleanup cleanup({inputs, num_allocated});
+      return err;
+    }
+  }
+  return BufferCleanup({inputs, num_allocated});
+}
+
+} // namespace util
+} // namespace executor
+} // namespace torch

--- a/extension/runner_util/inputs.h
+++ b/extension/runner_util/inputs.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/runtime/core/span.h>
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/method_meta.h>
+
+namespace torch {
+namespace executor {
+namespace util {
+
+/**
+ * RAII helper that frees a set of buffers when destroyed. Movable.
+ */
+class BufferCleanup final {
+ public:
+  /**
+   * Takes ownership of `buffers.data()` and the elements of `buffers`, which
+   * each will be passed to `free()` when the object is destroyed.
+   */
+  explicit BufferCleanup(Span<void*> buffers) : buffers_(buffers) {}
+
+  /**
+   * Move ctor. Takes ownership of the data previously owned by `rhs`, leaving
+   * `rhs` with an empty list of buffers.
+   */
+  BufferCleanup(BufferCleanup&& rhs) noexcept : buffers_(rhs.buffers_) {
+    rhs.buffers_ = Span<void*>();
+  }
+
+  ~BufferCleanup() {
+    for (auto buffer : buffers_) {
+      free(buffer);
+    }
+    free(buffers_.data());
+  }
+
+ private:
+  // Delete other rule-of-five methods.
+  BufferCleanup(const BufferCleanup&) = delete;
+  BufferCleanup& operator=(const BufferCleanup&) = delete;
+  BufferCleanup& operator=(BufferCleanup&&) noexcept = delete;
+
+  Span<void*> buffers_;
+};
+
+/**
+ * Allocates input tensors for the provided Method, filling them with ones. Does
+ * not modify inputs that are not Tensors.
+ *
+ * @param[in] method The Method that owns the inputs to prepare.
+ *
+ * @returns On success, an object that owns any allocated tensor memory. It must
+ *     remain alive when calling `method->execute()`.
+ * @returns An error on failure.
+ */
+Result<BufferCleanup> prepare_input_tensors(Method& method);
+
+namespace internal {
+/**
+ * INTERNAL-ONLY: Creates a Tensor using the provided shape and buffer,
+ * fills it with ones, and sets the input at `input_index`.
+ */
+Error fill_and_set_input(
+    Method& method,
+    TensorInfo& tensor_meta,
+    size_t input_index,
+    void* data_ptr);
+} // namespace internal
+
+} // namespace util
+} // namespace executor
+} // namespace torch

--- a/extension/runner_util/inputs_aten.cpp
+++ b/extension/runner_util/inputs_aten.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/runner_util/inputs.h>
+
+#include <vector>
+
+#include <ATen/ATen.h> // @manual=//caffe2/aten:ATen-core
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/method_meta.h>
+
+namespace torch {
+namespace executor {
+namespace util {
+
+namespace internal {
+
+Error fill_and_set_input(
+    Method& method,
+    TensorInfo& tensor_meta,
+    size_t input_index,
+    void* data_ptr) {
+  // Convert the sizes array from int32_t to int64_t.
+  std::vector<int64_t> sizes;
+  for (auto s : tensor_meta.sizes()) {
+    sizes.push_back(s);
+  }
+  at::Tensor t = at::from_blob(
+      data_ptr, sizes, at::TensorOptions(tensor_meta.scalar_type()));
+  t.fill_(1.0f);
+
+  return method.set_input(t, input_index);
+}
+
+} // namespace internal
+
+} // namespace util
+} // namespace executor
+} // namespace torch

--- a/extension/runner_util/inputs_portable.cpp
+++ b/extension/runner_util/inputs_portable.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/runner_util/inputs.h>
+
+#include <algorithm>
+
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/method_meta.h>
+#include <executorch/runtime/platform/log.h>
+
+namespace torch {
+namespace executor {
+namespace util {
+namespace internal {
+
+namespace {
+/**
+ * Sets all elements of a tensor to 1.
+ */
+Error fill_ones(torch::executor::Tensor tensor) {
+#define FILL_CASE(T, n)                                \
+  case (torch::executor::ScalarType::n):               \
+    std::fill(                                         \
+        tensor.mutable_data_ptr<T>(),                  \
+        tensor.mutable_data_ptr<T>() + tensor.numel(), \
+        1);                                            \
+    break;
+
+  switch (tensor.scalar_type()) {
+    ET_FORALL_REAL_TYPES_AND(Bool, FILL_CASE)
+    default:
+      ET_LOG(Error, "Unsupported scalar type %d", (int)tensor.scalar_type());
+      return Error::InvalidArgument;
+  }
+
+#undef FILL_CASE
+
+  return Error::Ok;
+}
+} // namespace
+
+Error fill_and_set_input(
+    Method& method,
+    TensorInfo& tensor_meta,
+    size_t input_index,
+    void* data_ptr) {
+  TensorImpl impl = TensorImpl(
+      tensor_meta.scalar_type(),
+      /*dim=*/tensor_meta.sizes().size(),
+      // These const pointers will not be modified because we never resize this
+      // short-lived TensorImpl. It only exists so that set_input() can verify
+      // that the shape is correct; the Method manages its own sizes and
+      // dim_order arrays for the input.
+      const_cast<TensorImpl::SizesType*>(tensor_meta.sizes().data()),
+      data_ptr,
+      const_cast<TensorImpl::DimOrderType*>(tensor_meta.dim_order().data()));
+  Tensor t(&impl);
+  ET_CHECK_OK_OR_RETURN_ERROR(fill_ones(t));
+  return method.set_input(t, input_index);
+}
+
+} // namespace internal
+} // namespace util
+} // namespace executor
+} // namespace torch

--- a/extension/runner_util/targets.bzl
+++ b/extension/runner_util/targets.bzl
@@ -1,0 +1,28 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    for aten_mode in (True, False):
+        aten_suffix = ("_aten" if aten_mode else "")
+
+        runtime.cxx_library(
+            name = "inputs" + aten_suffix,
+            srcs = [
+                "inputs.cpp",
+                "inputs{}.cpp".format("_aten" if aten_mode else "_portable"),
+            ],
+            exported_headers = ["inputs.h"],
+            visibility = [
+                "//executorch/...",
+                "@EXECUTORCH_CLIENTS",
+            ],
+            exported_deps = [
+                "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
+                "//executorch/runtime/executor:program" + aten_suffix,
+            ],
+        )

--- a/extension/runner_util/test/TARGETS
+++ b/extension/runner_util/test/TARGETS
@@ -1,0 +1,8 @@
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain xplat-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets(is_fbcode = True)

--- a/extension/runner_util/test/inputs_test.cpp
+++ b/extension/runner_util/test/inputs_test.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/runner_util/inputs.h>
+
+#include <executorch/extension/data_loader/file_data_loader.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/span.h>
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/program.h>
+#include <executorch/runtime/executor/test/managed_memory_manager.h>
+#include <executorch/runtime/platform/runtime.h>
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using exec_aten::ScalarType;
+using exec_aten::Tensor;
+using torch::executor::Error;
+using torch::executor::EValue;
+using torch::executor::MemoryAllocator;
+using torch::executor::MemoryManager;
+using torch::executor::Method;
+using torch::executor::Program;
+using torch::executor::Result;
+using torch::executor::Span;
+using torch::executor::Tag;
+using torch::executor::Tensor;
+using torch::executor::testing::ManagedMemoryManager;
+using torch::executor::util::BufferCleanup;
+using torch::executor::util::FileDataLoader;
+using torch::executor::util::prepare_input_tensors;
+
+class InputsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    torch::executor::runtime_init();
+
+    // Create a loader for the serialized ModuleAdd program.
+    const char* path = std::getenv("ET_MODULE_ADD_PATH");
+    Result<FileDataLoader> loader = FileDataLoader::from(path);
+    ASSERT_EQ(loader.error(), Error::Ok);
+    loader_ = std::make_unique<FileDataLoader>(std::move(loader.get()));
+
+    // Use it to load the program.
+    Result<Program> program = Program::load(
+        loader_.get(), Program::Verification::InternalConsistency);
+    ASSERT_EQ(program.error(), Error::Ok);
+    program_ = std::make_unique<Program>(std::move(program.get()));
+
+    mmm_ = std::make_unique<ManagedMemoryManager>(
+        /*planned_memory_bytes=*/32 * 1024U,
+        /*method_allocator_bytes=*/32 * 1024U);
+
+    // Load the forward method.
+    Result<Method> method = program_->load_method("forward", &mmm_->get());
+    ASSERT_EQ(method.error(), Error::Ok);
+    method_ = std::make_unique<Method>(std::move(method.get()));
+  }
+
+ private:
+  // Must outlive method_, but tests shouldn't need to touch them.
+  std::unique_ptr<FileDataLoader> loader_;
+  std::unique_ptr<ManagedMemoryManager> mmm_;
+  std::unique_ptr<Program> program_;
+
+ protected:
+  std::unique_ptr<Method> method_;
+};
+
+TEST_F(InputsTest, Smoke) {
+  Result<BufferCleanup> input_buffers = prepare_input_tensors(*method_);
+  ASSERT_EQ(input_buffers.error(), Error::Ok);
+
+  // We can't look at the input tensors, but we can check that the outputs make
+  // sense after executing the method.
+  Error status = method_->execute();
+  ASSERT_EQ(status, Error::Ok);
+
+  // Get the single output, which should be a floating-point Tensor.
+  ASSERT_EQ(method_->outputs_size(), 1);
+  const EValue& output_value = method_->get_output(0);
+  ASSERT_EQ(output_value.tag, Tag::Tensor);
+  Tensor output = output_value.toTensor();
+  ASSERT_EQ(output.scalar_type(), ScalarType::Float);
+
+  // ModuleAdd adds its two inputs together, so if the input elements were set
+  // to 1, the output elemements should all be 2.
+  Span<float> elements(output.mutable_data_ptr<float>(), output.numel());
+  EXPECT_GT(elements.size(), 0); // Make sure we're actually testing something.
+  for (float e : elements) {
+    EXPECT_EQ(e, 2.0);
+  }
+
+  // Although it's tough to test directly, ASAN should let us know if
+  // BufferCleanup doesn't behave properly: either freeing too soon or leaking
+  // the pointers.
+}
+
+TEST(BufferCleanupTest, Smoke) {
+  // Returns the size of the buffer at index `i`.
+  auto test_buffer_size = [](size_t i) {
+    // Use multiples of OS page sizes. As this gets bigger, we're more
+    // likely to allocate outside the main heap in a separate page, making
+    // it easier to catch uses-after-free.
+    return 4096 << i;
+  };
+
+  // Create some buffers.
+  constexpr size_t kNumBuffers = 8;
+  void** buffers = (void**)malloc(kNumBuffers * sizeof(void*));
+  for (int i = 0; i < kNumBuffers; i++) {
+    size_t nbytes = test_buffer_size(i);
+    buffers[i] = malloc(nbytes);
+    memset(reinterpret_cast<char*>(buffers[i]), 0x00, nbytes);
+  }
+
+  std::unique_ptr<BufferCleanup> bc2;
+  {
+    // bc1 should own `buffers` and the buffers that its entries point to.
+    BufferCleanup bc1({buffers, kNumBuffers});
+
+    // They're still alive; no segfaults or ASAN complaints if we write to them.
+    for (int i = 0; i < kNumBuffers; i++) {
+      size_t nbytes = test_buffer_size(i);
+      memset(reinterpret_cast<char*>(buffers[i]), 0xff, nbytes);
+    }
+
+    // Move ownership to a new object.
+    bc2 = std::make_unique<BufferCleanup>(std::move(bc1));
+
+    // Still alive.
+    for (int i = 0; i < kNumBuffers; i++) {
+      size_t nbytes = test_buffer_size(i);
+      memset(reinterpret_cast<char*>(buffers[i]), 0x00, nbytes);
+    }
+
+    // bc1 goes out of scope here. If it thinks it owns the buffers, it will
+    // try to free them.
+  }
+
+  // bc2 should own the buffers now, and they should still be alive.
+  for (int i = 0; i < kNumBuffers; i++) {
+    size_t nbytes = test_buffer_size(i);
+    memset(reinterpret_cast<char*>(buffers[i]), 0xff, nbytes);
+  }
+
+  // Destroy bc2, which should destroy the buffers. There's no way for us to
+  // check that it happened, but the sanitizer should complain if there's a
+  // memory leak. And if bc1 freed them before, we should get a double-free
+  // complaint.
+  bc2.reset();
+}

--- a/extension/runner_util/test/targets.bzl
+++ b/extension/runner_util/test/targets.bzl
@@ -1,0 +1,32 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets(is_fbcode = False):
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    for aten_mode in (True, False):
+        aten_suffix = ("_aten" if aten_mode else "")
+
+        # TODO(dbort): Find a way to make these run for ANDROID/APPLE in xplat. The
+        # android and ios test determinators don't like the reference to the model
+        # file in fbcode. See https://fburl.com/9esapdmd
+        if not runtime.is_oss and is_fbcode:
+            runtime.cxx_test(
+                name = "inputs_test" + aten_suffix,
+                srcs = [
+                    "inputs_test.cpp",
+                ],
+                deps = [
+                    "//executorch/extension/runner_util:inputs",
+                    "//executorch/runtime/executor/test:managed_memory_manager",
+                    "//executorch/runtime/executor:program",
+                    "//executorch/kernels/portable:generated_lib",
+                    "//executorch/extension/data_loader:file_data_loader",
+                ],
+                env = {
+                    "ET_MODULE_ADD_PATH": "$(location fbcode//executorch/test/models:exported_programs[ModuleAdd.pte])",
+                },
+            )

--- a/util/targets.bzl
+++ b/util/targets.bzl
@@ -24,6 +24,8 @@ def define_common_targets():
     for aten_mode in (True, False):
         aten_suffix = ("_aten" if aten_mode else "")
 
+        # DEPRECATED: Remove this once all users have migrated to
+        # extension/runner_util:inputs.
         runtime.cxx_library(
             name = "util" + aten_suffix,
             srcs = [],
@@ -33,9 +35,9 @@ def define_common_targets():
                 "@EXECUTORCH_CLIENTS",
             ],
             exported_deps = [
-                "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
+                "//executorch/extension/runner_util:inputs" + aten_suffix,
+                "//executorch/runtime/core:core",
                 "//executorch/runtime/executor:program" + aten_suffix,
-                "//executorch/runtime/platform:platform",
             ],
         )
 

--- a/util/util.h
+++ b/util/util.h
@@ -6,148 +6,52 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/**
+ * @file
+ * DEPRECATED: Do not use this file or add new functions to it.
+ */
+
 #pragma once
 
-#include <algorithm>
-
-#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/extension/runner_util/inputs.h>
+#include <executorch/runtime/core/array_ref.h>
 #include <executorch/runtime/executor/method.h>
-#include <executorch/runtime/executor/method_meta.h>
-#include <executorch/runtime/platform/log.h>
-#ifdef USE_ATEN_LIB
-#include <ATen/ATen.h> // @manual=//caffe2/aten:ATen-core
-#endif
 
 namespace torch {
 namespace executor {
 namespace util {
 
-using namespace exec_aten;
-
-// This macro defines all the scalar types that we currently support to fill a
-// tensor. FillOnes() is a quick and dirty util that allows us to quickly
-// initialize tensors and run a model.
-#define EX_SCALAR_TYPES_SUPPORTED_BY_FILL(_fill_case) \
-  _fill_case(uint8_t, Byte) /* 0 */                   \
-      _fill_case(int8_t, Char) /* 1 */                \
-      _fill_case(int16_t, Short) /* 2 */              \
-      _fill_case(int, Int) /* 3 */                    \
-      _fill_case(int64_t, Long) /* 4 */               \
-      _fill_case(float, Float) /* 6 */                \
-      _fill_case(double, Double) /* 7 */              \
-      _fill_case(bool, Bool) /* 11 */
-
-#define FILL_CASE(T, n)                                \
-  case (ScalarType::n):                                \
-    std::fill(                                         \
-        tensor.mutable_data_ptr<T>(),                  \
-        tensor.mutable_data_ptr<T>() + tensor.numel(), \
-        1);                                            \
-    break;
-
-#ifndef USE_ATEN_LIB
-inline void FillOnes(Tensor tensor) {
-  switch (tensor.scalar_type()) {
-    EX_SCALAR_TYPES_SUPPORTED_BY_FILL(FILL_CASE)
-    default:
-      ET_CHECK_MSG(false, "Scalar type is not supported by fill.");
-  }
-}
-#endif
-
 /**
+ * DEPRECATED: Use prepare_input_tensors() instead.
+ *
  * Allocates input tensors for the provided Method, filling them with ones.
  *
  * @param[in] method The Method that owns the inputs to prepare.
  * @returns An array of pointers that must be passed to `FreeInputs()` after
  *     the Method is no longer needed.
  */
+__ET_DEPRECATED
 inline exec_aten::ArrayRef<void*> PrepareInputTensors(Method& method) {
-  auto method_meta = method.method_meta();
-  size_t input_size = method.inputs_size();
-  size_t num_allocated = 0;
-  void** inputs = (void**)malloc(input_size * sizeof(void*));
-
-  for (size_t i = 0; i < input_size; i++) {
-    if (*method_meta.input_tag(i) != Tag::Tensor) {
-      ET_LOG(Info, "input %zu is not a tensor, skipping", i);
-      continue;
-    }
-
-    // Tensor Input. Grab meta data and allocate buffer
-    auto tensor_meta = method_meta.input_tensor_meta(i);
-    inputs[num_allocated++] = malloc(tensor_meta->nbytes());
-
-#ifdef USE_ATEN_LIB
-    std::vector<int64_t> at_tensor_sizes;
-    for (auto s : tensor_meta->sizes()) {
-      at_tensor_sizes.push_back(s);
-    }
-    at::Tensor t = at::from_blob(
-        inputs[num_allocated - 1],
-        at_tensor_sizes,
-        at::TensorOptions(tensor_meta->scalar_type()));
-    t.fill_(1.0f);
-
-#else // Portable Tensor
-    // The only memory that needs to persist after set_input is called is the
-    // data ptr of the input tensor, and that is only if the Method did not
-    // memory plan buffer space for the inputs and instead is expecting the user
-    // to provide them. Meta data like sizes and dim order are used to ensure
-    // the input aligns with the values expected by the plan, but references to
-    // them are not held onto.
-
-    TensorImpl::SizesType* sizes = static_cast<TensorImpl::SizesType*>(
-        malloc(sizeof(TensorImpl::SizesType) * tensor_meta->sizes().size()));
-    TensorImpl::DimOrderType* dim_order =
-        static_cast<TensorImpl::DimOrderType*>(malloc(
-            sizeof(TensorImpl::DimOrderType) *
-            tensor_meta->dim_order().size()));
-
-    for (size_t size_idx = 0; size_idx < tensor_meta->sizes().size();
-         size_idx++) {
-      sizes[size_idx] = tensor_meta->sizes()[size_idx];
-    }
-    for (size_t dim_idx = 0; dim_idx < tensor_meta->dim_order().size();
-         dim_idx++) {
-      dim_order[dim_idx] = tensor_meta->dim_order()[dim_idx];
-    }
-
-    TensorImpl impl = TensorImpl(
-        tensor_meta->scalar_type(),
-        tensor_meta->sizes().size(),
-        sizes,
-        inputs[num_allocated - 1],
-        dim_order);
-    Tensor t(&impl);
-    FillOnes(t);
-#endif
-    auto error = method.set_input(t, i);
-    ET_CHECK_MSG(
-        error == Error::Ok,
-        "Error: 0x%" PRIx32 " setting input %zu.",
-        static_cast<uint32_t>(error),
-        i);
-#ifndef USE_ATEN_LIB // Portable Tensor
-    free(sizes);
-    free(dim_order);
-#endif
-  }
-  return {inputs, num_allocated};
+  Result<BufferCleanup> inputs = prepare_input_tensors(method);
+  ET_CHECK(inputs.ok());
+  // A hack to work with the deprecated signature. Return an ArrayRef that
+  // points to a single BufferCleanup.
+  return {
+      reinterpret_cast<void**>(new BufferCleanup(std::move(inputs.get()))), 1};
 }
 
 /**
+ * DEPRECATED: Use prepare_input_tensors() instead, which does not need this.
+ *
  * Frees memory that was allocated by `PrepareInputTensors()`.
  */
+__ET_DEPRECATED
 inline void FreeInputs(exec_aten::ArrayRef<void*> inputs) {
-  for (size_t i = 0; i < inputs.size(); i++) {
-    free(inputs[i]);
-  }
-  free((void*)inputs.data());
+  ET_CHECK(inputs.size() == 1);
+  // A hack to work with the deprecated signature. The ArrayRef points to a
+  // single BufferCleanup for us to delete.
+  delete reinterpret_cast<BufferCleanup*>(const_cast<void**>(inputs.data()));
 }
-
-#undef FILL_VALUE
-#undef EX_SCALAR_TYPES_SUPPORTED_BY_FILL
 
 } // namespace util
 } // namespace executor


### PR DESCRIPTION
Summary:
Update our canonical example to use the new `prepare_input_tensors` API.

We still need to update other uses in the tree.

Differential Revision: D53072259


