### PR TITLE
[MPS] Add ETDump support to MPS runtime

### DIFF
--- a/examples/apple/mps/CMakeLists.txt
+++ b/examples/apple/mps/CMakeLists.txt
@@ -42,6 +42,7 @@ set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 # portable_ops_lib, etdump, bundled_program.
 find_package(executorch CONFIG REQUIRED)
 target_include_directories(executorch INTERFACE ${_common_include_directories})
+target_compile_options(executorch INTERFACE -DET_EVENT_TRACER_ENABLED)
 
 find_package(
   gflags REQUIRED PATHS ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party
@@ -77,12 +78,22 @@ target_include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}/../../../sdk/include
   ${CMAKE_CURRENT_BINARY_DIR}/../../../sdk/bundled_program
   ${EXECUTORCH_ROOT}/third-party/flatbuffers/include
+  ${EXECUTORCH_ROOT}/third-party/flatcc/include
   ${_mps_schema_headers}
 )
 list(TRANSFORM _mps_executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_executable(mps_executor_runner ${_mps_executor_runner__srcs})
+
+if (CMAKE_BUILD_TYPE MATCHES "Debug")
+    set(FLATCC_LIB flatcc_d)
+else()
+    set(FLATCC_LIB flatcc)
+endif()
+
 target_link_libraries(mps_executor_runner bundled_program
                                           executorch gflags
+                                          etdump
+                                          ${FLATCC_LIB}
                                           mpsdelegate
                                           ${mps_executor_runner_libs})
 target_compile_options(mps_executor_runner PUBLIC ${_common_compile_options})

--- a/examples/apple/mps/executor_runner/targets.bzl
+++ b/examples/apple/mps/executor_runner/targets.bzl
@@ -27,6 +27,7 @@ def define_common_targets():
                 "//executorch/extension/data_loader:file_data_loader",
                 "//executorch/kernels/portable:generated_lib_all_ops",
                 "//executorch/extension/data_loader:file_data_loader",
+                "//executorch/sdk/etdump:etdump_flatcc",
                 "//executorch/extension/data_loader:buffer_data_loader",
                 "//executorch/sdk/bundled_program:runtime",
                 "//executorch/util:util",

--- a/examples/apple/mps/scripts/mps_example.py
+++ b/examples/apple/mps/scripts/mps_example.py
@@ -5,6 +5,7 @@
 
 # Example script for exporting simple models to flatbuffer
 
+import copy
 import argparse
 import logging
 
@@ -13,6 +14,11 @@ from executorch import exir
 from executorch.backends.apple.mps.mps_preprocess import MPSBackend
 from executorch.exir import EdgeCompileConfig
 
+from executorch.exir import (
+    EdgeCompileConfig,
+    EdgeProgramManager,
+)
+from executorch.sdk import generate_etrecord
 from executorch.exir.backend.backend_api import to_backend
 from executorch.exir.backend.backend_details import CompileSpec
 from executorch.exir.capture._config import ExecutorchBackendConfig
@@ -54,6 +60,15 @@ if __name__ == "__main__":
         default=False,
         help="Flag for bundling inputs and outputs in the final flatbuffer program",
     )
+
+    parser.add_argument(
+        "--generate_etrecord",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Generate ETRecord metadata to link with runtime results (used for profiling)",
+    )
+
     args = parser.parse_args()
 
     if args.model_name not in MODEL_NAME_TO_MODEL:
@@ -68,11 +83,12 @@ if __name__ == "__main__":
     # pre-autograd export. eventually this will become torch.export
     model = export.capture_pre_autograd_graph(model, example_inputs)
 
-    edge = export_to_edge(
+    edge: EdgeProgramManager = export_to_edge(
         model,
         example_inputs,
         edge_compile_config=EdgeCompileConfig(_check_ir_validity=False),
     )
+    edge_program_manager_copy = copy.deepcopy(edge)
 
     compile_specs = [CompileSpec("use_fp16", bytes([args.use_fp16]))]
     lowered_module = to_backend(
@@ -115,5 +131,10 @@ if __name__ == "__main__":
         program_buffer = bundled_program_buffer
     else:
         program_buffer = executorch_program.buffer
+
+    if args.generate_etrecord:
+      etrecord_path = "etrecord.bin"
+      logging.info("generating etrecord.bin")
+      generate_etrecord(etrecord_path, edge_program_manager_copy, executorch_program)
 
     save_pte_program(program_buffer, model_name)


### PR DESCRIPTION
Summary of changes:
- Add `ETRecord` support to `mps_example` script 
- Add `ETDump` support to `mps_runtime`

```bash
# Generates `add_mul_mps_bundled_fp32.pte` and `etrecord.bin`

python3 -m examples.apple.mps.scripts.mps_example --model_name="add_mul" --no-use_fp16 --bundled --generate_etrecord

# Build executor runner 

## Build and install executorch 
cmake -DBUCK2="$BUCK" \
          -DCMAKE_INSTALL_PREFIX=cmake-out \
          -DCMAKE_BUILD_TYPE=Release \
          -DEXECUTORCH_BUILD_SDK=ON \
          -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \
          -DEXECUTORCH_BUILD_MPS=ON \
          -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
          -Bcmake-out .
cmake --build cmake-out -j9 --target install --config Release
CMAKE_PREFIX_PATH="${PWD}/cmake-out/lib/cmake/ExecuTorch;${PWD}/cmake-out/third-party/gflags"

## build mps_executor_runner
rm -rf cmake-out/examples/apple/mps
cmake \
    -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
    -DCMAKE_BUILD_TYPE=Release \
    -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
    -Bcmake-out/examples/apple/mps \
    examples/apple/mps
cmake --build cmake-out/examples/apple/mps -j9 --config Release


# Run executor runner. Generates `etdump.etdp`:
./cmake-out/examples/apple/mps/mps_executor_runner --model_path add_mul_mps_bundled_fp32.pte --bundled_program --dump_output

# Run the inspector cli tool to print the profiling results
python3 -m sdk.inspector.inspector_cli --etdump_path etdump.etdp --etrecord_path etrecord.bin
╒════╤════════════════════╤══════════════════════╤════════════╤════════════╤════════════╤════════════╤════════════╤════════════╤════════════╤═══════════════════╤═════════════════════════╕
│    │ event_block_name   │ event_name           │   p10 (ms) │   p50 (ms) │   p90 (ms) │   avg (ms) │   min (ms) │   max (ms) │ op_types   │ is_delegated_op   │ delegate_backend_name   │
╞════╪════════════════════╪══════════════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪═══════════════════╪═════════════════════════╡
│  0 │ Default            │ Method::init         │   16.7222  │    16.7222 │    16.7222 │    16.7222 │  16.7222   │    16.7222 │ []         │ False             │                         │
├────┼────────────────────┼──────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼───────────────────┼─────────────────────────┤
│  1 │ Default            │ Program::load_method │   16.7285  │    16.7285 │    16.7285 │    16.7285 │  16.7285   │    16.7285 │ []         │ False             │                         │
├────┼────────────────────┼──────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼───────────────────┼─────────────────────────┤
│  2 │ Execute            │ DELEGATE_CALL        │    4.20317 │    19.4712 │    34.7392 │    19.4712 │   0.386167 │    38.5562 │ []         │ False             │                         │
├────┼────────────────────┼──────────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼───────────────────┼─────────────────────────┤
│  3 │ Execute            │ Method::execute      │    4.21082 │    19.4848 │    34.7587 │    19.4848 │   0.392333 │    38.5772 │ []         │ False             │                         │
╘════╧════════════════════╧══════════════════════╧════════════╧════════════╧════════════╧════════════╧════════════╧════════════╧════════════╧═══════════════════╧═════════════════════════╛
```

cc @tarun292, @kimishpatel, @shoumikhin, @larryliu0820, @cccclai