### PR TITLE
[MPS] Add support for MPS partitioner

### DIFF
--- a/backends/apple/mps/partition/mps_partitioner.py
+++ b/backends/apple/mps/partition/mps_partitioner.py
@@ -4,63 +4,81 @@
 #
 
 import logging
+from typing import Any, Dict, List, Union
 
 import torch
+from executorch.backends.apple.mps.mps_preprocess import MPSBackend
+from executorch.backends.apple.mps.operators.node_visitor import get_node_visitors
+from executorch.exir.backend.backend_details import CompileSpec
+from executorch.exir.backend.canonical_partitioners.pattern_op_partitioner import (
+    generate_partitions_from_list_of_nodes,
+)
 from executorch.exir.backend.partitioner import (
     DelegationSpec,
     Partitioner,
     PartitionResult,
 )
-
 from torch._export.exported_program import ExportedProgram
-from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
+from torch.fx.passes.infra.partitioner import Partition
 from torch.fx.passes.operator_support import OperatorSupportBase
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
+FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
+logging.basicConfig(level=logging.DEBUG, format=FORMAT)
 
 
-class OperatorsSupportedForMpsBackend(OperatorSupportBase):
+class MPSOperatorSupport(OperatorSupportBase):
+    def __init__(self, edge_program: torch.export.ExportedProgram, compiler_specs):
+        self.node_visitors = get_node_visitors(edge_program)
+
     def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
-        supported_mps_ops = [
-            torch.ops.aten.add.Tensor,
-            torch.ops.aten.mm.default,
-            torch.ops.aten.div.default,
-        ]
-        ret_val = (
-            (node.op == "call_function" and node.target in supported_mps_ops)
-            or node.op == "get_attr"
-            or node.op == "output"
-        )
-        return ret_val
+        if node.op != "call_function":
+            return False
+
+        if node.target.__name__ not in self.node_visitors:
+            logging.debug(f"[UNSUPPORTED] Node {node.target.__name__} not supported")
+            return False
+
+        return True
 
 
-# TODO MPSPartitioner is work in progress currently.
-# Use whole graph delegation instead when lowering to MPS.
 class MPSPartitioner(Partitioner):
-    compile_spec = []
+    def __init__(self, compile_specs: List[CompileSpec]) -> None:
+        self.compile_specs = compile_specs
+        self.delegation_spec = DelegationSpec(MPSBackend.__name__, compile_specs)
+        self.partition_tags: Dict[str, DelegationSpec] = {}
 
-    def __init__(self) -> None:
-        self.delegation_spec = DelegationSpec("MPSBackend", self.compile_spec)
-
-    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
-        # Run the CapabilityBasedPartitioner to return the largest possible
-        # subgraphs containing the nodes with the tags
-        logger.info("MpsPartitioner::partition")
-        partition_tags = {}
-
-        capability_partitioner = CapabilityBasedPartitioner(
-            exported_program.graph_module,
-            OperatorsSupportedForMpsBackend(),
-            allows_single_node_partition=True,
+    def generate_partitions(self, edge_program: ExportedProgram) -> List[Any]:
+        self.supported_ops = MPSOperatorSupport(
+            edge_program=edge_program, compiler_specs=self.delegation_spec.compile_specs
         )
-        partition_list = capability_partitioner.propose_partitions()
-        for partition in partition_list:
+        return generate_partitions_from_list_of_nodes(
+            edge_program.graph_module,
+            op_support=self.supported_ops,
+        )
+
+    def tag_nodes(self, partitions: List[Partition]) -> None:
+        for partition in partitions:
             for node in partition.nodes:
-                tag = f"tag{partition.id}"
-                node.meta["delegation_tag"] = tag
-                partition_tags[tag] = self.delegation_spec
+                delegation_tag = f"mps_{partition.id}"
+                node.meta["delegation_tag"] = delegation_tag
+                self.partition_tags[delegation_tag] = self.delegation_spec
 
-        return PartitionResult(
-            tagged_exported_program=exported_program, partition_tags=partition_tags
+    @staticmethod
+    def check_partitions(partitions: Union[dict, list]) -> bool:
+        pl = len(partitions)
+        if pl == 0:
+            logging.warning("Nothing can be partitioned!")
+        else:
+            logging.info(f"Found {pl} subgraphs to be partitioned.")
+        return pl != 0
+
+    # override
+    def partition(self, edge_program: ExportedProgram) -> PartitionResult:
+        partitions = self.generate_partitions(edge_program=edge_program)
+        if self.check_partitions(partitions):
+            self.tag_nodes(partitions)
+        x = PartitionResult(
+            tagged_exported_program=edge_program, partition_tags=self.partition_tags
         )
+
+        return x

--- a/examples/apple/mps/CMakeLists.txt
+++ b/examples/apple/mps/CMakeLists.txt
@@ -31,6 +31,11 @@ if(NOT EXECUTORCH_ROOT)
   set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 endif()
 
+# Source root directory for pytorch.
+if(NOT TORCH_ROOT)
+  set(TORCH_ROOT ${EXECUTORCH_ROOT}/third-party/pytorch)
+endif()
+
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 
 set(_common_compile_options -Wno-deprecated-declarations -fPIC)
@@ -54,6 +59,16 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
   # mps_executor_runner: Like executor_runner but with MPS, the binary will
   # be at ${CMAKE_BINARY_DIR}/examples/apple/executor_runner/mps
   #
+
+# portable_ops_lib
+include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
+gen_selected_ops("" "" "ON")
+generate_bindings_for_kernels(
+  ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml ""
+)
+gen_operators_lib("portable_ops_lib" portable_kernels executorch)
+
 set(mps_executor_runner_libs "-framework Foundation"
                               "-weak_framework MetalPerformanceShaders"
                               "-weak_framework MetalPerformanceShadersGraph"
@@ -84,6 +99,7 @@ add_executable(mps_executor_runner ${_mps_executor_runner__srcs})
 target_link_libraries(mps_executor_runner bundled_program
                                           executorch gflags
                                           mpsdelegate
+                                          portable_ops_lib
                                           ${mps_executor_runner_libs})
 target_compile_options(mps_executor_runner PUBLIC ${_common_compile_options})
 endif()


### PR DESCRIPTION
Add support for **MPS Partitioner** (currently it partitions the nodes based on supported operators).

```bash
# AOT:
python3 -m unittest backends.apple.mps.test.test_mps --verbose -k test_mps_backend_partitioner

# Runtime
./cmake-out/examples/apple/mps/mps_executor_runner --model_path mps_backend_partitioner.pte --bundled_program -num_runs 0
```

cc @shoumikhin, @cccclai, @larryliu0820