### PR TITLE
Fix #pyre-strict lint error in two files and add type error comments

### DIFF
--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pye-strict
+# pyre-strict
 
 import typing
 import unittest
@@ -47,10 +47,15 @@ from torch.export import Dim, export
 
 
 class WrapperModule(torch.nn.Module):
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
     def __init__(self, fn):
         super().__init__()
+        # pyre-fixme[4]: Attribute must be annotated.
         self.fn = fn
 
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
     def forward(self, *args, **kwargs):
         return self.fn(*args, **kwargs)
 
@@ -921,7 +926,9 @@ class TestEmit(unittest.TestCase):
         inputs = (torch.ones(10, 5),)
 
         def make_program(
+            # pyre-fixme[2]: Parameter must be annotated.
             fn,
+            # pyre-fixme[2]: Parameter must be annotated.
             inputs,
         ) -> "ExecutorchProgramManager":
             return to_edge(

--- a/exir/passes/__init__.py
+++ b/exir/passes/__init__.py
@@ -464,6 +464,7 @@ def dead_code_elimination_pass(graph_module: torch.fx.GraphModule) -> PassResult
 
 # Passes to convert a graph module from ATen to Edge IR
 
+# pyre-fixme[5]: Global expression must be annotated.
 pre_op_replace_passes = PassManager(
     passes=[
         # ReplaceSymSizeOpPass need to be run before other passes which inherits
@@ -479,6 +480,7 @@ pre_op_replace_passes = PassManager(
     ]
 ).passes
 
+# pyre-fixme[5]: Global expression must be annotated.
 post_op_replace_passes = PassManager(
     passes=[
         dead_code_elimination_pass,

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -75,6 +75,7 @@ def _get_updated_graph_signature(
         arg = (
             old_input_spec.arg
             if isinstance(old_input_spec.arg, ConstantArgument)
+            # pyre-fixme[20]: Argument `class_fqn` expected.
             else type(old_input_spec.arg)(node.name)
         )
         new_input_specs.append(
@@ -94,6 +95,7 @@ def _get_updated_graph_signature(
         arg = (
             old_output_spec.arg
             if isinstance(old_output_spec.arg, ConstantArgument)
+            # pyre-fixme[20]: Argument `class_fqn` expected.
             else type(old_output_spec.arg)(node.name)
         )
         new_output_specs.append(

--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pye-strict
+# pyre-strict
 
 import unittest
 from typing import Any, Dict
@@ -38,12 +38,16 @@ lib.define("foo(Tensor self, Tensor other) -> Tensor")
 
 
 @impl(lib, "foo", "CPU")
+# pyre-fixme[3]: Return type must be annotated.
+# pyre-fixme[2]: Parameter must be annotated.
 def foo(a, b):
     # do nothing and return a.
     return a + b
 
 
 @impl(lib, "foo", "Meta")
+# pyre-fixme[3]: Return type must be annotated.
+# pyre-fixme[2]: Parameter must be annotated.
 def foo_meta(a, b):
     # do nothing and return a.
     return torch.empty_like(a)
@@ -79,9 +83,11 @@ def get_exported_programs() -> Dict[str, ExportedProgram]:
 
 
 def get_config_methods() -> Dict[str, Any]:
+    # pyre-fixme[3]: Return type must be annotated.
     def bam():
         return 3
 
+    # pyre-fixme[3]: Return type must be annotated.
     def bar():
         return "bar"
 
@@ -89,6 +95,8 @@ def get_config_methods() -> Dict[str, Any]:
 
 
 class AddToMulPassEdge(ExportPass):
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
     def call_operator(self, op, args, kwargs, meta):
         if op == exir_ops.edge.aten.add.Tensor:
             return super().call_operator(
@@ -99,6 +107,7 @@ class AddToMulPassEdge(ExportPass):
 
 
 class TestProgramManagers(unittest.TestCase):
+    # pyre-fixme[3]: Return type must be annotated.
     def test_edge_manager_basic_api(self):
         edge_manager: EdgeProgramManager = to_edge(
             get_exported_programs(), get_config_methods()
@@ -115,8 +124,10 @@ class TestProgramManagers(unittest.TestCase):
             )
             EXIREdgeDialectVerifier()(edge_manager.exported_program("foo").graph_module)
         except ExportError as e:
+            # pyre-fixme[16]: `ExportError` has no attribute `msg`.
             self.assertTrue(False, msg="Graph not in edge dialect : " + e.msg)
 
+    # pyre-fixme[3]: Return type must be annotated.
     def test_executorch_manager_basic_api(self):
         executorch_manager: ExecutorchProgramManager = to_edge(
             get_exported_programs(), get_config_methods()
@@ -150,6 +161,7 @@ class TestProgramManagers(unittest.TestCase):
             3,
         )
 
+    # pyre-fixme[3]: Return type must be annotated.
     def test_edge_manager_transform(self):
         edge_manager: EdgeProgramManager = to_edge(
             get_exported_programs(), get_config_methods()
@@ -183,6 +195,7 @@ class TestProgramManagers(unittest.TestCase):
             original_res,  # x * y + x
         )
 
+    # pyre-fixme[3]: Return type must be annotated.
     def test_transform_dict_api(self):
         edge_manager = to_edge(get_exported_programs(), get_config_methods())
 
@@ -206,6 +219,7 @@ class TestProgramManagers(unittest.TestCase):
             torch.ones(1) + 1,  # x + 1
         )
 
+    # pyre-fixme[3]: Return type must be annotated.
     def test_edge_to_backend_replaces_subgraph(self):
         edge_manager: EdgeProgramManager = to_edge(
             get_exported_programs(), get_config_methods()
@@ -268,6 +282,7 @@ class TestProgramManagers(unittest.TestCase):
             1,
         )
 
+    # pyre-fixme[3]: Return type must be annotated.
     def test_edge_to_backend_selective(self):
         edge_manager: EdgeProgramManager = to_edge(
             get_exported_programs(), get_config_methods()
@@ -320,12 +335,15 @@ class TestProgramManagers(unittest.TestCase):
             1,
         )
 
+    # pyre-fixme[3]: Return type must be annotated.
     def test_edge_manager_dialect(self):
         edge_manager: EdgeProgramManager = to_edge(
             get_exported_programs(), get_config_methods()
         )
         self.assertTrue(edge_manager.exported_program().dialect == "EDGE")
 
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
     def _test_edge_dialect_verifier(self, callable, validate_ir=True):
         from executorch.exir import EdgeCompileConfig
 
@@ -345,7 +363,9 @@ class TestProgramManagers(unittest.TestCase):
         exported_foo = export(callable, inputs)
         _ = to_edge(exported_foo, compile_config=edge_compile_config)
 
+    # pyre-fixme[3]: Return type must be annotated.
     def test_edge_dialect_custom_op(self):
+        # pyre-fixme[3]: Return type must be annotated.
         def _use_foo_add(a: torch.Tensor, b: torch.Tensor):
             return torch.ops.test_op.foo(a, b)
 

--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -699,6 +699,7 @@ class GraphModuleSerializer:
             # serialize/deserialize function.
             custom_obj_name = f"_custom_obj_{len(self.custom_objs)}"
             self.custom_objs[custom_obj_name] = arg
+            # pyre-fixme[20]: Argument `class_fqn` expected.
             return Argument.create(as_custom_obj=CustomObjArgument(custom_obj_name))
         else:
             raise SerializeError(f"Unsupported argument type: {type(arg)}")

--- a/exir/tests/models.py
+++ b/exir/tests/models.py
@@ -193,6 +193,7 @@ class TensorSplit(nn.Module):
         super().__init__()
 
     def forward(self, input: Tensor, sections: int, dim: int = 0) -> List[Tensor]:
+        # pyre-fixme[7]: Expected `List[Tensor]` but got `Tuple[Tensor, ...]`.
         return torch.tensor_split(input, sections, dim)
 
 


### PR DESCRIPTION
Summary:
Fix #pyre-strict  linting error using the PyreStrictLinter and silencing the resulting type errors using

 pyre -l path_to_file
 --output=json check | pyre-upgrade fixme

Differential Revision: D53208789


