### PR TITLE
Fix build failures

### DIFF
--- a/backends/apple/coreml/runtime/delegate/backend_delegate.h
+++ b/backends/apple/coreml/runtime/delegate/backend_delegate.h
@@ -6,6 +6,7 @@
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
 #include <system_error>
+#include <unordered_map>
 #include <vector>
 
 namespace executorchcoreml {

--- a/backends/apple/coreml/runtime/kvstore/database.hpp
+++ b/backends/apple/coreml/runtime/kvstore/database.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <bitset>
+#include <functional>
 #include <memory>
 #include <string>
 #include <system_error>

--- a/backends/apple/coreml/runtime/kvstore/key_value_store.hpp
+++ b/backends/apple/coreml/runtime/kvstore/key_value_store.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#import <functional>
 #include <optional>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Problem
`util::PrepareInputTensors` is deprecated and is unavailable when linking to `executorch.a`.  This is causing build failures.

Solution
Remove the `util::PrepareInputTensors` call and set the method input using a `std::vector` as the data storage.  