### PR TITLE
free segments for mps delegate

### DIFF
--- a/examples/apple/mps/scripts/mps_example.py
+++ b/examples/apple/mps/scripts/mps_example.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
             )
             .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
             .to_executorch(
-                config=ExecutorchBackendConfig(extract_constant_segment=False)
+                config=ExecutorchBackendConfig(extract_constant_segment=False, extract_delegate_segments=True)
             )
         )
 


### PR DESCRIPTION
It should be safe to free the delegate payload for mps backend, given that https://github.com/pytorch/executorch/blob/main/backends/apple/mps/runtime/MPSBackend.mm#L50-L51 mps backend is using flatbuffers as the serialization format for the payload and free inside the init() already there.

Differential Revision: D53240454


