### PR TITLE
Refactor export_llama_lib.py to serialize more constants for kv cache

### DIFF
--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -96,7 +96,6 @@ class ModelArgs:
     num_activated_experts: int = 2  # Number of experts to activate
     use_kv_cache: bool = False  # Use key/value cache
     # Additional Model Metadata needed at runtime
-    vocab_size: int = 256206
     bos_idx: int = 1
     eos_idx: int = 3
     bos_count: int = -1  # i.e., a single EOS is used as BOS

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -409,7 +409,8 @@ struct PyModule final {
     cpp_inputs.reserve(inputs_size);
 
 #ifndef USE_ATEN_LIB // Portable mode
-    // So the ETensors and their metadata stay in scope for Module->run_method.
+    // So the ETensors and their metadata stay in scope for
+    // Module->run_method.
     std::vector<torch::executor::TensorImpl> input_tensors;
     std::vector<std::vector<torch::executor::Tensor::SizesType>> input_sizes;
     std::vector<std::vector<torch::executor::Tensor::StridesType>>
@@ -691,7 +692,12 @@ PYBIND11_MODULE(EXECUTORCH_PYTHON_MODULE_NAME, m) {
           py::arg("atol") = 1e-8,
           call_guard)
       .def("plan_execute", &PyModule::plan_execute, call_guard)
-      .def("run_method", &PyModule::run_method, call_guard)
+      .def(
+          "run_method",
+          &PyModule::run_method,
+          py::arg("method_name"),
+          py::arg("inputs") = py::list(),
+          call_guard)
       .def("forward", &PyModule::forward, call_guard)
       .def("has_etdump", &PyModule::has_etdump, call_guard)
       .def(


### PR DESCRIPTION
Summary: As titled. K cache (and V cache) is a tensor of shape (batch_size, max_seq_len, n_kv_heads, head_dim) for each layer. For the current llama_runner.cpp setup, we are going to prepare the KV cache inside the runner in C++. Therefore we need to get these numbers from the .pte file. This adds support for that.

Reviewed By: JacobSzwejbka

Differential Revision: D53202215


