### PR TITLE
Support empty inputs into executorch method

### DIFF
--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -409,7 +409,8 @@ struct PyModule final {
     cpp_inputs.reserve(inputs_size);
 
 #ifndef USE_ATEN_LIB // Portable mode
-    // So the ETensors and their metadata stay in scope for Module->run_method.
+    // So the ETensors and their metadata stay in scope for
+    // Module->run_method.
     std::vector<torch::executor::TensorImpl> input_tensors;
     std::vector<std::vector<torch::executor::Tensor::SizesType>> input_sizes;
     std::vector<std::vector<torch::executor::Tensor::StridesType>>
@@ -691,7 +692,12 @@ PYBIND11_MODULE(EXECUTORCH_PYTHON_MODULE_NAME, m) {
           py::arg("atol") = 1e-8,
           call_guard)
       .def("plan_execute", &PyModule::plan_execute, call_guard)
-      .def("run_method", &PyModule::run_method, call_guard)
+      .def(
+          "run_method",
+          &PyModule::run_method,
+          py::arg("method_name"),
+          py::arg("inputs") = py::list(),
+          call_guard)
       .def("forward", &PyModule::forward, call_guard)
       .def("has_etdump", &PyModule::has_etdump, call_guard)
       .def(


### PR DESCRIPTION
Summary: As titled. With constant method support, we are able to serialize a constant method that returns a constant without any input. In our python binding we want to support this feature.

Reviewed By: mikekgfb

Differential Revision: D53201972


