### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/examples/demo-apps/android/ExecuTorchDemo/app/src/main/java/com/example/executorchdemo/ImageNetClasses.java
+++ b/examples/demo-apps/android/ExecuTorchDemo/app/src/main/java/com/example/executorchdemo/ImageNetClasses.java
@@ -191,7 +191,8 @@ public class ImageNetClasses {
         "Scottish deerhound, deerhound",
         "Weimaraner",
         "Staffordshire bullterrier, Staffordshire bull terrier",
-        "American Staffordshire terrier, Staffordshire terrier, American pit bull terrier, pit bull terrier",
+        "American Staffordshire terrier, Staffordshire terrier, American pit bull terrier, pit bull"
+            + " terrier",
         "Bedlington terrier",
         "Border terrier",
         "Kerry blue terrier",
@@ -330,7 +331,8 @@ public class ImageNetClasses {
         "cicada, cicala",
         "leafhopper",
         "lacewing, lacewing fly",
-        "dragonfly, darning needle, devil's darning needle, sewing needle, snake feeder, snake doctor, mosquito hawk, skeeter hawk",
+        "dragonfly, darning needle, devil's darning needle, sewing needle, snake feeder, snake"
+            + " doctor, mosquito hawk, skeeter hawk",
         "damselfly",
         "admiral",
         "ringlet, ringlet butterfly",
@@ -360,7 +362,8 @@ public class ImageNetClasses {
         "water buffalo, water ox, Asiatic buffalo, Bubalus bubalis",
         "bison",
         "ram, tup",
-        "bighorn, bighorn sheep, cimarron, Rocky Mountain bighorn, Rocky Mountain sheep, Ovis canadensis",
+        "bighorn, bighorn sheep, cimarron, Rocky Mountain bighorn, Rocky Mountain sheep, Ovis"
+            + " canadensis",
         "ibex, Capra ibex",
         "hartebeest",
         "impala, Aepyceros melampus",
@@ -423,7 +426,8 @@ public class ImageNetClasses {
         "analog clock",
         "apiary, bee house",
         "apron",
-        "ashcan, trash can, garbage can, wastebin, ash bin, ash-bin, ashbin, dustbin, trash barrel, trash bin",
+        "ashcan, trash can, garbage can, wastebin, ash bin, ash-bin, ashbin, dustbin, trash barrel,"
+            + " trash bin",
         "assault rifle, assault gun",
         "backpack, back pack, knapsack, packsack, rucksack, haversack",
         "bakery, bakeshop, bakehouse",
@@ -491,7 +495,8 @@ public class ImageNetClasses {
         "carpenter's kit, tool kit",
         "carton",
         "car wheel",
-        "cash machine, cash dispenser, automated teller machine, automatic teller machine, automated teller, automatic teller, ATM",
+        "cash machine, cash dispenser, automated teller machine, automatic teller machine,"
+            + " automated teller, automatic teller, ATM",
         "cassette",
         "cassette player",
         "castle",
@@ -997,7 +1002,8 @@ public class ImageNetClasses {
         "scuba diver",
         "rapeseed",
         "daisy",
-        "yellow lady's slipper, yellow lady-slipper, Cypripedium calceolus, Cypripedium parviflorum",
+        "yellow lady's slipper, yellow lady-slipper, Cypripedium calceolus, Cypripedium"
+            + " parviflorum",
         "corn",
         "acorn",
         "hip, rose hip, rosehip",

--- a/extension/android/src/main/java/org/pytorch/executorch/EValue.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/EValue.java
@@ -136,6 +136,7 @@ public class EValue {
     iv.mData = tensor;
     return iv;
   }
+
   /** Creates a new {@code EValue} of type {@code bool}. */
   @DoNotStrip
   public static EValue from(boolean value) {

--- a/extension/android/src/main/java/org/pytorch/executorch/Tensor.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/Tensor.java
@@ -362,7 +362,9 @@ public abstract class Tensor {
     return Arrays.copyOf(shape, shape.length);
   }
 
-  /** @return data type of this tensor. */
+  /**
+   * @return data type of this tensor.
+   */
   public abstract DType dtype();
 
   // Called from native
@@ -646,6 +648,7 @@ public abstract class Tensor {
         numel,
         Arrays.toString(shape));
   }
+
   // endregion checks
 
   // Called from native


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/flipper/pull/5456

X-link: https://github.com/facebook/hermes/pull/1290

X-link: https://github.com/facebook/TextLayoutBuilder/pull/35

X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


