### PR TITLE
support non-persistent buffers (#1769)

### DIFF
--- a/exir/lowered_backend_module.py
+++ b/exir/lowered_backend_module.py
@@ -398,6 +398,8 @@ def _get_new_signature(
     )
     new_state_dict = {}
 
+    non_persistent_buffers = set(old_signature.non_persistent_buffers)
+
     for node in gm.graph.nodes:
         if node.op == "placeholder":
             if node.name in old_signature.inputs_to_parameters:
@@ -423,6 +425,7 @@ def _get_new_signature(
                         kind=InputKind.BUFFER,
                         arg=TensorArgument(name=node.name),
                         target=buffer_name,
+                        persistent=buffer_name not in non_persistent_buffers,
                     )
                 )
 

--- a/exir/passes/constant_prop_pass.py
+++ b/exir/passes/constant_prop_pass.py
@@ -108,6 +108,7 @@ def constant_prop_pass(exported_program: ExportedProgram) -> ExportedProgram:
                         kind=InputKind.BUFFER,
                         arg=TensorArgument(name=const_placeholder_node.name),
                         target=prop_constant_tensor_fqn,
+                        persistent=True,
                     )
                     prop_constant_data.append(prop_constant_node_input_spec)
                     buffers.append(prop_constant_tensor_fqn)

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -78,7 +78,12 @@ def _get_updated_graph_signature(
             else type(old_input_spec.arg)(node.name)
         )
         new_input_specs.append(
-            InputSpec(old_input_spec.kind, arg, old_input_spec.target)
+            InputSpec(
+                old_input_spec.kind,
+                arg,
+                old_input_spec.target,
+                persistent=old_input_spec.persistent,
+            )
         )
         i += 1
 
@@ -196,6 +201,7 @@ def lift_constant_tensor_pass(ep):
                         kind=InputKind.BUFFER,
                         arg=TensorArgument(name=const_placeholder_node.name),
                         target=constant_tensor_fqn,
+                        persistent=True,
                     )
                 )
                 buffers.append(constant_tensor_fqn)

--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -739,6 +739,7 @@ class GraphModuleSerializer:
                 buffer=InputToBufferSpec(
                     arg=TensorArgument(name=spec.arg.name),
                     buffer_name=spec.target,  # pyre-ignore
+                    persistent=spec.persistent,  # pyre-ignore
                 )
             )
         elif spec.kind == ep.InputKind.CONSTANT_TENSOR:

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -617,8 +617,12 @@ class TestPasses(unittest.TestCase):
         model: torch.nn.Linear = torch.nn.Linear(5, 5)
 
         class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.model = model
+
             def forward(self, inp: torch.Tensor) -> torch.Tensor:
-                return model(inp)
+                return self.model(inp)
 
         f = Foo()
 

--- a/test/end2end/exported_module.py
+++ b/test/end2end/exported_module.py
@@ -159,9 +159,9 @@ class ExportedModule:
         # These cleanup passes are required to convert the `add` op to its out
         # variant, along with some other transformations.
         for method_name, method_input in method_name_to_args.items():
-            module = WrapperModule(getattr(eager_module, method_name))
+            # if not isinstance(eager_module, torch.nn.Module):
             exported_methods[method_name] = export(
-                module,
+                eager_module,
                 method_input,
                 constraints=method_name_to_constraints[method_name]
                 if method_name_to_constraints


### PR DESCRIPTION
Summary:

X-link: https://github.com/pytorch/pytorch/pull/118612

Basic support for non-persistent buffers, which are buffers that do not show up in the state dict.

One weird twist is that most of our other systems (FX, aot_export, dynamo) have completely buggy handling of non-persistent buffers. I tried to go on a wild goose chase to fix them all, but it got to be too much. So I introduced some sad rewrite passes in `_export` make the final state dict correctly align with the original module's state dict.

This exposed some bugs/ambiguous handling of parameters/buffers in existing test code. For example, `TestSaveLoad.test_save_buffer` traced over a module that was not in the root module hierarchy and caused some weird behavior. I think we should error explicitly on use cases like this: https://github.com/pytorch/pytorch/issues/118410. For now I just rewrote the tests or skipped them.

Differential Revision: D53253905


