### PR TITLE
[Executorch][llama2] Remove redundant xnnpack path

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -212,6 +212,8 @@ def export_llama(modelname, args) -> str:
             edge_compile_config=edge_config,
         )
     if args.xnnpack:
+        if args.half:
+            raise RuntimeError("XNNPACK does not support fp16")
         edge_manager = edge_manager.to_backend(XnnpackPartitioner())
         modelname = f"xnnpack_{modelname}"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1783
* #1782
* #1781
* __->__ #1780

as titile
plus throw when xnnpack plus fp16 requested

Differential Revision: [D53254871](https://our.internmc.facebook.com/intern/diff/D53254871/)