### PR TITLE
Add mixed mm op

### DIFF
--- a/exir/passes/_quant_patterns_and_replacements.py
+++ b/exir/passes/_quant_patterns_and_replacements.py
@@ -31,6 +31,10 @@ quantized_decomposed_lib.define(
 )
 
 quantized_decomposed_lib.define(
+    "mixed_mm(Tensor input, Tensor weight, Tensor weight_scales, Tensor? weight_zero_points) -> Tensor",
+)
+
+quantized_decomposed_lib.define(
     "add(Tensor a, float a_scale, int a_zero_point, int a_quant_min, int a_quant_max, Tensor b, float b_scale, int b_zero_point, int b_quant_min, int b_quant_max, float out_scale, int out_zero_point, int out_quant_min, int out_quant_max) -> Tensor qc"
 )
 

--- a/kernels/portable/cpu/vec_ops.h
+++ b/kernels/portable/cpu/vec_ops.h
@@ -83,6 +83,26 @@ inline void vec_matmul(
   }
 }
 
+template <typename T, typename U = T>
+inline void vec_quantized_matmul_int8(
+    T* __restrict__ z,
+    const U* __restrict__ x,
+    const int8_t* __restrict__ y,
+    const U* __restrict__ s,
+    int64_t m,
+    int64_t n,
+    int64_t p) {
+  for (size_t i = 0; i < m; ++i) {
+    for (size_t j = 0; j < p; ++j) {
+      T sum = 0;
+      for (size_t k = 0; k < n; ++k) {
+        sum += x[i * n + k] * y[k * p + j] * s[k];
+      }
+      z[i * p + j] = sum;
+    }
+  }
+}
+
 // mat1 (m x n), mat2 (n x p), out (m, p), self (m x p)
 // z[i][j] = sum(x[i][k] * y[k][j]), for k in range(n)
 // T for tensor dtype, U for scalar type

--- a/kernels/quantized/cpu/op_mixed_mm.cpp
+++ b/kernels/quantized/cpu/op_mixed_mm.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/kernels/portable/cpu/vec_ops.h>
+#include <executorch/runtime/kernel/kernel_includes.h>
+
+namespace torch {
+namespace executor {
+namespace native {
+
+using Tensor = exec_aten::Tensor;
+
+bool check_quantized_mixed_mm_args(
+    const Tensor& in,
+    const Tensor& weight,
+    const Tensor& weight_scales,
+    const optional<Tensor>& opt_weight_zero_points,
+    Tensor& out) {
+  ET_LOG_AND_RETURN_IF_FALSE(tensor_is_rank(in, 2));
+  ET_LOG_AND_RETURN_IF_FALSE(tensor_is_rank(weight, 2));
+  ET_LOG_AND_RETURN_IF_FALSE(tensor_is_rank(weight_scales, 1));
+  ET_LOG_AND_RETURN_IF_FALSE(tensor_is_rank(out, 2));
+
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_size_at_dims(in, 1, weight, 0));
+  ET_LOG_AND_RETURN_IF_FALSE(
+      tensors_have_same_size_at_dims(weight_scales, 0, weight, 0));
+
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, weight_scales, out));
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      weight.scalar_type() == ScalarType::Char, "weight dtype must be int8");
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      in.scalar_type() == ScalarType::Float ||
+          in.scalar_type() == ScalarType::Half,
+      "input dtype must be Float or Half");
+
+  if (opt_weight_zero_points.has_value()) {
+    ET_LOG_AND_RETURN_IF_FALSE(
+        tensors_have_same_shape(opt_weight_zero_points.value(), weight_scales));
+    ET_LOG_AND_RETURN_IF_FALSE(
+        tensors_have_same_dtype(opt_weight_zero_points.value(), in));
+  }
+
+  // Support for non-null zero points is not implemented yet.
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      !opt_weight_zero_points.has_value(), "zero points not supported yet.");
+  return true;
+}
+
+Tensor& quantized_mixed_mm_out(
+    const Tensor& in,
+    const Tensor& weight,
+    const Tensor& weight_scales,
+    const optional<Tensor>& opt_weight_zero_points,
+    Tensor& out) {
+  ET_KERNEL_CHECK(
+      ctx,
+      check_quantized_mixed_mm_args(
+          in, weight, weight_scales, opt_weight_zero_points, out),
+      InvalidArgument,
+      out);
+
+  size_t output_ndim = 2;
+  exec_aten::SizesType output_sizes[kTensorDimensionLimit];
+  output_sizes[0] = in.size(0);
+  output_sizes[1] = weight.size(1);
+
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, {output_sizes, output_ndim}) == Error::Ok,
+      InvalidArgument,
+      out);
+
+  constexpr auto name = "quantized_decomposed::mixed_mm.out";
+
+  ET_SWITCH_TWO_TYPES(Float, Half, in.scalar_type(), ctx, name, CTYPE, [&]() {
+    size_t m = in.size(0);
+    size_t n = in.size(1);
+    size_t p = weight.size(1);
+
+    vec_quantized_matmul_int8<CTYPE>(
+        out.mutable_data_ptr<CTYPE>(),
+        in.const_data_ptr<CTYPE>(),
+        weight.const_data_ptr<int8_t>(),
+        weight_scales.const_data_ptr<CTYPE>(),
+        m,
+        n,
+        p);
+  });
+
+  return out;
+}
+
+Tensor& quantized_mixed_mm_out(
+    RuntimeContext& ctx,
+    const Tensor& in,
+    const Tensor& weight,
+    const Tensor& weight_scales,
+    const optional<Tensor>& opt_weight_zero_points,
+    Tensor& out) {
+  // TODO(mcandales): Remove the need for this wrapper
+  (void)ctx;
+  return quantized_mixed_mm_out(
+      in, weight, weight_scales, opt_weight_zero_points, out);
+}
+
+} // namespace native
+} // namespace executor
+} // namespace torch

--- a/kernels/quantized/cpu/targets.bzl
+++ b/kernels/quantized/cpu/targets.bzl
@@ -24,6 +24,12 @@ _QUANT_OPS = (
         name = "op_embedding",
     ),
     op_target(
+        name = "op_mixed_mm",
+        deps = [
+            "//executorch/kernels/portable/cpu:vec_ops",
+        ],
+    ),
+    op_target(
         name = "op_quantize",
         deps = [
             "//executorch/kernels/portable/cpu/util:reduce_util",

--- a/kernels/quantized/quantized.yaml
+++ b/kernels/quantized/quantized.yaml
@@ -40,6 +40,12 @@
     - arg_meta: null
       kernel_name: torch::executor::quantized_embedding_byte_out
 
+- func: quantized_decomposed::mixed_mm.out(Tensor input, Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  kernels:
+    - arg_meta: null
+      kernel_name: torch::executor::quantized_mixed_mm_out
+
 - func: quantized_decomposed::quantize_per_tensor.out(Tensor input, float scale, int zero_point, int quant_min, int quant_max, ScalarType dtype, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:

--- a/kernels/quantized/test/op_mixed_mm_test.cpp
+++ b/kernels/quantized/test/op_mixed_mm_test.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/kernels/portable/NativeFunctions.h> // Declares the aten operator
+#include <executorch/kernels/quantized/NativeFunctions.h> // Declares the quantized operator
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using exec_aten::optional;
+using exec_aten::RuntimeContext;
+using exec_aten::ScalarType;
+using exec_aten::Tensor;
+using torch::executor::native::quantized_mixed_mm_out;
+using torch::executor::testing::TensorFactory;
+
+class OpQuantizedMixedMMTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Since these tests cause ET_LOG to be called, the PAL must be initialized
+    // first.
+    torch::executor::runtime_init();
+  }
+};
+
+template <ScalarType DTYPE>
+void test_dtype() {
+  TensorFactory<DTYPE> tf;
+  TensorFactory<ScalarType::Char> tf_char;
+
+  Tensor input = tf.make(
+      /*sizes=*/{1, 3},
+      /*data=*/{1.0, 1.5, 2.0});
+  Tensor weight = tf_char.make(
+      /*sizes=*/{3, 2},
+      /*data=*/{5, 4, 3, 2, 1, 1});
+  Tensor weight_scales = tf.make(
+      /*sizes=*/{3},
+      /*data=*/{0.2, 0.4, 0.5});
+  const optional<Tensor> opt_weight_zp{};
+
+  Tensor out = tf.zeros({1, 2});
+
+  Tensor expected = tf.make(
+      /*sizes=*/{1, 2},
+      /*data=*/{3.8, 3.0});
+
+  RuntimeContext ctx{};
+
+  quantized_mixed_mm_out(ctx, input, weight, weight_scales, opt_weight_zp, out);
+
+  EXPECT_TENSOR_CLOSE(out, expected);
+}
+
+TEST_F(OpQuantizedMixedMMTest, FloatInput) {
+  test_dtype<ScalarType::Float>();
+}
+
+TEST_F(OpQuantizedMixedMMTest, HalfInput) {
+  test_dtype<ScalarType::Half>();
+}

--- a/kernels/quantized/test/targets.bzl
+++ b/kernels/quantized/test/targets.bzl
@@ -25,3 +25,9 @@ def define_common_targets():
         "//executorch/kernels/portable/cpu:op_embedding",
         "//executorch/runtime/core/exec_aten/testing_util:tensor_util",
     ])
+    op_test("op_mixed_mm_test", kernel_name = "quantized", deps = [
+        "//executorch/kernels/quantized/cpu:op_mixed_mm",
+        "//executorch/kernels/quantized:generated_lib_headers",
+        "//executorch/kernels/portable:generated_lib_headers",
+        "//executorch/runtime/core/exec_aten/testing_util:tensor_util",
+    ])


### PR DESCRIPTION
Summary:
This op performs matrix multiplication between a Float/Half `input` tensor, and a quantized int8 `weight` tensor. The op takes a `weight_scales` tensor which must be of the same dtype than the `input`, and an optional `weight_zero_points` tensor, which also must have same dtype than the input.
The output tensor must also be of the same dtype than the input.

Differential Revision: D53283501


