### PR TITLE
Handle tensor memory offsets > 32 bits

### DIFF
--- a/exir/schema.py
+++ b/exir/schema.py
@@ -18,7 +18,14 @@ from executorch.exir.scalar_type import ScalarType
 @dataclass
 class AllocationDetails:
     memory_id: int
-    memory_offset: int
+    # Low 32 bits
+    memory_offset_low: int
+    # High 32 bits (typically zero)
+    memory_offset_high: int
+
+    @property
+    def memory_offset(self) -> int:
+        return self.memory_offset_low | (self.memory_offset_high << 32)
 
 
 @dataclass

--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -286,8 +286,17 @@ def make_allocation_info(mem_id: int, mem_offset: int) -> schema.AllocationDetai
     """
     Creates the allocation_details object for creating tensors
     """
+    if mem_offset < 0:
+        raise ValueError(f"mem_offset {mem_offset} must not be negative")
+    memory_offset_low = mem_offset & ((1 << 32) - 1)
+    memory_offset_high = mem_offset >> 32
+    if memory_offset_high >= 1 << 32:
+        raise ValueError(f"mem_offset {mem_offset} does not fit in 64 bits")
+
     allocation_info = schema.AllocationDetails(
-        memory_id=mem_id, memory_offset=mem_offset
+        memory_id=mem_id,
+        memory_offset_low=memory_offset_low,
+        memory_offset_high=memory_offset_high,
     )
     return allocation_info
 

--- a/exir/tests/common.py
+++ b/exir/tests/common.py
@@ -53,7 +53,9 @@ def get_test_program() -> Program:
                             layout=0,
                             constant_buffer_idx=0,
                             allocation_info=AllocationDetails(
-                                memory_id=1, memory_offset=16
+                                memory_id=1,
+                                memory_offset_high=0,
+                                memory_offset_low=16,
                             ),
                             shape_dynamism=TensorShapeDynamism.STATIC,
                         )

--- a/exir/tests/fixtures/basic_sin_max.txt
+++ b/exir/tests/fixtures/basic_sin_max.txt
@@ -25,7 +25,8 @@
             "constant_buffer_idx": 0,
             "allocation_info": {
               "memory_id": 1,
-              "memory_offset": 0
+              "memory_offset_low": 0,
+              "memory_offset_high": 0
             },
             "layout": 0,
             "shape_dynamism": "STATIC"
@@ -46,7 +47,8 @@
             "constant_buffer_idx": 0,
             "allocation_info": {
               "memory_id": 1,
-              "memory_offset": 400
+              "memory_offset_low": 400,
+              "memory_offset_high": 0
             },
             "layout": 0,
             "shape_dynamism": "STATIC"

--- a/exir/tests/fixtures/composite_delegate.txt
+++ b/exir/tests/fixtures/composite_delegate.txt
@@ -27,7 +27,8 @@
             "constant_buffer_idx": 0,
             "allocation_info": {
               "memory_id": 1,
-              "memory_offset": 0
+              "memory_offset_low": 0,
+              "memory_offset_high": 0
             },
             "layout": 0,
             "shape_dynamism": "STATIC"
@@ -50,7 +51,8 @@
             "constant_buffer_idx": 0,
             "allocation_info": {
               "memory_id": 1,
-              "memory_offset": 16
+              "memory_offset_low": 16,
+              "memory_offset_high": 0
             },
             "layout": 0,
             "shape_dynamism": "STATIC"
@@ -73,7 +75,8 @@
             "constant_buffer_idx": 0,
             "allocation_info": {
               "memory_id": 1,
-              "memory_offset": 32
+              "memory_offset_low": 32,
+              "memory_offset_high": 0
             },
             "layout": 0,
             "shape_dynamism": "STATIC"
@@ -96,7 +99,8 @@
             "constant_buffer_idx": 0,
             "allocation_info": {
               "memory_id": 1,
-              "memory_offset": 48
+              "memory_offset_low": 48,
+              "memory_offset_high": 0
             },
             "layout": 0,
             "shape_dynamism": "STATIC"
@@ -119,7 +123,8 @@
             "constant_buffer_idx": 0,
             "allocation_info": {
               "memory_id": 1,
-              "memory_offset": 0
+              "memory_offset_low": 0,
+              "memory_offset_high": 0
             },
             "layout": 0,
             "shape_dynamism": "STATIC"

--- a/schema/program.fbs
+++ b/schema/program.fbs
@@ -28,7 +28,16 @@ table Null {}
 // memory and at what offset from its base address.
 table AllocationDetails {
   memory_id:uint;  // ID of the memory where this data needs to be placed.
-  memory_offset:uint;  // Offset (in bytes) w.r.t. the memory base address.
+
+  // Offset in bytes relative to the start of the memory area indicated by
+  // memory_id.
+  //
+  // Originally this field was a single 32-bit uint, but we need 64 bits for
+  // larger models. To preserve backwards compatibility, the high bits are
+  // managed in a separate 32-bit field. Users should combine the two fields
+  // to get the full 64-bit offset.
+  memory_offset_low:uint;  // Least significant 32 bits
+  memory_offset_high:uint;  // Most significant 32 bits. Defaults to zero.
 }
 
 // Indicates the types of shape a Tensor may have, from the point


### PR DESCRIPTION
Summary:
The `AllocationDetails.memory_offset` field is declared as a `uint`, so it can only handle offsets of 32 bits (4GB).

Changing the type would break backward compatibility, so instead add a new field for the high 32 bits.

Based on some experimentation, this doesn't seem to increase the size of existing .pte files; there's a decent chance that it's sneaking its way into an alignment hole.

Differential Revision: D53293800


