### PR TITLE
Add Half dtype support

### DIFF
--- a/backends/xnnpack/partition/xnnpack_partitioner.py
+++ b/backends/xnnpack/partition/xnnpack_partitioner.py
@@ -144,6 +144,7 @@ class XnnpackOperatorSupport(OperatorSupportBase):
 
         valid_dtypes = {
             torch.float32,
+            torch.float16,
             torch.int8,
             torch.qint8,
         }
@@ -190,6 +191,7 @@ class XnnpackOperatorSupport(OperatorSupportBase):
             node
         )
 
+    @staticmethod
     def _constraint(target):  # noqa
         """
         Decorator to register a constraint fn for a node

--- a/extension/aten_util/aten_bridge.cpp
+++ b/extension/aten_util/aten_bridge.cpp
@@ -68,6 +68,8 @@ torch::executor::ScalarType torchToExecuTorchScalarType(caffe2::TypeMeta type) {
       return torch::executor::ScalarType::Byte;
     case c10::ScalarType::Char:
       return torch::executor::ScalarType::Char;
+    case c10::ScalarType::Half:
+      return torch::executor::ScalarType::Half;
     case c10::ScalarType::Int:
       return torch::executor::ScalarType::Int;
     case c10::ScalarType::Float:
@@ -93,6 +95,8 @@ c10::ScalarType execuTorchtoTorchScalarType(torch::executor::ScalarType type) {
       return c10::ScalarType::Byte;
     case torch::executor::ScalarType::Char:
       return c10::ScalarType::Char;
+    case torch::executor::ScalarType::Half:
+      return c10::ScalarType::Half;
     case torch::executor::ScalarType::Int:
       return c10::ScalarType::Int;
     case torch::executor::ScalarType::Float:

--- a/schema/scalar_type.fbs
+++ b/schema/scalar_type.fbs
@@ -14,6 +14,7 @@ enum ScalarType : byte {
   SHORT = 2,
   INT = 3,
   LONG = 4,
+  Half = 5,
   FLOAT = 6,
   DOUBLE = 7,
   BOOL = 11,
@@ -24,7 +25,6 @@ enum ScalarType : byte {
   QUINT4X2 = 16,
   QUINT2X4 = 17,
   // Types currently not implemented.
-  // Half = 5,
   // COMPLEXHALF = 8,
   // COMPLEXFLOAT = 9,
   // COMPLEXDOUBLE = 10,


### PR DESCRIPTION
Summary:
Rationale - this was needed to bypass errors while enabling xnnpack fp16 support up the stack.

* Add Half dtype for Aten bridge
* Allow serialization of Half - potentially FC breaking (already have it in [scalar types](https://www.internalfb.com/code/fbsource/[5dd332f406a1be2e184a14f83815a7bfb3a65ccd]/xplat/executorch/runtime/core/portable_type/scalar_type.h?lines=67))

Differential Revision: D53248905


