### PR TITLE
Don't promote fp16 to fp32

### DIFF
--- a/backends/xnnpack/partition/xnnpack_partitioner.py
+++ b/backends/xnnpack/partition/xnnpack_partitioner.py
@@ -144,6 +144,7 @@ class XnnpackOperatorSupport(OperatorSupportBase):
 
         valid_dtypes = {
             torch.float32,
+            torch.float16,
             torch.int8,
             torch.qint8,
         }
@@ -190,6 +191,7 @@ class XnnpackOperatorSupport(OperatorSupportBase):
             node
         )
 
+    @staticmethod
     def _constraint(target):  # noqa
         """
         Decorator to register a constraint fn for a node

--- a/exir/passes/remove_mixed_type_operators.py
+++ b/exir/passes/remove_mixed_type_operators.py
@@ -58,7 +58,7 @@ class RemoveMixedTypeOperators(ExportPass):
         promote_dtype: torch.dtype = elementwise_dtypes(
             *arg_tensor,
             type_promotion_kind=promotion_kind,
-        )[0]
+        )[1]
 
         def try_coerce(value: PyTree, arg: torch.Argument) -> PyTree:
             if type(arg.type) != torch.TensorType:

--- a/extension/aten_util/aten_bridge.cpp
+++ b/extension/aten_util/aten_bridge.cpp
@@ -68,6 +68,8 @@ torch::executor::ScalarType torchToExecuTorchScalarType(caffe2::TypeMeta type) {
       return torch::executor::ScalarType::Byte;
     case c10::ScalarType::Char:
       return torch::executor::ScalarType::Char;
+    case c10::ScalarType::Half:
+      return torch::executor::ScalarType::Half;
     case c10::ScalarType::Int:
       return torch::executor::ScalarType::Int;
     case c10::ScalarType::Float:
@@ -93,6 +95,8 @@ c10::ScalarType execuTorchtoTorchScalarType(torch::executor::ScalarType type) {
       return c10::ScalarType::Byte;
     case torch::executor::ScalarType::Char:
       return c10::ScalarType::Char;
+    case torch::executor::ScalarType::Half:
+      return c10::ScalarType::Half;
     case torch::executor::ScalarType::Int:
       return c10::ScalarType::Int;
     case torch::executor::ScalarType::Float:

--- a/schema/scalar_type.fbs
+++ b/schema/scalar_type.fbs
@@ -14,6 +14,7 @@ enum ScalarType : byte {
   SHORT = 2,
   INT = 3,
   LONG = 4,
+  Half = 5,
   FLOAT = 6,
   DOUBLE = 7,
   BOOL = 11,
@@ -24,7 +25,6 @@ enum ScalarType : byte {
   QUINT4X2 = 16,
   QUINT2X4 = 17,
   // Types currently not implemented.
-  // Half = 5,
   // COMPLEXHALF = 8,
   // COMPLEXFLOAT = 9,
   // COMPLEXDOUBLE = 10,


### PR DESCRIPTION
Summary:
for listed ops in the pass we may not want to use compute type but instead want to use result dtype.

Rationale:

for Add,

`fp16 + fp16` results in `convert to fp32, fp32 + fp32` which may be the desired outcome for either of the ops.

Differential Revision: D53248920


