### PR TITLE
Add most ops (parity w/ fp32)

### DIFF
--- a/backends/xnnpack/operators/node_visitor.py
+++ b/backends/xnnpack/operators/node_visitor.py
@@ -193,7 +193,10 @@ class NodeVisitor:
         return ext_id, id_out, flag
 
     def get_serialized_dtype(
-        self, quant_params: Optional[QuantParams], node: torch.fx.Node
+        self,
+        quant_params: Optional[QuantParams],
+        node: torch.fx.Node,
+        fp32_static_weight: bool = False,
     ) -> Tuple[XNNDatatype, XNNDatatype]:
         # Default initialization
         dtype, dq_dtype = (
@@ -243,7 +246,11 @@ class NodeVisitor:
         else:
             node_dtype = get_node_dtype(node)
             if node_dtype is not None and node_dtype == torch.float16:
-                dtype = XNNDatatype.xnn_datatype_fp16
+                dtype = (
+                    XNNDatatype.xnn_datatype_fp32
+                    if fp32_static_weight
+                    else XNNDatatype.xnn_datatype_fp16
+                )
 
         return (dtype, dq_dtype)
 
@@ -268,6 +275,7 @@ class NodeVisitor:
         convert_to_nhwc: bool = False,
         swap_nc_for_depthwise_weights: bool = False,
         quant_params: Optional[QuantParams] = None,
+        fp32_static_weights: bool = False,
     ) -> None:
         """
         Defines an tensor value into the XNNGraph
@@ -286,6 +294,7 @@ class NodeVisitor:
                         constant data. If used along with convert_to_nhwc, this
                         swap will happen before converting to nhwc.
             quant_params: Quantization meta data for this tensor, None if it is not quantized
+            fp32_static_weights: XNN_FLAG_FP32_STATIC_WEIGHTS for fp16 conv
         """
 
         if tensor in vals_to_ids:
@@ -313,6 +322,7 @@ class NodeVisitor:
             convert_to_nhwc,
             swap_nc_for_depthwise_weights,
             quant_params,
+            fp32_static_weights,
         )
 
         # convert tensor shape must reflect memory format, default is contiguous, so
@@ -323,7 +333,9 @@ class NodeVisitor:
             check_or_raise(len(dims) == 4, "Converting to nhwc requires 4d tensor")
             dims = [dims[i] for i in PERM_NCHW_TO_NHWC]
 
-        dtype, dq_dtype = self.get_serialized_dtype(quant_params, tensor)
+        dtype, dq_dtype = self.get_serialized_dtype(
+            quant_params, tensor, fp32_static_weight=fp32_static_weights
+        )
 
         tvalue = XNNTensorValue(
             datatype=dtype,
@@ -413,6 +425,7 @@ class NodeVisitor:
         convert_to_nhwc: bool,
         swap_nc_for_depthwise_weights: bool,
         quant_params: Optional[QuantParams],
+        fp32_static_weights: bool = False,
     ) -> int:
         """
         If tensor holds some constant data, serialize it and return the
@@ -432,6 +445,7 @@ class NodeVisitor:
                         constant data. If used along with convert_to_nhwc, this
                         swap will happen before converting to nhwc.
             quant_params: Quantization meta data for this tensor, None if it is not quantize
+            fp32_static_weights: bool to indicate whether tensor is fp32 static weights
 
         Returns:
             buffer_idx: idx of the serialized data. 0 If not associated constant
@@ -458,7 +472,7 @@ class NodeVisitor:
         # Quantize buffer if static data is indeed quantized
         if quant_params is not None and not quant_params.is_dynamic:
             const_val = quant_params.quantize_tensor(const_val).contiguous()
-        elif const_val.dtype != torch.float16:
+        elif const_val.dtype != torch.float16 or fp32_static_weights:
             # ensure that the const is fp32
             const_val = const_val.to(dtype=torch.float32).contiguous()
 

--- a/backends/xnnpack/operators/op_conv2d.py
+++ b/backends/xnnpack/operators/op_conv2d.py
@@ -73,6 +73,9 @@ class Conv2d(NodeVisitor):
         weight_quant_params = QuantParams.from_weights(
             weight_node, self._exported_program
         )
+
+        fp32_static_weights = weight_node.meta["val"].dtype == torch.float16
+
         self.define_tensor(
             weight_node,
             xnn_graph,
@@ -80,6 +83,7 @@ class Conv2d(NodeVisitor):
             convert_to_nhwc=True,
             swap_nc_for_depthwise_weights=is_depthwise_conv,
             quant_params=weight_quant_params,
+            fp32_static_weights=fp32_static_weights,
         )
         kwargs["filter_id"] = vals_to_ids[get_input_node(node, 1)]
 
@@ -109,6 +113,7 @@ class Conv2d(NodeVisitor):
                 vals_to_ids,
                 convert_to_nhwc=False,
                 quant_params=bias_quant_params,
+                fp32_static_weights=fp32_static_weights,
             )
             kwargs["bias_id"] = vals_to_ids[get_input_node(node, 2)]
 

--- a/backends/xnnpack/partition/xnnpack_partitioner.py
+++ b/backends/xnnpack/partition/xnnpack_partitioner.py
@@ -144,6 +144,7 @@ class XnnpackOperatorSupport(OperatorSupportBase):
 
         valid_dtypes = {
             torch.float32,
+            torch.float16,
             torch.int8,
             torch.qint8,
         }
@@ -190,6 +191,7 @@ class XnnpackOperatorSupport(OperatorSupportBase):
             node
         )
 
+    @staticmethod
     def _constraint(target):  # noqa
         """
         Decorator to register a constraint fn for a node

--- a/backends/xnnpack/test/ops/abs.py
+++ b/backends/xnnpack/test/ops/abs.py
@@ -19,15 +19,7 @@ class TestAbs(unittest.TestCase):
             z = torch.abs(x)
             return z
 
-    def test_fp32_abs(self):
-        inputs = (
-            torch.Tensor(
-                [
-                    [0.0, 0.1, 0.5, 0.499],
-                    [-0.6, -0.4, 100.1, -1000.1],
-                ],
-            ),
-        )
+    def _test_abs(self, inputs):
         (
             Tester(self.Abs(), inputs)
             .export()
@@ -42,3 +34,25 @@ class TestAbs(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_abs(self):
+        inputs = (
+            torch.Tensor(
+                [
+                    [0.0, 0.1, 0.5, 0.499],
+                    [-0.6, -0.4, 100.1, -1000.1],
+                ],
+            ).to(torch.float16),
+        )
+        self._test_abs(inputs)
+
+    def test_fp32_abs(self):
+        inputs = (
+            torch.Tensor(
+                [
+                    [0.0, 0.1, 0.5, 0.499],
+                    [-0.6, -0.4, 100.1, -1000.1],
+                ],
+            ),
+        )
+        self._test_abs(inputs)

--- a/backends/xnnpack/test/ops/add.py
+++ b/backends/xnnpack/test/ops/add.py
@@ -40,8 +40,7 @@ class TestAdd(unittest.TestCase):
             out2 = x + self._constant + self._constant
             return out1, out2
 
-    def test_fp32_add(self):
-        inputs = (torch.ones(1), torch.ones(1))
+    def _test_add(self, inputs):
         (
             Tester(self.Add(), inputs)
             .export()
@@ -56,6 +55,14 @@ class TestAdd(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_add(self):
+        inputs = (torch.ones(1).to(torch.float16), torch.ones(1).to(torch.float16))
+        self._test_add(inputs)
+
+    def test_fp32_add(self):
+        inputs = (torch.ones(1), torch.ones(1))
+        self._test_add(inputs)
 
     def test_fp32_add_constant(self):
         inputs = (torch.randn(4, 4, 4),)

--- a/backends/xnnpack/test/ops/avgpool2d.py
+++ b/backends/xnnpack/test/ops/avgpool2d.py
@@ -28,8 +28,7 @@ class TestAvgPool2d(unittest.TestCase):
         def forward(self, x):
             return self.avgPool(x)
 
-    def test_fp32_avgpool2d(self):
-        inputs = (torch.randn(1, 1, 10, 10),)
+    def _test_argpool2d(self, inputs):
         (
             Tester(self.AvgPool2d(), inputs)
             .export()
@@ -46,6 +45,14 @@ class TestAvgPool2d(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_avgpool2d(self):
+        inputs = (torch.randn(1, 1, 10, 10).to(torch.float16),)
+        self._test_argpool2d(inputs)
+
+    def test_fp32_avgpool2d(self):
+        inputs = (torch.randn(1, 1, 10, 10),)
+        self._test_argpool2d(inputs)
 
     def test_fp32_avgpool2d_ceil_mode_unsupported(self):
         """

--- a/backends/xnnpack/test/ops/ceil.py
+++ b/backends/xnnpack/test/ops/ceil.py
@@ -19,15 +19,7 @@ class TestCeil(unittest.TestCase):
             z = torch.ceil(x)
             return z
 
-    def test_fp32_ceil(self):
-        inputs = (
-            torch.Tensor(
-                [
-                    [0.0, 0.1, 0.5, 0.499],
-                    [-0.6, -0.4, 100.1, -1000.1],
-                ]
-            ),
-        )
+    def _test_ceil(self, inputs):
         (
             Tester(self.Ceil(), inputs)
             .export()
@@ -42,3 +34,25 @@ class TestCeil(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_ceil(self):
+        inputs = (
+            torch.Tensor(
+                [
+                    [0.0, 0.1, 0.5, 0.499],
+                    [-0.6, -0.4, 100.1, -1000.1],
+                ]
+            ).to(torch.float16),
+        )
+        self._test_ceil(inputs)
+
+    def test_fp32_ceil(self):
+        inputs = (
+            torch.Tensor(
+                [
+                    [0.0, 0.1, 0.5, 0.499],
+                    [-0.6, -0.4, 100.1, -1000.1],
+                ]
+            ),
+        )
+        self._test_ceil(inputs)

--- a/backends/xnnpack/test/ops/conv1d.py
+++ b/backends/xnnpack/test/ops/conv1d.py
@@ -14,11 +14,11 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 class TestConv1d(unittest.TestCase):
     class Conv1d(torch.nn.Module):
-        def __init__(self):
+        def __init__(self, dtype: torch.dtype = torch.float):
             groups = 1
-            stride = [2]
-            padding = [1]
-            dilation = [1]
+            stride = (2,)
+            padding = (1,)
+            dilation = (1,)
             in_channels = 2
             out_channels = 1
             kernel_size = (3,)
@@ -34,7 +34,7 @@ class TestConv1d(unittest.TestCase):
                 groups=groups,
                 dilation=dilation,
                 bias=True,
-            )
+            ).to(dtype)
 
         def forward(self, x):
             return self.conv1d(x)
@@ -100,6 +100,10 @@ class TestConv1d(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_conv1d(self):
+        inputs = (torch.randn(1, 2, 4).to(torch.float16),)
+        self._test_conv1d(self.Conv1d(dtype=torch.float16), inputs, conv_count=1)
 
     def test_fp32_conv1d(self):
         inputs = (torch.randn(1, 2, 4),)

--- a/backends/xnnpack/test/ops/div.py
+++ b/backends/xnnpack/test/ops/div.py
@@ -27,8 +27,7 @@ class TestDiv(unittest.TestCase):
             z = x / x
             return z
 
-    def test_fp32_div(self):
-        inputs = (torch.ones(1), torch.ones(1))
+    def _test_div(self, inputs):
         (
             Tester(self.Div(), inputs)
             .export()
@@ -43,6 +42,14 @@ class TestDiv(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_div(self):
+        inputs = (torch.ones(1).to(torch.float16), torch.ones(1).to(torch.float16))
+        self._test_div(inputs)
+
+    def test_fp32_div(self):
+        inputs = (torch.ones(1), torch.ones(1))
+        self._test_div(inputs)
 
     def test_fp32_div_single_input(self):
         inputs = (torch.ones(1),)

--- a/backends/xnnpack/test/ops/elu.py
+++ b/backends/xnnpack/test/ops/elu.py
@@ -23,9 +23,7 @@ class TestElu(unittest.TestCase):
         def forward(self, x):
             return torch.nn.functional.elu(x, alpha=1.2)
 
-    @unittest.skip("T171810227 - Missing recomposition for ELU")
-    def test_fp32_elu(self):
-        inputs = (torch.randn(1, 3, 3),)
+    def _test_elu(self, inputs):
         (
             Tester(self.ELU(), inputs)
             .export()
@@ -44,6 +42,16 @@ class TestElu(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    @unittest.skip("T171810227 - Missing recomposition for ELU")
+    def test_fp16_elu(self):
+        inputs = (torch.randn(1, 3, 3).to(torch.float16),)
+        self._test_elu(inputs)
+
+    @unittest.skip("T171810227 - Missing recomposition for ELU")
+    def test_fp32_elu(self):
+        inputs = (torch.randn(1, 3, 3),)
+        self._test_elu(inputs)
 
     @unittest.skip("T171810227 - Missing recomposition for ELU")
     def test_qs8_elu(self):

--- a/backends/xnnpack/test/ops/floor.py
+++ b/backends/xnnpack/test/ops/floor.py
@@ -19,15 +19,7 @@ class TestFloor(unittest.TestCase):
             z = torch.floor(x)
             return z
 
-    def test_fp32_floor(self):
-        inputs = (
-            torch.Tensor(
-                [
-                    [0.0, 0.1, 0.5, 0.499],
-                    [-0.6, -0.4, 100.1, -1000.1],
-                ],
-            ),
-        )
+    def _test_floor(self, inputs):
         (
             Tester(self.Floor(), inputs)
             .export()
@@ -42,3 +34,25 @@ class TestFloor(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_floor(self):
+        inputs = (
+            torch.Tensor(
+                [
+                    [0.0, 0.1, 0.5, 0.499],
+                    [-0.6, -0.4, 100.1, -1000.1],
+                ],
+            ).to(torch.float16),
+        )
+        self._test_floor(inputs)
+
+    def test_fp32_floor(self):
+        inputs = (
+            torch.Tensor(
+                [
+                    [0.0, 0.1, 0.5, 0.499],
+                    [-0.6, -0.4, 100.1, -1000.1],
+                ],
+            ),
+        )
+        self._test_floor(inputs)

--- a/backends/xnnpack/test/ops/hardswish.py
+++ b/backends/xnnpack/test/ops/hardswish.py
@@ -23,9 +23,7 @@ class TestHardswish(unittest.TestCase):
         def forward(self, x):
             return torch.nn.functional.hardswish(x)
 
-    @unittest.skip("T158969708 - Missing recomposition pass for hardswish")
-    def test_fp32_hardswish(self):
-        inputs = (torch.randn(1, 3, 3),)
+    def _test_hardswish(self, inputs):
         (
             Tester(self.Hardswish(), inputs)
             .export()
@@ -46,6 +44,16 @@ class TestHardswish(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    @unittest.skip("T158969708 - Missing recomposition pass for hardswish")
+    def test_fp16_hardswish(self):
+        inputs = (torch.randn(1, 3, 3).to(torch.float16),)
+        self._test_hardswish(inputs)
+
+    @unittest.skip("T158969708 - Missing recomposition pass for hardswish")
+    def test_fp32_hardswish(self):
+        inputs = (torch.randn(1, 3, 3),)
+        self._test_hardswish(inputs)
 
     @unittest.skip("T158969708 - Missing recomposition pass for hardswish")
     def test_fp32_hardswish_functional(self):

--- a/backends/xnnpack/test/ops/leaky_relu.py
+++ b/backends/xnnpack/test/ops/leaky_relu.py
@@ -25,10 +25,9 @@ class TestLeakyRelu(unittest.TestCase):
         def forward(self, x):
             return torch.nn.functional.leaky_relu(x)
 
-    def test_fp32_leaky_relu(self):
-        inputs = (torch.randn(1, 3, 3),)
+    def _test_leaky_relu(self, module, inputs):
         (
-            Tester(self.LeakyReLU(negative_slope=0.2), inputs)
+            Tester(module, inputs)
             .export()
             .check_count({"torch.ops.aten.leaky_relu.default": 1})
             .to_edge()
@@ -47,6 +46,16 @@ class TestLeakyRelu(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_leaky_relu(self):
+        inputs = (torch.randn(1, 3, 3).to(torch.float16),)
+        module = self.LeakyReLUFunctional()
+        self._test_leaky_relu(module, inputs)
+
+    def test_fp32_leaky_relu(self):
+        inputs = (torch.randn(1, 3, 3),)
+        module = self.LeakyReLU(negative_slope=0.2)
+        self._test_leaky_relu(module, inputs)
 
     def test_fp32_leaky_relu_functional(self):
         inputs = (torch.randn(1, 3, 3),)

--- a/backends/xnnpack/test/ops/max_dim.py
+++ b/backends/xnnpack/test/ops/max_dim.py
@@ -25,9 +25,7 @@ class TestMaxDim(unittest.TestCase):
             max_values_2, _ = torch.max(x, dim=3, keepdim=True)
             return (max_values_1, max_values_2)
 
-    @unittest.skip("T171468483 - Fails to partition due to index output dtype.")
-    def test_fp32_max_dim(self):
-        inputs = (torch.randn(16, 3, 12, 12),)
+    def _test_max_dim(self, inputs):
         (
             Tester(self.Max(), inputs)
             .export()
@@ -42,6 +40,16 @@ class TestMaxDim(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    @unittest.skip("T171468483 - Fails to partition due to index output dtype.")
+    def test_fp16_max_dim(self):
+        inputs = (torch.randn(16, 3, 12, 12).to(torch.float16),)
+        self._test_max_dim(inputs)
+
+    @unittest.skip("T171468483 - Fails to partition due to index output dtype.")
+    def test_fp32_max_dim(self):
+        inputs = (torch.randn(16, 3, 12, 12),)
+        self._test_max_dim(inputs)
 
     @unittest.skip("T171468483 - Fails to partition due to index output dtype.")
     def test_fp32_max_dim_no_indices(self):

--- a/backends/xnnpack/test/ops/maximum.py
+++ b/backends/xnnpack/test/ops/maximum.py
@@ -18,11 +18,7 @@ class TestMaximum(unittest.TestCase):
         def forward(self, x, y):
             return torch.maximum(x, y)
 
-    def test_fp32_maximum(self):
-        inputs = (
-            torch.randn(2, 3, 4),
-            torch.randn(2, 3, 4),
-        )
+    def _test_maximum(self, inputs):
         (
             Tester(self.Maximum(), inputs)
             .export()
@@ -37,6 +33,20 @@ class TestMaximum(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_maximum(self):
+        inputs = (
+            torch.randn(2, 3, 4).to(torch.float16),
+            torch.randn(2, 3, 4).to(torch.float16),
+        )
+        self._test_maximum(inputs)
+
+    def test_fp32_maximum(self):
+        inputs = (
+            torch.randn(2, 3, 4),
+            torch.randn(2, 3, 4),
+        )
+        self._test_maximum(inputs)
 
     def test_fp32_maximum_broadcast(self):
         inputs = (

--- a/backends/xnnpack/test/ops/maxpool2d.py
+++ b/backends/xnnpack/test/ops/maxpool2d.py
@@ -38,12 +38,11 @@ class TestMaxPool2d(unittest.TestCase):
         def forward(self, x):
             return self.max_pool2d_module(x)[1]
 
-    def test_fp32_maxpool2d(self):
+    def _test_maxpool2d(self, inputs):
         """
         Note that the export process generates aten.max_pool2d_with_indices. The remove_getitem_op
         pass transforms it into aten.max_pool2d (if supported).
         """
-        inputs = (torch.randn(4, 3, 24, 24),)
         (
             Tester(self.MaxPool2d(3, 1, 0, 1), inputs)
             .export()
@@ -68,6 +67,14 @@ class TestMaxPool2d(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_maxpool2d(self):
+        inputs = (torch.randn(4, 3, 24, 24).to(torch.float16),)
+        self._test_maxpool2d(inputs)
+
+    def test_fp32_maxpool2d(self):
+        inputs = (torch.randn(4, 3, 24, 24),)
+        self._test_maxpool2d(inputs)
 
     def test_fp32_maxpool2d_unsupported(self):
         """

--- a/backends/xnnpack/test/ops/mean_dim.py
+++ b/backends/xnnpack/test/ops/mean_dim.py
@@ -21,8 +21,7 @@ class TestMeanDim(unittest.TestCase):
             z = torch.mean(y, self.dims, keepdim=True)
             return z
 
-    def test_fp32_mean_dim(self):
-        inputs = (torch.randn(1, 5, 4, 4),)
+    def _test_mean_dim(self, inputs):
         (
             Tester(self.MeanDim((-1, -2)), inputs)
             .export()
@@ -37,6 +36,14 @@ class TestMeanDim(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_mean_dim(self):
+        inputs = (torch.randn(1, 5, 4, 4).to(torch.float16),)
+        self._test_mean_dim(inputs)
+
+    def test_fp32_mean_dim(self):
+        inputs = (torch.randn(1, 5, 4, 4),)
+        self._test_mean_dim(inputs)
 
     def test_fp32_mean_dim_unsupported(self):
         """

--- a/backends/xnnpack/test/ops/minimum.py
+++ b/backends/xnnpack/test/ops/minimum.py
@@ -18,11 +18,7 @@ class TestMinimum(unittest.TestCase):
         def forward(self, x, y):
             return torch.minimum(x, y)
 
-    def test_fp32_minimum(self):
-        inputs = (
-            torch.randn(1, 3, 6),
-            torch.randn(1, 3, 6),
-        )
+    def _test_minimum(self, inputs):
         (
             Tester(self.Minimum(), inputs)
             .export()
@@ -37,3 +33,17 @@ class TestMinimum(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_minimum(self):
+        inputs = (
+            torch.randn(1, 3, 6).to(torch.float16),
+            torch.randn(1, 3, 6).to(torch.float16),
+        )
+        self._test_minimum(inputs)
+
+    def test_fp32_minimum(self):
+        inputs = (
+            torch.randn(1, 3, 6),
+            torch.randn(1, 3, 6),
+        )
+        self._test_minimum(inputs)

--- a/backends/xnnpack/test/ops/multiply.py
+++ b/backends/xnnpack/test/ops/multiply.py
@@ -31,8 +31,7 @@ class TestMul(unittest.TestCase):
             z = x * y
             return torch.nn.functional.relu(z)
 
-    def test_fp32_mul(self):
-        inputs = (torch.randn((1, 3)), torch.randn((4, 3)))
+    def _test_mul(self, inputs):
         (
             Tester(self.Mul(), inputs)
             .export()
@@ -47,6 +46,17 @@ class TestMul(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_mul(self):
+        inputs = (
+            torch.randn((1, 3)).to(torch.float16),
+            torch.randn((4, 3)).to(torch.float16),
+        )
+        self._test_mul(inputs)
+
+    def test_fp32_mul(self):
+        inputs = (torch.randn((1, 3)), torch.randn((4, 3)))
+        self._test_mul(inputs)
 
     def test_qs8_mul(self):
         inputs = (torch.randn(1, 1, 4, 4), torch.randn(1, 1, 4, 1))

--- a/backends/xnnpack/test/ops/negate.py
+++ b/backends/xnnpack/test/ops/negate.py
@@ -19,15 +19,7 @@ class TestNegate(unittest.TestCase):
             z = torch.neg(x)
             return z
 
-    def test_fp32_negate(self):
-        inputs = (
-            torch.Tensor(
-                [
-                    [0.0, 0.1, 0.5, 0.499],
-                    [-0.6, -0.4, 100.1, -1000.1],
-                ],
-            ),
-        )
+    def _test_negate(self, inputs):
         (
             Tester(self.Negate(), inputs)
             .export()
@@ -42,3 +34,25 @@ class TestNegate(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_negate(self):
+        inputs = (
+            torch.Tensor(
+                [
+                    [0.0, 0.1, 0.5, 0.499],
+                    [-0.6, -0.4, 100.1, -1000.1],
+                ],
+            ).to(torch.float16),
+        )
+        self._test_negate(inputs)
+
+    def test_fp32_negate(self):
+        inputs = (
+            torch.Tensor(
+                [
+                    [0.0, 0.1, 0.5, 0.499],
+                    [-0.6, -0.4, 100.1, -1000.1],
+                ],
+            ),
+        )
+        self._test_negate(inputs)

--- a/backends/xnnpack/test/ops/permute.py
+++ b/backends/xnnpack/test/ops/permute.py
@@ -31,8 +31,7 @@ class TestPermute(unittest.TestCase):
             z = torch.permute_copy(y, self.dims)
             return z
 
-    def test_fp32_permute(self):
-        inputs = (torch.randn(1, 1, 4, 4),)
+    def _test_permute(self, inputs):
         (
             Tester(self.Permute([0, 2, 3, 1]), inputs)
             .export()
@@ -49,6 +48,14 @@ class TestPermute(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_permute(self):
+        inputs = (torch.randn(1, 1, 4, 4).to(torch.float16),)
+        self._test_permute(inputs)
+
+    def test_fp32_permute(self):
+        inputs = (torch.randn(1, 1, 4, 4),)
+        self._test_permute(inputs)
 
     def test_fp32_permute_copy(self):
         inputs = (torch.randn(1, 1, 4, 4),)

--- a/backends/xnnpack/test/ops/pow.py
+++ b/backends/xnnpack/test/ops/pow.py
@@ -20,9 +20,7 @@ class TestPow(unittest.TestCase):
             z = torch.pow(x, self.exp)
             return z
 
-    def test_fp32_pow2(self):
-        inputs = (torch.randn(20),)
-        pass
+    def _test_pow2(self, inputs):
         (
             Tester(self.Pow(2), inputs)
             .export()
@@ -39,6 +37,14 @@ class TestPow(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_pow2(self):
+        inputs = (torch.randn(20).to(torch.float16),)
+        self._test_pow2(inputs)
+
+    def test_fp32_pow2(self):
+        inputs = (torch.randn(20),)
+        self._test_pow2(inputs)
 
     def test_fp32_pow_unsupported(self):
         """

--- a/backends/xnnpack/test/ops/prelu.py
+++ b/backends/xnnpack/test/ops/prelu.py
@@ -20,11 +20,9 @@ class TestPrelu(unittest.TestCase):
             a = self.prelu(x)
             return a
 
-    @unittest.skip("T158653285 - Missing recomposition for PReLU")
-    def test_fp32_prelu(self):
-        inputs = (torch.randn(1, 5, 3, 2),)
+    def _test_prelu(self, module, inputs):
         (
-            Tester(self.PReLU(), inputs)
+            Tester(module, inputs)
             .export()
             .check_count({"torch.ops.aten._prelu_kernel.default": 1})
             .to_edge()
@@ -41,3 +39,15 @@ class TestPrelu(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    @unittest.skip("T158653285 - Missing recomposition for PReLU")
+    def test_fp16_prelu(self):
+        module = self.PReLU().to(torch.float16)
+        inputs = (torch.randn(1, 5, 3, 2).to(torch.float16),)
+        self._test_prelu(module, inputs)
+
+    @unittest.skip("T158653285 - Missing recomposition for PReLU")
+    def test_fp32_prelu(self):
+        module = self.PReLU()
+        inputs = (torch.randn(1, 5, 3, 2),)
+        self._test_prelu(module, inputs)

--- a/backends/xnnpack/test/ops/sigmoid.py
+++ b/backends/xnnpack/test/ops/sigmoid.py
@@ -20,8 +20,7 @@ class TestSigmoid(unittest.TestCase):
             z = self.sigmoid(x)
             return z
 
-    def test_fp32_sigmoid(self):
-        inputs = (torch.ones(4),)
+    def _test_sigmoid(self, inputs):
         (
             Tester(self.Sigmoid(), inputs)
             .export()
@@ -36,3 +35,11 @@ class TestSigmoid(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_sigmoid(self):
+        inputs = (torch.ones(4).to(torch.float16),)
+        self._test_sigmoid(inputs)
+
+    def test_fp32_sigmoid(self):
+        inputs = (torch.ones(4),)
+        self._test_sigmoid(inputs)

--- a/backends/xnnpack/test/ops/slice_copy.py
+++ b/backends/xnnpack/test/ops/slice_copy.py
@@ -31,6 +31,14 @@ class TestSliceCopy(unittest.TestCase):
             .compare_outputs()
         )
 
+    def test_fp16_slice_copy(self):
+        class SliceCopy(torch.nn.Module):
+            def forward(self, x):
+                return x[1:3, -2:, :-1]
+
+        inputs = (torch.randn(5, 5, 5).to(torch.float16),)
+        self._test_slice_copy(SliceCopy(), inputs, 3, 3)
+
     def test_fp32_slice_copy(self):
         class SliceCopy(torch.nn.Module):
             def forward(self, x):

--- a/backends/xnnpack/test/ops/softmax.py
+++ b/backends/xnnpack/test/ops/softmax.py
@@ -19,9 +19,7 @@ class TestSoftmax(unittest.TestCase):
         def forward(self, x):
             return torch.nn.Softmax(dim=self.dim)(x)
 
-    def test_fp32_softmax(self):
-        inputs = (torch.rand((3, 5, 7)),)
-
+    def _test_softmax(self, inputs):
         # Dim can be either the last dimension index or -1 (last dimension),
         # as xnnpack only supports softmax on the last dimension.
         valid_dims = [len(inputs[0]) - 1, -1]
@@ -43,6 +41,14 @@ class TestSoftmax(unittest.TestCase):
                 .run_method()
                 .compare_outputs()
             )
+
+    def test_fp16_softmax(self):
+        inputs = (torch.rand((3, 5, 7)).to(torch.float16),)
+        self._test_softmax(inputs)
+
+    def test_fp32_softmax(self):
+        inputs = (torch.rand((3, 5, 7)),)
+        self._test_softmax(inputs)
 
     def test_fp32_softmax_unsupported(self):
         inputs = (torch.rand((3, 5, 7)),)

--- a/backends/xnnpack/test/ops/sqrt.py
+++ b/backends/xnnpack/test/ops/sqrt.py
@@ -19,8 +19,7 @@ class TestSqrt(unittest.TestCase):
             z = torch.sqrt(x)
             return z
 
-    def test_fp32_sqrt(self):
-        inputs = (torch.randn(20).abs(),)
+    def _test_sqrt(self, inputs):
         (
             Tester(self.Sqrt(), inputs)
             .export()
@@ -35,3 +34,11 @@ class TestSqrt(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_sqrt(self):
+        inputs = (torch.randn(20).to(torch.float16).abs(),)
+        self._test_sqrt(inputs)
+
+    def test_fp32_sqrt(self):
+        inputs = (torch.randn(20).abs(),)
+        self._test_sqrt(inputs)

--- a/backends/xnnpack/test/ops/square.py
+++ b/backends/xnnpack/test/ops/square.py
@@ -19,12 +19,11 @@ class TestSquare(unittest.TestCase):
             z = torch.square(x)
             return z
 
-    def test_fp32_square(self):
+    def _test_square(self, inputs):
         """
         Note that torch.square maps to aten.pow.Tensor_Scalar. The pow visitor has logic
         to emit the appropriate XNNPACK square op when the exponent is 2.
         """
-        inputs = (torch.randn(20),)
         (
             Tester(self.Square(), inputs)
             .export()
@@ -41,3 +40,11 @@ class TestSquare(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_square(self):
+        inputs = (torch.randn(20).to(torch.float16),)
+        self._test_square(inputs)
+
+    def test_fp32_square(self):
+        inputs = (torch.randn(20),)
+        self._test_square(inputs)

--- a/backends/xnnpack/test/ops/static_constant_pad.py
+++ b/backends/xnnpack/test/ops/static_constant_pad.py
@@ -83,12 +83,7 @@ class TestStaticConstantPad(unittest.TestCase):
             z = y + y
             return z
 
-    def test_fp32_static_constant_pad_functional(self):
-        inputs = (
-            torch.randn(size=(5, 4, 3, 2)),
-            torch.randn(size=(5, 3, 2)),
-            torch.randn(size=(4, 3)),
-        )
+    def _test_static_constant_pad_functional(self, inputs):
         (
             Tester(self.StaticConstantPadFunctional(), inputs)
             .export()
@@ -107,6 +102,22 @@ class TestStaticConstantPad(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_static_constant_pad_functional(self):
+        inputs = (
+            torch.randn(size=(5, 4, 3, 2)).to(torch.float16),
+            torch.randn(size=(5, 3, 2)).to(torch.float16),
+            torch.randn(size=(4, 3)).to(torch.float16),
+        )
+        self._test_static_constant_pad_functional(inputs)
+
+    def test_fp32_static_constant_pad_functional(self):
+        inputs = (
+            torch.randn(size=(5, 4, 3, 2)),
+            torch.randn(size=(5, 3, 2)),
+            torch.randn(size=(4, 3)),
+        )
+        self._test_static_constant_pad_functional(inputs)
 
     def test_qs8_static_constant_pad_functional(self):
         class Pad(torch.nn.Module):

--- a/backends/xnnpack/test/ops/sub.py
+++ b/backends/xnnpack/test/ops/sub.py
@@ -27,8 +27,7 @@ class TestSub(unittest.TestCase):
             z = x - x
             return z
 
-    def test_fp32_sub(self):
-        inputs = (torch.randn((1, 3)), torch.randn((4, 3)))
+    def _test_sub(self, inputs):
         (
             Tester(self.Sub(), inputs)
             .export()
@@ -43,6 +42,17 @@ class TestSub(unittest.TestCase):
             .run_method()
             .compare_outputs()
         )
+
+    def test_fp16_sub(self):
+        inputs = (
+            torch.randn((1, 3)).to(torch.float16),
+            torch.randn((4, 3)).to(torch.float16),
+        )
+        self._test_sub(inputs)
+
+    def test_fp32_sub(self):
+        inputs = (torch.randn((1, 3)), torch.randn((4, 3)))
+        self._test_sub(inputs)
 
     @unittest.skip("T171957656 - Quantized sub not implemented.")
     def test_qs8_sub(self):

--- a/exir/passes/remove_mixed_type_operators.py
+++ b/exir/passes/remove_mixed_type_operators.py
@@ -58,7 +58,7 @@ class RemoveMixedTypeOperators(ExportPass):
         promote_dtype: torch.dtype = elementwise_dtypes(
             *arg_tensor,
             type_promotion_kind=promotion_kind,
-        )[0]
+        )[1]
 
         def try_coerce(value: PyTree, arg: torch.Argument) -> PyTree:
             if type(arg.type) != torch.TensorType:

--- a/extension/aten_util/aten_bridge.cpp
+++ b/extension/aten_util/aten_bridge.cpp
@@ -68,6 +68,8 @@ torch::executor::ScalarType torchToExecuTorchScalarType(caffe2::TypeMeta type) {
       return torch::executor::ScalarType::Byte;
     case c10::ScalarType::Char:
       return torch::executor::ScalarType::Char;
+    case c10::ScalarType::Half:
+      return torch::executor::ScalarType::Half;
     case c10::ScalarType::Int:
       return torch::executor::ScalarType::Int;
     case c10::ScalarType::Float:
@@ -93,6 +95,8 @@ c10::ScalarType execuTorchtoTorchScalarType(torch::executor::ScalarType type) {
       return c10::ScalarType::Byte;
     case torch::executor::ScalarType::Char:
       return c10::ScalarType::Char;
+    case torch::executor::ScalarType::Half:
+      return c10::ScalarType::Half;
     case torch::executor::ScalarType::Int:
       return c10::ScalarType::Int;
     case torch::executor::ScalarType::Float:

--- a/schema/scalar_type.fbs
+++ b/schema/scalar_type.fbs
@@ -14,6 +14,7 @@ enum ScalarType : byte {
   SHORT = 2,
   INT = 3,
   LONG = 4,
+  Half = 5,
   FLOAT = 6,
   DOUBLE = 7,
   BOOL = 11,
@@ -24,7 +25,6 @@ enum ScalarType : byte {
   QUINT4X2 = 16,
   QUINT2X4 = 17,
   // Types currently not implemented.
-  // Half = 5,
   // COMPLEXHALF = 8,
   // COMPLEXFLOAT = 9,
   // COMPLEXDOUBLE = 10,


### PR DESCRIPTION
Summary: Add all the ops in a single diff because since we are touching xnnpack, each one runs 250K jobs and killing infra in the process. Two ops are not in this, linear and sdpa.

Differential Revision: D53248927

