### PR TITLE
Remove calls to torch._export

### DIFF
--- a/backends/apple/coreml/partition/coreml_partitioner.py
+++ b/backends/apple/coreml/partition/coreml_partitioner.py
@@ -14,7 +14,7 @@ from executorch.exir.backend.partitioner import (
     Partitioner,
     PartitionResult,
 )
-from torch._export.exported_program import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
 from torch.fx.passes.operator_support import OperatorSupportBase
 

--- a/backends/apple/mps/partition/mps_partitioner.py
+++ b/backends/apple/mps/partition/mps_partitioner.py
@@ -18,7 +18,7 @@ from executorch.exir.backend.partitioner import (
     Partitioner,
     PartitionResult,
 )
-from torch._export.exported_program import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 from torch.fx.passes.infra.partitioner import Partition
 from torch.fx.passes.operator_support import OperatorSupportBase
 

--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -26,7 +26,7 @@ from executorch.backends.arm.tosa_utils import (
 )
 from executorch.exir.backend.backend_details import BackendDetails, PreprocessResult
 from executorch.exir.backend.compile_spec_schema import CompileSpec
-from torch._export.exported_program import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 
 # TOSA backend debug functionality
 logger = logging.getLogger(__name__)

--- a/backends/arm/arm_partitioner.py
+++ b/backends/arm/arm_partitioner.py
@@ -11,7 +11,7 @@ from executorch.exir.backend.partitioner import (
     PartitionResult,
 )
 from executorch.exir.dialects._ops import ops as exir_ops
-from torch._export.exported_program import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
 
 from torch.fx.passes.operator_support import OperatorSupportBase

--- a/backends/arm/operators/op_placeholder.py
+++ b/backends/arm/operators/op_placeholder.py
@@ -15,7 +15,7 @@ from executorch.backends.arm.tosa_quant_utils import (
 )
 from executorch.backends.arm.tosa_utils import getNodeArgs, is_bias_node_for_addmm
 from executorch.exir.dialects._ops import ops as exir_ops
-from torch._export.exported_program import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 
 
 def process_placeholder(

--- a/backends/example/test_example_delegate.py
+++ b/backends/example/test_example_delegate.py
@@ -8,7 +8,6 @@ import copy
 import unittest
 
 import torch
-import torch._export as export
 from executorch import exir
 from executorch.backends.example.example_partitioner import ExamplePartitioner
 from executorch.backends.example.example_quantizer import ExampleQuantizer
@@ -47,7 +46,7 @@ class TestExampleDelegate(unittest.TestCase):
         )
 
         m = model.eval()
-        m = export.capture_pre_autograd_graph(m, copy.deepcopy(example_inputs))
+        m = torch._export.capture_pre_autograd_graph(m, copy.deepcopy(example_inputs))
         # print("original model:", m)
         quantizer = ExampleQuantizer()
         # quantizer = XNNPACKQuantizer()
@@ -83,7 +82,7 @@ class TestExampleDelegate(unittest.TestCase):
         )
 
         m = model.eval()
-        m = export.capture_pre_autograd_graph(m, copy.deepcopy(example_inputs))
+        m = torch._export.capture_pre_autograd_graph(m, copy.deepcopy(example_inputs))
         quantizer = ExampleQuantizer()
 
         m = prepare_pt2e(m, quantizer)

--- a/backends/qualcomm/qnn_preprocess.py
+++ b/backends/qualcomm/qnn_preprocess.py
@@ -22,7 +22,7 @@ from executorch.exir.backend.backend_details import (
     PreprocessResult,
 )
 from executorch.exir.passes import PassManager
-from torch._export.exported_program import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 
 DEFAULT_DEBUG_HANDLE = 65535
 

--- a/backends/xnnpack/xnnpack_preprocess.py
+++ b/backends/xnnpack/xnnpack_preprocess.py
@@ -38,7 +38,7 @@ from executorch.exir.backend.backend_details import (
     PreprocessResult,
 )
 from executorch.exir.verification.verifier import EXIREdgeDialectVerifier
-from torch._export.exported_program import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 
 XNN_VALUE_FLAG_NON_EXTERNAL = 0
 XNN_VALUE_FLAG_EXTERNAL_INPUT = 1

--- a/examples/apple/mps/scripts/mps_example.py
+++ b/examples/apple/mps/scripts/mps_example.py
@@ -9,7 +9,7 @@ import argparse
 import copy
 import logging
 
-import torch._export as export
+import torch
 from executorch import exir
 from executorch.backends.apple.mps.mps_preprocess import MPSBackend
 from executorch.backends.apple.mps.partition.mps_partitioner import MPSPartitioner
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     model = model.eval()
 
     # pre-autograd export. eventually this will become torch.export
-    model = export.capture_pre_autograd_graph(model, example_inputs)
+    model = torch._export.capture_pre_autograd_graph(model, example_inputs)
 
     edge: EdgeProgramManager = export_to_edge(
         model,

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -11,7 +11,6 @@ import argparse
 import logging
 
 import torch
-import torch._export as export
 
 from executorch.backends.arm.arm_partitioner import ArmPartitioner
 from executorch.exir import EdgeCompileConfig, ExecutorchBackendConfig
@@ -121,7 +120,7 @@ if __name__ == "__main__":
     model = model.eval()
 
     # pre-autograd export. eventually this will become torch.export
-    model = export.capture_pre_autograd_graph(model, example_inputs)
+    model = torch._export.capture_pre_autograd_graph(model, example_inputs)
 
     edge = export_to_edge(
         model,

--- a/examples/portable/scripts/export_and_delegate.py
+++ b/examples/portable/scripts/export_and_delegate.py
@@ -10,7 +10,6 @@ import argparse
 import logging
 
 import torch
-import torch._export as export
 from executorch.exir.backend.backend_api import to_backend
 from executorch.exir.backend.test.backend_with_compiler_demo import (
     BackendWithCompilerDemo,
@@ -64,7 +63,7 @@ def export_composite_module_with_lower_graph():
     m_compile_spec = m.get_compile_spec()
 
     # pre-autograd export. eventually this will become torch.export
-    m = export.capture_pre_autograd_graph(m, m_inputs)
+    m = torch._export.capture_pre_autograd_graph(m, m_inputs)
     edge = export_to_edge(m, m_inputs)
     logging.info(f"Exported graph:\n{edge.exported_program().graph}")
 
@@ -87,7 +86,7 @@ def export_composite_module_with_lower_graph():
     m = CompositeModule()
     m = m.eval()
     # pre-autograd export. eventually this will become torch.export
-    m = export.capture_pre_autograd_graph(m, m_inputs)
+    m = torch._export.capture_pre_autograd_graph(m, m_inputs)
     composited_edge = export_to_edge(m, m_inputs)
 
     # The graph module is still runnerable
@@ -139,7 +138,7 @@ def export_and_lower_partitioned_graph():
     m = Model()
     m_inputs = m.get_example_inputs()
     # pre-autograd export. eventually this will become torch.export
-    m = export.capture_pre_autograd_graph(m, m_inputs)
+    m = torch._export.capture_pre_autograd_graph(m, m_inputs)
     edge = export_to_edge(m, m_inputs)
     logging.info(f"Exported graph:\n{edge.exported_program().graph}")
 
@@ -178,7 +177,7 @@ def export_and_lower_the_whole_graph():
 
     m_inputs = m.get_example_inputs()
     # pre-autograd export. eventually this will become torch.export
-    m = export.capture_pre_autograd_graph(m, m_inputs)
+    m = torch._export.capture_pre_autograd_graph(m, m_inputs)
     edge = export_to_edge(m, m_inputs)
     logging.info(f"Exported graph:\n{edge.exported_program().graph}")
 

--- a/examples/portable/test/test_export.py
+++ b/examples/portable/test/test_export.py
@@ -9,7 +9,6 @@ import unittest
 from typing import Any, Callable
 
 import torch
-import torch._export as export
 from executorch.examples.models import MODEL_NAME_TO_MODEL
 from executorch.examples.models.model_factory import EagerModelFactory
 
@@ -34,7 +33,7 @@ class ExportTest(unittest.TestCase):
         match.
         """
         eager_model = eager_model.eval()
-        model = export.capture_pre_autograd_graph(eager_model, example_inputs)
+        model = torch._export.capture_pre_autograd_graph(eager_model, example_inputs)
         edge_model = export_to_edge(model, example_inputs)
 
         executorch_prog = edge_model.to_executorch()

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -10,8 +10,7 @@ import argparse
 import copy
 import logging
 
-import torch._export as export
-
+import torch
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
 from executorch.exir import EdgeCompileConfig, ExecutorchBackendConfig
 from executorch.sdk import generate_etrecord
@@ -79,7 +78,7 @@ if __name__ == "__main__":
 
     model = model.eval()
     # pre-autograd export. eventually this will become torch.export
-    model = export.capture_pre_autograd_graph(model, example_inputs)
+    model = torch._export.capture_pre_autograd_graph(model, example_inputs)
 
     if args.quantize:
         logging.info("Quantizing Model...")

--- a/examples/xnnpack/quantization/example.py
+++ b/examples/xnnpack/quantization/example.py
@@ -10,7 +10,6 @@ import logging
 import time
 
 import torch
-import torch._export as export
 from executorch.exir import EdgeCompileConfig
 from executorch.exir.capture._config import ExecutorchBackendConfig
 from torch.ao.ns.fx.utils import compute_sqnr
@@ -59,7 +58,7 @@ def verify_xnnpack_quantizer_matching_fx_quant_model(model_name, model, example_
     m = model
 
     # 1. pytorch 2.0 export quantization flow (recommended/default flow)
-    m = export.capture_pre_autograd_graph(m, copy.deepcopy(example_inputs))
+    m = torch._export.capture_pre_autograd_graph(m, copy.deepcopy(example_inputs))
     quantizer = XNNPACKQuantizer()
     quantization_config = get_symmetric_quantization_config(is_per_channel=True)
     quantizer.set_global(quantization_config)
@@ -176,7 +175,7 @@ def main() -> None:
 
     model = model.eval()
     # pre-autograd export. eventually this will become torch.export
-    model = export.capture_pre_autograd_graph(model, example_inputs)
+    model = torch._export.capture_pre_autograd_graph(model, example_inputs)
     start = time.perf_counter()
     quantized_model = quantize(model, example_inputs)
     end = time.perf_counter()

--- a/exir/__init__.py
+++ b/exir/__init__.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from executorch.exir.capture import (
     _capture_legacy_do_not_use,
+    CallSpec,
     capture,
     capture_multiple,
     CaptureConfig,
@@ -28,11 +29,7 @@ from executorch.exir.program import (
     to_edge,
 )
 from executorch.exir.tracer import ExirDynamoConfig
-from torch._export import (  # lots of people are doing from exir import CallSpec, ExportGraphSignature, ExportedProgram which seems wrong
-    CallSpec,
-    ExportedProgram,
-    ExportGraphSignature,
-)
+from torch.export import ExportedProgram, ExportGraphSignature
 
 Value = Any
 

--- a/exir/backend/backend_details.py
+++ b/exir/backend/backend_details.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union
 
 from executorch.exir.backend.compile_spec_schema import CompileSpec
-from torch._export.exported_program import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 
 
 def enforcedmethod(func):

--- a/exir/backend/test/backend_with_compiler_demo.py
+++ b/exir/backend/test/backend_with_compiler_demo.py
@@ -11,7 +11,7 @@ import torch
 from executorch.exir.backend.backend_details import BackendDetails, PreprocessResult
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.dialects._ops import ops as exir_ops
-from torch._export.exported_program import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 
 
 # A simple way to represent an op used in BackendWithCompilerDemo

--- a/exir/backend/test/backend_with_delegate_mapping_demo.py
+++ b/exir/backend/test/backend_with_delegate_mapping_demo.py
@@ -12,7 +12,7 @@ from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.backend.utils import DelegateMappingBuilder
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch import nn
-from torch._export.exported_program import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 
 # A simple way to represent an op along with its delegate debug identifier.
 class DummyOp:

--- a/exir/capture/__init__.py
+++ b/exir/capture/__init__.py
@@ -8,6 +8,7 @@
 
 from executorch.exir.capture._capture import (
     _capture_legacy_do_not_use,
+    CallSpec,
     capture,
     capture_multiple,
 )
@@ -19,6 +20,7 @@ from executorch.exir.capture._config import (
 )
 
 __all__ = [
+    "CallSpec",
     "capture",
     "_capture_legacy_do_not_use",
     "capture_multiple",

--- a/exir/capture/_capture.py
+++ b/exir/capture/_capture.py
@@ -10,7 +10,6 @@ from collections import namedtuple
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import torch
-import torch._export
 from executorch.exir.capture._config import CaptureConfig
 from executorch.exir.error import ExportError, ExportErrorType, InternalError
 from executorch.exir.program import ExirExportedProgram, MultiMethodExirExportedProgram
@@ -25,11 +24,12 @@ from executorch.exir.tracer import (
 from executorch.exir.verification.verifier import EXIRATenDialectVerifierBase
 from torch import _guards
 from torch._dispatch.python import enable_python_dispatcher
-from torch._export import CallSpec, ExportedProgram, ExportGraphSignature
 from torch._export.passes import ReplaceViewOpsWithViewCopyOpsPass
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.export import export
 from torch.export.exported_program import (
+    ExportedProgram,
+    ExportGraphSignature,
     InputKind,
     InputSpec,
     ModuleCallEntry,
@@ -51,6 +51,9 @@ Val = Any
 CompileSpec = namedtuple(
     "CompileSpec", ["method_name", "callable", "args", "dynamic_shapes"]
 )
+
+
+CallSpec = namedtuple("CallSpec", ["in_spec", "out_spec"])
 
 
 @compatibility(is_backward_compatible=False)

--- a/exir/emit/_emit_program.py
+++ b/exir/emit/_emit_program.py
@@ -32,7 +32,7 @@ from executorch.exir.schema import (
 )
 from executorch.exir.tensor import layout_enum, scalar_type_enum
 from executorch.exir.version import EXECUTORCH_SCHEMA_VERSION
-from torch._export.exported_program import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 
 
 def _emit_prim_getters(prim_getters: Dict[str, Any]) -> List[ExecutionPlan]:

--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -87,7 +87,7 @@ from executorch.exir.tensor import (
 )
 from executorch.exir.types import LeafValueSpec, ValueSpec
 
-from torch._export.exported_program import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 from torch.utils import _pytree as pytree
 
 from typing_extensions import TypeAlias

--- a/exir/lowered_backend_module.py
+++ b/exir/lowered_backend_module.py
@@ -25,9 +25,9 @@ from executorch.exir.schema import Program
 
 from executorch.exir.tracer import Value
 
-from torch._export.exported_program import ExportedProgram
 from torch._subclasses import FakeTensor
 from torch.export.exported_program import (
+    ExportedProgram,
     ExportGraphSignature,
     InputKind,
     InputSpec,

--- a/exir/passes/constant_prop_pass.py
+++ b/exir/passes/constant_prop_pass.py
@@ -5,9 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from torch._export import ExportedProgram
 from torch._export.utils import get_buffer, get_param, is_buffer, is_param
 from torch._guards import detect_fake_mode
+from torch.export import ExportedProgram
 from torch.export.exported_program import InputKind, InputSpec, TensorArgument
 
 

--- a/exir/passes/spec_prop_pass.py
+++ b/exir/passes/spec_prop_pass.py
@@ -38,7 +38,7 @@ class SpecPropPass(ExportPass):
 
     def update_placeholder_tensor_specs(
         self,
-        exported_program: torch._export.ExportedProgram,
+        exported_program: torch.export.ExportedProgram,
         graph_module: torch.fx.GraphModule,
     ) -> None:
         """

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -36,8 +36,8 @@ from executorch.exir.verification.verifier import (
     EXIREdgeDialectVerifier,
     get_aten_verifier,
 )
-from torch._export import ExportedProgram
 from torch._export.passes import ReplaceViewOpsWithViewCopyOpsPass
+from torch.export import ExportedProgram
 from torch.export.exported_program import (
     _get_updated_range_constraints,
     ConstantArgument,

--- a/exir/serde/serialize.py
+++ b/exir/serde/serialize.py
@@ -18,8 +18,8 @@ import executorch.exir as exir
 import executorch.exir.memory as memory
 import executorch.exir.serde.export_serialize as export_serialize
 import torch
-import torch._export.exported_program as ep
 import torch._export.serde.schema as schema
+import torch.export.exported_program as ep
 from executorch.exir import delegate
 from executorch.exir.backend.compile_spec_schema import (
     CompileSpec as delegate_CompileSpec,

--- a/exir/tests/test_quantization.py
+++ b/exir/tests/test_quantization.py
@@ -9,7 +9,6 @@
 import unittest
 
 import torch
-import torch._export as export
 import torchvision
 from executorch import exir
 from executorch.exir import EdgeCompileConfig
@@ -52,7 +51,9 @@ class TestQuantization(unittest.TestCase):
             m = torchvision.models.resnet18().eval()  # pyre-ignore[16]
             m_copy = copy.deepcopy(m)
             # program capture
-            m = export.capture_pre_autograd_graph(m, copy.deepcopy(example_inputs))
+            m = torch._export.capture_pre_autograd_graph(
+                m, copy.deepcopy(example_inputs)
+            )
 
             quantizer = XNNPACKQuantizer()
             operator_config = get_symmetric_quantization_config(is_per_channel=True)

--- a/exir/tests/test_serde.py
+++ b/exir/tests/test_serde.py
@@ -21,8 +21,8 @@ from executorch.exir.backend.test.backend_with_compiler_demo import (
 from executorch.exir.backend.test.op_partitioner_demo import AddMulPartitionerDemo
 from executorch.exir.serde.serialize import deserialize, serialize
 from torch import nn
-from torch._export.exported_program import ExportedProgram as TorchExportedProgram
 from torch.export import export
+from torch.export.exported_program import ExportedProgram as TorchExportedProgram
 from torch.utils import _pytree as pytree
 
 

--- a/util/activation_memory_profiler.py
+++ b/util/activation_memory_profiler.py
@@ -13,7 +13,7 @@ import torch
 from executorch.exir import ExecutorchProgramManager
 from executorch.exir.memory_planning import get_node_tensor_specs
 from executorch.exir.tensor import num_bytes_from_shape_and_dtype
-from torch._export import ExportedProgram
+from torch.export import ExportedProgram
 
 
 @dataclass


### PR DESCRIPTION
Summary:
Replaced calls of `torch._export.ExportedProgram` to `torch.export.ExportedProgram` and `torch._export.export` to `torch.export.export`.

This should be a noop since `torch._export.ExportedProgram` points to `torch.export.ExportedProgram` and `torch._export.export` points to `torch.export.export`?

Differential Revision: D53316195


