### PR TITLE
Add support for const inputs in runner_util

### DIFF
--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -1369,9 +1369,19 @@ class _TopLevelEmitter(_Emitter):
             self.outputs.append(args_tuple.id)
         else:
             for arg in args_tuple:
-                # Every output should already have its value emitted outputs should only be abstract
-                # IDs at this point.
-                assert isinstance(arg, _AbstractValue)
+                if isinstance(arg, (int, float, bool)):
+                    arg = self._emit_evalue(self._constant_to_evalue(arg, None))
+                elif isinstance(arg, (type(None), str)):
+                    raise InternalError(
+                        self._emit_node_specific_error(
+                            self.node,
+                            f"Returning {arg} is not yet supported in the emitter.",
+                        )
+                    )
+                else:
+                    # Every other output should already have its value emitted.
+                    # They should only be abstract IDs at this point.
+                    assert isinstance(arg, _AbstractValue)
                 self.outputs.append(arg.id)
 
     def plan(self) -> ExecutionPlan:

--- a/exir/memory_planning.py
+++ b/exir/memory_planning.py
@@ -495,7 +495,11 @@ def get_node_tensor_specs(
     if not isinstance(specs, (list, tuple)):
         return []
     else:
-        return specs
+        return [
+            spec
+            for spec in specs
+            if not isinstance(spec, (int, float, bool, str, type(None)))
+        ]
 
 
 @register_algo


### PR DESCRIPTION
Summary: These are all valid input types now in an Executorch program.

Differential Revision: D53335087


