### PR TITLE
Use compile specs for backend configuration

### DIFF
--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -62,6 +62,22 @@ def generate_ethosu_compile_spec(
     return compile_spec
 
 
+def generate_tosa_compile_spec(
+    output_path: Optional[str] = None,
+) -> List[CompileSpec]:
+    """
+    Generate compile spec for TOSA flatbuffer output
+    """
+    compile_spec = [
+        CompileSpec("output_format", "tosa".encode()),
+    ]
+
+    if output_path is not None:
+        compile_spec.append(CompileSpec("debug_tosa_path", output_path.encode()))
+
+    return compile_spec
+
+
 @final
 class ArmBackend(BackendDetails):
     @staticmethod

--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -11,7 +11,7 @@
 
 import logging
 import os
-from typing import final, List
+from typing import final, List, Optional
 
 import serializer.tosa_serializer as ts
 from executorch.backends.arm.arm_vela import vela_compile
@@ -37,6 +37,31 @@ if TOSA_DBG_VERBOSE:
     logger.setLevel(logging.INFO)
 
 
+def generate_ethosu_compile_spec(
+    config: str,
+    system_config: Optional[str] = None,
+    memory_mode: Optional[str] = None,
+    extra_flags: Optional[str] = None,
+) -> List[CompileSpec]:
+    """
+    Generate compile spec for Ethos-U NPU
+    """
+    compiler_flags = [f"--accelerator-config={config}"]
+    if system_config is not None:
+        compiler_flags.append(f"--system-config={system_config}")
+    if memory_mode is not None:
+        compiler_flags.append(f"--memory-mode={memory_mode}")
+    if extra_flags is not None:
+        compiler_flags.append(extra_flags)
+
+    compile_spec = [
+        CompileSpec("output_format", "vela".encode()),
+        CompileSpec("compile_flags", "".join(compiler_flags).encode()),
+    ]
+
+    return compile_spec
+
+
 @final
 class ArmBackend(BackendDetails):
     @staticmethod
@@ -49,13 +74,25 @@ class ArmBackend(BackendDetails):
         # if a debug/test build capture output files from TOSA stage
         path = None
         debug_output = False
-        output_format = "vela"
+        output_format = ""
+        compile_flags = []
         for spec in compile_spec:
             if spec.key == "debug_tosa_path":
                 path = spec.value.decode()
                 debug_output = True
             if spec.key == "output_format":
                 output_format = spec.value.decode()
+            if spec.key == "compile_flags":
+                compile_flags.append(spec.value.decode())
+
+        # Check that the output format is set in the compile spec
+        if not output_format:
+            raise RuntimeError("output format is required")
+
+        if output_format == "vela" and len(compile_flags) == 0:
+            # Not testing for compile_flags correctness here, just that they are
+            # present. The compiler will give errors if they are not valid.
+            raise RuntimeError("compile flags are required for vela output format")
 
         # Converted output for this subgraph, serializer needs path early as it emits
         # const data directly. Path created and data written only in debug builds.
@@ -108,7 +145,7 @@ class ArmBackend(BackendDetails):
         # preprocess and some consume TOSA fb directly.
         if output_format == "vela":
             # Emit vela_bin_stream format
-            binary = vela_compile(tosa_graph)
+            binary = vela_compile(tosa_graph, compile_flags)
         elif output_format == "tosa":
             # Emit TOSA flatbuffer
             binary = bytes(tosa_graph.serialize())

--- a/backends/arm/arm_partitioner.py
+++ b/backends/arm/arm_partitioner.py
@@ -1,10 +1,16 @@
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import logging
 import operator
 import os
-from typing import final
+from typing import final, List
 
 import torch
 from executorch.backends.arm.arm_backend import ArmBackend
+from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.backend.partitioner import (
     DelegationSpec,
     Partitioner,
@@ -47,9 +53,10 @@ class TOSASupportedOperators(OperatorSupportBase):
 
 @final
 class ArmPartitioner(Partitioner):
-    compile_spec = []
+    compile_spec: List[CompileSpec]
 
-    def __init__(self) -> None:
+    def __init__(self, compile_spec: List[CompileSpec]) -> None:
+        self.compile_spec = compile_spec
         self.delegation_spec = DelegationSpec(ArmBackend.__name__, self.compile_spec)
 
     def partition(self, exported_program: ExportedProgram) -> PartitionResult:

--- a/backends/arm/arm_partitioner.py
+++ b/backends/arm/arm_partitioner.py
@@ -53,11 +53,8 @@ class TOSASupportedOperators(OperatorSupportBase):
 
 @final
 class ArmPartitioner(Partitioner):
-    compile_spec: List[CompileSpec]
-
     def __init__(self, compile_spec: List[CompileSpec]) -> None:
-        self.compile_spec = compile_spec
-        self.delegation_spec = DelegationSpec(ArmBackend.__name__, self.compile_spec)
+        self.delegation_spec = DelegationSpec(ArmBackend.__name__, compile_spec)
 
     def partition(self, exported_program: ExportedProgram) -> PartitionResult:
         # Run the CapabilityBasedPartitioner to return the largest possible

--- a/backends/arm/arm_vela.py
+++ b/backends/arm/arm_vela.py
@@ -1,7 +1,14 @@
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 import struct
 import subprocess
 import tempfile
+
+from typing import List
 
 import numpy as np
 
@@ -26,7 +33,7 @@ def vela_bin_pack_io(prefix, data):
 # Output via Vela to binary stream for ArmBackendEthosU
 # WARNING: Do not change this without changing VelaBinStream.cpp as that
 #          function consumes this format and the two need to align.
-def vela_compile(tosa_graph):
+def vela_compile(tosa_graph, args: List[str]):
     with tempfile.TemporaryDirectory() as tmpdir:
         tosaname = "out.tosa"
         flatbuffer = tosa_graph.serialize()
@@ -34,9 +41,7 @@ def vela_compile(tosa_graph):
             f.write(flatbuffer)
 
         # invoke vela
-        vela_command = (
-            f"cd {tmpdir}; vela --accelerator-config ethos-u55-128 {tosaname}"
-        )
+        vela_command = f"cd {tmpdir}; vela {' '.join(args)} {tosaname}"
         subprocess.run([vela_command], shell=True, check=True)
 
         np_path = os.path.join(tmpdir, "output", "out_sg0_vela.npz")

--- a/backends/arm/test/arm_tosa_reference.py
+++ b/backends/arm/test/arm_tosa_reference.py
@@ -11,10 +11,10 @@ import tempfile
 import executorch.exir as exir
 
 import numpy as np
+from executorch.backends.arm.arm_backend import generate_tosa_compile_spec
 from executorch.backends.arm.arm_partitioner import ArmPartitioner
 from executorch.backends.arm.test.test_models import TestList, TosaProfile
 from executorch.backends.arm.test.test_tosa import prepare_model_and_ref
-from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.capture._config import ExecutorchBackendConfig
 
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -158,10 +158,7 @@ def tosa_run_test(op, profile=TosaProfile.MI):  # noqa: C901
     # Debug flags for compilers
     # - Emit some debug files into /tmp
     # - output_format TOSA for this test (and pure tosa flows)
-    compile_spec = [
-        CompileSpec("debug_tosa_path", bytes(TOSA_OUT_PATH, "utf8")),
-        CompileSpec("output_format", bytes("tosa", "utf8")),
-    ]
+    compile_spec = generate_tosa_compile_spec(TOSA_OUT_PATH)
 
     model, inputs, torch_output = prepare_model_and_ref(op, profile)
 

--- a/backends/arm/test/arm_tosa_reference.py
+++ b/backends/arm/test/arm_tosa_reference.py
@@ -173,8 +173,6 @@ def tosa_run_test(op, profile=TosaProfile.MI):  # noqa: C901
     model_capture = export(model, inputs)
     model_edge = to_edge(model_capture, compile_config=_EDGE_COMPILE_CONFIG)
 
-    ArmPartitioner.compile_spec = compile_spec
-
     if profile == TosaProfile.BI:
         (
             input_quantization_scales,
@@ -185,7 +183,7 @@ def tosa_run_test(op, profile=TosaProfile.MI):  # noqa: C901
             output_quantization_zp,
         ) = get_output_quantization_param(model_edge)
 
-    model_edge = model_edge.to_backend(ArmPartitioner())
+    model_edge = model_edge.to_backend(ArmPartitioner(compile_spec))
     exec_prog = model_edge.to_executorch(
         config=ExecutorchBackendConfig(extract_constant_segment=False)
     )

--- a/backends/arm/test/test_tosa.py
+++ b/backends/arm/test/test_tosa.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Arm Limited and/or its affiliates.
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -103,8 +103,7 @@ def prepare_model_and_ref(test_model, profile=TosaProfile.MI):
 def export_model(model, inputs, compile_spec):
     model_capture = export(model, inputs)
     model_edge = to_edge(model_capture, compile_config=_EDGE_COMPILE_CONFIG)
-    ArmPartitioner.compile_spec = compile_spec
 
-    model_edge = model_edge.to_backend(ArmPartitioner())
+    model_edge = model_edge.to_backend(ArmPartitioner(compile_spec))
     exec_prog = model_edge.to_executorch()
     return model_edge, exec_prog

--- a/backends/arm/test/test_tosa.py
+++ b/backends/arm/test/test_tosa.py
@@ -11,11 +11,11 @@ import copy
 import unittest
 
 import executorch.exir as exir
+from executorch.backends.arm.arm_backend import generate_tosa_compile_spec
 from executorch.backends.arm.arm_partitioner import ArmPartitioner
 from executorch.backends.arm.test.test_models import TestList, TosaProfile
 from executorch.exir import EdgeCompileConfig
 
-from executorch.exir.backend.compile_spec_schema import CompileSpec
 from torch._export import capture_pre_autograd_graph
 from torch.export import export
 
@@ -45,7 +45,7 @@ class TestBasicNN(unittest.TestCase):
                 print("  Skipping, no inputs for this profile")
                 continue
             model_edge, exec_prog = export_model(
-                model, inputs, [CompileSpec("output_format", bytes("tosa", "utf8"))]
+                model, inputs, generate_tosa_compile_spec()
             )
 
     def test_minimal_BI(self):
@@ -56,7 +56,7 @@ class TestBasicNN(unittest.TestCase):
                 print("  Skipping, no inputs for this profile")
                 continue
             model_edge, exec_prog = export_model(
-                model, inputs, [CompileSpec("output_format", bytes("tosa", "utf8"))]
+                model, inputs, generate_tosa_compile_spec()
             )
 
     def test_minimal_BI_INT(self):
@@ -69,7 +69,7 @@ class TestBasicNN(unittest.TestCase):
                 print("  Skipping, no inputs for this profile")
                 continue
             model_edge, exec_prog = export_model(
-                model, inputs, [CompileSpec("output_format", bytes("tosa", "utf8"))]
+                model, inputs, generate_tosa_compile_spec()
             )
 
 

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-# Copyright 2023 Arm Limited and/or its affiliates.
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -11,6 +11,7 @@ import argparse
 import logging
 
 import torch
+from executorch.backends.arm.arm_backend import generate_ethosu_compile_spec
 
 from executorch.backends.arm.arm_partitioner import ArmPartitioner
 from executorch.exir import EdgeCompileConfig, ExecutorchBackendConfig
@@ -132,7 +133,9 @@ if __name__ == "__main__":
     logging.info(f"Exported graph:\n{edge.exported_program().graph}")
 
     if args.delegate is True:
-        edge = edge.to_backend(ArmPartitioner())
+        edge = edge.to_backend(
+            ArmPartitioner(generate_ethosu_compile_spec("ethos-u55-128"))
+        )
         logging.info(f"Lowered graph:\n{edge.exported_program().graph}")
 
     exec_prog = edge.to_executorch(


### PR DESCRIPTION
Move the compiler flags passed to the backend up to the user in order to target different configurations.