### PR TITLE
Run llama in xplat

### DIFF
--- a/examples/models/llama2/sampler/test/targets.bzl
+++ b/examples/models/llama2/sampler/test/targets.bzl
@@ -16,7 +16,7 @@ def define_common_targets():
             "//executorch/examples/models/llama2/sampler:sampler_aten",
         ],
         xplat_deps = [
-            "//caffe2:torch_mobile_all_ops",
+            "//caffe2:torch_mobile_all_ops_et",
         ],
         fbcode_deps = [
             "//caffe2:torch-cpp",

--- a/extension/aten_util/test/targets.bzl
+++ b/extension/aten_util/test/targets.bzl
@@ -25,6 +25,6 @@ def define_common_targets():
             "//xplat/caffe2/c10:c10",
             # Dont really like this but without this I dont have aten::empty
             # And havent figured out a more minimal target
-            "//xplat/caffe2:torch_mobile_all_ops",
+            "//xplat/caffe2:torch_mobile_all_ops_et",
         ],
     )

--- a/extension/pytree/aten_util/test/targets.bzl
+++ b/extension/pytree/aten_util/test/targets.bzl
@@ -15,6 +15,6 @@ def define_common_targets():
             "//caffe2:torch-cpp",
         ],
         xplat_deps = [
-            "//xplat/caffe2:torch_mobile_all_ops",
+            "//xplat/caffe2:torch_mobile_all_ops_et",
         ],
     )

--- a/shim/xplat/executorch/codegen/codegen.bzl
+++ b/shim/xplat/executorch/codegen/codegen.bzl
@@ -384,7 +384,7 @@ def executorch_generated_lib(
         deps: Additinal deps of the main C++ library. Needs to be in either `//executorch` or `//caffe2` module.
         platforms: platforms args to runtime.cxx_library (only used when in xplat)
         manual_registration: if true, generate RegisterKernels.cpp and RegisterKernels.h.
-        use_default_aten_ops_lib: If `aten_mode` is True AND this flag is True, use `torch_mobile_all_ops` for ATen operator library.
+        use_default_aten_ops_lib: If `aten_mode` is True AND this flag is True, use `torch_mobile_all_ops_et` for ATen operator library.
         xplat_deps: Additional xplat deps, can be used to provide custom operator library.
         fbcode_deps: Additional fbcode deps, can be used to provide custom operator library.
         compiler_flags: compiler_flags args to runtime.cxx_library


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/118831

Error running llama in xplat, where half type isnt part of c10_mobile targets. See:  D53158320

This diff:
- Creates a `torch_mobile_all_ops_et` target, which is the same as `torch_mobile_all_ops`, except with a preprocessor flag (C10_MOBILE_HALF) to support Half type
- Check C10_MOBILE_HALF in LinearAlgebra.cpp and include it
- Use `torch_mobile_all_ops_et` for executorch, instead of `torch_mobile_all_ops`. 

Considerations:
- Using `torch_mobile_all_ops_et` across executorch means that our runtime binary size for xplat aten increases (see test plan for increase amount, thanks tarun292 for the pointer). This may be okay, as aten mode isn't used in production.

Reviewed By: larryliu0820

Differential Revision: D53292674


