### PR TITLE
Serialize the flag of appending EOS tokens into the model

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -179,6 +179,8 @@ def _export_llama(modelname, args) -> str:
 
     # metadata that we want to serialize into .pte file
     metadata = get_metadata(model.params)
+    # For language llama, tell the runtime to always append EOS toekn(s) to prompt.
+    metadata["append_eos_to_prompt"] = args.fairseq2
 
     if args.use_kv_cache:
         # seq length is fixed to 1 with current kv cache impl

--- a/examples/models/llama2/main.cpp
+++ b/examples/models/llama2/main.cpp
@@ -15,11 +15,6 @@ DEFINE_string(
     "llama2.pte",
     "Model serialized in flatbuffer format.");
 
-DEFINE_bool(
-    eos,
-    false,
-    "Whether to append an end-of-sentence token to the end of the prompt");
-
 DEFINE_string(tokenizer_path, "tokenizer.bin", "Tokenizer stuff.");
 
 DEFINE_string(prompt, "The answer to the ultimate question is", "Prompt.");
@@ -40,7 +35,7 @@ int32_t main(int32_t argc, char** argv) {
   ::torch::executor::Runner runner(model_path, tokenizer_path);
 
   // generate
-  runner.generate(prompt, FLAGS_eos);
+  runner.generate(prompt);
 
   return 0;
 }

--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -53,6 +53,7 @@ Runner::Runner(const char* model_path, const char* tokenizer_path) {
   n_eos_ = getMetadataHelper<int64_t>("get_n_eos", 1);
   max_seq_len_ = getMetadataHelper<int64_t>("get_max_seq_len", 128);
   use_kv_cache_ = getMetadataHelper("use_kv_cache", false);
+  append_eos_ = getMetadataHelper("append_eos_to_prompt", false);
 
   // Load tokenizer
   tokenizer_ = std::make_unique<Tokenizer>(vocab_size_, bos_id_, eos_id_);
@@ -134,7 +135,6 @@ int32_t Runner::logitsToToken(
 
 Error Runner::generate(
     const char* prompt,
-    bool eos,
     std::function<void(const std::string&)> callback) {
   // Prepare the inputs.
   // Use ones-initialized inputs.
@@ -146,7 +146,11 @@ Error Runner::generate(
   int* prompt_tokens = new int[strlen(prompt) + 1 + n_bos_ + n_eos_];
 
   tokenizer_->encode(
-      prompt, n_bos_, eos ? n_eos_ : 0, prompt_tokens, &num_prompt_tokens);
+      prompt,
+      n_bos_,
+      append_eos_ ? n_eos_ : 0,
+      prompt_tokens,
+      &num_prompt_tokens);
   for (int i = 0; i < num_prompt_tokens; i++) {
     ET_LOG(Info, "prompt_tokens[%d]: %d", i, prompt_tokens[i]);
   }

--- a/examples/models/llama2/runner/runner.h
+++ b/examples/models/llama2/runner/runner.h
@@ -30,7 +30,6 @@ class Runner {
 
   Error generate(
       const char* prompt,
-      bool eos = false,
       std::function<void(const std::string&)> callback = {});
 
  private:
@@ -49,6 +48,7 @@ class Runner {
   int32_t n_eos_;
   int32_t max_seq_len_;
   bool use_kv_cache_;
+  bool append_eos_;
   std::unordered_set<std::string> model_methods_;
   // module
   std::unique_ptr<Module> module_;

--- a/examples/models/llama2/runner/runner.h
+++ b/examples/models/llama2/runner/runner.h
@@ -33,8 +33,12 @@ class Runner {
       std::function<void(const std::string&)> callback = {});
 
  private:
-  std::vector<int32_t> readMetadata(
-      std::unordered_set<std::string> method_names);
+  // metadata
+  template <typename T>
+  T getMetadataHelper(std::string method_name, T default_val);
+  template <typename T>
+  int32_t
+  logitsToToken(const exec_aten::Tensor& logits_tensor, int64_t pos, T _);
   // metadata
   int32_t vocab_size_;
   int32_t bos_id_;
@@ -42,6 +46,7 @@ class Runner {
   int32_t n_bos_;
   int32_t n_eos_;
   int32_t max_seq_len_;
+  std::unordered_set<std::string> model_methods_;
   // module
   std::unique_ptr<Module> module_;
   // tokenizer

--- a/examples/models/llama2/runner/runner.h
+++ b/examples/models/llama2/runner/runner.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -39,6 +40,7 @@ class Runner {
   template <typename T>
   int32_t
   logitsToToken(const exec_aten::Tensor& logits_tensor, int64_t pos, T _);
+  std::vector<exec_aten::SizesType> getKVCacheShape();
   // metadata
   int32_t vocab_size_;
   int32_t bos_id_;
@@ -46,6 +48,7 @@ class Runner {
   int32_t n_bos_;
   int32_t n_eos_;
   int32_t max_seq_len_;
+  bool use_kv_cache_;
   std::unordered_set<std::string> model_methods_;
   // module
   std::unique_ptr<Module> module_;

--- a/examples/models/llama2/runner/targets.bzl
+++ b/examples/models/llama2/runner/targets.bzl
@@ -20,10 +20,13 @@ def define_common_targets():
                 "@EXECUTORCH_CLIENTS",
             ],
             exported_deps = [
+                "//executorch/backends/xnnpack:xnnpack_backend",
                 "//executorch/examples/models/llama2/sampler:sampler" + aten_suffix,
                 "//executorch/examples/models/llama2/tokenizer:tokenizer",
                 "//executorch/extension/evalue_util:print_evalue" + aten_suffix,
+                "//executorch/extension/runner_util:managed_tensor" + aten_suffix,
                 "//executorch/extension/module:module" + aten_suffix,
+                "//executorch/kernels/quantized:generated_lib" + aten_suffix,
                 "//executorch/kernels/portable:" + ("generated_lib_aten" if aten else "generated_lib_all_ops"),
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
             ],

--- a/extension/runner_util/managed_tensor.h
+++ b/extension/runner_util/managed_tensor.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
+#ifdef USE_ATEN_LIB
+#include <torch/torch.h>
+#else
+#include <executorch/runtime/core/portable_type/tensor.h>
+#endif
+#pragma once
+
+namespace torch {
+namespace executor {
+
+/**
+ * A tensor wrapper takes ownership of all the memory of the necessary metadata
+ * for torch::executor::Tensor. Note that it doesn't own the data memory.
+ */
+class ManagedTensor {
+ public:
+  /// The type used for elements of `sizes()`.
+  using SizesType = exec_aten::SizesType;
+  /// The type used for elements of `dim_order()`.
+  using DimOrderType = exec_aten::DimOrderType;
+  /// The type used for elements of `strides()`.
+  using StridesType = exec_aten::StridesType;
+  ManagedTensor() = delete;
+
+  explicit ManagedTensor(
+      void* data,
+      ssize_t numel,
+      const std::vector<SizesType>& sizes,
+      ScalarType dtype)
+      : dtype_(dtype), sizes_(sizes), data_ptr_(data) {
+#ifdef USE_ATEN_LIB
+    tensor_ = torch::from_blob(data, sizes, dtype);
+#else
+    ssize_t dim = sizes.size();
+    dim_order_.resize(dim);
+    strides_.resize(dim);
+    for (size_t i = 0; i < dim; ++i) {
+      dim_order_[i] = i;
+    }
+    dim_order_to_stride_nocheck(
+        sizes.data(), dim_order_.data(), dim, strides_.data());
+    tensor_impl_ = std::make_unique<TensorImpl>(
+        dtype,
+        dim,
+        sizes_.data(),
+        data_ptr_,
+        dim_order_.data(),
+        strides_.data(),
+        TensorShapeDynamism::STATIC);
+#endif
+  }
+
+  /**
+   * Get the underlying Tensor object. This is assuming the copying is cheap.
+   */
+  Tensor get_aliasing_tensor() {
+#ifdef USE_ATEN_LIB
+    return tensor_;
+#else
+    return Tensor(tensor_impl_.get());
+#endif
+  }
+
+ private:
+  ScalarType dtype_;
+  std::unique_ptr<TensorImpl> tensor_impl_;
+  std::vector<SizesType> sizes_;
+  std::vector<StridesType> strides_;
+  std::vector<DimOrderType> dim_order_;
+  void* data_ptr_ = nullptr;
+#ifdef USE_ATEN_LIB
+  Tensor tensor_;
+#endif
+};
+} // namespace executor
+} // namespace torch

--- a/extension/runner_util/targets.bzl
+++ b/extension/runner_util/targets.bzl
@@ -26,3 +26,17 @@ def define_common_targets():
                 "//executorch/runtime/executor:program" + aten_suffix,
             ],
         )
+
+        runtime.cxx_library(
+            name = "managed_tensor" + aten_suffix,
+            exported_headers = [
+                "managed_tensor.h",
+            ],
+            visibility = [
+                "//executorch/...",
+                "@EXECUTORCH_CLIENTS",
+            ],
+            deps = [
+                "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
+            ],
+        )

--- a/runtime/core/exec_aten/exec_aten.h
+++ b/runtime/core/exec_aten/exec_aten.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <executorch/runtime/core/tensor_shape_dynamism.h> // @manual
-
 #ifdef USE_ATEN_LIB
 #include <ATen/Tensor.h> // @manual
 #include <c10/core/Device.h>


### PR DESCRIPTION
Summary:
Previously we need to pass in a flag into runner so that it conditionally append EOS tokens to prompt tokens.

This is flexible for the runtime to use llama2 7b, where the user can let llama2 finish the sentence if no EOS is in the prompt, or have a conversation where EOS is in the prompt.

However it is harder to control and is a footgun for developers to debug. This diff serialize the flag into the model and simplify the runner logic.

Reviewed By: shoumikhin, mikekgfb

Differential Revision: D53361647


