### PR TITLE
Fix use_static_deps

### DIFF
--- a/shim/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim/xplat/executorch/build/runtime_wrapper.bzl
@@ -60,13 +60,16 @@ def _patch_executorch_references(targets, use_static_deps = False):
             fail("References to executorch build targets must use " +
                  "`//executorch`, not `//xplat/executorch`")
 
-        # change the name of target reference to satisfy the build environment.
-        if env.target_needs_patch(target):
-            target = env.patch_target_for_env(target)
-
         # TODO(larryliu0820): it's confusing that we only apply "static" patch to target_needs_patch. We need to clean this up.
         if use_static_deps and env.target_needs_patch(target) and not target.endswith("..."):
             target = target + "_static"
+
+        # Change the name of target reference to satisfy the build environment.
+        # This needs to happen after any other target_needs_patch calls, because
+        # it can modify the prefix of the target.
+        if env.target_needs_patch(target):
+            target = env.patch_target_for_env(target)
+
         out_targets.append(target)
     return out_targets
 


### PR DESCRIPTION
Summary:
The patching logic wasn't actually modifying deps to use the `_static` targets when a top-level target specified `use_static_deps`.

E.g.,
```
buck2 cquery "fbsource//xplat/executorch/extension/module:module_static" --output-attribute buck.deps | grep /executorch
```
showed that this target depended on non-static deps
```
  "fbsource//xplat/executorch/extension/module:module_static (cfg:linux-x86_64-fbcode-platform010-asan-ubsan-dev#2092a9d2d16c9cde)": {
      "fbsource//xplat/executorch/extension/memory_allocator:malloc_memory_allocator (cfg:linux-x86_64-fbcode-platform010-asan-ubsan-dev#2092a9d2d16c9cde)",
      "fbsource//xplat/executorch/extension/data_loader:mmap_data_loader (cfg:linux-x86_64-fbcode-platform010-asan-ubsan-dev#2092a9d2d16c9cde)",
      "fbsource//xplat/executorch/runtime/executor:program (cfg:linux-x86_64-fbcode-platform010-asan-ubsan-dev#2092a9d2d16c9cde)",
```
instead of depending on the `_static` versions of those targets.

This happened because `_patch_executorch_references()` was calling `env.patch_target_for_env(target)` (which can add a prefix like `//xplat`) prefix before calling `env.target_needs_patch(target)` (which checks the prefix of the targets).

So, now we do the `patch_target_for_env()` after all other calls to `target_needs_patch()`.

Reviewed By: larryliu0820, kirklandsign

Differential Revision: D53374745


