### PR TITLE
fix tests

### DIFF
--- a/exir/backend/test/test_backends_lifted.py
+++ b/exir/backend/test/test_backends_lifted.py
@@ -512,7 +512,7 @@ class TestBackends(unittest.TestCase):
         class NonLowerableSubModel(torch.nn.Module):
             def __init__(self, bias):
                 super().__init__()
-                self.bias = bias
+                self.register_buffer("bias", bias)
 
             def forward(self, a, b):
                 return torch.add(torch.add(a, b), self.bias)
@@ -882,7 +882,7 @@ class TestBackends(unittest.TestCase):
         class AddOne(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.one = torch.ones(1, 3)
+                self.register_buffer("one", torch.ones(1, 3))
 
             def forward(self, x):
                 return x + self.one


### PR DESCRIPTION
Summary:
Continued fallout from https://github.com/pytorch/pytorch/pull/118969.

The major issue here is a clash between how we implemented multi-method capture in executorch with some invariants export would like to maintain.

Today, we do multi-method capture in executorch by trying to trace a method obj.

We've been trying to tighten up the invariants around export to make it require a module input and preserve properties about that input correctly (like the state dict). But exporting a method (or a method called from WrapperModule) will not behave correctly.

I think we should do some work here to align the design more fundmantally (will file a task), but restoring the tests to health for now

Differential Revision: D53398032


