### PR TITLE
Migrate the macOS runners label from macos-m1-12 to macos-m1-stable

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -16,7 +16,7 @@ from examples.xnnpack import MODEL_NAME_TO_OPTIONS
 
 DEFAULT_RUNNERS = {
     "linux": "linux.2xlarge",
-    "macos": "macos-m1-12",
+    "macos": "macos-m1-stable",
 }
 CUSTOM_RUNNERS = {
     "linux": {

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -46,7 +46,7 @@ jobs:
         include:
           - build-tool: buck2
     with:
-      runner: macos-m1-12
+      runner: macos-m1-stable
       python-version: '3.11'
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -70,7 +70,7 @@ jobs:
           - build-tool: cmake
       fail-fast: false
     with:
-      runner: macos-m1-12
+      runner: macos-m1-stable
       python-version: '3.11'
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -96,7 +96,7 @@ jobs:
           - build-tool: cmake
       fail-fast: false
     with:
-      runner: macos-m1-12
+      runner: macos-m1-stable
       python-version: '3.11'
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
There is a new label for our macOS runners: "macos-m1-stable". All runners labeled "macos-m1-12" should be switched to "macos-m1-stable". [Here](https://fb.workplace.com/groups/pytorch.dev.perf.infra.teams/permalink/7546708885348237/) you can find more detailed info.