### PR TITLE
Add gcc to executorch ci

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -14,20 +14,28 @@ echo "Building ${IMAGE_NAME} Docker image"
 
 OS=ubuntu
 OS_VERSION=22.04
-CLANG_VERSION=12
+CLANG_VERSION=""
+GCC_VERSION=""
 PYTHON_VERSION=3.10
 MINICONDA_VERSION=23.10.0-1
 BUCK2_VERSION=$(cat ci_commit_pins/buck2.txt)
 
 case "${IMAGE_NAME}" in
+  executorch-ubuntu-22.04-gcc9)
+    LINTRUNNER=""
+    GCC_VERSION=9
+    ;;
   executorch-ubuntu-22.04-clang12)
     LINTRUNNER=""
+    CLANG_VERSION=12
     ;;
   executorch-ubuntu-22.04-linter)
     LINTRUNNER=yes
+    CLANG_VERSION=12
     ;;
   executorch-ubuntu-22.04-arm-sdk)
     ARM_SDK=yes
+    CLANG_VERSION=12
     ;;
   *)
     echo "Invalid image name ${IMAGE_NAME}"
@@ -50,6 +58,7 @@ docker build \
   --progress=plain \
   --build-arg "OS_VERSION=${OS_VERSION}" \
   --build-arg "CLANG_VERSION=${CLANG_VERSION}" \
+  --build-arg "GCC_VERSION=${GCC_VERSION}" \
   --build-arg "PYTHON_VERSION=${PYTHON_VERSION}" \
   --build-arg "MINICONDA_VERSION=${MINICONDA_VERSION}" \
   --build-arg "TORCH_VERSION=${TORCH_VERSION}" \

--- a/.ci/docker/common/install_gcc.sh
+++ b/.ci/docker/common/install_gcc.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -ex
+
+if [ -n "$GCC_VERSION" ]; then
+
+  apt-get update
+  apt-get install -y g++-"$GCC_VERSION"
+  update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-"$GCC_VERSION" 50
+  update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-"$GCC_VERSION" 50
+  update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-"$GCC_VERSION" 50
+
+
+  # Cleanup package manager
+  apt-get autoclean && apt-get clean
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+fi

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -20,6 +20,11 @@ ARG CLANG_VERSION
 COPY ./common/install_clang.sh install_clang.sh
 RUN bash ./install_clang.sh && rm install_clang.sh
 
+# Install gcc
+ARG GCC_VERSION
+COPY ./common/install_gcc.sh install_gcc.sh
+RUN bash ./install_gcc.sh && rm install_gcc.sh
+
 # Setup buck
 ARG BUCK2_VERSION
 COPY ./common/install_buck.sh install_buck.sh

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -34,6 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - docker-image-name: executorch-ubuntu-22.04-gcc9
           - docker-image-name: executorch-ubuntu-22.04-clang12
           - docker-image-name: executorch-ubuntu-22.04-linter
           - docker-image-name: executorch-ubuntu-22.04-arm-sdk

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -31,6 +31,31 @@ jobs:
 
           PYTHONPATH="${PWD}" python .ci/scripts/gather_test_models.py --event "${GITHUB_EVENT_NAME}"
 
+  test-setup-linux-gcc:
+    name: test-setup-linux-gcc
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    strategy:
+      matrix:
+        include:
+          - build-tool: cmake
+      fail-fast: false
+    with:
+      runner: linux.2xlarge
+      docker-image: executorch-ubuntu-22.04-gcc9
+      submodules: 'true'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 90
+      script: |
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        BUILD_TOOL=${{ matrix.build-tool }}
+
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+        # Build and test ExecuTorch with the add model on portable backend.
+        PYTHON_EXECUTABLE=python bash .ci/scripts/test.sh "add" "${BUILD_TOOL}" "portable"
+
   test-models-linux:
     name: test-models-linux
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main


### PR DESCRIPTION
Summary: Use gcc to build executorch setup

Differential Revision: D53373332


