### PR TITLE
Ban tensor constants in tracing.

### DIFF
--- a/backends/xnnpack/test/TARGETS
+++ b/backends/xnnpack/test/TARGETS
@@ -57,6 +57,7 @@ runtime.python_test(
         "fbsource//third-party/pypi/transformers:transformers",  # @manual
         "//executorch/backends/xnnpack/test/tester:tester",
         "//executorch/examples/models/llama2:llama2_model",
+        "//executorch/examples/models/mobilebert:mobilebert_model",
         "//pytorch/audio/src:torchaudio_core",
         "//pytorch/vision:torchvision",  # @manual
     ],

--- a/backends/xnnpack/test/models/mobilebert.py
+++ b/backends/xnnpack/test/models/mobilebert.py
@@ -8,11 +8,11 @@ import unittest
 
 import torch
 from executorch.backends.xnnpack.test.tester import Tester
-from transformers import MobileBertConfig, MobileBertModel  # @manual
+from executorch.examples.models.mobilebert.modeling_mobilebert import MobileBertModel
+from transformers import MobileBertConfig  # @manual
 
 
 class TestMobilebert(unittest.TestCase):
-    # pyre-ignore
     mobilebert = MobileBertModel(MobileBertConfig()).eval()
     example_inputs = (torch.tensor([[101, 7592, 1010, 2026, 3899, 2003, 10140, 102]]),)
     supported_ops = {

--- a/docs/source/sdk-bundled-io.md
+++ b/docs/source/sdk-bundled-io.md
@@ -330,8 +330,8 @@ from torch.export import export
 class Module(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.a = 3 * torch.ones(2, 2, dtype=torch.float)
-        self.b = 2 * torch.ones(2, 2, dtype=torch.float)
+        self.register("a", 3 * torch.ones(2, 2, dtype=torch.float))
+        self.register("b", 2 * torch.ones(2, 2, dtype=torch.float))
 
     def forward(self, x):
         out_1 = torch.ones(2, 2, dtype=torch.float)
@@ -465,8 +465,8 @@ from torch.export import export
 class Module(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.a = 3 * torch.ones(2, 2, dtype=torch.float)
-        self.b = 2 * torch.ones(2, 2, dtype=torch.float)
+        self.register_buffer("a", 3 * torch.ones(2, 2, dtype=torch.float))
+        self.register_buffer("b", 2 * torch.ones(2, 2, dtype=torch.float))
 
     def forward(self, x):
         out_1 = torch.ones(2, 2, dtype=torch.float)

--- a/examples/models/mobilebert/model.py
+++ b/examples/models/mobilebert/model.py
@@ -8,9 +8,10 @@ import logging
 
 import torch
 
-from transformers import AutoTokenizer, MobileBertModel  # @manual
+from transformers import AutoTokenizer  # @manual
 
 from ..model_base import EagerModelBase
+from .modeling_mobilebert import MobileBertModel
 
 
 class MobileBertModelExample(EagerModelBase):
@@ -19,7 +20,6 @@ class MobileBertModelExample(EagerModelBase):
 
     def get_eager_model(self) -> torch.nn.Module:
         logging.info("loading mobilebert model")
-        # pyre-ignore
         model = MobileBertModel.from_pretrained(
             "google/mobilebert-uncased", return_dict=False
         )

--- a/examples/models/mobilebert/modeling_mobilebert.py
+++ b/examples/models/mobilebert/modeling_mobilebert.py
@@ -1,0 +1,83 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional, Tuple
+
+import torch
+
+from transformers.models.mobilebert.modeling_mobilebert import (
+    MobileBertLayer as MobileBertLayerBase,
+    MobileBertModel as MobileBertModelBase,
+)
+
+
+class MobileBertLayer(torch.nn.Module):
+    def __init__(self, base):
+        super().__init__()
+        assert isinstance(base, MobileBertLayerBase)
+        self.base = base
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        output_attentions: Optional[bool] = None,
+    ) -> Tuple[torch.Tensor]:
+        if self.base.use_bottleneck:
+            query_tensor, key_tensor, value_tensor, layer_input = self.base.bottleneck(
+                hidden_states
+            )
+        else:
+            query_tensor, key_tensor, value_tensor, layer_input = [hidden_states] * 4
+
+        self_attention_outputs = self.base.attention(
+            query_tensor,
+            key_tensor,
+            value_tensor,
+            layer_input,
+            attention_mask,
+            head_mask,
+            output_attentions=output_attentions,
+        )
+        attention_output = self_attention_outputs[0]
+        s = (attention_output,)
+        outputs = self_attention_outputs[
+            1:
+        ]  # add self attentions if we output attention weights
+
+        if self.base.num_feedforward_networks != 1:
+            for i, ffn_module in enumerate(self.base.ffn):
+                attention_output = ffn_module(attention_output)
+                s += (attention_output,)
+
+        intermediate_output = self.base.intermediate(attention_output)
+        layer_output = self.base.output(
+            intermediate_output, attention_output, hidden_states
+        )
+        outputs = (
+            (layer_output,)
+            + outputs
+            + (
+                torch.scalar_tensor(1000, dtype=torch.int64),
+                query_tensor,
+                key_tensor,
+                value_tensor,
+                layer_input,
+                attention_output,
+                intermediate_output,
+            )
+            + s
+        )
+        return outputs
+
+
+class MobileBertModel(MobileBertModelBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        layer = self.encoder.layer
+        assert isinstance(layer, torch.nn.ModuleList)
+        self.encoder.layer = torch.nn.ModuleList([MobileBertLayer(x) for x in layer])

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -51,6 +51,8 @@ class WrapperModule(torch.nn.Module):
     def __init__(self, fn):
         super().__init__()
         self.fn = fn
+        if hasattr(fn, "__self__"):
+            self.mod = fn.__self__
 
     def forward(self, *args, **kwargs):
         return self.fn(*args, **kwargs)
@@ -293,8 +295,8 @@ class TestEmit(unittest.TestCase):
         class OpRepeatedModule(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.a = torch.ones(2, 2)
-                self.b = 2 * torch.ones(2, 2)
+                self.register_buffer("a", torch.ones(2, 2))
+                self.register_buffer("b", 2 * torch.ones(2, 2))
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 for _ in range(10):
@@ -403,8 +405,8 @@ class TestEmit(unittest.TestCase):
         class Module_out(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.a = 3 * torch.ones(2, 2, dtype=torch.int32)
-                self.b = 2 * torch.ones(2, 2, dtype=torch.int32)
+                self.register_buffer("a", 3 * torch.ones(2, 2, dtype=torch.int32))
+                self.register_buffer("b", 2 * torch.ones(2, 2, dtype=torch.int32))
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 z = x.clone()
@@ -1300,8 +1302,8 @@ class TestEmit(unittest.TestCase):
             def __init__(self):
                 super(ModWithWeightViews, self).__init__()
                 self.W = torch.nn.Parameter(torch.randn(2))
-                self.W1 = self.W[:1]
-                self.W2 = self.W[1:]
+                self.register_buffer("W1", self.W[:1])
+                self.register_buffer("W2", self.W[1:])
 
             def forward(self, x):
                 return self.W1 + self.W2 + x

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -1071,7 +1071,7 @@ class TestPasses(unittest.TestCase):
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.a = torch.ones(2)
+                self.register_buffer("a", torch.ones(2))
 
             def forward(self, x):
                 return torch.arange(start=0, end=2) + x
@@ -1087,7 +1087,7 @@ class TestPasses(unittest.TestCase):
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.a = torch.ones(10)
+                self.register_buffer("a", torch.ones(10))
 
             def forward(self, x):
                 return self.a[:2] + x

--- a/exir/tests/test_verification.py
+++ b/exir/tests/test_verification.py
@@ -62,8 +62,8 @@ class TestVerification(unittest.TestCase):
         class Op1(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.a = torch.ones(2, 2)
-                self.b = 2 * torch.ones(2, 2)
+                self.register_buffer("a", torch.ones(2, 2))
+                self.register_buffer("b", 2 * torch.ones(2, 2))
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 for _ in range(10):
@@ -74,8 +74,8 @@ class TestVerification(unittest.TestCase):
         class Op2(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.a = torch.ones(2, 2)
-                self.b = 2 * torch.ones(2, 2)
+                self.register_buffer("a", torch.ones(2, 2))
+                self.register_buffer("b", 2 * torch.ones(2, 2))
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 for _ in range(10):
@@ -120,8 +120,8 @@ class TestVerification(unittest.TestCase):
         class Op2(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.a = torch.ones(2, 2)
-                self.b = 2 * torch.ones(2, 2)
+                self.register_buffer("a", torch.ones(2, 2))
+                self.register_buffer("b", 2 * torch.ones(2, 2))
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 for _ in range(10):

--- a/test/models/export_program.py
+++ b/test/models/export_program.py
@@ -52,12 +52,13 @@ class ModuleBasic(nn.Module):
 class ModuleIndex(nn.Module):
     def __init__(self):
         super(ModuleIndex, self).__init__()
+        self.register_buffer("b", torch.tensor([1, 2]))
 
     def forward(self, x):
         # Weird index that happens to generate a None in torch.index.Tensor_out
         # which is desirable for deserialization testing. A modified form of
         # an example index from https://pytorch.org/cppdocs/notes/tensor_indexing.html.
-        return x[1::2, torch.tensor([1, 2])]
+        return x[1::2, self.b]
 
     def get_random_inputs(self):
         return (torch.randn(10, 10, 10),)
@@ -131,8 +132,8 @@ class ModuleDynamicCatUnallocatedIO(nn.Module):
 class ModuleLinear(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.a = 3 * torch.ones(2, 2, dtype=torch.float)
-        self.b = 2 * torch.ones(2, 2, dtype=torch.float)
+        self.register_buffer("a", 3 * torch.ones(2, 2, dtype=torch.float))
+        self.register_buffer("b", 2 * torch.ones(2, 2, dtype=torch.float))
 
     def forward(self, x: torch.Tensor):
         out_1 = torch.mul(self.a, x)
@@ -146,8 +147,8 @@ class ModuleLinear(torch.nn.Module):
 class ModuleMultipleEntry(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.a = 3 * torch.ones(2, 2, dtype=torch.float)
-        self.b = 2 * torch.ones(2, 2, dtype=torch.float)
+        self.register_buffer("a", 3 * torch.ones(2, 2, dtype=torch.float))
+        self.register_buffer("b", 2 * torch.ones(2, 2, dtype=torch.float))
 
     def forward(self, x: torch.Tensor):
         return x + self.a

--- a/test/models/linear_model.py
+++ b/test/models/linear_model.py
@@ -10,8 +10,8 @@ import torch
 class LinearModel(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.a = 3 * torch.ones(2, 2, dtype=torch.float)
-        self.b = 2 * torch.ones(2, 2, dtype=torch.float)
+        self.register_buffer("a", 3 * torch.ones(2, 2, dtype=torch.float))
+        self.register_buffer("b", 2 * torch.ones(2, 2, dtype=torch.float))
 
     def forward(self, x: torch.Tensor):
         out_1 = torch.mul(self.a, x)


### PR DESCRIPTION
Summary:
There're two patterns resulting in the similar constant lifting effect during tracing:
```
def forward(self, x):
    return x + torch.tensor(...)
```
and
```
class Model(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.a = torch.tensor(...)
     def forward(self, x):
         return x + self.a
```
In theory and practice, it will be too implicit to promote them as buffers in tracing, due to two reasons:

1. They don't have a formal FQN.
2. They likely result in baked-in values without being noticed by users.
3. Their values can be easily mutated without being noticed by users.

Therefore we want to make a policy decision to ban any form of tensor constants to show up in the traced graph. To proceed in the tracing, users either need to register these constants explicitly as buffers, or use constructors to properly initialize them. In some cases, users can get away without even wrapping scalars inside a torch.tensor() call.

Differential Revision: D53436364


