### PR TITLE
turn back on const prop passes

### DIFF
--- a/exir/passes/TARGETS
+++ b/exir/passes/TARGETS
@@ -9,6 +9,7 @@ python_library(
     ],
     deps = [
         ":const_prop_pass",
+        ":constant_prop_pass",
         ":debug_handle_generator_pass",
         ":memory_format_ops_pass",
         ":memory_planning_pass",

--- a/exir/passes/__init__.py
+++ b/exir/passes/__init__.py
@@ -33,6 +33,7 @@ from executorch.exir.operator.convert import (
 from executorch.exir.pass_base import ExportPass
 from executorch.exir.pass_manager import PassManager, PassType
 from executorch.exir.passes.const_prop_pass import ConstPropPass
+from executorch.exir.passes.constant_prop_pass import constant_prop_pass
 from executorch.exir.passes.debug_handle_generator_pass import DebugHandleGeneratorPass
 
 from executorch.exir.passes.executorch_prim_ops_registry import _EXECUTORCH_SYM_OPS
@@ -65,6 +66,7 @@ __all__ = [
     "MemoryFormatOpsPass",
     "MemoryPlanningPass",
     "HintBasedSymShapeEvalPass",
+    "constant_prop_pass",
 ]
 
 Argument = Optional[

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -25,6 +25,7 @@ from executorch.exir.passes import (
     post_op_replace_passes,
     pre_op_replace_passes,
 )
+from executorch.exir.passes.constant_prop_pass import constant_prop_pass
 from executorch.exir.passes.remove_graph_asserts_pass import RemoveGraphAssertsPass
 from executorch.exir.passes.remove_mixed_type_operators import RemoveMixedTypeOperators
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
@@ -861,6 +862,7 @@ def to_edge(
         )
         # Lift the tensor constants created in ScalarToTensorPass
         edge_program = lift_constant_tensor_pass(edge_program)
+        edge_program = constant_prop_pass(edge_program)
         edge_program = _transform(edge_program, *post_op_replace_passes)
         edge_programs[name] = edge_program
     return EdgeProgramManager(edge_programs, constant_methods, config)


### PR DESCRIPTION
Summary: Not sure why these were turned off. The names of these are also not great ConstPropPass handles getattrs and constant_prop_pass handles placeholders. Ideally only constant_prop_pass will be needed soon. getattrs can still appear from scalar_to_tensor but angela is looking into it

Differential Revision: D53484600


