### PR TITLE
Enable running examples/arm/setup.sh

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -174,6 +174,10 @@ jobs:
         install_flatc_from_source
         install_executorch
 
+        git config --global user.email "github_executorch@arm.com"
+        git config --global user.name "Github Executorch"
+        bash examples/arm/setup.sh --i-agree-to-the-contained-eula
+
         source /opt/arm-sdk/setup_path.sh
         PYTHON_EXECUTABLE=python bash backends/arm/test/run_tosa_reference.sh
 

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -197,7 +197,7 @@ function setup_vela() {
         patch_repo
     fi
     cd "${root_dir}/ethos-u-vela"
-    pip install .
+    pip3 install . --user
 }
 
 ########


### PR DESCRIPTION
- The setup.sh script has never been enabled in the CI
- Enable running this script