### PR TITLE
Fix lifting constants

### DIFF
--- a/exir/emit/test/TARGETS
+++ b/exir/emit/test/TARGETS
@@ -18,6 +18,7 @@ python_unittest(
         "//executorch/exir/backend:backend_api",
         "//executorch/exir/emit:lib",
         "//executorch/exir/passes:const_prop_pass",
+        "//executorch/exir/passes:constant_prop_pass",
         "//executorch/exir/tests:lib",
         "//executorch/exir/tests:models",
         "//executorch/extension/pybindings:portable_lib",  # @manual

--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -150,6 +150,19 @@ class TestProgramManagers(unittest.TestCase):
             3,
         )
 
+    def test_no_getattr(self):
+        class Mul(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x * 3.14
+
+        mul = Mul()
+        ep = to_edge(torch.export.export(mul, (torch.ones(1),))).exported_program()
+        for node in ep.graph.nodes:
+            self.assertNotEqual(node.op, "get_attr")
+        self.assertEqual(
+            len([node for node in ep.graph.nodes if node.op == "placeholder"]), 2
+        )
+
     def test_constraint_present_after_dce(self):
         import executorch.exir as exir
 

--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -1039,7 +1039,7 @@ class ExportedProgramSerializer:
         constants = {}
         for n, c in gm_serializer.custom_objs.items():
             constants[n] = c
-        for n, t in exported_program.tensor_constants.items():
+        for n, t in exported_program.constants.items():
             assert n not in constants
             constants[n] = t
 
@@ -1709,9 +1709,7 @@ class ExportedProgramDeserializer:
         constants = deserialize_torch_artifact(serialized_artifact.constants)
 
         # TODO: No need to do this once CustomClassHolders are lifted to the ExportedProgram
-        tensor_constants = {
-            k: v for k, v in constants.items() if isinstance(v, torch.Tensor)
-        }
+        constants = {k: v for k, v in constants.items() if isinstance(v, torch.Tensor)}
 
         res = GraphModuleDeserializer().deserialize(
             serialized_artifact.exported_program.graph_module,  # pyre-ignore
@@ -1744,7 +1742,7 @@ class ExportedProgramDeserializer:
             verifier=load_verifier(
                 serialized_artifact.exported_program.dialect  # pyre-ignore
             ),
-            tensor_constants=tensor_constants,
+            constants=constants,  # type: ignore[arg-type]
         )
         return upgrader.upgrade(exported_program)
 

--- a/exir/serde/serialize.py
+++ b/exir/serde/serialize.py
@@ -337,7 +337,7 @@ class ExportedProgramSerializer(export_serialize.ExportedProgramSerializer):
         constants = {}
         for n, c in gm_serializer.custom_objs.items():
             constants[n] = c
-        for n, t in exported_program.tensor_constants.items():
+        for n, t in exported_program.constants.items():
             assert n not in constants
             constants[n] = t
 
@@ -647,14 +647,12 @@ class ExportedProgramDeserializer(export_serialize.ExportedProgramDeserializer):
         )
 
         # TODO: No need to do this once CustomClassHolders are lifted to the ExportedProgram
-        tensor_constants = {
-            k: v for k, v in constants.items() if isinstance(v, torch.Tensor)
-        }
+        constants = {k: v for k, v in constants.items() if isinstance(v, torch.Tensor)}
 
         res = GraphModuleDeserializer(state_dict).deserialize(
             serialized_artifact.exported_program.graph_module,  # pyre-ignore
             symbol_name_to_range,
-            tensor_constants,
+            constants,
         )
 
         graph_module = res.graph_module

--- a/exir/tests/TARGETS
+++ b/exir/tests/TARGETS
@@ -280,7 +280,6 @@ python_unittest(
         "//executorch/exir:lib",
         "//executorch/exir:schema",
         "//executorch/exir/passes:const_prop_pass",
-        "//executorch/exir/passes:lib",
         "//executorch/exir/verification:interpreter",
         "//executorch/exir/verification:verifier",
     ],

--- a/test/end2end/test_end2end.py
+++ b/test/end2end/test_end2end.py
@@ -514,7 +514,7 @@ def maketest(
             capture_config=capture_config,
         )
         if verify_graph:
-            verify_graph(self, module.graph_module)
+            verify_graph(self, module.exported_program.graph_module)
         print(f"inputs for tracing: {module.trace_inputs}")
 
         # compare the result between the eager module and graph module
@@ -526,8 +526,8 @@ def maketest(
                     # only one method is supported so just grab that single method
                     expected = getattr(module.eager_module, module.methods[0])(*inputs)
                 with torch.no_grad():
-                    result = module.graph_module(*inputs)
-                self.assertTrue(allclose(expected, result[0], rtol, atol))
+                    result = module.exported_program.module()(*inputs)
+                self.assertTrue(allclose(expected, result, rtol, atol))
 
         program = module.executorch_program.executorch_program
         pretty_print(program)


### PR DESCRIPTION
Summary: ScalarToTensorPass which is run as an aten_to_edge_pass lifts all scalars in the graph to tensors. However this breaks the contract that all constant tensors should be lifted as inputs. To fix this, we can move the lift_constants_pass to after the ScalarToTensorPass.

Differential Revision: D53454481


