### PR TITLE
Check named buffers in emitter, for non-persistent buffers

### DIFF
--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -1315,10 +1315,25 @@ class _TopLevelEmitter(_Emitter):
                 if target in self.exported_program.graph_signature.inputs_to_parameters
                 else self.exported_program.graph_signature.inputs_to_buffers[target]
             )
-            spec = TensorSpec.from_tensor(
-                self.exported_program.state_dict[fqn], const=True
-            )
-            const_tensor = True
+            if fqn in self.exported_program.state_dict:
+                spec = TensorSpec.from_tensor(
+                    self.exported_program.state_dict[fqn], const=True
+                )
+                const_tensor = True
+            else:
+                buffers = self.exported_program.named_buffers()
+                buf = next((x[1] for x in buffers if x[0] == fqn), None)
+                if buf is not None:
+                    spec = TensorSpec.from_tensor(buf, const=True)
+                    const_tensor = True
+                else:
+                    raise InternalError(
+                        self._emit_node_specific_error(
+                            self.node,
+                            f"Could not find buffer with fqn {fqn} in state_dict or named_buffers",
+                        )
+                    )
+
         evalue = (
             self._tensor_spec_to_evalue(spec)
             if isinstance(spec, TensorSpec)


### PR DESCRIPTION
Summary:
Non-persistent buffers should not show up in the state dict, after D53340041.
See [comments here](https://github.com/pytorch/pytorch/pull/118969/files#diff-4a060a24e1f81389eab7390d434dddf919af50aa8fda6cbd81e182a53bd9328eR2917-R2922).

freqs_cos and freqs_sin are [non-persistent](https://www.internalfb.com/code/fbsource/[656b0c837314]/fbcode/executorch/examples/models/llama2/model.py?lines=376), causing export issues like P1181876388. Thanks larryliu0820 for the pointers!

Differential Revision: D53500886


