### PR TITLE
Introduce `mem_obj_id` to `TensorSpec`

### DIFF
--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -177,6 +177,7 @@ class TensorSpec:
     def init_mem_planning_fields(self) -> None:
         self.lifetime = [None, None]
         self.mem_id = None
+        self.mem_obj_id = None
         self.mem_offset = None
 
     @property


### PR DESCRIPTION
Summary:
## Background

Using [Efficient Memory Planning for Deep Neural Networks](https://arxiv.org/pdf/2001.03288.pdf) as a reference, there are generally two approaches to solving the memory planning problem for a neural network:

* **Shared Objects Approach**
    * Match tensors to “shared objects” (i.e. shared memory allocation), based on tensor sizes and lifetimes
    * The goal is then to minimize the total size of each shared object
* **Memory Offset Calculation Approach**
    * Assign each tensor to a specific offset in a large memory arena shared by all tensors, based on tensor sizes and lifetimes
    * The goal is then to minimize the total size of the overall memory arena

Though the **Memory Offset Calculation Approach** can produce more optimal solutions, it cannot be used for GPU textures because a texture memory cannot be divided. **To plan memory for GPU textures, memory planning must be solved using the Shared Object Approach**. Note that a solution to the Shared Objects problem can be converted to a solution for the Memory Offses problem by materializing the shared objects as buffers within a memory arena.

## Context

Currently, memory planning algorithms implemented for `exir`'s `MemoryPlanningPass` output solutions to the memory planning problem in the **Memory Offsets** format. The `greedy` algorithm solves memory planning as a Shared Objects problem, but then converts the solution to the memory offset format.

This changeset introduces the `mem_obj_id` field to `TensorSpec`, which memory planning algorithms can use to record shared object ids.

## Review Guide

* The `greedy` memory planning algorithm now records `mem_obj_id` in addition to `mem_offset`
* `verify_storage_reuse()` of `Verifier` class now checks whether `mem_obj_id` is valid, if it is set

Differential Revision: D53496787


