### PR TITLE
llama runner add namespace to elementSize (v2)

### DIFF
--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -185,7 +185,7 @@ Error Runner::generate(
     for (exec_aten::SizesType shape : kv_cache_shape) {
       n_bytes *= shape;
     }
-    n_bytes *= elementSize(dtype);
+    n_bytes *= torch::executor::elementSize(dtype);
 
     k_data.resize(n_bytes);
     v_data.resize(n_bytes);


### PR DESCRIPTION
Summary:
recreating D53536563, export to GH issues.

Add explicit namespace to differentiate from aten scalar type.

Differential Revision: D53543450


