### PR TITLE
aten.pow.Tensor_Tensor

### DIFF
--- a/backends/vulkan/VulkanBackend.cpp
+++ b/backends/vulkan/VulkanBackend.cpp
@@ -52,6 +52,10 @@ class VulkanBackend final : public PyTorchBackendInterface {
                 vk_arithmetic_op_type_floor_div): {
         return at::native::vulkan::arithmetic::OpType::FLOOR_DIV;
       }
+      case (at::vulkan::delegate::VkArithmeticOpType::
+                vk_arithmetic_op_type_pow): {
+        return at::native::vulkan::arithmetic::OpType::POW;
+      }
     }
   }
 

--- a/backends/vulkan/serialization/schema/schema.fbs
+++ b/backends/vulkan/serialization/schema/schema.fbs
@@ -35,6 +35,7 @@ enum VkArithmeticOpType : short {
   vk_arithmetic_op_type_mul = 2,
   vk_arithmetic_op_type_div = 3,
   vk_arithmetic_op_type_floor_div = 4,
+  vk_arithmetic_op_type_pow = 5,
 }
 
 table VkArithmeticNode {

--- a/backends/vulkan/serialization/vulkan_graph_schema.py
+++ b/backends/vulkan/serialization/vulkan_graph_schema.py
@@ -47,6 +47,7 @@ class VkArithmeticOpType(IntEnum):
     vk_arithmetic_op_type_mul = 2
     vk_arithmetic_op_type_div = 3
     vk_arithmetic_op_type_floor_div = 4
+    vk_arithmetic_op_type_pow = 5
 
 
 @dataclass

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -232,3 +232,20 @@ class TestBackends(unittest.TestCase):
         )
 
         self.lower_module_and_test_output(arithmetic_module, model_inputs)
+
+    def test_vulkan_backend_pow(self):
+        class PowModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                z = torch.pow(x, y)
+                return z
+
+        pow_module = PowModule()
+        model_inputs = (
+            torch.rand(size=(2, 3), dtype=torch.float32),
+            torch.rand(size=(2, 3), dtype=torch.float32),
+        )
+
+        self.lower_module_and_test_output(pow_module, model_inputs)

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -49,6 +49,8 @@ class VulkanBackend(BackendDetails):
                 f"Invalid node kwargs for vulkan_preprocess (target_name: {target_name}, "
                 f"kwargs: {kwargs})"
             )
+        elif target_name == "aten.pow.Tensor_Tensor":
+            return vk_graph_schema.VkArithmeticOpType.vk_arithmetic_op_type_pow
 
         else:
             raise AssertionError(


### PR DESCRIPTION
Summary:
This wires the eager-mode operation to the Vulkan shader. We only cover the case where both inputs are Tensor type, which is on par with the existing operators: add, sub, mul, div, floor_div.

It doesn't seem like we can cover [any other of the 8 cases](https://www.internalfb.com/code/fbsource/[e45c04564445b5e67ebb61e6ba53995729686526]/xplat/caffe2/torch/distributed/_tensor/ops/pointwise_ops.py?lines=310-317), right now. We categorize them and explain that what's missing for each.

## Category 1
The other 2/3 "standard" cases requires one of the values to be a scalar, 
```
z = torch.pow(x, y)
```
```
aten.pow.Scalar,
aten.pow.Tensor_Scalar,
aten.pow.Tensor_Tensor,
```
which is not currently supported.
```
F 00:00:01.746228 executorch:aten_bridge.cpp:21] In function check_tensor_meta(), assert failed (b.sizes().data() != nullptr): ETensor must have valid sizes array
```

## Category 2
IIUC, these operators require an out argument in the declaration. However, when they are traced they collapsed into Category 1, e.g., we obtain `aten.pow.Tensor_Tensor` not `aten.pow.Tensor_Tensor_out`.

This appears in line with current PT-Vulkan, which only [implements the other two categories](https://www.internalfb.com/code/fbsource/[f148c22604b8e409696fd64f814cda89d091fe7a]/xplat/caffe2/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp?lines=533-558).
```
torch.pow(x, y, out=z)
```
```
aten.pow.Scalar_out,
aten.pow.Tensor_Scalar_out,
aten.pow.Tensor_Tensor_out,
```


## Category 3
IIUC, in-place operators are written like this:
```
x.pow_(y)
```
```
aten.pow_.Scalar,
aten.pow_.Tensor,
```
They are not currently supported.
```
  File "/data/users/jorgep31415/fbsource/buck-out/v2/gen/fbcode/b007eb344207ad7d/executorch/backends/vulkan/test/__test_vulkan_delegate__/test_vulkan_delegate#link-tree/torch/_export/verifier.py", line 188, in _check_valid_op
    raise SpecViolationError(
torch._export.verifier.SpecViolationError: operator 'aten.copy_.default' is not functional
```

Differential Revision: D53547865


