### PR TITLE
Fix the default export_llama checkpoint and config.

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -156,7 +156,7 @@ def build_args_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-c",
         "--checkpoint",
-        default=f"{ckpt_dir}/llama2.pt",
+        default=f"{ckpt_dir}/params/demo_rand_params.pth",
         help="checkpoint path",
     )
     parser.add_argument(
@@ -167,7 +167,10 @@ def build_args_parser() -> argparse.ArgumentParser:
         help="Whether or not to export a model using kv cache",
     )
     parser.add_argument(
-        "-p", "--params", default=f"{ckpt_dir}/llama2_params.json", help="config.json"
+        "-p",
+        "--params",
+        default=f"{ckpt_dir}/params/demo_config.json",
+        help="config.json",
     )
     parser.add_argument(
         "-m",


### PR DESCRIPTION
Summary: There are toy (random) model and config files in the folder. The export_llama should work without any arguments.

Reviewed By: tarun292, lucylq

Differential Revision: D53553166


