### PR TITLE
Ensure that lifted tensor constants don't show up as inputs in emitted program

### DIFF
--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -1308,16 +1308,28 @@ class _TopLevelEmitter(_Emitter):
         if isinstance(target, str) and (
             target in self.exported_program.graph_signature.inputs_to_parameters
             or target in self.exported_program.graph_signature.inputs_to_buffers
+            or target
+            in self.exported_program.graph_signature.inputs_to_lifted_tensor_constants
         ):
-
-            fqn = (
-                self.exported_program.graph_signature.inputs_to_parameters[target]
-                if target in self.exported_program.graph_signature.inputs_to_parameters
-                else self.exported_program.graph_signature.inputs_to_buffers[target]
-            )
+            if (
+                target
+                in self.exported_program.graph_signature.inputs_to_lifted_tensor_constants
+            ):
+                fqn = self.exported_program.graph_signature.inputs_to_lifted_tensor_constants[
+                    target
+                ]
+            elif target in self.exported_program.graph_signature.inputs_to_buffers:
+                fqn = self.exported_program.graph_signature.inputs_to_buffers[target]
+            else:
+                fqn = self.exported_program.graph_signature.inputs_to_parameters[target]
             if fqn in self.exported_program.state_dict:
                 spec = TensorSpec.from_tensor(
                     self.exported_program.state_dict[fqn], const=True
+                )
+                const_tensor = True
+            elif fqn in self.exported_program.constants:
+                spec = TensorSpec.from_tensor(
+                    self.exported_program.constants[fqn], const=True
                 )
                 const_tensor = True
             else:

--- a/exir/lowered_backend_module.py
+++ b/exir/lowered_backend_module.py
@@ -465,6 +465,21 @@ def _get_new_signature(
                     ]
                 else:
                     new_constants[buffer_name] = original_program.constants[buffer_name]
+            elif node.name in old_signature.inputs_to_lifted_tensor_constants:
+                constant_name = old_signature.inputs_to_lifted_tensor_constants[
+                    node.name
+                ]
+                # add constant to graph signature
+                input_specs.append(
+                    InputSpec(
+                        kind=InputKind.CONSTANT_TENSOR,
+                        arg=TensorArgument(name=node.name),
+                        target=constant_name,
+                    )
+                )
+
+                # add constant to new_constants
+                new_constants[constant_name] = original_program.constants[constant_name]
             else:
                 # not param or buffer then user input
                 input_specs.append(


### PR DESCRIPTION
Summary: Currently lifted tensor constants are showing up as inputs to the emitted program. This shouldn't be the case as they're embedded inside the program as constants and the user will not be passing these in as inputs.

Differential Revision: D53584903


