### PR TITLE
Integrate memory planning into Vulkan delegate

### DIFF
--- a/backends/vulkan/VulkanBackend.cpp
+++ b/backends/vulkan/VulkanBackend.cpp
@@ -193,8 +193,8 @@ class VulkanBackend final : public PyTorchBackendInterface {
       const std::vector<int64_t> input_dims_vector(
           input_dims_fb->cbegin(), input_dims_fb->cend());
 
-      const at::native::vulkan::ValueRef input_ref =
-          compute_graph->add_tensor(input_dims_vector, input_dtype);
+      const at::native::vulkan::ValueRef input_ref = compute_graph->add_tensor(
+          input_dims_vector, input_dtype, input_vk_tensor->mem_obj_id());
 
       ref_mapping[input_id] = input_ref;
       compute_graph->set_input_tensor(input_ref);
@@ -233,7 +233,8 @@ class VulkanBackend final : public PyTorchBackendInterface {
               input1_ref,
               input2_ref,
               1.0,
-              get_native_op_type(typed_node->op_type()));
+              get_native_op_type(typed_node->op_type()),
+              value_mapping->Get(output_id)->value()->mem_obj_id());
 
       ref_mapping[output_id] = output_ref;
     }

--- a/backends/vulkan/serialization/schema/schema.fbs
+++ b/backends/vulkan/serialization/schema/schema.fbs
@@ -23,6 +23,8 @@ table VkTensor {
   dims:[uint];
   // Index to the program's constant buffer table, value 0 is reserved to indicate non constant
   constant_buffer_idx:uint;
+  // Indicates which shared memory object this tensor uses; negative means the tensor does not share memory
+  mem_obj_id: int;
 }
 
 table VkValue {

--- a/backends/vulkan/serialization/vulkan_graph_schema.py
+++ b/backends/vulkan/serialization/vulkan_graph_schema.py
@@ -29,6 +29,7 @@ class VkTensor:
     datatype: VkDatatype
     dims: List[int]
     constant_buffer_idx: int
+    mem_obj_id: int
 
 
 @dataclass

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -18,7 +18,12 @@ from executorch.exir.backend.backend_details import (
     ExportedProgram,
     PreprocessResult,
 )
-from torch import dtype, float32, Tensor
+
+from executorch.exir.passes import MemoryPlanningPass, SpecPropPass
+
+from executorch.exir.program._program import _copy_module
+from executorch.exir.tensor import TensorSpec
+from torch import dtype, float32
 from torch.fx import Node
 from torch.fx.node import Argument
 
@@ -66,9 +71,9 @@ class VulkanBackend(BackendDetails):
 
     @classmethod
     # pyre-ignore
-    def preprocess(
+    def preprocess(  # noqa: C901
         cls,
-        edge_program: ExportedProgram,
+        program: ExportedProgram,
         module_compile_spec: List[CompileSpec],
     ) -> PreprocessResult:
         vk_nodes = []
@@ -80,28 +85,73 @@ class VulkanBackend(BackendDetails):
         # Mapping from node in the executorch graph to corresponding VkValue id
         node_vk_value_ids = {}
 
-        def assign_vk_value_id(node: Node, tensor: Tensor, buffer_idx: int) -> int:
-            assert node not in node_vk_value_ids
+        def create_single_vk_value(node: Node, buffer_idx: int = 0) -> int:
+            spec = node.meta.get("spec")
+            assert isinstance(spec, TensorSpec)
             new_id = len(vk_values)
-            node_vk_value_ids[node] = new_id
+            if node not in node_vk_value_ids:
+                node_vk_value_ids[node] = new_id
+            else:
+                current_ids = node_vk_value_ids[node]
+                if isinstance(current_ids, int):
+                    current_ids = [current_ids, new_id]
+                else:
+                    current_ids.append(new_id)
+
+            # Negative id indicates that this tensor will have its own dedicated memory.
+            mem_obj_id = -1
+            if spec.mem_obj_id is not None:
+                mem_obj_id = spec.mem_obj_id
+
             vk_values.append(
                 vk_graph_schema.VkValue(
                     value=vk_graph_schema.VkTensor(
-                        datatype=VulkanBackend.get_vk_datatype(tensor.dtype),
-                        dims=list(tensor.shape),
+                        datatype=VulkanBackend.get_vk_datatype(spec.dtype),
+                        dims=spec.shape,
                         constant_buffer_idx=buffer_idx,
+                        mem_obj_id=mem_obj_id,
                     )
                 )
             )
             return new_id
 
-        def assign_non_const_vk_value_id(node: Node) -> int:
-            return assign_vk_value_id(node, node.meta["val"], 0)
+        def create_vk_values_for(node: Node, buffer_idx: int = 0):
+            spec = node.meta.get("spec")
 
-        for node in edge_program.graph.nodes:
+            if isinstance(spec, TensorSpec):
+                return create_single_vk_value(node, buffer_idx)
+            else:
+                ids = []
+                for _ in spec:
+                    ids.append(create_single_vk_value(node, buffer_idx))
+                return ids
+
+        passes = [
+            SpecPropPass(),
+            MemoryPlanningPass("greedy"),
+        ]
+
+        new_gm = program.graph_module
+        for p in passes:
+            # This is a workaround to allow the memory planning pass to work without
+            # having to first apply ToOutVarPass(). See the `greedy()` function in
+            # `exir.memory_planning`; if this attribute isn't set, assertions in
+            # `collect_spec_from_nodes()` will fail.
+            if isinstance(p, MemoryPlanningPass):
+                new_gm.encounter_to_out_var_failure = True
+            new_gm_res = p(new_gm)
+            assert new_gm_res is not None
+            new_gm = new_gm_res.graph_module
+        _copy_module(program.graph_module, new_gm)
+
+        for node in program.graph_module.graph.nodes:
             if node.op == "placeholder":
                 # Input
-                vk_input_ids.append(assign_non_const_vk_value_id(node))
+                ids = create_vk_values_for(node)
+                if isinstance(ids, int):
+                    vk_input_ids.append(ids)
+                else:
+                    vk_input_ids += ids
             elif node.op == "call_function":
                 # Op
                 if (
@@ -116,7 +166,7 @@ class VulkanBackend(BackendDetails):
                         node=vk_graph_schema.VkArithmeticNode(
                             input1_id=node_vk_value_ids[node.all_input_nodes[0]],
                             input2_id=node_vk_value_ids[node.all_input_nodes[1]],
-                            output_id=assign_non_const_vk_value_id(node),
+                            output_id=create_vk_values_for(node),
                             op_type=VulkanBackend.get_vk_op_type(
                                 target_name=node.target.__name__, kwargs=node.kwargs
                             ),
@@ -142,7 +192,7 @@ class VulkanBackend(BackendDetails):
                 buffer = vk_graph_schema.Buffer(storage=bytes(array))
                 vk_const_buffers.append(buffer)
 
-                assign_vk_value_id(node, const_val, buffer_idx)
+                create_vk_values_for(node, buffer_idx)
 
             elif node.op == "output":
                 if node.all_input_nodes[0] not in node_vk_value_ids:


### PR DESCRIPTION
Summary:
## Context

Final changeset to integrate memory planning into the Vulkan delegate. Previously [PR #1868](https://github.com/pytorch/executorch/pull/1868 ) allowed the `greedy` memory algorithm to record the shared object index as `mem_obj_id` which can be used to construct `SharedObject` instances in the Vulkan `ComputeGraph`, which was added in [PR #118756](https://github.com/pytorch/pytorch/pull/118756).

Differential Revision: D53592204


