### PR TITLE
Run example llama2 model with fp16

### DIFF
--- a/backends/xnnpack/operators/op_linear.py
+++ b/backends/xnnpack/operators/op_linear.py
@@ -59,6 +59,7 @@ class LinearVisitor(NodeVisitor):
             xnn_graph,
             vals_to_ids,
             quant_params=weight_quant_params,
+            fp32_static_weights=True,
         )
         filter_id = vals_to_ids[weight_node]
 
@@ -73,6 +74,7 @@ class LinearVisitor(NodeVisitor):
                 xnn_graph,
                 vals_to_ids,
                 quant_params=bias_quant_params,
+                fp32_static_weights=True,
             )
             bias_id = vals_to_ids[bias_node]
         else:

--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -256,23 +256,25 @@ Error defineTensor(
               /*flags=*/0, // this is netiher external input or output
               /*id_out=*/&id);
 
-          // this is the FP32 external value that is dynamically quantized
-          uint32_t fp32_id;
+          // this is the FP16 or FP32 external value that is being dynamically
+          // quantized
+          uint32_t float_id;
+          enum xnn_datatype fp_datatype = getDataType(tensor_value->datatype());
           status = xnn_define_tensor_value(
               /*subgraph=*/subgraph_ptr,
-              /*datatype=*/xnn_datatype_fp32, // always fp32
+              /*datatype=*/fp_datatype,
               /*num_dims=*/tensor_value->num_dims(),
               /*dims=*/dims_data.data(),
               /*data=*/buffer_ptr,
               /*external_id=*/tensor_value->external_id(),
               /*flags=*/tensor_value->flags(),
-              /*id_out=*/&fp32_id);
-          executor->addDynamicQinput(fp32_id);
+              /*id_out=*/&float_id);
+          executor->addDynamicQinput(float_id);
 
-          // Define dynamic conversion from fp32 to qdint8
+          // Define dynamic conversion from float to qdint8
           status = xnn_define_convert(
               /*subgraph=*/subgraph_ptr,
-              /*input_id=*/fp32_id,
+              /*input_id=*/float_id,
               /*output_id=*/id,
               /*flags=*/0);
           break;


### PR DESCRIPTION
Summary:
FYI - there are hardcoded `float` in rmsnorm which makes bunch of nodes in the graph as fp32.

```
aten_embedding_default: "f16[1, 3, 64]" = executorch_exir_dialects_edge__ops_aten_embedding_default(arg11_1, arg55_1);  arg11_1 = arg55_1 = None
            aten_slice_copy_tensor: "f16[3, 4]" = executorch_exir_dialects_edge__ops_aten_slice_copy_Tensor(arg48_1, 0, 0, 3);  arg48_1 = None
            aten_slice_copy_tensor_1: "f16[3, 4]" = executorch_exir_dialects_edge__ops_aten_slice_copy_Tensor(arg49_1, 0, 0, 3);  arg49_1 = None
            aten__to_copy_default: "f32[1, 3, 64]" = executorch_exir_dialects_edge__ops_aten__to_copy_default(aten_embedding_default, dtype = torch.float32)
```

Copy from - https://www.internalfb.com/code/fbsource/%5B7e45e7bcd969%5D/xplat/executorch/examples/models/llama2/model.py?lines=78

Differential Revision: D53596500


