### PR TITLE
Fix interval construction in `storage_overlap()`

### DIFF
--- a/exir/memory_planning.py
+++ b/exir/memory_planning.py
@@ -113,7 +113,7 @@ class Verifier:
                 f"{spec} should have specified memory offset",
             )
             intervals.append(
-                [spec.mem_offset, spec.mem_offset + max(spec.allocated_memory - 1, 0)]
+                [spec.mem_offset, spec.mem_offset + spec.allocated_memory - 1]
             )
         has_overlap = cls.has_overlap(*intervals)
 
@@ -154,16 +154,6 @@ class Verifier:
 
                 has_storage_overlap = Verifier.storage_overlap(lhs_spec, rhs_spec)
                 if not has_storage_overlap:
-                    # Check that each mem_obj_id is consistent with whether the tensors
-                    # have storage overlap
-                    if Verifier.mem_obj_id_match(
-                        lhs_spec, rhs_spec, accept_both_none=False
-                    ):
-                        raise InternalError(
-                            f"Unexpected mem_obj_id match: "
-                            f"lhs {lhs_spec} with id {lhs_spec.mem_obj_id} "
-                            f"rhs {rhs_spec} with id {rhs_spec.mem_obj_id}"
-                        )
                     continue
 
                 if not allow_lifetime_and_storage_overlap and self.lifetime_overlap(


### PR DESCRIPTION
Summary:
## Context

[PR #1868](https://github.com/pytorch/executorch/pull/1868)  broke some internal tests due to a change in behaviour of the `Verifier` of the `MemoryPlanningPass`. Specifically, when checking for storage overlap the memory interval for a tensor was calculated as

```
[spec.mem_offset, spec.mem_offset + spec.allocated_memory - 1]
```

For tensors with `spec.allocated_memory == 0`, this would result in a constructed interval of `[N, N-1]`. [PR #1868](https://github.com/pytorch/executorch/pull/1868) updated the interval calculation to

```
[spec.mem_offset, max(spec.mem_offset + spec.allocated_memory - 1, 0)]
```

Which would produce an interval of `[N, N]` instead. However, this change broke some existing behaviour so this changeset reverts to the original interval calculation method.

Differential Revision: D53599825


