### PR TITLE
added CMakeLists.txt for llama2 runner

### DIFF
--- a/examples/models/llama2/CMakeLists.txt
+++ b/examples/models/llama2/CMakeLists.txt
@@ -103,99 +103,91 @@ target_include_directories(
   ${llama_schema_headers}
 )
 
-function(define_common_targets)
-    set(EXPORTED_HEADERS_RUNNER
-        "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.h"
-        "${CMAKE_CURRENT_SOURCE_DIR}/runner/util.h"
-    )
+target_include_directories(executorch PUBLIC ${_common_include_directories})
 
-    # Define a CMake target using runtime.cxx_library
-    add_library(runner
-        "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
-    )
+# Define a CMake target using runtime.cxx_library
+add_library(runner
+    "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
+)
 
-    # Specify exported headers
-    target_include_directories(runner PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
-        ${CMAKE_CURRENT_SOURCE_DIR}/runner
-        ${CMAKE_CURRENT_SOURCE_DIR}/sampler
-        ${CMAKE_CURRENT_SOURCE_DIR}/tokenizer
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
-    )
+# Specify exported headers
+target_include_directories(runner PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
+    ${CMAKE_CURRENT_SOURCE_DIR}/runner
+    ${CMAKE_CURRENT_SOURCE_DIR}/sampler
+    ${CMAKE_CURRENT_SOURCE_DIR}/tokenizer
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
+)
 
-    get_target_property(runner_include_dirs runner INCLUDE_DIRECTORIES)
-    message(">>>>Include Directories for runner_lib: ${runner_include_dirs}")
+get_target_property(runner_include_dirs runner INCLUDE_DIRECTORIES)
+message(">>>>Include Directories for runner_lib: ${runner_include_dirs}")
 
 
-    target_sources(runner PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
-        ${EXPORTED_HEADERS_RUNNER}
-    )
+target_sources(runner PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
+    ${EXPORTED_HEADERS_RUNNER}
+)
 
-    add_library(sampler
-        "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
-    )
+add_library(sampler
+    "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
+)
 
-    target_include_directories(sampler PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
-        ${CMAKE_CURRENT_SOURCE_DIR}/sampler
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
-    )
-
-
-    target_sources(sampler PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
-    )
+target_include_directories(sampler PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
+    ${CMAKE_CURRENT_SOURCE_DIR}/sampler
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
+)
 
 
-    add_library(tokenizer
-        "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
-    )
+target_sources(sampler PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
+)
 
-    target_include_directories(tokenizer PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
-        ${CMAKE_CURRENT_SOURCE_DIR}/tokenizer
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
-    )
 
-    target_sources(tokenizer PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
-    )
+add_library(tokenizer
+    "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
+)
 
-    # Specify visibility
-    target_compile_options(runner PRIVATE
-        -fvisibility=hidden
-    )
+target_include_directories(tokenizer PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
+    ${CMAKE_CURRENT_SOURCE_DIR}/tokenizer
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
+)
 
-    # Specify exported dependencies
-    target_link_libraries(runner PRIVATE
-        //executorch/backends/xnnpack:xnnpack_backend
-        //executorch/examples/models/llama2/sampler:sampler
-        //executorch/examples/models/llama2/tokenizer:tokenizer
-        //executorch/examples/models/llama2/runner:runner
-        //executorch/extension/evalue_util:print_evalue
-        //executorch/extension/runner_util:managed_tensor
-        //executorch/extension/module:module
-        //executorch/kernels/quantized:generated_lib
-        //executorch/kernels/portable:generated_lib_all_ops
-        //executorch/runtime/core/exec_aten:lib
-        //executorch/runtime/kernel:kernel_includes
-    )
+target_sources(tokenizer PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
+)
 
-endfunction()
+# Specify visibility
+target_compile_options(runner PRIVATE
+    -fvisibility=hidden
+)
 
-define_common_targets()
+# Specify exported dependencies
+target_link_libraries(runner PRIVATE
+    //executorch/backends/xnnpack:xnnpack_backend
+    //executorch/examples/models/llama2/sampler:sampler
+    //executorch/examples/models/llama2/tokenizer:tokenizer
+    //executorch/examples/models/llama2/runner:runner
+    //executorch/extension/evalue_util:print_evalue
+    //executorch/extension/runner_util:managed_tensor
+    //executorch/extension/module:module
+    //executorch/kernels/quantized:generated_lib
+    //executorch/kernels/portable:generated_lib_all_ops
+    //executorch/runtime/core/exec_aten:lib
+    //executorch/runtime/kernel:kernel_includes
+)
 
 set(_llama_executor_runner__srcs
     "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"

--- a/examples/models/llama2/CMakeLists.txt
+++ b/examples/models/llama2/CMakeLists.txt
@@ -1,0 +1,236 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+#
+# llama_executor_runner
+#
+
+cmake_minimum_required(VERSION 3.19)
+
+project(llama_runner_example)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(NOT PYTHON_EXECUTABLE)
+  set(PYTHON_EXECUTABLE python3)
+endif()
+
+if(NOT FLATC_EXECUTABLE)
+  set(FLATC_EXECUTABLE flatc)
+endif()
+
+# Source root directory for executorch.
+if(NOT EXECUTORCH_ROOT)
+  set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+endif()
+
+# Source root directory for pytorch.
+if(NOT TORCH_ROOT)
+  set(TORCH_ROOT ${EXECUTORCH_ROOT}/third-party/pytorch)
+endif()
+
+add_compile_options("-Wall" "-Werror")
+
+include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+
+set(_common_compile_options -Wno-deprecated-declarations -fPIC)
+
+# Let files say "include <executorch/path/to/header.h>".
+set(_common_include_directories ${EXECUTORCH_ROOT}/..)
+
+# Find prebuilt libraries. executorch package should contain
+# portable_ops_lib, etdump, bundled_program.
+find_package(executorch CONFIG REQUIRED)
+target_include_directories(executorch INTERFACE ${_common_include_directories})
+target_compile_options(executorch INTERFACE -DET_EVENT_TRACER_ENABLED)
+
+find_package(
+  gflags REQUIRED PATHS ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party
+)
+
+# portable_ops_lib
+include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
+gen_selected_ops("" "" "ON")
+generate_bindings_for_kernels(
+  ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml ""
+)
+gen_operators_lib("portable_ops_lib" portable_kernels executorch)
+
+set(llama_runner_libs "-framework Foundation")
+
+#
+# The `_<target>_srcs` lists are defined by including ${EXECUTORCH_SRCS_FILE}.
+#
+set(
+  EXECUTORCH_SRCS_FILE
+  "${CMAKE_CURRENT_BINARY_DIR}/../../../executorch_srcs.cmake"
+)
+
+extract_sources(${EXECUTORCH_SRCS_FILE})
+
+set(llama_schema_headers ${CMAKE_BINARY_DIR}/../../../schema/include/)
+include(${EXECUTORCH_SRCS_FILE})
+target_include_directories(
+  bundled_program
+  INTERFACE
+  ${CMAKE_CURRENT_BINARY_DIR}/../../../sdk/include
+  ${CMAKE_CURRENT_BINARY_DIR}/../../../sdk/bundled_program
+  ${EXECUTORCH_ROOT}/third-party/flatbuffers/include
+  ${EXECUTORCH_ROOT}/third-party/flatcc/include
+  ${llama_schema_headers}
+)
+
+function(define_common_targets)
+    foreach(aten IN ITEMS OFF) # ON OFF
+        if(aten)
+            set(aten_suffix "_aten")
+        else()
+            set(aten_suffix "")
+        endif()
+
+        message(">>>>>> CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
+
+        set(EXPORTED_HEADERS_RUNNER
+            "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.h"
+            "${CMAKE_CURRENT_SOURCE_DIR}/runner/util.h"
+        )
+
+        # Define a CMake target using runtime.cxx_library
+        add_library(runner${aten_suffix}
+            "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
+            "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
+            "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
+        )
+
+        # Specify exported headers
+        target_include_directories(runner${aten_suffix} PUBLIC
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
+            ${CMAKE_CURRENT_SOURCE_DIR}/runner
+            ${CMAKE_CURRENT_SOURCE_DIR}/sampler
+            ${CMAKE_CURRENT_SOURCE_DIR}/tokenizer
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
+        )
+
+        get_target_property(runner_include_dirs runner${aten_suffix} INCLUDE_DIRECTORIES)
+        message(">>>>Include Directories for runner_lib: ${runner_include_dirs}")
+
+
+        target_sources(runner${aten_suffix} PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
+            ${EXPORTED_HEADERS_RUNNER}
+        )
+
+        add_library(sampler${aten_suffix}
+            "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
+        )
+
+        target_include_directories(sampler${aten_suffix} PUBLIC
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
+            ${CMAKE_CURRENT_SOURCE_DIR}/sampler
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
+        )
+
+
+        target_sources(sampler${aten_suffix} PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
+        )
+
+
+        add_library(tokenizer${aten_suffix}
+            "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
+        )
+
+        target_include_directories(tokenizer${aten_suffix} PUBLIC
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
+            ${CMAKE_CURRENT_SOURCE_DIR}/tokenizer
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
+        )
+
+
+        target_sources(tokenizer${aten_suffix} PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
+        )
+
+
+        # Add preprocessor flags if aten is true
+        if(aten)
+            target_compile_definitions(runner${aten_suffix} PRIVATE
+                -DUSE_ATEN_LIB
+            )
+        endif()
+
+        # Specify visibility
+        target_compile_options(runner${aten_suffix} PRIVATE
+            -fvisibility=hidden
+        )
+
+        # Specify exported dependencies
+        target_link_libraries(runner${aten_suffix} PRIVATE
+            //executorch/backends/xnnpack:xnnpack_backend
+            //executorch/examples/models/llama2/sampler:sampler${aten_suffix}
+            //executorch/examples/models/llama2/tokenizer:tokenizer${aten_suffix}
+            //executorch/examples/models/llama2/runner:runner${aten_suffix}
+            //executorch/extension/evalue_util:print_evalue${aten_suffix}
+            //executorch/extension/runner_util:managed_tensor${aten_suffix}
+            //executorch/extension/module:module${aten_suffix}
+            //executorch/kernels/quantized:generated_lib${aten_suffix}
+            //executorch/kernels/portable:${aten_suffix}generated_lib_all_ops
+            //executorch/runtime/core/exec_aten:lib${aten_suffix}
+            //executorch/runtime/kernel:kernel_includes
+        )
+
+        # Specify external dependencies if aten is true
+        #if(aten)
+            target_link_libraries(runner${aten_suffix} PRIVATE
+                libtorch
+            )
+        #endif()
+
+        # Set target properties, visibility, etc. as needed
+
+    endforeach()
+endfunction()
+
+define_common_targets()
+
+set(_llama_executor_runner__srcs
+    "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
+)
+message(">>>>>_llama_executor_runner__srcs: ${_llama_executor_runner__srcs}")
+
+#list(TRANSFORM _llama_executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
+add_executable(llama_executor_runner ${_llama_executor_runner__srcs})
+
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+    set(FLATCC_LIB flatcc_d)
+else()
+    set(FLATCC_LIB flatcc)
+endif()
+
+target_link_libraries(llama_executor_runner bundled_program
+                                          executorch
+                                          gflags
+                                          etdump
+                                          ${FLATCC_LIB}
+                                          portable_ops_lib
+                                          ${llama_runner_libs})
+target_compile_options(llama_executor_runner PUBLIC ${_common_compile_options})

--- a/examples/models/llama2/CMakeLists.txt
+++ b/examples/models/llama2/CMakeLists.txt
@@ -75,6 +75,22 @@ set(
 
 extract_sources(${EXECUTORCH_SRCS_FILE})
 
+
+add_library(extension_module "${CMAKE_CURRENT_SOURCE_DIR}/../../../extension/module/module.cpp")
+target_include_directories(extension_module PUBLIC ${EXECUTORCH_ROOT}/..)
+
+#add_library(extension_data_loader "${CMAKE_CURRENT_SOURCE_DIR}/../../../extension/data_loader/mmap_data_loader.cpp")
+#target_link_libraries(extension_data_loader executorch)
+
+
+# Install libraries
+install(
+  TARGETS extension_module
+  DESTINATION ${CMAKE_BINARY_DIR}/lib
+  INCLUDES
+  DESTINATION ${_common_include_directories})
+
+
 set(llama_schema_headers ${CMAKE_BINARY_DIR}/../../../schema/include/)
 include(${EXECUTORCH_SRCS_FILE})
 target_include_directories(
@@ -162,7 +178,6 @@ function(define_common_targets)
             ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
         )
 
-
         target_sources(tokenizer${aten_suffix} PRIVATE
             "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
         )
@@ -232,5 +247,7 @@ target_link_libraries(llama_executor_runner bundled_program
                                           etdump
                                           ${FLATCC_LIB}
                                           portable_ops_lib
+                                          extension_module
+                                          extension_data_loader
                                           ${llama_runner_libs})
 target_compile_options(llama_executor_runner PUBLIC ${_common_compile_options})

--- a/examples/models/llama2/CMakeLists.txt
+++ b/examples/models/llama2/CMakeLists.txt
@@ -103,8 +103,6 @@ target_include_directories(
   ${llama_schema_headers}
 )
 
-target_include_directories(executorch PUBLIC ${_common_include_directories})
-
 # Define a CMake target using runtime.cxx_library
 add_library(runner
     "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
@@ -125,12 +123,11 @@ target_include_directories(runner PUBLIC
 )
 
 get_target_property(runner_include_dirs runner INCLUDE_DIRECTORIES)
-message(">>>>Include Directories for runner_lib: ${runner_include_dirs}")
-
 
 target_sources(runner PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
-    ${EXPORTED_HEADERS_RUNNER}
+    "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/runner/util.h"
 )
 
 add_library(sampler
@@ -195,7 +192,6 @@ set(_llama_executor_runner__srcs
     "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
 )
-message(">>>>>_llama_executor_runner__srcs: ${_llama_executor_runner__srcs}")
 
 #list(TRANSFORM _llama_executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_executable(llama_executor_runner ${_llama_executor_runner__srcs})

--- a/examples/models/llama2/CMakeLists.txt
+++ b/examples/models/llama2/CMakeLists.txt
@@ -104,122 +104,95 @@ target_include_directories(
 )
 
 function(define_common_targets)
-    foreach(aten IN ITEMS OFF) # ON OFF
-        if(aten)
-            set(aten_suffix "_aten")
-        else()
-            set(aten_suffix "")
-        endif()
+    set(EXPORTED_HEADERS_RUNNER
+        "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/runner/util.h"
+    )
 
-        message(">>>>>> CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
+    # Define a CMake target using runtime.cxx_library
+    add_library(runner
+        "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
+    )
 
-        set(EXPORTED_HEADERS_RUNNER
-            "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.h"
-            "${CMAKE_CURRENT_SOURCE_DIR}/runner/util.h"
-        )
+    # Specify exported headers
+    target_include_directories(runner PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
+        ${CMAKE_CURRENT_SOURCE_DIR}/runner
+        ${CMAKE_CURRENT_SOURCE_DIR}/sampler
+        ${CMAKE_CURRENT_SOURCE_DIR}/tokenizer
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
+    )
 
-        # Define a CMake target using runtime.cxx_library
-        add_library(runner${aten_suffix}
-            "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
-            "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
-            "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
-        )
-
-        # Specify exported headers
-        target_include_directories(runner${aten_suffix} PUBLIC
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
-            ${CMAKE_CURRENT_SOURCE_DIR}/runner
-            ${CMAKE_CURRENT_SOURCE_DIR}/sampler
-            ${CMAKE_CURRENT_SOURCE_DIR}/tokenizer
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
-        )
-
-        get_target_property(runner_include_dirs runner${aten_suffix} INCLUDE_DIRECTORIES)
-        message(">>>>Include Directories for runner_lib: ${runner_include_dirs}")
+    get_target_property(runner_include_dirs runner INCLUDE_DIRECTORIES)
+    message(">>>>Include Directories for runner_lib: ${runner_include_dirs}")
 
 
-        target_sources(runner${aten_suffix} PRIVATE
-            "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
-            ${EXPORTED_HEADERS_RUNNER}
-        )
+    target_sources(runner PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/runner/runner.cpp"
+        ${EXPORTED_HEADERS_RUNNER}
+    )
 
-        add_library(sampler${aten_suffix}
-            "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
-        )
+    add_library(sampler
+        "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
+    )
 
-        target_include_directories(sampler${aten_suffix} PUBLIC
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
-            ${CMAKE_CURRENT_SOURCE_DIR}/sampler
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
-        )
-
-
-        target_sources(sampler${aten_suffix} PRIVATE
-            "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
-        )
+    target_include_directories(sampler PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
+        ${CMAKE_CURRENT_SOURCE_DIR}/sampler
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
+    )
 
 
-        add_library(tokenizer${aten_suffix}
-            "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
-        )
-
-        target_include_directories(tokenizer${aten_suffix} PUBLIC
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
-            ${CMAKE_CURRENT_SOURCE_DIR}/tokenizer
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
-        )
-
-        target_sources(tokenizer${aten_suffix} PRIVATE
-            "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
-        )
+    target_sources(sampler PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/sampler/sampler.cpp"
+    )
 
 
-        # Add preprocessor flags if aten is true
-        if(aten)
-            target_compile_definitions(runner${aten_suffix} PRIVATE
-                -DUSE_ATEN_LIB
-            )
-        endif()
+    add_library(tokenizer
+        "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
+    )
 
-        # Specify visibility
-        target_compile_options(runner${aten_suffix} PRIVATE
-            -fvisibility=hidden
-        )
+    target_include_directories(tokenizer PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../..
+        ${CMAKE_CURRENT_SOURCE_DIR}/tokenizer
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch/torch/csrc/api/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch/include/torch/csrc/api/include/
+    )
 
-        # Specify exported dependencies
-        target_link_libraries(runner${aten_suffix} PRIVATE
-            //executorch/backends/xnnpack:xnnpack_backend
-            //executorch/examples/models/llama2/sampler:sampler${aten_suffix}
-            //executorch/examples/models/llama2/tokenizer:tokenizer${aten_suffix}
-            //executorch/examples/models/llama2/runner:runner${aten_suffix}
-            //executorch/extension/evalue_util:print_evalue${aten_suffix}
-            //executorch/extension/runner_util:managed_tensor${aten_suffix}
-            //executorch/extension/module:module${aten_suffix}
-            //executorch/kernels/quantized:generated_lib${aten_suffix}
-            //executorch/kernels/portable:${aten_suffix}generated_lib_all_ops
-            //executorch/runtime/core/exec_aten:lib${aten_suffix}
-            //executorch/runtime/kernel:kernel_includes
-        )
+    target_sources(tokenizer PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/tokenizer/tokenizer.cpp"
+    )
 
-        # Specify external dependencies if aten is true
-        #if(aten)
-            target_link_libraries(runner${aten_suffix} PRIVATE
-                libtorch
-            )
-        #endif()
+    # Specify visibility
+    target_compile_options(runner PRIVATE
+        -fvisibility=hidden
+    )
 
-        # Set target properties, visibility, etc. as needed
+    # Specify exported dependencies
+    target_link_libraries(runner PRIVATE
+        //executorch/backends/xnnpack:xnnpack_backend
+        //executorch/examples/models/llama2/sampler:sampler
+        //executorch/examples/models/llama2/tokenizer:tokenizer
+        //executorch/examples/models/llama2/runner:runner
+        //executorch/extension/evalue_util:print_evalue
+        //executorch/extension/runner_util:managed_tensor
+        //executorch/extension/module:module
+        //executorch/kernels/quantized:generated_lib
+        //executorch/kernels/portable:generated_lib_all_ops
+        //executorch/runtime/core/exec_aten:lib
+        //executorch/runtime/kernel:kernel_includes
+    )
 
-    endforeach()
 endfunction()
 
 define_common_targets()

--- a/examples/models/llama2/runner_cmake.sh
+++ b/examples/models/llama2/runner_cmake.sh
@@ -59,5 +59,5 @@ then
 fi
 
 
-#cmake_install_executorch_sdk_lib
+cmake_install_executorch_sdk_lib
 cmake_llama_runner

--- a/examples/models/llama2/runner_cmake.sh
+++ b/examples/models/llama2/runner_cmake.sh
@@ -45,7 +45,7 @@ cmake_llama_runner() {
   cmake --build ${build_dir} --config Release
 
   echo 'Running llama 2 runner'
-  ${build_dir}/main
+  ${build_dir}/llama_executor_runner
 }
 
 if [[ -z $PYTHON_EXECUTABLE ]];

--- a/examples/models/llama2/runner_cmake.sh
+++ b/examples/models/llama2/runner_cmake.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# build the llama 2 runner using cmake
+
+set -e
+
+source "$(dirname "${BASH_SOURCE[0]}")/../../../.ci/scripts/utils.sh"
+cmake_install_executorch_sdk_lib() {
+  echo "Installing libexecutorch.a, libportable_kernels.a, libetdump.a, libbundled_program.a"
+  rm -rf cmake-out
+
+  retry cmake -DBUCK2="$BUCK" \
+          -DCMAKE_INSTALL_PREFIX=cmake-out \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DEXECUTORCH_BUILD_SDK=ON \
+          -DEXECUTORCH_BUILD_MPS=ON \
+          -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \
+          -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
+          -Bcmake-out .
+  cmake --build cmake-out -j9 --target install --config Release
+}
+
+cmake_llama_runner() {
+    echo "Calling cmake_llama_runner"
+
+    local example_dir=examples/models/llama2
+    local build_dir=cmake-out/${example_dir}
+    CMAKE_PREFIX_PATH="${PWD}/cmake-out/lib/cmake/ExecuTorch;${PWD}/cmake-out/third-party/gflags"
+
+    # build llama2 runner
+    rm -rf ${build_dir}
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
+        -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
+        -B${build_dir} \
+        ${example_dir}
+
+      echo "Building ${example_dir}"
+  cmake --build ${build_dir} --config Release
+
+  echo 'Running llama 2 runner'
+  ${build_dir}/main
+}
+
+if [[ -z $PYTHON_EXECUTABLE ]];
+then
+  PYTHON_EXECUTABLE=python3
+fi
+
+if [[ -z $BUCK ]];
+then
+  BUCK=buck2
+fi
+
+
+#cmake_install_executorch_sdk_lib
+cmake_llama_runner


### PR DESCRIPTION
Before `cd executorch` and run `examples/models/llama2/runner_cmake.sh`, you may need to `wget https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-latest.zip` inside the executorch (or modify the CMakeLists.txt) to avoid a possible error of unable to find c10/macros/cmake_macros.h.

The 3 libs got built: 
$ ls -lt cmake-out/examples/models/llama2
-rw-r--r--   1 jeffxtang  staff   11432 Feb  8 21:27 libtokenizer.a
-rw-r--r--   1 jeffxtang  staff    4936 Feb  8 21:27 libsampler.a
-rw-r--r--   1 jeffxtang  staff   67480 Feb  8 21:27 librunner.a

But there's still some linker error at the end of running the runner_cmake.sh (no more Sampler or Tokenizer related error):
 
<img width="1480" alt="image" src="https://github.com/pytorch/executorch/assets/535090/83176a71-343b-48af-9428-57d241b689a9">

Thoughts on possible fix? @larryliu0820 @lucylq @iseeyuan 