### PR TITLE
Cache results from SDPA.get_graph and bilinear_2d graph

### DIFF
--- a/backends/xnnpack/partition/graphs/bilinear_2d.py
+++ b/backends/xnnpack/partition/graphs/bilinear_2d.py
@@ -4,12 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from functools import lru_cache
 from typing import Dict, List
 
 import executorch.exir as exir
 import torch
 
 
+@lru_cache(maxsize=None)
 def _get_bilinear_2d_graphs():
     class bilinear2d(torch.nn.Module):
         def __init__(self, align_corners):

--- a/backends/xnnpack/partition/graphs/sdpa.py
+++ b/backends/xnnpack/partition/graphs/sdpa.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from functools import lru_cache
 from typing import List, Optional
 
 import torch
@@ -12,6 +13,7 @@ from torch import Tensor
 from torch.export import export
 
 
+@lru_cache(maxsize=None)
 def get_graphs() -> List[torch.fx.GraphModule]:
     """
     Returns a list of SDPA graphs.
@@ -66,7 +68,7 @@ def get_graphs() -> List[torch.fx.GraphModule]:
 
             edge = to_edge(
                 export(
-                    SDPA(),
+                    SDPA(),  # pyre-ignore[16]
                     (
                         q,
                         k,


### PR DESCRIPTION
Summary:
This test is timing out a lot

executorch/backends/xnnpack/test:test_xnnpack_models - test_fp32_vit

https://www.internalfb.com/intern/test/844425039862774?ref_report_id=0

I did some profiling and looks like we are calculating this pattern over and over again for the unit test.

Let's try caching it

Differential Revision: D53613581


