### PR TITLE
Fix inconsistent "HALF" enum value name in scalar_type.fbs

### DIFF
--- a/schema/scalar_type.fbs
+++ b/schema/scalar_type.fbs
@@ -14,7 +14,7 @@ enum ScalarType : byte {
   SHORT = 2,
   INT = 3,
   LONG = 4,
-  Half = 5,
+  HALF = 5,
   FLOAT = 6,
   DOUBLE = 7,
   BOOL = 11,

--- a/sdk/bundled_program/schema/scalar_type.fbs
+++ b/sdk/bundled_program/schema/scalar_type.fbs
@@ -14,7 +14,7 @@ enum ScalarType : byte {
   SHORT = 2,
   INT = 3,
   LONG = 4,
-  Half = 5,
+  HALF = 5,
   FLOAT = 6,
   DOUBLE = 7,
   BOOL = 11,


### PR DESCRIPTION
Summary: All other enum value names are ALLCAPS, and Half should be too.

Reviewed By: lucylq

Differential Revision: D53633722


