### PR TITLE
Fix llama2 buck targets

### DIFF
--- a/examples/models/llama2/TARGETS
+++ b/examples/models/llama2/TARGETS
@@ -49,6 +49,7 @@ runtime.python_binary(
 runtime.python_library(
     name = "export_library",
     srcs = [
+        "export_llama.py",
         "export_llama_lib.py",
     ],
     base_module = "executorch.examples.models.llama2",


### PR DESCRIPTION
Summary:
Fix 2 targets in fbcode CI jobs (didn't repro in dev environment):

* fbcode//executorch/examples/models/llama2:export_llama
* fbcode//executorch/examples/models/llama2/fb:stories110M_test


See example failure:

https://www.internalfb.com/sandcastle/workflow/1490691476661671339/artifact/actionlog.1490691476702112874.stdout.1?selectedLines=1060-1060-48-102

Reviewed By: lucylq

Differential Revision: D53650711


