### PR TITLE
Export llama targets

### DIFF
--- a/examples/models/llama2/TARGETS
+++ b/examples/models/llama2/TARGETS
@@ -34,7 +34,7 @@ runtime.python_library(
 
 runtime.python_binary(
     name = "export_llama",
-    main_module = "executorch.examples.models.llama2.export_llama.main",
+    main_module = "executorch.examples.models.llama2.export_llama",
     # visibility = ["//executorch/examples/..."],
     preload_deps = [
         "//executorch/kernels/quantized:aot_lib",


### PR DESCRIPTION
Summary:
```
/usr/local/fbcode/platform010/bin/python3.10: Error while finding module specification for 'executorch.examples.models.llama2.export_llama.main' (ModuleNotFoundError: __path__ attribute not found on 'executorch.examples.models.llama2.export_llama' while trying to find 'executorch.examples.models.llama2.export_llama.main')
```

Reviewed By: cccclai

Differential Revision: D53670181


