### PR TITLE
Allow tokenizer_py to run in oss

### DIFF
--- a/examples/models/llama2/install_requirements.sh
+++ b/examples/models/llama2/install_requirements.sh
@@ -6,4 +6,5 @@
 # LICENSE file in the root directory of this source tree.
 
 # Install snakeviz for cProfile flamegraph
-pip install snakeviz
+# Install sentencepiece for llama tokenizer
+pip install snakeviz sentencepiece

--- a/examples/models/llama2/tokenizer/targets.bzl
+++ b/examples/models/llama2/tokenizer/targets.bzl
@@ -30,10 +30,7 @@ def define_common_targets():
             "//bento/...",
         ],
         _is_external_target = True,
-        deps = [
-            "fbsource//third-party/pypi/sentencepiece:sentencepiece",
-            "//caffe2:torch",
-        ],
+        deps = [] if runtime.is_oss else ["fbsource//third-party/pypi/sentencepiece:sentencepiece"],
     )
 
     runtime.python_binary(


### PR DESCRIPTION
Summary: Changes to let tokenizer run in OSS env

Differential Revision: D53676371


