### PR TITLE
Disable exported_program.__call__

### DIFF
--- a/exir/backend/test/test_backends_lifted.py
+++ b/exir/backend/test/test_backends_lifted.py
@@ -626,7 +626,7 @@ class TestBackends(unittest.TestCase):
             ),
         )
 
-        new_res = program_with_delegates.exported_program()(*inputs)
+        new_res = program_with_delegates.exported_program().module()(*inputs)
         for t1, t2 in zip(new_res, orig_res, strict=True):
             self.assertTrue(torch.allclose(t1, t2, atol=1e-03, rtol=1e-03))
 
@@ -745,7 +745,7 @@ class TestBackends(unittest.TestCase):
             HTAPartitionerOnePatternDemo()
         )
 
-        new_res = traced_with_delegate.exported_program()(*inputs)
+        new_res = traced_with_delegate.exported_program().module()(*inputs)
         for t1, t2 in zip(new_res, orig_res, strict=True):
             self.assertTrue(torch.allclose(t1, t2, atol=1e-03, rtol=1e-03))
 
@@ -768,7 +768,7 @@ class TestBackends(unittest.TestCase):
         #     config=exir.ExecutorchBackendConfig(extract_delegate_segments=extract_delegate_segments),
         # )
 
-        new_res = program_with_delegates.exported_program()(*inputs)
+        new_res = program_with_delegates.exported_program().module()(*inputs)
         for t1, t2 in zip(new_res, orig_res, strict=True):
             self.assertTrue(torch.allclose(t1, t2, atol=1e-03, rtol=1e-03))
 
@@ -1029,7 +1029,7 @@ class TestBackends(unittest.TestCase):
         partitioned = orig
         partitioned = partitioned.to_backend(AddMulPartitionerDemo())
 
-        new_res = partitioned.exported_program()(*inputs)
+        new_res = partitioned.exported_program().module()(*inputs)
         self.assertTrue(torch.allclose(orig_res, new_res[0]))
 
         toplevel_lowered = get_lowered_submodules(
@@ -1102,7 +1102,7 @@ class TestBackends(unittest.TestCase):
             map_fn_lowered[0][1].original_module.graph_module.code
         )
 
-        new_res = partitioned.exported_program()(*inputs)
+        new_res = partitioned.exported_program().module()(*inputs)
 
         self.assertTrue(torch.allclose(orig_res, new_res[0]))
 
@@ -1153,7 +1153,7 @@ class TestBackends(unittest.TestCase):
         partitioned = orig
         partitioned = partitioned.to_backend(AddMulPartitionerDemo())
 
-        new_res = partitioned.exported_program()(*inputs)
+        new_res = partitioned.exported_program().module()(*inputs)
         self.assertTrue(torch.allclose(orig_res, new_res[0]))
 
         toplevel_lowered = get_lowered_submodules(
@@ -1224,7 +1224,7 @@ class TestBackends(unittest.TestCase):
                 return self.lowered(x)
 
         gm = to_edge(export(ComposedM(), inputs))
-        gm.exported_program()(*inputs)
+        gm.exported_program().module()(*inputs)
 
     def test_dict_input(self):
         def f(x: Dict[str, torch.Tensor]):
@@ -1246,4 +1246,4 @@ class TestBackends(unittest.TestCase):
                 return self.lowered(x)
 
         gm = to_edge(export(ComposedM(), inputs))
-        gm.exported_program()(*inputs)
+        gm.exported_program().module()(*inputs)

--- a/exir/tests/test_verification.py
+++ b/exir/tests/test_verification.py
@@ -136,7 +136,7 @@ class TestVerification(unittest.TestCase):
         exec_prog = to_edge(export(model2, (inputs,))).to_executorch()
 
         exported_prog = exec_prog.exported_program()
-        res = exported_prog(inputs)[0]  # noqa
+        res = exported_prog.module()(inputs)[0]  # noqa
         # Verifiers are run internally in to_edge, export, and to_executorch.
         # If we make it this far then no errors were thrown in verification
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/119466

`ExportedProgram` is an artifact produced by torch.export, containing the graph that is exported, along with other attributes about the original program such as the graph signature, state dict, and constants. One slightly confusing thing that users run into is that they treat the `ExportedProgram` as a `torch.nn.Module`, since the object is callable. However, as we do not plan to support all features that `torch.nn.Module`s have, like hooks, we want to create a distinction between it and the `ExportedProgram` by removing the `__call__` method. Instead users can create a proper `torch.nn.Module` through `exported_program.module()` and use that as a callable.

Reviewed By: zhxchen17

Differential Revision: D53075378


