### PR TITLE
[TEST ONLY] Example to export to edge ir and mps backend

### DIFF
--- a/squeezenet_mps.py
+++ b/squeezenet_mps.py
@@ -1,0 +1,8 @@
+from executorch.util.export_edge_ir import export_to_edge
+from executorch.util.export_mps import export_to_mps
+import torch
+
+m = torch.hub.load('pytorch/vision:v0.10.0', 'squeezenet1_0', pretrained=True)
+example_inputs = (torch.rand(1, 3, 224, 224),)
+# edge = export_to_edge(m, example_inputs)
+export_to_mps(m, example_inputs)

--- a/util/export_edge_ir.py
+++ b/util/export_edge_ir.py
@@ -1,0 +1,63 @@
+from typing import Tuple, Union
+
+import executorch.exir as exir
+
+import torch
+from executorch.exir import EdgeProgramManager, ExecutorchProgramManager, to_edge
+from executorch.exir.tracer import Value
+from torch._export import capture_pre_autograd_graph
+from torch.export import export, ExportedProgram
+
+
+_EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(
+    _check_ir_validity=False,
+)
+
+
+def _to_core_aten(
+    model: Union[torch.fx.GraphModule, torch.nn.Module],
+    example_inputs: Tuple[Value, ...],
+) -> ExportedProgram:
+    # post autograd export. eventually this will become .to_core_aten
+    if not isinstance(model, torch.fx.GraphModule):
+        raise ValueError(
+            f"Expected passed in model to be an instance of fx.GraphModule, got {type(model)}"
+        )
+    core_aten_ep = export(model, example_inputs)
+    print(f"Core ATen graph:\n{core_aten_ep.graph}")
+    return core_aten_ep
+
+
+def _core_aten_to_edge(
+    core_aten_exir_ep: ExportedProgram,
+    edge_compile_config=None,
+) -> EdgeProgramManager:
+    if not edge_compile_config:
+        edge_compile_config = exir.EdgeCompileConfig(
+            _check_ir_validity=False,  # quant ops currently break ir verification
+        )
+    edge_manager: EdgeProgramManager = to_edge(
+        core_aten_exir_ep, compile_config=edge_compile_config
+    )
+    print(f"Exported graph:\n{edge_manager.exported_program().graph}")
+    return edge_manager
+
+
+def export_to_edge(
+    model: Union[torch.fx.GraphModule, torch.nn.Module],
+    example_inputs: Tuple[Value, ...],
+    edge_compile_config=_EDGE_COMPILE_CONFIG,
+) -> EdgeProgramManager:
+    model = capture_pre_autograd_graph(model, example_inputs)
+    core_aten_ep = _to_core_aten(model, example_inputs)
+    return _core_aten_to_edge(core_aten_ep, edge_compile_config)
+
+
+if __name__ == "__main__":
+    class MyModule(torch.nn.Module):
+        def forward(self, x):
+            return torch.rand(1, 3, 224, 224) + x
+
+    example_inputs = (torch.rand(1, 3, 224, 224),)
+    m = MyModule().eval()
+    export_to_edge(m, example_inputs)

--- a/util/export_mps.py
+++ b/util/export_mps.py
@@ -1,0 +1,104 @@
+#
+#  Copyright (c) 2023 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+# Example script for exporting simple models to flatbuffer
+
+import copy
+import logging
+
+import torch
+from executorch import exir
+from executorch.backends.apple.mps.mps_preprocess import MPSBackend
+from executorch.backends.apple.mps.partition.mps_partitioner import MPSPartitioner
+
+from executorch.exir import EdgeCompileConfig, EdgeProgramManager
+from executorch.exir.backend.backend_api import to_backend
+from executorch.exir.backend.backend_details import CompileSpec
+from executorch.exir.capture._config import ExecutorchBackendConfig
+from executorch.sdk import BundledProgram, generate_etrecord
+from executorch.sdk.bundled_program.config import MethodTestCase, MethodTestSuite
+from executorch.sdk.bundled_program.serialize import (
+    serialize_from_bundled_program_to_flatbuffer,
+)
+from executorch.util.export_edge_ir import export_to_edge
+
+FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+
+def export_to_mps(model, example_inputs, use_partitioner=False, bundled=False,use_fp16=True, generate_etrecord=False):
+
+    model = model.eval()
+
+    # pre-autograd export. eventually this will become torch.export
+    model = torch._export.capture_pre_autograd_graph(model, example_inputs)
+
+    edge: EdgeProgramManager = export_to_edge(
+        model,
+        example_inputs,
+        edge_compile_config=EdgeCompileConfig(_check_ir_validity=False),
+    )
+    edge_program_manager_copy = copy.deepcopy(edge)
+
+    compile_specs = [CompileSpec("use_fp16", bytes([1]))]
+
+    logging.info(f"Edge IR graph:\n{edge.exported_program().graph}")
+    if use_partitioner:
+        edge = edge.to_backend(MPSPartitioner(compile_specs=compile_specs))
+        logging.info(f"Lowered graph:\n{edge.exported_program().graph}")
+
+        executorch_program = edge.to_executorch(
+            config=ExecutorchBackendConfig(extract_constant_segment=False)
+        )
+    else:
+        lowered_module = to_backend(
+            MPSBackend.__name__, edge.exported_program(), compile_specs
+        )
+        executorch_program = (
+            exir.capture(
+                lowered_module,
+                example_inputs,
+                exir.CaptureConfig(enable_aot=True, _unlift=False),
+            )
+            .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
+            .to_executorch(
+                config=ExecutorchBackendConfig(extract_constant_segment=False)
+            )
+        )
+
+    model_name = f"model_mps"
+
+    if bundled:
+        method_test_suites = [
+            MethodTestSuite(
+                method_name="forward",
+                test_cases=[
+                    MethodTestCase(
+                        inputs=example_inputs, expected_outputs=[model(*example_inputs)]
+                    )
+                ],
+            )
+        ]
+        logging.info(f"Expected output: {model(*example_inputs)}")
+
+        bundled_program = BundledProgram(executorch_program, method_test_suites)
+        bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(
+            bundled_program
+        )
+        model_name = f"{model_name}_bundled"
+        extension = "fp16"
+        if not use_fp16:
+            extension = "fp32"
+        model_name = f"{model_name}_{extension}"
+        program_buffer = bundled_program_buffer
+    else:
+        program_buffer = executorch_program.buffer
+
+    if generate_etrecord:
+        etrecord_path = "etrecord.bin"
+        logging.info("generating etrecord.bin")
+        generate_etrecord(etrecord_path, edge_program_manager_copy, executorch_program)
+
+    # save_pte_program(program_buffer, model_name)
+


### PR DESCRIPTION
You can check out this script and `pip install .` Note: this PR is for test only and not for landing, until we find a better place to store the script. These are modified from scripts in examples/

To use it:
```
from executorch.util.export_edge_ir import export_to_edge
from executorch.util.export_mps import export_to_mps
```

Then for a model, we find its eager class and example inputs, and we can use `export_to_edge` and `export_to_mps` to validate whether they can export/delegate or not. If not, we can see the stack trace.

Example 1: squeezenet (see the script in this PR)

If torch.hub (or packages like torchvision) already has this model, we can simply
```
m = torch.hub.load('pytorch/vision:v0.10.0', 'squeezenet1_0', pretrained=True) # create model
example_inputs = (torch.rand(1, 3, 224, 224),)
# edge = export_to_edge(m, example_inputs) # export_to_mps should export_to_edge first, but we can uncomment and explicitly do this.
export_to_mps(m, example_inputs)
```

Example 2: a model in a public github repo

We want to do some detectron2 (https://github.com/facebookresearch/detectron2) models. Say we want to try the FPN backbone. 

We git clone, and `pip install .`

Then we find there is a helper `build_resnet_fpn_backbone`. We need to find a usage example (like https://github.com/facebookresearch/detectron2/blob/3ff5dd1cff4417af07097064813c9f28d7461d3c/tests/modeling/test_backbone.py#L28).

Then we make a script like this:
```
from detectron2 import model_zoo
from detectron2.config import get_cfg
from detectron2.layers import ShapeSpec
from detectron2.modeling.backbone import build_resnet_backbone
from detectron2.modeling.backbone.fpn import build_resnet_fpn_backbone

cfg = model_zoo.get_config("Misc/scratch_mask_rcnn_R_50_FPN_3x_gn.yaml")
m = build_resnet_fpn_backbone(cfg, ShapeSpec(channels=3))

example_inputs = (torch.rand(1, 3, 224, 224),)
from executorch.util.export_edge_ir import export_to_edge
from executorch.util.export_mps import export_to_mps
export_to_edge(m, example_inputs)
```
