### PR TITLE
BC Fix Stage 2 fully migrate to constant data

### DIFF
--- a/backends/xnnpack/operators/__init__.py
+++ b/backends/xnnpack/operators/__init__.py
@@ -16,6 +16,8 @@ from . import (  # noqa
     op_conv2d,
     op_dequantize_per_tensor,
     op_div,
+    op_dynamic_dequantize_per_tensor,
+    op_dynamic_quantize_per_tensor,
     op_elu,
     op_floor,
     op_hardswish,

--- a/backends/xnnpack/operators/op_dynamic_dequantize_per_tensor.py
+++ b/backends/xnnpack/operators/op_dynamic_dequantize_per_tensor.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict
+
+import torch
+from executorch.backends.xnnpack.operators.node_visitor import (
+    NodeVisitor,
+    register_node_visitor,
+)
+from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import XNNGraph
+from executorch.backends.xnnpack.utils.utils import get_input_node
+
+
+@register_node_visitor
+class OpDynamicDequantizePerTensor(NodeVisitor):
+    """
+    Dequantize Per Tensor Node visitor
+    """
+
+    target = "quantized_decomposed.dequantize_per_tensor.tensor"
+
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        xnn_graph: XNNGraph,
+        vals_to_ids: Dict[torch.fx.Node, int],
+        debug_handle: int,
+    ) -> None:
+        """
+        We always skip this node because we know it is implicit
+        """
+        dq_input = get_input_node(node, 0)
+        if dq_input in vals_to_ids:
+            vals_to_ids[node] = vals_to_ids[dq_input]

--- a/backends/xnnpack/operators/op_dynamic_quantize_per_tensor.py
+++ b/backends/xnnpack/operators/op_dynamic_quantize_per_tensor.py
@@ -1,0 +1,70 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict
+
+import torch
+from executorch.backends.xnnpack.operators.node_visitor import (
+    NodeVisitor,
+    register_node_visitor,
+)
+from executorch.backends.xnnpack.operators.quant_params import QuantParams
+from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
+    XNNConvert,
+    XNNGraph,
+    XNode,
+)
+from executorch.backends.xnnpack.utils.utils import check_or_raise, get_input_node
+
+
+@register_node_visitor
+class OpDynamicQuantizePerTensor(NodeVisitor):
+    """
+    Dynamic Quantize Per Tensor Node visitor
+    """
+
+    target = "quantized_decomposed.quantize_per_tensor.tensor"
+
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        xnn_graph: XNNGraph,
+        vals_to_ids: Dict[torch.fx.Node, int],
+        debug_handle: int,
+    ) -> None:
+        """
+        We always define dynamic quantize per tensor nodes because they are always explicit
+        """
+        q_input = get_input_node(node, 0)
+
+        # fp32 input
+        self.define_tensor(q_input, xnn_graph, vals_to_ids)
+        input_id = vals_to_ids[q_input]
+
+        # dynamic quantized output
+        input_quant_params = QuantParams.from_q_dq_node(node)
+        # qinput isn't needed for dynamically quantized nodes since it will always be
+        # the output of a convert node. Instead we set q_input to the node itself so
+        # we can extract the shape from the dq output
+        input_quant_params.q_input = node
+        input_quant_params.is_input = False
+        check_or_raise(
+            input_quant_params.is_dynamic,
+            "Internal Error, dynamically quantized node expected dynamic quantized params",
+        )
+        self.define_tensor(
+            node, xnn_graph, vals_to_ids, quant_params=input_quant_params
+        )
+        output_id = vals_to_ids[node]
+
+        ser_node = XNode(
+            xnode_union=XNNConvert(input_id=input_id, output_id=output_id, flags=0),
+            debug_handle=debug_handle,
+        )
+        xnn_graph.xnodes.append(ser_node)

--- a/backends/xnnpack/operators/op_skip_ops.py
+++ b/backends/xnnpack/operators/op_skip_ops.py
@@ -51,15 +51,6 @@ class OpDequantizePerChannelDefault(OpSkipOps):
 
 
 @register_node_visitor
-class OpDequantizePerTensorTensor(OpSkipOps):
-    """
-    do nothing if node is dequantize_per_tensor.tensor
-    """
-
-    target = "quantized_decomposed.dequantize_per_tensor.tensor"
-
-
-@register_node_visitor
 class OpGetItem(OpSkipOps):
     """
     do nothing if node is getitem
@@ -75,15 +66,6 @@ class OpQuantizePerChannelDefault(OpSkipOps):
     """
 
     target = "quantized_decomposed.quantize_per_channel.default"
-
-
-@register_node_visitor
-class OpQuantizePerTensorTensor(OpSkipOps):
-    """
-    do nothing if node is quantize_per_tensor.tensor
-    """
-
-    target = "quantized_decomposed.quantize_per_tensor.tensor"
 
 
 @register_node_visitor

--- a/backends/xnnpack/operators/quant_params.py
+++ b/backends/xnnpack/operators/quant_params.py
@@ -131,8 +131,9 @@ class QuantParams:
 
         if quant_node.target in [
             exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor,
+            exir_ops.edge.quantized_decomposed.quantize_per_tensor.tensor,
         ]:
-            return cls._from_dynamic_input_node(q_input)
+            return cls._from_dynamic_input_node(quant_node)
 
         per_channel = quant_node.target in [
             exir_ops.edge.quantized_decomposed.quantize_per_channel.default,

--- a/backends/xnnpack/serialization/schema.fbs
+++ b/backends/xnnpack/serialization/schema.fbs
@@ -3,7 +3,7 @@
 namespace fb_xnnpack;
 
 // Update after any BC breaking changes
-file_identifier "XN00";
+file_identifier "XN01";
 
 // datatype for xnn-values
 enum XNNDatatype : short {
@@ -25,12 +25,15 @@ enum XNNDatatype : short {
   xnn_datatype_qcint32 = 7,
   /// Quantized 4-bit signed integer with shared per-channel quantization parameters.
   xnn_datatype_qcint4 = 8,
+  /// Dynamically quantized 8-bit signed integer with per-batch quantization parameters.
+  xnn_datatype_qdint8 = 9,
 }
 
 // type of quantization
 union XNNQuantParams {
   PerChannelQuant,
   PerTensorQuant,
+  PerTokenDynamicQuant,
 }
 
 // taken from executorch
@@ -42,6 +45,10 @@ table Buffer {
 table PerChannelQuant {
   scale:[float];
   channel_dim:int;
+}
+
+table PerTokenDynamicQuant {
+  num_nonbatch_dims:int;
 }
 
 table PerTensorQuant {
@@ -69,9 +76,6 @@ table XNNTensorValue {
   // pointer to the variable that will be initialized with the Value ID upon successful return. If a
   // valid @a external_id was provided, the variable will be initialized with the @a external_id value.
   id_out:uint;
-  // does this value need to be quantized dynamically at runtime?
-  // if we are quantizing at runtime, this field points to a target dtype
-  dq_datatype:XNNDatatype = xnn_datatype_invalid;
 }
 
 table XNNQuantizedTensorValue {

--- a/backends/xnnpack/serialization/schema.fbs
+++ b/backends/xnnpack/serialization/schema.fbs
@@ -36,10 +36,9 @@ union XNNQuantParams {
   PerTokenDynamicQuant,
 }
 
-// taken from executorch
-// Data buffer abstraction.
+// Deprecated buffer abstraction, const data buffers do not belong in flatbuffer
 table Buffer {
-  storage:[ubyte] (force_align: 16);
+  storage:[ubyte] (deprecated, force_align: 16);
 }
 
 table PerChannelQuant {
@@ -324,18 +323,14 @@ table XNNGraph {
   // Ids of external outputs
   output_ids:[uint];
 
-  // Tables of constant data, used for constant Values (e.g.
-  // data field of weight tensors). Each constant is assigned an index into the table
-  // which are each individually aligned. 0 index is reserved to be pointed to by non-constant
-  // Tensors. Exactly one of constant_buffer and constant_data must be non-empty
-  constant_buffer:[Buffer];
+  // Deprecated constant buffer storage in flatbuffer
+  constant_buffer:[Buffer] (deprecated);
 
-  // the list index is memory buffer id, the value is the memory buffer size.
-  mem_buffer_sizes: [uint];
+  // Deprecated memory_buffer size tracking in flatbuffer
+  mem_buffer_sizes: [uint] (deprecated);
 
   // List of the constant data that follows the XNNGraph in this file. Each constant data is assigned an index into
-  // the table. 0 index is reserved to be pointed to by non-constant Tensor. Exactly one of constant_buffer and
-  // constant_data must be non-empty
+  // the table. 0 index is reserved to be pointed to by non-constant Tensor.
   constant_data:[ConstantDataOffset];
 }
 

--- a/backends/xnnpack/serialization/xnnpack_graph_schema.py
+++ b/backends/xnnpack/serialization/xnnpack_graph_schema.py
@@ -432,11 +432,6 @@ class XValue:
 
 
 @dataclass
-class Buffer:
-    storage: bytes
-
-
-@dataclass
 class ConstantDataOffset:
     offset: int
     size: int
@@ -451,8 +446,5 @@ class XNNGraph:
     num_externs: int
     input_ids: List[int]
     output_ids: List[int]
-
-    constant_buffer: List[Buffer]
-    mem_buffer_sizes: List[int]
 
     constant_data: List[ConstantDataOffset]

--- a/backends/xnnpack/serialization/xnnpack_graph_schema.py
+++ b/backends/xnnpack/serialization/xnnpack_graph_schema.py
@@ -380,6 +380,7 @@ class XNNDatatype(IntEnum):
     xnn_datatype_qcint8 = 6
     xnn_datatype_qcint32 = 7
     xnn_datatype_qcint4 = 8
+    xnn_datatype_qdint8 = 9
 
 
 @dataclass
@@ -389,12 +390,17 @@ class PerChannelQuant:
 
 
 @dataclass
+class PerTokenDynamicQuant:
+    num_nonbatch_dims: int
+
+
+@dataclass
 class PerTensorQuant:
     scale: float
     zero_point: int
 
 
-XNNQuantParams = Union[PerChannelQuant, PerTensorQuant]
+XNNQuantParams = Union[PerChannelQuant, PerTensorQuant, PerTokenDynamicQuant]
 
 
 @dataclass
@@ -406,7 +412,6 @@ class XNNTensorValue:
     external_id: int
     flags: int
     id_out: int
-    dq_datatype: XNNDatatype = XNNDatatype.xnn_datatype_invalid
 
 
 @dataclass

--- a/backends/xnnpack/targets.bzl
+++ b/backends/xnnpack/targets.bzl
@@ -40,7 +40,6 @@ def define_common_targets():
         ] + ([] if runtime.is_oss else ["-DENABLE_DYNAMIC_QUANTIZATION"]),
         deps = [
             third_party_dep("XNNPACK"),
-            ":dynamic_quant_utils",  # TODO Use (1) portable for choose_qparams(), (2) xnnpack for quantize_per_tensor(),
             "//executorch/runtime/backend:interface",
             "//executorch/backends/xnnpack/serialization:xnnpack_flatbuffer_header",
             "//executorch/backends/xnnpack/threadpool:threadpool",

--- a/backends/xnnpack/test/serialization/test_serialization.py
+++ b/backends/xnnpack/test/serialization/test_serialization.py
@@ -4,13 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
-import random
 import unittest
-from typing import List, Tuple
 
 from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
-    Buffer,
+    ConstantDataOffset,
     XNNGraph,
 )
 
@@ -22,23 +19,6 @@ from executorch.backends.xnnpack.serialization.xnnpack_graph_serialize import (
 
 
 class TestSerialization(unittest.TestCase):
-    def _generate_random_const_buffers(
-        self, num_tensors: int
-    ) -> Tuple[List[Buffer], List[int]]:
-        """
-        Helper function to generate `num_tensor` buffers of random sizes and random contents,
-        we return a tuple of (list_of_buffers, list_of_mem_sizes),
-        """
-        buffers = []
-        mem_sizes = []
-        for _ in range(num_tensors):
-            buffer_size = random.randint(1, 1000)
-            buffer = bytearray(os.urandom(buffer_size))
-            buffers.append(Buffer(storage=bytes(buffer)))
-            mem_sizes.append(buffer_size)
-
-        return buffers, mem_sizes
-
     def test_serialize_xnnpack_binary(self):
         xnn_graph = XNNGraph(
             version="0",
@@ -47,25 +27,18 @@ class TestSerialization(unittest.TestCase):
             num_externs=0,
             input_ids=[],
             output_ids=[],
-            constant_buffer=[Buffer(storage=b"")],
-            mem_buffer_sizes=[0],
-            constant_data=[],
+            constant_data=[ConstantDataOffset(0, 0)],
         )
-        buffers, sizes = self._generate_random_const_buffers(5)
-        xnn_graph.constant_buffer.extend(buffers)
-        xnn_graph.mem_buffer_sizes.extend(sizes)
-        buffers = xnn_graph.constant_buffer
 
-        serialized_binary = serialize_xnnpack_binary(xnn_graph)
-        offsets = xnn_graph.constant_data
+        constant_data_bytes = b"\x00" * 24
+        serialized_binary = serialize_xnnpack_binary(
+            xnn_graph, bytearray(constant_data_bytes)
+        )
 
         # Check header
         self.assertEqual(serialized_binary[0:4], b"\x00\x00\x00\x00")
         self.assertEqual(serialized_binary[XNNHeader.MAGIC_OFFSET], b"XH00")
         flatbuffer_offset_bytes = serialized_binary[XNNHeader.FLATBUFFER_OFFSET_OFFSET]
-        constant_data_offset_bytes = serialized_binary[
-            XNNHeader.CONSTANT_DATA_OFFSET_OFFSET
-        ]
 
         # Check flatbuffer is at flatbuffer offset
         flatbuffer_offset = int.from_bytes(
@@ -75,24 +48,3 @@ class TestSerialization(unittest.TestCase):
         self.assertEqual(
             serialized_binary[flatbuffer_offset:][XNNHeader.MAGIC_OFFSET], b"XN01"
         )
-
-        # Check constant data
-        # Check that constant buffers have been moved to constant data
-        self.assertEqual(len(offsets), len(buffers))
-        self.assertEqual(len(xnn_graph.constant_buffer), 0)
-
-        constant_data_offset = int.from_bytes(
-            constant_data_offset_bytes, byteorder=_HEADER_BYTEORDER
-        )
-        constant_data_payload = serialized_binary[constant_data_offset:]
-
-        # We check that constant data indexes stored in the xnn_graph correctly index
-        # into the correct buffer in the constant data section
-        for idx in range(1, len(offsets)):
-            offset = offsets[idx].offset
-            size = offsets[idx].size
-
-            constant_data_bytes = constant_data_payload[offset : offset + size]
-            constant_buffer_bytes = buffers[idx].storage
-
-            self.assertEqual(constant_data_bytes, constant_buffer_bytes)

--- a/backends/xnnpack/test/serialization/test_serialization.py
+++ b/backends/xnnpack/test/serialization/test_serialization.py
@@ -73,7 +73,7 @@ class TestSerialization(unittest.TestCase):
         )
         # Flatbuffer magic should be in the same spot as the Header's magic
         self.assertEqual(
-            serialized_binary[flatbuffer_offset:][XNNHeader.MAGIC_OFFSET], b"XN00"
+            serialized_binary[flatbuffer_offset:][XNNHeader.MAGIC_OFFSET], b"XN01"
         )
 
         # Check constant data

--- a/backends/xnnpack/xnnpack_preprocess.py
+++ b/backends/xnnpack/xnnpack_preprocess.py
@@ -18,7 +18,7 @@ from executorch.backends.xnnpack.passes.convert_to_linear import ConvertToLinear
 from executorch.backends.xnnpack.passes.tag_implicit_q_dq_pass import TagImplicitQDqPass
 
 from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
-    Buffer,
+    ConstantDataOffset,
     XNNGraph,
 )
 from executorch.backends.xnnpack.serialization.xnnpack_graph_serialize import (
@@ -134,12 +134,11 @@ class XnnpackBackend(BackendDetails):
             num_externs=len(node_to_external_map),
             input_ids=[],
             output_ids=[],
-            constant_buffer=[Buffer(storage=b"")],
-            mem_buffer_sizes=[0],
-            constant_data=[],
+            constant_data=[ConstantDataOffset(0, 0)],
         )
 
-        node_visitors = get_node_visitors(ep, node_to_external_map)
+        constant_data_bytes = bytearray()
+        node_visitors = get_node_visitors(ep, node_to_external_map, constant_data_bytes)
 
         for node in graph_module.graph.nodes:
             if node.op == "call_function":
@@ -164,5 +163,8 @@ class XnnpackBackend(BackendDetails):
             else:
                 raise RuntimeError(f"{node.op} is not supported in XNNPACK")
         return PreprocessResult(
-            processed_bytes=serialize_xnnpack_binary(xnnpack_graph), debug_handle_map={}
+            processed_bytes=serialize_xnnpack_binary(
+                xnnpack_graph, constant_data_bytes
+            ),
+            debug_handle_map={},
         )


### PR DESCRIPTION
Summary: This is part 2 of stage 2. We are updating the model generation to generate XN01 models. The change here is removing all usage of old constant data serialization (serializing data in flatbuffer) and moving completely to serializing data using the XNNHeader. This removes a few flatbuffer constructs like Buffer and also removes items from the XNNGraph like constant_buffer and mem_id_sizes

Differential Revision: D53495025

