### PR TITLE
BC Fix Stage 2 new DQ Linear Path

### DIFF
--- a/backends/xnnpack/operators/__init__.py
+++ b/backends/xnnpack/operators/__init__.py
@@ -16,6 +16,8 @@ from . import (  # noqa
     op_conv2d,
     op_dequantize_per_tensor,
     op_div,
+    op_dynamic_dequantize_per_tensor,
+    op_dynamic_quantize_per_tensor,
     op_elu,
     op_floor,
     op_hardswish,

--- a/backends/xnnpack/operators/op_dynamic_dequantize_per_tensor.py
+++ b/backends/xnnpack/operators/op_dynamic_dequantize_per_tensor.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict
+
+import torch
+from executorch.backends.xnnpack.operators.node_visitor import (
+    NodeVisitor,
+    register_node_visitor,
+)
+from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import XNNGraph
+from executorch.backends.xnnpack.utils.utils import get_input_node
+
+
+@register_node_visitor
+class OpDynamicDequantizePerTensor(NodeVisitor):
+    """
+    Dequantize Per Tensor Node visitor
+    """
+
+    target = "quantized_decomposed.dequantize_per_tensor.tensor"
+
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        xnn_graph: XNNGraph,
+        vals_to_ids: Dict[torch.fx.Node, int],
+        debug_handle: int,
+    ) -> None:
+        """
+        We always skip this node because we know it is implicit
+        """
+        dq_input = get_input_node(node, 0)
+        if dq_input in vals_to_ids:
+            vals_to_ids[node] = vals_to_ids[dq_input]

--- a/backends/xnnpack/operators/op_dynamic_quantize_per_tensor.py
+++ b/backends/xnnpack/operators/op_dynamic_quantize_per_tensor.py
@@ -1,0 +1,70 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict
+
+import torch
+from executorch.backends.xnnpack.operators.node_visitor import (
+    NodeVisitor,
+    register_node_visitor,
+)
+from executorch.backends.xnnpack.operators.quant_params import QuantParams
+from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
+    XNNConvert,
+    XNNGraph,
+    XNode,
+)
+from executorch.backends.xnnpack.utils.utils import check_or_raise, get_input_node
+
+
+@register_node_visitor
+class OpDynamicQuantizePerTensor(NodeVisitor):
+    """
+    Dynamic Quantize Per Tensor Node visitor
+    """
+
+    target = "quantized_decomposed.quantize_per_tensor.tensor"
+
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        xnn_graph: XNNGraph,
+        vals_to_ids: Dict[torch.fx.Node, int],
+        debug_handle: int,
+    ) -> None:
+        """
+        We always define dynamic quantize per tensor nodes because they are always explicit
+        """
+        q_input = get_input_node(node, 0)
+
+        # fp32 input
+        self.define_tensor(q_input, xnn_graph, vals_to_ids)
+        input_id = vals_to_ids[q_input]
+
+        # dynamic quantized output
+        input_quant_params = QuantParams.from_q_dq_node(node)
+        # qinput isn't needed for dynamically quantized nodes since it will always be
+        # the output of a convert node. Instead we set q_input to the node itself so
+        # we can extract the shape from the dq output
+        input_quant_params.q_input = node
+        input_quant_params.is_input = False
+        check_or_raise(
+            input_quant_params.is_dynamic,
+            "Internal Error, dynamically quantized node expected dynamic quantized params",
+        )
+        self.define_tensor(
+            node, xnn_graph, vals_to_ids, quant_params=input_quant_params
+        )
+        output_id = vals_to_ids[node]
+
+        ser_node = XNode(
+            xnode_union=XNNConvert(input_id=input_id, output_id=output_id, flags=0),
+            debug_handle=debug_handle,
+        )
+        xnn_graph.xnodes.append(ser_node)

--- a/backends/xnnpack/operators/op_skip_ops.py
+++ b/backends/xnnpack/operators/op_skip_ops.py
@@ -51,15 +51,6 @@ class OpDequantizePerChannelDefault(OpSkipOps):
 
 
 @register_node_visitor
-class OpDequantizePerTensorTensor(OpSkipOps):
-    """
-    do nothing if node is dequantize_per_tensor.tensor
-    """
-
-    target = "quantized_decomposed.dequantize_per_tensor.tensor"
-
-
-@register_node_visitor
 class OpGetItem(OpSkipOps):
     """
     do nothing if node is getitem
@@ -75,15 +66,6 @@ class OpQuantizePerChannelDefault(OpSkipOps):
     """
 
     target = "quantized_decomposed.quantize_per_channel.default"
-
-
-@register_node_visitor
-class OpQuantizePerTensorTensor(OpSkipOps):
-    """
-    do nothing if node is quantize_per_tensor.tensor
-    """
-
-    target = "quantized_decomposed.quantize_per_tensor.tensor"
 
 
 @register_node_visitor

--- a/backends/xnnpack/operators/quant_params.py
+++ b/backends/xnnpack/operators/quant_params.py
@@ -131,8 +131,9 @@ class QuantParams:
 
         if quant_node.target in [
             exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor,
+            exir_ops.edge.quantized_decomposed.quantize_per_tensor.tensor,
         ]:
-            return cls._from_dynamic_input_node(q_input)
+            return cls._from_dynamic_input_node(quant_node)
 
         per_channel = quant_node.target in [
             exir_ops.edge.quantized_decomposed.quantize_per_channel.default,

--- a/backends/xnnpack/serialization/schema.fbs
+++ b/backends/xnnpack/serialization/schema.fbs
@@ -3,7 +3,7 @@
 namespace fb_xnnpack;
 
 // Update after any BC breaking changes
-file_identifier "XN00";
+file_identifier "XN01";
 
 // datatype for xnn-values
 enum XNNDatatype : short {
@@ -25,12 +25,15 @@ enum XNNDatatype : short {
   xnn_datatype_qcint32 = 7,
   /// Quantized 4-bit signed integer with shared per-channel quantization parameters.
   xnn_datatype_qcint4 = 8,
+  /// Dynamically quantized 8-bit signed integer with per-batch quantization parameters.
+  xnn_datatype_qdint8 = 9,
 }
 
 // type of quantization
 union XNNQuantParams {
   PerChannelQuant,
   PerTensorQuant,
+  PerTokenDynamicQuant,
 }
 
 // taken from executorch
@@ -42,6 +45,10 @@ table Buffer {
 table PerChannelQuant {
   scale:[float];
   channel_dim:int;
+}
+
+table PerTokenDynamicQuant {
+  num_nonbatch_dims:int;
 }
 
 table PerTensorQuant {
@@ -69,9 +76,6 @@ table XNNTensorValue {
   // pointer to the variable that will be initialized with the Value ID upon successful return. If a
   // valid @a external_id was provided, the variable will be initialized with the @a external_id value.
   id_out:uint;
-  // does this value need to be quantized dynamically at runtime?
-  // if we are quantizing at runtime, this field points to a target dtype
-  dq_datatype:XNNDatatype = xnn_datatype_invalid;
 }
 
 table XNNQuantizedTensorValue {

--- a/backends/xnnpack/serialization/xnnpack_graph_schema.py
+++ b/backends/xnnpack/serialization/xnnpack_graph_schema.py
@@ -380,6 +380,7 @@ class XNNDatatype(IntEnum):
     xnn_datatype_qcint8 = 6
     xnn_datatype_qcint32 = 7
     xnn_datatype_qcint4 = 8
+    xnn_datatype_qdint8 = 9
 
 
 @dataclass
@@ -389,12 +390,17 @@ class PerChannelQuant:
 
 
 @dataclass
+class PerTokenDynamicQuant:
+    num_nonbatch_dims: int
+
+
+@dataclass
 class PerTensorQuant:
     scale: float
     zero_point: int
 
 
-XNNQuantParams = Union[PerChannelQuant, PerTensorQuant]
+XNNQuantParams = Union[PerChannelQuant, PerTensorQuant, PerTokenDynamicQuant]
 
 
 @dataclass
@@ -406,7 +412,6 @@ class XNNTensorValue:
     external_id: int
     flags: int
     id_out: int
-    dq_datatype: XNNDatatype = XNNDatatype.xnn_datatype_invalid
 
 
 @dataclass

--- a/backends/xnnpack/targets.bzl
+++ b/backends/xnnpack/targets.bzl
@@ -40,7 +40,6 @@ def define_common_targets():
         ] + ([] if runtime.is_oss else ["-DENABLE_DYNAMIC_QUANTIZATION"]),
         deps = [
             third_party_dep("XNNPACK"),
-            ":dynamic_quant_utils",  # TODO Use (1) portable for choose_qparams(), (2) xnnpack for quantize_per_tensor(),
             "//executorch/runtime/backend:interface",
             "//executorch/backends/xnnpack/serialization:xnnpack_flatbuffer_header",
             "//executorch/backends/xnnpack/threadpool:threadpool",

--- a/backends/xnnpack/test/serialization/test_serialization.py
+++ b/backends/xnnpack/test/serialization/test_serialization.py
@@ -73,7 +73,7 @@ class TestSerialization(unittest.TestCase):
         )
         # Flatbuffer magic should be in the same spot as the Header's magic
         self.assertEqual(
-            serialized_binary[flatbuffer_offset:][XNNHeader.MAGIC_OFFSET], b"XN00"
+            serialized_binary[flatbuffer_offset:][XNNHeader.MAGIC_OFFSET], b"XN01"
         )
 
         # Check constant data


### PR DESCRIPTION
Summary:
This is part 1 of BC Breaking changes.

Here we update the schema to XN01. We are now serializing new models. The changes in serialization here removing the old dqlinear path (dq_datatype). And using a new dq linear datapath. Serializing inputs as dynamically quantized for fully connected inputs.

We also introduce two new tensor types: DynamicallyQuantized and QuantizedPerChannel2 (this is used for 4 bit channel wise quantization)

Differential Revision: D53454518

