### PR TITLE
Add option to redirect stdout and stdcerr to a file for xcrun compatibility

### DIFF
--- a/backends/xnnpack/runtime/profiling/XNNProfiler.cpp
+++ b/backends/xnnpack/runtime/profiling/XNNProfiler.cpp
@@ -176,6 +176,8 @@ void XNNProfiler::log_operator_timings() {
         Info, ">>, %s, %" PRId64 " (%f)", op_name, op_timings_[i], avg_op_time);
   }
   ET_LOG(Info, ">>, Total Time, %f", total_time);
+#else
+  run_count_++;
 #endif
 }
 


### PR DESCRIPTION
Summary:
XCRun doesn't provide a convenient way to gather logs or know when a program has completed execution. (This is recognized by the dev community: see https://github.com/ios-control/ios-deploy/issues/588 )

We'll solve this by redirecting `stdout` and `stderr` to a file called `/tmp/BENCH_LOG`. Once the benchmark is complete, we'll create an empty file called `/tmp/BENCH_DONE` that we can poll for (let's say, every 5 seconds) to check whether the benchmark has completed.

Reviewed By: Jack-Khuu

Differential Revision: D53255873


