### PR TITLE
Demo CoreML Partitioner

### DIFF
--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -46,7 +46,29 @@ class TestCoreMLPartitioner(unittest.TestCase):
             "getitem",
         ]
 
+    def test_vit_skip_conv(self):
+        model = torchvision.models.vit_b_16(weights="IMAGENET1K_V1")
+        model.eval()
+
+        example_inputs = (torch.randn(1, 3, 224, 224),)
+        exir_program_aten = torch.export.export(model, example_inputs)
+        edge_program_manager = executorch.exir.to_edge(exir_program_aten)
+        delegated_program_manager = edge_program_manager.to_backend(
+            CoreMLPartitioner(skip_ops_for_coreml_delegation=["aten.convolution.default"])
+        )
+
+        assert [
+            node.target.__name__
+            for node in delegated_program_manager.exported_program().graph.nodes
+            if node.op == "call_function"
+        ] == [
+            "aten.convolution.default",
+            "executorch_call_delegate",
+            "getitem",
+        ]
+
 
 if __name__ == "__main__":
     test_runner = TestCoreMLPartitioner()
     test_runner.test_add_sub_skip_mm()
+    test_runner.test_vit_skip_conv()

--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -4,22 +4,17 @@
 
 import unittest
 
-import executorch.exir as exir
-
 import torch
+import torchvision
+import executorch.exir
 
-from executorch.backends.apple.coreml.partition.coreml_partitioner import (
-    CoreMLPartitioner,
-)
-from executorch.exir.backend.backend_api import to_backend
+from executorch.backends.apple.coreml.compiler import CoreMLBackend
+from executorch.backends.apple.coreml.partition.coreml_partitioner import CoreMLPartitioner
 
 
 class TestCoreMLPartitioner(unittest.TestCase):
-    def test_partition_add_mul(self):
+    def test_add_sub_skip_mm(self):
         class Model(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
             def forward(self, a, x, b):
                 y = torch.mm(a, x)
                 z = y + b
@@ -29,31 +24,18 @@ class TestCoreMLPartitioner(unittest.TestCase):
                 return z
 
         model = Model()
-        inputs = (torch.randn(2, 2), torch.randn(2, 2), torch.randn(2, 2))
-        exported_program = (
-            exir.capture(model, inputs, exir.CaptureConfig()).to_edge().exported_program
+        model.eval()
+
+        example_inputs = (torch.randn(2, 2), torch.randn(2, 2), torch.randn(2, 2))
+        exir_program_aten = torch.export.export(model, example_inputs)
+        edge_program_manager = executorch.exir.to_edge(exir_program_aten)
+        delegated_program_manager = edge_program_manager.to_backend(
+            CoreMLPartitioner(skip_ops_for_coreml_delegation=["aten.mm.default"])
         )
 
         assert [
             node.target.__name__
-            for node in exported_program.graph.nodes
-            if node.op == "call_function"
-        ] == [
-            "aten.mm.default",
-            "aten.add.Tensor",
-            "aten.sub.Tensor",
-            "aten.mm.default",
-            "aten.add.Tensor",
-        ]
-
-        exported_to_coreml = to_backend(
-            exported_program,
-            CoreMLPartitioner(skip_ops_for_coreml_delegation=["aten.mm.default"]),
-        )
-
-        assert [
-            node.target.__name__
-            for node in exported_to_coreml.graph.nodes
+            for node in delegated_program_manager.exported_program().graph.nodes
             if node.op == "call_function"
         ] == [
             "aten.mm.default",
@@ -67,4 +49,4 @@ class TestCoreMLPartitioner(unittest.TestCase):
 
 if __name__ == "__main__":
     test_runner = TestCoreMLPartitioner()
-    test_runner.test_partition_add_mul()
+    test_runner.test_add_sub_skip_mm()


### PR DESCRIPTION
## TLDR
This PR adds ViT as an e2e example of leveraging CoreML partitioner

💁‍♂️ Tips for reviewers: Review commit by commit would be easier
1. [Commit 1](https://github.com/pytorch/executorch/pull/1981/commits/96b9289fd8823de38ca7388301f08b061a6e7b2f) is just some polishing
2. [Commit 2](https://github.com/pytorch/executorch/pull/1981/commits/0deef84134193cf4124f7b60a3338b34addbc121) adds the e2e example

## Details: Motivation and Example Setup
CoreML partitioner is intended for non-resident models to benefit from CoreML as much as possible. Concretely, if a model cannot be fully converted to CoreML, then CoreML partitioner would help to have the convertible part run on CoreML backend. Unfortunately, for the models we have tried, we cannot find a perfect "torch exportable but CoreML unconvertible" example: they are either fully CoreML resident, or torch unexportable.

As a result, here we artificially create an example by utilizing the `skip_ops_for_coreml_delegation`. It is still a realistic example:
1. In many use cases, we may not want the initial (or final) embedding part to run on CoreML, especially if they are small
3. Our intended graph break emerges from this example

## Appendix: Exported Program
Use `CoreMLPartitioner()` (fully CoreML-resident)
```
        def forward(self, arg152_1: "f32[1, 3, 224, 224]"):
            # No stacktrace found for following nodes
            lowered_module_0 = self.lowered_module_0
            executorch_call_delegate = torch.ops.higher_order.executorch_call_delegate(lowered_module_0, arg152_1);  lowered_module_0 = arg152_1 = None
            getitem: "f32[1, 1000]" = executorch_call_delegate[0];  executorch_call_delegate = None
            return (getitem,)
```
Use `CoreMLPartitioner(skip_ops_for_coreml_delegation=["aten.convolution.default"])` (intentionally remove `conv` from CoreML)
```
        def forward(self, arg2_1: "f32[768, 3, 16, 16]", arg3_1: "f32[768]", arg152_1: "f32[1, 3, 224, 224]"):
            # File: /Volumes/data/Software/Mine/executorch_121559468/env/lib/python3.10/site-packages/torchvision/models/vision_transformer.py:277 in _process_input, code: x = self.conv_proj(x)
            aten_convolution_default: "f32[1, 768, 14, 14]" = executorch_exir_dialects_edge__ops_aten_convolution_default(arg152_1, arg2_1, arg3_1, [16, 16], [0, 0], [1, 1], False, [0, 0], 1);  arg152_1 = arg2_1 = arg3_1 = None
            
            # No stacktrace found for following nodes
            lowered_module_0 = self.lowered_module_0
            executorch_call_delegate = torch.ops.higher_order.executorch_call_delegate(lowered_module_0, aten_convolution_default);  lowered_module_0 = aten_convolution_default = None
            getitem: "f32[1, 1000]" = executorch_call_delegate[0];  executorch_call_delegate = None
            return (getitem,)
```
