### PR TITLE
Fix mask dtype mismatching query dtype properly

### DIFF
--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -260,9 +260,7 @@ class Attention(nn.Module):
         # Shape before: [1, 1, L, S], after: [L, S]
         # We make sure to specify the dimensions to be squeezed [0, 1] to ensure that the output
         # tensor will be 2-dimensional, regarldess of the values of L & S
-        mask = torch.squeeze(self.mask[:, :, :seqlen, :seqlen], [0, 1]).to(
-            dtype=xq.dtype
-        )
+        mask = torch.squeeze(mask, [0, 1])
 
         output = F.scaled_dot_product_attention(
             xq, keys, values, attn_mask=mask, dropout_p=0.0

--- a/examples/models/llama2/ops/quantized_ops.py
+++ b/examples/models/llama2/ops/quantized_ops.py
@@ -60,7 +60,8 @@ def embedding_byte_meta(
     assert weight_zero_points is None or weight_zero_points.size(0) == weight.size(
         0
     ), f"Expecting weight_zero_points tensor to be None or have same number of rows as weights, but found {weight.size()} and {weight_zero_points.size()}"
-
+    if not weight_zero_points:
+        weight_zero_points = torch.zeros(weight.size(0))
     weight = torch.ops.quantized_decomposed.dequantize_per_channel.default(
         weight,
         weight_scales,

--- a/examples/models/llama2/quantize.py
+++ b/examples/models/llama2/quantize.py
@@ -722,7 +722,7 @@ class QuantizedGroupEmbedding(torch.nn.Module):
     def forward(self, indices: torch.Tensor) -> torch.Tensor:
         return torch.ops.llama_quantized.embedding_byte.default(
             self.weight_int8, self.scales_fp16, None, 0, 0, indices
-        )
+        ).to(self.dtype)
 
 
 #        result_weights = self.weight_int8.index_select(0, indices.view(-1))


### PR DESCRIPTION
Summary:
Some refactoring on the mask handling in llama.

In our quantized group embedding implementation we directly call llama_quantized.embedding_type but that operator always return fp32. We need to convert it back to fp16 based on the dtype we got in the QuantizedGroupEmbedding module.

Differential Revision: D53796343


