### PR TITLE
Fix ExportedProgram calls

### DIFF
--- a/backends/xnnpack/test/tester/tester.py
+++ b/backends/xnnpack/test/tester/tester.py
@@ -78,7 +78,7 @@ class Stage(ABC):
         if isinstance(self.artifact, ExportedProgram):
             return self.artifact(*inputs)
         else:
-            return self.artifact.exported_program()(*inputs)
+            return self.artifact.exported_program().module()(*inputs)
 
     # Debug Tools for stages
     def artifact_str(self):
@@ -569,5 +569,5 @@ class Tester:
 
             dequant_node.target = dequant_shim
 
-        output = program(*inputs)
+        output = program.module()(*inputs)
         return output, scale

--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -184,7 +184,7 @@ class TestProgramManagers(unittest.TestCase):
             get_exported_programs(), get_config_methods()
         )
 
-        original_res = edge_manager.exported_program("forward")(
+        original_res = edge_manager.exported_program("forward").module()(
             torch.ones(1), torch.ones(1)
         )
 
@@ -234,7 +234,7 @@ class TestProgramManagers(unittest.TestCase):
         )
 
         self.assertEqual(
-            transformed_edge.exported_program("foo")(
+            transformed_edge.exported_program("foo").module()(
                 torch.ones(1),
             ),
             torch.ones(1) + 1,  # x + 1

--- a/exir/tests/TARGETS
+++ b/exir/tests/TARGETS
@@ -428,7 +428,6 @@ python_unittest(
     deps = [
         "//caffe2:torch",
         "//executorch/exir:lib",
-        "//executorch/exir/passes:lib",
     ],
 )
 

--- a/exir/tests/test_delegate.py
+++ b/exir/tests/test_delegate.py
@@ -61,7 +61,7 @@ class TestDelegate(unittest.TestCase):
         FileCheck().check("lowered_module_0").check(
             "torch.ops.higher_order.executorch_call_delegate"
         ).run(gm.graph_module.code)
-        self.assertTrue(torch.allclose(orig_res, gm(*inputs)))
+        self.assertTrue(torch.allclose(orig_res, gm.module()(*inputs)))
 
     def test_to_backend(self) -> None:
         """Check if we have patched a lowered module correctly (for delegation)"""
@@ -186,7 +186,7 @@ class TestDelegate(unittest.TestCase):
                 self.assertTrue(isinstance(node.args[0], list))
                 self.assertEqual(len(node.args[0]), 1)
 
-        new_res = prog.exported_program()(*inputs)
+        new_res = prog.exported_program().module()(*inputs)
         self.assertTrue(torch.allclose(new_res, orig_res))
 
     def test_create_submodule_multiple_return(self) -> None:
@@ -246,7 +246,7 @@ class TestDelegate(unittest.TestCase):
                 self.assertTrue(isinstance(node.args[0], list))
                 self.assertEqual(len(node.args[0]), 2)
 
-        new_res = prog.exported_program()(*inputs)
+        new_res = prog.exported_program().module()(*inputs)
         self.assertTrue(torch.allclose(new_res, orig_res))
 
     def test_create_submodule_list_return(self) -> None:
@@ -307,5 +307,5 @@ class TestDelegate(unittest.TestCase):
                 self.assertTrue(isinstance(node.args[0], list))
                 self.assertEqual(len(node.args[0]), 2)
 
-        new_res = prog.exported_program()(*inputs)
+        new_res = prog.exported_program().module()(*inputs)
         self.assertTrue(torch.allclose(new_res, orig_res))

--- a/exir/tests/test_memory_format_ops_pass.py
+++ b/exir/tests/test_memory_format_ops_pass.py
@@ -56,8 +56,8 @@ class TestMemoryFormatOpsPass(unittest.TestCase):
         ).run(epm.exported_program().graph_module.code)
 
         # check EdgeOp and the new BackendOp should behave the same
-        expected = before(*test_set.sample_input)
-        actual = epm.exported_program()(*test_set.sample_input)
+        expected = before.module()(*test_set.sample_input)
+        actual = epm.exported_program().module()(*test_set.sample_input)
         self.assertTrue(torch.allclose(actual, expected))
         self.assertEqual(
             self.is_channel_last(actual),

--- a/exir/tests/test_serde.py
+++ b/exir/tests/test_serde.py
@@ -37,8 +37,8 @@ class TestSerde(unittest.TestCase):
         """
         Checks if two graphs are equivalent
         """
-        orig_outputs = ep1(*inputs)
-        loaded_outputs = ep2(*inputs)
+        orig_outputs = ep1.module()(*inputs)
+        loaded_outputs = ep2.module()(*inputs)
 
         flat_orig_outputs, _ = pytree.tree_flatten(orig_outputs)
         flat_loaded_outputs, _ = pytree.tree_flatten(loaded_outputs)


### PR DESCRIPTION
Summary:
D53075378 removed the ExportedProgram's `__call__` function, but some
of the test failures were not caught by CI. Forward fixing the failures now

Reviewed By: cccclai

Differential Revision: D53813818


