### PR TITLE
update tensor::SizesType to exec_aten::SizeType

### DIFF
--- a/kernels/portable/cpu/util/copy_ops_util.cpp
+++ b/kernels/portable/cpu/util/copy_ops_util.cpp
@@ -121,7 +121,7 @@ bool check_cat_args(
 void get_cat_out_target_size(
     exec_aten::ArrayRef<Tensor> tensors,
     int64_t dim,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim) {
   // Find the first non-1D-or-empty tensor in the list to use as a reference
   // because an 1D empty tensor is a wildcard and should be ignored when we
@@ -301,7 +301,7 @@ bool check_unbind_copy_args(const Tensor& in, int64_t dim, TensorList out) {
 void get_permute_copy_out_target_size(
     const Tensor& in,
     IntArrayRef dims,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim) {
   *out_ndim = in.dim();
 
@@ -326,10 +326,10 @@ bool check_pixel_shuffle_args(
 void get_pixel_shuffle_out_target_size(
     const Tensor& in,
     int64_t upscale_factor,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim) {
   *out_ndim = in.dim();
-  const Tensor::SizesType casted_upscale_factor = upscale_factor;
+  const exec_aten::SizesType casted_upscale_factor = upscale_factor;
 
   size_t i = 0;
   for (; i < in.dim() - 3; ++i) {
@@ -360,7 +360,7 @@ bool check_select_copy_out_args(
 void get_select_copy_out_target_size(
     const Tensor& in,
     int64_t dim,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim) {
   *out_ndim = in.dim() - 1;
 
@@ -389,7 +389,7 @@ void get_slice_copy_out_target_size(
     const Tensor& in,
     int64_t dim,
     int64_t num_values,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim) {
   *out_ndim = in.dim();
 
@@ -430,7 +430,7 @@ void get_split_with_sizes_copy_out_target_size(
     const Tensor& in,
     int64_t split_size,
     int64_t dim,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim) {
   *out_ndim = in.dim();
 
@@ -453,7 +453,7 @@ bool check_squeeze_copy_dim_args(
 void get_squeeze_copy_dim_out_target_size(
     const Tensor in,
     int64_t dim,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim) {
   // For 0 dim tensors, the output should also be 0 dim.
   if (in.dim() == 0) {
@@ -506,7 +506,7 @@ bool check_squeeze_copy_dims_args(
 void get_squeeze_copy_dims_out_target_size(
     const Tensor in,
     const exec_aten::ArrayRef<int64_t> dims,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim) {
   // For 0 dim tensors, the output should also be 0 dim.
   if (in.dim() == 0) {
@@ -515,7 +515,7 @@ void get_squeeze_copy_dims_out_target_size(
   }
 
   // A dim is only removed if the size at the given dim is 1.
-  Tensor::SizesType dims_to_remove = 0;
+  exec_aten::SizesType dims_to_remove = 0;
   for (size_t i = 0; i < dims.size(); ++i) {
     int64_t dim = dims[i] < 0 ? dims[i] + nonzero_dim(in) : dims[i];
     if (in.size(dim) == 1) {
@@ -572,7 +572,7 @@ bool check_stack_args(
 void get_stack_out_target_size(
     exec_aten::ArrayRef<Tensor> tensors,
     int64_t dim,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim) {
   *out_ndim = tensors[0].dim() + 1;
 
@@ -821,7 +821,7 @@ bool get_view_copy_target_size(
     const Tensor input,
     exec_aten::ArrayRef<int64_t> size_int64_t,
     int64_t dim,
-    Tensor::SizesType* out_sizes) {
+    exec_aten::SizesType* out_sizes) {
   size_t out_numels_without_minus_1 = 1;
   int32_t minus_1_dim = -1;
 
@@ -829,7 +829,7 @@ bool get_view_copy_target_size(
 
   for (size_t i = 0; i < dim; ++i) {
     if (size_int64_t[i] != -1) {
-      out_sizes[i] = static_cast<Tensor::SizesType>(size_int64_t[i]);
+      out_sizes[i] = static_cast<exec_aten::SizesType>(size_int64_t[i]);
       out_numels_without_minus_1 = out_numels_without_minus_1 * size_int64_t[i];
     } else {
       // TODO(kimishpatel): Add test to hit this line

--- a/kernels/portable/cpu/util/copy_ops_util.h
+++ b/kernels/portable/cpu/util/copy_ops_util.h
@@ -28,7 +28,7 @@ bool check_cat_args(
 void get_cat_out_target_size(
     exec_aten::ArrayRef<Tensor> tensors,
     int64_t dim,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
 
 bool check_expand_copy_args(
@@ -50,7 +50,7 @@ bool check_unbind_copy_args(const Tensor& in, int64_t dim, TensorList out);
 void get_permute_copy_out_target_size(
     const Tensor& in,
     IntArrayRef dims,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
 
 bool check_pixel_shuffle_args(
@@ -61,7 +61,7 @@ bool check_pixel_shuffle_args(
 void get_pixel_shuffle_out_target_size(
     const Tensor& in,
     int64_t upscale_factor,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
 
 bool check_select_copy_out_args(
@@ -73,7 +73,7 @@ bool check_select_copy_out_args(
 void get_select_copy_out_target_size(
     const Tensor& in,
     int64_t dim,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
 
 bool check_slice_copy_args(
@@ -86,7 +86,7 @@ void get_slice_copy_out_target_size(
     const Tensor& in,
     int64_t dim,
     int64_t num_values,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
 
 bool check_split_with_sizes_copy_args(
@@ -99,7 +99,7 @@ void get_split_with_sizes_copy_out_target_size(
     const Tensor& in,
     int64_t split_size,
     int64_t dim,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
 
 bool check_squeeze_copy_dim_args(
@@ -110,7 +110,7 @@ bool check_squeeze_copy_dim_args(
 void get_squeeze_copy_dim_out_target_size(
     const Tensor in,
     int64_t dim,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
 
 bool check_squeeze_copy_dims_args(
@@ -121,7 +121,7 @@ bool check_squeeze_copy_dims_args(
 void get_squeeze_copy_dims_out_target_size(
     const Tensor in,
     const exec_aten::ArrayRef<int64_t> dims,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
 
 bool check_stack_args(
@@ -132,7 +132,7 @@ bool check_stack_args(
 void get_stack_out_target_size(
     exec_aten::ArrayRef<Tensor> tensors,
     int64_t dim,
-    Tensor::SizesType* out_sizes,
+    exec_aten::SizesType* out_sizes,
     size_t* out_ndim);
 
 bool check_tril_args(const Tensor& in, Tensor& out);
@@ -163,7 +163,7 @@ bool get_view_copy_target_size(
     const Tensor input,
     exec_aten::ArrayRef<int64_t> size_int64_t,
     int64_t dim,
-    Tensor::SizesType* out_sizes);
+    exec_aten::SizesType* out_sizes);
 
 } // namespace executor
 } // namespace torch


### PR DESCRIPTION
Summary:
There's no SizesType under at::Tensor, tensor::SizesType might cause issue under aten mode.
Update it to exec_aten::SizesType to fix the issue.

Differential Revision: D53821056


