### PR TITLE
Extend github-export-checks to include merge rule from ExecuTorch

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -1,0 +1,9 @@
+- name: superuser
+  patterns:
+  - '*'
+  approved_by:
+  - pytorch/metamates
+  mandatory_checks_name:
+  - Facebook CLA Check
+  - Lint
+  - pull


### PR DESCRIPTION
Summary: This adds a `merge_rules.yaml` file for ExecuTorch and extend github-export-checks to block diff when it fails

Differential Revision: D53838962


