### PR TITLE
Improve schema names and comments

### DIFF
--- a/backends/vulkan/serialization/schema/schema.fbs
+++ b/backends/vulkan/serialization/schema/schema.fbs
@@ -2,33 +2,12 @@
 
 namespace at.vulkan.delegate;
 
-// Update after any BC breaking changes
+// Update after any BC breaking changes.
 file_identifier "VK00";
 
-enum VkDatatype : short {
-  /// IEEE754 single-precision floating-point.
-  vk_datatype_fp32 = 0,
-}
-
-// Taken from executorch
-// Data buffer abstraction.
-table Buffer {
-  storage:[ubyte] (force_align: 16);
-}
-
-table VkTensor {
-  // type of the tensor elements.
-  datatype:VkDatatype;
-  // Array of shape dimensions
-  dims:[uint];
-  // Index to the program's constant buffer table, value 0 is reserved to indicate non constant
-  constant_buffer_idx:uint;
-  // Indicates which shared memory object this tensor uses; negative means the tensor does not share memory
-  mem_obj_id: int;
-}
-
-table VkValue {
-  value:VkTensor;
+enum VkDataType : short {
+  // IEEE754 single-precision floating-point.
+  fp32 = 0,
 }
 
 enum VkArithmeticOpType : short {
@@ -53,23 +32,46 @@ table VkNode {
   debug_handle:uint;
 }
 
+table VkTensor {
+  // Type of the tensor's elements.
+  datatype:VkDataType;
+  // Shape dimensions.
+  dims:[uint];
+  // Index to constant_buffer; index 0 is reserved for non-constant tensors.
+  constant_buffer_id:uint;
+  // Index to the shared memory object; negative means the tensor doesn't share memory.
+  mem_obj_id:int;
+}
+
+table VkValue {
+  value:VkTensor;
+}
+
+// Taken from ExecuTorch.
+// Data buffer abstraction.
+table Buffer {
+  storage:[ubyte] (force_align: 16);
+}
+
 table VkGraph {
   // Schema version.
   version:string;
-  vknodes:[VkNode];
-  vkvalues:[VkValue];
 
-  // Ids of external inputs
+  // All nodes used in this program.
+  nodes:[VkNode];
+
+  // All values used in this program.
+  values:[VkValue];
+
+  // All constant data used in this program (e.g. weight tensors). Constant data use VkTensor
+  // constant buffer indices. Index 0 is reserved for non-constant VkTensor.
+  constant_buffers:[Buffer];
+
+  // Index to values for external inputs.
   input_ids:[uint];
 
-  // Ids of external outputs
+  // Index to values for external outputs.
   output_ids:[uint];
-
-  // Tables of constant data, used for constant Values (e.g.
-  // data field of weight tensors). Each constant is assigned an index into the table
-  // which are each individually aligned. 0 index is reserved to be pointed to by non-constant
-  // Tensors
-  constant_buffer:[Buffer];
 }
 
 root_type VkGraph;

--- a/backends/vulkan/serialization/vulkan_graph_schema.py
+++ b/backends/vulkan/serialization/vulkan_graph_schema.py
@@ -15,31 +15,8 @@ from enum import IntEnum
 from typing import List
 
 
-class VkDatatype(IntEnum):
-    vk_datatype_fp32 = 0
-
-
-@dataclass
-class Buffer:
-    storage: bytes
-
-
-@dataclass
-class VkTensor:
-    datatype: VkDatatype
-    dims: List[int]
-    constant_buffer_idx: int
-    mem_obj_id: int
-
-
-@dataclass
-class VkScalar:
-    pass
-
-
-@dataclass
-class VkValue:
-    value: VkTensor
+class VkDataType(IntEnum):
+    fp32 = 0
 
 
 class VkArithmeticOpType(IntEnum):
@@ -67,12 +44,34 @@ class VkNode:
 
 
 @dataclass
+class VkTensor:
+    datatype: VkDataType
+    dims: List[int]
+    constant_buffer_id: int
+    mem_obj_id: int
+
+
+@dataclass
+class VkScalar:
+    pass
+
+
+@dataclass
+class VkValue:
+    value: VkTensor
+
+
+@dataclass
+class Buffer:
+    storage: bytes
+
+
+@dataclass
 class VkGraph:
     version: str
-    vknodes: List[VkNode]
-    vkvalues: List[VkValue]
+    nodes: List[VkNode]
+    values: List[VkValue]
+    constant_buffers: List[Buffer]
 
     input_ids: List[int]
     output_ids: List[int]
-
-    constant_buffer: List[Buffer]


### PR DESCRIPTION
Summary:
This change addresses a lot of nitpicks which improves readability (at least for me):
- Use of the "vk" vs "vk_" prefix in fields is inconsistent and redundant.
- Improve schema comments to adhere to one sentence style and limit line length.
- Use the suffix `_id` and `_ids` for an index and list of indices, respectively.
- Order `VkGraph` fields by non-index objects first, and then index objects.
- Improve understanding of python dict contents via name change: `node_vk_value_ids` -> `node_to_value_ids`.
- Order of tables matches their usage in `table VkGraph`.

Note we will remove `VkArithmeticOpType` soon, so we don't bother improving its readability.

Differential Revision: D53833736


