### PR TITLE
Clarify log when ignoring mlock error

### DIFF
--- a/extension/data_loader/mmap_data_loader.cpp
+++ b/extension/data_loader/mmap_data_loader.cpp
@@ -199,17 +199,27 @@ Result<FreeableBuffer> MmapDataLoader::Load(size_t offset, size_t size) {
       mlock_config_ == MlockConfig::UseMlockIgnoreErrors) {
     int err = ::mlock(pages, size);
     if (err < 0) {
-      ET_LOG(
-          Error,
-          "File %s: mlock(%p, %zu) failed: %s (%d)",
-          file_name_,
-          pages,
-          size,
-          ::strerror(errno),
-          errno);
       if (mlock_config_ == MlockConfig::UseMlockIgnoreErrors) {
-        ET_LOG(Info, "Ignoring mlock() error");
+        ET_LOG(
+            Info,
+            "Ignoring mlock error for file %s (off=0x%zd): "
+            "mlock(%p, %zu) failed: %s (%d)",
+            file_name_,
+            offset,
+            pages,
+            size,
+            ::strerror(errno),
+            errno);
       } else {
+        ET_LOG(
+            Error,
+            "File %s (off=0x%zd): mlock(%p, %zu) failed: %s (%d)",
+            file_name_,
+            offset,
+            pages,
+            size,
+            ::strerror(errno),
+            errno);
         ::munmap(pages, size);
         return Error::NotSupported;
       }


### PR DESCRIPTION
Summary:
It's been confusing to users when they see an Error-level log complaining about an `mlock()` failure even though it's being ignored. We do print a follow-up Info line after it, but some users may disable Info messages.

Instead, print the message at Info level when ignoring it, and make it clear that it is being ignored.

While I'm here, print the file offset of the region that we're trying to lock, to make it easier to figure out which segment is failing to lock.

Differential Revision: D53876334


