### PR TITLE
add __init__.py file for qualcomm passes

### DIFF
--- a/backends/qualcomm/passes/__init__.py
+++ b/backends/qualcomm/passes/__init__.py
@@ -1,0 +1,48 @@
+from executorch.backends.transforms.addmm_mm_to_linear import AddmmToLinearTransform
+from executorch.exir.passes import PassManager
+
+from .annotate_and_quant_scalar import AnnotateAndQuantScalar
+from .annotate_quant_attrs import AnnotateQuantAttrs
+from .convert_addmm_back_to_linear import ConvertAddmmmmWithLinear
+from .convert_hardsigmoid import ConvertHardsigmoid
+from .convert_hardswish import ConvertHardswish
+from .convert_interpolate_with_upsample2d import ConvertInterpolateWithUpsample2D
+from .fold_qdq import FoldQDQ
+from .i64_to_i32 import I64toI32
+from .insert_io_qdq import InsertIOQDQ
+from .layout_transform import LayoutTransform
+from .remove_clone import RemoveClone
+
+qnn_compiler_passes = PassManager(
+    passes=[
+        AddmmToLinearTransform(),
+        ConvertInterpolateWithUpsample2D(),
+        AddmmToLinearTransform(),
+        ConvertHardsigmoid(),
+        ConvertHardswish(),
+        ConvertInterpolateWithUpsample2D(),
+        RemoveClone(),
+    ]
+)
+
+qnn_compiler_passes = PassManager(
+    passes=[
+        AddmmToLinearTransform(),
+    ]
+)
+
+__all__ = [
+    qnn_compiler_passes,
+    AddmmToLinearTransform,
+    AnnotateAndQuantScalar,
+    AnnotateQuantAttrs,
+    ConvertHardsigmoid,
+    ConvertHardswish,
+    ConvertAddmmmmWithLinear,
+    ConvertInterpolateWithUpsample2D,
+    FoldQDQ,
+    I64toI32,
+    InsertIOQDQ,
+    LayoutTransform,
+    RemoveClone,
+]


### PR DESCRIPTION
Summary:
Fix the error
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/chenlai/qualcomm/meta-llama-mldemos-examples/executorch/examples/qualcomm/scripts/export_example.py", line 4, in <module>
    from executorch.backends.qualcomm.partition.qnn_partitioner import QnnPartitioner
  File "/home/chenlai/qualcomm/meta-llama-mldemos-examples/executorch/backends/qualcomm/partition/qnn_partitioner.py", line 12, in <module>
    from executorch.backends.qualcomm.qnn_preprocess import QnnBackend
  File "/home/chenlai/qualcomm/meta-llama-mldemos-examples/executorch/backends/qualcomm/qnn_preprocess.py", line 13, in <module>
    from executorch.backends.qualcomm.passes.convert_addmm_back_to_linear import (
  File "/home/chenlai/qualcomm/meta-llama-mldemos-examples/executorch/.executorch/lib/python3.10/site-packages/executorch/backends/qualcomm/passes/__init__.py", line 19, in <module>
    from .recompose_pixel_shuffle import RecomposePixelShuffle
ModuleNotFoundError: No module named 'executorch.backends.qualcomm.passes.recompose_pixel_shuffle'
```

Test by
```
pip install .
python3.10 -m examples.qualcomm.scripts.export_example -m "mul"
```

Differential Revision: D53894056


