### PR TITLE
Remove unused variables in executorch/examples/sdk/sdk_example_runner/sdk_example_runner.cpp

### DIFF
--- a/examples/sdk/sdk_example_runner/sdk_example_runner.cpp
+++ b/examples/sdk/sdk_example_runner/sdk_example_runner.cpp
@@ -228,8 +228,6 @@ int main(int argc, char** argv) {
     etdump_gen.set_event_tracer_debug_level(
         EventTracerDebugLogLevel::kProgramOutputs);
   }
-  // Prepare the inputs.
-  exec_aten::ArrayRef<void*> inputs;
   // Use the inputs embedded in the bundled program.
   status = torch::executor::bundled_program::LoadBundledInput(
       *method, file_data->data(), FLAGS_testset_idx);


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D53779562


