### PR TITLE
Optimize release build for binary size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if(EXECUTORCH_ENABLE_EVENT_TRACER)
   add_definitions(-DET_EVENT_TRACER_ENABLED)
 endif()
 
-# -O2: Moderate opt. -ffunction-sections -fdata-sections: breaks function and
+# -ffunction-sections -fdata-sections: breaks function and
 # data into sections so they can be properly gc'd. -s: strip symbol.
 # -fno-exceptions -fno-rtti: disables exceptions and runtime type.
 set(CMAKE_CXX_FLAGS_RELEASE
@@ -102,6 +102,16 @@ set(CMAKE_CXX_FLAGS_RELEASE
 if(NOT APPLE)
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
 endif()
+
+option(OPTIMIZE_SIZE "Build executorch runtime optimizing for binary size" OFF)
+if(OPTIMIZE_SIZE)
+  # -Os: Optimize for size
+  set(CMAKE_CXX_FLAGS_RELEASE "-Os ${CMAKE_CXX_FLAGS_RELEASE}")
+else()
+  # -O2: Moderate opt.
+  set(CMAKE_CXX_FLAGS_RELEASE "-O2 ${CMAKE_CXX_FLAGS_RELEASE}")
+endif()
+
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 
 # Option to register quantized ops with quantized kernels. See

--- a/docs/source/runtime-build-and-cross-compilation.md
+++ b/docs/source/runtime-build-and-cross-compilation.md
@@ -65,6 +65,21 @@ cd executorch
 
 Once this is done, you don't need to do it again until you pull from the upstream repo again, or if you modify any CMake-related files.
 
+### CMake Build Options
+
+The release build offers optimizations intended to improve performance and reduce binary size. It disables program verification and executorch logging, and adds optimizations flags.
+```bash
+-DCMAKE_BUILD_TYPE=Release
+```
+
+To further optimize the release build for size, use both:
+```bash
+-DCMAKE_BUILD_TYPE=Release \
+-DOPTIMIZE_SIZE=ON
+```
+
+See [CMakeLists.txt](https://github.com/pytorch/executorch/blob/main/CMakeLists.txt)
+
 ## Build the runtime components
 
 Build all targets with

--- a/test/build_size_test.sh
+++ b/test/build_size_test.sh
@@ -18,6 +18,7 @@ cmake_install_executorch_lib() {
   retry cmake -DBUCK2="$BUCK2" \
           -DCMAKE_INSTALL_PREFIX=cmake-out \
           -DCMAKE_BUILD_TYPE=Release \
+          -DOPTIMIZE_SIZE=ON \
           -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
           -Bcmake-out .
   cmake --build cmake-out -j9 --target install --config Release


### PR DESCRIPTION
Add option `OPTIMIZE_SIZE` to optimize the release build for binary size