### PR TITLE
Remove runtime_min and runtime_max arguments

### DIFF
--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -1135,8 +1135,6 @@ class GraphModuleDeserializer:
                             sym,
                             compiler_min=vr.lower,  # type: ignore[arg-type]
                             compiler_max=vr.upper,  # type: ignore[arg-type]
-                            runtime_min=vr.lower,  # type: ignore[arg-type]
-                            runtime_max=vr.upper,  # type: ignore[arg-type]
                         )
 
             if val.hint is None:


### PR DESCRIPTION
Summary: This function was originally authored in D52446586 by zhxchen17 and it is now broken because of a recent change to symbolic_shapes.py made in D53498537. I noticed it because Executorch SDK calls this function to deserialize etrecord and now that feature is broken.

Differential Revision: D53981108


