### PR TITLE
Support fp32 activation for quantizing llama2 to int8 activation and int4 weight

### DIFF
--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -46,6 +46,15 @@ class DType(Enum):
     fp32 = "fp32"
     fp16 = "fp16"
 
+    def to_torch_dtype(self) -> torch.dtype:
+        mapping = {
+            DType.fp32: torch.float32,
+            DType.fp16: torch.float16,
+        }
+        if self not in mapping:
+            raise ValueError(f"Unsupported dtype {self}")
+        return mapping[self]
+
 
 def load_llama_model(
     *,
@@ -141,13 +150,10 @@ class LlamaEdgeManager:
         assert not dtype_override or isinstance(
             dtype_override, DType
         ), "Override dtype needs to be of type <DType>"
-        if dtype_override == DType.fp16 and self.dtype != DType.fp16:
-            logging.info("model.to torch.float16")
-            self.model = self.model.to(dtype=torch.float16)
-            self.dtype = dtype_override
-        elif dtype_override == DType.fp32 and self.dtype != DType.fp32:
-            logging.info("model.to torch.float32")
-            self.model = self.model.to(dtype=torch.float32)
+        if dtype_override is not None and dtype_override != self.dtype:
+            torch_dtype = dtype_override.to_torch_dtype()
+            logging.info(f"model.to {torch_dtype}")
+            self.model = self.model.to(dtype=torch_dtype)
             self.dtype = dtype_override
         return self
 

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -11,7 +11,7 @@ import logging
 import shlex
 from functools import partial
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import pkg_resources
 import torch
@@ -94,7 +94,11 @@ def get_pt2e_quantizers(args) -> List[Quantizer]:
     return quantizers
 
 
-def quantize(model: torch.nn.Module, qmode: str) -> torch.nn.Module:
+def quantize(
+    model: torch.nn.Module,
+    qmode: str,
+    activation_dtype: Optional[DType],
+) -> torch.nn.Module:
     """
     Quantizes a model by converting all weights to int8.
     Args:
@@ -103,6 +107,11 @@ def quantize(model: torch.nn.Module, qmode: str) -> torch.nn.Module:
     Returns:
         A quantized model.
     """
+    if activation_dtype is not None:
+        torch_dtype = activation_dtype.to_torch_dtype()
+    else:
+        torch_dtype = torch.float16
+
     if qmode == "int8":
         model_int8 = WeightOnlyInt8QuantHandler(model)
         model_int8_state_dict = model_int8.create_quantized_state_dict()
@@ -110,7 +119,9 @@ def quantize(model: torch.nn.Module, qmode: str) -> torch.nn.Module:
         model_int8.load_state_dict(model_int8_state_dict)
         return model_int8
     elif qmode == "int4":
-        model_int4 = Int8DynActInt4WeightQuantHandler(model)
+        model_int4 = Int8DynActInt4WeightQuantHandler(
+            model, activation_precision=torch_dtype
+        )
         model_int4_state_dict = model_int4.create_quantized_state_dict()
         model_int4 = model_int4.convert_for_runtime()
         print("quantized model:", model_int4)
@@ -269,27 +280,28 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
     output_dir_path = canonical_path(args.output_dir, dir=True)
     modelname = "llama2"
     weight_type = WeightType.FAIRSEQ2 if args.fairseq2 else WeightType.LLAMA
+
+    # dtype override
+    if args.dtype_override is not None:
+        dtype_override = DType[args.dtype_override]
+    else:
+        dtype_override = DType["fp16"] if args.quantization_mode == "int4" else None
+
     # source transforms
     transforms = []
     if args.quantized_ckpt or args.quantization_mode:
         modelname = f"{modelname}_q"
-        transforms.append(partial(quantize, qmode=args.quantization_mode))
+        transforms.append(
+            partial(
+                quantize, qmode=args.quantization_mode, activation_dtype=dtype_override
+            )
+        )
 
     if args.embedding_quantize:
         modelname = f"{modelname}_e"
         transforms.append(
             lambda model: EmbeddingOnlyInt8QuantHandler(model).convert_for_runtime()
         )
-
-    # dtype override
-    if args.dtype_override:
-        override = (
-            DType["fp16"]
-            if args.quantization_mode == "int4"
-            else DType[args.dtype_override]
-        )
-    else:
-        override = None
 
     # export_to_edge
     quantizers = get_pt2e_quantizers(args)
@@ -323,7 +335,7 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
         .set_output_dir(output_dir_path)
         .set_metadata(args.metadata)
         .source_transform(transforms)
-        .to_dtype(override)
+        .to_dtype(dtype_override)
         .export_to_edge(quantizers)
         .to_backend(partitioners)
         .to_executorch()


### PR DESCRIPTION
Summary:
Previously we only supported quantizing fp16 activations to int8.
This adds support for quantizing fp32 activations as well to enable testing.

Representation:
https://www.internalfb.com/intern/everpaste/?handle=GAoWXBlf5O8T4TMBAP8Cps4UiVx7bsIXAAAz

Reviewed By: digantdesai

Differential Revision: D54032932


