### PR TITLE
Improve schema names and comments

### DIFF
--- a/backends/vulkan/serialization/schema.fbs
+++ b/backends/vulkan/serialization/schema.fbs
@@ -2,34 +2,8 @@
 
 namespace vkgraph;
 
-// Update after any BC breaking changes
+// Update after any BC breaking changes.
 file_identifier "VK00";
-
-enum VkDatatype : short {
-  /// IEEE754 single-precision floating-point.
-  vk_datatype_fp32 = 0,
-}
-
-// Abstraction to represent a region of bytes in a raw data buffer. Useful for referencing raw data serialized outside of the flatbuffer.
-table VkBytes {
-  offset: ulong;
-  length: ulong;
-}
-
-table VkTensor {
-  // type of the tensor elements.
-  datatype:VkDatatype;
-  // Array of shape dimensions
-  dims:[uint];
-  // Index to the program's constant buffer table, negative value indicates non constant
-  constant_buffer_idx:int;
-  // Indicates which shared memory object this tensor uses; negative value indicates the tensor does not share memory
-  mem_obj_id: int;
-}
-
-table VkValue {
-  value:VkTensor;
-}
 
 enum VkArithmeticOpType : short {
   vk_arithmetic_op_type_add = 0,
@@ -53,22 +27,46 @@ table VkNode {
   debug_handle:uint;
 }
 
+enum VkDataType : short {
+  // IEEE754 single-precision floating-point.
+  fp32 = 0,
+}
+
+table VkTensor {
+  // Type of the tensor elements.
+  datatype:VkDataType;
+  // Shape dimensions.
+  dims:[uint];
+  // Index to the program's constant data. Negative indicates tensor is non-constant.
+  constant_id:int;
+  // Index to the shared memory object. Negative indicates the tensor doesn't share memory.
+  mem_obj_id:int;
+}
+
+table VkValue {
+  value:VkTensor;
+}
+
+// Abstraction to represent a region of bytes in a raw data buffer. Useful for referencing raw data
+// serialized outside of the flatbuffer.
+table VkBytes {
+  offset:ulong;
+  length:ulong;
+}
+
 table VkGraph {
   // Schema version.
   version:string;
+
+  // Objects
   chain:[VkNode];
   values:[VkValue];
 
-  // Ids of external inputs
+  // Indices
   input_ids:[uint];
-
-  // Ids of external outputs
   output_ids:[uint];
 
-  // Tables of constant data, used for constant Values (e.g.
-  // data field of weight tensors). Each constant is assigned an index into the table
-  // which are each individually aligned. 0 index is reserved to be pointed to by non-constant
-  // Tensors
+  // Raw Objects (e.g. weight tensors and custom shaders)
   constants:[VkBytes];
   shaders:[VkBytes];
 }

--- a/backends/vulkan/serialization/vulkan_graph_schema.py
+++ b/backends/vulkan/serialization/vulkan_graph_schema.py
@@ -15,34 +15,6 @@ from enum import IntEnum
 from typing import List
 
 
-class VkDatatype(IntEnum):
-    vk_datatype_fp32 = 0
-
-
-@dataclass
-class VkBytes:
-    offset: int
-    length: int
-
-
-@dataclass
-class VkTensor:
-    datatype: VkDatatype
-    dims: List[int]
-    constant_buffer_idx: int
-    mem_obj_id: int
-
-
-@dataclass
-class VkScalar:
-    pass
-
-
-@dataclass
-class VkValue:
-    value: VkTensor
-
-
 class VkArithmeticOpType(IntEnum):
     vk_arithmetic_op_type_add = 0
     vk_arithmetic_op_type_sub = 1
@@ -67,9 +39,38 @@ class VkNode:
     debug_handle: int
 
 
+class VkDataType(IntEnum):
+    fp32 = 0
+
+
+@dataclass
+class VkTensor:
+    datatype: VkDataType
+    dims: List[int]
+    constant_id: int
+    mem_obj_id: int
+
+
+@dataclass
+class VkScalar:
+    pass
+
+
+@dataclass
+class VkValue:
+    value: VkTensor
+
+
+@dataclass
+class VkBytes:
+    offset: int
+    length: int
+
+
 @dataclass
 class VkGraph:
     version: str
+
     chain: List[VkNode]
     values: List[VkValue]
 


### PR DESCRIPTION
Summary:
This change addresses a lot of nitpicks which improves readability (at least for me):
- Improve schema comments to be sentences and limit line length.
- Use the suffix `_id` and `_ids` for an index and list of indices, respectively.
- Order of tables matches their usage in `table VkGraph`.
- Improve understanding of python dict contents via name change: `node_vk_value_ids` -> `node_to_value_ids`.

Note we will remove `VkArithmeticOpType` soon, so we don't bother improving its readability.

Reviewed By: SS-JIA

Differential Revision: D53982444


