### PR TITLE
Add support for constant arguments in delegate _get_new_signature

### DIFF
--- a/exir/backend/test/TARGETS
+++ b/exir/backend/test/TARGETS
@@ -195,6 +195,7 @@ python_unittest(
         "//executorch/exir:schema",
         "//executorch/exir/backend:backend_api",
         "//executorch/exir/backend:compile_spec_schema",
+        "//executorch/exir/backend/test:op_partitioner_demo",
         "//executorch/exir/tests:models",
         "//executorch/extension/pybindings:portable_lib",  # @manual
         "//executorch/kernels/portable:custom_ops_generated_lib",


### PR DESCRIPTION
Summary: Currently if a partitioned graph during delegation returns a constant it will fail when creating a new `ExportedProgram` in `create_exported_program_from_submodule`. This diff fixes that by generating `ConstantArgument` whenever a constant is present in the partitioned graph output.

Reviewed By: angelayi

Differential Revision: D53290986


