### PR TITLE
Do not define static target for `vulkan_backend_lib`

### DIFF
--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -57,6 +57,7 @@ def define_common_targets():
             "//caffe2:torch_vulkan_graph",
             "//executorch/runtime/backend:interface",
         ],
+        define_static_target = False,
         # VulkanBackend.cpp needs to compile with executor as whole
         # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
         link_whole = True,


### PR DESCRIPTION
Summary:
## Context

Fixes an internal CI breakage. The problem was the following:

* the `runtime.cxx_library()` wrapper has an arg `define_static_target` which is default `True`
* This will define a static version of the target with the name `vulkan_backend_lib_static`
* The static target dependencies with the `_static` suffix depending on [this logic](https://fburl.com/code/wz7kn4i4)
* Since `//caffe2:torch_vulkan_graph` is begins with `//caffe2`, it will be patched. However, there is no `"//caffe2:torch_vulkan_graph_static"` defined.

For now, disable defining a static target for `vulkan_backend_lib` to fix CI. Will need to think about the best/cleanest way to handle this - ideally there can be more fine-grained control over what dependencies should be patched.

Differential Revision: D54073762


