### PR TITLE
Address failing inf/nan gelu test

### DIFF
--- a/kernels/portable/cpu/op_gelu.cpp
+++ b/kernels/portable/cpu/op_gelu.cpp
@@ -38,6 +38,11 @@ Tensor& gelu_out(
     if (approximate == "tanh") {
       apply_unary_map_fn(
           [](const CTYPE x) {
+            if (x == -std::numeric_limits<CTYPE>::infinity()) {
+              return static_cast<CTYPE>(0.0);
+            } else if (x == std::numeric_limits<CTYPE>::infinity()) {
+              return std::numeric_limits<CTYPE>::infinity();
+            }
             const CTYPE kBeta = M_SQRT2 * M_2_SQRTPI * 0.5;
             const CTYPE kKappa = static_cast<float>(0.044715);
 
@@ -52,7 +57,14 @@ Tensor& gelu_out(
           in.numel());
     } else if (approximate == "none") {
       apply_unary_map_fn(
-          [](const CTYPE x) { return 0.5 * x * (1 + std::erf(x * M_SQRT1_2)); },
+          [](const CTYPE x) {
+            if (x == -std::numeric_limits<CTYPE>::infinity()) {
+              return static_cast<CTYPE>(0.0);
+            } else if (x == std::numeric_limits<CTYPE>::infinity()) {
+              return std::numeric_limits<CTYPE>::infinity();
+            }
+            return static_cast<CTYPE>(0.5 * x * (1 + std::erf(x * M_SQRT1_2)));
+          },
           in.const_data_ptr<CTYPE>(),
           out.mutable_data_ptr<CTYPE>(),
           in.numel());

--- a/kernels/portable/test/op_gelu_test.cpp
+++ b/kernels/portable/test/op_gelu_test.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/kernels/portable/NativeFunctions.h> // Declares the operator
+#include <executorch/kernels/test/TestUtil.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using exec_aten::ScalarType;
+using exec_aten::string_view;
+using exec_aten::Tensor;
+using torch::executor::testing::TensorFactory;
+
+// Note: This file is used for testing op_gelu for *portable kernel specific*.
+// If your test case is generic and should be tested on all kernels, add it to
+// executorch/kernels/test/op_gelu_test.cpp instead.
+
+Tensor& op_gelu_out(const Tensor& self, string_view approximate, Tensor& out) {
+  exec_aten::RuntimeContext context{};
+  return torch::executor::native::gelu_out(context, self, approximate, out);
+}
+
+TEST(OpGeluKernelTest, HandleInfAndNanInput) {
+  TensorFactory<ScalarType::Float> tf;
+
+  const std::vector<int32_t> sizes = {3, 2};
+
+  Tensor in = tf.make(
+      sizes,
+      /*data=*/
+      {-0.4775,
+       -std::numeric_limits<float>::infinity(),
+       -0.3984,
+       NAN,
+       std::numeric_limits<float>::infinity(),
+       -0.4848});
+
+  // Destination for the gelu.
+  Tensor out = tf.zeros(sizes);
+
+  // Run full gelu.
+  op_gelu_out(in, "none", out);
+
+  // Check that it matches the expected output.
+  EXPECT_TENSOR_CLOSE(
+      out,
+      tf.make(
+          sizes,
+          /*data=*/
+          {-0.15113, 0.0, -0.137515, NAN, INFINITY, -0.152183}));
+
+  // Run tanh gelu appx.
+  op_gelu_out(in, "tanh", out);
+
+  // Check that it matches the expected output.
+  EXPECT_TENSOR_CLOSE(
+      out,
+      tf.make(
+          sizes,
+          /*data=*/
+          {-0.151145, 0.0, -0.137522, NAN, INFINITY, -0.152199}));
+}

--- a/kernels/portable/test/targets.bzl
+++ b/kernels/portable/test/targets.bzl
@@ -10,4 +10,5 @@ def define_common_targets():
 
     op_test(name = "op_allclose_test", aten_compatible = False)
     op_test(name = "op_div_test")
+    op_test(name = "op_gelu_test")
     op_test(name = "op_mul_test")

--- a/kernels/test/op_gelu_test.cpp
+++ b/kernels/test/op_gelu_test.cpp
@@ -75,57 +75,6 @@ TEST(OpGeluKernelTest, DoubleTensors) {
   test_gelu_execution<ScalarType::Double>();
 }
 
-TEST(OpGeluKernelTest, InfAndNanPreserved) {
-  TensorFactory<ScalarType::Float> tf;
-
-  const std::vector<int32_t> sizes = {3, 2};
-
-  Tensor in = tf.make(
-      sizes,
-      /*data=*/
-      {-0.4775,
-       0.2948,
-       -0.3984,
-       NAN,
-       std::numeric_limits<float>::infinity(),
-       -0.4848});
-
-  // Destination for the gelu.
-  Tensor out = tf.zeros(sizes);
-
-  // Run full gelu.
-  op_gelu_out(in, "none", out);
-
-  // Check that it matches the expected output.
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf.make(
-          sizes,
-          /*data=*/
-          {-0.15113,
-           0.181575,
-           -0.137515,
-           NAN,
-           std::numeric_limits<float>::infinity(),
-           -0.152183}));
-
-  // Run tanh gelu appx.
-  op_gelu_out(in, "tanh", out);
-
-  // Check that it matches the expected output.
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf.make(
-          sizes,
-          /*data=*/
-          {-0.151145,
-           0.181573,
-           -0.137522,
-           NAN,
-           std::numeric_limits<float>::infinity(),
-           -0.152199}));
-}
-
 TEST(OpGeluKernelTest, UnhandledDtypeDies) {
   // gelu() doesn't handle Bool.
   TensorFactory<ScalarType::Bool> tf;


### PR DESCRIPTION
Summary:
ATen doesn't consistently handle the inf/-inf case. Hence, skipping test for ATen

Also discovered, while looking into this, that the portable kernel would return -nan when the input was -inf. However, gelu(-inf) should be 0.

Updated the portable kernel to ensure the proper handling of the infinities. Also updated the test, since the -inf case wasn't tested before.

Reviewed By: dbort

Differential Revision: D53960466


