### PR TITLE
Add seq_len to llama runner for early stopping

### DIFF
--- a/examples/models/llama2/main.cpp
+++ b/examples/models/llama2/main.cpp
@@ -24,6 +24,11 @@ DEFINE_double(
     0.8f,
     "Temperature; Default is 0.8f. 0 = greedy argmax sampling (deterministic). Lower temperature = more deterministic");
 
+DEFINE_int32(
+    seq_len,
+    128,
+    "Total number of tokens to generate (prompt + output). Defaults to max_seq_len. If the number of input tokens + seq_len > max_seq_len, the output will be truncated to max_seq_len tokens.");
+
 int32_t main(int32_t argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
@@ -38,11 +43,13 @@ int32_t main(int32_t argc, char** argv) {
 
   double temperature = FLAGS_temperature;
 
+  int32_t seq_len = FLAGS_seq_len;
+
   // create llama runner
   ::torch::executor::Runner runner(model_path, tokenizer_path, temperature);
 
   // generate
-  runner.generate(prompt);
+  runner.generate(prompt, seq_len);
 
   return 0;
 }

--- a/examples/models/llama2/runner/runner.h
+++ b/examples/models/llama2/runner/runner.h
@@ -34,6 +34,7 @@ class Runner {
   Error load();
   Error generate(
       const std::string& prompt,
+      int32_t seq_len = 128,
       std::function<void(const std::string&)> callback = {});
   void stop();
 
@@ -44,7 +45,7 @@ class Runner {
   template <typename T>
   int32_t
   logitsToToken(const exec_aten::Tensor& logits_tensor, int64_t pos, T _);
-  std::vector<exec_aten::SizesType> getKVCacheShape();
+  std::vector<exec_aten::SizesType> getKVCacheShape(int32_t seq_len);
   // metadata
   int32_t vocab_size_;
   int32_t bos_id_;


### PR DESCRIPTION
Summary: By default, the llama runner will continue generating until max_seq_len. This is a property embedded in the model metadata. We want a way to limit the number of tokens generated.

Reviewed By: larryliu0820

Differential Revision: D53873431


