### PR TITLE
[tosa] Support aten.mean.dim where dim = [-1, -2]

### DIFF
--- a/backends/arm/arm_partitioner.py
+++ b/backends/arm/arm_partitioner.py
@@ -44,11 +44,23 @@ class TOSASupportedOperators(OperatorSupportBase):
             exir_ops.edge.aten._softmax.default,
             exir_ops.edge.aten.view_copy.default,
             exir_ops.edge.aten.clone.default,
+            exir_ops.edge.aten.mean.dim,
             operator.getitem,
             exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
             exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
         ]
+
+        supported &= self.is_node_supported_custom(node)
+
         return supported
+
+    def is_node_supported_custom(self, node: torch.fx.Node) -> bool:
+        if node.target == exir_ops.edge.aten.mean.dim:
+            dim = node.args[1]
+            keep_dim = node.args[2]
+            if dim != [-1, -2] or keep_dim is False:
+                return False
+        return True
 
 
 @final

--- a/backends/arm/operators/__init__.py
+++ b/backends/arm/operators/__init__.py
@@ -15,6 +15,7 @@ from . import (  # noqa
     op_div,
     op_get_item,
     op_hardtanh,
+    op_mean_dim,
     op_permute,
     op_quant,
     op_softmax,

--- a/backends/arm/operators/op_avg_pool2d.py
+++ b/backends/arm/operators/op_avg_pool2d.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Arm Limited and/or its affiliates.
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -10,9 +10,8 @@ from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
 )
+from executorch.backends.arm.operators.op_common import build_avg_pool_2d_common
 from executorch.backends.arm.tosa_mapping import TosaArg
-from executorch.backends.arm.tosa_utils import transpose_helper
-from serializer.tosa_serializer import TosaOp
 
 
 @register_node_visitor
@@ -38,39 +37,13 @@ class AvgPool2dVisitor(NodeVisitor):
         except IndexError:
             pad_size_list = [0, 0, 0, 0]
 
-        attr = ts.TosaSerializerAttribute()
-        attr.PoolAttribute(
-            kernel=kernel_size_list,
-            stride=stride_size_list,
-            pad=pad_size_list,
-            input_zp=0,
-            output_zp=0,
-            accum_dtype=8,
-        )  # FP32 accum type
-
-        # Torch's input is [N,C,H,W], TOSA is [N, H, W, C],
-        # Transpose to align with TOSA
-        NHWC_Order = [0, 2, 3, 1]
-        input_transposed = transpose_helper(
-            tosa_graph, input_tensor, NHWC_Order, output.dtype
-        )
-
-        avg_pool2d_res_shape = [output.shape[i] for i in NHWC_Order]
-        avg_pool2d_res = tosa_graph.addIntermediate(avg_pool2d_res_shape, output.dtype)
-        tosa_graph.addOperator(
-            TosaOp.Op().AVG_POOL2D,
-            [input_transposed.name],
-            [avg_pool2d_res.name],
-            attr,
-        )
-
-        # TOSA is [N, H, W, C], Transpose back to Torch's [N, C, H, W]
-        NCHW_Order = [0, 3, 1, 2]
-        attr_output_transpose = ts.TosaSerializerAttribute()
-        attr_output_transpose.TransposeAttribute(NCHW_Order)
-        tosa_graph.addOperator(
-            TosaOp.Op().TRANSPOSE,
-            [avg_pool2d_res.name],
-            [output.name],
-            attr_output_transpose,
+        build_avg_pool_2d_common(
+            node,
+            tosa_graph,
+            input_tensor,
+            kernel_size_list,
+            stride_size_list,
+            pad_size_list,
+            is_quant_node,
+            output,
         )

--- a/backends/arm/operators/op_common.py
+++ b/backends/arm/operators/op_common.py
@@ -1,0 +1,78 @@
+# Copyright 2024 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import serializer.tosa_serializer as ts
+import torch
+from executorch.backends.arm.tosa_mapping import TosaArg
+from executorch.backends.arm.tosa_quant_utils import get_quant_node_args
+from executorch.backends.arm.tosa_utils import transpose_helper
+from serializer.tosa_serializer import TosaOp
+
+
+def build_avg_pool_2d_common(
+    node: torch.fx.Node,
+    tosa_graph: ts.TosaSerializer,
+    input_tensor: TosaArg,
+    kernel_size: list,
+    stride: list,
+    padding: list,
+    is_quant_node: bool,
+    output: TosaArg,
+):
+    accumulator_type = input_tensor.dtype
+    input_output_type = input_tensor.dtype
+
+    if is_quant_node:
+        # Accumulator type always is int32 when input tensor is an integer type.
+        accumulator_type = ts.DType.INT32
+        input_output_type = ts.DType.INT8
+
+    # Torch's input is [N,C,H,W], TOSA is [N, H, W, C],
+    # Transpose to align with TOSA
+    NHWC_Order = [0, 2, 3, 1]
+    input_transposed = transpose_helper(
+        tosa_graph,
+        input_tensor,
+        NHWC_Order,
+        input_output_type,
+    )
+
+    # Initilize zero point to zero.
+    input_zp = 0
+    output_zp = 0
+
+    if is_quant_node:
+        _, input_zp = get_quant_node_args(node.args[0])
+        _, output_zp = get_quant_node_args(list(node.users)[0])
+
+    attr = ts.TosaSerializerAttribute()
+    attr.PoolAttribute(
+        kernel=kernel_size,
+        stride=stride,
+        pad=padding,
+        input_zp=input_zp,
+        output_zp=output_zp,
+        accum_dtype=accumulator_type,
+    )
+
+    avg_pool2d_res_shape = [output.shape[i] for i in NHWC_Order]
+    avg_pool2d_res = tosa_graph.addIntermediate(avg_pool2d_res_shape, input_output_type)
+    tosa_graph.addOperator(
+        TosaOp.Op().AVG_POOL2D,
+        [input_transposed.name],
+        [avg_pool2d_res.name],
+        attr,
+    )
+
+    # TOSA is [N, H, W, C], Transpose back to Torch's [N, C, H, W]
+    NCHW_Order = [0, 3, 1, 2]
+    attr_output_transpose = ts.TosaSerializerAttribute()
+    attr_output_transpose.TransposeAttribute(NCHW_Order)
+    tosa_graph.addOperator(
+        TosaOp.Op().TRANSPOSE,
+        [avg_pool2d_res.name],
+        [output.name],
+        attr_output_transpose,
+    )

--- a/backends/arm/operators/op_mean_dim.py
+++ b/backends/arm/operators/op_mean_dim.py
@@ -1,0 +1,58 @@
+# Copyright 2024 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import List
+
+import serializer.tosa_serializer as ts
+import torch
+from executorch.backends.arm.operators.node_visitor import (
+    NodeVisitor,
+    register_node_visitor,
+)
+from executorch.backends.arm.operators.op_common import build_avg_pool_2d_common
+from executorch.backends.arm.tosa_mapping import TosaArg
+
+
+@register_node_visitor
+class MeanDimVisitor(NodeVisitor):
+    target = "aten.mean.dim"
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        tosa_graph: ts.TosaSerializer,
+        inputs: List[TosaArg],
+        output: TosaArg,
+        is_quant_node: bool,
+    ) -> None:
+
+        input_tensor = inputs[0]
+        dim = node.args[1]
+        keep_dim = node.args[2]
+
+        # mean.dim(-1, -2) is the same as avg_pool2d when just computing mean over HW dimensions.
+        # Since tosa doesn't have mean.dim operation, lowers it to average pooling instead.
+        if dim == [-1, -2]:
+            if keep_dim is True:
+                # Given the shape format of input is (N, C, H, W)
+                kernel_size = [input_tensor.shape[2], input_tensor.shape[3]]
+                stride = [1, 1]
+                padding = [0, 0, 0, 0]
+
+                build_avg_pool_2d_common(
+                    node,
+                    tosa_graph,
+                    input_tensor,
+                    kernel_size,
+                    stride,
+                    padding,
+                    is_quant_node,
+                    output,
+                )
+                return
+
+        raise AssertionError("unsupported")


### PR DESCRIPTION
When kernel_size == input_size occurs in adaptive_avg_pool2d, the op will be optimized to mean.dim as the operation actually performs HW dimensions reduction. Support this special case in Tosa.