### PR TITLE
Fix dtype check for builder.py

### DIFF
--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -75,7 +75,11 @@ def load_llama_model(
     )
     state_dict = model.state_dict()
     dtype = state_dict[next(iter(state_dict))].dtype
-    assert dtype in [torch.float16, torch.float32], "Only support fp16 or fp32"
+    assert dtype in [
+        torch.bfloat16,
+        torch.float16,
+        torch.float32,
+    ], f"Only support bfloat16, fp16 or fp32 got {dtype}"
     logging.info(f"Loaded model with dtype={dtype}")
 
     return LlamaEdgeManager(


### PR DESCRIPTION
Summary:
llama2 7b checkpoint is with bfloat16 hence this check doesnt work without including that.

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: larryliu0820

Differential Revision: D54122475


