### PR TITLE
Add note to setup-macos.sh about buck2 workaround

### DIFF
--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -29,9 +29,16 @@ install_buck() {
 
   pushd .ci/docker
 
+  # TODO(huydo): This is a one-off copy of buck2 2024-02-15 to unblock Jon and
+  # re-enable ShipIt. It’s not ideal that upgrading buck2 will require a manual
+  # update the cached binary on S3 bucket too. Let me figure out if there is a
+  # way to correctly implement the previous setup of installing a new version of
+  # buck2 only when it’s needed. AFAIK, the complicated part was that buck2
+  # --version doesn't say anything w.r.t its release version, i.e. 2024-02-15.
+  # See D53878006 for more details.
   BUCK2=buck2-aarch64-apple-darwin.zst
-
   wget -q "https://ossci-macos.s3.amazonaws.com/${BUCK2}"
+
   zstd -d "${BUCK2}" -o buck2
 
   chmod +x buck2


### PR DESCRIPTION
Summary:
D53878006 changed the logic for getting buck2 to unblock some shipit work, but it required manually copying the buck2 binary archive.

Add a comment to explain what's going on.

Differential Revision: D54131494


