### PR TITLE
Publicly link libtorch.so into pybind portable_lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,6 +431,7 @@ if(EXECUTORCH_BUILD_PYBIND)
       flatcc
       portable_ops_lib
       util
+      torch
       ${PYBIND_LINK_COREML}
       ${PYBIND_LINK_MPS}
       ${PYBIND_LINK_XNNPACK}


### PR DESCRIPTION
Summary:
Building from source on Google Colab reveals this issue that:

```
from executorch.extension.pybindings import portable_lib
```

Result in undefined symbols in libtorch.so.

Marking the dependency as PUBLIC fixes this issue.

Differential Revision: D54128075


