### PR TITLE
Move graph runtime from PT directory to ET directory

### DIFF
--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <ATen/native/vulkan/graph/Graph.h>
-#include <ATen/native/vulkan/graph/OperatorRegistry.h>
+#include <executorch/backends/vulkan/runtime/graph/Graph.h>
+#include <executorch/backends/vulkan/runtime/graph/OperatorRegistry.h>
 
 #include <executorch/backends/vulkan/runtime/VulkanDelegateHeader.h>
 #include <executorch/backends/vulkan/schema_generated.h>

--- a/backends/vulkan/runtime/graph/Config.h
+++ b/backends/vulkan/runtime/graph/Config.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/api/Context.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+struct GraphConfig final {
+  api::ContextConfig contextConfig;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/graph/Constant.cpp
+++ b/backends/vulkan/runtime/graph/Constant.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/Constant.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+TensorRef::TensorRef(
+    const std::vector<int64_t>& t_sizes,
+    api::ScalarType t_dtype,
+    const void* const t_data)
+    : sizes{}, dtype{t_dtype}, data{t_data} {
+  size_t ndim = t_sizes.size();
+  sizes.resize(ndim);
+  for (int i = 0; i < ndim; ++i) {
+    sizes[i] = t_sizes.at(i);
+  }
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/graph/Constant.h
+++ b/backends/vulkan/runtime/graph/Constant.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/api/Context.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+/*
+ * Represents a reference to a tensor that has been serialized with the model,
+ * such as a serialized weight tensor. It contains some metadata as well as a
+ * raw pointer to the data of the tensor, which is assumed to be contiguous.
+ */
+struct TensorRef final {
+  std::vector<int64_t> sizes;
+  api::ScalarType dtype;
+  const void* data;
+
+  explicit TensorRef(
+      const std::vector<int64_t>& t_sizes,
+      api::ScalarType t_dtype,
+      const void* const t_data);
+
+  TensorRef(const TensorRef&) = default;
+  TensorRef& operator=(const TensorRef&) = default;
+
+  TensorRef(TensorRef&&) = default;
+  TensorRef& operator=(TensorRef&&) = default;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/graph/Functions.cpp
+++ b/backends/vulkan/runtime/graph/Functions.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/native/vulkan/impl/Arithmetic.h>
+#include <ATen/native/vulkan/impl/Common.h>
+
+#include <executorch/backends/vulkan/runtime/graph/Functions.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/Arithmetic.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+#define DEFINE_ARITHMETIC_FN(function, op_type)                               \
+  ValueRef function(ComputeGraph& graph, const std::vector<ValueRef>& args) { \
+    return add_arithmetic_node(                                               \
+        graph,                                                                \
+        args[0],                                                              \
+        args[1],                                                              \
+        args[2],                                                              \
+        arithmetic::OpType::op_type,                                          \
+        args[3]);                                                             \
+  }
+
+DEFINE_ARITHMETIC_FN(add, ADD);
+DEFINE_ARITHMETIC_FN(sub, SUB);
+DEFINE_ARITHMETIC_FN(mul, MUL);
+DEFINE_ARITHMETIC_FN(div, DIV);
+DEFINE_ARITHMETIC_FN(floor_div, FLOOR_DIV);
+DEFINE_ARITHMETIC_FN(pow, POW);
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/graph/Functions.h
+++ b/backends/vulkan/runtime/graph/Functions.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/graph/Graph.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+#define DEFINE_OP_FN(name) \
+  ValueRef name(ComputeGraph& graph, const std::vector<ValueRef>& args);
+
+DEFINE_OP_FN(add);
+DEFINE_OP_FN(sub);
+DEFINE_OP_FN(mul);
+DEFINE_OP_FN(div);
+DEFINE_OP_FN(floor_div);
+DEFINE_OP_FN(pow);
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/graph/Graph.cpp
+++ b/backends/vulkan/runtime/graph/Graph.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/Graph.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/Staging.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+//
+// SharedObject
+//
+
+void SharedObject::add_user(ComputeGraph* const graph, const ValueRef idx) {
+  vTensor& t = graph->get_val(idx).toTensor();
+
+  //
+  // Aggregate Memory Requirements
+  //
+
+  const VkMemoryRequirements mem_reqs = t.get_memory_requirements();
+  aggregate_memory_requirements.size =
+      std::max(mem_reqs.size, aggregate_memory_requirements.size);
+  aggregate_memory_requirements.alignment =
+      std::max(mem_reqs.alignment, aggregate_memory_requirements.alignment);
+  aggregate_memory_requirements.memoryTypeBits |= mem_reqs.memoryTypeBits;
+
+  //
+  // Aggregate Allocation Create Info
+  //
+
+  const VmaAllocationCreateInfo create_info = t.get_allocation_create_info();
+  // Clear out CREATE_STRATEGY bit flags in case of conflict
+  VmaAllocationCreateFlags clear_mask = ~VMA_ALLOCATION_CREATE_STRATEGY_MASK;
+  VmaAllocationCreateFlags create_flags = create_info.flags & clear_mask;
+  // Use the default allocation strategy
+  aggregate_create_info.flags = create_flags | api::DEFAULT_ALLOCATION_STRATEGY;
+
+  // Set the usage flag if it is currently not set
+  if (aggregate_create_info.usage == VMA_MEMORY_USAGE_UNKNOWN) {
+    aggregate_create_info.usage = create_info.usage;
+  }
+  // Otherwise check that there is no conflict regarding usage
+  VK_CHECK_COND(aggregate_create_info.usage == create_info.usage);
+  aggregate_create_info.requiredFlags |= create_info.requiredFlags;
+  aggregate_create_info.preferredFlags |= create_info.preferredFlags;
+
+  users.emplace_back(idx);
+}
+
+void SharedObject::allocate(ComputeGraph* const graph) {
+  if (aggregate_memory_requirements.size == 0) {
+    return;
+  }
+  allocation = graph->context()->adapter_ptr()->vma().create_allocation(
+      aggregate_memory_requirements, aggregate_create_info);
+}
+
+void SharedObject::bind_users(ComputeGraph* const graph) {
+  if (users.empty()) {
+    return;
+  }
+  for (const ValueRef idx : users) {
+    graph->get_val(idx).toTensor().bind_allocation(allocation);
+  }
+}
+
+//
+// ComputeGraph
+//
+
+ComputeGraph::ComputeGraph(GraphConfig config)
+    : config_{config},
+      context_{new api::Context(
+          api::runtime()->default_adapter_i(),
+          config_.contextConfig)},
+      shared_objects_{},
+      values_{},
+      prepack_nodes_{},
+      execute_nodes_{},
+      inputs_{},
+      outputs_{} {
+  context_->set_cmd(/*reusable = */ true);
+}
+
+ComputeGraph::~ComputeGraph() {
+  values_.clear();
+
+  prepack_nodes_.clear();
+  execute_nodes_.clear();
+
+  context_->flush();
+}
+
+ValueRef ComputeGraph::add_tensor(
+    const std::vector<int64_t>& sizes,
+    const api::ScalarType dtype,
+    const int64_t shared_object_idx) {
+  bool allocate_memory = shared_object_idx < 0;
+
+  ValueRef idx(static_cast<int>(values_.size()));
+  values_.emplace_back(vTensor(
+      context(),
+      sizes,
+      dtype,
+      api::StorageType::TEXTURE_3D,
+      api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED,
+      allocate_memory));
+
+  if (!allocate_memory) {
+    get_shared_object(shared_object_idx).add_user(this, idx);
+  }
+  return idx;
+}
+
+ValueRef ComputeGraph::add_tensorref(
+    const std::vector<int64_t>& sizes,
+    const api::ScalarType dtype,
+    const void* const data) {
+  ValueRef idx(static_cast<int>(values_.size()));
+  values_.emplace_back(TensorRef(sizes, dtype, data));
+  return idx;
+}
+
+ValueRef ComputeGraph::add_staging(
+    const api::ScalarType dtype,
+    const size_t numel) {
+  ValueRef idx(static_cast<int>(values_.size()));
+  values_.emplace_back(api::StorageBuffer(context(), dtype, numel));
+  return idx;
+}
+
+ValueRef ComputeGraph::set_input_tensor(
+    const ValueRef idx,
+    const bool use_staging) {
+  if (use_staging) {
+    vTensor& tensor = get_val(idx).toTensor();
+    ValueRef staging_idx = add_staging(tensor.dtype(), tensor.gpu_numel());
+    execute_nodes_.emplace_back(new StagingNode(staging_idx, idx));
+    inputs_.push_back(staging_idx);
+    return staging_idx;
+  }
+  inputs_.push_back(idx);
+  return idx;
+}
+
+ValueRef ComputeGraph::set_output_tensor(
+    const ValueRef idx,
+    const bool use_staging) {
+  if (use_staging) {
+    vTensor& tensor = get_val(idx).toTensor();
+    ValueRef staging_idx = add_staging(tensor.dtype(), tensor.gpu_numel());
+    execute_nodes_.emplace_back(new StagingNode(idx, staging_idx));
+    outputs_.push_back(staging_idx);
+    return staging_idx;
+  }
+  outputs_.push_back(idx);
+  return idx;
+}
+
+SharedObject& ComputeGraph::get_shared_object(const int64_t idx) {
+  if (idx >= shared_objects_.size()) {
+    shared_objects_.resize(static_cast<size_t>(idx + 1));
+  }
+  return shared_objects_.at(idx);
+}
+
+void ComputeGraph::copy_into_staging(
+    const ValueRef idx,
+    const void* data,
+    const size_t numel) {
+  Value& in_val = get_val(idx);
+  api::StorageBuffer& staging = in_val.toStaging();
+  size_t nbytes = numel * api::element_size(staging.dtype());
+  copy_ptr_to_staging(data, staging, nbytes);
+}
+
+void ComputeGraph::copy_from_staging(
+    const ValueRef idx,
+    void* data,
+    const size_t numel) {
+  Value& out_val = get_val(idx);
+  api::StorageBuffer& staging = out_val.toStaging();
+  size_t nbytes = numel * api::element_size(staging.dtype());
+  copy_staging_to_ptr(staging, data, nbytes);
+}
+
+void ComputeGraph::encode_prepack() {
+  for (std::unique_ptr<OpNode>& node : prepack_nodes_) {
+    node->encode_prepack(this);
+  }
+}
+
+void ComputeGraph::prepack() const {
+  // Submit and execute the command buffer
+  api::VulkanFence fence = context_->fences().get_fence();
+  context_->submit_cmd_to_gpu(fence.get_submit_handle(), /*final_use = */ true);
+  fence.wait();
+
+  context_->flush();
+}
+
+void ComputeGraph::encode_execute() {
+  context_->flush();
+  context_->set_cmd(/*reusable = */ true);
+
+  for (SharedObject& shared_object : shared_objects_) {
+    shared_object.allocate(this);
+    shared_object.bind_users(this);
+  }
+
+  for (std::unique_ptr<OpNode>& node : execute_nodes_) {
+    node->encode_execute(this);
+  }
+}
+
+void ComputeGraph::execute() const {
+  api::VulkanFence fence = context_->fences().get_fence();
+  context_->submit_cmd_to_gpu(fence.get_submit_handle());
+  fence.wait();
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/graph/Graph.h
+++ b/backends/vulkan/runtime/graph/Graph.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/api/Context.h>
+#include <ATen/native/vulkan/api/Tensor.h>
+#include <ATen/native/vulkan/api/Types.h>
+
+#include <executorch/backends/vulkan/runtime/graph/Config.h>
+#include <executorch/backends/vulkan/runtime/graph/Value.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+using ValueRef = int32_t;
+
+struct IOValueRef {
+  ValueRef value;
+  ValueRef staging;
+};
+
+class ComputeGraph;
+
+/*
+ * Represents a single op in a ML model. In graph mode, ops will be implemented
+ * introducing a derived class that implements encode_execute, which will
+ * implement encoding of the shader corresponding to the op into the command
+ * buffer of a ComputeGraph, as well as encode_prepack, which will implement
+ * encoding of shaders transferring necessary data (such as weights and biases)
+ * to the GPU, wherever prepacking is necessary.
+ */
+class OpNode {
+  friend class ComputeGraph;
+
+ public:
+  OpNode(ValueRef input, ValueRef output) : inputs_{input}, outputs_{output} {}
+  OpNode(
+      const std::vector<ValueRef>& inputs,
+      const std::vector<ValueRef>& outputs)
+      : inputs_(inputs), outputs_(outputs) {}
+
+  virtual ~OpNode() = default;
+
+ protected:
+  std::vector<ValueRef> inputs_;
+  std::vector<ValueRef> outputs_;
+
+ public:
+  virtual void encode_prepack(ComputeGraph* graph) const {}
+  virtual void encode_execute(ComputeGraph* graph) const {}
+};
+
+struct SharedObject {
+  friend class ComputeGraph;
+
+  explicit SharedObject() = default;
+
+  VkMemoryRequirements aggregate_memory_requirements;
+  VmaAllocationCreateInfo aggregate_create_info;
+  std::vector<ValueRef> users;
+  api::MemoryAllocation allocation;
+
+  void add_user(ComputeGraph* const graph, const ValueRef idx);
+  void allocate(ComputeGraph* const graph);
+  void bind_users(ComputeGraph* const graph);
+};
+
+/*
+ * This is the core data structure used to execute Vulkan models in graph mode.
+ * As opposed to ATen/eager mode where a command buffer is encoded every
+ * inference (since ops are executed with the model), in graph mode the ops that
+ * compose the model are intended to be parsed only once, upon which a command
+ * buffer will be encoded. Model inference will then execute the cached command
+ * buffer without needing to encode a new one.
+ */
+class ComputeGraph final {
+ public:
+  explicit ComputeGraph(GraphConfig config);
+
+  ComputeGraph(ComputeGraph&&) = default;
+  ComputeGraph& operator=(ComputeGraph&&) = default;
+
+  ~ComputeGraph();
+
+ private:
+  GraphConfig config_;
+  std::unique_ptr<api::Context> context_;
+  std::vector<SharedObject> shared_objects_;
+  std::vector<Value> values_;
+
+  std::vector<std::unique_ptr<OpNode>> prepack_nodes_;
+  std::vector<std::unique_ptr<OpNode>> execute_nodes_;
+
+  std::vector<ValueRef> inputs_;
+  std::vector<ValueRef> outputs_;
+
+ public:
+  //
+  // Accessors
+  //
+
+  inline api::Context* context() {
+    return context_.get();
+  }
+
+  inline std::vector<ValueRef>& inputs() {
+    return inputs_;
+  }
+
+  inline std::vector<ValueRef>& outputs() {
+    return outputs_;
+  }
+
+  /*
+   * Returns the value at a particular reference
+   */
+  inline Value& get_val(ValueRef idx) {
+    return values_[idx];
+  }
+
+  inline const std::vector<int64_t>& get_val_sizes(ValueRef idx) {
+    Value& val = get_val(idx);
+    if (val.isTensor()) {
+      return val.toTensor().sizes();
+    } else if (val.isTensorRef()) {
+      return val.toTensorRef().sizes;
+    }
+    VK_THROW("Could not get sizes of value with type ", val.type());
+  }
+
+  inline api::ScalarType get_val_dtype(ValueRef idx) {
+    Value& val = get_val(idx);
+    if (val.isTensor()) {
+      return val.toTensor().dtype();
+    } else if (val.isTensorRef()) {
+      return val.toTensorRef().dtype;
+    }
+    VK_THROW("Could not get dtype of value with type ", val.type());
+  }
+
+  inline std::vector<std::unique_ptr<OpNode>>& prepack_nodes() {
+    return prepack_nodes_;
+  }
+
+  inline std::vector<std::unique_ptr<OpNode>>& execute_nodes() {
+    return execute_nodes_;
+  }
+
+  //
+  // Graph Building
+  //
+
+  ValueRef add_tensor(
+      const std::vector<int64_t>& sizes,
+      const api::ScalarType dtype = api::ScalarType::Float,
+      const int64_t shared_object_idx = -1);
+  ValueRef add_tensorref(
+      const std::vector<int64_t>& sizes,
+      const api::ScalarType dtype,
+      const void* const data);
+  ValueRef add_staging(const api::ScalarType dtype, const size_t numel);
+
+  ValueRef set_input_tensor(const ValueRef idx, const bool use_staging = true);
+  ValueRef set_output_tensor(const ValueRef idx, const bool use_staging = true);
+
+  /*
+   * Convenience function to add an input tensor along with its staging buffer
+   */
+  inline IOValueRef add_input_tensor(
+      const std::vector<int64_t>& sizes,
+      const api::ScalarType dtype,
+      const int64_t shared_object_idx = -1) {
+    ValueRef t = add_tensor(sizes, dtype, shared_object_idx);
+    ValueRef staging = set_input_tensor(t);
+    return {t, staging};
+  }
+
+  SharedObject& get_shared_object(const int64_t idx);
+
+  //
+  // Input/Output
+  //
+
+  void
+  copy_into_staging(const ValueRef idx, const void* data, const size_t numel);
+  void copy_from_staging(const ValueRef idx, void* data, const size_t numel);
+
+  //
+  // Graph Prepacking
+  //
+
+  void encode_prepack();
+  void prepack() const;
+
+  //
+  // Graph Execution
+  //
+
+  void encode_execute();
+  void execute() const;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/graph/OperatorRegistry.cpp
+++ b/backends/vulkan/runtime/graph/OperatorRegistry.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/Functions.h>
+#include <executorch/backends/vulkan/runtime/graph/OperatorRegistry.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+bool hasOpsFn(const std::string& name) {
+  return OperatorRegistry::getInstance().hasOpsFn(name);
+}
+
+OpFunction& getOpsFn(const std::string& name) {
+  return OperatorRegistry::getInstance().getOpsFn(name);
+}
+
+OperatorRegistry& OperatorRegistry::getInstance() {
+  static OperatorRegistry instance;
+  return instance;
+}
+
+bool OperatorRegistry::hasOpsFn(const std::string& name) {
+  return OperatorRegistry::kTable.count(name) > 0;
+}
+
+OpFunction& OperatorRegistry::getOpsFn(const std::string& name) {
+  return OperatorRegistry::kTable.find(name)->second;
+}
+
+// @lint-ignore-every CLANGTIDY modernize-avoid-bind
+// clang-format off
+#define OPERATOR_ENTRY(name, function) \
+  { #name, std::bind(&at::native::vulkan::function, std::placeholders::_1, std::placeholders::_2) }
+// clang-format on
+
+const OperatorRegistry::OpTable OperatorRegistry::kTable = {
+    OPERATOR_ENTRY(aten.add.Tensor, add),
+    OPERATOR_ENTRY(aten.sub.Tensor, sub),
+    OPERATOR_ENTRY(aten.mul.Tensor, mul),
+    OPERATOR_ENTRY(aten.div.Tensor, div),
+    OPERATOR_ENTRY(aten.div.Tensor_mode, floor_div),
+    OPERATOR_ENTRY(aten.pow.Tensor_Tensor, pow),
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/graph/OperatorRegistry.h
+++ b/backends/vulkan/runtime/graph/OperatorRegistry.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/graph/Graph.h>
+
+#include <functional>
+#include <unordered_map>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+using OpFunction = const std::function<at::native::vulkan::ValueRef(
+    at::native::vulkan::ComputeGraph&,
+    const std::vector<at::native::vulkan::ValueRef>&)>; // TODO: Generalize to
+                                                        // support float,
+                                                        // int64_t.
+
+bool hasOpsFn(const std::string& name);
+
+OpFunction& getOpsFn(const std::string& name);
+
+// The Vulkan operator registry is a simplified version of
+// fbcode/executorch/runtime/kernel/operator_registry.h
+// that uses the C++ Standard Library.
+class OperatorRegistry {
+ public:
+  static OperatorRegistry& getInstance();
+
+  bool hasOpsFn(const std::string& name);
+  OpFunction& getOpsFn(const std::string& name);
+
+  OperatorRegistry(const OperatorRegistry&) = delete;
+  OperatorRegistry(OperatorRegistry&&) = delete;
+  OperatorRegistry& operator=(const OperatorRegistry&) = delete;
+  OperatorRegistry& operator=(OperatorRegistry&&) = delete;
+
+ private:
+  // TODO: Input string corresponds to target_name. We may need to pass kwargs.
+  using OpTable = std::unordered_map<std::string, OpFunction>;
+  // @lint-ignore CLANGTIDY facebook-hte-NonPodStaticDeclaration
+  static const OpTable kTable;
+
+  OperatorRegistry() = default;
+  ~OperatorRegistry() = default;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/graph/Types.cpp
+++ b/backends/vulkan/runtime/graph/Types.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/Types.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+std::ostream& operator<<(std::ostream& out, const TypeTag& tag) {
+  switch (tag) {
+    case TypeTag::NONE:
+      out << "NONE";
+      break;
+    case TypeTag::TENSOR:
+      out << "TENSOR";
+      break;
+    case TypeTag::STAGING:
+      out << "STAGING";
+      break;
+    default:
+      out << "UNKNOWN";
+      break;
+  }
+  return out;
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/graph/Types.h
+++ b/backends/vulkan/runtime/graph/Types.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ostream>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+/*
+ * This class is modelled after c10::IValue; however, it is simplified and does
+ * not support as many types. However, the core design is the same; it is a
+ * tagged union over the types supported by the Vulkan Graph type.
+ */
+enum class TypeTag : uint32_t {
+  NONE,
+  TENSOR,
+  STAGING,
+  TENSORREF,
+  INT,
+  DOUBLE,
+  BOOL,
+};
+
+std::ostream& operator<<(std::ostream& out, const TypeTag& tag);
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/graph/Value.h
+++ b/backends/vulkan/runtime/graph/Value.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/api/Context.h>
+#include <ATen/native/vulkan/api/Tensor.h>
+
+#include <executorch/backends/vulkan/runtime/graph/Constant.h>
+#include <executorch/backends/vulkan/runtime/graph/Types.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+/*
+ * This class is modelled after c10::IValue; however, it is simplified and does
+ * not support as many types. However, the core design is the same; it is a
+ * tagged union over the types supported by the Vulkan Graph type.
+ */
+struct Value final {
+ private:
+  /*
+   * The union type which is used to store the value of the Value.
+   */
+  union Payload {
+    /*
+     * Similar to IValue::Payload, trivially copyable types are nested in their
+     * own union.
+     */
+    union TriviallyCopyablePayload {
+      TriviallyCopyablePayload() : as_int(0) {}
+      int64_t as_int;
+      double as_double;
+      bool as_bool;
+    } u;
+
+    vTensor as_tensor;
+    api::StorageBuffer as_staging;
+    TensorRef as_tensorref;
+
+    Payload() : u() {}
+    // NOLINTNEXTLINE
+    ~Payload(){};
+  };
+
+ public:
+  //
+  // Copy constructor and assignment (disabled)
+  //
+
+  Value(const Value& rhs) = delete;
+  Value& operator=(const Value&) = delete;
+
+  //
+  // Move constructor and assignment; Move assignment is disabled but
+  // construction is implemented to allow for use in container types.
+  //
+
+  Value& operator=(Value&&) = delete;
+
+  Value(Value&& rhs) noexcept : tag(rhs.tag) {
+    if (rhs.isTensor()) {
+      new (&payload.as_tensor) vTensor(std::move(rhs.payload.as_tensor));
+    } else if (rhs.isStaging()) {
+      new (&payload.as_staging)
+          api::StorageBuffer(std::move(rhs.payload.as_staging));
+    } else if (rhs.isTensorRef()) {
+      payload.as_tensorref = std::move(rhs.payload.as_tensorref);
+    } else {
+      payload.u = rhs.payload.u;
+    }
+    tag = rhs.tag;
+    rhs.clearToNone();
+  }
+
+  //
+  // Accessors
+  //
+
+  inline TypeTag type() const {
+    return tag;
+  }
+
+  //
+  // Destructor
+  //
+
+  ~Value() {
+    if (this->isTensor()) {
+      payload.as_tensor.~vTensor();
+    } else if (this->isStaging()) {
+      payload.as_staging.~StorageBuffer();
+    } else if (this->isTensorRef()) {
+      payload.as_tensorref.~TensorRef();
+    }
+  }
+
+  //
+  // Tensor
+  //
+
+  explicit Value(vTensor&& t) : tag(TypeTag::TENSOR) {
+    new (&payload.as_tensor) vTensor(std::move(t));
+  }
+
+  inline bool isTensor() const {
+    return TypeTag::TENSOR == tag;
+  }
+
+  inline vTensor& toTensor() {
+    VK_CHECK_COND(
+        isTensor(),
+        "Expected value to have type TENSOR, got ",
+        tag,
+        " instead.");
+    return payload.as_tensor;
+  }
+
+  //
+  // Staging
+  //
+
+  explicit Value(api::StorageBuffer&& t) : tag(TypeTag::STAGING) {
+    new (&payload.as_staging) api::StorageBuffer(std::move(t));
+  }
+
+  inline bool isStaging() const {
+    return TypeTag::STAGING == tag;
+  }
+
+  inline api::StorageBuffer& toStaging() {
+    VK_CHECK_COND(
+        isStaging(),
+        "Expected value to have type STAGING, got ",
+        tag,
+        " instead.");
+    return payload.as_staging;
+  }
+
+  //
+  // TensorRef
+  //
+
+  explicit Value(TensorRef&& t) : tag(TypeTag::TENSORREF) {
+    payload.as_tensorref = std::move(t);
+  }
+
+  inline bool isTensorRef() const {
+    return TypeTag::TENSORREF == tag;
+  }
+
+  inline TensorRef& toTensorRef() {
+    VK_CHECK_COND(
+        isTensorRef(),
+        "Expected value to have type TENSORREF, got ",
+        tag,
+        " instead.");
+    return payload.as_tensorref;
+  }
+
+ private:
+  Payload payload;
+  TypeTag tag;
+
+  //
+  // Utility Functions
+  //
+
+  inline void clearToNone() noexcept {
+    payload.u.as_int = 0;
+    tag = TypeTag::NONE;
+  }
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/graph/ops/Arithmetic.cpp
+++ b/backends/vulkan/runtime/graph/ops/Arithmetic.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/native/vulkan/impl/Common.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/Arithmetic.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/Staging.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+void add_arithmetic_node(
+    ComputeGraph& graph,
+    const ValueRef t1,
+    const ValueRef t2,
+    const ValueRef out,
+    const float alpha,
+    const arithmetic::OpType optype) {
+  // Prepacking first arg (if needed)
+  ValueRef arg1 = t1;
+  if (graph.get_val(t1).isTensorRef()) {
+    TensorRef& t1_asref = graph.get_val(t1).toTensorRef();
+    ValueRef t1_vten = graph.add_tensor(t1_asref.sizes, t1_asref.dtype);
+    graph.prepack_nodes().emplace_back(new ArithmeticPrepack(t1, t1_vten));
+    arg1 = t1_vten;
+  }
+  VK_CHECK_COND(graph.get_val(arg1).isTensor());
+  // Prepacking second arg (if needed)
+  ValueRef arg2 = t2;
+  if (graph.get_val(t2).isTensorRef()) {
+    TensorRef& t2_asref = graph.get_val(t2).toTensorRef();
+    ValueRef t2_vten = graph.add_tensor(t2_asref.sizes, t2_asref.dtype);
+    graph.prepack_nodes().emplace_back(new ArithmeticPrepack(t2, t2_vten));
+    arg2 = t2_vten;
+  }
+  VK_CHECK_COND(graph.get_val(arg2).isTensor());
+
+  graph.execute_nodes().emplace_back(
+      new ArithmeticNode(arg1, arg2, out, alpha, optype));
+}
+
+ValueRef add_arithmetic_node(
+    ComputeGraph& graph,
+    const ValueRef t1,
+    const ValueRef t2,
+    const float alpha,
+    const arithmetic::OpType optype,
+    const int64_t shared_object_idx) {
+  std::vector<int64_t> t1_sizes = graph.get_val_sizes(t1);
+  api::ScalarType t1_dtype = graph.get_val_dtype(t1);
+
+  ValueRef out = graph.add_tensor(t1_sizes, t1_dtype, shared_object_idx);
+  add_arithmetic_node(graph, t1, t2, out, alpha, optype);
+  return out;
+}
+
+ArithmeticPrepack::ArithmeticPrepack(const ValueRef tref, const ValueRef packed)
+    : OpNode(tref, packed) {}
+
+void ArithmeticPrepack::encode_prepack(ComputeGraph* graph) const {
+  TensorRef tref = graph->get_val(inputs_[0]).toTensorRef();
+  vTensor packed = graph->get_val(outputs_[0]).toTensor();
+
+  api::StorageBuffer staging(
+      graph->context(), packed.dtype(), packed.gpu_nbytes());
+
+  size_t numel = api::utils::multiply_integers(tref.sizes);
+  size_t nbytes = numel * api::element_size(tref.dtype);
+  copy_ptr_to_staging(tref.data, staging, nbytes);
+
+  encode_copy_to_vtensor(graph->context(), staging, packed);
+}
+
+ArithmeticNode::ArithmeticNode(
+    const ValueRef t1,
+    const ValueRef t2,
+    const ValueRef out,
+    const float alpha,
+    const arithmetic::OpType optype)
+    : OpNode({t1, t2}, {out}), alpha_(alpha), optype_(optype) {}
+
+void ArithmeticNode::encode_execute(ComputeGraph* graph) const {
+  vTensor& in1 = graph->get_val(inputs_[0]).toTensor();
+  vTensor& in2 = graph->get_val(inputs_[1]).toTensor();
+  vTensor& out = graph->get_val(outputs_[0]).toTensor();
+
+  api::ShaderInfo kernel = arithmetic::get_shader(optype_);
+  arithmetic::record_op(graph->context(), kernel, in1, in2, out, alpha_);
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/graph/ops/Arithmetic.h
+++ b/backends/vulkan/runtime/graph/ops/Arithmetic.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/impl/Arithmetic.h>
+
+#include <executorch/backends/vulkan/runtime/graph/Graph.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+void add_arithmetic_node(
+    ComputeGraph& graph,
+    const ValueRef t1,
+    const ValueRef t2,
+    const ValueRef out,
+    const float alpha,
+    const arithmetic::OpType optype);
+
+ValueRef add_arithmetic_node(
+    ComputeGraph& graph,
+    const ValueRef t1,
+    const ValueRef t2,
+    const float alpha,
+    const arithmetic::OpType optype,
+    const int64_t shared_object_idx = -1);
+
+class ArithmeticPrepack : public virtual OpNode {
+ public:
+  explicit ArithmeticPrepack(const ValueRef tref, const ValueRef packed);
+
+  void encode_prepack(ComputeGraph* graph) const override;
+};
+
+class ArithmeticNode : public virtual OpNode {
+ public:
+  explicit ArithmeticNode(
+      const ValueRef t1,
+      const ValueRef t2,
+      const ValueRef out,
+      const float alpha,
+      const arithmetic::OpType optype);
+
+  void encode_execute(ComputeGraph* graph) const override;
+
+ private:
+  float alpha_;
+  arithmetic::OpType optype_;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/graph/ops/Copy.cpp
+++ b/backends/vulkan/runtime/graph/ops/Copy.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/Copy.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+void add_copy_node(
+    ComputeGraph& graph,
+    const ValueRef from,
+    const ValueRef to) {
+  graph.execute_nodes().emplace_back(new CopyNode(from, to));
+}
+
+ValueRef add_copy_node(ComputeGraph& graph, const ValueRef from) {
+  std::vector<int64_t> out_sizes = graph.get_val_sizes(from);
+  api::ScalarType out_dtype = graph.get_val_dtype(from);
+  ValueRef to = graph.add_tensor(out_sizes, out_dtype);
+  add_copy_node(graph, from, to);
+  return to;
+}
+
+CopyNode::CopyNode(const ValueRef from, const ValueRef to) : OpNode(from, to) {}
+
+void CopyNode::encode_execute(ComputeGraph* graph) const {
+  api::PipelineBarrier pipeline_barrier{};
+
+  vTensor& from_tensor = graph->get_val(inputs_[0]).toTensor();
+  vTensor& to_tensor = graph->get_val(outputs_[0]).toTensor();
+
+  graph->context()->submit_copy<api::VulkanImage, api::VulkanImage>(
+      // pipeline barrier
+      pipeline_barrier,
+      // resources
+      from_tensor.image(
+          pipeline_barrier,
+          api::PipelineStage::TRANSFER,
+          api::MemoryAccessType::READ),
+      to_tensor.image(
+          pipeline_barrier,
+          api::PipelineStage::TRANSFER,
+          api::MemoryAccessType::WRITE),
+      // copy details
+      from_tensor.extents(),
+      {0u, 0u, 0u},
+      {0u, 0u, 0u},
+      // fence handle
+      VK_NULL_HANDLE);
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/graph/ops/Copy.h
+++ b/backends/vulkan/runtime/graph/ops/Copy.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/graph/Graph.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+void add_copy_node(ComputeGraph& graph, const ValueRef from, const ValueRef to);
+ValueRef add_copy_node(ComputeGraph& graph, const ValueRef from);
+
+class CopyNode : public virtual OpNode {
+ public:
+  explicit CopyNode(const ValueRef from, const ValueRef to);
+
+  void encode_execute(ComputeGraph* graph) const override;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/graph/ops/Staging.cpp
+++ b/backends/vulkan/runtime/graph/ops/Staging.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/native/vulkan/impl/Packing.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/Staging.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+void memcpy_to_mapping(
+    const void* src,
+    api::MemoryMap& dst_mapping,
+    const size_t nbytes,
+    const api::ScalarType dtype) {
+#define DTYPE_CASE(ctype, vkformat, name)                    \
+  case api::ScalarType::name:                                \
+    memcpy_to_mapping_impl<ctype>(src, dst_mapping, nbytes); \
+    break;
+
+  switch (dtype) {
+    VK_FORALL_SCALAR_TYPES(DTYPE_CASE)
+    default:
+      VK_THROW("Unrecognized dtype!");
+  }
+#undef DTYPE_CASE
+}
+
+void memcpy_from_mapping(
+    api::MemoryMap& src_mapping,
+    void* dst,
+    const size_t nbytes,
+    const api::ScalarType dtype) {
+#define DTYPE_CASE(ctype, vkformat, name)                      \
+  case api::ScalarType::name:                                  \
+    memcpy_from_mapping_impl<ctype>(src_mapping, dst, nbytes); \
+    break;
+
+  switch (dtype) {
+    VK_FORALL_SCALAR_TYPES(DTYPE_CASE)
+    default:
+      VK_THROW("Unrecognized dtype!");
+  }
+#undef DTYPE_CASE
+}
+
+void copy_ptr_to_staging(
+    const void* src,
+    api::StorageBuffer& staging,
+    const size_t nbytes) {
+  api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
+  mapping.invalidate();
+  memcpy_to_mapping(src, mapping, nbytes, staging.dtype());
+}
+
+void copy_staging_to_ptr(
+    api::StorageBuffer& staging,
+    void* dst,
+    const size_t nbytes) {
+  api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::READ);
+  mapping.invalidate();
+  memcpy_from_mapping(mapping, dst, nbytes, staging.dtype());
+}
+
+void encode_copy_to_vtensor(
+    api::Context* context,
+    api::StorageBuffer& staging,
+    vTensor& tensor) {
+  api::ShaderInfo shader = packing::get_nchw_to_image_shader(tensor);
+  api::PipelineBarrier pipeline_barrier{};
+  packing::record_nchw_to_image_op(
+      context,
+      shader,
+      staging.buffer(),
+      tensor,
+      pipeline_barrier,
+      VK_NULL_HANDLE);
+}
+
+void encode_copy_from_vtensor(
+    api::Context* context,
+    vTensor& tensor,
+    api::StorageBuffer& staging) {
+  api::ShaderInfo shader = packing::get_image_to_nchw_shader(tensor);
+  api::PipelineBarrier pipeline_barrier{};
+  packing::record_image_to_nchw_op(
+      context,
+      shader,
+      tensor,
+      staging.buffer(),
+      pipeline_barrier,
+      VK_NULL_HANDLE);
+}
+
+StagingNode::StagingNode(ValueRef from, ValueRef to) : OpNode(from, to) {}
+
+void StagingNode::encode_execute(ComputeGraph* graph) const {
+  Value& in_val = graph->get_val(inputs_[0]);
+  Value& out_val = graph->get_val(outputs_[0]);
+
+  if (in_val.isStaging() && out_val.isTensor()) {
+    api::StorageBuffer& from_staging = graph->get_val(inputs_[0]).toStaging();
+    vTensor& to_tensor = graph->get_val(outputs_[0]).toTensor();
+    encode_copy_to_vtensor(graph->context(), from_staging, to_tensor);
+  } else if (in_val.isTensor() && out_val.isStaging()) {
+    vTensor& from_tensor = graph->get_val(inputs_[0]).toTensor();
+    api::StorageBuffer& to_staging = graph->get_val(outputs_[0]).toStaging();
+    encode_copy_from_vtensor(graph->context(), from_tensor, to_staging);
+  } else {
+    VK_THROW(
+        "Unexpected input value type ",
+        in_val.type(),
+        " and output value type ",
+        out_val.type());
+  }
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/graph/ops/Staging.h
+++ b/backends/vulkan/runtime/graph/ops/Staging.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <string.h>
+
+#include <executorch/backends/vulkan/runtime/graph/Graph.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+//
+// Functions to memcpy data into staging buffer
+//
+
+void memcpy_to_mapping(
+    const void* src,
+    api::MemoryMap& dst_mapping,
+    const size_t nbytes,
+    const api::ScalarType dtype);
+void memcpy_from_mapping(
+    const api::MemoryMap& src_mapping,
+    void* dst,
+    const size_t nbytes,
+    const api::ScalarType dtype);
+
+//
+// Utility functions for memcpy
+//
+
+template <typename T>
+void memcpy_to_mapping_impl(
+    const void* src,
+    api::MemoryMap& dst_mapping,
+    const size_t nbytes) {
+  T* data_ptr = dst_mapping.template data<T>();
+  memcpy(data_ptr, reinterpret_cast<const T*>(src), nbytes);
+}
+
+template <typename T>
+void memcpy_from_mapping_impl(
+    api::MemoryMap& src_mapping,
+    void* dst,
+    const size_t nbytes) {
+  T* data_ptr = src_mapping.template data<T>();
+  memcpy(reinterpret_cast<T*>(dst), data_ptr, nbytes);
+}
+
+//
+// Functions to copy data into and out of a staging buffer
+//
+
+void copy_ptr_to_staging(
+    const void* src,
+    api::StorageBuffer& staging,
+    const size_t nbytes);
+void copy_staging_to_ptr(
+    api::StorageBuffer& staging,
+    void* dst,
+    const size_t nbytes);
+
+//
+// Functions to record copying data between a staging buffer and a vTensor
+//
+
+void encode_copy_to_vtensor(
+    api::Context* context,
+    api::StorageBuffer& staging,
+    vTensor& tensor);
+void encode_copy_from_vtensor(
+    api::Context* context,
+    vTensor& tensor,
+    api::StorageBuffer& staging);
+
+/*
+ * OpNode that allows copying data into and out of a staging buffer.
+ */
+class StagingNode : public virtual OpNode {
+ public:
+  explicit StagingNode(ValueRef from, ValueRef to);
+
+  void encode_execute(ComputeGraph* graph) const override;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -39,6 +39,27 @@ def define_common_targets():
     )
 
     runtime.cxx_library(
+        name = "vulkan_graph_runtime",
+        srcs = native.glob([
+            "runtime/graph/**/*.cpp",
+        ]),
+        exported_headers = native.glob([
+            "runtime/graph/**/*.h",
+        ]),
+        visibility = [
+            "//executorch/backends/...",
+            "//executorch/extension/pybindings/...",
+            "//executorch/test/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+        exported_deps = [
+            "//caffe2:torch_vulkan_api",
+            "//caffe2:torch_vulkan_ops",
+        ],
+        define_static_target = False,
+    )
+
+    runtime.cxx_library(
         name = "vulkan_backend_lib",
         srcs = native.glob([
             "runtime/*.cpp",
@@ -54,7 +75,7 @@ def define_common_targets():
         ],
         deps = [
             ":vk_delegate_schema",
-            "//caffe2:torch_vulkan_graph",
+            ":vulkan_graph_runtime",
             "//executorch/runtime/backend:interface",
         ],
         define_static_target = False,

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -1,0 +1,595 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <ATen/native/vulkan/api/api.h>
+
+#include <ATen/native/vulkan/impl/Arithmetic.h>
+#include <ATen/native/vulkan/impl/Packing.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/Arithmetic.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/Staging.h>
+
+using namespace at::native::vulkan;
+
+//
+// Utilities
+//
+
+#define CREATE_FLOAT_TEXTURE(sizes, allocate_memory) \
+  vTensor(                                           \
+      api::context(),                                \
+      sizes,                                         \
+      api::kFloat,                                   \
+      api::StorageType::TEXTURE_3D,                  \
+      api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED,  \
+      allocate_memory);
+
+#define CREATE_FLOAT_BUFFER(sizes, allocate_memory) \
+  vTensor(                                          \
+      api::context(),                               \
+      sizes,                                        \
+      api::kFloat,                                  \
+      api::StorageType::BUFFER,                     \
+      api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED, \
+      allocate_memory);
+
+void fill_vtensor(vTensor& vten, std::vector<float>& data) {
+  api::StorageBuffer staging_buffer(api::context(), api::kFloat, data.size());
+
+  copy_ptr_to_staging(data.data(), staging_buffer, vten.gpu_nbytes());
+
+  if (vten.storage_type() == api::StorageType::BUFFER) {
+    packing::record_nchw_to_buffer_op(
+        api::context(), staging_buffer.buffer(), vten, {}, VK_NULL_HANDLE);
+  } else {
+    api::ShaderInfo compute_shader = packing::get_nchw_to_image_shader(vten);
+    packing::record_nchw_to_image_op(
+        api::context(),
+        compute_shader,
+        staging_buffer.buffer(),
+        vten,
+        {},
+        VK_NULL_HANDLE);
+  }
+}
+
+void fill_vtensor(ComputeGraph& graph, const IOValueRef idx, float val) {
+  std::vector<float> data(graph.get_val(idx.value).toTensor().gpu_numel());
+  std::fill(data.begin(), data.end(), val);
+
+  graph.copy_into_staging(idx.staging, data.data(), data.size());
+}
+
+void extract_vtensor(vTensor& vten, std::vector<float>& data) {
+  api::StorageBuffer staging_buffer(
+      api::context(), api::kFloat, vten.gpu_numel());
+
+  if (vten.storage_type() == api::StorageType::BUFFER) {
+    packing::record_buffer_to_nchw_op(
+        api::context(), vten, staging_buffer.buffer(), {}, VK_NULL_HANDLE);
+  } else {
+    api::ShaderInfo compute_shader = packing::get_image_to_nchw_shader(vten);
+    packing::record_image_to_nchw_op(
+        api::context(),
+        compute_shader,
+        vten,
+        staging_buffer.buffer(),
+        {},
+        VK_NULL_HANDLE);
+  }
+
+  api::VulkanFence fence = api::context()->fences().get_fence();
+  api::context()->submit_cmd_to_gpu(fence.get_submit_handle());
+  fence.wait();
+
+  copy_staging_to_ptr(staging_buffer, data.data(), vten.gpu_nbytes());
+}
+
+api::MemoryAllocation allocate_memory_for(const vTensor& vten) {
+  return api::context()->adapter_ptr()->vma().create_allocation(
+      vten.get_memory_requirements(), vten.get_allocation_create_info());
+}
+
+VmaTotalStatistics get_vma_stats() {
+  return api::context()->adapter_ptr()->vma().get_memory_statistics();
+}
+
+size_t get_vma_allocation_count() {
+  return get_vma_stats().total.statistics.allocationCount;
+}
+
+GraphConfig generate_graph_config() {
+  const uint32_t submit_frequency = UINT32_MAX;
+
+  const api::CommandPoolConfig cmd_config{
+      4u, // cmdPoolInitialSize
+      2u, // cmdPoolBatchSize
+  };
+
+  const api::DescriptorPoolConfig descriptor_pool_config{
+      1024u, // descriptorPoolMaxSets
+      1024u, // descriptorUniformBufferCount
+      1024u, // descriptorStorageBufferCount
+      1024u, // descriptorCombinedSamplerCount
+      1024u, // descriptorStorageImageCount
+      32u, // descriptorPileSizes
+  };
+
+  const api::QueryPoolConfig query_pool_config{};
+
+  const api::ContextConfig context_config{
+      submit_frequency, // cmdSubmitFrequency
+      cmd_config, // cmdPoolConfig
+      descriptor_pool_config, // descriptorPoolConfig
+      query_pool_config, // queryPoolConfig
+  };
+
+  const GraphConfig graph_config{
+      context_config,
+  };
+
+  return graph_config;
+}
+
+//
+// Test Wrapper
+//
+
+class VulkanComputeAPITest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    // Make sure we are starting with a clean slate
+    EXPECT_TRUE(get_vma_allocation_count() == 0);
+  }
+
+  void TearDown() override {
+    api::context()->flush();
+
+    // Make sure we are ending with a clean slate
+    EXPECT_TRUE(get_vma_allocation_count() == 0);
+  }
+};
+
+//
+// Compute API Tests
+//
+
+TEST_F(VulkanComputeAPITest, buffer_copy_sanity_check) {
+  // Simple test that copies data into a and reads from a
+  std::vector<int64_t> sizes = {4, 4, 1};
+  vTensor a = CREATE_FLOAT_BUFFER(sizes, /*allocate_memory = */ true);
+
+  // Input data
+  std::vector<float> data_in(a.gpu_numel());
+  std::fill(data_in.begin(), data_in.end(), 2.524f);
+
+  // Fill input tensor
+  fill_vtensor(a, data_in);
+
+  // Read back data
+  std::vector<float> data_out(a.gpu_numel());
+  extract_vtensor(a, data_out);
+
+  // Check output
+  for (const auto& d : data_out) {
+    EXPECT_TRUE(d == 2.524f);
+  }
+}
+
+TEST_F(VulkanComputeAPITest, buffer_deferred_allocation_test) {
+  // Same as buffer_copy_sanity_check, but defers memory allocation
+
+  std::vector<int64_t> sizes = {4, 4, 1};
+  vTensor a = CREATE_FLOAT_BUFFER(sizes, /*allocate_memory = */ false);
+
+  // For buffer storage, a small uniform buffer is allocated containing size and
+  // stride data, which is why the check is for 1 allocation below.
+  EXPECT_TRUE(get_vma_allocation_count() == 1);
+
+  // Input data
+  std::vector<float> data_in(a.gpu_numel());
+  std::fill(data_in.begin(), data_in.end(), 1.234f);
+
+  // Allocate memory at the last possible opportunity
+  api::MemoryAllocation a_mem = allocate_memory_for(a);
+  a.buffer().bind_allocation(a_mem);
+
+  EXPECT_TRUE(get_vma_allocation_count() == 2);
+
+  // Fill input tensor
+  fill_vtensor(a, data_in);
+
+  // Read back data
+  std::vector<float> data_out(a.gpu_numel());
+  extract_vtensor(a, data_out);
+
+  // Check output
+  for (const auto& d : data_out) {
+    EXPECT_TRUE(d == 1.234f);
+  }
+}
+
+TEST_F(VulkanComputeAPITest, texture_add_sanity_check) {
+  // Simple test that performs a + b -> c
+
+  std::vector<int64_t> sizes = {4, 4, 1};
+  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+
+  // Input data
+  std::vector<float> data_a(a.gpu_numel());
+  std::fill(data_a.begin(), data_a.end(), 2.5f);
+  std::vector<float> data_b(b.gpu_numel());
+  std::fill(data_b.begin(), data_b.end(), 1.5f);
+
+  // Add shader kernel
+  api::ShaderInfo kernel = arithmetic::get_shader(arithmetic::OpType::ADD);
+
+  // Fill input tensors
+  fill_vtensor(a, data_a);
+  fill_vtensor(b, data_b);
+
+  // a + b -> c
+  arithmetic::record_op(api::context(), kernel, a, b, c, 1.0f);
+
+  // Extract output tensor
+  std::vector<float> data_out(c.gpu_numel());
+  extract_vtensor(c, data_out);
+
+  // Check output
+  for (const auto& d : data_out) {
+    EXPECT_TRUE(d == 4.0f);
+  }
+}
+
+TEST_F(VulkanComputeAPITest, texture_deferred_allocation_test) {
+  // This test is the same as texture_add_sanity_check, except that the tensor
+  // memory is allocated in a deferred fashion
+
+  std::vector<int64_t> sizes = {4, 4, 1};
+  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+
+  // No allocations made yet
+  EXPECT_TRUE(get_vma_allocation_count() == 0);
+
+  std::vector<float> data_a(a.gpu_numel());
+  std::fill(data_a.begin(), data_a.end(), 2.5f);
+  std::vector<float> data_b(b.gpu_numel());
+  std::fill(data_b.begin(), data_b.end(), 1.5f);
+
+  api::ShaderInfo kernel = arithmetic::get_shader(arithmetic::OpType::ADD);
+
+  // Allocate memory at the last possible opportunity
+  api::MemoryAllocation a_mem = allocate_memory_for(a);
+  a.image().bind_allocation(a_mem);
+  api::MemoryAllocation b_mem = allocate_memory_for(b);
+  b.image().bind_allocation(b_mem);
+  api::MemoryAllocation c_mem = allocate_memory_for(c);
+  c.image().bind_allocation(c_mem);
+
+  // One allocation for each tensor
+  EXPECT_TRUE(get_vma_allocation_count() == 3);
+
+  fill_vtensor(a, data_a);
+  fill_vtensor(b, data_b);
+
+  arithmetic::record_op(api::context(), kernel, a, b, c, 1.0f);
+
+  std::vector<float> data_c(c.gpu_numel());
+  extract_vtensor(c, data_c);
+
+  for (const auto& val : data_c) {
+    EXPECT_TRUE(val == 4.0f);
+  }
+}
+
+TEST_F(VulkanComputeAPITest, texture_resource_aliasing_test) {
+  // This test performs the following operations:
+  // 1. a + b -> c
+  // 2. c + d -> e
+  // and share memory between tensors whenever possible.
+
+  std::vector<int64_t> sizes = {4, 4, 1};
+  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  vTensor d = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  vTensor e = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+
+  // No allocations made yet
+  EXPECT_TRUE(get_vma_allocation_count() == 0);
+
+  // a and d can share the same memory allocation
+  api::MemoryAllocation a_d_mem = allocate_memory_for(a);
+  a.image().bind_allocation(a_d_mem);
+  d.image().bind_allocation(a_d_mem);
+  // b and e can share the same memory allocation
+  api::MemoryAllocation b_e_mem = allocate_memory_for(b);
+  b.image().bind_allocation(b_e_mem);
+  e.image().bind_allocation(b_e_mem);
+  // c must have its own memory allocation
+  api::MemoryAllocation c_mem = allocate_memory_for(c);
+  c.image().bind_allocation(c_mem);
+
+  // Only 3 allocations should be made
+  EXPECT_TRUE(get_vma_allocation_count() == 3);
+
+  // Specify input data
+  std::vector<float> data_a(a.gpu_numel());
+  std::fill(data_a.begin(), data_a.end(), 2.5f);
+  std::vector<float> data_b(b.gpu_numel());
+  std::fill(data_b.begin(), data_b.end(), 1.5f);
+  std::vector<float> data_d(b.gpu_numel());
+  std::fill(data_d.begin(), data_d.end(), 1.0f);
+
+  // Get shader kernel for add
+  api::ShaderInfo kernel = arithmetic::get_shader(arithmetic::OpType::ADD);
+
+  // First, fill a and b with data
+  fill_vtensor(a, data_a);
+  fill_vtensor(b, data_b);
+
+  // a + b -> c
+  arithmetic::record_op(api::context(), kernel, a, b, c, 1.0f);
+
+  // Now d can be filled with data
+  fill_vtensor(d, data_d);
+
+  // c + d -> e
+  arithmetic::record_op(api::context(), kernel, c, d, e, 1.0f);
+
+  // Extract data from e
+  std::vector<float> data_e(e.gpu_numel());
+  extract_vtensor(e, data_e);
+
+  // Sanity check that the values are correct
+  for (const auto& val : data_e) {
+    EXPECT_TRUE(val == 5.0f);
+  }
+}
+
+TEST_F(VulkanComputeAPITest, resource_bind_twice_fails) {
+  // Check that binding a resource that already has memory associated with it
+  // fails
+
+  std::vector<int64_t> sizes = {4, 4, 1};
+  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+
+  // Try to double bind a resource, which should fail
+  api::MemoryAllocation a_mem = allocate_memory_for(a);
+  EXPECT_THROW(a.image().bind_allocation(a_mem), api::Error);
+}
+
+TEST_F(VulkanComputeAPITest, resource_destructor_non_owning_memory) {
+  // Check that the destructor of a vTensor that does not own its memory
+  // does not free the memory
+
+  api::MemoryAllocation memory;
+
+  // Default MemoryAllocation constructor should not allocate memory
+  EXPECT_TRUE(get_vma_allocation_count() == 0);
+
+  std::vector<int64_t> sizes = {4, 4, 1};
+  {
+    vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+
+    memory = allocate_memory_for(a);
+    EXPECT_TRUE(get_vma_allocation_count() == 1);
+    a.image().bind_allocation(memory);
+  }
+
+  // Check that the memory is still allocated
+  EXPECT_TRUE(get_vma_allocation_count() == 1);
+}
+
+TEST_F(VulkanComputeAPITest, use_non_bound_textures_fails) {
+  // Try to encode a command buffer with a vTensor that does not have memory
+
+  std::vector<int64_t> sizes = {4, 4, 1};
+  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+
+  // No allocations made yet
+  EXPECT_TRUE(get_vma_allocation_count() == 0);
+
+  std::vector<float> data_a(a.gpu_numel());
+  std::fill(data_a.begin(), data_a.end(), 2.5f);
+
+  // Encoding a command buffer with a vTensor without memory should throw
+  EXPECT_THROW(fill_vtensor(a, data_a), api::Error);
+}
+
+//
+// Compute Graph Tests
+//
+
+#define EXTRACT_TENSOR(name)                             \
+  std::vector<float> data_##name(                        \
+      graph.get_val(name.value).toTensor().gpu_numel()); \
+  graph.copy_from_staging(name.staging, data_##name.data(), data_##name.size());
+
+TEST(VulkanComputeGraphTest, test_simple_graph) {
+  GraphConfig config = generate_graph_config();
+  ComputeGraph graph(config);
+
+  std::vector<int64_t> size_big = {4, 4, 4};
+  std::vector<int64_t> size_small = {4, 4, 1};
+
+  // Build graph
+
+  IOValueRef a = graph.add_input_tensor(size_big, api::kFloat);
+  IOValueRef b = graph.add_input_tensor(size_small, api::kFloat);
+
+  IOValueRef out = {};
+
+  out.value = add_arithmetic_node(
+      graph, a.value, b.value, 1.0, arithmetic::OpType::ADD);
+
+  out.staging = graph.set_output_tensor(out.value);
+
+  graph.encode_execute();
+
+  // Run graph
+
+  for (float i = 5.0f; i < 30.0f; i += 10.0f) {
+    float val_a = i + 2.0f;
+    float val_b = i + 1.5f;
+    float val_c = val_a + val_b;
+
+    fill_vtensor(graph, a, val_a);
+    fill_vtensor(graph, b, val_b);
+
+    graph.execute();
+
+    EXTRACT_TENSOR(out);
+
+    // Sanity check that the values are correct
+    for (const auto& val : data_out) {
+      EXPECT_TRUE(val == val_c);
+    }
+  }
+}
+
+#define CREATE_WEIGHT_TENSOR(name, sizes, val)                          \
+  std::vector<float> data_##name(api::utils::multiply_integers(sizes)); \
+  std::fill(data_##name.begin(), data_##name.end(), val);               \
+  ValueRef name = graph.add_tensorref(sizes, api::kFloat, data_##name.data());
+
+TEST(VulkanComputeGraphTest, test_simple_prepacked_graph) {
+  GraphConfig config = generate_graph_config();
+  ComputeGraph graph(config);
+
+  std::vector<int64_t> size_big = {4, 4, 4};
+  std::vector<int64_t> size_small = {4, 4, 1};
+
+  CREATE_WEIGHT_TENSOR(w1, size_small, 3.5f);
+  CREATE_WEIGHT_TENSOR(w2, size_small, 3.0f);
+
+  // Build graph
+
+  IOValueRef a = graph.add_input_tensor(size_big, api::kFloat);
+
+  ValueRef c =
+      add_arithmetic_node(graph, a.value, w1, 1.0, arithmetic::OpType::ADD);
+  ValueRef e = add_arithmetic_node(graph, c, w2, 1.0, arithmetic::OpType::MUL);
+
+  IOValueRef out = {};
+  out.value = e;
+  out.staging = graph.set_output_tensor(out.value);
+
+  graph.encode_prepack();
+  graph.prepack();
+
+  graph.encode_execute();
+
+  // Run graph
+
+  for (float i = 5.0f; i < 30.0f; i += 10.0f) {
+    float val_out = (i + 3.5f) * 3.0f;
+
+    fill_vtensor(graph, a, i);
+
+    // Execute graph
+    graph.execute();
+
+    EXTRACT_TENSOR(out);
+
+    // Sanity check that the values are correct
+    for (const auto& val : data_out) {
+      EXPECT_TRUE(val == val_out);
+    }
+  }
+}
+
+TEST(VulkanComputeGraphTest, test_simple_shared_objects) {
+  GraphConfig config = generate_graph_config();
+  ComputeGraph graph(config);
+
+  std::vector<int64_t> size_big = {4, 4, 4};
+  std::vector<int64_t> size_small = {4, 4, 1};
+
+  // Build graph
+
+  IOValueRef a = graph.add_input_tensor(
+      size_big,
+      api::kFloat,
+      /*shared_object_idx = */ 2);
+  IOValueRef b = graph.add_input_tensor(
+      size_small,
+      api::kFloat,
+      /*shared_object_idx = */ 4);
+
+  // Allocation count will be 2 (1 staging buffer for each input tensor)
+  EXPECT_TRUE(get_vma_allocation_count() == 2);
+
+  ValueRef c = add_arithmetic_node(
+      graph,
+      a.value,
+      b.value,
+      1.0,
+      arithmetic::OpType::ADD,
+      /*shared_object_idx = */ 6);
+
+  IOValueRef d = graph.add_input_tensor(
+      size_small,
+      api::kFloat,
+      /*shared_object_idx = */ 2);
+
+  // Allocation count will be 3 (1 staging buffer for each input tensor)
+  EXPECT_TRUE(get_vma_allocation_count() == 3);
+
+  ValueRef e = add_arithmetic_node(
+      graph,
+      c,
+      d.value,
+      1.0,
+      arithmetic::OpType::MUL,
+      /*shared_object_idx = */ 4);
+
+  IOValueRef out = {};
+  out.value = e;
+  out.staging = graph.set_output_tensor(out.value);
+
+  // Allocation count will be 4 (1 staging buffer for each I/O tensor)
+  EXPECT_TRUE(get_vma_allocation_count() == 4);
+
+  graph.encode_execute();
+
+  // Allocation count will be 13:
+  // 4 staging buffers for each I/O tensor
+  // 6 uniform buffers to store args for each shader dispatch
+  // 3 shared objects to back tensor memory
+  EXPECT_TRUE(get_vma_allocation_count() == 13);
+
+  // Run graph
+
+  for (float i = 4.0f; i < 30.0f; i += 7.0f) {
+    float val_a = i + 2.0f;
+    float val_b = i + 1.5f;
+    float val_d = i + 1.0f;
+    float val_out = (val_a + val_b) * val_d;
+
+    fill_vtensor(graph, a, val_a);
+    fill_vtensor(graph, b, val_b);
+    fill_vtensor(graph, d, val_d);
+
+    // Execute graph
+    graph.execute();
+
+    EXTRACT_TENSOR(out);
+
+    // Sanity check that the values are correct
+    for (const auto& val : data_out) {
+      EXPECT_TRUE(val == val_out);
+    }
+  }
+}


### PR DESCRIPTION
Summary:
## Context

Move Vulkan graph runtime from PyTorch directory to ExecuTorch directory to improve development logistics:

* ExecuTorch delegate changes will no longer require export to PyTorch directory
* Makes it much easier to enable OSS build for Vulkan delegate

Differential Revision: D54133350
