### PR TITLE
Enable embedding_byte output dtype be different than scales/zp dtype

### DIFF
--- a/examples/models/llama2/ops/quantized.yaml
+++ b/examples/models/llama2/ops/quantized.yaml
@@ -1,4 +1,4 @@
-- func: llama_quantized::embedding_byte.out(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, int weight_quant_min, int weight_quant_max, Tensor indices, *, Tensor(a!) out) -> Tensor(a!)
+- func: llama_quantized::embedding_byte.out(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, int weight_quant_min, int weight_quant_max, Tensor indices, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:
     - arg_meta: null

--- a/examples/models/llama2/ops/quantized_ops.py
+++ b/examples/models/llama2/ops/quantized_ops.py
@@ -14,12 +14,12 @@ quantized_lib = torch.library.Library(
 )  # to not be confused with torch.ops.quantized.* ops.
 quantized_lib.define(
     "embedding_byte(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, "
-    "int weight_quant_min, int weight_quant_max, Tensor indices) -> Tensor",
+    "int weight_quant_min, int weight_quant_max, Tensor indices, *, ScalarType? dtype=None) -> Tensor",
 )
 
 quantized_lib.define(
     "embedding_byte.out(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, "
-    "int weight_quant_min, int weight_quant_max, Tensor indices, *, Tensor(a!) out) -> Tensor(a!)",
+    "int weight_quant_min, int weight_quant_max, Tensor indices, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)",
 )
 
 
@@ -31,6 +31,8 @@ def embedding_byte_meta(
     weight_quant_min,
     weight_quant_max,
     indices,
+    *,
+    dtype,
 ):
     assert weight.dtype in [
         torch.int8,
@@ -71,7 +73,7 @@ def embedding_byte_meta(
         weight_quant_max,
         weight.dtype,
     )
-    return torch.ops.aten.embedding.default(weight, indices)
+    return torch.ops.aten.embedding.default(weight, indices).to(dtype)
 
 
 @impl_abstract("llama_quantized::embedding_byte.out")
@@ -82,6 +84,8 @@ def embedding_byte_out_meta(
     weight_quant_min,
     weight_quant_max,
     indices,
+    *,
+    dtype,
     out,
 ):
     return embedding_byte_meta(
@@ -91,4 +95,5 @@ def embedding_byte_out_meta(
         weight_quant_min,
         weight_quant_max,
         indices,
+        dtype=dtype,
     )

--- a/examples/models/llama2/quantize.py
+++ b/examples/models/llama2/quantize.py
@@ -818,8 +818,8 @@ class QuantizedGroupEmbedding(torch.nn.Module):
     @torch.no_grad()
     def forward(self, indices: torch.Tensor) -> torch.Tensor:
         return torch.ops.llama_quantized.embedding_byte.default(
-            self.weight, self.scales, None, 0, 0, indices
-        ).to(self.dtype)
+            self.weight, self.scales, None, 0, 0, indices, dtype=self.dtype
+        )
 
 
 #        result_weights = self.weight.index_select(0, indices.view(-1))

--- a/exir/passes/_quant_patterns_and_replacements.py
+++ b/exir/passes/_quant_patterns_and_replacements.py
@@ -27,7 +27,7 @@ __all__ = [
 
 quantized_decomposed_lib.define(
     "embedding_byte(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, "
-    "int weight_quant_min, int weight_quant_max, Tensor indices) -> Tensor",
+    "int weight_quant_min, int weight_quant_max, Tensor indices, *, ScalarType? dtype=None) -> Tensor",
 )
 
 quantized_decomposed_lib.define(
@@ -483,6 +483,48 @@ def _get_embedding_ops_patterns_and_replacements() -> List[
             return out
 
         @bind_pattern_to_op(quantized_decomposed_lib, "embedding_byte")
+        def pattern_with_dtype(
+            weight,
+            weight_scales,
+            weight_zero_points,
+            weight_quant_min,
+            weight_quant_max,
+            indicies,
+            dtype,
+        ):
+            weight = torch.ops.quantized_decomposed.dequantize_per_channel.default(
+                weight,
+                weight_scales,
+                weight_zero_points,
+                0,
+                weight_quant_min,
+                weight_quant_max,
+                torch.uint8,
+            )
+            out = torch.ops.aten.embedding.default(weight, indicies).to(dtype)
+            return out
+
+        def replacement_with_dtype(
+            weight,
+            weight_scales,
+            weight_zero_points,
+            weight_quant_min,
+            weight_quant_max,
+            indicies,
+            dtype,
+        ):
+            out = torch.ops.quantized_decomposed.embedding_byte.default(
+                weight,
+                weight_scales,
+                weight_zero_points,
+                weight_quant_min,
+                weight_quant_max,
+                indicies,
+                dtype=dtype,
+            )
+            return out
+
+        @bind_pattern_to_op(quantized_decomposed_lib, "embedding_byte")
         def pattern_with_padding_idx(
             weight,
             weight_scales,
@@ -527,6 +569,11 @@ def _get_embedding_ops_patterns_and_replacements() -> List[
             (
                 _trace_and_lower_to_edge_ops(pattern),
                 _trace_and_lower_to_edge_ops(replacement),
+                [],
+            ),
+            (
+                _trace_and_lower_to_edge_ops(pattern_with_dtype),
+                _trace_and_lower_to_edge_ops(replacement_with_dtype),
                 [],
             ),
             (

--- a/kernels/quantized/quantized.yaml
+++ b/kernels/quantized/quantized.yaml
@@ -34,7 +34,7 @@
     - arg_meta: null
       kernel_name: torch::executor::dequantize_per_channel_out
 
-- func: quantized_decomposed::embedding_byte.out(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, int weight_quant_min, int weight_quant_max, Tensor indices, *, Tensor(a!) out) -> Tensor(a!)
+- func: quantized_decomposed::embedding_byte.out(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, int weight_quant_min, int weight_quant_max, Tensor indices, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:
     - arg_meta: null

--- a/kernels/quantized/test/op_embedding_test.cpp
+++ b/kernels/quantized/test/op_embedding_test.cpp
@@ -76,6 +76,7 @@ void test_dtype() {
       quant_min,
       quant_max,
       indices,
+      out.scalar_type(),
       out);
 
   // (8 - 1) * 0.5 = 3.5
@@ -139,6 +140,7 @@ TEST(OpQuantizedEmbeddingTest, ConsitencyWithReferencePattern) {
       quant_min,
       quant_max,
       indices,
+      out.scalar_type(),
       out);
 
   // Do Q DQ embedding
@@ -196,6 +198,7 @@ TEST(OpQuantizedEmbeddingTest, TestGroupWiseQuantizedEmbedding) {
       quant_min,
       quant_max,
       indices,
+      out.scalar_type(),
       out);
 
   EXPECT_TENSOR_EQ(out, expected);
@@ -220,6 +223,7 @@ TEST(OpQuantizedEmbeddingTest, TestGroupWiseQuantizedEmbedding) {
       quant_min,
       quant_max,
       indices,
+      out.scalar_type(),
       out);
 
   EXPECT_TENSOR_EQ(out, expected);
@@ -251,6 +255,7 @@ TEST(OpQuantizedEmbeddingTest, TestGroupWiseQuantizedEmbeddingDeath1) {
           quant_min,
           quant_max,
           indices,
+          out.scalar_type(),
           out),
       "");
 }
@@ -281,6 +286,7 @@ TEST(OpQuantizedEmbeddingTest, TestGroupWiseQuantizedEmbeddingDeath2) {
           quant_min,
           quant_max,
           indices,
+          out.scalar_type(),
           out),
       "");
 }
@@ -310,6 +316,7 @@ TEST(OpQuantizedEmbeddingTest, TestGroupWiseQuantizedEmbeddingDeath3) {
           quant_min,
           quant_max,
           indices,
+          out.scalar_type(),
           out),
       "");
 }
@@ -339,6 +346,7 @@ TEST(OpQuantizedEmbeddingTest, TestGroupWiseQuantizedEmbeddingDeath4) {
           quant_min,
           quant_max,
           indices,
+          out.scalar_type(),
           out),
       "");
 }
@@ -368,6 +376,7 @@ TEST(OpQuantizedEmbeddingTest, TestGroupWiseQuantizedEmbeddingDeath5) {
           quant_min,
           quant_max,
           indices,
+          out.scalar_type(),
           out),
       "");
 }


### PR DESCRIPTION
Reviewed By: mikekgfb

Differential Revision: D54141337


