### PR TITLE
Resolve recurring errors where query is c10::Half and key and value float

### DIFF
--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -262,6 +262,10 @@ class Attention(nn.Module):
         # tensor will be 2-dimensional, regarldess of the values of L & S
         mask = torch.squeeze(mask, [0, 1])
 
+        # FIXME: This should be so automatically! MKG
+        keys = keys.to(dtype=xq.dtype)
+        values = values.to(dtype=xq.dtype)
+
         output = F.scaled_dot_product_attention(
             xq, keys, values, attn_mask=mask, dropout_p=0.0
         )


### PR DESCRIPTION
Summary:
Resolve recurring errors where query is c10::Half and key and value float.  This should ideally work from first principles, but somehow it does not.

We need to fix the underlying issue but in the meantime this ugly have will enable us to proceed and allow others to debug other aspects of ET lowering.

Differential Revision: D54167581


