### PR TITLE
Revert errorneous 4bit quant changes

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -156,13 +156,13 @@ def get_pt2e_quantizers(
                 "At the moment only per channel weight quantization is supported."
             )
         if quant_params.quantize_linear.is_qc4:
-            nbits = 4
+            operator_config_dynamic = get_symmetric_quantization_config(
+                is_per_channel=True, is_dynamic=True, weight_qmin=-8, weight_qmax=7
+            )
         else:
-            nbits = 8
-        qmin, qmax = -2 ^ (nbits), 2 ^ (nbits) - 1
-        operator_config_dynamic = get_symmetric_quantization_config(
-            is_per_channel=True, is_dynamic=True, weight_qmin=qmin, weight_qmax=qmax
-        )
+            operator_config_dynamic = get_symmetric_quantization_config(
+                is_per_channel=True, is_dynamic=True
+            )
         dynamic_quantizer.set_global(operator_config_dynamic)
         quantizers.append(dynamic_quantizer)
     return quantizers


### PR DESCRIPTION
Summary:
Earlier changes to 4bit working diff results in not working 4 bit support.

THis diff restores those and avoids using min/max. This would have also
intefered with 8bit quant that expects symmeteric min/max unlike 4bit.

Differential Revision: D54198222


