### PR TITLE
[ET-VK] Fix floor_div delegate test

### DIFF
--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -26,10 +26,10 @@ class VulkanSupportedOperators(OperatorSupportBase):
         supported = node.op == "call_function" and node.target in [
             exir_ops.edge.aten.add.Tensor,
             exir_ops.edge.aten.div.Tensor,
+            exir_ops.edge.aten.div.Tensor_mode,
             exir_ops.edge.aten.mul.Tensor,
             exir_ops.edge.aten.sub.Tensor,
             exir_ops.edge.aten.pow.Tensor_Tensor,
-            exir_ops.edge.aten.floor_divide.default,
         ]
         return supported
 

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -199,6 +199,26 @@ class TestBackends(unittest.TestCase):
 
         self.lower_module_and_test_output(arithmetic_module, model_inputs)
 
+    def test_vulkan_backend_floor_div(self):
+        class FloorDivModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                z = x // y
+                return z
+
+        floor_div_module = FloorDivModule()
+        model_inputs = (
+            torch.rand(size=(2, 3), dtype=torch.float32) * 10.0,
+            torch.rand(size=(2, 3), dtype=torch.float32) + 1.0,
+        )
+
+        # absolute tolerance is 1 because of flooring
+        self.lower_module_and_test_output(
+            floor_div_module, model_inputs, atol=1.0 + 1e-03
+        )
+
     def test_vulkan_backend_pow(self):
         class PowModule(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2102
* __->__ #2101

In [PR #2062](https://github.com/pytorch/executorch/pull/2062), we introduced the partitioner and removed this failing test. The test fails because we were using the wrong op name. We fix it to that from [PR #1737](https://github.com/pytorch/executorch/pull/1737).

Differential Revision: [D54206402](https://our.internmc.facebook.com/intern/diff/D54206402/)