### PR TITLE
Update kernels for non-fatal (part 14)

### DIFF
--- a/kernels/optimized/cpu/op_bmm.cpp
+++ b/kernels/optimized/cpu/op_bmm.cpp
@@ -28,47 +28,51 @@ using Tensor = exec_aten::Tensor;
 
 namespace {
 
-// Asserts that the parameters are valid.
-void check_bmm_out_args(const Tensor& self, const Tensor& mat2, Tensor& out) {
+// Verifies that the parameters are valid.
+bool check_bmm_out_args(const Tensor& self, const Tensor& mat2, Tensor& out) {
   // Ensure dimensions is 3 for all input and out
-  ET_CHECK_MSG(
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
       self.dim() == mat2.dim(),
       "self.dim() %zd != mat2.dim() %zd",
       self.dim(),
       mat2.dim());
-  ET_CHECK_MSG(
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
       self.dim() == out.dim(),
       "self.dim() %zd != out.dim() %zd",
       self.dim(),
       out.dim());
-  ET_CHECK_MSG(self.dim() == 3, "self.dim() %zd != 3", self.dim());
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      self.dim() == 3, "self.dim() %zd != 3", self.dim());
   // Ensure batch larger than or equals to 0
-  ET_CHECK_MSG(self.size(0) >= 0, "self.size(0) %zd < 0", self.size(0));
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      self.size(0) >= 0, "self.size(0) %zd < 0", self.size(0));
   // Ensure batches are the same
-  ET_CHECK_MSG(
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
       self.size(0) == mat2.size(0),
       "self.size(0) %zd != mat2.size(0) %zd",
       self.size(0),
       mat2.size(0));
-  ET_CHECK_MSG(
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
       self.size(0) == out.size(0),
       "self.size(0) %zd != out.size(0) %zd",
       self.size(0),
       out.size(0));
   // Ensure the out size is compatible with input tensors
-  ET_CHECK_MSG(
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
       mat2.size(2) == out.size(2),
       "mat2.size(2) %zd != out.size(2) %zd",
       mat2.size(2),
       out.size(2));
-  ET_CHECK_MSG(
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
       self.size(1) == out.size(1),
       "self.size(1) %zd != out.size(1) %zd",
       self.size(1),
       out.size(1));
 
   // Ensure that all tensors share a dtype
-  ET_CHECK_SAME_DTYPE3(self, mat2, out);
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(self, mat2, out));
+
+  return true;
 }
 
 template <typename CTYPE>
@@ -106,7 +110,7 @@ void bmm_kernel(const Tensor& self, const Tensor& mat2, Tensor& out) {
   }
 }
 
-void resize_out_tensor(const Tensor& self, const Tensor& mat2, Tensor& out) {
+Error resize_out_tensor(const Tensor& self, const Tensor& mat2, Tensor& out) {
   exec_aten::SizesType expected_output_size[kTensorDimensionLimit];
 
   const size_t m_dim = self.dim() - 2;
@@ -116,16 +120,18 @@ void resize_out_tensor(const Tensor& self, const Tensor& mat2, Tensor& out) {
     expected_output_size[i] = self.size(i);
   }
 
+  if (m_dim >= self.dim() || n_dim >= mat2.dim()) {
+    ET_LOG(Error, "Incompatible matrix multiply dimensions.");
+    return Error::InvalidArgument;
+  }
+
   expected_output_size[m_dim] = self.size(m_dim);
   expected_output_size[n_dim] = mat2.size(n_dim);
 
   ArrayRef<exec_aten::SizesType> output_size{
       expected_output_size, static_cast<size_t>(out.dim())};
 
-  torch::executor::Error err = resize_tensor(out, output_size);
-  ET_CHECK_MSG(
-      err == torch::executor::Error::Ok,
-      "Failed to resize out Tensor in bmm_out");
+  return resize_tensor(out, output_size);
 }
 } // namespace
 
@@ -136,8 +142,14 @@ Tensor& opt_bmm_out(
     const Tensor& mat2,
     Tensor& out) {
   (void)context;
-  resize_out_tensor(self, mat2, out);
-  check_bmm_out_args(self, mat2, out);
+
+  ET_KERNEL_CHECK(
+      context,
+      resize_out_tensor(self, mat2, out) == Error::Ok,
+      InvalidArgument,
+      out);
+  ET_KERNEL_CHECK(
+      context, check_bmm_out_args(self, mat2, out), InvalidArgument, out);
 
 #define BMM_TENSOR(ctype, dtype)        \
   case ScalarType::dtype:               \

--- a/kernels/optimized/cpu/op_div.cpp
+++ b/kernels/optimized/cpu/op_div.cpp
@@ -51,7 +51,12 @@ Tensor& opt_div_out(
   if (a_type == b_type && a_type == out_type && a.sizes().equals(b.sizes())) {
     // Resize for dynamic shape
     auto error = resize_tensor(out, a.sizes());
-    ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+    ET_KERNEL_CHECK_MSG(
+        ctx,
+        error == Error::Ok,
+        InvalidArgument,
+        out,
+        "Failed to resize output tensor.");
 
     ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, "div.out", CTYPE, [&]() {
       using Vec = executorch::vec::Vectorized<CTYPE>;
@@ -64,7 +69,7 @@ Tensor& opt_div_out(
     });
   } else {
     ScalarType common_type = get_compute_type(a_type, b_type);
-    ET_CHECK(canCast(common_type, out_type));
+    ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
     ET_KERNEL_CHECK(
         ctx,

--- a/kernels/optimized/cpu/op_exp.cpp
+++ b/kernels/optimized/cpu/op_exp.cpp
@@ -67,7 +67,14 @@ Tensor& opt_exp_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
 
   // Resize for dynamic shape
   auto error = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      error == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(ctx, tensor_is_floating_type(out), InvalidArgument, out);
 
   ET_SWITCH_REALHB_TYPES(in.scalar_type(), ctx, "exp.out", CTYPE_IN, [&] {
     ET_SWITCH_FLOATH_TYPES(out.scalar_type(), ctx, "exp.out", CTYPE_OUT, [&] {

--- a/kernels/optimized/cpu/op_le.cpp
+++ b/kernels/optimized/cpu/op_le.cpp
@@ -26,11 +26,16 @@ Tensor& opt_le_tensor_out(
     Tensor& out) {
   (void)ctx;
 
-  ET_CHECK_SAME_SHAPE2(a, b);
+  ET_KERNEL_CHECK(ctx, tensors_have_same_shape(a, b), InvalidArgument, out);
 
   // Resize for dynamic shape
   auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      error == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();
@@ -90,7 +95,12 @@ Tensor& opt_le_scalar_out(
 
   // Resize for dynamic shape
   auto error = resize_tensor(out, a.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      error == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);

--- a/kernels/optimized/cpu/op_log_softmax.cpp
+++ b/kernels/optimized/cpu/op_log_softmax.cpp
@@ -132,10 +132,17 @@ Tensor& opt_log_softmax_out(
     Tensor& out) {
   (void)context;
 
-  check_log_softmax_args(self, dim, half_to_float, out);
+  ET_KERNEL_CHECK(
+      context,
+      check_log_softmax_args(self, dim, half_to_float, out),
+      InvalidArgument,
+      out);
 
   ET_KERNEL_CHECK(
-      ctx, resize_tensor(out, self.sizes()) == Error::Ok, InvalidArgument, out);
+      context,
+      resize_tensor(out, self.sizes()) == Error::Ok,
+      InvalidArgument,
+      out);
 
   dim = dim < 0 ? dim + nonzero_dim(self) : dim;
 

--- a/kernels/optimized/cpu/op_mul.cpp
+++ b/kernels/optimized/cpu/op_mul.cpp
@@ -35,7 +35,12 @@ Tensor& opt_mul_out(
       a_type != ScalarType::Half) {
     // Resize for dynamic shape
     auto error = resize_tensor(out, a.sizes());
-    ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+    ET_KERNEL_CHECK_MSG(
+        ctx,
+        error == Error::Ok,
+        InvalidArgument,
+        out,
+        "Failed to resize output tensor.");
 
     ET_SWITCH_REALB_TYPES(out_type, ctx, "mul.out", CTYPE, [&]() {
       using Vec = executorch::vec::Vectorized<CTYPE>;
@@ -49,7 +54,7 @@ Tensor& opt_mul_out(
   } else {
     ScalarType common_type =
         promoteTypes(a_type, b_type, /*half_to_float*/ true);
-    ET_CHECK(canCast(common_type, out_type));
+    ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
 
     ET_KERNEL_CHECK(
         ctx,

--- a/kernels/optimized/cpu/op_neg.cpp
+++ b/kernels/optimized/cpu/op_neg.cpp
@@ -19,7 +19,12 @@ Tensor& opt_neg_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
 
   // Resize for dynamic shape
   auto error = resize_tensor(out, in.sizes());
-  ET_CHECK_MSG(error == Error::Ok, "Failed to resize output tensor.");
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      error == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
 
   ET_SWITCH_REAL_TYPES(in.scalar_type(), ctx, "neg.out", CTYPE, [&] {
     using Vec = executorch::vec::Vectorized<CTYPE>;

--- a/kernels/portable/cpu/op_add.cpp
+++ b/kernels/portable/cpu/op_add.cpp
@@ -29,6 +29,8 @@ Tensor& add_out(
       InvalidArgument,
       out);
 
+  ET_KERNEL_CHECK(ctx, tensor_is_realhb_type(out), InvalidArgument, out);
+
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();
   ScalarType alpha_type = utils::get_scalar_dtype(alpha);
@@ -80,6 +82,8 @@ Tensor& add_scalar_out(
       InvalidArgument,
       out,
       "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(ctx, tensor_is_realhb_type(out), InvalidArgument, out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);

--- a/kernels/portable/cpu/op_clone.cpp
+++ b/kernels/portable/cpu/op_clone.cpp
@@ -19,11 +19,11 @@ using Tensor = exec_aten::Tensor;
 // clone.out(Tensor self, *, MemoryFormat? memory_format=None, Tensor(a!) out)
 // -> Tensor(a!)
 Tensor& clone_out(
-    RuntimeContext& ctx,
+    RuntimeContext& context,
     const Tensor& self,
     exec_aten::optional<exec_aten::MemoryFormat> memory_format,
     Tensor& out) {
-  (void)ctx;
+  (void)context;
 
   ET_KERNEL_CHECK(
       context,

--- a/kernels/portable/cpu/op_copy.cpp
+++ b/kernels/portable/cpu/op_copy.cpp
@@ -29,12 +29,12 @@ Tensor& copy_out(
     Tensor& out) {
   (void)ctx;
   // Right now we only support blocking data transfer
-  ET_KERNEL_CHECK(ctx, non_blocking == false, InvalidArgument, non_blocking);
+  ET_KERNEL_CHECK(ctx, non_blocking == false, InvalidArgument, out);
 
   ET_KERNEL_CHECK(ctx, tensors_have_same_dtype(in, out), InvalidArgument, out);
 
   ET_KERNEL_CHECK(
-      ctx, tensor_is_broadcastable_to(src, in), InvalidArgument, src);
+      ctx, tensor_is_broadcastable_to(src, in), InvalidArgument, out);
 
   ET_KERNEL_CHECK(
       ctx, resize_tensor(out, in.sizes()) == Error::Ok, InvalidArgument, out);

--- a/kernels/portable/cpu/op_div.cpp
+++ b/kernels/portable/cpu/op_div.cpp
@@ -55,6 +55,8 @@ div_out(RuntimeContext& ctx, const Tensor& a, const Tensor& b, Tensor& out) {
       InvalidArgument,
       out);
 
+  ET_KERNEL_CHECK(ctx, tensor_is_real_type(out), InvalidArgument, out);
+
   ScalarType common_type = get_compute_type(a_type, b_type);
   ScalarType out_type = out.scalar_type();
 
@@ -99,6 +101,8 @@ Tensor& div_out_mode(
   ScalarType b_type = b.scalar_type();
   ScalarType common_type = get_compute_type(a_type, b_type);
   ScalarType out_type = out.scalar_type();
+
+  ET_KERNEL_CHECK(ctx, tensor_is_real_type(out), InvalidArgument, out);
 
   // Allow casting float -> integral here
   // non-bool -> bool is still disallowed

--- a/kernels/portable/cpu/op_embedding.cpp
+++ b/kernels/portable/cpu/op_embedding.cpp
@@ -28,6 +28,7 @@ namespace {
 
 template <typename CTYPE>
 void embedding_kernel(
+    RuntimeContext& ctx,
     const Tensor& weight,
     const Tensor& indices,
     Tensor& out) {
@@ -38,14 +39,20 @@ void embedding_kernel(
   ssize_t weight_height = weight.size(0);
   for (int i = 0; i < indices.numel(); i++) {
     // Ensure index is larger than 0 and smaller than weight.size(0)
-    ET_CHECK_MSG(
+    ET_KERNEL_CHECK_MSG(
+        ctx,
         indices_ptr[i] < weight_height,
+        InvalidArgument,
+        ,
         "indices_ptr[%d] %ld >= weight.size(0) %zd",
         i,
         static_cast<long>(indices_ptr[i]),
         weight_height);
-    ET_CHECK_MSG(
+    ET_KERNEL_CHECK_MSG(
+        ctx,
         indices_ptr[i] >= 0,
+        InvalidArgument,
+        ,
         "indices_ptr[%d] %ld < 0",
         i,
         static_cast<long>(indices_ptr[i]));
@@ -101,7 +108,7 @@ Tensor& embedding_out(
 
   ET_SWITCH_TWO_TYPES(
       Long, Int, ix_type, ctx, "op_embedding.out", CTYPE, [&]() {
-        embedding_kernel<CTYPE>(weight, indices, out);
+        embedding_kernel<CTYPE>(ctx, weight, indices, out);
       });
 
   return out;

--- a/kernels/portable/cpu/op_empty.cpp
+++ b/kernels/portable/cpu/op_empty.cpp
@@ -32,7 +32,7 @@ Tensor& empty_out(
 
   // Resize for dynamic shape
   ET_KERNEL_CHECK_MSG(
-      ctx,
+      context,
       resize_tensor(out, size) == Error::Ok,
       InvalidArgument,
       out,

--- a/kernels/portable/cpu/op_expand_copy.cpp
+++ b/kernels/portable/cpu/op_expand_copy.cpp
@@ -90,7 +90,11 @@ Tensor& expand_copy_out(
   const auto repeats_size{map_expand_to_repeats(
       self_sizes, expand_sizes, repeats, kTensorDimensionLimit)};
 
-  repeat_tensor(self, {repeats, repeats_size}, out);
+  ET_KERNEL_CHECK(
+      ctx,
+      repeat_tensor(self, {repeats, repeats_size}, out) == Error::Ok,
+      InvalidArgument,
+      out);
 
   return out;
 }

--- a/kernels/portable/cpu/op_fill.cpp
+++ b/kernels/portable/cpu/op_fill.cpp
@@ -29,7 +29,7 @@ Tensor& fill_scalar_out(
   ScalarType b_type = utils::get_scalar_dtype(b);
   ScalarType out_type = out.scalar_type();
 
-  ET_KERNEL_CHECK(ct, a_type == out_type, InvalidArgument, out);
+  ET_KERNEL_CHECK(ctx, a_type == out_type, InvalidArgument, out);
 
   // Resize for dynamic shape
   ET_KERNEL_CHECK_MSG(
@@ -65,7 +65,7 @@ Tensor& fill_tensor_out(
   (void)ctx;
 
   // Assert `b` must be a scalar tensor.
-  ET_KERNEL_CHECK(ctx, tensor_is_scalar(b), InvalidArgument, b);
+  ET_KERNEL_CHECK(ctx, tensor_is_scalar(b), InvalidArgument, out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();

--- a/kernels/portable/cpu/op_floor_divide.cpp
+++ b/kernels/portable/cpu/op_floor_divide.cpp
@@ -31,6 +31,8 @@ Tensor& floor_divide_out(
       InvalidArgument,
       out);
 
+  ET_KERNEL_CHECK(ctx, tensor_is_real_type(out), InvalidArgument, out);
+
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();
   ScalarType common_type = promoteTypes(a_type, b_type);

--- a/kernels/portable/cpu/op_index.cpp
+++ b/kernels/portable/cpu/op_index.cpp
@@ -95,7 +95,7 @@ Tensor& index_Tensor_out(
           bool success = true;
           std::tie(in_ix, success) =
               get_in_ix(in, indices, out, out_ix, start, xdim, dim_map, ix_map);
-          ET_KERNEL_CHECK(ctx, success, InvalidArgument, out);
+          ET_KERNEL_CHECK(ctx, success, InvalidArgument, );
           out_data[out_ix] = in_data[in_ix];
         }
       });

--- a/kernels/portable/cpu/op_index_put.cpp
+++ b/kernels/portable/cpu/op_index_put.cpp
@@ -131,8 +131,7 @@ Tensor& index_put_out(
           ctx,
           get_in_coord(
               in, indices, start, bc_ndim, dim_map, ix_map, x_coord, in_coord),
-          InvalidArgument,
-          out);
+          InvalidArgument, );
 
       in_ix = coordinateToIndex(in, in_coord);
 

--- a/kernels/portable/cpu/op_linear_scratch_example.cpp
+++ b/kernels/portable/cpu/op_linear_scratch_example.cpp
@@ -71,11 +71,10 @@ Tensor& linear_scratch_example(
   N = input.size(1);
   K = weight.size(0);
 
-  ET_KERNEL_CHECK(
-      ctx,
-      check_linear_scratch_example_args(input, weight, bias, out, scratch),
-      InvalidArgument,
-      out);
+  // TODO: Update to use ET_KERNEL_CHECK when context is available in custom
+  // ops.
+  ET_CHECK(
+      check_linear_scratch_example_args(input, weight, bias, out, scratch));
 
   // input @ weight -> scratch
   // TODO: does not handle the case that accumulator has different type
@@ -103,12 +102,7 @@ Tensor& linear_scratch_example(
 
     // add the bias
     if (bias.has_value()) {
-      ET_KERNEL_CHECK_MSG(
-          ctx,
-          K == bias.value().numel(),
-          InvalidArgument,
-          out,
-          "Unexpected numel for bias");
+      ET_CHECK_MSG(K == bias.value().numel(), "Unexpected numel for bias");
       for (size_t i = 0; i < M; ++i) {
         for (size_t j = 0; j < K; ++j) {
           scalar_t* scratch_ptr =

--- a/kernels/portable/cpu/op_logit.cpp
+++ b/kernels/portable/cpu/op_logit.cpp
@@ -28,6 +28,8 @@ Tensor& logit_out(
   ET_KERNEL_CHECK(
       ctx, resize_tensor(out, in.sizes()) == Error::Ok, InvalidArgument, out);
 
+  ET_KERNEL_CHECK(ctx, tensor_is_floating_type(out), InvalidArgument, out);
+
   ScalarType in_type = in.scalar_type();
   ScalarType out_type = out.scalar_type();
   ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "logit.out", CTYPE_IN, [&] {

--- a/kernels/portable/cpu/op_max.cpp
+++ b/kernels/portable/cpu/op_max.cpp
@@ -35,19 +35,19 @@ std::tuple<Tensor&, Tensor&> max_out(
       ctx,
       check_min_max_args(in, dim, keepdim, max, max_indices),
       InvalidArgument,
-      std::tuple({max, max_indices}));
+      (std::tuple<Tensor&, Tensor&>({max, max_indices})));
 
   ET_KERNEL_CHECK(
       ctx,
       resize_reduction_out(in, dim, keepdim, max) == Error::Ok,
       InvalidArgument,
-      std::tuple({max, max_indices}));
+      (std::tuple<Tensor&, Tensor&>({max, max_indices})));
 
   ET_KERNEL_CHECK(
       ctx,
       resize_tensor(max_indices, max.sizes()) == Error::Ok,
       InvalidArgument,
-      std::tuple({max, max_indices}));
+      (std::tuple<Tensor&, Tensor&>({max, max_indices})));
 
   dim = dim < 0 ? dim + in.dim() : dim;
 

--- a/kernels/portable/cpu/op_min.cpp
+++ b/kernels/portable/cpu/op_min.cpp
@@ -35,19 +35,19 @@ std::tuple<Tensor&, Tensor&> min_out(
       ctx,
       check_min_max_args(in, dim, keepdim, min, min_indices),
       InvalidArgument,
-      std::tuple({min, min_indices}));
+      (std::tuple<Tensor&, Tensor&>({min, min_indices})));
 
   ET_KERNEL_CHECK(
       ctx,
       resize_reduction_out(in, dim, keepdim, min) == Error::Ok,
       InvalidArgument,
-      std::tuple({min, min_indices}));
+      (std::tuple<Tensor&, Tensor&>({min, min_indices})));
 
   ET_KERNEL_CHECK(
       ctx,
       resize_tensor(min_indices, min.sizes()) == Error::Ok,
       InvalidArgument,
-      std::tuple({min, min_indices}));
+      (std::tuple<Tensor&, Tensor&>({min, min_indices})));
 
   dim = dim < 0 ? dim + in.dim() : dim;
 

--- a/kernels/portable/cpu/op_mul.cpp
+++ b/kernels/portable/cpu/op_mul.cpp
@@ -24,6 +24,8 @@ mul_out(RuntimeContext& ctx, const Tensor& a, const Tensor& b, Tensor& out) {
       InvalidArgument,
       out);
 
+  ET_KERNEL_CHECK(ctx, tensor_is_realhb_type(out), InvalidArgument, out);
+
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();
   ScalarType common_type = promoteTypes(a_type, b_type, /*half_to_float*/ true);
@@ -68,6 +70,8 @@ Tensor& mul_scalar_out(
       InvalidArgument,
       out,
       "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(ctx, tensor_is_realhb_type(out), InvalidArgument, out);
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = utils::get_scalar_dtype(b);

--- a/kernels/portable/cpu/op_nonzero.cpp
+++ b/kernels/portable/cpu/op_nonzero.cpp
@@ -39,7 +39,7 @@ void increment_index(size_t* index, const ArrayRef<SizesType> sizes) {
  * out to the appropriate size, and then loop again and properly write into out
  */
 template <typename CTYPE>
-void nonzero(const Tensor& input, Tensor& output) {
+void nonzero(RuntimeContext& ctx, const Tensor& input, Tensor& output) {
   const CTYPE* in_data = input.const_data_ptr<CTYPE>();
   size_t lim = input.numel();
   int32_t num_nonzero = 0;
@@ -58,8 +58,7 @@ void nonzero(const Tensor& input, Tensor& output) {
       ctx,
       resize_tensor(output, ArrayRef<exec_aten::SizesType>(out_shape, 2)) ==
           Error::Ok,
-      InvalidArgument,
-      out);
+      InvalidArgument, );
 
   size_t index[kTensorDimensionLimit];
   memset(index, 0, sizeof(index));
@@ -91,7 +90,7 @@ Tensor& nonzero_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
 
   ET_SWITCH_REAL_TYPES_AND(
       Bool, in.scalar_type(), ctx, "nonzero.out", CTYPE, [&] {
-        nonzero<CTYPE>(in, out);
+        nonzero<CTYPE>(ctx, in, out);
       });
 
   return out;

--- a/kernels/portable/cpu/pattern/unary_ufunc_realhb_to_floath.cpp
+++ b/kernels/portable/cpu/pattern/unary_ufunc_realhb_to_floath.cpp
@@ -23,6 +23,8 @@ Tensor& unary_ufunc_realhb_to_floath(
     Tensor& out) {
   (void)ctx;
 
+  ET_KERNEL_CHECK(ctx, tensor_is_floating_type(out), InvalidArgument, out);
+
   // Resize for dynamic shape
   ET_KERNEL_CHECK_MSG(
       ctx,

--- a/kernels/portable/cpu/util/activation_ops_util.cpp
+++ b/kernels/portable/cpu/util/activation_ops_util.cpp
@@ -15,6 +15,7 @@ namespace executor {
 
 bool check_gelu_args(const Tensor& in, string_view approximate, Tensor& out) {
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, out));
+  ET_LOG_AND_RETURN_IF_FALSE(in.scalar_type() != ScalarType::Bool);
   ET_LOG_MSG_AND_RETURN_IF_FALSE(
       approximate == "tanh" || approximate == "none",
       "Invalid approximation format: %.*s for gelu",

--- a/kernels/portable/cpu/util/broadcast_util.cpp
+++ b/kernels/portable/cpu/util/broadcast_util.cpp
@@ -198,7 +198,10 @@ Tensor broadcast_tensor(
       repeats[i] = 1;
     }
   }
-  repeat_tensor(broadcast_from, makeArrayRef(repeats, ndim), out);
+
+  ET_CHECK(
+      repeat_tensor(broadcast_from, makeArrayRef(repeats, ndim), out) ==
+      Error::Ok);
 
   free(repeats);
 

--- a/kernels/portable/cpu/util/broadcast_util.h
+++ b/kernels/portable/cpu/util/broadcast_util.h
@@ -97,7 +97,7 @@ __ET_DEPRECATED exec_aten::Tensor broadcast_tensor(
  * @param[out] out_dim The dimension of the broadcasted target
  * tensor
  */
-[[nodiscard]] Error get_broadcast_target_size(
+__ET_NODISCARD Error get_broadcast_target_size(
     const exec_aten::ArrayRef<Tensor::SizesType> a_size,
     const exec_aten::ArrayRef<Tensor::SizesType> b_size,
     Tensor::SizesType* out_sizes,
@@ -115,7 +115,7 @@ __ET_DEPRECATED exec_aten::Tensor broadcast_tensor(
  * @param[out] out_dim The dimension of the broadcasted target
  * tensor
  */
-[[nodiscard]] Error get_broadcast_target_size(
+__ET_NODISCARD Error get_broadcast_target_size(
     const Tensor& a,
     const Tensor& b,
     Tensor::SizesType* out_sizes,
@@ -130,7 +130,7 @@ __ET_DEPRECATED exec_aten::Tensor broadcast_tensor(
  * @param[in] b The second tensor going to be broadcasted.
  * @param[out] out The output tensor that will be resized.
  */
-[[nodiscard]] inline Error
+__ET_NODISCARD inline Error
 resize_to_broadcast_target_size(const Tensor& a, const Tensor& b, Tensor& out) {
   Tensor::SizesType expected_output_size[kTensorDimensionLimit];
   size_t expected_output_dim = 0;
@@ -156,7 +156,7 @@ resize_to_broadcast_target_size(const Tensor& a, const Tensor& b, Tensor& out) {
  * @param[in] c The third tensor going to be broadcasted.
  * @param[out] out The output tensor that will be resized.
  */
-[[nodiscard]] inline Error resize_to_broadcast_target_size(
+__ET_NODISCARD inline Error resize_to_broadcast_target_size(
     const Tensor& a,
     const Tensor& b,
     const Tensor& c,

--- a/kernels/portable/cpu/util/copy_ops_util.cpp
+++ b/kernels/portable/cpu/util/copy_ops_util.cpp
@@ -114,6 +114,7 @@ bool check_cat_args(
   // Ensure dim is in range.
   ET_LOG_AND_RETURN_IF_FALSE(
       tensors[ref_i].numel() == 0 || tensors[ref_i].dim() > dim);
+  ET_LOG_AND_RETURN_IF_FALSE(dim >= 0);
 
   return true;
 }
@@ -378,6 +379,7 @@ bool check_slice_copy_args(
     int64_t dim,
     int64_t step,
     Tensor& out) {
+  ET_LOG_AND_RETURN_IF_FALSE(in.dim() > 0);
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, out));
   ET_LOG_AND_RETURN_IF_FALSE(tensor_has_dim(in, dim));
   ET_LOG_MSG_AND_RETURN_IF_FALSE(
@@ -737,6 +739,8 @@ bool check_unsqueeze_copy_args(
     const Tensor input,
     int64_t dim,
     const Tensor out) {
+  ET_LOG_AND_RETURN_IF_FALSE(dim >= 0);
+
   // The input and out shall share same dtype
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(input, out));
 

--- a/kernels/portable/cpu/util/kernel_ops_util.cpp
+++ b/kernels/portable/cpu/util/kernel_ops_util.cpp
@@ -462,6 +462,8 @@ bool check_slice_scatter_args(
     int64_t num_values,
     int64_t step,
     Tensor output) {
+  ET_LOG_AND_RETURN_IF_FALSE(input.dim() > 0);
+
   // Check dim. The dim planed to be selected on shall exist in input
   ET_LOG_AND_RETURN_IF_FALSE(dim_is_valid(dim, input.dim()));
 

--- a/kernels/portable/cpu/util/repeat_util.cpp
+++ b/kernels/portable/cpu/util/repeat_util.cpp
@@ -20,12 +20,12 @@ using Tensor = exec_aten::Tensor;
 
 namespace {
 
-void check_repeat_args(
+bool check_repeat_args(
     Tensor self,
     exec_aten::ArrayRef<int64_t> repeats,
     Tensor& out) {
   // Ensure the self tensors list is non-empty.
-  ET_CHECK_MSG(
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
       repeats.size() >= self.dim(),
       "Number of dimensions of repeat dims can not be smaller than number of dimensions of tensor");
 
@@ -34,11 +34,11 @@ void check_repeat_args(
   for (auto repeat : repeats) {
     all_non_negative = all_non_negative && (repeat >= 0);
   }
-  ET_CHECK_MSG(
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
       all_non_negative, "Trying to create tensor with negative dimension");
 
   /// Check if out.size() is legal.
-  ET_CHECK_MSG(
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
       out.dim() == repeats.size(),
       "The dimension of out shall equal size of repeats, but now is %zd and %zd",
       out.dim(),
@@ -47,12 +47,12 @@ void check_repeat_args(
   // Right now we only support the tensors whose dimension is no greater than
   // kTensorDimensionLimit. Only check out tensor because the number of
   // dimension of out tensor shall have more than or equal to self tensor
-  ET_CHECK_MSG(
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
       out.dim() <= kTensorDimensionLimit,
       "The dimension of input and output should not be larger than %zd",
       kTensorDimensionLimit);
 
-  ET_CHECK_SAME_DTYPE2(out, self);
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(out, self));
 
   // We pad one to the beginning of self.size() to make its length equal
   // repeats, and called it reformat_self_size. We then make point-to-point mul
@@ -66,13 +66,15 @@ void check_repeat_args(
     reformat_self_size[out.dim() - 1 - i] = self.size(self.dim() - 1 - i);
   }
   for (size_t i = 0; i < repeats.size(); i++) {
-    ET_CHECK_MSG(
+    ET_LOG_MSG_AND_RETURN_IF_FALSE(
         reformat_self_size[i] * repeats[i] == out.size(i),
         "Expect out size at dimension %zu is %" PRId64 ", but now is %zd",
         i,
         reformat_self_size[i] * repeats[i],
         out.size(i));
   }
+
+  return true;
 }
 
 // Given the indices to a point in an n-D tensor, and the stride (in bytes)
@@ -163,16 +165,19 @@ void repeat_internal(
 
 // TODO(gasoonjia): dynamic allocate array to support tensor dimension larger
 // than kTensorDimensionLimit.
-Tensor& repeat_tensor(
+Error repeat_tensor(
     const Tensor& self,
     exec_aten::ArrayRef<int64_t> repeats,
     Tensor& out) {
-  // Assert that the args are valid.
-  check_repeat_args(self, repeats, out);
+  // Verify that the args are valid.
+  ET_CHECK_OR_RETURN_ERROR(
+      check_repeat_args(self, repeats, out),
+      InvalidArgument,
+      "Repeat arguments are invalid.");
 
   // Returns out if out.numel == 0, nothing needs to be repeated.
   if (out.numel() == 0) {
-    return out;
+    return Error::Ok;
   }
 
   ssize_t element_size = out.element_size();
@@ -183,7 +188,7 @@ Tensor& repeat_tensor(
     const char* src = self.const_data_ptr<char>();
     char* dest = out.mutable_data_ptr<char>();
     memcpy(dest, src, element_size);
-    return out;
+    return Error::Ok;
   }
 
   // Treats zero-dim self as one-dim tensor with size {1}.
@@ -274,7 +279,7 @@ Tensor& repeat_tensor(
     accum_offset *= out.size(i);
   }
 
-  return out;
+  return Error::Ok;
 }
 
 } // namespace executor

--- a/kernels/portable/cpu/util/repeat_util.h
+++ b/kernels/portable/cpu/util/repeat_util.h
@@ -20,9 +20,9 @@ namespace executor {
  * @param[in] The number of times to repeat this tensor along each dimension
  * @param[in] Output tensor to write to.
  *
- * @returns Repeated tensor.
+ * @returns The status of the repeat operation.
  */
-exec_aten::Tensor& repeat_tensor(
+Error repeat_tensor(
     const exec_aten::Tensor& in,
     exec_aten::ArrayRef<int64_t> repeats,
     exec_aten::Tensor& out);

--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -27,6 +27,7 @@ def define_common_targets():
         ],
         exported_headers = ["repeat_util.h"],
         deps = [
+            "//executorch/runtime/kernel:kernel_includes",
             "//executorch/runtime/core/exec_aten/util:scalar_type_util",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
         ],

--- a/kernels/portable/test/op_allclose_test.cpp
+++ b/kernels/portable/test/op_allclose_test.cpp
@@ -11,6 +11,7 @@
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
+#include <executorch/test/utils/DeathTest.h>
 
 #include <gtest/gtest.h>
 #include <cmath>
@@ -188,14 +189,16 @@ TEST(OpAllCloseTest, MismatchedInputShapesDeath) {
   TensorFactory<ScalarType::Bool> tf_bool;
   Tensor out = tf_bool.zeros(/*sizes=*/{1});
 
-  ET_EXPECT_KERNEL_FAILURE(allclose_out(
-      a,
-      b,
-      default_rtol,
-      default_atol,
-      /*equal_nan=*/false,
-      /*dummy_param=*/false,
-      out));
+  ET_EXPECT_DEATH(
+      allclose_out(
+          a,
+          b,
+          default_rtol,
+          default_atol,
+          /*equal_nan=*/false,
+          /*dummy_param=*/false,
+          out),
+      "");
 }
 
 TEST(OpAllCloseTest, MismatchedInputDtypesDeath) {
@@ -208,14 +211,16 @@ TEST(OpAllCloseTest, MismatchedInputDtypesDeath) {
   TensorFactory<ScalarType::Bool> tf_bool;
   Tensor out = tf_bool.zeros(/*sizes=*/{1});
 
-  ET_EXPECT_KERNEL_FAILURE(allclose_out(
-      a,
-      b,
-      default_rtol,
-      default_atol,
-      /*equal_nan=*/false,
-      /*dummy_param=*/false,
-      out));
+  ET_EXPECT_DEATH(
+      allclose_out(
+          a,
+          b,
+          default_rtol,
+          default_atol,
+          /*equal_nan=*/false,
+          /*dummy_param=*/false,
+          out),
+      "");
 }
 
 TEST(OpAllCloseTest, IncorrectOutputDtypeDeath) {
@@ -224,14 +229,16 @@ TEST(OpAllCloseTest, IncorrectOutputDtypeDeath) {
   Tensor b = tf_float.ones(/*sizes=*/{2, 2});
   Tensor out = tf_float.zeros(/*sizes=*/{1});
 
-  ET_EXPECT_KERNEL_FAILURE(allclose_out(
-      a,
-      b,
-      default_rtol,
-      default_atol,
-      /*equal_nan=*/false,
-      /*dummy_param=*/false,
-      out));
+  ET_EXPECT_DEATH(
+      allclose_out(
+          a,
+          b,
+          default_rtol,
+          default_atol,
+          /*equal_nan=*/false,
+          /*dummy_param=*/false,
+          out),
+      "");
 }
 
 TEST(OpAllCloseTest, IncorrectOutputShapeDeath) {
@@ -241,14 +248,16 @@ TEST(OpAllCloseTest, IncorrectOutputShapeDeath) {
   TensorFactory<ScalarType::Bool> tf_bool;
   Tensor out = tf_bool.zeros(/*sizes=*/{2, 2});
 
-  ET_EXPECT_KERNEL_FAILURE(allclose_out(
-      a,
-      b,
-      default_rtol,
-      default_atol,
-      /*equal_nan=*/false,
-      /*dummy_param=*/false,
-      out));
+  ET_EXPECT_DEATH(
+      allclose_out(
+          a,
+          b,
+          default_rtol,
+          default_atol,
+          /*equal_nan=*/false,
+          /*dummy_param=*/false,
+          out),
+      "");
 }
 
 TEST(OpAllCloseTest, FloatTensorsVaryWithinRelativeTolerance) {

--- a/kernels/portable/test/op_div_test.cpp
+++ b/kernels/portable/test/op_div_test.cpp
@@ -27,25 +27,29 @@ using torch::executor::testing::TensorFactory;
 // If your test case is generic and should be tested on all kernels, add it to
 // executorch/kernels/test/op_div_test.cpp instead.
 
-Tensor& op_div_out_mode(
-    const Tensor& a,
-    const Tensor& b,
-    exec_aten::optional<exec_aten::string_view> mode,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::div_outf(context, a, b, mode, out);
-}
+class OpDivScalarOutKernelTest : public OperatorTest {
+ protected:
+  Tensor& op_div_out_mode(
+      const Tensor& a,
+      const Tensor& b,
+      exec_aten::optional<exec_aten::string_view> mode,
+      Tensor& out) {
+    return torch::executor::aten::div_outf(context_, a, b, mode, out);
+  }
+};
 
-Tensor& op_div_scalar_mode_out(
-    const Tensor& a,
-    const Scalar& b,
-    exec_aten::optional<exec_aten::string_view> mode,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::div_outf(context, a, b, mode, out);
-}
+class OpDivScalarModeOutKernelTest : public OperatorTest {
+ protected:
+  Tensor& op_div_scalar_mode_out(
+      const Tensor& a,
+      const Scalar& b,
+      exec_aten::optional<exec_aten::string_view> mode,
+      Tensor& out) {
+    return torch::executor::aten::div_outf(context_, a, b, mode, out);
+  }
+};
 
-TEST(OpDivScalarOutKernelTest, SanityCheckModeTrunc) {
+TEST_F(OpDivScalarOutKernelTest, SanityCheckModeTrunc) {
   TensorFactory<ScalarType::Int> tf_a;
   TensorFactory<ScalarType::Float> tf_out;
 
@@ -63,7 +67,7 @@ TEST(OpDivScalarOutKernelTest, SanityCheckModeTrunc) {
   EXPECT_TENSOR_EQ(out, tf_out.make(sizes, {0.0, 1.0, 2.0, -4.0}));
 }
 
-TEST(OpDivScalarOutKernelTest, SanityCheckModeFloor) {
+TEST_F(OpDivScalarOutKernelTest, SanityCheckModeFloor) {
   TensorFactory<ScalarType::Int> tf_a;
   TensorFactory<ScalarType::Float> tf_out;
 
@@ -81,7 +85,7 @@ TEST(OpDivScalarOutKernelTest, SanityCheckModeFloor) {
   EXPECT_TENSOR_EQ(out, tf_out.make(sizes, {0.0, 1.0, 2.0, -5.0}));
 }
 
-TEST(OpDivScalarModeOutKernelTest, SanityCheckModeTrunc) {
+TEST_F(OpDivScalarModeOutKernelTest, SanityCheckModeTrunc) {
   TensorFactory<ScalarType::Int> tf_a;
   TensorFactory<ScalarType::Float> tf_out;
 
@@ -99,7 +103,7 @@ TEST(OpDivScalarModeOutKernelTest, SanityCheckModeTrunc) {
   EXPECT_TENSOR_EQ(out, tf_out.make(sizes, {0.0, 1.0, 2.0, -4.0}));
 }
 
-TEST(OpDivScalarModeOutKernelTest, SanityCheckModeFloor) {
+TEST_F(OpDivScalarModeOutKernelTest, SanityCheckModeFloor) {
   TensorFactory<ScalarType::Int> tf_a;
   TensorFactory<ScalarType::Float> tf_out;
 

--- a/kernels/portable/test/op_mul_test.cpp
+++ b/kernels/portable/test/op_mul_test.cpp
@@ -26,12 +26,14 @@ using torch::executor::testing::TensorFactory;
 // If your test case is generic and should be tested on all kernels, add it to
 // executorch/kernels/test/op_mul_test.cpp instead.
 
-Tensor& mul_out(const Tensor& self, const Tensor& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::native::mul_out(context, self, other, out);
-}
+class OpMulOutKernelTest : public OperatorTest {
+ protected:
+  Tensor& mul_out(const Tensor& self, const Tensor& other, Tensor& out) {
+    return torch::executor::native::mul_out(context_, self, other, out);
+  }
+};
 
-TEST(OpMulOutKernelTest, UnhandledDtypeDies) {
+TEST_F(OpMulOutKernelTest, UnhandledDtypeDies) {
   // mul_out() doesn't handle QInt8.
   // TensorFactory cannot be used with ScalarType::QInt8 since
   // torch::executor::qint8 does not have a default constructor. It must be
@@ -64,5 +66,5 @@ TEST(OpMulOutKernelTest, UnhandledDtypeDies) {
 
   // Multiplying the two QInt8 tensors should cause an assertion and
   // kill the test process.
-  ET_EXPECT_KERNEL_FAILURE(mul_out(a, b, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, mul_out(a, b, out));
 }

--- a/kernels/quantized/cpu/op_mixed_mm.cpp
+++ b/kernels/quantized/cpu/op_mixed_mm.cpp
@@ -57,23 +57,15 @@ Tensor& quantized_mixed_mm_out(
     const Tensor& weight_scales,
     const optional<Tensor>& opt_weight_zero_points,
     Tensor& out) {
-  ET_KERNEL_CHECK(
-      ctx,
-      check_quantized_mixed_mm_args(
-          in, weight, weight_scales, opt_weight_zero_points, out),
-      InvalidArgument,
-      out);
+  ET_CHECK(check_quantized_mixed_mm_args(
+      in, weight, weight_scales, opt_weight_zero_points, out));
 
   size_t output_ndim = 2;
   exec_aten::SizesType output_sizes[kTensorDimensionLimit];
   output_sizes[0] = in.size(0);
   output_sizes[1] = weight.size(1);
 
-  ET_KERNEL_CHECK(
-      ctx,
-      resize_tensor(out, {output_sizes, output_ndim}) == Error::Ok,
-      InvalidArgument,
-      out);
+  ET_CHECK(resize_tensor(out, {output_sizes, output_ndim}) == Error::Ok);
 
   constexpr auto name = "quantized_decomposed::mixed_mm.out";
 

--- a/kernels/test/TestUtil.h
+++ b/kernels/test/TestUtil.h
@@ -13,6 +13,9 @@
 
 #pragma once
 
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/kernel/kernel_includes.h>
+#include <executorch/runtime/platform/runtime.h>
 #include <executorch/test/utils/DeathTest.h>
 #include <gtest/gtest.h>
 
@@ -21,16 +24,62 @@
  * Ensure the kernel will fail when `_statement` is executed.
  * @param _statement Statement to execute.
  */
-#define ET_EXPECT_KERNEL_FAILURE(_statement) EXPECT_ANY_THROW(_statement)
+#define ET_EXPECT_KERNEL_FAILURE(_context, _statement) \
+  EXPECT_ANY_THROW(_statement)
 
-#define ET_EXPECT_KERNEL_FAILURE_WITH_MSG(_statement, _matcher) \
+#define ET_EXPECT_KERNEL_FAILURE_WITH_MSG(_context, _statement, _matcher) \
   EXPECT_ANY_THROW(_statement)
 
 #else
 
-#define ET_EXPECT_KERNEL_FAILURE(_statement) ET_EXPECT_DEATH(_statement, "")
+#define ET_EXPECT_KERNEL_FAILURE(_context, _statement)              \
+  do {                                                              \
+    _statement;                                                     \
+    expect_failure();                                               \
+    if ((_context).failure_state() == torch::executor::Error::Ok) { \
+      ET_LOG(Error, "Expected kernel failure but found success.");  \
+      ADD_FAILURE();                                                \
+    }                                                               \
+  } while (false)
 
-#define ET_EXPECT_KERNEL_FAILURE_WITH_MSG(_statement, _matcher) \
-  ET_EXPECT_DEATH(_statement, _matcher)
+#define ET_EXPECT_KERNEL_FAILURE_WITH_MSG(_context, _statement, _msg) \
+  do {                                                                \
+    _statement;                                                       \
+    expect_failure();                                                 \
+    if ((_context).failure_state() == torch::executor::Error::Ok) {   \
+      ET_LOG(Error, "Expected kernel failure but found success.");    \
+      ADD_FAILURE();                                                  \
+    }                                                                 \
+  } while (false)
 
 #endif // USE_ATEN_LIB
+
+/*
+ * Common test fixture for kernel / operator-level tests. Provides
+ * a runtime context object and verifies failure state post-execution.
+ */
+class OperatorTest : public ::testing::Test {
+ public:
+  OperatorTest() : expect_failure_(false) {}
+
+  void SetUp() override {
+    torch::executor::runtime_init();
+  }
+
+  void TearDown() override {
+    // Validate error state.
+    if (!expect_failure_) {
+      EXPECT_EQ(context_.failure_state(), torch::executor::Error::Ok);
+    } else {
+      EXPECT_NE(context_.failure_state(), torch::executor::Error::Ok);
+    }
+  }
+
+  void expect_failure() {
+    expect_failure_ = true;
+  }
+
+ protected:
+  exec_aten::RuntimeContext context_;
+  bool expect_failure_;
+};

--- a/kernels/test/op_abs_test.cpp
+++ b/kernels/test/op_abs_test.cpp
@@ -19,12 +19,14 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_abs_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::abs_outf(context, self, out);
-}
+class OpAbsTest : public OperatorTest {
+ protected:
+  Tensor& op_abs_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::abs_outf(context_, self, out);
+  }
+};
 
-TEST(OpAbsTest, SanityCheck) {
+TEST_F(OpAbsTest, SanityCheck) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor in = tf.make({1, 7}, {-3.0, -2.5, -1.01, 0.0, 1.01, 2.5, 3.0});

--- a/kernels/test/op_acos_test.cpp
+++ b/kernels/test/op_acos_test.cpp
@@ -21,12 +21,49 @@ using exec_aten::Tensor;
 using exec_aten::TensorShapeDynamism;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_acos_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::acos_outf(context, self, out);
-}
+class OpAcosOutTest : public OperatorTest {
+ protected:
+  Tensor& op_acos_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::acos_outf(context_, self, out);
+  }
 
-TEST(OpAcosOutKernelTest, HandleBoolInput) {
+  // Common testing for acos operator and all kinds of supported input types
+  template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
+  void test_floating_point_acos_out(
+      const std::vector<int32_t>& out_shape = {1, 6},
+      TensorShapeDynamism dynamism = TensorShapeDynamism::STATIC) {
+    TensorFactory<IN_DTYPE> tf_in;
+    TensorFactory<OUT_DTYPE> tf_out;
+
+    // Destination for the acos operator.
+    Tensor out = tf_out.zeros(out_shape, dynamism);
+
+    // clang-format off
+    op_acos_out(tf_in.make({1, 6}, { 0, 1, 3, 5, 10, 100 }), out);
+
+    // Check that it matches (or close to) the expected output.
+    EXPECT_TENSOR_CLOSE(
+        out,
+        tf_out.make({1, 6}, { 1.570796, 0.000000, NAN, NAN, NAN, NAN }));
+    // clang-format on
+  }
+
+  // Unhandled output dtypes.
+  template <ScalarType INPUT_DTYPE, ScalarType OUTPUT_DTYPE>
+  void test_acos_invalid_output_dtype_dies() {
+    TensorFactory<INPUT_DTYPE> tf;
+    TensorFactory<OUTPUT_DTYPE> tf_out;
+
+    const std::vector<int32_t> sizes = {2, 5};
+
+    Tensor in = tf.ones(sizes);
+    Tensor out = tf_out.zeros(sizes);
+
+    ET_EXPECT_KERNEL_FAILURE(context_, op_acos_out(in, out));
+  }
+};
+
+TEST_F(OpAcosOutTest, HandleBoolInput) {
   TensorFactory<ScalarType::Bool> tf_bool;
   TensorFactory<ScalarType::Float> tf_float;
 
@@ -39,28 +76,7 @@ TEST(OpAcosOutKernelTest, HandleBoolInput) {
   EXPECT_TENSOR_CLOSE(op_acos_out(a, out), res);
 }
 
-// Common testing for acos operator and all kinds of supported input types
-template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
-void test_floating_point_acos_out(
-    const std::vector<int32_t>& out_shape = {1, 6},
-    TensorShapeDynamism dynamism = TensorShapeDynamism::STATIC) {
-  TensorFactory<IN_DTYPE> tf_in;
-  TensorFactory<OUT_DTYPE> tf_out;
-
-  // Destination for the acos operator.
-  Tensor out = tf_out.zeros(out_shape, dynamism);
-
-  // clang-format off
-  op_acos_out(tf_in.make({1, 6}, { 0, 1, 3, 5, 10, 100 }), out);
-
-  // Check that it matches (or close to) the expected output.
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf_out.make({1, 6}, { 1.570796, 0.000000, NAN, NAN, NAN, NAN }));
-  // clang-format on
-}
-
-TEST(OpAcosOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+TEST_F(OpAcosOutTest, AllRealInputHalfOutputStaticDynamismSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -70,21 +86,21 @@ TEST(OpAcosOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAcosOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
+TEST_F(OpAcosOutTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_acos_out<ScalarType::dtype, ScalarType::Float>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpAcosOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
+TEST_F(OpAcosOutTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_acos_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpAcosOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+TEST_F(OpAcosOutTest, AllRealInputHalfOutputBoundDynamismSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -95,7 +111,7 @@ TEST(OpAcosOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAcosOutKernelTest, AllRealInputFloatOutputBoundDynamismSupport) {
+TEST_F(OpAcosOutTest, AllRealInputFloatOutputBoundDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype)                                      \
   test_floating_point_acos_out<ScalarType::dtype, ScalarType::Float>( \
       {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
@@ -103,7 +119,7 @@ TEST(OpAcosOutKernelTest, AllRealInputFloatOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAcosOutKernelTest, AllRealInputDoubleOutputBoundDynamismSupport) {
+TEST_F(OpAcosOutTest, AllRealInputDoubleOutputBoundDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype)                                       \
   test_floating_point_acos_out<ScalarType::dtype, ScalarType::Double>( \
       {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
@@ -111,7 +127,7 @@ TEST(OpAcosOutKernelTest, AllRealInputDoubleOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAcosOutKernelTest, AllRealInputFloatOutputUnboundDynamismSupport) {
+TEST_F(OpAcosOutTest, AllRealInputFloatOutputUnboundDynamismSupport) {
   if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }
@@ -122,7 +138,7 @@ TEST(OpAcosOutKernelTest, AllRealInputFloatOutputUnboundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAcosOutKernelTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
+TEST_F(OpAcosOutTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
   if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }
@@ -133,21 +149,7 @@ TEST(OpAcosOutKernelTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-// Unhandled output dtypes.
-template <ScalarType INPUT_DTYPE, ScalarType OUTPUT_DTYPE>
-void test_acos_invalid_output_dtype_dies() {
-  TensorFactory<INPUT_DTYPE> tf;
-  TensorFactory<OUTPUT_DTYPE> tf_out;
-
-  const std::vector<int32_t> sizes = {2, 5};
-
-  Tensor in = tf.ones(sizes);
-  Tensor out = tf_out.zeros(sizes);
-
-  ET_EXPECT_KERNEL_FAILURE(op_acos_out(in, out));
-}
-
-TEST(OpAcosOutKernelTest, AllNonFloatOutputDTypeDies) {
+TEST_F(OpAcosOutTest, AllNonFloatOutputDTypeDies) {
 #define TEST_ENTRY(ctype, dtype) \
   test_acos_invalid_output_dtype_dies<ScalarType::Float, ScalarType::dtype>();
   ET_FORALL_INT_TYPES(TEST_ENTRY);
@@ -155,7 +157,7 @@ TEST(OpAcosOutKernelTest, AllNonFloatOutputDTypeDies) {
 }
 
 // Mismatched shape tests.
-TEST(OpAcosOutKernelTest, MismatchedInputShapesDies) {
+TEST_F(OpAcosOutTest, MismatchedInputShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched input shapes";
   }
@@ -164,5 +166,5 @@ TEST(OpAcosOutKernelTest, MismatchedInputShapesDies) {
   Tensor a = tf.ones(/*sizes=*/{4});
   Tensor out = tf.ones(/*sizes=*/{2, 2});
 
-  ET_EXPECT_KERNEL_FAILURE(op_acos_out(a, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_acos_out(a, out));
 }

--- a/kernels/test/op_alias_copy_test.cpp
+++ b/kernels/test/op_alias_copy_test.cpp
@@ -17,9 +17,11 @@
 
 using namespace ::testing;
 
-exec_aten::Tensor& op_alias_copy_out(
-    const exec_aten::Tensor& self,
-    exec_aten::Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::alias_copy_outf(context, self, out);
-}
+class OpAliasCopyTest : public OperatorTest {
+ protected:
+  exec_aten::Tensor& op_alias_copy_out(
+      const exec_aten::Tensor& self,
+      exec_aten::Tensor& out) {
+    return torch::executor::aten::alias_copy_outf(context_, self, out);
+  }
+};

--- a/kernels/test/op_amin_test.cpp
+++ b/kernels/test/op_amin_test.cpp
@@ -23,46 +23,212 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_amin_out(
-    const Tensor& in,
-    ArrayRef<int64_t> dim,
-    bool keepdim,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::amin_outf(context, in, dim, keepdim, out);
-}
+class OpAminOutTest : public OperatorTest {
+ protected:
+  Tensor& op_amin_out(
+      const Tensor& in,
+      ArrayRef<int64_t> dim,
+      bool keepdim,
+      Tensor& out) {
+    return torch::executor::aten::amin_outf(context_, in, dim, keepdim, out);
+  }
 
-template <ScalarType DTYPE>
-void test_amin_out_invalid_dimensions() {
-  TensorFactory<DTYPE> tf;
+  template <ScalarType DTYPE>
+  void test_amin_out_invalid_dimensions() {
+    TensorFactory<DTYPE> tf;
 
-  // clang-format off
-  Tensor in = tf.make(
-    {2, 3, 4},
-    {
-      0, 1, 2, 4,
-      4, 2, 1, 0,
-      1, 0, 4, 2,
+    // clang-format off
+    Tensor in = tf.make(
+      {2, 3, 4},
+      {
+        0, 1, 2, 4,
+        4, 2, 1, 0,
+        1, 0, 4, 2,
 
-      4, 2, 1, 0,
-      0, 1, 2, 4,
-      1, 0, 4, 2,
-    });
-  // clang-format on
-  Tensor out = tf.zeros({2, 3, 1});
+        4, 2, 1, 0,
+        0, 1, 2, 4,
+        1, 0, 4, 2,
+      });
+    // clang-format on
+    Tensor out = tf.zeros({2, 3, 1});
 
-  // out-of-bound dim in dim list
-  int64_t dims_1[1] = {3};
-  ArrayRef<int64_t> dim_list{ArrayRef<int64_t>{dims_1, 1}};
-  ET_EXPECT_DEATH(op_amin_out(in, dim_list, /*keepdim=*/true, out), "");
+    // out-of-bound dim in dim list
+    int64_t dims_1[1] = {3};
+    ArrayRef<int64_t> dim_list{ArrayRef<int64_t>{dims_1, 1}};
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, op_amin_out(in, dim_list, /*keepdim=*/true, out));
 
-  // the same dim appears multiple times in list of dims
-  int64_t dims_2[2] = {2, 2};
-  dim_list = ArrayRef<int64_t>{dims_2, 2};
-  ET_EXPECT_DEATH(op_amin_out(in, dim_list, /*keepdim=*/true, out), "");
-}
+    // the same dim appears multiple times in list of dims
+    int64_t dims_2[2] = {2, 2};
+    dim_list = ArrayRef<int64_t>{dims_2, 2};
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, op_amin_out(in, dim_list, /*keepdim=*/true, out));
+  }
 
-TEST(OpAminOutTest, InvalidDimensionListDies) {
+  template <ScalarType DTYPE>
+  void test_amin_out_invalid_shape() {
+    TensorFactory<DTYPE> tf;
+
+    // clang-format off
+    Tensor in = tf.make(
+      {2, 3, 4},
+      {
+        0, 1, 2, 4,
+        4, 2, 1, 0,
+        1, 0, 4, 2,
+
+        4, 2, 1, 0,
+        0, 1, 2, 4,
+        1, 0, 4, 2,
+      });
+    // clang-format on
+
+    // dimension size mismatch when keepdim is true
+    Tensor out = tf.zeros({2, 4});
+
+    int64_t dims_1[1] = {1};
+    ArrayRef<int64_t> dim_list{ArrayRef<int64_t>{dims_1, 1}};
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, op_amin_out(in, dim_list, /*keepdim=*/true, out));
+
+    // dimension size mismatch when keepdim is false
+    out = tf.zeros({2, 1, 4});
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, op_amin_out(in, dim_list, /*keepdim=*/false, out));
+  }
+
+  template <ScalarType DTYPE>
+  void test_amin_out_dtype() {
+    TensorFactory<DTYPE> tf;
+    // clang-format off
+    Tensor in = tf.make(
+      {2, 3, 4},
+      {
+        0, 1, 2, 4,
+        4, 2, 1, 0,
+        1, 5, 4, 2,
+
+        4, 2, 1, 0,
+        5, 1, 2, 4,
+        7, 5, 4, 2,
+      });
+    // clang-format on
+
+    // keepdim=true should work
+    Tensor out = tf.zeros({2, 3, 1});
+    int64_t dims_1[1] = {2};
+    ArrayRef<int64_t> dim_list{ArrayRef<int64_t>{dims_1, 1}};
+
+    op_amin_out(in, dim_list, /*keepdim=*/true, out);
+    // clang-format off
+    EXPECT_TENSOR_CLOSE(out, tf.make(
+      {2, 3, 1},
+      {0, 0, 1, 0, 1, 2}));
+    // clang-format on
+
+    // keepdim=false should work
+    out = tf.zeros({2, 3});
+    op_amin_out(in, dim_list, /*keepdim=*/false, out);
+    // clang-format off
+    EXPECT_TENSOR_CLOSE(out, tf.make(
+      {2, 3},
+      {0, 0, 1, 0, 1, 2}));
+    // clang-format on
+
+    // dim list with multiple dimensions should work
+    out = tf.zeros({1, 1, 4});
+    int64_t dims_2[2] = {0, 1};
+    dim_list = ArrayRef<int64_t>{dims_2, 2};
+    op_amin_out(in, dim_list, /*keepdim=*/true, out);
+    EXPECT_TENSOR_CLOSE(out, tf.make({1, 1, 4}, {0, 1, 1, 0}));
+
+    out = tf.zeros({4});
+    op_amin_out(in, dim_list, /*keepdim=*/false, out);
+    EXPECT_TENSOR_CLOSE(out, tf.make({4}, {0, 1, 1, 0}));
+
+    // dim list with negative dimensions should work
+    out = tf.zeros({2, 1, 4});
+    int64_t dims_3[1] = {-2};
+    dim_list = ArrayRef<int64_t>{dims_3, 1};
+    op_amin_out(in, dim_list, /*keepdim=*/true, out);
+    // clang-format off
+    EXPECT_TENSOR_CLOSE(out, tf.make(
+      {2, 1, 4},
+      {
+        0, 1, 1, 0,
+
+        4, 1, 1, 0,
+      }));
+    // clang-format on
+
+    // empty/null dim list should work
+    // clang-format off
+    in = tf.make(
+      {2, 2, 4},
+      {
+        8, 7, 5, 4,
+        4, 3, 7, 9,
+
+        4, 2, 6, 8,
+        8, 7, 3, 4,
+      });
+    // clang-format on
+    out = tf.zeros({1, 1, 1});
+    ArrayRef<int64_t> null_dim_list;
+    op_amin_out(in, null_dim_list, /*keepdim=*/true, out);
+    EXPECT_TENSOR_CLOSE(out, tf.make({1, 1, 1}, {2}));
+
+    ArrayRef<int64_t> empty_dim_list{ArrayRef<int64_t>{}};
+    op_amin_out(in, empty_dim_list, /*keepdim=*/true, out);
+    EXPECT_TENSOR_CLOSE(out, tf.make({1, 1, 1}, {2}));
+
+    out = tf.zeros({});
+    op_amin_out(in, null_dim_list, /*keepdim=*/false, out);
+    EXPECT_TENSOR_CLOSE(out, tf.make({}, {2}));
+
+    op_amin_out(in, empty_dim_list, /*keepdim=*/false, out);
+    EXPECT_TENSOR_CLOSE(out, tf.make({}, {2}));
+  }
+
+  template <>
+  void test_amin_out_dtype<ScalarType::Bool>() {
+    TensorFactory<ScalarType::Bool> tf_bool;
+    // clang-format off
+    Tensor in = tf_bool.make(
+      {2, 3, 4},
+      {
+        true,  false, true,  false,
+        false, false, false, false,
+        false, true,  true,  false,
+
+        false, false, true,  false,
+        false, false, false, true,
+        true,  true,  true,  true,
+      });
+    // clang-format on
+
+    Tensor out = tf_bool.zeros({2, 3, 1});
+
+    // +/-inf and nan should work
+    op_amin_out(in, /*dim=*/-1, /*keepdim=*/true, out);
+    // clang-format off
+    EXPECT_TENSOR_CLOSE(
+        out, tf_bool.make(
+          {2, 3, 1},
+          {
+            false,
+            false,
+            false,
+
+            false,
+            false,
+            true
+          }));
+    // clang-format on
+  }
+};
+
+TEST_F(OpAminOutTest, InvalidDimensionListDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel test fails";
   }
@@ -72,37 +238,7 @@ TEST(OpAminOutTest, InvalidDimensionListDies) {
 #undef TEST_ENTRY
 }
 
-template <ScalarType DTYPE>
-void test_amin_out_invalid_shape() {
-  TensorFactory<DTYPE> tf;
-
-  // clang-format off
-  Tensor in = tf.make(
-    {2, 3, 4},
-    {
-      0, 1, 2, 4,
-      4, 2, 1, 0,
-      1, 0, 4, 2,
-
-      4, 2, 1, 0,
-      0, 1, 2, 4,
-      1, 0, 4, 2,
-    });
-  // clang-format on
-
-  // dimension size mismatch when keepdim is true
-  Tensor out = tf.zeros({2, 4});
-
-  int64_t dims_1[1] = {1};
-  ArrayRef<int64_t> dim_list{ArrayRef<int64_t>{dims_1, 1}};
-  ET_EXPECT_DEATH(op_amin_out(in, dim_list, /*keepdim=*/true, out), "");
-
-  // dimension size mismatch when keepdim is false
-  out = tf.zeros({2, 1, 4});
-  ET_EXPECT_DEATH(op_amin_out(in, dim_list, /*keepdim=*/false, out), "");
-}
-
-TEST(OpAminOutTest, InvalidShapeDies) {
+TEST_F(OpAminOutTest, InvalidShapeDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel test fails";
   }
@@ -112,7 +248,7 @@ TEST(OpAminOutTest, InvalidShapeDies) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAminOutTest, MismatchedDTypesDies) {
+TEST_F(OpAminOutTest, MismatchedDTypesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel test fails";
   }
@@ -138,146 +274,17 @@ TEST(OpAminOutTest, MismatchedDTypesDies) {
   ArrayRef<int64_t> dim_list{ArrayRef<int64_t>{dims_1, 1}};
 
   // out tensor should be of the same dtype with dtype when dtype is specified
-  ET_EXPECT_DEATH(op_amin_out(in, dim_list, /*keepdim=*/true, out), "");
+  ET_EXPECT_KERNEL_FAILURE(
+      context_, op_amin_out(in, dim_list, /*keepdim=*/true, out));
 }
 
-template <ScalarType DTYPE>
-void test_amin_out_dtype() {
-  TensorFactory<DTYPE> tf;
-  // clang-format off
-  Tensor in = tf.make(
-    {2, 3, 4},
-    {
-      0, 1, 2, 4,
-      4, 2, 1, 0,
-      1, 5, 4, 2,
-
-      4, 2, 1, 0,
-      5, 1, 2, 4,
-      7, 5, 4, 2,
-    });
-  // clang-format on
-
-  // keepdim=true should work
-  Tensor out = tf.zeros({2, 3, 1});
-  int64_t dims_1[1] = {2};
-  ArrayRef<int64_t> dim_list{ArrayRef<int64_t>{dims_1, 1}};
-
-  op_amin_out(in, dim_list, /*keepdim=*/true, out);
-  // clang-format off
-  EXPECT_TENSOR_CLOSE(out, tf.make(
-    {2, 3, 1},
-    {0, 0, 1, 0, 1, 2}));
-  // clang-format on
-
-  // keepdim=false should work
-  out = tf.zeros({2, 3});
-  op_amin_out(in, dim_list, /*keepdim=*/false, out);
-  // clang-format off
-  EXPECT_TENSOR_CLOSE(out, tf.make(
-    {2, 3},
-    {0, 0, 1, 0, 1, 2}));
-  // clang-format on
-
-  // dim list with multiple dimensions should work
-  out = tf.zeros({1, 1, 4});
-  int64_t dims_2[2] = {0, 1};
-  dim_list = ArrayRef<int64_t>{dims_2, 2};
-  op_amin_out(in, dim_list, /*keepdim=*/true, out);
-  EXPECT_TENSOR_CLOSE(out, tf.make({1, 1, 4}, {0, 1, 1, 0}));
-
-  out = tf.zeros({4});
-  op_amin_out(in, dim_list, /*keepdim=*/false, out);
-  EXPECT_TENSOR_CLOSE(out, tf.make({4}, {0, 1, 1, 0}));
-
-  // dim list with negative dimensions should work
-  out = tf.zeros({2, 1, 4});
-  int64_t dims_3[1] = {-2};
-  dim_list = ArrayRef<int64_t>{dims_3, 1};
-  op_amin_out(in, dim_list, /*keepdim=*/true, out);
-  // clang-format off
-  EXPECT_TENSOR_CLOSE(out, tf.make(
-    {2, 1, 4},
-    {
-      0, 1, 1, 0,
-
-      4, 1, 1, 0,
-    }));
-  // clang-format on
-
-  // empty/null dim list should work
-  // clang-format off
-  in = tf.make(
-    {2, 2, 4},
-    {
-      8, 7, 5, 4,
-      4, 3, 7, 9,
-
-      4, 2, 6, 8,
-      8, 7, 3, 4,
-    });
-  // clang-format on
-  out = tf.zeros({1, 1, 1});
-  ArrayRef<int64_t> null_dim_list;
-  op_amin_out(in, null_dim_list, /*keepdim=*/true, out);
-  EXPECT_TENSOR_CLOSE(out, tf.make({1, 1, 1}, {2}));
-
-  ArrayRef<int64_t> empty_dim_list{ArrayRef<int64_t>{}};
-  op_amin_out(in, empty_dim_list, /*keepdim=*/true, out);
-  EXPECT_TENSOR_CLOSE(out, tf.make({1, 1, 1}, {2}));
-
-  out = tf.zeros({});
-  op_amin_out(in, null_dim_list, /*keepdim=*/false, out);
-  EXPECT_TENSOR_CLOSE(out, tf.make({}, {2}));
-
-  op_amin_out(in, empty_dim_list, /*keepdim=*/false, out);
-  EXPECT_TENSOR_CLOSE(out, tf.make({}, {2}));
-}
-
-template <>
-void test_amin_out_dtype<ScalarType::Bool>() {
-  TensorFactory<ScalarType::Bool> tf_bool;
-  // clang-format off
-  Tensor in = tf_bool.make(
-    {2, 3, 4},
-    {
-      true,  false, true,  false,
-      false, false, false, false,
-      false, true,  true,  false,
-
-      false, false, true,  false,
-      false, false, false, true,
-      true,  true,  true,  true,
-    });
-  // clang-format on
-
-  Tensor out = tf_bool.zeros({2, 3, 1});
-
-  // +/-inf and nan should work
-  op_amin_out(in, /*dim=*/-1, /*keepdim=*/true, out);
-  // clang-format off
-  EXPECT_TENSOR_CLOSE(
-      out, tf_bool.make(
-        {2, 3, 1},
-        {
-          false,
-          false,
-          false,
-
-          false,
-          false,
-          true
-        }));
-  // clang-format on
-}
-
-TEST(OpAminOutTest, AllRealInputOutputPasses) {
+TEST_F(OpAminOutTest, AllRealInputOutputPasses) {
 #define TEST_ENTRY(ctype, dtype) test_amin_out_dtype<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpAminOutTest, InfinityAndNANTest) {
+TEST_F(OpAminOutTest, InfinityAndNANTest) {
   TensorFactory<ScalarType::Float> tf_float;
   // clang-format off
   Tensor in = tf_float.make(

--- a/kernels/test/op_argmax_test.cpp
+++ b/kernels/test/op_argmax_test.cpp
@@ -22,16 +22,18 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_argmax_out(
-    const Tensor& in,
-    optional<int64_t> dim,
-    bool keepdim,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::argmax_outf(context, in, dim, keepdim, out);
-}
+class OpArgmaxTest : public OperatorTest {
+ protected:
+  Tensor& op_argmax_out(
+      const Tensor& in,
+      optional<int64_t> dim,
+      bool keepdim,
+      Tensor& out) {
+    return torch::executor::aten::argmax_outf(context_, in, dim, keepdim, out);
+  }
+};
 
-TEST(OpArgmaxTest, SanityCheckLong) {
+TEST_F(OpArgmaxTest, SanityCheckLong) {
   TensorFactory<ScalarType::Long> tf;
 
   // clang-format off
@@ -56,7 +58,7 @@ TEST(OpArgmaxTest, SanityCheckLong) {
   // clang-format on
 }
 
-TEST(OpArgmaxTest, SanityCheckShort) {
+TEST_F(OpArgmaxTest, SanityCheckShort) {
   TensorFactory<ScalarType::Long> tfl;
   TensorFactory<ScalarType::Short> tfs;
 
@@ -82,7 +84,7 @@ TEST(OpArgmaxTest, SanityCheckShort) {
   // clang-format on
 }
 
-TEST(OpArgmaxTest, SanityCheckNullDim) {
+TEST_F(OpArgmaxTest, SanityCheckNullDim) {
   TensorFactory<ScalarType::Long> tf;
 
   // clang-format off

--- a/kernels/test/op_argmin_test.cpp
+++ b/kernels/test/op_argmin_test.cpp
@@ -22,16 +22,18 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_argmin_out(
-    const Tensor& in,
-    optional<int64_t> dim,
-    bool keepdim,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::argmin_outf(context, in, dim, keepdim, out);
-}
+class OpArgminTest : public OperatorTest {
+ protected:
+  Tensor& op_argmin_out(
+      const Tensor& in,
+      optional<int64_t> dim,
+      bool keepdim,
+      Tensor& out) {
+    return torch::executor::aten::argmin_outf(context_, in, dim, keepdim, out);
+  }
+};
 
-TEST(OpArgminTest, SanityCheckLong) {
+TEST_F(OpArgminTest, SanityCheckLong) {
   TensorFactory<ScalarType::Long> tf;
 
   // clang-format off
@@ -56,7 +58,7 @@ TEST(OpArgminTest, SanityCheckLong) {
   // clang-format on
 }
 
-TEST(OpArgminTest, SanityCheckShort) {
+TEST_F(OpArgminTest, SanityCheckShort) {
   TensorFactory<ScalarType::Long> tfl;
   TensorFactory<ScalarType::Short> tfs;
 
@@ -82,7 +84,7 @@ TEST(OpArgminTest, SanityCheckShort) {
   // clang-format on
 }
 
-TEST(OpArgminTest, SanityCheckNullDim) {
+TEST_F(OpArgminTest, SanityCheckNullDim) {
   TensorFactory<ScalarType::Long> tf;
 
   // clang-format off

--- a/kernels/test/op_as_strided_copy_test.cpp
+++ b/kernels/test/op_as_strided_copy_test.cpp
@@ -25,166 +25,180 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_as_strided_copy_out(
-    const Tensor& self,
-    ArrayRef<int64_t> size,
-    ArrayRef<int64_t> stride,
-    optional<int64_t> storage_offset,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::as_strided_copy_outf(
-      context, self, size, stride, storage_offset, out);
-}
+class OpAsStridedCopyOutTest : public OperatorTest {
+ protected:
+  Tensor& op_as_strided_copy_out(
+      const Tensor& self,
+      ArrayRef<int64_t> size,
+      ArrayRef<int64_t> stride,
+      optional<int64_t> storage_offset,
+      Tensor& out) {
+    return torch::executor::aten::as_strided_copy_outf(
+        context_, self, size, stride, storage_offset, out);
+  }
 
-// Common testing for eq operator
-template <ScalarType DTYPE>
-void test_detach_copy_out() {
-  TensorFactory<DTYPE> tf;
-  const std::vector<int32_t> in_sizes = {3, 3};
-  const std::vector<int32_t> out_sizes = {2, 2, 2};
+  // Common testing for eq operator
+  template <ScalarType DTYPE>
+  void test_detach_copy_out() {
+    TensorFactory<DTYPE> tf;
+    const std::vector<int32_t> in_sizes = {3, 3};
+    const std::vector<int32_t> out_sizes = {2, 2, 2};
 
-  Tensor in = tf.make(in_sizes, {1, 2, 3, 4, 5, 6, 7, 8, 9});
-  Tensor out = tf.zeros(out_sizes);
+    Tensor in = tf.make(in_sizes, {1, 2, 3, 4, 5, 6, 7, 8, 9});
+    Tensor out = tf.zeros(out_sizes);
 
-  // Valid input should give the expected output
-  optional<int64_t> storage_offset;
-  int64_t sizes[3] = {2, 2, 2};
-  int64_t stride[3] = {1, 2, 3};
-  op_as_strided_copy_out(
-      /*self=*/in,
-      /*size=*/ArrayRef<int64_t>{sizes, 3},
-      /*stride=*/ArrayRef<int64_t>{stride, 3},
-      storage_offset,
-      out);
-  EXPECT_TENSOR_EQ(out, tf.make(out_sizes, {1, 4, 3, 6, 2, 5, 4, 7}));
+    // Valid input should give the expected output
+    optional<int64_t> storage_offset;
+    int64_t sizes[3] = {2, 2, 2};
+    int64_t stride[3] = {1, 2, 3};
+    op_as_strided_copy_out(
+        /*self=*/in,
+        /*size=*/ArrayRef<int64_t>{sizes, 3},
+        /*stride=*/ArrayRef<int64_t>{stride, 3},
+        storage_offset,
+        out);
+    EXPECT_TENSOR_EQ(out, tf.make(out_sizes, {1, 4, 3, 6, 2, 5, 4, 7}));
 
-  // With storage offset
-  op_as_strided_copy_out(
-      /*self=*/in,
-      /*size=*/ArrayRef<int64_t>{sizes, 3},
-      /*stride=*/ArrayRef<int64_t>{stride, 3},
-      /*storage_offset=*/2,
-      out);
-  EXPECT_TENSOR_EQ(out, tf.make(out_sizes, {3, 6, 5, 8, 4, 7, 6, 9}));
-}
+    // With storage offset
+    op_as_strided_copy_out(
+        /*self=*/in,
+        /*size=*/ArrayRef<int64_t>{sizes, 3},
+        /*stride=*/ArrayRef<int64_t>{stride, 3},
+        /*storage_offset=*/2,
+        out);
+    EXPECT_TENSOR_EQ(out, tf.make(out_sizes, {3, 6, 5, 8, 4, 7, 6, 9}));
+  }
 
-template <>
-void test_detach_copy_out<ScalarType::Bool>() {
-  TensorFactory<ScalarType::Bool> tf;
-  const std::vector<int32_t> in_sizes = {3, 3};
-  const std::vector<int32_t> out_sizes = {2, 2, 2};
-  Tensor in = tf.make(
-      in_sizes, {false, true, false, true, false, true, false, true, false});
-  Tensor out = tf.zeros(out_sizes);
+  template <>
+  void test_detach_copy_out<ScalarType::Bool>() {
+    TensorFactory<ScalarType::Bool> tf;
+    const std::vector<int32_t> in_sizes = {3, 3};
+    const std::vector<int32_t> out_sizes = {2, 2, 2};
+    Tensor in = tf.make(
+        in_sizes, {false, true, false, true, false, true, false, true, false});
+    Tensor out = tf.zeros(out_sizes);
 
-  // Valid input should give the expected output
-  optional<int64_t> storage_offset = 2;
-  int64_t sizes[3] = {2, 2, 2};
-  int64_t stride[3] = {1, 2, 3};
-  op_as_strided_copy_out(
-      /*self=*/in,
-      /*size=*/ArrayRef<int64_t>{sizes, 3},
-      /*stride=*/ArrayRef<int64_t>{stride, 3},
-      storage_offset,
-      out);
-  EXPECT_TENSOR_EQ(
-      out,
-      tf.make(out_sizes, {false, true, false, true, true, false, true, false}));
-}
+    // Valid input should give the expected output
+    optional<int64_t> storage_offset = 2;
+    int64_t sizes[3] = {2, 2, 2};
+    int64_t stride[3] = {1, 2, 3};
+    op_as_strided_copy_out(
+        /*self=*/in,
+        /*size=*/ArrayRef<int64_t>{sizes, 3},
+        /*stride=*/ArrayRef<int64_t>{stride, 3},
+        storage_offset,
+        out);
+    EXPECT_TENSOR_EQ(
+        out,
+        tf.make(
+            out_sizes, {false, true, false, true, true, false, true, false}));
+  }
 
-template <>
-void test_detach_copy_out<ScalarType::Float>() {
-  TensorFactory<ScalarType::Float> tf;
-  const std::vector<int32_t> in_sizes = {3, 3};
-  const std::vector<int32_t> out_sizes = {2, 2, 2};
+  template <>
+  void test_detach_copy_out<ScalarType::Float>() {
+    TensorFactory<ScalarType::Float> tf;
+    const std::vector<int32_t> in_sizes = {3, 3};
+    const std::vector<int32_t> out_sizes = {2, 2, 2};
 
-  Tensor in = tf.make(
-      in_sizes, {3.14, 2.33, 42, INFINITY, -INFINITY, NAN, -3.14, -2.33, -42});
-  Tensor out = tf.zeros(out_sizes);
+    Tensor in = tf.make(
+        in_sizes,
+        {3.14, 2.33, 42, INFINITY, -INFINITY, NAN, -3.14, -2.33, -42});
+    Tensor out = tf.zeros(out_sizes);
 
-  // Valid input should give the expected output
-  optional<int64_t> storage_offset = 2;
-  int64_t sizes[3] = {2, 2, 2};
-  int64_t stride[3] = {1, 2, 3};
-  op_as_strided_copy_out(
-      /*self=*/in,
-      /*size=*/ArrayRef<int64_t>{sizes, 3},
-      /*stride=*/ArrayRef<int64_t>{stride, 3},
-      storage_offset,
-      out);
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf.make(
-          out_sizes,
-          {42.0, NAN, -INFINITY, 2.33, INFINITY, -3.14, NAN, -42.0}));
-}
+    // Valid input should give the expected output
+    optional<int64_t> storage_offset = 2;
+    int64_t sizes[3] = {2, 2, 2};
+    int64_t stride[3] = {1, 2, 3};
+    op_as_strided_copy_out(
+        /*self=*/in,
+        /*size=*/ArrayRef<int64_t>{sizes, 3},
+        /*stride=*/ArrayRef<int64_t>{stride, 3},
+        storage_offset,
+        out);
+    EXPECT_TENSOR_CLOSE(
+        out,
+        tf.make(
+            out_sizes,
+            {42.0, NAN, -INFINITY, 2.33, INFINITY, -3.14, NAN, -42.0}));
+  }
 
-TEST(OpAsStridedCopyOutKernelTest, AllScalarInputOutputSupport) {
+  template <ScalarType DTYPE>
+  void test_as_strided_copy_out_invalid_parameters() {
+    TensorFactory<DTYPE> tf;
+
+    const std::vector<int32_t> in_sizes = {3, 3};
+    const std::vector<int32_t> out_sizes = {2, 2, 2};
+
+    Tensor in = tf.ones(in_sizes);
+    Tensor out = tf.zeros(out_sizes);
+    optional<int64_t> storage_offset;
+    int64_t sizes[3] = {2, 2, 2};
+    int64_t stride[3] = {1, 2, 3};
+
+    // Mismatch strides and shape should die
+    int64_t stride_short[2] = {1, 2};
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_as_strided_copy_out(
+            /*self=*/in,
+            /*size=*/ArrayRef<int64_t>{sizes, 3},
+            /*stride=*/ArrayRef<int64_t>{stride_short, 2},
+            storage_offset,
+            out));
+
+    // Negative strides should die
+    int64_t stride_negative[3] = {1, 2, -1};
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_as_strided_copy_out(
+            /*self=*/in,
+            /*size=*/ArrayRef<int64_t>{sizes, 3},
+            /*stride=*/ArrayRef<int64_t>{stride_negative, 3},
+            storage_offset,
+            out));
+
+    // Mismatch output tensor shape and size should die
+    int64_t size_invalid[3] = {2, 2, 1};
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_as_strided_copy_out(
+            /*self=*/in,
+            /*size=*/ArrayRef<int64_t>{size_invalid, 3},
+            /*stride=*/ArrayRef<int64_t>{stride, 3},
+            storage_offset,
+            out));
+
+    // Invalid storage offset should die
+    storage_offset = -1;
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_as_strided_copy_out(
+            /*self=*/in,
+            /*size=*/ArrayRef<int64_t>{sizes, 3},
+            /*stride=*/ArrayRef<int64_t>{stride, 3},
+            storage_offset,
+            out));
+
+    // Out of bound storage access of `in` should die
+    storage_offset = 3;
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_as_strided_copy_out(
+            /*self=*/in,
+            /*size=*/ArrayRef<int64_t>{sizes, 3},
+            /*stride=*/ArrayRef<int64_t>{stride, 3},
+            storage_offset,
+            out));
+  }
+};
+
+TEST_F(OpAsStridedCopyOutTest, AllScalarInputOutputSupport) {
 #define TEST_ENTRY(ctype, dtype) test_detach_copy_out<ScalarType::dtype>();
   ET_FORALL_INT_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-template <ScalarType DTYPE>
-void test_as_strided_copy_out_invalid_parameters() {
-  TensorFactory<DTYPE> tf;
-
-  const std::vector<int32_t> in_sizes = {3, 3};
-  const std::vector<int32_t> out_sizes = {2, 2, 2};
-
-  Tensor in = tf.ones(in_sizes);
-  Tensor out = tf.zeros(out_sizes);
-  optional<int64_t> storage_offset;
-  int64_t sizes[3] = {2, 2, 2};
-  int64_t stride[3] = {1, 2, 3};
-
-  // Mismatch strides and shape should die
-  int64_t stride_short[2] = {1, 2};
-  ET_EXPECT_KERNEL_FAILURE(op_as_strided_copy_out(
-      /*self=*/in,
-      /*size=*/ArrayRef<int64_t>{sizes, 3},
-      /*stride=*/ArrayRef<int64_t>{stride_short, 2},
-      storage_offset,
-      out));
-
-  // Negative strides should die
-  int64_t stride_negative[3] = {1, 2, -1};
-  ET_EXPECT_KERNEL_FAILURE(op_as_strided_copy_out(
-      /*self=*/in,
-      /*size=*/ArrayRef<int64_t>{sizes, 3},
-      /*stride=*/ArrayRef<int64_t>{stride_negative, 3},
-      storage_offset,
-      out));
-
-  // Mismatch output tensor shape and size should die
-  int64_t size_invalid[3] = {2, 2, 1};
-  ET_EXPECT_KERNEL_FAILURE(op_as_strided_copy_out(
-      /*self=*/in,
-      /*size=*/ArrayRef<int64_t>{size_invalid, 3},
-      /*stride=*/ArrayRef<int64_t>{stride, 3},
-      storage_offset,
-      out));
-
-  // Invalid storage offset should die
-  storage_offset = -1;
-  ET_EXPECT_KERNEL_FAILURE(op_as_strided_copy_out(
-      /*self=*/in,
-      /*size=*/ArrayRef<int64_t>{sizes, 3},
-      /*stride=*/ArrayRef<int64_t>{stride, 3},
-      storage_offset,
-      out));
-
-  // Out of bound storage access of `in` should die
-  storage_offset = 3;
-  ET_EXPECT_KERNEL_FAILURE(op_as_strided_copy_out(
-      /*self=*/in,
-      /*size=*/ArrayRef<int64_t>{sizes, 3},
-      /*stride=*/ArrayRef<int64_t>{stride, 3},
-      storage_offset,
-      out));
-}
-
-TEST(OpAsStridedCopyOutKernelTest, InvalidParametersDies) {
+TEST_F(OpAsStridedCopyOutTest, InvalidParametersDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle invalid parameter";
   }
@@ -194,7 +208,7 @@ TEST(OpAsStridedCopyOutKernelTest, InvalidParametersDies) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAsStridedCopyOutKernelTest, MismatchedInputDtypesDies) {
+TEST_F(OpAsStridedCopyOutTest, MismatchedInputDtypesDies) {
   TensorFactory<ScalarType::Byte> tf_byte;
   TensorFactory<ScalarType::Char> tf_char;
   const std::vector<int32_t> in_sizes = {3, 3};
@@ -206,12 +220,14 @@ TEST(OpAsStridedCopyOutKernelTest, MismatchedInputDtypesDies) {
   int64_t sizes[3] = {2, 2, 2};
   int64_t stride[3] = {1, 2, 3};
 
-  ET_EXPECT_KERNEL_FAILURE(op_as_strided_copy_out(
-      /*self=*/in,
-      /*size=*/ArrayRef<int64_t>{sizes, 3},
-      /*stride=*/ArrayRef<int64_t>{stride, 3},
-      storage_offset,
-      out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_as_strided_copy_out(
+          /*self=*/in,
+          /*size=*/ArrayRef<int64_t>{sizes, 3},
+          /*stride=*/ArrayRef<int64_t>{stride, 3},
+          storage_offset,
+          out));
 }
 
 /* %python
@@ -229,7 +245,7 @@ opt_extra_params = "size, stride, storage_offset,"
 dtype = "ScalarType::Float"
 check = "EXPECT_TENSOR_EQ" */
 
-TEST(OpAsStridedCopyOutKernelTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpAsStridedCopyOutTest, DynamicShapeUpperBoundSameAsExpected) {
   /* %python
   out_args = "{2, 2, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND"
   %rewrite(unary_op) */
@@ -270,7 +286,7 @@ TEST(OpAsStridedCopyOutKernelTest, DynamicShapeUpperBoundSameAsExpected) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpAsStridedCopyOutKernelTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpAsStridedCopyOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   /* %python
   out_args = "{5, 5, 5}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND"
   %rewrite(unary_op) */
@@ -311,7 +327,7 @@ TEST(OpAsStridedCopyOutKernelTest, DynamicShapeUpperBoundLargerThanExpected) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpAsStridedCopyOutKernelTest, DynamicShapeUnbound) {
+TEST_F(OpAsStridedCopyOutTest, DynamicShapeUnbound) {
   if (!torch::executor::testing::SupportedFeatures::get()->output_resize) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }

--- a/kernels/test/op_asin_test.cpp
+++ b/kernels/test/op_asin_test.cpp
@@ -21,12 +21,49 @@ using exec_aten::Tensor;
 using exec_aten::TensorShapeDynamism;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_asin_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::asin_outf(context, self, out);
-}
+class OpAsinOutTest : public OperatorTest {
+ protected:
+  Tensor& op_asin_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::asin_outf(context_, self, out);
+  }
 
-TEST(OpAsinOutKernelTest, HandleBoolInput) {
+  // Common testing for asin operator and all kinds of supported input types
+  template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
+  void test_floating_point_asin_out(
+      const std::vector<int32_t>& out_shape = {1, 6},
+      TensorShapeDynamism dynamism = TensorShapeDynamism::STATIC) {
+    TensorFactory<IN_DTYPE> tf_in;
+    TensorFactory<OUT_DTYPE> tf_out;
+
+    // Destination for the asin operator.
+    Tensor out = tf_out.zeros(out_shape, dynamism);
+
+    // clang-format off
+    op_asin_out(tf_in.make({1, 6}, { 0, 1, 3, 5, 10, 100 }), out);
+  
+    // Check that it matches (or close to) the expected output.
+    EXPECT_TENSOR_CLOSE(
+        out,
+        tf_out.make({1, 6}, { 0.000000, 1.570796, NAN, NAN, NAN, NAN }));
+    // clang-format on
+  }
+
+  // Unhandled output dtypes.
+  template <ScalarType INPUT_DTYPE, ScalarType OUTPUT_DTYPE>
+  void test_asin_invalid_output_dtype_dies() {
+    TensorFactory<INPUT_DTYPE> tf;
+    TensorFactory<OUTPUT_DTYPE> tf_out;
+
+    const std::vector<int32_t> sizes = {2, 5};
+
+    Tensor in = tf.ones(sizes);
+    Tensor out = tf_out.zeros(sizes);
+
+    ET_EXPECT_KERNEL_FAILURE(context_, op_asin_out(in, out));
+  }
+};
+
+TEST_F(OpAsinOutTest, HandleBoolInput) {
   TensorFactory<ScalarType::Bool> tf_bool;
   TensorFactory<ScalarType::Float> tf_float;
 
@@ -39,28 +76,7 @@ TEST(OpAsinOutKernelTest, HandleBoolInput) {
   EXPECT_TENSOR_CLOSE(op_asin_out(a, out), res);
 }
 
-// Common testing for asin operator and all kinds of supported input types
-template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
-void test_floating_point_asin_out(
-    const std::vector<int32_t>& out_shape = {1, 6},
-    TensorShapeDynamism dynamism = TensorShapeDynamism::STATIC) {
-  TensorFactory<IN_DTYPE> tf_in;
-  TensorFactory<OUT_DTYPE> tf_out;
-
-  // Destination for the asin operator.
-  Tensor out = tf_out.zeros(out_shape, dynamism);
-
-  // clang-format off
-  op_asin_out(tf_in.make({1, 6}, { 0, 1, 3, 5, 10, 100 }), out);
-
-  // Check that it matches (or close to) the expected output.
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf_out.make({1, 6}, { 0.000000, 1.570796, NAN, NAN, NAN, NAN }));
-  // clang-format on
-}
-
-TEST(OpAsinOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+TEST_F(OpAsinOutTest, AllRealInputHalfOutputStaticDynamismSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -70,21 +86,21 @@ TEST(OpAsinOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
+TEST_F(OpAsinOutTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_asin_out<ScalarType::dtype, ScalarType::Float>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
+TEST_F(OpAsinOutTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_asin_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+TEST_F(OpAsinOutTest, AllRealInputHalfOutputBoundDynamismSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -95,7 +111,7 @@ TEST(OpAsinOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinOutKernelTest, AllRealInputFloatOutputBoundDynamismSupport) {
+TEST_F(OpAsinOutTest, AllRealInputFloatOutputBoundDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype)                                      \
   test_floating_point_asin_out<ScalarType::dtype, ScalarType::Float>( \
       {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
@@ -103,7 +119,7 @@ TEST(OpAsinOutKernelTest, AllRealInputFloatOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinOutKernelTest, AllRealInputDoubleOutputBoundDynamismSupport) {
+TEST_F(OpAsinOutTest, AllRealInputDoubleOutputBoundDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype)                                       \
   test_floating_point_asin_out<ScalarType::dtype, ScalarType::Double>( \
       {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
@@ -111,7 +127,7 @@ TEST(OpAsinOutKernelTest, AllRealInputDoubleOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinOutKernelTest, AllRealInputFloatOutputUnboundDynamismSupport) {
+TEST_F(OpAsinOutTest, AllRealInputFloatOutputUnboundDynamismSupport) {
   if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }
@@ -122,7 +138,7 @@ TEST(OpAsinOutKernelTest, AllRealInputFloatOutputUnboundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinOutKernelTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
+TEST_F(OpAsinOutTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
   if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }
@@ -133,21 +149,7 @@ TEST(OpAsinOutKernelTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-// Unhandled output dtypes.
-template <ScalarType INPUT_DTYPE, ScalarType OUTPUT_DTYPE>
-void test_asin_invalid_output_dtype_dies() {
-  TensorFactory<INPUT_DTYPE> tf;
-  TensorFactory<OUTPUT_DTYPE> tf_out;
-
-  const std::vector<int32_t> sizes = {2, 5};
-
-  Tensor in = tf.ones(sizes);
-  Tensor out = tf_out.zeros(sizes);
-
-  ET_EXPECT_KERNEL_FAILURE(op_asin_out(in, out));
-}
-
-TEST(OpAsinOutKernelTest, AllNonFloatOutputDTypeDies) {
+TEST_F(OpAsinOutTest, AllNonFloatOutputDTypeDies) {
 #define TEST_ENTRY(ctype, dtype) \
   test_asin_invalid_output_dtype_dies<ScalarType::Float, ScalarType::dtype>();
   ET_FORALL_INT_TYPES(TEST_ENTRY);
@@ -155,7 +157,7 @@ TEST(OpAsinOutKernelTest, AllNonFloatOutputDTypeDies) {
 }
 
 // Mismatched shape tests.
-TEST(OpAsinOutKernelTest, MismatchedInputShapesDies) {
+TEST_F(OpAsinOutTest, MismatchedInputShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched input shapes";
   }
@@ -164,5 +166,5 @@ TEST(OpAsinOutKernelTest, MismatchedInputShapesDies) {
   Tensor a = tf.ones(/*sizes=*/{4});
   Tensor out = tf.ones(/*sizes=*/{2, 2});
 
-  ET_EXPECT_KERNEL_FAILURE(op_asin_out(a, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_asin_out(a, out));
 }

--- a/kernels/test/op_asinh_test.cpp
+++ b/kernels/test/op_asinh_test.cpp
@@ -21,12 +21,49 @@ using exec_aten::Tensor;
 using exec_aten::TensorShapeDynamism;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_asinh_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::asinh_outf(context, self, out);
-}
+class OpAsinhOutTest : public OperatorTest {
+ protected:
+  Tensor& op_asinh_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::asinh_outf(context_, self, out);
+  }
 
-TEST(OpAsinhOutKernelTest, HandleBoolInput) {
+  // Common testing for asinh operator and all kinds of supported input types
+  template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
+  void test_floating_point_asinh_out(
+      const std::vector<int32_t>& out_shape = {1, 6},
+      TensorShapeDynamism dynamism = TensorShapeDynamism::STATIC) {
+    TensorFactory<IN_DTYPE> tf_in;
+    TensorFactory<OUT_DTYPE> tf_out;
+
+    // Destination for the asinh operator.
+    Tensor out = tf_out.zeros(out_shape, dynamism);
+
+    // clang-format off
+    op_asinh_out(tf_in.make({1, 6}, { 0, 1, 3, 5, 10, 100 }), out);
+  
+    // Check that it matches (or close to) the expected output.
+    EXPECT_TENSOR_CLOSE(
+        out,
+        tf_out.make({1, 6}, { 0.000000, 0.881374, 1.818447, 2.312438, 2.998223, 5.298342 }));
+    // clang-format on
+  }
+
+  // Unhandled output dtypes.
+  template <ScalarType INPUT_DTYPE, ScalarType OUTPUT_DTYPE>
+  void test_asinh_invalid_output_dtype_dies() {
+    TensorFactory<INPUT_DTYPE> tf;
+    TensorFactory<OUTPUT_DTYPE> tf_out;
+
+    const std::vector<int32_t> sizes = {2, 5};
+
+    Tensor in = tf.ones(sizes);
+    Tensor out = tf_out.zeros(sizes);
+
+    ET_EXPECT_KERNEL_FAILURE(context_, op_asinh_out(in, out));
+  }
+};
+
+TEST_F(OpAsinhOutTest, HandleBoolInput) {
   TensorFactory<ScalarType::Bool> tf_bool;
   TensorFactory<ScalarType::Float> tf_float;
 
@@ -39,28 +76,7 @@ TEST(OpAsinhOutKernelTest, HandleBoolInput) {
   EXPECT_TENSOR_CLOSE(op_asinh_out(a, out), res);
 }
 
-// Common testing for asinh operator and all kinds of supported input types
-template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
-void test_floating_point_asinh_out(
-    const std::vector<int32_t>& out_shape = {1, 6},
-    TensorShapeDynamism dynamism = TensorShapeDynamism::STATIC) {
-  TensorFactory<IN_DTYPE> tf_in;
-  TensorFactory<OUT_DTYPE> tf_out;
-
-  // Destination for the asinh operator.
-  Tensor out = tf_out.zeros(out_shape, dynamism);
-
-  // clang-format off
-  op_asinh_out(tf_in.make({1, 6}, { 0, 1, 3, 5, 10, 100 }), out);
-
-  // Check that it matches (or close to) the expected output.
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf_out.make({1, 6}, { 0.000000, 0.881374, 1.818447, 2.312438, 2.998223, 5.298342 }));
-  // clang-format on
-}
-
-TEST(OpAsinhOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+TEST_F(OpAsinhOutTest, AllRealInputHalfOutputStaticDynamismSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -70,21 +86,21 @@ TEST(OpAsinhOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinhOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
+TEST_F(OpAsinhOutTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_asinh_out<ScalarType::dtype, ScalarType::Float>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinhOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
+TEST_F(OpAsinhOutTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_asinh_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinhOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+TEST_F(OpAsinhOutTest, AllRealInputHalfOutputBoundDynamismSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -95,7 +111,7 @@ TEST(OpAsinhOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinhOutKernelTest, AllRealInputFloatOutputBoundDynamismSupport) {
+TEST_F(OpAsinhOutTest, AllRealInputFloatOutputBoundDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype)                                       \
   test_floating_point_asinh_out<ScalarType::dtype, ScalarType::Float>( \
       {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
@@ -103,7 +119,7 @@ TEST(OpAsinhOutKernelTest, AllRealInputFloatOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinhOutKernelTest, AllRealInputDoubleOutputBoundDynamismSupport) {
+TEST_F(OpAsinhOutTest, AllRealInputDoubleOutputBoundDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype)                                        \
   test_floating_point_asinh_out<ScalarType::dtype, ScalarType::Double>( \
       {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
@@ -111,7 +127,7 @@ TEST(OpAsinhOutKernelTest, AllRealInputDoubleOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinhOutKernelTest, AllRealInputFloatOutputUnboundDynamismSupport) {
+TEST_F(OpAsinhOutTest, AllRealInputFloatOutputUnboundDynamismSupport) {
   if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }
@@ -122,7 +138,7 @@ TEST(OpAsinhOutKernelTest, AllRealInputFloatOutputUnboundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAsinhOutKernelTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
+TEST_F(OpAsinhOutTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
   if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }
@@ -133,21 +149,7 @@ TEST(OpAsinhOutKernelTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-// Unhandled output dtypes.
-template <ScalarType INPUT_DTYPE, ScalarType OUTPUT_DTYPE>
-void test_asinh_invalid_output_dtype_dies() {
-  TensorFactory<INPUT_DTYPE> tf;
-  TensorFactory<OUTPUT_DTYPE> tf_out;
-
-  const std::vector<int32_t> sizes = {2, 5};
-
-  Tensor in = tf.ones(sizes);
-  Tensor out = tf_out.zeros(sizes);
-
-  ET_EXPECT_KERNEL_FAILURE(op_asinh_out(in, out));
-}
-
-TEST(OpAsinhOutKernelTest, AllNonFloatOutputDTypeDies) {
+TEST_F(OpAsinhOutTest, AllNonFloatOutputDTypeDies) {
 #define TEST_ENTRY(ctype, dtype) \
   test_asinh_invalid_output_dtype_dies<ScalarType::Float, ScalarType::dtype>();
   ET_FORALL_INT_TYPES(TEST_ENTRY);
@@ -155,7 +157,7 @@ TEST(OpAsinhOutKernelTest, AllNonFloatOutputDTypeDies) {
 }
 
 // Mismatched shape tests.
-TEST(OpAsinhOutKernelTest, MismatchedInputShapesDies) {
+TEST_F(OpAsinhOutTest, MismatchedInputShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched input shapes";
   }
@@ -164,5 +166,5 @@ TEST(OpAsinhOutKernelTest, MismatchedInputShapesDies) {
   Tensor a = tf.ones(/*sizes=*/{4});
   Tensor out = tf.ones(/*sizes=*/{2, 2});
 
-  ET_EXPECT_KERNEL_FAILURE(op_asinh_out(a, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_asinh_out(a, out));
 }

--- a/kernels/test/op_atan_test.cpp
+++ b/kernels/test/op_atan_test.cpp
@@ -21,12 +21,49 @@ using exec_aten::Tensor;
 using exec_aten::TensorShapeDynamism;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_atan_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::atan_outf(context, self, out);
-}
+class OpAtanOutTest : public OperatorTest {
+ protected:
+  Tensor& op_atan_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::atan_outf(context_, self, out);
+  }
 
-TEST(OpAtanOutKernelTest, HandleBoolInput) {
+  // Common testing for atan operator and all kinds of supported input types
+  template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
+  void test_floating_point_atan_out(
+      const std::vector<int32_t>& out_shape = {1, 6},
+      TensorShapeDynamism dynamism = TensorShapeDynamism::STATIC) {
+    TensorFactory<IN_DTYPE> tf_in;
+    TensorFactory<OUT_DTYPE> tf_out;
+
+    // Destination for the atan operator.
+    Tensor out = tf_out.zeros(out_shape, dynamism);
+
+    // clang-format off
+    op_atan_out(tf_in.make({1, 6}, { 0, 1, 3, 5, 10, 100 }), out);
+  
+    // Check that it matches (or close to) the expected output.
+    EXPECT_TENSOR_CLOSE(
+        out,
+        tf_out.make({1, 6}, { 0.000000, 0.785398, 1.249046, 1.373401, 1.471128, 1.560797 }));
+    // clang-format on
+  }
+
+  // Unhandled output dtypes.
+  template <ScalarType INPUT_DTYPE, ScalarType OUTPUT_DTYPE>
+  void test_atan_invalid_output_dtype_dies() {
+    TensorFactory<INPUT_DTYPE> tf;
+    TensorFactory<OUTPUT_DTYPE> tf_out;
+
+    const std::vector<int32_t> sizes = {2, 5};
+
+    Tensor in = tf.ones(sizes);
+    Tensor out = tf_out.zeros(sizes);
+
+    ET_EXPECT_KERNEL_FAILURE(context_, op_atan_out(in, out));
+  }
+};
+
+TEST_F(OpAtanOutTest, HandleBoolInput) {
   TensorFactory<ScalarType::Bool> tf_bool;
   TensorFactory<ScalarType::Float> tf_float;
 
@@ -39,28 +76,7 @@ TEST(OpAtanOutKernelTest, HandleBoolInput) {
   EXPECT_TENSOR_CLOSE(op_atan_out(a, out), res);
 }
 
-// Common testing for atan operator and all kinds of supported input types
-template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
-void test_floating_point_atan_out(
-    const std::vector<int32_t>& out_shape = {1, 6},
-    TensorShapeDynamism dynamism = TensorShapeDynamism::STATIC) {
-  TensorFactory<IN_DTYPE> tf_in;
-  TensorFactory<OUT_DTYPE> tf_out;
-
-  // Destination for the atan operator.
-  Tensor out = tf_out.zeros(out_shape, dynamism);
-
-  // clang-format off
-  op_atan_out(tf_in.make({1, 6}, { 0, 1, 3, 5, 10, 100 }), out);
-
-  // Check that it matches (or close to) the expected output.
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf_out.make({1, 6}, { 0.000000, 0.785398, 1.249046, 1.373401, 1.471128, 1.560797 }));
-  // clang-format on
-}
-
-TEST(OpAtanOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+TEST_F(OpAtanOutTest, AllRealInputHalfOutputStaticDynamismSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -70,21 +86,21 @@ TEST(OpAtanOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
+TEST_F(OpAtanOutTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_atan_out<ScalarType::dtype, ScalarType::Float>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
+TEST_F(OpAtanOutTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_atan_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+TEST_F(OpAtanOutTest, AllRealInputHalfOutputBoundDynamismSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -95,7 +111,7 @@ TEST(OpAtanOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanOutKernelTest, AllRealInputFloatOutputBoundDynamismSupport) {
+TEST_F(OpAtanOutTest, AllRealInputFloatOutputBoundDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype)                                      \
   test_floating_point_atan_out<ScalarType::dtype, ScalarType::Float>( \
       {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
@@ -103,7 +119,7 @@ TEST(OpAtanOutKernelTest, AllRealInputFloatOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanOutKernelTest, AllRealInputDoubleOutputBoundDynamismSupport) {
+TEST_F(OpAtanOutTest, AllRealInputDoubleOutputBoundDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype)                                       \
   test_floating_point_atan_out<ScalarType::dtype, ScalarType::Double>( \
       {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
@@ -111,7 +127,7 @@ TEST(OpAtanOutKernelTest, AllRealInputDoubleOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanOutKernelTest, AllRealInputFloatOutputUnboundDynamismSupport) {
+TEST_F(OpAtanOutTest, AllRealInputFloatOutputUnboundDynamismSupport) {
   if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }
@@ -122,7 +138,7 @@ TEST(OpAtanOutKernelTest, AllRealInputFloatOutputUnboundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanOutKernelTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
+TEST_F(OpAtanOutTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
   if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }
@@ -133,21 +149,7 @@ TEST(OpAtanOutKernelTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-// Unhandled output dtypes.
-template <ScalarType INPUT_DTYPE, ScalarType OUTPUT_DTYPE>
-void test_atan_invalid_output_dtype_dies() {
-  TensorFactory<INPUT_DTYPE> tf;
-  TensorFactory<OUTPUT_DTYPE> tf_out;
-
-  const std::vector<int32_t> sizes = {2, 5};
-
-  Tensor in = tf.ones(sizes);
-  Tensor out = tf_out.zeros(sizes);
-
-  ET_EXPECT_KERNEL_FAILURE(op_atan_out(in, out));
-}
-
-TEST(OpAtanOutKernelTest, AllNonFloatOutputDTypeDies) {
+TEST_F(OpAtanOutTest, AllNonFloatOutputDTypeDies) {
 #define TEST_ENTRY(ctype, dtype) \
   test_atan_invalid_output_dtype_dies<ScalarType::Float, ScalarType::dtype>();
   ET_FORALL_INT_TYPES(TEST_ENTRY);
@@ -155,7 +157,7 @@ TEST(OpAtanOutKernelTest, AllNonFloatOutputDTypeDies) {
 }
 
 // Mismatched shape tests.
-TEST(OpAtanOutKernelTest, MismatchedInputShapesDies) {
+TEST_F(OpAtanOutTest, MismatchedInputShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched input shapes";
   }
@@ -164,5 +166,5 @@ TEST(OpAtanOutKernelTest, MismatchedInputShapesDies) {
   Tensor a = tf.ones(/*sizes=*/{4});
   Tensor out = tf.ones(/*sizes=*/{2, 2});
 
-  ET_EXPECT_KERNEL_FAILURE(op_atan_out(a, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_atan_out(a, out));
 }

--- a/kernels/test/op_atanh_test.cpp
+++ b/kernels/test/op_atanh_test.cpp
@@ -21,12 +21,49 @@ using exec_aten::Tensor;
 using exec_aten::TensorShapeDynamism;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_atanh_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::atanh_outf(context, self, out);
-}
+class OpAtanhOutTest : public OperatorTest {
+ protected:
+  Tensor& op_atanh_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::atanh_outf(context_, self, out);
+  }
 
-TEST(OpAtanhOutKernelTest, HandleBoolInput) {
+  // Common testing for atanh operator and all kinds of supported input types
+  template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
+  void test_floating_point_atanh_out(
+      const std::vector<int32_t>& out_shape = {1, 6},
+      TensorShapeDynamism dynamism = TensorShapeDynamism::STATIC) {
+    TensorFactory<IN_DTYPE> tf_in;
+    TensorFactory<OUT_DTYPE> tf_out;
+
+    // Destination for the atanh operator.
+    Tensor out = tf_out.zeros(out_shape, dynamism);
+
+    // clang-format off
+    op_atanh_out(tf_in.make({1, 6}, { 0, 1, 3, 5, 10, 100 }), out);
+  
+    // Check that it matches (or close to) the expected output.
+    EXPECT_TENSOR_CLOSE(
+        out,
+        tf_out.make({1, 6}, { 0.0, std::numeric_limits<float>::infinity(), NAN, NAN, NAN, NAN }));
+    // clang-format on
+  }
+
+  // Unhandled output dtypes.
+  template <ScalarType INPUT_DTYPE, ScalarType OUTPUT_DTYPE>
+  void test_atanh_invalid_output_dtype_dies() {
+    TensorFactory<INPUT_DTYPE> tf;
+    TensorFactory<OUTPUT_DTYPE> tf_out;
+
+    const std::vector<int32_t> sizes = {2, 5};
+
+    Tensor in = tf.ones(sizes);
+    Tensor out = tf_out.zeros(sizes);
+
+    ET_EXPECT_KERNEL_FAILURE(context_, op_atanh_out(in, out));
+  }
+};
+
+TEST_F(OpAtanhOutTest, HandleBoolInput) {
   TensorFactory<ScalarType::Bool> tf_bool;
   TensorFactory<ScalarType::Float> tf_float;
 
@@ -39,28 +76,7 @@ TEST(OpAtanhOutKernelTest, HandleBoolInput) {
   EXPECT_TENSOR_CLOSE(op_atanh_out(a, out), res);
 }
 
-// Common testing for atanh operator and all kinds of supported input types
-template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
-void test_floating_point_atanh_out(
-    const std::vector<int32_t>& out_shape = {1, 6},
-    TensorShapeDynamism dynamism = TensorShapeDynamism::STATIC) {
-  TensorFactory<IN_DTYPE> tf_in;
-  TensorFactory<OUT_DTYPE> tf_out;
-
-  // Destination for the atanh operator.
-  Tensor out = tf_out.zeros(out_shape, dynamism);
-
-  // clang-format off
-  op_atanh_out(tf_in.make({1, 6}, { 0, 1, 3, 5, 10, 100 }), out);
-
-  // Check that it matches (or close to) the expected output.
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf_out.make({1, 6}, { 0.0, std::numeric_limits<float>::infinity(), NAN, NAN, NAN, NAN }));
-  // clang-format on
-}
-
-TEST(OpAtanhOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
+TEST_F(OpAtanhOutTest, AllRealInputHalfOutputStaticDynamismSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -70,21 +86,21 @@ TEST(OpAtanhOutKernelTest, AllRealInputHalfOutputStaticDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanhOutKernelTest, AllRealInputFloatOutputStaticDynamismSupport) {
+TEST_F(OpAtanhOutTest, AllRealInputFloatOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_atanh_out<ScalarType::dtype, ScalarType::Float>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanhOutKernelTest, AllRealInputDoubleOutputStaticDynamismSupport) {
+TEST_F(OpAtanhOutTest, AllRealInputDoubleOutputStaticDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_floating_point_atanh_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanhOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
+TEST_F(OpAtanhOutTest, AllRealInputHalfOutputBoundDynamismSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -95,7 +111,7 @@ TEST(OpAtanhOutKernelTest, AllRealInputHalfOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanhOutKernelTest, AllRealInputFloatOutputBoundDynamismSupport) {
+TEST_F(OpAtanhOutTest, AllRealInputFloatOutputBoundDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype)                                       \
   test_floating_point_atanh_out<ScalarType::dtype, ScalarType::Float>( \
       {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
@@ -103,7 +119,7 @@ TEST(OpAtanhOutKernelTest, AllRealInputFloatOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanhOutKernelTest, AllRealInputDoubleOutputBoundDynamismSupport) {
+TEST_F(OpAtanhOutTest, AllRealInputDoubleOutputBoundDynamismSupport) {
 #define TEST_ENTRY(ctype, dtype)                                        \
   test_floating_point_atanh_out<ScalarType::dtype, ScalarType::Double>( \
       {10, 10}, TensorShapeDynamism::DYNAMIC_BOUND);
@@ -111,7 +127,7 @@ TEST(OpAtanhOutKernelTest, AllRealInputDoubleOutputBoundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanhOutKernelTest, AllRealInputFloatOutputUnboundDynamismSupport) {
+TEST_F(OpAtanhOutTest, AllRealInputFloatOutputUnboundDynamismSupport) {
   if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }
@@ -122,7 +138,7 @@ TEST(OpAtanhOutKernelTest, AllRealInputFloatOutputUnboundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpAtanhOutKernelTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
+TEST_F(OpAtanhOutTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
   if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }
@@ -133,21 +149,7 @@ TEST(OpAtanhOutKernelTest, AllRealInputDoubleOutputUnboundDynamismSupport) {
 #undef TEST_ENTRY
 }
 
-// Unhandled output dtypes.
-template <ScalarType INPUT_DTYPE, ScalarType OUTPUT_DTYPE>
-void test_atanh_invalid_output_dtype_dies() {
-  TensorFactory<INPUT_DTYPE> tf;
-  TensorFactory<OUTPUT_DTYPE> tf_out;
-
-  const std::vector<int32_t> sizes = {2, 5};
-
-  Tensor in = tf.ones(sizes);
-  Tensor out = tf_out.zeros(sizes);
-
-  ET_EXPECT_KERNEL_FAILURE(op_atanh_out(in, out));
-}
-
-TEST(OpAtanhOutKernelTest, AllNonFloatOutputDTypeDies) {
+TEST_F(OpAtanhOutTest, AllNonFloatOutputDTypeDies) {
 #define TEST_ENTRY(ctype, dtype) \
   test_atanh_invalid_output_dtype_dies<ScalarType::Float, ScalarType::dtype>();
   ET_FORALL_INT_TYPES(TEST_ENTRY);
@@ -155,7 +157,7 @@ TEST(OpAtanhOutKernelTest, AllNonFloatOutputDTypeDies) {
 }
 
 // Mismatched shape tests.
-TEST(OpAtanhOutKernelTest, MismatchedInputShapesDies) {
+TEST_F(OpAtanhOutTest, MismatchedInputShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched input shapes";
   }
@@ -164,5 +166,5 @@ TEST(OpAtanhOutKernelTest, MismatchedInputShapesDies) {
   Tensor a = tf.ones(/*sizes=*/{4});
   Tensor out = tf.ones(/*sizes=*/{2, 2});
 
-  ET_EXPECT_KERNEL_FAILURE(op_atanh_out(a, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_atanh_out(a, out));
 }

--- a/kernels/test/op_avg_pool2d_test.cpp
+++ b/kernels/test/op_avg_pool2d_test.cpp
@@ -17,29 +17,31 @@
 
 using namespace ::testing;
 
-exec_aten::Tensor& op_avg_pool2d_out(
-    const exec_aten::Tensor& self,
-    exec_aten::ArrayRef<int64_t> kernel_size,
-    exec_aten::ArrayRef<int64_t> stride,
-    exec_aten::ArrayRef<int64_t> padding,
-    bool ceil_mode,
-    bool count_include_pad,
-    exec_aten::optional<int64_t> divisor_override,
-    exec_aten::Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::avg_pool2d_outf(
-      context,
-      self,
-      kernel_size,
-      stride,
-      padding,
-      ceil_mode,
-      count_include_pad,
-      divisor_override,
-      out);
-}
+class OpAvgPool2DOutTest : public OperatorTest {
+ protected:
+  exec_aten::Tensor& op_avg_pool2d_out(
+      const exec_aten::Tensor& self,
+      exec_aten::ArrayRef<int64_t> kernel_size,
+      exec_aten::ArrayRef<int64_t> stride,
+      exec_aten::ArrayRef<int64_t> padding,
+      bool ceil_mode,
+      bool count_include_pad,
+      exec_aten::optional<int64_t> divisor_override,
+      exec_aten::Tensor& out) {
+    return torch::executor::aten::avg_pool2d_outf(
+        context_,
+        self,
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        count_include_pad,
+        divisor_override,
+        out);
+  }
+};
 
-TEST(OpAvgPool2DOutTest, SanityCheck4D) {
+TEST_F(OpAvgPool2DOutTest, SanityCheck4D) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
 
   exec_aten::Tensor self = tfFloat.make(
@@ -191,7 +193,7 @@ TEST(OpAvgPool2DOutTest, SanityCheck4D) {
   EXPECT_TENSOR_CLOSE(out, out_expected);
 }
 
-TEST(OpAvgPool2DOutTest, SanityCheck4DDivisorOverride) {
+TEST_F(OpAvgPool2DOutTest, SanityCheck4DDivisorOverride) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
 
   exec_aten::Tensor self = tfFloat.make(
@@ -344,7 +346,7 @@ TEST(OpAvgPool2DOutTest, SanityCheck4DDivisorOverride) {
   EXPECT_TENSOR_CLOSE(out, out_expected);
 }
 
-TEST(OpAvgPool2DOutTest, SanityCheck4DCeilModeNoIncludePadding) {
+TEST_F(OpAvgPool2DOutTest, SanityCheck4DCeilModeNoIncludePadding) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
 
   exec_aten::Tensor self = tfFloat.make(

--- a/kernels/test/op_bitwise_and_test.cpp
+++ b/kernels/test/op_bitwise_and_test.cpp
@@ -20,18 +20,19 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_bitwise_and_scalar_out(
-    const Tensor& self,
-    const Scalar& other,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::bitwise_and_outf(context, self, other, out);
-}
+class OpwiseBitwiseAndTest : public OperatorTest {
+ protected:
+  Tensor& op_bitwise_and_scalar_out(
+      const Tensor& self,
+      const Scalar& other,
+      Tensor& out) {
+    return torch::executor::aten::bitwise_and_outf(context_, self, other, out);
+  }
 
-Tensor& op_bitwise_and_tensor_out(
-    const Tensor& self,
-    const Tensor& other,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::bitwise_and_outf(context, self, other, out);
-}
+  Tensor& op_bitwise_and_tensor_out(
+      const Tensor& self,
+      const Tensor& other,
+      Tensor& out) {
+    return torch::executor::aten::bitwise_and_outf(context_, self, other, out);
+  }
+};

--- a/kernels/test/op_bitwise_or_test.cpp
+++ b/kernels/test/op_bitwise_or_test.cpp
@@ -20,14 +20,19 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor&
-op_bitwise_or_scalar_out(const Tensor& self, const Scalar& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::bitwise_or_outf(context, self, other, out);
-}
+class OpBitwiseOrTest : public OperatorTest {
+ protected:
+  Tensor& op_bitwise_or_scalar_out(
+      const Tensor& self,
+      const Scalar& other,
+      Tensor& out) {
+    return torch::executor::aten::bitwise_or_outf(context_, self, other, out);
+  }
 
-Tensor&
-op_bitwise_or_tensor_out(const Tensor& self, const Tensor& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::bitwise_or_outf(context, self, other, out);
-}
+  Tensor& op_bitwise_or_tensor_out(
+      const Tensor& self,
+      const Tensor& other,
+      Tensor& out) {
+    return torch::executor::aten::bitwise_or_outf(context_, self, other, out);
+  }
+};

--- a/kernels/test/op_bitwise_xor_test.cpp
+++ b/kernels/test/op_bitwise_xor_test.cpp
@@ -20,18 +20,19 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_bitwise_xor_scalar_out(
-    const Tensor& self,
-    const Scalar& other,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::bitwise_xor_outf(context, self, other, out);
-}
+class OpBitwiseOrTest : public OperatorTest {
+ protected:
+  Tensor& op_bitwise_xor_scalar_out(
+      const Tensor& self,
+      const Scalar& other,
+      Tensor& out) {
+    return torch::executor::aten::bitwise_xor_outf(context_, self, other, out);
+  }
 
-Tensor& op_bitwise_xor_tensor_out(
-    const Tensor& self,
-    const Tensor& other,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::bitwise_xor_outf(context, self, other, out);
-}
+  Tensor& op_bitwise_xor_tensor_out(
+      const Tensor& self,
+      const Tensor& other,
+      Tensor& out) {
+    return torch::executor::aten::bitwise_xor_outf(context_, self, other, out);
+  }
+};

--- a/kernels/test/op_ceil_test.cpp
+++ b/kernels/test/op_ceil_test.cpp
@@ -20,12 +20,14 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_ceil_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::ceil_outf(context, self, out);
-}
+class OpCeilTest : public OperatorTest {
+ protected:
+  Tensor& op_ceil_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::ceil_outf(context_, self, out);
+  }
+};
 
-TEST(OpCeilTest, SanityCheck) {
+TEST_F(OpCeilTest, SanityCheck) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor in = tf.make({1, 7}, {-3.0, -2.99, -1.01, 0.0, 1.01, 2.99, 3.0});
@@ -38,7 +40,7 @@ TEST(OpCeilTest, SanityCheck) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpCeilTest, HalfSupport) {
+TEST_F(OpCeilTest, HalfSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }

--- a/kernels/test/op_clamp_test.cpp
+++ b/kernels/test/op_clamp_test.cpp
@@ -31,230 +31,261 @@ using torch::executor::testing::TensorFactory;
 
 using OptScalar = exec_aten::optional<Scalar>;
 
-Tensor& op_clamp_out(
-    const Tensor& self,
-    const optional<Scalar>& min,
-    const optional<Scalar>& max,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::clamp_outf(context, self, min, max, out);
-}
+class OpClampOutTest : public OperatorTest {
+ protected:
+  Tensor& op_clamp_out(
+      const Tensor& self,
+      const optional<Scalar>& min,
+      const optional<Scalar>& max,
+      Tensor& out) {
+    return torch::executor::aten::clamp_outf(context_, self, min, max, out);
+  }
 
-Tensor& op_clamp_tensor_out(
-    const Tensor& self,
-    const optional<Tensor>& min,
-    const optional<Tensor>& max,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::clamp_outf(context, self, min, max, out);
-}
+  template <ScalarType DTYPE>
+  struct ClampTestCase {
+    using ctype = typename TensorFactory<DTYPE>::ctype;
 
-/// Describes a test case, using tensors of the specified DTYPE.
-template <ScalarType DTYPE>
-struct ClampTestCase {
-  using ctype = typename TensorFactory<DTYPE>::ctype;
+    // Human-readable, unique title for the test case. Printed if the test
+    // fails.
+    const std::string title;
+    // Size vector for the input/output tensors.
+    const std::vector<int32_t> sizes;
+    // Data for the input tensor; must agree with `sizes`.
+    const std::vector<ctype> input_data;
+    // The (optional) min value to clamp to. Can be of any Scalar type.
+    const OptScalar min;
+    // The (optional) max value to clamp to. Can be of any Scalar type.
+    const OptScalar max;
+    // The expected output data when clamping `input_data` to `min`/`max`.
+    const std::vector<ctype> expected_data;
+  };
 
-  // Human-readable, unique title for the test case. Printed if the test fails.
-  const std::string title;
-  // Size vector for the input/output tensors.
-  const std::vector<int32_t> sizes;
-  // Data for the input tensor; must agree with `sizes`.
-  const std::vector<ctype> input_data;
-  // The (optional) min value to clamp to. Can be of any Scalar type.
-  const OptScalar min;
-  // The (optional) max value to clamp to. Can be of any Scalar type.
-  const OptScalar max;
-  // The expected output data when clamping `input_data` to `min`/`max`.
-  const std::vector<ctype> expected_data;
+  /// Runs the provided test cases.
+  template <ScalarType DTYPE>
+  void run_test_cases(std::vector<ClampTestCase<DTYPE>> test_cases) {
+    TensorFactory<DTYPE> tf;
+    for (const auto& test_case : test_cases) {
+      SCOPED_TRACE(test_case.title); // Printed if the test fails
+
+      Tensor in = tf.make(test_case.sizes, test_case.input_data);
+      Tensor out = tf.zeros(test_case.sizes);
+      Tensor ret = op_clamp_out(in, test_case.min, test_case.max, out);
+      EXPECT_TENSOR_EQ(out, ret);
+
+      Tensor expected = tf.make(test_case.sizes, test_case.expected_data);
+      ET_CHECK_SAME_SHAPE_AND_DTYPE2(out, expected);
+      EXPECT_TENSOR_EQ(out, expected);
+    }
+  }
+
+  template <ScalarType DTYPE>
+  void run_unsigned_integer_test_cases() {
+    const std::vector<ClampTestCase<DTYPE>> test_cases = {
+        {
+            std::string(__func__) + ": Simple clamp",
+            {2, 2}, // sizes
+            {0, 1, 10, 100}, // input_data
+            OptScalar(1), // min
+            OptScalar(6), // max
+            {1, 1, 6, 6}, // expected_data
+        },
+        {
+            std::string(__func__) + ": No max",
+            {2, 2}, // sizes
+            {0, 1, 10, 100}, // input_data
+            OptScalar(1), // min
+            nullopt, // max
+            {1, 1, 10, 100}, // expected_data
+        },
+        {
+            std::string(__func__) + ": No min",
+            {2, 2}, // sizes
+            {0, 1, 10, 100}, // input_data
+            nullopt, // min
+            OptScalar(6), // max
+            {0, 1, 6, 6}, // expected_data
+        },
+        {
+            std::string(__func__) + ": min > max",
+            {2, 2}, // sizes
+            {0, 1, 10, 100}, // input_data
+            OptScalar(10), // min
+            OptScalar(6), // max
+            // Should set all elements to max.
+            {6, 6, 6, 6}, // expected_data
+        },
+    };
+
+    run_test_cases(test_cases);
+  }
+
+  // types.
+  template <ScalarType DTYPE>
+  void run_signed_integer_test_cases() {
+    std::vector<ClampTestCase<DTYPE>> test_cases = {
+        {
+            std::string(__func__) + ": Simple negative/positive clamp",
+            {2, 2}, // sizes
+            {-10, -1, 1, 10}, // input_data
+            OptScalar(-5), // min
+            OptScalar(5), // max
+            {-5, -1, 1, 5}, // expected_data
+        },
+        {
+            std::string(__func__) + ": Simple negative-only clamp",
+            {2, 2}, // sizes
+            {-10, -5, 1, 10}, // input_data
+            OptScalar(-6), // min
+            OptScalar(-1), // max
+            {-6, -5, -1, -1}, // expected_data
+        },
+    };
+
+    run_test_cases(test_cases);
+  }
+
+  // Test cases that are compatible with float and double.
+  template <ScalarType DTYPE>
+  void run_floating_point_test_cases() {
+    constexpr auto kInfinity =
+        std::numeric_limits<typename TensorFactory<DTYPE>::ctype>::infinity();
+    std::vector<ClampTestCase<DTYPE>> test_cases = {
+        {
+            std::string(__func__) + ": Simple negative/positive clamp",
+            {2, 2}, // sizes
+            {-10.1, -1.1, 1.1, 10.1}, // input_data
+            OptScalar(-5.5), // min
+            OptScalar(5.5), // max
+            {-5.5, -1.1, 1.1, 5.5}, // expected_data
+        },
+        {
+            std::string(__func__) + ": Simple negative-only clamp",
+            {2, 2}, // sizes
+            {-10.1, -5.5, 1.1, 10.1}, // input_data
+            OptScalar(-6.6), // min
+            OptScalar(-1.1), // max
+            {-6.6, -5.5, -1.1, -1.1}, // expected_data
+        },
+        {
+            std::string(__func__) + ": Infinities are clamped",
+            {2, 2}, // sizes
+            {-kInfinity, -1.1, 1.1, kInfinity}, // input_data
+            OptScalar(-5.5), // min
+            OptScalar(5.5), // max
+            {-5.5, -1.1, 1.1, 5.5}, // expected_data
+        },
+        {
+            std::string(__func__) + ": Infinite min",
+            {2, 2}, // sizes
+            {-10.1, -1.1, 1.1, 10.1}, // input_data
+            OptScalar(-kInfinity), // min
+            OptScalar(5.5), // max
+            {-10.1, -1.1, 1.1, 5.5}, // expected_data
+        },
+        {
+            std::string(__func__) + ": Infinite max",
+            {2, 2}, // sizes
+            {-10.1, -1.1, 1.1, 10.1}, // input_data
+            OptScalar(-5.5), // min
+            OptScalar(kInfinity), // max
+            {-5.5, -1.1, 1.1, 10.1}, // expected_data
+        },
+        {
+            std::string(__func__) + ": NaN entries preserved",
+            {2, 2}, // sizes
+            {-10.1, NAN, NAN, 10.1}, // input_data
+            OptScalar(0.0), // min
+            OptScalar(0.0), // max
+            {0.0, NAN, NAN, 0.0}, // expected_data
+        },
+        {
+            std::string(__func__) + ": NaN min produces all NaN output",
+            {2, 2}, // sizes
+            {-10.1, -1.1, 1.1, 10.1}, // input_data
+            OptScalar(NAN), // min
+            OptScalar(5.5), // max
+            {NAN, NAN, NAN, NAN}, // expected_data
+        },
+        {
+            std::string(__func__) + ": NaN max produces all NaN output",
+            {2, 2}, // sizes
+            {-10.1, -1.1, 1.1, 10.1}, // input_data
+            OptScalar(-5.5), // min
+            OptScalar(NAN), // max
+            {NAN, NAN, NAN, NAN}, // expected_data
+        },
+    };
+
+    run_test_cases(test_cases);
+  }
+
+  // Tries clamping a DTYPE tensor to the provided value and expects it to die.
+  template <ScalarType DTYPE>
+  void expect_bad_clamp_value_dies(Scalar bad_value) {
+    TensorFactory<DTYPE> tf;
+    Tensor in = tf.ones({2, 2});
+    Tensor out = tf.zeros({2, 2});
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, op_clamp_out(in, /*min=*/bad_value, /*max=*/nullopt, out));
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, op_clamp_out(in, /*min=*/nullopt, /*max=*/bad_value, out));
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, op_clamp_out(in, /*min=*/bad_value, /*max=*/bad_value, out));
+  }
+
+  // One of min and max should be non-null
+  void expect_both_min_max_null_die() {
+    TensorFactory<ScalarType::Float> tf;
+    Tensor in = tf.ones({2, 2});
+    Tensor out = tf.zeros({2, 2});
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, op_clamp_out(in, /*min=*/nullopt, /*max=*/nullopt, out));
+  }
 };
 
-/// Runs the provided test cases.
-template <ScalarType DTYPE>
-void run_test_cases(std::vector<ClampTestCase<DTYPE>> test_cases) {
-  TensorFactory<DTYPE> tf;
-  for (const auto& test_case : test_cases) {
-    SCOPED_TRACE(test_case.title); // Printed if the test fails
-
-    Tensor in = tf.make(test_case.sizes, test_case.input_data);
-    Tensor out = tf.zeros(test_case.sizes);
-    Tensor ret = op_clamp_out(in, test_case.min, test_case.max, out);
-    EXPECT_TENSOR_EQ(out, ret);
-
-    Tensor expected = tf.make(test_case.sizes, test_case.expected_data);
-    ET_CHECK_SAME_SHAPE_AND_DTYPE2(out, expected);
-    EXPECT_TENSOR_EQ(out, expected);
+class OpClampTensorOutTest : public OperatorTest {
+ protected:
+  Tensor& op_clamp_tensor_out(
+      const Tensor& self,
+      const optional<Tensor>& min,
+      const optional<Tensor>& max,
+      Tensor& out) {
+    exec_aten::RuntimeContext context{};
+    return torch::executor::aten::clamp_outf(context, self, min, max, out);
   }
-}
+};
 
+/// Describes a test case, using tensors of the specified DTYPE.
 // Runs test cases that are compatible with uint8_t, and thus all other real
 // types. Cover the most cases here, since it's compatible with the most types.
-template <ScalarType DTYPE>
-void run_unsigned_integer_test_cases() {
-  const std::vector<ClampTestCase<DTYPE>> test_cases = {
-      {
-          std::string(__func__) + ": Simple clamp",
-          {2, 2}, // sizes
-          {0, 1, 10, 100}, // input_data
-          OptScalar(1), // min
-          OptScalar(6), // max
-          {1, 1, 6, 6}, // expected_data
-      },
-      {
-          std::string(__func__) + ": No max",
-          {2, 2}, // sizes
-          {0, 1, 10, 100}, // input_data
-          OptScalar(1), // min
-          nullopt, // max
-          {1, 1, 10, 100}, // expected_data
-      },
-      {
-          std::string(__func__) + ": No min",
-          {2, 2}, // sizes
-          {0, 1, 10, 100}, // input_data
-          nullopt, // min
-          OptScalar(6), // max
-          {0, 1, 6, 6}, // expected_data
-      },
-      {
-          std::string(__func__) + ": min > max",
-          {2, 2}, // sizes
-          {0, 1, 10, 100}, // input_data
-          OptScalar(10), // min
-          OptScalar(6), // max
-          // Should set all elements to max.
-          {6, 6, 6, 6}, // expected_data
-      },
-  };
-
-  run_test_cases(test_cases);
-}
-
 // Runs test cases that are compatible with int8_t, and thus all signed real
-// types.
-template <ScalarType DTYPE>
-void run_signed_integer_test_cases() {
-  std::vector<ClampTestCase<DTYPE>> test_cases = {
-      {
-          std::string(__func__) + ": Simple negative/positive clamp",
-          {2, 2}, // sizes
-          {-10, -1, 1, 10}, // input_data
-          OptScalar(-5), // min
-          OptScalar(5), // max
-          {-5, -1, 1, 5}, // expected_data
-      },
-      {
-          std::string(__func__) + ": Simple negative-only clamp",
-          {2, 2}, // sizes
-          {-10, -5, 1, 10}, // input_data
-          OptScalar(-6), // min
-          OptScalar(-1), // max
-          {-6, -5, -1, -1}, // expected_data
-      },
-  };
-
-  run_test_cases(test_cases);
-}
-
-// Test cases that are compatible with float and double.
-template <ScalarType DTYPE>
-void run_floating_point_test_cases() {
-  constexpr auto kInfinity =
-      std::numeric_limits<typename TensorFactory<DTYPE>::ctype>::infinity();
-  std::vector<ClampTestCase<DTYPE>> test_cases = {
-      {
-          std::string(__func__) + ": Simple negative/positive clamp",
-          {2, 2}, // sizes
-          {-10.1, -1.1, 1.1, 10.1}, // input_data
-          OptScalar(-5.5), // min
-          OptScalar(5.5), // max
-          {-5.5, -1.1, 1.1, 5.5}, // expected_data
-      },
-      {
-          std::string(__func__) + ": Simple negative-only clamp",
-          {2, 2}, // sizes
-          {-10.1, -5.5, 1.1, 10.1}, // input_data
-          OptScalar(-6.6), // min
-          OptScalar(-1.1), // max
-          {-6.6, -5.5, -1.1, -1.1}, // expected_data
-      },
-      {
-          std::string(__func__) + ": Infinities are clamped",
-          {2, 2}, // sizes
-          {-kInfinity, -1.1, 1.1, kInfinity}, // input_data
-          OptScalar(-5.5), // min
-          OptScalar(5.5), // max
-          {-5.5, -1.1, 1.1, 5.5}, // expected_data
-      },
-      {
-          std::string(__func__) + ": Infinite min",
-          {2, 2}, // sizes
-          {-10.1, -1.1, 1.1, 10.1}, // input_data
-          OptScalar(-kInfinity), // min
-          OptScalar(5.5), // max
-          {-10.1, -1.1, 1.1, 5.5}, // expected_data
-      },
-      {
-          std::string(__func__) + ": Infinite max",
-          {2, 2}, // sizes
-          {-10.1, -1.1, 1.1, 10.1}, // input_data
-          OptScalar(-5.5), // min
-          OptScalar(kInfinity), // max
-          {-5.5, -1.1, 1.1, 10.1}, // expected_data
-      },
-      {
-          std::string(__func__) + ": NaN entries preserved",
-          {2, 2}, // sizes
-          {-10.1, NAN, NAN, 10.1}, // input_data
-          OptScalar(0.0), // min
-          OptScalar(0.0), // max
-          {0.0, NAN, NAN, 0.0}, // expected_data
-      },
-      {
-          std::string(__func__) + ": NaN min produces all NaN output",
-          {2, 2}, // sizes
-          {-10.1, -1.1, 1.1, 10.1}, // input_data
-          OptScalar(NAN), // min
-          OptScalar(5.5), // max
-          {NAN, NAN, NAN, NAN}, // expected_data
-      },
-      {
-          std::string(__func__) + ": NaN max produces all NaN output",
-          {2, 2}, // sizes
-          {-10.1, -1.1, 1.1, 10.1}, // input_data
-          OptScalar(-5.5), // min
-          OptScalar(NAN), // max
-          {NAN, NAN, NAN, NAN}, // expected_data
-      },
-  };
-
-  run_test_cases(test_cases);
-}
-
-TEST(OpClampOutTest, ByteTensors) {
+TEST_F(OpClampOutTest, ByteTensors) {
   run_unsigned_integer_test_cases<ScalarType::Byte>();
 }
 
-TEST(OpClampOutTest, CharTensors) {
+TEST_F(OpClampOutTest, CharTensors) {
   run_unsigned_integer_test_cases<ScalarType::Char>();
   run_signed_integer_test_cases<ScalarType::Char>();
 }
 
-TEST(OpClampOutTest, ShortTensors) {
+TEST_F(OpClampOutTest, ShortTensors) {
   run_unsigned_integer_test_cases<ScalarType::Short>();
   run_signed_integer_test_cases<ScalarType::Short>();
 }
 
-TEST(OpClampOutTest, IntTensors) {
+TEST_F(OpClampOutTest, IntTensors) {
   run_unsigned_integer_test_cases<ScalarType::Int>();
   run_signed_integer_test_cases<ScalarType::Int>();
 }
 
-TEST(OpClampOutTest, LongTensors) {
+TEST_F(OpClampOutTest, LongTensors) {
   run_unsigned_integer_test_cases<ScalarType::Long>();
   run_signed_integer_test_cases<ScalarType::Long>();
 }
 
-TEST(OpClampOutTest, FloatTensors) {
+TEST_F(OpClampOutTest, FloatTensors) {
   // Note that the integer test cases test the situation where the min/max value
   // Scalars are integer types, demonstrating that floating point types can be
   // clamped to integer values.
@@ -263,7 +294,7 @@ TEST(OpClampOutTest, FloatTensors) {
   run_floating_point_test_cases<ScalarType::Float>();
 }
 
-TEST(OpClampOutTest, DoubleTensors) {
+TEST_F(OpClampOutTest, DoubleTensors) {
   // Note that the integer test cases test the situation where the min/max value
   // Scalars are integer types, demonstrating that floating point types can be
   // clamped to integer values.
@@ -272,27 +303,12 @@ TEST(OpClampOutTest, DoubleTensors) {
   run_floating_point_test_cases<ScalarType::Double>();
 }
 
-// Tries clamping a DTYPE tensor to the provided value and expects it to die.
-template <ScalarType DTYPE>
-void expect_bad_clamp_value_dies(Scalar bad_value) {
-  TensorFactory<DTYPE> tf;
-  Tensor in = tf.ones({2, 2});
-  Tensor out = tf.zeros({2, 2});
-
-  ET_EXPECT_KERNEL_FAILURE(
-      op_clamp_out(in, /*min=*/bad_value, /*max=*/nullopt, out));
-  ET_EXPECT_KERNEL_FAILURE(
-      op_clamp_out(in, /*min=*/nullopt, /*max=*/bad_value, out));
-  ET_EXPECT_KERNEL_FAILURE(
-      op_clamp_out(in, /*min=*/bad_value, /*max=*/bad_value, out));
-}
-
 //
 // Don't test every type, just a representative sample: unsigned int, signed
 // int, floating point.
 //
 
-TEST(OpClampOutTest, ByteTensorNegativeClampDies) {
+TEST_F(OpClampOutTest, ByteTensorNegativeClampDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle negative clamp on byte tensor";
   }
@@ -300,54 +316,44 @@ TEST(OpClampOutTest, ByteTensorNegativeClampDies) {
   expect_bad_clamp_value_dies<ScalarType::Byte>(-1);
 }
 
-TEST(OpClampOutTest, ByteTensorTooLargeClampDies) {
+TEST_F(OpClampOutTest, ByteTensorTooLargeClampDies) {
   // Cannot be represented by a uint8_t.
   expect_bad_clamp_value_dies<ScalarType::Byte>(256);
 }
 
-TEST(OpClampOutTest, ByteTensorFloatingPointClampDies) {
+TEST_F(OpClampOutTest, ByteTensorFloatingPointClampDies) {
   // Cannot be represented by a uint8_t.
   expect_bad_clamp_value_dies<ScalarType::Byte>(2.2);
 }
 
 #ifndef USE_ATEN_LIB
-TEST(OpClampOutTest, IntTensorTooSmallClampDies) {
+TEST_F(OpClampOutTest, IntTensorTooSmallClampDies) {
   // Cannot be represented by a int32_t.
   expect_bad_clamp_value_dies<ScalarType::Int>(-2147483649);
 }
 
-TEST(OpClampOutTest, IntTensorTooLargeClampDies) {
+TEST_F(OpClampOutTest, IntTensorTooLargeClampDies) {
   // Cannot be represented by a int32_t.
   expect_bad_clamp_value_dies<ScalarType::Int>(2147483648);
 }
 #endif
 
-TEST(OpClampOutTest, IntTensorFloatingPointClampDies) {
+TEST_F(OpClampOutTest, IntTensorFloatingPointClampDies) {
   // Cannot be represented by a uint32_t.
   expect_bad_clamp_value_dies<ScalarType::Int>(2.2);
 }
 
-TEST(OpClampOutTest, FloatTensorTooSmallClampDies) {
+TEST_F(OpClampOutTest, FloatTensorTooSmallClampDies) {
   // Cannot be represented by a float.
   expect_bad_clamp_value_dies<ScalarType::Float>(-3.41e+38);
 }
 
-TEST(OpClampOutTest, FloatTensorTooLargeClampDies) {
+TEST_F(OpClampOutTest, FloatTensorTooLargeClampDies) {
   // Cannot be represented by a float.
   expect_bad_clamp_value_dies<ScalarType::Float>(3.41e+38);
 }
 
-// One of min and max should be non-null
-void expect_both_min_max_null_die() {
-  TensorFactory<ScalarType::Float> tf;
-  Tensor in = tf.ones({2, 2});
-  Tensor out = tf.zeros({2, 2});
-
-  ET_EXPECT_KERNEL_FAILURE(
-      op_clamp_out(in, /*min=*/nullopt, /*max=*/nullopt, out));
-}
-
-TEST(OpClampOutTest, SimpleGeneratedCase) {
+TEST_F(OpClampOutTest, SimpleGeneratedCase) {
   TensorFactory<ScalarType::Float> tf;
 
   auto x = tf.make(
@@ -378,7 +384,7 @@ TEST(OpClampOutTest, SimpleGeneratedCase) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpClampOutTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpClampOutTest, DynamicShapeUpperBoundSameAsExpected) {
   TensorFactory<ScalarType::Float> tf;
 
   auto x = tf.make(
@@ -400,7 +406,7 @@ TEST(OpClampOutTest, DynamicShapeUpperBoundSameAsExpected) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpClampOutTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpClampOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   GTEST_SKIP() << "Dynamic shape not supported";
   TensorFactory<ScalarType::Float> tf;
 
@@ -423,7 +429,7 @@ TEST(OpClampOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpClampOutTest, DynamicShapeUnbound) {
+TEST_F(OpClampOutTest, DynamicShapeUnbound) {
   GTEST_SKIP() << "Dynamic shape not supported";
   TensorFactory<ScalarType::Float> tf;
 
@@ -446,7 +452,7 @@ TEST(OpClampOutTest, DynamicShapeUnbound) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpClampTensorOutTest, SmokeTest) {
+TEST_F(OpClampTensorOutTest, SmokeTest) {
   TensorFactory<ScalarType::Byte> tf_in;
   TensorFactory<ScalarType::Int> tf_min;
   TensorFactory<ScalarType::Char> tf_max;

--- a/kernels/test/op_clone_test.cpp
+++ b/kernels/test/op_clone_test.cpp
@@ -22,44 +22,57 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_clone_out(
-    const Tensor& self,
-    optional<MemoryFormat> memory_format,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::clone_outf(context, self, memory_format, out);
-}
+class OpCloneTest : public OperatorTest {
+ protected:
+  Tensor& op_clone_out(
+      const Tensor& self,
+      optional<MemoryFormat> memory_format,
+      Tensor& out) {
+    return torch::executor::aten::clone_outf(
+        context_, self, memory_format, out);
+  }
+
+  // test if clone.out works well under all kinds of legal input type.
+  template <class CTYPE, exec_aten::ScalarType DTYPE>
+  void test_dtype() {
+    TensorFactory<DTYPE> tf;
+    Tensor input = tf.make(/*sizes=*/{2, 4}, /*data=*/{2, 3, 2, 4, 1, 5, 1, 6});
+    Tensor out_nullopt = tf.zeros(/*sizes=*/{2, 4});
+    Tensor out_contiguous = tf.zeros(/*sizes=*/{2, 4});
+
+    // we only support contiguous memory, the memory type shall be either
+    // nullopt or MemoryFormat::Contiguous.
+    Tensor out_nullopt_ret = op_clone_out(
+        /*self=*/input,
+        /*memory_format=*/exec_aten::nullopt,
+        /*out=*/out_nullopt);
+    Tensor out_contiguous_ret = op_clone_out(
+        /*self=*/input,
+        /*memory_format=*/exec_aten::MemoryFormat::Contiguous,
+        /*out=*/out_contiguous);
+
+    // The original tensor a should share same value with the out variable and
+    // return variable of clone function
+    EXPECT_TENSOR_EQ(input, out_nullopt);
+    EXPECT_TENSOR_EQ(input, out_nullopt_ret);
+
+    EXPECT_TENSOR_EQ(input, out_contiguous);
+    EXPECT_TENSOR_EQ(input, out_contiguous_ret);
+  }
+
+  template <class CTYPE, ScalarType DTYPE>
+  void test_empty_input() {
+    TensorFactory<DTYPE> tf;
+    Tensor input = tf.make(/*sizes=*/{3, 0, 1, 2}, /*data=*/{});
+    Tensor out = tf.zeros({3, 0, 1, 2});
+    op_clone_out(input, /*memory_format=*/exec_aten::nullopt, out);
+    // check a and out share same value, but are different object
+    EXPECT_TENSOR_EQ(input, out);
+  }
+};
 
 // regular test for clone.out
-// test if clone.out works well under all kinds of legal input type.
-template <class CTYPE, exec_aten::ScalarType DTYPE>
-void test_dtype() {
-  TensorFactory<DTYPE> tf;
-  Tensor input = tf.make(/*sizes=*/{2, 4}, /*data=*/{2, 3, 2, 4, 1, 5, 1, 6});
-  Tensor out_nullopt = tf.zeros(/*sizes=*/{2, 4});
-  Tensor out_contiguous = tf.zeros(/*sizes=*/{2, 4});
-
-  // we only support contiguous memory, the memory type shall be either nullopt
-  // or MemoryFormat::Contiguous.
-  Tensor out_nullopt_ret = op_clone_out(
-      /*self=*/input,
-      /*memory_format=*/exec_aten::nullopt,
-      /*out=*/out_nullopt);
-  Tensor out_contiguous_ret = op_clone_out(
-      /*self=*/input,
-      /*memory_format=*/exec_aten::MemoryFormat::Contiguous,
-      /*out=*/out_contiguous);
-
-  // The original tensor a should share same value with the out variable and
-  // return variable of clone function
-  EXPECT_TENSOR_EQ(input, out_nullopt);
-  EXPECT_TENSOR_EQ(input, out_nullopt_ret);
-
-  EXPECT_TENSOR_EQ(input, out_contiguous);
-  EXPECT_TENSOR_EQ(input, out_contiguous_ret);
-}
-
-TEST(OpCloneTest, AllDtypesSupported) {
+TEST_F(OpCloneTest, AllDtypesSupported) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel test fails";
   }
@@ -68,23 +81,13 @@ TEST(OpCloneTest, AllDtypesSupported) {
 #undef TEST_ENTRY
 }
 
-template <class CTYPE, ScalarType DTYPE>
-void test_empty_input() {
-  TensorFactory<DTYPE> tf;
-  Tensor input = tf.make(/*sizes=*/{3, 0, 1, 2}, /*data=*/{});
-  Tensor out = tf.zeros({3, 0, 1, 2});
-  op_clone_out(input, /*memory_format=*/exec_aten::nullopt, out);
-  // check a and out share same value, but are different object
-  EXPECT_TENSOR_EQ(input, out);
-}
-
-TEST(OpCloneTest, EmptyInputSupported) {
+TEST_F(OpCloneTest, EmptyInputSupported) {
 #define TEST_ENTRY(ctype, dtype) test_empty_input<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpCloneTest, MismatchedSizesDie) {
+TEST_F(OpCloneTest, MismatchedSizesDie) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched sizes";
   }
@@ -92,23 +95,23 @@ TEST(OpCloneTest, MismatchedSizesDie) {
   Tensor input = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf.zeros({3, 2, 1, 1});
   ET_EXPECT_KERNEL_FAILURE(
-      op_clone_out(input, /*memory_format=*/exec_aten::nullopt, out));
+      context_, op_clone_out(input, /*memory_format=*/exec_aten::nullopt, out));
 }
 
-TEST(OpCloneTest, MismatchedTypesDie) {
+TEST_F(OpCloneTest, MismatchedTypesDie) {
   TensorFactory<ScalarType::Int> tf_in;
   TensorFactory<ScalarType::Float> tf_out;
   Tensor input =
       tf_in.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf_out.zeros({3, 1, 1, 2});
   ET_EXPECT_KERNEL_FAILURE(
-      op_clone_out(input, /*memory_format=*/exec_aten::nullopt, out));
+      context_, op_clone_out(input, /*memory_format=*/exec_aten::nullopt, out));
 }
 
 // Only contiguous memory is supported, the memory type other than nullopt or
 // MemoryFormat::Contiguous should not be allowed. The function is expected
 // depth if using the illegal memory format.
-TEST(OpCloneTest, MismatchedMemoryFormatDie) {
+TEST_F(OpCloneTest, MismatchedMemoryFormatDie) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle non contiguous memory formats";
   }
@@ -118,10 +121,11 @@ TEST(OpCloneTest, MismatchedMemoryFormatDie) {
       tf_in.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf_out.zeros({3, 1, 1, 2});
   ET_EXPECT_KERNEL_FAILURE(
+      context_,
       op_clone_out(input, static_cast<exec_aten::MemoryFormat>(55), out));
 }
 
-TEST(OpCloneTest, SimpleGeneratedCase) {
+TEST_F(OpCloneTest, SimpleGeneratedCase) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.make(
@@ -150,7 +154,7 @@ TEST(OpCloneTest, SimpleGeneratedCase) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpCloneTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpCloneTest, DynamicShapeUpperBoundSameAsExpected) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.make(
@@ -176,7 +180,7 @@ TEST(OpCloneTest, DynamicShapeUpperBoundSameAsExpected) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpCloneTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpCloneTest, DynamicShapeUpperBoundLargerThanExpected) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.make(
@@ -202,7 +206,7 @@ TEST(OpCloneTest, DynamicShapeUpperBoundLargerThanExpected) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpCloneTest, DynamicShapeUnbound) {
+TEST_F(OpCloneTest, DynamicShapeUnbound) {
   GTEST_SKIP() << "Dynamic shape unbound not supported";
   TensorFactory<ScalarType::Float> tf;
 

--- a/kernels/test/op_constant_pad_nd_test.cpp
+++ b/kernels/test/op_constant_pad_nd_test.cpp
@@ -23,331 +23,333 @@ using exec_aten::Tensor;
 using torch::executor::testing::SupportedFeatures;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_constant_pad_nd_out(
-    const Tensor& self,
-    const IntArrayRef padding,
-    const Scalar& value,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::constant_pad_nd_outf(
-      context, self, padding, value, out);
-}
+class OpConstantPadNDOutTest : public OperatorTest {
+ protected:
+  Tensor& op_constant_pad_nd_out(
+      const Tensor& self,
+      const IntArrayRef padding,
+      const Scalar& value,
+      Tensor& out) {
+    return torch::executor::aten::constant_pad_nd_outf(
+        context_, self, padding, value, out);
+  }
 
-template <ScalarType DTYPE>
-void test_constant_pad_nd_out_dim2() {
-  TensorFactory<DTYPE> tf;
+  template <ScalarType DTYPE>
+  void test_constant_pad_nd_out_dim2() {
+    TensorFactory<DTYPE> tf;
 
-  const std::vector<int32_t> sizes = {2, 4, 4};
-  const std::vector<int32_t> sizes_out = {2, 4, 6};
-  const std::vector<int64_t> padding = {1, 1};
+    const std::vector<int32_t> sizes = {2, 4, 4};
+    const std::vector<int32_t> sizes_out = {2, 4, 6};
+    const std::vector<int64_t> padding = {1, 1};
 
-  // clang-format off
-  Tensor self = tf.make(
-      sizes,
-      {
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
+    // clang-format off
+    Tensor self = tf.make(
+        sizes,
+        {
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+  
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+        });
+    // clang-format on
 
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-      });
-  // clang-format on
+    // clang-format off
+    Tensor expected = tf.make(
+        sizes_out,
+        {
+           7,  1,  2,  3,  4,  7,
+           7,  5,  6,  7,  8,  7,
+           7,  1,  2,  3,  4,  7,
+           7,  5,  6,  7,  8,  7,
+  
+           7,  1,  2,  3,  4,  7,
+           7,  5,  6,  7,  8,  7,
+           7,  1,  2,  3,  4,  7,
+           7,  5,  6,  7,  8,  7,
+        });
+    // clang-format on
 
-  // clang-format off
-  Tensor expected = tf.make(
-      sizes_out,
-      {
-         7,  1,  2,  3,  4,  7,
-         7,  5,  6,  7,  8,  7,
-         7,  1,  2,  3,  4,  7,
-         7,  5,  6,  7,  8,  7,
+    IntArrayRef padding_ref = IntArrayRef(padding.data(), padding.size());
+    Tensor out = tf.zeros(sizes_out);
 
-         7,  1,  2,  3,  4,  7,
-         7,  5,  6,  7,  8,  7,
-         7,  1,  2,  3,  4,  7,
-         7,  5,  6,  7,  8,  7,
-      });
-  // clang-format on
+    // Valid input should give the expected output
+    op_constant_pad_nd_out(self, padding_ref, 7, out);
+    EXPECT_TENSOR_CLOSE(out, expected);
+  }
 
-  IntArrayRef padding_ref = IntArrayRef(padding.data(), padding.size());
-  Tensor out = tf.zeros(sizes_out);
+  template <ScalarType DTYPE>
+  void test_constant_pad_nd_out_dim1() {
+    TensorFactory<DTYPE> tf;
 
-  // Valid input should give the expected output
-  op_constant_pad_nd_out(self, padding_ref, 7, out);
-  EXPECT_TENSOR_CLOSE(out, expected);
-}
+    const std::vector<int32_t> sizes = {2, 4, 4};
+    const std::vector<int32_t> sizes_out = {2, 6, 4};
+    const std::vector<int64_t> padding = {0, 0, 2, 0};
 
-template <ScalarType DTYPE>
-void test_constant_pad_nd_out_dim1() {
-  TensorFactory<DTYPE> tf;
+    // clang-format off
+    Tensor self = tf.make(
+        sizes,
+        {
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+  
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+        });
+    // clang-format on
 
-  const std::vector<int32_t> sizes = {2, 4, 4};
-  const std::vector<int32_t> sizes_out = {2, 6, 4};
-  const std::vector<int64_t> padding = {0, 0, 2, 0};
+    // clang-format off
+    Tensor expected = tf.make(
+        sizes_out,
+        {
+           7,  7,  7,  7,
+           7,  7,  7,  7,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+  
+           7,  7,  7,  7,
+           7,  7,  7,  7,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+        });
+    // clang-format on
 
-  // clang-format off
-  Tensor self = tf.make(
-      sizes,
-      {
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
+    IntArrayRef padding_ref = IntArrayRef(padding.data(), padding.size());
+    Tensor out = tf.zeros(sizes_out);
 
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-      });
-  // clang-format on
+    // Valid input should give the expected output
+    op_constant_pad_nd_out(self, padding_ref, 7, out);
+    EXPECT_TENSOR_CLOSE(out, expected);
+  }
 
-  // clang-format off
-  Tensor expected = tf.make(
-      sizes_out,
-      {
-         7,  7,  7,  7,
-         7,  7,  7,  7,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
+  template <ScalarType DTYPE>
+  void test_constant_pad_nd_out_dim0() {
+    TensorFactory<DTYPE> tf;
 
-         7,  7,  7,  7,
-         7,  7,  7,  7,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-      });
-  // clang-format on
+    const std::vector<int32_t> sizes = {2, 4, 4};
+    const std::vector<int32_t> sizes_out = {3, 4, 4};
+    const std::vector<int64_t> padding = {0, 0, 0, 0, 1, 0};
 
-  IntArrayRef padding_ref = IntArrayRef(padding.data(), padding.size());
-  Tensor out = tf.zeros(sizes_out);
+    // clang-format off
+    Tensor self = tf.make(
+        sizes,
+        {
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+  
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+        });
+    // clang-format on
 
-  // Valid input should give the expected output
-  op_constant_pad_nd_out(self, padding_ref, 7, out);
-  EXPECT_TENSOR_CLOSE(out, expected);
-}
+    // clang-format off
+    Tensor expected = tf.make(
+        sizes_out,
+        {
+           7,  7,  7,  7,
+           7,  7,  7,  7,
+           7,  7,  7,  7,
+           7,  7,  7,  7,
+  
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+  
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+        });
+    // clang-format on
 
-template <ScalarType DTYPE>
-void test_constant_pad_nd_out_dim0() {
-  TensorFactory<DTYPE> tf;
+    IntArrayRef padding_ref = IntArrayRef(padding.data(), padding.size());
+    Tensor out = tf.zeros(sizes_out);
 
-  const std::vector<int32_t> sizes = {2, 4, 4};
-  const std::vector<int32_t> sizes_out = {3, 4, 4};
-  const std::vector<int64_t> padding = {0, 0, 0, 0, 1, 0};
+    // Valid input should give the expected output
+    op_constant_pad_nd_out(self, padding_ref, 7, out);
+    EXPECT_TENSOR_CLOSE(out, expected);
+  }
 
-  // clang-format off
-  Tensor self = tf.make(
-      sizes,
-      {
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
+  template <ScalarType DTYPE>
+  void test_constant_pad_nd_out_dim12() {
+    TensorFactory<DTYPE> tf;
 
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-      });
-  // clang-format on
+    const std::vector<int32_t> sizes = {2, 4, 4};
+    const std::vector<int32_t> sizes_out = {2, 6, 7};
+    const std::vector<int64_t> padding = {2, 1, 0, 2};
 
-  // clang-format off
-  Tensor expected = tf.make(
-      sizes_out,
-      {
-         7,  7,  7,  7,
-         7,  7,  7,  7,
-         7,  7,  7,  7,
-         7,  7,  7,  7,
+    // clang-format off
+    Tensor self = tf.make(
+        sizes,
+        {
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+  
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+        });
+    // clang-format on
 
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
+    // clang-format off
+    Tensor expected = tf.make(
+        sizes_out,
+        {
+           7,  7,  1,  2,  3,  4,  7,
+           7,  7,  5,  6,  7,  8,  7,
+           7,  7,  1,  2,  3,  4,  7,
+           7,  7,  5,  6,  7,  8,  7,
+           7,  7,  7,  7,  7,  7,  7,
+           7,  7,  7,  7,  7,  7,  7,
+  
+           7,  7,  1,  2,  3,  4,  7,
+           7,  7,  5,  6,  7,  8,  7,
+           7,  7,  1,  2,  3,  4,  7,
+           7,  7,  5,  6,  7,  8,  7,
+           7,  7,  7,  7,  7,  7,  7,
+           7,  7,  7,  7,  7,  7,  7,
+        });
+    // clang-format on
 
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-      });
-  // clang-format on
+    IntArrayRef padding_ref = IntArrayRef(padding.data(), padding.size());
+    Tensor out = tf.zeros(sizes_out);
 
-  IntArrayRef padding_ref = IntArrayRef(padding.data(), padding.size());
-  Tensor out = tf.zeros(sizes_out);
+    // Valid input should give the expected output
+    op_constant_pad_nd_out(self, padding_ref, 7, out);
+    EXPECT_TENSOR_CLOSE(out, expected);
+  }
 
-  // Valid input should give the expected output
-  op_constant_pad_nd_out(self, padding_ref, 7, out);
-  EXPECT_TENSOR_CLOSE(out, expected);
-}
+  template <ScalarType DTYPE>
+  void test_constant_pad_nd_out_dim02() {
+    TensorFactory<DTYPE> tf;
 
-template <ScalarType DTYPE>
-void test_constant_pad_nd_out_dim12() {
-  TensorFactory<DTYPE> tf;
+    const std::vector<int32_t> sizes = {2, 4, 4};
+    const std::vector<int32_t> sizes_out = {3, 4, 7};
+    const std::vector<int64_t> padding = {2, 1, 0, 0, 0, 1};
 
-  const std::vector<int32_t> sizes = {2, 4, 4};
-  const std::vector<int32_t> sizes_out = {2, 6, 7};
-  const std::vector<int64_t> padding = {2, 1, 0, 2};
+    // clang-format off
+    Tensor self = tf.make(
+        sizes,
+        {
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+  
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+        });
+    // clang-format on
 
-  // clang-format off
-  Tensor self = tf.make(
-      sizes,
-      {
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
+    // clang-format off
+    Tensor expected = tf.make(
+        sizes_out,
+        {
+           7,  7,  1,  2,  3,  4,  7,
+           7,  7,  5,  6,  7,  8,  7,
+           7,  7,  1,  2,  3,  4,  7,
+           7,  7,  5,  6,  7,  8,  7,
+  
+           7,  7,  1,  2,  3,  4,  7,
+           7,  7,  5,  6,  7,  8,  7,
+           7,  7,  1,  2,  3,  4,  7,
+           7,  7,  5,  6,  7,  8,  7,
+  
+           7,  7,  7,  7,  7,  7,  7,
+           7,  7,  7,  7,  7,  7,  7,
+           7,  7,  7,  7,  7,  7,  7,
+           7,  7,  7,  7,  7,  7,  7,
+        });
+    // clang-format on
 
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-      });
-  // clang-format on
+    IntArrayRef padding_ref = IntArrayRef(padding.data(), padding.size());
+    Tensor out = tf.zeros(sizes_out);
 
-  // clang-format off
-  Tensor expected = tf.make(
-      sizes_out,
-      {
-         7,  7,  1,  2,  3,  4,  7,
-         7,  7,  5,  6,  7,  8,  7,
-         7,  7,  1,  2,  3,  4,  7,
-         7,  7,  5,  6,  7,  8,  7,
-         7,  7,  7,  7,  7,  7,  7,
-         7,  7,  7,  7,  7,  7,  7,
+    // Valid input should give the expected output
+    op_constant_pad_nd_out(self, padding_ref, 7, out);
+    EXPECT_TENSOR_CLOSE(out, expected);
+  }
 
-         7,  7,  1,  2,  3,  4,  7,
-         7,  7,  5,  6,  7,  8,  7,
-         7,  7,  1,  2,  3,  4,  7,
-         7,  7,  5,  6,  7,  8,  7,
-         7,  7,  7,  7,  7,  7,  7,
-         7,  7,  7,  7,  7,  7,  7,
-      });
-  // clang-format on
+  template <ScalarType DTYPE>
+  void test_constant_pad_nd_out_dim012() {
+    TensorFactory<DTYPE> tf;
 
-  IntArrayRef padding_ref = IntArrayRef(padding.data(), padding.size());
-  Tensor out = tf.zeros(sizes_out);
+    const std::vector<int32_t> sizes = {2, 4, 4};
+    const std::vector<int32_t> sizes_out = {3, 5, 7};
+    const std::vector<int64_t> padding = {2, 1, 1, 0, 0, 1};
 
-  // Valid input should give the expected output
-  op_constant_pad_nd_out(self, padding_ref, 7, out);
-  EXPECT_TENSOR_CLOSE(out, expected);
-}
+    // clang-format off
+    Tensor self = tf.make(
+        sizes,
+        {
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+  
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+           1,  2,  3,  4,
+           5,  6,  7,  8,
+        });
+    // clang-format on
 
-template <ScalarType DTYPE>
-void test_constant_pad_nd_out_dim02() {
-  TensorFactory<DTYPE> tf;
+    // clang-format off
+    Tensor expected = tf.make(
+        sizes_out,
+        {
+           7,  7,  7,  7,  7,  7,  7,
+           7,  7,  1,  2,  3,  4,  7,
+           7,  7,  5,  6,  7,  8,  7,
+           7,  7,  1,  2,  3,  4,  7,
+           7,  7,  5,  6,  7,  8,  7,
+  
+           7,  7,  7,  7,  7,  7,  7,
+           7,  7,  1,  2,  3,  4,  7,
+           7,  7,  5,  6,  7,  8,  7,
+           7,  7,  1,  2,  3,  4,  7,
+           7,  7,  5,  6,  7,  8,  7,
+  
+           7,  7,  7,  7,  7,  7,  7,
+           7,  7,  7,  7,  7,  7,  7,
+           7,  7,  7,  7,  7,  7,  7,
+           7,  7,  7,  7,  7,  7,  7,
+           7,  7,  7,  7,  7,  7,  7,
+        });
+    // clang-format on
 
-  const std::vector<int32_t> sizes = {2, 4, 4};
-  const std::vector<int32_t> sizes_out = {3, 4, 7};
-  const std::vector<int64_t> padding = {2, 1, 0, 0, 0, 1};
+    IntArrayRef padding_ref = IntArrayRef(padding.data(), padding.size());
+    Tensor out = tf.zeros(sizes_out);
 
-  // clang-format off
-  Tensor self = tf.make(
-      sizes,
-      {
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
+    // Valid input should give the expected output
+    op_constant_pad_nd_out(self, padding_ref, 7, out);
+    EXPECT_TENSOR_CLOSE(out, expected);
+  }
+};
 
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-      });
-  // clang-format on
-
-  // clang-format off
-  Tensor expected = tf.make(
-      sizes_out,
-      {
-         7,  7,  1,  2,  3,  4,  7,
-         7,  7,  5,  6,  7,  8,  7,
-         7,  7,  1,  2,  3,  4,  7,
-         7,  7,  5,  6,  7,  8,  7,
-
-         7,  7,  1,  2,  3,  4,  7,
-         7,  7,  5,  6,  7,  8,  7,
-         7,  7,  1,  2,  3,  4,  7,
-         7,  7,  5,  6,  7,  8,  7,
-
-         7,  7,  7,  7,  7,  7,  7,
-         7,  7,  7,  7,  7,  7,  7,
-         7,  7,  7,  7,  7,  7,  7,
-         7,  7,  7,  7,  7,  7,  7,
-      });
-  // clang-format on
-
-  IntArrayRef padding_ref = IntArrayRef(padding.data(), padding.size());
-  Tensor out = tf.zeros(sizes_out);
-
-  // Valid input should give the expected output
-  op_constant_pad_nd_out(self, padding_ref, 7, out);
-  EXPECT_TENSOR_CLOSE(out, expected);
-}
-
-template <ScalarType DTYPE>
-void test_constant_pad_nd_out_dim012() {
-  TensorFactory<DTYPE> tf;
-
-  const std::vector<int32_t> sizes = {2, 4, 4};
-  const std::vector<int32_t> sizes_out = {3, 5, 7};
-  const std::vector<int64_t> padding = {2, 1, 1, 0, 0, 1};
-
-  // clang-format off
-  Tensor self = tf.make(
-      sizes,
-      {
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-         1,  2,  3,  4,
-         5,  6,  7,  8,
-      });
-  // clang-format on
-
-  // clang-format off
-  Tensor expected = tf.make(
-      sizes_out,
-      {
-         7,  7,  7,  7,  7,  7,  7,
-         7,  7,  1,  2,  3,  4,  7,
-         7,  7,  5,  6,  7,  8,  7,
-         7,  7,  1,  2,  3,  4,  7,
-         7,  7,  5,  6,  7,  8,  7,
-
-         7,  7,  7,  7,  7,  7,  7,
-         7,  7,  1,  2,  3,  4,  7,
-         7,  7,  5,  6,  7,  8,  7,
-         7,  7,  1,  2,  3,  4,  7,
-         7,  7,  5,  6,  7,  8,  7,
-
-         7,  7,  7,  7,  7,  7,  7,
-         7,  7,  7,  7,  7,  7,  7,
-         7,  7,  7,  7,  7,  7,  7,
-         7,  7,  7,  7,  7,  7,  7,
-         7,  7,  7,  7,  7,  7,  7,
-      });
-  // clang-format on
-
-  IntArrayRef padding_ref = IntArrayRef(padding.data(), padding.size());
-  Tensor out = tf.zeros(sizes_out);
-
-  // Valid input should give the expected output
-  op_constant_pad_nd_out(self, padding_ref, 7, out);
-  EXPECT_TENSOR_CLOSE(out, expected);
-}
-
-TEST(OpConstantPadNDOutKernelTest, TestPadDim2) {
+TEST_F(OpConstantPadNDOutTest, TestPadDim2) {
 #define TEST_ENTRY(ctype, dtype) \
   test_constant_pad_nd_out_dim2<ScalarType::dtype>();
 
@@ -355,7 +357,7 @@ TEST(OpConstantPadNDOutKernelTest, TestPadDim2) {
 #undef TEST_ENTRY
 }
 
-TEST(OpConstantPadNDOutKernelTest, TestPadDim1) {
+TEST_F(OpConstantPadNDOutTest, TestPadDim1) {
 #define TEST_ENTRY(ctype, dtype) \
   test_constant_pad_nd_out_dim1<ScalarType::dtype>();
 
@@ -363,7 +365,7 @@ TEST(OpConstantPadNDOutKernelTest, TestPadDim1) {
 #undef TEST_ENTRY
 }
 
-TEST(OpConstantPadNDOutKernelTest, TestPadDim0) {
+TEST_F(OpConstantPadNDOutTest, TestPadDim0) {
 #define TEST_ENTRY(ctype, dtype) \
   test_constant_pad_nd_out_dim0<ScalarType::dtype>();
 
@@ -371,7 +373,7 @@ TEST(OpConstantPadNDOutKernelTest, TestPadDim0) {
 #undef TEST_ENTRY
 }
 
-TEST(OpConstantPadNDOutKernelTest, TestPadDim1And2) {
+TEST_F(OpConstantPadNDOutTest, TestPadDim1And2) {
 #define TEST_ENTRY(ctype, dtype) \
   test_constant_pad_nd_out_dim12<ScalarType::dtype>();
 
@@ -379,7 +381,7 @@ TEST(OpConstantPadNDOutKernelTest, TestPadDim1And2) {
 #undef TEST_ENTRY
 }
 
-TEST(OpConstantPadNDOutKernelTest, TestPadDim0And2) {
+TEST_F(OpConstantPadNDOutTest, TestPadDim0And2) {
 #define TEST_ENTRY(ctype, dtype) \
   test_constant_pad_nd_out_dim02<ScalarType::dtype>();
 
@@ -387,7 +389,7 @@ TEST(OpConstantPadNDOutKernelTest, TestPadDim0And2) {
 #undef TEST_ENTRY
 }
 
-TEST(OpConstantPadNDOutKernelTest, TestPadDim0And1And2) {
+TEST_F(OpConstantPadNDOutTest, TestPadDim0And1And2) {
 #define TEST_ENTRY(ctype, dtype) \
   test_constant_pad_nd_out_dim012<ScalarType::dtype>();
 
@@ -395,7 +397,7 @@ TEST(OpConstantPadNDOutKernelTest, TestPadDim0And1And2) {
 #undef TEST_ENTRY
 }
 
-TEST(OpConstantPadNDOutKernelTest, DifferentInputOutputTypesFail) {
+TEST_F(OpConstantPadNDOutTest, DifferentInputOutputTypesFail) {
   TensorFactory<ScalarType::Float> tf;
   TensorFactory<ScalarType::Double> tf_out;
 
@@ -408,10 +410,11 @@ TEST(OpConstantPadNDOutKernelTest, DifferentInputOutputTypesFail) {
   Tensor self = tf.ones(sizes);
   Tensor out = tf_out.zeros(sizes_out);
 
-  ET_EXPECT_KERNEL_FAILURE(op_constant_pad_nd_out(self, padding_ref, 0, out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_, op_constant_pad_nd_out(self, padding_ref, 0, out));
 }
 
-TEST(OpConstantPadNDOutKernelTest, OddNumberOfPaddingElementsFail) {
+TEST_F(OpConstantPadNDOutTest, OddNumberOfPaddingElementsFail) {
   TensorFactory<ScalarType::Float> tf;
 
   const std::vector<int32_t> sizes = {1, 4, 4};
@@ -423,10 +426,11 @@ TEST(OpConstantPadNDOutKernelTest, OddNumberOfPaddingElementsFail) {
   Tensor self = tf.ones(sizes);
   Tensor out = tf.zeros(sizes_out);
 
-  ET_EXPECT_KERNEL_FAILURE(op_constant_pad_nd_out(self, padding_ref, 0, out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_, op_constant_pad_nd_out(self, padding_ref, 0, out));
 }
 
-TEST(OpConstantPadNDOutKernelTest, TooManyPaddingElementsFail) {
+TEST_F(OpConstantPadNDOutTest, TooManyPaddingElementsFail) {
   TensorFactory<ScalarType::Float> tf;
 
   const std::vector<int32_t> sizes = {1, 4, 4};
@@ -438,10 +442,11 @@ TEST(OpConstantPadNDOutKernelTest, TooManyPaddingElementsFail) {
   Tensor self = tf.ones(sizes);
   Tensor out = tf.zeros(sizes_out);
 
-  ET_EXPECT_KERNEL_FAILURE(op_constant_pad_nd_out(self, padding_ref, 0, out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_, op_constant_pad_nd_out(self, padding_ref, 0, out));
 }
 
-TEST(OpConstantPadNDOutKernelTest, IncorrectOutputShapeFail) {
+TEST_F(OpConstantPadNDOutTest, IncorrectOutputShapeFail) {
   if (SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle reshape output";
   }
@@ -457,5 +462,6 @@ TEST(OpConstantPadNDOutKernelTest, IncorrectOutputShapeFail) {
   Tensor self = tf.ones(sizes);
   Tensor out = tf.zeros(sizes_out);
 
-  ET_EXPECT_KERNEL_FAILURE(op_constant_pad_nd_out(self, padding_ref, 0, out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_, op_constant_pad_nd_out(self, padding_ref, 0, out));
 }

--- a/kernels/test/op_convolution_test.cpp
+++ b/kernels/test/op_convolution_test.cpp
@@ -22,67 +22,130 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_convolution_out(
-    const Tensor& input,
-    const Tensor& weight,
-    const optional<Tensor>& bias,
-    ArrayRef<int64_t> stride,
-    ArrayRef<int64_t> padding,
-    ArrayRef<int64_t> dilation,
-    bool transposed,
-    ArrayRef<int64_t> output_padding,
-    int64_t groups,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::convolution_outf(
-      context,
-      input,
-      weight,
-      bias,
-      stride,
-      padding,
-      dilation,
-      transposed,
-      output_padding,
-      groups,
-      out);
-}
+class OpConvOutTest : public OperatorTest {
+ protected:
+  Tensor& op_convolution_out(
+      const Tensor& input,
+      const Tensor& weight,
+      const optional<Tensor>& bias,
+      ArrayRef<int64_t> stride,
+      ArrayRef<int64_t> padding,
+      ArrayRef<int64_t> dilation,
+      bool transposed,
+      ArrayRef<int64_t> output_padding,
+      int64_t groups,
+      Tensor& out) {
+    return torch::executor::aten::convolution_outf(
+        context_,
+        input,
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        transposed,
+        output_padding,
+        groups,
+        out);
+  }
 
-/* Correctness Test Template for test code generation via Python */
-/* %python
-correctness_test_template = f"""
-  {declare_tensor_factory("ScalarType::$DTYPE$", "tf")}
+  /* Correctness Test Template for test code generation via Python */
+  /* %python
+  correctness_test_template = f"""
+    {declare_tensor_factory("ScalarType::$DTYPE$", "tf")}
 
-  {declare_tensor_make_t("input", "tf")}
-  {declare_tensor_make_t("weight", "tf")}
-  {declare_optional_tensor_make_t("bias", "tf")}
-  {declare_tensor_make_t("expected", "tf")}
-  Tensor out = tf.zeros($out_size$, $dynamism$);
+    {declare_tensor_make_t("input", "tf")}
+    {declare_tensor_make_t("weight", "tf")}
+    {declare_optional_tensor_make_t("bias", "tf")}
+    {declare_tensor_make_t("expected", "tf")}
+    Tensor out = tf.zeros($out_size$, $dynamism$);
 
-  {declare_array_ref_t("stride", "int64_t")}
-  {declare_array_ref_t("padding", "int64_t")}
-  {declare_array_ref_t("dilation", "int64_t")}
-  {declare_array_ref_t("output_padding", "int64_t")}
+    {declare_array_ref_t("stride", "int64_t")}
+    {declare_array_ref_t("padding", "int64_t")}
+    {declare_array_ref_t("dilation", "int64_t")}
+    {declare_array_ref_t("output_padding", "int64_t")}
 
-  op_convolution_out(
-      input,
-      weight,
-      bias,
-      stride,
-      padding,
-      dilation,
-      $transposed$,
-      output_padding,
-      $groups$,
-      out);
-  EXPECT_TENSOR_CLOSE(out, expected);"""
-*/
+    op_convolution_out(
+        input,
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        $transposed$,
+        output_padding,
+        $groups$,
+        out);
+    EXPECT_TENSOR_CLOSE(out, expected);"""
+  */
+
+  /* %python
+  import torch
+  torch.manual_seed(0)
+  input = (torch.randint(10, 100, (1, 2, 5)).to(torch.double) / 10.0);
+  weight = (torch.randint(10, 100, (4, 2, 3)).to(torch.double) / 10.0);
+  bias = torch.ones(4).to(torch.double)
+  stride = [2]
+  padding = [0]
+  dilation = [1]
+  transposed = False
+  output_padding = [0]
+  groups = 1
+  expected = torch.nn.functional.conv1d(
+      input, weight, bias, stride, padding, dilation, groups)
+
+  DTYPE = "Float"
+  out_size = "out_shape"
+  dynamism = "dynamism"
+  */
+
+  void test_dynamic_shape(
+      const std::vector<int32_t>& out_shape,
+      enum torch::executor::TensorShapeDynamism dynamism) {
+    /* %python
+    %past-rewrite(correctness_test_template) */
+
+    TensorFactory<ScalarType::Float> tf;
+
+    Tensor input =
+        tf.make({1, 2, 5}, {5.4, 1.9, 9.3, 7.0, 5.3, 7.9, 1.7, 8.3, 4.7, 7.3});
+    Tensor weight =
+        tf.make({4, 2, 3}, {8.1, 6.6, 1.6, 4.9, 3.8, 6.6, 4.6, 2.8,
+                            2.4, 1.3, 3.6, 3.9, 8.1, 8.4, 5.4, 5.1,
+                            8.9, 9.9, 7.9, 1.0, 1.1, 8.2, 6.3, 7.0});
+    optional<Tensor> bias(tf.make({4}, {1.0, 1.0, 1.0, 1.0}));
+    Tensor expected = tf.make(
+        {1, 4, 2},
+        {172.11, 237.72, 102.24, 132.28, 248.51, 320.18, 189.38, 236.07});
+    Tensor out = tf.zeros(out_shape, dynamism);
+
+    int64_t stride[] = {2};
+    int64_t padding[] = {0};
+    int64_t dilation[] = {1};
+    int64_t output_padding[] = {0};
+
+    op_convolution_out(
+        input,
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        false,
+        output_padding,
+        1,
+        out);
+    EXPECT_TENSOR_CLOSE(out, expected);
+  }
+};
+
+class OpConvCorrectnessTest : public OpConvOutTest {};
 
 //
 // Correctness Tests
 //
 
-TEST(OpConvCorrectnessTest, GenericSmokeTest) {
+TEST_F(OpConvCorrectnessTest, GenericSmokeTest) {
   TensorFactory<ScalarType::Int> tf;
 
   auto input = tf.make({1, 2, 5}, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
@@ -131,7 +194,7 @@ DTYPE = "Float"
 out_size = expected.size()
 dynamism = "torch::executor::TensorShapeDynamism::STATIC"
 */
-TEST(OpConvCorrectnessTest, NonZeroPadding) {
+TEST_F(OpConvCorrectnessTest, NonZeroPadding) {
   /* %python
   %past-rewrite(correctness_test_template) */
 
@@ -202,7 +265,7 @@ DTYPE = "Float"
 out_size = expected.size()
 dynamism = "torch::executor::TensorShapeDynamism::STATIC"
 */
-TEST(OpConvCorrectnessTest, MultipleInputBatches) {
+TEST_F(OpConvCorrectnessTest, MultipleInputBatches) {
   /* %python
   %past-rewrite(correctness_test_template) */
 
@@ -264,7 +327,7 @@ DTYPE = "Float"
 out_size = expected.size()
 dynamism = "torch::executor::TensorShapeDynamism::STATIC"
 */
-TEST(OpConvCorrectnessTest, 2DSanityCheck) {
+TEST_F(OpConvCorrectnessTest, 2DSanityCheck) {
   /* %python
   %past-rewrite(correctness_test_template) */
 
@@ -328,7 +391,7 @@ TEST(OpConvCorrectnessTest, 2DSanityCheck) {
   EXPECT_TENSOR_CLOSE(out, expected);
 }
 
-TEST(OpConvCorrectnessTest, 2DSanityCheckChannelsLast) {
+TEST_F(OpConvCorrectnessTest, 2DSanityCheckChannelsLast) {
   /* %python
   %past-rewrite(correctness_test_template) */
 
@@ -392,75 +455,17 @@ TEST(OpConvCorrectnessTest, 2DSanityCheckChannelsLast) {
   EXPECT_TENSOR_CLOSE(out, expected);
 }
 
-/* %python
-import torch
-torch.manual_seed(0)
-input = (torch.randint(10, 100, (1, 2, 5)).to(torch.double) / 10.0);
-weight = (torch.randint(10, 100, (4, 2, 3)).to(torch.double) / 10.0);
-bias = torch.ones(4).to(torch.double)
-stride = [2]
-padding = [0]
-dilation = [1]
-transposed = False
-output_padding = [0]
-groups = 1
-expected = torch.nn.functional.conv1d(
-    input, weight, bias, stride, padding, dilation, groups)
-
-DTYPE = "Float"
-out_size = "out_shape"
-dynamism = "dynamism"
-*/
-
-void test_dynamic_shape(
-    const std::vector<int32_t>& out_shape,
-    enum torch::executor::TensorShapeDynamism dynamism) {
-  /* %python
-  %past-rewrite(correctness_test_template) */
-
-  TensorFactory<ScalarType::Float> tf;
-
-  Tensor input =
-      tf.make({1, 2, 5}, {5.4, 1.9, 9.3, 7.0, 5.3, 7.9, 1.7, 8.3, 4.7, 7.3});
-  Tensor weight = tf.make(
-      {4, 2, 3}, {8.1, 6.6, 1.6, 4.9, 3.8, 6.6, 4.6, 2.8, 2.4, 1.3, 3.6, 3.9,
-                  8.1, 8.4, 5.4, 5.1, 8.9, 9.9, 7.9, 1.0, 1.1, 8.2, 6.3, 7.0});
-  optional<Tensor> bias(tf.make({4}, {1.0, 1.0, 1.0, 1.0}));
-  Tensor expected = tf.make(
-      {1, 4, 2},
-      {172.11, 237.72, 102.24, 132.28, 248.51, 320.18, 189.38, 236.07});
-  Tensor out = tf.zeros(out_shape, dynamism);
-
-  int64_t stride[] = {2};
-  int64_t padding[] = {0};
-  int64_t dilation[] = {1};
-  int64_t output_padding[] = {0};
-
-  op_convolution_out(
-      input,
-      weight,
-      bias,
-      stride,
-      padding,
-      dilation,
-      false,
-      output_padding,
-      1,
-      out);
-  EXPECT_TENSOR_CLOSE(out, expected);
-}
-
-TEST(OpConvOut, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpConvOutTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(
       {1, 4, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpConvOut, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpConvOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   test_dynamic_shape(
       {10, 10, 10}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpConvOut, DynamicShapeUnbound) {
+TEST_F(OpConvOutTest, DynamicShapeUnbound) {
   if (!torch::executor::testing::SupportedFeatures::get()->output_resize) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }

--- a/kernels/test/op_copy_test.cpp
+++ b/kernels/test/op_copy_test.cpp
@@ -22,74 +22,113 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_copy_out(
-    const Tensor& self,
-    const Tensor& src,
-    bool non_blocking,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::copy_outf(
-      context, self, src, non_blocking, out);
-}
+class OpCopyTest : public OperatorTest {
+ protected:
+  Tensor& op_copy_out(
+      const Tensor& self,
+      const Tensor& src,
+      bool non_blocking,
+      Tensor& out) {
+    return torch::executor::aten::copy_outf(
+        context_, self, src, non_blocking, out);
+  }
+
+  // test if copy.out works well under all kinds of legal input type.
+  template <class CTYPE, exec_aten::ScalarType DTYPE>
+  void test_dtype() {
+    TensorFactory<DTYPE> tf;
+    Tensor self = tf.make(/*sizes=*/{2, 4}, /*data=*/{2, 3, 2, 4, 1, 5, 1, 6});
+    Tensor src = tf.make(/*sizes=*/{2, 4}, /*data=*/{2, 3, 2, 4, 1, 5, 1, 6});
+    bool non_blocking = false;
+    Tensor out_nullopt = tf.zeros(/*sizes=*/{2, 4});
+    Tensor out_contiguous = tf.zeros(/*sizes=*/{2, 4});
+
+    // we only support contiguous memory, the memory type shall be either
+    // nullopt or MemoryFormat::Contiguous.
+    Tensor out_nullopt_ret = op_copy_out(
+        /*self=*/self,
+        /*src=*/src,
+        /*non_blocking=*/non_blocking,
+        /*out=*/out_nullopt);
+    Tensor out_contiguous_ret = op_copy_out(
+        /*self=*/self,
+        /*src=*/src,
+        /*non_blocking=*/non_blocking,
+        /*out=*/out_contiguous);
+
+    // The original tensor a should share same value with the out variable and
+    // return variable of copy function
+    EXPECT_TENSOR_EQ(src, out_nullopt);
+    EXPECT_TENSOR_EQ(src, out_nullopt_ret);
+
+    EXPECT_TENSOR_EQ(src, out_contiguous);
+    EXPECT_TENSOR_EQ(src, out_contiguous_ret);
+  }
+
+  template <class CTYPE, ScalarType DTYPE>
+  void test_empty_input() {
+    TensorFactory<DTYPE> tf;
+    Tensor self = tf.make(/*sizes=*/{3, 0, 1, 2}, /*data=*/{});
+    Tensor src = tf.make(/*sizes=*/{3, 0, 1, 2}, /*data=*/{});
+    bool non_blocking = false;
+    Tensor out = tf.zeros({3, 0, 1, 2});
+    op_copy_out(self, src, non_blocking, out);
+    // check a and out share same value, but are different object
+    EXPECT_TENSOR_EQ(src, out);
+  }
+
+  /* %python
+  import torch
+  torch.manual_seed(0)
+  self = torch.randint(10, (3, 4))
+  src = torch.randint(10, (3, 4))
+  non_blocking = False
+  expected = src
+  out_args = "out_shape, dynamism"
+
+  copy_template = f"""
+    {declare_tensor_factory("ScalarType::Int", "tf")}
+
+    {declare_tensor_make_t("self", "tf")}
+    {declare_tensor_make_t("src", "tf")}
+    {declare_tensor_make_t("expected", "tf")}
+    {declare_tensor_zeros("out_shape, dynamism", "tf", "out")}
+
+    op_copy_out(self, src, $non_blocking$, out);
+    EXPECT_TENSOR_EQ(out, expected);""" */
+
+  void test_dynamic_shape(
+      const std::vector<int32_t>& out_shape,
+      enum torch::executor::TensorShapeDynamism dynamism) {
+    /* %python
+    %rewrite(copy_template) */
+
+    TensorFactory<ScalarType::Int> tf;
+
+    Tensor self = tf.make({3, 4}, {4, 9, 3, 0, 3, 9, 7, 3, 7, 3, 1, 6});
+    Tensor src = tf.make({3, 4}, {6, 9, 8, 6, 6, 8, 4, 3, 6, 9, 1, 4});
+    Tensor expected = tf.make({3, 4}, {6, 9, 8, 6, 6, 8, 4, 3, 6, 9, 1, 4});
+    Tensor out = tf.zeros(out_shape, dynamism);
+
+    op_copy_out(self, src, false, out);
+    EXPECT_TENSOR_EQ(out, expected);
+  }
+};
 
 // regular test for copy.out
-// test if copy.out works well under all kinds of legal input type.
-template <class CTYPE, exec_aten::ScalarType DTYPE>
-void test_dtype() {
-  TensorFactory<DTYPE> tf;
-  Tensor self = tf.make(/*sizes=*/{2, 4}, /*data=*/{2, 3, 2, 4, 1, 5, 1, 6});
-  Tensor src = tf.make(/*sizes=*/{2, 4}, /*data=*/{2, 3, 2, 4, 1, 5, 1, 6});
-  bool non_blocking = false;
-  Tensor out_nullopt = tf.zeros(/*sizes=*/{2, 4});
-  Tensor out_contiguous = tf.zeros(/*sizes=*/{2, 4});
-
-  // we only support contiguous memory, the memory type shall be either nullopt
-  // or MemoryFormat::Contiguous.
-  Tensor out_nullopt_ret = op_copy_out(
-      /*self=*/self,
-      /*src=*/src,
-      /*non_blocking=*/non_blocking,
-      /*out=*/out_nullopt);
-  Tensor out_contiguous_ret = op_copy_out(
-      /*self=*/self,
-      /*src=*/src,
-      /*non_blocking=*/non_blocking,
-      /*out=*/out_contiguous);
-
-  // The original tensor a should share same value with the out variable and
-  // return variable of copy function
-  EXPECT_TENSOR_EQ(src, out_nullopt);
-  EXPECT_TENSOR_EQ(src, out_nullopt_ret);
-
-  EXPECT_TENSOR_EQ(src, out_contiguous);
-  EXPECT_TENSOR_EQ(src, out_contiguous_ret);
-}
-
-TEST(OpCopyTest, AllRealDtypesSupported) {
+TEST_F(OpCopyTest, AllRealDtypesSupported) {
 #define TEST_ENTRY(ctype, dtype) test_dtype<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-template <class CTYPE, ScalarType DTYPE>
-void test_empty_input() {
-  TensorFactory<DTYPE> tf;
-  Tensor self = tf.make(/*sizes=*/{3, 0, 1, 2}, /*data=*/{});
-  Tensor src = tf.make(/*sizes=*/{3, 0, 1, 2}, /*data=*/{});
-  bool non_blocking = false;
-  Tensor out = tf.zeros({3, 0, 1, 2});
-  op_copy_out(self, src, non_blocking, out);
-  // check a and out share same value, but are different object
-  EXPECT_TENSOR_EQ(src, out);
-}
-
-TEST(OpCopyTest, EmptyInputSupported) {
+TEST_F(OpCopyTest, EmptyInputSupported) {
 #define TEST_ENTRY(ctype, dtype) test_empty_input<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpCopyTest, BroadCastSrcSupported) {
+TEST_F(OpCopyTest, BroadCastSrcSupported) {
   TensorFactory<ScalarType::Int> tf;
   Tensor self = tf.make(/*sizes=*/{2, 2}, /*data=*/{1, 2, 3, 4});
   Tensor src = tf.make(/*sizes=*/{1, 2}, /*data=*/{3, 3});
@@ -100,7 +139,7 @@ TEST(OpCopyTest, BroadCastSrcSupported) {
   EXPECT_TENSOR_EQ(out, out_expected);
 }
 
-TEST(OpCopyTest, BroadCastSrcMissingDimSupported) {
+TEST_F(OpCopyTest, BroadCastSrcMissingDimSupported) {
   TensorFactory<ScalarType::Int> tf;
   Tensor self = tf.make(/*sizes=*/{2, 2}, /*data=*/{1, 2, 3, 4});
   Tensor src = tf.make(/*sizes=*/{1, 2}, /*data=*/{3, 3});
@@ -111,16 +150,16 @@ TEST(OpCopyTest, BroadCastSrcMissingDimSupported) {
   EXPECT_TENSOR_EQ(out, out_expected);
 }
 
-TEST(OpCopyTest, BroadCastSelfcSupportedDie) {
+TEST_F(OpCopyTest, BroadCastSelfcSupportedDie) {
   TensorFactory<ScalarType::Int> tf;
   Tensor self = tf.make(/*sizes=*/{1, 2}, /*data=*/{3, 3});
   Tensor src = tf.make(/*sizes=*/{2, 2}, /*data=*/{1, 2, 3, 4});
   bool non_blocking = false;
   Tensor out = tf.zeros({2, 2});
-  ET_EXPECT_KERNEL_FAILURE(op_copy_out(self, src, non_blocking, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_copy_out(self, src, non_blocking, out));
 }
 
-TEST(OpCopyTest, MismatchSelfSrcTypeSupported) {
+TEST_F(OpCopyTest, MismatchSelfSrcTypeSupported) {
   TensorFactory<ScalarType::Int> tf_self;
   TensorFactory<ScalarType::Float> tf_src;
   Tensor self =
@@ -128,11 +167,11 @@ TEST(OpCopyTest, MismatchSelfSrcTypeSupported) {
   Tensor src = tf_src.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf_src.zeros({3, 0, 1, 2});
   bool non_blocking = false;
-  ET_EXPECT_KERNEL_FAILURE(op_copy_out(self, src, non_blocking, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_copy_out(self, src, non_blocking, out));
 }
 
 #ifndef USE_ATEN_LIB
-TEST(OpCopyTest, ResizeOutSupported) {
+TEST_F(OpCopyTest, ResizeOutSupported) {
   TensorFactory<ScalarType::Int> tf;
   Tensor self = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor src = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
@@ -145,7 +184,7 @@ TEST(OpCopyTest, ResizeOutSupported) {
   EXPECT_TENSOR_EQ(out, out_expected);
 }
 
-TEST(OpCopyTest, ResizeOutDie) {
+TEST_F(OpCopyTest, ResizeOutDie) {
   TensorFactory<ScalarType::Int> tf_self;
   TensorFactory<ScalarType::Float> tf_src;
   Tensor self =
@@ -154,11 +193,11 @@ TEST(OpCopyTest, ResizeOutDie) {
   Tensor out = tf_src.zeros(
       {3, 2, 0}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
   bool non_blocking = false;
-  ET_EXPECT_KERNEL_FAILURE(op_copy_out(self, src, non_blocking, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_copy_out(self, src, non_blocking, out));
 }
 #endif
 
-TEST(OpCopyTest, MismatchedSizesDie) {
+TEST_F(OpCopyTest, MismatchedSizesDie) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched sizes";
   }
@@ -167,23 +206,23 @@ TEST(OpCopyTest, MismatchedSizesDie) {
   Tensor src = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   bool non_blocking = false;
   Tensor out = tf.zeros({3, 2, 1, 1});
-  ET_EXPECT_KERNEL_FAILURE(op_copy_out(self, src, non_blocking, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_copy_out(self, src, non_blocking, out));
 }
 
-TEST(OpCopyTest, MismatchedSrcOutTypesDie) {
+TEST_F(OpCopyTest, MismatchedSrcOutTypesDie) {
   TensorFactory<ScalarType::Int> tf_in;
   TensorFactory<ScalarType::Float> tf_out;
   Tensor self = tf_in.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor src = tf_in.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   bool non_blocking = false;
   Tensor out = tf_out.zeros({3, 1, 1, 2});
-  ET_EXPECT_KERNEL_FAILURE(op_copy_out(self, src, non_blocking, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_copy_out(self, src, non_blocking, out));
 }
 
 // Only contiguous memory is supported, the memory type other than nullopt or
 // MemoryFormat::Contiguous should not be allowed. The function is expected
 // depth if using the illegal memory format.
-TEST(OpCopyTest, BlockingDie) {
+TEST_F(OpCopyTest, BlockingDie) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle non-contiguous memory formats";
   }
@@ -193,52 +232,15 @@ TEST(OpCopyTest, BlockingDie) {
   Tensor src = tf_in.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   bool non_blocking = true;
   Tensor out = tf_out.zeros({3, 1, 1, 2});
-  ET_EXPECT_KERNEL_FAILURE(op_copy_out(self, src, non_blocking, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_copy_out(self, src, non_blocking, out));
 }
 
-/* %python
-import torch
-torch.manual_seed(0)
-self = torch.randint(10, (3, 4))
-src = torch.randint(10, (3, 4))
-non_blocking = False
-expected = src
-out_args = "out_shape, dynamism"
-
-copy_template = f"""
-  {declare_tensor_factory("ScalarType::Int", "tf")}
-
-  {declare_tensor_make_t("self", "tf")}
-  {declare_tensor_make_t("src", "tf")}
-  {declare_tensor_make_t("expected", "tf")}
-  {declare_tensor_zeros("out_shape, dynamism", "tf", "out")}
-
-  op_copy_out(self, src, $non_blocking$, out);
-  EXPECT_TENSOR_EQ(out, expected);""" */
-
-void test_dynamic_shape(
-    const std::vector<int32_t>& out_shape,
-    enum torch::executor::TensorShapeDynamism dynamism) {
-  /* %python
-  %rewrite(copy_template) */
-
-  TensorFactory<ScalarType::Int> tf;
-
-  Tensor self = tf.make({3, 4}, {4, 9, 3, 0, 3, 9, 7, 3, 7, 3, 1, 6});
-  Tensor src = tf.make({3, 4}, {6, 9, 8, 6, 6, 8, 4, 3, 6, 9, 1, 4});
-  Tensor expected = tf.make({3, 4}, {6, 9, 8, 6, 6, 8, 4, 3, 6, 9, 1, 4});
-  Tensor out = tf.zeros(out_shape, dynamism);
-
-  op_copy_out(self, src, false, out);
-  EXPECT_TENSOR_EQ(out, expected);
-}
-
-TEST(OpCopyTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpCopyTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(
       {3, 4}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpCopyTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpCopyTest, DynamicShapeUpperBoundLargerThanExpected) {
   if (!torch::executor::testing::SupportedFeatures::get()->output_resize) {
     GTEST_SKIP() << "Dynamic shape not supported";
   }
@@ -246,7 +248,7 @@ TEST(OpCopyTest, DynamicShapeUpperBoundLargerThanExpected) {
       {10, 10}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpCopyTest, DynamicShapeUnbound) {
+TEST_F(OpCopyTest, DynamicShapeUnbound) {
   if (!torch::executor::testing::SupportedFeatures::get()->output_resize) {
     GTEST_SKIP() << "Dynamic shape not supported";
   }

--- a/kernels/test/op_embedding_test.cpp
+++ b/kernels/test/op_embedding_test.cpp
@@ -22,19 +22,97 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_embedding_out(
-    const Tensor& weight,
-    const Tensor& indices,
-    int64_t padding_idx,
-    bool scale_grad_by_freq,
-    bool sparse,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::embedding_outf(
-      context, weight, indices, padding_idx, scale_grad_by_freq, sparse, out);
-}
+class OpEmbeddingOutTest : public OperatorTest {
+ protected:
+  Tensor& op_embedding_out(
+      const Tensor& weight,
+      const Tensor& indices,
+      int64_t padding_idx,
+      bool scale_grad_by_freq,
+      bool sparse,
+      Tensor& out) {
+    return torch::executor::aten::embedding_outf(
+        context_,
+        weight,
+        indices,
+        padding_idx,
+        scale_grad_by_freq,
+        sparse,
+        out);
+  }
 
-TEST(OpEmbeddingOutTest, Smoke) {
+  template <class CTYPE, exec_aten::ScalarType DTYPE>
+  void test_dtype() {
+    TensorFactory<DTYPE> tf;
+    TensorFactory<ScalarType::Long> tfl;
+    // clang-format off
+    Tensor weight = tf.make(
+      {3, 2},
+      {
+        1, 2,
+        3, 4,
+        5, 6,
+      });
+    Tensor indices = tfl.make(
+      {1, 2},
+      {0, 2}
+    );
+    // clang-format on
+    Tensor out = tf.zeros({1, 2, 2});
+    Tensor actual = op_embedding_out(
+        weight,
+        indices,
+        /*padding_idx=*/0,
+        /*scale_grad_by_freq=*/false,
+        /*sparse=*/false,
+        out);
+
+    Tensor expected = tf.make({1, 2, 2}, {1, 2, 5, 6});
+
+    EXPECT_TENSOR_EQ(actual, out);
+    EXPECT_TENSOR_EQ(out, expected);
+  }
+
+  void test_dynamic_shape(
+      const std::vector<int32_t>& out_shape,
+      enum torch::executor::TensorShapeDynamism dynamism) {
+    /* %python
+    %rewrite(embedding_template) */
+
+    TensorFactory<ScalarType::Float> tf_weight;
+    TensorFactory<ScalarType::Long> tf_indices;
+
+    Tensor weight = tf_weight.make(
+        {10, 3},
+        {0.49625658988952637,  0.7682217955589294,  0.08847743272781372,
+         0.13203048706054688,  0.30742281675338745, 0.6340786814689636,
+         0.4900934100151062,   0.8964447379112244,  0.455627977848053,
+         0.6323062777519226,   0.3488934636116028,  0.40171730518341064,
+         0.022325754165649414, 0.16885894536972046, 0.2938884496688843,
+         0.518521785736084,    0.6976675987243652,  0.800011396408081,
+         0.16102945804595947,  0.28226858377456665, 0.6816085577011108,
+         0.9151939749717712,   0.39709991216659546, 0.8741558790206909,
+         0.41940832138061523,  0.5529070496559143,  0.9527381062507629,
+         0.036164820194244385, 0.1852310299873352,  0.37341737747192383});
+    Tensor indices = tf_indices.make({2, 4}, {1, 2, 4, 5, 4, 3, 2, 9});
+    Tensor expected = tf_weight.make(
+        {2, 4, 3},
+        {0.13203048706054688,  0.30742281675338745, 0.6340786814689636,
+         0.4900934100151062,   0.8964447379112244,  0.455627977848053,
+         0.022325754165649414, 0.16885894536972046, 0.2938884496688843,
+         0.518521785736084,    0.6976675987243652,  0.800011396408081,
+         0.022325754165649414, 0.16885894536972046, 0.2938884496688843,
+         0.6323062777519226,   0.3488934636116028,  0.40171730518341064,
+         0.4900934100151062,   0.8964447379112244,  0.455627977848053,
+         0.036164820194244385, 0.1852310299873352,  0.37341737747192383});
+    Tensor out = tf_weight.zeros(out_shape, dynamism);
+
+    op_embedding_out(weight, indices, 0, false, false, out);
+    EXPECT_TENSOR_CLOSE(out, expected);
+  }
+};
+
+TEST_F(OpEmbeddingOutTest, Smoke) {
   TensorFactory<ScalarType::Float> tff;
   // clang-format off
   Tensor weight = tff.make(
@@ -64,39 +142,7 @@ TEST(OpEmbeddingOutTest, Smoke) {
 
 /// A generic smoke test that works for any dtype that supports ones() and
 /// zeros().
-template <class CTYPE, exec_aten::ScalarType DTYPE>
-void test_dtype() {
-  TensorFactory<DTYPE> tf;
-  TensorFactory<ScalarType::Long> tfl;
-  // clang-format off
-  Tensor weight = tf.make(
-    {3, 2},
-    {
-      1, 2,
-      3, 4,
-      5, 6,
-    });
-  Tensor indices = tfl.make(
-    {1, 2},
-    {0, 2}
-  );
-  // clang-format on
-  Tensor out = tf.zeros({1, 2, 2});
-  Tensor actual = op_embedding_out(
-      weight,
-      indices,
-      /*padding_idx=*/0,
-      /*scale_grad_by_freq=*/false,
-      /*sparse=*/false,
-      out);
-
-  Tensor expected = tf.make({1, 2, 2}, {1, 2, 5, 6});
-
-  EXPECT_TENSOR_EQ(actual, out);
-  EXPECT_TENSOR_EQ(out, expected);
-}
-
-TEST(OpEmbeddingOutTest, AllDtypesSupported) {
+TEST_F(OpEmbeddingOutTest, AllDtypesSupported) {
 #define TEST_ENTRY(ctype, dtype) test_dtype<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
@@ -105,7 +151,7 @@ TEST(OpEmbeddingOutTest, AllDtypesSupported) {
   // for those types.
 }
 
-TEST(OpEmbeddingOutTest, IndicesMultiDims) {
+TEST_F(OpEmbeddingOutTest, IndicesMultiDims) {
   TensorFactory<ScalarType::Float> tff;
   // clang-format off
   Tensor weight = tff.make(
@@ -143,7 +189,7 @@ TEST(OpEmbeddingOutTest, IndicesMultiDims) {
   // clang-format on
 }
 
-TEST(OpEmbeddingOutTest, WeightWrongDimensionsDies) {
+TEST_F(OpEmbeddingOutTest, WeightWrongDimensionsDies) {
   TensorFactory<ScalarType::Float> tff;
   // clang-format off
   Tensor weight = tff.make(
@@ -160,16 +206,18 @@ TEST(OpEmbeddingOutTest, WeightWrongDimensionsDies) {
   // clang-format off
   Tensor indices = tfl.make({2, 2}, {1, 0, 2, 3});
   // clang-format on
-  ET_EXPECT_KERNEL_FAILURE(op_embedding_out(
-      weight,
-      indices,
-      /*padding_idx=*/0,
-      /*scale_grad_by_freq=*/false,
-      /*sparse=*/false,
-      out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_embedding_out(
+          weight,
+          indices,
+          /*padding_idx=*/0,
+          /*scale_grad_by_freq=*/false,
+          /*sparse=*/false,
+          out));
 }
 
-TEST(OpEmbeddingOutTest, WrongOutShapeDies) {
+TEST_F(OpEmbeddingOutTest, WrongOutShapeDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle wrong out shape";
   }
@@ -194,17 +242,19 @@ TEST(OpEmbeddingOutTest, WrongOutShapeDies) {
 
   for (auto wrong_out: wrong_outs) {
     // clang-format on
-    ET_EXPECT_KERNEL_FAILURE(op_embedding_out(
-        weight,
-        indices,
-        /*padding_idx=*/0,
-        /*scale_grad_by_freq=*/false,
-        /*sparse=*/false,
-        wrong_out));
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_embedding_out(
+            weight,
+            indices,
+            /*padding_idx=*/0,
+            /*scale_grad_by_freq=*/false,
+            /*sparse=*/false,
+            wrong_out));
   }
 }
 
-TEST(OpEmbeddingOutTest, UnmatchedOutTypeDie) {
+TEST_F(OpEmbeddingOutTest, UnmatchedOutTypeDie) {
   TensorFactory<ScalarType::Float> tff;
   TensorFactory<ScalarType::Long> tfl;
   // clang-format off
@@ -222,16 +272,18 @@ TEST(OpEmbeddingOutTest, UnmatchedOutTypeDie) {
   Tensor indices = tfl.make({2, 2}, {1, 0, 2, 3});
   // clang-format on
 
-  ET_EXPECT_KERNEL_FAILURE(op_embedding_out(
-      weight,
-      indices,
-      /*padding_idx=*/0,
-      /*scale_grad_by_freq=*/false,
-      /*sparse=*/false,
-      wrong_out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_embedding_out(
+          weight,
+          indices,
+          /*padding_idx=*/0,
+          /*scale_grad_by_freq=*/false,
+          /*sparse=*/false,
+          wrong_out));
 }
 
-TEST(OpEmbeddingOutTest, OutOfBoundIndicesDies) {
+TEST_F(OpEmbeddingOutTest, OutOfBoundIndicesDies) {
   TensorFactory<ScalarType::Float> tff;
   // clang-format off
   Tensor weight = tff.make(
@@ -250,24 +302,28 @@ TEST(OpEmbeddingOutTest, OutOfBoundIndicesDies) {
   Tensor neg_indices = tfl.make({2, 2}, {-1, 0, 2, 4});
   Tensor overflow_indices = tfl.make({2, 2}, {1, 0, 2, 8});
 
-  ET_EXPECT_KERNEL_FAILURE(op_embedding_out(
-      weight,
-      neg_indices,
-      /*padding_idx=*/0,
-      /*scale_grad_by_freq=*/false,
-      /*sparse=*/false,
-      out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_embedding_out(
+          weight,
+          neg_indices,
+          /*padding_idx=*/0,
+          /*scale_grad_by_freq=*/false,
+          /*sparse=*/false,
+          out));
 
-  ET_EXPECT_KERNEL_FAILURE(op_embedding_out(
-      weight,
-      overflow_indices,
-      /*padding_idx=*/0,
-      /*scale_grad_by_freq=*/false,
-      /*sparse=*/false,
-      out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_embedding_out(
+          weight,
+          overflow_indices,
+          /*padding_idx=*/0,
+          /*scale_grad_by_freq=*/false,
+          /*sparse=*/false,
+          out));
 }
 
-TEST(OpEmbeddingOutTest, EmptyWeightSupported) {
+TEST_F(OpEmbeddingOutTest, EmptyWeightSupported) {
   TensorFactory<ScalarType::Float> tff;
   // clang-format off
   Tensor weight = tff.make(
@@ -291,7 +347,7 @@ TEST(OpEmbeddingOutTest, EmptyWeightSupported) {
   EXPECT_TENSOR_EQ(actual, tff.zeros({2, 2, 0}));
 }
 
-TEST(OpEmbeddingOutTest, ZeroDimIndicesSupported) {
+TEST_F(OpEmbeddingOutTest, ZeroDimIndicesSupported) {
   TensorFactory<ScalarType::Float> tff;
   // clang-format off
   Tensor weight = tff.make(
@@ -328,7 +384,7 @@ TEST(OpEmbeddingOutTest, ZeroDimIndicesSupported) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpEmbeddingOutTest, EmptyDimIndicesSupported) {
+TEST_F(OpEmbeddingOutTest, EmptyDimIndicesSupported) {
   TensorFactory<ScalarType::Float> tff;
   // clang-format off
   Tensor weight = tff.make(
@@ -376,7 +432,7 @@ sparse = False
 expected = torch.nn.functional.embedding(
   indices, weight, padding_idx=padding, scale_grad_by_freq=scale, sparse=sparse
 )
-embedding_template = f"""
+embedding_ template = f"""
   {declare_tensor_factory("ScalarType::Float", "tf_weight")}
   {declare_tensor_factory("ScalarType::Long", "tf_indices")}
 
@@ -388,55 +444,17 @@ embedding_template = f"""
   op_embedding_out(weight, indices, $padding$, $scale$, $sparse$, out);
   EXPECT_TENSOR_CLOSE(out, expected);""" */
 
-void test_dynamic_shape(
-    const std::vector<int32_t>& out_shape,
-    enum torch::executor::TensorShapeDynamism dynamism) {
-  /* %python
-  %rewrite(embedding_template) */
-
-  TensorFactory<ScalarType::Float> tf_weight;
-  TensorFactory<ScalarType::Long> tf_indices;
-
-  Tensor weight = tf_weight.make(
-      {10, 3},
-      {0.49625658988952637,  0.7682217955589294,  0.08847743272781372,
-       0.13203048706054688,  0.30742281675338745, 0.6340786814689636,
-       0.4900934100151062,   0.8964447379112244,  0.455627977848053,
-       0.6323062777519226,   0.3488934636116028,  0.40171730518341064,
-       0.022325754165649414, 0.16885894536972046, 0.2938884496688843,
-       0.518521785736084,    0.6976675987243652,  0.800011396408081,
-       0.16102945804595947,  0.28226858377456665, 0.6816085577011108,
-       0.9151939749717712,   0.39709991216659546, 0.8741558790206909,
-       0.41940832138061523,  0.5529070496559143,  0.9527381062507629,
-       0.036164820194244385, 0.1852310299873352,  0.37341737747192383});
-  Tensor indices = tf_indices.make({2, 4}, {1, 2, 4, 5, 4, 3, 2, 9});
-  Tensor expected = tf_weight.make(
-      {2, 4, 3},
-      {0.13203048706054688,  0.30742281675338745, 0.6340786814689636,
-       0.4900934100151062,   0.8964447379112244,  0.455627977848053,
-       0.022325754165649414, 0.16885894536972046, 0.2938884496688843,
-       0.518521785736084,    0.6976675987243652,  0.800011396408081,
-       0.022325754165649414, 0.16885894536972046, 0.2938884496688843,
-       0.6323062777519226,   0.3488934636116028,  0.40171730518341064,
-       0.4900934100151062,   0.8964447379112244,  0.455627977848053,
-       0.036164820194244385, 0.1852310299873352,  0.37341737747192383});
-  Tensor out = tf_weight.zeros(out_shape, dynamism);
-
-  op_embedding_out(weight, indices, 0, false, false, out);
-  EXPECT_TENSOR_CLOSE(out, expected);
-}
-
-TEST(OpEmbeddingOutTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpEmbeddingOutTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(
       {2, 4, 3}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpEmbeddingOutTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpEmbeddingOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   test_dynamic_shape(
       {10, 10, 10}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpEmbeddingOutTest, DynamicShapeUnbound) {
+TEST_F(OpEmbeddingOutTest, DynamicShapeUnbound) {
   if (!torch::executor::testing::SupportedFeatures::get()->output_resize) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }

--- a/kernels/test/op_erf_test.cpp
+++ b/kernels/test/op_erf_test.cpp
@@ -20,12 +20,14 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_erf_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::erf_outf(context, self, out);
-}
+class OpErfTest : public OperatorTest {
+ protected:
+  Tensor& op_erf_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::erf_outf(context_, self, out);
+  }
+};
 
-TEST(OpErfTest, SanityCheck) {
+TEST_F(OpErfTest, SanityCheck) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor in = tf.make({1, 7}, {-3.0, -2.99, -1.01, 0.0, 1.01, 2.99, 3.0});
@@ -40,7 +42,7 @@ TEST(OpErfTest, SanityCheck) {
   EXPECT_TENSOR_CLOSE(out, expected);
 }
 
-TEST(OpErfTest, HandleBoolInput) {
+TEST_F(OpErfTest, HandleBoolInput) {
   TensorFactory<ScalarType::Bool> tf_bool;
   TensorFactory<ScalarType::Float> tf_float;
 
@@ -53,7 +55,7 @@ TEST(OpErfTest, HandleBoolInput) {
   EXPECT_TENSOR_CLOSE(op_erf_out(a, out), res);
 }
 
-TEST(OpErfTest, HalfSupport) {
+TEST_F(OpErfTest, HalfSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }

--- a/kernels/test/op_exp_test.cpp
+++ b/kernels/test/op_exp_test.cpp
@@ -22,63 +22,79 @@ using exec_aten::Tensor;
 using torch::executor::testing::SupportedFeatures;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_exp_out(const Tensor& a, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::exp_outf(context, a, out);
-}
+class OpExpOutTest : public OperatorTest {
+ protected:
+  Tensor& op_exp_out(const Tensor& a, Tensor& out) {
+    return torch::executor::aten::exp_outf(context_, a, out);
+  }
 
-template <typename CTYPE>
-CTYPE apply_log(double x) {
-  return static_cast<CTYPE>(std::log(x));
-}
+  template <typename CTYPE>
+  CTYPE apply_log(double x) {
+    return static_cast<CTYPE>(std::log(x));
+  }
 
-// Common testing for log operator
-template <typename CTYPE_IN, ScalarType DTYPE, ScalarType DTYPE_OUT>
-void test__exp_out() {
-  TensorFactory<DTYPE> tf;
-  TensorFactory<DTYPE_OUT> tf_out;
+  // Common testing for log operator
+  template <typename CTYPE_IN, ScalarType DTYPE, ScalarType DTYPE_OUT>
+  void test__exp_out() {
+    TensorFactory<DTYPE> tf;
+    TensorFactory<DTYPE_OUT> tf_out;
 
-  const std::vector<int32_t> sizes = {2, 2};
+    const std::vector<int32_t> sizes = {2, 2};
 
-  // clang-format off
-  Tensor x = tf.make(
-      sizes,
-      {
-          apply_log<CTYPE_IN>(1.),  apply_log<CTYPE_IN>(2.),
-          apply_log<CTYPE_IN>(4.),  apply_log<CTYPE_IN>(8.),
-      });
-  // clang-format on
+    // clang-format off
+    Tensor x = tf.make(
+        sizes,
+        {
+            apply_log<CTYPE_IN>(1.),  apply_log<CTYPE_IN>(2.),
+            apply_log<CTYPE_IN>(4.),  apply_log<CTYPE_IN>(8.),
+        });
+    // clang-format on
 
-  // clang-format off
-  Tensor expected = tf_out.make(
-      sizes,
-      {
-          1.,  2.,
-          4.,  8.,
-      });
-  // clang-format on
+    // clang-format off
+    Tensor expected = tf_out.make(
+        sizes,
+        {
+            1.,  2.,
+            4.,  8.,
+        });
+    // clang-format on
 
-  Tensor out = tf_out.zeros(sizes);
+    Tensor out = tf_out.zeros(sizes);
 
-  op_exp_out(x, out);
-  EXPECT_TENSOR_CLOSE(out, expected);
-}
+    op_exp_out(x, out);
+    EXPECT_TENSOR_CLOSE(out, expected);
+  }
 
-TEST(OpExpOutKernelTest, AllFloatInputFloatOutputSupport) {
+  // Unhandled output dtypes.
+  template <ScalarType OUTPUT_DTYPE>
+  void test_exp_invalid_output_dtype_dies() {
+    TensorFactory<ScalarType::Float> tf_float;
+    TensorFactory<OUTPUT_DTYPE> tf_out;
+
+    const std::vector<int32_t> sizes = {2, 5};
+
+    Tensor in = tf_float.ones(sizes);
+    Tensor out = tf_out.zeros(sizes);
+
+    ET_EXPECT_KERNEL_FAILURE(context_, op_exp_out(in, out));
+  }
+};
+
+TEST_F(OpExpOutTest, AllFloatInputFloatOutputSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test__exp_out<ctype, ScalarType::dtype, ScalarType::Float>();
   ET_FORALL_FLOAT_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpExpOutKernelTest, AllFloatInputDoubleOutputSupport) {
+TEST_F(OpExpOutTest, AllFloatInputDoubleOutputSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test__exp_out<ctype, ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_FLOAT_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpExpOutKernelTest, HandleBoolInput) {
+TEST_F(OpExpOutTest, HandleBoolInput) {
   // op_exp_out() handles Bool as input.
   TensorFactory<ScalarType::Bool> tf_bool;
   TensorFactory<ScalarType::Float> tf_float;
@@ -92,7 +108,7 @@ TEST(OpExpOutKernelTest, HandleBoolInput) {
   EXPECT_TENSOR_CLOSE(op_exp_out(a, out), res);
 }
 
-TEST(OpExpOutKernelTest, HandleHalfInput) {
+TEST_F(OpExpOutTest, HandleHalfInput) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -108,7 +124,7 @@ TEST(OpExpOutKernelTest, HandleHalfInput) {
 }
 
 // Mismatched shape tests.
-TEST(OpExpOutKernelTest, MismatchedShapesDies) {
+TEST_F(OpExpOutTest, MismatchedShapesDies) {
   if (SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
   }
@@ -119,24 +135,10 @@ TEST(OpExpOutKernelTest, MismatchedShapesDies) {
   Tensor a = tf_int.ones(/*sizes=*/{4});
   Tensor out = tf_float.ones(/*sizes=*/{2, 2});
 
-  ET_EXPECT_KERNEL_FAILURE(op_exp_out(a, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_exp_out(a, out));
 }
 
-// Unhandled output dtypes.
-template <ScalarType OUTPUT_DTYPE>
-void test_exp_invalid_output_dtype_dies() {
-  TensorFactory<ScalarType::Float> tf_float;
-  TensorFactory<OUTPUT_DTYPE> tf_out;
-
-  const std::vector<int32_t> sizes = {2, 5};
-
-  Tensor in = tf_float.ones(sizes);
-  Tensor out = tf_out.zeros(sizes);
-
-  ET_EXPECT_KERNEL_FAILURE(op_exp_out(in, out));
-}
-
-TEST(OpExpOutKernelTest, AllNonFloatOutputDTypeDies) {
+TEST_F(OpExpOutTest, AllNonFloatOutputDTypeDies) {
 #define TEST_ENTRY(ctype, dtype) \
   test_exp_invalid_output_dtype_dies<ScalarType::dtype>();
   ET_FORALL_INT_TYPES(TEST_ENTRY);
@@ -144,7 +146,7 @@ TEST(OpExpOutKernelTest, AllNonFloatOutputDTypeDies) {
 }
 
 #ifndef USE_ATEN_LIB
-TEST(OpExpOutKernelTest, DynamicOutputShape) {
+TEST_F(OpExpOutTest, DynamicOutputShape) {
   TensorFactory<ScalarType::Float> tf;
   TensorFactory<ScalarType::Float> tf_out;
 

--- a/kernels/test/op_fill_test.cpp
+++ b/kernels/test/op_fill_test.cpp
@@ -21,59 +21,60 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor&
-op_fill_scalar_out(const Tensor& self, const Scalar& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::fill_outf(context, self, other, out);
-}
-
-Tensor&
-op_fill_tensor_out(const Tensor& self, const Tensor& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::fill_outf(context, self, other, out);
-}
-
-template <ScalarType DTYPE>
-void test_fill_scalar_out(std::vector<int32_t>&& sizes) {
-  TensorFactory<DTYPE> tf;
-
-  // Before: `out` consists of 0s.
-  Tensor self = tf.zeros(sizes);
-  Tensor out = tf.zeros(sizes);
-
-  // After: `out` consists of 1s.
-  Scalar other = 1;
-  if (DTYPE == ScalarType::Bool) {
-    other = false;
-  }
-  op_fill_scalar_out(self, other, out);
-
-  Tensor exp_out = tf.full(sizes, 1);
-  if (DTYPE == ScalarType::Bool) {
-    exp_out = tf.full(sizes, false);
+class OpFillTest : public OperatorTest {
+ protected:
+  Tensor&
+  op_fill_scalar_out(const Tensor& self, const Scalar& other, Tensor& out) {
+    return torch::executor::aten::fill_outf(context_, self, other, out);
   }
 
-  // Check `out` matches expected output.
-  EXPECT_TENSOR_EQ(out, exp_out);
-}
+  Tensor&
+  op_fill_tensor_out(const Tensor& self, const Tensor& other, Tensor& out) {
+    return torch::executor::aten::fill_outf(context_, self, other, out);
+  }
 
-template <ScalarType DTYPE>
-void test_fill_tensor_out(std::vector<int32_t>&& sizes) {
-  TensorFactory<DTYPE> tf;
+  template <ScalarType DTYPE>
+  void test_fill_scalar_out(std::vector<int32_t>&& sizes) {
+    TensorFactory<DTYPE> tf;
 
-  // Before: `out` consists of 0s.
-  Tensor self = tf.zeros(sizes);
-  Tensor out = tf.zeros(sizes);
+    // Before: `out` consists of 0s.
+    Tensor self = tf.zeros(sizes);
+    Tensor out = tf.zeros(sizes);
 
-  // After: `out` consists of 1s.
-  Tensor other = tf.ones({});
-  op_fill_tensor_out(self, other, out);
+    // After: `out` consists of 1s.
+    Scalar other = 1;
+    if (DTYPE == ScalarType::Bool) {
+      other = false;
+    }
+    op_fill_scalar_out(self, other, out);
 
-  Tensor exp_out = tf.full(sizes, 1);
+    Tensor exp_out = tf.full(sizes, 1);
+    if (DTYPE == ScalarType::Bool) {
+      exp_out = tf.full(sizes, false);
+    }
 
-  // Check `out` matches expected output.
-  EXPECT_TENSOR_EQ(out, exp_out);
-}
+    // Check `out` matches expected output.
+    EXPECT_TENSOR_EQ(out, exp_out);
+  }
+
+  template <ScalarType DTYPE>
+  void test_fill_tensor_out(std::vector<int32_t>&& sizes) {
+    TensorFactory<DTYPE> tf;
+
+    // Before: `out` consists of 0s.
+    Tensor self = tf.zeros(sizes);
+    Tensor out = tf.zeros(sizes);
+
+    // After: `out` consists of 1s.
+    Tensor other = tf.ones({});
+    op_fill_tensor_out(self, other, out);
+
+    Tensor exp_out = tf.full(sizes, 1);
+
+    // Check `out` matches expected output.
+    EXPECT_TENSOR_EQ(out, exp_out);
+  }
+};
 
 // A macro for defining tests for both scalar and tensor variants of
 // `fill_out`. Here the `self` and `out` tensors will be created according
@@ -87,7 +88,7 @@ void test_fill_tensor_out(std::vector<int32_t>&& sizes) {
 
 // Create input support tests for scalar variant.
 #define GENERATE_SCALAR_INPUT_SUPPORT_TEST(_, DTYPE) \
-  TEST(OpFillTest, DTYPE##ScalarInputSupport) {      \
+  TEST_F(OpFillTest, DTYPE##ScalarInputSupport) {    \
     TEST_FILL_OUT(test_fill_scalar_out, DTYPE);      \
   }
 
@@ -95,13 +96,13 @@ ET_FORALL_REAL_TYPES_AND(Bool, GENERATE_SCALAR_INPUT_SUPPORT_TEST)
 
 // Create input support tests for tensor variant.
 #define GENERATE_TENSOR_INPUT_SUPPORT_TEST(_, DTYPE) \
-  TEST(OpFillTest, DTYPE##TensorInputSupport) {      \
+  TEST_F(OpFillTest, DTYPE##TensorInputSupport) {    \
     TEST_FILL_OUT(test_fill_tensor_out, DTYPE);      \
   }
 
 ET_FORALL_REAL_TYPES_AND(Bool, GENERATE_TENSOR_INPUT_SUPPORT_TEST)
 
-TEST(OpFillTest, MismatchedOtherPropertiesDies) {
+TEST_F(OpFillTest, MismatchedOtherPropertiesDies) {
   TensorFactory<ScalarType::Int> tf;
 
   // `self` and `out` have different shapes but same dtype.
@@ -124,12 +125,12 @@ TEST(OpFillTest, MismatchedOtherPropertiesDies) {
   EXPECT_EQ(other3.numel(), 9);
 
   // Assert `other` tensors with incompatible properties fails.
-  ET_EXPECT_KERNEL_FAILURE(op_fill_tensor_out(self, other1, out));
-  ET_EXPECT_KERNEL_FAILURE(op_fill_tensor_out(self, other2, out));
-  ET_EXPECT_KERNEL_FAILURE(op_fill_tensor_out(self, other3, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_fill_tensor_out(self, other1, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_fill_tensor_out(self, other2, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_fill_tensor_out(self, other3, out));
 }
 
-TEST(OpFillTest, MismatchedOutputShapesDies) {
+TEST_F(OpFillTest, MismatchedOutputShapesDies) {
   // Skip ATen test since it supports `self` and `out` having different shapes.
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched output shape";
@@ -142,10 +143,10 @@ TEST(OpFillTest, MismatchedOutputShapesDies) {
   Tensor out = tf.zeros({2, 2});
 
   // Assert `out` can't be filled due to incompatible shapes.
-  ET_EXPECT_KERNEL_FAILURE(op_fill_scalar_out(self, 0, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_fill_scalar_out(self, 0, out));
 }
 
-TEST(OpFillTest, MismatchedOutputDtypeDies) {
+TEST_F(OpFillTest, MismatchedOutputDtypeDies) {
   TensorFactory<ScalarType::Byte> tf_byte;
   TensorFactory<ScalarType::Float> tf_float;
 
@@ -154,5 +155,5 @@ TEST(OpFillTest, MismatchedOutputDtypeDies) {
   Tensor out = tf_float.ones({2, 2});
 
   // Assert `out` can't be filled due to incompatible dtype.
-  ET_EXPECT_KERNEL_FAILURE(op_fill_scalar_out(self, 0.0, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_fill_scalar_out(self, 0.0, out));
 }

--- a/kernels/test/op_floor_test.cpp
+++ b/kernels/test/op_floor_test.cpp
@@ -20,12 +20,14 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_floor_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::floor_outf(context, self, out);
-}
+class OpFloorTest : public OperatorTest {
+ protected:
+  Tensor& op_floor_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::floor_outf(context_, self, out);
+  }
+};
 
-TEST(OpFloorTest, SanityCheck) {
+TEST_F(OpFloorTest, SanityCheck) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor in = tf.make({1, 7}, {-3.0, -2.99, -1.01, 0.0, 1.01, 2.99, 3.0});
@@ -38,7 +40,7 @@ TEST(OpFloorTest, SanityCheck) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpFloorTest, HalfSupport) {
+TEST_F(OpFloorTest, HalfSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }

--- a/kernels/test/op_fmod_test.cpp
+++ b/kernels/test/op_fmod_test.cpp
@@ -20,14 +20,15 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor&
-op_fmod_tensor_out(const Tensor& self, const Tensor& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::fmod_outf(context, self, other, out);
-}
+class OpFmodTest : public OperatorTest {
+ protected:
+  Tensor&
+  op_fmod_tensor_out(const Tensor& self, const Tensor& other, Tensor& out) {
+    return torch::executor::aten::fmod_outf(context_, self, other, out);
+  }
 
-Tensor&
-op_fmod_scalar_out(const Tensor& self, const Scalar& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::fmod_outf(context, self, other, out);
-}
+  Tensor&
+  op_fmod_scalar_out(const Tensor& self, const Scalar& other, Tensor& out) {
+    return torch::executor::aten::fmod_outf(context_, self, other, out);
+  }
+};

--- a/kernels/test/op_full_test.cpp
+++ b/kernels/test/op_full_test.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
+#include <executorch/kernels/test/TestUtil.h>
 #include <executorch/kernels/test/supported_features.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
@@ -24,29 +25,31 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor&
-op_full_out(const IntArrayRef sizes, const Scalar& fill_value, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::full_outf(context, sizes, fill_value, out);
-}
+class OpFullOutTest : public OperatorTest {
+ protected:
+  Tensor&
+  op_full_out(const IntArrayRef sizes, const Scalar& fill_value, Tensor& out) {
+    return torch::executor::aten::full_outf(context_, sizes, fill_value, out);
+  }
 
-template <ScalarType DTYPE>
-void test_ones_out(std::vector<int32_t>&& size_int32_t) {
-  TensorFactory<DTYPE> tf;
-  std::vector<int64_t> size_int64_t(size_int32_t.begin(), size_int32_t.end());
-  auto aref = IntArrayRef(size_int64_t.data(), size_int64_t.size());
+  template <ScalarType DTYPE>
+  void test_ones_out(std::vector<int32_t>&& size_int32_t) {
+    TensorFactory<DTYPE> tf;
+    std::vector<int64_t> size_int64_t(size_int32_t.begin(), size_int32_t.end());
+    auto aref = IntArrayRef(size_int64_t.data(), size_int64_t.size());
 
-  // Before: `out` consists of 0s.
-  Tensor out = tf.zeros(size_int32_t);
+    // Before: `out` consists of 0s.
+    Tensor out = tf.zeros(size_int32_t);
 
-  // After: `out` consists of 1s.
-  op_full_out(aref, 1, out);
+    // After: `out` consists of 1s.
+    op_full_out(aref, 1, out);
 
-  EXPECT_TENSOR_EQ(out, tf.ones(size_int32_t));
-}
+    EXPECT_TENSOR_EQ(out, tf.ones(size_int32_t));
+  }
+};
 
 #define GENERATE_TEST(_, DTYPE)                  \
-  TEST(OpFullOutTest, DTYPE##Tensors) {          \
+  TEST_F(OpFullOutTest, DTYPE##Tensors) {        \
     test_ones_out<ScalarType::DTYPE>({});        \
     test_ones_out<ScalarType::DTYPE>({1});       \
     test_ones_out<ScalarType::DTYPE>({1, 1, 1}); \

--- a/kernels/test/op_gelu_test.cpp
+++ b/kernels/test/op_gelu_test.cpp
@@ -22,52 +22,55 @@ using exec_aten::Tensor;
 using torch::executor::testing::SupportedFeatures;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_gelu_out(const Tensor& self, string_view approximate, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::gelu_outf(context, self, approximate, out);
-}
+class OpGeluTest : public OperatorTest {
+ protected:
+  Tensor&
+  op_gelu_out(const Tensor& self, string_view approximate, Tensor& out) {
+    return torch::executor::aten::gelu_outf(context_, self, approximate, out);
+  }
 
-// Common testing for gelu on two floating point Tensors.
-template <ScalarType DTYPE>
-void test_gelu_execution() {
-  TensorFactory<DTYPE> tf;
+  // Common testing for gelu on two floating point Tensors.
+  template <ScalarType DTYPE>
+  void test_gelu_execution() {
+    TensorFactory<DTYPE> tf;
 
-  const std::vector<int32_t> sizes = {3, 2};
+    const std::vector<int32_t> sizes = {3, 2};
 
-  Tensor in = tf.make(
-      sizes, /*data=*/{-0.4775, 0.2948, -0.3984, 1.8690, -0.4048, -0.4848});
+    Tensor in = tf.make(
+        sizes, /*data=*/{-0.4775, 0.2948, -0.3984, 1.8690, -0.4048, -0.4848});
 
-  // Destination for the gelu.
-  Tensor out = tf.zeros(sizes);
+    // Destination for the gelu.
+    Tensor out = tf.zeros(sizes);
 
-  // Run full gelu.
-  op_gelu_out(in, "none", out);
+    // Run full gelu.
+    op_gelu_out(in, "none", out);
 
-  // Check that it matches the expected output.
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf.make(
-          sizes,
-          /*data=*/
-          {-0.15113, 0.181575, -0.137515, 1.81141, -0.13877, -0.152183}));
+    // Check that it matches the expected output.
+    EXPECT_TENSOR_CLOSE(
+        out,
+        tf.make(
+            sizes,
+            /*data=*/
+            {-0.15113, 0.181575, -0.137515, 1.81141, -0.13877, -0.152183}));
 
-  // Run tanh gelu appx.
-  op_gelu_out(in, "tanh", out);
+    // Run tanh gelu appx.
+    op_gelu_out(in, "tanh", out);
 
-  // Check that it matches the expected output.
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf.make(
-          sizes,
-          /*data=*/
-          {-0.151145, 0.181573, -0.137522, 1.8114, -0.138778, -0.152199}));
-}
+    // Check that it matches the expected output.
+    EXPECT_TENSOR_CLOSE(
+        out,
+        tf.make(
+            sizes,
+            /*data=*/
+            {-0.151145, 0.181573, -0.137522, 1.8114, -0.138778, -0.152199}));
+  }
+};
 
-TEST(OpGeluKernelTest, FloatTensors) {
+TEST_F(OpGeluTest, FloatTensors) {
   test_gelu_execution<ScalarType::Float>();
 }
 
-TEST(OpGeluKernelTest, DoubleTensors) {
+TEST_F(OpGeluTest, DoubleTensors) {
   if (!SupportedFeatures::get()->op_gelu_dtype_double) {
     GTEST_SKIP();
   }
@@ -75,7 +78,7 @@ TEST(OpGeluKernelTest, DoubleTensors) {
   test_gelu_execution<ScalarType::Double>();
 }
 
-TEST(OpGeluKernelTest, UnhandledDtypeDies) {
+TEST_F(OpGeluTest, UnhandledDtypeDies) {
   // gelu() doesn't handle Bool.
   TensorFactory<ScalarType::Bool> tf;
 
@@ -86,12 +89,12 @@ TEST(OpGeluKernelTest, UnhandledDtypeDies) {
   // Destination for the gelu.
   Tensor out = tf.zeros(sizes);
 
-  ET_EXPECT_KERNEL_FAILURE(op_gelu_out(a, "none", out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_gelu_out(a, "none", out));
 }
 
 // The output tensor may not have a dtype different from the inputs even if it
 // has the same shape.
-TEST(OpGeluKernelTest, MismatchedOutputDtypeDies) {
+TEST_F(OpGeluTest, MismatchedOutputDtypeDies) {
   // Two different dtypes. This test uses two types with the same size to
   // demonstrate that the ScalarType itself matters, not the size of the
   // tensor elements.
@@ -107,10 +110,10 @@ TEST(OpGeluKernelTest, MismatchedOutputDtypeDies) {
 
   // Running Gelu on an input into an output of a different dtype should kill
   // the program
-  ET_EXPECT_KERNEL_FAILURE(op_gelu_out(a, "none", out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_gelu_out(a, "none", out));
 }
 
-TEST(OpGeluKernelTest, InvalidAppxStringDies) {
+TEST_F(OpGeluTest, InvalidAppxStringDies) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor a = tf.ones(/*sizes=*/{4});
@@ -119,10 +122,10 @@ TEST(OpGeluKernelTest, InvalidAppxStringDies) {
   Tensor out = tf.zeros(/*sizes=*/{4});
 
   // Running Gelu with an invalid appx method should kill the program.
-  ET_EXPECT_KERNEL_FAILURE(op_gelu_out(a, "foo", out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_gelu_out(a, "foo", out));
 }
 
-TEST(OpGeluKernelTest, SimpleGeneratedCase) {
+TEST_F(OpGeluTest, SimpleGeneratedCase) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.make(
@@ -176,7 +179,7 @@ TEST(OpGeluKernelTest, SimpleGeneratedCase) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpGeluKernelTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpGeluTest, DynamicShapeUpperBoundSameAsExpected) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.make(
@@ -202,7 +205,7 @@ TEST(OpGeluKernelTest, DynamicShapeUpperBoundSameAsExpected) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpGeluKernelTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpGeluTest, DynamicShapeUpperBoundLargerThanExpected) {
   GTEST_SKIP() << "Dynamic shape not supported";
   TensorFactory<ScalarType::Float> tf;
 
@@ -229,7 +232,7 @@ TEST(OpGeluKernelTest, DynamicShapeUpperBoundLargerThanExpected) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpGeluKernelTest, DynamicShapeUnbound) {
+TEST_F(OpGeluTest, DynamicShapeUnbound) {
   GTEST_SKIP() << "Dynamic shape not supported";
   TensorFactory<ScalarType::Float> tf;
 

--- a/kernels/test/op_gt_test.cpp
+++ b/kernels/test/op_gt_test.cpp
@@ -21,32 +21,49 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_gt_scalar_out(const Tensor& self, Scalar& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::gt_outf(context, self, other, out);
-}
+class OpGtScalarOutTest : public OperatorTest {
+ protected:
+  Tensor& op_gt_scalar_out(const Tensor& self, Scalar& other, Tensor& out) {
+    return torch::executor::aten::gt_outf(context_, self, other, out);
+  }
 
-Tensor& op_gt_tensor_out(const Tensor& self, const Tensor& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::gt_outf(context, self, other, out);
-}
+  template <ScalarType DTYPE_IN, ScalarType DTYPE_OUT>
+  void test_gt_scalar_out() {
+    TensorFactory<DTYPE_IN> tf;
+    TensorFactory<DTYPE_OUT> tf_out;
 
-template <ScalarType DTYPE_IN, ScalarType DTYPE_OUT>
-void test_gt_scalar_out() {
-  TensorFactory<DTYPE_IN> tf;
-  TensorFactory<DTYPE_OUT> tf_out;
+    const std::vector<int32_t> sizes = {2, 2};
+    Tensor out = tf_out.ones(sizes);
+    Scalar other = 2;
 
-  const std::vector<int32_t> sizes = {2, 2};
-  Tensor out = tf_out.ones(sizes);
-  Scalar other = 2;
+    // Valid input should give the expected output
+    op_gt_scalar_out(tf.make(sizes, /*data=*/{3, 1, 2, 4}), other, out);
+    EXPECT_TENSOR_EQ(
+        out, tf_out.make(sizes, /*data=*/{true, false, false, true}));
+  }
+};
 
-  // Valid input should give the expected output
-  op_gt_scalar_out(tf.make(sizes, /*data=*/{3, 1, 2, 4}), other, out);
-  EXPECT_TENSOR_EQ(
-      out, tf_out.make(sizes, /*data=*/{true, false, false, true}));
-}
+class OpGtTensorOutTest : public OperatorTest {
+ protected:
+  Tensor&
+  op_gt_tensor_out(const Tensor& self, const Tensor& other, Tensor& out) {
+    return torch::executor::aten::gt_outf(context_, self, other, out);
+  }
 
-TEST(OpGtScalarOutKernelTest, AllRealInputBoolOutputSupport) {
+  template <ScalarType DTYPE_IN, ScalarType DTYPE_OUT>
+  void test_dtype() {
+    TensorFactory<DTYPE_IN> tf_input;
+    TensorFactory<DTYPE_OUT> tf_out;
+    Tensor a = tf_input.make(/*sizes=*/{2, 2}, /*data=*/{2, 3, 2, 4});
+    Tensor b = tf_input.make({2, 2}, {1, 4, 2, 3});
+    Tensor out = tf_out.zeros({2, 2});
+
+    op_gt_tensor_out(a, b, out);
+    EXPECT_TENSOR_EQ(out, tf_out.make({2, 2}, {true, false, false, true}));
+  }
+};
+
+TEST_F(OpGtScalarOutTest, AllRealInputBoolOutputSupport) {
 #define TEST_ENTRY(ctype_in, dtype_in, ctype_out, dtype_out) \
   test_gt_scalar_out<ScalarType::dtype_in, ScalarType::dtype_out>();
 
@@ -60,7 +77,7 @@ TEST(OpGtScalarOutKernelTest, AllRealInputBoolOutputSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpGtScalarOutKernelTest, BoolInputDtype) {
+TEST_F(OpGtScalarOutTest, BoolInputDtype) {
   TensorFactory<ScalarType::Bool> tf_bool;
 
   const std::vector<int32_t> sizes = {2, 2};
@@ -74,7 +91,7 @@ TEST(OpGtScalarOutKernelTest, BoolInputDtype) {
 }
 
 // Mismatched shape tests.
-TEST(OpGtScalarOutKernelTest, MismatchedInOutShapesDies) {
+TEST_F(OpGtScalarOutTest, MismatchedInOutShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
   }
@@ -85,10 +102,10 @@ TEST(OpGtScalarOutKernelTest, MismatchedInOutShapesDies) {
   Tensor out = tf_bool.ones(/*sizes=*/{2, 2});
   Scalar other = 3;
 
-  ET_EXPECT_KERNEL_FAILURE(op_gt_scalar_out(a, other, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_gt_scalar_out(a, other, out));
 }
 
-TEST(OpGtScalarOutKernelTest, DynamicOutShapeTest) {
+TEST_F(OpGtScalarOutTest, DynamicOutShapeTest) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int32_t> sizes = {2, 2};
@@ -103,19 +120,7 @@ TEST(OpGtScalarOutKernelTest, DynamicOutShapeTest) {
   EXPECT_TENSOR_EQ(out, tf.make(sizes, /*data=*/{true, false, false, true}));
 }
 
-template <ScalarType DTYPE_IN, ScalarType DTYPE_OUT>
-void test_dtype() {
-  TensorFactory<DTYPE_IN> tf_input;
-  TensorFactory<DTYPE_OUT> tf_out;
-  Tensor a = tf_input.make(/*sizes=*/{2, 2}, /*data=*/{2, 3, 2, 4});
-  Tensor b = tf_input.make({2, 2}, {1, 4, 2, 3});
-  Tensor out = tf_out.zeros({2, 2});
-
-  op_gt_tensor_out(a, b, out);
-  EXPECT_TENSOR_EQ(out, tf_out.make({2, 2}, {true, false, false, true}));
-}
-
-TEST(OpGtTensorOutKernelTest, AllDtypesSupported) {
+TEST_F(OpGtTensorOutTest, AllDtypesSupported) {
 #define TEST_ENTRY(ctype_in, dtype_in, ctype_out, dtype_out) \
   test_dtype<ScalarType::dtype_in, ScalarType::dtype_out>();
 
@@ -129,7 +134,7 @@ TEST(OpGtTensorOutKernelTest, AllDtypesSupported) {
 #undef TEST_ENTRY
 }
 
-TEST(OpGtTensorOutKernelTest, MismatchedInShapesDies) {
+TEST_F(OpGtTensorOutTest, MismatchedInShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
   }
@@ -140,10 +145,10 @@ TEST(OpGtTensorOutKernelTest, MismatchedInShapesDies) {
   Tensor b = tf_int.ones(/*sizes=*/{2, 2});
   Tensor out = tf_bool.ones(/*sizes=*/{4});
 
-  ET_EXPECT_KERNEL_FAILURE(op_gt_tensor_out(a, b, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_gt_tensor_out(a, b, out));
 }
 
-TEST(OpGtTensorOutKernelTest, MismatchedInOutShapesDies) {
+TEST_F(OpGtTensorOutTest, MismatchedInOutShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
   }
@@ -154,10 +159,10 @@ TEST(OpGtTensorOutKernelTest, MismatchedInOutShapesDies) {
   Tensor b = tf_int.ones(/*sizes=*/{4});
   Tensor out = tf_bool.ones(/*sizes=*/{2, 2});
 
-  ET_EXPECT_KERNEL_FAILURE(op_gt_tensor_out(a, b, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_gt_tensor_out(a, b, out));
 }
 
-TEST(OpGtTensorOutKernelTest, DynamicOutShapeTest) {
+TEST_F(OpGtTensorOutTest, DynamicOutShapeTest) {
   TensorFactory<ScalarType::Int> tf;
 
   Tensor a = tf.make(/*sizes=*/{2, 2}, /*data=*/{2, 3, 2, 4});

--- a/kernels/test/op_hardtanh_test.cpp
+++ b/kernels/test/op_hardtanh_test.cpp
@@ -20,17 +20,19 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_hardtanh_out(
-    const Tensor& self,
-    const Scalar& min_val,
-    const Scalar& max_val,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::hardtanh_outf(
-      context, self, min_val, max_val, out);
-}
+class OpHardTanhTest : public OperatorTest {
+ protected:
+  Tensor& op_hardtanh_out(
+      const Tensor& self,
+      const Scalar& min_val,
+      const Scalar& max_val,
+      Tensor& out) {
+    return torch::executor::aten::hardtanh_outf(
+        context_, self, min_val, max_val, out);
+  }
+};
 
-TEST(OpHardTanhTest, SanityCheck) {
+TEST_F(OpHardTanhTest, SanityCheck) {
   TensorFactory<ScalarType::Float> tf;
   Tensor in = tf.ones({2, 2});
   Tensor out = tf.zeros({2, 2});

--- a/kernels/test/op_index_select_test.cpp
+++ b/kernels/test/op_index_select_test.cpp
@@ -23,39 +23,124 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_index_select_out(
-    const Tensor& self,
-    int64_t dim,
-    const Tensor& index,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::index_select_outf(
-      context, self, dim, index, out);
-}
+class OpIndexSelectOutTest : public OperatorTest {
+ protected:
+  Tensor& op_index_select_out(
+      const Tensor& self,
+      int64_t dim,
+      const Tensor& index,
+      Tensor& out) {
+    return torch::executor::aten::index_select_outf(
+        context_, self, dim, index, out);
+  }
 
-namespace {
+  template <class CTYPE, exec_aten::ScalarType DTYPE>
+  void test_dtype() {
+    TensorFactory<DTYPE> tf;
+    TensorFactory<ScalarType::Long> tfl;
 
-// Run the test by selecting Tensor x on given dim and all available indexes on
-// that dimension
-void run_test_cases(
-    const Tensor& x,
-    ssize_t dim,
-    const Tensor& index,
-    const Tensor& expected) {
-  // Generated out tensor sharing same size and dtype with expected tensor
-  TensorFactory<ScalarType::Double> tf;
+    // test index_select on dimension 0.
 
-  const std::vector<int32_t> out_size(
-      expected.sizes().begin(), expected.sizes().end());
-  Tensor out = tf.ones(out_size);
+    // clang-format off
+    Tensor x = tf.make(
+        {3, 2, 4},
+        {
+          // all ones below are from x,
+          // and all zeros are from y.
+          // [0, :, :]
+          1, 1, 1, 1, // [0, 0, :]
+          0, 0, 0, 0, // [0, 1, :]
 
-  Tensor ret = op_index_select_out(x, dim, index, out);
-  EXPECT_TENSOR_EQ(out, ret);
-  EXPECT_TENSOR_EQ(ret, expected);
-}
-} // namespace
+          // [1, :, :]
+          1, 1, 1, 1, // [1, 0, :]
+          0, 0, 0, 0, // [1, 1, :]
 
-TEST(OpIndexSelectOutTest, SelectFrontDimAllIndexes) {
+          // [2, :, :]
+          1, 1, 1, 1, // [2, 0, :]
+          0, 0, 0, 0, // [2, 1, :]
+        });
+    // clang-format on
+
+    // Expected values for out_0 and ret_0 after the test are all ones(3, 4)
+    // based on the above rules. So here we set the default value of out_0 as
+    // zeros(3, 4) on purpose, to eliminate the influence to the final result
+    // from initial value. Same for out_1 and ret_1.
+
+    Tensor out_0 = tf.zeros({3, 1, 4});
+    Tensor out_1 = tf.ones({3, 1, 4});
+    Tensor index_0 = tfl.make({1}, {0});
+    Tensor index_1 = tfl.make({1}, {1});
+    Tensor ret_0 = op_index_select_out(x, /*dim=*/1, /*index=*/index_0, out_0);
+    Tensor ret_1 = op_index_select_out(x, /*dim=*/1, /*index=*/index_1, out_1);
+
+    EXPECT_TENSOR_EQ(ret_0, out_0);
+    EXPECT_TENSOR_EQ(ret_1, out_1);
+
+    EXPECT_TENSOR_EQ(ret_0, tf.ones({3, 1, 4}));
+    EXPECT_TENSOR_EQ(ret_1, tf.zeros({3, 1, 4}));
+  }
+
+  void test_dynamic_shape(
+      const std::vector<int32_t>& out_shape,
+      enum torch::executor::TensorShapeDynamism dynamism) {
+    /* %python
+    %rewrite(index_select_template) */
+
+    TensorFactory<ScalarType::Float> tf;
+    TensorFactory<ScalarType::Long> tf_index;
+
+    Tensor input = tf.make(
+        {2, 3, 4},
+        {0.49625658988952637,  0.7682217955589294,  0.08847743272781372,
+         0.13203048706054688,  0.30742281675338745, 0.6340786814689636,
+         0.4900934100151062,   0.8964447379112244,  0.455627977848053,
+         0.6323062777519226,   0.3488934636116028,  0.40171730518341064,
+         0.022325754165649414, 0.16885894536972046, 0.2938884496688843,
+         0.518521785736084,    0.6976675987243652,  0.800011396408081,
+         0.16102945804595947,  0.28226858377456665, 0.6816085577011108,
+         0.9151939749717712,   0.39709991216659546, 0.8741558790206909});
+    Tensor index = tf_index.make({2}, {0, 2});
+    Tensor expected = tf.make(
+        {2, 3, 2},
+        {0.49625658988952637,
+         0.08847743272781372,
+         0.30742281675338745,
+         0.4900934100151062,
+         0.455627977848053,
+         0.3488934636116028,
+         0.022325754165649414,
+         0.2938884496688843,
+         0.6976675987243652,
+         0.16102945804595947,
+         0.6816085577011108,
+         0.39709991216659546});
+    Tensor out = tf.zeros(out_shape, dynamism);
+
+    op_index_select_out(input, 2, index, out);
+    EXPECT_TENSOR_CLOSE(out, expected);
+  }
+
+  // Run the test by selecting Tensor x on given dim and all available indexes
+  // on that dimension
+  void run_test_cases(
+      const Tensor& x,
+      ssize_t dim,
+      const Tensor& index,
+      const Tensor& expected) {
+    // Generated out tensor sharing same size and dtype with expected tensor
+    TensorFactory<ScalarType::Double> tf;
+
+    const std::vector<int32_t> out_size(
+        expected.sizes().begin(), expected.sizes().end());
+    Tensor out = tf.ones(out_size);
+
+    Tensor ret = op_index_select_out(x, dim, index, out);
+    EXPECT_TENSOR_EQ(out, ret);
+    EXPECT_TENSOR_EQ(ret, expected);
+  }
+};
+
+TEST_F(OpIndexSelectOutTest, SelectFrontDimAllIndexes) {
   TensorFactory<ScalarType::Double> tf;
   TensorFactory<ScalarType::Long> tfl;
   // clang-format off
@@ -93,7 +178,7 @@ TEST(OpIndexSelectOutTest, SelectFrontDimAllIndexes) {
   run_test_cases(x, /*dim=*/0, /*index=*/index, expected);
 }
 
-TEST(OpIndexSelectOutTest, SelectMiddleDimAllIndexes) {
+TEST_F(OpIndexSelectOutTest, SelectMiddleDimAllIndexes) {
   TensorFactory<ScalarType::Double> tf;
   TensorFactory<ScalarType::Long> tfl;
   // clang-format off
@@ -133,7 +218,7 @@ TEST(OpIndexSelectOutTest, SelectMiddleDimAllIndexes) {
   run_test_cases(x, /*dim=*/1, /*index=*/index, expected);
 }
 
-TEST(OpIndexSelectOutTest, SelectEndDimAllIndexes) {
+TEST_F(OpIndexSelectOutTest, SelectEndDimAllIndexes) {
   TensorFactory<ScalarType::Double> tf;
   TensorFactory<ScalarType::Long> tfl;
   // clang-format off
@@ -178,53 +263,7 @@ TEST(OpIndexSelectOutTest, SelectEndDimAllIndexes) {
 
 /// A generic smoke test that works for any dtype that supports ones() and
 /// zeros().
-template <class CTYPE, exec_aten::ScalarType DTYPE>
-void test_dtype() {
-  TensorFactory<DTYPE> tf;
-  TensorFactory<ScalarType::Long> tfl;
-
-  // test index_select on dimension 0.
-
-  // clang-format off
-  Tensor x = tf.make(
-      {3, 2, 4},
-      {
-        // all ones below are from x,
-        // and all zeros are from y.
-        // [0, :, :]
-        1, 1, 1, 1, // [0, 0, :]
-        0, 0, 0, 0, // [0, 1, :]
-
-        // [1, :, :]
-        1, 1, 1, 1, // [1, 0, :]
-        0, 0, 0, 0, // [1, 1, :]
-
-        // [2, :, :]
-        1, 1, 1, 1, // [2, 0, :]
-        0, 0, 0, 0, // [2, 1, :]
-      });
-  // clang-format on
-
-  // Expected values for out_0 and ret_0 after the test are all ones(3, 4) based
-  // on the above rules. So here we set the default value of out_0 as zeros(3,
-  // 4) on purpose, to eliminate the influence to the final result from initial
-  // value. Same for out_1 and ret_1.
-
-  Tensor out_0 = tf.zeros({3, 1, 4});
-  Tensor out_1 = tf.ones({3, 1, 4});
-  Tensor index_0 = tfl.make({1}, {0});
-  Tensor index_1 = tfl.make({1}, {1});
-  Tensor ret_0 = op_index_select_out(x, /*dim=*/1, /*index=*/index_0, out_0);
-  Tensor ret_1 = op_index_select_out(x, /*dim=*/1, /*index=*/index_1, out_1);
-
-  EXPECT_TENSOR_EQ(ret_0, out_0);
-  EXPECT_TENSOR_EQ(ret_1, out_1);
-
-  EXPECT_TENSOR_EQ(ret_0, tf.ones({3, 1, 4}));
-  EXPECT_TENSOR_EQ(ret_1, tf.zeros({3, 1, 4}));
-}
-
-TEST(OpIndexSelectOutTest, AllDtypesSupported) {
+TEST_F(OpIndexSelectOutTest, AllDtypesSupported) {
 #define TEST_ENTRY(ctype, dtype) test_dtype<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
@@ -242,7 +281,7 @@ TEST(OpIndexSelectOutTest, AllDtypesSupported) {
 
 // In this test we are gonnna find if our select function support non-empty
 // tensor input and empty-size tensor output.
-TEST(OpIndexSelectOutTest, NonEmptyInputEmptyOutputWithMismatchDimDies) {
+TEST_F(OpIndexSelectOutTest, NonEmptyInputEmptyOutputWithMismatchDimDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
   }
@@ -258,12 +297,12 @@ TEST(OpIndexSelectOutTest, NonEmptyInputEmptyOutputWithMismatchDimDies) {
   // pass the empty-size tensor to the function,
   Tensor expect = tf.make({}, {5});
   ET_EXPECT_KERNEL_FAILURE(
-      op_index_select_out(x, /*dim=*/0, /*index=*/index, out));
+      context_, op_index_select_out(x, /*dim=*/0, /*index=*/index, out));
 }
 
 // This test focuses on the support for empty tensor (dim() > 0) input and empty
 // tensor output
-TEST(OpIndexSelectOutTest, EmptyInputEmptyOutputWithMatchingDimSupported) {
+TEST_F(OpIndexSelectOutTest, EmptyInputEmptyOutputWithMatchingDimSupported) {
   TensorFactory<ScalarType::Int> tf;
   TensorFactory<ScalarType::Long> tfl;
 
@@ -285,7 +324,7 @@ TEST(OpIndexSelectOutTest, EmptyInputEmptyOutputWithMatchingDimSupported) {
 
 ///////////////////////////////////////////////////////////////////////
 
-TEST(OpIndexSelectOutTest, DimOutOfBoundDies) {
+TEST_F(OpIndexSelectOutTest, DimOutOfBoundDies) {
   TensorFactory<ScalarType::Int> tf;
   TensorFactory<ScalarType::Long> tfl;
 
@@ -296,11 +335,12 @@ TEST(OpIndexSelectOutTest, DimOutOfBoundDies) {
   // Some invalid dim values.
   const std::vector<int32_t> invalid_dims = {3, 4, 5, -4, -5, -6};
   for (ssize_t dim : invalid_dims) {
-    ET_EXPECT_KERNEL_FAILURE(op_index_select_out(x, dim, /*index=*/index, out));
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, op_index_select_out(x, dim, /*index=*/index, out));
   }
 }
 
-TEST(OpIndexSelectOutTest, MismatchedDtypesDies) {
+TEST_F(OpIndexSelectOutTest, MismatchedDtypesDies) {
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Float> tf_float;
   TensorFactory<ScalarType::Long> tf_long;
@@ -312,10 +352,10 @@ TEST(OpIndexSelectOutTest, MismatchedDtypesDies) {
   Tensor index = tf_long.make({1}, {0});
 
   ET_EXPECT_KERNEL_FAILURE(
-      op_index_select_out(x, /*dim=*/0, /*index=*/index, out));
+      context_, op_index_select_out(x, /*dim=*/0, /*index=*/index, out));
 }
 
-TEST(OpIndexSelectOutTest, OutMatchNumelLackDimAtEndDies) {
+TEST_F(OpIndexSelectOutTest, OutMatchNumelLackDimAtEndDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
   }
@@ -330,10 +370,10 @@ TEST(OpIndexSelectOutTest, OutMatchNumelLackDimAtEndDies) {
   Tensor out = tf.ones({1, 2, 2});
 
   ET_EXPECT_KERNEL_FAILURE(
-      op_index_select_out(x, /*dim=*/0, /*index=*/index, out));
+      context_, op_index_select_out(x, /*dim=*/0, /*index=*/index, out));
 }
 
-TEST(OpIndexSelectOutTest, OutMatchNumelExtraDimAtFrontDies) {
+TEST_F(OpIndexSelectOutTest, OutMatchNumelExtraDimAtFrontDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
   }
@@ -348,10 +388,10 @@ TEST(OpIndexSelectOutTest, OutMatchNumelExtraDimAtFrontDies) {
   Tensor out = tf.ones({1, 1, 2});
 
   ET_EXPECT_KERNEL_FAILURE(
-      op_index_select_out(x, /*dim=*/0, /*index=*/index, out));
+      context_, op_index_select_out(x, /*dim=*/0, /*index=*/index, out));
 }
 
-TEST(OpIndexSelectOutTest, OutSizeMismatchDimDies) {
+TEST_F(OpIndexSelectOutTest, OutSizeMismatchDimDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
   }
@@ -366,10 +406,10 @@ TEST(OpIndexSelectOutTest, OutSizeMismatchDimDies) {
   Tensor out = tf.zeros({2, 4, 7});
 
   ET_EXPECT_KERNEL_FAILURE(
-      op_index_select_out(x, /*dim=*/2, /*index=*/index, out));
+      context_, op_index_select_out(x, /*dim=*/2, /*index=*/index, out));
 }
 
-TEST(OpIndexSelectOutTest, IndexWithInvalidDtypeDies) {
+TEST_F(OpIndexSelectOutTest, IndexWithInvalidDtypeDies) {
   TensorFactory<ScalarType::Int> tf;
   TensorFactory<ScalarType::Float> tff;
 
@@ -379,10 +419,10 @@ TEST(OpIndexSelectOutTest, IndexWithInvalidDtypeDies) {
   Tensor out = tf.zeros({2, 1, 7, 5});
 
   ET_EXPECT_KERNEL_FAILURE(
-      op_index_select_out(x, /*dim=*/1, /*index=*/index, out));
+      context_, op_index_select_out(x, /*dim=*/1, /*index=*/index, out));
 }
 
-TEST(OpIndexSelectOutTest, IndexWithInvalidDimDies) {
+TEST_F(OpIndexSelectOutTest, IndexWithInvalidDimDies) {
   TensorFactory<ScalarType::Int> tf;
   TensorFactory<ScalarType::Long> tfl;
 
@@ -393,11 +433,11 @@ TEST(OpIndexSelectOutTest, IndexWithInvalidDimDies) {
   Tensor out = tf.zeros({2, 1, 7, 5});
 
   ET_EXPECT_KERNEL_FAILURE(
-      op_index_select_out(x, /*dim=*/1, /*index=*/index, out));
+      context_, op_index_select_out(x, /*dim=*/1, /*index=*/index, out));
 }
 
 #if !defined(USE_ATEN_LIB)
-TEST(OpIndexSelectOutTest, UpperBoundOutTensor) {
+TEST_F(OpIndexSelectOutTest, UpperBoundOutTensor) {
   TensorFactory<ScalarType::Double> tf;
   TensorFactory<ScalarType::Long> tfl;
   // clang-format off
@@ -459,52 +499,12 @@ index_select_template = f"""
   op_index_select_out(input, $dim$, index, out);
   EXPECT_TENSOR_CLOSE(out, expected);""" */
 
-void test_dynamic_shape(
-    const std::vector<int32_t>& out_shape,
-    enum torch::executor::TensorShapeDynamism dynamism) {
-  /* %python
-  %rewrite(index_select_template) */
-
-  TensorFactory<ScalarType::Float> tf;
-  TensorFactory<ScalarType::Long> tf_index;
-
-  Tensor input = tf.make(
-      {2, 3, 4},
-      {0.49625658988952637,  0.7682217955589294,  0.08847743272781372,
-       0.13203048706054688,  0.30742281675338745, 0.6340786814689636,
-       0.4900934100151062,   0.8964447379112244,  0.455627977848053,
-       0.6323062777519226,   0.3488934636116028,  0.40171730518341064,
-       0.022325754165649414, 0.16885894536972046, 0.2938884496688843,
-       0.518521785736084,    0.6976675987243652,  0.800011396408081,
-       0.16102945804595947,  0.28226858377456665, 0.6816085577011108,
-       0.9151939749717712,   0.39709991216659546, 0.8741558790206909});
-  Tensor index = tf_index.make({2}, {0, 2});
-  Tensor expected = tf.make(
-      {2, 3, 2},
-      {0.49625658988952637,
-       0.08847743272781372,
-       0.30742281675338745,
-       0.4900934100151062,
-       0.455627977848053,
-       0.3488934636116028,
-       0.022325754165649414,
-       0.2938884496688843,
-       0.6976675987243652,
-       0.16102945804595947,
-       0.6816085577011108,
-       0.39709991216659546});
-  Tensor out = tf.zeros(out_shape, dynamism);
-
-  op_index_select_out(input, 2, index, out);
-  EXPECT_TENSOR_CLOSE(out, expected);
-}
-
-TEST(OpIndexSelectOutTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpIndexSelectOutTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(
       {2, 3, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpIndexSelectOutTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpIndexSelectOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   if (!torch::executor::testing::SupportedFeatures::get()->output_resize) {
     GTEST_SKIP() << "Dynamic shape not supported";
   }
@@ -512,7 +512,7 @@ TEST(OpIndexSelectOutTest, DynamicShapeUpperBoundLargerThanExpected) {
       {10, 10, 10}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpIndexSelectOutTest, DynamicShapeUnbound) {
+TEST_F(OpIndexSelectOutTest, DynamicShapeUnbound) {
   if (!torch::executor::testing::SupportedFeatures::get()->output_resize) {
     GTEST_SKIP() << "Dynamic shape not supported";
   }

--- a/kernels/test/op_isinf_test.cpp
+++ b/kernels/test/op_isinf_test.cpp
@@ -20,12 +20,14 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_isinf_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::isinf_outf(context, self, out);
-}
+class OpIsInfTest : public OperatorTest {
+ protected:
+  Tensor& op_isinf_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::isinf_outf(context_, self, out);
+  }
+};
 
-TEST(OpIsInfTest, SanityCheckFloat) {
+TEST_F(OpIsInfTest, SanityCheckFloat) {
   TensorFactory<ScalarType::Float> tf;
   TensorFactory<ScalarType::Bool> tfb;
 
@@ -40,7 +42,7 @@ TEST(OpIsInfTest, SanityCheckFloat) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpIsInfTest, SanityCheckHalf) {
+TEST_F(OpIsInfTest, SanityCheckHalf) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -58,7 +60,7 @@ TEST(OpIsInfTest, SanityCheckHalf) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpIsInfTest, SanityCheckByte) {
+TEST_F(OpIsInfTest, SanityCheckByte) {
   TensorFactory<ScalarType::Byte> tf;
   TensorFactory<ScalarType::Bool> tfb;
 
@@ -72,7 +74,7 @@ TEST(OpIsInfTest, SanityCheckByte) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpIsInfTest, SanityCheckBool) {
+TEST_F(OpIsInfTest, SanityCheckBool) {
   TensorFactory<ScalarType::Bool> tfb;
 
   Tensor in = tfb.make({1, 5}, {true, false, true, true, false});
@@ -85,11 +87,11 @@ TEST(OpIsInfTest, SanityCheckBool) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpIsInfTest, SanityCheckOutDtype) {
+TEST_F(OpIsInfTest, SanityCheckOutDtype) {
   TensorFactory<ScalarType::Int> tf;
 
   Tensor in = tf.make({1, 5}, {1, 2, 3, 4, 5});
   Tensor out = tf.zeros({1, 5});
 
-  ET_EXPECT_KERNEL_FAILURE(op_isinf_out(in, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_isinf_out(in, out));
 }

--- a/kernels/test/op_isnan_test.cpp
+++ b/kernels/test/op_isnan_test.cpp
@@ -20,12 +20,14 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_isnan_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::isnan_outf(context, self, out);
-}
+class OpIsNanTest : public OperatorTest {
+ protected:
+  Tensor& op_isnan_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::isnan_outf(context_, self, out);
+  }
+};
 
-TEST(OpIsNanTest, SanityCheckFloat) {
+TEST_F(OpIsNanTest, SanityCheckFloat) {
   TensorFactory<ScalarType::Float> tf;
   TensorFactory<ScalarType::Bool> tfb;
 
@@ -40,7 +42,7 @@ TEST(OpIsNanTest, SanityCheckFloat) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpIsNanTest, SanityCheckHalf) {
+TEST_F(OpIsNanTest, SanityCheckHalf) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -58,7 +60,7 @@ TEST(OpIsNanTest, SanityCheckHalf) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpIsNanTest, SanityCheckByte) {
+TEST_F(OpIsNanTest, SanityCheckByte) {
   TensorFactory<ScalarType::Byte> tf;
   TensorFactory<ScalarType::Bool> tfb;
 
@@ -72,7 +74,7 @@ TEST(OpIsNanTest, SanityCheckByte) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpIsNanTest, SanityCheckBool) {
+TEST_F(OpIsNanTest, SanityCheckBool) {
   TensorFactory<ScalarType::Bool> tfb;
 
   Tensor in = tfb.make({1, 5}, {true, false, true, true, false});
@@ -85,11 +87,11 @@ TEST(OpIsNanTest, SanityCheckBool) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpIsNanTest, SanityCheckOutDtype) {
+TEST_F(OpIsNanTest, SanityCheckOutDtype) {
   TensorFactory<ScalarType::Int> tf;
 
   Tensor in = tf.make({1, 5}, {1, 2, 3, 4, 5});
   Tensor out = tf.zeros({1, 5});
 
-  ET_EXPECT_KERNEL_FAILURE(op_isnan_out(in, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_isnan_out(in, out));
 }

--- a/kernels/test/op_leaky_relu_test.cpp
+++ b/kernels/test/op_leaky_relu_test.cpp
@@ -20,14 +20,18 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor&
-op_leaky_relu_out(const Tensor& in, const Scalar& negative_slope, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::leaky_relu_outf(
-      context, in, negative_slope, out);
-}
+class OpLeakyReluTest : public OperatorTest {
+ protected:
+  Tensor& op_leaky_relu_out(
+      const Tensor& in,
+      const Scalar& negative_slope,
+      Tensor& out) {
+    return torch::executor::aten::leaky_relu_outf(
+        context_, in, negative_slope, out);
+  }
+};
 
-TEST(OpLeakyReluTest, SanityCheck) {
+TEST_F(OpLeakyReluTest, SanityCheck) {
   TensorFactory<ScalarType::Float> tf;
   Tensor in = tf.ones({2, 2});
   Tensor out = tf.zeros({2, 2});

--- a/kernels/test/op_lift_fresh_copy_test.cpp
+++ b/kernels/test/op_lift_fresh_copy_test.cpp
@@ -21,66 +21,66 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-namespace {
-Tensor& op_lift_fresh_copy_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::lift_fresh_copy_outf(context, self, out);
-}
-} // namespace
+class OpLiftFreshCopyTest : public OperatorTest {
+ protected:
+  Tensor& op_lift_fresh_copy_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::lift_fresh_copy_outf(context_, self, out);
+  }
+
+  // test if lift_fresh_copy.out works well under all kinds of legal input type.
+  template <class CTYPE, exec_aten::ScalarType DTYPE>
+  void test_dtype() {
+    TensorFactory<DTYPE> tf;
+    Tensor self = tf.ones(/*sizes=*/{2, 4});
+    Tensor out = tf.zeros(/*sizes=*/{2, 4});
+
+    op_lift_fresh_copy_out(self, out);
+    EXPECT_TENSOR_EQ(self, out);
+
+    Tensor self_empty = tf.make(/*sizes=*/{}, /*data=*/{1});
+    Tensor out_empty = tf.make(/*sizes=*/{}, /*data=*/{0});
+
+    op_lift_fresh_copy_out(self_empty, out_empty);
+    EXPECT_TENSOR_EQ(self_empty, out_empty);
+  }
+
+  template <class CTYPE, ScalarType DTYPE>
+  void test_empty_input() {
+    TensorFactory<DTYPE> tf;
+    Tensor self = tf.make(/*sizes=*/{3, 0, 1, 2}, /*data=*/{});
+    Tensor out = tf.zeros({3, 0, 1, 2});
+    op_lift_fresh_copy_out(self, out);
+    EXPECT_TENSOR_EQ(self, out);
+  }
+};
 
 // regular test for lift_fresh_copy.out
-// test if lift_fresh_copy.out works well under all kinds of legal input type.
-template <class CTYPE, exec_aten::ScalarType DTYPE>
-void test_dtype() {
-  TensorFactory<DTYPE> tf;
-  Tensor self = tf.ones(/*sizes=*/{2, 4});
-  Tensor out = tf.zeros(/*sizes=*/{2, 4});
-
-  ::op_lift_fresh_copy_out(self, out);
-  EXPECT_TENSOR_EQ(self, out);
-
-  Tensor self_empty = tf.make(/*sizes=*/{}, /*data=*/{1});
-  Tensor out_empty = tf.make(/*sizes=*/{}, /*data=*/{0});
-
-  ::op_lift_fresh_copy_out(self_empty, out_empty);
-  EXPECT_TENSOR_EQ(self_empty, out_empty);
-}
-
-TEST(OpLiftFreshCopyTest, AllDtypesSupported) {
+TEST_F(OpLiftFreshCopyTest, AllDtypesSupported) {
 #define TEST_ENTRY(ctype, dtype) test_dtype<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-template <class CTYPE, ScalarType DTYPE>
-void test_empty_input() {
-  TensorFactory<DTYPE> tf;
-  Tensor self = tf.make(/*sizes=*/{3, 0, 1, 2}, /*data=*/{});
-  Tensor out = tf.zeros({3, 0, 1, 2});
-  ::op_lift_fresh_copy_out(self, out);
-  EXPECT_TENSOR_EQ(self, out);
-}
-
-TEST(OpLiftFreshCopyTest, EmptyInputSupported) {
+TEST_F(OpLiftFreshCopyTest, EmptyInputSupported) {
 #define TEST_ENTRY(ctype, dtype) test_empty_input<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpLiftFreshCopyTest, MismatchedSizesDie) {
+TEST_F(OpLiftFreshCopyTest, MismatchedSizesDie) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched sizes";
   }
   TensorFactory<ScalarType::Int> tf;
   Tensor self = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf.zeros({3, 2, 1, 1});
-  ET_EXPECT_KERNEL_FAILURE(::op_lift_fresh_copy_out(self, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_lift_fresh_copy_out(self, out));
 }
 
-TEST(OpLiftFreshCopyTest, MismatchedDTypeDie) {
+TEST_F(OpLiftFreshCopyTest, MismatchedDTypeDie) {
   TensorFactory<ScalarType::Int> tf_in;
   TensorFactory<ScalarType::Float> tf_out;
   Tensor self = tf_in.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf_out.zeros({3, 1, 1, 2});
-  ET_EXPECT_KERNEL_FAILURE(::op_lift_fresh_copy_out(self, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_lift_fresh_copy_out(self, out));
 }

--- a/kernels/test/op_logical_and_test.cpp
+++ b/kernels/test/op_logical_and_test.cpp
@@ -19,8 +19,10 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor&
-op_logical_and_out(const Tensor& self, const Tensor& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::logical_and_outf(context, self, other, out);
-}
+class OpLogicalAndTest : public OperatorTest {
+ protected:
+  Tensor&
+  op_logical_and_out(const Tensor& self, const Tensor& other, Tensor& out) {
+    return torch::executor::aten::logical_and_outf(context_, self, other, out);
+  }
+};

--- a/kernels/test/op_logical_or_test.cpp
+++ b/kernels/test/op_logical_or_test.cpp
@@ -19,8 +19,10 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor&
-op_logical_or_out(const Tensor& self, const Tensor& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::logical_or_outf(context, self, other, out);
-}
+class OpLogicalOrTest : public OperatorTest {
+ protected:
+  Tensor&
+  op_logical_or_out(const Tensor& self, const Tensor& other, Tensor& out) {
+    return torch::executor::aten::logical_or_outf(context_, self, other, out);
+  }
+};

--- a/kernels/test/op_logical_xor_test.cpp
+++ b/kernels/test/op_logical_xor_test.cpp
@@ -19,8 +19,10 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor&
-op_logical_xor_out(const Tensor& self, const Tensor& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::logical_xor_outf(context, self, other, out);
-}
+class OpLogicalXorTest : public OperatorTest {
+ protected:
+  Tensor&
+  op_logical_xor_out(const Tensor& self, const Tensor& other, Tensor& out) {
+    return torch::executor::aten::logical_xor_outf(context_, self, other, out);
+  }
+};

--- a/kernels/test/op_logit_test.cpp
+++ b/kernels/test/op_logit_test.cpp
@@ -21,86 +21,102 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_logit_out(const Tensor& self, optional<double> eps, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::logit_outf(context, self, eps, out);
-}
+class OpLogitOutTest : public OperatorTest {
+ protected:
+  Tensor& op_logit_out(const Tensor& self, optional<double> eps, Tensor& out) {
+    return torch::executor::aten::logit_outf(context_, self, eps, out);
+  }
 
-// Common testing for logit operator
-template <ScalarType DTYPE, ScalarType OUTPUT_DTYPE>
-void test_integer_logit_out() {
-  TensorFactory<DTYPE> tf;
-  TensorFactory<OUTPUT_DTYPE> tf_out;
+  // Common testing for logit operator
+  template <ScalarType DTYPE, ScalarType OUTPUT_DTYPE>
+  void test_integer_logit_out() {
+    TensorFactory<DTYPE> tf;
+    TensorFactory<OUTPUT_DTYPE> tf_out;
 
-  const std::vector<int32_t> sizes = {2, 2};
+    const std::vector<int32_t> sizes = {2, 2};
 
-  // Destination for the logit operator.
-  Tensor out = tf_out.zeros(sizes);
+    // Destination for the logit operator.
+    Tensor out = tf_out.zeros(sizes);
 
-  op_logit_out(tf.make(sizes, /*data=*/{1, 2, 4, 8}), 0, out);
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf_out.make(sizes, /*data=*/{INFINITY, INFINITY, INFINITY, INFINITY}));
-}
+    op_logit_out(tf.make(sizes, /*data=*/{1, 2, 4, 8}), 0, out);
+    EXPECT_TENSOR_CLOSE(
+        out,
+        tf_out.make(sizes, /*data=*/{INFINITY, INFINITY, INFINITY, INFINITY}));
+  }
 
-template <>
-void test_integer_logit_out<ScalarType::Float, ScalarType::Float>() {
-  TensorFactory<ScalarType::Float> tf;
-  TensorFactory<ScalarType::Float> tf_out;
+  template <>
+  void test_integer_logit_out<ScalarType::Float, ScalarType::Float>() {
+    TensorFactory<ScalarType::Float> tf;
+    TensorFactory<ScalarType::Float> tf_out;
 
-  const std::vector<int32_t> sizes = {2, 2};
+    const std::vector<int32_t> sizes = {2, 2};
 
-  // Destination for the logit operator.
-  Tensor out = tf_out.zeros(sizes);
+    // Destination for the logit operator.
+    Tensor out = tf_out.zeros(sizes);
 
-  // Check that it matches (or close to) the expected output.
-  op_logit_out(tf.make(sizes, /*data=*/{.1, .2, .4, .8}), 0, out);
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf_out.make(
-          sizes, /*data=*/{-2.197224, -1.386294, -0.405465, 1.3862943}));
-}
+    // Check that it matches (or close to) the expected output.
+    op_logit_out(tf.make(sizes, /*data=*/{.1, .2, .4, .8}), 0, out);
+    EXPECT_TENSOR_CLOSE(
+        out,
+        tf_out.make(
+            sizes, /*data=*/{-2.197224, -1.386294, -0.405465, 1.3862943}));
+  }
 
-// Common testing for logit operator
-template <ScalarType DTYPE, ScalarType OUTPUT_DTYPE>
-void test_integer_logit_out_eps_set() {
-  TensorFactory<DTYPE> tf;
-  TensorFactory<OUTPUT_DTYPE> tf_out;
+  // Common testing for logit operator
+  template <ScalarType DTYPE, ScalarType OUTPUT_DTYPE>
+  void test_integer_logit_out_eps_set() {
+    TensorFactory<DTYPE> tf;
+    TensorFactory<OUTPUT_DTYPE> tf_out;
 
-  const std::vector<int32_t> sizes = {2, 2};
+    const std::vector<int32_t> sizes = {2, 2};
 
-  // Destination for the logit operator.
-  Tensor out = tf_out.zeros(sizes);
+    // Destination for the logit operator.
+    Tensor out = tf_out.zeros(sizes);
 
-  op_logit_out(tf.make(sizes, /*data=*/{1, 2, 4, 8}), 0.1, out);
+    op_logit_out(tf.make(sizes, /*data=*/{1, 2, 4, 8}), 0.1, out);
 
-  // Check that it matches (or close to) the expected output.
-  EXPECT_TENSOR_CLOSE(
-      out,
-      tf_out.make(sizes, /*data=*/{2.197224, 2.197224, 2.197224, 2.197224}));
-}
+    // Check that it matches (or close to) the expected output.
+    EXPECT_TENSOR_CLOSE(
+        out,
+        tf_out.make(sizes, /*data=*/{2.197224, 2.197224, 2.197224, 2.197224}));
+  }
 
-TEST(OpLogitOutKernelTest, AllRealInputFloatOutputSupport) {
+  // Unhandled output dtypes.
+  template <ScalarType OUTPUT_DTYPE>
+  void test_logit_invalid_output_dtype_dies() {
+    TensorFactory<ScalarType::Float> tf;
+    TensorFactory<OUTPUT_DTYPE> tf_out;
+
+    const std::vector<int32_t> sizes = {2, 5};
+
+    Tensor in = tf.ones(sizes);
+    Tensor out = tf_out.zeros(sizes);
+
+    ET_EXPECT_KERNEL_FAILURE(context_, op_logit_out(in, 0, out));
+  }
+};
+
+TEST_F(OpLogitOutTest, AllRealInputFloatOutputSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_integer_logit_out<ScalarType::dtype, ScalarType::Float>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpLogitOutKernelTest, AllRealInputDoubleOutputSupport) {
+TEST_F(OpLogitOutTest, AllRealInputDoubleOutputSupport) {
 #define TEST_ENTRY(ctype, dtype) \
   test_integer_logit_out<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
-TEST(OpLogitOutKernelTest, AllRealInputFloatOutputSupportEpsSet) {
+TEST_F(OpLogitOutTest, AllRealInputFloatOutputSupportEpsSet) {
 #define TEST_ENTRY(ctype, dtype) \
   test_integer_logit_out_eps_set<ScalarType::dtype, ScalarType::Float>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpLogitOutKernelTest, AllRealInputDoubleOutputSupportEpsSet) {
+TEST_F(OpLogitOutTest, AllRealInputDoubleOutputSupportEpsSet) {
 #define TEST_ENTRY(ctype, dtype) \
   test_integer_logit_out_eps_set<ScalarType::dtype, ScalarType::Double>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
@@ -108,7 +124,7 @@ TEST(OpLogitOutKernelTest, AllRealInputDoubleOutputSupportEpsSet) {
 }
 
 // Mismatched shape tests.
-TEST(OpLogitOutKernelTest, MismatchedShapesDies) {
+TEST_F(OpLogitOutTest, MismatchedShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
   }
@@ -118,31 +134,17 @@ TEST(OpLogitOutKernelTest, MismatchedShapesDies) {
   Tensor a = tf.ones(/*sizes=*/{4});
   Tensor out = tf_out.ones(/*sizes=*/{2, 2});
 
-  ET_EXPECT_KERNEL_FAILURE(op_logit_out(a, 0, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_logit_out(a, 0, out));
 }
 
-// Unhandled output dtypes.
-template <ScalarType OUTPUT_DTYPE>
-void test_logit_invalid_output_dtype_dies() {
-  TensorFactory<ScalarType::Float> tf;
-  TensorFactory<OUTPUT_DTYPE> tf_out;
-
-  const std::vector<int32_t> sizes = {2, 5};
-
-  Tensor in = tf.ones(sizes);
-  Tensor out = tf_out.zeros(sizes);
-
-  ET_EXPECT_KERNEL_FAILURE(op_logit_out(in, 0, out));
-}
-
-TEST(OpLogitOutKernelTest, AllNonFloatOutputDTypeDies) {
+TEST_F(OpLogitOutTest, AllNonFloatOutputDTypeDies) {
 #define TEST_ENTRY(ctype, dtype) \
   test_logit_invalid_output_dtype_dies<ScalarType::dtype>();
   ET_FORALL_INT_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpLogitOutKernelTest, SimpleGeneratedCase) {
+TEST_F(OpLogitOutTest, SimpleGeneratedCase) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.make(
@@ -196,7 +198,7 @@ TEST(OpLogitOutKernelTest, SimpleGeneratedCase) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpLogitOutKernelTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpLogitOutTest, DynamicShapeUpperBoundSameAsExpected) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.make(
@@ -222,7 +224,7 @@ TEST(OpLogitOutKernelTest, DynamicShapeUpperBoundSameAsExpected) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpLogitOutKernelTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpLogitOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.make(
@@ -248,7 +250,7 @@ TEST(OpLogitOutKernelTest, DynamicShapeUpperBoundLargerThanExpected) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpLogitOutKernelTest, DynamicShapeUnbound) {
+TEST_F(OpLogitOutTest, DynamicShapeUnbound) {
   GTEST_SKIP() << "Dynamic shape unbound not supported";
   TensorFactory<ScalarType::Float> tf;
 

--- a/kernels/test/op_lt_test.cpp
+++ b/kernels/test/op_lt_test.cpp
@@ -21,32 +21,49 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_lt_scalar_out(const Tensor& self, Scalar& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::lt_outf(context, self, other, out);
-}
+class OpLtScalarOutTest : public OperatorTest {
+ protected:
+  Tensor& op_lt_scalar_out(const Tensor& self, Scalar& other, Tensor& out) {
+    return torch::executor::aten::lt_outf(context_, self, other, out);
+  }
 
-Tensor& op_lt_tensor_out(const Tensor& self, const Tensor& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::lt_outf(context, self, other, out);
-}
+  template <ScalarType DTYPE_IN, ScalarType DTYPE_OUT>
+  void test_lt_scalar_out() {
+    TensorFactory<DTYPE_IN> tf;
+    TensorFactory<DTYPE_OUT> tf_out;
 
-template <ScalarType DTYPE_IN, ScalarType DTYPE_OUT>
-void test_lt_scalar_out() {
-  TensorFactory<DTYPE_IN> tf;
-  TensorFactory<DTYPE_OUT> tf_out;
+    const std::vector<int32_t> sizes = {2, 2};
+    Tensor out = tf_out.ones(sizes);
+    Scalar other = 2;
 
-  const std::vector<int32_t> sizes = {2, 2};
-  Tensor out = tf_out.ones(sizes);
-  Scalar other = 2;
+    // Valid input should give the expected output
+    op_lt_scalar_out(tf.make(sizes, /*data=*/{3, 1, 2, 4}), other, out);
+    EXPECT_TENSOR_EQ(
+        out, tf_out.make(sizes, /*data=*/{false, true, false, false}));
+  }
+};
 
-  // Valid input should give the expected output
-  op_lt_scalar_out(tf.make(sizes, /*data=*/{3, 1, 2, 4}), other, out);
-  EXPECT_TENSOR_EQ(
-      out, tf_out.make(sizes, /*data=*/{false, true, false, false}));
-}
+class OpLtTensorOutTest : public OperatorTest {
+ protected:
+  Tensor&
+  op_lt_tensor_out(const Tensor& self, const Tensor& other, Tensor& out) {
+    return torch::executor::aten::lt_outf(context_, self, other, out);
+  }
 
-TEST(OpLtScalarOutKernelTest, AllRealInputBoolOutputSupport) {
+  template <ScalarType DTYPE_IN, ScalarType DTYPE_OUT>
+  void test_dtype() {
+    TensorFactory<DTYPE_IN> tf_input;
+    TensorFactory<DTYPE_OUT> tf_out;
+    Tensor a = tf_input.make(/*sizes=*/{2, 2}, /*data=*/{2, 3, 2, 4});
+    Tensor b = tf_input.make({2, 2}, {1, 4, 2, 3});
+    Tensor out = tf_out.zeros({2, 2});
+
+    op_lt_tensor_out(a, b, out);
+    EXPECT_TENSOR_EQ(out, tf_out.make({2, 2}, {false, true, false, false}));
+  }
+};
+
+TEST_F(OpLtScalarOutTest, AllRealInputBoolOutputSupport) {
 #define TEST_ENTRY(ctype_in, dtype_in, ctype_out, dtype_out) \
   test_lt_scalar_out<ScalarType::dtype_in, ScalarType::dtype_out>();
 
@@ -60,7 +77,7 @@ TEST(OpLtScalarOutKernelTest, AllRealInputBoolOutputSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpLtScalarOutKernelTest, BoolInputDtype) {
+TEST_F(OpLtScalarOutTest, BoolInputDtype) {
   TensorFactory<ScalarType::Bool> tf_bool;
 
   const std::vector<int32_t> sizes = {2, 2};
@@ -74,7 +91,7 @@ TEST(OpLtScalarOutKernelTest, BoolInputDtype) {
 }
 
 // Mismatched shape tests.
-TEST(OpLtScalarOutKernelTest, MismatchedInOutShapesDies) {
+TEST_F(OpLtScalarOutTest, MismatchedInOutShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
   }
@@ -85,10 +102,10 @@ TEST(OpLtScalarOutKernelTest, MismatchedInOutShapesDies) {
   Tensor out = tf_bool.ones(/*sizes=*/{2, 2});
   Scalar other = 3;
 
-  ET_EXPECT_KERNEL_FAILURE(op_lt_scalar_out(a, other, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_lt_scalar_out(a, other, out));
 }
 
-TEST(OpLtScalarOutKernelTest, DynamicOutShapeTest) {
+TEST_F(OpLtScalarOutTest, DynamicOutShapeTest) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int32_t> sizes = {2, 2};
@@ -103,19 +120,7 @@ TEST(OpLtScalarOutKernelTest, DynamicOutShapeTest) {
   EXPECT_TENSOR_EQ(out, tf.make(sizes, /*data=*/{false, true, false, false}));
 }
 
-template <ScalarType DTYPE_IN, ScalarType DTYPE_OUT>
-void test_dtype() {
-  TensorFactory<DTYPE_IN> tf_input;
-  TensorFactory<DTYPE_OUT> tf_out;
-  Tensor a = tf_input.make(/*sizes=*/{2, 2}, /*data=*/{2, 3, 2, 4});
-  Tensor b = tf_input.make({2, 2}, {1, 4, 2, 3});
-  Tensor out = tf_out.zeros({2, 2});
-
-  op_lt_tensor_out(a, b, out);
-  EXPECT_TENSOR_EQ(out, tf_out.make({2, 2}, {false, true, false, false}));
-}
-
-TEST(OpLtTensorOutKernelTest, AllDtypesSupported) {
+TEST_F(OpLtTensorOutTest, AllDtypesSupported) {
 #define TEST_ENTRY(ctype_in, dtype_in, ctype_out, dtype_out) \
   test_dtype<ScalarType::dtype_in, ScalarType::dtype_out>();
 
@@ -129,7 +134,7 @@ TEST(OpLtTensorOutKernelTest, AllDtypesSupported) {
 #undef TEST_ENTRY
 }
 
-TEST(OpLtTensorOutKernelTest, MismatchedInShapesDies) {
+TEST_F(OpLtTensorOutTest, MismatchedInShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
   }
@@ -140,10 +145,10 @@ TEST(OpLtTensorOutKernelTest, MismatchedInShapesDies) {
   Tensor b = tf_int.ones(/*sizes=*/{2, 2});
   Tensor out = tf_bool.ones(/*sizes=*/{4});
 
-  ET_EXPECT_KERNEL_FAILURE(op_lt_tensor_out(a, b, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_lt_tensor_out(a, b, out));
 }
 
-TEST(OpLtTensorOutKernelTest, MismatchedInOutShapesDies) {
+TEST_F(OpLtTensorOutTest, MismatchedInOutShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
   }
@@ -154,10 +159,10 @@ TEST(OpLtTensorOutKernelTest, MismatchedInOutShapesDies) {
   Tensor b = tf_int.ones(/*sizes=*/{4});
   Tensor out = tf_bool.ones(/*sizes=*/{2, 2});
 
-  ET_EXPECT_KERNEL_FAILURE(op_lt_tensor_out(a, b, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_lt_tensor_out(a, b, out));
 }
 
-TEST(OpLtTensorOutKernelTest, DynamicOutShapeTest) {
+TEST_F(OpLtTensorOutTest, DynamicOutShapeTest) {
   TensorFactory<ScalarType::Int> tf;
 
   Tensor a = tf.make(/*sizes=*/{2, 2}, /*data=*/{2, 3, 2, 4});

--- a/kernels/test/op_max_pool2d_with_indices_test.cpp
+++ b/kernels/test/op_max_pool2d_with_indices_test.cpp
@@ -17,30 +17,32 @@
 
 using namespace ::testing;
 
-::std::tuple<exec_aten::Tensor&, exec_aten::Tensor&>
-op_max_pool2d_with_indices_out(
-    const exec_aten::Tensor& self,
-    exec_aten::ArrayRef<int64_t> kernel_size,
-    exec_aten::ArrayRef<int64_t> stride,
-    exec_aten::ArrayRef<int64_t> padding,
-    exec_aten::ArrayRef<int64_t> dilation,
-    bool ceil_mode,
-    exec_aten::Tensor& out,
-    exec_aten::Tensor& indices) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::max_pool2d_with_indices_outf(
-      context,
-      self,
-      kernel_size,
-      stride,
-      padding,
-      dilation,
-      ceil_mode,
-      out,
-      indices);
-}
+class OpMaxPool2DWithIndicesOutTest : public OperatorTest {
+ protected:
+  ::std::tuple<exec_aten::Tensor&, exec_aten::Tensor&>
+  op_max_pool2d_with_indices_out(
+      const exec_aten::Tensor& self,
+      exec_aten::ArrayRef<int64_t> kernel_size,
+      exec_aten::ArrayRef<int64_t> stride,
+      exec_aten::ArrayRef<int64_t> padding,
+      exec_aten::ArrayRef<int64_t> dilation,
+      bool ceil_mode,
+      exec_aten::Tensor& out,
+      exec_aten::Tensor& indices) {
+    return torch::executor::aten::max_pool2d_with_indices_outf(
+        context_,
+        self,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        out,
+        indices);
+  }
+};
 
-TEST(OpMaxPool2DWithIndicesOutTest, SanityTest4D) {
+TEST_F(OpMaxPool2DWithIndicesOutTest, SanityTest4D) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Long> tfLong;
 
@@ -107,7 +109,7 @@ TEST(OpMaxPool2DWithIndicesOutTest, SanityTest4D) {
   EXPECT_TENSOR_CLOSE(indices, indices_expected);
 }
 
-TEST(OpMaxPool2DWithIndicesOutTest, SanityTest4D_2) {
+TEST_F(OpMaxPool2DWithIndicesOutTest, SanityTest4D_2) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Long> tfLong;
 
@@ -210,7 +212,7 @@ TEST(OpMaxPool2DWithIndicesOutTest, SanityTest4D_2) {
   EXPECT_TENSOR_CLOSE(indices, indices_expected);
 }
 
-TEST(OpMaxPool2DWithIndicesOutTest, SanityTest3D) {
+TEST_F(OpMaxPool2DWithIndicesOutTest, SanityTest3D) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Long> tfLong;
 

--- a/kernels/test/op_max_test.cpp
+++ b/kernels/test/op_max_test.cpp
@@ -23,51 +23,206 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-std::tuple<Tensor&, Tensor&> op_max_dim_max(
-    const Tensor& self,
-    int64_t dim,
-    bool keepdim,
-    Tensor& max,
-    Tensor& max_indices) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::max_outf(
-      context, self, dim, keepdim, max, max_indices);
-}
+class OpMaxOutTest : public OperatorTest {
+ protected:
+  std::tuple<Tensor&, Tensor&> op_max_dim_max(
+      const Tensor& self,
+      int64_t dim,
+      bool keepdim,
+      Tensor& max,
+      Tensor& max_indices) {
+    return torch::executor::aten::max_outf(
+        context_, self, dim, keepdim, max, max_indices);
+  }
 
-template <ScalarType IN_DTYPE>
-void test_max_out_invalid_dimensions() {
-  TensorFactory<IN_DTYPE> tf_in;
-  TensorFactory<ScalarType::Long> tf_long;
+  template <ScalarType IN_DTYPE>
+  void test_max_out_invalid_dimensions() {
+    TensorFactory<IN_DTYPE> tf_in;
+    TensorFactory<ScalarType::Long> tf_long;
 
-  Tensor self = tf_in.ones(/*sizes=*/{2, 3, 4});
-  Tensor max = tf_in.zeros({2, 3, 2});
-  Tensor max_indices = tf_in.zeros({2, 3});
+    Tensor self = tf_in.ones(/*sizes=*/{2, 3, 4});
+    Tensor max = tf_in.zeros({2, 3, 2});
+    Tensor max_indices = tf_in.zeros({2, 3});
 
-  // output tensor dim mismatch
-  ET_EXPECT_DEATH(
-      op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices), "");
+    // output tensor dim mismatch
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices));
 
-  // output tensor shape incorrect: size of dimension: dim should be 1
-  max = tf_in.zeros({2, 3, 2});
-  max_indices = tf_in.zeros({2, 3, 2});
-  ET_EXPECT_DEATH(
-      op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices), "");
+    // output tensor shape incorrect: size of dimension: dim should be 1
+    max = tf_in.zeros({2, 3, 2});
+    max_indices = tf_in.zeros({2, 3, 2});
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices));
 
-  // output tensor shape should be squeezed when keepdim is false
-  max = tf_in.zeros({2, 3, 1});
-  max_indices = tf_in.zeros({2, 3, 1});
-  ET_EXPECT_DEATH(
-      op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/false, max, max_indices),
-      "");
+    // output tensor shape should be squeezed when keepdim is false
+    max = tf_in.zeros({2, 3, 1});
+    max_indices = tf_in.zeros({2, 3, 1});
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/false, max, max_indices));
 
-  // invalid dim
-  max = tf_in.zeros({2, 3, 1});
-  max_indices = tf_in.zeros({2, 3, 1});
-  ET_EXPECT_DEATH(
-      op_max_dim_max(self, /*dim=*/3, /*keepdim=*/true, max, max_indices), "");
-}
+    // invalid dim
+    max = tf_in.zeros({2, 3, 1});
+    max_indices = tf_in.zeros({2, 3, 1});
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_max_dim_max(self, /*dim=*/3, /*keepdim=*/true, max, max_indices));
+  }
 
-TEST(OpMaxOutTest, MismatchedDimensionsDies) {
+  void test_dynamic_shape(
+      const std::vector<int32_t>& out_shape,
+      enum torch::executor::TensorShapeDynamism dynamism) {
+    /* %python
+    %rewrite(max_template) */
+
+    TensorFactory<ScalarType::Float> tf;
+    TensorFactory<ScalarType::Long> tfl;
+
+    Tensor input = tf.make(
+        {2, 3, 4},
+        {0.49625658988952637,  0.7682217955589294,  0.08847743272781372,
+         0.13203048706054688,  0.30742281675338745, 0.6340786814689636,
+         0.4900934100151062,   0.8964447379112244,  0.455627977848053,
+         0.6323062777519226,   0.3488934636116028,  0.40171730518341064,
+         0.022325754165649414, 0.16885894536972046, 0.2938884496688843,
+         0.518521785736084,    0.6976675987243652,  0.800011396408081,
+         0.16102945804595947,  0.28226858377456665, 0.6816085577011108,
+         0.9151939749717712,   0.39709991216659546, 0.8741558790206909});
+    Tensor expected_max = tf.make(
+        {2, 4},
+        {0.49625658988952637,
+         0.7682217955589294,
+         0.4900934100151062,
+         0.8964447379112244,
+         0.6976675987243652,
+         0.9151939749717712,
+         0.39709991216659546,
+         0.8741558790206909});
+    Tensor expected_max_indices = tfl.make({2, 4}, {0, 0, 1, 1, 1, 2, 2, 2});
+    Tensor max = tf.zeros(out_shape, dynamism);
+    Tensor max_indices = tfl.zeros(out_shape, dynamism);
+
+    op_max_dim_max(input, 1, false, max, max_indices);
+    EXPECT_TENSOR_EQ(max, expected_max);
+    EXPECT_TENSOR_EQ(max_indices, expected_max_indices);
+  }
+
+  template <ScalarType IN_DTYPE>
+  void test_max_out_dtype() {
+    TensorFactory<IN_DTYPE> tf_in;
+    TensorFactory<ScalarType::Long> tf_long;
+    // clang-format off
+    Tensor self = tf_in.make(
+      {2, 3, 4},
+      {
+        0, 1, 2, 4,
+        4, 2, 1, 0,
+        1, 0, 4, 2,
+
+        4, 2, 1, 0,
+        0, 1, 2, 4,
+        1, 0, 4, 2,
+      });
+    // clang-format on
+
+    Tensor max = tf_in.zeros({2, 4});
+    Tensor max_indices = tf_long.zeros({2, 4});
+    op_max_dim_max(self, /*dim=*/1, /*keepdim=*/false, max, max_indices);
+    // clang-format off
+    EXPECT_TENSOR_CLOSE(max, tf_in.make(
+      {2, 4},
+      {
+        4, 2, 4, 4,
+        4, 2, 4, 4
+      }));
+
+    EXPECT_TENSOR_EQ(max_indices, tf_long.make(
+      {2, 4},
+      {
+        1, 1, 2, 0,
+        0, 0, 2, 1
+      }));
+    // clang-format on
+
+    // negative dim should work
+    op_max_dim_max(self, /*dim=*/-2, /*keepdim=*/false, max, max_indices);
+    // clang-format off
+    EXPECT_TENSOR_CLOSE(max, tf_in.make(
+      {2, 4},
+      {
+        4, 2, 4, 4,
+        4, 2, 4, 4
+      }));
+    EXPECT_TENSOR_EQ(max_indices, tf_long.make(
+      {2, 4},
+      {
+        1, 1, 2, 0,
+        0, 0, 2, 1
+      }));
+    // clang-format on
+
+    // keepdim should work
+    max = tf_in.zeros({2, 3, 1});
+    max_indices = tf_long.zeros({2, 3, 1});
+    op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices);
+    EXPECT_TENSOR_CLOSE(max, tf_in.make({2, 3, 1}, {4, 4, 4, 4, 4, 4}));
+    EXPECT_TENSOR_EQ(max_indices, tf_long.make({2, 3, 1}, {3, 0, 2, 0, 3, 2}));
+  }
+
+  template <>
+  void test_max_out_dtype<ScalarType::Bool>() {
+    TensorFactory<ScalarType::Bool> tf_bool;
+    TensorFactory<ScalarType::Long> tf_long;
+    // clang-format off
+    Tensor self = tf_bool.make(
+      {2, 3, 4},
+      {
+        true,  false, true,  false,
+        false, false, false, false,
+        false, true,  true,  false,
+
+        false, false, true,  false,
+        false, false, false, true,
+        true,  true,  true,  true,
+      });
+    // clang-format on
+
+    Tensor max = tf_bool.zeros({2, 3, 1});
+    Tensor max_indices = tf_long.zeros({2, 3, 1});
+
+    // +/-inf and nan should work
+    op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices);
+    // clang-format off
+    EXPECT_TENSOR_CLOSE(
+        max, tf_bool.make(
+          {2, 3, 1},
+          {
+            true,
+            false,
+            true,
+
+            true,
+            true,
+            true
+          }));
+    EXPECT_TENSOR_EQ(max_indices, tf_long.make(
+      {2, 3, 1},
+      {
+        0,
+        0,
+        1,
+
+        2,
+        3,
+        0
+      }));
+    // clang-format on
+  }
+};
+
+TEST_F(OpMaxOutTest, MismatchedDimensionsDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel test fails";
   }
@@ -77,7 +232,7 @@ TEST(OpMaxOutTest, MismatchedDimensionsDies) {
 #undef TEST_ENTRY
 }
 
-TEST(OpMaxOutTest, MismatchedDTypesDies) {
+TEST_F(OpMaxOutTest, MismatchedDTypesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel test fails";
   }
@@ -89,135 +244,25 @@ TEST(OpMaxOutTest, MismatchedDTypesDies) {
   Tensor max_indices = tf_long.zeros({2, 3, 1});
 
   // dtype of self and max should match
-  ET_EXPECT_DEATH(
-      op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices), "");
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices));
 
   // max_value tensor should have long as dtype
   max = tf_float.zeros({2, 3, 1});
   max_indices = tf_float.zeros({2, 3, 1});
-  ET_EXPECT_DEATH(
-      op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices), "");
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices));
 }
 
-template <ScalarType IN_DTYPE>
-void test_max_out_dtype() {
-  TensorFactory<IN_DTYPE> tf_in;
-  TensorFactory<ScalarType::Long> tf_long;
-  // clang-format off
-  Tensor self = tf_in.make(
-    {2, 3, 4},
-    {
-      0, 1, 2, 4,
-      4, 2, 1, 0,
-      1, 0, 4, 2,
-
-      4, 2, 1, 0,
-      0, 1, 2, 4,
-      1, 0, 4, 2,
-    });
-  // clang-format on
-
-  Tensor max = tf_in.zeros({2, 4});
-  Tensor max_indices = tf_long.zeros({2, 4});
-  op_max_dim_max(self, /*dim=*/1, /*keepdim=*/false, max, max_indices);
-  // clang-format off
-  EXPECT_TENSOR_CLOSE(max, tf_in.make(
-    {2, 4},
-    {
-      4, 2, 4, 4,
-      4, 2, 4, 4
-    }));
-
-  EXPECT_TENSOR_EQ(max_indices, tf_long.make(
-    {2, 4},
-    {
-      1, 1, 2, 0,
-      0, 0, 2, 1
-    }));
-  // clang-format on
-
-  // negative dim should work
-  op_max_dim_max(self, /*dim=*/-2, /*keepdim=*/false, max, max_indices);
-  // clang-format off
-  EXPECT_TENSOR_CLOSE(max, tf_in.make(
-    {2, 4},
-    {
-      4, 2, 4, 4,
-      4, 2, 4, 4
-    }));
-  EXPECT_TENSOR_EQ(max_indices, tf_long.make(
-    {2, 4},
-    {
-      1, 1, 2, 0,
-      0, 0, 2, 1
-    }));
-  // clang-format on
-
-  // keepdim should work
-  max = tf_in.zeros({2, 3, 1});
-  max_indices = tf_long.zeros({2, 3, 1});
-  op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices);
-  EXPECT_TENSOR_CLOSE(max, tf_in.make({2, 3, 1}, {4, 4, 4, 4, 4, 4}));
-  EXPECT_TENSOR_EQ(max_indices, tf_long.make({2, 3, 1}, {3, 0, 2, 0, 3, 2}));
-}
-
-template <>
-void test_max_out_dtype<ScalarType::Bool>() {
-  TensorFactory<ScalarType::Bool> tf_bool;
-  TensorFactory<ScalarType::Long> tf_long;
-  // clang-format off
-  Tensor self = tf_bool.make(
-    {2, 3, 4},
-    {
-      true,  false, true,  false,
-      false, false, false, false,
-      false, true,  true,  false,
-
-      false, false, true,  false,
-      false, false, false, true,
-      true,  true,  true,  true,
-    });
-  // clang-format on
-
-  Tensor max = tf_bool.zeros({2, 3, 1});
-  Tensor max_indices = tf_long.zeros({2, 3, 1});
-
-  // +/-inf and nan should work
-  op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices);
-  // clang-format off
-  EXPECT_TENSOR_CLOSE(
-      max, tf_bool.make(
-        {2, 3, 1},
-        {
-          true,
-          false,
-          true,
-
-          true,
-          true,
-          true
-        }));
-  EXPECT_TENSOR_EQ(max_indices, tf_long.make(
-    {2, 3, 1},
-    {
-      0,
-      0,
-      1,
-
-      2,
-      3,
-      0
-    }));
-  // clang-format on
-}
-
-TEST(OpMaxOutTest, AllRealInputLongOutputPasses) {
+TEST_F(OpMaxOutTest, AllRealInputLongOutputPasses) {
 #define TEST_ENTRY(ctype, dtype) test_max_out_dtype<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpMaxOutTest, InfinityAndNANTest) {
+TEST_F(OpMaxOutTest, InfinityAndNANTest) {
   TensorFactory<ScalarType::Float> tf_float;
   TensorFactory<ScalarType::Long> tf_long;
   // clang-format off
@@ -278,55 +323,17 @@ max_template = f"""
   EXPECT_TENSOR_EQ(max, expected_max);
   EXPECT_TENSOR_EQ(max_indices, expected_max_indices);""" */
 
-void test_dynamic_shape(
-    const std::vector<int32_t>& out_shape,
-    enum torch::executor::TensorShapeDynamism dynamism) {
-  /* %python
-  %rewrite(max_template) */
-
-  TensorFactory<ScalarType::Float> tf;
-  TensorFactory<ScalarType::Long> tfl;
-
-  Tensor input = tf.make(
-      {2, 3, 4},
-      {0.49625658988952637,  0.7682217955589294,  0.08847743272781372,
-       0.13203048706054688,  0.30742281675338745, 0.6340786814689636,
-       0.4900934100151062,   0.8964447379112244,  0.455627977848053,
-       0.6323062777519226,   0.3488934636116028,  0.40171730518341064,
-       0.022325754165649414, 0.16885894536972046, 0.2938884496688843,
-       0.518521785736084,    0.6976675987243652,  0.800011396408081,
-       0.16102945804595947,  0.28226858377456665, 0.6816085577011108,
-       0.9151939749717712,   0.39709991216659546, 0.8741558790206909});
-  Tensor expected_max = tf.make(
-      {2, 4},
-      {0.49625658988952637,
-       0.7682217955589294,
-       0.4900934100151062,
-       0.8964447379112244,
-       0.6976675987243652,
-       0.9151939749717712,
-       0.39709991216659546,
-       0.8741558790206909});
-  Tensor expected_max_indices = tfl.make({2, 4}, {0, 0, 1, 1, 1, 2, 2, 2});
-  Tensor max = tf.zeros(out_shape, dynamism);
-  Tensor max_indices = tfl.zeros(out_shape, dynamism);
-
-  op_max_dim_max(input, 1, false, max, max_indices);
-  EXPECT_TENSOR_EQ(max, expected_max);
-  EXPECT_TENSOR_EQ(max_indices, expected_max_indices);
-}
-
-TEST(OpMaxOutTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpMaxOutTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(
       {2, 4}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpMaxOutTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpMaxOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   test_dynamic_shape(
       {10, 10}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpMaxOutTest, DynamicShapeUnbound) {
+TEST_F(OpMaxOutTest, DynamicShapeUnbound) {
   if (!torch::executor::testing::SupportedFeatures::get()->output_resize) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }

--- a/kernels/test/op_mean_test.cpp
+++ b/kernels/test/op_mean_test.cpp
@@ -24,52 +24,223 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_mean_out(
-    const Tensor& self,
-    optional<ArrayRef<int64_t>> dim,
-    bool keepdim,
-    optional<ScalarType> dtype,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::mean_outf(
-      context, self, dim, keepdim, dtype, out);
-}
+class OpMeanOutTest : public OperatorTest {
+ protected:
+  Tensor& op_mean_out(
+      const Tensor& self,
+      optional<ArrayRef<int64_t>> dim,
+      bool keepdim,
+      optional<ScalarType> dtype,
+      Tensor& out) {
+    return torch::executor::aten::mean_outf(
+        context_, self, dim, keepdim, dtype, out);
+  }
 
-template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
-void test_mean_dim_out_invalid_dimensions() {
-  TensorFactory<IN_DTYPE> tf_in;
-  TensorFactory<OUT_DTYPE> tf_out;
+  template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
+  void test_mean_dim_out_invalid_dimensions() {
+    TensorFactory<IN_DTYPE> tf_in;
+    TensorFactory<OUT_DTYPE> tf_out;
 
-  // clang-format off
-  Tensor self = tf_in.make(
-    {2, 3, 4},
-    {
-      0, 1, 2,  3,
-      4, 5, 6,  7,
-      8, 9, 10, 11,
+    // clang-format off
+    Tensor self = tf_in.make(
+      {2, 3, 4},
+      {
+        0, 1, 2,  3,
+        4, 5, 6,  7,
+        8, 9, 10, 11,
 
-      12, 13, 14, 15,
-      16, 17, 18, 19,
-      20, 21, 22, 23,
-    });
-  // clang-format on
-  Tensor out = tf_out.zeros({2, 3, 1});
-  optional<ScalarType> dtype = OUT_DTYPE;
+        12, 13, 14, 15,
+        16, 17, 18, 19,
+        20, 21, 22, 23,
+      });
+    // clang-format on
+    Tensor out = tf_out.zeros({2, 3, 1});
+    optional<ScalarType> dtype = OUT_DTYPE;
 
-  // out-of-bound dim in dim list
-  int64_t dims_1[1] = {3};
-  optional<ArrayRef<int64_t>> optional_dim_list{ArrayRef<int64_t>{dims_1, 1}};
-  ET_EXPECT_DEATH(
-      op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out), "");
+    // out-of-bound dim in dim list
+    int64_t dims_1[1] = {3};
+    optional<ArrayRef<int64_t>> optional_dim_list{ArrayRef<int64_t>{dims_1, 1}};
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out));
 
-  // the same dim appears multiple times in list of dims
-  int64_t dims_2[2] = {2, 2};
-  optional_dim_list = ArrayRef<int64_t>{dims_2, 2};
-  ET_EXPECT_DEATH(
-      op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out), "");
-}
+    // the same dim appears multiple times in list of dims
+    int64_t dims_2[2] = {2, 2};
+    optional_dim_list = ArrayRef<int64_t>{dims_2, 2};
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out));
+  }
 
-TEST(OpMeanOutTest, InvalidDimensionListDies) {
+  template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
+  void test_mean_dim_out_invalid_shape() {
+    TensorFactory<IN_DTYPE> tf_in;
+    TensorFactory<OUT_DTYPE> tf_out;
+
+    // clang-format off
+    Tensor self = tf_in.make(
+      {2, 3, 4},
+      {
+        0, 1, 2,  3,
+        4, 5, 6,  7,
+        8, 9, 10, 11,
+
+        12, 13, 14, 15,
+        16, 17, 18, 19,
+        20, 21, 22, 23,
+      });
+    // clang-format on
+
+    // dimension size mismatch when keepdim is true
+    Tensor out = tf_out.zeros({2, 4});
+    optional<ScalarType> dtype = OUT_DTYPE;
+    int64_t dims_1[1] = {1};
+    optional<ArrayRef<int64_t>> optional_dim_list{ArrayRef<int64_t>{dims_1, 1}};
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out));
+
+    // dimension size mismatch when keepdim is false
+    out = tf_out.zeros({2, 1, 4});
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_mean_out(self, optional_dim_list, /*keepdim=*/false, dtype, out));
+  }
+
+  template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
+  void test_mean_dim_out_dtype() {
+    TensorFactory<IN_DTYPE> tf_in;
+    TensorFactory<OUT_DTYPE> tf_out;
+    // clang-format off
+    Tensor self = tf_in.make(
+      {2, 3, 4},
+      {
+        0, 1, 2,  3,
+        4, 5, 6,  7,
+        8, 9, 10, 11,
+
+        12, 13, 14, 15,
+        16, 17, 18, 19,
+        20, 21, 22, 23,
+      });
+    // clang-format on
+
+    // keepdim=true should work
+    Tensor out = tf_out.zeros({2, 3, 1});
+    int64_t dims_1[1] = {2};
+    optional<ArrayRef<int64_t>> optional_dim_list{ArrayRef<int64_t>{dims_1, 1}};
+    optional<ScalarType> dtype = OUT_DTYPE;
+    op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out);
+    // clang-format off
+    EXPECT_TENSOR_CLOSE(out, tf_out.make(
+      {2, 3, 1},
+      {
+        1.5,
+        5.5,
+        9.5,
+
+        13.5,
+        17.5,
+        21.5
+      }));
+    // clang-format on
+
+    // keepdim=false should work
+    out = tf_out.zeros({2, 3});
+    op_mean_out(self, optional_dim_list, /*keepdim=*/false, dtype, out);
+    // clang-format off
+    EXPECT_TENSOR_CLOSE(out, tf_out.make(
+      {2, 3},
+      {
+        1.5,  5.5,  9.5,
+        13.5, 17.5, 21.5
+      }));
+    // clang-format on
+
+    // dim list with multiple dimensions should work
+    out = tf_out.zeros({1, 1, 4});
+    int64_t dims_2[2] = {0, 1};
+    optional_dim_list = ArrayRef<int64_t>{dims_2, 2};
+    op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out);
+    EXPECT_TENSOR_CLOSE(out, tf_out.make({1, 1, 4}, {10, 11, 12, 13}));
+
+    out = tf_out.zeros({4});
+    op_mean_out(self, optional_dim_list, false, dtype, out);
+    EXPECT_TENSOR_CLOSE(out, tf_out.make({4}, {10, 11, 12, 13}));
+
+    // dim list with negative dimensions should work
+    out = tf_out.zeros({2, 1, 4});
+    int64_t dims_3[1] = {-2};
+    optional_dim_list = ArrayRef<int64_t>{dims_3, 1};
+    op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out);
+    // clang-format off
+    EXPECT_TENSOR_CLOSE(out, tf_out.make(
+      {2, 1, 4},
+      {
+        4,  5,  6,  7,
+
+        16, 17, 18, 19,
+      }));
+    // clang-format on
+
+    // empty/null dim list should work
+    out = tf_out.zeros({1, 1, 1});
+    optional<ArrayRef<int64_t>> null_dim_list;
+    op_mean_out(self, null_dim_list, /*keepdim=*/true, dtype, out);
+    EXPECT_TENSOR_CLOSE(out, tf_out.make({1, 1, 1}, {11.5}));
+
+    optional<ArrayRef<int64_t>> empty_dim_list{ArrayRef<int64_t>{}};
+    op_mean_out(self, empty_dim_list, /*keepdim=*/true, dtype, out);
+    EXPECT_TENSOR_CLOSE(out, tf_out.make({1, 1, 1}, {11.5}));
+
+    out = tf_out.zeros({});
+    op_mean_out(self, null_dim_list, /*keepdim=*/false, dtype, out);
+    EXPECT_TENSOR_CLOSE(out, tf_out.make({}, {11.5}));
+
+    op_mean_out(self, empty_dim_list, /*keepdim=*/false, dtype, out);
+    EXPECT_TENSOR_CLOSE(out, tf_out.make({}, {11.5}));
+  }
+
+  template <ScalarType OUT_DTYPE>
+  void test_mean_dim_out_bool() {
+    TensorFactory<ScalarType::Bool> tf_bool;
+    TensorFactory<OUT_DTYPE> tf_float;
+    // clang-format off
+    Tensor self = tf_bool.make(
+      {2, 3, 4},
+      {
+        true,  false, true,  false,
+        false, false, false, false,
+        false, true,  true,  false,
+
+        false, false, true,  false,
+        false, false, false, true,
+        true,  true,  true,  true,
+      });
+    // clang-format on
+
+    Tensor out = tf_float.zeros({1, 1, 4});
+    int64_t dims[2] = {0, 1};
+    optional<ArrayRef<int64_t>> optional_dim_list{ArrayRef<int64_t>{dims, 2}};
+    optional<ScalarType> dtype = OUT_DTYPE;
+    op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out);
+    EXPECT_TENSOR_CLOSE(
+        out,
+        tf_float.make({1, 1, 4}, {0.333333, 0.333333, 0.666667, 0.333333}));
+  }
+
+  template <>
+  void test_mean_dim_out_dtype<ScalarType::Bool, ScalarType::Float>() {
+    test_mean_dim_out_bool<ScalarType::Float>();
+  }
+
+  template <>
+  void test_mean_dim_out_dtype<ScalarType::Bool, ScalarType::Double>() {
+    test_mean_dim_out_bool<ScalarType::Double>();
+  }
+};
+
+TEST_F(OpMeanOutTest, InvalidDimensionListDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel test fails";
   }
@@ -87,40 +258,7 @@ TEST(OpMeanOutTest, InvalidDimensionListDies) {
 #undef TEST_KERNEL
 }
 
-template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
-void test_mean_dim_out_invalid_shape() {
-  TensorFactory<IN_DTYPE> tf_in;
-  TensorFactory<OUT_DTYPE> tf_out;
-
-  // clang-format off
-  Tensor self = tf_in.make(
-    {2, 3, 4},
-    {
-      0, 1, 2,  3,
-      4, 5, 6,  7,
-      8, 9, 10, 11,
-
-      12, 13, 14, 15,
-      16, 17, 18, 19,
-      20, 21, 22, 23,
-    });
-  // clang-format on
-
-  // dimension size mismatch when keepdim is true
-  Tensor out = tf_out.zeros({2, 4});
-  optional<ScalarType> dtype = OUT_DTYPE;
-  int64_t dims_1[1] = {1};
-  optional<ArrayRef<int64_t>> optional_dim_list{ArrayRef<int64_t>{dims_1, 1}};
-  ET_EXPECT_DEATH(
-      op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out), "");
-
-  // dimension size mismatch when keepdim is false
-  out = tf_out.zeros({2, 1, 4});
-  ET_EXPECT_DEATH(
-      op_mean_out(self, optional_dim_list, /*keepdim=*/false, dtype, out), "");
-}
-
-TEST(OpMeanOutTest, InvalidShapeDies) {
+TEST_F(OpMeanOutTest, InvalidShapeDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel test fails";
   }
@@ -138,7 +276,7 @@ TEST(OpMeanOutTest, InvalidShapeDies) {
 #undef TEST_KERNEL
 }
 
-TEST(OpMeanOutTest, MismatchedDTypesDies) {
+TEST_F(OpMeanOutTest, MismatchedDTypesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel test fails";
   }
@@ -166,147 +304,18 @@ TEST(OpMeanOutTest, MismatchedDTypesDies) {
   optional<ScalarType> dtype;
 
   // self tensor must have a floating point dtype when dtype is not specified
-  ET_EXPECT_DEATH(
-      op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out), "");
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out));
 
   dtype = ScalarType::Double;
   // out tensor should be of the same dtype with dtype when dtype is specified
-  ET_EXPECT_DEATH(
-      op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out), "");
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out));
 }
 
-template <ScalarType IN_DTYPE, ScalarType OUT_DTYPE>
-void test_mean_dim_out_dtype() {
-  TensorFactory<IN_DTYPE> tf_in;
-  TensorFactory<OUT_DTYPE> tf_out;
-  // clang-format off
-  Tensor self = tf_in.make(
-    {2, 3, 4},
-    {
-      0, 1, 2,  3,
-      4, 5, 6,  7,
-      8, 9, 10, 11,
-
-      12, 13, 14, 15,
-      16, 17, 18, 19,
-      20, 21, 22, 23,
-    });
-  // clang-format on
-
-  // keepdim=true should work
-  Tensor out = tf_out.zeros({2, 3, 1});
-  int64_t dims_1[1] = {2};
-  optional<ArrayRef<int64_t>> optional_dim_list{ArrayRef<int64_t>{dims_1, 1}};
-  optional<ScalarType> dtype = OUT_DTYPE;
-  op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out);
-  // clang-format off
-  EXPECT_TENSOR_CLOSE(out, tf_out.make(
-    {2, 3, 1},
-    {
-      1.5,
-      5.5,
-      9.5,
-
-      13.5,
-      17.5,
-      21.5
-    }));
-  // clang-format on
-
-  // keepdim=false should work
-  out = tf_out.zeros({2, 3});
-  op_mean_out(self, optional_dim_list, /*keepdim=*/false, dtype, out);
-  // clang-format off
-  EXPECT_TENSOR_CLOSE(out, tf_out.make(
-    {2, 3},
-    {
-      1.5,  5.5,  9.5,
-      13.5, 17.5, 21.5
-    }));
-  // clang-format on
-
-  // dim list with multiple dimensions should work
-  out = tf_out.zeros({1, 1, 4});
-  int64_t dims_2[2] = {0, 1};
-  optional_dim_list = ArrayRef<int64_t>{dims_2, 2};
-  op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out);
-  EXPECT_TENSOR_CLOSE(out, tf_out.make({1, 1, 4}, {10, 11, 12, 13}));
-
-  out = tf_out.zeros({4});
-  op_mean_out(self, optional_dim_list, false, dtype, out);
-  EXPECT_TENSOR_CLOSE(out, tf_out.make({4}, {10, 11, 12, 13}));
-
-  // dim list with negative dimensions should work
-  out = tf_out.zeros({2, 1, 4});
-  int64_t dims_3[1] = {-2};
-  optional_dim_list = ArrayRef<int64_t>{dims_3, 1};
-  op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out);
-  // clang-format off
-  EXPECT_TENSOR_CLOSE(out, tf_out.make(
-    {2, 1, 4},
-    {
-      4,  5,  6,  7,
-
-      16, 17, 18, 19,
-    }));
-  // clang-format on
-
-  // empty/null dim list should work
-  out = tf_out.zeros({1, 1, 1});
-  optional<ArrayRef<int64_t>> null_dim_list;
-  op_mean_out(self, null_dim_list, /*keepdim=*/true, dtype, out);
-  EXPECT_TENSOR_CLOSE(out, tf_out.make({1, 1, 1}, {11.5}));
-
-  optional<ArrayRef<int64_t>> empty_dim_list{ArrayRef<int64_t>{}};
-  op_mean_out(self, empty_dim_list, /*keepdim=*/true, dtype, out);
-  EXPECT_TENSOR_CLOSE(out, tf_out.make({1, 1, 1}, {11.5}));
-
-  out = tf_out.zeros({});
-  op_mean_out(self, null_dim_list, /*keepdim=*/false, dtype, out);
-  EXPECT_TENSOR_CLOSE(out, tf_out.make({}, {11.5}));
-
-  op_mean_out(self, empty_dim_list, /*keepdim=*/false, dtype, out);
-  EXPECT_TENSOR_CLOSE(out, tf_out.make({}, {11.5}));
-}
-
-template <ScalarType OUT_DTYPE>
-void test_mean_dim_out_bool() {
-  TensorFactory<ScalarType::Bool> tf_bool;
-  TensorFactory<OUT_DTYPE> tf_float;
-  // clang-format off
-  Tensor self = tf_bool.make(
-    {2, 3, 4},
-    {
-      true,  false, true,  false,
-      false, false, false, false,
-      false, true,  true,  false,
-
-      false, false, true,  false,
-      false, false, false, true,
-      true,  true,  true,  true,
-    });
-  // clang-format on
-
-  Tensor out = tf_float.zeros({1, 1, 4});
-  int64_t dims[2] = {0, 1};
-  optional<ArrayRef<int64_t>> optional_dim_list{ArrayRef<int64_t>{dims, 2}};
-  optional<ScalarType> dtype = OUT_DTYPE;
-  op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out);
-  EXPECT_TENSOR_CLOSE(
-      out, tf_float.make({1, 1, 4}, {0.333333, 0.333333, 0.666667, 0.333333}));
-}
-
-template <>
-void test_mean_dim_out_dtype<ScalarType::Bool, ScalarType::Float>() {
-  test_mean_dim_out_bool<ScalarType::Float>();
-}
-
-template <>
-void test_mean_dim_out_dtype<ScalarType::Bool, ScalarType::Double>() {
-  test_mean_dim_out_bool<ScalarType::Double>();
-}
-
-TEST(OpMeanOutTest, AllRealInputFloatOutputPasses) {
+TEST_F(OpMeanOutTest, AllRealInputFloatOutputPasses) {
   // Use a two layer switch to hanldle each possible data pair
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_mean_dim_out_dtype<ScalarType::INPUT_DTYPE, ScalarType::OUTPUT_DTYPE>();
@@ -319,7 +328,7 @@ TEST(OpMeanOutTest, AllRealInputFloatOutputPasses) {
 #undef TEST_KERNEL
 }
 
-TEST(OpMeanOutTest, HalfSupport) {
+TEST_F(OpMeanOutTest, HalfSupport) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
   }
@@ -334,7 +343,7 @@ TEST(OpMeanOutTest, HalfSupport) {
 #undef TEST_ENTRY
 }
 
-TEST(OpMeanOutTest, InfinityAndNANTest) {
+TEST_F(OpMeanOutTest, InfinityAndNANTest) {
   TensorFactory<ScalarType::Float> tf_float;
   // clang-format off
   Tensor self = tf_float.make(
@@ -370,7 +379,7 @@ TEST(OpMeanOutTest, InfinityAndNANTest) {
   // clang-format on
 }
 
-TEST(OpMeanOutTest, SimpleGeneratedCase) {
+TEST_F(OpMeanOutTest, SimpleGeneratedCase) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.make(
@@ -392,7 +401,7 @@ TEST(OpMeanOutTest, SimpleGeneratedCase) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpMeanOutTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpMeanOutTest, DynamicShapeUpperBoundSameAsExpected) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.make(
@@ -413,7 +422,7 @@ TEST(OpMeanOutTest, DynamicShapeUpperBoundSameAsExpected) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpMeanOutTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpMeanOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.make(
@@ -434,7 +443,7 @@ TEST(OpMeanOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
-TEST(OpMeanOutTest, DynamicShapeUnbound) {
+TEST_F(OpMeanOutTest, DynamicShapeUnbound) {
   GTEST_SKIP() << "Dynamic shape unbound not supported";
   TensorFactory<ScalarType::Float> tf;
 

--- a/kernels/test/op_min_test.cpp
+++ b/kernels/test/op_min_test.cpp
@@ -23,86 +23,93 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-std::tuple<Tensor&, Tensor&> op_min_dim_min(
-    const Tensor& in,
-    int64_t dim,
-    bool keepdim,
-    Tensor& min,
-    Tensor& min_indices) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::min_outf(
-      context, in, dim, keepdim, min, min_indices);
-}
-
-template <ScalarType IN_DTYPE>
-void test_min_out_invalid_dimensions() {
-  TensorFactory<IN_DTYPE> tf_in;
-  TensorFactory<ScalarType::Long> tf_long;
-
-  Tensor in = tf_in.ones(/*sizes=*/{2, 3, 4});
-  Tensor min = tf_in.zeros({2, 3, 2});
-  Tensor min_indices = tf_in.zeros({2, 3});
-
-  // output tensor dim mismatch
-  ET_EXPECT_DEATH(
-      op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices), "");
-
-  // output tensor shape incorrect: size of dimension: dim should be 1
-  min = tf_in.zeros({2, 3, 2});
-  min_indices = tf_in.zeros({2, 3, 2});
-  ET_EXPECT_DEATH(
-      op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices), "");
-
-  // output tensor shape should be squeezed when keepdim is false
-  min = tf_in.zeros({2, 3, 1});
-  min_indices = tf_in.zeros({2, 3, 1});
-  ET_EXPECT_DEATH(
-      op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/false, min, min_indices), "");
-
-  // invalid dim
-  min = tf_in.zeros({2, 3, 1});
-  min_indices = tf_in.zeros({2, 3, 1});
-  ET_EXPECT_DEATH(
-      op_min_dim_min(in, /*dim=*/3, /*keepdim=*/true, min, min_indices), "");
-}
-
-TEST(OpMinOutTest, MismatchedDimensionsDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
+class OpMinOutTest : public OperatorTest {
+ protected:
+  std::tuple<Tensor&, Tensor&> op_min_dim_min(
+      const Tensor& in,
+      int64_t dim,
+      bool keepdim,
+      Tensor& min,
+      Tensor& min_indices) {
+    return torch::executor::aten::min_outf(
+        context_, in, dim, keepdim, min, min_indices);
   }
-#define TEST_ENTRY(ctype, dtype) \
-  test_min_out_invalid_dimensions<ScalarType::dtype>();
-  ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
-#undef TEST_ENTRY
-}
 
-TEST(OpMinOutTest, MismatchedDTypesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
+  template <ScalarType IN_DTYPE>
+  void test_min_out_invalid_dimensions() {
+    TensorFactory<IN_DTYPE> tf_in;
+    TensorFactory<ScalarType::Long> tf_long;
+
+    Tensor in = tf_in.ones(/*sizes=*/{2, 3, 4});
+    Tensor min = tf_in.zeros({2, 3, 2});
+    Tensor min_indices = tf_in.zeros({2, 3});
+
+    // output tensor dim mismatch
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices));
+
+    // output tensor shape incorrect: size of dimension: dim should be 1
+    min = tf_in.zeros({2, 3, 2});
+    min_indices = tf_in.zeros({2, 3, 2});
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices));
+
+    // output tensor shape should be squeezed when keepdim is false
+    min = tf_in.zeros({2, 3, 1});
+    min_indices = tf_in.zeros({2, 3, 1});
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/false, min, min_indices));
+
+    // invalid dim
+    min = tf_in.zeros({2, 3, 1});
+    min_indices = tf_in.zeros({2, 3, 1});
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        op_min_dim_min(in, /*dim=*/3, /*keepdim=*/true, min, min_indices));
   }
-  TensorFactory<ScalarType::Float> tf_float;
-  TensorFactory<ScalarType::Long> tf_long;
 
-  Tensor in = tf_float.ones(/*sizes=*/{2, 3, 4});
-  Tensor min = tf_long.zeros({2, 3, 1});
-  Tensor min_indices = tf_long.zeros({2, 3, 1});
+  void test_dynamic_shape(
+      const std::vector<int32_t>& out_shape,
+      enum torch::executor::TensorShapeDynamism dynamism) {
+    /* %python
+    %rewrite(min_template) */
 
-  // dtype of in and min should match
-  ET_EXPECT_DEATH(
-      op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices), "");
+    TensorFactory<ScalarType::Float> tf;
+    TensorFactory<ScalarType::Long> tfl;
 
-  // min_value tensor should have long as dtype
-  min = tf_float.zeros({2, 3, 1});
-  min_indices = tf_float.zeros({2, 3, 1});
-  ET_EXPECT_DEATH(
-      op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices), "");
-}
+    // clang-format off
+  Tensor input = tf.make(
+      {2, 3, 4},
+      {0.49, 0.76, 0.08, 0.13,
+       0.30, 0.63, 0.49, 0.89,
+       0.45, 0.63, 0.34, 0.40,
 
-template <ScalarType IN_DTYPE>
-void test_min_out_dtype() {
-  TensorFactory<IN_DTYPE> tf_in;
-  TensorFactory<ScalarType::Long> tf_long;
-  // clang-format off
+       0.02, 0.16, 0.29, 0.51,
+       0.69, 0.80, 0.16, 0.28,
+       0.68, 0.91, 0.39, 0.87});
+  Tensor expected_min = tf.make(
+      {2, 4},
+      {0.30, 0.63, 0.08, 0.13,
+       0.02, 0.16, 0.16, 0.28});
+    // clang-format on
+
+    Tensor expected_min_indices = tfl.make({2, 4}, {1, 1, 0, 0, 0, 0, 1, 1});
+    Tensor min = tf.zeros(out_shape, dynamism);
+    Tensor min_indices = tfl.zeros(out_shape, dynamism);
+
+    op_min_dim_min(input, 1, false, min, min_indices);
+    EXPECT_TENSOR_EQ(min, expected_min);
+    EXPECT_TENSOR_EQ(min_indices, expected_min_indices);
+  }
+
+  template <ScalarType IN_DTYPE>
+  void test_min_out_dtype() {
+    TensorFactory<IN_DTYPE> tf_in;
+    TensorFactory<ScalarType::Long> tf_long;
+    // clang-format off
   Tensor in = tf_in.make(
     {2, 3, 4},
     {
@@ -114,12 +121,12 @@ void test_min_out_dtype() {
       0, 1, 2, 4,
       1, 0, 4, 2,
     });
-  // clang-format on
+    // clang-format on
 
-  Tensor min = tf_in.zeros({2, 4});
-  Tensor min_indices = tf_long.zeros({2, 4});
-  op_min_dim_min(in, /*dim=*/1, /*keepdim=*/false, min, min_indices);
-  // clang-format off
+    Tensor min = tf_in.zeros({2, 4});
+    Tensor min_indices = tf_long.zeros({2, 4});
+    op_min_dim_min(in, /*dim=*/1, /*keepdim=*/false, min, min_indices);
+    // clang-format off
   EXPECT_TENSOR_CLOSE(min, tf_in.make(
     {2, 4},
     {
@@ -133,11 +140,11 @@ void test_min_out_dtype() {
       0, 2, 1, 1,
       1, 2, 0, 0
     }));
-  // clang-format on
+    // clang-format on
 
-  // negative dim should work
-  op_min_dim_min(in, /*dim=*/-2, /*keepdim=*/false, min, min_indices);
-  // clang-format off
+    // negative dim should work
+    op_min_dim_min(in, /*dim=*/-2, /*keepdim=*/false, min, min_indices);
+    // clang-format off
   EXPECT_TENSOR_CLOSE(min, tf_in.make(
     {2, 4},
     {
@@ -150,21 +157,21 @@ void test_min_out_dtype() {
       0, 2, 1, 1,
       1, 2, 0, 0
     }));
-  // clang-format on
+    // clang-format on
 
-  // keepdim should work
-  min = tf_in.zeros({2, 3, 1});
-  min_indices = tf_long.zeros({2, 3, 1});
-  op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices);
-  EXPECT_TENSOR_CLOSE(min, tf_in.make({2, 3, 1}, {0, 0, 0, 0, 0, 0}));
-  EXPECT_TENSOR_EQ(min_indices, tf_long.make({2, 3, 1}, {0, 3, 1, 3, 0, 1}));
-}
+    // keepdim should work
+    min = tf_in.zeros({2, 3, 1});
+    min_indices = tf_long.zeros({2, 3, 1});
+    op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices);
+    EXPECT_TENSOR_CLOSE(min, tf_in.make({2, 3, 1}, {0, 0, 0, 0, 0, 0}));
+    EXPECT_TENSOR_EQ(min_indices, tf_long.make({2, 3, 1}, {0, 3, 1, 3, 0, 1}));
+  }
 
-template <>
-void test_min_out_dtype<ScalarType::Bool>() {
-  TensorFactory<ScalarType::Bool> tf_bool;
-  TensorFactory<ScalarType::Long> tf_long;
-  // clang-format off
+  template <>
+  void test_min_out_dtype<ScalarType::Bool>() {
+    TensorFactory<ScalarType::Bool> tf_bool;
+    TensorFactory<ScalarType::Long> tf_long;
+    // clang-format off
   Tensor in = tf_bool.make(
     {2, 3, 4},
     {
@@ -176,14 +183,14 @@ void test_min_out_dtype<ScalarType::Bool>() {
       false, false, false, true,
       true,  true,  true,  true,
     });
-  // clang-format on
+    // clang-format on
 
-  Tensor min = tf_bool.zeros({2, 3, 1});
-  Tensor min_indices = tf_long.zeros({2, 3, 1});
+    Tensor min = tf_bool.zeros({2, 3, 1});
+    Tensor min_indices = tf_long.zeros({2, 3, 1});
 
-  // +/-inf and nan should work
-  op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices);
-  // clang-format off
+    // +/-inf and nan should work
+    op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices);
+    // clang-format off
   EXPECT_TENSOR_CLOSE(
       min, tf_bool.make(
         {2, 3, 1},
@@ -207,16 +214,51 @@ void test_min_out_dtype<ScalarType::Bool>() {
       0,
       0
     }));
-  // clang-format on
+    // clang-format on
+  }
+};
+
+TEST_F(OpMinOutTest, MismatchedDimensionsDies) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "ATen kernel test fails";
+  }
+#define TEST_ENTRY(ctype, dtype) \
+  test_min_out_invalid_dimensions<ScalarType::dtype>();
+  ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
+#undef TEST_ENTRY
 }
 
-TEST(OpMinOutTest, AllRealInputLongOutputPasses) {
+TEST_F(OpMinOutTest, MismatchedDTypesDies) {
+  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
+    GTEST_SKIP() << "ATen kernel test fails";
+  }
+  TensorFactory<ScalarType::Float> tf_float;
+  TensorFactory<ScalarType::Long> tf_long;
+
+  Tensor in = tf_float.ones(/*sizes=*/{2, 3, 4});
+  Tensor min = tf_long.zeros({2, 3, 1});
+  Tensor min_indices = tf_long.zeros({2, 3, 1});
+
+  // dtype of in and min should match
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices));
+
+  // min_value tensor should have long as dtype
+  min = tf_float.zeros({2, 3, 1});
+  min_indices = tf_float.zeros({2, 3, 1});
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices));
+}
+
+TEST_F(OpMinOutTest, AllRealInputLongOutputPasses) {
 #define TEST_ENTRY(ctype, dtype) test_min_out_dtype<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpMinOutTest, InfinityAndNANTest) {
+TEST_F(OpMinOutTest, InfinityAndNANTest) {
   TensorFactory<ScalarType::Float> tf_float;
   TensorFactory<ScalarType::Long> tf_long;
   // clang-format off
@@ -255,51 +297,17 @@ TEST(OpMinOutTest, InfinityAndNANTest) {
   // clang-format on
 }
 
-void test_dynamic_shape(
-    const std::vector<int32_t>& out_shape,
-    enum torch::executor::TensorShapeDynamism dynamism) {
-  /* %python
-  %rewrite(min_template) */
-
-  TensorFactory<ScalarType::Float> tf;
-  TensorFactory<ScalarType::Long> tfl;
-
-  // clang-format off
-  Tensor input = tf.make(
-      {2, 3, 4},
-      {0.49, 0.76, 0.08, 0.13,
-       0.30, 0.63, 0.49, 0.89,
-       0.45, 0.63, 0.34, 0.40,
-
-       0.02, 0.16, 0.29, 0.51,
-       0.69, 0.80, 0.16, 0.28,
-       0.68, 0.91, 0.39, 0.87});
-  Tensor expected_min = tf.make(
-      {2, 4},
-      {0.30, 0.63, 0.08, 0.13,
-       0.02, 0.16, 0.16, 0.28});
-  // clang-format on
-
-  Tensor expected_min_indices = tfl.make({2, 4}, {1, 1, 0, 0, 0, 0, 1, 1});
-  Tensor min = tf.zeros(out_shape, dynamism);
-  Tensor min_indices = tfl.zeros(out_shape, dynamism);
-
-  op_min_dim_min(input, 1, false, min, min_indices);
-  EXPECT_TENSOR_EQ(min, expected_min);
-  EXPECT_TENSOR_EQ(min_indices, expected_min_indices);
-}
-
-TEST(OpMinOutTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpMinOutTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(
       {2, 4}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpMinOutTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpMinOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   test_dynamic_shape(
       {10, 10}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpMinOutTest, DynamicShapeUnbound) {
+TEST_F(OpMinOutTest, DynamicShapeUnbound) {
   if (!torch::executor::testing::SupportedFeatures::get()->output_resize) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }

--- a/kernels/test/op_native_batch_norm_test.cpp
+++ b/kernels/test/op_native_batch_norm_test.cpp
@@ -17,63 +17,68 @@
 
 using namespace ::testing;
 
-::std::tuple<exec_aten::Tensor&, exec_aten::Tensor&, exec_aten::Tensor&>
-op_native_batch_norm_legit_no_training_out(
-    const exec_aten::Tensor& input,
-    const exec_aten::optional<exec_aten::Tensor>& weight,
-    const exec_aten::optional<exec_aten::Tensor>& bias,
-    const exec_aten::Tensor& running_mean,
-    const exec_aten::Tensor& running_var,
-    double momentum,
-    double eps,
-    exec_aten::Tensor& out0,
-    exec_aten::Tensor& out1,
-    exec_aten::Tensor& out2) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::_native_batch_norm_legit_no_training_outf(
-      context,
-      input,
-      weight,
-      bias,
-      running_mean,
-      running_var,
-      momentum,
-      eps,
-      out0,
-      out1,
-      out2);
-}
+class OpNativeBatchNormLegitNoTrainingOutTest : public OperatorTest {
+ protected:
+  ::std::tuple<exec_aten::Tensor&, exec_aten::Tensor&, exec_aten::Tensor&>
+  op_native_batch_norm_legit_no_training_out(
+      const exec_aten::Tensor& input,
+      const exec_aten::optional<exec_aten::Tensor>& weight,
+      const exec_aten::optional<exec_aten::Tensor>& bias,
+      const exec_aten::Tensor& running_mean,
+      const exec_aten::Tensor& running_var,
+      double momentum,
+      double eps,
+      exec_aten::Tensor& out0,
+      exec_aten::Tensor& out1,
+      exec_aten::Tensor& out2) {
+    return torch::executor::aten::_native_batch_norm_legit_no_training_outf(
+        context_,
+        input,
+        weight,
+        bias,
+        running_mean,
+        running_var,
+        momentum,
+        eps,
+        out0,
+        out1,
+        out2);
+  }
+};
 
-::std::tuple<exec_aten::Tensor&, exec_aten::Tensor&, exec_aten::Tensor&>
-op_native_batch_norm_legit_out(
-    const exec_aten::Tensor& input,
-    const exec_aten::optional<exec_aten::Tensor>& weight,
-    const exec_aten::optional<exec_aten::Tensor>& bias,
-    exec_aten::Tensor& running_mean,
-    exec_aten::Tensor& running_var,
-    bool training,
-    double momentum,
-    double eps,
-    exec_aten::Tensor& out0,
-    exec_aten::Tensor& out1,
-    exec_aten::Tensor& out2) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::_native_batch_norm_legit_outf(
-      context,
-      input,
-      weight,
-      bias,
-      running_mean,
-      running_var,
-      training,
-      momentum,
-      eps,
-      out0,
-      out1,
-      out2);
-}
+class OpNativeBatchNormLegitOutTest : public OperatorTest {
+ protected:
+  ::std::tuple<exec_aten::Tensor&, exec_aten::Tensor&, exec_aten::Tensor&>
+  op_native_batch_norm_legit_out(
+      const exec_aten::Tensor& input,
+      const exec_aten::optional<exec_aten::Tensor>& weight,
+      const exec_aten::optional<exec_aten::Tensor>& bias,
+      exec_aten::Tensor& running_mean,
+      exec_aten::Tensor& running_var,
+      bool training,
+      double momentum,
+      double eps,
+      exec_aten::Tensor& out0,
+      exec_aten::Tensor& out1,
+      exec_aten::Tensor& out2) {
+    exec_aten::RuntimeContext context{};
+    return torch::executor::aten::_native_batch_norm_legit_outf(
+        context,
+        input,
+        weight,
+        bias,
+        running_mean,
+        running_var,
+        training,
+        momentum,
+        eps,
+        out0,
+        out1,
+        out2);
+  }
+};
 
-TEST(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTest2D) {
+TEST_F(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTest2D) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
 
   exec_aten::Tensor input = tfFloat.make(
@@ -159,7 +164,7 @@ TEST(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTest2D) {
   EXPECT_TENSOR_CLOSE(out2, out2_expected);
 }
 
-TEST(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTest3D) {
+TEST_F(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTest3D) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
 
   exec_aten::Tensor input = tfFloat.make(
@@ -319,7 +324,7 @@ TEST(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTest3D) {
   EXPECT_TENSOR_CLOSE(out2, out2_expected);
 }
 
-TEST(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTest4D) {
+TEST_F(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTest4D) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
 
   exec_aten::Tensor input = tfFloat.make(
@@ -509,7 +514,7 @@ TEST(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTest4D) {
   EXPECT_TENSOR_CLOSE(out2, out2_expected);
 }
 
-TEST(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTestDouble) {
+TEST_F(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTestDouble) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Double>
       tfDouble;
 
@@ -638,7 +643,7 @@ TEST(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTestDouble) {
   EXPECT_TENSOR_CLOSE(out2, out2_expected);
 }
 
-TEST(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTestNoWeight) {
+TEST_F(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTestNoWeight) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
 
   exec_aten::Tensor input = tfFloat.make(
@@ -789,7 +794,9 @@ TEST(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTestNoWeight) {
   EXPECT_TENSOR_CLOSE(out2, out2_expected);
 }
 
-TEST(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTestNoWeightNoBias) {
+TEST_F(
+    OpNativeBatchNormLegitNoTrainingOutTest,
+    SampleAtomicTestNoWeightNoBias) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
 
   exec_aten::Tensor input = tfFloat.make(
@@ -855,7 +862,7 @@ TEST(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTestNoWeightNoBias) {
   EXPECT_TENSOR_CLOSE(out2, out2_expected);
 }
 
-TEST(OpNativeBatchNormLegitOutTest, SampleAtomicTest2D) {
+TEST_F(OpNativeBatchNormLegitOutTest, SampleAtomicTest2D) {
   torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
 
   exec_aten::Tensor input = tfFloat.make(

--- a/kernels/test/op_native_layer_norm_test.cpp
+++ b/kernels/test/op_native_layer_norm_test.cpp
@@ -32,19 +32,351 @@ using torch::executor::testing::TensorFactory;
 
 using OptScalar = exec_aten::optional<Scalar>;
 
-::std::tuple<Tensor&, Tensor&, Tensor&> op_native_layer_norm_out(
-    const Tensor& input,
-    IntArrayRef normalized_shape,
-    const optional<Tensor>& weight,
-    const optional<Tensor>& bias,
-    double eps,
-    Tensor& out0,
-    Tensor& out1,
-    Tensor& out2) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::native_layer_norm_outf(
-      context, input, normalized_shape, weight, bias, eps, out0, out1, out2);
-}
+class OpNativeLayerNormTest : public OperatorTest {
+ protected:
+  ::std::tuple<Tensor&, Tensor&, Tensor&> op_native_layer_norm_out(
+      const Tensor& input,
+      IntArrayRef normalized_shape,
+      const optional<Tensor>& weight,
+      const optional<Tensor>& bias,
+      double eps,
+      Tensor& out0,
+      Tensor& out1,
+      Tensor& out2) {
+    return torch::executor::aten::native_layer_norm_outf(
+        context_, input, normalized_shape, weight, bias, eps, out0, out1, out2);
+  }
+
+  template <ScalarType DTYPE>
+  struct NativeLayerNormTestCase {
+    using ctype = typename TensorFactory<DTYPE>::ctype;
+
+    // Human-readable, unique title for the test case. Printed if the test
+    // fails.
+    const std::string title;
+    // Size vector for the input/output
+    const std::vector<int32_t> sizes;
+    // Data for the input tensor; must agree with `sizes`.
+    const std::vector<ctype> input_data;
+    // The normalized shape. Only the last dim is accepted.
+    const std::vector<int32_t> normalized_shape;
+    // Affine transform weight.
+    const std::vector<ctype> weight_data;
+    // Affine transform bias.
+    const std::vector<ctype> bias_data;
+    // a value added to the denominator for numerical stability
+    const ctype eps;
+    // The expected output data.
+    const std::vector<ctype> expected_data;
+  };
+
+  /// Runs the provided test cases.
+  template <ScalarType DTYPE>
+  void run_test_cases(std::vector<NativeLayerNormTestCase<DTYPE>> test_cases) {
+    TensorFactory<DTYPE> tf;
+    for (const auto& test_case : test_cases) {
+      SCOPED_TRACE(test_case.title); // Printed if the test fails
+
+      Tensor in = tf.make(test_case.sizes, test_case.input_data);
+      Tensor weight =
+          tf.make(test_case.normalized_shape, test_case.weight_data);
+      Tensor bias = tf.make(test_case.normalized_shape, test_case.bias_data);
+      Tensor out0 = tf.zeros(test_case.sizes);
+      Tensor out1 = tf.zeros(
+          test_case.sizes, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
+      Tensor out2 = tf.zeros(
+          test_case.sizes, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
+      auto normalized_shape_vec = std::vector<int64_t>(
+          test_case.normalized_shape.begin(), test_case.normalized_shape.end());
+      auto normalized_shape = exec_aten::ArrayRef<int64_t>(
+          normalized_shape_vec.data(), normalized_shape_vec.size());
+      auto result = op_native_layer_norm_out(
+          in, normalized_shape, weight, bias, test_case.eps, out0, out1, out2);
+      EXPECT_TENSOR_CLOSE(out0, std::get<0>(result));
+
+      Tensor expected = tf.make(test_case.sizes, test_case.expected_data);
+      EXPECT_TENSOR_CLOSE(out0, expected);
+    }
+  }
+
+  // Test cases that are compatible with float and double.
+  template <ScalarType DTYPE>
+  void run_floating_point_test_cases() {
+    constexpr auto kInfinity =
+        std::numeric_limits<typename TensorFactory<DTYPE>::ctype>::infinity();
+    // Reference colab note:
+    // https://colab.research.google.com/drive/1KZT6sEY-h7lwZlwBanbLl77M5OuzzsZI#scrollTo=18WtUPCXYCPx
+    std::vector<NativeLayerNormTestCase<DTYPE>> test_cases = {
+        {
+            std::string(__func__) + ": Simple negative/positive layer norm",
+            {2, 3}, // sizes
+            {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
+            {3}, // normalized shape
+            {1.0, 1.0, 1.0}, // weights
+            {0.0, 0.0, 0.0}, // bias
+            1.0e-5, // eps
+            {1.22474,
+             0.0000,
+             -1.22474,
+             -0.925819,
+             1.38873,
+             -0.46291}, // expected_data
+        },
+        {
+            std::string(__func__) + ": non-default eps",
+            {2, 3}, // sizes
+            {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
+            {3}, // normalized shape
+            {1.0, 1.0, 1.0}, // weights
+            {0.0, 0.0, 0.0}, // bias
+            1.0e-3, // eps
+            {1.22383,
+             0,
+             -1.22383,
+             -0.925721,
+             1.38858,
+             -0.46286}, // expected_data
+        },
+        {
+            std::string(__func__) + ": non-default weights",
+            {2, 3}, // sizes
+            {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
+            {3}, // normalized shape
+            {2.0, 2.0, 2.0}, // weights
+            {0.0, 0.0, 0.0}, // bias
+            1.0e-5, // eps
+            {2.44947,
+             0,
+             -2.44947,
+             -1.85164,
+             2.77746,
+             -0.925819}, // expected_data
+        },
+        {
+            std::string(__func__) + ": non-default bias",
+            {2, 3}, // sizes
+            {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
+            {3}, // normalized shape
+            {1.0, 1.0, 1.0}, // weights
+            {1.0, 1.0, 1.0}, // bias
+            1.0e-5, // eps
+            {2.22474,
+             1,
+             -0.224736,
+             0.0741809,
+             2.38873,
+             0.53709}, // expected_data
+        },
+        {
+            std::string(__func__) + ": infinite input brings NAN results",
+            {2, 3}, // sizes
+            {kInfinity, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
+            {3}, // normalized shape
+            {1.0, 1.0, 1.0}, // weights
+            {1.0, 1.0, 1.0}, // bias
+            1.0e-5, // eps
+            {-NAN, -NAN, -NAN, 0.0741809, 2.38873, 0.53709}, // expected_data
+        },
+        {
+            std::string(__func__) + ": NAN input brings NAN results",
+            {2, 3}, // sizes
+            {NAN, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
+            {3}, // normalized shape
+            {1.0, 1.0, 1.0}, // weights
+            {1.0, 1.0, 1.0}, // bias
+            1.0e-5, // eps
+            {-NAN, -NAN, -NAN, 0.0741809, 2.38873, 0.53709}, // expected_data
+        },
+        {
+            std::string(__func__) + ": NAN weight brings NAN results",
+            {2, 3}, // sizes
+            {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
+            {3}, // normalized shape
+            {NAN, 1.0, 1.0}, // weights
+            {1.0, 1.0, 1.0}, // bias
+            1.0e-5, // eps
+            {NAN, 1, -0.224736, NAN, 2.38873, 0.53709}, // expected_data
+        },
+        {
+            std::string(__func__) + ": inf weight brings inf results",
+            {2, 3}, // sizes
+            {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
+            {3}, // normalized shape
+            {kInfinity, 1.0, 1.0}, // weights
+            {0.0, 0.0, 0.0}, // bias
+            1.0e-5, // eps
+            {kInfinity,
+             0,
+             -1.22474,
+             -kInfinity,
+             1.38873,
+             -0.46291}, // expected_data
+        },
+        {
+            std::string(__func__) + ": inf bias brings inf results",
+            {2, 3}, // sizes
+            {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
+            {3}, // normalized shape
+            {kInfinity, 1.0, 1.0}, // weights
+            {0.0, 0.0, 0.0}, // bias
+            1.0e-5, // eps
+            {kInfinity,
+             0,
+             -1.22474,
+             -kInfinity,
+             1.38873,
+             -0.46291}, // expected_data
+        },
+    };
+
+    run_test_cases(test_cases);
+  }
+
+  // Runs death test cases.
+  template <ScalarType DTYPE>
+  void run_death_test_cases(
+      std::vector<NativeLayerNormTestCase<DTYPE>> test_cases) {
+    TensorFactory<DTYPE> tf;
+    for (const auto& test_case : test_cases) {
+      SCOPED_TRACE(test_case.title); // Printed if the test fails
+
+      Tensor in = tf.make(test_case.sizes, test_case.input_data);
+      exec_aten::optional<Tensor> weight, bias;
+      if (!test_case.weight_data.empty()) {
+        weight = tf.make(test_case.normalized_shape, test_case.weight_data);
+      }
+      if (!test_case.bias_data.empty()) {
+        bias = tf.make(test_case.normalized_shape, test_case.bias_data);
+      }
+      Tensor out0 = tf.zeros(test_case.sizes);
+      Tensor out1 = tf.zeros(test_case.sizes);
+      Tensor out2 = tf.zeros(test_case.sizes);
+      auto normalized_shape_vec = std::vector<int64_t>(
+          test_case.normalized_shape.begin(), test_case.normalized_shape.end());
+      auto normalized_shape = exec_aten::ArrayRef<int64_t>(
+          normalized_shape_vec.data(), normalized_shape_vec.size());
+      ET_EXPECT_KERNEL_FAILURE(
+          context_,
+          op_native_layer_norm_out(
+              in,
+              normalized_shape,
+              weight,
+              bias,
+              test_case.eps,
+              out0,
+              out1,
+              out2));
+    }
+  }
+
+  // Test cases with imcompatible types.
+  template <ScalarType DTYPE>
+  void run_int_test_cases() {
+    std::vector<NativeLayerNormTestCase<DTYPE>> test_cases = {
+        {
+            std::string(__func__) + ": Simple negative/positive layer norm",
+            // Cannot be represented by a type other than float.
+            {2, 3}, // sizes
+            {1, 0, -1, -1, 4, 0}, // input_data
+            {3}, // normalized shape
+            {1, 1, 1}, // weights
+            {0, 0, 0}, // bias
+            1, // eps
+            {0, 0, 0, 0, 0, 0}, // expected_data
+        },
+    };
+    run_death_test_cases(test_cases);
+  }
+
+  // Test cases with wrong normalized shape.
+  template <ScalarType DTYPE>
+  void run_wrong_shape_test_cases() {
+    std::vector<NativeLayerNormTestCase<DTYPE>> test_cases = {
+        {
+            std::string(__func__) + ": Test with wrong normalized shape",
+            {2, 3}, // sizes
+            {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
+            {1}, // wrong normalized shape
+            {1.0}, // weights
+            {0.0}, // bias
+            1.0e-5, // eps
+            {1.22474,
+             0.0000,
+             -1.22474,
+             -0.925819,
+             1.38873,
+             -0.46291}, // expected_data
+        },
+    };
+    run_death_test_cases(test_cases);
+  }
+
+  /* %python
+  import torch
+  torch.manual_seed(0)
+
+  input = torch.rand(2, 3)
+  normalized_shape = [3]
+  weight = torch.tensor([1.0, 1.0, 1.0])
+  bias = torch.tensor([0.0, 0.0, 0.0])
+  eps = 1e-05
+  expected = torch.nn.functional.layer_norm(
+    input, normalized_shape, weight=weight, bias=bias, eps=eps)
+
+  native_layer_norm_template = f"""
+    {declare_tensor_factory("ScalarType::Float", "tf")}
+
+    {declare_tensor_make_t("input", "tf")}
+    {declare_optional_tensor_make_t("weight", "tf")}
+    {declare_optional_tensor_make_t("bias", "tf")}
+    {declare_tensor_make_t("expected", "tf")}
+    {declare_tensor_zeros("out_shape, dynamism", "tf", "out0")}
+    {declare_tensor_zeros("out_shape, dynamism", "tf", "out1")}
+    {declare_tensor_zeros("out_shape, dynamism", "tf", "out2")}
+
+    int64_t normalized_shape[] = $normalized_shape$;
+
+    op_native_layer_norm_out(
+      input, normalized_shape, weight, bias, $eps$, out0, out1, out2);
+    EXPECT_TENSOR_CLOSE(out0, expected);""" */
+  void test_dynamic_shape(
+      const std::vector<int32_t>& out_shape,
+      enum torch::executor::TensorShapeDynamism dynamism) {
+    /* %python
+    %rewrite(native_layer_norm_template) */
+
+    TensorFactory<ScalarType::Float> tf;
+
+    Tensor input = tf.make(
+        {2, 3},
+        {0.49625658988952637,
+         0.7682217955589294,
+         0.08847743272781372,
+         0.13203048706054688,
+         0.30742281675338745,
+         0.6340786814689636});
+    optional<Tensor> weight(tf.make({3}, {1.0, 1.0, 1.0}));
+    optional<Tensor> bias(tf.make({3}, {0.0, 0.0, 0.0}));
+    Tensor expected = tf.make(
+        {2, 3},
+        {0.16205203533172607,
+         1.1355723142623901,
+         -1.2976245880126953,
+         -1.0853172540664673,
+         -0.24233698844909668,
+         1.3276543617248535});
+    Tensor out0 = tf.zeros(out_shape, dynamism);
+    Tensor out1 = tf.zeros(out_shape, dynamism);
+    Tensor out2 = tf.zeros(out_shape, dynamism);
+
+    int64_t normalized_shape[] = {3};
+
+    op_native_layer_norm_out(
+        input, normalized_shape, weight, bias, 1e-05, out0, out1, out2);
+    EXPECT_TENSOR_CLOSE(out0, expected);
+  }
+};
+
 namespace {
 std::vector<int64_t> vector_32_to_64(std::vector<int32_t> vector_32) {
   std::vector<int64_t> vector_64(vector_32.size());
@@ -58,336 +390,32 @@ std::vector<int64_t> vector_32_to_64(std::vector<int32_t> vector_32) {
 } // namespace
 
 /// Describes a test case, using tensors of the specified DTYPE.
-template <ScalarType DTYPE>
-struct NativeLayerNormTestCase {
-  using ctype = typename TensorFactory<DTYPE>::ctype;
-
-  // Human-readable, unique title for the test case. Printed if the test fails.
-  const std::string title;
-  // Size vector for the input/output
-  const std::vector<int32_t> sizes;
-  // Data for the input tensor; must agree with `sizes`.
-  const std::vector<ctype> input_data;
-  // The normalized shape. Only the last dim is accepted.
-  const std::vector<int32_t> normalized_shape;
-  // Affine transform weight.
-  const std::vector<ctype> weight_data;
-  // Affine transform bias.
-  const std::vector<ctype> bias_data;
-  // a value added to the denominator for numerical stability
-  const ctype eps;
-  // The expected output data.
-  const std::vector<ctype> expected_data;
-};
-
-/// Runs the provided test cases.
-template <ScalarType DTYPE>
-void run_test_cases(std::vector<NativeLayerNormTestCase<DTYPE>> test_cases) {
-  TensorFactory<DTYPE> tf;
-  for (const auto& test_case : test_cases) {
-    SCOPED_TRACE(test_case.title); // Printed if the test fails
-
-    Tensor in = tf.make(test_case.sizes, test_case.input_data);
-    Tensor weight = tf.make(test_case.normalized_shape, test_case.weight_data);
-    Tensor bias = tf.make(test_case.normalized_shape, test_case.bias_data);
-    Tensor out0 = tf.zeros(test_case.sizes);
-    Tensor out1 = tf.zeros(
-        test_case.sizes, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
-    Tensor out2 = tf.zeros(
-        test_case.sizes, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
-    auto normalized_shape_vec = std::vector<int64_t>(
-        test_case.normalized_shape.begin(), test_case.normalized_shape.end());
-    auto normalized_shape = exec_aten::ArrayRef<int64_t>(
-        normalized_shape_vec.data(), normalized_shape_vec.size());
-    auto result = op_native_layer_norm_out(
-        in, normalized_shape, weight, bias, test_case.eps, out0, out1, out2);
-    EXPECT_TENSOR_CLOSE(out0, std::get<0>(result));
-
-    Tensor expected = tf.make(test_case.sizes, test_case.expected_data);
-    EXPECT_TENSOR_CLOSE(out0, expected);
-  }
-}
-
-// Test cases that are compatible with float and double.
-template <ScalarType DTYPE>
-void run_floating_point_test_cases() {
-  constexpr auto kInfinity =
-      std::numeric_limits<typename TensorFactory<DTYPE>::ctype>::infinity();
-  // Reference colab note:
-  // https://colab.research.google.com/drive/1KZT6sEY-h7lwZlwBanbLl77M5OuzzsZI#scrollTo=18WtUPCXYCPx
-  std::vector<NativeLayerNormTestCase<DTYPE>> test_cases = {
-      {
-          std::string(__func__) + ": Simple negative/positive layer norm",
-          {2, 3}, // sizes
-          {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
-          {3}, // normalized shape
-          {1.0, 1.0, 1.0}, // weights
-          {0.0, 0.0, 0.0}, // bias
-          1.0e-5, // eps
-          {1.22474,
-           0.0000,
-           -1.22474,
-           -0.925819,
-           1.38873,
-           -0.46291}, // expected_data
-      },
-      {
-          std::string(__func__) + ": non-default eps",
-          {2, 3}, // sizes
-          {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
-          {3}, // normalized shape
-          {1.0, 1.0, 1.0}, // weights
-          {0.0, 0.0, 0.0}, // bias
-          1.0e-3, // eps
-          {1.22383, 0, -1.22383, -0.925721, 1.38858, -0.46286}, // expected_data
-      },
-      {
-          std::string(__func__) + ": non-default weights",
-          {2, 3}, // sizes
-          {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
-          {3}, // normalized shape
-          {2.0, 2.0, 2.0}, // weights
-          {0.0, 0.0, 0.0}, // bias
-          1.0e-5, // eps
-          {2.44947, 0, -2.44947, -1.85164, 2.77746, -0.925819}, // expected_data
-      },
-      {
-          std::string(__func__) + ": non-default bias",
-          {2, 3}, // sizes
-          {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
-          {3}, // normalized shape
-          {1.0, 1.0, 1.0}, // weights
-          {1.0, 1.0, 1.0}, // bias
-          1.0e-5, // eps
-          {2.22474, 1, -0.224736, 0.0741809, 2.38873, 0.53709}, // expected_data
-      },
-      {
-          std::string(__func__) + ": infinite input brings NAN results",
-          {2, 3}, // sizes
-          {kInfinity, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
-          {3}, // normalized shape
-          {1.0, 1.0, 1.0}, // weights
-          {1.0, 1.0, 1.0}, // bias
-          1.0e-5, // eps
-          {-NAN, -NAN, -NAN, 0.0741809, 2.38873, 0.53709}, // expected_data
-      },
-      {
-          std::string(__func__) + ": NAN input brings NAN results",
-          {2, 3}, // sizes
-          {NAN, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
-          {3}, // normalized shape
-          {1.0, 1.0, 1.0}, // weights
-          {1.0, 1.0, 1.0}, // bias
-          1.0e-5, // eps
-          {-NAN, -NAN, -NAN, 0.0741809, 2.38873, 0.53709}, // expected_data
-      },
-      {
-          std::string(__func__) + ": NAN weight brings NAN results",
-          {2, 3}, // sizes
-          {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
-          {3}, // normalized shape
-          {NAN, 1.0, 1.0}, // weights
-          {1.0, 1.0, 1.0}, // bias
-          1.0e-5, // eps
-          {NAN, 1, -0.224736, NAN, 2.38873, 0.53709}, // expected_data
-      },
-      {
-          std::string(__func__) + ": inf weight brings inf results",
-          {2, 3}, // sizes
-          {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
-          {3}, // normalized shape
-          {kInfinity, 1.0, 1.0}, // weights
-          {0.0, 0.0, 0.0}, // bias
-          1.0e-5, // eps
-          {kInfinity,
-           0,
-           -1.22474,
-           -kInfinity,
-           1.38873,
-           -0.46291}, // expected_data
-      },
-      {
-          std::string(__func__) + ": inf bias brings inf results",
-          {2, 3}, // sizes
-          {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
-          {3}, // normalized shape
-          {kInfinity, 1.0, 1.0}, // weights
-          {0.0, 0.0, 0.0}, // bias
-          1.0e-5, // eps
-          {kInfinity,
-           0,
-           -1.22474,
-           -kInfinity,
-           1.38873,
-           -0.46291}, // expected_data
-      },
-  };
-
-  run_test_cases(test_cases);
-}
-
-/// Runs death test cases.
-template <ScalarType DTYPE>
-void run_death_test_cases(
-    std::vector<NativeLayerNormTestCase<DTYPE>> test_cases) {
-  TensorFactory<DTYPE> tf;
-  for (const auto& test_case : test_cases) {
-    SCOPED_TRACE(test_case.title); // Printed if the test fails
-
-    Tensor in = tf.make(test_case.sizes, test_case.input_data);
-    exec_aten::optional<Tensor> weight, bias;
-    if (!test_case.weight_data.empty()) {
-      weight = tf.make(test_case.normalized_shape, test_case.weight_data);
-    }
-    if (!test_case.bias_data.empty()) {
-      bias = tf.make(test_case.normalized_shape, test_case.bias_data);
-    }
-    Tensor out0 = tf.zeros(test_case.sizes);
-    Tensor out1 = tf.zeros(test_case.sizes);
-    Tensor out2 = tf.zeros(test_case.sizes);
-    auto normalized_shape_vec = std::vector<int64_t>(
-        test_case.normalized_shape.begin(), test_case.normalized_shape.end());
-    auto normalized_shape = exec_aten::ArrayRef<int64_t>(
-        normalized_shape_vec.data(), normalized_shape_vec.size());
-    ET_EXPECT_KERNEL_FAILURE(op_native_layer_norm_out(
-        in, normalized_shape, weight, bias, test_case.eps, out0, out1, out2));
-  }
-}
-
-// Test cases with imcompatible types.
-template <ScalarType DTYPE>
-void run_int_test_cases() {
-  std::vector<NativeLayerNormTestCase<DTYPE>> test_cases = {
-      {
-          std::string(__func__) + ": Simple negative/positive layer norm",
-          // Cannot be represented by a type other than float.
-          {2, 3}, // sizes
-          {1, 0, -1, -1, 4, 0}, // input_data
-          {3}, // normalized shape
-          {1, 1, 1}, // weights
-          {0, 0, 0}, // bias
-          1, // eps
-          {0, 0, 0, 0, 0, 0}, // expected_data
-      },
-  };
-  run_death_test_cases(test_cases);
-}
-
-// Test cases with wrong normalized shape.
-template <ScalarType DTYPE>
-void run_wrong_shape_test_cases() {
-  std::vector<NativeLayerNormTestCase<DTYPE>> test_cases = {
-      {
-          std::string(__func__) + ": Test with wrong normalized shape",
-          {2, 3}, // sizes
-          {1.0, 0.0, -1.0, -1.0, 4.0, 0.0}, // input_data
-          {1}, // wrong normalized shape
-          {1.0}, // weights
-          {0.0}, // bias
-          1.0e-5, // eps
-          {1.22474,
-           0.0000,
-           -1.22474,
-           -0.925819,
-           1.38873,
-           -0.46291}, // expected_data
-      },
-  };
-  run_death_test_cases(test_cases);
-}
-
-TEST(OpNativeLayerNormTest, FloatTensors) {
+TEST_F(OpNativeLayerNormTest, FloatTensors) {
   run_floating_point_test_cases<ScalarType::Float>();
   run_floating_point_test_cases<ScalarType::Double>();
 }
 
-TEST(OpNativeLayerNormTest, IntTensorsDies) {
+TEST_F(OpNativeLayerNormTest, IntTensorsDies) {
   // Cannot be represented by a type other than float.
   run_int_test_cases<ScalarType::Int>();
 }
 
-TEST(OpNativeLayerNormTest, WrongNomalizedShape) {
+TEST_F(OpNativeLayerNormTest, WrongNomalizedShape) {
   // Normalized shape does not match last dim of input.
   run_wrong_shape_test_cases<ScalarType::Float>();
 }
 
-/* %python
-import torch
-torch.manual_seed(0)
-
-input = torch.rand(2, 3)
-normalized_shape = [3]
-weight = torch.tensor([1.0, 1.0, 1.0])
-bias = torch.tensor([0.0, 0.0, 0.0])
-eps = 1e-05
-expected = torch.nn.functional.layer_norm(
-  input, normalized_shape, weight=weight, bias=bias, eps=eps)
-
-native_layer_norm_template = f"""
-  {declare_tensor_factory("ScalarType::Float", "tf")}
-
-  {declare_tensor_make_t("input", "tf")}
-  {declare_optional_tensor_make_t("weight", "tf")}
-  {declare_optional_tensor_make_t("bias", "tf")}
-  {declare_tensor_make_t("expected", "tf")}
-  {declare_tensor_zeros("out_shape, dynamism", "tf", "out0")}
-  {declare_tensor_zeros("out_shape, dynamism", "tf", "out1")}
-  {declare_tensor_zeros("out_shape, dynamism", "tf", "out2")}
-
-  int64_t normalized_shape[] = $normalized_shape$;
-
-  op_native_layer_norm_out(
-    input, normalized_shape, weight, bias, $eps$, out0, out1, out2);
-  EXPECT_TENSOR_CLOSE(out0, expected);""" */
-
-void test_dynamic_shape(
-    const std::vector<int32_t>& out_shape,
-    enum torch::executor::TensorShapeDynamism dynamism) {
-  /* %python
-  %rewrite(native_layer_norm_template) */
-
-  TensorFactory<ScalarType::Float> tf;
-
-  Tensor input = tf.make(
-      {2, 3},
-      {0.49625658988952637,
-       0.7682217955589294,
-       0.08847743272781372,
-       0.13203048706054688,
-       0.30742281675338745,
-       0.6340786814689636});
-  optional<Tensor> weight(tf.make({3}, {1.0, 1.0, 1.0}));
-  optional<Tensor> bias(tf.make({3}, {0.0, 0.0, 0.0}));
-  Tensor expected = tf.make(
-      {2, 3},
-      {0.16205203533172607,
-       1.1355723142623901,
-       -1.2976245880126953,
-       -1.0853172540664673,
-       -0.24233698844909668,
-       1.3276543617248535});
-  Tensor out0 = tf.zeros(out_shape, dynamism);
-  Tensor out1 = tf.zeros(out_shape, dynamism);
-  Tensor out2 = tf.zeros(out_shape, dynamism);
-
-  int64_t normalized_shape[] = {3};
-
-  op_native_layer_norm_out(
-      input, normalized_shape, weight, bias, 1e-05, out0, out1, out2);
-  EXPECT_TENSOR_CLOSE(out0, expected);
-}
-
-TEST(OpNativeLayerNormTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpNativeLayerNormTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(
       {2, 3}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpNativeLayerNormTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpNativeLayerNormTest, DynamicShapeUpperBoundLargerThanExpected) {
   test_dynamic_shape(
       {10, 10}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 }
 
-TEST(OpNativeLayerNormTest, DynamicShapeUnbound) {
+TEST_F(OpNativeLayerNormTest, DynamicShapeUnbound) {
   if (!torch::executor::testing::SupportedFeatures::get()->output_resize) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }

--- a/kernels/test/op_ne_test.cpp
+++ b/kernels/test/op_ne_test.cpp
@@ -21,40 +21,73 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_ne_scalar_out(const Tensor& self, Scalar& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::ne_outf(context, self, other, out);
-}
+class OpNeTest : public OperatorTest {
+ protected:
+  Tensor& op_ne_tensor_out(const Tensor& self, Tensor& other, Tensor& out) {
+    return torch::executor::aten::ne_outf(context_, self, other, out);
+  }
 
-Tensor& op_ne_tensor_out(const Tensor& self, Tensor& other, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::ne_outf(context, self, other, out);
-}
+  template <class CTYPE, ScalarType DTYPE>
+  void test_dtype() {
+    TensorFactory<DTYPE> tf_input;
+    TensorFactory<ScalarType::Bool> tf_bool;
+    Tensor a = tf_input.make(/*sizes=*/{2, 2}, /*data=*/{2, 3, 2, 4});
+    Tensor b = tf_input.make({2, 2}, {2, 2, 2, 2});
+    Tensor out = tf_bool.zeros({2, 2});
+    RuntimeContext context{};
 
-// Common testing for ne operator
-template <ScalarType DTYPE>
-void test_ne_scalar_out() {
-  TensorFactory<DTYPE> tf;
-  TensorFactory<ScalarType::Bool> tf_out;
+    torch::executor::aten::ne_outf(context, a, b, out);
+    EXPECT_TENSOR_EQ(out, tf_bool.make({2, 2}, {false, true, false, true}));
+  }
+};
 
-  const std::vector<int32_t> sizes = {2, 2};
-  // Destination for the ne
-  Tensor out = tf_out.ones(sizes);
-  Scalar other = 2;
+class OpNeScalarOutTest : public OperatorTest {
+ protected:
+  Tensor& op_ne_scalar_out(const Tensor& self, Scalar& other, Tensor& out) {
+    return torch::executor::aten::ne_outf(context_, self, other, out);
+  }
 
-  // Valid input should give the expected output
-  op_ne_scalar_out(tf.make(sizes, /*data=*/{2, 3, 2, 3}), other, out);
-  EXPECT_TENSOR_EQ(
-      out, tf_out.make(sizes, /*data=*/{false, true, false, true}));
-}
+  // Common testing for ne operator
+  template <ScalarType DTYPE>
+  void test_ne_scalar_out() {
+    TensorFactory<DTYPE> tf;
+    TensorFactory<ScalarType::Bool> tf_out;
 
-TEST(OpNeScalarOutKernelTest, AllRealInputBoolOutputSupport) {
+    const std::vector<int32_t> sizes = {2, 2};
+    // Destination for the ne
+    Tensor out = tf_out.ones(sizes);
+    Scalar other = 2;
+
+    // Valid input should give the expected output
+    op_ne_scalar_out(tf.make(sizes, /*data=*/{2, 3, 2, 3}), other, out);
+    EXPECT_TENSOR_EQ(
+        out, tf_out.make(sizes, /*data=*/{false, true, false, true}));
+  }
+
+  // Handle all output dtypes.
+  template <ScalarType OUTPUT_DTYPE>
+  void test_ne_all_output_dtypes() {
+    TensorFactory<ScalarType::Float> tf_float;
+    TensorFactory<OUTPUT_DTYPE> tf_out;
+
+    const std::vector<int32_t> sizes = {2, 5};
+
+    Tensor in = tf_float.ones(sizes);
+    Tensor out = tf_out.zeros(sizes);
+    Scalar other = 3;
+
+    op_ne_scalar_out(in, other, out);
+    EXPECT_TENSOR_EQ(out, tf_out.ones(sizes));
+  }
+};
+
+TEST_F(OpNeScalarOutTest, AllRealInputBoolOutputSupport) {
 #define TEST_ENTRY(ctype, dtype) test_ne_scalar_out<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-TEST(OpNeScalarOutKernelTest, BoolInputDtype) {
+TEST_F(OpNeScalarOutTest, BoolInputDtype) {
   TensorFactory<ScalarType::Bool> tf_bool;
 
   const std::vector<int32_t> sizes = {2, 2};
@@ -68,7 +101,7 @@ TEST(OpNeScalarOutKernelTest, BoolInputDtype) {
 }
 
 // Mismatched shape tests.
-TEST(OpNeScalarOutKernelTest, MismatchedShapesDies) {
+TEST_F(OpNeScalarOutTest, MismatchedShapesDies) {
   if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
     GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
   }
@@ -79,45 +112,16 @@ TEST(OpNeScalarOutKernelTest, MismatchedShapesDies) {
   Tensor out = tf_bool.ones(/*sizes=*/{2, 2});
   Scalar other = 3;
 
-  ET_EXPECT_KERNEL_FAILURE(op_ne_scalar_out(a, other, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_ne_scalar_out(a, other, out));
 }
 
-// Handle all output dtypes.
-template <ScalarType OUTPUT_DTYPE>
-void test_ne_all_output_dtypes() {
-  TensorFactory<ScalarType::Float> tf_float;
-  TensorFactory<OUTPUT_DTYPE> tf_out;
-
-  const std::vector<int32_t> sizes = {2, 5};
-
-  Tensor in = tf_float.ones(sizes);
-  Tensor out = tf_out.zeros(sizes);
-  Scalar other = 3;
-
-  op_ne_scalar_out(in, other, out);
-  EXPECT_TENSOR_EQ(out, tf_out.ones(sizes));
-}
-
-TEST(OpNeScalarOutKernelTest, AllRealOutputDTypesSupported) {
+TEST_F(OpNeScalarOutTest, AllRealOutputDTypesSupported) {
 #define TEST_ENTRY(ctype, dtype) test_ne_all_output_dtypes<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
-template <class CTYPE, ScalarType DTYPE>
-void test_dtype() {
-  TensorFactory<DTYPE> tf_input;
-  TensorFactory<ScalarType::Bool> tf_bool;
-  Tensor a = tf_input.make(/*sizes=*/{2, 2}, /*data=*/{2, 3, 2, 4});
-  Tensor b = tf_input.make({2, 2}, {2, 2, 2, 2});
-  Tensor out = tf_bool.zeros({2, 2});
-  RuntimeContext context{};
-
-  torch::executor::aten::ne_outf(context, a, b, out);
-  EXPECT_TENSOR_EQ(out, tf_bool.make({2, 2}, {false, true, false, true}));
-}
-
-TEST(OpNeTest, AllDtypesSupported) {
+TEST_F(OpNeTest, AllDtypesSupported) {
 #define TEST_ENTRY(ctype, dtype) test_dtype<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
@@ -137,7 +141,7 @@ dtype = "ScalarType::Int"
 out_dtype = "ScalarType::Bool"
 check = "EXPECT_TENSOR_EQ" */
 
-TEST(OpNeScalarOutKernelTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpNeScalarOutTest, DynamicShapeUpperBoundSameAsExpected) {
   /* %python
   out_args = "{3, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND"
   %rewrite(unary_op_out_dtype) */
@@ -156,7 +160,7 @@ TEST(OpNeScalarOutKernelTest, DynamicShapeUpperBoundSameAsExpected) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpNeScalarOutKernelTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpNeScalarOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   /* %python
   out_args = "{10, 10}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND"
   %rewrite(unary_op_out_dtype) */
@@ -175,7 +179,7 @@ TEST(OpNeScalarOutKernelTest, DynamicShapeUpperBoundLargerThanExpected) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpNeScalarOutKernelTest, DynamicShapeUnbound) {
+TEST_F(OpNeScalarOutTest, DynamicShapeUnbound) {
   if (!torch::executor::testing::SupportedFeatures::get()->output_resize) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }

--- a/kernels/test/op_neg_test.cpp
+++ b/kernels/test/op_neg_test.cpp
@@ -19,12 +19,14 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_neg_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::neg_outf(context, self, out);
-}
+class OpNegTest : public OperatorTest {
+ protected:
+  Tensor& op_neg_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::neg_outf(context_, self, out);
+  }
+};
 
-TEST(OpNegTest, SanityCheck) {
+TEST_F(OpNegTest, SanityCheck) {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor in = tf.make({1, 7}, {-3.0, -2.5, -1.01, 0.0, 1.01, 2.5, 3.0});

--- a/kernels/test/op_nonzero_test.cpp
+++ b/kernels/test/op_nonzero_test.cpp
@@ -18,37 +18,39 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_nonzero_out(const Tensor& self, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::nonzero_outf(context, self, out);
-}
+class OpNonzeroTest : public OperatorTest {
+ protected:
+  Tensor& op_nonzero_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::nonzero_outf(context_, self, out);
+  }
 
-template <class CTYPE, exec_aten::ScalarType DTYPE>
-void test_dtype() {
-  TensorFactory<DTYPE> tf_input;
-  TensorFactory<ScalarType::Long> tf_long;
-  // clang-format off
-  Tensor a = tf_input.make(/*sizes=*/{2, 2}, /*data=*/{2, 0,
-                                                       2, 4});
-  // clang-format on
-  Tensor out = tf_long.zeros({3, 2});
+  template <class CTYPE, exec_aten::ScalarType DTYPE>
+  void test_dtype() {
+    TensorFactory<DTYPE> tf_input;
+    TensorFactory<ScalarType::Long> tf_long;
+    // clang-format off
+    Tensor a = tf_input.make(/*sizes=*/{2, 2}, /*data=*/{2, 0,
+                                                         2, 4});
+    // clang-format on
+    Tensor out = tf_long.zeros({3, 2});
 
-  op_nonzero_out(a, out);
-  // clang-format off
-  EXPECT_TENSOR_EQ(out, tf_long.make({3, 2}, {0, 0,
-                                              1, 0,
-                                              1, 1}));
-  // clang-format on
-}
+    op_nonzero_out(a, out);
+    // clang-format off
+    EXPECT_TENSOR_EQ(out, tf_long.make({3, 2}, {0, 0,
+                                                1, 0,
+                                                1, 1}));
+    // clang-format on
+  }
+};
 
-TEST(OpNonzeroTest, AllDtypesSupported) {
+TEST_F(OpNonzeroTest, AllDtypesSupported) {
 #define TEST_ENTRY(ctype, dtype) test_dtype<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
 
 #if !defined(USE_ATEN_LIB)
-TEST(OpNonzeroTest, StaticShapeInconsistentSize) {
+TEST_F(OpNonzeroTest, StaticShapeInconsistentSize) {
   TensorFactory<ScalarType::Float> tf_input;
   TensorFactory<ScalarType::Long> tf_long;
   // clang-format off
@@ -60,10 +62,10 @@ TEST(OpNonzeroTest, StaticShapeInconsistentSize) {
   Tensor out =
       tf_long.zeros({4, 2}, torch::executor::TensorShapeDynamism::STATIC);
 
-  ET_EXPECT_KERNEL_FAILURE(op_nonzero_out(a, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_nonzero_out(a, out));
 }
 
-TEST(OpNonzeroTest, DynamicShape) {
+TEST_F(OpNonzeroTest, DynamicShape) {
   TensorFactory<ScalarType::Float> tf_input;
   TensorFactory<ScalarType::Long> tf_long;
   // clang-format off
@@ -81,7 +83,7 @@ TEST(OpNonzeroTest, DynamicShape) {
   // clang-format on
 }
 
-TEST(OpNonzeroTest, DynamicShapeInsufficientBuffer) {
+TEST_F(OpNonzeroTest, DynamicShapeInsufficientBuffer) {
   TensorFactory<ScalarType::Float> tf_input;
   TensorFactory<ScalarType::Long> tf_long;
   // clang-format off
@@ -91,6 +93,6 @@ TEST(OpNonzeroTest, DynamicShapeInsufficientBuffer) {
   Tensor out = tf_long.zeros(
       {2, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
 
-  ET_EXPECT_KERNEL_FAILURE(op_nonzero_out(a, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_nonzero_out(a, out));
 }
 #endif

--- a/kernels/test/op_ones_test.cpp
+++ b/kernels/test/op_ones_test.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
+#include <executorch/kernels/test/TestUtil.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -19,28 +20,30 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_ones_out(IntArrayRef size, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::ones_outf(context, size, out);
-}
+class OpOnesOutTest : public OperatorTest {
+ protected:
+  Tensor& op_ones_out(IntArrayRef size, Tensor& out) {
+    return torch::executor::aten::ones_outf(context_, size, out);
+  }
 
-template <ScalarType DTYPE>
-void test_ones_out(std::vector<int32_t>&& size_int32_t) {
-  TensorFactory<DTYPE> tf;
-  std::vector<int64_t> size_int64_t(size_int32_t.begin(), size_int32_t.end());
-  auto aref = IntArrayRef(size_int64_t.data(), size_int64_t.size());
+  template <ScalarType DTYPE>
+  void test_ones_out(std::vector<int32_t>&& size_int32_t) {
+    TensorFactory<DTYPE> tf;
+    std::vector<int64_t> size_int64_t(size_int32_t.begin(), size_int32_t.end());
+    auto aref = IntArrayRef(size_int64_t.data(), size_int64_t.size());
 
-  // Before: `out` consists of 0s.
-  Tensor out = tf.zeros(size_int32_t);
+    // Before: `out` consists of 0s.
+    Tensor out = tf.zeros(size_int32_t);
 
-  // After: `out` consists of 1s.
-  op_ones_out(aref, out);
+    // After: `out` consists of 1s.
+    op_ones_out(aref, out);
 
-  EXPECT_TENSOR_EQ(out, tf.ones(size_int32_t));
-}
+    EXPECT_TENSOR_EQ(out, tf.ones(size_int32_t));
+  }
+};
 
 #define GENERATE_TEST(_, DTYPE)                  \
-  TEST(OpOnesOutKernelTest, DTYPE##Tensors) {    \
+  TEST_F(OpOnesOutTest, DTYPE##Tensors) {        \
     test_ones_out<ScalarType::DTYPE>({});        \
     test_ones_out<ScalarType::DTYPE>({1});       \
     test_ones_out<ScalarType::DTYPE>({1, 1, 1}); \

--- a/kernels/test/op_permute_copy_test.cpp
+++ b/kernels/test/op_permute_copy_test.cpp
@@ -22,12 +22,15 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor& op_permute_copy_out(const Tensor& self, IntArrayRef dims, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::permute_copy_outf(context, self, dims, out);
-}
+class OpPermuteCopyTest : public OperatorTest {
+ protected:
+  Tensor&
+  op_permute_copy_out(const Tensor& self, IntArrayRef dims, Tensor& out) {
+    return torch::executor::aten::permute_copy_outf(context_, self, dims, out);
+  }
+};
 
-TEST(OpPermuteCopyKernelTest, OneDPermute) {
+TEST_F(OpPermuteCopyTest, OneDPermute) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int64_t> new_dim = {0};
@@ -42,7 +45,7 @@ TEST(OpPermuteCopyKernelTest, OneDPermute) {
   EXPECT_TENSOR_EQ(out, tf.make(sizes, {1, 2}));
 }
 
-TEST(OpPermuteCopyKernelTest, PermuteWithNoDataReorder) {
+TEST_F(OpPermuteCopyTest, PermuteWithNoDataReorder) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int64_t> new_dim = {1, 0, 2};
@@ -69,7 +72,7 @@ TEST(OpPermuteCopyKernelTest, PermuteWithNoDataReorder) {
   // clang-format on
 }
 
-TEST(OpPermuteCopyKernelTest, TwoDPermute) {
+TEST_F(OpPermuteCopyTest, TwoDPermute) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int64_t> new_dim = {1, 0};
@@ -97,7 +100,7 @@ TEST(OpPermuteCopyKernelTest, TwoDPermute) {
   // clang-format on
 }
 
-TEST(OpPermuteCopyKernelTest, ThreeDPermute) {
+TEST_F(OpPermuteCopyTest, ThreeDPermute) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int64_t> new_dim = {2, 0, 1};
@@ -131,7 +134,7 @@ TEST(OpPermuteCopyKernelTest, ThreeDPermute) {
   // clang-format on
 }
 
-TEST(OpPermuteCopyKernelTest, FourDPermute) {
+TEST_F(OpPermuteCopyTest, FourDPermute) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int64_t> new_dim = {0, 3, 2, 1};
@@ -218,7 +221,7 @@ TEST(OpPermuteCopyKernelTest, FourDPermute) {
   // clang-format on
 }
 
-TEST(OpPermuteCopyKernelTest, FiveDPermute) {
+TEST_F(OpPermuteCopyTest, FiveDPermute) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int64_t> new_dim = {4, 3, 2, 1, 0};
@@ -298,7 +301,7 @@ TEST(OpPermuteCopyKernelTest, FiveDPermute) {
   // clang-format on
 }
 
-TEST(OpPermuteCopyKernelTest, AllDimensionsSizeOne) {
+TEST_F(OpPermuteCopyTest, AllDimensionsSizeOne) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int64_t> new_dim = {4, 3, 2, 1, 0};
@@ -313,7 +316,7 @@ TEST(OpPermuteCopyKernelTest, AllDimensionsSizeOne) {
   EXPECT_TENSOR_EQ(out, tf.make(sizes, {1}));
 }
 
-TEST(OpPermuteCopyKernelTest, DupeDimensionPos) {
+TEST_F(OpPermuteCopyTest, DupeDimensionPos) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int64_t> new_dim = {0, 1, 1};
@@ -323,11 +326,13 @@ TEST(OpPermuteCopyKernelTest, DupeDimensionPos) {
 
   Tensor out = tf.zeros(sizes);
 
-  ET_EXPECT_KERNEL_FAILURE(op_permute_copy_out(
-      t_int, ArrayRef<int64_t>(new_dim.data(), new_dim.size()), out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_permute_copy_out(
+          t_int, ArrayRef<int64_t>(new_dim.data(), new_dim.size()), out));
 }
 
-TEST(OpPermuteCopyKernelTest, DupeDimensionPos2) {
+TEST_F(OpPermuteCopyTest, DupeDimensionPos2) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int64_t> new_dim = {1, 1, 1};
@@ -337,11 +342,13 @@ TEST(OpPermuteCopyKernelTest, DupeDimensionPos2) {
 
   Tensor out = tf.zeros(sizes);
 
-  ET_EXPECT_KERNEL_FAILURE(op_permute_copy_out(
-      t_int, ArrayRef<int64_t>(new_dim.data(), new_dim.size()), out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_permute_copy_out(
+          t_int, ArrayRef<int64_t>(new_dim.data(), new_dim.size()), out));
 }
 
-TEST(OpPermuteCopyKernelTest, DupeDimensionNeg) {
+TEST_F(OpPermuteCopyTest, DupeDimensionNeg) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int64_t> new_dim = {0, 1, -2};
@@ -351,11 +358,13 @@ TEST(OpPermuteCopyKernelTest, DupeDimensionNeg) {
 
   Tensor out = tf.zeros(sizes);
 
-  ET_EXPECT_KERNEL_FAILURE(op_permute_copy_out(
-      t_int, ArrayRef<int64_t>(new_dim.data(), new_dim.size()), out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_permute_copy_out(
+          t_int, ArrayRef<int64_t>(new_dim.data(), new_dim.size()), out));
 }
 
-TEST(OpPermuteCopyKernelTest, DupeDimensionNeg2) {
+TEST_F(OpPermuteCopyTest, DupeDimensionNeg2) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int64_t> new_dim = {0, 1, -5};
@@ -365,11 +374,13 @@ TEST(OpPermuteCopyKernelTest, DupeDimensionNeg2) {
 
   Tensor out = tf.zeros(sizes);
 
-  ET_EXPECT_KERNEL_FAILURE(op_permute_copy_out(
-      t_int, ArrayRef<int64_t>(new_dim.data(), new_dim.size()), out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_permute_copy_out(
+          t_int, ArrayRef<int64_t>(new_dim.data(), new_dim.size()), out));
 }
 
-TEST(OpPermuteCopyKernelTest, MismatchDim) {
+TEST_F(OpPermuteCopyTest, MismatchDim) {
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int64_t> new_dim = {0, 1, 2};
@@ -379,8 +390,10 @@ TEST(OpPermuteCopyKernelTest, MismatchDim) {
 
   Tensor out = tf.zeros(sizes);
 
-  ET_EXPECT_KERNEL_FAILURE(op_permute_copy_out(
-      t_int, ArrayRef<int64_t>(new_dim.data(), new_dim.size()), out));
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_permute_copy_out(
+          t_int, ArrayRef<int64_t>(new_dim.data(), new_dim.size()), out));
 }
 
 /* %python
@@ -396,7 +409,7 @@ opt_extra_params = "perm_aref,"
 dtype = "ScalarType::Int"
 check = "EXPECT_TENSOR_EQ" */
 
-TEST(OpPermuteCopyKernelTest, DynamicShapeUpperBoundSameAsExpected) {
+TEST_F(OpPermuteCopyTest, DynamicShapeUpperBoundSameAsExpected) {
   /* %python
   out_args = "{4, 2, 3}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND"
   %rewrite(unary_op) */
@@ -417,7 +430,7 @@ TEST(OpPermuteCopyKernelTest, DynamicShapeUpperBoundSameAsExpected) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpPermuteCopyKernelTest, DynamicShapeUpperBoundLargerThanExpected) {
+TEST_F(OpPermuteCopyTest, DynamicShapeUpperBoundLargerThanExpected) {
   /* %python
   out_args = "{5, 5, 5}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND"
   %rewrite(unary_op) */
@@ -438,7 +451,7 @@ TEST(OpPermuteCopyKernelTest, DynamicShapeUpperBoundLargerThanExpected) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
-TEST(OpPermuteCopyKernelTest, DynamicShapeUnbound) {
+TEST_F(OpPermuteCopyTest, DynamicShapeUnbound) {
   if (!torch::executor::testing::SupportedFeatures::get()->output_resize) {
     GTEST_SKIP() << "Dynamic shape unbound not supported";
   }

--- a/kernels/test/op_pixel_shuffle_test.cpp
+++ b/kernels/test/op_pixel_shuffle_test.cpp
@@ -22,42 +22,47 @@ using exec_aten::Tensor;
 using torch::executor::testing::SupportedFeatures;
 using torch::executor::testing::TensorFactory;
 
-Tensor&
-op_pixel_shuffle_out(const Tensor& self, int64_t upscale_factor, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::pixel_shuffle_outf(
-      context, self, upscale_factor, out);
-}
+class OpPixelShuffleOutTest : public OperatorTest {
+ protected:
+  Tensor& op_pixel_shuffle_out(
+      const Tensor& self,
+      int64_t upscale_factor,
+      Tensor& out) {
+    return torch::executor::aten::pixel_shuffle_outf(
+        context_, self, upscale_factor, out);
+  }
+
+  template <ScalarType DTYPE_IN>
+  void test_pixel_shuffle() {
+    TensorFactory<DTYPE_IN> tf_in;
+
+    const std::vector<int32_t> sizes = {1, 4, 2, 2};
+    const std::vector<int32_t> out_sizes = {1, 1, 4, 4};
+
+    // Destination for the pixel_shuffle.
+    Tensor out = tf_in.zeros(out_sizes);
+
+    op_pixel_shuffle_out(
+        tf_in.make(
+            sizes, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}),
+        2,
+        out);
+    EXPECT_TENSOR_EQ(
+        out,
+        // Pixel shuffle distributes channels amongst the spatial dimensions.
+        tf_in.make(
+            out_sizes, {0, 4, 1, 5, 8, 12, 9, 13, 2, 6, 3, 7, 10, 14, 11, 15}));
+  }
+};
 
 //
 // Correctness Tests
 //
 
-template <ScalarType DTYPE_IN>
-void test_pixel_shuffle() {
-  TensorFactory<DTYPE_IN> tf_in;
-
-  const std::vector<int32_t> sizes = {1, 4, 2, 2};
-  const std::vector<int32_t> out_sizes = {1, 1, 4, 4};
-
-  // Destination for the pixel_shuffle.
-  Tensor out = tf_in.zeros(out_sizes);
-
-  op_pixel_shuffle_out(
-      tf_in.make(sizes, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}),
-      2,
-      out);
-  EXPECT_TENSOR_EQ(
-      out,
-      // Pixel shuffle distributes channels amongst the spatial dimensions.
-      tf_in.make(
-          out_sizes, {0, 4, 1, 5, 8, 12, 9, 13, 2, 6, 3, 7, 10, 14, 11, 15}));
-}
-
 /**
  * Uses the function templates above to test all input dtypes.
  */
-TEST(OpPixelShuffleOutKernelTest, AllRealDtypesSupported) {
+TEST_F(OpPixelShuffleOutTest, AllRealDtypesSupported) {
 #define ENUMERATE_TEST_ENTRY(ctype, dtype) \
   test_pixel_shuffle<ScalarType::dtype>();
 
@@ -66,7 +71,7 @@ TEST(OpPixelShuffleOutKernelTest, AllRealDtypesSupported) {
 #undef ENUMERATE_TEST_ENTRY
 }
 
-TEST(OpPixelShuffleOutKernelTest, LargerInputRank) {
+TEST_F(OpPixelShuffleOutTest, LargerInputRank) {
   TensorFactory<ScalarType::Int> tf;
 
   // Pixel shuffle allows a 4D (or higher) input tensor, make sure the extra
@@ -81,7 +86,7 @@ TEST(OpPixelShuffleOutKernelTest, LargerInputRank) {
 }
 
 // Mismatched shape tests.
-TEST(OpPixelShuffleOutKernelTest, InvalidInputChannelsDies) {
+TEST_F(OpPixelShuffleOutTest, InvalidInputChannelsDies) {
   TensorFactory<ScalarType::Int> tf;
 
   // Input tensors with invalid shapes. 7 is not divisible by upsample_factor
@@ -91,10 +96,10 @@ TEST(OpPixelShuffleOutKernelTest, InvalidInputChannelsDies) {
   Tensor out = tf.zeros(/*sizes=*/{1, 1, 8, 8});
 
   // Using the wrong input shape should exit with an error code.
-  ET_EXPECT_KERNEL_FAILURE(op_pixel_shuffle_out(a, 2, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_pixel_shuffle_out(a, 2, out));
 }
 
-TEST(OpPixelShuffleOutKernelTest, WrongInputRankDies) {
+TEST_F(OpPixelShuffleOutTest, WrongInputRankDies) {
   TensorFactory<ScalarType::Int> tf;
 
   // Pixel shuffle requires a 4D input tensor.
@@ -105,10 +110,10 @@ TEST(OpPixelShuffleOutKernelTest, WrongInputRankDies) {
   Tensor out = tf.zeros(/*sizes=*/{1, 2});
 
   // Using the wrong input shape should exit with an error code.
-  ET_EXPECT_KERNEL_FAILURE(op_pixel_shuffle_out(a, 2, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_pixel_shuffle_out(a, 2, out));
 }
 
-TEST(OpPixelShuffleOutKernelTest, DifferentDtypeDies) {
+TEST_F(OpPixelShuffleOutTest, DifferentDtypeDies) {
   TensorFactory<ScalarType::Int> tf;
   TensorFactory<ScalarType::Float> tf_float;
 
@@ -118,13 +123,13 @@ TEST(OpPixelShuffleOutKernelTest, DifferentDtypeDies) {
   Tensor out = tf_float.zeros(/*sizes=*/{1, 2, 12, 12});
 
   // Using the wrong output shape should exit with an error code.
-  ET_EXPECT_KERNEL_FAILURE(op_pixel_shuffle_out(a, 3, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_pixel_shuffle_out(a, 3, out));
 }
 
-TEST(OpPixelShuffleOutKernelTest, NegativeUpscaleFactorDies) {
+TEST_F(OpPixelShuffleOutTest, NegativeUpscaleFactorDies) {
   TensorFactory<ScalarType::Int> tf;
   Tensor a = tf.ones(/*sizes=*/{1, 18, 4, 4});
   Tensor out = tf.zeros(/*sizes=*/{1, 2, 12, 12});
   // Using a negative upscale factor should exit with an error code.
-  ET_EXPECT_KERNEL_FAILURE(op_pixel_shuffle_out(a, -3, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_pixel_shuffle_out(a, -3, out));
 }

--- a/kernels/test/op_pow_test.cpp
+++ b/kernels/test/op_pow_test.cpp
@@ -20,29 +20,29 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using torch::executor::testing::TensorFactory;
 
-Tensor&
-op_pow_scalar_out(const Scalar& self, const Tensor& exponent, Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::pow_outf(context, self, exponent, out);
-}
+class OpPowTest : public OperatorTest {
+ protected:
+  Tensor&
+  op_pow_scalar_out(const Scalar& self, const Tensor& exponent, Tensor& out) {
+    return torch::executor::aten::pow_outf(context_, self, exponent, out);
+  }
 
-Tensor& op_pow_tensor_scalar_out(
-    const Tensor& self,
-    const Scalar& exponent,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::pow_outf(context, self, exponent, out);
-}
+  Tensor& op_pow_tensor_scalar_out(
+      const Tensor& self,
+      const Scalar& exponent,
+      Tensor& out) {
+    return torch::executor::aten::pow_outf(context_, self, exponent, out);
+  }
 
-Tensor& op_pow_tensor_tensor_out(
-    const Tensor& self,
-    const Tensor& exponent,
-    Tensor& out) {
-  exec_aten::RuntimeContext context{};
-  return torch::executor::aten::pow_outf(context, self, exponent, out);
-}
+  Tensor& op_pow_tensor_tensor_out(
+      const Tensor& self,
+      const Tensor& exponent,
+      Tensor& out) {
+    return torch::executor::aten::pow_outf(context_, self, exponent, out);
+  }
+};
 
-TEST(OpPowTest, TensorTensorSanityCheck) {
+TEST_F(OpPowTest, TensorTensorSanityCheck) {
   TensorFactory<ScalarType::Byte> tf;
   Tensor self = tf.make({2, 2}, {2, 2, 2, 2});
   Tensor exp = tf.make({2, 1}, {4, 4});
@@ -54,7 +54,7 @@ TEST(OpPowTest, TensorTensorSanityCheck) {
   EXPECT_TENSOR_EQ(out, tf.make({2, 2}, {16, 16, 16, 16}));
 }
 
-TEST(OpPowTest, TensorTensorSanityCheck2) {
+TEST_F(OpPowTest, TensorTensorSanityCheck2) {
   TensorFactory<ScalarType::Float> tf1;
   TensorFactory<ScalarType::Int> tf2;
   TensorFactory<ScalarType::Double> tf3;
@@ -69,7 +69,7 @@ TEST(OpPowTest, TensorTensorSanityCheck2) {
   EXPECT_TENSOR_EQ(out, tf3.make({2, 2}, {4, 9, 16, 25}));
 }
 
-TEST(OpPowTest, TensorTensorHalfSupport) {
+TEST_F(OpPowTest, TensorTensorHalfSupport) {
   TensorFactory<ScalarType::Half> tf;
 
   Tensor self = tf.make({2, 2}, {2.0, 3.0, 4.0, 5.0});
@@ -82,7 +82,7 @@ TEST(OpPowTest, TensorTensorHalfSupport) {
   EXPECT_TENSOR_EQ(out, tf.make({2, 2}, {8.0, 27.0, 16.0, 25.0}));
 }
 
-TEST(OpPowTest, TensorScalarSanityCheck) {
+TEST_F(OpPowTest, TensorScalarSanityCheck) {
   TensorFactory<ScalarType::Byte> tf;
   Tensor self = tf.make({2, 2}, {2, 2, 2, 2});
   Tensor out = tf.make({2, 2}, {16, 16, 16, 16});
@@ -93,7 +93,7 @@ TEST(OpPowTest, TensorScalarSanityCheck) {
   EXPECT_TENSOR_EQ(out, tf.make({2, 2}, {16, 16, 16, 16}));
 }
 
-TEST(OpPowTest, TensorScalarHalfSupport) {
+TEST_F(OpPowTest, TensorScalarHalfSupport) {
   TensorFactory<ScalarType::Half> tf;
   Tensor self = tf.make({2, 2}, {2.0, 2.0, 2.0, 2.0});
   Tensor out = tf.zeros({2, 2});
@@ -104,7 +104,7 @@ TEST(OpPowTest, TensorScalarHalfSupport) {
   EXPECT_TENSOR_EQ(out, tf.make({2, 2}, {16.0, 16.0, 16.0, 16.0}));
 }
 
-TEST(OpPowTest, ScalarSanityCheck) {
+TEST_F(OpPowTest, ScalarSanityCheck) {
   TensorFactory<ScalarType::Byte> tf;
   Tensor exp = tf.make({2, 2}, {2, 2, 2, 2});
   Tensor out = tf.make({2, 2}, {16, 16, 16, 16});
@@ -115,7 +115,7 @@ TEST(OpPowTest, ScalarSanityCheck) {
   EXPECT_TENSOR_EQ(out, tf.make({2, 2}, {16, 16, 16, 16}));
 }
 
-TEST(OpPowTest, ScalarHalfSupport) {
+TEST_F(OpPowTest, ScalarHalfSupport) {
   TensorFactory<ScalarType::Half> tf;
   Tensor exp = tf.make({2, 2}, {2, 2, 2, 2});
   Tensor out = tf.zeros({2, 2});

--- a/kernels/test/targets.bzl
+++ b/kernels/test/targets.bzl
@@ -50,10 +50,12 @@ def define_common_targets(is_fbcode = False):
             fbcode_exported_deps = [
                 "//common/init:init",
                 "//common/gtest:gtest",
+                "//executorch/runtime/kernel:kernel_includes",
             ],
             xplat_exported_deps = [
                 "//xplat/folly:init_init",
                 "//third-party/googletest:gtest_main",
+                "//executorch/runtime/kernel:kernel_includes",
             ],
         )
 

--- a/kernels/test/util.bzl
+++ b/kernels/test/util.bzl
@@ -49,6 +49,7 @@ def op_test(name, deps = [], kernel_name = "portable", use_kernel_prefix = False
         deps = [
             "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
             "//executorch/runtime/core/exec_aten/testing_util:tensor_util" + aten_suffix,
+            "//executorch/runtime/kernel:kernel_includes" + aten_suffix,
             "//executorch/kernels/test:test_util" + aten_suffix,
         ] + generated_lib_and_op_deps + deps,
     )
@@ -82,6 +83,7 @@ def generated_op_test(name, op_impl_target, generated_lib_headers_target, suppor
         deps = [
             "//executorch/runtime/core/exec_aten:lib",
             "//executorch/runtime/core/exec_aten/testing_util:tensor_util",
+            "//executorch/runtime/kernel:kernel_includes",
             "//executorch/kernels/test:test_util",
             op_impl_target,
             generated_lib_headers_target,

--- a/runtime/core/exec_aten/util/scalar_type_util.h
+++ b/runtime/core/exec_aten/util/scalar_type_util.h
@@ -360,6 +360,26 @@ inline bool isFloatingType(exec_aten::ScalarType t) {
       t == exec_aten::ScalarType::Half || t == exec_aten::ScalarType::BFloat16);
 }
 
+inline bool isRealType(exec_aten::ScalarType t) {
+  return (
+      t == exec_aten::ScalarType::Byte || t == exec_aten::ScalarType::Char ||
+      t == exec_aten::ScalarType::Short || t == exec_aten::ScalarType::Int ||
+      t == exec_aten::ScalarType::Long || t == exec_aten::ScalarType::Float ||
+      t == exec_aten::ScalarType::Double);
+}
+
+inline bool isRealHType(exec_aten::ScalarType t) {
+  return (
+      t == exec_aten::ScalarType::Byte || t == exec_aten::ScalarType::Char ||
+      t == exec_aten::ScalarType::Short || t == exec_aten::ScalarType::Int ||
+      t == exec_aten::ScalarType::Long || t == exec_aten::ScalarType::Float ||
+      t == exec_aten::ScalarType::Double || t == exec_aten::ScalarType::Half);
+}
+
+inline bool isRealHBType(exec_aten::ScalarType t) {
+  return (isRealHType(t) || t == exec_aten::ScalarType::Bool);
+}
+
 inline bool isComplexType(exec_aten::ScalarType t) {
   return (
       t == exec_aten::ScalarType::ComplexHalf ||

--- a/runtime/core/exec_aten/util/tensor_util.h
+++ b/runtime/core/exec_aten/util/tensor_util.h
@@ -357,9 +357,6 @@
  * If `cond` is false, log `cond` and return from the kernel with a failure
  * state set.
  *
- * TODO(ssjia): add context.fail(torch.executor::Error::error); before exit
- * TODO(ssjia): replace runtime_abort() with return retval
- *
  * @param[in] context the runtime context
  * @param[in] cond the condition to check
  * @param[in] error torch::executor::Error enum value (e.g `InvalidArgument`)
@@ -369,16 +366,14 @@
   do {                                                \
     if (!(cond)) {                                    \
       ET_LOG(Error, "Check failed (%s): ", #cond);    \
-      torch::executor::runtime_abort();               \
+      context.fail(torch::executor::Error::error);    \
+      return retval;                                  \
     }                                                 \
   } while (false)
 
 /**
  * If `cond` is false, log `message` and return from the kernel with a failure
  * state set.
- *
- * TODO(ssjia): add context.fail(torch.executor::Error::error); before exit
- * TODO(ssjia): replace runtime_abort() with return retval
  *
  * @param[in] context the runtime context
  * @param[in] cond the condition to check
@@ -389,7 +384,8 @@
   do {                                                                    \
     if (!(cond)) {                                                        \
       ET_LOG(Error, "Check failed (%s): " message, #cond, ##__VA_ARGS__); \
-      torch::executor::runtime_abort();                                   \
+      context.fail(torch::executor::Error::error);                        \
+      return retval;                                                      \
     }                                                                     \
   } while (false)
 
@@ -486,6 +482,33 @@ inline bool tensor_is_floating_type(exec_aten::Tensor t) {
   ET_LOG_MSG_AND_RETURN_IF_FALSE(
       torch::executor::isFloatingType(t.scalar_type()),
       "Expected to find a floating type, but tensor has type %s",
+      torch::executor::toString(t.scalar_type()));
+
+  return true;
+}
+
+inline bool tensor_is_real_type(exec_aten::Tensor t) {
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      torch::executor::isRealType(t.scalar_type()),
+      "Expected to find a real type, but tensor has type %s",
+      torch::executor::toString(t.scalar_type()));
+
+  return true;
+}
+
+inline bool tensor_is_realh_type(exec_aten::Tensor t) {
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      torch::executor::isRealHType(t.scalar_type()),
+      "Expected to find a real type, but tensor has type %s",
+      torch::executor::toString(t.scalar_type()));
+
+  return true;
+}
+
+inline bool tensor_is_realhb_type(exec_aten::Tensor t) {
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      torch::executor::isRealHBType(t.scalar_type()),
+      "Expected to find a real type, but tensor has type %s",
       torch::executor::toString(t.scalar_type()));
 
   return true;


### PR DESCRIPTION
Summary:
Update kernels and tests starting with 'p'.

Note to reviewers: Because the changeset for non-fatal touches so many files, I've split into a number of diffs. The tests will not all pass until the final diff, given that non-fatal tests are switched on in the first diff but tests are not updated until the respective later diff. See revision 6.6 of D53251417 to observe the full change-set passing CI.

Differential Revision: D54182362
