### PR TITLE
skip inplace variant nodes in memory planning

### DIFF
--- a/exir/memory_planning.py
+++ b/exir/memory_planning.py
@@ -24,7 +24,7 @@ from executorch.exir.error import (
     internal_assert,
     InternalError,
 )
-from executorch.exir.operator.convert import is_out_variant
+from executorch.exir.operator.convert import is_inplace_variant, is_out_variant
 from executorch.exir.schema import TensorShapeDynamism
 from executorch.exir.tensor import TensorSpec
 
@@ -266,6 +266,16 @@ def _is_out_var_node(node: torch.fx.Node) -> bool:
     )
 
 
+def _is_inplace_node(node: torch.fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and isinstance(node.target, torch._ops.OpOverload)
+        and is_inplace_variant(
+            node.target._schema.name, node.target._schema.overload_name
+        )
+    )
+
+
 def update_tensor_lifetime(spec: TensorSpec, node_idx: int) -> None:
     r"""
     Update the lifetime of the tensor to cover node_idx. A tensor's lifetime
@@ -349,6 +359,9 @@ def collect_specs_from_nodes(  # noqa: C901
             continue
 
         if not (specs := get_node_tensor_specs(node)):
+            continue
+
+        if _is_inplace_node(node):
             continue
 
         if do_assertion:

--- a/exir/operator/convert.py
+++ b/exir/operator/convert.py
@@ -280,3 +280,11 @@ def is_out_variant(qualified_opname: str, overload: str) -> bool:
     if schema is None:
         return False
     return schema.is_out_fn()
+
+
+def is_inplace_variant(qualified_opname: str, overload: str) -> bool:
+    op_overload = get_op_overload(qualified_opname, overload)
+    schema = _get_overload_schema(op_overload)
+    if schema is None:
+        return False
+    return schema.kind() == SchemaKind.inplace


### PR DESCRIPTION
Summary: Dont try to memory plan the outputs of an inplace op

Differential Revision: D53713434


