### PR TITLE
Fix vulkan delegate partial test

### DIFF
--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -241,12 +241,8 @@ class TestBackends(unittest.TestCase):
             def __init__(self):
                 super().__init__()
                 self.linear = torch.nn.Linear(10, 10)
-                self.offset_1 = self.weight = torch.rand(
-                    size=(2, 10), dtype=torch.float32
-                )
-                self.offset_2 = self.weight = torch.rand(
-                    size=(2, 10), dtype=torch.float32
-                )
+                self.offset_1 = torch.rand(size=(2, 10), dtype=torch.float32)
+                self.offset_2 = torch.rand(size=(2, 10), dtype=torch.float32)
 
             def forward(self, x):
                 return self.linear(x + self.offset_1) - self.offset_2


### PR DESCRIPTION
Summary:
## Context

Previously the `test_vulkan_backend_partial` was written erroneously as a duplicate constant reference was present in the graph. This was not caught previously, but https://github.com/pytorch/pytorch/pull/120664 added checks that now catch the error. This is a simple change to correct the badly written test.

Differential Revision: D54263601


