### PR TITLE
update buck url

### DIFF
--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -221,7 +221,7 @@ You will need the following prerequisits for this section:
    ```
 * Version `${executorch_version:buck2}` of the `buck2` commandline tool — you can download a
   prebuilt archive for your system from [the Buck2
-  repo](https://github.com/facebook/buck2/releases/tag/${executorch_version:buck2}). Note that
+  repo](https://github.com/facebook/buck2/releases/tag/2024-02-15). Note that
   the version is important, and newer or older versions may not work with the
   version of the buck2 prelude used by the ExecuTorch repo.
 


### PR DESCRIPTION
Summary: the url didn't work with `${executorch_version:buck2}`, use the actual url instead

Reviewed By: kirklandsign

Differential Revision: D54279553


