### PR TITLE
Add a few more TARGETS files

### DIFF
--- a/examples/demo-apps/android/LlamaDemo/app/src/main/TARGETS
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/TARGETS
@@ -1,0 +1,1 @@
+# This file needs to exist to avoid build system breakage, see https://fburl.com/workplace/jtdlgdmd

--- a/extension/apple/ExecuTorch/TARGETS
+++ b/extension/apple/ExecuTorch/TARGETS
@@ -1,0 +1,1 @@
+# This file needs to exist to avoid build system breakage, see https://fburl.com/workplace/jtdlgdmd


### PR DESCRIPTION
Summary: These files need to exist to prevent breakages when we enable the BUCK files to be visible in the fbcode build graph

Reviewed By: jailby

Differential Revision: D54269646


