### PR TITLE
Enable XNNPACK pybindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,7 +392,8 @@ if(EXECUTORCH_BUILD_PYBIND)
     set(PYBIND_LINK_MPS "mpsdelegate")
   endif()
 
-  if(PYBIND_LINK_XNNPACK)
+  if(EXECUTORCH_BUILD_XNNPACK)
+    # set PYBIND_LINK_XNNPACK variable to link with portable lib library
     set(PYBIND_LINK_XNNPACK "xnnpack_backend")
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,10 @@ endif()
 # Build pybind
 option(EXECUTORCH_BUILD_PYBIND "Build pybindings" OFF)
 if(EXECUTORCH_BUILD_PYBIND)
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/data_loader)
+  if(NOT EXECUTORCH_BUILD_EXTENSION_DATA_LOADER)
+    # This has already been added if above flag is on
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/data_loader)
+  endif()
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sdk)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/pybind11)
 
@@ -390,7 +393,6 @@ if(EXECUTORCH_BUILD_PYBIND)
   endif()
 
   if(PYBIND_LINK_XNNPACK)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backends/xnnpack)
     set(PYBIND_LINK_XNNPACK "xnnpack_backend")
   endif()
 

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ class CMakeBuild(build_ext):
         # Can be set with Conda-Build, for example.
         cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
 
+
         # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
         # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
         # from Python.
@@ -107,6 +108,13 @@ class CMakeBuild(build_ext):
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
         ]
+        # Build with XNNPACK if EXECUTORCH_BUILD_XNNPACK is on
+        if os.environ.get("EXEUCTORCH_BUILD_XNNPACK", None):
+            cmake_args.extend([
+                "-DEXECUTORCH_BUILD_XNNPACK=ON",
+                "-DPYBIND_LINK_XNNPACK=ON",
+            ])
+
         build_args = []
         # Adding CMake arguments set as environment variable
         # (needed e.g. to build for ARM OSx on conda-forge)

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,6 @@ class CMakeBuild(build_ext):
         # Can be set with Conda-Build, for example.
         cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
 
-
         # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
         # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
         # from Python.
@@ -110,10 +109,12 @@ class CMakeBuild(build_ext):
         ]
         # Build with XNNPACK if EXECUTORCH_BUILD_XNNPACK is on
         if os.environ.get("EXEUCTORCH_BUILD_XNNPACK", None):
-            cmake_args.extend([
-                "-DEXECUTORCH_BUILD_XNNPACK=ON",
-                "-DPYBIND_LINK_XNNPACK=ON",
-            ])
+            cmake_args.extend(
+                [
+                    "-DEXECUTORCH_BUILD_XNNPACK=ON",
+                    "-DPYBIND_LINK_XNNPACK=ON",
+                ]
+            )
 
         build_args = []
         # Adding CMake arguments set as environment variable

--- a/setup.py
+++ b/setup.py
@@ -108,13 +108,8 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
         ]
         # Build with XNNPACK if EXECUTORCH_BUILD_XNNPACK is on
-        if os.environ.get("EXEUCTORCH_BUILD_XNNPACK", None):
-            cmake_args.extend(
-                [
-                    "-DEXECUTORCH_BUILD_XNNPACK=ON",
-                    "-DPYBIND_LINK_XNNPACK=ON",
-                ]
-            )
+        if os.environ.get("EXECUTORCH_BUILD_XNNPACK", None):
+            cmake_args.append("-DEXECUTORCH_BUILD_XNNPACK=ON")
 
         build_args = []
         # Adding CMake arguments set as environment variable


### PR DESCRIPTION
Enabling pybindings for XNNPACK, this allows us to run XNNPACK Delegate's python tests in open source.


Test Plan:
```
CMAKE_BUILD_PARALLEL_LEVEL=9 EXECUTORCH_BUILD_XNNPACK=ON EXECUTORCH_BUILD_PYBIND=ON pip install . --no-build-isolation -v
```
After setup
```
python -m unittest backends/xnnpack/test/models/mobilenet_v2.py
```
