### PR TITLE
[Executorch][llama] modify model to use sdpa_with_kv_cache op

### DIFF
--- a/examples/models/llama2/TARGETS
+++ b/examples/models/llama2/TARGETS
@@ -28,6 +28,7 @@ runtime.python_library(
     deps = [
         "//caffe2:torch",
         "//executorch/examples/models:model_base",
+        "//executorch/examples/models/llama2/custom_ops:llama_custom_ops_aot_lib",
         "//executorch/examples/models/llama2/ops:quantized_aot_lib",
     ],
 )

--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -62,6 +62,7 @@ def load_llama_model(
     checkpoint: str,
     params_path: str,
     use_kv_cache: bool = False,
+    use_sdpa_with_kv_cache: bool = False,
     weight_type: WeightType = WeightType.LLAMA,
     verbose: bool = False,
 ) -> "LlamaEdgeManager":
@@ -81,6 +82,7 @@ def load_llama_model(
         checkpoint=checkpoint,
         params=params_path,
         use_kv_cache=use_kv_cache,
+        use_sdpa_with_kv_cache=use_sdpa_with_kv_cache,
         fairseq2=weight_type == WeightType.FAIRSEQ2,
     )
     state_dict = model.state_dict()
@@ -106,6 +108,7 @@ def load_llama_model(
         weight_type=weight_type,
         dtype=dtype,
         use_kv_cache=use_kv_cache,
+        use_sdpa_with_kv_cache=use_sdpa_with_kv_cache,
         example_inputs=example_inputs,
         verbose=verbose,
     )
@@ -122,6 +125,7 @@ class LlamaEdgeManager:
         weight_type,
         dtype,
         use_kv_cache,
+        use_sdpa_with_kv_cache,
         example_inputs,
         verbose: bool = False,
     ):
@@ -130,6 +134,7 @@ class LlamaEdgeManager:
         self.dtype = dtype
         self.example_inputs = example_inputs
         self.use_kv_cache = use_kv_cache
+        self.use_sdpa_with_kv_cache = use_sdpa_with_kv_cache
         self.metadata = None
         self.verbose = verbose
         self.applied_source_transforms = []
@@ -220,6 +225,7 @@ class LlamaEdgeManager:
             "get_n_layers": params.n_layers,
             "get_vocab_size": params.vocab_size,
             "use_kv_cache": self.use_kv_cache,
+            "use_sdpa_with_kv_cache": self.use_sdpa_with_kv_cache,
         }
         if self.metadata:
             try:

--- a/examples/models/llama2/custom_ops/targets.bzl
+++ b/examples/models/llama2/custom_ops/targets.bzl
@@ -43,6 +43,21 @@ def define_common_targets():
     The directory containing this targets.bzl file should also contain both
     TARGETS and BUCK files that call this function.
     """
+
+    runtime.python_library(
+        name = "llama_custom_ops_aot_lib",
+        srcs = [
+            "sdpa_with_kv_cache.py",
+        ],
+        visibility = [
+            "//executorch/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+        deps = [
+            "//caffe2:torch",
+        ],
+    )
+
     runtime.export_file(
         name = "custom_ops.yaml",
         visibility = [

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -266,6 +266,12 @@ def build_args_parser() -> argparse.ArgumentParser:
         help="Whether or not to export a model using kv cache",
     )
     parser.add_argument(
+        "--use_sdpa_with_kv_cache",
+        default=False,
+        action="store_true",
+        help="Whether to use sdpa_with_kv_cache update op when using kv cache",
+    )
+    parser.add_argument(
         "-p",
         "--params",
         default=f"{ckpt_dir}/params/demo_config.json",
@@ -407,6 +413,7 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
             checkpoint=checkpoint_path,
             params_path=params_path,
             use_kv_cache=args.use_kv_cache,
+            use_sdpa_with_kv_cache=args.use_sdpa_with_kv_cache,
             weight_type=weight_type,
             verbose=args.verbose,
         )

--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -32,6 +32,8 @@ except ImportError:
 
 from ..model_base import EagerModelBase
 
+from .custom_ops.sdpa_with_kv_cache import *
+
 
 class RMSNorm(torch.nn.Module):
     def __init__(self, dim: int, eps: float = 1e-6):
@@ -96,6 +98,7 @@ class ModelArgs:
     num_experts: int = 8  # Number of experts
     num_activated_experts: int = 2  # Number of experts to activate
     use_kv_cache: bool = False  # Use key/value cache
+    use_sdpa_with_kv_cache_op: bool = False  # Use key/value cache
     # Additional Model Metadata needed at runtime
     bos_idx: int = 1
     eos_idx: int = 3
@@ -157,7 +160,7 @@ def apply_rotary_emb(
 
 
 class Attention(nn.Module):
-    def __init__(self, args: ModelArgs):
+    def __init__(self, args: ModelArgs, layer_id):
         super().__init__()
         self.use_kv_cache = args.use_kv_cache
         self.n_kv_heads = args.n_heads if args.n_kv_heads is None else args.n_kv_heads
@@ -174,6 +177,9 @@ class Attention(nn.Module):
         self.wk = nn.Linear(args.dim, self.n_kv_heads * self.head_dim, bias=False)
         self.wv = nn.Linear(args.dim, self.n_kv_heads * self.head_dim, bias=False)
         self.wo = nn.Linear(args.n_heads * self.head_dim, args.dim, bias=False)
+
+        self.use_sdpa_with_kv_cache_op = args.use_sdpa_with_kv_cache_op
+        self.layer_id = layer_id
 
         mask = torch.full(
             (1, 1, args.max_seq_len, args.max_seq_len),
@@ -204,17 +210,22 @@ class Attention(nn.Module):
         freqs_cos: torch.Tensor,
         freqs_sin: torch.Tensor,
         start_pos: Optional[int] = None,
-        cache_k: Optional[
-            torch.Tensor
-        ] = None,  # shape: (args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
-        cache_v: Optional[
-            torch.Tensor
-        ] = None,  # shape: (args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
+        cache_k: Optional[torch.Tensor] = None,
+        # if use_sdpa_with_kv_cache_op
+        # shape: (num_layers, args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
+        # otherwise
+        # shape: (args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
+        cache_v: Optional[torch.Tensor] = None,
+        # if use_sdpa_with_kv_cache_op
+        # shape: (num_layers, args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
+        # otherwise
+        # shape: (args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
     ):
         bsz, seqlen, _ = x.shape
 
         # QKV
         xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+        # We need view_copy elimination
         xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
         xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
         xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
@@ -226,20 +237,34 @@ class Attention(nn.Module):
             assert start_pos is not None
             assert cache_k is not None and cache_v is not None
 
-            # Replace the entry in the cache for this token
-            # The following lines are equivalent to:
-            # cache_k[:bsz, start_pos : start_pos + seqlen] = xk
-            # cache_v[:bsz, start_pos : start_pos + seqlen] = xv
-            # We use .narrow() here to make the compiler happy
-            narrowed_k = cache_k[:bsz].narrow(1, start_pos, seqlen)
-            narrowed_v = cache_v[:bsz].narrow(1, start_pos, seqlen)
+            if self.use_sdpa_with_kv_cache_op:
+                output = torch.ops.llama.sdpa_with_kv_cache(
+                    xq,
+                    xk,
+                    xv,
+                    cache_k,
+                    cache_v,
+                    self.layer_id,
+                    start_pos,
+                    seqlen,
+                )
+                output = output.view(bsz, seqlen, -1)
+                output = self.wo(output)
+                return output, cache_k, cache_v
+            else:
+                # Replace the entry in the cache for this token
+                # The following lines are equivalent to:
+                # cache_k[:bsz, start_pos : start_pos + seqlen] = xk
+                # cache_v[:bsz, start_pos : start_pos + seqlen] = xv
+                # We use .narrow() here to make the compiler happy
+                narrowed_k = cache_k[:bsz].narrow(1, start_pos, seqlen)
+                narrowed_v = cache_v[:bsz].narrow(1, start_pos, seqlen)
 
-            narrowed_k.copy_(xk)
-            narrowed_v.copy_(xv)
+                narrowed_k.copy_(xk)
+                narrowed_v.copy_(xv)
 
-            keys = cache_k[:bsz].narrow(1, 0, start_pos + seqlen)
-            values = cache_v[:bsz].narrow(1, 0, start_pos + seqlen)
-
+                keys = cache_k[:bsz].narrow(1, 0, start_pos + seqlen)
+                values = cache_v[:bsz].narrow(1, 0, start_pos + seqlen)
         else:
             keys = xk
             values = xv
@@ -256,11 +281,11 @@ class Attention(nn.Module):
         assert hasattr(self, "mask")
         mask = self.mask[:, :, :seqlen, :seqlen]
 
-        # This is needed to support XNNPACK which requires mask shape to be 2D.
-        # This is a temporary workaround. Once we update XNNPACK we should be able to handle this.
-        # Shape before: [1, 1, L, S], after: [L, S]
-        # We make sure to specify the dimensions to be squeezed [0, 1] to ensure that the output
-        # tensor will be 2-dimensional, regarldess of the values of L & S
+        # this is needed to support xnnpack which requires mask shape to be 2d.
+        # this is a temporary workaround. once we update xnnpack we should be able to handle this.
+        # shape before: [1, 1, l, s], after: [l, s]
+        # we make sure to specify the dimensions to be squeezed [0, 1] to ensure that the output
+        # tensor will be 2-dimensional, regarldess of the values of l & s
         mask = torch.squeeze(mask, [0, 1])
 
         # FIXME: This should be so automatically! MKG
@@ -355,12 +380,11 @@ class TransformerBlock(nn.Module):
         self.n_heads = args.n_heads
         self.dim = args.dim
         self.head_dim = args.dim // args.n_heads
-        self.attention = Attention(args)
+        self.attention = Attention(args, layer_id)
         if args.moe:
             self.block_sparse_moe = MOEFeedForward(args)
         else:
             self.feed_forward = FeedForward(args)
-        self.layer_id = layer_id
         self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
         self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
 
@@ -398,6 +422,7 @@ class Transformer(nn.Module):
         self.norm = RMSNorm(params.dim, eps=params.norm_eps)
         self.output = nn.Linear(params.dim, params.vocab_size, bias=False)
         self.use_kv_cache = params.use_kv_cache
+        self.use_sdpa_with_kv_cache_op = params.use_sdpa_with_kv_cache_op
 
         freqs_cos, freqs_sin = precompute_freqs_cis(
             self.params.dim // self.params.n_heads, self.params.max_seq_len
@@ -455,16 +480,26 @@ class Transformer(nn.Module):
 
         for index, layer in enumerate(self.layers):
             if self.use_kv_cache:
-                h, updated_cache_k, updated_cache_v = layer(
-                    h,
-                    freqs_cos,
-                    freqs_sin,
-                    sp,  # pyre-ignore[61]
-                    cache_k[index],  # pyre-ignore[16]
-                    cache_v[index],
-                )
-                cache_k[index] = updated_cache_k  # pyre-ignore[16]
-                cache_v[index] = updated_cache_v
+                if self.use_sdpa_with_kv_cache_op:
+                    h, updated_cache_k, updated_cache_v = layer(
+                        h,
+                        freqs_cos,
+                        freqs_sin,
+                        sp,  # pyre-ignore[61]
+                        cache_k,  # pyre-ignore[16]
+                        cache_v,
+                    )
+                else:
+                    h, updated_cache_k, updated_cache_v = layer(
+                        h,
+                        freqs_cos,
+                        freqs_sin,
+                        sp,  # pyre-ignore[61]
+                        cache_k[index],  # pyre-ignore[16]
+                        cache_v[index],
+                    )
+                    cache_k[index] = updated_cache_k  # pyre-ignore[16]
+                    cache_v[index] = updated_cache_v
 
             else:
                 h, _, _ = layer(h, freqs_cos, freqs_sin)
@@ -520,6 +555,11 @@ class Llama2Model(EagerModelBase):
         self.use_kv_cache = (
             kwargs["use_kv_cache"] if "use_kv_cache" in kwargs else False
         )
+        self.use_sdpa_with_kv_cache_op = (
+            kwargs["use_sdpa_with_kv_cache"]
+            if "use_sdpa_with_kv_cache" in kwargs
+            else False
+        )
         # The example is using a dummy small model with random weights for demo purpose only.
         # Follow the instruction in https://github.com/facebookresearch/llama to download the model
         device = "cpu"
@@ -553,6 +593,7 @@ class Llama2Model(EagerModelBase):
             max_seq_len=max_seq_len,
             max_batch_size=max_batch_size,
             use_kv_cache=self.use_kv_cache,
+            use_sdpa_with_kv_cache_op=self.use_sdpa_with_kv_cache_op,
             **params,
         )
         if kwargs.get("fairseq2", False):

--- a/examples/models/llama2/runner/runner.h
+++ b/examples/models/llama2/runner/runner.h
@@ -54,6 +54,7 @@ class Runner {
   int32_t n_eos_;
   int32_t max_seq_len_;
   bool use_kv_cache_;
+  bool use_sdpa_with_kv_cache_;
   bool append_eos_;
   std::unordered_set<std::string> model_methods_;
   std::unique_ptr<Module> module_;

--- a/examples/models/llama2/runner/targets.bzl
+++ b/examples/models/llama2/runner/targets.bzl
@@ -29,9 +29,9 @@ def define_common_targets():
                 "//executorch/kernels/quantized:generated_lib" + aten_suffix,
                 "//executorch/kernels/portable:" + ("generated_lib_aten" if aten else "generated_lib_all_ops"),
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
-            ] + [
+            ] + ([
                 "//executorch/examples/models/llama2/custom_ops:custom_ops",
-            ] if ((not aten) and (not runtime.is_oss)) else [],
+            ] if ((not aten) and (not runtime.is_oss)) else []),
             external_deps = [
                 "libtorch",
             ] if aten else [],

--- a/examples/models/llama2/runner/targets.bzl
+++ b/examples/models/llama2/runner/targets.bzl
@@ -29,6 +29,7 @@ def define_common_targets():
                 "//executorch/kernels/quantized:generated_lib" + aten_suffix,
                 "//executorch/kernels/portable:" + ("generated_lib_aten" if aten else "generated_lib_all_ops"),
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
+                "//executorch/examples/models/llama2/custom_ops:custom_ops",
             ],
             external_deps = [
                 "libtorch",

--- a/examples/models/llama2/runner/targets.bzl
+++ b/examples/models/llama2/runner/targets.bzl
@@ -29,8 +29,9 @@ def define_common_targets():
                 "//executorch/kernels/quantized:generated_lib" + aten_suffix,
                 "//executorch/kernels/portable:" + ("generated_lib_aten" if aten else "generated_lib_all_ops"),
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
+            ] + [
                 "//executorch/examples/models/llama2/custom_ops:custom_ops",
-            ],
+            ] if ((not aten) and (not runtime.is_oss)) else [],
             external_deps = [
                 "libtorch",
             ] if aten else [],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2156
* #2155
* __->__ #2154
* #2153

This diff adds new option of `use_sdpa_with_kv_cache` to do model surgery and
make Attention layer use sdpa_with_kv_cache op.

NB: This will likely conflict with some upcoming refacotring.

NB: Model exported with this op is not runnable in aten mode

Differential Revision: [D54075828](https://our.internmc.facebook.com/intern/diff/D54075828/)