### PR TITLE
[Executorch][Llama] Dont memory plan for inputs

### DIFF
--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -21,6 +21,8 @@ from executorch.backends.transforms.duplicate_dynamic_quant_chain import (
 from executorch.exir import EdgeProgramManager
 from executorch.exir.backend.partitioner import Partitioner
 from executorch.exir.capture._config import EdgeCompileConfig, ExecutorchBackendConfig
+
+from executorch.exir.passes import MemoryPlanningPass
 from executorch.exir.passes.quant_fusion_pass import QuantFusionPass
 from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
 from torch._export import capture_pre_autograd_graph
@@ -310,6 +312,9 @@ class LlamaEdgeManager:
                 passes=[
                     QuantFusionPass(),
                 ],
+                memory_planning_pass=MemoryPlanningPass(
+                    "greedy", alloc_graph_input=False
+                ),
                 sym_shape_eval_pass=ConstraintBasedSymShapeEvalPass(),
             )
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2156
* __->__ #2155
* #2154
* #2153

For KV cache with IO tHis results in
1. allocating kv cache in the memory plan but also allocated by llama runner
2. Doing actual copy of kv cache

Also we should really make plan_input = false by default. I dont imagine a case
where this does not result in making copies. Planning for output is fine but
still dangerous as people may assume having reference to output tensor is all
good without realizing the underlying memory being shared.

Differential Revision: [D54161288](https://our.internmc.facebook.com/intern/diff/D54161288/)