### PR TITLE
Add constant_segment_data fields to emitter and serialization

### DIFF
--- a/exir/_serialize/TARGETS
+++ b/exir/_serialize/TARGETS
@@ -60,5 +60,6 @@ runtime.python_library(
     ],
     deps = [
         "//executorch/exir:schema",
+        "//executorch/exir:tensor",
     ],
 )

--- a/exir/_serialize/_program.py
+++ b/exir/_serialize/_program.py
@@ -29,6 +29,7 @@ from executorch.exir.schema import (
     Program,
     SubsegmentOffsets,
 )
+from executorch.exir.tensor import ALIGNMENT
 
 
 # Byte order of numbers written to program headers. Always little-endian
@@ -503,6 +504,7 @@ def _append_segments(
 def serialize_pte_binary(
     program: Program,
     *,
+    constant_segment_data: Optional[bytearray] = None,
     extract_delegate_segments: bool = False,
     extract_constant_segment: bool = False,
     segment_alignment: int = 4096,
@@ -513,6 +515,9 @@ def serialize_pte_binary(
 
     Args:
         program: The Program to serialize.
+        constant_segment_data: If provided, a bytearray containing the constant data
+            in a segment blob. If not provided, there are either no constants, or
+            constants are stored inside program.constant_buffer.
         extract_delegate_segments: Whether to move delegate data blobs from the
             Program into separate segments, rather than encoding those blobs
             in the flatbuffer data. When true, will also:
@@ -535,7 +540,7 @@ def serialize_pte_binary(
     """
     # Default tensor alignment.
     if constant_tensor_alignment is None:
-        constant_tensor_alignment = 16
+        constant_tensor_alignment = ALIGNMENT
 
     # Segment data to be written to the file following the flatbuffer data.
     segments: List[bytes] = []

--- a/exir/emit/_emit_program.py
+++ b/exir/emit/_emit_program.py
@@ -20,6 +20,7 @@ from executorch.exir.emit._emitter import (
 from executorch.exir.error import ExportError, ExportErrorType
 from executorch.exir.schema import (
     Bool,
+    Buffer,
     Chain,
     ContainerMetadata,
     Double,
@@ -30,7 +31,7 @@ from executorch.exir.schema import (
     String,
     SubsegmentOffsets,
 )
-from executorch.exir.tensor import layout_enum, scalar_type_enum
+from executorch.exir.tensor import ALIGNMENT, layout_enum, scalar_type_enum
 from executorch.exir.version import EXECUTORCH_SCHEMA_VERSION
 from torch.export.exported_program import ExportedProgram
 
@@ -121,11 +122,19 @@ class EmitterOutput:
         str, Dict[int, Dict[str, Union[str, _DelegateDebugIdentifierMap]]]
     ]
 
+    # If present, contains constant data in a segment blob. This is the contents of the
+    # segment pointed to by program.constant_segment.
+    # If not present, there is either no constant data, or constant data is stored inside
+    # program.constant_buffer.
+    constant_segment_data: Optional[bytearray]
+
 
 def emit_program(
     methods: Union[ExportedProgram, Dict[str, ExportedProgram]],
     emit_stacktrace: bool = False,
     prim_getters: Optional[Dict[str, Any]] = None,
+    extract_constant_segment: bool = False,
+    constant_tensor_alignment: Optional[int] = ALIGNMENT,
 ) -> EmitterOutput:
     """
     Given a exported program, it returns the program in the format
@@ -137,7 +146,14 @@ def emit_program(
             ExportedPrograms.
         emit_stacktrace: Flag to enable emission of a stacktrace for each
            instruction for debugging purposes
-
+        prim_getters: A mapping of function names to return values. All
+            values are primitives, or structures of them. If provided, emit
+            simple execution plans that return these constant values.
+        extract_constant_segment: Whether to emit constant data into a separate
+            segment. Otherwise, constant data is stored in program.constant_buffer.
+        constant_tensor_alignment: The minimum alignment of tensor buffers in the
+            program. Must be a power of 2. If not provided, uses a value that is
+            compatible with all standard dtypes.
     Return:
         The program in a Python class which mimics the flatbuffer schema
     """
@@ -156,10 +172,16 @@ def emit_program(
             f"Did not receive ExportedProgram for the following methods {str(bad_methods)}",
         )
 
+    if constant_tensor_alignment is None:
+        constant_tensor_alignment = ALIGNMENT
+
     plans = []
     debug_handle_map = {}
     method_to_delegate_debug_id_map = {}
-    program_state = _ProgramState()
+
+    # The 0 index of constant_buffer is reserved to be pointed to by non-constant tensors,
+    # so add an empty placeholder.
+    program_state = _ProgramState(constant_buffer=[Buffer(storage=b"")])
 
     # emit each entry point in order according to name.
     for name, exported_program in sorted(methods.items()):
@@ -179,6 +201,8 @@ def emit_program(
             operator_cache={},
             delegate_cache={},
             emit_stacktrace=emit_stacktrace,
+            extract_constant_segment=extract_constant_segment,
+            constant_tensor_alignment=constant_tensor_alignment,
         )
 
         emitter = _TopLevelEmitter(name, exported_program, program_state, emitter_state)
@@ -195,17 +219,21 @@ def emit_program(
     if prim_getters is not None:
         plans.extend(_emit_prim_getters(prim_getters))
 
+    constant_buffer = (
+        [] if program_state.constant_buffer is None else program_state.constant_buffer
+    )
     return EmitterOutput(
         debug_handle_map=debug_handle_map,
         method_to_delegate_debug_id_map=method_to_delegate_debug_id_map,
         program=Program(
             version=EXECUTORCH_SCHEMA_VERSION,
             execution_plan=plans,
-            constant_buffer=program_state.constant_buffer,
+            constant_buffer=constant_buffer,
             backend_delegate_data=program_state.backend_delegate_data,
             # Segments may be added at serialization time.
             segments=[],
             # Subsegment offsets may be added at serialization time.
             constant_segment=SubsegmentOffsets(segment_index=0, offsets=[]),
         ),
+        constant_segment_data=program_state.constant_segment_data,
     )

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -423,6 +423,7 @@ class ExecutorchProgram:
         if self._buffer is None:
             self._buffer = _serialize_pte_binary(
                 program=self.program,
+                constant_segment_data=self.constant_segment_data,
                 extract_delegate_segments=self._extract_delegate_segments,
                 extract_constant_segment=self._extract_constant_segment,
                 segment_alignment=self._segment_alignment,
@@ -433,11 +434,11 @@ class ExecutorchProgram:
 
     @property
     def program(self) -> Program:
-        if self._emitter_output is None:
-            self._emitter_output = emit_program(
-                self.exported_program, self._emit_stacktrace
-            )
-        return self._emitter_output.program
+        return self._get_emitter_output().program
+
+    @property
+    def constant_segment_data(self) -> Optional[bytearray]:
+        return self._get_emitter_output().constant_segment_data
 
     @property
     def debug_handle_map(self) -> Dict[int, Union[int, List[int]]]:
@@ -456,6 +457,16 @@ class ExecutorchProgram:
     @property
     def graph_module(self) -> torch.fx.GraphModule:
         return self.exported_program.graph_module
+
+    def _get_emitter_output(self) -> EmitterOutput:
+        if self._emitter_output is None:
+            self._emitter_output = emit_program(
+                methods=self.exported_program,
+                emit_stacktrace=self._emit_stacktrace,
+                extract_constant_segment=self._extract_constant_segment,
+                constant_tensor_alignment=self._constant_tensor_alignment,
+            )
+        return self._emitter_output
 
     # TODO (zhxchen17) Change this to property.
     def dump_graph_module(self) -> torch.fx.GraphModule:
@@ -725,9 +736,11 @@ class MultiMethodExecutorchProgram:
         for name, prog in executorch_dialect_program.methods().items():
             temp[name] = prog.exported_program
         self._emitter_output: EmitterOutput = emit_program(
-            temp,
-            emit_stacktrace,
-            executorch_dialect_program.prim_getters(),
+            methods=temp,
+            emit_stacktrace=emit_stacktrace,
+            prim_getters=executorch_dialect_program.prim_getters(),
+            extract_constant_segment=extract_constant_segment,
+            constant_tensor_alignment=constant_tensor_alignment,
         )
         self._executorch_dialect_ir_program = executorch_dialect_program
         self._extract_delegate_segments: bool = extract_delegate_segments
@@ -742,6 +755,7 @@ class MultiMethodExecutorchProgram:
         if self._buffer is None:
             self._buffer = _serialize_pte_binary(
                 program=self._emitter_output.program,
+                constant_segment_data=self._emitter_output.constant_segment_data,
                 extract_delegate_segments=self._extract_delegate_segments,
                 extract_constant_segment=self._extract_constant_segment,
                 segment_alignment=self._segment_alignment,
@@ -1111,14 +1125,17 @@ class ExecutorchProgramManager:
 
         # Emit methods
         self._emitter_output: EmitterOutput = emit_program(
-            self._execution_programs,
-            backend_config.emit_stacktrace,
-            self._config_methods,
+            methods=self._execution_programs,
+            emit_stacktrace=backend_config.emit_stacktrace,
+            prim_getters=self._config_methods,
+            extract_constant_segment=backend_config.extract_constant_segment,
+            constant_tensor_alignment=backend_config.constant_tensor_alignment,
         )
 
         # Serialize emitter output to a buffer
         self._buffer: bytes = _serialize_pte_binary(
             program=self._emitter_output.program,
+            constant_segment_data=self._emitter_output.constant_segment_data,
             extract_delegate_segments=backend_config.extract_delegate_segments,
             extract_constant_segment=backend_config.extract_constant_segment,
             segment_alignment=backend_config.segment_alignment,

--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -108,6 +108,7 @@ def determine_tensor_dynanism(shape: torch.Size) -> TensorShapeDynamism:
             return TensorShapeDynamism.DYNAMIC_UNBOUND
 
 
+# Default tensor alignment. Keep in sync with tensor-alignment in program.fbs.
 ALIGNMENT = 16
 
 

--- a/schema/program.fbs
+++ b/schema/program.fbs
@@ -337,7 +337,7 @@ table ExecutionPlan {
 table Buffer {
   // During serialization, this alignment may be rewritten to a larger value.
   // The magic "@executorch-tensor-alignment" comment tells EXIR which lines to
-  // patch.
+  // patch. Keep in sync with ALIGNMENT in exir/tensor.py
   storage:[ubyte] (force_align: 16);  // @executorch-tensor-alignment
 }
 


### PR DESCRIPTION
Summary:
This diff does some setup work to emit constant segment. 

_ProgramState:
- Add `constant_segment_data` 
- Add `constant_segment_offsets` 
- Use these to store the constant segment + associated metadata.

_EmitterState:
- Add `extract_constant_segment`
- Add `constant_tensor_alignment`
- Check these to decide whether we emit constants to buffer or segment.

Pass these values to executorch serialization.

Make constant data structures `Optional`s, as we should only have one or the other, not both.

Differential Revision: D54147841


