### PR TITLE
Remove documentation on old arg in BackendDetails

### DIFF
--- a/exir/backend/backend_details.py
+++ b/exir/backend/backend_details.py
@@ -45,7 +45,6 @@ class BackendDetails(ABC):
 
     Args:
         edge_program: The original exported program. It will not be modified in place.
-        backend_debug_handle_generator: A callable to map a graph to a dictionary (key is node, value is id)
         compile_specs: List of values needed for compilation
 
     Returns:


### PR DESCRIPTION
Summary: Looks like the argument, "backend_debug_handle_generator," is no longer used and has been removed from the code, so remove the comment as well

Reviewed By: cccclai

Differential Revision: D54322749


