### PR TITLE
Fix llama quantize_per_token numerics

### DIFF
--- a/examples/models/llama2/quantize.py
+++ b/examples/models/llama2/quantize.py
@@ -174,8 +174,9 @@ def quantize_per_token(
     """
     _quant_min_max_bounds_check(quant_min, quant_max, dtype)
     _per_token_quant_qparam_dim_check(input, scales, zero_points)
-    input = torch.round(input / scales).clamp(quant_min, quant_max).to(dtype)
-    input = input + zero_points
+    input = (
+        torch.round(input / scales + zero_points).clamp(quant_min, quant_max).to(dtype)
+    )
     return input
 
 


### PR DESCRIPTION
Summary:
The existing implementation can produce quantized values
outside the quant range, since we add the zero points after
clamping. This was not a problem for symmetric quantization
since zero points are 0 there, but causes dqlinear numerics
to diverge significantly from the lowered implementation for
asymmetric quantization.

Reviewed By: digantdesai

Differential Revision: D54320424


