### PR TITLE
Restrict promoting commit to stable branch

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           repository: pytorch/executorch
           stable-branch: viable/strict
-          requires: '[\"pull\", \"lint\", \"Build documentation\"]'
+          requires: '[\"pull\", \"lint\", \"trunk\", \"Build documentation\"]'
           secret-bot-token: ${{ secrets.UPDATEBOT_TOKEN }}
           rockset-api-key: ${{ secrets.ROCKSET_API_KEY }}


### PR DESCRIPTION
Summary:
Currently the commit got promoted to viable/strict isn't stable: [ET CI HUD](https://hud.pytorch.org/hud/pytorch/executorch/viable%2Fstrict).

ET CI is in a better state now, it's time to restrict promoting commit by including trunk jobs. It is a follow-up action from [#1697](https://github.com/pytorch/executorch/pull/1697).

Differential Revision: D54370551


