### PR TITLE
add check to ensure that all external input and output ids are used

### DIFF
--- a/backends/xnnpack/partition/configs.py
+++ b/backends/xnnpack/partition/configs.py
@@ -63,6 +63,7 @@ SUPPORTED_OPS = [
     exir_ops.edge.aten.avg_pool2d.default,
     exir_ops.edge.aten.leaky_relu.default,
     exir_ops.edge.aten.addmm.default,  # TODO(T163877189) add constraint for addmm
+    exir_ops.edge.aten.convolution.default,
 ]
 
 SUPPORTED_MODULES = [
@@ -99,6 +100,7 @@ SUPPORTED_QUANT_OPS = [
     exir_ops.edge.aten.t_copy.default,
     exir_ops.edge.aten.leaky_relu.default,
     exir_ops.edge.aten.addmm.default,  # TODO(T163877189) add constraint for addmm
+    exir_ops.edge.aten.convolution.default,
 ]
 
 SUPPORTED_IMPLICIT_Q_DQ_OP_NAMES_SET = {


### PR DESCRIPTION
Summary: it is important to check that the number of serialized input/output ids matches the number of externs.

Differential Revision: D54355243


