### PR TITLE
partition all convolutions

### DIFF
--- a/backends/xnnpack/partition/configs.py
+++ b/backends/xnnpack/partition/configs.py
@@ -63,6 +63,7 @@ SUPPORTED_OPS = [
     exir_ops.edge.aten.avg_pool2d.default,
     exir_ops.edge.aten.leaky_relu.default,
     exir_ops.edge.aten.addmm.default,  # TODO(T163877189) add constraint for addmm
+    exir_ops.edge.aten.convolution.default,
 ]
 
 SUPPORTED_MODULES = [
@@ -99,6 +100,7 @@ SUPPORTED_QUANT_OPS = [
     exir_ops.edge.aten.t_copy.default,
     exir_ops.edge.aten.leaky_relu.default,
     exir_ops.edge.aten.addmm.default,  # TODO(T163877189) add constraint for addmm
+    exir_ops.edge.aten.convolution.default,
 ]
 
 SUPPORTED_IMPLICIT_Q_DQ_OP_NAMES_SET = {


### PR DESCRIPTION
Summary: EDSR has some convolutions in which they do not have source_partition Conv2d. We instead use target name to partition in order to fix this

Reviewed By: digantdesai

Differential Revision: D54355245


