### PR TITLE
Update state dict loading to strict

### DIFF
--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -647,7 +647,7 @@ the checkpoint format to avoid generating faulty models.
             self.model_ = simple_quantizer.convert_for_runtime()
 
         self.model_.load_state_dict(
-            checkpoint, strict=False
+            checkpoint, strict=True
         )  # self.model_ = Transformer(gptconf)
 
     def get_eager_model(self):


### PR DESCRIPTION
Summary:
Without strict mode it ignores when the statedict being loaded is different from the one in the model. This can result in silent failures that will be hard to debug. 

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D54398265


