### PR TITLE
Avoid converting k and v to q dtype

### DIFF
--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -296,10 +296,6 @@ class Attention(nn.Module):
         # tensor will be 2-dimensional, regarldess of the values of l & s
         mask = torch.squeeze(mask, [0, 1])
 
-        # FIXME: This should be so automatically! MKG
-        keys = keys.to(dtype=xq.dtype)
-        values = values.to(dtype=xq.dtype)
-
         output = F.scaled_dot_product_attention(
             xq, keys, values, attn_mask=mask, dropout_p=0.0
         )
@@ -672,8 +668,8 @@ the checkpoint format to avoid generating faulty models.
 
     def get_example_inputs_kvcache(self):
         cache_sizes = self.model_.get_cache_sizes()
-        cache_k = torch.zeros(cache_sizes)
-        cache_v = torch.zeros(cache_sizes)
+        cache_k = torch.zeros(cache_sizes, dtype=self.dtype)
+        cache_v = torch.zeros(cache_sizes, dtype=self.dtype)
         return (
             torch.tensor(
                 [[1]], dtype=torch.long


### PR DESCRIPTION
Summary:
We don't want to hard code k and v into q's dtype, instead we should make sure they are always the same before feeding into sdpa.

The problem was due to dtype mismatch between the kv cache used for tracing and the actual weights. This happens in the fp16 flow. After we convert the whole model to fp16, we still use fp32 kv cache tensors for tracing and that's causes the dtype mismatch issue.

This diff changes the logic to be using the same dtype as the weights, for kv cache during tracing

Differential Revision: D54426672


