### PR TITLE
Quantization support for groupwise embedding, various fp16 support

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -426,6 +426,9 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
     if builder.dtype == DType.fp16:
         modelname = f"{modelname}_h"
 
+    if args.use_kv_cache:
+        modelname = f"{modelname}_kv"
+
     builder.save_to_pte(modelname)
     output_file = f"{builder.output_dir}/{modelname}.pte"
 

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -424,7 +424,7 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
         generate_memory_trace(builder.export_program, "memory_profile.json")
 
     if builder.dtype == DType.fp16:
-        modelname = f"{modelname}_h"
+        modelname = f"{modelname}_fp16"
 
     if args.use_kv_cache:
         modelname = f"{modelname}_kv"

--- a/exir/backend/backend_api.py
+++ b/exir/backend/backend_api.py
@@ -332,7 +332,7 @@ def _(
     Returns:
         ExportedProgram: The input program, with some portions targeted for delegation.
     """
-    copied_edge_program = copy.deepcopy(edge_program)
+    copied_edge_program = copy.copy(edge_program)  # MKG: deepcopy
     partitioner_result = partitioner_instance(copied_edge_program)
     tagged_exported_program = partitioner_result.tagged_exported_program
 

--- a/kernels/quantized/cpu/op_embedding.cpp
+++ b/kernels/quantized/cpu/op_embedding.cpp
@@ -54,12 +54,14 @@ void check_embedding_byte_args(
     if (weight_scales.dim() == 2) {
       auto num_groups = weight_scales.size(1);
       auto remainder = weight.size(1) % num_groups;
+#if 0 // handle a partial last group
       ET_CHECK_MSG(
           remainder == 0,
           "Number of groups must divide weight.size(1)=%zd"
           ", but got # of groups = %zd",
           weight.size(1),
           num_groups);
+#endif // handle a partial last group
     }
   }
 


### PR DESCRIPTION
Summary:
Quantization support for groupwise embedding, various fp16 support.

1 - Add support for dequantizing groupwise quantization in `dequantize_per_channel`
2 - Allowed fp16 in various places to move forward towards using fp16 in xnnpack

Differential Revision: D54454162
