### PR TITLE
Qualcomm AI Engine Direct - Implement sdk profiler and intergrate with Qnn profiler

### DIFF
--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -131,6 +131,7 @@ add_library(qnn_implementation STATIC)
 add_library(qnn_sys_function_interface INTERFACE)
 add_library(qnn_sys_implementation STATIC)
 add_library(qnn_logger STATIC)
+add_library(qnn_profiler STATIC)
 add_library(qnn_device STATIC)
 add_library(qnn_context STATIC)
 add_library(qnn_backend_cache STATIC)
@@ -179,6 +180,10 @@ target_link_libraries(qnn_executorch_logging
     PRIVATE
     qnn_schema
 )
+target_link_libraries(qnn_profiler
+    PRIVATE
+    qnn_executorch_logging
+)
 target_link_libraries(qnn_logger
     PRIVATE
     qnn_implementation
@@ -213,6 +218,7 @@ target_link_libraries(qnn_graph
     qnn_executorch_logging
     qnn_implementation
     qnn_context
+    qnn_profiler
 )
 target_link_libraries(qnn_factory
     PUBLIC
@@ -248,6 +254,12 @@ target_link_libraries(utils
 # add linker option
 #
 target_link_options_shared_lib(qnn_executorch_backend)
+
+#
+# add compile option
+#
+target_compile_options(executorch PUBLIC -DET_EVENT_TRACER_ENABLED)
+
 
 #
 # add sources

--- a/backends/qualcomm/passes/i64_to_i32.py
+++ b/backends/qualcomm/passes/i64_to_i32.py
@@ -30,7 +30,7 @@ class I64toI32(ExportPass):
             )
         else:
             if meta_val.dtype == torch.int64:
-                node.meta["val"] = meta_val.to(torch.int32)
+                node.meta["val"] = meta_val.to(torch.float)
 
     def _cast_to_int32(self, graph_module: torch.fx.GraphModule):
         for n in graph_module.graph.nodes:

--- a/backends/qualcomm/qnn_preprocess.py
+++ b/backends/qualcomm/qnn_preprocess.py
@@ -89,5 +89,7 @@ class QnnBackend(BackendDetails):
         )
         assert len(qnn_context_binary) != 0, "Failed to generate Qnn context binary."
         qnn_manager.Destroy()
-
-        return PreprocessResult(bytes(qnn_context_binary))
+        # For now, debug_handle_map is not used by QNN ExecuTorch
+        return PreprocessResult(
+            processed_bytes=bytes(qnn_context_binary), debug_handle_map={}
+        )

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
@@ -176,7 +176,7 @@ Result<DelegateHandle*> QnnExecuTorchBackend::init(
 }
 
 Error QnnExecuTorchBackend::execute(
-    __ET_UNUSED BackendExecutionContext& context,
+    BackendExecutionContext& context,
     DelegateHandle* handle,
     EValue** args) const {
   QnnManager* qnn_manager = static_cast<QnnManager*>(handle);
@@ -211,6 +211,11 @@ Error QnnExecuTorchBackend::execute(
           Error::Ok,
       Internal,
       "Fail to execute graph");
+  ET_CHECK_OR_RETURN_ERROR(
+      qnn_manager->ProfileExecuteData(context.event_tracer()) == Error::Ok,
+      Internal,
+      "Fail to profile graph");
+
   return Error::Ok;
 }
 

--- a/backends/qualcomm/runtime/QnnManager.cpp
+++ b/backends/qualcomm/runtime/QnnManager.cpp
@@ -48,6 +48,9 @@ QnnManager::QnnManager(
     QNN_EXECUTORCH_LOG_INFO(
         "log_level: %s", EnumNameQnnExecuTorchLogLevel(options_->log_level()));
     QNN_EXECUTORCH_LOG_INFO(
+        "profile_level: %s",
+        EnumNameQnnExecuTorchProfileLevel(options_->profile_level()));
+    QNN_EXECUTORCH_LOG_INFO(
         "the size of qnn context binary: %d",
         qnn_executorch_context_binary.nbytes);
     QNN_EXECUTORCH_LOG_INFO(
@@ -191,6 +194,20 @@ Error QnnManager::Execute(
     }
   }
 
+  return Error::Ok;
+}
+
+Error QnnManager::ProfileExecuteData(EventTracer* event_tracer) {
+  Qnn_ErrorHandle_t error = QNN_SUCCESS;
+  if (options_->profile_level() != QnnExecuTorchProfileLevel::kProfileOff) {
+    error =
+        backend_params_ptr_->qnn_graph_ptr_->ProfileExecuteData(event_tracer);
+    if (error != QNN_SUCCESS) {
+      QNN_EXECUTORCH_LOG_ERROR(
+          " Failed to profile. Error %d", QNN_GET_ERROR_CODE(error));
+      return Error::Internal;
+    }
+  }
   return Error::Ok;
 }
 

--- a/backends/qualcomm/runtime/QnnManager.h
+++ b/backends/qualcomm/runtime/QnnManager.h
@@ -38,6 +38,8 @@ class QnnManager {
       const std::vector<Qnn_Tensor_t>& input_tensor_structs,
       std::vector<Qnn_Tensor_t>& output_tensor_structs);
 
+  Error ProfileExecuteData(EventTracer* event_tracer);
+
   void Destroy();
 
   bool IsAvailable();

--- a/backends/qualcomm/runtime/backends/CMakeLists.txt
+++ b/backends/qualcomm/runtime/backends/CMakeLists.txt
@@ -41,6 +41,13 @@ target_sources(qnn_logger
     ${CMAKE_CURRENT_LIST_DIR}/QnnLogger.cpp
 )
 
+# qnn_profiler
+target_sources(qnn_profiler
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/QnnProfiler.h
+    ${CMAKE_CURRENT_LIST_DIR}/QnnProfiler.cpp
+)
+
 # qnn_device
 set(HOST_ARCHITECTURE
     ${CMAKE_CURRENT_LIST_DIR}/htpbackend/${CMAKE_SYSTEM_PROCESSOR}

--- a/backends/qualcomm/runtime/backends/QnnBackendCommon.h
+++ b/backends/qualcomm/runtime/backends/QnnBackendCommon.h
@@ -27,6 +27,10 @@ class QnnBackend {
       : handle_(nullptr), implementation_(implementation), logger_(logger) {}
 
   virtual ~QnnBackend();
+  virtual bool IsProfileEventTypeParentOfNodeTime(
+      QnnProfile_EventType_t /*event_type*/) {
+    return false;
+  }
 
   Error Configure();
 

--- a/backends/qualcomm/runtime/backends/QnnBackendFactory.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendFactory.cpp
@@ -63,7 +63,9 @@ std::unique_ptr<BackendConfigParameters> QnnBackendFactory::Create(
 
       backend_params->qnn_graph_ptr_ = std::make_unique<HtpGraph>(
           implementation,
+          backend_params->qnn_backend_ptr_.get(),
           backend_params->qnn_context_ptr_.get(),
+          options->profile_level(),
           options->graph_name()->str(),
           options->soc_info(),
           htp_options);

--- a/backends/qualcomm/runtime/backends/QnnGraphCommon.cpp
+++ b/backends/qualcomm/runtime/backends/QnnGraphCommon.cpp
@@ -51,8 +51,24 @@ Error QnnGraph::Configure() {
     return Error::Internal;
   }
 
+  // The profiler needs to be created after the backend is created.
+  profile_ =
+      std::make_unique<QnnProfile>(implementation_, backend_, profile_level_);
   return Error::Ok;
 }
+
+Qnn_ErrorHandle_t QnnGraph::GraphExecute(
+    const std::vector<Qnn_Tensor_t>& input_tensor_structs,
+    std::vector<Qnn_Tensor_t>& output_tensor_structs) {
+  return implementation_.GetQnnInterface().qnn_graph_execute(
+      handle_,
+      input_tensor_structs.data(),
+      input_tensor_structs.size(),
+      output_tensor_structs.data(),
+      output_tensor_structs.size(),
+      profile_->GetHandle(),
+      /*signalHandle=*/nullptr);
+};
 
 Error QnnGraph::EnsureTensorInQnnGraph(
     const std::shared_ptr<TensorWrapper>& tensor_wrapper) {

--- a/backends/qualcomm/runtime/backends/QnnProfiler.cpp
+++ b/backends/qualcomm/runtime/backends/QnnProfiler.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/qualcomm/runtime/backends/QnnProfiler.h>
+#include <iostream>
+
+namespace torch {
+namespace executor {
+namespace qnn {
+
+QnnProfile::QnnProfile(
+    const QnnImplementation& implementation,
+    QnnBackend* backend,
+    const QnnExecuTorchProfileLevel& profile_level)
+    : handle_(nullptr), implementation_(implementation), backend_(backend) {
+  if (profile_level != QnnExecuTorchProfileLevel::kProfileOff) {
+    const QnnInterface& qnn_interface = implementation_.GetQnnInterface();
+    Qnn_ErrorHandle_t error = qnn_interface.qnn_profile_create(
+        backend_->GetHandle(), static_cast<int>(profile_level), &handle_);
+    if (error != QNN_SUCCESS) {
+      QNN_EXECUTORCH_LOG_WARN(
+          "Failed to create profile_handle for backend "
+          " %u, error=%d",
+          qnn_interface.GetBackendId(),
+          QNN_GET_ERROR_CODE(error));
+
+      // ignore error and continue to create backend handle...
+      handle_ = nullptr;
+    }
+  }
+}
+
+Qnn_ErrorHandle_t QnnProfile::ProfileData(EventTracer* event_tracer) {
+  const QnnInterface& qnn_interface = implementation_.GetQnnInterface();
+  const QnnProfile_EventId_t* events_ptr = nullptr;
+  const QnnProfile_EventId_t* sub_events_ptr = nullptr;
+  std::uint32_t num_events = 0;
+  std::uint32_t num_sub_events = 0;
+  Qnn_ErrorHandle_t error =
+      qnn_interface.qnn_profile_get_events(handle_, &events_ptr, &num_events);
+  if (error != QNN_SUCCESS) {
+    QNN_EXECUTORCH_LOG_ERROR(
+        "ProfileData failed to get events: %d", QNN_GET_ERROR_CODE(error));
+    return error;
+  }
+  QnnProfile_EventData_t event_data;
+  for (std::uint32_t i = 0; i < num_events; ++i) {
+    error =
+        qnn_interface.qnn_profile_get_event_data(events_ptr[i], &event_data);
+    if (error != QNN_SUCCESS) {
+      QNN_EXECUTORCH_LOG_ERROR(
+          "ProfileData failed to get event data "
+          "for event %d: %d",
+          i,
+          QNN_GET_ERROR_CODE(error));
+      return error;
+    }
+    // Check an event's sub events only if it relates to graph execution time
+    // (and its sub events are the individual op executions):
+    if (backend_->IsProfileEventTypeParentOfNodeTime(event_data.type)) {
+      error = qnn_interface.qnn_profile_get_sub_events(
+          events_ptr[i], &sub_events_ptr, &num_sub_events);
+      if (error != QNN_SUCCESS) {
+        QNN_EXECUTORCH_LOG_ERROR(
+            "ProfileData failed to get sub events "
+            "for event %d: %d",
+            i,
+            QNN_GET_ERROR_CODE(error));
+        return error;
+      }
+      QnnProfile_EventData_t sub_event_data;
+      for (std::uint32_t j = 0; j < num_sub_events; ++j) {
+        error = qnn_interface.qnn_profile_get_event_data(
+            sub_events_ptr[j], &sub_event_data);
+        if (error != QNN_SUCCESS) {
+          QNN_EXECUTORCH_LOG_ERROR(
+              "ProfileData failed to get sub "
+              "event data for sub event %d of event %d: %d",
+              j,
+              i,
+              QNN_GET_ERROR_CODE(error));
+          return error;
+        }
+        if (sub_event_data.type == QNN_PROFILE_EVENTTYPE_NODE &&
+            (sub_event_data.unit == QNN_PROFILE_EVENTUNIT_MICROSEC ||
+             sub_event_data.unit == QNN_PROFILE_EVENTUNIT_CYCLES)) {
+          torch::executor::event_tracer_log_profiling_delegate(
+              event_tracer,
+              sub_event_data.identifier,
+              /*delegate_debug_id=*/
+              static_cast<torch::executor::DebugHandle>(-1),
+              0,
+              sub_event_data.value);
+        }
+      }
+    }
+  }
+  return error;
+}
+
+QnnProfile::~QnnProfile() {
+  const QnnInterface& qnn_interface = implementation_.GetQnnInterface();
+  if (handle_ != nullptr) {
+    Qnn_ErrorHandle_t error = qnn_interface.qnn_profile_free(handle_);
+    if (error != QNN_SUCCESS) {
+      QNN_EXECUTORCH_LOG_ERROR(
+          "Failed to free QNN profile_handle. Backend "
+          "ID %u, error %d",
+          qnn_interface.GetBackendId(),
+          QNN_GET_ERROR_CODE(error));
+    }
+    handle_ = nullptr;
+  }
+}
+} // namespace qnn
+} // namespace executor
+} // namespace torch

--- a/backends/qualcomm/runtime/backends/QnnProfiler.h
+++ b/backends/qualcomm/runtime/backends/QnnProfiler.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <executorch/backends/qualcomm/runtime/QnnExecuTorch.h>
+#include <executorch/backends/qualcomm/runtime/backends/QnnBackendCommon.h>
+#include <executorch/backends/qualcomm/runtime/backends/QnnImplementation.h>
+#include <executorch/runtime/core/event_tracer_hooks_delegate.h>
+#include "QnnProfile.h"
+namespace torch {
+namespace executor {
+namespace qnn {
+
+class QnnProfile {
+ public:
+  explicit QnnProfile(
+      const QnnImplementation& implementation,
+      QnnBackend* backend,
+      const QnnExecuTorchProfileLevel& profile_level);
+  ~QnnProfile();
+  Qnn_ErrorHandle_t ProfileData(EventTracer* event_tracer);
+
+  Qnn_ProfileHandle_t GetHandle() {
+    return handle_;
+  }
+
+ private:
+  Qnn_ProfileHandle_t handle_;
+  const QnnImplementation& implementation_;
+  QnnBackend* backend_;
+};
+} // namespace qnn
+} // namespace executor
+} // namespace torch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpBackend.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpBackend.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <executorch/backends/qualcomm/runtime/backends/QnnBackendCommon.h>
+#include "HTP/QnnHtpProfile.h"
 namespace torch {
 namespace executor {
 namespace qnn {
@@ -16,6 +17,12 @@ class HtpBackend : public QnnBackend {
   HtpBackend(const QnnImplementation& implementation, QnnLogger* logger)
       : QnnBackend(implementation, logger) {}
   ~HtpBackend() {}
+
+  bool IsProfileEventTypeParentOfNodeTime(
+      QnnProfile_EventType_t event_type) override {
+    return (
+        event_type == QNN_HTP_PROFILE_EVENTTYPE_GRAPH_EXECUTE_ACCEL_TIME_CYCLE);
+  }
 
  protected:
   Error MakeConfig(std::vector<const QnnBackend_Config_t*>& config) override {

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpGraph.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpGraph.h
@@ -20,11 +20,13 @@ class HtpGraph : public QnnGraph {
  public:
   HtpGraph(
       const QnnImplementation& implementation,
+      QnnBackend* backend,
       QnnContext* context,
+      const QnnExecuTorchProfileLevel& profile_level,
       const std::string& graph_name,
       const SocInfo* soc_info,
       const QnnExecuTorchHtpBackendOptions* htp_options)
-      : QnnGraph(implementation, context, graph_name),
+      : QnnGraph(implementation, backend, context, profile_level, graph_name),
         qcom_target_soc_info_(soc_info),
         htp_options_(htp_options) {
     htp_graph_custom_config_ =

--- a/backends/qualcomm/scripts/build.sh
+++ b/backends/qualcomm/scripts/build.sh
@@ -66,16 +66,20 @@ if [ "$BUILD_AARCH64" = true ]; then
     fi
 
     cd $BUILD_ROOT
+    # If we build debug type, we need to change flatcc to flatcc_d
     cmake .. \
         -DCMAKE_INSTALL_PREFIX=$BUILD_ROOT \
         -DEXECUTORCH_BUILD_QNN=ON \
+        -DEXECUTORCH_BUILD_SDK=ON \
+        -DFLATCC_TEST=OFF \
+        -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \
         -DQNN_SDK_ROOT=$QNN_SDK_ROOT \
         -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
         -DANDROID_ABI='arm64-v8a' \
         -DANDROID_NATIVE_API_LEVEL=23 \
         -DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE \
         -DBUCK2=$BUCK2 \
-	-B$BUILD_ROOT
+        -B$BUILD_ROOT
 
     cmake --build $BUILD_ROOT -j16 --target install
 

--- a/backends/qualcomm/serialization/qnn_compile_spec_schema.py
+++ b/backends/qualcomm/serialization/qnn_compile_spec_schema.py
@@ -108,6 +108,13 @@ class QnnExecuTorchLogLevel(IntEnum):
     kLogLevelDebug = 5
 
 
+@unique
+class QnnExecuTorchProfileLevel(IntEnum):
+    kProfileOff = 0
+    kProfileBasic = 1
+    kProfileDetailed = 2
+
+
 @dataclass
 class QnnExecuTorchBackendOptions:
     backend_type: QnnExecuTorchBackendType
@@ -123,3 +130,4 @@ class QnnExecuTorchOptions:
     log_level: QnnExecuTorchLogLevel = QnnExecuTorchLogLevel.kLogOff
     online_prepare: bool = False
     tensor_dump_output_path: str = ""
+    profile_level: QnnExecuTorchProfileLevel = QnnExecuTorchProfileLevel.kProfileOff

--- a/backends/qualcomm/serialization/schema.fbs
+++ b/backends/qualcomm/serialization/schema.fbs
@@ -129,6 +129,13 @@ enum QnnExecuTorchLogLevel: int {
   kLogLevelDebug,
 }
 
+/// Profiling level of the delegate and QNN backend.
+enum QnnExecuTorchProfileLevel: int {
+  kProfileOff = 0,
+  kProfileBasic,
+  kProfileDetailed,
+}
+
 /// QNN backends currently supported
 table QnnExecuTorchBackendOptions {
   /// The backend QNN library to open and execute the graph with. This is a
@@ -162,6 +169,9 @@ table QnnExecuTorchOptions {
   /// In ALL cases, we don't recommend to set this option.
   /// This option exist just for debugging some accuracy issues.
   tensor_dump_output_path:string;
+
+  /// Profiling level of the delegate and the backend. Default is off.
+  profile_level:QnnExecuTorchProfileLevel;
 }
 
 root_type QnnExecuTorchOptions;

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -51,6 +51,7 @@ class TestQNNFloatingPointOperator(TestQNN):
             saver=False,
             online_prepare=TestQNN.online_prepare,
             tensor_dump_output_path="",
+            profile=TestQNN.enable_profile,
         )
 
     def test_qnn_backend_arange(self):
@@ -383,6 +384,7 @@ class TestQNNFloatingPointModel(TestQNN):
             saver=False,
             online_prepare=TestQNN.online_prepare,
             tensor_dump_output_path="",
+            profile=TestQNN.enable_profile,
         )
 
     def test_qnn_backend_conv1d_relu_log_softmax(self):
@@ -477,6 +479,7 @@ class TestQNNQuantizedOperator(TestQNN):
             saver=False,
             online_prepare=TestQNN.online_prepare,
             tensor_dump_output_path="",
+            profile=TestQNN.enable_profile,
         )
 
     def test_qnn_backend_arange(self):
@@ -856,6 +859,7 @@ class TestQNNQuantizedModel(TestQNN):
             saver=False,
             online_prepare=TestQNN.online_prepare,
             tensor_dump_output_path="",
+            profile=TestQNN.enable_profile,
         )
 
     def test_qnn_backend_conv1d_relu_log_softmax(self):
@@ -1034,6 +1038,23 @@ class TestQNNFloatingPointUtils(TestQNN):
         exec_prog = edge_prog.to_executorch()
         self.verify_output(module.get_reference_module(), sample_input, exec_prog)
 
+    def test_qnn_backend_profile_op(self):
+        TestQNN.enable_profile = True
+        backend_options = generate_htp_compiler_spec(use_fp16=True)
+        TestQNN.compiler_specs = generate_qnn_executorch_compiler_spec(
+            soc_model=self.arch_table[TestQNN.model],
+            backend_options=backend_options,
+            profile=True,
+        )
+        module = SimpleModel()  # noqa: F405
+        sample_input = (torch.ones(1, 32, 28, 28), torch.ones(1, 32, 28, 28))
+        self.lower_module_and_test_output(
+            module,
+            sample_input,
+            expected_partitions=1,
+            expected_profile_events=25,
+        )
+
 
 class TestQNNQuantizedUtils(TestQNN):
     # TODO: refactor to support different backends
@@ -1117,6 +1138,24 @@ class TestQNNQuantizedUtils(TestQNN):
         canonicalize_program(edge_prog.exported_program)
         exec_prog = edge_prog.to_executorch()
         self.verify_output(module.get_reference_module(), sample_input, exec_prog)
+
+    def test_qnn_backend_profile_op(self):
+        TestQNN.enable_profile = True
+        backend_options = generate_htp_compiler_spec(use_fp16=False)
+        TestQNN.compiler_specs = generate_qnn_executorch_compiler_spec(
+            soc_model=self.arch_table[TestQNN.model],
+            backend_options=backend_options,
+            profile=True,
+        )
+        module = SimpleModel()  # noqa: F405
+        sample_input = (torch.ones(1, 32, 28, 28), torch.ones(1, 32, 28, 28))
+        module = self.get_qdq_module(module, sample_input)
+        self.lower_module_and_test_output(
+            module,
+            sample_input,
+            expected_partitions=1,
+            expected_profile_events=26,
+        )
 
 
 class TestExampleScript(TestQNN):
@@ -1500,6 +1539,12 @@ def setup_environment():
         action="store_true",
     )
     parser.add_argument(
+        "-P",
+        "--enable_profile",
+        help="Profile the performance of each operator with kProfileDetailed profile level",
+        action="store_true",
+    )
+    parser.add_argument(
         "-e",
         "--error_only",
         help="Emit log only when error happened",
@@ -1516,6 +1561,7 @@ def setup_environment():
     TestQNN.image_dataset = args.image_dataset
     TestQNN.pretrained_weight = args.pretrained_weight
     TestQNN.online_prepare = args.online_prepare
+    TestQNN.enable_profile = args.enable_profile
     TestQNN.error_only = args.error_only
     return sys.argv[:1] + ns_args
 

--- a/backends/qualcomm/tests/utils.py
+++ b/backends/qualcomm/tests/utils.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import collections
+import copy
 import os
 import tempfile
 import unittest
@@ -30,6 +31,8 @@ from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 from executorch.exir.program._program import ExecutorchProgram
+from executorch.sdk import generate_etrecord
+from executorch.sdk.inspector import Inspector
 from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
 
 
@@ -54,6 +57,7 @@ class TestQNN(unittest.TestCase):
     artifact_dir: Literal = ""
     image_dataset: Literal = ""
     pretrained_weight: Literal = ""
+    enable_profile: bool = False
     online_prepare: bool = False
 
     def _assert_outputs_equal(self, model_output, ref_output):
@@ -103,6 +107,8 @@ class TestQNN(unittest.TestCase):
         module: torch.nn.Module,
         sample_inputs: Tuple[torch.Tensor],
         executorch_prog: ExecutorchProgram,
+        etrecord_path: str,
+        expected_profile_events: int,
     ):
         with tempfile.TemporaryDirectory() as tmp_dir:
             (
@@ -118,6 +124,7 @@ class TestQNN(unittest.TestCase):
 
             device_output_dir = f"{tmp_dir}/outputs"
             device_outputs = []
+            etdump_path = f"{tmp_dir}/etdump.etdp"
 
             def post_process():
                 for i, f in enumerate(os.listdir(device_output_dir)):
@@ -125,6 +132,12 @@ class TestQNN(unittest.TestCase):
                     output = np.fromfile(filename, dtype=ref_outputs[i].numpy().dtype)
                     output = torch.from_numpy(output).reshape(ref_outputs[i].shape)
                     device_outputs.append(output)
+
+            def validate_profile():
+                inspector = Inspector(etdump_path=etdump_path, etrecord=etrecord_path)
+                self.assertTrue(
+                    len(inspector.to_dataframe().index) == expected_profile_events
+                )
 
             adb = SimpleADB(
                 qnn_sdk=os.getenv("QNN_SDK_ROOT"),
@@ -141,11 +154,15 @@ class TestQNN(unittest.TestCase):
             adb.pull(output_path=tmp_dir, callback=post_process)
             self._assert_outputs_equal(device_outputs, ref_outputs)
 
+            if expected_profile_events != -1:
+                adb.pull_etdump(etdump_path, callback=validate_profile)
+
     def lower_module_and_test_output(
         self,
         module: torch.nn.Module,
         sample_inputs: Tuple[torch.Tensor],
         expected_partitions: int = 1,
+        expected_profile_events: int = -1,
         assert_output_equal: bool = True,
         skip_node_id_set: set = None,
         skip_node_op_set: set = None,
@@ -154,6 +171,10 @@ class TestQNN(unittest.TestCase):
             self.compiler_specs, skip_node_id_set, skip_node_op_set
         )
         delegated_program = capture_program(module, sample_inputs)
+
+        # this is needed for the ETRecord as lowering modifies the graph in-place
+        edge_copy = copy.deepcopy(delegated_program)
+
         delegated_program.exported_program = to_backend(
             delegated_program.exported_program, qnn_partitioner
         )
@@ -169,9 +190,15 @@ class TestQNN(unittest.TestCase):
                 QnnBackend.__name__,
             )
 
+        etrecord_path = "etrecord.bin"
+        if self.enable_profile:
+            generate_etrecord(etrecord_path, edge_copy, exec_prog)
+
         # Check numerics
-        if assert_output_equal:
-            self.verify_output(module, sample_inputs, exec_prog)
+        if assert_output_equal or expected_profile_events != -1:
+            self.verify_output(
+                module, sample_inputs, exec_prog, etrecord_path, expected_profile_events
+            )
 
     def get_qdq_module(
         self,

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -43,6 +43,7 @@ from executorch.backends.qualcomm.serialization.qnn_compile_spec_schema import (
     QnnExecuTorchHtpPrecision,
     QnnExecuTorchLogLevel,
     QnnExecuTorchOptions,
+    QnnExecuTorchProfileLevel,
 )
 from executorch.backends.qualcomm.serialization.qnn_compile_spec_serialize import (
     convert_to_flatbuffer,
@@ -186,6 +187,7 @@ def generate_qnn_executorch_compiler_spec(
     saver: bool = False,
     online_prepare: bool = False,
     tensor_dump_output_path: str = "",
+    profile: bool = False,
 ) -> List[CompileSpec]:
     """
     Helper function generating compiler specs for Qualcomm AI Engine Direct
@@ -208,6 +210,9 @@ def generate_qnn_executorch_compiler_spec(
             outputs of each OP there in runtime. In ALL cases,
             we don't recommend to set this option. This option exist just
             for debugging some accuracy issues.
+        profile: Enable profile the performance of per operator.
+            Note that for now only support kProfileDetailed to
+            profile the performance of each operator with cycle unit.
 
     Returns:
         List[CompileSpec]: Compiler specs for Qualcomm AI Engine Direct.
@@ -235,6 +240,13 @@ def generate_qnn_executorch_compiler_spec(
 
     if len(tensor_dump_output_path.strip()) != 0:
         qnn_executorch_options.tensor_dump_output_path = tensor_dump_output_path
+
+    if profile:
+        qnn_executorch_options.profile_level = (
+            QnnExecuTorchProfileLevel.kProfileDetailed
+        )
+    else:
+        qnn_executorch_options.profile_level = QnnExecuTorchProfileLevel.kProfileOff
 
     if (
         online_prepare

--- a/examples/qualcomm/CMakeLists.txt
+++ b/examples/qualcomm/CMakeLists.txt
@@ -23,9 +23,14 @@ if(NOT TORCH_ROOT)
   set(TORCH_ROOT ${EXECUTORCH_ROOT}/third-party/pytorch)
 endif()
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Find prebuilt libraries. executorch package should contain
 # portable_ops_lib, etdump, bundled_program.
 find_package(executorch CONFIG REQUIRED)
+target_compile_options(executorch INTERFACE -DET_EVENT_TRACER_ENABLED)
 find_package(gflags REQUIRED)
 
 set(_common_compile_options -Wno-deprecated-declarations -fPIC)
@@ -56,6 +61,10 @@ generate_bindings_for_kernels(
   ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml ""
 )
 gen_operators_lib("full_portable_ops_lib" portable_kernels executorch)
+target_compile_options(full_portable_ops_lib
+    INTERFACE
+    -DET_EVENT_TRACER_ENABLED
+)
 target_include_directories(full_portable_ops_lib
     PUBLIC
     ${_common_include_directories}
@@ -88,6 +97,8 @@ target_include_directories(qnn_executor_runner
 target_link_libraries(qnn_executor_runner
     qnn_executorch_backend
     full_portable_ops_lib
+    etdump
+    ${FLATCC_LIB}
     gflags
 )
 target_compile_options(qnn_executor_runner

--- a/examples/qualcomm/scripts/utils.py
+++ b/examples/qualcomm/scripts/utils.py
@@ -52,6 +52,7 @@ class SimpleADB:
         self.host_id = host_id
         self.working_dir = Path(self.pte_path).parent.absolute()
         self.input_list_filename = "input_list.txt"
+        self.etdump_path = f"{self.workspace}/etdump.etdp"
         self.output_folder = f"{self.workspace}/outputs"
         arch_table = {
             "SM8650": "75",
@@ -118,6 +119,7 @@ class SimpleADB:
                 f"--model_path {os.path.basename(self.pte_path)}",
                 f"--output_folder_path {self.output_folder}",
                 f"--input_list_path {self.input_list_filename}",
+                f"--etdump_path {self.etdump_path}",
             ]
         )
         qnn_executor_runner_cmds = " ".join(
@@ -132,6 +134,11 @@ class SimpleADB:
 
     def pull(self, output_path, callback=None):
         self._adb(["pull", "-a", f"{self.output_folder}", output_path])
+        if callback:
+            callback()
+
+    def pull_etdump(self, output_path, callback=None):
+        self._adb(["pull", f"{self.etdump_path}", output_path])
         if callback:
             callback()
 

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -108,6 +108,9 @@ add_custom_command(
     ${CMAKE_SOURCE_DIR}/third-party/flatcc/bin/flatcc -cwr -o
     ${_program_schema__include_dir}/executorch/sdk/etdump
     ${_etdump_schema__srcs}
+  COMMAND
+    rm -f ${CMAKE_SOURCE_DIR}/third-party/flatcc/bin/*
+    ${CMAKE_SOURCE_DIR}/third-party/flatcc/lib/*
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/sdk
   DEPENDS flatcc_project
   COMMENT "Generating etdump headers"

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -108,6 +108,19 @@ add_custom_command(
     ${CMAKE_SOURCE_DIR}/third-party/flatcc/bin/flatcc -cwr -o
     ${_program_schema__include_dir}/executorch/sdk/etdump
     ${_etdump_schema__srcs}
+  # TODO(dbort): flatcc installs its files directly in its source directory
+  # instead of under CMAKE_BINARY_DIR, and it has no options to avoid
+  # doing this. We build flatcc twice in the executorch build: once to get
+  # the `flatcc` host commandline tool, and once to get the (potentially
+  # cross-compiled) target runtime library. The host build will put its outputs
+  # in the source tree, making the cross-compiling target build think that
+  # the outputs have already been built. It will then try to link against the
+  # host-architecture libraries, failing when cross-compiling. To work around
+  # this, delete the host outputs after running this command (which only runs
+  # when setting up the cmake files, not when actually building). This leaves
+  # room for the target build to put its own files in the source tree. We should
+  # try to remove this hack, ideally by submitting an upstream PR that adds an
+  # option to change the installation location.
   COMMAND
     rm -f ${CMAKE_SOURCE_DIR}/third-party/flatcc/bin/*
     ${CMAKE_SOURCE_DIR}/third-party/flatcc/lib/*


### PR DESCRIPTION
Summary:
- Implement Qnn Profiler for htp backend
    For now, only support kProfileDetailed to profile the performance of each operator with cycle unit.
    Follow up item: Add more qnn profile item
- Intergrated with sdk profiler
- Add the argument etdump_path to dump etdump which analyzes the contents by INSPECTOR  in qnn_executorch_runner
- Add unit test to test profile
- Add export example to generate etrecord

Reproduce commands:
```
python3 backends/qualcomm/tests/test_qnn_delegate.py TestQNNFloatingPointOperator.test_qnn_backend_conv2d -b /local3/mnt/workspace/shewu/executorch/executorch_shewu/executorch/build_android -s $LANAI1 -H $TWL1 -m SM8650 -r /local3/mnt/workspace/shewu/executorch/executorch_shewu/executorch -a /local3/mnt/workspace/shewu/executorch/unit_test -i /local3/mnt/workspace/shewu/executorch/models/data/ImageNet-Mini/images --enable_profile
# Pull the EtDump
adb pull  /data/local/tmp/qnn_executorch_test/etdump.etdp .
# Run inspector to produce the following table
python3 -m sdk.inspector.inspector_cli --etdump_path etdump.etdp --etrecord_path etrecord.bin
```
```
╒════╤════════════════════╤══════════════════════════════════════════════╤═════════════╤═════════════╤═════════════╤═════════════╤═════════════╤═════════════╤════════════╤═══════════════════╤═════════════════════════╕
│    │ event_block_name   │ event_name                                   │    p10 (ms) │    p50 (ms) │    p90 (ms) │    avg (ms) │    min (ms) │    max (ms) │ op_types   │ is_delegated_op   │ delegate_backend_name   │
╞════╪════════════════════╪══════════════════════════════════════════════╪═════════════╪═════════════╪═════════════╪═════════════╪═════════════╪═════════════╪════════════╪═══════════════════╪═════════════════════════╡
│  0 │ Default            │ Method::init                                 │   123.898   │   123.898   │   123.898   │   123.898   │   123.898   │   123.898   │ []         │ False             │                         │
├────┼────────────────────┼──────────────────────────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼────────────┼───────────────────┼─────────────────────────┤
│  1 │ Default            │ Program::load_method                         │   123.926   │   123.926   │   123.926   │   123.926   │   123.926   │   123.926   │ []         │ False             │                         │
├────┼────────────────────┼──────────────────────────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼────────────┼───────────────────┼─────────────────────────┤
│  2 │ Execute            │ Input OpId_2 (cycles)                        │  4018       │  4018       │  4018       │  4018       │  4018       │  4018       │ []         │ True              │ QnnBackend              │
├────┼────────────────────┼──────────────────────────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼────────────┼───────────────────┼─────────────────────────┤
│  3 │ Execute            │ aten_permute_copy_default:OpId_17 (cycles)   │ 16765       │ 16765       │ 16765       │ 16765       │ 16765       │ 16765       │ []         │ True              │ QnnBackend              │
├────┼────────────────────┼──────────────────────────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼────────────┼───────────────────┼─────────────────────────┤
│  4 │ Execute            │ aten_convolution_default:OpId_23 (cycles)    │ 12768       │ 12768       │ 12768       │ 12768       │ 12768       │ 12768       │ []         │ True              │ QnnBackend              │
├────┼────────────────────┼──────────────────────────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼────────────┼───────────────────┼─────────────────────────┤
│  5 │ Execute            │ aten_convolution_default_1:OpId_30 (cycles)  │  9439       │  9439       │  9439       │  9439       │  9439       │  9439       │ []         │ True              │ QnnBackend              │
├────┼────────────────────┼──────────────────────────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼────────────┼───────────────────┼─────────────────────────┤
│  6 │ Execute            │ aten_permute_copy_default_1:OpId_33 (cycles) │  2551       │  2551       │  2551       │  2551       │  2551       │  2551       │ []         │ True              │ QnnBackend              │
├────┼────────────────────┼──────────────────────────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼────────────┼───────────────────┼─────────────────────────┤
│  7 │ Execute            │ OpId_0 (cycles)                              │     0       │     0       │     0       │     0       │     0       │     0       │ []         │ True              │ QnnBackend              │
├────┼────────────────────┼──────────────────────────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼────────────┼───────────────────┼─────────────────────────┤
│  8 │ Execute            │ Output OpId_3 (cycles)                       │  3054       │  3054       │  3054       │  3054       │  3054       │  3054       │ []         │ True              │ QnnBackend              │
├────┼────────────────────┼──────────────────────────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼────────────┼───────────────────┼─────────────────────────┤
│  9 │ Execute            │ DELEGATE_CALL                                │     1.17151 │     1.17151 │     1.17151 │     1.17151 │     1.17151 │     1.17151 │ []         │ False             │ QnnBackend              │
├────┼────────────────────┼──────────────────────────────────────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┼────────────┼───────────────────┼─────────────────────────┤
│ 10 │ Execute            │ Method::execute                              │     1.18318 │     1.18318 │     1.18318 │     1.18318 │     1.18318 │     1.18318 │ []         │ False             │                         │
╘════╧════════════════════╧══════════════════════════════════════════════╧═════════════╧═════════════╧═════════════╧═════════════╧═════════════╧═════════════╧════════════╧═══════════════════╧═════════════════════════╛


```