### PR TITLE
Update black linter

### DIFF
--- a/backends/apple/mps/operators/node_visitor.py
+++ b/backends/apple/mps/operators/node_visitor.py
@@ -235,7 +235,6 @@ class NodeVisitor:
     def get_serialized_id(
         self, node: Union[torch.fx.Node, float, int], mps_graph: MPSGraph
     ) -> int:
-
         """
         Map a tensor to a unique id. If the tensor was already mapped, return
         the existent id.

--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -128,9 +128,11 @@ class ArmBackend(BackendDetails):
                 # Add output to TOSA graph
                 tosa_graph.currRegion.currBasicBlock.addTensor(
                     output.name,
-                    inputs[0].shape
-                    if is_permute_node_before_addmm(node)
-                    else output.shape,
+                    (
+                        inputs[0].shape
+                        if is_permute_node_before_addmm(node)
+                        else output.shape
+                    ),
                     ts.DType.INT8 if is_quant_node(node) else output.dtype,
                 )
 

--- a/backends/arm/arm_vela.py
+++ b/backends/arm/arm_vela.py
@@ -12,6 +12,7 @@ from typing import List
 
 import numpy as np
 
+
 # Pack either input or output tensor block, compose the related arrays into
 # per-io structs to simplify runtime use.
 def vela_bin_pack_io(prefix, data):

--- a/backends/qualcomm/passes/decompose_scaled_dot_product_attention.py
+++ b/backends/qualcomm/passes/decompose_scaled_dot_product_attention.py
@@ -42,9 +42,9 @@ class DecomposeScaledDotProductAttention(ExportPass):
                     # In decomposed module, there are only input tensors for placeholder op.
                     for decomposed_node in decomposed_module.graph.nodes:
                         if decomposed_node.op == "placeholder":
-                            decomposed_node_to_subgraph_node[
-                                decomposed_node
-                            ] = name_to_input_tensor_map[decomposed_node.name]
+                            decomposed_node_to_subgraph_node[decomposed_node] = (
+                                name_to_input_tensor_map[decomposed_node.name]
+                            )
 
                         if decomposed_node.op == "output":
                             last_decomposed_node = decomposed_node.args[0]
@@ -76,9 +76,9 @@ class DecomposeScaledDotProductAttention(ExportPass):
                         subgraph_node.meta["source_fn_stack"] = [
                             (subgraph_node, subgraph_node.target)
                         ]
-                        decomposed_node_to_subgraph_node[
-                            decomposed_node
-                        ] = subgraph_node
+                        decomposed_node_to_subgraph_node[decomposed_node] = (
+                            subgraph_node
+                        )
 
                     graph.erase_node(node)
 

--- a/backends/qualcomm/passes/i64_to_i32.py
+++ b/backends/qualcomm/passes/i64_to_i32.py
@@ -21,9 +21,11 @@ class I64toI32(ExportPass):
         meta_val = node.meta["val"]
         if isinstance(meta_val, tuple):
             node.meta["val"] = (
-                fake_tensor.to(torch.int32)
-                if fake_tensor.dtype == torch.int64
-                else fake_tensor
+                (
+                    fake_tensor.to(torch.int32)
+                    if fake_tensor.dtype == torch.int64
+                    else fake_tensor
+                )
                 for fake_tensor in meta_val
             )
         else:

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -26,6 +26,7 @@ logging.basicConfig(level=logging.INFO, format=FORMAT)
 #       quantization step in our example. This will take the models
 #       from examples/models/ and quantize then export to delegate.
 
+
 # Two simple models
 class AddModule(torch.nn.Module):
     def __init__(self):

--- a/examples/models/llama2/quantize.py
+++ b/examples/models/llama2/quantize.py
@@ -64,7 +64,8 @@ def dynamically_quantize_per_channel(
                         with a final group of a size less than group size.
 
     Assumptions:
-        This function assumes symmetric quantization, axis ==0 and a dense memory format."""
+        This function assumes symmetric quantization, axis ==0 and a dense memory format.
+    """
 
     # assumes symmetric quantization
     # assumes axis == 0

--- a/exir/passes/_quant_patterns_and_replacements.py
+++ b/exir/passes/_quant_patterns_and_replacements.py
@@ -337,9 +337,9 @@ def _get_binary_op_patterns_and_replacements(
     ]
 
 
-def _get_binary_ops_patterns_and_replacements() -> List[
-    Tuple[Callable, Callable, List[Callable]]
-]:
+def _get_binary_ops_patterns_and_replacements() -> (
+    List[Tuple[Callable, Callable, List[Callable]]]
+):
 
     # TODO: replace qbinary op with the ops implemented in lean mode
     binary_op_to_qbinary_ops = {
@@ -360,9 +360,9 @@ def _get_binary_ops_patterns_and_replacements() -> List[
     return pattern_and_replacements
 
 
-def _get_reshape_patterns_and_replacements() -> List[
-    Tuple[Callable, Callable, List[Callable]]
-]:
+def _get_reshape_patterns_and_replacements() -> (
+    List[Tuple[Callable, Callable, List[Callable]]]
+):
     def pattern(
         x,
         arg0,
@@ -413,9 +413,9 @@ def _get_reshape_patterns_and_replacements() -> List[
     ]
 
 
-def _get_slice_patterns_and_replacements() -> List[
-    Tuple[Callable, Callable, List[Callable]]
-]:
+def _get_slice_patterns_and_replacements() -> (
+    List[Tuple[Callable, Callable, List[Callable]]]
+):
     def pattern(x, dim, start, end, x_scale, x_zero_point, x_qmin, x_qmax):
         x = torch.ops.quantized_decomposed.dequantize_per_tensor.default(
             x, x_scale, x_zero_point, x_qmin, x_qmax, torch.uint8
@@ -439,9 +439,9 @@ def _get_slice_patterns_and_replacements() -> List[
     ]
 
 
-def _get_embedding_ops_patterns_and_replacements() -> List[
-    Tuple[Callable, Callable, List[Callable]]
-]:
+def _get_embedding_ops_patterns_and_replacements() -> (
+    List[Tuple[Callable, Callable, List[Callable]]]
+):
     def get_pattern_and_replacement():
         @bind_pattern_to_op(quantized_decomposed_lib, "embedding_byte")
         def pattern(
@@ -616,9 +616,9 @@ n        return [(pattern, replacement, [])]
 """
 
 
-def get_quant_patterns_and_replacements() -> List[
-    Tuple[Callable, Callable, List[Callable]]
-]:
+def get_quant_patterns_and_replacements() -> (
+    List[Tuple[Callable, Callable, List[Callable]]]
+):
 
     return copy.copy(
         [

--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -1728,9 +1728,9 @@ class ExportedProgramDeserializer:
             symbol_name_to_range,
             res.names_to_symbols,
         )
-        model_opset_version: Optional[
-            Dict[str, int]
-        ] = serialized_artifact.exported_program.opset_version  # pyre-ignore
+        model_opset_version: Optional[Dict[str, int]] = (
+            serialized_artifact.exported_program.opset_version  # pyre-ignore
+        )
         self._validate_model_opset_version(model_opset_version)
 
         upgrader = GraphModuleOpUpgrader(

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -13,7 +13,7 @@ pycodestyle==2.10.0
 torchfix==0.1.1
 
 # UFMT
-black==22.12.0
+black==24.2.0
 ufmt==2.0.1
 usort==1.0.5
 


### PR DESCRIPTION
Summary:
Black linter is upgraded to v24.2.0 in fbsource. Let's also upgrade the OSS linter to match this to reduce inconsistency between internal linter and OSS linters.

https://fb.workplace.com/groups/pyfmt/posts/1391116614859184/?fbclid=IwAR1Gag0Bkq2OE_4EeH5XY_iOFgwF6VE-7OAr9kmHeyB3QzkfaGvsWWY3nCo

Differential Revision: D54487606


