### PR TITLE
Add as install req in examples/llama2

### DIFF
--- a/examples/models/llama2/install_requirements.sh
+++ b/examples/models/llama2/install_requirements.sh
@@ -7,4 +7,6 @@
 
 # Install snakeviz for cProfile flamegraph
 # Install sentencepiece for llama tokenizer
+# Install lm-eval for accuracy evaluation (v0.4+)
 pip install snakeviz sentencepiece
+pip install lm-eval


### PR DESCRIPTION
Summary: Adding lm-eval as a pip install requirement to enabled Evaluation

Differential Revision: D54497840


