### PR TITLE
[ET-VK] Set up Vulkan executor_runner

### DIFF
--- a/backends/vulkan/CMakeLists.txt
+++ b/backends/vulkan/CMakeLists.txt
@@ -95,27 +95,27 @@ target_link_libraries(vulkan_backend PRIVATE executorch)
 
 target_compile_options(vulkan_backend PRIVATE ${VULKAN_CXX_FLAGS})
 
-# This is required to ensure that vulkan_backend gets linked with --whole-archive since
-# backends are registered via static variables that would otherwise be discarded
+# This is required to ensure that vulkan_backend gets linked with
+# --whole-archive since backends are registered via static variables that would
+# otherwise be discarded
 target_link_options_shared_lib(vulkan_backend)
 
 # Executor Runner
 
 if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
-  set(vulkan_runner_srcs ${_executor_runner__srcs})
-  list(TRANSFORM vulkan_runner_srcs PREPEND "${EXECUTORCH_ROOT}/")
-  add_executable(vulkan_executor_runner ${vulkan_runner_srcs})
+  set(VULKAN_RUNNER_SRCS ${_executor_runner__srcs})
+  list(TRANSFORM VULKAN_RUNNER_SRCS PREPEND "${EXECUTORCH_ROOT}/")
+  add_executable(vulkan_executor_runner ${VULKAN_RUNNER_SRCS})
   target_link_libraries(vulkan_executor_runner ${_executor_runner_libs})
   target_link_libraries(vulkan_executor_runner vulkan_schema)
   target_link_libraries(vulkan_executor_runner vulkan_backend)
   target_compile_options(vulkan_executor_runner PUBLIC ${VULKAN_CXX_FLAGS})
 
-  add_library(vulkan_executor_runner_lib STATIC ${vulkan_runner_srcs})
+  add_library(vulkan_executor_runner_lib STATIC ${VULKAN_RUNNER_SRCS})
   target_link_libraries(vulkan_executor_runner_lib ${_executor_runner_libs})
   target_link_libraries(vulkan_executor_runner_lib vulkan_schema)
   target_link_libraries(vulkan_executor_runner_lib vulkan_backend)
-  target_compile_options(vulkan_executor_runner_lib
-                         PUBLIC ${VULKAN_CXX_FLAGS})
+  target_compile_options(vulkan_executor_runner_lib PUBLIC ${VULKAN_CXX_FLAGS})
 endif()
 
 # Test targets

--- a/backends/vulkan/CMakeLists.txt
+++ b/backends/vulkan/CMakeLists.txt
@@ -32,6 +32,9 @@ if(NOT FLATC_EXECUTABLE)
   set(FLATC_EXECUTABLE flatc)
 endif()
 
+# Include this file to access target_link_options_shared_lib
+include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+
 # ATen Vulkan Libs
 
 set(PYTORCH_PATH ${EXECUTORCH_ROOT}/third-party/pytorch)
@@ -91,6 +94,29 @@ target_link_libraries(vulkan_backend PRIVATE vulkan_schema)
 target_link_libraries(vulkan_backend PRIVATE executorch)
 
 target_compile_options(vulkan_backend PRIVATE ${VULKAN_CXX_FLAGS})
+
+# This is required to ensure that vulkan_backend gets linked with --whole-archive since
+# backends are registered via static variables that would otherwise be discarded
+target_link_options_shared_lib(vulkan_backend)
+
+# Executor Runner
+
+if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
+  set(vulkan_runner_srcs ${_executor_runner__srcs})
+  list(TRANSFORM vulkan_runner_srcs PREPEND "${EXECUTORCH_ROOT}/")
+  add_executable(vulkan_executor_runner ${vulkan_runner_srcs})
+  target_link_libraries(vulkan_executor_runner ${_executor_runner_libs})
+  target_link_libraries(vulkan_executor_runner vulkan_schema)
+  target_link_libraries(vulkan_executor_runner vulkan_backend)
+  target_compile_options(vulkan_executor_runner PUBLIC ${VULKAN_CXX_FLAGS})
+
+  add_library(vulkan_executor_runner_lib STATIC ${vulkan_runner_srcs})
+  target_link_libraries(vulkan_executor_runner_lib ${_executor_runner_libs})
+  target_link_libraries(vulkan_executor_runner_lib vulkan_schema)
+  target_link_libraries(vulkan_executor_runner_lib vulkan_backend)
+  target_compile_options(vulkan_executor_runner_lib
+                         PUBLIC ${VULKAN_CXX_FLAGS})
+endif()
 
 # Test targets
 

--- a/backends/vulkan/__init__.py
+++ b/backends/vulkan/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Exposed Partitioners in XNNPACK Package
+from .partitioner.vulkan_partitioner import (
+    VulkanPartitioner,
+)
+
+# Vulkan Backend
+from .vulkan_preprocess import VulkanBackend
+
+__all__ = [
+    "VulkanPartitioner",
+    "VulkanBackend",
+]

--- a/backends/vulkan/__init__.py
+++ b/backends/vulkan/__init__.py
@@ -4,10 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Exposed Partitioners in XNNPACK Package
 from .partitioner.vulkan_partitioner import VulkanPartitioner
 
-# Vulkan Backend
 from .vulkan_preprocess import VulkanBackend
 
 __all__ = [

--- a/backends/vulkan/__init__.py
+++ b/backends/vulkan/__init__.py
@@ -5,9 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # Exposed Partitioners in XNNPACK Package
-from .partitioner.vulkan_partitioner import (
-    VulkanPartitioner,
-)
+from .partitioner.vulkan_partitioner import VulkanPartitioner
 
 # Vulkan Backend
 from .vulkan_preprocess import VulkanBackend

--- a/backends/vulkan/serialization/vulkan_graph_serialize.py
+++ b/backends/vulkan/serialization/vulkan_graph_serialize.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from typing import ClassVar, List
 
 # pyre-ignore[21]: Could not find module `executorch.exir._serialize._bindings`.
-import executorch.exir._serialize._bindings as bindings  # @manual=//executorch/exir/_serialize:_bindings
 import pkg_resources
 import torch
 
@@ -22,6 +21,8 @@ from executorch.backends.vulkan.serialization.vulkan_graph_schema import (
     VkGraph,
 )
 from executorch.exir._serialize._dataclass import _DataclassEncoder
+
+from executorch.exir._serialize._flatbuffer import _flatc_compile
 
 
 def convert_to_flatbuffer(vk_graph: VkGraph) -> bytes:
@@ -35,7 +36,7 @@ def convert_to_flatbuffer(vk_graph: VkGraph) -> bytes:
         with open(json_path, "wb") as json_file:
             json_file.write(vk_graph_json.encode("ascii"))
         # pyre-ignore
-        bindings.flatc_compile(d, schema_path, json_path)
+        _flatc_compile(d, schema_path, json_path)
         output_path = os.path.join(d, "schema.bin")
         with open(output_path, "rb") as output_file:
             return output_file.read()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2239


## Context

This changeset introduces the `vulkan_executor_runner`, which can be used to run the Vulkan Backend in open source. It is the Vulkan equivalent of `executor_runner`s found in other backends, such as XNNPACK and MPS.

Differential Revision: [D54512106](https://our.internmc.facebook.com/intern/diff/D54512106)