### PR TITLE
Adding Support for preserve_format when converting Evalues

### DIFF
--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -462,11 +462,11 @@ class _Emitter(torch.fx.Interpreter):
             return EValue(Int(layout_enum(val)))
 
         if isinstance(val, torch.memory_format):
-            if val != torch.contiguous_format:
+            if val != torch.contiguous_format and val != torch.preserve_format:
                 raise InternalError(
                     self._emit_node_specific_error(
                         self.node,
-                        "Non contiguous tensors are not supported in ExecuTorch",
+                        "Only Tensors that have a contiguous or preserve_format memory_format are supported in ExecuTorch",
                     )
                 )
             return EValue(Int(memory_format_enum(val)))

--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -231,6 +231,7 @@ def memory_format_enum(memory_format: torch.memory_format) -> int:
     )
     table = {
         torch.contiguous_format: 0,
+        torch.preserve_format: 1,
     }
     return table[memory_format]
 


### PR DESCRIPTION
Summary:
This diff adds support for `torch.preserve_format` when casting constants to Evalues.
---

Differential Revision: D54288165


