### PR TITLE
Support None's When Calculating Emitted ExecutionPlan Outputs

### DIFF
--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -1409,9 +1409,10 @@ class _TopLevelEmitter(_Emitter):
             self.outputs.append(args_tuple.id)
         else:
             for arg in args_tuple:
-                if isinstance(arg, (int, float, bool)):
+                if isinstance(arg, (int, float, bool, type(None))):
                     arg = self._emit_evalue(self._constant_to_evalue(arg, None))
-                elif isinstance(arg, (type(None), str)):
+                elif isinstance(arg, str):
+                    # TODO(jackkhuu): T181599879 Add support for string outputs IFF compiler supports
                     raise InternalError(
                         self._emit_node_specific_error(
                             self.node,

--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -463,14 +463,15 @@ class _Emitter(torch.fx.Interpreter):
             return EValue(Int(layout_enum(val)))
 
         if isinstance(val, torch.memory_format):
-            if val != torch.contiguous_format:
+            try:
+                return EValue(Int(memory_format_enum(val)))
+            except KeyError:
                 raise InternalError(
                     self._emit_node_specific_error(
                         self.node,
-                        "Non contiguous tensors are not supported in ExecuTorch",
+                        f"Tensor has a memory_format that is unsupported in ExecuTorch: {val}",
                     )
                 )
-            return EValue(Int(memory_format_enum(val)))
 
         if isinstance(val, torch.Tensor):
             raise ExportError(

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -215,14 +215,14 @@ class TestEmit(unittest.TestCase):
     def test_constant_output(self):
         class M(torch.nn.Module):
             def forward(self, x):
-                return [((1, 3, 1.2), True, [x + x, x * x])]
+                return [((1, 3, 1.2), True, [x + x, x * x], None)]
 
         ep = torch.export.export(M(), (torch.ones(2, 3),))
         res = ep.module()(torch.ones(2, 3))
         self.assertEqual(res[0][0], (1, 3, 1.2))
         program = to_edge(ep).to_executorch().executorch_program
         outputs = program.execution_plan[0].outputs
-        self.assertEqual(len(outputs), 6)
+        self.assertEqual(len(outputs), 7)
         self.assertEqual(program.execution_plan[0].values[outputs[0]].val.int_val, 1)
         self.assertEqual(program.execution_plan[0].values[outputs[1]].val.int_val, 3)
         self.assertEqual(
@@ -231,6 +231,7 @@ class TestEmit(unittest.TestCase):
         self.assertEqual(
             program.execution_plan[0].values[outputs[3]].val.bool_val, True
         )
+        self.assertIsInstance(program.execution_plan[0].values[outputs[6]].val, Null)
 
     def test_int_list_input(self):
         class M(torch.nn.Module):

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -21,6 +21,7 @@ from executorch.exir.backend.backend_api import to_backend
 from executorch.exir.backend.backend_details import BackendDetails, PreprocessResult
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.emit import emit_program  # noqa
+from executorch.exir.error import InternalError
 from executorch.exir.passes.constant_prop_pass import constant_prop_pass
 from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
 from executorch.exir.print_program import pretty_print, print_program  # noqa
@@ -837,6 +838,48 @@ class TestEmit(unittest.TestCase):
                 self.assertEqual(single_val.shape_dynamism, merged_val.shape_dynamism)
             else:
                 self.assertEqual(single_val, merged_val)
+
+    def test_emit_memory_format_valid(self) -> None:
+        class SimpleLinear(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                contiguous = x.to(
+                    dtype=torch.float32, memory_format=torch.contiguous_format
+                )
+                preserve = x.to(
+                    dtype=torch.float32, memory_format=torch.preserve_format
+                )
+                return contiguous + preserve
+
+        # Should succeed at exporting model with legal memory format (contiguous, preserve)
+        model = SimpleLinear()
+        inputs = (torch.ones(10, 5),)
+        try:
+            to_edge(
+                export(model, inputs),
+                compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+            ).to_executorch()
+        except:
+            self.fail("Failed to export model with legal memory format")
+
+    def test_emit_memory_format_invalid(self) -> None:
+        class SimpleLinear(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x.to(dtype=torch.float32, memory_format=torch.channels_last)
+
+        # Failure expected when exporting model with illegal memory format (channels_last)
+        model = SimpleLinear()
+        inputs = (torch.ones(10, 5, 2, 1),)
+        with self.assertRaises(InternalError):
+            to_edge(
+                export(model, inputs),
+                compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+            ).to_executorch()
 
     def test_emit_multiple_entry_points(self) -> None:
         class SimpleLinear(torch.nn.Module):

--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -231,6 +231,7 @@ def memory_format_enum(memory_format: torch.memory_format) -> int:
     )
     table = {
         torch.contiguous_format: 0,
+        torch.preserve_format: 1,
     }
     return table[memory_format]
 

--- a/runtime/core/portable_type/tensor_options.h
+++ b/runtime/core/portable_type/tensor_options.h
@@ -14,17 +14,21 @@ namespace torch {
 namespace executor {
 
 /**
- * Tensor data memory format. This concept only exists for compatibility
- * with ATen.
+ * Tensor data memory formats supported by ExecuTorch. This concept only exists
+ * for compatibility with ATen; use dim_order to describe non-contiguous
+ * layouts.
  */
 enum class MemoryFormat : int8_t {
   /**
-   * Row-major contiguous data format.
-   *
-   * This is the only format supported by ExecuTorch. Use dim orders to
-   * describe other layouts.
+   * Row-major contiguous data.
    */
-  Contiguous,
+  Contiguous = 0,
+  /**
+   * Output tensor format should remain the same as the input tensor format.
+   * E.g. if the input tensor is in channels_last format, operator output
+   * should be in channels_last format.
+   */
+  Preserve = 1,
 };
 
 /**
@@ -39,7 +43,7 @@ enum class Layout : int8_t {
    *
    * This is the only layout supported by ExecuTorch.
    */
-  Strided,
+  Strided = 0,
 };
 } // namespace executor
 } // namespace torch


### PR DESCRIPTION
Summary:
Previously Support for outputting int/float was added in D53256808 for Seamless

This extends on this by dropping None Outputs (Which can be outputted by NanoGPT)

Differential Revision: D54328663


