### PR TITLE
[Executorch][llama] Use dynamic quantized linear partitioner of xnnpack

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -394,7 +394,14 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
         modelname = f"xnnpack_dq_{modelname}"
 
     if args.xnnpack:
-        partitioners[XnnpackPartitioner.__name__] = XnnpackPartitioner()
+        # Following changes due to.
+        # 1. We need dynamically quantized partitioner for both pt2e_quantize options
+        #    as well as "qmode int4" which is also dynamic quantizes linear layers.
+        # 2. XNNPACK partitioner seems to result in seg fault for non dqlinear ops.
+        partitioners[
+            XnnpackDynamicallyQuantizedPartitioner.__name__
+        ] = XnnpackDynamicallyQuantizedPartitioner()
+        # partitioners[XnnpackPartitioner.__name__] = XnnpackPartitioner()
         modelname = f"xnnpack_{modelname}"
 
     # TODO: remove this after xnnpack delegation is ready


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2252
* #2251

For grupwise 4bit quant we need dynamic quantized linear partitioner. Ideally
-X option just uses both dqlinear as well as regular partitioner but the latter
doesnt yet work.

Differential Revision: [D54492109](https://our.internmc.facebook.com/intern/diff/D54492109/)