### PR TITLE
Fix op schema and avoid re-registering.

### DIFF
--- a/examples/models/llama2/ops/quantized.yaml
+++ b/examples/models/llama2/ops/quantized.yaml
@@ -4,7 +4,7 @@
     - arg_meta: null
       kernel_name: torch::executor::quantized_embedding_byte_out
 
-- func: llama_quantized::embedding_byte.dtype_out(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, int weight_quant_min, int weight_quant_max, Tensor indices, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
+- func: llama_quantized::embedding_byte.dtype_out(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, int weight_quant_min, int weight_quant_max, Tensor indices, ScalarType? dtype=None, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:
     - arg_meta: null

--- a/kernels/quantized/quantized.yaml
+++ b/kernels/quantized/quantized.yaml
@@ -40,7 +40,7 @@
     - arg_meta: null
       kernel_name: torch::executor::quantized_embedding_byte_out
 
-- func: quantized_decomposed::embedding_byte.dtype_out(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, int weight_quant_min, int weight_quant_max, Tensor indices, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
+- func: quantized_decomposed::embedding_byte.dtype_out(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, int weight_quant_min, int weight_quant_max, Tensor indices, ScalarType? dtype=None, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:
     - arg_meta: null


### PR DESCRIPTION
Summary:
Looks like in op schema declaration the special `*` arg should separate in- and out-args, so rearranging them a bit.
Additionally, skip lininking the runner with `examples/models/llama/ops`in favor of `kernels/quantized`.

Differential Revision: D54523778


