### PR TITLE
[ET-VK][ez] Introduce instrumentation test and custom shader library test for Compute API test

### DIFF
--- a/backends/vulkan/test/glsl/test_shader.glsl
+++ b/backends/vulkan/test/glsl/test_shader.glsl
@@ -1,0 +1,27 @@
+#version 450 core
+#define PRECISION ${PRECISION}
+#define FORMAT ${FORMAT}
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
+  ivec4 size;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    const vec4 intex = texelFetch(uInput, pos, 0);
+    imageStore(
+        uOutput,
+        pos,
+        intex + 5);
+  }
+}

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -162,7 +162,7 @@ class VulkanComputeAPITest : public ::testing::Test {
 //
 
 TEST_F(VulkanComputeAPITest, retrieve_custom_shader_test) {
-  // Try to shader from custom shader library
+  // Try to get shader from custom shader library
   const api::ShaderInfo& kernel = VK_KERNEL(test_shader);
 
   EXPECT_TRUE(kernel.kernel_name == "test_shader");

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -161,6 +161,13 @@ class VulkanComputeAPITest : public ::testing::Test {
 // Compute API Tests
 //
 
+TEST_F(VulkanComputeAPITest, retrieve_custom_shader_test) {
+  // Try to shader from custom shader library
+  const api::ShaderInfo& kernel = VK_KERNEL(test_shader);
+
+  EXPECT_TRUE(kernel.kernel_name == "test_shader");
+}
+
 TEST_F(VulkanComputeAPITest, buffer_copy_sanity_check) {
   // Simple test that copies data into a and reads from a
   std::vector<int64_t> sizes = {4, 4, 1};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2259

## Context

Add an Android instrumentation test for `vulkan_compute_api_test` so that changes to the Vulkan Compute API and the Vulkan graph runtime can be tested on Android devices.

Also add a test for retrieving a shader from a linked custom shader library.

Differential Revision: [D54520213](https://our.internmc.facebook.com/intern/diff/D54520213/)