### PR TITLE
Allow bento to see the ops library

### DIFF
--- a/examples/models/llama2/ops/targets.bzl
+++ b/examples/models/llama2/ops/targets.bzl
@@ -16,6 +16,7 @@ def define_common_targets():
         visibility = [
             "//executorch/...",
             "@EXECUTORCH_CLIENTS",
+            "//bento",
         ],
         deps = [
             "//caffe2:torch",


### PR DESCRIPTION
Summary:
Allow bento to see the ops library
Long-term, maybe bento should be listed as an executorch_client

Differential Revision: D54555495


