### PR TITLE
Extend support for scalars and scalar lists in Value class

### DIFF
--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -23,11 +23,14 @@
 #include <cstdlib> /* strtol */
 #include <memory>
 #include <type_traits>
+#include <vector>
 
 namespace torch {
 namespace executor {
 namespace vulkan {
 namespace {
+
+using namespace at::native::vulkan;
 
 // Flatbuffer types
 using VkGraphPtr = const vkgraph::VkGraph*;
@@ -51,102 +54,194 @@ const uint8_t* getConstantDataPtr(
   return constant_data + constant_bytes->offset();
 }
 
-using namespace at::native::vulkan;
+api::ScalarType get_scalar_type(const vkgraph::VkDataType& vk_datatype) {
+  switch (vk_datatype) {
+    case (vkgraph::VkDataType::fp32): {
+      return api::kFloat;
+    }
+  }
+}
+
+GraphConfig generate_config() {
+  const uint32_t submit_frequency = UINT32_MAX;
+
+  const api::CommandPoolConfig cmd_config{
+      4u, // cmdPoolInitialSize
+      2u, // cmdPoolBatchSize
+  };
+
+  const api::DescriptorPoolConfig descriptor_pool_config{
+      1024u, // descriptorPoolMaxSets
+      1024u, // descriptorUniformBufferCount
+      1024u, // descriptorStorageBufferCount
+      1024u, // descriptorCombinedSamplerCount
+      1024u, // descriptorStorageImageCount
+      32u, // descriptorPileSizes
+  };
+
+  const api::QueryPoolConfig query_pool_config{};
+
+  const api::ContextConfig context_config{
+      submit_frequency, // cmdSubmitFrequency
+      cmd_config, // cmdPoolConfig
+      descriptor_pool_config, // descriptorPoolConfig
+      query_pool_config, // queryPoolConfig
+  };
+
+  const GraphConfig graph_config{
+      context_config,
+  };
+
+  return graph_config;
+}
+
+class GraphBuilder {
+  ComputeGraph* compute_graph_;
+  VkGraphPtr flatbuffer_;
+  const uint8_t* constant_data_;
+
+  std::unordered_map<uint32_t, ValueRef> ref_mapping_;
+
+ public:
+  explicit GraphBuilder(
+      ComputeGraph* compute_graph,
+      VkGraphPtr flatbuffer,
+      const uint8_t* constant_data)
+      : compute_graph_(compute_graph),
+        flatbuffer_(flatbuffer),
+        constant_data_(constant_data),
+        ref_mapping_() {}
+
+  bool fb_id_exists(const uint32_t fb_id) {
+    const std::unordered_map<uint32_t, ValueRef>::iterator found_ref =
+        ref_mapping_.find(fb_id);
+
+    return found_ref != ref_mapping_.end();
+  }
+
+  ValueRef get_fb_id_valueref(const uint32_t fb_id) {
+    const std::unordered_map<uint32_t, ValueRef>::iterator found_ref =
+        ref_mapping_.find(fb_id);
+
+    ET_CHECK_MSG(
+        found_ref != ref_mapping_.end(),
+        "Trying to extract a value that hasn't yet been added to the graph.");
+
+    return found_ref->second;
+  }
+
+  void add_tensor_to_graph(const uint32_t fb_id, VkTensorPtr tensor_fb) {
+    const api::ScalarType& dtype = get_scalar_type(tensor_fb->datatype());
+
+    UIntVector dims_fb = tensor_fb->dims();
+    const std::vector<int64_t> dims_vector(dims_fb->cbegin(), dims_fb->cend());
+
+    ValueRef ref;
+    if (tensor_fb->constant_id() >= 0) {
+      const uint8_t* tensor_data = getConstantDataPtr(
+          flatbuffer_, tensor_fb->constant_id(), constant_data_);
+
+      ref = compute_graph_->add_tensorref(dims_vector, dtype, tensor_data);
+    } else {
+      ref = compute_graph_->add_tensor(
+          dims_vector, dtype, tensor_fb->mem_obj_id());
+    }
+
+    ref_mapping_[fb_id] = ref;
+  }
+
+  template <typename T>
+  typename std::enable_if<is_valid_scalar_type<T>::value, void>::type
+  add_scalar_to_graph(const uint32_t fb_id, T value) {
+    ValueRef ref = compute_graph_->add_scalar(value);
+    ref_mapping_[fb_id] = ref;
+  }
+
+  void add_string_to_graph(const uint32_t fb_id, VkValuePtr value) {
+    const auto fb_str = value->value_as_String()->string_val();
+    std::string string(fb_str->cbegin(), fb_str->cend());
+    ValueRef ref = compute_graph_->add_string(std::move(string));
+    ref_mapping_[fb_id] = ref;
+  }
+
+  void add_value_to_graph(const uint32_t fb_id, VkValuePtr value) {
+    ET_CHECK_MSG(
+        !fb_id_exists(fb_id),
+        "Trying to add a value that has already been added to the graph.");
+
+    switch (value->value_type()) {
+      case vkgraph::GraphTypes::Int:
+        add_scalar_to_graph(fb_id, value->value_as_Int()->int_val());
+        break;
+      case vkgraph::GraphTypes::Double:
+        add_scalar_to_graph(fb_id, value->value_as_Double()->double_val());
+        break;
+      case vkgraph::GraphTypes::Bool:
+        add_scalar_to_graph(fb_id, value->value_as_Bool()->bool_val());
+        break;
+      case vkgraph::GraphTypes::VkTensor:
+        add_tensor_to_graph(fb_id, value->value_as_VkTensor());
+        break;
+      case vkgraph::GraphTypes::String:
+        add_string_to_graph(fb_id, value);
+        break;
+      default:
+        ET_CHECK_MSG(false, "Unsupported value type.");
+    }
+  }
+
+  void build_graph() {
+    // First, add all values to the graph
+    for (uint32_t fb_id = 0; fb_id < flatbuffer_->values()->size(); ++fb_id) {
+      VkValuePtr value = flatbuffer_->values()->Get(fb_id);
+      add_value_to_graph(fb_id, value);
+    }
+
+    // Parse the inputs
+    for (const uint32_t fb_id : *flatbuffer_->input_ids()) {
+      const ValueRef ref = get_fb_id_valueref(fb_id);
+      compute_graph_->set_input_tensor(ref);
+    }
+
+    // Parse the operators
+    for (OpCallPtr op_call : *(flatbuffer_->chain())) {
+      std::string op_name = op_call->name()->str();
+      ET_CHECK_MSG(hasOpsFn(op_name), "Missing operator: %s", op_name.c_str());
+
+      const std::vector<int> arg_fb_ids(
+          op_call->args()->cbegin(), op_call->args()->cend());
+
+      std::vector<ValueRef> args;
+      for (const int arg_fb_id : arg_fb_ids) {
+        args.push_back(get_fb_id_valueref(arg_fb_id));
+      }
+
+      auto vkFn = getOpsFn(op_name);
+      vkFn(*compute_graph_, args);
+    }
+
+    // Parse the outputs
+    for (const uint32_t fb_id : *flatbuffer_->output_ids()) {
+      const ValueRef ref = get_fb_id_valueref(fb_id);
+      compute_graph_->set_output_tensor(ref);
+    }
+  }
+};
 
 class VulkanBackend final : public PyTorchBackendInterface {
  public:
   ~VulkanBackend() override = default;
 
   bool is_available() const override {
+    // TODO(ssjia): replace with an actual Vulkan runtime availability check
     return true;
-  }
-
-  api::ScalarType get_scalar_type(
-      const vkgraph::VkDataType& vk_datatype) const {
-    switch (vk_datatype) {
-      case (vkgraph::VkDataType::fp32): {
-        return api::kFloat;
-      }
-    }
-  }
-
-  ValueRef get_value_ref(
-      const uint32_t value_id,
-      VkGraphPtr flatbuffer_graph,
-      ComputeGraph* compute_graph,
-      std::unordered_map<uint32_t, ValueRef>& ref_mapping,
-      VkValuesVector value_mapping,
-      const uint8_t* constant_data) const {
-    const std::unordered_map<uint32_t, ValueRef>::iterator found_ref =
-        ref_mapping.find(value_id);
-
-    if (found_ref != ref_mapping.end()) {
-      return found_ref->second;
-    }
-
-    VkValuePtr vk_value = value_mapping->Get(value_id);
-    VkTensorPtr vk_tensor = vk_value->value();
-
-    ET_CHECK_MSG(
-        vk_tensor->constant_id() >= 0,
-        "Only constant buffers are supported when adding tensors to compute graph (indicated by constant_id < 0), but got constant_id of %d",
-        vk_tensor->constant_id());
-
-    const api::ScalarType& tensor_dtype =
-        get_scalar_type(vk_tensor->datatype());
-
-    UIntVector tensor_dims_fb = vk_tensor->dims();
-    const std::vector<int64_t> tensor_dims_vector(
-        tensor_dims_fb->cbegin(), tensor_dims_fb->cend());
-
-    const uint8_t* tensor_data = getConstantDataPtr(
-        flatbuffer_graph, vk_tensor->constant_id(), constant_data);
-
-    const ValueRef value_ref = compute_graph->add_tensorref(
-        tensor_dims_vector, tensor_dtype, tensor_data);
-
-    ref_mapping[value_id] = value_ref;
-
-    return value_ref;
-  }
-
-  GraphConfig generate_config() const {
-    const uint32_t submit_frequency = UINT32_MAX;
-
-    const api::CommandPoolConfig cmd_config{
-        4u, // cmdPoolInitialSize
-        2u, // cmdPoolBatchSize
-    };
-
-    const api::DescriptorPoolConfig descriptor_pool_config{
-        1024u, // descriptorPoolMaxSets
-        1024u, // descriptorUniformBufferCount
-        1024u, // descriptorStorageBufferCount
-        1024u, // descriptorCombinedSamplerCount
-        1024u, // descriptorStorageImageCount
-        32u, // descriptorPileSizes
-    };
-
-    const api::QueryPoolConfig query_pool_config{};
-
-    const api::ContextConfig context_config{
-        submit_frequency, // cmdSubmitFrequency
-        cmd_config, // cmdPoolConfig
-        descriptor_pool_config, // descriptorPoolConfig
-        query_pool_config, // queryPoolConfig
-    };
-
-    const GraphConfig graph_config{
-        context_config,
-    };
-
-    return graph_config;
   }
 
   __ET_NODISCARD Error
   compileModel(const void* buffer_pointer, ComputeGraph* compute_graph) const {
     Result<VulkanDelegateHeader> header =
         VulkanDelegateHeader::Parse(buffer_pointer);
+
     const uint8_t* flatbuffer_data = nullptr;
     const uint8_t* constant_data = nullptr;
 
@@ -169,92 +264,10 @@ class VulkanBackend final : public PyTorchBackendInterface {
 
     VkGraphPtr flatbuffer_graph = vkgraph::GetVkGraph(flatbuffer_data);
 
-    // Mapping from serialized VkValue ids to compute graph ValueRefs
-    // This will be populated as the compute graph is built
-    std::unordered_map<uint32_t, ValueRef> ref_mapping;
+    GraphBuilder builder =
+        GraphBuilder(compute_graph, flatbuffer_graph, constant_data);
 
-    // A vector which acts as a mapping from VkValue ids (vector indices) to
-    // VkValues
-    VkValuesVector value_mapping = flatbuffer_graph->values();
-
-    // 1. Add all inputs (and corresponding tensors) to the compute graph
-    UIntVector input_ids = flatbuffer_graph->input_ids();
-
-    for (size_t input_index = 0; input_index < input_ids->size();
-         ++input_index) {
-      const uint32_t input_id = input_ids->Get(input_index);
-      VkValuePtr input_vk_value = value_mapping->Get(input_id);
-
-      VkTensorPtr input_vk_tensor = input_vk_value->value();
-
-      ET_CHECK_MSG(
-          input_vk_tensor->constant_id() < 0,
-          "Expected constant buffer index for input at index %zu with id %d to be < 0 (since it is non-constant), but got: %d",
-          input_index,
-          input_id,
-          input_vk_tensor->constant_id());
-
-      const api::ScalarType& input_dtype =
-          get_scalar_type(input_vk_tensor->datatype());
-
-      UIntVector input_dims_fb = input_vk_tensor->dims();
-      const std::vector<int64_t> input_dims_vector(
-          input_dims_fb->cbegin(), input_dims_fb->cend());
-
-      const ValueRef input_ref = compute_graph->add_tensor(
-          input_dims_vector, input_dtype, input_vk_tensor->mem_obj_id());
-
-      ref_mapping[input_id] = input_ref;
-      compute_graph->set_input_tensor(input_ref);
-    }
-
-    // 2. Add all ops to the graph
-    // TODO: Generalize for ops that don't have 2 inputs and 1 output.
-    for (OpCallPtr op_call : *(flatbuffer_graph->chain())) {
-      std::string op_name = op_call->name()->str();
-
-      ET_CHECK_MSG(
-          op_call->args() != nullptr && op_call->args()->size() == 3,
-          "Vulkan currently only supports OperatorCall with 3 args");
-      const auto arg_ids = op_call->args()->data();
-
-      const uint32_t input1_id = arg_ids[0];
-      const uint32_t input2_id = arg_ids[1];
-      const uint32_t output_id = arg_ids[2];
-
-      const ValueRef input1_ref = get_value_ref(
-          input1_id,
-          flatbuffer_graph,
-          compute_graph,
-          ref_mapping,
-          value_mapping,
-          constant_data);
-
-      const ValueRef input2_ref = get_value_ref(
-          input2_id,
-          flatbuffer_graph,
-          compute_graph,
-          ref_mapping,
-          value_mapping,
-          constant_data);
-
-      ET_CHECK_MSG(hasOpsFn(op_name), "Missing operator: %s", op_name.c_str());
-      auto vkFn = getOpsFn(op_name);
-      const at::native::vulkan::ValueRef output_ref = vkFn(
-          *compute_graph,
-          {input1_ref,
-           input2_ref,
-           1,
-           value_mapping->Get(output_id)->value()->mem_obj_id()});
-
-      ref_mapping[output_id] = output_ref;
-    }
-
-    // 3. Add all outputs to the compute graph
-    for (const uint32_t output_id : *flatbuffer_graph->output_ids()) {
-      const ValueRef output_ref = ref_mapping[output_id];
-      compute_graph->set_output_tensor(output_ref);
-    }
+    builder.build_graph();
 
     compute_graph->encode_prepack();
     compute_graph->prepack();

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -77,6 +77,12 @@ ValueRef ComputeGraph::add_staging(
   return idx;
 }
 
+ValueRef ComputeGraph::add_string(std::string&& str) {
+  ValueRef idx(static_cast<int>(values_.size()));
+  values_.emplace_back(std::move(str));
+  return idx;
+}
+
 ValueRef ComputeGraph::set_input_tensor(
     const ValueRef idx,
     const bool use_staging) {

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -28,6 +28,19 @@ namespace at {
 namespace native {
 namespace vulkan {
 
+// Define valid scalar types that the Value class can accept
+template <typename T>
+struct is_valid_scalar_type : std::false_type {};
+
+template <>
+struct is_valid_scalar_type<int64_t> : std::true_type {};
+
+template <>
+struct is_valid_scalar_type<double> : std::true_type {};
+
+template <>
+struct is_valid_scalar_type<bool> : std::true_type {};
+
 /*
  * This is the core data structure used to execute Vulkan models in graph mode.
  * As opposed to ATen/eager mode where a command buffer is encoded every
@@ -123,6 +136,16 @@ class ComputeGraph final {
       const void* const data);
   ValueRef add_staging(const api::ScalarType dtype, const size_t numel);
 
+  template <typename T>
+  typename std::enable_if<is_valid_scalar_type<T>::value, ValueRef>::type
+  add_scalar_list(std::vector<T>&& values);
+
+  template <typename T>
+  typename std::enable_if<is_valid_scalar_type<T>::value, ValueRef>::type
+  add_scalar(T value);
+
+  ValueRef add_string(std::string&& str);
+
   ValueRef set_input_tensor(const ValueRef idx, const bool use_staging = true);
   ValueRef set_output_tensor(const ValueRef idx, const bool use_staging = true);
 
@@ -162,6 +185,22 @@ class ComputeGraph final {
   void encode_execute();
   void execute() const;
 };
+
+template <typename T>
+inline typename std::enable_if<is_valid_scalar_type<T>::value, ValueRef>::type
+ComputeGraph::add_scalar_list(std::vector<T>&& values) {
+  ValueRef idx(static_cast<int>(values_.size()));
+  values_.emplace_back(std::move(values));
+  return idx;
+}
+
+template <typename T>
+inline typename std::enable_if<is_valid_scalar_type<T>::value, ValueRef>::type
+ComputeGraph::add_scalar(T value) {
+  ValueRef idx(static_cast<int>(values_.size()));
+  values_.emplace_back(value);
+  return idx;
+}
 
 } // namespace vulkan
 } // namespace native

--- a/backends/vulkan/runtime/graph/containers/Types.cpp
+++ b/backends/vulkan/runtime/graph/containers/Types.cpp
@@ -12,20 +12,25 @@ namespace at {
 namespace native {
 namespace vulkan {
 
+#define PRINT_CASE(name) \
+  case TypeTag::name:    \
+    out << #name;        \
+    break;
+
 std::ostream& operator<<(std::ostream& out, const TypeTag& tag) {
   switch (tag) {
-    case TypeTag::NONE:
-      out << "NONE";
-      break;
-    case TypeTag::TENSOR:
-      out << "TENSOR";
-      break;
-    case TypeTag::STAGING:
-      out << "STAGING";
-      break;
-    default:
-      out << "UNKNOWN";
-      break;
+    PRINT_CASE(NONE)
+    PRINT_CASE(INT)
+    PRINT_CASE(DOUBLE)
+    PRINT_CASE(BOOL)
+    PRINT_CASE(TENSOR)
+    PRINT_CASE(STAGING)
+    PRINT_CASE(TENSORREF)
+    PRINT_CASE(INTLIST)
+    PRINT_CASE(DOUBLELIST)
+    PRINT_CASE(BOOLLIST)
+    PRINT_CASE(VALUELIST)
+    PRINT_CASE(STRING)
   }
   return out;
 }

--- a/backends/vulkan/runtime/graph/containers/Types.h
+++ b/backends/vulkan/runtime/graph/containers/Types.h
@@ -23,12 +23,21 @@ namespace vulkan {
  */
 enum class TypeTag : uint32_t {
   NONE,
-  TENSOR,
-  STAGING,
-  TENSORREF,
+  // Scalar types
   INT,
   DOUBLE,
   BOOL,
+  // Tensor and tensor adjacent types
+  TENSOR,
+  STAGING,
+  TENSORREF,
+  // Scalar lists
+  INTLIST,
+  DOUBLELIST,
+  BOOLLIST,
+  // Special Type
+  VALUELIST,
+  STRING,
 };
 
 std::ostream& operator<<(std::ostream& out, const TypeTag& tag);

--- a/backends/vulkan/runtime/graph/containers/Value.h
+++ b/backends/vulkan/runtime/graph/containers/Value.h
@@ -22,6 +22,19 @@ namespace at {
 namespace native {
 namespace vulkan {
 
+using ValueRef = int32_t;
+
+constexpr ValueRef kDummyValueRef = -1;
+
+inline bool is_valid(ValueRef value_ref) {
+  return value_ref >= 0;
+}
+
+struct IOValueRef {
+  ValueRef value;
+  ValueRef staging;
+};
+
 /*
  * This class is modelled after c10::IValue; however, it is simplified and does
  * not support as many types. However, the core design is the same; it is a
@@ -48,6 +61,17 @@ struct Value final {
     api::StorageBuffer as_staging;
     TensorRef as_tensorref;
 
+    std::vector<int64_t> as_int_list;
+    std::vector<double> as_double_list;
+    std::vector<bool> as_bool_list;
+
+    // The below is a special type that is used to represent a list of other
+    // values stored in the graph. One application of the type is to represent
+    // a list of tensors or a list of optional tensors.
+    std::vector<ValueRef> as_value_list;
+
+    std::string as_string;
+
     Payload() : u() {}
     // NOLINTNEXTLINE
     ~Payload(){};
@@ -68,20 +92,47 @@ struct Value final {
 
   Value& operator=(Value&&) = delete;
 
+#define CASE_MOVE_TRIVIALLY_COPYABLE_TYPE(type_tag, member_name) \
+  case type_tag:                                                 \
+    payload.u.member_name = rhs.payload.u.member_name;           \
+    break;
+
+#define CASE_MOVE_MOVEABLE_TYPE(type_tag, type, member_name)             \
+  case type_tag:                                                         \
+    new (&payload.member_name) type(std::move(rhs.payload.member_name)); \
+    break;
+
   Value(Value&& rhs) noexcept : tag(rhs.tag) {
-    if (rhs.isTensor()) {
-      new (&payload.as_tensor) vTensor(std::move(rhs.payload.as_tensor));
-    } else if (rhs.isStaging()) {
-      new (&payload.as_staging)
-          api::StorageBuffer(std::move(rhs.payload.as_staging));
-    } else if (rhs.isTensorRef()) {
-      payload.as_tensorref = std::move(rhs.payload.as_tensorref);
-    } else {
-      payload.u = rhs.payload.u;
+    switch (tag) {
+      // Scalar types
+      CASE_MOVE_TRIVIALLY_COPYABLE_TYPE(TypeTag::INT, as_int);
+      CASE_MOVE_TRIVIALLY_COPYABLE_TYPE(TypeTag::DOUBLE, as_double);
+      CASE_MOVE_TRIVIALLY_COPYABLE_TYPE(TypeTag::BOOL, as_bool);
+      // Tensor and tensor adjacent types
+      CASE_MOVE_MOVEABLE_TYPE(TypeTag::TENSOR, vTensor, as_tensor);
+      CASE_MOVE_MOVEABLE_TYPE(TypeTag::STAGING, api::StorageBuffer, as_staging);
+      CASE_MOVE_MOVEABLE_TYPE(TypeTag::TENSORREF, TensorRef, as_tensorref);
+      // Scalar lists
+      CASE_MOVE_MOVEABLE_TYPE(
+          TypeTag::INTLIST, std::vector<int64_t>, as_int_list);
+      CASE_MOVE_MOVEABLE_TYPE(
+          TypeTag::DOUBLELIST, std::vector<double>, as_double_list);
+      CASE_MOVE_MOVEABLE_TYPE(
+          TypeTag::BOOLLIST, std::vector<bool>, as_bool_list);
+      // Special types
+      CASE_MOVE_MOVEABLE_TYPE(
+          TypeTag::VALUELIST, std::vector<ValueRef>, as_value_list);
+      CASE_MOVE_MOVEABLE_TYPE(TypeTag::STRING, std::string, as_string);
+
+      case TypeTag::NONE:
+        clearToNone();
+        break;
     }
-    tag = rhs.tag;
     rhs.clearToNone();
   }
+
+#undef CASE_MOVE_TRIVIALLY_COPYABLE_TYPE
+#undef CASE_MOVE_MOVEABLE_TYPE
 
   //
   // Accessors
@@ -96,77 +147,127 @@ struct Value final {
   //
 
   ~Value() {
-    if (this->isTensor()) {
-      payload.as_tensor.~vTensor();
-    } else if (this->isStaging()) {
-      payload.as_staging.~StorageBuffer();
-    } else if (this->isTensorRef()) {
-      payload.as_tensorref.~TensorRef();
+    switch (tag) {
+      case TypeTag::TENSOR:
+        payload.as_tensor.~vTensor();
+        break;
+      case TypeTag::STAGING:
+        payload.as_staging.~StorageBuffer();
+        break;
+      case TypeTag::TENSORREF:
+        payload.as_tensorref.~TensorRef();
+        break;
+      case TypeTag::INTLIST:
+        payload.as_int_list.~vector();
+        break;
+      case TypeTag::DOUBLELIST:
+        payload.as_double_list.~vector();
+        break;
+      case TypeTag::BOOLLIST:
+        payload.as_bool_list.~vector();
+        break;
+      case TypeTag::VALUELIST:
+        payload.as_value_list.~vector();
+        break;
+      case TypeTag::STRING:
+        payload.as_string.~basic_string();
+        break;
+      // Manually list out the types so that if a type here is added later and
+      // not handled the compiler can catch it.
+      case TypeTag::NONE:
+      case TypeTag::INT:
+      case TypeTag::DOUBLE:
+      case TypeTag::BOOL:
+        break;
     }
   }
 
-  //
-  // Tensor
-  //
-
-  explicit Value(vTensor&& t) : tag(TypeTag::TENSOR) {
-    new (&payload.as_tensor) vTensor(std::move(t));
+#define SUPPORT_TRIVIALLY_COPYABLE_TYPE(                    \
+    type, type_name, type_tag, member_name)                 \
+  explicit Value(type t) : tag(type_tag) {                  \
+    payload.u.member_name = t;                              \
+  }                                                         \
+  inline bool is##type_name() const {                       \
+    return tag == type_tag;                                 \
+  }                                                         \
+  inline const type& to##type_name() const {                \
+    VK_CHECK_COND(                                          \
+        is##type_name(),                                    \
+        "Expected value to have type " #type_name ", got ", \
+        tag,                                                \
+        " instead.");                                       \
+    return payload.u.member_name;                           \
   }
 
-  inline bool isTensor() const {
-    return TypeTag::TENSOR == tag;
+  SUPPORT_TRIVIALLY_COPYABLE_TYPE(int64_t, Int, TypeTag::INT, as_int);
+  SUPPORT_TRIVIALLY_COPYABLE_TYPE(double, Double, TypeTag::DOUBLE, as_double);
+  SUPPORT_TRIVIALLY_COPYABLE_TYPE(bool, Bool, TypeTag::BOOL, as_bool);
+
+#undef SUPPORT_TRIVIALLY_COPYABLE_TYPE
+
+#define SUPPORT_TRIVIALLY_MOVEABLE_TYPE(                    \
+    type, type_name, type_tag, member_name)                 \
+  explicit Value(type&& t) : tag(type_tag) {                \
+    new (&payload.member_name) type(std::move(t));          \
+  }                                                         \
+  inline bool is##type_name() const {                       \
+    return tag == type_tag;                                 \
+  }                                                         \
+  inline type& to##type_name() {                            \
+    VK_CHECK_COND(                                          \
+        is##type_name(),                                    \
+        "Expected value to have type " #type_name ", got ", \
+        tag,                                                \
+        " instead.");                                       \
+    return payload.member_name;                             \
   }
 
-  inline vTensor& toTensor() {
-    VK_CHECK_COND(
-        isTensor(),
-        "Expected value to have type TENSOR, got ",
-        tag,
-        " instead.");
-    return payload.as_tensor;
-  }
+  SUPPORT_TRIVIALLY_MOVEABLE_TYPE(vTensor, Tensor, TypeTag::TENSOR, as_tensor);
 
-  //
-  // Staging
-  //
+  SUPPORT_TRIVIALLY_MOVEABLE_TYPE(
+      api::StorageBuffer,
+      Staging,
+      TypeTag::STAGING,
+      as_staging);
 
-  explicit Value(api::StorageBuffer&& t) : tag(TypeTag::STAGING) {
-    new (&payload.as_staging) api::StorageBuffer(std::move(t));
-  }
+  SUPPORT_TRIVIALLY_MOVEABLE_TYPE(
+      TensorRef,
+      TensorRef,
+      TypeTag::TENSORREF,
+      as_tensorref);
 
-  inline bool isStaging() const {
-    return TypeTag::STAGING == tag;
-  }
+  SUPPORT_TRIVIALLY_MOVEABLE_TYPE(
+      std::vector<int64_t>,
+      IntList,
+      TypeTag::INTLIST,
+      as_int_list);
 
-  inline api::StorageBuffer& toStaging() {
-    VK_CHECK_COND(
-        isStaging(),
-        "Expected value to have type STAGING, got ",
-        tag,
-        " instead.");
-    return payload.as_staging;
-  }
+  SUPPORT_TRIVIALLY_MOVEABLE_TYPE(
+      std::vector<double>,
+      DoubleList,
+      TypeTag::DOUBLELIST,
+      as_double_list);
 
-  //
-  // TensorRef
-  //
+  SUPPORT_TRIVIALLY_MOVEABLE_TYPE(
+      std::vector<bool>,
+      BoolList,
+      TypeTag::BOOLLIST,
+      as_bool_list);
 
-  explicit Value(TensorRef&& t) : tag(TypeTag::TENSORREF) {
-    payload.as_tensorref = std::move(t);
-  }
+  SUPPORT_TRIVIALLY_MOVEABLE_TYPE(
+      std::vector<ValueRef>,
+      ValueList,
+      TypeTag::VALUELIST,
+      as_value_list);
 
-  inline bool isTensorRef() const {
-    return TypeTag::TENSORREF == tag;
-  }
+  SUPPORT_TRIVIALLY_MOVEABLE_TYPE(
+      std::string,
+      String,
+      TypeTag::STRING,
+      as_string);
 
-  inline TensorRef& toTensorRef() {
-    VK_CHECK_COND(
-        isTensorRef(),
-        "Expected value to have type TENSORREF, got ",
-        tag,
-        " instead.");
-    return payload.as_tensorref;
-  }
+#undef SUPPORT_TRIVIALLY_COPYABLE_TYPE
+#undef SUPPORT_TRIVIALLY_MOVEABLE_TYPE
 
  private:
   Payload payload;
@@ -177,16 +278,9 @@ struct Value final {
   //
 
   inline void clearToNone() noexcept {
-    payload.u.as_int = 0;
+    payload.u.as_int = -1;
     tag = TypeTag::NONE;
   }
-};
-
-using ValueRef = int32_t;
-
-struct IOValueRef {
-  ValueRef value;
-  ValueRef staging;
 };
 
 } // namespace vulkan

--- a/backends/vulkan/runtime/graph/ops/OpUtils.h
+++ b/backends/vulkan/runtime/graph/ops/OpUtils.h
@@ -12,6 +12,8 @@
 
 #include <ATen/native/vulkan/api/api.h>
 
+#include <executorch/backends/vulkan/runtime/graph/containers/Value.h>
+
 namespace at {
 namespace native {
 namespace vulkan {
@@ -79,6 +81,20 @@ uint32_t dim_at(const vTensor& v_in) {
  */
 api::utils::uvec3 adaptive_work_group_size(
     const api::utils::uvec3& global_work_group);
+
+template <typename T>
+T extract_scalar(const Value& value) {
+  if (value.isInt()) {
+    return static_cast<T>(value.toInt());
+  }
+  if (value.isDouble()) {
+    return static_cast<T>(value.toDouble());
+  }
+  if (value.isBool()) {
+    return static_cast<T>(value.toBool());
+  }
+  VK_THROW("Cannot extract scalar from Value with type ", value.type());
+}
 
 } // namespace vulkan
 } // namespace native

--- a/backends/vulkan/runtime/graph/ops/OperatorRegistry.h
+++ b/backends/vulkan/runtime/graph/ops/OperatorRegistry.h
@@ -19,11 +19,8 @@ namespace at {
 namespace native {
 namespace vulkan {
 
-using OpFunction = const std::function<at::native::vulkan::ValueRef(
-    at::native::vulkan::ComputeGraph&,
-    const std::vector<at::native::vulkan::ValueRef>&)>; // TODO: Generalize to
-                                                        // support float,
-                                                        // int64_t.
+using OpFunction =
+    const std::function<void(ComputeGraph&, const std::vector<ValueRef>&)>;
 
 bool hasOpsFn(const std::string& name);
 

--- a/backends/vulkan/runtime/graph/ops/Utils.h
+++ b/backends/vulkan/runtime/graph/ops/Utils.h
@@ -17,7 +17,7 @@ namespace native {
 namespace vulkan {
 
 #define DECLARE_OP_FN(function) \
-  ValueRef function(ComputeGraph& graph, const std::vector<ValueRef>& args);
+  void function(ComputeGraph& graph, const std::vector<ValueRef>& args);
 
 api::utils::ivec4 get_size_as_ivec4(const vTensor& t);
 

--- a/backends/vulkan/runtime/graph/ops/impl/Arithmetic.h
+++ b/backends/vulkan/runtime/graph/ops/impl/Arithmetic.h
@@ -25,20 +25,12 @@ DECLARE_OP_FN(div);
 DECLARE_OP_FN(floor_div);
 DECLARE_OP_FN(pow);
 
-ValueRef add_arithmetic_node(
-    ComputeGraph& graph,
-    const ValueRef in1,
-    const ValueRef in2,
-    const float alpha,
-    const api::ShaderInfo& shader,
-    const int64_t shared_object_idx = -1);
-
 void add_arithmetic_node(
     ComputeGraph& graph,
     const ValueRef in1,
     const ValueRef in2,
+    const ValueRef alpha,
     const ValueRef out,
-    const float alpha,
     const api::ShaderInfo& shader);
 
 struct ArithmeticParams final {

--- a/backends/vulkan/serialization/schema.fbs
+++ b/backends/vulkan/serialization/schema.fbs
@@ -26,8 +26,55 @@ table VkTensor {
   mem_obj_id:int;
 }
 
+table Null {}
+
+table Int {
+  int_val:long;
+}
+
+table Bool {
+  bool_val:bool;
+}
+
+table Double {
+  double_val:double;
+}
+
+table String {
+  string_val:string;
+}
+
+table IntList {
+  items:[long];
+}
+
+table DoubleList {
+  items:[double];
+}
+
+table BoolList {
+  items:[bool];
+}
+
+table ValueList {
+  items:[int];
+}
+
+union GraphTypes {
+  Null,
+  Int,
+  Double,
+  Bool,
+  VkTensor,
+  IntList,
+  DoubleList,
+  BoolList,
+  ValueList,
+  String,
+}
+
 table VkValue {
-  value:VkTensor;
+  value:GraphTypes;
 }
 
 // Abstraction to represent a region of bytes in a raw data buffer. Useful for referencing raw data

--- a/backends/vulkan/serialization/vulkan_graph_builder.py
+++ b/backends/vulkan/serialization/vulkan_graph_builder.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional
+from typing import Optional, Union
 
 import executorch.backends.vulkan.serialization.vulkan_graph_schema as vk_graph_schema
 
@@ -14,6 +14,9 @@ from executorch.exir.tensor import TensorSpec
 from torch._export.utils import get_buffer, get_param, is_buffer, is_param
 from torch.export import ExportedProgram
 from torch.fx import Node
+
+_ScalarType = Union[int, bool, float]
+_Argument = Union[torch.fx.Node, int, bool, float, str]
 
 
 class VkGraphBuilder:
@@ -106,7 +109,7 @@ class VkGraphBuilder:
 
         return const_buffer_idx
 
-    def create_single_vk_value(self, node: Node) -> int:
+    def create_single_tensor_value(self, node: Node) -> int:
         constant_id = self.maybe_add_constant_tensor(node)
 
         spec = node.meta.get("spec")
@@ -138,17 +141,48 @@ class VkGraphBuilder:
         )
         return new_id
 
-    def create_vk_values_for(self, node: Node):
+    def create_tensor_values(self, node: Node) -> int:
         spec = node.meta.get("spec")
         if isinstance(spec, TensorSpec):
-            return self.create_single_vk_value(node)
+            return self.create_single_tensor_value(node)
         else:
             raise RuntimeError(
                 "Creating values for nodes with collection types is not supported yet."
             )
 
+    def create_scalar_value(self, scalar: _ScalarType) -> int:
+        new_id = len(self.values)
+        if isinstance(scalar, int):
+            self.values.append(vk_graph_schema.VkValue(vk_graph_schema.Int(scalar)))
+        if isinstance(scalar, float):
+            self.values.append(vk_graph_schema.VkValue(vk_graph_schema.Double(scalar)))
+        if isinstance(scalar, bool):
+            self.values.append(vk_graph_schema.VkValue(vk_graph_schema.Bool(scalar)))
+        return new_id
+
+    def create_string_value(self, string: str) -> int:
+        new_id = len(self.values)
+        self.values.append(
+            vk_graph_schema.VkValue(vk_graph_schema.String(string_val=string))
+        )
+        return new_id
+
+    def get_or_create_value_for(self, arg: _Argument):
+        if isinstance(arg, torch.fx.Node):
+            # If the value has already been created, return the existing id
+            if arg in self.node_to_value_ids:
+                return self.node_to_value_ids[arg]
+            # Return id for a newly created value
+            return self.create_tensor_values(arg)
+        elif isinstance(arg, (int, float, bool)):
+            return self.create_scalar_value(arg)
+        elif isinstance(arg, str):
+            return self.create_string_value(arg)
+        else:
+            raise RuntimeError(f"Cannot create value for arg of type {type(arg)}")
+
     def process_placeholder_node(self, node: Node) -> None:
-        ids = self.create_vk_values_for(node)
+        ids = self.create_tensor_values(node)
         if not self.is_param_node(node):
             if isinstance(ids, int):
                 self.input_ids.append(ids)
@@ -156,27 +190,32 @@ class VkGraphBuilder:
                 self.input_ids += ids
 
     def process_call_function_node(self, node) -> None:
-        args = []
-        # Add input nodes
-        for inp_node in node.all_input_nodes:
-            if inp_node not in self.node_to_value_ids:
-                raise AssertionError(
-                    "Cannot find input to current node in node_to_value_ids. This means "
-                    "this node is being serialized before its input which is not allowed."
-                )
-            args.append(self.node_to_value_ids[inp_node])
+        operator_call_args = []
+
+        for i, schema_arg in enumerate(node.target._schema.arguments):
+            if not schema_arg.kwarg_only and i < len(node.args):
+                function_arg = node.args[i]
+            elif schema_arg.name in node.kwargs:
+                function_arg = node.kwargs[schema_arg.name]
+            else:
+                function_arg = schema_arg.default_value
+
+            # Create a value for each function argument. If the argument has been
+            # previously encountered, then use the existing value id.
+            operator_call_args.append(self.get_or_create_value_for(function_arg))
+
         # Add output node
-        args.append(self.create_vk_values_for(node))
+        operator_call_args.append(self.create_tensor_values(node))
 
         self.chain.append(
             vk_graph_schema.OperatorCall(
                 name=node.target.__name__,
-                args=args,
+                args=operator_call_args,
             ),
         )
 
     def process_getattr_node(self, node: Node) -> None:
-        self.create_vk_values_for(node)
+        self.create_tensor_values(node)
 
     def process_output_node(self, node: Node) -> None:
         if node.all_input_nodes[0] not in self.node_to_value_ids:

--- a/backends/vulkan/serialization/vulkan_graph_schema.py
+++ b/backends/vulkan/serialization/vulkan_graph_schema.py
@@ -12,7 +12,7 @@ Please refer to fbcode/caffe2/executorch/backends/vulkan/serialization/schema/sc
 
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import List
+from typing import List, Union
 
 
 @dataclass
@@ -34,13 +34,67 @@ class VkTensor:
 
 
 @dataclass
-class VkScalar:
+class Null:
     pass
 
 
 @dataclass
+class Int:
+    int_val: int
+
+
+@dataclass
+class Bool:
+    bool_val: bool
+
+
+@dataclass
+class Double:
+    double_val: float
+
+
+@dataclass
+class IntList:
+    items: List[int]
+
+
+@dataclass
+class DoubleList:
+    items: List[float]
+
+
+@dataclass
+class BoolList:
+    items: List[bool]
+
+
+@dataclass
+class ValueList:
+    items: List[int]
+
+
+@dataclass
+class String:
+    string_val: str
+
+
+GraphTypes = Union[
+    Null,
+    Int,
+    Double,
+    Bool,
+    VkTensor,
+    IntList,
+    BoolList,
+    DoubleList,
+    ValueList,
+    String,
+]
+
+
+@dataclass
 class VkValue:
-    value: VkTensor
+    value: "GraphTypes"
 
 
 @dataclass


### PR DESCRIPTION
Summary:
## Context

This changeset enables serialization and execution of Operators with arbitrary function signatures. Previously, only operators with a very specific schema were supported (2 inputs, 1 output).

This is achieved by extending the `Value` class (which is essentially a tagged union) to support all necessary types. All objects needed to execute an operator are now serialized/deserialized as a tagged union.

This changeset also refactors `VulkanBackend.cpp` by introducing `GraphBuilder` which makes constructing a `ComputeGraph` from a serialized flatbuffer much clearer.

Differential Revision: D54561567


