### PR TITLE
Serialize union fields with single entry dict.

### DIFF
--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -220,7 +220,7 @@ def serialize_tensor_meta(t: torch.Tensor) -> TensorMeta:
         requires_grad=t.requires_grad,
         device=Device(type=t.device.type, index=t.device.index),
         strides=[serialize_sym_int(s) for s in t.stride()],
-        storage_offset=0,
+        storage_offset=serialize_sym_int(0),
         layout=_TORCH_TO_SERIALIZE_LAYOUT[t.layout],
     )
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/121263

remove "$type" and "$value" fields, instead only serialize as {type: value} for union fields directly.

bypass-github-export-checks

Differential Revision: D54600943


