### PR TITLE
Update serialize_pte_binary to return cord

### DIFF
--- a/exir/_serialize/_program.py
+++ b/exir/_serialize/_program.py
@@ -346,7 +346,7 @@ def serialize_pte_binary(
     segment_alignment: int = 4096,
     constant_tensor_alignment: Optional[int] = None,
     delegate_alignment: Optional[int] = None,
-) -> bytes:
+) -> Cord:
     """Returns the runtime binary representation of the given Program.
 
     Args:
@@ -429,7 +429,7 @@ def serialize_pte_binary(
 
     # If there are no segments present, do not insert the extended header.
     if len(segments_data) == 0:
-        return result.data
+        return Cord(result.data)
 
     # Size of the header to insert. Its size is padded to the largest
     # force_align value present in the schema.
@@ -482,9 +482,7 @@ def serialize_pte_binary(
             len(pte_data) == segment_base_offset
         ), f"Offset of first segment {len(pte_data)} != segment base offset {segment_base_offset}"
         pte_data.append(segments_data)
-
-    # TODO(lfq): this creates a copy of all the data; once we update existing callsites this will change.
-    return bytes(pte_data)
+    return pte_data
 
 
 def _restore_segments(program: Program, segment_data: bytes) -> Program:

--- a/exir/_serialize/test/test_program.py
+++ b/exir/_serialize/test/test_program.py
@@ -164,11 +164,13 @@ class TestProgram(unittest.TestCase):
         add_constant_data(program, blobs)
 
         # Extract blobs into constant segment during serialization.
-        pte_data = serialize_pte_binary(
-            program,
-            extract_constant_segment=True,
-            segment_alignment=SEGMENT_ALIGNMENT,
-            constant_tensor_alignment=constant_tensor_alignment,
+        pte_data = bytes(
+            serialize_pte_binary(
+                program,
+                extract_constant_segment=True,
+                segment_alignment=SEGMENT_ALIGNMENT,
+                constant_tensor_alignment=constant_tensor_alignment,
+            )
         )
 
         # The input Program should not be modified.
@@ -395,7 +397,7 @@ class TestProgram(unittest.TestCase):
         deserializing.
         """
         program = get_test_program()
-        pte_data = serialize_pte_binary(program)
+        pte_data = bytes(serialize_pte_binary(program))
         self.assertGreater(len(pte_data), 16)
 
         # File magic should be present at the expected offset.
@@ -418,7 +420,7 @@ class TestProgram(unittest.TestCase):
         """
         program = get_test_program()
         program.execution_plan[0].non_const_buffer_sizes = [0, 2**48]
-        flatbuffer_from_py = serialize_pte_binary(program)
+        flatbuffer_from_py = bytes(serialize_pte_binary(program))
         self.assert_programs_equal(program, deserialize_pte_binary(flatbuffer_from_py))
 
     def test_round_trip_no_segments_and_no_header(self) -> None:
@@ -428,8 +430,10 @@ class TestProgram(unittest.TestCase):
         that a Program remains the same after serializing and deserializing.
         """
         program = get_test_program()
-        pte_data = serialize_pte_binary(
-            program, extract_delegate_segments=True, extract_constant_segment=True
+        pte_data = bytes(
+            serialize_pte_binary(
+                program, extract_delegate_segments=True, extract_constant_segment=True
+            )
         )
         self.assertGreater(len(pte_data), 16)
 
@@ -477,8 +481,12 @@ class TestProgram(unittest.TestCase):
         add_delegate_data(program, program.execution_plan[0], blobs)
 
         # Extract the blobs into segments during serialization.
-        pte_data = serialize_pte_binary(
-            program, extract_delegate_segments=True, segment_alignment=SEGMENT_ALIGNMENT
+        pte_data = bytes(
+            serialize_pte_binary(
+                program,
+                extract_delegate_segments=True,
+                segment_alignment=SEGMENT_ALIGNMENT,
+            )
         )
 
         # The input Program should not have been modified.
@@ -588,8 +596,12 @@ class TestProgram(unittest.TestCase):
         add_delegate_data(program, program.execution_plan[0], blobs)
 
         # Extract the blobs into segments should succeeed.
-        pte_data = serialize_pte_binary(
-            program, extract_delegate_segments=True, segment_alignment=SEGMENT_ALIGNMENT
+        pte_data = bytes(
+            serialize_pte_binary(
+                program,
+                extract_delegate_segments=True,
+                segment_alignment=SEGMENT_ALIGNMENT,
+            )
         )
         self.assertGreater(len(pte_data), 16)
 
@@ -644,12 +656,14 @@ class TestProgram(unittest.TestCase):
         add_delegate_data(program, program.execution_plan[0], delegate_blobs)
 
         # Extract the blobs into segments during serialization.
-        pte_data = serialize_pte_binary(
-            program,
-            extract_delegate_segments=True,
-            extract_constant_segment=True,
-            segment_alignment=SEGMENT_ALIGNMENT,
-            constant_tensor_alignment=CONSTANT_TENSOR_ALIGNMENT,
+        pte_data = bytes(
+            serialize_pte_binary(
+                program,
+                extract_delegate_segments=True,
+                extract_constant_segment=True,
+                segment_alignment=SEGMENT_ALIGNMENT,
+                constant_tensor_alignment=CONSTANT_TENSOR_ALIGNMENT,
+            )
         )
 
         # The input Program should not be modified.

--- a/exir/lowered_backend_module.py
+++ b/exir/lowered_backend_module.py
@@ -141,12 +141,15 @@ class LoweredBackendModule(torch.nn.Module):
         """
         Returns a buffer containing the serialized ExecuTorch binary.
         """
-        out = _serialize_pte_binary(
-            program=self.program(),
-            extract_delegate_segments=extract_delegate_segments,
-            segment_alignment=segment_alignment,
-            constant_tensor_alignment=constant_tensor_alignment,
-            delegate_alignment=delegate_alignment,
+        # TODO(T181463742): avoid calling bytes(..) which incurs large copies.
+        out = bytes(
+            _serialize_pte_binary(
+                program=self.program(),
+                extract_delegate_segments=extract_delegate_segments,
+                segment_alignment=segment_alignment,
+                constant_tensor_alignment=constant_tensor_alignment,
+                delegate_alignment=delegate_alignment,
+            )
         )
         return out
 

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -12,6 +12,7 @@ import torch
 import torch._export
 
 from executorch.exir._serialize import _serialize_pte_binary
+from executorch.exir._serialize._cord import Cord
 from executorch.exir.backend.backend_api import to_backend
 from executorch.exir.backend.partitioner import Partitioner
 from executorch.exir.capture._config import EdgeCompileConfig, ExecutorchBackendConfig
@@ -409,6 +410,7 @@ class ExecutorchProgram:
                 "Need to call prog.to_edge prior to constructing ExecutorchProgram."
             )
         self.exported_program = exir_exported_program.exported_program
+        self._pte_data: Optional[Cord] = None
         self._buffer: Optional[bytes] = None
         self._emitter_output: Optional[EmitterOutput] = None
         self._emit_stacktrace: bool = emit_stacktrace
@@ -418,10 +420,9 @@ class ExecutorchProgram:
         self._constant_tensor_alignment: Optional[int] = constant_tensor_alignment
         self._delegate_alignment: Optional[int] = delegate_alignment
 
-    @property
-    def buffer(self) -> bytes:
-        if self._buffer is None:
-            self._buffer = _serialize_pte_binary(
+    def _get_pte_data(self) -> Cord:
+        if self._pte_data is None:
+            self._pte_data = _serialize_pte_binary(
                 program=self.program,
                 extract_delegate_segments=self._extract_delegate_segments,
                 extract_constant_segment=self._extract_constant_segment,
@@ -429,6 +430,19 @@ class ExecutorchProgram:
                 constant_tensor_alignment=self._constant_tensor_alignment,
                 delegate_alignment=self._delegate_alignment,
             )
+        return self._pte_data
+
+    @property
+    def buffer(self) -> bytes:
+        """Returns the serialized ExecuTorch binary as a byte string.
+
+        Note that the call to `buffer` may allocate a very large amount of
+        contiguous memory, depending on the model size.
+        """
+        # TODO(T181494963): update pybinding to remove buffer cache, which can consume large
+        # amounts of memory longer than necessary.
+        if self._buffer is None:
+            self._buffer = bytes(self._get_pte_data())
         return self._buffer
 
     @property
@@ -720,6 +734,7 @@ class MultiMethodExecutorchProgram:
         delegate_alignment: Optional[int] = None,
         prim_getters: Optional[Dict[str, Any]] = None,
     ) -> None:
+        self._pte_data: Optional[Cord] = None
         self._buffer: Optional[bytes] = None
         temp: Dict[str, ExportedProgram] = {}
         for name, prog in executorch_dialect_program.methods().items():
@@ -737,10 +752,9 @@ class MultiMethodExecutorchProgram:
         self._delegate_alignment: Optional[int] = delegate_alignment
         self._prim_getter_cache = prim_getters
 
-    @property
-    def buffer(self) -> bytes:
-        if self._buffer is None:
-            self._buffer = _serialize_pte_binary(
+    def _get_pte_data(self) -> Cord:
+        if self._pte_data is None:
+            self._pte_data = _serialize_pte_binary(
                 program=self._emitter_output.program,
                 extract_delegate_segments=self._extract_delegate_segments,
                 extract_constant_segment=self._extract_constant_segment,
@@ -748,6 +762,19 @@ class MultiMethodExecutorchProgram:
                 constant_tensor_alignment=self._constant_tensor_alignment,
                 delegate_alignment=self._delegate_alignment,
             )
+        return self._pte_data
+
+    @property
+    def buffer(self) -> bytes:
+        """Returns the serialized ExecuTorch binary as a byte string.
+
+        Note that the call to `buffer` may allocate a very large amount of
+        contiguous memory, depending on the model size.
+        """
+        # TODO(T181494963): update pybinding to remove buffer cache, which can consume large
+        # amounts of memory longer than necessary.
+        if self._buffer is None:
+            self._buffer = bytes(self._get_pte_data())
         return self._buffer
 
     @property
@@ -1116,8 +1143,8 @@ class ExecutorchProgramManager:
             self._config_methods,
         )
 
-        # Serialize emitter output to a buffer
-        self._buffer: bytes = _serialize_pte_binary(
+        # Serialize emitter output, ready to be written to a file.
+        self._pte_data: Cord = _serialize_pte_binary(
             program=self._emitter_output.program,
             extract_delegate_segments=backend_config.extract_delegate_segments,
             extract_constant_segment=backend_config.extract_constant_segment,
@@ -1125,6 +1152,7 @@ class ExecutorchProgramManager:
             constant_tensor_alignment=backend_config.constant_tensor_alignment,
             delegate_alignment=backend_config.delegate_alignment,
         )
+        self._buffer: Optional[bytes] = None
 
     @property
     def methods(self) -> Set[str]:
@@ -1179,7 +1207,13 @@ class ExecutorchProgramManager:
 
     @property
     def buffer(self) -> bytes:
+        """Returns the serialized ExecuTorch binary as a byte string.
+
+        Note that the call to `buffer` may allocate a very large amount of
+        contiguous memory, depending on the model size.
         """
-        Returns a buffer containing the serialized ExecuTorch binary.
-        """
+        # TODO(T181494963): update pybinding to remove buffer cache, which can consume large
+        # amounts of memory longer than necessary.
+        if self._buffer is None:
+            self._buffer = bytes(self._pte_data)
         return self._buffer

--- a/sdk/bundled_program/core.py
+++ b/sdk/bundled_program/core.py
@@ -127,7 +127,8 @@ class BundledProgram:
                 )
             )
 
-        program_bytes: bytes = _serialize_pte_binary(program)
+        # TODO(T181463742): avoid calling bytes(..) which may incur large copies.
+        program_bytes: bytes = bytes(_serialize_pte_binary(program))
         self._bundled_program_in_schema = bp_schema.BundledProgram(
             version=BUNDLED_PROGRAM_SCHEMA_VERSION,
             method_test_suites=bundled_method_test_suites,

--- a/sdk/bundled_program/test/test_bundle_data.py
+++ b/sdk/bundled_program/test/test_bundle_data.py
@@ -69,7 +69,7 @@ class TestBundle(unittest.TestCase):
 
         self.assertEqual(
             bundled_program.serialize_to_schema().program,
-            _serialize_pte_binary(executorch_program.executorch_program),
+            bytes(_serialize_pte_binary(executorch_program.executorch_program)),
         )
 
     def test_bundled_miss_methods(self) -> None:


### PR DESCRIPTION
Summary: And update existing callsites to use bytes(serialize_pte_binary..), or write_to_file

Differential Revision: D54524444


