### PR TITLE
suggested fixes for congruences

### DIFF
--- a/exir/tests/test_tracer.py
+++ b/exir/tests/test_tracer.py
@@ -234,6 +234,7 @@ class TestTorchDispatchFXTracer(unittest.TestCase):
                 exir.CaptureConfig(
                     enable_functionalization=False,
                     enable_dynamic_shape=True,
+                    _dynamo_config=ExirDynamoConfig(assume_static_by_default=True),
                 ),
                 # sym_size is not reg op
             )


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/121418

Now that we have derived dims we can suggest fixes when we simply `Mod(...)` guards, a.k.a. congruences. E.g., when we see that `dim % 2 == 0` we can suggest the fix `dim = 2*_dim` where the range of `_dim` is reverse-engineered given the original range of `dim`.

Differential Revision: D54636152
