### PR TITLE
[ET-VK][EZ] Clean up OperatorRegistry

### DIFF
--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -173,7 +173,7 @@ class GraphBuilder {
     // Parse the operators
     for (OpCallPtr op_call : *(flatbuffer_->chain())) {
       std::string op_name = op_call->name()->str();
-      ET_CHECK_MSG(hasOpsFn(op_name), "Missing operator: %s", op_name.c_str());
+      ET_CHECK_MSG(VK_HAS_OP(op_name), "Missing operator: %s", op_name.c_str());
 
       const std::vector<int> arg_fb_ids(
           op_call->args()->cbegin(), op_call->args()->cend());
@@ -183,7 +183,7 @@ class GraphBuilder {
         args.push_back(get_fb_id_valueref(arg_fb_id));
       }
 
-      auto vkFn = getOpsFn(op_name);
+      auto vkFn = VK_GET_OP_FN(op_name);
       vkFn(*compute_graph_, args);
     }
 

--- a/backends/vulkan/runtime/graph/ops/OperatorRegistry.cpp
+++ b/backends/vulkan/runtime/graph/ops/OperatorRegistry.cpp
@@ -14,31 +14,19 @@ namespace at {
 namespace native {
 namespace vulkan {
 
-bool hasOpsFn(const std::string& name) {
-  return OperatorRegistry::getInstance().hasOpsFn(name);
-}
-
-OpFunction& getOpsFn(const std::string& name) {
-  return OperatorRegistry::getInstance().getOpsFn(name);
-}
-
-OperatorRegistry& OperatorRegistry::getInstance() {
-  static OperatorRegistry instance;
-  return instance;
-}
-
-bool OperatorRegistry::hasOpsFn(const std::string& name) {
+bool OperatorRegistry::has_op(const std::string& name) {
   return OperatorRegistry::kTable.count(name) > 0;
 }
 
-OpFunction& OperatorRegistry::getOpsFn(const std::string& name) {
+OperatorRegistry::OpFunction& OperatorRegistry::get_op_fn(
+    const std::string& name) {
   return OperatorRegistry::kTable.find(name)->second;
 }
 
 // @lint-ignore-every CLANGTIDY modernize-avoid-bind
 // clang-format off
 #define OPERATOR_ENTRY(name, function) \
-  { #name, std::bind(&at::native::vulkan::function, std::placeholders::_1, std::placeholders::_2) }
+  { #name, std::bind(&function, std::placeholders::_1, std::placeholders::_2) }
 // clang-format on
 
 const OperatorRegistry::OpTable OperatorRegistry::kTable = {
@@ -49,6 +37,11 @@ const OperatorRegistry::OpTable OperatorRegistry::kTable = {
     OPERATOR_ENTRY(aten.div.Tensor_mode, floor_div),
     OPERATOR_ENTRY(aten.pow.Tensor_Tensor, pow),
 };
+
+OperatorRegistry& operator_registry() {
+  static OperatorRegistry registry;
+  return registry;
+}
 
 } // namespace vulkan
 } // namespace native


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2305
* __->__ #2304
* #2312

Align `OperatorRegistry` with the style of `ShaderRegistry` in https://github.com/pytorch/executorch/pull/2222

This means
- Improve comments and comment formatting.
- Use snake case, even if it deviates from the original registry I was following. Snake case is more consistent with the Vulkan backend code.
https://www.internalfb.com/code/fbsource/[a97f9ed1a715231bb61b05942273f1e8f8631503]/fbcode/executorch/runtime/kernel/operator_registry.h?lines=208%2C213
- Move `using` declarations and member variables to top of class definition.
- Place static `OperatorRegistry` instance declaration in a global function `operator_registry()` instead of in member function `getInstance()`.
- Use macros to wrap `OperatorRegistry` functions instead of global functions.
- For simplicity, remove unneeded ctor and assignment operator deletion/hiding. Note users can now create their own non-static `OperatorRegistry` instance and we can consider hiding this again later.

Differential Revision: [D54640160](https://our.internmc.facebook.com/intern/diff/D54640160/)