### PR TITLE
Handle multiple output from forward

### DIFF
--- a/examples/demo-apps/android/ExecuTorchDemo/app/src/main/java/com/example/executorchdemo/ClassificationActivity.java
+++ b/examples/demo-apps/android/ExecuTorchDemo/app/src/main/java/com/example/executorchdemo/ClassificationActivity.java
@@ -71,7 +71,7 @@ public class ClassificationActivity extends Activity implements Runnable {
             TensorImageUtils.TORCHVISION_NORM_STD_RGB);
 
     // running the model
-    final Tensor outputTensor = module.forward(EValue.from(inputTensor)).toTensor();
+    final Tensor outputTensor = module.forward(EValue.from(inputTensor))[0].toTensor();
 
     // getting tensor content as java array of floats
     final float[] scores = outputTensor.getDataAsFloatArray();

--- a/examples/demo-apps/android/ExecuTorchDemo/app/src/main/java/com/example/executorchdemo/MainActivity.java
+++ b/examples/demo-apps/android/ExecuTorchDemo/app/src/main/java/com/example/executorchdemo/MainActivity.java
@@ -189,7 +189,7 @@ public class MainActivity extends Activity implements Runnable {
     final float[] inputs = inputTensor.getDataAsFloatArray();
 
     final long startTime = SystemClock.elapsedRealtime();
-    Tensor outputTensor = mModule.forward(EValue.from(inputTensor)).toTensor();
+    Tensor outputTensor = mModule.forward(EValue.from(inputTensor))[0].toTensor();
     final long inferenceTime = SystemClock.elapsedRealtime() - startTime;
     Log.d("ImageSegmentation", "inference time (ms): " + inferenceTime);
 

--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -260,14 +260,14 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
         torch::executor::Module::MlockConfig::NoMlock);
   }
 
-  facebook::jni::local_ref<JEValue> forward(
+  facebook::jni::local_ref<facebook::jni::JArrayClass<JEValue>> forward(
       facebook::jni::alias_ref<
           facebook::jni::JArrayClass<JEValue::javaobject>::javaobject>
           jinputs) {
     return execute_method("forward", jinputs);
   }
 
-  facebook::jni::local_ref<JEValue> execute(
+  facebook::jni::local_ref<facebook::jni::JArrayClass<JEValue>> execute(
       facebook::jni::alias_ref<jstring> methodName,
       facebook::jni::alias_ref<
           facebook::jni::JArrayClass<JEValue::javaobject>::javaobject>
@@ -275,7 +275,7 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
     return execute_method(methodName->toStdString(), jinputs);
   }
 
-  facebook::jni::local_ref<JEValue> execute_method(
+  facebook::jni::local_ref<facebook::jni::JArrayClass<JEValue>> execute_method(
       std::string method,
       facebook::jni::alias_ref<
           facebook::jni::JArrayClass<JEValue::javaobject>::javaobject>
@@ -327,7 +327,15 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
         static_cast<error_code_t>(result.error()));
     ET_LOG(Info, "Model executed successfully.");
 
-    return JEValue::newJEValueFromEValue(result.get()[0]);
+    facebook::jni::local_ref<facebook::jni::JArrayClass<JEValue>> jresult =
+        facebook::jni::JArrayClass<JEValue>::newArray(result.get().size());
+
+    for (int i = 0; i < result.get().size(); i++) {
+      auto jevalue = JEValue::newJEValueFromEValue(result.get()[i]);
+      jresult->setElement(i, *jevalue);
+    }
+
+    return jresult;
   }
 
   static void registerNatives() {

--- a/extension/android/src/main/java/org/pytorch/executorch/INativePeer.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/INativePeer.java
@@ -14,8 +14,8 @@ interface INativePeer {
   void resetNative();
 
   /** Run a "forward" call with the given inputs */
-  EValue forward(EValue... inputs);
+  EValue[] forward(EValue... inputs);
 
   /** Run an arbitrary method on the module */
-  EValue execute(String methodName, EValue... inputs);
+  EValue[] execute(String methodName, EValue... inputs);
 }

--- a/extension/android/src/main/java/org/pytorch/executorch/Module.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/Module.java
@@ -52,7 +52,7 @@ public class Module {
    * @param inputs arguments for the ExecuTorch module's 'forward' method.
    * @return return value from the 'forward' method.
    */
-  public EValue forward(EValue... inputs) {
+  public EValue[] forward(EValue... inputs) {
     return mNativePeer.forward(inputs);
   }
 
@@ -63,7 +63,7 @@ public class Module {
    * @param inputs arguments that will be passed to ExecuTorch method.
    * @return return value from the method.
    */
-  public EValue execute(String methodName, EValue... inputs) {
+  public EValue[] execute(String methodName, EValue... inputs) {
     return mNativePeer.execute(methodName, inputs);
   }
 

--- a/extension/android/src/main/java/org/pytorch/executorch/NativePeer.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/NativePeer.java
@@ -34,8 +34,8 @@ class NativePeer implements INativePeer {
   }
 
   @DoNotStrip
-  public native EValue forward(EValue... inputs);
+  public native EValue[] forward(EValue... inputs);
 
   @DoNotStrip
-  public native EValue execute(String methodName, EValue... inputs);
+  public native EValue[] execute(String methodName, EValue... inputs);
 }


### PR DESCRIPTION
Summary: In PyTorch, we can handle tuple type so we assume we only have 1 output; for ExecuTorch, we want to handle multiple outputs.  Some models like torchvision DeepLab V3 has a tuple of outputs.

Differential Revision: D54660169


