### PR TITLE
Integrate sdk

### DIFF
--- a/backends/apple/coreml/.gitignore
+++ b/backends/apple/coreml/.gitignore
@@ -1,7 +1,7 @@
 # Mac OS X
 *.DS_Store
 
-cmake-out/
+*-cmake-out/
 
 
 # Xcode
@@ -18,6 +18,7 @@ runtime/runner/build/
 runtime/libraries/
 runtime/inmemoryfs/build/
 runtime/test/models/
+runtime/sdk/format/
 runtime/include/executorch/
 third-party/
 

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -38,6 +38,9 @@ set(DELEGATE_SOURCES
   runtime/delegate/coreml_backend_delegate.mm
   runtime/delegate/ETCoreMLAsset.mm
   runtime/delegate/ETCoreMLAssetManager.mm
+  runtime/delegate/ETCoreMLDefaultModelExecutor.mm
+  runtime/delegate/ETCoreMLModelLoader.mm
+  runtime/delegate/ETCoreMLModelCompiler.mm
   runtime/delegate/ETCoreMLLogging.mm
   runtime/delegate/ETCoreMLModel.mm
   runtime/delegate/ETCoreMLModelManager.mm
@@ -54,6 +57,57 @@ set(UTIL_SOURCES
   runtime/util/objc_json_serde.mm
 )
 
+# sdk sources
+set(SDK_SOURCES
+  runtime/sdk/ETCoreMLModelAnalyzer.mm
+  runtime/sdk/ETCoreMLModelStructurePath.mm
+  runtime/sdk/ETCoreMLOperationProfilingInfo.mm
+  runtime/sdk/ETCoreMLModelDebugger.mm
+  runtime/sdk/ETCoreMLModelProfiler.mm
+  runtime/sdk/ETCoreMLPair.mm
+  runtime/sdk/model_package_info.mm
+  runtime/sdk/model_event_logger_impl.mm
+  runtime/sdk/program_path.mm
+)
+
+# protobuf sources
+set(PROTOBUF_SOURCES
+  runtime/sdk/format/ArrayFeatureExtractor.pb.cc
+  runtime/sdk/format/AudioFeaturePrint.pb.cc
+  runtime/sdk/format/BayesianProbitRegressor.pb.cc
+  runtime/sdk/format/CategoricalMapping.pb.cc
+  runtime/sdk/format/ClassConfidenceThresholding.pb.cc
+  runtime/sdk/format/CustomModel.pb.cc
+  runtime/sdk/format/DataStructures.pb.cc
+  runtime/sdk/format/DictVectorizer.pb.cc
+  runtime/sdk/format/FeatureTypes.pb.cc
+  runtime/sdk/format/FeatureVectorizer.pb.cc
+  runtime/sdk/format/Gazetteer.pb.cc
+  runtime/sdk/format/GLMClassifier.pb.cc
+  runtime/sdk/format/GLMRegressor.pb.cc
+  runtime/sdk/format/Identity.pb.cc
+  runtime/sdk/format/Imputer.pb.cc
+  runtime/sdk/format/ItemSimilarityRecommender.pb.cc
+  runtime/sdk/format/LinkedModel.pb.cc
+  runtime/sdk/format/MIL.pb.cc
+  runtime/sdk/format/Model.pb.cc
+  runtime/sdk/format/NearestNeighbors.pb.cc
+  runtime/sdk/format/NeuralNetwork.pb.cc
+  runtime/sdk/format/NonMaximumSuppression.pb.cc
+  runtime/sdk/format/Normalizer.pb.cc
+  runtime/sdk/format/NonMaximumSuppression.pb.cc
+  runtime/sdk/format/OneHotEncoder.pb.cc
+  runtime/sdk/format/Parameters.pb.cc
+  runtime/sdk/format/Scaler.pb.cc
+  runtime/sdk/format/SoundAnalysisPreprocessing.pb.cc
+  runtime/sdk/format/SVM.pb.cc
+  runtime/sdk/format/TextClassifier.pb.cc
+  runtime/sdk/format/TreeEnsemble.pb.cc
+  runtime/sdk/format/VisionFeaturePrint.pb.cc
+  runtime/sdk/format/WordEmbedding.pb.cc
+  runtime/sdk/format/WordTagger.pb.cc
+)
+
 # Define the delegate library
 add_library(coremldelegate)
 target_sources(
@@ -63,6 +117,7 @@ target_sources(
   ${DELEGATE_SOURCES}
   ${UTIL_SOURCES}
 )
+
 target_include_directories(
   coremldelegate PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/runtime/include
@@ -87,7 +142,30 @@ target_include_directories(
   coremldelegate PRIVATE
   ${EXECUTORCH_ROOT}/..
 )
-target_compile_options(executorch PUBLIC -DET_EVENT_TRACER_ENABLED)
+target_link_libraries(
+  coremldelegate PRIVATE
+  executorch
+)
+
+if(EXECUTORCH_BUILD_SDK)
+target_sources(
+  coremldelegate PRIVATE
+  ${SDK_SOURCES}
+  ${PROTOBUF_SOURCES}
+)
+target_include_directories(
+  coremldelegate PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/runtime/sdk
+  ${CMAKE_CURRENT_SOURCE_DIR}/third-party/coremltools/deps/protobuf/src
+)
+add_subdirectory(
+  ${CMAKE_CURRENT_SOURCE_DIR}/third-party/coremltools/deps/protobuf/cmake
+)
+target_link_libraries(
+  coremldelegate PRIVATE
+  libprotobuf-lite
+)
+endif()
 
 find_library(ACCELERATE_FRAMEWORK Accelerate)
 find_library(COREML_FRAMEWORK CoreML)
@@ -105,7 +183,14 @@ target_link_libraries(coremldelegate
 
 target_compile_options(coremldelegate PRIVATE "-fobjc-arc")
 target_compile_options(coremldelegate PRIVATE "-fno-exceptions")
+
+if(EXECUTORCH_BUILD_SDK)
+target_compile_options(executorch PUBLIC -DET_EVENT_TRACER_ENABLED)
+target_compile_options(coremldelegate PRIVATE "-frtti")
+target_compile_options(libprotobuf-lite PRIVATE "-frtti")
+else()
 target_compile_options(coremldelegate PRIVATE "-fno-rtti")
+endif()
 
 set(
   TARGET coremldelegate

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLAsset.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLAsset.h
@@ -1,7 +1,7 @@
 //
 // ETCoreMLAsset.h
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Represents an asset on the filesystem. An asset is merely a directory with a unique identifier.
+/// Represents an asset on the filesystem.
 @interface ETCoreMLAsset : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Constructs an `ETCoreMLAsset` instance from `ModelAsset`
 ///
 /// @param backingAsset The cpp asset.
-- (instancetype)initWithBackingAsset:(const executorchcoreml::Asset&)backingAsset NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBackingAsset:(executorchcoreml::Asset)backingAsset NS_DESIGNATED_INITIALIZER;
 
 /// The unique identifier.
 @property (copy, readonly, nonatomic) NSString* identifier;
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @retval `YES` is the advisory read to all the files succeeded otherwise`NO`.
 - (BOOL)prewarmAndReturnError:(NSError* __autoreleasing*)error;
 
-/// Closes all the opened file handles by the `keepAliveAndReturnError` call.
+/// Closes all the file handles opened by the `keepAliveAndReturnError` call.
 - (void)close;
 
 @end

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLAsset.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLAsset.mm
@@ -1,7 +1,7 @@
 //
 // ETCoreMLAsset.mm
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
@@ -66,14 +66,14 @@ void set_error_from_error_code(const std::error_code& cppError, NSError * __auto
     os_unfair_lock _lock;
 }
 
-- (instancetype)initWithBackingAsset:(const executorchcoreml::Asset&)backingAsset {
+- (instancetype)initWithBackingAsset:(executorchcoreml::Asset)backingAsset {
     self = [super init];
     if (self) {
-        _backingAsset = backingAsset;
         _isValid = static_cast<BOOL>(is_asset_valid(backingAsset));
         _identifier = @(backingAsset.identifier.c_str());
         _contentURL = [NSURL fileURLWithPath:@(backingAsset.path.c_str())];
         _totalSizeInBytes = backingAsset.total_size_in_bytes();
+        _backingAsset = std::move(backingAsset);
     }
     
     return self;

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLAssetManager.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLAssetManager.h
@@ -1,7 +1,7 @@
 //
 // ETCoreMLAssetManager.h
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
@@ -116,6 +116,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The trash directory URL, the assets before removal are moved to this directory. The directory
 /// contents are deleted asynchronously.
 @property (copy, readonly, nonatomic) NSURL* trashDirectoryURL;
+
+/// The file manager.
+@property (strong, readonly, nonatomic) NSFileManager* fileManager;
 
 @end
 

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLAssetManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLAssetManager.mm
@@ -1,21 +1,18 @@
 //
 // ETCoreMLAssetManager.mm
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
 #import "ETCoreMLAssetManager.h"
-
-#import <iostream>
-#import <sstream>
-
-#import <database.hpp>
-#import <json_key_value_store.hpp>
-#import <serde_json.h>
-
 #import <ETCoreMLAsset.h>
 #import <ETCoreMLLogging.h>
+#import <database.hpp>
+#import <iostream>
+#import <json_key_value_store.hpp>
+#import <serde_json.h>
+#import <sstream>
 
 namespace  {
 
@@ -264,7 +261,6 @@ get_assets_to_remove(ModelAssetsStore& store,
 
 @property (assign, readwrite, atomic) NSInteger estimatedSizeInBytes;
 @property (copy, readonly, nonatomic) NSURL *assetsDirectoryURL;
-@property (strong, readonly, nonatomic) NSFileManager *fileManager;
 @property (strong, readonly, nonatomic) dispatch_queue_t syncQueue;
 @property (strong, readonly, nonatomic) dispatch_queue_t trashQueue;
 @property (strong, readonly, nonatomic) NSMapTable<NSString *, ETCoreMLAsset *> *assetsInUseMap;

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLComputeUnits.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLComputeUnits.h
@@ -1,0 +1,14 @@
+//
+// ETCoreMLComputeUnits.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+/// An enum representing the compute options on the system.
+typedef NS_OPTIONS(NSUInteger, ETCoreMLComputeUnits) {
+    ETCoreMLComputeUnitUnknown = 0, // Unknown compute unit.
+    ETCoreMLComputeUnitCPU = 1 << 0, // Represents the CPU compute unit.
+    ETCoreMLComputeUnitGPU = 1 << 1, // Represents the GPU compute unit.
+    ETCoreMLComputeUnitNeuralEngine = 1 << 2 // Represents the NeuralEngine compute unit.
+};

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLDefaultModelExecutor.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLDefaultModelExecutor.h
@@ -1,0 +1,32 @@
+//
+//  ETCoreMLDefaultModelExecutor.h
+//  executorchcoreml_tests
+//
+//  Created by Gyan Sinha on 2/25/24.
+//
+
+#import <CoreML/CoreML.h>
+
+#import <ETCoreMLModelExecutor.h>
+
+@class ETCoreMLModel;
+
+NS_ASSUME_NONNULL_BEGIN
+/// The default model executor, the executor ignores logging options.
+__attribute__((objc_subclassing_restricted)) @interface ETCoreMLDefaultModelExecutor : NSObject<ETCoreMLModelExecutor>
+
++ (instancetype)new NS_UNAVAILABLE;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Constructs an `ETCoreMLDefaultModelExecutor` from the given model.
+///
+/// @param model The model.
+- (instancetype)initWithModel:(ETCoreMLModel*)model NS_DESIGNATED_INITIALIZER;
+
+/// The model.
+@property (readonly, strong, nonatomic) ETCoreMLModel* model;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLDefaultModelExecutor.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLDefaultModelExecutor.mm
@@ -1,0 +1,55 @@
+//
+//  ETCoreMLDefaultModelExecutor.m
+//  executorchcoreml_tests
+//
+//  Created by Gyan Sinha on 2/25/24.
+//
+
+#import <ETCoreMLAsset.h>
+#import <ETCoreMLDefaultModelExecutor.h>
+#import <ETCoreMLLogging.h>
+#import <ETCoreMLModel.h>
+
+@implementation ETCoreMLDefaultModelExecutor
+
+- (instancetype)initWithModel:(ETCoreMLModel *)model {
+    self = [super init];
+    if (self) {
+        _model = model;
+    }
+    
+    return self;
+}
+
+- (nullable NSArray<MLMultiArray *> *)executeModelWithInputs:(id<MLFeatureProvider>)inputs
+                                           predictionOptions:(MLPredictionOptions *)predictionOptions
+                                              loggingOptions:(const executorchcoreml::ModelLoggingOptions& __unused)loggingOptions
+                                                 eventLogger:(const executorchcoreml::ModelEventLogger* _Nullable __unused)eventLogger
+                                                       error:(NSError * __autoreleasing *)error {
+    id<MLFeatureProvider> outputs = [self.model.mlModel predictionFromFeatures:inputs
+                                                                       options:predictionOptions
+                                                                         error:error];
+    if (!outputs) {
+        return nil;
+    }
+    
+    NSOrderedSet<NSString*>* orderedOutputNames = self.model.orderedOutputNames;
+    NSMutableArray<MLMultiArray *> *result = [NSMutableArray arrayWithCapacity:orderedOutputNames.count];
+    for (NSString *outputName in orderedOutputNames) {
+        MLFeatureValue *featureValue = [outputs featureValueForName:outputName];
+        if (!featureValue.multiArrayValue) {
+            ETCoreMLLogErrorAndSetNSError(error,
+                                          ETCoreMLErrorBrokenModel,
+                                          "%@: Model is broken, expected multiarray for output=%@.",
+                                          NSStringFromClass(self.class),
+                                          outputName);
+            return nil;
+        }
+        
+        [result addObject:featureValue.multiArrayValue];
+    }
+    
+    return result;
+}
+
+@end

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.h
@@ -1,7 +1,7 @@
 //
 // ETCoreMLLogging.h
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
@@ -22,7 +22,8 @@ typedef NS_ERROR_ENUM(ETCoreMLErrorDomain, ETCoreMLError) {
     ETCoreMLErrorBrokenModel, // CoreML model doesn't match the input and output specification.
     ETCoreMLErrorCompilationFailed, // CoreML model failed to compile.
     ETCoreMLErrorModelSaveFailed, // Failed to save CoreML model to disk.
-    ETCoreMLErrorModelCacheCreationFailed // Failed to create model cache.
+    ETCoreMLErrorModelCacheCreationFailed, // Failed to create model cache.
+    ETCoreMLErrorInternalError, // Internal error.
 };
 
 @interface ETCoreMLErrorUtils : NSObject

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.mm
@@ -1,7 +1,7 @@
 //
 // ETCoreMLLogging.mm
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModel.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModel.h
@@ -1,7 +1,7 @@
 //
 // ETCoreMLModel.h
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModel.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModel.mm
@@ -1,7 +1,7 @@
 //
 // ETCoreMLModel.mm
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelCompiler.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelCompiler.h
@@ -1,0 +1,29 @@
+//
+// ETCoreMLModelCompiler.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <CoreML/CoreML.h>
+
+NS_ASSUME_NONNULL_BEGIN
+/// A class responsible for compiling a CoreML model.
+__attribute__((objc_subclassing_restricted)) @interface ETCoreMLModelCompiler : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Synchronously compiles a model given the location of its on-disk representation.
+///
+/// @param modelURL The location of the model's on-disk representation (.mlpackage directory).
+/// @param maxWaitTimeInSeconds The maximum wait time in seconds.
+/// @param error   On failure, error is filled with the failure information.
++ (nullable NSURL*)compileModelAtURL:(NSURL*)modelURL
+                maxWaitTimeInSeconds:(NSTimeInterval)maxWaitTimeInSeconds
+                               error:(NSError* __autoreleasing*)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelCompiler.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelCompiler.mm
@@ -1,0 +1,39 @@
+//
+// ETCoreMLModelCompiler.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <ETCoreMLModelCompiler.h>
+#import <ETCoreMLLogging.h>
+
+@implementation ETCoreMLModelCompiler
+
++ (nullable NSURL *)compileModelAtURL:(NSURL *)modelURL
+                 maxWaitTimeInSeconds:(NSTimeInterval)maxWaitTimeInSeconds
+                                error:(NSError* __autoreleasing *)error {
+    __block NSError *localError = nil;
+    __block NSURL *result = nil;
+    
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    [MLModel compileModelAtURL:modelURL completionHandler:^(NSURL * _Nullable tempURL, NSError * _Nullable compilationError) {
+        result = [tempURL copy];
+        localError = compilationError;
+        dispatch_semaphore_signal(sema);
+    }];
+    
+    long status = dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(maxWaitTimeInSeconds * NSEC_PER_SEC)));
+    if (status != 0) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      ETCoreMLErrorCompilationFailed,
+                                      "%@: Failed to compile model in %f seconds.",
+                                      NSStringFromClass(ETCoreMLModelCompiler.class),
+                                      maxWaitTimeInSeconds);
+        return nil;
+    }
+    
+    return result;
+}
+
+@end

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelExecutor.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelExecutor.h
@@ -1,0 +1,41 @@
+//
+// ETCoreMLModelExecutor.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <CoreML/CoreML.h>
+
+@class ETCoreMLModel;
+
+namespace executorchcoreml {
+struct ModelLoggingOptions;
+class ModelEventLogger;
+}
+
+NS_ASSUME_NONNULL_BEGIN
+/// A protocol that an object must adopt for hooking into `ETCoreMLModelManager` as a model executor.
+@protocol ETCoreMLModelExecutor <NSObject>
+
+/// Executes the model with the given inputs and returns the outputs.
+///
+/// @param inputs The inputs to the model.
+/// @param predictionOptions The prediction options.
+/// @param loggingOptions The logging options.
+/// @param eventLogger The event logger.
+/// @param error   On failure, error is filled with the failure information.
+- (nullable NSArray<MLMultiArray*>*)executeModelWithInputs:(id<MLFeatureProvider>)inputs
+                                         predictionOptions:(MLPredictionOptions*)predictionOptions
+                                            loggingOptions:(const executorchcoreml::ModelLoggingOptions&)loggingOptions
+                                               eventLogger:
+                                                   (const executorchcoreml::ModelEventLogger* _Nullable)eventLogger
+                                                     error:(NSError* __autoreleasing*)error;
+
+/// The model.
+@property (readonly, strong, nonatomic) ETCoreMLModel* model;
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelLoader.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelLoader.h
@@ -1,0 +1,40 @@
+//
+// ETCoreMLModelLoader.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <CoreML/CoreML.h>
+
+@class ETCoreMLModel;
+@class ETCoreMLAssetManager;
+
+namespace executorchcoreml {
+struct ModelMetadata;
+}
+
+NS_ASSUME_NONNULL_BEGIN
+/// A class responsible for loading a CoreML model.
+__attribute__((objc_subclassing_restricted)) @interface ETCoreMLModelLoader : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Synchronously loads a model given the location of its on-disk representation and configuration.
+///
+/// @param compiledModelURL The location of the model's on-disk representation (.mlmodelc directory).
+/// @param configuration The model configuration.
+/// @param metadata   The model metadata.
+/// @param assetManager The asset manager used to manage storage of compiled models.
+/// @param error   On failure, error is filled with the failure information.
++ (nullable ETCoreMLModel*)loadModelWithContentsOfURL:(NSURL*)compiledModelURL
+                                        configuration:(MLModelConfiguration*)configuration
+                                             metadata:(const executorchcoreml::ModelMetadata&)metadata
+                                         assetManager:(ETCoreMLAssetManager*)assetManager
+                                                error:(NSError* __autoreleasing*)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelLoader.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelLoader.mm
@@ -1,0 +1,82 @@
+//
+// ETCoreMLModelLoader.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <ETCoreMLAsset.h>
+#import <ETCoreMLAssetManager.h>
+#import <ETCoreMLDefaultModelExecutor.h>
+#import <ETCoreMLLogging.h>
+#import <ETCoreMLModel.h>
+#import <ETCoreMLModelLoader.h>
+#import <asset.h>
+#import <model_metadata.h>
+
+using namespace executorchcoreml;
+
+namespace {
+    NSOrderedSet<NSString *> *get_ordered_set(const std::vector<std::string>& values) {
+        NSMutableOrderedSet<NSString *> *result = [NSMutableOrderedSet orderedSetWithCapacity:values.size()];
+        for (const auto& value : values) {
+            [result addObject:@(value.c_str())];
+        }
+        
+        return result;
+    }
+
+    ETCoreMLModel * _Nullable get_model_from_asset(ETCoreMLAsset *asset,
+                                                   MLModelConfiguration *configuration,
+                                                   const executorchcoreml::ModelMetadata& metadata,
+                                                   NSError * __autoreleasing *error) {
+        NSOrderedSet<NSString *> *orderedInputNames = ::get_ordered_set(metadata.input_names);
+        NSOrderedSet<NSString *> *orderedOutputNames = ::get_ordered_set(metadata.output_names);
+        ETCoreMLModel *model = [[ETCoreMLModel alloc] initWithAsset:asset
+                                                      configuration:configuration
+                                                  orderedInputNames:orderedInputNames
+                                                 orderedOutputNames:orderedOutputNames
+                                                              error:error];
+        return model;
+    }
+} // namespace
+
+@implementation ETCoreMLModelLoader
+
++ (nullable ETCoreMLModel *)loadModelWithContentsOfURL:(NSURL *)compiledModelURL
+                                         configuration:(MLModelConfiguration *)configuration
+                                              metadata:(const executorchcoreml::ModelMetadata&)metadata
+                                          assetManager:(ETCoreMLAssetManager *)assetManager
+                                                 error:(NSError * __autoreleasing *)error {
+    NSError *localError = nil;
+    NSString *identifier = @(metadata.identifier.c_str());
+    ETCoreMLAsset *asset = nil;
+    if ([assetManager hasAssetWithIdentifier:identifier error:&localError]) {
+        asset = [assetManager assetWithIdentifier:identifier error:&localError];
+    } else {
+        asset = [assetManager storeAssetAtURL:compiledModelURL withIdentifier:identifier error:&localError];
+    }
+    
+    ETCoreMLModel *model = (asset != nil) ? get_model_from_asset(asset, configuration, metadata, &localError) : nil;
+    if (model) {
+        return model;
+    }
+    
+    if (localError) {
+        ETCoreMLLogError(localError,
+                         "%@: Failed to load model from compiled asset with identifier = %@",
+                         NSStringFromClass(ETCoreMLModelLoader.class),
+                         identifier);
+    }
+    
+    // If store failed then we will load the model from compiledURL.
+    auto backingAsset = Asset::make(compiledModelURL, identifier, assetManager.fileManager, error);
+    if (!backingAsset) {
+        return nil;
+    }
+    
+    asset = [[ETCoreMLAsset alloc] initWithBackingAsset:backingAsset.value()];
+    return ::get_model_from_asset(asset, configuration, metadata, error);
+}
+
+@end

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.h
@@ -1,14 +1,18 @@
 //
 // ETCoreMLModelManager.h
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
-
 
 #import <CoreML/CoreML.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+namespace executorchcoreml {
+struct ModelLoggingOptions;
+class ModelEventLogger;
+};
 
 @class ETCoreMLModel;
 @class ETCoreMLAssetManager;
@@ -16,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void ModelHandle;
 
 /// A class responsible for managing the models loaded by the delegate.
-@interface ETCoreMLModelManager : NSObject
+__attribute__((objc_subclassing_restricted)) @interface ETCoreMLModelManager : NSObject
 
 + (instancetype)new NS_UNAVAILABLE;
 
@@ -24,7 +28,7 @@ typedef void ModelHandle;
 
 /// Constructs an `ETCoreMLModelManager` instance.
 ///
-/// @param assetManager The asset manager that will be used to store the compiled models.
+/// @param assetManager The asset manager used to manage storage of compiled models.
 - (instancetype)initWithAssetManager:(ETCoreMLAssetManager*)assetManager NS_DESIGNATED_INITIALIZER;
 
 /// Loads the model from the AOT  data.
@@ -46,10 +50,13 @@ typedef void ModelHandle;
 ///
 /// @param handle The handle to the loaded model.
 /// @param args The arguments to the model.
+/// @param loggingOptions The model logging options.
 /// @param error   On failure, error is filled with the failure information.
 /// @retval `YES` if the execution succeeded otherwise `NO`.
 - (BOOL)executeModelWithHandle:(ModelHandle*)handle
                           args:(NSArray<MLMultiArray*>*)args
+                loggingOptions:(const executorchcoreml::ModelLoggingOptions&)loggingOptions
+                   eventLogger:(const executorchcoreml::ModelEventLogger* _Nullable)eventLogger
                          error:(NSError* __autoreleasing*)error;
 
 /// Unloads the loaded model.

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLStrings.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLStrings.h
@@ -1,7 +1,7 @@
 //
 // ETCoreMLStrings.h
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (class, copy, readonly, nonatomic) NSString* metadataFileRelativePath;
 /// The model package relative path in the AOT blob.
 @property (class, copy, readonly, nonatomic) NSString* modelFileRelativePath;
+/// The compiled model relative path in the AOT blob.
+@property (class, copy, readonly, nonatomic) NSString* compiledModelFileRelativePath;
 
 /// The default assets directory path.
 @property (class, copy, readonly, nonatomic, nullable) NSString* assetsDirectoryPath;
@@ -59,6 +61,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (class, copy, readonly, nonatomic) NSString* cpuAndNeuralEngineComputeUnitsName;
 /// All compute units name.
 @property (class, copy, readonly, nonatomic) NSString* allComputeUnitsName;
+
+/// The name of debug symbols in the manifest file of `mlpackage`.
+@property (class, copy, readonly, nonatomic, nullable) NSString* debugSymbols;
 
 @end
 

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLStrings.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLStrings.mm
@@ -1,7 +1,7 @@
 //
 // ETCoreMLStrings.mm
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
@@ -55,6 +55,11 @@
     return ETCoreMLModelFileRelativePath;
 }
 
++ (NSString *)compiledModelFileRelativePath {
+    static NSString * const ETCoreMLCompiledModelFileRelativePath = @"model.mlmodelc";
+    return ETCoreMLCompiledModelFileRelativePath;
+}
+
 + (NSString *)cpuComputeUnitName {
     static NSString * const ETCoreMLCPUComputeUnitName = @"cpu_only";
     return ETCoreMLCPUComputeUnitName;
@@ -78,6 +83,11 @@
 + (NSString *)databaseName {
     static NSString * const ETCoreMLDatabaseName = @"assets.db";
     return ETCoreMLDatabaseName;
+}
+
++ (NSString *)debugSymbols {
+    static NSString * const ETCoreMLDebugSymbolsName = @"debugSymbols";
+    return ETCoreMLDebugSymbolsName;
 }
 
 + (nullable NSString *)assetsDirectoryPath {

--- a/backends/apple/coreml/runtime/delegate/MLModel_Prewarm.h
+++ b/backends/apple/coreml/runtime/delegate/MLModel_Prewarm.h
@@ -1,7 +1,7 @@
 //
 // MLModel+Prewarm.h
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/delegate/MLModel_Prewarm.mm
+++ b/backends/apple/coreml/runtime/delegate/MLModel_Prewarm.mm
@@ -1,7 +1,7 @@
 //
 // MLModel+Prewarm.m
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
@@ -47,7 +47,9 @@ id<MLFeatureProvider> _Nullable get_zeroed_inputs(MLModel *model, NSError * __au
         switch (feature_desc.type) {
             case MLFeatureTypeMultiArray: {
                 MLMultiArrayConstraint *constraint = feature_desc.multiArrayConstraint;
-                MLMultiArray *array = [MLMultiArray zeroedMultiArrayWithShape:constraint.shape dataType:constraint.dataType error:error];
+                MLMultiArray *array = [MLMultiArray zeroedMultiArrayWithShape:constraint.shape 
+                                                                     dataType:constraint.dataType
+                                                                        error:error];
                 MLFeatureValue *feature = (array != nil) ? [MLFeatureValue featureValueWithMultiArray:array] : nil;
                 if (!feature) {
                     return nil;

--- a/backends/apple/coreml/runtime/delegate/MLMultiArray_Copy.h
+++ b/backends/apple/coreml/runtime/delegate/MLMultiArray_Copy.h
@@ -1,7 +1,7 @@
 //
 // MLMultiArray+Copy.h
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/delegate/MLMultiArray_Copy.mm
+++ b/backends/apple/coreml/runtime/delegate/MLMultiArray_Copy.mm
@@ -1,7 +1,7 @@
 //
 // MLMultiArray+Copy.mm
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/delegate/asset.h
+++ b/backends/apple/coreml/runtime/delegate/asset.h
@@ -1,7 +1,7 @@
 //
 // ModelAsset.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/delegate/asset.mm
+++ b/backends/apple/coreml/runtime/delegate/asset.mm
@@ -1,7 +1,7 @@
 //
 // ModelAsset.cpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/delegate/backend_delegate.h
+++ b/backends/apple/coreml/runtime/delegate/backend_delegate.h
@@ -1,16 +1,20 @@
 //
 // backend_delegate.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
+#pragma once
+
+#include <model_logging_options.h>
 #include <system_error>
 #include <unordered_map>
 #include <vector>
 
 namespace executorchcoreml {
 
+class ModelEventLogger;
 class MultiArray;
 class Buffer;
 
@@ -80,10 +84,15 @@ public:
     ///
     /// @param handle The model handle.
     /// @param args The inputs and outputs to the model.
+    /// @param logging_options The model logging options.
+    /// @param event_logger The model event logger.
     /// @param error   On failure, error is filled with the failure information.
     /// @retval `true` if the execution succeeded otherwise `false`.
-    virtual bool
-    execute(Handle* handle, const std::vector<MultiArray>& args, std::error_code& error) const noexcept = 0;
+    virtual bool execute(Handle* handle,
+                         const std::vector<MultiArray>& args,
+                         const ModelLoggingOptions& logging_options,
+                         ModelEventLogger* event_logger,
+                         std::error_code& error) const noexcept = 0;
 
     /// Must return `true` if the delegate is available for execution otherwise
     /// `false`.

--- a/backends/apple/coreml/runtime/delegate/model_event_logger.h
+++ b/backends/apple/coreml/runtime/delegate/model_event_logger.h
@@ -1,0 +1,43 @@
+//
+// model_event_logger.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#import <CoreML/CoreML.h>
+
+@class ETCoreMLModelStructurePath;
+@class ETCoreMLOperationProfilingInfo;
+
+namespace executorchcoreml {
+
+/// An abstract class for logging model events (profiling/debugging) .
+class ModelEventLogger {
+public:
+    inline ModelEventLogger() noexcept { }
+    virtual ~ModelEventLogger() noexcept = default;
+
+    /// Must log profiling infos.
+    ///
+    /// @param op_path_to_profiling_info_map A dictionary with the operation path as the key and operation's profiling
+    /// info as the value.
+    /// @param op_path_to_debug_symbol_name_map A dictionary with the operation path as the key and the symbol name as
+    /// the value. The symbol name is the delegate handle.
+    virtual void log_profiling_infos(
+        NSDictionary<ETCoreMLModelStructurePath*, ETCoreMLOperationProfilingInfo*>* op_path_to_profiling_info_map,
+        NSDictionary<ETCoreMLModelStructurePath*, NSString*>* op_path_to_debug_symbol_name_map) const noexcept = 0;
+
+    /// Must log intermediate tensors.
+    ///
+    /// @param op_path_to_value_map A dictionary with the operation path as the key and the operation's value as the
+    /// value.
+    /// @param op_path_to_debug_symbol_name_map A dictionary with the operation path as the key and the symbol name as
+    /// the value. The symbol name is the delegate handle.
+    virtual void log_intermediate_tensors(
+        NSDictionary<ETCoreMLModelStructurePath*, MLMultiArray*>* op_path_to_value_map,
+        NSDictionary<ETCoreMLModelStructurePath*, NSString*>* op_path_to_debug_symbol_name_map) const noexcept = 0;
+};
+}

--- a/backends/apple/coreml/runtime/delegate/model_logging_options.h
+++ b/backends/apple/coreml/runtime/delegate/model_logging_options.h
@@ -1,0 +1,17 @@
+//
+// model_logging_options.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <string>
+
+namespace executorchcoreml {
+struct ModelLoggingOptions {
+    /// If set to `true` then the delegate would log the profiling info of operations in the Program.
+    bool log_profiling_info = false;
+    /// If set to `true` then the delegate would log the value of operations the Program.
+    bool log_intermediate_tensors = false;
+};
+}

--- a/backends/apple/coreml/runtime/delegate/model_metadata.h
+++ b/backends/apple/coreml/runtime/delegate/model_metadata.h
@@ -1,7 +1,7 @@
 //
-// metadata.h
+// model_metadata.h
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
@@ -14,7 +14,7 @@
 
 namespace executorchcoreml {
 
-/// A class representing a model's metadata.
+/// A struct representing a model's metadata.
 struct ModelMetadata {
     /// Constructs a `ModelMetada` instance.
     /// @param identifier The unique identifier.
@@ -29,7 +29,7 @@ struct ModelMetadata {
     inline ModelMetadata() noexcept { }
 
     /// Returns `true` if the metadata is valid otherwise `false`.
-    inline bool isValid() const noexcept {
+    inline bool is_valid() const noexcept {
         return !identifier.empty() && !input_names.empty() && !output_names.empty();
     }
 
@@ -46,5 +46,4 @@ struct ModelMetadata {
     /// Output names of the model.
     std::vector<std::string> output_names;
 };
-
 } // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/delegate/multiarray.h
+++ b/backends/apple/coreml/runtime/delegate/multiarray.h
@@ -1,7 +1,7 @@
 //
 // multiarray.h
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/delegate/serde_json.h
+++ b/backends/apple/coreml/runtime/delegate/serde_json.h
@@ -1,7 +1,7 @@
 //
 // Serdes.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/delegate/serde_json.mm
+++ b/backends/apple/coreml/runtime/delegate/serde_json.mm
@@ -1,7 +1,7 @@
 //
 // serde_json.mm
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
@@ -9,7 +9,7 @@
 
 #import <asset.h>
 #import <objc_json_serde.h>
-#import <metadata.h>
+#import <model_metadata.h>
 
 namespace  {
 struct FileInfoKeys {
@@ -41,7 +41,7 @@ namespace serde {
 namespace json {
 
 template <>
-struct JSONSerde<executorchcoreml::FileInfo> {
+struct Converter<executorchcoreml::FileInfo> {
     static id to_json(const executorchcoreml::FileInfo& file_info) {
         return @{
             to_string(FileInfoKeys::kRelativePath) : to_json_value(file_info.relative_path),
@@ -62,9 +62,8 @@ struct JSONSerde<executorchcoreml::FileInfo> {
     }
 };
 
-
 template <>
-struct JSONSerde<executorchcoreml::PackageInfo> {
+struct Converter<executorchcoreml::PackageInfo> {
     static id to_json(const executorchcoreml::PackageInfo& package_info) {
         return @{
             to_string(PackageInfoKeys::kNameKey) : to_json_value(package_info.name),
@@ -84,7 +83,7 @@ struct JSONSerde<executorchcoreml::PackageInfo> {
 };
 
 template <>
-struct JSONSerde<executorchcoreml::Asset> {
+struct Converter<executorchcoreml::Asset> {
     static id to_json(const executorchcoreml::Asset& asset) {
         return @{
             to_string(ModelAssetKeys::kIdentifierKey) : to_json_value(asset.identifier),
@@ -106,7 +105,7 @@ struct JSONSerde<executorchcoreml::Asset> {
 };
 
 template <>
-struct JSONSerde<executorchcoreml::ModelMetadata> {
+struct Converter<executorchcoreml::ModelMetadata> {
     static id to_json(const executorchcoreml::ModelMetadata& metadata) {
         return @{
             to_string(ModelMetadataKeys::kIdentifierKey) : to_json_value(metadata.identifier),
@@ -128,23 +127,23 @@ struct JSONSerde<executorchcoreml::ModelMetadata> {
 };
 
 std::string to_json_string(const Asset& asset) {
-    id json = JSONSerde<Asset>::to_json(asset);
+    id json = Converter<Asset>::to_json(asset);
     return to_json_string(json);
 }
 
 void from_json_string(const std::string& json_string, Asset& asset) {
     id json = to_json_object(json_string);
-    JSONSerde<Asset>::from_json(json, asset);
+    Converter<Asset>::from_json(json, asset);
 }
 
 std::string to_json_string(const ModelMetadata& metdata) {
-    id json = JSONSerde<ModelMetadata>::to_json(metdata);
+    id json = Converter<ModelMetadata>::to_json(metdata);
     return to_json_string(json);
 }
 
 void from_json_string(const std::string& json_string, ModelMetadata& metadata) {
     id json = to_json_object(json_string);
-    JSONSerde<ModelMetadata>::from_json(json, metadata);
+    Converter<ModelMetadata>::from_json(json, metadata);
 }
 
 } // namespace json

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.cpp
@@ -1,7 +1,7 @@
 //
 // inmemory_filesystem.cpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.hpp
@@ -1,7 +1,7 @@
 //
 // inmemory_filesystem.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata.hpp
@@ -1,7 +1,7 @@
 //
 // inmemory_filesystem_metadata.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata_keys.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata_keys.hpp
@@ -2,7 +2,7 @@
 // metadata_keys.hpp
 // inmemoryfs
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_py.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_py.cpp
@@ -1,7 +1,7 @@
 //
 // inmemory_filesystem_py.cpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.cpp
@@ -1,7 +1,7 @@
 //
 // inmemory_filesystem_utils.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.hpp
@@ -1,7 +1,7 @@
 //
 // inmemory_filesystem_utils.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.mm
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.mm
@@ -1,7 +1,7 @@
 //
 // inmemory_filesystem_utils.mm
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
@@ -26,7 +26,7 @@ namespace json {
 using namespace inmemoryfs;
 
 template <>
-struct JSONSerde<MemoryRegion> {
+struct Converter<MemoryRegion> {
     static id to_json(const MemoryRegion& region) {
         return @{
             to_string(MemoryRegionKeys::kOffset) : to_json_value(region.offset),
@@ -46,7 +46,7 @@ struct JSONSerde<MemoryRegion> {
 };
 
 template <>
-struct JSONSerde<InMemoryNodeMetadata> {
+struct Converter<InMemoryNodeMetadata> {
     static id to_json(const InMemoryNodeMetadata& node) {
         return @{
             to_string(InMemoryNodeMetadataKeys::kName) : to_json_value(node.name),
@@ -70,7 +70,7 @@ struct JSONSerde<InMemoryNodeMetadata> {
 };
 
 template <>
-struct JSONSerde<InMemoryFileSystemMetadata> {
+struct Converter<InMemoryFileSystemMetadata> {
     static id to_json(const InMemoryFileSystemMetadata& fs) {
         return @{
             to_string(InMemoryFileSystemMetadataKeys::kNodes) : to_json_value(fs.nodes)
@@ -96,7 +96,7 @@ using namespace::inmemoryfs;
 
 void write_metadata_to_stream(const InMemoryFileSystemMetadata& metadata, std::ostream& stream) {
     using namespace executorchcoreml::serde::json;
-    std::string json_string = to_json_string(JSONSerde<InMemoryFileSystemMetadata>::to_json(metadata));
+    std::string json_string = to_json_string(Converter<InMemoryFileSystemMetadata>::to_json(metadata));
     std::reverse(json_string.begin(), json_string.end());
     stream << json_string;
 }
@@ -109,7 +109,7 @@ std::optional<InMemoryFileSystemMetadata> read_metadata_from_stream(std::istream
     }
     
     InMemoryFileSystemMetadata metadata;
-    JSONSerde<InMemoryFileSystemMetadata>::from_json(to_json_object(json_object.value()), metadata);
+    Converter<InMemoryFileSystemMetadata>::from_json(to_json_object(json_object.value()), metadata);
     return metadata;
 }
 

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.cpp
@@ -1,7 +1,7 @@
 //
 // memory_buffer.cpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
@@ -1,7 +1,7 @@
 //
 // memory_buffer.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_stream.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_stream.cpp
@@ -1,7 +1,7 @@
 //
 // memory_stream.cpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_stream.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_stream.hpp
@@ -2,7 +2,7 @@
 //  Stream.hpp
 //  inmemoryfs
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.cpp
@@ -1,7 +1,7 @@
 //
 // reversed_memory_stream.cpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.hpp
@@ -1,7 +1,7 @@
 //
 // Stream.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/inmemoryfs/setup.py
+++ b/backends/apple/coreml/runtime/inmemoryfs/setup.py
@@ -28,7 +28,7 @@ ext_modules = [
         ],
         define_macros=[("VERSION_INFO", __version__)],
         cxx_std=cxx_std,
-        extra_compile_args=["-mmacosx-version-min=10.15"],
+        extra_compile_args=["-mmacosx-version-min=10.15", "-g"],
         include_dirs=[
             "../../third-party/nlohmann_json/single_include/nlohmann",
             ".",

--- a/backends/apple/coreml/runtime/kvstore/database.cpp
+++ b/backends/apple/coreml/runtime/kvstore/database.cpp
@@ -2,7 +2,7 @@
 //  database.cpp
 //  kvstore
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/kvstore/database.hpp
+++ b/backends/apple/coreml/runtime/kvstore/database.hpp
@@ -1,7 +1,7 @@
 //
 // database.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/kvstore/json_key_value_store.cpp
+++ b/backends/apple/coreml/runtime/kvstore/json_key_value_store.cpp
@@ -1,7 +1,7 @@
 //
 //  json_key_value_store.cpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/kvstore/json_key_value_store.hpp
+++ b/backends/apple/coreml/runtime/kvstore/json_key_value_store.hpp
@@ -1,7 +1,7 @@
 //
 // JSONKeyValueStore.h
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/kvstore/key_value_store.cpp
+++ b/backends/apple/coreml/runtime/kvstore/key_value_store.cpp
@@ -1,7 +1,7 @@
 //
 // KeyValueStore.cpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/kvstore/key_value_store.hpp
+++ b/backends/apple/coreml/runtime/kvstore/key_value_store.hpp
@@ -1,7 +1,7 @@
 //
 // key_value_store.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/kvstore/sqlite_error.cpp
+++ b/backends/apple/coreml/runtime/kvstore/sqlite_error.cpp
@@ -1,7 +1,7 @@
 //
 // sqlite_error.cpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 //

--- a/backends/apple/coreml/runtime/kvstore/sqlite_error.hpp
+++ b/backends/apple/coreml/runtime/kvstore/sqlite_error.hpp
@@ -1,7 +1,7 @@
 //
 // sqlite_error.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/kvstore/statement.cpp
+++ b/backends/apple/coreml/runtime/kvstore/statement.cpp
@@ -1,7 +1,7 @@
 //
 // Statement.cpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/kvstore/statement.hpp
+++ b/backends/apple/coreml/runtime/kvstore/statement.hpp
@@ -1,7 +1,7 @@
 //
 // database.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/kvstore/types.hpp
+++ b/backends/apple/coreml/runtime/kvstore/types.hpp
@@ -1,7 +1,7 @@
 //
 // types.hpp
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.h
@@ -1,0 +1,49 @@
+//
+// ETCoreMLModelAnalyzer.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <CoreML/CoreML.h>
+
+#import <ETCoreMLModelExecutor.h>
+
+namespace executorchcoreml {
+struct ModelMetadata;
+}
+
+@class ETCoreMLAsset;
+@class ETCoreMLAssetManager;
+@protocol ETCoreMLModelEventLogger;
+
+NS_ASSUME_NONNULL_BEGIN
+
+__attribute__((objc_subclassing_restricted))
+/// A class responsible for executing a model, it also logs model events (profiling and debugging ).
+@interface ETCoreMLModelAnalyzer : NSObject<ETCoreMLModelExecutor>
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Constructs an `ETCoreMLModelAnalyzer` instance.
+///
+/// @param compiledModelAsset The compiled model asset (mlmodelc).
+/// @param modelAsset The model asset (mlpackage).
+/// @param metadata The model metadata.
+/// @param configuration The model configuration.
+/// @param assetManager The asset manager used to manage storage of compiled models.
+/// @param error   On failure, error is filled with the failure information.
+- (nullable instancetype)initWithCompiledModelAsset:(ETCoreMLAsset*)compiledModelAsset
+                                         modelAsset:(ETCoreMLAsset*)modelAsset
+                                           metadata:(const executorchcoreml::ModelMetadata&)metadata
+                                      configuration:(MLModelConfiguration*)configuration
+                                       assetManager:(ETCoreMLAssetManager*)assetManager
+                                              error:(NSError* __autoreleasing*)error NS_DESIGNATED_INITIALIZER;
+/// The model.
+@property (readonly, strong, nonatomic) ETCoreMLModel* model;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.mm
@@ -1,0 +1,241 @@
+//
+// ETCoreMLModelAnalyzer.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <ETCoreMLAsset.h>
+#import <ETCoreMLAssetManager.h>
+#import <ETCoreMLDefaultModelExecutor.h>
+#import <ETCoreMLLogging.h>
+#import <ETCoreMLModel.h>
+#import <ETCoreMLModelAnalyzer.h>
+#import <ETCoreMLModelLoader.h>
+#import <ETCoreMLModelStructurePath.h>
+#import <ETCoreMLModelDebugger.h>
+#import <ETCoreMLModelProfiler.h>
+#import <ETCoreMLStrings.h>
+#import <model_logging_options.h>
+#import <model_event_logger.h>
+#import <model_metadata.h>
+#import <model_package_info.h>
+#import <objc_safe_cast.h>
+
+namespace {
+using namespace executorchcoreml;
+static constexpr NSInteger MAX_MODEL_OUTPUTS_COUNT = 50;
+
+NSDictionary<ETCoreMLModelStructurePath *, NSString *> * _Nullable get_path_to_symbol_name_map(ETCoreMLAsset *model_asset,
+                                                                                               NSFileManager *fm,
+                                                                                               NSError * __autoreleasing *error) {
+    auto package_info = ModelPackageInfo::make(model_asset.contentURL, fm, error);
+    if (!package_info) {
+        return nil;
+    }
+    
+    const auto& items = package_info.value().items;
+    auto debug_symbols_file_name = std::string(ETCoreMLStrings.debugSymbols.UTF8String);
+    auto it = std::find_if(items.begin(), items.end(), [&debug_symbols_file_name](const auto& pair) {
+        return pair.second.name == debug_symbols_file_name;
+    });
+    
+    if (it == items.end()) {
+        return nil;
+    }
+    
+    NSURL *debug_symbols_file_url = [model_asset.contentURL URLByAppendingPathComponent:@(it->second.path.c_str())];
+    NSData *data = [NSData dataWithContentsOfURL:debug_symbols_file_url
+                                         options:NSDataReadingMapped
+                                           error:error];
+    if (!data) {
+        return nil;
+    }
+    
+    id object = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:error];
+    if (!object) {
+        return nil;
+    }
+    
+    NSDictionary<NSString *, id> *json_dict = SAFE_CAST(object, NSDictionary);
+    NSCAssert(json_dict != nil, @"The contents of %s is not a json dictionary.", it->second.path.c_str());
+    NSMutableDictionary<ETCoreMLModelStructurePath *, NSString *> *result = [NSMutableDictionary dictionaryWithCapacity:json_dict.count];
+    for (NSString *symbol_name in json_dict) {
+        NSArray<NSDictionary<NSString *, id> *> *components = SAFE_CAST(json_dict[symbol_name], NSArray);
+        NSCAssert(components != nil, @"The path=%@ is invalid.", json_dict[symbol_name]);
+        ETCoreMLModelStructurePath *path = [[ETCoreMLModelStructurePath alloc] initWithComponents:json_dict[symbol_name]];
+        result[path] = symbol_name;
+    }
+    
+    return result;
+}
+} //namespace
+
+@interface ETCoreMLModelAnalyzer ()
+
+@property (readonly, strong, nonatomic) ETCoreMLAsset *modelAsset;
+@property (readonly, strong, nonatomic) ETCoreMLAssetManager *assetManager;
+@property (strong, nonatomic) ETCoreMLModelProfiler *profiler;
+@property (strong, nonatomic) ETCoreMLModelDebugger *debugger;
+@property (strong, nonatomic) id<ETCoreMLModelExecutor> executor;
+@property (readonly, copy, nonatomic, nullable) NSDictionary<ETCoreMLModelStructurePath *, NSString *> *pathToSymbolNameMap;
+@property (readonly, strong, nonatomic) MLModelConfiguration *configuration;
+
+@end
+
+@implementation ETCoreMLModelAnalyzer
+
+- (nullable instancetype)initWithCompiledModelAsset:(ETCoreMLAsset *)compiledModelAsset
+                                         modelAsset:(ETCoreMLAsset *)modelAsset
+                                           metadata:(const executorchcoreml::ModelMetadata&)metadata
+                                      configuration:(MLModelConfiguration *)configuration
+                                       assetManager:(ETCoreMLAssetManager *)assetManager
+                                              error:(NSError * __autoreleasing *)error {
+    if (![modelAsset keepAliveAndReturnError:error]) {
+        return nil;
+    }
+    
+    if (![compiledModelAsset keepAliveAndReturnError:error]) {
+        return nil;
+    }
+    
+    ETCoreMLModel *model = [ETCoreMLModelLoader loadModelWithContentsOfURL:compiledModelAsset.contentURL
+                                                             configuration:configuration
+                                                                  metadata:metadata
+                                                              assetManager:assetManager
+                                                                     error:error];
+    if (!model) {
+        return nil;
+    }
+    
+    NSError *localError = nil;
+    NSDictionary<ETCoreMLModelStructurePath *, NSString *> *pathToSymbolNameMap = get_path_to_symbol_name_map(modelAsset,
+                                                                                                              assetManager.fileManager,
+                                                                                                              &localError);
+    
+    if (localError) {
+        os_log_error(ETCoreMLErrorUtils.loggingChannel , "%@: The model package at path=%@ has invalid or missing debug symbols file.",
+                     NSStringFromClass(ETCoreMLModelAnalyzer.class),
+                     modelAsset.contentURL.path);
+    }
+    
+    ETCoreMLModelProfiler *profiler = [[ETCoreMLModelProfiler alloc] initWithCompiledModelAsset:model.asset
+                                                                                    outputNames:model.orderedOutputNames
+                                                                                  configuration:configuration
+                                                                                          error:error];
+    if (!profiler) {
+        return nil;
+    }
+    
+    self = [super init];
+    if (self) {
+        _model = model;
+        _modelAsset = modelAsset;
+        _assetManager = assetManager;
+        _configuration = configuration;
+        _pathToSymbolNameMap = pathToSymbolNameMap;
+        _executor = [[ETCoreMLDefaultModelExecutor alloc] initWithModel:model];
+        _profiler = profiler;
+    }
+    
+    return self;
+}
+
+- (nullable NSArray<MLMultiArray *> *)profileModelWithInputs:(id<MLFeatureProvider>)inputs
+                                           predictionOptions:(MLPredictionOptions *)predictionOptions
+                                                 eventLogger:(const executorchcoreml::ModelEventLogger *)eventLogger
+                                                       error:(NSError * __autoreleasing *)error {
+    NSArray<MLMultiArray *> *modelOutputs = nil;
+    NSArray<ETCoreMLModelStructurePath *> *operationPaths = self.profiler.operationPaths;
+    ETCoreMLModelProfilingResult *profilingInfos = [self.profiler profilingInfoForOperationsAtPaths:operationPaths
+                                                                                            options:predictionOptions
+                                                                                             inputs:inputs
+                                                                                       modelOutputs:&modelOutputs
+                                                                                              error:error];
+    if (!profilingInfos) {
+        return nil;
+    }
+    
+    eventLogger->log_profiling_infos(profilingInfos, self.pathToSymbolNameMap);
+    return modelOutputs;
+}
+
+- (nullable NSArray<MLMultiArray *> *)debugModelWithInputs:(id<MLFeatureProvider>)inputs
+                                         predictionOptions:(MLPredictionOptions *)predictionOptions
+                                               eventLogger:(const executorchcoreml::ModelEventLogger *)eventLogger
+                                                     error:(NSError * __autoreleasing *)error {
+    if (!self.debugger) {
+        self.debugger = [[ETCoreMLModelDebugger alloc] initWithModelAsset:self.modelAsset
+                                                              outputNames:self.model.orderedOutputNames
+                                                            configuration:self.configuration
+                                                             assetManager:self.assetManager
+                                                                    error:error];
+    }
+    
+    if (!self.debugger) {
+        return nil;
+    }
+    
+    NSArray<MLMultiArray *> *modelOutputs = nil;
+    NSArray<ETCoreMLModelStructurePath *> *operationPaths = self.debugger.operationPaths;
+    NSInteger n = operationPaths.count/MAX_MODEL_OUTPUTS_COUNT + (operationPaths.count % MAX_MODEL_OUTPUTS_COUNT == 0 ? 0 : 1);
+    for (NSInteger i = 0; i < n; i++) {
+        @autoreleasepool {
+            NSRange range = NSMakeRange(i * MAX_MODEL_OUTPUTS_COUNT, MIN(operationPaths.count - i * MAX_MODEL_OUTPUTS_COUNT, MAX_MODEL_OUTPUTS_COUNT));
+            ETCoreMLModelOutputs *outputs = [self.debugger outputsOfOperationsAtPaths:[operationPaths subarrayWithRange:range]
+                                                                              options:predictionOptions
+                                                                               inputs:inputs
+                                                                         modelOutputs:&modelOutputs
+                                                                                error:error];
+            if (!outputs) {
+                return nil;
+            }
+            
+            if (outputs.count > 0) {
+                eventLogger->log_intermediate_tensors(outputs, self.pathToSymbolNameMap);
+            }
+        }
+    }
+  
+    return modelOutputs;
+}
+
+- (nullable NSArray<MLMultiArray *> *)executeModelWithInputs:(id<MLFeatureProvider>)inputs
+                                           predictionOptions:(MLPredictionOptions *)predictionOptions
+                                             loggingOptions:(const executorchcoreml::ModelLoggingOptions&)loggingOptions
+                                                 eventLogger:(const executorchcoreml::ModelEventLogger* _Nullable)eventLogger
+                                                       error:(NSError * __autoreleasing *)error {
+    NSError *localError = nil;
+    NSArray<MLMultiArray *> *outputs = nil;
+    if (loggingOptions.log_profiling_info) {
+        NSAssert(eventLogger != nullptr, @"%@: Event logger is set to nullptr.", NSStringFromClass(ETCoreMLModelAnalyzer.class));
+        outputs = [self profileModelWithInputs:inputs
+                             predictionOptions:predictionOptions
+                                   eventLogger:eventLogger
+                                         error:&localError];
+    }
+    
+    if (loggingOptions.log_intermediate_tensors) {
+        NSAssert(eventLogger != nullptr, @"%@: Event logger is set to nullptr.", NSStringFromClass(ETCoreMLModelAnalyzer.class));
+        outputs = [self debugModelWithInputs:inputs
+                           predictionOptions:predictionOptions
+                                 eventLogger:eventLogger
+                                       error:&localError];
+    }
+    
+    if (!loggingOptions.log_profiling_info && !loggingOptions.log_intermediate_tensors) {
+        outputs = [self.executor executeModelWithInputs:inputs
+                                      predictionOptions:predictionOptions
+                                        loggingOptions:executorchcoreml::ModelLoggingOptions()
+                                            eventLogger:nullptr
+                                                  error:&localError];
+    }
+    
+    if (error) {
+        *error = localError;
+    }
+    
+    return outputs;
+}
+
+@end

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelDebugger.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelDebugger.h
@@ -1,0 +1,59 @@
+//
+// ETCoreMLModelDebugger.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <CoreML/CoreML.h>
+
+@class ETCoreMLAsset;
+@class ETCoreMLAssetManager;
+@class ETCoreMLModelStructurePath;
+
+typedef NSDictionary<ETCoreMLModelStructurePath*, MLMultiArray*> ETCoreMLModelOutputs;
+
+NS_ASSUME_NONNULL_BEGIN
+/// A class responsible for debugging a model.
+__attribute__((objc_subclassing_restricted)) @interface ETCoreMLModelDebugger : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Constructs an `ETCoreMLModelDebugger` instance.
+///
+/// @param modelAsset The model asset (mlpackage).
+/// @param outputNames The model output names.
+/// @param configuration The model configuration.
+/// @param assetManager The asset manager used to manage storage of compiled models.
+/// @param error   On failure, error is filled with the failure information.
+- (nullable instancetype)initWithModelAsset:(ETCoreMLAsset*)modelAsset
+                                outputNames:(NSOrderedSet<NSString*>*)outputNames
+                              configuration:(MLModelConfiguration*)configuration
+                               assetManager:(ETCoreMLAssetManager*)assetManager
+                                      error:(NSError* __autoreleasing*)error NS_DESIGNATED_INITIALIZER;
+
+/// Returns outputs of operations at the specified paths.
+///
+/// This is an expensive method, it creates models with intermediate outputs, compiles, and executes them.
+///
+/// @param paths The operation paths.
+/// @param options The prediction options.
+/// @param inputs The model inputs..
+/// @param modelOutputs  On success, modelOutputs is filled with the model outputs.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval A dictionary with the operation path as the key and the operation output as the value.
+- (nullable ETCoreMLModelOutputs*)
+    outputsOfOperationsAtPaths:(NSArray<ETCoreMLModelStructurePath*>*)paths
+                       options:(MLPredictionOptions*)options
+                        inputs:(id<MLFeatureProvider>)inputs
+                  modelOutputs:(NSArray<MLMultiArray*>* _Nullable __autoreleasing* _Nonnull)modelOutputs
+                         error:(NSError* __autoreleasing*)error;
+
+/// The paths to all the operations for which we can get the outputs.
+@property (readonly, copy, nonatomic) NSArray<ETCoreMLModelStructurePath*>* operationPaths;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelDebugger.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelDebugger.mm
@@ -1,0 +1,582 @@
+//
+// ETCoreMLModelDebugger.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <CoreML/CoreML.h>
+#import <ETCoreMLAsset.h>
+#import <ETCoreMLAssetManager.h>
+#import <ETCoreMLLogging.h>
+#import <ETCoreMLModelCompiler.h>
+#import <ETCoreMLModelStructurePath.h>
+#import <ETCoreMLPair.h>
+#import <ETCoreMLModelDebugger.h>
+#import <ETCoreMLStrings.h>
+#import <format/MIL.pb.h>
+#import <format/Model.pb.h>
+#import <fstream>
+#import <iostream>
+#import <model_package_info.h>
+#import <objc_json_serde.h>
+#import <string>
+#import <unordered_map>
+
+typedef ETCoreMLPair<MLModel *, NSArray<ETCoreMLModelStructurePath *> *> DebuggableModel;
+
+namespace {
+using namespace executorchcoreml;
+using namespace executorchcoreml::modelstructure;
+using namespace CoreML::Specification;
+
+NSURL * _Nullable get_model_spec_url(NSURL *model_package_url,
+                                     NSFileManager *file_manager,
+                                     NSError* __autoreleasing *error) {
+    auto info = ModelPackageInfo::make(model_package_url, file_manager, error);
+    if (!info) {
+        return nil;
+    }
+    
+    const auto& info_value = info.value();
+    auto it = info_value.items.find(info_value.root_model_identifier);
+    if (it == info_value.items.end()) {
+        ETCoreMLLogErrorAndSetNSError(error, 0, "%@ is broken, root model info doesn't exist.", model_package_url.lastPathComponent);
+        return nil;
+    }
+    
+    auto path = it->second.path;
+    if (path.empty()) {
+        ETCoreMLLogErrorAndSetNSError(error, 0, "%@ is broken, root model path doesn't exist.", model_package_url.lastPathComponent);
+        return nil;
+    }
+    
+    return [model_package_url URLByAppendingPathComponent:[NSString stringWithFormat:@"Data/%s", path.c_str()]];
+}
+
+std::optional<int> index_of_output(const MILSpec::Operation& operation, const std::string& output_name) {
+    for (int i = 0; i < operation.outputs_size(); i++) {
+        if (operation.outputs(i).name() == output_name) {
+            return i;
+        }
+    }
+    
+    return std::nullopt;
+}
+
+BOOL is_const_operation(const MILSpec::Operation& operation) {
+    return operation.type() == "const";
+}
+
+BOOL is_cast_operation(const MILSpec::Operation& operation) {
+    return operation.type() == "cast";
+}
+
+BOOL is_datatype_supported_as_model_output(MILSpec::DataType datatype) {
+    switch (datatype) {
+        case MILSpec::DataType::INT32:
+            return true;
+        case MILSpec::DataType::FLOAT16:
+            return true;
+        case MILSpec::DataType::FLOAT32:
+            return true;
+        case MILSpec::DataType::FLOAT64:
+            return true;
+        default:
+            return false;
+    }
+}
+
+BOOL is_output_type_supported_as_model_output(const MILSpec::ValueType& type) {
+    return type.has_tensortype() && is_datatype_supported_as_model_output(type.tensortype().datatype());
+}
+
+BOOL is_operation_output_supported_as_model_output(const MILSpec::Operation& operation) {
+    if (is_const_operation(operation)) {
+        return NO;
+    }
+    
+    if (is_cast_operation(operation)) {
+        return NO;
+    }
+    
+    return YES;
+}
+
+const MILSpec::NamedValueType *add_output(MILSpec::Block& block, const Path& path, size_t block_component_index) {
+    const auto& components = path.components();
+    auto block_component = std::get_if<Path::Program::Block>(&components[block_component_index]);
+    NSCAssert(block_component != nullptr, @"%@: Invalid path, component doesn't refer to a block.", NSStringFromClass(ETCoreMLModelDebugger.class));
+    // Next component must be an operation.
+    size_t operation_component_index = block_component_index + 1;
+    auto operation_component = std::get_if<Path::Program::Operation>(&components[operation_component_index]);
+    const auto& output_name = operation_component->output_name;
+    
+    for (int i = 0; i < block.operations_size(); i++) {
+        auto& operation = *(block.mutable_operations(i));
+        auto output_index = index_of_output(operation, output_name);
+        if (!output_index) {
+            continue;
+        }
+        
+        if (components.size() == operation_component_index + 1) {
+            const auto& output = operation.outputs(output_index.value());
+            if (!is_output_type_supported_as_model_output(output.type())) {
+                return nullptr;
+            }
+            
+            block.add_outputs(output.name());
+            return &output;
+        }
+        
+        // Handle nested block.
+        size_t nested_block_index = operation_component_index + 1;
+        auto nested_block_component = std::get_if<Path::Program::Block>(&components[nested_block_index]);
+        NSCAssert(nested_block_component != nullptr, @"%@: Invalid path, component doesn't refer to a nested block.", NSStringFromClass(ETCoreMLModelDebugger.class));
+        auto& nested_block = *(operation.mutable_blocks(static_cast<int>(nested_block_component->index)));
+        return add_output(nested_block, path, nested_block_index);
+    }
+    
+    return nullptr;
+}
+
+const MILSpec::NamedValueType *add_output(MILSpec::Function& function, const Path& path, size_t function_component_index) {
+    size_t block_component_index = function_component_index + 1;
+    const auto& block_name = function.opset();
+    auto& block = (*function.mutable_block_specializations())[block_name];
+    
+    return add_output(block, path, block_component_index);
+}
+
+const MILSpec::NamedValueType *add_output(MILSpec::Program& program, const Path& path) {
+    size_t function_component_index = 1;
+    const auto& components = path.components();
+    auto function_component = std::get_if<Path::Program::Function>(&components[function_component_index]);
+    NSCAssert(function_component != nullptr, @"%@: Invalid path, path doesn't refer to a function.", NSStringFromClass(ETCoreMLModelDebugger.class));
+    auto& functions = *(program.mutable_functions());
+    auto& function = functions[function_component->name];
+    
+    return add_output(function, path, function_component_index);
+}
+
+std::optional<ArrayFeatureType_ArrayDataType> to_array_datatype(MILSpec::DataType datatype,
+                                                                int model_specification_version) {
+    switch (datatype) {
+        case MILSpec::DataType::INT32:
+            return ArrayFeatureType_ArrayDataType::ArrayFeatureType_ArrayDataType_INT32;
+        case MILSpec::DataType::FLOAT16:
+            return ArrayFeatureType_ArrayDataType::ArrayFeatureType_ArrayDataType_FLOAT16;
+        case MILSpec::DataType::FLOAT32:
+            return ArrayFeatureType_ArrayDataType::ArrayFeatureType_ArrayDataType_FLOAT32;
+        case MILSpec::DataType::FLOAT64:
+            return ArrayFeatureType_ArrayDataType::ArrayFeatureType_ArrayDataType_DOUBLE;
+        default:
+            return std::nullopt;
+    }
+}
+
+const MILSpec::NamedValueType *add_output(Model& model, const Path& path) {
+    NSCAssert(model.has_mlprogram(), @"%@: Model is not a ML Program.", NSStringFromClass(ETCoreMLModelDebugger.class));
+    auto& program = *(model.mutable_mlprogram());
+    auto output = add_output(program, path);
+    if (!output) {
+        return nullptr;
+    }
+    
+    auto& description = *(model.mutable_description());
+    auto& output_feature = *(description.add_output());
+    output_feature.mutable_name()->assign(output->name());
+    auto& multi_array_type = *(output_feature.mutable_type()->mutable_multiarraytype());
+    NSCAssert(output->type().has_tensortype(), @"%@: Only a tensor type can be model output.", NSStringFromClass(ETCoreMLModelDebugger.class));
+    auto tensor_type = output->type().tensortype();
+    auto feature_data_type = to_array_datatype(tensor_type.datatype(), model.specificationversion());
+    NSCAssert(feature_data_type.has_value(), @"%@: Unsupported datatype.", NSStringFromClass(ETCoreMLModelDebugger.class));
+    multi_array_type.set_datatype(feature_data_type.value());
+    
+    return output;
+}
+
+void visit_program_operation(const MILSpec::Block& block,
+                             const Path& block_path,
+                             BOOL (^handler)(const MILSpec::Operation& operation, ETCoreMLModelStructurePath *path)) {
+    for (int i = 0; i < block.operations_size(); ++i) {
+        const MILSpec::Operation& operation = block.operations(i);
+        Path operation_path = block_path;
+        if (operation.outputs_size() == 0) {
+            continue;
+        }
+        operation_path.append_component(Path::Program::Operation(operation.outputs(0).name()));
+        if (!handler(operation, [[ETCoreMLModelStructurePath alloc] initWithUnderlyingValue:operation_path])) {
+            return;
+        }
+        
+        for (int j = 0; j < operation.blocks_size(); ++j) {
+            Path nested_block_path = operation_path;
+            nested_block_path.append_component(Path::Program::Block(j));
+            visit_program_operation(operation.blocks(j), nested_block_path, handler);
+        }
+    }
+}
+
+void visit_program_operation(Model& model, BOOL (^handler)(const MILSpec::Operation& operation, ETCoreMLModelStructurePath *path)) {
+    const auto& functions = model.mlprogram().functions();
+    for (const auto& [function_name, function] : functions) {
+        Path path;
+        path.append_component(Path::Program());
+        path.append_component(Path::Program::Function(function_name));
+        path.append_component(Path::Program::Block(-1));
+        const auto& blocks = function.block_specializations();
+        const auto& specialization = blocks.at(function.opset());
+        visit_program_operation(specialization, path, handler);
+    }
+}
+
+NSString *to_string(MLComputeUnits compute_units) {
+    switch (compute_units) {
+        case MLComputeUnitsAll: {
+            return ETCoreMLStrings.allComputeUnitsName;
+        }
+        case MLComputeUnitsCPUOnly: {
+            return ETCoreMLStrings.cpuComputeUnitName;
+        }
+        case MLComputeUnitsCPUAndGPU: {
+            return ETCoreMLStrings.cpuAndGpuComputeUnitsName;
+        }
+        case MLComputeUnitsCPUAndNeuralEngine: {
+            return ETCoreMLStrings.cpuAndNeuralEngineComputeUnitsName;
+        }
+        default: {
+            return ETCoreMLStrings.allComputeUnitsName;
+        }
+    }
+}
+
+NSString *get_asset_identifier(NSString *asset_identifier,
+                               MLComputeUnits compute_units,
+                               NSArray<ETCoreMLModelStructurePath *> *paths) {
+    size_t paths_hash = 0;
+    for (ETCoreMLModelStructurePath *path in paths) {
+        executorchcoreml::hash_combine(paths_hash, path.underlyingValue);
+    }
+    
+    return [NSString stringWithFormat:@"%@_%zu_%@", asset_identifier, paths_hash, to_string(compute_units)];
+}
+
+std::unique_ptr<Model> parse_model_spec(NSURL *model_spec_url,
+                                        NSError * __autoreleasing *error) {
+    NSData *data = [NSData dataWithContentsOfURL:model_spec_url options:NSDataReadingMapped error:error];
+    if (!data) {
+        return nullptr;
+    }
+    
+    auto model = std::make_unique<Model>();
+    if (!model->ParseFromArray(data.bytes, (int)data.length)) {
+        return nullptr;
+    }
+    
+    return model;
+}
+
+std::unique_ptr<Model> copy_model_spec(const Model& model_spec) {
+    auto model_spec_copy = std::make_unique<Model>();
+    model_spec_copy->CopyFrom(model_spec);
+    
+    return model_spec_copy;
+}
+
+void update_model_spec_version_to_include_fp16_output(Model& model_spec) {
+    constexpr int minimum_spec_version_with_fp16_support = 7;
+    int spec_version = MAX(model_spec.specificationversion(), minimum_spec_version_with_fp16_support);
+    model_spec.set_specificationversion(spec_version);
+}
+
+NSURL * _Nullable get_compiled_model_url_with_intermediate_outputs(NSURL *model_url,
+                                                                   NSURL *model_spec_url,
+                                                                   const Model& model_spec,
+                                                                   NSOrderedSet<NSString *> *outputNames,
+                                                                   NSArray<ETCoreMLModelStructurePath *> *paths,
+                                                                   NSError * __autoreleasing *error) {
+    // Update model asset spec.
+    auto model_spec_copy = copy_model_spec(model_spec);
+    for (ETCoreMLModelStructurePath *path in paths) {
+        if ([outputNames containsObject:path.operationOutputName]) {
+            continue;
+        }
+        add_output(*model_spec_copy.get(), path.underlyingValue);
+    }
+    
+    update_model_spec_version_to_include_fp16_output(*model_spec_copy);
+    int size = model_spec_copy->ByteSize();
+    NSMutableData *data = [NSMutableData dataWithLength:size];
+    if (!model_spec_copy->SerializeToArray(data.mutableBytes, size)) {
+        return nil;
+    }
+    
+    if (![data writeToURL:model_spec_url options:NSDataWritingAtomic error:error]) {
+        return nil;
+    }
+    
+    // Compile the model.
+    return [ETCoreMLModelCompiler compileModelAtURL:model_url
+                               maxWaitTimeInSeconds:(5 * 60)
+                                              error:error];
+}
+
+ETCoreMLAsset * _Nullable make_asset(NSURL *asset_url,
+                                     NSString *identifier,
+                                     NSFileManager *fm,
+                                     NSError * __autoreleasing *error) {
+    auto underlying_asset = Asset::make(asset_url, identifier, fm, error);
+    if (!underlying_asset) {
+        return nil;
+    }
+    
+    ETCoreMLAsset *asset = [[ETCoreMLAsset alloc] initWithBackingAsset:std::move(underlying_asset.value())];
+    if (![asset keepAliveAndReturnError:error]) {
+        return nil;
+    }
+    
+    return asset;
+}
+
+NSArray<NSString *> *get_output_names(NSArray<ETCoreMLModelStructurePath *> *paths) {
+    NSMutableArray<NSString *> *result = [NSMutableArray arrayWithCapacity:paths.count];
+    for (ETCoreMLModelStructurePath *path in paths) {
+        NSString *output_name = path.operationOutputName;
+        if (output_name) {
+            [result addObject:output_name];
+        }
+    }
+    
+    return result;
+}
+
+void set_model_outputs(id<MLFeatureProvider> output_features,
+                       NSOrderedSet<NSString *> *output_names,
+                       NSArray<MLMultiArray *> *_Nullable __autoreleasing *_Nonnull model_outputs) {
+    NSMutableArray<MLMultiArray *> *values = [NSMutableArray arrayWithCapacity:output_names.count];
+    for (NSString *output_name in output_names) {
+        MLFeatureValue *feature_value = [output_features featureValueForName:output_name];
+        NSCAssert(feature_value.multiArrayValue != nil, @"%@: Expected a multiarray value for output name=%@.",
+                  NSStringFromClass(ETCoreMLModelDebugger.class),
+                  output_name);
+        [values addObject:feature_value.multiArrayValue];
+    }
+    
+    *model_outputs = values;
+}
+
+void set_intermediate_outputs(id<MLFeatureProvider> output_features,
+                              NSArray<ETCoreMLModelStructurePath *> *paths,
+                              NSMutableDictionary<ETCoreMLModelStructurePath *, MLMultiArray *> *result) {
+    for (ETCoreMLModelStructurePath *path in paths) {
+        NSString *output_name = path.operationOutputName;
+        if (!output_name) {
+            continue;
+        }
+        
+        MLFeatureValue *feature_value = [output_features featureValueForName:output_name];
+        if (!feature_value) {
+            continue;
+        }
+        MLMultiArray *multi_array = feature_value.multiArrayValue;
+        result[path] = multi_array;
+    }
+}
+}
+
+@interface ETCoreMLModelDebugger ()
+/// The model output names.
+@property (readonly, copy, nonatomic) NSOrderedSet<NSString *> *outputNames;
+/// The model asset.
+@property (readonly, copy, nonatomic) ETCoreMLAsset *modelAsset;
+/// The asset manager.
+@property (readonly, copy, nonatomic) ETCoreMLAssetManager *assetManager;
+/// The model configuration.
+@property (readonly, strong, nonatomic) MLModelConfiguration *configuration;
+/// The url to the model specification.
+@property (readonly, copy, nonatomic) NSURL *modelSpecURL;
+
+@end
+
+@implementation ETCoreMLModelDebugger {
+    std::unique_ptr<Model> _modelSpec;
+}
+
+- (nullable instancetype)initWithModelAsset:(ETCoreMLAsset *)modelAsset
+                                outputNames:(NSOrderedSet<NSString *> *)outputNames
+                              configuration:(MLModelConfiguration *)configuration
+                               assetManager:(ETCoreMLAssetManager *)assetManager
+                                      error:(NSError * __autoreleasing *)error {
+    if (![modelAsset keepAliveAndReturnError:error]) {
+        return nil;
+    }
+    
+    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    NSURL *modelSpecURL = get_model_spec_url(modelAsset.contentURL, fileManager, error);
+    if (!modelSpecURL) {
+        return nil;
+    }
+    
+    auto modelSpec = parse_model_spec(modelSpecURL, error);
+    if (!modelSpec) {
+        return nil;
+    }
+    
+    __block NSMutableArray<ETCoreMLModelStructurePath *> *operationPaths = [NSMutableArray array];
+    visit_program_operation(*modelSpec, ^BOOL(const MILSpec::Operation &operation, ETCoreMLModelStructurePath *operationPath) {
+        if (is_operation_output_supported_as_model_output(operation)) {
+            [operationPaths addObject:operationPath];
+        }
+        return YES;
+    });
+    
+    self = [super init];
+    if (self) {
+        _modelAsset = modelAsset;
+        _configuration = configuration;
+        _outputNames = [outputNames copy];
+        _assetManager = assetManager;
+        _modelSpec = std::move(modelSpec);
+        _modelSpecURL = modelSpecURL;
+        _operationPaths = operationPaths;
+    }
+    
+    return self;
+}
+
+- (nullable ETCoreMLAsset *)compiledModelAssetWithOutputsAtPaths:(NSArray<ETCoreMLModelStructurePath *> *)paths
+                                                           error:(NSError* __autoreleasing *)error {
+    NSString *identifier = get_asset_identifier(self.modelAsset.identifier,
+                                                self.configuration.computeUnits,
+                                                paths);
+    NSError *localError = nil;
+    ETCoreMLAsset *compiledAsset = [self.assetManager assetWithIdentifier:identifier error:&localError];
+    if (compiledAsset) {
+        return compiledAsset;
+    }
+    
+    if (localError) {
+        os_log_error(ETCoreMLErrorUtils.loggingChannel, "%@: Failed to retrieve asset with identifier=%@, error=%@.",
+                     NSStringFromClass(ETCoreMLModelDebugger.class),
+                     identifier,
+                     localError);
+    }
+    
+    NSURL *compiledModelURL = get_compiled_model_url_with_intermediate_outputs(self.modelAsset.contentURL,
+                                                                               self.modelSpecURL,
+                                                                               *(_modelSpec.get()),
+                                                                               self.outputNames,
+                                                                               paths,
+                                                                               error);
+    if (!compiledModelURL) {
+        return nil;
+    }
+    
+    compiledAsset = [self.assetManager storeAssetAtURL:compiledModelURL
+                                        withIdentifier:identifier
+                                                 error:&localError];
+    
+    if (compiledAsset) {
+        return compiledAsset;
+    }
+    
+    if (localError) {
+        os_log_error(ETCoreMLErrorUtils.loggingChannel, "%@: Failed to store asset with identifier=%@, error=%@.",
+                     NSStringFromClass(ETCoreMLModelDebugger.class),
+                     identifier,
+                     localError);
+    }
+    
+    return make_asset(compiledModelURL, identifier, self.assetManager.fileManager, error);
+}
+
+- (nullable NSArray<DebuggableModel *> *)_modelsWithOutputsOfOperationsAtPath:(NSArray<ETCoreMLModelStructurePath *> *)paths
+                                                                        error:(NSError* __autoreleasing *)error {
+    if (paths.count == 0) {
+        return @[];
+    }
+    
+    ETCoreMLAsset *compiledAsset = [self compiledModelAssetWithOutputsAtPaths:paths error:error];
+    if (!compiledAsset) {
+        return nil;
+    }
+    
+    NSError *localError = nil;
+    MLModel *model = [MLModel modelWithContentsOfURL:compiledAsset.contentURL
+                                       configuration:self.configuration
+                                               error:&localError];
+    if (model) {
+        DebuggableModel *pair = [[ETCoreMLPair alloc] initWithFirst:model second:paths];
+        return @[pair];
+    }
+    
+    if (localError) {
+        os_log_error(ETCoreMLErrorUtils.loggingChannel , "%@: Failed to load model with outputs=%@.",
+                     NSStringFromClass(ETCoreMLModelDebugger.class),
+                     get_output_names(paths));
+    }
+    
+    if ([self.assetManager removeAssetWithIdentifier:compiledAsset.identifier error:&localError]) {
+        os_log_error(ETCoreMLErrorUtils.loggingChannel, "%@: Failed to remove compiled asset with identifier=%@, error=%@.",
+                     NSStringFromClass(ETCoreMLModelDebugger.class),
+                     compiledAsset.identifier,
+                     localError);
+    }
+    
+    if (paths.count == 1) {
+        *error = localError;
+        return nil;
+    }
+    
+    // There is a chance that the model compilation fails because of the number of outputs. In this case, we divide the paths into two and try again.
+    NSArray<ETCoreMLModelStructurePath *> *leftPaths = [paths subarrayWithRange:NSMakeRange(0, paths.count/2)];
+    NSArray<ETCoreMLModelStructurePath *> *rightPaths = [paths subarrayWithRange:NSMakeRange(paths.count/2, paths.count - paths.count/2)];
+    NSArray<DebuggableModel *> *leftModels = [self modelsWithOutputsOfOperationsAtPath:leftPaths error:&localError];
+    NSArray<DebuggableModel *> *rightModels = [self modelsWithOutputsOfOperationsAtPath:rightPaths error:&localError];
+    if (leftModels.count == 0 && rightModels.count == 0) {
+        *error = localError;
+        return nil;
+    }
+    
+    NSArray<DebuggableModel *> *models = [(leftModels == nil ? @[] : leftModels) arrayByAddingObjectsFromArray:(rightModels == nil ? @[] : rightModels)];
+    return models;
+}
+
+- (nullable NSArray<DebuggableModel *> *)modelsWithOutputsOfOperationsAtPath:(NSArray<ETCoreMLModelStructurePath *> *)paths
+                                                                       error:(NSError* __autoreleasing *)error {
+    @autoreleasepool {
+        return [self _modelsWithOutputsOfOperationsAtPath:paths error:error];
+    }
+}
+
+- (nullable ETCoreMLModelOutputs *)outputsOfOperationsAtPaths:(NSArray<ETCoreMLModelStructurePath *> *)paths
+                                                      options:(MLPredictionOptions *)options
+                                                       inputs:(id<MLFeatureProvider>)inputs
+                                                 modelOutputs:(NSArray<MLMultiArray *> *_Nullable __autoreleasing *_Nonnull)modelOutputs
+                                                        error:(NSError* __autoreleasing *)error {
+    NSArray<MLMultiArray *> *lModelOutputs = nil;
+    NSMutableDictionary<ETCoreMLModelStructurePath *, MLMultiArray *> *result = [NSMutableDictionary dictionaryWithCapacity:paths.count];
+    @autoreleasepool {
+        NSArray<DebuggableModel *> *models = [self modelsWithOutputsOfOperationsAtPath:paths error:error];
+        if (!models) {
+            return nil;
+        }
+        
+        for (DebuggableModel *pair in models) {
+            id<MLFeatureProvider> outputFeatures = [pair.first predictionFromFeatures:inputs options:options error:error];
+            set_intermediate_outputs(outputFeatures, paths, result);
+            if (modelOutputs) {
+                set_model_outputs(outputFeatures, self.outputNames, &lModelOutputs);
+            }
+        }
+    }
+    
+    if (modelOutputs) {
+        *modelOutputs = lModelOutputs;
+    }
+    
+    return result;
+}
+
+@end

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.h
@@ -1,0 +1,57 @@
+//
+// ETCoreMLModelProfiler.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <CoreML/CoreML.h>
+
+#import "ETCoreMLPair.h"
+
+@class ETCoreMLModel;
+@class ETCoreMLModelStructurePath;
+@class ETCoreMLOperationProfilingInfo;
+
+typedef NSDictionary<ETCoreMLModelStructurePath*, ETCoreMLOperationProfilingInfo*> ETCoreMLModelProfilingResult;
+
+NS_ASSUME_NONNULL_BEGIN
+/// A class responsible for profiling a model.
+__attribute__((objc_subclassing_restricted)) @interface ETCoreMLModelProfiler : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Constructs an `ETCoreMLModelProfiler` instance.
+///
+/// @param compiledModelAsset The compiled model asset (mlmodelc).
+/// @param outputNames The model output names.
+/// @param configuration The model configuration.
+/// @param error   On failure, error is filled with the failure information.
+- (nullable instancetype)initWithCompiledModelAsset:(ETCoreMLAsset*)compiledModelAsset
+                                        outputNames:(NSOrderedSet<NSString*>*)outputNames
+                                      configuration:(MLModelConfiguration*)configuration
+                                              error:(NSError* __autoreleasing*)error NS_DESIGNATED_INITIALIZER;
+
+/// Returns profiling info of operations at the specified paths.
+///
+/// @param paths The operation paths.
+/// @param options The prediction options.
+/// @param inputs The model inputs..
+/// @param modelOutputs  On success, modelOutputs is filled with the model outputs.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval A dictionary with the operation path as the key and the profiling info as the value.
+- (nullable ETCoreMLModelProfilingResult*)
+    profilingInfoForOperationsAtPaths:(NSArray<ETCoreMLModelStructurePath*>*)paths
+                              options:(MLPredictionOptions*)options
+                               inputs:(id<MLFeatureProvider>)inputs
+                         modelOutputs:(NSArray<MLMultiArray*>* _Nullable __autoreleasing* _Nonnull)modelOutputs
+                                error:(NSError* __autoreleasing*)error;
+
+/// The paths to all the operations for which we can get the profiling info.
+@property (readonly, copy, nonatomic) NSArray<ETCoreMLModelStructurePath*>* operationPaths;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.mm
@@ -1,0 +1,349 @@
+//
+// ETCoreMLModelProfiler.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <ETCoreMLAsset.h>
+#import <ETCoreMLLogging.h>
+#import <ETCoreMLModelStructurePath.h>
+#import <ETCoreMLOperationProfilingInfo.h>
+#import <ETCoreMLPair.h>
+#import <ETCoreMLModelProfiler.h>
+#import <ETCoreMLStrings.h>
+#import <mach/mach_time.h>
+#import <math.h>
+#import <program_path.h>
+
+namespace  {
+using namespace executorchcoreml::modelstructure;
+
+API_AVAILABLE(macos(14.4), ios(17.4), tvos(17.4), watchos(10.4))
+MLComputePlan *_Nullable get_compute_plan_of_model_at_url(NSURL *model_url,
+                                                          MLModelConfiguration *configuration,
+                                                          NSError* __autoreleasing *error) {
+    __block NSError *local_error = nil;
+    __block MLComputePlan *result = nil;
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    [MLComputePlan loadContentsOfURL:model_url configuration:configuration completionHandler:^(MLComputePlan * _Nullable compute_plan,
+                                                                                               NSError * _Nullable compute_plan_error) {
+        result = compute_plan;
+        local_error = compute_plan_error;
+        dispatch_semaphore_signal(sema);
+    }];
+    
+    long status = dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * 60 * NSEC_PER_SEC)));
+    if (status != 0) {
+        ETCoreMLLogUnderlyingErrorAndSetNSError(error,
+                                                ETCoreMLErrorCompilationFailed,
+                                                local_error,
+                                                "%@: Failed to get compute plan of model with name=%@.",
+                                                NSStringFromClass(ETCoreMLModelProfiler.class),
+                                                model_url.lastPathComponent);
+        return nil;
+    }
+    
+    return result;
+}
+
+API_AVAILABLE(macos(14.4), ios(17.4), tvos(17.4), watchos(10.4))
+void visit_program_operation(MLModelStructureProgramBlock *block,
+                             const Path& block_path,
+                             BOOL (^handler)(MLModelStructureProgramOperation *operation, ETCoreMLModelStructurePath *path)) {
+    for (MLModelStructureProgramOperation *operation in block.operations) {
+        Path operation_path = block_path;
+        operation_path.append_component(Path::Program::Operation(operation.outputs.firstObject.name.UTF8String));
+        if (!handler(operation, [[ETCoreMLModelStructurePath alloc] initWithUnderlyingValue:operation_path])) {
+            return;
+        }
+        
+        for (size_t i = 0; i < operation.blocks.count; ++i) {
+            Path nested_block_path = operation_path;
+            nested_block_path.append_component(Path::Program::Block(i));
+            visit_program_operation(operation.blocks[i], nested_block_path,handler);
+        }
+    }
+}
+
+API_AVAILABLE(macos(14.4), ios(17.4), tvos(17.4), watchos(10.4))
+void visit_program_operation(MLModelStructure *modelStructure, BOOL (^handler)(MLModelStructureProgramOperation *operation, ETCoreMLModelStructurePath *path)) {
+    using namespace executorchcoreml::modelstructure;
+    [modelStructure.program.functions enumerateKeysAndObjectsUsingBlock:^(NSString *function_name,
+                                                                          MLModelStructureProgramFunction *function,
+                                                                          BOOL * _Nonnull __unused stop) {
+        Path path;
+        path.append_component(Path::Program());
+        path.append_component(Path::Program::Function(function_name.UTF8String));
+        path.append_component(Path::Program::Block(-1));
+        visit_program_operation(function.block, path, handler);
+    }];
+}
+
+API_AVAILABLE(macos(14.4), ios(17.4), tvos(17.4), watchos(10.4))
+ETCoreMLComputeUnits to_compute_unit(id<MLComputeDeviceProtocol> compute_device) {
+    if ([compute_device isKindOfClass:MLCPUComputeDevice.class]) {
+        return ETCoreMLComputeUnitCPU;
+    } else if ([compute_device isKindOfClass:MLGPUComputeDevice.class]) {
+        return ETCoreMLComputeUnitGPU;
+    } else if ([compute_device isKindOfClass:MLNeuralEngineComputeDevice.class]) {
+        return ETCoreMLComputeUnitNeuralEngine;
+    } else {
+        return ETCoreMLComputeUnitUnknown;
+    }
+}
+
+API_AVAILABLE(macos(14.4), ios(17.4), tvos(17.4), watchos(10.4))
+ETCoreMLComputeUnits to_compute_units(NSArray<id<MLComputeDeviceProtocol>> *compute_devices) {
+    ETCoreMLComputeUnits units = ETCoreMLComputeUnitUnknown;
+    for (id<MLComputeDeviceProtocol> compute_device in compute_devices) {
+        units |= to_compute_unit(compute_device);
+    }
+    
+    return units;
+}
+
+API_AVAILABLE(macos(14.4), ios(17.4), tvos(17.4), watchos(10.4))
+ETCoreMLOperationProfilingInfo *get_profiling_info(MLComputePlanDeviceUsage *device_usage,
+                                                   MLModelStructureProgramOperation *operation,
+                                                   uint64_t op_execution_start_time,
+                                                   uint64_t op_execution_end_time,
+                                                   double estimatedCost) {
+    NSMutableArray<NSString *> *outputNames = [[NSMutableArray alloc] initWithCapacity:operation.outputs.count];
+    for (MLModelStructureProgramNamedValueType *output in operation.outputs) {
+        [outputNames addObject:output.name];
+    }
+    
+    ETCoreMLComputeUnits preferred_compute_unit = to_compute_unit(device_usage.preferredComputeDevice);
+    ETCoreMLComputeUnits supported_compute_units = to_compute_units(device_usage.supportedComputeDevices);
+    ETCoreMLOperationProfilingInfo *info = [[ETCoreMLOperationProfilingInfo alloc] initWithPreferredComputeUnit:preferred_compute_unit
+                                                                                          supportedComputeUnits:supported_compute_units
+                                                                                    estimatedExecutionStartTime:op_execution_start_time
+                                                                                      estimatedExecutionEndTime:op_execution_end_time
+                                                                                                  estimatedCost:estimatedCost
+                                                                                                    outputNames:outputNames
+                                                                                                   operatorName:operation.operatorName];
+    return info;
+}
+
+API_AVAILABLE(macos(14.4), ios(17.4), tvos(17.4), watchos(10.4))
+NSDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *
+prepare_profiling_infos(NSArray<MLModelStructureProgramOperation *> *operations,
+                        NSDictionary<NSValue *, ETCoreMLModelStructurePath *> *operation_to_path_map,
+                        MLComputePlan *compute_plan) {
+    NSMutableDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *result = [NSMutableDictionary dictionaryWithCapacity:operation_to_path_map.count];
+    for (MLModelStructureProgramOperation *operation in operations) {
+        MLComputePlanCost *estimated_cost = [compute_plan estimatedCostOfMLProgramOperation:operation];
+        if (!estimated_cost || std::isnan(estimated_cost.weight)) {
+            continue;
+        }
+        
+        NSValue *key = [NSValue valueWithPointer:(const void*)operation];
+        ETCoreMLModelStructurePath *path = operation_to_path_map[key];
+        MLComputePlanDeviceUsage *device_usage = [compute_plan computeDeviceUsageForMLProgramOperation:operation];
+        if (path && device_usage) {
+            ETCoreMLOperationProfilingInfo *profiling_info = get_profiling_info(device_usage,
+                                                                                operation,
+                                                                                0,
+                                                                                0,
+                                                                                estimated_cost.weight);
+            result[path] = profiling_info;
+        }
+    }
+    
+    return result;
+}
+
+API_AVAILABLE(macos(14.4), ios(17.4), tvos(17.4), watchos(10.4))
+NSDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *
+get_profiling_infos_for_paths(NSSet<ETCoreMLModelStructurePath *> *paths,
+                              NSArray<MLModelStructureProgramOperation *> *topologically_sorted_operations,
+                              NSDictionary<NSValue *, ETCoreMLModelStructurePath *> *operation_to_path_map,
+                              NSDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *profiling_infos,
+                              uint64_t model_execution_start_time,
+                              uint64_t model_execution_end_time) {
+    NSMutableDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *result = [NSMutableDictionary dictionaryWithCapacity:paths.count];
+    uint64_t op_execution_start_time = model_execution_start_time;
+    uint64_t op_execution_end_time = model_execution_start_time;
+    // `model_execution_end_time` >= `model_execution_start_time`.
+    uint64_t model_execution_duration = model_execution_end_time - model_execution_start_time;
+    for (MLModelStructureProgramOperation *operation in topologically_sorted_operations) {
+        NSValue *key = [NSValue valueWithPointer:(const void*)operation];
+        ETCoreMLModelStructurePath *path = operation_to_path_map[key];
+        ETCoreMLOperationProfilingInfo *profiling_info = profiling_infos[path];
+        if (!profiling_info) {
+            continue;
+        }
+        
+        op_execution_end_time = op_execution_start_time + static_cast<uint64_t>(static_cast<double>(model_execution_duration) * profiling_info.estimatedCost);
+        if (path && [paths containsObject:path]) {
+            ETCoreMLOperationProfilingInfo *profiling_info_new = [[ETCoreMLOperationProfilingInfo alloc] initWithPreferredComputeUnit:profiling_info.preferredComputeUnit
+                                                                                                                supportedComputeUnits:profiling_info.supportedComputeUnits
+                                                                                                          estimatedExecutionStartTime:op_execution_start_time
+                                                                                                            estimatedExecutionEndTime:op_execution_end_time
+                                                                                                                        estimatedCost:profiling_info.estimatedCost
+                                                                                                                          outputNames:profiling_info.outputNames
+                                                                                                                         operatorName:profiling_info.operatorName
+                                                                                                                             metadata:profiling_info.metadata];
+            result[path] = profiling_info_new;
+        }
+        op_execution_start_time = op_execution_end_time;
+    }
+    
+    return result;
+}
+
+API_AVAILABLE(macos(14.4), ios(17.4), tvos(17.4), watchos(10.4))
+BOOL is_const_operation(MLModelStructureProgramOperation *operation) {
+    return [operation.operatorName isEqualToString:@"const"];
+}
+
+void set_model_outputs(id<MLFeatureProvider> output_features,
+                       NSOrderedSet<NSString *> *output_names,
+                       NSArray<MLMultiArray *> *_Nullable __autoreleasing *_Nonnull model_outputs) {
+    NSMutableArray<MLMultiArray *> *values = [NSMutableArray arrayWithCapacity:output_names.count];
+    for (NSString *output_name in output_names) {
+        MLFeatureValue *feature_value = [output_features featureValueForName:output_name];
+        NSCAssert(feature_value.multiArrayValue != nil, @"%@: Expected a multiarray value for output name=%@.",
+                  NSStringFromClass(ETCoreMLModelProfiler.class),
+                  output_name);
+        [values addObject:feature_value.multiArrayValue];
+    }
+    
+    *model_outputs = values;
+}
+}
+
+API_AVAILABLE(macos(14.4), ios(17.4), tvos(17.4), watchos(10.4))
+@interface ETCoreMLModelProfiler ()
+/// The CoreML model.
+@property (readonly, strong, nonatomic) MLModel *model;
+/// The model output names.
+@property (readonly, copy, nonatomic) NSOrderedSet<NSString *> *outputNames;
+/// The compute plan.
+@property (readonly, strong, nonatomic) MLComputePlan *computePlan;
+/// The mapping from operation to it's path in the model structure.
+@property (readonly, strong, nonatomic) NSDictionary<NSValue *, ETCoreMLModelStructurePath *> *operationToPathMap;
+/// The topologically sorted operations.
+@property (readonly, copy, nonatomic) NSArray<MLModelStructureProgramOperation *> *topologicallySortedOperations;
+/// The profiling infos for all the operations.
+@property (readonly, copy, nonatomic) NSDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *profilingInfos;
+
+@end
+
+@implementation ETCoreMLModelProfiler
+
+- (nullable instancetype)initWithCompiledModelAsset:(ETCoreMLAsset *)compiledModelAsset
+                                        outputNames:(NSOrderedSet<NSString *> *)outputNames
+                                      configuration:(MLModelConfiguration *)configuration
+                                              error:(NSError * __autoreleasing *)error  {
+    if (@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)) {
+        NSURL *compiledModelURL = compiledModelAsset.contentURL;
+        MLComputePlan *computePlan = get_compute_plan_of_model_at_url(compiledModelURL,
+                                                                      configuration,
+                                                                      error);
+        if (!computePlan) {
+            return nil;
+        }
+        
+        MLModel *model = [MLModel modelWithContentsOfURL:compiledModelURL error:error];
+        if (!model) {
+            return nil;
+        }
+        
+        __block NSMutableArray<ETCoreMLModelStructurePath *> *operationPaths = [NSMutableArray array];
+        __block NSMutableDictionary<NSValue *, ETCoreMLModelStructurePath *> *operationToPathMap = [NSMutableDictionary dictionary];
+        __block NSMutableArray<MLModelStructureProgramOperation *> *topologicallySortedOperations = [NSMutableArray new];
+        visit_program_operation(computePlan.modelStructure, ^BOOL(MLModelStructureProgramOperation *operation, ETCoreMLModelStructurePath *operationPath) {
+            if (is_const_operation(operation)) {
+                return YES;
+            }
+            
+            [topologicallySortedOperations addObject:operation];
+            NSValue *key = [NSValue valueWithPointer:(const void*)operation];
+            operationToPathMap[key] = operationPath;
+            [operationPaths addObject:operationPath];
+            return YES;
+        });
+        
+        NSDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *profilingInfos = prepare_profiling_infos(topologicallySortedOperations,
+                                                                                                                               operationToPathMap,
+                                                                                                                               computePlan);
+        
+        self = [super init];
+        if (self) {
+            _outputNames = [outputNames copy];
+            _model = model;
+            _computePlan = computePlan;
+            _operationToPathMap = operationToPathMap;
+            _topologicallySortedOperations = topologicallySortedOperations;
+            _operationPaths = operationPaths;
+            _profilingInfos = profilingInfos;
+        }
+        
+        return self;
+    } else {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      ETCoreMLErrorCorruptedModel,
+                                      "%@: Model profiling is only available for macOS >= 14.4, iOS >= 17.4, tvOS >= 17.4 and watchOS >= 10.4.",
+                                      NSStringFromClass(self.class));
+        return nil;
+    }
+}
+
+- (nullable ETCoreMLModelProfilingResult *)profilingInfoForOperationsAtPaths:(NSArray<ETCoreMLModelStructurePath *> *)paths
+                                                                     options:(MLPredictionOptions *)options
+                                                                      inputs:(id<MLFeatureProvider>)inputs
+                                                                modelOutputs:(NSArray<MLMultiArray *> *_Nullable __autoreleasing *_Nonnull)modelOutputs
+                                                                       error:(NSError* __autoreleasing *)error {
+    uint64_t modelExecutionStartTime = mach_absolute_time();
+    id<MLFeatureProvider> outputFeatures = [self.model predictionFromFeatures:inputs options:options error:error];
+    uint64_t modelExecutionEndTime = mach_absolute_time();
+    if (!modelOutputs) {
+        return nil;
+    }
+    
+    if (@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)) {
+        ETCoreMLModelProfilingResult *profilingInfos = get_profiling_infos_for_paths([NSSet setWithArray:paths],
+                                                                                     self.topologicallySortedOperations,
+                                                                                     self.operationToPathMap,
+                                                                                     self.profilingInfos,
+                                                                                     modelExecutionStartTime,
+                                                                                     modelExecutionEndTime);
+        
+        
+        
+        if (outputFeatures) {
+            set_model_outputs(outputFeatures, self.outputNames, modelOutputs);
+        }
+        
+        return profilingInfos;
+    }
+    
+    return nil;
+}
+
+- (nullable ETCoreMLModelProfilingResult *)profilingInfoForAllOperationsWithOptions:(MLPredictionOptions *)options
+                                                                             inputs:(id<MLFeatureProvider>)inputs
+                                                                       modelOutputs:(NSArray<MLMultiArray *> *_Nullable __autoreleasing *_Nonnull)modelOutputs
+                                                                              error:(NSError* __autoreleasing *)error {
+    if (@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)) {
+        __block NSMutableArray<ETCoreMLModelStructurePath *> *paths = [NSMutableArray array];
+        visit_program_operation(self.computePlan.modelStructure, ^BOOL(MLModelStructureProgramOperation *operation, ETCoreMLModelStructurePath *path) {
+            if (!is_const_operation(operation)) {
+                [paths addObject:path];
+            }
+            return YES;
+        });
+        
+        return [self profilingInfoForOperationsAtPaths:paths
+                                               options:options
+                                                inputs:inputs
+                                          modelOutputs:modelOutputs
+                                                 error:error];
+    }
+    
+    return nil;
+}
+
+@end

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelStructurePath.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelStructurePath.h
@@ -1,0 +1,44 @@
+//
+// ETCoreModelStructurePath.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <Foundation/Foundation.h>
+
+#import "program_path.h"
+
+NS_ASSUME_NONNULL_BEGIN
+/// A class representing the path to a node in the model structure.
+///
+/// For a ML Program (ExecuTorch program), the structure is comprised of `Program`, `Function`, `Block`, and `Operation`
+/// nodes. The path can refer to any node in the structure.
+///
+/// The class is a thin wrapper over `executorchcoreml::modelstructure::path`.
+///
+__attribute__((objc_subclassing_restricted)) @interface ETCoreMLModelStructurePath : NSObject<NSCopying>
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Constructs an `ETCoreMLModelStructurePath` instance.
+///
+/// @param value The cpp value.
+- (instancetype)initWithUnderlyingValue:(executorchcoreml::modelstructure::Path)value NS_DESIGNATED_INITIALIZER;
+
+/// Constructs an `ETCoreMLModelStructurePath` instance.
+///
+/// @param components The path components.`
+- (instancetype)initWithComponents:(NSArray<NSDictionary<NSString*, id>*>*)components;
+
+/// The underlying value.
+@property (readonly, assign, nonatomic) executorchcoreml::modelstructure::Path underlyingValue;
+
+/// If the path refers to an operation then it returns the operation's output name otherwise `nil`.
+@property (readonly, copy, nonatomic, nullable) NSString* operationOutputName;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelStructurePath.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelStructurePath.mm
@@ -1,0 +1,185 @@
+//
+// ETCoreModelStructurePath.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import "ETCoreMLModelStructurePath.h"
+
+#import <objc_safe_cast.h>
+
+namespace {
+using namespace executorchcoreml::modelstructure;
+
+enum ComponentType: uint8_t {
+    program,
+    function,
+    operation,
+    block
+};
+
+template<typename T> void append_component(NSDictionary<NSString *, id> *component, Path& path);
+
+template<> void append_component<Path::Program>(NSDictionary<NSString *, id> * __unused component, Path& path) {
+    path.append_component(Path::Program());
+}
+
+template<> void append_component<Path::Program::Function>(NSDictionary<NSString *, id> *component, Path& path) {
+    NSString *name = SAFE_CAST(component[@(Path::Program::Function::kNameKeyName)], NSString);
+    path.append_component(Path::Program::Function(name.UTF8String));
+}
+
+template<> void append_component<Path::Program::Block>(NSDictionary<NSString *, id> *component, Path& path) {
+    NSNumber *index = SAFE_CAST(component[@(Path::Program::Block::kIndexKeyName)], NSNumber);
+    NSInteger indexValue = (index != nil) ? index.integerValue : -1;
+    path.append_component(Path::Program::Block(indexValue));
+}
+
+template<> void append_component<Path::Program::Operation>(NSDictionary<NSString *, id> *component, Path& path) {
+    NSString *output_name = SAFE_CAST(component[@(Path::Program::Operation::kOutputKeyName)], NSString) ?: @"";
+    NSCAssert(output_name.length > 0, @"Component=%@ is missing %s key.", component, Path::Program::Operation::kOutputKeyName);
+    path.append_component(Path::Program::Operation(output_name.UTF8String));
+}
+
+NSDictionary<NSString *, NSNumber *> *component_types() {
+    static NSDictionary<NSString *, NSNumber *> *result = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        result = @{
+            @(Path::Program::kTypeName): @(ComponentType::program),
+            @(Path::Program::Function::kTypeName): @(ComponentType::function),
+            @(Path::Program::Block::kTypeName): @(ComponentType::block),
+            @(Path::Program::Operation::kTypeName): @(ComponentType::operation)
+        };
+    });
+    
+    return result;
+}
+
+Path to_path(NSArray<NSDictionary<NSString *, id> *> *components) {
+    Path path;
+    NSDictionary<NSString *, NSNumber *> *types = component_types();
+    for (NSDictionary<NSString *, id> *component in components) {
+        NSString *type = SAFE_CAST(component[@(Path::kTypeKeyName)], NSString);
+        NSCAssert(type.length > 0, @"Component=%@ is missing %s key.", component, Path::kTypeKeyName);
+        switch (types[type].intValue) {
+            case ComponentType::program: {
+                append_component<Path::Program>(component, path);
+                break;
+            }
+            case ComponentType::function: {
+                append_component<Path::Program::Function>(component, path);
+                break;
+            }
+            case ComponentType::block: {
+                append_component<Path::Program::Block>(component, path);
+                break;
+            }
+            case ComponentType::operation: {
+                append_component<Path::Program::Operation>(component, path);
+                break;
+            }
+            default: {
+                NSCAssert(type.length == 0, @"Component=%@ has invalid type=%@.", component, type);
+            }
+        }
+    }
+    
+    return path;
+}
+
+NSDictionary<NSString *, id> *to_dictionary(const Path::Program& __unused program) {
+    return @{@(Path::kTypeKeyName) : @(Path::Program::kTypeName)};
+}
+
+NSDictionary<NSString *, id> *to_dictionary(const Path::Program::Function& function) {
+    return @{
+        @(Path::kTypeKeyName) : @(Path::Program::Function::kTypeName),
+        @(Path::Program::Function::kNameKeyName) : @(function.name.c_str())
+    };
+}
+
+NSDictionary<NSString *, id> *to_dictionary(const Path::Program::Block& block) {
+    return @{
+        @(Path::kTypeKeyName) : @(Path::Program::Block::kTypeName),
+        @(Path::Program::Block::kIndexKeyName) : @(block.index)
+    };
+}
+
+NSDictionary<NSString *, id> *to_dictionary(const Path::Program::Operation& operation) {
+    return @{
+        @(Path::kTypeKeyName) : @(Path::Program::Operation::kTypeName),
+        @(Path::Program::Operation::kOutputKeyName) : @(operation.output_name.c_str())
+    };
+}
+
+NSArray<NSDictionary<NSString *, id> *> *to_array(const Path& path) {
+    NSMutableArray<NSDictionary<NSString *, id> *> *result = [NSMutableArray arrayWithCapacity:path.size()];
+    for (const auto& component : path.components()) {
+        NSDictionary<NSString *, id> *value = std::visit([](auto&& arg){
+            return to_dictionary(arg);
+        }, component);
+        [result addObject:value];
+    }
+    
+    return result;
+}
+}
+
+@implementation ETCoreMLModelStructurePath
+
+- (instancetype)initWithUnderlyingValue:(executorchcoreml::modelstructure::Path)underlyingValue {
+    self = [super init];
+    if (self) {
+        _underlyingValue = std::move(underlyingValue);
+    }
+    
+    return self;
+}
+
+- (instancetype)initWithComponents:(NSArray<NSDictionary<NSString *, id> *> *)components {
+    auto underlyingValue = to_path(components);
+    return [self initWithUnderlyingValue:std::move(underlyingValue)];
+}
+
+- (BOOL)isEqual:(id)object {
+    if (object == self) {
+        return YES;
+    }
+    
+    if (![object isKindOfClass:self.class]) {
+        return NO;
+    }
+    
+    return _underlyingValue == ((ETCoreMLModelStructurePath *)object)->_underlyingValue;
+}
+
+- (NSUInteger)hash {
+    return std::hash<executorchcoreml::modelstructure::Path>()(_underlyingValue);
+}
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    return [[ETCoreMLModelStructurePath allocWithZone:zone] initWithUnderlyingValue:_underlyingValue];
+}
+
+- (nullable NSString *)operationOutputName {
+    using namespace executorchcoreml::modelstructure;
+    auto operation = std::get_if<Path::Program::Operation>(&(_underlyingValue.components().back()));
+    if (operation == nullptr) {
+        return nil;
+    }
+    
+    return @(operation->output_name.c_str());
+}
+
+- (NSArray<NSDictionary<NSString *, id> *> *)components {
+    return to_array(_underlyingValue);
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<MLModelStructurePath: %p> %@", (void *)self, self.components];
+}
+
+
+@end

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLOperationProfilingInfo.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLOperationProfilingInfo.h
@@ -1,0 +1,75 @@
+//
+// ETCoreMLOperationProfilingInfo.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <CoreML/CoreML.h>
+
+#import <ETCoreMLComputeUnits.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A class representing the profiling info of an operation.
+__attribute__((objc_subclassing_restricted)) @interface ETCoreMLOperationProfilingInfo : NSObject<NSCopying>
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Constructs an `ETCoreMLOperationProfilingInfo` instance.
+///
+/// @param preferredComputeUnit The compute unit used to execute the operation.
+/// @param supportedComputeUnits The compute units that can execute the operation.
+/// @param estimatedExecutionStartTime The estimated execution start time.
+/// @param estimatedExecutionEndTime The estimated execution end time.
+/// @param estimatedCost The estimated cost of executing an operation.
+/// @param outputNames The output names of the operation.
+/// @param operatorName The operator name of the operation.
+/// @param metadata The metadata, for logging additional info.
+- (instancetype)initWithPreferredComputeUnit:(ETCoreMLComputeUnits)preferredComputeUnit
+                       supportedComputeUnits:(ETCoreMLComputeUnits)supportedComputeUnits
+                 estimatedExecutionStartTime:(uint64_t)estimatedExecutionStartTime
+                   estimatedExecutionEndTime:(uint64_t)estimatedExecutionEndTime
+                               estimatedCost:(double)estimatedCost
+                                 outputNames:(NSArray<NSString*>*)outputNames
+                                operatorName:(NSString*)operatorName
+                                    metadata:(NSData*)metadata NS_DESIGNATED_INITIALIZER;
+
+/// Constructs an `ETCoreMLOperationProfilingInfo` instance.
+///
+/// @param preferredComputeUnit The compute unit used to execute the operation.
+/// @param supportedComputeUnits The compute units that can execute the operation.
+/// @param estimatedExecutionStartTime The estimated execution start time.
+/// @param estimatedExecutionEndTime The estimated execution end time.
+/// @param estimatedCost The estimated cost of executing an operation.
+/// @param outputNames The output names of the operation.
+/// @param operatorName The operator name of the operation.
+- (instancetype)initWithPreferredComputeUnit:(ETCoreMLComputeUnits)preferredComputeUnit
+                       supportedComputeUnits:(ETCoreMLComputeUnits)supportedComputeUnits
+                 estimatedExecutionStartTime:(uint64_t)estimatedExecutionStartTime
+                   estimatedExecutionEndTime:(uint64_t)estimatedExecutionEndTime
+                               estimatedCost:(double)estimatedCost
+                                 outputNames:(NSArray<NSString*>*)outputNames
+                                operatorName:(NSString*)operatorName;
+/// The preferred compute unit.
+@property (readonly, assign, nonatomic) ETCoreMLComputeUnits preferredComputeUnit;
+/// The supported compute units.
+@property (readonly, assign, nonatomic) ETCoreMLComputeUnits supportedComputeUnits;
+/// The estimated execution start time.
+@property (readwrite, assign, nonatomic) uint64_t estimatedExecutionStartTime;
+/// The estimated execution end time.
+@property (readwrite, assign, nonatomic) uint64_t estimatedExecutionEndTime;
+/// The output names of the operation.
+@property (readonly, copy, nonatomic) NSArray<NSString*>* outputNames;
+/// The operator name of the operation.
+@property (readonly, copy, nonatomic) NSString* operatorName;
+/// The estimated cost for executing the operation.
+@property (readonly, assign, nonatomic) double estimatedCost;
+/// The metadata, this is used to log additional info.
+@property (readonly, strong, nonatomic) NSData* metadata;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLOperationProfilingInfo.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLOperationProfilingInfo.mm
@@ -1,0 +1,140 @@
+//
+// ETCoreMLOperationProfilingInfo.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <ETCoreMLOperationProfilingInfo.h>
+#import <hash_util.h>
+#import <model_event_logger_impl.h>
+
+namespace  {
+NSString *const kPreferredComputeUnitKey = @"preferredComputeUnit";
+NSString *const kSupportedComputeUnitsKey = @"supportedComputeUnits";
+NSString *const kOutputNamesKey = @"outputNames";
+NSString *const kOperatorNameKey = @"operatorName";
+NSString *const kEstimatedCostKey = @"estimatedCost";
+
+NSArray<NSString *> *compute_unit_names(ETCoreMLComputeUnits compute_units) {
+    NSMutableArray<NSString *> *result = [NSMutableArray array];
+    if ((compute_units & ETCoreMLComputeUnitNeuralEngine) > 0) {
+        [result addObject:@"ANE"];
+    }
+    if ((compute_units & ETCoreMLComputeUnitCPU) > 0) {
+        [result addObject:@"CPU"];
+    }
+    if ((compute_units & ETCoreMLComputeUnitGPU) > 0) {
+        [result addObject:@"GPU"];
+    }
+    
+    return result;
+}
+
+NSData *get_metadata(ETCoreMLComputeUnits preferredComputeUnit,
+                     ETCoreMLComputeUnits supportedComputeUnits,
+                     NSArray<NSString *> *outputNames,
+                     NSString *operatorName,
+                     double estimatedCost) {
+    NSMutableDictionary<NSString *, id> *result = [NSMutableDictionary new];
+    result[kPreferredComputeUnitKey] = compute_unit_names(preferredComputeUnit).firstObject;
+    result[kSupportedComputeUnitsKey] = compute_unit_names(supportedComputeUnits);
+    result[kOutputNamesKey] = outputNames;
+    result[kOperatorNameKey] = operatorName;
+    result[kEstimatedCostKey] = @(estimatedCost);
+    NSError *local_error = nil;
+    NSData *data = [NSJSONSerialization dataWithJSONObject:result options:NSJSONWritingOptions(0) error:&local_error];
+    NSCAssert(data != nil, @"%@: Failed to serialize metadata.", NSStringFromClass(ETCoreMLOperationProfilingInfo.class));
+    
+    return data;
+};
+}
+
+@implementation ETCoreMLOperationProfilingInfo
+
+- (instancetype)initWithPreferredComputeUnit:(ETCoreMLComputeUnits)preferredComputeUnit
+                       supportedComputeUnits:(ETCoreMLComputeUnits)supportedComputeUnits
+                 estimatedExecutionStartTime:(uint64_t)estimatedExecutionStartTime
+                   estimatedExecutionEndTime:(uint64_t)estimatedExecutionEndTime
+                               estimatedCost:(double)estimatedCost
+                                 outputNames:(NSArray<NSString *> *)outputNames
+                                operatorName:(NSString *)operatorName
+                                    metadata:(NSData *)metadata {
+    self = [super init];
+    if (self) {
+        _preferredComputeUnit = preferredComputeUnit;
+        _supportedComputeUnits = supportedComputeUnits;
+        _estimatedExecutionStartTime = estimatedExecutionStartTime;
+        _estimatedExecutionEndTime = estimatedExecutionEndTime;
+        _estimatedCost = estimatedCost;
+        _outputNames = [outputNames copy];
+        _operatorName = [operatorName copy];
+        _metadata = get_metadata(preferredComputeUnit, supportedComputeUnits, outputNames, operatorName, estimatedCost);
+    }
+    
+    return self;
+}
+
+- (instancetype)initWithPreferredComputeUnit:(ETCoreMLComputeUnits)preferredComputeUnit
+                       supportedComputeUnits:(ETCoreMLComputeUnits)supportedComputeUnits
+                 estimatedExecutionStartTime:(uint64_t)estimatedExecutionStartTime
+                   estimatedExecutionEndTime:(uint64_t)estimatedExecutionEndTime
+                               estimatedCost:(double)estimatedCost
+                                 outputNames:(NSArray<NSString *> *)outputNames
+                                operatorName:(NSString *)operatorName {
+    NSData *metadata = get_metadata(preferredComputeUnit, supportedComputeUnits, outputNames, operatorName, estimatedCost);
+    return [self initWithPreferredComputeUnit:preferredComputeUnit
+                        supportedComputeUnits:supportedComputeUnits
+                  estimatedExecutionStartTime:estimatedExecutionStartTime
+                    estimatedExecutionEndTime:estimatedExecutionEndTime
+                                estimatedCost:estimatedCost
+                                  outputNames:outputNames
+                                 operatorName:operatorName
+                                     metadata:metadata];
+}
+
+- (BOOL)isEqual:(id)object {
+    if (object == self) {
+        return YES;
+    }
+    
+    if (![object isKindOfClass:self.class]) {
+        return NO;
+    }
+    
+    ETCoreMLOperationProfilingInfo *other = (ETCoreMLOperationProfilingInfo *)object;
+    
+    return self.preferredComputeUnit == other.preferredComputeUnit &&
+    self.supportedComputeUnits == other.supportedComputeUnits &&
+    self.estimatedExecutionStartTime == other.estimatedExecutionStartTime &&
+    self.estimatedExecutionEndTime == other.estimatedExecutionEndTime &&
+    [self.outputNames isEqualToArray:other.outputNames] &&
+    [self.operatorName isEqualToString:other.operatorName] &&
+    [self.metadata isEqualToData:other.metadata];
+}
+
+- (NSUInteger)hash {
+    size_t seed = 0;
+    executorchcoreml::hash_combine(seed, self.preferredComputeUnit);
+    executorchcoreml::hash_combine(seed, self.supportedComputeUnits);
+    executorchcoreml::hash_combine(seed, self.estimatedExecutionStartTime);
+    executorchcoreml::hash_combine(seed, self.estimatedExecutionEndTime);
+    executorchcoreml::hash_combine(seed, self.outputNames.hash);
+    executorchcoreml::hash_combine(seed, self.operatorName.hash);
+    executorchcoreml::hash_combine(seed, self.metadata.hash);
+    
+    return seed;
+}
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    return [[ETCoreMLOperationProfilingInfo allocWithZone:zone] initWithPreferredComputeUnit:self.preferredComputeUnit
+                                                                       supportedComputeUnits:self.supportedComputeUnits
+                                                                 estimatedExecutionStartTime:self.estimatedExecutionStartTime
+                                                                   estimatedExecutionEndTime:self.estimatedExecutionEndTime
+                                                                               estimatedCost:self.estimatedCost
+                                                                                 outputNames:self.outputNames
+                                                                                operatorName:self.operatorName
+                                                                                    metadata:self.metadata];
+}
+
+@end

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLPair.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLPair.h
@@ -1,0 +1,32 @@
+//
+// ETCoreMLPair.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+/// A class representing a pair with first and second objects.
+__attribute__((objc_subclassing_restricted)) @interface ETCoreMLPair<First, Second> : NSObject<NSCopying>
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Constructs an `ETCoreMLPair` instance.
+///
+/// @param first The first object of this pair.
+/// @param second The second object of this pair.
+- (instancetype)initWithFirst:(First)first second:(Second)second NS_DESIGNATED_INITIALIZER;
+
+/// The first object.
+@property (nonatomic, readonly) First first;
+
+/// The second object..
+@property (nonatomic, readonly) Second second;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLPair.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLPair.mm
@@ -1,0 +1,38 @@
+//
+// ETCoreMLPair.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <ETCoreMLPair.h>
+
+@implementation ETCoreMLPair
+
+- (instancetype)initWithFirst:(id)first second:(id)second {
+    self = [super init];
+    if (self) {
+        _first = first;
+        _second = second;
+    }
+    
+    return self;
+}
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    return [[ETCoreMLPair allocWithZone:zone] initWithFirst:self.first second:self.second];
+}
+
+- (BOOL)isEqual:(id)other {
+    if (other == self) {
+        return YES;
+    }
+    
+    if (![other isKindOfClass:self.class]) {
+        return NO;
+    }
+    
+    return [self.first isEqual:((ETCoreMLPair *)other).first] && [self.second isEqual:((ETCoreMLPair *)other).second];
+}
+
+@end

--- a/backends/apple/coreml/runtime/sdk/hash_util.h
+++ b/backends/apple/coreml/runtime/sdk/hash_util.h
@@ -1,0 +1,29 @@
+//
+// hash_util.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#include <functional>
+#include <type_traits>
+
+namespace executorchcoreml {
+inline void hash_combine(size_t& seed, size_t hash) {
+    // Combiner taken from boost::hash_combine
+    seed ^= hash + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+template <class T> inline void hash_combine(size_t& seed, T const& v) { hash_combine(seed, std::hash<T> {}(v)); }
+
+template <class T> inline size_t container_hash(const T& values) {
+    size_t seed = 0;
+    for (auto it = values.begin(); it != values.end(); ++it) {
+        executorchcoreml::hash_combine(seed, *it);
+    }
+
+    return seed;
+}
+}

--- a/backends/apple/coreml/runtime/sdk/model_event_logger_impl.h
+++ b/backends/apple/coreml/runtime/sdk/model_event_logger_impl.h
@@ -1,0 +1,49 @@
+//
+// model_event_logger_impl.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#import <CoreML/CoreML.h>
+#import <model_event_logger.h>
+
+namespace torch::executor {
+class EventTracer;
+}
+
+namespace executorchcoreml {
+/// A class implementing the `ModelEventLogger` protocol.
+///
+/// It doesn't own the tracer object, the object must not be used if the tracer is gone.
+class ModelEventLoggerImpl final : public ModelEventLogger {
+public:
+    /// Construct a `ModelEventLoggerImpl` from the `EventTracer`.
+    explicit ModelEventLoggerImpl(torch::executor::EventTracer* tracer) : tracer_(tracer) { }
+
+    /// Logs profiling infos.
+    ///
+    /// @param op_path_to_profiling_info_map A dictionary with the operation path as the key and operation's profiling
+    /// info as the value.
+    /// @param op_path_to_debug_symbol_name_map A dictionary with the operation path as the key and the symbol name as
+    /// the value. The symbol name is the delegate handle.
+    void log_profiling_infos(
+        NSDictionary<ETCoreMLModelStructurePath*, ETCoreMLOperationProfilingInfo*>* op_path_to_profiling_info_map,
+        NSDictionary<ETCoreMLModelStructurePath*, NSString*>* op_path_to_debug_symbol_name_map) const noexcept override;
+
+    /// Logs intermediate tensor values.
+    ///
+    /// @param op_path_to_value_map A dictionary with the operation path as the key and the operation's value as the
+    /// value.
+    /// @param op_path_to_debug_symbol_name_map A dictionary with the operation path as the key and the symbol name as
+    /// the value. The symbol name is the delegate handle.
+    void log_intermediate_tensors(
+        NSDictionary<ETCoreMLModelStructurePath*, MLMultiArray*>* op_path_to_value_map,
+        NSDictionary<ETCoreMLModelStructurePath*, NSString*>* op_path_to_debug_symbol_name_map) const noexcept override;
+
+private:
+    torch::executor::EventTracer* tracer_;
+};
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/sdk/model_event_logger_impl.mm
+++ b/backends/apple/coreml/runtime/sdk/model_event_logger_impl.mm
@@ -1,0 +1,59 @@
+//
+// model_event_logger_impl.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <ETCoreMLModelStructurePath.h>
+#import <ETCoreMLOperationProfilingInfo.h>
+#import <executorch/runtime/core/event_tracer.h>
+#import <mach/mach_time.h>
+#import <model_event_logger_impl.h>
+
+namespace {
+uint64_t time_units_to_nano_seconds(uint64_t time_units) {
+    static mach_timebase_info_data_t info;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSCAssert(mach_timebase_info(&info) == KERN_SUCCESS, @"ModelEventLogger: Failed to get time base.");
+    });
+    
+    return time_units * info.numer / info.denom;
+}
+
+}
+
+namespace executorchcoreml {
+
+void ModelEventLoggerImpl::log_profiling_infos(NSDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *op_path_to_profiling_info_map,
+                                               NSDictionary<ETCoreMLModelStructurePath *, NSString *> *op_path_to_debug_symbol_name_map) const noexcept {
+    [op_path_to_profiling_info_map enumerateKeysAndObjectsUsingBlock:^(ETCoreMLModelStructurePath *path,
+                                                                       ETCoreMLOperationProfilingInfo *profiling_info,
+                                                                       BOOL * _Nonnull __unused stop) {
+        if (profiling_info.estimatedExecutionEndTime == profiling_info.estimatedExecutionStartTime) {
+            return;
+        }
+        uint64_t estimated_execution_start_time_in_ns = time_units_to_nano_seconds(profiling_info.estimatedExecutionStartTime);
+        uint64_t estimated_execution_end_time_in_ns = time_units_to_nano_seconds(profiling_info.estimatedExecutionEndTime);
+        NSString *symbol_name = op_path_to_debug_symbol_name_map[path];
+        if (symbol_name == nil) {
+            // We will use the operation output name as a placeholder for now.
+            symbol_name = profiling_info.outputNames.firstObject;
+        }
+        NSData *metadata = profiling_info.metadata;
+        tracer_->log_profiling_delegate(symbol_name.UTF8String,
+                                        -1,
+                                        estimated_execution_start_time_in_ns,
+                                        estimated_execution_end_time_in_ns,
+                                        metadata.bytes,
+                                        metadata.length);
+        
+    }];
+}
+
+void ModelEventLoggerImpl::log_intermediate_tensors(NSDictionary<ETCoreMLModelStructurePath *, MLMultiArray *> *op_path_to_value_map,
+                                                    NSDictionary<ETCoreMLModelStructurePath *, NSString *> *op_path_to_debug_symbol_name_map) const noexcept {
+    //TODO: Implement logging for intermediate tensors once ExecuTorch has support.
+}
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/sdk/model_package_info.h
+++ b/backends/apple/coreml/runtime/sdk/model_package_info.h
@@ -1,0 +1,37 @@
+//
+// model_package_info.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+#import <serde_json.h>
+#import <string>
+#import <unordered_map>
+
+namespace executorchcoreml {
+/// A struct containing the info of a `mlpackage`.
+struct ModelPackageInfo {
+    struct Item {
+        /// The item author.
+        std::string author;
+        /// The item description.
+        std::string description;
+        /// The item name.
+        std::string name;
+        /// The item path.
+        std::string path;
+    };
+    /// The identifier of the root model item. An entry for the name must exist in the `items`.
+    std::string root_model_identifier;
+    /// The items in the `mlpackage`. This is populated by parsing the `mlpackage`'s manifest file.
+    std::unordered_map<std::string, Item> items;
+
+    static std::optional<ModelPackageInfo>
+    make(NSURL* url, NSFileManager* fm, NSError* __autoreleasing* error) noexcept;
+};
+}

--- a/backends/apple/coreml/runtime/sdk/model_package_info.mm
+++ b/backends/apple/coreml/runtime/sdk/model_package_info.mm
@@ -1,0 +1,87 @@
+//
+// model_package_info.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import "model_package_info.h"
+
+#import <ETCoreMLLogging.h>
+#import <objc_json_serde.h>
+#import <serde_json.h>
+
+namespace  {
+struct ModelPackageInfoKeys {
+    struct Item {
+        constexpr static std::string_view kAuthorKey = "author";
+        constexpr static std::string_view kDescriptionKey = "description";
+        constexpr static std::string_view kNameKey = "name";
+        constexpr static std::string_view kPathKey = "path";
+    };
+    
+    constexpr static std::string_view kItemInfoEntriesKey = "itemInfoEntries";
+    constexpr static std::string_view kRootModelIdentifierKey = "rootModelIdentifier";
+};
+}
+
+namespace executorchcoreml {
+namespace serde {
+namespace json {
+template <>
+struct Converter<ModelPackageInfo::Item> {
+    static void from_json(id json, ModelPackageInfo::Item& item) {
+        NSDictionary<NSString *, id> *json_dict = SAFE_CAST(json, NSDictionary);
+        if (!json_dict) {
+            return;
+        }
+        
+        from_json_value(json_dict[to_string(ModelPackageInfoKeys::Item::kAuthorKey)], item.author);
+        from_json_value(json_dict[to_string(ModelPackageInfoKeys::Item::kDescriptionKey)], item.description);
+        from_json_value(json_dict[to_string(ModelPackageInfoKeys::Item::kNameKey)], item.name);
+        from_json_value(json_dict[to_string(ModelPackageInfoKeys::Item::kPathKey)], item.path);
+    }
+};
+
+template <>
+struct Converter<ModelPackageInfo> {
+    static void from_json(id json, ModelPackageInfo& package_info) {
+        NSDictionary<NSString *, id> *json_dict = SAFE_CAST(json, NSDictionary);
+        if (!json_dict) {
+            return;
+        }
+        
+        from_json_value(json_dict[to_string(ModelPackageInfoKeys::kRootModelIdentifierKey)], package_info.root_model_identifier);
+        from_json_value(json_dict[to_string(ModelPackageInfoKeys::kItemInfoEntriesKey)], package_info.items);
+    }
+};
+}
+}
+}
+
+namespace executorchcoreml {
+std::optional<ModelPackageInfo> ModelPackageInfo::make(NSURL* model_package_url,
+                                                       NSFileManager* fm,
+                                                       NSError * __autoreleasing *error) noexcept {
+    NSURL *manifest_url = [model_package_url URLByAppendingPathComponent:@"manifest.json"].URLByStandardizingPath;
+    BOOL is_directory = NO;
+    if (![fm fileExistsAtPath:manifest_url.path isDirectory:&is_directory] || is_directory) {
+        ETCoreMLLogErrorAndSetNSError(error, 0, "%@ is broken, manifest doesn't exist.", model_package_url.lastPathComponent);
+        return std::nullopt;
+    }
+    
+    NSData *data = [NSData dataWithContentsOfURL:manifest_url options:NSDataReadingMapped error:error];
+    if (!data) {
+        return std::nullopt;
+    }
+    
+    id json_dictionary = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:error];
+    if (!json_dictionary) {
+        return std::nullopt;
+    }
+    
+    ModelPackageInfo info;
+    serde::json::from_json_value(json_dictionary, info);
+    return info;
+}
+}

--- a/backends/apple/coreml/runtime/sdk/program_path.h
+++ b/backends/apple/coreml/runtime/sdk/program_path.h
@@ -1,0 +1,125 @@
+//
+// program_path.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#pragma once
+
+#import <string>
+#import <variant>
+#import <vector>
+
+#import "hash_util.h"
+
+namespace executorchcoreml {
+namespace modelstructure {
+class Path final {
+public:
+    static const char* kTypeKeyName;
+    struct Program {
+        /// The type name, used for serializing/deserializing Program type.
+        static const char* kTypeName;
+        struct Function {
+            /// The type name, used for serializing/deserializing Function type.
+            static const char* kTypeName;
+            /// The name key name, used for serializing/deserializing function name.
+            static const char* kNameKeyName;
+            /// Name of the function.
+            std::string name;
+
+            Function(std::string name) : name(std::move(name)) { }
+
+            inline bool operator==(const Function& rhs) const noexcept { return name == rhs.name; }
+
+            inline bool operator<(const Function& rhs) const noexcept { return name < rhs.name; }
+        };
+
+        struct Block {
+            /// The type name, used for serializing/deserializing Block type.
+            static const char* kTypeName;
+            /// The index key name, used for serializing/deserializing index.
+            static const char* kIndexKeyName;
+            /// Index of the block.
+            int64_t index;
+
+            Block(int64_t index) : index(index) { }
+
+            inline bool operator==(const Block& rhs) const noexcept { return index == rhs.index; }
+
+            inline bool operator<(const Block& rhs) const noexcept { return index < rhs.index; }
+        };
+
+        struct Operation {
+            /// The type name, used for serializing/deserializing Operation type.
+            static const char* kTypeName;
+            /// The output key name, used for serializing/deserializing the Operation output.
+            static const char* kOutputKeyName;
+            /// Output name.
+            std::string output_name;
+
+            Operation(std::string output_name) : output_name(std::move(output_name)) { }
+
+            inline bool operator==(const Operation& rhs) const noexcept { return output_name == rhs.output_name; }
+
+            inline bool operator<(const Operation& rhs) const noexcept { return output_name < rhs.output_name; }
+        };
+
+        inline bool operator==(const Program& __unused rhs) const noexcept { return true; }
+    };
+
+    using Component = std::variant<Program, Program::Function, Program::Block, Program::Operation>;
+
+    /// Appends a component to the path.
+    void append_component(Component component) noexcept;
+
+    /// Removes the last component.
+    inline void remove_last_component() noexcept { components_.pop_back(); }
+
+    /// Removes the first component.
+    inline void remove_first_component() noexcept { components_.erase(components_.begin()); }
+
+    /// Returns the number of components.
+    inline size_t size() const noexcept { return components_.size(); }
+
+    /// Returns components.
+    inline const std::vector<Component>& components() const noexcept { return components_; }
+
+    const Component& operator[](size_t index) const { return components_[index]; }
+
+    inline bool operator==(const Path& rhs) const noexcept { return components() == rhs.components(); }
+
+private:
+    std::vector<Component> components_;
+};
+}
+}
+
+namespace std {
+using namespace executorchcoreml::modelstructure;
+
+template <> struct hash<Path::Program> {
+    inline size_t operator()(const Path::Program __unused& program) const { return typeid(Path::Program).hash_code(); }
+};
+
+template <> struct hash<Path::Program::Block> {
+    inline size_t operator()(const Path::Program::Block& block) const { return hash<int64_t>()(block.index); }
+};
+
+template <> struct hash<Path::Program::Function> {
+    inline size_t operator()(const Path::Program::Function& function) const {
+        return hash<std::string>()(function.name);
+    }
+};
+
+template <> struct hash<Path::Program::Operation> {
+    inline size_t operator()(const Path::Program::Operation& operation) const {
+        return hash<std::string>()(operation.output_name);
+    }
+};
+
+template <> struct hash<Path> {
+    inline size_t operator()(const Path& path) const { return executorchcoreml::container_hash(path.components()); }
+};
+} // namespace std

--- a/backends/apple/coreml/runtime/sdk/program_path.mm
+++ b/backends/apple/coreml/runtime/sdk/program_path.mm
@@ -1,0 +1,70 @@
+//
+// program_path.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <Foundation/Foundation.h>
+
+#import "program_path.h"
+
+namespace {
+using namespace executorchcoreml::modelstructure;
+
+template <typename LAST, typename CURRENT>
+void append_component(CURRENT component, std::vector<Path::Component>& components) {
+    LAST *lastComponent = nullptr;
+    if (components.size() > 0) {
+        lastComponent = std::get_if<LAST>(&(components.back()));
+    }
+    
+    NSCAssert(components.size() > 0 && lastComponent != nullptr, @"Failed to append %s component, last component is not a %s", CURRENT::kTypeName, LAST::kTypeName);
+    components.emplace_back(std::move(component));
+}
+
+void append_component(Path::Program component, std::vector<Path::Component>& components) {
+    NSCAssert(components.size() == 0, @"Failed to append %s component, components is not empty.", Path::Program::kTypeName);
+    components.emplace_back(std::move(component));
+}
+
+void append_component(Path::Program::Function component, std::vector<Path::Component>& components) {
+    append_component<Path::Program, Path::Program::Function>(std::move(component), components);
+}
+
+void append_component(Path::Program::Block component, std::vector<Path::Component>& components) {
+    if (component.index >= 0) {
+        append_component<Path::Program::Operation, Path::Program::Block>(std::move(component), components);
+    } else {
+        append_component<Path::Program::Function, Path::Program::Block>(std::move(component), components);
+    }
+}
+
+void append_component(Path::Program::Operation component, std::vector<Path::Component>& components) {
+    append_component<Path::Program::Block, Path::Program::Operation>(std::move(component), components);
+}
+}
+
+namespace executorchcoreml {
+namespace modelstructure {
+
+const char *Path::kTypeKeyName = "Type";
+
+const char *Path::Program::kTypeName = "Program";
+
+const char *Path::Program::Function::kTypeName = "Function";
+const char *Path::Program::Function::kNameKeyName = "Name";
+
+const char *Path::Program::Block::kTypeName = "Block";
+const char *Path::Program::Block::kIndexKeyName = "Index";
+
+const char *Path::Program::Operation::kTypeName = "Operation";
+const char *Path::Program::Operation::kOutputKeyName = "Output";
+
+void Path::append_component(Path::Component component) noexcept {
+    std::visit([&](auto&& arg){
+        return ::append_component(arg, components_);
+    }, component);
+}
+} // namespace modelstructure
+} // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/test/BackendDelegateTests.mm
+++ b/backends/apple/coreml/runtime/test/BackendDelegateTests.mm
@@ -1,22 +1,19 @@
 //
 // BackendDelegateTests.m
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
-#import <XCTest/XCTest.h>
-
+#import "ETCoreMLTestUtils.h"
 #import <CoreML/CoreML.h>
-
-#import <backend_delegate.h>
-#import <coreml_backend/delegate.h>
-#import <multiarray.h>
-
 #import <ETCoreMLModel.h>
 #import <ETCoreMLStrings.h>
-
-#import "ETCoreMLTestUtils.h"
+#import <XCTest/XCTest.h>
+#import <backend_delegate.h>
+#import <coreml_backend/delegate.h>
+#import <model_logging_options.h>
+#import <multiarray.h>
 
 using namespace executorchcoreml;
 
@@ -200,7 +197,11 @@ std::vector<MultiArray> toMultiArrays(NSArray<MLMultiArray *> *mlMultiArrays) {
     MLMultiArray *output = [ETCoreMLTestUtils filledMultiArrayWithShape:inputs[0].shape dataType:inputs[0].dataType repeatedValue:@(0) error:&localError];
     NSArray<MLMultiArray *> *args = [inputs arrayByAddingObject:output];
     std::error_code errorCode;
-    XCTAssertTrue(_delegate->execute(handle, toMultiArrays(args), errorCode));
+    XCTAssertTrue(_delegate->execute(handle,
+                                     toMultiArrays(args),
+                                     ModelLoggingOptions(),
+                                     nullptr,
+                                     errorCode));
     for (NSUInteger i = 0; i < output.count; i++) {
         NSNumber *value = [output objectAtIndexedSubscript:i];
         XCTAssertEqual(value.integerValue, z);
@@ -221,7 +222,11 @@ std::vector<MultiArray> toMultiArrays(NSArray<MLMultiArray *> *mlMultiArrays) {
     MLMultiArray *output = [ETCoreMLTestUtils filledMultiArrayWithShape:inputs[0].shape dataType:inputs[0].dataType repeatedValue:@(0) error:&localError];
     NSArray<MLMultiArray *> *args = [inputs arrayByAddingObject:output];
     std::error_code errorCode;
-    XCTAssertTrue(_delegate->execute(handle, toMultiArrays(args), errorCode));
+    XCTAssertTrue(_delegate->execute(handle, 
+                                     toMultiArrays(args),
+                                     ModelLoggingOptions(),
+                                     nullptr,
+                                     errorCode));
     for (NSUInteger i = 0; i < output.count; i++) {
         NSNumber *value = [output objectAtIndexedSubscript:i];
         XCTAssertEqual(value.integerValue, x * y);

--- a/backends/apple/coreml/runtime/test/DatabaseTests.mm
+++ b/backends/apple/coreml/runtime/test/DatabaseTests.mm
@@ -1,7 +1,7 @@
 //
 // DatabaseTests.mm
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/test/ETCoreMLAssetManagerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLAssetManagerTests.mm
@@ -2,7 +2,7 @@
 // ETCoreMLAssetManagerTests.mm
 //
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/test/ETCoreMLAssetTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLAssetTests.mm
@@ -1,7 +1,7 @@
 //
 // ETCoreMLAssetTests.mm
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/test/ETCoreMLModelDebuggerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLModelDebuggerTests.mm
@@ -1,0 +1,143 @@
+//
+// ETCoreMLModelDebuggerTests.mm
+//
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <XCTest/XCTest.h>
+#import <ETCoreMLModelAnalyzer.h>
+#import <ETCoreMLOperationProfilingInfo.h>
+#import <ETCoreMLModelStructurePath.h>
+#import <model_logging_options.h>
+#import <model_event_logger.h>
+
+#import "ETCoreMLTestUtils.h"
+
+namespace  {
+    using namespace executorchcoreml::modelstructure;
+    
+    using NotifyFn = std::function<void(NSDictionary<ETCoreMLModelStructurePath *, MLMultiArray *> *op_path_to_value_map,
+                                        NSDictionary<ETCoreMLModelStructurePath *, NSString *> *op_path_to_debug_symbol_name_map)>;
+    
+    class ModelProfilingEventLoggerImpl: public executorchcoreml::ModelEventLogger {
+    public:
+        explicit ModelProfilingEventLoggerImpl(NotifyFn fn)
+        :fn_(fn)
+        {}
+        
+        void log_profiling_infos(NSDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *op_path_to_profiling_info_map,
+                                 NSDictionary<ETCoreMLModelStructurePath *, NSString *> *op_path_to_debug_symbol_name_map) const noexcept {}
+        
+        void log_intermediate_tensors(NSDictionary<ETCoreMLModelStructurePath *, MLMultiArray *> *op_path_to_value_map,
+                                      NSDictionary<ETCoreMLModelStructurePath *, NSString *> *op_path_to_debug_symbol_name_map) const noexcept {
+            fn_(op_path_to_value_map, op_path_to_debug_symbol_name_map);
+        }
+        
+    private:
+        NotifyFn fn_;
+    };
+    
+    ETCoreMLModelStructurePath *make_path_with_output_name(const std::string& output_name,
+                                                           const std::string& function_name = "main") {
+        Path path;
+        path.append_component(Path::Program());
+        path.append_component(Path::Program::Function(function_name));
+        path.append_component(Path::Program::Block(-1));
+        path.append_component(Path::Program::Operation(output_name));
+        
+        return [[ETCoreMLModelStructurePath alloc] initWithUnderlyingValue:std::move(path)];
+    }
+}
+
+@interface ETCoreMLModelDebuggerTests : XCTestCase
+
+@end
+
+@implementation ETCoreMLModelDebuggerTests
+
++ (nullable NSURL *)bundledResourceWithName:(NSString *)name extension:(NSString *)extension {
+    NSBundle *bundle = [NSBundle bundleForClass:ETCoreMLModelDebuggerTests.class];
+    return [bundle URLForResource:name withExtension:extension];
+}
+
+- (void)debugModelWithName:(NSString *)modelName
+       repeatedInputValues:(NSArray<NSNumber *> *)repeatedInputValues
+                    notify:(NotifyFn)notify {
+    NSError *error = nil;
+    NSURL *modelURL = [[self class] bundledResourceWithName:modelName extension:@"bin"];
+    NSData *modelData = [NSData dataWithContentsOfURL:modelURL];
+    NSURL *dstURL = [[NSURL fileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+    NSFileManager *fm = [[NSFileManager alloc] init];
+    XCTAssert([fm createDirectoryAtURL:dstURL withIntermediateDirectories:NO attributes:@{} error:&error]);
+    @autoreleasepool {
+        ETCoreMLModelAnalyzer *analyzer = [ETCoreMLTestUtils createAnalyzerWithAOTData:modelData
+                                                                                dstURL:dstURL
+                                                                                 error:&error];
+        XCTAssertNotNil(analyzer);
+        id<MLFeatureProvider> inputs = [ETCoreMLTestUtils inputFeaturesForModel:analyzer.model
+                                                                 repeatedValues:repeatedInputValues
+                                                                          error:&error];
+        XCTAssertNotNil(inputs);
+        MLPredictionOptions *predictionOptions = [[MLPredictionOptions alloc] init];
+        executorchcoreml::ModelLoggingOptions loggingOptions;
+        loggingOptions.log_intermediate_tensors = true;
+        ModelProfilingEventLoggerImpl eventLogger(notify);
+        
+        NSArray<MLMultiArray *> *outputs = [analyzer executeModelWithInputs:inputs
+                                                          predictionOptions:predictionOptions
+                                                             loggingOptions:loggingOptions
+                                                                eventLogger:&eventLogger
+                                                                      error:&error];
+        XCTAssertNotNil(outputs);
+        
+    }
+    [fm removeItemAtURL:dstURL error:nil];
+}
+
+- (void)testAddProgramDebugging {
+    NotifyFn notify = [](NSDictionary<ETCoreMLModelStructurePath *, MLMultiArray *> *debuggingResult,
+                         NSDictionary<ETCoreMLModelStructurePath *, NSString *> *pathToSymbolNameMap) {
+        // There are 3 add ops, we verify that we get the outputs for the ops.
+        XCTAssertNotNil(debuggingResult[make_path_with_output_name("aten_add_tensor_2_cast_fp16")]);
+        XCTAssertNotNil(debuggingResult[make_path_with_output_name("aten_add_tensor_cast_fp16")]);
+        XCTAssertNotNil(debuggingResult[make_path_with_output_name("aten_add_tensor_1_cast_fp16")]);
+    };
+    
+    [self debugModelWithName:@"add_coreml_all"
+         repeatedInputValues:@[@(1), @(2)]
+                      notify:notify];
+}
+
+- (void)testMulProgramDebugging {
+    NotifyFn notify = [](NSDictionary<ETCoreMLModelStructurePath *, MLMultiArray *> *debuggingResult,
+                         NSDictionary<ETCoreMLModelStructurePath *, NSString *> *pathToSymbolNameMap) {
+        // There is 1 `mul` op, we verify that we get the output for the op.
+        XCTAssertNotNil(debuggingResult[make_path_with_output_name("aten_mul_tensor_cast_fp16")]);
+    };
+    
+    [self debugModelWithName:@"mul_coreml_all"
+         repeatedInputValues:@[@(1), @(2)]
+                      notify:notify];
+}
+
+- (void)testMV3ProgramDebugging {
+    XCTSkip(@"There is a device specialization issue when getting on of the outputs, will fix after investigation.");
+    NotifyFn notify = [](NSDictionary<ETCoreMLModelStructurePath *, MLMultiArray *> *debuggingResult,
+                         NSDictionary<ETCoreMLModelStructurePath *, NSString *> *pathToSymbolNameMap) {
+        // There are more than 200 ops, we verify the outputs for specific ops.
+        XCTAssertNotNil(debuggingResult[make_path_with_output_name("aten__native_batch_norm_legit_no_training_default_13_cast_fp16")]);
+        XCTAssertNotNil(debuggingResult[make_path_with_output_name("_inversed_aten_div_tensor_24_cast_fp16")]);
+        XCTAssertNotNil(debuggingResult[make_path_with_output_name("aten_mean_dim_7_cast_fp16")]);
+        XCTAssertNotNil(debuggingResult[make_path_with_output_name("aten_clamp_default_54_cast_fp16")]);
+        XCTAssertNotNil(debuggingResult[make_path_with_output_name("aten__native_batch_norm_legit_no_training_default_22_cast_fp16")]);
+        XCTAssertNotNil(debuggingResult[make_path_with_output_name("aten_mul_tensor_27_cast_fp16")]);
+    };
+    
+    [self debugModelWithName:@"mv3_coreml_all"
+         repeatedInputValues:@[@(1), @(2)]
+                      notify:notify];
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/ETCoreMLModelManagerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLModelManagerTests.mm
@@ -2,20 +2,20 @@
 // ETCoreMLModelManagerTests.m
 //
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
 #import <XCTest/XCTest.h>
 
-#import <ETCoreMLModelManager.h>
 
+#import "ETCoreMLTestUtils.h"
 #import <ETCoreMLAsset.h>
 #import <ETCoreMLAssetManager.h>
 #import <ETCoreMLModel.h>
+#import <ETCoreMLModelManager.h>
 #import <MLModel_Prewarm.h>
-
-#import "ETCoreMLTestUtils.h"
+#import <model_logging_options.h>
 
 @interface ETCoreMLModelManagerTests : XCTestCase
 
@@ -113,7 +113,11 @@
     XCTAssertNotNil(inputs);
     MLMultiArray *output = [ETCoreMLTestUtils filledMultiArrayWithShape:inputs[0].shape dataType:inputs[0].dataType repeatedValue:@(0) error:&localError];
     NSArray<MLMultiArray *> *args = [inputs arrayByAddingObject:output];
-    XCTAssertTrue([self.modelManager executeModelWithHandle:handle args:args error:&localError]);
+    XCTAssertTrue([self.modelManager executeModelWithHandle:handle 
+                                                       args:args
+                                            loggingOptions:executorchcoreml::ModelLoggingOptions()
+                                                eventLogger:nullptr
+                                                      error:&localError]);
     for (NSUInteger i = 0; i < output.count; i++) {
         NSNumber *value = [output objectAtIndexedSubscript:i];
         XCTAssertEqual(value.integerValue, z);
@@ -136,7 +140,11 @@
     XCTAssertNotNil(inputs);
     MLMultiArray *output = [ETCoreMLTestUtils filledMultiArrayWithShape:inputs[0].shape dataType:inputs[0].dataType repeatedValue:@(0) error:&localError];
     NSArray<MLMultiArray *> *args = [inputs arrayByAddingObject:output];
-    XCTAssertTrue([self.modelManager executeModelWithHandle:handle args:args error:&localError]);
+    XCTAssertTrue([self.modelManager executeModelWithHandle:handle
+                                                       args:args
+                                            loggingOptions:executorchcoreml::ModelLoggingOptions()
+                                                eventLogger:nullptr
+                                                      error:&localError]);
     for (NSUInteger i = 0; i < output.count; i++) {
         NSNumber *value = [output objectAtIndexedSubscript:i];
         XCTAssertEqual(value.integerValue, x * y);

--- a/backends/apple/coreml/runtime/test/ETCoreMLModelProfilerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLModelProfilerTests.mm
@@ -1,0 +1,148 @@
+//
+// ETCoreMLProgramProfilerTests.mm
+//
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <XCTest/XCTest.h>
+#import <ETCoreMLModelAnalyzer.h>
+#import <ETCoreMLOperationProfilingInfo.h>
+#import <ETCoreMLModelStructurePath.h>
+#import <model_logging_options.h>
+#import <model_event_logger.h>
+
+#import "ETCoreMLTestUtils.h"
+
+namespace  {
+using namespace executorchcoreml::modelstructure;
+
+using NotifyFn = std::function<void(NSDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *op_path_to_profiling_info_map,
+                                    NSDictionary<ETCoreMLModelStructurePath *, NSString *> *op_path_to_debug_symbol_name_map)>;
+
+class ModelProfilingEventLoggerImpl: public executorchcoreml::ModelEventLogger {
+public:
+    explicit ModelProfilingEventLoggerImpl(NotifyFn fn)
+    :fn_(fn)
+    {}
+    
+    void log_profiling_infos(NSDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *op_path_to_profiling_info_map,
+                             NSDictionary<ETCoreMLModelStructurePath *, NSString *> *op_path_to_debug_symbol_name_map) const noexcept {
+        fn_(op_path_to_profiling_info_map, op_path_to_debug_symbol_name_map);
+    }
+    
+    void log_intermediate_tensors(NSDictionary<ETCoreMLModelStructurePath *, MLMultiArray *> *op_path_to_value_map,
+                                  NSDictionary<ETCoreMLModelStructurePath *, NSString *> *op_path_to_debug_symbol_name_map) const noexcept {}
+    
+private:
+    NotifyFn fn_;
+};
+
+ETCoreMLModelStructurePath *make_path_with_output_name(const std::string& output_name,
+                                                       const std::string& function_name = "main") {
+    Path path;
+    path.append_component(Path::Program());
+    path.append_component(Path::Program::Function(function_name));
+    path.append_component(Path::Program::Block(-1));
+    path.append_component(Path::Program::Operation(output_name));
+    
+    return [[ETCoreMLModelStructurePath alloc] initWithUnderlyingValue:std::move(path)];
+}
+} // namespace
+
+@interface ETCoreMLModelProfilerTests : XCTestCase
+
+@end
+
+@implementation ETCoreMLModelProfilerTests
+
++ (nullable NSURL *)bundledResourceWithName:(NSString *)name extension:(NSString *)extension {
+    NSBundle *bundle = [NSBundle bundleForClass:ETCoreMLModelProfilerTests.class];
+    return [bundle URLForResource:name withExtension:extension];
+}
+
+- (void)profileModelWithName:(NSString *)modelName
+         repeatedInputValues:(NSArray<NSNumber *> *)repeatedInputValues
+                      notify:(NotifyFn)notify {
+    NSError *error = nil;
+    NSURL *modelURL = [[self class] bundledResourceWithName:modelName extension:@"bin"];
+    NSData *modelData = [NSData dataWithContentsOfURL:modelURL];
+    NSURL *dstURL = [[NSURL fileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+    NSFileManager *fm = [[NSFileManager alloc] init];
+    XCTAssert([fm createDirectoryAtURL:dstURL withIntermediateDirectories:NO attributes:@{} error:&error]);
+    @autoreleasepool {
+        ETCoreMLModelAnalyzer *analyzer = [ETCoreMLTestUtils createAnalyzerWithAOTData:modelData
+                                                                                dstURL:dstURL
+                                                                                 error:&error];
+        XCTAssertNotNil(analyzer);
+        id<MLFeatureProvider> inputs = [ETCoreMLTestUtils inputFeaturesForModel:analyzer.model
+                                                                 repeatedValues:repeatedInputValues
+                                                                          error:&error];
+        XCTAssertNotNil(inputs);
+        MLPredictionOptions *predictionOptions = [[MLPredictionOptions alloc] init];
+        executorchcoreml::ModelLoggingOptions loggingOptions;
+        loggingOptions.log_profiling_info = true;
+        ModelProfilingEventLoggerImpl eventLogger(notify);
+        
+        NSArray<MLMultiArray *> *outputs = [analyzer executeModelWithInputs:inputs
+                                                          predictionOptions:predictionOptions
+                                                             loggingOptions:loggingOptions
+                                                                eventLogger:&eventLogger
+                                                                      error:&error];
+        XCTAssertNotNil(outputs);
+        
+    }
+    [fm removeItemAtURL:dstURL error:nil];
+}
+
+- (void)testAddProgramProfiling {
+    if (@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)) {
+        NotifyFn notify = [](NSDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *profilingResult,
+                             NSDictionary<ETCoreMLModelStructurePath *, NSString *> *__unused pathToSymbolNameMap) {
+            // There are 3 add ops, we verify that the profiling info exists for the ops.
+            XCTAssertNotNil(profilingResult[make_path_with_output_name("aten_add_tensor_2_cast_fp16")]);
+            XCTAssertNotNil(profilingResult[make_path_with_output_name("aten_add_tensor_cast_fp16")]);
+            XCTAssertNotNil(profilingResult[make_path_with_output_name("aten_add_tensor_1_cast_fp16")]);
+        };
+        
+        [self profileModelWithName:@"add_coreml_all"
+               repeatedInputValues:@[@(1), @(2)]
+                            notify:notify];
+    }
+}
+
+- (void)testMulProgramProfiling {
+    if (@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)) {
+        NotifyFn notify = [](NSDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *profilingResult,
+                             NSDictionary<ETCoreMLModelStructurePath *, NSString *> *__unused pathToSymbolNameMap) {
+            // There is 1 `mul` op, we verify that the profiling info exists for the op.
+            XCTAssertNotNil(profilingResult[make_path_with_output_name("aten_mul_tensor_cast_fp16")]);
+        };
+        
+        [self profileModelWithName:@"mul_coreml_all"
+               repeatedInputValues:@[@(1), @(2)]
+                            notify:notify];
+    }
+}
+
+- (void)testMV3ProgramProfiling {
+    if (@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)) {
+        NotifyFn notify = [](NSDictionary<ETCoreMLModelStructurePath *, ETCoreMLOperationProfilingInfo *> *profilingResult,
+                             NSDictionary<ETCoreMLModelStructurePath *, NSString *> *__unused pathToSymbolNameMap) {
+            // There are more than 200 ops, we verify the profiling info for specific ops.
+            XCTAssertNotNil(profilingResult[make_path_with_output_name("aten__native_batch_norm_legit_no_training_default_13_cast_fp16")]);
+            XCTAssertNotNil(profilingResult[make_path_with_output_name("_inversed_aten_div_tensor_24_cast_fp16")]);
+            XCTAssertNotNil(profilingResult[make_path_with_output_name("aten_mean_dim_7_cast_fp16")]);
+            XCTAssertNotNil(profilingResult[make_path_with_output_name("aten_clamp_default_54_cast_fp16")]);
+            XCTAssertNotNil(profilingResult[make_path_with_output_name("aten__native_batch_norm_legit_no_training_default_22_cast_fp16")]);
+            XCTAssertNotNil(profilingResult[make_path_with_output_name("aten_mul_tensor_27_cast_fp16")]);
+        };
+        
+        [self profileModelWithName:@"mv3_coreml_all"
+               repeatedInputValues:@[@(1), @(2)]
+                            notify:notify];
+    }
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/ETCoreMLModelStructurePathTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLModelStructurePathTests.mm
@@ -1,0 +1,98 @@
+//
+// ETCoreMLModelStructurePathTests.mm
+//
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <XCTest/XCTest.h>
+#import <ETCoreMLModelStructurePath.h>
+#import <program_path.h>
+
+namespace {
+using namespace executorchcoreml::modelstructure;
+
+Path make_path_with_output_name(const std::string& output_name) {
+    Path path;
+    path.append_component(Path::Program());
+    path.append_component(Path::Program::Function("main"));
+    path.append_component(Path::Program::Block(-1));
+    path.append_component(Path::Program::Operation(output_name));
+    
+    return path;
+}
+}
+
+@interface ETCoreMLModelStructurePathTests : XCTestCase
+
+@end
+
+@implementation ETCoreMLModelStructurePathTests
+
+using namespace executorchcoreml::modelstructure;
+
+- (void)testPathConstruction {
+    Path path;
+    path.append_component(Path::Program());
+    XCTAssertEqual(path.size(), 1UL);
+    path.append_component(Path::Program::Function("main"));
+    XCTAssertEqual(path.size(), 2UL);
+    path.append_component(Path::Program::Block(-1));
+    XCTAssertEqual(path.size(), 3UL);
+    path.append_component(Path::Program::Operation("x"));
+    XCTAssertEqual(path.size(), 4UL);
+}
+
+- (void)testPathEquality {
+    {
+        Path path1 = make_path_with_output_name("x");
+        Path path2 = make_path_with_output_name("x");
+        XCTAssertEqual(path1, path2);
+    }
+    {
+        Path path1 = make_path_with_output_name("x");
+        Path path2 = make_path_with_output_name("y");
+        XCTAssertNotEqual(path1, path2);
+    }
+}
+
+- (void)testModelStructurePathConstruction {
+    {
+        Path path = make_path_with_output_name("x");
+        ETCoreMLModelStructurePath *modelStructurePath = [[ETCoreMLModelStructurePath alloc] initWithUnderlyingValue:std::move(path)];
+        XCTAssertEqual(modelStructurePath.underlyingValue.size(), 4UL);
+        XCTAssertEqualObjects(modelStructurePath.operationOutputName, @"x");
+    }
+    
+    {
+        NSMutableArray<NSDictionary<NSString *, id> *> *components = [NSMutableArray arrayWithCapacity:4];
+        [components addObject:@{@"Type" : @"Program"}];
+        [components addObject:@{@"Type" : @"Function", @"Name" : @"main"}];
+        [components addObject:@{@"Type" : @"Block", @"Index" : @(-1)}];
+        [components addObject:@{@"Type" : @"Operation", @"Output" : @"x"}];
+
+        ETCoreMLModelStructurePath *modelStructurePath = [[ETCoreMLModelStructurePath alloc] initWithComponents:components];
+        XCTAssertEqual(modelStructurePath.underlyingValue.size(), 4UL);
+        XCTAssertEqualObjects(modelStructurePath.operationOutputName, @"x");
+    }
+}
+
+- (void)testModelStructurePathEquality {
+    {
+        ETCoreMLModelStructurePath *modelStructurePath1 = [[ETCoreMLModelStructurePath alloc] initWithUnderlyingValue:make_path_with_output_name("x")];
+        ETCoreMLModelStructurePath *modelStructurePath2 = [[ETCoreMLModelStructurePath alloc] initWithUnderlyingValue:make_path_with_output_name("x")];
+        
+        XCTAssertEqualObjects(modelStructurePath1, modelStructurePath2);
+        XCTAssertEqual(modelStructurePath1.hash, modelStructurePath2.hash);
+    }
+    {
+        ETCoreMLModelStructurePath *modelStructurePath1 = [[ETCoreMLModelStructurePath alloc] initWithUnderlyingValue:make_path_with_output_name("x")];
+        ETCoreMLModelStructurePath *modelStructurePath2 = [[ETCoreMLModelStructurePath alloc] initWithUnderlyingValue:make_path_with_output_name("y")];
+        
+        XCTAssertNotEqualObjects(modelStructurePath1, modelStructurePath2);
+        XCTAssertNotEqual(modelStructurePath1.hash, modelStructurePath2.hash);
+    }
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/ETCoreMLTestUtils.h
+++ b/backends/apple/coreml/runtime/test/ETCoreMLTestUtils.h
@@ -2,14 +2,14 @@
 // ETCoreMLTestUtils.h
 //
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
 #import <CoreML/CoreML.h>
-
 #import <ETCoreMLAssetManager.h>
 #import <ETCoreMLModel.h>
+#import <ETCoreMLModelAnalyzer.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -66,13 +66,32 @@ NS_ASSUME_NONNULL_BEGIN
 /// Creates inputs with repeated values for a `ETCoreMLModel`.
 ///
 /// @param model The model.
-/// @param repeatedValues An array of values, the size of the array must be equal to the inputs
-/// count.
+/// @param repeatedValues An array of values, the size of the array must be equal to the inputs count.
 /// @param error   On failure, error is filled with the failure information.
 /// @retval Model inputs with repeated values.
 + (nullable NSArray<MLMultiArray*>*)inputsForModel:(ETCoreMLModel*)model
                                     repeatedValues:(NSArray<NSNumber*>*)repeatedValues
                                              error:(NSError* __autoreleasing*)error;
+
+/// Creates input features with repeated values for a `ETCoreMLModel`.
+///
+/// @param model The model.
+/// @param repeatedValues An array of values, the size of the array must be equal to the inputs count.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval Model inputs with repeated values.
++ (nullable id<MLFeatureProvider>)inputFeaturesForModel:(ETCoreMLModel*)model
+                                         repeatedValues:(NSArray<NSNumber*>*)repeatedValues
+                                                  error:(NSError* __autoreleasing*)error;
+
+/// Creates a `ETCoreMLModelAnalyzer`instance for analyzing (debugging and profiling) a CoreML model.
+///
+/// @param data The AOT data.
+/// @param dstURL The folder url that will be used for managing the assets.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval An `ETCoreMLModelAnalyzer` instance if the creation succeeded otherwise `nil`.
++ (nullable ETCoreMLModelAnalyzer*)createAnalyzerWithAOTData:(NSData*)data
+                                                      dstURL:(NSURL*)dstURL
+                                                       error:(NSError* __autoreleasing*)error;
 
 @end
 

--- a/backends/apple/coreml/runtime/test/ETCoreMLTestUtils.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLTestUtils.mm
@@ -2,13 +2,22 @@
 // ETCoreMLTestUtils.mm
 //
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
 #import "ETCoreMLTestUtils.h"
 
 #import <ETCoreMLAsset.h>
+#import <ETCoreMLLogging.h>
+#import <ETCoreMLModelAnalyzer.h>
+#import <ETCoreMLModelCompiler.h>
+#import <ETCoreMLStrings.h>
+#import <filesystem>
+#import <inmemory_filesystem_utils.hpp>
+#import <iostream>
+#import <memory>
+#import <model_metadata.h>
 
 namespace {
 NSURL * _Nullable create_directory_if_needed(NSURL *url,
@@ -51,7 +60,7 @@ ETCoreMLAssetManager * _Nullable create_asset_manager(NSString *assets_directory
                                                                                 error:error];
     return manager;
 }
-    
+
 template<typename T>
 T toValue(NSNumber *value);
 
@@ -59,17 +68,17 @@ template<>
 int32_t toValue(NSNumber *value) {
     return value.intValue;
 }
-    
+
 template<>
 double toValue(NSNumber *value) {
     return value.doubleValue;
 }
-    
+
 template<>
 float toValue(NSNumber *value) {
     return value.floatValue;
 }
-    
+
 template<>
 _Float16 toValue(NSNumber *value) {
     return static_cast<_Float16>(value.floatValue);
@@ -82,6 +91,33 @@ void fillBytesWithValue(void *mutableBytes, NSInteger size, NSNumber *value) {
     T fillValue = toValue<T>(value);
     std::fill(start, end, fillValue);
 }
+
+bool extract_model_metadata(const inmemoryfs::InMemoryFileSystem& inMemoryFS,
+                            executorchcoreml::ModelMetadata& model_metadata) {
+    std::error_code ec;
+    auto buffer = inMemoryFS.get_file_content({ETCoreMLStrings.metadataFileRelativePath.UTF8String}, ec);
+    if (!buffer) {
+        return false;
+    }
+    
+    std::string contents;
+    contents.assign(reinterpret_cast<char *>(buffer->data()), buffer->size());
+    model_metadata.from_json_string(std::move(contents));
+    return true;
+}
+
+ETCoreMLAsset * _Nullable make_asset(NSURL *url,
+                                     NSString *identifier,
+                                     NSFileManager *fm,
+                                     NSError * __autoreleasing *error) {
+    auto backingAsset = executorchcoreml::Asset::make(url, identifier, fm, error);
+    if (!backingAsset) {
+        return nil;
+    }
+    
+    return [[ETCoreMLAsset alloc] initWithBackingAsset:std::move(backingAsset.value())];
+}
+
 }
 
 @implementation ETCoreMLTestUtils
@@ -140,7 +176,7 @@ void fillBytesWithValue(void *mutableBytes, NSInteger size, NSNumber *value) {
                 fillBytesWithValue<double>(mutableBytes, multiArray.count, value);
                 break;
             }
-            
+                
             case MLMultiArrayDataTypeInt32: {
                 fillBytesWithValue<int>(mutableBytes, multiArray.count, value);
                 break;
@@ -179,5 +215,141 @@ void fillBytesWithValue(void *mutableBytes, NSInteger size, NSNumber *value) {
     
     return inputs;
 }
+
++ (nullable id<MLFeatureProvider>)inputFeaturesForModel:(ETCoreMLModel *)model
+                                         repeatedValues:(NSArray<NSNumber *> *)repeatedValues
+                                                  error:(NSError * __autoreleasing *)error {
+    NSDictionary<NSString *, MLFeatureDescription *> *inputDescriptionsByName = [model.mlModel.modelDescription inputDescriptionsByName];
+    NSMutableDictionary<NSString *, MLFeatureValue *> *inputs = [NSMutableDictionary dictionaryWithCapacity:inputDescriptionsByName.count];
+    NSEnumerator<NSNumber *> *enumerator = [repeatedValues objectEnumerator];
+    for (NSString *inputName in model.orderedInputNames) {
+        MLMultiArrayConstraint *constraint = inputDescriptionsByName[inputName].multiArrayConstraint;
+        MLMultiArray *multiArray = [ETCoreMLTestUtils filledMultiArrayWithConstraint:constraint repeatedValue:[enumerator nextObject] error:error];
+        if (!multiArray) {
+            return nil;
+        }
+        
+        MLFeatureValue *feature = [MLFeatureValue featureValueWithMultiArray:multiArray];
+        inputs[inputName] = feature;
+    }
+    
+    return [[MLDictionaryFeatureProvider alloc] initWithDictionary:inputs
+                                                             error:error];
+}
+
++ (BOOL)extractModelAssetAndMetadataFromAOTData:(NSData *)data
+                                     modelAsset:(ETCoreMLAsset *_Nullable __autoreleasing *_Nonnull)modelAsset
+                                       metadata:(executorchcoreml::ModelMetadata&)metadata
+                                         dstURL:(NSURL *)dstURL
+                                    fileManager:(NSFileManager *)fileManager
+                                          error:(NSError * __autoreleasing *)error {
+    auto buffer = inmemoryfs::MemoryBuffer::make_unowned(const_cast<void *>(data.bytes), data.length);
+    std::unique_ptr<inmemoryfs::InMemoryFileSystem> inMemoryFS = inmemoryfs::make(buffer);
+    if (!inMemoryFS) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      ETCoreMLErrorCorruptedModel,
+                                      "%@: Model data is corrupted.",
+                                      NSStringFromClass(ETCoreMLTestUtils.class));
+        return NO;
+    }
+    
+    if (!extract_model_metadata(*inMemoryFS, metadata) || !metadata.is_valid()) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      ETCoreMLErrorCorruptedMetadata,
+                                      "%@: Model metadata is corrupted.",
+                                      NSStringFromClass(ETCoreMLTestUtils.class));
+        return NO;
+    }
+    
+    NSString *modelName = [NSString stringWithFormat:@"model_%s", metadata.identifier.c_str()];
+    NSURL *modelURL = [dstURL URLByAppendingPathComponent:modelName];
+    [fileManager removeItemAtURL:modelURL error:nil];
+    if (![fileManager createDirectoryAtURL:modelURL withIntermediateDirectories:NO attributes:@{} error:error]) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      ETCoreMLErrorModelSaveFailed,
+                                      "%@: Failed to create directory when saving model with name = %@.",
+                                      NSStringFromClass(ETCoreMLTestUtils.class),
+                                      modelURL.lastPathComponent);
+        return NO;
+    }
+    
+    std::filesystem::path modelPath(modelURL.fileSystemRepresentation);
+    std::error_code ec;
+    if (!inMemoryFS->write_item_to_disk({ETCoreMLStrings.modelFileRelativePath.UTF8String}, modelPath, true, ec)) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      ETCoreMLErrorModelSaveFailed,
+                                      "%@: Failed to write model files to disk when saving model with name = %@.",
+                                      NSStringFromClass(ETCoreMLTestUtils.class),
+                                      modelURL.lastPathComponent);
+        return NO;
+    }
+    
+    ETCoreMLAsset *localAsset = ::make_asset([modelURL URLByAppendingPathComponent:ETCoreMLStrings.modelFileRelativePath],
+                                             @(metadata.identifier.c_str()),
+                                             fileManager,
+                                             error);
+    if (!localAsset) {
+        return NO;
+    }
+    
+    if (modelAsset) {
+        *modelAsset = localAsset;
+    }
+    
+    return YES;
+}
+
++ (ETCoreMLModelAnalyzer *)createAnalyzerWithAOTData:(NSData *)data
+                                             dstURL:(NSURL *)dstURL
+                                              error:(NSError * __autoreleasing *)error {
+    ETCoreMLAsset *modelAsset = nil;
+    executorchcoreml::ModelMetadata metadata;
+    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    if (![self extractModelAssetAndMetadataFromAOTData:data
+                                            modelAsset:&modelAsset
+                                              metadata:metadata
+                                                dstURL:dstURL
+                                           fileManager:fileManager
+                                                 error:error]) {
+        return nil;
+    }
+    
+    NSURL *tmpCompiledModelURL = [ETCoreMLModelCompiler compileModelAtURL:modelAsset.contentURL
+                                                     maxWaitTimeInSeconds:(5 * 60)
+                                                                    error:error];
+    if (!tmpCompiledModelURL) {
+        return nil;
+    }
+    
+    NSString *modelDirectoryName = [NSString stringWithFormat:@"model_%s", metadata.identifier.c_str()];
+    NSURL *compiledModelURL = [[dstURL URLByAppendingPathComponent:modelDirectoryName] URLByAppendingPathComponent:ETCoreMLStrings.compiledModelFileRelativePath];
+    if (![fileManager moveItemAtURL:tmpCompiledModelURL toURL:compiledModelURL error:error]) {
+        return nil;
+    }
+    
+    ETCoreMLAsset *compiledModelAsset = make_asset(compiledModelURL,
+                                                   @(metadata.identifier.c_str()),
+                                                   fileManager,
+                                                   error);
+    if (!compiledModelAsset) {
+        return nil;
+    }
+    
+    ETCoreMLAssetManager *assetManager = [self createAssetManagerWithURL:dstURL error:error];
+    if (!assetManager) {
+        return nil;
+    }
+    
+    MLModelConfiguration *configuration = [[MLModelConfiguration alloc] init];
+    ETCoreMLModelAnalyzer *analyzer = [[ETCoreMLModelAnalyzer alloc] initWithCompiledModelAsset:compiledModelAsset
+                                                                                     modelAsset:modelAsset
+                                                                                       metadata:metadata
+                                                                                  configuration:configuration
+                                                                                   assetManager:assetManager
+                                                                                          error:error];
+    
+    return analyzer;
+}
+
 
 @end

--- a/backends/apple/coreml/runtime/test/InMemoryFileSystemTests.mm
+++ b/backends/apple/coreml/runtime/test/InMemoryFileSystemTests.mm
@@ -2,7 +2,7 @@
 // InMemoryFileSystemTests.mm
 //
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/test/KeyValueStoreTests.mm
+++ b/backends/apple/coreml/runtime/test/KeyValueStoreTests.mm
@@ -1,8 +1,8 @@
 //
-// KeyValueStoreTests.m
+// KeyValueStoreTests.mm
 //
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/util/json_util.cpp
+++ b/backends/apple/coreml/runtime/util/json_util.cpp
@@ -2,7 +2,7 @@
 //  json_util.cpp
 //  util
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/util/json_util.hpp
+++ b/backends/apple/coreml/runtime/util/json_util.hpp
@@ -2,7 +2,7 @@
 //  json_util.hpp
 //  util
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/util/objc_json_serde.mm
+++ b/backends/apple/coreml/runtime/util/objc_json_serde.mm
@@ -2,7 +2,7 @@
 //  objc_json_serde.mm
 //  util
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/util/objc_safe_cast.h
+++ b/backends/apple/coreml/runtime/util/objc_safe_cast.h
@@ -2,7 +2,7 @@
 //  objc_safe_cast.h
 //  util
 //
-// Copyright © 2023 Apple Inc. All rights reserved.
+// Copyright © 2024 Apple Inc. All rights reserved.
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
@@ -7,9 +7,50 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C945E8E02B997ECE009C3FAC /* ETCoreMLModelProfiler.mm in Sources */ = {isa = PBXBuildFile; fileRef = C945E8CF2B997ECD009C3FAC /* ETCoreMLModelProfiler.mm */; };
+		C945E8E12B997ECE009C3FAC /* ETCoreMLModelAnalyzer.mm in Sources */ = {isa = PBXBuildFile; fileRef = C945E8D42B997ECD009C3FAC /* ETCoreMLModelAnalyzer.mm */; };
+		C945E8E22B997ECE009C3FAC /* program_path.mm in Sources */ = {isa = PBXBuildFile; fileRef = C945E8D52B997ECD009C3FAC /* program_path.mm */; };
+		C945E8E32B997ECE009C3FAC /* ETCoreMLModelStructurePath.mm in Sources */ = {isa = PBXBuildFile; fileRef = C945E8D62B997ECD009C3FAC /* ETCoreMLModelStructurePath.mm */; };
+		C945E8E42B997ECE009C3FAC /* model_event_logger_impl.mm in Sources */ = {isa = PBXBuildFile; fileRef = C945E8D82B997ECD009C3FAC /* model_event_logger_impl.mm */; };
+		C945E8E52B997ECE009C3FAC /* ETCoreMLOperationProfilingInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = C945E8D92B997ECD009C3FAC /* ETCoreMLOperationProfilingInfo.mm */; };
+		C945E8E62B997ECE009C3FAC /* ETCoreMLPair.mm in Sources */ = {isa = PBXBuildFile; fileRef = C945E8DA2B997ECD009C3FAC /* ETCoreMLPair.mm */; };
+		C945E8E72B997ECE009C3FAC /* model_package_info.mm in Sources */ = {isa = PBXBuildFile; fileRef = C945E8DE2B997ECE009C3FAC /* model_package_info.mm */; };
+		C945E8E82B997ECE009C3FAC /* ETCoreMLModelDebugger.mm in Sources */ = {isa = PBXBuildFile; fileRef = C945E8DF2B997ECE009C3FAC /* ETCoreMLModelDebugger.mm */; };
+		C945E92C2B997EEE009C3FAC /* ClassConfidenceThresholding.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E8EB2B997EEC009C3FAC /* ClassConfidenceThresholding.pb.cc */; };
+		C945E92D2B997EEE009C3FAC /* ArrayFeatureExtractor.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E8ED2B997EEC009C3FAC /* ArrayFeatureExtractor.pb.cc */; };
+		C945E92E2B997EEE009C3FAC /* CustomModel.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E8EE2B997EEC009C3FAC /* CustomModel.pb.cc */; };
+		C945E92F2B997EEE009C3FAC /* CategoricalMapping.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E8EF2B997EEC009C3FAC /* CategoricalMapping.pb.cc */; };
+		C945E9302B997EEE009C3FAC /* WordTagger.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E8F02B997EED009C3FAC /* WordTagger.pb.cc */; };
+		C945E9312B997EEE009C3FAC /* DataStructures.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E8F22B997EED009C3FAC /* DataStructures.pb.cc */; };
+		C945E9322B997EEE009C3FAC /* AudioFeaturePrint.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E8F52B997EED009C3FAC /* AudioFeaturePrint.pb.cc */; };
+		C945E9332B997EEE009C3FAC /* GLMRegressor.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E8F62B997EED009C3FAC /* GLMRegressor.pb.cc */; };
+		C945E9342B997EEE009C3FAC /* NeuralNetwork.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E8F92B997EED009C3FAC /* NeuralNetwork.pb.cc */; };
+		C945E9352B997EEE009C3FAC /* TreeEnsemble.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E8FB2B997EED009C3FAC /* TreeEnsemble.pb.cc */; };
+		C945E9362B997EEE009C3FAC /* Identity.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E8FD2B997EED009C3FAC /* Identity.pb.cc */; };
+		C945E9372B997EEE009C3FAC /* FeatureTypes.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E8FF2B997EED009C3FAC /* FeatureTypes.pb.cc */; };
+		C945E9382B997EEE009C3FAC /* Imputer.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9012B997EED009C3FAC /* Imputer.pb.cc */; };
+		C945E9392B997EEE009C3FAC /* Scaler.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9052B997EED009C3FAC /* Scaler.pb.cc */; };
+		C945E93A2B997EEE009C3FAC /* MIL.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9092B997EED009C3FAC /* MIL.pb.cc */; };
+		C945E93B2B997EEE009C3FAC /* Gazetteer.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E90A2B997EED009C3FAC /* Gazetteer.pb.cc */; };
+		C945E93C2B997EEE009C3FAC /* NearestNeighbors.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E90B2B997EED009C3FAC /* NearestNeighbors.pb.cc */; };
+		C945E93D2B997EEE009C3FAC /* TextClassifier.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E90C2B997EED009C3FAC /* TextClassifier.pb.cc */; };
+		C945E93E2B997EEE009C3FAC /* Model.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E90F2B997EED009C3FAC /* Model.pb.cc */; };
+		C945E93F2B997EEE009C3FAC /* Parameters.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9112B997EEE009C3FAC /* Parameters.pb.cc */; };
+		C945E9402B997EEE009C3FAC /* OneHotEncoder.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9132B997EEE009C3FAC /* OneHotEncoder.pb.cc */; };
+		C945E9412B997EEE009C3FAC /* SVM.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9152B997EEE009C3FAC /* SVM.pb.cc */; };
+		C945E9422B997EEE009C3FAC /* FeatureVectorizer.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9172B997EEE009C3FAC /* FeatureVectorizer.pb.cc */; };
+		C945E9432B997EEE009C3FAC /* VisionFeaturePrint.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9182B997EEE009C3FAC /* VisionFeaturePrint.pb.cc */; };
+		C945E9442B997EEE009C3FAC /* DictVectorizer.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9192B997EEE009C3FAC /* DictVectorizer.pb.cc */; };
+		C945E9452B997EEE009C3FAC /* BayesianProbitRegressor.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E91F2B997EEE009C3FAC /* BayesianProbitRegressor.pb.cc */; };
+		C945E9462B997EEE009C3FAC /* NonMaximumSuppression.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9202B997EEE009C3FAC /* NonMaximumSuppression.pb.cc */; };
+		C945E9472B997EEE009C3FAC /* SoundAnalysisPreprocessing.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9232B997EEE009C3FAC /* SoundAnalysisPreprocessing.pb.cc */; };
+		C945E9482B997EEE009C3FAC /* ItemSimilarityRecommender.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9252B997EEE009C3FAC /* ItemSimilarityRecommender.pb.cc */; };
+		C945E9492B997EEE009C3FAC /* GLMClassifier.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9262B997EEE009C3FAC /* GLMClassifier.pb.cc */; };
+		C945E94A2B997EEE009C3FAC /* LinkedModel.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9272B997EEE009C3FAC /* LinkedModel.pb.cc */; };
+		C945E94B2B997EEE009C3FAC /* Normalizer.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E9292B997EEE009C3FAC /* Normalizer.pb.cc */; };
+		C945E94C2B997EEE009C3FAC /* WordEmbedding.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = C945E92B2B997EEE009C3FAC /* WordEmbedding.pb.cc */; };
 		C94BC6492AD5EB400067A63B /* coreml_backend_delegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = C94BC6482AD5EB400067A63B /* coreml_backend_delegate.mm */; };
 		C94D50D92ABD7B2400AF47FD /* CoreML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C96560922AABF992005F8126 /* CoreML.framework */; };
-		C94D50DA2ABD7B6600AF47FD /* libexecutorch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C965608D2AABF72A005F8126 /* libexecutorch.a */; };
 		C94D50E52ABDF80A00AF47FD /* database.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DF062A9FD16F001CC178 /* database.cpp */; };
 		C94D50E72ABDF80D00AF47FD /* sqlite_error.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DF092A9FD16F001CC178 /* sqlite_error.cpp */; };
 		C94D50E82ABDF81100AF47FD /* key_value_store.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DF052A9FD16E001CC178 /* key_value_store.cpp */; };
@@ -32,6 +73,9 @@
 		C94D510C2ABDF84F00AF47FD /* serde_json.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9D3DFB02AA123E9001CC178 /* serde_json.mm */; };
 		C94D510E2ABDF86800AF47FD /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C96560942AABFDCE005F8126 /* libsqlite3.tbd */; };
 		C94D510F2ABDF87500AF47FD /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C96560902AABF982005F8126 /* Accelerate.framework */; };
+		C95578FB2B8C5D050066AEAD /* ETCoreMLDefaultModelExecutor.mm in Sources */ = {isa = PBXBuildFile; fileRef = C95578FA2B8C5D050066AEAD /* ETCoreMLDefaultModelExecutor.mm */; };
+		C95578FE2B8CB63B0066AEAD /* ETCoreMLModelLoader.mm in Sources */ = {isa = PBXBuildFile; fileRef = C95578FD2B8CB63B0066AEAD /* ETCoreMLModelLoader.mm */; };
+		C962271B2B984FB9002D13B7 /* ETCoreMLModelDebuggerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C962271A2B984FB9002D13B7 /* ETCoreMLModelDebuggerTests.mm */; };
 		C97716B52AEA21B600FC0DAC /* inmemory_filesystem_utils.mm in Sources */ = {isa = PBXBuildFile; fileRef = C97716B32AEA1F9900FC0DAC /* inmemory_filesystem_utils.mm */; };
 		C97716D52AF41B2E00FC0DAC /* json_key_value_store.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C97716D42AF41B2E00FC0DAC /* json_key_value_store.cpp */; };
 		C97716DA2AF44CFA00FC0DAC /* json_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C97716D82AF44CFA00FC0DAC /* json_util.cpp */; };
@@ -42,6 +86,11 @@
 		C98551A12AD2542D009143F9 /* mv3_coreml_all.bin in Resources */ = {isa = PBXBuildFile; fileRef = C985519B2AD2542D009143F9 /* mv3_coreml_all.bin */; };
 		C98551A22AD2542D009143F9 /* mul_coreml_all.pte in Resources */ = {isa = PBXBuildFile; fileRef = C985519C2AD2542D009143F9 /* mul_coreml_all.pte */; };
 		C98551A32AD2542D009143F9 /* add_coreml_all.pte in Resources */ = {isa = PBXBuildFile; fileRef = C985519D2AD2542D009143F9 /* add_coreml_all.pte */; };
+		C99883862B95AD7D000953A3 /* libprotobuf-lite.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C99883852B95AD7D000953A3 /* libprotobuf-lite.a */; };
+		C99883882B964413000953A3 /* libexecutorch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C99883872B964413000953A3 /* libexecutorch.a */; };
+		C998838D2B96841D000953A3 /* ETCoreMLModelStructurePathTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C998838C2B96841D000953A3 /* ETCoreMLModelStructurePathTests.mm */; };
+		C998838F2B96999F000953A3 /* ETCoreMLModelProfilerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C998838E2B96999F000953A3 /* ETCoreMLModelProfilerTests.mm */; };
+		C99883922B96BEED000953A3 /* ETCoreMLModelCompiler.mm in Sources */ = {isa = PBXBuildFile; fileRef = C99883912B96BEED000953A3 /* ETCoreMLModelCompiler.mm */; };
 		C9E7D78F2AB3F9BF00CCAE5D /* ETCoreMLTestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D7862AB3F9BF00CCAE5D /* ETCoreMLTestUtils.mm */; };
 		C9E7D7902AB3F9BF00CCAE5D /* InMemoryFileSystemTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D7882AB3F9BF00CCAE5D /* InMemoryFileSystemTests.mm */; };
 		C9E7D7912AB3F9BF00CCAE5D /* ETCoreMLAssetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D7892AB3F9BF00CCAE5D /* ETCoreMLAssetTests.mm */; };
@@ -66,6 +115,90 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		C945E8CD2B997ECD009C3FAC /* ETCoreMLModelProfiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelProfiler.h; path = ../sdk/ETCoreMLModelProfiler.h; sourceTree = "<group>"; };
+		C945E8CE2B997ECD009C3FAC /* ETCoreMLModelAnalyzer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelAnalyzer.h; path = ../sdk/ETCoreMLModelAnalyzer.h; sourceTree = "<group>"; };
+		C945E8CF2B997ECD009C3FAC /* ETCoreMLModelProfiler.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelProfiler.mm; path = ../sdk/ETCoreMLModelProfiler.mm; sourceTree = "<group>"; };
+		C945E8D02B997ECD009C3FAC /* ETCoreMLModelStructurePath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelStructurePath.h; path = ../sdk/ETCoreMLModelStructurePath.h; sourceTree = "<group>"; };
+		C945E8D12B997ECD009C3FAC /* ETCoreMLOperationProfilingInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLOperationProfilingInfo.h; path = ../sdk/ETCoreMLOperationProfilingInfo.h; sourceTree = "<group>"; };
+		C945E8D22B997ECD009C3FAC /* program_path.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = program_path.h; path = ../sdk/program_path.h; sourceTree = "<group>"; };
+		C945E8D32B997ECD009C3FAC /* ETCoreMLModelDebugger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelDebugger.h; path = ../sdk/ETCoreMLModelDebugger.h; sourceTree = "<group>"; };
+		C945E8D42B997ECD009C3FAC /* ETCoreMLModelAnalyzer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelAnalyzer.mm; path = ../sdk/ETCoreMLModelAnalyzer.mm; sourceTree = "<group>"; };
+		C945E8D52B997ECD009C3FAC /* program_path.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = program_path.mm; path = ../sdk/program_path.mm; sourceTree = "<group>"; };
+		C945E8D62B997ECD009C3FAC /* ETCoreMLModelStructurePath.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelStructurePath.mm; path = ../sdk/ETCoreMLModelStructurePath.mm; sourceTree = "<group>"; };
+		C945E8D82B997ECD009C3FAC /* model_event_logger_impl.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = model_event_logger_impl.mm; path = ../sdk/model_event_logger_impl.mm; sourceTree = "<group>"; };
+		C945E8D92B997ECD009C3FAC /* ETCoreMLOperationProfilingInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLOperationProfilingInfo.mm; path = ../sdk/ETCoreMLOperationProfilingInfo.mm; sourceTree = "<group>"; };
+		C945E8DA2B997ECD009C3FAC /* ETCoreMLPair.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLPair.mm; path = ../sdk/ETCoreMLPair.mm; sourceTree = "<group>"; };
+		C945E8DB2B997ECE009C3FAC /* hash_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hash_util.h; path = ../sdk/hash_util.h; sourceTree = "<group>"; };
+		C945E8DC2B997ECE009C3FAC /* ETCoreMLPair.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLPair.h; path = ../sdk/ETCoreMLPair.h; sourceTree = "<group>"; };
+		C945E8DD2B997ECE009C3FAC /* model_package_info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = model_package_info.h; path = ../sdk/model_package_info.h; sourceTree = "<group>"; };
+		C945E8DE2B997ECE009C3FAC /* model_package_info.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = model_package_info.mm; path = ../sdk/model_package_info.mm; sourceTree = "<group>"; };
+		C945E8DF2B997ECE009C3FAC /* ETCoreMLModelDebugger.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelDebugger.mm; path = ../sdk/ETCoreMLModelDebugger.mm; sourceTree = "<group>"; };
+		C945E8EA2B997EEC009C3FAC /* Imputer.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Imputer.pb.h; path = ../sdk/format/Imputer.pb.h; sourceTree = "<group>"; };
+		C945E8EB2B997EEC009C3FAC /* ClassConfidenceThresholding.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ClassConfidenceThresholding.pb.cc; path = ../sdk/format/ClassConfidenceThresholding.pb.cc; sourceTree = "<group>"; };
+		C945E8EC2B997EEC009C3FAC /* FeatureTypes.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FeatureTypes.pb.h; path = ../sdk/format/FeatureTypes.pb.h; sourceTree = "<group>"; };
+		C945E8ED2B997EEC009C3FAC /* ArrayFeatureExtractor.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ArrayFeatureExtractor.pb.cc; path = ../sdk/format/ArrayFeatureExtractor.pb.cc; sourceTree = "<group>"; };
+		C945E8EE2B997EEC009C3FAC /* CustomModel.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CustomModel.pb.cc; path = ../sdk/format/CustomModel.pb.cc; sourceTree = "<group>"; };
+		C945E8EF2B997EEC009C3FAC /* CategoricalMapping.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CategoricalMapping.pb.cc; path = ../sdk/format/CategoricalMapping.pb.cc; sourceTree = "<group>"; };
+		C945E8F02B997EED009C3FAC /* WordTagger.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WordTagger.pb.cc; path = ../sdk/format/WordTagger.pb.cc; sourceTree = "<group>"; };
+		C945E8F12B997EED009C3FAC /* DataStructures.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DataStructures.pb.h; path = ../sdk/format/DataStructures.pb.h; sourceTree = "<group>"; };
+		C945E8F22B997EED009C3FAC /* DataStructures.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DataStructures.pb.cc; path = ../sdk/format/DataStructures.pb.cc; sourceTree = "<group>"; };
+		C945E8F32B997EED009C3FAC /* LinkedModel.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LinkedModel.pb.h; path = ../sdk/format/LinkedModel.pb.h; sourceTree = "<group>"; };
+		C945E8F42B997EED009C3FAC /* Normalizer.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Normalizer.pb.h; path = ../sdk/format/Normalizer.pb.h; sourceTree = "<group>"; };
+		C945E8F52B997EED009C3FAC /* AudioFeaturePrint.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AudioFeaturePrint.pb.cc; path = ../sdk/format/AudioFeaturePrint.pb.cc; sourceTree = "<group>"; };
+		C945E8F62B997EED009C3FAC /* GLMRegressor.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GLMRegressor.pb.cc; path = ../sdk/format/GLMRegressor.pb.cc; sourceTree = "<group>"; };
+		C945E8F72B997EED009C3FAC /* Identity.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Identity.pb.h; path = ../sdk/format/Identity.pb.h; sourceTree = "<group>"; };
+		C945E8F82B997EED009C3FAC /* FeatureVectorizer.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FeatureVectorizer.pb.h; path = ../sdk/format/FeatureVectorizer.pb.h; sourceTree = "<group>"; };
+		C945E8F92B997EED009C3FAC /* NeuralNetwork.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NeuralNetwork.pb.cc; path = ../sdk/format/NeuralNetwork.pb.cc; sourceTree = "<group>"; };
+		C945E8FA2B997EED009C3FAC /* OneHotEncoder.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OneHotEncoder.pb.h; path = ../sdk/format/OneHotEncoder.pb.h; sourceTree = "<group>"; };
+		C945E8FB2B997EED009C3FAC /* TreeEnsemble.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TreeEnsemble.pb.cc; path = ../sdk/format/TreeEnsemble.pb.cc; sourceTree = "<group>"; };
+		C945E8FC2B997EED009C3FAC /* WordTagger.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WordTagger.pb.h; path = ../sdk/format/WordTagger.pb.h; sourceTree = "<group>"; };
+		C945E8FD2B997EED009C3FAC /* Identity.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Identity.pb.cc; path = ../sdk/format/Identity.pb.cc; sourceTree = "<group>"; };
+		C945E8FE2B997EED009C3FAC /* DictVectorizer.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DictVectorizer.pb.h; path = ../sdk/format/DictVectorizer.pb.h; sourceTree = "<group>"; };
+		C945E8FF2B997EED009C3FAC /* FeatureTypes.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FeatureTypes.pb.cc; path = ../sdk/format/FeatureTypes.pb.cc; sourceTree = "<group>"; };
+		C945E9002B997EED009C3FAC /* NonMaximumSuppression.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NonMaximumSuppression.pb.h; path = ../sdk/format/NonMaximumSuppression.pb.h; sourceTree = "<group>"; };
+		C945E9012B997EED009C3FAC /* Imputer.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Imputer.pb.cc; path = ../sdk/format/Imputer.pb.cc; sourceTree = "<group>"; };
+		C945E9022B997EED009C3FAC /* AudioFeaturePrint.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AudioFeaturePrint.pb.h; path = ../sdk/format/AudioFeaturePrint.pb.h; sourceTree = "<group>"; };
+		C945E9032B997EED009C3FAC /* SoundAnalysisPreprocessing.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SoundAnalysisPreprocessing.pb.h; path = ../sdk/format/SoundAnalysisPreprocessing.pb.h; sourceTree = "<group>"; };
+		C945E9042B997EED009C3FAC /* Model.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Model.pb.h; path = ../sdk/format/Model.pb.h; sourceTree = "<group>"; };
+		C945E9052B997EED009C3FAC /* Scaler.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Scaler.pb.cc; path = ../sdk/format/Scaler.pb.cc; sourceTree = "<group>"; };
+		C945E9062B997EED009C3FAC /* BayesianProbitRegressor.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BayesianProbitRegressor.pb.h; path = ../sdk/format/BayesianProbitRegressor.pb.h; sourceTree = "<group>"; };
+		C945E9072B997EED009C3FAC /* TextClassifier.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextClassifier.pb.h; path = ../sdk/format/TextClassifier.pb.h; sourceTree = "<group>"; };
+		C945E9082B997EED009C3FAC /* MIL.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MIL.pb.h; path = ../sdk/format/MIL.pb.h; sourceTree = "<group>"; };
+		C945E9092B997EED009C3FAC /* MIL.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MIL.pb.cc; path = ../sdk/format/MIL.pb.cc; sourceTree = "<group>"; };
+		C945E90A2B997EED009C3FAC /* Gazetteer.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Gazetteer.pb.cc; path = ../sdk/format/Gazetteer.pb.cc; sourceTree = "<group>"; };
+		C945E90B2B997EED009C3FAC /* NearestNeighbors.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NearestNeighbors.pb.cc; path = ../sdk/format/NearestNeighbors.pb.cc; sourceTree = "<group>"; };
+		C945E90C2B997EED009C3FAC /* TextClassifier.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TextClassifier.pb.cc; path = ../sdk/format/TextClassifier.pb.cc; sourceTree = "<group>"; };
+		C945E90D2B997EED009C3FAC /* VisionFeaturePrint.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VisionFeaturePrint.pb.h; path = ../sdk/format/VisionFeaturePrint.pb.h; sourceTree = "<group>"; };
+		C945E90E2B997EED009C3FAC /* Gazetteer.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Gazetteer.pb.h; path = ../sdk/format/Gazetteer.pb.h; sourceTree = "<group>"; };
+		C945E90F2B997EED009C3FAC /* Model.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Model.pb.cc; path = ../sdk/format/Model.pb.cc; sourceTree = "<group>"; };
+		C945E9102B997EED009C3FAC /* ArrayFeatureExtractor.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ArrayFeatureExtractor.pb.h; path = ../sdk/format/ArrayFeatureExtractor.pb.h; sourceTree = "<group>"; };
+		C945E9112B997EEE009C3FAC /* Parameters.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Parameters.pb.cc; path = ../sdk/format/Parameters.pb.cc; sourceTree = "<group>"; };
+		C945E9122B997EEE009C3FAC /* CategoricalMapping.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CategoricalMapping.pb.h; path = ../sdk/format/CategoricalMapping.pb.h; sourceTree = "<group>"; };
+		C945E9132B997EEE009C3FAC /* OneHotEncoder.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OneHotEncoder.pb.cc; path = ../sdk/format/OneHotEncoder.pb.cc; sourceTree = "<group>"; };
+		C945E9142B997EEE009C3FAC /* Parameters.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Parameters.pb.h; path = ../sdk/format/Parameters.pb.h; sourceTree = "<group>"; };
+		C945E9152B997EEE009C3FAC /* SVM.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SVM.pb.cc; path = ../sdk/format/SVM.pb.cc; sourceTree = "<group>"; };
+		C945E9162B997EEE009C3FAC /* SVM.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SVM.pb.h; path = ../sdk/format/SVM.pb.h; sourceTree = "<group>"; };
+		C945E9172B997EEE009C3FAC /* FeatureVectorizer.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FeatureVectorizer.pb.cc; path = ../sdk/format/FeatureVectorizer.pb.cc; sourceTree = "<group>"; };
+		C945E9182B997EEE009C3FAC /* VisionFeaturePrint.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VisionFeaturePrint.pb.cc; path = ../sdk/format/VisionFeaturePrint.pb.cc; sourceTree = "<group>"; };
+		C945E9192B997EEE009C3FAC /* DictVectorizer.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DictVectorizer.pb.cc; path = ../sdk/format/DictVectorizer.pb.cc; sourceTree = "<group>"; };
+		C945E91A2B997EEE009C3FAC /* NeuralNetwork.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NeuralNetwork.pb.h; path = ../sdk/format/NeuralNetwork.pb.h; sourceTree = "<group>"; };
+		C945E91B2B997EEE009C3FAC /* GLMRegressor.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GLMRegressor.pb.h; path = ../sdk/format/GLMRegressor.pb.h; sourceTree = "<group>"; };
+		C945E91C2B997EEE009C3FAC /* GLMClassifier.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GLMClassifier.pb.h; path = ../sdk/format/GLMClassifier.pb.h; sourceTree = "<group>"; };
+		C945E91D2B997EEE009C3FAC /* TreeEnsemble.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TreeEnsemble.pb.h; path = ../sdk/format/TreeEnsemble.pb.h; sourceTree = "<group>"; };
+		C945E91E2B997EEE009C3FAC /* WordEmbedding.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WordEmbedding.pb.h; path = ../sdk/format/WordEmbedding.pb.h; sourceTree = "<group>"; };
+		C945E91F2B997EEE009C3FAC /* BayesianProbitRegressor.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BayesianProbitRegressor.pb.cc; path = ../sdk/format/BayesianProbitRegressor.pb.cc; sourceTree = "<group>"; };
+		C945E9202B997EEE009C3FAC /* NonMaximumSuppression.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NonMaximumSuppression.pb.cc; path = ../sdk/format/NonMaximumSuppression.pb.cc; sourceTree = "<group>"; };
+		C945E9212B997EEE009C3FAC /* CustomModel.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CustomModel.pb.h; path = ../sdk/format/CustomModel.pb.h; sourceTree = "<group>"; };
+		C945E9222B997EEE009C3FAC /* Scaler.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Scaler.pb.h; path = ../sdk/format/Scaler.pb.h; sourceTree = "<group>"; };
+		C945E9232B997EEE009C3FAC /* SoundAnalysisPreprocessing.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SoundAnalysisPreprocessing.pb.cc; path = ../sdk/format/SoundAnalysisPreprocessing.pb.cc; sourceTree = "<group>"; };
+		C945E9242B997EEE009C3FAC /* NearestNeighbors.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NearestNeighbors.pb.h; path = ../sdk/format/NearestNeighbors.pb.h; sourceTree = "<group>"; };
+		C945E9252B997EEE009C3FAC /* ItemSimilarityRecommender.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ItemSimilarityRecommender.pb.cc; path = ../sdk/format/ItemSimilarityRecommender.pb.cc; sourceTree = "<group>"; };
+		C945E9262B997EEE009C3FAC /* GLMClassifier.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GLMClassifier.pb.cc; path = ../sdk/format/GLMClassifier.pb.cc; sourceTree = "<group>"; };
+		C945E9272B997EEE009C3FAC /* LinkedModel.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LinkedModel.pb.cc; path = ../sdk/format/LinkedModel.pb.cc; sourceTree = "<group>"; };
+		C945E9282B997EEE009C3FAC /* ItemSimilarityRecommender.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ItemSimilarityRecommender.pb.h; path = ../sdk/format/ItemSimilarityRecommender.pb.h; sourceTree = "<group>"; };
+		C945E9292B997EEE009C3FAC /* Normalizer.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Normalizer.pb.cc; path = ../sdk/format/Normalizer.pb.cc; sourceTree = "<group>"; };
+		C945E92A2B997EEE009C3FAC /* ClassConfidenceThresholding.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClassConfidenceThresholding.pb.h; path = ../sdk/format/ClassConfidenceThresholding.pb.h; sourceTree = "<group>"; };
+		C945E92B2B997EEE009C3FAC /* WordEmbedding.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WordEmbedding.pb.cc; path = ../sdk/format/WordEmbedding.pb.cc; sourceTree = "<group>"; };
 		C94BC6482AD5EB400067A63B /* coreml_backend_delegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = coreml_backend_delegate.mm; path = ../delegate/coreml_backend_delegate.mm; sourceTree = "<group>"; };
 		C95266352A7E06460016283E /* ETCoreMLModelManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelManager.h; path = ../delegate/ETCoreMLModelManager.h; sourceTree = "<group>"; };
 		C95266362A7E06460016283E /* ETCoreMLModel.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModel.mm; path = ../delegate/ETCoreMLModel.mm; sourceTree = "<group>"; };
@@ -85,9 +218,14 @@
 		C95266502A7F818A0016283E /* backend_delegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = backend_delegate.h; path = ../delegate/backend_delegate.h; sourceTree = "<group>"; };
 		C952665D2A8012400016283E /* ETCoreMLStrings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ETCoreMLStrings.h; path = ../delegate/ETCoreMLStrings.h; sourceTree = "<group>"; };
 		C952665E2A8012400016283E /* ETCoreMLStrings.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLStrings.mm; path = ../delegate/ETCoreMLStrings.mm; sourceTree = "<group>"; };
-		C96560792AABD1DF005F8126 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk/System/Library/Frameworks/Accelerate.framework; sourceTree = DEVELOPER_DIR; };
-		C965607B2AABD1E5005F8126 /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk/System/Library/Frameworks/CoreML.framework; sourceTree = DEVELOPER_DIR; };
-		C965607D2AABD1EA005F8126 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.0.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
+		C95578F82B8C472D0066AEAD /* ETCoreMLModelExecutor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelExecutor.h; path = ../delegate/ETCoreMLModelExecutor.h; sourceTree = "<group>"; };
+		C95578F92B8C5D050066AEAD /* ETCoreMLDefaultModelExecutor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ETCoreMLDefaultModelExecutor.h; path = ../delegate/ETCoreMLDefaultModelExecutor.h; sourceTree = "<group>"; };
+		C95578FA2B8C5D050066AEAD /* ETCoreMLDefaultModelExecutor.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLDefaultModelExecutor.mm; path = ../delegate/ETCoreMLDefaultModelExecutor.mm; sourceTree = "<group>"; };
+		C95578FC2B8CB63B0066AEAD /* ETCoreMLModelLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelLoader.h; path = ../delegate/ETCoreMLModelLoader.h; sourceTree = "<group>"; };
+		C95578FD2B8CB63B0066AEAD /* ETCoreMLModelLoader.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelLoader.mm; path = ../delegate/ETCoreMLModelLoader.mm; sourceTree = "<group>"; };
+		C95578FF2B8CC4490066AEAD /* model_logging_options.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = model_logging_options.h; path = ../delegate/model_logging_options.h; sourceTree = "<group>"; };
+		C96227162B97B767002D13B7 /* model_event_logger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = model_event_logger.h; path = ../delegate/model_event_logger.h; sourceTree = "<group>"; };
+		C962271A2B984FB9002D13B7 /* ETCoreMLModelDebuggerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelDebuggerTests.mm; path = ../test/ETCoreMLModelDebuggerTests.mm; sourceTree = "<group>"; };
 		C965608D2AABF72A005F8126 /* libexecutorch.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libexecutorch.a; path = ../libraries/libexecutorch.a; sourceTree = "<group>"; };
 		C96560902AABF982005F8126 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/Accelerate.framework; sourceTree = DEVELOPER_DIR; };
 		C96560922AABF992005F8126 /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/CoreML.framework; sourceTree = DEVELOPER_DIR; };
@@ -114,6 +252,14 @@
 		C985519B2AD2542D009143F9 /* mv3_coreml_all.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = mv3_coreml_all.bin; path = ../test/models/mv3_coreml_all.bin; sourceTree = "<group>"; };
 		C985519C2AD2542D009143F9 /* mul_coreml_all.pte */ = {isa = PBXFileReference; lastKnownFileType = file; name = mul_coreml_all.pte; path = ../test/models/mul_coreml_all.pte; sourceTree = "<group>"; };
 		C985519D2AD2542D009143F9 /* add_coreml_all.pte */ = {isa = PBXFileReference; lastKnownFileType = file; name = add_coreml_all.pte; path = ../test/models/add_coreml_all.pte; sourceTree = "<group>"; };
+		C988D69E2B998D8400979CF6 /* model_event_logger_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = model_event_logger_impl.h; path = ../sdk/model_event_logger_impl.h; sourceTree = "<group>"; };
+		C99883202B92D220000953A3 /* ETCoreMLComputeUnits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ETCoreMLComputeUnits.h; path = ../delegate/ETCoreMLComputeUnits.h; sourceTree = "<group>"; };
+		C99883852B95AD7D000953A3 /* libprotobuf-lite.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libprotobuf-lite.a"; path = "../libraries/libprotobuf-lite.a"; sourceTree = "<group>"; };
+		C99883872B964413000953A3 /* libexecutorch.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libexecutorch.a; path = ../libraries/libexecutorch.a; sourceTree = "<group>"; };
+		C998838C2B96841D000953A3 /* ETCoreMLModelStructurePathTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelStructurePathTests.mm; path = ../test/ETCoreMLModelStructurePathTests.mm; sourceTree = "<group>"; };
+		C998838E2B96999F000953A3 /* ETCoreMLModelProfilerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelProfilerTests.mm; path = ../test/ETCoreMLModelProfilerTests.mm; sourceTree = "<group>"; };
+		C99883902B96BEED000953A3 /* ETCoreMLModelCompiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelCompiler.h; path = ../delegate/ETCoreMLModelCompiler.h; sourceTree = "<group>"; };
+		C99883912B96BEED000953A3 /* ETCoreMLModelCompiler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelCompiler.mm; path = ../delegate/ETCoreMLModelCompiler.mm; sourceTree = "<group>"; };
 		C9D3DED52A9FCFC4001CC178 /* ETCoreMLAssetManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLAssetManager.mm; path = ../delegate/ETCoreMLAssetManager.mm; sourceTree = "<group>"; };
 		C9D3DED62A9FCFC4001CC178 /* ETCoreMLAssetManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLAssetManager.h; path = ../delegate/ETCoreMLAssetManager.h; sourceTree = "<group>"; };
 		C9D3DF002A9FD16E001CC178 /* statement.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = statement.hpp; path = ../kvstore/statement.hpp; sourceTree = "<group>"; };
@@ -130,7 +276,7 @@
 		C9D3DFAF2AA12097001CC178 /* asset.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = asset.h; path = ../delegate/asset.h; sourceTree = "<group>"; };
 		C9D3DFB02AA123E9001CC178 /* serde_json.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = serde_json.mm; path = ../delegate/serde_json.mm; sourceTree = "<group>"; };
 		C9D3DFB12AA123E9001CC178 /* serde_json.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = serde_json.h; path = ../delegate/serde_json.h; sourceTree = "<group>"; };
-		C9D3DFB22AA12683001CC178 /* metadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = metadata.h; path = ../delegate/metadata.h; sourceTree = "<group>"; };
+		C9D3DFB22AA12683001CC178 /* model_metadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = model_metadata.h; path = ../delegate/model_metadata.h; sourceTree = "<group>"; };
 		C9D3DFB52AA183BC001CC178 /* ETCoreMLAsset.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ETCoreMLAsset.h; path = ../delegate/ETCoreMLAsset.h; sourceTree = "<group>"; };
 		C9D3DFB62AA183BC001CC178 /* ETCoreMLAsset.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLAsset.mm; path = ../delegate/ETCoreMLAsset.mm; sourceTree = "<group>"; };
 		C9D3DFBC2AA84FC6001CC178 /* asset.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = asset.mm; path = ../delegate/asset.mm; sourceTree = "<group>"; };
@@ -146,8 +292,10 @@
 		C9E7D78D2AB3F9BF00CCAE5D /* ETCoreMLModelManagerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelManagerTests.mm; path = ../test/ETCoreMLModelManagerTests.mm; sourceTree = "<group>"; };
 		C9E7D78E2AB3F9BF00CCAE5D /* KeyValueStoreTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = KeyValueStoreTests.mm; path = ../test/KeyValueStoreTests.mm; sourceTree = "<group>"; };
 		C9E7D7A12AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = CoreMLBackendDelegateTests.mm; path = ../test/CoreMLBackendDelegateTests.mm; sourceTree = "<group>"; };
-		C9E7D7A92AB5081600CCAE5D /* libgflags_nothreads.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgflags_nothreads.a; path = ../libraries/libgflags_nothreads.a; sourceTree = "<group>"; };
 		C9E7D7AB2AB55AC100CCAE5D /* com.apple.executorchcoreml_config.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = com.apple.executorchcoreml_config.plist; path = ../delegate/com.apple.executorchcoreml_config.plist; sourceTree = "<group>"; };
+		C9EA3DB22B71A2B200B7D7BD /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = System/Library/Frameworks/CoreML.framework; sourceTree = SDKROOT; };
+		C9EA3FDE2B73EEA000B7D7BD /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
+		C9EA3FE52B73EF6300B7D7BD /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -158,16 +306,118 @@
 				C94D510F2ABDF87500AF47FD /* Accelerate.framework in Frameworks */,
 				C94D510E2ABDF86800AF47FD /* libsqlite3.tbd in Frameworks */,
 				C94D50D92ABD7B2400AF47FD /* CoreML.framework in Frameworks */,
-				C94D50DA2ABD7B6600AF47FD /* libexecutorch.a in Frameworks */,
+				C99883862B95AD7D000953A3 /* libprotobuf-lite.a in Frameworks */,
+				C99883882B964413000953A3 /* libexecutorch.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		C945E8CC2B997EB2009C3FAC /* sdk */ = {
+			isa = PBXGroup;
+			children = (
+				C945E8E92B997EDB009C3FAC /* format */,
+				C945E8CE2B997ECD009C3FAC /* ETCoreMLModelAnalyzer.h */,
+				C945E8D42B997ECD009C3FAC /* ETCoreMLModelAnalyzer.mm */,
+				C945E8D32B997ECD009C3FAC /* ETCoreMLModelDebugger.h */,
+				C945E8DF2B997ECE009C3FAC /* ETCoreMLModelDebugger.mm */,
+				C945E8CD2B997ECD009C3FAC /* ETCoreMLModelProfiler.h */,
+				C945E8CF2B997ECD009C3FAC /* ETCoreMLModelProfiler.mm */,
+				C945E8D02B997ECD009C3FAC /* ETCoreMLModelStructurePath.h */,
+				C945E8D62B997ECD009C3FAC /* ETCoreMLModelStructurePath.mm */,
+				C945E8D12B997ECD009C3FAC /* ETCoreMLOperationProfilingInfo.h */,
+				C945E8D92B997ECD009C3FAC /* ETCoreMLOperationProfilingInfo.mm */,
+				C945E8DC2B997ECE009C3FAC /* ETCoreMLPair.h */,
+				C945E8DA2B997ECD009C3FAC /* ETCoreMLPair.mm */,
+				C945E8DB2B997ECE009C3FAC /* hash_util.h */,
+				C988D69E2B998D8400979CF6 /* model_event_logger_impl.h */,
+				C945E8D82B997ECD009C3FAC /* model_event_logger_impl.mm */,
+				C945E8DD2B997ECE009C3FAC /* model_package_info.h */,
+				C945E8DE2B997ECE009C3FAC /* model_package_info.mm */,
+				C945E8D22B997ECD009C3FAC /* program_path.h */,
+				C945E8D52B997ECD009C3FAC /* program_path.mm */,
+			);
+			name = sdk;
+			sourceTree = "<group>";
+		};
+		C945E8E92B997EDB009C3FAC /* format */ = {
+			isa = PBXGroup;
+			children = (
+				C945E8ED2B997EEC009C3FAC /* ArrayFeatureExtractor.pb.cc */,
+				C945E9102B997EED009C3FAC /* ArrayFeatureExtractor.pb.h */,
+				C945E8F52B997EED009C3FAC /* AudioFeaturePrint.pb.cc */,
+				C945E9022B997EED009C3FAC /* AudioFeaturePrint.pb.h */,
+				C945E91F2B997EEE009C3FAC /* BayesianProbitRegressor.pb.cc */,
+				C945E9062B997EED009C3FAC /* BayesianProbitRegressor.pb.h */,
+				C945E8EF2B997EEC009C3FAC /* CategoricalMapping.pb.cc */,
+				C945E9122B997EEE009C3FAC /* CategoricalMapping.pb.h */,
+				C945E8EB2B997EEC009C3FAC /* ClassConfidenceThresholding.pb.cc */,
+				C945E92A2B997EEE009C3FAC /* ClassConfidenceThresholding.pb.h */,
+				C945E8EE2B997EEC009C3FAC /* CustomModel.pb.cc */,
+				C945E9212B997EEE009C3FAC /* CustomModel.pb.h */,
+				C945E8F22B997EED009C3FAC /* DataStructures.pb.cc */,
+				C945E8F12B997EED009C3FAC /* DataStructures.pb.h */,
+				C945E9192B997EEE009C3FAC /* DictVectorizer.pb.cc */,
+				C945E8FE2B997EED009C3FAC /* DictVectorizer.pb.h */,
+				C945E8FF2B997EED009C3FAC /* FeatureTypes.pb.cc */,
+				C945E8EC2B997EEC009C3FAC /* FeatureTypes.pb.h */,
+				C945E9172B997EEE009C3FAC /* FeatureVectorizer.pb.cc */,
+				C945E8F82B997EED009C3FAC /* FeatureVectorizer.pb.h */,
+				C945E90A2B997EED009C3FAC /* Gazetteer.pb.cc */,
+				C945E90E2B997EED009C3FAC /* Gazetteer.pb.h */,
+				C945E9262B997EEE009C3FAC /* GLMClassifier.pb.cc */,
+				C945E91C2B997EEE009C3FAC /* GLMClassifier.pb.h */,
+				C945E8F62B997EED009C3FAC /* GLMRegressor.pb.cc */,
+				C945E91B2B997EEE009C3FAC /* GLMRegressor.pb.h */,
+				C945E8FD2B997EED009C3FAC /* Identity.pb.cc */,
+				C945E8F72B997EED009C3FAC /* Identity.pb.h */,
+				C945E9012B997EED009C3FAC /* Imputer.pb.cc */,
+				C945E8EA2B997EEC009C3FAC /* Imputer.pb.h */,
+				C945E9252B997EEE009C3FAC /* ItemSimilarityRecommender.pb.cc */,
+				C945E9282B997EEE009C3FAC /* ItemSimilarityRecommender.pb.h */,
+				C945E9272B997EEE009C3FAC /* LinkedModel.pb.cc */,
+				C945E8F32B997EED009C3FAC /* LinkedModel.pb.h */,
+				C945E9092B997EED009C3FAC /* MIL.pb.cc */,
+				C945E9082B997EED009C3FAC /* MIL.pb.h */,
+				C945E90F2B997EED009C3FAC /* Model.pb.cc */,
+				C945E9042B997EED009C3FAC /* Model.pb.h */,
+				C945E90B2B997EED009C3FAC /* NearestNeighbors.pb.cc */,
+				C945E9242B997EEE009C3FAC /* NearestNeighbors.pb.h */,
+				C945E8F92B997EED009C3FAC /* NeuralNetwork.pb.cc */,
+				C945E91A2B997EEE009C3FAC /* NeuralNetwork.pb.h */,
+				C945E9202B997EEE009C3FAC /* NonMaximumSuppression.pb.cc */,
+				C945E9002B997EED009C3FAC /* NonMaximumSuppression.pb.h */,
+				C945E9292B997EEE009C3FAC /* Normalizer.pb.cc */,
+				C945E8F42B997EED009C3FAC /* Normalizer.pb.h */,
+				C945E9132B997EEE009C3FAC /* OneHotEncoder.pb.cc */,
+				C945E8FA2B997EED009C3FAC /* OneHotEncoder.pb.h */,
+				C945E9112B997EEE009C3FAC /* Parameters.pb.cc */,
+				C945E9142B997EEE009C3FAC /* Parameters.pb.h */,
+				C945E9052B997EED009C3FAC /* Scaler.pb.cc */,
+				C945E9222B997EEE009C3FAC /* Scaler.pb.h */,
+				C945E9232B997EEE009C3FAC /* SoundAnalysisPreprocessing.pb.cc */,
+				C945E9032B997EED009C3FAC /* SoundAnalysisPreprocessing.pb.h */,
+				C945E9152B997EEE009C3FAC /* SVM.pb.cc */,
+				C945E9162B997EEE009C3FAC /* SVM.pb.h */,
+				C945E90C2B997EED009C3FAC /* TextClassifier.pb.cc */,
+				C945E9072B997EED009C3FAC /* TextClassifier.pb.h */,
+				C945E8FB2B997EED009C3FAC /* TreeEnsemble.pb.cc */,
+				C945E91D2B997EEE009C3FAC /* TreeEnsemble.pb.h */,
+				C945E9182B997EEE009C3FAC /* VisionFeaturePrint.pb.cc */,
+				C945E90D2B997EED009C3FAC /* VisionFeaturePrint.pb.h */,
+				C945E92B2B997EEE009C3FAC /* WordEmbedding.pb.cc */,
+				C945E91E2B997EEE009C3FAC /* WordEmbedding.pb.h */,
+				C945E8F02B997EED009C3FAC /* WordTagger.pb.cc */,
+				C945E8FC2B997EED009C3FAC /* WordTagger.pb.h */,
+			);
+			name = format;
+			sourceTree = "<group>";
+		};
 		C95266222A7E05FB0016283E = {
 			isa = PBXGroup;
 			children = (
+				C945E8CC2B997EB2009C3FAC /* sdk */,
 				C97716D72AF44BCA00FC0DAC /* util */,
 				C9E7D7AE2AB6C0C000CCAE5D /* models */,
 				C9E7D7852AB3F99A00CCAE5D /* test */,
@@ -199,15 +449,25 @@
 				C952664F2A7F818A0016283E /* backend_delegate.mm */,
 				C9D3DF812A9FF394001CC178 /* multiarray.h */,
 				C96560B12AAF7CC2005F8126 /* multiarray.mm */,
-				C9D3DFB22AA12683001CC178 /* metadata.h */,
+				C9D3DFB22AA12683001CC178 /* model_metadata.h */,
+				C95578FF2B8CC4490066AEAD /* model_logging_options.h */,
+				C96227162B97B767002D13B7 /* model_event_logger.h */,
 				C9D3DFB52AA183BC001CC178 /* ETCoreMLAsset.h */,
 				C9D3DFB62AA183BC001CC178 /* ETCoreMLAsset.mm */,
 				C952663A2A7E06460016283E /* ETCoreMLModel.h */,
 				C95266362A7E06460016283E /* ETCoreMLModel.mm */,
 				C9D3DED62A9FCFC4001CC178 /* ETCoreMLAssetManager.h */,
 				C9D3DED52A9FCFC4001CC178 /* ETCoreMLAssetManager.mm */,
+				C99883202B92D220000953A3 /* ETCoreMLComputeUnits.h */,
+				C95578FC2B8CB63B0066AEAD /* ETCoreMLModelLoader.h */,
+				C95578FD2B8CB63B0066AEAD /* ETCoreMLModelLoader.mm */,
+				C99883902B96BEED000953A3 /* ETCoreMLModelCompiler.h */,
+				C99883912B96BEED000953A3 /* ETCoreMLModelCompiler.mm */,
 				C95266352A7E06460016283E /* ETCoreMLModelManager.h */,
 				C95266372A7E06460016283E /* ETCoreMLModelManager.mm */,
+				C95578F82B8C472D0066AEAD /* ETCoreMLModelExecutor.h */,
+				C95578F92B8C5D050066AEAD /* ETCoreMLDefaultModelExecutor.h */,
+				C95578FA2B8C5D050066AEAD /* ETCoreMLDefaultModelExecutor.mm */,
 				C952665D2A8012400016283E /* ETCoreMLStrings.h */,
 				C952665E2A8012400016283E /* ETCoreMLStrings.mm */,
 				C95266382A7E06460016283E /* ETCoreMLLogging.h */,
@@ -246,10 +506,11 @@
 		C952664C2A7E06B50016283E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				C9E7D7A92AB5081600CCAE5D /* libgflags_nothreads.a */,
-				C965607D2AABD1EA005F8126 /* libsqlite3.tbd */,
-				C965607B2AABD1E5005F8126 /* CoreML.framework */,
-				C96560792AABD1DF005F8126 /* Accelerate.framework */,
+				C99883852B95AD7D000953A3 /* libprotobuf-lite.a */,
+				C9EA3FE52B73EF6300B7D7BD /* Accelerate.framework */,
+				C9EA3FDE2B73EEA000B7D7BD /* libsqlite3.tbd */,
+				C9EA3DB22B71A2B200B7D7BD /* CoreML.framework */,
+				C99883872B964413000953A3 /* libexecutorch.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -301,13 +562,16 @@
 				C9E7D78C2AB3F9BF00CCAE5D /* BackendDelegateTests.mm */,
 				C9E7D7A12AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm */,
 				C9E7D78A2AB3F9BF00CCAE5D /* DatabaseTests.mm */,
+				C9E7D78E2AB3F9BF00CCAE5D /* KeyValueStoreTests.mm */,
+				C9E7D7882AB3F9BF00CCAE5D /* InMemoryFileSystemTests.mm */,
 				C9E7D78B2AB3F9BF00CCAE5D /* ETCoreMLAssetManagerTests.mm */,
 				C9E7D7892AB3F9BF00CCAE5D /* ETCoreMLAssetTests.mm */,
-				C9E7D78D2AB3F9BF00CCAE5D /* ETCoreMLModelManagerTests.mm */,
 				C9E7D7872AB3F9BF00CCAE5D /* ETCoreMLTestUtils.h */,
 				C9E7D7862AB3F9BF00CCAE5D /* ETCoreMLTestUtils.mm */,
-				C9E7D7882AB3F9BF00CCAE5D /* InMemoryFileSystemTests.mm */,
-				C9E7D78E2AB3F9BF00CCAE5D /* KeyValueStoreTests.mm */,
+				C9E7D78D2AB3F9BF00CCAE5D /* ETCoreMLModelManagerTests.mm */,
+				C998838C2B96841D000953A3 /* ETCoreMLModelStructurePathTests.mm */,
+				C998838E2B96999F000953A3 /* ETCoreMLModelProfilerTests.mm */,
+				C962271A2B984FB9002D13B7 /* ETCoreMLModelDebuggerTests.mm */,
 			);
 			name = test;
 			sourceTree = "<group>";
@@ -401,39 +665,87 @@
 			buildActionMask = 2147483647;
 			files = (
 				C94D50E72ABDF80D00AF47FD /* sqlite_error.cpp in Sources */,
+				C945E93C2B997EEE009C3FAC /* NearestNeighbors.pb.cc in Sources */,
 				C94D50FC2ABDF83500AF47FD /* ETCoreMLAsset.mm in Sources */,
+				C99883922B96BEED000953A3 /* ETCoreMLModelCompiler.mm in Sources */,
+				C945E9422B997EEE009C3FAC /* FeatureVectorizer.pb.cc in Sources */,
 				C94D51062ABDF84400AF47FD /* ETCoreMLLogging.mm in Sources */,
 				C97716D52AF41B2E00FC0DAC /* json_key_value_store.cpp in Sources */,
+				C998838F2B96999F000953A3 /* ETCoreMLModelProfilerTests.mm in Sources */,
+				C945E9342B997EEE009C3FAC /* NeuralNetwork.pb.cc in Sources */,
+				C945E92D2B997EEE009C3FAC /* ArrayFeatureExtractor.pb.cc in Sources */,
+				C945E93B2B997EEE009C3FAC /* Gazetteer.pb.cc in Sources */,
+				C945E8E02B997ECE009C3FAC /* ETCoreMLModelProfiler.mm in Sources */,
 				C94D50F22ABDF82200AF47FD /* reversed_memory_stream.cpp in Sources */,
 				C94D51022ABDF83E00AF47FD /* ETCoreMLModelManager.mm in Sources */,
 				C94D50F42ABDF82500AF47FD /* asset.mm in Sources */,
 				C97716DA2AF44CFA00FC0DAC /* json_util.cpp in Sources */,
+				C945E93F2B997EEE009C3FAC /* Parameters.pb.cc in Sources */,
 				C94D51042ABDF84100AF47FD /* ETCoreMLStrings.mm in Sources */,
 				C9E7D7932AB3F9BF00CCAE5D /* ETCoreMLAssetManagerTests.mm in Sources */,
+				C945E8E42B997ECE009C3FAC /* model_event_logger_impl.mm in Sources */,
+				C945E9472B997EEE009C3FAC /* SoundAnalysisPreprocessing.pb.cc in Sources */,
 				C97716B52AEA21B600FC0DAC /* inmemory_filesystem_utils.mm in Sources */,
 				C9E7D7922AB3F9BF00CCAE5D /* DatabaseTests.mm in Sources */,
+				C945E9432B997EEE009C3FAC /* VisionFeaturePrint.pb.cc in Sources */,
+				C945E9442B997EEE009C3FAC /* DictVectorizer.pb.cc in Sources */,
+				C95578FB2B8C5D050066AEAD /* ETCoreMLDefaultModelExecutor.mm in Sources */,
 				C9E7D7902AB3F9BF00CCAE5D /* InMemoryFileSystemTests.mm in Sources */,
 				C9E7D7962AB3F9BF00CCAE5D /* KeyValueStoreTests.mm in Sources */,
 				C94D50E52ABDF80A00AF47FD /* database.cpp in Sources */,
+				C945E8E72B997ECE009C3FAC /* model_package_info.mm in Sources */,
+				C945E9302B997EEE009C3FAC /* WordTagger.pb.cc in Sources */,
 				C97716DD2AF44E7B00FC0DAC /* objc_json_serde.mm in Sources */,
+				C945E9482B997EEE009C3FAC /* ItemSimilarityRecommender.pb.cc in Sources */,
 				C94D51082ABDF84800AF47FD /* MLModel_Prewarm.mm in Sources */,
 				C94D50F02ABDF81F00AF47FD /* memory_stream.cpp in Sources */,
 				C9E7D7A22AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm in Sources */,
 				C94BC6492AD5EB400067A63B /* coreml_backend_delegate.mm in Sources */,
+				C945E93D2B997EEE009C3FAC /* TextClassifier.pb.cc in Sources */,
+				C945E92C2B997EEE009C3FAC /* ClassConfidenceThresholding.pb.cc in Sources */,
 				C9E7D78F2AB3F9BF00CCAE5D /* ETCoreMLTestUtils.mm in Sources */,
+				C945E93A2B997EEE009C3FAC /* MIL.pb.cc in Sources */,
 				C94D51002ABDF83C00AF47FD /* ETCoreMLAssetManager.mm in Sources */,
+				C945E93E2B997EEE009C3FAC /* Model.pb.cc in Sources */,
+				C945E9362B997EEE009C3FAC /* Identity.pb.cc in Sources */,
 				C94D50EE2ABDF81B00AF47FD /* memory_buffer.cpp in Sources */,
+				C945E8E32B997ECE009C3FAC /* ETCoreMLModelStructurePath.mm in Sources */,
+				C945E8E82B997ECE009C3FAC /* ETCoreMLModelDebugger.mm in Sources */,
 				C94D50FE2ABDF83800AF47FD /* ETCoreMLModel.mm in Sources */,
 				C94D510A2ABDF84B00AF47FD /* MLMultiArray_Copy.mm in Sources */,
+				C945E8E22B997ECE009C3FAC /* program_path.mm in Sources */,
 				C94D510C2ABDF84F00AF47FD /* serde_json.mm in Sources */,
+				C945E9352B997EEE009C3FAC /* TreeEnsemble.pb.cc in Sources */,
 				C9E7D7912AB3F9BF00CCAE5D /* ETCoreMLAssetTests.mm in Sources */,
+				C945E9492B997EEE009C3FAC /* GLMClassifier.pb.cc in Sources */,
+				C945E8E62B997ECE009C3FAC /* ETCoreMLPair.mm in Sources */,
+				C945E9372B997EEE009C3FAC /* FeatureTypes.pb.cc in Sources */,
+				C945E9402B997EEE009C3FAC /* OneHotEncoder.pb.cc in Sources */,
 				C94D50E82ABDF81100AF47FD /* key_value_store.cpp in Sources */,
+				C945E9452B997EEE009C3FAC /* BayesianProbitRegressor.pb.cc in Sources */,
+				C945E8E52B997ECE009C3FAC /* ETCoreMLOperationProfilingInfo.mm in Sources */,
+				C945E9312B997EEE009C3FAC /* DataStructures.pb.cc in Sources */,
+				C945E94A2B997EEE009C3FAC /* LinkedModel.pb.cc in Sources */,
+				C945E92E2B997EEE009C3FAC /* CustomModel.pb.cc in Sources */,
 				C9E7D7942AB3F9BF00CCAE5D /* BackendDelegateTests.mm in Sources */,
+				C945E9392B997EEE009C3FAC /* Scaler.pb.cc in Sources */,
 				C94D50F62ABDF82900AF47FD /* backend_delegate.mm in Sources */,
+				C945E9322B997EEE009C3FAC /* AudioFeaturePrint.pb.cc in Sources */,
+				C962271B2B984FB9002D13B7 /* ETCoreMLModelDebuggerTests.mm in Sources */,
+				C945E94C2B997EEE009C3FAC /* WordEmbedding.pb.cc in Sources */,
 				C94D50EA2ABDF81400AF47FD /* statement.cpp in Sources */,
+				C945E8E12B997ECE009C3FAC /* ETCoreMLModelAnalyzer.mm in Sources */,
 				C94D50ED2ABDF81900AF47FD /* inmemory_filesystem.cpp in Sources */,
+				C945E94B2B997EEE009C3FAC /* Normalizer.pb.cc in Sources */,
 				C94D50FA2ABDF83200AF47FD /* multiarray.mm in Sources */,
 				C9E7D7952AB3F9BF00CCAE5D /* ETCoreMLModelManagerTests.mm in Sources */,
+				C945E9382B997EEE009C3FAC /* Imputer.pb.cc in Sources */,
+				C945E92F2B997EEE009C3FAC /* CategoricalMapping.pb.cc in Sources */,
+				C95578FE2B8CB63B0066AEAD /* ETCoreMLModelLoader.mm in Sources */,
+				C998838D2B96841D000953A3 /* ETCoreMLModelStructurePathTests.mm in Sources */,
+				C945E9332B997EEE009C3FAC /* GLMRegressor.pb.cc in Sources */,
+				C945E9412B997EEE009C3FAC /* SVM.pb.cc in Sources */,
+				C945E9462B997EEE009C3FAC /* NonMaximumSuppression.pb.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -569,8 +881,10 @@
 					"$(SRCROOT)/../kvstore",
 					"$(SRCROOT)/../inmemoryfs",
 					"$(SRCROOT)/../include",
+					"$(SRCROOT)/../sdk",
 					"$(SRCROOT)/../util",
 					"$(SRCROOT)/../../third-party/nlohmann_json/single_include/nlohmann",
+					"$(SRCROOT)/../../third-party/coremltools/deps/protobuf/src",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../libraries";
@@ -598,8 +912,10 @@
 					"$(SRCROOT)/../kvstore",
 					"$(SRCROOT)/../inmemoryfs",
 					"$(SRCROOT)/../include",
+					"$(SRCROOT)/../sdk",
 					"$(SRCROOT)/../util",
 					"$(SRCROOT)/../../third-party/nlohmann_json/single_include/nlohmann",
+					"$(SRCROOT)/../../third-party/coremltools/deps/protobuf/src",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../libraries";

--- a/backends/apple/coreml/scripts/build_tests.sh
+++ b/backends/apple/coreml/scripts/build_tests.sh
@@ -12,8 +12,10 @@ SCRIPT_DIR_PATH="$(
 
 EXECUTORCH_ROOT_PATH=$(realpath "$SCRIPT_DIR_PATH/../../../../")
 COREML_DIR_PATH="$EXECUTORCH_ROOT_PATH/backends/apple/coreml"
+PROTOBUF_DIR_PATH="$COREML_DIR_PATH/third-party/coremltools/deps/protobuf"
 IOS_TOOLCHAIN_PATH="$COREML_DIR_PATH/third-party/ios-cmake/ios.toolchain.cmake"
-CMAKE_BUILD_DIR_PATH="$COREML_DIR_PATH/cmake-out"
+CMAKE_EXECUTORCH_BUILD_DIR_PATH="$COREML_DIR_PATH/executorch-cmake-out"
+CMAKE_PROTOBUF_BUILD_DIR_PATH="$COREML_DIR_PATH/protobuf-cmake-out"
 LIBRARIES_DIR_PATH="$COREML_DIR_PATH/runtime/libraries"
 EXECUTORCH_INCLUDE_DIR_PATH="$COREML_DIR_PATH/runtime/include/executorch"
 
@@ -21,12 +23,12 @@ cd "$EXECUTORCH_ROOT_PATH"
 
 echo "ExecuTorch: Building Tests"
 
-echo "ExecuTorch: Removing build directory $CMAKE_BUILD_DIR"
-rm -rf "$CMAKE_BUILD_DIR_PATH"
-
 # Build executorch
 echo "ExecuTorch: Building executorch"
-cmake "$EXECUTORCH_ROOT_PATH" -B"$CMAKE_BUILD_DIR_PATH" \
+echo "ExecuTorch: Removing build directory $CMAKE_EXECUTORCH_BUILD_DIR_PATH"
+rm -rf "$CMAKE_EXECUTORCH_BUILD_DIR_PATH"
+
+cmake "$EXECUTORCH_ROOT_PATH" -B"$CMAKE_EXECUTORCH_BUILD_DIR_PATH" \
 -DCMAKE_TOOLCHAIN_FILE="$IOS_TOOLCHAIN_PATH" \
 -DPLATFORM=MAC_UNIVERSAL \
 -DDEPLOYMENT_TARGET=13.0 \
@@ -35,12 +37,29 @@ cmake "$EXECUTORCH_ROOT_PATH" -B"$CMAKE_BUILD_DIR_PATH" \
 -DEXECUTORCH_BUILD_XNNPACK=OFF \
 -DEXECUTORCH_BUILD_GFLAGS=OFF
 
-cmake --build "$CMAKE_BUILD_DIR_PATH"  -j9 -t executorch
+cmake --build "$CMAKE_EXECUTORCH_BUILD_DIR_PATH"  -j9 -t executorch
+
+# Build protobuf
+echo "ExecuTorch: Building libprotobuf-lite"
+echo "ExecuTorch: Removing build directory $CMAKE_PROTOBUF_BUILD_DIR_PATH"
+rm -rf "$CMAKE_PROTOBUF_BUILD_DIR_PATH"
+
+cmake "$PROTOBUF_DIR_PATH/cmake" -B"$CMAKE_PROTOBUF_BUILD_DIR_PATH" \
+-DCMAKE_TOOLCHAIN_FILE="$IOS_TOOLCHAIN_PATH" \
+-DPLATFORM=MAC_UNIVERSAL \
+-DDEPLOYMENT_TARGET=13.0 \
+-Dprotobuf_BUILD_TESTS=OFF \
+-Dprotobuf_BUILD_EXAMPLES=OFF \
+-DCMAKE_MACOSX_BUNDLE=OFF \
+-DCMAKE_CXX_STANDARD=17
+
+cmake --build "$CMAKE_PROTOBUF_BUILD_DIR_PATH"  -j9 -t libprotobuf-lite
 
 # Copy required libraries
 echo "ExecuTorch: Copying libraries"
 mkdir "$LIBRARIES_DIR_PATH"
-cp -f "$CMAKE_BUILD_DIR_PATH/libexecutorch.a" "$LIBRARIES_DIR_PATH"
+cp -f "$CMAKE_EXECUTORCH_BUILD_DIR_PATH/libexecutorch.a" "$LIBRARIES_DIR_PATH"
+cp -f "$CMAKE_PROTOBUF_BUILD_DIR_PATH/libprotobuf-lite.a" "$LIBRARIES_DIR_PATH"
 
 #Copy ExecuTorch headers
 echo "ExecuTorch: Copying headers"

--- a/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.pbxproj
+++ b/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		C94D51642ACFCBC500AF47FD /* CoreML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51632ACFCBC500AF47FD /* CoreML.framework */; };
 		C94D51662ACFCBCB00AF47FD /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51652ACFCBCB00AF47FD /* Accelerate.framework */; };
 		C94D51682ACFCC7100AF47FD /* libcoremldelegate.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51672ACFCC7100AF47FD /* libcoremldelegate.a */; };
+		C988D69D2B998CDE00979CF6 /* libprotobuf-lite.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C988D69C2B998CD700979CF6 /* libprotobuf-lite.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -39,6 +40,7 @@
 		C94D51632ACFCBC500AF47FD /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = System/Library/Frameworks/CoreML.framework; sourceTree = SDKROOT; };
 		C94D51652ACFCBCB00AF47FD /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		C94D51672ACFCC7100AF47FD /* libcoremldelegate.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcoremldelegate.a; path = libraries/libcoremldelegate.a; sourceTree = "<group>"; };
+		C988D69C2B998CD700979CF6 /* libprotobuf-lite.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libprotobuf-lite.a"; path = "libraries/libprotobuf-lite.a"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -50,6 +52,7 @@
 				38626BB42B225A560059413D /* libflatccrt.a in Frameworks */,
 				C94D51682ACFCC7100AF47FD /* libcoremldelegate.a in Frameworks */,
 				C94D51662ACFCBCB00AF47FD /* Accelerate.framework in Frameworks */,
+				C988D69D2B998CDE00979CF6 /* libprotobuf-lite.a in Frameworks */,
 				C94D51642ACFCBC500AF47FD /* CoreML.framework in Frameworks */,
 				C94D51622ACFCBBA00AF47FD /* libsqlite3.tbd in Frameworks */,
 				C94D515E2ACFCBA000AF47FD /* libexecutorch.a in Frameworks */,
@@ -79,6 +82,7 @@
 		C94D51602ACFCBBA00AF47FD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C988D69C2B998CD700979CF6 /* libprotobuf-lite.a */,
 				38626BB32B225A560059413D /* libflatccrt.a */,
 				38626BAF2B21C98F0059413D /* libetdump.a */,
 				C94D51652ACFCBCB00AF47FD /* Accelerate.framework */,

--- a/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/xcshareddata/xcschemes/coreml_executor_runner.xcscheme
+++ b/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/xcshareddata/xcschemes/coreml_executor_runner.xcscheme
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C94D514D2ACF4B9300AF47FD"
+               BuildableName = "coreml_executor_runner"
+               BlueprintName = "coreml_executor_runner"
+               ReferencedContainer = "container:coreml_executor_runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      internalIOSLaunchStyle = "3"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C94D514D2ACF4B9300AF47FD"
+            BuildableName = "coreml_executor_runner"
+            BlueprintName = "coreml_executor_runner"
+            ReferencedContainer = "container:coreml_executor_runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C94D514D2ACF4B9300AF47FD"
+            BuildableName = "coreml_executor_runner"
+            BlueprintName = "coreml_executor_runner"
+            ReferencedContainer = "container:coreml_executor_runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/examples/apple/coreml/executor_runner/main.mm
+++ b/examples/apple/coreml/executor_runner/main.mm
@@ -319,7 +319,7 @@ int main(int argc, char * argv[]) {
         ET_CHECK_MSG(method_name.ok(), "Failed to load method with name=%s from program=%p", method_name.get().c_str(), program.get());
         ET_LOG(Info, "Running method = %s", method_name.get().c_str());
 
-        auto inputs = prepare_input_tensors(*method);
+        auto inputs = ::prepare_input_tensors(*method);
         ET_LOG(Info, "Inputs prepared.");
 
         // Run the model.

--- a/examples/apple/coreml/scripts/build_executor_runner.sh
+++ b/examples/apple/coreml/scripts/build_executor_runner.sh
@@ -36,9 +36,12 @@ cmake "$EXECUTORCH_ROOT_PATH" -B"$CMAKE_BUILD_DIR_PATH" \
 -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF \
 -DEXECUTORCH_BUILD_XNNPACK=OFF \
 -DEXECUTORCH_BUILD_SDK=ON \
--DEXECUTORCH_BUILD_COREML=ON
+-DEXECUTORCH_BUILD_COREML=ON \
+-Dprotobuf_BUILD_TESTS=OFF \
+-Dprotobuf_BUILD_EXAMPLES=OFF \
+-DCMAKE_MACOSX_BUNDLE=OFF \
 
-cmake --build "$CMAKE_BUILD_DIR_PATH" -j9 -t coremldelegate -t gflags_nothreads_static
+cmake --build "$CMAKE_BUILD_DIR_PATH" -j9 -t coremldelegate
 cmake --build "$CMAKE_BUILD_DIR_PATH" -j9 -t etdump -t flatccrt
 
 # Copy CoreML delegate headers
@@ -57,9 +60,11 @@ cp -rf "$COREML_DIR_PATH/runtime/include/" "$INCLUDE_DIR_PATH"
 # Copy required libraries
 echo "ExecuTorch: Copying libraries"
 mkdir "$LIBRARIES_DIR_PATH"
-cp -f "$CMAKE_BUILD_DIR_PATH/libexecutorch.a" "$LIBRARIES_DIR_PATH"
-cp -f "$CMAKE_BUILD_DIR_PATH/sdk/libetdump.a" "$LIBRARIES_DIR_PATH"
-cp -f "$CMAKE_BUILD_DIR_PATH/backends/apple/coreml/libcoremldelegate.a" "$LIBRARIES_DIR_PATH"
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libexecutorch.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH"  \;
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libetdump.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH"  \;
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libcoremldelegate.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH"  \;
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libprotobuf-lite.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH"  \;
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libprotobuf-lited.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libprotobuf-lite.a"  \;
 cp -f "$EXECUTORCH_ROOT_PATH/third-party/flatcc/lib/libflatccrt.a" "$LIBRARIES_DIR_PATH"
 
 # Build the runner
@@ -68,4 +73,4 @@ XCODE_WORKSPACE_DIR_PATH="$EXAMPLES_COREML_DIR_PATH/executor_runner"
 XCODE_BUILD_DIR_PATH="$EXAMPLES_COREML_DIR_PATH/xcode-build"
 
 xcodebuild build -workspace "$XCODE_WORKSPACE_DIR_PATH/coreml_executor_runner.xcworkspace" -scheme coreml_executor_runner BUILD_DIR="$XCODE_BUILD_DIR_PATH"
-mv -f "$XCODE_BUILD_DIR_PATH/DEBUG/coreml_executor_runner" "$PWD"
+cp -f "$XCODE_BUILD_DIR_PATH/DEBUG/coreml_executor_runner" "$PWD"

--- a/examples/apple/coreml/scripts/inspector_cli.py
+++ b/examples/apple/coreml/scripts/inspector_cli.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import json
+
+from typing import Any, Dict, Final, List, Tuple
+
+from executorch.sdk import Inspector
+from executorch.sdk.inspector._inspector_utils import compare_results
+
+COREML_METADATA_KEYS: Final[List[Tuple[str, str]]] = [
+    ("operatorName", "coreml_operator"),
+    ("estimatedCost", "coreml_estimated_cost"),
+    ("preferredComputeUnit", "coreml_preferred_device"),
+    ("supportedComputeUnits", "coreml_supported_devices"),
+]
+
+
+def parse_coreml_delegate_metadata(delegate_metadatas: List[str]) -> Dict[str, Any]:
+    try:
+        coreml_metadata: Dict[str, Any] = json.loads(delegate_metadatas[0])
+        result: Dict[str, str] = {}
+        for col_key, col_name in COREML_METADATA_KEYS:
+            value = coreml_metadata.get(col_key, None)
+            if value is not None:
+                result[col_name] = value
+        return result
+
+    except ValueError:
+        return {}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--etdump_path",
+        required=True,
+        help="Provide an ETDump file path.",
+    )
+    parser.add_argument(
+        "--etrecord_path",
+        required=False,
+        help="Provide an optional ETRecord file path.",
+    )
+    parser.add_argument(
+        "--debug_buffer_path",
+        required=False,
+        help="Provide an optional buffer file path.",
+    )
+    parser.add_argument("--compare_results", action="store_true")
+
+    args = parser.parse_args()
+
+    print("Creating inspector")
+    inspector = Inspector(
+        etdump_path=args.etdump_path,
+        etrecord=args.etrecord_path,
+        debug_buffer_path=args.debug_buffer_path,
+        delegate_metadata_parser=parse_coreml_delegate_metadata,
+    )
+    inspector.print_data_tabular(include_delegate_debug_data=True)
+    if args.compare_results:
+        for event_block in inspector.event_blocks:
+            if event_block.name == "Execute":
+                compare_results(
+                    reference_output=event_block.reference_output,
+                    run_output=event_block.run_output,
+                    plot=True,
+                )
+
+
+if __name__ == "__main__":
+    main()  # pragma: no cover


### PR DESCRIPTION
The PR adds support for logging profiling information and intermediate outputs. The required files are only included if CoreML delegate is built with`EXECUTORCH_BUILD_SDK` option. 

- Profiling:  `ETCoreMLModelProfiler` adds profiling support, it uses the `MLComputePlan` API that's currently in beta but unlikely to change. The caveat is that it only works for macOS >= 14.4, iOS >= 17.4.
- Debugging: `ETCoreMLModelDebugger` adds support for getting intermediate tensors. The model spec is updated to include additional intermediate outputs, compiled, and then executed. It has a dependency on `protobuf` as it modifies the specification of the model. The logging part doesn't work yet, it would require ExecuTorch API (`log_tensor_delegate`).
- CLI: Added cli file for parsing CoreML delegate metadata.
- AOT: AOT integration is remaining but most likely it would be done in `coremltools`. `coremltools` will add a `json` file to `mlpackage` that would contain the operation path to debug handle mapping.
  
![Screenshot 2024-03-07 at 11 04 00 PM](https://github.com/pytorch/executorch/assets/709448/62bbc623-cd53-42cd-bec7-f7afca227f79)
