### PR TITLE
Fix quantization for input to reference model

### DIFF
--- a/backends/arm/operators/op_add.py
+++ b/backends/arm/operators/op_add.py
@@ -48,9 +48,11 @@ class AddVisitor(NodeVisitor):
             input_A, input_A_scale, input_A_zp, _, _, _ = getNodeArgs(input_node_A)
             input_B, input_B_scale, input_B_zp, _, _, _ = getNodeArgs(input_node_B)
 
-            max_scale_2x = 2.0 * max(input_A_scale.number, input_B_scale.number)
-            inputA_rescale_scale = input_A_scale.number / max_scale_2x
-            inputB_rescale_scale = input_B_scale.number / max_scale_2x
+            # Scale the int8 quantized input to a common scale in the integer
+            # domain.
+            min_scale = min(input_A_scale.number, input_B_scale.number)
+            inputA_rescale_scale = input_A_scale.number / min_scale
+            inputB_rescale_scale = input_B_scale.number / min_scale
 
             broadcasted_shape = broadcast_shapes(input_A.shape, input_B.shape)
             if permute_memory_to_nhwc:
@@ -88,7 +90,7 @@ class AddVisitor(NodeVisitor):
             # Output
             output_node = list(node.users)[0]
             _, output_scale, output_zp, _, _, _ = getNodeArgs(output_node)
-            output_rescale_scale = max_scale_2x / (output_scale.number)
+            output_rescale_scale = min_scale / output_scale.number
 
             # Rescale Back to INT8
             build_rescale_from_int32(

--- a/backends/arm/test/ops/test_add.py
+++ b/backends/arm/test/ops/test_add.py
@@ -48,6 +48,7 @@ class TestSimpleAdd(unittest.TestCase):
             (torch.ones(1, 1, 4, 4), torch.ones(1, 1, 4, 4)),
             (torch.randn(1, 1, 4, 4), torch.ones(1, 1, 4, 1)),
             (torch.randn(1, 1, 4, 4), torch.randn(1, 1, 4, 1)),
+            (10000 * torch.randn(1, 1, 4, 4), torch.randn(1, 1, 4, 1)),
         ]
 
         def __init__(self):
@@ -140,11 +141,11 @@ class TestSimpleAdd(unittest.TestCase):
         test_data = (test_data,)
         self._test_add_tosa_BI_pipeline(self.Add(), test_data)
 
+    @parameterized.expand(Add.test_parameters)
     @unittest.skipIf(
         not VELA_INSTALLED,
         "There is no point in running U55 tests if the Vela tool is not installed",
     )
-    @parameterized.expand(Add.test_parameters)
     def test_add_u55_BI(self, test_data: torch.Tensor):
         test_data = (test_data,)
         self._test_add_u55_BI_pipeline(self.Add(), test_data)
@@ -159,11 +160,11 @@ class TestSimpleAdd(unittest.TestCase):
         test_data = (operand1, operand2)
         self._test_add_tosa_BI_pipeline(self.Add2(), test_data)
 
+    @parameterized.expand(Add2.test_parameters)
     @unittest.skipIf(
         not VELA_INSTALLED,
         "There is no point in running U55 tests if the Vela tool is not installed",
     )
-    @parameterized.expand(Add2.test_parameters)
     def test_add2_u55_BI(self, operand1: torch.Tensor, operand2: torch.Tensor):
         test_data = (operand1, operand2)
         self._test_add_u55_BI_pipeline(self.Add2(), test_data)


### PR DESCRIPTION
Add the zerpoint instead of subtracting. This worked since the tests so far used the ones as inputs which quantize to a zp of -128 which gives the same np.int8 result in both cases since the int8 wraps. Also needs to round and clip the scaled values to the int8 range.

Signed-off-by: Per Åstrand <per.astrand@arm.com>