### PR TITLE
[ET-VK][EZ] Fix Android test linkage

### DIFF
--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -60,6 +60,8 @@ def define_common_targets():
         # therefore link_whole must be True to make sure unused symbols are not discarded.
         # @lint-ignore BUCKLINT: Avoid `link_whole=True`
         link_whole = True,
+        # Define an soname that can be used for dynamic loading in Java, Python, etc.
+        soname = "libvulkan_graph_runtime.$(ext)",
     )
 
     runtime.cxx_library(
@@ -85,6 +87,4 @@ def define_common_targets():
         # VulkanBackend.cpp needs to compile with executor as whole
         # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
         link_whole = True,
-        # Define an soname that can be used for dynamic loading in Java, Python, etc.
-        soname = "libvulkan_graph_runtime.$(ext)",
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2323
* __->__ #2319

In https://github.com/pytorch/executorch/pull/2305, I added the `soname = "libvulkan_graph_runtime.$(ext)"` to the wrong library. Noob mistake. Also, removed an unneeded dependency.

Differential Revision: [D54688153](https://our.internmc.facebook.com/intern/diff/D54688153/)