### PR TITLE
test_ios comments on pybindings

### DIFF
--- a/build/test_ios.sh
+++ b/build/test_ios.sh
@@ -112,3 +112,14 @@ xcodebuild test \
   -project "$APP_PATH.xcodeproj" \
   -scheme MobileNetClassifierTest \
   -destination name="$SIMULATOR_NAME"
+
+say "Installing Python Bindings"
+
+# Ensure that the pybindings build works on macOS. TODO(shoumikhin): Make this a
+# separate test to clarify that it's not required for the rest of the script.
+# Until then, make this the last step so that nothing can depend on it.
+EXECUTORCH_BUILD_PYBIND=ON \
+BUCK="$(pwd)/$BUCK2" \
+CMAKE_ARGS="-DEXECUTORCH_BUILD_COREML=ON -DEXECUTORCH_BUILD_MPS=ON -DEXECUTORCH_BUILD_XNNPACK=ON" \
+CMAKE_BUILD_PARALLEL_LEVEL=9 \
+pip install . --no-build-isolation -v

--- a/build/test_ios_ci.sh
+++ b/build/test_ios_ci.sh
@@ -69,3 +69,14 @@ xcodebuild test \
   -project "$APP_PATH.xcodeproj" \
   -scheme MobileNetClassifierTest \
   -destination name="$SIMULATOR_NAME"
+
+say "Installing Python Bindings"
+
+# Ensure that the pybindings build works on macOS. TODO(shoumikhin): Make this a
+# separate test to clarify that it's not required for the rest of the script.
+# Until then, make this the last step so that nothing can depend on it.
+EXECUTORCH_BUILD_PYBIND=ON \
+BUCK="$(which buck2)" \
+CMAKE_ARGS="-DEXECUTORCH_BUILD_COREML=ON -DEXECUTORCH_BUILD_MPS=ON -DEXECUTORCH_BUILD_XNNPACK=ON" \
+CMAKE_BUILD_PARALLEL_LEVEL=9 \
+pip install . --no-build-isolation -v


### PR DESCRIPTION
Summary:
Accoding to shoumikhin, this was a quick way to test the build for pybindings on macos, but pybindings isn't actually needed by the rest of the script.

Add comments to make it clear why these scripts are building the pybindings. Move the pybindings to the bottom so that nothing else can depend on them.

Differential Revision: D54695352


