### PR TITLE
remove exir.capture from models.py

### DIFF
--- a/exir/tests/models.py
+++ b/exir/tests/models.py
@@ -13,8 +13,10 @@ import executorch.exir as exir
 
 import torch  # noqa: F401
 import torch.nn as nn
+from executorch.exir import to_edge
 from executorch.exir.lowered_backend_module import LoweredBackendModule
 from torch import Tensor
+from torch.export import export
 
 # TODO: add one more test for data dependent op plus repeat
 
@@ -148,13 +150,14 @@ class CompositeDelegateModule(torch.nn.Module):
                 return (torch.randn(1, 3), torch.randn(1, 3))
 
         delegated_m = DelegateAdd()
-        edge_ir_m = exir.capture(
-            delegated_m,
-            delegated_m.get_random_inputs(),
-            exir.CaptureConfig(),
-        ).to_edge()
+        edge_ir_m = to_edge(
+            export(
+                delegated_m,
+                delegated_m.get_random_inputs(),
+            )
+        )
         lowered_module = LoweredBackendModule(
-            edge_program=edge_ir_m.exported_program,
+            edge_program=edge_ir_m.exported_program(),
             backend_id="backend_demo",
             processed_bytes=bytes("basic_module_add", encoding="utf8"),
             compile_specs=[],


### PR DESCRIPTION
Summary: capture is deprecated, use export

Differential Revision: D54695851


