### PR TITLE
Enable Dynamic shape support via tensor virtual and physical resizing

### DIFF
--- a/backends/vulkan/test/glsl/all_shaders.yaml
+++ b/backends/vulkan/test/glsl/all_shaders.yaml
@@ -1,0 +1,42 @@
+binary_op_nobroadcast__test:
+  parameter_names_with_default_values:
+    OPERATOR: X + Y
+  shader_variants:
+    - NAME: binary_add_nobroadcast__test
+      OPERATOR: X + Y
+    - NAME: binary_sub_nobroadcast__test
+      OPERATOR: X - Y
+    - NAME: binary_mul_nobroadcast__test
+      OPERATOR: X * Y
+    - NAME: binary_div_nobroadcast__test
+      OPERATOR: X / Y
+    - NAME: binary_pow_nobroadcast__test
+      OPERATOR: pow(X, Y)
+
+image_to_nchw__test:
+  parameter_names_with_default_values:
+    NDIM: 3
+    DTYPE: float
+    PACKING: CHANNELS_PACKED
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: "half"
+        SUFFIX: "half"
+      - VALUE: "float"
+        SUFFIX: "float"
+  shader_variants:
+    - NAME: image3d_to_nchw__test_C_packed
+
+nchw_to_image__test:
+  parameter_names_with_default_values:
+    NDIM: 3
+    DTYPE: float
+    PACKING: CHANNELS_PACKED
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: "half"
+        SUFFIX: "half"
+      - VALUE: "float"
+        SUFFIX: "float"
+  shader_variants:
+    - NAME: nchw_to_image3d__test_C_packed

--- a/backends/vulkan/test/glsl/binary_op_nobroadcast__test.glsl
+++ b/backends/vulkan/test/glsl/binary_op_nobroadcast__test.glsl
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+// clang-format off
+#define PRECISION ${PRECISION}
+#define FORMAT ${FORMAT}
+
+#define OP(X, Y) ${OPERATOR}
+// clang-format on
+
+layout(std430) buffer;
+
+// clang-format off
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D image_out;
+// clang-format on
+layout(set = 0, binding = 1) uniform PRECISION sampler3D image_in;
+layout(set = 0, binding = 2) uniform PRECISION sampler3D image_other;
+
+layout(set = 0, binding = 3) uniform PRECISION restrict OutExtents {
+  uvec4 data;
+}
+out_extents;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (any(greaterThanEqual(pos, out_extents.data.xyz))) {
+    return;
+  }
+
+  vec4 in_texel = texelFetch(image_in, pos, 0);
+  vec4 other_texel = texelFetch(image_other, pos, 0);
+
+  imageStore(image_out, pos, OP(in_texel, other_texel));
+}

--- a/backends/vulkan/test/glsl/fill_texture__test.glsl
+++ b/backends/vulkan/test/glsl/fill_texture__test.glsl
@@ -14,22 +14,23 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uInput;
-layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
-  ivec4 size;
-} uBlock;
+// clang-format off
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D uOutput;
+// clang-format on
+layout(set = 0, binding = 1) uniform PRECISION restrict Block {
+  ivec3 size;
+  int fill;
+  vec4 vals;
+} params;
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
 
-  if (all(lessThan(pos, uBlock.size.xyz))) {
-    const vec4 intex = texelFetch(uInput, pos, 0);
-    imageStore(
-        uOutput,
-        pos,
-        intex + 5);
+  if (any(greaterThanEqual(pos, params.size))) {
+    return;
   }
+
+  imageStore(uOutput, pos, params.vals);
 }

--- a/backends/vulkan/test/glsl/image_to_nchw__test.glsl
+++ b/backends/vulkan/test/glsl/image_to_nchw__test.glsl
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+// clang-format off
+#define PRECISION ${PRECISION}
+// clang-format on
+
+#include "indexing_utils.h"
+
+layout(std430) buffer;
+
+layout(set = 0, binding = 0) uniform PRECISION ${SAMPLER_T[NDIM][DTYPE]} image_in;
+layout(set = 0, binding = 1) buffer PRECISION restrict writeonly Buffer {
+  ${T[DTYPE]} data[];
+}
+buffer_out;
+
+layout(set = 0, binding = 2) uniform PRECISION restrict GpuSizes {
+  ivec4 data;
+}
+gpu_sizes;
+
+layout(set = 0, binding = 3) uniform PRECISION restrict CpuSizes {
+  ivec4 data;
+}
+cpu_sizes;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  const ivec4 coord = POS_TO_COORD_${PACKING}(pos, gpu_sizes.data);
+
+  if (any(greaterThanEqual(coord, gpu_sizes.data))) {
+    return;
+  }
+
+  const ${VEC4_T[DTYPE]} intex = texelFetch(image_in, pos, 0);
+
+  const int base_index = COORD_TO_BUFFER_IDX(coord, cpu_sizes.data);
+  const ivec4 buf_indices =
+      base_index + ivec4(0, 1, 2, 3) * (gpu_sizes.data.x * gpu_sizes.data.y);
+
+  if (coord.z < cpu_sizes.data.z) {
+    buffer_out.data[buf_indices.x] = intex.x;
+  }
+  if (coord.z + 1 < cpu_sizes.data.z) {
+    buffer_out.data[buf_indices.y] = intex.y;
+  }
+  if (coord.z + 2 < cpu_sizes.data.z) {
+    buffer_out.data[buf_indices.z] = intex.z;
+  }
+  if (coord.z + 3 < cpu_sizes.data.z) {
+    buffer_out.data[buf_indices.w] = intex.w;
+  }
+}

--- a/backends/vulkan/test/glsl/indexing_utils.h
+++ b/backends/vulkan/test/glsl/indexing_utils.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#define POS_TO_COORD_CHANNELS_PACKED(pos, sizes) \
+  ivec4(pos.x, pos.y, (pos.z * 4) % sizes.z, (pos.z * 4) / sizes.z)
+
+#define COORD_TO_BUFFER_IDX(coord, sizes)                  \
+  coord.x + coord.y* sizes.x + coord.z* sizes.y* sizes.x + \
+      coord.w* sizes.z* sizes.y* sizes.x;

--- a/backends/vulkan/test/glsl/nchw_to_image__test.glsl
+++ b/backends/vulkan/test/glsl/nchw_to_image__test.glsl
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+// clang-format off
+#define PRECISION ${PRECISION}
+// clang-format on
+
+#include "indexing_utils.h"
+
+layout(std430) buffer;
+
+// clang-format off
+layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly ${IMAGE_T[NDIM][DTYPE]} image_out;
+// clang-format on
+layout(set = 0, binding = 1) buffer  PRECISION restrict readonly Buffer {
+  ${T[DTYPE]} data[];
+}
+buffer_in;
+
+layout(set = 0, binding = 2) uniform PRECISION restrict GpuSizes {
+  ivec4 data;
+}
+gpu_sizes;
+
+layout(set = 0, binding = 3) uniform PRECISION restrict CpuSizes {
+  ivec4 data;
+}
+cpu_sizes;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  const ivec4 coord = POS_TO_COORD_${PACKING}(pos, gpu_sizes.data);
+
+  if (any(greaterThanEqual(coord, gpu_sizes.data))) {
+    return;
+  }
+
+  const int base_index = COORD_TO_BUFFER_IDX(coord, cpu_sizes.data);
+  const ivec4 buf_indices =
+      base_index + ivec4(0, 1, 2, 3) * (gpu_sizes.data.x * gpu_sizes.data.y);
+
+  ${T[DTYPE]} val_x = buffer_in.data[buf_indices.x];
+  ${T[DTYPE]} val_y = buffer_in.data[buf_indices.y];
+  ${T[DTYPE]} val_z = buffer_in.data[buf_indices.z];
+  ${T[DTYPE]} val_w = buffer_in.data[buf_indices.w];
+
+  ${VEC4_T[DTYPE]} texel = ${VEC4_T[DTYPE]}(val_x, val_y, val_z, val_w);
+
+  if (coord.z + 3 >= cpu_sizes.data.z) {
+    ivec4 c_ind = ivec4(coord.z) + ivec4(0, 1, 2, 3);
+    vec4 valid_c = vec4(lessThan(c_ind, ivec4(cpu_sizes.data.z)));
+    texel = texel * valid_c;
+  }
+
+  imageStore(image_out, ${GET_POS[NDIM]("pos")}, texel);
+}

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/test/utils/test_utils.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h>
+
+//
+// Operator Recording Functions
+//
+
+void record_nchw_to_buffer_op(
+    api::Context* const context,
+    api::VulkanBuffer& src_buffer,
+    vTensor& v_dst) {
+  uint32_t buf_len = api::utils::safe_downcast<uint32_t>(v_dst.gpu_numel());
+  api::utils::uvec3 global_size = {buf_len, 1u, 1u};
+  api::utils::uvec3 local_size = {32u, 1u, 1u};
+
+  api::UniformParamsBuffer cpu_buffer_metadata(
+      context, v_dst.get_cpu_buffer_metadata());
+  api::PipelineBarrier pipeline_barrier{};
+
+  context->submit_compute_job(
+      VK_KERNEL(buffer_to_buffer),
+      pipeline_barrier,
+      global_size,
+      local_size,
+      VK_NULL_HANDLE,
+      v_dst.buffer(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      v_dst.buffer_metadata(),
+      src_buffer,
+      cpu_buffer_metadata.buffer());
+}
+
+bool record_buffer_to_nchw_op(
+    api::Context* const context,
+    vTensor& v_src,
+    api::VulkanBuffer& dst_buffer) {
+  uint32_t buf_len = api::utils::safe_downcast<uint32_t>(v_src.numel());
+  api::utils::uvec3 global_size = {buf_len, 1u, 1u};
+  api::utils::uvec3 local_size = {4u, 1u, 1u};
+
+  api::UniformParamsBuffer cpu_buffer_metadata(
+      context, v_src.get_cpu_buffer_metadata());
+  api::PipelineBarrier pipeline_barrier{};
+
+  return context->submit_compute_job(
+      VK_KERNEL(buffer_to_buffer),
+      pipeline_barrier,
+      global_size,
+      local_size,
+      VK_NULL_HANDLE,
+      dst_buffer,
+      cpu_buffer_metadata.buffer(),
+      v_src.buffer(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      v_src.buffer_metadata());
+}
+
+void record_nchw_to_image_op(
+    api::Context* const context,
+    api::VulkanBuffer& src_buffer,
+    vTensor& v_dst) {
+  api::PipelineBarrier pipeline_barrier{};
+  api::ShaderInfo compute_shader =
+      VK_KERNEL(nchw_to_image3d__test_C_packed_half);
+  if (v_dst.image().format() == VK_FORMAT_R32G32B32A32_SFLOAT) {
+    compute_shader = VK_KERNEL(nchw_to_image3d__test_C_packed_float);
+  }
+  context->submit_compute_job(
+      compute_shader,
+      pipeline_barrier,
+      v_dst.virtual_extents(),
+      adaptive_work_group_size(v_dst.virtual_extents()),
+      VK_NULL_HANDLE,
+      v_dst.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      src_buffer,
+      v_dst.gpu_sizes_ubo()->buffer(),
+      v_dst.cpu_sizes_ubo()->buffer());
+}
+
+void record_image_to_nchw_op(
+    api::Context* const context,
+    vTensor& v_src,
+    api::VulkanBuffer& dst_buffer) {
+  api::ShaderInfo compute_shader =
+      VK_KERNEL(image3d_to_nchw__test_C_packed_half);
+  if (v_src.image().format() == VK_FORMAT_R32G32B32A32_SFLOAT) {
+    compute_shader = VK_KERNEL(image3d_to_nchw__test_C_packed_float);
+  }
+  api::PipelineBarrier pipeline_barrier{};
+  context->submit_compute_job(
+      compute_shader,
+      pipeline_barrier,
+      v_src.virtual_extents(),
+      adaptive_work_group_size(v_src.virtual_extents()),
+      VK_NULL_HANDLE,
+      v_src.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      dst_buffer,
+      v_src.gpu_sizes_ubo()->buffer(),
+      v_src.cpu_sizes_ubo()->buffer());
+}
+
+void record_arithmetic_op(
+    api::Context* const context,
+    const api::ShaderInfo& compute_shader,
+    vTensor& v_in1,
+    vTensor& v_in2,
+    vTensor& v_dst) {
+  api::PipelineBarrier pipeline_barrier{};
+  context->submit_compute_job(
+      compute_shader,
+      pipeline_barrier,
+      v_dst.virtual_extents(),
+      adaptive_work_group_size(v_dst.virtual_extents()),
+      VK_NULL_HANDLE,
+      v_dst.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      v_in1.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_in2.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_dst.extents_ubo()->buffer());
+}
+
+void execute_and_check_add(
+    vTensor& a,
+    vTensor& b,
+    vTensor& c,
+    float a_val,
+    float b_val) {
+  // Add shader kernel
+  api::ShaderInfo kernel = VK_KERNEL(binary_add_nobroadcast__test);
+
+  // Fill input tensors
+  fill_vtensor(a, a_val);
+  fill_vtensor(b, b_val);
+
+  // a + b = c
+  record_arithmetic_op(api::context(), kernel, a, b, c);
+
+  // Extract output tensor
+  std::vector<float> data_out = extract_vtensor(c);
+
+  // Check output
+  for (const auto& d : data_out) {
+    EXPECT_TRUE(d == (a_val + b_val));
+  }
+}
+
+//
+// Input & Output Utilities
+//
+
+void fill_vtensor(vTensor& vten, std::vector<float>& data) {
+  api::StorageBuffer staging_buffer(api::context(), api::kFloat, data.size());
+
+  copy_ptr_to_staging(data.data(), staging_buffer, vten.gpu_nbytes());
+
+  if (vten.storage_type() == api::StorageType::BUFFER) {
+    record_nchw_to_buffer_op(api::context(), staging_buffer.buffer(), vten);
+  } else {
+    record_nchw_to_image_op(api::context(), staging_buffer.buffer(), vten);
+  }
+}
+
+void fill_vtensor(ComputeGraph& graph, const IOValueRef idx, float val) {
+  std::vector<float> data(graph.get_val(idx.value).toTensor().gpu_numel());
+  std::fill(data.begin(), data.end(), val);
+
+  graph.copy_into_staging(idx.staging, data.data(), data.size());
+}
+
+void extract_vtensor(vTensor& vten, std::vector<float>& data) {
+  api::StorageBuffer staging_buffer(
+      api::context(), api::kFloat, vten.gpu_numel());
+
+  if (vten.storage_type() == api::StorageType::BUFFER) {
+    record_buffer_to_nchw_op(api::context(), vten, staging_buffer.buffer());
+  } else {
+    record_image_to_nchw_op(api::context(), vten, staging_buffer.buffer());
+  }
+
+  api::VulkanFence fence = api::context()->fences().get_fence();
+  api::context()->submit_cmd_to_gpu(fence.get_submit_handle());
+  fence.wait();
+
+  copy_staging_to_ptr(staging_buffer, data.data(), vten.gpu_nbytes());
+}
+
+//
+// Context Management
+//
+
+void submit_to_gpu() {
+  api::VulkanFence fence = api::context()->fences().get_fence();
+  api::context()->submit_cmd_to_gpu(fence.get_submit_handle());
+  fence.wait();
+}
+
+api::MemoryAllocation allocate_memory_for(const vTensor& vten) {
+  return api::context()->adapter_ptr()->vma().create_allocation(
+      vten.get_memory_requirements(), vten.get_allocation_create_info());
+}
+
+VmaTotalStatistics get_vma_stats() {
+  return api::context()->adapter_ptr()->vma().get_memory_statistics();
+}
+
+size_t get_vma_allocation_count() {
+  return get_vma_stats().total.statistics.allocationCount;
+}

--- a/backends/vulkan/test/utils/test_utils.h
+++ b/backends/vulkan/test/utils/test_utils.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <ATen/native/vulkan/api/api.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/StagingUtils.h>
+
+using namespace at::native::vulkan;
+
+#define CREATE_FLOAT_TEXTURE(sizes, allocate_memory) \
+  vTensor(                                           \
+      api::context(),                                \
+      sizes,                                         \
+      api::kFloat,                                   \
+      api::StorageType::TEXTURE_3D,                  \
+      api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED,  \
+      allocate_memory);
+
+#define CREATE_FLOAT_BUFFER(sizes, allocate_memory) \
+  vTensor(                                          \
+      api::context(),                               \
+      sizes,                                        \
+      api::kFloat,                                  \
+      api::StorageType::BUFFER,                     \
+      api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED, \
+      allocate_memory);
+
+#define DEFINE_STAGING_BUFFER_AND_RECORD_TO_GPU_FOR(tensor) \
+  api::StorageBuffer staging_buffer_##tensor(               \
+      api::context(), api::kFloat, tensor.gpu_numel());     \
+  record_nchw_to_image_op(                                  \
+      api::context(), staging_buffer_##tensor.buffer(), tensor);
+
+#define DEFINE_STAGING_BUFFER_AND_RECORD_FROM_GPU_FOR(tensor) \
+  api::StorageBuffer staging_buffer_##tensor(                 \
+      api::context(), api::kFloat, tensor.gpu_numel());       \
+  record_image_to_nchw_op(                                    \
+      api::context(), tensor, staging_buffer_##tensor.buffer());
+
+//
+// Operator Recording
+//
+
+void record_nchw_to_buffer_op(
+    api::Context* const context,
+    api::VulkanBuffer& src_buffer,
+    vTensor& v_dst);
+
+bool record_buffer_to_nchw_op(
+    api::Context* const context,
+    vTensor& v_src,
+    api::VulkanBuffer& dst_buffer);
+
+void record_nchw_to_image_op(
+    api::Context* const context,
+    api::VulkanBuffer& src_buffer,
+    vTensor& v_dst);
+
+void record_image_to_nchw_op(
+    api::Context* const context,
+    vTensor& v_src,
+    api::VulkanBuffer& dst_buffer);
+
+void record_arithmetic_op(
+    api::Context* const context,
+    const api::ShaderInfo& compute_shader,
+    vTensor& v_in1,
+    vTensor& v_in2,
+    vTensor& v_dst);
+
+void execute_and_check_add(
+    vTensor& a,
+    vTensor& b,
+    vTensor& c,
+    float a_val,
+    float b_val);
+
+//
+// Input & Output Utilities
+//
+
+inline void
+fill_staging(api::StorageBuffer& staging, float val, int numel = -1) {
+  if (numel < 0) {
+    numel = staging.numel();
+  }
+  std::vector<float> data(numel);
+  std::fill(data.begin(), data.end(), val);
+  copy_ptr_to_staging(data.data(), staging, sizeof(float) * numel);
+}
+
+void fill_vtensor(vTensor& vten, std::vector<float>& data);
+
+inline void fill_vtensor(vTensor& vten, float val) {
+  std::vector<float> vten_data(vten.gpu_numel());
+  std::fill(vten_data.begin(), vten_data.end(), val);
+
+  fill_vtensor(vten, vten_data);
+}
+
+void fill_vtensor(ComputeGraph& graph, const IOValueRef idx, float val);
+
+void extract_vtensor(vTensor& vten, std::vector<float>& data);
+
+inline std::vector<float> extract_vtensor(vTensor& vten) {
+  std::vector<float> data_out(vten.gpu_numel());
+  extract_vtensor(vten, data_out);
+  return data_out;
+}
+
+inline void
+check_staging_buffer(api::StorageBuffer& staging, float val, int numel = -1) {
+  if (numel < 0) {
+    numel = staging.numel();
+  }
+  std::vector<float> data(numel);
+  copy_staging_to_ptr(staging, data.data(), sizeof(float) * numel);
+
+  for (const auto& d : data) {
+    EXPECT_TRUE(d == val);
+  }
+}
+
+//
+// Context Management
+//
+
+void submit_to_gpu();
+
+api::MemoryAllocation allocate_memory_for(const vTensor& vten);
+
+VmaTotalStatistics get_vma_stats();
+
+size_t get_vma_allocation_count();


### PR DESCRIPTION
Summary:
## Context

This changeset lays the foundations for supporting dynamic shapes in the ExecuTorch Vulkan delegate via allowing Tensors to be resized in one of two ways:

1. Discarding underlying `vkImage` or `vkBuffer` and reallocating a new `vkImage` or `vkBuffer` with updated sizes. This method is intended to be used when the current `vkImage` or `vkBuffer` is not large enough to contain the new sizes.
2. Update the tensor's size metadata without reallocating any new resources. This allows shaders to interpret the underlying `vkImage` or `vkBuffer` as if it were smaller than it actually is, and allows command buffers to be preserved when sizes are changed.

Differential Revision: D54728401


