### PR TITLE
[CoreML Backend] Optimize memory when exporting.

### DIFF
--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
@@ -395,7 +395,7 @@ ETCoreMLAsset * _Nullable make_asset(NSURL *url,
     using namespace inmemoryfs;
     
     auto buffer = MemoryBuffer::make_unowned(const_cast<void *>(data.bytes), data.length);
-    std::unique_ptr<InMemoryFileSystem> inMemoryFS = inmemoryfs::make(buffer);
+    std::unique_ptr<InMemoryFileSystem> inMemoryFS = inmemoryfs::make_from_buffer(std::move(buffer));
     if (!inMemoryFS) {
         ETCoreMLLogErrorAndSetNSError(error,
                                       ETCoreMLErrorCorruptedModel,

--- a/backends/apple/coreml/runtime/delegate/backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/backend_delegate.mm
@@ -63,7 +63,7 @@ MLMultiArrayDataType get_data_type(MultiArray::DataType dataType) {
             return MLMultiArrayDataTypeFloat32;
         }
         case MultiArray::DataType::Double: {
-            return MLMultiArrayDataTypeFloat64;
+            return MLMultiArrayDataTypeDouble;
         }
         case MultiArray::DataType::Int: {
             return MLMultiArrayDataTypeInt32;

--- a/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
@@ -149,7 +149,7 @@ CoreMLBackendDelegate::init(BackendInitContext& context,
     ET_CHECK_OR_RETURN_ERROR(handle != nullptr,
                              InvalidProgram,
                              "%s: Failed to init the model.", ETCoreMLStrings.delegateIdentifier.UTF8String);
-    
+    processed->Free();
     return handle;
 }
 

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata.hpp
@@ -8,17 +8,17 @@
 #pragma once
 
 #include <memory_buffer.hpp>
-
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <range.hpp>
 
 namespace inmemoryfs {
 
 struct InMemoryNodeMetadata {
     std::string name;
     size_t kind;
-    MemoryRegion data_region;
+    Range data_region;
     std::unordered_map<std::string, size_t> child_name_to_indices_map;
 };
 

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata_keys.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata_keys.hpp
@@ -23,7 +23,7 @@ struct InMemoryFileSystemMetadataKeys {
     constexpr static std::string_view kNodes = "nodes";
 };
 
-struct MemoryRegionKeys {
+struct RangeKeys {
     constexpr static std::string_view kOffset = "offset";
     constexpr static std::string_view kSize = "size";
 };

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_py.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_py.cpp
@@ -5,15 +5,20 @@
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
-#include <memory>
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
-#include <string>
-#include <system_error>
 
 #include <inmemory_filesystem_utils.hpp>
+#include <iostream>
+#include <memory>
 #include <memory_buffer.hpp>
 #include <memory_stream.hpp>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <sstream>
+#include <string>
+#include <sys/mman.h>
+#include <system_error>
+#include <thread>
+#include <unistd.h>
 
 #if __has_include(<filesystem>)
 #include <filesystem>
@@ -25,6 +30,98 @@ namespace filesystem = std::experimental::filesystem;
 #endif
 
 namespace executorchcoreml {
+
+void* alloc_using_mmap(size_t size) {
+    return mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+}
+
+std::once_flag external_bytes_initialization_flag;
+static PyTypeObject PyExternalBytes_Type;
+
+static void external_bytes_free(void* ptr) {
+    printf("external_bytes_free called \n");
+    PyBytesObject* obj = (PyBytesObject*)ptr;
+    Py_ssize_t size = Py_SIZE(obj);
+    munmap(obj, size);
+}
+
+void intialize_external_bytes_type() {
+    std::call_once(external_bytes_initialization_flag, []() {
+        PyExternalBytes_Type = PyBytes_Type;
+        PyExternalBytes_Type.tp_free = external_bytes_free;
+    });
+}
+
+PyBytesObject* initialize_buffer_as_bytes_object(void* buffer, Py_ssize_t size) {
+    intialize_external_bytes_type();
+    PyBytesObject* obj = (PyBytesObject*)buffer;
+    PyObject_INIT_VAR(obj, &PyExternalBytes_Type, size);
+    obj->ob_sval[size] = '\0';
+
+    return obj;
+}
+
+/// The method allocates memory using `mmap` and then reads the contents of the all files in the directory. The file
+/// content is again memory mapped at fixed addresses in the allocated memory. The approach avoids dirtying the memory.
+/// The down side of this method is that it could result in a larger file when the bytes are dumped to disk.
+PyBytesObject* get_bytes_from_external_memory(const std::filesystem::path& dir_path) {
+    using namespace inmemoryfs;
+
+    std::error_code error;
+    std::stringstream ss;
+    auto fs = InMemoryFileSystem::make_from_directory(dir_path, InMemoryFileSystem::FileLoadOption::LazyMMap, error);
+    if (fs == nullptr) {
+        ss << "Failed to create InMemoryFileSystem because of error=" << error.message().c_str() << "\n";
+        PyErr_SetString(PyExc_RuntimeError, ss.str().c_str());
+        return nullptr;
+    }
+
+    size_t alignment = getpagesize();
+    size_t serialized_buffer_length = get_buffer_size_for_serialization(*fs, {}, alignment);
+    size_t py_bytes_obj_length = offsetof(PyBytesObject, ob_sval);
+    size_t py_bytes_obj_total_length = py_bytes_obj_length + serialized_buffer_length + 1;
+    void* backing_buffer = alloc_using_mmap(py_bytes_obj_total_length);
+    if (backing_buffer == NULL || (reinterpret_cast<int*>(backing_buffer) == MAP_FAILED)) {
+        ss << "Failed to allocate memory of size=" << py_bytes_obj_total_length / (1024 * 10224) << " mb.";
+        PyErr_SetString(PyExc_RuntimeError, ss.str().c_str());
+        return nullptr;
+    }
+
+    if (!serialize(*fs, {}, alignment, static_cast<uint8_t*>(backing_buffer) + py_bytes_obj_length, error)) {
+        ss << "Failed to serialize directory contents because of error=" << error.message().c_str() << ".";
+        PyErr_SetString(PyExc_RuntimeError, ss.str().c_str());
+        return nullptr;
+    }
+
+    PyBytesObject* bytes = initialize_buffer_as_bytes_object(backing_buffer, py_bytes_obj_total_length);
+    if (bytes == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to create bytes object.");
+        return nullptr;
+    }
+
+    return bytes;
+}
+
+/// The method writes to the memory managed by the python bytes object. The method dirties the memory and can be slow
+/// but results in a relatively smaller file when the bytes are dumped to disk.
+PyBytesObject* get_bytes(inmemoryfs::InMemoryFileSystem& fs, size_t length) {
+    using namespace inmemoryfs;
+
+    std::error_code error;
+    PyObject* bytes = PyBytes_FromStringAndSize(NULL, length);
+    void* data = static_cast<void*>(PyBytes_AsString(bytes));
+    if (!serialize(fs, {}, 1, data, error)) {
+        throw std::system_error(error.value(), error.category(), error.message());
+    }
+
+    return (PyBytesObject*)bytes;
+}
+
+bool is_large_model(size_t model_size_in_bytes) {
+    static constexpr size_t large_model_size_threshold = 1024 * 1024 * 1024; // 1 GB
+    return model_size_in_bytes > large_model_size_threshold;
+}
+
 /// Flattens the directory contents at the specified path.
 ///
 /// @param path  The directory path
@@ -33,21 +130,25 @@ pybind11::bytes flatten_directory_contents(const std::string& path) {
     using namespace inmemoryfs;
 
     std::filesystem::path fs_path(path);
-    std::error_code ec;
+    std::error_code error;
     auto canonical_path = std::filesystem::canonical(fs_path);
-    auto fs = InMemoryFileSystem::make(canonical_path, ec);
-    if (ec) {
-        throw std::system_error(ec.value(), ec.category(), ec.message());
+    std::stringstream ss;
+    auto fs = InMemoryFileSystem::make_from_directory(canonical_path, InMemoryFileSystem::FileLoadOption::MMap, error);
+    if (fs == nullptr) {
+        ss << "Failed to create InMemoryFileSystem because of error=" << error.message().c_str() << ".";
+        PyErr_SetString(PyExc_RuntimeError, ss.str().c_str());
+        return nullptr;
     }
 
-    size_t length = get_serialization_size(*fs, {}, 1);
-    auto bytes = PyBytes_FromStringAndSize(NULL, length);
-    void* data = static_cast<void*>(PyBytes_AsString(bytes));
-    auto buffer = MemoryBuffer::make_unowned(data, length);
-    auto memstream = MemoryOStream(buffer);
-    serialize(*fs, {}, 1, memstream);
+    size_t model_size_in_bytes = get_buffer_size_for_serialization(*fs, {}, 1);
+    PyBytesObject* bytes = nullptr;
+    if (is_large_model(model_size_in_bytes)) {
+        bytes = get_bytes_from_external_memory(canonical_path);
+    } else {
+        bytes = get_bytes(*fs, model_size_in_bytes);
+    }
 
-    return pybind11::reinterpret_steal<pybind11::bytes>((PyObject*)bytes);
+    return bytes == nullptr ? pybind11::none() : pybind11::reinterpret_steal<pybind11::object>((PyObject*)bytes);
 }
 
 } // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.hpp
@@ -18,28 +18,48 @@ namespace inmemoryfs {
 ///
 /// @param fs  The in-memory filesystem.
 /// @param canonical_path  The path components from the root.
-/// @param alignment  The offset alignment where an item is written to the stream.
+/// @param alignment  The alignment of the offset where an item is written to the stream.
 /// @param ostream   The output stream.
-void serialize(const InMemoryFileSystem& fs,
+/// @param error   On failure, error is populated with the failure reason.
+/// @retval `true` if the serialized bytes were written to `ostream` otherwise `false`.
+bool serialize(const InMemoryFileSystem& fs,
                const std::vector<std::string>& canonical_path,
                size_t alignment,
-               std::ostream& ostream) noexcept;
+               std::ostream& ostream,
+               std::error_code& error) noexcept;
+
+/// Serializes the item at the specified path and writes it to the stream.
+///
+/// The structure of the `InMemoryFileSystem` is identical to the structure of the filesystem at the
+/// specified path.
+///
+/// @param fs  The in-memory filesystem.
+/// @param canonical_path  The path components from the root.
+/// @param alignment  The alignment of the offset where an item is written to the stream.
+/// @param dst   The destination pointer, the buffer size must be >= the size returned by `get_buffer_size_for_serialization`.
+/// @param error   On failure, error is populated with the failure reason.
+/// @retval `true` if the serialized bytes were written to `ostream` otherwise `false`.
+bool serialize(const InMemoryFileSystem& fs,
+               const std::vector<std::string>& canonical_path,
+               size_t alignment,
+               void *dst,
+               std::error_code& error) noexcept;
 
 /// Computes the size of the buffer that would be needed to serialized the item at the specified path.
 ///
 /// @param fs  The in-memory filesystem.
 /// @param canonical_path  The path components from the root.
-/// @param alignment  The offset alignment where an item is written to the stream.
+/// @param alignment  The alignment of the offset where an item is written to the stream.
 /// @retval The size of the buffer that will be needed to write the item at the specified path.
-size_t get_serialization_size(const InMemoryFileSystem& fs,
-                              const std::vector<std::string>& canonical_path,
-                              size_t alignment) noexcept;
+size_t get_buffer_size_for_serialization(const InMemoryFileSystem& fs,
+                                         const std::vector<std::string>& canonical_path,
+                                         size_t alignment) noexcept;
 
 /// Constructs an `InMemoryFileSystem` instance from the buffer contents.
 ///
 /// @param buffer  The memory buffer.
 /// @retval The constructed `InMemoryFileSystem` or `nullptr` if the deserialization fail
-std::unique_ptr<InMemoryFileSystem> make(const std::shared_ptr<MemoryBuffer>& buffer) noexcept;
+std::unique_ptr<InMemoryFileSystem> make_from_buffer(const std::shared_ptr<MemoryBuffer>& buffer) noexcept;
 
 
 } // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.cpp
@@ -7,14 +7,34 @@
 
 #include <memory_buffer.hpp>
 
+#include <assert.h>
 #include <functional>
 #include <iostream>
+#include <mutex>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 namespace {
 using namespace inmemoryfs;
+
+using MMAP_HANDLE = std::unique_ptr<void, std::function<void(void*)>>;
+
+MMAP_HANDLE memory_map_file_range(FILE* file, Range range) {
+    auto ptr = mmap(nullptr, range.size, PROT_READ, MAP_PRIVATE, fileno(file), range.offset);
+    return MMAP_HANDLE(ptr, [size = range.size](void* bufferPtr) mutable { munmap(bufferPtr, size); });
+}
+
+MMAP_HANDLE alloc_using_mmap(size_t size) {
+    auto ptr = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    return MMAP_HANDLE(ptr, [size](void* bufferPtr) mutable { munmap(bufferPtr, size); });
+}
+
+void* memory_map_file_range_at_address(FILE* file, Range range, void* dst) {
+    return mmap(dst, range.size, PROT_READ, MAP_PRIVATE | MAP_FIXED, fileno(file), range.offset);
+}
 
 class MMappedBuffer : public MemoryBuffer {
 public:
@@ -31,25 +51,127 @@ private:
     const std::shared_ptr<void> buffer_;
 };
 
+class LazyMMappedBuffer : public MemoryBuffer {
+public:
+    explicit LazyMMappedBuffer(std::shared_ptr<FILE> file, Range range) noexcept
+        : MemoryBuffer(nullptr, range.size, MemoryBuffer::Kind::MMap), file_(std::move(file)), range_(range),
+          page_size_(getpagesize()) { }
+
+    LazyMMappedBuffer(const LazyMMappedBuffer&) = delete;
+    LazyMMappedBuffer& operator=(const LazyMMappedBuffer&) = delete;
+
+    bool load(std::error_code& error) noexcept override {
+        std::lock_guard<std::mutex> guard(mutex_);
+        if (memory_mapped_data_ != nullptr) {
+            return true;
+        }
+        auto ptr = memory_map_file_range(file_.get(), range_);
+        if (!ptr || (reinterpret_cast<int*>(ptr.get()) == MAP_FAILED)) {
+            error = std::error_code(errno, std::system_category());
+            return false;
+        }
+
+        memory_mapped_data_ = std::move(ptr);
+        return true;
+    }
+
+    void* data() noexcept override {
+        std::error_code ec;
+        assert(load(ec) == true);
+        return memory_mapped_data_.get();
+    }
+
+    std::pair<size_t, size_t> get_offset_range(size_t proposed_offset) const noexcept override {
+        return { proposed_offset, proposed_offset + page_size_ - 1 };
+    }
+
+    Range get_revised_range_for_writing(void* dst, Range proposed_range) const noexcept override {
+        uint8_t* ptr = static_cast<uint8_t*>(dst) + proposed_range.offset;
+        size_t alignment = page_size_;
+        uintptr_t addr = (uintptr_t)ptr;
+        if (addr % alignment == 0) {
+            return proposed_range;
+        }
+
+        uintptr_t mask = alignment - 1;
+        uintptr_t aligned_addr = (addr + mask) & ~mask;
+        assert(aligned_addr >= addr);
+        return Range(proposed_range.offset + (aligned_addr - addr), proposed_range.size);
+    }
+
+    bool write(void* dst, size_t offset, std::error_code& error) noexcept override {
+        uint8_t* ptr = static_cast<uint8_t*>(dst) + offset;
+        size_t alignment = page_size_;
+        uintptr_t addr = (uintptr_t)ptr;
+        if (addr % alignment != 0) {
+            error = std::error_code(EFAULT, std::system_category());
+            return false;
+        }
+
+        auto mmapped_ptr = memory_map_file_range_at_address(file_.get(), range_, ptr);
+        if (!mmapped_ptr || (reinterpret_cast<int*>(mmapped_ptr) == MAP_FAILED)) {
+            error = std::error_code(errno, std::system_category());
+            return false;
+        }
+
+        return true;
+    }
+
+    std::shared_ptr<MemoryBuffer> slice(Range range) noexcept override {
+        if (range.length() > size()) {
+            return nullptr;
+        }
+
+        return std::make_shared<LazyMMappedBuffer>(file_, range);
+    }
+
+    ~LazyMMappedBuffer() { }
+
+private:
+    std::shared_ptr<FILE> file_;
+    Range range_;
+    size_t page_size_;
+    std::unique_ptr<void, std::function<void(void*)>> memory_mapped_data_;
+    std::mutex mutex_;
+};
+
 class MallocedBuffer : public MemoryBuffer {
 public:
+    enum class Ownership : uint8_t { Unowned, Owned };
+
+    explicit MallocedBuffer(void* data, size_t size, Ownership ownership) noexcept
+        : MemoryBuffer(data, size, MemoryBuffer::Kind::Malloc), ownership_(ownership) { }
+
     explicit MallocedBuffer(std::vector<uint8_t> buffer) noexcept
-        : MemoryBuffer(buffer.data(), buffer.size(), MemoryBuffer::Kind::Malloc), buffer_(std::move(buffer)) { }
+        : MemoryBuffer(buffer.data(), buffer.size(), MemoryBuffer::Kind::Malloc), buffer_(std::move(buffer)),
+          ownership_(Ownership::Owned) { }
 
     MallocedBuffer(const MallocedBuffer&) = delete;
     MallocedBuffer& operator=(const MallocedBuffer&) = delete;
 
-    ~MallocedBuffer() { }
+    ~MallocedBuffer() {
+        if (buffer_.size() > 0) {
+            return;
+        }
+
+        if (!data()) {
+            return;
+        }
+
+        switch (ownership_) {
+            case Ownership::Owned:
+                free(data());
+                break;
+
+            default:
+                break;
+        }
+    }
 
 private:
-    const std::vector<uint8_t> buffer_;
+    std::vector<uint8_t> buffer_;
+    Ownership ownership_;
 };
-
-std::unique_ptr<void, std::function<void(void*)>> mmap_file_region(FILE* file, MemoryRegion region) {
-    auto ptr = mmap(nullptr, region.size, PROT_READ, MAP_PRIVATE, fileno(file), region.offset);
-    return std::unique_ptr<void, std::function<void(void*)>>(
-        ptr, [size = region.size](void* bufferPtr) mutable { munmap(bufferPtr, size); });
-}
 
 size_t get_file_length(const std::string& file_path, std::error_code& error) {
     struct stat fileInfo;
@@ -64,32 +186,35 @@ size_t get_file_length(const std::string& file_path, std::error_code& error) {
 std::unique_ptr<FILE, decltype(&fclose)> open_file(const std::string& file_path, std::error_code& error) {
     std::unique_ptr<FILE, decltype(&fclose)> file(fopen(file_path.c_str(), "rb"), fclose);
     if (!file) {
-        error = std::error_code(errno, std::generic_category());
+        error = std::error_code(errno, std::system_category());
     }
     return file;
 }
 
-std::unique_ptr<MemoryBuffer> mmap_buffer_from_file(FILE* file, MemoryRegion region, std::error_code& error) {
-    error.clear();
-    auto ptr = mmap_file_region(file, region);
+std::unique_ptr<MemoryBuffer> mmap_buffer_from_file(FILE* file, Range range, std::error_code& error) {
+    auto ptr = memory_map_file_range(file, range);
     if (!ptr || (reinterpret_cast<int*>(ptr.get()) == MAP_FAILED)) {
         error = std::error_code(errno, std::generic_category());
         return {};
     }
 
-    return std::make_unique<MMappedBuffer>(std::move(ptr), region.size);
+    return std::make_unique<MMappedBuffer>(std::move(ptr), range.size);
 }
 
-std::unique_ptr<MemoryBuffer> malloced_buffer_from_file(FILE* file, MemoryRegion region, std::error_code& error) {
-    error.clear();
-    size_t offset = region.offset;
+std::unique_ptr<MemoryBuffer>
+mmap_buffer_lazy_from_file(std::unique_ptr<FILE, decltype(&fclose)> file, Range range, std::error_code& error) {
+    return std::make_unique<LazyMMappedBuffer>(std::move(file), range);
+}
+
+std::unique_ptr<MemoryBuffer> malloced_buffer_from_file(FILE* file, Range range, std::error_code& error) {
+    size_t offset = range.offset;
     if (std::fseek(file, offset, SEEK_SET) != 0) {
         error = std::error_code(errno, std::generic_category());
         return nullptr;
     }
 
-    std::vector<uint8_t> buffer(region.size, 0);
-    if (std::fread(buffer.data(), 1, buffer.size(), file) != region.size) {
+    std::vector<uint8_t> buffer(range.size, 0);
+    if (std::fread(buffer.data(), 1, buffer.size(), file) != range.size) {
         error = std::error_code(errno, std::generic_category());
         return nullptr;
     }
@@ -97,40 +222,45 @@ std::unique_ptr<MemoryBuffer> malloced_buffer_from_file(FILE* file, MemoryRegion
     return std::make_unique<MallocedBuffer>(std::move(buffer));
 }
 
-std::unique_ptr<MemoryBuffer>
-read_file_content(FILE* file, MemoryRegion region, MMappedBuffer::ReadOption option, std::error_code& error) {
+std::unique_ptr<MemoryBuffer> read_file_content(std::unique_ptr<FILE, decltype(&fclose)> file,
+                                                Range range,
+                                                MMappedBuffer::ReadOption option,
+                                                std::error_code& error) {
     switch (option) {
         case MemoryBuffer::ReadOption::MMap: {
-            return mmap_buffer_from_file(file, region, error);
+            return ::mmap_buffer_from_file(file.get(), range, error);
+        }
+
+        case MemoryBuffer::ReadOption::LazyMMap: {
+            return ::mmap_buffer_lazy_from_file(std::move(file), range, error);
         }
 
         case MemoryBuffer::ReadOption::Malloc: {
-            return malloced_buffer_from_file(file, region, error);
-        }
-
-        case MemoryBuffer::ReadOption::Any: {
-            auto buffer = mmap_buffer_from_file(file, region, error);
-            if (!buffer) {
-                buffer = malloced_buffer_from_file(file, region, error);
-            }
-            return buffer;
+            return ::malloced_buffer_from_file(file.get(), range, error);
         }
     }
 }
+
 } // namespace
 
 namespace inmemoryfs {
-std::shared_ptr<MemoryBuffer> MemoryBuffer::slice(MemoryRegion region) noexcept {
-    if (region.get_length() > size()) {
+bool MemoryBuffer::write(void* dst, size_t offset, std::error_code& error) noexcept {
+    auto ptr = static_cast<uint8_t*>(dst);
+    std::memcpy(ptr + offset, data(), size());
+    return true;
+}
+
+std::shared_ptr<MemoryBuffer> MemoryBuffer::slice(Range range) noexcept {
+    if (range.length() > size()) {
         return nullptr;
     }
 
-    auto start = static_cast<void*>(static_cast<uint8_t*>(data()) + region.offset);
-    return std::make_shared<MemoryBuffer>(start, region.size, kind(), shared_from_this());
+    auto start = static_cast<void*>(static_cast<uint8_t*>(data()) + range.offset);
+    return std::make_shared<MemoryBuffer>(start, range.size, kind(), shared_from_this());
 }
 
 std::vector<std::shared_ptr<MemoryBuffer>> MemoryBuffer::read_file_content(const std::string& file_path,
-                                                                           const std::vector<MemoryRegion>& regions,
+                                                                           const std::vector<Range>& ranges,
                                                                            ReadOption option,
                                                                            std::error_code& error) {
     auto file = open_file(file_path, error);
@@ -139,12 +269,13 @@ std::vector<std::shared_ptr<MemoryBuffer>> MemoryBuffer::read_file_content(const
     }
 
     std::vector<std::shared_ptr<MemoryBuffer>> result;
-    result.reserve(regions.size());
-    for (const auto& region: regions) {
-        auto buffer = ::read_file_content(file.get(), region, option, error);
+    result.reserve(ranges.size());
+    for (const auto& range: ranges) {
+        auto buffer = ::read_file_content(std::move(file), range, option, error);
         if (!buffer) {
             return {};
         }
+
         result.emplace_back(std::move(buffer));
     }
 
@@ -163,23 +294,40 @@ MemoryBuffer::read_file_content(const std::string& file_path, ReadOption option,
         return {};
     }
 
-    auto buffer = ::read_file_content(file.get(), MemoryRegion(0, length), option, error);
+    auto buffer = ::read_file_content(std::move(file), Range(0, length), option, error);
     return buffer;
 }
 
-std::shared_ptr<MemoryBuffer> MemoryBuffer::make(const void* data, size_t size) {
-    std::vector<uint8_t> bytes;
-    bytes.resize(size);
-    std::memcpy(bytes.data(), data, size);
-    return std::make_unique<MallocedBuffer>(std::move(bytes));
+std::unique_ptr<MemoryBuffer> MemoryBuffer::make_using_malloc(size_t size, size_t alignment) {
+    void* data = nullptr;
+    if (alignment > 1) {
+        assert(size % alignment == 0);
+        data = aligned_alloc(alignment, size);
+    } else {
+        data = malloc(size);
+    }
+
+    return std::make_unique<MallocedBuffer>(data, size, MallocedBuffer::Ownership::Owned);
 }
 
-std::shared_ptr<MemoryBuffer> MemoryBuffer::make(std::vector<uint8_t> bytes) {
-    return std::make_unique<MallocedBuffer>(std::move(bytes));
+std::unique_ptr<MemoryBuffer> MemoryBuffer::make_using_mmap(size_t size) {
+    auto ptr = alloc_using_mmap(size);
+    if (!ptr || (reinterpret_cast<int*>(ptr.get()) == MAP_FAILED)) {
+        return nullptr;
+    }
+
+    return std::make_unique<MMappedBuffer>(std::move(ptr), size);
 }
 
-std::shared_ptr<MemoryBuffer> MemoryBuffer::make_unowned(void* data, size_t size) {
-    return std::make_unique<MemoryBuffer>(data, size);
+std::unique_ptr<MemoryBuffer> MemoryBuffer::make_unowned(void* data, size_t size) {
+    return std::make_unique<MallocedBuffer>(data, size, MallocedBuffer::Ownership::Unowned);
+}
+
+std::unique_ptr<MemoryBuffer> MemoryBuffer::make_copy(void* data, size_t size) {
+    std::vector<uint8_t> buffer;
+    buffer.resize(size);
+    std::memcpy(buffer.data(), data, size);
+    return std::make_unique<MallocedBuffer>(std::move(buffer));
 }
 
 } // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
@@ -7,34 +7,14 @@
 
 #pragma once
 
+#include <memory>
+#include <range.hpp>
 #include <stdio.h>
 #include <string>
-#include <memory>
+#include <system_error>
 #include <vector>
 
-#include <system_error>
-
 namespace inmemoryfs {
-
-/// A struct representing a memory region.
-struct MemoryRegion {
-    inline MemoryRegion(size_t offset, size_t size) noexcept:
-    offset(offset), size(size)
-    {}
-    
-    inline MemoryRegion() noexcept:
-    offset(0), size(0)
-    {}
-    
-    /// Returns the length of the region.
-    inline size_t get_length() const noexcept {
-        return offset + size;
-    }
-    
-    size_t offset = 0;
-    size_t size = 0;
-};
-
 /// A class representing a memory buffer.
 class MemoryBuffer: public std::enable_shared_from_this<MemoryBuffer> {
 public:
@@ -45,16 +25,19 @@ public:
     };
     
     enum class ReadOption: uint8_t {
-        MMap = 0,
-        Malloc,
-        Any
+        Malloc = 0,
+        MMap,
+        LazyMMap
     };
     
     inline MemoryBuffer(void *data,
                         size_t size,
                         Kind kind = Kind::Malloc,
                         std::shared_ptr<MemoryBuffer> parent = nullptr) noexcept:
-    data_(data), size_(size), kind_(kind), parent_(parent)
+    data_(data), 
+    size_(size),
+    kind_(kind),
+    parent_(parent)
     {}
     
     MemoryBuffer(const MemoryBuffer &) = delete;
@@ -63,7 +46,7 @@ public:
     virtual ~MemoryBuffer() noexcept {}
     
     /// Returns the underlying data.
-    inline void *data() const noexcept {
+    virtual inline void *data() noexcept {
         return data_;
     }
     
@@ -72,27 +55,65 @@ public:
         return size_;
     }
     
+    /// Loads the contents of the buffer.
+    ///
+    /// - For a malloced buffer, the method is a no op, content is loaded at the initialization time.
+    /// - For a memory mapped buffer, the method can result in memory mapping the contents of the backed file.
+    ///
+    /// @param error  On failure, error is populated with the failure reason.
+    /// @retval `true` if the copy succeeded otherwise `false`.
+    inline virtual bool load(std::error_code& error) noexcept {
+        return true;
+    }
+    
     /// Returns the kind of the buffer.
     inline const Kind kind() const noexcept {
         return kind_;
     }
     
+    /// Returns the offset range that would be used when writing the buffer content.
+    ///
+    /// @param proposed_offset The proposed offset.
+    /// @retval The  offset range that would be used when writing the buffer content.
+    inline virtual std::pair<size_t, size_t> get_offset_range(size_t proposed_offset) const noexcept {
+        return {proposed_offset, proposed_offset};
+    }
+    
+    /// Returns the revised range that must be used for writing.
+    ///
+    /// @param dst  The destination pointer.
+    /// @param proposed_range The proposed offset and size for writing the buffer content.
+    /// @retval The revised offset and size that must be used to write the buffer content.
+    inline virtual Range get_revised_range_for_writing(void *dst, Range proposed_range) const noexcept {
+        return proposed_range;
+    }
+    
+    /// Writes the contents of the buffer to the destination buffer at the given offset.
+    ///
+    /// @param dst The destination pointer.
+    /// @param offset The offset.
+    /// @param error  On failure, error is populated with the failure reason.
+    /// @retval `true` if the write succeeded otherwise `false`.
+    virtual bool write(void *dst,
+                       size_t offset,
+                       std::error_code& error) noexcept;
+    
     /// Slices a buffer.
     ///
-    /// @param region The memory region.
+    /// @param range The memory range.
     /// @retval The sliced buffer if the region is inside the buffer otherwise `nullptr`.
-    virtual std::shared_ptr<MemoryBuffer> slice(MemoryRegion region) noexcept;
+    virtual std::shared_ptr<MemoryBuffer> slice(Range range) noexcept;
     
     /// Reads the file content at the specified path.
     ///
     /// @param file_path The file path.
-    /// @param regions The regions to be read.
+    /// @param ranges The ranges to be read.
     /// @param option The read option.
-    /// @param error   On failure, error is populated with the failure reason.
+    /// @param error  On failure, error is populated with the failure reason.
     /// @retval The read buffers or an empty vector if the read failed.
     static std::vector<std::shared_ptr<MemoryBuffer>>
     read_file_content(const std::string& file_path,
-                      const std::vector<MemoryRegion>& regions,
+                      const std::vector<Range>& ranges,
                       ReadOption option,
                       std::error_code& error);
     
@@ -107,26 +128,33 @@ public:
                       ReadOption option,
                       std::error_code& error);
     
-    /// Constructs a `MemoryBuffer` by copying data.
+    /// Constructs a `MemoryBuffer`.
     ///
-    /// @param data The data pointer.
     /// @param size The size of the buffer.
-    static std::shared_ptr<MemoryBuffer>
-    make(const void *data, size_t size);
+    /// @param alignment The address alignment.
+    static std::unique_ptr<MemoryBuffer>
+    make_using_malloc(size_t size, size_t alignment = 1);
     
-    /// Constructs a `MemoryBuffer` from a bytes vector.
+    
+    /// Constructs a `MemoryBuffer` from memory allocated using `mmap`.
     ///
-    /// @param bytes A bytes vector.
-    static std::shared_ptr<MemoryBuffer>
-    make(std::vector<uint8_t> bytes);
+    /// @param size The size of the buffer.
+    static std::unique_ptr<MemoryBuffer>
+    make_using_mmap(size_t size);
     
     /// Constructs a `MemoryBuffer` without copying data.
     ///
-    /// @param data The data pointer.
+    /// @param data The buffer content.
     /// @param size The size of the buffer.
-    static std::shared_ptr<MemoryBuffer>
+    static std::unique_ptr<MemoryBuffer>
     make_unowned(void *data, size_t size);
     
+    /// Constructs a `MemoryBuffer` with copying data.
+    ///
+    /// @param data The buffer content.
+    /// @param size The size of the buffer.
+    static std::unique_ptr<MemoryBuffer>
+    make_copy(void *data, size_t size);
 private:
     void *data_;
     const size_t size_;

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_stream.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_stream.cpp
@@ -5,7 +5,7 @@
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
-#include <memory_stream.hpp>
+#include "memory_stream.hpp"
 
 namespace inmemoryfs {
 

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_stream.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_stream.hpp
@@ -1,6 +1,5 @@
 //
-//  Stream.hpp
-//  inmemoryfs
+// memory_stream.hpp
 //
 // Copyright © 2024 Apple Inc. All rights reserved.
 //

--- a/backends/apple/coreml/runtime/inmemoryfs/range.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/range.hpp
@@ -1,0 +1,27 @@
+//
+//  range.hpp
+//
+// Copyright © 2023 Apple Inc. All rights reserved.
+
+#pragma once
+
+namespace inmemoryfs {
+/// A struct representing a memory region.
+struct Range {
+    inline Range(size_t offset, size_t size) noexcept:
+    offset(offset), size(size)
+    {}
+    
+    inline Range() noexcept:
+    offset(0), size(0)
+    {}
+    
+    /// Returns the length of the region.
+    inline size_t length() const noexcept {
+        return offset + size;
+    }
+    
+    size_t offset = 0;
+    size_t size = 0;
+};
+} // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.cpp
@@ -5,7 +5,7 @@
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
-#include <reversed_memory_stream.hpp>
+#include "reversed_memory_stream.hpp"
 
 namespace inmemoryfs {
 
@@ -111,5 +111,4 @@ ReversedIMemoryStream::ReversedIMemoryStream(const std::shared_ptr<MemoryBuffer>
     : std::istream(nullptr), streambuf(buffer) {
     rdbuf(&streambuf);
 }
-
 } // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.hpp
@@ -1,5 +1,5 @@
 //
-// Stream.hpp
+// reversed_memory_stream.hpp
 //
 // Copyright © 2024 Apple Inc. All rights reserved.
 //

--- a/backends/apple/coreml/runtime/test/ETCoreMLTestUtils.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLTestUtils.mm
@@ -243,8 +243,8 @@ ETCoreMLAsset * _Nullable make_asset(NSURL *url,
                                          dstURL:(NSURL *)dstURL
                                     fileManager:(NSFileManager *)fileManager
                                           error:(NSError * __autoreleasing *)error {
-    auto buffer = inmemoryfs::MemoryBuffer::make_unowned(const_cast<void *>(data.bytes), data.length);
-    std::unique_ptr<inmemoryfs::InMemoryFileSystem> inMemoryFS = inmemoryfs::make(buffer);
+    std::shared_ptr<inmemoryfs::MemoryBuffer> buffer = inmemoryfs::MemoryBuffer::make_unowned(const_cast<void *>(data.bytes), data.length);
+    std::unique_ptr<inmemoryfs::InMemoryFileSystem> inMemoryFS = inmemoryfs::make_from_buffer(buffer);
     if (!inMemoryFS) {
         ETCoreMLLogErrorAndSetNSError(error,
                                       ETCoreMLErrorCorruptedModel,

--- a/backends/apple/coreml/runtime/test/InMemoryFileSystemTests.mm
+++ b/backends/apple/coreml/runtime/test/InMemoryFileSystemTests.mm
@@ -57,7 +57,7 @@ std::shared_ptr<MemoryBuffer> to_memory_buffer(const T& value) {
     to_json(j, value);
     ss << j;
     auto text = ss.str();
-    return MemoryBuffer::make(static_cast<void *>(text.data()), text.size());
+    return MemoryBuffer::make_copy(static_cast<void *>(text.data()), text.size());
 }
 
 template <typename T>
@@ -70,6 +70,26 @@ T from_memory_buffer(const std::shared_ptr<MemoryBuffer>& buffer) {
     return result;
 }
 
+std::string generate_random_string(size_t length) {
+    static const char chars[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+    std::string result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; ++i) {
+        result += chars[rand() % (sizeof(chars) - 1)];
+    }
+    
+    return result;
+}
+
+struct SerdeVerificationConfig {
+    InMemoryFileSystem::FileLoadOption file_load_option;
+    size_t alignment;
+    size_t n_files;
+    size_t file_base_length;
+};
 }
 
 @interface InMemoryFileSystemTests : XCTestCase
@@ -203,7 +223,9 @@ using namespace inmemoryfs;
     
     std::filesystem::path dirPath(dirURL.path.UTF8String);
     std::error_code error;
-    auto fs = InMemoryFileSystem::make(dirPath, error);
+    auto fs = InMemoryFileSystem::make_from_directory(dirPath,
+                                                      InMemoryFileSystem::FileLoadOption::Malloc,
+                                                      error);
     XCTAssertTrue(fs->is_directory({"dir1"}));
     XCTAssertTrue(fs->is_file({"dir1", "content.json"}));
     XCTAssertTrue(fs->is_directory({"dir2"}));
@@ -211,34 +233,108 @@ using namespace inmemoryfs;
     XCTAssertTrue([fm removeItemAtURL:dirURL error:&localError]);
 }
 
-- (void)testSerdes {
+- (void)_testSerdeWithConfig:(SerdeVerificationConfig)config {
+    NSURL *dirURL = [[NSURL fileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSError *localError = nil;
+    XCTAssertTrue([fm createDirectoryAtURL:dirURL withIntermediateDirectories:NO attributes:@{} error:&localError]);
+
+    // Create content.
     std::error_code error;
-    std::shared_ptr<MemoryBuffer> serializedBuffer = nullptr;
-    Content content1("id1", "value1");
-    Content content2("id2", "value2");
+    std::vector<Content> fileContents;
+    fileContents.reserve(config.n_files);
     {
         auto fs = InMemoryFileSystem("test");
-        XCTAssertTrue(fs.make_directory({"dir1"}, InMemoryFileSystem::Attributes(), false, error));
-        std::shared_ptr<MemoryBuffer> buffer1 = to_memory_buffer(content1);
-        XCTAssertTrue(fs.make_file({"dir1", "content.json"}, buffer1, InMemoryFileSystem::Attributes(), false /*overwrite*/, error));
-        XCTAssertTrue(fs.make_directory({"dir2"}, InMemoryFileSystem::Attributes(), false, error));
-        std::shared_ptr<MemoryBuffer> buffer2 = to_memory_buffer(content2);
-        XCTAssertTrue(fs.make_file({"dir2", "content.json"}, buffer2, InMemoryFileSystem::Attributes(), false /*overwrite*/, error));
-        size_t length = inmemoryfs::get_serialization_size(fs, {}, 1);
-        std::vector<uint8_t> bytes;
-        bytes.resize(length);
-        serializedBuffer = MemoryBuffer::make(std::move(bytes));
-        auto memstream = MemoryOStream(serializedBuffer);
-        inmemoryfs::serialize(fs, {}, 1, memstream);
+        XCTAssertTrue(fs.make_directory({"dir"}, InMemoryFileSystem::Attributes(), false, error));
+        for (NSUInteger i = 0; i < config.n_files; i++) {
+            std::string name = "file_";
+            name.append(std::to_string(i));
+            Content content(name, generate_random_string(config.file_base_length * (i + 1)));
+            std::shared_ptr<MemoryBuffer> buffer = to_memory_buffer(content);
+            XCTAssertTrue(fs.make_file({"dir", name}, buffer, InMemoryFileSystem::Attributes(), false /*overwrite*/, error));
+            fileContents.emplace_back(std::move(content));
+        }
+        XCTAssertTrue(fs.write_item_to_disk({}, dirURL.path.UTF8String, true, error));
     }
     
+    // Verify serialization.
+    std::shared_ptr<MemoryBuffer> buffer = nullptr;
     {
         std::error_code error;
-        auto fs = inmemoryfs::make(serializedBuffer);
-        XCTAssertTrue(fs->is_directory({"dir1"}));
-        XCTAssertTrue(fs->is_directory({"dir2"}));
-        XCTAssertEqual(from_memory_buffer<Content>(fs->get_file_content({"dir1", "content.json"}, error)), content1);
-        XCTAssertEqual(from_memory_buffer<Content>(fs->get_file_content({"dir2", "content.json"}, error)), content2);
+        auto fs = InMemoryFileSystem::make_from_directory(dirURL.path.UTF8String,
+                                                          config.file_load_option,
+                                                          error);
+    
+        XCTAssertTrue(fs != nullptr);
+        size_t length = inmemoryfs::get_buffer_size_for_serialization(*fs, {}, config.alignment);
+        switch (config.file_load_option) {
+            case InMemoryFileSystem::FileLoadOption::LazyMMap: {
+                buffer = MemoryBuffer::make_using_mmap(length);
+                break;
+            }
+                
+            default:
+                buffer = MemoryBuffer::make_using_malloc(length);
+                break;
+        }
+        
+        XCTAssertTrue(inmemoryfs::serialize(*fs, {}, config.alignment, buffer->data(), error));
+    }
+    
+    // Verify de-serialization.
+    {
+        auto fs = inmemoryfs::make_from_buffer(buffer);
+        XCTAssertTrue(fs != nullptr);
+        XCTAssertTrue(fs->is_directory({"test", "dir"}));
+        for (const auto& content : fileContents) {
+            XCTAssertEqual(from_memory_buffer<Content>(fs->get_file_content({"test", "dir", content.identifier}, error)), content);
+        }
+    }
+    
+    [fm removeItemAtURL:dirURL error:nil];
+}
+
+- (void)testSerde {
+    std::vector<SerdeVerificationConfig> configs;
+    configs.emplace_back(SerdeVerificationConfig {
+        .file_load_option = InMemoryFileSystem::FileLoadOption::Malloc,
+        .n_files = 5,
+        .file_base_length = 100,
+        .alignment = 1,
+    });
+    configs.emplace_back(SerdeVerificationConfig {
+        .file_load_option = InMemoryFileSystem::FileLoadOption::Malloc,
+        .n_files = 5,
+        .file_base_length = 100,
+        .alignment = 64,
+    });
+    configs.emplace_back(SerdeVerificationConfig {
+        .file_load_option = InMemoryFileSystem::FileLoadOption::MMap,
+        .n_files = 5,
+        .file_base_length = 100,
+        .alignment = 1,
+    });
+    configs.emplace_back(SerdeVerificationConfig {
+        .file_load_option = InMemoryFileSystem::FileLoadOption::MMap,
+        .n_files = 5,
+        .file_base_length = 100,
+        .alignment = 64,
+    });
+    configs.emplace_back(SerdeVerificationConfig {
+        .file_load_option = InMemoryFileSystem::FileLoadOption::LazyMMap,
+        .n_files = 5,
+        .file_base_length = 100,
+        .alignment = (size_t)getpagesize(),
+    });
+    configs.emplace_back(SerdeVerificationConfig {
+        .file_load_option = InMemoryFileSystem::FileLoadOption::LazyMMap,
+        .n_files = 5,
+        .file_base_length = 100,
+        .alignment = 2 * (size_t)getpagesize(),
+    });
+   
+    for (const auto& config : configs) {
+        [self _testSerdeWithConfig:config];
     }
 }
 

--- a/backends/apple/coreml/runtime/util/json_util.cpp
+++ b/backends/apple/coreml/runtime/util/json_util.cpp
@@ -71,8 +71,12 @@ std::optional<std::string> read_object_from_stream(std::istream& stream, size_t 
     static constexpr size_t buffer_size = 512;
     JSONParseState state;
     char ch;
+    // Ignore 0, 0 is added for padding.
+    do {
+        stream >> ch;
+    } while (stream.good() && static_cast<uint8_t>(ch) == 0);
     // The first character must be an opening brace.
-    if (!(stream >> ch) || ch != '{') {
+    if (ch != '{') {
         return std::optional<std::string>();
     }
     state.json_object += ch;

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
@@ -260,6 +260,7 @@
 		C998838E2B96999F000953A3 /* ETCoreMLModelProfilerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelProfilerTests.mm; path = ../test/ETCoreMLModelProfilerTests.mm; sourceTree = "<group>"; };
 		C99883902B96BEED000953A3 /* ETCoreMLModelCompiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelCompiler.h; path = ../delegate/ETCoreMLModelCompiler.h; sourceTree = "<group>"; };
 		C99883912B96BEED000953A3 /* ETCoreMLModelCompiler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelCompiler.mm; path = ../delegate/ETCoreMLModelCompiler.mm; sourceTree = "<group>"; };
+		C988D6FB2B9BA94000979CF6 /* range.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = range.hpp; path = ../inmemoryfs/range.hpp; sourceTree = "<group>"; };
 		C9D3DED52A9FCFC4001CC178 /* ETCoreMLAssetManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLAssetManager.mm; path = ../delegate/ETCoreMLAssetManager.mm; sourceTree = "<group>"; };
 		C9D3DED62A9FCFC4001CC178 /* ETCoreMLAssetManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLAssetManager.h; path = ../delegate/ETCoreMLAssetManager.h; sourceTree = "<group>"; };
 		C9D3DF002A9FD16E001CC178 /* statement.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = statement.hpp; path = ../kvstore/statement.hpp; sourceTree = "<group>"; };
@@ -485,6 +486,7 @@
 		C952663F2A7E065F0016283E /* inmemoryfs */ = {
 			isa = PBXGroup;
 			children = (
+				C988D6FB2B9BA94000979CF6 /* range.hpp */,
 				C95266442A7E06760016283E /* inmemory_filesystem.hpp */,
 				C95266452A7E06760016283E /* inmemory_filesystem.cpp */,
 				C97716B12AE9BBBA00FC0DAC /* inmemory_filesystem_utils.hpp */,

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/xcshareddata/xcschemes/executorchcoreml_tests.xcscheme
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/xcshareddata/xcschemes/executorchcoreml_tests.xcscheme
@@ -30,6 +30,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableUBSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/backends/apple/coreml/scripts/install_inmemoryfs.sh
+++ b/backends/apple/coreml/scripts/install_inmemoryfs.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2023 Apple Inc. All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+SCRIPT_DIR_PATH="$(
+    cd -- "$(dirname "$0")" >/dev/null 2>&1
+    pwd -P
+)"
+
+EXECUTORCH_ROOT_PATH=$(realpath "$SCRIPT_DIR_PATH/../../../../")
+COREML_DIR_PATH="$EXECUTORCH_ROOT_PATH/backends/apple/coreml"
+
+red=`tput setaf 1`
+green=`tput setaf 2`
+
+echo "${green}ExecuTorch: Installing inmemoryfs extension."
+pip install "$COREML_DIR_PATH/runtime/inmemoryfs"
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "${red}ExecuTorch: Failed to install inmemoryfs extension."
+    exit 1
+fi

--- a/backends/apple/coreml/scripts/install_requirements.sh
+++ b/backends/apple/coreml/scripts/install_requirements.sh
@@ -69,15 +69,8 @@ if [ $STATUS -ne 0 ]; then
     exit 1
 fi
 
-echo "${green}ExecuTorch: Installing inmemoryfs extension."
-pip install "$COREML_DIR_PATH/runtime/inmemoryfs"
-STATUS=$?
-if [ $STATUS -ne 0 ]; then
-    echo "${red}ExecuTorch: Failed to install inmemoryfs extension."
-    exit 1
-fi
+sh "$COREML_DIR_PATH/scripts/install_inmemoryfs.sh"
 
 echo "${green}ExecuTorch: Copying protobuf files."
 mkdir -p "$COREML_DIR_PATH/runtime/sdk/format/" 
 cp -rf "$PROTOBUF_FILES_DIR_PATH" "$COREML_DIR_PATH/runtime/sdk/format/" 
-


### PR DESCRIPTION
CoreML delegate when converting the `mlpackage` to an in-memory representation reads the directory contents in the `mlpackage` directory and writes it to a memory buffer this is expensive and the copying is not required. 

The change in the PR addresses by memory mapping the file contents to fixed addresses in the allocated memory, no memory is dirtied and the OS will bring the pages only when the bytes are read. 