### PR TITLE
Error while saving to softmax.pte: 'bytes' object has no attribute 'w…

### DIFF
--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -146,4 +146,4 @@ if __name__ == "__main__":
     model_name = f"{args.model_name}" + (
         "_arm_delegate" if args.delegate is True else ""
     )
-    save_pte_program(exec_prog.buffer, model_name)
+    save_pte_program(exec_prog, model_name)


### PR DESCRIPTION
Hi,
When I executed the following command (as described here: https://pytorch.org/executorch/main/executorch-arm-delegate-tutorial.html):
```
python3 -m examples.arm.aot_arm_compiler --model_name="softmax"
```
I got the following error:
```
[INFO 2024-03-11 15:39:26,639 utils.py:41] Core ATen graph:
graph():
    %arg0_1 : [num_users=1] = placeholder[target=arg0_1]
    %_softmax : [num_users=1] = call_function[target=torch.ops.aten._softmax.default](args = (%arg0_1, 0, False), kwargs = {})
    return (_softmax,)
[INFO 2024-03-11 15:39:26,672 utils.py:61] Exported graph:
graph():
    %arg0_1 : [num_users=1] = placeholder[target=arg0_1]
    %aten__softmax_default : [num_users=1] = call_function[target=executorch.exir.dialects.edge._ops.aten._softmax.default](args = (%arg0_1, 0, False), kwargs = {})
    return (aten__softmax_default,)
[INFO 2024-03-11 15:39:26,672 aot_arm_compiler.py:134] Exported graph:
graph():
    %arg0_1 : [num_users=1] = placeholder[target=arg0_1]
    %aten__softmax_default : [num_users=1] = call_function[target=executorch.exir.dialects.edge._ops.aten._softmax.default](args = (%arg0_1, 0, False), kwargs = {})
    return (aten__softmax_default,)
[ERROR 2024-03-11 15:39:26,686 utils.py:110] Error while saving to softmax.pte: 'bytes' object has no attribute 'write_to_file'
```
Cheers,
Christoph