### PR TITLE
[ET-VK] Support multiple UniformParamsBuffer

### DIFF
--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -154,6 +154,12 @@ class ComputeGraph final {
   ValueRef set_input_tensor(const ValueRef idx, const bool use_staging = true);
   ValueRef set_output_tensor(const ValueRef idx, const bool use_staging = true);
 
+  template <typename Block>
+  inline std::shared_ptr<api::UniformParamsBuffer> create_params_buffer(
+      const Block& data) {
+    return std::make_shared<api::UniformParamsBuffer>(context_.get(), data);
+  }
+
   /*
    * Convenience function to add an input tensor along with its staging buffer
    */

--- a/backends/vulkan/runtime/graph/ops/ExecuteNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/ExecuteNode.cpp
@@ -22,12 +22,12 @@ ExecuteNode::ExecuteNode(
     const api::utils::uvec3& global_workgroup_size,
     const api::utils::uvec3& local_workgroup_size,
     const std::vector<ArgGroup>& args,
-    api::UniformParamsBuffer&& params)
+    const std::vector<std::shared_ptr<api::UniformParamsBuffer>>& params)
     : shader_(shader),
       global_workgroup_size_(global_workgroup_size),
       local_workgroup_size_(local_workgroup_size),
       args_(args),
-      params_(std::move(params)) {
+      params_(params) {
   graph.update_descriptor_counts(shader, /*execute = */ true);
 }
 
@@ -43,7 +43,7 @@ void ExecuteNode::encode(ComputeGraph* graph) {
   uint32_t idx = 0;
   idx = bind_values_to_descriptor_set(
       graph, args_, pipeline_barrier, descriptor_set, idx);
-  descriptor_set.bind(idx, params_.buffer());
+  bind_params_to_descriptor_set(params_, descriptor_set, idx);
 
   context->register_shader_dispatch(
       descriptor_set, pipeline_barrier, shader_, global_workgroup_size_);

--- a/backends/vulkan/runtime/graph/ops/ExecuteNode.h
+++ b/backends/vulkan/runtime/graph/ops/ExecuteNode.h
@@ -53,7 +53,7 @@ class ExecuteNode final {
       const api::utils::uvec3& global_workgroup_size,
       const api::utils::uvec3& local_workgroup_size,
       const std::vector<ArgGroup>& args,
-      api::UniformParamsBuffer&& params);
+      const std::vector<std::shared_ptr<api::UniformParamsBuffer>>& params);
 
   ~ExecuteNode() = default;
 
@@ -64,9 +64,8 @@ class ExecuteNode final {
   const api::utils::uvec3 global_workgroup_size_;
   const api::utils::uvec3 local_workgroup_size_;
   const std::vector<ArgGroup> args_;
-  // TODO(T180906086): pass multiple buffers and index with ValueRef.
   // TODO(T180906457): allow re-computing param buffers.
-  api::UniformParamsBuffer params_;
+  std::vector<std::shared_ptr<api::UniformParamsBuffer>> params_;
 };
 
 } // namespace vulkan

--- a/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
@@ -24,13 +24,13 @@ PrepackNode::PrepackNode(
     const api::utils::uvec3& local_workgroup_size,
     const ValueRef tref,
     const ValueRef packed,
-    api::UniformParamsBuffer&& params)
+    const std::vector<std::shared_ptr<api::UniformParamsBuffer>>& params)
     : shader_(shader),
       global_workgroup_size_(global_workgroup_size),
       local_workgroup_size_(local_workgroup_size),
       tref_(tref),
       packed_(packed),
-      params_(std::move(params)) {
+      params_(params) {
   graph.update_descriptor_counts(shader, /*execute = */ false);
 }
 
@@ -61,7 +61,7 @@ void PrepackNode::encode(ComputeGraph* graph) {
       descriptor_set,
       idx++);
   bind_staging_to_descriptor_set(staging, descriptor_set, idx++);
-  descriptor_set.bind(idx, params_.buffer());
+  bind_params_to_descriptor_set(params_, descriptor_set, idx);
 
   context->register_shader_dispatch(
       descriptor_set, pipeline_barrier, shader_, global_workgroup_size_);

--- a/backends/vulkan/runtime/graph/ops/PrepackNode.h
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.h
@@ -37,7 +37,7 @@ class PrepackNode final {
       const api::utils::uvec3& local_workgroup_size,
       const ValueRef tref,
       const ValueRef packed,
-      api::UniformParamsBuffer&& params);
+      const std::vector<std::shared_ptr<api::UniformParamsBuffer>>& params);
 
   ~PrepackNode() = default;
 
@@ -49,9 +49,8 @@ class PrepackNode final {
   const api::utils::uvec3 local_workgroup_size_;
   const ValueRef tref_;
   const ValueRef packed_;
-  // TODO(T180906086): pass multiple buffers and index with ValueRef.
   // TODO(T180906457): allow re-computing param buffers.
-  api::UniformParamsBuffer params_;
+  std::vector<std::shared_ptr<api::UniformParamsBuffer>> params_;
 };
 
 } // namespace vulkan

--- a/backends/vulkan/runtime/graph/ops/impl/Arithmetic.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Arithmetic.cpp
@@ -72,7 +72,6 @@ void add_arithmetic_node(
       get_size_as_ivec4(t_in2),
       alpha_val,
   };
-  api::UniformParamsBuffer params(graph.context(), block);
 
   graph.execute_nodes().emplace_back(new ExecuteNode(
       graph,
@@ -81,7 +80,7 @@ void add_arithmetic_node(
       local_size,
       {{out, api::MemoryAccessType::WRITE},
        {{arg1, arg2}, api::MemoryAccessType::READ}},
-      std::move(params)));
+      {graph.create_params_buffer(block)}));
 }
 
 REGISTER_OPERATORS {

--- a/backends/vulkan/runtime/graph/ops/utils/BindingUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/utils/BindingUtils.cpp
@@ -29,13 +29,6 @@ void bind_tensor_to_descriptor_set(
   }
 }
 
-void bind_staging_to_descriptor_set(
-    api::StorageBuffer& staging,
-    api::DescriptorSet& descriptor_set,
-    const uint32_t idx) {
-  descriptor_set.bind(idx, staging.buffer());
-}
-
 uint32_t bind_values_to_descriptor_set(
     ComputeGraph* graph,
     const std::vector<ArgGroup>& args,
@@ -61,6 +54,24 @@ uint32_t bind_values_to_descriptor_set(
     }
   }
   return idx;
+}
+
+uint32_t bind_params_to_descriptor_set(
+    std::vector<std::shared_ptr<api::UniformParamsBuffer>>& params,
+    api::DescriptorSet& descriptor_set,
+    const uint32_t base_idx) {
+  uint32_t idx = base_idx;
+  for (auto& param : params) {
+    descriptor_set.bind(idx++, param->buffer());
+  }
+  return idx;
+}
+
+void bind_staging_to_descriptor_set(
+    api::StorageBuffer& staging,
+    api::DescriptorSet& descriptor_set,
+    const uint32_t idx) {
+  descriptor_set.bind(idx, staging.buffer());
 }
 
 } // namespace vulkan

--- a/backends/vulkan/runtime/graph/ops/utils/BindingUtils.h
+++ b/backends/vulkan/runtime/graph/ops/utils/BindingUtils.h
@@ -16,15 +16,14 @@ namespace at {
 namespace native {
 namespace vulkan {
 
+//
+// For objects in the graph
+//
+
 void bind_tensor_to_descriptor_set(
     vTensor& tensor,
     api::PipelineBarrier& pipeline_barrier,
     const api::MemoryAccessType accessType,
-    api::DescriptorSet& descriptor_set,
-    const uint32_t idx);
-
-void bind_staging_to_descriptor_set(
-    api::StorageBuffer& staging,
     api::DescriptorSet& descriptor_set,
     const uint32_t idx);
 
@@ -34,6 +33,20 @@ uint32_t bind_values_to_descriptor_set(
     api::PipelineBarrier& pipeline_barrier,
     api::DescriptorSet& descriptor_set,
     const uint32_t base_idx);
+
+//
+// For objects NOT in the graph
+//
+
+uint32_t bind_params_to_descriptor_set(
+    std::vector<std::shared_ptr<api::UniformParamsBuffer>>& params,
+    api::DescriptorSet& descriptor_set,
+    const uint32_t base_idx);
+
+void bind_staging_to_descriptor_set(
+    api::StorageBuffer& staging,
+    api::DescriptorSet& descriptor_set,
+    const uint32_t idx);
 
 } // namespace vulkan
 } // namespace native


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2348
* #2323
* #2319

Before: Each node contains a `UniformParamsBuffer`.
After: Each node contains a `std::vector<std::shared_ptr<UniformParamsBuffer>>`.

In follow up changes, we will break up parameters to be passed via multiple UniformParamsBuffer, since
1. some are tensor-specific (e.g. image extents) and
2. others are operator-specific (e.g. alpha for binary ops).

Hence, we need **`std::vector`**.

We are adding the methods for #1 in https://github.com/pytorch/executorch/pull/2340. Since #1 and #2 will be owned by different objects, we need **pointers**. Since #1 is owned by `vTensor` which is non-copyable, we can't use unique_ptr so we need **`std::shared_ptr`**.

Differential Revision: [D54691831](https://our.internmc.facebook.com/intern/diff/D54691831/)