### PR TITLE
Generate ETRecord from llama export script

### DIFF
--- a/examples/models/llama2/TARGETS
+++ b/examples/models/llama2/TARGETS
@@ -88,6 +88,7 @@ runtime.python_library(
         "//executorch/exir:lib",
         "//executorch/util:memory_profiler",
         "//executorch/util:python_profiler",
+        "//executorch/sdk/inspector:inspector",
         # one definition has to be included in the user of the libarary
         # depending on what library the client wants to use
         # "//executorch/extension/pybindings:aten_lib",


### PR DESCRIPTION
Summary: To make the llama export script being able to generate the etrecord during export. Followed this doc to do the integration: https://pytorch.org/executorch/main/sdk-etrecord.html#generating-an-etrecord

Differential Revision: D54785962


