### PR TITLE
Temporary fix of different memory formats between Pytorch and TOSA

### DIFF
--- a/backends/arm/operators/op_common.py
+++ b/backends/arm/operators/op_common.py
@@ -7,7 +7,6 @@ import serializer.tosa_serializer as ts
 import torch
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_quant_utils import get_quant_node_args
-from executorch.backends.arm.tosa_utils import transpose_helper
 from serializer.tosa_serializer import TosaOp
 
 
@@ -22,22 +21,10 @@ def build_avg_pool_2d_common(
     output: TosaArg,
 ):
     accumulator_type = input_tensor.dtype
-    input_output_type = input_tensor.dtype
 
     if is_quant_node:
         # Accumulator type always is int32 when input tensor is an integer type.
         accumulator_type = ts.DType.INT32
-        input_output_type = ts.DType.INT8
-
-    # Torch's input is [N,C,H,W], TOSA is [N, H, W, C],
-    # Transpose to align with TOSA
-    NHWC_Order = [0, 2, 3, 1]
-    input_transposed = transpose_helper(
-        tosa_graph,
-        input_tensor,
-        NHWC_Order,
-        input_output_type,
-    )
 
     # Initilize zero point to zero.
     input_zp = 0
@@ -57,22 +44,9 @@ def build_avg_pool_2d_common(
         accum_dtype=accumulator_type,
     )
 
-    avg_pool2d_res_shape = [output.shape[i] for i in NHWC_Order]
-    avg_pool2d_res = tosa_graph.addIntermediate(avg_pool2d_res_shape, input_output_type)
     tosa_graph.addOperator(
         TosaOp.Op().AVG_POOL2D,
-        [input_transposed.name],
-        [avg_pool2d_res.name],
-        attr,
-    )
-
-    # TOSA is [N, H, W, C], Transpose back to Torch's [N, C, H, W]
-    NCHW_Order = [0, 3, 1, 2]
-    attr_output_transpose = ts.TosaSerializerAttribute()
-    attr_output_transpose.TransposeAttribute(NCHW_Order)
-    tosa_graph.addOperator(
-        TosaOp.Op().TRANSPOSE,
-        [avg_pool2d_res.name],
+        [input_tensor.name],
         [output.name],
-        attr_output_transpose,
+        attr,
     )

--- a/backends/arm/operators/op_conv2d.py
+++ b/backends/arm/operators/op_conv2d.py
@@ -12,11 +12,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_quant_utils import build_rescale_conv_output
-from executorch.backends.arm.tosa_utils import (
-    build_reshape,
-    getNodeArgs,
-    transpose_helper,
-)
+from executorch.backends.arm.tosa_utils import build_reshape, getNodeArgs
 
 from serializer.tosa_serializer import TosaOp
 
@@ -43,7 +39,6 @@ class Conv2dVisitor(NodeVisitor):
             raise RuntimeError(
                 f"ignoring input element is not currently supported, got a large stride {stride}"
             )
-
         return pad - mod_remainder
 
     def define_node(
@@ -58,12 +53,6 @@ class Conv2dVisitor(NodeVisitor):
 
         # Currently only int8 is supported in quantized types.
         actual_out_type = ts.DType.INT8 if is_quant_node else output.dtype
-
-        ## Transpose input tensor to NHWC_Order for TOSA
-        NHWC_Order = [0, 2, 3, 1]
-        input_transposed = transpose_helper(
-            tosa_graph, input, NHWC_Order, actual_out_type
-        )
 
         # Get the attributes of convolution.
         attr = ts.TosaSerializerAttribute()
@@ -108,93 +97,57 @@ class Conv2dVisitor(NodeVisitor):
                 name=bias_name,
             )
 
+        # The output type is int32 when input type is int8.
+        conv2d_output_name = output.name
+        if is_quant_node:
+            conv2d_res = tosa_graph.addIntermediate(output.shape, ts.DType.INT32)
+            conv2d_output_name = conv2d_res.name
+
         if group.number > 1:
             """Depthwise convolution case"""
             # Given input.shape is (N, Ci, H, W), and weight.shape is (Co, Ci/G, H, W)
             in_channels = input.shape[1]
             out_channels = weight.shape[0]
-
             # Reshape torch shape format of weight tensor to tosa required format.
             # https://www.mlplatform.org/tosa/tosa_spec.html#_depthwise_conv2d
             m_length = int(round(out_channels / in_channels))
             weight_post_shape = (
-                in_channels,
-                m_length,
                 weight.shape[2],
                 weight.shape[3],
+                in_channels,
+                m_length,
             )
 
             weight_reshaped = tosa_graph.addIntermediate(
                 weight_post_shape,
                 ts.DType.INT8 if is_quant_node else weight.dtype,
             )
-
             build_reshape(
                 tosa_graph, weight.name, weight_post_shape, weight_reshaped.name
             )
 
-            # Transpose weight to [KH, KW, C, M]
-            weight_HWCM_Order = [2, 3, 0, 1]
-            weight_transposed = transpose_helper(
-                tosa_graph,
-                weight_reshaped,
-                weight_HWCM_Order,
-                ts.DType.INT8 if is_quant_node else weight.dtype,
-            )
-
-            ## TOSA output shape is [N, H, W, C*M]
-            NHWO_Order = [0, 2, 3, 1]
-            out_shape_TOSA_Depthwise_CONV2D = [output.shape[i] for i in NHWO_Order]
-
-            conv2d_res = tosa_graph.addIntermediate(
-                out_shape_TOSA_Depthwise_CONV2D,
-                ts.DType.INT32 if is_quant_node else output.dtype,
-            )
             tosa_graph.addOperator(
                 TosaOp.Op().DEPTHWISE_CONV2D,
                 [
-                    input_transposed.name,
-                    weight_transposed.name,
+                    input.name,
+                    weight_reshaped.name,
                     bias.name,
                 ],
-                [conv2d_res.name],
+                [conv2d_output_name],
                 attr,
             )
         else:
             """Regular convolution case"""
-            # Transpose weight to [OC, H, W, IC]
-            weight_CHWC_Order = [0, 2, 3, 1]
-            weight_transposed = transpose_helper(
-                tosa_graph,
-                weight,
-                weight_CHWC_Order,
-                actual_out_type,
-            )
-
-            ## TOSA output shape is [NHWO]
-            NHWO_Order = [0, 2, 3, 1]
-            out_shape_TOSA_CONV2D = [output.shape[i] for i in NHWO_Order]
-
-            # The output type is int32 when input type is int8.
-            conv2d_res = tosa_graph.addIntermediate(
-                out_shape_TOSA_CONV2D,
-                ts.DType.INT32 if is_quant_node else output.dtype,
-            )
             tosa_graph.addOperator(
                 TosaOp.Op().CONV2D,
                 [
-                    input_transposed.name,
-                    weight_transposed.name,
+                    input.name,
+                    weight.name,
                     bias.name,
                 ],
-                [conv2d_res.name],
+                [conv2d_output_name],
                 attr,
             )
-
-        ## Torch output shape is [NOHW]
-        NOHW_Order = [0, 3, 1, 2]
-        attr_output_transpose = ts.TosaSerializerAttribute()
-        attr_output_transpose.TransposeAttribute(NOHW_Order)
 
         # For quantized convolution, rescale the output value back to the same
         # integer value domain of the next op. Otherwise return float32 output.
@@ -203,19 +156,12 @@ class Conv2dVisitor(NodeVisitor):
             _, input_scale, _, _, _, _ = getNodeArgs(node.args[0])
             _, weight_scale, _, _, _, _ = getNodeArgs(node.args[1])
             _, output_scale, _, _, _, _ = getNodeArgs(list(node.users)[0])
-
-            conv2d_res = build_rescale_conv_output(
+            build_rescale_conv_output(
                 tosa_graph,
                 conv2d_res,
+                output.name,
                 actual_out_type,
                 input_scale,
                 weight_scale,
                 output_scale,
             )
-
-        tosa_graph.addOperator(
-            TosaOp.Op().TRANSPOSE,
-            [conv2d_res.name],
-            [output.name],
-            attr_output_transpose,
-        )

--- a/backends/arm/operators/op_placeholder.py
+++ b/backends/arm/operators/op_placeholder.py
@@ -8,18 +8,23 @@ import serializer.tosa_serializer as ts
 import torch
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_quant_utils import (
-    dq_q_ops,
     get_quant_node_args,
     is_quant_arg,
     q_op,
 )
-from executorch.backends.arm.tosa_utils import getNodeArgs, is_bias_node_for_addmm
+from executorch.backends.arm.tosa_utils import (
+    is_bias_node_for_addmm,
+    is_consumer_node_depthwise_conv2d,
+)
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch.export.exported_program import ExportedProgram
 
 
 def process_placeholder(
-    node: torch.fx.Node, tosa_graph: ts.TosaSerializer, edge_program: ExportedProgram
+    node: torch.fx.Node,
+    tosa_graph: ts.TosaSerializer,
+    edge_program: ExportedProgram,
+    permute_memory_to_nhwc: bool,
 ):
     assert node.name == node.target, "Expect placeholder name and target to match"
     assert 0 == len(node.args), "Can't handle default input values"
@@ -32,27 +37,11 @@ def process_placeholder(
 
         assert isinstance(p_data, torch.Tensor), "Expect Attr to be tensor"
         parameter_values = p_data.detach().numpy()
-
-        # Check if they're for quantized nodes
         consumer_node = list(node.users)[0]
-        if consumer_node.target in dq_q_ops:
-            _, weight_node_scale, weight_node_zp, _, _, _ = getNodeArgs(consumer_node)
 
-            int8_max = np.iinfo(np.int8).max
-            int8_min = np.iinfo(np.int8).min
-            parameter_values_quantized = (
-                ((parameter_values / weight_node_scale.number) + weight_node_zp.number)
-                .round()
-                .clip(int8_min, int8_max)
-                .astype(np.int8)
-            )
-            tosa_graph.addConst(
-                inputs[0].shape,
-                ts.DType.INT8,
-                parameter_values_quantized,
-                name=out,
-            )
-        elif is_bias_node_for_addmm(node):
+        if is_bias_node_for_addmm(node):
+            # Cases for:
+            # - BI_AddMM_bias
             (
                 _,
                 input_node,
@@ -65,7 +54,7 @@ def process_placeholder(
             else:
                 input_node_scale, _ = get_quant_node_args(input_node)
 
-            weight_node_scale, weight_node_zp = get_quant_node_args(weight_node)
+            weight_node_scale, _ = get_quant_node_args(weight_node)
 
             bias_values_quantized = (
                 (parameter_values / (input_node_scale * weight_node_scale))
@@ -83,6 +72,9 @@ def process_placeholder(
             consumer_node.target == exir_ops.edge.aten.convolution.default
             and list(consumer_node.users)[0].target == q_op
         ):
+            # Cases for:
+            # - BI_Conv2d_bias
+            # - BI_DepthwiseConv2d_bias
             (
                 input_node,
                 weight_node,
@@ -104,21 +96,74 @@ def process_placeholder(
                 name=out,
             )
         else:
+            # Cases for:
+            # - MI_AddMM_bias
+            # - MI_AddMM_weight
+            # - MI_Conv2d_non_bias_weight
+            # - MI_Conv2d_weight
+            # - MI_Conv2d_bias
+            # - MI_DepthwiseConv2d_weight
+            # - MI_DepthwiseConv2d_bias
+            if (
+                permute_memory_to_nhwc
+                and len(parameter_values.shape) == 4
+                and is_consumer_node_depthwise_conv2d(node)
+            ):
+                # For more details on TOSA depthwise_conv2d:
+                # https://www.mlplatform.org/tosa/tosa_spec.html#_depthwise_conv2d
+                HWCM_Order = [2, 3, 0, 1]
+                parameter_values = np.transpose(parameter_values, HWCM_Order)
+            elif permute_memory_to_nhwc and len(parameter_values.shape) == 4:
+                # For regular conv2d case
+                NHWC_Order = (0, 2, 3, 1)
+                parameter_values = np.transpose(parameter_values, NHWC_Order)
+
             tosa_graph.addConst(
-                inputs[0].shape, inputs[0].dtype, parameter_values, name=out
+                parameter_values.shape, inputs[0].dtype, parameter_values, name=out
             )
 
     elif out in edge_program.graph_signature.inputs_to_buffers:
+        # Cases for:
+        # - BI_AddMM_weight
+        # - BI_Conv2d_non_bias_weight
+        # - BI_Conv2d_weight
+        # - BI_DepthwiseConv2d_weight
+        # - MI_BatchNorm_variance
+        # - MI_BatchNorm_mean
         parameter_name = edge_program.graph_signature.inputs_to_buffers[node.name]
         p_data = edge_program.state_dict[parameter_name]
 
         assert isinstance(p_data, torch.Tensor), "Expect Attr to be tensor"
         buffer_values = p_data.detach().numpy()
-        tosa_graph.addConst(inputs[0].shape, inputs[0].dtype, buffer_values, name=out)
+
+        # TODO: fragile code for temporary fix
+        # the mean and var tensors are also stored here but they have shape (1, )
+        # we only transpose weights here
+        if permute_memory_to_nhwc and is_consumer_node_depthwise_conv2d(
+            list(node.users)[0]
+        ):
+            # For more details on TOSA depthwise_conv2d:
+            # https://www.mlplatform.org/tosa/tosa_spec.html#_depthwise_conv2d
+            HWCM_Order = (2, 3, 0, 1)
+            buffer_values = np.transpose(buffer_values, HWCM_Order)
+        elif permute_memory_to_nhwc and len(buffer_values.shape) == 4:
+            # For regular conv2d case
+            NHWC_Order = (0, 2, 3, 1)
+            buffer_values = np.transpose(buffer_values, NHWC_Order)
+
+        tosa_graph.addConst(
+            buffer_values.shape, inputs[0].dtype, buffer_values, name=out
+        )
     else:
+        # Cases for all the input tensors
+        if permute_memory_to_nhwc:
+            NHWC_Order = [0, 2, 3, 1]
+            input_shape = [inputs[0].shape[i] for i in NHWC_Order]
+        else:
+            input_shape = inputs[0].shape
         tensor = ts.TosaSerializerTensor(
             inputs[0].name,
-            inputs[0].shape,
+            input_shape,
             ts.DType.INT8 if is_quant_arg(node) else inputs[0].dtype,
             data=None,
             placeholderFilename=inputs[0].name + ".npy",

--- a/backends/arm/test/arm_tosa_reference.py
+++ b/backends/arm/test/arm_tosa_reference.py
@@ -48,6 +48,7 @@ SUPPORTED_BI_TEST_LIST = [
     "simple_conv2d_2x2_3x1x40x40_non_bias",
     "block_two_conv2d",
     "block_two_conv2d_non_bias",
+    "block_bottleneck_residual",
 ]
 
 
@@ -105,6 +106,7 @@ def tosa_ref_dump_inputs(
     path,
     input_quantization_scales,
     input_quantization_zps,
+    permute_memory_to_nhwc,
     profile=TosaProfile.MI,
     save_on_disk=True,
 ) -> Optional[List[Tuple[np.ndarray, str]]]:
@@ -129,6 +131,10 @@ def tosa_ref_dump_inputs(
     for arg in zip(argument_names, inputs):
         name = arg[0]
         data = arg[1].detach().numpy()
+
+        if permute_memory_to_nhwc:
+            NHWC_Order = (0, 2, 3, 1)
+            data = np.transpose(data, NHWC_Order)
 
         # Torch is doing Input[FP32]->Q[INT8]->DQ[FP32]->Operator[FP32]->Q[INT]->DQ[FP32]->[Output]FP32
         # Need to quantize the input to INT8 for TOSA comsumption
@@ -167,12 +173,14 @@ def tosa_run_test(op, profile=TosaProfile.MI):  # noqa: C901
     TOSA_OUT_PATH = os.path.join(DEBUG_OUTPUT_PATH, op, "tosa", "")
     os.makedirs(TOSA_OUT_PATH, exist_ok=True)
 
+    model, inputs, torch_output = prepare_model_and_ref(op, profile)
+
     # Debug flags for compilers
     # - Emit some debug files into /tmp
     # - output_format TOSA for this test (and pure tosa flows)
-    compile_spec = generate_tosa_compile_spec(TOSA_OUT_PATH)
-
-    model, inputs, torch_output = prepare_model_and_ref(op, profile)
+    compile_spec = generate_tosa_compile_spec(
+        model.permute_memory_to_nhwc, TOSA_OUT_PATH
+    )
 
     if inputs is None:
         print("\033[96m Skipping, no inputs for TOSA profile \033[0m")
@@ -208,10 +216,13 @@ def tosa_run_test(op, profile=TosaProfile.MI):  # noqa: C901
             TOSA_OUT_PATH,
             input_quantization_scales,
             input_quantization_zps,
+            model.permute_memory_to_nhwc,
             profile,
         )
     else:
-        tosa_ref_dump_inputs(model_edge, inputs, TOSA_OUT_PATH, {}, {})
+        tosa_ref_dump_inputs(
+            model_edge, inputs, TOSA_OUT_PATH, {}, {}, model.permute_memory_to_nhwc
+        )
 
     print(TORCH_OUT_PATH, TOSA_OUT_PATH)
 
@@ -250,6 +261,10 @@ def tosa_run_test(op, profile=TosaProfile.MI):  # noqa: C901
             tosa_output = (
                 tosa_output - output_quantization_zp
             ) * output_quantization_scale
+
+    if model.permute_memory_to_nhwc:
+        NCHW_Order = (0, 3, 1, 2)
+        tosa_output = np.transpose(tosa_output, NCHW_Order)
 
     ## Read the Torch Output
     torch_file = open(TORCH_OUT_PATH + "/torch_output.npy", "rb")

--- a/backends/arm/test/ops/test_add.py
+++ b/backends/arm/test/ops/test_add.py
@@ -32,6 +32,7 @@ class TestSimpleAdd(unittest.TestCase):
     class Add(torch.nn.Module):
         def __init__(self):
             super().__init__()
+            self.permute_memory_to_nhwc = False
 
         def forward(self, x):
             return x + x
@@ -39,6 +40,7 @@ class TestSimpleAdd(unittest.TestCase):
     class Add2(torch.nn.Module):
         def __init__(self):
             super().__init__()
+            self.permute_memory_to_nhwc = False
 
         def forward(self, x, y):
             return x + y
@@ -52,6 +54,7 @@ class TestSimpleAdd(unittest.TestCase):
                 inputs=test_data,
                 profile=TosaProfile.MI,
                 backend=ArmBackendSelector.TOSA,
+                permute_memory_to_nhwc=False,
             )
             .export()
             .check_count({"torch.ops.aten.add.Tensor": 1})
@@ -77,6 +80,7 @@ class TestSimpleAdd(unittest.TestCase):
                 inputs=test_data,
                 profile=TosaProfile.BI,
                 backend=ArmBackendSelector.TOSA,
+                permute_memory_to_nhwc=False,
             )
             .quantize()
             .export()

--- a/backends/arm/test/test_models.py
+++ b/backends/arm/test/test_models.py
@@ -13,6 +13,7 @@ import numpy as np
 
 import torch
 
+
 TestList = {}
 
 # Seed the RNG a convenient number so that we get the same random tests for each test each time
@@ -52,6 +53,8 @@ class TorchBuilder:
             TosaProfile.MI: (torch.ones(10),),
         }
 
+        permute_memory_to_nhwc = False
+
         def __init__(self):
             super().__init__()
 
@@ -65,6 +68,8 @@ class TorchBuilder:
             TosaProfile.BI: (torch.ones(10),),
             TosaProfile.MI: (torch.ones(10),),
         }
+
+        permute_memory_to_nhwc = False
 
         def __init__(self):
             super().__init__()
@@ -81,6 +86,8 @@ class TorchBuilder:
             TosaProfile.BI_INT: (torch.ones(5, dtype=torch.int32),),
         }
 
+        permute_memory_to_nhwc = False
+
         def __init__(self):
             super().__init__()
 
@@ -95,6 +102,8 @@ class TorchBuilder:
                 torch.ones(5, dtype=torch.int32),
             ),
         }
+
+        permute_memory_to_nhwc = False
 
         def __init__(self):
             super().__init__()
@@ -119,6 +128,8 @@ class TorchBuilder:
             ),
         }
 
+        permute_memory_to_nhwc = False
+
         def __init__(self):
             super().__init__()
 
@@ -138,6 +149,8 @@ class TorchBuilder:
             TosaProfile.BI: (data,),
             TosaProfile.MI: (data,),
         }
+
+        permute_memory_to_nhwc = True
 
         def __init__(self):
             super().__init__()
@@ -162,6 +175,8 @@ class TorchBuilder:
             TosaProfile.BI: (data,),
             TosaProfile.MI: (data,),
         }
+
+        permute_memory_to_nhwc = True
 
         def __init__(self):
             super().__init__()
@@ -191,6 +206,8 @@ class TorchBuilder:
             TosaProfile.MI: (data,),
         }
 
+        permute_memory_to_nhwc = True
+
         def __init__(self):
             super().__init__()
             self.conv2d = torch.nn.Conv2d(
@@ -215,6 +232,8 @@ class TorchBuilder:
             TosaProfile.BI: (data,),
             TosaProfile.MI: (data,),
         }
+
+        permute_memory_to_nhwc = True
 
         def __init__(self):
             super().__init__()
@@ -245,6 +264,8 @@ class TorchBuilder:
             TosaProfile.MI: (data,),
         }
 
+        permute_memory_to_nhwc = True
+
         def __init__(self):
             super().__init__()
             self.conv2d = torch.nn.Conv2d(
@@ -274,6 +295,8 @@ class TorchBuilder:
             TosaProfile.MI: (data,),
         }
 
+        permute_memory_to_nhwc = True
+
         def __init__(self):
             super().__init__()
             self.conv2d = torch.nn.Conv2d(
@@ -300,6 +323,8 @@ class TorchBuilder:
             TosaProfile.BI: (data,),
             TosaProfile.MI: (data,),
         }
+
+        permute_memory_to_nhwc = True
 
         def __init__(self):
             super().__init__()
@@ -328,6 +353,8 @@ class TorchBuilder:
             TosaProfile.MI: (data,),
         }
 
+        permute_memory_to_nhwc = True
+
         def __init__(self):
             super().__init__()
             self.conv2d = torch.nn.Conv2d(
@@ -355,6 +382,8 @@ class TorchBuilder:
             TosaProfile.MI: (data,),
         }
 
+        permute_memory_to_nhwc = True
+
         def __init__(self):
             super().__init__()
             """ in_channels == out_channels """
@@ -378,6 +407,8 @@ class TorchBuilder:
             TosaProfile.BI: (data,),
             TosaProfile.MI: (data,),
         }
+
+        permute_memory_to_nhwc = True
 
         def __init__(self):
             super().__init__()
@@ -405,6 +436,8 @@ class TorchBuilder:
             TosaProfile.MI: (data,),
         }
 
+        permute_memory_to_nhwc = True
+
         def __init__(self):
             super().__init__()
             self.depthwise_conv2d = torch.nn.Conv2d(
@@ -429,6 +462,8 @@ class TorchBuilder:
             TosaProfile.BI: (data,),
             TosaProfile.MI: (data,),
         }
+
+        permute_memory_to_nhwc = True
 
         def __init__(self):
             super().__init__()
@@ -457,6 +492,8 @@ class TorchBuilder:
             TosaProfile.BI: (data,),
             TosaProfile.MI: (data,),
         }
+
+        permute_memory_to_nhwc = True
 
         def __init__(self):
             super().__init__()
@@ -498,6 +535,8 @@ class TorchBuilder:
             ),
         }
 
+        permute_memory_to_nhwc = False
+
         def __init__(self):
             super().__init__()
 
@@ -517,6 +556,8 @@ class TorchBuilder:
             ),
             TosaProfile.MI: (torch.ones(20, 100, 35, 45),),
         }
+
+        permute_memory_to_nhwc = False
 
         def __init__(self):
             super().__init__()
@@ -540,6 +581,8 @@ class TorchBuilder:
             TosaProfile.MI: (torch.ones(20, 16, 50, 32),),
         }
 
+        permute_memory_to_nhwc = True
+
         def __init__(self):
             super().__init__()
             self.avg_pool_2d = torch.nn.AvgPool2d(4, stride=2, padding=0)
@@ -554,6 +597,8 @@ class TorchBuilder:
             TosaProfile.BI: (data,),
             TosaProfile.MI: (data,),
         }
+
+        permute_memory_to_nhwc = True
 
         def __init__(self):
             super().__init__()
@@ -570,6 +615,8 @@ class TorchBuilder:
             TosaProfile.BI: (data,),
             TosaProfile.MI: (data,),
         }
+
+        permute_memory_to_nhwc = True
 
         def __init__(self):
             super().__init__()
@@ -594,6 +641,8 @@ class TorchBuilder:
             TosaProfile.MI: (torch.ones(2, 3),),
         }
 
+        permute_memory_to_nhwc = False
+
         def __init__(self):
             super().__init__()
             self.softmax = torch.nn.Softmax(dim=1)
@@ -601,12 +650,14 @@ class TorchBuilder:
         def forward(self, x):
             return self.softmax(x)
 
-    # @register_test
+    @register_test
     class block_conv_norm_activation(torch.nn.Module):
         inputs = {
             TosaProfile.BI: (torch.ones(1, 3, 256, 256),),
             TosaProfile.MI: (torch.ones(1, 3, 256, 256),),
         }
+
+        permute_memory_to_nhwc = True
 
         def __init__(self):
             super().__init__()
@@ -623,14 +674,17 @@ class TorchBuilder:
             x = self.relu6(x)
             return x
 
-    # @register_test
+    @register_test
     class block_bottleneck_residual(torch.nn.Module):
         # This is the essence of MobileNetV2
         # Ref: https://arxiv.org/abs/1801.04381
 
         inputs = {
             TosaProfile.MI: (torch.ones(1, 64, 81, 81),),
+            TosaProfile.BI: (torch.ones(1, 64, 81, 81),),
         }
+
+        permute_memory_to_nhwc = True
 
         def __init__(self):
             super().__init__()
@@ -642,6 +696,18 @@ class TorchBuilder:
             self.batch_norm2d_16 = torch.nn.BatchNorm2d(384, affine=False)
             self.relu6 = torch.nn.ReLU6()
 
+            with torch.no_grad():
+                self.pointwise_conv2d.weight.copy_(
+                    torch.from_numpy(
+                        np.float32(rng.integers(low=1, high=4, size=(384, 64, 1, 1)))
+                    )
+                )
+                self.pointwise_conv2d.bias.copy_(
+                    torch.from_numpy(
+                        np.float32(rng.integers(low=1, high=4, size=(384)))
+                    )
+                )
+
             # 2. 3x3 DepthwiseConv2d + ReLu6
             self.depthwise_conv2d = torch.nn.Conv2d(
                 in_channels=384,
@@ -652,10 +718,32 @@ class TorchBuilder:
                 groups=384,
             )  ## (1, 384, H, W)
 
+            with torch.no_grad():
+                self.depthwise_conv2d.weight.copy_(
+                    torch.from_numpy(
+                        np.float32(rng.integers(low=1, high=4, size=(384, 1, 3, 3)))
+                    )
+                )
+                self.depthwise_conv2d.bias.copy_(
+                    torch.from_numpy(
+                        np.float32(rng.integers(low=1, high=4, size=(384)))
+                    )
+                )
+
             # 3. Linear 1x1 Conv2d
             self.pointwise_conv2d_linear = torch.nn.Conv2d(
                 in_channels=384, out_channels=64, kernel_size=1, stride=1, groups=1
             )  ## (1, 64, 81, 81)
+
+            with torch.no_grad():
+                self.pointwise_conv2d_linear.weight.copy_(
+                    torch.from_numpy(
+                        np.float32(rng.integers(low=1, high=3, size=(64, 384, 1, 1)))
+                    )
+                )
+                self.pointwise_conv2d_linear.bias.copy_(
+                    torch.from_numpy(np.float32(rng.integers(low=1, high=3, size=(64))))
+                )
 
             self.eval()
 

--- a/backends/arm/test/test_tosa.py
+++ b/backends/arm/test/test_tosa.py
@@ -82,6 +82,7 @@ def prepare_model_and_ref(test_model, profile=TosaProfile.MI):
 
     model.eval()
     if profile == TosaProfile.BI:
+        permute_memory_to_nhwc = model.permute_memory_to_nhwc
         # Quantize the model
         captured_model_graph_module = capture_pre_autograd_graph(
             model, copy.deepcopy(model.inputs[profile])
@@ -95,6 +96,7 @@ def prepare_model_and_ref(test_model, profile=TosaProfile.MI):
         prepared_model = prepare_pt2e(captured_model_graph_module, quantizer)
         prepared_model(*model.inputs[profile])
         model = convert_pt2e(prepared_model)
+        model.permute_memory_to_nhwc = permute_memory_to_nhwc
 
     model_outputs = model.forward(*model_inputs)
     return model, model_inputs, model_outputs

--- a/backends/arm/test/tosautil/tosa_test_utils.py
+++ b/backends/arm/test/tosautil/tosa_test_utils.py
@@ -101,6 +101,7 @@ class TosaTestUtils:
         params_input: Tuple[List[str], List[QuantizationParams]],
         param_output: Tuple[str, QuantizationParams],
         inputs: Tuple[torch.Tensor],
+        permute_memory_to_nhwc: bool,
     ) -> torch.Tensor:
         """
         Run TOSA reference model using the tosa_refence_model program.
@@ -164,6 +165,11 @@ class TosaTestUtils:
             params_input[0], params_input[1], inputs
         ):
             data_np = data.detach().numpy()
+
+            if permute_memory_to_nhwc:
+                NHWC_Order = (0, 2, 3, 1)
+                data_np = np.transpose(data_np, NHWC_Order)
+
             if self.profile is TosaProfile.BI:
                 assert (
                     quant_param.node_name == input_name

--- a/backends/arm/tosa_quant_utils.py
+++ b/backends/arm/tosa_quant_utils.py
@@ -96,6 +96,7 @@ def build_rescale(
     tosa_fb,
     scale,
     input_node,
+    output_name,
     output_type,
     output_shape,
     input_zp,
@@ -118,12 +119,11 @@ def build_rescale(
         output_unsigned=False,
     )
 
-    rescale_out = tosa_fb.addIntermediate(output_shape, output_type)
     tosa_fb.addOperator(
-        TosaOp.Op().RESCALE, [input_node.name], [rescale_out.name], attr_rescale
+        TosaOp.Op().RESCALE, [input_node.name], [output_name], attr_rescale
     )
 
-    return rescale_out
+    return
 
 
 def build_rescale_to_int32(
@@ -187,7 +187,7 @@ def build_rescale_from_int32(
 
 
 def build_rescale_conv_output(
-    tosa_fb, op, output_type, input_scale, weight_scale, output_scale
+    tosa_fb, op, output_name, output_type, input_scale, weight_scale, output_scale
 ):
     # Only use double round if we are doing 32 bit scaling
     double_round = is_scale32(output_type)
@@ -196,7 +196,15 @@ def build_rescale_conv_output(
     post_conv2d_scale = (input_scale.number * weight_scale.number) / output_scale.number
 
     # Since we assume the input tensor that is being rescaled is int32 date type, zero point must be 0.
-    rescale_op = build_rescale(
-        tosa_fb, post_conv2d_scale, op, output_type, op.shape, 0, 0, double_round
+    build_rescale(
+        tosa_fb,
+        post_conv2d_scale,
+        op,
+        output_name,
+        output_type,
+        op.shape,
+        0,
+        0,
+        double_round,
     )
-    return rescale_op
+    return

--- a/backends/arm/tosa_utils.py
+++ b/backends/arm/tosa_utils.py
@@ -174,3 +174,16 @@ def is_bias_node_for_addmm(node):
         )
 
     return is_rank2_linear_bias or is_rank_greater_than_2_linear_bias
+
+
+def is_consumer_node_depthwise_conv2d(node):
+    consumer_node = list(node.users)[0]
+    if consumer_node.target == exir_ops.edge.aten.convolution.default:
+        inputs = []
+        for arg in consumer_node.args:
+            inputs.append(TosaArg(arg))
+        group = inputs[-1]
+        if group.number > 1:
+            return True
+
+    return False


### PR DESCRIPTION
- This patch will be reverted once Github issue #1110 is resolved
- Torch graph operators like Conv2d are using NCHW formats while the TOSA equivalents are using NHWC formats.
- In the previous implementation, a pair of transpose operators are added around the TOSA Conv2d operator to cope with the memory format differences.
- In this patch, it removes those intermediate transposes around operators like Conv2d.
- Instead, we're transposing the inputs and outputs around the whole lowered graph and the Tosa compiler assumes the torch graph is in NHWC format so all the input/output shapes can match.
