### PR TITLE
Add torch.no_grad() guard on export

### DIFF
--- a/examples/portable/scripts/export.py
+++ b/examples/portable/scripts/export.py
@@ -9,6 +9,8 @@
 import argparse
 import logging
 
+import torch
+
 from executorch.exir.capture import EdgeCompileConfig, ExecutorchBackendConfig
 
 from ...models import MODEL_NAME_TO_MODEL
@@ -75,4 +77,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()  # pragma: no cover
+    with torch.no_grad():
+        main()  # pragma: no cover


### PR DESCRIPTION
Summary: For some models where the grad is enabled (like LLava model), we need to disable grad before exporting. This PR is to add this guard when using export script. It would not affect the models that grad is not enabled.

Reviewed By: cccclai

Differential Revision: D54812718


