### PR TITLE
Truncate long op_types lists and reindex df rows

### DIFF
--- a/examples/models/llama2/TARGETS
+++ b/examples/models/llama2/TARGETS
@@ -86,6 +86,7 @@ runtime.python_library(
         "//executorch/examples/models:models",
         "//executorch/examples/portable:utils",
         "//executorch/exir:lib",
+        "//executorch/sdk/etrecord:etrecord",
         "//executorch/util:memory_profiler",
         "//executorch/util:python_profiler",
         # one definition has to be included in the user of the libarary

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -7,6 +7,7 @@
 # Example script for exporting Llama2 to flatbuffer
 
 import argparse
+import copy
 import logging
 import shlex
 from dataclasses import dataclass
@@ -20,6 +21,7 @@ import torch
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
     XnnpackDynamicallyQuantizedPartitioner,
 )
+from executorch.sdk.etrecord import generate_etrecord
 from executorch.util.activation_memory_profiler import generate_memory_trace
 from sentencepiece import SentencePieceProcessor
 from torch.ao.quantization.quantizer import Quantizer
@@ -357,6 +359,14 @@ def build_args_parser() -> argparse.ArgumentParser:
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("-X", "--xnnpack", action="store_true")
 
+    parser.add_argument(
+        "--generate_etrecord",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Generate the ETRecord debug artifact.",
+    )
+
     return parser
 
 
@@ -452,7 +462,7 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
         # partitioners[XnnpackPartitioner.__name__] = XnnpackPartitioner()
         modelname = f"xnnpack_{modelname}"
 
-    builder = (
+    builder_exported_to_edge = (
         load_llama_model(
             checkpoint=checkpoint_path,
             params_path=params_path,
@@ -466,9 +476,22 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
         .source_transform(transforms)
         .to_dtype(dtype_override)
         .export_to_edge(quantizers)
-        .to_backend(partitioners)
-        .to_executorch()
     )
+
+    if args.generate_etrecord and not builder_exported_to_edge.edge_manager:
+        raise ValueError("Unable to generate etrecord due to missing edge manager.")
+
+    edge_manager_copy = copy.deepcopy(builder_exported_to_edge.edge_manager)
+    builder = builder_exported_to_edge.to_backend(partitioners).to_executorch()
+
+    # Generate ETRecord
+    if args.generate_etrecord and edge_manager_copy:
+        logging.info("Generating etrecord.bin")
+        generate_etrecord(
+            etrecord_path="etrecord.bin",
+            edge_dialect_program=edge_manager_copy,
+            executorch_program=builder.export_program,
+        )
 
     if args.profile_memory:
         generate_memory_trace(builder.export_program, "memory_profile.json")

--- a/sdk/inspector/_inspector.py
+++ b/sdk/inspector/_inspector.py
@@ -354,6 +354,10 @@ class Event:
         Returns:
             A dict with the Event data
         """
+
+        def truncated_list(long_list: List[str]) -> str:
+            return f"['{long_list[0]}', '{long_list[1]}' ... '{long_list[-1]}'] ({len(long_list)} total)"
+
         return {
             "event_name": self.name,
             "raw": [self.perf_data.raw if self.perf_data else None],
@@ -363,7 +367,13 @@ class Event:
             "avg" + _units: self.perf_data.avg if self.perf_data else None,
             "min" + _units: self.perf_data.min if self.perf_data else None,
             "max" + _units: self.perf_data.max if self.perf_data else None,
-            "op_types": [self.op_types],
+            "op_types": [
+                (
+                    self.op_types
+                    if len(self.op_types) < 5
+                    else truncated_list(self.op_types)
+                )
+            ],
             "delegate_debug_identifier": self.delegate_debug_identifier,
             "stack_traces": [self.stack_traces],
             "module_hierarchy": [self.module_hierarchy],
@@ -1039,6 +1049,8 @@ class Inspector:
             filtered_column_df = filtered_column_df[
                 ~filtered_column_df["event_name"].str.contains(filter_name)
             ]
+        filtered_column_df.reset_index(drop=True, inplace=True)
+
         try:
             from IPython import get_ipython
             from IPython.display import display


### PR DESCRIPTION
Summary:
This diffs increases the *readability* of the Inspector print_data_tabular() by doing 2 things:
1. When the op_types list is long, only show the head and tail parts of it;
2. Because we dropped some rows, reindex the dataframe otherwise there're missing numbers in the left most column.

Differential Revision: D54790779


