### PR TITLE
Add config option for log level

### DIFF
--- a/runtime/platform/log.bzl
+++ b/runtime/platform/log.bzl
@@ -1,0 +1,23 @@
+
+def et_logging_enabled():
+    return native.read_config("executorch", "enable_et_log", "true") == "true"
+
+def et_log_level():
+    raw_level = native.read_config("executorch", "log_level", "Info").lower()
+    if raw_level == "debug":
+        return "Debug"
+    elif raw_level == "info":
+        return "Info"
+    elif raw_level == "error":
+        return "Error"
+    elif raw_level == "fatal":
+        return "Fatal"
+    else:
+        fail("Unknown log level '{}'. Expected one of 'Debug', 'Info', 'Error', or 'Fatal'.".format(raw_level))
+
+def get_et_logging_flags():
+    if et_logging_enabled():
+        # On by default.
+        return ["-DET_MIN_LOG_LEVEL=" + et_log_level()]
+    else:
+        return ["-DET_LOG_ENABLED=0"]

--- a/runtime/platform/targets.bzl
+++ b/runtime/platform/targets.bzl
@@ -1,4 +1,5 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load(":log.bzl", "get_et_logging_flags")
 
 def _select_pal(dict_):
     """Returns an element of `dict_` based on the value of the
@@ -9,16 +10,6 @@ def _select_pal(dict_):
     if not pal_default in dict_:
         fail("Missing key for executorch.pal_default value '{}' in dict '{}'".format(pal_default, dict_))
     return dict_[pal_default]
-
-def logging_enabled():
-    return native.read_config("executorch", "enable_et_log", "true") == "true"
-
-def get_logging_flags():
-    if logging_enabled():
-        # On by default.
-        return []
-    else:
-        return ["-DET_LOG_ENABLED=0"]
 
 def profiling_enabled():
     return native.read_config("executorch", "prof_enabled", "false") == "true"
@@ -84,7 +75,7 @@ def define_common_targets():
             "profiler.cpp",
             "runtime.cpp",
         ],
-        exported_preprocessor_flags = get_profiling_flags() + get_logging_flags(),
+        exported_preprocessor_flags = get_profiling_flags() + get_et_logging_flags(),
         exported_deps = [
             "//executorch/runtime/platform:pal_interface",
             ":compiler",


### PR DESCRIPTION
Summary:
Add a buck config option to set the ExecuTorch log level. Used as follows:

`buck2 run ... -c executorch.log_level=[level]`

Where [level] is one of Debug, Info, Error, or Fatal (case-in-sensitive).

Log methods are refactored into a separate bazel file to facilitate re-use. I need to override the XNNPACK log level when ET log level is set to Debug, and I don't want to duplicate the log level parsing logic.

Differential Revision: D54800053


