### PR TITLE
Access last element of vector for current input details

### DIFF
--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -461,13 +461,13 @@ struct PyModule final {
         input_tensors.emplace_back(
             type,
             dim,
-            input_sizes[i].data(),
+            input_sizes.back().data(),
             nullptr,
-            input_dim_order[i].data(),
-            input_strides[i].data());
+            input_dim_order.back().data(),
+            input_strides.back().data());
 
         torch::executor::Tensor temp =
-            torch::executor::Tensor(&input_tensors[i]);
+            torch::executor::Tensor(&input_tensors.back());
         torch::util::alias_etensor_to_attensor(at_tensor, temp);
         EValue evalue(temp);
 #endif


### PR DESCRIPTION
Summary:
In pybindings when iterating on the inputs, preparing them for execution we were using the index `i` to access sizes, dim_order, strides etc. of the current tensor being iterated on. This worked previously because all our inputs were all always tensors.

In the seamless model we ran into a case where the inputs are a mixed tuple of tensors and constants (int's). In this case index `i` is not accurate anymore when accessing `input_tensors` to get the current tensor being operated on because we haven't pushed `i` number of tensors into the `input_tensors` vector as some of the inputs till now were non-tensors.

Differential Revision: D54836802


