### PR TITLE
[ET-VK] Serialize list types from function args

### DIFF
--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -125,6 +125,20 @@ class GraphBuilder {
     ref_mapping_[fb_id] = ref;
   }
 
+  template <typename T>
+  typename std::enable_if<is_valid_scalar_type<T>::value, void>::type
+  add_scalar_list_to_graph(const uint32_t fb_id, std::vector<T>&& value) {
+    ValueRef ref = compute_graph_->add_scalar_list(std::move(value));
+    ref_mapping_[fb_id] = ref;
+  }
+
+  void add_value_list_to_graph(
+      const uint32_t fb_id,
+      std::vector<ValueRef>&& value) {
+    ValueRef ref = compute_graph_->add_value_list(std::move(value));
+    ref_mapping_[fb_id] = ref;
+  }
+
   void add_string_to_graph(const uint32_t fb_id, VkValuePtr value) {
     const auto fb_str = value->value_as_String()->string_val();
     std::string string(fb_str->cbegin(), fb_str->cend());
@@ -149,6 +163,34 @@ class GraphBuilder {
         break;
       case vkgraph::GraphTypes::VkTensor:
         add_tensor_to_graph(fb_id, value->value_as_VkTensor());
+        break;
+      case vkgraph::GraphTypes::IntList:
+        add_scalar_list_to_graph(
+            fb_id,
+            std::vector<int64_t>(
+                value->value_as_IntList()->items()->cbegin(),
+                value->value_as_IntList()->items()->cend()));
+        break;
+      case vkgraph::GraphTypes::DoubleList:
+        add_scalar_list_to_graph(
+            fb_id,
+            std::vector<double>(
+                value->value_as_DoubleList()->items()->cbegin(),
+                value->value_as_DoubleList()->items()->cend()));
+        break;
+      case vkgraph::GraphTypes::BoolList:
+        add_scalar_list_to_graph(
+            fb_id,
+            std::vector<bool>(
+                value->value_as_BoolList()->items()->cbegin(),
+                value->value_as_BoolList()->items()->cend()));
+        break;
+      case vkgraph::GraphTypes::ValueList:
+        add_value_list_to_graph(
+            fb_id,
+            std::vector<ValueRef>(
+                value->value_as_ValueList()->items()->cbegin(),
+                value->value_as_ValueList()->items()->cend()));
         break;
       case vkgraph::GraphTypes::String:
         add_string_to_graph(fb_id, value);

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -122,6 +122,12 @@ ValueRef ComputeGraph::add_staging(
   return idx;
 }
 
+ValueRef ComputeGraph::add_value_list(std::vector<ValueRef>&& value) {
+  ValueRef idx(static_cast<int>(values_.size()));
+  values_.emplace_back(std::move(value));
+  return idx;
+}
+
 ValueRef ComputeGraph::add_string(std::string&& str) {
   ValueRef idx(static_cast<int>(values_.size()));
   values_.emplace_back(std::move(str));

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -143,11 +143,13 @@ class ComputeGraph final {
 
   template <typename T>
   typename std::enable_if<is_valid_scalar_type<T>::value, ValueRef>::type
-  add_scalar_list(std::vector<T>&& values);
+  add_scalar(T value);
 
   template <typename T>
   typename std::enable_if<is_valid_scalar_type<T>::value, ValueRef>::type
-  add_scalar(T value);
+  add_scalar_list(std::vector<T>&& value);
+
+  ValueRef add_value_list(std::vector<ValueRef>&& value);
 
   ValueRef add_string(std::string&& str);
 
@@ -212,17 +214,17 @@ class ComputeGraph final {
 
 template <typename T>
 inline typename std::enable_if<is_valid_scalar_type<T>::value, ValueRef>::type
-ComputeGraph::add_scalar_list(std::vector<T>&& values) {
+ComputeGraph::add_scalar(T value) {
   ValueRef idx(static_cast<int>(values_.size()));
-  values_.emplace_back(std::move(values));
+  values_.emplace_back(value);
   return idx;
 }
 
 template <typename T>
 inline typename std::enable_if<is_valid_scalar_type<T>::value, ValueRef>::type
-ComputeGraph::add_scalar(T value) {
+ComputeGraph::add_scalar_list(std::vector<T>&& value) {
   ValueRef idx(static_cast<int>(values_.size()));
-  values_.emplace_back(value);
+  values_.emplace_back(std::move(value));
   return idx;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2405
* __->__ #2404
* #2403

In https://github.com/pytorch/executorch/pull/2271, we already added
- IntList
- DoubleList
- BoolList
- ValueList

to the schema and the runtime's Value class. Their serialization was incomplete missing two components:
1. Receiving a list in `torch.fx.Node.args`.
2. Receiving a non-tensor in `torch.fx.Node`.

This change completes #1.


Also, this change fixes a bug where values type `bool` matches both types `bool` and `int` and hence were being added twice.

If our type support grows more complex, we can consider using our own types similar to the core Executorch runtime: https://github.com/pytorch/executorch/blob/689796499024fc4a133318d707f4c10db73da967/exir/emit/_emitter.py#L158-L166

Differential Revision: [D54708353](https://our.internmc.facebook.com/intern/diff/D54708353/)