### PR TITLE
Android LLAMA demo app build rule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,13 @@ else()
   set(CMAKE_TOOLCHAIN_IOS OFF)
 endif()
 
+# Detect if an Android toolchain is set.
+if(CMAKE_TOOLCHAIN_FILE MATCHES ".*android\.toolchain\.cmake$")
+  set(CMAKE_TOOLCHAIN_ANDROID ON)
+else()
+  set(CMAKE_TOOLCHAIN_ANDROID OFF)
+endif()
+
 # EXECUTORCH_BUILD_HOST_TARGETS: Option to control the building of host-only
 # tools like `flatc`, along with example executables like `executor_runner` and
 # libraries that it uses, like `gflags`. Disabling this can be helpful when
@@ -328,11 +335,6 @@ if(EXECUTORCH_BUILD_GTESTS)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/googletest)
 endif()
 
-option(EXECUTORCH_BUILD_ANDROID_JNI "Build Android JNI" OFF)
-if(EXECUTORCH_BUILD_ANDROID_JNI)
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/android)
-endif()
-
 if(EXECUTORCH_BUILD_SDK)
   set(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER
       ON
@@ -363,6 +365,12 @@ endif()
 
 if(EXECUTORCH_BUILD_VULKAN)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backends/vulkan)
+endif()
+
+option(EXECUTORCH_BUILD_ANDROID_JNI "Build Android JNI" OFF)
+if(EXECUTORCH_BUILD_ANDROID_JNI)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples/models/llama2/runner)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/android)
 endif()
 
 option(EXECUTORCH_BUILD_QNN "Build the backends/qualcomm directory" OFF)

--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -246,9 +246,10 @@ excludes = [
 ]
 deps = [
   "executorch",
+  "extension_data_loader",
   "extension_module",
   "portable_kernels",
   "quantized_kernels",
   "xnnpack_backend",
 ]
-# ---------------------------------- LLama start ----------------------------------
+# ---------------------------------- LLama end ----------------------------------

--- a/examples/models/llama2/runner/CMakeLists.txt
+++ b/examples/models/llama2/runner/CMakeLists.txt
@@ -16,6 +16,10 @@
 # It should also be cmake-lint clean.
 #
 
+if(NOT EXECUTORCH_ROOT)
+  set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../..)
+endif()
+
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
 #
@@ -34,7 +38,14 @@ list(TRANSFORM _llama_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
 target_include_directories(extension_module
                            INTERFACE ${_common_include_directories})
 
-add_library(llama_runner SHARED ${_llama_runner__srcs})
+if(CMAKE_TOOLCHAIN_IOS OR CMAKE_TOOLCHAIN_ANDROID)
+  # Building a share library on iOS requires code signing
+  # On Android we see duplicated registration when using shared lib
+  add_library(llama_runner STATIC ${_llama_runner__srcs})
+else()
+  add_library(llama_runner SHARED ${_llama_runner__srcs})
+endif()
+
 target_link_libraries(
   llama_runner PUBLIC executorch portable_kernels extension_module
                       extension_data_loader)

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -28,6 +28,8 @@ if(CMAKE_TOOLCHAIN_ANDROID)
     target_compile_options(executorch_jni PUBLIC ${_common_compile_options})
 
     add_library(executorch_llama_jni SHARED jni/jni_layer_llama.cpp)
-    target_link_libraries(executorch_llama_jni fbjni llama_runner portable_ops_lib)
-    target_compile_options(executorch_llama_jni PUBLIC ${_common_compile_options})
+    target_link_libraries(executorch_llama_jni fbjni llama_runner
+                          portable_ops_lib)
+    target_compile_options(executorch_llama_jni PUBLIC
+                           ${_common_compile_options})
 endif()

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -18,7 +18,7 @@ add_subdirectory(
         ${EXECUTORCH_ROOT}/examples/third-party/fbjni
         ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni)
 
-if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*ios\.toolchain\.cmake$")
+if(CMAKE_TOOLCHAIN_ANDROID)
     add_library(executorch_jni SHARED jni/jni_layer.cpp)
     target_link_libraries(executorch_jni extension_data_loader
         extension_module xnn_executor_runner_lib fbjni)
@@ -26,4 +26,8 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*ios\.toolchain\.cmake$")
         target_link_libraries(executorch_jni qnn_executorch_backend)
     endif()
     target_compile_options(executorch_jni PUBLIC ${_common_compile_options})
+
+    add_library(executorch_llama_jni SHARED jni/jni_layer_llama.cpp)
+    target_link_libraries(executorch_llama_jni fbjni llama_runner portable_ops_lib)
+    target_compile_options(executorch_llama_jni PUBLIC ${_common_compile_options})
 endif()

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -23,6 +23,33 @@
 #include <fbjni/ByteBuffer.h>
 #include <fbjni/fbjni.h>
 
+#ifdef __ANDROID__
+#include <android/log.h>
+
+// For Android, write to logcat
+void et_pal_emit_log_message(
+    et_timestamp_t timestamp,
+    et_pal_log_level_t level,
+    const char* filename,
+    const char* function,
+    size_t line,
+    const char* message,
+    size_t length) {
+  int android_log_level = ANDROID_LOG_UNKNOWN;
+  if (level == 'D') {
+    android_log_level = ANDROID_LOG_DEBUG;
+  } else if (level == 'I') {
+    android_log_level = ANDROID_LOG_INFO;
+  } else if (level == 'E') {
+    android_log_level = ANDROID_LOG_ERROR;
+  } else if (level == 'F') {
+    android_log_level = ANDROID_LOG_FATAL;
+  }
+
+  __android_log_print(android_log_level, "LLAMA", "%s", message);
+}
+#endif
+
 using namespace torch::executor;
 
 namespace executorch_jni {

--- a/extension/module/CMakeLists.txt
+++ b/extension/module/CMakeLists.txt
@@ -17,13 +17,14 @@ if(NOT EXECUTORCH_ROOT)
 endif()
 
 list(TRANSFORM _extension_module__srcs PREPEND "${EXECUTORCH_ROOT}/")
-if(CMAKE_TOOLCHAIN_IOS)
+if(CMAKE_TOOLCHAIN_IOS OR CMAKE_TOOLCHAIN_ANDROID)
   # Building a share library on iOS requires code signing
+  # On Android we see duplicated registration when using shared lib
   add_library(extension_module STATIC ${_extension_module__srcs})
 else()
   add_library(extension_module SHARED ${_extension_module__srcs})
 endif()
-target_link_libraries(extension_module PRIVATE executorch)
+target_link_libraries(extension_module PRIVATE executorch extension_data_loader)
 target_include_directories(extension_module PUBLIC ${EXECUTORCH_ROOT}/..)
 target_compile_options(extension_module PUBLIC -Wno-deprecated-declarations
                                                -fPIC)


### PR DESCRIPTION
* Unfortunately, we need to build from ExecuTorch root for Android example, because we need Android toolchain and we can't find required packages like gflags, until we have a better solution.
* Add the CMake rule for Android LLAMA JNI code.
* extension_module depends on in its source.