### PR TITLE
[ExecuTorch Android] Add api to explicitly load a method

### DIFF
--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -275,6 +275,10 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
     return execute_method(methodName->toStdString(), jinputs);
   }
 
+  jint load_method(facebook::jni::alias_ref<jstring> methodName) {
+    return static_cast<jint>(module_->load_method(methodName->toStdString()));
+  }
+
   facebook::jni::local_ref<facebook::jni::JArrayClass<JEValue>> execute_method(
       std::string method,
       facebook::jni::alias_ref<
@@ -343,6 +347,7 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
         makeNativeMethod("initHybrid", ExecuTorchJni::initHybrid),
         makeNativeMethod("forward", ExecuTorchJni::forward),
         makeNativeMethod("execute", ExecuTorchJni::execute),
+        makeNativeMethod("loadMethod", ExecuTorchJni::load_method),
     });
   }
 };

--- a/extension/android/src/main/java/org/pytorch/executorch/INativePeer.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/INativePeer.java
@@ -18,4 +18,11 @@ interface INativePeer {
 
   /** Run an arbitrary method on the module */
   EValue[] execute(String methodName, EValue... inputs);
+
+  /**
+   * Load a method on this module.
+   *
+   * @return the Error code if there was an error loading the method
+   */
+  int loadMethod(String methodName);
 }

--- a/extension/android/src/main/java/org/pytorch/executorch/Module.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/Module.java
@@ -68,6 +68,19 @@ public class Module {
   }
 
   /**
+   * Load a method on this module. This might help with the first time inference performance,
+   * because otherwise the method is loaded lazily when it's execute. Note: this function is
+   * synchronous, and will block until the method is loaded. Therefore, it is recommended to call
+   * this on a background thread. However, users need to make sure that they don't execute before
+   * this function returns.
+   *
+   * @return the Error code if there was an error loading the method
+   */
+  public int loadMethod(String methodName) {
+    return mNativePeer.loadMethod(methodName);
+  }
+
+  /**
    * Explicitly destroys the native torch::jit::Module. Calling this method is not required, as the
    * native object will be destroyed when this object is garbage-collected. However, the timing of
    * garbage collection is not guaranteed, so proactively calling {@code destroy} can free memory

--- a/extension/android/src/main/java/org/pytorch/executorch/NativePeer.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/NativePeer.java
@@ -38,4 +38,7 @@ class NativePeer implements INativePeer {
 
   @DoNotStrip
   public native EValue[] execute(String methodName, EValue... inputs);
+
+  @DoNotStrip
+  public native int loadMethod(String methodName);
 }


### PR DESCRIPTION
Summary:

We lazy load methods during the first execute (forward). However, sometimes we want to explicitly load the method before the first inference, so that we get consistent performance between all runs.

Adding a method so that user can load method, if they wish. Otherwise, they can still depend on execute to lazy load for them.