### PR TITLE
Create model with device='meta'

### DIFF
--- a/examples/models/llama2/llama_transformer.py
+++ b/examples/models/llama2/llama_transformer.py
@@ -110,7 +110,9 @@ def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
 
 
 def precompute_freqs_cis(dim: int, end: int, theta: float):
-    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    freqs = 1.0 / (
+        theta ** (torch.arange(0, dim, 2, device="cpu")[: (dim // 2)].float() / dim)
+    )
     t = torch.arange(end, device=freqs.device)  # pyre-ignore
     freqs = torch.outer(t, freqs).float()  # pyre-ignore
     freqs_cos = torch.cos(freqs)
@@ -171,6 +173,7 @@ class Attention(nn.Module):
         mask = torch.full(
             (1, 1, args.max_seq_len, args.max_seq_len),
             float("-inf"),
+            device="cpu",
         )
 
         mask = torch.triu(mask, diagonal=1)


### PR DESCRIPTION
Summary:
See discussion: D54825007

Two optimizations:
1. Use `mmap=True` to load the checkpoint. 

2. Create model with device="meta". Tensors created in this context do not carry data. Previously, llama7b model was created with fp32 (default), using up 25GB ram. With device="meta", tensors are assigned only when we load the state dict. 

- Note: non-persistent buffers and tensors that do not have keys in the state dict will be created with device="meta" as well. These have to be manually initialized when creating the model.

Checkpoint loading time: 10s -> 0.011s

Peak memory usage: [37.8GB](https://lookaside.facebook.com/intern/diff/file/data/?number=1467921211&download=1) ->[25.5GB](https://lookaside.facebook.com/intern/diff/file/data/?number=1468357208&download=1)
Model creation time:[ 77s](https://lookaside.facebook.com/intern/diff/file/data/?number=1468360493&download=1) -> [11.6s](https://lookaside.facebook.com/intern/diff/file/data/?number=1468364061&download=1)

Follow on: iterate over params/buffers and initialize uninitialized tensors (instead of manually initializing the specific ones) T182328293

thanks iseeyuan for the tips:
https://pytorch.org/tutorials/recipes/recipes/module_load_state_dict_tips.html

Differential Revision: D54871495


