### PR TITLE
Don't partition non_packable constants

### DIFF
--- a/backends/xnnpack/test/ops/add.py
+++ b/backends/xnnpack/test/ops/add.py
@@ -83,6 +83,25 @@ class TestAdd(unittest.TestCase):
             .compare_outputs()
         )
 
+    def test_qs8_add_constant(self):
+        inputs = (torch.randn(4, 4, 4),)
+        (
+            Tester(self.AddConstant(torch.ones(4, 4, 4)), inputs)
+            .quantize()
+            .export()
+            .check_count({"torch.ops.aten.add.Tensor": 4})
+            .to_edge()
+            .check_count({"executorch_exir_dialects_edge__ops_aten_add_Tensor": 4})
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .check_not(["executorch_exir_dialects_edge__ops_aten_add_Tensor"])
+            .to_executorch()
+            .serialize()
+            .dump_artifact("/data/users/maxren/models/q_add_constant.pte")
+            .run_method()
+            .compare_outputs()
+        )
+
     def test_qs8_add(self):
         inputs = (torch.randn(1, 1, 4, 4), torch.randn(1, 1, 4, 4))
         (


### PR DESCRIPTION
Summary:
When constant data is not packed(constant data is packed for weights and biases like those supplied to convolution, bmm, linear, etc.), it is not copied by XNNPACK runtime. As a result, when the flatbuffer payload is freed after init, so are the pointers given to XNNPACK.

We can solve this by unpartitioning constant data nodes which aren't packed. As a result they are owned by ExecuTorch and are not freed by xnnpack delegate after init

Differential Revision: D54877319


