### PR TITLE
Don't absorb constant data unless explicitly tagged

### DIFF
--- a/backends/apple/coreml/partition/coreml_partitioner.py
+++ b/backends/apple/coreml/partition/coreml_partitioner.py
@@ -17,6 +17,7 @@ from executorch.exir.backend.partitioner import (
     Partitioner,
     PartitionResult,
 )
+from executorch.exir.backend.utils import tag_constant_data
 from torch.export.exported_program import ExportedProgram
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
 from torch.fx.passes.operator_support import OperatorSupportBase
@@ -86,6 +87,8 @@ class CoreMLPartitioner(Partitioner):
                 tag = f"tag{partition.id}"
                 node.meta["delegation_tag"] = tag
                 partition_tags[tag] = self.delegation_spec
+
+        tag_constant_data(exported_program)
 
         return PartitionResult(
             tagged_exported_program=exported_program, partition_tags=partition_tags

--- a/backends/apple/mps/partition/mps_partitioner.py
+++ b/backends/apple/mps/partition/mps_partitioner.py
@@ -18,6 +18,7 @@ from executorch.exir.backend.partitioner import (
     Partitioner,
     PartitionResult,
 )
+from executorch.exir.backend.utils import tag_constant_data
 from torch.export.exported_program import ExportedProgram
 from torch.fx.passes.infra.partitioner import Partition
 from torch.fx.passes.operator_support import OperatorSupportBase
@@ -77,6 +78,7 @@ class MPSPartitioner(Partitioner):
         partitions = self.generate_partitions(edge_program=edge_program)
         if self.check_partitions(partitions):
             self.tag_nodes(partitions)
+            tag_constant_data(edge_program)
         x = PartitionResult(
             tagged_exported_program=edge_program, partition_tags=self.partition_tags
         )

--- a/backends/arm/arm_partitioner.py
+++ b/backends/arm/arm_partitioner.py
@@ -16,6 +16,7 @@ from executorch.exir.backend.partitioner import (
     Partitioner,
     PartitionResult,
 )
+from executorch.exir.backend.utils import tag_constant_data
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch.export.exported_program import ExportedProgram
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
@@ -85,6 +86,8 @@ class ArmPartitioner(Partitioner):
                 tag = f"tag{partition.id}"
                 node.meta["delegation_tag"] = tag
                 partition_tags[tag] = self.delegation_spec
+
+        tag_constant_data(exported_program)
 
         return PartitionResult(
             tagged_exported_program=exported_program, partition_tags=partition_tags

--- a/backends/qualcomm/partition/qnn_partitioner.py
+++ b/backends/qualcomm/partition/qnn_partitioner.py
@@ -21,6 +21,7 @@ from executorch.exir.backend.partitioner import (
     Partitioner,
     PartitionResult,
 )
+from executorch.exir.backend.utils import tag_constant_data
 from torch.fx.passes.infra.partitioner import Partition
 from torch.fx.passes.operator_support import OperatorSupportBase
 
@@ -137,6 +138,7 @@ class QnnPartitioner(Partitioner):
         partitions = self.generate_partitions(edge_program)
         if len(partitions) != 0:
             self.tag_nodes(partitions)
+            tag_constant_data(edge_program)
         for node in edge_program.graph_module.graph.nodes:
             if hasattr(node, "meta"):
                 # pop certain keys in meta for not affecting the passes in compilation

--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -15,6 +15,7 @@ from executorch.exir.backend.partitioner import (
     Partitioner,
     PartitionResult,
 )
+from executorch.exir.backend.utils import tag_constant_data
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch.export.exported_program import ExportedProgram
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
@@ -59,6 +60,8 @@ class VulkanPartitioner(Partitioner):
                 tag = f"tag{partition.id}"
                 node.meta["delegation_tag"] = tag
                 partition_tags[tag] = self.delegation_spec
+
+        tag_constant_data(exported_program)
 
         return PartitionResult(
             tagged_exported_program=exported_program, partition_tags=partition_tags

--- a/exir/backend/test/TARGETS
+++ b/exir/backend/test/TARGETS
@@ -292,6 +292,7 @@ python_unittest(
         "//executorch/exir/backend/canonical_partitioners:canonical_partitioner_lib",
         "//executorch/exir/backend/test/demos/rpc:executor_backend_partitioner",
         "//executorch/exir/backend/test/demos/rpc:executor_backend_preprocess",
+        "//executorch/exir/dialects:lib",
         "//executorch/exir/tests:models",
         "//executorch/extension/pybindings:portable_lib",  # @manual
         "//executorch/runtime/executor/test:test_backend_compiler_lib",

--- a/exir/backend/test/hta_partitioner_demo.py
+++ b/exir/backend/test/hta_partitioner_demo.py
@@ -19,6 +19,7 @@ from executorch.exir.backend.partitioner import (
     PartitionResult,
 )
 from executorch.exir.backend.test.qnn_backend_demo import QnnBackend
+from executorch.exir.backend.utils import tag_constant_data
 from torch.export import ExportedProgram
 from torch.fx.passes.infra.partitioner import Partition
 
@@ -199,6 +200,7 @@ class HTAPartitionerMultiplePatternsDemo(Partitioner):
                 delegation_tag = f"tag{partition.id}"
                 node.meta["delegation_tag"] = delegation_tag
                 partition_tags[delegation_tag] = self.delegation_spec
+        tag_constant_data(exported_program)
         return PartitionResult(
             tagged_exported_program=exported_program, partition_tags=partition_tags
         )
@@ -280,6 +282,7 @@ class HTAPartitionerOnePatternDemo(Partitioner):
                 delegation_tag = f"tag{partition.id}"
                 node.meta["delegation_tag"] = delegation_tag
                 partition_tags[delegation_tag] = self.delegation_spec
+        tag_constant_data(exported_program)
         return PartitionResult(
             tagged_exported_program=exported_program, partition_tags=partition_tags
         )

--- a/exir/backend/test/test_backends_lifted.py
+++ b/exir/backend/test/test_backends_lifted.py
@@ -891,10 +891,11 @@ class TestBackends(unittest.TestCase):
             def __init__(self):
                 super().__init__()
                 self.add_one = AddOne()
+                self.add_one_2 = AddOne()
 
             def forward(self, x, y):
                 x = self.add_one(x) * y
-                return self.add_one(x)
+                return self.add_one_2(x)
 
         inputs = (torch.randn(1, 3), torch.randn(1, 3))
         orig_res = Model()(*inputs)

--- a/exir/backend/test/test_partitioner.py
+++ b/exir/backend/test/test_partitioner.py
@@ -7,8 +7,9 @@
 import unittest
 from types import MappingProxyType
 
-from executorch import exir
+import torch
 
+from executorch import exir
 from executorch.exir.backend.backend_details import CompileSpec, ExportedProgram
 from executorch.exir.backend.canonical_partitioners.pattern_op_partitioner import (
     generate_pattern_op_partitions,
@@ -26,6 +27,8 @@ from executorch.exir.backend.test.demos.rpc.executor_backend_preprocess import (
     ExecutorBackend,
 )
 from executorch.exir.backend.utils import get_delegates
+
+from executorch.exir.dialects._ops import ops as exir_ops
 
 from executorch.exir.tests.models import MLP
 from torch._export import capture_pre_autograd_graph
@@ -175,3 +178,280 @@ class TestPartitioner(unittest.TestCase):
             "placeholder node for non-params, non-buffer, and non-tensor constants should not be tagged",
         ):
             _ = edge.to_backend(PartitionerTagInput())
+
+    class AddConst(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.const1 = torch.ones(2, 2)
+            self.register_buffer("const2", torch.ones(2, 2), persistent=False)
+            self.register_parameter("const3", torch.nn.Parameter(torch.ones(2, 2)))
+
+        def forward(self, x):
+            return x + self.const1 + self.const2 + self.const3
+
+    def test_partitioner_not_tag_data(self):
+        """
+        We test here that when partitioners do not explicitly tag constant data nodes,
+        then the partitioned ExportedProgram will not own the data. Instead the owning program
+        will still own the constant data and instead feed it as inputs to the partitioned
+        program
+        """
+
+        class PartitionerNoTagData(Partitioner):
+            def __init__(self):
+                super().__init__()
+                self.delegation_spec = DelegationSpec(
+                    ExecutorBackend.__name__,
+                    [CompileSpec(key, value) for key, value in self.spec.items()],
+                )
+
+            def partition(
+                self, edge_exported_program: ExportedProgram
+            ) -> PartitionResult:
+                partition_tags = {}
+                for node in edge_exported_program.graph.nodes:
+                    if node.op == "call_function" and node.target in [
+                        exir_ops.edge.aten.add.Tensor
+                    ]:
+                        delegation_tag = "tag0"
+                        node.meta["delegation_tag"] = delegation_tag
+                        partition_tags[delegation_tag] = self.delegation_spec
+
+                return PartitionResult(
+                    tagged_exported_program=edge_exported_program,
+                    partition_tags=partition_tags,
+                )
+
+        model = capture_pre_autograd_graph(self.AddConst(), (torch.ones(2, 2),))
+        edge = exir.to_edge(export(model, (torch.ones(2, 2),)))
+        delegated = edge.to_backend(PartitionerNoTagData())
+
+        # Check Owning Program still owns all constant data
+        owning_program = delegated.exported_program()
+        self.assertEqual(len(owning_program.state_dict), 3)
+        self.assertEqual(len(owning_program.graph_signature.buffers), 2)
+        self.assertEqual(len(owning_program.graph_signature.parameters), 1)
+
+        # Check Lowered Module Exported Program does not have any constant data
+        lowered_module_nodes = get_delegates(delegated.exported_program().graph)
+        self.assertEqual(len(lowered_module_nodes), 1)
+        lowered_module_node = lowered_module_nodes[0]
+
+        # get call delegate node
+        call_delegate_node = list(lowered_module_node.users.keys())[0]
+        # 5 args to lowered module are: delegated_payload, x, const1, const2, const3
+        self.assertEqual(len(call_delegate_node.args), 5)
+        lower_module = getattr(
+            delegated.exported_program().graph_module, lowered_module_node.name
+        )
+        delegated_ep = lower_module.original_module
+        self.assertEqual(len(delegated_ep.state_dict), 0)
+        self.assertEqual(len(delegated_ep.graph_signature.buffers), 0)
+        self.assertEqual(len(delegated_ep.graph_signature.parameters), 0)
+
+        # check exported program is still runnable
+        output = delegated.exported_program().module()(torch.ones(2, 2))
+        reference_output = model(torch.ones(2, 2))
+        self.assertTrue(torch.allclose(reference_output, output))
+
+    def test_partitioner_tag_data(self):
+        """
+        We test here that when partitioners explicitly tag constant data nodes,
+        then the partitioned ExportedProgram will own the data, and the data will
+        be removed from the owning program.
+        """
+
+        class PartitionerTagData(Partitioner):
+            def __init__(self):
+                super().__init__()
+                self.delegation_spec = DelegationSpec(
+                    ExecutorBackend.__name__,
+                    [CompileSpec(key, value) for key, value in self.spec.items()],
+                )
+
+            def partition(
+                self, edge_exported_program: ExportedProgram
+            ) -> PartitionResult:
+                partition_tags = {}
+                for node in edge_exported_program.graph.nodes:
+                    if node.op == "call_function" and node.target in [
+                        exir_ops.edge.aten.add.Tensor
+                    ]:
+                        delegation_tag = "tag0"
+                        node.meta["delegation_tag"] = delegation_tag
+                        partition_tags[delegation_tag] = self.delegation_spec
+
+                    if node.op == "placeholder" and (
+                        is_param(edge_exported_program, node)
+                        or is_buffer(edge_exported_program, node)
+                    ):
+                        delegation_tag = "tag0"
+                        node.meta["delegation_tag"] = delegation_tag
+                        partition_tags[delegation_tag] = self.delegation_spec
+
+                return PartitionResult(
+                    tagged_exported_program=edge_exported_program,
+                    partition_tags=partition_tags,
+                )
+
+        model = capture_pre_autograd_graph(self.AddConst(), (torch.ones(2, 2),))
+        edge = exir.to_edge(export(model, (torch.ones(2, 2),)))
+        delegated = edge.to_backend(PartitionerTagData())
+
+        # Check Owning Program still owns all constant data
+        owning_program = delegated.exported_program()
+        self.assertEqual(len(owning_program.state_dict), 0)
+        self.assertEqual(len(owning_program.graph_signature.buffers), 0)
+        self.assertEqual(len(owning_program.graph_signature.parameters), 0)
+
+        # Check Lowered Module Exported Program does not have any constant data
+        lowered_module_nodes = get_delegates(delegated.exported_program().graph)
+        self.assertEqual(len(lowered_module_nodes), 1)
+        lowered_module_node = lowered_module_nodes[0]
+
+        # get call delegate node
+        call_delegate_node = list(lowered_module_node.users.keys())[0]
+        # 5 args to lowered module are: delegated_payload, x
+        self.assertEqual(len(call_delegate_node.args), 2)
+        lower_module = getattr(
+            delegated.exported_program().graph_module, lowered_module_node.name
+        )
+        delegated_ep = lower_module.original_module
+        self.assertEqual(len(delegated_ep.state_dict), 3)
+        self.assertEqual(len(delegated_ep.graph_signature.buffers), 2)
+        self.assertEqual(len(delegated_ep.graph_signature.parameters), 1)
+
+        # check exported program is still runnable
+        output = delegated.exported_program().module()(torch.ones(2, 2))
+        reference_output = model(torch.ones(2, 2))
+        self.assertTrue(torch.allclose(reference_output, output))
+
+    def test_partitioner_tag_only_params(self):
+        """
+        We test here that when partitioners explicitly tag constant data nodes,
+        then the partitioned ExportedProgram will own the data, and the data will
+        be removed from the owning program.
+        """
+
+        class PartitionerTagData(Partitioner):
+            def __init__(self):
+                super().__init__()
+                self.delegation_spec = DelegationSpec(
+                    ExecutorBackend.__name__,
+                    [CompileSpec(key, value) for key, value in self.spec.items()],
+                )
+
+            def partition(
+                self, edge_exported_program: ExportedProgram
+            ) -> PartitionResult:
+                partition_tags = {}
+                for node in edge_exported_program.graph.nodes:
+                    if node.op == "call_function" and node.target in [
+                        exir_ops.edge.aten.add.Tensor
+                    ]:
+                        delegation_tag = "tag0"
+                        node.meta["delegation_tag"] = delegation_tag
+                        partition_tags[delegation_tag] = self.delegation_spec
+
+                    if node.op == "placeholder" and (
+                        is_param(edge_exported_program, node)
+                    ):
+                        delegation_tag = "tag0"
+                        node.meta["delegation_tag"] = delegation_tag
+                        partition_tags[delegation_tag] = self.delegation_spec
+
+                return PartitionResult(
+                    tagged_exported_program=edge_exported_program,
+                    partition_tags=partition_tags,
+                )
+
+        model = capture_pre_autograd_graph(self.AddConst(), (torch.ones(2, 2),))
+        edge = exir.to_edge(export(model, (torch.ones(2, 2),)))
+        delegated = edge.to_backend(PartitionerTagData())
+
+        # Check Owning Program still owns only buffers
+        owning_program = delegated.exported_program()
+        self.assertEqual(len(owning_program.state_dict), 2)
+        self.assertEqual(len(owning_program.graph_signature.buffers), 2)
+        self.assertEqual(len(owning_program.graph_signature.parameters), 0)
+
+        # Check Lowered Module Exported Program does not own any buffers
+        lowered_module_nodes = get_delegates(delegated.exported_program().graph)
+        self.assertEqual(len(lowered_module_nodes), 1)
+        lowered_module_node = lowered_module_nodes[0]
+
+        # get call delegate node
+        call_delegate_node = list(lowered_module_node.users.keys())[0]
+        # 5 args to lowered module are: delegated_payload, x, buffer1, buffer2
+        self.assertEqual(len(call_delegate_node.args), 4)
+        lower_module = getattr(
+            delegated.exported_program().graph_module, lowered_module_node.name
+        )
+        delegated_ep = lower_module.original_module
+        self.assertEqual(len(delegated_ep.state_dict), 1)
+        self.assertEqual(len(delegated_ep.graph_signature.buffers), 0)
+        self.assertEqual(len(delegated_ep.graph_signature.parameters), 1)
+
+        # check exported program is still runnable
+        output = delegated.exported_program().module()(torch.ones(2, 2))
+        reference_output = model(torch.ones(2, 2))
+        self.assertTrue(torch.allclose(reference_output, output))
+
+    def test_partitioner_splits_constant_data(self):
+        """
+        We test that we throw an error when constant data users are split
+        between different delegated payloads or owning program.
+        """
+
+        class ReuseConstData(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.const = torch.ones(2, 2)
+
+            def forward(self, x):
+                y = x + self.const
+                z = x - self.const
+                return y, z
+
+        class PartitionerTagData(Partitioner):
+            def __init__(self):
+                super().__init__()
+                self.delegation_spec = DelegationSpec(
+                    ExecutorBackend.__name__,
+                    [CompileSpec(key, value) for key, value in self.spec.items()],
+                )
+
+            def partition(
+                self, edge_exported_program: ExportedProgram
+            ) -> PartitionResult:
+                partition_tags = {}
+                for node in edge_exported_program.graph.nodes:
+                    if node.op == "call_function" and node.target in [
+                        exir_ops.edge.aten.add.Tensor
+                    ]:
+                        delegation_tag = "tag0"
+                        node.meta["delegation_tag"] = delegation_tag
+                        partition_tags[delegation_tag] = self.delegation_spec
+
+                    if node.op == "placeholder" and (
+                        is_param(edge_exported_program, node)
+                        or is_buffer(edge_exported_program, node)
+                    ):
+                        delegation_tag = "tag0"
+                        node.meta["delegation_tag"] = delegation_tag
+                        partition_tags[delegation_tag] = self.delegation_spec
+
+                return PartitionResult(
+                    tagged_exported_program=edge_exported_program,
+                    partition_tags=partition_tags,
+                )
+
+        model = capture_pre_autograd_graph(ReuseConstData(), (torch.ones(2, 2),))
+        edge = exir.to_edge(export(model, (torch.ones(2, 2),)))
+        with self.assertRaises(RuntimeError) as error:
+            _ = edge.to_backend(PartitionerTagData())
+
+        self.assertEqual(
+            "constant data node (arg0_1) is tagged with (tag0) but has user (aten_sub_tensor) which has tag (None)",
+            str(error.exception),
+        )

--- a/exir/backend/utils.py
+++ b/exir/backend/utils.py
@@ -11,11 +11,13 @@ from functools import lru_cache
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import torch
+from executorch.exir.backend.backend_details import ExportedProgram
 from executorch.exir.common import setting_python_recursive_limit
 from executorch.exir.delegate import executorch_call_delegate
 from executorch.exir.dialects._ops import ops as exir_ops
 
 from executorch.exir.lowered_backend_module import create_submodule_from_nodes
+from torch._export.utils import is_buffer, is_lifted_tensor_constant, is_param
 from torch.fx.node import Node
 from torch.fx.passes.utils.source_matcher_utils import SourcePartition
 
@@ -258,6 +260,38 @@ def print_delegated_graph(graph_module: torch.fx.GraphModule) -> str:
                 )
     print(graph_format_str)
     return graph_format_str
+
+
+def tag_constant_data(edge_program: ExportedProgram) -> None:
+    """
+    Util function for partitioners. This function tags the const/param/buffers nodes
+    whose users all belong within the same partition. This should be called after tagging all other nodes.
+    Any const/param/buffer which is used as input to a subgraph, will be tagged with the same tag as that
+    subgraph. Throw error when const/param/buffers is used across different partitions. That is the
+    underlying data will be owned by multiple delegates.
+    """
+    for node in edge_program.graph.nodes:
+        # go through const/param/buffer nodes
+        is_attr = (
+            node.op == "placeholder"
+            and (
+                is_param(edge_program, node)
+                or is_buffer(edge_program, node)
+                or is_lifted_tensor_constant(edge_program, node)
+            )
+        ) or (node.op == "get_attr")
+        # if all users of const/param/buffer nodes are partitioned then partition
+        if is_attr:
+            user_tags = set()
+            for user in node.users:
+                user_tags.add(user.meta.get("delegation_tag", None))
+            assert len(user_tags) <= 1, (
+                "Const/Param/Buffer users have multiple tags because one constant data can't "
+                "be owned by multiple backends. Consider duplicating the constant data so that "
+                "each user is unique"
+            )
+            if len(user_tags) == 1:
+                node.meta["delegation_tag"] = user_tags.pop()
 
 
 # TODO - style: use templated types


### PR DESCRIPTION
Summary:
As long as constant data is used as input to a partitioned graph, it will be absorbed by the partitioned edge program. Meaning all constant data would be moved from the owning program to the partitioned program. 

Delegates owning data is not always a desired affect. Delegates should instead be able to choose whether or not they want to take ownership of the data by explicitly tagging the constant data nodes. If they are tagged, then transfer ownership to the delegate, if they are not tagged, then constant data will be owned by overarching edge_program and fed in as inputs to the delegate.

This changes enables this functionality. Note that delegates owning data now must be explicitly tagged. Delegates with partitioners which previously did not tag data will now have to do so in order to preserve their functionality.

Differential Revision: D54874255


