### PR TITLE
Enable GPTQ in executorch

### DIFF
--- a/examples/models/llama2/llama_transformer.py
+++ b/examples/models/llama2/llama_transformer.py
@@ -464,9 +464,9 @@ class Transformer(nn.Module):
             freqs_cos = self.freqs_cos[sp : sp + seqlen]
             freqs_sin = self.freqs_sin[sp : sp + seqlen]
         else:
-            assert (
-                start_pos is None and cache_k is None and cache_v is None
-            ), "Caches and start_pos are unused when use_kv_cache is False"
+            # assert (
+            #     start_pos is None and cache_k is None and cache_v is None
+            # ), "Caches and start_pos are unused when use_kv_cache is False"
             freqs_cos = self.freqs_cos[:seqlen]
             freqs_sin = self.freqs_sin[:seqlen]
 

--- a/examples/models/llama2/quantize.py
+++ b/examples/models/llama2/quantize.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from .ops.quantized_ops import *  # noqa
 
+# TODO: move to correct place
 from torchao.quantization.quant_primitives import (
     get_group_qparams_symmetric,
     group_quantize_tensor_symmetric,
@@ -652,7 +653,7 @@ class Int8DynActInt4WeightLinear(torch.nn.Module):
             self.scales,
             self.zeros,
             self.out_features,
-            self.groupsize,
+            self.group_size,
             self.precision,
         )
 
@@ -737,7 +738,6 @@ class GPTQQuantHandler(QuantHandler):
     """
 
     def __init__(self):
-        assert self.mod is not None
         assert self.get_qparams_func is not None
         assert self.quantize_func is not None
         assert self.dequantize_func is not None


### PR DESCRIPTION
Summary:
Previously we just added the code but didn't test it, this PR also tests gptq locally to make sure we can produce a model using gptq from torchao repo

Test Plan:
python3 -m examples.models.llama2.export_llama -c stories110M.pt -p params.json -qmode 8da4w-gptq -X -d fp32

Reviewers:

Subscribers:

Tasks:

Tags: