### PR TITLE
[ET-VK] Fix OSS build for Vulkan Delegate

### DIFF
--- a/backends/vulkan/CMakeLists.txt
+++ b/backends/vulkan/CMakeLists.txt
@@ -8,7 +8,7 @@
 #
 # This file should be formatted with
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format --first-comment-is-literal=True -i CMakeLists.txt
 # ~~~
 # It should also be cmake-lint clean.
 #
@@ -32,7 +32,10 @@ if(NOT FLATC_EXECUTABLE)
   set(FLATC_EXECUTABLE flatc)
 endif()
 
-# Include this file to access target_link_options_shared_lib
+# Include this file to access target_link_options_shared_lib This is required to
+# provide access to target_link_options_shared_lib which allows libraries to be
+# linked with the --whole-archive flag. This is required for libraries that
+# perform dynamic registration via static initialization.
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 
 # ATen Vulkan Libs
@@ -48,12 +51,19 @@ set(COMMON_INCLUDES ${VULKAN_API_HEADERS} ${EXECUTORCH_ROOT}/..)
 file(GLOB_RECURSE vulkan_graph_cpp ${RUNTIME_PATH}/graph/*)
 
 add_library(vulkan_graph_lib STATIC ${vulkan_graph_cpp})
-
 target_include_directories(vulkan_graph_lib PRIVATE ${COMMON_INCLUDES})
-
-target_link_libraries(vulkan_graph_lib vulkan_shader_lib)
-
+target_link_libraries(${LIBRARY_NAME} vulkan_api_lib)
 target_compile_options(vulkan_graph_lib PRIVATE ${VULKAN_CXX_FLAGS})
+# Link this library with --whole-archive due to dynamic operator registrations
+target_link_options_shared_lib(vulkan_graph_lib)
+
+# Due to dynamic registrations, these libraries must be explicitly linked
+set(VULKAN_STANDARD_OPS_LIBS vulkan_graph_lib vulkan_graph_shaderlib)
+
+# vulkan_graph_shaderlib
+
+set(VULKAN_GRAPH_SHADERS_PATH ${RUNTIME_PATH}/graph/ops/glsl/)
+vulkan_shader_library(${VULKAN_GRAPH_SHADERS_PATH} vulkan_graph_shaderlib)
 
 # Generate Files from flatc
 
@@ -85,19 +95,12 @@ target_include_directories(
 file(GLOB vulkan_backend_cpp ${RUNTIME_PATH}/*.cpp)
 
 add_library(vulkan_backend ${vulkan_backend_cpp})
-
-target_include_directories(vulkan_backend PRIVATE ${SCHEMA_INCLUDE_DIR})
-target_include_directories(vulkan_backend PRIVATE ${COMMON_INCLUDES})
-
-target_link_libraries(vulkan_backend PRIVATE vulkan_graph_lib)
-target_link_libraries(vulkan_backend PRIVATE vulkan_schema)
-target_link_libraries(vulkan_backend PRIVATE executorch)
-
+target_include_directories(vulkan_backend PRIVATE ${SCHEMA_INCLUDE_DIR}
+                                                  ${COMMON_INCLUDES})
+target_link_libraries(vulkan_backend PRIVATE vulkan_graph_lib vulkan_schema
+                                             executorch)
 target_compile_options(vulkan_backend PRIVATE ${VULKAN_CXX_FLAGS})
-
-# This is required to ensure that vulkan_backend gets linked with
-# --whole-archive since backends are registered via static variables that would
-# otherwise be discarded
+# Link this library with --whole-archive due to dynamic backend registration
 target_link_options_shared_lib(vulkan_backend)
 
 # Executor Runner
@@ -105,28 +108,38 @@ target_link_options_shared_lib(vulkan_backend)
 if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
   set(VULKAN_RUNNER_SRCS ${_executor_runner__srcs})
   list(TRANSFORM VULKAN_RUNNER_SRCS PREPEND "${EXECUTORCH_ROOT}/")
+
   add_executable(vulkan_executor_runner ${VULKAN_RUNNER_SRCS})
-  target_link_libraries(vulkan_executor_runner ${_executor_runner_libs})
-  target_link_libraries(vulkan_executor_runner vulkan_schema)
-  target_link_libraries(vulkan_executor_runner vulkan_backend)
+  target_link_libraries(
+    vulkan_executor_runner ${_executor_runner_libs} vulkan_schema
+    vulkan_backend ${VULKAN_STANDARD_OPS_LIBS})
   target_compile_options(vulkan_executor_runner PUBLIC ${VULKAN_CXX_FLAGS})
 
   add_library(vulkan_executor_runner_lib STATIC ${VULKAN_RUNNER_SRCS})
-  target_link_libraries(vulkan_executor_runner_lib ${_executor_runner_libs})
-  target_link_libraries(vulkan_executor_runner_lib vulkan_schema)
-  target_link_libraries(vulkan_executor_runner_lib vulkan_backend)
+  target_link_libraries(vulkan_executor_runner_lib ${_executor_runner_libs}
+                        vulkan_schema vulkan_backend)
   target_compile_options(vulkan_executor_runner_lib PUBLIC ${VULKAN_CXX_FLAGS})
 endif()
 
 # Test targets
 
 if(EXECUTORCH_BUILD_GTESTS)
+  set(TEST_UTILS_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/test/utils)
+  file(GLOB TEST_UTILS_CPP ${CMAKE_CURRENT_SOURCE_DIR}/test/utils/*.cpp)
+
+  set(TEST_SHADERS_PATH ${CMAKE_CURRENT_SOURCE_DIR}/test/glsl)
+  vulkan_shader_library(${TEST_SHADERS_PATH} test_shaderlib)
+
   # vulkan_compute_api_test
-  set(TEST_CPP ${CMAKE_CURRENT_SOURCE_DIR}/test/vulkan_compute_api_test.cpp)
-  add_executable(vulkan_compute_api_test ${TEST_CPP})
-  target_include_directories(vulkan_compute_api_test PRIVATE ${COMMON_INCLUDES})
-  target_link_libraries(vulkan_compute_api_test vulkan_api_lib)
-  target_link_libraries(vulkan_compute_api_test vulkan_graph_lib)
-  target_link_libraries(vulkan_compute_api_test gtest_main)
+  set(COMPUTE_API_TEST_CPP
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/vulkan_compute_api_test.cpp)
+
+  add_executable(vulkan_compute_api_test ${COMPUTE_API_TEST_CPP}
+                                         ${TEST_UTILS_CPP})
+  target_include_directories(vulkan_compute_api_test
+                             PRIVATE ${COMMON_INCLUDES} ${TEST_UTILS_HEADERS})
+  target_link_libraries(
+    vulkan_compute_api_test PRIVATE gtest_main ${VULKAN_STANDARD_OPS_LIBS}
+                                    test_shaderlib)
   target_compile_options(vulkan_compute_api_test PRIVATE ${VULKAN_CXX_FLAGS})
 endif()

--- a/backends/vulkan/test/glsl/all_shaders.yaml
+++ b/backends/vulkan/test/glsl/all_shaders.yaml
@@ -1,6 +1,13 @@
 binary_op_nobroadcast__test:
   parameter_names_with_default_values:
+    DTYPE: float
     OPERATOR: X + Y
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: "half"
+        SUFFIX: "half"
+      - VALUE: "float"
+        SUFFIX: "float"
   shader_variants:
     - NAME: binary_add_nobroadcast__test
       OPERATOR: X + Y
@@ -12,6 +19,19 @@ binary_op_nobroadcast__test:
       OPERATOR: X / Y
     - NAME: binary_pow_nobroadcast__test
       OPERATOR: pow(X, Y)
+
+fill_texture__test:
+  parameter_names_with_default_values:
+    DTYPE: float
+    NDIM: 3
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: "half"
+        SUFFIX: "half"
+      - VALUE: "float"
+        SUFFIX: "float"
+  shader_variants:
+    - NAME: fill_texture__test
 
 image_to_nchw__test:
   parameter_names_with_default_values:

--- a/backends/vulkan/test/glsl/binary_op_nobroadcast__test.glsl
+++ b/backends/vulkan/test/glsl/binary_op_nobroadcast__test.glsl
@@ -9,7 +9,6 @@
 #version 450 core
 // clang-format off
 #define PRECISION ${PRECISION}
-#define FORMAT ${FORMAT}
 
 #define OP(X, Y) ${OPERATOR}
 // clang-format on
@@ -17,7 +16,7 @@
 layout(std430) buffer;
 
 // clang-format off
-layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D image_out;
+layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly image3D image_out;
 // clang-format on
 layout(set = 0, binding = 1) uniform PRECISION sampler3D image_in;
 layout(set = 0, binding = 2) uniform PRECISION sampler3D image_other;

--- a/backends/vulkan/test/glsl/fill_texture__test.glsl
+++ b/backends/vulkan/test/glsl/fill_texture__test.glsl
@@ -8,14 +8,13 @@
 
 #version 450 core
 #define PRECISION ${PRECISION}
-#define FORMAT ${FORMAT}
 
 layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
 // clang-format off
-layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D uOutput;
+layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly ${IMAGE_T[NDIM][DTYPE]} uOutput;
 // clang-format on
 layout(set = 0, binding = 1) uniform PRECISION restrict Block {
   ivec3 size;

--- a/backends/vulkan/test/utils/test_utils.h
+++ b/backends/vulkan/test/utils/test_utils.h
@@ -12,6 +12,7 @@
 
 #include <ATen/native/vulkan/api/api.h>
 
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/StagingUtils.h>
 
 using namespace at::native::vulkan;
@@ -70,9 +71,9 @@ void record_image_to_nchw_op(
     vTensor& v_src,
     api::VulkanBuffer& dst_buffer);
 
-void record_arithmetic_op(
+void record_binary_op(
     api::Context* const context,
-    const api::ShaderInfo& compute_shader,
+    const std::string& op_name,
     vTensor& v_in1,
     vTensor& v_in2,
     vTensor& v_dst);

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -51,6 +51,10 @@ TEST_F(VulkanComputeAPITest, update_params_between_submit) {
   std::vector<int64_t> sizes = {4, 4, 2};
   vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
 
+  std::stringstream kernel_name;
+  kernel_name << "fill_texture__test";
+  apply_dtype_suffix(kernel_name, a);
+
   struct Params final {
     api::utils::ivec3 size;
     int32_t fill;
@@ -68,7 +72,7 @@ TEST_F(VulkanComputeAPITest, update_params_between_submit) {
   {
     api::PipelineBarrier pipeline_barrier{};
     api::context()->submit_compute_job(
-        VK_KERNEL(fill_texture__test),
+        VK_KERNEL_FROM_STR(kernel_name.str()),
         pipeline_barrier,
         {4, 4, 4},
         {4, 4, 4},
@@ -111,8 +115,7 @@ TEST_F(VulkanComputeAPITest, texture_add_sanity_check) {
   fill_vtensor(b, 1.5f);
 
   // a + b -> c
-  record_arithmetic_op(
-      api::context(), VK_KERNEL(binary_add_nobroadcast__test), a, b, c);
+  record_binary_op(api::context(), "add", a, b, c);
 
   // Extract output tensor
   std::vector<float> data_out = extract_vtensor(c);
@@ -140,8 +143,6 @@ TEST_F(VulkanComputeAPITest, texture_deferred_allocation_test) {
   std::vector<float> data_b(b.gpu_numel());
   std::fill(data_b.begin(), data_b.end(), 1.5f);
 
-  api::ShaderInfo kernel = VK_KERNEL(binary_add_nobroadcast__test);
-
   // Allocate memory at the last possible opportunity
   api::MemoryAllocation a_mem = allocate_memory_for(a);
   a.image().bind_allocation(a_mem);
@@ -156,7 +157,7 @@ TEST_F(VulkanComputeAPITest, texture_deferred_allocation_test) {
   fill_vtensor(a, data_a);
   fill_vtensor(b, data_b);
 
-  record_arithmetic_op(api::context(), kernel, a, b, c);
+  record_binary_op(api::context(), "add", a, b, c);
 
   std::vector<float> data_c(c.gpu_numel());
   extract_vtensor(c, data_c);
@@ -205,21 +206,18 @@ TEST_F(VulkanComputeAPITest, texture_resource_aliasing_test) {
   std::vector<float> data_d(b.gpu_numel());
   std::fill(data_d.begin(), data_d.end(), 1.0f);
 
-  // Get shader kernel for add
-  api::ShaderInfo kernel = VK_KERNEL(binary_add_nobroadcast__test);
-
   // First, fill a and b with data
   fill_vtensor(a, data_a);
   fill_vtensor(b, data_b);
 
   // a + b -> c
-  record_arithmetic_op(api::context(), kernel, a, b, c);
+  record_binary_op(api::context(), "add", a, b, c);
 
   // Now d can be filled with data
   fill_vtensor(d, data_d);
 
   // c + d -> e
-  record_arithmetic_op(api::context(), kernel, c, d, e);
+  record_binary_op(api::context(), "add", c, d, e);
 
   // Extract data from e
   std::vector<float> data_e(e.gpu_numel());
@@ -352,8 +350,7 @@ TEST_F(VulkanComputeAPITest, texture_virtual_resize) {
   fill_staging(staging_buffer_a, 11.5f);
   fill_staging(staging_buffer_b, 12.5f);
 
-  record_arithmetic_op(
-      api::context(), VK_KERNEL(binary_add_nobroadcast__test), a, b, c);
+  record_binary_op(api::context(), "add", a, b, c);
 
   DEFINE_STAGING_BUFFER_AND_RECORD_FROM_GPU_FOR(c)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2434

## Context

Recent changes to the Vulkan backend and PyTorch Vulkan API requires that the CMake build for the Vulkan delegate be reworked. This PR updates the CMake rules for the Vulkan delegate and makes sure that the Vulkan delegate can build correctly.

Differential Revision: [D54914149](https://our.internmc.facebook.com/intern/diff/D54914149)