### PR TITLE
Move macros out of torch::executor namespace

### DIFF
--- a/extension/aten_util/make_aten_functor_from_et_functor.h
+++ b/extension/aten_util/make_aten_functor_from_et_functor.h
@@ -164,15 +164,16 @@ struct wrapper_impl<R (*)(Args...), f, int, N> {
   }
 };
 
+} // namespace executor
+} // namespace torch
+
 // Wrapper macro for out variant function. N is the index of the out tensor.
 // We need N to know how to preserve the semantics of modifying out tensor and
 // return the reference without allocating a new memory buffer for out tensor.
 #define _WRAP_2(func, N) \
-  wrapper_impl<decltype(&func), func, decltype(N), N>::wrap
-#define _WRAP_1(func) wrapper_impl<decltype(&func), func>::wrap
+  ::torch::executor::wrapper_impl<decltype(&func), func, decltype(N), N>::wrap
+#define _WRAP_1(func) \
+  ::torch::executor::wrapper_impl<decltype(&func), func>::wrap
 
 #define GET_MACRO(_1, _2, NAME, ...) NAME
 #define WRAP_TO_ATEN(...) GET_MACRO(__VA_ARGS__, _WRAP_2, _WRAP_1)(__VA_ARGS__)
-
-} // namespace executor
-} // namespace torch

--- a/extension/kernel_util/make_boxed_from_unboxed_functor.h
+++ b/extension/kernel_util/make_boxed_from_unboxed_functor.h
@@ -138,8 +138,10 @@ static Kernel make_boxed_kernel(const char* name, FuncType) {
   return Kernel(name, WrapUnboxedIntoFunctor<FuncType>::call);
 }
 
-#define EXECUTORCH_LIBRARY(ns, op_name, func) \
-  static auto res_##ns = register_kernels(    \
-      make_boxed_kernel(#ns "::" op_name, EXECUTORCH_FN(func)))
 } // namespace executor
 } // namespace torch
+
+#define EXECUTORCH_LIBRARY(ns, op_name, func)                 \
+  static auto res_##ns = ::torch::executor::register_kernels( \
+      ::torch::executor::make_boxed_kernel(                   \
+          #ns "::" op_name, EXECUTORCH_FN(func)))


### PR DESCRIPTION
Summary: So that we can use `EXECUTORCH_LIBRARY` and `WRAP_TO_ATEN` outside of `torch::executor` namespace.

Reviewed By: lucylq

Differential Revision: D54918164


