### PR TITLE
Delete loop unroll in SDPA op

### DIFF
--- a/examples/models/llama2/custom_ops/op_sdpa.cpp
+++ b/examples/models/llama2/custom_ops/op_sdpa.cpp
@@ -177,10 +177,6 @@ inline void fill_stub(scalar_t* data, scalar_t val, int64_t size) {
   for (; d < size - (size % Vec::size()); d += Vec::size()) {
     data_vec.store(data + d);
   }
-#if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE) && \
-    !defined(__ANDROID__)
-#pragma unroll
-#endif
   for (; d < size; d++) {
     data[d] = val;
   }


### PR DESCRIPTION
Summary: Delete #pragma unroll as it's causing compiler errors when building llama/runner.cpp for AOSP targets

Differential Revision: D54916248


