### PR TITLE
[ET-VK] Serialize NoneType as Null/None

### DIFF
--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -127,6 +127,11 @@ class GraphBuilder {
     ref_mapping_[fb_id] = ref;
   }
 
+  void add_none_to_graph(const uint32_t fb_id) {
+    ValueRef ref = compute_graph_->add_none();
+    ref_mapping_[fb_id] = ref;
+  }
+
   template <typename T>
   typename std::enable_if<is_valid_scalar_type<T>::value, void>::type
   add_scalar_to_graph(const uint32_t fb_id, T value) {
@@ -161,6 +166,9 @@ class GraphBuilder {
         "Trying to add a value that has already been added to the graph.");
 
     switch (value->value_type()) {
+      case vkgraph::GraphTypes::Null:
+        add_none_to_graph(fb_id);
+        break;
       case vkgraph::GraphTypes::Int:
         add_scalar_to_graph(fb_id, value->value_as_Int()->int_val());
         break;

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -122,6 +122,12 @@ ValueRef ComputeGraph::add_staging(
   return idx;
 }
 
+ValueRef ComputeGraph::add_none() {
+  ValueRef idx(static_cast<int>(values_.size()));
+  values_.emplace_back();
+  return idx;
+}
+
 ValueRef ComputeGraph::add_value_list(std::vector<ValueRef>&& value) {
   ValueRef idx(static_cast<int>(values_.size()));
   values_.emplace_back(std::move(value));

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -141,6 +141,8 @@ class ComputeGraph final {
       const void* const data);
   ValueRef add_staging(const api::ScalarType dtype, const size_t numel);
 
+  ValueRef add_none();
+
   template <typename T>
   typename std::enable_if<is_valid_scalar_type<T>::value, ValueRef>::type
   add_scalar(T value);

--- a/backends/vulkan/runtime/graph/containers/Value.h
+++ b/backends/vulkan/runtime/graph/containers/Value.h
@@ -182,6 +182,16 @@ struct Value final {
     }
   }
 
+  //
+  // Constructors, isType(), toType()
+  //
+
+  Value() : tag(TypeTag::NONE) {}
+
+  inline bool isNone() const {
+    return tag == TypeTag::NONE;
+  }
+
 #define SUPPORT_TRIVIALLY_COPYABLE_TYPE(                    \
     type, type_name, type_tag, member_name)                 \
   explicit Value(type t) : tag(type_tag) {                  \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

For operators that have optional types such as [`aten.clamp.default`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/native_functions.yaml#L1482), we obtain a `NoneType` if they are not specified.

Hence, we serialize `NoneType` as a `Null` type. Since the `NULL` keyword is reserved in C++, and the `None` keyword is reserved in Python, this leads to the usage of both names in our pipeline. Oh well.
```
NoneType -> create_null_value() -> GraphTypes.Null -> add_none_to_graph() -> add_none() -> TypeTag::NONE
```

Additionally, some nit reordering of functions and switch statements to roughly match [the schema order](https://github.com/pytorch/executorch/blob/main/backends/vulkan/serialization/schema.fbs#L67-L78).
```
union GraphTypes {
  Null,
  Int,
  Double,
  Bool,
  VkTensor,
  IntList,
  DoubleList,
  BoolList,
  ValueList,
  String,
}
```

This change is a sample of what adding operators to ET-VK will look like.

It copies the core logic from [`clamp.glsl`](https://github.com/pytorch/pytorch/blob/cceabe873f11c6611f627a3bb0055994952ec6b8/aten/src/ATen/native/vulkan/glsl/clamp.glsl) and [`Clamp.cpp`](https://github.com/pytorch/pytorch/blob/cceabe873f11c6611f627a3bb0055994952ec6b8/aten/src/ATen/native/vulkan/ops/Clamp.cpp) into the new framework.

Differential Revision: [D54927551](https://our.internmc.facebook.com/intern/diff/D54927551/)