### PR TITLE
[ET-VK][Ops] aten.clamp, aten.hardtanh, aten.relu

### DIFF
--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -25,12 +25,18 @@ from torch.fx.passes.operator_support import OperatorSupportBase
 class VulkanSupportedOperators(OperatorSupportBase):
     def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
         supported = node.op == "call_function" and node.target in [
+            # BinaryOp
             exir_ops.edge.aten.add.Tensor,
+            exir_ops.edge.aten.sub.Tensor,
+            exir_ops.edge.aten.mul.Tensor,
             exir_ops.edge.aten.div.Tensor,
             exir_ops.edge.aten.div.Tensor_mode,
-            exir_ops.edge.aten.mul.Tensor,
-            exir_ops.edge.aten.sub.Tensor,
             exir_ops.edge.aten.pow.Tensor_Tensor,
+            # Clamp
+            exir_ops.edge.aten.clamp.default,
+            exir_ops.edge.aten.hardtanh.default,
+            exir_ops.edge.aten.relu.default,
+            # Other
             operator.getitem,
         ]
         return supported

--- a/backends/vulkan/runtime/graph/ops/glsl/all_shaders.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/all_shaders.yaml
@@ -29,6 +29,19 @@ binary_op:
     - NAME: binary_floor_divide
       OPERATOR: floor(X / Y)
 
+clamp:
+  parameter_names_with_default_values:
+    NDIM: 3
+    DTYPE: float
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: "half"
+        SUFFIX: "half"
+      - VALUE: "float"
+        SUFFIX: "float"
+  shader_variants:
+    - NAME: clamp
+
 image_to_nchw:
   parameter_names_with_default_values:
     NDIM: 3

--- a/backends/vulkan/runtime/graph/ops/glsl/clamp.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/clamp.glsl
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+
+#define PRECISION ${PRECISION}
+
+layout(std430) buffer;
+
+layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly ${IMAGE_T[NDIM][DTYPE]} image_out;
+layout(set = 0, binding = 1) uniform PRECISION sampler3D image_in;
+
+layout(set = 0, binding = 2) uniform PRECISION restrict OutSizes {
+  ivec4 data;
+}
+out_sizes;
+
+layout(set = 0, binding = 3) uniform PRECISION restrict Min {
+  float data;
+}
+minimum;
+
+layout(set = 0, binding = 4) uniform PRECISION restrict Max {
+  float data;
+}
+maximum;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  vec4 in_texel = texelFetch(image_in, pos, 0);
+
+  imageStore(image_out, pos, clamp(in_texel, minimum.data, maximum.data));
+}

--- a/backends/vulkan/runtime/graph/ops/impl/Clamp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Clamp.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/ScalarUtils.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+void resize_clamp_node(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& extra_args) {
+  (void)extra_args;
+  vTensor& out = graph->get_val(args[0].refs[0]).toTensor();
+  vTensor& self = graph->get_val(args[1].refs[0]).toTensor();
+
+  std::vector<int64_t> new_out_sizes(self.sizes().size());
+
+  for (int i = 0; i < new_out_sizes.size(); ++i) {
+    new_out_sizes.at(i) = api::utils::val_at(i, self.sizes());
+  }
+
+  out.virtual_resize(new_out_sizes);
+}
+
+void add_clamp_node(
+    ComputeGraph& graph,
+    const ValueRef in,
+    const float min,
+    const float max,
+    const ValueRef out) {
+  ValueRef arg = prepack_if_tensor_ref(graph, in);
+
+  vTensor& t_out = graph.get_val(out).toTensor();
+  api::utils::uvec3 global_size = t_out.virtual_extents();
+  api::utils::uvec3 local_size = adaptive_work_group_size(global_size);
+
+  std::stringstream kernel_name;
+  kernel_name << "clamp";
+  apply_dtype_suffix(kernel_name, t_out);
+
+  graph.execute_nodes().emplace_back(new ExecuteNode(
+      graph,
+      VK_KERNEL_FROM_STR(kernel_name.str()),
+      global_size,
+      local_size,
+      // Inputs and Outputs
+      {{out, api::MemoryAccessType::WRITE}, {arg, api::MemoryAccessType::READ}},
+      // Shader params buffers
+      {t_out.gpu_sizes_ubo(),
+       graph.create_params_buffer(min),
+       graph.create_params_buffer(max)},
+      // Resizing
+      resize_clamp_node));
+}
+
+float get_val_or_inf(ComputeGraph& graph, const ValueRef& val, bool max) {
+  if (!graph.get_val(val).isNone()) {
+    return extract_scalar<float>(graph.get_val(val));
+  }
+  return max ? std::numeric_limits<float>::infinity()
+             : -std::numeric_limits<float>::infinity();
+}
+
+#define DEFINE_CLAMP_FN(op_name)                                         \
+  void op_name(ComputeGraph& graph, const std::vector<ValueRef>& args) { \
+    return add_clamp_node(                                               \
+        graph,                                                           \
+        args[0],                                                         \
+        get_val_or_inf(graph, args[1], /*max =*/false),                  \
+        get_val_or_inf(graph, args[2], /*max =*/true),                   \
+        args[3]);                                                        \
+  }
+
+#define DEFINE_RELU_FN(op_name)                                              \
+  void op_name(ComputeGraph& graph, const std::vector<ValueRef>& args) {     \
+    return add_clamp_node(                                                   \
+        graph, args[0], 0, std::numeric_limits<float>::infinity(), args[1]); \
+  }
+
+DEFINE_CLAMP_FN(clamp);
+DEFINE_CLAMP_FN(hardtanh);
+DEFINE_RELU_FN(relu);
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(aten.clamp.default, clamp);
+  VK_REGISTER_OP(aten.hardtanh.default, hardtanh);
+  VK_REGISTER_OP(aten.relu.default, relu);
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -253,6 +253,46 @@ class TestBackends(unittest.TestCase):
 
         self.lower_module_and_test_output(pow_module, sample_inputs)
 
+    def test_vulkan_backend_clamp(self):
+        class ClampModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.clamp(x, min=-3.14)
+
+        clamp_module = ClampModule()
+        sample_inputs = (torch.rand(size=(1, 8, 96, 72), dtype=torch.float32),)
+
+        self.lower_module_and_test_output(clamp_module, sample_inputs)
+
+    def test_vulkan_backend_hardtanh(self):
+        class HardTanHModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.tanh = torch.nn.Hardtanh(min_val=-3.14, max_val=6.28)
+
+            def forward(self, x):
+                return self.tanh(x)
+
+        hard_tanh_module = HardTanHModule()
+        sample_inputs = (torch.rand(size=(1, 8, 96, 72), dtype=torch.float32),)
+
+        self.lower_module_and_test_output(hard_tanh_module, sample_inputs)
+
+    def test_vulkan_backend_relu(self):
+        class ReLUModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.relu(x)
+
+        relu_module = ReLUModule()
+        sample_inputs = (torch.rand(size=(1, 8, 96, 72), dtype=torch.float32),)
+
+        self.lower_module_and_test_output(relu_module, sample_inputs)
+
     def test_vulkan_backend_partial(self):
         class SimpleModel(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

EZ operator for warmup. The most complicated logic is merging them.
```
- func: clamp(Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor
- func: hardtanh(Tensor self, Scalar min_val=-1, Scalar max_val=1) -> Tensor
- func: relu(Tensor self) -> Tensor
```

Differential Revision: [D54886406](https://our.internmc.facebook.com/intern/diff/D54886406/)