### PR TITLE
pybind env var

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,7 @@ cmdclass = {
     "egg_info": CustomEggInfoCommand,
 }
 ext_modules = None
-if os.environ.get("EXECUTORCH_BUILD_PYBIND", None):
+if os.environ.get("EXECUTORCH_BUILD_PYBIND", "OFF") == "ON":
     cmdclass["build_ext"] = CMakeBuild
     ext_modules = [CMakeExtension("executorch.extension.pybindings.portable_lib")]
 


### PR DESCRIPTION
Summary:
Check the value of `EXECUTORCH_BUILD_PYBIND`, by default set to false, and build pybind if on.

Previously, seeing error P1196368933 when running ./install_requirements.sh , without `--pybind` flag.

Reviewed By: shoumikhin

Differential Revision: D54928464


