### PR TITLE
Upload apple ios artifacts

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -135,5 +135,5 @@ jobs:
 
           for FILENAME in "${RUNNER_TEMP}"/frameworks-ios/*.zip; do
             [ -e "${FILENAME}" ] || continue
-            ${AWS_CMD} "${FILENAME}" s3://ossci-ios/ --acl public-read
+            ${AWS_CMD} "${FILENAME}" s3://ossci-ios/executorch/ --acl public-read
           done

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -95,7 +95,6 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build-frameworks-ios
     timeout-minutes: 30
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     permissions:
       id-token: write
       contents: read
@@ -116,4 +115,25 @@ jobs:
           # NB: The name here needs to match the upload-artifact name from build-frameworks-ios job
           name: executorch-frameworks-ios
           path: ${{ runner.temp }}/frameworks-ios/
-      - run: make deploy
+      - name: Only push to S3 from main branch
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        shell: bash
+        run: |
+          set -eux
+          echo "UPLOAD_ON_MAIN=1" >> "${GITHUB_ENV}"
+      - name: Upload the artifact to ossci-ios S3 bucket
+        shell: bash
+        run: |
+          set -eux
+
+          pip install awscli==1.32.18
+
+          AWS_CMD="aws s3 cp --dryrun"
+          if [[ "${UPLOAD_ON_MAIN:-0}" == "1" ]]; then
+            AWS_CMD="aws s3 cp"
+          fi
+
+          for FILENAME in "${RUNNER_TEMP}"/frameworks-ios/*.zip; do
+            [ -e "${FILENAME}" ] || continue
+            ${AWS_CMD} "${FILENAME}" s3://ossci-ios/ --acl public-read
+          done

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -58,7 +58,7 @@ jobs:
       python-version: '3.11'
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      upload-artifact: executorch.zip
+      upload-artifact: executorch-frameworks-ios
       timeout: 90
       script: |
         WORKSPACE=$(pwd)
@@ -90,3 +90,30 @@ jobs:
         zip -r "${RUNNER_TEMP}/artifacts/${OUTPUT}.zip" "${OUTPUT}"
 
         popd
+
+  upload-frameworks-ios:
+    runs-on: ubuntu-22.04
+    needs: build-frameworks-ios
+    timeout-minutes: 30
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: pip
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1.7.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_executorch_upload-frameworks-ios
+          aws-region: us-east-1
+      - name: Download the artifact
+        uses: actions/download-artifact@v3
+        with:
+          # NB: The name here needs to match the upload-artifact name from build-frameworks-ios job
+          name: executorch-frameworks-ios
+          path: ${{ runner.temp }}/frameworks-ios/
+      - run: make deploy

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - .ci/docker/**
-      - .github/workflows/app-build.yml
+      - .github/workflows/apple.yml
       - install_requirements.sh
       - backends/apple/**
       - build/build_apple_frameworks.sh


### PR DESCRIPTION
The role `arn:aws:iam::308535385114:role/gha_executorch_upload-frameworks-ios` needs to be created by https://github.com/pytorch-labs/pytorch-gha-infra/pull/358 first before this can be landed.

The frameworks zip archive will be uploaded to `s3://ossci-ios/executorch`

### Testing

https://github.com/pytorch/executorch/actions/runs/8290224151/job/22722065037?pr=2449#step:7:81