### PR TITLE
make the graph comilation based on xnnpack compile config

### DIFF
--- a/backends/xnnpack/partition/graphs/bilinear_2d.py
+++ b/backends/xnnpack/partition/graphs/bilinear_2d.py
@@ -10,6 +10,8 @@ from typing import Dict, List
 import executorch.exir as exir
 import torch
 
+from executorch.backends.xnnpack.utils.configs import get_xnnpack_edge_compile_config
+
 
 @lru_cache(maxsize=None)
 def _get_bilinear_2d_graphs():
@@ -37,7 +39,9 @@ def _get_bilinear_2d_graphs():
         for config in capture_configs:
             edge = exir.capture(
                 bilinear2d(align_corners), sample_inputs, config
-            ).to_edge()
+            ).to_edge(
+                config=get_xnnpack_edge_compile_config(),
+            )
             _bilinear2d_graphs[edge.exported_program.graph_module] = align_corners
     return _bilinear2d_graphs
 

--- a/backends/xnnpack/partition/graphs/sdpa.py
+++ b/backends/xnnpack/partition/graphs/sdpa.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from typing import List, Optional
 
 import torch
+from executorch.backends.xnnpack.utils.configs import get_xnnpack_edge_compile_config
 from executorch.exir import to_edge
 from torch import Tensor
 from torch.export import export
@@ -75,7 +76,8 @@ def get_graphs() -> List[torch.fx.GraphModule]:
                         v,
                         mask,
                     ),
-                )
+                ),
+                compile_config=get_xnnpack_edge_compile_config(),
             )
             gm = edge.exported_program().graph_module
             graphs.append(gm)


### PR DESCRIPTION
Summary: This diff makes graphs modules under xnnpack rely on xnnpack compile config, to make xnnpack compile config control edge compilation, and easier to control the flow.

Differential Revision: D54929119


