### PR TITLE
Change install requirements for lm-eval

### DIFF
--- a/examples/models/llama2/install_requirements.sh
+++ b/examples/models/llama2/install_requirements.sh
@@ -10,13 +10,8 @@
 pip install snakeviz sentencepiece
 pip install torchao-nightly
 
-# Install datasets for HuggingFace dataloader
-# v2.14.0 is intentional to force lm-eval v0.3.0 compatibility
-pip install datasets==2.14.0
-
 # Install lm-eval for Model Evaluation with lm-evalution-harness
-# v0.3.0 is intentional
-pip install lm-eval==0.3.
+pip install lm-eval
 
 # Call the install helper for further setup
 python examples/models/llama2/install_requirement_helper.py


### PR DESCRIPTION
Summary:
Previously, explicit `datasets`  and `lm-eval` package versions were required due to conflicting requirements with ET.

As a result of recent pin and requirement bumps, the conflicts are resolved.

Removing explicit versions

Differential Revision: D54934068


