### PR TITLE
Add torchao dependency

### DIFF
--- a/exir/passes/TARGETS
+++ b/exir/passes/TARGETS
@@ -127,6 +127,7 @@ python_library(
         "//caffe2:torch",
         "//executorch/exir:pass_base",
         "//executorch/exir/dialects:lib",
+        "//pytorch/ao:torchao",
     ],
 )
 

--- a/exir/passes/_quant_patterns_and_replacements.py
+++ b/exir/passes/_quant_patterns_and_replacements.py
@@ -15,7 +15,7 @@ from executorch.exir.passes.replace_aten_with_edge_pass import (
     should_lower_to_edge,
 )
 from torch import fx
-from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib
+from torchao.quantization.quant_primitives import quantized_decomposed_lib
 
 
 __all__ = [

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -77,3 +77,6 @@ pip install . --no-build-isolation -v
 
 # Install flatc dependency
 bash build/install_flatc.sh
+
+# Install torchao dependency
+pip install torchao-nightly


### PR DESCRIPTION
Summary: This is needed outside llama2 because xnnpack had dqlinears which uses the new per_token and groupwise q/dq introduced by torchao.

Differential Revision: D54957630
