### PR TITLE
Remove RemoveRedundantViewCopyPass

### DIFF
--- a/exir/passes/normalize_view_copy_base_pass.py
+++ b/exir/passes/normalize_view_copy_base_pass.py
@@ -29,8 +29,6 @@ class NormalizeViewCopyBasePass(PassBase):
 
     When combined with dead-code elimination, this pass removes redundant
     view_copy nodes.
-
-    TODO: replace RemoveRedundantViewCopyPass with NormalizeViewCopyBasePass + dead code elimination.
     """
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -24,6 +24,7 @@ from executorch.exir.pass_manager import PassType
 from executorch.exir.passes import (
     base_post_op_replace_passes,
     base_pre_op_replace_passes,
+    dead_code_elimination_pass,
     EdgeToBackendOpsPass,
     MemoryFormatOpsPass,
     OpReplacePass,
@@ -626,6 +627,7 @@ def pre_memory_planning_passes(config: ExecutorchBackendConfig) -> List[PassType
         # pyre-ignore
         return [
             NormalizeViewCopyBasePass(),
+            dead_code_elimination_pass,
             ReplaceViewCopyWithViewPass(),
             config.sym_shape_eval_pass,
             config.to_out_var_pass,


### PR DESCRIPTION
Summary: The RemoveRedundantViewCopyPass is unnecessary and can be replaced by NormalizeViewCopyBasePass + dead code elimintation.

Differential Revision: D54866523


