### PR TITLE
Fix flatcc + pybindings linking on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,7 +453,6 @@ if(EXECUTORCH_BUILD_PYBIND)
       etdump
       executorch
       extension_data_loader
-      flatcc
       portable_ops_lib
       util
       torch

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -53,6 +53,11 @@ endforeach()
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../third-party/flatcc
                  ${CMAKE_BINARY_DIR}/third-party/flatcc)
 
+# Fix for "relocation R_X86_64_32 against `.rodata' can not be used when making
+# a shared object; recompile with -fPIC" when building on some x86 linux
+# systems.
+set_property(TARGET flatccrt PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 # Assume we are cross-compiling and the CMAKE_TOOLCHAIN_FILE is set
 include(ExternalProject)
 
@@ -118,7 +123,7 @@ add_library(etdump ${CMAKE_CURRENT_SOURCE_DIR}/etdump/etdump_flatcc.cpp
 
 target_link_libraries(
   etdump
-  PUBLIC etdump_schema flatcc
+  PUBLIC etdump_schema flatccrt
   PRIVATE executorch)
 
 add_custom_command(
@@ -148,7 +153,7 @@ target_include_directories(
 
 # Install libraries
 install(
-  TARGETS bundled_program etdump flatcc
+  TARGETS bundled_program etdump flatccrt
   DESTINATION ${CMAKE_BINARY_DIR}/lib
   INCLUDES
   DESTINATION ${_common_include_directories})


### PR DESCRIPTION
Summary:
On some linux systems, the pybindings build would fail with

`relocation R_X86_64_32 against '.rodata' can not be used when making a shared object; recompile with -fPIC`

Digging into it further, I also noticed that etdump was depending on `libflatcc` (the compiler) instead of `libflatccrt` (the runtime).

Fix that dep, then mark `flatccrt` as positition-independent (thus adding `-fPIC` on appropriate systems) to fix the pybindings build.

Differential Revision: D54966723


