### PR TITLE
Get access to ExecuTorch

### DIFF
--- a/backends/vulkan/TARGETS
+++ b/backends/vulkan/TARGETS
@@ -19,6 +19,7 @@ runtime.python_library(
     visibility = [
         "//executorch/...",
         "//executorch/vulkan/...",
+        "@EXECUTORCH_CLIENTS",
     ],
     deps = [
         "//executorch/exir:graph_module",


### PR DESCRIPTION
Summary: Need to access ExecuTorch to export EMG-hw model for wrist devices' Vulkan GPU.

Reviewed By: JacobSzwejbka, dbort

Differential Revision: D54963814


