### PR TITLE
Dynamic ViT

### DIFF
--- a/backends/xnnpack/test/models/deeplab_v3.py
+++ b/backends/xnnpack/test/models/deeplab_v3.py
@@ -36,6 +36,5 @@ class TestDeepLabV3(unittest.TestCase):
             .partition()
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/models/edsr.py
+++ b/backends/xnnpack/test/models/edsr.py
@@ -25,8 +25,7 @@ class TestEDSR(unittest.TestCase):
             .partition()
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_edsr(self):
@@ -38,6 +37,5 @@ class TestEDSR(unittest.TestCase):
             .partition()
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/models/emformer_rnnt.py
+++ b/backends/xnnpack/test/models/emformer_rnnt.py
@@ -21,8 +21,8 @@ class TestEmformerModel(unittest.TestCase):
             self.rnnt = decoder.model
 
     class Joiner(EmformerRnnt):
-        def forward(self, predict_inputs):
-            return self.rnnt.join(*predict_inputs)
+        def forward(self, a, b, c, d):
+            return self.rnnt.join(a, b, c, d)
 
         def get_example_inputs(self):
             join_inputs = (
@@ -31,7 +31,7 @@ class TestEmformerModel(unittest.TestCase):
                 torch.rand([1, 128, 1024]),
                 torch.tensor([128]),
             )
-            return (join_inputs,)
+            return join_inputs
 
     def test_fp32_emformer_joiner(self):
         joiner = self.Joiner()
@@ -43,21 +43,19 @@ class TestEmformerModel(unittest.TestCase):
             .check(["torch.ops.higher_order.executorch_call_delegate"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     class Predictor(EmformerRnnt):
-        def forward(self, predict_inputs):
-            return self.rnnt.predict(*predict_inputs)
+        def forward(self, a, b):
+            return self.rnnt.predict(a, b, None)
 
         def get_example_inputs(self):
             predict_inputs = (
                 torch.zeros([1, 128], dtype=int),
                 torch.tensor([128], dtype=int),
-                None,
             )
-            return (predict_inputs,)
+            return predict_inputs
 
     @unittest.skip("T183426271")
     def test_fp32_emformer_predictor(self):
@@ -70,20 +68,19 @@ class TestEmformerModel(unittest.TestCase):
             .check(["torch.ops.higher_order.executorch_call_delegate"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     class Transcriber(EmformerRnnt):
-        def forward(self, predict_inputs):
-            return self.rnnt.transcribe(*predict_inputs)
+        def forward(self, a, b):
+            return self.rnnt.transcribe(a, b)
 
         def get_example_inputs(self):
             transcribe_inputs = (
                 torch.randn(1, 128, 80),
                 torch.tensor([128]),
             )
-            return (transcribe_inputs,)
+            return transcribe_inputs
 
     def test_fp32_emformer_transcriber(self):
         transcriber = self.Transcriber()
@@ -95,6 +92,5 @@ class TestEmformerModel(unittest.TestCase):
             .check(["torch.ops.higher_order.executorch_call_delegate"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/models/inception_v3.py
+++ b/backends/xnnpack/test/models/inception_v3.py
@@ -42,8 +42,7 @@ class TestInceptionV3(unittest.TestCase):
             .check_not(list(self.all_operators))
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_ic3(self):
@@ -63,6 +62,5 @@ class TestInceptionV3(unittest.TestCase):
             .check_not(list(ops_after_quantization))
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/models/inception_v4.py
+++ b/backends/xnnpack/test/models/inception_v4.py
@@ -39,8 +39,7 @@ class TestInceptionV4(unittest.TestCase):
             .check_not(list(self.all_operators))
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_ic4(self):
@@ -60,6 +59,5 @@ class TestInceptionV4(unittest.TestCase):
             .check_not(list(ops_after_quantization))
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/models/llama2_et_example.py
+++ b/backends/xnnpack/test/models/llama2_et_example.py
@@ -45,6 +45,5 @@ class TestLlama2ETExample(unittest.TestCase):
             .dump_artifact()
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs(atol=5e-2)
+            .run_method_and_compare_outputs(atol=5e-2)
         )

--- a/backends/xnnpack/test/models/mobilebert.py
+++ b/backends/xnnpack/test/models/mobilebert.py
@@ -38,6 +38,5 @@ class TestMobilebert(unittest.TestCase):
             .check_not(list(self.supported_ops))
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/models/mobilenet_v2.py
+++ b/backends/xnnpack/test/models/mobilenet_v2.py
@@ -29,9 +29,15 @@ class TestMobileNetV2(unittest.TestCase):
     }
 
     def test_fp32_mv2(self):
+        dynamic_shapes = (
+            {
+                2: torch.export.Dim("height", min=224, max=455),
+                3: torch.export.Dim("width", min=224, max=455),
+            },
+        )
 
         (
-            Tester(self.mv2, self.model_inputs)
+            Tester(self.mv2, self.model_inputs, dynamic_shapes=dynamic_shapes)
             .export()
             .to_edge()
             .check(list(self.all_operators))
@@ -40,7 +46,7 @@ class TestMobileNetV2(unittest.TestCase):
             .check_not(list(self.all_operators))
             .to_executorch()
             .serialize()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(num_runs=10)
         )
 
     def test_qs8_mv2(self):
@@ -49,8 +55,15 @@ class TestMobileNetV2(unittest.TestCase):
             "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
         }
 
+        dynamic_shapes = (
+            {
+                2: torch.export.Dim("height", min=224, max=455),
+                3: torch.export.Dim("width", min=224, max=455),
+            },
+        )
+
         (
-            Tester(self.mv2, self.model_inputs)
+            Tester(self.mv2, self.model_inputs, dynamic_shapes=dynamic_shapes)
             .quantize(Quantize(calibrate=False))
             .export()
             .to_edge()
@@ -60,5 +73,5 @@ class TestMobileNetV2(unittest.TestCase):
             .check_not(list(ops_after_quantization))
             .to_executorch()
             .serialize()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(num_runs=10)
         )

--- a/backends/xnnpack/test/models/mobilenet_v2.py
+++ b/backends/xnnpack/test/models/mobilenet_v2.py
@@ -40,8 +40,7 @@ class TestMobileNetV2(unittest.TestCase):
             .check_not(list(self.all_operators))
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_mv2(self):
@@ -61,6 +60,5 @@ class TestMobileNetV2(unittest.TestCase):
             .check_not(list(ops_after_quantization))
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/models/mobilenet_v3.py
+++ b/backends/xnnpack/test/models/mobilenet_v3.py
@@ -16,6 +16,12 @@ class TestMobileNetV3(unittest.TestCase):
     mv3 = models.mobilenetv3.mobilenet_v3_small(pretrained=True)
     mv3 = mv3.eval()
     model_inputs = (torch.ones(1, 3, 224, 224),)
+    dynamic_shapes = (
+        {
+            2: torch.export.Dim("height", min=224, max=455),
+            3: torch.export.Dim("width", min=224, max=455),
+        },
+    )
 
     all_operators = {
         "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
@@ -33,7 +39,7 @@ class TestMobileNetV3(unittest.TestCase):
 
     def test_fp32_mv3(self):
         (
-            Tester(self.mv3, self.model_inputs)
+            Tester(self.mv3, self.model_inputs, dynamic_shapes=self.dynamic_shapes)
             .export()
             .to_edge()
             .check(list(self.all_operators))
@@ -42,7 +48,7 @@ class TestMobileNetV3(unittest.TestCase):
             .check_not(list(self.all_operators))
             .to_executorch()
             .serialize()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(num_runs=5)
         )
 
     def test_qs8_mv3(self):
@@ -52,7 +58,7 @@ class TestMobileNetV3(unittest.TestCase):
         ops_after_lowering = self.all_operators
 
         (
-            Tester(self.mv3, self.model_inputs)
+            Tester(self.mv3, self.model_inputs, dynamic_shapes=self.dynamic_shapes)
             .quantize(Quantize(calibrate=False))
             .export()
             .to_edge()
@@ -62,5 +68,5 @@ class TestMobileNetV3(unittest.TestCase):
             .check_not(list(ops_after_lowering))
             .to_executorch()
             .serialize()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(num_runs=5)
         )

--- a/backends/xnnpack/test/models/mobilenet_v3.py
+++ b/backends/xnnpack/test/models/mobilenet_v3.py
@@ -42,8 +42,7 @@ class TestMobileNetV3(unittest.TestCase):
             .check_not(list(self.all_operators))
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_mv3(self):
@@ -63,6 +62,5 @@ class TestMobileNetV3(unittest.TestCase):
             .check_not(list(ops_after_lowering))
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/models/resnet.py
+++ b/backends/xnnpack/test/models/resnet.py
@@ -23,8 +23,7 @@ class TestResNet18(unittest.TestCase):
             .partition()
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_resnet18(self):
@@ -37,6 +36,5 @@ class TestResNet18(unittest.TestCase):
             .partition()
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/models/resnet.py
+++ b/backends/xnnpack/test/models/resnet.py
@@ -14,27 +14,63 @@ from executorch.backends.xnnpack.test.tester.tester import Quantize
 
 
 class TestResNet18(unittest.TestCase):
-    def test_fp32_resnet18(self):
-        inputs = (torch.ones(1, 3, 224, 224),)
+    inputs = (torch.ones(1, 3, 224, 224),)
+    dynamic_shapes = (
+        {
+            2: torch.export.Dim("height", min=224, max=455),
+            3: torch.export.Dim("width", min=224, max=455),
+        },
+    )
+
+    class DynamicResNet(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = torchvision.models.resnet18()
+
+        def forward(self, x):
+            x = torch.nn.functional.interpolate(
+                x,
+                size=(224, 224),
+                mode="bilinear",
+                align_corners=True,
+                antialias=False,
+            )
+            return self.model(x)
+
+    def _test_exported_resnet(self, tester):
         (
-            Tester(torchvision.models.resnet18(), inputs)
-            .export()
+            tester.export()
             .to_edge()
             .partition()
+            .check_not(
+                [
+                    "executorch_exir_dialects_edge__ops_aten_convolution_default",
+                    "executorch_exir_dialects_edge__ops_aten_mean_dim",
+                ]
+            )
+            .check(["torch.ops.higher_order.executorch_call_delegate"])
             .to_executorch()
             .serialize()
             .run_method_and_compare_outputs()
         )
 
+    def test_fp32_resnet18(self):
+        self._test_exported_resnet(Tester(torchvision.models.resnet18(), self.inputs))
+
     def test_qs8_resnet18(self):
-        inputs = (torch.ones(1, 3, 224, 224),)
-        (
-            Tester(torchvision.models.resnet18(), inputs)
-            .quantize(Quantize(calibrate=False))
-            .export()
-            .to_edge()
-            .partition()
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
+        quantized_tester = Tester(torchvision.models.resnet18(), self.inputs).quantize(
+            Quantize(calibrate=False)
+        )
+        self._test_exported_resnet(quantized_tester)
+
+    def test_fp32_resnet18_dynamic(self):
+        self._test_exported_resnet(
+            Tester(self.DynamicResNet(), self.inputs, self.dynamic_shapes)
+        )
+
+    def test_qs8_resnet18_dynamic(self):
+        self._test_exported_resnet(
+            Tester(self.DynamicResNet(), self.inputs, self.dynamic_shapes).quantize(
+                Quantize(calibrate=False)
+            )
         )

--- a/backends/xnnpack/test/models/torchvision_vit.py
+++ b/backends/xnnpack/test/models/torchvision_vit.py
@@ -57,6 +57,5 @@ class TestViT(unittest.TestCase):
             .check_not(list(lowerable_xnn_operators))
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/models/torchvision_vit.py
+++ b/backends/xnnpack/test/models/torchvision_vit.py
@@ -15,6 +15,29 @@ class TestViT(unittest.TestCase):
     vit = models.vision_transformer.vit_b_16(weights="IMAGENET1K_V1")
     vit = vit.eval()
     model_inputs = (torch.ones(1, 3, 224, 224),)
+    dynamic_shapes = (
+        {
+            2: torch.export.Dim("height", min=224, max=455),
+            3: torch.export.Dim("width", min=224, max=455),
+        },
+    )
+
+    class DynamicViT(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.vit = models.vision_transformer.vit_b_16(weights="IMAGENET1K_V1")
+            self.vit = self.vit.eval()
+
+        def forward(self, x):
+            x = torch.nn.functional.interpolate(
+                x,
+                size=(224, 224),
+                mode="bilinear",
+                align_corners=True,
+                antialias=False,
+            )
+            return self.vit(x)
+
     all_operators = {
         "executorch_exir_dialects_edge__ops_aten_expand_copy_default",
         "executorch_exir_dialects_edge__ops_aten_cat_default",
@@ -34,7 +57,8 @@ class TestViT(unittest.TestCase):
         "executorch_exir_dialects_edge__ops_aten_bmm_default",
     }
 
-    def test_fp32_vit(self):
+    def _test_exported_vit(self, tester, check_nots=None):
+        check_nots = check_nots or []
         lowerable_xnn_operators = self.all_operators - {
             "executorch_exir_dialects_edge__ops_aten_expand_copy_default",
             "executorch_exir_dialects_edge__ops_aten_gelu_default",
@@ -48,14 +72,33 @@ class TestViT(unittest.TestCase):
             "executorch_exir_dialects_edge__ops_aten_bmm_default",
         }
         (
-            Tester(self.vit, self.model_inputs)
-            .export()
+            tester.export()
             .to_edge()
             .check(list(self.all_operators))
             .partition()
             .check(["torch.ops.higher_order.executorch_call_delegate"])
             .check_not(list(lowerable_xnn_operators))
+            .check_not(check_nots)
             .to_executorch()
             .serialize()
             .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_vit(self):
+        self._test_exported_vit(Tester(self.vit, self.model_inputs))
+
+    def test_dynamic_vit(self):
+        bilinear_ops = {
+            "executorch_exir_dialects_edge__ops_aten_sub_Tensor",
+            "executorch_exir_dialects_edge__ops_aten_mul_Tensor",
+            "executorch_exir_dialects_edge__ops_aten_index_Tensor",
+            "executorch_exir_dialects_edge__ops_aten_arange_start_step",
+            "executorch_exir_dialects_edge__ops_aten__to_copy_default",
+            "executorch_exir_dialects_edge__ops_aten_add_Tensor",
+            "executorch_exir_dialects_edge__ops_aten_clamp_default",
+        }
+
+        self._test_exported_vit(
+            Tester(self.DynamicViT(), self.model_inputs, self.dynamic_shapes),
+            bilinear_ops,
         )

--- a/backends/xnnpack/test/models/very_big_model.py
+++ b/backends/xnnpack/test/models/very_big_model.py
@@ -39,6 +39,5 @@ class TestVeryBigModel(unittest.TestCase):
             .check(["torch.ops.higher_order.executorch_call_delegate"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/models/w2l.py
+++ b/backends/xnnpack/test/models/w2l.py
@@ -34,8 +34,7 @@ class TestW2L(unittest.TestCase):
             .check(["torch.ops.higher_order.executorch_call_delegate"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_w2l(self):
@@ -54,6 +53,5 @@ class TestW2L(unittest.TestCase):
             .check(["torch.ops.higher_order.executorch_call_delegate"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/abs.py
+++ b/backends/xnnpack/test/ops/abs.py
@@ -31,8 +31,7 @@ class TestAbs(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_abs_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_abs(self):

--- a/backends/xnnpack/test/ops/add.py
+++ b/backends/xnnpack/test/ops/add.py
@@ -54,8 +54,7 @@ class TestAdd(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_add_Tensor"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_add(self):
@@ -79,8 +78,7 @@ class TestAdd(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_add_Tensor"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_add_constant(self):
@@ -121,8 +119,7 @@ class TestAdd(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_add2(self):
@@ -145,8 +142,7 @@ class TestAdd(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_add3(self):
@@ -169,8 +165,7 @@ class TestAdd(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     class AddRelu(torch.nn.Module):
@@ -194,8 +189,7 @@ class TestAdd(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_add_relu(self):
@@ -214,8 +208,7 @@ class TestAdd(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_add_relu_seq(self):
@@ -261,6 +254,5 @@ class TestAdd(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/avgpool2d.py
+++ b/backends/xnnpack/test/ops/avgpool2d.py
@@ -42,8 +42,7 @@ class TestAvgPool2d(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_avg_pool2d_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_avgpool2d(self):

--- a/backends/xnnpack/test/ops/bilinear2d.py
+++ b/backends/xnnpack/test/ops/bilinear2d.py
@@ -87,8 +87,7 @@ class TestUpsampleBilinear2d(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp32_static_resize_bilinear2d_with_align_cornesr(self):
@@ -103,8 +102,7 @@ class TestUpsampleBilinear2d(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp32_static_resize_bilinear2d_antialiased(self):

--- a/backends/xnnpack/test/ops/ceil.py
+++ b/backends/xnnpack/test/ops/ceil.py
@@ -31,8 +31,7 @@ class TestCeil(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_ceil_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_ceil(self):

--- a/backends/xnnpack/test/ops/clamp.py
+++ b/backends/xnnpack/test/ops/clamp.py
@@ -33,8 +33,7 @@ class TestClamp(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_clamp_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_clamp(self):
@@ -77,6 +76,5 @@ class TestClamp(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/conv1d.py
+++ b/backends/xnnpack/test/ops/conv1d.py
@@ -97,8 +97,7 @@ class TestConv1d(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_conv1d(self):

--- a/backends/xnnpack/test/ops/conv2d.py
+++ b/backends/xnnpack/test/ops/conv2d.py
@@ -152,8 +152,7 @@ class TestConv2d(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(qtol=1)
         )
 
     def test_fp16_conv2d(self) -> None:

--- a/backends/xnnpack/test/ops/div.py
+++ b/backends/xnnpack/test/ops/div.py
@@ -39,8 +39,7 @@ class TestDiv(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_div_Tensor"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_div(self):
@@ -64,6 +63,5 @@ class TestDiv(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_div_Tensor"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/elu.py
+++ b/backends/xnnpack/test/ops/elu.py
@@ -39,8 +39,7 @@ class TestElu(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     @unittest.skip("T171810227 - Missing recomposition for ELU")
@@ -74,8 +73,7 @@ class TestElu(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     @unittest.skip("T171810227 - Missing recomposition for ELU")
@@ -99,6 +97,5 @@ class TestElu(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/floor.py
+++ b/backends/xnnpack/test/ops/floor.py
@@ -31,8 +31,7 @@ class TestFloor(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_floor_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_floor(self):

--- a/backends/xnnpack/test/ops/hardswish.py
+++ b/backends/xnnpack/test/ops/hardswish.py
@@ -41,8 +41,7 @@ class TestHardswish(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     @unittest.skip("T158969708 - Missing recomposition pass for hardswish")
@@ -75,6 +74,5 @@ class TestHardswish(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/hardtanh.py
+++ b/backends/xnnpack/test/ops/hardtanh.py
@@ -38,8 +38,7 @@ class TestHardTanh(unittest.TestCase):
                 .check_not(["executorch_exir_dialects_edge__ops_aten_hardtanh_default"])
                 .to_executorch()
                 .serialize()
-                .run_method()
-                .compare_outputs()
+                .run_method_and_compare_outputs()
             )
 
     def test_fp32_hardtanh_bound(self):
@@ -58,8 +57,7 @@ class TestHardTanh(unittest.TestCase):
                 .check_not(["executorch_exir_dialects_edge__ops_aten_hardtanh_default"])
                 .to_executorch()
                 .serialize()
-                .run_method()
-                .compare_outputs()
+                .run_method_and_compare_outputs()
             )
 
     def test_qs8_hardtanh(self):
@@ -90,6 +88,5 @@ class TestHardTanh(unittest.TestCase):
                 )
                 .to_executorch()
                 .serialize()
-                .run_method()
-                .compare_outputs()
+                .run_method_and_compare_outputs()
             )

--- a/backends/xnnpack/test/ops/leaky_relu.py
+++ b/backends/xnnpack/test/ops/leaky_relu.py
@@ -43,8 +43,7 @@ class TestLeakyRelu(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_leaky_relu(self):
@@ -76,8 +75,7 @@ class TestLeakyRelu(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     @unittest.skip("T172863987 - Missing quantizer support.")
@@ -107,8 +105,7 @@ class TestLeakyRelu(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     @unittest.skip("T172863987 - Missing quantizer support.")
@@ -143,6 +140,5 @@ class TestLeakyRelu(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/linear.py
+++ b/backends/xnnpack/test/ops/linear.py
@@ -26,23 +26,27 @@ from torch.ao.quantization.quantizer.xnnpack_quantizer_utils import Quantization
 class TestLinear(unittest.TestCase):
     def test_fp16_linear(self):
         for use_bias in (True, False):
-            self._test_linear(
-                lambda in_size, out_size: torch.nn.Linear(
-                    in_size, out_size, bias=use_bias  # noqa
-                ),
-                uses_bias=use_bias,
-                dtype=torch.float16,
-                atol=5e-2,
-            )
+            for num_batch_dims in range(1, 3):
+                self._test_linear(
+                    lambda in_size, out_size: torch.nn.Linear(
+                        in_size, out_size, bias=use_bias  # noqa
+                    ),
+                    num_batch_dims=num_batch_dims,
+                    uses_bias=use_bias,
+                    dtype=torch.float16,
+                    atol=5e-2,
+                )
 
     def test_fp32_linear(self):
         for use_bias in (True, False):
-            self._test_linear(
-                lambda in_size, out_size: torch.nn.Linear(
-                    in_size, out_size, bias=use_bias  # noqa
-                ),
-                uses_bias=use_bias,
-            )
+            for num_batch_dims in range(1, 3):
+                self._test_linear(
+                    lambda in_size, out_size: torch.nn.Linear(
+                        in_size, out_size, bias=use_bias  # noqa
+                    ),
+                    uses_bias=use_bias,
+                    num_batch_dims=num_batch_dims,
+                )
 
     def test_fp32_addmm(self):
         """
@@ -63,24 +67,71 @@ class TestLinear(unittest.TestCase):
             uses_bias=True,
         )
 
+    def test_fp32_linear_fused_relu(self):
+        class LinearReluModule(torch.nn.Module):
+            def __init__(self, in_size, out_size, use_bias):
+                super().__init__()
+                self.linear = torch.nn.Linear(in_size, out_size, bias=use_bias)
+
+            def forward(self, x):
+                return torch.nn.functional.relu(self.linear(x))
+
+        for use_bias in (True, False):
+            for num_batch_dims in range(1, 3):
+                self._test_linear(
+                    lambda in_size, out_size: LinearReluModule(
+                        in_size,
+                        out_size,
+                        use_bias,  # noqa
+                    ),
+                    uses_bias=use_bias,
+                    num_batch_dims=num_batch_dims,
+                )
+
+    def test_qs8_linear_fused_relu(self):
+        class LinearReluModule(torch.nn.Module):
+            def __init__(self, in_size, out_size, use_bias):
+                super().__init__()
+                self.linear = torch.nn.Linear(in_size, out_size, bias=use_bias)
+
+            def forward(self, x):
+                return torch.nn.functional.relu(self.linear(x))
+
+        for use_bias in (True, False):
+            for num_batch_dims in range(1, 3):
+                self._test_linear(
+                    lambda in_size, out_size: LinearReluModule(
+                        in_size,
+                        out_size,
+                        use_bias,  # noqa
+                    ),
+                    num_batch_dims=num_batch_dims,
+                    uses_bias=use_bias,
+                    quant=True,
+                )
+
     def test_qs8_linear(self):
         for use_bias in (True, False):
-            self._test_linear(
-                lambda in_size, out_size: torch.nn.Linear(
-                    in_size, out_size, bias=use_bias  # noqa
-                ),
-                uses_bias=use_bias,
-            )
+            for num_batch_dims in range(1, 3):
+                self._test_linear(
+                    lambda in_size, out_size: torch.nn.Linear(
+                        in_size, out_size, bias=use_bias  # noqa
+                    ),
+                    uses_bias=use_bias,
+                    num_batch_dims=num_batch_dims,
+                )
 
     @unittest.skip("XNNPACK currently only supports per-channel dynamic quantization.")
     def test_qd8_per_tensor_linear(self):
         for uses_bias in (False, True):
             inputs = (torch.randn(2, 4),)
             module = torch.nn.Linear(4, 5, bias=uses_bias)
+            dynamic_shapes = ({0: torch.export.Dim("batch", max=100)},)
 
             self._test_dqlinear(
                 module,
                 inputs,
+                dynamic_shapes=dynamic_shapes,
                 is_per_channel=False,
                 uses_bias=uses_bias,
             )
@@ -93,6 +144,7 @@ class TestLinear(unittest.TestCase):
             self._test_dqlinear(
                 module,
                 inputs,
+                dynamic_shapes=({0: torch.export.Dim("batch", max=100)},),
                 is_per_channel=True,
                 uses_bias=uses_bias,
             )
@@ -114,7 +166,7 @@ class TestLinear(unittest.TestCase):
         qconfig = self._get_4b_dqconfig()
         input_channels = [2, 63]
         output_channels = [1, 8, 127]
-        batches = [1, 2]
+        batches = [2, 2]
         use_bias = [False, True]
 
         for bs, bias, ipc, opc in product(
@@ -129,13 +181,14 @@ class TestLinear(unittest.TestCase):
             self._test_dqlinear(
                 module,
                 inputs,
+                dynamic_shapes=({0: torch.export.Dim("batch", max=100)},),
                 is_per_channel=True,
                 uses_bias=bias,
                 qconfig=qconfig,
             )
 
     def test_qd8_per_channel_linear_parallel(self):
-        in_size = 1
+        in_size = 2
         input_size = 4
         output_size = 5
 
@@ -165,17 +218,39 @@ class TestLinear(unittest.TestCase):
             torch.rand(in_size, input_size, dtype=torch.float),
             torch.rand(in_size, input_size, dtype=torch.float),
         )
+        batch_dim = torch.export.Dim("batch", max=100)
+        dynamic_shapes = ({0: batch_dim}, {0: batch_dim})
 
         self._test_dqlinear(
             ParallelLinear(),
             inputs,
+            dynamic_shapes=dynamic_shapes,
             linear_count=2,
             is_per_channel=True,
             uses_bias=True,
         )
 
+    def test_qd8_per_channel_linear_with_two_batch(self):
+        in_size = 2
+        input_size = 4
+        output_size = 5
+
+        linear = torch.nn.Linear(input_size, output_size)
+        inputs = (torch.randn(2, in_size, input_size, dtype=torch.float),)
+        batch_dim = torch.export.Dim("batch", max=100)
+        dynamic_shapes = ({0: batch_dim, 1: batch_dim},)
+
+        self._test_dqlinear(
+            linear,
+            inputs,
+            dynamic_shapes=dynamic_shapes,
+            linear_count=1,
+            is_per_channel=True,
+            uses_bias=True,
+        )
+
     def test_qd8_per_channel_linear_sequential(self):
-        in_size = 1
+        in_size = 2
         input_size = 4
         intermediate_size = 5
         output_size = 3
@@ -203,17 +278,20 @@ class TestLinear(unittest.TestCase):
                 return b
 
         inputs = (torch.rand(in_size, input_size, dtype=torch.float),)
+        dynamic_shapes = ({0: torch.export.Dim("batch", max=100)},)
 
         self._test_dqlinear(
             LinearSequential(),
             inputs,
+            dynamic_shapes=dynamic_shapes,
             linear_count=2,
             is_per_channel=True,
             uses_bias=True,
+            atol=1e-1,
         )
 
     def test_qd8_per_channel_linear_parellel_and_sequential(self):
-        in_size = 1
+        in_size = 2
         input_size = 4
         intermediate_size = 5
         output_size = 3
@@ -252,49 +330,20 @@ class TestLinear(unittest.TestCase):
             torch.rand(in_size, input_size, dtype=torch.float),
             torch.rand(in_size, input_size, dtype=torch.float),
         )
-
-        self._test_dqlinear(
-            LinearModule(), inputs, linear_count=3, is_per_channel=True, uses_bias=True
+        dynamic_shapes = (
+            {0: torch.export.Dim("batch", max=100)},
+            {0: torch.export.Dim("batch2", max=100)},
         )
 
-    def test_fp32_linear_fused_relu(self):
-        class LinearReluModule(torch.nn.Module):
-            def __init__(self, in_size, out_size, use_bias):
-                super().__init__()
-                self.linear = torch.nn.Linear(in_size, out_size, bias=use_bias)
-
-            def forward(self, x):
-                return torch.nn.functional.relu(self.linear(x))
-
-        for use_bias in (True, False):
-            self._test_linear(
-                lambda in_size, out_size: LinearReluModule(
-                    in_size,
-                    out_size,
-                    use_bias,  # noqa
-                ),
-                uses_bias=use_bias,
-            )
-
-    def test_qs8_linear_fused_relu(self):
-        class LinearReluModule(torch.nn.Module):
-            def __init__(self, in_size, out_size, use_bias):
-                super().__init__()
-                self.linear = torch.nn.Linear(in_size, out_size, bias=use_bias)
-
-            def forward(self, x):
-                return torch.nn.functional.relu(self.linear(x))
-
-        for use_bias in (True, False):
-            self._test_linear(
-                lambda in_size, out_size: LinearReluModule(
-                    in_size,
-                    out_size,
-                    use_bias,  # noqa
-                ),
-                uses_bias=use_bias,
-                quant=True,
-            )
+        self._test_dqlinear(
+            LinearModule(),
+            inputs,
+            dynamic_shapes=dynamic_shapes,
+            linear_count=3,
+            is_per_channel=True,
+            uses_bias=True,
+            atol=1e-1,
+        )
 
     class ManualDQLinear(torch.nn.Module):
         def __init__(
@@ -676,6 +725,7 @@ class TestLinear(unittest.TestCase):
         self,
         make_module,
         uses_bias,
+        num_batch_dims=1,
         quant=False,
         dtype: torch.dtype = torch.float,
         atol=1e-03,
@@ -692,7 +742,7 @@ class TestLinear(unittest.TestCase):
             )
         )
 
-        in_sizes = [1, 4, 4]
+        in_sizes = [3, 4, 4]
         input_sizes = [4, 37, 17]
         output_sizes = [4, 17, 37]
 
@@ -704,11 +754,19 @@ class TestLinear(unittest.TestCase):
             in_size = int(in_sizes[i])
             input_size = int(input_sizes[i])
             output_size = int(output_sizes[i])
+            input_shape = [in_size] * num_batch_dims + [input_size]
+            print(f"Testing input_shape {input_shape} with {output_size} out_channels")
 
             module = make_module(input_size, output_size).eval().to(dtype)
-            inputs = (torch.randn(in_size, input_size).to(dtype),)
+            inputs = (torch.randn(input_shape).to(dtype),)
+            dynamic_shape = {}
+            for i in range(num_batch_dims):
+                dynamic_shape[i] = torch.export.Dim(f"batch{i}", min=2, max=in_size)
 
-            tester = Tester(module, inputs)
+            dynamic_shape = (dynamic_shape,)
+            print(dynamic_shape)
+
+            tester = Tester(module, inputs, dynamic_shapes=dynamic_shape)
 
             if quant:
                 tester.quantize()
@@ -736,10 +794,12 @@ class TestLinear(unittest.TestCase):
         self,
         module,
         inputs,
+        dynamic_shapes,
         linear_count=1,
         is_per_channel=False,
         uses_bias=False,
         qconfig: Optional[QuantizationConfig] = None,
+        atol=5e-02,
     ):
         aten_op, edge_op = (
             (
@@ -758,13 +818,12 @@ class TestLinear(unittest.TestCase):
             is_dynamic=True,
         )
 
-        tester = Tester(module, inputs)
+        tester = Tester(module, inputs, dynamic_shapes=dynamic_shapes)
         tester.quantize(Quantize(quantization_config=quant_config))
 
         tester.export()
         tester.check_count({aten_op: linear_count})
         tester.check(["torch.ops.quantized_decomposed"])
-        tester.dump_artifact()
         tester.to_edge()
         tester.check_count({edge_op: linear_count})
 
@@ -776,4 +835,4 @@ class TestLinear(unittest.TestCase):
 
         tester.to_executorch()
         tester.serialize()
-        tester.run_method_and_compare_outputs(atol=5e-02)
+        tester.run_method_and_compare_outputs(atol=atol)

--- a/backends/xnnpack/test/ops/linear.py
+++ b/backends/xnnpack/test/ops/linear.py
@@ -595,8 +595,7 @@ class TestLinear(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs(atol=atol, rtol=rtol)
+            .run_method_and_compare_outputs(atol=atol, rtol=rtol)
         )
 
     def _run_manual_dqlinear_tests(self, weight_n_bit: int, op_dtype: torch.dtype):
@@ -731,9 +730,7 @@ class TestLinear(unittest.TestCase):
 
             tester.to_executorch()
             tester.serialize()
-            tester.run_method()
-            tester.compare_outputs(qtol=quant, atol=atol)
-            print("success")
+            tester.run_method_and_compare_outputs(qtol=quant, atol=atol)
 
     def _test_dqlinear(
         self,
@@ -779,5 +776,4 @@ class TestLinear(unittest.TestCase):
 
         tester.to_executorch()
         tester.serialize()
-        tester.run_method()
-        tester.compare_outputs(atol=5e-02)
+        tester.run_method_and_compare_outputs(atol=5e-02)

--- a/backends/xnnpack/test/ops/max_dim.py
+++ b/backends/xnnpack/test/ops/max_dim.py
@@ -37,8 +37,7 @@ class TestMaxDim(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_max_dim"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     @unittest.skip("T171468483 - Fails to partition due to index output dtype.")
@@ -65,6 +64,5 @@ class TestMaxDim(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_max_dim"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/maximum.py
+++ b/backends/xnnpack/test/ops/maximum.py
@@ -30,8 +30,7 @@ class TestMaximum(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_maximum_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_maximum(self):
@@ -64,6 +63,5 @@ class TestMaximum(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_maximum_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/maxpool2d.py
+++ b/backends/xnnpack/test/ops/maxpool2d.py
@@ -64,8 +64,7 @@ class TestMaxPool2d(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_maxpool2d(self):
@@ -135,6 +134,5 @@ class TestMaxPool2d(unittest.TestCase):
                 )
                 .to_executorch()
                 .serialize()
-                .run_method()
-                .compare_outputs()
+                .run_method_and_compare_outputs()
             )

--- a/backends/xnnpack/test/ops/mean_dim.py
+++ b/backends/xnnpack/test/ops/mean_dim.py
@@ -33,8 +33,7 @@ class TestMeanDim(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_mean_dim"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_mean_dim(self):
@@ -85,6 +84,5 @@ class TestMeanDim(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(qtol=1)
         )

--- a/backends/xnnpack/test/ops/minimum.py
+++ b/backends/xnnpack/test/ops/minimum.py
@@ -30,8 +30,7 @@ class TestMinimum(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_minimum_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_minimum(self):

--- a/backends/xnnpack/test/ops/multiply.py
+++ b/backends/xnnpack/test/ops/multiply.py
@@ -43,8 +43,7 @@ class TestMul(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_mul_Tensor"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_mul(self):
@@ -78,8 +77,7 @@ class TestMul(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_mul2(self):
@@ -102,8 +100,7 @@ class TestMul(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_mul_functional(self):
@@ -126,8 +123,7 @@ class TestMul(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_mul_relu(self):
@@ -156,6 +152,5 @@ class TestMul(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/negate.py
+++ b/backends/xnnpack/test/ops/negate.py
@@ -31,8 +31,7 @@ class TestNegate(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_neg_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_negate(self):

--- a/backends/xnnpack/test/ops/permute.py
+++ b/backends/xnnpack/test/ops/permute.py
@@ -45,8 +45,7 @@ class TestPermute(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_permute_copy_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_permute(self):
@@ -72,8 +71,7 @@ class TestPermute(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_permute_copy_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_permute(self):
@@ -102,8 +100,7 @@ class TestPermute(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_permute_copy(self):
@@ -132,6 +129,5 @@ class TestPermute(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/pow.py
+++ b/backends/xnnpack/test/ops/pow.py
@@ -34,8 +34,7 @@ class TestPow(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_pow_Tensor_Scalar"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_pow2(self):

--- a/backends/xnnpack/test/ops/prelu.py
+++ b/backends/xnnpack/test/ops/prelu.py
@@ -36,8 +36,7 @@ class TestPrelu(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     @unittest.skip("T158653285 - Missing recomposition for PReLU")

--- a/backends/xnnpack/test/ops/quantize_per_tensor.py
+++ b/backends/xnnpack/test/ops/quantize_per_tensor.py
@@ -39,8 +39,7 @@ class TestQuantizePerTensor(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_dequantize_per_tenstor(self):
@@ -76,6 +75,5 @@ class TestQuantizePerTensor(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/relu.py
+++ b/backends/xnnpack/test/ops/relu.py
@@ -33,6 +33,5 @@ class TestRelu(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_relu_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/sdpa.py
+++ b/backends/xnnpack/test/ops/sdpa.py
@@ -70,8 +70,7 @@ class TestSDPA(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs(atol=atol, rtol=rtol)
+            .run_method_and_compare_outputs(atol=atol, rtol=rtol)
         )
 
     def test_fp16_sdpa_mask2d(self):

--- a/backends/xnnpack/test/ops/sigmoid.py
+++ b/backends/xnnpack/test/ops/sigmoid.py
@@ -32,8 +32,7 @@ class TestSigmoid(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_sigmoid_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_sigmoid(self):

--- a/backends/xnnpack/test/ops/slice_copy.py
+++ b/backends/xnnpack/test/ops/slice_copy.py
@@ -27,8 +27,7 @@ class TestSliceCopy(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_slice_copy_Tensor"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_slice_copy(self):
@@ -143,6 +142,5 @@ class TestSliceCopy(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_slice_copy_Tensor"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/softmax.py
+++ b/backends/xnnpack/test/ops/softmax.py
@@ -38,8 +38,7 @@ class TestSoftmax(unittest.TestCase):
                 .check_not(["executorch_exir_dialects_edge__ops_aten__softmax_default"])
                 .to_executorch()
                 .serialize()
-                .run_method()
-                .compare_outputs()
+                .run_method_and_compare_outputs()
             )
 
     def test_fp16_softmax(self):

--- a/backends/xnnpack/test/ops/sqrt.py
+++ b/backends/xnnpack/test/ops/sqrt.py
@@ -16,6 +16,7 @@ class TestSqrt(unittest.TestCase):
             super().__init__()
 
         def forward(self, x):
+            x = torch.abs(x)
             z = torch.sqrt(x)
             return z
 
@@ -31,14 +32,13 @@ class TestSqrt(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_sqrt_default"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_sqrt(self):
-        inputs = (torch.randn(20).to(torch.float16).abs(),)
+        inputs = (torch.randn(20).to(torch.float16),)
         self._test_sqrt(inputs)
 
     def test_fp32_sqrt(self):
-        inputs = (torch.randn(20).abs(),)
+        inputs = (torch.randn(20),)
         self._test_sqrt(inputs)

--- a/backends/xnnpack/test/ops/square.py
+++ b/backends/xnnpack/test/ops/square.py
@@ -37,8 +37,7 @@ class TestSquare(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_pow_Tensor_Scalar"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_square(self):

--- a/backends/xnnpack/test/ops/static_constant_pad.py
+++ b/backends/xnnpack/test/ops/static_constant_pad.py
@@ -99,8 +99,7 @@ class TestStaticConstantPad(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_static_constant_pad_functional(self):
@@ -154,8 +153,7 @@ class TestStaticConstantPad(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_static_constant_pad_2d(self):
@@ -180,6 +178,5 @@ class TestStaticConstantPad(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/ops/sub.py
+++ b/backends/xnnpack/test/ops/sub.py
@@ -39,8 +39,7 @@ class TestSub(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_sub_Tensor"])
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp16_sub(self):
@@ -75,8 +74,7 @@ class TestSub(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     @unittest.skip("T171957656 - Quantized sub not implemented.")
@@ -100,8 +98,7 @@ class TestSub(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     @unittest.skip("T171957656 - Quantized sub not implemented.")
@@ -125,8 +122,7 @@ class TestSub(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     @unittest.skip("T171957656 - Quantized sub not implemented.")
@@ -166,6 +162,5 @@ class TestSub(unittest.TestCase):
             )
             .to_executorch()
             .serialize()
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/passes/test_batch_norm_fusion.py
+++ b/backends/xnnpack/test/passes/test_batch_norm_fusion.py
@@ -40,8 +40,7 @@ class TestBatchNormFusion(unittest.TestCase):
             .to_edge()
             .run_passes(self.PassStage)
             .check_count({self.bn_name: 1})
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_q8_batch_norm_fusion(self):
@@ -52,8 +51,7 @@ class TestBatchNormFusion(unittest.TestCase):
             .to_edge()
             .run_passes(self.PassStage)
             .check_count({self.bn_name: 1})
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_fp32_batch_norm_no_fusion_doesnt_partition(self):

--- a/backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py
+++ b/backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py
@@ -42,8 +42,7 @@ class TestChannelsLastTaggedReshapePass(unittest.TestCase):
                         self.to_copy_name: num_reshape,
                     }
                 )
-                .run_method()
-                .compare_outputs()
+                .run_method_and_compare_outputs()
             )
 
     def test_qs8_channels_last_tagged_reshape_pass(self):
@@ -64,8 +63,7 @@ class TestChannelsLastTaggedReshapePass(unittest.TestCase):
                     ]
                     * num_reshape
                 )
-                .run_method()
-                .compare_outputs()
+                .run_method_and_compare_outputs()
             )
 
     class ConvRelu(torch.nn.Module):
@@ -86,8 +84,7 @@ class TestChannelsLastTaggedReshapePass(unittest.TestCase):
             .check(
                 [self.to_copy_name, self.conv_name, self.relu_name, self.to_copy_name]
             )
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_qs8_channels_last_tagged_reshape_pass_conv_relu(self):
@@ -109,8 +106,7 @@ class TestChannelsLastTaggedReshapePass(unittest.TestCase):
                     self.to_copy_name,
                 ]
             )
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     class Conv2dBnHardtanhMeanSequenceModule(torch.nn.Module):
@@ -175,6 +171,5 @@ class TestChannelsLastTaggedReshapePass(unittest.TestCase):
                     self.to_copy_name: 4,
                 }
             )
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/passes/test_convert_to_linear.py
+++ b/backends/xnnpack/test/passes/test_convert_to_linear.py
@@ -35,6 +35,5 @@ class TestConvertToLinear(unittest.TestCase):
                 .check_count(
                     {"executorch_exir_dialects_edge__ops_aten_linear_default": 1}
                 )
-                .run_method()
-                .compare_outputs()
+                .run_method_and_compare_outputs()
             )

--- a/backends/xnnpack/test/passes/test_remove_get_item_pass.py
+++ b/backends/xnnpack/test/passes/test_remove_get_item_pass.py
@@ -42,8 +42,7 @@ class TestRemoveGetItemPass(unittest.TestCase):
             .to_edge()
             .run_passes(self.PassStage)
             .check_count({self.max_pool2d_name: 1})
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_q8_max_pool2d_remove_getitem(self):
@@ -54,8 +53,7 @@ class TestRemoveGetItemPass(unittest.TestCase):
             .to_edge()
             .run_passes(self.PassStage)
             .check_count({self.max_pool2d_name: 1})
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     class MaxModule(torch.nn.Module):
@@ -79,8 +77,7 @@ class TestRemoveGetItemPass(unittest.TestCase):
                     self.amax_name: 1,
                 }
             )
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )
 
     def test_q8_max_remove_getitem(self):
@@ -95,6 +92,5 @@ class TestRemoveGetItemPass(unittest.TestCase):
                     self.amax_name: 1,
                 }
             )
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
         )

--- a/backends/xnnpack/test/passes/test_tag_implicit_q_dq_pass.py
+++ b/backends/xnnpack/test/passes/test_tag_implicit_q_dq_pass.py
@@ -55,8 +55,7 @@ class TestTagImplicitQDq(unittest.TestCase):
             .export()
             .to_edge()
             .run_passes(self.PassStage)
-            .run_method()
-            .compare_outputs()
+            .run_method_and_compare_outputs()
             .get_artifact(Tester.stage_name(self.PassStage))
         )
 


### PR DESCRIPTION
Summary:
Tests for Dynamic ViT

We make ViT dynamic by bilinear resizing the input before feeding to ViT

Differential Revision: D54972681
