### PR TITLE
Adding initial eval port for pre-to_edge evaluation

### DIFF
--- a/examples/models/llama2/eval_llama.py
+++ b/examples/models/llama2/eval_llama.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Example script for evaluating pre-to_edge Llama
+
+import logging
+
+import torch
+
+from .eval_llama_lib import build_args_parser, eval_llama
+
+FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+
+
+def main() -> None:
+    seed = 42
+    torch.manual_seed(seed)
+    modelname = "llama2"
+    parser = build_args_parser()
+    args = parser.parse_args()
+    eval_llama(modelname, args)
+
+
+if __name__ == "__main__":
+    main()  # pragma: no cover

--- a/examples/models/llama2/eval_llama_lib.py
+++ b/examples/models/llama2/eval_llama_lib.py
@@ -1,0 +1,233 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import argparse
+from typing import Optional
+
+import lm_eval
+
+import torch
+import torch._dynamo.config
+import torch._inductor.config
+from sentencepiece import SentencePieceProcessor
+from torch import nn
+
+torch._dynamo.config.automatic_dynamic_shapes = True
+torch._inductor.config.triton.unique_kernel_names = True
+torch._inductor.config.epilogue_fusion = False
+torch._inductor.config.triton.cudagraphs = True
+torch._dynamo.config.cache_size_limit = 100000
+
+from lm_eval.evaluator import evaluate
+from lm_eval.models.huggingface import HFLM as eval_wrapper
+from lm_eval.tasks import get_task_dict
+
+from .builder import LlamaEdgeManager
+from .export_llama_lib import (
+    _prepare_for_llama_export,
+    build_args_parser as _build_args_parser,
+)
+
+
+def encode_tokens(tokenizer, string: str, bos: bool = True, device: str = "cpu"):
+    # if torch.cuda.is_available():
+    #     device = "cuda"
+
+    tokens = tokenizer.encode(string)
+    if bos:
+        tokens = [tokenizer.bos_id()] + tokens
+    return torch.tensor(tokens, dtype=torch.int, device=device)
+
+
+def model_forward(model, x, input_pos):
+    return model(x, input_pos)
+
+
+def setup_padded_seq_input_pos_max_seq_length_for_prefill(
+    prompt: torch.Tensor,
+    max_new_tokens: int,
+    max_seq_length: Optional[int],
+):
+    """
+    Bookkeeping calculations for prompt, input_pos and max_seq_length
+    that are needed for prefill or model_forward
+
+    Args:
+        prompt (torch.Tensor): Tensor of shape (T) with indices of the prompt sequence.
+        max_new_tokens (int): The desired maximum number of new tokens that can be generated.
+        max_seq_length (Optional[int], optional): The maximum sequence length allowed.
+
+    Returns:
+        seq (torch.Tensor): prompt but padded with zeros to size max_seq_length
+        input_pos (torch.Tensor): tensor of integers in increasing order
+        max_seq_length (int): The maximum sequence length allowed, updated based on other numbers
+    """
+    T = prompt.size(0)
+    T_new = T + max_new_tokens
+
+    device, dtype = prompt.device, prompt.dtype
+    # create an empty tensor of the expected final shape and fill in the current tokens
+    empty = torch.empty(T_new, dtype=dtype, device=device)
+    empty[:T] = prompt
+    seq = empty
+    input_pos = torch.arange(0, T, device=device)
+
+    return seq, input_pos, max_seq_length
+
+
+class GPTFastEvalWrapper(eval_wrapper):
+    """
+    A wrapper class for GPTFast, providing integration with the lm-evaluation-harness library.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        tokenizer,
+        max_seq_length: Optional[int] = None,
+    ):
+        super().__init__()
+        self._model = model
+        self._tokenizer = tokenizer
+        self._device = torch.device("cpu")
+        self._max_seq_length = 2048 if max_seq_length is None else max_seq_length
+
+    @property
+    def eot_token_id(self):
+        return self._tokenizer.eos_id()
+
+    @property
+    def max_length(self):
+        return self._max_seq_length
+
+    @property
+    def max_gen_toks(self):
+        return 50
+
+    @property
+    def batch_size(self):
+        return 1
+
+    @property
+    def device(self):
+        return self._device
+
+    def tok_encode(self, string: str, **kwargs):
+        encoded = encode_tokens(self._tokenizer, string, bos=True, device=self._device)
+        # encoded is a pytorch tensor, but some internal logic in the
+        # eval harness expects it to be a list instead
+        # TODO: verify this for multi-batch as well
+        encoded = encoded.tolist()
+        return encoded
+
+    def tok_decode(self, tokens):
+        decoded = self._tokenizer.decode(tokens)
+        return decoded
+
+    def _model_call(self, inps):
+        # TODO: make batches work
+        inps = inps.squeeze(0)
+
+        max_new_tokens = 1
+        seq, input_pos, max_seq_length = (
+            setup_padded_seq_input_pos_max_seq_length_for_prefill(
+                inps,
+                max_new_tokens,
+                self.max_length,
+            )
+        )
+        x = seq.index_select(0, input_pos).view(1, -1)
+        logits = model_forward(self._model, x, input_pos)
+        return logits
+
+    def _model_generate(self, context, max_length, eos_token_id):
+        raise Exception("unimplemented")
+
+
+@torch.no_grad()
+def eval(
+    model: nn.Module,
+    tokenizer,
+    tasks: Optional[list] = None,
+    limit: Optional[int] = None,
+    max_seq_length: Optional[int] = None,
+) -> dict:
+    """
+    Evaluates a language model on a specified task using the lm-evaluation-harness library.
+
+    Args:
+        model (nn.Module): The pre-trained language model to evaluate.
+        tokenizer: The tokenizer to use for encoding/decoding text.
+        task (str): The name of the evaluation task to perform.
+        limit (Optional[int]): The maximum number of samples to evaluate (None for all available).
+        max_seq_length (Optional[int]): The maximum sequence length allowed for input text.
+
+    Returns:
+        eval_results (dict): A dictionary of evaluation results for the specified task(s).
+    """
+
+    if tasks is None:
+        tasks = ["wikitext"]
+
+    model_eval_wrapper = GPTFastEvalWrapper(
+        model,
+        tokenizer,
+        max_seq_length,
+    )
+
+    if "hendrycks_test" in tasks:
+        tasks.remove("hendrycks_test")
+        tasks += list(lm_eval.tasks.hendrycks_test.create_all_tasks().keys())
+    task_dict = get_task_dict(tasks)
+
+    eval_results = evaluate(
+        model_eval_wrapper,
+        task_dict,
+        limit=limit,
+    )
+    return eval_results
+
+
+def build_args_parser() -> argparse.ArgumentParser:
+    # Start with arg parser from export_llama_lib
+    parser = _build_args_parser()
+
+    # Add additional args specific to eval
+    parser.add_argument(
+        "--tasks",
+        nargs="+",
+        type=str,
+        default=["wikitext"],
+        help="list of lm-eluther tasks to evaluate usage: --tasks task1 task2",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=5, help="number of samples to evalulate"
+    )
+    parser.add_argument(
+        "--max_seq_length",
+        type=int,
+        default=100,
+        help="maximum length sequence to evaluate",
+    )
+
+    return parser
+
+
+def eval_llama(
+    model_name: str,
+    args: argparse.ArgumentParser,
+) -> None:
+    # Get a pre-lowering/to_edge LlamaEdgeManager instance
+    manager: LlamaEdgeManager = _prepare_for_llama_export(model_name, args)
+    tokenizer = SentencePieceProcessor(model_file=str(args.tokenizer_path))
+
+    # Evaluate the model
+    eval_results = eval(
+        manager.model.to(device="cpu"), tokenizer, args.tasks, args.limit
+    )
+
+    print("Results: ", eval_results)


### PR DESCRIPTION
Summary:
Derivative of:
* https://github.com/pytorch-labs/gpt-fast/blob/main/eval.py
* https://github.com/pytorch/executorch/blob/main/examples/models/llama2/export_llama.py
* https://github.com/pytorch-labs/gpt-fast/blob/main/generate.py

Differential Revision: D54970638


