### PR TITLE
[CoreML Backend] Expand export options.

### DIFF
--- a/backends/apple/coreml/compiler/coreml_preprocess.py
+++ b/backends/apple/coreml/compiler/coreml_preprocess.py
@@ -5,10 +5,12 @@
 import json
 import shutil
 import uuid
+from dataclasses import asdict, dataclass
+from enum import Enum
 
 from pathlib import Path
 
-from typing import final, List
+from typing import Dict, final, List
 
 import coremltools as ct
 import executorchcoreml
@@ -21,56 +23,237 @@ from executorch.exir.backend.backend_details import (
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 
 
+class COMPILE_SPEC_KEYS(Enum):
+    COMPUTE_UNITS = "compute_units"
+    MODEL_TYPE = "model_type"
+    MIN_DEPLOYMENT_TARGET = "min_deployment_target"
+    MODEL_COMPUTE_PRECISION = "model_compute_precision"
+
+
+@dataclass
+class ModelMetadata:
+    # The model input names.
+    inputNames: List[str]
+    # The model output names.
+    outputNames: List[str]
+    # The model identifier.
+    identifier: str
+
+
 @final
 class CoreMLBackend(BackendDetails):
-    @staticmethod
-    def to_bytes(mlmodel):
-        dir_path = Path("tmp")
-        model_dir_path = dir_path / "lowered_module"
-        Path(model_dir_path).mkdir(parents=True, exist_ok=True)
-        model_path = model_dir_path / "model.mlpackage"
-        mlmodel.save(model_path)
+    class MODEL_TYPE(Enum):
+        MODEL = "model"
+        COMPILED_MODEL = "compiled_model"
 
-        # save model metdata
-        spec = mlmodel.get_spec()
-        input_names = [input.name for input in spec.description.input]
-        output_names = [output.name for output in spec.description.output]
+    @staticmethod
+    def generate_model_type_compile_spec(model_type: MODEL_TYPE) -> CompileSpec:
+        """
+        Returns the compile spec representing the given model type.
+
+        If the model type is ``MODEL_TYPE.Model`` then the ``CoreMLBackend`` returns
+        the in-memory representation of the ``mlpackage`` contents.
+
+        If the model type is ``MODEL_TYPE.COMPILED_MODEL`` then the ``CoreMLBackend`` compiles the model
+        and returns the in-memory representation of ``mlmodelc`` (compiled model) contents.
+        """
+        return CompileSpec(
+            COMPILE_SPEC_KEYS.MODEL_TYPE.value, model_type.value.encode("utf-8")
+        )
+
+    @staticmethod
+    def model_type_from_compile_specs(compile_specs: List[CompileSpec]) -> MODEL_TYPE:
+        """
+        Returns the model type by parsing the list of compile specs.
+        """
+        for compile_spec in compile_specs:
+            if compile_spec.key == COMPILE_SPEC_KEYS.MODEL_TYPE.value:
+                return CoreMLBackend.MODEL_TYPE(compile_spec.value.decode("utf-8"))
+
+        return CoreMLBackend.MODEL_TYPE.MODEL
+
+    @staticmethod
+    def generate_compute_precision_compile_spec(
+        compute_precision: ct.precision,
+    ) -> CompileSpec:
+        """
+        Returns the compile spec representing the model compute precision, for additional details
+        please refer to the documentation for ``coremltools.precision``.
+        """
+        return CompileSpec(
+            COMPILE_SPEC_KEYS.MODEL_COMPUTE_PRECISION.value,
+            compute_precision.value.encode("utf-8"),
+        )
+
+    @staticmethod
+    def model_compute_precision_from_compile_specs(
+        compile_specs: List[CompileSpec],
+    ) -> ct.precision:
+        """
+        Returns the model's compute precision by parsing the list of compile specs.
+        """
+        for compile_spec in compile_specs:
+            if compile_spec.key == COMPILE_SPEC_KEYS.MODEL_COMPUTE_PRECISION.value:
+                return ct.precision(compile_spec.value.decode("utf-8"))
+
+        return ct.precision.FLOAT16
+
+    @staticmethod
+    def generate_minimum_deployment_target_compile_spec(
+        min_deployment_target: ct.target,
+    ) -> CompileSpec:
+        """
+        Returns the compile spec representing the minimum deployment target on which the model can run,
+        for additional details please refer to the documentation for ``coremltools.target``.
+        """
+        return CompileSpec(
+            COMPILE_SPEC_KEYS.MIN_DEPLOYMENT_TARGET.value,
+            str(min_deployment_target.value).encode("utf-8"),
+        )
+
+    @staticmethod
+    def min_deployment_target_from_compile_specs(
+        compile_specs: List[CompileSpec],
+    ) -> ct.target:
+        """
+        Returns the minimum deployment target by parsing the list of compile specs.
+        """
+        for compile_spec in compile_specs:
+            if compile_spec.key == COMPILE_SPEC_KEYS.MIN_DEPLOYMENT_TARGET.value:
+                compile_spec_value: int = int(compile_spec.value.decode("utf-8"))
+                return ct.target(compile_spec_value)
+
+        return ct.target.iOS15
+
+    @staticmethod
+    def generate_compute_unit_compile_spec(
+        compute_unit: ct.ComputeUnit,
+    ) -> CompileSpec:
+        """
+        Returns the compile spec representing the compute units on which the model can run, for additional details
+        please refer to the documentation for ``coremltools.ComputeUnit`.
+        """
+        return CompileSpec(
+            COMPILE_SPEC_KEYS.COMPUTE_UNITS.value,
+            compute_unit.name.lower().encode("utf-8"),
+        )
+
+    @staticmethod
+    def generate_compile_specs(
+        compute_unit: ct.ComputeUnit = ct.ComputeUnit.ALL,
+        minimum_deployment_target: ct.target = ct.target.iOS15,
+        compute_precision: ct.precision = ct.precision.FLOAT16,
+        model_type: MODEL_TYPE = MODEL_TYPE.MODEL,
+    ) -> List[CompileSpec]:
+        """
+        Returns the list of compile specs that's used by CoreMLBackend to lower the module.
+        """
+        compile_specs: List[CompileSpec] = []
+        compile_specs.append(
+            CoreMLBackend.generate_compute_unit_compile_spec(compute_unit)
+        )
+        compile_specs.append(
+            CoreMLBackend.generate_minimum_deployment_target_compile_spec(
+                minimum_deployment_target
+            )
+        )
+        compile_specs.append(
+            CoreMLBackend.generate_compute_precision_compile_spec(compute_precision)
+        )
+        compile_specs.append(CoreMLBackend.generate_model_type_compile_spec(model_type))
+
+        return compile_specs
+
+    @staticmethod
+    def model_metadata_from_spec(model_spec: ct.proto.Model_pb2) -> Dict[str, str]:
+        input_names: List[str] = [input.name for input in model_spec.description.input]
+        output_names = [output.name for output in model_spec.description.output]
         identifier = uuid.uuid4()
 
-        model_metadata = {
-            "inputNames": input_names,
-            "outputNames": output_names,
-            "identifier": str(identifier),
-        }
+        return ModelMetadata(
+            inputNames=input_names, outputNames=output_names, identifier=str(identifier)
+        )
 
-        # store metadata
+    @staticmethod
+    def to_bytes(mlmodel: ct.models.MLModel, model_type: MODEL_TYPE) -> bytes:
+        dir_path: Path = Path("tmp")
+        model_dir_path: Path = dir_path / "lowered_module"
+        model_spec: ct.proto.Model_pb2 = mlmodel.get_spec()
+        model_metadata: ModelMetadata = CoreMLBackend.model_metadata_from_spec(
+            model_spec
+        )
+        match model_type:
+            case CoreMLBackend.MODEL_TYPE.MODEL:
+                # Store model.
+                model_path = model_dir_path / "model.mlpackage"
+                mlmodel.save(model_path)
+
+            case CoreMLBackend.MODEL_TYPE.COMPILED_MODEL:
+                # Store compiled model
+                model_path = model_dir_path / "model.mlmodelc"
+                compiled_model_path = mlmodel.get_compiled_model_path()
+
+                shutil.copytree(
+                    compiled_model_path,
+                    str(model_path.resolve()),
+                    dirs_exist_ok=True,
+                )
+
+        # Store model metadata.
         model_metadata_path = Path(model_dir_path) / "metadata.json"
-        json_object = json.dumps(model_metadata)
+        model_metadata_json = json.dumps(asdict(model_metadata))
         with open(model_metadata_path, "w") as outfile:
-            outfile.write(json_object)
+            outfile.write(model_metadata_json)
 
         # flatten directory contents and convert it to bytes
         flattened_bytes = executorchcoreml.flatten_directory_contents(
             str(model_dir_path.resolve())
         )
+
         shutil.rmtree(str(model_dir_path.resolve()))
         return flattened_bytes
 
     @classmethod
-    # pyre-ignore
     def preprocess(
         cls,
         edge_program: ExportedProgram,
-        module_compile_spec: List[CompileSpec],
+        module_compile_specs: List[CompileSpec],
     ) -> PreprocessResult:
+        model_type: CoreMLBackend.MODEL_TYPE = (
+            CoreMLBackend.model_type_from_compile_specs(
+                module_compile_specs,
+            )
+        )
+
+        model_compute_precision: ct.precision = (
+            CoreMLBackend.model_compute_precision_from_compile_specs(
+                module_compile_specs
+            )
+        )
+
+        minimum_deployment_target: ct.target = (
+            CoreMLBackend.min_deployment_target_from_compile_specs(module_compile_specs)
+        )
+
+        skip_model_load: bool = False
+        match model_type:
+            case CoreMLBackend.MODEL_TYPE.MODEL:
+                skip_model_load = True
+
+            case CoreMLBackend.MODEL_TYPE.COMPILED_MODEL:
+                skip_model_load = False
+
         mlmodel = ct.convert(
             model=edge_program,
             source="pytorch",
             convert_to="mlprogram",
             pass_pipeline=ct.PassPipeline.DEFAULT,
-            skip_model_load=True,
+            skip_model_load=skip_model_load,
+            compute_precision=model_compute_precision,
+            minimum_deployment_target=minimum_deployment_target,
         )
-        flattened_bytes = CoreMLBackend.to_bytes(mlmodel)
+
+        processed_bytes = CoreMLBackend.to_bytes(mlmodel, model_type=model_type)
         return PreprocessResult(
-            processed_bytes=flattened_bytes,
+            processed_bytes=processed_bytes,
         )

--- a/backends/apple/coreml/partition/coreml_partitioner.py
+++ b/backends/apple/coreml/partition/coreml_partitioner.py
@@ -9,6 +9,9 @@ import coremltools as ct
 
 import torch
 
+from executorch.backends.apple.coreml.compiler import CoreMLBackend
+from executorch.exir.backend.compile_spec_schema import CompileSpec
+
 from executorch.exir.backend.partitioner import (
     DelegationSpec,
     Partitioner,
@@ -52,15 +55,19 @@ class OperatorsSupportedForCoreMLBackend(OperatorSupportBase):
 
 
 class CoreMLPartitioner(Partitioner):
-    compile_spec = []
 
     def __init__(
-        self, skip_ops_for_coreml_delegation: Optional[List[str]] = None
+        self,
+        skip_ops_for_coreml_delegation: Optional[List[str]] = None,
+        compile_specs: Optional[List[CompileSpec]] = None,
     ) -> None:
         if skip_ops_for_coreml_delegation is None:
             skip_ops_for_coreml_delegation = []
         self.skip_ops_for_coreml_delegation = skip_ops_for_coreml_delegation
-        self.delegation_spec = DelegationSpec("CoreMLBackend", self.compile_spec)
+        self.delegation_spec = DelegationSpec(
+            backend_id=CoreMLBackend.__name__,
+            compile_specs=compile_specs if compile_specs is not None else [],
+        )
 
     def partition(self, exported_program: ExportedProgram) -> PartitionResult:
         # Run the CapabilityBasedPartitioner to return the largest possible

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.h
@@ -21,6 +21,7 @@ typedef NS_ERROR_ENUM(ETCoreMLErrorDomain, ETCoreMLError) {
     ETCoreMLErrorCorruptedModel, // AOT blob has incorrect or missing CoreML model.
     ETCoreMLErrorBrokenModel, // CoreML model doesn't match the input and output specification.
     ETCoreMLErrorCompilationFailed, // CoreML model failed to compile.
+    ETCoreMLErrorModelCompilationNotSupported, // CoreML model compilation is not supported by the target.
     ETCoreMLErrorModelSaveFailed, // Failed to save CoreML model to disk.
     ETCoreMLErrorModelCacheCreationFailed, // Failed to create model cache.
     ETCoreMLErrorInternalError, // Internal error.

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelCompiler.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelCompiler.mm
@@ -7,12 +7,23 @@
 
 #import <ETCoreMLModelCompiler.h>
 #import <ETCoreMLLogging.h>
+#import <TargetConditionals.h>
 
 @implementation ETCoreMLModelCompiler
 
 + (nullable NSURL *)compileModelAtURL:(NSURL *)modelURL
                  maxWaitTimeInSeconds:(NSTimeInterval)maxWaitTimeInSeconds
                                 error:(NSError* __autoreleasing *)error {
+#if TARGET_OS_WATCH
+    (void)modelURL;
+    (void)maxWaitTimeInSeconds;
+    (void)error;
+    ETCoreMLLogErrorAndSetNSError(error,
+                                  ETCoreMLErrorModelCompilationNotSupported,
+                                  "%@: Model compilation is not supported on the target, please make sure to export a compiled model.",
+                                  NSStringFromClass(ETCoreMLModelCompiler.class));
+    return nil;
+#else
     __block NSError *localError = nil;
     __block NSURL *result = nil;
     
@@ -34,6 +45,7 @@
     }
     
     return result;
+#endif
 }
 
 @end

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLStrings.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLStrings.mm
@@ -71,7 +71,7 @@
 }
 
 + (NSString *)cpuAndNeuralEngineComputeUnitsName {
-    static NSString * const ETCoreMLCPUAndNeuralEngineComputeUnitsName = @"cpu_and_ane";
+    static NSString * const ETCoreMLCPUAndNeuralEngineComputeUnitsName = @"cpu_and_ne";
     return ETCoreMLCPUAndNeuralEngineComputeUnitsName;
 }
 

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.cpp
@@ -427,7 +427,7 @@ bool InMemoryFileSystem::is_file(const std::vector<std::string>& canonical_path)
     return node && node->isFile();
 }
 
-bool InMemoryFileSystem::exists(const std::vector<std::string>& canonical_path) noexcept {
+bool InMemoryFileSystem::exists(const std::vector<std::string>& canonical_path) const noexcept {
     auto node = get_node(root_.get(), canonical_path.begin(), canonical_path.end());
     return node != nullptr;
 }

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.hpp
@@ -158,7 +158,7 @@ public:
     ///
     /// @param canonical_path   The path components from the root.
     /// @retval `true` if the node at the specified path exists.
-    bool exists(const std::vector<std::string>& canonical_path) noexcept;
+    bool exists(const std::vector<std::string>& canonical_path) const noexcept;
     
     /// Retrieves the canonical path of all the child nodes at the specified path. The node
     /// at the specified path must be a directory otherwise it returns an empty vector with the `error`

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.h
@@ -36,7 +36,7 @@ __attribute__((objc_subclassing_restricted))
 /// @param assetManager The asset manager used to manage storage of compiled models.
 /// @param error   On failure, error is filled with the failure information.
 - (nullable instancetype)initWithCompiledModelAsset:(ETCoreMLAsset*)compiledModelAsset
-                                         modelAsset:(ETCoreMLAsset*)modelAsset
+                                         modelAsset:(nullable ETCoreMLAsset*)modelAsset
                                            metadata:(const executorchcoreml::ModelMetadata&)metadata
                                       configuration:(MLModelConfiguration*)configuration
                                        assetManager:(ETCoreMLAssetManager*)assetManager

--- a/backends/apple/coreml/runtime/test/BackendDelegateTests.mm
+++ b/backends/apple/coreml/runtime/test/BackendDelegateTests.mm
@@ -146,7 +146,7 @@ std::vector<MultiArray> toMultiArrays(NSArray<MLMultiArray *> *mlMultiArrays) {
     
     {
         std::unordered_map<std::string, Buffer> compileSpecs;
-        NSData *specData = [@"cpu_and_ane" dataUsingEncoding:NSUTF8StringEncoding];
+        NSData *specData = [@"cpu_and_ne" dataUsingEncoding:NSUTF8StringEncoding];
         compileSpecs.emplace(computeUnitsKey, Buffer(specData.bytes, specData.length));
         BackendDelegate::Handle *handle = _delegate->init(Buffer(data.bytes, data.length), compileSpecs);
         ETCoreMLModel *model = (__bridge ETCoreMLModel *)handle;

--- a/examples/apple/coreml/scripts/export.py
+++ b/examples/apple/coreml/scripts/export.py
@@ -8,6 +8,8 @@ import copy
 import pathlib
 import sys
 
+import coremltools as ct
+
 import executorch.exir as exir
 
 import torch
@@ -19,7 +21,6 @@ from executorch.backends.apple.coreml.partition.coreml_partitioner import (
 )
 
 from executorch.exir.backend.backend_api import to_backend
-from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.sdk.etrecord import generate_etrecord
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent.parent.parent
@@ -36,8 +37,6 @@ _EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(
     _check_ir_validity=False,
 )
 
-compute_units = ["cpu_only", "cpu_and_gpu", "cpu_and_ane", "all"]
-
 
 def parse_args() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
@@ -51,11 +50,21 @@ def parse_args() -> argparse.ArgumentParser:
 
     parser.add_argument(
         "-c",
-        "--compute_units",
+        "--compute_unit",
         required=False,
-        default="all",
-        help=f"Provide compute units. Valid ones: {compute_units}",
+        default=ct.ComputeUnit.ALL.name.lower(),
+        help=f"Provide compute unit for the model. Valid ones: {[[compute_unit.name.lower() for compute_unit in ct.ComputeUnit]]}",
     )
+
+    parser.add_argument(
+        "-precision",
+        "--compute_precision",
+        required=False,
+        default=ct.precision.FLOAT16.value,
+        help=f"Provide compute precision for the model. Valid ones: {[[precision.value for precision in ct.precision]]}",
+    )
+
+    parser.add_argument("--compile", action=argparse.BooleanOptionalAction)
     parser.add_argument("--use_partitioner", action=argparse.BooleanOptionalAction)
     parser.add_argument("--generate_etrecord", action=argparse.BooleanOptionalAction)
     parser.add_argument("--save_processed_bytes", action=argparse.BooleanOptionalAction)
@@ -68,7 +77,7 @@ def partition_module_to_coreml(module):
     module = module.eval()
 
 
-def lower_module_to_coreml(module, compute_units):
+def lower_module_to_coreml(module, compile_specs):
     module = module.eval()
     edge = exir.capture(module, example_inputs, _CAPTURE_CONFIG).to_edge(
         _EDGE_COMPILE_CONFIG
@@ -82,7 +91,7 @@ def lower_module_to_coreml(module, compute_units):
     lowered_module = to_backend(
         CoreMLBackend.__name__,
         edge.exported_program,
-        [CompileSpec("compute_units", bytes(compute_units, "utf-8"))],
+        compile_specs,
     )
 
     return lowered_module, edge_copy
@@ -101,21 +110,37 @@ def export_lowered_module_to_executorch_program(lowered_module, example_inputs):
     return exec_prog
 
 
-def save_executorch_program(exec_prog, model_name, compute_units):
+def save_executorch_program(exec_prog, model_name, compute_unit):
     buffer = exec_prog.buffer
-    filename = f"{model_name}_coreml_{compute_units}.pte"
+    filename = f"{model_name}_coreml_{compute_unit}.pte"
     print(f"Saving exported program to {filename}")
     with open(filename, "wb") as file:
         file.write(buffer)
     return
 
 
-def save_processed_bytes(processed_bytes, model_name, compute_units):
-    filename = f"{model_name}_coreml_{compute_units}.bin"
+def save_processed_bytes(processed_bytes, model_name, compute_unit):
+    filename = f"{model_name}_coreml_{compute_unit}.bin"
     print(f"Saving processed bytes to {filename}")
     with open(filename, "wb") as file:
         file.write(processed_bytes)
     return
+
+
+def generate_compile_specs_from_args(args):
+    model_type = (
+        CoreMLBackend.MODEL_TYPE.MODEL
+        if args.compile
+        else CoreMLBackend.MODEL_TYPE.COMPILED_MODEL
+    )
+    compute_precision = ct.precision(args.compute_precision)
+    compute_unit = ct.ComputeUnit[args.compute_unit.upper()]
+
+    return CoreMLBackend.generate_compile_specs(
+        compute_precision=compute_precision,
+        compute_unit=compute_unit,
+        model_type=model_type,
+    )
 
 
 if __name__ == "__main__":
@@ -127,37 +152,44 @@ if __name__ == "__main__":
             f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}."
         )
 
-    if args.compute_units not in compute_units:
+    valid_compute_units = [compute_unit.name.lower() for compute_unit in ct.ComputeUnit]
+    if args.compute_unit not in valid_compute_units:
         raise RuntimeError(
-            f"{args.compute_units} is invalid. "
-            f"Valid compute units are {compute_units}."
+            f"{args.compute_unit} is invalid. "
+            f"Valid compute units are {valid_compute_units}."
         )
 
     model, example_inputs, _ = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 
+    compile_specs = generate_compile_specs_from_args(args)
+    lowered_module = None
+
     if args.use_partitioner:
         model.eval()
         exir_program_aten = torch.export.export(model, example_inputs)
         edge_program_manager = exir.to_edge(exir_program_aten)
         edge_copy = copy.deepcopy(edge_program_manager)
-        delegated_program_manager = edge_program_manager.to_backend(CoreMLPartitioner())
+        partitioner = CoreMLPartitioner(
+            skip_ops_for_coreml_delegation=None, compile_specs=compile_specs
+        )
+        delegated_program_manager = edge_program_manager.to_backend(partitioner)
         exec_program = delegated_program_manager.to_executorch()
     else:
         lowered_module, edge_copy = lower_module_to_coreml(
-            model,
-            args.compute_units,
+            module=model,
+            compile_specs=compile_specs,
         )
         exec_program = export_lowered_module_to_executorch_program(
             lowered_module,
             example_inputs,
         )
 
-    save_executorch_program(exec_program, args.model_name, args.compute_units)
+    save_executorch_program(exec_program, args.model_name, args.compute_unit)
     generate_etrecord(f"{args.model_name}_coreml_etrecord.bin", edge_copy, exec_program)
 
-    if args.save_processed_bytes:
+    if args.save_processed_bytes and lowered_module is not None:
         save_processed_bytes(
-            lowered_module.processed_bytes, args.model_name, args.compute_units
+            lowered_module.processed_bytes, args.model_name, args.compute_unit
         )


### PR DESCRIPTION
Expand export options
- `generate_compute_precision_compile_spec ` adds compute precision for the model.
- `generate_min_deployment_target_compile_spec` adds a minimum deployment target for the model. 
- `generate_model_type_compile_spec ` adds an option to bundle the `mlmodelc` contents in the exported program. This avoids the extra step to compile the model on the device. CoreML backend can now be used on `watchos`,  `watchos` has no model compilation API.

The export script has been updated to include the expanded options.