### PR TITLE
[ET-VK][EZ] Generate int variants for nchw_to_image and image_to_nchw

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/image_to_nchw.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/image_to_nchw.yaml
@@ -15,6 +15,8 @@ image_to_nchw:
         SUFFIX: "half"
       - VALUE: "float"
         SUFFIX: "float"
+      - VALUE: "int"
+        SUFFIX: "int"
   shader_variants:
     - NAME: image3d_to_nchw_C_packed
     - NAME: image2d_to_nchw_C_packed

--- a/backends/vulkan/runtime/graph/ops/glsl/nchw_to_image.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/nchw_to_image.glsl
@@ -53,7 +53,7 @@ void main() {
 
   if (coord.z + 3 >= cpu_sizes.data.z) {
     ivec4 c_ind = ivec4(coord.z) + ivec4(0, 1, 2, 3);
-    vec4 valid_c = vec4(lessThan(c_ind, ivec4(cpu_sizes.data.z)));
+    ${VEC4_T[DTYPE]} valid_c = ${VEC4_T[DTYPE]}(lessThan(c_ind, ivec4(cpu_sizes.data.z)));
     texel = texel * valid_c;
   }
 

--- a/backends/vulkan/runtime/graph/ops/glsl/nchw_to_image.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/nchw_to_image.yaml
@@ -15,6 +15,8 @@ nchw_to_image:
         SUFFIX: "half"
       - VALUE: "float"
         SUFFIX: "float"
+      - VALUE: "int"
+        SUFFIX: "int"
   shader_variants:
     - NAME: nchw_to_image3d_C_packed
     - NAME: nchw_to_image2d_C_packed


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2488
* #2446
* #2445

Required for `aten.max_pool2d_with_indices` which is coming soon, where we work with an `int` tensor on Vulkan.

Differential Revision: [D54961928](https://our.internmc.facebook.com/intern/diff/D54961928/)