### PR TITLE
Move OSS XNNPACK to groupwise fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,7 +30,7 @@
 	url = https://github.com/Maratyszcza/FXdiv.git
 [submodule "backends/xnnpack/third-party/XNNPACK"]
 	path = backends/xnnpack/third-party/XNNPACK
-	url = https://github.com/google/XNNPACK.git
+	url = https://github.com/digantdesai/XNNPACK.git
 [submodule "backends/arm/third-party/serialization_lib"]
 	path = backends/arm/third-party/serialization_lib
 	url = https://review.mlplatform.org/tosa/serialization_lib


### PR DESCRIPTION
Summary:
```
❯ git log -n1
commit b9b042db5ad8011b3e73721399dc7dac9b51daaa (HEAD, tag: et_v17, origin/local_blockwise)
Author: Digant Desai <digantdesai@meta.com>
Date:   Tue Mar 12 10:08:13 2024 -0500

    [blockwise] Add qd8-f16-qb4w support for fully-connected subgraph op
```

Differential Revision: D55041833


