### PR TITLE
Reduce log level of mlock failure in mmap_data_loader

### DIFF
--- a/extension/data_loader/mmap_data_loader.cpp
+++ b/extension/data_loader/mmap_data_loader.cpp
@@ -201,7 +201,7 @@ Result<FreeableBuffer> MmapDataLoader::Load(size_t offset, size_t size) {
     if (err < 0) {
       if (mlock_config_ == MlockConfig::UseMlockIgnoreErrors) {
         ET_LOG(
-            Info,
+            Debug,
             "Ignoring mlock error for file %s (off=0x%zd): "
             "mlock(%p, %zu) failed: %s (%d)",
             file_name_,


### PR DESCRIPTION
Summary:
Some large models with a large number of segments will fail this check, spamming the log with this message every time.

Drop the level to Debug so we can still see it if interested, but to keep it silenced by default (Info is the default log level).

The downside of this is that people may not know that their memory isn't being locked. But in those situations, they may not be looking at the logs anyway.

Differential Revision: D55045041


