### PR TITLE
New pip build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,8 @@ cmake-android-out/
 cmake-ios-out/
 ethos-u-scratch/
 executorch.egg-info
+pip-out/
 __pycache__/
-build/lib/
-exir/_serialize/scalar_type.fbs
-exir/_serialize/program.fbs
-sdk/bundled_program/serialize/bundled_program_schema.fbs
-sdk/bundled_program/serialize/scalar_type.fbs
 
 # Any exported models and profiling outputs
 *.pte

--- a/build/pip_data_bin_init.py.in
+++ b/build/pip_data_bin_init.py.in
@@ -1,0 +1,42 @@
+# This file should be written to the wheel package as
+# `executorch/data/bin/__init__.py`.
+#
+# Setuptools will expect to be able to say something like `from
+# executorch.data.bin import mybin; mybin()` for each entry listed in the
+# [project.scripts] section of pyproject.toml. This file makes the `mybin()`
+# function execute the binary at `executorch/data/bin/mybin` and exit with that
+# binary's exit status.
+
+import subprocess
+import os
+import sys
+import types
+
+# This file should live in the target `bin` directory.
+_bin_dir = os.path.join(os.path.dirname(__file__))
+
+def _find_executable_files_under(dir):
+    """Lists all executable files in the given directory."""
+    bin_names = []
+    for filename in os.listdir(dir):
+        filepath = os.path.join(dir, filename)
+        if os.path.isfile(filepath) and os.access(filepath, os.X_OK):
+            bin_names.append(filename)
+    return bin_names
+
+# The list of binaries to create wrapper functions for.
+_bin_names = _find_executable_files_under(_bin_dir)
+
+# We'll define functions named after each binary. Make them importable.
+__all__ = _bin_names
+
+def _run(name):
+    """Runs the named binary, which should live under _bin_dir.
+
+    Exits the current process with the return code of the subprocess.
+    """
+    raise SystemExit(subprocess.call([os.path.join(_bin_dir, name)] + sys.argv[1:], close_fds=False))
+
+# Define a function named after each of the binaries.
+for bin_name in _bin_names:
+    exec(f"def {bin_name}(): _run('{bin_name}')")

--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -111,36 +111,11 @@ Follow these steps:
    source .executorch/bin/activate
    ```
 
-1. Install [Cmake](https://cmake.org/download)
-
-   ```bash
-   conda install cmake
-   ```
-
-   Alternatively:
-
-   ```bash
-   pip install cmake
-   ```
-
 1. Install ExecuTorch and dependencies:
 
    ```bash
    ./install_requirements.sh
    ```
-
-   **Optional:** Install ExecuTorch as an editable installation:
-   ```bash
-   pip install --editable . --config-settings editable_mode=strict --no-build-isolation
-   ```
-
-1. Expose FlatBuffers compiler:
-
-   ExecuTorch uses `flatc` to export models and builds it from sources at
-   `third-party/flatbuffers`. Make it available by adding it to the `$PATH` environment variable,
-   as prompted by the previous step, or exporting as `$FLATC_EXECUTABLE`
-   enironment variable.
-   Run `./build/install_flatc.sh` to make sure `flatc` is installed correctly.
 
 You have successfully set up your environment to work with ExecuTorch. The next
 step is to generate a sample ExecuTorch program.

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -28,7 +28,8 @@ for arg in "$@"; do
       ;;
     coreml|mps|xnnpack)
       if [[ "$EXECUTORCH_BUILD_PYBIND" == "ON" ]]; then
-        CMAKE_ARGS="$CMAKE_ARGS -DEXECUTORCH_BUILD_${arg^^}=ON"
+        arg_upper="$(echo "${arg}" | tr '[:lower:]' '[:upper:]')"
+        CMAKE_ARGS="$CMAKE_ARGS -DEXECUTORCH_BUILD_${arg_upper}=ON"
       else
         echo "Error: $arg must follow --pybind"
         exit 1
@@ -65,6 +66,7 @@ EXIR_REQUIREMENTS=(
 
 # pip packages needed for development.
 DEVEL_REQUIREMENTS=(
+  cmake  # For building binary targets.
   setuptools  # For building the pip package.
   tomli  # Imported by extract_sources.py when using python < 3.11.
   wheel  # For building the pip package archive.
@@ -94,13 +96,9 @@ pip install --extra-index-url "${TORCH_NIGHTLY_URL}" \
     "${REQUIREMENTS_TO_INSTALL[@]}"
 
 #
-# Install executorch pip package.
+# Install executorch pip package. This also makes `flatc` available on the path.
 #
 
-EXECUTORCH_BUILD_PYBIND="$EXECUTORCH_BUILD_PYBIND" \
-CMAKE_ARGS="$CMAKE_ARGS" \
-CMAKE_BUILD_PARALLEL_LEVEL=9 \
-pip install . --no-build-isolation -v
-
-# Install flatc dependency
-bash build/install_flatc.sh
+EXECUTORCH_BUILD_PYBIND="${EXECUTORCH_BUILD_PYBIND}" \
+    CMAKE_ARGS="${CMAKE_ARGS}" \
+    pip install . --no-build-isolation -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,15 +20,27 @@ dependencies=[
   "ruamel.yaml",
   "sympy",
   "tabulate",
-  "tomli",
-  "zstd",
 ]
 
+# Tell setuptools to generate commandline wrappers for tools that we install
+# under data/bin in the pip package. This will put these commands on the user's
+# path.
+[project.scripts]
+flatc = "executorch.data.bin:flatc"
+
 [tool.setuptools.package-data]
-"*" = ["*.fbs", "*.yaml"]
+# TODO(dbort): Prune /test[s]/ dirs, /third-party/ dirs, yaml files that we
+# don't need.
+"*" = [
+  # Some backends like XNNPACK need their .fbs files.
+  "*.fbs",
+  # Some kernel libraries need their .yaml files.
+  "*.yaml",
+]
 
 [tool.setuptools.exclude-package-data]
 "*" = ["*.pyc"]
 
 [tool.usort]
+# Do not try to put "first-party" imports in their own section.
 first_party_detection = false

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -77,6 +77,8 @@ ExternalProject_Add(
   SOURCE_DIR ${CMAKE_SOURCE_DIR}/third-party/flatcc
   BINARY_DIR ${CMAKE_BINARY_DIR}/_host_build
   CMAKE_CACHE_ARGS -DFLATCC_TEST:BOOL=OFF -DFLATCC_REFLECTION:BOOL=OFF
+      # See above comment about POSITION_INDEPENDENT_CODE.
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
   INSTALL_COMMAND "" # Prevent the install step, modify as needed
 )
 

--- a/setup.py
+++ b/setup.py
@@ -47,194 +47,408 @@
 
 import os
 import re
-import shutil
-import subprocess
 import sys
+
+# Import this before distutils so that setuptools can intercept the distuils
+# imports.
+import setuptools  # noqa: F401 # usort: skip
+
+from distutils import log
 from distutils.sysconfig import get_python_lib
 from pathlib import Path
 
 from setuptools import Extension, setup
+from setuptools.command.build import build
 from setuptools.command.build_ext import build_ext
-from setuptools.command.develop import develop
-from setuptools.command.egg_info import egg_info
-from setuptools.command.install import install
+from setuptools.command.build_py import build_py
 
-# Convert distutils Windows platform specifiers to CMake -A arguments
-PLAT_TO_CMAKE = {
-    "win32": "Win32",
-    "win-amd64": "x64",
-    "win-arm32": "ARM",
-    "win-arm64": "ARM64",
-}
+# For information on setuptools Command subclassing see
+# https://setuptools.pypa.io/en/latest/userguide/extension.html
 
 
-# A CMakeExtension needs a sourcedir instead of a file list.
-# The name must be the _single_ output extension from the CMake build.
-# If you need multiple extensions, see scikit-build.
-class CMakeExtension(Extension):
-    def __init__(self, name: str, sourcedir: str = "") -> None:
-        super().__init__(name, sources=[])
-        self.sourcedir = os.fspath(Path(sourcedir).resolve())
+class ShouldBuild:
+    """Indicates whether to build various components."""
+
+    @staticmethod
+    def _is_env_enabled(env_var: str, default: bool = False) -> bool:
+        val = os.environ.get(env_var, None)
+        if val is None:
+            return default
+        if val in ("OFF", "0", ""):
+            return False
+        return True
+
+    @classmethod
+    @property
+    def pybindings(cls) -> bool:
+        return cls._is_env_enabled("EXECUTORCH_BUILD_PYBIND", default=False)
+
+    @classmethod
+    @property
+    def xnnpack(cls) -> bool:
+        return cls._is_env_enabled("EXECUTORCH_BUILD_XNNPACK", default=False)
 
 
-class CMakeBuild(build_ext):
-    def build_extension(self, ext: CMakeExtension) -> None:
-        # Must be in this form due to bug in .resolve() only fixed in Python 3.10+
-        ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)
-        extdir = ext_fullpath.parent.resolve()
+class _BaseExtension(Extension):
+    """A base class that maps an abstract source to an abstract destination."""
 
-        # Using this requires trailing slash for auto-detection & inclusion of
-        # auxiliary "native" libs
+    def __init__(self, src: str, dst: str, name: str):
+        # Source path; semantics defined by the subclass.
+        self.src: str = src
+
+        # Destination path relative to a namespace defined elsewhere. If this ends
+        # in "/", it is treated as a directory. If this is "", it is treated as the
+        # root of the namespace.
+        # Destination path; semantics defined by the subclass.
+        self.dst: str = dst
+
+        # Other parts of setuptools expects .name to exist. For actual extensions
+        # this can be the module path, but otherwise it should be somehing unique
+        # that doesn't look like a module path.
+        self.name: str = name
+
+        super().__init__(name=self.name, sources=[])
+
+    def src_path(self, installer: "InstallerBuildExt") -> Path:
+        """Returns the path to the source file, resolving globs.
+
+        Args:
+            installer: The InstallerBuildExt instance that is installing the
+                file.
+        """
+        # TODO(dbort): share the cmake-out location with CustomBuild. Can get a
+        # handle with installer.get_finalized_command('build')
+        cmake_cache_dir: Path = Path().cwd() / installer.build_temp / "cmake-out"
+
+        # Construct the full source path, resolving globs. If there are no glob
+        # pattern characters, this will just ensure that the source file exists.
+        srcs = tuple(cmake_cache_dir.glob(self.src))
+        if len(srcs) != 1:
+            raise ValueError(
+                f"Expected exactly one file matching '{self.src}'; found {repr(srcs)}"
+            )
+        return srcs[0]
+
+
+class BuiltFile(_BaseExtension):
+    """An extension that installs a single file that was built by cmake.
+
+    This isn't technically a `build_ext` style python extension, but there's no
+    dedicated command for installing arbitrary data. It's convenient to use
+    this, though, because it lets us manage the files to install as entries in
+    `ext_modules`.
+    """
+
+    def __init__(self, src: str, dst: str):
+        """Initializes a BuiltFile.
+
+        Args:
+            src: The path to the file to install, relative to the cmake-out
+                directory. May be an fnmatch-style glob that matches exactly one
+                file.
+            dst: The path to install to, relative to the root of the pip
+                package. If dst ends in "/", it is treated as a directory.
+                Otherwise it is treated as a filename.
+        """
+        # This is not a real extension, so use a unique name that doesn't look
+        # like a module path. Some of setuptools's autodiscovery will look for
+        # extension names with prefixes that match certain module paths.
+        super().__init__(src=src, dst=dst, name=f"@EXECUTORCH_BuiltFile_{src}:{dst}")
+
+    def dst_path(self, installer: "InstallerBuildExt") -> Path:
+        """Returns the path to the destination file.
+
+        Args:
+            installer: The InstallerBuildExt instance that is installing the
+                file.
+        """
+        dst_root = Path(installer.build_lib).resolve()
+
+        if self.dst.endswith("/"):
+            # Destination looks like a directory. Use the basename of the source
+            # file for its final component.
+            return dst_root / Path(self.dst) / self.src_path(installer).name
+        else:
+            # Destination looks like a file.
+            return dst_root / Path(self.dst)
+
+
+class BuiltExtension(_BaseExtension):
+    """An extension that installs a python extension that was built by cmake."""
+
+    def __init__(self, src: str, modpath: str):
+        """Initializes a BuiltExtension.
+
+        Args:
+            src: The path to the file to install (typically a shared library),
+                relative to the cmake-out directory. May be an fnmatch-style
+                glob that matches exactly one file. If the path ends in `.so`,
+                this class will also look for similarly-named `.dylib` files.
+            modpath: The dotted path of the python module that maps to the
+                extension.
+        """
+        assert (
+            "/" not in modpath
+        ), f"modpath must be a dotted python module path: saw '{modpath}'"
+        # This is a real extension, so use the modpath as the name.
+        super().__init__(src=src, dst=modpath, name=modpath)
+
+    def src_path(self, installer: "InstallerBuildExt") -> Path:
+        """Returns the path to the source file, resolving globs.
+
+        Args:
+            installer: The InstallerBuildExt instance that is installing the
+                file.
+        """
+        try:
+            return super().src_path(installer)
+        except ValueError:
+            # Probably couldn't find the file. If the path ends with .so, try
+            # looking for a .dylib file instead, in case we're running on macos.
+            if self.src.endswith(".so"):
+                dylib_src = re.sub(r"\.so$", ".dylib", self.src)
+                return BuiltExtension(src=dylib_src, modpath=self.dst).src_path(
+                    installer
+                )
+            else:
+                raise
+
+    def dst_path(self, installer: "InstallerBuildExt") -> Path:
+        """Returns the path to the destination file.
+
+        Args:
+            installer: The InstallerBuildExt instance that is installing the
+                file.
+        """
+        # Our destination is a dotted module path. get_ext_fullpath() returns
+        # the relative path to the .so/.dylib/etc. file that maps to the module
+        # path: that's the file we're creating.
+        return Path(installer.get_ext_fullpath(self.dst))
+
+
+class InstallerBuildExt(build_ext):
+    """Installs files that were built by cmake."""
+
+    # TODO(dbort): Depend on the "build" command to ensure it runs first
+
+    def build_extension(self, ext: _BaseExtension) -> None:
+        src_file: Path = ext.src_path(self)
+        dst_file: Path = ext.dst_path(self)
+
+        # Ensure that the destination directory exists.
+        self.mkpath(os.fspath(dst_file.parent))
+
+        # Copy the file.
+        self.copy_file(os.fspath(src_file), os.fspath(dst_file))
+
+        # Ensure that the destination file is writable, even if the source was
+        # not. build_py does this by passing preserve_mode=False to copy_file,
+        # but that would clobber the X bit on any executables. TODO(dbort): This
+        # probably won't work on Windows.
+        if not os.access(src_file, os.W_OK):
+            # Make the file writable. This should respect the umask.
+            os.chmod(src_file, os.stat(src_file).st_mode | 0o222)
+
+
+class CustomBuildPy(build_py):
+    """Copies platform-independent files from the source tree into the output
+    package directory.
+
+    Override it so we can copy some files to locations that don't match their
+    original relative locations.
+
+    Standard setuptools features like package_data and MANIFEST.in can only
+    include or exclude a file in the source tree; they don't have a way to map
+    a file to a different relative location under the output package directory.
+    """
+
+    def run(self):
+        # Copy python files to the output directory. This set of files is
+        # defined by the py_module list and package_data patterns.
+        build_py.run(self)
+
+        # dst_root is the root of the `executorch` module in the output package
+        # directory. build_lib is the platform-independent root of the output
+        # package, and will look like `pip-out/lib`. It can contain multiple
+        # python packages, so be sure to copy the files into the `executorch`
+        # package subdirectory.
+        dst_root = os.path.join(self.build_lib, self.get_package_dir("executorch"))
+
+        # Manually copy files into the output package directory. These are
+        # typically python "resource" files that will live alongside the python
+        # code that uses them.
+        src_to_dst = [
+            # TODO(dbort): See if we can add a custom pyproject.toml section for
+            # these, instead of hard-coding them here. See
+            # https://setuptools.pypa.io/en/latest/userguide/extension.html
+            ("schema/scalar_type.fbs", "exir/_serialize/scalar_type.fbs"),
+            ("schema/program.fbs", "exir/_serialize/program.fbs"),
+            (
+                "sdk/bundled_program/schema/bundled_program_schema.fbs",
+                "sdk/bundled_program/serialize/bundled_program_schema.fbs",
+            ),
+            (
+                "sdk/bundled_program/schema/scalar_type.fbs",
+                "sdk/bundled_program/serialize/scalar_type.fbs",
+            ),
+        ]
+        for src, dst in src_to_dst:
+            dst = os.path.join(dst_root, dst)
+
+            # When modifying the filesystem, use the self.* methods defined by
+            # Command to benefit from the same logging and dry_run logic as
+            # setuptools.
+
+            # Ensure that the destination directory exists.
+            self.mkpath(os.path.dirname(dst))
+            # Follow the example of the base build_py class by not preserving
+            # the mode. This ensures that the output file is read/write even if
+            # the input file is read-only.
+            self.copy_file(src, dst, preserve_mode=False)
+
+
+# TODO(dbort): For editable wheels, may need to update get_source_files(),
+# get_outputs(), and get_output_mapping() to satisfy
+# https://setuptools.pypa.io/en/latest/userguide/extension.html#setuptools.command.build.SubCommand.get_output_mapping
+
+
+class CustomBuild(build):
+    def initialize_options(self):
+        super().initialize_options()
+        # The default build_base directory is called "build", but we have a
+        # top-level directory with that name. Setting build_base in setup()
+        # doesn't affect this, so override the core build command.
+        #
+        # See build.initialize_options() in
+        # setuptools/_distutils/command/build.py for the default.
+        self.build_base = "pip-out"
+
+        # Default build parallelism based on number of cores, but allow
+        # overriding through the environment.
+        default_parallel = str(os.cpu_count() - 1)
+        self.parallel = os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", default_parallel)
+
+    def run(self):
+        self.dump_options()
 
         debug = int(os.environ.get("DEBUG", 0)) if self.debug is None else self.debug
         cfg = "Debug" if debug else "Release"
 
-        # CMake lets you override the generator - we need to check this.
-        # Can be set with Conda-Build, for example.
-        cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
-
-        # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
-        # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
-        # from Python.
-        buck = os.environ.get("BUCK", "")
+        # get_python_lib() typically returns the path to site-packages, where
+        # all pip packages in the environment are installed.
         cmake_prefix_path = os.environ.get("CMAKE_PREFIX_PATH", get_python_lib())
+
+        # The root of the repo should be the current working directory. Get
+        # the absolute path.
+        repo_root = os.fspath(Path.cwd())
+
+        # If blank, the cmake build system will find an appropriate binary.
+        buck2 = os.environ.get(
+            "BUCK2_EXECUTABLE", os.environ.get("BUCK2", os.environ.get("BUCK", ""))
+        )
+
         cmake_args = [
-            "-DEXECUTORCH_BUILD_PYBIND=ON",
-            "-DBUILD_SHARED_LIBS=ON",  # For flatcc
-            f"-DBUCK2={buck}",
-            f"-DCMAKE_PREFIX_PATH={cmake_prefix_path}",
-            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
+            f"-DBUCK2={buck2}",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
-            f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
+            # Let cmake calls like `find_package(Torch)` find cmake config files
+            # like `TorchConfig.cmake` that are provided by pip packages.
+            f"-DCMAKE_PREFIX_PATH={cmake_prefix_path}",
+            f"-DCMAKE_BUILD_TYPE={cfg}",
+            # Enable logging even when in release mode. We are building for
+            # desktop, where saving a few kB is less important than showing
+            # useful error information to users.
+            "-DEXECUTORCH_ENABLE_LOGGING=ON",
+            "-DEXECUTORCH_LOG_LEVEL=Info",
         ]
 
-        build_args = []
-        # Adding CMake arguments set as environment variable
-        # (needed e.g. to build for ARM OSx on conda-forge)
+        build_args = [f"-j{self.parallel}"]
+
+        # TODO(dbort): Try to manage these targets and the cmake args from the
+        # extension entries themselves instead of hard-coding them here.
+        build_args += ["--target", "flatc"]
+
+        if ShouldBuild.pybindings:
+            cmake_args += [
+                "-DEXECUTORCH_BUILD_PYBIND=ON",
+            ]
+            build_args += ["--target", "portable_lib"]
+            if ShouldBuild.xnnpack:
+                cmake_args += [
+                    "-DEXECUTORCH_BUILD_XNNPACK=ON",
+                ]
+                # No target needed; the cmake arg will link xnnpack
+                # into the portable_lib target.
+            # TODO(dbort): Add MPS/CoreML backends when building on macos.
+
+        # Allow adding extra cmake args through the environment. Used by some
+        # tests and demos to expand the set of targets included in the pip
+        # package.
         if "CMAKE_ARGS" in os.environ:
             cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
 
-        # In this example, we pass in the version to C++. You might not need to.
-        cmake_args += [f"-DEXAMPLE_VERSION_INFO={self.distribution.get_version()}"]
+        # Put the cmake cache under the temp directory, like
+        # "pip-out/temp.<plat>/cmake-out".
+        cmake_cache_dir = os.path.join(repo_root, self.build_temp, "cmake-out")
+        self.mkpath(cmake_cache_dir)
 
-        if self.compiler.compiler_type != "msvc":
-            # Using Ninja-build since it a) is available as a wheel and b)
-            # multithreads automatically. MSVC would require all variables be
-            # exported for Ninja to pick it up, which is a little tricky to do.
-            # Users can override the generator with CMAKE_GENERATOR in CMake
-            # 3.15+.
-            if not cmake_generator or cmake_generator == "Ninja":
-                try:
-                    import ninja
+        # Generate the cmake cache from scratch to ensure that the cache state
+        # is predictable.
+        cmake_cache_file = Path(cmake_cache_dir) / "CMakeCache.txt"
+        log.info(f"deleting {cmake_cache_file}")
+        if not self.dry_run:
+            # Dry run should log the command but not actually run it.
+            (Path(cmake_cache_dir) / "CMakeCache.txt").unlink(missing_ok=True)
+        self.spawn(["cmake", "-S", repo_root, "-B", cmake_cache_dir, *cmake_args])
 
-                    ninja_executable_path = Path(ninja.BIN_DIR) / "ninja"
-                    cmake_args += [
-                        "-GNinja",
-                        f"-DCMAKE_MAKE_PROGRAM:FILEPATH={ninja_executable_path}",
-                    ]
-                except ImportError:
-                    pass
+        # Build the system.
+        self.spawn(["cmake", "--build", cmake_cache_dir, *build_args])
 
-        else:
-            # Single config generators are handled "normally"
-            single_config = any(x in cmake_generator for x in {"NMake", "Ninja"})
+        # Non-python files should live under this data directory.
+        data_root = os.path.join(self.build_lib, "executorch", "data")
 
-            # CMake allows an arch-in-generator style for backward compatibility
-            contains_arch = any(x in cmake_generator for x in {"ARM", "Win64"})
+        # Directories like bin/ and lib/ live under data/.
+        bin_dir = os.path.join(data_root, "bin")
 
-            # Specify the arch if using MSVC generator, but only if it doesn't
-            # contain a backward-compatibility arch spec already in the
-            # generator name.
-            if not single_config and not contains_arch:
-                cmake_args += ["-A", PLAT_TO_CMAKE[self.plat_name]]
-
-            # Multi-config generators have a different way to specify configs
-            if not single_config:
-                cmake_args += [
-                    f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}"
-                ]
-                build_args += ["--config", cfg]
-
-        if sys.platform.startswith("darwin"):
-            # Cross-compile support for macOS - respect ARCHFLAGS if set
-            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
-            if archs:
-                cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
-
-        # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
-        # across all generators.
-        parallel = self.parallel if hasattr(self, "parallel") and self.parallel else "1"
-        parallel = os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", parallel)
-        # self.parallel is a Python 3 only way to set parallel jobs by hand
-        # using -j in the build_ext call, not supported by pip or PyPA-build.
-        build_args += [f"-j{parallel}"]
-        print(self.build_temp)
-        build_temp = Path(self.build_temp) / ext.name
-        if not build_temp.exists():
-            build_temp.mkdir(parents=True)
-
-        subprocess.run(
-            ["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True
-        )
-        subprocess.run(
-            ["cmake", "--build", ".", *build_args], cwd=build_temp, check=True
+        # Copy the bin wrapper so that users can run any executables under
+        # data/bin, as long as they are listed in the [project.scripts] section
+        # of pyproject.toml.
+        self.mkpath(bin_dir)
+        self.copy_file(
+            "build/pip_data_bin_init.py.in",
+            os.path.join(bin_dir, "__init__.py"),
         )
 
+        # Finally, run the underlying subcommands like build_py, build_ext.
+        build.run(self)
 
-def custom_command():
-    src_dst_list = [
-        ("schema/scalar_type.fbs", "exir/_serialize/scalar_type.fbs"),
-        ("schema/program.fbs", "exir/_serialize/program.fbs"),
-        (
-            "sdk/bundled_program/schema/bundled_program_schema.fbs",
-            "sdk/bundled_program/serialize/bundled_program_schema.fbs",
-        ),
-        (
-            "sdk/bundled_program/schema/scalar_type.fbs",
-            "sdk/bundled_program/serialize/scalar_type.fbs",
-        ),
+
+def get_ext_modules() -> list[Extension]:
+    """Returns the set of extension modules to build."""
+
+    ext_modules = [
+        BuiltFile("third-party/flatbuffers/flatc", "executorch/data/bin/"),
     ]
-    for src, dst in src_dst_list:
-        print(f"copying from {src} to {dst}")
-        shutil.copyfile(src, dst)
-
-    for _, dst in src_dst_list:
-        if not os.path.isfile(dst):
-            raise FileNotFoundError(
-                f"Could not find {dst}, copying file from {src} fails."
+    if ShouldBuild.pybindings:
+        ext_modules.append(
+            # Install the prebuilt pybindings extension wrapper for the runtime,
+            # portable kernels, and a selection of backends. This lets users
+            # load and execute .pte files from python.
+            BuiltExtension(
+                "portable_lib.*", "executorch.extension.pybindings.portable_lib"
             )
+        )
 
+    # Note that setuptools uses the presence of ext_modules as the main signal
+    # that a wheel is platform-specific. If we install any platform-specific
+    # files, this list must be non-empty. Therefore, we should always install
+    # platform-specific files using InstallerBuildExt.
+    return ext_modules
 
-class CustomInstallCommand(install):
-    def run(self):
-        custom_command()
-        install.run(self)
-
-
-class CustomDevelopCommand(develop):
-    def run(self):
-        custom_command()
-        develop.run(self)
-
-
-class CustomEggInfoCommand(egg_info):
-    def run(self):
-        custom_command()
-        egg_info.run(self)
-
-
-cmdclass = {
-    "build_ext": CMakeBuild,
-    "install": CustomInstallCommand,
-    "develop": CustomDevelopCommand,
-    "egg_info": CustomEggInfoCommand,
-}
-ext_modules = []
-
-if os.environ.get("EXECUTORCH_BUILD_PYBIND", "OFF") == "ON":
-    ext_modules.append(CMakeExtension("executorch.extension.pybindings.portable_lib"))
 
 setup(
+    # TODO(dbort): Could use py_modules to restrict the set of modules we
+    # package, and package_data to restrict the set up non-python files we
+    # include. See also setuptools/discovery.py for custom finders.
     package_dir={
         "executorch/backends": "backends",
         # TODO(mnachin T180504136): Do not put examples/models
@@ -247,9 +461,15 @@ setup(
         "executorch/sdk": "sdk",
         "executorch/sdk/bundled_program": "sdk/bundled_program",
         "executorch/util": "util",
+        # Note: This will install a top-level module called "serializer",
+        # which seems too generic and might conflict with other pip packages.
         "serializer": "backends/arm/third-party/serialization_lib/python/serializer",
         "tosa": "backends/arm/third-party/serialization_lib/python/tosa",
     },
-    cmdclass=cmdclass,
-    ext_modules=ext_modules,
+    cmdclass={
+        "build": CustomBuild,
+        "build_ext": InstallerBuildExt,
+        "build_py": CustomBuildPy,
+    },
+    ext_modules=get_ext_modules(),
 )


### PR DESCRIPTION
Summary:
Compatible with `python -m build -wheel` instead of using the deprecated `python setup.py bdist_wheel`.

A new custom build command builds all CMake targets, and a new custom build_ext command installs built files into the wheel.

A new custom build_py command copies platform-independent files into the wheel instead of copying them into the source tree.

Puts all generated files under `pip-out` instead of mixing with files in the tree.

Uses Command methods like `mkpath` and `copy_file` to benefit from setuptools concepts like dry_run, and to get logging for free.

Adds `flatc` to the wheel and puts it on the user's PATH. Removes the call to `install_flatc.sh` in `install_requirements.sh`; but, leaves the script in place since someone might want to run it on their own.

Also:
- Enables runtime logging for pybindings even in release mode
- Fixes another `-fPIC` requirement when building the `flatcc` host tools
- Picks a number of build jobs based on the cores in the system, instead of defaulting to 9
- Removes now-unnecessary steps from the Getting Started docs
- Removes a use of `${arg^^}`, which doesn't work with older versions of bash

Test Plan:
Iteration command to test wheel building without completely rebuilding the system:
```
rm -rf \
    /tmp/wheel-out \
    pip-out/lib* \
    pip-out/bdist.* \
    pip-out/temp.*/cmake-out/CMake* \
    executorch.egg-info \
    third-party/flatcc/{bin,lib} \
    ; \
  python setup.py bdist_wheel --dist-dir /tmp/wheel-out
```
To fully rebuild the system, also `rm -rf pip-out`.

The wheel file is written to (e.g.)
```
/tmp/wheel-out/executorch-0.1.0-cp310-cp310-linux_x86_64.whl
```

Examine it with `unzip -l`, or install it with `pip install /tmp/wheel-out/executorch*.whl`.

Also tested creating the wheel via `install_requirements.sh` and creating a simple model file.
```
./install_requirements.sh
python3 -m examples.portable.scripts.export --model_name="add"
<creates add.pte file>
```

Also tested that it can build pybindings with xnnpack when invoked via `install_requirements.sh`:
```
./install_requirements.sh --pybind xnnpack
python -m unittest backends/xnnpack/test/models/mobilenet_v2.py
```
Builds successfully, but trying to run the test currently fails during xnnpack init() due to T184024365. But it fails in the same way that the main branch does, so this new diff does not regress.

Reviewers:

Subscribers:

Tasks:

Tags: