### PR TITLE
Upload iOS frameworks to S3 on demand

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -5,6 +5,17 @@ on:
     branches:
       - main
       - release/*
+    paths:
+      - .ci/docker/**
+      - .github/workflows/apple.yml
+      - install_requirements.sh
+      - backends/apple/**
+      - build/build_apple_frameworks.sh
+      - build/create_frameworks.sh
+      - build/test_ios_ci.sh
+      - examples/demo-apps/**
+      - extension/apple/**
+      - extension/module/**
   pull_request:
     paths:
       - .ci/docker/**
@@ -125,8 +136,8 @@ jobs:
           # NB: The name here needs to match the upload-artifact name from build-frameworks-ios job
           name: executorch-frameworks-ios
           path: ${{ runner.temp }}/frameworks-ios/
-      - name: Only push to S3 from main branch
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Only push to S3 when running the workflow manually from main branch
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
         shell: bash
         run: |
           set -eux


### PR DESCRIPTION
To avoid re-uploading the iOS frameworks artifact to S3 for every main commit, I tweak the workflow so that:

1. The job will only be run in trunk when the targeted list of file paths is updated, not on every trunk commit
2. The upload step is only run when the job is triggered manually using https://github.com/pytorch/executorch/actions/workflows/apple.yml

The swift package file can be the updated manually using a PR for the time being.