### PR TITLE
[CoreML Backend] Fix debugger tests - sdk issue

### DIFF
--- a/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.h
@@ -22,6 +22,7 @@ typedef NS_ERROR_ENUM(ETCoreMLErrorDomain, ETCoreMLError) {
     ETCoreMLErrorBrokenModel, // CoreML model doesn't match the input and output specification.
     ETCoreMLErrorCompilationFailed, // CoreML model failed to compile.
     ETCoreMLErrorModelCompilationNotSupported, // CoreML model compilation is not supported by the target.
+    ETCoreMLErrorModelProfilingNotSupported, // Model profiling is not supported by the target.
     ETCoreMLErrorModelSaveFailed, // Failed to save CoreML model to disk.
     ETCoreMLErrorModelCacheCreationFailed, // Failed to create model cache.
     ETCoreMLErrorInternalError, // Internal error.

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.mm
@@ -292,7 +292,7 @@ void set_model_outputs(id<MLFeatureProvider> output_features,
     }
 #endif
     ETCoreMLLogErrorAndSetNSError(error,
-                                  ETCoreMLErrorCorruptedModel,
+                                  ETCoreMLErrorModelProfilingNotSupported,
                                   "%@: Model profiling is only available for macOS >= 14.4, iOS >= 17.4, tvOS >= 17.4 and watchOS >= 10.4.",
                                   NSStringFromClass(self.class));
     return nil;


### PR DESCRIPTION
For sdk < 17.4 there is no profiling support and we were returning `nil` from `ETCoreMLModelAnalyzer` if the profiler was nil. We could still support model debugging even if we can't profile the model, the change addresses it by creating the `ETCoreMLModelAnalyzer` instance.