### PR TITLE
use partitioner instance directly in to_backend

### DIFF
--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -12,7 +12,7 @@ import json
 import logging
 from enum import Enum
 from json import JSONDecodeError
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional
 
 import torch
 from executorch.backends.transforms.duplicate_dynamic_quant_chain import (
@@ -286,30 +286,18 @@ class LlamaEdgeManager:
             )
         return self
 
-    def to_backend(
-        self, partitioner: Union[Partitioner, Dict[str, Partitioner]]
-    ) -> "LlamaEdgeManager":
+    def to_backend(self, partitioner: Optional[Partitioner]) -> "LlamaEdgeManager":
         """
         Partition the model and lower to different backends. The signature is
         aligned with the signature of `to_backend` method of EdgeManager.
         Args:
-            partitioner (Union[Partitioner, Dict[str, Partitioner]]): One or more
+            partitioner (Optional[Partitioner]): One or more
                 partitioner to be sent to EdgeManager.to_backend().
         """
         assert self.edge_manager is not None, "Need to run export_to_edge() first"
-        if isinstance(partitioner, dict):
-            for key, p in partitioner.items():
-                assert self.edge_manager is not None
-                self.edge_manager = self.edge_manager.to_backend(p)
-                if self.verbose:
-                    logging.info(
-                        print_delegated_graph(
-                            self.edge_manager.exported_program().graph_module
-                        )
-                    )
-                    logging.info(f"Applied partitioners: {key}")
-        elif isinstance(partitioner, Partitioner):
-            assert self.edge_manager is not None
+        if partitioner is None:
+            logging.info("No partitioner provided, passing...")
+        else:
             self.edge_manager = self.edge_manager.to_backend(partitioner)
             if self.verbose:
                 logging.info(
@@ -318,8 +306,6 @@ class LlamaEdgeManager:
                     )
                 )
                 logging.info(f"Applied partitioners: {partitioner}")
-        else:
-            logging.warning("Invalid partitioner, skipping...")
         return self
 
     def to_executorch(self) -> "LlamaEdgeManager":


### PR DESCRIPTION
Summary: to_backend either takes partitioner or a dict of partitioner `key: method_name, value: partitioner`. We shouldn't do key as the backend name and value as the partitioner.

Differential Revision: D55078939


