### PR TITLE
[ET-VK] Add binary op support for height and width packing GPU layouts

### DIFF
--- a/backends/vulkan/runtime/graph/GraphConfig.cpp
+++ b/backends/vulkan/runtime/graph/GraphConfig.cpp
@@ -49,6 +49,26 @@ GraphConfig::GraphConfig() {
   // Empirically selected safety factor. If descriptor pools start running out
   // of memory, increase this safety factor.
   descriptorPoolSafetyFactor = 1.25;
+
+  // For now, force TEXTURE_3D storage as we are still developing shader
+  // support for buffer storage type.
+  enableStorageTypeOverride = true;
+  storageTypeOverride = api::StorageType::TEXTURE_3D;
+
+  // For now, force TENSOR_CHANNELS_PACKED memory layout by default as we are
+  // still developing support for other memory layouts.
+  enableMemoryLayoutOverride = true;
+  memoryLayoutOverride = api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED;
+}
+
+void GraphConfig::setStorageTypeOverride(api::StorageType storage_type) {
+  enableStorageTypeOverride = true;
+  storageTypeOverride = storage_type;
+}
+
+void GraphConfig::setMemoryLayoutOverride(api::GPUMemoryLayout memory_layout) {
+  enableMemoryLayoutOverride = true;
+  memoryLayoutOverride = memory_layout;
 }
 
 } // namespace vulkan

--- a/backends/vulkan/runtime/graph/GraphConfig.h
+++ b/backends/vulkan/runtime/graph/GraphConfig.h
@@ -26,8 +26,17 @@ struct GraphConfig final {
   // risk.
   float descriptorPoolSafetyFactor;
 
+  bool enableStorageTypeOverride;
+  api::StorageType storageTypeOverride;
+
+  bool enableMemoryLayoutOverride;
+  api::GPUMemoryLayout memoryLayoutOverride;
+
   // Generate a default graph config with pre-configured settings
   explicit GraphConfig();
+
+  void setStorageTypeOverride(api::StorageType storage_type);
+  void setMemoryLayoutOverride(api::GPUMemoryLayout memory_layout);
 };
 
 } // namespace vulkan

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_op.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_op.glsl
@@ -63,5 +63,10 @@ void main() {
     COORD_TO_POS_${PACKING}(other_coord, other_sizes.data),
     0);
 
+  // Detect broadcasting
+  if (PACKED_DIM_${PACKING}(other_sizes.data) < PACKED_DIM_${PACKING}(in_sizes.data)) {
+    other_texel = other_texel.xxxx;
+  }
+
   imageStore(image_out, pos, OP(in_texel, other_texel, alpha.data));
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_op.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_op.yaml
@@ -11,11 +11,18 @@ binary_op:
     DTYPE: float
     PACKING: CHANNELS_PACKED
   generate_variant_forall:
+    PACKING:
+      - VALUE: CHANNELS_PACKED
+        SUFFIX: C_packed
+      - VALUE: WIDTH_PACKED
+        SUFFIX: W_packed
+      - VALUE: HEIGHT_PACKED
+        SUFFIX: H_packed
     DTYPE:
-      - VALUE: "half"
-        SUFFIX: "half"
-      - VALUE: "float"
-        SUFFIX: "float"
+      - VALUE: half
+        SUFFIX: half
+      - VALUE: float
+        SUFFIX: float
   shader_variants:
     - NAME: binary_add
     - NAME: binary_sub

--- a/backends/vulkan/runtime/graph/ops/glsl/broadcasting_utils.h
+++ b/backends/vulkan/runtime/graph/ops/glsl/broadcasting_utils.h
@@ -9,7 +9,7 @@
 ivec4 out_coord_to_in_coord(const ivec4 out_coord, const ivec4 in_sizes) {
   ivec4 in_coord = out_coord;
   for (int i = 0; i < 4; ++i) {
-    if (in_sizes[i] == 1) {
+    if (out_coord[i] >= in_sizes[i]) {
       in_coord[i] = 0;
     }
   }

--- a/backends/vulkan/runtime/graph/ops/glsl/indexing_utils.h
+++ b/backends/vulkan/runtime/graph/ops/glsl/indexing_utils.h
@@ -24,6 +24,15 @@
 #define COORD_TO_POS_CHANNELS_PACKED(coord, sizes) \
   ivec3(coord.x, coord.y, (coord.z + coord.w * sizes.z) / 4)
 
+#define COORD_TO_POS_WIDTH_PACKED(coord, sizes) \
+  ivec3(coord.x / 4, coord.y, (coord.z + coord.w * sizes.z))
+
+#define COORD_TO_POS_HEIGHT_PACKED(coord, sizes) \
+  ivec3(coord.x, coord.y / 4, (coord.z + coord.w * sizes.z))
+
+#define COORD_TO_POS_CHANNELS_PACKED(coord, sizes) \
+  ivec3(coord.x, coord.y, (coord.z + coord.w * sizes.z) / 4)
+
 #define COORD_TO_BUFFER_IDX(coord, sizes)                  \
   coord.x + coord.y* sizes.x + coord.z* sizes.y* sizes.x + \
       coord.w* sizes.z* sizes.y* sizes.x;

--- a/backends/vulkan/runtime/graph/ops/impl/Staging.h
+++ b/backends/vulkan/runtime/graph/ops/impl/Staging.h
@@ -28,6 +28,11 @@ void add_tensor_to_staging_node(
     const ValueRef in_tensor,
     const ValueRef out_staging);
 
+ValueRef prepack_if_tensor_ref(
+    ComputeGraph& graph,
+    const ValueRef v,
+    const api::GPUMemoryLayout layout);
+
 ValueRef prepack_if_tensor_ref(ComputeGraph& graph, const ValueRef v);
 
 } // namespace vulkan

--- a/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h
@@ -16,10 +16,33 @@ namespace at {
 namespace native {
 namespace vulkan {
 
+//
+// Tensor output size calculation functions
+//
+
+std::vector<int64_t> calculate_broadcasted_output_size(
+    const vTensor& t1,
+    const vTensor& t2);
+
+//
+// Tensor property checking functions
+//
+
+bool check_same_memory_layout(const vTensor& t1, const vTensor& t2);
+
+bool check_same_memory_layout(
+    const vTensor& t1,
+    const vTensor& t2,
+    const vTensor& t3);
+
+bool check_broadcastable(const vTensor& t1, const vTensor& t2);
+
+//
+// Work Group Size Calculation Utilities
+//
+
 api::utils::uvec3 adaptive_work_group_size(
     const api::utils::uvec3& global_work_group);
-
-api::utils::ivec4 get_size_as_ivec4(const vTensor& t);
 
 } // namespace vulkan
 } // namespace native

--- a/backends/vulkan/test/utils/test_utils.h
+++ b/backends/vulkan/test/utils/test_utils.h
@@ -154,6 +154,15 @@ VmaTotalStatistics get_vma_stats();
 size_t get_vma_allocation_count();
 
 //
+// Graph Test Utilities
+//
+
+void execute_graph_and_check_output(
+    ComputeGraph& graph,
+    std::vector<float> input_vals,
+    std::vector<float> expected_outputs);
+
+//
 // Debugging Utilities
 //
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2518
* #2517
* __->__ #2516
* #2515

## Context

Enable `binary_op` to support inputs that are `HEIGHT_PACKED` and `WIDTH_PACKED`.

Differential Revision: [D55031044](https://our.internmc.facebook.com/intern/diff/D55031044/)