### PR TITLE
[ET-VK][EZ] Return if unary_op is out of bounds

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/unary_op.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/unary_op.glsl
@@ -18,7 +18,7 @@ layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict 
 layout(set = 0, binding = 1) uniform PRECISION sampler3D image_in;
 
 layout(set = 0, binding = 2) uniform PRECISION restrict OutExtents {
-  ivec4 data;
+  uvec4 data;
 }
 out_extents;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/unary_op.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/unary_op.glsl
@@ -17,10 +17,10 @@ layout(std430) buffer;
 layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly ${IMAGE_T[NDIM][DTYPE]} image_out;
 layout(set = 0, binding = 1) uniform PRECISION sampler3D image_in;
 
-layout(set = 0, binding = 2) uniform PRECISION restrict OutSizes {
+layout(set = 0, binding = 2) uniform PRECISION restrict OutExtents {
   ivec4 data;
 }
-out_sizes;
+out_extents;
 
 layout(set = 0, binding = 3) uniform PRECISION restrict Min {
   float data;
@@ -36,6 +36,10 @@ layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (any(greaterThanEqual(pos, out_extents.data.xyz))) {
+    return;
+  }
 
   vec4 in_texel = texelFetch(image_in, pos, 0);
   imageStore(image_out, pos, OP(in_texel, minimum.data, maximum.data));

--- a/backends/vulkan/runtime/graph/ops/impl/Clamp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Clamp.cpp
@@ -54,7 +54,7 @@ void add_clamp_node(
       // Inputs and Outputs
       {{out, api::MemoryAccessType::WRITE}, {arg, api::MemoryAccessType::READ}},
       // Shader params buffers
-      {t_out.gpu_sizes_ubo(),
+      {t_out.extents_ubo(),
        graph.create_params_buffer(min),
        graph.create_params_buffer(max)},
       // Resizing


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2520

Eliminate additional computation when we go out of bounds, which can occur when
1. global work group size is not a perfect multiple of local work group size, and/or 
2. dynamic shapes are used to reshape the logical tensor data.

## Aside on sizes and extents

This is the extension of me struggling on the `max_pool2d` implementation and hence looking closer at how `gpu_sizes_ubo()` and `extents_ubo()` differ. I'm writing this summary to explain this to future me when I inevitably forget. This knowledge can be obtained by studying [`Tensor.*`](https://github.com/pytorch/pytorch/blob/cceabe873f11c6611f627a3bb0055994952ec6b8/aten/src/ATen/native/vulkan/api/Tensor.cpp). 

If our tensor has
- `cpu_sizes`: (N, C, H, W)

then
- `gpu_sizes`: (W, H, C, N) but the packed-dim size is aligned up to a multiple of 4.
- `extents`: Size of the actual image texture, i.e., gpu_sizes but merging C,N and dividing the packed-dim size by 4.

So we obtain:
1. WIDTH_PACKED => `extents`: (W / 4, H, C*N)
2. HEIGHT_PACKED => `extents`: (W, H / 4, C*N)
3. CHANNELS_PACKED => `extents`: (W, H, C*N / 4)

Hence, 
- for texture positions, use `extents`,
- for logical coordinates, use `gpu_sizes`.

Differential Revision: [D55097275](https://our.internmc.facebook.com/intern/diff/D55097275/)