### PR TITLE
Fix gguf util for models without rope_freq_base

### DIFF
--- a/extension/gguf_util/load_gguf.py
+++ b/extension/gguf_util/load_gguf.py
@@ -78,7 +78,8 @@ def _build_model_args(metadata: dict[str, Any]) -> GGUFModelArgs:
             layer_norm_rms_epsilon=metadata[f"{arch}.attention.layer_norm_rms_epsilon"],
         ),
         rope=RopeArgs(
-            freq_base=metadata[f"{arch}.rope.freq_base"],
+            # default value from llama2 model definition
+            freq_base=metadata.get(f"{arch}.rope.freq_base", 1e4),
         ),
     )
 


### PR DESCRIPTION
Summary: Give them a default value from official llama2 model definition: https://github.com/meta-llama/llama/blob/main/llama/model.py#L80

Reviewed By: mergennachin

Differential Revision: D55097529


