### PR TITLE
Qualcomm AI Engine Direct - Enable zero copy feature

### DIFF
--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -118,27 +118,29 @@ include_directories(
 #
 # declare targets
 #
+add_library(executorch_backend INTERFACE)
 add_library(qcir INTERFACE qcir_schema_output)
 add_library(qcir_utils STATIC)
-add_library(qnn_schema INTERFACE ${_qnn_schema__outputs})
-add_library(executorch_backend INTERFACE)
+add_library(qnn_backend STATIC)
+add_library(qnn_backend_cache STATIC)
+add_library(qnn_context STATIC)
+add_library(qnn_device STATIC)
 add_library(qnn_executorch_backend SHARED)
 add_library(qnn_executorch_header INTERFACE)
 add_library(qnn_executorch_logging STATIC)
-add_library(qnn_manager STATIC)
+add_library(qnn_factory STATIC)
 add_library(qnn_function_interface INTERFACE)
+add_library(qnn_graph STATIC)
+add_library(qnn_header INTERFACE)
 add_library(qnn_implementation STATIC)
+add_library(qnn_logger STATIC)
+add_library(qnn_manager STATIC)
+add_library(qnn_mem_manager STATIC)
+add_library(qnn_profiler STATIC)
+add_library(qnn_schema INTERFACE ${_qnn_schema__outputs})
 add_library(qnn_sys_function_interface INTERFACE)
 add_library(qnn_sys_implementation STATIC)
-add_library(qnn_logger STATIC)
-add_library(qnn_profiler STATIC)
-add_library(qnn_device STATIC)
-add_library(qnn_context STATIC)
-add_library(qnn_backend_cache STATIC)
-add_library(qnn_graph STATIC)
-add_library(qnn_backend STATIC)
-add_library(qnn_factory STATIC)
-add_library(qnn_header INTERFACE)
+add_library(shared_buffer STATIC)
 add_library(wrappers STATIC)
 add_library(utils STATIC)
 
@@ -220,6 +222,13 @@ target_link_libraries(qnn_graph
     qnn_context
     qnn_profiler
 )
+target_link_libraries(qnn_mem_manager
+    PRIVATE
+    qnn_executorch_logging
+    qnn_implementation
+    qnn_context
+)
+
 target_link_libraries(qnn_factory
     PUBLIC
     qnn_header
@@ -229,6 +238,7 @@ target_link_libraries(qnn_factory
     qnn_device
     qnn_context
     qnn_graph
+    qnn_mem_manager
 )
 target_link_libraries(qnn_manager
     PRIVATE
@@ -236,6 +246,7 @@ target_link_libraries(qnn_manager
     wrappers
     qnn_schema
     utils
+    shared_buffer
 )
 target_link_libraries(qnn_executorch_backend
     PRIVATE
@@ -249,7 +260,11 @@ target_link_libraries(utils
     PRIVATE
     qnn_executorch_logging
 )
-
+target_link_libraries(shared_buffer
+    PRIVATE
+    qnn_executorch_logging
+    ${CMAKE_DL_LIBS}
+)
 #
 # add linker option
 #

--- a/backends/qualcomm/aot/wrappers/TensorWrapper.cpp
+++ b/backends/qualcomm/aot/wrappers/TensorWrapper.cpp
@@ -105,6 +105,7 @@ TensorWrapper::TensorWrapper(
 
 Error TensorWrapper::FillDataBuffer(const void* data, bool copy_data) {
   if (data != nullptr) {
+    QNN_VER_PTR(tensor_)->memType = QNN_TENSORMEMTYPE_RAW;
     QNN_VER_PTR(tensor_)->clientBuf.dataSize = bytes_;
     if (copy_data) {
       owned_data_ = std::make_unique<char[]>(bytes_);
@@ -141,6 +142,12 @@ void TensorWrapper::UpdateQnnTensorMeta(const Qnn_Tensor_t& tensor_src) {
 Error TensorWrapper::SetName(const std::string& name) {
   qnn_tensor_name_ = name;
   QNN_VER_PTR(tensor_)->name = qnn_tensor_name_.c_str();
+  return Error::Ok;
+}
+
+Error TensorWrapper::SetMemHandle(Qnn_MemHandle_t mem_handle) {
+  QNN_VER_PTR(tensor_)->memType = QNN_TENSORMEMTYPE_MEMHANDLE;
+  QNN_VER_PTR(tensor_)->memHandle = mem_handle;
   return Error::Ok;
 }
 

--- a/backends/qualcomm/aot/wrappers/TensorWrapper.h
+++ b/backends/qualcomm/aot/wrappers/TensorWrapper.h
@@ -59,15 +59,37 @@ class TensorWrapper {
     return QNN_VER_PTR(tensor_)->type == QNN_TENSOR_TYPE_STATIC;
   };
 
-  const void* GetStaticTensorData() const {
-    return QNN_VER_PTR(tensor_)->clientBuf.data;
+  std::uint32_t* GetDims() const {
+    return QNN_VER_PTR(tensor_)->dimensions;
+  };
+
+  Qnn_DataType_t GetDataType() const {
+    return QNN_VER_PTR(tensor_)->dataType;
+  };
+
+  Qnn_MemHandle_t const GetMemHandle() {
+    return QNN_VER_PTR(tensor_)->memHandle;
+  };
+
+  Qnn_TensorMemType_t GetMemType() const {
+    return QNN_VER_PTR(tensor_)->memType;
   };
 
   std::string GetName() const {
     return qnn_tensor_name_;
   };
 
+  std::uint32_t GetRank() const {
+    return QNN_VER_PTR(tensor_)->rank;
+  };
+
+  const void* GetStaticTensorData() const {
+    return QNN_VER_PTR(tensor_)->clientBuf.data;
+  };
+
   Error SetName(const std::string& name);
+
+  Error SetMemHandle(Qnn_MemHandle_t mem_handle);
 
  private:
   // need this to handle QNN_TENSOR_ERROR_NAME_HASH_COLLISION

--- a/backends/qualcomm/passes/insert_io_qdq.py
+++ b/backends/qualcomm/passes/insert_io_qdq.py
@@ -38,6 +38,12 @@ class InsertIOQDQ(ExportPass):
         arg_schemas = list(target._schema.arguments)[1:]
         for arg_schema in arg_schemas:
             name = arg_schema.name
+            # TODO: Due to the new parameter "out_dtype" in the dequantize node,
+            # it could not be found in the quant_attrs of other nodes,
+            # and it will cause a key error. For now, the output type
+            # of our dequantize node is only float. (by default in pytorch)
+            if name == "out_dtype":
+                continue
             value = quant_attrs[name]
             if type(arg_schema.type) == torch.tensor and type(value) in [int, float]:
                 value = torch.tensor(value)

--- a/backends/qualcomm/runtime/CMakeLists.txt
+++ b/backends/qualcomm/runtime/CMakeLists.txt
@@ -47,3 +47,10 @@ target_sources(utils
     PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp
 )
+
+# shared_buffer
+target_sources(shared_buffer
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/SharedBuffer.h
+    ${CMAKE_CURRENT_LIST_DIR}/SharedBuffer.cpp
+)

--- a/backends/qualcomm/runtime/QnnExecuTorch.h
+++ b/backends/qualcomm/runtime/QnnExecuTorch.h
@@ -8,8 +8,10 @@
 #pragma once
 
 #ifdef __cplusplus
+#include <cstddef>
 #include <cstdint>
 #else
+#include <stddef.h>
 #include <stdint.h>
 #endif
 
@@ -30,6 +32,16 @@ typedef struct {
     0,              /*nbytes*/           \
   }
 // clang-format on
+
+/// Allocate specific tensors (usually graph inputs and outputs) on shared
+/// memory. Users are responsible to allocate "enough" tensor bytes, and set
+/// alignment as MemoryAllocator::kDefaultAlignment.
+/// See runtime/core/memory_allocator.h. The function returns a valid pointer
+/// if allocation is successful.
+void* QnnExecuTorchAllocCustomMem(size_t bytes, size_t alignment);
+
+/// Free the allocated shared memory.
+void QnnExecuTorchFreeCustomMem(void* buffer_ptr);
 
 #ifdef __cplusplus
 }

--- a/backends/qualcomm/runtime/QnnManager.cpp
+++ b/backends/qualcomm/runtime/QnnManager.cpp
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <executorch/backends/qualcomm/runtime/QnnManager.h>
+#include <executorch/backends/qualcomm/runtime/SharedBuffer.h>
 #include <executorch/backends/qualcomm/runtime/Utils.h>
 #include <executorch/backends/qualcomm/runtime/backends/QnnImplementation.h>
-
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -54,7 +54,9 @@ QnnManager::QnnManager(
         "the size of qnn context binary: %d",
         qnn_executorch_context_binary.nbytes);
     QNN_EXECUTORCH_LOG_INFO(
-        "Is on-device graph construction: %d", options_->online_prepare());
+        "Is on-device graph construction: %d", options->online_prepare());
+    QNN_EXECUTORCH_LOG_INFO(
+        "Enable shared buffer: %d", options->shared_buffer());
   }
 
   if (library_path.empty()) {
@@ -80,6 +82,53 @@ QnnManager::QnnManager(
 Error QnnManager::LoadQnnLibrary() {
   Error ret = qnn_loaded_backend_.Load(nullptr);
   return ret;
+}
+
+Error QnnManager::RegisterMem(
+    void* data_ptr,
+    const std::shared_ptr<TensorWrapper>& tensor_wrapper) {
+  SharedBuffer& shared_buffer_manager = SharedBuffer::GetSharedBufferManager();
+  // Not enable shared buffer
+  if (!options_->shared_buffer())
+    return Error::Internal;
+
+  if (backend_params_ptr_->qnn_mem_manager_ptr_ == nullptr) {
+    QNN_EXECUTORCH_LOG_WARN(
+        "Backend %s doesn't supported shared buffer.",
+        EnumNameQnnExecuTorchBackendType(
+            options_->backend_options()->backend_type()));
+    return Error::Internal;
+  }
+
+  if (!shared_buffer_manager.IsAllocated(data_ptr)) {
+    // It means two scenarios here:
+    // 1. the input and output partitioned graph
+    // 2. Actually, user doesn't allocate shared buffer with
+    // QnnExecuTorchAllocCustomMem API
+    return Error::Internal;
+  } else if (backend_params_ptr_->qnn_mem_manager_ptr_->IsRegistered(
+                 tensor_wrapper->GetMemHandle())) {
+    if (options_->log_level() >= QnnExecuTorchLogLevel::kLogLevelInfo)
+      QNN_EXECUTORCH_LOG_INFO(
+          "Tensor name %s has been registered shared memory.",
+          tensor_wrapper->GetName().c_str());
+    return Error::Ok;
+  }
+
+  int32_t mem_fd = SharedBuffer::GetSharedBufferManager().MemToFd(data_ptr);
+  if (mem_fd == -1) {
+    QNN_EXECUTORCH_LOG_WARN(
+        "Tensor name %s is failed to get file descriptor.",
+        tensor_wrapper->GetName().c_str());
+    return Error::Internal;
+  }
+  ET_CHECK_OR_RETURN_ERROR(
+      backend_params_ptr_->qnn_mem_manager_ptr_->RegisterMem(
+          tensor_wrapper, mem_fd) == Error::Ok,
+      Internal,
+      "Fail to register to shared memory.");
+
+  return Error::Ok;
 }
 
 Error QnnManager::Init() {
@@ -219,14 +268,6 @@ void QnnManager::Destroy() {
   qnn_loaded_backend_.TerminateAllBackends();
 }
 
-bool QnnManager::IsAvailable() {
-  return true;
-}
-
-bool QnnManager::IsOnlinePrepare() {
-  return options_->online_prepare();
-}
-
 bool QnnManager::IsNodeSupportedByBackend(
     std::vector<std::shared_ptr<OpWrapper>>& op_wrappers) {
   Qnn_ErrorHandle_t error = QNN_SUCCESS;
@@ -329,3 +370,14 @@ Error QnnManager::Compile(
 } // namespace qnn
 } // namespace executor
 } // namespace torch
+void* QnnExecuTorchAllocCustomMem(size_t bytes, size_t alignment) {
+  using torch::executor::qnn::SharedBuffer;
+  void* buffer_ptr =
+      SharedBuffer::GetSharedBufferManager().AllocMem(bytes, alignment);
+  return buffer_ptr;
+}
+
+void QnnExecuTorchFreeCustomMem(void* buffer_ptr) {
+  using torch::executor::qnn::SharedBuffer;
+  SharedBuffer::GetSharedBufferManager().FreeMem(buffer_ptr);
+}

--- a/backends/qualcomm/runtime/QnnManager.h
+++ b/backends/qualcomm/runtime/QnnManager.h
@@ -42,13 +42,17 @@ class QnnManager {
 
   void Destroy();
 
-  bool IsAvailable();
+  bool IsAvailable() {
+    return true;
+  }
+
+  bool IsOnlinePrepare() {
+    return options_->online_prepare();
+  }
 
   bool IsTensorDump() {
     return options_->tensor_dump_output_path()->size() > 0;
   }
-
-  bool IsOnlinePrepare();
 
   bool IsNodeSupportedByBackend(
       std::vector<std::shared_ptr<OpWrapper>>& op_wrappers);
@@ -56,6 +60,10 @@ class QnnManager {
   Error Compile(
       std::vector<std::shared_ptr<OpWrapper>>& op_wrappers,
       QnnExecuTorchContextBinary& qnn_executorch_context_binary);
+
+  Error RegisterMem(
+      void* data_ptr,
+      const std::shared_ptr<TensorWrapper>& tensor_wrapper);
 
   std::vector<std::shared_ptr<TensorWrapper>> GetGraphInputs() {
     return input_tensors_;

--- a/backends/qualcomm/runtime/SharedBuffer.cpp
+++ b/backends/qualcomm/runtime/SharedBuffer.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <dlfcn.h>
+#include <executorch/backends/qualcomm/runtime/Logging.h>
+#include <executorch/backends/qualcomm/runtime/SharedBuffer.h>
+
+// Refer to the QNN HTP Shared Buffer Tutorial
+// in Qualcomm® AI Engine Direct document
+constexpr uint8_t RPCMEM_HEAP_ID_SYSTEM = 25;
+constexpr uint8_t RPCMEM_DEFAULT_FLAGS = 1;
+
+namespace torch {
+namespace executor {
+namespace qnn {
+
+namespace {
+
+intptr_t alignTo(size_t alignment, intptr_t offset) {
+  return offset % alignment == 0 ? offset
+                                 : offset +
+          (static_cast<intptr_t>(alignment) -
+           offset % static_cast<intptr_t>(alignment));
+}
+
+} // namespace
+
+std::mutex SharedBuffer::init_mutex_;
+
+SharedBuffer& SharedBuffer::GetSharedBufferManager() {
+  std::lock_guard<std::mutex> lk(init_mutex_);
+  static SharedBuffer shared_buffer_manager;
+  if (!shared_buffer_manager.GetInitialize()) {
+    Error status = shared_buffer_manager.Load();
+    if (status == Error::Ok) {
+      shared_buffer_manager.SetInitialize(true);
+    }
+  }
+  return shared_buffer_manager;
+}
+
+SharedBuffer::~SharedBuffer() {
+  if (initialize_) {
+    SharedBuffer::GetSharedBufferManager().UnLoad();
+  }
+};
+
+void* SharedBuffer::AllocMem(size_t bytes, size_t alignment) {
+  if (!initialize_) {
+    QNN_EXECUTORCH_LOG_ERROR("Shared memory not initialized.");
+    return nullptr;
+  }
+  // do alignment:
+  auto allocate_bytes = static_cast<int32_t>(bytes + alignment);
+  void* buf = rpc_mem_alloc_(
+      RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS, allocate_bytes);
+  if (buf == nullptr) {
+    QNN_EXECUTORCH_LOG_WARN("Failed to allocate the tensor by RPC memory.");
+    return nullptr;
+  }
+  auto aligned_buf = reinterpret_cast<void*>(
+      alignTo(alignment, reinterpret_cast<intptr_t>(buf)));
+  bool status =
+      restore_map_.insert(std::pair<void*, void*>(aligned_buf, buf)).second;
+  if (!status) {
+    QNN_EXECUTORCH_LOG_ERROR("Failed to allocate the tensor by RPC memory.");
+    rpc_mem_free_(buf);
+  }
+  return aligned_buf;
+}
+
+int32_t SharedBuffer::MemToFd(void* buf) {
+  int32_t memFd = -1;
+  if (!initialize_) {
+    QNN_EXECUTORCH_LOG_ERROR("Shared memory not initialized.");
+  } else {
+    memFd = rpc_mem_to_fd_(buf);
+  }
+  return memFd;
+}
+
+void SharedBuffer::FreeMem(void* buf) {
+  if (!initialize_) {
+    QNN_EXECUTORCH_LOG_ERROR("Shared memory not initialized.");
+  } else if (restore_map_.count(buf) == 0) {
+    QNN_EXECUTORCH_LOG_WARN("Don't free an unallocated tensor.");
+  } else {
+    rpc_mem_free_(restore_map_[buf]);
+    restore_map_.erase(buf);
+  }
+}
+
+bool SharedBuffer::IsAllocated(void* buf) {
+  return restore_map_.count(buf) != 0U;
+}
+
+Error SharedBuffer::Load() {
+  // On Android, 32-bit and 64-bit libcdsprpc.so can be found at /vendor/lib/
+  // and /vendor/lib64/ respectively.
+  lib_cdsp_rpc_ = dlopen("libcdsprpc.so", RTLD_NOW | RTLD_LOCAL);
+  if (lib_cdsp_rpc_ == nullptr) {
+    QNN_EXECUTORCH_LOG_ERROR(
+        "Unable to load shared buffer. dlerror(): %s", dlerror());
+    return Error::Internal;
+  }
+  rpc_mem_alloc_ = reinterpret_cast<RpcMemAllocFn_t>( // NOLINT
+      dlsym(lib_cdsp_rpc_, "rpcmem_alloc"));
+  rpc_mem_free_ = reinterpret_cast<RpcMemFreeFn_t>( // NOLINT
+      dlsym(lib_cdsp_rpc_, "rpcmem_free"));
+  rpc_mem_to_fd_ = reinterpret_cast<RpcMemToFdFn_t>( // NOLINT
+      dlsym(lib_cdsp_rpc_, "rpcmem_to_fd"));
+  if (nullptr == rpc_mem_alloc_ || nullptr == rpc_mem_free_ ||
+      nullptr == rpc_mem_to_fd_) {
+    QNN_EXECUTORCH_LOG_ERROR(
+        "Unable to access symbols in shared buffer. dlerror(): %s", dlerror());
+    dlclose(lib_cdsp_rpc_);
+    return Error::Internal;
+  }
+  return Error::Ok;
+}
+
+Error SharedBuffer::UnLoad() {
+  if (dlclose(lib_cdsp_rpc_) != 0) {
+    QNN_EXECUTORCH_LOG_ERROR(
+        "Unable to close shared buffer. dlerror(): %s", dlerror());
+    return Error::Internal;
+  };
+  return Error::Ok;
+}
+} // namespace qnn
+} // namespace executor
+} // namespace torch

--- a/backends/qualcomm/runtime/SharedBuffer.h
+++ b/backends/qualcomm/runtime/SharedBuffer.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+#include <executorch/runtime/core/error.h>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+using RpcMemAllocFn_t = void* (*)(int, uint32_t, int);
+using RpcMemFreeFn_t = void (*)(void*);
+using RpcMemToFdFn_t = int (*)(void*);
+
+namespace torch {
+namespace executor {
+namespace qnn {
+class SharedBuffer final {
+ public:
+  SharedBuffer(const SharedBuffer&) = delete;
+  SharedBuffer& operator=(const SharedBuffer&) = delete;
+  SharedBuffer(SharedBuffer&&) = delete;
+  SharedBuffer& operator=(SharedBuffer&&) = delete;
+  ~SharedBuffer();
+
+  static SharedBuffer& GetSharedBufferManager();
+  void* AllocMem(size_t bytes, size_t alignment);
+  // map a buffer allocated via RPCMem to a file descriptor so it can be
+  // registered with a backend via QnnMem_register()
+  int32_t MemToFd(void* buf);
+
+  void FreeMem(void* buf);
+
+  bool IsAllocated(void* buf);
+
+  bool GetInitialize() {
+    return initialize_;
+  }
+  void SetInitialize(bool initialize) {
+    initialize_ = initialize;
+  }
+
+ private:
+  SharedBuffer() = default;
+
+  // dlopen RPCMem library and dlysm required functions
+  Error Load();
+
+  Error UnLoad();
+
+  // Pointer to the dlopen'd libcdsprpc.so shared library which contains
+  // rpcmem_alloc, rpcmem_free, rpcmem_to_fd APIs
+  void* lib_cdsp_rpc_;
+  // Function pointer to rpcmem_alloc
+  RpcMemAllocFn_t rpc_mem_alloc_;
+  // Function pointer to rpcmem_free
+  RpcMemFreeFn_t rpc_mem_free_;
+  // Function pointer to rpcmem_to_fd
+  RpcMemToFdFn_t rpc_mem_to_fd_;
+  std::unordered_map<void*, void*> restore_map_;
+  std::atomic_bool initialize_{false};
+  static std::mutex init_mutex_;
+};
+
+} // namespace qnn
+} // namespace executor
+} // namespace torch

--- a/backends/qualcomm/runtime/backends/CMakeLists.txt
+++ b/backends/qualcomm/runtime/backends/CMakeLists.txt
@@ -109,6 +109,14 @@ target_sources(qnn_backend
     ${CMAKE_CURRENT_LIST_DIR}/QnnBackendCommon.cpp
 )
 
+# qnn_mem_manager
+target_sources(qnn_mem_manager
+    PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/QnnMemManager.h
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/QnnMemManager.cpp
+)
+
 # qnn_factory
 target_sources(qnn_factory
     PUBLIC

--- a/backends/qualcomm/runtime/backends/QnnBackendFactory.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendFactory.cpp
@@ -69,6 +69,8 @@ std::unique_ptr<BackendConfigParameters> QnnBackendFactory::Create(
           options->graph_name()->str(),
           options->soc_info(),
           htp_options);
+      backend_params->qnn_mem_manager_ptr_ = std::make_unique<QnnMemManager>(
+          implementation, backend_params->qnn_context_ptr_.get());
       backend_params->backend_init_state_ = BackendInitializeState::INITIALIZED;
       return backend_params;
     } break;

--- a/backends/qualcomm/runtime/backends/QnnBackendFactory.h
+++ b/backends/qualcomm/runtime/backends/QnnBackendFactory.h
@@ -14,6 +14,7 @@
 #include <executorch/backends/qualcomm/runtime/backends/QnnGraphCommon.h>
 #include <executorch/backends/qualcomm/runtime/backends/QnnImplementation.h>
 #include <executorch/backends/qualcomm/runtime/backends/QnnLogger.h>
+#include <executorch/backends/qualcomm/runtime/backends/QnnMemManager.h>
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpBackend.h>
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpContext.h>
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpDevice.h>
@@ -33,6 +34,7 @@ typedef struct BackendConfigParameters {
   std::unique_ptr<QnnContext> qnn_context_ptr_;
   std::unique_ptr<QnnDevice> qnn_device_ptr_;
   std::unique_ptr<QnnGraph> qnn_graph_ptr_;
+  std::unique_ptr<QnnMemManager> qnn_mem_manager_ptr_;
 
   // Default ctor
   BackendConfigParameters()
@@ -40,10 +42,12 @@ typedef struct BackendConfigParameters {
         backend_init_state_(BackendInitializeState::UNINITIALIZED),
         qnn_context_ptr_(nullptr),
         qnn_device_ptr_(nullptr),
-        qnn_graph_ptr_(nullptr) {}
+        qnn_graph_ptr_(nullptr),
+        qnn_mem_manager_ptr_(nullptr) {}
   // Default dtor
   ~BackendConfigParameters() {
     qnn_graph_ptr_.reset();
+    qnn_mem_manager_ptr_.reset();
     qnn_context_ptr_.reset();
     qnn_device_ptr_.reset();
     qnn_backend_ptr_.reset();

--- a/backends/qualcomm/runtime/backends/QnnMemManager.cpp
+++ b/backends/qualcomm/runtime/backends/QnnMemManager.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <executorch/backends/qualcomm/runtime/backends/QnnMemManager.h>
+
+namespace torch {
+namespace executor {
+namespace qnn {
+
+bool QnnMemManager::IsRegistered(Qnn_MemHandle_t handle) {
+  return registered_set_.count(handle) != 0U;
+}
+
+Error QnnMemManager::RegisterMem(
+    const std::shared_ptr<TensorWrapper>& tensor_wrapper,
+    int32_t mem_fd) {
+  const QnnInterface& qnn_interface = implementation_.GetQnnInterface();
+  Qnn_MemDescriptor_t descriptor = {
+      {tensor_wrapper->GetRank(), tensor_wrapper->GetDims(), nullptr},
+      tensor_wrapper->GetDataType(),
+      QNN_MEM_TYPE_ION,
+      {{mem_fd}}};
+  Qnn_MemHandle_t handle = nullptr;
+  Qnn_ErrorHandle_t error = QNN_SUCCESS;
+  error = qnn_interface.qnn_mem_register(
+      context_->GetHandle(),
+      &descriptor,
+      /*numDescriptors=*/1,
+      &handle);
+  if (error != QNN_SUCCESS) {
+    QNN_EXECUTORCH_LOG_WARN(
+        "Tensor %s is failed to register shared memory. Error %d",
+        tensor_wrapper->GetName().c_str(),
+        QNN_GET_ERROR_CODE(error));
+    return Error::Internal;
+  }
+  tensor_wrapper->SetMemHandle(handle);
+  registered_set_.insert(handle);
+  QNN_EXECUTORCH_LOG_INFO(
+      "Tensor %s is successfully registered to shared memory.",
+      tensor_wrapper->GetName().c_str());
+  return Error::Ok;
+}
+
+void QnnMemManager::DeRegisterMem() {
+  const QnnInterface& qnn_interface = implementation_.GetQnnInterface();
+  Qnn_ErrorHandle_t error = QNN_SUCCESS;
+
+  for (auto& mem_handle : registered_set_) {
+    error = qnn_interface.qnn_mem_de_register(&mem_handle, /*numHandles=*/1);
+    if (error != QNN_SUCCESS) {
+      QNN_EXECUTORCH_LOG_WARN(
+          "Failed to de-register shared memory. Error %d",
+          QNN_GET_ERROR_CODE(error));
+    }
+  }
+  registered_set_.clear();
+}
+
+} // namespace qnn
+} // namespace executor
+} // namespace torch

--- a/backends/qualcomm/runtime/backends/QnnMemManager.h
+++ b/backends/qualcomm/runtime/backends/QnnMemManager.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+#include <executorch/backends/qualcomm/aot/wrappers/TensorWrapper.h>
+#include <executorch/backends/qualcomm/runtime/backends/QnnContextCommon.h>
+#include <executorch/backends/qualcomm/runtime/backends/QnnImplementation.h>
+#include <unordered_set>
+
+namespace torch {
+namespace executor {
+namespace qnn {
+
+class QnnMemManager {
+ public:
+  explicit QnnMemManager(
+      const QnnImplementation& implementation,
+      QnnContext* context)
+      : implementation_(implementation), context_(context) {}
+  ~QnnMemManager() {
+    DeRegisterMem();
+  }
+
+  Error RegisterMem(
+      const std::shared_ptr<TensorWrapper>& tensor_wrapper,
+      int32_t mem_fd);
+
+  bool IsRegistered(Qnn_MemHandle_t handle);
+
+ private:
+  void DeRegisterMem();
+
+  const QnnImplementation& implementation_;
+  QnnContext* context_;
+  std::unordered_set<Qnn_MemHandle_t> registered_set_;
+};
+} // namespace qnn
+} // namespace executor
+} // namespace torch

--- a/backends/qualcomm/serialization/qnn_compile_spec_schema.py
+++ b/backends/qualcomm/serialization/qnn_compile_spec_schema.py
@@ -131,3 +131,4 @@ class QnnExecuTorchOptions:
     online_prepare: bool = False
     tensor_dump_output_path: str = ""
     profile_level: QnnExecuTorchProfileLevel = QnnExecuTorchProfileLevel.kProfileOff
+    shared_buffer: bool = False

--- a/backends/qualcomm/serialization/schema.fbs
+++ b/backends/qualcomm/serialization/schema.fbs
@@ -172,6 +172,9 @@ table QnnExecuTorchOptions {
 
   /// Profiling level of the delegate and the backend. Default is off.
   profile_level:QnnExecuTorchProfileLevel;
+  
+  /// Enables usage of shared buffer between application and backend for graph I/O.
+  shared_buffer:bool;
 }
 
 root_type QnnExecuTorchOptions;

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -56,6 +56,7 @@ class TestQNNFloatingPointOperator(TestQNN):
             online_prepare=TestQNN.online_prepare,
             tensor_dump_output_path="",
             profile=TestQNN.enable_profile,
+            shared_buffer=TestQNN.shared_buffer,
         )
 
     def test_qnn_backend_arange(self):
@@ -389,6 +390,7 @@ class TestQNNFloatingPointModel(TestQNN):
             online_prepare=TestQNN.online_prepare,
             tensor_dump_output_path="",
             profile=TestQNN.enable_profile,
+            shared_buffer=TestQNN.shared_buffer,
         )
 
     def test_qnn_backend_conv1d_relu_log_softmax(self):
@@ -484,6 +486,7 @@ class TestQNNQuantizedOperator(TestQNN):
             online_prepare=TestQNN.online_prepare,
             tensor_dump_output_path="",
             profile=TestQNN.enable_profile,
+            shared_buffer=TestQNN.shared_buffer,
         )
 
     def test_qnn_backend_16a4w_conv2d(self):
@@ -880,6 +883,7 @@ class TestQNNQuantizedModel(TestQNN):
             online_prepare=TestQNN.online_prepare,
             tensor_dump_output_path="",
             profile=TestQNN.enable_profile,
+            shared_buffer=TestQNN.shared_buffer,
         )
 
     def test_qnn_backend_conv1d_relu_log_softmax(self):
@@ -1077,6 +1081,24 @@ class TestQNNFloatingPointUtils(TestQNN):
             expected_profile_events=25,
         )
 
+    def test_qnn_backend_shared_buffer(self):
+        TestQNN.shared_buffer = True
+        backend_options = generate_htp_compiler_spec(
+            use_fp16=True,
+        )
+        TestQNN.compiler_specs = generate_qnn_executorch_compiler_spec(
+            soc_model=self.arch_table[TestQNN.model],
+            backend_options=backend_options,
+            shared_buffer=True,
+        )
+        module = SimpleModel()  # noqa: F405
+        sample_input = (torch.ones(1, 32, 28, 28), torch.ones(1, 32, 28, 28))
+        self.lower_module_and_test_output(
+            module,
+            sample_input,
+            expected_partitions=1,
+        )
+
 
 class TestQNNQuantizedUtils(TestQNN):
     # TODO: refactor to support different backends
@@ -1179,6 +1201,25 @@ class TestQNNQuantizedUtils(TestQNN):
             expected_profile_events=26,
         )
 
+    def test_qnn_backend_shared_buffer(self):
+        TestQNN.shared_buffer = True
+        backend_options = generate_htp_compiler_spec(
+            use_fp16=False,
+        )
+        TestQNN.compiler_specs = generate_qnn_executorch_compiler_spec(
+            soc_model=self.arch_table[TestQNN.model],
+            backend_options=backend_options,
+            shared_buffer=True,
+        )
+        module = SimpleModel()  # noqa: F405
+        sample_input = (torch.ones(1, 32, 28, 28), torch.ones(1, 32, 28, 28))
+        module = self.get_qdq_module(module, sample_input)
+        self.lower_module_and_test_output(
+            module,
+            sample_input,
+            expected_partitions=1,
+        )
+
 
 class TestExampleScript(TestQNN):
     def required_envs(self, conditions=None) -> bool:
@@ -1215,6 +1256,8 @@ class TestExampleScript(TestQNN):
         ]
         if self.host:
             cmds.extend(["--host", self.host])
+        if self.shared_buffer:
+            cmds.extend(["--shared_buffer"])
 
         p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
         with Listener((self.ip, self.port)) as listener:
@@ -1248,6 +1291,8 @@ class TestExampleScript(TestQNN):
         ]
         if self.host:
             cmds.extend(["--host", self.host])
+        if self.shared_buffer:
+            cmds.extend(["--shared_buffer"])
 
         p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
         with Listener((self.ip, self.port)) as listener:
@@ -1281,6 +1326,8 @@ class TestExampleScript(TestQNN):
         ]
         if self.host:
             cmds.extend(["--host", self.host])
+        if self.shared_buffer:
+            cmds.extend(["--shared_buffer"])
 
         p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
         with Listener((self.ip, self.port)) as listener:
@@ -1314,6 +1361,8 @@ class TestExampleScript(TestQNN):
         ]
         if self.host:
             cmds.extend(["--host", self.host])
+        if self.shared_buffer:
+            cmds.extend(["--shared_buffer"])
 
         p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
         with Listener((self.ip, self.port)) as listener:
@@ -1346,6 +1395,8 @@ class TestExampleScript(TestQNN):
         ]
         if self.host:
             cmds.extend(["--host", self.host])
+        if self.shared_buffer:
+            cmds.extend(["--shared_buffer"])
 
         p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
         with Listener((self.ip, self.port)) as listener:
@@ -1378,6 +1429,8 @@ class TestExampleScript(TestQNN):
         ]
         if self.host:
             cmds.extend(["--host", self.host])
+        if self.shared_buffer:
+            cmds.extend(["--shared_buffer"])
 
         p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
         with Listener((self.ip, self.port)) as listener:
@@ -1411,6 +1464,8 @@ class TestExampleScript(TestQNN):
         ]
         if self.host:
             cmds.extend(["--host", self.host])
+        if self.shared_buffer:
+            cmds.extend(["--shared_buffer"])
 
         p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
         with Listener((self.ip, self.port)) as listener:
@@ -1442,6 +1497,8 @@ class TestExampleScript(TestQNN):
         ]
         if self.host:
             cmds.extend(["--host", self.host])
+        if self.shared_buffer:
+            cmds.extend(["--shared_buffer"])
 
         p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
         with Listener((self.ip, self.port)) as listener:
@@ -1475,6 +1532,8 @@ class TestExampleScript(TestQNN):
         ]
         if self.host:
             cmds.extend(["--host", self.host])
+        if self.shared_buffer:
+            cmds.extend(["--shared_buffer"])
 
         p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
         with Listener((self.ip, self.port)) as listener:
@@ -1515,6 +1574,8 @@ class TestExampleScript(TestQNN):
         ]
         if self.host:
             cmds.extend(["--host", self.host])
+        if self.shared_buffer:
+            cmds.extend(["--shared_buffer"])
 
         p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
         with Listener((self.ip, self.port)) as listener:
@@ -1585,6 +1646,7 @@ def setup_environment():
     TestQNN.online_prepare = args.online_prepare
     TestQNN.enable_profile = args.enable_profile
     TestQNN.error_only = args.error_only
+    TestQNN.shared_buffer = args.shared_buffer
     return sys.argv[:1] + ns_args
 
 

--- a/backends/qualcomm/tests/utils.py
+++ b/backends/qualcomm/tests/utils.py
@@ -32,6 +32,7 @@ from executorch.exir.backend.backend_api import to_backend
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
+from executorch.exir.passes.memory_planning_pass import MemoryPlanningPass
 from executorch.exir.program._program import ExecutorchProgram
 from executorch.sdk import generate_etrecord
 from executorch.sdk.inspector import Inspector
@@ -64,6 +65,7 @@ class TestQNN(unittest.TestCase):
     use_8a8w: str = "8a8w"
     use_16a16w: str = "16a16w"
     use_16a4w: str = "16a4w"
+    shared_buffer: bool = False
 
     def _assert_outputs_equal(self, model_output, ref_output):
         self.assertTrue(len(ref_output) == len(model_output))
@@ -183,7 +185,19 @@ class TestQNN(unittest.TestCase):
         delegated_program.exported_program = to_backend(
             delegated_program.exported_program, qnn_partitioner
         )
-        exec_prog = delegated_program.to_executorch()
+        exec_prog = delegated_program.to_executorch(
+            exir.ExecutorchBackendConfig(
+                # For shared buffer, user must pass the memory address
+                # which is allocated by RPC memory to executor runner.
+                # Therefore, won't want to pre-allocate
+                # by memory manager in runtime.
+                memory_planning_pass=MemoryPlanningPass(
+                    memory_planning_algo="greedy",
+                    alloc_graph_input=not self.shared_buffer,
+                    alloc_graph_output=not self.shared_buffer,
+                )
+            )
+        )
 
         # Assert the backend name is qnn
         self.assertEqual(

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -190,6 +190,7 @@ def generate_qnn_executorch_compiler_spec(
     online_prepare: bool = False,
     tensor_dump_output_path: str = "",
     profile: bool = False,
+    shared_buffer: bool = False,
 ) -> List[CompileSpec]:
     """
     Helper function generating compiler specs for Qualcomm AI Engine Direct
@@ -215,6 +216,8 @@ def generate_qnn_executorch_compiler_spec(
         profile: Enable profile the performance of per operator.
             Note that for now only support kProfileDetailed to
             profile the performance of each operator with cycle unit.
+        shared_buffer: Enables usage of shared buffer between application
+            and backend for graph I/O.
 
     Returns:
         List[CompileSpec]: Compiler specs for Qualcomm AI Engine Direct.
@@ -249,6 +252,9 @@ def generate_qnn_executorch_compiler_spec(
         )
     else:
         qnn_executorch_options.profile_level = QnnExecuTorchProfileLevel.kProfileOff
+
+    if shared_buffer:
+        qnn_executorch_options.shared_buffer = True
 
     if (
         online_prepare

--- a/examples/qualcomm/CMakeLists.txt
+++ b/examples/qualcomm/CMakeLists.txt
@@ -100,7 +100,7 @@ target_link_libraries(qnn_executor_runner
     qnn_executorch_backend
     full_portable_ops_lib
     etdump
-    ${FLATCC_LIB}
+    ${FLATCCRT_LIB}
     gflags
 )
 target_compile_options(qnn_executor_runner

--- a/examples/qualcomm/scripts/deeplab_v3.py
+++ b/examples/qualcomm/scripts/deeplab_v3.py
@@ -109,6 +109,7 @@ if __name__ == "__main__":
         skip_node_id_set=skip_node_id_set,
         skip_node_op_set=skip_node_op_set,
         quant_dtype=QuantDtype.use_8a8w,
+        shared_buffer=args.shared_buffer,
     )
 
     if args.compile_only:
@@ -128,6 +129,7 @@ if __name__ == "__main__":
         device_id=args.device,
         host_id=args.host,
         soc_model=args.model,
+        shared_buffer=args.shared_buffer,
     )
     adb.push(inputs=inputs, input_list=input_list)
     adb.execute()

--- a/examples/qualcomm/scripts/dummy_llama2.py
+++ b/examples/qualcomm/scripts/dummy_llama2.py
@@ -128,6 +128,7 @@ if __name__ == "__main__":
         inputs,
         custom_annotations=(),
         quant_dtype=quant_dtype,
+        shared_buffer=args.shared_buffer,
     )
 
     if args.compile_only:
@@ -141,6 +142,7 @@ if __name__ == "__main__":
         device_id=args.device,
         host_id=args.host,
         soc_model=args.model,
+        shared_buffer=args.shared_buffer,
     )
     adb.push(inputs=inputs, input_list=input_list)
     adb.execute()

--- a/examples/qualcomm/scripts/edsr.py
+++ b/examples/qualcomm/scripts/edsr.py
@@ -156,6 +156,7 @@ if __name__ == "__main__":
         skip_node_id_set=skip_node_id_set,
         skip_node_op_set=skip_node_op_set,
         quant_dtype=QuantDtype.use_8a8w,
+        shared_buffer=args.shared_buffer,
     )
 
     if args.compile_only:
@@ -175,6 +176,7 @@ if __name__ == "__main__":
         device_id=args.device,
         host_id=args.host,
         soc_model=args.model,
+        shared_buffer=args.shared_buffer,
     )
     adb.push(inputs=inputs, input_list=input_list)
     adb.execute()

--- a/examples/qualcomm/scripts/export_example.py
+++ b/examples/qualcomm/scripts/export_example.py
@@ -12,6 +12,7 @@ from executorch.backends.qualcomm.serialization.qnn_compile_spec_schema import (
 )
 from executorch.backends.qualcomm.utils.utils import (
     capture_program,
+    generate_htp_compiler_spec,
     generate_qnn_executorch_compiler_spec,
 )
 from executorch.examples.models import MODEL_NAME_TO_MODEL
@@ -71,12 +72,13 @@ if __name__ == "__main__":
     edge_copy = copy.deepcopy(edge_program)
 
     # Delegate to QNN backend
+    backend_options = generate_htp_compiler_spec(
+        use_fp16=False,
+    )
     qnn_partitioner = QnnPartitioner(
         generate_qnn_executorch_compiler_spec(
-            is_fp16=False,
             soc_model=QcomChipset.SM8550,
-            debug=False,
-            saver=False,
+            backend_options=backend_options,
         )
     )
     with validation_disabled():

--- a/examples/qualcomm/scripts/inception_v3.py
+++ b/examples/qualcomm/scripts/inception_v3.py
@@ -111,6 +111,7 @@ if __name__ == "__main__":
         skip_node_id_set=skip_node_id_set,
         skip_node_op_set=skip_node_op_set,
         quant_dtype=QuantDtype.use_8a8w,
+        shared_buffer=args.shared_buffer,
     )
 
     if args.compile_only:
@@ -130,6 +131,7 @@ if __name__ == "__main__":
         device_id=args.device,
         host_id=args.host,
         soc_model=args.model,
+        shared_buffer=args.shared_buffer,
     )
     adb.push(inputs=inputs, input_list=input_list)
     adb.execute()

--- a/examples/qualcomm/scripts/inception_v4.py
+++ b/examples/qualcomm/scripts/inception_v4.py
@@ -110,6 +110,7 @@ if __name__ == "__main__":
         skip_node_id_set=skip_node_id_set,
         skip_node_op_set=skip_node_op_set,
         quant_dtype=QuantDtype.use_8a8w,
+        shared_buffer=args.shared_buffer,
     )
 
     if args.compile_only:
@@ -129,6 +130,7 @@ if __name__ == "__main__":
         device_id=args.device,
         host_id=args.host,
         soc_model=args.model,
+        shared_buffer=args.shared_buffer,
     )
     adb.push(inputs=inputs, input_list=input_list)
     adb.execute()

--- a/examples/qualcomm/scripts/mobilebert_fine_tune.py
+++ b/examples/qualcomm/scripts/mobilebert_fine_tune.py
@@ -294,6 +294,7 @@ if __name__ == "__main__":
         skip_node_id_set=skip_node_id_set,
         skip_node_op_set=skip_node_op_set,
         quant_dtype=quant_dtype,
+        shared_buffer=args.shared_buffer,
     )
 
     if args.compile_only:
@@ -313,6 +314,7 @@ if __name__ == "__main__":
         device_id=args.device,
         host_id=args.host,
         soc_model=args.model,
+        shared_buffer=args.shared_buffer,
     )
     adb.push(inputs=inputs, input_list=input_list)
     adb.execute()

--- a/examples/qualcomm/scripts/mobilenet_v2.py
+++ b/examples/qualcomm/scripts/mobilenet_v2.py
@@ -111,6 +111,7 @@ if __name__ == "__main__":
         skip_node_id_set=skip_node_id_set,
         skip_node_op_set=skip_node_op_set,
         quant_dtype=QuantDtype.use_8a8w,
+        shared_buffer=args.shared_buffer,
     )
 
     if args.compile_only:
@@ -130,6 +131,7 @@ if __name__ == "__main__":
         device_id=args.device,
         host_id=args.host,
         soc_model=args.model,
+        shared_buffer=args.shared_buffer,
     )
     adb.push(inputs=inputs, input_list=input_list)
     adb.execute()

--- a/examples/qualcomm/scripts/torchvision_vit.py
+++ b/examples/qualcomm/scripts/torchvision_vit.py
@@ -150,6 +150,7 @@ if __name__ == "__main__":
         f"{args.artifact}/{pte_filename}",
         inputs,
         quant_dtype=QuantDtype.use_8a8w,
+        shared_buffer=args.shared_buffer,
     )
     # setup required paths accordingly
     # qnn_sdk       : QNN SDK path setup in environment variable
@@ -165,6 +166,7 @@ if __name__ == "__main__":
         device_id=args.device,
         host_id=args.host,
         soc_model=args.model,
+        shared_buffer=args.shared_buffer,
     )
     adb.push(inputs=inputs, input_list=input_list)
     adb.execute()


### PR DESCRIPTION
Summary:
- Add argument "shared_buffer" into compiler_spec, qnn_executor_runner and test scripts
  -  Actually, shared_buffer should be a runtime option since user are responsible to allocate memory for tensors on device. But it seems to have no way to set the runtime option to QnnBackend. Therefore, we put it to compile_spec for now.
- Implement SharedBuffer to allocate and free RPC memory
- Add QnnMemManger to register shared buffer for tensor
  - During exection time, we will register memory of tensor data for QNN. And we will deregister them during destruction time of QnnBackend
- Add two API `void* QnnExecuTorchAllocCustomMem(size_t bytes, size_t alignment)` and `void QnnExecuTorchFreeCustomMem(void* buffer_ptr)` to allocate RPC memory with SharedBuffer
  -  Users are responsible to allocate "enough" tensor bytes, and set alignment as MemoryAllocator::kDefaultAlignment. See runtime/core/memory_allocator.h.