### PR TITLE
Add EXECUTORCH_LOG_LEVEL option to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,24 @@ if(NOT EXECUTORCH_ENABLE_LOGGING)
   add_definitions(-DET_LOG_ENABLED=0)
 endif()
 
+# Configure log level. Must be one of debug, info, error, fatal.
+set(EXECUTORCH_LOG_LEVEL "Info" CACHE STRING
+      "Build with the given ET_MIN_LOG_LEVEL value")
+string(TOLOWER "${EXECUTORCH_LOG_LEVEL}" LOG_LEVEL_LOWER)
+if(LOG_LEVEL_LOWER STREQUAL "debug")
+  add_definitions(-DET_MIN_LOG_LEVEL=Debug)
+elseif(LOG_LEVEL_LOWER STREQUAL "info")
+  add_definitions(-DET_MIN_LOG_LEVEL=Info)
+elseif(LOG_LEVEL_LOWER STREQUAL "error")
+  add_definitions(-DET_MIN_LOG_LEVEL=Error)
+elseif(LOG_LEVEL_LOWER STREQUAL "fatal")
+  add_definitions(-DET_MIN_LOG_LEVEL=Fatal)
+else()
+  message(SEND_ERROR
+      "Unknown log level \"${EXECUTORCH_LOG_LEVEL}\". Expected one of Debug, " +
+      "Info, Error, or Fatal.")
+endif()
+
 option(EXECUTORCH_ENABLE_PROGRAM_VERIFICATION
        "Build with ET_ENABLE_PROGRAM_VERIFICATION"
        ${_default_release_disabled_options})

--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -1,8 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #
-# Copyright 2024 Arm Limited and/or its affiliates.
-#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
@@ -34,6 +32,8 @@ function(executorch_print_configuration_summary)
   message(STATUS "  FLATC_EXECUTABLE              : ${FLATC_EXECUTABLE}")
   message(
     STATUS "  EXECUTORCH_ENABLE_LOGGING     : ${EXECUTORCH_ENABLE_LOGGING}")
+  message(
+    STATUS "  EXECUTORCH_LOG_LEVEL          : ${EXECUTORCH_LOG_LEVEL}")
   message(STATUS "  EXECUTORCH_ENABLE_PROGRAM_VERIFICATION : "
                  "${EXECUTORCH_ENABLE_PROGRAM_VERIFICATION}")
   message(
@@ -46,6 +46,8 @@ function(executorch_print_configuration_summary)
   )
   message(
     STATUS "  REGISTER_EXAMPLE_CUSTOM_OPS   : ${REGISTER_EXAMPLE_CUSTOM_OPS}")
+  message(STATUS "  EXECUTORCH_BUILD_EXTENSION_AOT_UTIL : "
+                 "${EXECUTORCH_BUILD_EXTENSION_AOT_UTIL}")
   message(STATUS "  EXECUTORCH_BUILD_EXTENSION_DATA_LOADER : "
                  "${EXECUTORCH_BUILD_EXTENSION_DATA_LOADER}")
   message(STATUS "  EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL : "


### PR DESCRIPTION
Add a CMake setting (EXECUTORCH_LOG_LEVEL) to set ET_MIN_LOG_LEVEL. Must be one of Debug, Info, Error, or Fatal (case-insensitive).