### PR TITLE
[CoreML Backend] Fix coreml runner build

### DIFF
--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
@@ -384,7 +384,7 @@ ETCoreMLAsset * _Nullable make_asset(NSURL *url,
     auto modelAssetType = get_model_asset_type(inMemoryFS);
     ETCoreMLAsset *modelAsset = nil;
     // Write the model files.
-    if (modelAssetType == ModelAssetType::ModelPackage) {
+    if (modelAssetType == ModelAssetType::Model) {
         NSURL *modelURL = ::write_model_files(dstURL, self.fileManager, identifier, modelAssetType.value(), inMemoryFS, error);
         if (modelURL) {
             modelAsset = make_asset(modelURL,


### PR DESCRIPTION
The runner fails to build
```
/Users/runner/work/executorch/executorch/pytorch/executorch/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm:387:43: error: no member named 'ModelPackage' in '(anonymous namespace)::ModelAssetType'
    if (modelAssetType == ModelAssetType::ModelPackage) {
```

The PR fixes the issue. Tested all CoreML builds.