### PR TITLE
scalar_type doesn't depend on other runtime/core lib

### DIFF
--- a/runtime/core/portable_type/targets.bzl
+++ b/runtime/core/portable_type/targets.bzl
@@ -52,8 +52,4 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten/util/...",
             "//executorch/kernels/...",
         ],
-        exported_deps = [
-            "//executorch/runtime/core:core",
-            "//executorch/runtime/core:tag",
-        ],
     )


### PR DESCRIPTION
Summary: We shouldn't add them to exported_deps.

Reviewed By: mergennachin

Differential Revision: D55090249


