### PR TITLE
Replace wget with curl when setup macos job

### DIFF
--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -23,8 +23,8 @@ install_buck() {
     brew install zstd
   fi
 
-  if ! command -v wget &> /dev/null; then
-    brew install wget
+  if ! command -v curl &> /dev/null; then
+    brew install curl
   fi
 
   pushd .ci/docker
@@ -37,7 +37,7 @@ install_buck() {
   # --version doesn't say anything w.r.t its release version, i.e. 2024-02-15.
   # See D53878006 for more details.
   BUCK2=buck2-aarch64-apple-darwin.zst
-  wget -q "https://ossci-macos.s3.amazonaws.com/${BUCK2}"
+  curl -s "https://ossci-macos.s3.amazonaws.com/${BUCK2}" -o "${BUCK2}"
 
   zstd -d "${BUCK2}" -o buck2
 


### PR DESCRIPTION
I'm seeing lots of flaky macOS job failing to download buck2 from S3 https://github.com/pytorch/executorch/actions/runs/8364218071/job/22899003145#step:9:94.  Logging into the runner and run the command shows that using wget getting an invalid HTTPS certificate, but using curl is fine (weird).  The runner is probably having an issue with openssl setup (https://serverfault.com/questions/922222/why-does-curl-work-with-a-specific-https-site-but-wget-has-problems-with-certif), so we can figure it out latter while this is to make macOS signal less flaky.