### PR TITLE
[ET-VK] Enable storage type and memory layout settings to be serialized with Vulkan graph

### DIFF
--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -5,7 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import operator
-from typing import final, List, Optional
+from typing import Any, Dict, final, List, Optional
+
+import executorch.backends.vulkan.serialization.vulkan_graph_schema as vk_graph_schema
 
 import torch
 from executorch.backends.vulkan.vulkan_preprocess import VulkanBackend
@@ -45,11 +47,29 @@ class VulkanSupportedOperators(OperatorSupportBase):
         return supported
 
 
+def parse_compile_options(
+    compile_options: Optional[Dict[str, Any]] = None
+) -> List[CompileSpec]:
+    compile_specs = []
+    if compile_options is None:
+        return compile_specs
+
+    for key, value in compile_options.items():
+        if isinstance(
+            value, (vk_graph_schema.VkStorageType, vk_graph_schema.VkMemoryLayout)
+        ):
+            value_bytes = int(value).to_bytes(4, byteorder="little")
+            compile_specs.append(CompileSpec(key, value_bytes))
+        else:
+            raise RuntimeError(f"Invalid compile option {key} with type {type(value)}")
+
+    return compile_specs
+
+
 @final
 class VulkanPartitioner(Partitioner):
-    def __init__(self, compile_spec: Optional[List[CompileSpec]] = None) -> None:
-        if compile_spec is None:
-            compile_spec = []
+    def __init__(self, compile_options: Optional[Dict[str, Any]] = None) -> None:
+        compile_spec = parse_compile_options(compile_options)
         self.delegation_spec = DelegationSpec(VulkanBackend.__name__, compile_spec)
 
     def partition(self, exported_program: ExportedProgram) -> PartitionResult:

--- a/backends/vulkan/runtime/VulkanDelegateHeader.cpp
+++ b/backends/vulkan/runtime/VulkanDelegateHeader.cpp
@@ -36,6 +36,8 @@ constexpr ByteSlice kFlatbufferSize = {14, 4};
 constexpr ByteSlice kBytesOffset = {18, 4};
 constexpr ByteSlice kBytesSize = {22, 8};
 
+} // namespace
+
 /// Interprets the 8 bytes at `data` as a little-endian uint64_t.
 uint64_t GetUInt64LE(const uint8_t* data) {
   return (uint64_t)data[0] | ((uint64_t)data[1] << 8) |
@@ -54,8 +56,6 @@ uint32_t GetUInt32LE(const uint8_t* data) {
 uint32_t GetUInt16LE(const uint8_t* data) {
   return (uint32_t)data[0] | ((uint32_t)data[1] << 8);
 }
-
-} // namespace
 
 bool VulkanDelegateHeader::is_valid() const {
   if (header_size < kExpectedSize) {

--- a/backends/vulkan/runtime/VulkanDelegateHeader.h
+++ b/backends/vulkan/runtime/VulkanDelegateHeader.h
@@ -14,6 +14,11 @@ namespace torch {
 namespace executor {
 namespace vulkan {
 
+// Byte decoding utilities
+uint64_t GetUInt64LE(const uint8_t* data);
+uint32_t GetUInt32LE(const uint8_t* data);
+uint32_t GetUInt16LE(const uint8_t* data);
+
 struct VulkanDelegateHeader {
   bool is_valid() const;
 

--- a/backends/vulkan/serialization/schema.fbs
+++ b/backends/vulkan/serialization/schema.fbs
@@ -21,7 +21,7 @@ enum VkDataType : byte {
 
 // Describes what kind of GPU resource should be used to represent a tensor. The
 // int values assigned to each entry must match the corresponding entry in
-// api::GPUMemoryLayout.
+// api::StorageType.
 enum VkStorageType : ubyte {
   BUFFER = 0,
   TEXTURE_3D = 1,

--- a/backends/vulkan/serialization/schema.fbs
+++ b/backends/vulkan/serialization/schema.fbs
@@ -19,6 +19,32 @@ enum VkDataType : byte {
   FLOAT32 = 5,
 }
 
+// Describes what kind of GPU resource should be used to represent a tensor. The
+// int values assigned to each entry must match the corresponding entry in
+// api::GPUMemoryLayout.
+enum VkStorageType : ubyte {
+  BUFFER = 0,
+  TEXTURE_3D = 1,
+  TEXTURE_2D = 2,
+  // Magic Number
+  DEFAULT_STORAGE = 255,
+}
+
+// Describes how memory should be laid out in GPU memory. See the GPUMemoryLayout
+// enum class in PyTorch Vulkan for more details. The int values assigned to each
+// entry must match the corresponding entry in api::GPUMemoryLayout.
+enum VkMemoryLayout : ubyte {
+  TENSOR_WIDTH_PACKED = 0,
+  TENSOR_HEIGHT_PACKED = 1,
+  TENSOR_CHANNELS_PACKED = 2,
+  WHCW = 3,
+  WHCH = 4,
+  WHCC = 5,
+  CHWC = 6,
+  // Magic number
+  DEFAULT_LAYOUT = 255,
+}
+
 table VkTensor {
   // Type of the tensor elements.
   datatype:VkDataType;
@@ -28,6 +54,10 @@ table VkTensor {
   constant_id:int;
   // Index to the shared memory object. Negative indicates the tensor doesn't share memory.
   mem_obj_id:int;
+  // Storage type that should be used to represent this tensor
+  storage_type:VkStorageType = DEFAULT_STORAGE;
+  // Memory layout that should be used to represent this tensor
+  memory_layout:VkMemoryLayout = DEFAULT_LAYOUT;
 }
 
 table Null {}
@@ -103,6 +133,17 @@ table VkGraph {
   // Raw Objects (e.g. weight tensors and custom shaders)
   constants:[VkBytes];
   shaders:[VkBytes];
+
+  // Graph configuration
+  // As per flatbuffer BC/FC policy, new fields can be freely added to this
+  // section. It is recommended to provide default values, since older blobs
+  // without the field will be deserialized with the default value.
+
+  // Sets an override for the storage type and memory layout that will be used
+  // to represent a VkTensor if the VkTensor is not serialized with a particular
+  // storage type or memory layout setting
+  storage_type_override:VkStorageType = DEFAULT_STORAGE;
+  memory_layout_override:VkMemoryLayout = DEFAULT_LAYOUT;
 }
 
 root_type VkGraph;

--- a/backends/vulkan/serialization/schema.fbs
+++ b/backends/vulkan/serialization/schema.fbs
@@ -26,7 +26,6 @@ enum VkStorageType : ubyte {
   BUFFER = 0,
   TEXTURE_3D = 1,
   TEXTURE_2D = 2,
-  // Magic Number
   DEFAULT_STORAGE = 255,
 }
 
@@ -37,11 +36,6 @@ enum VkMemoryLayout : ubyte {
   TENSOR_WIDTH_PACKED = 0,
   TENSOR_HEIGHT_PACKED = 1,
   TENSOR_CHANNELS_PACKED = 2,
-  WHCW = 3,
-  WHCH = 4,
-  WHCC = 5,
-  CHWC = 6,
-  // Magic number
   DEFAULT_LAYOUT = 255,
 }
 

--- a/backends/vulkan/serialization/vulkan_graph_schema.py
+++ b/backends/vulkan/serialization/vulkan_graph_schema.py
@@ -30,12 +30,32 @@ class VkDataType(IntEnum):
     FLOAT32 = 5
 
 
+class VkStorageType(IntEnum):
+    BUFFER = 0
+    TEXTURE_3D = 1
+    TEXTURE_2D = 2
+    DEFAULT_STORAGE = 255
+
+
+class VkMemoryLayout(IntEnum):
+    TENSOR_WIDTH_PACKED = 0
+    TENSOR_HEIGHT_PACKED = 1
+    TENSOR_CHANNELS_PACKED = 2
+    WHCW = 3
+    WHCH = 4
+    WHCC = 5
+    CHWC = 6
+    DEFAULT_LAYOUT = 255
+
+
 @dataclass
 class VkTensor:
     datatype: VkDataType
     dims: List[int]
     constant_id: int
     mem_obj_id: int
+    storage_type: VkStorageType = VkStorageType.DEFAULT_STORAGE
+    memory_layout: VkMemoryLayout = VkMemoryLayout.DEFAULT_LAYOUT
 
 
 @dataclass
@@ -120,3 +140,6 @@ class VkGraph:
 
     constants: List[VkBytes]
     shaders: List[VkBytes]
+
+    storage_type_override: VkStorageType = VkStorageType.DEFAULT_STORAGE
+    memory_layout_override: VkMemoryLayout = VkMemoryLayout.DEFAULT_LAYOUT

--- a/backends/vulkan/serialization/vulkan_graph_schema.py
+++ b/backends/vulkan/serialization/vulkan_graph_schema.py
@@ -41,10 +41,6 @@ class VkMemoryLayout(IntEnum):
     TENSOR_WIDTH_PACKED = 0
     TENSOR_HEIGHT_PACKED = 1
     TENSOR_CHANNELS_PACKED = 2
-    WHCW = 3
-    WHCH = 4
-    WHCC = 5
-    CHWC = 6
     DEFAULT_LAYOUT = 255
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2548
* #2547
* __->__ #2540

## Context

Allow `api::StorageType` and `api::GPUMemoryLayout` settings to be serialized with the flatbuffer. There are two entry points for this:

1. `VkTensor` table now has two fields that can be set to select particular settings for that tensor
2. A storage type and memory layout override can be set via the `CompileSpec` API

Differential Revision: [D55154628](https://our.internmc.facebook.com/intern/diff/D55154628/)