### PR TITLE
export coreml kv-cache without dynamic shape

### DIFF
--- a/examples/models/llama2/llama_transformer.py
+++ b/examples/models/llama2/llama_transformer.py
@@ -148,6 +148,31 @@ def apply_rotary_emb(
     return xq_out.type_as(xq), xk_out.type_as(xk)
 
 
+class KVCache(nn.Module):
+    def __init__(
+        self, max_batch_size, max_seq_length, n_heads, head_dim, dtype=torch.bfloat16
+    ):
+        super().__init__()
+        cache_shape = (max_batch_size, n_heads, max_seq_length, head_dim)
+        self.register_buffer(
+            "k_cache", torch.zeros(cache_shape, dtype=dtype, device="cpu")
+        )
+        self.register_buffer(
+            "v_cache", torch.zeros(cache_shape, dtype=dtype, device="cpu")
+        )
+
+    def update(self, input_pos, k_val, v_val):
+        # input_pos: [S], k_val: [B, H, S, D]
+        assert input_pos.shape[0] == k_val.shape[2]
+
+        k_out = self.k_cache
+        v_out = self.v_cache
+        k_out[:, :, input_pos] = k_val
+        v_out[:, :, input_pos] = v_val
+
+        return k_out, v_out
+
+
 class Attention(nn.Module):
     def __init__(self, args: ModelArgs, layer_id: int):
         super().__init__()
@@ -161,6 +186,7 @@ class Attention(nn.Module):
         self.head_dim = args.dim // args.n_heads
         self.max_batch_size = args.max_batch_size
         self.max_seq_len = args.max_seq_len
+        self.dim = args.dim
         # args.dim = 4096, args.n_heads = 32, self.head_dim = 4096 / 32 = 125
         self.wq = nn.Linear(args.dim, args.n_heads * self.head_dim, bias=False)
         self.wk = nn.Linear(args.dim, self.n_kv_heads * self.head_dim, bias=False)
@@ -170,111 +196,70 @@ class Attention(nn.Module):
         self.use_sdpa_with_kv_cache_op = args.use_sdpa_with_kv_cache_op
         self.layer_id = layer_id
 
-        mask = torch.full(
-            (1, 1, args.max_seq_len, args.max_seq_len),
-            float("-inf"),
-            device="cpu",
+        causal_mask = torch.tril(
+            torch.ones(
+                self.max_seq_len,
+                self.max_seq_len,
+                dtype=torch.bool,
+                device="cpu",
+            )
         )
+        self.register_buffer("mask", causal_mask, persistent=False)
 
-        mask = torch.triu(mask, diagonal=1)
-        self.register_buffer("mask", mask)
-
-        # This is what we would use if ExecuTorch could support mutable buffers. We can't at this time, so instead
-        # what is done is this module takes in the cache as io.
-        # self.cache_k = torch.zeros(
-        #     (args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
-        # )
-        # self.cache_v = torch.zeros(
-        #     (args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
-        # )
-        self.kv_cache_sizes = [
-            args.max_batch_size,
-            args.max_seq_len,
-            self.n_kv_heads,
-            self.head_dim,
-        ]
+        if self.use_kv_cache:
+            self.kv_cache = KVCache(
+                args.max_batch_size,
+                args.max_seq_len,
+                self.n_kv_heads,
+                self.head_dim,
+            )
 
     def forward(
         self,
         x: torch.Tensor,
         freqs_cos: torch.Tensor,
         freqs_sin: torch.Tensor,
-        start_pos: Optional[int] = None,
-        cache_k: Optional[torch.Tensor] = None,
-        # if use_sdpa_with_kv_cache_op
-        # shape: (num_layers, args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
-        # otherwise
-        # shape: (args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
-        cache_v: Optional[torch.Tensor] = None,
-        # if use_sdpa_with_kv_cache_op
-        # shape: (num_layers, args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
-        # otherwise
-        # shape: (args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
+        input_pos: Optional[torch.Tensor] = None,
     ):
         bsz, seqlen, _ = x.shape
 
         # QKV
-        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+        q, k, v = self.wq(x), self.wk(x), self.wv(x)
         # We need view_copy elimination
-        xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
-        xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
-        xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+        q = q.view(bsz, seqlen, self.n_local_heads, self.head_dim)
+        k = k.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+        v = v.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
 
         # RoPE relative positional embeddings
-        xq, xk = apply_rotary_emb(xq, xk, freqs_cos, freqs_sin)
+        q, k = apply_rotary_emb(q, k, freqs_cos, freqs_sin)
+
+        q = q.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
 
         if self.use_kv_cache:
-            assert start_pos is not None
-            assert cache_k is not None and cache_v is not None
+            if not self.use_sdpa_with_kv_cache_op:
 
-            # TODO(T180671810)
-            # Refactor this code to make custom op based
-            # SDPA into a separate optimized attention module
-            if self.use_sdpa_with_kv_cache_op:
-                from .custom_ops.sdpa_with_kv_cache import sdpa_with_kv_cache  # noqa
+                k, v = self.kv_cache.update(input_pos, k, v)
+                mask = self.mask[None, None, input_pos]
 
-                output = torch.ops.llama.sdpa_with_kv_cache(
-                    xq,
-                    xk,
-                    xv,
-                    cache_k,
-                    cache_v,
-                    self.layer_id,
-                    start_pos,
-                    seqlen,
+                k = k.repeat_interleave(self.n_rep, dim=1)
+                v = v.repeat_interleave(self.n_rep, dim=1)
+                y = F.scaled_dot_product_attention(
+                    q, k, v, attn_mask=mask, dropout_p=0.0
                 )
-                output = output.view(bsz, seqlen, -1)
-                output = self.wo(output)
-                return output, cache_k, cache_v
-            else:
-                # Replace the entry in the cache for this token
-                # The following lines are equivalent to:
-                # cache_k[:bsz, start_pos : start_pos + seqlen] = xk
-                # cache_v[:bsz, start_pos : start_pos + seqlen] = xv
-                # We use .narrow() here to make the compiler happy
-                narrowed_k = cache_k[:bsz].narrow(1, start_pos, seqlen)
-                narrowed_v = cache_v[:bsz].narrow(1, start_pos, seqlen)
 
-                narrowed_k.copy_(xk)
-                narrowed_v.copy_(xv)
+                y = y.transpose(1, 2).contiguous().view(bsz, seqlen, self.dim)
 
-                keys = cache_k[:bsz].narrow(1, 0, start_pos + seqlen)
-                values = cache_v[:bsz].narrow(1, 0, start_pos + seqlen)
-        else:
-            keys = xk
-            values = xv
+                y = self.wo(y)
+                return y
 
         # grouped multiquery attention: expand out keys and values
-        keys = repeat_kv(keys, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
-        values = repeat_kv(values, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
-
-        # make heads into a batch dimension
-        xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
-        keys = keys.transpose(1, 2)
-        values = values.transpose(1, 2)
+        k = k.repeat_interleave(self.n_rep, dim=1)
+        v = v.repeat_interleave(self.n_rep, dim=1)
 
         assert hasattr(self, "mask")
-        mask = self.mask[:, :, :seqlen, :seqlen]
+        mask = self.mask[:seqlen, :seqlen]
 
         # this is needed to support xnnpack which requires mask shape to be 2d.
         # this is a temporary workaround. once we update xnnpack we should be able to handle this.
@@ -283,18 +268,13 @@ class Attention(nn.Module):
         # tensor will be 2-dimensional, regarldess of the values of l & s
         mask = torch.squeeze(mask, [0, 1])
 
-        output = F.scaled_dot_product_attention(
-            xq, keys, values, attn_mask=mask, dropout_p=0.0
-        )
+        output = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, dropout_p=0.0)
 
         output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
 
         output = self.wo(output)
 
-        if self.use_kv_cache:
-            return output, cache_k, cache_v
-        else:
-            return output, None, None
+        return output
 
 
 class FeedForward(nn.Module):
@@ -379,16 +359,9 @@ class TransformerBlock(nn.Module):
         self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
         self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
 
-    def forward(
-        self, x, freqs_cos, freqs_sin, start_pos=None, cache_k=None, cache_v=None
-    ):  # x: 1xN
-        h, cache_k, cache_v = self.attention.forward(
-            self.attention_norm(x),
-            freqs_cos,
-            freqs_sin,
-            start_pos,
-            cache_k,
-            cache_v,
+    def forward(self, x, freqs_cos, freqs_sin, input_pos=None):  # x: 1xN
+        h = self.attention.forward(
+            self.attention_norm(x), freqs_cos, freqs_sin, input_pos
         )
 
         h = x + h
@@ -396,7 +369,7 @@ class TransformerBlock(nn.Module):
             out = h + self.block_sparse_moe(self.ffn_norm(h))
         else:
             out = h + self.feed_forward(self.ffn_norm(h))
-        return out, cache_k, cache_v
+        return out
 
 
 class Transformer(nn.Module):
@@ -425,87 +398,35 @@ class Transformer(nn.Module):
     def forward(
         self,
         tokens: torch.Tensor,
-        start_pos: Optional[
+        input_pos: Optional[
             torch.Tensor
         ] = None,  # Scalar tensor indicating size of window of the caches
-        cache_k: Optional[
-            torch.Tensor
-        ] = None,  # n_layers long, it should be a list of tensors to accommodate the potential size difference among attention layers. The current implementation is overly simplified.
-        cache_v: Optional[torch.Tensor] = None,  # n_layers long
-    ) -> Union[
-        torch.Tensor, Tuple[torch.Tensor, List[torch.Tensor], List[torch.Tensor]]
-    ]:
+    ) -> torch.Tensor:
         _bsz, seqlen = tokens.shape
         h = self.tok_embeddings(tokens)
 
         if self.use_kv_cache:
             assert (
-                cache_k is not None and cache_v is not None and start_pos is not None
-            ), "Caches and start_pos must be provided when use_kv_cache is True"
-            assert (
-                cache_k.size(0) == self.n_layers
-            ), f"{cache_k.size(0)} != {self.n_layers}"
-            assert (
-                cache_v.size(0) == self.n_layers
-            ), f"{cache_v.size(0)} != {self.n_layers}"
+                input_pos is not None
+            ), "input_pos must be provided when use_kv_cache is True"
 
-            sp = start_pos.item()
-            # self.params.max_seq_len - 1 because of 0 based indexing, and - 1 again because our input seq len is 1 and its added to the cache before accessing the cache
-            torch._constrain_as_size(sp, min=0, max=self.params.max_seq_len - 2)
-            torch._constrain_as_value(
-                cache_k.shape[0],
-                max=self.n_layers,
-                min=self.n_layers,
-            )
-            torch._constrain_as_value(
-                cache_v.shape[0], min=self.n_layers, max=self.n_layers
-            )
             # when KV cache is used, seqlen is most likely 1. We want to slice from the start_pos.
-            freqs_cos = self.freqs_cos[sp : sp + seqlen]
-            freqs_sin = self.freqs_sin[sp : sp + seqlen]
+            freqs_cos = self.freqs_cos[input_pos]
+            freqs_sin = self.freqs_sin[input_pos]
         else:
-            # assert (
-            #     start_pos is None and cache_k is None and cache_v is None
-            # ), "Caches and start_pos are unused when use_kv_cache is False"
+            assert input_pos is None, "input_pos is unused when use_kv_cache is False"
             freqs_cos = self.freqs_cos[:seqlen]
             freqs_sin = self.freqs_sin[:seqlen]
 
-        for index, layer in enumerate(self.layers):
-            if self.use_kv_cache:
-                if self.params.use_sdpa_with_kv_cache_op:
-                    h, updated_cache_k, updated_cache_v = layer(
-                        h,
-                        freqs_cos,
-                        freqs_sin,
-                        sp,  # pyre-ignore[61]
-                        cache_k,
-                        cache_v,
-                    )
-                else:
-                    h, updated_cache_k, updated_cache_v = layer(
-                        h,
-                        freqs_cos,
-                        freqs_sin,
-                        sp,  # pyre-ignore[61]
-                        cache_k[index],  # pyre-ignore[16]
-                        cache_v[index],
-                    )
-                    cache_k[index] = updated_cache_k  # pyre-ignore[16]
-                    cache_v[index] = updated_cache_v
-
-            else:
-                h, _, _ = layer(h, freqs_cos, freqs_sin)
+        for layer in self.layers:
+            h = layer(
+                h,
+                freqs_cos,
+                freqs_sin,
+                input_pos,
+            )
 
         h = self.norm(h)
 
         logits = self.output(h)
-        if self.use_kv_cache:
-            return (logits, cache_k, cache_v)  # pyre-ignore
-        else:
-            # 'None' is not a valid return for export so have to split the return into if else
-            return logits
-
-    # For each layer return the sizes of the needed caches
-    def get_cache_sizes(self):
-        # cache_k and cache_v have the same shape so could pick either here.
-        return [self.n_layers, *self.layers[0].attention.kv_cache_sizes]
+        return logits

--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -210,25 +210,18 @@ Error Runner::generate(
   int v_cache_index = 0;
   std::vector<exec_aten::SizesType> kv_cache_shape = getKVCacheShape();
   std::vector<exec_aten::SizesType> input_shape = {1, 1};
-  std::vector<exec_aten::SizesType> pos_shape = {};
+  std::vector<exec_aten::SizesType> pos_shape = {1};
   std::vector<uint8_t> k_data;
   std::vector<uint8_t> v_data;
   std::vector<int64_t> token_data; // allocate space for the tokens
+  std::vector<int64_t> pos_data; // allocate space for the tokens
   ScalarType dtype = static_cast<ScalarType>(
       getMetadataHelper("get_dtype", (int64_t)ScalarType::Float));
 
   if (use_kv_cache_) {
     // set pos to 0, refill token by token
     pos = 0;
-    logits_index = 2;
-    k_cache_index = 0;
-    v_cache_index = 1;
-    // TODO(): Fix this by inspecting graph signature
-    if (use_sdpa_with_kv_cache_) {
-      logits_index = 0;
-      k_cache_index = 1;
-      v_cache_index = 2;
-    }
+    logits_index = 0;
     // initialize kv cache
     size_t n_bytes = 1;
     for (exec_aten::SizesType shape : kv_cache_shape) {
@@ -236,20 +229,16 @@ Error Runner::generate(
     }
     n_bytes *= torch::executor::elementSize(dtype);
 
-    k_data.resize(n_bytes);
-    std::fill(k_data.begin(), k_data.end(), 0);
-    v_data.resize(n_bytes);
-    std::fill(v_data.begin(), v_data.end(), 0);
     token_data.resize(1);
+    pos_data.resize(seq_len);
   } else {
     // reserve data for tokens, notice the size is still 0.
     token_data.resize(seq_len);
   }
 
   // initialize tensor wrappers
-  ManagedTensor k_managed(k_data.data(), k_data.size(), kv_cache_shape, dtype);
-  ManagedTensor v_managed(v_data.data(), v_data.size(), kv_cache_shape, dtype);
-  ManagedTensor pos_managed(&pos, 0, {}, ScalarType::Long);
+  ManagedTensor pos_managed(
+      pos_data.data(), pos_data.size(), pos_shape, ScalarType::Long);
 
   // copy prompt tokens into data
   for (int i = 0; i <= pos; ++i) {
@@ -273,8 +262,6 @@ Error Runner::generate(
       input_shape[1] = 1;
       // inputs: [tokens, start_pos, k_cache, v_cache]
       inputs.emplace_back(pos_managed.get_aliasing_tensor());
-      inputs.emplace_back(k_managed.get_aliasing_tensor());
-      inputs.emplace_back(v_managed.get_aliasing_tensor());
     } else {
       // @lint-ignore CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
       token_data[pos] = token;
@@ -334,6 +321,9 @@ Error Runner::generate(
     }
     // ET_LOG(Info, "Output saved, next = %d", next);
     pos++;
+    if (use_kv_cache_) {
+      pos_data[0] = pos;
+    }
 
     // print the token as string, decode it with the Tokenizer object
     auto piece_res = tokenizer_->decode(token, next);
@@ -361,17 +351,6 @@ Error Runner::generate(
 
     token = next;
 
-    if (use_kv_cache_) {
-      // outputs: [k_cache, v_cache, logits, k_cache, v_cache]
-      memcpy(
-          k_data.data(),
-          outputs.at(k_cache_index).toTensor().const_data_ptr(),
-          k_data.size());
-      memcpy(
-          v_data.data(),
-          outputs.at(v_cache_index).toTensor().const_data_ptr(),
-          v_data.size());
-    }
   }
   timers_.inference_end_ms = util::time_in_ms();
   printf("\n");


### PR DESCRIPTION
Differential Revision: D55159979


Test command line:

dummy weight:
```
python3 -m examples.apple.coreml.scripts.export --model_name llama2
```

Stories110M (weight downloaded from https://github.com/karpathy/llama2.c?tab=readme-ov-file#models, tokenizer the same as llama7b)
```
python3 -m examples.apple.coreml.scripts.export --model_name llama2 --checkpoint /Users/chenlai/Documents/stories110M/stories110M.pt  --params /Users/chenlai/Documents/stories110M/params.json
```

Use partitioner:
```
python3 -m examples.apple.coreml.scripts.export --model_name llama2 --use_partitioner
```