### PR TITLE
Only add copy_ if necessary for correctness

### DIFF
--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -177,15 +177,6 @@ class LlamaEdgeManager:
             logging.info(f"model.to {torch_dtype}")
             self.model = self.model.to(dtype=torch_dtype)
             self.dtype = dtype_override
-
-        # convert kv cache to dtype as well. This should be removed after mutable buffer is supported.
-        # assuming the kv cache are the last 2 tensors in the example inputs
-        if self.use_kv_cache:
-            dtype = torch.float16 if self.dtype == DType.fp16 else torch.float32
-            example_inputs = list(self.example_inputs[:-2]) + [
-                cache.to(dtype) for cache in self.example_inputs[-2:]
-            ]
-            self.example_inputs = tuple(example_inputs)
         return self
 
     def source_transform(
@@ -207,11 +198,11 @@ class LlamaEdgeManager:
         return self
 
     def _get_dynamic_shape(self) -> Optional[Dict[str, Any]]:
-        if self.use_kv_cache:
-            return None
         dim = torch.export.Dim("token_dim", max=self.model.params.max_seq_len - 1)
-        dynamic_shape = {"tokens": {1: dim}}
-        return dynamic_shape
+        if self.use_kv_cache:
+            return {"tokens": {1: dim}, "input_pos": {0: dim}}
+        else:
+            return {"tokens": {1: dim}}
 
     def _get_edge_config(self) -> EdgeCompileConfig:
         edge_config = EdgeCompileConfig(

--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -200,7 +200,10 @@ class LlamaEdgeManager:
     def _get_dynamic_shape(self) -> Optional[Dict[str, Any]]:
         dim = torch.export.Dim("token_dim", max=self.model.params.max_seq_len - 1)
         if self.use_kv_cache:
-            return {"tokens": {1: dim}, "input_pos": {0: dim}}
+            if self.use_sdpa_with_kv_cache:
+                return None
+            else:
+                return {"tokens": {1: dim}, "input_pos": {0: dim}}
         else:
             return {"tokens": {1: dim}}
 

--- a/examples/models/llama2/custom_ops/custom_ops.yaml
+++ b/examples/models/llama2/custom_ops/custom_ops.yaml
@@ -8,7 +8,7 @@
     - arg_meta: null
       kernel_name: torch::executor::flash_attention_kernel_out
 
-- func: llama::sdpa_with_kv_cache.out(Tensor query, Tensor key, Tensor value, Tensor key_cache, Tensor value_cache, int layer_id, int start_pos, int seq_len, Tensor? attn_mask=None, float drpout_p=0.0, bool is_causal=False, float? scale=None, *, Tensor(a!) out) -> Tensor(a!)
+- func: llama::sdpa_with_kv_cache.out(Tensor query, Tensor key, Tensor value, Tensor(a!) key_cache, Tensor(b!) value_cache, int start_pos, int seq_len, Tensor? attn_mask=None, float drpout_p=0.0, bool is_causal=False, float? scale=None, *, Tensor(c!) out) -> Tensor(c!)
   kernels:
     - arg_meta: null
       kernel_name: torch::executor::sdpa_with_kv_cache_out

--- a/examples/models/llama2/custom_ops/op_sdpa.cpp
+++ b/examples/models/llama2/custom_ops/op_sdpa.cpp
@@ -541,41 +541,34 @@ bool validate_flash_attention_args(
 bool validate_cache_params(
     const Tensor& k_cache,
     const Tensor& v_cache,
-    int64_t layer_id,
     int64_t start_pos,
     int64_t seq_length) {
   ET_LOG_MSG_AND_RETURN_IF_FALSE(
-      k_cache.dim() == 5, "kcache must be a 5D tensor");
+      k_cache.dim() == 4, "kcache must be a 4D tensor");
 
   ET_LOG_MSG_AND_RETURN_IF_FALSE(
-      v_cache.dim() == 5, "v_cache must be a 5D tensor");
+      v_cache.dim() == 4, "v_cache must be a 4D tensor");
 
   ET_LOG_MSG_AND_RETURN_IF_FALSE(
-      layer_id < k_cache.size(0), "layer_id must be less than kcache dim 0");
-
-  ET_LOG_MSG_AND_RETURN_IF_FALSE(
-      layer_id < v_cache.size(0), "layer_id must be less than vcache dim 0");
-
-  ET_LOG_MSG_AND_RETURN_IF_FALSE(
-      start_pos < k_cache.size(2),
+      start_pos < k_cache.size(1),
       "start_pos must be less than key cache at dim 1");
 
   ET_LOG_MSG_AND_RETURN_IF_FALSE(
-      start_pos < v_cache.size(2),
+      start_pos < v_cache.size(1),
       "start_pos must be less than value cache at dim 1");
 
   ET_LOG_MSG_AND_RETURN_IF_FALSE(
-      (start_pos + seq_length) < k_cache.size(2),
+      (start_pos + seq_length) < k_cache.size(1),
       "start_post + seq_length must be less than max seq length supported by key cache."
       "start pos: %" PRId64 ", seq_length: %" PRId64
       "."
       "key cache size: %zd",
       start_pos,
       seq_length,
-      k_cache.size(2));
+      k_cache.size(1));
 
   ET_LOG_MSG_AND_RETURN_IF_FALSE(
-      (start_pos + seq_length) < v_cache.size(2),
+      (start_pos + seq_length) < v_cache.size(1),
       "start_post + seq_length must be less than max seq length supported by key cache."
       "start pos: %" PRId64 ", seq_length: %" PRId64
       "."
@@ -600,14 +593,13 @@ bool validate_cache_params(
 void update_cache(
     const Tensor& projected_value,
     const Tensor& cache,
-    int64_t layer_id,
     int64_t start_pos,
     int64_t seq_length) {
   ET_CHECK_MSG(seq_length == 1, "seq_length must be 1");
   ET_CHECK_MSG(
       projected_value.size(0) == 1,
       "projected_value must have batch size of 1");
-  ET_CHECK_MSG(cache.size(1) == 1, "cache must have batch size of 1");
+  ET_CHECK_MSG(cache.size(0) == 1, "cache must have batch size of 1");
   ET_CHECK_MSG(
       is_default_dim_order(
           projected_value.dim_order().data(), projected_value.dim()),
@@ -619,10 +611,8 @@ void update_cache(
   ET_CHECK_MSG(cache_data, "cache data is null");
 
   auto strides = cache.strides();
-  exec_aten::StridesType layer_stride = strides[0];
-  exec_aten::StridesType seq_dim_stride = strides[2];
-  exec_aten::SizesType pos_offset =
-      layer_id * layer_stride + start_pos * seq_dim_stride;
+  exec_aten::StridesType seq_dim_stride = strides[1];
+  exec_aten::SizesType pos_offset = start_pos * seq_dim_stride;
   exec_aten::SizesType pos_offset_bytes =
       pos_offset * projected_value.element_size();
   exec_aten::SizesType num_bytes =
@@ -713,8 +703,6 @@ Tensor& flash_attention_kernel_out(
   @params[in]: key_cache: Cache of previous v_projected.
   Format [n_layers, batch size, max_seq_len, num heads, head dim]
   ....
-  @params[in] layer_id: which layer this call belongs to.
-  Used to updated appropriate entry of kv cache
   @params[in]: start_pos: sequence position
   @params[in]: seq_len: Seq length. e.g. seq_len dim of q_projected.
 */
@@ -723,9 +711,8 @@ Tensor& sdpa_with_kv_cache_out(
     const Tensor& q_projected,
     const Tensor& k_projected,
     const Tensor& v_projected,
-    const Tensor& key_cache,
-    const Tensor& value_cache,
-    const int64_t layer_id, // THis should be gone with buffer based impl
+    Tensor& key_cache,
+    Tensor& value_cache,
     const int64_t start_pos,
     const int64_t seq_len,
     const optional<Tensor>& attn_mask,
@@ -737,34 +724,31 @@ Tensor& sdpa_with_kv_cache_out(
   (void)ctx;
   ET_KERNEL_CHECK(
       ctx,
-      validate_cache_params(
-          key_cache, value_cache, layer_id, start_pos, seq_len),
+      validate_cache_params(key_cache, value_cache, start_pos, seq_len),
       InvalidArgument,
       output);
 
   ET_CHECK_MSG(q_projected.dim() == 4, "query must be a 4D tensor");
 
-  update_cache(k_projected, key_cache, layer_id, start_pos, seq_len);
-  update_cache(v_projected, value_cache, layer_id, start_pos, seq_len);
+  update_cache(k_projected, key_cache, start_pos, seq_len);
+  update_cache(v_projected, value_cache, start_pos, seq_len);
 
   auto q_seq_len = q_projected.size(1);
 
   std::array<exec_aten::DimOrderType, util::kKVDim> sliced_key_dim_order{
       0, 1, 2, 3};
   std::array<exec_aten::SizesType, util::kKVDim> sliced_key_sizes;
-  sliced_key_sizes[0] = key_cache.size(1);
+  sliced_key_sizes[0] = key_cache.size(0);
   sliced_key_sizes[1] = start_pos + seq_len; // key_cache.size(2);
-  sliced_key_sizes[2] = key_cache.size(3);
-  sliced_key_sizes[3] = key_cache.size(4);
+  sliced_key_sizes[2] = key_cache.size(2);
+  sliced_key_sizes[3] = key_cache.size(3);
   std::array<exec_aten::StridesType, util::kKVDim> sliced_key_strides;
   dim_order_to_stride_nocheck(
       sliced_key_sizes.data(),
       sliced_key_dim_order.data(),
       util::kKVDim,
       sliced_key_strides.data());
-  void* key_cache_data = reinterpret_cast<void*>(
-      reinterpret_cast<ptrdiff_t>(key_cache.mutable_data_ptr()) +
-      layer_id * key_cache.strides()[0] * key_cache.element_size());
+  void* key_cache_data = key_cache.mutable_data_ptr();
   TensorImpl k_impl = TensorImpl(
       key_cache.scalar_type(),
       util::kKVDim,
@@ -778,19 +762,17 @@ Tensor& sdpa_with_kv_cache_out(
   std::array<exec_aten::DimOrderType, util::kKVDim> sliced_value_dim_order{
       0, 1, 2, 3};
   std::array<exec_aten::SizesType, util::kKVDim> sliced_value_sizes;
-  sliced_value_sizes[0] = value_cache.size(1);
+  sliced_value_sizes[0] = value_cache.size(0);
   sliced_value_sizes[1] = start_pos + seq_len; // value_cache.size(2);
-  sliced_value_sizes[2] = value_cache.size(3);
-  sliced_value_sizes[3] = value_cache.size(4);
+  sliced_value_sizes[2] = value_cache.size(2);
+  sliced_value_sizes[3] = value_cache.size(3);
   std::array<exec_aten::StridesType, util::kKVDim> sliced_value_strides;
   dim_order_to_stride_nocheck(
       sliced_value_sizes.data(),
       sliced_value_dim_order.data(),
       util::kKVDim,
       sliced_value_strides.data());
-  void* value_cache_data = reinterpret_cast<void*>(
-      reinterpret_cast<ptrdiff_t>(value_cache.mutable_data_ptr()) +
-      layer_id * value_cache.strides()[0] * value_cache.element_size());
+  void* value_cache_data = value_cache.mutable_data_ptr();
   TensorImpl value_impl = TensorImpl(
       value_cache.scalar_type(),
       util::kKVDim,

--- a/examples/models/llama2/custom_ops/op_sdpa_with_kv_cache_test.cpp
+++ b/examples/models/llama2/custom_ops/op_sdpa_with_kv_cache_test.cpp
@@ -22,9 +22,8 @@ exec_aten::Tensor op_sdpa_with_kv_cache(
     const exec_aten::Tensor& query,
     const exec_aten::Tensor& key,
     const exec_aten::Tensor& value,
-    const exec_aten::Tensor& key_cache,
-    const exec_aten::Tensor& value_cache,
-    const int64_t layer_id,
+    exec_aten::Tensor& key_cache,
+    exec_aten::Tensor& value_cache,
     const int64_t start_pos,
     const int64_t seq_len,
     const exec_aten::optional<exec_aten::Tensor>& attn_mask,
@@ -40,7 +39,6 @@ exec_aten::Tensor op_sdpa_with_kv_cache(
       value,
       key_cache,
       value_cache,
-      layer_id,
       start_pos,
       seq_len,
       attn_mask,
@@ -57,15 +55,15 @@ SDPA with cache is equivalent of the following code
 # k cache, v cache = (num layers, batch size, max seq length, num heads, head
 dim) # attn_mask = [max seq length, max seq length]
 
-def sdpa_with_cache(q, k, v, k_cache, v_cache, layer_id, start_pos, attn_mask):
+def sdpa_with_cache(q, k, v, k_cache, v_cache, start_pos, attn_mask):
     attn_mask = attn_mask[start_pos].view((1, -1))
     q = q.transpose(1, 2)
-    k_cache[layer_id, :, start_pos] = k
-    v_cache[layer_id, :, start_pos] = v
+    k_cache[:, start_pos] = k
+    v_cache[:, start_pos] = v
     k = k.transpose(1, 2)
     v = v.transpose(1, 2)
-    sliced_k_cache = k_cache[layer_id]
-    sliced_v_cache = v_cache[layer_id]
+    sliced_k_cache = k_cache
+    sliced_v_cache = v_cache
     sliced_k_cache = sliced_k_cache.transpose(1, 2)
     sliced_v_cache = sliced_v_cache.transpose(1, 2)
     out = F.scaled_dot_product_attention(q, sliced_k_cache, sliced_v_cache,
@@ -141,8 +139,12 @@ TEST(OpScaledDotProductAttentionTest, BasicTest) {
        0.2814,
        0.7886,
        0.5895});
-  exec_aten::Tensor key_cache = tfFloat.zeros({3, 1, 5, 4, 4});
-  exec_aten::Tensor value_cache = tfFloat.zeros({3, 1, 5, 4, 4});
+  exec_aten::Tensor key_cache_0 = tfFloat.zeros({1, 5, 4, 4});
+  exec_aten::Tensor value_cache_0 = tfFloat.zeros({1, 5, 4, 4});
+  exec_aten::Tensor key_cache_1 = tfFloat.zeros({1, 5, 4, 4});
+  exec_aten::Tensor value_cache_1 = tfFloat.zeros({1, 5, 4, 4});
+  exec_aten::Tensor key_cache_2 = tfFloat.zeros({1, 5, 4, 4});
+  exec_aten::Tensor value_cache_2 = tfFloat.zeros({1, 5, 4, 4});
   exec_aten::optional<exec_aten::Tensor> attn_mask;
   double dropout_p = 0;
   bool is_causal = false;
@@ -174,9 +176,8 @@ TEST(OpScaledDotProductAttentionTest, BasicTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      0,
+      key_cache_0,
+      value_cache_0,
       0,
       1,
       attn_mask,
@@ -210,9 +211,8 @@ TEST(OpScaledDotProductAttentionTest, BasicTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      2,
+      key_cache_2,
+      value_cache_2,
       0,
       1,
       attn_mask,
@@ -246,9 +246,8 @@ TEST(OpScaledDotProductAttentionTest, BasicTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      0,
+      key_cache_0,
+      value_cache_0,
       1,
       1,
       attn_mask,
@@ -282,9 +281,8 @@ TEST(OpScaledDotProductAttentionTest, BasicTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      1,
+      key_cache_1,
+      value_cache_1,
       1,
       1,
       attn_mask,
@@ -318,9 +316,8 @@ TEST(OpScaledDotProductAttentionTest, BasicTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      1,
+      key_cache_1,
+      value_cache_1,
       2,
       1,
       attn_mask,
@@ -354,9 +351,8 @@ TEST(OpScaledDotProductAttentionTest, BasicTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      2,
+      key_cache_2,
+      value_cache_2,
       2,
       1,
       attn_mask,
@@ -385,8 +381,12 @@ TEST(OpScaledDotProductAttentionTest, LargerTest) {
                      0.3278, 0.6532, 0.3958, 0.9147, 0.2036, 0.2018, 0.2018,
                      0.9497, 0.6666, 0.9811, 0.0874, 0.0041, 0.1088, 0.1637,
                      0.7025, 0.6790, 0.9155, 0.2418, 0.1591, 0.7653, 0.2979});
-  exec_aten::Tensor key_cache = tfFloat.zeros({3, 1, 8, 7, 4});
-  exec_aten::Tensor value_cache = tfFloat.zeros({3, 1, 8, 7, 4});
+  exec_aten::Tensor key_cache_0 = tfFloat.zeros({1, 8, 7, 4});
+  exec_aten::Tensor value_cache_0 = tfFloat.zeros({1, 8, 7, 4});
+  exec_aten::Tensor key_cache_1 = tfFloat.zeros({1, 8, 7, 4});
+  exec_aten::Tensor value_cache_1 = tfFloat.zeros({1, 8, 7, 4});
+  exec_aten::Tensor key_cache_2 = tfFloat.zeros({1, 8, 7, 4});
+  exec_aten::Tensor value_cache_2 = tfFloat.zeros({1, 8, 7, 4});
   exec_aten::optional<exec_aten::Tensor> attn_mask;
   double dropout_p = 0;
   bool is_causal = false;
@@ -405,9 +405,8 @@ TEST(OpScaledDotProductAttentionTest, LargerTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      0,
+      key_cache_0,
+      value_cache_0,
       0,
       1,
       attn_mask,
@@ -428,9 +427,8 @@ TEST(OpScaledDotProductAttentionTest, LargerTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      2,
+      key_cache_2,
+      value_cache_2,
       0,
       1,
       attn_mask,
@@ -451,9 +449,8 @@ TEST(OpScaledDotProductAttentionTest, LargerTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      0,
+      key_cache_0,
+      value_cache_0,
       1,
       1,
       attn_mask,
@@ -474,9 +471,8 @@ TEST(OpScaledDotProductAttentionTest, LargerTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      1,
+      key_cache_1,
+      value_cache_1,
       1,
       1,
       attn_mask,
@@ -497,9 +493,8 @@ TEST(OpScaledDotProductAttentionTest, LargerTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      1,
+      key_cache_1,
+      value_cache_1,
       2,
       1,
       attn_mask,
@@ -520,9 +515,8 @@ TEST(OpScaledDotProductAttentionTest, LargerTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      2,
+      key_cache_2,
+      value_cache_2,
       2,
       1,
       attn_mask,
@@ -591,8 +585,12 @@ TEST(OpScaledDotProductAttentionTest, BasicTestWithAttnMask) {
        0.7886,
        0.5895});
   exec_aten::Tensor attn_mask = tfFloat.make({1, 1}, {0});
-  exec_aten::Tensor key_cache = tfFloat.zeros({3, 1, 5, 4, 4});
-  exec_aten::Tensor value_cache = tfFloat.zeros({3, 1, 5, 4, 4});
+  exec_aten::Tensor key_cache_0 = tfFloat.zeros({1, 5, 4, 4});
+  exec_aten::Tensor value_cache_0 = tfFloat.zeros({1, 5, 4, 4});
+  exec_aten::Tensor key_cache_1 = tfFloat.zeros({1, 5, 4, 4});
+  exec_aten::Tensor value_cache_1 = tfFloat.zeros({1, 5, 4, 4});
+  exec_aten::Tensor key_cache_2 = tfFloat.zeros({1, 5, 4, 4});
+  exec_aten::Tensor value_cache_2 = tfFloat.zeros({1, 5, 4, 4});
   double dropout_p = 0;
   bool is_causal = false;
   exec_aten::optional<double> scale;
@@ -623,9 +621,8 @@ TEST(OpScaledDotProductAttentionTest, BasicTestWithAttnMask) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      0,
+      key_cache_0,
+      value_cache_0,
       0,
       1,
       attn_mask,
@@ -659,9 +656,8 @@ TEST(OpScaledDotProductAttentionTest, BasicTestWithAttnMask) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      2,
+      key_cache_2,
+      value_cache_2,
       0,
       1,
       attn_mask,
@@ -696,9 +692,8 @@ TEST(OpScaledDotProductAttentionTest, BasicTestWithAttnMask) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      0,
+      key_cache_0,
+      value_cache_0,
       1,
       1,
       attn_mask,
@@ -732,9 +727,8 @@ TEST(OpScaledDotProductAttentionTest, BasicTestWithAttnMask) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      1,
+      key_cache_1,
+      value_cache_1,
       1,
       1,
       attn_mask,
@@ -769,9 +763,8 @@ TEST(OpScaledDotProductAttentionTest, BasicTestWithAttnMask) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      1,
+      key_cache_1,
+      value_cache_1,
       2,
       1,
       attn_mask,
@@ -805,9 +798,8 @@ TEST(OpScaledDotProductAttentionTest, BasicTestWithAttnMask) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      2,
+      key_cache_2,
+      value_cache_2,
       2,
       1,
       attn_mask,
@@ -840,8 +832,13 @@ TEST(OpScaledDotProductAttentionTest, SequenceTest) {
        0.0975, 0.8920, 0.5081, 0.6053, 0.2981, 0.2660, 0.5824, 0.6849,
        0.6121, 0.2590, 0.9854, 0.4264, 0.1938, 0.2661, 0.9922, 0.5000});
 
-  exec_aten::Tensor key_cache = tfFloat.zeros({3, 1, 5, 8, 4});
-  exec_aten::Tensor value_cache = tfFloat.zeros({3, 1, 5, 8, 4});
+  exec_aten::Tensor key_cache_0 = tfFloat.zeros({1, 5, 8, 4});
+  exec_aten::Tensor value_cache_0 = tfFloat.zeros({1, 5, 8, 4});
+  exec_aten::Tensor key_cache_1 = tfFloat.zeros({1, 5, 8, 4});
+  exec_aten::Tensor value_cache_1 = tfFloat.zeros({1, 5, 8, 4});
+  exec_aten::Tensor key_cache_2 = tfFloat.zeros({1, 5, 8, 4});
+  exec_aten::Tensor value_cache_2 = tfFloat.zeros({1, 5, 8, 4});
+
   exec_aten::optional<exec_aten::Tensor> attn_mask;
   double dropout_p = 0;
   bool is_causal = false;
@@ -861,9 +858,8 @@ TEST(OpScaledDotProductAttentionTest, SequenceTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      0,
+      key_cache_0,
+      value_cache_0,
       0,
       1,
       attn_mask,
@@ -903,9 +899,8 @@ TEST(OpScaledDotProductAttentionTest, SequenceTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      0,
+      key_cache_0,
+      value_cache_0,
       1,
       1,
       attn_mask,
@@ -945,9 +940,8 @@ TEST(OpScaledDotProductAttentionTest, SequenceTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      0,
+      key_cache_0,
+      value_cache_0,
       2,
       1,
       attn_mask,
@@ -987,9 +981,8 @@ TEST(OpScaledDotProductAttentionTest, SequenceTest) {
       query,
       key,
       value,
-      key_cache,
-      value_cache,
-      0,
+      key_cache_0,
+      value_cache_0,
       3,
       1,
       attn_mask,

--- a/examples/models/llama2/llama_transformer.py
+++ b/examples/models/llama2/llama_transformer.py
@@ -157,6 +157,31 @@ def apply_rotary_emb(
     return xq_out.type_as(xq), xk_out.type_as(xk)
 
 
+class KVCache(nn.Module):
+    def __init__(
+        self, max_batch_size, max_seq_length, n_heads, head_dim, dtype=torch.bfloat16
+    ):
+        super().__init__()
+        cache_shape = (max_batch_size, n_heads, max_seq_length, head_dim)
+        self.register_buffer(
+            "k_cache", torch.zeros(cache_shape, dtype=dtype, device="cpu")
+        )
+        self.register_buffer(
+            "v_cache", torch.zeros(cache_shape, dtype=dtype, device="cpu")
+        )
+
+    def update(self, input_pos, k_val, v_val):
+        # input_pos: [S], k_val: [B, H, S, D]
+        assert input_pos.shape[0] == k_val.shape[2]
+
+        k_out = self.k_cache
+        v_out = self.v_cache
+        k_out[:, :, input_pos] = k_val
+        v_out[:, :, input_pos] = v_val
+
+        return k_out, v_out
+
+
 class Attention(nn.Module):
     def __init__(self, args: ModelArgs, layer_id: int):
         super().__init__()
@@ -170,6 +195,7 @@ class Attention(nn.Module):
         self.head_dim = args.dim // args.n_heads
         self.max_batch_size = args.max_batch_size
         self.max_seq_len = args.max_seq_len
+        self.dim = args.dim
         # args.dim = 4096, args.n_heads = 32, self.head_dim = 4096 / 32 = 125
         self.wq = nn.Linear(args.dim, args.n_heads * self.head_dim, bias=False)
         self.wk = nn.Linear(args.dim, self.n_kv_heads * self.head_dim, bias=False)
@@ -179,111 +205,70 @@ class Attention(nn.Module):
         self.use_sdpa_with_kv_cache_op = args.use_sdpa_with_kv_cache_op
         self.layer_id = layer_id
 
-        mask = torch.full(
-            (1, 1, args.max_seq_len, args.max_seq_len),
-            float("-inf"),
-            device="cpu",
+        causal_mask = torch.tril(
+            torch.ones(
+                self.max_seq_len,
+                self.max_seq_len,
+                dtype=torch.bool,
+                device="cpu",
+            )
         )
+        self.register_buffer("mask", causal_mask, persistent=False)
 
-        mask = torch.triu(mask, diagonal=1)
-        self.register_buffer("mask", mask)
-
-        # This is what we would use if ExecuTorch could support mutable buffers. We can't at this time, so instead
-        # what is done is this module takes in the cache as io.
-        # self.cache_k = torch.zeros(
-        #     (args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
-        # )
-        # self.cache_v = torch.zeros(
-        #     (args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
-        # )
-        self.kv_cache_sizes = [
-            args.max_batch_size,
-            args.max_seq_len,
-            self.n_kv_heads,
-            self.head_dim,
-        ]
+        if self.use_kv_cache:
+            self.kv_cache = KVCache(
+                args.max_batch_size,
+                args.max_seq_len,
+                self.n_kv_heads,
+                self.head_dim,
+            )
 
     def forward(
         self,
         x: torch.Tensor,
         freqs_cos: torch.Tensor,
         freqs_sin: torch.Tensor,
-        start_pos: Optional[int] = None,
-        cache_k: Optional[torch.Tensor] = None,
-        # if use_sdpa_with_kv_cache_op
-        # shape: (num_layers, args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
-        # otherwise
-        # shape: (args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
-        cache_v: Optional[torch.Tensor] = None,
-        # if use_sdpa_with_kv_cache_op
-        # shape: (num_layers, args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
-        # otherwise
-        # shape: (args.max_batch_size, args.max_seq_len, self.n_kv_heads, self.head_dim)
+        input_pos: Optional[torch.Tensor] = None,
     ):
         bsz, seqlen, _ = x.shape
 
         # QKV
-        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+        q, k, v = self.wq(x), self.wk(x), self.wv(x)
         # We need view_copy elimination
-        xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
-        xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
-        xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+        q = q.view(bsz, seqlen, self.n_local_heads, self.head_dim)
+        k = k.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+        v = v.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
 
         # RoPE relative positional embeddings
-        xq, xk = apply_rotary_emb(xq, xk, freqs_cos, freqs_sin)
+        q, k = apply_rotary_emb(q, k, freqs_cos, freqs_sin)
+
+        q = q.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
 
         if self.use_kv_cache:
-            assert start_pos is not None
-            assert cache_k is not None and cache_v is not None
+            if not self.use_sdpa_with_kv_cache_op:
 
-            # TODO(T180671810)
-            # Refactor this code to make custom op based
-            # SDPA into a separate optimized attention module
-            if self.use_sdpa_with_kv_cache_op:
-                from .custom_ops.sdpa_with_kv_cache import sdpa_with_kv_cache  # noqa
+                k, v = self.kv_cache.update(input_pos, k, v)
+                mask = self.mask[None, None, input_pos]
 
-                output = torch.ops.llama.sdpa_with_kv_cache(
-                    xq,
-                    xk,
-                    xv,
-                    cache_k,
-                    cache_v,
-                    self.layer_id,
-                    start_pos,
-                    seqlen,
+                k = k.repeat_interleave(self.n_rep, dim=1)
+                v = v.repeat_interleave(self.n_rep, dim=1)
+                y = F.scaled_dot_product_attention(
+                    q, k, v, attn_mask=mask, dropout_p=0.0
                 )
-                output = output.view(bsz, seqlen, -1)
-                output = self.wo(output)
-                return output, cache_k, cache_v
-            else:
-                # Replace the entry in the cache for this token
-                # The following lines are equivalent to:
-                # cache_k[:bsz, start_pos : start_pos + seqlen] = xk
-                # cache_v[:bsz, start_pos : start_pos + seqlen] = xv
-                # We use .narrow() here to make the compiler happy
-                narrowed_k = cache_k[:bsz].narrow(1, start_pos, seqlen)
-                narrowed_v = cache_v[:bsz].narrow(1, start_pos, seqlen)
 
-                narrowed_k.copy_(xk)
-                narrowed_v.copy_(xv)
+                y = y.transpose(1, 2).contiguous().view(bsz, seqlen, self.dim)
 
-                keys = cache_k[:bsz].narrow(1, 0, start_pos + seqlen)
-                values = cache_v[:bsz].narrow(1, 0, start_pos + seqlen)
-        else:
-            keys = xk
-            values = xv
+                y = self.wo(y)
+                return y
 
         # grouped multiquery attention: expand out keys and values
-        keys = repeat_kv(keys, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
-        values = repeat_kv(values, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
-
-        # make heads into a batch dimension
-        xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
-        keys = keys.transpose(1, 2)
-        values = values.transpose(1, 2)
+        k = k.repeat_interleave(self.n_rep, dim=1)
+        v = v.repeat_interleave(self.n_rep, dim=1)
 
         assert hasattr(self, "mask")
-        mask = self.mask[:, :, :seqlen, :seqlen]
+        mask = self.mask[:seqlen, :seqlen]
 
         # this is needed to support xnnpack which requires mask shape to be 2d.
         # this is a temporary workaround. once we update xnnpack we should be able to handle this.
@@ -292,18 +277,13 @@ class Attention(nn.Module):
         # tensor will be 2-dimensional, regarldess of the values of l & s
         mask = torch.squeeze(mask, [0, 1])
 
-        output = F.scaled_dot_product_attention(
-            xq, keys, values, attn_mask=mask, dropout_p=0.0
-        )
+        output = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, dropout_p=0.0)
 
         output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
 
         output = self.wo(output)
 
-        if self.use_kv_cache:
-            return output, cache_k, cache_v
-        else:
-            return output, None, None
+        return output
 
 
 class FeedForward(nn.Module):
@@ -388,16 +368,9 @@ class TransformerBlock(nn.Module):
         self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
         self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
 
-    def forward(
-        self, x, freqs_cos, freqs_sin, start_pos=None, cache_k=None, cache_v=None
-    ):  # x: 1xN
-        h, cache_k, cache_v = self.attention.forward(
-            self.attention_norm(x),
-            freqs_cos,
-            freqs_sin,
-            start_pos,
-            cache_k,
-            cache_v,
+    def forward(self, x, freqs_cos, freqs_sin, input_pos=None):  # x: 1xN
+        h = self.attention.forward(
+            self.attention_norm(x), freqs_cos, freqs_sin, input_pos
         )
 
         h = x + h
@@ -405,7 +378,7 @@ class TransformerBlock(nn.Module):
             out = h + self.block_sparse_moe(self.ffn_norm(h))
         else:
             out = h + self.feed_forward(self.ffn_norm(h))
-        return out, cache_k, cache_v
+        return out
 
 
 class Transformer(nn.Module):
@@ -434,87 +407,35 @@ class Transformer(nn.Module):
     def forward(
         self,
         tokens: torch.Tensor,
-        start_pos: Optional[
+        input_pos: Optional[
             torch.Tensor
         ] = None,  # Scalar tensor indicating size of window of the caches
-        cache_k: Optional[
-            torch.Tensor
-        ] = None,  # n_layers long, it should be a list of tensors to accommodate the potential size difference among attention layers. The current implementation is overly simplified.
-        cache_v: Optional[torch.Tensor] = None,  # n_layers long
-    ) -> Union[
-        torch.Tensor, Tuple[torch.Tensor, List[torch.Tensor], List[torch.Tensor]]
-    ]:
+    ) -> torch.Tensor:
         _bsz, seqlen = tokens.shape
         h = self.tok_embeddings(tokens)
 
         if self.use_kv_cache:
             assert (
-                cache_k is not None and cache_v is not None and start_pos is not None
-            ), "Caches and start_pos must be provided when use_kv_cache is True"
-            assert (
-                cache_k.size(0) == self.n_layers
-            ), f"{cache_k.size(0)} != {self.n_layers}"
-            assert (
-                cache_v.size(0) == self.n_layers
-            ), f"{cache_v.size(0)} != {self.n_layers}"
+                input_pos is not None
+            ), "input_pos must be provided when use_kv_cache is True"
 
-            sp = start_pos.item()
-            # self.params.max_seq_len - 1 because of 0 based indexing, and - 1 again because our input seq len is 1 and its added to the cache before accessing the cache
-            torch._constrain_as_size(sp, min=0, max=self.params.max_seq_len - 2)
-            torch._constrain_as_value(
-                cache_k.shape[0],
-                max=self.n_layers,
-                min=self.n_layers,
-            )
-            torch._constrain_as_value(
-                cache_v.shape[0], min=self.n_layers, max=self.n_layers
-            )
             # when KV cache is used, seqlen is most likely 1. We want to slice from the start_pos.
-            freqs_cos = self.freqs_cos[sp : sp + seqlen]
-            freqs_sin = self.freqs_sin[sp : sp + seqlen]
+            freqs_cos = self.freqs_cos[input_pos]
+            freqs_sin = self.freqs_sin[input_pos]
         else:
-            # assert (
-            #     start_pos is None and cache_k is None and cache_v is None
-            # ), "Caches and start_pos are unused when use_kv_cache is False"
+            assert input_pos is None, "input_pos is unused when use_kv_cache is False"
             freqs_cos = self.freqs_cos[:seqlen]
             freqs_sin = self.freqs_sin[:seqlen]
 
-        for index, layer in enumerate(self.layers):
-            if self.use_kv_cache:
-                if self.params.use_sdpa_with_kv_cache_op:
-                    h, updated_cache_k, updated_cache_v = layer(
-                        h,
-                        freqs_cos,
-                        freqs_sin,
-                        sp,  # pyre-ignore[61]
-                        cache_k,
-                        cache_v,
-                    )
-                else:
-                    h, updated_cache_k, updated_cache_v = layer(
-                        h,
-                        freqs_cos,
-                        freqs_sin,
-                        sp,  # pyre-ignore[61]
-                        cache_k[index],  # pyre-ignore[16]
-                        cache_v[index],
-                    )
-                    cache_k[index] = updated_cache_k  # pyre-ignore[16]
-                    cache_v[index] = updated_cache_v
-
-            else:
-                h, _, _ = layer(h, freqs_cos, freqs_sin)
+        for layer in self.layers:
+            h = layer(
+                h,
+                freqs_cos,
+                freqs_sin,
+                input_pos,
+            )
 
         h = self.norm(h)
 
         logits = self.output(h)
-        if self.use_kv_cache:
-            return (logits, cache_k, cache_v)  # pyre-ignore
-        else:
-            # 'None' is not a valid return for export so have to split the return into if else
-            return logits
-
-    # For each layer return the sizes of the needed caches
-    def get_cache_sizes(self):
-        # cache_k and cache_v have the same shape so could pick either here.
-        return [self.n_layers, *self.layers[0].attention.kv_cache_sizes]
+        return logits

--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -179,16 +179,11 @@ the checkpoint format to avoid generating faulty models.
             )
 
     def get_example_inputs_kvcache(self):
-        cache_sizes = self.model_.get_cache_sizes()
-        cache_k = torch.zeros(cache_sizes, dtype=self.dtype)
-        cache_v = torch.zeros(cache_sizes, dtype=self.dtype)
         return (
             torch.tensor(
-                [[1]], dtype=torch.long
+                [[1, 2, 3]], dtype=torch.long
             ),  # tokens, with kv cache our input token length is always just 1 token.
             torch.tensor(
-                0, dtype=torch.long
+                [0, 1, 2], dtype=torch.long
             ),  # start_pos, what token of output are we on.
-            cache_k,  # key caches
-            cache_v,  # value caches
         )

--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -170,13 +170,27 @@ the checkpoint format to avoid generating faulty models.
 
     def get_example_inputs(self):
         if self.use_kv_cache:
-            return self.get_example_inputs_kvcache()
+            if self.use_sdpa_with_kv_cache_op:
+                return self.get_example_inputs_kvcache_sdpa()
+            else:
+                return self.get_example_inputs_kvcache()
         else:
             return (
                 torch.tensor(
                     [[1, 2, 3]], dtype=torch.long
                 ),  # tokens, with kv cache our input token length is always just 1 token.
             )
+
+    # assumption is the custom op doesnt support dynamic shape right now. It might but its untested so lets first get static shape working
+    def get_example_inputs_kvcache_sdpa(self):
+        return (
+            torch.tensor(
+                [[1]], dtype=torch.long
+            ),  # tokens, with kv cache our input token length is always just 1 token.
+            torch.tensor(
+                [0], dtype=torch.long
+            ),  # start_pos, what token of output are we on.)
+        )
 
     def get_example_inputs_kvcache(self):
         return (

--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -210,25 +210,18 @@ Error Runner::generate(
   int v_cache_index = 0;
   std::vector<exec_aten::SizesType> kv_cache_shape = getKVCacheShape();
   std::vector<exec_aten::SizesType> input_shape = {1, 1};
-  std::vector<exec_aten::SizesType> pos_shape = {};
+  std::vector<exec_aten::SizesType> pos_shape = {1};
   std::vector<uint8_t> k_data;
   std::vector<uint8_t> v_data;
   std::vector<int64_t> token_data; // allocate space for the tokens
+  std::vector<int64_t> pos_data; // allocate space for the tokens
   ScalarType dtype = static_cast<ScalarType>(
       getMetadataHelper("get_dtype", (int64_t)ScalarType::Float));
 
   if (use_kv_cache_) {
     // set pos to 0, refill token by token
     pos = 0;
-    logits_index = 2;
-    k_cache_index = 0;
-    v_cache_index = 1;
-    // TODO(): Fix this by inspecting graph signature
-    if (use_sdpa_with_kv_cache_) {
-      logits_index = 0;
-      k_cache_index = 1;
-      v_cache_index = 2;
-    }
+    logits_index = 0;
     // initialize kv cache
     size_t n_bytes = 1;
     for (exec_aten::SizesType shape : kv_cache_shape) {
@@ -236,20 +229,16 @@ Error Runner::generate(
     }
     n_bytes *= torch::executor::elementSize(dtype);
 
-    k_data.resize(n_bytes);
-    std::fill(k_data.begin(), k_data.end(), 0);
-    v_data.resize(n_bytes);
-    std::fill(v_data.begin(), v_data.end(), 0);
     token_data.resize(1);
+    pos_data.resize(seq_len);
   } else {
     // reserve data for tokens, notice the size is still 0.
     token_data.resize(seq_len);
   }
 
   // initialize tensor wrappers
-  ManagedTensor k_managed(k_data.data(), k_data.size(), kv_cache_shape, dtype);
-  ManagedTensor v_managed(v_data.data(), v_data.size(), kv_cache_shape, dtype);
-  ManagedTensor pos_managed(&pos, 0, {}, ScalarType::Long);
+  ManagedTensor pos_managed(
+      pos_data.data(), pos_data.size(), pos_shape, ScalarType::Long);
 
   // copy prompt tokens into data
   for (int i = 0; i <= pos; ++i) {
@@ -273,8 +262,6 @@ Error Runner::generate(
       input_shape[1] = 1;
       // inputs: [tokens, start_pos, k_cache, v_cache]
       inputs.emplace_back(pos_managed.get_aliasing_tensor());
-      inputs.emplace_back(k_managed.get_aliasing_tensor());
-      inputs.emplace_back(v_managed.get_aliasing_tensor());
     } else {
       // @lint-ignore CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
       token_data[pos] = token;
@@ -334,6 +321,9 @@ Error Runner::generate(
     }
     // ET_LOG(Info, "Output saved, next = %d", next);
     pos++;
+    if (use_kv_cache_) {
+      pos_data[0] = pos;
+    }
 
     // print the token as string, decode it with the Tokenizer object
     auto piece_res = tokenizer_->decode(token, next);
@@ -360,18 +350,6 @@ Error Runner::generate(
     }
 
     token = next;
-
-    if (use_kv_cache_) {
-      // outputs: [k_cache, v_cache, logits, k_cache, v_cache]
-      memcpy(
-          k_data.data(),
-          outputs.at(k_cache_index).toTensor().const_data_ptr(),
-          k_data.size());
-      memcpy(
-          v_data.data(),
-          outputs.at(v_cache_index).toTensor().const_data_ptr(),
-          v_data.size());
-    }
   }
   timers_.inference_end_ms = util::time_in_ms();
   printf("\n");

--- a/examples/models/llama2/runner/targets.bzl
+++ b/examples/models/llama2/runner/targets.bzl
@@ -2,7 +2,7 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 def _get_operator_lib(aten = False):
     if aten:
-        return ["//executorch/kernels/portable:generated_lib_aten"]
+        return ["//executorch/kernels/aten:generated_lib_aten"]
     elif runtime.is_oss:
         return ["//executorch/kernels/portable:generated_lib"]
     else:

--- a/exir/passes/insert_write_back_for_buffers_pass.py
+++ b/exir/passes/insert_write_back_for_buffers_pass.py
@@ -88,12 +88,6 @@ def insert_write_back_for_buffers_pass(
         for in_spec in ep.graph_signature.input_specs
     ]
 
-    # Grab the mutable buffer nodes in the outputs
-    mutated_outputs: List[Optional[str]] = [
-        out_spec.target if out_spec.kind in (OutputKind.BUFFER_MUTATION,) else None
-        for out_spec in ep.graph_signature.output_specs
-    ]
-
     input_name_to_node: Dict[str, torch.fx.Node] = {}
 
     placeholder_nodes = [node for node in gm.graph.nodes if node.op == "placeholder"]
@@ -102,6 +96,20 @@ def insert_write_back_for_buffers_pass(
     for input_node, lifted_node in zip(placeholder_nodes, lifted_inputs):
         if lifted_node is not None:
             input_name_to_node[lifted_node] = input_node
+
+    # Grab the mutable buffer nodes in the outputs,
+    mutated_outputs: List[Optional[str]] = [
+        (
+            out_spec.target
+            if out_spec.kind in (OutputKind.BUFFER_MUTATION,)
+            and out_spec.arg.name
+            not in [
+                val.name for val in input_name_to_node.values()
+            ]  # if the output arg is the input value then all operations on it are in-place so theres no need to add a copy_ node
+            else None
+        )
+        for out_spec in ep.graph_signature.output_specs
+    ]
 
     # insert the copy ops and update the outputs
     buffer_output_nodes = _insert_copy(gm, mutated_outputs, input_name_to_node)

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -44,6 +44,9 @@ from executorch.exir.verification.verifier import (
 )
 from torch._export.passes import ReplaceViewOpsWithViewCopyOpsPass
 from torch.export import ExportedProgram
+from torch.export._remove_auto_functionalized_pass import (
+    unsafe_remove_auto_functionalized_pass,
+)
 from torch.export.exported_program import (
     _get_updated_range_constraints,
     ConstantArgument,
@@ -832,6 +835,7 @@ class EdgeProgramManager:
 
         execution_programs: Dict[str, ExportedProgram] = {}
         for name, program in self._edge_programs.items():
+            program = unsafe_remove_auto_functionalized_pass(program)
             gm, new_signature = insert_write_back_for_buffers_pass(program)
             new_gm = program.graph_module
             for p in edge_to_executorch_passes(config):
@@ -927,6 +931,7 @@ class ExecutorchProgramManager:
             delegate_alignment=backend_config.delegate_alignment,
         )
         self._buffer: Optional[bytes] = None
+        self.dump_executorch_program(True)
 
     @property
     def methods(self) -> Set[str]:

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -931,7 +931,6 @@ class ExecutorchProgramManager:
             delegate_alignment=backend_config.delegate_alignment,
         )
         self._buffer: Optional[bytes] = None
-        self.dump_executorch_program(True)
 
     @property
     def methods(self) -> Set[str]:


### PR DESCRIPTION
Summary: If the output is the exact same variable as the input then all operations on it in the graph must be in place so dont bother adding a copy_ since it would be x.copy_(x) which is useless.

Differential Revision: D55172554
