### PR TITLE
Fallback to deepcopy when fake program fails

### DIFF
--- a/exir/backend/backend_api.py
+++ b/exir/backend/backend_api.py
@@ -351,8 +351,10 @@ def _(
     # Fall back to deepcopy if no fake mode is found. TODO(T182910699): Remove this fallback.
     try:
         fake_edge_program = get_fake_program(edge_program)
-    except AssertionError as e:
-        logging.warning(f"No fake mode found for {edge_program.graph_module}: {e}")
+    except Exception as e:
+        logging.warning(
+            f"Error in get_fake_program for graph {edge_program.graph_module}, fallback to deepcopy: {e}"
+        )
         fake_edge_program = copy.deepcopy(edge_program)
     partitioner_result = partitioner_instance(fake_edge_program)
     tagged_exported_program = partitioner_result.tagged_exported_program


### PR DESCRIPTION
Summary: Catch the general Exception case, not only AssertionError.

Differential Revision: D55204315


