### PR TITLE
preserve is fine in our ops

### DIFF
--- a/kernels/portable/cpu/op_full_like.cpp
+++ b/kernels/portable/cpu/op_full_like.cpp
@@ -27,7 +27,8 @@ Tensor& full_like_out(
   if (memory_format.has_value()) {
     ET_KERNEL_CHECK_MSG(
         ctx,
-        memory_format.value() == MemoryFormat::Contiguous,
+        memory_format.value() == MemoryFormat::Contiguous ||
+            memory_format.value() == MemoryFormat::Preserve,
         InvalidArgument,
         out,
         "memory_format must be contiguous");


### PR DESCRIPTION
Summary: hit this when trying to run llama. Preserve should be fine since our input mem format is contiguous already.

Reviewed By: SS-JIA

Differential Revision: D55215189


