### PR TITLE
Rename int4 to 8da4w in llama2 quantization

### DIFF
--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -142,8 +142,8 @@ the checkpoint format to avoid generating faulty models.
 
             simple_quantizer = WeightOnlyInt8QuantHandler(self.model_)
             self.model_ = simple_quantizer.convert_for_runtime()
-        elif "int4" in str(checkpoint_path):
-            print("Using int4 weight-only quantization!")
+        elif "8da4w" in str(checkpoint_path):
+            print("Using int4 weight and int8 dynamic activation quantization!")
             from .quantize import Int8DynActInt4WeightQuantHandler
 
             simple_quantizer = Int8DynActInt4WeightQuantHandler(self.model_)


### PR DESCRIPTION
Summary:
int4 has been confused with "int4 weight only" before, when
in reality it is "int4 weights + int8 dynamic activations".
Renaming it to "8da4w" will reduce confusion and make it
more consistent with "8da4w-gptq".

Differential Revision: D55215146


