### PR TITLE
[ET-VK][EZ] Clean up max_pool2d

### DIFF
--- a/backends/vulkan/runtime/graph/ops/ExecuteNode.h
+++ b/backends/vulkan/runtime/graph/ops/ExecuteNode.h
@@ -77,7 +77,6 @@ class ExecuteNode final {
   const api::utils::uvec3 global_workgroup_size_;
   const api::utils::uvec3 local_workgroup_size_;
   const std::vector<ArgGroup> args_;
-  // TODO(T180906457): allow re-computing param buffers.
   std::vector<std::shared_ptr<api::UniformParamsBuffer>> params_;
   const ResizeFunction resize_fn_;
   const std::vector<ValueRef> resize_args_;

--- a/backends/vulkan/runtime/graph/ops/glsl/max_pool2d.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/max_pool2d.glsl
@@ -30,7 +30,7 @@ layout(set = 0, binding = 4) uniform PRECISION restrict InExtents {
 in_extents;
 
 layout(set = 0, binding = 5) uniform PRECISION restrict Params {
-  ivec2 kernel;
+  ivec2 kernel_size;
   ivec2 stride;
   ivec2 padding;
   ivec2 dilation;
@@ -49,7 +49,7 @@ void main() {
   const ivec2 ipos = pos.xy * params.stride - params.padding;
 
   const ivec2 start = ipos;
-  const ivec2 end = ipos + params.kernel * params.dilation;
+  const ivec2 end = ipos + params.kernel_size * params.dilation;
 
   vec4 out_texel = vec4(FLT_MIN);
   ivec4 idx_texel = ivec4(0);
@@ -65,9 +65,6 @@ void main() {
         idx_texel = ivec4(mix(idx_texel, cur_idx, mask));
 
         out_texel = max(cur_texel, out_texel);
-      }
-      else {
-        out_texel = max(vec4(FLT_MIN), out_texel);
       }
     }
   }

--- a/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.cpp
@@ -28,13 +28,9 @@ int64_t calc_out_size(
   return out_size;
 }
 
-api::utils::ivec2 normalize_wh(Value& v) {
-  if (v.isInt()) {
-    return api::utils::make_ivec2({v.toInt(), v.toInt()});
-  } else {
-    auto l = v.toIntList();
-    return api::utils::make_ivec2({l.at(1), l.at(0)});
-  }
+api::utils::ivec2 reverse(ComputeGraph& graph, ValueRef vref) {
+  return api::utils::make_ivec2(
+      graph.get_val(vref).toIntList(), /*reverse=*/true);
 }
 
 } // namespace vulkan

--- a/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.h
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.h
@@ -12,6 +12,8 @@
 
 #include <ATen/native/vulkan/api/api.h>
 
+#include <executorch/backends/vulkan/runtime/graph/ComputeGraph.h>
+
 #include <executorch/backends/vulkan/runtime/graph/containers/Value.h>
 
 namespace at {
@@ -19,7 +21,7 @@ namespace native {
 namespace vulkan {
 
 struct KernelParams final {
-  api::utils::ivec2 kernel;
+  api::utils::ivec2 kernel_size;
   api::utils::ivec2 stride;
   api::utils::ivec2 padding;
   api::utils::ivec2 dilation;
@@ -27,13 +29,13 @@ struct KernelParams final {
 
 int64_t calc_out_size(
     const int64_t in_size,
-    const int64_t kernel,
+    const int64_t kernel_size,
     const int64_t stride,
     const int64_t padding,
     const int64_t dilation,
     const bool ceil_mode);
 
-api::utils::ivec2 normalize_wh(Value& v);
+api::utils::ivec2 reverse(ComputeGraph& graph, ValueRef vref);
 
 } // namespace vulkan
 } // namespace native


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2575

In anticipation of convolution, I noticed some nits in the max_pool2d implementation:
1. Removed unneeded shader branch.
2. Renamed `kernel` to `kernel_size`.
3. Removed `Int` to `IntList` normalization since this is already performed by the compiler, so the serialized graph will always have `IntList`. The fact that the Python tests still pass when they specify `Int` for `padding=0` and `dilation=1` affirms this. Renamed the helper function appropriately and improve readability.

Differential Revision: [D55220203](https://our.internmc.facebook.com/intern/diff/D55220203/)