### PR TITLE
Add some gptq related args to quantize function

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -327,12 +327,6 @@ def build_args_parser() -> argparse.ArgumentParser:
         help="checkpoint path",
     )
     parser.add_argument(
-        "-g",
-        "--group_size",
-        default=256,
-        help="Group size for weight quantization",
-    )
-    parser.add_argument(
         "--calibration_tasks",
         nargs="+",
         type=str,
@@ -401,7 +395,7 @@ def build_args_parser() -> argparse.ArgumentParser:
         default=None,
         help="Use cProfile to profile model export. Results saved to profile_path as a html file.",
     )
-    parser.add_argument("-G", "--groupsize", default=None, help="specify the groupsize")
+    parser.add_argument("-G", "--group_size", default=None, help="specify the group_size")
 
     parser.add_argument(
         "-d",

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -335,7 +335,7 @@ def build_args_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--calibration_limit",
         type=int,
-        default=100,
+        default=5,
         help="number of samples used for calibration",
     )
     parser.add_argument(

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -226,7 +226,6 @@ def quantize(
     Returns:
         A quantized model.
     """
-    print(group_size, calibration_tasks, calibration_limit, calibration_seq_length)
     if activation_dtype is not None:
         torch_dtype = activation_dtype.to_torch_dtype()
     else:
@@ -395,7 +394,9 @@ def build_args_parser() -> argparse.ArgumentParser:
         default=None,
         help="Use cProfile to profile model export. Results saved to profile_path as a html file.",
     )
-    parser.add_argument("-G", "--group_size", default=None, help="specify the group_size")
+    parser.add_argument(
+        "-G", "--group_size", default=None, help="group_size for weight quantization"
+    )
 
     parser.add_argument(
         "-d",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2577

Summary:

Test Plan:
Manully verified locally that the args passed through to quantize function
`python3 -m examples.models.llama2.export_llama -c stories110M.pt -p params.json -qmode 8da4w-gptq -X -d fp32 -G 2568 --calibration_tasks wikitext fads --calibration_seq_length 1288 --calibration_limit 5123`
Reviewers:

Subscribers:

Tasks:

Tags: