### PR TITLE
ET Core shouldn't depend on torchao experimental repo

### DIFF
--- a/exir/passes/_quant_patterns_and_replacements.py
+++ b/exir/passes/_quant_patterns_and_replacements.py
@@ -14,8 +14,7 @@ from executorch.exir.passes.replace_aten_with_edge_pass import (
     should_lower_to_edge,
 )
 from torch import fx
-from torchao.quantization.quant_primitives import quantized_decomposed_lib
-
+from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib
 
 __all__ = [
     "get_quant_patterns_and_replacements",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies=[
   "sympy",
   "tabulate",
   "tomli",
-  "torchao-nightly",
   "zstd",
 ]
 


### PR DESCRIPTION
Summary: Examples can depend on it but ET Core shouldn't

Differential Revision: D55227758


