### PR TITLE
allow dummy_llama2 script to take real checkpoint/params

### DIFF
--- a/examples/qualcomm/scripts/dummy_llama2.py
+++ b/examples/qualcomm/scripts/dummy_llama2.py
@@ -72,12 +72,34 @@ if __name__ == "__main__":
         default="8a8w",
     )
 
+    parser.add_argument(
+        "--checkpoint",
+        help="Pass llama2 checkpoint.",
+        default=False,
+    )
+
+    parser.add_argument(
+        "--params",
+        help="Pass llama2 params json file.",
+        default=False,
+    )
+
     args = parser.parse_args()
 
     # ensure the working directory exist.
     os.makedirs(args.artifact, exist_ok=True)
 
-    instance = Llama2Model(use_kv_cache=args.use_kv_cache)
+    if args.params and args.checkpoint:
+        instance = Llama2Model(
+            use_kv_cache=args.use_kv_cache,
+            checkpoint=args.checkpoint,
+            params=args.params,
+        )
+    else:
+        instance = Llama2Model(
+            use_kv_cache=args.use_kv_cache,
+        )
+
     inputs, input_list = create_device_inputs(
         instance.get_example_inputs(), args.use_kv_cache
     )


### PR DESCRIPTION
Summary:
In this way we can pass the checkpoint/params to the script

```
python3.10 dummy_llama2.py -b artifact/ -m SM8650 --checkpoint /home/chenlai/qualcomm/meta-llama-mldemos-examples/models/stories110M/stories110M.pt --params /home/chenlai/qualcomm/meta-llama-mldemos-examples/models/stories110M/params.json
```

Differential Revision: D55172497


