### PR TITLE
Build CPUBLAS as a separate CMake target

### DIFF
--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -20,6 +20,19 @@
 # It should also be cmake-lint clean.
 #
 
+# Platform-specific definitions.
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+  set(arm64 ON)
+else()
+  set(arm64 OFF)
+endif()
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+    set(x86 ON)
+else()
+    set(x86 OFF)
+endif()
+
 # Public function to print summary for all configurations. For new variables,
 # it's recommended to add them here.
 function(executorch_print_configuration_summary)
@@ -32,6 +45,8 @@ function(executorch_print_configuration_summary)
   message(STATUS "  BUCK2                         : ${BUCK2}")
   message(STATUS "  PYTHON_EXECUTABLE             : ${PYTHON_EXECUTABLE}")
   message(STATUS "  FLATC_EXECUTABLE              : ${FLATC_EXECUTABLE}")
+  message(STATUS "  X86                           : ${x86}")
+  message(STATUS "  ARM64                         : ${arm64}")
   message(
     STATUS "  EXECUTORCH_ENABLE_LOGGING     : ${EXECUTORCH_ENABLE_LOGGING}")
   message(

--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -56,6 +56,8 @@ excludes = [
   # Exclude the codegen templates, which are picked up because the buck target
   # is the generated_lib and not the unwrapped set of kernels.
   "^codegen/templates",
+  # Exclude blas, since it's built as a separate target.
+  "^kernels/optimized/blas",
 ]
 deps = [
   "executorch",
@@ -83,6 +85,19 @@ buck_targets = [
 ]
 filters = [
   ".fbs$",
+]
+
+[targets.optimized_cpublas]
+buck_targets = [
+  "//kernels/optimized:libblas",
+]
+filters = [
+  ".cpp$",
+]
+excludes = [
+]
+deps = [
+  "executorch",
 ]
 
 # ---------------------------------- core end ----------------------------------

--- a/kernels/optimized/CMakeLists.txt
+++ b/kernels/optimized/CMakeLists.txt
@@ -30,8 +30,23 @@ endif()
 
 set(_common_compile_options -Wno-deprecated-declarations)
 
+# Set platform-specific definitions.
+if(arm64)
+  list(APPEND _common_compile_options -DET_BUILD_WITH_BLAS)
+elseif(x86)
+  # TODO(T183193812) Enable once sleef is built in OSS.
+  # list(APPEND _common_compile_options -DCPU_CAPABILITY_AVX2)
+endif()
+
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
+
+# Build cpublas.
+list(TRANSFORM _optimized_cpublas__srcs PREPEND "${EXECUTORCH_ROOT}/")
+add_library(cpublas ${_optimized_cpublas__srcs})
+target_link_libraries(cpublas PRIVATE executorch)
+target_compile_options(cpublas PUBLIC ${_common_compile_options})
+
 
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in optimized.yaml
@@ -44,7 +59,7 @@ message("Generated files ${gen_command_sources}")
 
 list(TRANSFORM _optimized_kernels__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(optimized_kernels ${_optimized_kernels__srcs})
-target_link_libraries(optimized_kernels PRIVATE executorch)
+target_link_libraries(optimized_kernels PRIVATE executorch cpublas)
 target_compile_options(optimized_kernels PUBLIC ${_common_compile_options})
 # Build a library for _optimized_kernels_srcs
 #


### PR DESCRIPTION
Split out CPUBLAS build from optimized kernel to promote reuse.