### PR TITLE
[xnnpack_backend][cmake] fix xnn executor runner cmake

### DIFF
--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -100,7 +100,7 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
   #
   list(TRANSFORM _xnn_executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
   add_executable(xnn_executor_runner ${_xnn_executor_runner__srcs})
-  target_link_libraries(xnn_executor_runner xnnpack_backend gflags)
+  target_link_libraries(xnn_executor_runner xnnpack_backend gflags portable_ops_lib)
   target_compile_options(xnn_executor_runner PUBLIC ${_common_compile_options})
 endif()
 

--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -100,7 +100,8 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
   #
   list(TRANSFORM _xnn_executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
   add_executable(xnn_executor_runner ${_xnn_executor_runner__srcs})
-  target_link_libraries(xnn_executor_runner xnnpack_backend gflags portable_ops_lib)
+  target_link_libraries(xnn_executor_runner
+                        xnnpack_backend gflags portable_ops_lib)
   target_compile_options(xnn_executor_runner PUBLIC ${_common_compile_options})
 endif()
 


### PR DESCRIPTION
the xnnpack backend's cmake refactor lost the portable_ops_lib for xnn_executor_runner so adding it back in this diff

