### PR TITLE
Automatically download buck2 when not provided

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,10 +170,6 @@ option(EXECUTORCH_BUILD_XNNPACK "Build the XNNPACK backend" OFF)
 
 option(EXECUTORCH_BUILD_VULKAN "Build the Vulkan backend" OFF)
 
-if(NOT BUCK2)
-  set(BUCK2 buck2)
-endif()
-
 if(NOT PYTHON_EXECUTABLE)
   set(PYTHON_EXECUTABLE python3)
 endif()
@@ -189,6 +185,9 @@ set(_common_include_directories ${CMAKE_CURRENT_SOURCE_DIR}/..)
 #
 
 if(NOT EXECUTORCH_SRCS_FILE)
+  # Find or download buck2 binary.
+  resolve_buck2()
+
   # A file wasn't provided. Run a script to extract the source lists from the
   # buck2 build system and write them to a file we can include.
   #

--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -135,15 +135,16 @@ function(extract_sources sources_file)
     else()
       set(executorch_root ${CMAKE_CURRENT_SOURCE_DIR})
     endif()
+
     execute_process(
-      COMMAND
-        ${PYTHON_EXECUTABLE} ${executorch_root}/build/extract_sources.py
-        --buck2=${BUCK2} --config=${executorch_root}/build/cmake_deps.toml
-        --out=${sources_file}
+      COMMAND ${PYTHON_EXECUTABLE} ${executorch_root}/build/extract_sources.py
+      --config=${executorch_root}/build/cmake_deps.toml --out=${sources_file}
+      --buck2=${BUCK2}
       OUTPUT_VARIABLE gen_srcs_output
       ERROR_VARIABLE gen_srcs_error
       RESULT_VARIABLE gen_srcs_exit_code
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
     if(NOT gen_srcs_exit_code EQUAL 0)
       message("Error while generating ${sources_file}. "
               "Exit code: ${gen_srcs_exit_code}")
@@ -152,4 +153,48 @@ function(extract_sources sources_file)
       message(FATAL_ERROR "executorch: source list generation failed")
     endif()
   endif()
+endfunction()
+
+# Sets the value of the BUCK2 variable by searching for a buck2 binary
+# with the correct version.
+#
+# The resolve_buck.py script uses the following logic to find buck2:
+#  1) If BUCK2 argument is set explicitly, use it. Warn if the version is
+#     incorrect.
+#  2) Look for a binary named buck2 on the system path. Take it if it is
+#     the correct version.
+#  3) Check for a previously downloaded buck2 binary (from step 4).
+#  4) Download and cache correct version of buck2.
+function(resolve_buck2)
+  if(EXECUTORCH_ROOT)
+    set(executorch_root ${EXECUTORCH_ROOT})
+  else()
+    set(executorch_root ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+
+  set(resolve_buck2_command
+    ${PYTHON_EXECUTABLE} ${executorch_root}/build/resolve_buck.py
+    --cache_dir=${CMAKE_CURRENT_BINARY_DIR}/buck2-bin)
+
+  if(NOT ${BUCK2} STREQUAL "")
+    list(APPEND resolve_buck2_command --buck2=${BUCK2})
+  endif()
+
+  execute_process(
+    COMMAND ${resolve_buck2_command}
+    OUTPUT_VARIABLE resolve_buck2_output
+    ERROR_VARIABLE resolve_buck2_error
+    RESULT_VARIABLE resolve_buck2_exit_code
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(resolve_buck2_exit_code EQUAL 0)
+      set(BUCK2 ${resolve_buck2_output} PARENT_SCOPE)
+      message(STATUS "Resolved buck2 as ${resolve_buck2_output}.")
+    else()
+      # Wrong buck version used. Stop here to ensure that the user sees
+      # the error.
+      message(FATAL_ERROR "Failed to resolve buck2.")
+      message(FATAL_ERROR ${resolve_buck2_error})
+    endif()
 endfunction()

--- a/build/__init__.py
+++ b/build/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/build/buck_util.py
+++ b/build/buck_util.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import subprocess
+import sys
+
+from typing import Optional, Sequence
+
+
+# Run buck2 from the same directory (and thus repo) as this script.
+BUCK_CWD: str = os.path.dirname(os.path.realpath(__file__))
+
+
+class Buck2Runner:
+    def __init__(self, tool_path: str) -> None:
+        self._path = tool_path
+
+    def run(self, args: Sequence[str]) -> list[str]:
+        """Runs buck2 with the given args and returns its stdout as a sequence of lines."""
+        try:
+            cp: subprocess.CompletedProcess = subprocess.run(
+                [self._path] + args, capture_output=True, cwd=BUCK_CWD, check=True
+            )
+            return [line.strip().decode("utf-8") for line in cp.stdout.splitlines()]
+        except subprocess.CalledProcessError as ex:
+            raise RuntimeError(ex.stderr.decode("utf-8")) from ex
+
+
+def get_buck2_version(path: str) -> Optional[str]:
+    try:
+        runner = Buck2Runner(path)
+        output = runner.run(["--version"])
+
+        # Example output:
+        # buck2 38f7c508bf1b87bcdc816bf56d1b9f2d2411c6be <build-id>
+        #
+        # We want the second value.
+
+        return output[0].split()[1]
+
+    except Exception as e:
+        print(f"Failed to retrieve buck2 version: {e}.", file=sys.stderr)
+        return None

--- a/build/extract_sources.py
+++ b/build/extract_sources.py
@@ -9,10 +9,11 @@ import argparse
 import copy
 import os
 import re
-import subprocess
 
 from enum import Enum
 from typing import Any, Optional, Sequence
+
+from buck_util import Buck2Runner
 
 try:
     import tomllib  # Standard in 3.11 and later
@@ -64,24 +65,6 @@ Example config:
     ".cpp$",
     ]
 """
-
-# Run buck2 from the same directory (and thus repo) as this script.
-BUCK_CWD: str = os.path.dirname(os.path.realpath(__file__))
-
-
-class Buck2Runner:
-    def __init__(self, tool_path: str) -> None:
-        self._path = tool_path
-
-    def run(self, args: Sequence[str]) -> list[str]:
-        """Runs buck2 with the given args and returns its stdout as a sequence of lines."""
-        try:
-            cp: subprocess.CompletedProcess = subprocess.run(
-                [self._path] + args, capture_output=True, cwd=BUCK_CWD, check=True
-            )
-            return [line.strip().decode("utf-8") for line in cp.stdout.splitlines()]
-        except subprocess.CalledProcessError as ex:
-            raise RuntimeError(ex.stderr.decode("utf-8")) from ex
 
 
 class Target:

--- a/build/resolve_buck.py
+++ b/build/resolve_buck.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+import platform
+import stat
+import sys
+import tempfile
+import urllib.request
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence, Union
+
+import buck_util
+import zstd
+
+"""
+Locate or download the version of buck2 needed to build ExecuTorch.
+It is intended to be invoked from the CMake build logic, and it returns
+the path to 'buck2' via stdout. Log messages are written to stderr.
+
+It uses the following logic, in order of precedence, to locate or download
+buck2:
+
+ 1) If BUCK2 argument is set explicitly, use it. Warn if the version is
+    incorrect.
+ 2) Look for a binary named buck2 on the system path. Take it if it is
+    the correct version.
+ 3) Check for a previously downloaded buck2 binary (from step 4).
+ 4) Download and cache correct version of buck2.
+
+"""
+
+# Path to the file containing BUCK2 version (build date) for ExecuTorch.
+# Note that this path is relative to this script file, not the working
+# directory.
+BUCK_VERSION_FILE = "../.ci/docker/ci_commit_pins/buck2.txt"
+
+
+@dataclass
+class BuckInfo:
+    archive_name: str
+    target_versions: Sequence[str]
+
+
+# Mapping of os family and architecture to buck2 binary versions. The
+# target version is the hash given by running 'buck2 --version'. The
+# archive name is the archive file name to download, as seen under
+# https://github.com/facebook/buck2/releases/.
+#
+# To add or update versions, download the appropriate version of buck2
+# and run 'buck2 --version'. Add the corresponding entry to the platform
+# map below, and if adding new os families or architectures, update the
+# platform detection logic in resolve_buck2().
+#
+# Some platforms (linux) provide multiple binaries (GNU and MUSL). All
+# versions in the list are accepted when validating a user-provided or
+# system buck2.
+BUCK_PLATFORM_MAP = {
+    ("linux", "x86_64"): BuckInfo(
+        archive_name="buck2-x86_64-unknown-linux-musl.zst",
+        target_versions=[
+            # MUSL
+            "071372cfde6e9936c62eb92823742392af4a945570df5c5b34d3eed1b03813c3",
+            # GNU
+            "38f7c508bf1b87bcdc816bf56d1b9f2d2411c6be",
+        ],
+    ),
+    ("darwin", "aarch64"): BuckInfo(
+        archive_name="buck2-aarch64-apple-darwin.zst",
+        target_versions=["99e407b49dc432eda0cbddd67ea78346"],
+    ),
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Locates or downloads the appropriate version of buck2.",
+    )
+    parser.add_argument(
+        "--buck2",
+        default="",
+        help="Optional user-provided 'buck2' path. If provided, it will be "
+        "used. If the version is incorrect, a warning will be logged.",
+    )
+    parser.add_argument(
+        "--cache_dir",
+        help="Directory to cache downloaded versions of buck2.",
+    )
+    return parser.parse_args()
+
+
+# Returns the path to buck2 on success or a return code on failure.
+def resolve_buck2(args: argparse.Namespace) -> Union[str, int]:
+    # Find buck2, in order of priority:
+    #  1) Explicit buck2 argument.
+    #  2) System buck2 (if correct version).
+    #  3) Cached buck2 (previously downloaded).
+    #  3) Download buck2.
+
+    # Read the target version (build date) from the CI pin file. Note that
+    # this path is resolved relative to the directory containing this script.
+    script_dir = os.path.dirname(__file__)
+    version_file_path = Path(script_dir) / BUCK_VERSION_FILE
+    with open(version_file_path.absolute().as_posix()) as f:
+        target_buck_version = f.read().strip()
+
+    # Determine the target buck2 version string according to the current
+    # platform. If the platform isn't linux or darwin, we won't perform
+    # any version validation.
+    machine = platform.machine().lower()
+    arch = "unknown"
+    if machine == "x86" or machine == "x86_64" or machine == "amd64":
+        arch = "x86_64"
+    elif machine == "arm64":
+        arch = "aarch64"
+
+    os_family = "unknown"
+    if sys.platform.startswith("linux"):
+        os_family = "linux"
+    elif sys.platform.startswith("darwin"):
+        os_family = "darwin"
+
+    platform_key = (os_family, arch)
+    if platform_key not in BUCK_PLATFORM_MAP:
+        print(
+            f"Unknown platform {platform_key}. Buck2 binary must be downloaded manually.",
+            file=sys.stderr,
+        )
+        return args.buck2 or "buck2"
+
+    buck_info = BUCK_PLATFORM_MAP[platform_key]
+
+    if args.buck2:
+        # If we have an explicit buck2 arg, check the version and fail if
+        # there is a mismatch.
+        ver = buck_util.get_buck2_version(args.buck2)
+        if ver in buck_info.target_versions:
+            return args.buck2
+        else:
+            print(
+                f'The provided buck2 binary "{args.buck2}" reports version '
+                f'"{ver}", but ExecuTorch needs version '
+                f'"{buck_info.target_versions[0]}". Ensure that the correct buck2'
+                " version is installed or avoid explicitly passing the BUCK2 "
+                "version to automatically download the correct version.",
+                file=sys.stderr,
+            )
+
+            # Return an error, since the build will fail later. This lets us
+            # give the user a more useful error message.
+            return -1
+    else:
+        # Look for system buck2 and check version. Note that this can return
+        # None.
+        ver = buck_util.get_buck2_version("buck2")
+        if ver in buck_info.target_versions:
+            # Use system buck2.
+            return "buck2"
+        else:
+            # Download buck2 or used previously cached download.
+            cache_dir = Path(args.cache_dir)
+            os.makedirs(cache_dir, exist_ok=True)
+
+            buck2_local_path = (
+                (cache_dir / f"buck2-{buck_info.target_versions[0]}")
+                .absolute()
+                .as_posix()
+            )
+
+            # Check for a previously cached buck2 binary. The filename includes
+            # the version hash, so we don't have to worry about using an
+            # outdated binary, in the event that the target version is updated.
+            if os.path.isfile(buck2_local_path):
+                return buck2_local_path
+
+            buck2_archive_url = f"https://github.com/facebook/buck2/releases/download/{target_buck_version}/{buck_info.archive_name}"
+
+            with tempfile.NamedTemporaryFile() as archive_file:
+                print(f"Downloading buck2 from {buck2_archive_url}...", file=sys.stderr)
+                urllib.request.urlretrieve(buck2_archive_url, archive_file.name)
+
+                # Extract and chmod.
+                with open(archive_file.name, "rb") as f:
+                    data = f.read()
+                    decompressed_bytes = zstd.decompress(data)
+
+                with open(buck2_local_path, "wb") as f:
+                    f.write(decompressed_bytes)
+
+                file_stat = os.stat(buck2_local_path)
+                os.chmod(buck2_local_path, file_stat.st_mode | stat.S_IEXEC)
+
+            return buck2_local_path
+
+
+def main():
+    args = parse_args()
+    resolved_path_or_error = resolve_buck2(args)
+    if isinstance(resolved_path_or_error, str):
+        print(resolved_path_or_error)
+    else:
+        sys.exit(resolved_path_or_error)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Resolve buck2, in order of precedence:

1) Use explicitly provided buck2 path (via -DBUCK2). Warn if version is incorrect.
2) Check system buck2. Use if version is correct.
3) Look for a cached (previously downloaded) buck2 binary.
3) Download and cache buck2.

Test Plan:

Repeated on x86_64 linux and m1 mac.

Build with explicit buck2 (correct version). Confirm that provided buck is used without warning.
Build with explicit buck2 (wrong version). Confirm that warning is shown.
Build without explicit buck (system buck wrong version). Confirm that buck is downloaded and cached. Build succeeds.
Build without explicit buck (system buck correct version). Confirm that buck is downloaded and cached. Build succeeds.
Build without explicit buck (no system buck). Confirm that buck is downloaded and cached. Build succeeds.