### PR TITLE
Back out "Qualcomm AI Engine Direct - Fixed the bug in dummy_llama2 script"

### DIFF
--- a/examples/qualcomm/scripts/dummy_llama2.py
+++ b/examples/qualcomm/scripts/dummy_llama2.py
@@ -7,7 +7,6 @@
 import json
 import os
 import re
-import sys
 from multiprocessing.connection import Client
 
 import numpy as np
@@ -72,6 +71,20 @@ if __name__ == "__main__":
         default="8a8w",
     )
 
+    # QNN_SDK_ROOT might also be an argument, but it is used in various places.
+    # So maybe it's fine to just use the environment.
+    if "QNN_SDK_ROOT" not in os.environ:
+        raise RuntimeError("Environment variable QNN_SDK_ROOT must be set")
+    print(f"QNN_SDK_ROOT={os.getenv('QNN_SDK_ROOT')}")
+
+    if "LD_LIBRARY_PATH" not in os.environ:
+        print(
+            "[Warning] LD_LIBRARY_PATH is not set. If errors like libQnnHtp.so "
+            "not found happen, please follow setup.md to set environment."
+        )
+    else:
+        print(f"LD_LIBRARY_PATH={os.getenv('LD_LIBRARY_PATH')}")
+
     args = parser.parse_args()
 
     # ensure the working directory exist.
@@ -107,10 +120,6 @@ if __name__ == "__main__":
         custom_annotations=(),
         quant_dtype=quant_dtype,
     )
-
-    if args.compile_only:
-        sys.exit(0)
-
     adb = SimpleADB(
         qnn_sdk=os.getenv("QNN_SDK_ROOT"),
         artifact_path=f"{args.build_folder}",


### PR DESCRIPTION
Summary:
```
2024-03-22T22:34:06.3076009Z   /tmp/tmp7zi48ffq/data.json:1: 44891: error: cannot parse value starting with: -
2024-03-22T22:34:06.3076537Z 
2024-03-22T22:34:06.3076667Z Traceback (most recent call last):
2024-03-22T22:34:06.3077777Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/executorch/exir/_serialize/_flatbuffer.py", line 288, in _program_json_to_flatbuffer
2024-03-22T22:34:06.3078876Z     _flatc_compile(temp_dir, schema_info.root_path, json_path)
2024-03-22T22:34:06.3080025Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/executorch/exir/_serialize/_flatbuffer.py", line 211, in _flatc_compile
2024-03-22T22:34:06.3080939Z     _run_flatc(
2024-03-22T22:34:06.3081823Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/executorch/exir/_serialize/_flatbuffer.py", line 197, in _run_flatc
2024-03-22T22:34:06.3082829Z     subprocess.run([flatc_path] + list(args), check=True)
2024-03-22T22:34:06.3083537Z   File "/opt/conda/envs/py_3.10/lib/python3.10/subprocess.py", line 526, in run
2024-03-22T22:34:06.3084228Z     raise CalledProcessError(retcode, process.args,
2024-03-22T22:34:06.3085692Z subprocess.CalledProcessError: Command '['flatc', '--binary', '-o', '/tmp/tmp7zi48ffq', '/tmp/tmp7zi48ffq/program.fbs', '/tmp/tmp7zi48ffq/data.json']' returned non-zero exit status 1.
2024-03-22T22:34:06.3086733Z 
```
The issue is not directly caused by the original diff/pr, it just triggers a bug. The bug is an known issue tracked in T182299196. This the feature landed in the original diff is needed by alpha, T182299196 is the blocker. Otherwise, we should backout the diff to restore the CI.
----------------------










Original commit changeset: cc11560b3022

Original Phabricator Diff: D55248247

Differential Revision: D55283970


