### PR TITLE
pytest - add e2e python tests for XNNPACK

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts =
     # show summary of all tests that did not pass
-    -rEfX
+    -rA
     # Make tracebacks shorter
     --tb=native
     # capture only Python print and C++ py::print, but not C output (low-level Python errors)
@@ -36,6 +36,8 @@ addopts =
     kernels/test/test_case_gen.py
     # backends/arm
     backends/arm/test
+    # backends/xnnpack (linear only)
+    backends/xnnpack/operators/op_linear.py
     # test
     test/end2end/test_end2end.py
 


### PR DESCRIPTION
Summary: Only ops and not the models since they are covered with examples/models

Differential Revision: D55299312


