### PR TITLE
add is_xplat to env_interface

### DIFF
--- a/shim/xplat/executorch/build/env_interface.bzl
+++ b/shim/xplat/executorch/build/env_interface.bzl
@@ -215,6 +215,7 @@ env = struct(
     # @lint-ignore BUCKLINT: native and fb_native are explicitly forbidden in fbcode.
     genrule = native.genrule,
     is_oss = True,
+    is_xplat = False,
     patch_deps = _patch_deps,
     patch_cxx_compiler_flags = _patch_cxx_compiler_flags,
     patch_executorch_genrule_cmd = _patch_executorch_genrule_cmd,

--- a/shim/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim/xplat/executorch/build/runtime_wrapper.bzl
@@ -29,6 +29,9 @@ use TARGETS files normally. Same for xplat-only directories and BUCK files.
 load(":env_interface.bzl", "env")
 load(":selects.bzl", "selects")
 
+def is_xplat():
+    return env.is_xplat()
+
 def struct_to_json(x):
     return env.struct_to_json(struct(**x))
 

--- a/shim/xplat/executorch/kernels/test/util.bzl
+++ b/shim/xplat/executorch/kernels/test/util.bzl
@@ -1,5 +1,4 @@
-load("@fbsource//tools/build_defs:fbsource_utils.bzl", "is_xplat")
-load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "is_xplat", "runtime")
 
 def op_test(name, deps = [], kernel_name = "portable", use_kernel_prefix = False):
     """Defines a cxx_test() for an "op_*_test.cpp" file.


### PR DESCRIPTION
Summary:
`fbcode/executorch/kernels/test/util.bzl` is included in shim now. 

Remove the dependency on `fbsource//tools/build_defs:fbsource_utils.bzl`, so we can reference the file in OSS Cmake build. 

Specifically, required for: https://github.com/pytorch/executorch/pull/2633

Differential Revision: D55300977


