### PR TITLE
Cleanup dependencies for the runner.

### DIFF
--- a/examples/models/llama2/runner/targets.bzl
+++ b/examples/models/llama2/runner/targets.bzl
@@ -35,7 +35,6 @@ def define_common_targets():
                 "//executorch/extension/runner_util:managed_tensor" + aten_suffix,
                 "//executorch/extension/module:module" + aten_suffix,
                 "//executorch/kernels/quantized:generated_lib" + aten_suffix,
-                "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
             ] + (_get_operator_lib(aten)) + ([
                 # Vulkan API currently cannot build on some platforms (e.g. Apple, FBCODE)
                 # Therefore enable it explicitly for now to avoid failing tests

--- a/examples/models/llama2/tokenizer/targets.bzl
+++ b/examples/models/llama2/tokenizer/targets.bzl
@@ -11,7 +11,7 @@ def define_common_targets():
         ],
         exported_deps = [
             "//executorch/runtime/core/exec_aten:lib",
-            "//executorch/runtime/kernel:kernel_includes",
+            "//executorch/runtime/core/exec_aten/util:scalar_type_util",
         ],
         visibility = [
             "@EXECUTORCH_CLIENTS",

--- a/examples/models/llama2/tokenizer/tokenizer.h
+++ b/examples/models/llama2/tokenizer/tokenizer.h
@@ -19,8 +19,8 @@
 
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 #include <executorch/runtime/core/result.h>
-#include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
 namespace executor {


### PR DESCRIPTION
Summary: Some of the currently used deps are either coming transitevely or are not part of what we distribute on iOS, and aren't actually needed, since only a specific subset is used.

Differential Revision: D55317712


