### PR TITLE
fix export dynamic shapes key error

### DIFF
--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -12,7 +12,7 @@ import json
 import logging
 from enum import Enum
 from json import JSONDecodeError
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, List, Optional
 
 import torch
 from executorch.backends.transforms.duplicate_dynamic_quant_chain import (
@@ -199,16 +199,16 @@ class LlamaEdgeManager:
             logging.info(f"Applied source transforms: {self.applied_source_transforms}")
         return self
 
-    def _get_dynamic_shape(self) -> Optional[Dict[str, Any]]:
+    def _get_dynamic_shape(self) -> Any:
         dim = torch.export.Dim("token_dim", max=self.model.params.max_seq_len - 1)
         if self.use_kv_cache:
             if self.use_sdpa_with_kv_cache:
                 return None
             else:
-                # return {"tokens": {1: dim}, "input_pos": {0: dim}} TODO update xnnpack to be able to handle dynamic shape kv cache
+                # return {1: dim}, {0: dim}} TODO update xnnpack to be able to handle dynamic shape kv cache
                 return None
         else:
-            return {"tokens": {1: dim}}
+            return ({1: dim},)
 
     def _get_edge_config(self) -> EdgeCompileConfig:
         edge_config = EdgeCompileConfig(


### PR DESCRIPTION
Summary: Patch to fix internal ci Not sure why this error is being thrown. Using a dict should be fine and passes in other places. switching to list is also fine here so doing that to unblock ci in the meantime

Differential Revision: D55331712


