### PR TITLE
Disable internal fp16 llama unittest

### DIFF
--- a/backends/xnnpack/test/models/llama2_et_example.py
+++ b/backends/xnnpack/test/models/llama2_et_example.py
@@ -16,6 +16,7 @@ class TestLlama2ETExample(unittest.TestCase):
     def test_f32(self):
         self._test()
 
+    @unittest.skip("T183420542: Add proper fp16 support.")
     def test_f16(self):
         self._test(torch.float16)
 


### PR DESCRIPTION
Summary:
Something non-xnnpack is falling on to portable and it is failing to handle it.

```
[op_scalar_tensor.cpp:33] In function operator()(), assert failed (false): Unhandled dtype Half for scalar_tensor.out
```

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: JacobSzwejbka

Differential Revision: D55332891


