### PR TITLE
Mark quantized ops depend on portable ops to avoid duplicated symbols error.

### DIFF
--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -75,6 +75,7 @@ excludes = [
 ]
 deps = [
   "executorch",
+  "portable_kernels",
 ]
 
 [targets.program_schema]


### PR DESCRIPTION
Summary: .

Differential Revision: D55338954


