### PR TITLE
Mark optimized ops depend on portable ops to avoid duplicated symbols error.

### DIFF
--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -59,6 +59,7 @@ excludes = [
 ]
 deps = [
   "executorch",
+  "portable_kernels",
 ]
 
 [targets.quantized_kernels]


### PR DESCRIPTION
Summary: bypass-github-export-checks

Differential Revision: D55341186


