### PR TITLE
[gh-pages] Create a new 0.2 docs directory

### DIFF
--- a/0.2/index.html
+++ b/0.2/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome to the ExecuTorch Documentation &mdash; ExecuTorch  documentation</title>
+  <link rel="shortcut icon" href="_static/ExecuTorch-Logo-cropped.svg"/>
+</head>
+
+v0.2.0 placeholder

--- a/versions.html
+++ b/versions.html
@@ -20,6 +20,9 @@
           <a class="reference internal" href="main/">main (unstable)</a>
         </li>
         <li class="toctree-l1">
+          <a class="reference internal" href="0.2">0.2 (stable release)</a>
+        </li>
+        <li class="toctree-l1">
           <a class="reference internal" href="0.1">0.1 (stable release)</a>
         </li>
       </ul>


### PR DESCRIPTION
Create a new directory for the 0.2 release, with a placeholder file to make the directory non-empty. This will be overwritten once the 0.2.0 release branch is active.

Add a new entry to versions.html that points to the new release.

Once 0.2 is stable, we will need to update the `stable` symlink to point to `0.2`.