### PR TITLE
Make docs build use the install pip package

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,9 +25,8 @@ import sys
 
 import pytorch_sphinx_theme
 
+# To let us import ./custom_directives.py
 sys.path.insert(0, os.path.abspath("."))
-sys.path.insert(0, os.path.abspath("../../.."))
-sys.path.insert(0, os.path.abspath("../.."))
 # -- Project information -----------------------------------------------------
 
 project = "ExecuTorch"
@@ -43,8 +42,6 @@ author = "ExecuTorch Contributors"
 
 import os
 import sys
-
-sys.path.insert(0, os.path.abspath("../../"))
 
 extensions = [
     "breathe",

--- a/docs/source/export-to-executorch-api-reference.rst
+++ b/docs/source/export-to-executorch-api-reference.rst
@@ -1,7 +1,7 @@
 Export to ExecuTorch API Reference
 ----------------------------------
 
-.. automodule:: exir
+.. automodule:: executorch.exir
 .. autofunction:: to_edge
 
 .. autoclass:: EdgeProgramManager
@@ -10,7 +10,7 @@ Export to ExecuTorch API Reference
 .. autoclass:: ExecutorchProgramManager
     :members: methods, config_methods, exported_program, buffer, debug_handle_map, dump_executorch_program
 
-.. automodule:: exir.backend.backend_api
+.. automodule:: executorch.exir.backend.backend_api
 .. autofunction:: to_backend
 
 .. autoclass:: LoweredBackendModule

--- a/docs/source/sdk-bundled-io.md
+++ b/docs/source/sdk-bundled-io.md
@@ -26,7 +26,7 @@ In `BundledProgram`, we create two new classes, `MethodTestCase` and `MethodTest
 :::{dropdown} `MethodTestCase`
 
 ```{eval-rst}
-.. autofunction:: bundled_program.config.MethodTestCase.__init__
+.. autofunction:: executorch.sdk.bundled_program.config.MethodTestCase.__init__
     :noindex:
 ```
 :::
@@ -34,7 +34,7 @@ In `BundledProgram`, we create two new classes, `MethodTestCase` and `MethodTest
 :::{dropdown} `MethodTestSuite`
 
 ```{eval-rst}
-.. autofunction:: bundled_program.config.MethodTestSuite
+.. autofunction:: executorch.sdk.bundled_program.config.MethodTestSuite
     :noindex:
 ```
 :::
@@ -49,7 +49,7 @@ We provide `create_bundled_program` API under `executorch/sdk/bundled_program/co
 :::{dropdown} `BundledProgram`
 
 ```{eval-rst}
-.. currentmodule:: bundled_program.core
+.. currentmodule:: executorch.sdk.bundled_program.core
 .. autofunction:: create_bundled_program
     :noindex:
 ```
@@ -66,13 +66,13 @@ To serialize `BundledProgram` to make runtime APIs use it, we provide two APIs, 
 :::{dropdown} Serialize and Deserialize
 
 ```{eval-rst}
-.. currentmodule:: bundled_program.serialize
+.. currentmodule:: executorch.sdk.bundled_program.serialize
 .. autofunction:: serialize_from_bundled_program_to_flatbuffer
     :noindex:
 ```
 
 ```{eval-rst}
-.. currentmodule:: bundled_program.serialize
+.. currentmodule:: executorch.sdk.bundled_program.serialize
 .. autofunction:: deserialize_from_flatbuffer_to_bundled_program
     :noindex:
 ```

--- a/docs/source/sdk-etrecord.rst
+++ b/docs/source/sdk-etrecord.rst
@@ -31,7 +31,7 @@ they are interested in working with via our tooling.
 .. warning::
     Users should do a deepcopy of the output of to_edge() and pass in the deepcopy to the generate_etrecord API. This is needed because the subsequent call, to_executorch(), does an in-place mutation and will lose debug data in the process.
 
-.. currentmodule:: sdk.etrecord._etrecord
+.. currentmodule:: executorch.sdk.etrecord._etrecord
 .. autofunction:: generate_etrecord
 
 Using an ``ETRecord``

--- a/docs/source/sdk-inspector.rst
+++ b/docs/source/sdk-inspector.rst
@@ -26,7 +26,7 @@ Inspector Methods
 Constructor
 ~~~~~~~~~~~
 
-.. autofunction:: sdk.Inspector.__init__
+.. autofunction:: executorch.sdk.Inspector.__init__
 
 **Example Usage:**
 
@@ -39,13 +39,13 @@ Constructor
 to_dataframe
 ~~~~~~~~~~~~~~~~
 
-.. autofunction:: sdk.Inspector.to_dataframe
+.. autofunction:: executorch.sdk.Inspector.to_dataframe
 
 
 print_data_tabular
 ~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: sdk.Inspector.print_data_tabular
+.. autofunction:: executorch.sdk.Inspector.print_data_tabular
 
 .. _example-usage-1:
 
@@ -61,7 +61,7 @@ print_data_tabular
 find_total_for_module
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: sdk.Inspector.find_total_for_module
+.. autofunction:: executorch.sdk.Inspector.find_total_for_module
 
 .. _example-usage-2:
 
@@ -79,7 +79,7 @@ find_total_for_module
 get_exported_program
 ~~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: sdk.Inspector.get_exported_program
+.. autofunction:: executorch.sdk.Inspector.get_exported_program
 
 .. _example-usage-3:
 
@@ -118,7 +118,7 @@ of an ``Inspector`` instance, for example:
 
     inspector.event_blocks
 
-.. autoclass:: sdk.inspector.inspector.EventBlock
+.. autoclass:: executorch.sdk.inspector.EventBlock
 
 ``Event`` Class
 ~~~~~~~~~~~~~~~
@@ -126,7 +126,7 @@ of an ``Inspector`` instance, for example:
 Access ``Event`` instances through the ``events`` attribute of an
 ``EventBlock`` instance.
 
-.. autoclass:: sdk.inspector.inspector.Event
+.. autoclass:: executorch.sdk.inspector.Event
 
 **Example Usage:**
 


### PR DESCRIPTION
Summary:
Before now, the docs execution environment was adding the source tree to the import path instead of using the installed pip files.

Also, it added the `executorch` directory, making it possible to refer to packages like `sdk.bundled_program` instead of
`executorch.sdk.bundled_program`.

Stop adding the source directories to the path, and fix up imports.

Test Plan:
```
cd docs/source
make html
```

Reviewers:

Subscribers:

Tasks:

Tags: