### PR TITLE
revert mask definition to avoid full_like

### DIFF
--- a/examples/models/llama2/llama_transformer.py
+++ b/examples/models/llama2/llama_transformer.py
@@ -216,15 +216,14 @@ class Attention(nn.Module):
         self.use_sdpa_with_kv_cache_op = args.use_sdpa_with_kv_cache_op
         self.layer_id = layer_id
 
-        causal_mask = torch.tril(
-            torch.ones(
-                self.max_seq_len,
-                self.max_seq_len,
-                dtype=torch.bool,
-                device="cpu",
-            )
+        mask = torch.full(
+            (args.max_seq_len, args.max_seq_len),
+            float("-inf"),
+            device="cpu",
         )
-        self.register_buffer("mask", causal_mask, persistent=False)
+
+        mask = torch.triu(mask, diagonal=1)
+        self.register_buffer("mask", mask, persistent=False)
 
         if self.use_kv_cache:
             self.kv_cache = KVCache(


### PR DESCRIPTION
Summary: not sure why full like appears with the gpt fast way of doing things. Presenting this as an alternative, but i dont recommend it since its possible users exporting gpt fast will hit the full_like decomp

Differential Revision: D55356402


