### PR TITLE
Differentiate between resolve_buck failing due to bad buck version and failing from unexpected error

### DIFF
--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -191,10 +191,17 @@ function(resolve_buck2)
     if(resolve_buck2_exit_code EQUAL 0)
       set(BUCK2 ${resolve_buck2_output} PARENT_SCOPE)
       message(STATUS "Resolved buck2 as ${resolve_buck2_output}.")
-    else()
+    elseif(resolve_buck2_exit_code EQUAL 2)
       # Wrong buck version used. Stop here to ensure that the user sees
       # the error.
-      message(FATAL_ERROR "Failed to resolve buck2.")
-      message(FATAL_ERROR ${resolve_buck2_error})
+      message(FATAL_ERROR "Failed to resolve buck2.\n${resolve_buck2_error}")
+    else()
+      # Unexpected failure of the script. Warn.
+      message(WARNING "Failed to resolve buck2.")
+      message(WARNING "${resolve_buck2_error}")
+
+      if("${BUCK2}" STREQUAL "")
+        set(BUCK2 "buck2" PARENT_SCOPE)
+      endif()
     endif()
 endfunction()

--- a/build/resolve_buck.py
+++ b/build/resolve_buck.py
@@ -154,8 +154,10 @@ def resolve_buck2(args: argparse.Namespace) -> Union[str, int]:
             )
 
             # Return an error, since the build will fail later. This lets us
-            # give the user a more useful error message.
-            return -1
+            # give the user a more useful error message. Note that an exit
+            # code of 2 allows us to distinguish from an unexpected error,
+            # such as a failed import, which exits with 1.
+            return 2
     else:
         # Look for system buck2 and check version. Note that this can return
         # None.


### PR DESCRIPTION
A missing dependency (or other unexpected error) in resolve_buck.py can cause the CMake build to fail. It needs to gracefully fall back to the previous behavior in this case.

Test Plan:
Uninstalled zstd via pip uninstall zstd.
Ran cmake ... Confirmed output message contained warning on script failure and gracefully fell back to system buck2.
Repeated above with cmake -DBUCK2=buck2-et2. Confirmed script failure warning and successful build.
Reinstalled zstd via pip install zstd.

Differential Revision: D55391962


