### PR TITLE
Rationalize .quantize vs .quantized_model()

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -245,7 +245,7 @@ def quantize(
 
     if qmode == "int8":
         # Add quantization mode options here: group size, bit width, etc.
-        return WeightOnlyInt8QuantHandler(model).quantized_model()
+        return WeightOnlyInt8QuantHandler(model).quantize()
     elif qmode == "8da4w":
         from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
 
@@ -547,7 +547,7 @@ def _prepare_for_llama_export(modelname: str, args) -> LlamaEdgeManager:
         transforms.append(
             lambda model: EmbeddingOnlyInt8QuantHandler(
                 model, bitwidth=bitwidth, group_size=group_size
-            ).quantized_model()
+            ).quantize()
         )
 
     if args.expand_rope_table:

--- a/examples/models/llama2/quantize.py
+++ b/examples/models/llama2/quantize.py
@@ -235,7 +235,7 @@ class WeightOnlyInt8QuantHandler:
         replace_linear_weight_only_int8_per_channel(self.mod, self.node_type)
         return self.mod
 
-    def quantized_model(self) -> nn.Module:
+    def quantize(self) -> nn.Module:
         model_updated_state_dict = self.create_quantized_state_dict()
         self.convert_for_runtime()
         self.mod.load_state_dict(model_updated_state_dict)
@@ -350,7 +350,7 @@ class EmbeddingOnlyInt8QuantHandler:
         )
         return self.mod
 
-    def quantized_model(self) -> nn.Module:
+    def quantize(self) -> nn.Module:
         model_updated_state_dict = self.create_quantized_state_dict()
         self.convert_for_runtime()
         self.mod.load_state_dict(model_updated_state_dict)
@@ -570,7 +570,7 @@ class Int8DynActInt4WeightQuantHandler:
         )
         return self.mod
 
-    def quantized_model(self) -> nn.Module:
+    def quantize(self) -> nn.Module:
         model_updated_state_dict = self.create_quantized_state_dict()
         self.convert_for_runtime()
         self.mod.load_state_dict(model_updated_state_dict)


### PR DESCRIPTION
Summary:
Rationalize .quantize vs .quantized_model()
Let's keep one name for quanthandler functions?

Differential Revision: D55395844


