### PR TITLE
fix a bug and more flexible handling inf max and min values

### DIFF
--- a/backends/qualcomm/passes/replace_inf_buffer.py
+++ b/backends/qualcomm/passes/replace_inf_buffer.py
@@ -14,8 +14,11 @@ class ReplaceInfBuffer(ExportPass):
     def call(self, graph_module: torch.fx.GraphModule):
         for buf_name, tensor in graph_module.named_buffers():
             if tensor.is_floating_point():
-                tensor[tensor == float("inf")] = torch.finfo(torch.float32).max
-                tensor[tensor == float("-inf")] = torch.finfo(torch.float32).min
+                finfo = torch.finfo(tensor.dtype)
+                max_val = finfo.max
+                min_val = finfo.min
+                tensor[tensor == float("inf")] = max_val
+                tensor[tensor == float("-inf")] = min_val
                 setattr(graph_module, buf_name, tensor)
 
         graph_module.recompile()

--- a/backends/qualcomm/serialization/qnn_compile_spec_schema.py
+++ b/backends/qualcomm/serialization/qnn_compile_spec_schema.py
@@ -8,7 +8,7 @@
 Please refer to executorch/backends/qualcomm/serialization/schema.fbs for the schema definitions
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum, unique
 
 
@@ -39,7 +39,7 @@ class QcomChipset(IntEnum):
 @dataclass
 class SocInfo:
     soc_model: QcomChipset = QcomChipset.UNKNOWN_SM
-    htp_info: HtpInfo = HtpInfo()
+    htp_info: HtpInfo = field(default_factory=HtpInfo)
 
 
 _soc_info_table = {


### PR DESCRIPTION
when I run the command :
```
(executorch) root@autodl-container-ca1347932c-a4925574:~/autodl-tmp/executorch# python ./examples/qualcomm/scripts/dummy_llama2.py -m SM8550 --checkpoint /root/autodl-tmp/Llama-2-7b-chat/consolidated.00.pth --params /root/autodl-tmp/Llama-2-7b-chat/params.json --compile-only
```
I got this output:
```
ValueError: mutable default <class 'executorch.backends.qualcomm.serialization.qnn_compile_spec_schema.HtpInfo'> for field htp_info is not allowed: use default_factory
```