### PR TITLE
extract the delegate segments to allow emit large models

### DIFF
--- a/examples/qualcomm/scripts/utils.py
+++ b/examples/qualcomm/scripts/utils.py
@@ -226,6 +226,7 @@ def build_executorch_binary(
                 alloc_graph_input=not shared_buffer,
                 alloc_graph_output=not shared_buffer,
             ),
+            extract_delegate_segments=True,
         )
     )
     with open(f"{file_name}.pte", "wb") as file:


### PR DESCRIPTION
Summary: If the delegated blob is part of flatbffers, it will exceed the flatbuffers limit (4GB). extract the segments as default for qnn backend

Differential Revision: D55432338


