### PR TITLE
Restore CMake configure comment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,16 @@
 # cloning or pulling the upstream repo. Once this is done, you don't need to do
 # it again until you pull from the upstream repo again.
 #
+# NOTE: Build options can be configured by passing arguments to cmake. For
+# example, to enable the EXECUTORCH_BUILD_XNNPACK option, change the cmake
+# command to 'cmake -DEXECUTORCH_BUILD_XNNPACK=ON ..'.
+#[[
+  (rm -rf cmake-out \
+    && mkdir cmake-out \
+    && cd cmake-out \
+    && cmake ..)
+]]
+#
 # ### Build ###
 #
 # NOTE: The `-j` argument specifies how many jobs/processes to use when


### PR DESCRIPTION
A comment at the top of the top-level CMakeLists.txt file was removed previously as part of an update to automatically download buck. I removed more than was needed. This change restores the comment (minus the explicit buck path).

Test Plan:
This is a comment-only change. I did configure and build on linux x86-64 to validate syntax.