### PR TITLE
include vector explicitly

### DIFF
--- a/examples/models/llama2/custom_ops/op_sdpa.cpp
+++ b/examples/models/llama2/custom_ops/op_sdpa.cpp
@@ -16,6 +16,7 @@
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 
 #include <array>
+#include <vector>
 
 #ifdef ET_USE_THREADPOOL
 #include <executorch/backends/xnnpack/threadpool/threadpool.h>


### PR DESCRIPTION
Summary:
errors out when cross compile for android

 {F1474271712}

Reviewed By: JacobSzwejbka

Differential Revision: D55457736


