### PR TITLE
Restrict promoting commit to stable branch by including Android & Apple jobs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,4 @@
-name: Build ExecuTorch Android demo apps
+name: Android
 
 on:
   push:

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           repository: pytorch/executorch
           stable-branch: viable/strict
-          requires: '[\"pull\", \"lint\", \"trunk\", \"Build documentation\", \"android\", \"apple\"]'
+          requires: '[\"pull\", \"lint\", \"trunk\", \"Build documentation\", \"Android\", \"Apple\"]'
           secret-bot-token: ${{ secrets.UPDATEBOT_TOKEN }}
           rockset-api-key: ${{ secrets.ROCKSET_API_KEY }}

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           repository: pytorch/executorch
           stable-branch: viable/strict
-          requires: '[\"pull\", \"lint\", \"trunk\", \"Build documentation\"]'
+          requires: '[\"pull\", \"lint\", \"trunk\", \"Build documentation\", \"android\", \"apple\"]'
           secret-bot-token: ${{ secrets.UPDATEBOT_TOKEN }}
           rockset-api-key: ${{ secrets.ROCKSET_API_KEY }}


### PR DESCRIPTION
Hardening our OSS CI. Just realized recently added jobs Apple/Android demo apps are not included in the stable branch check.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2757

Differential Revision: [D55510295](https://our.internmc.facebook.com/intern/diff/D55510295)