### PR TITLE
Fix GPTQ quantization in executorch

### DIFF
--- a/examples/models/llama2/eval_llama_lib.py
+++ b/examples/models/llama2/eval_llama_lib.py
@@ -24,7 +24,6 @@ from .export_llama_lib import (
     build_args_parser as _build_args_parser,
 )
 
-
 class GPTFastEvalWrapper(eval_wrapper):
     """
     A wrapper class based on GPTFast, providing integration with the lm-evaluation-harness library.
@@ -65,13 +64,20 @@ class GPTFastEvalWrapper(eval_wrapper):
         return self._device
 
     def tok_encode(self, string: str, **kwargs):
-        tokens = [self._tokenizer.bos_id()] + self._tokenizer.encode(string)
-        encoded = torch.tensor(tokens, dtype=torch.int, device=self.device)
-        # encoded is a pytorch tensor, but some internal logic in the
-        # eval harness expects it to be a list instead
         # TODO: verify this for multi-batch as well
-        encoded = encoded.tolist()
-        return encoded
+        tokens = self._tokenizer.encode(string)
+        if hasattr(self._tokenizer, "bos_id"):
+            tokens = [self._tokenizer.bos_id()] + tokens
+        return tokens
+
+    # def tok_encode(self, string: str, **kwargs):
+    #     tokens = [self._tokenizer.bos_id()] + self._tokenizer.encode(string)
+    #     encoded = torch.tensor(tokens, dtype=torch.int, device=self.device)
+    #     # encoded is a pytorch tensor, but some internal logic in the
+    #     # eval harness expects it to be a list instead
+    #     # TODO: verify this for multi-batch as well
+    #     encoded = encoded.tolist()
+    #     return encoded
 
     def tok_decode(self, tokens):
         decoded = self._tokenizer.decode(tokens)
@@ -98,7 +104,7 @@ def eval(
         task (str): The name of the evaluation task to perform.
         limit (Optional[int]): The maximum number of samples to evaluate (None for all available).
 
-    Returns:
+    Returns:p
         eval_results (dict): A dictionary of evaluation results for the specified task(s).
     """
 

--- a/examples/models/llama2/llama_transformer.py
+++ b/examples/models/llama2/llama_transformer.py
@@ -185,10 +185,12 @@ class KVCache(nn.Module):
         self, input_pos: torch.Tensor, k_val: torch.Tensor, v_val: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # input_pos: [S], k_val: [B, H, S, D] or [B, S, H, D] depending on transpose_cache
-        k_out = self.k_cache
-        v_out = self.v_cache
-        k_out[:, :, input_pos] = k_val
-        v_out[:, :, input_pos] = v_val
+        # k_out = self.k_cache
+        # v_out = self.v_cache
+        # k_out[:, :, input_pos] = k_val
+        # v_out[:, :, input_pos] = v_val
+        k_out = torch.ops.aten.index_put_(self.k_cache, [None, None, input_pos], k_val)
+        v_out = torch.ops.aten.index_put_(self.v_cache, [None, None, input_pos], v_val)
 
         return k_out, v_out
 
@@ -442,15 +444,15 @@ class Transformer(nn.Module):
         h = self.tok_embeddings(tokens)
 
         if self.use_kv_cache:
-            assert (
-                input_pos is not None
-            ), "input_pos must be provided when use_kv_cache is True"
+            # assert (
+            #     input_pos is not None
+            # ), "input_pos must be provided when use_kv_cache is True"
 
             # when KV cache is used, seqlen is most likely 1. We want to slice from the start_pos.
             freqs_cos = self.freqs_cos[input_pos]
             freqs_sin = self.freqs_sin[input_pos]
         else:
-            assert input_pos is None, "input_pos is unused when use_kv_cache is False"
+            # assert input_pos is None, "input_pos is unused when use_kv_cache is False"
             freqs_cos = self.freqs_cos[:seqlen]
             freqs_sin = self.freqs_sin[:seqlen]
 


### PR DESCRIPTION
Summary:
GPTQ didn't run / produce correct result currently, this PR tries to fix that

Test Plan:
with-proxy python -m examples.models.llama2.eval_llama -c llama2-7b.pt -p llama2-7b-params.json -t llama2-7b-tok.model -d fp32 --limit 1000 --tasks wikitext --calibration_seq_length 2048 --max_seq_len 2048 --group_size 256 -qmode 8da4w-gptq

Reviewers:

Subscribers:

Tasks:

Tags: