### PR TITLE
Adding EXECUTORCH_CLIENTS visibility to parallel extension

### DIFF
--- a/extension/parallel/targets.bzl
+++ b/extension/parallel/targets.bzl
@@ -20,6 +20,7 @@ def define_common_targets():
             ],
             visibility = [
                 "//executorch/...",
+                "@EXECUTORCH_CLIENTS",
             ],
             deps = [
                 "//executorch/backends/xnnpack/threadpool:threadpool",


### PR DESCRIPTION
Summary: title.

Differential Revision: D55505037

@bypass-github-pytorch-ci-checks

