### PR TITLE
Remove obsolete vTensor members for buffer storage support

### DIFF
--- a/backends/vulkan/runtime/api/Tensor.cpp
+++ b/backends/vulkan/runtime/api/Tensor.cpp
@@ -197,25 +197,6 @@ api::utils::uvec3 create_image_extents(
   }
 }
 
-api::UniformParamsBuffer make_metadata_uniform(
-    api::Context* const context,
-    const std::vector<int64_t>& sizes,
-    const std::vector<int64_t>& strides,
-    const api::StorageType storage_type) {
-  if (storage_type != api::StorageType::BUFFER) {
-    return api::UniformParamsBuffer();
-  }
-
-  vTensor::BufferMetadata metadata{
-      api::utils::make_whcn_uvec4(sizes),
-      api::utils::make_whcn_uvec4(strides),
-      api::utils::safe_downcast<uint32_t>(sizes.size()),
-      api::utils::safe_downcast<uint32_t>(api::utils::multiply_integers(sizes)),
-  };
-
-  return api::UniformParamsBuffer(context, metadata);
-}
-
 } // namespace
 
 //
@@ -239,7 +220,6 @@ vTensor::vTensor(
       virtual_extents_(
           create_image_extents(gpu_sizes_, storage_type, memory_layout)),
       // Utility Uniform Buffers that can be passed to shaders as arguments
-      metadata_uniform_(),
       cpu_sizes_uniform_(nullptr),
       gpu_sizes_uniform_(nullptr),
       extents_uniform_(nullptr),
@@ -270,7 +250,6 @@ vTensor::vTensor(
       virtual_extents_(
           create_image_extents(gpu_sizes_, storage_type, memory_layout)),
       // Vulkan uniform buffer containing sizes and stride info
-      metadata_uniform_(),
       cpu_sizes_uniform_(nullptr),
       gpu_sizes_uniform_(nullptr),
       extents_uniform_(nullptr),
@@ -316,14 +295,6 @@ api::VulkanBuffer& vTensor::buffer(
   return view_->buffer_;
 }
 
-api::VulkanBuffer& vTensor::buffer_metadata() {
-  if (!metadata_uniform_.buffer()) {
-    metadata_uniform_ = make_metadata_uniform(
-        view_->context_, gpu_sizes_, gpu_strides_, storage_type());
-  }
-  return metadata_uniform_.buffer();
-}
-
 std::shared_ptr<api::UniformParamsBuffer> vTensor::cpu_sizes_ubo() {
   if (!cpu_sizes_uniform_) {
     cpu_sizes_uniform_.reset(new api::UniformParamsBuffer(
@@ -351,16 +322,6 @@ std::shared_ptr<api::UniformParamsBuffer> vTensor::extents_ubo() {
              1u})));
   }
   return extents_uniform_;
-}
-
-vTensor::BufferMetadata vTensor::get_cpu_buffer_metadata() const {
-  return {
-      api::utils::make_whcn_uvec4(sizes_),
-      api::utils::make_whcn_uvec4(strides_),
-      api::utils::safe_downcast<uint32_t>(sizes_.size()),
-      api::utils::safe_downcast<uint32_t>(
-          api::utils::multiply_integers(sizes_)),
-  };
 }
 
 VmaAllocationCreateInfo vTensor::get_allocation_create_info() const {

--- a/backends/vulkan/runtime/api/Tensor.h
+++ b/backends/vulkan/runtime/api/Tensor.h
@@ -129,14 +129,6 @@ class vTensor final {
   vTensor(vTensor&& other) = default;
   vTensor& operator=(vTensor&& other) = default;
 
-  // Used for passing buffer sizes and strides data to shaders
-  struct BufferMetadata {
-    api::utils::uvec4 sizes;
-    api::utils::uvec4 strides;
-    uint32_t ndim;
-    uint32_t buffer_length;
-  };
-
  private:
   // Tensor Options
   api::ScalarType dtype_;
@@ -158,10 +150,6 @@ class vTensor final {
   // vTensor can be virtually resized via virtual_resize() which will cause it
   // to be interpreted as a tensor with a different size.
   api::utils::uvec3 virtual_extents_;
-
-  // A Vulkan uniform buffer containing sizes and strides of the GPU buffer that
-  // can be passed into a shader.
-  api::UniformParamsBuffer metadata_uniform_;
 
   // A Vulkan uniform buffer containing the tensor sizes that can be passed into
   // a shader.
@@ -286,12 +274,6 @@ class vTensor final {
   }
 
   /*
-   * Get a uniform buffer containing sizes and strides information of the GPU
-   * buffer
-   */
-  api::VulkanBuffer& buffer_metadata();
-
-  /*
    * Get a uniform buffer object containing the tensor sizes to use in a compute
    * shader. Note that the UBO will be created the first time this function is
    * called.
@@ -311,12 +293,6 @@ class vTensor final {
    * function is called.
    */
   std::shared_ptr<api::UniformParamsBuffer> extents_ubo();
-
-  /*
-   * Constructs a BufferMetdata struct based on the original sizes and strides
-   * to pass into a shader.
-   */
-  BufferMetadata get_cpu_buffer_metadata() const;
 
   inline void set_is_quantized() {
     is_quantized_ = true;

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -16,60 +16,6 @@
 // Operator Recording Functions
 //
 
-void record_nchw_to_buffer_op(
-    api::Context* const context,
-    api::VulkanBuffer& src_buffer,
-    vTensor& v_dst) {
-  uint32_t buf_len = api::utils::safe_downcast<uint32_t>(v_dst.gpu_numel());
-  api::utils::uvec3 global_size = {buf_len, 1u, 1u};
-  api::utils::uvec3 local_size = {32u, 1u, 1u};
-
-  api::UniformParamsBuffer cpu_buffer_metadata(
-      context, v_dst.get_cpu_buffer_metadata());
-  api::PipelineBarrier pipeline_barrier{};
-
-  context->submit_compute_job(
-      VK_KERNEL(buffer_to_buffer),
-      pipeline_barrier,
-      global_size,
-      local_size,
-      VK_NULL_HANDLE,
-      v_dst.buffer(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE,
-          api::MemoryAccessType::WRITE),
-      v_dst.buffer_metadata(),
-      src_buffer,
-      cpu_buffer_metadata.buffer());
-}
-
-bool record_buffer_to_nchw_op(
-    api::Context* const context,
-    vTensor& v_src,
-    api::VulkanBuffer& dst_buffer) {
-  uint32_t buf_len = api::utils::safe_downcast<uint32_t>(v_src.numel());
-  api::utils::uvec3 global_size = {buf_len, 1u, 1u};
-  api::utils::uvec3 local_size = {4u, 1u, 1u};
-
-  api::UniformParamsBuffer cpu_buffer_metadata(
-      context, v_src.get_cpu_buffer_metadata());
-  api::PipelineBarrier pipeline_barrier{};
-
-  return context->submit_compute_job(
-      VK_KERNEL(buffer_to_buffer),
-      pipeline_barrier,
-      global_size,
-      local_size,
-      VK_NULL_HANDLE,
-      dst_buffer,
-      cpu_buffer_metadata.buffer(),
-      v_src.buffer(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE,
-          api::MemoryAccessType::WRITE),
-      v_src.buffer_metadata());
-}
-
 void record_nchw_to_image_op(
     api::Context* const context,
     api::VulkanBuffer& src_buffer,
@@ -166,7 +112,7 @@ void fill_vtensor(vTensor& vten, std::vector<float>& data) {
   copy_ptr_to_staging(data.data(), staging_buffer, vten.gpu_nbytes());
 
   if (vten.storage_type() == api::StorageType::BUFFER) {
-    record_nchw_to_buffer_op(api::context(), staging_buffer.buffer(), vten);
+    VK_THROW("Not supported!");
   } else {
     record_nchw_to_image_op(api::context(), staging_buffer.buffer(), vten);
   }
@@ -192,7 +138,7 @@ void extract_vtensor(vTensor& vten, std::vector<float>& data) {
       api::context(), api::kFloat, vten.gpu_numel());
 
   if (vten.storage_type() == api::StorageType::BUFFER) {
-    record_buffer_to_nchw_op(api::context(), vten, staging_buffer.buffer());
+    VK_THROW("Not supported!");
   } else {
     record_image_to_nchw_op(api::context(), vten, staging_buffer.buffer());
   }


### PR DESCRIPTION
Summary:
## Context

Support for using buffer storage for tensors in compute shaders will be reworked. For now, remove some of the obsolete mechanisms that were introduced to support buffer storage.

Differential Revision: D55544884


