### PR TITLE
re-enable etdump gen in llama runner without breaking ci

### DIFF
--- a/examples/models/llama2/main.cpp
+++ b/examples/models/llama2/main.cpp
@@ -39,6 +39,11 @@ DEFINE_int32(
     -1,
     "Number of CPU threads for inference. Defaults to -1, which implies we'll use a heuristic to derive the # of performant cores for a specific device.");
 
+DEFINE_string(
+    etdump_path,
+    "llama_etdump.etdp",
+    "Where to write the llama etdump.");
+
 int32_t main(int32_t argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
@@ -73,6 +78,9 @@ int32_t main(int32_t argc, char** argv) {
 
   // generate
   runner.generate(prompt, seq_len);
+
+  // dump etdump profiling data
+  runner.dump_etdump(FLAGS_etdump_path);
 
   return 0;
 }

--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -12,7 +12,9 @@
 #include <executorch/examples/models/llama2/runner/runner.h>
 #include <executorch/extension/evalue_util/print_evalue.h>
 #include <executorch/extension/runner_util/managed_tensor.h>
+#ifdef ET_EVENT_TRACER_ENABLED
 #include <executorch/sdk/etdump/etdump_flatcc.h>
+#endif
 
 #include <ctime>
 #include <memory>
@@ -37,6 +39,7 @@ Runner::Runner(
     const std::string& tokenizer_path,
     const float temperature)
     : tokenizer_path_(tokenizer_path), temperature_(temperature) {
+  #ifdef ET_EVENT_TRACER_ENABLED
   std::unique_ptr<torch::executor::ETDumpGen> etdump_gen_ =
       std::make_unique<torch::executor::ETDumpGen>();
 
@@ -44,6 +47,11 @@ Runner::Runner(
       model_path,
       Module::MlockConfig::UseMlockIgnoreErrors,
       std::move(etdump_gen_));
+  #else
+  module_ = std::make_unique<Module>(
+      model_path,
+      Module::MlockConfig::UseMlockIgnoreErrors);
+  #endif
   ET_LOG(
       Info,
       "Creating LLaMa runner: model_path=%s, tokenizer_path=%s",

--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -12,6 +12,7 @@
 #include <executorch/examples/models/llama2/runner/runner.h>
 #include <executorch/extension/evalue_util/print_evalue.h>
 #include <executorch/extension/runner_util/managed_tensor.h>
+#include <executorch/sdk/etdump/etdump_flatcc.h>
 
 #include <ctime>
 #include <memory>
@@ -35,11 +36,14 @@ Runner::Runner(
     const std::string& model_path,
     const std::string& tokenizer_path,
     const float temperature)
-    : module_(std::make_unique<Module>(
-          model_path,
-          Module::MlockConfig::UseMlockIgnoreErrors)),
-      tokenizer_path_(tokenizer_path),
-      temperature_(temperature) {
+    : tokenizer_path_(tokenizer_path), temperature_(temperature) {
+  std::unique_ptr<torch::executor::ETDumpGen> etdump_gen_ =
+      std::make_unique<torch::executor::ETDumpGen>();
+
+  module_ = std::make_unique<Module>(
+      model_path,
+      Module::MlockConfig::UseMlockIgnoreErrors,
+      std::move(etdump_gen_));
   ET_LOG(
       Info,
       "Creating LLaMa runner: model_path=%s, tokenizer_path=%s",
@@ -389,6 +393,26 @@ Error Runner::generate(
   timers_.printReport(num_prompt_tokens, pos - num_prompt_tokens);
 
   delete[] prompt_tokens;
+  return Error::Ok;
+}
+
+
+Error Runner::dump_etdump(std::string etdump_path) {
+#ifdef ET_EVENT_TRACER_ENABLED
+  torch::executor::ETDumpGen* etdump_gen =
+      static_cast<torch::executor::ETDumpGen*>(module_->event_tracer());
+
+  ET_LOG(Info, "ETDump size: %zu blocks", etdump_gen->get_num_blocks());
+  etdump_result result = etdump_gen->get_etdump_data();
+  if (result.buf != nullptr && result.size > 0) {
+    // On a device with a file system users can just write it out
+    // to the file-system.
+    FILE* f = fopen(etdump_path.c_str(), "w+");
+    fwrite((uint8_t*)result.buf, 1, result.size, f);
+    fclose(f);
+    free(result.buf);
+  }
+#endif
   return Error::Ok;
 }
 

--- a/examples/models/llama2/runner/runner.h
+++ b/examples/models/llama2/runner/runner.h
@@ -21,6 +21,7 @@
 #include <executorch/examples/models/llama2/tokenizer/tokenizer.h>
 #include <executorch/extension/module/module.h>
 #include <executorch/extension/runner_util/managed_tensor.h>
+#include <executorch/sdk/etdump/etdump_flatcc.h>
 
 namespace torch::executor {
 
@@ -38,6 +39,7 @@ class Runner {
       int32_t seq_len = 128,
       std::function<void(const std::string&)> callback = {});
   void stop();
+  Error dump_etdump(std::string etdump_path);
 
  private:
   // metadata

--- a/examples/models/llama2/runner/targets.bzl
+++ b/examples/models/llama2/runner/targets.bzl
@@ -37,6 +37,7 @@ def define_common_targets():
                 "//executorch/kernels/quantized:generated_lib" + aten_suffix,
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
                 "//executorch/runtime/core/exec_aten/util:tensor_util" + aten_suffix,
+                "//executorch/sdk/etdump:etdump_flatcc",
             ] + (_get_operator_lib(aten)) + ([
                 # Vulkan API currently cannot build on some platforms (e.g. Apple, FBCODE)
                 # Therefore enable it explicitly for now to avoid failing tests

--- a/sdk/etdump/emitter.cpp
+++ b/sdk/etdump/emitter.cpp
@@ -14,6 +14,7 @@
 
 namespace torch {
 namespace executor {
+#ifdef ET_EVENT_TRACER_ENABLED
 
 static int _allocator_fn(
     void* alloc_context,
@@ -179,5 +180,6 @@ int et_flatcc_custom_init(
       builder, _emitter_fn, alloc, _allocator_fn, alloc);
 }
 
+#endif // ET_EVENT_TRACER_ENABLED
 } // namespace executor
 } // namespace torch

--- a/sdk/etdump/emitter.h
+++ b/sdk/etdump/emitter.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef ET_EVENT_TRACER_ENABLED
 #include <executorch/sdk/etdump/etdump_flatcc.h>
 #include <flatcc/flatcc_builder.h>
 
@@ -29,3 +30,4 @@ void etdump_static_allocator_reset(struct etdump_static_allocator* alloc);
 
 } // namespace executor
 } // namespace torch
+#endif //ET_EVENT_TRACER_ENABLED

--- a/sdk/etdump/etdump_flatcc.cpp
+++ b/sdk/etdump/etdump_flatcc.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifdef ET_EVENT_TRACER_ENABLED
 #include "executorch/sdk/etdump/etdump_flatcc.h"
 #include <executorch/sdk/etdump/etdump_schema_flatcc_builder.h>
 #include <executorch/sdk/etdump/etdump_schema_flatcc_reader.h>
@@ -496,3 +497,4 @@ bool ETDumpGen::is_static_etdump() {
 
 } // namespace executor
 } // namespace torch
+#endif // ET_EVENT_TRACER_ENABLED


### PR DESCRIPTION
```
bash .ci/scripts/test_llama.sh stories110M.pt cmake fp32
```

```
...
+ echo 'Expected result prefix: Once upon a time,'
Expected result prefix: Once upon a time,
+ echo 'Actual result: Once upon a time, there was a little
PyTorchObserver {"prompt_tokens":2,"generated_tokens":7,"model_load_start_ms":1711754028137,"model_load_end_ms":1711754028327,"inference_start_ms":1711754028327,"inference_end_ms":1711754028493,"prompt_eval_end_ms":1711754028340,"first_token_ms":1711754028352,"aggregate_sampling_time_ms":8133999520,"SCALING_FACTOR_UNITS_PER_SECOND":1000}'
Actual result: Once upon a time, there was a little
PyTorchObserver {"prompt_tokens":2,"generated_tokens":7,"model_load_start_ms":1711754028137,"model_load_end_ms":1711754028327,"inference_start_ms":1711754028327,"inference_end_ms":1711754028493,"prompt_eval_end_ms":1711754028340,"first_token_ms":1711754028352,"aggregate_sampling_time_ms":8133999520,"SCALING_FACTOR_UNITS_PER_SECOND":1000}
+ echo Success
Success
+ cleanup_files
+ echo 'Deleting downloaded and generated files'
Deleting downloaded and generated files
+ rm stories110M.pt
+ rm tokenizer.model
+ rm tokenizer.bin
+ rm llama2.pte
+ rm result.txt
+ rm params.json
```