### PR TITLE
Do not ignore init() errors

### DIFF
--- a/backends/xnnpack/runtime/XNNPACKBackend.cpp
+++ b/backends/xnnpack/runtime/XNNPACKBackend.cpp
@@ -44,13 +44,17 @@ class XnnpackBackend final : public PyTorchBackendInterface {
         processed->size(),
         executor,
         context.get_runtime_allocator());
-    if (err != Error::Ok) {
-      ET_LOG(Error, "XNNCompiler::compleModel failed: 0x%x", (unsigned int)err);
-    }
-
-    // Free the flatbuffer
+    // This backend does not need its processed data after compiling the model.
     processed->Free();
 
+    if (err != Error::Ok) {
+      // destroy() won't be called on this handle, so we need to clean it up
+      // now.
+      executor->~XNNExecutor();
+
+      ET_LOG(Error, "XNNCompiler::compleModel failed: 0x%x", (unsigned int)err);
+      return err;
+    }
     return executor;
   }
 


### PR DESCRIPTION
Summary:
XnnpackBackend logged but did not return errors. This meant that the runtime could try to execute uninitialized delegate handles, leading to bad behavior like seg faults.

Now it returns the error to the runtime, failing clearly and gracefully during model load.

Differential Revision: D55549758


