### PR TITLE
NMS op implementation for ExecuTorch in portable mode

### DIFF
--- a/kernels/portable/cpu/util/broadcast_util.cpp
+++ b/kernels/portable/cpu/util/broadcast_util.cpp
@@ -19,15 +19,13 @@ namespace executor {
 using Tensor = exec_aten::Tensor;
 using ScalarType = exec_aten::ScalarType;
 
-void free_broadcast_tensor(const Tensor& broadcast_tensor) {
-  free((void*)broadcast_tensor.const_data_ptr());
-  free((void*)broadcast_tensor.sizes().data());
-  free((void*)broadcast_tensor.dim_order().data());
-  free((void*)broadcast_tensor.strides().data());
-  free(broadcast_tensor.unsafeGetTensorImpl());
+void free_tensor(const Tensor& tensor) {
+  free((void*)tensor.const_data_ptr());
+  free((void*)tensor.sizes().data());
+  free((void*)tensor.dim_order().data());
+  free((void*)tensor.strides().data());
+  free(tensor.unsafeGetTensorImpl());
 }
-
-namespace {
 
 Tensor make_tensor(
     const ArrayRef<Tensor::SizesType>& sizes,
@@ -73,8 +71,6 @@ Tensor make_tensor(
 
   return Tensor{tensor_impl};
 }
-
-} // namespace
 
 bool tensor_is_broadcastable_to(
     const exec_aten::ArrayRef<Tensor::SizesType> broadcast_from_shape,

--- a/kernels/portable/cpu/util/broadcast_util.h
+++ b/kernels/portable/cpu/util/broadcast_util.h
@@ -63,6 +63,21 @@ bool tensors_are_broadcastable_between(
 bool tensors_are_broadcastable_between(const Tensor& a, const Tensor& b);
 
 /**
+ * Create a new tensor with the given sizes, dim_order, and strides.
+ *
+ * @param[in] sizes The sizes of the tensor.
+ * @param[in] dim_order The dim order of the tensor.
+ * @param[in] strides The strides of the tensor.
+ * @param[in] dtype The data type of the tensor.
+ * @returns A new tensor with the given sizes, dim_order, and strides.
+ */
+Tensor make_tensor(
+    const ArrayRef<Tensor::SizesType>& sizes,
+    const ArrayRef<Tensor::DimOrderType>& dim_order,
+    const ArrayRef<Tensor::StridesType>& strides,
+    const ScalarType& dtype);
+
+/**
  * DEPRECATED: Use `delinearize_index()` and `linearize_access_indexes()` for
  * index remapping to avoid memory allocation.
  *
@@ -75,7 +90,7 @@ bool tensors_are_broadcastable_between(const Tensor& a, const Tensor& b);
  * @param[in] broadcast_to The tensor to which we want to broadcast to.
  * @returns A new tensor with the same shape as broadcast_to and the data
  * repeated as appropriate. This tensor contains dynamically allocated memory
- * and must be freed using free_broadcast_tensor.
+ * and must be freed using free_tensor.
  */
 __ET_DEPRECATED exec_aten::Tensor broadcast_tensor(
     const exec_aten::Tensor& broadcast_from,
@@ -202,8 +217,7 @@ __ET_NODISCARD inline Error resize_to_broadcast_target_size(
  * broadcast_tensor.
  * @returns void
  */
-__ET_DEPRECATED void free_broadcast_tensor(
-    const exec_aten::Tensor& broadcast_tensor);
+__ET_DEPRECATED void free_tensor(const exec_aten::Tensor& broadcast_tensor);
 
 /**
  * Delinearize a flattened index to per-dimension indexes.

--- a/kernels/portable/cpu/util/sort_util.cpp
+++ b/kernels/portable/cpu/util/sort_util.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "executorch/kernels/portable/cpu/util/sort_util.h"
+#include <executorch/runtime/kernel/kernel_includes.h>
+#include <algorithm>
+
+namespace torch {
+namespace executor {
+
+using Tensor = exec_aten::Tensor;
+
+Error sort_tensor(
+    const Tensor& tensor,
+    Tensor& sorted_tensor,
+    Tensor& sorted_indices,
+    bool descending) {
+  // Check if the input tensor is a valid input
+  ET_CHECK_MSG(tensor.dim() == 1, "Input tensor must be 1D");
+
+  // Check if the output tensors are valid
+  ET_CHECK_MSG(sorted_tensor.dim() == 1, "Output tensor must be 1D");
+  ET_CHECK_MSG(sorted_indices.dim() == 1, "Output tensor must be 1D");
+
+  // Check if the output tensors have the same dtype
+  ET_CHECK_MSG(
+      tensor.scalar_type() == sorted_tensor.scalar_type(),
+      "Input and output tensors must have the same dtype");
+  ET_CHECK_MSG(
+      tensor.scalar_type() == ScalarType::Float,
+      "Only float inputs are supported currently");
+  ET_CHECK_MSG(
+      sorted_indices.scalar_type() == exec_aten::ScalarType::Long,
+      "Output tensor must be of type int64");
+
+  // Get the number of elements in the tensor
+  int size = tensor.numel();
+
+  // Create a tensor to store the indices
+  for (int i = 0; i < size; i++) {
+    sorted_indices.mutable_data_ptr<int64_t>()[i] = i;
+  }
+
+  // Sort the indices based on the corresponding tensor values
+  std::sort(
+      sorted_indices.mutable_data_ptr<int64_t>(),
+      sorted_indices.mutable_data_ptr<int64_t>() + size,
+      [&tensor, descending](int64_t i, int64_t j) {
+        if (descending) {
+          return tensor.const_data_ptr<float>()[i] >
+              tensor.const_data_ptr<float>()[j];
+        } else {
+          return tensor.const_data_ptr<float>()[i] <
+              tensor.const_data_ptr<float>()[j];
+        }
+      });
+
+  // Rearrange the tensor values based on the sorted indices
+  for (int i = 0; i < size; i++) {
+    sorted_tensor.mutable_data_ptr<float>()[i] = tensor.const_data_ptr<
+        float>()[sorted_indices.const_data_ptr<int64_t>()[i]];
+  }
+
+  return Error::Ok;
+}
+
+} // namespace executor
+} // namespace torch

--- a/kernels/portable/cpu/util/sort_util.h
+++ b/kernels/portable/cpu/util/sort_util.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+
+namespace torch {
+namespace executor {
+
+using Tensor = exec_aten::Tensor;
+
+Error sort_tensor(
+    const Tensor& tensor,
+    Tensor& sorted_tensor,
+    Tensor& sorted_indice,
+    bool descending = false);
+
+} // namespace executor
+} // namespace torch

--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -203,6 +203,17 @@ def define_common_targets():
         visibility = ["//executorch/kernels/portable/cpu/..."],
     )
 
+    runtime.cxx_library(
+        name = "sort_util",
+        srcs = ["sort_util.cpp"],
+        exported_headers = ["sort_util.h"],
+        deps = [
+            "//executorch/runtime/kernel:kernel_includes",
+            "//executorch/runtime/core/exec_aten/util:tensor_util",
+        ],
+        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/torchvision/..."],
+    )
+
     # Utility functions that can be used by operators that perform reduction
     for aten_mode in [True, False]:
         suffix = "_aten" if aten_mode else ""

--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -48,7 +48,7 @@ def define_common_targets():
             "//executorch/runtime/kernel:kernel_includes",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/...", "//executorch/kernels/torchvision/..."],
     )
 
     runtime.cxx_library(
@@ -200,7 +200,7 @@ def define_common_targets():
             "//executorch/runtime/kernel:kernel_includes",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/..."],
+        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/torchvision/..."],
     )
 
     runtime.cxx_library(

--- a/kernels/portable/cpu/util/test/broadcast_test.cpp
+++ b/kernels/portable/cpu/util/test/broadcast_test.cpp
@@ -32,11 +32,11 @@ TEST(BroadcastUtilTest, BroadcastTensor) {
 
   Tensor d = torch::executor::broadcast_tensor(a, c);
   EXPECT_TENSOR_DATA_EQ(d, tf.make({2, 2}, {2, 2, 2, 2}));
-  torch::executor::free_broadcast_tensor(d);
+  torch::executor::free_tensor(d);
 
   d = torch::executor::broadcast_tensor(b, c);
   EXPECT_TENSOR_DATA_EQ(d, tf.make({2, 2}, {2, 2, 2, 2}));
-  torch::executor::free_broadcast_tensor(d);
+  torch::executor::free_tensor(d);
 }
 
 TEST(BroadcastUtilTest, BroadcastableBetween) {
@@ -63,12 +63,12 @@ TEST(BroadcastUtilTest, BroadcastableToFrom) {
   ASSERT_TRUE(tensor_is_broadcastable_to(a, c));
   Tensor d = torch::executor::broadcast_tensor(a, c);
   EXPECT_TENSOR_DATA_EQ(d, tf.make({2, 2}, {2, 2, 2, 2}));
-  torch::executor::free_broadcast_tensor(d);
+  torch::executor::free_tensor(d);
 
   ASSERT_TRUE(tensor_is_broadcastable_to(b, c));
   d = torch::executor::broadcast_tensor(b, c);
   EXPECT_TENSOR_DATA_EQ(d, tf.make({2, 2}, {2, 2, 2, 2}));
-  torch::executor::free_broadcast_tensor(d);
+  torch::executor::free_tensor(d);
 }
 
 TEST(BroadcastUtilTest, NotBroadcastableTo) {

--- a/kernels/portable/cpu/util/test/sort_util_test.cpp
+++ b/kernels/portable/cpu/util/test/sort_util_test.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/kernels/portable/cpu/util/sort_util.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
+#include <executorch/test/utils/DeathTest.h>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using exec_aten::ScalarType;
+using exec_aten::Tensor;
+using torch::executor::ArrayRef;
+using torch::executor::testing::TensorFactory;
+
+TEST(SortUtilTest, SortTensorTest) {
+  TensorFactory<ScalarType::Float> tf;
+  TensorFactory<ScalarType::Long> lf;
+
+  Tensor a = tf.make({4}, {3, 2, 1, 4});
+  Tensor b = tf.zeros({4});
+  Tensor c = lf.zeros({4});
+
+  // Ascending order sort test
+  sort_tensor(a, b, c);
+
+  Tensor expected = tf.make({4}, {1, 2, 3, 4});
+  Tensor expected_indices = lf.make({4}, {2, 1, 0, 3});
+  EXPECT_TENSOR_EQ(b, expected);
+  EXPECT_TENSOR_EQ(c, expected_indices);
+
+  // Descending order sort test
+  sort_tensor(a, b, c, true);
+  expected = tf.make({4}, {4, 3, 2, 1});
+  expected_indices = lf.make({4}, {3, 0, 1, 2});
+  EXPECT_TENSOR_EQ(b, expected);
+  EXPECT_TENSOR_EQ(c, expected_indices);
+}

--- a/kernels/portable/cpu/util/test/targets.bzl
+++ b/kernels/portable/cpu/util/test/targets.bzl
@@ -21,3 +21,13 @@ def define_common_targets():
             "//executorch/kernels/portable/cpu/util:reduce_util",
         ],
     )
+
+    runtime.cxx_test(
+        name = "sort_util_test",
+        srcs = ["sort_util_test.cpp"],
+        deps = [
+            "//executorch/runtime/core/exec_aten:lib",
+            "//executorch/runtime/core/exec_aten/testing_util:tensor_util",
+            "//executorch/kernels/portable/cpu/util:sort_util",
+        ],
+    )

--- a/kernels/torchvision/TARGETS
+++ b/kernels/torchvision/TARGETS
@@ -1,0 +1,5 @@
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/kernels/torchvision/cpu/TARGETS
+++ b/kernels/torchvision/cpu/TARGETS
@@ -1,0 +1,3 @@
+load(":targets.bzl", "define_common_targets")
+
+define_common_targets()

--- a/kernels/torchvision/cpu/op_nms.cpp
+++ b/kernels/torchvision/cpu/op_nms.cpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/kernels/portable/cpu/util/broadcast_util.h>
+#include <executorch/kernels/portable/cpu/util/select_copy_util.h>
+#include <executorch/kernels/portable/cpu/util/sort_util.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
+#include <executorch/runtime/kernel/kernel_includes.h>
+#include <cstring>
+
+namespace torch {
+namespace executor {
+namespace native {
+
+using namespace exec_aten;
+
+Tensor& nms_out(
+    RuntimeContext& ctx,
+    const Tensor& dets,
+    const Tensor& scores,
+    double iou_threshold,
+    Tensor& out) {
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      dets.dim() == 2,
+      InvalidArgument,
+      out,
+      "boxes should be a 2d tensor, got %zd",
+      dets.dim());
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      dets.size(1) == 4,
+      InvalidArgument,
+      out,
+      "boxes should have 4 elements in dimension 1, got %zd",
+      dets.size(1));
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      scores.dim() == 1,
+      InvalidArgument,
+      out,
+      "scores should be a 1d tensor, got %zd",
+      scores.dim());
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      dets.size(0) == scores.size(0),
+      InvalidArgument,
+      out,
+      "boxes and scores should have same number of elements in dimension 0, got %zd and %zd",
+      dets.size(0),
+      scores.size(0));
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      dets.scalar_type() == scores.scalar_type(),
+      InvalidArgument,
+      out,
+      "boxes and scores should have same type, got %s and %s",
+      toString(dets.scalar_type()),
+      toString(scores.scalar_type()));
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      dets.scalar_type() == ScalarType::Float,
+      InvalidArgument,
+      out,
+      "dets should have type float, got %s",
+      toString(dets.scalar_type()));
+
+  if (dets.numel() == 0) {
+    ET_KERNEL_CHECK_MSG(
+        ctx,
+        resize_tensor(out, {0}) == Error::Ok,
+        InvalidArgument,
+        out,
+        "Failed to resize output tensor.");
+  }
+
+  ArrayRef<exec_aten::SizesType> sizes = {dets.sizes()[0]};
+  ArrayRef<exec_aten::StridesType> strides = {dets.strides()[0]};
+  ArrayRef<exec_aten::DimOrderType> dim_orders = {dets.dim_order()[0]};
+
+  Tensor x1_t = make_tensor(sizes, dim_orders, strides, dets.scalar_type());
+  Tensor y1_t = make_tensor(sizes, dim_orders, strides, dets.scalar_type());
+  Tensor x2_t = make_tensor(sizes, dim_orders, strides, dets.scalar_type());
+  Tensor y2_t = make_tensor(sizes, dim_orders, strides, dets.scalar_type());
+
+  select_copy_util(dets, 1, 0, x1_t);
+  select_copy_util(dets, 1, 1, y1_t);
+  select_copy_util(dets, 1, 2, x2_t);
+  select_copy_util(dets, 1, 3, y2_t);
+
+  Tensor x_diff = make_tensor(
+      x1_t.sizes(), x1_t.dim_order(), x1_t.strides(), x1_t.scalar_type());
+  Tensor y_diff = make_tensor(
+      y1_t.sizes(), y1_t.dim_order(), y1_t.strides(), y1_t.scalar_type());
+  Tensor areas_t = make_tensor(
+      y1_t.sizes(), y1_t.dim_order(), y1_t.strides(), y1_t.scalar_type());
+
+  apply_binary_elementwise_fn<float, float, float>(
+      [](const float val_a, const float val_b) { return val_a - val_b; },
+      x2_t,
+      x1_t,
+      x_diff);
+
+  apply_binary_elementwise_fn<float, float, float>(
+      [](const float val_a, const float val_b) { return val_a - val_b; },
+      y2_t,
+      y1_t,
+      y_diff);
+
+  apply_binary_elementwise_fn<float, float, float>(
+      [](const float val_a, const float val_b) { return val_a * val_b; },
+      x_diff,
+      y_diff,
+      areas_t);
+
+  free_tensor(x_diff);
+  free_tensor(y_diff);
+
+  Tensor sorted_tensor = make_tensor(
+      scores.sizes(),
+      scores.dim_order(),
+      scores.strides(),
+      scores.scalar_type());
+  Tensor sorted_indices = make_tensor(
+      scores.sizes(), scores.dim_order(), scores.strides(), ScalarType::Long);
+  Error error = sort_tensor(scores, sorted_tensor, sorted_indices, true);
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      error == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to sort scores tensor.");
+
+  auto ndets = dets.size(0);
+  Tensor suppressed_t = make_tensor(
+      {ndets}, {dets.dim_order()[0]}, {dets.strides()[0]}, ScalarType::Byte);
+  std::memset(
+      suppressed_t.mutable_data_ptr<uint8_t>(), 0, suppressed_t.nbytes());
+  std::memset(out.mutable_data_ptr<int64_t>(), 0, out.nbytes());
+
+  auto suppressed = suppressed_t.mutable_data_ptr<uint8_t>();
+  auto keep = out.mutable_data_ptr<int64_t>();
+  auto order = sorted_indices.const_data_ptr<int64_t>();
+  auto x1 = x1_t.const_data_ptr<float>();
+  auto y1 = y1_t.const_data_ptr<float>();
+  auto x2 = x2_t.const_data_ptr<float>();
+  auto y2 = y2_t.const_data_ptr<float>();
+  auto areas = areas_t.const_data_ptr<float>();
+
+  int64_t num_to_keep = 0;
+
+  for (int64_t _i = 0; _i < ndets; _i++) {
+    auto i = order[_i];
+    if (suppressed[i] == 1) {
+      continue;
+    }
+    keep[num_to_keep++] = i;
+    auto ix1 = x1[i];
+    auto iy1 = y1[i];
+    auto ix2 = x2[i];
+    auto iy2 = y2[i];
+    auto iarea = areas[i];
+
+    for (int64_t _j = _i + 1; _j < ndets; _j++) {
+      auto j = order[_j];
+      if (suppressed[j] == 1) {
+        continue;
+      }
+      auto xx1 = std::max(ix1, x1[j]);
+      auto yy1 = std::max(iy1, y1[j]);
+      auto xx2 = std::min(ix2, x2[j]);
+      auto yy2 = std::min(iy2, y2[j]);
+
+      auto w = std::max(static_cast<float>(0), xx2 - xx1);
+      auto h = std::max(static_cast<float>(0), yy2 - yy1);
+      auto inter = w * h;
+      auto ovr = inter / (iarea + areas[j] - inter);
+      if (ovr > iou_threshold) {
+        suppressed[j] = 1;
+      }
+    }
+  }
+
+  free_tensor(x1_t);
+  free_tensor(y1_t);
+  free_tensor(x2_t);
+  free_tensor(y2_t);
+  free_tensor(areas_t);
+  free_tensor(sorted_tensor);
+  free_tensor(sorted_indices);
+  free_tensor(suppressed_t);
+
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, {num_to_keep}) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  return out;
+}
+
+} // namespace native
+} // namespace executor
+} // namespace torch

--- a/kernels/torchvision/cpu/targets.bzl
+++ b/kernels/torchvision/cpu/targets.bzl
@@ -1,0 +1,26 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load("@fbsource//xplat/executorch/kernels/portable:op_registration_util.bzl", "define_op_target", "op_target")
+
+_TORCHVISION_OPS = (
+    op_target(
+        name = "op_nms",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:broadcast_util",
+            "//executorch/kernels/portable/cpu/util:select_copy_util",
+            "//executorch/kernels/portable/cpu/util:sort_util",
+        ],
+    ),
+)
+
+def define_common_targets():
+    for op in _TORCHVISION_OPS:
+        define_op_target(is_aten_op = False, **op)
+
+    torchvision_op_targets = [":{}".format(op["name"]) for op in _TORCHVISION_OPS]
+
+    runtime.cxx_library(
+        name = "torchvision_cpu",
+        srcs = [],
+        visibility = ["//executorch/kernels/torchvision/..."],
+        exported_deps = torchvision_op_targets,
+    )

--- a/kernels/torchvision/ops.yaml
+++ b/kernels/torchvision/ops.yaml
@@ -1,0 +1,7 @@
+- func: torchvision::nms.out(Tensor dets, Tensor scores, float iou_threshold, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  device_check: NoCheck
+  device_guard: False
+  kernels:
+    - arg_meta: null
+      kernel_name: torch::executor::nms_out

--- a/kernels/torchvision/targets.bzl
+++ b/kernels/torchvision/targets.bzl
@@ -1,0 +1,42 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load("@fbsource//xplat/executorch/codegen:codegen.bzl", "et_operator_library", "executorch_generated_lib")
+
+def define_common_targets():
+    runtime.export_file(
+        name = "ops.yaml",
+        visibility = [
+            "@EXECUTORCH_CLIENTS",
+        ],
+    )
+
+    et_operator_library(
+        name = "torchvision_ops",
+        ops_schema_yaml_target = ":ops.yaml",
+        define_static_targets = True,
+    )
+
+    runtime.cxx_library(
+        name = "torchvision_operators",
+        srcs = [],
+        visibility = [
+            "//executorch/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+        exported_deps = [
+            "//executorch/kernels/torchvision/cpu:torchvision_cpu",
+        ],
+    )
+
+    executorch_generated_lib(
+        name = "generated_lib",
+        deps = [
+            ":torchvision_ops",
+            ":torchvision_operators",
+        ],
+        custom_ops_yaml_target = ":ops.yaml",
+        visibility = [
+            "//executorch/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+        define_static_targets = True,
+    )

--- a/kernels/torchvision/test/TARGETS
+++ b/kernels/torchvision/test/TARGETS
@@ -1,0 +1,25 @@
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+# Disabling this pybinding test for now as it fails to emit a program with the nms op in
+# it. Needs to be debugged further, most probably has to do something with symbolic shapes.
+#
+# python_unittest(
+#    # @autodeps-skip
+#    name = "test_ops",
+#    srcs = [
+#        "test_ops.py",
+#    ],
+#    preload_deps = [
+#        "//executorch/kernels/torchvision:custom_ops_generated_lib",
+#    ],
+#    deps = [
+#        "//caffe2:torch",
+#        "//executorch/exir:lib",
+#        "//executorch/extension/pybindings:portable_lib",  # @manual
+#        "//pytorch/vision:torchvision",
+#    ],
+#)
+
+define_common_targets()

--- a/kernels/torchvision/test/op_nms_test.cpp
+++ b/kernels/torchvision/test/op_nms_test.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/kernels/torchvision/NativeFunctions.h> // Declares the operator
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
+#include <executorch/test/utils/DeathTest.h>
+
+#include <gtest/gtest.h>
+#include <limits>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using exec_aten::optional;
+using exec_aten::RuntimeContext;
+using exec_aten::ScalarType;
+using exec_aten::Tensor;
+using torch::executor::testing::TensorFactory;
+
+using torch::executor::native::nms_out;
+
+TEST(OpDequantizeOutTest, NonWholeNumbers) {
+  RuntimeContext ctx{};
+  TensorFactory<ScalarType::Float> tf_float;
+  TensorFactory<ScalarType::Long> tf_long;
+  Tensor boxes =
+      tf_float.make({5, 4}, {0.0, 0.0, 0.5, 0.5, 0.2, 0.2, 0.6, 0.6, 0.4, 0.4,
+                             0.9, 0.9, 0.6, 0.6, 0.8, 0.8, 0.1, 0.1, 0.4, 0.4});
+  Tensor scores = tf_float.make({5}, {0.9, 0.8, 0.7, 0.6, 0.5});
+  double iou_threshold = 0.5;
+  Tensor out =
+      tf_long.zeros({5}, exec_aten::TensorShapeDynamism::DYNAMIC_BOUND);
+  Tensor expected = tf_long.make({5}, {0, 1, 2, 3, 4});
+
+  nms_out(ctx, boxes, scores, iou_threshold, out);
+
+  EXPECT_TENSOR_EQ(out, expected);
+
+  scores = tf_float.make({5}, {0.3, 0.7, 0.2, 0.6, 0.5});
+  expected = tf_long.make({5}, {1, 3, 4, 0, 2});
+  nms_out(ctx, boxes, scores, iou_threshold, out);
+
+  EXPECT_TENSOR_EQ(out, expected);
+
+  // Test a case where the output tensor will have to be resized.
+  iou_threshold = 0.1;
+  expected = tf_long.make({2}, {1, 3});
+  nms_out(ctx, boxes, scores, iou_threshold, out);
+
+  EXPECT_TENSOR_EQ(out, expected);
+}

--- a/kernels/torchvision/test/supported_features_def.yaml
+++ b/kernels/torchvision/test/supported_features_def.yaml
@@ -1,0 +1,1 @@
+# no override

--- a/kernels/torchvision/test/test_ops.py
+++ b/kernels/torchvision/test/test_ops.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+
+import torch
+from executorch.exir import EdgeCompileConfig, ExecutorchBackendConfig, to_edge
+from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
+from executorch.extension.pybindings.portable_lib import (
+    _load_for_executorch_from_buffer,
+)
+from torchvision.ops import nms
+
+
+class WrapperModule(torch.nn.Module):
+    def __init__(self, fn):
+        super().__init__()
+        self.fn = fn
+
+    def forward(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)
+
+
+class TestOps(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_nms(self) -> None:
+        def apply_nms(boxes, scores, iou_threshold=0.5):
+            keep = nms(boxes, scores, iou_threshold)
+            torch._check(keep.shape[0] <= 200)
+            return keep
+
+        boxes = torch.tensor(
+            [[10, 10, 50, 50], [20, 20, 60, 60], [40, 40, 70, 70]], dtype=torch.float32
+        )
+        scores = torch.tensor([0.9, 0.8, 0.7])
+        inputs = (boxes, scores)
+        ep = torch.export.export(WrapperModule(apply_nms), inputs)
+
+        edge = to_edge(
+            ep,
+            compile_config=EdgeCompileConfig(
+                _check_ir_validity=False,
+                _use_edge_ops=True,
+            ),
+        )
+        executorch_program = edge.to_executorch(
+            ExecutorchBackendConfig(
+                sym_shape_eval_pass=ConstraintBasedSymShapeEvalPass()
+            )
+        )
+
+        executorch_module = _load_for_executorch_from_buffer(executorch_program.buffer)
+        et_output = executorch_module(boxes, scores)  # pyre-ignore
+        eager_output = apply_nms(boxes, scores)
+        torch.testing.assert_close(et_output, eager_output)

--- a/runtime/core/exec_aten/testing_util/targets.bzl
+++ b/runtime/core/exec_aten/testing_util/targets.bzl
@@ -28,6 +28,7 @@ def define_common_targets():
                 "//executorch/kernels/portable/cpu/util/test/...",
                 "//executorch/kernels/quantized/test/...",
                 "//executorch/kernels/optimized/test/...",
+                "//executorch/kernels/torchvision/test/...",
                 "//executorch/kernels/test/...",
                 "//executorch/runtime/core/test/...",
                 "//executorch/test/...",

--- a/shim/xplat/executorch/kernels/portable/op_registration_util.bzl
+++ b/shim/xplat/executorch/kernels/portable/op_registration_util.bzl
@@ -116,6 +116,7 @@ def define_op_library(name, deps, android_deps, aten_target, _allow_third_party_
             "//executorch/kernels/portable/test/...",
             "//executorch/kernels/quantized/test/...",
             "//executorch/kernels/optimized/test/...",
+            "//executorch/kernels/torchvision/test/...",
             "//executorch/kernels/test/...",
             "@EXECUTORCH_CLIENTS",
         ],


### PR DESCRIPTION
Summary:
This diff contains the implementation of NMS op for ExecuTorch in portable mode using the ExecuTorch lean tensor.

Reference implementation used for this:
https://fburl.com/code/6qd2y6ty

Current limitations:
- It expects `dets` and `scores` to be of float32, this can be fixed through the templatization of this impl which will be done in a follow up diff.

Differential Revision: D54473147


