### PR TITLE
add aten.sum.dim_IntList

### DIFF
--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -46,6 +46,8 @@ class VulkanSupportedOperators(OperatorSupportBase):
             exir_ops.edge.aten.mm.default,
             # Pooling operators
             exir_ops.edge.aten.max_pool2d_with_indices.default,
+            # Sum
+            exir_ops.edge.aten.sum.dim_IntList,
             # Other
             operator.getitem,
         ]

--- a/backends/vulkan/runtime/graph/ops/glsl/sum_dim.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sum_dim.glsl
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+
+#include "broadcasting_utils.h"
+#include "indexing_utils.h"
+
+#define PRECISION ${PRECISION}
+
+layout(std430) buffer;
+
+layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly ${IMAGE_T[NDIM][DTYPE]} image_out;
+layout(set = 0, binding = 1) uniform PRECISION sampler3D image_in;
+
+layout(set = 0, binding = 2) uniform PRECISION restrict OutExtents {
+  uvec4 data;
+}
+out_extents;
+
+// dim to sum
+layout(set = 0, binding = 3) uniform PRECISION restrict DimVal {
+  int data;
+}
+dim;
+
+// size of dim (in the input)
+layout(set = 0, binding = 4) uniform PRECISION restrict DimSize {
+  int data;
+}
+dim_size;
+
+layout(set = 0, binding = 5) uniform PRECISION restrict Channel {
+  int data;
+}
+flattened_channels;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+/*
+ * Returns a new tensor with values summed along dimension dim
+ * Dimension dim is squeezed
+ * For each pos:
+ *  - Iterate over the out_texel and the summed dimension
+ *  - For H,W; rearrange pos.x, pos.y
+ *  - For C,H,W;
+ *      When CHW are summed, batch moves into channel
+ *      The src N is determined by pos.z * 4 + out_index
+ */
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  vec4 out_texel = vec4(0);
+
+  int src_n;
+  int src_c;
+
+  // Batch
+  if (dim.data == 0) {
+    for (int batch = 0; batch < dim_size.data; ++batch) {
+      src_n = batch;
+      src_c = pos.z;
+      int src_z = src_n * flattened_channels.data + src_c;
+      vec4 v = texelFetch(image_in, ivec3(pos.x, pos.y, src_z), 0);
+      out_texel += v;
+    }
+    imageStore(image_out, pos, out_texel);
+  }
+
+  // Channel
+  else if (dim.data == 1) {
+    for (int out_index = 0; out_index < 4; ++out_index) {
+      for (int channel = 0; channel < dim_size.data; ++channel) {
+        src_n = pos.z * 4 + out_index;
+        src_c = channel;
+        int src_z =
+            src_n * flattened_channels.data + src_c / 4;
+        vec4 v = texelFetch(image_in, ivec3(pos.x, pos.y, src_z), 0);
+        out_texel[out_index] += v[channel % 4];
+      }
+    }
+    imageStore(image_out, pos, out_texel);
+  }
+
+  // Height, Width
+  else {
+    for (int out_index = 0; out_index < 4; ++out_index) {
+      src_n = pos.z * 4 + out_index;
+      src_c = pos.y;
+      int src_z = src_n * flattened_channels.data + src_c / 4;
+      for (int hw = 0; hw < dim_size.data; ++hw) {
+        vec4 v = (dim.data == 2)
+            ? texelFetch(image_in, ivec3(pos.x, hw, src_z), 0) // Height
+            : texelFetch(image_in, ivec3(hw, pos.x, src_z), 0); // Width
+        out_texel[out_index] += v[pos.y % 4];
+      }
+    }
+    imageStore(image_out, pos, out_texel);
+  }
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/sum_dim.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/sum_dim.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+sum_dim:
+  parameter_names_with_default_values:
+    NDIM: 3
+    DTYPE: float
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: half
+        SUFFIX: half
+      - VALUE: float
+        SUFFIX: float
+  shader_variants:
+    - NAME: sum_dim

--- a/backends/vulkan/runtime/graph/ops/glsl/sum_dim_keepdim.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sum_dim_keepdim.glsl
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+
+#include "indexing_utils.h"
+
+#define PRECISION ${PRECISION}
+
+layout(std430) buffer;
+
+layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly ${IMAGE_T[NDIM][DTYPE]} image_out;
+layout(set = 0, binding = 1) uniform PRECISION sampler3D image_in;
+
+layout(set = 0, binding = 2) uniform PRECISION restrict OutExtents {
+  uvec4 data;
+}
+out_extents;
+
+// dim to sum
+layout(set = 0, binding = 3) uniform PRECISION restrict DimVal {
+  int data;
+}
+dim;
+
+// size of dim (in the input)
+layout(set = 0, binding = 4) uniform PRECISION restrict DimSize {
+  int data;
+}
+dim_size;
+
+layout(set = 0, binding = 5) uniform PRECISION restrict Channel {
+  int data;
+}
+flattened_channels;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+/*
+ * Returns a new tensor with values summed along dimension dim.
+ * Output and input have same number of dimensions.
+ * summed dimension is of size 1.
+ */
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  vec4 out_texel = vec4(0);
+
+  int src_n;
+  int src_c;
+
+  // Batch
+  if (dim.data == 0) {
+    for (int batch = 0; batch < dim_size.data; ++batch) {
+      src_n = batch;
+      src_c = pos.z;
+      int src_z = src_n * flattened_channels.data + src_c;
+      out_texel += texelFetch(image_in, ivec3(pos.x, pos.y, src_z), 0);
+    }
+    imageStore(image_out, pos, out_texel);
+  }
+
+  // Channel
+  else if (dim.data == 1) {
+    for (int out_index = 0; out_index < 4; ++out_index) {
+      for (int channel = 0; channel < dim_size.data; ++channel) {
+        src_n = pos.z;
+        src_c = channel;
+        int src_z = src_n * flattened_channels.data + src_c / 4;
+        vec4 v = texelFetch(image_in, ivec3(pos.x, pos.y, src_z), 0);
+        out_texel[out_index] += v[channel % 4];
+      }
+    }
+    imageStore(image_out, pos, out_texel);
+  }
+
+  // Height, Width
+  else {
+    for (int hw = 0; hw < dim_size.data; ++hw) {
+      vec4 v = (dim.data == 2)
+          ? texelFetch(image_in, ivec3(pos.x, hw, pos.z), 0) // Height
+          : texelFetch(image_in, ivec3(hw, pos.y, pos.z), 0); // Width
+      out_texel += v;
+    }
+    imageStore(image_out, pos, out_texel);
+  }
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/sum_dim_keepdim.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/sum_dim_keepdim.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+sum_dim_keepdim:
+  parameter_names_with_default_values:
+    NDIM: 3
+    DTYPE: float
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: half
+        SUFFIX: half
+      - VALUE: float
+        SUFFIX: float
+  shader_variants:
+    - NAME: sum_dim_keepdim

--- a/backends/vulkan/runtime/graph/ops/impl/Sum.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Sum.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// #include <containers/Value.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+#include <cstdint>
+#include <set>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+std::vector<int64_t> calc_out_sizes(vTensor& self, int64_t dim, bool keepdim) {
+  std::vector<int64_t> output_size = self.sizes();
+  if (keepdim) {
+    output_size.at(dim) = 1;
+  } else {
+    output_size.erase(output_size.begin() + dim);
+  }
+  return output_size;
+}
+
+void resize_sum_node(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& extra_args) {
+  (void)args;
+  vTensor& out = graph->get_val(extra_args[0]).toTensor();
+  vTensor& in = graph->get_val(extra_args[1]).toTensor();
+
+  const auto dim = extra_args[2];
+  const auto keepdim = extra_args[3];
+
+  std::vector<int64_t> output_size = calc_out_sizes(in, dim, keepdim);
+
+  out.virtual_resize(output_size);
+}
+
+void check_sum_args(const vTensor& in, const vTensor& out) {
+  VK_CHECK_COND(
+      check_memory_layout_is(in, api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED));
+  VK_CHECK_COND(check_memory_layout_is(
+      out, api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED));
+}
+
+void add_sum_dim_node(
+    ComputeGraph& graph,
+    const ValueRef in,
+    const int64_t dim,
+    const bool keepdim,
+    const ValueRef out) {
+  ValueRef arg = prepack_if_tensor_ref(graph, in);
+
+  vTensor& t_out = graph.get_val(out).toTensor();
+  vTensor& t_input = graph.get_val(in).toTensor();
+
+  check_sum_args(t_input, t_out);
+
+  int64_t in_dim = t_input.sizes().size();
+  int32_t channel =
+      in_dim > 2 ? static_cast<int32_t>(t_input.sizes()[in_dim - 3]) : 1;
+  uint32_t dim_size = t_input.sizes()[dim];
+
+  api::utils::uvec3 global_size = t_out.virtual_extents();
+  api::utils::uvec3 local_size = adaptive_work_group_size(global_size);
+
+  std::stringstream kernel_name;
+  kernel_name << "sum_dim";
+  if (keepdim) {
+    kernel_name << "_keepdim";
+  }
+
+  apply_dtype_suffix(kernel_name, t_out);
+
+  graph.execute_nodes().emplace_back(new ExecuteNode(
+      graph,
+      VK_KERNEL_FROM_STR(kernel_name.str()),
+      global_size,
+      local_size,
+      // Inputs and Outputs
+      {{out, api::MemoryAccessType::WRITE}, {arg, api::MemoryAccessType::READ}},
+      // Shader params buffers
+      {t_out.extents_ubo(),
+       graph.create_params_buffer(dim + 4 - in_dim),
+       graph.create_params_buffer(dim_size),
+       graph.create_params_buffer(int(ceil(channel / 4.0)))},
+      // Resizing
+      resize_sum_node,
+      {out, in, static_cast<int>(dim), keepdim}));
+}
+
+ValueRef add_node(
+    ComputeGraph& graph,
+    const ValueRef input,
+    const int dim,
+    const bool keepdim,
+    const api::ScalarType dtype = api::kFloat) {
+  vTensor& v_input = graph.get_val(input).toTensor();
+  std::vector<int64_t> output_size = calc_out_sizes(v_input, dim, keepdim);
+  return graph.add_tensor(
+      output_size, dtype, api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED);
+}
+
+void add_sum_dim_IntList(
+    ComputeGraph& graph,
+    const ValueRef in,
+    const ValueRef opt_dim,
+    const ValueRef keepdim,
+    const ValueRef out) {
+  bool keepdim_val = graph.get_val(keepdim).toBool();
+  vTensor& in_tensor = graph.get_val(in).toTensor();
+
+  std::set<int64_t> dims_set;
+  auto dims_to_sum = graph.get_val(opt_dim).toIntList();
+  int64_t in_dim = in_tensor.sizes().size();
+
+  for (const auto& dim : dims_to_sum) {
+    // Normalize (negative) dim into range [0, self.dim() - 1]
+    int64_t dim_normalized = normalize(dim, in_dim);
+    dims_set.insert(dim_normalized);
+  }
+
+  // Reduce the higher dimensionalities first, otherwise when keepdim is
+  // false, it will be reducing the wrong dimension.
+  // We add intermediate nodes before the final output node, so we traverse
+  // until `std::prev(dims_set.rend())`. The final output node is added after
+  // the for loop.
+  ValueRef input = in;
+  for (auto dim = dims_set.rbegin(); dim != std::prev(dims_set.rend()); ++dim) {
+    ValueRef tmp_node = add_node(graph, input, *dim, keepdim_val);
+    add_sum_dim_node(graph, input, *dim, keepdim_val, tmp_node);
+    input = tmp_node;
+  }
+  // We add the final output node.
+  add_sum_dim_node(graph, input, *dims_set.begin(), keepdim_val, out);
+}
+
+void sum_dim_IntList(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  // args[3] represents dtype, however serialization of `ScalarType` is not
+  // supported yet. Since our usecase for this op is always float/half, it's
+  // removed from parameters for now.
+  return add_sum_dim_IntList(graph, args[0], args[1], args[2], args[4]);
+}
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(aten.sum.dim_IntList, sum_dim_IntList);
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h
@@ -60,6 +60,14 @@ api::utils::ivec2 create_broadcast_params(const vTensor& t1, const vTensor& t2);
 api::utils::uvec3 adaptive_work_group_size(
     const api::utils::uvec3& global_work_group);
 
+//
+// Tensor dim utilities
+//
+
+inline int64_t normalize(const int64_t dimension, const int64_t n) {
+  return (dimension % n + n) % n;
+}
+
 } // namespace vulkan
 } // namespace native
 } // namespace at

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -477,3 +477,22 @@ class TestBackends(unittest.TestCase):
         sample_inputs = (torch.ones(size=(31, 63), dtype=torch.float32),)
 
         self.lower_module_and_test_output(module, sample_inputs)
+
+    def test_vulkan_backend_sum_dim_list(self):
+        class SumModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                x = torch.sum(x, (0, -1), keepdim=True)
+                x = torch.sum(x, 2, keepdim=False)
+                return x
+
+        module = SumModule()
+        sample_inputs = (torch.ones(size=(3, 2, 7, 5), dtype=torch.float32),)
+
+        self.lower_module_and_test_output(
+            module,
+            sample_inputs,
+            memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
+        )


### PR DESCRIPTION
Summary: ` aten.sum.dim_IntList` reads in a parameter `dims` which are the dimensions we want to reduce. We process these dimensions one by one by adding intermediate nodes to store the intermediate output.

Reviewed By: jorgep31415

Differential Revision: D55288560


