### PR TITLE
Fork Vulkan API into ExecuTorch directory

### DIFF
--- a/backends/vulkan/runtime/api/Adapter.cpp
+++ b/backends/vulkan/runtime/api/Adapter.cpp
@@ -1,0 +1,449 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/Adapter.h>
+
+#include <bitset>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <utility>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
+    : handle(physical_device_handle),
+      properties{},
+      memory_properties{},
+      queue_families{},
+      num_compute_queues(0),
+      has_unified_memory(false),
+      has_timestamps(properties.limits.timestampComputeAndGraphics),
+      timestamp_period(properties.limits.timestampPeriod) {
+  // Extract physical device properties
+  vkGetPhysicalDeviceProperties(handle, &properties);
+  vkGetPhysicalDeviceMemoryProperties(handle, &memory_properties);
+
+  // Check if there are any memory types have both the HOST_VISIBLE and the
+  // DEVICE_LOCAL property flags
+  const VkMemoryPropertyFlags unified_memory_flags =
+      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+  for (size_t i = 0; i < memory_properties.memoryTypeCount; ++i) {
+    if (memory_properties.memoryTypes[i].propertyFlags | unified_memory_flags) {
+      has_unified_memory = true;
+      break;
+    }
+  }
+
+  uint32_t queue_family_count = 0;
+  vkGetPhysicalDeviceQueueFamilyProperties(
+      handle, &queue_family_count, nullptr);
+
+  queue_families.resize(queue_family_count);
+  vkGetPhysicalDeviceQueueFamilyProperties(
+      handle, &queue_family_count, queue_families.data());
+
+  // Find the total number of compute queues
+  for (const VkQueueFamilyProperties& properties : queue_families) {
+    // Check if this family has compute capability
+    if (properties.queueFlags & VK_QUEUE_COMPUTE_BIT) {
+      num_compute_queues += properties.queueCount;
+    }
+  }
+}
+
+namespace {
+
+void find_requested_device_extensions(
+    VkPhysicalDevice physical_device,
+    std::vector<const char*>& enabled_extensions,
+    const std::vector<const char*>& requested_extensions) {
+  uint32_t device_extension_properties_count = 0;
+  VK_CHECK(vkEnumerateDeviceExtensionProperties(
+      physical_device, nullptr, &device_extension_properties_count, nullptr));
+  std::vector<VkExtensionProperties> device_extension_properties(
+      device_extension_properties_count);
+  VK_CHECK(vkEnumerateDeviceExtensionProperties(
+      physical_device,
+      nullptr,
+      &device_extension_properties_count,
+      device_extension_properties.data()));
+
+  std::vector<const char*> enabled_device_extensions;
+
+  for (const auto& requested_extension : requested_extensions) {
+    for (const auto& extension : device_extension_properties) {
+      if (strcmp(requested_extension, extension.extensionName) == 0) {
+        enabled_extensions.push_back(requested_extension);
+        break;
+      }
+    }
+  }
+}
+
+VkDevice create_logical_device(
+    const PhysicalDevice& physical_device,
+    const uint32_t num_queues_to_create,
+    std::vector<Adapter::Queue>& queues,
+    std::vector<uint32_t>& queue_usage) {
+  // Find compute queues up to the requested number of queues
+
+  std::vector<VkDeviceQueueCreateInfo> queue_create_infos;
+  queue_create_infos.reserve(num_queues_to_create);
+
+  std::vector<std::pair<uint32_t, uint32_t>> queues_to_get;
+  queues_to_get.reserve(num_queues_to_create);
+
+  uint32_t remaining_queues = num_queues_to_create;
+  for (uint32_t family_i = 0; family_i < physical_device.queue_families.size();
+       ++family_i) {
+    const VkQueueFamilyProperties& queue_properties =
+        physical_device.queue_families.at(family_i);
+    // Check if this family has compute capability
+    if (queue_properties.queueFlags & VK_QUEUE_COMPUTE_BIT) {
+      const uint32_t queues_to_init =
+          std::min(remaining_queues, queue_properties.queueCount);
+
+      const std::vector<float> queue_priorities(queues_to_init, 1.0f);
+      queue_create_infos.push_back({
+          VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO, // sType
+          nullptr, // pNext
+          0u, // flags
+          family_i, // queueFamilyIndex
+          queues_to_init, // queueCount
+          queue_priorities.data(), // pQueuePriorities
+      });
+
+      for (size_t queue_i = 0; queue_i < queues_to_init; ++queue_i) {
+        // Use this to get the queue handle once device is created
+        queues_to_get.emplace_back(family_i, queue_i);
+      }
+      remaining_queues -= queues_to_init;
+    }
+    if (remaining_queues == 0) {
+      break;
+    }
+  }
+
+  queues.reserve(queues_to_get.size());
+  queue_usage.reserve(queues_to_get.size());
+
+  // Create the VkDevice
+
+  std::vector<const char*> requested_device_extensions{
+#ifdef VK_KHR_portability_subset
+      VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME,
+#endif /* VK_KHR_portability_subset */
+  };
+
+  std::vector<const char*> enabled_device_extensions;
+  find_requested_device_extensions(
+      physical_device.handle,
+      enabled_device_extensions,
+      requested_device_extensions);
+
+  const VkDeviceCreateInfo device_create_info{
+      VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      static_cast<uint32_t>(queue_create_infos.size()), // queueCreateInfoCount
+      queue_create_infos.data(), // pQueueCreateInfos
+      0u, // enabledLayerCount
+      nullptr, // ppEnabledLayerNames
+      static_cast<uint32_t>(
+          enabled_device_extensions.size()), // enabledExtensionCount
+      enabled_device_extensions.data(), // ppEnabledExtensionNames
+      nullptr, // pEnabledFeatures
+  };
+
+  VkDevice handle = nullptr;
+  VK_CHECK(vkCreateDevice(
+      physical_device.handle, &device_create_info, nullptr, &handle));
+
+#ifdef USE_VULKAN_VOLK
+  volkLoadDevice(handle);
+#endif /* USE_VULKAN_VOLK */
+
+  // Obtain handles for the created queues and initialize queue usage heuristic
+
+  for (const std::pair<uint32_t, uint32_t>& queue_idx : queues_to_get) {
+    VkQueue queue_handle = VK_NULL_HANDLE;
+    VkQueueFlags flags =
+        physical_device.queue_families.at(queue_idx.first).queueFlags;
+    vkGetDeviceQueue(handle, queue_idx.first, queue_idx.second, &queue_handle);
+    queues.push_back({queue_idx.first, queue_idx.second, flags, queue_handle});
+    // Initial usage value
+    queue_usage.push_back(0);
+  }
+
+  return handle;
+}
+
+// Print utils
+
+std::string get_device_type_str(const VkPhysicalDeviceType type) {
+  switch (type) {
+    case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+      return "INTEGRATED_GPU";
+    case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+      return "DISCRETE_GPU";
+    case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
+      return "VIRTUAL_GPU";
+    case VK_PHYSICAL_DEVICE_TYPE_CPU:
+      return "CPU";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+std::string get_memory_properties_str(const VkMemoryPropertyFlags flags) {
+  std::bitset<10> values(flags);
+  std::stringstream ss("|");
+  if (values[0]) {
+    ss << " DEVICE_LOCAL |";
+  }
+  if (values[1]) {
+    ss << " HOST_VISIBLE |";
+  }
+  if (values[2]) {
+    ss << " HOST_COHERENT |";
+  }
+  if (values[3]) {
+    ss << " HOST_CACHED |";
+  }
+  if (values[4]) {
+    ss << " LAZILY_ALLOCATED |";
+  }
+
+  return ss.str();
+}
+
+std::string get_queue_family_properties_str(const VkQueueFlags flags) {
+  std::bitset<10> values(flags);
+  std::stringstream ss("|");
+  if (values[0]) {
+    ss << " GRAPHICS |";
+  }
+  if (values[1]) {
+    ss << " COMPUTE |";
+  }
+  if (values[2]) {
+    ss << " TRANSFER |";
+  }
+
+  return ss.str();
+}
+
+} // namespace
+
+//
+// DeviceHandle
+//
+
+DeviceHandle::DeviceHandle(VkDevice device) : handle_(device) {}
+
+DeviceHandle::DeviceHandle(DeviceHandle&& other) noexcept
+    : handle_(other.handle_) {
+  other.handle_ = VK_NULL_HANDLE;
+}
+
+DeviceHandle::~DeviceHandle() {
+  if (VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroyDevice(handle_, nullptr);
+}
+
+//
+// Adapter
+//
+
+Adapter::Adapter(
+    VkInstance instance,
+    PhysicalDevice physical_device,
+    const uint32_t num_queues)
+    : queue_usage_mutex_{},
+      physical_device_(std::move(physical_device)),
+      queues_{},
+      queue_usage_{},
+      queue_mutexes_{},
+      instance_(instance),
+      device_(create_logical_device(
+          physical_device_,
+          num_queues,
+          queues_,
+          queue_usage_)),
+      shader_layout_cache_(device_.handle_),
+      shader_cache_(device_.handle_),
+      pipeline_layout_cache_(device_.handle_),
+      compute_pipeline_cache_(device_.handle_),
+      sampler_cache_(device_.handle_),
+      vma_(instance_, physical_device_.handle, device_.handle_) {}
+
+Adapter::Queue Adapter::request_queue() {
+  // Lock the mutex as multiple threads can request a queue at the same time
+  std::lock_guard<std::mutex> lock(queue_usage_mutex_);
+
+  uint32_t min_usage = UINT32_MAX;
+  uint32_t min_used_i = 0;
+  for (size_t i = 0; i < queues_.size(); ++i) {
+    if (queue_usage_[i] < min_usage) {
+      min_used_i = i;
+      min_usage = queue_usage_[i];
+    }
+  }
+  queue_usage_[min_used_i] += 1;
+
+  return queues_[min_used_i];
+}
+
+void Adapter::return_queue(Adapter::Queue& compute_queue) {
+  for (size_t i = 0; i < queues_.size(); ++i) {
+    if ((queues_[i].family_index == compute_queue.family_index) &&
+        (queues_[i].queue_index == compute_queue.queue_index)) {
+      std::lock_guard<std::mutex> lock(queue_usage_mutex_);
+      queue_usage_[i] -= 1;
+      break;
+    }
+  }
+}
+
+void Adapter::submit_cmd(
+    const Adapter::Queue& device_queue,
+    VkCommandBuffer cmd,
+    VkFence fence) {
+  const VkSubmitInfo submit_info{
+      VK_STRUCTURE_TYPE_SUBMIT_INFO, // sType
+      nullptr, // pNext
+      0u, // waitSemaphoreCount
+      nullptr, // pWaitSemaphores
+      nullptr, // pWaitDstStageMask
+      1u, // commandBufferCount
+      &cmd, // pCommandBuffers
+      0u, // signalSemaphoreCount
+      nullptr, // pSignalSemaphores
+  };
+
+  std::lock_guard<std::mutex> queue_lock(
+      queue_mutexes_[device_queue.queue_index % NUM_QUEUE_MUTEXES]);
+
+  VK_CHECK(vkQueueSubmit(device_queue.handle, 1u, &submit_info, fence));
+}
+
+void Adapter::submit_cmds(
+    const Adapter::Queue& device_queue,
+    const std::vector<VkCommandBuffer>& cmds,
+    VkFence fence) {
+  const VkSubmitInfo submit_info{
+      VK_STRUCTURE_TYPE_SUBMIT_INFO, // sType
+      nullptr, // pNext
+      0u, // waitSemaphoreCount
+      nullptr, // pWaitSemaphores
+      nullptr, // pWaitDstStageMask
+      utils::safe_downcast<uint32_t>(cmds.size()), // commandBufferCount
+      cmds.data(), // pCommandBuffers
+      0u, // signalSemaphoreCount
+      nullptr, // pSignalSemaphores
+  };
+
+  VK_CHECK(vkQueueSubmit(device_queue.handle, 1u, &submit_info, fence));
+}
+
+std::string Adapter::stringize() const {
+  std::stringstream ss;
+
+  VkPhysicalDeviceProperties properties = physical_device_.properties;
+  uint32_t v_major = VK_VERSION_MAJOR(properties.apiVersion);
+  uint32_t v_minor = VK_VERSION_MINOR(properties.apiVersion);
+  std::string device_type = get_device_type_str(properties.deviceType);
+  VkPhysicalDeviceLimits limits = properties.limits;
+
+  ss << "{" << std::endl;
+  ss << "  Physical Device Info {" << std::endl;
+  ss << "    apiVersion:    " << v_major << "." << v_minor << std::endl;
+  ss << "    driverversion: " << properties.driverVersion << std::endl;
+  ss << "    deviceType:    " << device_type << std::endl;
+  ss << "    deviceName:    " << properties.deviceName << std::endl;
+
+#define PRINT_LIMIT_PROP(name)                                         \
+  ss << "      " << std::left << std::setw(36) << #name << limits.name \
+     << std::endl;
+
+#define PRINT_LIMIT_PROP_VEC3(name)                                       \
+  ss << "      " << std::left << std::setw(36) << #name << limits.name[0] \
+     << "," << limits.name[1] << "," << limits.name[2] << std::endl;
+
+  ss << "    Physical Device Limits {" << std::endl;
+  PRINT_LIMIT_PROP(maxImageDimension1D);
+  PRINT_LIMIT_PROP(maxImageDimension2D);
+  PRINT_LIMIT_PROP(maxImageDimension3D);
+  PRINT_LIMIT_PROP(maxTexelBufferElements);
+  PRINT_LIMIT_PROP(maxPushConstantsSize);
+  PRINT_LIMIT_PROP(maxMemoryAllocationCount);
+  PRINT_LIMIT_PROP(maxSamplerAllocationCount);
+  PRINT_LIMIT_PROP(maxComputeSharedMemorySize);
+  PRINT_LIMIT_PROP_VEC3(maxComputeWorkGroupCount);
+  PRINT_LIMIT_PROP(maxComputeWorkGroupInvocations);
+  PRINT_LIMIT_PROP_VEC3(maxComputeWorkGroupSize);
+  ss << "    }" << std::endl;
+  ss << "  }" << std::endl;
+  ;
+
+  const VkPhysicalDeviceMemoryProperties& mem_props =
+      physical_device_.memory_properties;
+
+  ss << "  Memory Info {" << std::endl;
+  ss << "    Memory Types [" << std::endl;
+  for (size_t i = 0; i < mem_props.memoryTypeCount; ++i) {
+    ss << "      "
+       << " [Heap " << mem_props.memoryTypes[i].heapIndex << "] "
+       << get_memory_properties_str(mem_props.memoryTypes[i].propertyFlags)
+       << std::endl;
+  }
+  ss << "    ]" << std::endl;
+  ss << "    Memory Heaps [" << std::endl;
+  for (size_t i = 0; i < mem_props.memoryHeapCount; ++i) {
+    ss << "      " << mem_props.memoryHeaps[i].size << std::endl;
+  }
+  ss << "    ]" << std::endl;
+  ss << "  }" << std::endl;
+
+  ss << "  Queue Families {" << std::endl;
+  for (const VkQueueFamilyProperties& queue_family_props :
+       physical_device_.queue_families) {
+    ss << "    (" << queue_family_props.queueCount << " Queues) "
+       << get_queue_family_properties_str(queue_family_props.queueFlags)
+       << std::endl;
+  }
+  ss << "  }" << std::endl;
+  ss << "  VkDevice: " << device_.handle_ << std::endl;
+  ss << "  Compute Queues [" << std::endl;
+  for (const Adapter::Queue& compute_queue : queues_) {
+    ss << "    Family " << compute_queue.family_index << ", Queue "
+       << compute_queue.queue_index << ": " << compute_queue.handle
+       << std::endl;
+    ;
+  }
+  ss << "  ]" << std::endl;
+  ss << "}";
+
+  return ss.str();
+}
+
+std::ostream& operator<<(std::ostream& os, const Adapter& adapter) {
+  os << adapter.stringize() << std::endl;
+  return os;
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/api/Adapter.h
+++ b/backends/vulkan/runtime/api/Adapter.h
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#include <executorch/backends/vulkan/runtime/api/Pipeline.h>
+#include <executorch/backends/vulkan/runtime/api/Shader.h>
+#include <executorch/backends/vulkan/runtime/api/Utils.h>
+
+#include <array>
+#include <mutex>
+#include <ostream>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+struct PhysicalDevice final {
+  // Handle
+  VkPhysicalDevice handle;
+
+  // Properties obtained from Vulkan
+  VkPhysicalDeviceProperties properties;
+  VkPhysicalDeviceMemoryProperties memory_properties;
+  std::vector<VkQueueFamilyProperties> queue_families;
+
+  // Metadata
+  uint32_t num_compute_queues;
+  bool has_unified_memory;
+  bool has_timestamps;
+  float timestamp_period;
+
+  explicit PhysicalDevice(VkPhysicalDevice);
+};
+
+class DeviceHandle final {
+ public:
+  explicit DeviceHandle(VkDevice device);
+
+  DeviceHandle(const DeviceHandle&) = delete;
+  DeviceHandle& operator=(const DeviceHandle&) = delete;
+
+  DeviceHandle(DeviceHandle&&) noexcept;
+  DeviceHandle& operator=(DeviceHandle&&) = delete;
+
+  ~DeviceHandle();
+
+ private:
+  VkDevice handle_;
+
+  friend class Adapter;
+};
+
+//
+// A Vulkan Adapter represents a logical device and all its properties. It
+// manages all relevant properties of the underlying physical device, a
+// handle to the logical device, and a number of compute queues available to
+// the device. It is primarily responsible for managing the VkDevice handle
+// which points to the logical device object on the GPU.
+//
+// This class is primarily used by the Runtime class, which holds one Adapter
+// instance for each physical device visible to the VkInstance. Upon
+// construction, this class will populate the physical device properties, but
+// will not create the logical device until specifically requested via the
+// init_device() function.
+//
+// init_device() will create the logical device and obtain the VkDevice handle
+// for it. It will also create a number of compute queues up to the amount
+// requested when the Adapter instance was constructed.
+//
+// Contexts (which represent one thread of execution) will request a compute
+// queue from an Adapter. The Adapter will then select a compute queue to
+// assign to the Context, attempting to balance load between all available
+// queues. This will allow different Contexts (which typically execute on
+// separate threads) to run concurrently.
+//
+
+#define NUM_QUEUE_MUTEXES 4
+
+class Adapter final {
+ public:
+  explicit Adapter(
+      VkInstance instance,
+      PhysicalDevice physical_device,
+      const uint32_t num_queues);
+
+  Adapter(const Adapter&) = delete;
+  Adapter& operator=(const Adapter&) = delete;
+
+  Adapter(Adapter&&) = delete;
+  Adapter& operator=(Adapter&&) = delete;
+
+  ~Adapter() = default;
+
+  struct Queue {
+    uint32_t family_index;
+    uint32_t queue_index;
+    VkQueueFlags capabilities;
+    VkQueue handle;
+  };
+
+ private:
+  // Use a mutex to manage queue usage info since
+  // it can be accessed from multiple threads
+  std::mutex queue_usage_mutex_;
+  // Physical Device Info
+  PhysicalDevice physical_device_;
+  // Queue Management
+  std::vector<Queue> queues_;
+  std::vector<uint32_t> queue_usage_;
+  std::array<std::mutex, NUM_QUEUE_MUTEXES> queue_mutexes_;
+  // Handles
+  VkInstance instance_;
+  DeviceHandle device_;
+  // Device-level resource caches
+  ShaderLayoutCache shader_layout_cache_;
+  ShaderCache shader_cache_;
+  PipelineLayoutCache pipeline_layout_cache_;
+  ComputePipelineCache compute_pipeline_cache_;
+  // Memory Management
+  SamplerCache sampler_cache_;
+  MemoryAllocator vma_;
+
+ public:
+  // Physical Device metadata
+
+  inline VkPhysicalDevice physical_handle() const {
+    return physical_device_.handle;
+  }
+
+  inline VkDevice device_handle() const {
+    return device_.handle_;
+  }
+
+  inline bool has_unified_memory() const {
+    return physical_device_.has_unified_memory;
+  }
+
+  inline uint32_t num_compute_queues() const {
+    return physical_device_.num_compute_queues;
+  }
+
+  inline bool timestamp_compute_and_graphics() const {
+    return physical_device_.has_timestamps;
+  }
+
+  inline float timestamp_period() const {
+    return physical_device_.timestamp_period;
+  }
+
+  // Queue Management
+
+  Queue request_queue();
+  void return_queue(Queue&);
+
+  // Caches
+
+  inline ShaderLayoutCache& shader_layout_cache() {
+    return shader_layout_cache_;
+  }
+
+  inline ShaderCache& shader_cache() {
+    return shader_cache_;
+  }
+
+  inline PipelineLayoutCache& pipeline_layout_cache() {
+    return pipeline_layout_cache_;
+  }
+
+  inline ComputePipelineCache& compute_pipeline_cache() {
+    return compute_pipeline_cache_;
+  }
+
+  // Memory Allocation
+
+  inline SamplerCache& sampler_cache() {
+    return sampler_cache_;
+  }
+
+  inline MemoryAllocator& vma() {
+    return vma_;
+  }
+
+  // Command Buffer Submission
+
+  void
+  submit_cmd(const Queue&, VkCommandBuffer, VkFence fence = VK_NULL_HANDLE);
+
+  void submit_cmds(
+      const Adapter::Queue&,
+      const std::vector<VkCommandBuffer>&,
+      VkFence fence = VK_NULL_HANDLE);
+
+  // Miscellaneous
+
+  inline utils::uvec3 local_work_group_size() const {
+    return {
+        4u,
+        4u,
+        4u,
+    };
+  }
+
+  std::string stringize() const;
+  friend std::ostream& operator<<(std::ostream&, const Adapter&);
+};
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/Allocator.cpp
+++ b/backends/vulkan/runtime/api/Allocator.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#define VMA_IMPLEMENTATION
+#include <executorch/backends/vulkan/runtime/api/Allocator.h>

--- a/backends/vulkan/runtime/api/Allocator.h
+++ b/backends/vulkan/runtime/api/Allocator.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+//
+// Do NOT include vk_mem_alloc.h directly.
+// Always include this file (Allocator.h) instead.
+//
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#ifdef USE_VULKAN_API
+
+#define VMA_VULKAN_VERSION 1000000
+
+#ifdef USE_VULKAN_WRAPPER
+#define VMA_STATIC_VULKAN_FUNCTIONS 0
+#else
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 0
+#endif /* USE_VULKAN_WRAPPER */
+
+#define VMA_DEFAULT_LARGE_HEAP_BLOCK_SIZE (32ull * 1024 * 1024)
+#define VMA_SMALL_HEAP_MAX_SIZE (256ull * 1024 * 1024)
+
+#define VMA_STATS_STRING_ENABLED 0
+
+#ifdef VULKAN_DEBUG
+#define VMA_DEBUG_ALIGNMENT 4096
+#define VMA_DEBUG_ALWAYS_DEDICATED_MEMORY 0
+#define VMA_DEBUG_DETECT_CORRUPTION 1
+#define VMA_DEBUG_GLOBAL_MUTEX 1
+#define VMA_DEBUG_INITIALIZE_ALLOCATIONS 1
+#define VMA_DEBUG_MARGIN 64
+#define VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY 256
+#define VMA_RECORDING_ENABLED 1
+
+#define VMA_DEBUG_LOG(format, ...)
+/*
+#define VMA_DEBUG_LOG(format, ...) do { \
+    printf(format, __VA_ARGS__); \
+    printf("\n"); \
+} while(false)
+*/
+#endif /* VULKAN_DEBUG */
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+#pragma clang diagnostic ignored "-Wunused-variable"
+#endif /* __clang__ */
+
+#include <include/vk_mem_alloc.h>
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif /* __clang__ */
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/Command.cpp
+++ b/backends/vulkan/runtime/api/Command.cpp
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/Adapter.h>
+#include <executorch/backends/vulkan/runtime/api/Command.h>
+
+#include <mutex>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+//
+// CommandBuffer
+//
+
+CommandBuffer::CommandBuffer(
+    VkCommandBuffer handle,
+    const VkCommandBufferUsageFlags flags)
+    : handle_(handle),
+      flags_(flags),
+      state_(CommandBuffer::State::NEW),
+      bound_{} {}
+
+CommandBuffer::CommandBuffer(CommandBuffer&& other) noexcept
+    : handle_(other.handle_),
+      flags_(other.flags_),
+      state_(CommandBuffer::State::INVALID),
+      bound_(other.bound_) {
+  other.handle_ = VK_NULL_HANDLE;
+  other.bound_.reset();
+}
+
+CommandBuffer& CommandBuffer::operator=(CommandBuffer&& other) noexcept {
+  handle_ = other.handle_;
+  flags_ = other.flags_;
+  state_ = other.state_;
+  bound_ = other.bound_;
+
+  other.handle_ = VK_NULL_HANDLE;
+  other.bound_.reset();
+  other.state_ = CommandBuffer::State::INVALID;
+
+  return *this;
+}
+
+void CommandBuffer::begin() {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::NEW,
+      "Vulkan CommandBuffer: called begin() on a command buffer whose state "
+      "is not NEW.");
+
+  const VkCommandBufferBeginInfo begin_info{
+      VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+      nullptr,
+      flags_,
+      nullptr,
+  };
+
+  VK_CHECK(vkBeginCommandBuffer(handle_, &begin_info));
+  state_ = CommandBuffer::State::RECORDING;
+}
+
+void CommandBuffer::end() {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::RECORDING ||
+          state_ == CommandBuffer::State::SUBMITTED,
+      "Vulkan CommandBuffer: called end() on a command buffer whose state "
+      "is not RECORDING or SUBMITTED.");
+
+  if (state_ == CommandBuffer::State::RECORDING) {
+    VK_CHECK(vkEndCommandBuffer(handle_));
+  }
+  state_ = CommandBuffer::State::READY;
+}
+
+void CommandBuffer::bind_pipeline(
+    VkPipeline pipeline,
+    VkPipelineLayout pipeline_layout,
+    const utils::uvec3 local_workgroup_size) {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::RECORDING,
+      "Vulkan CommandBuffer: called bind_pipeline() on a command buffer whose state "
+      "is not RECORDING.");
+
+  if (pipeline != bound_.pipeline) {
+    vkCmdBindPipeline(handle_, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+
+    bound_.pipeline = pipeline;
+  }
+
+  bound_.pipeline_layout = pipeline_layout;
+  bound_.local_workgroup_size = local_workgroup_size;
+
+  state_ = CommandBuffer::State::PIPELINE_BOUND;
+}
+
+void CommandBuffer::bind_descriptors(VkDescriptorSet descriptors) {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::PIPELINE_BOUND,
+      "Vulkan CommandBuffer: called bind_descriptors() on a command buffer whose state "
+      "is not PIPELINE_BOUND.");
+
+  if (descriptors != bound_.descriptors) {
+    vkCmdBindDescriptorSets(
+        handle_, // commandBuffer
+        VK_PIPELINE_BIND_POINT_COMPUTE, // pipelineBindPoint
+        bound_.pipeline_layout, // layout
+        0u, // firstSet
+        1u, // descriptorSetCount
+        &descriptors, // pDescriptorSets
+        0u, // dynamicOffsetCount
+        nullptr); // pDynamicOffsets
+  }
+
+  bound_.descriptors = descriptors;
+
+  state_ = CommandBuffer::State::DESCRIPTORS_BOUND;
+}
+
+void CommandBuffer::insert_barrier(PipelineBarrier& pipeline_barrier) {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::DESCRIPTORS_BOUND ||
+          state_ == CommandBuffer::State::RECORDING,
+      "Vulkan CommandBuffer: called insert_barrier() on a command buffer whose state "
+      "is not DESCRIPTORS_BOUND or RECORDING.");
+
+  if (pipeline_barrier) {
+    if (!pipeline_barrier.buffer_barrier_handles.empty()) {
+      pipeline_barrier.buffer_barrier_handles.clear();
+    }
+    for (const api::BufferMemoryBarrier& memory_barrier :
+         pipeline_barrier.buffers) {
+      pipeline_barrier.buffer_barrier_handles.push_back(memory_barrier.handle);
+    }
+
+    if (!pipeline_barrier.image_barrier_handles.empty()) {
+      pipeline_barrier.image_barrier_handles.clear();
+    }
+    for (const api::ImageMemoryBarrier& memory_barrier :
+         pipeline_barrier.images) {
+      pipeline_barrier.image_barrier_handles.push_back(memory_barrier.handle);
+    }
+    vkCmdPipelineBarrier(
+        handle_, // commandBuffer
+        pipeline_barrier.stage.src, // srcStageMask
+        pipeline_barrier.stage.dst, // dstStageMask
+        0u, // dependencyFlags
+        0u, // memoryBarrierCount
+        nullptr, // pMemoryBarriers
+        pipeline_barrier.buffers.size(), // bufferMemoryBarrierCount
+        !pipeline_barrier.buffers.empty()
+            ? pipeline_barrier.buffer_barrier_handles.data()
+            : nullptr, // pMemoryBarriers
+        pipeline_barrier.images.size(), // imageMemoryBarrierCount
+        !pipeline_barrier.images.empty()
+            ? pipeline_barrier.image_barrier_handles.data()
+            : nullptr); // pImageMemoryBarriers
+  }
+
+  state_ = CommandBuffer::State::BARRIERS_INSERTED;
+}
+
+void CommandBuffer::dispatch(const utils::uvec3& global_workgroup_size) {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::BARRIERS_INSERTED,
+      "Vulkan CommandBuffer: called dispatch() on a command buffer whose state "
+      "is not BARRIERS_INSERTED.");
+
+  vkCmdDispatch(
+      handle_,
+      utils::div_up(
+          global_workgroup_size.data[0u], bound_.local_workgroup_size.data[0u]),
+      utils::div_up(
+          global_workgroup_size.data[1u], bound_.local_workgroup_size.data[1u]),
+      utils::div_up(
+          global_workgroup_size.data[2u],
+          bound_.local_workgroup_size.data[2u]));
+
+  state_ = CommandBuffer::State::RECORDING;
+}
+
+void CommandBuffer::copy_buffer_to_buffer(
+    const api::VulkanBuffer& source,
+    const api::VulkanBuffer& destination,
+    const api::utils::uvec3& copy_range,
+    const api::utils::uvec3& src_offset,
+    const api::utils::uvec3& dst_offset) {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::BARRIERS_INSERTED,
+      "Vulkan CommandBuffer: called copy_buffer_to_buffer() on a command buffer whose state "
+      "is not BARRIERS_INSERTED.");
+
+  const VkBufferCopy copy_details{
+      src_offset.data[0u], // srcOffset
+      dst_offset.data[0u], // dstOffset
+      copy_range.data[0u], // size
+  };
+
+  vkCmdCopyBuffer(
+      handle_, source.handle(), destination.handle(), 1u, &copy_details);
+
+  state_ = CommandBuffer::State::RECORDING;
+}
+
+void CommandBuffer::copy_texture_to_texture(
+    const api::VulkanImage& source,
+    const api::VulkanImage& destination,
+    const api::utils::uvec3& copy_range,
+    const api::utils::uvec3& src_offset,
+    const api::utils::uvec3& dst_offset) {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::BARRIERS_INSERTED,
+      "Vulkan CommandBuffer: called copy_texture_to_texture() on a command buffer whose state "
+      "is not BARRIERS_INSERTED.");
+
+  const VkImageSubresourceLayers src_subresource_layers{
+      VK_IMAGE_ASPECT_COLOR_BIT, // aspectMask
+      0u, // mipLevel
+      0u, // baseArrayLayer
+      1u, // layerCount
+  };
+
+  const VkImageSubresourceLayers dst_subresource_layers{
+      VK_IMAGE_ASPECT_COLOR_BIT, // aspectMask
+      0u, // mipLevel
+      0u, // baseArrayLayer
+      1u, // layerCount
+  };
+
+  const VkImageCopy copy_details{
+      src_subresource_layers, // srcSubresource
+      create_offset3d(src_offset), // srcOffset
+      dst_subresource_layers, // dstSubresource
+      create_offset3d(dst_offset), // dstOffset
+      create_extent3d(copy_range), // extent
+  };
+
+  vkCmdCopyImage(
+      handle_,
+      source.handle(),
+      source.layout(),
+      destination.handle(),
+      destination.layout(),
+      1u,
+      &copy_details);
+
+  state_ = CommandBuffer::State::RECORDING;
+}
+
+void CommandBuffer::copy_texture_to_buffer(
+    const api::VulkanImage& source,
+    const api::VulkanBuffer& destination,
+    const api::utils::uvec3& copy_range,
+    const api::utils::uvec3& src_offset,
+    const api::utils::uvec3& dst_offset) {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::BARRIERS_INSERTED,
+      "Vulkan CommandBuffer: called copy_texture_to_buffer() on a command buffer whose state "
+      "is not BARRIERS_INSERTED.");
+
+  const VkImageSubresourceLayers src_subresource_layers{
+      VK_IMAGE_ASPECT_COLOR_BIT, // aspectMask
+      0u, // mipLevel
+      0u, // baseArrayLayer
+      1u, // layerCount
+  };
+
+  const VkBufferImageCopy copy_details{
+      dst_offset.data[0u], // bufferOffset
+      dst_offset.data[1u], // bufferRowLength
+      dst_offset.data[2u], // bufferImageHeight
+      src_subresource_layers, // imageSubresource
+      create_offset3d(src_offset), // imageOffset
+      create_extent3d(copy_range), // imageExtent
+  };
+
+  vkCmdCopyImageToBuffer(
+      handle_,
+      source.handle(),
+      source.layout(),
+      destination.handle(),
+      1u,
+      &copy_details);
+
+  state_ = CommandBuffer::State::RECORDING;
+}
+
+void CommandBuffer::copy_buffer_to_texture(
+    const api::VulkanBuffer& source,
+    const api::VulkanImage& destination,
+    const api::utils::uvec3& copy_range,
+    const api::utils::uvec3& src_offset,
+    const api::utils::uvec3& dst_offset) {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::BARRIERS_INSERTED,
+      "Vulkan CommandBuffer: called copy_buffer_to_texture() on a command buffer whose state "
+      "is not BARRIERS_INSERTED.");
+
+  const VkImageSubresourceLayers dst_subresource_layers{
+      VK_IMAGE_ASPECT_COLOR_BIT, // aspectMask
+      0u, // mipLevel
+      0u, // baseArrayLayer
+      1u, // layerCount
+  };
+
+  const VkBufferImageCopy copy_details{
+      src_offset.data[0u], // bufferOffset
+      src_offset.data[1u], // bufferRowLength
+      src_offset.data[2u], // bufferImageHeight
+      dst_subresource_layers, // imageSubresource
+      create_offset3d(dst_offset), // imageOffset
+      create_extent3d(copy_range), // imageExtent
+  };
+
+  vkCmdCopyBufferToImage(
+      handle_,
+      source.handle(),
+      destination.handle(),
+      destination.layout(),
+      1u,
+      &copy_details);
+
+  state_ = CommandBuffer::State::RECORDING;
+}
+
+void CommandBuffer::write_timestamp(VkQueryPool querypool, const uint32_t idx)
+    const {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::RECORDING,
+      "Vulkan CommandBuffer: called write_timestamp() on a command buffer whose state "
+      "is not RECORDING.");
+
+  vkCmdWriteTimestamp(
+      handle_, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, querypool, idx);
+}
+
+void CommandBuffer::reset_querypool(
+    VkQueryPool querypool,
+    const uint32_t first_idx,
+    const uint32_t count) const {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::RECORDING,
+      "Vulkan CommandBuffer: called reset_querypool() on a command buffer whose state "
+      "is not RECORDING.");
+
+  vkCmdResetQueryPool(handle_, querypool, first_idx, count);
+}
+
+VkCommandBuffer CommandBuffer::get_submit_handle(const bool final_use) {
+  VK_CHECK_COND(
+      state_ == CommandBuffer::State::READY,
+      "Vulkan CommandBuffer: called begin() on a command buffer whose state "
+      "is not READY.");
+
+  VkCommandBuffer handle = handle_;
+
+  if (!is_reusable() || final_use) {
+    invalidate();
+  }
+  state_ = CommandBuffer::State::SUBMITTED;
+
+  return handle;
+}
+
+//
+// CommandPool
+//
+
+CommandPool::CommandPool(
+    VkDevice device,
+    const uint32_t queue_family_idx,
+    const CommandPoolConfig& config)
+    : device_(device),
+      queue_family_idx_(queue_family_idx),
+      pool_(VK_NULL_HANDLE),
+      config_(config),
+      mutex_{},
+      buffers_{},
+      in_use_(0u) {
+  const VkCommandPoolCreateInfo create_info{
+      VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+      nullptr,
+      VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
+      queue_family_idx_,
+  };
+
+  VK_CHECK(vkCreateCommandPool(device_, &create_info, nullptr, &pool_));
+
+  // Pre-allocate some command buffers
+  allocate_new_batch(config_.cmdPoolInitialSize);
+}
+
+CommandPool::~CommandPool() {
+  if (VK_NULL_HANDLE == pool_) {
+    return;
+  }
+  vkDestroyCommandPool(device_, pool_, nullptr);
+}
+
+CommandBuffer CommandPool::get_new_cmd(bool reusable) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // No-ops if there are command buffers available
+  allocate_new_batch(config_.cmdPoolBatchSize);
+
+  VkCommandBuffer handle = buffers_[in_use_];
+
+  VkCommandBufferUsageFlags cmd_flags = 0u;
+  if (!reusable) {
+    cmd_flags |= VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+  }
+
+  in_use_++;
+  return CommandBuffer(handle, cmd_flags);
+}
+
+void CommandPool::flush() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  VK_CHECK(vkResetCommandPool(device_, pool_, 0u));
+  in_use_ = 0u;
+}
+
+void CommandPool::allocate_new_batch(const uint32_t count) {
+  // No-ops if there are still command buffers available
+  if (in_use_ < buffers_.size()) {
+    return;
+  }
+
+  buffers_.resize(buffers_.size() + count);
+
+  const VkCommandBufferAllocateInfo allocate_info{
+      VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, // sType
+      nullptr, // pNext
+      pool_, // commandPool
+      VK_COMMAND_BUFFER_LEVEL_PRIMARY, // level
+      count, // commandBufferCount
+  };
+
+  VK_CHECK(vkAllocateCommandBuffers(
+      device_, &allocate_info, buffers_.data() + in_use_));
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/api/Command.h
+++ b/backends/vulkan/runtime/api/Command.h
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#include <executorch/backends/vulkan/runtime/api/Descriptor.h>
+#include <executorch/backends/vulkan/runtime/api/Pipeline.h>
+#include <executorch/backends/vulkan/runtime/api/Resource.h>
+#include <executorch/backends/vulkan/runtime/api/Shader.h>
+#include <executorch/backends/vulkan/runtime/api/Utils.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+class CommandBuffer final {
+ public:
+  explicit CommandBuffer(VkCommandBuffer, const VkCommandBufferUsageFlags);
+
+  CommandBuffer(const CommandBuffer&) = delete;
+  CommandBuffer& operator=(const CommandBuffer&) = delete;
+
+  CommandBuffer(CommandBuffer&&) noexcept;
+  CommandBuffer& operator=(CommandBuffer&&) noexcept;
+
+  ~CommandBuffer() = default;
+
+  // The lifecycle of a command buffer is as follows:
+  enum State {
+    INVALID, // Used to indicate the command buffer is moved from
+    NEW, // Set during constructor
+    RECORDING, // Set during call to begin(), dispatch(), and
+               // copy_*_to_*()
+    PIPELINE_BOUND, // Set during call to  bind_pipeline()
+    DESCRIPTORS_BOUND, // Set during call to bind_descriptors()
+    BARRIERS_INSERTED, // Set during call to insert_barrier()
+    READY, //  Set during call to end()
+    SUBMITTED, // Set during call to get_submit_handle()
+  };
+
+  struct Bound {
+    VkPipeline pipeline;
+    VkPipelineLayout pipeline_layout;
+    utils::uvec3 local_workgroup_size;
+    VkDescriptorSet descriptors;
+
+    explicit Bound()
+        : pipeline{VK_NULL_HANDLE},
+          pipeline_layout{VK_NULL_HANDLE},
+          local_workgroup_size{0u, 0u, 0u},
+          descriptors{VK_NULL_HANDLE} {}
+
+    inline void reset() {
+      pipeline = VK_NULL_HANDLE;
+      pipeline_layout = VK_NULL_HANDLE;
+      local_workgroup_size = {0u, 0u, 0u};
+      descriptors = VK_NULL_HANDLE;
+    }
+  };
+
+ private:
+  VkCommandBuffer handle_;
+  VkCommandBufferUsageFlags flags_;
+  State state_;
+  Bound bound_;
+
+ public:
+  inline bool is_reusable() {
+    return !(flags_ & VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+  }
+
+  inline void invalidate() {
+    handle_ = VK_NULL_HANDLE;
+    bound_.reset();
+  }
+
+  void begin();
+  void end();
+
+  void bind_pipeline(VkPipeline, VkPipelineLayout, const utils::uvec3);
+  void bind_descriptors(VkDescriptorSet);
+
+  void insert_barrier(PipelineBarrier& pipeline_barrier);
+  void dispatch(const utils::uvec3&);
+
+  void copy_buffer_to_buffer(
+      const api::VulkanBuffer&,
+      const api::VulkanBuffer&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&);
+
+  void copy_texture_to_texture(
+      const api::VulkanImage&,
+      const api::VulkanImage&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&);
+
+  void copy_texture_to_buffer(
+      const api::VulkanImage&,
+      const api::VulkanBuffer&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&);
+
+  void copy_buffer_to_texture(
+      const api::VulkanBuffer&,
+      const api::VulkanImage&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&);
+
+  void write_timestamp(VkQueryPool, const uint32_t) const;
+  void reset_querypool(VkQueryPool, const uint32_t, const uint32_t) const;
+
+  VkCommandBuffer get_submit_handle(const bool final_use = false);
+
+  inline operator bool() const {
+    return VK_NULL_HANDLE != handle_;
+  }
+};
+
+struct CommandPoolConfig final {
+  uint32_t cmdPoolInitialSize;
+  uint32_t cmdPoolBatchSize;
+};
+
+class CommandPool final {
+ public:
+  explicit CommandPool(VkDevice, const uint32_t, const CommandPoolConfig&);
+
+  CommandPool(const CommandPool&) = delete;
+  CommandPool& operator=(const CommandPool&) = delete;
+
+  CommandPool(CommandPool&&) = delete;
+  CommandPool& operator=(CommandPool&&) = delete;
+
+  ~CommandPool();
+
+ private:
+  VkDevice device_;
+  uint32_t queue_family_idx_;
+  VkCommandPool pool_;
+  CommandPoolConfig config_;
+  // New Buffers
+  std::mutex mutex_;
+  std::vector<VkCommandBuffer> buffers_;
+  size_t in_use_;
+
+ public:
+  CommandBuffer get_new_cmd(bool reusable = false);
+
+  void flush();
+
+ private:
+  void allocate_new_batch(const uint32_t);
+};
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/Context.h>
+
+#include <cstring>
+#include <memory>
+#include <sstream>
+
+#ifndef VULKAN_DESCRIPTOR_POOL_SIZE
+#define VULKAN_DESCRIPTOR_POOL_SIZE 1024u
+#endif
+
+#ifndef VULKAN_QUERY_POOL_SIZE
+#define VULKAN_QUERY_POOL_SIZE 4096u
+#endif
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+Context::Context(size_t adapter_i, const ContextConfig& config)
+    : config_(config),
+      // Important handles
+      adapter_p_(runtime()->get_adapter_p(adapter_i)),
+      device_(adapter_p_->device_handle()),
+      queue_(adapter_p_->request_queue()),
+      // Resource pools
+      command_pool_(device_, queue_.family_index, config_.cmdPoolConfig),
+      descriptor_pool_(device_, config_.descriptorPoolConfig),
+      fences_(device_),
+// Diagnostics
+#ifdef USE_VULKAN_GPU_DIAGNOSTICS
+      querypool_(config_.queryPoolConfig, adapter_p_),
+#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
+      // Command buffer submission
+      cmd_mutex_{},
+      cmd_(VK_NULL_HANDLE, 0u),
+      submit_count_{0u},
+      // Memory Management
+      buffer_clearlist_mutex_{},
+      buffers_to_clear_{},
+      image_clearlist_mutex_{},
+      images_to_clear_{} {
+}
+
+Context::~Context() {
+  try {
+    flush();
+    // Let the device know the context is done with the queue
+    adapter_p_->return_queue(queue_);
+  } catch (...) {
+  }
+}
+
+DescriptorSet Context::get_descriptor_set(
+    const ShaderInfo& shader_descriptor,
+    const utils::uvec3& local_workgroup_size) {
+  VkDescriptorSetLayout shader_layout =
+      shader_layout_cache().retrieve(shader_descriptor.kernel_layout);
+
+  VkPipelineLayout pipeline_layout =
+      pipeline_layout_cache().retrieve(shader_layout);
+
+  VkPipeline pipeline = pipeline_cache().retrieve(
+      {pipeline_layout_cache().retrieve(shader_layout),
+       shader_cache().retrieve(shader_descriptor),
+       local_workgroup_size});
+
+  cmd_.bind_pipeline(pipeline, pipeline_layout, local_workgroup_size);
+
+  return descriptor_pool().get_descriptor_set(
+      shader_layout, shader_descriptor.kernel_layout);
+}
+
+void Context::register_shader_dispatch(
+    const DescriptorSet& descriptors,
+    PipelineBarrier& pipeline_barrier,
+    const ShaderInfo& shader_descriptor,
+    const utils::uvec3& global_workgroup_size) {
+  // Adjust the global workgroup size based on the output tile size
+  const utils::uvec3 effective_global_wg = {
+      utils::div_up(
+          global_workgroup_size.data[0u],
+          shader_descriptor.out_tile_size.data[0u]),
+      utils::div_up(
+          global_workgroup_size.data[1u],
+          shader_descriptor.out_tile_size.data[1u]),
+      utils::div_up(
+          global_workgroup_size.data[2u],
+          shader_descriptor.out_tile_size.data[2u]),
+  };
+
+  cmd_.bind_descriptors(descriptors.get_bind_handle());
+  cmd_.insert_barrier(pipeline_barrier);
+
+  cmd_.dispatch(effective_global_wg);
+}
+
+void Context::submit_cmd_to_gpu(VkFence fence_handle, const bool final_use) {
+  if (cmd_) {
+    cmd_.end();
+    adapter_p_->submit_cmd(
+        queue_, cmd_.get_submit_handle(final_use), fence_handle);
+
+    submit_count_ = 0u;
+  }
+}
+
+void Context::flush() {
+  VK_CHECK(vkQueueWaitIdle(queue()));
+
+  command_pool_.flush();
+  descriptor_pool_.flush();
+
+  // If there is an existing command buffer, invalidate it
+  if (cmd_) {
+    cmd_.invalidate();
+  }
+
+  std::lock_guard<std::mutex> bufferlist_lock(buffer_clearlist_mutex_);
+  std::lock_guard<std::mutex> imagelist_lock(image_clearlist_mutex_);
+  buffers_to_clear_.clear();
+  images_to_clear_.clear();
+}
+
+bool available() {
+  return context();
+}
+
+Context* context() {
+  static const std::unique_ptr<Context> context([]() -> Context* {
+    try {
+      const uint32_t submit_frequency = 16u;
+
+      const CommandPoolConfig cmd_config{
+          32u, // cmdPoolInitialSize
+          8u, // cmdPoolBatchSize
+      };
+
+      const DescriptorPoolConfig descriptor_pool_config{
+          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorPoolMaxSets
+          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorUniformBufferCount
+          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorStorageBufferCount
+          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorCombinedSamplerCount
+          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorStorageImageCount
+          32u, // descriptorPileSizes
+      };
+
+      const QueryPoolConfig query_pool_config{
+          VULKAN_QUERY_POOL_SIZE, // maxQueryCount
+          256u, // initialReserveSize
+      };
+
+      const ContextConfig config{
+          submit_frequency, // cmdSubmitFrequency
+          cmd_config, // cmdPoolConfig
+          descriptor_pool_config, // descriptorPoolConfig
+          query_pool_config, // queryPoolConfig
+      };
+
+      return new Context(runtime()->default_adapter_i(), config);
+    } catch (...) {
+    }
+
+    return nullptr;
+  }());
+
+  return context.get();
+}
+
+//
+// UniformParamsBuffer
+//
+
+namespace {
+
+void memcpy_to_buffer(const VulkanBuffer& src, VulkanBuffer& dst) {
+  MemoryMap dst_mapping(dst, MemoryAccessType::WRITE);
+
+  MemoryMap src_mapping(src, MemoryAccessType::READ);
+  src_mapping.invalidate();
+
+  void* dst_ptr = dst_mapping.template data<void>();
+  void* src_ptr = src_mapping.template data<void>();
+
+  // @lint-ignore CLANGTIDY facebook-security-vulnerable-memcpy
+  memcpy(dst_ptr, src_ptr, src.mem_size());
+}
+
+} // namespace
+
+UniformParamsBuffer::UniformParamsBuffer(const UniformParamsBuffer& other)
+    : context_p_(other.context_p_), vulkan_buffer_{} {
+  if (other.vulkan_buffer_) {
+    vulkan_buffer_ = context_p_->adapter_ptr()->vma().create_uniform_buffer(
+        other.vulkan_buffer_.mem_size());
+
+    memcpy_to_buffer(other.vulkan_buffer_, vulkan_buffer_);
+  }
+}
+
+UniformParamsBuffer& UniformParamsBuffer::operator=(
+    const UniformParamsBuffer& other) {
+  if (&other != this) {
+    context_p_ = other.context_p_;
+
+    // Move vulkan_buffer_ to another VulkanBuffer for cleanup
+    if (vulkan_buffer_) {
+      VulkanBuffer temp_buffer(std::move(vulkan_buffer_));
+      context_p_->register_buffer_cleanup(temp_buffer);
+    }
+    // vulkan_buffer_ should now be empty
+
+    if (other.vulkan_buffer_) {
+      vulkan_buffer_ = context_p_->adapter_ptr()->vma().create_uniform_buffer(
+          other.vulkan_buffer_.mem_size());
+
+      memcpy_to_buffer(other.vulkan_buffer_, vulkan_buffer_);
+    }
+  }
+
+  return *this;
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/api/Context.h
+++ b/backends/vulkan/runtime/api/Context.h
@@ -1,0 +1,567 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#include <executorch/backends/vulkan/runtime/api/Adapter.h>
+#include <executorch/backends/vulkan/runtime/api/Command.h>
+#include <executorch/backends/vulkan/runtime/api/Descriptor.h>
+#include <executorch/backends/vulkan/runtime/api/Pipeline.h>
+#include <executorch/backends/vulkan/runtime/api/QueryPool.h>
+#include <executorch/backends/vulkan/runtime/api/Resource.h>
+#include <executorch/backends/vulkan/runtime/api/Runtime.h>
+#include <executorch/backends/vulkan/runtime/api/Shader.h>
+#include <executorch/backends/vulkan/runtime/api/Utils.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+struct ContextConfig final {
+  uint32_t cmdSubmitFrequency;
+  CommandPoolConfig cmdPoolConfig;
+  DescriptorPoolConfig descriptorPoolConfig;
+  QueryPoolConfig queryPoolConfig;
+};
+
+//
+// Vulkan Context holds onto all relevant Vulkan state as it pertains to our
+// use of Vulkan in PyTorch.  A Context is associated with one, and only one,
+// Adapter as a precursor to multi-GPU support.  All Vulkan tensors in PyTorch
+// are associated with a Context to make tensor <-> device affinity explicit.
+// The context is currently a global object, but technically it does not need
+// to be if we were to make it explicit to the user.
+//
+
+class Context final {
+ public:
+  explicit Context(size_t adapter_i, const ContextConfig&);
+
+  Context(const Context&) = delete;
+  Context& operator=(const Context&) = delete;
+
+  Context(Context&&) = delete;
+  Context& operator=(Context&&) = delete;
+
+  ~Context();
+
+ private:
+  // Config
+  ContextConfig config_;
+  // Important handles
+  Adapter* adapter_p_;
+  VkDevice device_;
+  Adapter::Queue queue_;
+  // Resource Pools
+  CommandPool command_pool_;
+  DescriptorPool descriptor_pool_;
+  FencePool fences_;
+  // Diagnostics
+  // TODO: remove USE_VULKAN_GPU_DIAGNOSTICS
+  bool enable_op_profiling_{false};
+#ifdef USE_VULKAN_GPU_DIAGNOSTICS
+  QueryPool querypool_;
+#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
+  // Command buffers submission
+  std::mutex cmd_mutex_;
+  CommandBuffer cmd_;
+  uint32_t submit_count_;
+  // Memory Management
+  std::mutex buffer_clearlist_mutex_;
+  std::vector<VulkanBuffer> buffers_to_clear_;
+  std::mutex image_clearlist_mutex_;
+  std::vector<VulkanImage> images_to_clear_;
+
+ public:
+  // Adapter access
+
+  inline Adapter* adapter_ptr() {
+    return adapter_p_;
+  }
+
+  inline void enable_op_profiling() {
+    enable_op_profiling_ = true;
+  }
+
+  inline void disable_op_profiling() {
+    enable_op_profiling_ = false;
+  }
+
+  inline bool op_profiling_enabled() {
+    return enable_op_profiling_;
+  }
+
+  inline VkDevice device() {
+    return device_;
+  }
+
+  inline VkQueue queue() {
+    return queue_.handle;
+  }
+
+  // Device Caches
+
+  inline ShaderLayoutCache& shader_layout_cache() {
+    return adapter_ptr()->shader_layout_cache();
+  }
+
+  inline ShaderCache& shader_cache() {
+    return adapter_ptr()->shader_cache();
+  }
+
+  inline PipelineLayoutCache& pipeline_layout_cache() {
+    return adapter_ptr()->pipeline_layout_cache();
+  }
+
+  inline ComputePipelineCache& pipeline_cache() {
+    return adapter_ptr()->compute_pipeline_cache();
+  }
+
+  // Resource Pools
+
+  inline DescriptorPool& descriptor_pool() {
+    return descriptor_pool_;
+  }
+
+  inline FencePool& fences() {
+    return fences_;
+  }
+
+  // Diagnostics
+
+#ifdef USE_VULKAN_GPU_DIAGNOSTICS
+  inline QueryPool& querypool() {
+    return querypool_;
+  }
+
+  inline void reset_querypool() {
+    set_cmd();
+    querypool_.reset(cmd_);
+  }
+#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
+
+  // Memory Management
+  void register_buffer_cleanup(VulkanBuffer& buffer) {
+    std::lock_guard<std::mutex> bufferlist_lock(buffer_clearlist_mutex_);
+    buffers_to_clear_.emplace_back(std::move(buffer));
+  }
+
+  void register_image_cleanup(VulkanImage& image) {
+    std::lock_guard<std::mutex> imagelist_lock(image_clearlist_mutex_);
+    images_to_clear_.emplace_back(std::move(image));
+  }
+
+  // GPU RPC
+
+  inline std::unique_lock<std::mutex> dispatch_lock() {
+    return std::unique_lock<std::mutex>(cmd_mutex_);
+  }
+
+  inline void set_cmd(bool reusable = false) {
+    if (!cmd_) {
+      cmd_ = command_pool_.get_new_cmd(reusable);
+      cmd_.begin();
+    }
+  }
+
+  DescriptorSet get_descriptor_set(const ShaderInfo&, const utils::uvec3&);
+
+  void register_shader_dispatch(
+      const DescriptorSet&,
+      PipelineBarrier&,
+      const ShaderInfo&,
+      const utils::uvec3&);
+
+  template <class S, class D>
+  bool submit_copy(
+      PipelineBarrier&,
+      const S&,
+      const D&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&,
+      VkFence fence_handle);
+
+  template <typename... Arguments>
+  bool submit_compute_job(
+      const ShaderInfo&,
+      PipelineBarrier&,
+      const utils::uvec3&,
+      const utils::uvec3&,
+      VkFence fence_handle,
+      Arguments&&...);
+
+  void submit_cmd_to_gpu(
+      VkFence fence_handle = VK_NULL_HANDLE,
+      const bool final_use = false);
+
+  void flush();
+};
+
+class UniformParamsBuffer final {
+ private:
+  Context* context_p_;
+  size_t nbytes_;
+  VulkanBuffer vulkan_buffer_;
+
+ public:
+  UniformParamsBuffer() : context_p_{nullptr}, vulkan_buffer_{} {}
+
+  template <typename Block>
+  UniformParamsBuffer(Context* context_p, const Block& block)
+      : context_p_(context_p),
+        nbytes_(sizeof(block)),
+        vulkan_buffer_(
+            context_p_->adapter_ptr()->vma().create_params_buffer(block)) {}
+
+  UniformParamsBuffer(const UniformParamsBuffer&);
+  UniformParamsBuffer& operator=(const UniformParamsBuffer&);
+
+  UniformParamsBuffer(UniformParamsBuffer&&) = default;
+  UniformParamsBuffer& operator=(UniformParamsBuffer&&) = default;
+
+  ~UniformParamsBuffer() {
+    if (vulkan_buffer_) {
+      context_p_->register_buffer_cleanup(vulkan_buffer_);
+    }
+  }
+
+  VulkanBuffer& buffer() {
+    return vulkan_buffer_;
+  }
+
+  template <typename Block>
+  void update(const Block& block) {
+    if (sizeof(block) != nbytes_) {
+      VK_THROW(
+          "Attempted to update UniformParamsBuffer with data of different size");
+    }
+    // Fill the uniform buffer with data in block
+    {
+      MemoryMap mapping(vulkan_buffer_, MemoryAccessType::WRITE);
+      Block* data_ptr = mapping.template data<Block>();
+
+      *data_ptr = block;
+    }
+  }
+};
+
+class StorageBuffer final {
+ private:
+  Context* context_p_;
+  ScalarType dtype_;
+  size_t numel_;
+  size_t nbytes_;
+  VulkanBuffer vulkan_buffer_;
+
+ public:
+  StorageBuffer(
+      Context* context_p,
+      const ScalarType dtype,
+      const size_t numel,
+      const bool gpuonly = false)
+      : context_p_(context_p),
+        dtype_(dtype),
+        numel_(numel),
+        nbytes_(element_size(dtype_) * numel_),
+        vulkan_buffer_(context_p_->adapter_ptr()->vma().create_storage_buffer(
+            nbytes_,
+            gpuonly)) {}
+
+  StorageBuffer(const StorageBuffer&) = delete;
+  StorageBuffer& operator=(const StorageBuffer&) = delete;
+
+  StorageBuffer(StorageBuffer&&) = default;
+  StorageBuffer& operator=(StorageBuffer&&) = default;
+
+  ~StorageBuffer() {
+    context_p_->register_buffer_cleanup(vulkan_buffer_);
+  }
+
+  inline ScalarType dtype() {
+    return dtype_;
+  }
+
+  inline VulkanBuffer& buffer() {
+    return vulkan_buffer_;
+  }
+
+  inline size_t numel() {
+    return numel_;
+  }
+
+  inline size_t nbytes() {
+    return nbytes_;
+  }
+};
+
+bool available();
+
+// The global runtime is retrieved using this function, where it is declared as
+// a static local variable.
+Context* context();
+
+namespace detail {
+
+inline void arg_is_empty(bool& any_is_empty, const VulkanBuffer& buffer) {
+  // bool(buffer) will evaluate to false if no memory has been allocated
+  any_is_empty = any_is_empty || !buffer;
+}
+
+inline void arg_is_empty(bool& any_is_empty, const VulkanImage& image) {
+  // bool(image) will evaluate to false if no memory has been allocated
+  any_is_empty = any_is_empty || !image;
+}
+
+/*
+  Reports if any VulkanBuffer or VulkanImage argument in a variadic argument
+  list does not have any memory associated with it.
+ */
+template <typename... Arguments>
+inline bool any_arg_is_empty(Arguments&&... arguments) {
+  bool any_is_empty = false;
+  VK_UNUSED const int _[]{
+      0,
+      (arg_is_empty(any_is_empty, std::forward<Arguments>(arguments)), 0)...,
+  };
+
+  return any_is_empty;
+}
+
+template <size_t... Indices, typename... Arguments>
+inline void bind(
+    DescriptorSet& descriptor_set,
+    const std::index_sequence<Indices...>&,
+    Arguments&&... arguments) {
+  VK_UNUSED const int _[]{
+      0,
+      (descriptor_set.bind(Indices, std::forward<Arguments>(arguments)), 0)...,
+  };
+}
+
+} // namespace detail
+
+template <class S, class D>
+inline void record_copy(
+    CommandBuffer& cmd,
+    const S& source,
+    const D& destination,
+    const api::utils::uvec3& copy_range,
+    const api::utils::uvec3& src_offset,
+    const api::utils::uvec3& dst_offset) = delete;
+
+template <>
+inline void record_copy<VulkanBuffer, VulkanBuffer>(
+    CommandBuffer& cmd,
+    const VulkanBuffer& source,
+    const VulkanBuffer& destination,
+    const api::utils::uvec3& copy_range,
+    const api::utils::uvec3& src_offset,
+    const api::utils::uvec3& dst_offset) {
+  cmd.copy_buffer_to_buffer(
+      source, destination, copy_range, src_offset, dst_offset);
+}
+
+template <>
+inline void record_copy<VulkanImage, VulkanImage>(
+    CommandBuffer& cmd,
+    const VulkanImage& source,
+    const VulkanImage& destination,
+    const api::utils::uvec3& copy_range,
+    const api::utils::uvec3& src_offset,
+    const api::utils::uvec3& dst_offset) {
+  cmd.copy_texture_to_texture(
+      source, destination, copy_range, src_offset, dst_offset);
+}
+
+template <>
+inline void record_copy<VulkanImage, VulkanBuffer>(
+    CommandBuffer& cmd,
+    const VulkanImage& source,
+    const VulkanBuffer& destination,
+    const api::utils::uvec3& copy_range,
+    const api::utils::uvec3& src_offset,
+    const api::utils::uvec3& dst_offset) {
+  cmd.copy_texture_to_buffer(
+      source, destination, copy_range, src_offset, dst_offset);
+}
+
+template <>
+inline void record_copy<VulkanBuffer, VulkanImage>(
+    CommandBuffer& cmd,
+    const VulkanBuffer& source,
+    const VulkanImage& destination,
+    const api::utils::uvec3& copy_range,
+    const api::utils::uvec3& src_offset,
+    const api::utils::uvec3& dst_offset) {
+  cmd.copy_buffer_to_texture(
+      source, destination, copy_range, src_offset, dst_offset);
+}
+
+/*
+  Records a GPU data copy into the current command buffer. If the number of
+  submit_*_job calls exceeds the configured frequency, or if a fence is
+  provided, then the command buffer is submitted to the GPU for execution.
+  Returns a bool indicating whether or not the function call resulted in a GPU
+  queue submission.
+ */
+template <class S, class D>
+inline bool Context::submit_copy(
+    PipelineBarrier& pipeline_barrier,
+    const S& source,
+    const D& destination,
+    const api::utils::uvec3& copy_range,
+    const api::utils::uvec3& src_offset,
+    const api::utils::uvec3& dst_offset,
+    VkFence fence_handle) {
+  // If any of the provided arguments does not have memory associated with it,
+  // then exit early as there is no work to be done. However, if a fence has
+  // been passed the command buffer is not empty, then the current command
+  // buffer must still be submitted so that the fence can be signaled.
+  if (!source || !destination) {
+    if (fence_handle != VK_NULL_HANDLE && submit_count_ > 0) {
+      submit_cmd_to_gpu(fence_handle);
+      return true;
+    }
+    return false;
+  }
+
+  // Serialize recording to the shared command buffer. Do not initialize with a
+  // mutex just yet, since in some cases it will be externally managed.
+  std::unique_lock<std::mutex> cmd_lock;
+  // Refer to comments in submit_compute_job for explanation.
+  if (fence_handle == VK_NULL_HANDLE) {
+    cmd_lock = std::unique_lock<std::mutex>(cmd_mutex_);
+  }
+
+  set_cmd();
+
+#ifdef USE_VULKAN_GPU_DIAGNOSTICS
+  uint32_t log_idx = UINT32_MAX;
+  if (enable_op_profiling_) {
+    std::string label = "cmd_copy";
+    log_idx = querypool_.shader_profile_begin(
+        cmd_, label, create_extent3d({0, 0, 0}), create_extent3d({0, 0, 0}));
+  }
+#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
+
+  cmd_.insert_barrier(pipeline_barrier);
+
+  record_copy(cmd_, source, destination, copy_range, src_offset, dst_offset);
+
+#ifdef USE_VULKAN_GPU_DIAGNOSTICS
+  if (enable_op_profiling_) {
+    querypool_.shader_profile_end(cmd_, log_idx);
+  }
+#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
+
+  submit_count_++;
+  if (fence_handle != VK_NULL_HANDLE ||
+      submit_count_ >= config_.cmdSubmitFrequency) {
+    submit_cmd_to_gpu(fence_handle);
+    return true;
+  }
+  return false;
+}
+
+/*
+  Records a compute shader dispatch into the current command buffer. If the
+  number of submit_*_job calls exceeds the configured frequency, or if a fence
+  is provided, then the command buffer is submitted to the GPU for execution.
+  Returns a bool indicating whether or not the function call resulted in a GPU
+  queue submission.
+ */
+template <typename... Arguments>
+inline bool Context::submit_compute_job(
+    const ShaderInfo& shader,
+    PipelineBarrier& pipeline_barrier,
+    const utils::uvec3& global_work_group,
+    const utils::uvec3& local_work_group_size,
+    VkFence fence_handle,
+    Arguments&&... arguments) {
+  // If any of the provided arguments does not have memory associated with it,
+  // then exit early as there is no work to be done. However, if a fence has
+  // been passed the command buffer is not empty, then the current command
+  // buffer must still be submitted so that the fence can be signaled.
+  if (detail::any_arg_is_empty(arguments...)) {
+    if (fence_handle != VK_NULL_HANDLE && submit_count_ > 0) {
+      submit_cmd_to_gpu(fence_handle);
+      return true;
+    }
+    return false;
+  }
+
+  // Serialize recording to the shared command buffer. Do not initialize with a
+  // mutex just yet, since in some cases it will be externally managed.
+  std::unique_lock<std::mutex> cmd_lock;
+  // If a fence was passed, then assume that the host intends to sync with
+  // the GPU, implying there will be imminent calls to fence.wait() and flush().
+  // We therefore assume the mutex is externally managed in this case, and the
+  // calling thread has already locked the mutex prior to calling the function,
+  // and will release the mutex manually after calling flush(). This will
+  // prevent more dispatches from being recorded until we have flushed the
+  // Context.
+  if (fence_handle == VK_NULL_HANDLE) {
+    cmd_lock = std::unique_lock<std::mutex>(cmd_mutex_);
+  }
+
+  set_cmd();
+
+#ifdef USE_VULKAN_GPU_DIAGNOSTICS
+  uint32_t log_idx = UINT32_MAX;
+  if (enable_op_profiling_) {
+    log_idx = querypool_.shader_profile_begin(
+        cmd_,
+        shader.kernel_name,
+        create_extent3d(global_work_group),
+        create_extent3d(local_work_group_size));
+  }
+#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
+
+  // Factor out template parameter independent code to minimize code bloat.
+  DescriptorSet descriptor_set =
+      get_descriptor_set(shader, local_work_group_size);
+
+  detail::bind(
+      descriptor_set,
+      std::index_sequence_for<Arguments...>{},
+      std::forward<Arguments>(arguments)...);
+
+  // Factor out template parameter independent code to minimize code bloat.
+  register_shader_dispatch(
+      descriptor_set, pipeline_barrier, shader, global_work_group);
+
+#ifdef USE_VULKAN_GPU_DIAGNOSTICS
+  if (enable_op_profiling_) {
+    querypool_.shader_profile_end(cmd_, log_idx);
+  }
+#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
+
+  submit_count_++;
+  if (fence_handle != VK_NULL_HANDLE ||
+      submit_count_ >= config_.cmdSubmitFrequency) {
+    submit_cmd_to_gpu(fence_handle);
+    return true;
+  }
+
+  return false;
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/Descriptor.cpp
+++ b/backends/vulkan/runtime/api/Descriptor.cpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/Descriptor.h>
+#include <executorch/backends/vulkan/runtime/api/Utils.h>
+
+#include <algorithm>
+#include <utility>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+//
+// DescriptorSet
+//
+
+DescriptorSet::DescriptorSet(
+    VkDevice device,
+    VkDescriptorSet handle,
+    ShaderLayout::Signature shader_layout_signature)
+    : device_(device),
+      handle_(handle),
+      shader_layout_signature_(std::move(shader_layout_signature)),
+      bindings_{} {}
+
+DescriptorSet::DescriptorSet(DescriptorSet&& other) noexcept
+    : device_(other.device_),
+      handle_(other.handle_),
+      shader_layout_signature_(std::move(other.shader_layout_signature_)),
+      bindings_(std::move(other.bindings_)) {
+  other.handle_ = VK_NULL_HANDLE;
+}
+
+DescriptorSet& DescriptorSet::operator=(DescriptorSet&& other) noexcept {
+  device_ = other.device_;
+  handle_ = other.handle_;
+  shader_layout_signature_ = std::move(other.shader_layout_signature_);
+  bindings_ = std::move(other.bindings_);
+
+  other.handle_ = VK_NULL_HANDLE;
+
+  return *this;
+}
+
+DescriptorSet& DescriptorSet::bind(
+    const uint32_t idx,
+    const VulkanBuffer& buffer) {
+  VK_CHECK_COND(
+      buffer.has_memory(),
+      "Buffer must be bound to memory for it to be usable");
+
+  DescriptorSet::ResourceBinding binder{};
+  binder.binding_idx = idx; // binding_idx
+  binder.descriptor_type = shader_layout_signature_[idx]; // descriptor_type
+  binder.is_image = false; // is_image
+  binder.resource_info.buffer_info.buffer = buffer.handle(); // buffer
+  binder.resource_info.buffer_info.offset = buffer.mem_offset(); // offset
+  binder.resource_info.buffer_info.range = buffer.mem_range(); // range
+  add_binding(binder);
+
+  return *this;
+}
+
+DescriptorSet& DescriptorSet::bind(
+    const uint32_t idx,
+    const VulkanImage& image) {
+  VK_CHECK_COND(
+      image.has_memory(), "Image must be bound to memory for it to be usable");
+
+  VkImageLayout binding_layout = image.layout();
+  if (shader_layout_signature_[idx] == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+    binding_layout = VK_IMAGE_LAYOUT_GENERAL;
+  }
+
+  DescriptorSet::ResourceBinding binder{};
+  binder.binding_idx = idx; // binding_idx
+  binder.descriptor_type = shader_layout_signature_[idx]; // descriptor_type
+  binder.is_image = true; // is_image
+  binder.resource_info.image_info.sampler = image.sampler(); // buffer
+  binder.resource_info.image_info.imageView = image.image_view(); // imageView
+  binder.resource_info.image_info.imageLayout = binding_layout; // imageLayout
+  add_binding(binder);
+
+  return *this;
+}
+
+VkDescriptorSet DescriptorSet::get_bind_handle() const {
+  std::vector<VkWriteDescriptorSet> write_descriptor_sets;
+
+  for (const ResourceBinding& binding : bindings_) {
+    VkWriteDescriptorSet write{
+        VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, // sType
+        nullptr, // pNext
+        handle_, // dstSet
+        binding.binding_idx, // dstBinding
+        0u, // dstArrayElement
+        1u, // descriptorCount
+        binding.descriptor_type, // descriptorType
+        nullptr, // pImageInfo
+        nullptr, // pBufferInfo
+        nullptr, // pTexelBufferView
+    };
+
+    if (binding.is_image) {
+      write.pImageInfo = &binding.resource_info.image_info;
+    } else {
+      write.pBufferInfo = &binding.resource_info.buffer_info;
+    }
+
+    write_descriptor_sets.emplace_back(write);
+  }
+
+  vkUpdateDescriptorSets(
+      device_,
+      write_descriptor_sets.size(),
+      write_descriptor_sets.data(),
+      0u,
+      nullptr);
+
+  VkDescriptorSet ret = handle_;
+
+  return ret;
+}
+
+void DescriptorSet::add_binding(const ResourceBinding& binding) {
+  const auto bindings_itr = std::find_if(
+      bindings_.begin(),
+      bindings_.end(),
+      [binding_idx = binding.binding_idx](const ResourceBinding& other) {
+        return other.binding_idx == binding_idx;
+      });
+
+  if (bindings_.end() == bindings_itr) {
+    bindings_.emplace_back(binding);
+  } else {
+    *bindings_itr = binding;
+  }
+}
+
+//
+// DescriptorSetPile
+//
+
+DescriptorSetPile::DescriptorSetPile(
+    const uint32_t pile_size,
+    VkDescriptorSetLayout descriptor_set_layout,
+    VkDevice device,
+    VkDescriptorPool descriptor_pool)
+    : pile_size_{pile_size},
+      set_layout_{descriptor_set_layout},
+      device_{device},
+      pool_{descriptor_pool},
+      descriptors_{},
+      in_use_(0u) {
+  descriptors_.resize(pile_size_);
+  allocate_new_batch();
+}
+
+VkDescriptorSet DescriptorSetPile::get_descriptor_set() {
+  // No-ops if there are descriptor sets available
+  allocate_new_batch();
+
+  VkDescriptorSet handle = descriptors_[in_use_];
+  descriptors_[in_use_] = VK_NULL_HANDLE;
+
+  in_use_++;
+  return handle;
+}
+
+void DescriptorSetPile::allocate_new_batch() {
+  // No-ops if there are still descriptor sets available
+  if (in_use_ < descriptors_.size() &&
+      descriptors_[in_use_] != VK_NULL_HANDLE) {
+    return;
+  }
+
+  std::vector<VkDescriptorSetLayout> layouts(descriptors_.size());
+  fill(layouts.begin(), layouts.end(), set_layout_);
+
+  const VkDescriptorSetAllocateInfo allocate_info{
+      VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, // sType
+      nullptr, // pNext
+      pool_, // descriptorPool
+      utils::safe_downcast<uint32_t>(layouts.size()), // descriptorSetCount
+      layouts.data(), // pSetLayouts
+  };
+
+  VK_CHECK(
+      vkAllocateDescriptorSets(device_, &allocate_info, descriptors_.data()));
+
+  in_use_ = 0u;
+}
+
+//
+// DescriptorPool
+//
+
+DescriptorPool::DescriptorPool(
+    VkDevice device,
+    const DescriptorPoolConfig& config)
+    : device_(device),
+      pool_(VK_NULL_HANDLE),
+      config_(config),
+      mutex_{},
+      piles_{} {
+  if (config.descriptorPoolMaxSets > 0) {
+    init(config);
+  }
+}
+
+DescriptorPool::~DescriptorPool() {
+  if (VK_NULL_HANDLE == pool_) {
+    return;
+  }
+  vkDestroyDescriptorPool(device_, pool_, nullptr);
+}
+
+void DescriptorPool::init(const DescriptorPoolConfig& config) {
+  VK_CHECK_COND(
+      pool_ == VK_NULL_HANDLE,
+      "Trying to init a DescriptorPool that has already been created!");
+
+  config_ = config;
+
+  std::vector<VkDescriptorPoolSize> type_sizes{
+      {
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          config_.descriptorUniformBufferCount,
+      },
+      {
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          config_.descriptorStorageBufferCount,
+      },
+      {
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          config_.descriptorCombinedSamplerCount,
+      },
+      {
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          config_.descriptorStorageBufferCount,
+      },
+  };
+
+  const VkDescriptorPoolCreateInfo create_info{
+      VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      config_.descriptorPoolMaxSets, // maxSets
+      static_cast<uint32_t>(type_sizes.size()), // poolSizeCounts
+      type_sizes.data(), // pPoolSizes
+  };
+
+  VK_CHECK(vkCreateDescriptorPool(device_, &create_info, nullptr, &pool_));
+}
+
+DescriptorSet DescriptorPool::get_descriptor_set(
+    VkDescriptorSetLayout set_layout,
+    const ShaderLayout::Signature& signature) {
+  VK_CHECK_COND(
+      pool_ != VK_NULL_HANDLE, "DescriptorPool has not yet been initialized!");
+
+  auto it = piles_.find(set_layout);
+  if (piles_.cend() == it) {
+    it = piles_
+             .insert({
+                 set_layout,
+                 DescriptorSetPile(
+                     config_.descriptorPileSizes, set_layout, device_, pool_),
+             })
+             .first;
+  }
+
+  VkDescriptorSet handle = it->second.get_descriptor_set();
+
+  return DescriptorSet(device_, handle, signature);
+}
+
+void DescriptorPool::flush() {
+  if (pool_ != VK_NULL_HANDLE) {
+    VK_CHECK(vkResetDescriptorPool(device_, pool_, 0u));
+    piles_.clear();
+  }
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/api/Descriptor.h
+++ b/backends/vulkan/runtime/api/Descriptor.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#include <executorch/backends/vulkan/runtime/api/Resource.h>
+#include <executorch/backends/vulkan/runtime/api/Shader.h>
+
+#include <unordered_map>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+class DescriptorSet final {
+ public:
+  explicit DescriptorSet(VkDevice, VkDescriptorSet, ShaderLayout::Signature);
+
+  DescriptorSet(const DescriptorSet&) = delete;
+  DescriptorSet& operator=(const DescriptorSet&) = delete;
+
+  DescriptorSet(DescriptorSet&&) noexcept;
+  DescriptorSet& operator=(DescriptorSet&&) noexcept;
+
+  ~DescriptorSet() = default;
+
+  struct ResourceBinding final {
+    uint32_t binding_idx;
+    VkDescriptorType descriptor_type;
+    bool is_image;
+
+    union {
+      VkDescriptorBufferInfo buffer_info;
+      VkDescriptorImageInfo image_info;
+    } resource_info;
+  };
+
+ private:
+  VkDevice device_;
+  VkDescriptorSet handle_;
+  ShaderLayout::Signature shader_layout_signature_;
+  std::vector<ResourceBinding> bindings_;
+
+ public:
+  DescriptorSet& bind(const uint32_t, const VulkanBuffer&);
+  DescriptorSet& bind(const uint32_t, const VulkanImage&);
+
+  VkDescriptorSet get_bind_handle() const;
+
+ private:
+  void add_binding(const ResourceBinding& resource);
+};
+
+class DescriptorSetPile final {
+ public:
+  DescriptorSetPile(
+      const uint32_t,
+      VkDescriptorSetLayout,
+      VkDevice,
+      VkDescriptorPool);
+
+  DescriptorSetPile(const DescriptorSetPile&) = delete;
+  DescriptorSetPile& operator=(const DescriptorSetPile&) = delete;
+
+  DescriptorSetPile(DescriptorSetPile&&) = default;
+  DescriptorSetPile& operator=(DescriptorSetPile&&) = default;
+
+  ~DescriptorSetPile() = default;
+
+ private:
+  uint32_t pile_size_;
+  VkDescriptorSetLayout set_layout_;
+  VkDevice device_;
+  VkDescriptorPool pool_;
+  std::vector<VkDescriptorSet> descriptors_;
+  size_t in_use_;
+
+ public:
+  VkDescriptorSet get_descriptor_set();
+
+ private:
+  void allocate_new_batch();
+};
+
+struct DescriptorPoolConfig final {
+  // Overall Pool capacity
+  uint32_t descriptorPoolMaxSets;
+  // DescriptorCounts by type
+  uint32_t descriptorUniformBufferCount;
+  uint32_t descriptorStorageBufferCount;
+  uint32_t descriptorCombinedSamplerCount;
+  uint32_t descriptorStorageImageCount;
+  // Pile size for pre-allocating descriptor sets
+  uint32_t descriptorPileSizes;
+};
+
+class DescriptorPool final {
+ public:
+  explicit DescriptorPool(VkDevice, const DescriptorPoolConfig&);
+
+  DescriptorPool(const DescriptorPool&) = delete;
+  DescriptorPool& operator=(const DescriptorPool&) = delete;
+
+  DescriptorPool(DescriptorPool&&) = delete;
+  DescriptorPool& operator=(DescriptorPool&&) = delete;
+
+  ~DescriptorPool();
+
+ private:
+  VkDevice device_;
+  VkDescriptorPool pool_;
+  DescriptorPoolConfig config_;
+  // New Descriptors
+  std::mutex mutex_;
+  std::unordered_map<VkDescriptorSetLayout, DescriptorSetPile> piles_;
+
+ public:
+  operator bool() const {
+    return (pool_ != VK_NULL_HANDLE);
+  }
+
+  void init(const DescriptorPoolConfig& config);
+
+  DescriptorSet get_descriptor_set(
+      VkDescriptorSetLayout handle,
+      const ShaderLayout::Signature& signature);
+
+  void flush();
+};
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/Exception.cpp
+++ b/backends/vulkan/runtime/api/Exception.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/Exception.h>
+
+#include <sstream>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+#define VK_RESULT_CASE(code) \
+  case code:                 \
+    out << #code;            \
+    break;
+
+std::ostream& operator<<(std::ostream& out, const VkResult result) {
+  switch (result) {
+    VK_RESULT_CASE(VK_SUCCESS)
+    VK_RESULT_CASE(VK_NOT_READY)
+    VK_RESULT_CASE(VK_TIMEOUT)
+    VK_RESULT_CASE(VK_EVENT_SET)
+    VK_RESULT_CASE(VK_EVENT_RESET)
+    VK_RESULT_CASE(VK_INCOMPLETE)
+    VK_RESULT_CASE(VK_ERROR_OUT_OF_HOST_MEMORY)
+    VK_RESULT_CASE(VK_ERROR_OUT_OF_DEVICE_MEMORY)
+    VK_RESULT_CASE(VK_ERROR_INITIALIZATION_FAILED)
+    VK_RESULT_CASE(VK_ERROR_DEVICE_LOST)
+    VK_RESULT_CASE(VK_ERROR_MEMORY_MAP_FAILED)
+    VK_RESULT_CASE(VK_ERROR_LAYER_NOT_PRESENT)
+    VK_RESULT_CASE(VK_ERROR_EXTENSION_NOT_PRESENT)
+    VK_RESULT_CASE(VK_ERROR_FEATURE_NOT_PRESENT)
+    VK_RESULT_CASE(VK_ERROR_INCOMPATIBLE_DRIVER)
+    VK_RESULT_CASE(VK_ERROR_TOO_MANY_OBJECTS)
+    VK_RESULT_CASE(VK_ERROR_FORMAT_NOT_SUPPORTED)
+    VK_RESULT_CASE(VK_ERROR_FRAGMENTED_POOL)
+    default:
+      out << "VK_ERROR_UNKNOWN (VkResult " << result << ")";
+      break;
+  }
+  return out;
+}
+
+#undef VK_RESULT_CASE
+
+//
+// SourceLocation
+//
+
+std::ostream& operator<<(std::ostream& out, const SourceLocation& loc) {
+  out << loc.function << " at " << loc.file << ":" << loc.line;
+  return out;
+}
+
+//
+// Exception
+//
+
+Error::Error(SourceLocation source_location, std::string msg)
+    : msg_(std::move(msg)), source_location_{source_location} {
+  std::ostringstream oss;
+  oss << "Exception raised from " << source_location_ << ": ";
+  oss << msg_;
+  what_ = oss.str();
+}
+
+Error::Error(SourceLocation source_location, const char* cond, std::string msg)
+    : msg_(std::move(msg)), source_location_{source_location} {
+  std::ostringstream oss;
+  oss << "Exception raised from " << source_location_ << ": ";
+  oss << "(" << cond << ") is false! ";
+  oss << msg_;
+  what_ = oss.str();
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/api/Exception.h
+++ b/backends/vulkan/runtime/api/Exception.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+#ifdef USE_VULKAN_API
+
+#include <exception>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include <executorch/backends/vulkan/runtime/api/StringUtil.h>
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#define VK_CHECK(function)                                       \
+  do {                                                           \
+    const VkResult result = (function);                          \
+    if (VK_SUCCESS != result) {                                  \
+      throw ::at::native::vulkan::api::Error(                    \
+          {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
+          ::at::native::vulkan::api::concat_str(                 \
+              #function, " returned ", result));                 \
+    }                                                            \
+  } while (false)
+
+#define VK_CHECK_COND(cond, ...)                                 \
+  do {                                                           \
+    if (!(cond)) {                                               \
+      throw ::at::native::vulkan::api::Error(                    \
+          {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
+          #cond,                                                 \
+          ::at::native::vulkan::api::concat_str(__VA_ARGS__));   \
+    }                                                            \
+  } while (false)
+
+#define VK_THROW(...)                                          \
+  do {                                                         \
+    throw ::at::native::vulkan::api::Error(                    \
+        {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
+        ::at::native::vulkan::api::concat_str(__VA_ARGS__));   \
+  } while (false)
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+std::ostream& operator<<(std::ostream& out, const VkResult loc);
+
+struct SourceLocation {
+  const char* function;
+  const char* file;
+  uint32_t line;
+};
+
+std::ostream& operator<<(std::ostream& out, const SourceLocation& loc);
+
+class Error : public std::exception {
+ public:
+  Error(SourceLocation source_location, std::string msg);
+  Error(SourceLocation source_location, const char* cond, std::string msg);
+
+ private:
+  std::string msg_;
+  SourceLocation source_location_;
+  std::string what_;
+
+ public:
+  const std::string& msg() const {
+    return msg_;
+  }
+
+  const char* what() const noexcept override {
+    return what_.c_str();
+  }
+};
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/Pipeline.cpp
+++ b/backends/vulkan/runtime/api/Pipeline.cpp
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/Pipeline.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+//
+// Utility Functions
+//
+
+VkAccessFlags vk_access(
+    const PipelineStageFlags stage,
+    const MemoryAccessFlags access) {
+  VkAccessFlags vk_access = 0u;
+
+  if (access & MemoryAccessType::READ) {
+    if (stage & PipelineStage::COMPUTE) {
+      vk_access |= VK_ACCESS_SHADER_READ_BIT;
+    }
+
+    if (stage & PipelineStage::HOST) {
+      vk_access |= VK_ACCESS_HOST_READ_BIT;
+    }
+
+    if (stage & PipelineStage::TRANSFER) {
+      vk_access |= VK_ACCESS_TRANSFER_READ_BIT;
+    }
+  }
+
+  if (access & MemoryAccessType::WRITE) {
+    if (stage & PipelineStage::COMPUTE) {
+      vk_access |= VK_ACCESS_SHADER_WRITE_BIT;
+    }
+
+    if (stage & PipelineStage::HOST) {
+      vk_access |= VK_ACCESS_HOST_WRITE_BIT;
+    }
+
+    if (stage & PipelineStage::TRANSFER) {
+      vk_access |= VK_ACCESS_TRANSFER_WRITE_BIT;
+    }
+  }
+
+  return vk_access;
+}
+
+VkPipelineStageFlags vk_stage(const PipelineStageFlags stage) {
+  VkPipelineStageFlags vk_stage = 0u;
+
+  if (stage & PipelineStage::COMPUTE) {
+    vk_stage |= VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+  }
+
+  if (stage & PipelineStage::HOST) {
+    vk_stage |= VK_PIPELINE_STAGE_HOST_BIT;
+  }
+
+  if (stage & PipelineStage::TRANSFER) {
+    vk_stage |= VK_PIPELINE_STAGE_TRANSFER_BIT;
+  }
+
+  return vk_stage;
+}
+
+VkImageLayout vk_layout(
+    const PipelineStageFlags stage,
+    const MemoryAccessFlags access) {
+  switch (stage) {
+    case PipelineStage::COMPUTE:
+      switch (access) {
+        case MemoryAccessType::READ:
+          return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        default:
+          return VK_IMAGE_LAYOUT_GENERAL;
+      }
+      break;
+    case PipelineStage::TRANSFER:
+      switch (access) {
+        case MemoryAccessType::READ:
+          return VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        case MemoryAccessType::WRITE:
+          return VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        default:
+          VK_THROW("Invalid memory access type for transfer stage!");
+      }
+      break;
+    default:
+      VK_THROW("Cannot determine appropriate image layout");
+  }
+
+  return VK_IMAGE_LAYOUT_UNDEFINED;
+}
+
+//
+// PipelineLayout
+//
+
+PipelineLayout::PipelineLayout(
+    VkDevice device,
+    VkDescriptorSetLayout descriptor_layout)
+    : device_(device), handle_{VK_NULL_HANDLE} {
+  // TODO: Enable push constants
+  const VkPipelineLayoutCreateInfo pipeline_layout_create_info{
+      VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      1u, // setLayoutCount
+      &descriptor_layout, // pSetLayouts
+      0u, // pushConstantRangeCount
+      nullptr, // pPushConstantRanges
+  };
+
+  VK_CHECK(vkCreatePipelineLayout(
+      device_, &pipeline_layout_create_info, nullptr, &handle_));
+}
+
+PipelineLayout::PipelineLayout(PipelineLayout&& other) noexcept
+    : device_(other.device_), handle_(other.handle_) {
+  other.handle_ = VK_NULL_HANDLE;
+}
+
+PipelineLayout::~PipelineLayout() {
+  if (VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroyPipelineLayout(device_, handle_, nullptr);
+  handle_ = VK_NULL_HANDLE;
+}
+
+void swap(PipelineLayout& lhs, PipelineLayout& rhs) noexcept {
+  VkDevice tmp_device = lhs.device_;
+  VkPipelineLayout tmp_handle = lhs.handle_;
+
+  lhs.device_ = rhs.device_;
+  lhs.handle_ = rhs.handle_;
+
+  rhs.device_ = tmp_device;
+  rhs.handle_ = tmp_handle;
+}
+
+//
+// ComputePipeline
+//
+
+ComputePipeline::ComputePipeline(
+    VkDevice device,
+    const ComputePipeline::Descriptor& descriptor,
+    VkPipelineCache pipeline_cache)
+    : device_(device), handle_{VK_NULL_HANDLE} {
+  // NOLINTNEXTLINE
+  constexpr VkSpecializationMapEntry specialization_map_entries[3]{
+      // X
+      {
+          0u,
+          offsetof(utils::uvec3, data[0u]),
+          sizeof(utils::uvec3::data[0u]),
+      },
+      // Y
+      {
+          1u,
+          offsetof(utils::uvec3, data[1u]),
+          sizeof(utils::uvec3::data[1u]),
+      },
+      // Z
+      {
+          2u,
+          offsetof(utils::uvec3, data[2u]),
+          sizeof(utils::uvec3::data[2u]),
+      },
+  };
+
+  const VkSpecializationInfo specialization_info{
+      3u, // mapEntryCount
+      specialization_map_entries, // pMapEntries
+      sizeof(descriptor.local_work_group), // dataSize
+      &descriptor.local_work_group, // pData
+  };
+
+  const VkPipelineShaderStageCreateInfo shader_stage_create_info{
+      VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      VK_SHADER_STAGE_COMPUTE_BIT, // stage
+      descriptor.shader_module, // module
+      "main", // pName
+      &specialization_info, // pSpecializationInfo
+  };
+
+  const VkComputePipelineCreateInfo compute_pipeline_create_info{
+      VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      shader_stage_create_info, // stage
+      descriptor.pipeline_layout, // layout
+      VK_NULL_HANDLE, // basePipelineHandle
+      0u, // basePipelineIndex
+  };
+
+  VK_CHECK(vkCreateComputePipelines(
+      device_,
+      pipeline_cache,
+      1u,
+      &compute_pipeline_create_info,
+      nullptr,
+      &handle_));
+}
+
+ComputePipeline::ComputePipeline(ComputePipeline&& other) noexcept
+    : device_(other.device_), handle_(other.handle_) {
+  other.handle_ = VK_NULL_HANDLE;
+}
+
+ComputePipeline::~ComputePipeline() {
+  if (VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroyPipeline(device_, handle_, nullptr);
+  handle_ = VK_NULL_HANDLE;
+}
+
+void swap(ComputePipeline& lhs, ComputePipeline& rhs) noexcept {
+  VkDevice tmp_device = lhs.device_;
+  VkPipeline tmp_handle = lhs.handle_;
+
+  lhs.device_ = rhs.device_;
+  lhs.handle_ = rhs.handle_;
+
+  rhs.device_ = tmp_device;
+  rhs.handle_ = tmp_handle;
+}
+
+bool operator==(
+    const ComputePipeline::Descriptor& _1,
+    const ComputePipeline::Descriptor& _2) {
+  return (
+      _1.pipeline_layout == _2.pipeline_layout &&
+      _1.shader_module == _2.shader_module &&
+      _1.local_work_group == _2.local_work_group);
+}
+
+//
+// PipelineLayoutCache
+//
+
+PipelineLayoutCache::PipelineLayoutCache(VkDevice device)
+    : cache_mutex_{}, device_(device), cache_{} {}
+
+PipelineLayoutCache::PipelineLayoutCache(PipelineLayoutCache&& other) noexcept
+    : cache_mutex_{}, device_(other.device_), cache_(std::move(other.cache_)) {
+  std::lock_guard<std::mutex> lock(other.cache_mutex_);
+}
+
+PipelineLayoutCache::~PipelineLayoutCache() {
+  purge();
+}
+
+VkPipelineLayout PipelineLayoutCache::retrieve(
+    const PipelineLayoutCache::Key& key) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  auto it = cache_.find(key);
+  if (cache_.cend() == it) {
+    it = cache_.insert({key, PipelineLayoutCache::Value(device_, key)}).first;
+  }
+
+  return it->second.handle();
+}
+
+void PipelineLayoutCache::purge() {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  cache_.clear();
+}
+
+//
+// ComputePipelineCache
+//
+
+ComputePipelineCache::ComputePipelineCache(VkDevice device)
+    : cache_mutex_{},
+      device_(device),
+      pipeline_cache_{VK_NULL_HANDLE},
+      cache_{} {
+  const VkPipelineCacheCreateInfo pipeline_cache_create_info{
+      VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      0u, // initialDataSize
+      nullptr, // pInitialData
+  };
+
+  VK_CHECK(vkCreatePipelineCache(
+      device, &pipeline_cache_create_info, nullptr, &pipeline_cache_));
+}
+
+ComputePipelineCache::ComputePipelineCache(
+    ComputePipelineCache&& other) noexcept
+    : cache_mutex_{},
+      device_(other.device_),
+      pipeline_cache_(other.pipeline_cache_),
+      cache_(std::move(other.cache_)) {
+  std::lock_guard<std::mutex> lock(other.cache_mutex_);
+
+  other.pipeline_cache_ = VK_NULL_HANDLE;
+}
+
+ComputePipelineCache::~ComputePipelineCache() {
+  purge();
+
+  if (VK_NULL_HANDLE == pipeline_cache_) {
+    return;
+  }
+  vkDestroyPipelineCache(device_, pipeline_cache_, nullptr);
+  pipeline_cache_ = VK_NULL_HANDLE;
+}
+
+VkPipeline ComputePipelineCache::retrieve(
+    const ComputePipelineCache::Key& key) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  auto it = cache_.find(key);
+  if (cache_.cend() == it) {
+    it = cache_
+             .insert(
+                 {key,
+                  ComputePipelineCache::Value(device_, key, pipeline_cache_)})
+             .first;
+  }
+
+  return it->second.handle();
+}
+
+void ComputePipelineCache::purge() {
+  cache_.clear();
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/api/Pipeline.h
+++ b/backends/vulkan/runtime/api/Pipeline.h
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#include <executorch/backends/vulkan/runtime/api/Resource.h>
+#include <executorch/backends/vulkan/runtime/api/Shader.h>
+
+#include <mutex>
+#include <unordered_map>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+struct PipelineBarrier final {
+  struct Stages final {
+    VkPipelineStageFlags src;
+    VkPipelineStageFlags dst;
+  } stage;
+
+  std::vector<BufferMemoryBarrier> buffers;
+  std::vector<ImageMemoryBarrier> images;
+  std::vector<VkBufferMemoryBarrier> buffer_barrier_handles;
+  std::vector<VkImageMemoryBarrier> image_barrier_handles;
+
+  inline operator bool() const {
+    return (0u != stage.src) || (0u != stage.dst) || !buffers.empty() ||
+        !images.empty();
+  }
+};
+
+using PipelineStageFlags = uint8_t;
+
+enum PipelineStage : PipelineStageFlags {
+  NO_STAGE = 0u << 0u,
+  COMPUTE = 1u << 0u,
+  HOST = 1u << 1u,
+  TRANSFER = 1u << 2u,
+};
+
+VkAccessFlags vk_access(const PipelineStageFlags, const MemoryAccessFlags);
+VkPipelineStageFlags vk_stage(const PipelineStageFlags);
+VkImageLayout vk_layout(const PipelineStageFlags, const MemoryAccessFlags);
+
+class PipelineLayout final {
+ public:
+  explicit PipelineLayout(VkDevice, VkDescriptorSetLayout);
+
+  PipelineLayout(const PipelineLayout&) = delete;
+  PipelineLayout& operator=(const PipelineLayout&) = delete;
+
+  PipelineLayout(PipelineLayout&&) noexcept;
+  PipelineLayout& operator=(PipelineLayout&&) = delete;
+
+  ~PipelineLayout();
+
+ private:
+  VkDevice device_;
+  VkPipelineLayout handle_;
+
+ public:
+  VkPipelineLayout handle() const {
+    return handle_;
+  }
+
+  // We need to define a custom swap function since this class
+  // does not allow for move assignment. The swap function will
+  // be used in the hash map.
+  friend void swap(PipelineLayout& lhs, PipelineLayout& rhs) noexcept;
+};
+
+class ComputePipeline final {
+ public:
+  struct Descriptor final {
+    VkPipelineLayout pipeline_layout;
+    VkShaderModule shader_module;
+    utils::uvec3 local_work_group;
+  };
+
+  explicit ComputePipeline(
+      VkDevice device,
+      const Descriptor& descriptor,
+      VkPipelineCache pipeline_cache);
+
+  ComputePipeline(const ComputePipeline&) = delete;
+  ComputePipeline& operator=(const ComputePipeline&) = delete;
+
+  ComputePipeline(ComputePipeline&&) noexcept;
+  ComputePipeline& operator=(ComputePipeline&&) = delete;
+
+  ~ComputePipeline();
+
+ private:
+  VkDevice device_;
+  VkPipeline handle_;
+
+ public:
+  inline VkPipeline handle() const {
+    return handle_;
+  }
+
+  // We need to define a custom swap function since this class
+  // does not allow for move assignment. The swap function will
+  // be used in the hash map.
+  friend void swap(ComputePipeline& lhs, ComputePipeline& rhs) noexcept;
+};
+
+class PipelineLayoutCache final {
+ public:
+  explicit PipelineLayoutCache(VkDevice device);
+
+  PipelineLayoutCache(const PipelineLayoutCache&) = delete;
+  PipelineLayoutCache& operator=(const PipelineLayoutCache&) = delete;
+
+  PipelineLayoutCache(PipelineLayoutCache&&) noexcept;
+  PipelineLayoutCache& operator=(PipelineLayoutCache&&) = delete;
+
+  ~PipelineLayoutCache();
+
+  using Key = VkDescriptorSetLayout;
+  using Value = PipelineLayout;
+
+  struct Hasher {
+    inline size_t operator()(VkDescriptorSetLayout descriptor_layout) const {
+      return std::hash<VkDescriptorSetLayout>()(descriptor_layout);
+    }
+  };
+
+ private:
+  // Multiple threads could potentially be adding entries into the cache, so use
+  // a mutex to manage access
+  std::mutex cache_mutex_;
+
+  VkDevice device_;
+  std::unordered_map<Key, Value, Hasher> cache_;
+
+ public:
+  VkPipelineLayout retrieve(const Key&);
+  void purge();
+};
+
+class ComputePipelineCache final {
+ public:
+  explicit ComputePipelineCache(VkDevice device);
+
+  ComputePipelineCache(const ComputePipelineCache&) = delete;
+  ComputePipelineCache& operator=(const ComputePipelineCache&) = delete;
+
+  ComputePipelineCache(ComputePipelineCache&&) noexcept;
+  ComputePipelineCache& operator=(ComputePipelineCache&&) = delete;
+
+  ~ComputePipelineCache();
+
+  using Key = ComputePipeline::Descriptor;
+  using Value = ComputePipeline;
+
+  struct Hasher {
+    inline size_t operator()(
+        const ComputePipeline::Descriptor& descriptor) const {
+      size_t seed = 0;
+      seed = utils::hash_combine(
+          seed, std::hash<VkPipelineLayout>()(descriptor.pipeline_layout));
+      seed = utils::hash_combine(
+          seed, std::hash<VkShaderModule>()(descriptor.shader_module));
+      seed = utils::hash_combine(
+          seed, std::hash<uint32_t>()(descriptor.local_work_group.data[0u]));
+      seed = utils::hash_combine(
+          seed, std::hash<uint32_t>()(descriptor.local_work_group.data[1u]));
+      seed = utils::hash_combine(
+          seed, std::hash<uint32_t>()(descriptor.local_work_group.data[2u]));
+
+      return seed;
+    }
+  };
+
+ private:
+  // Multiple threads could potentially be adding entries into the cache, so use
+  // a mutex to manage access
+  std::mutex cache_mutex_;
+
+  VkDevice device_;
+  VkPipelineCache pipeline_cache_;
+  std::unordered_map<Key, Value, Hasher> cache_;
+
+ public:
+  VkPipeline retrieve(const Key&);
+  void purge();
+};
+
+//
+// Impl
+//
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/QueryPool.cpp
+++ b/backends/vulkan/runtime/api/QueryPool.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/QueryPool.h>
+#include <executorch/backends/vulkan/runtime/api/Utils.h>
+#ifdef USE_KINETO
+#include <torch/csrc/autograd/profiler_kineto.h>
+#include <torch/csrc/profiler/orchestration/vulkan.h>
+#endif // USE_KINETO
+
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <utility>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+namespace {
+// On Mali gpus timestamp_period seems to return 0.
+// For some reason when 52.08 is used op runtimes seem to make more sense
+// TODO: Figure out what is special about 52.08
+constexpr int64_t kDefaultNsPerTick = 52; // lround(52.08f);
+} // namespace
+
+QueryPool::QueryPool(const QueryPoolConfig& config, const Adapter* adapter_p)
+    : mutex_{},
+      device_(adapter_p->device_handle()),
+      config_(config),
+      querypool_(VK_NULL_HANDLE),
+      shader_logs_(1),
+      in_use_(0),
+      previous_shader_count_(0u),
+      results_pending_(false) {
+  const VkQueryPoolCreateInfo info{
+      VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      VK_QUERY_TYPE_TIMESTAMP, // queryType
+      config_.maxQueryCount, // queryCount
+      0u, // pipelineStatistics
+  };
+
+  VK_CHECK(vkCreateQueryPool(device_, &info, nullptr, &querypool_));
+
+  shader_log().reserve(config_.initialReserveSize);
+
+  VK_CHECK_COND(adapter_p, "Valid GPU device must be created for QueryPool");
+  ns_per_tick_ = std::lround(adapter_p->timestamp_period());
+  ns_per_tick_ = (ns_per_tick_ == 0) ? kDefaultNsPerTick : ns_per_tick_;
+
+#ifdef USE_KINETO
+  torch::profiler::impl::vulkan::registerGetShaderNameAndDurationNs(
+      [this](int64_t vulkan_id) {
+        return get_shader_name_and_execution_duration_ns(vulkan_id);
+      });
+#endif // USE_KINETO
+}
+
+QueryPool::~QueryPool() {
+  if (VK_NULL_HANDLE == querypool_) {
+    return;
+  }
+  vkDestroyQueryPool(device_, querypool_, nullptr);
+
+#ifdef USE_KINETO
+  torch::profiler::impl::vulkan::deregisterGetShaderNameAndDurationNs();
+#endif // USE_KINETO
+}
+
+void QueryPool::reset(const CommandBuffer& cmd) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  cmd.reset_querypool(querypool_, 0u, in_use_);
+  previous_shader_count_ += shader_log().size();
+  in_use_ = 0u;
+  shader_logs_.emplace_back();
+  shader_log().reserve(config_.initialReserveSize);
+  results_pending_ = false;
+}
+
+size_t QueryPool::write_timestamp(const CommandBuffer& cmd) {
+  VK_CHECK_COND(
+      in_use_ < config_.maxQueryCount,
+      "Vulkan QueryPool: Exceeded the maximum number of queries "
+      "allowed by the queryPool (",
+      config_.maxQueryCount,
+      ")!");
+
+  cmd.write_timestamp(querypool_, in_use_);
+
+  return in_use_++;
+}
+
+uint32_t QueryPool::shader_profile_begin(
+    const CommandBuffer& cmd,
+    const std::string& kernel_name,
+    const VkExtent3D global_workgroup_size,
+    const VkExtent3D local_workgroup_size) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  uint32_t query_idx = write_timestamp(cmd);
+
+  uint32_t log_idx = shader_log().size();
+  ShaderDuration log_entry{
+      log_idx,
+      // Execution Properties
+      kernel_name,
+      global_workgroup_size,
+      local_workgroup_size,
+      // Query indexes
+      query_idx, // start query idx
+      UINT32_MAX, // end query idx
+      // Timings
+      0u, // start time
+      0u, // end time
+      0u, // duration
+  };
+
+  shader_log().emplace_back(log_entry);
+
+  results_pending_ = true;
+
+#ifdef USE_KINETO
+  torch::profiler::impl::vulkan_id_t vulkan_id =
+      torch::profiler::impl::vulkan_id_t(previous_shader_count_ + log_idx);
+
+  torch::profiler::impl::_reportVulkanEventToProfiler(vulkan_id);
+#endif // USE_KINETO
+
+  return log_idx;
+}
+
+void QueryPool::shader_profile_end(
+    const CommandBuffer& cmd,
+    const uint32_t log_idx) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  size_t query_idx = write_timestamp(cmd);
+
+  shader_log()[log_idx].end_query_idx = query_idx;
+}
+
+void QueryPool::extract_results() {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!results_pending_) {
+    return;
+  }
+
+  const VkQueryResultFlags flags = VK_QUERY_RESULT_64_BIT;
+
+  std::vector<uint64_t> query_data;
+  query_data.resize(in_use_);
+
+  VK_CHECK(vkGetQueryPoolResults(
+      device_,
+      querypool_,
+      0u, // firstQuery
+      in_use_, // queryCount
+      sizeof(uint64_t) * in_use_, // dataSize
+      query_data.data(), // pData
+      sizeof(uint64_t), // stride
+      flags)); // flags
+
+  for (ShaderDuration& entry : shader_log()) {
+    entry.start_time_ns = query_data.at(entry.start_query_idx) * ns_per_tick_;
+    entry.end_time_ns = query_data.at(entry.end_query_idx) * ns_per_tick_;
+    entry.execution_duration_ns = entry.end_time_ns - entry.start_time_ns;
+  }
+
+  results_pending_ = false;
+}
+
+std::ostream& operator<<(std::ostream& os, const VkExtent3D& extents) {
+  os << "{" << extents.width << ", " << extents.height << ", " << extents.depth
+     << "}";
+  return os;
+}
+
+std::string stringize(const VkExtent3D& extents) {
+  std::stringstream ss;
+  ss << "{" << extents.width << ", " << extents.height << ", " << extents.depth
+     << "}";
+  return ss.str();
+}
+
+std::string QueryPool::generate_string_report() {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  std::stringstream ss;
+
+  int kernel_name_w = 40;
+  int global_size_w = 15;
+  int duration_w = 25;
+
+  ss << std::left;
+  ss << std::setw(kernel_name_w) << "Kernel Name";
+  ss << std::setw(global_size_w) << "Workgroup Size";
+  ss << std::right << std::setw(duration_w) << "Duration (ns)";
+  ss << std::endl;
+
+  ss << std::left;
+  ss << std::setw(kernel_name_w) << "===========";
+  ss << std::setw(global_size_w) << "==============";
+  ss << std::right << std::setw(duration_w) << "===========";
+  ss << std::endl;
+
+  for (ShaderDuration& entry : shader_log()) {
+    std::chrono::duration<size_t, std::nano> exec_duration_ns(
+        entry.execution_duration_ns);
+
+    ss << std::left;
+    ss << std::setw(kernel_name_w) << entry.kernel_name;
+    ss << std::setw(global_size_w) << stringize(entry.global_workgroup_size);
+    ss << std::right << std::setw(duration_w) << exec_duration_ns.count();
+    ss << std::endl;
+  }
+
+  return ss.str();
+}
+
+void QueryPool::print_results() {
+  std::cout << generate_string_report() << std::endl;
+}
+
+uint64_t QueryPool::get_total_op_ns(const std::string& op_name) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  uint64_t sum = 0;
+  for (ShaderDuration& entry : shader_log()) {
+    if (entry.kernel_name == op_name) {
+      sum += entry.execution_duration_ns;
+    }
+  }
+  return sum;
+}
+
+void QueryPool::shader_log_for_each(
+    std::function<void(const ShaderDuration&)> fn) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::for_each(shader_log().begin(), shader_log().end(), std::move(fn));
+}
+
+std::tuple<std::string, uint64_t>
+QueryPool::get_shader_name_and_execution_duration_ns(size_t query_index) {
+  extract_results();
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  const size_t entry_count = shader_logs_entry_count_thread_unsafe();
+  VK_CHECK_COND(
+      (query_index >= 0 && query_index < entry_count),
+      "query_index of ",
+      query_index,
+      " is out of bounds (",
+      entry_count,
+      ") in QueryPool::get_shader_name_and_duration_ns");
+
+  size_t log_idx = 0;
+  size_t entry_count_acc = 0;
+  while (entry_count_acc + shader_logs_[log_idx].size() <= query_index) {
+    entry_count_acc += shader_logs_[log_idx].size();
+    log_idx += 1;
+  }
+
+  const ShaderDuration& entry =
+      shader_logs_[log_idx][query_index - entry_count_acc];
+
+  return std::tuple<std::string, uint64_t>(
+      entry.kernel_name, entry.execution_duration_ns);
+}
+
+size_t QueryPool::shader_logs_entry_count_thread_unsafe() {
+  return previous_shader_count_ + shader_log().size();
+}
+
+size_t QueryPool::shader_logs_entry_count() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return shader_logs_entry_count_thread_unsafe();
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/api/QueryPool.h
+++ b/backends/vulkan/runtime/api/QueryPool.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#include <functional>
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#include <executorch/backends/vulkan/runtime/api/Adapter.h>
+#include <executorch/backends/vulkan/runtime/api/Command.h>
+#include <executorch/backends/vulkan/runtime/api/Pipeline.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+struct QueryPoolConfig final {
+  uint32_t maxQueryCount;
+  uint32_t initialReserveSize;
+};
+
+struct ShaderDuration final {
+  uint32_t idx;
+
+  // Execution Properties
+  std::string kernel_name;
+  VkExtent3D global_workgroup_size;
+  VkExtent3D local_workgroup_size;
+
+  // Query indexes
+  uint32_t start_query_idx;
+  uint32_t end_query_idx;
+
+  // Timings
+  uint64_t start_time_ns;
+  uint64_t end_time_ns;
+  uint64_t execution_duration_ns;
+};
+
+class QueryPool final {
+ public:
+  explicit QueryPool(const QueryPoolConfig&, const Adapter* adapter_p);
+
+  QueryPool(const QueryPool&) = delete;
+  QueryPool& operator=(const QueryPool&) = delete;
+
+  QueryPool(QueryPool&&) = delete;
+  QueryPool& operator=(QueryPool&&) = delete;
+
+  ~QueryPool();
+
+ private:
+  std::mutex mutex_;
+
+  VkDevice device_;
+  QueryPoolConfig config_;
+
+  VkQueryPool querypool_;
+
+  std::vector<std::vector<ShaderDuration>> shader_logs_;
+  size_t in_use_;
+
+  /** Total number of entries in shader logs from before most recent reset */
+  size_t previous_shader_count_;
+
+  /**
+   * Indicates whether there are new log entries in the shader log since the
+   * most recent call to extract_results()
+   */
+  bool results_pending_;
+
+ private:
+  size_t write_timestamp(const CommandBuffer&);
+
+  std::string generate_string_report();
+
+  /** Most recent shader log since the last time the QueryPool was reset */
+  inline std::vector<ShaderDuration>& shader_log() {
+    return shader_logs_[shader_logs_.size() - 1];
+  }
+
+  /** Total number of entries in all shader logs, but without locking mutex */
+  size_t shader_logs_entry_count_thread_unsafe();
+
+ public:
+  inline bool is_enabled() const {
+    return VK_NULL_HANDLE != querypool_;
+  }
+
+  void reset(const CommandBuffer&);
+
+  uint32_t shader_profile_begin(
+      const CommandBuffer&,
+      const std::string&,
+      const VkExtent3D,
+      const VkExtent3D);
+  void shader_profile_end(const CommandBuffer&, const uint32_t);
+
+  void extract_results();
+  void print_results();
+  uint64_t get_total_op_ns(const std::string& op_name);
+  uint64_t ns_per_tick_;
+  void shader_log_for_each(std::function<void(const ShaderDuration&)> fn);
+  /**
+   * query_index is what number entry across all of the QueryPool's shader logs
+   * is being queried, regardless of resets. This may be different than
+   * ShaderDuration's idx field, which is what number entry it is since the last
+   * reset before it was added to the shader logs.
+   */
+  std::tuple<std::string, uint64_t> get_shader_name_and_execution_duration_ns(
+      size_t query_index);
+  /** Total number of entries in all shader logs */
+  size_t shader_logs_entry_count();
+};
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/Resource.cpp
+++ b/backends/vulkan/runtime/api/Resource.cpp
@@ -1,0 +1,842 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/Adapter.h>
+#include <executorch/backends/vulkan/runtime/api/Resource.h>
+
+#define PRINT_FIELD(struct, field) #field << ": " << struct.field << std::endl
+
+std::ostream& operator<<(std::ostream& out, VmaTotalStatistics stats) {
+  VmaDetailedStatistics total_stats = stats.total;
+  out << "VmaTotalStatistics: " << std::endl;
+  out << "  " << PRINT_FIELD(total_stats.statistics, blockCount);
+  out << "  " << PRINT_FIELD(total_stats.statistics, allocationCount);
+  out << "  " << PRINT_FIELD(total_stats.statistics, blockBytes);
+  out << "  " << PRINT_FIELD(total_stats.statistics, allocationBytes);
+  return out;
+}
+
+#undef PRINT_FIELD
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+//
+// MemoryBarrier
+//
+
+MemoryBarrier::MemoryBarrier(
+    const VkAccessFlags src_access_flags,
+    const VkAccessFlags dst_access_flags)
+    : handle{
+          VK_STRUCTURE_TYPE_MEMORY_BARRIER, // sType
+          nullptr, // pNext
+          src_access_flags, // srcAccessMask
+          dst_access_flags, // dstAccessMask
+      } {}
+
+//
+// MemoryAllocation
+//
+
+MemoryAllocation::MemoryAllocation()
+    : memory_requirements{},
+      create_info{},
+      allocator(VK_NULL_HANDLE),
+      allocation(VK_NULL_HANDLE) {}
+
+MemoryAllocation::MemoryAllocation(
+    VmaAllocator vma_allocator,
+    const VkMemoryRequirements& mem_props,
+    const VmaAllocationCreateInfo& create_info)
+    : memory_requirements(mem_props),
+      create_info(create_info),
+      allocator(vma_allocator),
+      allocation(VK_NULL_HANDLE) {
+  VK_CHECK(vmaAllocateMemory(
+      allocator, &memory_requirements, &create_info, &allocation, nullptr));
+}
+
+MemoryAllocation::MemoryAllocation(MemoryAllocation&& other) noexcept
+    : memory_requirements(other.memory_requirements),
+      create_info(other.create_info),
+      allocator(other.allocator),
+      allocation(other.allocation) {
+  other.allocation = VK_NULL_HANDLE;
+}
+
+MemoryAllocation& MemoryAllocation::operator=(
+    MemoryAllocation&& other) noexcept {
+  VmaAllocation tmp_allocation = allocation;
+
+  memory_requirements = other.memory_requirements;
+  create_info = other.create_info;
+  allocator = other.allocator;
+  allocation = other.allocation;
+
+  other.allocation = tmp_allocation;
+
+  return *this;
+}
+
+MemoryAllocation::~MemoryAllocation() {
+  if (VK_NULL_HANDLE != allocation) {
+    vmaFreeMemory(allocator, allocation);
+  }
+}
+
+//
+// VulkanBuffer
+//
+
+VulkanBuffer::VulkanBuffer()
+    : buffer_properties_{},
+      allocator_(VK_NULL_HANDLE),
+      memory_{},
+      owns_memory_(false),
+      handle_(VK_NULL_HANDLE) {}
+
+VulkanBuffer::VulkanBuffer(
+    VmaAllocator vma_allocator,
+    const VkDeviceSize size,
+    const VmaAllocationCreateInfo& allocation_create_info,
+    const VkBufferUsageFlags usage,
+    const bool allocate_memory)
+    : buffer_properties_({
+          size,
+          0u,
+          size,
+          usage,
+      }),
+      allocator_(vma_allocator),
+      memory_{},
+      owns_memory_(allocate_memory),
+      handle_(VK_NULL_HANDLE) {
+  // Only allocate memory if the buffer has non-zero size
+  if (size == 0) {
+    return;
+  }
+
+  const VkBufferCreateInfo buffer_create_info{
+      VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      size, // size
+      buffer_properties_.buffer_usage, // usage
+      VK_SHARING_MODE_EXCLUSIVE, // sharingMode
+      0u, // queueFamilyIndexCount
+      nullptr, // pQueueFamilyIndices
+  };
+
+  memory_.create_info = allocation_create_info;
+
+  if (allocate_memory) {
+    VK_CHECK(vmaCreateBuffer(
+        allocator_,
+        &buffer_create_info,
+        &allocation_create_info,
+        &handle_,
+        &(memory_.allocation),
+        nullptr));
+  } else {
+    VmaAllocatorInfo allocator_info{};
+    vmaGetAllocatorInfo(allocator_, &allocator_info);
+    VK_CHECK(vkCreateBuffer(
+        allocator_info.device, &buffer_create_info, nullptr, &handle_));
+  }
+}
+
+VulkanBuffer::VulkanBuffer(VulkanBuffer&& other) noexcept
+    : buffer_properties_(other.buffer_properties_),
+      allocator_(other.allocator_),
+      memory_(std::move(other.memory_)),
+      owns_memory_(other.owns_memory_),
+      handle_(other.handle_) {
+  other.handle_ = VK_NULL_HANDLE;
+}
+
+VulkanBuffer& VulkanBuffer::operator=(VulkanBuffer&& other) noexcept {
+  VkBuffer tmp_buffer = handle_;
+  bool tmp_owns_memory = owns_memory_;
+
+  buffer_properties_ = other.buffer_properties_;
+  allocator_ = other.allocator_;
+  memory_ = std::move(other.memory_);
+  owns_memory_ = other.owns_memory_;
+  handle_ = other.handle_;
+
+  other.handle_ = tmp_buffer;
+  other.owns_memory_ = tmp_owns_memory;
+
+  return *this;
+}
+
+VulkanBuffer::~VulkanBuffer() {
+  if (VK_NULL_HANDLE != handle_) {
+    if (owns_memory_) {
+      vmaDestroyBuffer(allocator_, handle_, memory_.allocation);
+    } else {
+      vkDestroyBuffer(this->device(), handle_, nullptr);
+    }
+    // Prevent the underlying memory allocation from being freed; it was either
+    // freed by vmaDestroyBuffer, or this resource does not own the underlying
+    // memory
+    memory_.allocation = VK_NULL_HANDLE;
+  }
+}
+
+VkMemoryRequirements VulkanBuffer::get_memory_requirements() const {
+  VkMemoryRequirements memory_requirements;
+  vkGetBufferMemoryRequirements(this->device(), handle_, &memory_requirements);
+  return memory_requirements;
+}
+
+//
+// MemoryMap
+//
+
+MemoryMap::MemoryMap(const VulkanBuffer& buffer, const uint8_t access)
+    : access_(access),
+      allocator_(buffer.vma_allocator()),
+      allocation_(buffer.allocation()),
+      data_(nullptr),
+      data_len_{buffer.mem_size()} {
+  if (allocation_) {
+    VK_CHECK(vmaMapMemory(allocator_, allocation_, &data_));
+  }
+}
+
+MemoryMap::MemoryMap(MemoryMap&& other) noexcept
+    : access_(other.access_),
+      allocator_(other.allocator_),
+      allocation_(other.allocation_),
+      data_(other.data_),
+      data_len_{other.data_len_} {
+  other.allocation_ = VK_NULL_HANDLE;
+  other.data_ = nullptr;
+}
+
+MemoryMap::~MemoryMap() {
+  if (!data_) {
+    return;
+  }
+
+  if (allocation_) {
+    if (access_ & MemoryAccessType::WRITE) {
+      // Call will be ignored by implementation if the memory type this
+      // allocation belongs to is not HOST_VISIBLE or is HOST_COHERENT, which is
+      // the behavior we want. Don't check the result here as the destructor
+      // cannot throw.
+      vmaFlushAllocation(allocator_, allocation_, 0u, VK_WHOLE_SIZE);
+    }
+
+    vmaUnmapMemory(allocator_, allocation_);
+  }
+}
+
+void MemoryMap::invalidate() {
+  if (access_ & MemoryAccessType::READ && allocation_) {
+    // Call will be ignored by implementation if the memory type this allocation
+    // belongs to is not HOST_VISIBLE or is HOST_COHERENT, which is the behavior
+    // we want.
+    VK_CHECK(
+        vmaInvalidateAllocation(allocator_, allocation_, 0u, VK_WHOLE_SIZE));
+  }
+}
+
+//
+// BufferMemoryBarrier
+//
+
+BufferMemoryBarrier::BufferMemoryBarrier(
+    const VkAccessFlags src_access_flags,
+    const VkAccessFlags dst_access_flags,
+    const VulkanBuffer& buffer)
+    : handle{
+          VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, // sType
+          nullptr, // pNext
+          src_access_flags, // srcAccessMask
+          dst_access_flags, // dstAccessMask
+          VK_QUEUE_FAMILY_IGNORED, // srcQueueFamilyIndex
+          VK_QUEUE_FAMILY_IGNORED, // dstQueueFamilyIndex
+          buffer.handle_, // buffer
+          buffer.buffer_properties_.mem_offset, // offset
+          buffer.buffer_properties_.mem_range, // size
+      } {}
+
+//
+// ImageSampler
+//
+
+bool operator==(
+    const ImageSampler::Properties& _1,
+    const ImageSampler::Properties& _2) {
+  return (
+      _1.filter == _2.filter && _1.mipmap_mode == _2.mipmap_mode &&
+      _1.address_mode == _2.address_mode && _1.border_color == _2.border_color);
+}
+
+ImageSampler::ImageSampler(
+    VkDevice device,
+    const ImageSampler::Properties& props)
+    : device_(device), handle_(VK_NULL_HANDLE) {
+  const VkSamplerCreateInfo sampler_create_info{
+      VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      props.filter, // magFilter
+      props.filter, // minFilter
+      props.mipmap_mode, // mipmapMode
+      props.address_mode, // addressModeU
+      props.address_mode, // addressModeV
+      props.address_mode, // addressModeW
+      0.0f, // mipLodBias
+      VK_FALSE, // anisotropyEnable
+      1.0f, // maxAnisotropy,
+      VK_FALSE, // compareEnable
+      VK_COMPARE_OP_NEVER, // compareOp
+      0.0f, // minLod
+      VK_LOD_CLAMP_NONE, // maxLod
+      props.border_color, // borderColor
+      VK_FALSE, // unnormalizedCoordinates
+  };
+
+  VK_CHECK(vkCreateSampler(device_, &sampler_create_info, nullptr, &handle_));
+}
+
+ImageSampler::ImageSampler(ImageSampler&& other) noexcept
+    : device_(other.device_), handle_(other.handle_) {
+  other.handle_ = VK_NULL_HANDLE;
+}
+
+ImageSampler::~ImageSampler() {
+  if (VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroySampler(device_, handle_, nullptr);
+}
+
+size_t ImageSampler::Hasher::operator()(
+    const ImageSampler::Properties& props) const {
+  size_t seed = 0;
+  seed = utils::hash_combine(seed, std::hash<VkFilter>()(props.filter));
+  seed = utils::hash_combine(
+      seed, std::hash<VkSamplerMipmapMode>()(props.mipmap_mode));
+  seed = utils::hash_combine(
+      seed, std::hash<VkSamplerAddressMode>()(props.address_mode));
+  seed =
+      utils::hash_combine(seed, std::hash<VkBorderColor>()(props.border_color));
+  return seed;
+}
+
+void swap(ImageSampler& lhs, ImageSampler& rhs) noexcept {
+  VkDevice tmp_device = lhs.device_;
+  VkSampler tmp_handle = lhs.handle_;
+
+  lhs.device_ = rhs.device_;
+  lhs.handle_ = rhs.handle_;
+
+  rhs.device_ = tmp_device;
+  rhs.handle_ = tmp_handle;
+}
+
+//
+// VulkanImage
+//
+
+VulkanImage::VulkanImage()
+    : image_properties_{},
+      view_properties_{},
+      sampler_properties_{},
+      allocator_(VK_NULL_HANDLE),
+      memory_{},
+      owns_memory_(false),
+      handles_{
+          VK_NULL_HANDLE,
+          VK_NULL_HANDLE,
+          VK_NULL_HANDLE,
+      },
+      layout_{} {}
+
+VulkanImage::VulkanImage(
+    VmaAllocator vma_allocator,
+    const VmaAllocationCreateInfo& allocation_create_info,
+    const ImageProperties& image_props,
+    const ViewProperties& view_props,
+    const SamplerProperties& sampler_props,
+    const VkImageLayout layout,
+    VkSampler sampler,
+    const bool allocate_memory)
+    : image_properties_(image_props),
+      view_properties_(view_props),
+      sampler_properties_(sampler_props),
+      allocator_(vma_allocator),
+      memory_{},
+      owns_memory_{allocate_memory},
+      handles_{
+          VK_NULL_HANDLE,
+          VK_NULL_HANDLE,
+          sampler,
+      },
+      layout_(layout) {
+  VmaAllocatorInfo allocator_info{};
+  vmaGetAllocatorInfo(allocator_, &allocator_info);
+
+  // If any dims are zero, then no memory will be allocated for the image.
+  if (image_props.image_extents.width == 0 ||
+      image_props.image_extents.height == 0 ||
+      image_props.image_extents.depth == 0) {
+    return;
+  }
+
+  const VkImageCreateInfo image_create_info{
+      VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      image_properties_.image_type, // imageType
+      image_properties_.image_format, // format
+      image_properties_.image_extents, // extents
+      1u, // mipLevels
+      1u, // arrayLayers
+      VK_SAMPLE_COUNT_1_BIT, // samples
+      VK_IMAGE_TILING_OPTIMAL, // tiling
+      image_properties_.image_usage, // usage
+      VK_SHARING_MODE_EXCLUSIVE, // sharingMode
+      0u, // queueFamilyIndexCount
+      nullptr, // pQueueFamilyIndices
+      layout_, // initialLayout
+  };
+
+  memory_.create_info = allocation_create_info;
+
+  if (allocate_memory) {
+    VK_CHECK(vmaCreateImage(
+        allocator_,
+        &image_create_info,
+        &allocation_create_info,
+        &(handles_.image),
+        &(memory_.allocation),
+        nullptr));
+    // Only create the image view if the image has been bound to memory
+    create_image_view();
+  } else {
+    VK_CHECK(vkCreateImage(
+        allocator_info.device, &image_create_info, nullptr, &(handles_.image)));
+  }
+}
+
+VulkanImage::VulkanImage(VulkanImage&& other) noexcept
+    : image_properties_(other.image_properties_),
+      view_properties_(other.view_properties_),
+      sampler_properties_(other.sampler_properties_),
+      allocator_(other.allocator_),
+      memory_(std::move(other.memory_)),
+      owns_memory_(other.owns_memory_),
+      handles_(other.handles_),
+      layout_(other.layout_) {
+  other.handles_.image = VK_NULL_HANDLE;
+  other.handles_.image_view = VK_NULL_HANDLE;
+  other.handles_.sampler = VK_NULL_HANDLE;
+  other.owns_memory_ = false;
+}
+
+VulkanImage& VulkanImage::operator=(VulkanImage&& other) noexcept {
+  VkImage tmp_image = handles_.image;
+  VkImageView tmp_image_view = handles_.image_view;
+  bool tmp_owns_memory = owns_memory_;
+
+  image_properties_ = other.image_properties_;
+  view_properties_ = other.view_properties_;
+  sampler_properties_ = other.sampler_properties_;
+  allocator_ = other.allocator_;
+  memory_ = std::move(other.memory_);
+  owns_memory_ = other.owns_memory_;
+  handles_ = other.handles_;
+  layout_ = other.layout_;
+
+  other.handles_.image = tmp_image;
+  other.handles_.image_view = tmp_image_view;
+  other.owns_memory_ = tmp_owns_memory;
+
+  return *this;
+}
+
+VulkanImage::~VulkanImage() {
+  if (VK_NULL_HANDLE != handles_.image_view) {
+    vkDestroyImageView(this->device(), handles_.image_view, nullptr);
+  }
+
+  if (VK_NULL_HANDLE != handles_.image) {
+    if (owns_memory_) {
+      vmaDestroyImage(allocator_, handles_.image, memory_.allocation);
+    } else {
+      vkDestroyImage(this->device(), handles_.image, nullptr);
+    }
+    // Prevent the underlying memory allocation from being freed; it was either
+    // freed by vmaDestroyImage, or this resource does not own the underlying
+    // memory
+    memory_.allocation = VK_NULL_HANDLE;
+  }
+}
+
+void VulkanImage::create_image_view() {
+  VmaAllocatorInfo allocator_info{};
+  vmaGetAllocatorInfo(allocator_, &allocator_info);
+
+  const VkComponentMapping component_mapping{
+      VK_COMPONENT_SWIZZLE_IDENTITY, // r
+      VK_COMPONENT_SWIZZLE_IDENTITY, // g
+      VK_COMPONENT_SWIZZLE_IDENTITY, // b
+      VK_COMPONENT_SWIZZLE_IDENTITY, // a
+  };
+
+  const VkImageSubresourceRange subresource_range{
+      VK_IMAGE_ASPECT_COLOR_BIT, // aspectMask
+      0u, // baseMipLevel
+      VK_REMAINING_MIP_LEVELS, // levelCount
+      0u, // baseArrayLayer
+      VK_REMAINING_ARRAY_LAYERS, // layerCount
+  };
+
+  const VkImageViewCreateInfo image_view_create_info{
+      VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      handles_.image, // image
+      view_properties_.view_type, // viewType
+      view_properties_.view_format, // format
+      component_mapping, // components
+      subresource_range, // subresourceRange
+  };
+
+  VK_CHECK(vkCreateImageView(
+      allocator_info.device,
+      &(image_view_create_info),
+      nullptr,
+      &(handles_.image_view)));
+}
+
+VkMemoryRequirements VulkanImage::get_memory_requirements() const {
+  VkMemoryRequirements memory_requirements;
+  vkGetImageMemoryRequirements(
+      this->device(), handles_.image, &memory_requirements);
+  return memory_requirements;
+}
+
+//
+// ImageMemoryBarrier
+//
+
+ImageMemoryBarrier::ImageMemoryBarrier(
+    const VkAccessFlags src_access_flags,
+    const VkAccessFlags dst_access_flags,
+    const VkImageLayout src_layout_flags,
+    const VkImageLayout dst_layout_flags,
+    const VulkanImage& image)
+    : handle{
+          VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, // sType
+          nullptr, // pNext
+          src_access_flags, // srcAccessMask
+          dst_access_flags, // dstAccessMask
+          src_layout_flags, // oldLayout
+          dst_layout_flags, // newLayout
+          VK_QUEUE_FAMILY_IGNORED, // srcQueueFamilyIndex
+          VK_QUEUE_FAMILY_IGNORED, // dstQueueFamilyIndex
+          image.handles_.image, // image
+          {
+              // subresourceRange
+              VK_IMAGE_ASPECT_COLOR_BIT, // aspectMask
+              0u, // baseMipLevel
+              VK_REMAINING_MIP_LEVELS, // levelCount
+              0u, // baseArrayLayer
+              VK_REMAINING_ARRAY_LAYERS, // layerCount
+          },
+      } {}
+
+//
+// SamplerCache
+//
+
+SamplerCache::SamplerCache(VkDevice device)
+    : cache_mutex_{}, device_(device), cache_{} {}
+
+SamplerCache::SamplerCache(SamplerCache&& other) noexcept
+    : cache_mutex_{}, device_(other.device_), cache_(std::move(other.cache_)) {
+  std::lock_guard<std::mutex> lock(other.cache_mutex_);
+}
+
+SamplerCache::~SamplerCache() {
+  purge();
+}
+
+VkSampler SamplerCache::retrieve(const SamplerCache::Key& key) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  auto it = cache_.find(key);
+  if (cache_.cend() == it) {
+    it = cache_.insert({key, SamplerCache::Value(device_, key)}).first;
+  }
+
+  return it->second.handle();
+}
+
+void SamplerCache::purge() {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  cache_.clear();
+}
+
+//
+// MemoryAllocator
+//
+
+MemoryAllocator::MemoryAllocator(
+    VkInstance instance,
+    VkPhysicalDevice physical_device,
+    VkDevice device)
+    : instance_{},
+      physical_device_(physical_device),
+      device_(device),
+      allocator_{VK_NULL_HANDLE} {
+  VmaVulkanFunctions vk_functions{};
+  vk_functions.vkGetInstanceProcAddr = vkGetInstanceProcAddr;
+  vk_functions.vkGetDeviceProcAddr = vkGetDeviceProcAddr;
+
+  const VmaAllocatorCreateInfo allocator_create_info{
+      0u, // flags
+      physical_device_, // physicalDevice
+      device_, // device
+      0u, // preferredLargeHeapBlockSize
+      nullptr, // pAllocationCallbacks
+      nullptr, // pDeviceMemoryCallbacks
+      nullptr, // pHeapSizeLimit
+      &vk_functions, // pVulkanFunctions
+      instance, // instance
+      VK_API_VERSION_1_0, // vulkanApiVersion
+      nullptr, // pTypeExternalMemoryHandleTypes
+  };
+
+  VK_CHECK(vmaCreateAllocator(&allocator_create_info, &allocator_));
+}
+
+MemoryAllocator::MemoryAllocator(MemoryAllocator&& other) noexcept
+    : instance_(other.instance_),
+      physical_device_(other.physical_device_),
+      device_(other.device_),
+      allocator_(other.allocator_) {
+  other.allocator_ = VK_NULL_HANDLE;
+  other.device_ = VK_NULL_HANDLE;
+  other.physical_device_ = VK_NULL_HANDLE;
+  other.instance_ = VK_NULL_HANDLE;
+}
+
+MemoryAllocator::~MemoryAllocator() {
+  if (VK_NULL_HANDLE == allocator_) {
+    return;
+  }
+  vmaDestroyAllocator(allocator_);
+}
+
+MemoryAllocation MemoryAllocator::create_allocation(
+    const VkMemoryRequirements& memory_requirements,
+    const VmaAllocationCreateInfo& create_info) {
+  VmaAllocationCreateInfo alloc_create_info = create_info;
+  // Protect against using VMA_MEMORY_USAGE_AUTO_* flags when allocating memory
+  // directly, since those usage flags require that VkBufferCreateInfo and/or
+  // VkImageCreateInfo also be available.
+  switch (create_info.usage) {
+    // The logic for the below usage options are too complex, therefore prevent
+    // those from being used with direct memory allocation.
+    case VMA_MEMORY_USAGE_AUTO:
+    case VMA_MEMORY_USAGE_AUTO_PREFER_HOST:
+      VK_THROW(
+          "Only the VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE usage flag is compatible with create_allocation()");
+      break;
+    // Most of the time, VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE will simply set the
+    // DEVICE_LOCAL_BIT as a preferred memory flag. Therefore the below is a
+    // decent approximation for VMA behaviour.
+    case VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE:
+      alloc_create_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+      alloc_create_info.usage = VMA_MEMORY_USAGE_UNKNOWN;
+      break;
+    default:
+      break;
+  }
+
+  return MemoryAllocation(allocator_, memory_requirements, alloc_create_info);
+}
+
+VulkanImage MemoryAllocator::create_image(
+    const VkExtent3D& extents,
+    const VkFormat image_format,
+    const VkImageType image_type,
+    const VkImageViewType image_view_type,
+    const VulkanImage::SamplerProperties& sampler_props,
+    VkSampler sampler,
+    const bool allow_transfer,
+    const bool allocate_memory) {
+  VkImageUsageFlags usage =
+      VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
+  if (allow_transfer) {
+    usage |=
+        (VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+  }
+
+  VmaAllocationCreateInfo alloc_create_info = {};
+  alloc_create_info.flags = DEFAULT_ALLOCATION_STRATEGY;
+  alloc_create_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+
+  const VulkanImage::ImageProperties image_props{
+      image_type,
+      image_format,
+      extents,
+      usage,
+  };
+
+  const VulkanImage::ViewProperties view_props{
+      image_view_type,
+      image_format,
+  };
+
+  const VkImageLayout initial_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+  return VulkanImage(
+      allocator_,
+      alloc_create_info,
+      image_props,
+      view_props,
+      sampler_props,
+      initial_layout,
+      sampler,
+      allocate_memory);
+}
+
+VulkanBuffer MemoryAllocator::create_storage_buffer(
+    const VkDeviceSize size,
+    const bool gpu_only,
+    const bool allocate_memory) {
+  const VkBufferUsageFlags buffer_usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+
+  VmaAllocationCreateInfo alloc_create_info = {};
+  alloc_create_info.flags = DEFAULT_ALLOCATION_STRATEGY;
+  alloc_create_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+
+  // The create storage buffer will be accessed by both the CPU and GPU, so set
+  // the appropriate flags to indicate that the host device will be accessing
+  // the data from this buffer.
+  if (!gpu_only) {
+    // Deferred memory allocation should only be used for GPU only buffers.
+    VK_CHECK_COND(
+        allocate_memory,
+        "Only GPU-only buffers should use deferred memory allocation");
+
+    alloc_create_info.flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT;
+    alloc_create_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_HOST;
+    alloc_create_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+    alloc_create_info.preferredFlags = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT |
+        VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+  }
+
+  return VulkanBuffer(
+      allocator_, size, alloc_create_info, buffer_usage, allocate_memory);
+}
+
+VulkanBuffer MemoryAllocator::create_staging_buffer(const VkDeviceSize size) {
+  VmaAllocationCreateInfo alloc_create_info = {};
+  alloc_create_info.flags = DEFAULT_ALLOCATION_STRATEGY;
+  alloc_create_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_HOST;
+
+  VkBufferUsageFlags buffer_usage =
+      VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+
+  return VulkanBuffer(allocator_, size, alloc_create_info, buffer_usage);
+}
+
+VulkanBuffer MemoryAllocator::create_uniform_buffer(const VkDeviceSize size) {
+  VmaAllocationCreateInfo alloc_create_info = {};
+  alloc_create_info.flags = DEFAULT_ALLOCATION_STRATEGY |
+      VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
+  alloc_create_info.usage = VMA_MEMORY_USAGE_AUTO;
+
+  VkBufferUsageFlags buffer_usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+
+  VulkanBuffer uniform_buffer(
+      allocator_, size, alloc_create_info, buffer_usage);
+  return uniform_buffer;
+}
+
+//
+// VulkanFence
+//
+
+VulkanFence::VulkanFence()
+    : device_(VK_NULL_HANDLE), handle_(VK_NULL_HANDLE), waiting_(false) {}
+
+VulkanFence::VulkanFence(VkDevice device)
+    : device_(device), handle_(VK_NULL_HANDLE), waiting_(VK_NULL_HANDLE) {
+  const VkFenceCreateInfo fence_create_info{
+      VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+  };
+
+  VK_CHECK(vkCreateFence(device_, &fence_create_info, nullptr, &handle_));
+}
+
+VulkanFence::VulkanFence(VulkanFence&& other) noexcept
+    : device_(other.device_), handle_(other.handle_), waiting_(other.waiting_) {
+  other.handle_ = VK_NULL_HANDLE;
+  other.waiting_ = false;
+}
+
+VulkanFence& VulkanFence::operator=(VulkanFence&& other) noexcept {
+  device_ = other.device_;
+  handle_ = other.handle_;
+  waiting_ = other.waiting_;
+
+  other.device_ = VK_NULL_HANDLE;
+  other.handle_ = VK_NULL_HANDLE;
+  other.waiting_ = false;
+
+  return *this;
+}
+
+VulkanFence::~VulkanFence() {
+  if (VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroyFence(device_, handle_, nullptr);
+}
+
+void VulkanFence::wait() {
+  // if get_submit_handle() has not been called, then this will no-op
+  if (waiting_) {
+    VkResult fence_status = VK_NOT_READY;
+    // Run the wait in a loop to keep the CPU hot. A single call to
+    // vkWaitForFences with no timeout may cause the calling thread to be
+    // scheduled out.
+    do {
+      // The timeout (last) arg is in units of ns
+      fence_status = vkWaitForFences(device_, 1u, &handle_, VK_TRUE, 100000);
+
+      VK_CHECK_COND(
+          fence_status != VK_ERROR_DEVICE_LOST,
+          "Vulkan Fence: Device lost while waiting for fence!");
+    } while (fence_status != VK_SUCCESS);
+
+    VK_CHECK(vkResetFences(device_, 1u, &handle_));
+
+    waiting_ = false;
+  }
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/api/Resource.h
+++ b/backends/vulkan/runtime/api/Resource.h
@@ -1,0 +1,607 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#include <executorch/backends/vulkan/runtime/api/Allocator.h>
+#include <executorch/backends/vulkan/runtime/api/Types.h>
+#include <executorch/backends/vulkan/runtime/api/Utils.h>
+
+#include <mutex>
+#include <ostream>
+#include <stack>
+#include <unordered_map>
+
+std::ostream& operator<<(std::ostream& out, VmaTotalStatistics stats);
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+using MemoryAccessFlags = uint8_t;
+
+constexpr VmaAllocationCreateFlags DEFAULT_ALLOCATION_STRATEGY =
+    VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT;
+
+enum MemoryAccessType : MemoryAccessFlags {
+  NONE = 0u << 0u,
+  READ = 1u << 0u,
+  WRITE = 1u << 1u,
+};
+
+struct MemoryBarrier final {
+  VkMemoryBarrier handle;
+
+  MemoryBarrier(
+      const VkAccessFlags src_access_flags,
+      const VkAccessFlags dst_access_flags);
+};
+
+struct MemoryAllocation final {
+  explicit MemoryAllocation();
+
+  explicit MemoryAllocation(
+      const VmaAllocator,
+      const VkMemoryRequirements&,
+      const VmaAllocationCreateInfo&);
+
+  MemoryAllocation(const MemoryAllocation&) = delete;
+  MemoryAllocation& operator=(const MemoryAllocation&) = delete;
+
+  MemoryAllocation(MemoryAllocation&&) noexcept;
+  MemoryAllocation& operator=(MemoryAllocation&&) noexcept;
+
+  ~MemoryAllocation();
+
+  VkMemoryRequirements memory_requirements;
+  // The properties this allocation was created with
+  VmaAllocationCreateInfo create_info;
+  // The allocator object this was allocated from
+  VmaAllocator allocator;
+  // Handles to the allocated memory
+  VmaAllocation allocation;
+
+  operator bool() const {
+    return (allocation != VK_NULL_HANDLE);
+  }
+};
+
+class VulkanBuffer final {
+ public:
+  struct BufferProperties final {
+    VkDeviceSize size;
+    VkDeviceSize mem_offset;
+    VkDeviceSize mem_range;
+    VkBufferUsageFlags buffer_usage;
+  };
+
+  explicit VulkanBuffer();
+
+  explicit VulkanBuffer(
+      const VmaAllocator,
+      const VkDeviceSize,
+      const VmaAllocationCreateInfo&,
+      const VkBufferUsageFlags,
+      const bool allocate_memory = true);
+
+  VulkanBuffer(const VulkanBuffer&) = delete;
+  VulkanBuffer& operator=(const VulkanBuffer&) = delete;
+
+  VulkanBuffer(VulkanBuffer&&) noexcept;
+  VulkanBuffer& operator=(VulkanBuffer&&) noexcept;
+
+  ~VulkanBuffer();
+
+  struct Package final {
+    VkBuffer handle;
+    VkDeviceSize buffer_offset;
+    VkDeviceSize buffer_range;
+  };
+
+  friend struct BufferMemoryBarrier;
+
+ private:
+  BufferProperties buffer_properties_;
+  VmaAllocator allocator_;
+  MemoryAllocation memory_;
+  // Indicates whether the underlying memory is owned by this resource
+  bool owns_memory_;
+  VkBuffer handle_;
+
+ public:
+  inline VkDevice device() const {
+    VmaAllocatorInfo allocator_info{};
+    vmaGetAllocatorInfo(allocator_, &allocator_info);
+    return allocator_info.device;
+  }
+
+  inline VmaAllocator vma_allocator() const {
+    return allocator_;
+  }
+
+  inline VmaAllocation allocation() const {
+    return memory_.allocation;
+  }
+
+  inline VmaAllocationCreateInfo allocation_create_info() const {
+    return VmaAllocationCreateInfo(memory_.create_info);
+  }
+
+  inline VkBuffer handle() const {
+    return handle_;
+  }
+
+  inline VkDeviceSize mem_offset() const {
+    return buffer_properties_.mem_offset;
+  }
+
+  inline VkDeviceSize mem_range() const {
+    return buffer_properties_.mem_range;
+  }
+
+  inline VkDeviceSize mem_size() const {
+    return buffer_properties_.size;
+  }
+
+  inline bool has_memory() const {
+    return (memory_.allocation != VK_NULL_HANDLE);
+  }
+
+  inline bool owns_memory() const {
+    return owns_memory_;
+  }
+
+  operator bool() const {
+    return (handle_ != VK_NULL_HANDLE);
+  }
+
+  inline void bind_allocation(const MemoryAllocation& memory) {
+    VK_CHECK_COND(!memory_, "Cannot bind an already bound allocation!");
+    VK_CHECK(vmaBindBufferMemory(allocator_, memory.allocation, handle_));
+    memory_.allocation = memory.allocation;
+  }
+
+  VkMemoryRequirements get_memory_requirements() const;
+};
+
+class MemoryMap final {
+ public:
+  explicit MemoryMap(
+      const VulkanBuffer& buffer,
+      const MemoryAccessFlags access);
+
+  MemoryMap(const MemoryMap&) = delete;
+  MemoryMap& operator=(const MemoryMap&) = delete;
+
+  MemoryMap(MemoryMap&&) noexcept;
+  MemoryMap& operator=(MemoryMap&&) = delete;
+
+  ~MemoryMap();
+
+ private:
+  uint8_t access_;
+  VmaAllocator allocator_;
+  VmaAllocation allocation_;
+  void* data_;
+  VkDeviceSize data_len_;
+
+ public:
+  template <typename T>
+  T* data() {
+    return reinterpret_cast<T*>(data_);
+  }
+
+  inline size_t nbytes() {
+    return utils::safe_downcast<size_t>(data_len_);
+  }
+
+  void invalidate();
+};
+
+struct BufferMemoryBarrier final {
+  VkBufferMemoryBarrier handle;
+
+  BufferMemoryBarrier(
+      const VkAccessFlags src_access_flags,
+      const VkAccessFlags dst_access_flags,
+      const VulkanBuffer& buffer);
+};
+
+class ImageSampler final {
+ public:
+  struct Properties final {
+    VkFilter filter;
+    VkSamplerMipmapMode mipmap_mode;
+    VkSamplerAddressMode address_mode;
+    VkBorderColor border_color;
+  };
+
+  explicit ImageSampler(VkDevice, const Properties&);
+
+  ImageSampler(const ImageSampler&) = delete;
+  ImageSampler& operator=(const ImageSampler&) = delete;
+
+  ImageSampler(ImageSampler&&) noexcept;
+  ImageSampler& operator=(ImageSampler&&) = delete;
+
+  ~ImageSampler();
+
+ private:
+  VkDevice device_;
+  VkSampler handle_;
+
+ public:
+  VkSampler handle() const {
+    return handle_;
+  }
+
+  struct Hasher {
+    size_t operator()(const Properties&) const;
+  };
+
+  // We need to define a custom swap function since this class
+  // does not allow for move assignment. The swap function will
+  // be used in the hash map.
+  friend void swap(ImageSampler& lhs, ImageSampler& rhs) noexcept;
+};
+
+class VulkanImage final {
+ public:
+  struct ImageProperties final {
+    VkImageType image_type;
+    VkFormat image_format;
+    VkExtent3D image_extents;
+    VkImageUsageFlags image_usage;
+  };
+
+  struct ViewProperties final {
+    VkImageViewType view_type;
+    VkFormat view_format;
+  };
+
+  using SamplerProperties = ImageSampler::Properties;
+
+  struct Handles final {
+    VkImage image;
+    VkImageView image_view;
+    VkSampler sampler;
+  };
+
+  explicit VulkanImage();
+
+  explicit VulkanImage(
+      const VmaAllocator,
+      const VmaAllocationCreateInfo&,
+      const ImageProperties&,
+      const ViewProperties&,
+      const SamplerProperties&,
+      const VkImageLayout layout,
+      VkSampler,
+      const bool allocate_memory = true);
+
+  VulkanImage(const VulkanImage&) = delete;
+  VulkanImage& operator=(const VulkanImage&) = delete;
+
+  VulkanImage(VulkanImage&&) noexcept;
+  VulkanImage& operator=(VulkanImage&&) noexcept;
+
+  ~VulkanImage();
+
+  struct Package final {
+    VkImage handle;
+    VkImageLayout image_layout;
+    VkImageView image_view;
+    VkSampler image_sampler;
+  };
+
+  friend struct ImageMemoryBarrier;
+
+ private:
+  ImageProperties image_properties_;
+  ViewProperties view_properties_;
+  SamplerProperties sampler_properties_;
+  // The allocator object this was allocated from
+  VmaAllocator allocator_;
+  // Handles to the allocated memory
+  MemoryAllocation memory_;
+  // Indicates whether the underlying memory is owned by this resource
+  bool owns_memory_;
+  Handles handles_;
+  // Layout
+  VkImageLayout layout_;
+
+ public:
+  void create_image_view();
+
+  inline VkDevice device() const {
+    VmaAllocatorInfo allocator_info{};
+    vmaGetAllocatorInfo(allocator_, &allocator_info);
+    return allocator_info.device;
+  }
+
+  inline VmaAllocator vma_allocator() const {
+    return allocator_;
+  }
+
+  inline VmaAllocation allocation() const {
+    return memory_.allocation;
+  }
+
+  inline VmaAllocationCreateInfo allocation_create_info() const {
+    return VmaAllocationCreateInfo(memory_.create_info);
+  }
+
+  inline VkFormat format() const {
+    return image_properties_.image_format;
+  }
+
+  inline VkExtent3D extents() const {
+    return image_properties_.image_extents;
+  }
+
+  inline VkImage handle() const {
+    return handles_.image;
+  }
+
+  inline VkImageView image_view() const {
+    return handles_.image_view;
+  }
+
+  inline VkSampler sampler() const {
+    return handles_.sampler;
+  }
+
+  Package package() const {
+    return {
+        handles_.image,
+        layout_,
+        handles_.image_view,
+        handles_.sampler,
+    };
+  }
+
+  inline VkImageLayout layout() const {
+    return layout_;
+  }
+
+  inline void set_layout(const VkImageLayout layout) {
+    layout_ = layout;
+  }
+
+  inline bool has_memory() const {
+    return (memory_.allocation != VK_NULL_HANDLE);
+  }
+
+  inline bool owns_memory() const {
+    return owns_memory_;
+  }
+
+  inline operator bool() const {
+    return (handles_.image != VK_NULL_HANDLE);
+  }
+
+  inline void bind_allocation(const MemoryAllocation& memory) {
+    VK_CHECK_COND(!memory_, "Cannot bind an already bound allocation!");
+    VK_CHECK(vmaBindImageMemory(allocator_, memory.allocation, handles_.image));
+    memory_.allocation = memory.allocation;
+
+    // Only create the image view if the image has been bound to memory
+    create_image_view();
+  }
+
+  VkMemoryRequirements get_memory_requirements() const;
+};
+
+struct ImageMemoryBarrier final {
+  VkImageMemoryBarrier handle;
+
+  ImageMemoryBarrier(
+      const VkAccessFlags src_access_flags,
+      const VkAccessFlags dst_access_flags,
+      const VkImageLayout src_layout_flags,
+      const VkImageLayout dst_layout_flags,
+      const VulkanImage& image);
+};
+
+class SamplerCache final {
+ public:
+  explicit SamplerCache(VkDevice device);
+
+  SamplerCache(const SamplerCache&) = delete;
+  SamplerCache& operator=(const SamplerCache&) = delete;
+
+  SamplerCache(SamplerCache&&) noexcept;
+  SamplerCache& operator=(SamplerCache&&) = delete;
+
+  ~SamplerCache();
+
+  using Key = ImageSampler::Properties;
+  using Value = ImageSampler;
+  using Hasher = ImageSampler::Hasher;
+
+ private:
+  // Multiple threads could potentially be adding entries into the cache, so use
+  // a mutex to manage access
+  std::mutex cache_mutex_;
+
+  VkDevice device_;
+  std::unordered_map<Key, Value, Hasher> cache_;
+
+ public:
+  VkSampler retrieve(const Key&);
+  void purge();
+};
+
+class MemoryAllocator final {
+ public:
+  explicit MemoryAllocator(
+      VkInstance instance,
+      VkPhysicalDevice physical_device,
+      VkDevice device);
+
+  MemoryAllocator(const MemoryAllocator&) = delete;
+  MemoryAllocator& operator=(const MemoryAllocator&) = delete;
+
+  MemoryAllocator(MemoryAllocator&&) noexcept;
+  MemoryAllocator& operator=(MemoryAllocator&&) = delete;
+
+  ~MemoryAllocator();
+
+ private:
+  VkInstance instance_;
+  VkPhysicalDevice physical_device_;
+  VkDevice device_;
+  VmaAllocator allocator_;
+
+ public:
+  MemoryAllocation create_allocation(
+      const VkMemoryRequirements& memory_requirements,
+      const VmaAllocationCreateInfo& create_info);
+
+  VulkanImage create_image(
+      const VkExtent3D&,
+      const VkFormat,
+      const VkImageType,
+      const VkImageViewType,
+      const VulkanImage::SamplerProperties&,
+      VkSampler,
+      const bool allow_transfer = false,
+      const bool allocate_memory = true);
+
+  VulkanBuffer create_storage_buffer(
+      const VkDeviceSize,
+      const bool gpu_only = true,
+      const bool allocate_memory = true);
+
+  VulkanBuffer create_staging_buffer(const VkDeviceSize);
+
+  /*
+   * Create a uniform buffer with a specified size
+   */
+  VulkanBuffer create_uniform_buffer(const VkDeviceSize);
+
+  /*
+   * Create a uniform buffer containing the data in an arbitrary struct
+   */
+  template <typename Block>
+  VulkanBuffer create_params_buffer(const Block& block);
+
+  VmaTotalStatistics get_memory_statistics() const {
+    VmaTotalStatistics stats = {};
+    vmaCalculateStatistics(allocator_, &stats);
+    return stats;
+  }
+};
+
+class VulkanFence final {
+ public:
+  // TODO: This is required for the lazy allocation pattern in api/Tensor.
+  //       It will be disabled pending future refactors.
+  explicit VulkanFence();
+
+  explicit VulkanFence(VkDevice);
+
+  VulkanFence(const VulkanFence&) = delete;
+  VulkanFence& operator=(const VulkanFence&) = delete;
+
+  VulkanFence(VulkanFence&&) noexcept;
+  VulkanFence& operator=(VulkanFence&&) noexcept;
+
+  ~VulkanFence();
+
+ private:
+  VkDevice device_;
+  VkFence handle_;
+  bool waiting_;
+
+ public:
+  // Used to get the handle for a queue submission.
+  VkFence get_submit_handle() {
+    if (handle_ != VK_NULL_HANDLE) {
+      // Indicate we are now waiting for this fence to be signaled
+      waiting_ = true;
+    }
+    return handle_;
+  }
+
+  VkFence handle() {
+    return handle_;
+  }
+
+  // Trigger a synchronous wait for the fence to be signaled
+  void wait();
+
+  bool waiting() const {
+    return waiting_;
+  }
+
+  operator bool() const {
+    return (VK_NULL_HANDLE != handle_);
+  }
+};
+
+// A pool to track created Fences and reuse ones that are available.
+// Only intended to be modified by one thread at a time.
+struct FencePool final {
+  VkDevice device_;
+
+  std::stack<VulkanFence> pool_;
+
+  explicit FencePool(VkDevice device) : device_(device), pool_{} {}
+
+  // Returns an rvalue reference to a fence, so that it can be moved
+  inline VulkanFence get_fence() {
+    if (pool_.empty()) {
+      VulkanFence new_fence = VulkanFence(device_);
+      return new_fence;
+    }
+
+    VulkanFence top_fence = std::move(pool_.top());
+    pool_.pop();
+
+    return top_fence;
+  }
+
+  // Marks the fence as available
+  inline void return_fence(VulkanFence& fence) {
+    pool_.push(std::move(fence));
+  }
+};
+
+//
+// Impl
+//
+
+template <typename Block>
+inline VulkanBuffer MemoryAllocator::create_params_buffer(const Block& block) {
+  VulkanBuffer uniform_buffer = create_uniform_buffer(sizeof(Block));
+
+  // Fill the uniform buffer with data in block
+  {
+    MemoryMap mapping(uniform_buffer, MemoryAccessType::WRITE);
+    Block* data_ptr = mapping.template data<Block>();
+
+    *data_ptr = block;
+  }
+
+  return uniform_buffer;
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/Runtime.cpp
+++ b/backends/vulkan/runtime/api/Runtime.cpp
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstring>
+#include <iostream>
+#include <sstream>
+
+#include <executorch/backends/vulkan/runtime/api/Adapter.h>
+#include <executorch/backends/vulkan/runtime/api/Runtime.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+namespace {
+
+void find_requested_layers_and_extensions(
+    std::vector<const char*>& enabled_layers,
+    std::vector<const char*>& enabled_extensions,
+    const std::vector<const char*>& requested_layers,
+    const std::vector<const char*>& requested_extensions) {
+  // Get supported instance layers
+  uint32_t layer_count = 0;
+  VK_CHECK(vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
+
+  std::vector<VkLayerProperties> layer_properties(layer_count);
+  VK_CHECK(vkEnumerateInstanceLayerProperties(
+      &layer_count, layer_properties.data()));
+
+  // Search for requested layers
+  for (const auto& requested_layer : requested_layers) {
+    for (const auto& layer : layer_properties) {
+      if (strcmp(requested_layer, layer.layerName) == 0) {
+        enabled_layers.push_back(requested_layer);
+        break;
+      }
+    }
+  }
+
+  // Get supported instance extensions
+  uint32_t extension_count = 0;
+  VK_CHECK(vkEnumerateInstanceExtensionProperties(
+      nullptr, &extension_count, nullptr));
+
+  std::vector<VkExtensionProperties> extension_properties(extension_count);
+  VK_CHECK(vkEnumerateInstanceExtensionProperties(
+      nullptr, &extension_count, extension_properties.data()));
+
+  // Search for requested extensions
+  for (const auto& requested_extension : requested_extensions) {
+    for (const auto& extension : extension_properties) {
+      if (strcmp(requested_extension, extension.extensionName) == 0) {
+        enabled_extensions.push_back(requested_extension);
+        break;
+      }
+    }
+  }
+}
+
+VkInstance create_instance(const RuntimeConfiguration& config) {
+  const VkApplicationInfo application_info{
+      VK_STRUCTURE_TYPE_APPLICATION_INFO, // sType
+      nullptr, // pNext
+      "PyTorch Vulkan Backend", // pApplicationName
+      0, // applicationVersion
+      nullptr, // pEngineName
+      0, // engineVersion
+      VK_API_VERSION_1_0, // apiVersion
+  };
+
+  std::vector<const char*> enabled_layers;
+  std::vector<const char*> enabled_extensions;
+
+  if (config.enableValidationMessages) {
+    std::vector<const char*> requested_layers{
+        // "VK_LAYER_LUNARG_api_dump",
+        "VK_LAYER_KHRONOS_validation",
+    };
+    std::vector<const char*> requested_extensions{
+#ifdef VK_EXT_debug_report
+        VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
+#endif /* VK_EXT_debug_report */
+    };
+
+    find_requested_layers_and_extensions(
+        enabled_layers,
+        enabled_extensions,
+        requested_layers,
+        requested_extensions);
+  }
+
+  const VkInstanceCreateInfo instance_create_info{
+      VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      &application_info, // pApplicationInfo
+      static_cast<uint32_t>(enabled_layers.size()), // enabledLayerCount
+      enabled_layers.data(), // ppEnabledLayerNames
+      static_cast<uint32_t>(enabled_extensions.size()), // enabledExtensionCount
+      enabled_extensions.data(), // ppEnabledExtensionNames
+  };
+
+  VkInstance instance{};
+  VK_CHECK(vkCreateInstance(&instance_create_info, nullptr, &instance));
+  VK_CHECK_COND(instance, "Invalid Vulkan instance!");
+
+#ifdef USE_VULKAN_VOLK
+  volkLoadInstance(instance);
+#endif /* USE_VULKAN_VOLK */
+
+  return instance;
+}
+
+std::vector<Runtime::DeviceMapping> create_physical_devices(
+    VkInstance instance) {
+  if (VK_NULL_HANDLE == instance) {
+    return std::vector<Runtime::DeviceMapping>();
+  }
+
+  uint32_t device_count = 0;
+  VK_CHECK(vkEnumeratePhysicalDevices(instance, &device_count, nullptr));
+
+  std::vector<VkPhysicalDevice> devices(device_count);
+  VK_CHECK(vkEnumeratePhysicalDevices(instance, &device_count, devices.data()));
+
+  std::vector<Runtime::DeviceMapping> device_mappings;
+  device_mappings.reserve(device_count);
+  for (VkPhysicalDevice physical_device : devices) {
+    device_mappings.emplace_back(PhysicalDevice(physical_device), -1);
+  }
+
+  return device_mappings;
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL debug_report_callback_fn(
+    const VkDebugReportFlagsEXT flags,
+    const VkDebugReportObjectTypeEXT /* object_type */,
+    const uint64_t /* object */,
+    const size_t /* location */,
+    const int32_t message_code,
+    const char* const layer_prefix,
+    const char* const message,
+    void* const /* user_data */) {
+  (void)flags;
+
+  std::stringstream stream;
+  stream << layer_prefix << " " << message_code << " " << message << std::endl;
+  const std::string log = stream.str();
+
+  std::cout << log;
+
+  return VK_FALSE;
+}
+
+VkDebugReportCallbackEXT create_debug_report_callback(
+    VkInstance instance,
+    const RuntimeConfiguration config) {
+  if (VK_NULL_HANDLE == instance || !config.enableValidationMessages) {
+    return VkDebugReportCallbackEXT{};
+  }
+
+  const VkDebugReportCallbackCreateInfoEXT debugReportCallbackCreateInfo{
+      VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT, // sType
+      nullptr, // pNext
+      VK_DEBUG_REPORT_INFORMATION_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT |
+          VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT |
+          VK_DEBUG_REPORT_ERROR_BIT_EXT |
+          VK_DEBUG_REPORT_DEBUG_BIT_EXT, // flags
+      debug_report_callback_fn, // pfnCallback
+      nullptr, // pUserData
+  };
+
+  const auto vkCreateDebugReportCallbackEXT =
+      (PFN_vkCreateDebugReportCallbackEXT)vkGetInstanceProcAddr(
+          instance, "vkCreateDebugReportCallbackEXT");
+
+  VK_CHECK_COND(
+      vkCreateDebugReportCallbackEXT,
+      "Could not load vkCreateDebugReportCallbackEXT");
+
+  VkDebugReportCallbackEXT debug_report_callback{};
+  VK_CHECK(vkCreateDebugReportCallbackEXT(
+      instance,
+      &debugReportCallbackCreateInfo,
+      nullptr,
+      &debug_report_callback));
+
+  VK_CHECK_COND(debug_report_callback, "Invalid Vulkan debug report callback!");
+
+  return debug_report_callback;
+}
+
+//
+// Adapter selection methods
+//
+
+uint32_t select_first(const std::vector<Runtime::DeviceMapping>& devices) {
+  if (devices.empty()) {
+    return devices.size() + 1; // return out of range to signal invalidity
+  }
+
+  // Select the first adapter that has compute capability
+  for (size_t i = 0; i < devices.size(); ++i) {
+    if (devices[i].first.num_compute_queues > 0) {
+      return i;
+    }
+  }
+
+  return devices.size() + 1;
+}
+
+//
+// Global runtime initialization
+//
+
+std::unique_ptr<Runtime> init_global_vulkan_runtime() {
+  // Load Vulkan drivers
+#if defined(USE_VULKAN_VOLK)
+  if (VK_SUCCESS != volkInitialize()) {
+    return std::unique_ptr<Runtime>(nullptr);
+  }
+#elif defined(USE_VULKAN_WRAPPER)
+  if (!InitVulkan()) {
+    return std::unique_ptr<Runtime>(nullptr);
+  }
+#endif /* USE_VULKAN_VOLK, USE_VULKAN_WRAPPER */
+
+  const bool enableValidationMessages =
+#if defined(VULKAN_DEBUG)
+      true;
+#else
+      false;
+#endif /* VULKAN_DEBUG */
+  const bool initDefaultDevice = true;
+  const uint32_t numRequestedQueues = 1; // TODO: raise this value
+
+  const RuntimeConfiguration default_config{
+      enableValidationMessages,
+      initDefaultDevice,
+      AdapterSelector::First,
+      numRequestedQueues,
+  };
+
+  try {
+    return std::make_unique<Runtime>(Runtime(default_config));
+  } catch (...) {
+  }
+
+  return std::unique_ptr<Runtime>(nullptr);
+}
+
+} // namespace
+
+Runtime::Runtime(const RuntimeConfiguration config)
+    : config_(config),
+      instance_(create_instance(config_)),
+      device_mappings_(create_physical_devices(instance_)),
+      adapters_{},
+      default_adapter_i_(UINT32_MAX),
+      debug_report_callback_(create_debug_report_callback(instance_, config_)) {
+  // List of adapters will never exceed the number of physical devices
+  adapters_.reserve(device_mappings_.size());
+
+  if (config.initDefaultDevice) {
+    try {
+      switch (config.defaultSelector) {
+        case AdapterSelector::First:
+          default_adapter_i_ = create_adapter(select_first);
+      }
+    } catch (...) {
+    }
+  }
+}
+
+Runtime::~Runtime() {
+  if (VK_NULL_HANDLE == instance_) {
+    return;
+  }
+
+  // Clear adapters list to trigger device destruction before destroying
+  // VkInstance
+  adapters_.clear();
+
+  // Instance must be destroyed last as its used to destroy the debug report
+  // callback.
+  if (debug_report_callback_) {
+    const auto vkDestroyDebugReportCallbackEXT =
+        (PFN_vkDestroyDebugReportCallbackEXT)vkGetInstanceProcAddr(
+            instance_, "vkDestroyDebugReportCallbackEXT");
+
+    if (vkDestroyDebugReportCallbackEXT) {
+      vkDestroyDebugReportCallbackEXT(
+          instance_, debug_report_callback_, nullptr);
+    }
+
+    debug_report_callback_ = {};
+  }
+
+  vkDestroyInstance(instance_, nullptr);
+  instance_ = VK_NULL_HANDLE;
+}
+
+Runtime::Runtime(Runtime&& other) noexcept
+    : config_(other.config_),
+      instance_(other.instance_),
+      adapters_(std::move(other.adapters_)),
+      default_adapter_i_(other.default_adapter_i_),
+      debug_report_callback_(other.debug_report_callback_) {
+  other.instance_ = VK_NULL_HANDLE;
+  other.debug_report_callback_ = {};
+}
+
+uint32_t Runtime::create_adapter(const Selector& selector) {
+  VK_CHECK_COND(
+      !device_mappings_.empty(),
+      "Pytorch Vulkan Runtime: Could not initialize adapter because no "
+      "devices were found by the Vulkan instance.");
+
+  uint32_t physical_device_i = selector(device_mappings_);
+  VK_CHECK_COND(
+      physical_device_i < device_mappings_.size(),
+      "Pytorch Vulkan Runtime: no suitable device adapter was selected! "
+      "Device could not be initialized");
+
+  Runtime::DeviceMapping& device_mapping = device_mappings_[physical_device_i];
+  // If an Adapter has already been created, return that
+  int32_t adapter_i = device_mapping.second;
+  if (adapter_i >= 0) {
+    return adapter_i;
+  }
+  // Otherwise, create an adapter for the selected physical device
+  adapter_i = utils::safe_downcast<int32_t>(adapters_.size());
+  adapters_.emplace_back(
+      new Adapter(instance_, device_mapping.first, config_.numRequestedQueues));
+  device_mapping.second = adapter_i;
+
+  return adapter_i;
+}
+
+Runtime* runtime() {
+  // The global vulkan runtime is declared as a static local variable within a
+  // non-static function to ensure it has external linkage. If it were a global
+  // static variable there would be one copy per translation unit that includes
+  // Runtime.h as it would have internal linkage.
+  static const std::unique_ptr<Runtime> p_runtime =
+      init_global_vulkan_runtime();
+
+  VK_CHECK_COND(
+      p_runtime,
+      "Pytorch Vulkan Runtime: The global runtime could not be retrieved "
+      "because it failed to initialize.");
+
+  return p_runtime.get();
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/api/Runtime.h
+++ b/backends/vulkan/runtime/api/Runtime.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#include <functional>
+#include <memory>
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#include <executorch/backends/vulkan/runtime/api/Adapter.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+//
+// A Vulkan Runtime initializes a Vulkan instance and decouples the concept of
+// Vulkan instance initialization from initialization of, and subsequent
+// interactions with,  Vulkan [physical and logical] devices as a precursor to
+// multi-GPU support.  The Vulkan Runtime can be queried for available Adapters
+// (i.e. physical devices) in the system which in turn can be used for creation
+// of a Vulkan Context (i.e. logical devices).  All Vulkan tensors in PyTorch
+// are associated with a Context to make tensor <-> device affinity explicit.
+//
+
+enum AdapterSelector {
+  First,
+};
+
+struct RuntimeConfiguration final {
+  bool enableValidationMessages;
+  bool initDefaultDevice;
+  AdapterSelector defaultSelector;
+  uint32_t numRequestedQueues;
+};
+
+class Runtime final {
+ public:
+  explicit Runtime(const RuntimeConfiguration);
+
+  // Do not allow copying. There should be only one global instance of this
+  // class.
+  Runtime(const Runtime&) = delete;
+  Runtime& operator=(const Runtime&) = delete;
+
+  Runtime(Runtime&&) noexcept;
+  Runtime& operator=(Runtime&&) = delete;
+
+  ~Runtime();
+
+  using DeviceMapping = std::pair<PhysicalDevice, int32_t>;
+  using AdapterPtr = std::unique_ptr<Adapter>;
+
+ private:
+  RuntimeConfiguration config_;
+
+  VkInstance instance_;
+
+  std::vector<DeviceMapping> device_mappings_;
+  std::vector<AdapterPtr> adapters_;
+  uint32_t default_adapter_i_;
+
+  VkDebugReportCallbackEXT debug_report_callback_;
+
+ public:
+  inline VkInstance instance() const {
+    return instance_;
+  }
+
+  inline Adapter* get_adapter_p() {
+    VK_CHECK_COND(
+        default_adapter_i_ >= 0 && default_adapter_i_ < adapters_.size(),
+        "Pytorch Vulkan Runtime: Default device adapter is not set correctly!");
+    return adapters_[default_adapter_i_].get();
+  }
+
+  inline Adapter* get_adapter_p(uint32_t i) {
+    VK_CHECK_COND(
+        i >= 0 && i < adapters_.size(),
+        "Pytorch Vulkan Runtime: Adapter at index ",
+        i,
+        " is not available!");
+    return adapters_[i].get();
+  }
+
+  inline uint32_t default_adapter_i() const {
+    return default_adapter_i_;
+  }
+
+  using Selector =
+      std::function<uint32_t(const std::vector<Runtime::DeviceMapping>&)>;
+  uint32_t create_adapter(const Selector&);
+};
+
+// The global runtime is retrieved using this function, where it is declared as
+// a static local variable.
+Runtime* runtime();
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/Shader.cpp
+++ b/backends/vulkan/runtime/api/Shader.cpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <utility>
+
+#include <executorch/backends/vulkan/runtime/api/Shader.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+//
+// ShaderInfo
+//
+
+ShaderInfo::ShaderInfo()
+    : src_code{
+          nullptr,
+          0u,
+      } {}
+
+ShaderInfo::ShaderInfo(
+    std::string name,
+    const uint32_t* const spirv_bin,
+    const uint32_t size,
+    std::vector<VkDescriptorType>  layout)
+    : src_code{
+          spirv_bin,
+          size,
+      },
+      kernel_name{std::move(name)},
+      kernel_layout{std::move(layout)} {}
+
+ShaderInfo::ShaderInfo(
+    std::string name,
+    const uint32_t* const spirv_bin,
+    const uint32_t size,
+    std::vector<VkDescriptorType>  layout,
+    const std::vector<uint32_t>& tile_size,
+    const StorageType bias_storage_type,
+    const StorageType weight_storage_type)
+    : src_code{
+          spirv_bin,
+          size,
+      },
+      kernel_name{std::move(name)},
+      kernel_layout{std::move(layout)},
+      tile_size(tile_size),
+      bias_storage_type(bias_storage_type),
+      weight_storage_type(weight_storage_type) {
+  for (uint64_t i = 0; i < tile_size.size(); ++i) {
+    out_tile_size.data[i] = tile_size[i];
+  }
+}
+
+bool operator==(const ShaderInfo& _1, const ShaderInfo& _2) {
+  return (
+      _1.src_code.bin == _2.src_code.bin &&
+      _1.src_code.size == _2.src_code.size);
+}
+
+//
+// ShaderLayout
+//
+
+ShaderLayout::ShaderLayout(
+    VkDevice device,
+    const ShaderLayout::Signature& signature)
+    : device_(device), handle_{VK_NULL_HANDLE} {
+  std::vector<VkDescriptorSetLayoutBinding> bindings;
+
+  uint32_t binding_num = 0u;
+  for (const VkDescriptorType type : signature) {
+    bindings.push_back({
+        binding_num++, // binding
+        type, // descriptorType
+        1u, // descriptorCount
+        VK_SHADER_STAGE_COMPUTE_BIT, // stageFlags
+        nullptr, // pImmutableSamplers
+    });
+  }
+
+  const VkDescriptorSetLayoutCreateInfo descriptor_set_layout_create_info{
+      VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      static_cast<uint32_t>(bindings.size()), // bindingCount
+      bindings.data(), // pBindings
+  };
+
+  VK_CHECK(vkCreateDescriptorSetLayout(
+      device_, &descriptor_set_layout_create_info, nullptr, &handle_));
+}
+
+ShaderLayout::ShaderLayout(ShaderLayout&& other) noexcept
+    : device_(other.device_), handle_(other.handle_) {
+  other.handle_ = VK_NULL_HANDLE;
+}
+
+ShaderLayout::~ShaderLayout() {
+  if (VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroyDescriptorSetLayout(device_, handle_, nullptr);
+  handle_ = VK_NULL_HANDLE;
+}
+
+void swap(ShaderLayout& lhs, ShaderLayout& rhs) noexcept {
+  VkDevice tmp_device = lhs.device_;
+  VkDescriptorSetLayout tmp_handle = lhs.handle_;
+
+  lhs.device_ = rhs.device_;
+  lhs.handle_ = rhs.handle_;
+
+  rhs.device_ = tmp_device;
+  rhs.handle_ = tmp_handle;
+}
+
+//
+// ShaderModule
+//
+
+ShaderModule::ShaderModule(VkDevice device, const ShaderInfo& source)
+    : device_(device), handle_{VK_NULL_HANDLE} {
+  const uint32_t* code = source.src_code.bin;
+  uint32_t size = source.src_code.size;
+
+  const VkShaderModuleCreateInfo shader_module_create_info{
+      VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      size, // codeSize
+      code, // pCode
+  };
+
+  VK_CHECK(vkCreateShaderModule(
+      device_, &shader_module_create_info, nullptr, &handle_));
+}
+
+ShaderModule::ShaderModule(ShaderModule&& other) noexcept
+    : device_(other.device_), handle_(other.handle_) {
+  other.handle_ = VK_NULL_HANDLE;
+}
+
+ShaderModule::~ShaderModule() {
+  if (VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroyShaderModule(device_, handle_, nullptr);
+  handle_ = VK_NULL_HANDLE;
+}
+
+void swap(ShaderModule& lhs, ShaderModule& rhs) noexcept {
+  VkDevice tmp_device = lhs.device_;
+  VkShaderModule tmp_handle = lhs.handle_;
+
+  lhs.device_ = rhs.device_;
+  lhs.handle_ = rhs.handle_;
+
+  rhs.device_ = tmp_device;
+  rhs.handle_ = tmp_handle;
+}
+
+//
+// ShaderLayoutCache
+//
+
+ShaderLayoutCache::ShaderLayoutCache(VkDevice device)
+    : cache_mutex_{}, device_(device), cache_{} {}
+
+ShaderLayoutCache::ShaderLayoutCache(ShaderLayoutCache&& other) noexcept
+    : cache_mutex_{}, device_(other.device_), cache_(std::move(other.cache_)) {
+  std::lock_guard<std::mutex> lock(other.cache_mutex_);
+}
+
+ShaderLayoutCache::~ShaderLayoutCache() {
+  purge();
+}
+
+VkDescriptorSetLayout ShaderLayoutCache::retrieve(
+    const ShaderLayoutCache::Key& key) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  auto it = cache_.find(key);
+  if (cache_.cend() == it) {
+    it = cache_.insert({key, ShaderLayoutCache::Value(device_, key)}).first;
+  }
+
+  return it->second.handle();
+}
+
+void ShaderLayoutCache::purge() {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  cache_.clear();
+}
+
+//
+// ShaderCache
+//
+
+ShaderCache::ShaderCache(VkDevice device)
+    : cache_mutex_{}, device_(device), cache_{} {}
+
+ShaderCache::ShaderCache(ShaderCache&& other) noexcept
+    : cache_mutex_{}, device_(other.device_), cache_(std::move(other.cache_)) {
+  std::lock_guard<std::mutex> lock(other.cache_mutex_);
+}
+
+ShaderCache::~ShaderCache() {
+  purge();
+}
+
+VkShaderModule ShaderCache::retrieve(const ShaderCache::Key& key) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  auto it = cache_.find(key);
+  if (cache_.cend() == it) {
+    it = cache_.insert({key, ShaderCache::Value(device_, key)}).first;
+  }
+
+  return it->second.handle();
+}
+
+void ShaderCache::purge() {
+  cache_.clear();
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/api/Shader.h
+++ b/backends/vulkan/runtime/api/Shader.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#include <executorch/backends/vulkan/runtime/api/Types.h>
+#include <executorch/backends/vulkan/runtime/api/Utils.h>
+
+#include <mutex>
+#include <unordered_map>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+class ShaderLayout final {
+ public:
+  using Signature = std::vector<VkDescriptorType>;
+
+  explicit ShaderLayout(VkDevice, const Signature&);
+
+  ShaderLayout(const ShaderLayout&) = delete;
+  ShaderLayout& operator=(const ShaderLayout&) = delete;
+
+  ShaderLayout(ShaderLayout&&) noexcept;
+  ShaderLayout& operator=(ShaderLayout&&) = delete;
+
+  ~ShaderLayout();
+
+ private:
+  VkDevice device_;
+  VkDescriptorSetLayout handle_;
+
+ public:
+  VkDescriptorSetLayout handle() const {
+    return handle_;
+  }
+
+  // We need to define a custom swap function since this class
+  // does not allow for move assignment. The swap function will
+  // be used in the hash map.
+  friend void swap(ShaderLayout& lhs, ShaderLayout& rhs) noexcept;
+};
+
+struct ShaderInfo final {
+  struct {
+    const uint32_t* bin;
+    uint32_t size;
+  } src_code;
+
+  std::string kernel_name{""};
+  ShaderLayout::Signature kernel_layout{};
+
+  // Shader Metadata
+  utils::uvec3 out_tile_size{1u, 1u, 1u};
+
+  std::vector<uint32_t> tile_size;
+  StorageType bias_storage_type{StorageType::UNKNOWN};
+  StorageType weight_storage_type{StorageType::UNKNOWN};
+
+  explicit ShaderInfo();
+  explicit ShaderInfo(std::string, const char*);
+  explicit ShaderInfo(
+      std::string,
+      const uint32_t*,
+      const uint32_t,
+      std::vector<VkDescriptorType>);
+  explicit ShaderInfo(
+      std::string,
+      const uint32_t*,
+      const uint32_t,
+      std::vector<VkDescriptorType>,
+      const std::vector<uint32_t>& tile_size,
+      const StorageType bias_storage_type,
+      const StorageType weight_storage_type);
+};
+
+bool operator==(const ShaderInfo& _1, const ShaderInfo& _2);
+
+class ShaderModule final {
+ public:
+  explicit ShaderModule(VkDevice device, const ShaderInfo& source);
+
+  ShaderModule(const ShaderModule&) = delete;
+  ShaderModule& operator=(const ShaderModule&) = delete;
+
+  ShaderModule(ShaderModule&&) noexcept;
+  ShaderModule& operator=(ShaderModule&&) = delete;
+
+  ~ShaderModule();
+
+ private:
+  VkDevice device_;
+  VkShaderModule handle_;
+
+ public:
+  inline VkShaderModule handle() const {
+    return handle_;
+  }
+
+  // We need to define a custom swap function since this class
+  // does not allow for move assignment. The swap function will
+  // be used in the hash map.
+  friend void swap(ShaderModule& lhs, ShaderModule& rhs) noexcept;
+};
+
+class ShaderLayoutCache final {
+ public:
+  explicit ShaderLayoutCache(VkDevice device);
+
+  ShaderLayoutCache(const ShaderLayoutCache&) = delete;
+  ShaderLayoutCache& operator=(const ShaderLayoutCache&) = delete;
+
+  ShaderLayoutCache(ShaderLayoutCache&&) noexcept;
+  ShaderLayoutCache& operator=(ShaderLayoutCache&&) = delete;
+
+  ~ShaderLayoutCache();
+
+  using Key = ShaderLayout::Signature;
+  using Value = ShaderLayout;
+
+  struct Hasher {
+    inline size_t operator()(const ShaderLayout::Signature& signature) const {
+      size_t hashed = 0u;
+
+      for (const VkDescriptorType type : signature) {
+        hashed =
+            utils::hash_combine(hashed, std::hash<VkDescriptorType>()(type));
+      }
+
+      return hashed;
+    }
+  };
+
+ private:
+  // Multiple threads could potentially be adding entries into the cache, so use
+  // a mutex to manage access
+  std::mutex cache_mutex_;
+
+  VkDevice device_;
+  std::unordered_map<Key, Value, Hasher> cache_;
+
+ public:
+  VkDescriptorSetLayout retrieve(const Key&);
+  void purge();
+};
+
+class ShaderCache final {
+ public:
+  explicit ShaderCache(VkDevice device);
+
+  ShaderCache(const ShaderCache&) = delete;
+  ShaderCache& operator=(const ShaderCache&) = delete;
+
+  ShaderCache(ShaderCache&&) noexcept;
+  ShaderCache& operator=(ShaderCache&&) = delete;
+
+  ~ShaderCache();
+
+  using Key = ShaderInfo;
+  using Value = ShaderModule;
+
+  struct Hasher {
+    inline size_t operator()(const ShaderInfo& source) const {
+      size_t seed = 0;
+      seed = utils::hash_combine(
+          seed, std::hash<const uint32_t*>()(source.src_code.bin));
+      seed = utils::hash_combine(
+          seed, std::hash<uint32_t>()(source.src_code.size));
+
+      return seed;
+    }
+  };
+
+ private:
+  // Multiple threads could potentially be adding entries into the cache, so use
+  // a mutex to manage access
+  std::mutex cache_mutex_;
+
+  VkDevice device_;
+  std::unordered_map<Key, Value, Hasher> cache_;
+
+ public:
+  VkShaderModule retrieve(const Key&);
+  void purge();
+};
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+inline bool operator==(
+    const VkDescriptorSetLayoutBinding& _1,
+    const VkDescriptorSetLayoutBinding& _2) {
+  return (
+      _1.binding == _2.binding && _1.descriptorType == _2.descriptorType &&
+      _1.descriptorCount == _2.descriptorCount &&
+      _1.stageFlags == _2.stageFlags &&
+      _1.pImmutableSamplers == _2.pImmutableSamplers);
+}
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/ShaderRegistry.cpp
+++ b/backends/vulkan/runtime/api/ShaderRegistry.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/ShaderRegistry.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+bool ShaderRegistry::has_shader(const std::string& shader_name) {
+  const ShaderListing::const_iterator it = listings_.find(shader_name);
+  return it != listings_.end();
+}
+
+bool ShaderRegistry::has_dispatch(const std::string& op_name) {
+  const Registry::const_iterator it = registry_.find(op_name);
+  return it != registry_.end();
+}
+
+void ShaderRegistry::register_shader(ShaderInfo&& shader_info) {
+  if (has_shader(shader_info.kernel_name)) {
+    VK_THROW(
+        "Shader with name ", shader_info.kernel_name, "already registered");
+  }
+  listings_.emplace(shader_info.kernel_name, shader_info);
+}
+
+void ShaderRegistry::register_op_dispatch(
+    const std::string& op_name,
+    const DispatchKey key,
+    const std::string& shader_name) {
+  if (!has_dispatch(op_name)) {
+    registry_.emplace(op_name, Dispatcher());
+  }
+  const Dispatcher::const_iterator it = registry_[op_name].find(key);
+  if (it != registry_[op_name].end()) {
+    registry_[op_name][key] = shader_name;
+  } else {
+    registry_[op_name].emplace(key, shader_name);
+  }
+}
+
+const ShaderInfo& ShaderRegistry::get_shader_info(
+    const std::string& shader_name) {
+  const ShaderListing::const_iterator it = listings_.find(shader_name);
+
+  VK_CHECK_COND(
+      it != listings_.end(),
+      "Could not find ShaderInfo with name ",
+      shader_name);
+
+  return it->second;
+}
+
+ShaderRegistry& shader_registry() {
+  static ShaderRegistry registry;
+  return registry;
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/api/ShaderRegistry.h
+++ b/backends/vulkan/runtime/api/ShaderRegistry.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/api/Shader.h>
+
+#include <string>
+#include <unordered_map>
+
+#define VK_KERNEL(shader_name) \
+  ::at::native::vulkan::api::shader_registry().get_shader_info(#shader_name)
+
+#define VK_KERNEL_FROM_STR(shader_name_str) \
+  ::at::native::vulkan::api::shader_registry().get_shader_info(shader_name_str)
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+enum class DispatchKey : int8_t {
+  CATCHALL,
+  ADRENO,
+  MALI,
+  OVERRIDE,
+};
+
+class ShaderRegistry final {
+  using ShaderListing = std::unordered_map<std::string, ShaderInfo>;
+  using Dispatcher = std::unordered_map<DispatchKey, std::string>;
+  using Registry = std::unordered_map<std::string, Dispatcher>;
+
+  ShaderListing listings_;
+  Dispatcher dispatcher_;
+  Registry registry_;
+
+ public:
+  /*
+   * Check if the registry has a shader registered under the given name
+   */
+  bool has_shader(const std::string& shader_name);
+
+  /*
+   * Check if the registry has a dispatch registered under the given name
+   */
+  bool has_dispatch(const std::string& op_name);
+
+  /*
+   * Register a ShaderInfo to a given shader name
+   */
+  void register_shader(ShaderInfo&& shader_info);
+
+  /*
+   * Register a dispatch entry to the given op name
+   */
+  void register_op_dispatch(
+      const std::string& op_name,
+      const DispatchKey key,
+      const std::string& shader_name);
+
+  /*
+   * Given a shader name, return the ShaderInfo which contains the SPIRV binary
+   */
+  const ShaderInfo& get_shader_info(const std::string& shader_name);
+};
+
+class ShaderRegisterInit final {
+  using InitFn = void();
+
+ public:
+  ShaderRegisterInit(InitFn* init_fn) {
+    init_fn();
+  };
+};
+
+// The global shader registry is retrieved using this function, where it is
+// declared as a static local variable.
+ShaderRegistry& shader_registry();
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/StringUtil.h
+++ b/backends/vulkan/runtime/api/StringUtil.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+// @lint-ignore-every CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
+#ifdef USE_VULKAN_API
+
+#include <exception>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+namespace detail {
+
+struct CompileTimeEmptyString {
+  operator const std::string&() const {
+    static const std::string empty_string_literal;
+    return empty_string_literal;
+  }
+  operator const char*() const {
+    return "";
+  }
+};
+
+template <typename T>
+struct CanonicalizeStrTypes {
+  using type = const T&;
+};
+
+template <size_t N>
+struct CanonicalizeStrTypes<char[N]> {
+  using type = const char*;
+};
+
+inline std::ostream& _str(std::ostream& ss) {
+  return ss;
+}
+
+template <typename T>
+inline std::ostream& _str(std::ostream& ss, const T& t) {
+  ss << t;
+  return ss;
+}
+
+template <>
+inline std::ostream& _str<CompileTimeEmptyString>(
+    std::ostream& ss,
+    const CompileTimeEmptyString&) {
+  return ss;
+}
+
+template <typename T, typename... Args>
+inline std::ostream& _str(std::ostream& ss, const T& t, const Args&... args) {
+  return _str(_str(ss, t), args...);
+}
+
+template <typename... Args>
+struct _str_wrapper final {
+  static std::string call(const Args&... args) {
+    std::ostringstream ss;
+    _str(ss, args...);
+    return ss.str();
+  }
+};
+
+template <>
+struct _str_wrapper<> final {
+  static CompileTimeEmptyString call() {
+    return CompileTimeEmptyString();
+  }
+};
+
+} // namespace detail
+
+template <typename... Args>
+inline std::string concat_str(const Args&... args) {
+  return detail::_str_wrapper<
+      typename detail::CanonicalizeStrTypes<Args>::type...>::call(args...);
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/Tensor.cpp
+++ b/backends/vulkan/runtime/api/Tensor.cpp
@@ -1,0 +1,686 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/Tensor.h>
+#include <executorch/backends/vulkan/runtime/api/Utils.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+namespace {
+
+/*
+ * Calculates the strides of a contiguous tensor. empty_tensor_restride from
+ * TensorImpl.h was used as a reference.
+ */
+std::vector<int64_t> calc_contiguous_strides(
+    const std::vector<int64_t>& sizes) {
+  int64_t ndim = static_cast<int64_t>(sizes.size());
+  std::vector<int64_t> strides(ndim);
+
+  int64_t running_product = 1;
+  if (ndim >= 1) {
+    strides.at(ndim - 1) = running_product;
+    for (int i = static_cast<int>(sizes.size()) - 2; i >= 0; --i) {
+      running_product *= sizes.at(i + 1);
+      strides.at(i) = running_product;
+    }
+  }
+
+  return strides;
+}
+
+std::vector<int64_t> calc_channels_last_strides(
+    const std::vector<int64_t>& sizes) {
+  std::vector<int64_t> strides(sizes.size());
+
+  switch (sizes.size()) {
+    case 4:
+      strides.at(1) = 1;
+      strides.at(3) = sizes.at(1);
+      strides.at(2) = strides.at(3) * sizes.at(3);
+      strides.at(0) = strides.at(2) * sizes.at(2);
+      return strides;
+    case 3:
+      strides.at(0) = 1;
+      strides.at(2) = sizes.at(0);
+      strides.at(1) = strides.at(2) * sizes.at(2);
+      return strides;
+    default:
+      VK_THROW("ChannelsLast format only available for 3 <= ndim <= 4!");
+  }
+
+  return strides;
+}
+
+/*
+ * Calculates the strides of a tensor based on the sizes and memory format. Note
+ * that strides are only valid for vTensors that are backed by buffer storage;
+ * if texture storage is used then the strides are invalid and set to zeros.
+ */
+std::vector<int64_t> calc_strides(
+    const std::vector<int64_t>& sizes,
+    const api::GPUMemoryLayout memory_layout,
+    const api::StorageType storage_type) {
+  switch (storage_type) {
+    case api::StorageType::BUFFER:
+      switch (memory_layout) {
+        case api::GPUMemoryLayout::TENSOR_WIDTH_PACKED:
+          return calc_contiguous_strides(sizes);
+          break;
+        case api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED:
+          return calc_channels_last_strides(sizes);
+          break;
+        default:
+          VK_THROW("Invalid memory format used to create vTensor!");
+      }
+      break;
+    case api::StorageType::TEXTURE_3D:
+    case api::StorageType::TEXTURE_2D:
+      return std::vector<int64_t>(sizes.size());
+    default:
+      VK_THROW("Invalid storage type used to create vTensor!");
+  }
+}
+
+/*
+ * When stored on the GPU, one dimension will be aligned to the next multiple of
+ * 4 in order to take advantage of vec4 data types. The dimension that is
+ * packed is denoted by the GPUMemoryLayout. This function adjusts one of
+ * the dimensions based on the desired memory format and storage type and
+ * returns a sizes array describing the dimensions of the memory used to store
+ * the tensor data on the GPU.
+ */
+std::vector<int64_t> calc_gpu_sizes(
+    const std::vector<int64_t>& sizes,
+    const api::GPUMemoryLayout memory_layout,
+    const api::StorageType storage_type) {
+  VK_CHECK_COND(storage_type != api::StorageType::UNKNOWN);
+
+  std::vector<int64_t> gpu_sizes;
+  if (storage_type == api::StorageType::BUFFER) {
+    gpu_sizes.resize(sizes.size());
+    for (size_t i = 0; i < sizes.size(); i++) {
+      gpu_sizes.at(i) = sizes.at(i);
+    }
+  }
+  // For texture storage, tensors are typically stored using 3D image textures.
+  // Batches are stacked along the depth dimension. To represent the physical
+  // 3 dimensionality of the image texture (with concatenated batches) GPU sizes
+  // will be fixed to 4 dimensions when using texture storage.
+  else {
+    VK_CHECK_COND(
+        sizes.size() >= 0 && sizes.size() <= 4,
+        "Texture storage only valid for 0 <= ndim <= 4, received: ",
+        sizes.size());
+
+    gpu_sizes.resize(4);
+    gpu_sizes.at(0) = api::utils::val_at(-4, sizes);
+    gpu_sizes.at(1) = api::utils::val_at(-3, sizes);
+    gpu_sizes.at(2) = api::utils::val_at(-2, sizes);
+    gpu_sizes.at(3) = api::utils::val_at(-1, sizes);
+  }
+
+  size_t ndim = gpu_sizes.size();
+  switch (memory_layout) {
+    case api::GPUMemoryLayout::TENSOR_WIDTH_PACKED:
+      if (ndim >= 1) {
+        gpu_sizes.at(ndim - 1) =
+            api::utils::align_up(api::utils::val_at(-1, sizes), INT64_C(4));
+      }
+      break;
+
+    case api::GPUMemoryLayout::TENSOR_HEIGHT_PACKED:
+      if (ndim >= 2) {
+        gpu_sizes.at(ndim - 2) =
+            api::utils::align_up(api::utils::val_at(-2, sizes), INT64_C(4));
+      }
+      break;
+
+    case api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED:
+      if (ndim >= 3) {
+        gpu_sizes.at(ndim - 3) =
+            api::utils::align_up(api::utils::val_at(-3, sizes), INT64_C(4));
+      }
+      break;
+  }
+
+  return gpu_sizes;
+}
+
+/*
+ * Creates a uvec3 denoting the extents of the image texture that will be
+ * created to store a tensor of a given size.
+ */
+api::utils::uvec3 create_image_extents(
+    const std::vector<int64_t>& gpu_sizes,
+    const api::StorageType storage_type,
+    const api::GPUMemoryLayout memory_layout) {
+  size_t ndim = gpu_sizes.size();
+
+  if (storage_type == api::StorageType::BUFFER) {
+    // image extents do not apply to buffer storage
+    return {0u, 0u, 0u};
+  } else {
+    VK_CHECK_COND(
+        ndim >= 1 && ndim <= 4,
+        "Texture storage only valid for 1 <= ndim <= 4!");
+
+    using namespace api::utils;
+    uint32_t width = safe_downcast<uint32_t>(val_at(-1, gpu_sizes));
+    uint32_t height = safe_downcast<uint32_t>(val_at(-2, gpu_sizes));
+    uint32_t channels = safe_downcast<uint32_t>(val_at(-3, gpu_sizes));
+    uint32_t batch = safe_downcast<uint32_t>(val_at(-4, gpu_sizes));
+
+    switch (memory_layout) {
+      case api::GPUMemoryLayout::TENSOR_WIDTH_PACKED:
+        VK_CHECK_COND(width % 4 == 0, "Channels must be divisible by 4!");
+        width /= 4;
+        break;
+      case api::GPUMemoryLayout::TENSOR_HEIGHT_PACKED:
+        VK_CHECK_COND(height % 4 == 0, "Channels must be divisible by 4!");
+        height /= 4;
+        break;
+      case api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED:
+        VK_CHECK_COND(channels % 4 == 0, "Channels must be divisible by 4!");
+        channels /= 4;
+        break;
+      default:
+        VK_THROW("Invalid memory format used!");
+    }
+
+    return {width, height, batch * channels};
+  }
+}
+
+api::UniformParamsBuffer make_metadata_uniform(
+    api::Context* const context,
+    const std::vector<int64_t>& sizes,
+    const std::vector<int64_t>& strides,
+    const api::StorageType storage_type) {
+  if (storage_type != api::StorageType::BUFFER) {
+    return api::UniformParamsBuffer();
+  }
+
+  vTensor::BufferMetadata metadata{
+      api::utils::make_whcn_uvec4(sizes),
+      api::utils::make_whcn_uvec4(strides),
+      api::utils::safe_downcast<uint32_t>(sizes.size()),
+      api::utils::safe_downcast<uint32_t>(api::utils::multiply_integers(sizes)),
+  };
+
+  return api::UniformParamsBuffer(context, metadata);
+}
+
+} // namespace
+
+//
+// vTensor
+//
+
+vTensor::vTensor(
+    api::Context* const context,
+    const std::vector<int64_t>& sizes,
+    const api::ScalarType dtype,
+    const api::StorageType storage_type,
+    const api::GPUMemoryLayout memory_layout,
+    const bool allocate_memory)
+    : dtype_(dtype),
+      memory_layout_(memory_layout),
+      // Calculate sizes and strides
+      sizes_(sizes.begin(), sizes.end()),
+      strides_{calc_strides(sizes, memory_layout_, storage_type)},
+      gpu_sizes_{calc_gpu_sizes(sizes, memory_layout_, storage_type)},
+      gpu_strides_{calc_strides(gpu_sizes_, memory_layout_, storage_type)},
+      virtual_extents_(
+          create_image_extents(gpu_sizes_, storage_type, memory_layout)),
+      // Utility Uniform Buffers that can be passed to shaders as arguments
+      metadata_uniform_(),
+      cpu_sizes_uniform_(nullptr),
+      gpu_sizes_uniform_(nullptr),
+      extents_uniform_(nullptr),
+      // Construct Tensor storage
+      view_(std::make_shared<vTensorStorage>(
+          context,
+          storage_type,
+          memory_layout_,
+          gpu_sizes_,
+          dtype_,
+          allocate_memory)) {}
+
+vTensor::vTensor(
+    api::Context* const context,
+    const std::vector<int64_t>& sizes,
+    double q_scale,
+    int64_t q_zero_point,
+    const api::ScalarType dtype,
+    const api::StorageType storage_type,
+    const api::GPUMemoryLayout memory_layout)
+    : dtype_(dtype),
+      memory_layout_(memory_layout),
+      // Calculate sizes and strides
+      sizes_(sizes.begin(), sizes.end()),
+      strides_{calc_strides(sizes, memory_layout_, storage_type)},
+      gpu_sizes_{calc_gpu_sizes(sizes, memory_layout_, storage_type)},
+      gpu_strides_{calc_strides(gpu_sizes_, memory_layout_, storage_type)},
+      virtual_extents_(
+          create_image_extents(gpu_sizes_, storage_type, memory_layout)),
+      // Vulkan uniform buffer containing sizes and stride info
+      metadata_uniform_(),
+      cpu_sizes_uniform_(nullptr),
+      gpu_sizes_uniform_(nullptr),
+      extents_uniform_(nullptr),
+      // Quantization params
+      is_quantized_{true},
+      q_scale_{q_scale},
+      q_zero_point_{q_zero_point},
+      // Construct Tensor storage
+      view_(std::make_shared<vTensorStorage>(
+          context,
+          storage_type,
+          memory_layout_,
+          gpu_sizes_,
+          dtype_)) {}
+
+api::VulkanImage& vTensor::image(
+    api::PipelineBarrier& pipeline_barrier,
+    const api::PipelineStageFlags stage) const& {
+  view_->transition(pipeline_barrier, stage, api::MemoryAccessType::READ);
+  return view_->image_;
+}
+
+api::VulkanImage& vTensor::image(
+    api::PipelineBarrier& pipeline_barrier,
+    const api::PipelineStageFlags stage,
+    const api::MemoryAccessFlags access) & {
+  view_->transition(pipeline_barrier, stage, access);
+  return view_->image_;
+}
+
+api::VulkanBuffer& vTensor::buffer(
+    api::PipelineBarrier& pipeline_barrier,
+    const api::PipelineStageFlags stage) const& {
+  view_->transition(pipeline_barrier, stage, api::MemoryAccessType::READ);
+  return view_->buffer_;
+}
+
+api::VulkanBuffer& vTensor::buffer(
+    api::PipelineBarrier& pipeline_barrier,
+    const api::PipelineStageFlags stage,
+    const api::MemoryAccessFlags access) & {
+  view_->transition(pipeline_barrier, stage, access);
+  return view_->buffer_;
+}
+
+api::VulkanBuffer& vTensor::buffer_metadata() {
+  if (!metadata_uniform_.buffer()) {
+    metadata_uniform_ = make_metadata_uniform(
+        view_->context_, gpu_sizes_, gpu_strides_, storage_type());
+  }
+  return metadata_uniform_.buffer();
+}
+
+std::shared_ptr<api::UniformParamsBuffer> vTensor::cpu_sizes_ubo() {
+  if (!cpu_sizes_uniform_) {
+    cpu_sizes_uniform_.reset(new api::UniformParamsBuffer(
+        view_->context_, api::utils::make_whcn_ivec4(sizes_)));
+  }
+  return cpu_sizes_uniform_;
+}
+
+std::shared_ptr<api::UniformParamsBuffer> vTensor::gpu_sizes_ubo() {
+  if (!gpu_sizes_uniform_) {
+    gpu_sizes_uniform_.reset(new api::UniformParamsBuffer(
+        view_->context_, api::utils::make_whcn_ivec4(gpu_sizes_)));
+  }
+  return gpu_sizes_uniform_;
+}
+
+std::shared_ptr<api::UniformParamsBuffer> vTensor::extents_ubo() {
+  if (!extents_uniform_) {
+    extents_uniform_.reset(new api::UniformParamsBuffer(
+        view_->context_,
+        api::utils::uvec4(
+            {view_->extents_.data[0],
+             view_->extents_.data[1],
+             view_->extents_.data[2],
+             1u})));
+  }
+  return extents_uniform_;
+}
+
+vTensor::BufferMetadata vTensor::get_cpu_buffer_metadata() const {
+  return {
+      api::utils::make_whcn_uvec4(sizes_),
+      api::utils::make_whcn_uvec4(strides_),
+      api::utils::safe_downcast<uint32_t>(sizes_.size()),
+      api::utils::safe_downcast<uint32_t>(
+          api::utils::multiply_integers(sizes_)),
+  };
+}
+
+VmaAllocationCreateInfo vTensor::get_allocation_create_info() const {
+  switch (storage_type()) {
+    case api::StorageType::BUFFER:
+      return view_->buffer_.allocation_create_info();
+    case api::StorageType::TEXTURE_2D:
+    case api::StorageType::TEXTURE_3D:
+      return view_->image_.allocation_create_info();
+    case api::StorageType::UNKNOWN:
+      break;
+  }
+  return {};
+}
+
+VkMemoryRequirements vTensor::get_memory_requirements() const {
+  switch (storage_type()) {
+    case api::StorageType::BUFFER:
+      return view_->buffer_.get_memory_requirements();
+    case api::StorageType::TEXTURE_2D:
+    case api::StorageType::TEXTURE_3D:
+      return view_->image_.get_memory_requirements();
+    case api::StorageType::UNKNOWN:
+      break;
+  }
+  return {};
+}
+
+void vTensor::bind_allocation(const api::MemoryAllocation& allocation) {
+  switch (storage_type()) {
+    case api::StorageType::BUFFER:
+      view_->buffer_.bind_allocation(allocation);
+      break;
+    case api::StorageType::TEXTURE_2D:
+    case api::StorageType::TEXTURE_3D:
+      view_->image_.bind_allocation(allocation);
+      break;
+    case api::StorageType::UNKNOWN:
+      break;
+  }
+}
+
+void vTensor::update_size_metadata(const std::vector<int64_t>& new_sizes) {
+  sizes_ = new_sizes;
+  gpu_sizes_ = calc_gpu_sizes(sizes_, memory_layout_, storage_type());
+  virtual_extents_ =
+      create_image_extents(gpu_sizes_, storage_type(), memory_layout_);
+
+  if (cpu_sizes_uniform_) {
+    cpu_sizes_uniform_->update(api::utils::make_whcn_ivec4(sizes_));
+  }
+
+  if (gpu_sizes_uniform_) {
+    gpu_sizes_uniform_->update(api::utils::make_whcn_ivec4(gpu_sizes_));
+  }
+
+  if (extents_uniform_) {
+    extents_uniform_->update(api::utils::uvec4(
+        {virtual_extents_.data[0],
+         virtual_extents_.data[1],
+         virtual_extents_.data[2],
+         1u}));
+  }
+}
+
+void vTensor::reallocate(const std::vector<int64_t>& new_sizes) {
+  update_size_metadata(new_sizes);
+  view_->discard_and_reallocate(
+      calc_gpu_sizes(new_sizes, memory_layout_, storage_type()),
+      memory_layout_,
+      dtype_);
+}
+
+void vTensor::virtual_resize(const std::vector<int64_t>& new_sizes) {
+  update_size_metadata(new_sizes);
+  if (storage_type() == api::StorageType::BUFFER) {
+    if (gpu_nbytes() > view_->buffer_.mem_size()) {
+      VK_THROW(
+          "Cannot virtual_resize a vTensor with sizes that require a larger "
+          "buffer! reallocate() should be used instead.");
+    }
+  } else {
+    bool valid_resize = true;
+    if (virtual_extents_.data[0] > view_->extents_.data[0]) {
+      valid_resize = false;
+    }
+    if (virtual_extents_.data[1] > view_->extents_.data[1]) {
+      valid_resize = false;
+    }
+    if (virtual_extents_.data[2] > view_->extents_.data[2]) {
+      valid_resize = false;
+    }
+
+    if (!valid_resize) {
+      VK_THROW(
+          "Cannot virtual_resize a vTensor with sizes that require a larger "
+          "image texture! reallocate() should be used instead.");
+    }
+  }
+}
+
+//
+// vTensorStorage
+//
+
+api::VulkanImage allocate_image(
+    api::Context* const context_ptr,
+    api::utils::uvec3& extents,
+    const api::StorageType storage_type,
+    const VkFormat image_format,
+    const bool allocate_memory) {
+  api::Adapter* adapter_ptr = context_ptr->adapter_ptr();
+
+  api::ImageSampler::Properties sampler_props{
+      VK_FILTER_NEAREST,
+      VK_SAMPLER_MIPMAP_MODE_NEAREST,
+      VK_SAMPLER_ADDRESS_MODE_REPEAT,
+      VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
+  };
+
+  VkImageType image_type = VK_IMAGE_TYPE_3D;
+  VkImageViewType image_view_type = VK_IMAGE_VIEW_TYPE_3D;
+
+  switch (storage_type) {
+    case api::StorageType::TEXTURE_3D:
+      image_type = VK_IMAGE_TYPE_3D;
+      image_view_type = VK_IMAGE_VIEW_TYPE_3D;
+      break;
+    case api::StorageType::TEXTURE_2D:
+      image_type = VK_IMAGE_TYPE_2D;
+      image_view_type = VK_IMAGE_VIEW_TYPE_2D;
+      break;
+    default:
+      // Return an empty VulkanImage by default
+      return api::VulkanImage();
+  }
+
+  VkSampler sampler = adapter_ptr->sampler_cache().retrieve(sampler_props);
+
+  return adapter_ptr->vma().create_image(
+      api::create_extent3d(extents),
+      image_format,
+      image_type,
+      image_view_type,
+      sampler_props,
+      sampler,
+      /*allow_transfer = */ true,
+      /*allocate_memory = */ allocate_memory);
+}
+
+api::VulkanBuffer allocate_buffer(
+    api::Context* const context_ptr,
+    const int64_t numel,
+    const api::StorageType storage_type,
+    const api::ScalarType dtype,
+    const bool allocate_memory) {
+  api::Adapter* adapter_ptr = context_ptr->adapter_ptr();
+
+  switch (storage_type) {
+    case api::StorageType::BUFFER:
+      break;
+    default:
+      // Return an empty VulkanBuffer if Buffer storage is not used
+      return api::VulkanBuffer();
+  }
+
+  return adapter_ptr->vma().create_storage_buffer(
+      api::element_size(dtype) * numel, /*gpu_only = */ true, allocate_memory);
+}
+
+vTensorStorage::vTensorStorage(
+    api::Context* const context,
+    const api::StorageType storage_type,
+    const api::GPUMemoryLayout gpu_memory_layout,
+    const std::vector<int64_t>& gpu_sizes,
+    const api::ScalarType dtype,
+    const bool allocate_memory)
+    : context_(context),
+      storage_type_{storage_type},
+      extents_(
+          create_image_extents(gpu_sizes, storage_type, gpu_memory_layout)),
+      buffer_length_{api::utils::multiply_integers(gpu_sizes)},
+      image_(allocate_image(
+          context_,
+          extents_,
+          storage_type_,
+          api::to_vkformat(dtype),
+          allocate_memory)),
+      buffer_(allocate_buffer(
+          context_,
+          buffer_length_,
+          storage_type_,
+          dtype,
+          allocate_memory)),
+      last_access_{} {}
+
+vTensorStorage::~vTensorStorage() {
+  flush();
+}
+
+void vTensorStorage::flush() {
+  if (image_) {
+    context_->register_image_cleanup(image_);
+  } else if (buffer_) {
+    context_->register_buffer_cleanup(buffer_);
+  }
+  last_access_ = {};
+}
+
+void vTensorStorage::transition(
+    api::PipelineBarrier& pipeline_barrier,
+    const api::PipelineStageFlags cur_stage,
+    const api::MemoryAccessFlags cur_access) {
+  // Get last stage access
+  api::PipelineStageFlags prev_stage = last_access_.stage;
+  api::MemoryAccessFlags prev_access = last_access_.access;
+
+  const bool prev_written = (prev_access & api::MemoryAccessType::WRITE) != 0;
+
+  VkImageLayout cur_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+  VkImageLayout new_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+  bool layout_changed = false;
+  if (image_) {
+    cur_layout = image_.layout();
+    new_layout = api::vk_layout(cur_stage, cur_access);
+
+    layout_changed = cur_layout != new_layout;
+  }
+
+  if (prev_written || layout_changed) {
+    VkPipelineStageFlags src_stage = api::vk_stage(prev_stage);
+    if (0u == src_stage) {
+      src_stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+    }
+    VkPipelineStageFlags dst_stage = api::vk_stage(cur_stage);
+    if (0u == dst_stage) {
+      dst_stage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+    }
+
+    pipeline_barrier.stage.src |= src_stage;
+    pipeline_barrier.stage.dst |= dst_stage;
+
+    if (image_) {
+      pipeline_barrier.images.emplace_back(
+          api::vk_access(prev_stage, prev_access),
+          api::vk_access(cur_stage, cur_access),
+          cur_layout,
+          new_layout,
+          image_);
+
+      image_.set_layout(new_layout);
+    } else if (buffer_) {
+      pipeline_barrier.buffers.emplace_back(
+          api::vk_access(prev_stage, prev_access),
+          api::vk_access(cur_stage, cur_access),
+          buffer_);
+    }
+  }
+
+  last_access_.stage = cur_stage;
+  last_access_.access = cur_access;
+}
+
+void add_buffer_barrier(
+    api::PipelineBarrier& pipeline_barrier,
+    const api::VulkanBuffer& buffer,
+    const api::PipelineStageFlags prev_stage,
+    const api::MemoryAccessFlags prev_access,
+    const api::PipelineStageFlags cur_stage,
+    const api::MemoryAccessFlags cur_access) {
+  // Check for RAW
+  const bool read_requested = (cur_access & api::MemoryAccessType::READ) != 0;
+  const bool prev_written = (prev_access & api::MemoryAccessType::WRITE) != 0;
+
+  const bool is_RAW = read_requested && prev_written;
+
+  if (is_RAW) {
+    VkPipelineStageFlags src_stage = api::vk_stage(prev_stage);
+    if (0u == src_stage) {
+      src_stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+    }
+    VkPipelineStageFlags dst_stage = api::vk_stage(cur_stage);
+    if (0u == dst_stage) {
+      dst_stage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+    }
+
+    pipeline_barrier.stage.src |= src_stage;
+    pipeline_barrier.stage.dst |= dst_stage;
+
+    pipeline_barrier.buffers.emplace_back(
+        api::vk_access(prev_stage, prev_access),
+        api::vk_access(cur_stage, cur_access),
+        buffer);
+  }
+}
+
+void vTensorStorage::discard_and_reallocate(
+    const std::vector<int64_t>& gpu_sizes,
+    const api::GPUMemoryLayout gpu_memory_layout,
+    const api::ScalarType dtype) {
+  const bool image_owns_memory = image_.owns_memory();
+  const bool buffer_owns_memory = buffer_.owns_memory();
+
+  flush();
+
+  extents_ = create_image_extents(gpu_sizes, storage_type_, gpu_memory_layout);
+  image_ = allocate_image(
+      context_,
+      extents_,
+      storage_type_,
+      api::to_vkformat(dtype),
+      image_owns_memory);
+
+  buffer_length_ = api::utils::multiply_integers(gpu_sizes);
+  buffer_ = allocate_buffer(
+      context_, buffer_length_, storage_type_, dtype, buffer_owns_memory);
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/backends/vulkan/runtime/api/Tensor.h
+++ b/backends/vulkan/runtime/api/Tensor.h
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/api/Context.h>
+#include <executorch/backends/vulkan/runtime/api/Types.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+struct LastAccess {
+  api::PipelineStageFlags stage;
+  api::MemoryAccessFlags access;
+
+  LastAccess()
+      : stage{api::PipelineStage::NO_STAGE},
+        access{api::MemoryAccessType::NONE} {}
+
+  LastAccess(
+      api::PipelineStageFlags stage_flags,
+      api::MemoryAccessFlags access_flags)
+      : stage{stage_flags}, access{access_flags} {}
+};
+
+class vTensorStorage final {
+ public:
+  // Do not allow empty vTensorStorage construction
+  vTensorStorage() = default;
+
+  vTensorStorage(
+      api::Context* context,
+      const api::StorageType storage_type,
+      const api::GPUMemoryLayout gpu_memory_layout,
+      const std::vector<int64_t>& sizes,
+      const api::ScalarType dtype,
+      const bool allocate_memory = true);
+
+  vTensorStorage(const vTensorStorage&) = delete;
+  vTensorStorage& operator=(const vTensorStorage&) = delete;
+
+  vTensorStorage(vTensorStorage&&) = default;
+  vTensorStorage operator=(vTensorStorage&&) = delete;
+
+  ~vTensorStorage();
+
+  friend class vTensor;
+
+ private:
+  // Context
+  api::Context* context_{};
+
+  api::StorageType storage_type_;
+
+  // Resource sizings
+  api::utils::uvec3 extents_{};
+  int64_t buffer_length_{};
+
+  // Image Texture
+  mutable api::VulkanImage image_;
+  mutable api::VulkanBuffer buffer_;
+
+  // Last Access - used to insert memory barriers
+  LastAccess last_access_;
+
+ private:
+  // Registers underlying memory for cleanup
+  void flush();
+
+  // Memory barrier insertion
+  void transition(
+      api::PipelineBarrier&,
+      const api::PipelineStageFlags,
+      const api::MemoryAccessFlags);
+
+  // Validation
+  void verify() const;
+
+ public:
+  inline VkFormat texture_format() {
+    return image_.format();
+  }
+
+  void discard_and_reallocate(
+      const std::vector<int64_t>& gpu_sizes,
+      const api::GPUMemoryLayout gpu_memory_layout,
+      const api::ScalarType dtype);
+};
+
+class vTensor final {
+ public:
+  // Do not allow empty vTensor construction
+  vTensor() = default;
+
+  // Default constructor
+  vTensor(
+      api::Context* context,
+      const std::vector<int64_t>& sizes,
+      const api::ScalarType dtype,
+      const api::StorageType storage_type = api::StorageType::TEXTURE_3D,
+      const api::GPUMemoryLayout memory_layout =
+          api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED,
+      const bool allocate_memory = true);
+
+  // Default constructor for quantized vTensor
+  vTensor(
+      api::Context* const context,
+      const std::vector<int64_t>& sizes,
+      double q_scale,
+      int64_t q_zero_point,
+      const api::ScalarType dtype,
+      const api::StorageType storage_type = api::StorageType::TEXTURE_3D,
+      const api::GPUMemoryLayout memory_layout =
+          api::GPUMemoryLayout::TENSOR_CHANNELS_PACKED);
+
+  // Copy Constructor and Assignment; Ideally copying  would be disabled
+  // (see the reasoning for move assignment below) but it is required for
+  // compatibility with OpaqueTensorImpl
+  vTensor(const vTensor& other) = default;
+  vTensor& operator=(const vTensor& other) = default;
+
+  // Move Constructor and assignment
+  vTensor(vTensor&& other) = default;
+  vTensor& operator=(vTensor&& other) = default;
+
+  // Used for passing buffer sizes and strides data to shaders
+  struct BufferMetadata {
+    api::utils::uvec4 sizes;
+    api::utils::uvec4 strides;
+    uint32_t ndim;
+    uint32_t buffer_length;
+  };
+
+ private:
+  // Tensor Options
+  api::ScalarType dtype_;
+
+  // GPU specific memory layout qualifier
+  api::GPUMemoryLayout memory_layout_;
+
+  // Sizes and Strides
+  std::vector<int64_t> sizes_;
+  std::vector<int64_t> strides_;
+
+  // Storage Dimensions. When stored on the GPU, one dimension will be aligned
+  // to the next multiple of 4 in order to take advantage of vec4 data types.
+  std::vector<int64_t> gpu_sizes_;
+  std::vector<int64_t> gpu_strides_;
+
+  // The extents that correspond to the tensor's size metadata. Note that this
+  // may not be the same as the extents of the underlying image texture because
+  // vTensor can be virtually resized via virtual_resize() which will cause it
+  // to be interpreted as a tensor with a different size.
+  api::utils::uvec3 virtual_extents_;
+
+  // A Vulkan uniform buffer containing sizes and strides of the GPU buffer that
+  // can be passed into a shader.
+  api::UniformParamsBuffer metadata_uniform_;
+
+  // A Vulkan uniform buffer containing the tensor sizes that can be passed into
+  // a shader.
+  std::shared_ptr<api::UniformParamsBuffer> cpu_sizes_uniform_;
+
+  // A Vulkan uniform buffer containing the GPU tensor sizes that can be passed
+  // into a shader. GPU sizes refers to the sizes of the tensor after padding
+  // has been applied to one dimension to align it to the next multiple of 4.
+  std::shared_ptr<api::UniformParamsBuffer> gpu_sizes_uniform_;
+
+  // A Vulkan uniform buffer containing the image extents of the underlying
+  // image texture that can be passed into a shader.
+  std::shared_ptr<api::UniformParamsBuffer> extents_uniform_;
+
+  // Quantization params
+  bool is_quantized_{false};
+  double q_scale_{1.0f};
+  int64_t q_zero_point_{0u};
+
+  // Even at the cost of a heap allocation plus the resulting negative impact
+  // on cache locality due to the subsequent pointer chasing, it is still
+  // critical to share the view across vTensor implementations to minimize
+  // programmer errors.  Ideally this class should have been only made movable,
+  // and non-copyable - something we cannot do unfortunately due to the inner
+  // workings of at::TensorImpl requiring copy semantics in
+  // at::TensorImpl::release_resources() to function as expected.  Now that this
+  // class is made copyable though, a new door to a whole new class of bugs is
+  // opened, in that there now is a chance of two [shallow] copies, have their
+  // StorageState objects go out of sync as a result of an operation being
+  // performed on one shallow copy that is not reflected in the other.
+  // Technically, if the programmer is very careful, it is possible to avoid
+  // this trap and not pay the cost of indirection, but the resulting bugs of
+  // missing memory barriers will be so frustrating to hunt down for those
+  // unfamiliar with the internal mechanics of this class, that I decided to
+  // take the performance penalty of this extra layer of indirection in favor
+  // of making this class easier to use.
+  std::shared_ptr<vTensorStorage> view_;
+
+ public:
+  /*
+   Texture Access
+  */
+
+  inline api::StorageType storage_type() const {
+    return view_->storage_type_;
+  }
+
+  inline api::VulkanImage& image() const& {
+    return view_->image_;
+  }
+
+  api::VulkanImage& image(api::PipelineBarrier&, const api::PipelineStageFlags)
+      const&;
+
+  api::VulkanImage& image(
+      api::PipelineBarrier&,
+      const api::PipelineStageFlags,
+      const api::MemoryAccessFlags) &;
+
+  inline api::VulkanBuffer& buffer() const& {
+    return view_->buffer_;
+  }
+
+  api::VulkanBuffer& buffer(
+      api::PipelineBarrier&,
+      const api::PipelineStageFlags) const&;
+
+  api::VulkanBuffer& buffer(
+      api::PipelineBarrier&,
+      const api::PipelineStageFlags,
+      const api::MemoryAccessFlags) &;
+
+  /*
+    Metadata
+  */
+
+  inline const api::utils::uvec3& extents() const {
+    return view_->extents_;
+  }
+
+  /*
+   * Extract an `api::ScalarType` from the TensorOptions member
+   */
+  inline api::ScalarType dtype() const {
+    return dtype_;
+  }
+
+  /*
+   * Get an `api::ScalarType` that corresponds to the image format of the
+   * texture
+   */
+  inline api::ScalarType texture_dtype() const {
+    return api::element_scalartype(view_->texture_format());
+  }
+
+  inline api::GPUMemoryLayout gpu_memory_layout() const {
+    return memory_layout_;
+  }
+
+  inline uint32_t gpu_memory_layout_as_uint() const {
+    return static_cast<uint32_t>(memory_layout_);
+  }
+
+  inline const std::vector<int64_t>& sizes() const {
+    return sizes_;
+  }
+
+  inline const std::vector<int64_t>& strides() const {
+    return strides_;
+  }
+
+  inline const std::vector<int64_t>& gpu_sizes() const {
+    return gpu_sizes_;
+  }
+
+  inline const std::vector<int64_t>& gpu_strides() const {
+    return gpu_strides_;
+  }
+
+  inline const api::utils::uvec3& virtual_extents() const {
+    return virtual_extents_;
+  }
+
+  /*
+   * Get a uniform buffer containing sizes and strides information of the GPU
+   * buffer
+   */
+  api::VulkanBuffer& buffer_metadata();
+
+  /*
+   * Get a uniform buffer object containing the tensor sizes to use in a compute
+   * shader. Note that the UBO will be created the first time this function is
+   * called.
+   */
+  std::shared_ptr<api::UniformParamsBuffer> cpu_sizes_ubo();
+
+  /*
+   * Get a uniform buffer object containing the tensor GPU sizes to use in a
+   * compute shader. Note that the UBO will be created the first time this
+   * function is called.
+   */
+  std::shared_ptr<api::UniformParamsBuffer> gpu_sizes_ubo();
+
+  /*
+   * Get a uniform buffer object containing the image extents to use in a
+   * compute shader. Note that the UBO will be created the first time this
+   * function is called.
+   */
+  std::shared_ptr<api::UniformParamsBuffer> extents_ubo();
+
+  /*
+   * Constructs a BufferMetdata struct based on the original sizes and strides
+   * to pass into a shader.
+   */
+  BufferMetadata get_cpu_buffer_metadata() const;
+
+  inline void set_is_quantized() {
+    is_quantized_ = true;
+  }
+
+  inline bool is_quantized() const {
+    return is_quantized_;
+  }
+
+  inline void set_scale(const double q_scale) {
+    q_scale_ = q_scale;
+  }
+
+  inline double get_scale() const {
+    return q_scale_;
+  }
+
+  inline float get_scale_float() const {
+    return api::utils::safe_downcast<float>(q_scale_);
+  }
+
+  inline void set_zero_point(const int64_t q_zero_point) {
+    q_zero_point_ = q_zero_point;
+  }
+
+  inline int64_t get_zero_point() const {
+    return q_zero_point_;
+  }
+
+  inline int32_t get_zero_point_int32() const {
+    return api::utils::safe_downcast<int32_t>(q_zero_point_);
+  }
+
+  inline size_t numel() const {
+    return api::utils::multiply_integers(sizes());
+  }
+
+  inline size_t nbytes() const {
+    return api::element_size(dtype()) * numel();
+  }
+
+  /*
+   * Returns numel but based on gpu_sizes_ instead of sizes_
+   */
+  inline size_t gpu_numel() const {
+    return api::utils::multiply_integers(gpu_sizes_);
+  }
+
+  /*
+   * Return nbytes but bnased on gpu_sizes_ instead of sizes_
+   */
+  inline VkDeviceSize gpu_nbytes() const {
+    return api::element_size(dtype()) * gpu_numel();
+  }
+
+  /*
+   * Return the VmaAllocationCreateInfo of the underlying resource
+   */
+  VmaAllocationCreateInfo get_allocation_create_info() const;
+
+  /*
+   * Return the VkMemoryRequirements of the underlying resource
+   */
+  VkMemoryRequirements get_memory_requirements() const;
+
+  /*
+   * Binds the underlying resource to the given memory allocation
+   */
+  void bind_allocation(const api::MemoryAllocation& allocation);
+
+ private:
+  /*
+   * Update the size metadata of the vTensor to be new sizes. Should not be used
+   * directly, reallocate() or virtual_resize() should be used instead.
+   */
+  void update_size_metadata(const std::vector<int64_t>& new_sizes);
+
+ public:
+  /*
+   * Discard the underlying VkImage or VkBuffer and re-allocate based on new
+   * tensor sizes
+   */
+  void reallocate(const std::vector<int64_t>& new_sizes);
+
+  /*
+   * Perform a virtual resize of the vTensor by modifying the size metadata that
+   * gets used in compute shaders. This allows the shader to treat the
+   * underlying resource as if it were a different size.
+   */
+  void virtual_resize(const std::vector<int64_t>& new_sizes);
+};
+
+void add_buffer_barrier(
+    api::PipelineBarrier&,
+    const api::VulkanBuffer&,
+    const api::PipelineStageFlags,
+    const api::MemoryAccessFlags,
+    const api::PipelineStageFlags,
+    const api::MemoryAccessFlags);
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/Types.h
+++ b/backends/vulkan/runtime/api/Types.h
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY bugprone-branch-clone
+
+#ifdef USE_VULKAN_API
+
+#include <cstddef>
+#include <cstdint>
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#include <executorch/backends/vulkan/runtime/api/Exception.h>
+
+#ifdef USE_VULKAN_FP16_INFERENCE
+#define VK_FORMAT_FLOAT4 VK_FORMAT_R16G16B16A16_SFLOAT
+#else
+#define VK_FORMAT_FLOAT4 VK_FORMAT_R32G32B32A32_SFLOAT
+#endif /* USE_VULKAN_FP16_INFERENCE */
+
+#define VK_FORALL_SCALAR_TYPES(_)               \
+  _(uint8_t, VK_FORMAT_R8G8B8A8_UINT, Byte)     \
+  _(int8_t, VK_FORMAT_R8G8B8A8_SINT, Char)      \
+  _(int32_t, VK_FORMAT_R32G32B32A32_SINT, Int)  \
+  _(bool, VK_FORMAT_R8G8B8A8_SINT, Bool)        \
+  _(float, VK_FORMAT_R16G16B16A16_SFLOAT, Half) \
+  _(float, VK_FORMAT_FLOAT4, Float)             \
+  _(int8_t, VK_FORMAT_R8G8B8A8_SINT, QInt8)     \
+  _(uint8_t, VK_FORMAT_R8G8B8A8_UINT, QUInt8)   \
+  _(int32_t, VK_FORMAT_R32G32B32A32_SINT, QInt32)
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+//
+// Scalar Types
+//
+
+enum class ScalarType : int8_t {
+#define DEFINE_ENUM_VAL_(ctype, vkformat, name) name,
+  VK_FORALL_SCALAR_TYPES(DEFINE_ENUM_VAL_)
+#undef DEFINE_ENUM_VAL_
+      Undefined,
+  NumOptions
+};
+
+#define DEFINE_CONSTANT(ctype, vkformat, name) \
+  constexpr ScalarType k##name = ScalarType::name;
+
+VK_FORALL_SCALAR_TYPES(DEFINE_CONSTANT)
+#undef DEFINE_CONSTANT
+
+/*
+ * Given a `ScalarType`, return the corresponding `VkFormat` that should be used
+ * for image texture storage. The `ScalarType` to `VkFormat` mapping is dictated
+ * by the `VK_FORALL_SCALAR_TYPE` macro in `api/Types.h`
+ */
+inline VkFormat to_vkformat(const ScalarType t) {
+#define CASE_VK_FORMAT(ctype, vkformat, name) \
+  case ScalarType::name:                      \
+    return vkformat;
+
+  switch (t) {
+    VK_FORALL_SCALAR_TYPES(CASE_VK_FORMAT)
+    default:
+      VK_THROW("Unknown ScalarType: ", t);
+  }
+#undef CASE_VK_FORMAT
+}
+
+/*
+ * Given a `VkFormat`, return the `ScalarType` that best represents the data
+ * type of invidivual elements in an image texture of the `VkFormat`. Note that
+ * this mapping is different from the `to_vkformat()` function, since different
+ * `ScalarType`s may use the same `VkFormat`.
+ */
+inline ScalarType element_scalartype(const VkFormat vkformat) {
+  switch (vkformat) {
+    case VK_FORMAT_R8G8B8A8_SINT:
+      return kChar;
+    case VK_FORMAT_R8G8B8A8_UINT:
+      return kByte;
+    case VK_FORMAT_R32G32B32A32_SINT:
+      return kInt;
+    case VK_FORMAT_R32G32B32A32_SFLOAT:
+      return kFloat;
+    case VK_FORMAT_R16G16B16A16_SFLOAT:
+      return kHalf;
+    default:
+      VK_THROW("No corresponding scalar type for unknown VkFormat: ", vkformat);
+  }
+}
+
+/*
+ * Given a ScalarType, return `sizeof(ctype)` where ctype is the C type
+ * corresponding to the ScalarType. The C type to ScalarType mapping is dictated
+ * by the VK_FORALL_SCALAR_TYPE macro in api/Types.h
+ */
+inline size_t element_size(const ScalarType t) {
+#define CASE_ELEMENTSIZE_CASE(ctype, vkformat, name) \
+  case ScalarType::name:                             \
+    return sizeof(ctype);
+
+  switch (t) {
+    VK_FORALL_SCALAR_TYPES(CASE_ELEMENTSIZE_CASE)
+    default:
+      VK_THROW("Unknown ScalarType: ", t);
+  }
+#undef CASE_ELEMENTSIZE_CASE
+}
+
+inline const char* to_string(const ScalarType t) {
+#define CASE_TO_STRING(ctype, vkformat, name) \
+  case ScalarType::name:                      \
+    return #name;
+
+  switch (t) {
+    VK_FORALL_SCALAR_TYPES(CASE_TO_STRING)
+    default:
+      return "UNKNOWN_SCALAR_TYPE";
+  }
+#undef CASE_TO_STRING
+}
+
+inline std::ostream& operator<<(std::ostream& os, const ScalarType dtype) {
+  return os << to_string(dtype);
+}
+
+//
+// Map ScalarTypes to C++ types
+//
+
+template <ScalarType N>
+struct ScalarTypeToCType;
+
+#define SPECIALIZE_ScalarTypeToCType(ctype, vkformat, scalar_type) \
+  template <>                                                      \
+  struct ScalarTypeToCType<                                        \
+      ::at::native::vulkan::api::ScalarType::scalar_type> {        \
+    using type = ctype;                                            \
+  };
+
+VK_FORALL_SCALAR_TYPES(SPECIALIZE_ScalarTypeToCType)
+
+#undef SPECIALIZE_ScalarTypeToCPPType
+
+//
+// GPU Storage Options
+//
+
+/**
+ * The enum below is used to describe what type of GPU memory will be used to
+ * store a particular tensor's data.
+ *
+ * BUFFER means that a SSBO (Shader Storage Buffer Object) will be used.
+ * TEXTURE_3D means that a 3-dimensional image texture will be used.
+ * TEXTURE_2D means that a 2-dimensional image texture will be used.
+ *
+ * UNKNOWN is not expected to be used.
+ */
+enum class StorageType {
+  BUFFER,
+  TEXTURE_3D,
+  TEXTURE_2D,
+  UNKNOWN,
+};
+
+/**
+ * The enum below is used to describe how tensor data is laid out when stored in
+ * GPU memory. The name of the enum describes which dimension is tightly packed;
+ * so for tensors that are stored as image textures, loading a texel will
+ * retrieve 4 consecutive elements of the named dimension, and for tensors
+ * stored as buffers, the named dimension will have a stride of 1.
+ *
+ * The GPU memory layout qualifier will be used by compute shaders to determine
+ * how to convert between logical tensor coordinates and physical texel
+ * coordinates. For tensors that are stored as buffers, it is expected that the
+ * strides of the tensor will be used instead to convert between logical tensor
+ * coordinates and linear access indices.
+ */
+enum class GPUMemoryLayout : uint32_t {
+  TENSOR_WIDTH_PACKED = 0u,
+  TENSOR_HEIGHT_PACKED = 1u,
+  TENSOR_CHANNELS_PACKED = 2u,
+};
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/Utils.h
+++ b/backends/vulkan/runtime/api/Utils.h
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cmath>
+#include <numeric>
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+#include <executorch/backends/vulkan/runtime/api/Exception.h>
+
+#ifdef USE_VULKAN_API
+
+// Compiler Macros
+
+// Suppress an unused variable. Copied from C10_UNUSED
+#if defined(_MSC_VER) && !defined(__clang__)
+#define VK_UNUSED __pragma(warning(suppress : 4100 4101))
+#else
+#define VK_UNUSED __attribute__((__unused__))
+#endif //_MSC_VER
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+namespace utils {
+
+//
+// Hashing
+//
+
+/**
+ * hash_combine is taken from c10/util/hash.h, which in turn is based on
+ * implementation from Boost
+ */
+inline size_t hash_combine(size_t seed, size_t value) {
+  return seed ^ (value + 0x9e3779b9 + (seed << 6u) + (seed >> 2u));
+}
+
+//
+// Alignment
+//
+
+template <typename Type>
+inline constexpr Type align_down(const Type& number, const Type& multiple) {
+  return (number / multiple) * multiple;
+}
+
+template <typename Type>
+inline constexpr Type align_up(const Type& number, const Type& multiple) {
+  return align_down(number + multiple - 1, multiple);
+}
+
+template <typename Type>
+inline constexpr Type div_up(const Type& numerator, const Type& denominator) {
+  return (numerator + denominator - 1) / denominator;
+}
+
+//
+// Casting Utilities
+//
+
+namespace detail {
+
+/*
+ * x cannot be less than 0 if x is unsigned
+ */
+template <typename T>
+static inline constexpr bool is_negative(
+    const T& /*x*/,
+    std::true_type /*is_unsigned*/) {
+  return false;
+}
+
+/*
+ * check if x is less than 0 if x is signed
+ */
+template <typename T>
+static inline constexpr bool is_negative(
+    const T& x,
+    std::false_type /*is_unsigned*/) {
+  return x < T(0);
+}
+
+/*
+ * Returns true if x < 0
+ */
+template <typename T>
+inline constexpr bool is_negative(const T& x) {
+  return is_negative(x, std::is_unsigned<T>());
+}
+
+/*
+ * Returns true if x < lowest(Limit); standard comparison
+ */
+template <typename Limit, typename T>
+static inline constexpr bool less_than_lowest(
+    const T& x,
+    std::false_type /*limit_is_unsigned*/,
+    std::false_type /*x_is_unsigned*/) {
+  return x < std::numeric_limits<Limit>::lowest();
+}
+
+/*
+ * Limit can contained negative values, but x cannot; return false
+ */
+template <typename Limit, typename T>
+static inline constexpr bool less_than_lowest(
+    const T& /*x*/,
+    std::false_type /*limit_is_unsigned*/,
+    std::true_type /*x_is_unsigned*/) {
+  return false;
+}
+
+/*
+ * Limit cannot contained negative values, but x can; check if x is negative
+ */
+template <typename Limit, typename T>
+static inline constexpr bool less_than_lowest(
+    const T& x,
+    std::true_type /*limit_is_unsigned*/,
+    std::false_type /*x_is_unsigned*/) {
+  return x < T(0);
+}
+
+/*
+ * Both x and Limit cannot be negative; return false
+ */
+template <typename Limit, typename T>
+static inline constexpr bool less_than_lowest(
+    const T& /*x*/,
+    std::true_type /*limit_is_unsigned*/,
+    std::true_type /*x_is_unsigned*/) {
+  return false;
+}
+
+/*
+ * Returns true if x is less than the lowest value of type T
+ */
+template <typename Limit, typename T>
+inline constexpr bool less_than_lowest(const T& x) {
+  return less_than_lowest<Limit>(
+      x, std::is_unsigned<Limit>(), std::is_unsigned<T>());
+}
+
+// Suppress sign compare warning when compiling with GCC
+// as later does not account for short-circuit rule before
+// raising the warning, see https://godbolt.org/z/Tr3Msnz99
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
+
+/*
+ * Returns true if x is greater than the greatest value of the type Limit
+ */
+template <typename Limit, typename T>
+inline constexpr bool greater_than_max(const T& x) {
+  constexpr bool can_overflow =
+      std::numeric_limits<T>::digits > std::numeric_limits<Limit>::digits;
+  return can_overflow && x > std::numeric_limits<Limit>::max();
+}
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+template <typename To, typename From>
+std::enable_if_t<std::is_integral_v<From> && !std::is_same_v<From, bool>, bool>
+overflows(From f) {
+  using limit = std::numeric_limits<To>;
+  // Casting from signed to unsigned; allow for negative numbers to wrap using
+  // two's complement arithmetic.
+  if (!limit::is_signed && std::numeric_limits<From>::is_signed) {
+    return greater_than_max<To>(f) ||
+        (is_negative(f) && -static_cast<uint64_t>(f) > limit::max());
+  }
+  // standard case, check if f is outside the range of type To
+  else {
+    return less_than_lowest<To>(f) || greater_than_max<To>(f);
+  }
+}
+
+template <typename To, typename From>
+std::enable_if_t<std::is_floating_point_v<From>, bool> overflows(From f) {
+  using limit = std::numeric_limits<To>;
+  if (limit::has_infinity && std::isinf(static_cast<double>(f))) {
+    return false;
+  }
+  return f < limit::lowest() || f > limit::max();
+}
+
+template <typename To, typename From>
+inline constexpr To safe_downcast(const From& v) {
+  VK_CHECK_COND(!overflows<To>(v), "Cast failed: out of range!");
+  return static_cast<To>(v);
+}
+
+template <typename To, typename From>
+inline constexpr bool is_signed_to_unsigned() {
+  return std::is_signed<From>::value && std::is_unsigned<To>::value;
+}
+
+} // namespace detail
+
+template <
+    typename To,
+    typename From,
+    std::enable_if_t<detail::is_signed_to_unsigned<To, From>(), bool> = true>
+inline constexpr To safe_downcast(const From& v) {
+  VK_CHECK_COND(v >= From{}, "Cast failed: negative signed to unsigned!");
+  return detail::safe_downcast<To, From>(v);
+}
+
+template <
+    typename To,
+    typename From,
+    std::enable_if_t<!detail::is_signed_to_unsigned<To, From>(), bool> = true>
+inline constexpr To safe_downcast(const From& v) {
+  return detail::safe_downcast<To, From>(v);
+}
+
+//
+// Vector Types
+//
+
+namespace detail {
+
+template <typename Type, uint32_t N>
+struct vec final {
+  // NOLINTNEXTLINE
+  Type data[N];
+};
+
+} // namespace detail
+
+template <uint32_t N>
+using ivec = detail::vec<int32_t, N>;
+using ivec2 = ivec<2u>;
+using ivec3 = ivec<3u>;
+using ivec4 = ivec<4u>;
+
+template <uint32_t N>
+using uvec = detail::vec<uint32_t, N>;
+using uvec2 = uvec<2u>;
+using uvec3 = uvec<3u>;
+using uvec4 = uvec<4u>;
+
+template <uint32_t N>
+using vec = detail::vec<float, N>;
+using vec2 = vec<2u>;
+using vec3 = vec<3u>;
+using vec4 = vec<4u>;
+
+// uvec3 is the type representing tensor extents. Useful for debugging.
+inline std::ostream& operator<<(std::ostream& os, const uvec3& v) {
+  os << "(" << v.data[0u] << ", " << v.data[1u] << ", " << v.data[2u] << ")";
+  return os;
+}
+
+//
+// std::vector<T> Handling
+//
+
+/*
+ * Utility function to perform indexing on an std::vector<T>. Negative indexing
+ * is allowed. For instance, passing an index of -1 will retrieve the last
+ * element. If the requested index is out of bounds, then 1u will be returned.
+ */
+template <typename T>
+inline T val_at(const int64_t index, const std::vector<T>& sizes) {
+  const int64_t ndim = static_cast<int64_t>(sizes.size());
+  if (index >= 0) {
+    return index >= ndim ? 1 : sizes[index];
+  } else {
+    return ndim + index < 0 ? 1 : sizes[ndim + index];
+  }
+}
+
+inline ivec2 make_ivec2(
+    const std::vector<int64_t>& ints,
+    bool reverse = false) {
+  VK_CHECK_COND(ints.size() == 2);
+  if (reverse) {
+    return {safe_downcast<int32_t>(ints[1]), safe_downcast<int32_t>(ints[0])};
+  } else {
+    return {safe_downcast<int32_t>(ints[0]), safe_downcast<int32_t>(ints[1])};
+  }
+}
+
+inline ivec4 make_ivec4(
+    const std::vector<int64_t>& ints,
+    bool reverse = false) {
+  VK_CHECK_COND(ints.size() == 4);
+  if (reverse) {
+    return {
+        safe_downcast<int32_t>(ints[3]),
+        safe_downcast<int32_t>(ints[2]),
+        safe_downcast<int32_t>(ints[1]),
+        safe_downcast<int32_t>(ints[0]),
+    };
+  } else {
+    return {
+        safe_downcast<int32_t>(ints[0]),
+        safe_downcast<int32_t>(ints[1]),
+        safe_downcast<int32_t>(ints[2]),
+        safe_downcast<int32_t>(ints[3]),
+    };
+  }
+}
+
+inline ivec4 make_ivec4_prepadded1(const std::vector<int64_t>& ints) {
+  VK_CHECK_COND(ints.size() <= 4);
+
+  ivec4 result = {1, 1, 1, 1};
+  size_t base = 4 - ints.size();
+  for (size_t i = 0; i < ints.size(); ++i) {
+    result.data[i + base] = safe_downcast<int32_t>(ints[i]);
+  }
+
+  return result;
+}
+
+inline ivec3 make_ivec3(uvec3 ints) {
+  return {
+      safe_downcast<int32_t>(ints.data[0u]),
+      safe_downcast<int32_t>(ints.data[1u]),
+      safe_downcast<int32_t>(ints.data[2u])};
+}
+
+/*
+ * Given an vector of up to 4 uint64_t representing the sizes of a tensor,
+ * constructs a uvec4 containing those elements in reverse order.
+ */
+inline uvec4 make_whcn_uvec4(const std::vector<int64_t>& arr) {
+  uint32_t w = safe_downcast<uint32_t>(val_at(-1, arr));
+  uint32_t h = safe_downcast<uint32_t>(val_at(-2, arr));
+  uint32_t c = safe_downcast<uint32_t>(val_at(-3, arr));
+  uint32_t n = safe_downcast<uint32_t>(val_at(-4, arr));
+
+  return {w, h, c, n};
+}
+
+/*
+ * Given an vector of up to 4 int64_t representing the sizes of a tensor,
+ * constructs an ivec4 containing those elements in reverse order.
+ */
+inline ivec4 make_whcn_ivec4(const std::vector<int64_t>& arr) {
+  int32_t w = val_at(-1, arr);
+  int32_t h = val_at(-2, arr);
+  int32_t c = val_at(-3, arr);
+  int32_t n = val_at(-4, arr);
+
+  return {w, h, c, n};
+}
+
+/*
+ * Wrapper around std::accumulate that accumulates values of a container of
+ * integral types into int64_t. Taken from `multiply_integers` in
+ * <c10/util/accumulate.h>
+ */
+template <
+    typename C,
+    std::enable_if_t<std::is_integral_v<typename C::value_type>, int> = 0>
+inline int64_t multiply_integers(const C& container) {
+  return std::accumulate(
+      container.begin(),
+      container.end(),
+      static_cast<int64_t>(1),
+      std::multiplies<>());
+}
+
+} // namespace utils
+
+inline bool operator==(const utils::uvec3& _1, const utils::uvec3& _2) {
+  return (
+      _1.data[0u] == _2.data[0u] && _1.data[1u] == _2.data[1u] &&
+      _1.data[2u] == _2.data[2u]);
+}
+
+inline VkOffset3D create_offset3d(const utils::uvec3& offsets) {
+  return VkOffset3D{
+      utils::safe_downcast<int32_t>(offsets.data[0u]),
+      static_cast<int32_t>(offsets.data[1u]),
+      static_cast<int32_t>(offsets.data[2u])};
+}
+
+inline VkExtent3D create_extent3d(const utils::uvec3& extents) {
+  return VkExtent3D{extents.data[0u], extents.data[1u], extents.data[2u]};
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/api.h
+++ b/backends/vulkan/runtime/api/api.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <executorch/backends/vulkan/runtime/api/Adapter.h>
+#include <executorch/backends/vulkan/runtime/api/Command.h>
+#include <executorch/backends/vulkan/runtime/api/Context.h>
+#include <executorch/backends/vulkan/runtime/api/Descriptor.h>
+#include <executorch/backends/vulkan/runtime/api/Pipeline.h>
+#include <executorch/backends/vulkan/runtime/api/Resource.h>
+#include <executorch/backends/vulkan/runtime/api/Runtime.h>
+#include <executorch/backends/vulkan/runtime/api/Shader.h>
+#include <executorch/backends/vulkan/runtime/api/ShaderRegistry.h>
+#include <executorch/backends/vulkan/runtime/api/Tensor.h>
+#include <executorch/backends/vulkan/runtime/api/Utils.h>
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/api/gen_vulkan_spv.py
+++ b/backends/vulkan/runtime/api/gen_vulkan_spv.py
@@ -1,0 +1,774 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import array
+import codecs
+import copy
+import glob
+import io
+import os
+import re
+import sys
+from itertools import product
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import subprocess
+import textwrap
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode
+
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader  # type: ignore[assignment, misc]
+
+CPP_H_NAME = "spv.h"
+CPP_SRC_NAME = "spv.cpp"
+
+DEFAULT_ENV: Dict[str, Any] = {
+    "PRECISION": "highp",
+    "FLOAT_IMAGE_FORMAT": "rgba16f",
+    "INT_IMAGE_FORMAT": "rgba32i",
+    "UINT_IMAGE_FORMAT": "rgba32ui",
+}
+
+TYPES_ENV: Dict[str, Any] = {
+    "IMAGE_FORMAT": {
+        "float": "rgba32f",
+        "half": "rgba16f",
+        "int": "rgba32i",
+        "uint": "rgba32ui",
+        "int8": "rgba8i",
+        "uint8": "rgba8ui",
+    },
+    "IMAGE_T": {
+        3: {
+            "float": "image3D",
+            "half": "image3D",
+            "int": "iimage3D",
+            "uint": "uimage3D",
+        },
+        2: {
+            "float": "image2D",
+            "half": "image2D",
+            "int": "iimage2D",
+            "uint": "uimage2D",
+        },
+    },
+    "SAMPLER_T": {
+        3: {
+            "float": "sampler3D",
+            "half": "sampler3D",
+            "int": "isampler3D",
+            "uint": "usampler3D",
+        },
+        2: {
+            "float": "sampler2D",
+            "half": "sampler2D",
+            "int": "isampler2D",
+            "uint": "usampler2D",
+        },
+    },
+    "VEC4_T": {
+        "float": "vec4",
+        "half": "vec4",
+        "int": "ivec4",
+        "uint": "uvec4",
+        "int8": "vec4",
+        "uint8": "uvec4",
+    },
+    "T": {
+        "float": "float",
+        "half": "float",
+        "int": "int",
+        "uint": "uint",
+        "int8": "int",
+        "uint8": "uint8",
+    },
+}
+
+FUNCS_ENV: Dict[str, Any] = {
+    "GET_POS": {
+        3: lambda pos: pos,
+        2: lambda pos: f"{pos}.xy",
+    }
+}
+
+
+def extract_filename(path: str, keep_ext: bool = True) -> Any:
+    if keep_ext:
+        return os.path.basename(path)
+    else:
+        return os.path.basename(path).split(".")[0]
+
+
+############################
+#  SPIR-V Code Generation  #
+############################
+
+
+# https://gist.github.com/pypt/94d747fe5180851196eb
+class UniqueKeyLoader(Loader):
+    def construct_mapping(self, node, deep=False):  # type: ignore[no-untyped-def]
+        if not isinstance(node, MappingNode):
+            raise ConstructorError(
+                None,
+                None,
+                f"expected a mapping node, but found {node.id}",
+                node.start_mark,
+            )
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)  # type: ignore[no-untyped-call]
+            try:
+                hash(key)
+            except TypeError as e:
+                raise ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found unacceptable key ",
+                    key_node.start_mark,
+                ) from e
+            # check for duplicate keys
+            if key in mapping:
+                raise ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found duplicate key",
+                    key_node.start_mark,
+                )
+            value = self.construct_object(value_node, deep=deep)  # type: ignore[no-untyped-call]
+            mapping[key] = value
+        return mapping
+
+
+# https://github.com/google/XNNPACK/blob/master/tools/xngen.py
+def extract_leading_whitespace(line: str) -> str:
+    match = re.match(r"\s*", line)
+    return match.group(0) if match else ""
+
+
+# https://github.com/google/XNNPACK/blob/master/tools/xngen.py
+def escape(line: str) -> str:
+    output_parts = []
+    while "${" in line:
+        start_pos = line.index("${")
+        end_pos = line.index("}", start_pos + 2)
+        if start_pos != 0:
+            output_parts.append('"' + line[:start_pos].replace('"', '\\"') + '"')
+        output_parts.append("str(" + line[start_pos + 2 : end_pos] + ")")
+        line = line[end_pos + 1 :]
+    if line:
+        output_parts.append('"' + line.replace('"', '\\"') + '"')
+    return " + ".join(output_parts)
+
+
+# https://github.com/google/XNNPACK/blob/master/tools/xngen.py
+def preprocess(
+    input_text: str, variables: Dict[str, Any], input_path: str = "codegen"
+) -> str:
+    input_lines = input_text.splitlines()
+    python_lines = []
+
+    blank_lines = 0
+
+    last_indent = ""
+
+    # List of tuples (total_index, python_indent)
+    indent_stack = [("", "")]
+
+    # Indicates whether this is the first line inside Python
+    # code block (i.e. for, while, if, elif, else)
+    python_block_start = True
+    for input_line in input_lines:
+        if input_line == "":
+            blank_lines += 1
+            continue
+        # Skip lint markers.
+        if "LINT" in input_line:
+            continue
+
+        input_indent = extract_leading_whitespace(input_line)
+        if python_block_start:
+            assert input_indent.startswith(last_indent)
+            extra_python_indent = input_indent[len(last_indent) :]
+            python_indent = indent_stack[-1][1] + extra_python_indent
+            indent_stack.append((input_indent, python_indent))
+            assert input_indent.startswith(indent_stack[-1][0])
+        else:
+            while not input_indent.startswith(indent_stack[-1][0]):
+                del indent_stack[-1]
+        python_block_start = False
+
+        python_indent = indent_stack[-1][1]
+        stripped_input_line = input_line.strip()
+        if stripped_input_line.startswith("$") and not stripped_input_line.startswith(
+            "${"
+        ):
+            if stripped_input_line.endswith(":"):
+                python_block_start = True
+            while blank_lines != 0:
+                python_lines.append(python_indent + "print(file=OUT_STREAM)")
+                blank_lines -= 1
+            python_lines.append(python_indent + stripped_input_line.replace("$", ""))
+        else:
+            assert input_line.startswith(python_indent)
+            while blank_lines != 0:
+                python_lines.append(python_indent + "print(file=OUT_STREAM)")
+                blank_lines -= 1
+            python_lines.append(
+                python_indent
+                + "print(%s, file=OUT_STREAM)"
+                % escape(input_line[len(python_indent) :])
+            )
+        last_indent = input_indent
+
+    while blank_lines != 0:
+        python_lines.append(python_indent + "print(file=OUT_STREAM)")
+        blank_lines -= 1
+
+    exec_globals = dict(variables)
+    output_stream = io.StringIO()
+    exec_globals["OUT_STREAM"] = output_stream
+
+    python_bytecode = compile("\n".join(python_lines), input_path, "exec")
+    exec(python_bytecode, exec_globals)
+
+    return output_stream.getvalue()
+
+
+class SPVGenerator:
+    def __init__(
+        self,
+        src_dir_paths: Union[str, List[str]],
+        env: Dict[Any, Any],
+        glslc_path: Optional[str],
+    ) -> None:
+        if isinstance(src_dir_paths, str):
+            self.src_dir_paths = [src_dir_paths]
+        else:
+            self.src_dir_paths = src_dir_paths
+
+        self.env = env
+        self.glslc_path = glslc_path
+
+        self.glsl_src_files: Dict[str, str] = {}
+        self.template_yaml_files: List[str] = []
+
+        self.addSrcAndYamlFiles(self.src_dir_paths)
+        self.shader_template_params: Dict[Any, Any] = {}
+        for yaml_file in self.template_yaml_files:
+            self.parseTemplateYaml(yaml_file)
+
+        self.output_shader_map: Dict[str, Tuple[str, Dict[str, str]]] = {}
+        self.constructOutputMap()
+
+    def addSrcAndYamlFiles(self, src_dir_paths: List[str]) -> None:
+        for src_path in src_dir_paths:
+            # Collect glsl source files
+            glsl_files = glob.glob(
+                os.path.join(src_path, "**", "*.glsl*"), recursive=True
+            )
+            for file in glsl_files:
+                if len(file) > 1:
+                    self.glsl_src_files[extract_filename(file, keep_ext=False)] = file
+            # Collect template yaml files
+            yaml_files = glob.glob(
+                os.path.join(src_path, "**", "*.yaml"), recursive=True
+            )
+            for file in yaml_files:
+                if len(file) > 1:
+                    self.template_yaml_files.append(file)
+
+    def generateVariantCombinations(
+        self,
+        iterated_params: Dict[str, Any],
+        exclude_params: Optional[Set[str]] = None,
+    ) -> List[Any]:
+        if exclude_params is None:
+            exclude_params = set()
+        all_iterated_params = []
+        for param_name, value_list in iterated_params.items():
+            if param_name not in exclude_params:
+                param_values = []
+                for value in value_list:
+                    suffix = value.get("SUFFIX", value["VALUE"])
+                    param_values.append((param_name, suffix, value["VALUE"]))
+                all_iterated_params.append(param_values)
+
+        return list(product(*all_iterated_params))
+
+    def parseTemplateYaml(self, yaml_file: str) -> None:
+        with open(yaml_file) as f:
+            contents = yaml.load(f, Loader=UniqueKeyLoader)
+            for template_name, params_dict in contents.items():
+                if template_name in self.shader_template_params:
+                    raise KeyError(f"{template_name} params file is defined twice")
+
+                default_params = params_dict["parameter_names_with_default_values"]
+                params_names = set(default_params.keys()).union({"NAME"})
+
+                self.shader_template_params[template_name] = []
+
+                default_iterated_params = params_dict.get(
+                    "generate_variant_forall", None
+                )
+
+                for variant in params_dict["shader_variants"]:
+                    variant_params_names = set(variant.keys())
+                    invalid_keys = (
+                        variant_params_names
+                        - params_names
+                        - {"generate_variant_forall"}
+                    )
+                    assert len(invalid_keys) == 0
+
+                    iterated_params = variant.get(
+                        "generate_variant_forall", default_iterated_params
+                    )
+
+                    if iterated_params is not None:
+                        variant_combinations = self.generateVariantCombinations(
+                            iterated_params, variant_params_names
+                        )
+
+                        for combination in variant_combinations:
+                            default_params_copy = copy.deepcopy(default_params)
+                            for key in variant:
+                                if key != "generate_variant_forall":
+                                    default_params_copy[key] = variant[key]
+
+                            variant_name = variant["NAME"]
+                            for param_value in combination:
+                                default_params_copy[param_value[0]] = param_value[2]
+                                if len(param_value[1]) > 0:
+                                    variant_name = f"{variant_name}_{param_value[1]}"
+
+                            default_params_copy["NAME"] = variant_name
+
+                            self.shader_template_params[template_name].append(
+                                default_params_copy
+                            )
+                    else:
+                        default_params_copy = copy.deepcopy(default_params)
+                        for key in variant:
+                            default_params_copy[key] = variant[key]
+
+                        self.shader_template_params[template_name].append(
+                            default_params_copy
+                        )
+
+    def create_shader_params(
+        self, variant_params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, str]:
+        if variant_params is None:
+            variant_params = {}
+        shader_params = copy.deepcopy(self.env)
+        for key, value in variant_params.items():
+            shader_params[key] = value
+
+        shader_dtype = shader_params.get("DTYPE", "float")
+
+        if shader_dtype == "int":
+            shader_params["FORMAT"] = self.env["INT_IMAGE_FORMAT"]
+        elif shader_dtype == "uint":
+            shader_params["FORMAT"] = self.env["UINT_IMAGE_FORMAT"]
+        elif shader_dtype == "int32":
+            shader_params["FORMAT"] = "rgba32i"
+        elif shader_dtype == "uint32":
+            shader_params["FORMAT"] = "rgba32ui"
+        elif shader_dtype == "int8":
+            shader_params["FORMAT"] = "rgba8i"
+        elif shader_dtype == "uint8":
+            shader_params["FORMAT"] = "rgba8ui"
+        elif shader_dtype == "float32":
+            shader_params["FORMAT"] = "rgba32f"
+        # Assume float by default
+        else:
+            shader_params["FORMAT"] = self.env["FLOAT_IMAGE_FORMAT"]
+
+        return shader_params
+
+    def constructOutputMap(self) -> None:
+        for shader_name, params in self.shader_template_params.items():
+            for variant in params:
+                source_glsl = self.glsl_src_files[shader_name]
+
+                self.output_shader_map[variant["NAME"]] = (
+                    source_glsl,
+                    self.create_shader_params(variant),
+                )
+
+        for shader_name, source_glsl in self.glsl_src_files.items():
+            if shader_name not in self.shader_template_params:
+                self.output_shader_map[shader_name] = (
+                    source_glsl,
+                    self.create_shader_params(),
+                )
+
+    def generateSPV(self, output_dir: str) -> Dict[str, str]:
+        output_file_map = {}
+        for shader_name in self.output_shader_map:
+            source_glsl = self.output_shader_map[shader_name][0]
+            shader_params = self.output_shader_map[shader_name][1]
+
+            with codecs.open(source_glsl, "r", encoding="utf-8") as input_file:
+                input_text = input_file.read()
+                output_text = preprocess(input_text, shader_params)
+
+            glsl_out_path = os.path.join(output_dir, f"{shader_name}.glsl")
+            with codecs.open(glsl_out_path, "w", encoding="utf-8") as output_file:
+                output_file.write(output_text)
+
+            # If no GLSL compiler is specified, then only write out the generated GLSL shaders.
+            # This is mainly for testing purposes.
+            if self.glslc_path is not None:
+                spv_out_path = os.path.join(output_dir, f"{shader_name}.spv")
+
+                cmd = [
+                    self.glslc_path,
+                    "-fshader-stage=compute",
+                    glsl_out_path,
+                    "-o",
+                    spv_out_path,
+                    "--target-env=vulkan1.0",
+                    "-Werror",
+                ] + [
+                    arg
+                    for src_dir_path in self.src_dir_paths
+                    for arg in ["-I", src_dir_path]
+                ]
+
+                print("glslc cmd:", cmd)
+                # pyre-ignore
+                subprocess.check_call(cmd)
+
+                output_file_map[spv_out_path] = glsl_out_path
+
+        return output_file_map
+
+
+##############################################
+#  Shader Info and Shader Registry Handling  #
+##############################################
+
+
+@dataclass
+class ShaderInfo:
+    tile_size: List[int]
+    layouts: List[str]
+    weight_storage_type: str = ""
+    bias_storage_type: str = ""
+    register_for: Optional[Tuple[str, List[str]]] = None
+
+
+def getName(filePath: str) -> str:
+    return os.path.basename(filePath).replace("/", "_").replace(".", "_")
+
+
+def isDescriptorLine(lineStr: str) -> bool:
+    descriptorLineId = r"^layout\(set"
+    return re.search(descriptorLineId, lineStr) is not None
+
+
+def isTileSizeLine(lineStr: str) -> bool:
+    tile_size_id = r"^ \* TILE_SIZE = \("
+    return re.search(tile_size_id, lineStr) is not None
+
+
+def findTileSizes(lineStr: str) -> List[int]:
+    tile_size_id = r"^ \* TILE_SIZE = \(([0-9]+), ([0-9]+), ([0-9]+)\)"
+    matches = re.search(tile_size_id, lineStr)
+    if matches is None:
+        raise AssertionError("matches is None in findTileSizes")
+    return [int(matches.group(1)), int(matches.group(2)), int(matches.group(3))]
+
+
+def isWeightStorageTypeLine(lineStr: str) -> bool:
+    weight_storage_id = r"^ \* WEIGHT_STORAGE = "
+    return re.search(weight_storage_id, lineStr) is not None
+
+
+def getWeightStorageType(lineStr: str) -> str:
+    weight_storage_id = r"^ \* WEIGHT_STORAGE = ([a-zA-Z]+_\dD)"
+    matches = re.search(weight_storage_id, lineStr)
+    if matches is None:
+        raise AssertionError("matches is None in getWeightStorageType")
+    return matches.group(1)
+
+
+def isBiasStorageTypeLine(lineStr: str) -> bool:
+    weight_storage_id = r"^ \* BIAS_STORAGE = "
+    return re.search(weight_storage_id, lineStr) is not None
+
+
+def getBiasStorageType(lineStr: str) -> str:
+    weight_storage_id = r"^ \* BIAS_STORAGE = ([a-zA-Z]+_\dD)"
+    matches = re.search(weight_storage_id, lineStr)
+    if matches is None:
+        raise AssertionError("matches is None in getBiasStorageType")
+    return matches.group(1)
+
+
+def isRegisterForLine(lineStr: str) -> bool:
+    # Check for Shader Name and a list of at least one Registry Key
+    register_for_id = (
+        r"^ \* REGISTER_FOR = \('([A-Za-z0-9_]+)'\s*,\s*\['([A-Za-z0-9_]+)'.*\]\)"
+    )
+    return re.search(register_for_id, lineStr) is not None
+
+
+def findRegisterFor(lineStr: str) -> Tuple[str, List[str]]:
+    register_for_pattern = r"'([A-Za-z0-9_]+)'"
+    matches = re.findall(register_for_pattern, lineStr)
+    if matches is None:
+        raise AssertionError("matches is None in getBiasStorageType")
+    matches_list = list(matches)
+    return (matches_list[0], matches_list[1:])
+
+
+typeIdMapping = {
+    r"image[123]D\b": "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE",
+    r"sampler[123]D\b": "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
+    r"\bbuffer\b": "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+    r"\buniform\b": "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER",
+}
+
+storageTypeToEnum = {
+    "TEXTURE_2D": "api::StorageType::TEXTURE_2D",
+    "TEXTURE_3D": "api::StorageType::TEXTURE_3D",
+    "BUFFER": "api::StorageType::BUFFER",
+    "": "api::StorageType::UNKNOWN",
+}
+
+
+def determineDescriptorType(lineStr: str) -> str:
+    for identifier, typeNum in typeIdMapping.items():
+        if re.search(identifier, lineStr):
+            return typeNum
+    raise AssertionError(
+        "No matching descriptor type for " + lineStr + " in determineDescriptorType"
+    )
+
+
+def getShaderInfo(srcFilePath: str) -> ShaderInfo:
+    shader_info = ShaderInfo([], [], "")
+    with open(srcFilePath) as srcFile:
+        for line in srcFile:
+            if isDescriptorLine(line):
+                shader_info.layouts.append(determineDescriptorType(line))
+            if isTileSizeLine(line):
+                shader_info.tile_size = findTileSizes(line)
+            if isWeightStorageTypeLine(line):
+                shader_info.weight_storage_type = getWeightStorageType(line)
+            if isBiasStorageTypeLine(line):
+                shader_info.bias_storage_type = getBiasStorageType(line)
+            if isRegisterForLine(line):
+                shader_info.register_for = findRegisterFor(line)
+
+    return shader_info
+
+
+##########################
+#  C++ File Generation  #
+#########################
+
+cpp_template = """
+#include <executorch/backends/vulkan/runtime/api/ShaderRegistry.h>
+#include <stdint.h>
+#include <vector>
+
+using namespace at::native::vulkan;
+
+namespace at {{
+namespace native {{
+namespace vulkan {{
+
+namespace {{
+
+{spv_bin_arrays}
+
+}}
+
+static void register_fn() {{
+
+{register_shader_infos}
+
+{shader_info_registry}
+
+}}
+
+static const api::ShaderRegisterInit register_shaders(&register_fn);
+
+}}
+}}
+}}
+
+"""
+
+
+def generateSpvBinStr(spvPath: str, name: str) -> Tuple[int, str]:
+    with open(spvPath, "rb") as fr:
+        next_bin = array.array("I", fr.read())
+        sizeBytes = 4 * len(next_bin)
+        spv_bin_str = "const uint32_t {}_bin[] = {{\n{}\n}};".format(
+            name,
+            textwrap.indent(",\n".join(str(x) for x in next_bin), "  "),
+        )
+
+    return sizeBytes, spv_bin_str
+
+
+def generateShaderInfoStr(shader_info: ShaderInfo, name: str, sizeBytes: int) -> str:
+    tile_size = (
+        f"{{{', '.join(str(x) for x in shader_info.tile_size)}}}"
+        if (len(shader_info.tile_size) > 0)
+        else "std::vector<uint32_t>()"
+    )
+
+    shader_info_layouts = "{{{}}}".format(",\n ".join(shader_info.layouts))
+
+    shader_info_args = [
+        f'"{name}"',
+        f"{name}_bin",
+        str(sizeBytes),
+        shader_info_layouts,
+        tile_size,
+        storageTypeToEnum[shader_info.weight_storage_type],
+        storageTypeToEnum[shader_info.bias_storage_type],
+    ]
+
+    shader_info_str = textwrap.indent(
+        "api::shader_registry().register_shader(\n  api::ShaderInfo(\n{args}));\n".format(
+            args=textwrap.indent(",\n".join(shader_info_args), "     "),
+        ),
+        "    ",
+    )
+
+    return shader_info_str
+
+
+def generateShaderDispatchStr(shader_info: ShaderInfo, name: str) -> str:
+    if shader_info.register_for is None:
+        return ""
+
+    (op_name, registry_keys) = shader_info.register_for
+    shader_dispatch_str = ""
+    for registry_key in registry_keys:
+        shader_dispatch_str = textwrap.indent(
+            f'api::shader_registry().register_op_dispatch("{op_name}", api::DispatchKey::{registry_key.upper()}, "{name}");',
+            "    ",
+        )
+
+    return shader_dispatch_str
+
+
+def genCppFiles(
+    spv_files: Dict[str, str], cpp_header_path: str, cpp_src_file_path: str
+) -> None:
+    spv_bin_strs = []
+    register_shader_info_strs = []
+    shader_registry_strs = []
+
+    for spvPath, srcPath in spv_files.items():
+        name = getName(spvPath).replace("_spv", "")
+
+        sizeBytes, spv_bin_str = generateSpvBinStr(spvPath, name)
+        spv_bin_strs.append(spv_bin_str)
+
+        shader_info = getShaderInfo(srcPath)
+
+        register_shader_info_strs.append(
+            generateShaderInfoStr(shader_info, name, sizeBytes)
+        )
+
+        if shader_info.register_for is not None:
+            shader_registry_strs.append(generateShaderDispatchStr(shader_info, name))
+
+    spv_bin_arrays = "\n".join(spv_bin_strs)
+    register_shader_infos = "\n".join(register_shader_info_strs)
+    shader_info_registry = "\n".join(shader_registry_strs)
+
+    cpp = cpp_template.format(
+        spv_bin_arrays=spv_bin_arrays,
+        register_shader_infos=register_shader_infos,
+        shader_info_registry=shader_info_registry,
+    )
+
+    with open(cpp_src_file_path, "w") as fw:
+        fw.write(cpp)
+
+
+##########
+#  Main  #
+##########
+
+
+def parse_arg_env(items: Dict[Any, Any]) -> Dict[Any, Any]:
+    d = {}
+    if items:
+        for item in items:
+            tokens = item.split("=")
+            key = tokens[0].strip()
+            value = tokens[1].strip()
+            d[key] = value
+    return d
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument(
+        "-i",
+        "--glsl-paths",
+        nargs="+",
+        help='List of paths to look for GLSL source files, separated by spaces. Ex: --glsl-paths "path1 path2 path3"',
+        default=["."],
+    )
+    parser.add_argument("-c", "--glslc-path", required=True, help="")
+    parser.add_argument("-t", "--tmp-dir-path", required=True, help="/tmp")
+    parser.add_argument("-o", "--output-path", required=True, help="")
+    parser.add_argument(
+        "--env", metavar="KEY=VALUE", nargs="*", help="Set a number of key-value pairs"
+    )
+    options = parser.parse_args()
+
+    DEFAULT_ENV.update(TYPES_ENV)
+    DEFAULT_ENV.update(FUNCS_ENV)
+    env = DEFAULT_ENV
+
+    for key, value in parse_arg_env(options.env).items():
+        env[key] = value
+
+    if not os.path.exists(options.output_path):
+        os.makedirs(options.output_path)
+
+    if not os.path.exists(options.tmp_dir_path):
+        os.makedirs(options.tmp_dir_path)
+
+    shader_generator = SPVGenerator(options.glsl_paths, env, options.glslc_path)
+    output_spv_files = shader_generator.generateSPV(options.tmp_dir_path)
+
+    genCppFiles(
+        output_spv_files,
+        f"{options.output_path}/{CPP_H_NAME}",
+        f"{options.output_path}/{CPP_SRC_NAME}",
+    )
+
+    return 0
+
+
+def invoke_main() -> None:
+    sys.exit(main(sys.argv))
+
+
+if __name__ == "__main__":
+    invoke_main()  # pragma: no cover

--- a/backends/vulkan/runtime/api/vk_api.h
+++ b/backends/vulkan/runtime/api/vk_api.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#ifdef USE_VULKAN_WRAPPER
+#ifdef USE_VULKAN_VOLK
+#include <volk.h>
+#else
+#include <vulkan_wrapper.h>
+#endif /* USE_VULKAN_VOLK */
+#else
+#include <vulkan/vulkan.h>
+#endif /* USE_VULKAN_WRAPPER */
+
+#endif /* USE_VULKAN_API */

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -12,7 +12,7 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/api.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 #include <executorch/backends/vulkan/runtime/graph/GraphConfig.h>
 

--- a/backends/vulkan/runtime/graph/GraphConfig.h
+++ b/backends/vulkan/runtime/graph/GraphConfig.h
@@ -10,7 +10,7 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/api.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 namespace at {
 namespace native {

--- a/backends/vulkan/runtime/graph/containers/Constant.h
+++ b/backends/vulkan/runtime/graph/containers/Constant.h
@@ -10,7 +10,7 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/Context.h>
+#include <executorch/backends/vulkan/runtime/api/Context.h>
 
 namespace at {
 namespace native {

--- a/backends/vulkan/runtime/graph/containers/SharedObject.h
+++ b/backends/vulkan/runtime/graph/containers/SharedObject.h
@@ -12,9 +12,9 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/Context.h>
-#include <ATen/native/vulkan/api/Tensor.h>
-#include <ATen/native/vulkan/api/Types.h>
+#include <executorch/backends/vulkan/runtime/api/Context.h>
+#include <executorch/backends/vulkan/runtime/api/Tensor.h>
+#include <executorch/backends/vulkan/runtime/api/Types.h>
 
 #include <executorch/backends/vulkan/runtime/graph/GraphConfig.h>
 

--- a/backends/vulkan/runtime/graph/containers/Value.h
+++ b/backends/vulkan/runtime/graph/containers/Value.h
@@ -12,8 +12,8 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/Context.h>
-#include <ATen/native/vulkan/api/Tensor.h>
+#include <executorch/backends/vulkan/runtime/api/Context.h>
+#include <executorch/backends/vulkan/runtime/api/Tensor.h>
 
 #include <executorch/backends/vulkan/runtime/graph/containers/Constant.h>
 #include <executorch/backends/vulkan/runtime/graph/containers/Types.h>

--- a/backends/vulkan/runtime/graph/ops/ExecuteNode.h
+++ b/backends/vulkan/runtime/graph/ops/ExecuteNode.h
@@ -10,7 +10,7 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/api.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 #include <executorch/backends/vulkan/runtime/graph/containers/Value.h>
 

--- a/backends/vulkan/runtime/graph/ops/PrepackNode.h
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.h
@@ -10,7 +10,7 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/api.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 #include <executorch/backends/vulkan/runtime/graph/containers/Value.h>
 

--- a/backends/vulkan/runtime/graph/ops/impl/utils/DimUtils.h
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/DimUtils.h
@@ -10,7 +10,7 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/api.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 namespace at {
 namespace native {

--- a/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.h
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.h
@@ -10,7 +10,7 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/api.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ComputeGraph.h>
 

--- a/backends/vulkan/runtime/graph/ops/impl/utils/ScalarUtils.h
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/ScalarUtils.h
@@ -10,7 +10,7 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/api.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 #include <executorch/backends/vulkan/runtime/graph/containers/Value.h>
 

--- a/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h
@@ -10,7 +10,7 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/api.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 namespace at {
 namespace native {

--- a/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h
+++ b/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h
@@ -10,7 +10,7 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/api.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 #include <sstream>
 

--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -1,10 +1,9 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 def vulkan_spv_shader_lib(name, spv_filegroups, is_fbcode = False):
-    gen_aten_vulkan_spv_target = "//caffe2/tools:gen_aten_vulkan_spv_bin"
+    gen_vulkan_spv_target = "//executorch/backends/vulkan:gen_vulkan_spv_bin"
     glslc_path = "//caffe2/fb/vulkan/dotslash:glslc"
     if is_fbcode:
-        gen_aten_vulkan_spv_target = "//caffe2:gen_vulkan_spv_bin"
         glslc_path = "//caffe2/fb/vulkan/tools:glslc"
 
     glsl_paths = []
@@ -14,7 +13,7 @@ def vulkan_spv_shader_lib(name, spv_filegroups, is_fbcode = False):
         glsl_paths.append("$(location {})/{}".format(target, subpath))
 
     genrule_cmd = [
-        "$(exe {})".format(gen_aten_vulkan_spv_target),
+        "$(exe {})".format(gen_vulkan_spv_target),
         "--glsl-paths {}".format(" ".join(glsl_paths)),
         "--output-path $OUT",
         "--glslc-path=$(exe {})".format(glslc_path),
@@ -45,11 +44,34 @@ def vulkan_spv_shader_lib(name, spv_filegroups, is_fbcode = False):
         # Define a soname that can be used for dynamic loading in Java, Python, etc.
         soname = "lib{}.$(ext)".format(name),
         exported_deps = [
-            "//caffe2:torch_vulkan_api",
+            "//executorch/backends/vulkan:vulkan_compute_api",
         ],
     )
 
 def define_common_targets(is_fbcode = False):
+    runtime.python_library(
+        name = "gen_vulkan_spv_lib",
+        srcs = [
+            "runtime/api/gen_vulkan_spv.py",
+        ],
+        base_module = "",
+        deps = [
+            "//caffe2/torchgen:torchgen",
+        ],
+    )
+
+    runtime.python_binary(
+        name = "gen_vulkan_spv_bin",
+        main_module = "runtime.api.gen_vulkan_spv",
+        visibility = [
+            "//executorch/backends/vulkan/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+        deps = [
+            ":gen_vulkan_spv_lib",
+        ],
+    )
+
     runtime.genrule(
         name = "gen_vk_delegate_schema",
         srcs = [
@@ -100,6 +122,44 @@ def define_common_targets(is_fbcode = False):
             ":vulkan_graph_runtime_shaders": "runtime/graph/ops/glsl",
         },
         is_fbcode = is_fbcode,
+    )
+
+    VK_API_PREPROCESSOR_FLAGS = [
+        "-DUSE_VULKAN_API",
+    ]
+    VK_API_DEPS = [
+        "fbsource//third-party/VulkanMemoryAllocator/3.0.1:VulkanMemoryAllocator_xplat",
+    ]
+
+    if not is_fbcode:
+        VK_API_DEPS += [
+            "fbsource//third-party/volk:volk",
+        ]
+        VK_API_PREPROCESSOR_FLAGS += [
+            "-DUSE_VULKAN_WRAPPER",
+            "-DUSE_VULKAN_VOLK",
+        ]
+    else:
+        VK_API_DEPS += [
+            "fbsource//third-party/swiftshader:swiftshader_vk_headers",
+            "fbsource//third-party/swiftshader/lib/linux-x64:libvk_swiftshader_fbcode",
+            "fbsource//third-party/swiftshader/lib/linux-x64:libvk_swiftshader_so",
+        ]
+
+    runtime.cxx_library(
+        name = "vulkan_compute_api",
+        srcs = native.glob([
+            "runtime/api/*.cpp",
+        ]),
+        exported_headers = native.glob([
+            "runtime/api/*.h",
+        ]),
+        visibility = [
+            "//executorch/backends/vulkan/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+        exported_preprocessor_flags = VK_API_PREPROCESSOR_FLAGS,
+        exported_deps = VK_API_DEPS,
     )
 
     runtime.cxx_library(

--- a/backends/vulkan/test/op_tests/utils/codegen.py
+++ b/backends/vulkan/test/op_tests/utils/codegen.py
@@ -396,7 +396,7 @@ class VkTestSuiteGen(TestSuiteGen):
 ###############################
 
 preamble_str = """
-#include <ATen/native/vulkan/api/api.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
 #include <executorch/backends/vulkan/runtime/graph/ComputeGraph.h>
 

--- a/backends/vulkan/test/utils/test_utils.h
+++ b/backends/vulkan/test/utils/test_utils.h
@@ -10,7 +10,7 @@
 
 #include <gtest/gtest.h>
 
-#include <ATen/native/vulkan/api/api.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/StagingUtils.h>

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -8,7 +8,7 @@
 
 #include <gtest/gtest.h>
 
-#include <ATen/native/vulkan/api/api.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
 


### PR DESCRIPTION
Summary:
## Context

Similar to https://github.com/pytorch/executorch/pull/2086 which moved the `ComputeGraph` API to the ExecuTorch repo, this changeset forks the Vulkan Compute API (under `pytorch/aten/src/ATen/native/vulkan/api`) to the ExecuTorch repository.

This is critical for development speed as it allows us to make foundational changes to the Vulkan compute API without

1. Having to export changes to PyTorch
2. Having to worry about breaking ATen Vulkan

The next change in the stack will deprecate the `at::native::vulkan` namespace now that everything is local to ExecuTorch.

Differential Revision: D55607115
