### PR TITLE
Add evaluation mode for llama_runner

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 
 from functools import partial
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import pkg_resources
 import torch
@@ -214,12 +214,12 @@ def quantize(
     qmode: str,
     activation_dtype: Optional[DType],
     checkpoint_path: Optional[Path] = None,
-    # following arguments only available when setting int4 quantization.
-    group_size: int = 128,
-    # following arguments only used for GPTQ
+    # following arguments only available when setting int4 or gptq quantization.
+    group_size: Optional[int] = 128,
+    # following arguments are only used for GPTQ
     calibration_tasks: Optional[list] = None,
-    calibration_limit: int = 100,
-    calibration_seq_length: int = 2048,
+    calibration_limit: Optional[int] = None,
+    calibration_seq_length: Optional[int] = None,
     pad_calibration_inputs: bool = False,
     percdamp: float = 0.01,
     blocksize: int = 128,
@@ -245,13 +245,13 @@ def quantize(
     # if checkpoint_path is None:
     #     checkpoint_path = Path("checkpoints/meta-llama/Llama-2-7b-chat-hf/model.pth")
 
-    if calibration_tasks is None:
-        calibration_tasks = ["wikitext"]
-
     if qmode == "int8":
         # Add quantization mode options here: group size, bit width, etc.
         return WeightOnlyInt8QuantHandler(model).quantized_model()
     elif qmode == "8da4w":
+        # Check for required args
+        if group_size is None:
+            raise Exception("For 8da4w quantization, group size must be specified.")
         from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
 
         model = Int8DynActInt4WeightQuantizer(
@@ -261,6 +261,19 @@ def quantize(
             print("quantized model:", model)
         return model
     elif qmode == "8da4w-gptq":
+        # Check for required args
+        required_args: Optional[Any] = [
+            group_size,
+            calibration_limit,
+            calibration_seq_length,
+        ]
+        if any(arg is None for arg in required_args):
+            raise Exception(
+                "For 8da4w quantization, group size, calibration limit and calibration sequence length must be specified."
+            )
+        if calibration_tasks is None:
+            calibration_tasks = ["wikitext"]
+
         from torchao.quantization.quant_api import Int8DynActInt4WeightGPTQQuantizer
 
         if tokenizer_path is None:

--- a/examples/models/llama2/main.cpp
+++ b/examples/models/llama2/main.cpp
@@ -39,6 +39,11 @@ DEFINE_int32(
     -1,
     "Number of CPU threads for inference. Defaults to -1, which implies we'll use a heuristic to derive the # of performant cores for a specific device.");
 
+DEFINE_bool(
+    eval_mode,
+    false,
+    "Defaults to false. If enabled, output the logits after a single forward call for evaluation.");
+
 int32_t main(int32_t argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
@@ -57,6 +62,8 @@ int32_t main(int32_t argc, char** argv) {
 
   int32_t cpu_threads = FLAGS_cpu_threads;
 
+  bool eval_mode = FLAGS_eval_mode;
+
 #if defined(ET_USE_THREADPOOL)
   uint32_t num_performant_cores = cpu_threads == -1
       ? torch::executorch::cpuinfo::get_num_performant_cores()
@@ -71,8 +78,21 @@ int32_t main(int32_t argc, char** argv) {
   // create llama runner
   ::torch::executor::Runner runner(model_path, tokenizer_path, temperature);
 
+  // callback
+  std::function<void(const exec_aten::Tensor)> eval_callback = {};
+  if (eval_mode) {
+    eval_callback = [](const exec_aten::Tensor& logits_tensor) -> void {
+      float* logits_data = logits_tensor.mutable_data_ptr<float>();
+      printf("\n(Logits: %zd)\n", logits_tensor.numel());
+      for (int i = 0; i < logits_tensor.numel(); ++i) {
+        printf(" %f", logits_data[i]);
+      }
+      exit(0);
+    };
+  }
+
   // generate
-  runner.generate(prompt, seq_len);
+  runner.generate(prompt, seq_len, {}, eval_callback);
 
   return 0;
 }

--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -208,7 +208,8 @@ Result<torch::executor::Tensor> Runner::run_model_step(
 Error Runner::generate(
     const std::string& prompt,
     int32_t seq_len,
-    std::function<void(const std::string&)> callback) {
+    std::function<void(const std::string&)> callback,
+    std::function<void(const exec_aten::Tensor&)> eval_callback) {
   // Prepare the inputs.
   // Use ones-initialized inputs.
   ET_CHECK_MSG(!prompt.empty(), "Prompt cannot be null");
@@ -366,6 +367,10 @@ Error Runner::generate(
 
     if (callback) {
       callback(piece);
+    }
+
+    if (eval_callback) {
+      eval_callback(logits_tensor);
     }
 
     if (shouldStop_) {

--- a/examples/models/llama2/runner/runner.h
+++ b/examples/models/llama2/runner/runner.h
@@ -36,7 +36,8 @@ class Runner {
   Error generate(
       const std::string& prompt,
       int32_t seq_len = 128,
-      std::function<void(const std::string&)> callback = {});
+      std::function<void(const std::string&)> callback = {},
+      std::function<void(const exec_aten::Tensor&)> eval_callback = {});
   void stop();
 
  private:


### PR DESCRIPTION
Summary:
Introduces an eval_mode flag that prints out the logits after a single call to forward.

This is used to evaluate the llama runtime accuracy via lm_eval (Python)

Differential Revision: D55607393


