### PR TITLE
[ET-VK][CMake] Build with forked API instead of depending on PyTorch

### DIFF
--- a/backends/vulkan/CMakeLists.txt
+++ b/backends/vulkan/CMakeLists.txt
@@ -20,14 +20,12 @@ if(NOT EXECUTORCH_ROOT)
   set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 endif()
 
-include(${EXECUTORCH_ROOT}/build/Utils.cmake)
-
 if(NOT RUNTIME_PATH)
   set(RUNTIME_PATH ${CMAKE_CURRENT_SOURCE_DIR}/runtime)
 endif()
 
 if(NOT PYTHON_EXECUTABLE)
-  resolve_python_executable()
+  set(PYTHON_EXECUTABLE python3)
 endif()
 
 if(NOT FLATC_EXECUTABLE)
@@ -40,13 +38,29 @@ endif()
 # perform dynamic registration via static initialization.
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 
-# ATen Vulkan Libs
+include(cmake/ShaderLibrary.cmake)
 
-set(PYTORCH_PATH ${EXECUTORCH_ROOT}/third-party/pytorch)
+# Third party libs
+
 set(VULKAN_THIRD_PARTY_PATH ${CMAKE_CURRENT_SOURCE_DIR}/third-party)
-include(cmake/ATenVulkan.cmake)
 
-set(COMMON_INCLUDES ${VULKAN_API_HEADERS} ${EXECUTORCH_ROOT}/..)
+set(VULKAN_HEADERS_PATH ${VULKAN_THIRD_PARTY_PATH}/Vulkan-Headers/include)
+set(VOLK_PATH ${VULKAN_THIRD_PARTY_PATH}/volk)
+set(VMA_PATH ${VULKAN_THIRD_PARTY_PATH}/VulkanMemoryAllocator)
+
+# Compile settings
+
+set(VULKAN_CXX_FLAGS "")
+list(APPEND VULKAN_CXX_FLAGS "-DUSE_VULKAN_WRAPPER")
+list(APPEND VULKAN_CXX_FLAGS "-DUSE_VULKAN_VOLK")
+
+# Vulkan Compute API
+
+file(GLOB vulkan_api_cpp ${RUNTIME_PATH}/api/*.cpp)
+list(APPEND vulkan_api_cpp ${VOLK_PATH}/volk.c)
+
+set(COMMON_INCLUDES ${EXECUTORCH_ROOT}/.. ${VULKAN_HEADERS_PATH} ${VOLK_PATH}
+                    ${VMA_PATH})
 
 # vulkan_graph_lib
 

--- a/backends/vulkan/cmake/ShaderLibrary.cmake
+++ b/backends/vulkan/cmake/ShaderLibrary.cmake
@@ -14,45 +14,6 @@
 #
 # The targets in this file will be built if EXECUTORCH_BUILD_VULKAN is ON
 
-if(NOT PYTORCH_PATH)
-  set(PYTORCH_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/pytorch)
-endif()
-
-if(NOT VULKAN_THIRD_PARTY_PATH)
-  set(VULKAN_THIRD_PARTY_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../third-party)
-endif()
-
-# Source file paths
-
-set(ATEN_PATH ${PYTORCH_PATH}/aten/src)
-set(ATEN_VULKAN_PATH ${ATEN_PATH}/ATen/native/vulkan)
-
-set(VULKAN_HEADERS_PATH ${VULKAN_THIRD_PARTY_PATH}/Vulkan-Headers/include)
-set(VOLK_PATH ${VULKAN_THIRD_PARTY_PATH}/volk)
-set(VMA_PATH ${VULKAN_THIRD_PARTY_PATH}/VulkanMemoryAllocator)
-
-# Compile settings
-
-set(VULKAN_CXX_FLAGS "")
-list(APPEND VULKAN_CXX_FLAGS "-DUSE_VULKAN_API")
-list(APPEND VULKAN_CXX_FLAGS "-DUSE_VULKAN_WRAPPER")
-list(APPEND VULKAN_CXX_FLAGS "-DUSE_VULKAN_VOLK")
-list(APPEND VULKAN_CXX_FLAGS "-DVK_NO_PROTOTYPES")
-list(APPEND VULKAN_CXX_FLAGS "-DVOLK_DEFAULT_VISIBILITY")
-
-# vulkan_api source files
-
-file(GLOB vulkan_api_cpp ${ATEN_VULKAN_PATH}/api/*.cpp)
-list(APPEND vulkan_api_cpp ${VOLK_PATH}/volk.c)
-
-set(VULKAN_API_HEADERS)
-list(APPEND VULKAN_API_HEADERS ${ATEN_PATH})
-list(APPEND VULKAN_API_HEADERS ${VULKAN_HEADERS_PATH})
-list(APPEND VULKAN_API_HEADERS ${VOLK_PATH})
-list(APPEND VULKAN_API_HEADERS ${VMA_PATH})
-
-# Find GLSL compiler executable
-
 if(ANDROID)
   if(NOT ANDROID_NDK)
     message(FATAL_ERROR "ANDROID_NDK not set")
@@ -84,7 +45,8 @@ macro(VULKAN_SHADER_LIBRARY shaders_path library_name)
 
   execute_process(
     COMMAND
-      "${PYTHON_EXECUTABLE}" ${PYTORCH_PATH}/tools/gen_vulkan_spv.py --glsl-path
+      "${PYTHON_EXECUTABLE}"
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtime/api/gen_vulkan_spv.py --glsl-path
       ${shaders_path} --output-path ${VULKAN_SHADERGEN_OUT_PATH}
       --glslc-path=${GLSLC_PATH} --tmp-dir-path=${VULKAN_SHADERGEN_OUT_PATH}
       --env ${VULKAN_GEN_ARG_ENV}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2813

## Context

https://github.com/pytorch/executorch/pull/2797 forked the required components from PyTorch-Vulkan into the ExecuTorch directory, which means that building the ExecuTorch Vulkan delegate no longer needs to depend on PyTorch.

This is a simple change to the Vulkan delegate CMakeLists.txt to build using the forked Vulkan API instead of the Vulkan API contained in `pytorch` submodule.

Differential Revision: [D55660791](https://our.internmc.facebook.com/intern/diff/D55660791)