### PR TITLE
[RELEASE-ONLY CHANGES] Update release/0.2 to pin and test against PyTorch release/2.3

### DIFF
--- a/.ci/docker/ci_commit_pins/pytorch.txt
+++ b/.ci/docker/ci_commit_pins/pytorch.txt
@@ -1,1 +1,1 @@
-0a038cf0cff2d071b7359ac0491fd2ba7798a438
+release/2.3

--- a/backends/arm/arm_quantizer_utils.py
+++ b/backends/arm/arm_quantizer_utils.py
@@ -23,7 +23,7 @@ from torch.ao.quantization.pt2e.graph_utils import find_sequential_partitions
 from torch.ao.quantization.pt2e.utils import (
     _conv1d_bn_example_inputs,
     _conv2d_bn_example_inputs,
-    _get_aten_graph_module_for_pattern,
+    get_aten_graph_module,
 )
 from torch.ao.quantization.quantizer import (
     QuantizationAnnotation,
@@ -478,7 +478,7 @@ def _do_annotate_conv_bn(
     # Match against all conv dimensions and cuda variants
     for (conv_fn, example_inputs), is_cuda, relu_is_inplace in combinations:
         pattern = _get_pattern(conv_fn, relu_is_inplace, has_relu)
-        pattern = _get_aten_graph_module_for_pattern(pattern, example_inputs, is_cuda)
+        pattern = get_aten_graph_module(pattern, example_inputs, is_cuda)
         pattern.graph.eliminate_dead_code()
         pattern.recompile()
         matcher = SubgraphMatcherWithNameNodeMap(pattern, ignore_literals=True)

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -49,19 +49,14 @@ done
 # Since ExecuTorch often uses main-branch features of pytorch, only the nightly
 # pip versions will have the required features. The NIGHTLY_VERSION value should
 # agree with the third-party/pytorch pinned submodule commit.
-#
-# NOTE: If a newly-fetched version of the executorch repo changes the value of
-# NIGHTLY_VERSION, you should re-run this script to install the necessary
-# package versions.
-NIGHTLY_VERSION=dev20240324
 
 # The pip repository that hosts nightly torch packages.
-TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cpu"
+TORCH_URL="https://download.pytorch.org/whl/test/cpu"
 
 # pip packages needed by exir.
 EXIR_REQUIREMENTS=(
-  torch=="2.4.0.${NIGHTLY_VERSION}"
-  torchvision=="0.19.0.${NIGHTLY_VERSION}"  # For testing.
+  torch=="2.3.0"
+  torchvision=="0.18.0"
 )
 
 # pip packages needed for development.
@@ -77,7 +72,7 @@ DEVEL_REQUIREMENTS=(
 # TODO(dbort): Make each example publish its own requirements.txt
 EXAMPLES_REQUIREMENTS=(
   timm==0.6.13
-  torchaudio=="2.2.0.${NIGHTLY_VERSION}"
+  torchaudio=="2.3.0"
   torchsr==1.0.4
   transformers==4.38.2
 )
@@ -92,7 +87,7 @@ REQUIREMENTS_TO_INSTALL=(
 
 # Install the requirements. `--extra-index-url` tells pip to look for package
 # versions on the provided URL if they aren't available on the default URL.
-pip install --extra-index-url "${TORCH_NIGHTLY_URL}" \
+pip install --extra-index-url "${TORCH_URL}" \
     "${REQUIREMENTS_TO_INSTALL[@]}"
 
 #


### PR DESCRIPTION
 - CI: Pin to latest commit in release/2.3 (somehow directly pinning `release/2.3` doesn't work)
 - DevX: Update `install_requirements.sh` to install prebuilt torch-2.3 and torchvision/torchaudio.
 - Fix ExecuTorch downstream to use the old API