### PR TITLE
Qualcomm AI Engine Direct - Requantization Mechanism Implementation

### DIFF
--- a/backends/qualcomm/builders/op_add.py
+++ b/backends/qualcomm/builders/op_add.py
@@ -31,6 +31,7 @@ class Add(NodeVisitor):
             out_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         add_output_tensors = [output_tensor_wrapper]
 
@@ -45,6 +46,7 @@ class Add(NodeVisitor):
                 input_tensor,
                 tensor_type,
                 nodes_to_wrappers,
+                is_input_tensor=True,
             )
             add_input_tensors.append(input_tensor_wrapper)
 

--- a/backends/qualcomm/builders/op_avg_pool2d.py
+++ b/backends/qualcomm/builders/op_avg_pool2d.py
@@ -33,6 +33,7 @@ class AvgPool2d(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -41,6 +42,7 @@ class AvgPool2d(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         # kernel info
         filter_size = cast(List[int], node.args[1])

--- a/backends/qualcomm/builders/op_batch_norm.py
+++ b/backends/qualcomm/builders/op_batch_norm.py
@@ -38,6 +38,7 @@ class BatchNorm(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         bias_node = node.args[2]
@@ -52,6 +53,7 @@ class BatchNorm(NodeVisitor):
             bias_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         filter_tensor = filter_tensor / torch.sqrt(var_tensor + eps)
@@ -60,6 +62,7 @@ class BatchNorm(NodeVisitor):
             filter_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         batch_norm_input_tensors = [
@@ -74,6 +77,7 @@ class BatchNorm(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         batch_norm_output_tensors = [output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_bmm.py
+++ b/backends/qualcomm/builders/op_bmm.py
@@ -35,6 +35,7 @@ class BMM(NodeVisitor):
                 input_tensor,
                 PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
                 nodes_to_wrappers,
+                is_input_tensor=True,
             )
             bmm_input_tensors.append(input_tensor_wrapper)
 
@@ -44,6 +45,7 @@ class BMM(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         bmm_output_tensors = [output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_cast.py
+++ b/backends/qualcomm/builders/op_cast.py
@@ -33,6 +33,7 @@ class Cast(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -42,6 +43,7 @@ class Cast(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         cast_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_cat.py
+++ b/backends/qualcomm/builders/op_cat.py
@@ -37,6 +37,7 @@ class Cat(NodeVisitor):
                     input_tensor,
                     PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
                     nodes_to_wrappers,
+                    is_input_tensor=True,
                 )
             )
 
@@ -52,6 +53,7 @@ class Cat(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         # node args[1] might not exist

--- a/backends/qualcomm/builders/op_ceil.py
+++ b/backends/qualcomm/builders/op_ceil.py
@@ -32,6 +32,7 @@ class Ceil(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -40,6 +41,7 @@ class Ceil(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         ceil_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_clamp.py
+++ b/backends/qualcomm/builders/op_clamp.py
@@ -33,6 +33,7 @@ class Clamp(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         # default value of output_min and output_max
@@ -53,6 +54,7 @@ class Clamp(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         clamp_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_conv2d.py
+++ b/backends/qualcomm/builders/op_conv2d.py
@@ -96,7 +96,7 @@ class Conv2d(NodeVisitor):
         op_wrapper_list = []  # op_wrapper to return
         unsqueeze_input_node = node.args[0]
         input_quant_encoding, input_quant_configs = self.get_quant_encoding_conf(
-            unsqueeze_input_node
+            unsqueeze_input_node,
         )
 
         unsqueeze_input_tensor = self.get_tensor(unsqueeze_input_node, node)
@@ -105,6 +105,7 @@ class Conv2d(NodeVisitor):
             unsqueeze_input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
         unsqueeze_output_tensor = unsqueeze_input_tensor.unsqueeze(1).contiguous()
         dtype = self.get_data_type(unsqueeze_output_tensor, input_quant_configs, True)
@@ -144,6 +145,7 @@ class Conv2d(NodeVisitor):
             filter_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         conv_input_tensors = [unsqueeze_output_tensor_wrapper, filter_tensor_wrapper]
         if node.args[2] is not None:
@@ -154,6 +156,7 @@ class Conv2d(NodeVisitor):
                 bias_tensor,
                 PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
                 nodes_to_wrappers,
+                is_input_tensor=False,
             )
             conv_input_tensors.append(bias_tensor_wrapper)
 
@@ -221,7 +224,8 @@ class Conv2d(NodeVisitor):
             squeeze_output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
-            node.name,
+            is_input_tensor=False,
+            node_name=node.name,
         )
         squeeze_op.AddInputTensors([conv_output_tensor_wrapper])
         squeeze_op.AddOutputTensors([squeeze_output_tensor_wrapper])
@@ -244,6 +248,7 @@ class Conv2d(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         filter_node = node.args[1]
@@ -256,6 +261,7 @@ class Conv2d(NodeVisitor):
             filter_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         conv_input_tensors = [input_tensor_wrapper, filter_tensor_wrapper]
 
@@ -267,6 +273,7 @@ class Conv2d(NodeVisitor):
                 bias_tensor,
                 PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
                 nodes_to_wrappers,
+                is_input_tensor=False,
             )
             conv_input_tensors.append(bias_tensor_wrapper)
 
@@ -276,6 +283,7 @@ class Conv2d(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         conv_output_tensors = [output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_depth_to_space.py
+++ b/backends/qualcomm/builders/op_depth_to_space.py
@@ -34,6 +34,7 @@ class DepthToSpaceVisitor(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -42,6 +43,7 @@ class DepthToSpaceVisitor(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         block_size = []

--- a/backends/qualcomm/builders/op_dequantize.py
+++ b/backends/qualcomm/builders/op_dequantize.py
@@ -30,6 +30,7 @@ class DequantizeOpBase(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
         dequant_input_tensors.append(inp_tensor_wrapper)
 
@@ -39,6 +40,7 @@ class DequantizeOpBase(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         dequant_output_tensors = [output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_div.py
+++ b/backends/qualcomm/builders/op_div.py
@@ -31,6 +31,7 @@ class Div(NodeVisitor):
             out_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         div_output_tensors = [output_tensor_wrapper]
 
@@ -45,6 +46,7 @@ class Div(NodeVisitor):
                 input_tensor,
                 tensor_type,
                 nodes_to_wrappers,
+                is_input_tensor=True,
             )
             div_input_tensors.append(input_tensor_wrapper)
 

--- a/backends/qualcomm/builders/op_embedding.py
+++ b/backends/qualcomm/builders/op_embedding.py
@@ -34,15 +34,17 @@ class Embedding(NodeVisitor):
             weight_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         indices_node = node.args[1]
         indices_tensor = self.get_tensor(indices_node, node)
-        indices_tensor_wrapper = self.define_scalar(
+        indices_tensor_wrapper = self.define_tensor(
             indices_node,
             indices_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         gather_input_tensors = [weight_tensor_wrapper, indices_tensor_wrapper]
@@ -53,6 +55,7 @@ class Embedding(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         gather_output_tensors = [output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_expand.py
+++ b/backends/qualcomm/builders/op_expand.py
@@ -33,6 +33,7 @@ class Expand(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -41,6 +42,7 @@ class Expand(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         sizes = cast(List[int], node.args[1])

--- a/backends/qualcomm/builders/op_gelu.py
+++ b/backends/qualcomm/builders/op_gelu.py
@@ -33,6 +33,7 @@ class GeluVisitor(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -41,6 +42,7 @@ class GeluVisitor(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         gelu_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_hardswish.py
+++ b/backends/qualcomm/builders/op_hardswish.py
@@ -33,6 +33,7 @@ class HardSwishVisitor(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -41,6 +42,7 @@ class HardSwishVisitor(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         hardswish_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_hardtanh.py
+++ b/backends/qualcomm/builders/op_hardtanh.py
@@ -34,6 +34,7 @@ class HardTanhVisitor(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         # default value of output_min and output_max
@@ -52,6 +53,7 @@ class HardTanhVisitor(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         hardtanh_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_layer_norm.py
+++ b/backends/qualcomm/builders/op_layer_norm.py
@@ -35,6 +35,7 @@ class LayerNormVisitor(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         normalized_shapes = node.args[1]
@@ -54,6 +55,7 @@ class LayerNormVisitor(NodeVisitor):
             weight_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         bias_node = node.args[3]
@@ -63,6 +65,7 @@ class LayerNormVisitor(NodeVisitor):
             bias_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         epsilon = node.args[4]
@@ -73,6 +76,7 @@ class LayerNormVisitor(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         layer_norm_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_linear.py
+++ b/backends/qualcomm/builders/op_linear.py
@@ -35,6 +35,7 @@ class LinearVisitor(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
         linear_input_tensors.append(input_tensor_wrapper)
 
@@ -45,6 +46,7 @@ class LinearVisitor(NodeVisitor):
             weight_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         linear_input_tensors.append(weight_tensor_wrapper)
 
@@ -56,6 +58,7 @@ class LinearVisitor(NodeVisitor):
                 bias_tensor,
                 PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
                 nodes_to_wrappers,
+                is_input_tensor=False,
             )
             linear_input_tensors.append(bias_tensor_wrapper)
 
@@ -65,6 +68,7 @@ class LinearVisitor(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         linear_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_log_softmax.py
+++ b/backends/qualcomm/builders/op_log_softmax.py
@@ -34,6 +34,7 @@ class LogSoftmax(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
         log_softmax_input_tensors = [log_softmax_inp_tensor_wrapper]
         output_tensor = self.get_tensor(node, node)
@@ -43,6 +44,7 @@ class LogSoftmax(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         log_softmax_output_tensors = [log_softmax_output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_matmul.py
+++ b/backends/qualcomm/builders/op_matmul.py
@@ -35,6 +35,7 @@ class Matmul(NodeVisitor):
                 input_tensor,
                 PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
                 nodes_to_wrappers,
+                is_input_tensor=True,
             )
             matmul_input_tensors.append(input_tensor_wrapper)
 
@@ -44,6 +45,7 @@ class Matmul(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         matmul_output_tensors = [output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_max_pool2d.py
+++ b/backends/qualcomm/builders/op_max_pool2d.py
@@ -33,6 +33,7 @@ class MaxPool2d(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         users = list(node.users.keys())
@@ -51,6 +52,7 @@ class MaxPool2d(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         # kernel info
         filter_size = cast(List[int], node.args[1])

--- a/backends/qualcomm/builders/op_mean_dim.py
+++ b/backends/qualcomm/builders/op_mean_dim.py
@@ -34,6 +34,7 @@ class MeanDim(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         # mean dims and keep dims
@@ -53,6 +54,7 @@ class MeanDim(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         reduce_mean_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_mul.py
+++ b/backends/qualcomm/builders/op_mul.py
@@ -31,6 +31,7 @@ class Mul(NodeVisitor):
             out_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         mul_output_tensors = [output_tensor_wrapper]
 
@@ -45,6 +46,7 @@ class Mul(NodeVisitor):
                 input_tensor,
                 tensor_type,
                 nodes_to_wrappers,
+                is_input_tensor=True,
             )
             mul_input_tensors.append(input_tensor_wrapper)
 

--- a/backends/qualcomm/builders/op_pad.py
+++ b/backends/qualcomm/builders/op_pad.py
@@ -33,6 +33,7 @@ class Pad(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
         pad_input_tensors = [pad_inp_tensor_wrapper]
 
@@ -42,6 +43,7 @@ class Pad(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         pad_output_tensors = [output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_pow.py
+++ b/backends/qualcomm/builders/op_pow.py
@@ -33,6 +33,7 @@ class PowTensorScalar(NodeVisitor):
             out_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         pow_output_tensors = [output_tensor_wrapper]
 
@@ -47,6 +48,7 @@ class PowTensorScalar(NodeVisitor):
             input_tensor,
             tensor_type,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         # scalar input
@@ -77,6 +79,7 @@ class PowTensorScalar(NodeVisitor):
             scalar_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         pow_input_tensors = [input_tensor_wrapper, scalar_tensor_wrapper]

--- a/backends/qualcomm/builders/op_quantize.py
+++ b/backends/qualcomm/builders/op_quantize.py
@@ -30,6 +30,7 @@ class QuantizeOpBase(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
         quant_input_tensors.append(inp_tensor_wrapper)
 
@@ -45,6 +46,7 @@ class QuantizeOpBase(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         quant_output_tensors = [output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_relu.py
+++ b/backends/qualcomm/builders/op_relu.py
@@ -32,6 +32,7 @@ class Relu(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
         relu_input_tensors = [relu_inp_tensor_wrapper]
 
@@ -41,6 +42,7 @@ class Relu(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         relu_output_tensors = [output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_reshape.py
+++ b/backends/qualcomm/builders/op_reshape.py
@@ -32,6 +32,7 @@ class Reshape(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor_wrapper = self.define_tensor(
@@ -39,6 +40,7 @@ class Reshape(NodeVisitor):
             node.meta["val"],
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         reshape_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_rsqrt.py
+++ b/backends/qualcomm/builders/op_rsqrt.py
@@ -32,6 +32,7 @@ class Rsqrt(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
         rsqrt_input_tensors = [rsqrt_inp_tensor_wrapper]
 
@@ -41,6 +42,7 @@ class Rsqrt(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         rsqrt_output_tensors = [output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_select_copy.py
+++ b/backends/qualcomm/builders/op_select_copy.py
@@ -34,6 +34,7 @@ class SelectCopy(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -42,6 +43,7 @@ class SelectCopy(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         dim = cast(int, node.args[1])

--- a/backends/qualcomm/builders/op_sigmoid.py
+++ b/backends/qualcomm/builders/op_sigmoid.py
@@ -32,6 +32,7 @@ class Sigmoid(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
         sigmoid_input_tensors = [sigmoid_inp_tensor_wrapper]
 
@@ -41,6 +42,7 @@ class Sigmoid(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         sigmoid_output_tensors = [output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_slice_copy.py
+++ b/backends/qualcomm/builders/op_slice_copy.py
@@ -35,6 +35,7 @@ class StrideSlice(NodeVisitor):
             input_tensor,
             tensor_type,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -43,6 +44,7 @@ class StrideSlice(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         dim = cast(int, node.args[1])

--- a/backends/qualcomm/builders/op_softmax.py
+++ b/backends/qualcomm/builders/op_softmax.py
@@ -33,6 +33,7 @@ class Softmax(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
         softmax_input_tensors = [softmax_inp_tensor_wrapper]
 
@@ -42,6 +43,7 @@ class Softmax(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         softmax_output_tensors = [output_tensor_wrapper]
 

--- a/backends/qualcomm/builders/op_squeeze.py
+++ b/backends/qualcomm/builders/op_squeeze.py
@@ -33,6 +33,7 @@ class Squeeze(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -41,6 +42,7 @@ class Squeeze(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         squeeze_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_sub.py
+++ b/backends/qualcomm/builders/op_sub.py
@@ -31,6 +31,7 @@ class Sub(NodeVisitor):
             out_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
         sub_output_tensors = [output_tensor_wrapper]
 
@@ -45,6 +46,7 @@ class Sub(NodeVisitor):
                 input_tensor,
                 tensor_type,
                 nodes_to_wrappers,
+                is_input_tensor=True,
             )
             sub_input_tensors.append(input_tensor_wrapper)
 

--- a/backends/qualcomm/builders/op_tanh.py
+++ b/backends/qualcomm/builders/op_tanh.py
@@ -33,6 +33,7 @@ class Tanh(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -41,6 +42,7 @@ class Tanh(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         tanh_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_transpose.py
+++ b/backends/qualcomm/builders/op_transpose.py
@@ -35,6 +35,7 @@ class TransposeVisitor(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         # permutation
@@ -47,6 +48,7 @@ class TransposeVisitor(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         transpose_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_unsqueeze.py
+++ b/backends/qualcomm/builders/op_unsqueeze.py
@@ -33,6 +33,7 @@ class Unsqueeze(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -41,6 +42,7 @@ class Unsqueeze(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         unsqueeze_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/builders/op_upsample_bilinear2d.py
+++ b/backends/qualcomm/builders/op_upsample_bilinear2d.py
@@ -32,6 +32,7 @@ class ResizeBilinear(NodeVisitor):
             input_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=True,
         )
 
         output_tensor = self.get_tensor(node, node)
@@ -40,6 +41,7 @@ class ResizeBilinear(NodeVisitor):
             output_tensor,
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
+            is_input_tensor=False,
         )
 
         reisze_bilinear_op = PyQnnWrapper.PyQnnOpWrapper(

--- a/backends/qualcomm/passes/insert_requantize.py
+++ b/backends/qualcomm/passes/insert_requantize.py
@@ -16,42 +16,46 @@ class InsertRequantize(InsertIOQDQ):
     different quantization specs in input and activation
     """
 
+    # Storing ops that has multi output but run _single_output_annotation logic
+    # instead of _multi_output_annotation. Ops might be added into this set because
+    # we don't use the 2nd output, 2nd output is an integer, etc.
+    multi_output_op_ignore_set = {
+        exir_ops.edge.aten._native_batch_norm_legit_no_training.default,
+    }
+
     def __init__(
         self,
         edge_program: torch.export.ExportedProgram,
         insert_requantize: bool = False,
     ):
         super().__init__(edge_program)
-        # add non-arithmetic operators here if condition met
-        self.op_map = {
-            exir_ops.edge.aten.permute_copy.default: self._single_io_annotation,
-        }
         self.insert_requantize = insert_requantize
 
-    def _single_io_annotation(self, gm: torch.fx.GraphModule, n: torch.fx.node) -> None:
-        in_q_attr = n.args[0].meta.get("quant_attrs")
-        out_q_attr = n.meta["quant_attrs"]
-        if in_q_attr is not None and in_q_attr["dtype"] != out_q_attr["dtype"]:
-            if self.insert_requantize:
-                dq_attr = n.meta["requantize"]["dq_attrs"]
-                q_attr = n.meta["requantize"]["q_attrs"]
-                # insert dq with given quantization attribute in input node
-                dq = self._insert_quant_node(gm, n, dq_attr["encoding"], dq_attr)
-                dq.meta["quant_attrs"] = dq_attr
-                # insert q with given quantization attribute in current node
-                q = self._insert_quant_node(gm, dq, q_attr["encoding"], q_attr)
-                q.meta["quant_attrs"] = q_attr
-            else:
-                dq_attr = in_q_attr.copy()
-                dq_attr["encoding"] = self.q_dq_map[out_q_attr["encoding"]]
-                q_attr = out_q_attr.copy()
-                n.meta["requantize"] = {"dq_attrs": dq_attr, "q_attrs": q_attr}
+    # TODO: Implement this function when we have an op with
+    # multiple outputs that requires quant attributes.
+    def _multi_output_annotation(self) -> None:
+        raise NotImplementedError("requant is not implemented for multi output yet")
+
+    def _single_output_annotation(
+        self, gm: torch.fx.GraphModule, n: torch.fx.node
+    ) -> None:
+        dq_attr = n.meta["quant_attrs"]
+        q_attr = n.meta["requantize"]
+        # insert dq with given quantization attribute in input node
+        dq = self._insert_quant_node(
+            gm, n, InsertIOQDQ.q_dq_map[q_attr["encoding"]], dq_attr
+        )
+        dq.meta["quant_attrs"] = dq_attr
+        # insert q with given quantization attribute in current node
+        q = self._insert_quant_node(gm, dq, q_attr["encoding"], q_attr)
+        q.meta["quant_attrs"] = q_attr
 
     def _insert(self, graph_module: torch.fx.GraphModule) -> torch.fx.GraphModule:
         for n in graph_module.graph.nodes:
-            if (
-                n.op == "call_function"
-                and n.meta.get("quant_attrs")
-                and n.target in self.op_map
-            ):
-                self.op_map[n.target](graph_module, n)
+            if "requantize" in n.meta:
+                (
+                    self._single_output_annotation(graph_module, n)
+                    if len(n.meta["val"]) == 1
+                    or n.target in self.multi_output_op_ignore_set
+                    else self._multi_output_annotation()
+                )

--- a/backends/qualcomm/qnn_preprocess.py
+++ b/backends/qualcomm/qnn_preprocess.py
@@ -44,8 +44,8 @@ class QnnBackend(BackendDetails):
         qnn_compiler_passes = PassManager(
             passes=[
                 ConvertToLinear(),
+                InsertRequantize(edge_program),
                 InsertIOQDQ(edge_program),
-                InsertRequantize(edge_program, insert_requantize=True),
                 LayoutTransform(edge_program, insert_permute=True),
             ]
         )
@@ -83,7 +83,6 @@ class QnnBackend(BackendDetails):
                 continue
             else:
                 raise RuntimeError(f"{node.op} is not supported in Qnn")
-
         qnn_context_binary = qnn_manager.Compile(
             [py_op_wrapper.GetOpWrapper() for py_op_wrapper in py_op_wrapper_list]
         )

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -981,7 +981,7 @@ class TestQNNQuantizedModel(TestQNN):
         sample_input = (torch.randn([1, 8, 512]), torch.randn([1, 2, 8, 256]))
         module = self.get_qdq_module(module, sample_input)
         self.lower_module_and_test_output(module, sample_input)
-        # check if requantization work
+        # check if requantization work by reusing the 8bit qdq module
         module = self.get_qdq_module(
             module, sample_input, quant_dtype=QuantDtype.use_16a16w
         )

--- a/backends/qualcomm/tests/utils.py
+++ b/backends/qualcomm/tests/utils.py
@@ -114,8 +114,8 @@ class TestQNN(unittest.TestCase):
         module: torch.nn.Module,
         sample_inputs: Tuple[torch.Tensor],
         executorch_prog: ExecutorchProgram,
-        etrecord_path: str,
-        expected_profile_events: int,
+        etrecord_path: str = "etrecord.bin",
+        expected_profile_events: int = -1,
     ):
         with tempfile.TemporaryDirectory() as tmp_dir:
             (

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -25,7 +25,6 @@ from executorch.backends.qualcomm.passes.convert_interpolate_with_upsample2d imp
 from executorch.backends.qualcomm.passes.convert_to_linear import ConvertToLinear
 from executorch.backends.qualcomm.passes.fold_qdq import FoldQDQ
 from executorch.backends.qualcomm.passes.i64_to_i32 import I64toI32
-from executorch.backends.qualcomm.passes.insert_requantize import InsertRequantize
 from executorch.backends.qualcomm.passes.layout_transform import LayoutTransform
 from executorch.backends.qualcomm.passes.remove_clone import RemoveClone
 from executorch.backends.qualcomm.serialization.qnn_compile_spec_schema import (
@@ -111,7 +110,6 @@ def _transform(edge_program: ExportedProgram) -> None:
     AnnotateAndQuantScalar(edge_program)(graph_module)
     AnnotateDecomposed(edge_program)(graph_module)
     FoldQDQ()(graph_module)
-    InsertRequantize(edge_program)(graph_module)
     LayoutTransform(edge_program)(graph_module)
 
 

--- a/examples/qualcomm/executor_runner/qnn_executor_runner.cpp
+++ b/examples/qualcomm/executor_runner/qnn_executor_runner.cpp
@@ -413,5 +413,20 @@ int main(int argc, char** argv) {
     ET_LOG(Info, "Model executed successfully.");
   }
 
+  // Dump the etdump data containing profiling/debugging data to the specified
+  // file.
+  etdump_result result = etdump_gen.get_etdump_data();
+  if (result.buf != nullptr && result.size > 0) {
+    ET_LOG(
+        Info,
+        "Write etdump to %s, Size = %zu",
+        FLAGS_etdump_path.c_str(),
+        result.size);
+    FILE* f = fopen(FLAGS_etdump_path.c_str(), "w+");
+    fwrite((uint8_t*)result.buf, 1, result.size, f);
+    fclose(f);
+    free(result.buf);
+  }
+
   return 0;
 }

--- a/examples/qualcomm/scripts/torchvision_vit.py
+++ b/examples/qualcomm/scripts/torchvision_vit.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import argparse
 import json
 import os
 from multiprocessing.connection import Client
@@ -17,6 +16,7 @@ from executorch.examples.models.torchvision_vit.model import TorchVisionViTModel
 from executorch.examples.qualcomm.scripts.utils import (
     build_executorch_binary,
     make_output_dir,
+    setup_common_args_and_variables,
     SimpleADB,
     topk_accuracy,
 )
@@ -57,7 +57,7 @@ def get_dataset(dataset_path, data_size):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = setup_common_args_and_variables()
     parser.add_argument(
         "-d",
         "--dataset",
@@ -76,60 +76,6 @@ if __name__ == "__main__":
         default="./vit",
         type=str,
     )
-    parser.add_argument(
-        "-b",
-        "--build_folder",
-        help="path to cmake binary directory for android, e.g., /path/to/build_android",
-        type=str,
-        required=True,
-    )
-    parser.add_argument(
-        "-s",
-        "--device",
-        help="serial number for android device communicated via ADB.",
-        type=str,
-        required=True,
-    )
-    parser.add_argument(
-        "-H",
-        "--host",
-        help="hostname where android device is connected.",
-        default=None,
-        type=str,
-    )
-    parser.add_argument(
-        "-m",
-        "--model",
-        help="SoC model of current device. e.g. 'SM8550' for Snapdragon 8 Gen 2",
-        type=str,
-        required=True,
-    )
-    parser.add_argument(
-        "--ip",
-        help="IPC address for delivering execution result",
-        default="",
-        type=str,
-    )
-    parser.add_argument(
-        "--port",
-        help="IPC port for delivering execution result",
-        default=-1,
-        type=int,
-    )
-
-    # QNN_SDK_ROOT might also be an argument, but it is used in various places.
-    # So maybe it's fine to just use the environment.
-    if "QNN_SDK_ROOT" not in os.environ:
-        raise RuntimeError("Environment variable QNN_SDK_ROOT must be set")
-    print(f"QNN_SDK_ROOT={os.getenv('QNN_SDK_ROOT')}")
-
-    if "LD_LIBRARY_PATH" not in os.environ:
-        print(
-            "[Warning] LD_LIBRARY_PATH is not set. If errors like libQnnHtp.so "
-            "not found happen, please follow setup.md to set environment."
-        )
-    else:
-        print(f"LD_LIBRARY_PATH={os.getenv('LD_LIBRARY_PATH')}")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Summary:

- Implement requantization so mix quantization ( e.g., 8bit quant + 16 bit quant) can be properly delegated to QNN.
- Reusing test_qnn_backend_view_permute_matmul unit test to check mix quantization is working as expected.
- Added etdump logic back to qnn_executor_runner that was deleted unintentionally during this PR: https://github.com/pytorch/executorch/commit/a531ca5a5ab5b5e503739a40a7cbec2e46767f0b#diff-f3647de74042ac9a417e2d4000a6f2db00c22c89fd028e9433d3c79ffb7d56f6
- Refactor common arguments in VIT.