### PR TITLE
Skip one op for coreml partitioner

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -593,7 +593,10 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
         partitioners.append(
             # pyre-ignore: Undefined attribute [16]: Module `executorch.backends` has no attribute `apple`
             CoreMLPartitioner(
-                skip_ops_for_coreml_delegation=None, compile_specs=compile_specs
+                skip_ops_for_coreml_delegation=[
+                    "aten.index_put.default",
+                ],
+                compile_specs=compile_specs,
             )
         )
         modelname = f"coreml_{modelname}"


### PR DESCRIPTION
Summary:
There are some issues with the current two ops in coreml side. While waiting for the fix, skip them for now 
```
"aten.index_put.default"
```
test with
```
python3 -m examples.models.llama2.export_llama --coreml --use_kv_cache
```
also test the stories-llama model
```
python3 -m examples.models.llama2.export_llama -kv --coreml --checkpoint /Users/chenlai/Documents/stories110M/stories110M.pt  --params /Users/chenlai/Documents/stories110M/params.json
```

Differential Revision: D55680297


