### PR TITLE
fix a set union bug

### DIFF
--- a/exir/backend/utils.py
+++ b/exir/backend/utils.py
@@ -246,7 +246,9 @@ def _maybe_duplicate_constant_nodes(
     copied_nodes = set()
     for candidate_node in candidate_nodes:
         # Both tagged exported program and the owning program need to go through the same duplication pass
-        copied_nodes = duplicate_constant_node(tagged_exported_program, candidate_node)
+        copied_nodes = copied_nodes.union(
+            duplicate_constant_node(tagged_exported_program, candidate_node)
+        )
         duplicate_constant_node(owning_program, candidate_node)
     candidate_node_with_copies = candidate_nodes.union(copied_nodes)
     _assign_new_tag(tagged_exported_program, candidate_node_with_copies)


### PR DESCRIPTION
Summary:
It's a bug, we need to keep union the original set with the new set from the for loop, however the original code just overwrite the original set. Test with coreml + llama code

```
python3 -m examples.models.llama2.export_llama --coreml --use_kv_cache
```

Differential Revision: D55680296


