### PR TITLE
Migrated profiler and scuba gen to bundled program

### DIFF
--- a/profiler/parse_profiler_results.py
+++ b/profiler/parse_profiler_results.py
@@ -434,21 +434,21 @@ def profile_framework_tax_table(
 
 def deserialize_profile_results_files(
     profile_results_path: str,
-    model_ff_path: str,
+    bundled_program_ff_path: str,
     time_scale: TimeScale = TimeScale.TIME_IN_NS,
 ):
     with open(profile_results_path, "rb") as prof_res_file, open(
-        model_ff_path, "rb"
+        bundled_program_ff_path, "rb"
     ) as model_ff_file:
         prof_res_buf = prof_res_file.read()
-        model_ff_buf = model_ff_file.read()
+        bundled_program_ff_buf = model_ff_file.read()
 
     prof_data, mem_allocations = deserialize_profile_results(prof_res_buf, time_scale)
     framework_tax_data = profile_aggregate_framework_tax(prof_data)
 
-    prof_tables = profile_table(prof_data, model_ff_buf)
+    prof_tables = profile_table(prof_data, bundled_program_ff_buf)
     for table in prof_tables:
-        print(table)
+        print(table)  # TODO(zonglin): implement pretty print
 
     prof_tables_agg = profile_framework_tax_table(framework_tax_data)
     for table in prof_tables_agg:


### PR DESCRIPTION
Summary: Currently the original program workflow is no longer compatible with the Executorch SDK for IO. This diff switches the profiler and scuba gen to bundled program from program.

Differential Revision: D55434851
