### PR TITLE
Android automate cmake build in gradle

### DIFF
--- a/build/test_android_ci.sh
+++ b/build/test_android_ci.sh
@@ -30,8 +30,7 @@ build_android_demo_app() {
 
 build_android_llama_demo_app() {
   pushd examples/demo-apps/android/LlamaDemo
-  ANDROID_NDK=/opt/ndk ANDROID_HOME=/opt/android/sdk ANDROID_ABI=arm64-v8a \
-      ./gradlew setup
+  ANDROID_NDK=/opt/ndk ANDROID_ABI=arm64-v8a ./gradlew setup
   ANDROID_HOME=/opt/android/sdk ./gradlew build
   popd
 }

--- a/build/test_android_ci.sh
+++ b/build/test_android_ci.sh
@@ -20,8 +20,6 @@ build_executorch() {
   rm -rf cmake-out && mkdir cmake-out
   ANDROID_NDK=/opt/ndk BUCK2=$(which buck2) FLATC=$(which flatc) ANDROID_ABI=arm64-v8a \
     bash examples/demo-apps/android/ExecuTorchDemo/setup.sh
-  ANDROID_NDK=/opt/ndk BUCK2=$(which buck2) FLATC=$(which flatc) ANDROID_ABI=arm64-v8a \
-    bash examples/demo-apps/android/LlamaDemo/setup.sh
 }
 
 build_android_demo_app() {
@@ -32,6 +30,7 @@ build_android_demo_app() {
 
 build_android_llama_demo_app() {
   pushd examples/demo-apps/android/LlamaDemo
+  ANDROID_HOME=/opt/android/sdk ./gradlew setup
   ANDROID_HOME=/opt/android/sdk ./gradlew build
   popd
 }

--- a/build/test_android_ci.sh
+++ b/build/test_android_ci.sh
@@ -30,7 +30,8 @@ build_android_demo_app() {
 
 build_android_llama_demo_app() {
   pushd examples/demo-apps/android/LlamaDemo
-  ANDROID_HOME=/opt/android/sdk ./gradlew setup
+  ANDROID_NDK=/opt/ndk ANDROID_HOME=/opt/android/sdk ANDROID_ABI=arm64-v8a \
+      ./gradlew setup
   ANDROID_HOME=/opt/android/sdk ./gradlew build
   popd
 }

--- a/examples/demo-apps/android/LlamaDemo/README.md
+++ b/examples/demo-apps/android/LlamaDemo/README.md
@@ -35,7 +35,7 @@ export ANDROID_ABI=arm64-v8a
 3. Run the following command set up the required JNI library:
 ```bash
 pushd examples/demo-apps/android/LlamaDemo
-./gradlew setup
+./gradlew :app:setup
 popd
 ```
 This is running the shell script [setup.sh](./setup.sh) which configures the required core ExecuTorch, LLAMA2, and Android libraries, builds them, and copy to jniLibs.
@@ -50,8 +50,7 @@ Without Android Studio UI, we can run gradle directly to build the app. We need 
 ```bash
 export ANDROID_HOME=<path_to_android_sdk_home>
 pushd examples/demo-apps/android/LlamaDemo
-./gradlew build
-adb install -t ./app/build/outputs/apk/debug/app-debug.apk
+./gradlew :app:installDebug
 popd
 ```
 

--- a/examples/demo-apps/android/LlamaDemo/README.md
+++ b/examples/demo-apps/android/LlamaDemo/README.md
@@ -41,8 +41,19 @@ popd
 This is running the shell script [setup.sh](./setup.sh) which configures the required core ExecuTorch, LLAMA2, and Android libraries, builds them, and copy to jniLibs.
 
 ## Build Java app
+### Alternative 1: Android Studio (Recommended)
 1. Open Android Studio and select "Open an existing Android Studio project" to open examples/demo-apps/android/LlamaDemo.
 2. Run the app (^R). This builds and launches the app on the phone.
+
+### Alternative 2: Command line
+Without Android Studio UI, we can run gradle directly to build the app. We need to set up the Android SDK path and invoke gradle.
+```bash
+export ANDROID_HOME=<path_to_android_sdk_home>
+pushd examples/demo-apps/android/LlamaDemo
+./gradlew build
+adb install -t ./app/build/outputs/apk/debug/app-debug.apk
+popd
+```
 
 On the phone or emulator, you can try running the model:
 <img src="../_static/img/android_llama_app.png" alt="Android LLaMA App" /><br>

--- a/examples/demo-apps/android/LlamaDemo/README.md
+++ b/examples/demo-apps/android/LlamaDemo/README.md
@@ -2,20 +2,10 @@
 
 This app demonstrates the use of the LLaMA chat app demonstrating local inference use case with ExecuTorch.
 
-::::{grid} 2
-:::{grid-item-card}  What you will learn
-:class-card: card-prerequisites
-* How to set up a build target for Android arm64-v8a
-* How to build the required ExecuTorch runtime, LLaMA runner, and JNI wrapper for Android
-* How to build the app with required JNI library
-:::
-:::{grid-item-card} Prerequisites
-:class-card: card-prerequisites
+## Prerequisites
 * Refer to [Setting up ExecuTorch](https://pytorch.org/executorch/stable/getting-started-setup) to set up the repo and dev environment.
 * Download and install [Android Studio and SDK](https://developer.android.com/studio).
 * Supported Host OS: CentOS, macOS Sonoma on Apple Silicon.
-:::
-::::
 
 ```{note}
 This demo app and tutorial has only been validated with arm64-v8a [ABI](https://developer.android.com/ndk/guides/abis), with NDK 25.
@@ -42,50 +32,13 @@ The demo app searches in `/data/local/tmp/llama` for .pte and .bin files as LLAM
 export ANDROID_NDK=<path_to_android_ndk>
 export ANDROID_ABI=arm64-v8a
 ```
-3. Run the following command to configure the CMake build:
+3. Run the following command set up the required JNI library:
 ```bash
-# Build the core ExecuTorch runtime library
-cmake . -DCMAKE_INSTALL_PREFIX=cmake-out \
-  -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
-  -DANDROID_ABI="${ANDROID_ABI}" \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DEXECUTORCH_BUILD_XNNPACK=ON \
-  -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
-  -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
-  -DEXECUTORCH_BUILD_OPTIMIZED=ON \
-  -Bcmake-out
-
-cmake --build cmake-out -j16 --target install --config Release
-
-# Build the llama2 runner library and custom ops
-cmake examples/models/llama2 \
-         -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
-         -DANDROID_ABI="$ANDROID_ABI" \
-         -DCMAKE_BUILD_TYPE=Release \
-         -DEXECUTORCH_BUILD_OPTIMIZED=ON \
-         -DCMAKE_INSTALL_PREFIX=cmake-out \
-         -Bcmake-out/examples/models/llama2
-
-cmake --build cmake-out/examples/models/llama2 -j16 --config Release
-
-# Build the Android JNI library
-cmake extension/android \
-  -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
-  -DANDROID_ABI="${ANDROID_ABI}" \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX=cmake-out \
-  -DEXECUTORCH_BUILD_LLAMA_JNI=ON \
-  -Bcmake-out/extension/android
-
-cmake --build cmake-out/extension/android -j16 --config Release
+pushd examples/demo-apps/android/LlamaDemo
+./gradlew setup
+popd
 ```
-
-4. Copy the built library to Java app jniLibs:
-```bash
-JNI_LIBS_PATH="examples/demo-apps/android/LlamaDemo/app/src/main/jniLibs"
-mkdir -p "${JNI_LIBS_PATH}/${ANDROID_ABI}"
-cp cmake-out/extension/android/libexecutorch_llama_jni.so "${JNI_LIBS_PATH}/${ANDROID_ABI}/"
-```
+This is running the shell script [setup.sh](./setup.sh) which configures the required core ExecuTorch, LLAMA2, and Android libraries, builds them, and copy to jniLibs.
 
 ## Build Java app
 1. Open Android Studio and select "Open an existing Android Studio project" to open examples/demo-apps/android/LlamaDemo.

--- a/examples/demo-apps/android/LlamaDemo/README.md
+++ b/examples/demo-apps/android/LlamaDemo/README.md
@@ -59,7 +59,7 @@ On the phone or emulator, you can try running the model:
 <img src="../_static/img/android_llama_app.png" alt="Android LLaMA App" /><br>
 
 ## Takeaways
-Through this tutorial we've learnt how to build the ExecuTorch LLAMA library with XNNPACK backend, and expose it to JNI layer to build the Android app.
+Through this tutorial we've learnt how to build the ExecuTorch LLAMA library, and expose it to JNI layer to build the Android app.
 
 ## Reporting Issues
 If you encountered any bugs or issues following this tutorial please file a bug/issue here on [Github](https://github.com/pytorch/executorch/issues/new).

--- a/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
+++ b/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
@@ -67,3 +67,12 @@ dependencies {
   debugImplementation("androidx.compose.ui:ui-tooling")
   debugImplementation("androidx.compose.ui:ui-test-manifest")
 }
+
+tasks.register("setup") {
+  doFirst {
+    exec {
+      commandLine("sh", "examples/demo-apps/android/LlamaDemo/setup.sh" )
+      workingDir("../../../../../")
+    }
+  }
+}

--- a/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
+++ b/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
 tasks.register("setup") {
   doFirst {
     exec {
-      commandLine("sh", "examples/demo-apps/android/LlamaDemo/setup.sh" )
+      commandLine("sh", "examples/demo-apps/android/LlamaDemo/setup.sh")
       workingDir("../../../../../")
     }
   }

--- a/examples/demo-apps/android/LlamaDemo/setup.sh
+++ b/examples/demo-apps/android/LlamaDemo/setup.sh
@@ -4,7 +4,6 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-
 set -eu
 
 CMAKE_OUT=cmake-out
@@ -12,11 +11,8 @@ CMAKE_OUT=cmake-out
 cmake . -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
   -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
   -DANDROID_ABI="${ANDROID_ABI}" \
-  -DBUCK2="${BUCK2}" \
   -DEXECUTORCH_BUILD_XNNPACK=ON \
-  -DEXECUTORCH_BUILD_FLATC=OFF \
   -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
-  -DFLATC_EXECUTABLE="${FLATC}" \
   -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
   -DEXECUTORCH_BUILD_OPTIMIZED=ON \
   -B"${CMAKE_OUT}"
@@ -28,7 +24,7 @@ else
 fi
 cmake --build "${CMAKE_OUT}" -j "${CMAKE_JOBS}" --target install
 
-cmake examples/models/llama2 -DBUCK2="${BUCK2}" \
+cmake examples/models/llama2 \
          -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
          -DANDROID_ABI="$ANDROID_ABI" \
          -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
@@ -36,7 +32,7 @@ cmake examples/models/llama2 -DBUCK2="${BUCK2}" \
 
 cmake --build "${CMAKE_OUT}"/examples/models/llama2 -j "${CMAKE_JOBS}"
 
-cmake extension/android -DBUCK2="${BUCK2}" \
+cmake extension/android \
   -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
   -DANDROID_ABI="${ANDROID_ABI}" \
   -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \

--- a/examples/demo-apps/android/LlamaDemo/setup.sh
+++ b/examples/demo-apps/android/LlamaDemo/setup.sh
@@ -4,9 +4,10 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
 set -eu
 
-CMAKE_OUT=cmake-out
+CMAKE_OUT="${CMAKE_OUT:-cmake-out}"
 # Note: Set up ANDROID_NDK, ANDROID_ABI, BUCK2, and FLATC
 cmake . -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
   -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \


### PR DESCRIPTION
Automatically invoke `examples/demo-apps/android/LlamaDemo/setup.sh` in `gradle setup` task. Users doesn't need to run examples/demo-apps/android/LlamaDemo/setup.sh manually.

Test (follow https://github.com/pytorch/executorch/blob/ba824577f495f7522cc9be91d38cf8ad187bc841/examples/demo-apps/android/LlamaDemo/README.md):
1. Fetch source
```
git fetch origin pull/2838/head
git checkout FETCH_HEAD
```
2. Push model
```
adb shell mkdir -p /data/local/tmp/llama
adb push llama2.pte /data/local/tmp/llama <--- Use your pte file
adb push tokenizer.bin /data/local/tmp/llama <--- Use your tokenizer.bin
```
3. Build JNI
```
export ANDROID_NDK=<path_to_android_ndk> <---- You can download NDK from https://developer.android.com/ndk/downloads
export ANDROID_ABI=arm64-v8a

pushd examples/demo-apps/android/LlamaDemo
./gradlew :app:setup
popd
```
4. Build app
* (Method 1) Open Android Studio and select "Open an existing Android Studio project" to open examples/demo-apps/android/LlamaDemo. Run the app (^R). This builds and launches the app on the phone.
* (Method 2)
```
export ANDROID_HOME=<path_to_android_sdk_home> <---- You can download SDK from https://developer.android.com/studio

pushd examples/demo-apps/android/LlamaDemo
./gradlew :app:installDebug
popd
```
