### PR TITLE
[Executorch][llama] Make pthreadpool not use GCD on apple platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,11 @@ if(EXECUTORCH_BUILD_PTHREADPOOL)
   set(PTHREADPOOL_ALLOW_DEPRECATED_API
       ON
       CACHE BOOL "")
+  if(APPLE)
+    set(PTHREADPOOL_SYNC_PRIMITIVE
+       "condvar"
+       CACHE STRING "")
+  endif()
   add_subdirectory("${PTHREADPOOL_SOURCE_DIR}")
 endif()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2839

My local M1 runs reveal that GCG was not great as a threadpool

Differential Revision: [D55712512](https://our.internmc.facebook.com/intern/diff/D55712512/)