### PR TITLE
Run strict=False for llama export flow

### DIFF
--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -280,6 +280,7 @@ class LlamaEdgeManager:
                 edge_constant_methods=metadata,
                 edge_compile_config=edge_config,
                 verbose=True,
+                strict=False,
             )
         return self
 


### PR DESCRIPTION
Summary:
For examples/models/llama folder, let's try using the strict=False mode.

For local testing, stories110M took 24seconds with strict=False and 45 seconds otherwise.

I wanna see if anything will fail in our internal and github CI testing

Differential Revision: D55714622


