### PR TITLE
change torchao version

### DIFF
--- a/examples/models/llama2/install_requirements.sh
+++ b/examples/models/llama2/install_requirements.sh
@@ -8,7 +8,7 @@
 # Install snakeviz for cProfile flamegraph
 # Install sentencepiece for llama tokenizer
 pip install snakeviz sentencepiece
-pip install torchao-nightly
+pip install torchao==0.1
 
 # Install lm-eval for Model Evaluation with lm-evalution-harness
 pip install lm-eval


### PR DESCRIPTION
Summary:
torchao released v0.1, this PR changes the version to torchao==0.1

Test Plan:

with-proxy python -m examples.models.llama2.eval_llama -c llama2-7b.pt -p llama2-7b-params.json -t llama2-7b-tok.model -d fp32 --calibration_seq_length 100 --calibration_limit 1 --limit 1 --tasks wikitext --max_seq_len 2048 --group_size 256 -qmode 8da4w

with-proxy python -m examples.models.llama2.eval_llama -c llama2-7b.pt -p llama2-7b-params.json -t llama2-7b-tok.model -d fp32 --calibration_seq_length 100 --calibration_limit 1 --limit 1 --tasks wikitext --max_seq_len 2048 --group_size 256 -qmode 8da4w-gptq

Reviewers:

Subscribers:

Tasks:

Tags: