### PR TITLE
Add a Python Wrapper that parses logits from llama_runner eval_mode

### DIFF
--- a/examples/models/llama2/llama_runner_lib.py
+++ b/examples/models/llama2/llama_runner_lib.py
@@ -1,0 +1,121 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+"""
+Thin wrapper around llama_runner to generate output
+"""
+
+import argparse
+import subprocess
+from argparse import Namespace
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+EVAL_HEADER = "=====START_EVAL====="
+EVAL_FOOTER = "=====END_EVAL====="
+
+
+@dataclass
+class LlamaRunnerResults:
+    logits: torch.Tensor
+    raw_results: str
+
+    prompt: Optional[str] = None
+
+
+def run_llama_runner(
+    model_path: str,
+    tokenizer_path: str,
+    prompt: str,
+) -> str:
+    args = [
+        "buck2",
+        "run",
+        "fbcode//executorch/examples/models/llama2:main",
+        "--",
+        "--model_path",
+        model_path,
+        "--tokenizer_path",
+        tokenizer_path,
+        "--prompt",
+        prompt,
+        "--eval_mode",
+    ]
+
+    # Run the command
+    output = subprocess.check_output(args)
+    return output.decode()
+
+
+def parse_results(result: str) -> None:
+    """
+    Parse the results from the output of the llama_runner
+    """
+    rows = result.split("\n")
+
+    header = rows.index(EVAL_HEADER) if EVAL_HEADER in rows else None
+    footer = rows.index(EVAL_FOOTER) if EVAL_FOOTER in rows else None
+    if header is None or footer is None:
+        raise ValueError("Could not find eval header or footer in results")
+    elif footer - header != 2:
+        raise ValueError("Expected 1 row of logits between eval header/footer")
+
+    logit_row = [float(logit) for logit in rows[header + 1].split()]
+    logits = torch.tensor(logit_row, dtype=torch.float32).view(1, -1, 32000)
+
+    return LlamaRunnerResults(logits=logits, raw_results=result)
+
+
+def get_llama_runner_result(
+    model_path: str,
+    tokenizer_path: str,
+    prompt: str,
+) -> LlamaRunnerResults:
+    """
+    Send the prompt to the llama_runner and parse the results
+    """
+    raw_result = run_llama_runner(
+        model_path,
+        tokenizer_path,
+        prompt,
+    )
+
+    parsed_results = parse_results(raw_result)
+    parse_results.prompt = prompt
+    return parsed_results
+
+
+def main(args: Namespace) -> None:
+    llama_results = get_llama_runner_result(
+        args.model_path,
+        args.tokenizer_path,
+        args.prompt,
+    )
+    print("Logits Shape: ", llama_results.logits.shape)
+
+
+def parse_args() -> Namespace:
+    """
+    Parse command line arguments.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model_path", type=str, help="Path of Executorch Model")
+    parser.add_argument(
+        "tokenizer_path", type=str, help="Path of Tokenizer to Feed the Model"
+    )
+    parser.add_argument(
+        "prompt", type=str, default="I like Chocolates", help="Prompt to Feed the Model"
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)

--- a/examples/models/llama2/main.cpp
+++ b/examples/models/llama2/main.cpp
@@ -83,10 +83,11 @@ int32_t main(int32_t argc, char** argv) {
   if (eval_mode) {
     eval_callback = [](const exec_aten::Tensor& logits_tensor) -> void {
       float* logits_data = logits_tensor.mutable_data_ptr<float>();
-      printf("\n(Logits: %zd)\n", logits_tensor.numel());
+      printf("\n=====START_EVAL=====\n");
       for (int i = 0; i < logits_tensor.numel(); ++i) {
         printf(" %f", logits_data[i]);
       }
+      printf("\n=====END_EVAL=====\n");
       exit(0);
     };
   }

--- a/examples/models/llama2/main.cpp
+++ b/examples/models/llama2/main.cpp
@@ -39,6 +39,11 @@ DEFINE_int32(
     -1,
     "Number of CPU threads for inference. Defaults to -1, which implies we'll use a heuristic to derive the # of performant cores for a specific device.");
 
+DEFINE_bool(
+    eval_mode,
+    false,
+    "Defaults to false. If enabled, output the logits after a single forward call for evaluation.");
+
 int32_t main(int32_t argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
@@ -57,6 +62,8 @@ int32_t main(int32_t argc, char** argv) {
 
   int32_t cpu_threads = FLAGS_cpu_threads;
 
+  bool eval_mode = FLAGS_eval_mode;
+
 #if defined(ET_USE_THREADPOOL)
   uint32_t num_performant_cores = cpu_threads == -1
       ? torch::executorch::cpuinfo::get_num_performant_cores()
@@ -71,8 +78,21 @@ int32_t main(int32_t argc, char** argv) {
   // create llama runner
   ::torch::executor::Runner runner(model_path, tokenizer_path, temperature);
 
+  // callback
+  std::function<void(const exec_aten::Tensor)> eval_callback = {};
+  if (eval_mode) {
+    eval_callback = [](const exec_aten::Tensor& logits_tensor) -> void {
+      float* logits_data = logits_tensor.mutable_data_ptr<float>();
+      printf("\n(Logits: %zd)\n", logits_tensor.numel());
+      for (int i = 0; i < logits_tensor.numel(); ++i) {
+        printf(" %f", logits_data[i]);
+      }
+      exit(0);
+    };
+  }
+
   // generate
-  runner.generate(prompt, seq_len);
+  runner.generate(prompt, seq_len, {}, {}, eval_callback);
 
   return 0;
 }

--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -211,7 +211,8 @@ Error Runner::generate(
     const std::string& prompt,
     int32_t seq_len,
     std::function<void(const std::string&)> token_callback,
-    std::function<void(const Stats&)> stats_callback) {
+    std::function<void(const Stats&)> stats_callback,
+    std::function<void(const exec_aten::Tensor&)> eval_callback) {
   // Prepare the inputs.
   // Use ones-initialized inputs.
   ET_CHECK_MSG(!prompt.empty(), "Prompt cannot be null");
@@ -369,6 +370,10 @@ Error Runner::generate(
 
     if (token_callback) {
       token_callback(piece);
+    }
+
+    if (eval_callback) {
+      eval_callback(logits_tensor);
     }
 
     if (shouldStop_) {

--- a/examples/models/llama2/runner/runner.h
+++ b/examples/models/llama2/runner/runner.h
@@ -63,7 +63,8 @@ class Runner {
       const std::string& prompt,
       int32_t seq_len = 128,
       std::function<void(const std::string&)> token_callback = {},
-      std::function<void(const Stats&)> stats_callback = {});
+      std::function<void(const Stats&)> stats_callback = {},
+      std::function<void(const exec_aten::Tensor&)> eval_callback = {});
   void stop();
 
  private:


### PR DESCRIPTION
Summary:
Added Llama_runner_lib.py which abstracts a Subprocess call to `llama_runner` in eval_mode.
* All the API takes is a .pte path, a tokenizer path, and a prompt to evaluate

It returns stdout from the llama_runner call, with special post processing for extracting the logits.
This is used to integrate with ET runtime evaluation

Differential Revision: D55659623
