### PR TITLE
[RELEASE-ONLY CHANGES] Make dequantize op schemas in ExecuTorch 0.2 compatible with PyTorch 2.3

### DIFF
--- a/kernels/quantized/quantized.yaml
+++ b/kernels/quantized/quantized.yaml
@@ -10,13 +10,13 @@
     - arg_meta: null
       kernel_name: torch::executor::choose_qparams_tensor_out
 
-- func: quantized_decomposed::dequantize_per_tensor.out(Tensor input, float scale, int zero_point, int quant_min, int quant_max, ScalarType dtype, *, ScalarType? out_dtype=None, Tensor(a!) out) -> Tensor(a!)
+- func: quantized_decomposed::dequantize_per_tensor.out(Tensor input, float scale, int zero_point, int quant_min, int quant_max, ScalarType dtype, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:
     - arg_meta: null
       kernel_name: torch::executor::dequantize_per_tensor_out
 
-- func: quantized_decomposed::dequantize_per_tensor.Tensor_out(Tensor input, Tensor scale, Tensor zero_point, int quant_min, int quant_max, ScalarType dtype, *, ScalarType? out_dtype=None, Tensor(a!) out) -> Tensor(a!)
+- func: quantized_decomposed::dequantize_per_tensor.Tensor_out(Tensor input, Tensor scale, Tensor zero_point, int quant_min, int quant_max, ScalarType dtype, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:
     - arg_meta: null
@@ -28,7 +28,7 @@
     - arg_meta: null
       kernel_name: torch::executor::quantize_per_channel_out
 
-- func: quantized_decomposed::dequantize_per_channel.out(Tensor input, Tensor scales, Tensor? zero_points, int axis, int quant_min, int quant_max, ScalarType dtype, *, ScalarType? out_dtype=None, Tensor(a!) out) -> Tensor(a!)
+- func: quantized_decomposed::dequantize_per_channel.out(Tensor input, Tensor scales, Tensor zero_points, int axis, int quant_min, int quant_max, ScalarType dtype, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:
     - arg_meta: null

--- a/kernels/quantized/test/op_add_test.cpp
+++ b/kernels/quantized/test/op_add_test.cpp
@@ -20,7 +20,6 @@
 
 using namespace ::testing;
 using exec_aten::ArrayRef;
-using exec_aten::optional;
 using exec_aten::RuntimeContext;
 using exec_aten::Scalar;
 using exec_aten::ScalarType;
@@ -191,8 +190,6 @@ TEST(OpQuantizeAddTest, ConsitencyWithReferencePattern) {
   Tensor qinput2 = tfo.zeros({3, 5});
   Tensor qoutput = tfo.zeros({3, 5});
 
-  optional<ScalarType> out_dtype = optional<ScalarType>();
-
   RuntimeContext context{};
   // q -> qadd -> dq
   // 3.5 / 0.5 + 1 = 8
@@ -238,7 +235,6 @@ TEST(OpQuantizeAddTest, ConsitencyWithReferencePattern) {
       quant_min,
       quant_max,
       ScalarType::Byte,
-      out_dtype,
       reference_op_output);
 
   // now get results for q -> dq -> fp add -> q -> dq
@@ -249,7 +245,6 @@ TEST(OpQuantizeAddTest, ConsitencyWithReferencePattern) {
       quant_min,
       quant_max,
       ScalarType::Byte,
-      out_dtype,
       dq_input1);
 
   dequantize_per_tensor_out(
@@ -259,7 +254,6 @@ TEST(OpQuantizeAddTest, ConsitencyWithReferencePattern) {
       quant_min,
       quant_max,
       ScalarType::Byte,
-      out_dtype,
       dq_input2);
 
   add_out(context, dq_input1, dq_input2, 1.0, fp_output);
@@ -280,7 +274,6 @@ TEST(OpQuantizeAddTest, ConsitencyWithReferencePattern) {
       quant_min,
       quant_max,
       ScalarType::Byte,
-      out_dtype,
       reference_pattern_output);
 
   Tensor expected = tf.full({3, 5}, 7.0);

--- a/kernels/quantized/test/op_dequantize_test.cpp
+++ b/kernels/quantized/test/op_dequantize_test.cpp
@@ -18,7 +18,6 @@
 
 using namespace ::testing;
 using exec_aten::ArrayRef;
-using exec_aten::optional;
 using exec_aten::Scalar;
 using exec_aten::ScalarType;
 using exec_aten::Tensor;
@@ -44,14 +43,7 @@ void test_dtype() {
   // (100 - 30) * 0.5
   Tensor expected = tfo.full({3, 5}, 35);
   dequantize_per_tensor_out(
-      input,
-      scale,
-      zero_point,
-      quant_min,
-      quant_max,
-      DTYPE,
-      optional<ScalarType>(),
-      out);
+      input, scale, zero_point, quant_min, quant_max, DTYPE, out);
 
   EXPECT_TENSOR_EQ(out, expected);
 }
@@ -74,14 +66,7 @@ TEST(OpDequantizeOutTest, NonWholeNumbers) {
   // (100 - 30) * 0.5
   Tensor expected = tfo.full({3, 5}, 31.5);
   dequantize_per_tensor_out(
-      input,
-      scale,
-      zero_point,
-      quant_min,
-      quant_max,
-      ScalarType::Byte,
-      optional<ScalarType>(),
-      out);
+      input, scale, zero_point, quant_min, quant_max, ScalarType::Byte, out);
 
   EXPECT_TENSOR_EQ(out, expected);
 }
@@ -102,14 +87,7 @@ TEST(OpDequantizeOutTest, TensorArgOverload) {
   // (100 - 30) * 0.5
   Tensor expected = tfo.full({3, 5}, 31.5);
   dequantize_per_tensor_tensor_args_out(
-      input,
-      scale,
-      zero_point,
-      quant_min,
-      quant_max,
-      ScalarType::Byte,
-      optional<ScalarType>(),
-      out);
+      input, scale, zero_point, quant_min, quant_max, ScalarType::Byte, out);
 
   EXPECT_TENSOR_EQ(out, expected);
 }
@@ -138,7 +116,6 @@ TEST(OpDequantizeOutTest, DequantizePerChannel) {
       quant_min,
       quant_max,
       ScalarType::Byte,
-      optional<ScalarType>(),
       out);
 
   EXPECT_TENSOR_EQ(out, expected);
@@ -159,7 +136,6 @@ TEST(OpDequantizeOutTest, DequantizePerChannel) {
       quant_min,
       quant_max,
       ScalarType::Byte,
-      optional<ScalarType>(),
       out);
 
   EXPECT_TENSOR_EQ(out, expected);

--- a/kernels/quantized/test/op_embedding_test.cpp
+++ b/kernels/quantized/test/op_embedding_test.cpp
@@ -20,7 +20,6 @@
 
 using namespace ::testing;
 using exec_aten::ArrayRef;
-using exec_aten::optional;
 using exec_aten::RuntimeContext;
 using exec_aten::Scalar;
 using exec_aten::ScalarType;
@@ -150,7 +149,6 @@ TEST(OpQuantizedEmbeddingTest, ConsitencyWithReferencePattern) {
       quant_min,
       quant_max,
       ScalarType::Byte,
-      optional<ScalarType>(),
       weight);
 
   embedding_out(


### PR DESCRIPTION
Reverts the schemas of dequantize ops, so that they are compatible in ExecuTorch release 0.2 with PyTorch release 2.3
The changes reverted are the ones introduced in https://github.com/pytorch/executorch/pull/2308 and https://github.com/pytorch/executorch/pull/2364, which will continue to be present in the main branch, but will be excluded from release 0.2