### PR TITLE
Fix llama runner mac CI jobs

### DIFF
--- a/.ci/scripts/test_llama.sh
+++ b/.ci/scripts/test_llama.sh
@@ -139,6 +139,7 @@ if [[ "${MODE}" == "xnnpack+kv+custom" ]]; then
 fi
 # Add dynamically linked library location
 export LD_LIBRARY_PATH=${PWD}/cmake-out/lib
+export DYLD_LIBRARY_PATH=${PWD}/cmake-out/lib
 $PYTHON_EXECUTABLE -m examples.models.llama2.export_llama ${EXPORT_ARGS}
 
 # Create tokenizer.bin.


### PR DESCRIPTION
In MacOS python will go look for `DYLD_LIBRARY_PATH` instead of `LD_LIBRARY_PATH` so add that fixes the CI failures.