### PR TITLE
Add static module extension target

### DIFF
--- a/extension/module/CMakeLists.txt
+++ b/extension/module/CMakeLists.txt
@@ -29,6 +29,14 @@ target_include_directories(extension_module PUBLIC ${EXECUTORCH_ROOT}/..)
 target_compile_options(extension_module PUBLIC -Wno-deprecated-declarations
                                                -fPIC)
 
+# Module extension built as a static library.
+# TODO(gjcomer) Remove this target after cleaning up CMake targets.
+add_library(extension_module_static STATIC ${_extension_module__srcs})
+target_link_libraries(extension_module_static PRIVATE executorch extension_data_loader)
+target_include_directories(extension_module_static PUBLIC ${EXECUTORCH_ROOT}/..)
+target_compile_options(extension_module_static PUBLIC -Wno-deprecated-declarations
+                                               -fPIC)
+
 # Install libraries
 install(
   TARGETS extension_module


### PR DESCRIPTION
Add an module extension target always built as a static library. This is a hacky workaround to the fact that the llama runner currently relies on some fragile linking behavior and requires consuming the module extension as a static lib. However, the nanogpt_runner needs to consume it as a static lib to avoid duplicate primitive op registration. I'm not 100% clear on why llama runner doesn't hit this yet. Maybe something to do with the primitive op -> executorch -> llama_runner -> llama_main chain having a top level target that doesn't reference the core executorch dependency leading to it not being pulled in at the top level?

Anyway, this new target will be removed once we refactor the CMake build post-alpha. Note that by adding a completely new target, this should cause no regressions and should be safe to land.