### PR TITLE
[executorch] Use __ET_UNLIKELY in assertion macros

### DIFF
--- a/runtime/platform/assert.h
+++ b/runtime/platform/assert.h
@@ -35,7 +35,7 @@
  */
 #define ET_CHECK_MSG(_cond, _format, ...)                               \
   ({                                                                    \
-    if (!(_cond)) {                                                     \
+    if __ET_UNLIKELY (!(_cond)) {                                       \
       ET_ASSERT_MESSAGE_EMIT(" (%s): " _format, #_cond, ##__VA_ARGS__); \
       torch::executor::runtime_abort();                                 \
     }                                                                   \
@@ -49,7 +49,7 @@
  */
 #define ET_CHECK(_cond)                       \
   ({                                          \
-    if (!(_cond)) {                           \
+    if __ET_UNLIKELY (!(_cond)) {             \
       ET_ASSERT_MESSAGE_EMIT(": %s", #_cond); \
       torch::executor::runtime_abort();       \
     }                                         \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2949

It is supposed to be unlikely for assert/check conditions to fail; let's tell the compiler about that.

Differential Revision: [D55929730](https://our.internmc.facebook.com/intern/diff/D55929730/)