### PR TITLE
remove duplicate generate_lib_aten target under aten kernel

### DIFF
--- a/examples/models/llama2/runner/targets.bzl
+++ b/examples/models/llama2/runner/targets.bzl
@@ -2,7 +2,7 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 def _get_operator_lib(aten = False):
     if aten:
-        return ["//executorch/kernels/aten:generated_lib_aten"]
+        return ["//executorch/kernels/aten:generated_lib"]
     elif runtime.is_oss:
         return ["//executorch/kernels/portable:generated_lib", "//executorch/examples/models/llama2/custom_ops:custom_ops"]
     else:

--- a/kernels/aten/targets.bzl
+++ b/kernels/aten/targets.bzl
@@ -35,18 +35,3 @@ def define_common_targets():
             "@EXECUTORCH_CLIENTS",
         ],
     )
-
-    # TODO(T149415783): temporarily testing portable kernel "in aten mode" and remove after migration is done
-    executorch_generated_lib(
-        name = "generated_lib_aten",
-        aten_mode = True,
-        deps = [
-            ":executorch_aten_ops",
-        ],
-        functions_yaml_target = None,
-        define_static_targets = True,
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
-    )

--- a/shim/xplat/executorch/extension/pybindings/pybindings.bzl
+++ b/shim/xplat/executorch/extension/pybindings/pybindings.bzl
@@ -37,7 +37,7 @@ ATEN_MODULE_DEPS = [
 # Generated lib for all ATen ops with aten kernel used by models in model inventory
 MODELS_ATEN_OPS_ATEN_MODE_GENERATED_LIB = [
     "//executorch/kernels/quantized:generated_lib_aten",
-    "//executorch/kernels/aten:generated_lib_aten",
+    "//executorch/kernels/aten:generated_lib",
 ]
 
 def executorch_pybindings(python_module_name, srcs = [], cppdeps = [], visibility = ["//executorch/..."], types = [], compiler_flags = []):


### PR DESCRIPTION
Summary: generate_lib and generate_lib_aten are exactly the same under executorch/kernels/aten. Remove the generate_lib_aten for better understanding.

Differential Revision: D55937122


