### PR TITLE
Consolidate tokenizer interface

### DIFF
--- a/examples/models/llama2/tokenizer/test/test_tokenizer.cpp
+++ b/examples/models/llama2/tokenizer/test/test_tokenizer.cpp
@@ -9,6 +9,7 @@
 #include <executorch/examples/models/llama2/tokenizer/tokenizer.h>
 #include <executorch/runtime/platform/runtime.h>
 #include <gtest/gtest.h>
+#include <vector>
 
 using namespace ::testing;
 
@@ -28,8 +29,8 @@ class TokenizerExtensionTest : public Test {
 };
 
 TEST_F(TokenizerExtensionTest, EncodeWithoutLoadFails) {
-  Error error = tokenizer_->encode("hello world", 0, 0, nullptr, nullptr);
-  EXPECT_EQ(error, Error::NotSupported);
+  Result<std::vector<uint64_t>> res = tokenizer_->encode("hello world", 0, 0);
+  EXPECT_EQ(res.error(), Error::NotSupported);
 }
 
 TEST_F(TokenizerExtensionTest, DecodeWithoutLoadFails) {

--- a/examples/models/llama2/tokenizer/tokenizer.h
+++ b/examples/models/llama2/tokenizer/tokenizer.h
@@ -16,6 +16,7 @@
 #include <cstring>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
@@ -32,37 +33,33 @@ struct TokenIndex {
 
 class Tokenizer {
  public:
-  explicit Tokenizer(int32_t vocab_size, int32_t bos_tok, int32_t eos_tok);
+  explicit Tokenizer(int32_t vocab_size, uint64_t bos_tok, uint64_t eos_tok);
   ~Tokenizer();
 
   Error load(const std::string& tokenizer_path);
 
-  Error encode(
-      const char* text,
-      int8_t bos,
-      int8_t eos,
-      int32_t* tokens,
-      int32_t* n_tokens);
+  Result<std::vector<uint64_t>>
+  encode(const std::string& input, int8_t bos, int8_t eos);
 
-  Result<const char*> decode(int prev_token, int token);
+  Result<std::string> decode(uint64_t prev_token, uint64_t token);
 
   // getters
   int32_t vocab_size() const {
     return vocab_size_;
   }
 
-  int32_t bos_tok() const {
+  uint64_t bos_tok() const {
     return bos_tok_;
   }
 
-  int32_t eos_tok() const {
+  uint64_t eos_tok() const {
     return eos_tok_;
   }
 
  private:
   bool initialized_;
   const int32_t vocab_size_;
-  int32_t bos_tok_, eos_tok_;
+  uint64_t bos_tok_, eos_tok_;
   std::unique_ptr<char*[]> vocab_;
   std::unique_ptr<float[]> vocab_scores_;
   std::unique_ptr<TokenIndex[]> sorted_vocab_;


### PR DESCRIPTION
Summary:
Change the tokenizer APIs to:

```
Result<std::vector<uint64_t>> encode(const std::string& input, int8_t bos, int8_t eos);
Result<std::string> decode(uint64_t prev_token, uint64_t token);
```

Notice that: we use `uint64_t` for token id just to be safe. We return a std::vector of tokens for encode() API.

Differential Revision: D55944780


