### PR TITLE
Fix pip wheel build jobs

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -23,3 +23,14 @@
 
 [parser]
   target_platform_detector_spec = target:root//...->prelude//platforms:default target:shim//...->prelude//platforms:default
+
+# Limit the number of files that the buck daemon needs to monitor. If every
+# submodule is cloned recursively, some system can fail to build with "OS file
+# watch limit reached".
+[project]
+  ignore = \
+      .git, \
+      **/.git, \
+      third-party/pytorch/third_party, \
+      cmake-out, \
+      pip-out

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -54,6 +54,7 @@ jobs:
       # "recursive" default to do less work, and to give the buck daemon fewer
       # files to look at.
       submodules: true
+      env-var-script: build/packaging/env_var_script_linux.sh
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -50,6 +50,10 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: release/2.3
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      # ExecuTorch only needs the first layer of submodules; override the
+      # "recursive" default to do less work, and to give the buck daemon fewer
+      # files to look at.
+      submodules: true
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -54,6 +54,7 @@ jobs:
       # "recursive" default to do less work, and to give the buck daemon fewer
       # files to look at.
       submodules: true
+      env-var-script: build/packaging/env_var_script_m1.sh
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -50,6 +50,10 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: release/2.3
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      # ExecuTorch only needs the first layer of submodules; override the
+      # "recursive" default to do less work, and to give the buck daemon fewer
+      # files to look at.
+      submodules: true
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}

--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -213,6 +213,12 @@ function(resolve_buck2)
           PARENT_SCOPE)
     endif()
   endif()
+
+  # The buck2 daemon can get stuck. Killing it can help.
+  message(STATUS "Killing buck2 daemon")
+  execute_process(
+    COMMAND "${BUCK2} kill"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endfunction()
 
 # Sets the value of the PYTHON_EXECUTABLE variable to 'python' if in an active

--- a/build/packaging/env_var_script_linux.sh
+++ b/build/packaging/env_var_script_linux.sh
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This file is sourced into the environment before building a pip wheel. It
+# should typically only contain shell variable assignments. Be sure to export
+# any variables so that subprocesses will see them.
+
+# Enable pybindings so that users can execute ExecuTorch programs from python.
+export EXECUTORCH_BUILD_PYBIND=1
+
+# Ensure that CMAKE_ARGS is defined before referencing it. Defaults to empty
+# if not defined.
+export CMAKE_ARGS="${CMAKE_ARGS:-}"
+
+# Link the XNNPACK backend into the pybindings runtime so that users can execute
+# ExecuTorch programs that delegate to it.
+CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_XNNPACK=ON"

--- a/build/packaging/env_var_script_m1.sh
+++ b/build/packaging/env_var_script_m1.sh
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This file is sourced into the environment before building a pip wheel. It
+# should typically only contain shell variable assignments. Be sure to export
+# any variables so that subprocesses will see them.
+
+# Enable pybindings so that users can execute ExecuTorch programs from python.
+export EXECUTORCH_BUILD_PYBIND=1
+
+# Ensure that CMAKE_ARGS is defined before referencing it. Defaults to empty
+# if not defined.
+export CMAKE_ARGS="${CMAKE_ARGS:-}"
+
+# Link the XNNPACK backend into the pybindings runtime so that users can execute
+# ExecuTorch programs that delegate to it.
+CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_XNNPACK=ON"
+
+# When building for macOS, link additional backends into the pybindings runtime.
+
+# TODO(dbort): Core ML requires features only available in macOS 10.15, but the
+# build machine uses an older version.
+# CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_COREML=ON"
+
+CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_MPS=ON"

--- a/build/packaging/pre_build_script.sh
+++ b/build/packaging/pre_build_script.sh
@@ -5,6 +5,21 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-set -eux
+set -euxo pipefail
 
-echo "This script is run before building ExecuTorch binaries"
+# This script is run before building ExecuTorch binaries
+
+# Manually install build requirements because `python setup.py bdist_wheel` does
+# not install them. TODO(dbort): Switch to using `python -m build --wheel`,
+# which does install them. Though we'd need to disable build isolation to be
+# able to see the installed torch package.
+readonly BUILD_DEPS=(
+  # This list must match the build-system.requires list from pyproject.toml.
+  "cmake"
+  "pyyaml"
+  "setuptools"
+  "tomli"
+  "wheel"
+  "zstd"
+)
+pip install --progress-bar off "${BUILD_DEPS[@]}"

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -70,6 +70,7 @@ EXIR_REQUIREMENTS=(
 # pip packages needed for development.
 DEVEL_REQUIREMENTS=(
   cmake  # For building binary targets.
+  pyyaml  # Imported by the kernel codegen tools.
   setuptools  # For building the pip package.
   tomli  # Imported by extract_sources.py when using python < 3.11.
   wheel  # For building the pip package archive.

--- a/kernels/portable/cpu/op_isinf.cpp
+++ b/kernels/portable/cpu/op_isinf.cpp
@@ -14,8 +14,18 @@ namespace torch {
 namespace executor {
 namespace native {
 
+namespace {
+// Passing std::isinf directly to unary_ufunc_realhb_to_bool can cause "error:
+// cannot resolve overloaded function ‘isinf’ based on conversion to type
+// ‘torch::executor::FunctionRef<bool(double)>’" in some compilation
+// environments.
+bool isinf_wrapper(double num) {
+  return std::isinf(num);
+}
+} // namespace
+
 Tensor& isinf_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realhb_to_bool(std::isinf, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_bool(isinf_wrapper, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_isnan.cpp
+++ b/kernels/portable/cpu/op_isnan.cpp
@@ -14,8 +14,18 @@ namespace torch {
 namespace executor {
 namespace native {
 
+namespace {
+// Passing std::isnan directly to unary_ufunc_realhb_to_bool can cause "error:
+// cannot resolve overloaded function ‘isnan’ based on conversion to type
+// ‘torch::executor::FunctionRef<bool(double)>’" in some compilation
+// environments.
+bool isnan_wrapper(double num) {
+  return std::isnan(num);
+}
+} // namespace
+
 Tensor& isnan_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realhb_to_bool(std::isnan, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_bool(isnan_wrapper, ctx, in, out);
 }
 
 } // namespace native

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,20 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = [
+  "cmake",  # For building binary targets in the wheel.
+  "pyyaml",  # Imported by the kernel codegen tools.
+  "setuptools",  # For building the pip package contents.
+  "tomli",  # Imported by extract_sources.py when using python < 3.11.
+  "wheel",  # For building the pip package archive.
+  "zstd",  # Imported by resolve_buck.py.
+]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "executorch"
-version = "0.1.0"
+# TODO(dbort): Use setuptools-git-versioning or setuptools-scm to get the
+# version from the git branch state. For now, use a version that doesn't look
+# like a real release.
+version = "0.2.0.dev0+unknown"
 # Python dependencies required for development
 dependencies=[
   "expecttest",

--- a/setup.py
+++ b/setup.py
@@ -398,7 +398,17 @@ class CustomBuild(build):
         if not self.dry_run:
             # Dry run should log the command but not actually run it.
             (Path(cmake_cache_dir) / "CMakeCache.txt").unlink(missing_ok=True)
-        self.spawn(["cmake", "-S", repo_root, "-B", cmake_cache_dir, *cmake_args])
+        try:
+            # This script is sometimes run as root in docker containers. buck2
+            # doesn't allow running as root unless $HOME is owned by root or
+            # does not exist. So temporarily undefine it while configuring
+            # cmake, which runs buck2 to get some source lists.
+            old_home = os.environ.pop("HOME", None)
+            # Generate the build system files.
+            self.spawn(["cmake", "-S", repo_root, "-B", cmake_cache_dir, *cmake_args])
+        finally:
+            if old_home is not None:
+                os.environ["HOME"] = old_home
 
         # Build the system.
         self.spawn(["cmake", "--build", cmake_cache_dir, *build_args])

--- a/setup.py
+++ b/setup.py
@@ -83,11 +83,6 @@ class ShouldBuild:
     def pybindings(cls) -> bool:
         return cls._is_env_enabled("EXECUTORCH_BUILD_PYBIND", default=False)
 
-    @classmethod
-    @property
-    def xnnpack(cls) -> bool:
-        return cls._is_env_enabled("EXECUTORCH_BUILD_XNNPACK", default=False)
-
 
 class _BaseExtension(Extension):
     """A base class that maps an abstract source to an abstract destination."""
@@ -372,13 +367,9 @@ class CustomBuild(build):
                 "-DEXECUTORCH_BUILD_PYBIND=ON",
             ]
             build_args += ["--target", "portable_lib"]
-            if ShouldBuild.xnnpack:
-                cmake_args += [
-                    "-DEXECUTORCH_BUILD_XNNPACK=ON",
-                ]
-                # No target needed; the cmake arg will link xnnpack
-                # into the portable_lib target.
-            # TODO(dbort): Add MPS/CoreML backends when building on macos.
+            # To link backends into the portable_lib target, callers should
+            # add entries like `-DEXECUTORCH_BUILD_XNNPACK=ON` to the CMAKE_ARGS
+            # environment variable.
 
         # Allow adding extra cmake args through the environment. Used by some
         # tests and demos to expand the set of targets included in the pip


### PR DESCRIPTION
These pip dependencies need to be present to build the pip wheel.

Also, change the version to a stub that looks less like a real version, until we can hook up the logic to get the version from the git repo state.