### PR TITLE
Handle multiple memory IDs using pid

### DIFF
--- a/util/activation_memory_profiler.py
+++ b/util/activation_memory_profiler.py
@@ -54,6 +54,8 @@ def create_tensor_allocation_info(graph: torch.fx.Graph) -> List[MemoryTimeline]
     nodes = graph.nodes
     memory_timeline = [None] * len(nodes)
     for i, node in enumerate(nodes):
+        if node.op == "output":
+            continue
         if node.target == memory.alloc:
             continue
         tensor_specs = get_node_tensor_specs(node)


### PR DESCRIPTION
Summary:
Handle multiple memory IDs by dumping them into different processes in trace view. This solution seemed the simplest, and since the time stamps match between processes it should be fairly straightforward to look through 

An alternate solution I attempted was to place different memory spaces across each other separated by some horizontal "space". However, it quickly became ugly/difficult to differentiate which allocation was on which memory space - I think the above solution is probably the easier one to read.

Reviewed By: kimishpatel, hsharma35

Differential Revision: D55494986


