### PR TITLE
Core ML Has Added `Index_Put` Support, No Need to Skip Anymore

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -605,9 +605,6 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
         partitioners.append(
             # pyre-ignore: Undefined attribute [16]: Module `executorch.backends` has no attribute `apple`
             CoreMLPartitioner(
-                skip_ops_for_coreml_delegation=[
-                    "aten.index_put.default",
-                ],
                 compile_specs=compile_specs,
             )
         )


### PR DESCRIPTION
It was a workaround to skip `aten.index_put` op in Core ML delegation, at the cost of partitioning the Llama model into 13 pieces.

For better performance, we prefer to delegate the whole model to Core ML. Since Core ML has added the [necessary support](https://github.com/apple/coremltools/pull/2190), it is time to revert this workaround