### PR TITLE
[CoreML Backend] Handle missing data types.

### DIFF
--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -13,6 +13,8 @@ if(NOT EXECUTORCH_ROOT)
   set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 endif()
 
+option(COREML_BUILD_EXECUTOR_RUNNER "Build CoreML executor runner." OFF)
+
 # inmemoryfs sources
 set(INMEMORYFS_SOURCES
   runtime/inmemoryfs/inmemory_filesystem.cpp
@@ -180,6 +182,14 @@ target_link_libraries(coremldelegate
   ${FOUNDATION_FRAMEWORK}
   ${SQLITE_LIBRARY}
 )
+
+if(COREML_BUILD_EXECUTOR_RUNNER)
+target_link_libraries(coremldelegate
+  PRIVATE
+  portable_ops_lib
+  portable_kernels
+)
+endif()
 
 target_compile_options(coremldelegate PRIVATE "-fobjc-arc")
 target_compile_options(coremldelegate PRIVATE "-fno-exceptions")

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLAssetManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLAssetManager.mm
@@ -630,7 +630,7 @@ get_assets_to_remove(ModelAssetsStore& store,
     }
     
     if (_estimatedSizeInBytes <= sizeInBytes) {
-        return YES;
+        return _estimatedSizeInBytes;
     }
     
     std::error_code ec;

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLDefaultModelExecutor.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLDefaultModelExecutor.h
@@ -28,6 +28,9 @@ __attribute__((objc_subclassing_restricted))
 /// The model.
 @property (readonly, strong, nonatomic) ETCoreMLModel* model;
 
+/// If set to `YES` then output backing are ignored.
+@property (readwrite, atomic) BOOL ignoreOutputBackings;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLDefaultModelExecutor.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLDefaultModelExecutor.mm
@@ -26,6 +26,9 @@
                                               loggingOptions:(const executorchcoreml::ModelLoggingOptions& __unused)loggingOptions
                                                  eventLogger:(const executorchcoreml::ModelEventLogger* _Nullable __unused)eventLogger
                                                        error:(NSError * __autoreleasing *)error {
+    if (self.ignoreOutputBackings) {
+        predictionOptions.outputBackings = @{};
+    }
     id<MLFeatureProvider> outputs = [self.model.mlModel predictionFromFeatures:inputs
                                                                        options:predictionOptions
                                                                          error:error];

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLLogging.h
@@ -7,6 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import <executorch/runtime/platform/log.h>
 #import <os/log.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -48,7 +49,11 @@ typedef NS_ERROR_ENUM(ETCoreMLErrorDomain, ETCoreMLError) {
 
 /// Record the error with `os_log_error` and fills `*errorOut` with `NSError`.
 #define ETCoreMLLogErrorAndSetNSError(errorOut, errorCode, formatString, ...)                                        \
-    os_log_error(ETCoreMLErrorUtils.loggingChannel, formatString, ##__VA_ARGS__);                                    \
+    if (ET_LOG_ENABLED) {                                                                                            \
+        ET_LOG(Error, "%s", [NSString stringWithFormat:@formatString, ##__VA_ARGS__].UTF8String);                    \
+    } else {                                                                                                         \
+        os_log_error(ETCoreMLErrorUtils.loggingChannel, formatString, ##__VA_ARGS__);                                \
+    }                                                                                                                \
     if (errorOut) {                                                                                                  \
         *errorOut =                                                                                                  \
             [NSError errorWithDomain:ETCoreMLErrorDomain                                                             \
@@ -58,24 +63,31 @@ typedef NS_ERROR_ENUM(ETCoreMLErrorDomain, ETCoreMLError) {
                             }];                                                                                      \
     }
 
-/// Record the error and its underlying error with `os_log_error` and fills
-/// `*errorOut` with NSError.
+/// Record the error and its underlying error with `os_log_error` and fills `*errorOut` with `NSError`.
 #define ETCoreMLLogUnderlyingErrorAndSetNSError(errorOut, errorCode, underlyingNSError, formatString, ...) \
-    os_log_error(ETCoreMLErrorUtils.loggingChannel,                                                        \
-                 formatString ", with underlying error= %@.",                                              \
-                 ##__VA_ARGS__,                                                                            \
-                 (underlyingNSError).localizedDescription);                                                \
+    if (ET_LOG_ENABLED) {                                                                                  \
+        ET_LOG(Error, "%s", [NSString stringWithFormat:@formatString, ##__VA_ARGS__].UTF8String);          \
+    } else {                                                                                               \
+        os_log_error(ETCoreMLErrorUtils.loggingChannel,                                                    \
+                     formatString ", with underlying error= %@.",                                          \
+                     ##__VA_ARGS__,                                                                        \
+                     (underlyingNSError).localizedDescription);                                            \
+    }                                                                                                      \
     if (errorOut) {                                                                                        \
         *errorOut = [ETCoreMLErrorUtils errorWithCode:errorCode                                            \
                                       underlyingError:underlyingNSError                                    \
                                                format:@formatString, ##__VA_ARGS__];                       \
     }
 
-#define ETCoreMLLogError(error, formatString, ...)  \
-    os_log_error(ETCoreMLErrorUtils.loggingChannel, \
-                 formatString ", with error= %@.",  \
-                 ##__VA_ARGS__,                     \
-                 (error).localizedDescription);
+#define ETCoreMLLogError(error, formatString, ...)                                                \
+    if (ET_LOG_ENABLED) {                                                                         \
+        ET_LOG(Error, "%s", [NSString stringWithFormat:@formatString, ##__VA_ARGS__].UTF8String); \
+    } else {                                                                                      \
+        os_log_error(ETCoreMLErrorUtils.loggingChannel,                                           \
+                     formatString ", with error= %@.",                                            \
+                     ##__VA_ARGS__,                                                               \
+                     (error).localizedDescription);                                               \
+    }
 
 
 #pragma clang diagnostic pop

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModel.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModel.h
@@ -6,12 +6,18 @@
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
 #import <CoreML/CoreML.h>
+#import <vector>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class ETCoreMLAsset;
 
+namespace executorchcoreml {
+class MultiArray;
+}
+
 /// Represents a ML model, the class is a thin wrapper over `MLModel` with additional properties.
+__attribute__((objc_subclassing_restricted))
 @interface ETCoreMLModel : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -30,6 +36,12 @@ NS_ASSUME_NONNULL_BEGIN
                      orderedInputNames:(NSOrderedSet<NSString*>*)orderedInputNames
                     orderedOutputNames:(NSOrderedSet<NSString*>*)orderedOutputNames
                                  error:(NSError* __autoreleasing*)error NS_DESIGNATED_INITIALIZER;
+
+- (nullable NSArray<MLMultiArray*>*)prepareInputs:(const std::vector<executorchcoreml::MultiArray>&)inputs
+                                            error:(NSError* __autoreleasing*)error;
+
+- (nullable NSArray<MLMultiArray*>*)prepareOutputBackings:(const std::vector<executorchcoreml::MultiArray>&)outputs
+                                                    error:(NSError* __autoreleasing*)error;
 
 /// The underlying MLModel.
 @property (strong, readonly, nonatomic) MLModel* mlModel;

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModel.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModel.mm
@@ -8,6 +8,164 @@
 #import <ETCoreMLModel.h>
 
 #import <ETCoreMLAsset.h>
+#import <functional>
+#import <objc_array_util.h>
+#import <multiarray.h>
+#import <numeric>
+
+#pragma mark - ETCoreMLMultiArrayDescriptor
+__attribute__((objc_subclassing_restricted))
+@interface ETCoreMLMultiArrayDescriptor: NSObject <NSCopying>
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)new NS_UNAVAILABLE;
+
+- (instancetype)initWithShape:(NSArray<NSNumber *> *)shape
+                     dataType:(MLMultiArrayDataType)dataType NS_DESIGNATED_INITIALIZER;
+
+@property (copy, readonly, nonatomic) NSArray<NSNumber *> *shape;
+
+@property (assign, readonly, nonatomic) MLMultiArrayDataType dataType;
+
+@end
+
+@implementation ETCoreMLMultiArrayDescriptor
+
+- (instancetype)initWithShape:(NSArray<NSNumber *> *)shape
+                     dataType:(MLMultiArrayDataType)dataType {
+    self = [super init];
+    if (self) {
+        _shape = shape;
+        _dataType = dataType;
+    }
+    
+    return self;
+}
+
+- (BOOL)isEqual:(id)object {
+    if (object == self) {
+        return YES;
+    }
+    
+    if (![object isKindOfClass:self.class]) {
+        return NO;
+    }
+    
+    ETCoreMLMultiArrayDescriptor *other = (ETCoreMLMultiArrayDescriptor *)object;
+    return [self.shape isEqualToArray:other.shape] && self.dataType == other.dataType;
+}
+
+- (NSUInteger)hash {
+    return [self.shape hash] ^ (NSUInteger)self.dataType;
+}
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    return [[ETCoreMLMultiArrayDescriptor allocWithZone:zone] initWithShape:self.shape
+                                                                   dataType:self.dataType];
+}
+
+@end
+
+namespace {
+
+using namespace executorchcoreml;
+
+size_t get_number_of_bytes(MLMultiArrayDataType data_type) {
+    switch (data_type) {
+        case MLMultiArrayDataTypeFloat16: {
+            return 2;
+        }
+        case MLMultiArrayDataTypeFloat32: {
+            return 4;
+        }
+        case MLMultiArrayDataTypeInt32: {
+            return 4;
+        }
+        case MLMultiArrayDataTypeFloat64: {
+            return 8;
+        }
+        default: {
+            return 0;
+        }
+    }
+}
+
+std::vector<size_t> calculate_strides(const std::vector<size_t>& shape) {
+    if (shape.size() == 0) {
+        return {};
+    }
+    
+    if (shape.size() == 1) {
+        return {1};
+    }
+    
+    std::vector<size_t> strides(shape.size(), 1);
+    size_t product = 1;
+    for (size_t i = shape.size(); i > 0; i--) {
+        strides[i - 1] = product;
+        product *= shape[i - 1];
+    }
+    
+    return strides;
+}
+
+MLMultiArray * _Nullable make_ml_multi_array(const std::vector<size_t>& shape,
+                                             MLMultiArrayDataType dataType,
+                                             NSCache<ETCoreMLMultiArrayDescriptor *, NSMutableData *> *cache,
+                                             NSError * __autoreleasing *error) {
+    ETCoreMLMultiArrayDescriptor *descriptor = [[ETCoreMLMultiArrayDescriptor alloc] initWithShape:to_array(shape)
+                                                                                          dataType:dataType];
+    // Check the cache first otherwise allocate a new backing storage.
+    NSMutableData *backing_storage = [cache objectForKey:descriptor];
+    if (backing_storage) {
+        [cache removeObjectForKey:descriptor];
+    } else {
+        size_t n = std::accumulate(shape.cbegin(), shape.cend(), 1, std::multiplies<size_t>{});
+        backing_storage = [[NSMutableData alloc] initWithLength:n * get_number_of_bytes(dataType)];
+    }
+    
+    __weak NSCache<ETCoreMLMultiArrayDescriptor *, NSMutableData *> *weakCache = cache;
+    // Add the storage back to the cache when it gets deallocated, the next prediction would use the same storage.
+    MLMultiArray *result = [[MLMultiArray alloc] initWithDataPointer:backing_storage.mutableBytes
+                                                               shape:descriptor.shape
+                                                            dataType:descriptor.dataType
+                                                             strides:to_array(calculate_strides(shape))
+                                                         deallocator:^(void * _Nonnull bytes) {[weakCache setObject:backing_storage forKey:descriptor];}
+                                                               error:error];
+    
+    return result;
+}
+
+NSDictionary<NSString *, MLMultiArrayConstraint *> *
+get_multi_array_constraints_by_name(NSDictionary<NSString *, MLFeatureDescription *> *feature_descriptions) {
+    NSMutableDictionary<NSString *, MLMultiArrayConstraint *> *result = [NSMutableDictionary dictionaryWithCapacity:feature_descriptions.count];
+    [feature_descriptions enumerateKeysAndObjectsUsingBlock:^(NSString *key, MLFeatureDescription *description, BOOL * _Nonnull stop) {
+        result[key] = description.multiArrayConstraint;
+    }];
+    
+    return result;
+}
+
+NSDictionary<NSString *, MLMultiArrayConstraint *> *get_multi_array_input_constraints_by_name(MLModelDescription *description) {
+    return get_multi_array_constraints_by_name(description.inputDescriptionsByName);
+}
+
+NSDictionary<NSString *, MLMultiArrayConstraint *> *get_multi_array_output_constraints_by_name(MLModelDescription *description) {
+    return get_multi_array_constraints_by_name(description.outputDescriptionsByName);
+}
+
+}
+
+#pragma mark - ETCoreMLModel
+@interface ETCoreMLModel ()
+
+@property (strong, readonly, nonatomic) NSCache<ETCoreMLMultiArrayDescriptor *, NSMutableData *> *cache;
+@property (copy, readonly, nonatomic) NSDictionary<NSString *, MLMultiArrayConstraint *> *inputConstraintsByName;
+@property (copy, readonly, nonatomic) NSDictionary<NSString *, MLMultiArrayConstraint *> *outputConstraintsByName;
+
+@end
+
 
 @implementation ETCoreMLModel
 
@@ -33,13 +191,85 @@
         _asset = asset;
         _orderedInputNames = [orderedInputNames copy];
         _orderedOutputNames = [orderedOutputNames copy];
+        _cache = [[NSCache alloc] init];
+        _inputConstraintsByName = get_multi_array_input_constraints_by_name(mlModel.modelDescription);
+        _outputConstraintsByName = get_multi_array_output_constraints_by_name(mlModel.modelDescription);
     }
-
+    
     return self;
 }
 
 - (NSString *)identifier {
     return self.asset.identifier;
+}
+
+- (nullable NSArray<MLMultiArray *> *)prepareArgs:(const std::vector<executorchcoreml::MultiArray>&)args
+                                         argNames:(NSOrderedSet<NSString *> *)argNames
+                             argConstraintsByName:(NSDictionary<NSString *, MLMultiArrayConstraint *> *)argConstraintsByName
+                                         copyData:(const BOOL)copyData
+                                            error:(NSError * __autoreleasing *)error {
+    NSEnumerator *nameEnumerator = [argNames objectEnumerator];
+    NSMutableArray<MLMultiArray *> *result = [NSMutableArray arrayWithCapacity:args.size()];
+    for (const auto& arg : args) {
+        BOOL lCopyData = copyData;
+        NSString *argName = [nameEnumerator nextObject];
+        MLMultiArrayConstraint *constraint = argConstraintsByName[argName];
+        const auto& layout = arg.layout();
+        auto dataType = to_ml_multiarray_data_type(layout.dataType());
+        MLMultiArray *multiArrayArg = nil;
+        if (dataType == constraint.dataType) {
+            // We can use the same data storage.
+            multiArrayArg = [[MLMultiArray alloc] initWithDataPointer:arg.data()
+                                                                shape:to_array(layout.shape())
+                                                             dataType:constraint.dataType
+                                                              strides:to_array(layout.strides())
+                                                          deallocator:^(void * _Nonnull bytes) {}
+                                                                error:error];
+            lCopyData = NO;
+        } else {
+            // We can't use the same data storage, data types are not the same.
+            multiArrayArg = ::make_ml_multi_array(layout.shape(), constraint.dataType, self.cache, error);
+        }
+        
+        if (!multiArrayArg) {
+            return nil;
+        }
+        
+        if (multiArrayArg && lCopyData) {
+            [multiArrayArg getMutableBytesWithHandler:^(void *_Nonnull mutableBytes,
+                                                        NSInteger __unused size,
+                                                        NSArray<NSNumber *> *strides) {
+                MultiArray buffer(mutableBytes, MultiArray::MemoryLayout(to_multiarray_data_type(constraint.dataType).value(),
+                                                                         layout.shape(),
+                                                                         to_vector<ssize_t>(strides)));
+                arg.copy(buffer);
+            }];
+        }
+        
+        [result addObject:multiArrayArg];
+    }
+    
+    return result;
+}
+
+- (nullable NSArray<MLMultiArray *> *)prepareInputs:(const std::vector<executorchcoreml::MultiArray>&)inputs
+                                              error:(NSError * __autoreleasing *)error {
+    return [self prepareArgs:inputs
+                    argNames:self.orderedInputNames
+        argConstraintsByName:self.inputConstraintsByName
+                    copyData:YES
+                       error:error];
+    
+}
+
+- (nullable NSArray<MLMultiArray *> *)prepareOutputBackings:(const std::vector<executorchcoreml::MultiArray>&)outputs
+                                                      error:(NSError * __autoreleasing *)error {
+    return [self prepareArgs:outputs
+                    argNames:self.orderedOutputNames
+        argConstraintsByName:self.outputConstraintsByName
+                    copyData:NO
+                       error:error];
+    
 }
 
 @end

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelExecutor.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelExecutor.h
@@ -35,6 +35,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The model.
 @property (readonly, strong, nonatomic) ETCoreMLModel* model;
 
+/// If set to `YES` then output backing are ignored.
+@property (readwrite, atomic) BOOL ignoreOutputBackings;
+
 
 @end
 

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.h
@@ -7,11 +7,14 @@
 
 #import <CoreML/CoreML.h>
 
+#import <vector>
+
 NS_ASSUME_NONNULL_BEGIN
 
 namespace executorchcoreml {
 struct ModelLoggingOptions;
 class ModelEventLogger;
+class MultiArray;
 };
 
 @class ETCoreMLModel;
@@ -50,12 +53,25 @@ __attribute__((objc_subclassing_restricted))
 /// Executes the loaded model.
 ///
 /// @param handle The handle to the loaded model.
-/// @param args The arguments to the model.
+/// @param args The arguments (inputs and outputs) of the model.
 /// @param loggingOptions The model logging options.
 /// @param error   On failure, error is filled with the failure information.
 /// @retval `YES` if the execution succeeded otherwise `NO`.
 - (BOOL)executeModelWithHandle:(ModelHandle*)handle
                           args:(NSArray<MLMultiArray*>*)args
+                loggingOptions:(const executorchcoreml::ModelLoggingOptions&)loggingOptions
+                   eventLogger:(const executorchcoreml::ModelEventLogger* _Nullable)eventLogger
+                         error:(NSError* __autoreleasing*)error;
+
+/// Executes the loaded model.
+///
+/// @param handle The handle to the loaded model.
+/// @param argsVec The arguments (inputs and outputs) of the model.
+/// @param loggingOptions The model logging options.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval `YES` if the execution succeeded otherwise `NO`.
+- (BOOL)executeModelWithHandle:(ModelHandle*)handle
+                       argsVec:(const std::vector<executorchcoreml::MultiArray>&)argsVec
                 loggingOptions:(const executorchcoreml::ModelLoggingOptions&)loggingOptions
                    eventLogger:(const executorchcoreml::ModelEventLogger* _Nullable)eventLogger
                          error:(NSError* __autoreleasing*)error;

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
@@ -22,6 +22,8 @@
 #import <iostream>
 #import <memory>
 #import <model_metadata.h>
+#import <multiarray.h>
+#import <objc_array_util.h>
 #import <optional>
 #import <os/lock.h>
 #import <serde_json.h>
@@ -98,32 +100,60 @@ MLPredictionOptions *get_prediction_options(NSArray<MLMultiArray *> *outputs,
     return options;
 }
 
-BOOL copy(MLMultiArray *src, MLMultiArray *dst, NSError * __autoreleasing *error) {
-    if (![src.shape isEqualToArray:dst.shape]) {
-        ETCoreMLLogErrorAndSetNSError(error, 0, "%@: Model is broken", NSStringFromClass(ETCoreMLModelManager.class));
-        return NO;
-    }
+void copy(MLMultiArray *src, MLMultiArray *dst) {
     if (::is_backed_by_same_buffer(src, dst)) {
-        return YES;
+        return;
     }
-    @autoreleasepool {
-        [src copyInto:dst];
-    }
-    return YES;
+    
+    [src copyInto:dst];
 }
 
-BOOL set_outputs(NSArray<MLMultiArray *> *outputs,
-                 NSArray<MLMultiArray *> *model_outputs,
-                 NSError * __autoreleasing *error) {
+void set_outputs(NSArray<MLMultiArray *> *outputs, NSArray<MLMultiArray *> *model_outputs) {
     NSEnumerator<MLMultiArray *> *enumerator = [model_outputs objectEnumerator];
     for (MLMultiArray *output in outputs) {
         MLMultiArray *model_output = [enumerator nextObject];
-        if (!::copy(output, model_output, error)) {
-            return NO;
+        ::copy(model_output, output);
+    }
+}
+
+std::optional<MultiArray::DataType> get_data_type(MLMultiArrayDataType data_type) {
+    switch (data_type) {
+        case MLMultiArrayDataTypeFloat16: {
+            return MultiArray::DataType::Float16;
+        }
+        case MLMultiArrayDataTypeFloat32: {
+            return MultiArray::DataType::Float32;
+        }
+        case MLMultiArrayDataTypeFloat64: {
+            return MultiArray::DataType::Float64;
+        }
+        case MLMultiArrayDataTypeInt32: {
+            return MultiArray::DataType::Int32;
+        }
+        default: {
+            return std::nullopt;
         }
     }
-    
-    return YES;
+}
+
+void copy(MLMultiArray *src, executorchcoreml::MultiArray& dst) {
+    [src getBytesWithHandler:^(const void * _Nonnull bytes, NSInteger size) {
+        if (bytes == dst.data()) {
+            return;
+        }
+        
+        MultiArray::MemoryLayout src_layout(get_data_type(src.dataType).value(), to_vector<size_t>(src.shape), to_vector<ssize_t>(src.strides));
+        MultiArray(const_cast<void *>(bytes), std::move(src_layout)).copy(dst);
+    }];
+}
+
+void set_outputs(std::vector<executorchcoreml::MultiArray>& outputs,
+                 NSArray<MLMultiArray *> *model_outputs) {
+    NSEnumerator<MLMultiArray *> *enumerator = [model_outputs objectEnumerator];
+    for (auto& output : outputs) {
+        MLMultiArray *model_output = [enumerator nextObject];
+        ::copy(model_output, output);
+    }
 }
 
 NSData * _Nullable get_file_data(const inmemoryfs::InMemoryFileSystem *inMemoryFS,
@@ -313,6 +343,7 @@ NSDictionary<ETCoreMLModelStructurePath *, NSString *> * _Nullable get_operation
     
     return result;
 }
+
 #endif
 } //namespace
 
@@ -467,7 +498,7 @@ NSDictionary<ETCoreMLModelStructurePath *, NSString *> * _Nullable get_operation
     return [[ETCoreMLModelAnalyzer alloc] initWithCompiledModelAsset:compiledModelAsset
                                                           modelAsset:modelAsset
                                                             metadata:metadata
-                                       operationPathToDebugSymbolMap: operation_path_to_symbol_name_map
+                                       operationPathToDebugSymbolMap:operation_path_to_symbol_name_map
                                                        configuration:configuration
                                                         assetManager:self.assetManager
                                                                error:error];
@@ -641,6 +672,48 @@ NSDictionary<ETCoreMLModelStructurePath *, NSString *> * _Nullable get_operation
     os_unfair_lock_unlock(&_lock);
 }
 
+- (nullable NSArray<MLMultiArray *> *)executeModelUsingExecutor:(id<ETCoreMLModelExecutor>)executor
+                                                         inputs:(NSArray<MLMultiArray *> *)inputs
+                                                 outputBackings:(NSArray<MLMultiArray *> *)outputBackings
+                                                 loggingOptions:(const executorchcoreml::ModelLoggingOptions&)loggingOptions
+                                                    eventLogger:(const executorchcoreml::ModelEventLogger* _Nullable)eventLogger
+                                                          error:(NSError * __autoreleasing *)error {
+    NSError *localError = nil;
+    ETCoreMLModel *model = executor.model;
+    MLPredictionOptions *predictionOptions = ::get_prediction_options(outputBackings, model.orderedOutputNames, error);
+    if (!predictionOptions) {
+        return nil;
+    }
+    
+    id<MLFeatureProvider> inputFeatures = ::get_feature_provider(inputs, model.orderedInputNames, error);
+    if (!inputFeatures) {
+        return nil;
+    }
+    
+    NSArray<MLMultiArray *> *modelOutputs = [executor executeModelWithInputs:inputFeatures
+                                                           predictionOptions:predictionOptions
+                                                             loggingOptions:loggingOptions
+                                                                 eventLogger:eventLogger
+                                                                       error:&localError];
+    // Try without output backings.
+    if (!modelOutputs && predictionOptions.outputBackings.count > 0) {
+        localError = nil;
+        executor.ignoreOutputBackings = YES;
+    }
+    
+    modelOutputs = [executor executeModelWithInputs:inputFeatures
+                                  predictionOptions:predictionOptions
+                                     loggingOptions:loggingOptions
+                                        eventLogger:eventLogger
+                                              error:&localError];
+    
+    if (error) {
+        *error = localError;
+    }
+    
+    return modelOutputs;
+}
+
 - (BOOL)executeModelWithHandle:(ModelHandle *)handle
                           args:(NSArray<MLMultiArray *> *)args
                 loggingOptions:(const executorchcoreml::ModelLoggingOptions&)loggingOptions
@@ -659,33 +732,91 @@ NSDictionary<ETCoreMLModelStructurePath *, NSString *> * _Nullable get_operation
     if (args.count != model.orderedInputNames.count + model.orderedOutputNames.count) {
         ETCoreMLLogErrorAndSetNSError(error,
                                       ETCoreMLErrorCorruptedModel,
-                                      "%@: Model is invalid.",
+                                      "%@: Model is invalid, expected args count to be %lu but got %lu.",
+                                      NSStringFromClass(self.class),
+                                      static_cast<unsigned long>(model.orderedInputNames.count + model.orderedOutputNames.count),
+                                      args.count);
+        return NO;
+    }
+    @autoreleasepool {
+        NSArray<MLMultiArray *> *inputs = [args subarrayWithRange:NSMakeRange(0, model.orderedInputNames.count)];
+        NSArray<MLMultiArray *> *outputs = [args subarrayWithRange:NSMakeRange(model.orderedInputNames.count, args.count - model.orderedInputNames.count)];
+        NSArray<MLMultiArray *> *outputBackings = @[];
+        if (executor.ignoreOutputBackings == NO) {
+            outputBackings = outputs;
+        }
+        
+        NSArray<MLMultiArray *> *modelOutputs = [self executeModelUsingExecutor:executor
+                                                                         inputs:inputs
+                                                                 outputBackings:outputBackings
+                                                                 loggingOptions:loggingOptions
+                                                                    eventLogger:eventLogger
+                                                                          error:error];
+        if (!modelOutputs) {
+            return NO;
+        }
+        
+        ::set_outputs(outputs, modelOutputs);
+    }
+    
+    return YES;
+}
+
+- (BOOL)executeModelWithHandle:(ModelHandle *)handle
+                       argsVec:(const std::vector<executorchcoreml::MultiArray>&)argsVec
+                loggingOptions:(const executorchcoreml::ModelLoggingOptions&)loggingOptions
+                   eventLogger:(const executorchcoreml::ModelEventLogger* _Nullable)eventLogger
+                         error:(NSError * __autoreleasing *)error {
+    id<ETCoreMLModelExecutor> executor = [self executorWithHandle:handle];
+    if (!executor) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      0,
+                                      "%@: Model is already unloaded.",
                                       NSStringFromClass(self.class));
         return NO;
     }
     
-    NSArray<MLMultiArray *> *inputs = [args subarrayWithRange:NSMakeRange(0, model.orderedInputNames.count)];
-    NSArray<MLMultiArray *> *outputs = [args subarrayWithRange:NSMakeRange(model.orderedInputNames.count, args.count - model.orderedInputNames.count)];
-    id<MLFeatureProvider> inputFeatures = ::get_feature_provider(inputs, model.orderedInputNames, error);
-    if (!inputFeatures) {
+    ETCoreMLModel *model = executor.model;
+    if (argsVec.size() != model.orderedInputNames.count + model.orderedOutputNames.count) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      ETCoreMLErrorCorruptedModel,
+                                      "%@: Model is invalid, expected args count to be %lu but got %lu.",
+                                      NSStringFromClass(self.class),
+                                      static_cast<unsigned long>(model.orderedInputNames.count + model.orderedOutputNames.count),
+                                      argsVec.size());
         return NO;
     }
     
-    MLPredictionOptions *predictionOptions = ::get_prediction_options(outputs, model.orderedOutputNames, error);
-    if (!predictionOptions) {
-        return NO;
+    std::vector<executorchcoreml::MultiArray> inputArgs(argsVec.begin(), argsVec.begin() + model.orderedInputNames.count);
+    std::vector<executorchcoreml::MultiArray> outputArgs(argsVec.begin() + model.orderedInputNames.count, argsVec.end());
+    @autoreleasepool {
+        NSArray<MLMultiArray *> *inputs = [model prepareInputs:inputArgs error:error];
+        if (!inputs) {
+            return NO;
+        }
+        
+        NSArray<MLMultiArray *> *outputBackings = @[];
+        if (executor.ignoreOutputBackings == NO) {
+            outputBackings = [model prepareOutputBackings:outputArgs error:error];
+        }
+        
+        if (!outputBackings) {
+            return NO;
+        }
+        
+        NSArray<MLMultiArray *> *modelOutputs = [self executeModelUsingExecutor:executor
+                                                                         inputs:inputs
+                                                                 outputBackings:outputBackings
+                                                                 loggingOptions:loggingOptions
+                                                                    eventLogger:eventLogger
+                                                                          error:error];
+        if (!modelOutputs) {
+            return NO;
+        }
+        
+        ::set_outputs(outputArgs, modelOutputs);
+        return YES;
     }
-    
-    NSArray<MLMultiArray *> *modelOutputs = [executor executeModelWithInputs:inputFeatures
-                                                           predictionOptions:predictionOptions
-                                                             loggingOptions:loggingOptions
-                                                                 eventLogger:eventLogger
-                                                                       error:error];
-    if (!outputs) {
-        return NO;
-    }
-    
-    return ::set_outputs(outputs, modelOutputs, error);
 }
 
 - (BOOL)unloadModelWithHandle:(ModelHandle *)handle {

--- a/backends/apple/coreml/runtime/delegate/MLMultiArray_Copy.mm
+++ b/backends/apple/coreml/runtime/delegate/MLMultiArray_Copy.mm
@@ -7,55 +7,17 @@
 
 #import <MLMultiArray_Copy.h>
 
+#import <objc_array_util.h>
 #import <multiarray.h>
 
 namespace {
 using namespace executorchcoreml;
 
-template<typename T>
-T toValue(NSNumber *value);
-
-template<> size_t toValue(NSNumber *value) {
-    return value.unsignedLongValue;
-}
-
-template<> ssize_t toValue(NSNumber *value) {
-    return value.longLongValue;
-}
-
-template<typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
-std::vector<T> to_vector(NSArray<NSNumber *> *numbers) {
-    std::vector<T> result;
-    result.reserve(numbers.count);
-    for (NSNumber *number in numbers) {
-        result.emplace_back(toValue<T>(number));
-    }
-    
-    return result;
-}
-
-MultiArray::DataType to_multi_array_data_type(MLMultiArrayDataType data_type) {
-    switch (data_type) {
-        case MLMultiArrayDataTypeInt32: {
-            return MultiArray::DataType::Int;
-        }
-        case MLMultiArrayDataTypeFloat: {
-            return MultiArray::DataType::Float;
-        }
-        case MLMultiArrayDataTypeFloat16: {
-            return MultiArray::DataType::Float16;
-        }
-        case MLMultiArrayDataTypeDouble: {
-            return MultiArray::DataType::Double;
-        }
-    }
-}
-
 MultiArray to_multi_array(void *data,
                           MLMultiArrayDataType dataType,
                           NSArray<NSNumber *> *shape,
                           NSArray<NSNumber *> *strides) {
-    auto layout = MultiArray::MemoryLayout(to_multi_array_data_type(dataType),
+    auto layout = MultiArray::MemoryLayout(to_multiarray_data_type(dataType).value(),
                                            to_vector<size_t>(shape),
                                            to_vector<ssize_t>(strides));
     return MultiArray(data, std::move(layout));

--- a/backends/apple/coreml/runtime/delegate/backend_delegate.h
+++ b/backends/apple/coreml/runtime/delegate/backend_delegate.h
@@ -26,7 +26,7 @@ public:
 
     struct Config {
         // Max models cache size in bytes.
-        size_t max_models_cache_size = 2 * size_t(1024) * size_t(1024) * size_t(1024);
+        size_t max_models_cache_size = 10 * size_t(1024) * size_t(1024) * size_t(1024);
         // If set to `true`, delegate pre-warms the most recently used asset.
         bool should_prewarm_asset = true;
         // If set to `true`, delegate pre-warms the model in `init`.

--- a/backends/apple/coreml/runtime/delegate/com.apple.executorchcoreml_config.plist
+++ b/backends/apple/coreml/runtime/delegate/com.apple.executorchcoreml_config.plist
@@ -7,6 +7,6 @@
 	<key>shouldPrewarmModel</key>
 	<true/>
 	<key>maxAssetsSizeInBytes</key>
-	<integer>2147483648</integer>
+	<integer>1073741824</integer>
 </dict>
 </plist>

--- a/backends/apple/coreml/runtime/delegate/multiarray.h
+++ b/backends/apple/coreml/runtime/delegate/multiarray.h
@@ -7,6 +7,9 @@
 
 #pragma once
 
+#import <CoreML/CoreML.h>
+#import <iostream>
+#import <optional>
 #import <vector>
 
 namespace executorchcoreml {
@@ -29,13 +32,33 @@ private:
 };
 
 /// A class representing a MultiArray.
-class MultiArray {
+class MultiArray final {
 public:
     /// The MultiArray datatype.
-    enum class DataType : uint8_t { Int = 0, Double, Float, Float16 };
+    enum class DataType : uint8_t {
+        Bool = 0,
+        Byte,
+        Char,
+        Short,
+        Int32,
+        Int64,
+        Float16,
+        Float32,
+        Float64,
+    };
+
+    /// Options for copying.
+    struct CopyOptions {
+        inline CopyOptions() noexcept : use_bnns(true), use_memcpy(true) { }
+
+        inline CopyOptions(bool use_bnns, bool use_memcpy) noexcept : use_bnns(use_bnns), use_memcpy(use_memcpy) { }
+
+        bool use_bnns = true;
+        bool use_memcpy = true;
+    };
 
     /// A class describing the memory layout of a MultiArray.
-    class MemoryLayout {
+    class MemoryLayout final {
     public:
         MemoryLayout(DataType dataType, std::vector<size_t> shape, std::vector<ssize_t> strides)
             : dataType_(dataType), shape_(std::move(shape)), strides_(std::move(strides)) { }
@@ -53,7 +76,10 @@ public:
         inline size_t rank() const noexcept { return shape_.size(); }
 
         /// Returns the number of elements in the MultiArray.
-        size_t get_num_elements() const noexcept;
+        size_t num_elements() const noexcept;
+
+        /// Returns the byte size of an element.
+        size_t num_bytes() const noexcept;
 
         /// Returns `true` if the memory layout is packed otherwise `false`.
         bool is_packed() const noexcept;
@@ -78,11 +104,42 @@ public:
     /// Copies this into another `MultiArray`.
     ///
     /// @param dst The destination `MultiArray`.
-    bool copy(MultiArray& dst) const noexcept;
+    void copy(MultiArray& dst, CopyOptions options = CopyOptions()) const noexcept;
+
+    /// Get the value at `indices`.
+    template <typename T> inline T value(const std::vector<size_t>& indices) const noexcept {
+        return *(static_cast<T*>(data(indices)));
+    }
+
+    /// Set the value at `indices`.
+    template <typename T> inline void set_value(const std::vector<size_t>& indices, T value) const noexcept {
+        T* ptr = static_cast<T*>(data(indices));
+        *ptr = value;
+    }
+
+    /// Get the value at `index`.
+    template <typename T> inline T value(size_t index) const noexcept { return *(static_cast<T*>(data(index))); }
+
+    /// Set the value at `index`.
+    template <typename T> inline void set_value(size_t index, T value) const noexcept {
+        T* ptr = static_cast<T*>(data(index));
+        *ptr = value;
+    }
 
 private:
+    void* data(const std::vector<size_t>& indices) const noexcept;
+
+    void* data(size_t index) const noexcept;
+
     void* data_;
     MemoryLayout layout_;
 };
+
+/// Converts `MultiArray::DataType` to `MLMultiArrayDataType`.
+std::optional<MLMultiArrayDataType> to_ml_multiarray_data_type(MultiArray::DataType data_type);
+
+/// Converts `MLMultiArrayDataType` to `MultiArray::DataType`.
+std::optional<MultiArray::DataType> to_multiarray_data_type(MLMultiArrayDataType data_type);
+
 
 } // namespace executorchcoreml

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.h
@@ -48,6 +48,9 @@ __attribute__((objc_subclassing_restricted))
 /// The model.
 @property (readonly, strong, nonatomic) ETCoreMLModel* model;
 
+/// If set to `YES` then output backing are ignored.
+@property (readwrite, atomic) BOOL ignoreOutputBackings;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.mm
@@ -170,6 +170,10 @@ static constexpr NSInteger MAX_MODEL_OUTPUTS_COUNT = 50;
                                               loggingOptions:(const executorchcoreml::ModelLoggingOptions&)loggingOptions
                                                  eventLogger:(const executorchcoreml::ModelEventLogger* _Nullable)eventLogger
                                                        error:(NSError * __autoreleasing *)error {
+    if (self.ignoreOutputBackings) {
+        predictionOptions.outputBackings = @{};
+    }
+    
     NSError *localError = nil;
     NSArray<MLMultiArray *> *outputs = nil;
     if (loggingOptions.log_profiling_info) {

--- a/backends/apple/coreml/runtime/test/BackendDelegateTests.mm
+++ b/backends/apple/coreml/runtime/test/BackendDelegateTests.mm
@@ -14,69 +14,32 @@
 #import <coreml_backend/delegate.h>
 #import <model_logging_options.h>
 #import <multiarray.h>
+#import <objc_array_util.h>
 
 using namespace executorchcoreml;
 
 namespace {
-template<typename T>
-T toValue(NSNumber *value);
 
-template<>
-size_t toValue(NSNumber *value) {
-    return value.unsignedLongLongValue;
-}
-
-template<>
-ssize_t toValue(NSNumber *value) {
-    return value.longLongValue;
-}
-
-template<typename T>
-std::vector<T> toVector(NSArray<NSNumber *> *values) {
-    std::vector<T> result;
-    result.reserve(values.count);
-    for (NSNumber *value in values) {
-        result.emplace_back(toValue<T>(value));
-    }
-    
-    return result;
-}
-
-MultiArray::DataType toDataType(MLMultiArrayDataType dataType) {
-    switch (dataType) {
-        case MLMultiArrayDataTypeFloat: {
-            return MultiArray::DataType::Float;
-        }
-        case MLMultiArrayDataTypeFloat16: {
-            return MultiArray::DataType::Float16;
-        }
-        case MLMultiArrayDataTypeDouble: {
-            return MultiArray::DataType::Double;
-        }
-        case MLMultiArrayDataTypeInt32: {
-            return MultiArray::DataType::Int;
-        }
-    }
-}
-
-MultiArray toMultiArray(MLMultiArray *mlMultiArray) {
-    auto shape = toVector<size_t>(mlMultiArray.shape);
-    auto strides = toVector<ssize_t>(mlMultiArray.strides);
-    auto layout = MultiArray::MemoryLayout(toDataType(mlMultiArray.dataType), std::move(shape), std::move(strides));
+MultiArray to_multiarray(MLMultiArray *ml_multiarray) {
+    auto shape = to_vector<size_t>(ml_multiarray.shape);
+    auto strides = to_vector<ssize_t>(ml_multiarray.strides);
+    auto layout = MultiArray::MemoryLayout(to_multiarray_data_type(ml_multiarray.dataType).value(),
+                                           std::move(shape),
+                                           std::move(strides));
     __block void *bytes = nullptr;
-    [mlMultiArray getMutableBytesWithHandler:^(void *mutableBytes, __unused NSInteger size, __unused NSArray<NSNumber *> *strides) {
+    [ml_multiarray getMutableBytesWithHandler:^(void *mutableBytes, __unused NSInteger size, __unused NSArray<NSNumber *> *strides) {
         bytes = mutableBytes;
     }];
     
     return MultiArray(bytes, std::move(layout));
 }
 
-std::vector<MultiArray> toMultiArrays(NSArray<MLMultiArray *> *mlMultiArrays) {
+std::vector<MultiArray> to_multiarrays(NSArray<MLMultiArray *> *ml_multiarrays) {
     std::vector<MultiArray> result;
-    result.reserve(mlMultiArrays.count);
+    result.reserve(ml_multiarrays.count);
     
-    for (MLMultiArray *mlMultiArray in mlMultiArrays) {
-        result.emplace_back(toMultiArray(mlMultiArray));
+    for (MLMultiArray *ml_multiarray in ml_multiarrays) {
+        result.emplace_back(to_multiarray(ml_multiarray));
     }
     return result;
 }
@@ -198,7 +161,7 @@ std::vector<MultiArray> toMultiArrays(NSArray<MLMultiArray *> *mlMultiArrays) {
     NSArray<MLMultiArray *> *args = [inputs arrayByAddingObject:output];
     std::error_code errorCode;
     XCTAssertTrue(_delegate->execute(handle,
-                                     toMultiArrays(args),
+                                     to_multiarrays(args),
                                      ModelLoggingOptions(),
                                      nullptr,
                                      errorCode));
@@ -223,7 +186,7 @@ std::vector<MultiArray> toMultiArrays(NSArray<MLMultiArray *> *mlMultiArrays) {
     NSArray<MLMultiArray *> *args = [inputs arrayByAddingObject:output];
     std::error_code errorCode;
     XCTAssertTrue(_delegate->execute(handle, 
-                                     toMultiArrays(args),
+                                     to_multiarrays(args),
                                      ModelLoggingOptions(),
                                      nullptr,
                                      errorCode));

--- a/backends/apple/coreml/runtime/test/ETCoreMLModelManagerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLModelManagerTests.mm
@@ -115,7 +115,7 @@
     NSArray<MLMultiArray *> *args = [inputs arrayByAddingObject:output];
     XCTAssertTrue([self.modelManager executeModelWithHandle:handle 
                                                        args:args
-                                            loggingOptions:executorchcoreml::ModelLoggingOptions()
+                                             loggingOptions:executorchcoreml::ModelLoggingOptions()
                                                 eventLogger:nullptr
                                                       error:&localError]);
     for (NSUInteger i = 0; i < output.count; i++) {

--- a/backends/apple/coreml/runtime/test/MultiArrayTests.mm
+++ b/backends/apple/coreml/runtime/test/MultiArrayTests.mm
@@ -1,0 +1,133 @@
+//
+// MultiArrayTests.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <multiarray.h>
+#import <objc_array_util.h>
+#import <vector>
+
+#import <XCTest/XCTest.h>
+
+using namespace executorchcoreml;
+
+namespace {
+size_t get_buffer_size(const std::vector<size_t>& shape, const std::vector<ssize_t>& srides) {
+    auto max_stride_it = std::max_element(srides.begin(), srides.end());
+    size_t max_stride_axis = static_cast<size_t>(std::distance(srides.begin(), max_stride_it));
+    size_t dimension_with_max_stride = shape[max_stride_axis];
+    return dimension_with_max_stride * (*max_stride_it);
+}
+
+template<typename T>
+MultiArray::DataType get_multiarray_data_type();
+
+template<> MultiArray::DataType get_multiarray_data_type<float>() {
+    return MultiArray::DataType::Float32;
+}
+
+template<> MultiArray::DataType get_multiarray_data_type<double>() {
+    return MultiArray::DataType::Float64;
+}
+
+template<> MultiArray::DataType get_multiarray_data_type<int64_t>() {
+    return MultiArray::DataType::Int64;
+}
+
+template<> MultiArray::DataType get_multiarray_data_type<int32_t>() {
+    return MultiArray::DataType::Int32;
+}
+
+template<> MultiArray::DataType get_multiarray_data_type<int16_t>() {
+    return MultiArray::DataType::Short;
+}
+
+template<> MultiArray::DataType get_multiarray_data_type<_Float16>() {
+    return MultiArray::DataType::Float16;
+}
+
+template<typename T1, typename T2>
+void verify_values(const MultiArray& multiarray1, const MultiArray& multiarray2) {
+    for (size_t i = 0;  i < multiarray1.layout().num_elements(); ++i) {
+        XCTAssertEqual(multiarray1.value<T1>(i), multiarray2.value<T2>(i));
+    }
+}
+
+template<typename T>
+MultiArray make_multi_array(const std::vector<size_t>& shape, const std::vector<ssize_t>& strides, std::vector<uint8_t>& storage) {
+    storage.resize(get_buffer_size(shape, strides) * sizeof(T), 0);
+    MultiArray::MemoryLayout layout(get_multiarray_data_type<T>(), shape, strides);
+    return MultiArray(storage.data(), std::move(layout));
+}
+
+template<typename T>
+MultiArray make_multi_array_and_fill(const std::vector<size_t>& shape, const std::vector<ssize_t>& strides, std::vector<uint8_t>& storage) {
+    auto result = make_multi_array<T>(shape, strides, storage);
+    for (size_t i = 0;  i < result.layout().num_elements(); ++i) {
+        T value = static_cast<T>(i);
+        result.set_value(i, value);
+    }
+    
+    return result;
+}
+
+template<typename T1, typename T2>
+void verify_copy_(const std::vector<size_t>& shape,
+                  const std::vector<ssize_t>& src_strides,
+                  const std::vector<ssize_t>& dst_strides) {
+    std::vector<uint8_t> src_storage;
+    auto src_multiarray = make_multi_array_and_fill<T1>(shape, src_strides, src_storage);
+    
+    std::vector<uint8_t> dst_storage;
+    auto dst_multiarray = make_multi_array<T2>(shape, dst_strides, dst_storage);
+    src_multiarray.copy(dst_multiarray, MultiArray::CopyOptions(true, false));
+    verify_values<T1, T2>(src_multiarray, dst_multiarray);
+    
+    dst_storage.clear();
+    dst_storage.resize(get_buffer_size(shape, dst_strides) * sizeof(T2), 0);
+    src_multiarray.copy(dst_multiarray, MultiArray::CopyOptions(false, false));
+    verify_values<T1, T2>(src_multiarray, dst_multiarray);
+}
+
+template<typename T1, typename T2>
+void verify_copy(const std::vector<size_t>& shape,
+                 const std::vector<ssize_t>& src_strides,
+                 const std::vector<ssize_t>& dst_strides) {
+    verify_copy_<T1, T2>(shape, src_strides, dst_strides);
+    verify_copy_<T2, T1>(shape, src_strides, dst_strides);
+}
+} //namespace
+
+@interface MultiArrayTests : XCTestCase
+
+@end
+
+@implementation MultiArrayTests
+
+- (void)verifyDataCopyWithShape:(const std::vector<size_t>&)shape
+                     srcStrides:(const std::vector<ssize_t>&)srcStrides
+                     dstStrides:(const std::vector<ssize_t>&)dstStrides {
+    verify_copy<int16_t, int32_t>(shape, srcStrides, dstStrides);
+    verify_copy<int16_t, int64_t>(shape, srcStrides, dstStrides);
+    verify_copy<int32_t, int64_t>(shape, srcStrides, dstStrides);
+    verify_copy<float, double>(shape, srcStrides, srcStrides);
+    verify_copy<float, _Float16>(shape, srcStrides, dstStrides);
+    verify_copy<double, _Float16>(shape, srcStrides, srcStrides);
+}
+
+- (void)testAdjacentDataCopy {
+    std::vector<size_t> shape = {1, 3, 10, 10};
+    std::vector<ssize_t> strides = {3 * 10 * 10, 10 * 10, 10, 1};
+    [self verifyDataCopyWithShape:shape srcStrides:strides dstStrides:strides];
+}
+
+- (void)testNonAdjacentDataCopy {
+    std::vector<size_t> shape = {1, 3, 10, 10};
+    std::vector<ssize_t> srcStrides = {3 * 10 * 64, 10 * 64, 64, 1};
+    std::vector<ssize_t> dstStrides = {3 * 10 * 10 * 10, 10 * 10 * 10, 100, 10};
+    [self verifyDataCopyWithShape:shape srcStrides:srcStrides dstStrides:dstStrides];
+}
+
+@end

--- a/backends/apple/coreml/runtime/util/objc_array_util.h
+++ b/backends/apple/coreml/runtime/util/objc_array_util.h
@@ -1,0 +1,42 @@
+//
+//  objc_array_util.h
+//  util
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <Foundation/Foundation.h>
+#import <type_traits>
+#import <vector>
+
+namespace executorchcoreml {
+
+template <typename T> T to_value(NSNumber* value);
+
+template <> inline size_t to_value(NSNumber* value) { return value.unsignedLongValue; }
+
+template <> inline ssize_t to_value(NSNumber* value) { return value.longLongValue; }
+
+template <typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
+inline NSArray<NSNumber*>* to_array(const std::vector<T>& array) {
+    NSMutableArray<NSNumber*>* result = [NSMutableArray arrayWithCapacity:array.size()];
+    for (T value: array) {
+        [result addObject:@(value)];
+    }
+
+    return result;
+}
+
+template <typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
+inline std::vector<T> to_vector(NSArray<NSNumber*>* numbers) {
+    std::vector<T> result;
+    result.reserve(numbers.count);
+    for (NSNumber* number in numbers) {
+        result.emplace_back(to_value<T>(number));
+    }
+
+    return result;
+}
+
+}

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		C9E7D7962AB3F9BF00CCAE5D /* KeyValueStoreTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D78E2AB3F9BF00CCAE5D /* KeyValueStoreTests.mm */; };
 		C9E7D7A22AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D7A12AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm */; };
 		F24817E52BC655E100E80D98 /* libexecutorch_no_prim_ops.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F24817E42BC655E100E80D98 /* libexecutorch_no_prim_ops.a */; };
+		C9EC7E1B2BC73B3200A6B166 /* MultiArrayTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9EC7E1A2BC73B3200A6B166 /* MultiArrayTests.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -299,6 +300,8 @@
 		C9EA3FDE2B73EEA000B7D7BD /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		C9EA3FE52B73EF6300B7D7BD /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		F24817E42BC655E100E80D98 /* libexecutorch_no_prim_ops.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libexecutorch_no_prim_ops.a; path = ../libraries/libexecutorch_no_prim_ops.a; sourceTree = "<group>"; };
+		C9EC7E092BC662A300A6B166 /* objc_array_util.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = objc_array_util.h; path = ../util/objc_array_util.h; sourceTree = "<group>"; };
+		C9EC7E1A2BC73B3200A6B166 /* MultiArrayTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MultiArrayTests.mm; path = ../test/MultiArrayTests.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -540,6 +543,7 @@
 				C97716DB2AF44D9A00FC0DAC /* objc_json_serde.h */,
 				C97716DC2AF44E7B00FC0DAC /* objc_json_serde.mm */,
 				C97716DE2AF44FC400FC0DAC /* objc_safe_cast.h */,
+				C9EC7E092BC662A300A6B166 /* objc_array_util.h */,
 			);
 			name = util;
 			sourceTree = "<group>";
@@ -578,6 +582,7 @@
 				C998838C2B96841D000953A3 /* ETCoreMLModelStructurePathTests.mm */,
 				C998838E2B96999F000953A3 /* ETCoreMLModelProfilerTests.mm */,
 				C962271A2B984FB9002D13B7 /* ETCoreMLModelDebuggerTests.mm */,
+				C9EC7E1A2BC73B3200A6B166 /* MultiArrayTests.mm */,
 			);
 			name = test;
 			sourceTree = "<group>";
@@ -728,6 +733,7 @@
 				C945E9372B997EEE009C3FAC /* FeatureTypes.pb.cc in Sources */,
 				C945E9402B997EEE009C3FAC /* OneHotEncoder.pb.cc in Sources */,
 				C94D50E82ABDF81100AF47FD /* key_value_store.cpp in Sources */,
+				C9EC7E1B2BC73B3200A6B166 /* MultiArrayTests.mm in Sources */,
 				C945E9452B997EEE009C3FAC /* BayesianProbitRegressor.pb.cc in Sources */,
 				C945E8E52B997ECE009C3FAC /* ETCoreMLOperationProfilingInfo.mm in Sources */,
 				C945E9312B997EEE009C3FAC /* DataStructures.pb.cc in Sources */,

--- a/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.pbxproj
+++ b/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		C94D51642ACFCBC500AF47FD /* CoreML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51632ACFCBC500AF47FD /* CoreML.framework */; };
 		C94D51662ACFCBCB00AF47FD /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51652ACFCBCB00AF47FD /* Accelerate.framework */; };
 		C94D51682ACFCC7100AF47FD /* libcoremldelegate.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51672ACFCC7100AF47FD /* libcoremldelegate.a */; };
+		C97BFFA42BC0C17300F55BAC /* libportable_kernels.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C97BFFA32BC0C17300F55BAC /* libportable_kernels.a */; };
+		C97BFFA62BC0C1F200F55BAC /* libportable_ops_lib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C97BFFA52BC0C1F200F55BAC /* libportable_ops_lib.a */; };
 		C988D69D2B998CDE00979CF6 /* libprotobuf-lite.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C988D69C2B998CD700979CF6 /* libprotobuf-lite.a */; };
 		F24817E72BC65B2000E80D98 /* libexecutorch_no_prim_ops.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F24817E62BC65B2000E80D98 /* libexecutorch_no_prim_ops.a */; };
 /* End PBXBuildFile section */
@@ -41,6 +43,8 @@
 		C94D51632ACFCBC500AF47FD /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = System/Library/Frameworks/CoreML.framework; sourceTree = SDKROOT; };
 		C94D51652ACFCBCB00AF47FD /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		C94D51672ACFCC7100AF47FD /* libcoremldelegate.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcoremldelegate.a; path = libraries/libcoremldelegate.a; sourceTree = "<group>"; };
+		C97BFFA32BC0C17300F55BAC /* libportable_kernels.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libportable_kernels.a; path = libraries/libportable_kernels.a; sourceTree = "<group>"; };
+		C97BFFA52BC0C1F200F55BAC /* libportable_ops_lib.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libportable_ops_lib.a; path = libraries/libportable_ops_lib.a; sourceTree = "<group>"; };
 		C988D69C2B998CD700979CF6 /* libprotobuf-lite.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libprotobuf-lite.a"; path = "libraries/libprotobuf-lite.a"; sourceTree = "<group>"; };
 		F24817E62BC65B2000E80D98 /* libexecutorch_no_prim_ops.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libexecutorch_no_prim_ops.a; path = libraries/libexecutorch_no_prim_ops.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -56,7 +60,9 @@
 				C94D51682ACFCC7100AF47FD /* libcoremldelegate.a in Frameworks */,
 				C94D51662ACFCBCB00AF47FD /* Accelerate.framework in Frameworks */,
 				C988D69D2B998CDE00979CF6 /* libprotobuf-lite.a in Frameworks */,
+				C97BFFA62BC0C1F200F55BAC /* libportable_ops_lib.a in Frameworks */,
 				C94D51642ACFCBC500AF47FD /* CoreML.framework in Frameworks */,
+				C97BFFA42BC0C17300F55BAC /* libportable_kernels.a in Frameworks */,
 				C94D51622ACFCBBA00AF47FD /* libsqlite3.tbd in Frameworks */,
 				C94D515E2ACFCBA000AF47FD /* libexecutorch.a in Frameworks */,
 			);
@@ -94,6 +100,8 @@
 				C94D51612ACFCBBA00AF47FD /* libsqlite3.tbd */,
 				C94D51672ACFCC7100AF47FD /* libcoremldelegate.a */,
 				F24817E62BC65B2000E80D98 /* libexecutorch_no_prim_ops.a */,
+				C97BFFA32BC0C17300F55BAC /* libportable_kernels.a */,
+				C97BFFA52BC0C1F200F55BAC /* libportable_ops_lib.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/examples/apple/coreml/scripts/build_executor_runner.sh
+++ b/examples/apple/coreml/scripts/build_executor_runner.sh
@@ -37,6 +37,7 @@ cmake "$EXECUTORCH_ROOT_PATH" -B"$CMAKE_BUILD_DIR_PATH" \
 -DEXECUTORCH_BUILD_XNNPACK=OFF \
 -DEXECUTORCH_BUILD_SDK=ON \
 -DEXECUTORCH_BUILD_COREML=ON \
+-DCOREML_BUILD_EXECUTOR_RUNNER=ON \
 -Dprotobuf_BUILD_TESTS=OFF \
 -Dprotobuf_BUILD_EXAMPLES=OFF \
 -DCMAKE_MACOSX_BUNDLE=OFF \
@@ -60,13 +61,15 @@ cp -rf "$COREML_DIR_PATH/runtime/include/" "$INCLUDE_DIR_PATH"
 # Copy required libraries
 echo "ExecuTorch: Copying libraries"
 mkdir "$LIBRARIES_DIR_PATH"
-find "$CMAKE_BUILD_DIR_PATH/" -name 'libexecutorch.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH"  \;
-find "$CMAKE_BUILD_DIR_PATH/" -name 'libexecutorch_no_prim_ops.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH"  \;
-find "$CMAKE_BUILD_DIR_PATH/" -name 'libetdump.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH"  \;
-find "$CMAKE_BUILD_DIR_PATH/" -name 'libcoremldelegate.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH"  \;
-find "$CMAKE_BUILD_DIR_PATH/" -name 'libprotobuf-lite.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH"  \;
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libexecutorch.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libexecutorch.a"  \;
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libexecutorch_no_prim_ops.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libexecutorch_no_prim_ops.a"  \;
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libprotobuf-lite.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libprotobuf-lite.a"  \;
 find "$CMAKE_BUILD_DIR_PATH/" -name 'libprotobuf-lited.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libprotobuf-lite.a"  \;
-cp -f "$EXECUTORCH_ROOT_PATH/third-party/flatcc/lib/libflatccrt.a" "$LIBRARIES_DIR_PATH"
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libetdump.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libetdump.a"  \;
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libcoremldelegate.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libcoremldelegate.a"  \;
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libportable_ops_lib.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libportable_ops_lib.a"  \;
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libportable_kernels.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libportable_kernels.a"  \;
+cp -f "$EXECUTORCH_ROOT_PATH/third-party/flatcc/lib/libflatccrt.a" "$LIBRARIES_DIR_PATH/libflatccrt.a"
 
 # Build the runner
 echo "ExecuTorch: Building runner"

--- a/examples/apple/coreml/scripts/extract_coreml_models.py
+++ b/examples/apple/coreml/scripts/extract_coreml_models.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Copyright © 2024 Apple Inc. All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -55,7 +53,8 @@ def extract_coreml_models(pte_data: bytes):
         if executorchcoreml.unflatten_directory_contents(
             coreml_processed_bytes, str(model_path.absolute())
         ):
-            print(f"CoreML model is extracted and saved to path = {model_path}")
+            print(f"Core ML models are extracted and saved to path = {model_path}")
+        model_index += 1
 
     if len(coreml_delegates) == 0:
         print("The model isn't delegated to CoreML.")
@@ -63,7 +62,7 @@ def extract_coreml_models(pte_data: bytes):
 
 if __name__ == "__main__":
     """
-    Extracts the CoreML models embedded in the ``.pte`` file and saves them to the
+    Extracts the Core ML models embedded in the ``.pte`` file and saves them to the
     file system.
     """
     parser = argparse.ArgumentParser()

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -667,7 +667,8 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
         # pyre-ignore: Undefined attribute [16]: Module `executorch.backends` has no attribute `apple`.
         compile_specs = CoreMLBackend.generate_compile_specs(
             compute_precision=ct.precision(ct.precision.FLOAT16.value),
-            compute_unit=ct.ComputeUnit[ct.ComputeUnit.ALL.name.upper()],
+            # using `ComputeUnit.ALL` can increase the model load time, default to `ComputeUnit.CPU_AND_GPU`
+            compute_unit=ct.ComputeUnit[ct.ComputeUnit.CPU_AND_GPU.name.upper()],
             # pyre-ignore: Undefined attribute [16]: Module `executorch.backends` has no attribute `apple`
             model_type=CoreMLBackend.MODEL_TYPE.MODEL,
         )


### PR DESCRIPTION
**Changes**
- The runtime was failing if it encountered a datatype not supported by CoreML framework. The changes add support for all the datatypes that are supported by coremltools basically if `CoreMLBackend` can export a model then runtime would execute it. Complex types are not supported because `coremltools` doesn't support it.

- Improves and cleans the multiarray copying code.  

- Adds portable ops to CoreML executor so that it can run a partitioned model.

**Testing**
- Tested partitioned model `coreml_stories.pte`
- Added multiarray copying tests.