### PR TITLE
Fix build-framework-ios CI job

### DIFF
--- a/runtime/executor/targets.bzl
+++ b/runtime/executor/targets.bzl
@@ -84,6 +84,8 @@ def define_common_targets():
                 "//executorch/runtime/kernel:operator_registry",
                 "//executorch/runtime/platform:platform",
                 "//executorch/schema:extended_header",
+            ],
+            deps = [
                 "//executorch/schema:program",
             ],
             visibility = [


### PR DESCRIPTION
As titled. `build_apple_frameworks.sh` is copying all the exported headers out and in #2934 `//executorch/schema:program` is being moved to `exported_deps` and causing `build_apple_frameworks.sh` to not able to copy generated headers `program_generated.h` and `scalar_type_generated.h`.

This PR fixes it by moving it back to `deps`.