### PR TITLE
Handle empty (size=0) tensor in Inspector

### DIFF
--- a/sdk/inspector/_inspector_utils.py
+++ b/sdk/inspector/_inspector_utils.py
@@ -103,6 +103,9 @@ def _parse_tensor_value(
         return torch.zeros(tensor.sizes, dtype=torch_dtype)
 
     tensor_bytes_size = math.prod(tensor.sizes) * dtype_size
+    if tensor_bytes_size == 0:
+        # Empty tensor. Return empty tensor.
+        return torch.zeros(tensor.sizes, dtype=torch_dtype)
 
     if tensor.offset is None:
         raise ValueError("Tensor offset cannot be None")


### PR DESCRIPTION
Summary:
Empty tensors are not handled so they throw errors.
 {F1484412951}

Differential Revision: D56027102


