### PR TITLE
[RELEASE-ONLY] Fix install_requirements.sh

### DIFF
--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -95,7 +95,7 @@ REQUIREMENTS_TO_INSTALL=(
 
 # Install the requirements. `--extra-index-url` tells pip to look for package
 # versions on the provided URL if they aren't available on the default URL.
-$PIP_EXECUTABLE install --extra-index-url "${TORCH_NIGHTLY_URL}" \
+$PIP_EXECUTABLE install --extra-index-url "${TORCH_URL}" \
     "${REQUIREMENTS_TO_INSTALL[@]}"
 
 #


### PR DESCRIPTION
The `TORCH_URL` in install_requirements.sh is mistakenly override by a cherry-picking PR. This PR is to fix it in the release/0.2 branch.