### PR TITLE
Add semihosting to cmake for executor_runner

### DIFF
--- a/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake
+++ b/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake
@@ -58,7 +58,13 @@ add_compile_definitions(
 add_link_options(
     -mcpu=${GCC_CPU}
     -mthumb
-    --specs=nosys.specs)
+)
+
+if(SEMIHOSTING)
+    add_link_options(--specs=rdimon.specs)
+else()
+    add_link_options(--specs=nosys.specs)
+endif()
 
 # Set floating point unit
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "\\+fp")

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -12,6 +12,8 @@ if(NOT DEFINED ET_PTE_FILE_PATH)
     "model is built into the binary.")
 endif()
 
+option(SEMIHOSTING "Enable semihosting" OFF)
+
 # Example ExecuTorch demo for bare metal Cortex-M based systems
 set(ET_DIR_PATH "../../.." CACHE PATH
   "Path to ExecuTorch dir")
@@ -105,3 +107,17 @@ target_include_directories(arm_executor_runner PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR})
 
 add_dependencies(arm_executor_runner gen_model_header)
+
+
+if(SEMIHOSTING)
+target_compile_definitions(arm_executor_runner PUBLIC SEMIHOSTING)
+endif()
+
+# Fixup compilation of retarget.c
+if(SEMIHOSTING)
+# Remove this when MLBEDSW-8910 is closed.
+set_source_files_properties(
+  ${ETHOS_SDK_PATH}/core_platform/targets/corstone-300/retarget.c
+  PROPERTIES HEADER_FILE_ONLY TRUE
+)
+endif()


### PR DESCRIPTION
Add cmake option to enable semihosting for the executor runner application.

Change-Id: I5db7271413b39e5122f86f321d15dd2a1086a547