### PR TITLE
Remove unused variables in eki/builder/offloading/BlockAllocator.cpp

### DIFF
--- a/examples/sdk/sdk_example_runner/sdk_example_runner.cpp
+++ b/examples/sdk/sdk_example_runner/sdk_example_runner.cpp
@@ -32,8 +32,6 @@
 #include <executorch/util/util.h>
 
 static uint8_t method_allocator_pool[4 * 1024U * 1024U]; // 4MB
-static constexpr size_t kBundledAllocatorPoolSize = 16 * 1024U;
-static uint8_t bundled_allocator_pool[kBundledAllocatorPoolSize];
 
 DEFINE_string(
     bundled_program_path,


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D56065747


