### PR TITLE
[Release-only] Fix the wrong test-infra branch on release/0.2

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -222,7 +222,7 @@ jobs:
 
   test-pybind-build-macos:
     name: test-pybind-build-macos
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.3
     strategy:
       matrix:
         include:
@@ -249,7 +249,7 @@ jobs:
 
   test-llama-runner-macos:
     name: test-llama-runner-mac
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.3
     strategy:
       matrix:
         dtype: [fp32]


### PR DESCRIPTION
https://github.com/pytorch/executorch/pull/3020 is not needed, instead, the test-infra branch needs to be pinned to `release/2.3`