### PR TITLE
Update README.md and add submodule update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,11 @@ To build the documentation locally:
    ```bash
    pip3 install -r ./.ci/docker/requirements-ci.txt
    ```
+1. Update submodules
 
+   ```bash
+   git submodule sync && git submodule update --init
+   ```
 1. Run:
 
    ```bash


### PR DESCRIPTION
Without the submodule update, install_requitements would not work. Add this step in the documentation's README.md