### PR TITLE
: Fix lint in clang-format

### DIFF
--- a/backends/apple/coreml/.clang-format
+++ b/backends/apple/coreml/.clang-format
@@ -1,5 +1,4 @@
 BasedOnStyle: WebKit
-BreakBeforeBraces: Attach
 AllowShortIfStatementsOnASingleLine: false
 BreakBeforeBinaryOperators: None
 BreakConstructorInitializers: BeforeColon

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLDefaultModelExecutor.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLDefaultModelExecutor.h
@@ -13,7 +13,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 /// The default model executor, the executor ignores logging options.
-__attribute__((objc_subclassing_restricted)) @interface ETCoreMLDefaultModelExecutor : NSObject<ETCoreMLModelExecutor>
+__attribute__((objc_subclassing_restricted))
+@interface ETCoreMLDefaultModelExecutor : NSObject<ETCoreMLModelExecutor>
 
 + (instancetype)new NS_UNAVAILABLE;
 

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelCompiler.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelCompiler.h
@@ -9,7 +9,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 /// A class responsible for compiling a CoreML model.
-__attribute__((objc_subclassing_restricted)) @interface ETCoreMLModelCompiler : NSObject
+__attribute__((objc_subclassing_restricted))
+@interface ETCoreMLModelCompiler : NSObject
 
 + (instancetype)new NS_UNAVAILABLE;
 

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelLoader.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelLoader.h
@@ -16,7 +16,8 @@ struct ModelMetadata;
 
 NS_ASSUME_NONNULL_BEGIN
 /// A class responsible for loading a CoreML model.
-__attribute__((objc_subclassing_restricted)) @interface ETCoreMLModelLoader : NSObject
+__attribute__((objc_subclassing_restricted))
+@interface ETCoreMLModelLoader : NSObject
 
 + (instancetype)new NS_UNAVAILABLE;
 

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.h
@@ -20,7 +20,8 @@ class ModelEventLogger;
 typedef void ModelHandle;
 
 /// A class responsible for managing the models loaded by the delegate.
-__attribute__((objc_subclassing_restricted)) @interface ETCoreMLModelManager : NSObject
+__attribute__((objc_subclassing_restricted))
+@interface ETCoreMLModelManager : NSObject
 
 + (instancetype)new NS_UNAVAILABLE;
 

--- a/backends/apple/coreml/runtime/kvstore/key_value_store.cpp
+++ b/backends/apple/coreml/runtime/kvstore/key_value_store.cpp
@@ -53,8 +53,7 @@ get_create_store_statement(std::string_view store_name, StorageType key_storage_
 
 std::string get_create_index_statement(std::string_view store_name, std::string_view column_name) {
     std::stringstream ss;
-    ss << "CREATE INDEX IF NOT EXISTS " << column_name << "_INDEX"
-       << " ON " << store_name << "(" << column_name << ")";
+    ss << "CREATE INDEX IF NOT EXISTS " << column_name << "_INDEX" << " ON " << store_name << "(" << column_name << ")";
 
     return ss.str();
 }

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelDebugger.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelDebugger.h
@@ -15,7 +15,8 @@ typedef NSDictionary<ETCoreMLModelStructurePath*, MLMultiArray*> ETCoreMLModelOu
 
 NS_ASSUME_NONNULL_BEGIN
 /// A class responsible for debugging a model.
-__attribute__((objc_subclassing_restricted)) @interface ETCoreMLModelDebugger : NSObject
+__attribute__((objc_subclassing_restricted))
+@interface ETCoreMLModelDebugger : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.h
@@ -21,7 +21,8 @@ typedef NSDictionary<ETCoreMLModelStructurePath*, ETCoreMLOperationProfilingInfo
 
 NS_ASSUME_NONNULL_BEGIN
 /// A class responsible for profiling a model.
-__attribute__((objc_subclassing_restricted)) @interface ETCoreMLModelProfiler : NSObject
+__attribute__((objc_subclassing_restricted))
+@interface ETCoreMLModelProfiler : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelStructurePath.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelStructurePath.h
@@ -17,7 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// The class is a thin wrapper over `executorchcoreml::modelstructure::path`.
 ///
-__attribute__((objc_subclassing_restricted)) @interface ETCoreMLModelStructurePath : NSObject<NSCopying>
+__attribute__((objc_subclassing_restricted))
+@interface ETCoreMLModelStructurePath : NSObject<NSCopying>
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLOperationProfilingInfo.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLOperationProfilingInfo.h
@@ -12,7 +12,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// A class representing the profiling info of an operation.
-__attribute__((objc_subclassing_restricted)) @interface ETCoreMLOperationProfilingInfo : NSObject<NSCopying>
+__attribute__((objc_subclassing_restricted))
+@interface ETCoreMLOperationProfilingInfo : NSObject<NSCopying>
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLPair.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLPair.h
@@ -9,7 +9,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 /// A class representing a pair with first and second objects.
-__attribute__((objc_subclassing_restricted)) @interface ETCoreMLPair<First, Second> : NSObject<NSCopying>
+__attribute__((objc_subclassing_restricted))
+@interface ETCoreMLPair<First, Second> : NSObject<NSCopying>
 
 - (instancetype)init NS_UNAVAILABLE;
 


### PR DESCRIPTION
Summary:
We are updating to clang-formatter 18.

The current clang-format in coreml code has duplicate key. Deleting one of them. It didn't complain in the old clang-formatter 12

Differential Revision: D56139927


