### PR TITLE
Fix iOS build by excluding external CoreML SDK dependencies

### DIFF
--- a/runtime/core/targets.bzl
+++ b/runtime/core/targets.bzl
@@ -9,6 +9,15 @@ def get_event_tracer_flags():
         event_tracer_flags += ["-DET_EVENT_TRACER_ENABLED"]
     return event_tracer_flags
 
+def build_sdk():
+    return native.read_config("executorch", "build_sdk", "false") == "true"
+
+def get_sdk_flags():
+    sdk_flags = []
+    if build_sdk():
+        sdk_flags += ["-DEXECUTORCH_BUILD_SDK"]
+    return sdk_flags
+
 def define_common_targets():
     """Defines targets that should be shared between fbcode and xplat.
 
@@ -92,7 +101,7 @@ def define_common_targets():
                 "//executorch/...",
                 "@EXECUTORCH_CLIENTS",
             ],
-            exported_preprocessor_flags = get_event_tracer_flags(),
+            exported_preprocessor_flags = get_event_tracer_flags() + get_sdk_flags(),
             exported_deps = [
                 "//executorch/runtime/platform:platform",
                 "//executorch/runtime/core:evalue" + aten_suffix,

--- a/sdk/targets.bzl
+++ b/sdk/targets.bzl
@@ -1,0 +1,8 @@
+def build_sdk():
+    return native.read_config("executorch", "build_sdk", "false") == "true"
+
+def get_sdk_flags():
+    sdk_flags = []
+    if build_sdk():
+        sdk_flags += ["-DEXECUTORCH_BUILD_SDK"]
+    return sdk_flags


### PR DESCRIPTION
Summary:
CoreML delegate SDK integration broke the app build. Getting the SDK integration to work properly internally will require buckifying the third-party targets on which the CoreML delegate SDK itself depends (not to be confused with the third-party dependencies from ET itself). Running the `install_requirements.sh` script (CoreML's, not the generic ET one) clones a bunch of Git repos, XCode-specific tooling, and generates Protobuf headers on which their SDK integration relies.

To avoid this, we simply add the `BUILD_SDK` flag and set it to false and disable building the SDK and exclude references to generated headers.

Reviewed By: kirklandsign

Differential Revision: D55456558


