### PR TITLE
Skip annotate boolean input (#2957)

### DIFF
--- a/backends/qualcomm/quantizer/utils.py
+++ b/backends/qualcomm/quantizer/utils.py
@@ -42,6 +42,7 @@ def register_annotator(ops: List[OpOverload]):
 
     return decorator
 
+
 def _is_input_float_tensor(node: Node):
     """Check if the input is not a float tensor, so that we can skip quantization for the node
     since observers only works with float Tensors

--- a/backends/qualcomm/quantizer/utils.py
+++ b/backends/qualcomm/quantizer/utils.py
@@ -9,6 +9,7 @@ from typing import Callable, Dict, List, Optional, Sequence
 import torch
 
 from torch._ops import OpOverload
+from torch._subclasses import FakeTensor
 
 from torch.ao.quantization.quantizer import (
     QuantizationAnnotation,
@@ -40,6 +41,18 @@ def register_annotator(ops: List[OpOverload]):
             OP_ANNOTATOR[op] = annotator
 
     return decorator
+
+def _is_input_float_tensor(node: Node):
+    """Check if the input is not a float tensor, so that we can skip quantization for the node
+    since observers only works with float Tensors
+    """
+    if (
+        not isinstance(node, Node)
+        or "val" not in node.meta
+        or not isinstance(node.meta["val"], FakeTensor)
+    ):
+        return False
+    return node.meta["val"].dtype == torch.float32
 
 
 def _is_annotated(nodes: List[Node]):
@@ -123,11 +136,11 @@ def annotate_binary(node: Node, quantization_config: QuantizationConfig) -> None
 
     input_qspec_map = {}
     input_act0 = node.args[0]
-    if isinstance(input_act0, Node):
+    if _is_input_float_tensor(input_act0):
         input_qspec_map[input_act0] = input_act_qspec
 
     input_act1 = node.args[1]
-    if isinstance(input_act1, Node):
+    if _is_input_float_tensor(input_act1):
         input_qspec_map[input_act1] = input_act_qspec
 
     node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/executorch/pull/2957

ghstack-source-id: 222200589
exported-using-ghexport

It only makes sense to quantize fp tensor, but not boolean. Add a check to make sure only fp tensor are annotated in quantizer

Reviewed By: jerryzh168

Differential Revision: D55946526

fbshipit-source-id: d94bfee38ab2d29fc9672ab631b4d5d0c5239d25
