### PR TITLE
Add support for MobileNet v2 in Ethos-U55 and arm baremetal runner

### DIFF
--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -45,6 +45,7 @@ class ArmCompileSpecBuilder:
         self.output_format = None
         self.path_for_intermediates = None
         self.permute_nhwc = False
+        self.quantize_io = False
 
     def ethosu_compile_spec(
         self,
@@ -104,6 +105,10 @@ class ArmCompileSpecBuilder:
         self.permute_nhwc = set_nhwc_permutation
         return self
 
+    def set_quantize_io(self, quantize_io: bool = False):
+        self.quantize_io = quantize_io
+        return self
+
     def build(self):
         """
         Generate a list of compile spec objects from the builder
@@ -124,6 +129,11 @@ class ArmCompileSpecBuilder:
         if self.permute_nhwc:
             self.compile_spec.append(
                 CompileSpec("permute_memory_format", "nhwc".encode())
+            )
+
+        if self.quantize_io:
+            self.compile_spec.append(
+                CompileSpec("quantize_io", "True".encode())
             )
 
         return self.compile_spec
@@ -153,6 +163,7 @@ def get_intermediate_path(compile_spec: List[CompileSpec]) -> str:
 def generate_ethosu_compile_spec(
     config: str,
     permute_memory_to_nhwc: Optional[bool] = None,
+    quantize_io: Optional[bool] = None,
     system_config: Optional[str] = None,
     memory_mode: Optional[str] = None,
     extra_flags: Optional[str] = None,
@@ -168,9 +179,9 @@ def generate_ethosu_compile_spec(
             config_ini=config_ini,
         )
         .set_permute_memory_format(permute_memory_to_nhwc)
+        .set_quantize_io(quantize_io)
         .build()
     )
-
 
 def generate_tosa_compile_spec(
     permute_memory_to_nhwc: Optional[bool] = None,

--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -132,9 +132,7 @@ class ArmCompileSpecBuilder:
             )
 
         if self.quantize_io:
-            self.compile_spec.append(
-                CompileSpec("quantize_io", "True".encode())
-            )
+            self.compile_spec.append(CompileSpec("quantize_io", "True".encode()))
 
         return self.compile_spec
 
@@ -182,6 +180,7 @@ def generate_ethosu_compile_spec(
         .set_quantize_io(quantize_io)
         .build()
     )
+
 
 def generate_tosa_compile_spec(
     permute_memory_to_nhwc: Optional[bool] = None,

--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -102,10 +102,18 @@ class ArmCompileSpecBuilder:
         return self
 
     def set_permute_memory_format(self, set_nhwc_permutation: bool = True):
+        """
+        Permute to channel last in compiler and runtime. Compilation and
+        runtime will convert rank 4 inputs to channel last for each sub-graph.
+        """
         self.permute_nhwc = set_nhwc_permutation
         return self
 
     def set_quantize_io(self, quantize_io: bool = False):
+        """
+        Quantization of inputs and dequantization of outputs for cases where
+        whole graph is quantized and method signature is not of quantized type.
+        """
         self.quantize_io = quantize_io
         return self
 

--- a/backends/arm/arm_partitioner.py
+++ b/backends/arm/arm_partitioner.py
@@ -56,6 +56,7 @@ class TOSASupportedOperators(OperatorSupportBase):
         # Override partitioning based on pre partition passes
         if supported and "arm_partition" in node.meta:
             supported = supported & node.meta["arm_partition"]
+            node.meta.pop("arm_partition")
 
         return supported
 

--- a/backends/arm/operators/op_placeholder.py
+++ b/backends/arm/operators/op_placeholder.py
@@ -157,8 +157,8 @@ def process_placeholder(
             buffer_values.shape, inputs[0].dtype, buffer_values, name=out
         )
     else:
-        # Cases for all the input tensors
-        if permute_memory_to_nhwc:
+        # Cases for all the input tensors of rank4
+        if permute_memory_to_nhwc and len(inputs[0].shape) == 4:
             NHWC_Order = [0, 2, 3, 1]
             input_shape = [inputs[0].shape[i] for i in NHWC_Order]
         else:

--- a/backends/arm/runtime/VelaBinStream.h
+++ b/backends/arm/runtime/VelaBinStream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Arm Limited and/or its affiliates.
+ * Copyright 2023-2024 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -49,7 +49,7 @@ typedef struct {
   size_t cmd_data_size;
   const char* weight_data;
   size_t weight_data_size;
-  const char* scratch_data;
+  char* scratch_data;
   size_t scratch_data_size;
   VelaIOs* inputs;
   VelaIOs* outputs;

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -202,7 +202,9 @@ if __name__ == "__main__":
         edge = edge.to_backend(
             ArmPartitioner(
                 generate_ethosu_compile_spec(
-                    "ethos-u55-128", permute_memory_to_nhwc=True
+                    "ethos-u55-128",
+                    permute_memory_to_nhwc=True,
+                    quantize_io=True,
                 )
             )
         )

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -49,7 +49,7 @@ def quantize(model, example_inputs):
     return m
 
 
-# Two simple models
+# Simple example models
 class AddModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -133,8 +133,20 @@ if __name__ == "__main__":
         default=False,
         help="Produce a quantized model",
     )
+    parser.add_argument(
+        "-s",
+        "--so_library",
+        required=False,
+        default=None,
+        help="Provide path to so library. E.g., cmake-out/examples/portable/custom_ops/libcustom_ops_aot_lib.so",
+    )
 
     args = parser.parse_args()
+
+    # if we have custom ops, register them before processing the model
+    if args.so_library is not None:
+        logging.info(f"Loading custom ops from {args.so_library}")
+        torch.ops.load_library(args.so_library)
 
     # support models defined within this file or examples/models/ lists
     if (

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -188,7 +188,11 @@ if __name__ == "__main__":
 
     if args.delegate is True:
         edge = edge.to_backend(
-            ArmPartitioner(generate_ethosu_compile_spec("ethos-u55-128"))
+            ArmPartitioner(
+                generate_ethosu_compile_spec(
+                    "ethos-u55-128", permute_memory_to_nhwc=True
+                )
+            )
         )
         logging.debug(f"Lowered graph:\n{edge.exported_program().graph}")
 

--- a/examples/arm/ethos-u-setup/core_platform/patches/0001-New-phdr-for-.data-section.patch
+++ b/examples/arm/ethos-u-setup/core_platform/patches/0001-New-phdr-for-.data-section.patch
@@ -1,7 +1,7 @@
-From efe17bf0ed88cc1f163dedb29e7e9feabd47c7d7 Mon Sep 17 00:00:00 2001
+From fc2ff3e005999ec185a1ae20c78c06a45651f5bc Mon Sep 17 00:00:00 2001
 From: Digant Desai <digantdesai@meta.com>
 Date: Mon, 2 Oct 2023 20:39:39 -0700
-Subject: [PATCH] New phdr for .data section
+Subject: [PATCH 1/2] New phdr for .data section
 
 ---
  targets/corstone-300/platform.ld | 3 ++-

--- a/examples/arm/ethos-u-setup/core_platform/patches/0002-move-heap-to-DDR-on-Corstone-300.patch
+++ b/examples/arm/ethos-u-setup/core_platform/patches/0002-move-heap-to-DDR-on-Corstone-300.patch
@@ -1,0 +1,33 @@
+From 4213b02079aa355490ee493cb5785191356e246f Mon Sep 17 00:00:00 2001
+From: Rob Elliott <robert.elliott@arm.com>
+Date: Tue, 12 Mar 2024 14:05:35 +0000
+Subject: [PATCH 2/2] move heap to DDR on Corstone-300
+
+Signed-off-by: Rob Elliott <robert.elliott@arm.com>
+---
+ targets/corstone-300/platform.ld | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/targets/corstone-300/platform.ld b/targets/corstone-300/platform.ld
+index 8de77c4..476a2f8 100644
+--- a/targets/corstone-300/platform.ld
++++ b/targets/corstone-300/platform.ld
+@@ -312,7 +312,7 @@ SECTIONS
+     . = . + __HEAP_SIZE;
+     . = ALIGN(8);
+     __HeapLimit = .;
+-  } > DTCM :null
++  } > DDR :null
+ 
+   .stack (ORIGIN(DTCM) + LENGTH(DTCM) - __STACK_SIZE) (COPY) :
+   {
+@@ -325,5 +325,5 @@ SECTIONS
+   PROVIDE(__stack = __StackTop);
+ 
+   /* Check if data + heap + stack exceeds DTCM limit */
+-  ASSERT(__StackLimit >= __HeapLimit, "region DTCM overflowed with stack")
++  ASSERT(__StackLimit >= __bss_end__, "region DTCM overflowed with stack")
+ }
+-- 
+2.34.1
+

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -61,10 +61,16 @@ set_property(TARGET executorch_delegate_ethos_u PROPERTY IMPORTED_LOCATION
 add_library(portable_ops_lib STATIC IMPORTED)
 set_property(TARGET portable_ops_lib PROPERTY IMPORTED_LOCATION
   "${ET_BUILD_DIR_PATH}/examples/arm/libarm_portable_ops_lib.a")
-
 add_library(portable_kernels STATIC IMPORTED)
 set_property(TARGET portable_kernels PROPERTY IMPORTED_LOCATION
   "${ET_BUILD_DIR_PATH}/kernels/portable/libportable_kernels.a")
+
+add_library(quantized_ops_lib STATIC IMPORTED)
+set_property(TARGET quantized_ops_lib PROPERTY IMPORTED_LOCATION
+  "${ET_BUILD_DIR_PATH}/kernels/quantized/libquantized_ops_lib.a")
+add_library(quantized_kernels STATIC IMPORTED)
+set_property(TARGET quantized_kernels PROPERTY IMPORTED_LOCATION
+  "${ET_BUILD_DIR_PATH}/kernels/quantized/libquantized_kernels.a")
 
 add_library(extension_runner_util STATIC IMPORTED)
 set_property(TARGET extension_runner_util PROPERTY IMPORTED_LOCATION
@@ -95,13 +101,15 @@ ethosu_eval_link_options( arm_executor_runner )
 # bin size as we link in a number of other symbols
 target_link_libraries(
   arm_executor_runner
-  "-Wl,--whole-archive"
-  ethosu_target_init
   extension_runner_util
+  ethosu_target_init
   executorch
+  "-Wl,--whole-archive"
   executorch_delegate_ethos_u
-  portable_kernels
+  quantized_ops_lib
   portable_ops_lib
+  quantized_kernels
+  portable_kernels
   "-Wl,--no-whole-archive"
   )
 

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -38,6 +38,10 @@ get_filename_component(ETHOS_SDK_PATH ${ETHOS_SDK_PATH} REALPATH)
 # This is the platform target of Corstone-300, that includes ethosu_core_driver
 # and bare-metal bringup libraries. We link against ethosu_target_init which
 # includes all of these dependencies.
+
+# For Corstone-300 FVP builds we put models into the larger DRAM area
+set(MEMORY_MODEL "dram")
+set(MEMORY_ARENA "dram")
 add_subdirectory(${ETHOS_SDK_PATH}/core_platform/targets/corstone-300 target)
 
 # Dependencies from the ExecuTorch build

--- a/examples/arm/executor_runner/pte_to_header.py
+++ b/examples/arm/executor_runner/pte_to_header.py
@@ -53,7 +53,7 @@ parser.add_argument(
     help="Section attribute for the data array",
     type=str,
     required=False,
-    default=".sram.data",
+    default="network_model_sec",
 )
 
 if __name__ == "__main__":

--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -43,7 +43,7 @@ function generate_pte_file() {
     local delegate=${2}
 
     local model_filename=${model}.pte
-    if [ "${delegate}" = "--delegate" ]; then
+    if [[ "${delegate}" == *"--delegate"* ]]; then
         model_filename=${model}_arm_delegate.pte
     fi
     cd $et_root_dir
@@ -131,8 +131,9 @@ function run_fvp() {
         -C mps3_board.visualisation.disable-visualisation=1 \
         -C mps3_board.telnetterminal0.start_telnet=0        \
         -C mps3_board.uart0.out_file='-'                    \
+        -C mps3_board.uart0.shutdown_on_eot=1               \
         -a "${elf}"                                         \
-        --timelimit 5 || true # seconds
+        --timelimit 30 || true # seconds
     echo "[${FUNCNAME[0]} Simulation complete, $?"
 }
 
@@ -165,8 +166,8 @@ type ${buck2} 2>&1 > /dev/null \
 build_executorch
 
 # the test models run, and whether to delegate
-test_model=( "softmax" "add" "add3" )
-test_delegate=( "" "--delegate" "--delegate" )
+test_model=( "softmax" "add" "add3" "mv2" )
+test_delegate=( "" "--delegate" "--delegate" "--delegate --quantize" )
 
 # loop over running the AoT flow and executing the model on device
 for i in "${!test_model[@]}"; do

--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -77,6 +77,7 @@ function build_executorch() {
         -DCMAKE_BUILD_TYPE=Release                        \
         -DEXECUTORCH_ENABLE_LOGGING=ON                    \
         -DEXECUTORCH_BUILD_ARM_BAREMETAL=ON               \
+        -DEXECUTORCH_BUILD_QUANTIZED=ON                   \
         -DEXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL=ON       \
         -DFLATC_EXECUTABLE="$(which flatc)"               \
         -DCMAKE_TOOLCHAIN_FILE="${toolchain_cmake}"       \
@@ -140,7 +141,7 @@ function run_fvp() {
         -C mps3_board.uart0.out_file='-'                    \
         -C mps3_board.uart0.shutdown_on_eot=1               \
         -a "${elf}"                                         \
-        --timelimit 30 || true # seconds
+        --timelimit 120 || true # seconds
     echo "[${FUNCNAME[0]} Simulation complete, $?"
 }
 

--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -135,6 +135,7 @@ function run_fvp() {
     elf=$(find ${script_dir}/executor_runner -name "${elf_name}")
     [[ ! -f $elf ]] && { echo "[${FUNCNAME[0]}]: Unable to find executor_runner elf: ${elf}"; exit 1; }
     FVP_Corstone_SSE-300_Ethos-U55                          \
+        -C cpu0.CFGITCMSZ=11 \
         -C ethosu.num_macs=128                              \
         -C mps3_board.visualisation.disable-visualisation=1 \
         -C mps3_board.telnetterminal0.start_telnet=0        \

--- a/kernels/portable/cpu/vec_ops.h
+++ b/kernels/portable/cpu/vec_ops.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
+ * Copyright 2024 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -98,7 +99,7 @@ inline void vec_quantized_matmul_int8(
     for (size_t j = 0; j < p; ++j) {
       T sum = 0;
       for (size_t k = 0; k < n; ++k) {
-        sum += x[i * n + k] * y[k * p + j] * s[k];
+        sum += x[i * n + k] * static_cast<U>(y[k * p + j]) * s[k];
       }
       z[i * p + j] = sum;
     }
@@ -130,7 +131,7 @@ inline void vec_quantized_matmul_transb_int8(
         T psum = 0;
         // the last group may have fewer than g elements
         for (size_t k2 = k; k2 < bounds_min(k + g, n); k2++) {
-          psum += x[i * n + k2] * y[j * n + k2];
+          psum += x[i * n + k2] * static_cast<U>(y[j * n + k2]);
         }
         sum += psum * s[j * n_over_g + k / g];
       }

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright 2024 Arm Limited and/or its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -55,6 +56,8 @@ message("Generated files ${gen_command_sources}")
 # dependency of the other(s). This is not allowed by the Xcode "new build
 # system".
 if(NOT CMAKE_GENERATOR STREQUAL "Xcode" AND EXECUTORCH_BUILD_QUANTIZED_OPS_AOT)
+# Not targeting ARM_BAREMETAL as aot_lib depends on incompatible libraries
+if(NOT EXECUTORCH_BUILD_ARM_BAREMETAL)
   set(_quantized_aot_ops
       "quantized_decomposed::add.out"
       "quantized_decomposed::choose_qparams.Tensor_out"
@@ -79,6 +82,7 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode" AND EXECUTORCH_BUILD_QUANTIZED_OPS_AOT)
       ${EXECUTORCH_ROOT}/runtime/core/exec_aten/util/tensor_util_aten.cpp)
   gen_custom_ops_aot_lib(LIB_NAME "quantized_ops_aot_lib" KERNEL_SOURCES
                          "${_quantized_sources}")
+endif()
 endif()
 
 add_library(quantized_kernels ${_quantized_kernels__srcs})


### PR DESCRIPTION
- Builds on TOSA support for mv2
- Currently has accuracy issues for on-target execution.
- Adding support mv2 from examples/models (torchvision mv2)
- Adds ability to use portable Q/DQ ops to enable float signature quantized models (to be improved with int signature when possible to enable integer images rather than int -> float -> quant flow.
- Adds permute for ethos-u backend to enable NCHW to NHWC (which we'll aim to replace with a compiler pass on entry/exit of the subgraph, or the NHWC support when available.
- small fix to enable qantized ops in runtime for the IOQDQ pass, and build/register those kernels/ops in bare metal build