### PR TITLE
Decouple custom ops in llama_transformer.py Part 2/N (#3007)

### DIFF
--- a/examples/models/llama2/TARGETS
+++ b/examples/models/llama2/TARGETS
@@ -18,7 +18,6 @@ runtime.python_library(
     ],
     deps = [
         "//caffe2:torch",
-        "//executorch/examples/models/llama2/custom_ops:llama_custom_ops_aot_lib",
     ],
 )
 
@@ -85,6 +84,7 @@ runtime.python_library(
         "//executorch/backends/vulkan/partitioner:vulkan_partitioner",
         "//executorch/examples/models:model_base",
         "//executorch/examples/models:models",
+        "//executorch/examples/models/llama2/custom_ops:custom_ops_aot_py",
         "//executorch/examples/portable:utils",
         "//executorch/exir:lib",
         "//executorch/sdk/etrecord:etrecord",


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/executorch/pull/3007

Keep llama_transformer.py to look like stock implementation, so that it can be reused everywhere.

Do module swap

Reviewed By: cccclai

Differential Revision: D56048640

fbshipit-source-id: 76de1b09b7f5d79422bb3b32bc830a9a7ecd935c (cherry picked from commit 74eb8b345834db0a4053fb41c796de6b97aaae07)