### PR TITLE
Fix formatting issues in executorch/test/size_test.cpp

### DIFF
--- a/test/size_test.cpp
+++ b/test/size_test.cpp
@@ -37,13 +37,17 @@ int main(int argc, char** argv) {
 
   Result<FileDataLoader> loader = FileDataLoader::from(argv[1]);
   ET_CHECK_MSG(
-      loader.ok(), "FileDataLoader::from() failed: 0x%" PRIx32, loader.error());
+      loader.ok(),
+      "FileDataLoader::from() failed: 0x%" PRIx32,
+      static_cast<uint32_t>(loader.error()));
 
   uint32_t prof_tok = EXECUTORCH_BEGIN_PROF("de-serialize model");
   const auto program = Program::load(&loader.get());
   EXECUTORCH_END_PROF(prof_tok);
   ET_CHECK_MSG(
-      program.ok(), "Program::load() failed: 0x%" PRIx32, program.error());
+      program.ok(),
+      "Program::load() failed: 0x%" PRIx32,
+      static_cast<uint32_t>(program.error()));
   ET_LOG(Info, "Program file %s loaded.", argv[1]);
 
   // Use the first method in the program.


### PR DESCRIPTION
Summary: Required for LLVM-17. Fixes a mismatch between what the format string expects and the type supplied.

Differential Revision: D56206887


