### PR TITLE
Add int16 support to aten_bridge

### DIFF
--- a/extension/aten_util/aten_bridge.cpp
+++ b/extension/aten_util/aten_bridge.cpp
@@ -68,6 +68,8 @@ torch::executor::ScalarType torchToExecuTorchScalarType(caffe2::TypeMeta type) {
       return torch::executor::ScalarType::Byte;
     case c10::ScalarType::Char:
       return torch::executor::ScalarType::Char;
+    case c10::ScalarType::Short:
+      return torch::executor::ScalarType::Short;
     case c10::ScalarType::Half:
       return torch::executor::ScalarType::Half;
     case c10::ScalarType::Int:
@@ -95,6 +97,8 @@ c10::ScalarType execuTorchtoTorchScalarType(torch::executor::ScalarType type) {
       return c10::ScalarType::Byte;
     case torch::executor::ScalarType::Char:
       return c10::ScalarType::Char;
+    case torch::executor::ScalarType::Short:
+      return c10::ScalarType::Short;
     case torch::executor::ScalarType::Half:
       return c10::ScalarType::Half;
     case torch::executor::ScalarType::Int:


### PR DESCRIPTION
Summary: Running an executorch program via pybindings requires the aten_bridge. This currently fails if the model uses the `int16` dtype. This diff adds support for the type by adding it to the conversion switch statements.

Differential Revision: D56199304


