### PR TITLE
remove exir.capture from test_mps_utils

### DIFF
--- a/backends/apple/mps/test/test_mps_utils.py
+++ b/backends/apple/mps/test/test_mps_utils.py
@@ -30,7 +30,6 @@ from executorch.sdk.bundled_program.serialize import (
 from torch.export import export, ExportedProgram
 
 # Config for Capturing the weights, will be moved in the future
-_CAPTURE_CONFIG = exir.CaptureConfig(enable_aot=True, _unlift=True)
 _EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(_check_ir_validity=False)
 
 
@@ -247,16 +246,14 @@ class TestMPS(unittest.TestCase):
                 MPSBackend.__name__, edge_program.exported_program(), compile_specs
             )
 
-            executorch_program = (
-                exir.capture(
+            executorch_program = to_edge(
+                export(
                     delegated_program,
                     sample_inputs,
-                    exir.CaptureConfig(enable_aot=True, _unlift=False),
-                )
-                .to_edge(exir.EdgeCompileConfig(_check_ir_validity=False))
-                .to_executorch(
-                    config=ExecutorchBackendConfig(extract_constant_segment=False)
-                )
+                ),
+                compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+            ).to_executorch(
+                config=ExecutorchBackendConfig(extract_constant_segment=False)
             )
 
         if bundled_program:


### PR DESCRIPTION
Summary: capture is deprecated use export instead

Differential Revision: D56217525


