### PR TITLE
[ET-VK][4/n] Improve codegen for aten.permute

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/Permute.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Permute.cpp
@@ -101,6 +101,7 @@ void permute(ComputeGraph& graph, const std::vector<ValueRef>& args) {
 }
 
 REGISTER_OPERATORS {
+  VK_REGISTER_OP(aten.permute.default, permute);
   VK_REGISTER_OP(aten.permute_copy.default, permute);
 }
 

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -206,5 +206,6 @@ test_suites = {
     "aten.full.default": get_full_inputs(),
     "aten.select.int": get_select_int_inputs(),
     "aten.select_copy.int": get_select_int_inputs(),
+    "aten.permute.default": get_permute_inputs(),
     "aten.permute_copy.default": get_permute_inputs(),
 }

--- a/backends/vulkan/test/op_tests/utils/codegen.py
+++ b/backends/vulkan/test/op_tests/utils/codegen.py
@@ -310,7 +310,9 @@ class ComputeGraphGen:
                 ret_str += self.declare_vk_out_for(r)
             return ret_str
 
-        return f"at::Tensor vk_{ref.name} = at::empty_like({ref.src_cpp_name});\n"
+        ret_str = f"at::Tensor vk_{ref.name} = at::empty_like({ref.src_cpp_name})"
+        ret_str += ".contiguous();\n"
+        return ret_str
 
     def copy_from_staging(self, ref: ValueRefList) -> str:
         if isinstance(ref, list):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3088
* __->__ #3087
* #3086
* #3085

In the generated code, it uses CPU as reference implementation.

Tricky part happens when CPU modify the stride for some indexing operations like `permute`, leading the return Tensor with a non-continous stride.

When we create a `vk_out` tensor based on this non-continous tensor with `at::empty_like`, the `vk_out` tensor inherits the stride property. Leading to wrong answer when moving data back from staging.

As a solution, we add `.continous()` to after `at::empty_like` to revert back to default stride.

Differential Revision: [D56095204](https://our.internmc.facebook.com/intern/diff/D56095204/)