### PR TITLE
[ET-VK][5/n] make_seq_tensor in codegen

### DIFF
--- a/backends/vulkan/test/op_tests/utils/codegen_base.py
+++ b/backends/vulkan/test/op_tests/utils/codegen_base.py
@@ -218,6 +218,25 @@ at::Tensor make_rand_tensor(
     return at::rand(sizes, at::device(at::kCPU).dtype(dtype)) * (high - low) + low;
 }}
 
+
+at::Tensor make_seq_tensor(
+    std::vector<int64_t> sizes,
+      at::ScalarType dtype = at::kFloat) {{
+  int64_t n = 1;
+  for (auto size: sizes) {{
+    n *= size;
+  }}
+
+  std::vector<float> values(n);
+  for (int i=0;i<n;i++) {{
+    values[i] = (float) i;
+  }}
+
+  // from_blob doesn't take ownership of data. Hence must create a copy as
+  // "values" will go out of scope.
+  return at::from_blob(values.data(), sizes, dtype).detach().clone();
+}}
+
 {test_suites_cpp}
 """
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3088
* #3087
* #3086
* #3085

increasing sequence is very useful for development, particularly for "slicing" and "indexing" operations.

Differential Revision: [D56095314](https://our.internmc.facebook.com/intern/diff/D56095314/)