### PR TITLE
[ET-VK][6/n] vulkan copy_command

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -101,6 +101,24 @@ void Context::register_shader_dispatch(
   cmd_.dispatch(effective_global_wg);
 }
 
+
+void Context::register_copy(
+      PipelineBarrier& pipeline_barrier,
+      const VulkanImage& src,
+      const VulkanImage& dst,
+      const api::utils::uvec3& copy_range,
+      const api::utils::uvec3& src_offset,
+      const api::utils::uvec3& dst_offset) {
+  cmd_.insert_barrier(pipeline_barrier);
+  cmd_.copy_texture_to_texture(
+      src,
+      dst,
+      copy_range,
+      src_offset,
+      dst_offset);
+}
+
+
 void Context::submit_cmd_to_gpu(VkFence fence_handle, const bool final_use) {
   if (cmd_) {
     cmd_.end();

--- a/backends/vulkan/runtime/api/Context.h
+++ b/backends/vulkan/runtime/api/Context.h
@@ -180,6 +180,14 @@ class Context final {
       const ShaderInfo&,
       const utils::uvec3&);
 
+  void register_copy(
+      PipelineBarrier&,
+      const VulkanImage& src,
+      const VulkanImage& dst,
+      const api::utils::uvec3& copy_range,
+      const api::utils::uvec3& src_offset,
+      const api::utils::uvec3& dst_offset);
+
   template <class S, class D>
   bool submit_copy(
       PipelineBarrier&,

--- a/backends/vulkan/runtime/graph/ops/ExecuteNode.h
+++ b/backends/vulkan/runtime/graph/ops/ExecuteNode.h
@@ -1,3 +1,5 @@
+//123123
+
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3090
* #3088
* #3087
* #3086
* #3085

Some operators can be specified directly as a copy-command with offsets.

This diff exposes the command thru the ComputeGraph.

Differential Revision: [D56174686](https://our.internmc.facebook.com/intern/diff/D56174686/)