### PR TITLE
Fix build time warning

### DIFF
--- a/examples/models/llama2/README.md
+++ b/examples/models/llama2/README.md
@@ -146,6 +146,7 @@ The Wikitext results generated above used: `{max_seq_len: 2048, limit: 1000}`
         -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
         -DEXECUTORCH_BUILD_XNNPACK=ON \
         -DEXECUTORCH_BUILD_OPTIMIZED=ON \
+        -DEXECUTORCH_BUILD_CUSTOM=ON \
         -Bcmake-out .
 
     cmake --build cmake-out -j16 --target install --config Release
@@ -156,7 +157,9 @@ The Wikitext results generated above used: `{max_seq_len: 2048, limit: 1000}`
     cmake -DPYTHON_EXECUTABLE=python \
         -DCMAKE_INSTALL_PREFIX=cmake-out \
         -DCMAKE_BUILD_TYPE=Release \
+        -DEXECUTORCH_BUILD_CUSTOM=ON \
         -DEXECUTORCH_BUILD_OPTIMIZED=ON \
+        -DEXECUTORCH_BUILD_XNNPACK=ON \
         -Bcmake-out/examples/models/llama2 \
         examples/models/llama2
 

--- a/extension/evalue_util/print_evalue.cpp
+++ b/extension/evalue_util/print_evalue.cpp
@@ -149,12 +149,12 @@ void print_tensor(std::ostream& os, exec_aten::Tensor tensor) {
   //
   // TODO(T159700776): Format multidimensional data like numpy/PyTorch does.
   // https://github.com/pytorch/pytorch/blob/main/torch/_tensor_str.py
-#define PRINT_TENSOR_DATA(ctype, dtype)                            \
-  case ScalarType::dtype:                                          \
-    print_scalar_list(                                             \
-        os,                                                        \
-        ArrayRef<ctype>(tensor.data_ptr<ctype>(), tensor.numel()), \
-        /*print_length=*/false);                                   \
+#define PRINT_TENSOR_DATA(ctype, dtype)                                  \
+  case ScalarType::dtype:                                                \
+    print_scalar_list(                                                   \
+        os,                                                              \
+        ArrayRef<ctype>(tensor.const_data_ptr<ctype>(), tensor.numel()), \
+        /*print_length=*/false);                                         \
     break;
 
   switch (tensor.scalar_type()) {


### PR DESCRIPTION
Summary: tensor.data_ptr() is deprecated. To avoid warning change it to tensor.const_data_ptr()

Differential Revision: D56251975


