### PR TITLE
throw Java exception when execution fails

### DIFF
--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -325,8 +325,8 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
 #endif
 
     if (!result.ok()) {
-      ET_LOG(
-          Error,
+      facebook::jni::throwNewJavaException(
+          "java/lang/Exception",
           "Execution of method %s failed with status 0x%" PRIx32,
           method.c_str(),
           static_cast<error_code_t>(result.error()));


### PR DESCRIPTION
Summary: Instead of logging, we throw a java exception and let user catch it.

Reviewed By: dbcakadbc

Differential Revision: D56270287


