### PR TITLE
Free Vulkan delegate segments after loading

### DIFF
--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -449,6 +449,9 @@ class VulkanBackend final : public PyTorchBackendInterface {
 
     Error err = compileModel(processed->data(), compute_graph);
 
+    // This backend does not need its processed data after compiling the model.
+    processed->Free();
+
     if (err != Error::Ok) {
       return err;
     }


### PR DESCRIPTION
Summary:
It's been a while since I had an impactful one-liner. :)

Nothing innovative here, just reusing the same solution as [other backends](https://github.com/pytorch/executorch/blob/b19d5860568187f2567d93dd5e7cd5af32378d9f/backends/xnnpack/runtime/XNNPACKBackend.cpp#L47-L48).

Differential Revision: D56281665


