### PR TITLE
cherry-pick: Add required deps to pyproject.toml

### DIFF
--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -75,6 +75,7 @@ EXIR_REQUIREMENTS=(
 # pip packages needed for development.
 DEVEL_REQUIREMENTS=(
   cmake  # For building binary targets.
+  pyyaml  # Imported by the kernel codegen tools.
   setuptools  # For building the pip package.
   tomli  # Imported by extract_sources.py when using python < 3.11.
   wheel  # For building the pip package archive.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,20 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = [
+  "cmake",  # For building binary targets in the wheel.
+  "pyyaml",  # Imported by the kernel codegen tools.
+  "setuptools",  # For building the pip package contents.
+  "tomli",  # Imported by extract_sources.py when using python < 3.11.
+  "wheel",  # For building the pip package archive.
+  "zstd",  # Imported by resolve_buck.py.
+]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "executorch"
-version = "0.1.0"
+# TODO(dbort): Use setuptools-git-versioning or setuptools-scm to get the
+# version from the git branch state. For now, use a version that doesn't look
+# like a real release.
+version = "0.2.1.dev0+unknown"
 # Python dependencies required for development
 dependencies=[
   "expecttest",


### PR DESCRIPTION
Cherry-pick 28f1c8cb54cbd0faa2e80660d809d53edb014dcc from release/0.2 into main

These pip dependencies need to be present to build the pip wheel.

Also, change the version to a stub that looks less like a real version,
until we can hook up the logic to get the version from the git repo
state.