### PR TITLE
Add missing ops for RNNT predictor

### DIFF
--- a/examples/cadence/ops/CMakeLists.txt
+++ b/examples/cadence/ops/CMakeLists.txt
@@ -29,6 +29,8 @@ set(_aten_ops__srcs
     "${CMAKE_CURRENT_SOURCE_DIR}/op_embedding.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/op_full.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/op_view_copy.cpp"
+    "${EXECUTORCH_ROOT}/kernels/portable/cpu/op_permute_copy.cpp"
+    "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/copy_ops_util.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/broadcast_util.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/repeat_util.cpp")
 add_library(aten_ops_cadence ${_aten_ops__srcs})

--- a/examples/cadence/ops/functions.yaml
+++ b/examples/cadence/ops/functions.yaml
@@ -27,6 +27,11 @@
     - arg_meta: null
       kernel_name: torch::executor::full_out
 
+- op: permute_copy.out
+  kernels:
+    - arg_meta: null
+      kernel_name: torch::executor::permute_copy_out
+
 - op: view_copy.out
   kernels:
     - arg_meta: null
@@ -49,6 +54,11 @@
   kernels:
     - arg_meta: null
       kernel_name: impl::HiFi::quantized_conv_out
+
+- func: cadence::quantized_layer_norm.out(Tensor input, Tensor in_scale, Tensor in_zero_point, int[] normalized_shape, Tensor weight, Tensor bias, float eps, float output_scale, int output_zero_point, *, Tensor(a!) out) -> Tensor(a!)
+  kernels:
+    - arg_meta: null
+      kernel_name: impl::HiFi::quantized_layer_norm_out
 
 - func: cadence::quantized_linear.out(Tensor src, Tensor weight, Tensor bias, float src_scale, int src_zero_point, float weight_scale, int weight_zero_point, Tensor out_multiplier, Tensor out_shift, int out_zero_point, *, Tensor(a!) out) -> Tensor(a!)
   kernels:


### PR DESCRIPTION
Summary: As titled. Permute and quantized_linear were not registered properly.

Differential Revision: D56305088


