### PR TITLE
Revise memory monitor to align with Xcode metrics

### DIFF
--- a/examples/demo-apps/apple_ios/LLaMA/LLaMA/Application/ResourceMonitor.swift
+++ b/examples/demo-apps/apple_ios/LLaMA/LLaMA/Application/ResourceMonitor.swift
@@ -33,16 +33,16 @@ final class ResourceMonitor: ObservableObject {
   }
 
   private func usedMemoryInMB() -> Int {
-    var info = mach_task_basic_info()
-    var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+    var info = task_vm_info_data_t()
+    var count = mach_msg_type_number_t(MemoryLayout<task_vm_info>.size) / 4
 
     let kerr: kern_return_t = withUnsafeMutablePointer(to: &info) {
       $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
-        task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+        task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
       }
     }
     guard kerr == KERN_SUCCESS else { return 0 }
-    return Int(info.resident_size / 0x100000)
+    return Int(info.phys_footprint / 0x100000)
   }
 
   private func availableMemoryInMB() -> Int {


### PR DESCRIPTION
Summary:
Ref: https://forums.developer.apple.com/forums/thread/105088

*If you’re going to record a single number, this footprint value is a good one to use. I don’t think we guarantee that it’ll align with the Xcode memory gauge, but it’s much more useful value than all the older stuff (like resident_size)*

Therefore revise it.

Differential Revision: D56290391


