### PR TITLE
DynamicShim for dlsym user

### DIFF
--- a/runtime/core/portable_type/targets.bzl
+++ b/runtime/core/portable_type/targets.bzl
@@ -49,6 +49,7 @@ def define_common_targets():
             "bits_types.h",
         ],
         visibility = [
+            "//executorch/extension/...",
             "//executorch/runtime/core/exec_aten/util/...",
             "//executorch/kernels/...",
         ],


### PR DESCRIPTION
Summary:
Add a shim layer so that users just need the header and load the symbol with dlsym.

we will have two libraries:
- header, where declarations and class (shim) are to be compiled with their codebase statically. Want to keep this minimal.
- implementation, which pulls in the ET libraries and shim implementation. It’s compiled separately as a .so file and they can load and find symbols with dlopen and dlsym.


Note that users only need to compile the header dynamic_shim.h into their code in compile time. dynamic_shim.h contains minimal dependency from ExecuTorch, so it won't impact static time binary size or startup time. The actual implementation dynamic_shim_impl is compiled into a separate shared library, which has all the ExecuTorch libraries. The shared library can be loaded later with dlopen.

For users, they can now only load the so library, and just use dysym to look for exposed API `create_executorch_dynamic_shim` and `free_executorch_dynamic_shim`, and use API code in DynamicShim (as a pointer to an interface), and the DynamicShimImpl will invoke the actual ET Module code in its implementation details.

Differential Revision: D55025594


