### PR TITLE
Comply llama2 runner with gcc 11.4

### DIFF
--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -51,8 +51,8 @@ Module::Module(
     std::unique_ptr<EventTracer> event_tracer)
     : data_loader_(std::move(data_loader)),
       memory_allocator_(
-          std::move(memory_allocator)
-              ?: std::make_unique<util::MallocMemoryAllocator>()),
+          memory_allocator ? std::move(memory_allocator)
+                           : std::make_unique<util::MallocMemoryAllocator>()),
       event_tracer_(std::move(event_tracer)) {
   runtime_init();
 }


### PR DESCRIPTION
Summary: This seems like a simple change so that it can compile with gcc 11.4

Differential Revision: D56320381


