### PR TITLE
[Llama3] Add reference to the llama2 example for llama3

### DIFF
--- a/examples/models/llama3/README.md
+++ b/examples/models/llama3/README.md
@@ -1,0 +1,2 @@
+# Summary
+For Llama3, use the same example code, minus tokenizer, as Llama2. Please see the ../llama2/README.md for details.


### PR DESCRIPTION
In conjunction with @iseeyuan's changes, add an `examples/models/llama3/README.md` just in case people are looking for a Llama 3 folder in examples.