### PR TITLE
[ET-VK] Introduce `ParamsBindList` to prevent needing to pass `shared_ptr` to bind parameter UBOs

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -235,5 +235,28 @@ UniformParamsBuffer& UniformParamsBuffer::operator=(
   return *this;
 }
 
+ParamsBindList::ParamsBindList(
+    std::initializer_list<const api::BufferBindInfo> init_list) {
+  bind_infos.resize(init_list.size());
+  std::copy(init_list.begin(), init_list.end(), bind_infos.begin());
+}
+
+ParamsBindList::ParamsBindList(
+    std::initializer_list<const api::UniformParamsBuffer*> init_list) {
+  bind_infos.resize(init_list.size());
+  for (int i = 0; i < init_list.size(); ++i) {
+    bind_infos[i] = api::BufferBindInfo(init_list.begin()[i]->buffer());
+  }
+}
+
+ParamsBindList::ParamsBindList(
+    std::initializer_list<std::shared_ptr<api::UniformParamsBuffer>>
+        init_list) {
+  bind_infos.resize(init_list.size());
+  for (int i = 0; i < init_list.size(); ++i) {
+    bind_infos[i] = api::BufferBindInfo(init_list.begin()[i]->buffer());
+  }
+}
+
 } // namespace api
 } // namespace vkcompute

--- a/backends/vulkan/runtime/api/Context.h
+++ b/backends/vulkan/runtime/api/Context.h
@@ -244,7 +244,7 @@ class UniformParamsBuffer final {
     }
   }
 
-  VulkanBuffer& buffer() {
+  const VulkanBuffer& buffer() const {
     return vulkan_buffer_;
   }
 
@@ -262,6 +262,19 @@ class UniformParamsBuffer final {
       *data_ptr = block;
     }
   }
+};
+
+struct ParamsBindList final {
+  std::vector<api::BufferBindInfo> bind_infos;
+
+  ParamsBindList(std::initializer_list<const api::BufferBindInfo> init_list);
+
+  ParamsBindList(
+      std::initializer_list<const api::UniformParamsBuffer*> init_list);
+
+  ParamsBindList(
+      std::initializer_list<std::shared_ptr<api::UniformParamsBuffer>>
+          init_list);
 };
 
 class StorageBuffer final {
@@ -329,6 +342,11 @@ inline void arg_is_empty(bool& any_is_empty, const VulkanBuffer& buffer) {
 inline void arg_is_empty(bool& any_is_empty, const VulkanImage& image) {
   // bool(image) will evaluate to false if no memory has been allocated
   any_is_empty = any_is_empty || !image;
+}
+
+inline void arg_is_empty(bool& any_is_empty, const BufferBindInfo& bind_info) {
+  // bool(image) will evaluate to false if no memory has been allocated
+  any_is_empty = any_is_empty || (bind_info.handle == VK_NULL_HANDLE);
 }
 
 /*

--- a/backends/vulkan/runtime/api/Descriptor.cpp
+++ b/backends/vulkan/runtime/api/Descriptor.cpp
@@ -16,6 +16,18 @@ namespace vkcompute {
 namespace api {
 
 //
+// BufferBinding
+//
+
+BufferBindInfo::BufferBindInfo()
+    : handle(VK_NULL_HANDLE), offset(0u), range(0u) {}
+
+BufferBindInfo::BufferBindInfo(const VulkanBuffer& buffer_p)
+    : handle(buffer_p.handle()),
+      offset(buffer_p.mem_offset()),
+      range(buffer_p.mem_range()) {}
+
+//
 // DescriptorSet
 //
 
@@ -61,6 +73,21 @@ DescriptorSet& DescriptorSet::bind(
   binder.resource_info.buffer_info.buffer = buffer.handle(); // buffer
   binder.resource_info.buffer_info.offset = buffer.mem_offset(); // offset
   binder.resource_info.buffer_info.range = buffer.mem_range(); // range
+  add_binding(binder);
+
+  return *this;
+}
+
+DescriptorSet& DescriptorSet::bind(
+    const uint32_t idx,
+    const BufferBindInfo& bind_info) {
+  DescriptorSet::ResourceBinding binder{};
+  binder.binding_idx = idx; // binding_idx
+  binder.descriptor_type = shader_layout_signature_[idx]; // descriptor_type
+  binder.is_image = false; // is_image
+  binder.resource_info.buffer_info.buffer = bind_info.handle; // buffer
+  binder.resource_info.buffer_info.offset = bind_info.offset; // offset
+  binder.resource_info.buffer_info.range = bind_info.range; // range
   add_binding(binder);
 
   return *this;

--- a/backends/vulkan/runtime/api/Descriptor.h
+++ b/backends/vulkan/runtime/api/Descriptor.h
@@ -20,6 +20,20 @@
 namespace vkcompute {
 namespace api {
 
+/*
+ * Stores the binding information of a Vulkan Buffer so that the buffer can be
+ * bound at a later time. This struct should only be used if the buffer to be
+ * bound is guaranteed to be active at the time of binding.
+ */
+struct BufferBindInfo final {
+  VkBuffer handle;
+  VkDeviceSize offset;
+  VkDeviceSize range;
+
+  BufferBindInfo();
+  BufferBindInfo(const VulkanBuffer& buffer_p);
+};
+
 class DescriptorSet final {
  public:
   explicit DescriptorSet(VkDevice, VkDescriptorSet, ShaderLayout::Signature);
@@ -50,6 +64,7 @@ class DescriptorSet final {
   std::vector<ResourceBinding> bindings_;
 
  public:
+  DescriptorSet& bind(const uint32_t, const BufferBindInfo&);
   DescriptorSet& bind(const uint32_t, const VulkanBuffer&);
   DescriptorSet& bind(const uint32_t, const VulkanImage&);
 

--- a/backends/vulkan/runtime/api/Tensor.h
+++ b/backends/vulkan/runtime/api/Tensor.h
@@ -118,17 +118,17 @@ class vTensor final {
 
   // A Vulkan uniform buffer containing the tensor sizes in WHCN that can be
   // passed into a shader.
-  std::shared_ptr<api::UniformParamsBuffer> cpu_sizes_uniform_;
+  api::UniformParamsBuffer cpu_sizes_uniform_;
 
   // A Vulkan uniform buffer containing the GPU tensor sizes in WHCN that can
   // be passed into a shader. GPU sizes refers to the sizes of the tensor after
   // padding has been applied to one dimension to align it to the next multiple
   // of 4.
-  std::shared_ptr<api::UniformParamsBuffer> gpu_sizes_uniform_;
+  api::UniformParamsBuffer gpu_sizes_uniform_;
 
   // A Vulkan uniform buffer containing the image extents of the underlying
   // image texture that can be passed into a shader.
-  std::shared_ptr<api::UniformParamsBuffer> extents_uniform_;
+  api::UniformParamsBuffer extents_uniform_;
 
   // Store the backing storage of the tensor as a shared pointer to allow two
   // tensors to share the same underlying resource, but with different metadata.
@@ -210,21 +210,21 @@ class vTensor final {
    * shader. Note that the UBO will be created the first time this function is
    * called.
    */
-  std::shared_ptr<api::UniformParamsBuffer> cpu_sizes_ubo();
+  const api::BufferBindInfo cpu_sizes_ubo();
 
   /*
    * Get a uniform buffer object containing the tensor GPU sizes to use in a
    * compute shader. Note that the UBO will be created the first time this
    * function is called.
    */
-  std::shared_ptr<api::UniformParamsBuffer> gpu_sizes_ubo();
+  const api::BufferBindInfo gpu_sizes_ubo();
 
   /*
    * Get a uniform buffer object containing the image extents to use in a
    * compute shader. Note that the UBO will be created the first time this
    * function is called.
    */
-  std::shared_ptr<api::UniformParamsBuffer> extents_ubo();
+  const api::BufferBindInfo extents_ubo();
 
   inline size_t numel() const {
     return api::utils::multiply_integers(sizes());

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -59,6 +59,7 @@ ComputeGraph::ComputeGraph(GraphConfig config)
           config_.contextConfig)},
       shared_objects_{},
       values_{},
+      param_ubos_{},
       prepack_nodes_{},
       execute_nodes_{},
       inputs_{},

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -93,6 +93,7 @@ class ComputeGraph final {
   std::unique_ptr<api::Context> context_;
   std::vector<SharedObject> shared_objects_;
   std::vector<Value> values_;
+  std::vector<api::UniformParamsBuffer> param_ubos_;
 
   std::vector<std::unique_ptr<PrepackNode>> prepack_nodes_;
   std::vector<std::unique_ptr<ExecuteNode>> execute_nodes_;
@@ -314,9 +315,9 @@ class ComputeGraph final {
   ValueRef set_output_tensor(const ValueRef idx, const bool use_staging = true);
 
   template <typename Block>
-  inline std::shared_ptr<api::UniformParamsBuffer> create_params_buffer(
-      const Block& data) {
-    return std::make_shared<api::UniformParamsBuffer>(context_.get(), data);
+  const api::BufferBindInfo create_params_buffer(const Block& data) {
+    param_ubos_.emplace_back(api::UniformParamsBuffer(context_.get(), data));
+    return api::BufferBindInfo(param_ubos_.back().buffer());
   }
 
   /*

--- a/backends/vulkan/runtime/graph/ops/ExecuteNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/ExecuteNode.cpp
@@ -20,7 +20,7 @@ ExecuteNode::ExecuteNode(
     const api::utils::uvec3& global_workgroup_size,
     const api::utils::uvec3& local_workgroup_size,
     const std::vector<ArgGroup>& args,
-    const std::vector<std::shared_ptr<api::UniformParamsBuffer>>& params,
+    const api::ParamsBindList& params,
     const ResizeFunction& resize_fn,
     const std::vector<ValueRef>& resize_args,
     const api::SpecVarList& spec_vars)
@@ -47,6 +47,7 @@ void ExecuteNode::encode(ComputeGraph* graph) {
   uint32_t idx = 0;
   idx = bind_values_to_descriptor_set(
       graph, args_, pipeline_barrier, descriptor_set, idx);
+
   bind_params_to_descriptor_set(params_, descriptor_set, idx);
 
   context->register_shader_dispatch(

--- a/backends/vulkan/runtime/graph/ops/ExecuteNode.h
+++ b/backends/vulkan/runtime/graph/ops/ExecuteNode.h
@@ -54,7 +54,7 @@ class ExecuteNode final {
       const api::utils::uvec3& global_workgroup_size,
       const api::utils::uvec3& local_workgroup_size,
       const std::vector<ArgGroup>& args,
-      const std::vector<std::shared_ptr<api::UniformParamsBuffer>>& params,
+      const api::ParamsBindList& params,
       const ResizeFunction& resize_fn = nullptr,
       const std::vector<ValueRef>& resize_args = {},
       const api::SpecVarList& spec_vars = {});
@@ -74,7 +74,7 @@ class ExecuteNode final {
   const api::utils::uvec3 global_workgroup_size_;
   const api::utils::uvec3 local_workgroup_size_;
   const std::vector<ArgGroup> args_;
-  std::vector<std::shared_ptr<api::UniformParamsBuffer>> params_;
+  const api::ParamsBindList params_;
   const ResizeFunction resize_fn_;
   const std::vector<ValueRef> resize_args_;
   const api::SpecVarList spec_vars_;

--- a/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
@@ -31,7 +31,7 @@ PrepackNode::PrepackNode(
     const api::utils::uvec3& local_workgroup_size,
     const ValueRef tref,
     const ValueRef packed,
-    const std::vector<std::shared_ptr<api::UniformParamsBuffer>>& params)
+    const api::ParamsBindList& params)
     : shader_(shader),
       noop_shader_(get_noop_shader(graph, packed)),
       global_workgroup_size_(global_workgroup_size),

--- a/backends/vulkan/runtime/graph/ops/PrepackNode.h
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.h
@@ -33,7 +33,7 @@ class PrepackNode final {
       const api::utils::uvec3& local_workgroup_size,
       const ValueRef tref,
       const ValueRef packed,
-      const std::vector<std::shared_ptr<api::UniformParamsBuffer>>& params);
+      const api::ParamsBindList& params);
 
   ~PrepackNode() = default;
 
@@ -46,7 +46,7 @@ class PrepackNode final {
   const api::utils::uvec3 local_workgroup_size_;
   const ValueRef tref_;
   const ValueRef packed_;
-  std::vector<std::shared_ptr<api::UniformParamsBuffer>> params_;
+  const api::ParamsBindList params_;
 
  private:
   api::StorageBuffer create_staging_buffer(ComputeGraph* graph);

--- a/backends/vulkan/runtime/graph/ops/utils/BindingUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/utils/BindingUtils.cpp
@@ -55,12 +55,12 @@ uint32_t bind_values_to_descriptor_set(
 }
 
 uint32_t bind_params_to_descriptor_set(
-    std::vector<std::shared_ptr<api::UniformParamsBuffer>>& params,
+    const api::ParamsBindList& params,
     api::DescriptorSet& descriptor_set,
     const uint32_t base_idx) {
   uint32_t idx = base_idx;
-  for (auto& param : params) {
-    descriptor_set.bind(idx++, param->buffer());
+  for (auto& param : params.bind_infos) {
+    descriptor_set.bind(idx++, param);
   }
   return idx;
 }

--- a/backends/vulkan/runtime/graph/ops/utils/BindingUtils.h
+++ b/backends/vulkan/runtime/graph/ops/utils/BindingUtils.h
@@ -35,7 +35,7 @@ uint32_t bind_values_to_descriptor_set(
 //
 
 uint32_t bind_params_to_descriptor_set(
-    std::vector<std::shared_ptr<api::UniformParamsBuffer>>& params,
+    const api::ParamsBindList& params,
     api::DescriptorSet& descriptor_set,
     const uint32_t base_idx);
 

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -35,8 +35,8 @@ void record_nchw_to_image_op(
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
       src_buffer,
-      v_dst.gpu_sizes_ubo()->buffer(),
-      v_dst.cpu_sizes_ubo()->buffer());
+      v_dst.gpu_sizes_ubo(),
+      v_dst.cpu_sizes_ubo());
 }
 
 void record_image_to_nchw_op(
@@ -55,8 +55,8 @@ void record_image_to_nchw_op(
       VK_NULL_HANDLE,
       v_src.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       dst_buffer,
-      v_src.gpu_sizes_ubo()->buffer(),
-      v_src.cpu_sizes_ubo()->buffer());
+      v_src.gpu_sizes_ubo(),
+      v_src.cpu_sizes_ubo());
 }
 
 void record_conv2d_prepack_weights_op(
@@ -96,7 +96,7 @@ void record_conv2d_prepack_weights_op(
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
       src_buffer,
-      v_dst.gpu_sizes_ubo()->buffer(),
+      v_dst.gpu_sizes_ubo(),
       original_sizes_ubo.buffer(),
       padded_sizes_ubo.buffer());
 }
@@ -125,7 +125,7 @@ void record_binary_op(
           api::MemoryAccessType::WRITE),
       v_in1.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       v_in2.image(pipeline_barrier, api::PipelineStage::COMPUTE),
-      v_dst.extents_ubo()->buffer());
+      v_dst.extents_ubo());
 }
 
 void execute_and_check_add(

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -923,8 +923,8 @@ void run_from_gpu_test(
             pipeline_barrier,
             api::PipelineStage::COMPUTE,
             api::MemoryAccessType::WRITE),
-        vten.gpu_sizes_ubo()->buffer(),
-        vten.cpu_sizes_ubo()->buffer());
+        vten.gpu_sizes_ubo(),
+        vten.cpu_sizes_ubo());
   }
 
   api::StorageBuffer staging_buffer(api::context(), dtype, vten.gpu_numel());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3150
* #3149
* #3148

## Context

In keeping with the below changeset in this stack, this diff introduces the `ParamsBindList` structure to avoid storing shared pointers to `api::UniformParamsBuffer` objects in `ExecuteNode` and `PrepackNode`.

The idea is to store the binding information of each UPB instead of taking ownership of the UPB itself. There isn't really a need for `ExecuteNode` and `PrepackNode` to take ownership since `ComputeGraph` provides a guarantee that the UPBs will be in scope at the time of binding.

With this change, all `shared_ptr` members can be eliminated from `vTensor`, further reducing heap allocations and pointer chasing.

In the future I will change `prepack_nodes_` and `execute_nodes_` to store `PrepackNode` and `ExecuteNode` instances directly instead of storing unique pointers to them.


Differential Revision: [D56357188](https://our.internmc.facebook.com/intern/diff/D56357188/)