### PR TITLE
Fix embedding_4bit out variant

### DIFF
--- a/exir/passes/_quant_patterns_and_replacements.py
+++ b/exir/passes/_quant_patterns_and_replacements.py
@@ -179,7 +179,7 @@ quantized_decomposed_lib.define(
 
 quantized_decomposed_lib.define(
     "embedding_4bit.dtype(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, "
-    "int weight_quant_min, int weight_quant_max, Tensor indices, ScalarType? dtype=None) -> Tensor",
+    "int weight_quant_min, int weight_quant_max, Tensor indices, *, ScalarType? dtype=None) -> Tensor",
 )
 
 quantized_decomposed_lib.define(


### PR DESCRIPTION
Summary: In  #3095 there's an issue with the embedding_4bit schema which causes mismatch between functional and out variant. P1217884556

Differential Revision: D56357762


