### PR TITLE
Use "main" as the version for prebuilt frameworks.

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -58,7 +58,7 @@ jobs:
       timeout: 90
       script: |
         BUILD_TOOL=cmake
-        VERSION="0.1.0"
+        VERSION="main"
         FRAMEWORKS=(
           "executorch"
           "coreml_backend"


### PR DESCRIPTION
Summary: .

Differential Revision: D56363475


