### PR TITLE
Fix build-framework-ios CI job (#2996)

### DIFF
--- a/runtime/executor/targets.bzl
+++ b/runtime/executor/targets.bzl
@@ -84,6 +84,8 @@ def define_common_targets():
                 "//executorch/runtime/kernel:operator_registry",
                 "//executorch/runtime/platform:platform",
                 "//executorch/schema:extended_header",
+            ],
+            deps = [
                 "//executorch/schema:program",
             ],
             visibility = [


### PR DESCRIPTION
Summary:
As titled. `build_apple_frameworks.sh` is copying all the exported headers out and in #2934 `//executorch/schema:program` is being moved to `exported_deps` and causing `build_apple_frameworks.sh` to not able to copy generated headers `program_generated.h` and `scalar_type_generated.h`.

This PR fixes it by moving it back to `deps`.

Pull Request resolved: https://github.com/pytorch/executorch/pull/2996

Reviewed By: kirklandsign

Differential Revision: D56028952

Pulled By: larryliu0820

fbshipit-source-id: 2cd4999154877b0ac7b49cd1f54d518cba34b2f2 (cherry picked from commit 3b727a785cf3faac498065a80fdc0e24be6c16f7)