### PR TITLE
Add memory and vector include in managed_tensor.h

### DIFF
--- a/extension/runner_util/managed_tensor.h
+++ b/extension/runner_util/managed_tensor.h
@@ -10,6 +10,10 @@
 #include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 #include <executorch/runtime/core/exec_aten/util/tensor_util.h>
 #include <executorch/runtime/platform/assert.h>
+#include <memory>
+// NOTE: required by torchchat install_et.sh script.
+// @nolint PATTERNLINT Ok to use stdlib for this optional library
+#include <vector>
 
 #ifdef USE_ATEN_LIB
 #include <torch/torch.h>


### PR DESCRIPTION
Summary:
In order to get rid of this patch https://github.com/pytorch/torchchat/blob/main/scripts/install_et.sh#L35-L36

We upstream the changes into ExecuTorch.

Differential Revision: D56424633


