### PR TITLE
update gihub links to release/0.2 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Key value propositions of ExecuTorch are:
   capabilities such as CPUs, NPUs, and DSPs.
 
 For a comprehensive technical overview of ExecuTorch and step-by-step tutorials,
-please visit our documentation website [for the latest release](https://pytorch.org/executorch/stable/index.html) (or the [main branch](https://pytorch.org/executorch/main/index.html)).
+please visit our documentation website [for the latest release](https://pytorch.org/executorch/0.2/index.html) (or the [main branch](https://pytorch.org/executorch/0.2/index.html)).
 
 ## Important: This is a preview release
 

--- a/backends/apple/mps/setup.md
+++ b/backends/apple/mps/setup.md
@@ -27,7 +27,7 @@ In order to be able to successfully build and run a model using the MPS backend 
 
 ## Setting up Developer Environment
 
-***Step 1.*** Please finish tutorial [Setting up ExecuTorch](https://pytorch.org/executorch/stable/getting-started-setup).
+***Step 1.*** Please finish tutorial [Setting up ExecuTorch](https://pytorch.org/executorch/0.2/getting-started-setup).
 
 ***Step 2.*** Install dependencies needed to lower MPS delegate:
 

--- a/backends/qualcomm/README.md
+++ b/backends/qualcomm/README.md
@@ -6,7 +6,7 @@ we reserve the right to modify interfaces and implementations.
 
 This backend is implemented on the top of
 [Qualcomm AI Engine Direct SDK](https://developer.qualcomm.com/software/qualcomm-ai-engine-direct-sdk).
-Please follow [tutorial](https://pytorch.org/executorch/stable/build-run-qualcomm-ai-engine-direct-backend.html) to setup environment, build, and run executorch models by this backend (Qualcomm AI Engine Direct is also referred to as QNN in the source and documentation).
+Please follow [tutorial](https://pytorch.org/executorch/0.2/build-run-qualcomm-ai-engine-direct-backend.html) to setup environment, build, and run executorch models by this backend (Qualcomm AI Engine Direct is also referred to as QNN in the source and documentation).
 
 ## Delegate Options
 

--- a/backends/xnnpack/README.md
+++ b/backends/xnnpack/README.md
@@ -88,4 +88,4 @@ which captures the sigmoid op.
 
 #### Adding Tests for newly minted operators
 To test newly added operators, we can add unit tests in:
-[tests](https://github.com/pytorch/executorch/tree/main/backends/xnnpack/test)
+[tests](https://github.com/pytorch/executorch/tree/release/0.2/backends/xnnpack/test)

--- a/build/test_android_ci.sh
+++ b/build/test_android_ci.sh
@@ -7,7 +7,7 @@
 
 set -ex
 
-# https://github.com/pytorch/executorch/tree/main/examples/demo-apps/android/ExecuTorchDemo
+# https://github.com/pytorch/executorch/tree/release/0.2/examples/demo-apps/android/ExecuTorchDemo
 build_executorch() {
   MODEL_NAME=dl3
   # Delegating DeepLab v3 to XNNPACK backend

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -74,7 +74,7 @@
               <div class="local-toc">{{ toc }}</div>
          {% endif %}
 {% endblock %}
-<!-- END OF LOCAL OVERRIDE -->  
+<!-- END OF LOCAL OVERRIDE -->
 
 {% block footer %}
 {{ super() }}
@@ -131,14 +131,14 @@ for (var i = 0; i < menuItems.length; i++) {
     $(".main-menu a:contains('GitHub')").each(overwrite);
     // Overwrite link to Tutorials and Get Started top navigation. If these sections are moved
     // this overrides need to be updated.
-    $(".main-menu a:contains('Tutorials')").attr("href", "https://pytorch.org/executorch/stable/index.html#tutorials-and-examples");
-    $(".main-menu a:contains('Get Started')").attr("href", "https://pytorch.org/executorch/stable/getting-started-setup.html");
+    $(".main-menu a:contains('Tutorials')").attr("href", "https://pytorch.org/executorch/0.2/index.html#tutorials-and-examples");
+    $(".main-menu a:contains('Get Started')").attr("href", "https://pytorch.org/executorch/0.2/getting-started-setup.html");
     // Mobile
     $(".mobile-menu a:contains('Github')").each(overwrite);
     // Overwrite link to Tutorials and Get Started top navigation. If these sections are moved
     // this overrides need to be updated.
-    $(".mobile-menu a:contains('Tutorials')").attr("href", "https://pytorch.org/executorch/stable/index.html#tutorials-and-examples");
-    $(".mobile-menu a:contains('Get Started')").attr("href", "https://pytorch.org/executorch/stable/getting-started-setup.html");
+    $(".mobile-menu a:contains('Tutorials')").attr("href", "https://pytorch.org/executorch/0.2/index.html#tutorials-and-examples");
+    $(".mobile-menu a:contains('Get Started')").attr("href", "https://pytorch.org/executorch/0.2/getting-started-setup.html");
 
   });
 </script>

--- a/docs/source/build-run-qualcomm-ai-engine-direct-backend.md
+++ b/docs/source/build-run-qualcomm-ai-engine-direct-backend.md
@@ -245,7 +245,7 @@ I 00:00:01.835706 executorch:qnn_executor_runner.cpp:298] 100 inference took 109
 ### Running a model via ExecuTorch's android demo-app
 
 An Android demo-app using Qualcomm AI Engine Direct Backend can be found in
-`examples`. Please refer to android demo app [tutorial](https://pytorch.org/executorch/stable/demo-apps-android.html).
+`examples`. Please refer to android demo app [tutorial](https://pytorch.org/executorch/0.2/demo-apps-android.html).
 
 
 ## What is coming?

--- a/docs/source/build-run-xtensa.md
+++ b/docs/source/build-run-xtensa.md
@@ -79,7 +79,7 @@ The AoT folder contains all of the python scripts and functions needed to export
 
 ***Operators***:
 
-The operators folder contains two kinds of operators: existing operators from the [ExecuTorch portable library](https://github.com/pytorch/executorch/tree/main/kernels/portable/cpu) and new operators that define custom computations. The former is simply dispatching the operator to the relevant ExecuTorch implementation, while the latter acts as an interface, setting up everything needed for the custom kernels to compute the outputs.
+The operators folder contains two kinds of operators: existing operators from the [ExecuTorch portable library](https://github.com/pytorch/executorch/tree/release/0.2/kernels/portable/cpu) and new operators that define custom computations. The former is simply dispatching the operator to the relevant ExecuTorch implementation, while the latter acts as an interface, setting up everything needed for the custom kernels to compute the outputs.
 
 ***Kernels***:
 

--- a/docs/source/executorch-arm-delegate-tutorial.md
+++ b/docs/source/executorch-arm-delegate-tutorial.md
@@ -23,7 +23,7 @@ This ExecuTorch backend delegate is under active development. You may encounter 
 ```
 
 ```{tip}
-If you are already familiar with this delegate, you may want to jump directly to the examples source dir - [https://github.com/pytorch/executorch/tree/main/examples/arm](https://github.com/pytorch/executorch/tree/main/examples/arm)
+If you are already familiar with this delegate, you may want to jump directly to the examples source dir - [https://github.com/pytorch/executorch/tree/release/0.2/examples/arm](https://github.com/pytorch/executorch/tree/release/0.2/examples/arm)
 ```
 
 ## Prerequisites

--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -109,7 +109,7 @@ to ExecuTorch.
 ### Export a Program
 ExecuTorch provides APIs to compile a PyTorch [`nn.Module`](https://pytorch.org/docs/stable/generated/torch.nn.Module.html) to a `.pte` binary consumed by the ExecuTorch runtime.
 1. [`torch.export`](https://pytorch.org/docs/stable/export.html)
-1. [`exir.to_edge`](https://pytorch.org/executorch/stable/export-to-executorch-api-reference.html#exir.to_edge)
+1. [`exir.to_edge`](https://pytorch.org/executorch/0.2/export-to-executorch-api-reference.html#exir.to_edge)
 1. [`exir.to_executorch`](ir-exir.md)
 1. Save the result as a [`.pte` binary](pte-file-format.md) to be consumed by the ExecuTorch runtime.
 

--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -193,4 +193,4 @@ explore its advanced features and capabilities below.
 * Build an [Android](demo-apps-android.md) or [iOS](demo-apps-ios.md) demo app
 * Learn more about the [export process](export-overview.md)
 * Dive deeper into the [Export Intermediate Representation (EXIR)](ir-exir.md) for complex export workflows
-* Refer to [advanced examples in executorch/examples](https://github.com/pytorch/executorch/tree/main/examples)
+* Refer to [advanced examples in executorch/examples](https://github.com/pytorch/executorch/tree/release/0.2/examples)

--- a/docs/source/llm/getting-started.md
+++ b/docs/source/llm/getting-started.md
@@ -90,7 +90,7 @@ cd ../..
 :::
 ::::
 
-For more information, see [Setting Up ExecuTorch](https://pytorch.org/executorch/stable/getting-started-setup.html).
+For more information, see [Setting Up ExecuTorch](https://pytorch.org/executorch/0.2/getting-started-setup.html).
 
 
 ## Running a Large Language Model Locally
@@ -184,7 +184,7 @@ with open("nanogpt.pte", "wb") as file:
 
 To export, run the script with `python export_nanogpt.py` (or python3, as appropriate for your environment). It will generate a `nanogpt.pte` file in the current directory.
 
-For more information, see [Exporting to ExecuTorch](https://pytorch.org/executorch/main/tutorials/export-to-executorch-tutorial.html) and
+For more information, see [Exporting to ExecuTorch](https://pytorch.org/executorch/0.2/tutorials/export-to-executorch-tutorial.html) and
 [torch.export](https://pytorch.org/docs/stable/export.html).
 
 ### Step 2. Invoking the Runtime
@@ -342,8 +342,8 @@ curl -O https://raw.githubusercontent.com/pytorch/executorch/release/0.2/example
 curl -O https://raw.githubusercontent.com/pytorch/executorch/release/0.2/examples/llm_manual/managed_tensor.h
 ```
 
-To learn more, see [Running an ExecuTorch Model in C++](https://pytorch.org/executorch/main/running-a-model-cpp-tutorial.html)
-and the [ExecuTorch Runtime API Reference](https://pytorch.org/executorch/main/executorch-runtime-api-reference.html).
+To learn more, see [Running an ExecuTorch Model in C++](https://pytorch.org/executorch/0.2/running-a-model-cpp-tutorial.html)
+and the [ExecuTorch Runtime API Reference](https://pytorch.org/executorch/0.2/executorch-runtime-api-reference.html).
 
 ### Building and Running
 
@@ -538,9 +538,9 @@ target_link_libraries(
 ```
 
 Keep the rest of the code the same. For more details refer to
-[Exporting to ExecuTorch](https://pytorch.org/executorch/main/llm/getting-started.html#step-1-exporting-to-executorch)
+[Exporting to ExecuTorch](https://pytorch.org/executorch/0.2/llm/getting-started.html#step-1-exporting-to-executorch)
 and
-[Invoking the Runtime](https://pytorch.org/executorch/main/llm/getting-started.html#step-2-invoking-the-runtime)
+[Invoking the Runtime](https://pytorch.org/executorch/0.2/llm/getting-started.html#step-2-invoking-the-runtime)
 for more details
 
 At this point, the working directory should contain the following files:
@@ -588,9 +588,9 @@ Now you'll be able to clearly feel the acceleration of the generation process, c
 
 For more information regarding backend delegateion, see the ExecuTorch guides
 for the
-[XNNPACK Backend](https://pytorch.org/executorch/stable/tutorial-xnnpack-delegate-lowering.html)
+[XNNPACK Backend](https://pytorch.org/executorch/0.2/tutorial-xnnpack-delegate-lowering.html)
 and
-[CoreML Backend](https://pytorch.org/executorch/stable/build-run-coreml.html).
+[CoreML Backend](https://pytorch.org/executorch/0.2/build-run-coreml.html).
 
 ## Quantization
 
@@ -676,7 +676,7 @@ target_link_libraries(
     xnnpack_backend) # Provides the XNNPACK CPU acceleration backend
 ```
 
-For more information, see [Quantization in ExecuTorch](https://pytorch.org/executorch/stable/quantization-overview.html).
+For more information, see [Quantization in ExecuTorch](https://pytorch.org/executorch/0.2/quantization-overview.html).
 
 ## Profiling and Debugging
 After lowering a model by calling `to_backend()`, you may want to see what got delegated and what didn’t. ExecuTorch
@@ -754,7 +754,7 @@ Through the ExecuTorch SDK, users are able to profile model execution, giving ti
 
 ##### ETRecord generation (Optional)
 
-An ETRecord is an artifact generated at the time of export that contains model graphs and source-level metadata linking the ExecuTorch program to the original PyTorch model. You can view all profiling events without an ETRecord, though with an ETRecord, you will also be able to link each event to the types of operators being executed, module hierarchy, and stack traces of the original PyTorch source code. For more information, see [https://pytorch.org/executorch/main/sdk-etrecord.html](https://pytorch.org/executorch/main/sdk-etrecord.html)
+An ETRecord is an artifact generated at the time of export that contains model graphs and source-level metadata linking the ExecuTorch program to the original PyTorch model. You can view all profiling events without an ETRecord, though with an ETRecord, you will also be able to link each event to the types of operators being executed, module hierarchy, and stack traces of the original PyTorch source code. For more information, see [https://pytorch.org/executorch/0.2/sdk-etrecord.html](https://pytorch.org/executorch/0.2/sdk-etrecord.html)
 
 
 In your export script, after calling `to_edge()` and `to_executorch()`, call `generate_etrecord()` with the `EdgeProgramManager` from `to_edge()` and the `ExecuTorchProgramManager` from `to_executorch()`. Make sure to copy the `EdgeProgramManager`, as the call to `to_backend()` mutates the graph in-place.
@@ -776,7 +776,7 @@ Run the export script and the ETRecord will be generated as `etrecord.bin`.
 
 ##### ETDump generation
 
-An ETDump is an artifact generated at runtime containing a trace of the model execution. For more information, see [https://pytorch.org/executorch/main/sdk-etdump.html](https://pytorch.org/executorch/main/sdk-etdump.html)
+An ETDump is an artifact generated at runtime containing a trace of the model execution. For more information, see [https://pytorch.org/executorch/0.2/sdk-etdump.html](https://pytorch.org/executorch/0.2/sdk-etdump.html)
 
 Include the ETDump header in your code.
 ```cpp
@@ -846,7 +846,7 @@ This prints the performance data in a tabular format in “inspector_out.txt”,
 ![](../_static/img/llm_manual_print_data_tabular.png)
 <a href="../_static/img/llm_manual_print_data_tabular.png" target="_blank">View in full size</a>
 
-To learn more about the Inspector and the rich functionality it provides, see the [Inspector API Reference](https://pytorch.org/executorch/main/sdk-inspector.html).
+To learn more about the Inspector and the rich functionality it provides, see the [Inspector API Reference](https://pytorch.org/executorch/0.2/sdk-inspector.html).
 
 ## Custom Kernels
 With the ExecuTorch custom operator APIs, custom operator and kernel authors can easily bring in their kernel into PyTorch/ExecuTorch.
@@ -924,7 +924,7 @@ torch.ops.load_library("libcustom_linear.so")
 Once loaded, you can use the custom operator in PyTorch code.
 
 For more information, see [PyTorch Custom Operators](https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html) and
-and [ExecuTorch Kernel Registration](https://pytorch.org/executorch/stable/kernel-library-custom-aten-kernel.html).
+and [ExecuTorch Kernel Registration](https://pytorch.org/executorch/0.2/kernel-library-custom-aten-kernel.html).
 
 ### Using a Custom Operator in a Model
 
@@ -949,6 +949,6 @@ The remaining steps are the same as the normal flow. Now you can run this module
 ## How to build Mobile Apps
 You can execute an LLM using ExecuTorch on iOS and Android.
 
-**For iOS see the [iLLaMA App](https://pytorch.org/executorch/main/llm/llama-demo-ios.html).**
+**For iOS see the [iLLaMA App](https://pytorch.org/executorch/0.2/llm/llama-demo-ios.html).**
 
-**For Android, see the [Android Sample App](https://pytorch.org/executorch/main/llm/llama-demo-android.html).**
+**For Android, see the [Android Sample App](https://pytorch.org/executorch/0.2/llm/llama-demo-android.html).**

--- a/docs/source/native-delegates-executorch-xnnpack-delegate.md
+++ b/docs/source/native-delegates-executorch-xnnpack-delegate.md
@@ -40,7 +40,7 @@ The `XnnpackPartitioner` also partitions using op targets. It traverses the grap
 
 ##### Passes
 
-Before any serialization, we apply passes on the subgraphs to prepare the graph. These passes are essentially graph transformations that help improve the performance of the delegate. We give an overview of the most significant passes and their function below. For a description of all passes see [here](https://github.com/pytorch/executorch/tree/main/backends/xnnpack/passes):
+Before any serialization, we apply passes on the subgraphs to prepare the graph. These passes are essentially graph transformations that help improve the performance of the delegate. We give an overview of the most significant passes and their function below. For a description of all passes see [here](https://github.com/pytorch/executorch/tree/release/0.2/backends/xnnpack/passes):
 
 * Channels Last Reshape
     * ExecuTorch tensors tend to be contiguous before passing them into delegates, while XNNPACK only accepts channels-last memory layout. This pass minimizes the number of permutation operators inserted to pass in channels-last memory format.

--- a/docs/source/running-a-model-cpp-tutorial.md
+++ b/docs/source/running-a-model-cpp-tutorial.md
@@ -19,7 +19,7 @@ the model `SimpleConv` generated from the [Exporting to ExecuTorch tutorial](./t
 
 The first step towards running your model is to load it. ExecuTorch uses an abstraction called a `DataLoader` to handle the specifics of retrieving the `.pte` file data, and then `Program` represents the loaded state.
 
-Users can define their own `DataLoader`s to fit the needs of their particular system. In this tutorial we will be using the `FileDataLoader`, but you can look under [Example Data Loader Implementations](https://github.com/pytorch/executorch/tree/main/extension/data_loader) to see other options provided by the ExecuTorch project.
+Users can define their own `DataLoader`s to fit the needs of their particular system. In this tutorial we will be using the `FileDataLoader`, but you can look under [Example Data Loader Implementations](https://github.com/pytorch/executorch/tree/release/0.2/extension/data_loader) to see other options provided by the ExecuTorch project.
 
 For the `FileDataLoader` all we need to do is provide a file path to the constructor.
 

--- a/docs/source/runtime-overview.md
+++ b/docs/source/runtime-overview.md
@@ -3,7 +3,7 @@
 This document discusses the design of the ExecuTorch runtime, which executes
 ExecuTorch program files on edge devices like smartphones, wearables, and
 embedded devices. The code for the main execution API is under
-[`executorch/runtime/executor/`](https://github.com/pytorch/executorch/tree/main/runtime/executor).
+[`executorch/runtime/executor/`](https://github.com/pytorch/executorch/tree/release/0.2/runtime/executor).
 
 Before reading this document we recommend that you read [How ExecuTorch
 Works](intro-how-it-works.md).

--- a/examples/README.md
+++ b/examples/README.md
@@ -68,4 +68,4 @@ The [`xtensa/`](./xtensa) directory hosts a demo that showcases the process of e
 
 ## Dependencies
 
-Various models and workflows listed in this directory have dependencies on some other packages. You need to follow the setup guide in [Setting up ExecuTorch from GitHub](https://pytorch.org/executorch/stable/getting-started-setup) to have appropriate packages installed.
+Various models and workflows listed in this directory have dependencies on some other packages. You need to follow the setup guide in [Setting up ExecuTorch from GitHub](https://pytorch.org/executorch/0.2/getting-started-setup) to have appropriate packages installed.

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,7 +48,7 @@ Explore mobile apps with ExecuTorch models integrated and deployable on Android 
 
 ## Demo of XNNPACK delegation
 
-The demos in the [`xnnpack/`](./xnnpack) directory provide valuable insights into the process of lowering and executing an ExecuTorch model with built-in performance enhancements. These demos specifically showcase the workflow involving [XNNPACK backend](https://github.com/pytorch/executorch/tree/main/backends/xnnpack) delegation and quantization.
+The demos in the [`xnnpack/`](./xnnpack) directory provide valuable insights into the process of lowering and executing an ExecuTorch model with built-in performance enhancements. These demos specifically showcase the workflow involving [XNNPACK backend](https://github.com/pytorch/executorch/tree/release/0.2/backends/xnnpack) delegation and quantization.
 
 ## Demo of ExecuTorch Apple Backend
 

--- a/examples/apple/coreml/README.md
+++ b/examples/apple/coreml/README.md
@@ -15,7 +15,7 @@ coreml
 
 We will walk through an example model to generate a **Core ML** delegated binary file from a python `torch.nn.module` then we will use the `coreml/executor_runner` to run the exported binary file.
 
-1. Following the setup guide in [Setting Up ExecuTorch](https://pytorch.org/executorch/stable/getting-started-setup)
+1. Following the setup guide in [Setting Up ExecuTorch](https://pytorch.org/executorch/0.2/getting-started-setup)
 you should be able to get the basic development environment for ExecuTorch working.
 
 2. Run `install_requirements.sh` to install dependencies required by the **Core ML** backend.

--- a/examples/apple/mps/README.md
+++ b/examples/apple/mps/README.md
@@ -8,7 +8,7 @@ This README gives some examples on backend-specific model workflow.
 ## Prerequisite
 
 Please finish the following tutorials:
-- [Setting up ExecuTorch](https://pytorch.org/executorch/stable/getting-started-setup).
+- [Setting up ExecuTorch](https://pytorch.org/executorch/0.2/getting-started-setup).
 - [Setting up MPS backend](../../../backends/apple/mps/setup.md).
 
 ## Delegation to MPS backend

--- a/examples/arm/README.md
+++ b/examples/arm/README.md
@@ -31,6 +31,6 @@ $ ./run.sh [same-optional-scratch-dir-as-before]
 ```
 ### Online Tutorial
 
-We also have a [tutorial](https://pytorch.org/executorch/stable/executorch-arm-delegate-tutorial.html) explaining the steps performed in these
+We also have a [tutorial](https://pytorch.org/executorch/0.2/executorch-arm-delegate-tutorial.html) explaining the steps performed in these
 scripts, expected results, and more. It is a step-by-step guide
 you can follow to better understand this delegate.

--- a/examples/demo-apps/android/ExecuTorchDemo/README.md
+++ b/examples/demo-apps/android/ExecuTorchDemo/README.md
@@ -14,7 +14,7 @@ This guide explains how to setup ExecuTorch for Android using a demo app. The ap
 
 :::{grid-item-card} Prerequisites
 :class-card: card-prerequisites
-* Refer to [Setting up ExecuTorch](https://pytorch.org/executorch/stable/getting-started-setup) to set up the repo and dev environment.
+* Refer to [Setting up ExecuTorch](https://pytorch.org/executorch/0.2/getting-started-setup) to set up the repo and dev environment.
 * Download and install [Android Studio and SDK](https://developer.android.com/studio).
 * Supported Host OS: CentOS, macOS Ventura (M1/x86_64). See below for Qualcomm HTP specific requirements.
 * *Qualcomm HTP Only[^1]:* To build and run on Qualcomm's AI Engine Direct, please follow [Building and Running ExecuTorch with Qualcomm AI Engine Direct Backend](build-run-qualcomm-ai-engine-direct-backend.md) for hardware and software pre-requisites. The version we use for this tutorial is 2.19. The chip we use for this tutorial is SM8450.

--- a/examples/demo-apps/android/LlamaDemo/README.md
+++ b/examples/demo-apps/android/LlamaDemo/README.md
@@ -3,7 +3,7 @@
 This app demonstrates the use of the LLaMA chat app demonstrating local inference use case with ExecuTorch.
 
 ## Prerequisites
-* Set up your ExecuTorch repo and environment if you haven’t done so by following the [Setting up ExecuTorch](https://pytorch.org/executorch/stable/getting-started-setup) to set up the repo and dev environment.
+* Set up your ExecuTorch repo and environment if you haven’t done so by following the [Setting up ExecuTorch](https://pytorch.org/executorch/0.2/getting-started-setup) to set up the repo and dev environment.
 * Install [Java 17 JDK](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html).
 * Install the [Android SDK API Level 34](https://developer.android.com/about/versions/14/setup-sdk) and
   [Android NDK 25.0.8775105](https://developer.android.com/studio/projects/install-ndk).

--- a/examples/demo-apps/apple_ios/ExecuTorchDemo/README.md
+++ b/examples/demo-apps/apple_ios/ExecuTorchDemo/README.md
@@ -40,7 +40,7 @@ pip --version
 
 ### 3. Getting Started Tutorial
 
-Before proceeding, follow the [Setting Up ExecuTorch](https://pytorch.org/executorch/stable/getting-started-setup)
+Before proceeding, follow the [Setting Up ExecuTorch](https://pytorch.org/executorch/0.2/getting-started-setup)
 tutorial to configure the basic environment. Feel free to skip building anything
 just yet. Make sure you have all the required dependencies installed, including
 the following tools:

--- a/examples/demo-apps/apple_ios/LLaMA/README.md
+++ b/examples/demo-apps/apple_ios/LLaMA/README.md
@@ -7,7 +7,7 @@ This app demonstrates the use of the LLaMA chat app demonstrating local inferenc
 ## Prerequisites
 * [Xcode 15](https://developer.apple.com/xcode).
 * [iOS 17 SDK](https://developer.apple.com/ios).
-* Set up your ExecuTorch repo and environment if you haven’t done so by following the [Setting up ExecuTorch](https://pytorch.org/executorch/stable/getting-started-setup) to set up the repo and dev environment.
+* Set up your ExecuTorch repo and environment if you haven’t done so by following the [Setting up ExecuTorch](https://pytorch.org/executorch/0.2/getting-started-setup) to set up the repo and dev environment.
 
 ## Exporting models
 Please refer to the [ExecuTorch Llama2 docs](https://github.com/pytorch/executorch/blob/main/examples/models/llama2/README.md) to export the model.

--- a/examples/llm_manual/CMakeLists.txt
+++ b/examples/llm_manual/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.19)
+project(nanogpt_runner)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Set options for executorch build.
+option(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER "" ON)
+option(EXECUTORCH_BUILD_EXTENSION_MODULE "" ON)
+option(EXECUTORCH_BUILD_OPTIMIZED "" ON)
+option(EXECUTORCH_BUILD_XNNPACK "" ON) # Build with Xnnpack backend
+
+# Include the executorch subdirectory.
+add_subdirectory(
+    ${CMAKE_CURRENT_SOURCE_DIR}/third-party/executorch
+    ${CMAKE_BINARY_DIR}/executorch)
+
+# include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+add_executable(nanogpt_runner main.cpp)
+target_link_libraries(
+    nanogpt_runner
+    PRIVATE
+    executorch
+    extension_module_static # Provides the Module class
+    optimized_native_cpu_ops_lib # Provides baseline cross-platform kernels
+    xnnpack_backend) # Provides the XNNPACK CPU acceleration backend

--- a/examples/llm_manual/basic_sampler.h
+++ b/examples/llm_manual/basic_sampler.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <algorithm>
+#include <vector>
+class BasicSampler {
+ public:
+  BasicSampler() {}
+  int64_t sample(std::vector<float> logits) {
+    // Find the token with the highest log probability.
+    int64_t max_index =
+        std::max_element(logits.begin(), logits.end()) - logits.begin();
+    return max_index;
+  }
+};

--- a/examples/llm_manual/basic_tokenizer.h
+++ b/examples/llm_manual/basic_tokenizer.h
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class BasicTokenizer {
+ public:
+  BasicTokenizer(const std::string& filePath) {
+    std::ifstream file(filePath);
+
+    if (!file) {
+      std::cerr << "Unable to open file";
+      exit(9); // return with error code
+    }
+    std::string str(
+        (std::istreambuf_iterator<char>(file)),
+        std::istreambuf_iterator<char>());
+
+    size_t i = 0u;
+    i = consume_whitespace(str, i);
+    i = expect(str, i, '{');
+
+    while (i < str.size() && str[i] != '}') {
+      i = consume_field(str, i);
+    }
+
+    // Build decode map as inverse of encode.
+    for (auto& i : encode_) {
+      decode_[i.second] = i.first;
+    }
+  }
+
+  std::vector<int64_t> encode(const std::string& prompt) {
+    std::vector<std::string> words = parse_prompt(prompt);
+    std::vector<int64_t> result;
+    for (auto word : words) {
+      result.push_back(encode_[word]);
+    }
+    return result;
+  }
+
+  std::string decode(const std::vector<int64_t>& indices) {
+    std::string result;
+    for (const auto& index : indices) {
+      result += decode_[index];
+    }
+    return result;
+  }
+
+ private:
+  std::unordered_map<std::string, int64_t> encode_;
+  std::unordered_map<int64_t, std::string> decode_;
+
+  // Advance the input string index until a non-whitespace character is found
+  // or it reaches the end of string.
+  size_t consume_whitespace(const std::string& data, size_t i) {
+    while (i < data.size() && std::isspace(data[i])) {
+      i++;
+    }
+
+    return i;
+  }
+
+  // Consumes an JSON field of the form
+  //  "str": id,
+  size_t consume_field(const std::string& data, size_t i) {
+    i = consume_whitespace(data, i);
+
+    // Parse the key literal.
+    i = expect(data, i, '"');
+
+    auto in_escape = false;
+    std::string key = "";
+    while (i < data.size()) {
+      if (in_escape) {
+        key += data[i];
+        i++;
+        in_escape = false;
+      } else { // !in_escape
+        if (data[i] == '"') { // End of string literal
+          i++;
+          break;
+        } else if (data[i] == '\\') { // Escaped code point
+          in_escape = true;
+        }
+        key += data[i];
+        i++;
+      }
+    }
+
+    key = post_process_key(key);
+
+    i = expect(data, i, ':');
+    i = consume_whitespace(data, i);
+
+    // Read unsigned integer value
+    auto value_start = i;
+    while (i < data.size() && std::isdigit(data[i])) {
+      i++;
+    }
+    auto value = static_cast<int64_t>(
+        std::stol(data.substr(value_start, i - value_start)));
+
+    encode_[key] = value;
+
+    i = consume_whitespace(data, i);
+    if (i < data.size() && data[i] == ',') {
+      i++;
+    }
+
+    return i;
+  }
+
+  // Assert that the next character in the input string is equal to c. Increment
+  // the input string index by one.
+  size_t expect(const std::string& data, size_t i, char c) {
+    if (i >= data.size() || data[i] != c) {
+      std::cerr << "Invalid tokenizer vocabulary file. Expected '" << c
+                << "' at index " << i << std::endl;
+      exit(1);
+    }
+
+    return i + 1;
+  }
+
+  std::string post_process_key(std::string key) {
+    // Replace the unicode characters with the corresponding byte encoding
+    // TODO: adopt byte encoder to handle unicode characters in json file.
+
+    std::unordered_map<std::string, std::string> replacements = {
+        {"\\u0120", " "},
+        {"\\u010a", "\n"},
+    };
+
+    for (const auto& replacement : replacements) {
+      size_t pos = 0;
+      // While loop through all instances of the substring in the string
+      while ((pos = key.find(replacement.first, pos)) != std::string::npos) {
+        key.replace(pos, replacement.first.length(), replacement.second);
+        pos += replacement.second.length();
+      }
+    }
+
+    // remove duplicate backslashes
+    for (size_t idx = 0; idx < key.length(); idx++) {
+      if (key[idx] == '\\') {
+        key.erase(idx, 1);
+        if (key[idx] == '\\') {
+          // If there are two backslashes, keep the second one
+          idx += 1;
+        }
+      }
+    }
+
+    return key;
+  }
+  std::vector<std::string> parse_prompt(const std::string& prompt) {
+    std::vector<std::string> result;
+    std::string word;
+    for (char c : prompt) {
+      if (c == ' ') {
+        if (!word.empty()) {
+          result.push_back(word);
+          word.clear();
+        }
+        word += c;
+      } else if (ispunct(c)) {
+        if (!word.empty()) {
+          result.push_back(word);
+          word.clear();
+        }
+        result.push_back(std::string(1, c));
+      } else {
+        word += c;
+      }
+    }
+    if (!word.empty()) {
+      result.push_back(word);
+    }
+    return result;
+  }
+};

--- a/examples/llm_manual/export_nanogpt.py
+++ b/examples/llm_manual/export_nanogpt.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# export_nanogpt.py
+
+# Load partitioner for Xnnpack backend
+import torch
+from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
+
+# Model to be delegated to specific backend should use specific edge compile config
+from executorch.backends.xnnpack.utils.configs import get_xnnpack_edge_compile_config
+from executorch.exir import to_edge
+
+from model import GPT
+from torch._export import capture_pre_autograd_graph
+from torch.export import export
+from torch.nn.attention import sdpa_kernel, SDPBackend
+
+model = GPT.from_pretrained("gpt2")  # use gpt2 weight as pretrained weight
+example_inputs = (
+    torch.randint(0, 100, (1, model.config.block_size), dtype=torch.long),
+)
+dynamic_shape = ({1: torch.export.Dim("token_dim", max=model.config.block_size)},)
+
+# Trace the model, converting it to a portable intermediate representation.
+# The torch.no_grad() call tells PyTorch to exclude training-specific logic.
+with sdpa_kernel([SDPBackend.MATH]), torch.no_grad():
+    m = capture_pre_autograd_graph(model, example_inputs, dynamic_shapes=dynamic_shape)
+    traced_model = export(m, example_inputs, dynamic_shapes=dynamic_shape)
+
+# Convert the model into a runnable ExecuTorch program.
+# To be further lowered to Xnnpack backend, `traced_model` needs xnnpack-specific edge compile config
+edge_config = get_xnnpack_edge_compile_config()
+edge_manager = to_edge(traced_model, compile_config=edge_config)
+
+# Delegate exported model to Xnnpack backend by invoking `to_backend` function with Xnnpack partitioner.
+edge_manager = edge_manager.to_backend(XnnpackPartitioner())
+et_program = edge_manager.to_executorch()
+
+# Save the Xnnpack-delegated ExecuTorch program to a file.
+with open("nanogpt.pte", "wb") as file:
+    file.write(et_program.buffer)

--- a/examples/llm_manual/main.cpp
+++ b/examples/llm_manual/main.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// main.cpp
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <unordered_map>
+
+#include "basic_sampler.h"
+#include "basic_tokenizer.h"
+#include "managed_tensor.h"
+
+#include <executorch/extension/evalue_util/print_evalue.h>
+#include <executorch/extension/module/module.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
+
+using namespace torch::executor;
+
+using SizesType = exec_aten::SizesType;
+using DimOrderType = exec_aten::DimOrderType;
+using StridesType = exec_aten::StridesType;
+
+// main.cpp
+
+#define ENDOFTEXT 50256
+
+std::string generate(
+    Module& llm_model,
+    std::string& prompt,
+    BasicTokenizer& tokenizer,
+    BasicSampler& sampler,
+    size_t max_input_length,
+    size_t max_output_length) {
+  // Convert the input text into a list of integers (tokens) that represents
+  // it, using the string-to-token mapping that the model was trained on.
+  // Each token is an integer that represents a word or part of a word.
+  std::vector<int64_t> input_tokens = tokenizer.encode(prompt);
+  std::vector<int64_t> output_tokens;
+
+  for (auto i = 0u; i < max_output_length; i++) {
+    // Convert the input_tokens from a vector of int64_t to EValue.
+    // EValue is a unified data type in the ExecuTorch runtime.
+    ManagedTensor tensor_tokens(
+        input_tokens.data(),
+        {1, static_cast<int>(input_tokens.size())},
+        ScalarType::Long);
+    std::vector<EValue> inputs = {tensor_tokens.get_tensor()};
+
+    // Run the model. It will return a tensor of logits (log-probabilities).
+    Result<std::vector<EValue>> logits_evalue = llm_model.forward(inputs);
+
+    // Convert the output logits from EValue to std::vector, which is what
+    // the sampler expects.
+    Tensor logits_tensor = logits_evalue.get()[0].toTensor();
+    std::vector<float> logits(
+        logits_tensor.data_ptr<float>(),
+        logits_tensor.data_ptr<float>() + logits_tensor.numel());
+
+    // Sample the next token from the logits.
+    int64_t next_token = sampler.sample(logits);
+
+    // Break if we reached the end of the text.
+    if (next_token == ENDOFTEXT) {
+      break;
+    }
+
+    // Add the next token to the output.
+    output_tokens.push_back(next_token);
+
+    std::cout << tokenizer.decode({next_token});
+    std::cout.flush();
+
+    // Update next input.
+    input_tokens.push_back(next_token);
+    if (input_tokens.size() > max_input_length) {
+      input_tokens.erase(input_tokens.begin());
+    }
+  }
+
+  std::cout << std::endl;
+
+  // Convert the output tokens into a human-readable string.
+  std::string output_string = tokenizer.decode(output_tokens);
+  return output_string;
+}
+
+// main.cpp
+
+int main() {
+  // Set up the prompt. This provides the seed text for the model to elaborate.
+  std::cout << "Prompt: ";
+  std::string prompt;
+  std::getline(std::cin, prompt);
+
+  // The tokenizer is used to convert between tokens (used by the model) and
+  // human-readable strings.
+  BasicTokenizer tokenizer("vocab.json");
+
+  // The sampler is used to sample the next token from the logits.
+  BasicSampler sampler = BasicSampler();
+
+  // Load the exported nanoGPT program, which was generated via the previous
+  // steps.
+  Module model(
+      "nanogpt.pte",
+      torch::executor::Module::MlockConfig::UseMlockIgnoreErrors);
+
+  const auto max_input_tokens = 1024;
+  const auto max_output_tokens = 30;
+  std::cout << prompt;
+  generate(
+      model, prompt, tokenizer, sampler, max_input_tokens, max_output_tokens);
+}

--- a/examples/llm_manual/managed_tensor.h
+++ b/examples/llm_manual/managed_tensor.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
+#include <executorch/runtime/platform/assert.h>
+
+#include <executorch/runtime/core/portable_type/tensor.h>
+
+#pragma once
+
+namespace torch {
+namespace executor {
+
+/**
+ * A tensor wrapper takes ownership of all the memory of the necessary metadata
+ * for torch::executor::Tensor. Note that it doesn't own the data memory.
+ */
+class ManagedTensor {
+ public:
+  /// The type used for elements of `sizes()`.
+  using SizesType = exec_aten::SizesType;
+  /// The type used for elements of `dim_order()`.
+  using DimOrderType = exec_aten::DimOrderType;
+  /// The type used for elements of `strides()`.
+  using StridesType = exec_aten::StridesType;
+  ManagedTensor() = delete;
+
+  explicit ManagedTensor(
+      void* data,
+      const std::vector<SizesType>& sizes,
+      ScalarType dtype)
+      : dtype_(dtype), sizes_(sizes), data_ptr_(data) {
+    ssize_t dim = sizes.size();
+    dim_order_.resize(dim);
+    strides_.resize(dim);
+    for (size_t i = 0; i < dim; ++i) {
+      dim_order_[i] = i;
+    }
+    dim_order_to_stride_nocheck(
+        sizes.data(), dim_order_.data(), dim, strides_.data());
+    tensor_impl_ = std::make_unique<TensorImpl>(
+        dtype_,
+        dim,
+        sizes_.data(),
+        data_ptr_,
+        dim_order_.data(),
+        strides_.data(),
+        TensorShapeDynamism::DYNAMIC_BOUND);
+  }
+
+  /**
+   * Get the Tensor object managed by this class.
+   */
+  Tensor get_tensor() {
+    return Tensor(tensor_impl_.get());
+  }
+
+ private:
+  void* data_ptr_ = nullptr;
+  std::unique_ptr<TensorImpl> tensor_impl_;
+  std::vector<SizesType> sizes_;
+  std::vector<StridesType> strides_;
+  std::vector<DimOrderType> dim_order_;
+  ScalarType dtype_;
+};
+} // namespace executor
+} // namespace torch

--- a/examples/models/llama2/README.md
+++ b/examples/models/llama2/README.md
@@ -57,7 +57,7 @@ Performance was measured on Samsung Galaxy S22, S24, One Plus 12 and iPhone 15 m
 - For Llama7b, your device may require at least 32GB RAM. If this is a constraint for you, please try the smaller stories model.
 
 ## Step 1: Setup
-1. Follow the [tutorial](https://pytorch.org/executorch/main/getting-started-setup) to set up ExecuTorch. For installation run `./install_requirements.sh --pybind xnnpack`
+1. Follow the [tutorial](https://pytorch.org/executorch/0.2/getting-started-setup) to set up ExecuTorch. For installation run `./install_requirements.sh --pybind xnnpack`
 2. Run `examples/models/llama2/install_requirements.sh` to install a few dependencies.
 
 ## Step 2: Prepare model
@@ -255,14 +255,14 @@ adb shell "cd /data/local/tmp/llama && ./llama_main --model_path <model.pte> --t
 
 ### iOS
 
-Please refer to [this tutorial](https://pytorch.org/executorch/main/llm/llama-demo-ios.html) to for full instructions on building the iOS LLAMA Demo App.
+Please refer to [this tutorial](https://pytorch.org/executorch/0.2/llm/llama-demo-ios.html) to for full instructions on building the iOS LLAMA Demo App.
 
 ### Android
-Please refer to [this tutorial](https://pytorch.org/executorch/main/llm/llama-demo-android.html) to for full instructions on building the Android LLAMA Demo App.
+Please refer to [this tutorial](https://pytorch.org/executorch/0.2/llm/llama-demo-android.html) to for full instructions on building the Android LLAMA Demo App.
 
 ## Optional: Smaller models delegated to other backends
 Currently we supported lowering the stories model to other backends, including, CoreML, MPS and QNN. Please refer to the instruction
-for each backend ([CoreML](https://pytorch.org/executorch/main/build-run-coreml.html), [MPS](https://pytorch.org/executorch/main/build-run-mps.html), [QNN](https://pytorch.org/executorch/main/build-run-qualcomm.html)) before trying to lower them. After the backend library is installed, the script to export a lowered model is
+for each backend ([CoreML](https://pytorch.org/executorch/0.2/build-run-coreml.html), [MPS](https://pytorch.org/executorch/0.2/build-run-mps.html), [QNN](https://pytorch.org/executorch/0.2/build-run-qualcomm.html)) before trying to lower them. After the backend library is installed, the script to export a lowered model is
 
 - Lower to CoreML: `python -m examples.models.llama2.export_llama -kv --coreml -c stories110M.pt -p params.json`
 - MPS: `python -m examples.models.llama2.export_llama -kv --mps -c stories110M.pt -p params.json`

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -676,7 +676,7 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
             quantizers = []
         except ImportError:
             raise ImportError(
-                "Please install the Qualcomm backend follwing https://pytorch.org/executorch/main/build-run-qualcomm.html"
+                "Please install the Qualcomm backend follwing https://pytorch.org/executorch/0.2/build-run-qualcomm.html"
             )
 
         backend, quant_config = args.pt2e_quantize.split("_")
@@ -760,7 +760,7 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
             )
         except ImportError:
             raise ImportError(
-                "Please install the MPS backend follwing https://pytorch.org/executorch/main/build-run-mps.html"
+                "Please install the MPS backend follwing https://pytorch.org/executorch/0.2/build-run-mps.html"
             )
 
         compile_specs = [CompileSpec("use_fp16", bytes([True]))]
@@ -785,7 +785,7 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
             )
         except ImportError:
             raise ImportError(
-                "Please install the CoreML backend follwing https://pytorch.org/executorch/main/build-run-coreml.html"
+                "Please install the CoreML backend follwing https://pytorch.org/executorch/0.2/build-run-coreml.html"
             )
 
         # pyre-ignore: Undefined attribute [16]: Module `executorch.backends` has no attribute `apple`.
@@ -827,7 +827,7 @@ def _export_llama(modelname, args) -> str:  # noqa: C901
             )
         except ImportError:
             raise ImportError(
-                "Please install the Qualcomm backend follwing https://pytorch.org/executorch/main/build-run-qualcomm.html"
+                "Please install the Qualcomm backend follwing https://pytorch.org/executorch/0.2/build-run-qualcomm.html"
             )
 
         use_fp16 = True

--- a/examples/models/llava_encoder/README.md
+++ b/examples/models/llava_encoder/README.md
@@ -1,7 +1,7 @@
 ## Summary
 In this example, we initiate the process of running multi modality through ExecuTorch.
 - Demonstrate how to export the image encoder model in the [LLava](https://github.com/haotian-liu/LLaVA) multimodal model.
-- Provide TODO steps on how to use the exported .pte file and the existing [exported Llama2 model](https://github.com/pytorch/executorch/tree/main/examples/models/llama2), to build the multimodal pipeline.
+- Provide TODO steps on how to use the exported .pte file and the existing [exported Llama2 model](https://github.com/pytorch/executorch/tree/release/0.2/examples/models/llama2), to build the multimodal pipeline.
 
 ## Instructions
 Note that this folder does not host the pretrained LLava model.

--- a/examples/portable/README.md
+++ b/examples/portable/README.md
@@ -20,7 +20,7 @@ We will walk through an example model to generate a `.pte` file in [portable mod
 from the [`models/`](../models) directory using scripts in the `portable/scripts` directory. Then we will run on the `.pte` model on the ExecuTorch runtime. For that we will use `executor_runner`.
 
 
-1. Following the setup guide in [Setting up ExecuTorch](https://pytorch.org/executorch/stable/getting-started-setup)
+1. Following the setup guide in [Setting up ExecuTorch](https://pytorch.org/executorch/0.2/getting-started-setup)
 you should be able to get the basic development environment for ExecuTorch working.
 
 2. Using the script `portable/scripts/export.py` generate a model binary file by selecting a

--- a/examples/portable/custom_ops/README.md
+++ b/examples/portable/custom_ops/README.md
@@ -3,7 +3,7 @@ This folder contains examples to register custom operators into PyTorch as well 
 
 ## How to run
 
-Prerequisite: finish the [setting up wiki](https://pytorch.org/executorch/stable/getting-started-setup).
+Prerequisite: finish the [setting up wiki](https://pytorch.org/executorch/0.2/getting-started-setup).
 
 Run:
 

--- a/examples/qualcomm/README.md
+++ b/examples/qualcomm/README.md
@@ -8,7 +8,7 @@ Here are some general information and limitations.
 
 ## Prerequisite
 
-Please finish tutorial [Setting up executorch](https://pytorch.org/executorch/stable/getting-started-setup).
+Please finish tutorial [Setting up executorch](https://pytorch.org/executorch/0.2/getting-started-setup).
 
 Please finish [setup QNN backend](../../backends/qualcomm/setup.md).
 

--- a/examples/sdk/README.md
+++ b/examples/sdk/README.md
@@ -14,7 +14,7 @@ examples/sdk
 We will use an example model (in `torch.nn.Module`) and its representative inputs, both from [`models/`](../models) directory, to generate a [BundledProgram(`.bpte`)](../../docs/source/sdk-bundled-io.md) file using the [script](scripts/export_bundled_program.py). Then we will use [sdk_example_runner](sdk_example_runner/sdk_example_runner.cpp) to execute the `.bpte` model on the ExecuTorch runtime and verify the model on BundledProgram API.
 
 
-1. Sets up the basic development environment for ExecuTorch by [Setting up ExecuTorch from GitHub](https://pytorch.org/executorch/stable/getting-started-setup).
+1. Sets up the basic development environment for ExecuTorch by [Setting up ExecuTorch from GitHub](https://pytorch.org/executorch/0.2/getting-started-setup).
 
 2. Using the [script](scripts/export_bundled_program.py) to generate a BundledProgram binary file by retreiving a `torch.nn.Module` model and its representative inputs from the list of available models in the [`models/`](../models) dir。
 

--- a/examples/selective_build/README.md
+++ b/examples/selective_build/README.md
@@ -3,7 +3,7 @@ To optimize binary size of ExecuTorch runtime, selective build can be used. This
 
 ## How to run
 
-Prerequisite: finish the [setting up wiki](https://pytorch.org/executorch/stable/getting-started-setup).
+Prerequisite: finish the [setting up wiki](https://pytorch.org/executorch/0.2/getting-started-setup).
 
 Run:
 

--- a/examples/xnnpack/README.md
+++ b/examples/xnnpack/README.md
@@ -1,8 +1,8 @@
 # XNNPACK Backend
 
 [XNNPACK](https://github.com/google/XNNPACK) is a library of optimized neural network operators for ARM and x86 CPU platforms. Our delegate lowers models to run using these highly optimized CPU operators. You can try out lowering and running some example models in the demo. Please refer to the following docs for information on the XNNPACK Delegate
-- [XNNPACK Backend Delegate Overview](https://pytorch.org/executorch/stable/native-delegates-executorch-xnnpack-delegate.html)
-- [XNNPACK Delegate Export Tutorial](https://pytorch.org/executorch/stable/tutorial-xnnpack-delegate-lowering.html)
+- [XNNPACK Backend Delegate Overview](https://pytorch.org/executorch/0.2/native-delegates-executorch-xnnpack-delegate.html)
+- [XNNPACK Delegate Export Tutorial](https://pytorch.org/executorch/0.2/tutorial-xnnpack-delegate-lowering.html)
 
 
 ## Directory structure
@@ -32,7 +32,7 @@ buck2 run examples/xnnpack:xnn_executor_runner -- --model_path ./mv2_xnnpack_fp3
 ```
 
 ## Quantization
-First, learn more about the generic PyTorch 2 Export Quantization workflow in the [Quantization Flow Docs](https://pytorch.org/executorch/stable/quantization-overview.html), if you are not familiar already.
+First, learn more about the generic PyTorch 2 Export Quantization workflow in the [Quantization Flow Docs](https://pytorch.org/executorch/0.2/quantization-overview.html), if you are not familiar already.
 
 Here we will discuss quantizing a model suitable for XNNPACK delegation using XNNPACKQuantizer.
 

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -733,7 +733,7 @@ def to_edge(
 class EdgeProgramManager:
     """
     Package of one or more `ExportedPrograms` in Edge dialect. Designed to simplify
-    lowering to ExecuTorch. See: https://pytorch.org/executorch/stable/ir-exir.html
+    lowering to ExecuTorch. See: https://pytorch.org/executorch/0.2/ir-exir.html
 
     Allows easy applications of transforms across a collection of exported programs
     including the delegation of subgraphs.
@@ -933,7 +933,7 @@ class EdgeProgramManager:
 class ExecutorchProgramManager:
     """
     Package of one or more `ExportedPrograms` in Execution dialect. Designed to simplify
-    lowering to ExecuTorch. See: https://pytorch.org/executorch/stable/ir-exir.html
+    lowering to ExecuTorch. See: https://pytorch.org/executorch/0.2/ir-exir.html
 
     When the ExecutorchProgramManager is constructed the ExportedPrograms in execution dialect
     are used to form the executorch binary (in a process called emission) and then serialized

--- a/kernels/portable/README.md
+++ b/kernels/portable/README.md
@@ -43,7 +43,7 @@ compatible but restricted subsets of those types.
 [`//runtime/core/exec_aten/exec_aten.h`](https://github.com/pytorch/executorch/blob/main/runtime/core/exec_aten/exec_aten.h)
 contains the mapping between ATen/c10 types and the ExecuTorch types. The
 ExecuTorch types are defined in other headers in that same directory,
-[`//runtime/core/portable_type/`](https://github.com/pytorch/executorch/tree/main/runtime/core/portable_type).
+[`//runtime/core/portable_type/`](https://github.com/pytorch/executorch/tree/release/0.2/runtime/core/portable_type).
 
 The ExecuTorch types are source-compatible with the ATen/c10 types; if you write
 code that works with the ExecuTorch types, then that same code should work when


### PR DESCRIPTION
Summary: In readme of alpha github, some links are pointing to stable or main branch github repostory. However, for alpha release, we need to make sure those links are also pointing to alpha branch (release/0.2). This diff makes the update.

Differential Revision: D56406191
