### PR TITLE
Create dependabot rule to upgrade TorchFix version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "kit1980"
-      - "pytorch/pytorch-dev-infra"
+      - "pytorch/team-executorch"
     allow:
       - dependency-name: "torchfix"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
+      - "kit1980"
       - "pytorch/pytorch-dev-infra"
     allow:
       - dependency-name: "torchfix"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# From https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "pytorch/pytorch-dev-infra"
+    allow:
+      - dependency-name: "torchfix"


### PR DESCRIPTION
The parameters are from From https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

### Testing
On my own fork https://github.com/huydhn/executorch/blob/main/.github/dependabot.yml, and the PR to upgrade TorchFix is created successfully https://github.com/huydhn/executorch/pull/2