### PR TITLE
Add allocate_temp method to KernelRuntimeContext

### DIFF
--- a/runtime/core/memory_allocator.h
+++ b/runtime/core/memory_allocator.h
@@ -63,7 +63,7 @@ class MemoryAllocator {
   /**
    * Allocates `size` bytes of memory.
    *
-   * @param[in] size Number of memory chunks to allocate.
+   * @param[in] size Number of bytes to allocate.
    * @param[in] alignment Minimum alignment for the returned pointer. Must be a
    *     power of 2.
    *

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -1013,11 +1013,14 @@ Error Method::execute_instruction() {
       EXECUTORCH_SCOPE_PROF("OPERATOR_CALL");
       internal::EventTracerProfileScope event_tracer_scope =
           internal::EventTracerProfileScope(event_tracer_, "OPERATOR_CALL");
-      // TODO(T147221312): Also expose the temp allocator and tensor resizer
-      // via the context.
-      KernelRuntimeContext context(event_tracer_);
+      // TODO(T147221312): Also expose tensor resizer via the context.
+      // The temp_allocator passed can be null, but calling allocate_temp will
+      // fail
+      KernelRuntimeContext context(
+          event_tracer_, memory_manager_->temp_allocator());
       auto args = chain.argument_lists_[step_state_.instr_idx];
       chain.kernels_[step_state_.instr_idx](context, args.data());
+      // We reset the temp_allocator after the switch statement
       err = context.failure_state();
       if (err != Error::Ok) {
         // We know that instr_args_as_KernelCall is non-null because it was

--- a/runtime/kernel/targets.bzl
+++ b/runtime/kernel/targets.bzl
@@ -55,6 +55,7 @@ def define_common_targets():
             exported_deps = [
                 "//executorch/runtime/core:core",
                 "//executorch/runtime/platform:platform",
+                "//executorch/runtime/core:memory_allocator",
                 "//executorch/runtime/core:event_tracer" + aten_suffix,
                 # TODO(T147221312): This will eventually depend on exec_aten
                 # once KernelRuntimeContext support tensor resizing, which is


### PR DESCRIPTION
Summary: This adds an `allocate_temp` method to KernelRuntimeContext, and passes the temporary memory allocator from `execute_instruction`. The method returns a result that errors if the temporary `MemoryAllocator` was not provided or the memory could not be allocated.

Differential Revision: D56421957


