### PR TITLE
backout the schema definition change

### DIFF
--- a/kernels/quantized/quantized.yaml
+++ b/kernels/quantized/quantized.yaml
@@ -40,7 +40,7 @@
     - arg_meta: null
       kernel_name: torch::executor::quantized_embedding_byte_out
 
-- func: quantized_decomposed::embedding_byte.dtype_out(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, int weight_quant_min, int weight_quant_max, Tensor indices, ScalarType? dtype=None, *, Tensor(a!) out) -> Tensor(a!)
+- func: quantized_decomposed::embedding_byte.dtype_out(Tensor weight, Tensor weight_scales, Tensor? weight_zero_points, int weight_quant_min, int weight_quant_max, Tensor indices, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:
     - arg_meta: null


### PR DESCRIPTION
Summary: The schame was changed to avoid double register, but it was hiding the symptons by using a differnt schema. Resume the correct the schema

Differential Revision: D56432559


