### PR TITLE
[RELEASE ONLY] Fix llava encoder

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -23,7 +23,7 @@ CUSTOM_RUNNERS = {
         "w2l": "linux.12xlarge",
         "ic4": "linux.12xlarge",
         "resnet50": "linux.12xlarge",
-        "llava_encoder": "linux.4xlarge",
+        "llava_encoder": "linux.12xlarge",
         # This one causes timeout on smaller runner, the root cause is unclear (T161064121)
         "dl3": "linux.12xlarge",
         "emformer_join": "linux.12xlarge",


### PR DESCRIPTION
OOM on a 4x runner: https://github.com/pytorch/executorch/actions/runs/8789756421/job/24120235936#step:11:9704