### PR TITLE
[Android] Add more prebuilt artifacts

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -49,11 +49,16 @@ jobs:
         bash build/test_android_ci.sh
 
         mkdir -p artifacts-to-be-uploaded
+        mkdir -p artifacts-to-be-uploaded/arm64-v8a/
+        mkdir -p artifacts-to-be-uploaded/x86_64/
         # Copy the app and its test suite to S3
         cp examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/debug/*.apk artifacts-to-be-uploaded/
         cp examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/androidTest/debug/*.apk artifacts-to-be-uploaded/
         # Also copy the share libraries
-        cp cmake-out-android/lib/*.a artifacts-to-be-uploaded/
+        cp cmake-out-android-arm64-v8a/lib/*.a artifacts-to-be-uploaded/arm64-v8a/
+        cp cmake-out-android-arm64-v8a/extension/android/*.so artifacts-to-be-uploaded/arm64-v8a/
+        cp cmake-out-android-x86_64/lib/*.a artifacts-to-be-uploaded/x86_64/
+        cp cmake-out-android-x86_64/extension/android/*.so artifacts-to-be-uploaded/x86_64/
 
   # Upload the app and its test suite to S3 so that they can be downloaded by the test job
   upload-artifacts:

--- a/build/test_android_ci.sh
+++ b/build/test_android_ci.sh
@@ -8,7 +8,7 @@
 set -ex
 
 # https://github.com/pytorch/executorch/tree/main/examples/demo-apps/android/ExecuTorchDemo
-build_executorch() {
+export_model() {
   MODEL_NAME=dl3
   # Delegating DeepLab v3 to XNNPACK backend
   python -m examples.xnnpack.aot_compiler --model_name="${MODEL_NAME}" --delegate
@@ -16,10 +16,12 @@ build_executorch() {
   ASSETS_DIR=examples/demo-apps/android/ExecuTorchDemo/app/src/main/assets/
   mkdir -p "${ASSETS_DIR}"
   cp "${MODEL_NAME}_xnnpack_fp32.pte" "${ASSETS_DIR}"
+}
 
-  rm -rf cmake-out && mkdir cmake-out
-  ANDROID_NDK=/opt/ndk BUCK2=$(which buck2) FLATC=$(which flatc) ANDROID_ABI=arm64-v8a \
-    bash examples/demo-apps/android/ExecuTorchDemo/setup.sh
+build_android_native_library() {
+  pushd examples/demo-apps/android/LlamaDemo
+  CMAKE_OUT="cmake-out-android-$1" ANDROID_NDK=/opt/ndk ANDROID_ABI="$1" ./gradlew setup
+  popd
 }
 
 build_android_demo_app() {
@@ -30,12 +32,13 @@ build_android_demo_app() {
 
 build_android_llama_demo_app() {
   pushd examples/demo-apps/android/LlamaDemo
-  ANDROID_NDK=/opt/ndk ANDROID_ABI=arm64-v8a ./gradlew setup
   ANDROID_HOME=/opt/android/sdk ./gradlew build
   ANDROID_HOME=/opt/android/sdk ./gradlew assembleAndroidTest
   popd
 }
 
-build_executorch
+build_android_native_library arm64-v8a
+build_android_native_library x86_64
+export_model
 build_android_demo_app
 build_android_llama_demo_app


### PR DESCRIPTION
Build for different ABI in prebuild.

Next step: Build and use libllama_runner.so instead of static libs, so that we can combine RE2 and ABSL stuff together.