### PR TITLE
Remove unused extension/aot_util directory

### DIFF
--- a/extension/aot_util/README.md
+++ b/extension/aot_util/README.md
@@ -1,9 +1,0 @@
-# AOT Util
-
-Ahead-of-time (AOT) utility library. Contains native code used by the AOT lowering and delegation logic. Note 
-that this library should build independently of the runtime code, and as such, should not have dependencies 
-on runtime targets.
-
-This library is intended to be built and distributed as part of the Python pip package, such that it can be
-loaded by AOT Python code.
-


### PR DESCRIPTION
The AOT util extension was removed a while back, but the directory and README still exist. This PR cleans them up. Note that the aot_util sources were deleted previously, so this is not a functional change.