### PR TITLE
strip symbol when linking

### DIFF
--- a/examples/models/llama2/CMakeLists.txt
+++ b/examples/models/llama2/CMakeLists.txt
@@ -175,8 +175,8 @@ if(ANDROID)
 endif()
 
 add_executable(llama_main ${_srcs})
-if(CMAKE_BUILD_TYPE EQUAL "RELEASE")
-  target_link_options(llama_main PRIVATE "LINKER:--gc-sections")
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  target_link_options(llama_main PRIVATE "LINKER:--gc-sections,-s")
 endif()
 
 target_include_directories(llama_main PUBLIC ${_common_include_directories})


### PR DESCRIPTION
Summary:
Refer to https://sourceware.org/binutils/docs/binutils/strip.html
command to build for android
```
rm -rf cmake-android-out && mkdir cmake-android-out

cmake -DBUCK2="$BUCK" \
    -DCMAKE_INSTALL_PREFIX=cmake-android-out \
    -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
    -DANDROID_ABI="arm64-v8a" \
    -DANDROID_PLATFORM=android-29 \
    -DCMAKE_BUILD_TYPE=Release \
    -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
    -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
    -DEXECUTORCH_BUILD_CUSTOM=ON \
    -DEXECUTORCH_BUILD_OPTIMIZED=ON \
    -DEXECUTORCH_BUILD_QUANTIZED=ON \
    -DEXECUTORCH_BUILD_XNNPACK=ON \
    -DEXECUTORCH_ENABLE_LOGGING=ON \
    -Bcmake-android-out .

cmake --build cmake-android-out -j16 --target install --config Release

cmake -DBUCK2="$BUCK" \
    -DCMAKE_INSTALL_PREFIX=cmake-android-out \
    -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
    -DANDROID_ABI="arm64-v8a" \
    -DANDROID_PLATFORM=android-23 \
    -DCMAKE_BUILD_TYPE=Release \
    -DEXECUTORCH_BUILD_CUSTOM=ON \
    -DEXECUTORCH_BUILD_OPTIMIZED=ON \
    -DEXECUTORCH_BUILD_XNNPACK=ON \
    -DEXECUTORCH_ENABLE_LOGGING=ON \
    -DEXECUTORCH_USE_TIKTOKEN=ON \
    -Bcmake-android-out/${dir} \
    ${dir}

cmake --build cmake-android-out/${dir} -j16 --config Release

```

```
(executorch) chenlai@chenlai-mbp executorch % du -sh cmake-android-out/examples/models/llama2/*
 44K	cmake-android-out/examples/models/llama2/CMakeCache.txt
2.2M	cmake-android-out/examples/models/llama2/CMakeFiles
 76K	cmake-android-out/examples/models/llama2/Makefile
4.0K	cmake-android-out/examples/models/llama2/cmake_install.cmake
4.0K	cmake-android-out/examples/models/llama2/compile_commands.json
4.9M	cmake-android-out/examples/models/llama2/custom_ops
736K	cmake-android-out/examples/models/llama2/lib
 54M	cmake-android-out/examples/models/llama2/llama_main
 16K	cmake-android-out/examples/models/llama2/options-pinned.h
 11M	cmake-android-out/examples/models/llama2/runner
151M	cmake-android-out/examples/models/llama2/third-party
```

Reviewed By: lucylq

Differential Revision: D56450794


