### PR TITLE
[BE] Fix compilation on older Linux flavors

### DIFF
--- a/kernels/portable/cpu/op_isinf.cpp
+++ b/kernels/portable/cpu/op_isinf.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& isinf_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realhb_to_bool([](double x) {return std::isinf(x); }, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_bool(static_cast<bool(*)(double)>(std::isinf), ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_isinf.cpp
+++ b/kernels/portable/cpu/op_isinf.cpp
@@ -15,7 +15,8 @@ namespace executor {
 namespace native {
 
 Tensor& isinf_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realhb_to_bool(static_cast<bool(*)(double)>(std::isinf), ctx, in, out);
+  return internal::unary_ufunc_realhb_to_bool(
+      static_cast<bool (*)(double)>(std::isinf), ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_isinf.cpp
+++ b/kernels/portable/cpu/op_isinf.cpp
@@ -14,8 +14,13 @@ namespace torch {
 namespace executor {
 namespace native {
 
+namespace {
+bool isinf(double x) {
+  return ::std::isinf(x);
+}
+}
 Tensor& isinf_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realhb_to_bool(std::isinf, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_bool(isinf, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_isinf.cpp
+++ b/kernels/portable/cpu/op_isinf.cpp
@@ -14,13 +14,8 @@ namespace torch {
 namespace executor {
 namespace native {
 
-namespace {
-bool isinf(double x) {
-  return ::std::isinf(x);
-}
-}
 Tensor& isinf_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realhb_to_bool(isinf, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_bool([](double x) {return std::isinf(x); }, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_isnan.cpp
+++ b/kernels/portable/cpu/op_isnan.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& isnan_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realhb_to_bool(std::isnan, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_bool([](double x) { return ::std::isnan(x); }, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_isnan.cpp
+++ b/kernels/portable/cpu/op_isnan.cpp
@@ -15,7 +15,8 @@ namespace executor {
 namespace native {
 
 Tensor& isnan_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realhb_to_bool(static_cast<bool(*)(double)>(std::isnan), ctx, in, out);
+  return internal::unary_ufunc_realhb_to_bool(
+      static_cast<bool (*)(double)>(std::isnan), ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_isnan.cpp
+++ b/kernels/portable/cpu/op_isnan.cpp
@@ -15,7 +15,7 @@ namespace executor {
 namespace native {
 
 Tensor& isnan_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  return internal::unary_ufunc_realhb_to_bool([](double x) { return ::std::isnan(x); }, ctx, in, out);
+  return internal::unary_ufunc_realhb_to_bool(static_cast<bool(*)(double)>(std::isnan), ctx, in, out);
 }
 
 } // namespace native


### PR DESCRIPTION
To fix `cannot resolve overloaded function ‘isinf’ based on conversion to type ‘torch::executor::FunctionRef<bool(double)>’` error, even though it should work on modern OSes(see https://godbolt.org/z/nYfP93f4K ) , it does not hurt to explicitly cast overloaded function to the form we expect it to be
