### PR TITLE
Fix portable is[inf|nan|_out compilation on older Linux

### DIFF
--- a/kernels/portable/cpu/op_isinf.cpp
+++ b/kernels/portable/cpu/op_isinf.cpp
@@ -15,8 +15,10 @@ namespace executor {
 namespace native {
 
 Tensor& isinf_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
+  // Lambda is syntactic sugar needed to workaround compilation on some older
+  // non-compatible distros where isnan is returning int rather than bool
   return internal::unary_ufunc_realhb_to_bool(
-      static_cast<bool (*)(double)>(std::isinf), ctx, in, out);
+      [](double x) -> bool { return std::isinf(x); }, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_isnan.cpp
+++ b/kernels/portable/cpu/op_isnan.cpp
@@ -15,8 +15,10 @@ namespace executor {
 namespace native {
 
 Tensor& isnan_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
+  // Lambda is syntactic sugar needed to workaround compilation on some older non-compatible distros
+  // where isnan is not defined for double, but either for float or for long double
   return internal::unary_ufunc_realhb_to_bool(
-      static_cast<bool (*)(double)>(std::isnan), ctx, in, out);
+      [](double x) -> bool { return std::isnan(x); }, ctx, in, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_isnan.cpp
+++ b/kernels/portable/cpu/op_isnan.cpp
@@ -15,8 +15,8 @@ namespace executor {
 namespace native {
 
 Tensor& isnan_out(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  // Lambda is syntactic sugar needed to workaround compilation on some older non-compatible distros
-  // where isnan is not defined for double, but either for float or for long double
+  // Lambda is syntactic sugar needed to workaround compilation on some older
+  // non-compatible distros where isnan is returning int rather than bool
   return internal::unary_ufunc_realhb_to_bool(
       [](double x) -> bool { return std::isnan(x); }, ctx, in, out);
 }


### PR DESCRIPTION
Follow up after https://github.com/pytorch/executorch/pull/3262 that didn't actually solved the problem..
By wrapping a potentially non-compliant `isinf`/`isnan` implementations into a lambda with a defined return type

Compiler should be able to optimize it out into direct function call, see https://godbolt.org/z/bqYGd47Mx