### PR TITLE
[pyproject.toml] Add a dependency on `torch==2.3`

### DIFF
--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -18,8 +18,11 @@ retry () {
 install_executorch() {
   which pip
   # Install executorch, this assumes that Executorch is checked out in the
-  # current directory
-  pip install . --no-build-isolation -v
+  # current directory. The --extra-index-url options tell pip to look on the
+  # pytorch servers for nightly and pre-release versions of torch packages.
+  pip install . --no-build-isolation -v \
+      --extra-index-url https://download.pytorch.org/whl/test/cpu \
+      --extra-index-url https://download.pytorch.org/whl/nightly/cpu
   # Just print out the list of packages for debugging
   pip list
 }

--- a/examples/models/llava_encoder/install_requirements.sh
+++ b/examples/models/llava_encoder/install_requirements.sh
@@ -5,6 +5,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+set -x
+
 # install llava from the submodule
 pip install --force-reinstall -e examples/third-party/LLaVA
 
@@ -19,4 +21,4 @@ pip install bitsandbytes -I
 # For example, torch version required from llava is older than ExecuTorch.
 # To make both work, recover ExecuTorch's original dependencies by rerunning
 # the install_requirements.sh.
-./install_requirements.sh
+bash -x ./install_requirements.sh

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -101,8 +101,11 @@ $PIP_EXECUTABLE install --extra-index-url "${TORCH_URL}" \
 
 #
 # Install executorch pip package. This also makes `flatc` available on the path.
+# The --extra-index-url may be necessary if pyproject.toml has a dependency on a
+# pre-release or nightly version of a torch package.
 #
 
 EXECUTORCH_BUILD_PYBIND="${EXECUTORCH_BUILD_PYBIND}" \
     CMAKE_ARGS="${CMAKE_ARGS}" \
-    $PIP_EXECUTABLE install . --no-build-isolation -v
+    $PIP_EXECUTABLE install . --no-build-isolation -v \
+        --extra-index-url "${TORCH_URL}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ classifiers = [
 ]
 
 # Python dependencies required for use.
-requires-python = ">=3.10"
 dependencies=[
   "expecttest",
   "flatbuffers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies=[
   "ruamel.yaml",
   "sympy",
   "tabulate",
+  "torch==2.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
This is the version that the release/0.2 version of executorch depends on.

Also update the CI setup scripts so it can find this version before it's available on PyPI