### PR TITLE
Improve op_permute_copy perf by preprocessing dims

### DIFF
--- a/kernels/portable/cpu/op_convolution.cpp
+++ b/kernels/portable/cpu/op_convolution.cpp
@@ -72,6 +72,13 @@ void conv2d_impl(
   exec_aten::SizesType w_coord[kTensorDimensionLimit];
   w_coord[0] = out_c;
 
+  const int64_t stride_y = val_at(stride, 0);
+  const int64_t padding_y = val_at(padding, 0, /*default_value=*/0);
+  const int64_t dilation_y = val_at(dilation, 0);
+  const int64_t stride_x = val_at(stride, 1);
+  const int64_t padding_x = val_at(padding, 1, /*default_value=*/0);
+  const int64_t dilation_x = val_at(dilation, 1);
+
   // Compute 2D output region
   for (size_t out_y = 0; out_y < out_H; ++out_y) {
     out_coord[2] = out_y;
@@ -87,9 +94,6 @@ void conv2d_impl(
         for (size_t w_y = 0; w_y < w_H; ++w_y) {
           w_coord[2] = w_y;
 
-          int64_t stride_y = val_at(stride, 0);
-          int64_t padding_y = val_at(padding, 0, /*default_value=*/0);
-          int64_t dilation_y = val_at(dilation, 0);
           size_t in_y = stride_y * out_y + dilation_y * w_y - padding_y;
           in_coord[2] = in_y;
           // Only proceed if input y coordinate is within bounds
@@ -97,9 +101,6 @@ void conv2d_impl(
             for (size_t w_x = 0; w_x < w_W; ++w_x) {
               w_coord[3] = w_x;
 
-              int64_t stride_x = val_at(stride, 1);
-              int64_t padding_x = val_at(padding, 1, /*default_value=*/0);
-              int64_t dilation_x = val_at(dilation, 1);
               size_t in_x = stride_x * out_x + dilation_x * w_x - padding_x;
               in_coord[3] = in_x;
 

--- a/kernels/portable/cpu/util/kernel_ops_util.cpp
+++ b/kernels/portable/cpu/util/kernel_ops_util.cpp
@@ -46,16 +46,6 @@ bool param_array_is_valid(
 
 } // namespace
 
-int64_t val_at(IntArrayRef array, size_t i, int64_t default_value) {
-  if (array.size() == 1) {
-    return array[0];
-  } else if (array.size() > 1) {
-    return array[i];
-  } else {
-    return default_value;
-  }
-}
-
 bool int_array_all_ge(IntArrayRef array, int64_t val) {
   for (size_t i = 0; i < array.size(); ++i) {
     if (array[i] < val) {

--- a/kernels/portable/cpu/util/kernel_ops_util.h
+++ b/kernels/portable/cpu/util/kernel_ops_util.h
@@ -20,7 +20,15 @@ namespace executor {
  * the first element will be returned regardless of what i is requested to
  * simulate broadcasting.
  */
-int64_t val_at(IntArrayRef array, size_t i, int64_t default_value = 1);
+inline int64_t val_at(IntArrayRef array, size_t i, int64_t default_value = 1) {
+  if (array.size() == 1) {
+    return array[0];
+  } else if (array.size() > 1) {
+    return array[i];
+  } else {
+    return default_value;
+  }
+}
 
 /**
  * Checks that all elements of an IntArray are greater than or equal to `val`.

--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -55,54 +55,9 @@ size_t TensorImpl::nbytes() const {
   return numel_ * elementSize(type_);
 }
 
-ssize_t TensorImpl::size(ssize_t dim) const {
-  ET_CHECK_MSG(
-      dim < dim_ && dim >= 0,
-      "Dimension out of range (expected to be in range of [0, %zd], but got %zd",
-      dim_ - 1,
-      dim);
-  return sizes_[dim];
-}
-
-ssize_t TensorImpl::dim() const {
-  return dim_;
-}
-
-ssize_t TensorImpl::numel() const {
-  return numel_;
-}
-
-ScalarType TensorImpl::scalar_type() const {
-  return type_;
-}
-
 // Return the size of one element of the tensor
 ssize_t TensorImpl::element_size() const {
   return elementSize(type_);
-}
-
-const ArrayRef<TensorImpl::SizesType> TensorImpl::sizes() const {
-  return ArrayRef<SizesType>{sizes_, static_cast<size_t>(dim_)};
-}
-
-const ArrayRef<TensorImpl::DimOrderType> TensorImpl::dim_order() const {
-  return ArrayRef<DimOrderType>{dim_order_, static_cast<size_t>(dim_)};
-}
-
-const ArrayRef<TensorImpl::StridesType> TensorImpl::strides() const {
-  return ArrayRef<StridesType>{strides_, static_cast<size_t>(dim_)};
-}
-
-const void* TensorImpl::data() const {
-  return data_;
-}
-
-void* TensorImpl::mutable_data() const {
-  return data_;
-}
-
-void TensorImpl::set_data(void* ptr) {
-  data_ = ptr;
 }
 
 Error TensorImpl::internal_resize_contiguous(ArrayRef<SizesType> new_sizes) {

--- a/runtime/core/portable_type/tensor_impl.h
+++ b/runtime/core/portable_type/tensor_impl.h
@@ -122,28 +122,47 @@ class TensorImpl {
    * this method more compatible with at::Tensor, and more consistent with the
    * rest of the methods on this class and in ETensor.
    */
-  ssize_t size(ssize_t dim) const;
+  ssize_t size(ssize_t dim) const {
+    ET_CHECK_MSG(
+        dim < dim_ && dim >= 0,
+        "Dimension out of range (expected to be in range of [0, %zd], but got %zd",
+        dim_ - 1,
+        dim);
+    return sizes_[dim];
+  }
 
   /// Returns the tensor's number of dimensions.
-  ssize_t dim() const;
+  ssize_t dim() const {
+    return dim_;
+  }
 
   /// Returns the number of elements in the tensor.
-  ssize_t numel() const;
+  ssize_t numel() const {
+    return numel_;
+  }
 
   /// Returns the type of the elements in the tensor (int32, float, bool, etc).
-  ScalarType scalar_type() const;
+  ScalarType scalar_type() const {
+    return type_;
+  }
 
   /// Returns the size in bytes of one element of the tensor.
   ssize_t element_size() const;
 
   /// Returns the sizes of the tensor at each dimension.
-  const ArrayRef<SizesType> sizes() const;
+  const ArrayRef<SizesType> sizes() const {
+    return ArrayRef<SizesType>{sizes_, static_cast<size_t>(dim_)};
+  }
 
   /// Returns the order the dimensions are laid out in memory.
-  const ArrayRef<DimOrderType> dim_order() const;
+  const ArrayRef<DimOrderType> dim_order() const {
+    return ArrayRef<DimOrderType>{dim_order_, static_cast<size_t>(dim_)};
+  }
 
   /// Returns the strides of the tensor at each dimension.
-  const ArrayRef<StridesType> strides() const;
+  const ArrayRef<StridesType> strides() const {
+    return ArrayRef<StridesType>{strides_, static_cast<size_t>(dim_)};
+  }
 
   /// Returns a pointer of type T to the constant underlying data blob.
   template <typename T>
@@ -152,7 +171,9 @@ class TensorImpl {
   }
 
   /// Returns a pointer to the constant underlying data blob.
-  const void* data() const;
+  const void* data() const {
+    return data_;
+  }
 
   /// Returns a pointer of type T to the mutable underlying data blob.
   template <typename T>
@@ -161,10 +182,14 @@ class TensorImpl {
   }
 
   /// Returns a pointer to the mutable underlying data blob.
-  void* mutable_data() const;
+  void* mutable_data() const {
+    return data_;
+  }
 
   /// Sets the underlying data blob to the passed in pointer.
-  void set_data(void* ptr);
+  void set_data(void* ptr) {
+    data_ = ptr;
+  }
 
   /*
    * DEPRECATED: Use torch::executor::resize_tensor() or


### PR DESCRIPTION
Summary: It seems the compiler is suddenly able to understand and optimize permute_copy_out if we get that annoying extra branch in the inner loop to go away.

Differential Revision: D56505520


