### PR TITLE
Update README-wheel.md to document what's linked into pybindings

### DIFF
--- a/README-wheel.md
+++ b/README-wheel.md
@@ -4,6 +4,20 @@ standard on-device iOS and Android mobile deployments. One of the main goals for
 ExecuTorch is to enable wider customization and deployment capabilities of the
 PyTorch programs.
 
+The `executorch` pip package is in alpha.
+* Required python version: `==3.10`
+* Compatible systems: Linux x86_64, macOS aarch64
+
+The prebuilt `executorch.extension.pybindings.portable_lib` module included in
+this package provides a way to run ExecuTorch `.pte` files, with some
+restrictions:
+* Only [core ATen
+  operators](https://pytorch.org/executorch/stable/ir-ops-set-definition.html)
+  are linked into the prebuilt module
+* Only the [XNNPACK backend
+  delegate](https://pytorch.org/executorch/main/native-delegates-executorch-xnnpack-delegate.html)
+  is linked into the prebuilt module
+
 Please visit the [ExecuTorch website](https://pytorch.org/executorch/) for
 tutorials and documentation. Here are some starting points:
 * [Getting

--- a/build/packaging/env_var_script_m1.sh
+++ b/build/packaging/env_var_script_m1.sh
@@ -21,8 +21,7 @@ CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_XNNPACK=ON"
 
 # When building for macOS, link additional backends into the pybindings runtime.
 
-# TODO(dbort): Core ML requires features only available in macOS 10.15, but the
+# TODO(dbort): Make these build properly in the CI environment.
 # build machine uses an older version.
 # CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_COREML=ON"
-
-CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_MPS=ON"
+# CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_MPS=ON"


### PR DESCRIPTION
Since pybindings can be built with many configurations, it's important to tell users what's actually present in the wheel.