### PR TITLE
[MPS] Remove the sorting of the nodes from partitioning (not needed for now as Custom Metal kernels are yet not enabled)

### DIFF
--- a/backends/apple/mps/partition/mps_partitioner.py
+++ b/backends/apple/mps/partition/mps_partitioner.py
@@ -102,7 +102,7 @@ class MPSPartitioner(Partitioner):
     def tag_nodes(self, partitions: List[Partition]) -> None:
         for partition in partitions:
             crt_partition_counter = 0
-            for node in sorted(partition.nodes):
+            for node in partition.nodes:
                 delegation_tag = f"mps_{partition.id}"
                 if self.use_metal_kernel(node):
                     logging.warning(f"[WARNING] Using Metal kernel for op {node.name}!")


### PR DESCRIPTION
Remove the sorting of the nodes from partitioning (not needed for now as Custom Metal kernels are yet not enabled)

**Testing**:
Verified that tracing works correctly with release branch:  `python3 -m examples.apple.mps.scripts.mps_example --model_name="mv3"`


cc @shoumikhin , @cccclai 