### PR TITLE
add buck2 installation into setup.md

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -37,7 +37,7 @@ build_cmake_executor_runner() {
   (rm -rf ${CMAKE_OUTPUT_DIR} \
     && mkdir ${CMAKE_OUTPUT_DIR} \
     && cd ${CMAKE_OUTPUT_DIR} \
-    && retry cmake -DBUCK2=buck2 -DCMAKE_BUILD_TYPE=Release \
+    && retry cmake -DCMAKE_BUILD_TYPE=Release \
       -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
 
   cmake --build ${CMAKE_OUTPUT_DIR} -j4
@@ -84,8 +84,7 @@ build_cmake_xnn_executor_runner() {
   (rm -rf ${CMAKE_OUTPUT_DIR} \
     && mkdir ${CMAKE_OUTPUT_DIR} \
     && cd ${CMAKE_OUTPUT_DIR} \
-    && retry cmake -DBUCK2=buck2 \
-      -DCMAKE_BUILD_TYPE=Release \
+    && retry cmake -DCMAKE_BUILD_TYPE=Release \
       -DEXECUTORCH_BUILD_XNNPACK=ON \
       -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
       -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)

--- a/.ci/scripts/test_quantized_aot_lib.sh
+++ b/.ci/scripts/test_quantized_aot_lib.sh
@@ -21,8 +21,7 @@ build_cmake_quantized_aot_lib() {
   (rm -rf ${CMAKE_OUTPUT_DIR} \
     && mkdir ${CMAKE_OUTPUT_DIR} \
     && cd ${CMAKE_OUTPUT_DIR} \
-    && retry cmake -DBUCK2=buck2 \
-      -DCMAKE_BUILD_TYPE=Release \
+    && retry cmake -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
       -DEXECUTORCH_BUILD_QUANTIZED=ON \
       -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -102,7 +102,7 @@ build_executorch_runner_cmake() {
   pushd "${CMAKE_OUTPUT_DIR}" || return
   # This command uses buck2 to gather source files and buck2 could crash flakily
   # on MacOS
-  retry cmake -DBUCK2=buck2 -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" -DCMAKE_BUILD_TYPE=Release ..
+  retry cmake -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" -DCMAKE_BUILD_TYPE=Release ..
   popd || return
 
   if [ "$(uname)" == "Darwin" ]; then

--- a/backends/qualcomm/setup.md
+++ b/backends/qualcomm/setup.md
@@ -93,7 +93,6 @@ mkdir build_android
 cd build_android
 # build executorch & qnn_executorch_backend
 cmake .. \
-    -DBUCK2=buck2 \
     -DCMAKE_INSTALL_PREFIX=$PWD \
     -DEXECUTORCH_BUILD_QNN=ON \
     -DQNN_SDK_ROOT=$QNN_SDK_ROOT \

--- a/docs/source/build-run-xtensa.md
+++ b/docs/source/build-run-xtensa.md
@@ -135,8 +135,7 @@ In order to run the CMake build, you need the path to the following:
 cd executorch
 rm -rf cmake-out
 # prebuild and install executorch library
-cmake -DBUCK2=buck2 \
-    -DCMAKE_TOOLCHAIN_FILE=<path_to_executorch>/examples/xtensa/xtensa.cmake \
+cmake -DCMAKE_TOOLCHAIN_FILE=<path_to_executorch>/examples/cadence/cadence.cmake \
     -DCMAKE_INSTALL_PREFIX=cmake-out \
     -DCMAKE_BUILD_TYPE=Debug \
     -DEXECUTORCH_BUILD_HOST_TARGETS=ON \

--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -184,6 +184,39 @@ Output 0: tensor(sizes=[1], [2.])
 
 To learn how to build a similar program, visit the [ExecuTorch in C++ Tutorial](running-a-model-cpp-tutorial.md).
 
+### [Optional] Setting Up Buck2
+**Buck2** is an open-source build system that some of our examples currently utilize for building and running.
+
+However, please note that the installation of `Buck2` is optional for using ExecuTorch and we are in the process of transitioning away from `Buck2` and migrating all relevant sections to `cmake`. This section will be removed once we finish the migration.
+
+To set up `Buck2`, You will need the following prerequisits for this section:
+* The `zstd` command line tool — install by running
+   ```bash
+   pip3 install zstd
+   ```
+* Version `${executorch_version:buck2}` of the `buck2` commandline tool — you can download a
+  prebuilt archive for your system from [the Buck2
+  repo](https://github.com/facebook/buck2/releases/tag/2024-02-15). Note that
+  the version is important, and newer or older versions may not work with the
+  version of the buck2 prelude used by the ExecuTorch repo.
+
+Configure Buck2 by decompressing with the following command (filename depends
+   on your system):
+
+   ```bash
+   # For example, buck2-x86_64-unknown-linux-musl.zst or buck2-aarch64-apple-darwin.zst
+   zstd -cdq buck2-DOWNLOADED_FILENAME.zst > /tmp/buck2 && chmod +x /tmp/buck2
+   ```
+
+You may want to copy the `buck2` binary into your `$PATH` so you can run it
+   as `buck2`.
+
+After the installation, you can run the `add.pte` program by following `buck2` command:
+
+```bash
+/tmp/buck2 run //examples/portable/executor_runner:executor_runner -- --model_path add.pte
+```
+
 ## Next Steps
 
 Congratulations! You have successfully exported, built, and run your first

--- a/docs/source/runtime-build-and-cross-compilation.md
+++ b/docs/source/runtime-build-and-cross-compilation.md
@@ -60,7 +60,7 @@ cd executorch
 #
 # NOTE: If your `buck2` binary is not on the PATH, you can change this line to
 # say something like `-DBUCK2=/tmp/buck2` to point directly to the tool.
-(rm -rf cmake-out && mkdir cmake-out && cd cmake-out && cmake -DBUCK2=buck2 ..)
+(rm -rf cmake-out && mkdir cmake-out && cd cmake-out && cmake ..)
 ```
 
 Once this is done, you don't need to do it again until you pull from the upstream repo again, or if you modify any CMake-related files.

--- a/docs/source/tutorial-xnnpack-delegate-lowering.md
+++ b/docs/source/tutorial-xnnpack-delegate-lowering.md
@@ -171,7 +171,7 @@ Now you should be able to find the executable built at `./cmake-out/backends/xnn
 
 
 ## Running the XNNPACK Model with Buck
-Alternatively, you can use `buck2` to run the `.pte` file with XNNPACK delegate instructions in it on your host platform. You can follow the instructions here to install [buck2](getting-started-setup.md#building-a-runtime). You can now run it with the prebuilt `xnn_executor_runner` provided in the examples. This will run the model on some sample inputs.
+Alternatively, you can use `buck2` to run the `.pte` file with XNNPACK delegate instructions in it on your host platform. You can follow the instructions here to install [buck2](getting-started-setup.md#Build-&-Run). You can now run it with the prebuilt `xnn_executor_runner` provided in the examples. This will run the model on some sample inputs.
 
 ```bash
 buck2 run examples/xnnpack:xnn_executor_runner -- --model_path ./mv2_xnnpack_fp32.pte

--- a/examples/portable/scripts/test_demo_backend_delegation.sh
+++ b/examples/portable/scripts/test_demo_backend_delegation.sh
@@ -22,8 +22,7 @@ build_cmake_executor_runner() {
   (rm -rf ${CMAKE_OUTPUT_DIR} \
     && mkdir ${CMAKE_OUTPUT_DIR} \
     && cd ${CMAKE_OUTPUT_DIR} \
-    && retry cmake -DBUCK2=buck2 \
-      -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
+    && retry cmake -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
 
   cmake --build ${CMAKE_OUTPUT_DIR} -j4
 }

--- a/examples/sdk/README.md
+++ b/examples/sdk/README.md
@@ -56,7 +56,7 @@ Running the program will generate an `ETDump` file (`.etdp`) at the location spe
 
 ```bash
    cd executorch
-   rm -rf cmake-out && mkdir cmake-out && cd cmake-out && cmake -DBUCK2=buck2 -DEXECUTORCH_BUILD_SDK=1 -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=1 ..
+   rm -rf cmake-out && mkdir cmake-out && cd cmake-out && cmake -DEXECUTORCH_BUILD_SDK=1 -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=1 ..
    cd ..
    cmake --build cmake-out -j8 -t sdk_example_runner
    ./cmake-out/examples/sdk/sdk_example_runner --bundled_program_path mv2_bundled.bpte --etdump_path mv2_etdump.etdp


### PR DESCRIPTION
Summary: bring buck2 installation back, and scrub any "-DBUCK2=buck2" in our docs, to unblock users from using buck2

Reviewed By: guangy10

Differential Revision: D56540769

fbshipit-source-id: 363e592c17dd2747a693e59d8d6b6d20f43c8451 (cherry picked from commit 590cbcee7e2ef3b6af3762b0145294b8e8bd0e6d)