### PR TITLE
Remove unneeded _to_copy in edge dialect.

### DIFF
--- a/exir/passes/__init__.py
+++ b/exir/passes/__init__.py
@@ -43,7 +43,7 @@ from executorch.exir.passes.memory_format_ops_pass import MemoryFormatOpsPass
 from executorch.exir.passes.memory_planning_pass import MemoryPlanningPass
 from executorch.exir.passes.normalize_transpose_pass import NormalizeTransposePass
 from executorch.exir.passes.quant_fusion_pass import QuantFusionPass
-from executorch.exir.passes.remove_noop_pass import RemoveNoopPass
+from executorch.exir.passes.remove_noop_pass import RemoveNoopPass, RemoveToCopyPass
 from executorch.exir.passes.replace_aten_with_edge_pass import OpReplacePass
 from executorch.exir.passes.replace_broken_ops_with_function_ops_pass import (
     ReplaceBrokenOpsWithFunctionalOpsPass,
@@ -482,6 +482,7 @@ base_pre_op_replace_passes: List[Callable[[torch.nn.Module], PassResult]] = Pass
         ScalarToTensorPass(),
         SymToTensorPass(),
         RemoveNoopPass(),
+        RemoveToCopyPass(),
     ]
 ).passes
 

--- a/exir/passes/remove_noop_pass.py
+++ b/exir/passes/remove_noop_pass.py
@@ -90,3 +90,30 @@ class RemoveNoopPass(ExportPass):
         graph_module.graph.eliminate_dead_code()
 
         return PassResult(graph_module, True)
+
+
+class RemoveToCopyPass(ExportPass):
+    """
+    Removes _to_copy that pass through arguments.
+    """
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        for node in graph_module.graph.nodes:
+            if node.op != "call_function":
+                continue
+
+            if node.target not in (torch.ops.aten._to_copy.default,):
+                continue
+
+            orig_tensor = node.args[0].meta["val"]
+
+            if (
+                orig_tensor.dtype == node.meta["val"].dtype
+                and orig_tensor.device == node.meta["val"].device
+            ):
+                node.replace_all_uses_with(node.args[0])
+
+        graph_module.graph.eliminate_dead_code()
+        graph_module.graph.lint()
+
+        return PassResult(graph_module, True)


### PR DESCRIPTION
Summary: In executorch we will dtype-specialize the kernels and also run on a single device with export. Therefore _to_copy is not needed in edge dialect.

Differential Revision: D56579169
