### PR TITLE
Fix extension/data_loader installation

### DIFF
--- a/extension/data_loader/CMakeLists.txt
+++ b/extension/data_loader/CMakeLists.txt
@@ -25,6 +25,6 @@ target_compile_options(extension_data_loader PUBLIC ${_common_compile_options})
 # Install libraries
 install(
   TARGETS extension_data_loader
-  DESTINATION ${CMAKE_BINARY_DIR}/lib
+  DESTINATION lib
   INCLUDES
   DESTINATION ${_common_include_directories})


### PR DESCRIPTION
Summary:

`libextension_data_loader.a` is not installed properly. This PR removes the prefix so that it can be properly installed

Test Plan: See `libextension_data_loader.a` showing up under executorch/cmake-out/lib.

Reviewers:

Subscribers:

Tasks:

Tags: