### PR TITLE
Remove -s compile option from release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,9 +120,6 @@ endif()
 # disables exceptions and runtime type.
 set(CMAKE_CXX_FLAGS_RELEASE
     "-ffunction-sections -fdata-sections -fno-exceptions -fno-rtti")
-if(NOT APPLE)
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
-endif()
 
 option(OPTIMIZE_SIZE "Build executorch runtime optimizing for binary size" OFF)
 if(OPTIMIZE_SIZE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,9 @@ endif()
 # disables exceptions and runtime type.
 set(CMAKE_CXX_FLAGS_RELEASE
     "-ffunction-sections -fdata-sections -fno-exceptions -fno-rtti")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+endif()
 
 option(OPTIMIZE_SIZE "Build executorch runtime optimizing for binary size" OFF)
 if(OPTIMIZE_SIZE)


### PR DESCRIPTION
Summary: This compile option causes a lot of warnings in cmake build:

```
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
```

So removing it for now.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: