### PR TITLE
Remove clone operations in quantization step

### DIFF
--- a/backends/arm/arm_quantizer.py
+++ b/backends/arm/arm_quantizer.py
@@ -27,6 +27,7 @@ from executorch.backends.arm.arm_quantizer_utils import (
     OperatorPatternType,
     propagate_annotation,
     QuantizationConfig,
+    remove_clone_ops,
 )
 from torch.ao.quantization.fake_quantize import (
     FakeQuantize,
@@ -369,6 +370,7 @@ class ArmQuantizer(Quantizer):
         self, model: torch.fx.GraphModule
     ) -> torch.fx.GraphModule:
         """Transforms scalar values to tensor attributes"""
+        remove_clone_ops(model)
         return _convert_scalars_to_attrs(model)
 
     def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:

--- a/backends/arm/test/ops/test_clone.py
+++ b/backends/arm/test/ops/test_clone.py
@@ -1,0 +1,116 @@
+# Copyright 2024 Arm Limited and/or its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# Tests the clone op which copies the data of the input tensor (possibly with new data format)
+#
+
+import logging
+import unittest
+from typing import Tuple
+
+import torch
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.arm_tester import ArmTester
+from parameterized import parameterized
+
+logger = logging.getLogger(__name__)
+
+
+class TestSimpleClone(unittest.TestCase):
+    class Clone(torch.nn.Module):
+        sizes = [10, 15, 50, 100]
+        test_parameters = [(torch.ones(n),) for n in sizes]
+
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x: torch.Tensor):
+            x = x.clone()
+            return x
+
+    def _test_clone_tosa_MI_pipeline(
+        self, module: torch.nn.Module, test_data: torch.Tensor
+    ):
+        tester = (
+            ArmTester(
+                module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
+            )
+            .export()
+            .check_count({"torch.ops.aten.clone.default": 1})
+            .to_edge()
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+        )
+
+        if common.TOSA_REF_MODEL_INSTALLED:
+            tester.run_method_and_compare_outputs(qtol=1)
+        else:
+            logger.warning(
+                "TOSA ref model tool not installed, skip numerical correctness tests"
+            )
+
+    def _test_clone_tosa_BI_pipeline(
+        self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
+    ):
+        tester = (
+            ArmTester(
+                module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
+            )
+            .quantize()
+            .export()
+            .check_count({"torch.ops.aten.clone.default": 1})
+            .to_edge()
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+        )
+
+        if common.TOSA_REF_MODEL_INSTALLED:
+            tester.run_method_and_compare_outputs(qtol=1)
+        else:
+            logger.warning(
+                "TOSA ref model tool not installed, skip numerical correctness tests"
+            )
+
+    def _test_clone_tosa_u55_pipeline(
+        self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
+    ):
+        (
+            ArmTester(
+                module, inputs=test_data, compile_spec=common.get_u55_compile_spec()
+            )
+            .quantize()
+            .export()
+            .check_count({"torch.ops.aten.clone.default": 1})
+            .to_edge()
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+        )
+
+    @parameterized.expand(Clone.test_parameters)
+    def test_clone_tosa_MI(self, test_tensor: torch.Tensor):
+        self._test_clone_tosa_MI_pipeline(self.Clone(), (test_tensor,))
+
+    # Expected to fail since ArmQuantizer cannot quantize a Clone layer
+    # TODO MLETROCH-125
+    @parameterized.expand(Clone.test_parameters)
+    @unittest.expectedFailure
+    def test_clone_tosa_BI(self, test_tensor: torch.Tensor):
+        self._test_clone_tosa_BI_pipeline(self.Clone(), (test_tensor,))
+
+    # Expected to fail since ArmQuantizer cannot quantize a Clone layer
+    # TODO MLETROCH-125
+    @parameterized.expand(Clone.test_parameters)
+    @unittest.expectedFailure
+    @unittest.skipIf(
+        not common.VELA_INSTALLED,
+        "There is no point in running U55 tests if the Vela tool is not installed",
+    )
+    def test_clone_u55_BI(self, test_tensor: torch.Tensor):
+        self._test_clone_tosa_u55_pipeline(self.Clone(), (test_tensor,))

--- a/backends/arm/test/ops/test_view.py
+++ b/backends/arm/test/ops/test_view.py
@@ -1,0 +1,113 @@
+# Copyright 2024 Arm Limited and/or its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# Tests the view op which changes the size of a Tensor without changing the underlying data.
+#
+
+import logging
+import unittest
+from typing import Tuple
+
+import torch
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.arm_tester import ArmTester
+from parameterized import parameterized
+
+logger = logging.getLogger(__name__)
+
+
+class TestSimpleView(unittest.TestCase):
+    class View(torch.nn.Module):
+
+        sizes = [10, 15, 50, 100]
+        test_parameters = [(torch.ones(n),) for n in sizes]
+
+        def forward(self, x: torch.Tensor):
+            return x.view(-1, 5)
+
+    def _test_view_tosa_MI_pipeline(
+        self, module: torch.nn.Module, test_data: torch.Tensor
+    ):
+        tester = (
+            ArmTester(
+                module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
+            )
+            .export()
+            .check_count({"torch.ops.aten.view.default": 1})
+            .to_edge()
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+        )
+
+        if common.TOSA_REF_MODEL_INSTALLED:
+            tester.run_method_and_compare_outputs(qtol=1)
+        else:
+            logger.warning(
+                "TOSA ref model tool not installed, skip numerical correctness tests"
+            )
+
+    def _test_view_tosa_BI_pipeline(
+        self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
+    ):
+        tester = (
+            ArmTester(
+                module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
+            )
+            .quantize()
+            .export()
+            .check_count({"torch.ops.aten.view.default": 1})
+            .to_edge()
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+        )
+
+        if common.TOSA_REF_MODEL_INSTALLED:
+            tester.run_method_and_compare_outputs(qtol=1)
+        else:
+            logger.warning(
+                "TOSA ref model tool not installed, skip numerical correctness tests"
+            )
+
+    def _test_view_u55_BI_pipeline(
+        self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
+    ):
+        (
+            ArmTester(
+                module, inputs=test_data, compile_spec=common.get_u55_compile_spec()
+            )
+            .quantize()
+            .export()
+            .check_count({"torch.ops.aten.view.default": 1})
+            .to_edge()
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+        )
+
+    @parameterized.expand(View.test_parameters)
+    def test_view_tosa_MI(self, test_tensor: torch.Tensor):
+        self._test_view_tosa_MI_pipeline(self.View(), (test_tensor,))
+
+    # Expected to fail since ArmQuantizer cannot quantize a View layer.
+    # TODO MLETROCH-125
+    @parameterized.expand(View.test_parameters)
+    @unittest.expectedFailure
+    def test_view_tosa_BI(self, test_tensor: torch.Tensor):
+        self._test_view_tosa_BI_pipeline(self.View(), (test_tensor,))
+
+    # Expected to fail since ArmQuantizer cannot quantize a View layer.
+    # TODO MLETROCH-125
+    @parameterized.expand(View.test_parameters)
+    @unittest.expectedFailure
+    @unittest.skipIf(
+        not common.VELA_INSTALLED,
+        "There is no point in running U55 tests if the Vela tool is not installed",
+    )
+    def test_view_u55_BI(self, test_tensor: torch.Tensor):
+        self._test_view_u55_BI_pipeline(self.View(), (test_tensor,))

--- a/backends/arm/test/test_models.py
+++ b/backends/arm/test/test_models.py
@@ -47,38 +47,6 @@ class TorchBuilder:
         pass
 
     @register_test
-    class simple_clone(torch.nn.Module):
-        inputs = {
-            TosaProfile.BI: (torch.ones(10),),
-            TosaProfile.MI: (torch.ones(10),),
-        }
-
-        permute_memory_to_nhwc = False
-
-        def __init__(self):
-            super().__init__()
-
-        def forward(self, x):
-            x = x.clone()
-            return x
-
-    @register_test
-    class simple_view(torch.nn.Module):
-        inputs = {
-            TosaProfile.BI: (torch.ones(10),),
-            TosaProfile.MI: (torch.ones(10),),
-        }
-
-        permute_memory_to_nhwc = False
-
-        def __init__(self):
-            super().__init__()
-
-        def forward(self, x):
-            x = x.view(2, 5)
-            return x
-
-    @register_test
     class simple_add_broadcast(torch.nn.Module):
         inputs = {
             TosaProfile.BI_INT: (

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -93,6 +93,13 @@ def _get_input_quantization_params(
     return quant_params
 
 
+def _has_op_nodes(program: ExportedProgram) -> bool:
+    num_inputs = len(program.graph_signature.user_inputs)
+    num_outputs = len(program.graph_signature.user_outputs)
+    num_nodes = len(program.graph.nodes)
+    return num_nodes > num_inputs + num_outputs
+
+
 def _get_output_node(program: ExportedProgram) -> Node:
     """
     Get output node to this model.
@@ -239,6 +246,10 @@ class ArmTester(Tester):
 
         export_stage = self.stages[self.stage_name(Export)]
         exported_program = export_stage.artifact
+        assert _has_op_nodes(
+            exported_program
+        ), "Cannot compare outputs on a model without ops."
+
         input_names = _get_input_names(exported_program)
         output_node = _get_output_node(exported_program)
         output_name = output_node.name

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -28,7 +28,7 @@ from executorch.backends.arm.test.tosautil.tosa_test_utils import (
 from executorch.backends.xnnpack.test.tester import Tester
 from executorch.backends.xnnpack.test.tester.tester import (
     Export,
-    Partition,
+    Partition as PartitionSuperclass,
     Quantize,
     ToEdge,
 )
@@ -36,90 +36,108 @@ from executorch.backends.xnnpack.test.tester.tester import (
 from executorch.exir import EdgeCompileConfig
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from torch.export import ExportedProgram
+from torch.fx.node import Node
 
 
-def _get_input_params(
-    program: ExportedProgram, is_quantized: bool
-) -> Tuple[str, Union[List[QuantizationParams], List[None]]]:
+def _get_input_names(program: ExportedProgram) -> list[str]:
     """
-    Get name and optionally quantization parameters for the inputs to this
-    model.
+    Get a list[str] with the names of the inputs to this model.
 
     Args:
-        program (ExportedProgram): The program to get input parameters from
+        program (ExportedProgram): The program to get input names from.
     Returns:
-        Tuple[str, Optional[QuantizationParams]]: A tuple containing the
-            input node names and their quantization parameters.
+        A list of strings with the names of the model input.
     """
     input_names = []
+
     # E.g. bias and weights are 'placeholders' as well. This is used to
     # get only the use inputs.
     usr_inputs = program.graph_signature.user_inputs
     for node in program.graph.nodes:
         if node.op == "placeholder" and node.name in usr_inputs:
             input_names.append(node.name)
-            continue
 
-    if is_quantized:
-        quant_params = []
-        for node in program.graph.nodes:
-            if (
-                node.target
-                == torch.ops.quantized_decomposed.quantize_per_tensor.default
-                and node.args[0].name in input_names
-            ):
-                qp = QuantizationParams(
-                    node_name=node.args[0].name, scale=node.args[1], zp=node.args[2]
-                )
-                quant_params.append(qp)
-                if len(quant_params) == len(
-                    input_names
-                ):  # break early if we have all the inputs quantized parameters
-                    break
-        assert len(quant_params) != 0, "Quantization paramerters not found"
-        return (input_names, quant_params)
-    else:
-        return (input_names, len(input_names) * [None])  # return a list of None's
+    return input_names
 
 
-def _get_output_param(
-    program: ExportedProgram, is_quantized: bool
-) -> Tuple[str, Union[QuantizationParams, None]]:
+def _get_input_quantization_params(
+    program: ExportedProgram, input_names: list[str]
+) -> list[QuantizationParams]:
     """
-    Get name and optionally quantization parameters for the inputs to this
-    model.
+    Get input QuantizationParams in a program, maximum one per input to the program.
+    Args:
+        program (ExportedProgram): The program to get input quantization parameters from.
+    Returns:
+        list[QuantizationParams]: The found quantization parameters.
+    Raises:
+        RuntimeError if no quantization parameters are found.
+    """
+
+    quant_params = []
+    num_inputs = len(input_names)
+    for node in program.graph.nodes:
+        if (
+            node.target == torch.ops.quantized_decomposed.quantize_per_tensor.default
+            and node.args[0].name in input_names
+        ):
+            qp = QuantizationParams(
+                node_name=node.args[0].name, scale=node.args[1], zp=node.args[2]
+            )
+            quant_params.append(qp)
+            if (
+                len(quant_params) == num_inputs
+            ):  # break early if we have all the inputs quantized parameters
+                break
+    if len(quant_params) == 0:
+        raise RuntimeError("No Quantization parameters not found in exported model.")
+    return quant_params
+
+
+def _get_output_node(program: ExportedProgram) -> Node:
+    """
+    Get output node to this model.
 
     Args:
-        program (ExportedProgram): The program to get output parameters from.
+        program (ExportedProgram): The program to get output node from.
     Returns:
-        Tuple[str, Optional[QuantizationParams]]: A tuple containing the
-            output node name and its quantization parameters.
+        The node that is the output of 'program'.
     """
-    output_node = None
+
     for node in program.graph.nodes:
         if node.op == "output":
-            output_node = node
-            break
-
-    if is_quantized:
-        quant_params = None
-        for node in program.graph.nodes:
-            if (
-                node.target
-                == torch.ops.quantized_decomposed.dequantize_per_tensor.default
-                and node == output_node.args[0][0]
-            ):
-                quant_params = QuantizationParams(
-                    node_name=node.args[0].name, scale=node.args[1], zp=node.args[2]
-                )
-                break  # break early, there's only one output node
-        assert quant_params is not None, "Quantization paramerters not found"
-        return (output_node.name, quant_params)
-    else:
-        return (output_node.name, None)
+            return node
+    raise RuntimeError("No output node found.")
 
 
-class Partition(Partition):
+def _get_output_quantization_params(
+    program: ExportedProgram, output_node: Node
+) -> QuantizationParams:
+    """
+    Get output QuantizationParams from a program.
+    Args:
+        program (ExportedProgram): The program to get output quantization parameters from.
+    Returns:
+        QuantizationParams: The found quantization parameters.
+    Raises:
+        RuntimeError if no output quantization parameters are found.
+    """
+
+    quant_params = None
+    for node in program.graph.nodes:
+        if (
+            node.target == torch.ops.quantized_decomposed.dequantize_per_tensor.default
+            and node == output_node.args[0][0]
+        ):
+            quant_params = QuantizationParams(
+                node_name=node.args[0].name, scale=node.args[1], zp=node.args[2]
+            )
+            break  # break early, there's only one output node
+    if quant_params is None:
+        raise RuntimeError("No Quantization parameters not found in exported model.")
+    return quant_params
+
+
+class Partition(PartitionSuperclass):
     def dump_artifact(self, path_to_dump: Optional[str]):
         super().dump_artifact(path_to_dump)
         from pprint import pformat
@@ -220,12 +238,18 @@ class ArmTester(Tester):
         stage = stage or self.cur
 
         export_stage = self.stages[self.stage_name(Export)]
+        exported_program = export_stage.artifact
+        input_names = _get_input_names(exported_program)
+        output_node = _get_output_node(exported_program)
+        output_name = output_node.name
+        is_quantized = self.stages[self.stage_name(Quantize)] is not None
 
-        is_quantized = self.stages["Quantize"] is not None
-        (input_names, qp_input) = _get_input_params(export_stage.artifact, is_quantized)
-        (output_name, qp_output) = _get_output_param(
-            export_stage.artifact, is_quantized
-        )
+        if is_quantized:
+            qp_input = _get_input_quantization_params(exported_program, input_names)
+            qp_output = _get_output_quantization_params(exported_program, output_node)
+        else:
+            qp_input = [None] * len(input_names)
+            qp_output = None
 
         # Calculate the reference output using the original module or the quant
         # module.


### PR DESCRIPTION
The main purpose of the PR is to handle quantization of clone operations by removing them in the transform_for_annotation step of the ArmQuantizer. The previous commits do some refactoring and add an assertion check related to this. 