### PR TITLE
Fix remove _to_copy pass.

### DIFF
--- a/exir/passes/remove_noop_pass.py
+++ b/exir/passes/remove_noop_pass.py
@@ -110,6 +110,8 @@ class RemoveToCopyPass(ExportPass):
             if (
                 orig_tensor.dtype == node.meta["val"].dtype
                 and orig_tensor.device == node.meta["val"].device
+                and orig_tensor.shape == node.meta["val"].shape
+                and orig_tensor.stride() == node.meta["val"].stride()
             ):
                 node.replace_all_uses_with(node.args[0])
 


### PR DESCRIPTION
Summary: Turns out that .to() can also change memory format, therefore we need to ensure the strides and shapes don't change before removing _to_copy node.

Reviewed By: cccclai

Differential Revision: D56637766
