### PR TITLE
Remove preview wording and TODOs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,16 @@ Key value propositions of ExecuTorch are:
 For a comprehensive technical overview of ExecuTorch and step-by-step tutorials,
 please visit our documentation website [for the latest release](https://pytorch.org/executorch/stable/index.html) (or the [main branch](https://pytorch.org/executorch/main/index.html)).
 
-## Important: This is a preview release
+## Feedback
 
-This is a preview version of ExecuTorch and should be used for testing and
-evaluation purposes only. It is not recommended for use in production settings.
 We welcome any feedback, suggestions, and bug reports from the community to help
-us improve the technology. Please use the [PyTorch
+us improve our technology. Please use the [PyTorch
 Forums](https://discuss.pytorch.org/c/executorch) for discussion and feedback
 about ExecuTorch using the **ExecuTorch** category, and our [GitHub
 repository](https://github.com/pytorch/executorch/issues) for bug reporting.
 
-The ExecuTorch code and APIs are still changing quickly, and there are not yet
-any guarantees about forward/backward source compatibility. We recommend using
-the latest `v#.#.#` release tag from the
-[Releases](https://github.com/pytorch/executorch/releases) page when
-experimenting with this preview release.
+We recommend using the latest release tag from the
+[Releases](https://github.com/pytorch/executorch/releases) page when developing.
 
 ## Directory Structure
 
@@ -42,9 +37,9 @@ experimenting with this preview release.
 executorch
 ├── backends                        #  Backend delegate implementations.
 ├── build                           #  Utilities for managing the build system.
-├── bundled_program                 #  Utilities for attaching reference inputs and outputs to models. TODO move to extension
-├── codegen                         #  Tooling to autogenerate bindings between kernels and the runtime. TODO move to tool
-├── configurations                  #  TODO delete this
+├── bundled_program                 #  Utilities for attaching reference inputs and outputs to models.
+├── codegen                         #  Tooling to autogenerate bindings between kernels and the runtime.
+├── configurations
 ├── docs                            #  Static docs tooling
 ├── examples                        #  Examples of various user flows, such as model export, delegates, and runtime execution.
 ├── exir                            #  Ahead of time library, model capture and lowering apis.
@@ -69,20 +64,20 @@ executorch
 |   ├── portable                    #  Reference implementations of ATen operators.
 |   ├── prim_ops                    #  Special ops used in executorch runtime for control flow and symbolic primitives.
 |   ├── quantized
-├── profiler                        #  Utilities for profiling. TODO delete in favor of ETDump in sdk/
-├── runtime                         #  core cpp runtime of executorch
+├── profiler                        #  Utilities for profiling.
+├── runtime                         #  Core cpp runtime
 |   ├── backend                     #  Backend delegate runtime APIs
 |   ├── core                        #  Core structures used across all levels of the runtime
 |   ├── executor                    #  Model loading, initalization, and execution.
 |   ├── kernel                      #  Kernel registration and management.
 |   ├── platform                    #  Layer between architecture specific code and user calls.
-├── schema                          #  ExecuTorch program definition, TODO move under serialization/
+├── schema                          #  ExecuTorch program definition
 ├── scripts                         #  Utility scripts for size management, dependency management, etc.
 ├── sdk                             #  Model profiling, debugging, and introspection.
 ├── shim                            #  Compatibility layer between OSS and Internal builds
 ├── test                            #  Broad scoped end2end tests
-├── third-party                     #  third-party dependencies
-├── util                            #  TODO delete this
+├── third-party                     #  Third-party dependencies
+├── util
 ```
 
 ## License


### PR DESCRIPTION
Refining the README.md to not include preview wording now that we are at alpha and also no TODO in the directory structure.