### PR TITLE
Refactor Codegen.cmake to add argument names

### DIFF
--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -109,6 +109,7 @@ endfunction()
 # Generate an AOT lib for registering custom ops into PyTorch
 function(gen_custom_ops_aot_lib)
   set(multi_arg_names LIB_NAME KERNEL_SOURCES)
+  cmake_parse_arguments(GEN "" "${multi_arg_names}" "" ${ARGN})
   message(STATUS "Generating custom ops aot lib:")
   message(STATUS "  LIB_NAME: ${GEN_LIB_NAME}")
   message(STATUS "  KERNEL_SOURCES: ${GEN_KERNEL_SOURCES}")

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -112,13 +112,15 @@ function(gen_custom_ops_aot_lib)
   cmake_parse_arguments(GEN "" "${multi_arg_names}" "" ${ARGN})
   message(STATUS "Generating custom ops aot lib:")
   message(STATUS "  LIB_NAME: ${GEN_LIB_NAME}")
-  message(STATUS "  KERNEL_SOURCES: ${GEN_KERNEL_SOURCES}")
+  foreach(SOURCE IN LISTS GEN_KERNEL_SOURCES)
+    message(STATUS "  KERNEL_SOURCE: ${SOURCE}")
+  endforeach()
 
   set(_out_dir ${CMAKE_CURRENT_BINARY_DIR}/${GEN_LIB_NAME})
   add_library(
     ${GEN_LIB_NAME} SHARED
     ${_out_dir}/RegisterCPUCustomOps.cpp ${_out_dir}/RegisterSchema.cpp
-    ${_out_dir}/CustomOpsNativeFunctions.h ${GEN_KERNEL_SOURCES})
+    ${_out_dir}/CustomOpsNativeFunctions.h "${GEN_KERNEL_SOURCES}")
   # Find `Torch`.
   find_package(Torch REQUIRED)
   # This lib uses ATen lib, so we explicitly enable rtti and exceptions.

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -108,8 +108,7 @@ endfunction()
 
 # Generate an AOT lib for registering custom ops into PyTorch
 function(gen_custom_ops_aot_lib)
-  set(multi_arg_names LIB_NAME KERNEL_SOURCES)
-  cmake_parse_arguments(GEN "" "${multi_arg_names}" "" ${ARGN})
+  cmake_parse_arguments(GEN "" "LIB_NAME" "KERNEL_SOURCES" ${ARGN})
   message(STATUS "Generating custom ops aot lib:")
   message(STATUS "  LIB_NAME: ${GEN_LIB_NAME}")
   foreach(SOURCE IN LISTS GEN_KERNEL_SOURCES)

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -44,7 +44,7 @@ function(gen_selected_ops)
     COMMENT "Generating selected_operators.yaml for ${GEN_LIB_NAME}"
     OUTPUT ${_oplist_yaml}
     COMMAND ${_gen_oplist_command}
-    DEPENDS ${ops_schema_yaml} ${_codegen_tools_srcs}
+    DEPENDS ${GEN_OPS_SCHEMA_YAML} ${_codegen_tools_srcs}
     WORKING_DIRECTORY ${EXECUTORCH_ROOT})
 
 endfunction()
@@ -164,6 +164,10 @@ endfunction()
 function(merge_yaml)
   set(arg_names FUNCTIONS_YAML FALLBACK_YAML OUTPUT_DIR)
   cmake_parse_arguments(GEN "" "${arg_names}" "" ${ARGN})
+  message(STATUS "Merging kernel yaml files:")
+  message(STATUS "  FUNCTIONS_YAML: ${GEN_FUNCTIONS_YAML}")
+  message(STATUS "  FALLBACK_YAML: ${GEN_FALLBACK_YAML}")
+  message(STATUS "  OUTPUT_DIR: ${GEN_OUTPUT_DIR}")
 
   set(_gen_command
       "${PYTHON_EXECUTABLE}" -m codegen.tools.merge_yaml
@@ -174,5 +178,6 @@ function(merge_yaml)
     COMMENT "Merging kernel yaml files"
     OUTPUT ${GEN_OUTPUT_DIR}/merged.yaml
     COMMAND ${_gen_command}
+    DEPENDS ${GEN_FUNCTIONS_YAML} ${GEN_FALLBACK_YAML}
     WORKING_DIRECTORY ${EXECUTORCH_ROOT})
 endfunction()

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -21,6 +21,8 @@ function(gen_selected_ops)
 
   set(_oplist_yaml
       ${CMAKE_CURRENT_BINARY_DIR}/${GEN_LIB_NAME}/selected_operators.yaml)
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${GEN_LIB_NAME})
+
   file(GLOB_RECURSE _codegen_tools_srcs "${EXECUTORCH_ROOT}/codegen/tools/*.py")
 
   set(_gen_oplist_command "${PYTHON_EXECUTABLE}" -m codegen.tools.gen_oplist
@@ -39,7 +41,7 @@ function(gen_selected_ops)
 
   message("Command - ${_gen_oplist_command}")
   add_custom_command(
-    COMMENT "Generating selected_operators.yaml for custom ops"
+    COMMENT "Generating selected_operators.yaml for ${GEN_LIB_NAME}"
     OUTPUT ${_oplist_yaml}
     COMMAND ${_gen_oplist_command}
     DEPENDS ${ops_schema_yaml} ${_codegen_tools_srcs}

--- a/configurations/CMakeLists.txt
+++ b/configurations/CMakeLists.txt
@@ -39,7 +39,7 @@ if(EXECUTORCH_BUILD_OPTIMIZED)
     ${CMAKE_CURRENT_BINARY_DIR})
 
   gen_selected_ops(LIB_NAME "optimized_native_cpu_ops_lib"
-                   OPS_SCHEMA_YAML"${CMAKE_CURRENT_BINARY_DIR}/merged.yaml")
+                   OPS_SCHEMA_YAML "${CMAKE_CURRENT_BINARY_DIR}/merged.yaml")
 
   generate_bindings_for_kernels(
     LIB_NAME "optimized_native_cpu_ops_lib" FUNCTIONS_YAML

--- a/configurations/CMakeLists.txt
+++ b/configurations/CMakeLists.txt
@@ -34,22 +34,27 @@ include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
 if(EXECUTORCH_BUILD_OPTIMIZED)
   # Merge optimized and portable definitions, taking optimized where available.
   merge_yaml(
-      FUNCTIONS_YAML ${EXECUTORCH_ROOT}/kernels/optimized/optimized-oss.yaml
-      FALLBACK_YAML ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
-      OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}
-  )
+    FUNCTIONS_YAML ${EXECUTORCH_ROOT}/kernels/optimized/optimized-oss.yaml
+    FALLBACK_YAML ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml OUTPUT_DIR
+    ${CMAKE_CURRENT_BINARY_DIR})
 
-  gen_selected_ops("${CMAKE_CURRENT_BINARY_DIR}/merged.yaml" "" "")
+  gen_selected_ops(LIB_NAME "optimized_native_cpu_ops_lib"
+                   OPS_SCHEMA_YAML"${CMAKE_CURRENT_BINARY_DIR}/merged.yaml")
 
   generate_bindings_for_kernels(
-      FUNCTIONS_YAML ${CMAKE_CURRENT_BINARY_DIR}/merged.yaml)
+    LIB_NAME "optimized_native_cpu_ops_lib" FUNCTIONS_YAML
+    ${CMAKE_CURRENT_BINARY_DIR}/merged.yaml)
   message("Generated files ${gen_command_sources}")
 
   # optimized_native_cpu_ops_lib: Register optimized op kernels into the runtime
   gen_operators_lib(
+    LIB_NAME
     "optimized_native_cpu_ops_lib"
-    KERNEL_LIBS portable_kernels optimized_kernels
-    DEPS executorch)
+    KERNEL_LIBS
+    portable_kernels
+    optimized_kernels
+    DEPS
+    executorch)
 
   install(TARGETS optimized_native_cpu_ops_lib DESTINATION lib)
 endif()

--- a/examples/apple/mps/CMakeLists.txt
+++ b/examples/apple/mps/CMakeLists.txt
@@ -68,12 +68,15 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
 # portable_ops_lib
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
-gen_selected_ops("" "" "ON")
+gen_selected_ops(
+  LIB_NAME "mps_portable_ops_lib"
+  INCLUDE_ALL_OPS "ON")
 generate_bindings_for_kernels(
+  LIB_NAME "mps_portable_ops_lib"
   FUNCTIONS_YAML ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
 )
 gen_operators_lib(
-  "mps_portable_ops_lib"
+  LIB_NAME "mps_portable_ops_lib"
   KERNEL_LIBS portable_kernels
   DEPS executorch)
 

--- a/examples/arm/CMakeLists.txt
+++ b/examples/arm/CMakeLists.txt
@@ -45,9 +45,15 @@ include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
 
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in functions.yaml
-gen_selected_ops("" "${EXECUTORCH_SELECT_OPS_LIST}" "")
+gen_selected_ops(
+  LIB_NAME "arm_portable_ops_lib"
+  OPS_SCHEMA_YAML ""
+  ROOT_OPS "${EXECUTORCH_SELECT_OPS_LIST}"
+  INCLUDE_ALL_OPS "")
 generate_bindings_for_kernels(
+  LIB_NAME "arm_portable_ops_lib"
   FUNCTIONS_YAML ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml)
-gen_operators_lib("arm_portable_ops_lib"
+gen_operators_lib(
+  LIB_NAME "arm_portable_ops_lib"
   KERNEL_LIBS portable_kernels
   DEPS executorch)

--- a/examples/cadence/ops/CMakeLists.txt
+++ b/examples/cadence/ops/CMakeLists.txt
@@ -40,17 +40,17 @@ target_link_libraries(aten_ops_cadence PRIVATE cadence_kernels)
 # Let files say "include <executorch/path/to/header.h>".
 set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 
-target_include_directories(aten_ops_cadence PUBLIC ${ROOT_DIR}/..
-                                                ${CMAKE_BINARY_DIR}
-                                                ${_common_include_directories})
+target_include_directories(
+  aten_ops_cadence PUBLIC ${ROOT_DIR}/.. ${CMAKE_BINARY_DIR}
+                          ${_common_include_directories})
 
 # Custom ops that are needed to run the test model.
 add_library(
-  custom_ops "quantized_linear_out.cpp" "quantized_conv_out.cpp"
-  "quantized_relu_out.cpp" "quantized_layer_norm.cpp"
-  "quantize_per_tensor.cpp" "dequantize_per_tensor.cpp")
-target_include_directories(custom_ops PUBLIC ${ROOT_DIR}/..
-                                             ${CMAKE_BINARY_DIR}
+  custom_ops
+  "quantized_linear_out.cpp" "quantized_conv_out.cpp" "quantized_relu_out.cpp"
+  "quantized_layer_norm.cpp" "quantize_per_tensor.cpp"
+  "dequantize_per_tensor.cpp")
+target_include_directories(custom_ops PUBLIC ${ROOT_DIR}/.. ${CMAKE_BINARY_DIR}
                                              ${_common_include_directories})
 
 target_link_libraries(custom_ops PUBLIC executorch)
@@ -58,12 +58,11 @@ target_link_libraries(custom_ops PRIVATE cadence_kernels)
 
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in functions.yaml
-gen_selected_ops("${CMAKE_CURRENT_LIST_DIR}/functions.yaml" "" "")
-generate_bindings_for_kernels(
-  FUNCTIONS_YAML ${CMAKE_CURRENT_SOURCE_DIR}/functions.yaml)
+gen_selected_ops(LIB_NAME "cadence_ops_lib" OPS_SCHEMA_YAML
+                 "${CMAKE_CURRENT_LIST_DIR}/functions.yaml")
+generate_bindings_for_kernels(LIB_NAME "cadence_ops_lib" FUNCTIONS_YAML
+                              ${CMAKE_CURRENT_SOURCE_DIR}/functions.yaml)
 message("Generated files ${gen_command_sources}")
 
-gen_operators_lib(
-  "cadence_ops_lib"
-  KERNEL_LIBS custom_ops
-  DEPS aten_ops_cadence)
+gen_operators_lib(LIB_NAME "cadence_ops_lib" KERNEL_LIBS custom_ops DEPS
+                  aten_ops_cadence)

--- a/examples/portable/custom_ops/CMakeLists.txt
+++ b/examples/portable/custom_ops/CMakeLists.txt
@@ -73,9 +73,13 @@ include(${EXECUTORCH_SRCS_FILE})
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime).
 if(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 1)
-  gen_selected_ops("custom_ops_lib" "" "my_ops::mul3.out" "")
+  gen_selected_ops(
+    LIB_NAME "custom_ops_lib"
+    ROOT_OPS "my_ops::mul3.out")
 elseif(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
-  gen_selected_ops("custom_ops_lib" "" "my_ops::mul4.out" "")
+  gen_selected_ops(
+    LIB_NAME "custom_ops_lib"
+    ROOT_OPS "my_ops::mul4.out")
 endif()
 # Expect gen_selected_ops output file to be selected_operators.yaml
 generate_bindings_for_kernels(LIB_NAME "custom_ops_lib" CUSTOM_OPS_YAML
@@ -86,11 +90,16 @@ message("Generated files ${gen_command_sources}")
 
 # C++ library to register custom ops into PyTorch.
 if(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
+  gen_selected_ops(
+    LIB_NAME "custom_ops_aot_lib"
+    ROOT_OPS "my_ops::mul4.out")
+  generate_bindings_for_kernels(LIB_NAME "custom_ops_aot_lib" CUSTOM_OPS_YAML
+    ${CMAKE_CURRENT_LIST_DIR}/custom_ops.yaml)
   set(custom_ops_kernel_sources
       ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2.cpp # register my_ops::mul4
       ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2_out.cpp # register my_ops::mul4.out
   )
-  gen_custom_ops_aot_lib("custom_ops_aot_lib" "${custom_ops_kernel_sources}")
+  gen_custom_ops_aot_lib(LIB_NAME "custom_ops_aot_lib" KERNEL_SOURCES "${custom_ops_kernel_sources}")
   target_include_directories(custom_ops_aot_lib
                              PUBLIC ${_common_include_directories})
 endif()

--- a/examples/portable/custom_ops/CMakeLists.txt
+++ b/examples/portable/custom_ops/CMakeLists.txt
@@ -99,7 +99,7 @@ if(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
       ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2.cpp # register my_ops::mul4
       ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2_out.cpp # register my_ops::mul4.out
   )
-  gen_custom_ops_aot_lib(LIB_NAME "custom_ops_aot_lib" KERNEL_SOURCES ${custom_ops_kernel_sources})
+  gen_custom_ops_aot_lib(LIB_NAME "custom_ops_aot_lib" KERNEL_SOURCES "${custom_ops_kernel_sources}")
   target_include_directories(custom_ops_aot_lib
                              PUBLIC ${_common_include_directories})
 endif()

--- a/examples/portable/custom_ops/CMakeLists.txt
+++ b/examples/portable/custom_ops/CMakeLists.txt
@@ -106,7 +106,8 @@ add_library(custom_kernels ${kernel_sources})
 target_link_libraries(custom_kernels PRIVATE executorch)
 target_compile_options(custom_kernels PUBLIC ${_common_compile_options})
 
-gen_operators_lib("custom_ops_lib" KERNEL_LIBS custom_kernels DEPS executorch)
+gen_operators_lib(LIB_NAME "custom_ops_lib" KERNEL_LIBS custom_kernels DEPS
+                  executorch)
 
 list(TRANSFORM _executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
 

--- a/examples/portable/custom_ops/CMakeLists.txt
+++ b/examples/portable/custom_ops/CMakeLists.txt
@@ -73,12 +73,12 @@ include(${EXECUTORCH_SRCS_FILE})
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime).
 if(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 1)
-  gen_selected_ops("" "my_ops::mul3.out" "")
+  gen_selected_ops("custom_ops_lib" "" "my_ops::mul3.out" "")
 elseif(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
-  gen_selected_ops("" "my_ops::mul4.out" "")
+  gen_selected_ops("custom_ops_lib" "" "my_ops::mul4.out" "")
 endif()
 # Expect gen_selected_ops output file to be selected_operators.yaml
-generate_bindings_for_kernels(CUSTOM_OPS_YAML
+generate_bindings_for_kernels(LIB_NAME "custom_ops_lib" CUSTOM_OPS_YAML
                               ${CMAKE_CURRENT_LIST_DIR}/custom_ops.yaml)
 message("Generated files ${gen_command_sources}")
 

--- a/examples/portable/custom_ops/CMakeLists.txt
+++ b/examples/portable/custom_ops/CMakeLists.txt
@@ -99,7 +99,7 @@ if(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
       ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2.cpp # register my_ops::mul4
       ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2_out.cpp # register my_ops::mul4.out
   )
-  gen_custom_ops_aot_lib(LIB_NAME "custom_ops_aot_lib" KERNEL_SOURCES "${custom_ops_kernel_sources}")
+  gen_custom_ops_aot_lib(LIB_NAME "custom_ops_aot_lib" KERNEL_SOURCES ${custom_ops_kernel_sources})
   target_include_directories(custom_ops_aot_lib
                              PUBLIC ${_common_include_directories})
 endif()

--- a/examples/qualcomm/CMakeLists.txt
+++ b/examples/qualcomm/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # qnn_executor_runner: Like executor_runner but with QNN
 if(NOT ${ANDROID})
-    message(FATAL_ERROR "Not building Android, quitting...")
+  message(FATAL_ERROR "Not building Android, quitting...")
 endif()
 cmake_minimum_required(VERSION 3.19)
 project(qualcomm_runner_example)
@@ -31,8 +31,8 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-# Find prebuilt libraries. executorch package should contain
-# portable_ops_lib, etdump, bundled_program.
+# Find prebuilt libraries. executorch package should contain portable_ops_lib,
+# etdump, bundled_program.
 find_package(executorch CONFIG REQUIRED)
 target_compile_options(executorch INTERFACE -DET_EVENT_TRACER_ENABLED)
 find_package(gflags REQUIRED)
@@ -46,66 +46,35 @@ set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 # The `_<target>_srcs` lists are defined by including ${EXECUTORCH_SRCS_FILE}.
 #
 set(EXECUTORCH_SRCS_FILE
-  "${CMAKE_CURRENT_BINARY_DIR}/../../executorch_srcs.cmake"
-)
+    "${CMAKE_CURRENT_BINARY_DIR}/../../executorch_srcs.cmake")
 extract_sources(${EXECUTORCH_SRCS_FILE})
 include(${EXECUTORCH_SRCS_FILE})
 
-get_filename_component(EXECUTORCH_SOURCE_DIR
-    "${CMAKE_CURRENT_LIST_DIR}/../.."
-    ABSOLUTE
-)
+get_filename_component(EXECUTORCH_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.."
+                       ABSOLUTE)
 set(_qnn_executor_runner__srcs ${_executor_runner__srcs})
 
 # portable_ops_lib
-gen_selected_ops("" "" "ON")
+gen_selected_ops(LIB_NAME "full_portable_ops_lib" INCLUDE_ALL_OPS "ON")
 generate_bindings_for_kernels(
-  FUNCTIONS_YAML ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
-)
-gen_operators_lib("full_portable_ops_lib"
-  KERNEL_LIBS portable_kernels
-  DEPS executorch)
+  LIB_NAME "full_portable_ops_lib" FUNCTIONS_YAML
+  ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml)
+gen_operators_lib(LIB_NAME "full_portable_ops_lib" KERNEL_LIBS portable_kernels
+                  DEPS executorch)
 target_compile_options(full_portable_ops_lib
-    INTERFACE
-    -DET_EVENT_TRACER_ENABLED
-)
+                       INTERFACE -DET_EVENT_TRACER_ENABLED)
 target_include_directories(full_portable_ops_lib
-    PUBLIC
-    ${_common_include_directories}
-)
+                           PUBLIC ${_common_include_directories})
 
-list(
-    TRANSFORM
-    _qnn_executor_runner__srcs
-    PREPEND
-    "${EXECUTORCH_SOURCE_DIR}/"
-)
-list(
-    FILTER
-    _qnn_executor_runner__srcs
-    EXCLUDE REGEX
-    ".*executor_runner.cpp$"
-)
-list(
-    PREPEND
-    _qnn_executor_runner__srcs
-    ${CMAKE_CURRENT_LIST_DIR}/executor_runner/qnn_executor_runner.cpp
-)
+list(TRANSFORM _qnn_executor_runner__srcs PREPEND "${EXECUTORCH_SOURCE_DIR}/")
+list(FILTER _qnn_executor_runner__srcs EXCLUDE REGEX ".*executor_runner.cpp$")
+list(PREPEND _qnn_executor_runner__srcs
+     ${CMAKE_CURRENT_LIST_DIR}/executor_runner/qnn_executor_runner.cpp)
 
 add_executable(qnn_executor_runner ${_qnn_executor_runner__srcs})
 
 target_include_directories(qnn_executor_runner
-    PUBLIC
-    ${_common_include_directories}
-)
-target_link_libraries(qnn_executor_runner
-    qnn_executorch_backend
-    full_portable_ops_lib
-    etdump
-    ${FLATCCRT_LIB}
-    gflags
-)
-target_compile_options(qnn_executor_runner
-    PUBLIC
-    ${_common_compile_options}
-)
+                           PUBLIC ${_common_include_directories})
+target_link_libraries(qnn_executor_runner qnn_executorch_backend
+                      full_portable_ops_lib etdump ${FLATCCRT_LIB} gflags)
+target_compile_options(qnn_executor_runner PUBLIC ${_common_compile_options})

--- a/examples/selective_build/CMakeLists.txt
+++ b/examples/selective_build/CMakeLists.txt
@@ -39,9 +39,8 @@ set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 
 find_package(executorch CONFIG REQUIRED)
-find_package(
-  gflags REQUIRED PATHS ${CMAKE_CURRENT_BINARY_DIR}/../../third-party
-)
+find_package(gflags REQUIRED PATHS
+             ${CMAKE_CURRENT_BINARY_DIR}/../../third-party)
 
 target_include_directories(executorch INTERFACE ${_common_include_directories})
 
@@ -63,10 +62,8 @@ option(EXECUTORCH_SELECT_ALL_OPS
 #
 # The `_<target>_srcs` lists are defined by including ${EXECUTORCH_SRCS_FILE}.
 #
-set(
-  EXECUTORCH_SRCS_FILE
-  "${CMAKE_CURRENT_BINARY_DIR}/../../executorch_srcs.cmake"
-)
+set(EXECUTORCH_SRCS_FILE
+    "${CMAKE_CURRENT_BINARY_DIR}/../../executorch_srcs.cmake")
 
 extract_sources(${EXECUTORCH_SRCS_FILE})
 
@@ -96,17 +93,22 @@ else()
 endif()
 
 gen_selected_ops(
+  LIB_NAME
+  "select_build_lib"
+  OPS_SCHEMA_YAML
   "${_custom_ops_yaml}"
+  ROOT_OPS
   "${EXECUTORCH_SELECT_OPS_LIST}"
+  INCLUDE_ALL_OPS
   "${EXECUTORCH_SELECT_ALL_OPS}")
 
 generate_bindings_for_kernels(
-  FUNCTIONS_YAML ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
-  CUSTOM_OPS_YAML "${_custom_ops_yaml}")
-gen_operators_lib(
-  "select_build_lib"
-  KERNEL_LIBS ${_kernel_lib}
-  DEPS executorch)
+  LIB_NAME "select_build_lib" FUNCTIONS_YAML
+  ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml CUSTOM_OPS_YAML
+  "${_custom_ops_yaml}")
+
+gen_operators_lib(LIB_NAME "select_build_lib" KERNEL_LIBS ${_kernel_lib} DEPS
+                  executorch)
 
 list(TRANSFORM _executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
 
@@ -118,9 +120,8 @@ add_executable(selective_build_test ${_executor_runner__srcs})
 if(CMAKE_BUILD_TYPE EQUAL "Release")
   target_link_options(selective_build_test PRIVATE "LINKER:--gc-sections")
 endif()
-target_link_libraries(
-  selective_build_test PRIVATE executorch gflags select_build_lib
-)
+target_link_libraries(selective_build_test PRIVATE executorch gflags
+                                                   select_build_lib)
 target_link_options_shared_lib(select_build_lib)
 target_link_options_shared_lib(executorch)
 target_compile_options(selective_build_test PUBLIC ${_common_compile_options})

--- a/kernels/optimized/CMakeLists.txt
+++ b/kernels/optimized/CMakeLists.txt
@@ -27,16 +27,15 @@ endif()
 
 set(_common_compile_options -Wno-deprecated-declarations)
 
-# Note for apple platform we can rely on Accelerate framework
-# Will come back to this
+# Note for apple platform we can rely on Accelerate framework Will come back to
+# this
 include(${CMAKE_CURRENT_LIST_DIR}/External/EigenBLAS.cmake)
 list(APPEND _common_compile_options -DET_BUILD_WITH_BLAS)
 
-# For us to set CPU_CAPABILITY_AVX2 we need to detect architecture
-# plus processor. The way aten has implemented this is slightly
-# different. We probably need to figure out how to detect compiler
-# flag that suggest we are compiling for avx2
-# for now punting this to come back
+# For us to set CPU_CAPABILITY_AVX2 we need to detect architecture plus
+# processor. The way aten has implemented this is slightly different. We
+# probably need to figure out how to detect compiler flag that suggest we are
+# compiling for avx2 for now punting this to come back
 
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
@@ -53,10 +52,10 @@ target_compile_options(cpublas PUBLIC ${_common_compile_options})
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in optimized.yaml
 set(_yaml "${CMAKE_CURRENT_LIST_DIR}/optimized-oss.yaml")
-gen_selected_ops("${_yaml}" "" "")
+gen_selected_ops(LIB_NAME "optimized_ops_lib" OPS_SCHEMA_YAML "${_yaml}")
 
-generate_bindings_for_kernels(
-  FUNCTIONS_YAML ${CMAKE_CURRENT_SOURCE_DIR}/optimized-oss.yaml)
+generate_bindings_for_kernels(LIB_NAME "optimized_ops_lib" FUNCTIONS_YAML
+                              ${CMAKE_CURRENT_SOURCE_DIR}/optimized-oss.yaml)
 message("Generated files ${gen_command_sources}")
 
 list(TRANSFORM _optimized_kernels__srcs PREPEND "${EXECUTORCH_ROOT}/")
@@ -66,10 +65,8 @@ target_compile_options(optimized_kernels PUBLIC ${_common_compile_options})
 # Build a library for _optimized_kernels_srcs
 #
 # optimized_ops_lib: Register optimized ops kernels into Executorch runtime
-gen_operators_lib(
-  "optimized_ops_lib"
-  KERNEL_LIBS optimized_kernels
-  DEPS executorch)
+gen_operators_lib(LIB_NAME "optimized_ops_lib" KERNEL_LIBS optimized_kernels
+                  DEPS executorch)
 
 install(TARGETS cpublas optimized_kernels optimized_ops_lib DESTINATION lib)
 

--- a/kernels/portable/CMakeLists.txt
+++ b/kernels/portable/CMakeLists.txt
@@ -42,9 +42,12 @@ list(FILTER _portable_kernels__srcs EXCLUDE REGEX "codegen")
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in functions.yaml
 set(_yaml "${CMAKE_CURRENT_LIST_DIR}/functions.yaml")
-gen_selected_ops("${_yaml}" "" "")
+gen_selected_ops(
+  LIB_NAME "portable_ops_lib"
+  OPS_SCHEMA_YAML "${_yaml}")
 # Expect gen_selected_ops output file to be selected_operators.yaml
 generate_bindings_for_kernels(
+  LIB_NAME "portable_ops_lib"
   FUNCTIONS_YAML ${CMAKE_CURRENT_SOURCE_DIR}/functions.yaml)
 message("Generated files ${gen_command_sources}")
 
@@ -62,7 +65,7 @@ target_compile_options(portable_kernels PUBLIC ${_common_compile_options})
 # portable_ops_lib: Register portable_ops_lib ops kernels into Executorch
 # runtime
 gen_operators_lib(
-  "portable_ops_lib"
+  LIB_NAME "portable_ops_lib"
   KERNEL_LIBS portable_kernels
   DEPS executorch)
 

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -66,7 +66,7 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode" AND EXECUTORCH_BUILD_QUANTIZED_OPS_AOT)
       ${_quantized_kernels__srcs}
       ${EXECUTORCH_ROOT}/runtime/core/exec_aten/util/tensor_util_aten.cpp)
   gen_custom_ops_aot_lib(LIB_NAME "quantized_ops_aot_lib" KERNEL_SOURCES
-                         "${_quantized_sources}")
+                         ${_quantized_sources})
 endif()
 
 add_library(quantized_kernels ${_quantized_kernels__srcs})

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -55,11 +55,11 @@ message("Generated files ${gen_command_sources}")
 # dependency of the other(s). This is not allowed by the Xcode "new build
 # system".
 if(NOT CMAKE_GENERATOR STREQUAL "Xcode" AND EXECUTORCH_BUILD_QUANTIZED_OPS_AOT)
-  gen_selected_ops(LIB_NAME "quantized_aot_ops_lib" OPS_SCHEMA_YAML
+  gen_selected_ops(LIB_NAME "quantized_ops_aot_lib" OPS_SCHEMA_YAML
                    "${_yaml_file}")
   # Expect gen_selected_ops output file to be
   # quantized_aot_ops_lib/selected_operators.yaml
-  generate_bindings_for_kernels(LIB_NAME "quantized_aot_ops_lib"
+  generate_bindings_for_kernels(LIB_NAME "quantized_ops_aot_lib"
                                 CUSTOM_OPS_YAML "${_yaml_file}")
   # Build a AOT library to register quantized ops into PyTorch. This is a hack.
   set(_quantized_sources

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -66,7 +66,7 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode" AND EXECUTORCH_BUILD_QUANTIZED_OPS_AOT)
       ${_quantized_kernels__srcs}
       ${EXECUTORCH_ROOT}/runtime/core/exec_aten/util/tensor_util_aten.cpp)
   gen_custom_ops_aot_lib(LIB_NAME "quantized_ops_aot_lib" KERNEL_SOURCES
-                         ${_quantized_sources})
+                         "${_quantized_sources}")
 endif()
 
 add_library(quantized_kernels ${_quantized_kernels__srcs})

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -42,12 +42,11 @@ list(TRANSFORM _quantized_kernels__srcs PREPEND "${EXECUTORCH_ROOT}/")
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in quantized.yaml
 set(_yaml_file ${CMAKE_CURRENT_LIST_DIR}/quantized.yaml)
-gen_selected_ops(
-  LIB_NAME "quantized_ops_lib"
-  OPS_SCHEMA_YAML "${_yaml_file}")
+gen_selected_ops(LIB_NAME "quantized_ops_lib" OPS_SCHEMA_YAML "${_yaml_file}")
 
 # Expect gen_selected_ops output file to be selected_operators.yaml
-generate_bindings_for_kernels(LIB_NAME "quantized_ops_lib" CUSTOM_OPS_YAML "${_yaml_file}")
+generate_bindings_for_kernels(LIB_NAME "quantized_ops_lib" CUSTOM_OPS_YAML
+                              "${_yaml_file}")
 message("Generated files ${gen_command_sources}")
 
 # Not targeting Xcode, because the custom command generating
@@ -56,21 +55,18 @@ message("Generated files ${gen_command_sources}")
 # dependency of the other(s). This is not allowed by the Xcode "new build
 # system".
 if(NOT CMAKE_GENERATOR STREQUAL "Xcode" AND EXECUTORCH_BUILD_QUANTIZED_OPS_AOT)
-  gen_selected_ops(
-    LIB_NAME "quantized_aot_ops_lib"
-    OPS_SCHEMA_YAML "${_yaml_file}")
+  gen_selected_ops(LIB_NAME "quantized_aot_ops_lib" OPS_SCHEMA_YAML
+                   "${_yaml_file}")
   # Expect gen_selected_ops output file to be
   # quantized_aot_ops_lib/selected_operators.yaml
-  generate_bindings_for_kernels(
-    LIB_NAME "quantized_aot_ops_lib"
-    CUSTOM_OPS_YAML "${_yaml_file}")
+  generate_bindings_for_kernels(LIB_NAME "quantized_aot_ops_lib"
+                                CUSTOM_OPS_YAML "${_yaml_file}")
   # Build a AOT library to register quantized ops into PyTorch. This is a hack.
   set(_quantized_sources
       ${_quantized_kernels__srcs}
       ${EXECUTORCH_ROOT}/runtime/core/exec_aten/util/tensor_util_aten.cpp)
-  gen_custom_ops_aot_lib(
-    LIB_NAME "quantized_ops_aot_lib"
-    KERNEL_SOURCES "${_quantized_sources}")
+  gen_custom_ops_aot_lib(LIB_NAME "quantized_ops_aot_lib" KERNEL_SOURCES
+                         "${_quantized_sources}")
 endif()
 
 add_library(quantized_kernels ${_quantized_kernels__srcs})
@@ -79,9 +75,7 @@ target_compile_options(quantized_kernels PUBLIC ${_common_compile_options})
 # Build a library for _quantized_kernels_srcs
 #
 # quantized_ops_lib: Register quantized ops kernels into Executorch runtime
-gen_operators_lib(
-  LIB_NAME "quantized_ops_lib"
-  KERNEL_LIBS quantized_kernels
-  DEPS executorch)
+gen_operators_lib(LIB_NAME "quantized_ops_lib" KERNEL_LIBS quantized_kernels
+                  DEPS executorch)
 
 install(TARGETS quantized_kernels quantized_ops_lib DESTINATION lib)

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -41,9 +41,12 @@ endif()
 list(TRANSFORM _quantized_kernels__srcs PREPEND "${EXECUTORCH_ROOT}/")
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in quantized.yaml
-gen_selected_ops("${CMAKE_CURRENT_LIST_DIR}/quantized.yaml" "" "")
+gen_selected_ops(
+  LIB_NAME "quantized_ops_lib"
+  OPS_SCHEMA_YAML "${CMAKE_CURRENT_LIST_DIR}/quantized.yaml")
+
 # Expect gen_selected_ops output file to be selected_operators.yaml
-generate_bindings_for_kernels(CUSTOM_OPS_YAML
+generate_bindings_for_kernels(LIB_NAME "quantized_ops_lib" CUSTOM_OPS_YAML
                               ${CMAKE_CURRENT_SOURCE_DIR}/quantized.yaml)
 message("Generated files ${gen_command_sources}")
 
@@ -53,11 +56,21 @@ message("Generated files ${gen_command_sources}")
 # dependency of the other(s). This is not allowed by the Xcode "new build
 # system".
 if(NOT CMAKE_GENERATOR STREQUAL "Xcode" AND EXECUTORCH_BUILD_QUANTIZED_OPS_AOT)
+  gen_selected_ops(
+    LIB_NAME "quantized_aot_ops_lib"
+    OPS_SCHEMA_YAML ${CMAKE_CURRENT_SOURCE_DIR}/quantized.yaml)
+  # Expect gen_selected_ops output file to be
+  # quantized_aot_ops_lib/selected_operators.yaml
+  generate_bindings_for_kernels(
+    LIB_NAME "quantized_aot_ops_lib"
+    CUSTOM_OPS_YAML ${CMAKE_CURRENT_SOURCE_DIR}/quantized.yaml)
   # Build a AOT library to register quantized ops into PyTorch. This is a hack.
   set(_quantized_sources
       ${_quantized_kernels__srcs}
       ${EXECUTORCH_ROOT}/runtime/core/exec_aten/util/tensor_util_aten.cpp)
-  gen_custom_ops_aot_lib("quantized_ops_aot_lib" "${_quantized_sources}")
+  gen_custom_ops_aot_lib(
+    LIB_NAME "quantized_ops_aot_lib"
+    KERNEL_SOURCES "${_quantized_sources}")
 endif()
 
 add_library(quantized_kernels ${_quantized_kernels__srcs})
@@ -66,7 +79,9 @@ target_compile_options(quantized_kernels PUBLIC ${_common_compile_options})
 # Build a library for _quantized_kernels_srcs
 #
 # quantized_ops_lib: Register quantized ops kernels into Executorch runtime
-gen_operators_lib("quantized_ops_lib" KERNEL_LIBS quantized_kernels DEPS
-                  executorch)
+gen_operators_lib(
+  LIB_NAME "quantized_ops_lib"
+  KERNEL_LIBS quantized_kernels
+  DEPS executorch)
 
 install(TARGETS quantized_kernels quantized_ops_lib DESTINATION lib)

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -41,13 +41,13 @@ endif()
 list(TRANSFORM _quantized_kernels__srcs PREPEND "${EXECUTORCH_ROOT}/")
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in quantized.yaml
+set(_yaml_file ${CMAKE_CURRENT_LIST_DIR}/quantized.yaml)
 gen_selected_ops(
   LIB_NAME "quantized_ops_lib"
-  OPS_SCHEMA_YAML "${CMAKE_CURRENT_LIST_DIR}/quantized.yaml")
+  OPS_SCHEMA_YAML "${_yaml_file}")
 
 # Expect gen_selected_ops output file to be selected_operators.yaml
-generate_bindings_for_kernels(LIB_NAME "quantized_ops_lib" CUSTOM_OPS_YAML
-                              ${CMAKE_CURRENT_SOURCE_DIR}/quantized.yaml)
+generate_bindings_for_kernels(LIB_NAME "quantized_ops_lib" CUSTOM_OPS_YAML "${_yaml_file}")
 message("Generated files ${gen_command_sources}")
 
 # Not targeting Xcode, because the custom command generating
@@ -58,12 +58,12 @@ message("Generated files ${gen_command_sources}")
 if(NOT CMAKE_GENERATOR STREQUAL "Xcode" AND EXECUTORCH_BUILD_QUANTIZED_OPS_AOT)
   gen_selected_ops(
     LIB_NAME "quantized_aot_ops_lib"
-    OPS_SCHEMA_YAML ${CMAKE_CURRENT_SOURCE_DIR}/quantized.yaml)
+    OPS_SCHEMA_YAML "${_yaml_file}")
   # Expect gen_selected_ops output file to be
   # quantized_aot_ops_lib/selected_operators.yaml
   generate_bindings_for_kernels(
     LIB_NAME "quantized_aot_ops_lib"
-    CUSTOM_OPS_YAML ${CMAKE_CURRENT_SOURCE_DIR}/quantized.yaml)
+    CUSTOM_OPS_YAML "${_yaml_file}")
   # Build a AOT library to register quantized ops into PyTorch. This is a hack.
   set(_quantized_sources
       ${_quantized_kernels__srcs}

--- a/kernels/quantized/targets.bzl
+++ b/kernels/quantized/targets.bzl
@@ -22,7 +22,7 @@ def define_common_targets():
             "quantized_decomposed::mixed_linear.out",
             "quantized_decomposed::mixed_mm.out",
             "quantized_decomposed::quantize_per_channel.out",
-            "quantized_decomposed::quantize_per_tensor.out",
+            "quantized_decomposed::qupantize_per_tensor.out",
             "quantized_decomposed::quantize_per_tensor.Tensor_out",
         ],
         define_static_targets = True,

--- a/kernels/quantized/targets.bzl
+++ b/kernels/quantized/targets.bzl
@@ -22,7 +22,7 @@ def define_common_targets():
             "quantized_decomposed::mixed_linear.out",
             "quantized_decomposed::mixed_mm.out",
             "quantized_decomposed::quantize_per_channel.out",
-            "quantized_decomposed::qupantize_per_tensor.out",
+            "quantized_decomposed::quantize_per_tensor.out",
             "quantized_decomposed::quantize_per_tensor.Tensor_out",
         ],
         define_static_targets = True,


### PR DESCRIPTION
Summary:

This is putting generated C++ code under a directory of library name.

This allows 2 sets of generated code in one CMakeLists.txt.

We also add argument names for all 4 codegen functions, so it's easier to read.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: