### PR TITLE
[ET-VK] Nit staging glsl `mix` optimization

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_prepack_weights.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_prepack_weights.glsl
@@ -72,21 +72,14 @@ void main() {
   // Map modified tensor_idx to modifed buffer_i
   // Zero out if modified tensor idx is out of bounds
   const ivec4 buf_i = n * C*H*W + h * W + w;
-  const bvec4 mask = bvec4(lessThan(n, ivec4(N)));
+  const bvec4 mask = lessThan(n, ivec4(N));
 
-  VEC4_T texel = VEC4_T(0);
-  if (mask.x) {
-    texel.x = SCALAR_T(buffer_in[buf_i.x]);
-  }
-  if (mask.y) {
-    texel.y = SCALAR_T(buffer_in[buf_i.y]);
-  }
-  if (mask.z) {
-    texel.z = SCALAR_T(buffer_in[buf_i.z]);
-  }
-  if (mask.w) {
-    texel.w = SCALAR_T(buffer_in[buf_i.w]);
-  }
+  VEC4_T texel = VEC4_T(
+    mix(0, SCALAR_T(buffer_in[buf_i.x]), mask.x),
+    mix(0, SCALAR_T(buffer_in[buf_i.y]), mask.y),
+    mix(0, SCALAR_T(buffer_in[buf_i.z]), mask.z),
+    mix(0, SCALAR_T(buffer_in[buf_i.w]), mask.w)
+  );
 
   imageStore(image_out, pos.xy, texel);
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_prepack_weights.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_prepack_weights.glsl
@@ -76,21 +76,14 @@ void main() {
   // Map modified tensor_idx to modified buffer_i
   // Zero out if modified tensor idx is out of bounds
   const ivec4 buf_i = n * C*H*W + c * H*W + h * W + w;
-  const bvec4 mask = bvec4(ivec4(lessThan(n, ivec4(N))) & ivec4(lessThan(c, ivec4(C))));
+  const ivec4 mask = ivec4(lessThan(n, ivec4(N))) & ivec4(lessThan(c, ivec4(C)));
 
-  VEC4_T texel = VEC4_T(0);
-  if (mask.x) {
-    texel.x = SCALAR_T(buffer_in[buf_i.x]);
-  }
-  if (mask.y) {
-    texel.y = SCALAR_T(buffer_in[buf_i.y]);
-  }
-  if (mask.z) {
-    texel.z = SCALAR_T(buffer_in[buf_i.z]);
-  }
-  if (mask.w) {
-    texel.w = SCALAR_T(buffer_in[buf_i.w]);
-  }
+  VEC4_T texel = VEC4_T(
+    mix(0, SCALAR_T(buffer_in[buf_i.x]), mask.x),
+    mix(0, SCALAR_T(buffer_in[buf_i.y]), mask.y),
+    mix(0, SCALAR_T(buffer_in[buf_i.z]), mask.z),
+    mix(0, SCALAR_T(buffer_in[buf_i.w]), mask.w)
+  );
 
   imageStore(image_out, pos.xy, texel);
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/conv_transpose2d_prepack_weights.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv_transpose2d_prepack_weights.glsl
@@ -75,21 +75,14 @@ void main() {
   // Map modified tensor_idx to modifed buffer_i
   // Zero out if modified tensor idx is out of bounds
   const ivec4 buf_i = n * C*H*W + c * H*W + h * W + w;
-  const bvec4 mask = bvec4(ivec4(lessThan(n, ivec4(N))) & ivec4(lessThan(c, ivec4(C))));
+  const ivec4 mask = ivec4(lessThan(n, ivec4(N))) & ivec4(lessThan(c, ivec4(C)));
 
-  VEC4_T texel = VEC4_T(0);
-  if (mask.x) {
-    texel.x = SCALAR_T(buffer_in[buf_i.x]);
-  }
-  if (mask.y) {
-    texel.y = SCALAR_T(buffer_in[buf_i.y]);
-  }
-  if (mask.z) {
-    texel.z = SCALAR_T(buffer_in[buf_i.z]);
-  }
-  if (mask.w) {
-    texel.w = SCALAR_T(buffer_in[buf_i.w]);
-  }
+  VEC4_T texel = VEC4_T(
+    mix(0, SCALAR_T(buffer_in[buf_i.x]), mask.x),
+    mix(0, SCALAR_T(buffer_in[buf_i.y]), mask.y),
+    mix(0, SCALAR_T(buffer_in[buf_i.z]), mask.z),
+    mix(0, SCALAR_T(buffer_in[buf_i.w]), mask.w)
+  );
 
   imageStore(image_out, pos.xy, texel);
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/nchw_to_image.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/nchw_to_image.glsl
@@ -42,24 +42,17 @@ void main() {
     return;
   }
 
-  const ivec4 buf_indices = get_texel_nchw_buffer_ixs(idx, sizes, packed_dim);
+  const ivec4 buf_i = get_texel_nchw_buffer_ixs(idx, sizes, packed_dim);
 
   const int packed_dim_size = sizes[packed_dim];
   int packed_idx = idx[packed_dim];
 
-  VEC4_T texel = VEC4_T(0);
-  if (packed_idx < packed_dim_size) {
-    texel.x = SCALAR_T(buffer_in[buf_indices.x]);
-  }
-  if (packed_idx + 1 < packed_dim_size) {
-    texel.y = SCALAR_T(buffer_in[buf_indices.y]);
-  }
-  if (packed_idx + 2 < packed_dim_size) {
-    texel.z = SCALAR_T(buffer_in[buf_indices.z]);
-  }
-  if (packed_idx + 3 < packed_dim_size) {
-    texel.w = SCALAR_T(buffer_in[buf_indices.w]);
-  }
+  VEC4_T texel = VEC4_T(
+    mix(0, SCALAR_T(buffer_in[buf_i.x]), packed_idx < packed_dim_size),
+    mix(0, SCALAR_T(buffer_in[buf_i.y]), packed_idx + 1 < packed_dim_size),
+    mix(0, SCALAR_T(buffer_in[buf_i.z]), packed_idx + 2 < packed_dim_size),
+    mix(0, SCALAR_T(buffer_in[buf_i.w]), packed_idx + 3 < packed_dim_size)
+  );
 
   imageStore(image_out, ${get_pos[NDIM]("pos")}, texel);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3384
* #3368

In the previous change, @yipjustin recommended this neat optimization. I iterate it on it by using the [`mix`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/mix.xhtml) glsl function.

In the future, if you ever have a case where you may write to a texel, depending on a condition:
```
 VEC4_T texel = VEC4_T(0);
 if (cond_x) {
   texel.x = SCALAR_T(buffer_in[buf_i.x]);
 }
 if (cond_y) {
   texel.y = SCALAR_T(buffer_in[buf_i.y]);
 }
 if (cond_z) {
   texel.z = SCALAR_T(buffer_in[buf_i.z]);
 }
 if (cond_w) {
   texel.w = SCALAR_T(buffer_in[buf_i.w]);
 }
```

do the following instead. The way it works is that if
- arg-3 is true, arg-2 is written
- arg-3 is false, arg-1 is written.
```
 VEC4_T texel = VEC4_T(
   mix(0, SCALAR_T(buffer_in[buf_i.x]), cond_x),
   mix(0, SCALAR_T(buffer_in[buf_i.y]), cond_y),
   mix(0, SCALAR_T(buffer_in[buf_i.z]), cond_z),
   mix(0, SCALAR_T(buffer_in[buf_i.w]), cond_w)
 );

Differential Revision: [D56657451](https://our.internmc.facebook.com/intern/diff/D56657451/)