### PR TITLE
Fix the broken cmake commands in sdk integration tutorial

### DIFF
--- a/docs/source/tutorials_source/sdk-integration-tutorial.py
+++ b/docs/source/tutorials_source/sdk-integration-tutorial.py
@@ -172,10 +172,23 @@ with open(save_path, "wb") as f:
 # Use CMake (follow `these instructions <../runtime-build-and-cross-compilation.html#configure-the-cmake-build>`__ to set up cmake) to execute the Bundled Program to generate the ``ETDump``::
 #
 #       cd executorch
-#       rm -rf cmake-out && mkdir cmake-out && cd cmake-out && cmake -DEXECUTORCH_BUILD_SDK=1 -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=1 ..
-#       cd ..
-#       cmake --build cmake-out -j8 -t sdk_example_runner
-#       ./cmake-out/examples/sdk/sdk_example_runner --bundled_program_path <bundled_program>
+#       rm -rf cmake-out
+#       cmake -DCMAKE_INSTALL_PREFIX=cmake-out \
+#           -DCMAKE_BUILD_TYPE=Release \
+#           -DEXECUTORCH_BUILD_SDK=ON \
+#           -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \-Bcmake-out .
+#       cmake --build cmake-out -j9 --target install --config Release
+#
+#       local example_dir=examples/sdk
+#       local build_dir=cmake-out/${example_dir}
+#       CMAKE_PREFIX_PATH="${PWD}/cmake-out/lib/cmake/ExecuTorch;${PWD}/cmake-out/third-party/gflags"
+#       rm -rf ${build_dir}
+#       cmake -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
+#           -DCMAKE_BUILD_TYPE=Release \
+#           -B${build_dir} \
+#           ${example_dir}
+#       cmake --build ${build_dir} -j9 --config Release
+#       ${build_dir}/sdk_example_runner --bundled_program_path="bundled_program.bp"
 
 ######################################################################
 # Creating an Inspector

--- a/docs/source/tutorials_source/sdk-integration-tutorial.py
+++ b/docs/source/tutorials_source/sdk-integration-tutorial.py
@@ -176,7 +176,8 @@ with open(save_path, "wb") as f:
 #       cmake -DCMAKE_INSTALL_PREFIX=cmake-out \
 #           -DCMAKE_BUILD_TYPE=Release \
 #           -DEXECUTORCH_BUILD_SDK=ON \
-#           -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \-Bcmake-out .
+#           -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \
+#           -Bcmake-out .
 #       cmake --build cmake-out -j9 --target install --config Release
 #
 #       local example_dir=examples/sdk


### PR DESCRIPTION
## Summary
The added cmake commands are copied from a .sh recently updated in https://github.com/pytorch/executorch/pull/3298. The removed commands in this tutorial.py are old and don't work. 

*I also realized that https://github.com/pytorch/executorch/pull/3298 was never cherry-picked to 0.2. Whatever we will do to this PR (whether it ends up in 0.2.0, 0.2.1 or something other branch), let's the do same for that one too.*

## Test Plan
I followed the tutorial through and it worked.