### PR TITLE
rename the print delegate graph api

### DIFF
--- a/docs/source/debug-backend-delegate.md
+++ b/docs/source/debug-backend-delegate.md
@@ -39,12 +39,12 @@ Number  of  non-delegated  nodes:  430
 From the table, the operator `aten_view_copy_default` appears 170 times in delegate graphs and 48 times in non-delegated graphs. Users can use information like this to debug.
 
 ## Visualize delegated graph
-To see a more detailed view, use the `print_delegated_graph()` method to display a printout of the whole graph:
+To see a more detailed view, use the `format_delegated_graph()` method to get a str of printout of the whole graph or use `print_delegated_graph()` to print directly:
 
 ```python
-from executorch.exir.backend.utils import print_delegated_graph
+from executorch.exir.backend.utils import format_delegated_graph
 graph_module = edge_manager.exported_program().graph_module
-print(print_delegated_graph(graph_module))
+print(format_delegated_graph(graph_module)) # or call print_delegated_graph(graph_module)
 ```
 It will print the whole model as well as the subgraph consumed by the backend. The generic debug function provided by fx like `print_tabular()` or `print_readable()` will only show `call_delegate` but hide the the subgraph consumes by the backend, while this function exposes the contents inside the subgraph.
 

--- a/docs/source/llm/getting-started.md
+++ b/docs/source/llm/getting-started.md
@@ -721,12 +721,12 @@ Number  of  non-delegated  nodes:  430
 |  26  |  Total  |  473  |  430  |
 
 From the table, the operator `aten_view_copy_default` appears 170 times in delegate graphs and 48 times in non-delegated graphs.
-To see a more detailed view, use the `print_delegated_graph()` method to display a printout of the whole graph.
+To see a more detailed view, use the `format_delegated_graph()` method to get a formatted str of printout of the whole graph or use `print_delegated_graph()` to print directly:
 
 ```python
-from executorch.exir.backend.utils import print_delegated_graph
+from executorch.exir.backend.utils import format_delegated_graph
 graph_module = edge_manager.exported_program().graph_module
-print(print_delegated_graph(graph_module))
+print(format_delegated_graph(graph_module))
 ```
 This may generate a large amount of output for large models. Consider using "Control+F" or "Command+F" to locate the operator you’re interested in
 (e.g. “aten_view_copy_default”). Observe which instances are not under lowered graphs.

--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -21,7 +21,7 @@ from executorch.backends.transforms.duplicate_dynamic_quant_chain import (
 from executorch.exir import EdgeProgramManager
 from executorch.exir.backend.partitioner import Partitioner
 
-from executorch.exir.backend.utils import print_delegated_graph
+from executorch.exir.backend.utils import format_delegated_graph
 from executorch.exir.capture._config import EdgeCompileConfig, ExecutorchBackendConfig
 
 from executorch.exir.passes import MemoryPlanningPass
@@ -308,7 +308,7 @@ class LlamaEdgeManager:
                     self.edge_manager = self.edge_manager.to_backend(partitioner)
                     if self.verbose:
                         logging.info(
-                            print_delegated_graph(
+                            format_delegated_graph(
                                 self.edge_manager.exported_program().graph_module
                             )
                         )

--- a/exir/backend/test/test_utils.py
+++ b/exir/backend/test/test_utils.py
@@ -16,11 +16,11 @@ from executorch.exir.backend.partitioner import Partitioner, PartitionResult
 from executorch.exir.backend.test.op_partitioner_demo import AddMulPartitionerDemo
 from executorch.exir.backend.utils import (
     DelegationBreakdown,
+    format_delegated_graph,
     get_delegates,
     get_delegation_info,
     get_non_lowered_nodes,
     is_identical_graph,
-    print_delegated_graph,
 )
 
 from executorch.exir.dialects._ops import bind_pattern_to_op, ops as exir_ops
@@ -266,7 +266,7 @@ class TestUtils(unittest.TestCase):
 
         edge = to_edge(export(m, inputs)).to_backend(AddMulPartitionerDemo())
 
-        graph_str = print_delegated_graph(edge.exported_program().graph_module)
+        graph_str = format_delegated_graph(edge.exported_program().graph_module)
         self.assertIn(
             "BackendWithCompilerDemo",
             graph_str,

--- a/exir/backend/utils.py
+++ b/exir/backend/utils.py
@@ -448,9 +448,16 @@ def get_delegation_info(
     )
 
 
-def print_delegated_graph(graph_module: torch.fx.GraphModule) -> str:
+def print_delegated_graph(graph_module: torch.fx.GraphModule) -> None:
     """
-    Print the graph of including lowered_module (both backend id and original graph) together with the graph module. Example output:
+    Print the formatted graph string.
+    """
+    print(format_delegated_graph(graph_module))
+
+
+def format_delegated_graph(graph_module: torch.fx.GraphModule) -> str:
+    """
+    Return the formatted graph string of including lowered_module (both backend id and original graph) together with the graph module. Example output:
     graph():
         %arg0_1 : [num_users=2] = placeholder[target=arg0_1]
         %arg1_1 : [num_users=2] = placeholder[target=arg1_1]


### PR DESCRIPTION
Summary: The current api name is a bit weird and user will need to call `print(print_delegated_graph(graph_module)))`. Add an api `format_delegated_graph` which is the same as the original `print_delegated_graph`. For the original `print_delegated_graph` api, it just print the string returned from `format_delegated_graph`

Reviewed By: lucylq

Differential Revision: D56711090
