### PR TITLE
apply verbose flag from args

### DIFF
--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -283,7 +283,7 @@ class LlamaEdgeManager:
                 dynamic_shapes=dynamic_shape,
                 edge_constant_methods=metadata,
                 edge_compile_config=edge_config,
-                verbose=True,
+                verbose=self.verbose,
             )
         return self
 


### PR DESCRIPTION
Summary: Just so we have more control on the what will be printed. Right now the graph will always be printed, even for large graph

Reviewed By: lucylq

Differential Revision: D56712539
