### PR TITLE
`bmm` and `baddbmm`

### DIFF
--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -44,6 +44,7 @@ class VulkanSupportedOperators(OperatorSupportBase):
             exir_ops.edge.aten.tanh.default,
             # Matrix multiplication operators
             exir_ops.edge.aten.mm.default,
+            exir_ops.edge.aten.bmm.default,
             # Pooling operators
             exir_ops.edge.aten.max_pool2d_with_indices.default,
             # Sum

--- a/backends/vulkan/runtime/api/Utils.h
+++ b/backends/vulkan/runtime/api/Utils.h
@@ -417,6 +417,23 @@ inline int64_t multiply_integers(const C& container) {
       std::multiplies<>());
 }
 
+/*
+ * Product of integer elements referred to by iterators; accumulates into the
+ * int64_t datatype. Taken from `multiply_integers` in <c10/util/accumulate.h>
+ */
+template <
+    typename Iter,
+    std::enable_if_t<
+        std::is_integral_v<typename std::iterator_traits<Iter>::value_type>,
+        int> = 0>
+inline int64_t multiply_integers(Iter begin, Iter end) {
+  // std::accumulate infers return type from `init` type, so if the `init` type
+  // is not large enough to hold the result, computation can overflow. We use
+  // `int64_t` here to avoid this.
+  return std::accumulate(
+      begin, end, static_cast<int64_t>(1), std::multiplies<>());
+}
+
 } // namespace utils
 
 inline bool operator==(const utils::uvec3& _1, const utils::uvec3& _2) {

--- a/backends/vulkan/runtime/graph/ops/glsl/convert_channels_to_height_packed.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/convert_channels_to_height_packed.glsl
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+
+#define PRECISION ${PRECISION}
+
+#include "indexing_utils.h"
+
+$if DTYPE == "half":
+  #extension GL_EXT_shader_16bit_storage : require
+
+layout(std430) buffer;
+
+layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly image3D image_out;
+layout(set = 0, binding = 1) uniform PRECISION ${SAMPLER_T[NDIM][DTYPE]} image_in;
+
+layout(set = 0, binding = 2) uniform PRECISION restrict Sizes {
+  ivec4 sizes;
+};
+
+layout(set = 0, binding = 3) uniform PRECISION restrict OutLimits {
+  ivec3 out_limits;
+};
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (any(greaterThanEqual(pos, out_limits))) {
+    return;
+  }
+
+  int src_w = pos.x;
+  int src_base_h = pos.y * 4;
+
+  int num_c = sizes.y;
+
+  int src_c = pos.z % num_c;
+  int src_n = pos.z / num_c;
+
+  // Fetch the 4 elements from the channel-packed tensor
+  ivec4 src_pos0 = get_channel_packed_pos_from_index(
+    ivec4(src_n, src_c, src_base_h, src_w),
+    sizes);
+
+  ivec4 src_pos1 = get_channel_packed_pos_from_index(
+    ivec4(src_n, src_c, src_base_h + 1, src_w),
+    sizes);
+
+  ivec4 src_pos2 = get_channel_packed_pos_from_index(
+    ivec4(src_n, src_c, src_base_h + 2, src_w),
+    sizes);
+
+  ivec4 src_pos3 = get_channel_packed_pos_from_index(
+    ivec4(src_n, src_c, src_base_h + 3, src_w),
+    sizes);
+
+  vec4 t0 = texelFetch(image_in, src_pos0.xyz, 0);
+  vec4 t1 = texelFetch(image_in, src_pos1.xyz, 0);
+  vec4 t2 = texelFetch(image_in, src_pos2.xyz, 0);
+  vec4 t3 = texelFetch(image_in, src_pos3.xyz, 0);
+
+  vec4 out_t = vec4(
+    t0[src_pos0.w],
+    t1[src_pos1.w],
+    t2[src_pos2.w],
+    t3[src_pos3.w]);
+
+  imageStore(image_out, pos, out_t);
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/convert_channels_to_height_packed.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/convert_channels_to_height_packed.yaml
@@ -4,14 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-matmul:
+convert_channels_to_height_packed:
   parameter_names_with_default_values:
     DTYPE: float
     NDIM: 3
-    PACKING: C_packed
   generate_variant_forall:
     DTYPE:
-      - VALUE: float
       - VALUE: half
+      - VALUE: float
   shader_variants:
-    - NAME: matmul
+    - NAME: convert_channels_to_height_packed

--- a/backends/vulkan/runtime/graph/ops/glsl/convert_channels_to_width_packed.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/convert_channels_to_width_packed.glsl
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+
+#define PRECISION ${PRECISION}
+
+#include "indexing_utils.h"
+
+$if DTYPE == "half":
+  #extension GL_EXT_shader_16bit_storage : require
+
+layout(std430) buffer;
+
+layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly image3D image_out;
+layout(set = 0, binding = 1) uniform PRECISION ${SAMPLER_T[NDIM][DTYPE]} image_in;
+
+layout(set = 0, binding = 2) uniform PRECISION restrict Sizes {
+  ivec4 sizes;
+};
+
+layout(set = 0, binding = 3) uniform PRECISION restrict OutLimits {
+  ivec3 out_limits;
+};
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (any(greaterThanEqual(pos, out_limits))) {
+    return;
+  }
+
+  int src_base_w = pos.x * 4;
+  int src_h = pos.y;
+
+  int num_c = sizes.y;
+
+  int src_c = pos.z % num_c;
+  int src_n = pos.z / num_c;
+
+  // Fetch the 4 elements from the channel-packed tensor
+  ivec4 src_pos0 = get_channel_packed_pos_from_index(
+    ivec4(src_n, src_c, src_h, src_base_w),
+    sizes);
+
+  ivec4 src_pos1 = get_channel_packed_pos_from_index(
+    ivec4(src_n, src_c, src_h, src_base_w + 1),
+    sizes);
+
+  ivec4 src_pos2 = get_channel_packed_pos_from_index(
+    ivec4(src_n, src_c, src_h, src_base_w + 2),
+    sizes);
+
+  ivec4 src_pos3 = get_channel_packed_pos_from_index(
+    ivec4(src_n, src_c, src_h, src_base_w + 3),
+    sizes);
+
+  vec4 t0 = texelFetch(image_in, src_pos0.xyz, 0);
+  vec4 t1 = texelFetch(image_in, src_pos1.xyz, 0);
+  vec4 t2 = texelFetch(image_in, src_pos2.xyz, 0);
+  vec4 t3 = texelFetch(image_in, src_pos3.xyz, 0);
+
+  vec4 out_t = vec4(
+    t0[src_pos0.w],
+    t1[src_pos1.w],
+    t2[src_pos2.w],
+    t3[src_pos3.w]);
+
+  imageStore(image_out, pos, out_t);
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/convert_channels_to_width_packed.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/convert_channels_to_width_packed.yaml
@@ -4,14 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-matmul:
+convert_channels_to_width_packed:
   parameter_names_with_default_values:
     DTYPE: float
     NDIM: 3
-    PACKING: C_packed
   generate_variant_forall:
     DTYPE:
-      - VALUE: float
       - VALUE: half
+      - VALUE: float
   shader_variants:
-    - NAME: matmul
+    - NAME: convert_channels_to_width_packed

--- a/backends/vulkan/runtime/graph/ops/glsl/indexing_utils.h
+++ b/backends/vulkan/runtime/graph/ops/glsl/indexing_utils.h
@@ -154,3 +154,36 @@ ivec4 to_texture_elem_pos(ivec4 idx, ivec4 sizes, int packed_dim) {
   pos.w = idx[packed_dim] % 4;
   return pos;
 }
+
+//
+// Miscellaneous Utility Functions and Macros
+//
+
+// Given a buffer(1-D) index cur, compute a new index where the corresponding
+// tensor(N-D)'s adjacent dimensions are swapped. The parameters x,y and plane
+// describe sizes. As an example, let's say we want to swap dimensions 0,1 for a
+// tensor of shape {4,3,2,24} to obtain {3,4,2,24}. Then, x=4, y=3 and
+// plane=2*24=48.
+#define swap_adj_dims(cur, x, y, plane)                        \
+  cur +                                                        \
+      plane *                                                  \
+          ((1 - y) * ((cur % (x * y * plane)) / (y * plane)) + \
+           (x - 1) * ((cur % (y * plane)) / plane))
+
+// Return the x, y, z and index value the channel-packed 3D tensor from the {n,
+// c, h, w}-index.
+ivec4 get_channel_packed_pos_from_index(ivec4 nchw, ivec4 sizes) {
+  int n = nchw.x;
+  int c = nchw.y;
+  int h = nchw.z;
+  int w = nchw.w;
+
+  int aligned_c = alignup4(sizes.y);
+  int c_stride = aligned_c / 4;
+
+  return ivec4(
+      w, // x
+      h, // y
+      n * c_stride + c / 4, // z
+      c % 4);
+}

--- a/backends/vulkan/runtime/graph/ops/impl/Packing.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Packing.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/Utils.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Packing.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+namespace vkcompute {
+
+ValueRef channel_image_repacking(
+    ComputeGraph& graph,
+    ValueRef in,
+    api::GPUMemoryLayout target_layout,
+    std::string kernel_name) {
+  const auto sizes = graph.get_sizes_of(in);
+
+  ValueRef out = graph.add_tensor(
+      sizes, graph.get_dtype_of(in), api::kTexture3D, target_layout);
+  vTensorPtr t = graph.get_tensor(out);
+
+  api::utils::uvec3 global_size = t->extents();
+  api::utils::uvec3 local_size = adaptive_work_group_size(global_size);
+
+  add_dtype_suffix(kernel_name, *t);
+
+  graph.execute_nodes().emplace_back(new ExecuteNode(
+      graph,
+      VK_KERNEL_FROM_STR(kernel_name),
+      global_size,
+      local_size,
+      // Inputs and Outputs
+      {{out, api::MemoryAccessType::WRITE}, {in, api::MemoryAccessType::READ}},
+      // Shader params buffers
+      {
+          // The shader assumes a 4d nchw to calculate the lookup coordinate.
+          // If the input is not 4d, we need to pad it with 1's on the front.
+          graph.create_params_buffer(
+              api::utils::make_ivec4_prepadded1(graph.get_sizes_of(in))),
+          t->texture_limits_ubo(),
+      },
+      // Specialization constants
+      {}));
+
+  return out;
+}
+
+ValueRef convert_image_channels_packed_to_width_packed(
+    ComputeGraph& graph,
+    ValueRef in) {
+  std::string kernel_name("convert_channels_to_width_packed");
+  kernel_name.reserve(kShaderNameReserve);
+  return channel_image_repacking(graph, in, api::kWidthPacked, kernel_name);
+}
+
+ValueRef convert_image_channels_packed_to_height_packed(
+    ComputeGraph& graph,
+    ValueRef in) {
+  std::string kernel_name("convert_channels_to_height_packed");
+  kernel_name.reserve(kShaderNameReserve);
+  return channel_image_repacking(graph, in, api::kHeightPacked, kernel_name);
+}
+
+} // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/impl/Packing.h
+++ b/backends/vulkan/runtime/graph/ops/impl/Packing.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/backends/vulkan/runtime/api/api.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ComputeGraph.h>
+
+namespace vkcompute {
+
+ValueRef channel_image_repacking(
+    ComputeGraph& graph,
+    ValueRef in,
+    api::GPUMemoryLayout target_layout,
+    const api::ShaderInfo& shader);
+
+ValueRef convert_image_channels_packed_to_width_packed(
+    ComputeGraph& graph,
+    ValueRef in);
+
+ValueRef convert_image_channels_packed_to_height_packed(
+    ComputeGraph& graph,
+    ValueRef in);
+
+} // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/impl/View.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/View.cpp
@@ -46,6 +46,7 @@ void view(ComputeGraph& graph, const std::vector<ValueRef>& args) {
 
 REGISTER_OPERATORS {
   VK_REGISTER_OP(aten.view_copy.default, view);
+  VK_REGISTER_OP(aten.reshape.default, view);
 }
 
 } // namespace vkcompute

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -51,7 +51,6 @@ def get_mm_inputs():
     # ATen matmul doesn't support half
     test_suite.dtypes = ["at::kFloat"]
     test_suite.layouts = [
-        "api::kWidthPacked",
         "api::kChannelsPacked",
     ]
     return test_suite

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -73,6 +73,22 @@ def get_addmm_inputs():
     return test_suite
 
 
+def get_bmm_inputs():
+    test_suite = VkTestSuite(
+        [
+            ((S, M1, L), (S, L, M2)),
+            ((M, S1, S2), (M, S2, M)),
+        ],
+    )
+    test_suite.prepacked_args = ["mat2"]
+    # ATen matmul doesn't support half
+    test_suite.dtypes = ["at::kFloat"]
+    test_suite.layouts = [
+        "api::kChannelsPacked",
+    ]
+    return test_suite
+
+
 def get_pool2d_inputs():
     test_suite = VkTestSuite(
         [
@@ -496,6 +512,7 @@ test_suites = {
     "aten.div.Tensor": get_binary_elementwise_inputs(),
     "aten.mul.Tensor": get_binary_elementwise_inputs(),
     "aten.addmm.default": get_addmm_inputs(),
+    "aten.bmm.default": get_bmm_inputs(),
     "aten.mm.default": get_mm_inputs(),
     "aten.max_pool2d_with_indices.default": get_pool2d_inputs(),
     "aten.convolution.default": get_conv_inputs(),

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -56,6 +56,23 @@ def get_mm_inputs():
     return test_suite
 
 
+def get_addmm_inputs():
+    test_suite = VkTestSuite(
+        [
+            ((M1, M2), (M1, M2), (M2, M2)),
+            ((M1, M2), (M1, M2), (M2, M2), 1.0, 1.0),
+            ((M1, L), (M1, L), (L, L), 2.0, 3.0),
+            # ((M2), (M1, M2), (M2, M2)), // broadcasting
+        ]
+    )
+    # ATen matmul doesn't support half
+    test_suite.dtypes = ["at::kFloat"]
+    test_suite.layouts = [
+        "api::kChannelsPacked",
+    ]
+    return test_suite
+
+
 def get_pool2d_inputs():
     test_suite = VkTestSuite(
         [
@@ -478,6 +495,7 @@ test_suites = {
     "aten.sub.Tensor": get_binary_elementwise_inputs(),
     "aten.div.Tensor": get_binary_elementwise_inputs(),
     "aten.mul.Tensor": get_binary_elementwise_inputs(),
+    "aten.addmm.default": get_addmm_inputs(),
     "aten.mm.default": get_mm_inputs(),
     "aten.max_pool2d_with_indices.default": get_pool2d_inputs(),
     "aten.convolution.default": get_conv_inputs(),

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -490,6 +490,43 @@ class TestBackends(unittest.TestCase):
             memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
         )
 
+    def test_vulkan_backend_bmm(self):
+        class BMMModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.randn(size=(4, 4, 5), dtype=torch.float32)
+
+            def forward(self, x):
+                return torch.bmm(x, self.weight)
+
+        module = BMMModule()
+        sample_inputs = (torch.randn(size=(4, 3, 4), dtype=torch.float32),)
+
+        self.lower_module_and_test_output(
+            module,
+            sample_inputs,
+            memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
+        )
+
+    def test_vulkan_backend_baddbmm(self):
+        class BaddbmmModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.m = torch.randn(3, 3, 5)
+                self.weight = torch.randn(size=(3, 4, 5), dtype=torch.float32)
+
+            def forward(self, x):
+                return torch.baddbmm(self.m, x, self.weight, beta=1.0, alpha=2.0)
+
+        module = BaddbmmModule()
+        sample_inputs = (torch.randn(size=(3, 3, 4), dtype=torch.float32),)
+
+        self.lower_module_and_test_output(
+            module,
+            sample_inputs,
+            memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
+        )
+
     def test_vulkan_backend_sum_dim_list(self):
         class SumModule(torch.nn.Module):
             def __init__(self):

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -476,7 +476,11 @@ class TestBackends(unittest.TestCase):
         module = MatMulModule()
         sample_inputs = (torch.ones(size=(31, 63), dtype=torch.float32),)
 
-        self.lower_module_and_test_output(module, sample_inputs)
+        self.lower_module_and_test_output(
+            module,
+            sample_inputs,
+            memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
+        )
 
     def test_vulkan_backend_sum_dim_list(self):
         class SumModule(torch.nn.Module):

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -427,7 +427,11 @@ class TestBackends(unittest.TestCase):
         model = SimpleModel()
         sample_inputs = (torch.rand(size=(2, 10), dtype=torch.float32),)
 
-        self.lower_module_and_test_output(model, sample_inputs)
+        self.lower_module_and_test_output(
+            model,
+            sample_inputs,
+            memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
+        )
 
     def test_vulkan_backend_partial_dynamic_shapes(self):
         class SimpleModel(torch.nn.Module):
@@ -461,7 +465,11 @@ class TestBackends(unittest.TestCase):
         ]
 
         self.lower_module_and_test_output(
-            model, sample_inputs, dynamic_shapes=dynamic_shapes, test_inputs=test_inputs
+            model,
+            sample_inputs,
+            dynamic_shapes=dynamic_shapes,
+            test_inputs=test_inputs,
+            memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
         )
 
     def test_vulkan_backend_matmul(self):

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -1503,7 +1503,6 @@ TEST(VulkanComputeGraphOpsTest, mm_smoke_test) {
       layout,                             \
       prepack);
 
-  CALL_TEST_FN_FOR_W_PACKED(RUN_TESTS);
   CALL_TEST_FN_FOR_C_PACKED(RUN_TESTS);
 
 #undef RUN_TESTS


### PR DESCRIPTION
Summary:
We implement `bmm`. Thereafter `baddbmm` is also supported since it is [decomposed as](https://www.internalfb.com/code/fbsource/[f7ead67da83314531c85723ab852b61e9d9abdd0]/xplat/caffe2/torch/_decomp/decompositions.py?lines=4680-4694)
```
aten.add.Tensor
aten.mul.Tensor
aten.mul.Tensor
aten.bmm.default
```

Differential Revision: D56679087
