### PR TITLE
half support for index_copy, copy and slice_scatter

### DIFF
--- a/kernels/portable/cpu/op_copy.cpp
+++ b/kernels/portable/cpu/op_copy.cpp
@@ -42,8 +42,8 @@ Tensor& copy_out(
   ScalarType in_type = in.scalar_type();
   ScalarType src_type = src.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "copy.out", CTYPE, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, src_type, ctx, "copy.out", CTYPE_SRC, [&]() {
+  ET_SWITCH_REALHB_TYPES(in_type, ctx, "copy.out", CTYPE, [&]() {
+    ET_SWITCH_REALHB_TYPES(src_type, ctx, "copy.out", CTYPE_SRC, [&]() {
       apply_binary_elementwise_fn<CTYPE, CTYPE_SRC, CTYPE>(
           [](const CTYPE val_in, const CTYPE_SRC val_src) {
             return convert<CTYPE, CTYPE_SRC>(val_src);
@@ -69,8 +69,8 @@ copy_(RuntimeContext& ctx, Tensor& in, const Tensor& src, bool non_blocking) {
   ScalarType in_type = in.scalar_type();
   ScalarType src_type = src.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "copy_", CTYPE, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, src_type, ctx, "copy_", CTYPE_SRC, [&]() {
+  ET_SWITCH_REALHB_TYPES(in_type, ctx, "copy_", CTYPE, [&]() {
+    ET_SWITCH_REALHB_TYPES(src_type, ctx, "copy_", CTYPE_SRC, [&]() {
       apply_binary_elementwise_fn<CTYPE, CTYPE_SRC, CTYPE>(
           [](const CTYPE val_in, const CTYPE_SRC val_src) {
             return convert<CTYPE, CTYPE_SRC>(val_src);

--- a/kernels/portable/cpu/op_index_put.cpp
+++ b/kernels/portable/cpu/op_index_put.cpp
@@ -48,7 +48,7 @@ Tensor& index_put_out(
     ET_KERNEL_CHECK(
         ctx, tensor_is_broadcastable_to(values, out), InvalidArgument, out);
 
-    ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "index_put.out", CTYPE, [&]() {
+    ET_SWITCH_REALHB_TYPES(in_type, ctx, "index_put.out", CTYPE, [&]() {
       apply_binary_elementwise_fn<CTYPE, CTYPE, CTYPE>(
           [accumulate](const CTYPE val_in, const CTYPE val) {
             return accumulate ? val_in + val : val;
@@ -115,7 +115,7 @@ Tensor& index_put_out(
     x_numel *= x_sizes[i];
   }
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, in_type, ctx, "index_put.out", CTYPE, [&]() {
+  ET_SWITCH_REALHB_TYPES(in_type, ctx, "index_put.out", CTYPE, [&]() {
     const CTYPE* const values_data = values.const_data_ptr<CTYPE>();
     CTYPE* const out_data = out.mutable_data_ptr<CTYPE>();
 

--- a/kernels/portable/cpu/op_slice_scatter.cpp
+++ b/kernels/portable/cpu/op_slice_scatter.cpp
@@ -74,28 +74,27 @@ Tensor& slice_scatter_out(
   ScalarType in_type = input.scalar_type();
   ScalarType src_type = src.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(
-      Bool, in_type, ctx, "slice_scatter.out", CTYPE, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(
-            Bool, src_type, ctx, "slice_scatter.out", CTYPE_SRC, [&]() {
-              CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
-              const CTYPE_SRC* src_data = src.const_data_ptr<CTYPE_SRC>();
+  ET_SWITCH_REALHB_TYPES(in_type, ctx, "slice_scatter.out", CTYPE, [&]() {
+    ET_SWITCH_REALHB_TYPES(
+        src_type, ctx, "slice_scatter.out", CTYPE_SRC, [&]() {
+          CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
+          const CTYPE_SRC* src_data = src.const_data_ptr<CTYPE_SRC>();
 
-              size_t src_offset = 0;
+          size_t src_offset = 0;
 
-              for (int i = 0; i < leading_dims; i++) {
-                size_t out_offset = (i * dim_length + start) * trailing_dims;
-                for (int j = 0; j < num_values; j++) {
-                  for (size_t k = 0; k < trailing_dims; ++k) {
-                    out_data[out_offset + k] =
-                        convert<CTYPE, CTYPE_SRC>(src_data[src_offset + k]);
-                  }
-                  src_offset += trailing_dims;
-                  out_offset += step * trailing_dims;
-                }
+          for (int i = 0; i < leading_dims; i++) {
+            size_t out_offset = (i * dim_length + start) * trailing_dims;
+            for (int j = 0; j < num_values; j++) {
+              for (size_t k = 0; k < trailing_dims; ++k) {
+                out_data[out_offset + k] =
+                    convert<CTYPE, CTYPE_SRC>(src_data[src_offset + k]);
               }
-            });
-      });
+              src_offset += trailing_dims;
+              out_offset += step * trailing_dims;
+            }
+          }
+        });
+  });
 
   return out;
 }


### PR DESCRIPTION
Summary: Add half support for 3 more ops: `index_copy`, `copy`, `slice_scatter`

Differential Revision: D56712670
