### PR TITLE
log_softmax

### DIFF
--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -67,6 +67,7 @@ class VulkanSupportedOperators(OperatorSupportBase):
             exir_ops.edge.aten.repeat.default,
             # Softmax
             exir_ops.edge.aten._softmax.default,
+            exir_ops.edge.aten._log_softmax.default,
             # Other
             operator.getitem,
             exir_ops.edge.aten.full.default,

--- a/backends/vulkan/runtime/graph/ops/glsl/softmax_batch_height_width.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/softmax_batch_height_width.glsl
@@ -10,6 +10,10 @@
 
 #define PRECISION ${PRECISION}
 
+#define op1(X) ${OPERATOR1}
+
+#define op2(X, Y) ${OPERATOR2}
+
 #include "indexing_utils.h"
 #include "softmax.h"
 
@@ -73,8 +77,8 @@ void main() {
   // Calculate every final element along the direction of input_dim_stride.
   cand_pos = pos;
   while (all(lessThan(cand_pos, extents.xyz))) {
-    const vec4 numerator = exp(texelFetch(image_in, cand_pos, 0) - max_element);
-    imageStore(image_out, cand_pos, numerator / denominator);
+    const vec4 numerator = op1(texelFetch(image_in, cand_pos, 0) - max_element);
+    imageStore(image_out, cand_pos, op2(numerator, denominator));
     cand_pos += input_dim_stride.xyz;
   }
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/softmax_batch_height_width.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/softmax_batch_height_width.yaml
@@ -6,6 +6,8 @@
 
 softmax_batch_height_width:
   parameter_names_with_default_values:
+    OPERATOR1: exp(X)
+    OPERATOR2: X / Y
     NDIM: 3
     DTYPE: float
   generate_variant_forall:
@@ -14,3 +16,6 @@ softmax_batch_height_width:
       - VALUE: float
   shader_variants:
     - NAME: softmax_batch_height_width
+    - NAME: log_softmax_batch_height_width
+      OPERATOR1: X
+      OPERATOR2: X - log(Y)

--- a/backends/vulkan/runtime/graph/ops/glsl/softmax_channel.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/softmax_channel.glsl
@@ -10,6 +10,10 @@
 
 #define PRECISION ${PRECISION}
 
+#define op1(X) ${OPERATOR1}
+
+#define op2(X, Y) ${OPERATOR2}
+
 #include "indexing_utils.h"
 #include "softmax.h"
 
@@ -94,7 +98,7 @@ void main() {
   // Calculate every final channel element.
   for (int c = 0; c < b_stride; c++) {
     const ivec3 dst_pos = ivec3(src_pos.x, src_pos.y, src_pos.z + c);
-    const vec4 numerator = exp(texelFetch(image_in, dst_pos, 0) - max_element);
-    imageStore(image_out, dst_pos, numerator / denominator);
+    const vec4 numerator = op1(texelFetch(image_in, dst_pos, 0) - max_element);
+    imageStore(image_out, dst_pos, op2(numerator, denominator));
   }
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/softmax_channel.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/softmax_channel.yaml
@@ -6,6 +6,8 @@
 
 softmax_channel:
   parameter_names_with_default_values:
+    OPERATOR1: exp(X)
+    OPERATOR2: X / Y
     NDIM: 3
     DTYPE: float
   generate_variant_forall:
@@ -14,3 +16,6 @@ softmax_channel:
       - VALUE: float
   shader_variants:
     - NAME: softmax_channel
+    - NAME: log_softmax_channel
+      OPERATOR1: X
+      OPERATOR2: X - log(Y)

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -661,4 +661,5 @@ test_suites = {
     "aten.split.Tensor": get_split_tensor_inputs(),
     "aten.sqrt.default": get_unary_ops_inputs(),
     "aten._softmax.default": get_softmax_inputs(),
+    "aten._log_softmax.default": get_softmax_inputs(),
 }

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -1015,3 +1015,22 @@ class TestBackends(unittest.TestCase):
             sample_inputs,
             memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
         )
+
+    def test_vulkan_backend_logsoftmax(self):
+        class LogSoftmaxModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                x = x.log_softmax(dim=0)
+                x = x.log_softmax(dim=1)
+                x = x.log_softmax(dim=2)
+                return x
+
+        sample_inputs = (torch.randn(size=(3, 2, 7), dtype=torch.float32),)
+
+        self.lower_module_and_test_output(
+            LogSoftmaxModule(),
+            sample_inputs,
+            memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
+        )


### PR DESCRIPTION
Summary:
Use the following property to implement `log_softmax`
```
log(exp(x_i) / sum(exp(x_j))) = x_i - log(sum(exp(x_j)))
```
- numerically stable, since we can avoid log(small_number) -> -\infty
- reusing existing `softmax` shader to generate variants

Differential Revision: D56688093
