### PR TITLE
[ET-VK][EZ] Fix conv2d_prepack_test

### DIFF
--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -64,7 +64,6 @@ void record_conv2d_prepack_weights_op(
     api::VulkanBuffer& src_buffer,
     vTensor& v_dst,
     const std::vector<int64_t>& original_sizes,
-    const std::vector<int64_t>& padded_sizes,
     const bool transposed) {
   api::PipelineBarrier pipeline_barrier{};
 
@@ -80,8 +79,6 @@ void record_conv2d_prepack_weights_op(
 
   api::UniformParamsBuffer original_sizes_ubo(
       context, api::utils::make_ivec4(original_sizes, /*reverse = */ true));
-  api::UniformParamsBuffer padded_sizes_ubo(
-      context, api::utils::make_ivec2(padded_sizes, /*reverse = */ true));
 
   api::SpecVarList specialization_constants = {};
   context->submit_compute_job(
@@ -97,8 +94,7 @@ void record_conv2d_prepack_weights_op(
           api::MemoryAccessType::WRITE),
       src_buffer,
       v_dst.sizes_ubo(),
-      original_sizes_ubo.buffer(),
-      padded_sizes_ubo.buffer());
+      original_sizes_ubo.buffer());
 }
 
 void record_binary_op(

--- a/backends/vulkan/test/utils/test_utils.h
+++ b/backends/vulkan/test/utils/test_utils.h
@@ -87,7 +87,6 @@ void record_conv2d_prepack_weights_op(
     api::VulkanBuffer& src_buffer,
     vTensor& v_dst,
     const std::vector<int64_t>& original_sizes,
-    const std::vector<int64_t>& padded_sizes,
     const bool transposed);
 
 void record_binary_op(

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -1633,7 +1633,6 @@ void test_conv2d(
       staging_buffer_in.buffer(),
       vten,
       original_sizes,
-      padded_sizes,
       transposed);
   record_image_to_nchw_op(api::context(), vten, staging_buffer_out.buffer());
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3415

TIL smoke tests are not part of the CI.

Forgot to update this in https://github.com/pytorch/executorch/pull/3368

Differential Revision: [D56739385](https://our.internmc.facebook.com/intern/diff/D56739385/)