### PR TITLE
Reduce build time for op_where by consolidating bool & byte

### DIFF
--- a/kernels/portable/cpu/op_where.cpp
+++ b/kernels/portable/cpu/op_where.cpp
@@ -37,23 +37,23 @@ Tensor& where_out(
 
   constexpr auto name = "where.self_out";
 
-  ET_SWITCH_TWO_TYPES(Bool, Byte, cond_type, ctx, name, CTYPE_COND, [&]() {
-    ET_SWITCH_REALHB_TYPES(a_type, ctx, name, CTYPE_A, [&]() {
-      ET_SWITCH_REALHB_TYPES(b_type, ctx, name, CTYPE_B, [&]() {
-        ET_SWITCH_REALHB_TYPES(out_type, ctx, name, CTYPE_OUT, [&]() {
-          apply_ternary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_COND, CTYPE_OUT>(
-              [](const CTYPE_A val_a,
-                 const CTYPE_B val_b,
-                 const CTYPE_COND val_c) {
-                CTYPE_OUT a_casted = static_cast<CTYPE_OUT>(val_a);
-                CTYPE_OUT b_casted = static_cast<CTYPE_OUT>(val_b);
-                return val_c ? a_casted : b_casted;
-              },
-              a,
-              b,
-              cond,
-              out);
-        });
+  ET_CHECK_MSG(
+      cond_type == ScalarType::Bool || cond_type == ScalarType::Byte,
+      "Unhandled dtype %s for where.self_out",
+      torch::executor::toString(cond_type));
+  ET_SWITCH_REALHB_TYPES(a_type, ctx, name, CTYPE_A, [&]() {
+    ET_SWITCH_REALHB_TYPES(b_type, ctx, name, CTYPE_B, [&]() {
+      ET_SWITCH_REALHB_TYPES(out_type, ctx, name, CTYPE_OUT, [&]() {
+        apply_ternary_elementwise_fn<CTYPE_A, CTYPE_B, uint8_t, CTYPE_OUT>(
+            [](const CTYPE_A val_a, const CTYPE_B val_b, const uint8_t val_c) {
+              CTYPE_OUT a_casted = static_cast<CTYPE_OUT>(val_a);
+              CTYPE_OUT b_casted = static_cast<CTYPE_OUT>(val_b);
+              return val_c ? a_casted : b_casted;
+            },
+            a,
+            b,
+            cond,
+            out);
       });
     });
   });

--- a/kernels/test/op_where_test.cpp
+++ b/kernels/test/op_where_test.cpp
@@ -38,6 +38,7 @@ class OpWhereOutTest : public OperatorTest {
       return;
     }
     TensorFactory<ScalarType::Bool> tf_condition;
+    TensorFactory<ScalarType::Byte> tf_condition_byte;
     TensorFactory<DTYPE_A> tf_a;
     TensorFactory<DTYPE_B> tf_b;
     TensorFactory<DTYPE_OUT> tf_out;
@@ -48,19 +49,30 @@ class OpWhereOutTest : public OperatorTest {
     Tensor out = tf_out.zeros(sizes);
 
     // clang-format off
+    std::vector<uint8_t> condition_data = {
+      false, true, false, true, true, false,
+      false, true, false, true, true, false
+    };
+    const auto a_tensor = tf_a.make(sizes, /*data=*/{  1,  2,  3,  4,  5,  6,  6,  5,  4,  3,  2,  1});
+    const auto b_tensor = tf_b.make(sizes, /*data=*/{  6,  5,  4,  3,  2,  1,  1,  2,  3,  4,  5,  6});
+    // clang-format on
     op_where_self_out(
-        tf_condition.make(condition_sizes, /*data=*/{false, true, false, true, true, false,
-                                                     false, true, false, true, true, false}),
-        tf_a.make(sizes, /*data=*/{  1,  2,  3,  4,  5,  6,  6,  5,  4,  3,  2,  1}),
-        tf_b.make(sizes, /*data=*/{  6,  5,  4,  3,  2,  1,  1,  2,  3,  4,  5,  6}),
+        tf_condition.make(condition_sizes, /*data=*/condition_data),
+        a_tensor,
+        b_tensor,
         out);
 
+    auto expectedOut =
+        tf_out.make(sizes, /*data=*/{6, 2, 4, 4, 5, 1, 1, 5, 3, 3, 2, 6});
     // Check that it matches the expected output.
-    EXPECT_TENSOR_CLOSE(
-        out,
-        tf_out.make(
-            sizes, /*data=*/{  6,  2,  4,  4,  5,  1,  1,  5,  3,  3,  2,  6}));
-    // clang-format on
+    EXPECT_TENSOR_CLOSE(out, expectedOut);
+
+    op_where_self_out(
+        tf_condition_byte.make(condition_sizes, condition_data),
+        a_tensor,
+        b_tensor,
+        out);
+    EXPECT_TENSOR_CLOSE(out, expectedOut);
   }
 
   template <ScalarType DTYPE_A, ScalarType DTYPE_B>


### PR DESCRIPTION
Summary: bool is implicitly convertible to uint8_t, so I think this should Just Work?

Differential Revision: D56650339
