### PR TITLE
Use macro to implement binary Tensor elementwise comparison ops

### DIFF
--- a/kernels/portable/cpu/op_eq.cpp
+++ b/kernels/portable/cpu/op_eq.cpp
@@ -6,6 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// patternlint-disable-next-line executorch-cpp-nostdinc
+#include <functional>
+
+#include <executorch/kernels/portable/cpu/pattern/comparison_op.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
@@ -24,40 +28,7 @@ Tensor& eq_tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  ET_KERNEL_CHECK(
-      ctx,
-      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
-      InvalidArgument,
-      out);
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
-  ScalarType common_type = promoteTypes(a_type, b_type);
-  ScalarType out_type = out.scalar_type();
-
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "eq.Scalar_out", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(
-        Bool, b_type, ctx, "eq.Scalar_out", CTYPE_B, [&]() {
-          ET_SWITCH_REAL_TYPES_AND(
-              Bool, common_type, ctx, "eq.Scalar_out", CTYPE_IN, [&]() {
-                ET_SWITCH_REAL_TYPES_AND(
-                    Bool, out_type, ctx, "eq.Scalar_out", CTYPE_OUT, [&]() {
-                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                          [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                            bool value = a_casted == b_casted;
-                            return static_cast<CTYPE_OUT>(value);
-                          },
-                          a,
-                          b,
-                          out);
-                    });
-              });
-        });
-  });
-
-  return out;
+  return comparison_op_out<std::equal_to>(ctx, a, b, out, "eq.Tensor_out");
 }
 
 Tensor& eq_scalar_out(

--- a/kernels/portable/cpu/op_ge.cpp
+++ b/kernels/portable/cpu/op_ge.cpp
@@ -6,6 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// patternlint-disable-next-line executorch-cpp-nostdinc
+#include <functional>
+
+#include <executorch/kernels/portable/cpu/pattern/comparison_op.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
@@ -24,41 +28,7 @@ Tensor& ge_tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  // Determine output size and resize for dynamic shapes
-  ET_KERNEL_CHECK(
-      ctx,
-      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
-      InvalidArgument,
-      out);
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
-  ScalarType common_type = promoteTypes(a_type, b_type);
-  ScalarType out_type = out.scalar_type();
-
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "ge.Tensor_out", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(
-        Bool, b_type, ctx, "ge.Tensor_out", CTYPE_B, [&]() {
-          ET_SWITCH_REAL_TYPES_AND(
-              Bool, common_type, ctx, "ge.Tensor_out", CTYPE_IN, [&]() {
-                ET_SWITCH_REAL_TYPES_AND(
-                    Bool, out_type, ctx, "ge.Tensor_out", CTYPE_OUT, [&]() {
-                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                          [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                            bool value = a_casted >= b_casted;
-                            return static_cast<CTYPE_OUT>(value);
-                          },
-                          a,
-                          b,
-                          out);
-                    });
-              });
-        });
-  });
-
-  return out;
+  return comparison_op_out<std::greater_equal>(ctx, a, b, out, "ge.Tensor_out");
 }
 
 Tensor& ge_scalar_out(

--- a/kernels/portable/cpu/op_gt.cpp
+++ b/kernels/portable/cpu/op_gt.cpp
@@ -6,6 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// patternlint-disable-next-line executorch-cpp-nostdinc
+#include <functional>
+
+#include <executorch/kernels/portable/cpu/pattern/comparison_op.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
@@ -24,41 +28,7 @@ Tensor& gt_tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  // Determine output size and resize for dynamic shapes
-  ET_KERNEL_CHECK(
-      ctx,
-      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
-      InvalidArgument,
-      out);
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
-  ScalarType common_type = promoteTypes(a_type, b_type);
-  ScalarType out_type = out.scalar_type();
-
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "gt.Tensor_out", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(
-        Bool, b_type, ctx, "gt.Tensor_out", CTYPE_B, [&]() {
-          ET_SWITCH_REAL_TYPES_AND(
-              Bool, common_type, ctx, "gt.Tensor_out", CTYPE_IN, [&]() {
-                ET_SWITCH_REAL_TYPES_AND(
-                    Bool, out_type, ctx, "gt.Tensor_out", CTYPE_OUT, [&]() {
-                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                          [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                            bool value = a_casted > b_casted;
-                            return static_cast<CTYPE_OUT>(value);
-                          },
-                          a,
-                          b,
-                          out);
-                    });
-              });
-        });
-  });
-
-  return out;
+  return comparison_op_out<std::greater>(ctx, a, b, out, "gt.Tensor_out");
 }
 
 Tensor& gt_scalar_out(

--- a/kernels/portable/cpu/op_le.cpp
+++ b/kernels/portable/cpu/op_le.cpp
@@ -6,6 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// patternlint-disable-next-line executorch-cpp-nostdinc
+#include <functional>
+
+#include <executorch/kernels/portable/cpu/pattern/comparison_op.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
@@ -24,41 +28,7 @@ Tensor& le_tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  // Determine output size and resize for dynamic shapes
-  ET_KERNEL_CHECK(
-      ctx,
-      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
-      InvalidArgument,
-      out);
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
-  ScalarType common_type = promoteTypes(a_type, b_type);
-  ScalarType out_type = out.scalar_type();
-
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "le.Tensor_out", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(
-        Bool, b_type, ctx, "le.Tensor_out", CTYPE_B, [&]() {
-          ET_SWITCH_REAL_TYPES_AND(
-              Bool, common_type, ctx, "le.Tensor_out", CTYPE_IN, [&]() {
-                ET_SWITCH_REAL_TYPES_AND(
-                    Bool, out_type, ctx, "le.Tensor_out", CTYPE_OUT, [&]() {
-                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                          [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                            bool value = a_casted <= b_casted;
-                            return static_cast<CTYPE_OUT>(value);
-                          },
-                          a,
-                          b,
-                          out);
-                    });
-              });
-        });
-  });
-
-  return out;
+  return comparison_op_out<std::less_equal>(ctx, a, b, out, "le.Tensor_out");
 }
 
 Tensor& le_scalar_out(

--- a/kernels/portable/cpu/op_lt.cpp
+++ b/kernels/portable/cpu/op_lt.cpp
@@ -6,6 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// patternlint-disable-next-line executorch-cpp-nostdinc
+#include <functional>
+
+#include <executorch/kernels/portable/cpu/pattern/comparison_op.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
@@ -24,41 +28,7 @@ Tensor& lt_tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  // Determine output size and resize for dynamic shapes
-  ET_KERNEL_CHECK(
-      ctx,
-      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
-      InvalidArgument,
-      out);
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
-  ScalarType common_type = promoteTypes(a_type, b_type);
-  ScalarType out_type = out.scalar_type();
-
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "lt.Tensor_out", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(
-        Bool, b_type, ctx, "lt.Tensor_out", CTYPE_B, [&]() {
-          ET_SWITCH_REAL_TYPES_AND(
-              Bool, common_type, ctx, "lt.Tensor_out", CTYPE_IN, [&]() {
-                ET_SWITCH_REAL_TYPES_AND(
-                    Bool, out_type, ctx, "lt.Tensor_out", CTYPE_OUT, [&]() {
-                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                          [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                            bool value = a_casted < b_casted;
-                            return static_cast<CTYPE_OUT>(value);
-                          },
-                          a,
-                          b,
-                          out);
-                    });
-              });
-        });
-  });
-
-  return out;
+  return comparison_op_out<std::less>(ctx, a, b, out, "lt.Tensor_out");
 }
 
 Tensor& lt_scalar_out(

--- a/kernels/portable/cpu/op_mul.cpp
+++ b/kernels/portable/cpu/op_mul.cpp
@@ -16,6 +16,52 @@ namespace torch {
 namespace executor {
 namespace native {
 
+namespace {
+template <
+    bool can_cast,
+    typename CTYPE_A,
+    typename CTYPE_B,
+    typename CTYPE_IN,
+    typename CTYPE_OUT>
+struct MulInner;
+
+template <
+    typename CTYPE_A,
+    typename CTYPE_B,
+    typename CTYPE_IN,
+    typename CTYPE_OUT>
+struct MulInner<true, CTYPE_A, CTYPE_B, CTYPE_IN, CTYPE_OUT> {
+  static void run(const Tensor& a, const Tensor& b, Tensor& out) {
+    // NOLINTNEXTLINE(facebook-hte-ConstantArgumentPassByValue)
+    apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
+        [](const CTYPE_A val_a, const CTYPE_B val_b) {
+          CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+          CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+          CTYPE_IN value = a_casted * b_casted;
+
+          return static_cast<CTYPE_OUT>(value);
+        },
+        a,
+        b,
+        out);
+  }
+};
+
+struct ReportCanCastBug {
+  static void run(const Tensor&, const Tensor&, Tensor&) {
+    ET_DCHECK_MSG(false, "BUG: canCast should have been checked above");
+  }
+};
+
+template <
+    typename CTYPE_A,
+    typename CTYPE_B,
+    typename CTYPE_IN,
+    typename CTYPE_OUT>
+struct MulInner<false, CTYPE_A, CTYPE_B, CTYPE_IN, CTYPE_OUT>
+    : public ReportCanCastBug {};
+} // namespace
+
 Tensor&
 mul_out(RuntimeContext& ctx, const Tensor& a, const Tensor& b, Tensor& out) {
   ET_KERNEL_CHECK(
@@ -35,20 +81,16 @@ mul_out(RuntimeContext& ctx, const Tensor& a, const Tensor& b, Tensor& out) {
 
   ET_SWITCH_REALHB_TYPES(a_type, ctx, "mul.out", CTYPE_A, [&]() {
     ET_SWITCH_REALHB_TYPES(b_type, ctx, "mul.out", CTYPE_B, [&]() {
-      ET_SWITCH_REALB_TYPES(common_type, ctx, "mul.out", CTYPE_IN, [&]() {
-        ET_SWITCH_REALHB_TYPES(out_type, ctx, "mul.out", CTYPE_OUT, [&]() {
-          apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-              [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                CTYPE_IN value = a_casted * b_casted;
-
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a,
-              b,
-              out);
-        });
+      using CTYPE_IN = typename torch::executor::
+          promote_types<CTYPE_A, CTYPE_B, /*half_to_float*/ true>::type;
+      ET_DCHECK(CppTypeToScalarType<CTYPE_IN>::value == common_type);
+      ET_SWITCH_REALHB_TYPES(out_type, ctx, "mul.out", CTYPE_OUT, [&]() {
+        MulInner<
+            can_cast<CTYPE_IN, CTYPE_OUT>::value,
+            CTYPE_A,
+            CTYPE_B,
+            CTYPE_IN,
+            CTYPE_OUT>::run(a, b, out);
       });
     });
   });

--- a/kernels/portable/cpu/op_ne.cpp
+++ b/kernels/portable/cpu/op_ne.cpp
@@ -6,6 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// patternlint-disable-next-line executorch-cpp-nostdinc
+#include <functional>
+
+#include <executorch/kernels/portable/cpu/pattern/comparison_op.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
@@ -24,40 +28,7 @@ Tensor& ne_tensor_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  ET_KERNEL_CHECK(
-      ctx,
-      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
-      InvalidArgument,
-      out);
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
-  ScalarType common_type = promoteTypes(a_type, b_type);
-  ScalarType out_type = out.scalar_type();
-
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, "ne.Tensor_out", CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(
-        Bool, b_type, ctx, "ne.Tensor_out", CTYPE_B, [&]() {
-          ET_SWITCH_REAL_TYPES_AND(
-              Bool, common_type, ctx, "ne.Tensor_out", CTYPE_IN, [&]() {
-                ET_SWITCH_REAL_TYPES_AND(
-                    Bool, out_type, ctx, "ne.Tensor_out", CTYPE_OUT, [&]() {
-                      apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                          [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                            CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                            CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                            bool value = a_casted != b_casted;
-                            return static_cast<CTYPE_OUT>(value);
-                          },
-                          a,
-                          b,
-                          out);
-                    });
-              });
-        });
-  });
-
-  return out;
+  return comparison_op_out<std::not_equal_to>(ctx, a, b, out, "ne.Tensor_out");
 }
 
 Tensor& ne_scalar_out(

--- a/kernels/portable/cpu/pattern/comparison_op.h
+++ b/kernels/portable/cpu/pattern/comparison_op.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/kernels/portable/cpu/util/broadcast_util.h>
+#include <executorch/runtime/kernel/kernel_includes.h>
+
+namespace torch {
+namespace executor {
+namespace native {
+template <template <typename> typename OpFunc>
+Tensor& comparison_op_out(
+    RuntimeContext& ctx,
+    const Tensor& a,
+    const Tensor& b,
+    Tensor& out,
+    const char* op_name) {
+  /* Determine output size and resize for dynamic shapes */
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
+
+  ScalarType a_type = a.scalar_type();
+  ScalarType b_type = b.scalar_type();
+  ScalarType common_type = promoteTypes(a_type, b_type);
+  ScalarType out_type = out.scalar_type();
+
+  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, op_name, CTYPE_A, [&]() {
+    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, op_name, CTYPE_B, [&]() {
+      ET_SWITCH_REAL_TYPES_AND(
+          Bool, common_type, ctx, op_name, CTYPE_IN, [&]() {
+            ET_SWITCH_REAL_TYPES_AND(
+                Bool, out_type, ctx, op_name, CTYPE_OUT, [&]() {
+                  apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
+                      [](const CTYPE_A val_a, const CTYPE_B val_b) {
+                        CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
+                        CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
+                        bool value = OpFunc<CTYPE_IN>()(a_casted, b_casted);
+                        return static_cast<CTYPE_OUT>(value);
+                      },
+                      a,
+                      b,
+                      out);
+                });
+          });
+    });
+  });
+
+  return out;
+}
+} // namespace native
+} // namespace executor
+} // namespace torch

--- a/kernels/portable/cpu/pattern/targets.bzl
+++ b/kernels/portable/cpu/pattern/targets.bzl
@@ -6,6 +6,17 @@ def define_common_targets():
     The directory containing this targets.bzl file should also contain both
     TARGETS and BUCK files that call this function.
     """
+    runtime.cxx_library(
+        name = "comparison_op",
+        exported_headers = [
+            "comparison_op.h",
+        ],
+        compiler_flags = [],
+        deps = [
+            "//executorch/runtime/kernel:kernel_includes",
+        ],
+        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+    )
 
     runtime.cxx_library(
         name = "pattern",

--- a/kernels/portable/cpu/targets.bzl
+++ b/kernels/portable/cpu/targets.bzl
@@ -288,6 +288,7 @@ _ATEN_OPS = (
         deps = [
             ":scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
+            "//executorch/kernels/portable/cpu/pattern:comparison_op",
             "//executorch/kernels/portable/cpu/util:functional_util",
         ],
     ),
@@ -379,6 +380,7 @@ _ATEN_OPS = (
         deps = [
             ":scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
+            "//executorch/kernels/portable/cpu/pattern:comparison_op",
             "//executorch/kernels/portable/cpu/util:functional_util",
         ],
     ),
@@ -403,6 +405,7 @@ _ATEN_OPS = (
         deps = [
             ":scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
+            "//executorch/kernels/portable/cpu/pattern:comparison_op",
             "//executorch/kernels/portable/cpu/util:functional_util",
         ],
     ),
@@ -451,6 +454,7 @@ _ATEN_OPS = (
         deps = [
             ":scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
+            "//executorch/kernels/portable/cpu/pattern:comparison_op",
             "//executorch/kernels/portable/cpu/util:functional_util",
         ],
     ),
@@ -536,6 +540,7 @@ _ATEN_OPS = (
         deps = [
             ":scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
+            "//executorch/kernels/portable/cpu/pattern:comparison_op",
             "//executorch/kernels/portable/cpu/util:functional_util",
         ],
     ),
@@ -634,6 +639,7 @@ _ATEN_OPS = (
         deps = [
             ":scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
+            "//executorch/kernels/portable/cpu/pattern:comparison_op",
             "//executorch/kernels/portable/cpu/util:functional_util",
         ],
     ),

--- a/runtime/core/exec_aten/util/scalar_type_util.h
+++ b/runtime/core/exec_aten/util/scalar_type_util.h
@@ -881,7 +881,7 @@ inline exec_aten::ScalarType promoteTypes(
 #define ET_INTERNAL_SWITCH(TYPE, CONTEXT, NAME, ...) \
   [&] {                                              \
     const auto& _st = TYPE;                          \
-    constexpr const char* et_switch_name = NAME;     \
+    const char* et_switch_name = NAME;               \
     switch (_st) {                                   \
       __VA_ARGS__                                    \
       default:                                       \


### PR DESCRIPTION
Summary: These ops' code is all duplicated; add a macro so we can change it all at once instead of in 6 places.

Differential Revision: D56744651
