### PR TITLE
Add support for getting executorch quantized model (non-lowered) from ModAI

### DIFF
--- a/shim/xplat/executorch/extension/pybindings/pybindings.bzl
+++ b/shim/xplat/executorch/extension/pybindings/pybindings.bzl
@@ -4,6 +4,7 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 # Aten ops with portable kernel
 MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB = [
     "//executorch/kernels/portable:generated_lib",
+    "//executorch/kernels/quantized:generated_lib",
 ]
 
 PORTABLE_MODULE_DEPS = [


### PR DESCRIPTION
Summary: Adding support in this diff for getting the executorch quantized model from ModAI manager. This is the non lowered quantized model (with dq->op->q patterns) running on CPU that will be used for CPU eval's in various places.

Reviewed By: navsud

Differential Revision: D56740679
