### PR TITLE
Set min numpy version 1.25.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies=[
   "expecttest",
   "flatbuffers",
   "hypothesis",
-  "numpy",
+  "numpy>=1.25.2",
   "packaging",
   "pandas",
   "parameterized",


### PR DESCRIPTION
numpy version in ci is 1.25.2: https://github.com/pytorch/executorch/blob/main/.ci/docker/requirements-ci.txt#L2

https://github.com/pytorch/executorch/issues/3430
