### PR TITLE
min setuptools version

### DIFF
--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -75,7 +75,7 @@ EXIR_REQUIREMENTS=(
 DEVEL_REQUIREMENTS=(
   cmake  # For building binary targets.
   pyyaml  # Imported by the kernel codegen tools.
-  setuptools  # For building the pip package.
+  "setuptools>=63"  # For building the pip package.
   tomli  # Imported by extract_sources.py when using python < 3.11.
   wheel  # For building the pip package archive.
   zstd  # Imported by resolve_buck.py.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "cmake",  # For building binary targets in the wheel.
   "pyyaml",  # Imported by the kernel codegen tools.
-  "setuptools",  # For building the pip package contents.
+  "setuptools>=63",  # For building the pip package contents.
   "tomli",  # Imported by extract_sources.py when using python < 3.11.
   "wheel",  # For building the pip package archive.
   "zstd",  # Imported by resolve_buck.py.


### PR DESCRIPTION
setuptools below 63 does not have setuptools.command.build
```
Processing /data/users/lfq/torchchat/et-build/src/executorch
  Running command Preparing metadata (pyproject.toml)
  setup.py:57: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
    from distutils.sysconfig import get_python_lib
  Traceback (most recent call last):
    File "/data/users/lfq/torchchat/.venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
      main()
    File "/data/users/lfq/torchchat/.venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/data/users/lfq/torchchat/.venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
      return hook(metadata_directory, config_settings)
    File "/data/users/lfq/torchchat/.venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 161, in prepare_metadata_for_build_wheel
      self.run_setup()
    File "/data/users/lfq/torchchat/.venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 145, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 61, in <module>
      from setuptools.command.build import build
  ModuleNotFoundError: No module named 'setuptools.command.build'
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /data/users/lfq/torchchat/.venv/bin/python3.10 /data/users/lfq/torchchat/.venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpl32pxnts
  cwd: /data/users/lfq/torchchat/et-build/src/executorch
  Preparing metadata (pyproject.toml) ... error
error: metadata-generation-failed
× Encountered error while generating package metadata.
╰─> See above for output.
note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```