### PR TITLE
relax check on bf16

### DIFF
--- a/runtime/executor/tensor_parser_portable.cpp
+++ b/runtime/executor/tensor_parser_portable.cpp
@@ -39,8 +39,7 @@ Result<torch::executor::Tensor> parseTensor(
           // Types that do not yet have deserialization support.
           scalar_type != exec_aten::ScalarType::ComplexHalf &&
           scalar_type != exec_aten::ScalarType::ComplexFloat &&
-          scalar_type != exec_aten::ScalarType::ComplexDouble &&
-          scalar_type != exec_aten::ScalarType::BFloat16,
+          scalar_type != exec_aten::ScalarType::ComplexDouble,
       InvalidProgram,
       "Invalid or unsupported ScalarType %" PRId8,
       static_cast<int8_t>(scalar_type));


### PR DESCRIPTION
Now require kernel support for bf16.

Export: 
python3 torchchat.py export llama3 --dtype [fp16 | bf16] --output-pte-path llama3.pte
```
(.venv) (base) [lfq@devvm20128.prn0 /data/users/lfq/torchchat (lfq.export-bf16)]$ python3 torchchat.py generate llama3 --device cpu --pte-path llama3.pte --prompt "Hello my name is"
Warning: checkpoint path ignored because an exported DSO or PTE path specified
Warning: checkpoint path ignored because an exported DSO or PTE path specified
Using device=cpu Intel Core Processor (Broadwell)
Loading model...
Time to load model: 0.11 seconds
I 00:00:00.000905 executorch:program.cpp:129] InternalConsistency verification requested but not available
E 00:00:51.744419 executorch:method.cpp:936] Overriding output data pointer allocated by memory plan is not allowed.
I 00:00:51.744460 executorch:pybindings.cpp:196] Cannot set_output_data_ptr(): this likely means the outputs were MemoryPlanned inspect the error code to know for sure, but likely this is not an issue. 0x2
F 00:00:51.747880 executorch:op_index.cpp:87] In function operator()(), assert failed (false): Unhandled dtype BFloat16 for index.Tensor_out
Aborted (core dumped)
```

fp16 runs well!
```
(.venv) (base) [lfq@devvm20128.prn0 /data/users/lfq/torchchat (lfq.export-bf16)]$ python3 torchchat.py generate llama3 --device cpu --pte-path llama3_f16.pte --prompt "Hello my name is" 2>/dev/null
Warning: checkpoint path ignored because an exported DSO or PTE path specified
Warning: checkpoint path ignored because an exported DSO or PTE path specified
Using device=cpu Intel Core Processor (Broadwell)
Loading model...
Time to load model: 0.10 seconds
Hello my name is Elsie, I'm a 28 year old woman who loves to be outdoors and try new things. I'm a bit of a thrill-seeker and love to push myself out of my comfort zone. I'm also a big fan of nature and love spending time in the wilderness.
I'm a bit of a foodSerializedName and love trying new recipes and experimenting with different flavors and ingredients. I'm also a big fan of coffee and love a good cup of joe in the morning.
I'm a bit of a homebody and love spending time at home with my family and friends. I'm also a big fan of movies and TV shows and love getting lost in a good story.
 Injector

I'm a bit of a hopeless romantic and love the idea of finding true love and building a life with someone. I'm looking for someone who is kind, honest, and genuine, and who also loves the outdoors and trying new things. If you're a fellow thrill-seeker who loves nature and<|begin_of_text|>Hello my name is Elsie, I'm a 28 year old woman who loves to be outdoors and try new things. I'm a bit of a thrill-seeker and love to push myself out of my comfort zone. I'm also a big fan of nature and love spending time in the wilderness.
I'm a bit of a foodSerializedName and love trying new recipes and experimenting with different flavors and ingredients. I'm also a big fan of coffee and love a good cup of joe in the morning.
I'm a bit of a homebody and love spending time at home with my family and friends. I'm also a big fan of movies and TV shows and love getting lost in a good story.
 Injector

I'm a bit of a hopeless romantic and love the idea of finding true love and building a life with someone. I'm looking for someone who is kind, honest, and genuine, and who also loves the outdoors and trying new things. If you're a fellow thrill-seeker who loves nature and<|eot_id|>
Max Sequence Length Reached. Ending Conversation.
==========

```