### PR TITLE
Install build requirements in pre_build_script.sh

### DIFF
--- a/build/packaging/pre_build_script.sh
+++ b/build/packaging/pre_build_script.sh
@@ -5,6 +5,21 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-set -eux
+set -euxo pipefail
 
-echo "This script is run before building ExecuTorch binaries"
+# This script is run before building ExecuTorch binaries
+
+# Manually install build requirements because `python setup.py bdist_wheel` does
+# not install them. TODO(dbort): Switch to using `python -m build --wheel`,
+# which does install them. Though we'd need to disable build isolation to be
+# able to see the installed torch package.
+readonly BUILD_DEPS=(
+  # This list must match the build-system.requires list from pyproject.toml.
+  "cmake"
+  "pyyaml"
+  "setuptools"
+  "tomli"
+  "wheel"
+  "zstd"
+)
+pip install --progress-bar off "${BUILD_DEPS[@]}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3477
* #3476
* #3475
* #3474
* #3473
* #3472
* #3471
* #3470
* #3469
* #3468
* #3467
* __->__ #3466

Manually install build requirements because `python setup.py
bdist_wheel` does not install them.

Differential Revision: [D56857485](https://our.internmc.facebook.com/intern/diff/D56857485)