### PR TITLE
Have setup.py unset HOME when running buck2

### DIFF
--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -213,6 +213,12 @@ function(resolve_buck2)
           PARENT_SCOPE)
     endif()
   endif()
+
+  # The buck2 daemon can get stuck. Killing it can help.
+  message(STATUS "Killing buck2 daemon")
+  execute_process(
+    COMMAND "${BUCK2} kill"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endfunction()
 
 # Sets the value of the PYTHON_EXECUTABLE variable to 'python' if in an active


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3477
* #3476
* #3475
* #3474
* #3473
* #3472
* #3471
* #3470
* #3469
* #3468
* __->__ #3467
* #3466

setup.py is sometimes run as root in docker containers. buck2 doesn't
allow running as root unless $HOME is owned by root or does not exist.
So temporarily undefine it while configuring cmake, which runs buck2 to
get some source lists.

Also, the buck2 daemon can sometimes get stuck on the CI workers. Try
killing it before starting the build, ignoring any failures.

Differential Revision: [D56857494](https://our.internmc.facebook.com/intern/diff/D56857494)