### PR TITLE
Add project.ignore to .buckconfig to reduce watched files

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -23,3 +23,14 @@
 
 [parser]
   target_platform_detector_spec = target:root//...->prelude//platforms:default target:shim//...->prelude//platforms:default
+
+# Limit the number of files that the buck daemon needs to monitor. If every
+# submodule is cloned recursively, some system can fail to build with "OS file
+# watch limit reached".
+[project]
+  ignore = \
+      .git, \
+      **/.git, \
+      third-party/pytorch/third_party, \
+      cmake-out, \
+      pip-out


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3477
* #3476
* #3475
* #3474
* #3473
* #3472
* #3471
* #3470
* #3469
* __->__ #3468
* #3467
* #3466

Some CI jobs can fail with "OS file watch limit reached" when running
buck2. This section should reduce the number of files that it tries to
watch.

Differential Revision: [D56857491](https://our.internmc.facebook.com/intern/diff/D56857491)