### PR TITLE
Don't recurse submodules when building wheels

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -50,6 +50,10 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      # ExecuTorch only needs the first layer of submodules; override the
+      # "recursive" default to do less work, and to give the buck daemon fewer
+      # files to look at.
+      submodules: true
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -50,6 +50,10 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      # ExecuTorch only needs the first layer of submodules; override the
+      # "recursive" default to do less work, and to give the buck daemon fewer
+      # files to look at.
+      submodules: true
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3477
* #3476
* #3475
* #3474
* #3473
* #3472
* #3471
* #3470
* __->__ #3469
* #3468
* #3467
* #3466

Change the build-wheels workflow to only fetch the first layer of
submodules. ExecuTorch only needs the first layer of submodules to
build its pip package, but the `build_wheels_*.yaml` workflows will
recursively fetch all submodules by default.

Fetching all submodules can also cause `buck2` to fail because it will
try to watch too many files.

This change makes `buck2` work on the CI runners, speeds up the jobs,
and reduces disk/network usage.

Differential Revision: [D56857487](https://our.internmc.facebook.com/intern/diff/D56857487)