### PR TITLE
Build pybindings and link in backends when building pip wheels

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -54,6 +54,7 @@ jobs:
       # "recursive" default to do less work, and to give the buck daemon fewer
       # files to look at.
       submodules: true
+      env-var-script: build/packaging/env_var_script_linux.sh
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -54,6 +54,7 @@ jobs:
       # "recursive" default to do less work, and to give the buck daemon fewer
       # files to look at.
       submodules: true
+      env-var-script: build/packaging/env_var_script_m1.sh
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}

--- a/build/packaging/env_var_script_linux.sh
+++ b/build/packaging/env_var_script_linux.sh
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This file is sourced into the environment before building a pip wheel. It
+# should typically only contain shell variable assignments. Be sure to export
+# any variables so that subprocesses will see them.
+
+# Enable pybindings so that users can execute ExecuTorch programs from python.
+export EXECUTORCH_BUILD_PYBIND=1
+
+# Ensure that CMAKE_ARGS is defined before referencing it. Defaults to empty
+# if not defined.
+export CMAKE_ARGS="${CMAKE_ARGS:-}"
+
+# Link the XNNPACK backend into the pybindings runtime so that users can execute
+# ExecuTorch programs that delegate to it.
+CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_XNNPACK=ON"

--- a/build/packaging/env_var_script_m1.sh
+++ b/build/packaging/env_var_script_m1.sh
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This file is sourced into the environment before building a pip wheel. It
+# should typically only contain shell variable assignments. Be sure to export
+# any variables so that subprocesses will see them.
+
+# Enable pybindings so that users can execute ExecuTorch programs from python.
+export EXECUTORCH_BUILD_PYBIND=1
+
+# Ensure that CMAKE_ARGS is defined before referencing it. Defaults to empty
+# if not defined.
+export CMAKE_ARGS="${CMAKE_ARGS:-}"
+
+# Link the XNNPACK backend into the pybindings runtime so that users can execute
+# ExecuTorch programs that delegate to it.
+CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_XNNPACK=ON"
+
+# When building for macOS, link additional backends into the pybindings runtime.
+
+# TODO(dbort): Make these build properly in the CI environment.
+# CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_COREML=ON"
+# CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_MPS=ON"

--- a/setup.py
+++ b/setup.py
@@ -85,11 +85,6 @@ class ShouldBuild:
 
     @classmethod
     @property
-    def xnnpack(cls) -> bool:
-        return cls._is_env_enabled("EXECUTORCH_BUILD_XNNPACK", default=False)
-
-    @classmethod
-    @property
     def llama_custom_ops(cls) -> bool:
         return cls._is_env_enabled("EXECUTORCH_BUILD_CUSTOM_OPS_AOT", default=True)
 
@@ -384,13 +379,9 @@ class CustomBuild(build):
                 "-DEXECUTORCH_BUILD_QUANTIZED=ON",  # add quantized ops to pybindings.
             ]
             build_args += ["--target", "portable_lib"]
-            if ShouldBuild.xnnpack:
-                cmake_args += [
-                    "-DEXECUTORCH_BUILD_XNNPACK=ON",
-                ]
-                # No target needed; the cmake arg will link xnnpack
-                # into the portable_lib target.
-            # TODO(dbort): Add MPS/CoreML backends when building on macos.
+            # To link backends into the portable_lib target, callers should
+            # add entries like `-DEXECUTORCH_BUILD_XNNPACK=ON` to the CMAKE_ARGS
+            # environment variable.
 
         if ShouldBuild.llama_custom_ops:
             cmake_args += [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3477
* #3476
* #3475
* #3474
* #3473
* #3472
* #3471
* __->__ #3470
* #3469
* #3468
* #3467
* #3466

Always build the pybindings when building the pip wheel.

Always link in XNNPACK.

Differential Revision: [D56857488](https://our.internmc.facebook.com/intern/diff/D56857488)