### PR TITLE
Build pybindings with -D_GLIBCXX_USE_CXX11_ABI=0 to match libtorch.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,9 +575,14 @@ if(EXECUTORCH_BUILD_PYBIND)
     list(APPEND _dep_libs custom_ops)
   endif()
   # compile options for pybind
-
-  set(_pybind_compile_options -Wno-deprecated-declarations -fPIC -frtti
-                              -fexceptions)
+  set(_pybind_compile_options
+      -Wno-deprecated-declarations
+      -fPIC
+      -frtti
+      -fexceptions
+      # libtorch is built with the old ABI, so we need to do the same for any
+      # .cpp files that include torch, c10, or ATen targets.
+      -D_GLIBCXX_USE_CXX11_ABI=0)
   # util lib
   add_library(
     util


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3477
* #3476
* #3475
* #3474
* #3473
* #3472
* __->__ #3471
* #3470
* #3469
* #3468
* #3467
* #3466

libtorch.so builds with the old glibc ABI, so we need to as well,
for any source files that include torch headers.

Differential Revision: [D56857493](https://our.internmc.facebook.com/intern/diff/D56857493)