### PR TITLE
Dynamically determine the version of the pip package.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "executorch"
-# TODO(dbort): Use setuptools-git-versioning or setuptools-scm to get the
-# version from the git branch state. For now, use a version that doesn't look
-# like a real release.
-version = "0.2.1.dev0+unknown"
+dynamic = [
+  # setup.py will set the version.
+  'version',
+]
 # Python dependencies required for development
 dependencies=[
   "expecttest",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3477
* #3476
* __->__ #3475
* #3474
* #3473
* #3472
* #3471
* #3470
* #3469
* #3468
* #3467
* #3466

Use the logic from
https://github.com/pytorch/torcharrow/blob/15a7f7124d4c73c8c541547aef072264baab63b7/setup.py#L21
to play nicely with the pytorch ecosystem CI build environment.

Test Plan:
```
$ ./install_requirements.sh
...
Successfully installed executorch-0.2.0a0+1ba292a

$ python
>>> from executorch import version
>>> version.__version__
'0.2.0a0+1ba292a'
>>> version.git_version
'1ba292ae4071c4eede8ea14e8f10ffd973a085b4'
>>> ^D

$ grep Version /home/dbort/.conda/envs/executorch-tmp/lib/python3.10/site-packages/executorch-0.2.0a0+1ba292a.dist-info/METADATA
Metadata-Version: 2.1
Version: 0.2.0a0+1ba292a
```

Temporarily commented out the call to `setup()` in `setup.py` then
imported it.

```
$ python
>>> from setup import Version
>>> Version.string
'0.2.0a0+1ba292a'
>>> Version.git_hash
'1ba292ae4071c4eede8ea14e8f10ffd973a085b4'
>>> Version.write_to_python_file("/tmp/version.py")
>>> ^D
$ cat /tmp/version.py
from typing import Optional
__all__ = ["__version__", "git_version"]
__version__ = "0.2.0a0+1ba292a"
git_version: Optional[str] = '1ba292ae4071c4eede8ea14e8f10ffd973a085b4'
```

```
$ BUILD_VERSION="5.5.5" python
>>> from setup import Version
>>> Version.string
'5.5.5'
```

Differential Revision: [D56857484](https://our.internmc.facebook.com/intern/diff/D56857484)