### PR TITLE
Audit and update the pip package metadata

### DIFF
--- a/README-wheel.md
+++ b/README-wheel.md
@@ -1,0 +1,39 @@
+**ExecuTorch** is a [PyTorch](https://pytorch.org/) platform that provides
+infrastructure to run PyTorch programs everywhere from AR/VR wearables to
+standard on-device iOS and Android mobile deployments. One of the main goals for
+ExecuTorch is to enable wider customization and deployment capabilities of the
+PyTorch programs.
+
+The `executorch` pip package is in alpha.
+* Supported python versions: 3.10, 3.11
+* Compatible systems: Linux x86_64, macOS aarch64
+
+The prebuilt `executorch.extension.pybindings.portable_lib` module included in
+this package provides a way to run ExecuTorch `.pte` files, with some
+restrictions:
+* Only [core ATen
+  operators](https://pytorch.org/executorch/stable/ir-ops-set-definition.html)
+  are linked into the prebuilt module
+* Only the [XNNPACK backend
+  delegate](https://pytorch.org/executorch/main/native-delegates-executorch-xnnpack-delegate.html)
+  is linked into the prebuilt module
+
+Please visit the [ExecuTorch website](https://pytorch.org/executorch/) for
+tutorials and documentation. Here are some starting points:
+* [Getting
+  Started](https://pytorch.org/executorch/stable/getting-started-setup.html)
+  * Set up the ExecuTorch environment and run PyTorch models locally.
+* [Working with
+  local LLMs](https://pytorch.org/executorch/stable/llm/getting-started.html)
+  * Learn how to use ExecuTorch to export and accelerate a large-language model
+    from scratch.
+* [Exporting to
+  ExecuTorch](https://pytorch.org/executorch/main/tutorials/export-to-executorch-tutorial.html)
+  * Learn the fundamentals of exporting a PyTorch `nn.Module` to ExecuTorch, and
+    optimizing its performance using quantization and hardware delegation.
+* Running LLaMA on
+  [iOS](https://pytorch.org/executorch/stable/llm/llama-demo-ios.html) and
+  [Android](https://pytorch.org/executorch/stable/llm/llama-demo-android.html)
+  devices.
+  * Build and run LLaMA in a demo mobile app, and learn how to integrate models
+    with your own apps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,37 @@ dynamic = [
   # setup.py will set the version.
   'version',
 ]
-# Python dependencies required for development
+description = "On-device AI across mobile, embedded and edge for PyTorch"
+readme = "README-wheel.md"
+authors = [
+  {name="PyTorch Team", email="packages@pytorch.org"},
+]
+license = {file = "LICENSE"}
+keywords = ["pytorch", "machine learning"]
+# PyPI package information.
+classifiers = [
+    # How mature is this project? Common values are
+    #   3 - Alpha
+    #   4 - Beta
+    #   5 - Production/Stable
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: C++",
+    "Programming Language :: Python :: 3",
+    # Update this as we support more versions of python.
+    "Programming Language :: Python :: 3.10",
+]
+
+# Python dependencies required for use.
 dependencies=[
   "expecttest",
   "flatbuffers",
@@ -31,6 +61,13 @@ dependencies=[
   "sympy",
   "tabulate",
 ]
+
+[project.urls]
+# The keys are arbitrary but will be visible on PyPI.
+Homepage = "https://pytorch.org/executorch/"
+Repository = "https://github.com/pytorch/executorch"
+Issues = "https://github.com/pytorch/executorch/issues"
+Changelog = "https://github.com/pytorch/executorch/releases"
 
 # Tell setuptools to generate commandline wrappers for tools that we install
 # under data/bin in the pip package. This will put these commands on the user's


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3477
* __->__ #3476
* #3475
* #3474
* #3473
* #3472
* #3471
* #3470
* #3469
* #3468
* #3467
* #3466

Fill out the recommended `project` keys, most of which will affect the
web page that PyPI will render for the `executorch` package.

See
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#about-your-project
for the latest guidance.

Use
https://github.com/pytorch/pytorch/blob/a21327e0b03cc18850a0608be2d9c5bd38fd4646/setup.py#L1394
as a guide for the actual values.

Add a README-wheel.md file that will be included in the wheel, and will
become the main page contents on PyPI.

Test Plan:
* Installed the package with `./install_requirements.sh`
* Looked at the files under ~/miniconda3/envs/executorch/lib/python3.10/site-packages/executorch-0.2.0a0+1a499e0.dist-info. METADATA and LICENSE both contain the new metadata.

Differential Revision: [D56857482](https://our.internmc.facebook.com/intern/diff/D56857482)