### PR TITLE
[ci] Look on pytorch servers when installing pip deps

### DIFF
--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -18,8 +18,11 @@ retry () {
 install_executorch() {
   which pip
   # Install executorch, this assumes that Executorch is checked out in the
-  # current directory
-  pip install . --no-build-isolation -v
+  # current directory. The --extra-index-url options tell pip to look on the
+  # pytorch servers for nightly and pre-release versions of torch packages.
+  pip install . --no-build-isolation -v \
+      --extra-index-url https://download.pytorch.org/whl/test/cpu \
+      --extra-index-url https://download.pytorch.org/whl/nightly/cpu
   # Just print out the list of packages for debugging
   pip list
 }

--- a/examples/models/llava_encoder/install_requirements.sh
+++ b/examples/models/llava_encoder/install_requirements.sh
@@ -5,6 +5,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+set -x
+
 # install llava from the submodule
 pip install --force-reinstall -e examples/third-party/LLaVA
 
@@ -19,4 +21,4 @@ pip install bitsandbytes -I
 # For example, torch version required from llava is older than ExecuTorch.
 # To make both work, recover ExecuTorch's original dependencies by rerunning
 # the install_requirements.sh.
-./install_requirements.sh
+bash -x ./install_requirements.sh

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -105,9 +105,12 @@ $PIP_EXECUTABLE install --extra-index-url "${TORCH_NIGHTLY_URL}" \
 
 #
 # Install executorch pip package. This also makes `flatc` available on the path.
+# The --extra-index-url may be necessary if pyproject.toml has a dependency on a
+# pre-release or nightly version of a torch package.
 #
 
 EXECUTORCH_BUILD_PYBIND="${EXECUTORCH_BUILD_PYBIND}" \
     CMAKE_ARGS="${CMAKE_ARGS}" \
     CMAKE_BUILD_ARGS="${CMAKE_BUILD_ARGS}" \
-    $PIP_EXECUTABLE install . --no-build-isolation -v
+    $PIP_EXECUTABLE install . --no-build-isolation -v \
+        --extra-index-url "${TORCH_URL}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3477
* #3476
* #3475
* #3474
* #3473
* #3472
* #3471
* #3470
* #3469
* #3468
* #3467
* #3466

When installing the executorch pip package for CI jobs, look on the
pytorch servers when resolving dependencies. This lets the executorch
package depend on pytorch pre-release and nightly versions.

Also run the llava setup with `-x` to make it easier to debug failures.

Differential Revision: [D56857486](https://our.internmc.facebook.com/intern/diff/D56857486)