### PR TITLE
Resolve compiler_flags to allow Mac build

### DIFF
--- a/backends/vulkan/runtime/api/Adapter.cpp
+++ b/backends/vulkan/runtime/api/Adapter.cpp
@@ -70,10 +70,10 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
       handle, &queue_family_count, queue_families.data());
 
   // Find the total number of compute queues
-  for (const VkQueueFamilyProperties& properties : queue_families) {
+  for (const VkQueueFamilyProperties& p : queue_families) {
     // Check if this family has compute capability
-    if (properties.queueFlags & VK_QUEUE_COMPUTE_BIT) {
-      num_compute_queues += properties.queueCount;
+    if (p.queueFlags & VK_QUEUE_COMPUTE_BIT) {
+      num_compute_queues += p.queueCount;
     }
   }
 }

--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -1,5 +1,8 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+def get_vulkan_compiler_flags():
+    return ["-Wno-missing-prototypes", "-Wno-global-constructors"]
+
 def vulkan_spv_shader_lib(name, spv_filegroups, is_fbcode = False):
     gen_vulkan_spv_target = "//executorch/backends/vulkan:gen_vulkan_spv_bin"
     glslc_path = "//caffe2/fb/vulkan/dotslash:glslc"
@@ -36,6 +39,7 @@ def vulkan_spv_shader_lib(name, spv_filegroups, is_fbcode = False):
         srcs = [
             ":{}[{}.cpp]".format(genrule_name, name),
         ],
+        compiler_flags = get_vulkan_compiler_flags(),
         define_static_target = False,
         # Static initialization is used to register shaders to the global shader registry,
         # therefore link_whole must be True to make sure unused symbols are not discarded.
@@ -146,6 +150,7 @@ def define_common_targets(is_fbcode = False):
 
     runtime.cxx_library(
         name = "vulkan_compute_api",
+        compiler_flags = get_vulkan_compiler_flags(),
         srcs = native.glob([
             "runtime/api/*.cpp",
         ]),
@@ -165,6 +170,7 @@ def define_common_targets(is_fbcode = False):
         srcs = native.glob([
             "runtime/graph/**/*.cpp",
         ]),
+        compiler_flags = get_vulkan_compiler_flags(),
         exported_headers = native.glob([
             "runtime/graph/**/*.h",
         ]),
@@ -191,6 +197,7 @@ def define_common_targets(is_fbcode = False):
         srcs = native.glob([
             "runtime/*.cpp",
         ]),
+        compiler_flags = get_vulkan_compiler_flags(),
         headers = native.glob([
             "runtime/*.h",
         ]),


### PR DESCRIPTION
## `-Wglobal-constructors`

In ET-Vulkan, we use global constructors without global destructors.

Example: [`auto cls = VulkanBackend();`](https://github.com/pytorch/executorch/blob/3a253e96baa89e5a5434e91a236df63d54e0949e/backends/vulkan/runtime/VulkanBackend.cpp#L511-L513)
```
xplat/executorch/backends/vulkan/runtime/VulkanBackend.cpp:511:6: error: declaration requires a global destructor [-Werror,-Wglobal-constructors]
auto cls = VulkanBackend();
     ^
```

On Mac, this results in a `-Wglobal-constructors` warning, which is disabled in this change.


## `-Wmissing-prototypes`
## `-Wshadow`

Same as https://github.com/pytorch/pytorch/pull/125361

Differential Revision: D56860764
