### PR TITLE
fix the temp allocator for backend

### DIFF
--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -1063,7 +1063,9 @@ Error Method::execute_instruction() {
           delegate_idx,
           n_delegate_,
           step_state_.instr_idx);
-      BackendExecutionContext backend_execution_context(event_tracer_);
+      BackendExecutionContext backend_execution_context(
+          /*event_tracer*/ event_tracer_,
+          /*temp_allocator*/ memory_manager_->temp_allocator());
       err = delegates_[delegate_idx].Execute(
           backend_execution_context,
           chain.argument_lists_[step_state_.instr_idx].data());


### PR DESCRIPTION
Summary: Seems like forget to pass temp allocator to `BackendExecutionContext`...

Differential Revision: D56893727
