### PR TITLE
Change custom_skip_targets meaning for constant_prop_pass

### DIFF
--- a/exir/passes/constant_prop_pass.py
+++ b/exir/passes/constant_prop_pass.py
@@ -112,11 +112,11 @@ def get_propagated_const_tensor_dict(
     # Initialize dict with all constant placeholders.
     const_node_to_tensor = get_constant_placeholder_dict(exported_program)
 
-    all_skip_targets: set[EdgeOpOverload] = set()
-    # Default set of targets to skip.
-    all_skip_targets.update(_DEFAULT_SKIP_TARGETS)
     if custom_skip_targets is not None:
-        all_skip_targets.update(custom_skip_targets)
+        all_skip_targets = custom_skip_targets
+    else:
+        # Default set of targets to skip.
+        all_skip_targets = _DEFAULT_SKIP_TARGETS
 
     for node in exported_program.graph.nodes:
         if node.op != "call_function" or node.target in all_skip_targets:


### PR DESCRIPTION
Summary:
Some users of `constant_prop_pass` want to fold across calls to
`full`, because representing a tensor as a program constant is a requirement
for some backends.
This came up when writing some tests using `torch.ones` as a weight tensor,
which is represented as `aten.full` in Edge Dialect.

When the user specifies a custom skip set, do *not* add the default `aten.full`
function, in case the user doesn't want it.

Differential Revision: D56894215
