### PR TITLE
Pin the setuptools version in pre_build_script.sh

### DIFF
--- a/build/packaging/pre_build_script.sh
+++ b/build/packaging/pre_build_script.sh
@@ -17,7 +17,7 @@ readonly BUILD_DEPS=(
   # This list must match the build-system.requires list from pyproject.toml.
   "cmake"
   "pyyaml"
-  "setuptools"
+  "setuptools>=63"
   "tomli"
   "wheel"
   "zstd"


### PR DESCRIPTION
Reflects the pinned version in install_requirements.sh and pyproject.toml.