### PR TITLE
make quantized model tests better

### DIFF
--- a/backends/xnnpack/test/models/deeplab_v3.py
+++ b/backends/xnnpack/test/models/deeplab_v3.py
@@ -25,7 +25,7 @@ class DL3Wrapper(torch.nn.Module):
 class TestDeepLabV3(unittest.TestCase):
     dl3 = DL3Wrapper()
     dl3 = dl3.eval()
-    model_inputs = (torch.ones(1, 3, 224, 224),)
+    model_inputs = (torch.randn(1, 3, 224, 224),)
 
     def test_fp32_dl3(self):
 

--- a/backends/xnnpack/test/models/edsr.py
+++ b/backends/xnnpack/test/models/edsr.py
@@ -15,7 +15,7 @@ from torchsr.models import edsr_r16f64
 
 class TestEDSR(unittest.TestCase):
     edsr = edsr_r16f64(2, False).eval()  # noqa
-    model_inputs = (torch.ones(1, 3, 224, 224),)
+    model_inputs = (torch.randn(1, 3, 224, 224),)
 
     def test_fp32_edsr(self):
         (
@@ -28,7 +28,21 @@ class TestEDSR(unittest.TestCase):
             .run_method_and_compare_outputs()
         )
 
+    @unittest.skip("T187799178: Debugging Numerical Issues with Calibration")
     def test_qs8_edsr(self):
+        (
+            Tester(self.edsr, self.model_inputs)
+            .quantize()
+            .export()
+            .to_edge()
+            .partition()
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    # TODO: Delete and only used calibrated test after T187799178
+    def test_qs8_edsr_no_calibrate(self):
         (
             Tester(self.edsr, self.model_inputs)
             .quantize(Quantize(calibrate=False))

--- a/backends/xnnpack/test/models/emformer_rnnt.py
+++ b/backends/xnnpack/test/models/emformer_rnnt.py
@@ -57,7 +57,9 @@ class TestEmformerModel(unittest.TestCase):
             )
             return predict_inputs
 
-    @unittest.skip("T183426271")
+    @unittest.skip(
+        "T183426271: Emformer Predictor Takes too long to export + partition"
+    )
     def test_fp32_emformer_predictor(self):
         predictor = self.Predictor()
         (

--- a/backends/xnnpack/test/models/inception_v3.py
+++ b/backends/xnnpack/test/models/inception_v3.py
@@ -15,7 +15,7 @@ from torchvision import models
 class TestInceptionV3(unittest.TestCase):
     # pyre-ignore
     ic3 = models.inception_v3(weights="IMAGENET1K_V1").eval()  # noqa
-    model_inputs = (torch.ones(1, 3, 224, 224),)
+    model_inputs = (torch.randn(1, 3, 224, 224),)
 
     all_operators = {
         "executorch_exir_dialects_edge__ops_aten_addmm_default",
@@ -45,7 +45,29 @@ class TestInceptionV3(unittest.TestCase):
             .run_method_and_compare_outputs()
         )
 
+    @unittest.skip("T187799178: Debugging Numerical Issues with Calibration")
     def test_qs8_ic3(self):
+        # Quantization fuses away batchnorm, so it is no longer in the graph
+        ops_after_quantization = self.all_operators - {
+            "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
+        }
+
+        (
+            Tester(self.ic3, self.model_inputs)
+            .quantize()
+            .export()
+            .to_edge()
+            .check(list(ops_after_quantization))
+            .partition()
+            .check(["torch.ops.higher_order.executorch_call_delegate"])
+            .check_not(list(ops_after_quantization))
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    # TODO: Delete and only used calibrated test after T187799178
+    def test_qs8_ic3_no_calibration(self):
         # Quantization fuses away batchnorm, so it is no longer in the graph
         ops_after_quantization = self.all_operators - {
             "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",

--- a/backends/xnnpack/test/models/inception_v4.py
+++ b/backends/xnnpack/test/models/inception_v4.py
@@ -13,7 +13,7 @@ from timm.models import inception_v4
 
 class TestInceptionV4(unittest.TestCase):
     ic4 = inception_v4(pretrained=False).eval()
-    model_inputs = (torch.ones(3, 299, 299).unsqueeze(0),)
+    model_inputs = (torch.randn(3, 299, 299).unsqueeze(0),)
 
     all_operators = {
         "executorch_exir_dialects_edge__ops_aten_addmm_default",

--- a/backends/xnnpack/test/models/llama2_et_example.py
+++ b/backends/xnnpack/test/models/llama2_et_example.py
@@ -45,5 +45,5 @@ class TestLlama2ETExample(unittest.TestCase):
             .dump_artifact()
             .to_executorch()
             .serialize()
-            .run_method_and_compare_outputs(atol=5e-2)
+            .run_method_and_compare_outputs(atol=5e-2, inputs=example_inputs)
         )

--- a/backends/xnnpack/test/models/mobilebert.py
+++ b/backends/xnnpack/test/models/mobilebert.py
@@ -38,5 +38,5 @@ class TestMobilebert(unittest.TestCase):
             .check_not(list(self.supported_ops))
             .to_executorch()
             .serialize()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(inputs=self.example_inputs)
         )

--- a/backends/xnnpack/test/models/mobilenet_v2.py
+++ b/backends/xnnpack/test/models/mobilenet_v2.py
@@ -16,7 +16,7 @@ from torchvision.models.mobilenetv2 import MobileNet_V2_Weights
 class TestMobileNetV2(unittest.TestCase):
     mv2 = models.mobilenetv2.mobilenet_v2(weights=MobileNet_V2_Weights)
     mv2 = mv2.eval()
-    model_inputs = (torch.ones(1, 3, 224, 224),)
+    model_inputs = (torch.randn(1, 3, 224, 224),)
 
     all_operators = {
         "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
@@ -49,7 +49,36 @@ class TestMobileNetV2(unittest.TestCase):
             .run_method_and_compare_outputs(num_runs=10)
         )
 
+    @unittest.skip("T187799178: Debugging Numerical Issues with Calibration")
     def test_qs8_mv2(self):
+        # Quantization fuses away batchnorm, so it is no longer in the graph
+        ops_after_quantization = self.all_operators - {
+            "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
+        }
+
+        dynamic_shapes = (
+            {
+                2: torch.export.Dim("height", min=224, max=455),
+                3: torch.export.Dim("width", min=224, max=455),
+            },
+        )
+
+        (
+            Tester(self.mv2, self.model_inputs, dynamic_shapes=dynamic_shapes)
+            .quantize()
+            .export()
+            .to_edge()
+            .check(list(ops_after_quantization))
+            .partition()
+            .check(["torch.ops.higher_order.executorch_call_delegate"])
+            .check_not(list(ops_after_quantization))
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs(num_runs=10)
+        )
+
+    # TODO: Delete and only used calibrated test after T187799178
+    def test_qs8_mv2_no_calibration(self):
         # Quantization fuses away batchnorm, so it is no longer in the graph
         ops_after_quantization = self.all_operators - {
             "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",

--- a/backends/xnnpack/test/models/mobilenet_v3.py
+++ b/backends/xnnpack/test/models/mobilenet_v3.py
@@ -15,7 +15,7 @@ from torchvision import models
 class TestMobileNetV3(unittest.TestCase):
     mv3 = models.mobilenetv3.mobilenet_v3_small(pretrained=True)
     mv3 = mv3.eval()
-    model_inputs = (torch.ones(1, 3, 224, 224),)
+    model_inputs = (torch.randn(1, 3, 224, 224),)
     dynamic_shapes = (
         {
             2: torch.export.Dim("height", min=224, max=455),
@@ -51,7 +51,29 @@ class TestMobileNetV3(unittest.TestCase):
             .run_method_and_compare_outputs(num_runs=5)
         )
 
+    @unittest.skip("T187799178: Debugging Numerical Issues with Calibration")
     def test_qs8_mv3(self):
+        ops_after_quantization = self.all_operators - {
+            "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
+        }
+        ops_after_lowering = self.all_operators
+
+        (
+            Tester(self.mv3, self.model_inputs, dynamic_shapes=self.dynamic_shapes)
+            .quantize()
+            .export()
+            .to_edge()
+            .check(list(ops_after_quantization))
+            .partition()
+            .check(["torch.ops.higher_order.executorch_call_delegate"])
+            .check_not(list(ops_after_lowering))
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs(num_runs=5)
+        )
+
+    # TODO: Delete and only used calibrated test after T187799178
+    def test_qs8_mv3_no_calibration(self):
         ops_after_quantization = self.all_operators - {
             "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
         }

--- a/backends/xnnpack/test/models/torchvision_vit.py
+++ b/backends/xnnpack/test/models/torchvision_vit.py
@@ -14,7 +14,7 @@ from torchvision import models
 class TestViT(unittest.TestCase):
     vit = models.vision_transformer.vit_b_16(weights="IMAGENET1K_V1")
     vit = vit.eval()
-    model_inputs = (torch.ones(1, 3, 224, 224),)
+    model_inputs = (torch.randn(1, 3, 224, 224),)
     dynamic_shapes = (
         {
             2: torch.export.Dim("height", min=224, max=455),


### PR DESCRIPTION
Summary:
XNNPACK should be testing with random inputs and quantized models should be calibrated before lowering and testing. Right now there are some numerical issues being debugged and tracked by: T187799178. this has been a bit difficult, but for now, we can first make these tests better by giving random inptus and enabling calibration.  

We don't fix the numerical issues in this diff.

Differential Revision: D56906440


