### PR TITLE
Format all cmake files.

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,2 @@
+first_comment_is_literal: true
+dangle_parens: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@
 #
 # This file should be formatted with
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 # It should also be cmake-lint clean.
 #
@@ -71,7 +71,8 @@ else()
 endif()
 
 option(EXECUTORCH_ENABLE_LOGGING "Build with ET_LOG_ENABLED"
-       ${_default_release_disabled_options})
+       ${_default_release_disabled_options}
+)
 if(NOT EXECUTORCH_ENABLE_LOGGING)
   # Avoid pulling in the logging strings, which can be large. Note that this
   # will set the compiler flag for all targets in this directory, and for all
@@ -82,7 +83,8 @@ endif()
 # Configure log level. Must be one of debug, info, error, fatal.
 set(EXECUTORCH_LOG_LEVEL
     "Info"
-    CACHE STRING "Build with the given ET_MIN_LOG_LEVEL value")
+    CACHE STRING "Build with the given ET_MIN_LOG_LEVEL value"
+)
 string(TOLOWER "${EXECUTORCH_LOG_LEVEL}" LOG_LEVEL_LOWER)
 if(LOG_LEVEL_LOWER STREQUAL "debug")
   add_definitions(-DET_MIN_LOG_LEVEL=Debug)
@@ -96,12 +98,14 @@ else()
   message(
     SEND_ERROR
       "Unknown log level \"${EXECUTORCH_LOG_LEVEL}\". Expected one of Debug, "
-      + "Info, Error, or Fatal.")
+      + "Info, Error, or Fatal."
+  )
 endif()
 
 option(EXECUTORCH_ENABLE_PROGRAM_VERIFICATION
        "Build with ET_ENABLE_PROGRAM_VERIFICATION"
-       ${_default_release_disabled_options})
+       ${_default_release_disabled_options}
+)
 if(NOT EXECUTORCH_ENABLE_PROGRAM_VERIFICATION)
   # Avoid pulling in the flatbuffer data verification logic, which can add about
   # 20kB. Note that this will set the compiler flag for all targets in this
@@ -110,7 +114,8 @@ if(NOT EXECUTORCH_ENABLE_PROGRAM_VERIFICATION)
 endif()
 
 option(EXECUTORCH_ENABLE_EVENT_TRACER "Build with ET_EVENT_TRACER_ENABLED=ON"
-       OFF)
+       OFF
+)
 if(EXECUTORCH_ENABLE_EVENT_TRACER)
   add_definitions(-DET_EVENT_TRACER_ENABLED)
 endif()
@@ -119,7 +124,8 @@ endif()
 # they can be properly gc'd. -s: strip symbol. -fno-exceptions -fno-rtti:
 # disables exceptions and runtime type.
 set(CMAKE_CXX_FLAGS_RELEASE
-    "-ffunction-sections -fdata-sections -fno-exceptions -fno-rtti")
+    "-ffunction-sections -fdata-sections -fno-exceptions -fno-rtti"
+)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
 endif()
@@ -138,7 +144,8 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 option(EXECUTORCH_BUILD_ANDROID_JNI "Build Android JNI" OFF)
 
 option(EXECUTORCH_BUILD_ARM_BAREMETAL
-       "Build the Arm Baremetal flow for Cortex-M and Ethos-U" OFF)
+       "Build the Arm Baremetal flow for Cortex-M and Ethos-U" OFF
+)
 
 option(EXECUTORCH_BUILD_COREML "Build the Core ML backend" OFF)
 
@@ -147,12 +154,14 @@ option(EXECUTORCH_BUILD_CUSTOM "Build the custom kernels" OFF)
 option(EXECUTORCH_BUILD_CUSTOM_OPS_AOT "Build the custom ops lib for AOT" OFF)
 
 option(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER "Build the Data Loader extension"
-       OFF)
+       OFF
+)
 
 option(EXECUTORCH_BUILD_EXTENSION_MODULE "Build the Module extension" OFF)
 
 option(EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL "Build the Runner Util extension"
-       OFF)
+       OFF
+)
 
 option(EXECUTORCH_BUILD_GTESTS "Build googletest based test binaries" OFF)
 
@@ -179,13 +188,16 @@ option(EXECUTORCH_BUILD_VULKAN "Build the Vulkan backend" OFF)
 #
 cmake_dependent_option(
   EXECUTORCH_BUILD_PTHREADPOOL "Build pthreadpool library." ON
-  "NOT EXECUTORCH_BUILD_ARM_BAREMETAL" OFF)
+  "NOT EXECUTORCH_BUILD_ARM_BAREMETAL" OFF
+)
 
 #
 # cpuinfo: build cpuinfo library. Disable on unsupported platforms
 #
-cmake_dependent_option(EXECUTORCH_BUILD_CPUINFO "Build cpuinfo library." ON
-                       "NOT EXECUTORCH_BUILD_ARM_BAREMETAL" OFF)
+cmake_dependent_option(
+  EXECUTORCH_BUILD_CPUINFO "Build cpuinfo library." ON
+  "NOT EXECUTORCH_BUILD_ARM_BAREMETAL" OFF
+)
 
 if(EXECUTORCH_BUILD_CUSTOM_OPS_AOT)
   set(EXECUTORCH_BUILD_CUSTOM ON)
@@ -198,59 +210,74 @@ endif()
 if(EXECUTORCH_BUILD_CPUINFO)
   # --- cpuinfo
   set(ORIGINAL_CMAKE_POSITION_INDEPENDENT_CODE_FLAG
-      ${CMAKE_POSITION_INDEPENDENT_CODE})
+      ${CMAKE_POSITION_INDEPENDENT_CODE}
+  )
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   set(CPUINFO_SOURCE_DIR "backends/xnnpack/third-party/cpuinfo")
   set(CPUINFO_BUILD_TOOLS
       OFF
-      CACHE BOOL "")
+      CACHE BOOL ""
+  )
   set(CPUINFO_BUILD_UNIT_TESTS
       OFF
-      CACHE BOOL "")
+      CACHE BOOL ""
+  )
   set(CPUINFO_BUILD_MOCK_TESTS
       OFF
-      CACHE BOOL "")
+      CACHE BOOL ""
+  )
   set(CPUINFO_BUILD_BENCHMARKS
       OFF
-      CACHE BOOL "")
+      CACHE BOOL ""
+  )
   set(CPUINFO_LIBRARY_TYPE
       "static"
-      CACHE STRING "")
+      CACHE STRING ""
+  )
   set(CPUINFO_LOG_LEVEL
       "error"
-      CACHE STRING "")
+      CACHE STRING ""
+  )
   set(CLOG_SOURCE_DIR "${CPUINFO_SOURCE_DIR}/deps/clog")
   add_subdirectory("${CPUINFO_SOURCE_DIR}")
   set(CMAKE_POSITION_INDEPENDENT_CODE
-      ${ORIGINAL_CMAKE_POSITION_INDEPENDENT_CODE_FLAG})
+      ${ORIGINAL_CMAKE_POSITION_INDEPENDENT_CODE_FLAG}
+  )
 endif()
 
 if(EXECUTORCH_BUILD_PTHREADPOOL)
   # --- pthreadpool
   set(ORIGINAL_CMAKE_POSITION_INDEPENDENT_CODE_FLAG
-      ${CMAKE_POSITION_INDEPENDENT_CODE})
+      ${CMAKE_POSITION_INDEPENDENT_CODE}
+  )
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   set(PTHREADPOOL_SOURCE_DIR "backends/xnnpack/third-party/pthreadpool")
   set(PTHREADPOOL_BUILD_TESTS
       OFF
-      CACHE BOOL "")
+      CACHE BOOL ""
+  )
   set(PTHREADPOOL_BUILD_BENCHMARKS
       OFF
-      CACHE BOOL "")
+      CACHE BOOL ""
+  )
   set(PTHREADPOOL_LIBRARY_TYPE
       "static"
-      CACHE STRING "")
+      CACHE STRING ""
+  )
   set(PTHREADPOOL_ALLOW_DEPRECATED_API
       ON
-      CACHE BOOL "")
+      CACHE BOOL ""
+  )
   if(APPLE)
     set(PTHREADPOOL_SYNC_PRIMITIVE
-       "condvar"
-       CACHE STRING "")
+        "condvar"
+        CACHE STRING ""
+    )
   endif()
   add_subdirectory("${PTHREADPOOL_SOURCE_DIR}")
   set(CMAKE_POSITION_INDEPENDENT_CODE
-      ${ORIGINAL_CMAKE_POSITION_INDEPENDENT_CODE_FLAG})
+      ${ORIGINAL_CMAKE_POSITION_INDEPENDENT_CODE_FLAG}
+  )
 endif()
 
 if(NOT PYTHON_EXECUTABLE)
@@ -319,14 +346,18 @@ endif()
 # libraries that it uses, like `gflags`. Disabling this can be helpful when
 # cross-compiling, but some required tools that would have been built need to be
 # provided directly (via, for example, FLATC_EXECUTABLE).
-cmake_dependent_option(EXECUTORCH_BUILD_HOST_TARGETS "Build host-only targets."
-                       ON "NOT CMAKE_TOOLCHAIN_IOS" OFF)
+cmake_dependent_option(
+  EXECUTORCH_BUILD_HOST_TARGETS "Build host-only targets." ON
+  "NOT CMAKE_TOOLCHAIN_IOS" OFF
+)
 
 #
 # flatc: Flatbuffer commandline tool to generate .h files from .fbs files
 #
-cmake_dependent_option(EXECUTORCH_BUILD_FLATC "Build the flatc executable." ON
-                       "NOT FLATC_EXECUTABLE;EXECUTORCH_BUILD_HOST_TARGETS" OFF)
+cmake_dependent_option(
+  EXECUTORCH_BUILD_FLATC "Build the flatc executable." ON
+  "NOT FLATC_EXECUTABLE;EXECUTORCH_BUILD_HOST_TARGETS" OFF
+)
 
 if(EXECUTORCH_BUILD_FLATC)
   if(FLATC_EXECUTABLE)
@@ -339,19 +370,24 @@ if(EXECUTORCH_BUILD_FLATC)
   set(FLATC_EXECUTABLE flatc)
   set(FLATBUFFERS_BUILD_FLATC
       ON
-      CACHE BOOL "")
+      CACHE BOOL ""
+  )
   set(FLATBUFFERS_BUILD_FLATHASH
       OFF
-      CACHE BOOL "")
+      CACHE BOOL ""
+  )
   set(FLATBUFFERS_BUILD_FLATLIB
       OFF
-      CACHE BOOL "")
+      CACHE BOOL ""
+  )
   set(FLATBUFFERS_BUILD_TESTS
       OFF
-      CACHE BOOL "")
+      CACHE BOOL ""
+  )
   set(FLATBUFFERS_INSTALL
       OFF
-      CACHE BOOL "")
+      CACHE BOOL ""
+  )
   add_subdirectory(third-party/flatbuffers)
 endif()
 if(NOT FLATC_EXECUTABLE)
@@ -359,7 +395,8 @@ if(NOT FLATC_EXECUTABLE)
     FATAL_ERROR
       "FLATC_EXECUTABLE must be set when EXECUTORCH_BUILD_FLATC is disabled. "
       "Note that EXECUTORCH_BUILD_FLATC may be disabled implicitly when "
-      "cross-compiling or when EXECUTORCH_BUILD_HOST_TARGETS is disabled.")
+      "cross-compiling or when EXECUTORCH_BUILD_HOST_TARGETS is disabled."
+  )
 endif()
 
 #
@@ -381,11 +418,14 @@ find_library(DL_LIBRARY_EXISTS NAMES dl)
 if(DL_LIBRARY_EXISTS)
   target_link_libraries(executorch_no_prim_ops PRIVATE dl) # For dladdr()
 endif()
-target_include_directories(executorch_no_prim_ops PUBLIC ${_common_include_directories})
+target_include_directories(
+  executorch_no_prim_ops PUBLIC ${_common_include_directories}
+)
 target_compile_options(executorch_no_prim_ops PUBLIC ${_common_compile_options})
 if(MAX_KERNEL_NUM)
-  target_compile_definitions(executorch_no_prim_ops
-                             PRIVATE MAX_KERNEL_NUM=${MAX_KERNEL_NUM})
+  target_compile_definitions(
+    executorch_no_prim_ops PRIVATE MAX_KERNEL_NUM=${MAX_KERNEL_NUM}
+  )
 endif()
 
 add_library(executorch ${_executorch__srcs})
@@ -406,7 +446,8 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/kernels/portable)
 if(EXECUTORCH_BUILD_CUSTOM)
   # TODO: move all custom kernels to ${CMAKE_CURRENT_SOURCE_DIR}/kernels/custom
   add_subdirectory(
-    ${CMAKE_CURRENT_SOURCE_DIR}/examples/models/llama2/custom_ops)
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/models/llama2/custom_ops
+  )
 endif()
 
 if(EXECUTORCH_BUILD_OPTIMIZED)
@@ -422,8 +463,10 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/configurations)
 #
 # gflags: Commandline flag host library.
 #
-cmake_dependent_option(EXECUTORCH_BUILD_GFLAGS "Build the gflags library." ON
-                       EXECUTORCH_BUILD_HOST_TARGETS OFF)
+cmake_dependent_option(
+  EXECUTORCH_BUILD_GFLAGS "Build the gflags library." ON
+  EXECUTORCH_BUILD_HOST_TARGETS OFF
+)
 if(EXECUTORCH_BUILD_GFLAGS)
   add_subdirectory(third-party/gflags)
 endif()
@@ -434,7 +477,8 @@ install(
   TARGETS executorch executorch_no_prim_ops
   DESTINATION lib
   INCLUDES
-  DESTINATION ${_common_include_directories})
+  DESTINATION ${_common_include_directories}
+)
 install(FILES build/executorch-config.cmake DESTINATION lib/cmake/ExecuTorch)
 
 #
@@ -442,7 +486,8 @@ install(FILES build/executorch-config.cmake DESTINATION lib/cmake/ExecuTorch)
 #
 cmake_dependent_option(
   EXECUTORCH_BUILD_EXECUTOR_RUNNER "Build the executor_runner executable" ON
-  EXECUTORCH_BUILD_HOST_TARGETS OFF)
+  EXECUTORCH_BUILD_HOST_TARGETS OFF
+)
 if(EXECUTORCH_BUILD_EXECUTOR_RUNNER)
   # Baseline libraries that executor_runner will link against.
   set(_executor_runner_libs executorch gflags)
@@ -474,7 +519,8 @@ endif()
 if(EXECUTORCH_BUILD_SDK)
   set(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER
       ON
-      CACHE BOOL "EXECUTORCH_BUILD_EXTENSION_DATA_LOADER" FORCE)
+      CACHE BOOL "EXECUTORCH_BUILD_EXTENSION_DATA_LOADER" FORCE
+  )
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sdk)
 endif()
 
@@ -531,8 +577,9 @@ if(EXECUTORCH_BUILD_PYBIND)
 
   # find pytorch lib, to allow pybind to take at::Tensor as input/output
   find_package(Torch CONFIG REQUIRED)
-  find_library(TORCH_PYTHON_LIBRARY torch_python
-               PATHS "${TORCH_INSTALL_PREFIX}/lib")
+  find_library(
+    TORCH_PYTHON_LIBRARY torch_python PATHS "${TORCH_INSTALL_PREFIX}/lib"
+  )
 
   set(_dep_libs
       ${TORCH_PYTHON_LIBRARY}
@@ -542,7 +589,8 @@ if(EXECUTORCH_BUILD_PYBIND)
       extension_data_loader
       portable_ops_lib
       util
-      torch)
+      torch
+  )
 
   if(EXECUTORCH_BUILD_COREML)
     list(APPEND _dep_libs coremldelegate)
@@ -582,15 +630,18 @@ if(EXECUTORCH_BUILD_PYBIND)
       -fexceptions
       # libtorch is built with the old ABI, so we need to do the same for any
       # .cpp files that include torch, c10, or ATen targets.
-      -D_GLIBCXX_USE_CXX11_ABI=0)
+      -D_GLIBCXX_USE_CXX11_ABI=0
+  )
   # util lib
   add_library(
     util
     ${CMAKE_CURRENT_SOURCE_DIR}/extension/evalue_util/print_evalue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/extension/aten_util/aten_bridge.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/util/read_file.cpp)
-  target_include_directories(util PUBLIC ${_common_include_directories}
-                                         ${TORCH_INCLUDE_DIRS})
+    ${CMAKE_CURRENT_SOURCE_DIR}/util/read_file.cpp
+  )
+  target_include_directories(
+    util PUBLIC ${_common_include_directories} ${TORCH_INCLUDE_DIRS}
+  )
   target_compile_options(util PUBLIC ${_pybind_compile_options})
   target_link_libraries(util PRIVATE torch c10 executorch)
 
@@ -599,8 +650,9 @@ if(EXECUTORCH_BUILD_PYBIND)
   # The actual output file needs a leading underscore so it can coexist with
   # portable_lib.py in the same python package.
   set_target_properties(portable_lib PROPERTIES OUTPUT_NAME "_portable_lib")
-  target_compile_definitions(portable_lib
-                             PUBLIC EXECUTORCH_PYTHON_MODULE_NAME=_portable_lib)
+  target_compile_definitions(
+    portable_lib PUBLIC EXECUTORCH_PYTHON_MODULE_NAME=_portable_lib
+  )
   target_include_directories(portable_lib PRIVATE ${TORCH_INCLUDE_DIRS})
   target_compile_options(portable_lib PUBLIC ${_pybind_compile_options})
   target_link_libraries(portable_lib PUBLIC ${_dep_libs})
@@ -620,11 +672,13 @@ if(EXECUTORCH_BUILD_PYBIND)
                  # `site-packages/executorch/extension/pybindings`, and that
                  # the torch libs are in `site-packages/torch/lib`.
                  BUILD_RPATH "@loader_path/../../../torch/lib"
-                 INSTALL_RPATH "@loader_path/../../../torch/lib")
+                 INSTALL_RPATH "@loader_path/../../../torch/lib"
+    )
   endif()
 
   install(TARGETS portable_lib
-          LIBRARY DESTINATION executorch/extension/pybindings)
+          LIBRARY DESTINATION executorch/extension/pybindings
+  )
 endif()
 
 # Print all summary

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -17,156 +17,131 @@ option(COREML_BUILD_EXECUTOR_RUNNER "Build CoreML executor runner." OFF)
 
 # inmemoryfs sources
 set(INMEMORYFS_SOURCES
-  runtime/inmemoryfs/inmemory_filesystem.cpp
-  runtime/inmemoryfs/inmemory_filesystem_utils.mm
-  runtime/inmemoryfs/memory_buffer.cpp
-  runtime/inmemoryfs/memory_stream.cpp
-  runtime/inmemoryfs/reversed_memory_stream.cpp
+    runtime/inmemoryfs/inmemory_filesystem.cpp
+    runtime/inmemoryfs/inmemory_filesystem_utils.mm
+    runtime/inmemoryfs/memory_buffer.cpp
+    runtime/inmemoryfs/memory_stream.cpp
+    runtime/inmemoryfs/reversed_memory_stream.cpp
 )
 
 # kvstore sources
 set(KVSTORE_SOURCES
-  runtime/kvstore/database.cpp
-  runtime/kvstore/json_key_value_store.cpp
-  runtime/kvstore/sqlite_error.cpp
-  runtime/kvstore/key_value_store.cpp
-  runtime/kvstore/statement.cpp
+    runtime/kvstore/database.cpp runtime/kvstore/json_key_value_store.cpp
+    runtime/kvstore/sqlite_error.cpp runtime/kvstore/key_value_store.cpp
+    runtime/kvstore/statement.cpp
 )
 
 # delegate sources
 set(DELEGATE_SOURCES
-  runtime/delegate/asset.mm
-  runtime/delegate/backend_delegate.mm
-  runtime/delegate/coreml_backend_delegate.mm
-  runtime/delegate/ETCoreMLAsset.mm
-  runtime/delegate/ETCoreMLAssetManager.mm
-  runtime/delegate/ETCoreMLDefaultModelExecutor.mm
-  runtime/delegate/ETCoreMLModelLoader.mm
-  runtime/delegate/ETCoreMLModelCompiler.mm
-  runtime/delegate/ETCoreMLLogging.mm
-  runtime/delegate/ETCoreMLModel.mm
-  runtime/delegate/ETCoreMLModelManager.mm
-  runtime/delegate/ETCoreMLStrings.mm
-  runtime/delegate/MLModel_Prewarm.mm
-  runtime/delegate/MLMultiArray_Copy.mm
-  runtime/delegate/multiarray.mm
-  runtime/delegate/serde_json.mm
+    runtime/delegate/asset.mm
+    runtime/delegate/backend_delegate.mm
+    runtime/delegate/coreml_backend_delegate.mm
+    runtime/delegate/ETCoreMLAsset.mm
+    runtime/delegate/ETCoreMLAssetManager.mm
+    runtime/delegate/ETCoreMLDefaultModelExecutor.mm
+    runtime/delegate/ETCoreMLModelLoader.mm
+    runtime/delegate/ETCoreMLModelCompiler.mm
+    runtime/delegate/ETCoreMLLogging.mm
+    runtime/delegate/ETCoreMLModel.mm
+    runtime/delegate/ETCoreMLModelManager.mm
+    runtime/delegate/ETCoreMLStrings.mm
+    runtime/delegate/MLModel_Prewarm.mm
+    runtime/delegate/MLMultiArray_Copy.mm
+    runtime/delegate/multiarray.mm
+    runtime/delegate/serde_json.mm
 )
 
 # util sources
-set(UTIL_SOURCES
-  runtime/util/json_util.cpp
-  runtime/util/objc_json_serde.mm
-)
+set(UTIL_SOURCES runtime/util/json_util.cpp runtime/util/objc_json_serde.mm)
 
 # sdk sources
 set(SDK_SOURCES
-  runtime/sdk/ETCoreMLModelAnalyzer.mm
-  runtime/sdk/ETCoreMLModelStructurePath.mm
-  runtime/sdk/ETCoreMLOperationProfilingInfo.mm
-  runtime/sdk/ETCoreMLModelDebugger.mm
-  runtime/sdk/ETCoreMLModelProfiler.mm
-  runtime/sdk/ETCoreMLPair.mm
-  runtime/sdk/model_package_info.mm
-  runtime/sdk/model_event_logger_impl.mm
-  runtime/sdk/program_path.mm
+    runtime/sdk/ETCoreMLModelAnalyzer.mm
+    runtime/sdk/ETCoreMLModelStructurePath.mm
+    runtime/sdk/ETCoreMLOperationProfilingInfo.mm
+    runtime/sdk/ETCoreMLModelDebugger.mm
+    runtime/sdk/ETCoreMLModelProfiler.mm
+    runtime/sdk/ETCoreMLPair.mm
+    runtime/sdk/model_package_info.mm
+    runtime/sdk/model_event_logger_impl.mm
+    runtime/sdk/program_path.mm
 )
 
 # protobuf sources
 set(PROTOBUF_SOURCES
-  runtime/sdk/format/ArrayFeatureExtractor.pb.cc
-  runtime/sdk/format/AudioFeaturePrint.pb.cc
-  runtime/sdk/format/BayesianProbitRegressor.pb.cc
-  runtime/sdk/format/CategoricalMapping.pb.cc
-  runtime/sdk/format/ClassConfidenceThresholding.pb.cc
-  runtime/sdk/format/CustomModel.pb.cc
-  runtime/sdk/format/DataStructures.pb.cc
-  runtime/sdk/format/DictVectorizer.pb.cc
-  runtime/sdk/format/FeatureTypes.pb.cc
-  runtime/sdk/format/FeatureVectorizer.pb.cc
-  runtime/sdk/format/Gazetteer.pb.cc
-  runtime/sdk/format/GLMClassifier.pb.cc
-  runtime/sdk/format/GLMRegressor.pb.cc
-  runtime/sdk/format/Identity.pb.cc
-  runtime/sdk/format/Imputer.pb.cc
-  runtime/sdk/format/ItemSimilarityRecommender.pb.cc
-  runtime/sdk/format/LinkedModel.pb.cc
-  runtime/sdk/format/MIL.pb.cc
-  runtime/sdk/format/Model.pb.cc
-  runtime/sdk/format/NearestNeighbors.pb.cc
-  runtime/sdk/format/NeuralNetwork.pb.cc
-  runtime/sdk/format/NonMaximumSuppression.pb.cc
-  runtime/sdk/format/Normalizer.pb.cc
-  runtime/sdk/format/NonMaximumSuppression.pb.cc
-  runtime/sdk/format/OneHotEncoder.pb.cc
-  runtime/sdk/format/Parameters.pb.cc
-  runtime/sdk/format/Scaler.pb.cc
-  runtime/sdk/format/SoundAnalysisPreprocessing.pb.cc
-  runtime/sdk/format/SVM.pb.cc
-  runtime/sdk/format/TextClassifier.pb.cc
-  runtime/sdk/format/TreeEnsemble.pb.cc
-  runtime/sdk/format/VisionFeaturePrint.pb.cc
-  runtime/sdk/format/WordEmbedding.pb.cc
-  runtime/sdk/format/WordTagger.pb.cc
+    runtime/sdk/format/ArrayFeatureExtractor.pb.cc
+    runtime/sdk/format/AudioFeaturePrint.pb.cc
+    runtime/sdk/format/BayesianProbitRegressor.pb.cc
+    runtime/sdk/format/CategoricalMapping.pb.cc
+    runtime/sdk/format/ClassConfidenceThresholding.pb.cc
+    runtime/sdk/format/CustomModel.pb.cc
+    runtime/sdk/format/DataStructures.pb.cc
+    runtime/sdk/format/DictVectorizer.pb.cc
+    runtime/sdk/format/FeatureTypes.pb.cc
+    runtime/sdk/format/FeatureVectorizer.pb.cc
+    runtime/sdk/format/Gazetteer.pb.cc
+    runtime/sdk/format/GLMClassifier.pb.cc
+    runtime/sdk/format/GLMRegressor.pb.cc
+    runtime/sdk/format/Identity.pb.cc
+    runtime/sdk/format/Imputer.pb.cc
+    runtime/sdk/format/ItemSimilarityRecommender.pb.cc
+    runtime/sdk/format/LinkedModel.pb.cc
+    runtime/sdk/format/MIL.pb.cc
+    runtime/sdk/format/Model.pb.cc
+    runtime/sdk/format/NearestNeighbors.pb.cc
+    runtime/sdk/format/NeuralNetwork.pb.cc
+    runtime/sdk/format/NonMaximumSuppression.pb.cc
+    runtime/sdk/format/Normalizer.pb.cc
+    runtime/sdk/format/NonMaximumSuppression.pb.cc
+    runtime/sdk/format/OneHotEncoder.pb.cc
+    runtime/sdk/format/Parameters.pb.cc
+    runtime/sdk/format/Scaler.pb.cc
+    runtime/sdk/format/SoundAnalysisPreprocessing.pb.cc
+    runtime/sdk/format/SVM.pb.cc
+    runtime/sdk/format/TextClassifier.pb.cc
+    runtime/sdk/format/TreeEnsemble.pb.cc
+    runtime/sdk/format/VisionFeaturePrint.pb.cc
+    runtime/sdk/format/WordEmbedding.pb.cc
+    runtime/sdk/format/WordTagger.pb.cc
 )
 
 # Define the delegate library
 add_library(coremldelegate)
 target_sources(
-  coremldelegate PRIVATE
-  ${INMEMORYFS_SOURCES}
-  ${KVSTORE_SOURCES}
-  ${DELEGATE_SOURCES}
-  ${UTIL_SOURCES}
+  coremldelegate PRIVATE ${INMEMORYFS_SOURCES} ${KVSTORE_SOURCES}
+                         ${DELEGATE_SOURCES} ${UTIL_SOURCES}
 )
 
 target_include_directories(
-  coremldelegate PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/runtime/include
+  coremldelegate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/include
 )
 target_include_directories(
-  coremldelegate PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/runtime/kvstore
+  coremldelegate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/kvstore
 )
 target_include_directories(
-  coremldelegate PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/runtime/inmemoryfs
+  coremldelegate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/inmemoryfs
 )
 target_include_directories(
-  coremldelegate PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/runtime/delegate
+  coremldelegate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/delegate
 )
 target_include_directories(
-  coremldelegate PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/runtime/util
+  coremldelegate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/util
 )
-target_include_directories(
-  coremldelegate PRIVATE
-  ${EXECUTORCH_ROOT}/..
-)
-target_link_libraries(
-  coremldelegate PRIVATE
-  executorch_no_prim_ops
-)
+target_include_directories(coremldelegate PRIVATE ${EXECUTORCH_ROOT}/..)
+target_link_libraries(coremldelegate PRIVATE executorch_no_prim_ops)
 
 if(EXECUTORCH_BUILD_SDK)
-target_sources(
-  coremldelegate PRIVATE
-  ${SDK_SOURCES}
-  ${PROTOBUF_SOURCES}
-)
-target_include_directories(
-  coremldelegate PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/runtime/sdk
-  ${CMAKE_CURRENT_SOURCE_DIR}/third-party/coremltools/deps/protobuf/src
-)
-add_subdirectory(
-  ${CMAKE_CURRENT_SOURCE_DIR}/third-party/coremltools/deps/protobuf/cmake
-)
-target_link_libraries(
-  coremldelegate PRIVATE
-  libprotobuf-lite
-)
+  target_sources(coremldelegate PRIVATE ${SDK_SOURCES} ${PROTOBUF_SOURCES})
+  target_include_directories(
+    coremldelegate
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtime/sdk
+      ${CMAKE_CURRENT_SOURCE_DIR}/third-party/coremltools/deps/protobuf/src
+  )
+  add_subdirectory(
+    ${CMAKE_CURRENT_SOURCE_DIR}/third-party/coremltools/deps/protobuf/cmake
+  )
+  target_link_libraries(coremldelegate PRIVATE libprotobuf-lite)
 endif()
 
 find_library(ACCELERATE_FRAMEWORK Accelerate)
@@ -174,45 +149,39 @@ find_library(COREML_FRAMEWORK CoreML)
 find_library(FOUNDATION_FRAMEWORK Foundation)
 find_library(SQLITE_LIBRARY sqlite3)
 
-target_link_libraries(coremldelegate
-  PRIVATE
-  executorch_no_prim_ops
-  ${ACCELERATE_FRAMEWORK}
-  ${COREML_FRAMEWORK}
-  ${FOUNDATION_FRAMEWORK}
-  ${SQLITE_LIBRARY}
+target_link_libraries(
+  coremldelegate
+  PRIVATE executorch_no_prim_ops ${ACCELERATE_FRAMEWORK} ${COREML_FRAMEWORK}
+          ${FOUNDATION_FRAMEWORK} ${SQLITE_LIBRARY}
 )
 
 if(COREML_BUILD_EXECUTOR_RUNNER)
-target_link_libraries(coremldelegate
-  PRIVATE
-  portable_ops_lib
-  portable_kernels
-)
+  target_link_libraries(
+    coremldelegate PRIVATE portable_ops_lib portable_kernels
+  )
 endif()
 
 target_compile_options(coremldelegate PRIVATE "-fobjc-arc")
 target_compile_options(coremldelegate PRIVATE "-fno-exceptions")
 
 if(EXECUTORCH_BUILD_SDK)
-target_compile_options(executorch_no_prim_ops PUBLIC -DET_EVENT_TRACER_ENABLED)
-target_compile_options(coremldelegate PRIVATE "-frtti")
-target_compile_options(libprotobuf-lite PRIVATE "-frtti")
+  target_compile_options(
+    executorch_no_prim_ops PUBLIC -DET_EVENT_TRACER_ENABLED
+  )
+  target_compile_options(coremldelegate PRIVATE "-frtti")
+  target_compile_options(libprotobuf-lite PRIVATE "-frtti")
 else()
-target_compile_options(coremldelegate PRIVATE "-fno-rtti")
+  target_compile_options(coremldelegate PRIVATE "-fno-rtti")
 endif()
 
-set(
-  TARGET coremldelegate
-  APPEND_STRING PROPERTY COMPILE_FLAGS "-x objective-c++"
+set(TARGET coremldelegate APPEND_STRING PROPERTY COMPILE_FLAGS
+           "-x objective-c++"
 )
 
-set(
-  TARGET coremldelegate
-  APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-null-character"
+set(TARGET coremldelegate APPEND_STRING PROPERTY COMPILE_FLAGS
+           "-Wno-null-character"
 )
 
-set(
-  TARGET coremldelegate
-  APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-receiver-expr"
+set(TARGET coremldelegate APPEND_STRING PROPERTY COMPILE_FLAGS
+           "-Wno-receiver-expr"
 )

--- a/backends/apple/mps/CMakeLists.txt
+++ b/backends/apple/mps/CMakeLists.txt
@@ -35,9 +35,11 @@ set(_mps_schema__include_dir "${CMAKE_BINARY_DIR}/schema/include")
 set(_mps_schema__outputs)
 foreach(fbs_file ${_mps_schema__srcs})
   string(REGEX REPLACE "serialization/([^/]+)[.]fbs$" "\\1_generated.h"
-                       generated "${fbs_file}")
+                       generated "${fbs_file}"
+  )
   list(APPEND _mps_schema__outputs
-       "${_mps_schema__include_dir}/executorch/${generated}")
+       "${_mps_schema__include_dir}/executorch/${generated}"
+  )
 endforeach()
 
 # Generate the headers from the .fbs files.
@@ -49,14 +51,17 @@ add_custom_command(
     ${_mps_schema__srcs}
   WORKING_DIRECTORY ${EXECUTORCH_ROOT}
   COMMENT "Generating mps_schema headers"
-  VERBATIM)
+  VERBATIM
+)
 
 add_library(mps_schema INTERFACE ${_mps_schema__outputs})
 set_target_properties(mps_schema PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(
-mps_schema INTERFACE ${_mps_schema__include_dir}
-                     ${EXECUTORCH_ROOT}/third-party/flatbuffers/include
-                     ${_common_include_directories})
+  mps_schema
+  INTERFACE ${_mps_schema__include_dir}
+            ${EXECUTORCH_ROOT}/third-party/flatbuffers/include
+            ${_common_include_directories}
+)
 
 list(TRANSFORM _mps_backend__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(mpsdelegate ${_mps_backend__srcs})
@@ -66,15 +71,15 @@ find_library(METAL_FRAMEWORK Metal)
 find_library(MPS_FRAMEWORK MetalPerformanceShaders)
 find_library(MPS_GRAPG_FRAMEWORK MetalPerformanceShadersGraph)
 
-target_link_libraries(mpsdelegate
-  PRIVATE
-  bundled_program
-  mps_schema
-  executorch_no_prim_ops
-  ${FOUNDATION_FRAMEWORK}
-  ${METAL_FRAMEWORK}
-  ${MPS_FRAMEWORK}
-  ${MPS_GRAPG_FRAMEWORK}
+target_link_libraries(
+  mpsdelegate
+  PRIVATE bundled_program
+          mps_schema
+          executorch_no_prim_ops
+          ${FOUNDATION_FRAMEWORK}
+          ${METAL_FRAMEWORK}
+          ${MPS_FRAMEWORK}
+          ${MPS_GRAPG_FRAMEWORK}
 )
 
 target_link_options_shared_lib(mpsdelegate)
@@ -84,4 +89,5 @@ install(
   TARGETS mpsdelegate
   DESTINATION lib
   INCLUDES
-  DESTINATION ${_common_include_directories})
+  DESTINATION ${_common_include_directories}
+)

--- a/backends/arm/CMakeLists.txt
+++ b/backends/arm/CMakeLists.txt
@@ -19,25 +19,17 @@ set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 # Third-party folder and Ethos-U driver inclued
 set(THIRD_PARTY_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/third-party")
 set(DRIVER_ETHOSU_INCLUDE_DIR "${THIRD_PARTY_ROOT}/ethos-u-core-driver/include")
-include_directories( ${DRIVER_ETHOSU_INCLUDE_DIR} )
+include_directories(${DRIVER_ETHOSU_INCLUDE_DIR})
 
-set(_arm_baremetal_sources
-  backends/arm/runtime/ArmBackendEthosU.cpp
-  backends/arm/runtime/VelaBinStream.cpp
+set(_arm_baremetal_sources backends/arm/runtime/ArmBackendEthosU.cpp
+                           backends/arm/runtime/VelaBinStream.cpp
 )
 list(TRANSFORM _arm_baremetal_sources PREPEND "${EXECUTORCH_ROOT}/")
 
-add_library(
-  executorch_delegate_ethos_u
-  STATIC ${_arm_baremetal_sources}
+add_library(executorch_delegate_ethos_u STATIC ${_arm_baremetal_sources})
+target_include_directories(
+  executorch_delegate_ethos_u PUBLIC ${_common_include_directories}
 )
 target_include_directories(
-  executorch_delegate_ethos_u
-  PUBLIC
-  ${_common_include_directories}
-)
-target_include_directories(
-  executorch_delegate_ethos_u
-  PUBLIC
-  ${DRIVER_ETHOSU_INCLUDE_DIR}
+  executorch_delegate_ethos_u PUBLIC ${DRIVER_ETHOSU_INCLUDE_DIR}
 )

--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -11,30 +11,31 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 #
 # get path
 #
-get_filename_component(EXECUTORCH_SOURCE_DIR
-                       "${CMAKE_CURRENT_LIST_DIR}/../.."
-                       ABSOLUTE)
-get_filename_component(QNN_EXECUTORCH_ROOT_DIR
-                       ${CMAKE_CURRENT_LIST_DIR}
-                       ABSOLUTE)
+get_filename_component(
+  EXECUTORCH_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE
+)
+get_filename_component(
+  QNN_EXECUTORCH_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR} ABSOLUTE
+)
 # Let files say "include <executorch/path/to/header.h>".
-get_filename_component(_common_include_directories
-                       "${EXECUTORCH_SOURCE_DIR}/.."
-                       ABSOLUTE)
+get_filename_component(
+  _common_include_directories "${EXECUTORCH_SOURCE_DIR}/.." ABSOLUTE
+)
 
 if(NOT DEFINED QNN_SDK_ROOT)
-    message(FATAL_ERROR
-            "Please define QNN_SDK_ROOT, e.g. cmake <..> -DQNN_SDK_ROOT=<...>")
+  message(
+    FATAL_ERROR
+      "Please define QNN_SDK_ROOT, e.g. cmake <..> -DQNN_SDK_ROOT=<...>"
+  )
 elseif(CMAKE_TOOLCHAIN_FILE MATCHES ".*ios\.toolchain\.cmake$")
-    message(FATAL_ERROR
-            "ios is not supported by Qualcomm AI Engine Direct")
+  message(FATAL_ERROR "ios is not supported by Qualcomm AI Engine Direct")
 endif()
 
 message(STATUS "Using qnn sdk root ${QNN_SDK_ROOT}")
 message(STATUS "Using EXECUTORCH_SOURCE_DIR ${EXECUTORCH_SOURCE_DIR}")
 
 if(${ANDROID})
-    find_library(android_log log)
+  find_library(android_log log)
 endif()
 
 if(NOT FLATC_EXECUTABLE)
@@ -45,56 +46,50 @@ set(qcir_schema_include_dir ${CMAKE_CURRENT_LIST_DIR}/aot/ir)
 set(qcir_schema_output ${qcir_schema_include_dir}/qcir_generated.h)
 add_custom_command(
   OUTPUT qcir_schema_output
-  COMMAND
-    ${FLATC_EXECUTABLE} --cpp --cpp-std c++11 --scoped-enums -o
-    ${qcir_schema_include_dir}
-    ${qcir_schema_include_dir}/qcir.fbs
+  COMMAND ${FLATC_EXECUTABLE} --cpp --cpp-std c++11 --scoped-enums -o
+          ${qcir_schema_include_dir} ${qcir_schema_include_dir}/qcir.fbs
   COMMENT "Generating qualcomm ir schema headers"
   VERBATIM
 )
 
 add_compile_options("-Wall" "-Werror" "-Wno-sign-compare")
 
-# GNU emit wanring for ignored attributes
-# Unfortunately, we use [[maybe_unused]] which can be ignored by GNU.
-# So we make it a warning, not an error in GNU.
+# GNU emit wanring for ignored attributes Unfortunately, we use [[maybe_unused]]
+# which can be ignored by GNU. So we make it a warning, not an error in GNU.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options("-Wno-error=attributes")
+  add_compile_options("-Wno-error=attributes")
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    # strip symbols
-    add_link_options("-s")
-    # hide dynamic symbols
-    set(CMAKE_C_VISIBILITY_PRESET hidden)
-    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+  # strip symbols
+  add_link_options("-s")
+  # hide dynamic symbols
+  set(CMAKE_C_VISIBILITY_PRESET hidden)
+  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
-    # --gc-sections is added by torch.
-    add_compile_options("-O3"
-                        "-ffunction-sections"
-                        "-fdata-sections"
-                        "-frtti"
-                        "-Wno-unused-command-line-argument")
+  # --gc-sections is added by torch.
+  add_compile_options(
+    "-O3" "-ffunction-sections" "-fdata-sections" "-frtti"
+    "-Wno-unused-command-line-argument"
+  )
 endif()
 
 include_directories(
-    BEFORE
-    ${_common_include_directories}
-    ${QNN_SDK_ROOT}/include/QNN
-    ${EXECUTORCH_SOURCE_DIR}/third-party/flatbuffers/include
+  BEFORE ${_common_include_directories} ${QNN_SDK_ROOT}/include/QNN
+  ${EXECUTORCH_SOURCE_DIR}/third-party/flatbuffers/include
 )
 
-set(_qnn_schema__srcs
-    backends/qualcomm/serialization/schema.fbs
-)
+set(_qnn_schema__srcs backends/qualcomm/serialization/schema.fbs)
 set(_qnn_schema__include_dir "${CMAKE_BINARY_DIR}/schema/include")
 # Paths to headers generated from the .fbs files.
 set(_qnn_schema__outputs)
 foreach(fbs_file ${_qnn_schema__srcs})
   string(REGEX REPLACE "serialization/([^/]+)[.]fbs$" "\\1_generated.h"
-                       generated "${fbs_file}")
+                       generated "${fbs_file}"
+  )
   list(APPEND _qnn_schema__outputs
-       "${_qnn_schema__include_dir}/executorch/${generated}")
+       "${_qnn_schema__include_dir}/executorch/${generated}"
+  )
 endforeach()
 
 # Generate the headers from the .fbs files.
@@ -106,13 +101,12 @@ add_custom_command(
     ${_qnn_schema__srcs}
   WORKING_DIRECTORY ${EXECUTORCH_SOURCE_DIR}
   COMMENT "Generating qnn_schema headers"
-  VERBATIM)
-
+  VERBATIM
+)
 
 include_directories(
-    BEFORE
-    ${_qnn_schema__include_dir}
-    ${EXECUTORCH_SOURCE_DIR}/third-party/flatbuffers/include
+  BEFORE ${_qnn_schema__include_dir}
+  ${EXECUTORCH_SOURCE_DIR}/third-party/flatbuffers/include
 )
 
 #
@@ -147,123 +141,56 @@ add_library(utils STATIC)
 #
 # declare dependency
 #
-target_link_libraries(qcir_utils
-    PRIVATE
-    qcir
+target_link_libraries(qcir_utils PRIVATE qcir)
+target_link_libraries(wrappers PRIVATE qnn_header qnn_executorch_logging)
+target_link_libraries(qnn_function_interface INTERFACE qnn_header)
+target_link_libraries(
+  qnn_implementation PRIVATE qnn_function_interface qnn_header
+                             qnn_executorch_logging ${CMAKE_DL_LIBS}
 )
-target_link_libraries(wrappers
-    PRIVATE
-    qnn_header
-    qnn_executorch_logging
+target_link_libraries(qnn_sys_function_interface INTERFACE qnn_header)
+target_link_libraries(
+  qnn_sys_implementation PRIVATE qnn_sys_function_interface qnn_header
+                                 qnn_executorch_logging ${CMAKE_DL_LIBS}
 )
-target_link_libraries(qnn_function_interface
-    INTERFACE
-    qnn_header
+target_link_libraries(qnn_executorch_logging PRIVATE qnn_schema)
+target_link_libraries(qnn_profiler PRIVATE qnn_executorch_logging)
+target_link_libraries(qnn_logger PRIVATE qnn_implementation ${android_log})
+target_link_libraries(qnn_backend PRIVATE qnn_implementation qnn_logger)
+target_link_libraries(
+  qnn_device PRIVATE qnn_executorch_logging qnn_implementation qnn_logger
 )
-target_link_libraries(qnn_implementation
-    PRIVATE
-    qnn_function_interface
-    qnn_header
-    qnn_executorch_logging
-    ${CMAKE_DL_LIBS}
+target_link_libraries(
+  qnn_backend_cache PRIVATE qnn_sys_implementation qcir_utils
 )
-target_link_libraries(qnn_sys_function_interface
-    INTERFACE
-    qnn_header
+target_link_libraries(
+  qnn_context PRIVATE qnn_implementation qnn_logger qnn_backend qnn_device
+                      qnn_backend_cache
 )
-target_link_libraries(qnn_sys_implementation
-    PRIVATE
-    qnn_sys_function_interface
-    qnn_header
-    qnn_executorch_logging
-    ${CMAKE_DL_LIBS}
+target_link_libraries(
+  qnn_graph PRIVATE qnn_executorch_logging qnn_implementation qnn_context
+                    qnn_profiler
 )
-target_link_libraries(qnn_executorch_logging
-    PRIVATE
-    qnn_schema
-)
-target_link_libraries(qnn_profiler
-    PRIVATE
-    qnn_executorch_logging
-)
-target_link_libraries(qnn_logger
-    PRIVATE
-    qnn_implementation
-    ${android_log}
-)
-target_link_libraries(qnn_backend
-    PRIVATE
-    qnn_implementation
-    qnn_logger
-)
-target_link_libraries(qnn_device
-    PRIVATE
-    qnn_executorch_logging
-    qnn_implementation
-    qnn_logger
-)
-target_link_libraries(qnn_backend_cache
-    PRIVATE
-    qnn_sys_implementation
-    qcir_utils
-)
-target_link_libraries(qnn_context
-    PRIVATE
-    qnn_implementation
-    qnn_logger
-    qnn_backend
-    qnn_device
-    qnn_backend_cache
-)
-target_link_libraries(qnn_graph
-    PRIVATE
-    qnn_executorch_logging
-    qnn_implementation
-    qnn_context
-    qnn_profiler
-)
-target_link_libraries(qnn_mem_manager
-    PRIVATE
-    qnn_executorch_logging
-    qnn_implementation
-    qnn_context
+target_link_libraries(
+  qnn_mem_manager PRIVATE qnn_executorch_logging qnn_implementation qnn_context
 )
 
-target_link_libraries(qnn_factory
-    PUBLIC
-    qnn_header
-    PRIVATE
-    qnn_schema
-    qnn_backend
-    qnn_device
-    qnn_context
-    qnn_graph
-    qnn_mem_manager
+target_link_libraries(
+  qnn_factory
+  PUBLIC qnn_header
+  PRIVATE qnn_schema qnn_backend qnn_device qnn_context qnn_graph
+          qnn_mem_manager
 )
-target_link_libraries(qnn_manager
-    PRIVATE
-    qnn_factory
-    wrappers
-    qnn_schema
-    utils
-    shared_buffer
+target_link_libraries(
+  qnn_manager PRIVATE qnn_factory wrappers qnn_schema utils shared_buffer
 )
-target_link_libraries(qnn_executorch_backend
-    PRIVATE
-    qnn_executorch_header
-    qnn_schema
-    qnn_manager
-    executorch_no_prim_ops
-    qcir_utils
+target_link_libraries(
+  qnn_executorch_backend PRIVATE qnn_executorch_header qnn_schema qnn_manager
+                                 executorch_no_prim_ops qcir_utils
 )
-target_link_libraries(utils
-    PRIVATE
-    qnn_executorch_logging
-)
-target_link_libraries(shared_buffer
-    PRIVATE
-    qnn_executorch_logging
-    ${CMAKE_DL_LIBS}
+target_link_libraries(utils PRIVATE qnn_executorch_logging)
+target_link_libraries(
+  shared_buffer PRIVATE qnn_executorch_logging ${CMAKE_DL_LIBS}
 )
 #
 # add linker option
@@ -275,68 +202,65 @@ target_link_options_shared_lib(qnn_executorch_backend)
 #
 target_compile_options(executorch PUBLIC -DET_EVENT_TRACER_ENABLED)
 
-
 #
 # add sources
 #
 add_subdirectory(
-    ${QNN_EXECUTORCH_ROOT_DIR}/runtime
-    ${CMAKE_CURRENT_BINARY_DIR}/qnn_executorch
+  ${QNN_EXECUTORCH_ROOT_DIR}/runtime ${CMAKE_CURRENT_BINARY_DIR}/qnn_executorch
 )
 add_subdirectory(
-    ${QNN_EXECUTORCH_ROOT_DIR}/runtime/backends
-    ${CMAKE_CURRENT_BINARY_DIR}/qnn_executorch/backends
+  ${QNN_EXECUTORCH_ROOT_DIR}/runtime/backends
+  ${CMAKE_CURRENT_BINARY_DIR}/qnn_executorch/backends
 )
 add_subdirectory(
-    ${QNN_EXECUTORCH_ROOT_DIR}/aot/wrappers
-    ${CMAKE_CURRENT_BINARY_DIR}/qnn_executorch/wrappers
+  ${QNN_EXECUTORCH_ROOT_DIR}/aot/wrappers
+  ${CMAKE_CURRENT_BINARY_DIR}/qnn_executorch/wrappers
 )
 add_subdirectory(
-    ${QNN_EXECUTORCH_ROOT_DIR}/aot/ir
-    ${CMAKE_CURRENT_BINARY_DIR}/qnn_executorch/ir
+  ${QNN_EXECUTORCH_ROOT_DIR}/aot/ir
+  ${CMAKE_CURRENT_BINARY_DIR}/qnn_executorch/ir
 )
 install(TARGETS qnn_executorch_backend DESTINATION lib)
 
 # QNN pybind
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
-    add_subdirectory(${EXECUTORCH_SOURCE_DIR}/third-party/pybind11
-                    ${CMAKE_CURRENT_BINARY_DIR}/pybind11)
-    add_library(PyQnnManagerAdaptor MODULE)
-    add_library(PyQnnWrapperAdaptor MODULE)
-    # PyQnnManager containing a pybind type triggers the warning
-    # because pybind11 code internally forces hidden visibility.
-    set_target_properties(PyQnnManagerAdaptor
-        PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  add_subdirectory(
+    ${EXECUTORCH_SOURCE_DIR}/third-party/pybind11
+    ${CMAKE_CURRENT_BINARY_DIR}/pybind11
+  )
+  add_library(PyQnnManagerAdaptor MODULE)
+  add_library(PyQnnWrapperAdaptor MODULE)
+  # PyQnnManager containing a pybind type triggers the warning because pybind11
+  # code internally forces hidden visibility.
+  set_target_properties(
+    PyQnnManagerAdaptor PROPERTIES CXX_VISIBILITY_PRESET hidden
+  )
 
-    target_link_libraries(PyQnnManagerAdaptor
-        PRIVATE
-        pybind11::module
-        pybind11::lto
-        qnn_schema
-        qnn_manager
-        qnn_executorch_header
-        executorch
-        qcir_utils
-    )
-    target_link_libraries(PyQnnWrapperAdaptor
-        PRIVATE
-        pybind11::module
-        pybind11::lto
-        wrappers
-        qnn_executorch_logging
-        qnn_executorch_header
-    )
+  target_link_libraries(
+    PyQnnManagerAdaptor
+    PRIVATE pybind11::module
+            pybind11::lto
+            qnn_schema
+            qnn_manager
+            qnn_executorch_header
+            executorch
+            qcir_utils
+  )
+  target_link_libraries(
+    PyQnnWrapperAdaptor PRIVATE pybind11::module pybind11::lto wrappers
+                                qnn_executorch_logging qnn_executorch_header
+  )
 
-    pybind11_extension(PyQnnManagerAdaptor)
-    pybind11_extension(PyQnnWrapperAdaptor)
-    if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
-        # Strip unnecessary sections of the binary
-        pybind11_strip(PyQnnManagerAdaptor)
-        pybind11_strip(PyQnnWrapperAdaptor)
-    endif()
+  pybind11_extension(PyQnnManagerAdaptor)
+  pybind11_extension(PyQnnWrapperAdaptor)
+  if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
+    # Strip unnecessary sections of the binary
+    pybind11_strip(PyQnnManagerAdaptor)
+    pybind11_strip(PyQnnWrapperAdaptor)
+  endif()
 
-    add_subdirectory(
-        ${QNN_EXECUTORCH_ROOT_DIR}/aot/python
-        ${CMAKE_CURRENT_BINARY_DIR}/qnn_executorch/python
-    )
+  add_subdirectory(
+    ${QNN_EXECUTORCH_ROOT_DIR}/aot/python
+    ${CMAKE_CURRENT_BINARY_DIR}/qnn_executorch/python
+  )
 endif()

--- a/backends/qualcomm/aot/ir/CMakeLists.txt
+++ b/backends/qualcomm/aot/ir/CMakeLists.txt
@@ -4,10 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 # QCIR
-target_sources(qcir_utils
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/qcir_utils.h
-    ${CMAKE_CURRENT_LIST_DIR}/qcir_utils.cpp
+target_sources(
+  qcir_utils PRIVATE ${CMAKE_CURRENT_LIST_DIR}/qcir_utils.h
+                     ${CMAKE_CURRENT_LIST_DIR}/qcir_utils.cpp
 )

--- a/backends/qualcomm/aot/python/CMakeLists.txt
+++ b/backends/qualcomm/aot/python/CMakeLists.txt
@@ -4,18 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 # PyQnnManagerAdaptor
-target_sources(PyQnnManagerAdaptor
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/PyQnnManagerAdaptor.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/PyQnnManagerAdaptor.h
+target_sources(
+  PyQnnManagerAdaptor PUBLIC ${CMAKE_CURRENT_LIST_DIR}/PyQnnManagerAdaptor.cpp
+                             ${CMAKE_CURRENT_LIST_DIR}/PyQnnManagerAdaptor.h
 )
 
 # PyQnnWrapperAdaptor
-target_sources(PyQnnWrapperAdaptor
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/PyQnnWrapperAdaptor.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/PyQnnWrapperAdaptor.h
+target_sources(
+  PyQnnWrapperAdaptor PUBLIC ${CMAKE_CURRENT_LIST_DIR}/PyQnnWrapperAdaptor.cpp
+                             ${CMAKE_CURRENT_LIST_DIR}/PyQnnWrapperAdaptor.h
 )
-

--- a/backends/qualcomm/aot/wrappers/CMakeLists.txt
+++ b/backends/qualcomm/aot/wrappers/CMakeLists.txt
@@ -5,16 +5,15 @@
 # LICENSE file in the root directory of this source tree.
 
 # wrappers
-target_sources(wrappers
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/TensorWrapper.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/TensorWrapper.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QuantizeParamsWrapper.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/QuantizeParamsWrapper.h
-    ${CMAKE_CURRENT_LIST_DIR}/OpWrapper.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/OpWrapper.h
-    ${CMAKE_CURRENT_LIST_DIR}/ParamWrapper.h
-    ${CMAKE_CURRENT_LIST_DIR}/ScalarParamWrapper.h
-    ${CMAKE_CURRENT_LIST_DIR}/TensorParamWrapper.h
+target_sources(
+  wrappers
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/TensorWrapper.cpp
+         ${CMAKE_CURRENT_LIST_DIR}/TensorWrapper.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QuantizeParamsWrapper.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/QuantizeParamsWrapper.h
+          ${CMAKE_CURRENT_LIST_DIR}/OpWrapper.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/OpWrapper.h
+          ${CMAKE_CURRENT_LIST_DIR}/ParamWrapper.h
+          ${CMAKE_CURRENT_LIST_DIR}/ScalarParamWrapper.h
+          ${CMAKE_CURRENT_LIST_DIR}/TensorParamWrapper.h
 )

--- a/backends/qualcomm/runtime/CMakeLists.txt
+++ b/backends/qualcomm/runtime/CMakeLists.txt
@@ -5,52 +5,45 @@
 # LICENSE file in the root directory of this source tree.
 
 # executorch_backend
-target_sources(executorch_backend
-    INTERFACE
-    ${EXECUTORCH_SOURCE_DIR}/backends/backend.h
+target_sources(
+  executorch_backend INTERFACE ${EXECUTORCH_SOURCE_DIR}/backends/backend.h
 )
 
 # qnn_executorch_header
-target_sources(qnn_executorch_header
-    INTERFACE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnExecuTorch.h
+target_sources(
+  qnn_executorch_header INTERFACE ${CMAKE_CURRENT_LIST_DIR}/QnnExecuTorch.h
 )
 
 # qnn_executorch_backend
-target_sources(qnn_executorch_backend
-    INTERFACE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnExecuTorchBackend.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnExecuTorchBackend.cpp
+target_sources(
+  qnn_executorch_backend
+  INTERFACE ${CMAKE_CURRENT_LIST_DIR}/QnnExecuTorchBackend.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnExecuTorchBackend.cpp
 )
 
 # qnn_manager
-target_sources(qnn_manager
-    INTERFACE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnManager.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnManager.cpp
+target_sources(
+  qnn_manager
+  INTERFACE ${CMAKE_CURRENT_LIST_DIR}/QnnManager.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnManager.cpp
 )
 
 # logging
-target_sources(qnn_executorch_logging
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/Logging.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/Logging.cpp
+target_sources(
+  qnn_executorch_logging
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/Logging.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/Logging.cpp
 )
 
 # utils
-target_sources(utils
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/Utils.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp
+target_sources(
+  utils
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/Utils.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp
 )
 
 # shared_buffer
-target_sources(shared_buffer
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/SharedBuffer.h
-    ${CMAKE_CURRENT_LIST_DIR}/SharedBuffer.cpp
+target_sources(
+  shared_buffer PRIVATE ${CMAKE_CURRENT_LIST_DIR}/SharedBuffer.h
+                        ${CMAKE_CURRENT_LIST_DIR}/SharedBuffer.cpp
 )

--- a/backends/qualcomm/runtime/backends/CMakeLists.txt
+++ b/backends/qualcomm/runtime/backends/CMakeLists.txt
@@ -4,48 +4,43 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 # qnn_implementation
-target_sources(qnn_implementation
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/QnnImplementation.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnImplementation.cpp
+target_sources(
+  qnn_implementation
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/QnnImplementation.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnImplementation.cpp
 )
 
 # qnn_interface
-target_sources(qnn_function_interface
-    INTERFACE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnFunctionInterface.h
+target_sources(
+  qnn_function_interface
+  INTERFACE ${CMAKE_CURRENT_LIST_DIR}/QnnFunctionInterface.h
 )
 
 # qnn_sys_implementation
-target_sources(qnn_sys_implementation
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/QnnSysImplementation.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnSysImplementation.cpp
+target_sources(
+  qnn_sys_implementation
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/QnnSysImplementation.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnSysImplementation.cpp
 )
 
 # qnn_sys_interface
-target_sources(qnn_sys_function_interface
-    INTERFACE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnSysFunctionInterface.h
+target_sources(
+  qnn_sys_function_interface
+  INTERFACE ${CMAKE_CURRENT_LIST_DIR}/QnnSysFunctionInterface.h
 )
 
 # qnn_logger
-target_sources(qnn_logger
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/QnnLogger.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnLogger.cpp
+target_sources(
+  qnn_logger
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/QnnLogger.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnLogger.cpp
 )
 
 # qnn_profiler
-target_sources(qnn_profiler
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnProfiler.h
-    ${CMAKE_CURRENT_LIST_DIR}/QnnProfiler.cpp
+target_sources(
+  qnn_profiler PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnProfiler.h
+                       ${CMAKE_CURRENT_LIST_DIR}/QnnProfiler.cpp
 )
 
 # qnn_device
@@ -53,76 +48,69 @@ set(HOST_ARCHITECTURE
     ${CMAKE_CURRENT_LIST_DIR}/htpbackend/${CMAKE_SYSTEM_PROCESSOR}
 )
 
-target_sources(qnn_device
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/QnnDeviceCommon.h
-    ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpDevice.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnDeviceCommon.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpDevice.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpDevicePlatformInfoConfig.h
-    ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpDeviceCustomConfig.h
-    # When offline prepare context cache in x86 host
-    # we have to provide platform infomation and SocModel to Qnn
-    ${HOST_ARCHITECTURE}/HtpDevicePlatformInfoConfig.cpp
-    ${HOST_ARCHITECTURE}/HtpDeviceCustomConfig.cpp
+target_sources(
+  qnn_device
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/QnnDeviceCommon.h
+         ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpDevice.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnDeviceCommon.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpDevice.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpDevicePlatformInfoConfig.h
+          ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpDeviceCustomConfig.h
+          # When offline prepare context cache in x86 host we have to provide
+          # platform infomation and SocModel to Qnn
+          ${HOST_ARCHITECTURE}/HtpDevicePlatformInfoConfig.cpp
+          ${HOST_ARCHITECTURE}/HtpDeviceCustomConfig.cpp
 )
 
 # qnn_context
-target_sources(qnn_context
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/QnnContextCommon.h
-    ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpContext.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnContextCommon.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpContext.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpContextCustomConfig.h
-    ${HOST_ARCHITECTURE}/HtpContextCustomConfig.cpp
+target_sources(
+  qnn_context
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/QnnContextCommon.h
+         ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpContext.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnContextCommon.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpContext.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpContextCustomConfig.h
+          ${HOST_ARCHITECTURE}/HtpContextCustomConfig.cpp
 )
 
 # qnn_backend_cache
-target_sources(qnn_backend_cache
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/QnnBackendCache.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnBackendCache.cpp
+target_sources(
+  qnn_backend_cache
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/QnnBackendCache.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnBackendCache.cpp
 )
 
 # qnn_graph
-target_sources(qnn_graph
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/QnnGraphCommon.h
-    ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpGraph.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnGraphCommon.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpGraph.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpGraphCustomConfig.h
-    ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpGraphCustomConfig.cpp
+target_sources(
+  qnn_graph
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/QnnGraphCommon.h
+         ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpGraph.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnGraphCommon.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpGraph.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpGraphCustomConfig.h
+          ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpGraphCustomConfig.cpp
 )
 
 # qnn_backend
-target_sources(qnn_backend
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/QnnBackendCommon.h
-    ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpBackend.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnBackendCommon.cpp
+target_sources(
+  qnn_backend
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/QnnBackendCommon.h
+         ${CMAKE_CURRENT_LIST_DIR}/htpbackend/HtpBackend.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnBackendCommon.cpp
 )
 
 # qnn_mem_manager
-target_sources(qnn_mem_manager
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/QnnMemManager.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnMemManager.cpp
+target_sources(
+  qnn_mem_manager
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/QnnMemManager.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnMemManager.cpp
 )
 
 # qnn_factory
-target_sources(qnn_factory
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/QnnBackendFactory.h
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/QnnBackendFactory.cpp
+target_sources(
+  qnn_factory
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/QnnBackendFactory.h
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnBackendFactory.cpp
 )
 
 set(qnn_header_basenames
@@ -159,21 +147,17 @@ set(qnn_header_basenames
     System/QnnSystemInterface.h
 )
 
-set(QNN_HEADER_DIR_DST
-    ${CMAKE_CURRENT_BINARY_DIR}/QNN/include)
+set(QNN_HEADER_DIR_DST ${CMAKE_CURRENT_BINARY_DIR}/QNN/include)
 
 # add the custom commands to copy each headers
 foreach(_qnn_header ${qnn_header_basenames})
-    # copy at generation time to make below target_sources(qnn_header) happy.
-    configure_file(${QNN_SDK_ROOT}/include/QNN/${_qnn_header}
-        ${QNN_HEADER_DIR_DST}/${_qnn_header}
-        COPYONLY
-    )
-    list(APPEND qnn_header_files ${QNN_HEADER_DIR_DST}/${_qnn_header})
+  # copy at generation time to make below target_sources(qnn_header) happy.
+  configure_file(
+    ${QNN_SDK_ROOT}/include/QNN/${_qnn_header}
+    ${QNN_HEADER_DIR_DST}/${_qnn_header} COPYONLY
+  )
+  list(APPEND qnn_header_files ${QNN_HEADER_DIR_DST}/${_qnn_header})
 endforeach()
 
 # qnn_header
-target_sources(qnn_header
-    INTERFACE
-    ${qnn_header_files}
-)
+target_sources(qnn_header INTERFACE ${qnn_header_files})

--- a/backends/vulkan/CMakeLists.txt
+++ b/backends/vulkan/CMakeLists.txt
@@ -8,7 +8,7 @@
 #
 # This file should be formatted with
 # ~~~
-# cmake-format --first-comment-is-literal=True -i CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 # It should also be cmake-lint clean.
 #
@@ -60,7 +60,8 @@ file(GLOB vulkan_api_cpp ${RUNTIME_PATH}/api/*.cpp)
 list(APPEND vulkan_api_cpp ${VOLK_PATH}/volk.c)
 
 set(COMMON_INCLUDES ${EXECUTORCH_ROOT}/.. ${VULKAN_HEADERS_PATH} ${VOLK_PATH}
-                    ${VMA_PATH})
+                    ${VMA_PATH}
+)
 
 # vulkan_graph_lib
 
@@ -81,14 +82,16 @@ set(VULKAN_GRAPH_SHADERS_PATH ${RUNTIME_PATH}/graph/ops/glsl/)
 vulkan_shader_library(${VULKAN_GRAPH_SHADERS_PATH} vulkan_standard_shaders)
 # preserve the path of the generated cpp file
 set(vulkan_standard_shaders_cpp
-    ${CMAKE_BINARY_DIR}/vulkan_standard_shaders/spv.cpp)
+    ${CMAKE_BINARY_DIR}/vulkan_standard_shaders/spv.cpp
+)
 
 # Generate Files from flatc
 
 set(SCHEMA_INCLUDE_DIR ${CMAKE_BINARY_DIR}/schema/include)
 
 set(GENERATED_HEADER
-    ${SCHEMA_INCLUDE_DIR}/executorch/backends/vulkan/schema_generated.h)
+    ${SCHEMA_INCLUDE_DIR}/executorch/backends/vulkan/schema_generated.h
+)
 
 add_custom_command(
   OUTPUT ${GENERATED_HEADER}
@@ -97,7 +100,8 @@ add_custom_command(
     "${SCHEMA_INCLUDE_DIR}/executorch/backends/vulkan/" ${_vulkan_schema__srcs}
   WORKING_DIRECTORY ${EXECUTORCH_ROOT}
   COMMENT "Generating vulkan_schema headers"
-  VERBATIM)
+  VERBATIM
+)
 
 # vulkan_schema library
 
@@ -106,7 +110,8 @@ set_target_properties(vulkan_schema PROPERTIES LINKER_LANGUAGE CXX)
 
 target_include_directories(
   vulkan_schema INTERFACE ${SCHEMA_INCLUDE_DIR}
-                          ${EXECUTORCH_ROOT}/third-party/flatbuffers/include)
+                          ${EXECUTORCH_ROOT}/third-party/flatbuffers/include
+)
 
 # vulkan_backend
 
@@ -115,8 +120,9 @@ list(APPEND vulkan_backend_cpp ${vulkan_graph_cpp})
 list(APPEND vulkan_backend_cpp ${vulkan_standard_shaders_cpp})
 
 add_library(vulkan_backend STATIC ${vulkan_backend_cpp})
-target_include_directories(vulkan_backend PRIVATE ${SCHEMA_INCLUDE_DIR}
-                                                  ${COMMON_INCLUDES})
+target_include_directories(
+  vulkan_backend PRIVATE ${SCHEMA_INCLUDE_DIR} ${COMMON_INCLUDES}
+)
 target_link_libraries(vulkan_backend PRIVATE vulkan_schema executorch)
 target_compile_options(vulkan_backend PRIVATE ${VULKAN_CXX_FLAGS})
 # Link this library with --whole-archive due to dynamic backend registration
@@ -129,13 +135,17 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
   list(TRANSFORM VULKAN_RUNNER_SRCS PREPEND "${EXECUTORCH_ROOT}/")
 
   add_executable(vulkan_executor_runner ${VULKAN_RUNNER_SRCS})
-  target_link_libraries(vulkan_executor_runner ${_executor_runner_libs}
-                        vulkan_schema vulkan_backend)
+  target_link_libraries(
+    vulkan_executor_runner ${_executor_runner_libs} vulkan_schema
+    vulkan_backend
+  )
   target_compile_options(vulkan_executor_runner PUBLIC ${VULKAN_CXX_FLAGS})
 
   add_library(vulkan_executor_runner_lib STATIC ${VULKAN_RUNNER_SRCS})
-  target_link_libraries(vulkan_executor_runner_lib ${_executor_runner_libs}
-                        vulkan_schema vulkan_backend)
+  target_link_libraries(
+    vulkan_executor_runner_lib ${_executor_runner_libs} vulkan_schema
+    vulkan_backend
+  )
   target_compile_options(vulkan_executor_runner_lib PUBLIC ${VULKAN_CXX_FLAGS})
 endif()
 
@@ -150,15 +160,19 @@ if(EXECUTORCH_BUILD_GTESTS)
 
   # vulkan_compute_api_test
   set(COMPUTE_API_TEST_CPP
-      ${CMAKE_CURRENT_SOURCE_DIR}/test/vulkan_compute_api_test.cpp)
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/vulkan_compute_api_test.cpp
+  )
 
-  add_executable(vulkan_compute_api_test ${COMPUTE_API_TEST_CPP}
-                                         ${TEST_UTILS_CPP})
-  target_include_directories(vulkan_compute_api_test
-                             PRIVATE ${COMMON_INCLUDES} ${TEST_UTILS_HEADERS})
+  add_executable(
+    vulkan_compute_api_test ${COMPUTE_API_TEST_CPP} ${TEST_UTILS_CPP}
+  )
+  target_include_directories(
+    vulkan_compute_api_test PRIVATE ${COMMON_INCLUDES} ${TEST_UTILS_HEADERS}
+  )
   target_link_libraries(
     vulkan_compute_api_test PRIVATE gtest_main vulkan_graph_lib
-                                    vulkan_standard_shaders test_shaderlib)
+                                    vulkan_standard_shaders test_shaderlib
+  )
   target_compile_options(vulkan_compute_api_test PRIVATE ${VULKAN_CXX_FLAGS})
 endif()
 
@@ -166,4 +180,5 @@ install(
   TARGETS vulkan_backend
   DESTINATION lib
   INCLUDES
-  DESTINATION ${COMMON_INCLUDES})
+  DESTINATION ${COMMON_INCLUDES}
+)

--- a/backends/vulkan/cmake/ShaderLibrary.cmake
+++ b/backends/vulkan/cmake/ShaderLibrary.cmake
@@ -8,7 +8,7 @@
 #
 # This file should be formatted with
 # ~~~
-# cmake-format --first-comment-is-literal=True -i ATenVulkan.cmake
+# cmake-format -i ATenVulkan.cmake
 # ~~~
 # It should also be cmake-lint clean.
 #
@@ -20,12 +20,14 @@ if(ANDROID)
   endif()
 
   set(GLSLC_PATH
-      "${ANDROID_NDK}/shader-tools/${ANDROID_NDK_HOST_SYSTEM_NAME}/glslc")
+      "${ANDROID_NDK}/shader-tools/${ANDROID_NDK_HOST_SYSTEM_NAME}/glslc"
+  )
 else()
   find_program(
     GLSLC_PATH glslc
     PATHS ENV VULKAN_SDK "$ENV{VULKAN_SDK}/${CMAKE_HOST_SYSTEM_PROCESSOR}/bin"
-          "$ENV{VULKAN_SDK}/bin")
+          "$ENV{VULKAN_SDK}/bin"
+  )
 
   if(NOT GLSLC_PATH)
     message(FATAL_ERROR "USE_VULKAN glslc not found")
@@ -50,7 +52,8 @@ macro(VULKAN_SHADER_LIBRARY shaders_path library_name)
       ${shaders_path} --output-path ${VULKAN_SHADERGEN_OUT_PATH}
       --glslc-path=${GLSLC_PATH} --tmp-dir-path=${VULKAN_SHADERGEN_OUT_PATH}
       --env ${VULKAN_GEN_ARG_ENV}
-    RESULT_VARIABLE error_code)
+    RESULT_VARIABLE error_code
+  )
   set(ENV{PYTHONPATH} ${PYTHONPATH})
 
   set(generated_spv_cpp ${VULKAN_SHADERGEN_OUT_PATH}/spv.cpp)

--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Please this file formatted by running:
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 
 cmake_minimum_required(VERSION 3.19)
@@ -39,18 +39,22 @@ set(_xnnpack_schema__include_dir "${CMAKE_BINARY_DIR}/schema/include")
 # Paths to headers generated from the .fbs files.
 set(_xnnpack_flatbuffer__outputs)
 foreach(fbs_file ${_xnnpack_schema__srcs})
-  string(REGEX REPLACE "([^/]+)[.]fbs$" "\\1_generated.h"
-                       generated "${fbs_file}")
+  string(REGEX REPLACE "([^/]+)[.]fbs$" "\\1_generated.h" generated
+                       "${fbs_file}"
+  )
   list(APPEND _xnnpack_flatbuffer__outputs
-       "${_xnnpack_schema__include_dir}/executorch/${generated}")
+       "${_xnnpack_schema__include_dir}/executorch/${generated}"
+  )
 endforeach()
 
 set(_xnnpack_schema__outputs)
 foreach(fbs_file ${_xnnpack_schema__srcs})
-  string(REGEX REPLACE "runtime_([^/]+)[.]fbs$" "\\1_generated.h"
-                       generated "${fbs_file}")
+  string(REGEX REPLACE "runtime_([^/]+)[.]fbs$" "\\1_generated.h" generated
+                       "${fbs_file}"
+  )
   list(APPEND _xnnpack_schema__outputs
-       "${_xnnpack_schema__include_dir}/executorch/${generated}")
+       "${_xnnpack_schema__include_dir}/executorch/${generated}"
+  )
 endforeach()
 
 # Generate the headers from the .fbs files.
@@ -60,17 +64,18 @@ add_custom_command(
     ${FLATC_EXECUTABLE} --cpp --cpp-std c++11 --scoped-enums -o
     "${_xnnpack_schema__include_dir}/executorch/backends/xnnpack/serialization"
     ${_xnnpack_schema__srcs}
-  COMMAND
-    mv ${_xnnpack_flatbuffer__outputs} ${_xnnpack_schema__outputs}
+  COMMAND mv ${_xnnpack_flatbuffer__outputs} ${_xnnpack_schema__outputs}
   WORKING_DIRECTORY ${EXECUTORCH_ROOT}
   COMMENT "Generating xnnpack_schema headers"
-  VERBATIM)
+  VERBATIM
+)
 
 add_library(xnnpack_schema INTERFACE ${_xnnpack_schema__outputs})
 set_target_properties(xnnpack_schema PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(
   xnnpack_schema INTERFACE ${_xnnpack_schema__include_dir}
-                           ${EXECUTORCH_ROOT}/third-party/flatbuffers/include)
+                           ${EXECUTORCH_ROOT}/third-party/flatbuffers/include
+)
 
 set(xnnpack_third_party pthreadpool cpuinfo)
 
@@ -78,19 +83,23 @@ include(cmake/Dependencies.cmake)
 
 list(TRANSFORM _xnnpack_backend__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(xnnpack_backend STATIC ${_xnnpack_backend__srcs})
-target_link_libraries(xnnpack_backend
-                      PRIVATE
-                      ${xnnpack_third_party}
-                      executorch_no_prim_ops
-                      xnnpack_schema)
+target_link_libraries(
+  xnnpack_backend PRIVATE ${xnnpack_third_party} executorch_no_prim_ops
+                          xnnpack_schema
+)
 
-target_include_directories(xnnpack_backend
-                           PUBLIC ${_common_include_directories})
+target_include_directories(
+  xnnpack_backend PUBLIC ${_common_include_directories}
+)
 target_include_directories(xnnpack_backend PUBLIC ${XNNPACK_INCLUDE_DIR})
-target_include_directories(xnnpack_backend PUBLIC
-${CMAKE_CURRENT_SOURCE_DIR}/third-party/pthreadpool/include)
-target_include_directories(xnnpack_backend PUBLIC
-${CMAKE_CURRENT_SOURCE_DIR}/third-party/cpuinfo/include)
+target_include_directories(
+  xnnpack_backend
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/third-party/pthreadpool/include
+)
+target_include_directories(
+  xnnpack_backend
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/third-party/cpuinfo/include
+)
 target_compile_options(xnnpack_backend PUBLIC ${_common_compile_options})
 target_link_options_shared_lib(xnnpack_backend)
 
@@ -104,8 +113,9 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
   #
   list(TRANSFORM _xnn_executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
   add_executable(xnn_executor_runner ${_xnn_executor_runner__srcs})
-  target_link_libraries(xnn_executor_runner
-                        xnnpack_backend gflags portable_ops_lib)
+  target_link_libraries(
+    xnn_executor_runner xnnpack_backend gflags portable_ops_lib
+  )
   target_compile_options(xnn_executor_runner PUBLIC ${_common_compile_options})
 endif()
 
@@ -113,4 +123,5 @@ install(
   TARGETS xnnpack_backend
   DESTINATION lib
   INCLUDES
-  DESTINATION ${_common_include_directories})
+  DESTINATION ${_common_include_directories}
+)

--- a/backends/xnnpack/cmake/Dependencies.cmake
+++ b/backends/xnnpack/cmake/Dependencies.cmake
@@ -10,21 +10,37 @@ set(THIRD_PARTY_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/third-party")
 
 # --- XNNPACK
 
-# Setting this global PIC flag for all XNNPACK targets.
-# This is needed for Object libraries within XNNPACK which must
-# be PIC to successfully link this static libXNNPACK
-set(ORIGINAL_CMAKE_POSITION_INDEPENDENT_CODE_FLAG ${CMAKE_POSITION_INDEPENDENT_CODE})
+# Setting this global PIC flag for all XNNPACK targets. This is needed for
+# Object libraries within XNNPACK which must be PIC to successfully link this
+# static libXNNPACK
+set(ORIGINAL_CMAKE_POSITION_INDEPENDENT_CODE_FLAG
+    ${CMAKE_POSITION_INDEPENDENT_CODE}
+)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(XNNPACK_SOURCE_DIR "${THIRD_PARTY_ROOT}/XNNPACK")
 set(XNNPACK_INCLUDE_DIR "${XNNPACK_SOURCE_DIR}/include")
-set(XNNPACK_LIBRARY_TYPE "static" CACHE STRING "")
-set(XNNPACK_BUILD_BENCHMARKS OFF CACHE BOOL "")
-set(XNNPACK_BUILD_TESTS OFF CACHE BOOL "")
-set(XNNPACK_ENABLE_AVXVNNI OFF CACHE BOOL "")
+set(XNNPACK_LIBRARY_TYPE
+    "static"
+    CACHE STRING ""
+)
+set(XNNPACK_BUILD_BENCHMARKS
+    OFF
+    CACHE BOOL ""
+)
+set(XNNPACK_BUILD_TESTS
+    OFF
+    CACHE BOOL ""
+)
+set(XNNPACK_ENABLE_AVXVNNI
+    OFF
+    CACHE BOOL ""
+)
 add_subdirectory("${XNNPACK_SOURCE_DIR}")
 include_directories(SYSTEM ${XNNPACK_INCLUDE_DIR})
 list(APPEND xnnpack_third_party XNNPACK)
 
 # Revert PIC Flag to what it originally was
-set(CMAKE_POSITION_INDEPENDENT_CODE ${ORIGINAL_CMAKE_POSITION_INDEPENDENT_CODE_FLAG})
+set(CMAKE_POSITION_INDEPENDENT_CODE
+    ${ORIGINAL_CMAKE_POSITION_INDEPENDENT_CODE_FLAG}
+)

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -20,17 +20,20 @@ function(gen_selected_ops)
   message(STATUS "  INCLUDE_ALL_OPS: ${GEN_INCLUDE_ALL_OPS}")
 
   set(_oplist_yaml
-      ${CMAKE_CURRENT_BINARY_DIR}/${GEN_LIB_NAME}/selected_operators.yaml)
+      ${CMAKE_CURRENT_BINARY_DIR}/${GEN_LIB_NAME}/selected_operators.yaml
+  )
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${GEN_LIB_NAME})
 
   file(GLOB_RECURSE _codegen_tools_srcs "${EXECUTORCH_ROOT}/codegen/tools/*.py")
 
   set(_gen_oplist_command "${PYTHON_EXECUTABLE}" -m codegen.tools.gen_oplist
-                          --output_path=${_oplist_yaml})
+                          --output_path=${_oplist_yaml}
+  )
 
   if(GEN_OPS_SCHEMA_YAML)
     list(APPEND _gen_oplist_command
-         --ops_schema_yaml_path="${GEN_OPS_SCHEMA_YAML}")
+         --ops_schema_yaml_path="${GEN_OPS_SCHEMA_YAML}"
+    )
   endif()
   if(GEN_ROOT_OPS)
     list(APPEND _gen_oplist_command --root_ops="${GEN_ROOT_OPS}")
@@ -45,7 +48,8 @@ function(gen_selected_ops)
     OUTPUT ${_oplist_yaml}
     COMMAND ${_gen_oplist_command}
     DEPENDS ${GEN_OPS_SCHEMA_YAML} ${_codegen_tools_srcs}
-    WORKING_DIRECTORY ${EXECUTORCH_ROOT})
+    WORKING_DIRECTORY ${EXECUTORCH_ROOT}
+  )
 
 endfunction()
 
@@ -78,11 +82,13 @@ function(generate_bindings_for_kernels)
       --source-path=${EXECUTORCH_ROOT}/codegen --install-dir=${_out_dir}
       --tags-path=${TORCH_ROOT}/aten/src/ATen/native/tags.yaml
       --aten-yaml-path=${TORCH_ROOT}/aten/src/ATen/native/native_functions.yaml
-      --op-selection-yaml-path=${_oplist_yaml})
+      --op-selection-yaml-path=${_oplist_yaml}
+  )
 
   set(_gen_command_sources
       ${_out_dir}/RegisterCodegenUnboxedKernelsEverything.cpp
-      ${_out_dir}/Functions.h ${_out_dir}/NativeFunctions.h)
+      ${_out_dir}/Functions.h ${_out_dir}/NativeFunctions.h
+  )
 
   if(GEN_FUNCTIONS_YAML)
     list(APPEND _gen_command --functions-yaml-path=${GEN_FUNCTIONS_YAML})
@@ -90,7 +96,8 @@ function(generate_bindings_for_kernels)
   if(GEN_CUSTOM_OPS_YAML)
     list(APPEND _gen_command --custom-ops-yaml-path=${GEN_CUSTOM_OPS_YAML})
     list(APPEND _gen_command_sources ${_out_dir}/RegisterCPUCustomOps.cpp
-         ${_out_dir}/RegisterSchema.cpp ${_out_dir}/CustomOpsNativeFunctions.h)
+         ${_out_dir}/RegisterSchema.cpp ${_out_dir}/CustomOpsNativeFunctions.h
+    )
   endif()
 
   add_custom_command(
@@ -99,11 +106,13 @@ function(generate_bindings_for_kernels)
     COMMAND ${_gen_command}
     DEPENDS ${_oplist_yaml} ${GEN_CUSTOM_OPS_YAML} ${GEN_FUNCTIONS_YAML}
             ${_codegen_templates} ${_torchgen_srcs}
-    WORKING_DIRECTORY ${EXECUTORCH_ROOT})
+    WORKING_DIRECTORY ${EXECUTORCH_ROOT}
+  )
   # Make generated file list available in parent scope
   set(gen_command_sources
       ${_gen_command_sources}
-      PARENT_SCOPE)
+      PARENT_SCOPE
+  )
 endfunction()
 
 # Generate an AOT lib for registering custom ops into PyTorch
@@ -119,7 +128,8 @@ function(gen_custom_ops_aot_lib)
   add_library(
     ${GEN_LIB_NAME} SHARED
     ${_out_dir}/RegisterCPUCustomOps.cpp ${_out_dir}/RegisterSchema.cpp
-    ${_out_dir}/CustomOpsNativeFunctions.h "${GEN_KERNEL_SOURCES}")
+    ${_out_dir}/CustomOpsNativeFunctions.h "${GEN_KERNEL_SOURCES}"
+  )
   # Find `Torch`.
   find_package(Torch REQUIRED)
   # This lib uses ATen lib, so we explicitly enable rtti and exceptions.
@@ -149,7 +159,8 @@ function(gen_operators_lib)
   target_sources(
     ${GEN_LIB_NAME}
     PRIVATE ${_out_dir}/RegisterCodegenUnboxedKernelsEverything.cpp
-            ${_out_dir}/Functions.h ${_out_dir}/NativeFunctions.h)
+            ${_out_dir}/Functions.h ${_out_dir}/NativeFunctions.h
+  )
   target_link_libraries(${GEN_LIB_NAME} PRIVATE ${GEN_DEPS})
   if(GEN_KERNEL_LIBS)
     target_link_libraries(${GEN_LIB_NAME} PUBLIC ${GEN_KERNEL_LIBS})
@@ -172,12 +183,14 @@ function(merge_yaml)
   set(_gen_command
       "${PYTHON_EXECUTABLE}" -m codegen.tools.merge_yaml
       --functions_yaml_path=${GEN_FUNCTIONS_YAML}
-      --fallback_yaml_path=${GEN_FALLBACK_YAML} --output_dir=${GEN_OUTPUT_DIR})
+      --fallback_yaml_path=${GEN_FALLBACK_YAML} --output_dir=${GEN_OUTPUT_DIR}
+  )
 
   add_custom_command(
     COMMENT "Merging kernel yaml files"
     OUTPUT ${GEN_OUTPUT_DIR}/merged.yaml
     COMMAND ${_gen_command}
     DEPENDS ${GEN_FUNCTIONS_YAML} ${GEN_FALLBACK_YAML}
-    WORKING_DIRECTORY ${EXECUTORCH_ROOT})
+    WORKING_DIRECTORY ${EXECUTORCH_ROOT}
+  )
 endfunction()

--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -13,7 +13,7 @@
 #
 # This file should be formatted with
 # ~~~
-# cmake-format --first-comment-is-literal=True Utils.cmake
+# cmake-format -i Utils.cmake
 # ~~~
 # It should also be cmake-lint clean.
 #
@@ -32,68 +32,93 @@ function(executorch_print_configuration_summary)
   message(STATUS "  FLATC_EXECUTABLE              : ${FLATC_EXECUTABLE}")
   message(
     STATUS
-      "  EXECUTORCH_ENABLE_LOGGING              : ${EXECUTORCH_ENABLE_LOGGING}")
+      "  EXECUTORCH_ENABLE_LOGGING              : ${EXECUTORCH_ENABLE_LOGGING}"
+  )
   message(STATUS "  EXECUTORCH_ENABLE_PROGRAM_VERIFICATION : "
-                 "${EXECUTORCH_ENABLE_PROGRAM_VERIFICATION}")
+                 "${EXECUTORCH_ENABLE_PROGRAM_VERIFICATION}"
+  )
   message(
-    STATUS "  EXECUTORCH_LOG_LEVEL                   : ${EXECUTORCH_LOG_LEVEL}")
+    STATUS "  EXECUTORCH_LOG_LEVEL                   : ${EXECUTORCH_LOG_LEVEL}"
+  )
   message(STATUS "  EXECUTORCH_BUILD_ANDROID_JNI           : "
-                 "${EXECUTORCH_BUILD_ANDROID_JNI}")
+                 "${EXECUTORCH_BUILD_ANDROID_JNI}"
+  )
   message(STATUS "  EXECUTORCH_BUILD_ARM_BAREMETAL         : "
-                 "${EXECUTORCH_BUILD_ARM_BAREMETAL}")
+                 "${EXECUTORCH_BUILD_ARM_BAREMETAL}"
+  )
   message(
     STATUS
-      "  EXECUTORCH_BUILD_COREML                : ${EXECUTORCH_BUILD_COREML}")
+      "  EXECUTORCH_BUILD_COREML                : ${EXECUTORCH_BUILD_COREML}"
+  )
   message(STATUS "  EXECUTORCH_BUILD_CUSTOM                : "
-                 "${EXECUTORCH_BUILD_CUSTOM}")
+                 "${EXECUTORCH_BUILD_CUSTOM}"
+  )
   message(STATUS "  EXECUTORCH_BUILD_EXECUTOR_RUNNER       : "
-                 "${EXECUTORCH_BUILD_EXECUTOR_RUNNER}")
+                 "${EXECUTORCH_BUILD_EXECUTOR_RUNNER}"
+  )
   message(STATUS "  EXECUTORCH_BUILD_EXTENSION_DATA_LOADER : "
-                 "${EXECUTORCH_BUILD_EXTENSION_DATA_LOADER}")
+                 "${EXECUTORCH_BUILD_EXTENSION_DATA_LOADER}"
+  )
   message(STATUS "  EXECUTORCH_BUILD_EXTENSION_MODULE      : "
-                 "${EXECUTORCH_BUILD_EXTENSION_MODULE}")
+                 "${EXECUTORCH_BUILD_EXTENSION_MODULE}"
+  )
   message(STATUS "  EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL : "
-                 "${EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL}")
+                 "${EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL}"
+  )
   message(
     STATUS
-      "  EXECUTORCH_BUILD_FLATC                 : ${EXECUTORCH_BUILD_FLATC}")
+      "  EXECUTORCH_BUILD_FLATC                 : ${EXECUTORCH_BUILD_FLATC}"
+  )
   message(
     STATUS
-      "  EXECUTORCH_BUILD_GFLAGS                : ${EXECUTORCH_BUILD_GFLAGS}")
+      "  EXECUTORCH_BUILD_GFLAGS                : ${EXECUTORCH_BUILD_GFLAGS}"
+  )
   message(
     STATUS
-      "  EXECUTORCH_BUILD_GTESTS                : ${EXECUTORCH_BUILD_GTESTS}")
+      "  EXECUTORCH_BUILD_GTESTS                : ${EXECUTORCH_BUILD_GTESTS}"
+  )
   message(STATUS "  EXECUTORCH_BUILD_HOST_TARGETS          : "
-                 "${EXECUTORCH_BUILD_HOST_TARGETS}")
+                 "${EXECUTORCH_BUILD_HOST_TARGETS}"
+  )
   message(
-    STATUS "  EXECUTORCH_BUILD_MPS                   : ${EXECUTORCH_BUILD_MPS}")
+    STATUS "  EXECUTORCH_BUILD_MPS                   : ${EXECUTORCH_BUILD_MPS}"
+  )
   message(
     STATUS
-      "  EXECUTORCH_BUILD_PYBIND                : ${EXECUTORCH_BUILD_PYBIND}")
+      "  EXECUTORCH_BUILD_PYBIND                : ${EXECUTORCH_BUILD_PYBIND}"
+  )
   message(
-    STATUS "  EXECUTORCH_BUILD_QNN                   : ${EXECUTORCH_BUILD_QNN}")
+    STATUS "  EXECUTORCH_BUILD_QNN                   : ${EXECUTORCH_BUILD_QNN}"
+  )
   message(STATUS "  EXECUTORCH_BUILD_OPTIMIZED             : "
-                 "${EXECUTORCH_BUILD_OPTIMIZED}")
+                 "${EXECUTORCH_BUILD_OPTIMIZED}"
+  )
   message(STATUS "  EXECUTORCH_BUILD_QUANTIZED             : "
-                 "${EXECUTORCH_BUILD_QUANTIZED}")
+                 "${EXECUTORCH_BUILD_QUANTIZED}"
+  )
   message(
-    STATUS "  EXECUTORCH_BUILD_SDK                   : ${EXECUTORCH_BUILD_SDK}")
+    STATUS "  EXECUTORCH_BUILD_SDK                   : ${EXECUTORCH_BUILD_SDK}"
+  )
   message(
     STATUS
       "  EXECUTORCH_BUILD_SIZE_TEST             : ${EXECUTORCH_BUILD_SIZE_TEST}"
   )
   message(
     STATUS
-      "  EXECUTORCH_BUILD_XNNPACK               : ${EXECUTORCH_BUILD_XNNPACK}")
+      "  EXECUTORCH_BUILD_XNNPACK               : ${EXECUTORCH_BUILD_XNNPACK}"
+  )
   message(
     STATUS
-      "  EXECUTORCH_BUILD_VULKAN                : ${EXECUTORCH_BUILD_VULKAN}")
+      "  EXECUTORCH_BUILD_VULKAN                : ${EXECUTORCH_BUILD_VULKAN}"
+  )
   message(
     STATUS
-      "  EXECUTORCH_BUILD_PTHREADPOOL           : ${EXECUTORCH_BUILD_PTHREADPOOL}")
+      "  EXECUTORCH_BUILD_PTHREADPOOL           : ${EXECUTORCH_BUILD_PTHREADPOOL}"
+  )
   message(
     STATUS
-      "  EXECUTORCH_BUILD_CPUINFO               : ${EXECUTORCH_BUILD_CPUINFO}")
+      "  EXECUTORCH_BUILD_CPUINFO               : ${EXECUTORCH_BUILD_CPUINFO}"
+  )
 
 endfunction()
 
@@ -106,13 +131,16 @@ function(kernel_link_options target_name)
   target_link_options(
     ${target_name} INTERFACE "SHELL:LINKER:--whole-archive \
     $<TARGET_FILE:${target_name}> \
-    LINKER:--no-whole-archive")
+    LINKER:--no-whole-archive"
+  )
 endfunction()
 
 # Same as kernel_link_options but it's for MacOS linker
 function(macos_kernel_link_options target_name)
-  target_link_options(${target_name} INTERFACE
-                      "SHELL:LINKER:-force_load,$<TARGET_FILE:${target_name}>")
+  target_link_options(
+    ${target_name} INTERFACE
+    "SHELL:LINKER:-force_load,$<TARGET_FILE:${target_name}>"
+  )
 endfunction()
 
 # Ensure that the load-time constructor functions run. By default, the linker
@@ -151,11 +179,13 @@ function(extract_sources sources_file)
       OUTPUT_VARIABLE gen_srcs_output
       ERROR_VARIABLE gen_srcs_error
       RESULT_VARIABLE gen_srcs_exit_code
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
 
     if(NOT gen_srcs_exit_code EQUAL 0)
       message("Error while generating ${sources_file}. "
-              "Exit code: ${gen_srcs_exit_code}")
+              "Exit code: ${gen_srcs_exit_code}"
+      )
       message("Output:\n${gen_srcs_output}")
       message("Error:\n${gen_srcs_error}")
       message(FATAL_ERROR "executorch: source list generation failed")
@@ -180,7 +210,8 @@ function(resolve_buck2)
 
   set(resolve_buck2_command
       ${PYTHON_EXECUTABLE} ${executorch_root}/build/resolve_buck.py
-      --cache_dir=${CMAKE_CURRENT_BINARY_DIR}/buck2-bin)
+      --cache_dir=${CMAKE_CURRENT_BINARY_DIR}/buck2-bin
+  )
 
   if(NOT ${BUCK2} STREQUAL "")
     list(APPEND resolve_buck2_command --buck2=${BUCK2})
@@ -192,12 +223,14 @@ function(resolve_buck2)
     ERROR_VARIABLE resolve_buck2_error
     RESULT_VARIABLE resolve_buck2_exit_code
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
 
   if(resolve_buck2_exit_code EQUAL 0)
     set(BUCK2
         ${resolve_buck2_output}
-        PARENT_SCOPE)
+        PARENT_SCOPE
+    )
     message(STATUS "Resolved buck2 as ${resolve_buck2_output}.")
   elseif(resolve_buck2_exit_code EQUAL 2)
     # Wrong buck version used. Stop here to ensure that the user sees the error.
@@ -210,15 +243,16 @@ function(resolve_buck2)
     if("${BUCK2}" STREQUAL "")
       set(BUCK2
           "buck2"
-          PARENT_SCOPE)
+          PARENT_SCOPE
+      )
     endif()
   endif()
 
   # The buck2 daemon can get stuck. Killing it can help.
   message(STATUS "Killing buck2 daemon")
   execute_process(
-    COMMAND "${BUCK2} kill"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    COMMAND "${BUCK2} kill" WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
 endfunction()
 
 # Sets the value of the PYTHON_EXECUTABLE variable to 'python' if in an active
@@ -229,13 +263,16 @@ function(resolve_python_executable)
   # Counter-intuitively, CONDA_DEFAULT_ENV contains the name of the active
   # environment.
   if(DEFINED ENV{CONDA_DEFAULT_ENV} AND NOT $ENV{CONDA_DEFAULT_ENV} STREQUAL
-                                        "base")
+                                        "base"
+  )
     set(PYTHON_EXECUTABLE
         python
-        PARENT_SCOPE)
+        PARENT_SCOPE
+    )
   else()
     set(PYTHON_EXECUTABLE
         python3
-        PARENT_SCOPE)
+        PARENT_SCOPE
+    )
   endif()
 endfunction()

--- a/build/executorch-config.cmake
+++ b/build/executorch-config.cmake
@@ -5,8 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 # Config defining how CMake should find ExecuTorch package. CMake will search
-# for this file and find ExecuTorch package if it is installed.
-# Typical usage is:
+# for this file and find ExecuTorch package if it is installed. Typical usage
+# is:
 #
 # find_package(executorch REQUIRED)
 
@@ -15,50 +15,68 @@ cmake_minimum_required(VERSION 3.19)
 set(_root "${CMAKE_CURRENT_LIST_DIR}/../..")
 set(required_lib_list executorch executorch_no_prim_ops portable_kernels)
 foreach(lib ${required_lib_list})
-    set(lib_var "LIB_${lib}")
-    add_library(${lib} STATIC IMPORTED)
-    find_library(
-        ${lib_var} ${lib} HINTS "${_root}" CMAKE_FIND_ROOT_PATH_BOTH
-    )
-    set_target_properties(
-        ${lib} PROPERTIES IMPORTED_LOCATION "${${lib_var}}"
-    )
-    target_include_directories(${lib} INTERFACE ${_root})
+  set(lib_var "LIB_${lib}")
+  add_library(${lib} STATIC IMPORTED)
+  find_library(
+    ${lib_var} ${lib}
+    HINTS "${_root}"
+    CMAKE_FIND_ROOT_PATH_BOTH
+  )
+  set_target_properties(${lib} PROPERTIES IMPORTED_LOCATION "${${lib_var}}")
+  target_include_directories(${lib} INTERFACE ${_root})
 endforeach()
 
 target_link_libraries(executorch INTERFACE executorch_no_prim_ops)
 
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
-    set(FLATCCRT_LIB flatccrt_d)
+  set(FLATCCRT_LIB flatccrt_d)
 else()
-    set(FLATCCRT_LIB flatccrt)
+  set(FLATCCRT_LIB flatccrt)
 endif()
 
 set(lib_list
-    etdump bundled_program extension_data_loader ${FLATCCRT_LIB} mpsdelegate
-    qnn_executorch_backend portable_ops_lib extension_module xnnpack_backend
-    XNNPACK cpuinfo pthreadpool vulkan_backend optimized_kernels cpublas eigen_blas
-    optimized_ops_lib optimized_native_cpu_ops_lib quantized_kernels quantized_ops_lib
+    etdump
+    bundled_program
+    extension_data_loader
+    ${FLATCCRT_LIB}
+    mpsdelegate
+    qnn_executorch_backend
+    portable_ops_lib
+    extension_module
+    xnnpack_backend
+    XNNPACK
+    cpuinfo
+    pthreadpool
+    vulkan_backend
+    optimized_kernels
+    cpublas
+    eigen_blas
+    optimized_ops_lib
+    optimized_native_cpu_ops_lib
+    quantized_kernels
+    quantized_ops_lib
 )
 foreach(lib ${lib_list})
-    # Name of the variable which stores result of the find_library search
-    set(lib_var "LIB_${lib}")
-    find_library(${lib_var} ${lib} HINTS "${_root}" CMAKE_FIND_ROOT_PATH_BOTH)
-    if(NOT ${lib_var})
-        message("${lib} library is not found.
-            If needed rebuild with the proper options in CMakeLists.txt")
+  # Name of the variable which stores result of the find_library search
+  set(lib_var "LIB_${lib}")
+  find_library(
+    ${lib_var} ${lib}
+    HINTS "${_root}"
+    CMAKE_FIND_ROOT_PATH_BOTH
+  )
+  if(NOT ${lib_var})
+    message("${lib} library is not found.
+            If needed rebuild with the proper options in CMakeLists.txt"
+    )
+  else()
+    if("${lib}" STREQUAL "extension_module" AND (NOT CMAKE_TOOLCHAIN_IOS))
+      add_library(${lib} SHARED IMPORTED)
     else()
-        if("${lib}" STREQUAL "extension_module" AND (NOT CMAKE_TOOLCHAIN_IOS))
-            add_library(${lib} SHARED IMPORTED)
-        else()
-            # Building a share library on iOS requires code signing, so it's
-            # easier to keep all libs as static when CMAKE_TOOLCHAIN_IOS is
-            # used
-            add_library(${lib} STATIC IMPORTED)
-        endif()
-        set_target_properties(
-            ${lib} PROPERTIES IMPORTED_LOCATION "${${lib_var}}"
-        )
-        target_include_directories(${lib} INTERFACE ${_root})
+      # Building a share library on iOS requires code signing, so it's easier to
+      # keep all libs as static when CMAKE_TOOLCHAIN_IOS is used
+      add_library(${lib} STATIC IMPORTED)
     endif()
+    set_target_properties(${lib} PROPERTIES IMPORTED_LOCATION "${${lib_var}}")
+    target_include_directories(${lib} INTERFACE ${_root})
+  endif()
 endforeach()

--- a/configurations/CMakeLists.txt
+++ b/configurations/CMakeLists.txt
@@ -36,14 +36,18 @@ if(EXECUTORCH_BUILD_OPTIMIZED)
   merge_yaml(
     FUNCTIONS_YAML ${EXECUTORCH_ROOT}/kernels/optimized/optimized-oss.yaml
     FALLBACK_YAML ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml OUTPUT_DIR
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_BINARY_DIR}
+  )
 
-  gen_selected_ops(LIB_NAME "optimized_native_cpu_ops_lib"
-                   OPS_SCHEMA_YAML "${CMAKE_CURRENT_BINARY_DIR}/merged.yaml")
+  gen_selected_ops(
+    LIB_NAME "optimized_native_cpu_ops_lib" OPS_SCHEMA_YAML
+    "${CMAKE_CURRENT_BINARY_DIR}/merged.yaml"
+  )
 
   generate_bindings_for_kernels(
     LIB_NAME "optimized_native_cpu_ops_lib" FUNCTIONS_YAML
-    ${CMAKE_CURRENT_BINARY_DIR}/merged.yaml)
+    ${CMAKE_CURRENT_BINARY_DIR}/merged.yaml
+  )
   message("Generated files ${gen_command_sources}")
 
   # optimized_native_cpu_ops_lib: Register optimized op kernels into the runtime
@@ -54,7 +58,8 @@ if(EXECUTORCH_BUILD_OPTIMIZED)
     portable_kernels
     optimized_kernels
     DEPS
-    executorch)
+    executorch
+  )
 
   install(TARGETS optimized_native_cpu_ops_lib DESTINATION lib)
 endif()

--- a/examples/apple/mps/CMakeLists.txt
+++ b/examples/apple/mps/CMakeLists.txt
@@ -4,8 +4,8 @@
 #
 
 #
-# mps_executor_runner: Host tool that demonstrates program
-#                      execution using MPSBackend.
+# mps_executor_runner: Host tool that demonstrates program execution using
+# MPSBackend.
 #
 
 cmake_minimum_required(VERSION 3.19)
@@ -42,13 +42,15 @@ add_compile_options("-Wall" "-Werror")
 
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 
-set(_common_compile_options -Wno-deprecated-declarations -fPIC -DET_EVENT_TRACER_ENABLED)
+set(_common_compile_options -Wno-deprecated-declarations -fPIC
+                            -DET_EVENT_TRACER_ENABLED
+)
 
 # Let files say "include <executorch/path/to/header.h>".
 set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 
-# Find prebuilt libraries. executorch package should contain
-# portable_ops_lib, etdump, bundled_program.
+# Find prebuilt libraries. executorch package should contain portable_ops_lib,
+# etdump, bundled_program.
 find_package(executorch CONFIG REQUIRED)
 target_include_directories(executorch INTERFACE ${_common_include_directories})
 target_compile_options(executorch INTERFACE ${_common_compile_options})
@@ -57,70 +59,69 @@ find_package(
   gflags REQUIRED PATHS ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party
 )
 
-
 # ios can only build library but not binary
 if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*iOS\.cmake$")
   #
-  # mps_executor_runner: Like executor_runner but with MPS, the binary will
-  # be at ${CMAKE_BINARY_DIR}/examples/apple/executor_runner/mps
+  # mps_executor_runner: Like executor_runner but with MPS, the binary will be
+  # at ${CMAKE_BINARY_DIR}/examples/apple/executor_runner/mps
   #
 
-# portable_ops_lib
-include(${EXECUTORCH_ROOT}/build/Utils.cmake)
-include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
-gen_selected_ops(
-  LIB_NAME "mps_portable_ops_lib"
-  INCLUDE_ALL_OPS "ON")
-generate_bindings_for_kernels(
-  LIB_NAME "mps_portable_ops_lib"
-  FUNCTIONS_YAML ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
-)
-gen_operators_lib(
-  LIB_NAME "mps_portable_ops_lib"
-  KERNEL_LIBS portable_kernels
-  DEPS executorch)
+  # portable_ops_lib
+  include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+  include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
+  gen_selected_ops(LIB_NAME "mps_portable_ops_lib" INCLUDE_ALL_OPS "ON")
+  generate_bindings_for_kernels(
+    LIB_NAME "mps_portable_ops_lib" FUNCTIONS_YAML
+    ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
+  )
+  gen_operators_lib(
+    LIB_NAME "mps_portable_ops_lib" KERNEL_LIBS portable_kernels DEPS
+    executorch
+  )
 
-set(mps_executor_runner_libs "-framework Foundation"
-                              "-weak_framework MetalPerformanceShaders"
-                              "-weak_framework MetalPerformanceShadersGraph"
-                              "-weak_framework Metal")
+  set(mps_executor_runner_libs
+      "-framework Foundation" "-weak_framework MetalPerformanceShaders"
+      "-weak_framework MetalPerformanceShadersGraph" "-weak_framework Metal"
+  )
 
-#
-# The `_<target>_srcs` lists are defined by including ${EXECUTORCH_SRCS_FILE}.
-#
-set(
-  EXECUTORCH_SRCS_FILE
-  "${CMAKE_CURRENT_BINARY_DIR}/../../../executorch_srcs.cmake"
-)
+  #
+  # The `_<target>_srcs` lists are defined by including ${EXECUTORCH_SRCS_FILE}.
+  #
+  set(EXECUTORCH_SRCS_FILE
+      "${CMAKE_CURRENT_BINARY_DIR}/../../../executorch_srcs.cmake"
+  )
 
-extract_sources(${EXECUTORCH_SRCS_FILE})
+  extract_sources(${EXECUTORCH_SRCS_FILE})
 
-set(_mps_schema_headers ${CMAKE_BINARY_DIR}/../../../schema/include/)
-include(${EXECUTORCH_SRCS_FILE})
-target_include_directories(
-  bundled_program
-  INTERFACE
-  ${CMAKE_CURRENT_BINARY_DIR}/../../../sdk/include
-  ${CMAKE_CURRENT_BINARY_DIR}/../../../sdk/bundled_program
-  ${EXECUTORCH_ROOT}/third-party/flatbuffers/include
-  ${EXECUTORCH_ROOT}/third-party/flatcc/include
-  ${_mps_schema_headers}
-)
-list(TRANSFORM _mps_executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
-add_executable(mps_executor_runner ${_mps_executor_runner__srcs})
+  set(_mps_schema_headers ${CMAKE_BINARY_DIR}/../../../schema/include/)
+  include(${EXECUTORCH_SRCS_FILE})
+  target_include_directories(
+    bundled_program
+    INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/../../../sdk/include
+              ${CMAKE_CURRENT_BINARY_DIR}/../../../sdk/bundled_program
+              ${EXECUTORCH_ROOT}/third-party/flatbuffers/include
+              ${EXECUTORCH_ROOT}/third-party/flatcc/include
+              ${_mps_schema_headers}
+  )
+  list(TRANSFORM _mps_executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
+  add_executable(mps_executor_runner ${_mps_executor_runner__srcs})
 
-if(CMAKE_BUILD_TYPE MATCHES "Debug")
-  set(FLATCC_LIB flatccrt_d)
-else()
-  set(FLATCC_LIB flatccrt)
-endif()
+  if(CMAKE_BUILD_TYPE MATCHES "Debug")
+    set(FLATCC_LIB flatccrt_d)
+  else()
+    set(FLATCC_LIB flatccrt)
+  endif()
 
-target_link_libraries(mps_executor_runner bundled_program
-                                          executorch gflags
-                                          etdump
-                                          ${FLATCC_LIB}
-                                          mpsdelegate
-                                          mps_portable_ops_lib
-                                          ${mps_executor_runner_libs})
-target_compile_options(mps_executor_runner PUBLIC ${_common_compile_options})
+  target_link_libraries(
+    mps_executor_runner
+    bundled_program
+    executorch
+    gflags
+    etdump
+    ${FLATCC_LIB}
+    mpsdelegate
+    mps_portable_ops_lib
+    ${mps_executor_runner_libs}
+  )
+  target_compile_options(mps_executor_runner PUBLIC ${_common_compile_options})
 endif()

--- a/examples/arm/CMakeLists.txt
+++ b/examples/arm/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Kernel library for portable kernels. Please this file formatted by running:
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 
 cmake_minimum_required(VERSION 3.19)
@@ -46,14 +46,19 @@ include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in functions.yaml
 gen_selected_ops(
-  LIB_NAME "arm_portable_ops_lib"
-  OPS_SCHEMA_YAML ""
-  ROOT_OPS "${EXECUTORCH_SELECT_OPS_LIST}"
-  INCLUDE_ALL_OPS "")
+  LIB_NAME
+  "arm_portable_ops_lib"
+  OPS_SCHEMA_YAML
+  ""
+  ROOT_OPS
+  "${EXECUTORCH_SELECT_OPS_LIST}"
+  INCLUDE_ALL_OPS
+  ""
+)
 generate_bindings_for_kernels(
-  LIB_NAME "arm_portable_ops_lib"
-  FUNCTIONS_YAML ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml)
+  LIB_NAME "arm_portable_ops_lib" FUNCTIONS_YAML
+  ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
+)
 gen_operators_lib(
-  LIB_NAME "arm_portable_ops_lib"
-  KERNEL_LIBS portable_kernels
-  DEPS executorch)
+  LIB_NAME "arm_portable_ops_lib" KERNEL_LIBS portable_kernels DEPS executorch
+)

--- a/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake
+++ b/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake
@@ -16,10 +16,13 @@
 # limitations under the License.
 #
 
-# Copied this file from core_platform/cmake/toolchain/arm-non-eabi-gcc.cmake
-# And modified to align better with cs300 platform
+# Copied this file from core_platform/cmake/toolchain/arm-non-eabi-gcc.cmake And
+# modified to align better with cs300 platform
 
-set(TARGET_CPU "cortex-m55" CACHE STRING "Target CPU")
+set(TARGET_CPU
+    "cortex-m55"
+    CACHE STRING "Target CPU"
+)
 string(TOLOWER ${TARGET_CPU} CMAKE_SYSTEM_PROCESSOR)
 
 set(CMAKE_SYSTEM_NAME Generic)
@@ -43,69 +46,56 @@ string(REPLACE "cortex-m85" "cortex-m55" GCC_CPU ${GCC_CPU})
 
 # Compile options
 add_compile_options(
-    -mcpu=${GCC_CPU}
-    -mthumb
-    "$<$<CONFIG:DEBUG>:-gdwarf-3>"
-    "$<$<COMPILE_LANGUAGE:CXX>:-fno-unwind-tables;-fno-rtti;-fno-exceptions>"
-    -fdata-sections
-    -ffunction-sections)
-
-# Compile defines
-add_compile_definitions(
-    "$<$<NOT:$<CONFIG:DEBUG>>:NDEBUG>")
-
-# Link options
-add_link_options(
-    -mcpu=${GCC_CPU}
-    -mthumb
+  -mcpu=${GCC_CPU} -mthumb "$<$<CONFIG:DEBUG>:-gdwarf-3>"
+  "$<$<COMPILE_LANGUAGE:CXX>:-fno-unwind-tables;-fno-rtti;-fno-exceptions>"
+  -fdata-sections -ffunction-sections
 )
 
+# Compile defines
+add_compile_definitions("$<$<NOT:$<CONFIG:DEBUG>>:NDEBUG>")
+
+# Link options
+add_link_options(-mcpu=${GCC_CPU} -mthumb)
+
 if(SEMIHOSTING)
-    add_link_options(--specs=rdimon.specs)
+  add_link_options(--specs=rdimon.specs)
 else()
-    add_link_options(--specs=nosys.specs)
+  add_link_options(--specs=nosys.specs)
 endif()
 
 # Set floating point unit
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "\\+fp")
-    set(FLOAT hard)
+  set(FLOAT hard)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "\\+nofp")
-    set(FLOAT soft)
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m33(\\+|$)" OR
-       CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m55(\\+|$)" OR
-       CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m85(\\+|$)")
-    set(FLOAT hard)
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m4(\\+|$)" OR
-       CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m7(\\+|$)")
-    set(FLOAT hard)
-    set(FPU_CONFIG "fpv4-sp-d16")
-    add_compile_options(-mfpu=${FPU_CONFIG})
-    add_link_options(-mfpu=${FPU_CONFIG})
+  set(FLOAT soft)
+elseif(
+  CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m33(\\+|$)"
+  OR CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m55(\\+|$)"
+  OR CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m85(\\+|$)"
+)
+  set(FLOAT hard)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m4(\\+|$)"
+       OR CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m7(\\+|$)"
+)
+  set(FLOAT hard)
+  set(FPU_CONFIG "fpv4-sp-d16")
+  add_compile_options(-mfpu=${FPU_CONFIG})
+  add_link_options(-mfpu=${FPU_CONFIG})
 else()
-    set(FLOAT soft)
+  set(FLOAT soft)
 endif()
 
 if(FLOAT)
-    add_compile_options(-mfloat-abi=${FLOAT})
-    add_link_options(-mfloat-abi=${FLOAT})
+  add_compile_options(-mfloat-abi=${FLOAT})
+  add_link_options(-mfloat-abi=${FLOAT})
 endif()
 
 add_link_options(LINKER:--nmagic,--gc-sections)
 
 # Compilation warnings
 add_compile_options(
-    # -Wall
-    # -Wextra
-    # -Wcast-align
-    # -Wdouble-promotion
-    # -Wformat
-    # -Wmissing-field-initializers
-    # -Wnull-dereference
-    # -Wredundant-decls
-    # -Wshadow
-    # -Wswitch
-    # -Wswitch-default
-    # -Wunused
-    # -Wno-redundant-decls
-    -Wno-psabi
+  # -Wall -Wextra -Wcast-align -Wdouble-promotion -Wformat
+  # -Wmissing-field-initializers -Wnull-dereference -Wredundant-decls -Wshadow
+  # -Wswitch -Wswitch-default -Wunused -Wno-redundant-decls
+  -Wno-psabi
 )

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -7,26 +7,40 @@ cmake_minimum_required(VERSION 3.20)
 project(arm_executor_runner)
 
 if(NOT DEFINED ET_PTE_FILE_PATH)
-  message(FATAL_ERROR
-    "ET_PTE_FILE_PATH must specify a model .pte, for bare metal systems the "
-    "model is built into the binary.")
+  message(
+    FATAL_ERROR
+      "ET_PTE_FILE_PATH must specify a model .pte, for bare metal systems the "
+      "model is built into the binary."
+  )
 endif()
 
 option(SEMIHOSTING "Enable semihosting" OFF)
 
 # Example ExecuTorch demo for bare metal Cortex-M based systems
-set(ET_DIR_PATH "../../.." CACHE PATH
-  "Path to ExecuTorch dir")
-set(ET_BUILD_DIR_PATH "${ET_DIR_PATH}/cmake-out" CACHE PATH
-  "Path to ExecuTorch build dir")
-set(ET_INCLUDE_PATH "${ET_DIR_PATH}/.." CACHE PATH
-  "Path to ExecuTorch headers")
-set(ET_PTE_FILE_PATH "" CACHE PATH
-  "Path to ExecuTorch model pte")
-set(ETHOS_SDK_PATH "../ethos-u-scratch/ethos-u" CACHE PATH
-  "Path to Ethos-U bare metal driver/env")
-set(PYTHON_EXECUTABLE "python" CACHE PATH
-  "Define to override python executable used")
+set(ET_DIR_PATH
+    "../../.."
+    CACHE PATH "Path to ExecuTorch dir"
+)
+set(ET_BUILD_DIR_PATH
+    "${ET_DIR_PATH}/cmake-out"
+    CACHE PATH "Path to ExecuTorch build dir"
+)
+set(ET_INCLUDE_PATH
+    "${ET_DIR_PATH}/.."
+    CACHE PATH "Path to ExecuTorch headers"
+)
+set(ET_PTE_FILE_PATH
+    ""
+    CACHE PATH "Path to ExecuTorch model pte"
+)
+set(ETHOS_SDK_PATH
+    "../ethos-u-scratch/ethos-u"
+    CACHE PATH "Path to Ethos-U bare metal driver/env"
+)
+set(PYTHON_EXECUTABLE
+    "python"
+    CACHE PATH "Define to override python executable used"
+)
 
 get_filename_component(ET_BUILD_DIR_PATH ${ET_BUILD_DIR_PATH} REALPATH)
 get_filename_component(ET_DIR_PATH ${ET_DIR_PATH} REALPATH)
@@ -34,10 +48,10 @@ get_filename_component(ET_INCLUDE_PATH ${ET_INCLUDE_PATH} REALPATH)
 get_filename_component(ET_PTE_FILE_PATH ${ET_PTE_FILE_PATH} REALPATH)
 get_filename_component(ETHOS_SDK_PATH ${ETHOS_SDK_PATH} REALPATH)
 
-# Dependencies from the Ethos-U Core
-# This is the platform target of Corstone-300, that includes ethosu_core_driver
-# and bare-metal bringup libraries. We link against ethosu_target_init which
-# includes all of these dependencies.
+# Dependencies from the Ethos-U Core This is the platform target of
+# Corstone-300, that includes ethosu_core_driver and bare-metal bringup
+# libraries. We link against ethosu_target_init which includes all of these
+# dependencies.
 
 # For Corstone-300 FVP builds we put models into the larger DRAM area
 set(MEMORY_MODEL "dram")
@@ -46,56 +60,79 @@ add_subdirectory(${ETHOS_SDK_PATH}/core_platform/targets/corstone-300 target)
 
 # Dependencies from the ExecuTorch build
 add_library(executorch STATIC IMPORTED)
-set_property(TARGET executorch PROPERTY IMPORTED_LOCATION
-  "${ET_BUILD_DIR_PATH}/libexecutorch.a")
+set_property(
+  TARGET executorch PROPERTY IMPORTED_LOCATION
+                             "${ET_BUILD_DIR_PATH}/libexecutorch.a"
+)
 
 add_library(executorch_no_prim_ops STATIC IMPORTED)
-set_property(TARGET executorch_no_prim_ops PROPERTY IMPORTED_LOCATION
-  "${ET_BUILD_DIR_PATH}/libexecutorch_no_prim_ops.a")
+set_property(
+  TARGET executorch_no_prim_ops
+  PROPERTY IMPORTED_LOCATION "${ET_BUILD_DIR_PATH}/libexecutorch_no_prim_ops.a"
+)
 target_link_libraries(executorch INTERFACE executorch_no_prim_ops)
 
 add_library(executorch_delegate_ethos_u STATIC IMPORTED)
-set_property(TARGET executorch_delegate_ethos_u PROPERTY IMPORTED_LOCATION
-  "${ET_BUILD_DIR_PATH}/backends/arm/libexecutorch_delegate_ethos_u.a")
+set_property(
+  TARGET executorch_delegate_ethos_u
+  PROPERTY IMPORTED_LOCATION
+           "${ET_BUILD_DIR_PATH}/backends/arm/libexecutorch_delegate_ethos_u.a"
+)
 
 add_library(portable_ops_lib STATIC IMPORTED)
-set_property(TARGET portable_ops_lib PROPERTY IMPORTED_LOCATION
-  "${ET_BUILD_DIR_PATH}/examples/arm/libarm_portable_ops_lib.a")
+set_property(
+  TARGET portable_ops_lib
+  PROPERTY IMPORTED_LOCATION
+           "${ET_BUILD_DIR_PATH}/examples/arm/libarm_portable_ops_lib.a"
+)
 add_library(portable_kernels STATIC IMPORTED)
-set_property(TARGET portable_kernels PROPERTY IMPORTED_LOCATION
-  "${ET_BUILD_DIR_PATH}/kernels/portable/libportable_kernels.a")
+set_property(
+  TARGET portable_kernels
+  PROPERTY IMPORTED_LOCATION
+           "${ET_BUILD_DIR_PATH}/kernels/portable/libportable_kernels.a"
+)
 
 add_library(quantized_ops_lib STATIC IMPORTED)
-set_property(TARGET quantized_ops_lib PROPERTY IMPORTED_LOCATION
-  "${ET_BUILD_DIR_PATH}/kernels/quantized/libquantized_ops_lib.a")
+set_property(
+  TARGET quantized_ops_lib
+  PROPERTY IMPORTED_LOCATION
+           "${ET_BUILD_DIR_PATH}/kernels/quantized/libquantized_ops_lib.a"
+)
 add_library(quantized_kernels STATIC IMPORTED)
-set_property(TARGET quantized_kernels PROPERTY IMPORTED_LOCATION
-  "${ET_BUILD_DIR_PATH}/kernels/quantized/libquantized_kernels.a")
+set_property(
+  TARGET quantized_kernels
+  PROPERTY IMPORTED_LOCATION
+           "${ET_BUILD_DIR_PATH}/kernels/quantized/libquantized_kernels.a"
+)
 
 add_library(extension_runner_util STATIC IMPORTED)
-set_property(TARGET extension_runner_util PROPERTY IMPORTED_LOCATION
-  "${ET_BUILD_DIR_PATH}/extension/runner_util/libextension_runner_util.a")
+set_property(
+  TARGET extension_runner_util
+  PROPERTY
+    IMPORTED_LOCATION
+    "${ET_BUILD_DIR_PATH}/extension/runner_util/libextension_runner_util.a"
+)
 
 # Convert pte to header
-add_custom_target(gen_model_header
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/model_pte.h)
+add_custom_target(
+  gen_model_header DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/model_pte.h
+)
 
 add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/model_pte.h
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/pte_to_header.py
-    --pte ${ET_PTE_FILE_PATH}
-    --outdir ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${ET_PTE_FILE_PATH}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/model_pte.h
+  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/pte_to_header.py --pte
+          ${ET_PTE_FILE_PATH} --outdir ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${ET_PTE_FILE_PATH}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 # The arm_executor_runner executable
-add_executable( arm_executor_runner )
+add_executable(arm_executor_runner)
 
-target_sources( arm_executor_runner PRIVATE arm_executor_runner.cpp )
+target_sources(arm_executor_runner PRIVATE arm_executor_runner.cpp)
 
 # Include the target's bare-metal linker script
-ethosu_eval_link_options( arm_executor_runner )
+ethosu_eval_link_options(arm_executor_runner)
 
 # Need whole-archive to ensure C++ ctor's are called - this may be wasteful for
 # bin size as we link in a number of other symbols
@@ -111,25 +148,24 @@ target_link_libraries(
   quantized_kernels
   portable_kernels
   "-Wl,--no-whole-archive"
-  )
+)
 
 # ET headers and generated headers includes
-target_include_directories(arm_executor_runner PRIVATE
-  ${ET_INCLUDE_PATH}
-  ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(
+  arm_executor_runner PRIVATE ${ET_INCLUDE_PATH} ${CMAKE_CURRENT_BINARY_DIR}
+)
 
 add_dependencies(arm_executor_runner gen_model_header)
 
-
 if(SEMIHOSTING)
-target_compile_definitions(arm_executor_runner PUBLIC SEMIHOSTING)
+  target_compile_definitions(arm_executor_runner PUBLIC SEMIHOSTING)
 endif()
 
 # Fixup compilation of retarget.c
 if(SEMIHOSTING)
-# Remove this when MLBEDSW-8910 is closed.
-set_source_files_properties(
-  ${ETHOS_SDK_PATH}/core_platform/targets/corstone-300/retarget.c
-  PROPERTIES HEADER_FILE_ONLY TRUE
-)
+  # Remove this when MLBEDSW-8910 is closed.
+  set_source_files_properties(
+    ${ETHOS_SDK_PATH}/core_platform/targets/corstone-300/retarget.c
+    PROPERTIES HEADER_FILE_ONLY TRUE
+  )
 endif()

--- a/examples/cadence/CMakeLists.txt
+++ b/examples/cadence/CMakeLists.txt
@@ -44,7 +44,8 @@ add_compile_options(
   -fsigned-char
   -Wno-missing-braces
   -fmessage-length=0
-  -DPRINTF_FLOAT_ENABLE=1)
+  -DPRINTF_FLOAT_ENABLE=1
+)
 
 if(NOT DEFINED NXP_SDK_ROOT_DIR)
   message(FATAL_ERROR "NXP_SDK_ROOT_DIR is not set")
@@ -67,7 +68,8 @@ set(SOURCES
     ${NXP_SDK_ROOT_DIR}/devices/MIMXRT685S/utilities/debug_console_lite/fsl_debug_console.c
     ${NXP_SDK_ROOT_DIR}/boards/evkmimxrt685/dsp_examples/mu_polling/dsp/board_hifi4.c
     ${NXP_SDK_ROOT_DIR}/boards/evkmimxrt685/dsp_examples/mu_polling/dsp/pin_mux.c
-    ${NXP_SDK_ROOT_DIR}/devices/MIMXRT685S/utilities/str/fsl_str.c)
+    ${NXP_SDK_ROOT_DIR}/devices/MIMXRT685S/utilities/str/fsl_str.c
+)
 
 add_library(dsp_mu_polling_libs STATIC ${SOURCES})
 
@@ -81,11 +83,16 @@ target_include_directories(
          ${NXP_SDK_ROOT_DIR}/devices/MIMXRT685S
          ${NXP_SDK_ROOT_DIR}/CMSIS/Core/Include
          ${NXP_SDK_ROOT_DIR}/devices/MIMXRT685S/utilities/str
-         ${NXP_SDK_ROOT_DIR}/boards/evkmimxrt685/dsp_examples/mu_polling/dsp)
+         ${NXP_SDK_ROOT_DIR}/boards/evkmimxrt685/dsp_examples/mu_polling/dsp
+)
 
 add_library(extension_runner_util STATIC IMPORTED)
-set_property(TARGET extension_runner_util PROPERTY IMPORTED_LOCATION
-  "${CMAKE_CURRENT_LIST_DIR}/../../cmake-out/extension/runner_util/libextension_runner_util.a")
+set_property(
+  TARGET extension_runner_util
+  PROPERTY
+    IMPORTED_LOCATION
+    "${CMAKE_CURRENT_LIST_DIR}/../../cmake-out/extension/runner_util/libextension_runner_util.a"
+)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ops)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/kernels)
@@ -96,7 +103,8 @@ add_custom_command(
   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/utils/gen_header.py
           --model_path ${MODEL_PATH} --header_output_path ${CMAKE_BINARY_DIR}
   COMMENT "Converting .pte model to header file..."
-  DEPENDS ${CMAKE_CURRENT_LIST_DIR}/utils/gen_header.py)
+  DEPENDS ${CMAKE_CURRENT_LIST_DIR}/utils/gen_header.py
+)
 
 add_custom_target(gen_model_header DEPENDS ${CMAKE_BINARY_DIR}/model_pte.h)
 
@@ -104,14 +112,19 @@ add_executable(cadence_executorch_example executor_runner.cpp)
 add_dependencies(cadence_executorch_example gen_model_header)
 
 # lint_cmake: -linelength
-target_include_directories(cadence_executorch_example PUBLIC ${ROOT_DIR}/..
-                                                            ${CMAKE_BINARY_DIR}
-                                                            ${_common_include_directories})
+target_include_directories(
+  cadence_executorch_example PUBLIC ${ROOT_DIR}/.. ${CMAKE_BINARY_DIR}
+                                    ${_common_include_directories}
+)
 
-target_link_options(cadence_executorch_example PRIVATE
-                    -mlsp=${NXP_SDK_ROOT_DIR}/devices/MIMXRT685S/xtensa/min-rt)
-target_link_libraries(cadence_executorch_example dsp_mu_polling_libs
-                      cadence_ops_lib extension_runner_util executorch)
+target_link_options(
+  cadence_executorch_example PRIVATE
+  -mlsp=${NXP_SDK_ROOT_DIR}/devices/MIMXRT685S/xtensa/min-rt
+)
+target_link_libraries(
+  cadence_executorch_example dsp_mu_polling_libs cadence_ops_lib
+  extension_runner_util executorch
+)
 
 add_custom_command(
   TARGET cadence_executorch_example
@@ -124,4 +137,5 @@ add_custom_command(
     the dsp_text_release.bin and dsp_data_release.bin that are generated into
     your NXP MCUXpresso IDE workspace and flash the DSP with these binaries."
     DEPENDS
-    ${CMAKE_CURRENT_LIST_DIR}/utils/post_compilation.py)
+    ${CMAKE_CURRENT_LIST_DIR}/utils/post_compilation.py
+)

--- a/examples/cadence/cadence.cmake
+++ b/examples/cadence/cadence.cmake
@@ -9,7 +9,8 @@ set(XTENSA_TOOLCHAIN_PATH $ENV{XTENSA_TOOLCHAIN})
 if(NOT EXISTS ${XTENSA_TOOLCHAIN_PATH})
   message(
     FATAL_ERROR
-      "Nothing found at XTENSA_TOOLCHAIN_PATH: '${XTENSA_TOOLCHAIN_PATH}'")
+      "Nothing found at XTENSA_TOOLCHAIN_PATH: '${XTENSA_TOOLCHAIN_PATH}'"
+  )
 endif()
 
 set(TOOLCHAIN_HOME ${XTENSA_TOOLCHAIN_PATH}/$ENV{TOOLCHAIN_VER}/XtensaTools)
@@ -29,7 +30,8 @@ list(APPEND TOOLCHAIN_C_FLAGS -fms-extensions)
 
 set(TOOLCHAIN_HAS_NEWLIB
     OFF
-    CACHE BOOL "True if toolchain supports newlib")
+    CACHE BOOL "True if toolchain supports newlib"
+)
 
 set(COMPILER xt-clang)
 # set(CC clang) set(C++ clang++)

--- a/examples/cadence/kernels/CMakeLists.txt
+++ b/examples/cadence/kernels/CMakeLists.txt
@@ -5,7 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 # lint_cmake: -linelength
-add_library(cadence_kernels kernels.cpp ${EXECUTORCH_ROOT}/examples/cadence/third-party/nnlib-hifi4/matmul_asym8uxasym8u_asym8u.cpp)
+add_library(
+  cadence_kernels
+  kernels.cpp
+  ${EXECUTORCH_ROOT}/examples/cadence/third-party/nnlib-hifi4/matmul_asym8uxasym8u_asym8u.cpp
+)
 
 target_include_directories(
   cadence_kernels
@@ -14,4 +18,5 @@ target_include_directories(
          ${NN_LIB_BASE_DIR}/xa_nnlib/include/nnlib
          ${NN_LIB_BASE_DIR}/xa_nnlib/include
          ${NN_LIB_BASE_DIR}/xa_nnlib/algo/ndsp/hifi4/include/
-         ${NXP_SDK_ROOT_DIR}/middleware/dsp/naturedsp/hifi4/include/)
+         ${NXP_SDK_ROOT_DIR}/middleware/dsp/naturedsp/hifi4/include/
+)

--- a/examples/cadence/ops/CMakeLists.txt
+++ b/examples/cadence/ops/CMakeLists.txt
@@ -32,7 +32,8 @@ set(_aten_ops__srcs
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/op_permute_copy.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/copy_ops_util.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/broadcast_util.cpp"
-    "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/repeat_util.cpp")
+    "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/repeat_util.cpp"
+)
 add_library(aten_ops_cadence ${_aten_ops__srcs})
 target_link_libraries(aten_ops_cadence PUBLIC executorch)
 target_link_libraries(aten_ops_cadence PRIVATE cadence_kernels)
@@ -42,27 +43,36 @@ set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 
 target_include_directories(
   aten_ops_cadence PUBLIC ${ROOT_DIR}/.. ${CMAKE_BINARY_DIR}
-                          ${_common_include_directories})
+                          ${_common_include_directories}
+)
 
 # Custom ops that are needed to run the test model.
 add_library(
   custom_ops
   "quantized_linear_out.cpp" "quantized_conv_out.cpp" "quantized_relu_out.cpp"
   "quantized_layer_norm.cpp" "quantize_per_tensor.cpp"
-  "dequantize_per_tensor.cpp")
-target_include_directories(custom_ops PUBLIC ${ROOT_DIR}/.. ${CMAKE_BINARY_DIR}
-                                             ${_common_include_directories})
+  "dequantize_per_tensor.cpp"
+)
+target_include_directories(
+  custom_ops PUBLIC ${ROOT_DIR}/.. ${CMAKE_BINARY_DIR}
+                    ${_common_include_directories}
+)
 
 target_link_libraries(custom_ops PUBLIC executorch)
 target_link_libraries(custom_ops PRIVATE cadence_kernels)
 
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in functions.yaml
-gen_selected_ops(LIB_NAME "cadence_ops_lib" OPS_SCHEMA_YAML
-                 "${CMAKE_CURRENT_LIST_DIR}/functions.yaml")
-generate_bindings_for_kernels(LIB_NAME "cadence_ops_lib" FUNCTIONS_YAML
-                              ${CMAKE_CURRENT_SOURCE_DIR}/functions.yaml)
+gen_selected_ops(
+  LIB_NAME "cadence_ops_lib" OPS_SCHEMA_YAML
+  "${CMAKE_CURRENT_LIST_DIR}/functions.yaml"
+)
+generate_bindings_for_kernels(
+  LIB_NAME "cadence_ops_lib" FUNCTIONS_YAML
+  ${CMAKE_CURRENT_SOURCE_DIR}/functions.yaml
+)
 message("Generated files ${gen_command_sources}")
 
-gen_operators_lib(LIB_NAME "cadence_ops_lib" KERNEL_LIBS custom_ops DEPS
-                  aten_ops_cadence)
+gen_operators_lib(
+  LIB_NAME "cadence_ops_lib" KERNEL_LIBS custom_ops DEPS aten_ops_cadence
+)

--- a/examples/llm_manual/CMakeLists.txt
+++ b/examples/llm_manual/CMakeLists.txt
@@ -18,16 +18,18 @@ option(EXECUTORCH_BUILD_XNNPACK "" ON) # Build with Xnnpack backend
 
 # Include the executorch subdirectory.
 add_subdirectory(
-    ${CMAKE_CURRENT_SOURCE_DIR}/third-party/executorch
-    ${CMAKE_BINARY_DIR}/executorch)
+  ${CMAKE_CURRENT_SOURCE_DIR}/third-party/executorch
+  ${CMAKE_BINARY_DIR}/executorch
+)
 
 # include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 add_executable(nanogpt_runner main.cpp)
 target_link_libraries(
-    nanogpt_runner
-    PRIVATE
-    executorch
-    extension_module_static # Provides the Module class
-    optimized_native_cpu_ops_lib # Provides baseline cross-platform kernels
-    xnnpack_backend) # Provides the XNNPACK CPU acceleration backend
+  nanogpt_runner
+  PRIVATE executorch
+          extension_module_static # Provides the Module class
+          optimized_native_cpu_ops_lib # Provides baseline cross-platform
+                                       # kernels
+          xnnpack_backend
+) # Provides the XNNPACK CPU acceleration backend

--- a/examples/models/llama2/CMakeLists.txt
+++ b/examples/models/llama2/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 # This file should be formatted with
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 # It should also be cmake-lint clean.
 #
@@ -29,12 +29,15 @@ include(CMakeDependentOption)
 #
 cmake_dependent_option(
   EXECUTORCH_BUILD_PTHREADPOOL "Build pthreadpool library." ON
-  "NOT EXECUTORCH_BUILD_ARM_BAREMETAL" OFF)
+  "NOT EXECUTORCH_BUILD_ARM_BAREMETAL" OFF
+)
 #
 # cpuinfo: build cpuinfo library. Disable on unsupported platforms
 #
-cmake_dependent_option(EXECUTORCH_BUILD_CPUINFO "Build cpuinfo library." ON
-                       "NOT EXECUTORCH_BUILD_ARM_BAREMETAL" OFF)
+cmake_dependent_option(
+  EXECUTORCH_BUILD_CPUINFO "Build cpuinfo library." ON
+  "NOT EXECUTORCH_BUILD_ARM_BAREMETAL" OFF
+)
 
 if(NOT PYTHON_EXECUTABLE)
   set(PYTHON_EXECUTABLE python3)
@@ -111,7 +114,8 @@ if(EXECUTORCH_BUILD_OPTIMIZED)
     optimized_kernels
     portable_kernels
     cpublas
-    eigen_blas)
+    eigen_blas
+  )
   target_link_options_shared_lib(optimized_native_cpu_ops_lib)
 else()
   list(APPEND link_libraries portable_ops_lib portable_kernels)
@@ -135,10 +139,12 @@ if(EXECUTORCH_BUILD_PTHREADPOOL)
   # These 2 source files are included in xnnpack_backend
   if(NOT TARGET xnnpack_backend)
     list(APPEND _srcs ${XNNPACK_ROOT}/threadpool/threadpool.cpp
-         ${XNNPACK_ROOT}/threadpool/threadpool_guard.cpp)
+         ${XNNPACK_ROOT}/threadpool/threadpool_guard.cpp
+    )
   endif()
   list(APPEND _common_include_directories
-       ${XNNPACK_ROOT}/third-party/pthreadpool/include)
+       ${XNNPACK_ROOT}/third-party/pthreadpool/include
+  )
 endif()
 
 # Extra sources for cpuinfo
@@ -146,7 +152,8 @@ if(EXECUTORCH_BUILD_CPUINFO)
   list(APPEND link_libraries cpuinfo)
   list(APPEND _srcs ${XNNPACK_ROOT}/threadpool/cpuinfo_utils.cpp)
   list(APPEND _common_include_directories
-       ${XNNPACK_ROOT}/third-party/cpuinfo/include)
+       ${XNNPACK_ROOT}/third-party/cpuinfo/include
+  )
 endif()
 
 # XNNPACK
@@ -177,7 +184,8 @@ if(TARGET mpsdelegate)
     "-framework Foundation"
     "-weak_framework MetalPerformanceShaders"
     "-weak_framework MetalPerformanceShadersGraph"
-    "-weak_framework Metal")
+    "-weak_framework Metal"
+  )
   target_link_options_shared_lib(mpsdelegate)
 endif()
 

--- a/examples/models/llama2/custom_ops/CMakeLists.txt
+++ b/examples/models/llama2/custom_ops/CMakeLists.txt
@@ -34,7 +34,8 @@ include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
 # The `_<target>_srcs` lists are defined by including ${EXECUTORCH_SRCS_FILE}.
 #
 set(EXECUTORCH_SRCS_FILE
-    "${CMAKE_CURRENT_BINARY_DIR}/../../../../executorch_srcs.cmake")
+    "${CMAKE_CURRENT_BINARY_DIR}/../../../../executorch_srcs.cmake"
+)
 
 extract_sources(${EXECUTORCH_SRCS_FILE})
 
@@ -69,26 +70,34 @@ add_library(custom_ops ${_custom_ops__srcs})
 
 target_include_directories(custom_ops PUBLIC "${_common_include_directories}")
 target_include_directories(
-  custom_ops PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../../../../include")
+  custom_ops PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../../../../include"
+)
 target_link_libraries(custom_ops PUBLIC ${custom_ops_libs})
 
-target_compile_options(custom_ops PUBLIC ${_common_compile_options}
-                                         -DET_USE_THREADPOOL)
+target_compile_options(
+  custom_ops PUBLIC ${_common_compile_options} -DET_USE_THREADPOOL
+)
 
 install(TARGETS custom_ops DESTINATION lib)
 
 if(EXECUTORCH_BUILD_CUSTOM_OPS_AOT)
   # Add a AOT library
   find_package(Torch CONFIG REQUIRED)
-  add_library(custom_ops_aot_lib SHARED
-              ${CMAKE_CURRENT_SOURCE_DIR}/op_sdpa_aot.cpp)
-  target_include_directories(custom_ops_aot_lib
-                            PUBLIC "${_common_include_directories}")
+  add_library(
+    custom_ops_aot_lib SHARED ${CMAKE_CURRENT_SOURCE_DIR}/op_sdpa_aot.cpp
+  )
   target_include_directories(
-    custom_ops_aot_lib PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../../../../include")
+    custom_ops_aot_lib PUBLIC "${_common_include_directories}"
+  )
+  target_include_directories(
+    custom_ops_aot_lib
+    PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../../../../include"
+  )
   target_link_libraries(custom_ops_aot_lib PUBLIC custom_ops torch)
-  target_compile_options(custom_ops_aot_lib PUBLIC -Wno-deprecated-declarations
-                                                  -fPIC -frtti -fexceptions)
+  target_compile_options(
+    custom_ops_aot_lib PUBLIC -Wno-deprecated-declarations -fPIC -frtti
+                              -fexceptions
+  )
 
   install(TARGETS custom_ops_aot_lib DESTINATION lib)
 endif()

--- a/examples/models/llama2/runner/CMakeLists.txt
+++ b/examples/models/llama2/runner/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 # This file should be formatted with
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 # It should also be cmake-lint clean.
 #
@@ -27,7 +27,8 @@ include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
 # The `_<target>_srcs` lists are defined by including ${EXECUTORCH_SRCS_FILE}.
 #
 set(EXECUTORCH_SRCS_FILE
-    "${CMAKE_CURRENT_BINARY_DIR}/../../../../executorch_srcs.cmake")
+    "${CMAKE_CURRENT_BINARY_DIR}/../../../../executorch_srcs.cmake"
+)
 
 extract_sources(${EXECUTORCH_SRCS_FILE})
 
@@ -36,18 +37,21 @@ include(${EXECUTORCH_SRCS_FILE})
 # build llama_runner library
 list(TRANSFORM _llama_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
 
-target_include_directories(extension_module
-                           INTERFACE ${_common_include_directories})
+target_include_directories(
+  extension_module INTERFACE ${_common_include_directories}
+)
 
 if(EXECUTORCH_USE_TIKTOKEN)
   list(APPEND _llama_runner__srcs
-       ${CMAKE_CURRENT_SOURCE_DIR}/../tokenizer/tiktoken.cpp)
+       ${CMAKE_CURRENT_SOURCE_DIR}/../tokenizer/tiktoken.cpp
+  )
   set(_preprocessor_flag -DET_USE_TIKTOKEN)
 endif()
 
 if(CMAKE_TOOLCHAIN_IOS
    OR ANDROID
-   OR APPLE)
+   OR APPLE
+)
   # Building a share library on iOS requires code signing On Android we see
   # duplicated registration when using shared lib
   add_library(llama_runner STATIC ${_llama_runner__srcs})
@@ -59,6 +63,7 @@ set(llama_runner_deps executorch extension_module extension_data_loader)
 
 target_link_libraries(llama_runner PUBLIC ${llama_runner_deps})
 
-target_include_directories(llama_runner INTERFACE ${_common_include_directories}
-                                                  ${EXECUTORCH_ROOT})
+target_include_directories(
+  llama_runner INTERFACE ${_common_include_directories} ${EXECUTORCH_ROOT}
+)
 target_compile_options(llama_runner PUBLIC ${_preprocessor_flag})

--- a/examples/portable/custom_ops/CMakeLists.txt
+++ b/examples/portable/custom_ops/CMakeLists.txt
@@ -44,8 +44,9 @@ set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 
 find_package(executorch CONFIG REQUIRED)
-find_package(gflags REQUIRED PATHS
-             ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party)
+find_package(
+  gflags REQUIRED PATHS ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party
+)
 
 target_include_directories(executorch INTERFACE ${_common_include_directories})
 
@@ -57,14 +58,16 @@ target_include_directories(executorch INTERFACE ${_common_include_directories})
 option(
   REGISTER_EXAMPLE_CUSTOM_OP
   "Register whether custom op 1 (my_ops::mul3) or custom op 2 (my_ops::mul4) \
-  or no custom op at all." OFF)
+  or no custom op at all." OFF
+)
 # ------------------------------- OPTIONS END --------------------------------
 
 #
 # The `_<target>_srcs` lists are defined by including ${EXECUTORCH_SRCS_FILE}.
 #
 set(EXECUTORCH_SRCS_FILE
-    "${CMAKE_CURRENT_BINARY_DIR}/../../../executorch_srcs.cmake")
+    "${CMAKE_CURRENT_BINARY_DIR}/../../../executorch_srcs.cmake"
+)
 
 extract_sources(${EXECUTORCH_SRCS_FILE})
 
@@ -73,35 +76,36 @@ include(${EXECUTORCH_SRCS_FILE})
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime).
 if(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 1)
-  gen_selected_ops(
-    LIB_NAME "custom_ops_lib"
-    ROOT_OPS "my_ops::mul3.out")
+  gen_selected_ops(LIB_NAME "custom_ops_lib" ROOT_OPS "my_ops::mul3.out")
 elseif(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
-  gen_selected_ops(
-    LIB_NAME "custom_ops_lib"
-    ROOT_OPS "my_ops::mul4.out")
+  gen_selected_ops(LIB_NAME "custom_ops_lib" ROOT_OPS "my_ops::mul4.out")
 endif()
 # Expect gen_selected_ops output file to be selected_operators.yaml
-generate_bindings_for_kernels(LIB_NAME "custom_ops_lib" CUSTOM_OPS_YAML
-                              ${CMAKE_CURRENT_LIST_DIR}/custom_ops.yaml)
+generate_bindings_for_kernels(
+  LIB_NAME "custom_ops_lib" CUSTOM_OPS_YAML
+  ${CMAKE_CURRENT_LIST_DIR}/custom_ops.yaml
+)
 message("Generated files ${gen_command_sources}")
 
 # Prepare for C++ libraries.
 
 # C++ library to register custom ops into PyTorch.
 if(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
-  gen_selected_ops(
-    LIB_NAME "custom_ops_aot_lib"
-    ROOT_OPS "my_ops::mul4.out")
-  generate_bindings_for_kernels(LIB_NAME "custom_ops_aot_lib" CUSTOM_OPS_YAML
-    ${CMAKE_CURRENT_LIST_DIR}/custom_ops.yaml)
+  gen_selected_ops(LIB_NAME "custom_ops_aot_lib" ROOT_OPS "my_ops::mul4.out")
+  generate_bindings_for_kernels(
+    LIB_NAME "custom_ops_aot_lib" CUSTOM_OPS_YAML
+    ${CMAKE_CURRENT_LIST_DIR}/custom_ops.yaml
+  )
   set(custom_ops_kernel_sources
       ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2.cpp # register my_ops::mul4
       ${CMAKE_CURRENT_LIST_DIR}/custom_ops_2_out.cpp # register my_ops::mul4.out
   )
-  gen_custom_ops_aot_lib(LIB_NAME "custom_ops_aot_lib" KERNEL_SOURCES "${custom_ops_kernel_sources}")
-  target_include_directories(custom_ops_aot_lib
-                             PUBLIC ${_common_include_directories})
+  gen_custom_ops_aot_lib(
+    LIB_NAME "custom_ops_aot_lib" KERNEL_SOURCES "${custom_ops_kernel_sources}"
+  )
+  target_include_directories(
+    custom_ops_aot_lib PUBLIC ${_common_include_directories}
+  )
 endif()
 
 # C++ library to register custom ops into Executorch runtime.
@@ -115,13 +119,16 @@ add_library(custom_kernels ${kernel_sources})
 target_link_libraries(custom_kernels PRIVATE executorch)
 target_compile_options(custom_kernels PUBLIC ${_common_compile_options})
 
-gen_operators_lib(LIB_NAME "custom_ops_lib" KERNEL_LIBS custom_kernels DEPS
-                  executorch)
+gen_operators_lib(
+  LIB_NAME "custom_ops_lib" KERNEL_LIBS custom_kernels DEPS executorch
+)
 
 list(TRANSFORM _executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
 
 add_executable(custom_ops_executor_runner ${_executor_runner__srcs})
-target_link_libraries(custom_ops_executor_runner custom_ops_lib executorch
-                      gflags)
-target_compile_options(custom_ops_executor_runner
-                       PUBLIC ${_common_compile_options})
+target_link_libraries(
+  custom_ops_executor_runner custom_ops_lib executorch gflags
+)
+target_compile_options(
+  custom_ops_executor_runner PUBLIC ${_common_compile_options}
+)

--- a/examples/qualcomm/CMakeLists.txt
+++ b/examples/qualcomm/CMakeLists.txt
@@ -46,35 +46,45 @@ set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 # The `_<target>_srcs` lists are defined by including ${EXECUTORCH_SRCS_FILE}.
 #
 set(EXECUTORCH_SRCS_FILE
-    "${CMAKE_CURRENT_BINARY_DIR}/../../executorch_srcs.cmake")
+    "${CMAKE_CURRENT_BINARY_DIR}/../../executorch_srcs.cmake"
+)
 extract_sources(${EXECUTORCH_SRCS_FILE})
 include(${EXECUTORCH_SRCS_FILE})
 
-get_filename_component(EXECUTORCH_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.."
-                       ABSOLUTE)
+get_filename_component(
+  EXECUTORCH_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE
+)
 set(_qnn_executor_runner__srcs ${_executor_runner__srcs})
 
 # portable_ops_lib
 gen_selected_ops(LIB_NAME "full_portable_ops_lib" INCLUDE_ALL_OPS "ON")
 generate_bindings_for_kernels(
   LIB_NAME "full_portable_ops_lib" FUNCTIONS_YAML
-  ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml)
-gen_operators_lib(LIB_NAME "full_portable_ops_lib" KERNEL_LIBS portable_kernels
-                  DEPS executorch)
-target_compile_options(full_portable_ops_lib
-                       INTERFACE -DET_EVENT_TRACER_ENABLED)
-target_include_directories(full_portable_ops_lib
-                           PUBLIC ${_common_include_directories})
+  ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
+)
+gen_operators_lib(
+  LIB_NAME "full_portable_ops_lib" KERNEL_LIBS portable_kernels DEPS executorch
+)
+target_compile_options(
+  full_portable_ops_lib INTERFACE -DET_EVENT_TRACER_ENABLED
+)
+target_include_directories(
+  full_portable_ops_lib PUBLIC ${_common_include_directories}
+)
 
 list(TRANSFORM _qnn_executor_runner__srcs PREPEND "${EXECUTORCH_SOURCE_DIR}/")
 list(FILTER _qnn_executor_runner__srcs EXCLUDE REGEX ".*executor_runner.cpp$")
 list(PREPEND _qnn_executor_runner__srcs
-     ${CMAKE_CURRENT_LIST_DIR}/executor_runner/qnn_executor_runner.cpp)
+     ${CMAKE_CURRENT_LIST_DIR}/executor_runner/qnn_executor_runner.cpp
+)
 
 add_executable(qnn_executor_runner ${_qnn_executor_runner__srcs})
 
-target_include_directories(qnn_executor_runner
-                           PUBLIC ${_common_include_directories})
-target_link_libraries(qnn_executor_runner qnn_executorch_backend
-                      full_portable_ops_lib etdump ${FLATCCRT_LIB} gflags)
+target_include_directories(
+  qnn_executor_runner PUBLIC ${_common_include_directories}
+)
+target_link_libraries(
+  qnn_executor_runner qnn_executorch_backend full_portable_ops_lib etdump
+  ${FLATCCRT_LIB} gflags
+)
 target_compile_options(qnn_executor_runner PUBLIC ${_common_compile_options})

--- a/examples/sdk/CMakeLists.txt
+++ b/examples/sdk/CMakeLists.txt
@@ -35,8 +35,8 @@ set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 # Let files say "include <executorch/path/to/header.h>".
 set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 
-# Find prebuilt libraries. executorch package should contain
-# portable_ops_lib, etdump, bundled_program.
+# Find prebuilt libraries. executorch package should contain portable_ops_lib,
+# etdump, bundled_program.
 find_package(executorch CONFIG REQUIRED)
 target_link_options_shared_lib(executorch)
 target_link_options_shared_lib(portable_ops_lib)
@@ -47,15 +47,12 @@ find_package(
   gflags REQUIRED PATHS ${CMAKE_CURRENT_BINARY_DIR}/../../third-party
 )
 
-add_executable(sdk_example_runner
-               sdk_example_runner/sdk_example_runner.cpp)
+add_executable(sdk_example_runner sdk_example_runner/sdk_example_runner.cpp)
 target_compile_options(executorch INTERFACE -DET_EVENT_TRACER_ENABLED)
 
 target_include_directories(
-  etdump
-  INTERFACE
-  ${CMAKE_CURRENT_BINARY_DIR}/../../sdk/include
-  ${EXECUTORCH_ROOT}/third-party/flatcc/include
+  etdump INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/../../sdk/include
+                   ${EXECUTORCH_ROOT}/third-party/flatcc/include
 )
 target_link_libraries(
   sdk_example_runner

--- a/examples/selective_build/CMakeLists.txt
+++ b/examples/selective_build/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 # This file should be formatted with
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 # It should also be cmake-lint clean.
 #
@@ -39,8 +39,9 @@ set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 
 find_package(executorch CONFIG REQUIRED)
-find_package(gflags REQUIRED PATHS
-             ${CMAKE_CURRENT_BINARY_DIR}/../../third-party)
+find_package(
+  gflags REQUIRED PATHS ${CMAKE_CURRENT_BINARY_DIR}/../../third-party
+)
 
 target_include_directories(executorch INTERFACE ${_common_include_directories})
 
@@ -48,22 +49,26 @@ target_include_directories(executorch INTERFACE ${_common_include_directories})
 
 # Option to register ops from yaml file
 option(EXECUTORCH_SELECT_OPS_YAML "Register all the ops from a given yaml file"
-       OFF)
+       OFF
+)
 
 # Option to register op list
 option(EXECUTORCH_SELECT_OPS_LIST "Register a list of ops, separated by comma"
-       OFF)
+       OFF
+)
 
 # Selective build options.
 option(EXECUTORCH_SELECT_ALL_OPS
-       "Whether to register all ops defined in portable kernel library." OFF)
+       "Whether to register all ops defined in portable kernel library." OFF
+)
 # ------------------------------- OPTIONS END --------------------------------
 
 #
 # The `_<target>_srcs` lists are defined by including ${EXECUTORCH_SRCS_FILE}.
 #
 set(EXECUTORCH_SRCS_FILE
-    "${CMAKE_CURRENT_BINARY_DIR}/../../executorch_srcs.cmake")
+    "${CMAKE_CURRENT_BINARY_DIR}/../../executorch_srcs.cmake"
+)
 
 extract_sources(${EXECUTORCH_SRCS_FILE})
 
@@ -76,10 +81,12 @@ include(${EXECUTORCH_SRCS_FILE})
 set(_kernel_lib)
 if(EXECUTORCH_SELECT_OPS_YAML)
   set(_custom_ops_yaml
-      ${EXECUTORCH_ROOT}/examples/portable/custom_ops/custom_ops.yaml)
+      ${EXECUTORCH_ROOT}/examples/portable/custom_ops/custom_ops.yaml
+  )
   set(kernel_sources
       ${EXECUTORCH_ROOT}/examples/portable/custom_ops/custom_ops_1_out.cpp
-      ${EXECUTORCH_ROOT}/examples/portable/custom_ops/custom_ops_2_out.cpp)
+      ${EXECUTORCH_ROOT}/examples/portable/custom_ops/custom_ops_2_out.cpp
+  )
   #
   # custom_kernels: C++ kernel implementations of custom ops
   #
@@ -100,15 +107,18 @@ gen_selected_ops(
   ROOT_OPS
   "${EXECUTORCH_SELECT_OPS_LIST}"
   INCLUDE_ALL_OPS
-  "${EXECUTORCH_SELECT_ALL_OPS}")
+  "${EXECUTORCH_SELECT_ALL_OPS}"
+)
 
 generate_bindings_for_kernels(
   LIB_NAME "select_build_lib" FUNCTIONS_YAML
   ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml CUSTOM_OPS_YAML
-  "${_custom_ops_yaml}")
+  "${_custom_ops_yaml}"
+)
 
-gen_operators_lib(LIB_NAME "select_build_lib" KERNEL_LIBS ${_kernel_lib} DEPS
-                  executorch)
+gen_operators_lib(
+  LIB_NAME "select_build_lib" KERNEL_LIBS ${_kernel_lib} DEPS executorch
+)
 
 list(TRANSFORM _executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
 
@@ -120,8 +130,9 @@ add_executable(selective_build_test ${_executor_runner__srcs})
 if(CMAKE_BUILD_TYPE EQUAL "Release")
   target_link_options(selective_build_test PRIVATE "LINKER:--gc-sections")
 endif()
-target_link_libraries(selective_build_test PRIVATE executorch gflags
-                                                   select_build_lib)
+target_link_libraries(
+  selective_build_test PRIVATE executorch gflags select_build_lib
+)
 target_link_options_shared_lib(select_build_lib)
 target_link_options_shared_lib(executorch)
 target_compile_options(selective_build_test PUBLIC ${_common_compile_options})

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -22,8 +22,10 @@ include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 
-add_subdirectory(${EXECUTORCH_ROOT}/examples/third-party/fbjni
-                 ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni)
+add_subdirectory(
+  ${EXECUTORCH_ROOT}/examples/third-party/fbjni
+  ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni
+)
 
 set(executorch_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../lib/cmake/ExecuTorch)
 find_package(executorch CONFIG REQUIRED)
@@ -31,11 +33,19 @@ target_link_options_shared_lib(executorch)
 
 set(link_libraries)
 list(APPEND link_libraries extension_data_loader extension_module executorch
-            fbjni)
+     fbjni
+)
 
 if(TARGET optimized_native_cpu_ops_lib)
-  list(APPEND link_libraries optimized_native_cpu_ops_lib optimized_kernels
-              portable_kernels cpublas eigen_blas)
+  list(
+    APPEND
+    link_libraries
+    optimized_native_cpu_ops_lib
+    optimized_kernels
+    portable_kernels
+    cpublas
+    eigen_blas
+  )
   target_link_options_shared_lib(optimized_native_cpu_ops_lib)
 else()
   list(APPEND link_libraries portable_ops_lib portable_kernels)
@@ -55,15 +65,23 @@ endif()
 
 add_library(executorch_jni SHARED jni/jni_layer.cpp)
 target_link_libraries(executorch_jni ${link_libraries})
-target_include_directories(executorch_jni PRIVATE ${_common_include_directories})
+target_include_directories(
+  executorch_jni PRIVATE ${_common_include_directories}
+)
 target_compile_options(executorch_jni PUBLIC ${_common_compile_options})
 
 if(EXECUTORCH_BUILD_LLAMA_JNI)
-  set(LLAMA_RUNNER_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../examples/models/llama2/runner/libllama_runner.a)
+  set(LLAMA_RUNNER_PATH
+      ${CMAKE_CURRENT_BINARY_DIR}/../../examples/models/llama2/runner/libllama_runner.a
+  )
   add_library(llama_runner STATIC IMPORTED)
-  set_property(TARGET llama_runner PROPERTY IMPORTED_LOCATION ${LLAMA_RUNNER_PATH})
+  set_property(
+    TARGET llama_runner PROPERTY IMPORTED_LOCATION ${LLAMA_RUNNER_PATH}
+  )
 
-  set(CUSTOM_OPS_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../examples/models/llama2/custom_ops/libcustom_ops.a)
+  set(CUSTOM_OPS_PATH
+      ${CMAKE_CURRENT_BINARY_DIR}/../../examples/models/llama2/custom_ops/libcustom_ops.a
+  )
   add_library(custom_ops STATIC IMPORTED)
   set_property(TARGET custom_ops PROPERTY IMPORTED_LOCATION ${CUSTOM_OPS_PATH})
   target_link_options_shared_lib(custom_ops)
@@ -71,29 +89,52 @@ if(EXECUTORCH_BUILD_LLAMA_JNI)
   target_link_options_shared_lib(quantized_ops_lib)
 
   if(TARGET pthreadpool)
-    set(LLAMA_JNI_SRCS jni/jni_layer_llama.cpp ../../backends/xnnpack/threadpool/cpuinfo_utils.cpp)
+    set(LLAMA_JNI_SRCS jni/jni_layer_llama.cpp
+                       ../../backends/xnnpack/threadpool/cpuinfo_utils.cpp
+    )
   else()
     set(LLAMA_JNI_SRCS jni/jni_layer_llama.cpp)
   endif()
   add_library(executorch_llama_jni SHARED ${LLAMA_JNI_SRCS})
   if(TARGET pthreadpool)
     target_compile_definitions(executorch_llama_jni PRIVATE ET_USE_THREADPOOL=1)
-    target_include_directories(executorch_llama_jni PUBLIC
-      ${CMAKE_CURRENT_SOURCE_DIR}/../../backends/xnnpack/third-party/cpuinfo/include)
-    target_include_directories(executorch_llama_jni PUBLIC
-      ${CMAKE_CURRENT_SOURCE_DIR}/../../backends/xnnpack/third-party/pthreadpool/include)
+    target_include_directories(
+      executorch_llama_jni
+      PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../backends/xnnpack/third-party/cpuinfo/include
+    )
+    target_include_directories(
+      executorch_llama_jni
+      PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../backends/xnnpack/third-party/pthreadpool/include
+    )
   endif()
-  target_include_directories(executorch_llama_jni PRIVATE ${_common_include_directories})
-  target_link_libraries(executorch_llama_jni ${link_libraries} llama_runner
-                        custom_ops cpublas eigen_blas quantized_kernels quantized_ops_lib)
+  target_include_directories(
+    executorch_llama_jni PRIVATE ${_common_include_directories}
+  )
+  target_link_libraries(
+    executorch_llama_jni
+    ${link_libraries}
+    llama_runner
+    custom_ops
+    cpublas
+    eigen_blas
+    quantized_kernels
+    quantized_ops_lib
+  )
   target_compile_options(executorch_llama_jni PUBLIC ${_common_compile_options})
   if(EXECUTORCH_USE_TIKTOKEN)
     set(ABSL_ENABLE_INSTALL ON)
-    set(_pic_flag
-      ${CMAKE_POSITION_INDEPENDENT_CODE})
+    set(_pic_flag ${CMAKE_POSITION_INDEPENDENT_CODE})
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../examples/models/llama2/third-party/abseil-cpp ${CMAKE_CURRENT_BINARY_DIR}/abseil-cpp)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../examples/models/llama2/third-party/re2 ${CMAKE_CURRENT_BINARY_DIR}/re2)
+    add_subdirectory(
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/models/llama2/third-party/abseil-cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/abseil-cpp
+    )
+    add_subdirectory(
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/models/llama2/third-party/re2
+      ${CMAKE_CURRENT_BINARY_DIR}/re2
+    )
     set(CMAKE_POSITION_INDEPENDENT_CODE ${_pic_flag})
     target_link_libraries(executorch_llama_jni re2::re2)
   endif()

--- a/extension/apple/CMakeLists.txt
+++ b/extension/apple/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Please this file formatted by running:
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 
 cmake_minimum_required(VERSION 3.19)
@@ -18,25 +18,15 @@ endif()
 
 add_library(extension_apple)
 
-set(EXPORTED_SOURCES
-  ExecuTorch/Exported/ExecuTorchLog.mm
-)
+set(EXPORTED_SOURCES ExecuTorch/Exported/ExecuTorchLog.mm)
 
-target_sources(
-  extension_apple PRIVATE
-  ${EXPORTED_SOURCES}
-)
+target_sources(extension_apple PRIVATE ${EXPORTED_SOURCES})
 
-target_include_directories(
-  extension_apple PUBLIC
-  ExecuTorch/Exported
-)
+target_include_directories(extension_apple PUBLIC ExecuTorch/Exported)
 
 find_library(FOUNDATION_FRAMEWORK Foundation)
-target_link_libraries(extension_apple
-  PRIVATE
-  executorch
-  ${FOUNDATION_FRAMEWORK}
+target_link_libraries(
+  extension_apple PRIVATE executorch ${FOUNDATION_FRAMEWORK}
 )
 
 target_compile_options(extension_apple PUBLIC ${_common_compile_options})

--- a/extension/data_loader/CMakeLists.txt
+++ b/extension/data_loader/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Please this file formatted by running:
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 
 cmake_minimum_required(VERSION 3.19)
@@ -27,4 +27,5 @@ install(
   TARGETS extension_data_loader
   DESTINATION lib
   INCLUDES
-  DESTINATION ${_common_include_directories})
+  DESTINATION ${_common_include_directories}
+)

--- a/extension/module/CMakeLists.txt
+++ b/extension/module/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Please this file formatted by running:
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 
 cmake_minimum_required(VERSION 3.19)
@@ -17,29 +17,37 @@ if(NOT EXECUTORCH_ROOT)
 endif()
 
 list(TRANSFORM _extension_module__srcs PREPEND "${EXECUTORCH_ROOT}/")
-if(CMAKE_TOOLCHAIN_IOS OR CMAKE_TOOLCHAIN_ANDROID OR APPLE)
-  # Building a share library on iOS requires code signing
-  # On Android we see duplicated registration when using shared lib
+if(CMAKE_TOOLCHAIN_IOS
+   OR CMAKE_TOOLCHAIN_ANDROID
+   OR APPLE
+)
+  # Building a share library on iOS requires code signing On Android we see
+  # duplicated registration when using shared lib
   add_library(extension_module STATIC ${_extension_module__srcs})
 else()
   add_library(extension_module SHARED ${_extension_module__srcs})
 endif()
 target_link_libraries(extension_module PRIVATE executorch extension_data_loader)
 target_include_directories(extension_module PUBLIC ${EXECUTORCH_ROOT}/..)
-target_compile_options(extension_module PUBLIC -Wno-deprecated-declarations
-                                               -fPIC)
+target_compile_options(
+  extension_module PUBLIC -Wno-deprecated-declarations -fPIC
+)
 
-# Module extension built as a static library.
-# TODO(gjcomer) Remove this target after cleaning up CMake targets.
+# Module extension built as a static library. TODO(gjcomer) Remove this target
+# after cleaning up CMake targets.
 add_library(extension_module_static STATIC ${_extension_module__srcs})
-target_link_libraries(extension_module_static PRIVATE executorch extension_data_loader)
+target_link_libraries(
+  extension_module_static PRIVATE executorch extension_data_loader
+)
 target_include_directories(extension_module_static PUBLIC ${EXECUTORCH_ROOT}/..)
-target_compile_options(extension_module_static PUBLIC -Wno-deprecated-declarations
-                                               -fPIC)
+target_compile_options(
+  extension_module_static PUBLIC -Wno-deprecated-declarations -fPIC
+)
 
 # Install libraries
 install(
   TARGETS extension_module
   DESTINATION lib
   INCLUDES
-  DESTINATION ${_common_include_directories})
+  DESTINATION ${_common_include_directories}
+)

--- a/extension/runner_util/CMakeLists.txt
+++ b/extension/runner_util/CMakeLists.txt
@@ -1,14 +1,12 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #
-# Copyright 2024 Arm Limited and/or its affiliates.
-#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 # Please this file formatted by running:
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 
 cmake_minimum_required(VERSION 3.19)
@@ -29,4 +27,5 @@ install(
   TARGETS extension_runner_util
   DESTINATION ${CMAKE_BINARY_DIR}/lib
   INCLUDES
-  DESTINATION ${_common_include_directories})
+  DESTINATION ${_common_include_directories}
+)

--- a/kernels/optimized/CMakeLists.txt
+++ b/kernels/optimized/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Kernel library for optimized kernels. Please this file formatted by running:
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 
 cmake_minimum_required(VERSION 3.19)
@@ -54,8 +54,10 @@ target_compile_options(cpublas PUBLIC ${_common_compile_options})
 set(_yaml "${CMAKE_CURRENT_LIST_DIR}/optimized-oss.yaml")
 gen_selected_ops(LIB_NAME "optimized_ops_lib" OPS_SCHEMA_YAML "${_yaml}")
 
-generate_bindings_for_kernels(LIB_NAME "optimized_ops_lib" FUNCTIONS_YAML
-                              ${CMAKE_CURRENT_SOURCE_DIR}/optimized-oss.yaml)
+generate_bindings_for_kernels(
+  LIB_NAME "optimized_ops_lib" FUNCTIONS_YAML
+  ${CMAKE_CURRENT_SOURCE_DIR}/optimized-oss.yaml
+)
 message("Generated files ${gen_command_sources}")
 
 list(TRANSFORM _optimized_kernels__srcs PREPEND "${EXECUTORCH_ROOT}/")
@@ -65,8 +67,9 @@ target_compile_options(optimized_kernels PUBLIC ${_common_compile_options})
 # Build a library for _optimized_kernels_srcs
 #
 # optimized_ops_lib: Register optimized ops kernels into Executorch runtime
-gen_operators_lib(LIB_NAME "optimized_ops_lib" KERNEL_LIBS optimized_kernels
-                  DEPS executorch)
+gen_operators_lib(
+  LIB_NAME "optimized_ops_lib" KERNEL_LIBS optimized_kernels DEPS executorch
+)
 
 install(TARGETS cpublas optimized_kernels optimized_ops_lib DESTINATION lib)
 

--- a/kernels/optimized/External/EigenBLAS.cmake
+++ b/kernels/optimized/External/EigenBLAS.cmake
@@ -9,45 +9,50 @@ if(__EIGEN_BLAS_INCLUDED)
 endif()
 set(__EIGEN_BLAS_INCLUDED TRUE)
 
-##############################################################################
-# Eigen BLAS is built together with Libtorch mobile.
-# By default, it builds code from third-party/eigen/blas submodule.
-##############################################################################
+# ##############################################################################
+# Eigen BLAS is built together with Libtorch mobile. By default, it builds code
+# from third-party/eigen/blas submodule.
+# ##############################################################################
 
-set(EIGEN_BLAS_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third-party/eigen/blas" CACHE STRING "Eigen BLAS source directory")
+set(EIGEN_BLAS_SRC_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/third-party/eigen/blas"
+    CACHE STRING "Eigen BLAS source directory"
+)
 
 set(EigenBlas_SRCS
-  ${EIGEN_BLAS_SRC_DIR}/single.cpp
-  ${EIGEN_BLAS_SRC_DIR}/double.cpp
-  ${EIGEN_BLAS_SRC_DIR}/complex_single.cpp
-  ${EIGEN_BLAS_SRC_DIR}/complex_double.cpp
-  ${EIGEN_BLAS_SRC_DIR}/xerbla.cpp
-  ${EIGEN_BLAS_SRC_DIR}/f2c/srotm.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/srotmg.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/drotm.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/drotmg.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/lsame.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/dspmv.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/ssbmv.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/chbmv.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/sspmv.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/zhbmv.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/chpmv.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/dsbmv.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/zhpmv.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/dtbmv.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/stbmv.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/ctbmv.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/ztbmv.c
-  ${EIGEN_BLAS_SRC_DIR}/f2c/complexdots.c
+    ${EIGEN_BLAS_SRC_DIR}/single.cpp
+    ${EIGEN_BLAS_SRC_DIR}/double.cpp
+    ${EIGEN_BLAS_SRC_DIR}/complex_single.cpp
+    ${EIGEN_BLAS_SRC_DIR}/complex_double.cpp
+    ${EIGEN_BLAS_SRC_DIR}/xerbla.cpp
+    ${EIGEN_BLAS_SRC_DIR}/f2c/srotm.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/srotmg.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/drotm.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/drotmg.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/lsame.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/dspmv.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/ssbmv.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/chbmv.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/sspmv.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/zhbmv.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/chpmv.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/dsbmv.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/zhpmv.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/dtbmv.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/stbmv.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/ctbmv.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/ztbmv.c
+    ${EIGEN_BLAS_SRC_DIR}/f2c/complexdots.c
 )
 
 add_library(eigen_blas STATIC ${EigenBlas_SRCS})
 
-#Dont know what to do with this
-# We build static versions of eigen blas but link into a shared library, so they need PIC.
+# Dont know what to do with this We build static versions of eigen blas but link
+# into a shared library, so they need PIC.
 set_property(TARGET eigen_blas PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-install(TARGETS eigen_blas
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+install(
+  TARGETS eigen_blas
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/kernels/portable/CMakeLists.txt
+++ b/kernels/portable/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Kernel library for portable kernels. Please this file formatted by running:
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 
 cmake_minimum_required(VERSION 3.19)
@@ -36,19 +36,19 @@ endif()
 
 # Portable kernel sources TODO(larryliu0820): use buck2 to gather the sources
 file(GLOB_RECURSE _portable_kernels__srcs
-     "${CMAKE_CURRENT_SOURCE_DIR}/cpu/*.cpp")
+     "${CMAKE_CURRENT_SOURCE_DIR}/cpu/*.cpp"
+)
 list(FILTER _portable_kernels__srcs EXCLUDE REGEX "test/*.cpp")
 list(FILTER _portable_kernels__srcs EXCLUDE REGEX "codegen")
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in functions.yaml
 set(_yaml "${CMAKE_CURRENT_LIST_DIR}/functions.yaml")
-gen_selected_ops(
-  LIB_NAME "portable_ops_lib"
-  OPS_SCHEMA_YAML "${_yaml}")
+gen_selected_ops(LIB_NAME "portable_ops_lib" OPS_SCHEMA_YAML "${_yaml}")
 # Expect gen_selected_ops output file to be selected_operators.yaml
 generate_bindings_for_kernels(
-  LIB_NAME "portable_ops_lib"
-  FUNCTIONS_YAML ${CMAKE_CURRENT_SOURCE_DIR}/functions.yaml)
+  LIB_NAME "portable_ops_lib" FUNCTIONS_YAML
+  ${CMAKE_CURRENT_SOURCE_DIR}/functions.yaml
+)
 message("Generated files ${gen_command_sources}")
 
 #
@@ -65,8 +65,7 @@ target_compile_options(portable_kernels PUBLIC ${_common_compile_options})
 # portable_ops_lib: Register portable_ops_lib ops kernels into Executorch
 # runtime
 gen_operators_lib(
-  LIB_NAME "portable_ops_lib"
-  KERNEL_LIBS portable_kernels
-  DEPS executorch)
+  LIB_NAME "portable_ops_lib" KERNEL_LIBS portable_kernels DEPS executorch
+)
 
 install(TARGETS portable_kernels portable_ops_lib DESTINATION lib)

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# Copyright 2024 Arm Limited and/or its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -7,12 +6,13 @@
 
 # Kernel library for quantized operators. Please this file formatted by running:
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 cmake_minimum_required(VERSION 3.19)
 
 option(EXECUTORCH_BUILD_QUANTIZED_OPS_AOT
-       "Build the optimized ops library for AOT export usage" OFF)
+       "Build the optimized ops library for AOT export usage" OFF
+)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if(NOT CMAKE_CXX_STANDARD)
@@ -46,8 +46,9 @@ set(_yaml_file ${CMAKE_CURRENT_LIST_DIR}/quantized.yaml)
 gen_selected_ops(LIB_NAME "quantized_ops_lib" OPS_SCHEMA_YAML "${_yaml_file}")
 
 # Expect gen_selected_ops output file to be selected_operators.yaml
-generate_bindings_for_kernels(LIB_NAME "quantized_ops_lib" CUSTOM_OPS_YAML
-                              "${_yaml_file}")
+generate_bindings_for_kernels(
+  LIB_NAME "quantized_ops_lib" CUSTOM_OPS_YAML "${_yaml_file}"
+)
 message("Generated files ${gen_command_sources}")
 
 # Not targeting Xcode, because the custom command generating
@@ -56,33 +57,39 @@ message("Generated files ${gen_command_sources}")
 # dependency of the other(s). This is not allowed by the Xcode "new build
 # system".
 if(NOT CMAKE_GENERATOR STREQUAL "Xcode" AND EXECUTORCH_BUILD_QUANTIZED_OPS_AOT)
-# Not targeting ARM_BAREMETAL as aot_lib depends on incompatible libraries
-if(NOT EXECUTORCH_BUILD_ARM_BAREMETAL)
-  set(_quantized_aot_ops
-      "quantized_decomposed::add.out"
-      "quantized_decomposed::choose_qparams.Tensor_out"
-      "quantized_decomposed::dequantize_per_channel.out"
-      "quantized_decomposed::dequantize_per_tensor.out"
-      "quantized_decomposed::dequantize_per_tensor.Tensor_out"
-      "quantized_decomposed::mixed_linear.out"
-      "quantized_decomposed::mixed_mm.out"
-      "quantized_decomposed::quantize_per_channel.out"
-      "quantized_decomposed::quantize_per_tensor.out"
-      "quantized_decomposed::quantize_per_tensor.Tensor_out")
-  gen_selected_ops(LIB_NAME "quantized_ops_aot_lib" ROOT_OPS
-                   ${_quantized_aot_ops})
-  # Expect gen_selected_ops output file to be
-  # quantized_ops_aot_lib/selected_operators.yaml
-  generate_bindings_for_kernels(LIB_NAME "quantized_ops_aot_lib"
-                                CUSTOM_OPS_YAML "${_yaml_file}")
-  # Build a AOT library to register quantized ops into PyTorch. This is a hack.
-  set(_quantized_sources
-      ${_quantized_kernels__srcs}
-      ${EXECUTORCH_ROOT}/kernels/portable/cpu/util/reduce_util.cpp
-      ${EXECUTORCH_ROOT}/runtime/core/exec_aten/util/tensor_util_aten.cpp)
-  gen_custom_ops_aot_lib(LIB_NAME "quantized_ops_aot_lib" KERNEL_SOURCES
-                         "${_quantized_sources}")
-endif()
+  # Not targeting ARM_BAREMETAL as aot_lib depends on incompatible libraries
+  if(NOT EXECUTORCH_BUILD_ARM_BAREMETAL)
+    set(_quantized_aot_ops
+        "quantized_decomposed::add.out"
+        "quantized_decomposed::choose_qparams.Tensor_out"
+        "quantized_decomposed::dequantize_per_channel.out"
+        "quantized_decomposed::dequantize_per_tensor.out"
+        "quantized_decomposed::dequantize_per_tensor.Tensor_out"
+        "quantized_decomposed::mixed_linear.out"
+        "quantized_decomposed::mixed_mm.out"
+        "quantized_decomposed::quantize_per_channel.out"
+        "quantized_decomposed::quantize_per_tensor.out"
+        "quantized_decomposed::quantize_per_tensor.Tensor_out"
+    )
+    gen_selected_ops(
+      LIB_NAME "quantized_ops_aot_lib" ROOT_OPS ${_quantized_aot_ops}
+    )
+    # Expect gen_selected_ops output file to be
+    # quantized_ops_aot_lib/selected_operators.yaml
+    generate_bindings_for_kernels(
+      LIB_NAME "quantized_ops_aot_lib" CUSTOM_OPS_YAML "${_yaml_file}"
+    )
+    # Build a AOT library to register quantized ops into PyTorch. This is a
+    # hack.
+    set(_quantized_sources
+        ${_quantized_kernels__srcs}
+        ${EXECUTORCH_ROOT}/kernels/portable/cpu/util/reduce_util.cpp
+        ${EXECUTORCH_ROOT}/runtime/core/exec_aten/util/tensor_util_aten.cpp
+    )
+    gen_custom_ops_aot_lib(
+      LIB_NAME "quantized_ops_aot_lib" KERNEL_SOURCES "${_quantized_sources}"
+    )
+  endif()
 endif()
 
 add_library(quantized_kernels ${_quantized_kernels__srcs})
@@ -91,7 +98,8 @@ target_compile_options(quantized_kernels PUBLIC ${_common_compile_options})
 # Build a library for _quantized_kernels_srcs
 #
 # quantized_ops_lib: Register quantized ops kernels into Executorch runtime
-gen_operators_lib(LIB_NAME "quantized_ops_lib" KERNEL_LIBS quantized_kernels
-                  DEPS executorch)
+gen_operators_lib(
+  LIB_NAME "quantized_ops_lib" KERNEL_LIBS quantized_kernels DEPS executorch
+)
 
 install(TARGETS quantized_kernels quantized_ops_lib DESTINATION lib)

--- a/schema/CMakeLists.txt
+++ b/schema/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Flatbuffer schema header lib. Please this file formatted by running:
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 
 if(NOT FLATC_EXECUTABLE)
@@ -26,7 +26,8 @@ function(generate_program_schema _schema_srcs _schema_name)
   foreach(fbs_file ${_schema_srcs})
     string(REGEX REPLACE "[.]fbs$" "_generated.h" generated "${fbs_file}")
     list(APPEND _schema_outputs
-         "${_program_schema__include_dir}/executorch/${generated}")
+         "${_program_schema__include_dir}/executorch/${generated}"
+    )
   endforeach()
 
   # Generate the headers from the .fbs files.
@@ -38,14 +39,16 @@ function(generate_program_schema _schema_srcs _schema_name)
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${FLATC_EXECUTABLE} ${_schema_srcs}
     COMMENT "Generating ${_schema_name} headers"
-    VERBATIM)
+    VERBATIM
+  )
 
   add_library(${_schema_name} INTERFACE ${_schema_outputs})
   set_target_properties(${_schema_name} PROPERTIES LINKER_LANGUAGE CXX)
   target_include_directories(
     ${_schema_name}
     INTERFACE ${_program_schema__include_dir}
-              ${EXECUTORCH_ROOT}/third-party/flatbuffers/include)
+              ${EXECUTORCH_ROOT}/third-party/flatbuffers/include
+  )
 endfunction()
 
 # Generate common schema

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Please this file formatted by running:
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 
 cmake_minimum_required(VERSION 3.19)
@@ -44,16 +44,24 @@ set(_bundled_input_schema_names "bundled_program_schema.fbs" "scalar_type.fbs")
 
 foreach(schema_file ${_etdump_schema_names})
   list(APPEND _etdump_schema__srcs
-       "${CMAKE_CURRENT_SOURCE_DIR}/etdump/${schema_file}")
+       "${CMAKE_CURRENT_SOURCE_DIR}/etdump/${schema_file}"
+  )
 endforeach()
 
 foreach(schema_file ${_bundled_input_schema_names})
   list(APPEND _bundled_program_schema__srcs
-       "${CMAKE_CURRENT_SOURCE_DIR}/bundled_program/schema/${schema_file}")
+       "${CMAKE_CURRENT_SOURCE_DIR}/bundled_program/schema/${schema_file}"
+  )
 endforeach()
 
-set(FLATCC_TEST OFF CACHE BOOL "")
-set(FLATCC_REFLECTION OFF CACHE BOOL "")
+set(FLATCC_TEST
+    OFF
+    CACHE BOOL ""
+)
+set(FLATCC_REFLECTION
+    OFF
+    CACHE BOOL ""
+)
 set(_flatcc_source_dir ${CMAKE_CURRENT_SOURCE_DIR}/../third-party/flatcc)
 add_subdirectory(${_flatcc_source_dir} ${CMAKE_BINARY_DIR}/third-party/flatcc)
 
@@ -72,7 +80,8 @@ set(_bundled_schema__include_dir "${CMAKE_BINARY_DIR}/sdk/bundled_program")
 # TODO(dbort): Only enable this when cross-compiling. It can cause build race
 # conditions (libflatcc.a errors) when enabled.
 option(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT
-  "Whether to build the flatcc commandline tool as a separate project" ON)
+       "Whether to build the flatcc commandline tool as a separate project" ON
+)
 
 if(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT)
   # Add the host project. We build this separately so that we can generate
@@ -101,10 +110,12 @@ set(_etdump_schema__outputs)
 foreach(fbs_file ${_etdump_schema_names})
   string(REGEX REPLACE "[.]fbs$" "_reader.h" generated "${fbs_file}")
   list(APPEND _etdump_schema__outputs
-       "${_program_schema__include_dir}/executorch/sdk/etdump/${generated}")
+       "${_program_schema__include_dir}/executorch/sdk/etdump/${generated}"
+  )
   string(REGEX REPLACE "[.]fbs$" "_builder.h" generated "${fbs_file}")
   list(APPEND _etdump_schema__outputs
-       "${_program_schema__include_dir}/executorch/sdk/etdump/${generated}")
+       "${_program_schema__include_dir}/executorch/sdk/etdump/${generated}"
+  )
 endforeach()
 
 # lint_cmake: -linelength
@@ -119,15 +130,17 @@ foreach(fbs_file ${_bundled_input_schema_names})
 endforeach()
 
 add_library(etdump_schema INTERFACE ${_etdump_schema__outputs})
-add_library(bundled_program_schema INTERFACE
-            ${_bundled_program_schema__outputs})
+add_library(
+  bundled_program_schema INTERFACE ${_bundled_program_schema__outputs}
+)
 
 # Ensure the host tool is built before the main project
 add_dependencies(etdump_schema flatcc_cli)
 
 file(MAKE_DIRECTORY ${_program_schema__include_dir}/executorch/sdk/etdump)
 file(MAKE_DIRECTORY
-     ${_program_schema__include_dir}/executorch/sdk/bundled_program)
+     ${_program_schema__include_dir}/executorch/sdk/bundled_program
+)
 
 if(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT)
   # If we cross-compiling, we need to use the version of the commandline tool
@@ -148,7 +161,8 @@ if(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT)
   # try to remove this hack, ideally by submitting an upstream PR that adds an
   # option to change the installation location.
   set(_etdump_schema_cleanup_paths ${_flatcc_source_dir}/bin/*
-                                   ${_flatcc_source_dir}/lib/*)
+                                   ${_flatcc_source_dir}/lib/*
+  )
 else()
   # If we're not cross-compiling we can use the plain commandline target, and we
   # don't need to delete any files.
@@ -169,15 +183,19 @@ add_custom_command(
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/sdk
   DEPENDS ${_etdump_schema_gen_dep}
   COMMENT "Generating etdump headers"
-  VERBATIM)
+  VERBATIM
+)
 
-add_library(etdump ${CMAKE_CURRENT_SOURCE_DIR}/etdump/etdump_flatcc.cpp
-                   ${CMAKE_CURRENT_SOURCE_DIR}/etdump/emitter.cpp)
+add_library(
+  etdump ${CMAKE_CURRENT_SOURCE_DIR}/etdump/etdump_flatcc.cpp
+         ${CMAKE_CURRENT_SOURCE_DIR}/etdump/emitter.cpp
+)
 
 target_link_libraries(
   etdump
   PUBLIC etdump_schema flatccrt
-  PRIVATE executorch)
+  PRIVATE executorch
+)
 
 add_custom_command(
   OUTPUT ${_bundled_program_schema__outputs}
@@ -188,25 +206,30 @@ add_custom_command(
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/sdk
   DEPENDS ${FLATC_EXECUTABLE} ${_bundled_program_schema__srcs}
   COMMENT "Generating bundled_program headers"
-  VERBATIM)
+  VERBATIM
+)
 
 # add_library(bundled_program INTERFACE ${_bundled_program_schema__outputs})
-add_library(bundled_program
-            ${CMAKE_CURRENT_SOURCE_DIR}/bundled_program/bundled_program.cpp)
+add_library(
+  bundled_program
+  ${CMAKE_CURRENT_SOURCE_DIR}/bundled_program/bundled_program.cpp
+)
 target_link_libraries(bundled_program executorch bundled_program_schema)
 
 set_target_properties(bundled_program PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(
   bundled_program PUBLIC ${_bundled_schema__include_dir}
-                         ${EXECUTORCH_ROOT}/third-party/flatbuffers/include)
+                         ${EXECUTORCH_ROOT}/third-party/flatbuffers/include
+)
 
 target_include_directories(
-  etdump PUBLIC ${_program_schema__include_dir}
-                ${_flatcc_source_dir}/include)
+  etdump PUBLIC ${_program_schema__include_dir} ${_flatcc_source_dir}/include
+)
 
 # Install libraries
 install(
   TARGETS bundled_program etdump flatccrt
   DESTINATION ${CMAKE_BINARY_DIR}/lib
   INCLUDES
-  DESTINATION ${_common_include_directories})
+  DESTINATION ${_common_include_directories}
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 # This file should be formatted with
 # ~~~
-# cmake-format --first-comment-is-literal=True CMakeLists.txt
+# cmake-format -i CMakeLists.txt
 # ~~~
 # It should also be cmake-lint clean.
 #
@@ -33,10 +33,7 @@ target_include_directories(executorch INTERFACE ${_common_include_directories})
 #
 # The `_<target>_srcs` lists are defined by including ${EXECUTORCH_SRCS_FILE}.
 #
-set(
-  EXECUTORCH_SRCS_FILE
-  "${CMAKE_CURRENT_BINARY_DIR}/../executorch_srcs.cmake"
-)
+set(EXECUTORCH_SRCS_FILE "${CMAKE_CURRENT_BINARY_DIR}/../executorch_srcs.cmake")
 
 extract_sources(${EXECUTORCH_SRCS_FILE})
 


### PR DESCRIPTION
Summary:
Let's add a `.cmake-format.yaml` and run it over all our cmake files:
`find . \( -name 'CMakeLists.txt' -o -name '*.cmake' \) -exec cmake-format {} -i \;`

`dangle_parens` is needed to put the closing parenthesis on a new line, since we've been doing that most of the time manually.

Differential Revision: D56896610
