### PR TITLE
update delegate for derived bias qspec

### DIFF
--- a/backends/xnnpack/operators/node_visitor.py
+++ b/backends/xnnpack/operators/node_visitor.py
@@ -625,7 +625,7 @@ class NodeVisitor:
             if input_type_map.node_bias is not None:
                 bias_node = get_input_node(node, input_type_map.node_bias)
                 bias_quant_params = QuantParams.from_bias(
-                    bias_node, weight_quant_params, input_quant_params
+                    bias_node, self._exported_program
                 )
                 self.define_tensor(
                     bias_node,

--- a/backends/xnnpack/operators/op_conv2d.py
+++ b/backends/xnnpack/operators/op_conv2d.py
@@ -104,9 +104,7 @@ class Conv2d(NodeVisitor):
         if node.args[2] is not None:
             # If there is a bias
             bias_node = get_input_node(node, 2)
-            bias_quant_params = QuantParams.from_bias(
-                bias_node, weight_quant_params, input_quant_params
-            )
+            bias_quant_params = QuantParams.from_bias(bias_node, self._exported_program)
             self.define_tensor(
                 get_input_node(node, 2),
                 xnn_graph,

--- a/backends/xnnpack/operators/op_linear.py
+++ b/backends/xnnpack/operators/op_linear.py
@@ -66,9 +66,7 @@ class LinearVisitor(NodeVisitor):
         # bias
         if len(node.args) > 2:
             bias_node = get_input_node(node, 2)
-            bias_quant_params = QuantParams.from_bias(
-                bias_node, weight_quant_params, input_quant_params
-            )
+            bias_quant_params = QuantParams.from_bias(bias_node, self._exported_program)
             self.define_tensor(
                 get_input_node(node, 2),
                 xnn_graph,


### PR DESCRIPTION
Summary: In the below we added quantizer annotation to the bias of GEMM operations. We update some of our delegate lowering logic to allow for this change

Differential Revision: D56959071


