### PR TITLE
Rust: Update sysinfo crate

### DIFF
--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -183,7 +183,7 @@ syn1 = { package = "syn", version = "1.0.109", features = ["extra-traits", "fold
 synstructure = "0.12"
 sync_wrapper = "0.1.0"
 sys-info = "0.9.1"
-sysinfo = "0.26.8"
+sysinfo = "0.30.11"
 take_mut = "0.2.2"
 tar = "0.4.38"
 tempfile = "3.1.0"


### PR DESCRIPTION
Summary: I need an update sysinfo for some Windows stuff, the previous version doesn't seem to work correctly (plus the documented API has changed a bit and the examples just don't build).

Reviewed By: koronthaly

Differential Revision: D56913751
