### PR TITLE
use edge_compile_config in verifier

### DIFF
--- a/backends/apple/mps/test/test_mps_utils.py
+++ b/backends/apple/mps/test/test_mps_utils.py
@@ -30,7 +30,11 @@ from executorch.sdk.bundled_program.serialize import (
 from torch.export import export, ExportedProgram
 
 # Config for Capturing the weights, will be moved in the future
-_EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(_check_ir_validity=False)
+
+# TODO(T182928844): Delegate dim order op to backend.
+_EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(
+    _check_ir_validity=False, _skip_dim_order=True
+)
 
 
 def _to_core_aten(
@@ -54,6 +58,7 @@ def _core_aten_to_edge(
     if not edge_compile_config:
         edge_compile_config = exir.EdgeCompileConfig(
             _check_ir_validity=False,  # quant ops currently break ir verification
+            _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
         )
     edge_manager: EdgeProgramManager = to_edge(
         core_aten_exir_ep, compile_config=edge_compile_config
@@ -220,7 +225,10 @@ class TestMPS(unittest.TestCase):
         edge_program = export_to_edge(
             model,
             sample_inputs,
-            edge_compile_config=EdgeCompileConfig(_check_ir_validity=False),
+            edge_compile_config=EdgeCompileConfig(
+                _check_ir_validity=False,
+                _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
+            ),
         )
 
         logging.info(
@@ -251,7 +259,10 @@ class TestMPS(unittest.TestCase):
                     delegated_program,
                     sample_inputs,
                 ),
-                compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+                compile_config=exir.EdgeCompileConfig(
+                    _check_ir_validity=False,
+                    _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
+                ),
             ).to_executorch(
                 config=ExecutorchBackendConfig(extract_constant_segment=False)
             )

--- a/backends/arm/test/arm_tosa_reference.py
+++ b/backends/arm/test/arm_tosa_reference.py
@@ -36,6 +36,7 @@ DEBUG_OUTPUT_PATH = tempfile.mkdtemp(prefix="arm_tosa_")
 # Config for Capturing the weights, will be moved in the future
 _EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(
     _check_ir_validity=False,
+    _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
 )
 
 SUPPORTED_BI_TEST_LIST = [

--- a/backends/arm/test/models/test_mobilenet_v2_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v2_arm.py
@@ -13,6 +13,7 @@ from executorch.backends.arm.test import common
 
 from executorch.backends.arm.test.tester.arm_tester import ArmTester
 from executorch.backends.xnnpack.test.tester.tester import Quantize
+from executorch.exir import EdgeCompileConfig
 from torchvision import models
 from torchvision.models.mobilenetv2 import MobileNet_V2_Weights
 
@@ -41,6 +42,11 @@ class TestMobileNetV2(unittest.TestCase):
         "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
     }
 
+    _edge_compile_config: EdgeCompileConfig = EdgeCompileConfig(
+        _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
+    )
+
+    @unittest.skip("This test is not supported yet")
     def test_mv2_tosa_MI(self):
         (
             ArmTester(
@@ -49,7 +55,7 @@ class TestMobileNetV2(unittest.TestCase):
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .export()
-            .to_edge()
+            .to_edge(config=self._edge_compile_config)
             .check(list(self.all_operators))
             .partition()
             .to_executorch()
@@ -64,7 +70,7 @@ class TestMobileNetV2(unittest.TestCase):
             )
             .quantize(Quantize(calibrate=False))
             .export()
-            .to_edge()
+            .to_edge(config=self._edge_compile_config)
             .check(list(self.operators_after_quantization))
             .partition()
             .to_executorch()
@@ -89,7 +95,7 @@ class TestMobileNetV2(unittest.TestCase):
             )
             .quantize(Quantize(calibrate=False))
             .export()
-            .to_edge()
+            .to_edge(config=self._edge_compile_config)
             .check(list(self.operators_after_quantization))
             .partition()
             .to_executorch()

--- a/backends/arm/test/ops/test_add.py
+++ b/backends/arm/test/ops/test_add.py
@@ -14,6 +14,7 @@ import torch
 from executorch.backends.arm.test import common
 
 from executorch.backends.arm.test.tester.arm_tester import ArmTester
+from executorch.exir import EdgeCompileConfig
 from parameterized import parameterized
 
 logger = logging.getLogger(__name__)
@@ -50,6 +51,10 @@ class TestSimpleAdd(unittest.TestCase):
         def forward(self, x, y):
             return x + y
 
+    _edge_compile_config: EdgeCompileConfig = EdgeCompileConfig(
+        _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
+    )
+
     def _test_add_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
@@ -62,7 +67,7 @@ class TestSimpleAdd(unittest.TestCase):
             .export()
             .check_count({"torch.ops.aten.add.Tensor": 1})
             .check_not(["torch.ops.quantized_decomposed"])
-            .to_edge()
+            .to_edge(config=self._edge_compile_config)
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
@@ -87,7 +92,7 @@ class TestSimpleAdd(unittest.TestCase):
             .export()
             .check_count({"torch.ops.aten.add.Tensor": 1})
             .check(["torch.ops.quantized_decomposed"])
-            .to_edge()
+            .to_edge(config=self._edge_compile_config)
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
@@ -113,7 +118,7 @@ class TestSimpleAdd(unittest.TestCase):
             .export()
             .check_count({"torch.ops.aten.add.Tensor": 1})
             .check(["torch.ops.quantized_decomposed"])
-            .to_edge()
+            .to_edge(config=self._edge_compile_config)
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()

--- a/backends/arm/test/ops/test_linear.py
+++ b/backends/arm/test/ops/test_linear.py
@@ -14,6 +14,7 @@ import torch
 from executorch.backends.arm.test import common
 
 from executorch.backends.arm.test.tester.arm_tester import ArmTester
+from executorch.exir import EdgeCompileConfig
 from parameterized import parameterized
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,11 @@ test_data_suite_rank4 = [
 
 
 class TestLinear(unittest.TestCase):
+
+    _edge_compile_config: EdgeCompileConfig = EdgeCompileConfig(
+        _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
+    )
+
     class Linear(torch.nn.Module):
         def __init__(
             self,
@@ -119,7 +125,7 @@ class TestLinear(unittest.TestCase):
             .export()
             .check_count({"torch.ops.aten.addmm.default": 1})
             .check_not(["torch.ops.quantized_decomposed"])
-            .to_edge()
+            .to_edge(config=self._edge_compile_config)
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
@@ -144,7 +150,7 @@ class TestLinear(unittest.TestCase):
             .export()
             .check_count({"torch.ops.aten.addmm.default": 1})
             .check(["torch.ops.quantized_decomposed"])
-            .to_edge()
+            .to_edge(config=self._edge_compile_config)
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
@@ -169,7 +175,7 @@ class TestLinear(unittest.TestCase):
             .export()
             .check_count({"torch.ops.aten.addmm.default": 1})
             .check(["torch.ops.quantized_decomposed"])
-            .to_edge()
+            .to_edge(config=self._edge_compile_config)
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()

--- a/backends/arm/test/test_tosa.py
+++ b/backends/arm/test/test_tosa.py
@@ -23,6 +23,7 @@ from torch.export import export
 _CAPTURE_CONFIG = exir.CaptureConfig(enable_aot=True)
 _EDGE_COMPILE_CONFIG: EdgeCompileConfig = exir.EdgeCompileConfig(
     _check_ir_validity=False,
+    _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
 )
 
 ## For quantization

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -181,6 +181,9 @@ class ArmTester(Tester):
     def to_edge(self, to_edge_stage: Optional[ToEdge] = None):
         if to_edge_stage is None:
             to_edge_stage = ToEdge(EdgeCompileConfig(_check_ir_validity=False))
+
+        # TODO(T182928844): Delegate dim order op to backend.
+        to_edge_stage.edge_compile_conf._skip_dim_order = True
         return super().to_edge(to_edge_stage)
 
     def partition(self, partition_stage: Optional[Partition] = None):

--- a/backends/example/test_example_delegate.py
+++ b/backends/example/test_example_delegate.py
@@ -42,6 +42,7 @@ class TestExampleDelegate(unittest.TestCase):
         example_inputs = Conv2dModule.get_example_inputs()
         EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(
             _check_ir_validity=False,
+            _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
         )
 
         m = model.eval()
@@ -77,6 +78,7 @@ class TestExampleDelegate(unittest.TestCase):
 
         EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(
             _check_ir_validity=False,
+            _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
         )
 
         m = model.eval()

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -1110,7 +1110,12 @@ class TestQNNFloatingPointUtils(TestQNN):
         edge_prog = ExirExportedProgram(
             torch.export.export(module, sample_input),
             after_to_edge_passes=False,
-        ).to_edge(EdgeCompileConfig(_check_ir_validity=False))
+        ).to_edge(
+            EdgeCompileConfig(
+                _check_ir_validity=False,
+                _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
+            )
+        )
         canonicalize_program(edge_prog.exported_program)
         exec_prog = edge_prog.to_executorch()
         self.verify_output(module.get_reference_module(), sample_input, exec_prog)
@@ -1243,7 +1248,12 @@ class TestQNNQuantizedUtils(TestQNN):
         edge_prog = ExirExportedProgram(
             torch.export.export(module, sample_input),
             after_to_edge_passes=False,
-        ).to_edge(EdgeCompileConfig(_check_ir_validity=False))
+        ).to_edge(
+            EdgeCompileConfig(
+                _check_ir_validity=False,
+                _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
+            )
+        )
         canonicalize_program(edge_prog.exported_program)
         exec_prog = edge_prog.to_executorch()
         self.verify_output(module.get_reference_module(), sample_input, exec_prog)

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -58,7 +58,10 @@ def qnn_capture_config():
 
 
 def qnn_edge_config() -> exir.EdgeCompileConfig:
-    return exir.EdgeCompileConfig(_check_ir_validity=False)
+    return exir.EdgeCompileConfig(
+        _check_ir_validity=False,
+        _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
+    )
 
 
 def canonicalize_program(prog: ExportedProgram):

--- a/backends/xnnpack/test/tester/tester.py
+++ b/backends/xnnpack/test/tester/tester.py
@@ -474,7 +474,11 @@ class Tester:
         )
 
     def to_edge(self, to_edge_stage: Optional[ToEdge] = None):
-        return self._run_stage(to_edge_stage or ToEdge())
+        # TODO(T182187531): Skip dim order for now. Support dim order and its op after alpha release.
+        if not to_edge_stage:
+            to_edge_stage = ToEdge()
+        to_edge_stage.edge_compile_conf._skip_dim_order = True
+        return self._run_stage(to_edge_stage)
 
     def run_passes(self, run_passes_stage: Optional[RunPasses] = None):
         return self._run_stage(run_passes_stage or RunPasses())

--- a/backends/xnnpack/utils/configs.py
+++ b/backends/xnnpack/utils/configs.py
@@ -16,9 +16,7 @@ from executorch.exir.pass_manager import PassType
 
 ### XNNPACK Configs ###
 def get_xnnpack_edge_compile_config() -> exir.EdgeCompileConfig:
-    return exir.EdgeCompileConfig(
-        _check_ir_validity=False,
-    )
+    return exir.EdgeCompileConfig(_check_ir_validity=False, _skip_dim_order=True)
 
 
 def get_transform_passes(additional_passes=None) -> List[PassType]:

--- a/backends/xnnpack/xnnpack_preprocess.py
+++ b/backends/xnnpack/xnnpack_preprocess.py
@@ -22,6 +22,7 @@ from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
 from executorch.backends.xnnpack.serialization.xnnpack_graph_serialize import (
     serialize_xnnpack_binary,
 )
+from executorch.backends.xnnpack.utils.configs import get_xnnpack_edge_compile_config
 from executorch.backends.xnnpack.utils.utils import is_param_node
 
 from executorch.backends.xnnpack.utils.xnnpack_constants import (
@@ -84,6 +85,9 @@ class XnnpackBackend(BackendDetails):
         edge_program: ExportedProgram,
         compile_specs: List[CompileSpec],
     ) -> PreprocessResult:
+
+        xnnpack_edge_compile_config = get_xnnpack_edge_compile_config()
+
         # Need to wrap EP here because xnnpack does addmm to linear
         # transforms. This makes resulting graph not aten compliant
         # as aten.linear is not a core aten op.
@@ -102,7 +106,7 @@ class XnnpackBackend(BackendDetails):
             module_call_graph=edge_program.module_call_graph,
             example_inputs=edge_program.example_inputs,
             verifier=EXIREdgeDialectVerifier(
-                check_edge_ops=False, enable=False, class_only=True
+                edge_compile_config=xnnpack_edge_compile_config, class_only=True
             ),
             constants=edge_program.constants,
         )

--- a/examples/apple/coreml/scripts/export.py
+++ b/examples/apple/coreml/scripts/export.py
@@ -36,6 +36,7 @@ from models.model_factory import EagerModelFactory
 
 _EDGE_COMPILE_CONFIG = exir.EdgeCompileConfig(
     _check_ir_validity=False,
+    _skip_dim_order=True,  # TODO(T182928844): enable dim_order in backend
 )
 
 

--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -218,6 +218,7 @@ class LlamaEdgeManager:
         edge_config = EdgeCompileConfig(
             _check_ir_validity=False,
             _skip_type_promotion=bool(self.dtype == DType.fp16),
+            _skip_dim_order=True,
         )
         return edge_config
 

--- a/examples/portable/utils.py
+++ b/examples/portable/utils.py
@@ -51,6 +51,7 @@ def _core_aten_to_edge(
     if not edge_compile_config:
         edge_compile_config = exir.EdgeCompileConfig(
             _check_ir_validity=False,  # quant ops currently break ir verification
+            _skip_dim_order=True,  # TODO(T182928844): dim order ops can not delegate to backend
         )
     edge_manager: EdgeProgramManager = to_edge(
         core_aten_exir_ep,

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -91,6 +91,7 @@ if __name__ == "__main__":
         example_inputs,
         edge_compile_config=EdgeCompileConfig(
             _check_ir_validity=False if args.quantize else True,
+            _skip_dim_order=True,  # TODO(T182187531): enable dim order in xnnpack
         ),
     )
     logging.info(f"Exported graph:\n{edge.exported_program().graph}")

--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -37,8 +37,8 @@ class EdgeCompileConfig:
     # TODO(larryliu): remove this
     _use_edge_ops: bool = True
     _skip_type_promotion: bool = False
-    # TODO(gasoonjia): set it as False by default, and remove it in the long term
-    _skip_dim_order: bool = True
+    # TODO(gasoonjia): remove this
+    _skip_dim_order: bool = False
 
 
 @compatibility(is_backward_compatible=False)

--- a/exir/dim_order_utils.py
+++ b/exir/dim_order_utils.py
@@ -14,8 +14,10 @@ Set of simple utilities for translating between torch.memory_format and dim_orde
 
 
 def _get_contiguous_dim_order(ndim: int) -> List[int]:
-    if ndim <= 0:
-        raise AssertionError(f"Unsupported rank: {ndim}")
+    if ndim < 0:
+        raise AssertionError(
+            f"Unsupported rank for contiguous dim order. Only supports ndim greater than or equal to 0, but got {ndim}"
+        )
 
     return list(range(ndim))
 
@@ -24,7 +26,9 @@ def _get_channels_last_dim_order(ndim: int) -> List[int]:
     if ndim == 4:
         return [0, 2, 3, 1]
 
-    raise AssertionError(f"Unsupported rank: {ndim}")
+    raise AssertionError(
+        f"Unsupported rank for channels last dim order. Only support ndim equal to 4, but got {ndim}"
+    )
 
 
 def get_memory_format(dim_order: Optional[List[int]]) -> torch.memory_format:

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -1139,7 +1139,7 @@ class TestPasses(unittest.TestCase):
 
         # Check there is a lifted tensor followed by a to_copy node
         FileCheck().check("_lifted_tensor_constant0").check(
-            "executorch_exir_dialects_edge__ops_aten__to_copy_default"
+            "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default"
         ).run(exported_program.graph_module.code)
 
         new_ep = constant_prop_pass(exported_program)
@@ -1147,7 +1147,9 @@ class TestPasses(unittest.TestCase):
         # Check (_lifted_tensor_constant + to_copy) node is replaced by prop tensor
         FileCheck().check_not("_lifted_tensor_constant").check(
             "_prop_tensor_constant0"
-        ).check_not("executorch_exir_dialects_edge__ops_aten__to_copy_default").run(
+        ).check_not(
+            "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default"
+        ).run(
             new_ep.graph_module.code
         )
 

--- a/exir/verification/TARGETS
+++ b/exir/verification/TARGETS
@@ -54,6 +54,7 @@ python_library(
         "//caffe2:torch",
         "//executorch/exir:error",
         "//executorch/exir:lowered_backend_module",
+        "//executorch/exir/capture:config",
         "//executorch/exir/dialects/edge:lib",
         "//executorch/exir/emit:emit",
     ],
@@ -65,6 +66,7 @@ python_unittest(
     deps = [
         ":verifier",
         "//caffe2:torch",
+        "//executorch/exir:lib",
         "//executorch/exir/dialects:lib",
     ],
 )

--- a/exir/verification/test/test_verifier.py
+++ b/exir/verification/test/test_verifier.py
@@ -7,9 +7,13 @@
 import unittest
 from contextlib import contextmanager
 
+import torch
+from executorch.exir import EdgeCompileConfig, to_edge
+
 from executorch.exir.dialects._ops import ops
 from torch._export.verifier import SpecViolationError
 from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib  # noqa: F401
+from torch.export import export
 
 from ..verifier import EXIREdgeDialectVerifier
 
@@ -24,7 +28,79 @@ class TestEdgeDialectVerifier(unittest.TestCase):
 
     def test_edge_verifier_check_valid_op_succeed_given_custom_op(self) -> None:
         edge_op = ops.edge.quantized_decomposed.quantize_per_tensor.default
-        verifier = EXIREdgeDialectVerifier(check_edge_ops=True)
+        verifier = EXIREdgeDialectVerifier()
         with self.assertNotRaises(SpecViolationError):
             verifier.check_valid_edge_op(edge_op)
             verifier.check_valid_op(edge_op)
+
+    def test_edge_verifier_enablement(self) -> None:
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                z = y.item()
+                torch._constrain_as_value(z, 0, 4)
+                return x[z : z + y.shape[0]]
+
+        ep = torch.export.export(M(), (torch.randn(10), torch.tensor([3])))
+
+        compile_config_with_disable_ir_validity = EdgeCompileConfig(
+            _check_ir_validity=False
+        )
+        edge_manager = to_edge(
+            ep, compile_config=compile_config_with_disable_ir_validity
+        )
+
+        normal_verifier = EXIREdgeDialectVerifier()
+        disable_ir_validity_verifier = EXIREdgeDialectVerifier(
+            compile_config_with_disable_ir_validity
+        )
+
+        # exported model can not pass normal verifier due to
+        # aten.sym_constrain_range.default is illegal to be edge op
+        with self.assertRaises(SpecViolationError):
+            normal_verifier(edge_manager.exported_program())
+
+        # exported model can pass disable_ir_validity_verifier due to verifier
+        # is disabled by compile_config_with_disable_ir_validity
+        # (_check_ir_validity=False). Noted that this verifation has been done
+        # when calling `to_edge`. Explicitly calling verifier here just for better
+        # demonstration and is unnecessary in real world for ir verification.
+        disable_ir_validity_verifier(edge_manager.exported_program())
+
+    def test_edge_verifier_check_edge_op(self) -> None:
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x.transpose(0, 1)
+
+        m = Model().eval()
+
+        example_input = (torch.zeros([2, 2]),)
+
+        export_model = export(m, example_input)
+
+        # In default we use dim order.
+        compile_config_without_edge_op = EdgeCompileConfig(_use_edge_ops=False)
+
+        edge_manager = to_edge(
+            export_model, compile_config=compile_config_without_edge_op
+        )
+
+        normal_verifier = EXIREdgeDialectVerifier()
+        disable_edge_op_check_verifier = EXIREdgeDialectVerifier(
+            compile_config_without_edge_op
+        )
+
+        # exported model can not pass normal verifier due to
+        # incontiguous memory layout tensor is not supported in ET
+        with self.assertRaises(SpecViolationError):
+            normal_verifier(edge_manager.exported_program())
+
+        # exported model can pass disable_edge_op_check_verifier due to the
+        # incontiguous memory layout tensor verification is disabled by
+        # compile_config_without_edge_op (_use_edge_ops=False). Noted that this
+        # verifation has been done when calling `to_edge`. Explicitly calling
+        # verifier here just for better demonstration and is unnecessary
+        # in real world for ir verification.
+        disable_edge_op_check_verifier(edge_manager.exported_program())

--- a/exir/verification/verifier.py
+++ b/exir/verification/verifier.py
@@ -72,6 +72,7 @@ class EXIRATenDialectVerifier(EXIRATenDialectVerifierBase):
                 "boltnn_nimble",
                 "nimble",
                 "quantized",
+                "dim_order_ops",
             ) or op in (
                 torch.ops.aten.mkldnn_rnn_layer.default,
                 torch.ops.aten._upsample_bilinear2d_aa.default,


### PR DESCRIPTION
Summary:
this diff use `edge_compile_config` to create edge verifier, to replace the original `enable` and `_check_edge_ops`. This update has three advantages:

1. User friendly. Both `enable` and `_check_edge_ops` are from `edge_compile_config`, in the previous setting user needs to manually extract the two attributes from their compile_config then forward them to verifier. Now user can just forward their config to verifier, without extra work.
2. Consistency. In ET, we use `EdgeCompileConfig` to control how we lower compile model graph to edge graph. We should use the same config to test whether or not the graph is as we expected, rather than manually set the test criteria.
3. Decreaase reduntancy. Directly using `EdgeCompileConfig` can decrease redundancy, expecially if new attribute has been introduced to `EdgeCompileConfig`, or old need to be removed. Otherwise we need to take forever to add/remove options to verifier

Differential Revision: D57010390


