### PR TITLE
Fix backends/arm test after _skip_dim_order update

### DIFF
--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -178,9 +178,16 @@ class ArmTester(Tester):
             )
         return super().quantize(quantize_stage)
 
-    def to_edge(self, to_edge_stage: Optional[ToEdge] = None):
+    def to_edge(
+        self,
+        to_edge_stage: Optional[ToEdge] = None,
+        config: Optional[EdgeCompileConfig] = None,
+    ):
         if to_edge_stage is None:
-            to_edge_stage = ToEdge(EdgeCompileConfig(_check_ir_validity=False))
+            to_edge_stage = ToEdge(config)
+        else:
+            if config is not None:
+                to_edge_stage.edge_compile_conf = config
 
         # TODO(T182928844): Delegate dim order op to backend.
         to_edge_stage.edge_compile_conf._skip_dim_order = True


### PR DESCRIPTION
This fixes the backends/arm unit tests