### PR TITLE
Update `sorted_vector_map`

### DIFF
--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -22,7 +22,7 @@ path = "top/main.rs"
 
 gazebo = {version = "0.8.1", features = ["str_pattern_extensions"]}
 fbinit = "0.1"
-sorted_vector_map = "0.1"
+sorted_vector_map = "0.2"
 watchman_client = "0.8.0"
 
 annotate-snippets = { version = "0.9.0", features = ["color"] }


### PR DESCRIPTION
Summary: The most recent fbsource version was just released onto crates.io, so builds are failing until we update

Reviewed By: IanChilds

Differential Revision: D57091891


