### PR TITLE
Add permute operator to vulkan_partitioner.py

### DIFF
--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -55,6 +55,7 @@ class VulkanSupportedOperators(OperatorSupportBase):
             # Normalization
             exir_ops.edge.aten.native_layer_norm.default,
             # Shape-related operators
+            exir_ops.edge.aten.permute.default,
             exir_ops.edge.aten.select_copy.int,
             exir_ops.edge.aten.unsqueeze_copy.default,
             exir_ops.edge.aten.view_copy.default,


### PR DESCRIPTION
Summary:
Add permute operator to vulkan_partitioner.py

Following the guide: https://docs.google.com/document/d/1xy4RoJLasHcrPL_lmwzgD3B2QaJ8Y8YdoZVILU6NZjc/edit

.cpp, glsl and yaml files of permute are implemented. 32 bit tests passed, 16bit tests skipped


cpp: https://www.internalfb.com/code/fbsource/xplat/executorch/backends/vulkan/runtime/graph/ops/impl/Permute.cpp
glsl: https://www.internalfb.com/code/fbsource/xplat/executorch/backends/vulkan/runtime/graph/ops/glsl/permute.glsl

Differential Revision: D57113667




cc @SS-JIA @manuelcandales @cbilgin