### PR TITLE
[ET-VK][EZ] Rename `Allocator.*` as `vma_api.*`

### DIFF
--- a/backends/vulkan/runtime/api/Resource.h
+++ b/backends/vulkan/runtime/api/Resource.h
@@ -11,8 +11,8 @@
 // @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
 
 #include <executorch/backends/vulkan/runtime/api/vk_api.h>
+#include <executorch/backends/vulkan/runtime/api/vma_api.h>
 
-#include <executorch/backends/vulkan/runtime/api/Allocator.h>
 #include <executorch/backends/vulkan/runtime/api/Types.h>
 #include <executorch/backends/vulkan/runtime/api/Utils.h>
 

--- a/backends/vulkan/runtime/api/vma_api.cpp
+++ b/backends/vulkan/runtime/api/vma_api.cpp
@@ -7,4 +7,4 @@
  */
 
 #define VMA_IMPLEMENTATION
-#include <executorch/backends/vulkan/runtime/api/Allocator.h>
+#include <executorch/backends/vulkan/runtime/api/vma_api.h>

--- a/backends/vulkan/runtime/api/vma_api.h
+++ b/backends/vulkan/runtime/api/vma_api.h
@@ -10,10 +10,8 @@
 
 //
 // Do NOT include vk_mem_alloc.h directly.
-// Always include this file (Allocator.h) instead.
+// Always include this file (vma_api.h) instead.
 //
-
-#include <executorch/backends/vulkan/runtime/api/vk_api.h>
 
 #define VMA_VULKAN_VERSION 1000000
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3546
* #3554
* #3553
* __->__ #3552
* #3545

We currently use `vk_api.h` for inclusion of third-party `vulkan-headers`.

To adhere to the same style, we rename as `vma_api.h` for inclusion of third-party `VulkanMemoryAllocator`. (This also opens the door to renaming our wrapper `MemoryAllocator` to `Allocator` in the next change.)

Differential Revision: [D57126895](https://our.internmc.facebook.com/intern/diff/D57126895/)