### PR TITLE
Add target_link_options_shared_lib to coremldelegate build

### DIFF
--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -155,6 +155,8 @@ target_link_libraries(
           ${FOUNDATION_FRAMEWORK} ${SQLITE_LIBRARY}
 )
 
+target_link_options_shared_lib(coremldelegate)
+
 if(COREML_BUILD_EXECUTOR_RUNNER)
   target_link_libraries(
     coremldelegate PRIVATE portable_ops_lib portable_kernels


### PR DESCRIPTION
Summary: Backends use a static initializer to register themselves. We have an established solution to forcing the Apple linker to load the object files containing said initializer, so let's use it for CoreML.

Test Plan: Attempt to load a CoreML PTE from Python no longer fails with error about the backend not being registered
