### PR TITLE
free the qnn context binary after buliding qnn manager

### DIFF
--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
@@ -172,6 +172,7 @@ Result<DelegateHandle*> QnnExecuTorchBackend::init(
         Internal,
         "Fail to allocate tensor");
   }
+  processed->Free();
   return qnn_manager;
 }
 


### PR DESCRIPTION
Summary: After `qnn_manager` is constructed with the qnn context binary, it's no longer needed and can be freed.

Differential Revision: D57143386


