### PR TITLE
Disable view_copy elimination for graph outputs

### DIFF
--- a/exir/passes/replace_view_copy_with_view_pass.py
+++ b/exir/passes/replace_view_copy_with_view_pass.py
@@ -273,7 +273,9 @@ class ReplaceViewCopyWithViewPass(PassBase):
             if not isinstance(module, torch.fx.GraphModule):
                 continue
             for node in module.graph.nodes:
-                if _is_view_copy(node):
+                # Note: We only replace view_copy nodes that are not output, since
+                # the output pointer could be modified at runtime (T187925929)
+                if _is_view_copy(node) and node.next.op != "output":
                     base, _ = node.args
                     node.target = _VIEW_OP
 
@@ -298,7 +300,9 @@ class ReplaceViewCopyWithViewPass(PassBase):
             if not isinstance(module, torch.fx.GraphModule):
                 continue
             for node in module.graph.nodes:
-                assert not _is_view_copy(node)
+                # Note: We only replace view_copy nodes that are not output, since
+                # the output pointer could be modified at runtime (T187925929)
+                assert not (_is_view_copy(node) and node.next.op != "output")
                 if node.op == "call_function" and node.target == _VIEW_OP:
                     assert isinstance(node.meta["spec"], _ViewSpec)
 
@@ -311,6 +315,8 @@ class ReplaceViewCopyWithViewPass(PassBase):
             if not isinstance(module, torch.fx.GraphModule):
                 continue
             for node in module.graph.nodes:
-                if _is_view_copy(node):
+                # Note: We only replace view_copy nodes that are not output, since
+                # the output pointer could be modified at runtime (T187925929)
+                if _is_view_copy(node) and node.next.op != "output":
                     base, size = node.args
                     assert not _is_view_copy(base)

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -1630,10 +1630,11 @@ class TestPasses(unittest.TestCase):
         assert gm_res is not None
         gm = gm_res.graph_module
 
-        # Check before transformation
+        # Check after transformation
+        # Note: one view copy is not replaced, because it's the output of the graph
         FileCheck().check_count(
-            "torch.ops.aten.view_copy.default", 0, exactly=True
+            "torch.ops.aten.view_copy.default", 1, exactly=True
         ).run(gm.code)
-        FileCheck().check_count("executorch_exir_memory_view", 2, exactly=True).run(
+        FileCheck().check_count("executorch_exir_memory_view", 1, exactly=True).run(
             gm.code
         )


### PR DESCRIPTION
Summary:
If the `view_copy` op is a graph output, leave it as a view_copy for now since the output pointer may be modified at runtime when deploying on device.

Right now, the modified pointer would be ignored since the view_copy op will always point to its predecessor memory.

cc chrismthompson jcoriell fengwang

Differential Revision: D57132664


