### PR TITLE
explicitly import _export.exported_program.

### DIFF
--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Union
 import sympy
 
 import torch
+import torch._export.exported_program
 import torch.export.exported_program as ep
 
 from torch._export.serde.schema import (


### PR DESCRIPTION
Summary: We will still merge two serialization, but for now just fix the missing imports.

Differential Revision: D57219425


