### PR TITLE
 Install mpmath in pip installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies=[
   "expecttest",
   "flatbuffers",
   "hypothesis",
+  "mpmath==1.3.0",
   "numpy>=1.25.2",
   "packaging",
   "pandas",


### PR DESCRIPTION
Summary:
A followup to https://github.com/pytorch/executorch/issues/2209 and https://github.com/pytorch/executorch/issues/2228

Consistent with https://github.com/pytorch/executorch/blob/main/.ci/docker/requirements-ci.txt

Differential Revision: D57289472


