### PR TITLE
Fix includes in Core ML backend.

### DIFF
--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem.cpp
@@ -10,7 +10,6 @@
 #include <assert.h>
 #include <fstream>
 #include <iostream>
-#include <range.hpp>
 #include <sstream>
 
 #if __has_include(<filesystem>)
@@ -22,7 +21,8 @@ namespace filesystem = std::experimental::filesystem;
 }
 #endif
 
-#include <reversed_memory_stream.hpp>
+#include "range.hpp"
+#include "reversed_memory_stream.hpp"
 
 namespace {
 using namespace inmemoryfs;

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_metadata.hpp
@@ -7,11 +7,12 @@
 
 #pragma once
 
-#include <memory_buffer.hpp>
 #include <string>
 #include <vector>
 #include <unordered_map>
-#include <range.hpp>
+
+#include "memory_buffer.hpp"
+#include "range.hpp"
 
 namespace inmemoryfs {
 
@@ -27,4 +28,3 @@ struct InMemoryFileSystemMetadata {
 };
 
 } // namespace inmemoryfs
-

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_py.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_py.cpp
@@ -6,13 +6,9 @@
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
 
-#include <inmemory_filesystem_utils.hpp>
 #include <iostream>
 #include <memory>
-#include <memory_buffer.hpp>
-#include <memory_stream.hpp>
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -20,6 +16,13 @@
 #include <system_error>
 #include <thread>
 #include <unistd.h>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+
+#include "inmemory_filesystem_utils.hpp"
+#include "memory_buffer.hpp"
+#include "memory_stream.hpp"
 
 #if __has_include(<filesystem>)
 #include <filesystem>

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.cpp
@@ -5,13 +5,16 @@
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
-#include <inmemory_filesystem_metadata.hpp>
-#include <inmemory_filesystem_metadata_keys.hpp>
-#include <inmemory_filesystem_utils.hpp>
+#include "inmemory_filesystem_utils.hpp"
+
 #include <iostream>
-#include <json.hpp>
-#include <json_util.hpp>
 #include <sstream>
+
+#include <nlohmann/json.hpp>
+
+#include "inmemory_filesystem_metadata.hpp"
+#include "inmemory_filesystem_metadata_keys.hpp"
+#include "json_util.hpp"
 
 namespace inmemoryfs {
 

--- a/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.mm
+++ b/backends/apple/coreml/runtime/inmemoryfs/inmemory_filesystem_utils.mm
@@ -6,14 +6,17 @@
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
 #import "inmemory_filesystem_utils.hpp"
-#import <Foundation/Foundation.h>
-#import <inmemory_filesystem_metadata.hpp>
-#import <inmemory_filesystem_metadata_keys.hpp>
+
 #import <iostream>
-#import <json_util.hpp>
-#import <objc_json_serde.h>
 #import <sstream>
 #import <unordered_map>
+
+#import <Foundation/Foundation.h>
+
+#import "inmemory_filesystem_metadata.hpp"
+#import "inmemory_filesystem_metadata_keys.hpp"
+#import "json_util.hpp"
+#import "objc_json_serde.h"
 
 namespace executorchcoreml {
 namespace serde {
@@ -29,13 +32,13 @@ struct Converter<Range> {
             to_string(RangeKeys::kSize) : to_json_value(range.size)
         };
     }
-    
+
     static void from_json(id json, Range& range) {
         NSDictionary<NSString *, id> *json_dict = SAFE_CAST(json, NSDictionary);
         if (!json_dict) {
             return;
         }
-        
+
         from_json_value(json_dict[to_string(RangeKeys::kOffset)], range.offset);
         from_json_value(json_dict[to_string(RangeKeys::kSize)], range.size);
     }
@@ -51,13 +54,13 @@ struct Converter<InMemoryNodeMetadata> {
             to_string(InMemoryNodeMetadataKeys::kKind) : to_json_value(node.kind)
         };
     }
-    
+
     static void from_json(id json, InMemoryNodeMetadata& node) {
         NSDictionary<NSString *, id> *json_dict = SAFE_CAST(json, NSDictionary);
         if (!json_dict) {
             return;
         }
-        
+
         from_json_value(json_dict[to_string(InMemoryNodeMetadataKeys::kName)], node.name);
         from_json_value(json_dict[to_string(InMemoryNodeMetadataKeys::kDataRegion)], node.data_region);
         from_json_value(json_dict[to_string(InMemoryNodeMetadataKeys::kChildIndices)], node.child_name_to_indices_map);
@@ -72,13 +75,13 @@ struct Converter<InMemoryFileSystemMetadata> {
             to_string(InMemoryFileSystemMetadataKeys::kNodes) : to_json_value(fs.nodes)
         };
     }
-    
+
     static void from_json(id json, InMemoryFileSystemMetadata& fs) {
         NSDictionary<NSString *, id> *json_dict = SAFE_CAST(json, NSDictionary);
         if (!json_dict) {
             return;
         }
-        
+
         from_json_value(json_dict[to_string(InMemoryFileSystemMetadataKeys::kNodes)], fs.nodes);
     }
 };
@@ -114,7 +117,7 @@ std::optional<InMemoryFileSystemMetadata> read_metadata_from_stream(std::istream
     if (!json_object) {
         return std::optional<InMemoryFileSystemMetadata>();
     }
-    
+
     InMemoryFileSystemMetadata metadata;
     Converter<InMemoryFileSystemMetadata>::from_json(to_json_object(json_object.value()), metadata);
     return metadata;
@@ -132,7 +135,7 @@ bool serialize(const InMemoryFileSystem& file_system,
         write_metadata_to_stream(fs_metadata, stream);
         return true;
     };
-    
+
     return file_system.serialize(canonical_path, alignment, metadata_writer, ostream, ec);
 }
 
@@ -145,7 +148,7 @@ bool serialize(const InMemoryFileSystem& file_system,
                                                                     void *metadata_dst) {
         return ::write_metadata_to_buffer(fs_metadata, metadata_dst);
     };
-    
+
     return file_system.serialize(canonical_path, alignment, metadata_writer, dst, ec);
 }
 
@@ -156,7 +159,7 @@ size_t get_buffer_size_for_serialization(const InMemoryFileSystem& file_system,
                                                             std::ostream& stream) {
         return ::write_metadata_to_stream(fs_metadata, stream);
     };
-    
+
     return file_system.get_buffer_size_for_serialization(canonical_path, alignment, metadata_writer);
 }
 
@@ -164,7 +167,7 @@ std::unique_ptr<InMemoryFileSystem> make_from_buffer(const std::shared_ptr<Memor
     InMemoryFileSystem::MetadataReader metadata_reader = [](std::istream& stream) {
         return ::read_metadata_from_stream(stream);
     };
-    
+
     return InMemoryFileSystem::make_from_buffer(buffer, metadata_reader);
 }
 } // namespace inmemoryfs

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.cpp
@@ -5,9 +5,10 @@
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
-#include <memory_buffer.hpp>
+#include "memory_buffer.hpp"
 
 #include <assert.h>
+#include <cstring>
 #include <functional>
 #include <iostream>
 #include <mutex>

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
@@ -8,11 +8,12 @@
 #pragma once
 
 #include <memory>
-#include <range.hpp>
 #include <stdio.h>
 #include <string>
 #include <system_error>
 #include <vector>
+
+#include "range.hpp"
 
 namespace inmemoryfs {
 /// A class representing a memory buffer.
@@ -23,38 +24,38 @@ public:
         MMap = 0,  // If the buffer is memory mapped.
         Malloc ,   // If the buffer is heap allocated.
     };
-    
+
     enum class ReadOption: uint8_t {
         Malloc = 0,
         MMap,
         LazyMMap
     };
-    
+
     inline MemoryBuffer(void *data,
                         size_t size,
                         Kind kind = Kind::Malloc,
                         std::shared_ptr<MemoryBuffer> parent = nullptr) noexcept:
-    data_(data), 
+    data_(data),
     size_(size),
     kind_(kind),
     parent_(parent)
     {}
-    
+
     MemoryBuffer(const MemoryBuffer &) = delete;
     MemoryBuffer &operator=(const MemoryBuffer &) = delete;
-    
+
     virtual ~MemoryBuffer() noexcept {}
-    
+
     /// Returns the underlying data.
     virtual inline void *data() noexcept {
         return data_;
     }
-    
+
     /// Returns the size of the buffer.
     inline const size_t size() const noexcept {
         return size_;
     }
-    
+
     /// Loads the contents of the buffer.
     ///
     /// - For a malloced buffer, the method is a no op, content is loaded at the initialization time.
@@ -65,12 +66,12 @@ public:
     inline virtual bool load(std::error_code& error) noexcept {
         return true;
     }
-    
+
     /// Returns the kind of the buffer.
     inline const Kind kind() const noexcept {
         return kind_;
     }
-    
+
     /// Returns the offset range that would be used when writing the buffer content.
     ///
     /// @param proposed_offset The proposed offset.
@@ -78,7 +79,7 @@ public:
     inline virtual std::pair<size_t, size_t> get_offset_range(size_t proposed_offset) const noexcept {
         return {proposed_offset, proposed_offset};
     }
-    
+
     /// Returns the revised range that must be used for writing.
     ///
     /// @param dst  The destination pointer.
@@ -87,7 +88,7 @@ public:
     inline virtual Range get_revised_range_for_writing(void *dst, Range proposed_range) const noexcept {
         return proposed_range;
     }
-    
+
     /// Writes the contents of the buffer to the destination buffer at the given offset.
     ///
     /// @param dst The destination pointer.
@@ -97,13 +98,13 @@ public:
     virtual bool write(void *dst,
                        size_t offset,
                        std::error_code& error) noexcept;
-    
+
     /// Slices a buffer.
     ///
     /// @param range The memory range.
     /// @retval The sliced buffer if the region is inside the buffer otherwise `nullptr`.
     virtual std::shared_ptr<MemoryBuffer> slice(Range range) noexcept;
-    
+
     /// Reads the file content at the specified path.
     ///
     /// @param file_path The file path.
@@ -116,7 +117,7 @@ public:
                       const std::vector<Range>& ranges,
                       ReadOption option,
                       std::error_code& error);
-    
+
     /// Reads the whole file content at the specified path.
     ///
     /// @param file_path The file path.
@@ -127,28 +128,28 @@ public:
     read_file_content(const std::string& file_path,
                       ReadOption option,
                       std::error_code& error);
-    
+
     /// Constructs a `MemoryBuffer`.
     ///
     /// @param size The size of the buffer.
     /// @param alignment The address alignment.
     static std::unique_ptr<MemoryBuffer>
     make_using_malloc(size_t size, size_t alignment = 1);
-    
-    
+
+
     /// Constructs a `MemoryBuffer` from memory allocated using `mmap`.
     ///
     /// @param size The size of the buffer.
     static std::unique_ptr<MemoryBuffer>
     make_using_mmap(size_t size);
-    
+
     /// Constructs a `MemoryBuffer` without copying data.
     ///
     /// @param data The buffer content.
     /// @param size The size of the buffer.
     static std::unique_ptr<MemoryBuffer>
     make_unowned(void *data, size_t size);
-    
+
     /// Constructs a `MemoryBuffer` with copying data.
     ///
     /// @param data The buffer content.

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_stream.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_stream.cpp
@@ -7,6 +7,8 @@
 
 #include "memory_stream.hpp"
 
+#include <limits>
+
 namespace inmemoryfs {
 
 MemoryStreamBuf::MemoryStreamBuf(const std::shared_ptr<MemoryBuffer>& buffer) noexcept : buffer_(buffer) {

--- a/backends/apple/coreml/runtime/inmemoryfs/memory_stream.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_stream.hpp
@@ -7,10 +7,10 @@
 
 #pragma once
 
-#include <memory_buffer.hpp>
-
 #include <istream>
 #include <ostream>
+
+#include "memory_buffer.hpp"
 
 namespace inmemoryfs {
 
@@ -18,7 +18,7 @@ namespace inmemoryfs {
 class MemoryStreamBuf: public std::streambuf {
 public:
     ~MemoryStreamBuf() = default;
-    
+
     /// Constructs a `MemoryStreamBuf` from a `MemoryBuffer`.
     ///
     /// @param buffer  The memory buffer.
@@ -31,7 +31,7 @@ protected:
     /// @param dir  The seek direction.
     /// @retval The stream position.
     pos_type iseekoff(off_type offset, std::ios_base::seekdir dir);
-    
+
     /// Called by `seekof` if the `openmode` is output.
     ///
     /// @param offset  The offset  value relative to the `dir`.
@@ -44,7 +44,7 @@ protected:
     /// @param which  The open mode.
     /// @retval The stream position.
     pos_type seekpos(pos_type pos, std::ios_base::openmode which) override;
-    
+
     /// Called by the public member function `pubseekoff` to alter the stream position.
     ///
     /// @param offset  The offset  value relative to the `dir`.
@@ -74,18 +74,18 @@ protected:
     ///
     /// Returns the value of the current character, converted to a value of type int.
     std::streambuf::int_type uflow() override;
-    
+
     /// Called by other member functions to put a character into the controlled output sequence.
     ///
     /// Returns the value of the character that's put into the stream, converted to a value of type int.
     int_type overflow(int_type ch) override;
-    
+
     /// Retrieves characters from the controlled input sequence and stores them in the array pointed by s,
     /// until either n characters have been extracted or the end of the sequence is reached.
     ///
     /// Returns the number of characters copied.
     std::streamsize xsgetn(char *s, std::streamsize n) override;
-    
+
     /// Writes characters from the array pointed to by s into the controlled output sequence,
     /// until either n characters have been written or the end of the output sequence is reached.
     ///
@@ -122,4 +122,3 @@ private:
 };
 
 }
-

--- a/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.cpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.cpp
@@ -7,6 +7,8 @@
 
 #include "reversed_memory_stream.hpp"
 
+#include <limits>
+
 namespace inmemoryfs {
 
 ReversedIMemoryStreamBuf::ReversedIMemoryStreamBuf(std::shared_ptr<MemoryBuffer> buffer) noexcept

--- a/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/reversed_memory_stream.hpp
@@ -7,10 +7,10 @@
 
 #pragma once
 
-#include <memory_buffer.hpp>
-
 #include <istream>
 #include <ostream>
+
+#include "memory_buffer.hpp"
 
 namespace inmemoryfs {
 
@@ -18,7 +18,7 @@ namespace inmemoryfs {
 class ReversedIMemoryStreamBuf: public std::streambuf {
 public:
     ~ReversedIMemoryStreamBuf() = default;
-    
+
     /// Constructs a `ReversedIMemoryStreamBuf` from a `MemoryBuffer`.
     ///
     /// @param buffer  The memory buffer.
@@ -50,7 +50,7 @@ protected:
     ///
     /// Returns the value of the current character, converted to a value of type int.
     std::streambuf::int_type uflow() override;
-    
+
     /// Retrieves characters from the controlled input sequence and stores them in the array pointed by s,
     /// until either n characters have been extracted or the end of the sequence is reached.
     ///
@@ -60,7 +60,7 @@ protected:
 private:
     /// Reads the character at the specified position.
     std::streambuf::int_type read(char *pos);
-    
+
     const std::shared_ptr<MemoryBuffer> buffer_;
     char *start_;
     char *current_;
@@ -70,7 +70,7 @@ private:
 /// A class for reading an in-memory buffer in reverse.
 class ReversedIMemoryStream final : public std::istream  {
 public:
-    
+
     /// Constructs a `ReversedIMemoryStream` from a `MemoryBuffer`.
     ///
     /// @param buffer  The memory buffer.
@@ -83,4 +83,3 @@ private:
 };
 
 }
-

--- a/backends/apple/coreml/runtime/util/json_util.cpp
+++ b/backends/apple/coreml/runtime/util/json_util.cpp
@@ -6,7 +6,7 @@
 //
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
-#include <json_util.hpp>
+#include "json_util.hpp"
 
 #include <string>
 #include <vector>

--- a/backends/apple/coreml/runtime/util/objc_json_serde.mm
+++ b/backends/apple/coreml/runtime/util/objc_json_serde.mm
@@ -7,7 +7,7 @@
 // Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
 
-#import <objc_json_serde.h>
+#import "objc_json_serde.h"
 
 namespace executorchcoreml {
 namespace serde {


### PR DESCRIPTION
Summary: Some headers are relying on transitive includes, that may be missing when building for different platforms, so we have to include everything explicitly. Also, need to use quotes over angle parenthesis for local headers includes.

Differential Revision: D57340360


