### PR TITLE
Fix initialization of pre_allocated_input and pre_allocated_output in Method

### DIFF
--- a/exir/passes/replace_view_copy_with_view_pass.py
+++ b/exir/passes/replace_view_copy_with_view_pass.py
@@ -275,7 +275,7 @@ class ReplaceViewCopyWithViewPass(PassBase):
             for node in module.graph.nodes:
                 # Note: We only replace view_copy nodes that are not output, since
                 # the output pointer could be modified at runtime (T187925929)
-                if _is_view_copy(node) and node.next.op != "output":
+                if _is_view_copy(node) and all(u.op != "output" for u in node.users):
                     base, _ = node.args
                     node.target = _VIEW_OP
 
@@ -302,7 +302,9 @@ class ReplaceViewCopyWithViewPass(PassBase):
             for node in module.graph.nodes:
                 # Note: We only replace view_copy nodes that are not output, since
                 # the output pointer could be modified at runtime (T187925929)
-                assert not (_is_view_copy(node) and node.next.op != "output")
+                assert not (
+                    _is_view_copy(node) and all(u.op != "output" for u in node.users)
+                )
                 if node.op == "call_function" and node.target == _VIEW_OP:
                     assert isinstance(node.meta["spec"], _ViewSpec)
 
@@ -317,6 +319,6 @@ class ReplaceViewCopyWithViewPass(PassBase):
             for node in module.graph.nodes:
                 # Note: We only replace view_copy nodes that are not output, since
                 # the output pointer could be modified at runtime (T187925929)
-                if _is_view_copy(node) and node.next.op != "output":
+                if _is_view_copy(node) and all(u.op != "output" for u in node.users):
                     base, size = node.args
                     assert not _is_view_copy(base)

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -188,6 +188,13 @@ class Module final {
             method->outputs_size());
       }
       for (size_t i = 0; i < output_storages->size(); ++i) {
+        const auto& output_tensor_meta =
+            method->method_meta().output_tensor_meta(i);
+        // If there is no tensor meta for this output, we cannot override its
+        // pointer. The span will also be unused.
+        if (!output_tensor_meta.ok()) {
+          continue;
+        }
         Error output_status = method->set_output_data_ptr(
             (*output_storages)[i].data(), (*output_storages)[i].size(), i);
         // InvalidState can be the status if outputs are already memory planned.


### PR DESCRIPTION
Summary:
A recent issue with `memory.view` manifested as a SIGSEGV in the
Executorch runtime because the `Method::pre_allocated_output_` field
was an OR condition over all the outputs; however, it is feasible for
some outputs to be pre-allocated, and for some not to be.
The property for pre_allocated_output should be
enforced for all outputs, just like in the memory planning algorithm.
Same goes for `pre_allocated_input_`.

Add a check to ensure all outputs are the same. Also update the pybindings
to not try to call this function for a non-tensor, as that will generate
an error condition unnecessarily.

Differential Revision: D57337808


