### PR TITLE
Ignore the FLATC_EXECUTABLE env var when empty

### DIFF
--- a/exir/_serialize/_flatbuffer.py
+++ b/exir/_serialize/_flatbuffer.py
@@ -201,7 +201,9 @@ def _run_flatc(args: Sequence[str]) -> None:
             subprocess.run([flatc_path] + list(args), check=True)
     else:
         # Expect the `flatc` tool to be on the system path or set as an env var.
-        flatc_path = os.getenv("FLATC_EXECUTABLE", "flatc")
+        flatc_path = os.getenv("FLATC_EXECUTABLE")
+        if not flatc_path:
+            flatc_path = "flatc"
         subprocess.run([flatc_path] + list(args), check=True)
 
 


### PR DESCRIPTION
We've seen some situations fail because flatc_path is an empty string. This seems like a likely culprit, but doesn't hurt either way.

Test Plan:
Ran the following script with `(. /tmp/run.sh)`, which successfully created `/tmp/et-test/executorch/add.pte`.

`/tmp/run.sh`:
```
set -euxo pipefail

conda remove -yn et-test --all
conda create -yn et-test python=3.10
conda activate et-test

mkdir -p /tmp/et-test
cd /tmp/et-test
# Get this PR
git clone -b flatc-empty-path https://github.com/dbort/executorch-1
cd executorch

git submodule sync
git submodule update --init

./install_requirements.sh

cat > /tmp/export_add.py << HERE
import torch
from torch.export import export
from executorch.exir import to_edge

# Start with a PyTorch model that adds two input tensors (matrices)
class Add(torch.nn.Module):
  def __init__(self):
    super(Add, self).__init__()

  def forward(self, x: torch.Tensor, y: torch.Tensor):
      return x + y

# 1. torch.export: Defines the program with the ATen operator set.
aten_dialect = export(Add(), (torch.ones(1), torch.ones(1)))

# 2. to_edge: Make optimizations for Edge devices
edge_program = to_edge(aten_dialect)

# 3. to_executorch: Convert the graph to an ExecuTorch program
executorch_program = edge_program.to_executorch()

# 4. Save the compiled .pte program
with open("add.pte", "wb") as file:
    file.write(executorch_program.buffer)
HERE

python /tmp/export_add.py
echo "Created" *.pte
```