### PR TITLE
mean_to_sum_div export pass

### DIFF
--- a/backends/transforms/TARGETS
+++ b/backends/transforms/TARGETS
@@ -30,6 +30,20 @@ runtime.python_library(
 )
 
 runtime.python_library(
+    name = "mean_to_sum_div",
+    srcs = ["mean_to_sum_div.py"],
+    visibility = [
+        "//executorch/backends/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir:pass_base",
+        "//executorch/exir:sym_util",
+        "//executorch/exir/dialects:lib",
+    ],
+)
+
+runtime.python_library(
     name = "duplicate_dynamic_quant_chain",
     srcs = ["duplicate_dynamic_quant_chain.py"],
     visibility = [

--- a/backends/transforms/mean_to_sum_div.py
+++ b/backends/transforms/mean_to_sum_div.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.exir.dialects._ops import ops as exir_ops
+
+from executorch.exir.pass_base import ExportPass
+
+
+class MeanToSumDiv(ExportPass):
+    def call_operator(self, op, args, kwargs, meta):
+        if op != exir_ops.edge.aten.mean.dim:
+            return super().call_operator(op, args, kwargs, meta)
+        sum_res = super().call_operator(
+            exir_ops.edge.aten.sum.dim_IntList, args, kwargs, meta
+        )
+        # args[0] is the input tensor
+        shape = args[0].node.meta["val"].shape
+        dims_to_reduce = args[1]
+        size = 1.0
+        for dim in dims_to_reduce:
+            size = size * shape[dim]
+
+        size_tensor = super().call_operator(
+            exir_ops.edge.aten.full.default,
+            (
+                [
+                    1,
+                ],
+                size,
+            ),
+            {"dtype": torch.float32},
+            meta,
+        )
+
+        return super().call_operator(
+            exir_ops.edge.aten.div.Tensor, (sum_res, size_tensor), {}, meta
+        )

--- a/backends/vulkan/test/TARGETS
+++ b/backends/vulkan/test/TARGETS
@@ -14,9 +14,11 @@ python_unittest(
     ],
     deps = [
         "//caffe2:torch",
+        "//executorch/backends/transforms:mean_to_sum_div",
         "//executorch/backends/vulkan:vulkan_preprocess",
         "//executorch/backends/vulkan/partitioner:vulkan_partitioner",
         "//executorch/exir:lib",
+        "//executorch/exir:pass_base",
         "//executorch/extension/pybindings:portable_lib",  # @manual
         "//executorch/extension/pytree:pylib",
         "//executorch/kernels/portable:custom_ops_generated_lib",


### PR DESCRIPTION
Summary: ET-VK does not support aten.mean yet. Work-around is to introduce an mean-to-sum-div export pass.

Differential Revision: D57369610


