### PR TITLE
add missing cmake flag to set up JNI for LLama Android Demo

### DIFF
--- a/examples/demo-apps/android/LlamaDemo/setup.sh
+++ b/examples/demo-apps/android/LlamaDemo/setup.sh
@@ -13,6 +13,7 @@ EXECUTORCH_USE_TIKTOKEN="${EXECUTORCH_USE_TIKTOKEN:-OFF}"
 cmake . -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
   -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
   -DANDROID_ABI="${ANDROID_ABI}" \
+  -DANDROID_PLATFORM=android-23 \
   -DEXECUTORCH_BUILD_XNNPACK=ON \
   -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
   -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
@@ -32,6 +33,7 @@ cmake --build "${CMAKE_OUT}" -j "${CMAKE_JOBS}" --target install --config Releas
 cmake examples/models/llama2 \
          -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
          -DANDROID_ABI="$ANDROID_ABI" \
+         -DANDROID_PLATFORM=android-23 \
          -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
          -DEXECUTORCH_USE_TIKTOKEN="${EXECUTORCH_USE_TIKTOKEN}" \
          -DEXECUTORCH_BUILD_KERNELS_CUSTOM=ON \
@@ -45,6 +47,7 @@ cmake --build "${CMAKE_OUT}"/examples/models/llama2 -j "${CMAKE_JOBS}" --config 
 cmake extension/android \
   -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
   -DANDROID_ABI="${ANDROID_ABI}" \
+  -DANDROID_PLATFORM=android-23 \
   -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
   -DEXECUTORCH_BUILD_LLAMA_JNI=ON \
   -DEXECUTORCH_USE_TIKTOKEN="${EXECUTORCH_USE_TIKTOKEN}" \


### PR DESCRIPTION
Compilation of JNI library results in the following error, due to missing cmake flag ` -DANDROID_PLATFORM=android-23 `
```
[ 92%] Built target statusor
[ 92%] Building CXX object re2/CMakeFiles/re2.dir/re2/prog.cc.o
[ 93%] Building CXX object re2/CMakeFiles/re2.dir/re2/re2.cc.o
[ 94%] Linking CXX shared library libexecutorch_jni.so
[ 94%] Building CXX object re2/CMakeFiles/re2.dir/re2/regexp.cc.o
[ 94%] Linking CXX static library libabsl_log_flags.a
[ 94%] Built target log_flags
ld: error: undefined symbol: stderr
>>> referenced by Posix.cpp:101 (/home/salykova/Projects/executorch/runtime/platform/target/Posix.cpp:101)
>>>               Posix.cpp.o:(et_pal_current_ticks) in archive /home/salykova/Projects/executorch/cmake-out-android/lib/libexecutorch_no_prim_ops.a
>>> referenced by Posix.cpp:101 (/home/salykova/Projects/executorch/runtime/platform/target/Posix.cpp:101)
>>>               Posix.cpp.o:(et_pal_current_ticks) in archive /home/salykova/Projects/executorch/cmake-out-android/lib/libexecutorch_no_prim_ops.a
[ 95%] Building CXX object re2/CMakeFiles/re2.dir/re2/set.cc.o
[ 95%] Building CXX object re2/CMakeFiles/re2.dir/re2/simplify.cc.o
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[2]: *** [CMakeFiles/executorch_jni.dir/build.make:151: libexecutorch_jni.so] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:738: CMakeFiles/executorch_jni.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
[ 95%] Building CXX object re2/CMakeFiles/re2.dir/re2/tostring.cc.o
[ 96%] Building CXX object re2/CMakeFiles/re2.dir/re2/unicode_casefold.cc.o
[ 96%] Building CXX object re2/CMakeFiles/re2.dir/re2/unicode_groups.cc.o
[ 96%] Building CXX object re2/CMakeFiles/re2.dir/util/rune.cc.o
[ 97%] Building CXX object re2/CMakeFiles/re2.dir/util/strutil.cc.o
[ 97%] Linking CXX static library libabsl_flags_usage_internal.a
[ 97%] Built target flags_usage_internal
[ 97%] Linking CXX static library libre2.a
[ 97%] Built target re2
gmake: *** [Makefile:136: all] Error 2

```