### PR TITLE
[ET-VK] Recompose linear operator during serialization

### DIFF
--- a/backends/transforms/addmm_mm_to_linear.py
+++ b/backends/transforms/addmm_mm_to_linear.py
@@ -122,9 +122,8 @@ def replace_addmm_mm_with_linear(graph: torch.fx.Graph) -> torch.fx.Graph:
                         ops.aten.t_copy.default,
                         ops.aten.permute_copy.default,
                     ]:
-                        raise RuntimeError(
-                            f"Weight input to addmm must be tranposed but found {weight_t_node}"
-                        )
+                        # Skip this node as it appears to be a standalone `addmm`
+                        continue
                     weight_node = weight_t_node.args[0]
                     args = (node.args[1], weight_node, node.args[0])
                     linear_node = graph.create_node(
@@ -140,9 +139,8 @@ def replace_addmm_mm_with_linear(graph: torch.fx.Graph) -> torch.fx.Graph:
                         ops.aten.t_copy.default,
                         ops.aten.permute_copy.default,
                     ]:
-                        raise RuntimeError(
-                            f"Weight input to addmm must be tranposed but found {weight_t_node}"
-                        )
+                        # Skip this node as it appears to be a standalone `mm`
+                        continue
                     weight_node = weight_t_node.args[0]
                     args = (node.args[0], weight_node)
                     linear_node = graph.create_node(

--- a/backends/vulkan/TARGETS
+++ b/backends/vulkan/TARGETS
@@ -22,6 +22,7 @@ runtime.python_library(
         "@EXECUTORCH_CLIENTS",
     ],
     deps = [
+        "//executorch/backends/transforms:addmm_mm_to_linear",
         "//executorch/exir:graph_module",
         "//executorch/exir/_serialize:_bindings",
         "//executorch/exir/_serialize:lib",

--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -47,6 +47,7 @@ class VulkanSupportedOperators(OperatorSupportBase):
             # Matrix multiplication operators
             exir_ops.edge.aten.bmm.default,
             exir_ops.edge.aten.mm.default,
+            exir_ops.edge.aten.addmm.default,
             # Pooling operators
             exir_ops.edge.aten.max_pool2d_with_indices.default,
             # Sum
@@ -60,6 +61,7 @@ class VulkanSupportedOperators(OperatorSupportBase):
             exir_ops.edge.aten.unsqueeze_copy.default,
             exir_ops.edge.aten.view_copy.default,
             # Copy-releated operators
+            exir_ops.edge.aten.permute_copy.default,
             exir_ops.edge.aten.clone.default,
             exir_ops.edge.aten.cat.default,
             exir_ops.edge.aten.split_with_sizes_copy.default,

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -541,11 +541,7 @@ class TestBackends(unittest.TestCase):
             model, sample_inputs, dynamic_shapes=dynamic_shapes, test_inputs=test_inputs
         )
 
-    # TODO(ssjia): Currently the pass used to reconstruct linear will error out if mm or
-    # addmm is used directly (i.e. not through linear). We will have to patch the pass
-    # directly or prevent the decomposition of linear after the decomposition selection
-    # feature is landed in order to prevent this test from crashing.
-    def DISABLED_test_vulkan_backend_matmul(self):
+    def test_vulkan_backend_matmul(self):
         class MatMulModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -461,6 +461,35 @@ class TestBackends(unittest.TestCase):
 
         self.lower_unary_module_and_test_output(TanhModule())
 
+    def test_vulkan_backend_linear(self):
+        class LinearModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(128, 64, bias=False)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        module = LinearModule()
+        sample_inputs = (torch.rand(size=(32, 128), dtype=torch.float32),)
+        batch = Dim("batch", max=32)
+        dynamic_shapes = {"x": {0: batch}}
+
+        test_inputs = [
+            (torch.rand(15, 128),),
+            (torch.rand(6, 128),),
+            (torch.rand(30, 128),),
+            (torch.rand(20, 128),),
+            (torch.rand(19, 128),),
+        ]
+
+        self.lower_module_and_test_output(
+            module,
+            sample_inputs,
+            dynamic_shapes=dynamic_shapes,
+            test_inputs=test_inputs,
+        )
+
     def test_vulkan_backend_partial(self):
         class SimpleModel(torch.nn.Module):
             def __init__(self):
@@ -512,7 +541,11 @@ class TestBackends(unittest.TestCase):
             model, sample_inputs, dynamic_shapes=dynamic_shapes, test_inputs=test_inputs
         )
 
-    def test_vulkan_backend_matmul(self):
+    # TODO(ssjia): Currently the pass used to reconstruct linear will error out if mm or
+    # addmm is used directly (i.e. not through linear). We will have to patch the pass
+    # directly or prevent the decomposition of linear after the decomposition selection
+    # feature is landed in order to prevent this test from crashing.
+    def DISABLED_test_vulkan_backend_matmul(self):
         class MatMulModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -861,7 +894,7 @@ class TestBackends(unittest.TestCase):
             memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
         )
 
-    def DISABLED_test_vulkan_backend_permute_copy(self):
+    def test_vulkan_backend_permute_copy(self):
         # aten.permute_copy.default is not enabled yet in partitioner
         class PermuteModule(torch.nn.Module):
             def __init__(self):
@@ -979,7 +1012,7 @@ class TestBackends(unittest.TestCase):
             memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
         )
 
-    def DISABLED_test_vulkan_backend_t_default(self):
+    def test_vulkan_backend_t_default(self):
         # aten.permute_copy.default is not enabled yet in partitioner
         class TestModule(torch.nn.Module):
             def __init__(self):

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -6,6 +6,8 @@
 
 from typing import final, List
 
+from executorch.backends.transforms.addmm_mm_to_linear import AddmmToLinearTransform
+
 from executorch.backends.vulkan.serialization.vulkan_graph_builder import VkGraphBuilder
 from executorch.backends.vulkan.serialization.vulkan_graph_serialize import (
     serialize_vulkan_graph,
@@ -37,6 +39,7 @@ class VulkanBackend(BackendDetails):
         module_compile_spec: List[CompileSpec],
     ) -> PreprocessResult:
         passes = [
+            AddmmToLinearTransform(),
             SpecPropPass(),
             ConstraintBasedSymShapeEvalPass(),
             MemoryPlanningPass("greedy"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3624
* #3622
* __->__ #3621

As title.

Introduce a pass to reconstruct linear. This allows us to add `permute` and `addmm` to the partitioner list since `linear` will be recomposed and is now supported in the backend.

Differential Revision: [D57203868](https://our.internmc.facebook.com/intern/diff/D57203868/)