### PR TITLE
clean up trunk by disabling skipped tests

### DIFF
--- a/backends/xnnpack/test/models/edsr.py
+++ b/backends/xnnpack/test/models/edsr.py
@@ -29,7 +29,7 @@ class TestEDSR(unittest.TestCase):
         )
 
     @unittest.skip("T187799178: Debugging Numerical Issues with Calibration")
-    def test_qs8_edsr(self):
+    def _test_qs8_edsr(self):
         (
             Tester(self.edsr, self.model_inputs)
             .quantize()

--- a/backends/xnnpack/test/models/emformer_rnnt.py
+++ b/backends/xnnpack/test/models/emformer_rnnt.py
@@ -60,7 +60,7 @@ class TestEmformerModel(unittest.TestCase):
     @unittest.skip(
         "T183426271: Emformer Predictor Takes too long to export + partition"
     )
-    def test_fp32_emformer_predictor(self):
+    def _test_fp32_emformer_predictor(self):
         predictor = self.Predictor()
         (
             Tester(predictor, predictor.get_example_inputs())

--- a/backends/xnnpack/test/models/inception_v3.py
+++ b/backends/xnnpack/test/models/inception_v3.py
@@ -46,7 +46,7 @@ class TestInceptionV3(unittest.TestCase):
         )
 
     @unittest.skip("T187799178: Debugging Numerical Issues with Calibration")
-    def test_qs8_ic3(self):
+    def _test_qs8_ic3(self):
         # Quantization fuses away batchnorm, so it is no longer in the graph
         ops_after_quantization = self.all_operators - {
             "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",

--- a/backends/xnnpack/test/models/mobilenet_v2.py
+++ b/backends/xnnpack/test/models/mobilenet_v2.py
@@ -50,7 +50,7 @@ class TestMobileNetV2(unittest.TestCase):
         )
 
     @unittest.skip("T187799178: Debugging Numerical Issues with Calibration")
-    def test_qs8_mv2(self):
+    def _test_qs8_mv2(self):
         # Quantization fuses away batchnorm, so it is no longer in the graph
         ops_after_quantization = self.all_operators - {
             "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",

--- a/backends/xnnpack/test/models/mobilenet_v3.py
+++ b/backends/xnnpack/test/models/mobilenet_v3.py
@@ -52,7 +52,7 @@ class TestMobileNetV3(unittest.TestCase):
         )
 
     @unittest.skip("T187799178: Debugging Numerical Issues with Calibration")
-    def test_qs8_mv3(self):
+    def _test_qs8_mv3(self):
         ops_after_quantization = self.all_operators - {
             "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default",
         }

--- a/backends/xnnpack/test/models/resnet.py
+++ b/backends/xnnpack/test/models/resnet.py
@@ -57,7 +57,7 @@ class TestResNet18(unittest.TestCase):
         self._test_exported_resnet(Tester(torchvision.models.resnet18(), self.inputs))
 
     @unittest.skip("T187799178: Debugging Numerical Issues with Calibration")
-    def test_qs8_resnet18(self):
+    def _test_qs8_resnet18(self):
         quantized_tester = Tester(torchvision.models.resnet18(), self.inputs).quantize()
         self._test_exported_resnet(quantized_tester)
 
@@ -74,7 +74,7 @@ class TestResNet18(unittest.TestCase):
         )
 
     @unittest.skip("T187799178: Debugging Numerical Issues with Calibration")
-    def test_qs8_resnet18_dynamic(self):
+    def _test_qs8_resnet18_dynamic(self):
         self._test_exported_resnet(
             Tester(self.DynamicResNet(), self.inputs, self.dynamic_shapes).quantize()
         )

--- a/backends/xnnpack/test/models/very_big_model.py
+++ b/backends/xnnpack/test/models/very_big_model.py
@@ -29,7 +29,7 @@ class TestVeryBigModel(unittest.TestCase):
             return self.seq(x)
 
     @unittest.skip("This test is used for benchmarking and should not be run in CI")
-    def test_very_big_model(self):
+    def _test_very_big_model(self):
 
         (
             Tester(self.BigModel(), (torch.randn(1, 5000),))

--- a/backends/xnnpack/test/ops/cat.py
+++ b/backends/xnnpack/test/ops/cat.py
@@ -189,7 +189,7 @@ class TestCat(unittest.TestCase):
             return z + z
 
     @unittest.skip("T172862540 - Runtime failure.")
-    def test_qs8_cat_nhwc(self):
+    def _test_qs8_cat_nhwc(self):
         inputs = (torch.randn(1, 1, 3, 3), torch.randn(1, 1, 3, 3))
         self._test_cat(self.CatNhwc(), inputs, quant=True, quant_ops=3)
 
@@ -211,6 +211,6 @@ class TestCat(unittest.TestCase):
             return z + z
 
     @unittest.skip("T172862540 - Runtime failure.")
-    def test_qs8_cat_nhwc2(self):
+    def _test_qs8_cat_nhwc2(self):
         inputs = (torch.randn(1, 1, 3, 3), torch.randn(1, 1, 3, 3))
         self._test_cat(self.CatNhwc(), inputs, quant=True, quant_ops=4)

--- a/backends/xnnpack/test/ops/elu.py
+++ b/backends/xnnpack/test/ops/elu.py
@@ -43,17 +43,17 @@ class TestElu(unittest.TestCase):
         )
 
     @unittest.skip("T171810227 - Missing recomposition for ELU")
-    def test_fp16_elu(self):
+    def _test_fp16_elu(self):
         inputs = (torch.randn(1, 3, 3).to(torch.float16),)
         self._test_elu(inputs)
 
     @unittest.skip("T171810227 - Missing recomposition for ELU")
-    def test_fp32_elu(self):
+    def _test_fp32_elu(self):
         inputs = (torch.randn(1, 3, 3),)
         self._test_elu(inputs)
 
     @unittest.skip("T171810227 - Missing recomposition for ELU")
-    def test_qs8_elu(self):
+    def _test_qs8_elu(self):
         inputs = (torch.randn(1, 3, 4, 4),)
         (
             Tester(self.ELU(), inputs)
@@ -77,7 +77,7 @@ class TestElu(unittest.TestCase):
         )
 
     @unittest.skip("T171810227 - Missing recomposition for ELU")
-    def test_qs8_elu_functional(self):
+    def _test_qs8_elu_functional(self):
         inputs = (torch.randn(1, 3, 4, 4),)
         (
             Tester(self.ELU(), inputs)

--- a/backends/xnnpack/test/ops/hardswish.py
+++ b/backends/xnnpack/test/ops/hardswish.py
@@ -45,17 +45,17 @@ class TestHardswish(unittest.TestCase):
         )
 
     @unittest.skip("T158969708 - Missing recomposition pass for hardswish")
-    def test_fp16_hardswish(self):
+    def _test_fp16_hardswish(self):
         inputs = (torch.randn(1, 3, 3).to(torch.float16),)
         self._test_hardswish(inputs)
 
     @unittest.skip("T158969708 - Missing recomposition pass for hardswish")
-    def test_fp32_hardswish(self):
+    def _test_fp32_hardswish(self):
         inputs = (torch.randn(1, 3, 3),)
         self._test_hardswish(inputs)
 
     @unittest.skip("T158969708 - Missing recomposition pass for hardswish")
-    def test_fp32_hardswish_functional(self):
+    def _test_fp32_hardswish_functional(self):
         inputs = (torch.randn(1, 3, 3),)
         (
             Tester(self.HardswishFunctional(), inputs)

--- a/backends/xnnpack/test/ops/linear.py
+++ b/backends/xnnpack/test/ops/linear.py
@@ -135,7 +135,7 @@ class TestLinear(unittest.TestCase):
                 )
 
     @unittest.skip("XNNPACK currently only supports per-channel dynamic quantization.")
-    def test_qd8_per_tensor_linear(self):
+    def _test_qd8_per_tensor_linear(self):
         for uses_bias in (False, True):
             inputs = (torch.randn(2, 4),)
             module = torch.nn.Linear(4, 5, bias=uses_bias)
@@ -697,11 +697,11 @@ class TestLinear(unittest.TestCase):
     #    Max: 12.518657684326172, 12.516003608703613
     #    Min: -20.070953369140625, -20.077701568603516
     @unittest.skip("Need to fix the dq_per_channel output dtype")
-    def test_qd8_fp16_per_token_weight_per_channel_int8(self):
+    def _test_qd8_fp16_per_token_weight_per_channel_int8(self):
         self._run_manual_dqlinear_tests(8, torch.float16)
 
     @unittest.skip("Need to fix the dq_per_channel output dtype")
-    def test_qd8_fp16_per_token_weight_per_channel_int4(self):
+    def _test_qd8_fp16_per_token_weight_per_channel_int4(self):
         self._run_manual_dqlinear_tests(4, torch.float16)
 
     def test_qd8_fp32_per_token_weight_per_channel_group_int4(self):

--- a/backends/xnnpack/test/ops/max_dim.py
+++ b/backends/xnnpack/test/ops/max_dim.py
@@ -41,17 +41,17 @@ class TestMaxDim(unittest.TestCase):
         )
 
     @unittest.skip("T171468483 - Fails to partition due to index output dtype.")
-    def test_fp16_max_dim(self):
+    def _test_fp16_max_dim(self):
         inputs = (torch.randn(16, 3, 12, 12).to(torch.float16),)
         self._test_max_dim(inputs)
 
     @unittest.skip("T171468483 - Fails to partition due to index output dtype.")
-    def test_fp32_max_dim(self):
+    def _test_fp32_max_dim(self):
         inputs = (torch.randn(16, 3, 12, 12),)
         self._test_max_dim(inputs)
 
     @unittest.skip("T171468483 - Fails to partition due to index output dtype.")
-    def test_fp32_max_dim_no_indices(self):
+    def _test_fp32_max_dim_no_indices(self):
         inputs = (torch.randn(16, 3, 12, 12),)
         (
             Tester(self.MaxNoIndices(), inputs)

--- a/backends/xnnpack/test/ops/slice_copy.py
+++ b/backends/xnnpack/test/ops/slice_copy.py
@@ -115,7 +115,7 @@ class TestSliceCopy(unittest.TestCase):
     # Note: Slice ends up as slice_copy later in the process, but during quantization,
     # it's still slice, which isn't supported by the XNNPACK quantizer.
     @unittest.skip("T156004676 - slice isn't propagated")
-    def test_qs8_slice_copy(self):
+    def _test_qs8_slice_copy(self):
         class SliceCopy(torch.nn.Module):
             def forward(self, x):
                 y = x + x

--- a/backends/xnnpack/test/ops/sub.py
+++ b/backends/xnnpack/test/ops/sub.py
@@ -54,7 +54,7 @@ class TestSub(unittest.TestCase):
         self._test_sub(inputs)
 
     @unittest.skip("T171957656 - Quantized sub not implemented.")
-    def test_qs8_sub(self):
+    def _test_qs8_sub(self):
         inputs = (torch.randn(1, 1, 4, 4), torch.randn(1, 1, 4, 4))
         (
             Tester(self.Sub(), inputs)
@@ -78,7 +78,7 @@ class TestSub(unittest.TestCase):
         )
 
     @unittest.skip("T171957656 - Quantized sub not implemented.")
-    def test_qs8_sub2(self):
+    def _test_qs8_sub2(self):
         inputs = (torch.randn(1, 1, 4, 4),)
         (
             Tester(self.Sub2(), inputs)
@@ -102,7 +102,7 @@ class TestSub(unittest.TestCase):
         )
 
     @unittest.skip("T171957656 - Quantized sub not implemented.")
-    def test_qs8_sub3(self):
+    def _test_qs8_sub3(self):
         inputs = (torch.randn(1, 1, 4, 4), torch.randn(1, 1, 4, 1))
         (
             Tester(self.Sub(), inputs)
@@ -126,7 +126,7 @@ class TestSub(unittest.TestCase):
         )
 
     @unittest.skip("T171957656 - Quantized sub not implemented.")
-    def test_qs8_sub_relu(self):
+    def _test_qs8_sub_relu(self):
         class Sub(torch.nn.Module):
             def forward(self, x, y):
                 z = x - y


### PR DESCRIPTION
Summary: These tests are all being skipped, and have been marked with the associated tasks. However, on trunk it clutters the dashboard because it displays all of these as brokens

Differential Revision: D57396890


