### PR TITLE
Improve ET perf on M1 mac

### DIFF
--- a/backends/xnnpack/threadpool/cpuinfo_utils.cpp
+++ b/backends/xnnpack/threadpool/cpuinfo_utils.cpp
@@ -32,6 +32,7 @@ bool is_non_performant_core(const struct cpuinfo_uarch_info* uarch_info) {
     case cpuinfo_uarch_cortex_a55:
     case cpuinfo_uarch_cortex_a53:
     case cpuinfo_uarch_cortex_a510:
+    case cpuinfo_uarch_icestorm:
       return true;
     // This can be so many other cores.
     // Need to update this to better account for slow cores


### PR DESCRIPTION
Summary: Improve perf of ET on M1 by labeling cpuinfo_uarch_icestorm as a non-performant core.  With this change, we use 6 cores on M1 instead of 10.

Differential Revision: D57416160


