### PR TITLE
checking "transposed convolution" at beginning

### DIFF
--- a/kernels/portable/cpu/util/kernel_ops_util.cpp
+++ b/kernels/portable/cpu/util/kernel_ops_util.cpp
@@ -294,6 +294,8 @@ bool check_convolution_args(
     IntArrayRef output_padding,
     int64_t groups,
     Tensor& out) {
+  ET_LOG_MSG_AND_RETURN_IF_FALSE(
+      !transposed, "transposed convolution not supported yet.");
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, weight, out));
 
   ET_LOG_AND_RETURN_IF_FALSE(tensor_is_default_or_channels_last_dim_order(in));
@@ -334,9 +336,6 @@ bool check_convolution_args(
       "groups %" PRId64 " is not divisible by in.size(1) = %zd",
       groups,
       in.size(1));
-
-  ET_LOG_MSG_AND_RETURN_IF_FALSE(
-      !transposed, "transposed convolution not supported yet.");
 
   return true;
 }


### PR DESCRIPTION
Summary:
Current `check_convolution_args` checks shapes of parameters before checking `transposed`. For a model using `ConvTranspose2d`, this may incur error like
```
executorch:tensor_util.h:655] Check failed (a.size(dim_a) == b.size(dim_b)): Tensors do not match: a.size(0) = 512 does not match b.size(0) = 1024
```
instead of showing `"transposed convolution not supported yet."` (see "ET CPU" in the test plan of D57258810).

The reason for getting the error above is due to the difference of shape of `weight` between `ConvTranspose2d` and `Conv2d`, specifically,
- [shape of `weight` in `ConvTranspose2d` ](https://pytorch.org/docs/stable/generated/torch.nn.ConvTranspose2d.html) is (note that the first item is `in_channels`)
```
(in_channels, out_channels/groups, kernel_size[0], kernel_size[1])
```
- instead, [shape of `weight` in `Conv2d`](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html) is (note that the first item is `out_channels`)
```
(out_channels, in_channels/groups​, kernel_size[0], kernel_size[1])
```
so [`tensors_have_same_size_at_dims(bias.value(), 0, weight, 0));`](https://www.internalfb.com/code/fbsource/[d34494a8af88b8c9742d00d62046d7884da47d7e]/fbcode/executorch/kernels/portable/cpu/util/kernel_ops_util.cpp?lines=314) may fail for `ConvTranspose2d`.

The error message would be more informative if we check `transposed` at the beginning.

Differential Revision: D57424572


