### PR TITLE
ArmQuantizer: quantize dropout with SharedQuantizationSpec

### DIFF
--- a/backends/arm/quantizer/arm_quantizer_utils.py
+++ b/backends/arm/quantizer/arm_quantizer_utils.py
@@ -103,6 +103,7 @@ def is_share_obs_or_fq_op(op: Callable) -> bool:
         torch.ops.aten.view.default,
         torch.ops.aten.slice_copy.Tensor,
         torch.ops.aten.flatten.using_ints,
+        torch.ops.aten.dropout.default,
     ]
 
 


### PR DESCRIPTION
- Quantize Dropout with a SharedQuantizationSpec.
- Use ArmQuantizer for MobileNetV2 unittests.