### PR TITLE
Fill in missing pieces from macro layers for folly

### DIFF
--- a/shim/BUCK
+++ b/shim/BUCK
@@ -1,5 +1,57 @@
-load("@prelude//toolchains:demo.bzl", "system_demo_toolchains")
+load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
+load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
+load("@prelude//toolchains:go.bzl", "system_go_toolchain")
+load("@prelude//toolchains:haskell.bzl", "system_haskell_toolchain")
+load("@prelude//toolchains:ocaml.bzl", "system_ocaml_toolchain")
+load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain", "system_python_toolchain")
+load("@prelude//toolchains:remote_test_execution.bzl", "remote_test_execution_toolchain")
+load("@prelude//toolchains:rust.bzl", "system_rust_toolchain")
 
-# All the default toolchains, suitable for a quick demo or early prototyping.
-# Most real projects should copy/paste the implementation to configure them.
-system_demo_toolchains()
+oncall("open_source")
+
+system_cxx_toolchain(
+    name = "cxx",
+    cxx_flags = ["-std=c++20"],
+    visibility = ["PUBLIC"],
+)
+
+system_genrule_toolchain(
+    name = "genrule",
+    visibility = ["PUBLIC"],
+)
+
+system_go_toolchain(
+    name = "go",
+    visibility = ["PUBLIC"],
+)
+
+system_haskell_toolchain(
+    name = "haskell",
+    visibility = ["PUBLIC"],
+)
+
+system_ocaml_toolchain(
+    name = "ocaml",
+    visibility = ["PUBLIC"],
+)
+
+system_python_toolchain(
+    name = "python",
+    visibility = ["PUBLIC"],
+)
+
+system_python_bootstrap_toolchain(
+    name = "python_bootstrap",
+    visibility = ["PUBLIC"],
+)
+
+system_rust_toolchain(
+    name = "rust",
+    default_edition = "2021",
+    visibility = ["PUBLIC"],
+)
+
+remote_test_execution_toolchain(
+    name = "remote_test_execution",
+    visibility = ["PUBLIC"],
+)

--- a/shim/antlir/fbpkg/fbpkg.bzl
+++ b/shim/antlir/fbpkg/fbpkg.bzl
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+def _builder(**_):
+    pass
+
+def _buck_opts(**_):
+    pass
+
+fbpkg = struct(
+    builder = _builder,
+    buck_opts = _buck_opts,
+)

--- a/shim/build_defs/auto_headers.bzl
+++ b/shim/build_defs/auto_headers.bzl
@@ -1,0 +1,33 @@
+load("@prelude//utils:buckconfig.bzl", "read_choice")
+
+AutoHeaders = struct(
+    NONE = "none",
+    # Uses a recursive glob to resolve all transitive headers under the given
+    # directory.
+    RECURSIVE_GLOB = "recursive_glob",
+    # Infer headers from sources of the rule.
+    SOURCES = "sources",
+)
+
+_VALUES = [
+    AutoHeaders.NONE,
+    AutoHeaders.RECURSIVE_GLOB,
+    AutoHeaders.SOURCES,
+]
+
+def get_auto_headers(auto_headers):
+    """
+    Returns the level of auto-headers to apply to a rule.
+
+    Args:
+        auto_headers: One of the values in `AutoHeaders`
+
+    Returns:
+        The value passed in as auto_headers, or the value from configuration if
+        `auto_headers` is None
+    """
+    if auto_headers != None:
+        if auto_headers not in _VALUES:
+            fail("unexpected `auto_headers` value: {!r}".format(auto_headers))
+        return auto_headers
+    return read_choice("cxx", "auto_headers", _VALUES, AutoHeaders.SOURCES)

--- a/shim/build_defs/config.bzl
+++ b/shim/build_defs/config.bzl
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+def _get_build_mode():
+    return ""
+
+config = struct(
+    get_build_mode = _get_build_mode,
+)

--- a/shim/build_defs/cpp_benchmark.bzl
+++ b/shim/build_defs/cpp_benchmark.bzl
@@ -1,0 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+def cpp_benchmark(**_):
+    pass

--- a/shim/build_defs/cpp_binary.bzl
+++ b/shim/build_defs/cpp_binary.bzl
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+load("//:shims.bzl", _cpp_binary = "cpp_binary")
+
+cpp_binary = _cpp_binary

--- a/shim/build_defs/cpp_unittest.bzl
+++ b/shim/build_defs/cpp_unittest.bzl
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+load("//:shims.bzl", _cpp_unittest = "cpp_unittest")
+
+cpp_unittest = _cpp_unittest

--- a/shim/build_defs/custom_rule.bzl
+++ b/shim/build_defs/custom_rule.bzl
@@ -1,0 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+def custom_rule(**_):
+    pass

--- a/shim/build_defs/cython_library.bzl
+++ b/shim/build_defs/cython_library.bzl
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+load("//build_defs:python_library.bzl", "python_library")
+
+def cython_library(name, visibility = ["PUBLIC"], **_):
+    python_library(name = name, visibility = visibility)

--- a/shim/build_defs/export_files.bzl
+++ b/shim/build_defs/export_files.bzl
@@ -8,3 +8,8 @@
 def export_file(visibility = ["PUBLIC"], **kwargs):
     # @lint-ignore BUCKLINT: avoid "native is forbidden in fbcode"
     native.export_file(visibility = visibility, **kwargs)
+
+def export_files(files, visibility = ["PUBLIC"], **kwargs):
+    # @lint-ignore BUCKLINT: avoid "native is forbidden in fbcode"
+    for file in files:
+        native.export_file(name = file, visibility = visibility, **kwargs)

--- a/shim/build_defs/native_rules.bzl
+++ b/shim/build_defs/native_rules.bzl
@@ -20,3 +20,7 @@ def alias(actual, visibility = ["PUBLIC"], **kwargs):
     if actual.startswith("//buck2/"):
         actual = "root//" + actual.removeprefix("//buck2/")
     native.alias(actual = actual, visibility = visibility, **kwargs)
+
+def buck_sh_binary(visibility = ["PUBLIC"], **kwargs):
+    # @lint-ignore BUCKLINT: avoid "native is forbidden in fbcode"
+    native.sh_binary(visibility = visibility, **kwargs)

--- a/shim/build_defs/prebuilt_cpp_library.bzl
+++ b/shim/build_defs/prebuilt_cpp_library.bzl
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+load("//:shims.bzl", _prebuilt_cpp_library = "prebuilt_cpp_library")
+
+prebuilt_cpp_library = _prebuilt_cpp_library

--- a/shim/build_defs/python_library.bzl
+++ b/shim/build_defs/python_library.bzl
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+def python_library(srcs = [], visibility = ["PUBLIC"], **kwargs):
+    _unused = srcs  # @unused
+
+    # @lint-ignore BUCKLINT: avoid "Direct usage of native rules is not allowed."
+    native.python_library(visibility = visibility, **kwargs)

--- a/shim/build_defs/python_unittest.bzl
+++ b/shim/build_defs/python_unittest.bzl
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+def python_unittest(srcs = [], **kwargs):
+    _unused = srcs  # @unused
+
+    # @lint-ignore BUCKLINT: avoid "Direct usage of native rules is not allowed."
+    native.python_test(**kwargs)

--- a/shim/lib/dicts.bzl
+++ b/shim/lib/dicts.bzl
@@ -1,0 +1,41 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing functions that operate on dictionaries."""
+
+def _add(*dictionaries):
+    """Returns a new `dict` that has all the entries of the given dictionaries.
+
+    If the same key is present in more than one of the input dictionaries, the
+    last of them in the argument list overrides any earlier ones.
+
+    This function is designed to take zero or one arguments as well as multiple
+    dictionaries, so that it follows arithmetic identities and callers can avoid
+    special cases for their inputs: the sum of zero dictionaries is the empty
+    dictionary, and the sum of a single dictionary is a copy of itself.
+
+    Args:
+      *dictionaries: Zero or more dictionaries to be added.
+
+    Returns:
+      A new `dict` that has all the entries of the given dictionaries.
+    """
+    result = {}
+    for d in dictionaries:
+        result.update(d)
+    return result
+
+dicts = struct(
+    add = _add,
+)

--- a/shim/lib/new_sets.bzl
+++ b/shim/lib/new_sets.bzl
@@ -1,0 +1,236 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing common hash-set algorithms.
+
+  An empty set can be created using: `sets.make()`, or it can be created with some starting values
+  if you pass it an sequence: `sets.make([1, 2, 3])`. This returns a struct containing all of the
+  values as keys in a dictionary - this means that all passed in values must be hashable.  The
+  values in the set can be retrieved using `sets.to_list(my_set)`.
+"""
+
+load(":dicts.bzl", "dicts")
+
+def _make(elements = None):
+    """Creates a new set.
+
+    All elements must be hashable.
+
+    Args:
+      elements: Optional sequence to construct the set out of.
+
+    Returns:
+      A set containing the passed in values.
+    """
+    elements = elements if elements else []
+    return struct(_values = {e: None for e in elements})
+
+def _copy(s):
+    """Creates a new set from another set.
+
+    Args:
+      s: A set, as returned by `sets.make()`.
+
+    Returns:
+      A new set containing the same elements as `s`.
+    """
+    return struct(_values = dict(s._values))
+
+def _to_list(s):
+    """Creates a list from the values in the set.
+
+    Args:
+      s: A set, as returned by `sets.make()`.
+
+    Returns:
+      A list of values inserted into the set.
+    """
+    return list(s._values.keys())
+
+def _insert(s, e):
+    """Inserts an element into the set.
+
+    Element must be hashable.  This mutates the orginal set.
+
+    Args:
+      s: A set, as returned by `sets.make()`.
+      e: The element to be inserted.
+
+    Returns:
+       The set `s` with `e` included.
+    """
+    s._values[e] = None
+    return s
+
+def _remove(s, e):
+    """Removes an element from the set.
+
+    Element must be hashable.  This mutates the orginal set.
+
+    Args:
+      s: A set, as returned by `sets.make()`.
+      e: The element to be removed.
+
+    Returns:
+       The set `s` with `e` removed.
+    """
+    s._values.pop(e)
+    return s
+
+def _contains(a, e):
+    """Checks for the existence of an element in a set.
+
+    Args:
+      a: A set, as returned by `sets.make()`.
+      e: The element to look for.
+
+    Returns:
+      True if the element exists in the set, False if the element does not.
+    """
+    return e in a._values
+
+def _get_shorter_and_longer(a, b):
+    """Returns two sets in the order of shortest and longest.
+
+    Args:
+      a: A set, as returned by `sets.make()`.
+      b: A set, as returned by `sets.make()`.
+
+    Returns:
+      `a`, `b` if `a` is shorter than `b` - or `b`, `a` if `b` is shorter than `a`.
+    """
+    if _length(a) < _length(b):
+        return a, b
+    return b, a
+
+def _is_equal(a, b):
+    """Returns whether two sets are equal.
+
+    Args:
+      a: A set, as returned by `sets.make()`.
+      b: A set, as returned by `sets.make()`.
+
+    Returns:
+      True if `a` is equal to `b`, False otherwise.
+    """
+    return a._values == b._values
+
+def _is_subset(a, b):
+    """Returns whether `a` is a subset of `b`.
+
+    Args:
+      a: A set, as returned by `sets.make()`.
+      b: A set, as returned by `sets.make()`.
+
+    Returns:
+      True if `a` is a subset of `b`, False otherwise.
+    """
+    for e in a._values.keys():
+        if e not in b._values:
+            return False
+    return True
+
+def _disjoint(a, b):
+    """Returns whether two sets are disjoint.
+
+    Two sets are disjoint if they have no elements in common.
+
+    Args:
+      a: A set, as returned by `sets.make()`.
+      b: A set, as returned by `sets.make()`.
+
+    Returns:
+      True if `a` and `b` are disjoint, False otherwise.
+    """
+    shorter, longer = _get_shorter_and_longer(a, b)
+    for e in shorter._values.keys():
+        if e in longer._values:
+            return False
+    return True
+
+def _intersection(a, b):
+    """Returns the intersection of two sets.
+
+    Args:
+      a: A set, as returned by `sets.make()`.
+      b: A set, as returned by `sets.make()`.
+
+    Returns:
+      A set containing the elements that are in both `a` and `b`.
+    """
+    shorter, longer = _get_shorter_and_longer(a, b)
+    return struct(_values = {e: None for e in shorter._values.keys() if e in longer._values})
+
+def _union(*args):
+    """Returns the union of several sets.
+
+    Args:
+      *args: An arbitrary number of sets or lists.
+
+    Returns:
+      The set union of all sets or lists in `*args`.
+    """
+    return struct(_values = dicts.add(*[s._values for s in args]))
+
+def _difference(a, b):
+    """Returns the elements in `a` that are not in `b`.
+
+    Args:
+      a: A set, as returned by `sets.make()`.
+      b: A set, as returned by `sets.make()`.
+
+    Returns:
+      A set containing the elements that are in `a` but not in `b`.
+    """
+    return struct(_values = {e: None for e in a._values.keys() if e not in b._values})
+
+def _length(s):
+    """Returns the number of elements in a set.
+
+    Args:
+      s: A set, as returned by `sets.make()`.
+
+    Returns:
+      An integer representing the number of elements in the set.
+    """
+    return len(s._values)
+
+def _repr(s):
+    """Returns a string value representing the set.
+
+    Args:
+      s: A set, as returned by `sets.make()`.
+
+    Returns:
+      A string representing the set.
+    """
+    return repr(s._values.keys())
+
+sets = struct(
+    make = _make,
+    copy = _copy,
+    to_list = _to_list,
+    insert = _insert,
+    contains = _contains,
+    is_equal = _is_equal,
+    is_subset = _is_subset,
+    disjoint = _disjoint,
+    intersection = _intersection,
+    union = _union,
+    difference = _difference,
+    length = _length,
+    remove = _remove,
+    repr = _repr,
+    str = _repr,
+)

--- a/shim/lib/paths.bzl
+++ b/shim/lib/paths.bzl
@@ -1,0 +1,242 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing file path manipulation functions.
+
+NOTE: The functions in this module currently only support paths with Unix-style
+path separators (forward slash, "/"); they do not handle Windows-style paths
+with backslash separators or drive letters.
+"""
+
+def _basename(p):
+    """Returns the basename (i.e., the file portion) of a path.
+
+    Note that if `p` ends with a slash, this function returns an empty string.
+    This matches the behavior of Python's `os.path.basename`, but differs from
+    the Unix `basename` command (which would return the path segment preceding
+    the final slash).
+
+    Args:
+      p: The path whose basename should be returned.
+
+    Returns:
+      The basename of the path, which includes the extension.
+    """
+    return p.rpartition("/")[-1]
+
+def _dirname(p):
+    """Returns the dirname of a path.
+
+    The dirname is the portion of `p` up to but not including the file portion
+    (i.e., the basename). Any slashes immediately preceding the basename are not
+    included, unless omitting them would make the dirname empty.
+
+    Args:
+      p: The path whose dirname should be returned.
+
+    Returns:
+      The dirname of the path.
+    """
+    prefix, sep, _ = p.rpartition("/")
+    if not prefix:
+        return sep
+    else:
+        # If there are multiple consecutive slashes, strip them all out as Python's
+        # os.path.dirname does.
+        return prefix.rstrip("/")
+
+def _is_absolute(path):
+    """Returns `True` if `path` is an absolute path.
+
+    Args:
+      path: A path (which is a string).
+
+    Returns:
+      `True` if `path` is an absolute path.
+    """
+    return path.startswith("/") or (len(path) > 2 and path[1] == ":")
+
+def _join(path, *others):
+    """Joins one or more path components intelligently.
+
+    This function mimics the behavior of Python's `os.path.join` function on POSIX
+    platform. It returns the concatenation of `path` and any members of `others`,
+    inserting directory separators before each component except the first. The
+    separator is not inserted if the path up until that point is either empty or
+    already ends in a separator.
+
+    If any component is an absolute path, all previous components are discarded.
+
+    Args:
+      path: A path segment.
+      *others: Additional path segments.
+
+    Returns:
+      A string containing the joined paths.
+    """
+    result = path
+
+    for p in others:
+        if _is_absolute(p):
+            result = p
+        elif not result or result.endswith("/"):
+            result += p
+        else:
+            result += "/" + p
+
+    return result
+
+def _normalize(path):
+    """Normalizes a path, eliminating double slashes and other redundant segments.
+
+    This function mimics the behavior of Python's `os.path.normpath` function on
+    POSIX platforms; specifically:
+
+    - If the entire path is empty, "." is returned.
+    - All "." segments are removed, unless the path consists solely of a single
+      "." segment.
+    - Trailing slashes are removed, unless the path consists solely of slashes.
+    - ".." segments are removed as long as there are corresponding segments
+      earlier in the path to remove; otherwise, they are retained as leading ".."
+      segments.
+    - Single and double leading slashes are preserved, but three or more leading
+      slashes are collapsed into a single leading slash.
+    - Multiple adjacent internal slashes are collapsed into a single slash.
+
+    Args:
+      path: A path.
+
+    Returns:
+      The normalized path.
+    """
+    if not path:
+        return "."
+
+    if path.startswith("//") and not path.startswith("///"):
+        initial_slashes = 2
+    elif path.startswith("/"):
+        initial_slashes = 1
+    else:
+        initial_slashes = 0
+    is_relative = (initial_slashes == 0)
+
+    components = path.split("/")
+    new_components = []
+
+    for component in components:
+        if component in ("", "."):
+            continue
+        if component == "..":
+            if new_components and new_components[-1] != "..":
+                # Only pop the last segment if it isn't another "..".
+                new_components.pop()
+            elif is_relative:
+                # Preserve leading ".." segments for relative paths.
+                new_components.append(component)
+        else:
+            new_components.append(component)
+
+    path = "/".join(new_components)
+    if not is_relative:
+        path = ("/" * initial_slashes) + path
+
+    return path or "."
+
+def _relativize(path, start):
+    """Returns the portion of `path` that is relative to `start`.
+
+    Because we do not have access to the underlying file system, this
+    implementation differs slightly from Python's `os.path.relpath` in that it
+    will fail if `path` is not beneath `start` (rather than use parent segments to
+    walk up to the common file system root).
+
+    Relativizing paths that start with parent directory references only works if
+    the path both start with the same initial parent references.
+
+    Args:
+      path: The path to relativize.
+      start: The ancestor path against which to relativize.
+
+    Returns:
+      The portion of `path` that is relative to `start`.
+    """
+    segments = _normalize(path).split("/")
+    start_segments = _normalize(start).split("/")
+    if start_segments == ["."]:
+        start_segments = []
+    start_length = len(start_segments)
+
+    if (path.startswith("/") != start.startswith("/") or
+        len(segments) < start_length):
+        fail("Path '%s' is not beneath '%s'" % (path, start))
+
+    for ancestor_segment, segment in zip(start_segments, segments):
+        if ancestor_segment != segment:
+            fail("Path '%s' is not beneath '%s'" % (path, start))
+
+    length = len(segments) - start_length
+    result_segments = segments[-length:]
+    return "/".join(result_segments)
+
+def _replace_extension(p, new_extension):
+    """Replaces the extension of the file at the end of a path.
+
+    If the path has no extension, the new extension is added to it.
+
+    Args:
+      p: The path whose extension should be replaced.
+      new_extension: The new extension for the file. The new extension should
+          begin with a dot if you want the new filename to have one.
+
+    Returns:
+      The path with the extension replaced (or added, if it did not have one).
+    """
+    return _split_extension(p)[0] + new_extension
+
+def _split_extension(p):
+    """Splits the path `p` into a tuple containing the root and extension.
+
+    Leading periods on the basename are ignored, so
+    `path.split_extension(".bashrc")` returns `(".bashrc", "")`.
+
+    Args:
+      p: The path whose root and extension should be split.
+
+    Returns:
+      A tuple `(root, ext)` such that the root is the path without the file
+      extension, and `ext` is the file extension (which, if non-empty, contains
+      the leading dot). The returned tuple always satisfies the relationship
+      `root + ext == p`.
+    """
+    b = _basename(p)
+    last_dot_in_basename = b.rfind(".")
+
+    # If there is no dot or the only dot in the basename is at the front, then
+    # there is no extension.
+    if last_dot_in_basename <= 0:
+        return (p, "")
+
+    dot_distance_from_end = len(b) - last_dot_in_basename
+    return (p[:-dot_distance_from_end], p[-dot_distance_from_end:])
+
+paths = struct(
+    basename = _basename,
+    dirname = _dirname,
+    is_absolute = _is_absolute,
+    join = _join,
+    normalize = _normalize,
+    relativize = _relativize,
+    replace_extension = _replace_extension,
+    split_extension = _split_extension,
+)

--- a/shim/lib/shell.bzl
+++ b/shim/lib/shell.bzl
@@ -1,0 +1,63 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing shell utility functions."""
+
+def _array_literal(iterable):
+    """Creates a string from a sequence that can be used as a shell array.
+
+    For example, `shell.array_literal(["a", "b", "c"])` would return the string
+    `("a" "b" "c")`, which can be used in a shell script wherever an array
+    literal is needed.
+
+    Note that all elements in the array are quoted (using `shell.quote`) for
+    safety, even if they do not need to be.
+
+    Args:
+      iterable: A sequence of elements. Elements that are not strings will be
+          converted to strings first, by calling `str()`.
+
+    Returns:
+      A string that represents the sequence as a shell array; that is,
+      parentheses containing the quoted elements.
+    """
+    return "(" + " ".join([_quote(str(i)) for i in iterable]) + ")"
+
+def _quote(s):
+    """Quotes the given string for use in a shell command.
+
+    This function quotes the given string (in case it contains spaces or other
+    shell metacharacters.)
+
+    Args:
+      s: The string to quote.
+
+    Returns:
+      A quoted version of the string that can be passed to a shell command.
+    """
+    return "'" + s.replace("'", "'\\''") + "'"
+
+def _powershell_quote(s):
+    """Quoting multiline strings for Powershell.
+    References:
+     1. https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_special_characters?view=powershell-7.4
+     2. https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.4
+    """
+    return s.replace("`", "``").replace("\n", "`n").replace('"', '""').replace("$", "`$")
+
+shell = struct(
+    array_literal = _array_literal,
+    quote = _quote,
+    powershell_quote = _powershell_quote,
+)


### PR DESCRIPTION
Summary:
I found these by repeatedly running `dotslash-oss ./buck2 targets ...` in the GitHub version of folly.

(third-party changes are in the next diff, split for reviewability)

These changes are just hacks to convert fbcode's macro layer to the buck2 prelude with the minimal work possible.

Reviewed By: namanahuja

Differential Revision: D57383968


