### PR TITLE
[executorch] Make //executorch/backends/apple/mps:mps build internally

### DIFF
--- a/backends/apple/mps/targets.bzl
+++ b/backends/apple/mps/targets.bzl
@@ -56,11 +56,13 @@ def define_common_targets(is_xplat = False, platforms = []):
 
     if is_xplat:
         kwargs["fbobjc_frameworks"] = [
+            "Foundation",
             "Metal",
             "MetalPerformanceShaders",
             "MetalPerformanceShadersGraph",
         ]
         kwargs["fbobjc_ios_target_sdk_version"] = "17.0"
+        kwargs["fbobjc_macosx_target_sdk_version"] = "14.0"
         kwargs["platforms"] = platforms
 
     if runtime.is_oss or is_xplat:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3642
* __->__ #3641
* #3639

Was getting linker errors due to missing foundation framework, and need to deploy to recent macOS SDK.

Differential Revision: [D57456696](https://our.internmc.facebook.com/intern/diff/D57456696/)