### PR TITLE
Use c++17 for OSS gtest

### DIFF
--- a/extension/data_loader/test/CMakeLists.txt
+++ b/extension/data_loader/test/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 3.19)
 project(extension_data_loader_test)
 
-# Use C++14 for test.
-set(CMAKE_CXX_STANDARD 14)
+# Use C++17 for test.
+set(CMAKE_CXX_STANDARD 17)
 
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 

--- a/runtime/core/exec_aten/testing_util/test/CMakeLists.txt
+++ b/runtime/core/exec_aten/testing_util/test/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 3.19)
 project(runtime_core_exec_aten_testing_util_test)
 
-# Use C++14 for test.
-set(CMAKE_CXX_STANDARD 14)
+# Use C++17 for test.
+set(CMAKE_CXX_STANDARD 17)
 
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../../..)
 

--- a/runtime/core/exec_aten/util/test/CMakeLists.txt
+++ b/runtime/core/exec_aten/util/test/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 3.19)
 project(runtime_core_exec_aten_util_test)
 
-# Use C++14 for test.
-set(CMAKE_CXX_STANDARD 14)
+# Use C++17 for test.
+set(CMAKE_CXX_STANDARD 17)
 
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../../..)
 

--- a/runtime/core/portable_type/test/CMakeLists.txt
+++ b/runtime/core/portable_type/test/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 3.19)
 project(runtime_core_portable_type_test)
 
-# Use C++14 for test.
-set(CMAKE_CXX_STANDARD 14)
+# Use C++17 for test.
+set(CMAKE_CXX_STANDARD 17)
 
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../..)
 

--- a/runtime/core/test/CMakeLists.txt
+++ b/runtime/core/test/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 3.19)
 project(runtime_core_test)
 
-# Use C++14 for test.
-set(CMAKE_CXX_STANDARD 14)
+# Use C++17 for test.
+set(CMAKE_CXX_STANDARD 17)
 
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 

--- a/test/utils/OSSTest.cmake.in
+++ b/test/utils/OSSTest.cmake.in
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 3.19)
 project({project_name})
 
-# Use C++14 for test.
-set(CMAKE_CXX_STANDARD 14)
+# Use C++17 for test.
+set(CMAKE_CXX_STANDARD 17)
 
 set(EXECUTORCH_ROOT ${{CMAKE_CURRENT_SOURCE_DIR}}/{path_to_root})
 


### PR DESCRIPTION
Some test code uses c++17 feature (inline static member)

Test Plan: CI. `sh test/run_oss_cpp_tests.sh`