### PR TITLE
aten.hardshrink

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/hardshrink.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/hardshrink.glsl
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+
+#define PRECISION ${PRECISION}
+
+#define VEC4_T ${texel_type(DTYPE)}
+
+#include "indexing_utils.h"
+
+layout(std430) buffer;
+
+layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly ${IMAGE_T[NDIM][DTYPE]} image_out;
+layout(set = 0, binding = 1) uniform PRECISION sampler3D image_in;
+
+layout(set = 0, binding = 2) uniform PRECISION restrict OutLimits {
+  ivec3 out_limits;
+};
+
+layout(set = 0, binding = 3) uniform PRECISION restrict Lambd {
+  float lambd;
+};
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+    const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+    if (any(greaterThanEqual(pos, out_limits))) {
+        return;
+    }
+
+    VEC4_T in_texel = texelFetch(image_in, pos, 0);
+    VEC4_T mask = vec4(greaterThanEqual(in_texel, vec4(-lambd)))*vec4(lessThanEqual(in_texel, vec4(lambd)));
+    VEC4_T outval = (vec4(1.0) - mask)*in_texel;
+    imageStore(image_out, pos, outval);
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/hardshrink.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/hardshrink.yaml
@@ -1,0 +1,10 @@
+hardshrink:
+  parameter_names_with_default_values:
+    NDIM: 3
+    DTYPE: float
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: half
+      - VALUE: float
+  shader_variants:
+    - NAME: hardshrink

--- a/backends/vulkan/runtime/graph/ops/impl/Hardshrink.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Hardshrink.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/ScalarUtils.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+namespace vkcompute {
+
+void resize_hardshrink_node(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& extra_args) {
+  (void)extra_args;
+  vTensorPtr out = graph->get_tensor(args[0].refs[0]);
+  vTensorPtr self = graph->get_tensor(args[1].refs[0]);
+
+  out->virtual_resize(self->sizes());
+}
+
+void add_hardshrink_node(
+    ComputeGraph& graph,
+    const ValueRef in,
+    const ValueRef lambd,
+    const ValueRef out) {
+  float lambd_val = graph.extract_scalar<float>(lambd);
+  ValueRef arg = prepack_if_tensor_ref(graph, in);
+
+  vTensorPtr t_out = graph.get_tensor(out);
+  api::utils::uvec3 global_size = t_out->extents();
+  api::utils::uvec3 local_size = adaptive_work_group_size(global_size);
+
+  std::string kernel_name("hardshrink");
+  kernel_name.reserve(kShaderNameReserve);
+
+  add_dtype_suffix(kernel_name, *t_out);
+
+  graph.execute_nodes().emplace_back(new ExecuteNode(
+      graph,
+      VK_KERNEL_FROM_STR(kernel_name),
+      global_size,
+      local_size,
+      // Inputs and Outputs
+      {{out, api::MemoryAccessType::WRITE}, {arg, api::MemoryAccessType::READ}},
+      // Shader params buffers
+      {t_out->texture_limits_ubo(), graph.create_params_buffer(lambd_val)},
+      // Specialization Constants
+      {},
+      // Resizing Logic
+      resize_hardshrink_node));
+}
+
+void hardshrink(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  return add_hardshrink_node(graph, args[0], args[1], args[2]);
+}
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(aten.hardshrink.default, hardshrink);
+}
+
+} // namespace vkcompute

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -789,6 +789,7 @@ test_suites = {
     "aten.split_with_sizes_copy.default": get_split_with_sizes_inputs(),
     "aten.split.Tensor": get_split_tensor_inputs(),
     "aten.sqrt.default": get_unary_ops_inputs(),
+    "aten.hardshrink.default": get_unary_ops_inputs(),
     "aten._softmax.default": get_softmax_inputs(),
     "aten._log_softmax.default": get_softmax_inputs(),
     "aten._native_batch_norm_legit_no_training.default": get_native_batch_norm_inputs(),


### PR DESCRIPTION
Summary:
Implementing aten.hardshrink to start
```
func: hardshrink.out(Tensor self, Scalar lambd=0.5, *, Tensor(a!) out) -> Tensor(a!)
```

Differential Revision: D57500203


