### PR TITLE
Fix the naming for some of the eval wrappers

### DIFF
--- a/examples/models/llama2/eval_llama_lib.py
+++ b/examples/models/llama2/eval_llama_lib.py
@@ -31,7 +31,7 @@ from .export_llama_lib import (
 )
 
 
-class GPTFastEvalWrapper(eval_wrapper):
+class EagerEvalWrapper(eval_wrapper):
     """
     A wrapper class based on GPTFast, providing integration with the lm-evaluation-harness library.
     """
@@ -99,9 +99,9 @@ class GPTFastEvalWrapper(eval_wrapper):
         raise Exception("unimplemented")
 
 
-class ETEagerEvalWrapper(GPTFastEvalWrapper):
+class ETPybindEvalWrapper(EagerEvalWrapper):
     """
-    A wrapper class for ExecuTorch Eager integration with the
+    A wrapper class for ExecuTorch py-binded integration with the
     lm-evaluation-harness library.
     """
 
@@ -135,7 +135,7 @@ class ETEagerEvalWrapper(GPTFastEvalWrapper):
             return result[0]
 
 
-class ETRunnerEvalWrapper(GPTFastEvalWrapper):
+class ETRunnerEvalWrapper(EagerEvalWrapper):
     """
     A wrapper class for ExecuTorch Runtime integration with the
     lm-evaluation-harness library.
@@ -224,8 +224,8 @@ def gen_eval_wrapper(
                 max_seq_length=args.max_seq_length,
             )
 
-        # ETRunnerEvalWrapper: Create a wrapper around an ExecuTorch model, evaluated eagerly
-        return ETEagerEvalWrapper(
+        # ETPybindEvalWrapper: Create a wrapper around an ExecuTorch model, evaluated with pybindings
+        return ETPybindEvalWrapper(
             model=model,
             tokenizer=tokenizer,
             # Exported model takes at most (max_seq_length - 1) tokens.
@@ -240,7 +240,7 @@ def gen_eval_wrapper(
         if torch.cuda.is_available()
         else manager.model.to(device="cpu")
     )
-    return GPTFastEvalWrapper(
+    return EagerEvalWrapper(
         model=model,
         tokenizer=tokenizer,
         max_seq_length=args.max_seq_length,


### PR DESCRIPTION
Summary:
Harmless naming and comment fixes in eval_llama_lib:
* `GPTFastEvalWrapper` => `EagerEvalWrapper`
* `ETEagerEvalWrapper` => `ETPybindEvalWrapper`

Note: Also fixed a comment that used the wrong wrapper name

Differential Revision: D57516150


