### PR TITLE
Improve cmake testing setup

### DIFF
--- a/build/Test.cmake
+++ b/build/Test.cmake
@@ -17,11 +17,26 @@
 # It should also be cmake-lint clean.
 #
 
+# A helper function to generate a gtest cxx executable target
+# @param target_name: name for the executable
+# @param SOURCES <list_of_sources>: test sources to be compiled. Sometimes
+# util sources are used as well
+# @param EXTRA LIBS <list_of_libs>: additional libraries to be linked against
+# the target. gtest, gmock, executorch are linked by default, but Sometimes
+# user may need additional libraries like kernels.
+# We use CMake package executorch in this helper, so user can easily add
+# installed libraries.
+#
+# Example:
+# et_cxx_test(my_test SOURCES my_test.cpp EXTRA_LIBS portable_kernels)
+#
+# This defines a gtest executable my_test, compiling my_test.cpp, and linking
+# against libportable_kernels.a.
+#
 function(et_cxx_test target_name)
+
 set(multi_arg_names SOURCES EXTRA_LIBS)
 cmake_parse_arguments(ET_CXX_TEST "" "" "${multi_arg_names}" ${ARGN})
-
-message(${ET_CXX_TEST_SOURCES})
 
 # Find prebuilt executorch library
 find_package(executorch CONFIG REQUIRED)
@@ -30,8 +45,7 @@ enable_testing()
 find_package(GTest CONFIG REQUIRED)
 
 # Let files say "include <executorch/path/to/header.h>".
-set(_common_include_directories ${EXECUTORCH_ROOT}/..)
-target_include_directories(executorch INTERFACE ${_common_include_directories})
+target_include_directories(executorch INTERFACE ${EXECUTORCH_ROOT}/..)
 
 add_executable(${target_name} ${ET_CXX_TEST_SOURCES})
 # Includes gtest, gmock, executorch by default
@@ -39,6 +53,11 @@ target_link_libraries(
   ${target_name} GTest::gtest GTest::gtest_main GTest::gmock executorch
   ${ET_CXX_TEST_EXTRA_LIBS}
 )
+
+# add_test adds a test target to be used by ctest.
+# We use `ExecuTorchTest` as the ctest target name for the test executable
+# Usage: cd cmake-out/path/to/test/; ctest
+# Note: currently we directly invoke the test target, without using ctest
 add_test(ExecuTorchTest ${target_name})
 
 endfunction()

--- a/build/Test.cmake
+++ b/build/Test.cmake
@@ -1,0 +1,44 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# This file is intended to have helper functions for test-related
+# CMakeLists.txt files.
+#
+# ### Editing this file ###
+#
+# This file should be formatted with
+# ~~~
+# cmake-format -i Utils.cmake
+# ~~~
+# It should also be cmake-lint clean.
+#
+
+function(et_cxx_test target_name)
+set(multi_arg_names SOURCES EXTRA_LIBS)
+cmake_parse_arguments(ET_CXX_TEST "" "" "${multi_arg_names}" ${ARGN})
+
+message(${ET_CXX_TEST_SOURCES})
+
+# Find prebuilt executorch library
+find_package(executorch CONFIG REQUIRED)
+
+enable_testing()
+find_package(GTest CONFIG REQUIRED)
+
+# Let files say "include <executorch/path/to/header.h>".
+set(_common_include_directories ${EXECUTORCH_ROOT}/..)
+target_include_directories(executorch INTERFACE ${_common_include_directories})
+
+add_executable(${target_name} ${ET_CXX_TEST_SOURCES})
+# Includes gtest, gmock, executorch by default
+target_link_libraries(
+  ${target_name} GTest::gtest GTest::gtest_main GTest::gmock executorch
+  ${ET_CXX_TEST_EXTRA_LIBS}
+)
+add_test(ExecuTorchTest ${target_name})
+
+endfunction()

--- a/extension/data_loader/test/CMakeLists.txt
+++ b/extension/data_loader/test/CMakeLists.txt
@@ -21,25 +21,14 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
+include(${EXECUTORCH_ROOT}/build/Test.cmake)
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
-
-# Find prebuilt executorch library
-find_package(executorch CONFIG REQUIRED)
-
-enable_testing()
-find_package(GTest CONFIG REQUIRED)
-
-# Let files say "include <executorch/path/to/header.h>".
-set(_common_include_directories ${EXECUTORCH_ROOT}/..)
-target_include_directories(executorch INTERFACE ${_common_include_directories})
 
 set(_test_srcs buffer_data_loader_test.cpp shared_ptr_data_loader_test.cpp
                file_data_loader_test.cpp mmap_data_loader_test.cpp
 )
 
-add_executable(extension_data_loader_test ${_test_srcs})
-target_link_libraries(
-  extension_data_loader_test GTest::gtest GTest::gtest_main GTest::gmock
-  executorch extension_data_loader
+et_cxx_test(
+  extension_data_loader_test SOURCES ${_test_srcs} EXTRA_LIBS
+  extension_data_loader
 )
-add_test(ExecuTorchTest extension_data_loader_test)

--- a/extension/data_loader/test/CMakeLists.txt
+++ b/extension/data_loader/test/CMakeLists.txt
@@ -22,7 +22,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
 include(${EXECUTORCH_ROOT}/build/Test.cmake)
-include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 
 set(_test_srcs buffer_data_loader_test.cpp shared_ptr_data_loader_test.cpp
                file_data_loader_test.cpp mmap_data_loader_test.cpp

--- a/runtime/core/exec_aten/testing_util/test/CMakeLists.txt
+++ b/runtime/core/exec_aten/testing_util/test/CMakeLists.txt
@@ -22,7 +22,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../../..)
 
 include(${EXECUTORCH_ROOT}/build/Test.cmake)
-include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 
 set(_test_srcs tensor_util_test.cpp tensor_factory_test.cpp ../tensor_util.cpp)
 

--- a/runtime/core/exec_aten/testing_util/test/CMakeLists.txt
+++ b/runtime/core/exec_aten/testing_util/test/CMakeLists.txt
@@ -21,23 +21,11 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../../..)
 
+include(${EXECUTORCH_ROOT}/build/Test.cmake)
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
-
-# Find prebuilt executorch library
-find_package(executorch CONFIG REQUIRED)
-
-enable_testing()
-find_package(GTest CONFIG REQUIRED)
-
-# Let files say "include <executorch/path/to/header.h>".
-set(_common_include_directories ${EXECUTORCH_ROOT}/..)
-target_include_directories(executorch INTERFACE ${_common_include_directories})
 
 set(_test_srcs tensor_util_test.cpp tensor_factory_test.cpp ../tensor_util.cpp)
 
-add_executable(runtime_core_exec_aten_testing_util_test ${_test_srcs})
-target_link_libraries(
-  runtime_core_exec_aten_testing_util_test GTest::gtest GTest::gtest_main
-  GTest::gmock executorch
+et_cxx_test(
+  runtime_core_exec_aten_testing_util_test SOURCES ${_test_srcs} EXTRA_LIBS
 )
-add_test(ExecuTorchTest runtime_core_exec_aten_testing_util_test)

--- a/runtime/core/exec_aten/util/test/CMakeLists.txt
+++ b/runtime/core/exec_aten/util/test/CMakeLists.txt
@@ -21,17 +21,8 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../../..)
 
+include(${EXECUTORCH_ROOT}/build/Test.cmake)
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
-
-# Find prebuilt executorch library
-find_package(executorch CONFIG REQUIRED)
-
-enable_testing()
-find_package(GTest CONFIG REQUIRED)
-
-# Let files say "include <executorch/path/to/header.h>".
-set(_common_include_directories ${EXECUTORCH_ROOT}/..)
-target_include_directories(executorch INTERFACE ${_common_include_directories})
 
 set(_test_srcs
     tensor_util_test.cpp scalar_type_util_test.cpp
@@ -39,9 +30,4 @@ set(_test_srcs
     ../../testing_util/tensor_util.cpp
 )
 
-add_executable(runtime_core_exec_aten_util_test ${_test_srcs})
-target_link_libraries(
-  runtime_core_exec_aten_util_test GTest::gtest GTest::gtest_main GTest::gmock
-  executorch
-)
-add_test(ExecuTorchTest runtime_core_exec_aten_util_test)
+et_cxx_test(runtime_core_exec_aten_util_test SOURCES ${_test_srcs} EXTRA_LIBS)

--- a/runtime/core/exec_aten/util/test/CMakeLists.txt
+++ b/runtime/core/exec_aten/util/test/CMakeLists.txt
@@ -22,7 +22,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../../..)
 
 include(${EXECUTORCH_ROOT}/build/Test.cmake)
-include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 
 set(_test_srcs
     tensor_util_test.cpp scalar_type_util_test.cpp

--- a/runtime/core/portable_type/test/CMakeLists.txt
+++ b/runtime/core/portable_type/test/CMakeLists.txt
@@ -22,7 +22,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../..)
 
 include(${EXECUTORCH_ROOT}/build/Test.cmake)
-include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 
 set(_test_srcs optional_test.cpp executor_tensor_test.cpp half_test.cpp
                scalar_test.cpp tensor_impl_test.cpp

--- a/runtime/core/portable_type/test/CMakeLists.txt
+++ b/runtime/core/portable_type/test/CMakeLists.txt
@@ -21,25 +21,11 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../..)
 
+include(${EXECUTORCH_ROOT}/build/Test.cmake)
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
-
-# Find prebuilt executorch library
-find_package(executorch CONFIG REQUIRED)
-
-enable_testing()
-find_package(GTest CONFIG REQUIRED)
-
-# Let files say "include <executorch/path/to/header.h>".
-set(_common_include_directories ${EXECUTORCH_ROOT}/..)
-target_include_directories(executorch INTERFACE ${_common_include_directories})
 
 set(_test_srcs optional_test.cpp executor_tensor_test.cpp half_test.cpp
                scalar_test.cpp tensor_impl_test.cpp
 )
 
-add_executable(runtime_core_portable_type_test ${_test_srcs})
-target_link_libraries(
-  runtime_core_portable_type_test GTest::gtest GTest::gtest_main GTest::gmock
-  executorch
-)
-add_test(ExecuTorchTest runtime_core_portable_type_test)
+et_cxx_test(runtime_core_portable_type_test SOURCES ${_test_srcs} EXTRA_LIBS)

--- a/runtime/core/test/CMakeLists.txt
+++ b/runtime/core/test/CMakeLists.txt
@@ -21,17 +21,8 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
+include(${EXECUTORCH_ROOT}/build/Test.cmake)
 include(${EXECUTORCH_ROOT}/build/Utils.cmake)
-
-# Find prebuilt executorch library
-find_package(executorch CONFIG REQUIRED)
-
-enable_testing()
-find_package(GTest CONFIG REQUIRED)
-
-# Let files say "include <executorch/path/to/header.h>".
-set(_common_include_directories ${EXECUTORCH_ROOT}/..)
-target_include_directories(executorch INTERFACE ${_common_include_directories})
 
 set(_test_srcs
     span_test.cpp
@@ -44,8 +35,4 @@ set(_test_srcs
     evalue_test.cpp
 )
 
-add_executable(runtime_core_test ${_test_srcs})
-target_link_libraries(
-  runtime_core_test GTest::gtest GTest::gtest_main GTest::gmock executorch
-)
-add_test(ExecuTorchTest runtime_core_test)
+et_cxx_test(runtime_core_test SOURCES ${_test_srcs} EXTRA_LIBS)

--- a/runtime/core/test/CMakeLists.txt
+++ b/runtime/core/test/CMakeLists.txt
@@ -22,7 +22,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
 include(${EXECUTORCH_ROOT}/build/Test.cmake)
-include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 
 set(_test_srcs
     span_test.cpp

--- a/test/run_oss_cpp_tests.sh
+++ b/test/run_oss_cpp_tests.sh
@@ -24,6 +24,8 @@ build_and_run_test() {
 }
 
 probe_tests() {
+  # This function finds the set of directories that contain C++ tests
+  # CMakeLists.txt rules, that are buildable using build_and_run_test
   dirs=(
     backends
     examples
@@ -41,9 +43,11 @@ probe_tests() {
       | sort -u
 }
 
-probe_tests
-
 build_executorch
+
+echo "Found test directories:"
+echo "$(probe_tests)"
+
 for test_dir in $(probe_tests); do
   build_and_run_test $test_dir
 done

--- a/test/run_oss_cpp_tests.sh
+++ b/test/run_oss_cpp_tests.sh
@@ -5,6 +5,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# This script helps build and run C++ tests with CMakeLists.txt.
+# It builds and installs the root ExecuTorch package, and then sub-directories.
+#
+# If no arg is given, it probes all sub-directories containing
+# test/CMakeLists.txt. It builds and runs these tests.
+# If an arg is given, like `runtime/core/test/`, it runs that directory only.
+
 set -ex
 
 build_executorch() {
@@ -47,11 +54,11 @@ build_executorch
 
 if [ -z "$1" ]; then
   echo "Running all directories:"
-  echo "$(probe_tests)"
+  probe_tests
 
   for test_dir in $(probe_tests); do
-    build_and_run_test $test_dir
+    build_and_run_test "${test_dir}"
   done
 else
-  build_and_run_test $1
+  build_and_run_test "$1"
 fi

--- a/test/run_oss_cpp_tests.sh
+++ b/test/run_oss_cpp_tests.sh
@@ -23,9 +23,27 @@ build_and_run_test() {
   for t in cmake-out/"${test_dir}"/*test; do ./"$t"; done
 }
 
+probe_tests() {
+  dirs=(
+    backends
+    examples
+    extension
+    kernels
+    runtime
+    schema
+    sdk
+    test
+  )
+
+  find "${dirs[@]}" \
+      \( -type f -wholename '*/test/CMakeLists.txt' -exec dirname {} \; \) -o \
+      \( -type d -path '*/third-party/*' -prune \) \
+      | sort -u
+}
+
+probe_tests
+
 build_executorch
-build_and_run_test extension/data_loader/test/
-build_and_run_test runtime/core/portable_type/test/
-build_and_run_test runtime/core/test/
-build_and_run_test runtime/core/exec_aten/util/test/
-build_and_run_test runtime/core/exec_aten/testing_util/test/
+for test_dir in $(probe_tests); do
+  build_and_run_test $test_dir
+done

--- a/test/run_oss_cpp_tests.sh
+++ b/test/run_oss_cpp_tests.sh
@@ -45,9 +45,13 @@ probe_tests() {
 
 build_executorch
 
-echo "Found test directories:"
-echo "$(probe_tests)"
+if [ -z "$1" ]; then
+  echo "Running all directories:"
+  echo "$(probe_tests)"
 
-for test_dir in $(probe_tests); do
-  build_and_run_test $test_dir
-done
+  for test_dir in $(probe_tests); do
+    build_and_run_test $test_dir
+  done
+else
+  build_and_run_test $1
+fi

--- a/test/utils/OSSTest.cmake.in
+++ b/test/utils/OSSTest.cmake.in
@@ -21,25 +21,10 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(EXECUTORCH_ROOT ${{CMAKE_CURRENT_SOURCE_DIR}}/{path_to_root})
 
+include(${{EXECUTORCH_ROOT}}/build/Test.cmake)
 include(${{EXECUTORCH_ROOT}}/build/Utils.cmake)
 
-# Find prebuilt executorch library
-find_package(executorch CONFIG REQUIRED)
-
-enable_testing()
-find_package(GTest CONFIG REQUIRED)
-
-# Let files say "include <executorch/path/to/header.h>".
-set(_common_include_directories
-    ${{EXECUTORCH_ROOT}}/..
+set(_test_srcs {test_srcs}
 )
-target_include_directories(executorch INTERFACE ${{_common_include_directories}})
 
-set(_test_srcs {test_srcs})
-
-add_executable({project_name} ${{_test_srcs}})
-target_link_libraries(
-  {project_name} GTest::gtest GTest::gtest_main GTest::gmock executorch
-  {additional_libs}
-)
-add_test(ExecuTorchTest {project_name})
+et_cxx_test({project_name} SOURCES ${{_test_srcs}} EXTRA_LIBS {additional_libs})

--- a/test/utils/OSSTest.cmake.in
+++ b/test/utils/OSSTest.cmake.in
@@ -22,9 +22,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(EXECUTORCH_ROOT ${{CMAKE_CURRENT_SOURCE_DIR}}/{path_to_root})
 
 include(${{EXECUTORCH_ROOT}}/build/Test.cmake)
-include(${{EXECUTORCH_ROOT}}/build/Utils.cmake)
 
-set(_test_srcs {test_srcs}
-)
+set(_test_srcs {test_srcs})
 
 et_cxx_test({project_name} SOURCES ${{_test_srcs}} EXTRA_LIBS {additional_libs})


### PR DESCRIPTION
* Add build/Test.cmake and provide helper function for users to add tests targets 
Example: 
```
et_cxx_test(my_test SOURCES my_test.cpp EXTRA_LIBS portable_kernels)
```
User need to invoke et_cxx_test and add their srcs/deps. Note: gtest, gmock, executorch are added to deps by default.
* Update existign CMakeLists.txt and template test/utils/OSSTest.cmake.in for that
* In test/run_oss_cpp_tests.sh, probe tests so user don't need to add them manually We will utilize add_test from cmake later

Test Plan: `sh test/run_oss_cpp_tests.sh`