### PR TITLE
Add ETDumpGen_Done state and reset when in that state

### DIFF
--- a/sdk/etdump/etdump_flatcc.h
+++ b/sdk/etdump/etdump_flatcc.h
@@ -25,6 +25,7 @@ enum ETDumpGen_State {
   ETDumpGen_Block_Created,
   ETDumpGen_Adding_Allocators,
   ETDumpGen_Adding_Events,
+  ETDumpGen_Done,
 };
 
 struct etdump_result {
@@ -100,6 +101,7 @@ class ETDumpGen : public EventTracer {
   etdump_result get_etdump_data();
   size_t get_num_blocks();
   bool is_static_etdump();
+  void reset();
 
  private:
   struct flatcc_builder* builder;


### PR DESCRIPTION
Summary:
Currently when we call `get_etdump_data()` we finalize the flatbuffer and close it. In order to add entries to etdump once again after we've closed it we need to reset the etdump buffer.

In order to support this, adding a `ETDumpGen_Done` state to which we move after calling `get_etdump_data()`. When this state is detected in `create_event_block` we implicitly call `reset()` and thus enabling writing to the flatbuffer again without any user intervention.

Differential Revision: D57517927


