### PR TITLE
migrate from capture_pre_autograd_graph to export(pre_dispatch=True)

### DIFF
--- a/examples/models/llama2/builder.py
+++ b/examples/models/llama2/builder.py
@@ -271,9 +271,12 @@ class LlamaEdgeManager:
         # 2. torch.no_grad() is for getting rid of the dropout (not sure why training ops will show up)
         if quantizers:
             with torch.nn.attention.sdpa_kernel([SDPBackend.MATH]), torch.no_grad():
-                m = capture_pre_autograd_graph(
-                    self.model, self.example_inputs, dynamic_shapes=dynamic_shape
-                )
+                m = torch.export._trace._export(
+                    self.model,
+                    self.example_inputs,
+                    dynamic_shapes=dynamic_shape,
+                    pre_dispatch=True,
+                ).module()
                 if self.verbose:
                     logging.info(f"Applied quantizers: {quantizers}")
                 composed_quantizer = ComposableQuantizer(quantizers)

--- a/examples/portable/utils.py
+++ b/examples/portable/utils.py
@@ -37,7 +37,9 @@ def _to_core_aten(
         raise ValueError(
             f"Expected passed in model to be an instance of fx.GraphModule, got {type(model)}"
         )
-    core_aten_ep = export(model, example_inputs, dynamic_shapes=dynamic_shapes)
+    core_aten_ep = torch.export._trace._export(
+        model, example_inputs, dynamic_shapes=dynamic_shapes, pre_dispatch=True
+    )
     if verbose:
         logging.info(f"Core ATen graph:\n{core_aten_ep.graph}")
     return core_aten_ep


### PR DESCRIPTION
Summary: As title, move to the llama example to the new export flow

Differential Revision: D57530660


