### PR TITLE
Arm: Enable MobileNetV2 MI unittest

### DIFF
--- a/backends/arm/operators/op_conv2d.py
+++ b/backends/arm/operators/op_conv2d.py
@@ -110,14 +110,14 @@ class Conv2dVisitor(NodeVisitor):
             conv2d_res = tosa_graph.addIntermediate(output.shape, ts.DType.INT32)
             conv2d_output_name = conv2d_res.name
 
-        if group.number > 1:
+        # Given input.shape is (N, Ci, H, W), and weight.shape is (Co, Ci/G, H, W)
+        in_channels = input.shape[1]
+        out_channels = weight.shape[0]
+        if (in_channels == group.number) and (out_channels % in_channels) == 0:
             """Depthwise convolution case"""
-            # Given input.shape is (N, Ci, H, W), and weight.shape is (Co, Ci/G, H, W)
-            in_channels = input.shape[1]
-            out_channels = weight.shape[0]
             # Reshape torch shape format of weight tensor to tosa required format.
             # https://www.mlplatform.org/tosa/tosa_spec.html#_depthwise_conv2d
-            m_length = int(round(out_channels / in_channels))
+            m_length = int(out_channels / in_channels)
             weight_post_shape = (
                 weight.shape[2],
                 weight.shape[3],

--- a/backends/arm/test/models/test_mobilenet_v2_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v2_arm.py
@@ -46,9 +46,8 @@ class TestMobileNetV2(unittest.TestCase):
         _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.
     )
 
-    @unittest.skip("This test is not supported yet")
     def test_mv2_tosa_MI(self):
-        (
+        tester = (
             ArmTester(
                 self.mv2,
                 inputs=self.model_inputs,
@@ -60,6 +59,12 @@ class TestMobileNetV2(unittest.TestCase):
             .partition()
             .to_executorch()
         )
+        if common.TOSA_REF_MODEL_INSTALLED:
+            tester.run_method_and_compare_outputs()
+        else:
+            logger.warning(
+                "TOSA ref model tool not installed, skip numerical correctness tests"
+            )
 
     def test_mv2_tosa_BI(self):
         tester = (

--- a/backends/arm/tosa_utils.py
+++ b/backends/arm/tosa_utils.py
@@ -183,7 +183,9 @@ def is_consumer_node_depthwise_conv2d(node):
         for arg in consumer_node.args:
             inputs.append(TosaArg(arg))
         group = inputs[-1]
-        if group.number > 1:
+        in_channels = inputs[0].shape[1]
+        out_channels = inputs[1].shape[0]
+        if (in_channels == group.number) and (out_channels % in_channels) == 0:
             return True
 
     return False


### PR DESCRIPTION
- Enable MV2 MI unittest.
- Rewrite condition for depthwise convolution.