### PR TITLE
add clamp op int variant

### DIFF
--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -50,6 +50,10 @@ class VulkanSupportedOperators(OperatorSupportBase):
             if len(node_val.shape) > 4:
                 return False
 
+            # bool dtype not currently supported
+            if node_val.dtype == torch.bool:
+                return False
+
         if isinstance(node_val, (list, tuple)):
             for item in node_val:
                 if not self.node_val_is_compatible(item):

--- a/backends/vulkan/runtime/graph/ops/glsl/unary_op.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/unary_op.glsl
@@ -19,7 +19,7 @@
 layout(std430) buffer;
 
 layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly ${IMAGE_T[NDIM][DTYPE]} image_out;
-layout(set = 0, binding = 1) uniform PRECISION sampler3D image_in;
+layout(set = 0, binding = 1) uniform PRECISION ${SAMPLER_T[NDIM][DTYPE]} image_in;
 
 layout(set = 0, binding = 2) uniform PRECISION restrict OutLimits {
   ivec3 out_limits;

--- a/backends/vulkan/runtime/graph/ops/glsl/unary_op.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/unary_op.yaml
@@ -12,6 +12,9 @@ unary_op:
       OPERATOR: abs(X)
     - NAME: clamp
       OPERATOR: clamp(X, A, B)
+    - NAME: clamp_int
+      OPERATOR: VEC4_T(clamp(X, A, B))
+      DTYPE: int
     - NAME: exp
       OPERATOR: exp(X)
     - NAME: gelu

--- a/backends/vulkan/runtime/graph/ops/impl/UnaryOp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/UnaryOp.cpp
@@ -83,7 +83,7 @@ float get_val_or_inf(ComputeGraph& graph, const ValueRef& val, bool max) {
     return add_unary_op_node(                                            \
         graph,                                                           \
         args[0],                                                         \
-        get_val_or_inf(graph, args[1], /*max = */ false),                \
+        get_val_or_inf(graph, args[1], /*min = */ false),                \
         get_val_or_inf(graph, args[2], /*max = */ true),                 \
         args[3],                                                         \
         kClampShaderName);                                               \

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -379,6 +379,20 @@ class TestBackends(unittest.TestCase):
 
         self.lower_unary_module_and_test_output(ClampModule())
 
+    def test_vulkan_backend_clamp_int(self):
+        class ClampModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.clamp(x, min=-3)
+
+        sample_inputs = (
+            torch.randint(low=-100, high=100, size=(5, 5), dtype=torch.int32),
+        )
+
+        self.lower_module_and_test_output(ClampModule(), sample_inputs)
+
     def test_vulkan_backend_hardtanh(self):
         class HardTanHModule(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
Summary:
Adding int variant of clamp.

Adding as a separate op to specify int only for clamp, as int variant for some other ops don't make sense

Differential Revision: D57514823


