### PR TITLE
let coreml leverage all backends

### DIFF
--- a/examples/models/llama2/lib/partitioner_lib.py
+++ b/examples/models/llama2/lib/partitioner_lib.py
@@ -72,7 +72,7 @@ def get_coreml_partitioner(args):
     compile_specs = CoreMLBackend.generate_compile_specs(
         compute_precision=ct.precision(ct.precision.FLOAT16.value),
         # using `ComputeUnit.ALL` can increase the model load time, default to `ComputeUnit.CPU_AND_GPU`
-        compute_unit=ct.ComputeUnit[ct.ComputeUnit.CPU_AND_GPU.name.upper()],
+        compute_unit=ct.ComputeUnit[ct.ComputeUnit.ALL.name.upper()],
         model_type=CoreMLBackend.MODEL_TYPE.MODEL,
     )
     return CoreMLPartitioner(


### PR DESCRIPTION
Summary:
coreml tools have 4 options for the [`ComputeUnit`](https://github.com/apple/coremltools/blob/9883e8d60aea3e7feeeec005c9a883576f6ce2eb/coremltools/__init__.py#L68-L77)

```
class ComputeUnit(_Enum):
    '''
    The set of processing-unit configurations the model can use to make predictions.
    '''
    ALL = 1  # Allows the model to use all compute units available, including the neural engine
    CPU_AND_GPU = 2 # Allows the model to use both the CPU and GPU, but not the neural engine
    CPU_ONLY = 3 # Limit the model to only use the CPU
    CPU_AND_NE = 4 # Allows the model to use both the CPU and neural engine, but not the GPU.
                   # Only available on macOS >= 13.0
```
target to ALL so we can use ANE

Differential Revision: D57575739


