### PR TITLE
Use quantize_and_export_to_jarvis in more places

### DIFF
--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -18,7 +18,6 @@ from torch.export.exported_program import ExportedProgram
 def export_program(
     model: torch.nn.Module,
     inputs: Any,
-    pt2_quant: bool = False,
 ) -> ExportedProgram:
     # We don't support training mode. Make it eval
     if hasattr(model, "eval"):

--- a/backends/cadence/aot/export_example.py
+++ b/backends/cadence/aot/export_example.py
@@ -69,9 +69,7 @@ def export_model(
     QuantFusion(patterns)(converted_model)
 
     # Get edge program (note: the name will change to export_to_cadence in future PRs)
-    edge_prog_manager, expo_prog = export_to_edge(
-        converted_model, example_inputs, pt2_quant=True
-    )
+    edge_prog_manager, expo_prog = export_to_edge(converted_model, example_inputs)
 
     # Run a couple required passes for quant/dequant ops
     cadence_prog_manager = edge_prog_manager.transform(


### PR DESCRIPTION
Summary: As titled. It cleans up a lot of tests, is easier to read and encapsulates things better.

Differential Revision: D57554527
