### PR TITLE
Update the existing extra data ARN when running Android test on devices

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -115,4 +115,5 @@ jobs:
       test-spec: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/abd86868-fa63-467e-a5c7-218194665a77
       # The exported llama2 model and its tokenizer, can be downloaded from https://ossci-assets.s3.amazonaws.com/executorch-android-llama2-7b.zip.
       # Among the input, this is the biggest file and uploading it to AWS beforehand makes the test run much faster
-      extra-data: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/bd15825b-ddab-4e47-9fef-a9c8935778dd
+      extra-data: https://ossci-assets.s3.amazonaws.com/executorch-android-llama2-7b.zip
+      # arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/bd15825b-ddab-4e47-9fef-a9c8935778dd

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -115,5 +115,4 @@ jobs:
       test-spec: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/abd86868-fa63-467e-a5c7-218194665a77
       # The exported llama2 model and its tokenizer, can be downloaded from https://ossci-assets.s3.amazonaws.com/executorch-android-llama2-7b.zip.
       # Among the input, this is the biggest file and uploading it to AWS beforehand makes the test run much faster
-      extra-data: https://ossci-assets.s3.amazonaws.com/executorch-android-llama2-7b.zip
-      # arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/bd15825b-ddab-4e47-9fef-a9c8935778dd
+      extra-data: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/30168984-65d3-4637-a54d-908649e70141


### PR DESCRIPTION
The previous resource was deleted on AWS somehow, I need to follow up with AWS support on why it was deleted.  But here is the quick fix using a new ARN uploaded from S3.