### PR TITLE
add handling of out-of-range indices to Slice

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/Slice.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Slice.cpp
@@ -17,6 +17,20 @@
 
 namespace vkcompute {
 
+inline int64_t normalize_idx(
+    const int64_t index,
+    const int64_t max,
+    const int64_t default_value) {
+  // INT64_MAX is passed when value is unspecified
+  if (index == INT64_MAX) {
+    return default_value;
+  }
+  if (index == default_value) {
+    return index;
+  }
+  return normalize(index, max);
+}
+
 void add_slice_tensor_out_node(
     ComputeGraph& graph,
     ValueRef in,
@@ -57,8 +71,8 @@ void add_slice_tensor_out_node(
   int64_t start = opt_start.value_or(0);
   int64_t end = opt_end.value_or(in_sizes[dim]);
 
-  VK_CHECK_COND((0 <= start) && (start < in_sizes[dim]));
-  VK_CHECK_COND((0 <= end) && (end <= in_sizes[dim]));
+  start = normalize_idx(start, in_sizes[dim], 0);
+  end = normalize_idx(end, in_sizes[dim], in_sizes[dim]);
 
   if (dim_index == kChannel4D) {
     // slice by channel

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -392,6 +392,23 @@ def get_slice_inputs():
         Test(self=[13, 1, 10], dim=0, start=1, step=20),
     ]
 
+    # Slice by negative/unspecified indices
+    INT64_MAX = 9223372036854775807  # represents arr[:]
+    test_cases += [
+        Test(self=[8, 9], dim=0, start=-2, step=1),
+        Test(self=[8, 9], dim=0, start=-2, step=2),
+        Test(self=[8, 9], dim=0, end=-2, step=1),
+        Test(self=[8, 9], dim=0, end=-2, step=2),
+        Test(self=[8, 9], dim=0, end=INT64_MAX, step=1),
+        Test(self=[8, 9], dim=0, end=INT64_MAX, step=2),
+        Test(self=[8, 9], dim=1, start=-2, step=1),
+        Test(self=[8, 9], dim=1, start=-2, step=2),
+        Test(self=[8, 9], dim=1, end=-2, step=1),
+        Test(self=[8, 9], dim=1, end=-2, step=2),
+        Test(self=[8, 9], dim=1, end=INT64_MAX, step=1),
+        Test(self=[8, 9], dim=1, end=INT64_MAX, step=2),
+    ]
+
     test_suite = VkTestSuite([tuple(tc) for tc in test_cases])
 
     test_suite.dtypes = ["at::kFloat"]


### PR DESCRIPTION
Summary:
Seeing some ops in graph like:
```aten edge dialect
new_k[-self.left_context :, :, :],
        slice_66: "f32[10, 1, 256]" = torch.ops.aten.slice.Tensor(cat_8, 0, -10, 9223372036854775807);  cat_8 = None
```
Negative indices and 9223372036854775807 are valid inputs to `start` and `end` params on slice op, but runtime checks in Slice.cpp don't accept them.
(9223372036854775807 is the max value of signed int_64; it maps to the index not being provided.)

Adding code to compute the real values to the range [0, size(dim))

Differential Revision: D57597106


