### PR TITLE
Merge order-dependent exir/dialects/backend/test

### DIFF
--- a/exir/dialects/backend/test/test_backend_ops.py
+++ b/exir/dialects/backend/test/test_backend_ops.py
@@ -52,10 +52,6 @@ class TestBackendOps(unittest.TestCase):
         self.assertTrue(self.torch_foo(a).allclose(self.backend_foo(a)))
         self.assertTrue(self.edge_foo(a).allclose(self.backend_foo(a)))
 
-    def test_backend_ops_with_no_kernel_raise_exception(self):
-        with self.assertRaises(AssertionError):
-            ops.backend.DO_NOT_USE_TEST_ONLY.bar.default
-
     def test_backend_ops_with_meta_kernel_passes(self):
         x = torch.randn(2, 3)
         with FakeTensorMode() as mode:
@@ -67,6 +63,9 @@ class TestBackendOps(unittest.TestCase):
         self.assertEqual(meta_result.size(), x.size())
 
     def test_backend_ops_equivalent_pattern(self):
+        with self.assertRaises(AssertionError):
+            ops.backend.DO_NOT_USE_TEST_ONLY.bar.default
+
         @bind_pattern_to_op(lib, "bar")
         def f(x: torch.Tensor):
             return x + x

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,6 +22,7 @@ addopts =
     exir/backend/test/test_backends_nested.py
     exir/backend/test/test_debug_handle_map.py
     exir/backend/test/test_delegate_map_builder.py
+    exir/dialects/backend/test
     exir/dialects/edge/test
     exir/dialects/test
     exir/tests/test_arg_validator.py


### PR DESCRIPTION
If we run `test_backend_ops_equivalent_pattern` first, and then `test_backend_ops_with_no_kernel_raise_exception`, it won't raise because the first one has global side effect.
