### PR TITLE
Verify types in custom op schemas

### DIFF
--- a/exir/dialects/edge/test/test_edge_ops.py
+++ b/exir/dialects/edge/test/test_edge_ops.py
@@ -426,22 +426,6 @@ class TestEdgeOps(unittest.TestCase):
         ):
             view_op.to_out_variant()
 
-    def test_to_out_variant_ignores_overload_that_cant_convert_to_native_schema(
-        self,
-    ) -> None:
-        library = Library("TEST_ONLY", "DEF")
-        library.define(
-            "foo.t(t[] a, t[] b) -> t[]"
-        )  # can't convert torch._C.FunctionSchema into torchgen.model.FunctionSchema
-        library.define("foo.Tensor(Tensor a, Tensor b) -> Tensor")
-        library.define(
-            "foo.Tensor_out(Tensor a, Tensor b, *, Tensor(a!) out) -> Tensor(a!)"
-        )
-
-        op = ops.edge.TEST_ONLY.foo.Tensor
-        out = op.to_out_variant()
-        self.assertEqual(out, torch.ops.TEST_ONLY.foo.Tensor_out)
-
     def test_get_new_registered_out_var(
         self,
     ) -> None:


### PR DESCRIPTION
Summary:
co-dev reland of https://github.com/pytorch/pytorch/pull/124520, which requires
the removal of some executorch tests.

Before this PR, we didn't check that types in a schema were valid. This
is because TorchScript treats unknown types as type variables.

This PR checks types in a schema for the TORCH_LIBRARY APIs. To do this,
we add an `allow_typevars` flag to parseSchema so that TorchScript can
use allow_typevars=True. We also add some error messages for common
mistakes (e.g. using int64_t or double in schema).

Differential Revision: D57666659


