### PR TITLE
Mac OSS CI use cmake built gtest

### DIFF
--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -77,16 +77,11 @@ install_sccache() {
 
   export PATH="${SCCACHE_PATH}:${PATH}"
 
-  # Create temp directory for sccache shims
-  TMP_DIR=$(mktemp -d)
-  trap 'rm -rfv ${TMP_DIR}' EXIT
-
   write_sccache_stub "${TMP_DIR}/c++"
   write_sccache_stub "${TMP_DIR}/cc"
   write_sccache_stub "${TMP_DIR}/clang++"
   write_sccache_stub "${TMP_DIR}/clang"
 
-  export PATH="${TMP_DIR}:$PATH"
   sccache --zero-stats || true
 }
 

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -41,10 +41,6 @@ jobs:
 
   macos:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
-    strategy:
-      matrix:
-        include:
-          - build-tool: buck2
     with:
       runner: macos-m1-stable
       python-version: '3.11'
@@ -53,18 +49,21 @@ jobs:
       script: |
         set -eux
 
-        BUILD_TOOL=${{ matrix.build-tool }}
-
         bash .ci/scripts/setup-conda.sh
+
+        # Create temp directory for sccache shims
+        export TMP_DIR=$(mktemp -d)
+        export PATH="${TMP_DIR}:$PATH"
+        trap 'rm -rfv ${TMP_DIR}' EXIT
 
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
         PYTHON_EXECUTABLE=python \
         EXECUTORCH_BUILD_PYBIND=ON \
         CMAKE_ARGS="-DEXECUTORCH_BUILD_COREML=ON -DEXECUTORCH_BUILD_MPS=ON -DEXECUTORCH_BUILD_XNNPACK=ON -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON" \
         ${CONDA_RUN} --no-capture-output \
-        .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+        .ci/scripts/setup-macos.sh cmake
 
         # Run pytest with coverage
         ${CONDA_RUN} pytest -n auto --cov=./ --cov-report=xml
         # Run gtest
-        ${CONDA_RUN} buck2 test runtime/core/... runtime/platform/...
+        ${CONDA_RUN} test/run_oss_cpp_tests.sh


### PR DESCRIPTION
Instead of using buck. Note that for sccache shims, we need to create
the tempdir outside of setup-macos.sh, to prevent from files removed
after the script finishes.
