### PR TITLE
register and test `batch_norm`

### DIFF
--- a/backends/vulkan/partitioner/supported_ops.py
+++ b/backends/vulkan/partitioner/supported_ops.py
@@ -84,6 +84,7 @@ REDUCTION_OPS = [
 ]
 
 NORMALIZATION_OPS = [
+    exir_ops.edge.aten._native_batch_norm_legit_no_training.default,
     exir_ops.edge.aten.native_layer_norm.default,
 ]
 

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -857,6 +857,23 @@ class TestBackends(unittest.TestCase):
             memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
         )
 
+    def test_vulkan_backend_batch_norm(self):
+        class BatchNormModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.bn = torch.nn.BatchNorm2d(num_features=3)
+
+            def forward(self, x):
+                return self.bn(x)
+
+        sample_inputs = (torch.randn(size=(4, 3, 2, 5), dtype=torch.float32),)
+
+        self.lower_module_and_test_output(
+            BatchNormModule(),
+            sample_inputs,
+            memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
+        )
+
     def test_vulkan_backend_full(self):
         class FullModule(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
Summary: `batch_norm` has been implemented in ..., but not registered due to 0-dim tensors are not supported. Since 0-dim tensors are supported now, we register this op.

Differential Revision: D57707822


