### PR TITLE
Enable customization of atol and rtol

### DIFF
--- a/backends/vulkan/partitioner/supported_ops.py
+++ b/backends/vulkan/partitioner/supported_ops.py
@@ -52,12 +52,15 @@ BINARY_OPS = [
 UNARY_OPS = [
     exir_ops.edge.aten.abs.default,
     exir_ops.edge.aten.clamp.default,
+    exir_ops.edge.aten.cos.default,
     exir_ops.edge.aten.exp.default,
     exir_ops.edge.aten.gelu.default,
     exir_ops.edge.aten.hardshrink.default,
     exir_ops.edge.aten.hardtanh.default,
+    exir_ops.edge.aten.neg.default,
     exir_ops.edge.aten.relu.default,
     exir_ops.edge.aten.sigmoid.default,
+    exir_ops.edge.aten.sin.default,
     exir_ops.edge.aten.sqrt.default,
     exir_ops.edge.aten.tanh.default,
 ]

--- a/backends/vulkan/runtime/graph/ops/glsl/unary_op.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/unary_op.yaml
@@ -18,12 +18,18 @@ unary_op:
     - NAME: clamp_int
       OPERATOR: clamp(X, A, B)
       DTYPE: int
+    - NAME: cos
+      OPERATOR: cos(X)
     - NAME: exp
       OPERATOR: exp(X)
     - NAME: gelu
       OPERATOR: 0.5 * X * (1 + tanh(sqrt(2 / 3.141593) * (X + 0.044715 * X * X * X)))
+    - NAME: neg
+      OPERATOR: -X
     - NAME: sigmoid
       OPERATOR: 1 / (1 + exp(-1 * X))
+    - NAME: sin
+      OPERATOR: sin(X)
     - NAME: sqrt
       OPERATOR: sqrt(X)
     - NAME: tanh

--- a/backends/vulkan/runtime/graph/ops/impl/UnaryOp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/UnaryOp.cpp
@@ -122,8 +122,11 @@ void gelu(ComputeGraph& graph, const std::vector<ValueRef>& args) {
 }
 
 DEFINE_ACTIVATION_FN(abs);
+DEFINE_ACTIVATION_FN(cos);
 DEFINE_ACTIVATION_FN(exp);
+DEFINE_ACTIVATION_FN(neg);
 DEFINE_ACTIVATION_FN(sigmoid);
+DEFINE_ACTIVATION_FN(sin);
 DEFINE_ACTIVATION_FN(sqrt);
 DEFINE_ACTIVATION_FN(tanh);
 DEFINE_CLAMP_FN(clamp);
@@ -134,11 +137,14 @@ DEFINE_HARDSHRINK_FN(hardshrink);
 REGISTER_OPERATORS {
   VK_REGISTER_OP(aten.abs.default, abs);
   VK_REGISTER_OP(aten.clamp.default, clamp);
+  VK_REGISTER_OP(aten.cos.default, cos);
   VK_REGISTER_OP(aten.exp.default, exp);
   VK_REGISTER_OP(aten.gelu.default, gelu);
   VK_REGISTER_OP(aten.hardtanh.default, hardtanh);
+  VK_REGISTER_OP(aten.neg.default, neg);
   VK_REGISTER_OP(aten.relu.default, relu);
   VK_REGISTER_OP(aten.sigmoid.default, sigmoid);
+  VK_REGISTER_OP(aten.sin.default, sin);
   VK_REGISTER_OP(aten.sqrt.default, sqrt);
   VK_REGISTER_OP(aten.tanh.default, tanh);
   VK_REGISTER_OP(aten.hardshrink.default, hardshrink);

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -682,6 +682,8 @@ def get_unary_ops_inputs():
         ]
     )
     test_suite.storage_types = ["api::kTexture3D", "api::kBuffer"]
+    test_suite.atol = "1e-4"
+    test_suite.rtol = "1e-4"
     return test_suite
 
 

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -807,4 +807,7 @@ test_suites = {
     "aten.gelu.default": get_gelu_inputs(),
     "aten.hardshrink.default": get_unary_ops_inputs(),
     "aten.upsample_nearest2d.vec": get_upsample_inputs(),
+    "aten.sin.default": get_unary_ops_inputs(),
+    "aten.neg.default": get_unary_ops_inputs(),
+    "aten.cos.default": get_unary_ops_inputs(),
 }

--- a/backends/vulkan/test/op_tests/utils/codegen.py
+++ b/backends/vulkan/test/op_tests/utils/codegen.py
@@ -600,8 +600,8 @@ class GeneratedOpsTest_{op_name} : public ::testing::TestWithParam< ::std::tuple
   protected:
     ComputeGraph* graph;
     at::ScalarType test_dtype = at::kFloat;
-    float rtol = 1e-4;
-    float atol = 1e-4;
+    float rtol = {rtol};
+    float atol = {atol};
 
     void SetUp() override {{
         GraphConfig config;
@@ -651,6 +651,8 @@ class VkTestSuiteGen(TestSuiteGen):
             op_name=self.op_name,
             check_fn=check_fn,
             prepacked_check_fn=prepacked_check_fn,
+            rtol=self.suite_def.rtol,
+            atol=self.suite_def.atol,
         )
 
     def gen_parameterization(self) -> str:

--- a/backends/vulkan/test/op_tests/utils/codegen.py
+++ b/backends/vulkan/test/op_tests/utils/codegen.py
@@ -600,8 +600,8 @@ class GeneratedOpsTest_{op_name} : public ::testing::TestWithParam< ::std::tuple
   protected:
     ComputeGraph* graph;
     at::ScalarType test_dtype = at::kFloat;
-    float rtol = 1e-5;
-    float atol = 1e-5;
+    float rtol = 1e-4;
+    float atol = 1e-4;
 
     void SetUp() override {{
         GraphConfig config;

--- a/backends/vulkan/test/op_tests/utils/codegen_base.py
+++ b/backends/vulkan/test/op_tests/utils/codegen_base.py
@@ -47,6 +47,8 @@ class TestSuite:
         self.prepacked_args: List[str] = []
         self.requires_prepack: bool = False
         self.dtypes: List[str] = ["at::kFloat", "at::kHalf"]
+        self.atol: str = "1e-5"
+        self.rtol: str = "1e-5"
 
     def supports_prepack(self):
         return len(self.prepacked_args) > 0

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -393,6 +393,16 @@ class TestBackends(unittest.TestCase):
 
         self.lower_module_and_test_output(ClampModule(), sample_inputs)
 
+    def test_vulkan_backend_cos(self):
+        class CosModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.cos(x)
+
+        self.lower_unary_module_and_test_output(CosModule())
+
     def test_vulkan_backend_hardtanh(self):
         class HardTanHModule(torch.nn.Module):
             def __init__(self):
@@ -413,6 +423,26 @@ class TestBackends(unittest.TestCase):
                 return torch.exp(x)
 
         self.lower_unary_module_and_test_output(ExpModule())
+
+    def test_vulkan_backend_neg(self):
+        class NegModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.neg(x)
+
+        self.lower_unary_module_and_test_output(NegModule())
+
+    def test_vulkan_backend_sin(self):
+        class SinModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.sin(x)
+
+        self.lower_unary_module_and_test_output(SinModule())
 
     def test_vulkan_backend_relu(self):
         class ReLUModule(torch.nn.Module):


### PR DESCRIPTION
Summary:
Enable customization of atol and rtol for TestSuite in codegen. The reason for this is: we need to relax atol and rtol to pass some tests. (D57686850)

bypass-github-export-checks
bypass-github-pytorch-ci-checks
bypass-github-executorch-ci-checks

Reviewed By: copyrightly

Differential Revision: D57698945


