### PR TITLE
Default construct QueryPool with nonzero values

### DIFF
--- a/backends/vulkan/runtime/api/QueryPool.h
+++ b/backends/vulkan/runtime/api/QueryPool.h
@@ -18,12 +18,16 @@
 #include <executorch/backends/vulkan/runtime/api/Command.h>
 #include <executorch/backends/vulkan/runtime/api/Pipeline.h>
 
+#ifndef VULKAN_QUERY_POOL_SIZE
+#define VULKAN_QUERY_POOL_SIZE 4096u
+#endif
+
 namespace vkcompute {
 namespace api {
 
 struct QueryPoolConfig final {
-  uint32_t max_query_count;
-  uint32_t initial_reserve_size;
+  uint32_t max_query_count = VULKAN_QUERY_POOL_SIZE;
+  uint32_t initial_reserve_size = 256u;
 };
 
 struct ShaderDuration final {


### PR DESCRIPTION
Summary:
**We must bugfix this first to unblock either dumping querypool directly after inference or SDK development**

Currently, if you try to init QueryPool during inference, it will crash at `vkCreateQueryPool`. Some debugging revealed in the test binary, it will crash only on VulkanComputeGraphTest but not VulkanComputeAPITest. 

It is because the `Context` instance is initialized in two different ways and then `QueryPoolConfig` is then initialized in two different ways. 

1. Static singleton https://fburl.com/code/iqo8xcg2 with above nonzero max query count and the compile time flag to change the query pool. We don't use this for model inference. 

2. Explicit constructor https://fburl.com/code/m1xga4ra, invoked in `VulkanBackend::Init()` https://fburl.com/code/4j8y3pzu which goes through default construction of `GraphConfig`, default construction of `QueryPoolConfig`, leading to zero max query count and crash. We use this for model inference.

3. This should be probably be unified, as it was extremely confusing to have the compile time flag work in non inference cases but not in inference case, and explicit const struct construction happens in the former vs completely default struct construction in the latter. 

4. A quick solution to unblock. `QueryPoolConfig` has default init values of the compile time flags.

Reviewed By: SS-JIA

Differential Revision: D57735873


