### PR TITLE
Fully quality all deps in the shim

### DIFF
--- a/shim/buck2/buck_rust_binary.bzl
+++ b/shim/buck2/buck_rust_binary.bzl
@@ -6,7 +6,7 @@
 # of this source tree.
 
 load(
-    "//:shims.bzl",
+    "@shim//:shims.bzl",
     _rust_binary = "rust_binary",
 )
 

--- a/shim/buck2/proto_defs.bzl
+++ b/shim/buck2/proto_defs.bzl
@@ -6,7 +6,7 @@
 # of this source tree.
 
 load(
-    "//:shims.bzl",
+    "@shim//:shims.bzl",
     _rust_protobuf_library = "rust_protobuf_library",
 )
 

--- a/shim/build_defs/cpp_binary.bzl
+++ b/shim/build_defs/cpp_binary.bzl
@@ -5,6 +5,6 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("//:shims.bzl", _cpp_binary = "cpp_binary")
+load("@shim//:shims.bzl", _cpp_binary = "cpp_binary")
 
 cpp_binary = _cpp_binary

--- a/shim/build_defs/cpp_library.bzl
+++ b/shim/build_defs/cpp_library.bzl
@@ -5,6 +5,6 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("//:shims.bzl", _cpp_library = "cpp_library")
+load("@shim//:shims.bzl", _cpp_library = "cpp_library")
 
 cpp_library = _cpp_library

--- a/shim/build_defs/cpp_unittest.bzl
+++ b/shim/build_defs/cpp_unittest.bzl
@@ -5,6 +5,6 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("//:shims.bzl", _cpp_unittest = "cpp_unittest")
+load("@shim//:shims.bzl", _cpp_unittest = "cpp_unittest")
 
 cpp_unittest = _cpp_unittest

--- a/shim/build_defs/cython_library.bzl
+++ b/shim/build_defs/cython_library.bzl
@@ -5,7 +5,7 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("//build_defs:python_library.bzl", "python_library")
+load("@shim//build_defs:python_library.bzl", "python_library")
 
 def cython_library(name, visibility = ["PUBLIC"], **_):
     python_library(name = name, visibility = visibility)

--- a/shim/build_defs/ocaml_binary.bzl
+++ b/shim/build_defs/ocaml_binary.bzl
@@ -5,6 +5,6 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("//:shims.bzl", _ocaml_binary = "ocaml_binary")
+load("@shim//:shims.bzl", _ocaml_binary = "ocaml_binary")
 
 ocaml_binary = _ocaml_binary

--- a/shim/build_defs/prebuilt_cpp_library.bzl
+++ b/shim/build_defs/prebuilt_cpp_library.bzl
@@ -5,6 +5,6 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("//:shims.bzl", _prebuilt_cpp_library = "prebuilt_cpp_library")
+load("@shim//:shims.bzl", _prebuilt_cpp_library = "prebuilt_cpp_library")
 
 prebuilt_cpp_library = _prebuilt_cpp_library

--- a/shim/build_defs/rust_binary.bzl
+++ b/shim/build_defs/rust_binary.bzl
@@ -5,6 +5,6 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("//:shims.bzl", _rust_binary = "rust_binary")
+load("@shim//:shims.bzl", _rust_binary = "rust_binary")
 
 rust_binary = _rust_binary

--- a/shim/build_defs/rust_library.bzl
+++ b/shim/build_defs/rust_library.bzl
@@ -5,6 +5,6 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("//:shims.bzl", _rust_library = "rust_library")
+load("@shim//:shims.bzl", _rust_library = "rust_library")
 
 rust_library = _rust_library

--- a/shim/build_defs/rust_unittest.bzl
+++ b/shim/build_defs/rust_unittest.bzl
@@ -5,6 +5,6 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("//:shims.bzl", _rust_unittest = "rust_unittest")
+load("@shim//:shims.bzl", _rust_unittest = "rust_unittest")
 
 rust_unittest = _rust_unittest

--- a/shim/third-party/glog/BUCK
+++ b/shim/third-party/glog/BUCK
@@ -12,5 +12,5 @@ oncall("open_source")
 third_party_library(
     name = "glog",
     pkgconfig_name = "libglog",
-    deps = ["//third-party/gflags:gflags"],
+    deps = ["shim//third-party/gflags:gflags"],
 )

--- a/shim/third-party/rust/reindeer.toml
+++ b/shim/third-party/rust/reindeer.toml
@@ -25,5 +25,5 @@ prebuilt_cxx_library = "third_party_rust_prebuilt_cxx_library"
 buckfile_imports = """
 load("@prelude//rust:cargo_buildscript.bzl", "buildscript_run")
 load("@prelude//rust:cargo_package.bzl", "cargo")
-load("//third-party/macros:rust_third_party.bzl", "third_party_rust_prebuilt_cxx_library")
+load("@shim//third-party/macros:rust_third_party.bzl", "third_party_rust_prebuilt_cxx_library")
 """


### PR DESCRIPTION
Summary: This is needed in case the shim is included as part of a submodule in order to correctly resolve dep locations.

Reviewed By: namanahuja

Differential Revision: D57746640


