### PR TITLE
Migrate upsample op to new layout declare using the gen_vulkan_spv.py

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/upsample.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/upsample.glsl
@@ -13,21 +13,15 @@
 
 #define PRECISION ${PRECISION}
 
-#define VEC4_T ${texel_type(DTYPE)}
+#define VEC4_T ${texel_load_type(DTYPE, STORAGE)}
+${define_active_storage_type(STORAGE)}
 
 layout(std430) buffer;
 
-layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly ${IMAGE_T[NDIM][DTYPE]} image_out;
-
-layout(set = 0, binding = 1) uniform PRECISION sampler3D image_in;
-
-layout(set = 0, binding = 2) uniform PRECISION restrict OutLimits {
-  ivec3 out_limits;
-};
-
-layout(set = 0, binding = 3) uniform PRECISION restrict Sizes {
-  ivec4 sizes;
-};
+${layout_declare_tensor(0, "w", "image_out", DTYPE, STORAGE)}
+${layout_declare_tensor(1, "r", "image_in", DTYPE, STORAGE)}
+${layout_declare_ubo(2, "ivec3", "out_limits")}
+${layout_declare_ubo(3, "ivec4", "sizes")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/upsample.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/upsample.yaml
@@ -9,6 +9,7 @@ upsample:
     NDIM: 3
     DTYPE: float
     PACKING: C_packed
+    STORAGE: texture3d
   generate_variant_forall:
     DTYPE:
       - VALUE: half


### PR DESCRIPTION
Summary:
Migrate upsample op to new layout declare using the gen_vulkan_spv.py
- layout_declare_tensor: https://www.internalfb.com/code/fbsource/[0ba7858aa186]/fbcode/executorch/backends/vulkan/runtime/api/gen_vulkan_spv.py?lines=219
- layout_declare_ubo, ubo: Uniform Buffer Object, OpenGL data structure

Differential Revision: D57781160


