### PR TITLE
Remove torch._constrain_as_value

### DIFF
--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -219,7 +219,8 @@ class TestProgramManagers(unittest.TestCase):
         class M(torch.nn.Module):
             def forward(self, x, y):
                 z = y.item()
-                torch._constrain_as_value(z, 0, 4)
+                torch._check(z > 0)
+                torch._check(z < 4)
                 return x[z : z + y.shape[0]]
 
         ep = torch.export.export(M(), (torch.randn(10), torch.tensor([3])))

--- a/exir/verification/test/test_verifier.py
+++ b/exir/verification/test/test_verifier.py
@@ -37,7 +37,8 @@ class TestEdgeDialectVerifier(unittest.TestCase):
         class M(torch.nn.Module):
             def forward(self, x, y):
                 z = y.item()
-                torch._constrain_as_value(z, 0, 4)
+                torch._check(z > 0)
+                torch._check(z < 4)
                 return x[z : z + y.shape[0]]
 
         ep = torch.export.export(M(), (torch.randn(10), torch.tensor([3])))


### PR DESCRIPTION
Summary: This API doesn't do anything useful and should be subsumed by torch._check.

Differential Revision: D57786740


