### PR TITLE
add flag for dynamic shapes to filter out static ops

### DIFF
--- a/backends/xnnpack/partition/configs.py
+++ b/backends/xnnpack/partition/configs.py
@@ -144,14 +144,12 @@ SUPPORTED_DYN_QUANT_LINEAR_MODULES = [
 
 SUPPORTED_DYN_QUANT_MODULES = SUPPORTED_DYN_QUANT_LINEAR_MODULES
 
-# TODO delete this once we catch up to 100% of the supported op with dynamic shape support.
-# This is tobe used only during the transition when we may not want to partition all the
-# nodes for a dynamic model.
-_SUPPORTED_OPS_WITH_DYNAMIC_SHAPE = [
-    exir_ops.edge.aten.add.Tensor,
-    exir_ops.edge.aten.mul.Tensor,
+# XNNPACK supports majority of shape dynamism, however some ops are
+# explicitly static, so we maintain a set here to exclude them from
+# dynamic shape support.
+STATIC_OPS = [
+    exir_ops.edge.aten.cat.default,
+    exir_ops.edge.aten.slice_copy.Tensor,
 ]
-_SUPPORTED_MODULES_WITH_DYNAMIC_SHAPE = [
-    torch.nn.Conv1d,
-    torch.nn.Conv2d,
-]
+
+STATIC_MODULES = []

--- a/backends/xnnpack/test/ops/slice_copy.py
+++ b/backends/xnnpack/test/ops/slice_copy.py
@@ -7,7 +7,8 @@
 import unittest
 
 import torch
-from executorch.backends.xnnpack.test.tester import Tester
+from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
+from executorch.backends.xnnpack.test.tester import Partition, Tester
 
 
 class TestSliceCopy(unittest.TestCase):
@@ -109,6 +110,26 @@ class TestSliceCopy(unittest.TestCase):
                 {"executorch_exir_dialects_edge__ops_aten_slice_copy_Tensor": 3}
             )
             .partition()
+            .check_not(["torch.ops.higher_order.executorch_call_delegate"])
+        )
+
+    def test_fp32_static_slice_with_dynamic_dim(self):
+        """
+        XNNPACK does not support dynamic dims with static slice
+        """
+
+        class SliceCopy(torch.nn.Module):
+            def forward(self, x):
+                return x[1:3, -2:, :-1]
+
+        inputs = (torch.randn(5, 5, 5),)
+        (
+            Tester(SliceCopy(), inputs)
+            .export()
+            .to_edge()
+            .partition(
+                Partition(partitioner=XnnpackPartitioner(has_dynamic_shapes=True))
+            )
             .check_not(["torch.ops.higher_order.executorch_call_delegate"])
         )
 


### PR DESCRIPTION
Summary: Since we have updated XNNPACK to support almost 100% of dynamic shape ops, we can now create static_op lists which do not have any dynamic shape support and filter them out instead

Differential Revision: D57787384


