### PR TITLE
Arm test: Pass inputs to run_method_and_compare_outputs

### DIFF
--- a/backends/arm/test/models/test_mobilenet_v2_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v2_arm.py
@@ -60,7 +60,7 @@ class TestMobileNetV2(unittest.TestCase):
             .check(list(self.all_operators))
             .partition()
             .to_executorch()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(inputs=self.model_inputs)
         )
 
     def test_mv2_tosa_BI(self):

--- a/backends/arm/test/ops/test_add.py
+++ b/backends/arm/test/ops/test_add.py
@@ -71,7 +71,7 @@ class TestSimpleAdd(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_add_tosa_BI_pipeline(
@@ -91,7 +91,7 @@ class TestSimpleAdd(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(inputs=test_data, qtol=1)
         )
 
     def _test_add_u55_BI_pipeline(

--- a/backends/arm/test/ops/test_avg_pool.py
+++ b/backends/arm/test/ops/test_avg_pool.py
@@ -60,7 +60,7 @@ class TestAvgPool2d(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_avg_pool2d_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_avgpool2d_tosa_BI_pipeline(
@@ -81,7 +81,7 @@ class TestAvgPool2d(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_avg_pool2d_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(inputs=test_data, qtol=1)
         )
 
     def _test_avgpool2d_tosa_u55_BI_pipeline(

--- a/backends/arm/test/ops/test_batch_norm.py
+++ b/backends/arm/test/ops/test_batch_norm.py
@@ -552,7 +552,7 @@ class TestBatchNorm2d(unittest.TestCase):
                 ]
             )
             .to_executorch()
-            .run_method_and_compare_outputs(test_data)
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_batchnorm2d_no_stats_tosa_MI_pipeline(
@@ -581,7 +581,7 @@ class TestBatchNorm2d(unittest.TestCase):
                 ]
             )
             .to_executorch()
-            .run_method_and_compare_outputs(test_data)
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_batchnorm2d_tosa_BI_pipeline(
@@ -613,7 +613,7 @@ class TestBatchNorm2d(unittest.TestCase):
                 ]
             )
             .to_executorch()
-            .run_method_and_compare_outputs(test_data)
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_batchnorm2d_u55_BI_pipeline(

--- a/backends/arm/test/ops/test_clone.py
+++ b/backends/arm/test/ops/test_clone.py
@@ -47,7 +47,7 @@ class TestSimpleClone(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_clone_tosa_BI_pipeline(
@@ -66,7 +66,7 @@ class TestSimpleClone(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(inputs=test_data, qtol=1)
         )
 
     def _test_clone_tosa_u55_pipeline(

--- a/backends/arm/test/ops/test_conv.py
+++ b/backends/arm/test/ops/test_conv.py
@@ -256,7 +256,7 @@ class TestConv2D(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .check_not(["executorch_exir_dialects_edge__ops_aten_convolution_default"])
             .to_executorch()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_conv2d_tosa_BI_pipeline(
@@ -277,7 +277,7 @@ class TestConv2D(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .check_not(["executorch_exir_dialects_edge__ops_aten_convolution_default"])
             .to_executorch()
-            .run_method_and_compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(inputs=test_data, qtol=1)
         )
 
     def _test_conv2d_u55_BI_pipeline(

--- a/backends/arm/test/ops/test_conv_combos.py
+++ b/backends/arm/test/ops/test_conv_combos.py
@@ -169,7 +169,7 @@ class TestConvCombos(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .check_not(list(module.edge_op_list))
             .to_executorch()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_conv_combo_tosa_BI_pipeline(
@@ -192,7 +192,9 @@ class TestConvCombos(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .check_not(list(module.edge_op_list))
             .to_executorch()
-            .run_method_and_compare_outputs(atol=atol, rtol=rtol, qtol=1)
+            .run_method_and_compare_outputs(
+                inputs=test_data, atol=atol, rtol=rtol, qtol=1
+            )
         )
 
     def _test_conv_combo_u55_BI_pipeline(

--- a/backends/arm/test/ops/test_depthwise_conv.py
+++ b/backends/arm/test/ops/test_depthwise_conv.py
@@ -142,7 +142,7 @@ class TestDepthwiseConv2D(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_convolution_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_dw_conv2d_tosa_BI_pipeline(
@@ -161,7 +161,7 @@ class TestDepthwiseConv2D(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_convolution_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(inputs=test_data, qtol=1)
         )
 
     def _test_dw_conv2d_u55_BI_pipeline(

--- a/backends/arm/test/ops/test_div.py
+++ b/backends/arm/test/ops/test_div.py
@@ -117,7 +117,7 @@ class TestDiv(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(test_data)
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_div_tosa_BI_pipeline(
@@ -137,7 +137,7 @@ class TestDiv(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(test_data)
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_div_u55_BI_pipeline(

--- a/backends/arm/test/ops/test_linear.py
+++ b/backends/arm/test/ops/test_linear.py
@@ -129,7 +129,7 @@ class TestLinear(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_linear_tosa_BI_pipeline(
@@ -149,7 +149,7 @@ class TestLinear(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(qtol=True)
+            .run_method_and_compare_outputs(inputs=test_data, qtol=True)
         )
 
     def _test_linear_tosa_u55_BI_pipeline(

--- a/backends/arm/test/ops/test_mean_dim.py
+++ b/backends/arm/test/ops/test_mean_dim.py
@@ -65,7 +65,7 @@ class TestMeanDim(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_mean_dim"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_meandim_tosa_BI_pipeline(
@@ -86,7 +86,7 @@ class TestMeanDim(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_mean_dim"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(inputs=test_data, qtol=1)
         )
 
     def _test_meandim_tosa_u55_BI_pipeline(

--- a/backends/arm/test/ops/test_softmax.py
+++ b/backends/arm/test/ops/test_softmax.py
@@ -53,7 +53,7 @@ class TestSoftmax(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten__softmax_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs()
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_softmax_tosa_BI_pipeline(
@@ -74,7 +74,7 @@ class TestSoftmax(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten__softmax_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(inputs=test_data, qtol=1)
         )
 
     def _test_softmax_tosa_u55_BI_pipeline(

--- a/backends/arm/test/ops/test_view.py
+++ b/backends/arm/test/ops/test_view.py
@@ -44,7 +44,7 @@ class TestSimpleView(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_view_tosa_BI_pipeline(
@@ -63,7 +63,7 @@ class TestSimpleView(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(inputs=test_data, qtol=1)
         )
 
     def _test_view_u55_BI_pipeline(


### PR DESCRIPTION
Pass inputs to ArmTester.run_method_and_compare_outputs to make sure that the test data is from the same distribution as the calibration data.


Change-Id: I690b9a22c1e12465364998bdaddd4903bcc1c18f