### PR TITLE
example of updating dim order for specific part of graph

### DIFF
--- a/exir/tests/test_memory_format_ops_pass.py
+++ b/exir/tests/test_memory_format_ops_pass.py
@@ -4,17 +4,23 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 import unittest
 from dataclasses import dataclass
 from typing import Any, Tuple
 
 import torch
 from executorch.exir import to_edge
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.dialects.edge._ops import EdgeOpOverload
 
 from executorch.exir.dim_order_utils import (
+    get_dim_order,
     is_channel_last_dim_order,
     is_contiguous_dim_order,
 )
+
+from executorch.exir.pass_base import ExportPass, ProxyValue
 
 from torch.export import export
 from torch.testing import FileCheck
@@ -215,3 +221,131 @@ class TestMemoryFormatOpsPass(unittest.TestCase):
                 is_aten_mode=True,
             )
         )
+
+    def test_dim_order_replacement(self) -> None:
+        class ToyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                t1 = x + y
+                t2 = t1 * x
+                t3 = t2 + y
+                return t3
+
+        class MulIOToChannelsLastPass(ExportPass):
+            """
+            This pass updates the dim order of the input tensors of mul op from contiguous to channels_last, and change the output dim order back to contiguous.
+            """
+
+            def call_operator(self, op, args, kwargs, meta):
+                if not (
+                    isinstance(op, EdgeOpOverload) and op.__name__ == "aten.mul.Tensor"
+                ):
+                    return super().call_operator(
+                        op,
+                        args,
+                        kwargs,
+                        meta,
+                    )
+
+                # new kwargs with dim_order, and no memory_format for the new op
+                nkwargs = dict(copy.deepcopy(kwargs))  # orig kwargs are immutable
+
+                _to_dim_order_copy_op = (
+                    exir_ops.edge.dim_order_ops._to_dim_order_copy.default
+                )
+
+                # update the dim order of the input tensors of mul op from contiguous to channels_last
+                new_args = []
+                for arg in args:
+                    # get the number of dimmention of mul op's input, as well as its dtype
+                    ndim = None
+                    dtype = None
+                    tensor_input = None
+                    # can always get the shape, assuming rank is specialized
+                    if isinstance(arg, ProxyValue) and arg.is_tensor():
+                        ndim = arg.to_tensor().dim()
+                        dtype = arg.to_tensor().dtype
+                        tensor_input = arg.to_tensor()
+
+                    elif isinstance(arg, torch.Tensor):
+                        ndim = arg.dim()
+                        dtype = arg.dtype
+                        tensor_input = arg
+                    else:
+                        assert (
+                            0
+                        ), f"Expecting a Tensor or a ProxyValue buy got {type(arg)}"
+
+                    ndim = tensor_input.dim()
+                    dtype = tensor_input.dtype
+
+                    assert tensor_input.is_contiguous(
+                        memory_format=torch.contiguous_format
+                    ), "mul input should be in contiguous memory format"
+
+                    channels_last_dim_order = get_dim_order(torch.channels_last, ndim)
+                    contiguous_dim_order = get_dim_order(torch.contiguous_format, ndim)
+
+                    # convert the input tensors to channels_last
+                    arg_channels_last = super().call_operator(
+                        _to_dim_order_copy_op,
+                        (arg,),
+                        {"dtype": dtype, "dim_order": channels_last_dim_order},
+                        meta,
+                    )
+
+                    new_args.append(arg_channels_last)
+
+                new_args = tuple(new_args)
+
+                # call the mul op with the self tensor in channels_last
+                # mul op is using the same kernel to handle contiguous and channels_last inputs.
+                mul_out = super().call_operator(
+                    op,
+                    new_args,
+                    nkwargs,
+                    meta,
+                )
+
+                # convert the mul op output to contiguous
+                mul_out_contiguous = super().call_operator(
+                    _to_dim_order_copy_op,
+                    (mul_out,),
+                    {"dtype": dtype, "dim_order": contiguous_dim_order},
+                    meta,
+                )
+
+                return mul_out_contiguous
+
+        toy_model = ToyModel()
+        sample_input = (
+            torch.randn([2, 2, 2, 2], dtype=torch.float32),
+            torch.randn([2, 2, 2, 2], dtype=torch.float32),
+        )
+
+        _to_dim_order_op_str = "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default"
+
+        before_epm = to_edge(export(toy_model, sample_input))
+
+        # should not contain _to_dim_order_copy op
+        FileCheck().check_not(_to_dim_order_op_str).run(
+            before_epm.exported_program().graph_module.code
+        )
+
+        # add the pass to update the input and output of mul op from contiguous to channels_last
+        updated_epm = before_epm.transform([MulIOToChannelsLastPass()])
+
+        # should contain exactly three _to_dim_order_copy op to update the dim order of input and output of mul op
+        FileCheck().check_count(_to_dim_order_op_str, 3, exactly=True).run(
+            updated_epm.exported_program().graph_module.code
+        )
+
+        # check original graph and update graph should have same result
+        expected = before_epm.exported_program().module()(*sample_input)
+        actual = updated_epm.exported_program().module()(*sample_input)
+        self.assertTrue(torch.allclose(actual, expected))
+
+        self.assertTrue(is_contiguous_dim_order(actual))
+        self.assertTrue(is_contiguous_dim_order(expected))


### PR DESCRIPTION
Summary:
An example of how to update the tensor's memory format of specific part in graph by inserting `_to_dim_order_copy` op before and after the specific part we want to update (here is the mul op).

Making it as a test for memory format pass.

Differential Revision: D57877264


