### PR TITLE
Inspector CLI Specify source and Target Timescale

### DIFF
--- a/sdk/inspector/inspector_cli.py
+++ b/sdk/inspector/inspector_cli.py
@@ -7,7 +7,7 @@
 import argparse
 
 from executorch.sdk import Inspector
-from executorch.sdk.inspector._inspector_utils import compare_results
+from executorch.sdk.inspector._inspector_utils import compare_results, TimeScale
 
 
 def main() -> None:
@@ -16,6 +16,20 @@ def main() -> None:
         "--etdump_path",
         required=True,
         help="Provide an ETDump file path.",
+    )
+    parser.add_argument(
+        "--source_time_scale",
+        type=str,
+        choices=[ts.value for ts in TimeScale],
+        help="Enter the source time scale (ns, us, ms, s, cycles)",
+        default=TimeScale.NS.value,
+    )
+    parser.add_argument(
+        "--target_time_scale",
+        type=str,
+        choices=[ts.value for ts in TimeScale],
+        help="Enter the target time scale (ns, us, ms, s, cycles)",
+        default=TimeScale.MS.value,
     )
     parser.add_argument(
         "--etrecord_path",
@@ -35,6 +49,8 @@ def main() -> None:
         etdump_path=args.etdump_path,
         etrecord=args.etrecord_path,
         debug_buffer_path=args.debug_buffer_path,
+        source_time_scale=TimeScale(args.source_time_scale),
+        target_time_scale=TimeScale(args.target_time_scale),
     )
     inspector.print_data_tabular()
     if args.compare_results:


### PR DESCRIPTION
Summary:
et pal defines a function which expects "ticks" to be returned as et_timestamp_t.

https://www.internalfb.com/code/fbsource/[f8d32ccd3afec7d761b6e04f1809210892973b20]/fbcode/executorch/runtime/platform/platform.h?lines=66

Inspector CLI treats these ticks as "nanoseconds" by default

https://www.internalfb.com/code/fbsource/[f8d32ccd3afec7d761b6e04f1809210892973b20]/fbcode/executorch/sdk/inspector/_inspector.py?lines=610

I understand ticks and nanoseconds as different things unless operating processor at 1GHz, but don't necessarily need to change the default in case it breaks some existing workflows. Specifying source/target time scale to the CLI tool would be useful flexibility, though, since I would ultimately like our PAL to return ticks which seems to be original intent.

Reviewed By: tarun292

Differential Revision: D57888750


