### PR TITLE
Add get_inputs to method.cpp

### DIFF
--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -998,6 +998,28 @@ Method::get_outputs(EValue* output_evalues, size_t length) {
   return Error::Ok;
 }
 
+__ET_NODISCARD Error Method::get_inputs(EValue* input_evalues, size_t length) {
+  ET_CHECK_OR_RETURN_ERROR(
+      initialized(),
+      InvalidState,
+      "Inputs can not be retrieved until method has been initialized.");
+
+  ET_CHECK_OR_RETURN_ERROR(
+      length >= inputs_size(),
+      InvalidArgument,
+      "The given array is not large enough to hold all inputs.");
+
+  for (size_t i = 0; i < inputs_size(); i++) {
+    input_evalues[i] = values_[get_input_index(i)];
+  }
+
+  for (size_t i = inputs_size(); i < length; i++) {
+    input_evalues[i] = EValue();
+  }
+
+  return Error::Ok;
+}
+
 Error Method::execute_instruction() {
   auto& chain = chains_[step_state_.chain_idx];
   auto instructions = chain.s_chain_->instructions();

--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -163,6 +163,22 @@ class Method final {
   __ET_NODISCARD Error get_outputs(EValue* output_evalues, size_t length);
 
   /**
+   * Copies the method's inputs into the provided array.
+   *
+   * WARNING: The input contains shallow copies of internal tensor inputs.
+   * Please do not mutate returned Tensor elements.
+   *
+   * @param[in] input_evalues The array to copy the inputs into. The first
+   *     `inputs_size()` elements will be set to the corresponding input
+   *     values. The rest of the array will be set to the EValue value None.
+   * @param[in] length The size of the `input_evalues` array in elements. Must
+   *     be greater than or equal to `inputs_size()`.
+   *
+   * @returns Error::Ok on success, non-Ok on failure.
+   */
+  __ET_NODISCARD Error get_inputs(EValue* input_evalues, size_t length);
+
+  /**
    * Execute the method.
    *
    * NOTE: Will fail if the method has been partially executed using the


### PR DESCRIPTION
Summary: There are use cases where users would like to access the input EValues after they've been memory planned and allocated buffers so that they can directly copy their inputs to these buffers. Adding a method to support that.

Differential Revision: D57970255


