### PR TITLE
rename op lib to be clearer on its usage

### DIFF
--- a/backends/vulkan/test/TARGETS
+++ b/backends/vulkan/test/TARGETS
@@ -10,7 +10,7 @@ python_unittest(
     preload_deps = [
         "fbsource//third-party/swiftshader/lib/linux-x64:libvk_swiftshader_fbcode",
         "//executorch/backends/vulkan:vulkan_backend_lib",
-        "//executorch/kernels/portable:custom_ops_generated_lib",
+        "//executorch/kernels/portable:python_preload_generated_lib",
     ],
     deps = [
         "//caffe2:torch",
@@ -21,7 +21,7 @@ python_unittest(
         "//executorch/exir:lib",
         "//executorch/extension/pybindings:portable_lib",  # @manual
         "//executorch/extension/pytree:pylib",
-        "//executorch/kernels/portable:custom_ops_generated_lib",
+        "//executorch/kernels/portable:python_preload_generated_lib",
     ],
 )
 

--- a/exir/backend/test/TARGETS
+++ b/exir/backend/test/TARGETS
@@ -106,8 +106,8 @@ python_unittest(
         "test_backends.py",
     ],
     preload_deps = [
-        "//executorch/kernels/portable:custom_ops_generated_lib",
-        "//executorch/kernels/quantized:custom_ops_generated_lib",
+        "//executorch/kernels/portable:python_preload_generated_lib",
+        "//executorch/kernels/quantized:python_preload_generated_lib",
         "//executorch/runtime/executor/test:test_backend_compiler_lib",
     ],
     deps = [
@@ -155,8 +155,8 @@ python_unittest(
         "test_backends_lifted.py",
     ],
     preload_deps = [
-        "//executorch/kernels/portable:custom_ops_generated_lib",
-        "//executorch/kernels/quantized:custom_ops_generated_lib",
+        "//executorch/kernels/portable:python_preload_generated_lib",
+        "//executorch/kernels/quantized:python_preload_generated_lib",
         "//executorch/runtime/executor/test:test_backend_compiler_lib",
     ],
     deps = [
@@ -201,8 +201,8 @@ python_unittest(
         "//executorch/exir/backend:compile_spec_schema",
         "//executorch/exir/tests:models",
         "//executorch/extension/pybindings:portable_lib",  # @manual
-        "//executorch/kernels/portable:custom_ops_generated_lib",
-        "//executorch/kernels/quantized:custom_ops_generated_lib",
+        "//executorch/kernels/portable:python_preload_generated_lib",
+        "//executorch/kernels/quantized:python_preload_generated_lib",
     ],
 )
 
@@ -229,8 +229,8 @@ python_unittest(
         "test_backends_nested.py",
     ],
     preload_deps = [
-        "//executorch/kernels/portable:custom_ops_generated_lib",
-        "//executorch/kernels/quantized:custom_ops_generated_lib",
+        "//executorch/kernels/portable:python_preload_generated_lib",
+        "//executorch/kernels/quantized:python_preload_generated_lib",
     ],
     deps = [
         ":op_partitioner_demo",

--- a/exir/backend/test/demos/TARGETS
+++ b/exir/backend/test/demos/TARGETS
@@ -6,8 +6,8 @@ python_unittest(
         "test_xnnpack_qnnpack.py",
     ],
     preload_deps = [
-        "//executorch/kernels/portable:custom_ops_generated_lib",
-        "//executorch/kernels/quantized:custom_ops_generated_lib",
+        "//executorch/kernels/portable:python_preload_generated_lib",
+        "//executorch/kernels/quantized:python_preload_generated_lib",
     ],
     deps = [
         "//caffe2:torch",
@@ -31,7 +31,7 @@ python_unittest(
         "test_delegate_aten_mode.py",
     ],
     preload_deps = [
-        "//executorch/kernels/portable:custom_ops_generated_lib_aten",
+        "//executorch/kernels/portable:python_preload_generated_lib_aten",
     ],
     deps = [
         "//caffe2:torch",

--- a/exir/backend/test/demos/rpc/TARGETS
+++ b/exir/backend/test/demos/rpc/TARGETS
@@ -46,8 +46,8 @@ python_unittest(
         "test_rpc.py",
     ],
     preload_deps = [
-        "//executorch/kernels/portable:custom_ops_generated_lib",
-        "//executorch/kernels/quantized:custom_ops_generated_lib",
+        "//executorch/kernels/portable:python_preload_generated_lib",
+        "//executorch/kernels/quantized:python_preload_generated_lib",
         # the executor backend is prebuilt and linked when building the unit test binary. When it's linked, it'll register the backend.
         # It can also be loaded in PyThon runtime via torch.ops.load_library("//executorch/exir/backend/test/demos/rpc:executor_backend")
         # However, it's a better practice to build/link everything at earlier stage, instead of during runtime

--- a/exir/backend/test/test_backends.py
+++ b/exir/backend/test/test_backends.py
@@ -988,7 +988,7 @@ class TestBackends(unittest.TestCase):
 
     def test_quantized_with_delegate(self) -> None:
         torch.ops.load_library(
-            "//executorch/kernels/quantized:custom_ops_generated_lib"
+            "//executorch/kernels/quantized:python_preload_generated_lib"
         )
         qconfig_mapping = get_default_qconfig_mapping("qnnpack")
         in_size = 2

--- a/exir/backend/test/test_backends_lifted.py
+++ b/exir/backend/test/test_backends_lifted.py
@@ -968,7 +968,7 @@ class TestBackends(unittest.TestCase):
 
     def test_quantized_with_delegate(self) -> None:
         torch.ops.load_library(
-            "//executorch/kernels/quantized:custom_ops_generated_lib"
+            "//executorch/kernels/quantized:python_preload_generated_lib"
         )
         qconfig_mapping = get_default_qconfig_mapping("qnnpack")
         in_size = 2

--- a/exir/operator/convert.py
+++ b/exir/operator/convert.py
@@ -259,7 +259,7 @@ def to_out_variant(op_overload: OpOverload) -> Tuple[OpOverload, Tuple[str]]:
         out_var = _func_to_out_variant_map.get(op_overload)
 
     if not out_var:
-        msg = f"Missing out variant for functional op: {schema} . Make sure you have loaded your custom operator library for compiler. E.g., custom_ops_generated_lib"
+        msg = f"Missing out variant for functional op: {schema} . Make sure you have loaded your custom operator library for compiler. E.g., python_preload_generated_lib"
         if op_overload in _schema_mismatch_map:
             if _schema_mismatch_map[op_overload]:
                 msg += (

--- a/exir/tests/TARGETS
+++ b/exir/tests/TARGETS
@@ -141,7 +141,7 @@ python_unittest(
         "test_op_convert.py",
     ],
     preload_deps = [
-        "//executorch/kernels/portable:custom_ops_generated_lib",
+        "//executorch/kernels/portable:python_preload_generated_lib",
         ":test_lib",  # @manual
     ],
     deps = [
@@ -156,7 +156,7 @@ python_unittest(
         "test_memory_planning.py",
     ],
     preload_deps = [
-        "//executorch/kernels/portable:custom_ops_generated_lib",
+        "//executorch/kernels/portable:python_preload_generated_lib",
     ],
     # Static listing does not support tests generated with parameterized
     supports_static_listing = False,
@@ -274,7 +274,7 @@ python_unittest(
         "test_quant_fusion_pass.py",
     ],
     preload_deps = [
-        "//executorch/kernels/quantized:custom_ops_generated_lib",
+        "//executorch/kernels/quantized:python_preload_generated_lib",
     ],
     deps = [
         ":lib",
@@ -290,7 +290,7 @@ python_unittest(
         "test_quantization.py",
     ],
     preload_deps = [
-        "//executorch/kernels/quantized:custom_ops_generated_lib",
+        "//executorch/kernels/quantized:python_preload_generated_lib",
     ],
     deps = [
         "fbsource//third-party/pypi/expecttest:expecttest",  # @manual

--- a/exir/tests/test_memory_planning.py
+++ b/exir/tests/test_memory_planning.py
@@ -50,7 +50,7 @@ from torch.export.exported_program import ExportGraphSignature
 from torch.fx import Graph, GraphModule, Node
 from torch.nn import functional as F
 
-torch.ops.load_library("//executorch/kernels/portable:custom_ops_generated_lib")
+torch.ops.load_library("//executorch/kernels/portable:python_preload_generated_lib")
 
 
 def swap_modules(

--- a/exir/tests/test_quantization.py
+++ b/exir/tests/test_quantization.py
@@ -33,7 +33,7 @@ from torch.testing import FileCheck
 from torch.testing._internal.common_quantized import override_quantized_engine
 
 # load executorch out variant ops
-torch.ops.load_library("//executorch/kernels/quantized:custom_ops_generated_lib")
+torch.ops.load_library("//executorch/kernels/quantized:python_preload_generated_lib")
 
 
 class TestQuantization(unittest.TestCase):

--- a/kernels/quantized/targets.bzl
+++ b/kernels/quantized/targets.bzl
@@ -30,7 +30,7 @@ def define_common_targets():
 
     # lib used to register quantized ops into EXIR
     exir_custom_ops_aot_lib(
-        name = "custom_ops_generated_lib",
+        name = "python_preload_generated_lib",
         yaml_target = ":quantized.yaml",
         visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
         kernels = [":quantized_operators_aten"],
@@ -40,7 +40,7 @@ def define_common_targets():
     )
 
     # lib used to register quantized ops into EXIR
-    # TODO: merge this with custom_ops_generated_lib
+    # TODO: merge this with python_preload_generated_lib
     exir_custom_ops_aot_lib(
         name = "aot_lib",
         yaml_target = ":quantized.yaml",

--- a/kernels/quantized/test/TARGETS
+++ b/kernels/quantized/test/TARGETS
@@ -9,7 +9,7 @@ python_unittest(
     name = "test_out_variants",
     srcs = ["test_out_variants.py"],
     preload_deps = [
-        "//executorch/kernels/quantized:custom_ops_generated_lib",
+        "//executorch/kernels/quantized:python_preload_generated_lib",
     ],
     deps = [
         "//caffe2:torch",

--- a/sdk/bundled_program/test/TARGETS
+++ b/sdk/bundled_program/test/TARGETS
@@ -53,7 +53,7 @@ python_unittest(
         "//executorch/exir/tests:transformer",
         "//executorch/extension/pybindings:portable_lib",
         "//executorch/extension/pytree:pybindings",
-        "//executorch/kernels/portable:custom_ops_generated_lib",
+        "//executorch/kernels/portable:python_preload_generated_lib",
         "//executorch/sdk/bundled_program:config",
         "//executorch/sdk/bundled_program:core",
         "//executorch/sdk/bundled_program/serialize:lib",

--- a/shim/xplat/executorch/codegen/codegen.bzl
+++ b/shim/xplat/executorch/codegen/codegen.bzl
@@ -428,7 +428,7 @@ def executorch_generated_lib(
     Generates
     * `<name>` C++ library responsible to register both ATen operators and custom ops
         into Executorch runtime.
-    * `custom_ops_<name>` C++ library responsible to register custom ops into PyTorch
+    * `python_preload_<name>` C++ library responsible to register custom ops into PyTorch python
         runtime.
     Args:
         name: The name of the C++ library target to emit. Also emits a
@@ -436,7 +436,7 @@ def executorch_generated_lib(
             the signatures for the C++ functions that map to the entries in
             `functions.yaml` and `custom_ops.yaml`.
             If `custom_ops_yaml_target` is specified, also emits:
-            - `custom_ops_<name>`: A host-only C++ library that declares and
+            - `python_preload_<name>`: A host-only C++ library that declares and
               registers the ops defined in that file. Clients can load this
               library into local PyTorch using `torch.ops.load_library()` to
               make them visible while authoring models.
@@ -628,7 +628,7 @@ def executorch_generated_lib(
 
     if custom_ops_yaml_target and custom_ops_requires_aot_registration:
         exir_custom_ops_aot_lib(
-            name = "custom_ops_" + name,
+            name = "python_preload_" + name,
             yaml_target = custom_ops_yaml_target,
             visibility = visibility,
             kernels = custom_ops_aten_kernel_deps,

--- a/test/end2end/TARGETS
+++ b/test/end2end/TARGETS
@@ -37,7 +37,7 @@ python_unittest(
     srcs = [
         "test_end2end.py",
     ],
-    preload_deps = ["//executorch/kernels/portable:custom_ops_generated_lib"],
+    preload_deps = ["//executorch/kernels/portable:python_preload_generated_lib"],
     deps = [
         ":exported_module",
         ":register_scratch_meta_fns",
@@ -68,7 +68,7 @@ python_unittest(
     srcs = [
         "test_end2end.py",
     ],
-    preload_deps = ["//executorch/kernels/portable:custom_ops_generated_lib"],
+    preload_deps = ["//executorch/kernels/portable:python_preload_generated_lib"],
     deps = [
         ":exported_module",
         ":register_scratch_meta_fns",

--- a/test/end2end/register_scratch_meta_fns.py
+++ b/test/end2end/register_scratch_meta_fns.py
@@ -22,7 +22,7 @@ from executorch.exir.operator.manip import (
 )
 from executorch.exir.tensor import TensorSpec
 
-torch.ops.load_library("//executorch/kernels/portable:custom_ops_generated_lib")
+torch.ops.load_library("//executorch/kernels/portable:python_preload_generated_lib")
 
 
 @attach_get_scratch_metas_fn(torch.ops.aten.linear.out)


### PR DESCRIPTION
Summary: custom_ops... is only supposed to be used as a dependency of python libs to register the ops in the aot space. This is confusing when users write custom ops and are trying to include them in cpp

Differential Revision: D57972206


