### PR TITLE
[executorch] Manual LICM for mutable/const_data_ptr calls in quantize ops

### DIFF
--- a/kernels/quantized/cpu/op_dequantize.cpp
+++ b/kernels/quantized/cpu/op_dequantize.cpp
@@ -91,15 +91,16 @@ Tensor& dequantize_per_tensor_out(
 
   // calculate the dequantized output, cast scale to float to match fbgemm
   // behavior
-#define DEQUANTIZE_IMPL(IN_CTYPE, OUT_CTYPE, out_dtype)              \
-  case ScalarType::out_dtype:                                        \
-    for (size_t i = 0; i < input.numel(); i++) {                     \
-      out.mutable_data_ptr<OUT_CTYPE>()[i] = static_cast<OUT_CTYPE>( \
-          (input.const_data_ptr<IN_CTYPE>()[i] -                     \
-           static_cast<int32_t>(zero_point)) *                       \
-          static_cast<float>(scale));                                \
-    }                                                                \
-    break;
+#define DEQUANTIZE_IMPL(IN_CTYPE, OUT_CTYPE, out_dtype)            \
+  case ScalarType::out_dtype: {                                    \
+    auto* out_data_ptr = out.mutable_data_ptr<OUT_CTYPE>();        \
+    const auto* input_data_ptr = input.const_data_ptr<IN_CTYPE>(); \
+    for (size_t i = 0; i < input.numel(); i++) {                   \
+      out_data_ptr[i] = static_cast<OUT_CTYPE>(                    \
+          (input_data_ptr[i] - static_cast<int32_t>(zero_point)) * \
+          static_cast<float>(scale));                              \
+    }                                                              \
+  } break;
 #define CALCULATE_INT_TYPE(IN_CTYPE, in_dtype)               \
   case ScalarType::in_dtype:                                 \
     switch (out.scalar_type()) {                             \
@@ -255,11 +256,12 @@ Tensor& dequantize_per_channel_out(
       if (zero_point_data != nullptr) {                                        \
         _zero_point = zero_point_data[channel_ix];                             \
       }                                                                        \
+      auto* out_data_ptr = out.mutable_data_ptr<CTYPE_OUT>();                  \
+      const auto* input_data_ptr = input.const_data_ptr<CTYPE_IN>();           \
       apply_over_dim_list(                                                     \
-          [input, out, _scale, _zero_point](size_t in_ix) {                    \
-            out.mutable_data_ptr<CTYPE_OUT>()[in_ix] = static_cast<CTYPE_OUT>( \
-                (input.const_data_ptr<CTYPE_IN>()[in_ix] - _zero_point) *      \
-                _scale);                                                       \
+          [input_data_ptr, out_data_ptr, _scale, _zero_point](size_t in_ix) {  \
+            out_data_ptr[in_ix] = static_cast<CTYPE_OUT>(                      \
+                (input_data_ptr[in_ix] - _zero_point) * _scale);               \
           },                                                                   \
           input,                                                               \
           optional_dim_list,                                                   \

--- a/kernels/quantized/cpu/op_quantize.cpp
+++ b/kernels/quantized/cpu/op_quantize.cpp
@@ -118,15 +118,16 @@ Tensor& quantize_per_tensor_out(
   check_quantize_per_tensor_args(input, quant_min, quant_max, dtype, out);
 
   // calculate the quantized input
-#define QUANTIZE_IMPL(IN_CTYPE, OUT_CTYPE, out_dtype)          \
-  case ScalarType::out_dtype:                                  \
-    for (size_t i = 0; i < input.numel(); i++) {               \
-      IN_CTYPE value = input.const_data_ptr<IN_CTYPE>()[i];    \
-      out.mutable_data_ptr<OUT_CTYPE>()[i] =                   \
-          quantize_val<OUT_CTYPE, IN_CTYPE>(                   \
-              scale, zero_point, value, quant_min, quant_max); \
-    }                                                          \
-    break;
+#define QUANTIZE_IMPL(IN_CTYPE, OUT_CTYPE, out_dtype)              \
+  case ScalarType::out_dtype: {                                    \
+    auto* out_data_ptr = out.mutable_data_ptr<OUT_CTYPE>();        \
+    const auto* input_data_ptr = input.const_data_ptr<IN_CTYPE>(); \
+    for (size_t i = 0; i < input.numel(); i++) {                   \
+      IN_CTYPE value = input_data_ptr[i];                          \
+      out_data_ptr[i] = quantize_val<OUT_CTYPE, IN_CTYPE>(         \
+          scale, zero_point, value, quant_min, quant_max);         \
+    }                                                              \
+  } break;
 #define CALCULATE_FLOAT_TYPE(IN_CTYPE, in_dtype)         \
   case ScalarType::in_dtype:                             \
     switch (out.scalar_type()) {                         \
@@ -306,16 +307,21 @@ Tensor& quantize_per_channel_out(
     for (size_t channel_ix = 0; channel_ix < input.size(axis); ++channel_ix) { \
       double _scale = scale_data[channel_ix];                                  \
       int64_t _zero_point = zero_point_data[channel_ix];                       \
+      auto* out_data_ptr = out.mutable_data_ptr<CTYPE_OUT>();                  \
+      const auto* input_data_ptr = input.const_data_ptr<CTYPE_IN>();           \
       apply_over_dim_list(                                                     \
-          [input, out, _scale, _zero_point, quant_min, quant_max](             \
-              size_t in_ix) {                                                  \
-            out.mutable_data_ptr<CTYPE_OUT>()[in_ix] =                         \
-                quantize_val<CTYPE_OUT, CTYPE_IN>(                             \
-                    _scale,                                                    \
-                    _zero_point,                                               \
-                    input.const_data_ptr<CTYPE_IN>()[in_ix],                   \
-                    quant_min,                                                 \
-                    quant_max);                                                \
+          [input_data_ptr,                                                     \
+           out_data_ptr,                                                       \
+           _scale,                                                             \
+           _zero_point,                                                        \
+           quant_min,                                                          \
+           quant_max](size_t in_ix) {                                          \
+            out_data_ptr[in_ix] = quantize_val<CTYPE_OUT, CTYPE_IN>(           \
+                _scale,                                                        \
+                _zero_point,                                                   \
+                input_data_ptr[in_ix],                                         \
+                quant_min,                                                     \
+                quant_max);                                                    \
           },                                                                   \
           input,                                                               \
           optional_dim_list,                                                   \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3785
* __->__ #3784

Profiling showed that these calls were not getting inlined in ATen mode. Since function calls can have side effects, lack of inlining prevented the compiler from doing this transform itself.

Differential Revision: [D57987182](https://our.internmc.facebook.com/intern/diff/D57987182/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D57987182/)!