### PR TITLE
[executorch] Manual LICM for numel() in quantize ops

### DIFF
--- a/kernels/quantized/cpu/op_dequantize.cpp
+++ b/kernels/quantized/cpu/op_dequantize.cpp
@@ -95,7 +95,8 @@ Tensor& dequantize_per_tensor_out(
   case ScalarType::out_dtype: {                                    \
     auto* out_data_ptr = out.mutable_data_ptr<OUT_CTYPE>();        \
     const auto* input_data_ptr = input.const_data_ptr<IN_CTYPE>(); \
-    for (size_t i = 0; i < input.numel(); i++) {                   \
+    const auto input_numel = input.numel();                        \
+    for (size_t i = 0; i < input_numel; i++) {                     \
       out_data_ptr[i] = static_cast<OUT_CTYPE>(                    \
           (input_data_ptr[i] - static_cast<int32_t>(zero_point)) * \
           static_cast<float>(scale));                              \

--- a/kernels/quantized/cpu/op_quantize.cpp
+++ b/kernels/quantized/cpu/op_quantize.cpp
@@ -122,7 +122,8 @@ Tensor& quantize_per_tensor_out(
   case ScalarType::out_dtype: {                                    \
     auto* out_data_ptr = out.mutable_data_ptr<OUT_CTYPE>();        \
     const auto* input_data_ptr = input.const_data_ptr<IN_CTYPE>(); \
-    for (size_t i = 0; i < input.numel(); i++) {                   \
+    const auto input_numel = input.numel();                        \
+    for (size_t i = 0; i < input_numel; i++) {                     \
       IN_CTYPE value = input_data_ptr[i];                          \
       out_data_ptr[i] = quantize_val<OUT_CTYPE, IN_CTYPE>(         \
           scale, zero_point, value, quant_min, quant_max);         \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3785
* #3784

Profiling showed that numel() is not getting inlined, which was preventing optimization.

Differential Revision: [D57988068](https://our.internmc.facebook.com/intern/diff/D57988068/)