### PR TITLE
[Release Only][pyproject.toml] Also pin torchvision and torchaudio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ dependencies=[
   "sympy",
   "tabulate",
   "torch==2.3",
+  "torchvision==0.18",
+  "torchaudio==2.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
T186838701, the CI already build torch and all domain libraries (vision, audio) from scratch using pinned commits, but having `torch==2.3` in pyproject.toml overwrites torch installation with 2.3 release.

I think this is a consistent way to fix the issue because:

* Vision and audio are needed in some cases
* Vision and audio need to be compatible with the torch version to work. Assuming that someone install executorch 0.2 which will overwrite their local torch installation, they would also need the corresponding vision and audio.  If they have an existing installation of vision/audio around, it would likely fail
* It's a simple fix

The con is that install executorch 0.2 will always install torch, vision, and audio.  However, that might not be that bad because that's how the installation instruction on https://pytorch.org/get-started/locally/ says anyway.