### PR TITLE
Clean up Shader Profiling Capability

### DIFF
--- a/backends/vulkan/runtime/api/Context.h
+++ b/backends/vulkan/runtime/api/Context.h
@@ -67,11 +67,7 @@ class Context final {
   DescriptorPool descriptor_pool_;
   FencePool fences_;
   // Diagnostics
-  // TODO: remove USE_VULKAN_GPU_DIAGNOSTICS
-  bool enable_op_profiling_{false};
-#ifdef USE_VULKAN_GPU_DIAGNOSTICS
   QueryPool querypool_;
-#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
   // Command buffers submission
   std::mutex cmd_mutex_;
   CommandBuffer cmd_;
@@ -87,18 +83,6 @@ class Context final {
 
   inline Adapter* adapter_ptr() {
     return adapter_p_;
-  }
-
-  inline void enable_op_profiling() {
-    enable_op_profiling_ = true;
-  }
-
-  inline void disable_op_profiling() {
-    enable_op_profiling_ = false;
-  }
-
-  inline bool op_profiling_enabled() {
-    return enable_op_profiling_;
   }
 
   inline VkDevice device() {
@@ -139,18 +123,42 @@ class Context final {
 
   // Diagnostics
 
-#ifdef USE_VULKAN_GPU_DIAGNOSTICS
   inline QueryPool& querypool() {
     return querypool_;
   }
 
-  inline void reset_querypool() {
-    set_cmd();
-    querypool_.reset(cmd_);
-  }
-#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
+  /*
+   * By default, the querypool attached to a Context instance is uninitialized.
+   * This function triggers the querypool to be created via vkCreateQueryPool.
+   */
+  void initialize_querypool();
+
+  /*
+   * Encodes a vkResetQueryPool command to the current command buffer, and reset
+   * the internal state of the querypool. If the querypool is not initialized
+   * this function is a no-op.
+   */
+  void cmd_reset_querypool();
+
+  /*
+   * Encodes a vkCmdWriteTimestamp command to the current command buffer and
+   * record some metadata about the shader that will be dispatched. If the
+   * querypool is not initialized this function is a no-op.
+   */
+  void report_shader_dispatch_start(
+      const std::string& shader_name,
+      const utils::uvec3& global_wg_size,
+      const utils::uvec3& local_wg_size);
+
+  /*
+   * Encodes a vkCmdWriteTimstamp command to the current command buffer to
+   * record when the last shader that was dispatched has completed execution.
+   * If the querypool is not initialized this function is a no-op.
+   */
+  void report_shader_dispatch_end();
 
   // Memory Management
+
   void register_buffer_cleanup(VulkanBuffer& buffer) {
     std::lock_guard<std::mutex> bufferlist_lock(buffer_clearlist_mutex_);
     buffers_to_clear_.emplace_back(std::move(buffer));
@@ -468,24 +476,14 @@ inline bool Context::submit_copy(
 
   set_cmd();
 
-#ifdef USE_VULKAN_GPU_DIAGNOSTICS
-  uint32_t log_idx = UINT32_MAX;
-  if (enable_op_profiling_) {
-    std::string label = "cmd_copy";
-    log_idx = querypool_.shader_profile_begin(
-        cmd_, label, create_extent3d({0, 0, 0}), create_extent3d({0, 0, 0}));
-  }
-#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
+  std::string label = "cmd_copy";
+  report_shader_dispatch_start(label, {0, 0, 0}, {0, 0, 0});
 
   cmd_.insert_barrier(pipeline_barrier);
 
   record_copy(cmd_, source, destination, copy_range, src_offset, dst_offset);
 
-#ifdef USE_VULKAN_GPU_DIAGNOSTICS
-  if (enable_op_profiling_) {
-    querypool_.shader_profile_end(cmd_, log_idx);
-  }
-#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
+  report_shader_dispatch_end();
 
   submit_count_++;
   if (fence_handle != VK_NULL_HANDLE ||
@@ -540,16 +538,8 @@ inline bool Context::submit_compute_job(
 
   set_cmd();
 
-#ifdef USE_VULKAN_GPU_DIAGNOSTICS
-  uint32_t log_idx = UINT32_MAX;
-  if (enable_op_profiling_) {
-    log_idx = querypool_.shader_profile_begin(
-        cmd_,
-        shader.kernel_name,
-        create_extent3d(global_work_group),
-        create_extent3d(local_work_group_size));
-  }
-#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
+  report_shader_dispatch_start(
+      shader.kernel_name, global_work_group, local_work_group_size);
 
   // Factor out template parameter independent code to minimize code bloat.
   DescriptorSet descriptor_set = get_descriptor_set(
@@ -564,11 +554,7 @@ inline bool Context::submit_compute_job(
   register_shader_dispatch(
       descriptor_set, pipeline_barrier, shader, global_work_group);
 
-#ifdef USE_VULKAN_GPU_DIAGNOSTICS
-  if (enable_op_profiling_) {
-    querypool_.shader_profile_end(cmd_, log_idx);
-  }
-#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
+  report_shader_dispatch_end();
 
   submit_count_++;
   if (fence_handle != VK_NULL_HANDLE ||

--- a/backends/vulkan/runtime/api/QueryPool.h
+++ b/backends/vulkan/runtime/api/QueryPool.h
@@ -49,6 +49,20 @@ struct ShaderDuration final {
 };
 
 class QueryPool final {
+  // Configuration
+  QueryPoolConfig config_;
+  uint64_t ns_per_tick_;
+
+  // Vulkan handles
+  VkDevice device_;
+  VkQueryPool querypool_;
+
+  // Internal State
+  uint32_t num_queries_;
+  std::vector<ShaderDuration> shader_durations_;
+
+  std::mutex mutex_;
+
  public:
   explicit QueryPool(const QueryPoolConfig&, const Adapter* adapter_p);
 
@@ -60,68 +74,32 @@ class QueryPool final {
 
   ~QueryPool();
 
- private:
-  std::mutex mutex_;
-
-  VkDevice device_;
-  QueryPoolConfig config_;
-
-  VkQueryPool querypool_;
-
-  std::vector<std::vector<ShaderDuration>> shader_logs_;
-  size_t in_use_;
-
-  /** Total number of entries in shader logs from before most recent reset */
-  size_t previous_shader_count_;
-
-  /**
-   * Indicates whether there are new log entries in the shader log since the
-   * most recent call to extract_results()
-   */
-  bool results_pending_;
+  void initialize(const Adapter* adapter_p);
 
  private:
   size_t write_timestamp(const CommandBuffer&);
 
-  std::string generate_string_report();
-
-  /** Most recent shader log since the last time the QueryPool was reset */
-  inline std::vector<ShaderDuration>& shader_log() {
-    return shader_logs_[shader_logs_.size() - 1];
-  }
-
-  /** Total number of entries in all shader logs, but without locking mutex */
-  size_t shader_logs_entry_count_thread_unsafe();
-
  public:
-  inline bool is_enabled() const {
-    return VK_NULL_HANDLE != querypool_;
-  }
+  void reset_querypool(const CommandBuffer&);
 
-  void reset(const CommandBuffer&);
+  void reset_state();
 
-  uint32_t shader_profile_begin(
+  void shader_profile_begin(
       const CommandBuffer&,
       const std::string&,
       const VkExtent3D,
       const VkExtent3D);
-  void shader_profile_end(const CommandBuffer&, const uint32_t);
+
+  void shader_profile_end(const CommandBuffer&);
 
   void extract_results();
+
+  std::string generate_string_report();
   void print_results();
-  uint64_t get_total_op_ns(const std::string& op_name);
-  uint64_t ns_per_tick_;
-  void shader_log_for_each(std::function<void(const ShaderDuration&)> fn);
-  /**
-   * query_index is what number entry across all of the QueryPool's shader logs
-   * is being queried, regardless of resets. This may be different than
-   * ShaderDuration's idx field, which is what number entry it is since the last
-   * reset before it was added to the shader logs.
-   */
-  std::tuple<std::string, uint64_t> get_shader_name_and_execution_duration_ns(
-      size_t query_index);
-  /** Total number of entries in all shader logs */
-  size_t shader_logs_entry_count();
+
+  operator bool() const {
+    return querypool_ != VK_NULL_HANDLE;
+  }
 };
 
 } // namespace api

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -385,6 +385,10 @@ void ComputeGraph::prepare() {
     context_->descriptor_pool().init(config);
   }
 #undef MERGE_FIELD
+
+  if (config_.enable_querypool) {
+    context_->initialize_querypool();
+  }
 }
 
 void ComputeGraph::encode_prepack() {
@@ -405,6 +409,8 @@ void ComputeGraph::prepack() const {
 void ComputeGraph::encode_execute() {
   context_->flush();
   context_->set_cmd(/*reusable = */ true);
+
+  context_->cmd_reset_querypool();
 
   for (SharedObject& shared_object : shared_objects_) {
     shared_object.allocate(this);

--- a/backends/vulkan/runtime/graph/GraphConfig.cpp
+++ b/backends/vulkan/runtime/graph/GraphConfig.cpp
@@ -56,6 +56,10 @@ GraphConfig::GraphConfig() {
   // settings will be serialized as part of the graph.
   enable_memory_layout_override = true;
   memory_layout_override = api::kWidthPacked;
+
+  // QueryPool objects are used to measure execution times of individual shader
+  // dispatches. By default, this functionality is disabled.
+  enable_querypool = false;
 }
 
 void GraphConfig::set_storage_type_override(api::StorageType storage_type) {

--- a/backends/vulkan/runtime/graph/GraphConfig.h
+++ b/backends/vulkan/runtime/graph/GraphConfig.h
@@ -28,6 +28,8 @@ struct GraphConfig final {
   bool enable_memory_layout_override;
   api::GPUMemoryLayout memory_layout_override;
 
+  bool enable_querypool;
+
   // Generate a default graph config with pre-configured settings
   explicit GraphConfig();
 

--- a/backends/vulkan/runtime/graph/ops/ExecuteNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/ExecuteNode.cpp
@@ -41,6 +41,9 @@ void ExecuteNode::encode(ComputeGraph* graph) {
 
   std::unique_lock<std::mutex> cmd_lock = context->dispatch_lock();
 
+  context->report_shader_dispatch_start(
+      shader_.kernel_name, global_workgroup_size_, local_workgroup_size_);
+
   api::DescriptorSet descriptor_set =
       context->get_descriptor_set(shader_, local_workgroup_size_, spec_vars_);
 
@@ -52,6 +55,8 @@ void ExecuteNode::encode(ComputeGraph* graph) {
 
   context->register_shader_dispatch(
       descriptor_set, pipeline_barrier, shader_, global_workgroup_size_);
+
+  context->report_shader_dispatch_end();
 }
 
 } // namespace vkcompute

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -887,6 +887,7 @@ TEST(VulkanComputeGraphTest, test_simple_graph) {
 
 TEST(VulkanComputeGraphTest, test_simple_prepacked_graph) {
   GraphConfig config;
+  config.enable_querypool = true;
   ComputeGraph graph(config);
 
   std::vector<int64_t> size_big = {8, 73, 62};
@@ -934,6 +935,11 @@ TEST(VulkanComputeGraphTest, test_simple_prepacked_graph) {
     // Sanity check that the values are correct
     for (size_t i = 0; i < graph.get_tensor(out.value)->numel(); ++i) {
       CHECK_VALUE(data_out, i, val_out);
+    }
+
+    if (graph.context()->querypool()) {
+      graph.context()->querypool().extract_results();
+      graph.context()->querypool().print_results();
     }
   }
 }


### PR DESCRIPTION
Summary:
## Context

1. Clean up `QueryPool` class; remove a bunch of unnecessary functionality, rename member functions to be more clear, etc.
2. Rename `USE_VULKAN_GPU_DIAGNOSTICS` to `VULKAN_SHADER_PROFILING_ENABLED`
3. Make it so that `QueryPool` is always included in `Context`; this is to reduce the amount of `#ifdef VULKAN_SHADER_PROFILING_ENABLED` blocks in order to improve readability and developer experience
4. Enable shader profiling in `ComputeGraph`.

Differential Revision: D58016869


