### PR TITLE
Tester: rename inputs to example_inputs

### DIFF
--- a/backends/arm/test/misc/test_debug_feats.py
+++ b/backends/arm/test/misc/test_debug_feats.py
@@ -45,7 +45,7 @@ class TestDumpPartitionedArtifact(unittest.TestCase):
         (
             ArmTester(
                 module,
-                inputs=module.get_inputs(),
+                example_inputs=module.get_inputs(),
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .export()
@@ -59,7 +59,7 @@ class TestDumpPartitionedArtifact(unittest.TestCase):
         (
             ArmTester(
                 module,
-                inputs=module.get_inputs(),
+                example_inputs=module.get_inputs(),
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .quantize()
@@ -101,7 +101,7 @@ class TestNumericalDiffPrints(unittest.TestCase):
         tester = (
             ArmTester(
                 model,
-                inputs=model.get_inputs(),
+                example_inputs=model.get_inputs(),
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .quantize()

--- a/backends/arm/test/models/test_mobilenet_v2_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v2_arm.py
@@ -52,7 +52,7 @@ class TestMobileNetV2(unittest.TestCase):
         tester = (
             ArmTester(
                 self.mv2,
-                inputs=self.model_inputs,
+                example_inputs=self.model_inputs,
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .export()
@@ -72,7 +72,7 @@ class TestMobileNetV2(unittest.TestCase):
         tester = (
             ArmTester(
                 self.mv2,
-                inputs=self.model_inputs,
+                example_inputs=self.model_inputs,
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .quantize()
@@ -102,7 +102,7 @@ class TestMobileNetV2(unittest.TestCase):
         (
             ArmTester(
                 self.mv2,
-                inputs=self.model_inputs,
+                example_inputs=self.model_inputs,
                 compile_spec=common.get_u55_compile_spec(permute_memory_to_nhwc=True),
             )
             .quantize()

--- a/backends/arm/test/ops/test_add.py
+++ b/backends/arm/test/ops/test_add.py
@@ -61,7 +61,7 @@ class TestSimpleAdd(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .export()
@@ -85,7 +85,7 @@ class TestSimpleAdd(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .quantize()
@@ -111,7 +111,7 @@ class TestSimpleAdd(unittest.TestCase):
         (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_u55_compile_spec(),
             )
             .quantize()

--- a/backends/arm/test/ops/test_avg_pool.py
+++ b/backends/arm/test/ops/test_avg_pool.py
@@ -49,7 +49,7 @@ class TestAvgPool2d(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .export()
@@ -74,7 +74,7 @@ class TestAvgPool2d(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .quantize()
@@ -100,7 +100,7 @@ class TestAvgPool2d(unittest.TestCase):
         (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_u55_compile_spec(permute_memory_to_nhwc=True),
             )
             .quantize()

--- a/backends/arm/test/ops/test_batch_norm.py
+++ b/backends/arm/test/ops/test_batch_norm.py
@@ -530,7 +530,7 @@ class TestBatchNorm2d(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .export()
@@ -566,7 +566,7 @@ class TestBatchNorm2d(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .export()
@@ -600,7 +600,7 @@ class TestBatchNorm2d(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .quantize()
@@ -638,7 +638,7 @@ class TestBatchNorm2d(unittest.TestCase):
         (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_u55_compile_spec(),
             )
             .quantize()

--- a/backends/arm/test/ops/test_clone.py
+++ b/backends/arm/test/ops/test_clone.py
@@ -37,7 +37,9 @@ class TestSimpleClone(unittest.TestCase):
     ):
         tester = (
             ArmTester(
-                module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_tosa_compile_spec(),
             )
             .export()
             .check_count({"torch.ops.aten.clone.default": 1})
@@ -59,7 +61,9 @@ class TestSimpleClone(unittest.TestCase):
     ):
         tester = (
             ArmTester(
-                module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_tosa_compile_spec(),
             )
             .quantize()
             .export()
@@ -82,7 +86,9 @@ class TestSimpleClone(unittest.TestCase):
     ):
         (
             ArmTester(
-                module, inputs=test_data, compile_spec=common.get_u55_compile_spec()
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_u55_compile_spec(),
             )
             .quantize()
             .export()

--- a/backends/arm/test/ops/test_conv.py
+++ b/backends/arm/test/ops/test_conv.py
@@ -247,7 +247,7 @@ class TestConv2D(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .export()
@@ -272,7 +272,7 @@ class TestConv2D(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .quantize()
@@ -296,7 +296,7 @@ class TestConv2D(unittest.TestCase):
         (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_u55_compile_spec(permute_memory_to_nhwc=True),
             )
             .quantize()

--- a/backends/arm/test/ops/test_conv_combos.py
+++ b/backends/arm/test/ops/test_conv_combos.py
@@ -160,7 +160,7 @@ class TestConvCombos(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .export()
@@ -187,7 +187,7 @@ class TestConvCombos(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .quantize()
@@ -211,7 +211,7 @@ class TestConvCombos(unittest.TestCase):
         (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_u55_compile_spec(permute_memory_to_nhwc=True),
             )
             .quantize()

--- a/backends/arm/test/ops/test_depthwise_conv.py
+++ b/backends/arm/test/ops/test_depthwise_conv.py
@@ -133,7 +133,7 @@ class TestDepthwiseConv2D(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .export()
@@ -156,7 +156,7 @@ class TestDepthwiseConv2D(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .quantize()
@@ -180,7 +180,7 @@ class TestDepthwiseConv2D(unittest.TestCase):
         (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_u55_compile_spec(permute_memory_to_nhwc=True),
             )
             .quantize()

--- a/backends/arm/test/ops/test_div.py
+++ b/backends/arm/test/ops/test_div.py
@@ -107,7 +107,7 @@ class TestDiv(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .export()
@@ -131,7 +131,7 @@ class TestDiv(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .quantize()
@@ -156,7 +156,7 @@ class TestDiv(unittest.TestCase):
         (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_u55_compile_spec(),
             )
             .quantize()

--- a/backends/arm/test/ops/test_linear.py
+++ b/backends/arm/test/ops/test_linear.py
@@ -119,7 +119,7 @@ class TestLinear(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .export()
@@ -143,7 +143,7 @@ class TestLinear(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .quantize()
@@ -168,7 +168,7 @@ class TestLinear(unittest.TestCase):
         (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_u55_compile_spec(),
             )
             .quantize()

--- a/backends/arm/test/ops/test_mean_dim.py
+++ b/backends/arm/test/ops/test_mean_dim.py
@@ -54,7 +54,7 @@ class TestMeanDim(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .export()
@@ -79,7 +79,7 @@ class TestMeanDim(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(permute_memory_to_nhwc=True),
             )
             .quantize()
@@ -105,7 +105,7 @@ class TestMeanDim(unittest.TestCase):
         (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_u55_compile_spec(permute_memory_to_nhwc=True),
             )
             .quantize()

--- a/backends/arm/test/ops/test_softmax.py
+++ b/backends/arm/test/ops/test_softmax.py
@@ -42,7 +42,7 @@ class TestSoftmax(unittest.TestCase):
         tester = (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .export()
@@ -66,7 +66,9 @@ class TestSoftmax(unittest.TestCase):
     ):
         tester = (
             ArmTester(
-                module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_tosa_compile_spec(),
             )
             .quantize()
             .export()
@@ -91,7 +93,7 @@ class TestSoftmax(unittest.TestCase):
         (
             ArmTester(
                 module,
-                inputs=test_data,
+                example_inputs=test_data,
                 compile_spec=common.get_u55_compile_spec(),
             )
             .quantize()

--- a/backends/arm/test/ops/test_view.py
+++ b/backends/arm/test/ops/test_view.py
@@ -34,7 +34,9 @@ class TestSimpleView(unittest.TestCase):
     ):
         tester = (
             ArmTester(
-                module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_tosa_compile_spec(),
             )
             .export()
             .check_count({"torch.ops.aten.view.default": 1})
@@ -56,7 +58,9 @@ class TestSimpleView(unittest.TestCase):
     ):
         tester = (
             ArmTester(
-                module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_tosa_compile_spec(),
             )
             .quantize()
             .export()
@@ -79,7 +83,9 @@ class TestSimpleView(unittest.TestCase):
     ):
         (
             ArmTester(
-                module, inputs=test_data, compile_spec=common.get_u55_compile_spec()
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_u55_compile_spec(),
             )
             .quantize()
             .export()

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -155,13 +155,13 @@ class ArmTester(Tester):
     def __init__(
         self,
         model: torch.nn.Module,
-        inputs: Tuple[torch.Tensor],
+        example_inputs: Tuple[torch.Tensor],
         compile_spec: List[CompileSpec] = None,
     ):
         """
         Args:
             model (torch.nn.Module): The model to test
-            inputs (Tuple[torch.Tensor]): The inputs to the model
+            example_inputs (Tuple[torch.Tensor]): Example inputs to the model
             compile_spec (List[CompileSpec]): The compile spec to use
         """
 
@@ -173,7 +173,7 @@ class ArmTester(Tester):
 
         self.compile_spec = compile_spec
 
-        super().__init__(model, inputs)
+        super().__init__(model, example_inputs)
 
     def quantize(self, quantize_stage: Optional[Quantize] = None):
         if quantize_stage is None:


### PR DESCRIPTION
Rename inputs to example_inputs to differentiate between what's used as test data and what's used as example/calibration data.

Change-Id: Ibe6e65fd3f6ec14a8f27fe2270595a3835b1e038