### PR TITLE
[Android] Rename so file to match soname

### DIFF
--- a/build/test_android_ci.sh
+++ b/build/test_android_ci.sh
@@ -45,9 +45,11 @@ build_aar() {
    \<uses-sdk android:minSdkVersion=\"19\" /\> \
    \</manifest\> > build_aar/AndroidManifest.xml
   pushd build_aar
+  mv jni/arm64-v8a/libexecutorch_jni.so jni/arm64-v8a/libexecutorch.so
+  mv jni/x86_64/libexecutorch_jni.so jni/x86_64/libexecutorch.so
   zip -r executorch.aar libs jni AndroidManifest.xml
 
-  rm jni/arm64-v8a/libexecutorch_jni.so jni/x86_64/libexecutorch_jni.so
+  rm jni/arm64-v8a/libexecutorch.so jni/x86_64/libexecutorch.so
   zip -r executorch-llama.aar libs jni AndroidManifest.xml
   popd
 }

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -41,7 +41,6 @@ void et_pal_emit_log_message(
     const char* message,
     size_t length) {
   int android_log_level = ANDROID_LOG_UNKNOWN;
-
   if (level == 'D') {
     android_log_level = ANDROID_LOG_DEBUG;
   } else if (level == 'I') {

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -41,6 +41,7 @@ void et_pal_emit_log_message(
     const char* message,
     size_t length) {
   int android_log_level = ANDROID_LOG_UNKNOWN;
+
   if (level == 'D') {
     android_log_level = ANDROID_LOG_DEBUG;
   } else if (level == 'I') {


### PR DESCRIPTION
Java layer expects `libexecutorch.so`. Fix the name in aar.