### PR TITLE
Ignore the FLATC_EXECUTABLE env var when empty

### DIFF
--- a/exir/_serialize/_flatbuffer.py
+++ b/exir/_serialize/_flatbuffer.py
@@ -201,7 +201,9 @@ def _run_flatc(args: Sequence[str]) -> None:
             subprocess.run([flatc_path] + list(args), check=True)
     else:
         # Expect the `flatc` tool to be on the system path or set as an env var.
-        flatc_path = os.getenv("FLATC_EXECUTABLE", "flatc")
+        flatc_path = os.getenv("FLATC_EXECUTABLE")
+        if not flatc_path:
+            flatc_path = "flatc"
         subprocess.run([flatc_path] + list(args), check=True)
 
 


### PR DESCRIPTION
We've seen some situations fail because flatc_path is an empty string. This seems like a likely culprit, but doesn't hurt either way.