### PR TITLE
Add modelname argument to export_llama, to export more model types

### DIFF
--- a/examples/models/llama2/export_llama.py
+++ b/examples/models/llama2/export_llama.py
@@ -20,10 +20,9 @@ logging.basicConfig(level=logging.INFO, format=FORMAT)
 def main() -> None:
     seed = 42
     torch.manual_seed(seed)
-    modelname = "llama2"
     parser = build_args_parser()
     args = parser.parse_args()
-    export_llama(modelname, args)
+    export_llama(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We are using export_llama to export a variety of models. Before moving the flow to a proper location, we extend it's capability of exporting other models by modelname. 

Test:
```
 % python3 -m examples.models.llama2.export_llama -p /Users/myuan/data/llama/story110m/params.json -c /Users/myuan/data/llama/story110m/checkpoint.pt --modelname stories
[INFO 2024-06-03 14:21:34,742 export_llama_lib.py:397] Applying quantizers: []
[INFO 2024-06-03 14:21:34,742 builder.py:91] Loading model with checkpoint=/Users/myuan/data/llama/story110m/checkpoint.pt, params=/Users/myuan/data/llama/story110m/params.json, use_kv_cache=False, weight_type=WeightType.LLAMA
[INFO 2024-06-03 14:21:34,763 builder.py:112] Loaded model with dtype=torch.float32
[INFO 2024-06-03 14:21:37,946 builder.py:285] Using pt2e [] to quantizing the model...
[INFO 2024-06-03 14:21:37,946 builder.py:305] No quantizer provided, passing...
[INFO 2024-06-03 14:21:55,367 builder.py:383] Required memory for activation in bytes: [0, 158066176]
[INFO 2024-06-03 14:21:55,751 utils.py:114] Saved exported program to ./stories.pte
```