### PR TITLE
Improve the workflow for Android prebuilt

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - .ci/docker/**
       - .github/workflows/android.yml
+      - build/build_android_library.sh
+      - build/test_android_ci.sh
       - install_requirements.sh
       - examples/demo-apps/android/**
       - extension/android/**

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -47,6 +47,8 @@ jobs:
         BUILD_TOOL=${{ matrix.build-tool }}
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "${BUILD_TOOL}"
+        # Build Android library
+        bash build/build_android_library.sh
         # Build Android demo app
         bash build/test_android_ci.sh
 

--- a/build/build_android_library.sh
+++ b/build/build_android_library.sh
@@ -17,7 +17,7 @@ build_jar() {
 build_android_native_library() {
   ANDROID_ABI="$1"
   ANDROID_NDK="${ANDROID_NDK:-/opt/ndk}"
-  CMAKE_OUT="${cmake-out-android-$1}"
+  CMAKE_OUT="cmake-out-android-$1"
   EXECUTORCH_USE_TIKTOKEN="${EXECUTORCH_USE_TIKTOKEN:-OFF}"
   cmake . -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
     -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \

--- a/build/build_android_library.sh
+++ b/build/build_android_library.sh
@@ -78,7 +78,7 @@ build_aar() {
   # between Java and JNI
   mv jni/arm64-v8a/libexecutorch_jni.so jni/arm64-v8a/libexecutorch.so
   mv jni/x86_64/libexecutorch_jni.so jni/x86_64/libexecutorch.so
-  zip -r executorch.aar jni/arm64-v8a/libexecutorch.so jni/x86_64/libexecutorch.so jni AndroidManifest.xml
+  zip -r executorch.aar libs jni/arm64-v8a/libexecutorch.so jni/x86_64/libexecutorch.so AndroidManifest.xml
 
   rm jni/arm64-v8a/libexecutorch.so jni/x86_64/libexecutorch.so
   zip -r executorch-llama.aar libs jni/arm64-v8a/libexecutorch_llama_jni.so jni/x86_64/libexecutorch_llama_jni.so AndroidManifest.xml

--- a/build/build_android_library.sh
+++ b/build/build_android_library.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -ex
+
+build_jar() {
+  pushd extension/android
+  ./gradlew build
+  popd
+  cp extension/android/build/libs/executorch.jar build_aar/libs
+}
+
+build_android_native_library() {
+  ANDROID_ABI="$1"
+  ANDROID_NDK="${ANDROID_NDK:-/opt/ndk}"
+  CMAKE_OUT="${cmake-out-android-$1}"
+  EXECUTORCH_USE_TIKTOKEN="${EXECUTORCH_USE_TIKTOKEN:-OFF}"
+  cmake . -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
+    -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
+    -DANDROID_ABI="${ANDROID_ABI}" \
+    -DANDROID_PLATFORM=android-23 \
+    -DEXECUTORCH_BUILD_XNNPACK=ON \
+    -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
+    -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
+    -DEXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON \
+    -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON \
+    -DEXECUTORCH_BUILD_KERNELS_CUSTOM=ON \
+    -DCMAKE_BUILD_TYPE=Release \
+    -B"${CMAKE_OUT}"
+
+  if [ "$(uname)" == "Darwin" ]; then
+    CMAKE_JOBS=$(( $(sysctl -n hw.ncpu) - 1 ))
+  else
+    CMAKE_JOBS=$(( $(nproc) - 1 ))
+  fi
+  cmake --build "${CMAKE_OUT}" -j "${CMAKE_JOBS}" --target install --config Release
+
+  cmake examples/models/llama2 \
+    -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+    -DANDROID_ABI="$ANDROID_ABI" \
+    -DANDROID_PLATFORM=android-23 \
+    -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
+    -DEXECUTORCH_USE_TIKTOKEN="${EXECUTORCH_USE_TIKTOKEN}" \
+    -DEXECUTORCH_BUILD_KERNELS_CUSTOM=ON \
+    -DEXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON \
+    -DEXECUTORCH_BUILD_XNNPACK=ON \
+    -DCMAKE_BUILD_TYPE=Release \
+    -B"${CMAKE_OUT}"/examples/models/llama2
+
+  cmake --build "${CMAKE_OUT}"/examples/models/llama2 -j "${CMAKE_JOBS}" --config Release
+
+  cmake extension/android \
+    -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
+    -DANDROID_ABI="${ANDROID_ABI}" \
+    -DANDROID_PLATFORM=android-23 \
+    -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
+    -DEXECUTORCH_BUILD_LLAMA_JNI=ON \
+    -DEXECUTORCH_USE_TIKTOKEN="${EXECUTORCH_USE_TIKTOKEN}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -B"${CMAKE_OUT}"/extension/android
+
+  cmake --build "${CMAKE_OUT}"/extension/android -j "${CMAKE_JOBS}" --config Release
+
+  cp "${CMAKE_OUT}"/extension/android/*.so build_aar/jni/$1/
+}
+
+build_aar() {
+  echo \<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" \
+   package=\"org.pytorch.executorch\"\> \
+   \<uses-sdk android:minSdkVersion=\"19\" /\> \
+   \</manifest\> > build_aar/AndroidManifest.xml
+  pushd build_aar
+  # Rename libexecutorch_jni.so to libexecutorch.so for soname consistency
+  # between Java and JNI
+  mv jni/arm64-v8a/libexecutorch_jni.so jni/arm64-v8a/libexecutorch.so
+  mv jni/x86_64/libexecutorch_jni.so jni/x86_64/libexecutorch.so
+  zip -r executorch.aar jni/arm64-v8a/libexecutorch.so jni/x86_64/libexecutorch.so jni AndroidManifest.xml
+
+  rm jni/arm64-v8a/libexecutorch.so jni/x86_64/libexecutorch.so
+  zip -r executorch-llama.aar libs jni/arm64-v8a/libexecutorch_llama_jni.so jni/x86_64/libexecutorch_llama_jni.so AndroidManifest.xml
+  popd
+}
+
+mkdir -p build_aar/jni/arm64-v8a build_aar/jni/x86_64 build_aar/libs
+build_jar
+build_android_native_library arm64-v8a
+build_android_native_library x86_64
+build_aar

--- a/build/test_android_ci.sh
+++ b/build/test_android_ci.sh
@@ -18,13 +18,6 @@ export_model() {
   cp "${MODEL_NAME}_xnnpack_fp32.pte" "${ASSETS_DIR}"
 }
 
-build_android_native_library() {
-  pushd examples/demo-apps/android/LlamaDemo
-  CMAKE_OUT="cmake-out-android-$1" ANDROID_NDK=/opt/ndk ANDROID_ABI="$1" ./gradlew setup
-  popd
-  cp "cmake-out-android-$1"/extension/android/*.so build_aar/jni/$1/
-}
-
 build_android_demo_app() {
   pushd examples/demo-apps/android/ExecuTorchDemo
   ANDROID_HOME=/opt/android/sdk ./gradlew build
@@ -38,27 +31,6 @@ build_android_llama_demo_app() {
   popd
 }
 
-build_aar() {
-  cp extension/android/build/libs/executorch.jar build_aar/libs
-  echo \<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" \
-   package=\"org.pytorch.executorch\"\> \
-   \<uses-sdk android:minSdkVersion=\"19\" /\> \
-   \</manifest\> > build_aar/AndroidManifest.xml
-  pushd build_aar
-  mv jni/arm64-v8a/libexecutorch_jni.so jni/arm64-v8a/libexecutorch.so
-  mv jni/x86_64/libexecutorch_jni.so jni/x86_64/libexecutorch.so
-  zip -r executorch.aar libs jni AndroidManifest.xml
-
-  rm jni/arm64-v8a/libexecutorch.so jni/x86_64/libexecutorch.so
-  zip -r executorch-llama.aar libs jni AndroidManifest.xml
-  popd
-}
-
-mkdir -p build_aar/jni/arm64-v8a build_aar/jni/x86_64 build_aar/libs
-
-build_android_native_library arm64-v8a
-build_android_native_library x86_64
 export_model
 build_android_demo_app
 build_android_llama_demo_app
-build_aar


### PR DESCRIPTION
Don't depend on demo app. Instead, build JAR/JNI/AAR directly