### PR TITLE
Ignore backends/arm unit tests from pytest.ini

### DIFF
--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -5,18 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-import shutil
 import tempfile
 
 from executorch.backends.arm.arm_backend import ArmCompileSpecBuilder
-
-# TODO: fixme! These globs are a temporary workaround. Reasoning:
-# Running the jobs in _unittest.yml will not work since that environment doesn't
-# have the vela tool, nor the tosa_reference_model tool. Hence, we need a way to
-# run what we can in that env temporarily. Long term, vela and tosa_reference_model
-# should be installed in the CI env.
-TOSA_REF_MODEL_INSTALLED = shutil.which("tosa_reference_model")
-VELA_INSTALLED = shutil.which("vela")
 
 
 def get_tosa_compile_spec(permute_memory_to_nhwc=False, custom_path=None):

--- a/backends/arm/test/misc/test_debug_feats.py
+++ b/backends/arm/test/misc/test_debug_feats.py
@@ -110,18 +110,13 @@ class TestNumericalDiffPrints(unittest.TestCase):
             .partition()
             .to_executorch()
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            # We expect an assertion error here. Any other issues will cause the
-            # test to fail. Likewise the test will fail if the assertion error is
-            # not present.
-            try:
-                # Tolerate 0 difference => we want to trigger a numerical diff
-                tester.run_method_and_compare_outputs(atol=0, rtol=0, qtol=0)
-            except AssertionError:
-                pass  # Implicit pass test
-            else:
-                self.fail()
+        # We expect an assertion error here. Any other issues will cause the
+        # test to fail. Likewise the test will fail if the assertion error is
+        # not present.
+        try:
+            # Tolerate 0 difference => we want to trigger a numerical diff
+            tester.run_method_and_compare_outputs(atol=0, rtol=0, qtol=0)
+        except AssertionError:
+            pass  # Implicit pass test
         else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
+            self.fail()

--- a/backends/arm/test/models/test_mobilenet_v2_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v2_arm.py
@@ -49,7 +49,7 @@ class TestMobileNetV2(unittest.TestCase):
     )
 
     def test_mv2_tosa_MI(self):
-        tester = (
+        (
             ArmTester(
                 self.mv2,
                 inputs=self.model_inputs,
@@ -60,16 +60,11 @@ class TestMobileNetV2(unittest.TestCase):
             .check(list(self.all_operators))
             .partition()
             .to_executorch()
+            .run_method_and_compare_outputs()
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs()
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def test_mv2_tosa_BI(self):
-        tester = (
+        (
             ArmTester(
                 self.mv2,
                 inputs=self.model_inputs,
@@ -81,23 +76,12 @@ class TestMobileNetV2(unittest.TestCase):
             .check(list(self.operators_after_quantization))
             .partition()
             .to_executorch()
-        )
-        if common.TOSA_REF_MODEL_INSTALLED:
             # atol=1.0 is a defensive upper limit
             # TODO MLETROCH-72
             # TODO MLETROCH-149
-            tester.run_method_and_compare_outputs(
-                atol=1.0, qtol=1, inputs=self.model_inputs
-            )
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
+            .run_method_and_compare_outputs(atol=1.0, qtol=1, inputs=self.model_inputs)
+        )
 
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_mv2_u55_BI(self):
         (
             ArmTester(

--- a/backends/arm/test/ops/test_add.py
+++ b/backends/arm/test/ops/test_add.py
@@ -58,7 +58,7 @@ class TestSimpleAdd(unittest.TestCase):
     def _test_add_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -71,18 +71,13 @@ class TestSimpleAdd(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs()
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs()
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_add_tosa_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -96,14 +91,8 @@ class TestSimpleAdd(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs(qtol=1)
         )
-
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(qtol=1)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_add_u55_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
@@ -135,10 +124,6 @@ class TestSimpleAdd(unittest.TestCase):
         self._test_add_tosa_BI_pipeline(self.Add(), test_data)
 
     @parameterized.expand(Add.test_parameters)
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_add_u55_BI(self, test_data: torch.Tensor):
         test_data = (test_data,)
         self._test_add_u55_BI_pipeline(self.Add(), test_data)
@@ -154,10 +139,6 @@ class TestSimpleAdd(unittest.TestCase):
         self._test_add_tosa_BI_pipeline(self.Add2(), test_data)
 
     @parameterized.expand(Add2.test_parameters)
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_add2_u55_BI(self, operand1: torch.Tensor, operand2: torch.Tensor):
         test_data = (operand1, operand2)
         self._test_add_u55_BI_pipeline(self.Add2(), test_data)

--- a/backends/arm/test/ops/test_avg_pool.py
+++ b/backends/arm/test/ops/test_avg_pool.py
@@ -46,7 +46,7 @@ class TestAvgPool2d(unittest.TestCase):
     def _test_avgpool2d_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -60,18 +60,13 @@ class TestAvgPool2d(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_avg_pool2d_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs()
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs()
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_avgpool2d_tosa_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -86,13 +81,8 @@ class TestAvgPool2d(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_avg_pool2d_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs(qtol=1)
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(qtol=1)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_avgpool2d_tosa_u55_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
@@ -142,10 +132,6 @@ class TestAvgPool2d(unittest.TestCase):
     # Expected to fail since ArmQuantizer cannot quantize a AvgPool2D layer
     # TODO(MLETORCH-93)
     @parameterized.expand(test_data_suite)
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     @unittest.expectedFailure
     def test_avgpool2d_tosa_u55_BI(
         self,

--- a/backends/arm/test/ops/test_batch_norm.py
+++ b/backends/arm/test/ops/test_batch_norm.py
@@ -527,7 +527,7 @@ class TestBatchNorm2d(unittest.TestCase):
     def _test_batchnorm2d_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -552,18 +552,13 @@ class TestBatchNorm2d(unittest.TestCase):
                 ]
             )
             .to_executorch()
+            .run_method_and_compare_outputs(test_data)
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(test_data)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_batchnorm2d_no_stats_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -586,18 +581,13 @@ class TestBatchNorm2d(unittest.TestCase):
                 ]
             )
             .to_executorch()
+            .run_method_and_compare_outputs(test_data)
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(test_data)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_batchnorm2d_tosa_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -623,14 +613,8 @@ class TestBatchNorm2d(unittest.TestCase):
                 ]
             )
             .to_executorch()
+            .run_method_and_compare_outputs(test_data)
         )
-
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(test_data)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_batchnorm2d_u55_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
@@ -723,10 +707,6 @@ class TestBatchNorm2d(unittest.TestCase):
     @parameterized.expand(test_data_suite)
     @unittest.skip(
         reason="Expected to fail since ArmQuantizer cannot quantize a BatchNorm layer"
-    )
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
     )
     @unittest.expectedFailure
     def test_batchnorm2d_u55_BI(

--- a/backends/arm/test/ops/test_clone.py
+++ b/backends/arm/test/ops/test_clone.py
@@ -35,7 +35,7 @@ class TestSimpleClone(unittest.TestCase):
     def _test_clone_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: torch.Tensor
     ):
-        tester = (
+        (
             ArmTester(
                 module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
             )
@@ -45,19 +45,13 @@ class TestSimpleClone(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs(qtol=1)
         )
-
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(qtol=1)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_clone_tosa_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
             )
@@ -68,14 +62,8 @@ class TestSimpleClone(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs(qtol=1)
         )
-
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(qtol=1)
-        else:
-            raise RuntimeError(
-                "TOSA ref model tool not installed and the test is an expected fail"
-            )
 
     def _test_clone_tosa_u55_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
@@ -108,9 +96,5 @@ class TestSimpleClone(unittest.TestCase):
     # TODO MLETROCH-125
     @parameterized.expand(Clone.test_parameters)
     @unittest.expectedFailure
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_clone_u55_BI(self, test_tensor: torch.Tensor):
         self._test_clone_tosa_u55_pipeline(self.Clone(), (test_tensor,))

--- a/backends/arm/test/ops/test_conv.py
+++ b/backends/arm/test/ops/test_conv.py
@@ -244,7 +244,7 @@ class TestConv2D(unittest.TestCase):
     def _test_conv2d_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -256,20 +256,15 @@ class TestConv2D(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .check_not(["executorch_exir_dialects_edge__ops_aten_convolution_default"])
             .to_executorch()
+            .run_method_and_compare_outputs()
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs()
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_conv2d_tosa_BI_pipeline(
         self,
         module: torch.nn.Module,
         test_data: Tuple[torch.Tensor],
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -282,13 +277,8 @@ class TestConv2D(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .check_not(["executorch_exir_dialects_edge__ops_aten_convolution_default"])
             .to_executorch()
+            .run_method_and_compare_outputs(qtol=1)
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(qtol=1)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_conv2d_u55_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
@@ -317,9 +307,5 @@ class TestConv2D(unittest.TestCase):
         self._test_conv2d_tosa_BI_pipeline(model, model.get_inputs())
 
     @parameterized.expand(testsuite_u55)
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_conv2d_u55_BI(self, test_name, model):
         self._test_conv2d_u55_BI_pipeline(model, model.get_inputs())

--- a/backends/arm/test/ops/test_conv_combos.py
+++ b/backends/arm/test/ops/test_conv_combos.py
@@ -157,7 +157,7 @@ class TestConvCombos(unittest.TestCase):
     def _test_conv_combo_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -169,13 +169,8 @@ class TestConvCombos(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .check_not(list(module.edge_op_list))
             .to_executorch()
+            .run_method_and_compare_outputs()
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs()
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_conv_combo_tosa_BI_pipeline(
         self,
@@ -184,7 +179,7 @@ class TestConvCombos(unittest.TestCase):
         atol: float = 1e-3,
         rtol: float = 1e-3,
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -197,13 +192,8 @@ class TestConvCombos(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .check_not(list(module.edge_op_list))
             .to_executorch()
+            .run_method_and_compare_outputs(atol=atol, rtol=rtol, qtol=1)
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(atol=atol, rtol=rtol, qtol=1)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_conv_combo_u55_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
@@ -234,10 +224,6 @@ class TestConvCombos(unittest.TestCase):
         model = ComboConv2dMeandim()
         self._test_conv_combo_tosa_BI_pipeline(model, model.get_inputs())
 
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_conv_meandim_u55_BI(self):
         model = ComboConv2dMeandim()
         self._test_conv_combo_u55_BI_pipeline(model, model.get_inputs())
@@ -253,10 +239,6 @@ class TestConvCombos(unittest.TestCase):
         model = ComboConvBatchnormRelu()
         self._test_conv_combo_tosa_BI_pipeline(model, model.get_inputs())
 
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_conv_batchnorm_relu_u55_BI(self):
         model = ComboConvBatchnormRelu()
         self._test_conv_combo_u55_BI_pipeline(model, model.get_inputs())
@@ -277,10 +259,6 @@ class TestConvCombos(unittest.TestCase):
         self._test_conv_combo_tosa_BI_pipeline(model, test_data)
 
     @parameterized.expand(ComboConvRelu6.test_data)
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_conv_relu6_u55_BI(self, test_data: torch.Tensor):
         model = ComboConvRelu6()
         test_data = (test_data,)
@@ -297,10 +275,6 @@ class TestConvCombos(unittest.TestCase):
         model = ComboBlockBottleneckResidual()
         self._test_conv_combo_tosa_BI_pipeline(model, model.get_inputs())
 
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_block_bottleneck_residual_u55_BI(self):
         model = ComboBlockBottleneckResidual()
         self._test_conv_combo_u55_BI_pipeline(model, model.get_inputs())

--- a/backends/arm/test/ops/test_depthwise_conv.py
+++ b/backends/arm/test/ops/test_depthwise_conv.py
@@ -130,7 +130,7 @@ class TestDepthwiseConv2D(unittest.TestCase):
     def _test_dw_conv2d_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -142,18 +142,13 @@ class TestDepthwiseConv2D(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_convolution_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs()
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs()
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_dw_conv2d_tosa_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -166,13 +161,8 @@ class TestDepthwiseConv2D(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_convolution_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs(qtol=1)
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(qtol=1)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_dw_conv2d_u55_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
@@ -201,9 +191,5 @@ class TestDepthwiseConv2D(unittest.TestCase):
         self._test_dw_conv2d_tosa_BI_pipeline(model, model.get_inputs())
 
     @parameterized.expand(testsuite_u55)
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_dw_conv2d_u55_BI(self, test_name, model):
         self._test_dw_conv2d_u55_BI_pipeline(model, model.get_inputs())

--- a/backends/arm/test/ops/test_div.py
+++ b/backends/arm/test/ops/test_div.py
@@ -104,7 +104,7 @@ class TestDiv(unittest.TestCase):
     def _test_div_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -117,18 +117,13 @@ class TestDiv(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs(test_data)
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(test_data)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_div_tosa_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -142,13 +137,8 @@ class TestDiv(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs(test_data)
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(test_data)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_div_u55_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
@@ -202,10 +192,6 @@ class TestDiv(unittest.TestCase):
     # Expected to fail since ArmQuantizer cannot quantize a Div layer
     # TODO(MLETORCH-129)
     @parameterized.expand(test_data_suite)
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     @unittest.expectedFailure
     def test_div_u55_BI(
         self,

--- a/backends/arm/test/ops/test_linear.py
+++ b/backends/arm/test/ops/test_linear.py
@@ -116,7 +116,7 @@ class TestLinear(unittest.TestCase):
     def _test_linear_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -129,18 +129,13 @@ class TestLinear(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs()
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs()
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_linear_tosa_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -154,13 +149,8 @@ class TestLinear(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs(qtol=True)
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(qtol=True)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_linear_tosa_u55_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
@@ -212,10 +202,6 @@ class TestLinear(unittest.TestCase):
         )
 
     @parameterized.expand(test_data_suite_rank1)
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_linear_tosa_u55_BI(
         self,
         test_name: str,

--- a/backends/arm/test/ops/test_mean_dim.py
+++ b/backends/arm/test/ops/test_mean_dim.py
@@ -51,7 +51,7 @@ class TestMeanDim(unittest.TestCase):
     def _test_meandim_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -65,18 +65,13 @@ class TestMeanDim(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_mean_dim"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs()
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs()
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_meandim_tosa_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -91,13 +86,8 @@ class TestMeanDim(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten_mean_dim"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs(qtol=1)
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(qtol=1)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_meandim_tosa_u55_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
@@ -136,10 +126,6 @@ class TestMeanDim(unittest.TestCase):
         self._test_meandim_tosa_BI_pipeline(self.MeanDim(), (test_data,))
 
     @parameterized.expand(test_data_suite)
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_meandim_tosa_u55_BI(
         self,
         test_name: str,

--- a/backends/arm/test/ops/test_softmax.py
+++ b/backends/arm/test/ops/test_softmax.py
@@ -39,7 +39,7 @@ class TestSoftmax(unittest.TestCase):
     def _test_softmax_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module,
                 inputs=test_data,
@@ -53,18 +53,13 @@ class TestSoftmax(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten__softmax_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs()
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs()
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_softmax_tosa_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
             )
@@ -77,13 +72,8 @@ class TestSoftmax(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten__softmax_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs(qtol=1)
         )
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(qtol=1)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_softmax_tosa_u55_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
@@ -129,10 +119,6 @@ class TestSoftmax(unittest.TestCase):
     # Expected to fail since ArmQuantizer cannot quantize a SoftMax layer
     # TODO(MLETORCH-92)
     @parameterized.expand(test_data_suite)
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     @unittest.expectedFailure
     def test_softmax_tosa_u55_BI(
         self,

--- a/backends/arm/test/ops/test_view.py
+++ b/backends/arm/test/ops/test_view.py
@@ -32,7 +32,7 @@ class TestSimpleView(unittest.TestCase):
     def _test_view_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: torch.Tensor
     ):
-        tester = (
+        (
             ArmTester(
                 module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
             )
@@ -42,19 +42,13 @@ class TestSimpleView(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs(qtol=1)
         )
-
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(qtol=1)
-        else:
-            logger.warning(
-                "TOSA ref model tool not installed, skip numerical correctness tests"
-            )
 
     def _test_view_tosa_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):
-        tester = (
+        (
             ArmTester(
                 module, inputs=test_data, compile_spec=common.get_tosa_compile_spec()
             )
@@ -65,14 +59,8 @@ class TestSimpleView(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .run_method_and_compare_outputs(qtol=1)
         )
-
-        if common.TOSA_REF_MODEL_INSTALLED:
-            tester.run_method_and_compare_outputs(qtol=1)
-        else:
-            raise RuntimeError(
-                "TOSA ref model tool not installed and the test is an expected fail"
-            )
 
     def _test_view_u55_BI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
@@ -105,9 +93,5 @@ class TestSimpleView(unittest.TestCase):
     # TODO MLETROCH-125
     @parameterized.expand(View.test_parameters)
     @unittest.expectedFailure
-    @unittest.skipIf(
-        not common.VELA_INSTALLED,
-        "There is no point in running U55 tests if the Vela tool is not installed",
-    )
     def test_view_u55_BI(self, test_tensor: torch.Tensor):
         self._test_view_u55_BI_pipeline(self.View(), (test_tensor,))

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,9 @@ addopts =
     --capture=sys
     # don't suppress warnings, but don't shove them all to the end either
     -p no:warnings
+    # Ignore backends/arm tests you need to run examples/arm/setup.sh to install some tool to make them work
+    # For GitHub testing this is setup/executed in the unittest-arm job see .github/workflows/pull.yml for more info.
+    --ignore-glob=backends/arm/**/*
     # explicitly list out tests that are running successfully in oss
     examples/portable/test
     # sdk/
@@ -37,8 +40,6 @@ addopts =
     # kernels/
     kernels/prim_ops/test
     kernels/test/test_case_gen.py
-    # backends/arm
-    backends/arm/test
     # backends/xnnpack
     backends/xnnpack/test/models
     # test


### PR DESCRIPTION
The Arm tests needs to have TOSA/Vela tools installed and they are not installed by default by installed_requirements.sh Most backends/arm tests will not test anything out of the box when running all tests without it those tools installed.

To run backends/arm test you first need to install the Arm dependacies with:

$ examples/arm/setup.sh --i-agree-to-the-contained-eula

Then the test can be executed with:

$ pytest --config-file=/dev/null backends/arm/test/

For GitHub testing this is setup/executed in the unittest-arm job see .github/workflows/pull.yml for more info.