### PR TITLE
Make flatc-build optional in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright 2024 Arm Limited and/or its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -89,6 +90,11 @@ class ShouldBuild:
     @property
     def llama_custom_ops(cls) -> bool:
         return cls._is_env_enabled("EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT", default=True)
+
+    @classmethod
+    @property
+    def flatc(cls) -> bool:
+        return cls._is_env_enabled("EXECUTORCH_BUILD_FLATC", default=True)
 
 
 class Version:
@@ -549,9 +555,12 @@ class CustomBuild(build):
 def get_ext_modules() -> list[Extension]:
     """Returns the set of extension modules to build."""
 
-    ext_modules = [
-        BuiltFile("third-party/flatbuffers/flatc", "executorch/data/bin/"),
-    ]
+    ext_modules = []
+    if ShouldBuild.flatc:
+        ext_modules.append(
+            BuiltFile("third-party/flatbuffers/flatc", "executorch/data/bin/")
+        )
+
     if ShouldBuild.pybindings:
         ext_modules.append(
             # Install the prebuilt pybindings extension wrapper for the runtime,


### PR DESCRIPTION
Make flatc-build optional to be able to install in editable mode.

Install ExecuTorch in editable mode with:
`EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT=OFF EXECUTORCH_BUILD_FLATC=OFF pip install --editable . --config-settings editable-mode=strict --no-build-isolation`


Change-Id: I4a198d1d2372be81f55c9a9678e075d9f0640bfe