### PR TITLE
Verify the exported program after passes

### DIFF
--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -121,6 +121,8 @@ def _transform(edge_program: ExportedProgram) -> None:
     AnnotateDecomposed(edge_program)(graph_module)
     FoldQDQ()(graph_module)
     LayoutTransform(edge_program)(graph_module)
+    # Ensure the exported_program is still valid, ideally we want to verify for each pass
+    edge_program._validate()
 
 
 def capture_program(


### PR DESCRIPTION
Summary: There are some passes running on ExportedProgram, but we didn't verify them immediately and it may cause failure in the later downstream work.

Differential Revision: D58212409


