### PR TITLE
Harcode scale and zero point to double and long

### DIFF
--- a/kernels/quantized/cpu/op_dequantize.cpp
+++ b/kernels/quantized/cpu/op_dequantize.cpp
@@ -196,8 +196,8 @@ Tensor& dequantize_per_channel_out(
       "Failed to resize out Tensor in dequantize_per_channel_out");
 
   ET_CHECK_MSG(
-      scale.scalar_type() == ScalarType::Double,
-      "scale.scalar_type() %" PRId8 " is not double type",
+      scale.scalar_type() == ScalarType::Float,
+      "scale.scalar_type() %" PRId8 " is not float type",
       static_cast<int8_t>(scale.scalar_type()));
 
   ET_CHECK_MSG(
@@ -232,7 +232,7 @@ Tensor& dequantize_per_channel_out(
       dims[i] = i - 1;
     }
   }
-  const double* scale_data = scale.const_data_ptr<double>();
+  const float* scale_data = scale.const_data_ptr<float>();
   const int64_t* zero_point_data;
   if (opt_zero_points.has_value()) {
     zero_point_data = opt_zero_points.value().const_data_ptr<int64_t>();
@@ -254,7 +254,7 @@ Tensor& dequantize_per_channel_out(
 #define DEQUANTIZE_IMPL(CTYPE_IN, CTYPE_OUT, out_dtype)                        \
   case ScalarType::out_dtype:                                                  \
     for (size_t channel_ix = 0; channel_ix < input.size(axis); ++channel_ix) { \
-      double _scale = scale_data[channel_ix];                                  \
+      float _scale = scale_data[channel_ix];                                   \
       int64_t _zero_point = 0;                                                 \
       if (zero_point_data != nullptr) {                                        \
         _zero_point = zero_point_data[channel_ix];                             \

--- a/kernels/quantized/test/op_dequantize_test.cpp
+++ b/kernels/quantized/test/op_dequantize_test.cpp
@@ -116,11 +116,11 @@ TEST(OpDequantizeOutTest, TensorArgOverload) {
 
 TEST(OpDequantizeOutTest, DequantizePerChannel) {
   TensorFactory<ScalarType::Byte> tf_byte;
-  TensorFactory<ScalarType::Double> tf_double;
+  TensorFactory<ScalarType::Float> tf_float;
   TensorFactory<ScalarType::Long> tf_long;
 
   Tensor input = tf_byte.full({3, 2}, 100);
-  Tensor scale = tf_double.make({2}, {0.5, 1});
+  Tensor scale = tf_float.make({2}, {0.5, 1});
   Tensor zero_point = tf_long.make({2}, {30, 60});
   int64_t quant_min = 0;
   int64_t quant_max = 255;
@@ -145,7 +145,7 @@ TEST(OpDequantizeOutTest, DequantizePerChannel) {
 
   // Test with a different axis
   out = tfo.zeros({3, 2});
-  scale = tf_double.make({3}, {0.5, 0.75, 1});
+  scale = tf_float.make({3}, {0.5, 0.75, 1});
   zero_point = tf_long.make({3}, {30, 50, 60});
   // (100 - 30) * 0.5
   // (100 - 50) * 0.75
@@ -161,6 +161,5 @@ TEST(OpDequantizeOutTest, DequantizePerChannel) {
       ScalarType::Byte,
       optional<ScalarType>(),
       out);
-
   EXPECT_TENSOR_EQ(out, expected);
 }


### PR DESCRIPTION
Summary: Harcode scale and zero point to double and long so that we don't get varying outputs of scale and zero points from this call. Currently these are sometimes outputting `floats` and `doubles` for scales, and `int` and `long` for zero point based on the input.

Differential Revision: D58149278


