### PR TITLE
remove old buck2 setup code

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -152,7 +152,7 @@ jobs:
         sudo sysctl fs.inotify.max_user_watches=1048576 # 1024 * 1024
 
         # Test ethos-u delegate examples with run.sh
-        PYTHON_EXECUTABLE=python bash examples/arm/run.sh examples/arm/ethos-u-scratch/ buck2
+        PYTHON_EXECUTABLE=python bash examples/arm/run.sh examples/arm/ethos-u-scratch/
 
   test-arm-reference-delegation:
     name: test-arm-reference-delegation

--- a/docs/source/executorch-arm-delegate-tutorial.md
+++ b/docs/source/executorch-arm-delegate-tutorial.md
@@ -357,7 +357,6 @@ cd <executorch_source_root_dir>
 toolchain_cmake=<executorch_source_root_dir>/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake
 
 cmake                                                 \
-    -DBUCK2=${buck2}                                  \
     -DCMAKE_INSTALL_PREFIX=<executorch_build_dir>     \
     -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF            \
     -DCMAKE_BUILD_TYPE=Release                        \

--- a/examples/arm/README.md
+++ b/examples/arm/README.md
@@ -18,8 +18,6 @@ There are two main scripts, setup.sh and run.sh. Each takes one optional,
 positional argument. It is a path to a scratch dir to download and generate
 build artifacts. If supplied, the same argument must be supplied to both the scripts.
 
-run.sh also takes a second optional positional arg to specify a buck2 command.
-
 To run these scripts. On a Linux system, in a terminal, with a working internet connection,
 ```
 # Step [1] - setup necessary tools

--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -10,7 +10,7 @@
 set -eu
 
 if [[ "${1:-'.'}" == "-h" || "${#}" -gt 2 ]]; then
-    echo "Usage: $(basename $0) [path-to-a-scratch-dir] [buck2 binary]"
+    echo "Usage: $(basename $0) [path-to-a-scratch-dir]"
     echo "Supplied args: $*"
     exit 1
 fi
@@ -23,8 +23,6 @@ script_dir=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 # Ethos-u
 root_dir=${1:-"${script_dir}/ethos-u-scratch"}
 root_dir=$(realpath ${root_dir})
-buck2=${2:-"/tmp/buck2"}
-[[ -x ${buck2} ]] || buck2=`which buck2`
 
 ethos_u_root_dir="$(cd ${root_dir}/ethos-u && pwd)"
 ethos_u_build_dir=${ethos_u_root_dir}/core_platform/build
@@ -70,14 +68,14 @@ function build_quantization_aot_lib()
 
     cd $et_root_dir
     mkdir -p cmake-out-aot-lib
-    cmake -DBUCK2=${buck2} \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DEXECUTORCH_BUILD_XNNPACK=OFF \
         -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON \
         -DEXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT=ON \
         -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" \
         -DPYTHON_EXECUTABLE=python3 \
-	-Bcmake-out-aot-lib \
+        -Bcmake-out-aot-lib \
         "${et_root_dir}"
 
     n=$(nproc)
@@ -95,7 +93,6 @@ function build_executorch() {
 
     cd "${et_root_dir}"
     cmake                                                 \
-        -DBUCK2=${buck2}                                  \
         -DCMAKE_INSTALL_PREFIX=${et_build_dir}            \
         -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF            \
         -DCMAKE_BUILD_TYPE=Release                        \
@@ -191,9 +188,6 @@ hash arm-none-eabi-gcc \
 
 [[ -f ${et_root_dir}/CMakeLists.txt ]] \
     || { echo "Executorch repo doesn't contain CMakeLists.txt file at root level"; exit 1; }
-
-type ${buck2} 2>&1 > /dev/null \
-    || { echo "Need a functioning buck2. Got ${buck2}."; exit 1; }
 
 # build executorch libraries
 build_executorch


### PR DESCRIPTION
 now fetching the tool is part of the buildsystem proper, we can just expunge references to buck2. Only bit I couldn't fully test is the github workflow which will happen in CI now.