### PR TITLE
Separate aten and portable tests in memory_planning_ops

### DIFF
--- a/exir/tests/TARGETS
+++ b/exir/tests/TARGETS
@@ -356,16 +356,38 @@ python_unittest(
 )
 
 python_unittest(
-    name = "memory_format_ops_pass",
+    name = "test_memory_format_ops_pass_aten",
+    srcs = [
+        "test_memory_format_ops_pass_aten.py",
+    ],
+    deps = [
+        ":test_memory_format_ops_pass_utils",
+        "//caffe2:torch",
+        "//executorch/extension/pybindings:aten_lib",  # @manual
+    ],
+)
+
+python_unittest(
+    name = "test_memory_format_ops_pass",
     srcs = [
         "test_memory_format_ops_pass.py",
+    ],
+    deps = [
+        ":test_memory_format_ops_pass_utils",
+        "//caffe2:torch",
+        "//executorch/extension/pybindings:portable_lib",  # @manual
+    ],
+)
+
+python_library(
+    name = "test_memory_format_ops_pass_utils",
+    srcs = [
+        "test_memory_format_ops_pass_utils.py",
     ],
     deps = [
         "//caffe2:torch",
         "//executorch/exir:dim_order_utils",
         "//executorch/exir:lib",
-        "//executorch/extension/pybindings:aten_lib",  # @manual
-        "//executorch/extension/pybindings:portable_lib",  # @manual
     ],
 )
 

--- a/exir/tests/test_memory_format_ops_pass_aten.py
+++ b/exir/tests/test_memory_format_ops_pass_aten.py
@@ -16,13 +16,13 @@ from executorch.exir.tests.test_memory_format_ops_pass_utils import (
     SimpleToCopyContiguousModule,
 )
 
-from executorch.extension.pybindings.portable_lib import (  # @manual
+from executorch.extension.pybindings.aten_lib import (  # @manual
     _load_for_executorch_from_buffer,
 )
 
 
 class TestMemoryFormatOpsPass(unittest.TestCase):
-    def test_op_to_copy_replacement_2d(self) -> None:
+    def test_op_to_copy_replacement_2d_aten(self) -> None:
         MemoryFormatOpsPassTestUtils.memory_format_test_runner(
             self,
             MemoryFormatTestSet(
@@ -33,7 +33,7 @@ class TestMemoryFormatOpsPass(unittest.TestCase):
             ),
         )
 
-    def test_op_to_copy_replacement_4d(self) -> None:
+    def test_op_to_copy_replacement_4d_aten(self) -> None:
         MemoryFormatOpsPassTestUtils.memory_format_test_runner(
             self,
             MemoryFormatTestSet(
@@ -44,7 +44,7 @@ class TestMemoryFormatOpsPass(unittest.TestCase):
             ),
         )
 
-    def test_op_dim_order_update(self) -> None:
+    def test_op_dim_order_update_aten(self) -> None:
         MemoryFormatOpsPassTestUtils.memory_format_test_runner(
             self,
             MemoryFormatTestSet(
@@ -61,7 +61,7 @@ class TestMemoryFormatOpsPass(unittest.TestCase):
             ),
         )
 
-    def test_op_dim_order_propagation(self) -> None:
+    def test_op_dim_order_propagation_aten(self) -> None:
         MemoryFormatOpsPassTestUtils.memory_format_test_runner(
             self,
             MemoryFormatTestSet(


### PR DESCRIPTION
Summary:
In opt build mode, we can't link both aten and portable pybindings. Duplicate symbols failures.

https://www.internalfb.com/intern/test/562950098227943?ref_report_id=0

Let's separate into two different tests. This will be good in the long term because we will only enable the portable in OSS anyway.

Differential Revision: D58246232
