### PR TITLE
Implement custom op `conv_with_clamp` on Vulkan

### DIFF
--- a/backends/vulkan/passes/TARGETS
+++ b/backends/vulkan/passes/TARGETS
@@ -1,0 +1,29 @@
+load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+oncall("executorch")
+
+runtime.python_library(
+    name = "custom_ops_defs",
+    srcs = [
+        "custom_ops_defs.py",
+    ],
+    visibility = [
+        "//executorch/...",
+        "@EXECUTORCH_CLIENTS",
+    ],
+    deps = [
+        "//caffe2:torch",
+    ],
+)
+
+python_unittest(
+    name = "test_custom_ops",
+    srcs = [
+        "test_custom_ops.py",
+    ],
+    deps = [
+        ":custom_ops_defs",
+        "//caffe2:torch",
+    ],
+)

--- a/backends/vulkan/passes/custom_ops_defs.py
+++ b/backends/vulkan/passes/custom_ops_defs.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch.library
+
+
+def conv_with_clamp_impl(
+    input,
+    weight,
+    bias=None,
+    stride=1,
+    padding=0,
+    dilation=1,
+    transposed=False,
+    output_padding=0,
+    groups=1,
+    output_min=-float("inf"),
+    output_max=float("inf"),
+):
+    return torch.clamp(
+        torch.convolution(
+            input,
+            weight,
+            bias,
+            stride,
+            padding,
+            dilation,
+            transposed,
+            output_padding,
+            groups,
+        ),
+        output_min,
+        output_max,
+    )
+
+
+namespace = "et_vk"
+lib = torch.library.Library(namespace, "DEF")
+name = "conv_with_clamp"
+lib.define(
+    f"{name}(Tensor input, Tensor weight, Tensor? bias, SymInt[] stride, SymInt[] padding, SymInt[] dilation, bool transposed, SymInt[] output_padding, SymInt groups, Scalar? output_min, Scalar? output_max) -> Tensor"
+)
+lib.impl(name, conv_with_clamp_impl, "CompositeExplicitAutograd")
+conv_with_clamp_op = getattr(getattr(torch.ops, namespace), name)

--- a/backends/vulkan/passes/test_custom_ops.py
+++ b/backends/vulkan/passes/test_custom_ops.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+
+from .custom_ops_defs import conv_with_clamp_op  # noqa
+
+
+class TestCustomOps(unittest.TestCase):
+    def test_conv_with_clamp(self):
+        class ConvWithClamp(torch.nn.Module):
+            def __init__(
+                self,
+                weight,
+                bias,
+                stride,
+                padding,
+                dilation,
+                transposed,
+                output_padding,
+                groups,
+                output_min,
+                output_max,
+            ):
+                super().__init__()
+                self.weight = weight
+                self.bias = bias
+                self.stride = stride
+                self.padding = padding
+                self.dilation = dilation
+                self.transposed = transposed
+                self.output_padding = output_padding
+                self.groups = groups
+                self.output_min = output_min
+                self.output_max = output_max
+
+            def forward(self, x):
+                return torch.ops.et_vk.conv_with_clamp(
+                    x,
+                    self.weight,
+                    self.bias,
+                    self.stride,
+                    self.padding,
+                    self.dilation,
+                    self.transposed,
+                    self.output_padding,
+                    self.groups,
+                    self.output_min,
+                    self.output_max,
+                )
+
+        model = ConvWithClamp(
+            weight=torch.randn(64, 64, 3, 3),
+            bias=torch.randn(64),
+            stride=[1],
+            padding=[0],
+            dilation=[1],
+            transposed=False,
+            output_padding=[0],
+            groups=1,
+            output_min=0,
+            output_max=float("inf"),
+        )
+        x = torch.randn(2, 64, 10, 10)
+        custom_out = model(x)
+
+        expected_out = torch.clamp(
+            torch.convolution(
+                x,
+                model.weight,
+                model.bias,
+                model.stride,
+                model.padding,
+                model.dilation,
+                model.transposed,
+                model.output_padding,
+                model.groups,
+            ),
+            min=model.output_min,
+            max=model.output_max,
+        )
+
+        self.assertEqual(
+            custom_out.shape,
+            expected_out.shape,
+            "custom op `conv_with_clamp` output shape matches expected",
+        )
+        self.assertTrue(torch.allclose(custom_out, expected_out))

--- a/backends/vulkan/runtime/graph/ops/glsl/conv1d.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv1d.glsl
@@ -12,6 +12,8 @@
 
 #define VEC4_T ${texel_type(DTYPE)}
 
+#define op(X, A, B) ${OPERATOR}
+
 #include "indexing_utils.h"
 
 layout(std430) buffer;
@@ -36,6 +38,11 @@ layout(set = 0, binding = 6) uniform PRECISION restrict Params {
   int dilation;
   int in_group_size;
   int out_group_size;
+};
+
+layout(set = 0, binding = 7) uniform PRECISION restrict OutputParams {
+  float out_min;
+  float out_max;
 };
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -118,7 +125,7 @@ void main() {
       }
 
       ivec3 out_pos = ivec3(out_l, out_c, n / 4);
-      imageStore(image_out, out_pos, sum + bias.x);
+      imageStore(image_out, out_pos, op(sum + bias.x, out_min, out_max));
     }
   }
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/conv1d.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv1d.yaml
@@ -6,6 +6,7 @@
 
 conv1d:
   parameter_names_with_default_values:
+    OPERATOR: X
     NDIM: 3
     DTYPE: float
     PACKING: C_packed
@@ -15,3 +16,5 @@ conv1d:
       - VALUE: float
   shader_variants:
     - NAME: conv1d
+    - NAME: conv1d_clamp
+      OPERATOR: clamp(X, A, B)

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d.glsl
@@ -12,6 +12,8 @@
 
 #define VEC4_T ${texel_type(DTYPE)}
 
+#define op(X, A, B) ${OPERATOR}
+
 #include "indexing_utils.h"
 
 layout(std430) buffer;
@@ -40,6 +42,11 @@ layout(set = 0, binding = 6) uniform PRECISION restrict Params {
 layout(set = 0, binding = 7) uniform PRECISION restrict ExtraParams {
   ivec2 overlay_region;
   int in_group_size;
+};
+
+layout(set = 0, binding = 8) uniform PRECISION restrict OutputParams {
+  float out_min;
+  float out_max;
 };
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -124,5 +131,5 @@ void main() {
     }
   }
 
-  imageStore(image_out, pos, sum);
+  imageStore(image_out, pos, op(sum, out_min, out_max));
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d.yaml
@@ -6,6 +6,7 @@
 
 conv2d:
   parameter_names_with_default_values:
+    OPERATOR: X
     NDIM: 3
     DTYPE: float
   generate_variant_forall:
@@ -14,3 +15,5 @@ conv2d:
       - VALUE: float
   shader_variants:
     - NAME: conv2d
+    - NAME: conv2d_clamp
+      OPERATOR: clamp(X, A, B)

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw.glsl
@@ -12,6 +12,8 @@
 
 #define VEC4_T ${texel_type(DTYPE)}
 
+#define op(X, A, B) ${OPERATOR}
+
 #include "indexing_utils.h"
 
 layout(std430) buffer;
@@ -40,6 +42,11 @@ layout(set = 0, binding = 6) uniform PRECISION restrict Params {
 layout(set = 0, binding = 7) uniform PRECISION restrict ExtraParams {
   ivec2 overlay_region;
   int in_group_size;
+};
+
+layout(set = 0, binding = 8) uniform PRECISION restrict OutputParams {
+  float out_min;
+  float out_max;
 };
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -77,5 +84,5 @@ void main() {
     }
   }
 
-  imageStore(image_out, pos, sum);
+  imageStore(image_out, pos, op(sum, out_min, out_max));
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw.yaml
@@ -6,6 +6,7 @@
 
 conv2d_dw:
   parameter_names_with_default_values:
+    OPERATOR: X
     NDIM: 3
     DTYPE: float
   generate_variant_forall:
@@ -14,3 +15,5 @@ conv2d_dw:
       - VALUE: float
   shader_variants:
     - NAME: conv2d_dw
+    - NAME: conv2d_dw_clamp
+      OPERATOR: clamp(X, A, B)

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.glsl
@@ -12,6 +12,8 @@
 
 #define VEC4_T ${texel_type(DTYPE)}
 
+#define op(X, A, B) ${OPERATOR}
+
 #include "indexing_utils.h"
 
 layout(std430) buffer;
@@ -40,6 +42,11 @@ layout(set = 0, binding = 6) uniform PRECISION restrict Params {
 layout(set = 0, binding = 7) uniform PRECISION restrict ExtraParams {
   ivec2 overlay_region;
   int in_group_size;
+};
+
+layout(set = 0, binding = 8) uniform PRECISION restrict OutputParams {
+  float out_min;
+  float out_max;
 };
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -77,5 +84,5 @@ void main() {
     }
   }
 
-  imageStore(image_out, pos, sum);
+  imageStore(image_out, pos, op(sum, out_min, out_max));
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.yaml
@@ -6,6 +6,7 @@
 
 conv2d_dw_output_tile:
   parameter_names_with_default_values:
+    OPERATOR: X
     NDIM: 3
     DTYPE: float
     TILE_SIZE: 3
@@ -15,5 +16,10 @@ conv2d_dw_output_tile:
       - VALUE: float
   shader_variants:
     - NAME: conv2d_dw_output_tile_3x3
+    - NAME: conv2d_dw_output_tile_3x3_clamp
+      OPERATOR: clamp(X, A, B)
     - NAME: conv2d_dw_output_tile_5x5
+      TILE_SIZE: 5
+    - NAME: conv2d_dw_output_tile_5x5_clamp
+      OPERATOR: clamp(X, A, B)
       TILE_SIZE: 5

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_pw.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_pw.glsl
@@ -12,6 +12,8 @@
 
 #define VEC4_T ${texel_type(DTYPE)}
 
+#define op(X, A, B) ${OPERATOR}
+
 #include "indexing_utils.h"
 
 layout(std430) buffer;
@@ -40,6 +42,11 @@ layout(set = 0, binding = 6) uniform PRECISION restrict Params {
 layout(set = 0, binding = 7) uniform PRECISION restrict ExtraParams {
   ivec2 overlay_region;
   int in_group_size;
+};
+
+layout(set = 0, binding = 8) uniform PRECISION restrict OutputParams {
+  float out_min;
+  float out_max;
 };
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -145,7 +152,7 @@ void main() {
 
   for (int i = 0; i < ${TILE_SIZE * TILE_SIZE}; ++i) {
     if (all(lessThan(pos[i], out_limits))) {
-      imageStore(image_out, pos[i], sum[i]);
+      imageStore(image_out, pos[i], op(sum[i], out_min, out_max));
     }
   }
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_pw.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_pw.yaml
@@ -6,6 +6,7 @@
 
 conv2d_pw:
   parameter_names_with_default_values:
+    OPERATOR: X
     NDIM: 3
     DTYPE: float
     TILE_SIZE: 2
@@ -15,3 +16,5 @@ conv2d_pw:
       - VALUE: float
   shader_variants:
     - NAME: conv2d_pw
+    - NAME: conv2d_pw_clamp
+      OPERATOR: clamp(X, A, B)

--- a/backends/vulkan/runtime/graph/ops/glsl/conv_transpose2d.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv_transpose2d.glsl
@@ -12,6 +12,8 @@
 
 #define VEC4_T ${texel_type(DTYPE)}
 
+#define op(X, A, B) ${OPERATOR}
+
 #include "indexing_utils.h"
 
 layout(std430) buffer;
@@ -40,6 +42,11 @@ layout(set = 0, binding = 6) uniform PRECISION restrict Params {
 layout(set = 0, binding = 7) uniform PRECISION restrict ExtraParams {
   ivec2 overlay_region;
   int in_group_size;
+};
+
+layout(set = 0, binding = 8) uniform PRECISION restrict OutputParams {
+  float out_min;
+  float out_max;
 };
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -88,5 +95,5 @@ void main() {
     }
   }
 
-  imageStore(image_out, pos, sum);
+  imageStore(image_out, pos, op(sum, out_min, out_max));
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/conv_transpose2d.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv_transpose2d.yaml
@@ -6,6 +6,7 @@
 
 conv_transpose2d:
   parameter_names_with_default_values:
+    OPERATOR: X
     NDIM: 3
     DTYPE: float
   generate_variant_forall:
@@ -14,3 +15,5 @@ conv_transpose2d:
       - VALUE: float
   shader_variants:
     - NAME: conv_transpose2d
+    - NAME: conv_transpose2d_clamp
+      OPERATOR: clamp(X, A, B)


### PR DESCRIPTION
Summary:
We modify the existing convolution ops to accommodate the custom op `conv_with_clamp`. Specifically
- add two arguments `out_min` and `out_max` to `Convolution.cpp` and `conv*.glsl`
- add variants `conv*_clamp` to yaml files

Differential Revision: D58116622
