### PR TITLE
ptez_loader

### DIFF
--- a/extension/testing_util/targets.bzl
+++ b/extension/testing_util/targets.bzl
@@ -15,5 +15,6 @@ def define_common_targets():
             "//executorch/extension/data_loader/test/...",
             "//executorch/extension/testing_util/test/...",
             "//executorch/extension/fb/ptez/decompression_methods/test/...",
+            "//executorch/extension/fb/ptez/test/...",
         ],
     )

--- a/extension/testing_util/targets.bzl
+++ b/extension/testing_util/targets.bzl
@@ -11,5 +11,9 @@ def define_common_targets():
         name = "temp_file",
         srcs = [],
         exported_headers = ["temp_file.h"],
-        visibility = ["//executorch/extension/data_loader/test/...", "//executorch/extension/testing_util/test/..."],
+        visibility = [
+            "//executorch/extension/data_loader/test/...",
+            "//executorch/extension/testing_util/test/...",
+            "//executorch/extension/fb/ptez/decompression_methods/test/...",
+        ],
     )


### PR DESCRIPTION
Summary:
This diff creates a data loader, called PtezDataLoader, to load ptez file during the runtime.
For this diff, PtezDataLoader is only focusing on loading from disk every time we invoke Load function.

Differential Revision: D58133351
