### PR TITLE
Mitigate the "dim_order" not found error in dim order op

### DIFF
--- a/exir/passes/dim_order_ops_registry.py
+++ b/exir/passes/dim_order_ops_registry.py
@@ -22,8 +22,8 @@ lib.define(
 
 
 def _op_impl(target, *args, **kwargs):
-    kwargs["memory_format"] = get_memory_format(kwargs["dim_order"])
-    _ = kwargs.pop("dim_order")
+    kwargs["memory_format"] = get_memory_format(kwargs.get("dim_order", None))
+    _ = kwargs.pop("dim_order", None)
     res = target(*args, **kwargs)
     # assert list(res.dim_order()) == dim_order
     return res


### PR DESCRIPTION
Summary:
SS-JIA encountered an issue that dim order attribute can not be found in aot dim order op when assigned dim_order as None. D57649650 and P1400808908 are the details.
This diff mitigates the issue by assigning dim order attribute as None if it does not exist. Will further investigate afterwards.

Differential Revision: D58304763
