### PR TITLE
Complete revamp of float/promotion sympy handling

### DIFF
--- a/examples/selective_build/test_selective_build.sh
+++ b/examples/selective_build/test_selective_build.sh
@@ -32,9 +32,9 @@ test_buck2_select_ops_in_list() {
     ${PYTHON_EXECUTABLE} -m examples.portable.scripts.export --model_name="add_mul"
 
     echo "Running selective build test"
-    # set max_kernel_num=18: 16 primops, add, mul
+    # set max_kernel_num=19: 17 primops, add, mul
     $BUCK run //examples/selective_build:selective_build_test \
-        --config=executorch.max_kernel_num=18 \
+        --config=executorch.max_kernel_num=19 \
         --config=executorch.select_ops=list \
         -- --model_path=./add_mul.pte
 
@@ -100,11 +100,11 @@ test_cmake_select_ops_in_list() {
 
     local example_dir=examples/selective_build
     local build_dir=cmake-out/${example_dir}
-    # set MAX_KERNEL_NUM=18: 16 primops, add, mul
+    # set MAX_KERNEL_NUM=19: 17 primops, add, mul
     rm -rf ${build_dir}
     retry cmake -DBUCK2="$BUCK" \
             -DCMAKE_BUILD_TYPE=Release \
-            -DMAX_KERNEL_NUM=18 \
+            -DMAX_KERNEL_NUM=19 \
             -DEXECUTORCH_SELECT_OPS_LIST="aten::convolution.out,\
 aten::_native_batch_norm_legit_no_training.out,aten::hardtanh.out,aten::add.out,\
 aten::mean.out,aten::view_copy.out,aten::permute_copy.out,aten::addmm.out,\

--- a/exir/pass_base.py
+++ b/exir/pass_base.py
@@ -54,6 +54,7 @@ PassType = Callable[[torch.fx.GraphModule], Optional[PassResult]]
 
 _TORCH_SYM_OPS: Set[Any] = {  # pyre-ignore
     torch.sym_int,
+    torch.sym_float,
     torch.sym_ite,
     torch.sym_max,
     torch.sym_min,

--- a/exir/passes/executorch_prim_ops_registry.py
+++ b/exir/passes/executorch_prim_ops_registry.py
@@ -49,6 +49,11 @@ def truediv(a: _SymScalar, b: _SymScalar) -> _SymScalar:
     return a / b  # pyre-ignore
 
 
+@bind_pattern_to_op(executorch_prims_lib, "sym_float.Scalar(Scalar a) -> Scalar")
+def sym_float(a: _SymScalar) -> _SymScalar:
+    return float(a)  # pyre-ignore
+
+
 # TODO: ideally we should return SymBool in the schema, but it seems
 # the schema parser does not recognize SymBool yet: P629748075
 @bind_pattern_to_op(executorch_prims_lib, "gt.Scalar(Scalar a, Scalar b) -> bool")
@@ -87,6 +92,7 @@ _PYTHON_SYM_OPS_TO_EXECUTORCH_SYM_OPS: Dict[OpOverload, OpOverload] = {
     operator.lt: ops.backend.executorch_prim.lt.Scalar,
     operator.ge: ops.backend.executorch_prim.ge.Scalar,
     operator.le: ops.backend.executorch_prim.le.Scalar,
+    torch.sym_float: ops.backend.executorch_prim.sym_float.Scalar,
 }
 
 

--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -150,6 +150,7 @@ _SYM_INT_OPS = {
     operator.mod,
     torch.sym_sqrt,
     torch.sym_int,
+    torch.sym_float,
     torch.sym_ite,
     torch.sym_max,
     torch.sym_min,

--- a/kernels/prim_ops/register_prim_ops.cpp
+++ b/kernels/prim_ops/register_prim_ops.cpp
@@ -193,6 +193,27 @@ static Kernel prim_ops[] = {
           }
         }),
 
+    // executorch_prim::sym_float.Scalar(Scalar) -> Scalar
+    Kernel(
+        "executorch_prim::sym_float.Scalar",
+        [](RuntimeContext& context, EValue** stack) {
+          // can't use macro because of custom casting behavior
+          // TODO: Now that we are reliably generating conversion operators,
+          // we can remove the mixed type handling for other operators
+          (void)context;
+          EValue& a = *stack[0];
+          EValue& out = *stack[1];
+          if (a.isInt()) {
+            out = EValue(static_cast<double>(a.toInt()));
+          } else if (a.isDouble()) {
+            // TODO: This should be impossible
+            out = EValue(a.toDouble());
+          } else {
+            // TODO Fail using runtime context
+            ET_CHECK_MSG(false, "%zu", (size_t)a.tag);
+          }
+        }),
+
     // executorch_prim::eq.Scalar(Scalar, Scalar) -> bool
     Kernel(
         "executorch_prim::eq.Scalar",

--- a/kernels/prim_ops/test/prim_ops_test.cpp
+++ b/kernels/prim_ops/test/prim_ops_test.cpp
@@ -111,6 +111,9 @@ TEST_F(RegisterPrimOpsTest, TestAlgebraOps) {
 
   getOpsFn("executorch_prim::truediv.Scalar")(context, stack);
   EXPECT_FLOAT_EQ(stack[2]->toDouble(), 0.75);
+
+  getOpsFn("executorch_prim::sym_float.Scalar")(context, stack);
+  EXPECT_FLOAT_EQ(stack[1]->toDouble(), 3.0);
 }
 
 TEST_F(RegisterPrimOpsTest, TestETCopyIndex) {


### PR DESCRIPTION
Summary:
Original PR https://github.com/pytorch/pytorch/pull/126905

Below line forces Sandcastle to run only specified contbuilds.
build_only[github-export-checks,executorch,pytorch_benchmark,pytorch_quantization,pytorch_distributed,pytorch_distributed_gpu,pytorch_dynamo_inductor,pytorch_functorch,pytorch_fx2trt,pytorch_diff_train_tests_ads,glow_fb_pytorch_tests,training_platform,training_platform_compatibility,training_toolkit_applications,training_toolkit_examples,training_toolkit_model_optimization,dper3_pytorch,xplat_caffe2,pytorch_dev,android-pytorch-instrumentation-tests,smart__pytorch__github_first_try_merge,frl-target-determinator,f6-buck,training_platform_for_github,sigmoid_cpu,sigmoid_gpu,aiplatform_modelprocessing_for_github,accelerators_workloads_models_slimdsnn,ae_aotinductor_benchmark_test,aps_,apf,aps_deterministic_ne_tests,dper_lib_silvertorch,torchrec,torchrec_fb,deeplearning_aot_inductor,aiplatform_modelstore]
#skipfbcodelongtail

Differential Revision: D58294450
