### PR TITLE
backend compatibility api

### DIFF
--- a/exir/backend/TARGETS
+++ b/exir/backend/TARGETS
@@ -31,6 +31,18 @@ runtime.python_library(
 )
 
 runtime.python_library(
+    name = "runtime_info_schema",
+    srcs = [
+        "runtime_info_schema.py",
+    ],
+    visibility = [
+        "//executorch/...",
+        "//executorch/test/...",
+        "@EXECUTORCH_CLIENTS",
+    ],
+)
+
+runtime.python_library(
     name = "compile_spec_schema",
     srcs = [
         "compile_spec_schema.py",
@@ -71,6 +83,7 @@ runtime.python_library(
     deps = [
         ":compile_spec_schema",
         ":partitioner",
+        ":runtime_info_schema",
         "//caffe2:torch",
         "//executorch/exir:delegate",
         "//executorch/exir:graph_module",

--- a/exir/backend/backend_details.py
+++ b/exir/backend/backend_details.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union
 
 from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.exir.backend.runtime_info_schema import RuntimeInfo
 from torch.export.exported_program import ExportedProgram
 
 
@@ -65,4 +66,24 @@ class BackendDetails(ABC):
     ) -> PreprocessResult:
         # Users should return a compiled blob - a binary that can run the desired
         # program in the backend.
+        pass
+
+    """
+    Args:
+        processed_bytes: The preprocessed binary result from preprocessed given the graph.
+        compile_spec: The same compile spec given to preprocess.
+        runtime_info: The runtime info provided by the backend runtime
+
+    Returns:
+        A boolean to indicated whether the preprocessed result is compatible with the backend runtime.
+    """
+
+    @staticmethod
+    @abstractmethod
+    def is_compatible(
+        processed_bytes: bytes,
+        compile_spec: List[CompileSpec],
+        runtime_info: List[RuntimeInfo],
+    ) -> bool:
+        # Users should return if the preprocesssed_blob is compatible with the runtime info.
         pass

--- a/exir/backend/runtime_info_schema.py
+++ b/exir/backend/runtime_info_schema.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+
+
+@dataclass
+class RuntimeInfo:
+    key: str  # runtime info key like "runtime_version"
+    value: bytes  # runtime info value like "v0.4.2"

--- a/exir/backend/test/demos/rpc/ExecutorBackend.cpp
+++ b/exir/backend/test/demos/rpc/ExecutorBackend.cpp
@@ -39,6 +39,22 @@ class ExecutorBackend final : public PyTorchBackendInterface {
  public:
   ~ExecutorBackend() = default;
 
+  Error runtime_info(ArrayRef<RuntimeInfo> runtime_info) const override {
+    static const char* const kKey = "version";
+    static const char* const kRuntimeVersion = "ET_12";
+
+    for (auto&& [key, value] : runtime_info) {
+      if (strcmp(key, kKey) == 0) {
+        if (value.nbytes > strlen(kRuntimeVersion) + 1) {
+          return Error::DelegateInvalidCompatibility;
+        }
+        // Update the runtime version from ExecutorBackend
+        memcpy(value.buffer, kRuntimeVersion, strlen(kRuntimeVersion) + 1);
+      }
+    }
+    return Error::Ok; // Key found and value set
+  }
+
   bool is_available() const override {
     return true;
   }

--- a/exir/backend/test/demos/rpc/executor_backend_preprocess.py
+++ b/exir/backend/test/demos/rpc/executor_backend_preprocess.py
@@ -7,12 +7,14 @@
 from typing import final, List
 
 from executorch.exir import ExirExportedProgram
+from executorch.exir._serialize._program import deserialize_pte_binary
 from executorch.exir.backend.backend_details import (
     BackendDetails,
     ExportedProgram,
     PreprocessResult,
 )
 from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.exir.backend.runtime_info_schema import RuntimeInfo
 
 
 @final
@@ -31,3 +33,24 @@ class ExecutorBackend(BackendDetails):
             .to_executorch()
             .buffer,
         )
+
+    @staticmethod
+    def is_compatible(
+        processed_bytes: bytes,
+        compile_spec: List[CompileSpec],
+        runtime_info: List[RuntimeInfo],
+    ) -> bool:
+        runtime_dict = {runtime.key: runtime.value for runtime in runtime_info}
+        # This is optional, we don't necessarily need to fully deserialize the model to check binary version
+        binary = deserialize_pte_binary(processed_bytes)
+        current_binary_version = binary.version
+
+        binary_version_matches = (
+            int(runtime_dict["supported_binary_version"].decode("utf-8"))
+            == current_binary_version
+        )
+
+        # Since we don't have a way to get the runtime version from c++, hardcoded for now
+        runtime_version_is_compatible = runtime_dict["runtime_version"] == b"ET_12"
+
+        return binary_version_matches and runtime_version_is_compatible

--- a/exir/backend/test/demos/rpc/targets.bzl
+++ b/exir/backend/test/demos/rpc/targets.bzl
@@ -29,6 +29,9 @@ def define_common_targets():
             "//executorch/extension/data_loader:buffer_data_loader",
             "//executorch/util:util",
         ] + MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB,
+        visibility = [
+            "//executorch/runtime/backend/test/...",
+        ],
         exported_deps = [
             "//executorch/runtime/core:core",
         ],
@@ -40,6 +43,7 @@ def define_common_targets():
             "ExecutorBackendRegister.cpp",
         ],
         visibility = [
+            "//executorch/runtime/backend/test/...",
             "//executorch/exir/backend/test/...",
         ],
         deps = [

--- a/exir/backend/test/test_compatibility_api.py
+++ b/exir/backend/test/test_compatibility_api.py
@@ -1,0 +1,55 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch import exir
+from executorch.exir.backend.runtime_info_schema import RuntimeInfo
+from executorch.exir.backend.test.demos.rpc.executor_backend_preprocess import (
+    ExecutorBackend,
+)
+from executorch.exir.tests.models import MLP
+
+
+class TestBackends(unittest.TestCase):
+    def test_compatibility(self):
+        mlp = MLP()
+        example_inputs = mlp.get_random_inputs()
+        exported_program = torch.export.export(mlp, example_inputs)
+        edge_program = exir.to_edge(
+            exported_program,
+            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+        )
+
+        # Preprocess the subgraph and get the processed bytes
+        preprocess_result = ExecutorBackend.preprocess(
+            edge_program.exported_program(), []
+        )
+
+        def runtime_version(compatible):
+            return b"ET_12" if compatible else b"ET_13"
+
+        def binary_version(compatible):
+            return b"0" if compatible else b"1"
+
+        for compatible_runtime_version in (True, False):
+            for compatible_binary_version in (True, False):
+                runtime_info = [
+                    RuntimeInfo(
+                        "runtime_version", runtime_version(compatible_runtime_version)
+                    ),
+                    RuntimeInfo(
+                        "supported_binary_version",
+                        binary_version(compatible_binary_version),
+                    ),
+                ]
+                result = ExecutorBackend.is_compatible(
+                    preprocess_result.processed_bytes, [], runtime_info
+                )
+                self.assertEqual(
+                    result, compatible_runtime_version and compatible_binary_version
+                )

--- a/runtime/backend/test/targets.bzl
+++ b/runtime/backend/test/targets.bzl
@@ -1,7 +1,15 @@
-def define_common_targets():
-    """Defines targets that should be shared between fbcode and xplat.
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-    The directory containing this targets.bzl file should also contain both
-    TARGETS and BUCK files that call this function.
-    """
-    pass
+def define_common_targets():
+    runtime.cxx_test(
+        name = "test_backend_compatibility",
+        srcs = [
+            "test_backend_compatibility.cpp",
+        ],
+        deps = [
+            "fbsource//third-party/googletest:gtest_main",
+            "//executorch/runtime/backend:interface",
+            "//executorch/exir/backend/test/demos/rpc:executor_backend",
+            "//executorch/exir/backend/test/demos/rpc:executor_backend_register",
+        ],
+    )

--- a/runtime/backend/test/test_backend_compatibility.cpp
+++ b/runtime/backend/test/test_backend_compatibility.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/exir/backend/test/demos/rpc/ExecutorBackend.h>
+#include <executorch/runtime/backend/interface.h>
+#include <executorch/runtime/core/error.h>
+#include <gtest/gtest.h>
+#include <cstring>
+using torch::executor::ArrayRef;
+using torch::executor::Error;
+using torch::executor::PyTorchBackendInterface;
+using torch::executor::RuntimeInfo;
+using torch::executor::SizedBuffer;
+
+TEST(BackendCompatibility, GetRuntimeInfo) {
+  torch::executor::registerExecutorBackend();
+  PyTorchBackendInterface* executor_backend =
+      torch::executor::get_backend_class("ExecutorBackend");
+
+  const char* kKey = "version";
+  const char* kET00 = "ET_00";
+  const char* kET12 = "ET_12";
+
+  std::array<char, 6> buffer;
+  ASSERT_EQ(buffer.size(), strlen(kET00) + 1);
+  size_t nbytes = strlen(kET00) + 1;
+  memcpy(buffer.data(), kET00, nbytes);
+  // Check the default value is ET_00
+  EXPECT_STREQ(reinterpret_cast<const char*>(buffer.data()), kET00);
+  SizedBuffer runtime_info_value = {buffer.data(), nbytes};
+  RuntimeInfo runtime_info = {kKey, runtime_info_value};
+
+  ArrayRef<RuntimeInfo> runtime_info_list(runtime_info);
+  Error err = executor_backend->runtime_info(runtime_info_list);
+  EXPECT_EQ(err, Error::Ok);
+  // Check the runtime version is updated to ET_12
+  EXPECT_STREQ(
+      reinterpret_cast<const char*>(runtime_info_list.at(0).value.buffer),
+      kET12);
+}


### PR DESCRIPTION
Summary:
# Problem Statement

Backend delegate might be 1rd party (XNNPACK) or 3rd party, or just any backend developer who would like to add a new backend to delegate.

During delegation AOT (ahead of time) process, part of (or the whole) model will be tagged, preprocessed and serialized as a delegated payload by the backend. During delegate runtime process, the delegated payload will be received by the backend runtime, further initialized and executed.

 {F1677736526}

delegate process includes taking a subgraph (or the whole graph), preprocessed to a delegated payload and sent to the backend runtime later.

For backend delegate, the compatibility we’re comparing is the delegated payload (backend preprocess ahead of time given subgraph or the whole graph) and the backend runtime.

# Goals

- Unlock backend’s capabilities to run compatibility checks
    - Server side: Enable checking compatibility between .pte program and the target device. ExecuTorch Holistic BC/FC Detection and Enforcement covers more details about the high details in general. And this document is specifically for detecting compatibility between the delegated payload and the backend runtime.
        - Success criteria: If we send the .pte file to the target device, it will be successful to run.
        - can check compatibility when the backend runtime is not available.
    - On device side:
        - Runtime API that can provide a serializable representation of the capabilities of each backend, in a format that can be compared against a .pte file on the server side
        - Allow backend to report compatibility error code in runtime such that it can propagated to the high stack
        - Given an incompatible pte file, the runtime should error gracefully during load/init time.

## Challenges
Every backend might have its own container options, and the majority backend will be proprietary especially for hardware accelarators. With that being said, we have to provide an abstraction layer for the backend to implement such that the executorch can query/reason the compatibility from the backend.

Backend compatibility check is also complicated and various from backend to backend, possible incompatibility error can be:

- Incompatible payload (binary) version
- Incompatible backend runtime (api) version
- Incompatible backend device
- Incompatible backend OS
- Wrong alignment
- Incompatible op set
- …

We want to ensure that backends can unlock its full functionality when they’re integrated to ExecuTorch, but not let the framework restrict them. Being able to unlock backends’ full potential when integrating with ExecuTorch is our biggest selling point. Mostly: it’s easy to integrate, ExecuTorch will help the backend with the boiler plate code and generic work. Backend has its full potential

In this diff, we provide the prototype implementation. And we add two test cases for both testing and learning purpose:

- test_compatibility_api.py
- test_backend_compatibility.cpp

they can be used to show how it will work. Since we don't have the top level `is_compatible` c++/python api yet, the unit test is only for the delegate.

Differential Revision: D58002896
