### PR TITLE
Use portable lib in exir/emit/test/test_emit.py

### DIFF
--- a/exir/emit/test/TARGETS
+++ b/exir/emit/test/TARGETS
@@ -21,6 +21,6 @@ python_unittest(
         "//executorch/exir/passes:constant_prop_pass",
         "//executorch/exir/tests:lib",
         "//executorch/exir/tests:models",
-        "//executorch/extension/pybindings:aten_lib",
+        "//executorch/extension/pybindings:portable_lib",
     ],
 )

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -49,7 +49,10 @@ from executorch.exir.schema import (
 )
 from executorch.exir.tests.common import register_additional_test_aten_ops
 from executorch.exir.tests.models import Mul
-from executorch.extension.pybindings.aten_lib import _load_for_executorch_from_buffer
+from executorch.extension.pybindings.portable_lib import (
+    _load_for_executorch_from_buffer,
+)
+
 from functorch.experimental import control_flow
 from torch import nn
 

--- a/extension/pybindings/TARGETS
+++ b/extension/pybindings/TARGETS
@@ -63,6 +63,9 @@ executorch_pybindings(
 runtime.python_library(
     name = "portable_lib",
     srcs = ["portable_lib.py"],
-    visibility = ["@EXECUTORCH_CLIENTS"],
+    visibility = [
+        "//executorch/exir/...",
+        "@EXECUTORCH_CLIENTS",
+    ],
     deps = [":_portable_lib"],
 )


### PR DESCRIPTION
Summary: Now portable lib is available, we should use it instead of aten.

Differential Revision: D58371265
