### PR TITLE
Fix discrepancy on eos and bos tokens for different pte files

### DIFF
--- a/examples/models/llama2/tokenizer/bpe_tokenizer.cpp
+++ b/examples/models/llama2/tokenizer/bpe_tokenizer.cpp
@@ -23,14 +23,13 @@ static int compare_tokens(const void* a, const void* b) {
   return strcmp(((TokenIndex*)a)->str, ((TokenIndex*)b)->str);
 }
 
-BPETokenizer::BPETokenizer(
-    int32_t vocab_size,
-    uint64_t bos_tok,
-    uint64_t eos_tok)
-    : Tokenizer(vocab_size, bos_tok, eos_tok),
-      vocab_(std::make_unique<char*[]>(vocab_size)),
-      vocab_scores_(std::make_unique<float[]>(vocab_size)),
-      sorted_vocab_(std::make_unique<TokenIndex[]>(vocab_size)) {
+BPETokenizer::BPETokenizer() : Tokenizer() {
+  vocab_size_ = kVocabSize;
+  vocab_ = std::make_unique<char*[]>(kVocabSize);
+  vocab_scores_ = std::make_unique<float[]>(kVocabSize);
+  sorted_vocab_ = std::make_unique<TokenIndex[]>(kVocabSize);
+  bos_tok_ = 1;
+  eos_tok_ = 2;
   for (int i = 0; i < 256; i++) {
     byte_pieces_[i * 2] = (unsigned char)i;
     byte_pieces_[i * 2 + 1] = '\0';
@@ -72,19 +71,7 @@ Error BPETokenizer::load(const std::string& tokenizer_path) {
   // now we have two vocab_sizes one from the model and another from the
   // tokenizer file.
   int32_t tokenizer_vocab_size = metadata[0];
-  if (tokenizer_vocab_size < vocab_size_) {
-    ET_LOG(
-        Info,
-        "The tokenizer vocab size %d is smaller than the model vocab size %d, will add padding tokens.",
-        tokenizer_vocab_size,
-        vocab_size_);
-  } else if (tokenizer_vocab_size > vocab_size_) {
-    ET_LOG(
-        Info,
-        "The tokenizer vocab size %d is larger than the model vocab size %d.",
-        tokenizer_vocab_size,
-        vocab_size_);
-  }
+  vocab_size_ = tokenizer_vocab_size;
 
   max_token_length_ = metadata[1];
 

--- a/examples/models/llama2/tokenizer/bpe_tokenizer.h
+++ b/examples/models/llama2/tokenizer/bpe_tokenizer.h
@@ -14,6 +14,8 @@
 namespace torch {
 namespace executor {
 
+constexpr int32_t kVocabSize = 32000;
+
 struct TokenIndex {
   const char* str;
   int32_t id;
@@ -21,7 +23,7 @@ struct TokenIndex {
 
 class BPETokenizer : public Tokenizer {
  public:
-  explicit BPETokenizer(int32_t vocab_size, uint64_t bos_tok, uint64_t eos_tok);
+  explicit BPETokenizer();
   ~BPETokenizer() override;
 
   Error load(const std::string& tokenizer_path) override;

--- a/examples/models/llama2/tokenizer/test/test_bpe_tokenizer.cpp
+++ b/examples/models/llama2/tokenizer/test/test_bpe_tokenizer.cpp
@@ -21,7 +21,7 @@ class TokenizerExtensionTest : public Test {
  public:
   void SetUp() override {
     torch::executor::runtime_init();
-    tokenizer_ = std::make_unique<BPETokenizer>(32000, 1, 2);
+    tokenizer_ = std::make_unique<BPETokenizer>();
     modelPath_ = std::getenv("RESOURCES_PATH") + std::string("/test.bin");
   }
 
@@ -50,9 +50,8 @@ TEST_F(TokenizerExtensionTest, DecodeOutOfRangeFails) {
 TEST_F(TokenizerExtensionTest, TokenizerVocabSizeIsExpected) {
   Error res = tokenizer_->load(modelPath_.c_str());
   EXPECT_EQ(res, Error::Ok);
-  // test.bin has vocab size 0 but the tokenizer respects the vocab size being
-  // passed in and add placeholder tokens.
-  EXPECT_EQ(tokenizer_->vocab_size(), 32000);
+  // test.bin has vocab size 0.
+  EXPECT_EQ(tokenizer_->vocab_size(), 0);
   EXPECT_EQ(tokenizer_->bos_tok(), 1);
   EXPECT_EQ(tokenizer_->eos_tok(), 2);
 }

--- a/examples/models/llama2/tokenizer/test/test_tiktoken.cpp
+++ b/examples/models/llama2/tokenizer/test/test_tiktoken.cpp
@@ -21,7 +21,7 @@ class TiktokenExtensionTest : public Test {
  public:
   void SetUp() override {
     torch::executor::runtime_init();
-    tokenizer_ = std::make_unique<Tiktoken>(128256, 128000, 128001);
+    tokenizer_ = std::make_unique<Tiktoken>();
     modelPath_ =
         std::getenv("RESOURCES_PATH") + std::string("/tokenizer.model");
   }

--- a/examples/models/llama2/tokenizer/tiktoken.cpp
+++ b/examples/models/llama2/tokenizer/tiktoken.cpp
@@ -343,6 +343,11 @@ Error Tiktoken::load(const std::string& path) {
 
   _special_token_regex = _build_special_token_regex(_special_token_encoder);
 
+  // initialize vocab_size, bos_tok, eos_tok
+  vocab_size_ = _encoder.size() + _special_token_encoder.size();
+  bos_tok_ = _special_token_encoder.at("<|begin_of_text|>");
+  eos_tok_ = _special_token_encoder.at("<|end_of_text|>");
+
   initialized_ = true;
   return Error::Ok;
 }

--- a/examples/models/llama2/tokenizer/tiktoken.h
+++ b/examples/models/llama2/tokenizer/tiktoken.h
@@ -26,8 +26,7 @@ using Re2UPtr = std::unique_ptr<re2::RE2>;
 
 class Tiktoken : public Tokenizer {
  public:
-  explicit Tiktoken(int32_t vocab_size, uint64_t bos_tok, uint64_t eos_tok)
-      : Tokenizer(vocab_size, bos_tok, eos_tok){};
+  explicit Tiktoken() : Tokenizer() {}
   ~Tiktoken(){};
 
   Error load(const std::string& tokenizer_path);

--- a/examples/models/llama2/tokenizer/tokenizer.h
+++ b/examples/models/llama2/tokenizer/tokenizer.h
@@ -28,11 +28,7 @@ namespace executor {
 
 class Tokenizer {
  public:
-  explicit Tokenizer(int32_t vocab_size, uint64_t bos_tok, uint64_t eos_tok)
-      : initialized_(false),
-        vocab_size_(vocab_size),
-        bos_tok_(bos_tok),
-        eos_tok_(eos_tok) {}
+  explicit Tokenizer() : initialized_(false) {}
   virtual ~Tokenizer() {}
 
   virtual Error load(const std::string& tokenizer_path) = 0;
@@ -73,7 +69,7 @@ class Tokenizer {
 
  protected:
   bool initialized_;
-  const int32_t vocab_size_;
+  int32_t vocab_size_;
   uint64_t bos_tok_, eos_tok_;
 };
 


### PR DESCRIPTION
Currently the logic is that if pte file doesn't contain metadata such as vocab size, bos id and eos id, use a default value. This doesn't work well because llama2 and llama3 are using different tokenizer artifacts, therefore they have different default values.

Instead assuming a default value at the runner level, we should deduce the values for vocab size bos id and eos id from the tokenizer aritifact, and let the metadata in the pte file override it.

This PR fixes this issue.

Test plan: demo app works for pte file without vocab size and eos id bos id:

![Simulator Screenshot - iPhone 15 Pro - 2024-06-10 at 18 07 21](https://github.com/pytorch/executorch/assets/8188269/923c60c5-0bec-4c4b-879f-419e04e52481)
