### PR TITLE
Fix manual permute within channels_last block

### DIFF
--- a/backends/xnnpack/operators/op_permute.py
+++ b/backends/xnnpack/operators/op_permute.py
@@ -11,12 +11,20 @@ from executorch.backends.xnnpack.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
 )
+from executorch.backends.xnnpack.passes.channels_last_tagged_reshape_pass import (
+    ChannelsLastTaggedReshapePass,
+)
 from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
     XNNGraph,
     XNNStaticTranspose,
     XNode,
 )
-from executorch.backends.xnnpack.utils.utils import get_input_node
+from executorch.backends.xnnpack.utils.utils import (
+    check_or_raise,
+    get_input_node,
+    PERM_NCHW_TO_NHWC,
+    PERM_NHWC_TO_NCHW,
+)
 
 
 @register_node_visitor
@@ -43,6 +51,21 @@ class PermuteVisitor(NodeVisitor):
 
         # permutation
         permute_order = cast(List[int], node.args[1])
+
+        # change permute order if under channels last
+        is_channels_last = node.meta.get(
+            ChannelsLastTaggedReshapePass.XNN_NHWC_NODE, False
+        )
+        if is_channels_last:
+            check_or_raise(
+                len(permute_order) == 4,
+                "Internal Error: Permute was tagged in channels last but is not 4D",
+            )
+            permute_order_in_contiguous = [PERM_NHWC_TO_NCHW[i] for i in permute_order]
+            permute_order_in_channels_last = [
+                permute_order_in_contiguous[i] for i in PERM_NCHW_TO_NHWC
+            ]
+            permute_order = permute_order_in_channels_last
 
         ser_node = XNode(
             xnode_union=XNNStaticTranspose(

--- a/backends/xnnpack/test/ops/conv2d.py
+++ b/backends/xnnpack/test/ops/conv2d.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
 import unittest
 from typing import Optional
 
@@ -124,6 +125,28 @@ class Conv2dBatchNorm(torch.nn.Module):
         return (torch.randn(2, 2, 4, 4),)
 
 
+class Conv2dPermute(torch.nn.Module):
+    def __init__(self, permute_order):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(
+            2,
+            2,
+            (2, 2),
+            bias=False,
+            padding=[2, 2],
+            stride=[2, 2],
+        )
+        self.permute_order = permute_order
+
+    def forward(self, x):
+        result = self.conv(x)
+        channels_last = torch.permute(result, self.permute_order)
+        return channels_last
+
+    def get_inputs(self):
+        return (torch.randn(2, 2, 4, 4),)
+
+
 class TestConv2d(unittest.TestCase):
     def _test(
         self,
@@ -162,6 +185,10 @@ class TestConv2d(unittest.TestCase):
     def test_fp32_conv2d(self) -> None:
         for has_bias in (True, False):
             self._test(Conv2d(bias=has_bias))
+
+    def test_fp32_conv2d_permute(self) -> None:
+        for perm_order in list(itertools.permutations([0, 1, 2, 3])):
+            self._test(Conv2dPermute(perm_order))
 
     def test_qs8_conv2d_test(self) -> None:
         for has_bias in (True, False):


### PR DESCRIPTION
Summary:
Our Channels Last reshape pass propagates channels_last computation for as long as possible in order to reduce the number of computes. As a result, we propagate the ending to_contiguous permute past actual permute operations. This means we end up computing permutes when the input is in channels last. As a result, we need to recalculate the permute order in order to correctly perform the permute within the channels last block.

Consider a manual permute reversing the dims within the channels last block below:
```
--> to_channels_last([0, 2, 3, 1])
--> permute([3, 2, 1, 0]) # needs to rewrite [3, 2, 1, 0] in channels last form
--> to_contiguous([0, 3, 1, 2])
```

In order to calculate the correct permutation order, we must perform the following
```
--> to_channels_last([0, 2, 3, 1])
--> to_contiguous([0, 3, 1, 2])
--> permute([3, 2, 1, 0])
--> to_channels_last([0, 2, 3, 1])
--> to_contiguous([0, 3, 1, 2])
```

We can then combine the middle permutes:
```
--> to_channels_last([0, 2, 3, 1])
--> permute([2, 3, 0, 1]) # [3, 2, 1, 0] in channels last form
--> to_contiguous([0, 3, 1, 2])
```

Reviewed By: digantdesai

Differential Revision: D58393086
