### PR TITLE
Add exir/program/test

### DIFF
--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -47,7 +47,7 @@ class WrapperModule(torch.nn.Module):
         return self.fn(*args, **kwargs)
 
 
-lib = Library("test_op", "DEF")
+lib = Library("exir_program_test_op", "DEF")
 
 # Fake a operator for testing.
 # This operator takes two tensors as input and returns the first one.
@@ -474,7 +474,7 @@ class TestProgramManagers(unittest.TestCase):
 
     def test_edge_dialect_custom_op(self):
         def _use_foo_add(a: torch.Tensor, b: torch.Tensor):
-            return torch.ops.test_op.foo(a, b)
+            return torch.ops.exir_program_test_op.foo(a, b)
 
         from torch._export.verifier import SpecViolationError
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -26,6 +26,7 @@ addopts =
     exir/dialects/backend/test
     exir/dialects/edge/test
     exir/dialects/test
+    exir/program/test
     exir/tests/test_arg_validator.py
     exir/tests/test_capture.py
     exir/tests/test_delegate.py


### PR DESCRIPTION
In exir/program/test/test_program.py, changed the library name to `exir_program_test_op` to avoid duplicated name between tests