### PR TITLE
Add runtime/kernel test

### DIFF
--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -7,11 +7,6 @@
 # This file contains util functions to generate code for kernel registration for
 # both AOT and runtime.
 
-include(${EXECUTORCH_ROOT}/build/Utils.cmake)
-if(NOT PYTHON_EXECUTABLE)
-  resolve_python_executable()
-endif()
-
 # Selective build. See codegen/tools/gen_oplist.py for how to use these
 # arguments.
 function(gen_selected_ops)
@@ -151,6 +146,8 @@ function(gen_custom_ops_aot_lib)
   target_compile_definitions(${GEN_LIB_NAME} PRIVATE USE_ATEN_LIB=1)
   include_directories(${TORCH_INCLUDE_DIRS})
   target_link_libraries(${GEN_LIB_NAME} PRIVATE torch executorch)
+
+  include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 
   target_link_options_shared_lib(${GEN_LIB_NAME})
 endfunction()

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -7,6 +7,11 @@
 # This file contains util functions to generate code for kernel registration for
 # both AOT and runtime.
 
+include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+if(NOT PYTHON_EXECUTABLE)
+  resolve_python_executable()
+endif()
+
 # Selective build. See codegen/tools/gen_oplist.py for how to use these
 # arguments.
 function(gen_selected_ops)
@@ -146,8 +151,6 @@ function(gen_custom_ops_aot_lib)
   target_compile_definitions(${GEN_LIB_NAME} PRIVATE USE_ATEN_LIB=1)
   include_directories(${TORCH_INCLUDE_DIRS})
   target_link_libraries(${GEN_LIB_NAME} PRIVATE torch executorch)
-
-  include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 
   target_link_options_shared_lib(${GEN_LIB_NAME})
 endfunction()

--- a/runtime/kernel/test/CMakeLists.txt
+++ b/runtime/kernel/test/CMakeLists.txt
@@ -22,17 +22,50 @@ set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
 include(${EXECUTORCH_ROOT}/build/Test.cmake)
 
-add_executable(operator_registry_test operator_registry_test.cpp ../operator_registry.cpp
- ../../core/evalue.cpp ../../platform/abort.cpp ../../platform/log.cpp ../../platform/runtime.cpp ../../platform/target/Posix.cpp)
+add_executable(operator_registry_test operator_registry_test.cpp)
 target_link_libraries(
-  operator_registry_test GTest::gtest GTest::gtest_main GTest::gmock
+  operator_registry_test GTest::gtest GTest::gtest_main GTest::gmock executorch
 )
 target_include_directories(operator_registry_test PRIVATE ${EXECUTORCH_ROOT}/..)
 add_test(ExecuTorchTest operator_registry_test)
 
 
-# et_cxx_test(operator_registry_test SOURCES operator_registry_test.cpp)
+add_executable(kernel_runtime_context_test kernel_runtime_context_test.cpp)
+target_link_libraries(
+  kernel_runtime_context_test GTest::gtest GTest::gtest_main GTest::gmock executorch
+)
+target_include_directories(kernel_runtime_context_test PRIVATE ${EXECUTORCH_ROOT}/..)
+add_test(ExecuTorchTest kernel_runtime_context_test)
 
-# et_cxx_test(runtime_max_kernel_num_test SOURCES operator_registry_max_kernel_num_test)
 
-# et_cxx_test(runtime_double_registration_test SOURCES kernel_double_registration_test)
+add_executable(operator_registry_max_kernel_num_test operator_registry_max_kernel_num_test.cpp ../operator_registry.cpp
+ ../../core/evalue.cpp ../../platform/abort.cpp ../../platform/log.cpp ../../platform/runtime.cpp ../../platform/target/Posix.cpp)
+target_link_libraries(
+  operator_registry_max_kernel_num_test GTest::gtest GTest::gtest_main GTest::gmock
+)
+target_compile_definitions(operator_registry_max_kernel_num_test PRIVATE "-DMAX_KERNEL_NUM=1")
+target_include_directories(operator_registry_max_kernel_num_test PRIVATE ${EXECUTORCH_ROOT}/..)
+add_test(ExecuTorchTest operator_registry_max_kernel_num_test)
+
+
+include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
+gen_selected_ops(LIB_NAME "specialized_ops_lib" OPS_SCHEMA_YAML "${CMAKE_CURRENT_LIST_DIR}/functions.yaml")
+generate_bindings_for_kernels(
+  LIB_NAME "specialized_ops_lib" FUNCTIONS_YAML "${CMAKE_CURRENT_LIST_DIR}/functions.yaml"
+)
+gen_operators_lib(
+  LIB_NAME "specialized_ops_lib" KERNEL_LIBS portable_kernels DEPS executorch
+)
+et_cxx_test(runtime_double_registration_test SOURCES kernel_double_registration_test.cpp)
+target_link_libraries(
+  runtime_double_registration_test GTest::gtest GTest::gtest_main GTest::gmock executorch
+)
+target_include_directories(runtime_double_registration_test PRIVATE ${EXECUTORCH_ROOT}/..)
+add_test(ExecuTorchTest runtime_double_registration_test)
+
+# add_executable(test_kernel_manual_registration_test test_kernel_manual_registration.cpp)
+# target_link_libraries(
+#   test_kernel_manual_registration_test GTest::gtest GTest::gtest_main GTest::gmock executorch portable_kernels portable_ops_lib
+# )
+# target_include_directories(test_kernel_manual_registration_test PRIVATE ${EXECUTORCH_ROOT}/..)
+# add_test(ExecuTorchTest test_kernel_manual_registration_test)

--- a/runtime/kernel/test/CMakeLists.txt
+++ b/runtime/kernel/test/CMakeLists.txt
@@ -29,43 +29,37 @@ target_link_libraries(
 target_include_directories(operator_registry_test PRIVATE ${EXECUTORCH_ROOT}/..)
 add_test(ExecuTorchTest operator_registry_test)
 
-
 add_executable(kernel_runtime_context_test kernel_runtime_context_test.cpp)
 target_link_libraries(
-  kernel_runtime_context_test GTest::gtest GTest::gtest_main GTest::gmock executorch
+  kernel_runtime_context_test GTest::gtest GTest::gtest_main GTest::gmock
+  executorch
 )
-target_include_directories(kernel_runtime_context_test PRIVATE ${EXECUTORCH_ROOT}/..)
+target_include_directories(
+  kernel_runtime_context_test PRIVATE ${EXECUTORCH_ROOT}/..
+)
 add_test(ExecuTorchTest kernel_runtime_context_test)
 
-
-add_executable(operator_registry_max_kernel_num_test operator_registry_max_kernel_num_test.cpp ../operator_registry.cpp
- ../../core/evalue.cpp ../../platform/abort.cpp ../../platform/log.cpp ../../platform/runtime.cpp ../../platform/target/Posix.cpp)
-target_link_libraries(
-  operator_registry_max_kernel_num_test GTest::gtest GTest::gtest_main GTest::gmock
+add_executable(
+  operator_registry_max_kernel_num_test
+  operator_registry_max_kernel_num_test.cpp
+  ../operator_registry.cpp
+  ../../core/evalue.cpp
+  ../../platform/abort.cpp
+  ../../platform/log.cpp
+  ../../platform/runtime.cpp
+  ../../platform/target/Posix.cpp
 )
-target_compile_definitions(operator_registry_max_kernel_num_test PRIVATE "-DMAX_KERNEL_NUM=1")
-target_include_directories(operator_registry_max_kernel_num_test PRIVATE ${EXECUTORCH_ROOT}/..)
+target_link_libraries(
+  operator_registry_max_kernel_num_test GTest::gtest GTest::gtest_main
+  GTest::gmock
+)
+target_compile_definitions(
+  operator_registry_max_kernel_num_test PRIVATE "-DMAX_KERNEL_NUM=1"
+)
+target_include_directories(
+  operator_registry_max_kernel_num_test PRIVATE ${EXECUTORCH_ROOT}/..
+)
 add_test(ExecuTorchTest operator_registry_max_kernel_num_test)
 
-
-include(${EXECUTORCH_ROOT}/build/Codegen.cmake)
-gen_selected_ops(LIB_NAME "specialized_ops_lib" OPS_SCHEMA_YAML "${CMAKE_CURRENT_LIST_DIR}/functions.yaml")
-generate_bindings_for_kernels(
-  LIB_NAME "specialized_ops_lib" FUNCTIONS_YAML "${CMAKE_CURRENT_LIST_DIR}/functions.yaml"
-)
-gen_operators_lib(
-  LIB_NAME "specialized_ops_lib" KERNEL_LIBS portable_kernels DEPS executorch
-)
-et_cxx_test(runtime_double_registration_test SOURCES kernel_double_registration_test.cpp)
-target_link_libraries(
-  runtime_double_registration_test GTest::gtest GTest::gtest_main GTest::gmock executorch
-)
-target_include_directories(runtime_double_registration_test PRIVATE ${EXECUTORCH_ROOT}/..)
-add_test(ExecuTorchTest runtime_double_registration_test)
-
-# add_executable(test_kernel_manual_registration_test test_kernel_manual_registration.cpp)
-# target_link_libraries(
-#   test_kernel_manual_registration_test GTest::gtest GTest::gtest_main GTest::gmock executorch portable_kernels portable_ops_lib
-# )
-# target_include_directories(test_kernel_manual_registration_test PRIVATE ${EXECUTORCH_ROOT}/..)
-# add_test(ExecuTorchTest test_kernel_manual_registration_test)
+# TODO: Migrate kernel_double_registration_test and
+# test_kernel_manual_registration. Make sure dtype selective build is working.

--- a/runtime/kernel/test/CMakeLists.txt
+++ b/runtime/kernel/test/CMakeLists.txt
@@ -22,13 +22,17 @@ set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
 include(${EXECUTORCH_ROOT}/build/Test.cmake)
 
-set(_test_srcs
-    kernel_runtime_context_test.cpp
-    operator_registry_test
+add_executable(operator_registry_test operator_registry_test.cpp ../operator_registry.cpp
+ ../../core/evalue.cpp ../../platform/abort.cpp ../../platform/log.cpp ../../platform/runtime.cpp ../../platform/target/Posix.cpp)
+target_link_libraries(
+  operator_registry_test GTest::gtest GTest::gtest_main GTest::gmock
 )
+target_include_directories(operator_registry_test PRIVATE ${EXECUTORCH_ROOT}/..)
+add_test(ExecuTorchTest operator_registry_test)
 
-et_cxx_test(runtime_kernel_test SOURCES ${_test_srcs} EXTRA_LIBS)
 
-et_cxx_test(runtime_max_kernel_num_test SOURCES operator_registry_max_kernel_num_test)
+# et_cxx_test(operator_registry_test SOURCES operator_registry_test.cpp)
 
-et_cxx_test(runtime_double_registration_test SOURCES kernel_double_registration_test)
+# et_cxx_test(runtime_max_kernel_num_test SOURCES operator_registry_max_kernel_num_test)
+
+# et_cxx_test(runtime_double_registration_test SOURCES kernel_double_registration_test)

--- a/runtime/kernel/test/CMakeLists.txt
+++ b/runtime/kernel/test/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# This file should be formatted with
+# ~~~
+# cmake-format -i CMakeLists.txt
+# ~~~
+# It should also be cmake-lint clean.
+#
+
+cmake_minimum_required(VERSION 3.19)
+project(runtime_kernel_test)
+
+# Use C++17 for test.
+set(CMAKE_CXX_STANDARD 17)
+
+set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+
+include(${EXECUTORCH_ROOT}/build/Test.cmake)
+
+set(_test_srcs
+    kernel_runtime_context_test.cpp
+    operator_registry_test
+)
+
+et_cxx_test(runtime_kernel_test SOURCES ${_test_srcs} EXTRA_LIBS)
+
+et_cxx_test(runtime_max_kernel_num_test SOURCES operator_registry_max_kernel_num_test)
+
+et_cxx_test(runtime_double_registration_test SOURCES kernel_double_registration_test)

--- a/runtime/kernel/test/operator_registry_test.cpp
+++ b/runtime/kernel/test/operator_registry_test.cpp
@@ -112,12 +112,12 @@ TEST_F(OperatorRegistryTest, RegisterTwoKernels) {
   make_kernel_key({{ScalarType::Float, {0, 1, 2, 3}}}, buf_float_contiguous);
   KernelKey key_2 = KernelKey(buf_float_contiguous);
   Kernel kernel_1 =
-      Kernel("test::boo", key_1, [](RuntimeContext& context, EValue** stack) {
+      Kernel("test::bar", key_1, [](RuntimeContext& context, EValue** stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });
   Kernel kernel_2 =
-      Kernel("test::boo", key_2, [](RuntimeContext& context, EValue** stack) {
+      Kernel("test::bar", key_2, [](RuntimeContext& context, EValue** stack) {
         (void)context;
         *(stack[0]) = Scalar(50);
       });
@@ -132,11 +132,11 @@ TEST_F(OperatorRegistryTest, RegisterTwoKernels) {
   TensorMeta meta_2[] = {TensorMeta(ScalarType::Float, dim_order_type)};
   ArrayRef<TensorMeta> user_kernel_key_2 = ArrayRef<TensorMeta>(meta_2, 1);
 
-  EXPECT_TRUE(hasOpsFn("test::boo", user_kernel_key_1));
-  EXPECT_TRUE(hasOpsFn("test::boo", user_kernel_key_2));
+  EXPECT_TRUE(hasOpsFn("test::bar", user_kernel_key_1));
+  EXPECT_TRUE(hasOpsFn("test::bar", user_kernel_key_2));
 
   // no fallback kernel is registered
-  EXPECT_FALSE(hasOpsFn("test::boo", {}));
+  EXPECT_FALSE(hasOpsFn("test::bar", {}));
 
   EValue values[1];
   values[0] = Scalar(0);
@@ -145,7 +145,7 @@ TEST_F(OperatorRegistryTest, RegisterTwoKernels) {
   RuntimeContext context{};
 
   // test kernel_1
-  OpFunction func_1 = getOpsFn("test::boo", user_kernel_key_1);
+  OpFunction func_1 = getOpsFn("test::bar", user_kernel_key_1);
   func_1(context, evalues);
 
   auto val_1 = values[0].toScalar().to<int64_t>();
@@ -153,7 +153,7 @@ TEST_F(OperatorRegistryTest, RegisterTwoKernels) {
 
   // test kernel_2
   values[0] = Scalar(0);
-  OpFunction func_2 = getOpsFn("test::boo", user_kernel_key_2);
+  OpFunction func_2 = getOpsFn("test::bar", user_kernel_key_2);
   func_2(context, evalues);
 
   auto val_2 = values[0].toScalar().to<int64_t>();
@@ -166,12 +166,12 @@ TEST_F(OperatorRegistryTest, DoubleRegisterKernelsDies) {
   KernelKey key = KernelKey(buf_long_contiguous);
 
   Kernel kernel_1 =
-      Kernel("test::boo", key, [](RuntimeContext& context, EValue** stack) {
+      Kernel("test::baz", key, [](RuntimeContext& context, EValue** stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });
   Kernel kernel_2 =
-      Kernel("test::boo", key, [](RuntimeContext& context, EValue** stack) {
+      Kernel("test::baz", key, [](RuntimeContext& context, EValue** stack) {
         (void)context;
         *(stack[0]) = Scalar(50);
       });
@@ -187,7 +187,7 @@ TEST_F(OperatorRegistryTest, ExecutorChecksKernel) {
   KernelKey key = KernelKey(buf_long_contiguous);
 
   Kernel kernel_1 =
-      Kernel("test::boo", key, [](RuntimeContext& context, EValue** stack) {
+      Kernel("test::qux", key, [](RuntimeContext& context, EValue** stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });
@@ -198,7 +198,7 @@ TEST_F(OperatorRegistryTest, ExecutorChecksKernel) {
   auto dim_order_type = ArrayRef<Tensor::DimOrderType>(dims, 4);
   TensorMeta meta[] = {TensorMeta(ScalarType::Long, dim_order_type)};
   ArrayRef<TensorMeta> user_kernel_key_1 = ArrayRef<TensorMeta>(meta, 1);
-  EXPECT_TRUE(hasOpsFn("test::boo", user_kernel_key_1));
+  EXPECT_TRUE(hasOpsFn("test::qux", user_kernel_key_1));
 
   Tensor::DimOrderType dims_channel_first[] = {0, 3, 1, 2};
   auto dim_order_type_channel_first =
@@ -207,11 +207,11 @@ TEST_F(OperatorRegistryTest, ExecutorChecksKernel) {
       TensorMeta(ScalarType::Long, dim_order_type_channel_first)};
   ArrayRef<TensorMeta> user_kernel_key_2 =
       ArrayRef<TensorMeta>(meta_channel_first, 1);
-  EXPECT_FALSE(hasOpsFn("test::boo", user_kernel_key_2));
+  EXPECT_FALSE(hasOpsFn("test::qux", user_kernel_key_2));
 
   TensorMeta meta_float[] = {TensorMeta(ScalarType::Float, dim_order_type)};
   ArrayRef<TensorMeta> user_kernel_key_3 = ArrayRef<TensorMeta>(meta_float, 1);
-  EXPECT_FALSE(hasOpsFn("test::boo", ArrayRef<TensorMeta>(user_kernel_key_3)));
+  EXPECT_FALSE(hasOpsFn("test::qux", ArrayRef<TensorMeta>(user_kernel_key_3)));
 }
 
 TEST_F(OperatorRegistryTest, ExecutorUsesKernel) {
@@ -220,7 +220,7 @@ TEST_F(OperatorRegistryTest, ExecutorUsesKernel) {
   KernelKey key = KernelKey(buf_long_contiguous);
 
   Kernel kernel_1 =
-      Kernel("test::boo", key, [](RuntimeContext& context, EValue** stack) {
+      Kernel("test::quux", key, [](RuntimeContext& context, EValue** stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });
@@ -231,9 +231,9 @@ TEST_F(OperatorRegistryTest, ExecutorUsesKernel) {
   auto dim_order_type = ArrayRef<Tensor::DimOrderType>(dims, 4);
   TensorMeta meta[] = {TensorMeta(ScalarType::Long, dim_order_type)};
   ArrayRef<TensorMeta> user_kernel_key_1 = ArrayRef<TensorMeta>(meta, 1);
-  EXPECT_TRUE(hasOpsFn("test::boo", ArrayRef<TensorMeta>(meta)));
+  EXPECT_TRUE(hasOpsFn("test::quux", ArrayRef<TensorMeta>(meta)));
 
-  OpFunction func = getOpsFn("test::boo", ArrayRef<TensorMeta>(meta));
+  OpFunction func = getOpsFn("test::quux", ArrayRef<TensorMeta>(meta));
 
   EValue values[1];
   values[0] = Scalar(0);
@@ -248,17 +248,17 @@ TEST_F(OperatorRegistryTest, ExecutorUsesKernel) {
 
 TEST_F(OperatorRegistryTest, ExecutorUsesFallbackKernel) {
   Kernel kernel_1 = Kernel(
-      "test::boo", KernelKey{}, [](RuntimeContext& context, EValue** stack) {
+      "test::corge", KernelKey{}, [](RuntimeContext& context, EValue** stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });
   auto s1 = register_kernels({kernel_1});
   EXPECT_EQ(s1, torch::executor::Error::Ok);
 
-  EXPECT_TRUE(hasOpsFn("test::boo"));
-  EXPECT_TRUE(hasOpsFn("test::boo", ArrayRef<TensorMeta>()));
+  EXPECT_TRUE(hasOpsFn("test::corge"));
+  EXPECT_TRUE(hasOpsFn("test::corge", ArrayRef<TensorMeta>()));
 
-  OpFunction func = getOpsFn("test::boo", ArrayRef<TensorMeta>());
+  OpFunction func = getOpsFn("test::corge", ArrayRef<TensorMeta>());
 
   EValue values[1];
   values[0] = Scalar(0);

--- a/runtime/kernel/test/targets.bzl
+++ b/runtime/kernel/test/targets.bzl
@@ -37,18 +37,6 @@ def define_common_targets():
         define_static_targets = True,
     )
 
-    executorch_generated_lib(
-        name = "test_generated_lib_1",
-        deps = [
-            ":executorch_all_ops",
-            "//executorch/kernels/portable:operators",
-        ],
-        functions_yaml_target = "//executorch/kernels/portable:functions.yaml",
-        visibility = [
-            "//executorch/...",
-        ],
-    )
-
     runtime.export_file(
         name = "functions.yaml",
     )


### PR DESCRIPTION
Migrate operator_registry_test, kernel_runtime_context_test, operator_registry_max_kernel_num_test.

TODO: Migrate kernel_double_registration_test and test_kernel_manual_registration. It requires setting up new specialized ops library target.

Test Plan: `sh test/run_oss_cpp_tests.sh runtime/kernel/test/`