### PR TITLE
[ExecuTorch][Vulkan] SDK Integration  1/n: AOT DDI Serialization

### DIFF
--- a/backends/vulkan/serialization/schema.fbs
+++ b/backends/vulkan/serialization/schema.fbs
@@ -6,6 +6,7 @@ namespace vkgraph;
 file_identifier "VK00";
 
 table OperatorCall {
+  node_id:uint;
   name:string;
   args:[int];
 }

--- a/backends/vulkan/serialization/vulkan_graph_builder.py
+++ b/backends/vulkan/serialization/vulkan_graph_builder.py
@@ -12,6 +12,7 @@ from typing import cast, List, Optional, Union
 import executorch.backends.vulkan.serialization.vulkan_graph_schema as vk_graph_schema
 
 import torch
+from executorch.exir.backend.utils import DelegateMappingBuilder
 
 from executorch.exir.tensor import TensorSpec
 from torch._export.utils import get_buffer, get_param, is_buffer, is_param
@@ -25,9 +26,13 @@ _Argument = Union[
 
 
 class VkGraphBuilder:
-    def __init__(self, program: ExportedProgram) -> None:
+    def __init__(
+        self,
+        program: ExportedProgram,
+        delegate_mapping_builder: DelegateMappingBuilder,
+    ) -> None:
         self.program = program
-
+        self.delegate_mapping_builder = delegate_mapping_builder
         self.chain = []
         self.values = []
         self.input_ids = []
@@ -295,9 +300,14 @@ class VkGraphBuilder:
 
         # Add output node
         operator_call_args.append(self.create_node_value(node))
-
+        operator_node_id = (
+            0
+            if not self.delegate_mapping_builder
+            else self.delegate_mapping_builder.insert_delegate_mapping_entry(node)
+        )
         self.chain.append(
             vk_graph_schema.OperatorCall(
+                node_id=operator_node_id,  # pyre-ignore[6]: this is going to be an int
                 name=node.target.__name__,
                 args=operator_call_args,
             ),
@@ -316,13 +326,14 @@ class VkGraphBuilder:
                 )
             self.output_ids.append(self.node_to_value_ids[out_node])
 
-    def process_node(self, node: Node) -> None:
+    def process_node(self, node: Node, call_node_debug_hdl: int) -> None:
         if node.op == "placeholder":
             self.process_placeholder_node(node)
         elif node.op == "call_function":
             if node.target == operator.getitem:
                 self.process_getitem_node(node)
             else:
+                node.meta["debug_handle"] = call_node_debug_hdl
                 self.process_call_function_node(node)
         elif node.op == "get_attr":
             self.process_getattr_node(node)
@@ -332,8 +343,10 @@ class VkGraphBuilder:
             raise AssertionError(f"Unsupported node op: {node.op}")
 
     def build_graph(self) -> vk_graph_schema.VkGraph:
+        call_node_debug_hdl = 0
         for node in self.program.graph_module.graph.nodes:
-            self.process_node(node)
+            self.process_node(node, call_node_debug_hdl)
+            call_node_debug_hdl += 1
 
         logging.info("Operators included in this Vulkan partition: ")
         for op in self.seen_ops:

--- a/backends/vulkan/serialization/vulkan_graph_schema.py
+++ b/backends/vulkan/serialization/vulkan_graph_schema.py
@@ -17,6 +17,7 @@ from typing import List, Union
 
 @dataclass
 class OperatorCall:
+    node_id: int
     name: str
     args: List[int]
 

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -23,6 +23,7 @@ from executorch.exir.backend.backend_details import (
     ExportedProgram,
     PreprocessResult,
 )
+from executorch.exir.backend.utils import DelegateMappingBuilder
 
 from executorch.exir.passes import MemoryPlanningPass, SpecPropPass
 
@@ -66,11 +67,14 @@ class VulkanBackend(BackendDetails):
 
         _copy_module(program.graph_module, new_gm)
 
-        graph_builder = VkGraphBuilder(program)
+        graph_builder = VkGraphBuilder(
+            program, DelegateMappingBuilder(generated_identifiers=True)
+        )
         vk_graph = graph_builder.build_graph()
 
         return PreprocessResult(
             processed_bytes=serialize_vulkan_graph(
                 vk_graph, graph_builder.const_tensors, []
             ),
+            debug_handle_map=graph_builder.delegate_mapping_builder.get_delegate_mapping(),
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3961
* #3960
* #3959
* #3958
* __->__ #3957

**See [design doc](https://docs.google.com/document/d/1KQ0vH0IhZK24sBbym7TYXfYssAgtPjI-htcxraoxEaM/edit).**
__1/n: AOT DDI Serialization__
- I begin by modifying `OperatorCall`'s flatbuffer schema to have `node_id`, which will store the DDI
- I pass optional `DelegateMappingBuilder` to `VkGraphBuilder`'s Python ctor and then assign and construct `OperatorCall` objects with generated DDIs
- I modify the `OperatorCall` Python dataclass to have `node_id` as well

Differential Revision: [D57424318](https://our.internmc.facebook.com/intern/diff/D57424318/)