### PR TITLE
[ExecuTorch][Vulkan] SDK Integration 2/n: Runtime DDI Deserialization

### DIFF
--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -131,6 +131,10 @@ class ComputeGraph final {
     return execute_nodes_;
   }
 
+  inline GraphConfig& graphconfig() {
+    return config_;
+  }
+
   //
   // Value Extraction
   //

--- a/backends/vulkan/runtime/graph/ops/ExecuteNode.h
+++ b/backends/vulkan/runtime/graph/ops/ExecuteNode.h
@@ -69,7 +69,12 @@ class ExecuteNode final {
     }
   }
 
+  inline void set_node_id(uint32_t node_id) {
+    node_id_ = node_id;
+  }
+
  protected:
+  uint32_t node_id_;
   const api::ShaderInfo shader_;
   const api::utils::uvec3 global_workgroup_size_;
   const api::utils::uvec3 local_workgroup_size_;

--- a/backends/vulkan/runtime/graph/ops/PrepackNode.h
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.h
@@ -40,7 +40,12 @@ class PrepackNode final {
 
   void encode(ComputeGraph* graph);
 
+  inline void set_node_id(uint32_t node_id) {
+    node_id_ = node_id;
+  }
+
  protected:
+  uint32_t node_id_;
   const api::ShaderInfo shader_;
   api::ShaderInfo noop_shader_;
   const api::utils::uvec3 global_workgroup_size_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3961
* #3960
* #3959
* __->__ #3958
* #3957

See [design doc](https://docs.google.com/document/d/1KQ0vH0IhZK24sBbym7TYXfYssAgtPjI-htcxraoxEaM/edit).

__2/n: Runtime DDI Deserialization__



- We parse the `node_id` from `OperatorCall` from the model flatbuffer chain on init,
  - Due to how `<Execute/Prepack>Node` construction is abstracted away, we set the parsed `node_id` of themselves after their construction by checking if there are new additions to the vector with new functions and new member `uint32_t node_id`
  - `ExecuteNode::set_shader_node_id()`
  - `PrepackNode::set_shader_node_id()`

Differential Revision: [D57424319](https://our.internmc.facebook.com/intern/diff/D57424319/)