### PR TITLE
[ExecuTorch][Vulkan] SDK Integration 3/n:  QueryPool With node_id

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -8,6 +8,7 @@
 
 #include <executorch/backends/vulkan/runtime/api/Context.h>
 
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <sstream>
@@ -68,10 +69,12 @@ void Context::cmd_reset_querypool() {
 void Context::report_shader_dispatch_start(
     const std::string& shader_name,
     const utils::uvec3& global_wg_size,
-    const utils::uvec3& local_wg_size) {
+    const utils::uvec3& local_wg_size,
+    const uint32_t dispatch_id) {
   if (querypool_) {
     querypool_.shader_profile_begin(
         cmd_,
+        dispatch_id,
         shader_name,
         create_extent3d(global_wg_size),
         create_extent3d(local_wg_size));

--- a/backends/vulkan/runtime/api/Context.h
+++ b/backends/vulkan/runtime/api/Context.h
@@ -148,7 +148,8 @@ class Context final {
   void report_shader_dispatch_start(
       const std::string& shader_name,
       const utils::uvec3& global_wg_size,
-      const utils::uvec3& local_wg_size);
+      const utils::uvec3& local_wg_size,
+      const uint32_t dispatch_id = UINT32_MAX);
 
   /*
    * Encodes a vkCmdWriteTimstamp command to the current command buffer to
@@ -217,6 +218,7 @@ class Context final {
       const utils::uvec3&,
       const SpecVarList&,
       VkFence fence_handle,
+      const uint32_t dispatch_id,
       Arguments&&...);
 
   void submit_cmd_to_gpu(
@@ -509,6 +511,7 @@ inline bool Context::submit_compute_job(
     const utils::uvec3& local_work_group_size,
     const SpecVarList& specialization_constants,
     VkFence fence_handle,
+    const uint32_t dispatch_id,
     Arguments&&... arguments) {
   // If any of the provided arguments does not have memory associated with it,
   // then exit early as there is no work to be done. However, if a fence has
@@ -539,7 +542,10 @@ inline bool Context::submit_compute_job(
   set_cmd();
 
   report_shader_dispatch_start(
-      shader.kernel_name, global_work_group, local_work_group_size);
+      shader.kernel_name,
+      global_work_group,
+      local_work_group_size,
+      dispatch_id);
 
   // Factor out template parameter independent code to minimize code bloat.
   DescriptorSet descriptor_set = get_descriptor_set(

--- a/backends/vulkan/runtime/api/QueryPool.cpp
+++ b/backends/vulkan/runtime/api/QueryPool.cpp
@@ -101,6 +101,7 @@ void QueryPool::reset_state() {
 
 void QueryPool::shader_profile_begin(
     const CommandBuffer& cmd,
+    const uint32_t dispatch_id,
     const std::string& kernel_name,
     const VkExtent3D global_workgroup_size,
     const VkExtent3D local_workgroup_size) {
@@ -112,6 +113,7 @@ void QueryPool::shader_profile_begin(
   ShaderDuration log_entry{
       api::utils::safe_downcast<uint32_t>(shader_durations_.size()),
       // Execution Properties
+      dispatch_id,
       kernel_name,
       global_workgroup_size,
       local_workgroup_size,

--- a/backends/vulkan/runtime/api/QueryPool.h
+++ b/backends/vulkan/runtime/api/QueryPool.h
@@ -10,6 +10,7 @@
 
 // @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
 
+#include <cstdint>
 #include <functional>
 
 #include <executorch/backends/vulkan/runtime/api/vk_api.h>
@@ -34,6 +35,7 @@ struct ShaderDuration final {
   uint32_t idx;
 
   // Execution Properties
+  uint32_t dispatch_id;
   std::string kernel_name;
   VkExtent3D global_workgroup_size;
   VkExtent3D local_workgroup_size;
@@ -86,6 +88,7 @@ class QueryPool final {
 
   void shader_profile_begin(
       const CommandBuffer&,
+      const uint32_t,
       const std::string&,
       const VkExtent3D,
       const VkExtent3D);

--- a/backends/vulkan/runtime/graph/ops/ExecuteNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/ExecuteNode.cpp
@@ -42,7 +42,10 @@ void ExecuteNode::encode(ComputeGraph* graph) {
   std::unique_lock<std::mutex> cmd_lock = context->dispatch_lock();
 
   context->report_shader_dispatch_start(
-      shader_.kernel_name, global_workgroup_size_, local_workgroup_size_);
+      shader_.kernel_name,
+      global_workgroup_size_,
+      local_workgroup_size_,
+      node_id_);
 
   api::DescriptorSet descriptor_set =
       context->get_descriptor_set(shader_, local_workgroup_size_, spec_vars_);

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -32,6 +32,7 @@ void record_nchw_to_buffer_op(
       {64, 1, 1},
       specialization_constants,
       VK_NULL_HANDLE,
+      0,
       v_dst.buffer(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
@@ -56,6 +57,7 @@ void record_buffer_to_nchw_op(
       {64, 1, 1},
       specialization_constants,
       VK_NULL_HANDLE,
+      0,
       v_src.buffer(pipeline_barrier, api::PipelineStage::COMPUTE),
       dst_buffer,
       v_src.sizes_ubo(),
@@ -77,6 +79,7 @@ void record_nchw_to_image_op(
       adaptive_work_group_size(v_dst.image_extents()),
       specialization_constants,
       VK_NULL_HANDLE,
+      0,
       v_dst.image(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
@@ -99,6 +102,7 @@ void record_image_to_nchw_op(
       adaptive_work_group_size(v_src.image_extents()),
       specialization_constants,
       VK_NULL_HANDLE,
+      0,
       v_src.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       dst_buffer,
       v_src.sizes_ubo());
@@ -133,6 +137,7 @@ void record_conv2d_prepack_weights_op(
       adaptive_work_group_size(v_dst.image_extents()),
       specialization_constants,
       VK_NULL_HANDLE,
+      0,
       v_dst.image(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
@@ -160,6 +165,7 @@ void record_binary_op(
       adaptive_work_group_size(v_dst.image_extents()),
       specialization_constants,
       VK_NULL_HANDLE,
+      0,
       v_dst.image(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
@@ -223,6 +229,7 @@ void record_index_fill_buffer(api::Context* context, vTensor& v_ten) {
         {64, 1, 1},
         specialization_constants,
         VK_NULL_HANDLE,
+        0,
         v_ten.buffer(
             pipeline_barrier,
             api::PipelineStage::COMPUTE,
@@ -246,6 +253,7 @@ void record_scalar_add_buffer(
       {64, 1, 1},
       specialization_constants,
       VK_NULL_HANDLE,
+      0,
       v_ten.buffer(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -227,6 +227,7 @@ TEST_F(VulkanComputeAPITest, spec_var_shader_test) {
         {len_div4, 1, 1},
         {SV(scale), SV(offset)},
         VK_NULL_HANDLE,
+        0,
         buffer.buffer(),
         params.buffer());
   }
@@ -273,6 +274,7 @@ TEST_F(VulkanComputeAPITest, update_params_between_submit) {
         {4, 4, 4},
         specialization_constants,
         VK_NULL_HANDLE,
+        0,
         a.image(
             pipeline_barrier,
             api::PipelineStage::COMPUTE,
@@ -334,6 +336,7 @@ void test_storage_buffer_type(const size_t len) {
         {len_div4, 1, 1},
         specialization_constants,
         VK_NULL_HANDLE,
+        0,
         buffer.buffer(),
         params.buffer());
   }
@@ -1569,6 +1572,7 @@ void run_from_gpu_test(
         {4, 4, 4},
         specialization_constants,
         VK_NULL_HANDLE,
+        0,
         vten.image(
             pipeline_barrier,
             api::PipelineStage::COMPUTE,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3961
* #3960
* __->__ #3959
* #3958
* #3957

See [design doc](https://docs.google.com/document/d/1KQ0vH0IhZK24sBbym7TYXfYssAgtPjI-htcxraoxEaM/edit).

__3/n: QueryPool with node_id__
- Now we have the full E2E linked of a coherent DDI, serialized AOT to the flatbuffer, deserialized Runtime to `ShaderInfo`.
- We add `node_id` as default-valued argument (`UINT32_MAX`) to `Context::submit_compute_job()` which allows`ShaderDuration` to be constructed later with `node_id`
- I modify `QueryPool::shader_profile_begin()` , `Context::report_shader_dispatch_start()`, to construct `ShaderDuration` with the `node_id` from `ExecuteNode`

Differential Revision: [D57424317](https://our.internmc.facebook.com/intern/diff/D57424317/)