### PR TITLE
[ExecuTorch][Vulkan] SDK Integration 4/n: Expose QueryPool data to ComputeGraph

### DIFF
--- a/backends/vulkan/runtime/api/QueryPool.cpp
+++ b/backends/vulkan/runtime/api/QueryPool.cpp
@@ -175,6 +175,23 @@ std::string stringize(const VkExtent3D& extents) {
      << "}";
   return ss.str();
 }
+std::vector<std::tuple<std::string, uint32_t, uint64_t, uint64_t>>
+QueryPool::get_shader_timestamp_data() {
+  if (VK_NULL_HANDLE == querypool_) {
+    return {};
+  }
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<std::tuple<std::string, uint32_t, uint64_t, uint64_t>>
+      shader_timestamp_data;
+  for (ShaderDuration& entry : shader_durations_) {
+    shader_timestamp_data.emplace_back(std::make_tuple(
+        entry.kernel_name,
+        entry.dispatch_id,
+        entry.start_time_ns,
+        entry.end_time_ns));
+  }
+  return shader_timestamp_data;
+}
 
 std::string QueryPool::generate_string_report() {
   std::lock_guard<std::mutex> lock(mutex_);

--- a/backends/vulkan/runtime/api/QueryPool.h
+++ b/backends/vulkan/runtime/api/QueryPool.h
@@ -97,6 +97,8 @@ class QueryPool final {
 
   void extract_results();
 
+  std::vector<std::tuple<std::string, uint32_t, uint64_t, uint64_t>>
+  get_shader_timestamp_data();
   std::string generate_string_report();
   void print_results();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3961
* __->__ #3960
* #3959
* #3958
* #3957

See [design doc](https://docs.google.com/document/d/1KQ0vH0IhZK24sBbym7TYXfYssAgtPjI-htcxraoxEaM/edit).

__4/n: Expose QueryPool data to ComputeGraph__
- I make a simple change to QueryPool given the complexity of its lifecycle now and deviate from the design of `VulkanProfiler`. We can implement more of those feature later.
- Turn the shader data into vector of tuples

Differential Revision: [D57426500](https://our.internmc.facebook.com/intern/diff/D57426500/)