### PR TITLE
[ExecuTorch][Vulkan] SDK Integration 5/n: EventTracer

### DIFF
--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -208,6 +208,7 @@ def define_common_targets(is_fbcode = False):
         deps = [
             ":vk_delegate_schema",
             ":vulkan_graph_runtime",
+            "//executorch/runtime/core:event_tracer",
             "//executorch/runtime/backend:interface",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
         ],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3961
* #3960
* #3959
* #3958
* #3957

See [design doc](https://docs.google.com/document/d/1KQ0vH0IhZK24sBbym7TYXfYssAgtPjI-htcxraoxEaM/edit).

__EventTracer__
- We integrate the SDK's `EventTracer` flow into `VulkanBackend.cpp` which is not part of `vulkan_graph_runtime`.
- Simply follow the SDK a posteriori logging flow using the durations from `QueryPool::generate_et_tracing_data()`, at the end of `VulkanBackend::execute()` inference
- Compile time gate with `ET_EVENT_TRACER_ENABLED` in this case because the dependency is not coming from Vulkan delegate itsel

Differential Revision: [D57508095](https://our.internmc.facebook.com/intern/diff/D57508095/)