### PR TITLE
Implement aten.constant_pad_nd.default with constant mode

### DIFF
--- a/backends/vulkan/partitioner/supported_ops.py
+++ b/backends/vulkan/partitioner/supported_ops.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import operator
 
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -116,6 +118,7 @@ ORCHESTRATION_OPS = [
 CREATION_OPS = [
     exir_ops.edge.aten.arange.start_step,
     exir_ops.edge.aten.clone.default,
+    exir_ops.edge.aten.constant_pad_nd.default,
     exir_ops.edge.aten.full.default,
     exir_ops.edge.aten.full_like.default,
     exir_ops.edge.aten.ones.default,

--- a/backends/vulkan/runtime/graph/ops/glsl/pad_channel.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/pad_channel.glsl
@@ -1,0 +1,80 @@
+#version 450 core
+
+#define PRECISION ${PRECISION}
+
+#define VEC4_T ${texel_type(DTYPE)}
+
+layout(std430) buffer;
+
+#include "indexing_utils.h"
+
+${layout_declare_tensor(0, "w", "t_out", DTYPE, STORAGE)}
+${layout_declare_tensor(1, "r", "t_in", DTYPE, STORAGE)}
+${layout_declare_ubo(2, "ivec4", "out_sizes")}
+${layout_declare_ubo(3, "ivec4", "in_sizes")}
+${layout_declare_ubo(4, "int", "pad_left", "int", "pad_top", "int", "pad_front")}
+${layout_declare_ubo(5, "float", "fill_value")}
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+layout(constant_id = 3) const int packed_dim = C_DIM;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  const ivec4 idx = to_tensor_idx(pos, out_sizes, packed_dim);
+
+  if (pos_out_of_bounds(pos, out_sizes, packed_dim)) {
+    return;
+  }
+
+  VEC4_T outtex = VEC4_T(fill_value);
+  // mask_z/y/x is used to determine whether need to fecth data from input tensor
+  bool mask_z = (idx.z + 3) < pad_front || idx.z > (pad_front + in_sizes.z - 1);
+  bool mask_y = idx.y >= pad_top && idx.y <= pad_top + in_sizes.y - 1;
+  bool mask_x = idx.x >= pad_left && idx.x <= pad_left + in_sizes.x - 1;
+
+  if (!mask_z && mask_y && mask_x) {
+    // channel_mask is to determine the situation that when padding channel dimension,
+    // in one texel, some elements are filled vaule and some value are from input tensor
+    ivec4 c_ind = ivec4(idx.z) + ivec4(0, 1, 2, 3);
+    ivec4 channel_mask = ivec4(lessThan(c_ind, ivec4(pad_front))) + ivec4(greaterThan(c_ind, ivec4(pad_front + in_sizes.z - 1)));
+
+    ivec4 in_idx = idx;
+    in_idx.x -= pad_left;
+    in_idx.y -= pad_top;
+    in_idx.z -= divup4(pad_front) * 4;
+    const int shift = pad_front % 4;
+    VEC4_T cur_in_texel = texelFetch(t_in, to_texture_pos(in_idx, in_sizes, packed_dim), 0);
+    VEC4_T next_in_texel;
+    // When shift is not 0, we need to read 2 texels from input tensor to write into output
+    // for example:
+    // input texel is [[1 2 3 4], [5 6 x x]] and front_pad = 2
+    // output texel is [[p p 1 2], [3 4 5 6]], where p is the filled value then need to fetch 2 texels to fill [3 4 5 6].
+    if (shift != 0) {
+      in_idx.z += 4;
+      next_in_texel = texelFetch(t_in, to_texture_pos(in_idx, in_sizes, packed_dim), 0);
+    } else {
+      next_in_texel = cur_in_texel;
+    }
+
+    VEC4_T inter_texel;
+    for (int i = 0; i < 4; i++) {
+      if (i < shift) {
+        inter_texel[i] = cur_in_texel[4-shift+i];
+      } else {
+        inter_texel[i] = next_in_texel[i-shift];
+      }
+    }
+    outtex = inter_texel * (VEC4_T(1) - channel_mask) + outtex * channel_mask;
+  }
+
+  int packed_idx = idx[packed_dim];
+  const int packed_dim_size = out_sizes[packed_dim];
+  if (packed_idx + 3 >= packed_dim_size) {
+    ivec4 packed_ind = ivec4(packed_idx) + ivec4(0, 1, 2, 3);
+    VEC4_T valid_idx = VEC4_T(lessThan(packed_ind, ivec4(packed_dim_size)));
+    outtex = outtex * valid_idx;
+  }
+
+  imageStore(t_out, pos, outtex);
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/pad_channel.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/pad_channel.yaml
@@ -1,0 +1,12 @@
+pad_channel:
+  parameter_names_with_default_values:
+    NDIM: 3
+    DTYPE: float
+    PACKING: C_packed
+    STORAGE: texture3d
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: float
+      - VALUE: half
+  shader_variants:
+    - NAME: pad_channel

--- a/backends/vulkan/runtime/graph/ops/glsl/pad_height_width.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/pad_height_width.glsl
@@ -1,0 +1,50 @@
+#version 450 core
+
+#define PRECISION ${PRECISION}
+
+#define VEC4_T ${texel_type(DTYPE)}
+
+layout(std430) buffer;
+
+#include "indexing_utils.h"
+
+${layout_declare_tensor(0, "w", "t_out", DTYPE, STORAGE)}
+${layout_declare_tensor(1, "r", "t_in", DTYPE, STORAGE)}
+${layout_declare_ubo(2, "ivec4", "out_sizes")}
+${layout_declare_ubo(3, "ivec4", "in_sizes")}
+${layout_declare_ubo(4, "int", "pad_left", "int", "pad_top", "int", "pad_front")}
+${layout_declare_ubo(5, "float", "fill_value")}
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+layout(constant_id = 3) const int packed_dim = C_DIM;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  const ivec4 idx = to_tensor_idx(pos, out_sizes, packed_dim);
+
+  if (pos_out_of_bounds(pos, out_sizes, packed_dim)) {
+    return;
+  }
+
+  bool mask_height = idx.y >= pad_top && idx.y <= pad_top + in_sizes.y - 1;
+  bool mask_width = idx.x >= pad_left && idx.x <= pad_left + in_sizes.x - 1;
+
+  VEC4_T outtex = VEC4_T(fill_value);
+  if (mask_height && mask_width) {
+    ivec4 in_idx = idx;
+    in_idx.x -= pad_left;
+    in_idx.y -= pad_top;
+    outtex = texelFetch(t_in, to_texture_pos(in_idx, in_sizes, packed_dim), 0);
+  }
+
+  int packed_idx = idx[packed_dim];
+  const int packed_dim_size = out_sizes[packed_dim];
+  if (packed_idx + 3 >= packed_dim_size) {
+    ivec4 packed_ind = ivec4(packed_idx) + ivec4(0, 1, 2, 3);
+    VEC4_T valid_idx = VEC4_T(lessThan(packed_ind, ivec4(packed_dim_size)));
+    outtex = outtex * valid_idx;
+  }
+
+  imageStore(t_out, pos, outtex);
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/pad_height_width.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/pad_height_width.yaml
@@ -1,0 +1,12 @@
+pad_height_width:
+  parameter_names_with_default_values:
+    NDIM: 3
+    DTYPE: float
+    PACKING: C_packed
+    STORAGE: texture3d
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: float
+      - VALUE: half
+  shader_variants:
+    - NAME: pad_height_width

--- a/backends/vulkan/runtime/graph/ops/impl/Pad.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Pad.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+namespace vkcompute {
+
+struct PadParam final {
+  int32_t left;
+  int32_t top;
+  int32_t front;
+};
+
+PadParam creat_pad_param(const std::vector<int64_t>& pad) {
+  if (pad.size() == 2) {
+    return PadParam{static_cast<int32_t>(pad[0]), 0, 0};
+  } else if (pad.size() == 4) {
+    return PadParam{
+        static_cast<int32_t>(pad[0]), static_cast<int32_t>(pad[2]), 0};
+  } else if (pad.size() == 6) {
+    return PadParam{
+        static_cast<int32_t>(pad[0]),
+        static_cast<int32_t>(pad[2]),
+        static_cast<int32_t>(pad[4])};
+  } else {
+    VK_THROW("invalid pad form");
+  }
+}
+
+void resize_constant_pad_node(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& extra_args) {
+  vTensorPtr out = graph->get_tensor(args[0].refs[0]);
+  vTensorPtr self = graph->get_tensor(args[1].refs[0]);
+  IntListPtr pad_vec = graph->get_int_list(extra_args[0]);
+  std::vector<int64_t> in_size = self->sizes();
+  int dim = in_size.size() - 1;
+  for (int i = 0; i < pad_vec->size(); i += 2) {
+    in_size.at(dim) += pad_vec->at(i) + pad_vec->at(i + 1);
+    dim--;
+  }
+
+  out->virtual_resize(in_size);
+}
+
+void add_constant_pad_nd_node(
+    ComputeGraph& graph,
+    const ValueRef& in,
+    const ValueRef& pad,
+    const ValueRef& fill_value,
+    const ValueRef& out) {
+  float fill_value_val = graph.extract_scalar<float>(fill_value);
+  IntListPtr pad_vec = graph.get_int_list(pad);
+  vTensorPtr t_in = graph.get_tensor(in);
+  vTensorPtr t_out = graph.get_tensor(out);
+
+  api::utils::uvec3 global_size = t_out->image_extents();
+  api::utils::uvec3 local_size = adaptive_work_group_size(global_size);
+
+  std::string kernel_name = "";
+  PadParam pad_param = creat_pad_param(*pad_vec);
+
+  if (pad_vec->size() <= 4) {
+    kernel_name = "pad_height_width";
+    kernel_name.reserve(kShaderNameReserve);
+    add_dtype_suffix(kernel_name, *t_out);
+  } else {
+    kernel_name = "pad_channel";
+    kernel_name.reserve(kShaderNameReserve);
+    add_dtype_suffix(kernel_name, *t_out);
+  }
+
+  graph.execute_nodes().emplace_back(new ExecuteNode(
+      graph,
+      VK_KERNEL_FROM_STR(kernel_name),
+      global_size,
+      local_size,
+      // Inputs and Outputs
+      {{out, api::MemoryAccessType::WRITE}, {in, api::MemoryAccessType::READ}},
+      // Shader params buffers
+      {t_out->sizes_ubo(),
+       t_in->sizes_ubo(),
+       graph.create_params_buffer(pad_param),
+       graph.create_params_buffer(fill_value_val)},
+      // Specialization Constants
+      {},
+      resize_constant_pad_node,
+      {pad}));
+}
+
+void constant_pad_nd(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  return add_constant_pad_nd_node(graph, args[0], args[1], args[2], args[3]);
+}
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(aten.constant_pad_nd.default, constant_pad_nd);
+}
+
+} // namespace vkcompute

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -989,3 +989,20 @@ def get_arange_inputs():
         "api::kChannelsPacked",
     ]
     return test_suite
+
+
+@register_test_suite("aten.constant_pad_nd.default")
+def get_constant_pad_nd_inputs():
+    test_suite = VkTestSuite(
+        [
+            ([S1, S2], [1, 1], 24.0),
+            ([M, M1, M2], [2, 2], 23.2),
+            ([L, M, M1, M2], [3, 5], 12.2),
+            ([S1, S2], [1, 1, 1, 1], 24.0),
+            ([M, M1, M2], [2, 2, 2, 2], 23.2),
+            ([L, M, M1, M2], [3, 5, 3, 5], 12.2),
+            ([M, M1, M2], [1, 2, 3, 4, 5, 6], 23.2),
+            ([L, M, M1, M2], [3, 3, 3, 3, 3, 3], 12.2),
+        ]
+    )
+    return test_suite

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -1275,6 +1275,22 @@ class TestBackends(unittest.TestCase):
             memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
         )
 
+    def test_vulkan_backend_constant_pad_nd(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.nn.functional.pad(x, (1, 2, 3, 4, 5, 6), "constant", 24.2)
+
+        sample_inputs = (torch.randn(size=(3, 7, 5, 11), dtype=torch.float32),)
+
+        self.lower_module_and_test_output(
+            TestModule(),
+            sample_inputs,
+            memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
+        )
+
     def test_vulkan_backend_repeat(self):
         class TestModule(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
Summary:
Implement aten.constant_pad_nd.default, needed in OCR full model.
```
- func: constant_pad_nd(Tensor self, SymInt[] pad, Scalar value=0) -> Tensor
```
[torch.nn.functional.pad](https://pytorch.org/docs/stable/generated/torch.nn.functional.pad.html) is compiled to this op when `mode="constant"`.

`pad` has the form:
(left, right): pad last one dimension
(left, right, top, bottom): pad last 2 dimensions
(left, right, top, bottom, front, back): pad last 3 dimensions

Differential Revision: D58441509
