### PR TITLE
skip dim order for now to avoid delegation issue

### DIFF
--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import ctypes
 import unittest
 from typing import Tuple
@@ -117,7 +119,9 @@ class TestBackends(unittest.TestCase):
             program: ExportedProgram = export(
                 model, sample_inputs, dynamic_shapes=dynamic_shapes
             )
-            edge_program: EdgeProgramManager = to_edge(program)
+            edge_program: EdgeProgramManager = to_edge(
+                program, compile_config=self._edge_compile_config
+            )
 
             edge_program = edge_program.transform([I64toI32(), MeanToSumDiv()])
 

--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
@@ -38,7 +40,8 @@ class EdgeCompileConfig:
     _use_edge_ops: bool = True
     _skip_type_promotion: bool = False
     # TODO(gasoonjia): remove this
-    _skip_dim_order: bool = False
+    # TODO(T192537614): reenanle dim order as default
+    _skip_dim_order: bool = True
 
 
 @compatibility(is_backward_compatible=False)

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pye-strict
+# pyre-unsafe
 
 import typing
 import unittest
@@ -866,7 +866,9 @@ class TestEmit(unittest.TestCase):
         # Success if you use dim_order
         to_edge(
             export(model, inputs),
-            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+            compile_config=exir.EdgeCompileConfig(
+                _check_ir_validity=False, _skip_dim_order=False
+            ),
         ).to_executorch()
 
     def test_emit_multiple_entry_points(self) -> None:

--- a/exir/tests/test_memory_format_ops_pass_utils.py
+++ b/exir/tests/test_memory_format_ops_pass_utils.py
@@ -4,12 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import unittest
 from dataclasses import dataclass
 from typing import Any, Tuple
 
 import torch
 from executorch.exir import to_edge
+from executorch.exir.capture._config import EdgeCompileConfig
 
 from executorch.exir.dim_order_utils import (
     is_channel_last_dim_order,
@@ -70,7 +73,7 @@ class MemoryFormatOpsPassTestUtils:
             edge_op_str
         ).run(before.graph_module.code)
 
-        epm = to_edge(before)
+        epm = to_edge(before, compile_config=EdgeCompileConfig(_skip_dim_order=False))
 
         # check op strings
         FileCheck().check_not(aten_op_str).check_count(

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -1134,7 +1134,10 @@ class TestPasses(unittest.TestCase):
 
         add = Add()
 
-        edge = to_edge(export(add, (torch.ones(1),)))
+        edge = to_edge(
+            export(add, (torch.ones(1),)),
+            compile_config=EdgeCompileConfig(_skip_dim_order=False),
+        )
         edge = edge.transform([ScalarToTensorPass(), RemoveMixedTypeOperators()])
         exported_program = lift_constant_tensor_pass(edge.exported_program())
 

--- a/exir/verification/test/test_verifier.py
+++ b/exir/verification/test/test_verifier.py
@@ -4,8 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import unittest
 from contextlib import contextmanager
+from typing import Any
 
 import torch
 from executorch.exir import EdgeCompileConfig, to_edge
@@ -20,7 +23,7 @@ from ..verifier import EXIREdgeDialectVerifier
 
 class TestEdgeDialectVerifier(unittest.TestCase):
     @contextmanager
-    def assertNotRaises(self, exc_type):
+    def assertNotRaises(self, exc_type: Any) -> Any:
         try:
             yield None
         except exc_type:
@@ -81,8 +84,9 @@ class TestEdgeDialectVerifier(unittest.TestCase):
 
         export_model = export(m, example_input)
 
-        # In default we use dim order.
-        compile_config_without_edge_op = EdgeCompileConfig(_use_edge_ops=False)
+        compile_config_without_edge_op = EdgeCompileConfig(
+            _use_edge_ops=False, _skip_dim_order=False
+        )
 
         edge_manager = to_edge(
             export_model, compile_config=compile_config_without_edge_op
@@ -128,8 +132,7 @@ class TestEdgeDialectVerifier(unittest.TestCase):
 
         export_model = export(m, example_input)
 
-        # In default we use dim order.
-        compile_config_with_dim_order = EdgeCompileConfig()
+        compile_config_with_dim_order = EdgeCompileConfig(_skip_dim_order=False)
         compile_config_with_stride = EdgeCompileConfig(_skip_dim_order=True)
 
         dim_order_edge_model = to_edge(


### PR DESCRIPTION
Summary: some delegate authors claim can not found dim order when partition. Temporary disable dim order as default for unblock others.

Reviewed By: digantdesai

Differential Revision: D58593014
