### PR TITLE
Add PFH in buck for FoA

### DIFF
--- a/shim/xplat/executorch/build/env_interface.bzl
+++ b/shim/xplat/executorch/build/env_interface.bzl
@@ -129,6 +129,7 @@ def _remove_unsupported_kwargs(kwargs):
     kwargs.pop("tags", None)  # tags = ["long_running"] doesn't work in oss
     kwargs.pop("types", None)  # will have to find a different way to handle .pyi files in oss
     kwargs.pop("resources", None)  # doesn't support resources in python_library/python_binary yet
+    kwargs.pop("feature", None)  # internal-only, used for Product-Feature Hierarchy (PFH)
     return kwargs
 
 def _patch_headers(kwargs):


### PR DESCRIPTION
Summary:
See:
- https://www.internalfb.com/intern/wiki/Privacy_Graph/Product_Asset_Graph/PFH_Asset_Linking/PFH_in_Buck_Targets/
- https://www.internalfb.com/intern/wiki/Privacy_Graph/Product_Feature_Hierarchy/

Seems to be a new requirement for FoA, where all buck targets owned by the app must be tagged with the product name. Codegen.bzl is included by third-parties and the libraries created 'belong' to the target app? So we add the feature name to the libraries constructed in codegen.

See failure: D58557891

Differential Revision: D58620058
