### PR TITLE
Fix partitioning for constants

### DIFF
--- a/backends/xnnpack/partition/xnnpack_partitioner.py
+++ b/backends/xnnpack/partition/xnnpack_partitioner.py
@@ -560,6 +560,23 @@ class XnnpackFloatingPointPartitioner(Partitioner):
             log.info(f"Found {pl} subgraphs to be partitioned.")
         return pl != 0
 
+    def get_input_deps(  # noqa
+        self, input_nodes: List[torch.fx.Node], ep: ExportedProgram
+    ) -> List[torch.fx.Node]:
+        """
+        For each input node, walk up and pull necessary param/attr nodes in the partition
+        """
+        nodes = set()
+
+        def is_param(ep: ExportedProgram, node) -> bool:
+            return isinstance(node, torch.fx.Node) and is_param_node(ep, node)
+
+        for inp in input_nodes:
+            if is_param(ep, inp):
+                nodes.add(inp)
+
+        return list(nodes)
+
     def get_nodes(
         self, src_partition: SourcePartition, ep: ExportedProgram
     ) -> List[torch.fx.Node]:
@@ -569,7 +586,7 @@ class XnnpackFloatingPointPartitioner(Partitioner):
         This is a wrapper to allow derived classes to add their own custom
         logic to extend the src_partition nodes list.
         """
-        return src_partition.nodes
+        return src_partition.nodes + self.get_input_deps(src_partition.input_nodes, ep)
 
     def qualify_nodes(
         self, input_nodes: List[torch.fx.Node], ep: ExportedProgram

--- a/backends/xnnpack/passes/conv1d_unsqueeze_pass.py
+++ b/backends/xnnpack/passes/conv1d_unsqueeze_pass.py
@@ -94,6 +94,16 @@ class Conv1dUnsqueezePass(XNNPACKPass):
             ]
             self.exported_program.state_dict[buffer_name] = kernel_param_4d
             kernel_node.meta["val"] = kernel_param_4d.data.contiguous()
+        elif torch._export.utils.is_lifted_tensor_constant(
+            self.exported_program, kernel_node
+        ):
+            buffer_name = (
+                self.exported_program.graph_signature.inputs_to_lifted_tensor_constants[
+                    kernel_node.name
+                ]
+            )
+            self.exported_program.constants[buffer_name] = kernel_param_4d
+            kernel_node.meta["val"] = kernel_param_4d.data.contiguous()
         else:
             setattr(
                 kernel_node.graph.owning_module,
@@ -133,7 +143,7 @@ class Conv1dUnsqueezePass(XNNPACKPass):
                         node.args[4] + [0],  # padding
                         node.args[5] + [1],  # dilation
                         node.args[6],
-                        node.args[7],
+                        node.args[7] + [0],
                         node.args[8],
                     )
 

--- a/backends/xnnpack/test/TARGETS
+++ b/backends/xnnpack/test/TARGETS
@@ -36,6 +36,7 @@ runtime.python_test(
     deps = [
         "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
         "//executorch/backends/xnnpack/test/tester:tester",
+        "//executorch/exir/passes:constant_prop_pass",
         "//executorch/sdk:lib",
         "//executorch/sdk/bundled_program:config",
         "//executorch/sdk/bundled_program/serialize:lib",

--- a/backends/xnnpack/test/ops/conv1d.py
+++ b/backends/xnnpack/test/ops/conv1d.py
@@ -7,9 +7,14 @@
 import unittest
 
 import torch
+from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
+    XnnpackFloatingPointPartitioner,
+)
 from executorch.backends.xnnpack.test.test_xnnpack_utils import randomize_bn
 
-from executorch.backends.xnnpack.test.tester import Tester
+from executorch.backends.xnnpack.test.tester import RunPasses, Tester
+from executorch.backends.xnnpack.test.tester.tester import Partition
+from executorch.exir.passes.constant_prop_pass import constant_prop_pass
 
 
 class TestConv1d(unittest.TestCase):
@@ -82,9 +87,17 @@ class TestConv1d(unittest.TestCase):
             return z
 
     def _test_conv1d(
-        self, module, inputs, conv_count, quantized=False, dynamic_shape=None
+        self,
+        module,
+        inputs,
+        conv_count,
+        quantized=False,
+        dynamic_shape=None,
+        partition=None,
+        passes=None,
+        skip_to_executorch=False,
     ):
-        (
+        tester = (
             (
                 Tester(module, inputs, dynamic_shape).quantize()
                 if quantized
@@ -98,13 +111,15 @@ class TestConv1d(unittest.TestCase):
                     "executorch_exir_dialects_edge__ops_aten_convolution_default": conv_count
                 }
             )
-            .partition()
+            .run_passes(passes)
+            .partition(partition)
             .check_not(["executorch_exir_dialects_edge__ops_aten_convolution_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
         )
+        # For some tests we want to skip to_executorch because otherwise it will require the
+        # quantized operators to be loaded and we don't want to do that in the test.
+        if not skip_to_executorch:
+            tester.to_executorch().serialize().run_method_and_compare_outputs()
 
     def test_fp16_conv1d(self):
         inputs = (torch.randn(2, 2, 4).to(torch.float16),)
@@ -144,4 +159,18 @@ class TestConv1d(unittest.TestCase):
             2,
             quantized=True,
             dynamic_shape=dynamic_shapes,
+        )
+
+    def test_qs8_conv1d_with_floating_point_partitioner(self):
+        inputs = (torch.randn(2, 2, 4),)
+        dynamic_shapes = ({0: torch.export.Dim("batch", min=2, max=10)},)
+        self._test_conv1d(
+            self.Conv1d(),
+            inputs,
+            1,
+            quantized=True,
+            dynamic_shape=dynamic_shapes,
+            partition=Partition(XnnpackFloatingPointPartitioner()),
+            passes=RunPasses(pass_functions=[constant_prop_pass]),
+            skip_to_executorch=True,
         )


### PR DESCRIPTION
Summary: After we run the constant prop pass the weights/biases might become constants in the exported program which we're not looking for currently when partitioning the graph. This diff fixes that and also ensures that the update is properly done in `unsqueeze_kernel_weights`.

Differential Revision: D58399313


