### PR TITLE
[ET-VK] Print local workgroup size

### DIFF
--- a/backends/vulkan/runtime/api/QueryPool.cpp
+++ b/backends/vulkan/runtime/api/QueryPool.cpp
@@ -212,9 +212,9 @@ std::string QueryPool::generate_string_report() {
 
   ss << std::left;
   ss << std::setw(kernel_name_w) << "===========";
-  ss << std::setw(global_size_w) << "====================";
+  ss << std::setw(global_size_w) << "=====================";
   ss << std::setw(local_size_w) << "====================";
-  ss << std::right << std::setw(duration_w) << "===========";
+  ss << std::right << std::setw(duration_w) << "=============";
   ss << std::endl;
 
   for (ShaderDuration& entry : shader_durations_) {

--- a/backends/vulkan/runtime/api/QueryPool.cpp
+++ b/backends/vulkan/runtime/api/QueryPool.cpp
@@ -199,18 +199,21 @@ std::string QueryPool::generate_string_report() {
   std::stringstream ss;
 
   int kernel_name_w = 40;
-  int global_size_w = 15;
+  int global_size_w = 25;
+  int local_size_w = 25;
   int duration_w = 25;
 
   ss << std::left;
   ss << std::setw(kernel_name_w) << "Kernel Name";
-  ss << std::setw(global_size_w) << "Workgroup Size";
+  ss << std::setw(global_size_w) << "Global Workgroup Size";
+  ss << std::setw(local_size_w) << "Local Workgroup Size";
   ss << std::right << std::setw(duration_w) << "Duration (ns)";
   ss << std::endl;
 
   ss << std::left;
   ss << std::setw(kernel_name_w) << "===========";
-  ss << std::setw(global_size_w) << "==============";
+  ss << std::setw(global_size_w) << "====================";
+  ss << std::setw(local_size_w) << "====================";
   ss << std::right << std::setw(duration_w) << "===========";
   ss << std::endl;
 
@@ -221,6 +224,7 @@ std::string QueryPool::generate_string_report() {
     ss << std::left;
     ss << std::setw(kernel_name_w) << entry.kernel_name;
     ss << std::setw(global_size_w) << stringize(entry.global_workgroup_size);
+    ss << std::setw(local_size_w) << stringize(entry.local_workgroup_size);
     ss << std::right << std::setw(duration_w) << exec_duration_ns.count();
     ss << std::endl;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3996
* __->__ #3995

## Before
```
Kernel Name                             Workgroup Size             Duration (ns)
===========                             ==============               ===========
nchw_to_tensor_float_texture3d          {512, 672, 4}                   13848640
conv2d_pw_clamp_float                   {512, 672, 16}                 124203820
```

## After
```
Kernel Name                             Global Workgroup Size    Local Workgroup Size                 Duration (ns)
===========                             ====================     ====================                   ===========
nchw_to_tensor_float_texture3d          {512, 672, 4}            {4, 4, 4}                                 13806728
conv2d_pw_clamp_float                   {512, 672, 16}           {4, 4, 4}                                124192224
```

Differential Revision: [D58476014](https://our.internmc.facebook.com/intern/diff/D58476014/)