### PR TITLE
Remove targets.xnnpack_dynamic_quant_utils from cmake_deps.toml

### DIFF
--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -262,14 +262,6 @@ deps = [
   "executorch_no_prim_ops",
 ]
 
-[targets.xnnpack_dynamic_quant_utils]
-buck_targets = [
-  "//backends/xnnpack:dynamic_quant_utils",
-]
-filters = [
-  ".cpp$",
-]
-
 [targets.xnnpack_schema]
 buck_targets = [
   "//backends/xnnpack/serialization:xnnpack_flatbuffer_header",


### PR DESCRIPTION
The only reference to this was removed in
https://github.com/pytorch/executorch/pull/2585

Test Plan:
- CI
- `./install_requirements.sh --pybind xnnpack` built successfully