### PR TITLE
Remove buck2 from selective build readme

### DIFF
--- a/examples/selective_build/README.md
+++ b/examples/selective_build/README.md
@@ -1,5 +1,5 @@
 # Selective Build Examples
-To optimize binary size of ExecuTorch runtime, selective build can be used. This folder contains examples to select only the operators needed for ExecuTorch build. We provide APIs for both CMake build and buck2 build. This example will demonstrate both. You can find more information on how to use buck2 macros in [wiki](../../docs/source/kernel-library-selective_build.md).
+To optimize binary size of ExecuTorch runtime, selective build can be used. This folder contains examples to select only the operators needed for ExecuTorch build. This example will demonstrate the CMake build.
 
 ## How to run
 
@@ -9,29 +9,15 @@ Run:
 
 ```bash
 cd executorch
-bash examples/selective_build/test_selective_build.sh [cmake|buck2]
+bash examples/selective_build/test_selective_build.sh cmake
 ```
 
-## BUCK2 examples
-
-Check out `targets.bzl` for demo of 4 selective build APIs:
-1. `--config executorch.select_ops=all`: Select all ops from the dependency kernel libraries, register all of them into ExecuTorch runtime.
-2. `--config executorch.select_ops=list`: Only select ops from `ops` kwarg in `et_operator_library` macro.
-3. `--config executorch.select_ops=yaml`: Only select from a yaml file from `ops_schema_yaml_target` kwarg in `et_operator_library` macro.
-4. `--config executorch.select_ops=dict`: Only select ops with from `ops_dict` kwarg in `et_operator_library` macro. Optionally, add dtype information to each operator and add `dtype_selective_build = True` to only select those dtypes.
-Eg. if the model only uses the float implementation of add, then only the float add will be registered. Note: setting `dtype_selective_build = True` is only available in xplat.
-
-Other configs:
-- `--config executorch.max_kernel_num=N`: Only allocate memory for the required number of operators. Take this result from `selected_operators.yaml`.
-
-## CMake examples
-
 Check out `CMakeLists.txt` for demo of 3 selective build APIs:
-1. `SELECT_ALL_OPS`
-2. `SELECT_OPS_LIST`
-3. `SELECT_OPS_YAML`
+1. `SELECT_ALL_OPS`: Select all ops from the dependency kernel libraries, register all of them into ExecuTorch runtime.
+2. `SELECT_OPS_LIST`: Only select operators from a list.
+3. `SELECT_OPS_YAML`: Only select operators from a yaml file.
 
 Other configs:
-- `MAX_KERNEL_NUM=N`
+- `MAX_KERNEL_NUM=N`: Only allocate memory for N operators.
 
 We have one more API incoming: only select from an exported model file (.pte).

--- a/examples/selective_build/test_selective_build.sh
+++ b/examples/selective_build/test_selective_build.sh
@@ -15,6 +15,22 @@ set -e
 # shellcheck source=/dev/null
 source "$(dirname "${BASH_SOURCE[0]}")/../../.ci/scripts/utils.sh"
 
+
+# BUCK2 examples; test internally in fbcode/xplat
+# 1. `--config executorch.select_ops=all`: select all ops from the dependency
+#       kernel libraries, register all of them into ExecuTorch runtime.
+# 2. `--config executorch.select_ops=list`: Only select ops from `ops` kwarg
+#       in `et_operator_library` macro.
+# 3. `--config executorch.select_ops=yaml`: Only select from a yaml file from
+#       `ops_schema_yaml_target` kwarg in `et_operator_library` macro
+# 4. `--config executorch.select_ops=dict`: Only select ops from `ops_dict`
+#       kwarg in `et_operator_library` macro. Add `dtype_selective_build = True`
+#       to executorch_generated_lib to select dtypes specified in the dictionary.
+
+# Other configs:
+# - `--config executorch.max_kernel_num=N`: Only allocate memory for the
+#       required number of operators. Users can retrieve N from `selected_operators.yaml`.
+
 test_buck2_select_all_ops() {
     echo "Exporting MobilenetV3"
     ${PYTHON_EXECUTABLE} -m examples.portable.scripts.export --model_name="mv3"
@@ -69,6 +85,7 @@ test_buck2_select_ops_from_yaml() {
     rm "./custom_ops_1.pte"
 }
 
+# CMake examples; test in OSS. Check the README for more information.
 test_cmake_select_all_ops() {
     echo "Exporting MobilenetV3"
     ${PYTHON_EXECUTABLE} -m examples.portable.scripts.export --model_name="mv3"


### PR DESCRIPTION
Summary: However, keep the description / documentation inside test_selective_build.sh for internal users.

Differential Revision: D58706163
