### PR TITLE
 [ET][VK] refactor mm and linear implementation

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/addmm_optimized.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/addmm_optimized.glsl
@@ -13,6 +13,9 @@
 $if MAT2_IS_TRANSPOSED:
   #define MAT2_IS_TRANSPOSED
 
+$if BATCH_MODE:
+  #define BATCH_MODE
+
 #include "indexing_utils.h"
 #include "matmul.h"
 
@@ -52,12 +55,20 @@ void main() {
     return;
   }
 
-  FloatMatrix results = matmul_partial_4x4(
+  $if BATCH_MODE:
+    FloatMatrix_3d results = matmul_partial_4x4x4(
       im_mat1,
       im_mat2,
       pos,
       out_sizes[2],
       in_limits[0]);
+  $else:
+    FloatMatrix_2d results = matmul_partial_4x4(
+        im_mat1,
+        im_mat2,
+        pos,
+        out_sizes[2],
+        in_limits[0]);
 
   for (int idx_c = 0; idx_c < FOUR; idx_c++) {
     for (int idx_r = 0; idx_r < FOUR; idx_r++) {
@@ -71,7 +82,8 @@ void main() {
           self_sizes.y == 1);
 
       // results is in transposed order w.r.t. the desired output
-      imageStore(
+      $if BATCH_MODE:
+        imageStore(
           im_out,
           out_pos,
           vec4(
@@ -79,6 +91,12 @@ void main() {
               beta * self_texel.x + alpha * results.data[idx_c][idx_r][1],
               beta * self_texel.x + alpha * results.data[idx_c][idx_r][2],
               beta * self_texel.x + alpha * results.data[idx_c][idx_r][3]));
+      $else:
+        imageStore(
+            im_out,
+            out_pos,
+            vec4(
+                beta * self_texel.x + alpha * results.data[idx_c][idx_r], 0.0, 0.0, 0.0));
     }
   }
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/addmm_optimized.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/addmm_optimized.yaml
@@ -10,6 +10,7 @@ addmm_optimized:
     NDIM: 3
     PACKING: C_packed
     MAT2_IS_TRANSPOSED: false
+    BATCH_MODE: false
   generate_variant_forall:
     DTYPE:
       - VALUE: float
@@ -18,3 +19,8 @@ addmm_optimized:
     - NAME: addmm_optimized
     - NAME: linear_optimized
       MAT2_IS_TRANSPOSED: true
+    - NAME: batch_addmm_optimized
+      BATCH_MODE: true
+    - NAME: batch_linear_optimized
+      MAT2_IS_TRANSPOSED: true
+      BATCH_MODE: true

--- a/backends/vulkan/runtime/graph/ops/glsl/matmul_optimized.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/matmul_optimized.glsl
@@ -13,6 +13,9 @@
 $if MAT2_IS_TRANSPOSED:
   #define MAT2_IS_TRANSPOSED
 
+$if BATCH_MODE:
+  #define BATCH_MODE
+
 #include "indexing_utils.h"
 #include "matmul.h"
 
@@ -41,12 +44,20 @@ void main() {
     return;
   }
 
-  FloatMatrix results = matmul_partial_4x4(
-      im_mat1,
-      im_mat2,
-      pos,
-      out_sizes[2],
-      in_limits[0]);
+  $if BATCH_MODE:
+    FloatMatrix_3d results = matmul_partial_4x4x4(
+        im_mat1,
+        im_mat2,
+        pos,
+        out_sizes[2],
+        in_limits[0]);
+  $else:
+    FloatMatrix_2d results = matmul_partial_4x4(
+        im_mat1,
+        im_mat2,
+        pos,
+        out_sizes[2],
+        in_limits[0]);
 
   for (int idx_c = 0; idx_c < FOUR; idx_c++) {
     for (int idx_r = 0; idx_r < FOUR; idx_r++) {
@@ -54,7 +65,8 @@ void main() {
           ivec3(idx_r + FOUR * pos.x, idx_c + FOUR * pos.y, pos.z);
 
       // results is in transposed order w.r.t. the desired output
-      imageStore(
+      $if BATCH_MODE:
+        imageStore(
           im_out,
           out_pos,
           vec4(
@@ -62,6 +74,11 @@ void main() {
               results.data[idx_c][idx_r][1],
               results.data[idx_c][idx_r][2],
               results.data[idx_c][idx_r][3]));
+      $else:
+        imageStore(
+            im_out,
+            out_pos,
+            vec4(results.data[idx_c][idx_r], 0.0, 0.0, 0.0));
     }
   }
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/matmul_optimized.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/matmul_optimized.yaml
@@ -10,6 +10,7 @@ matmul_optimized:
     NDIM: 3
     PACKING: C_packed
     MAT2_IS_TRANSPOSED: false
+    BATCH_MODE: false
   generate_variant_forall:
     DTYPE:
       - VALUE: float
@@ -18,3 +19,8 @@ matmul_optimized:
     - NAME: matmul_optimized
     - NAME: matmul_transposed_optimized
       MAT2_IS_TRANSPOSED: true
+    - NAME: batch_matmul_optimized
+      BATCH_MODE: true
+    - NAME: batch_matmul_transposed_optimized
+      MAT2_IS_TRANSPOSED: true
+      BATCH_MODE: true

--- a/backends/vulkan/runtime/graph/ops/impl/Linear.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Linear.cpp
@@ -169,6 +169,12 @@ void add_addmm_optimized_node(
   std::string kernel_name = graph.get_bool(mat2_is_transposed)
       ? "linear_optimized"
       : "addmm_optimized";
+
+  int mat1_dims = graph.sizes_of(mat1_W_packed).size();
+  if (mat1_dims == 3) {
+    kernel_name = "batch_" + kernel_name;
+  }
+
   add_dtype_suffix(kernel_name, graph.dtype_of(out));
 
   graph.execute_nodes().emplace_back(new ExecuteNode(

--- a/backends/vulkan/runtime/graph/ops/impl/MatMul.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/MatMul.cpp
@@ -134,6 +134,12 @@ void add_matmul_optimized_node(
   std::string kernel_name = mat2_is_transposed_val
       ? "matmul_transposed_optimized"
       : "matmul_optimized";
+
+  int mat1_dims = graph.sizes_of(mat1_W_packed).size();
+  if (mat1_dims == 3) {
+    kernel_name = "batch_" + kernel_name;
+  }
+
   add_dtype_suffix(kernel_name, graph.dtype_of(out));
 
   graph.execute_nodes().emplace_back(new ExecuteNode(


### PR DESCRIPTION
Our existing mm uses a generalized shader for both 2d and 3d input. [@nathanaelsee](https://www.internalfb.com/intern/profile/?id=1339110118) found that edge graphs smartly convert some 3d input into 2d, i.e. the needed op becomes mm instead of bmm. To optimize performance, we split the current implementation for 2d and 3d respectively using template variants.

Differential Revision: D58629158
