### PR TITLE
Make Tokenizer methods const

### DIFF
--- a/examples/models/llama2/tokenizer/bpe_tokenizer.cpp
+++ b/examples/models/llama2/tokenizer/bpe_tokenizer.cpp
@@ -132,7 +132,8 @@ BPETokenizer::~BPETokenizer() {
  * @return Result<std::string> A pointer to the string representation of the
  * token.
  */
-Result<std::string> BPETokenizer::decode(uint64_t prev_token, uint64_t token) {
+Result<std::string> BPETokenizer::decode(uint64_t prev_token, uint64_t token)
+    const {
   ET_CHECK_OK_OR_RETURN_ERROR(Tokenizer::decode_verify(token));
   const char* piece = vocab_[token];
   // following BOS token, sentencepiece decoder strips any leading
@@ -171,7 +172,7 @@ str_lookup(const char* str, TokenIndex* sorted_vocab, int32_t vocab_size) {
  * @return Result<std::vector<uint64_t>>
  */
 Result<std::vector<uint64_t>>
-BPETokenizer::encode(const std::string& text, int8_t bos, int8_t eos) {
+BPETokenizer::encode(const std::string& text, int8_t bos, int8_t eos) const {
   if (!initialized_) {
     ET_LOG(Error, "Tokenizer not initialized");
     return Error::NotSupported;

--- a/examples/models/llama2/tokenizer/bpe_tokenizer.h
+++ b/examples/models/llama2/tokenizer/bpe_tokenizer.h
@@ -29,9 +29,10 @@ class BPETokenizer : public Tokenizer {
   Error load(const std::string& tokenizer_path) override;
 
   Result<std::vector<uint64_t>>
-  encode(const std::string& input, int8_t bos, int8_t eos) override;
+  encode(const std::string& input, int8_t bos, int8_t eos) const override;
 
-  Result<std::string> decode(uint64_t prev_token, uint64_t token) override;
+  Result<std::string> decode(uint64_t prev_token, uint64_t token)
+      const override;
 
  private:
   std::unique_ptr<char*[]> vocab_;

--- a/examples/models/llama2/tokenizer/tiktoken.cpp
+++ b/examples/models/llama2/tokenizer/tiktoken.cpp
@@ -250,7 +250,7 @@ template <typename T>
 std::pair<std::optional<std::string>, re2::StringPiece>
 Tiktoken::_split_with_allowed_special_token(
     re2::StringPiece& input,
-    const T& allowed_special) {
+    const T& allowed_special) const {
   if (!_special_token_regex) {
     return std::make_pair(std::nullopt, input);
   }
@@ -277,7 +277,7 @@ Tiktoken::_split_with_allowed_special_token(
 void Tiktoken::_encode(
     re2::StringPiece& input,
     std::vector<uint64_t>& ret,
-    uint64_t& last_piece_token_len) {
+    uint64_t& last_piece_token_len) const {
   std::string piece;
   assert(_regex);
   while (re2::RE2::FindAndConsume(&input, *_regex, &piece)) {
@@ -296,7 +296,7 @@ void Tiktoken::_encode(
 template <typename T>
 std::pair<std::vector<uint64_t>, uint64_t> Tiktoken::_encode_with_special_token(
     const std::string& text,
-    const T& allowed_special) {
+    const T& allowed_special) const {
   std::vector<uint64_t> tokens;
   uint64_t last_piece_token_len = 0;
   re2::StringPiece input(text);
@@ -353,7 +353,7 @@ Error Tiktoken::load(const std::string& path) {
 }
 
 Result<std::vector<uint64_t>>
-Tiktoken::encode(const std::string& text, int8_t bos, int8_t eos) {
+Tiktoken::encode(const std::string& text, int8_t bos, int8_t eos) const {
   if (!initialized_) {
     return Error::NotSupported;
   }
@@ -367,7 +367,7 @@ Tiktoken::encode(const std::string& text, int8_t bos, int8_t eos) {
   return Result(res);
 }
 
-Result<std::string> Tiktoken::decode(uint64_t prev, uint64_t cur) {
+Result<std::string> Tiktoken::decode(uint64_t prev, uint64_t cur) const {
   (void)prev;
   ET_CHECK_OK_OR_RETURN_ERROR(Tokenizer::decode_verify(cur));
   std::string ret;

--- a/examples/models/llama2/tokenizer/tiktoken.h
+++ b/examples/models/llama2/tokenizer/tiktoken.h
@@ -29,12 +29,13 @@ class Tiktoken : public Tokenizer {
   explicit Tiktoken() : Tokenizer() {}
   ~Tiktoken(){};
 
-  Error load(const std::string& tokenizer_path);
+  Error load(const std::string& tokenizer_path) override;
 
   Result<std::vector<uint64_t>>
-  encode(const std::string& input, int8_t bos, int8_t eos);
+  encode(const std::string& input, int8_t bos, int8_t eos) const override;
 
-  Result<std::string> decode(uint64_t prev_token, uint64_t token);
+  Result<std::string> decode(uint64_t prev_token, uint64_t token)
+      const override;
 
  private:
   static inline const Encoder _get_special_tokens(ssize_t num_base_tokens) {
@@ -61,17 +62,17 @@ class Tiktoken : public Tokenizer {
   std::pair<std::optional<std::string>, re2::StringPiece>
   _split_with_allowed_special_token(
       re2::StringPiece& input,
-      const T& allowed_special);
+      const T& allowed_special) const;
 
   void _encode(
       re2::StringPiece& input,
       std::vector<uint64_t>& ret,
-      uint64_t& last_piece_token_len);
+      uint64_t& last_piece_token_len) const;
 
   template <typename T>
   std::pair<std::vector<uint64_t>, uint64_t> _encode_with_special_token(
       const std::string& text,
-      const T& allowed_special);
+      const T& allowed_special) const;
 
   // Removed negative lookahead \s+(?!\S) since it's not supported by RE2.
   const std::string _pattern =

--- a/examples/models/llama2/tokenizer/tokenizer.h
+++ b/examples/models/llama2/tokenizer/tokenizer.h
@@ -34,7 +34,7 @@ class Tokenizer {
   virtual Error load(const std::string& tokenizer_path) = 0;
 
   virtual Result<std::vector<uint64_t>>
-  encode(const std::string& input, int8_t bos, int8_t eos) = 0;
+  encode(const std::string& input, int8_t bos, int8_t eos) const = 0;
 
   Error decode_verify(uint64_t token) const {
     if (!initialized_) {
@@ -52,7 +52,8 @@ class Tokenizer {
     return Error::Ok;
   }
 
-  virtual Result<std::string> decode(uint64_t prev_token, uint64_t token) = 0;
+  virtual Result<std::string> decode(uint64_t prev_token, uint64_t token)
+      const = 0;
 
   // getters
   int32_t vocab_size() const {


### PR DESCRIPTION
Summary: The Tokenizer class supports encode() and decode() functions. They (and all sub functions) have to be 'const' in order to guarantee the Tokenizer object itself isn't mutated during those calls, which means it can be used in a multi threaded environment and is stateless, e.g. 2 decoding runs (parallel or sequential) have no influence on each other.

Differential Revision: D58780400
