### PR TITLE
new fuse_view_copy pass to merge chains of single-user view_copy nodes

### DIFF
--- a/backends/transforms/TARGETS
+++ b/backends/transforms/TARGETS
@@ -49,7 +49,6 @@ runtime.python_library(
     srcs = ["fuse_conv_with_clamp.py"],
     visibility = [
         "//executorch/backends/...",
-        "@EXECUTORCH_CLIENTS",
     ],
     deps = [
         ":utils",
@@ -57,6 +56,19 @@ runtime.python_library(
         "//executorch/backends/vulkan/passes:custom_ops_defs",
         "//executorch/exir:pass_base",
         "//executorch/exir:sym_util",
+        "//executorch/exir/dialects:lib",
+    ],
+)
+
+runtime.python_library(
+    name = "fuse_view_copy",
+    srcs = ["fuse_view_copy.py"],
+    visibility = [
+        "//executorch/backends/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir:pass_base",
         "//executorch/exir/dialects:lib",
     ],
 )

--- a/backends/transforms/fuse_view_copy.py
+++ b/backends/transforms/fuse_view_copy.py
@@ -1,0 +1,46 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import torch
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+
+
+def merge_view_copy_chains(graph: torch.fx.Graph) -> torch.fx.Graph:
+    """
+    Find chains of view_copy nodes and merge them into one view_copy node.
+    Only merges view_copy nodes that are not used by any other nodes.
+    """
+    ops = exir_ops.edge
+    view_op = ops.aten.view_copy.default
+    for node in graph.nodes:
+        if node.op == "call_function" and node.target == view_op:
+            # find ending view_copy node in chain
+            end_node = node
+            while (
+                end_node.op == "call_function"
+                and end_node.target == view_op
+                and len(end_node.users) == 1
+                and list(end_node.users)[0].target == view_op
+            ):
+                end_node = list(end_node.users)[0]
+            # we can swap the first node's shape arg with the last node's shape arg
+            if node != end_node:
+                with graph.inserting_after(node):
+                    new_args = (node.args[0], end_node.args[1])
+                    node.args = new_args
+                    end_node.replace_all_uses_with(node)
+
+    graph.eliminate_dead_code()
+    return graph
+
+
+class FuseViewCopyTransform(ExportPass):
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        graph_module.graph = merge_view_copy_chains(graph_module.graph)
+        return PassResult(graph_module, True)

--- a/backends/vulkan/TARGETS
+++ b/backends/vulkan/TARGETS
@@ -25,6 +25,7 @@ runtime.python_library(
         "//executorch/backends/transforms:addmm_mm_to_linear",
         "//executorch/backends/transforms:fuse_batch_norm_with_conv",
         "//executorch/backends/transforms:fuse_conv_with_clamp",
+        "//executorch/backends/transforms:fuse_view_copy",
         "//executorch/exir:graph_module",
         "//executorch/exir/_serialize:_bindings",
         "//executorch/exir/_serialize:lib",

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 from typing import final, List
 
 from executorch.backends.transforms.addmm_mm_to_linear import AddmmToLinearTransform
@@ -11,6 +13,7 @@ from executorch.backends.transforms.fuse_batch_norm_with_conv import (
     FuseBatchNormWithConvPass,
 )
 from executorch.backends.transforms.fuse_conv_with_clamp import FuseClampPass
+from executorch.backends.transforms.fuse_view_copy import FuseViewCopyTransform
 
 from executorch.backends.vulkan.serialization.vulkan_graph_builder import VkGraphBuilder
 from executorch.backends.vulkan.serialization.vulkan_graph_serialize import (
@@ -45,6 +48,7 @@ class VulkanBackend(BackendDetails):
     ) -> PreprocessResult:
         passes = [
             AddmmToLinearTransform(),
+            FuseViewCopyTransform(),
             FuseBatchNormWithConvPass(program),
             FuseClampPass(),
             SpecPropPass(),


### PR DESCRIPTION
Summary:
There are some chains of view_copy -> view_copy nodes which get introduced when running the AddmmToLinearTransform pass.
We can merge two view_copy nodes if the first has only one user (the second view_copy node).

Reviewed By: jorgep31415

Differential Revision: D58761418
