### PR TITLE
Pass in exported program in call to ops_to_not_decompose()

### DIFF
--- a/exir/backend/partitioner.py
+++ b/exir/backend/partitioner.py
@@ -96,6 +96,7 @@ class Partitioner(ABC):
 
     def ops_to_not_decompose(
         self,
+        ep: ExportedProgram,
     ) -> Tuple[List[torch._ops.OpOverload], Optional[Callable[[torch.fx.Node], bool]]]:
         """
         Returns a list of operator names that should not be decomposed. When these ops are

--- a/exir/backend/test/backend_with_compiler_demo.py
+++ b/exir/backend/test/backend_with_compiler_demo.py
@@ -90,6 +90,7 @@ class BackendWithCompilerDemo(BackendDetails):
             torch.ops.aten.sin.default,
             exir_ops.edge.aten.linear.default,
             exir_ops.edge.aten.scaled_dot_product_attention.default,
+            exir_ops.edge.aten.upsample_nearest2d.vec,
         ]
 
         for node in edge_program.graph.nodes:

--- a/exir/backend/test/op_partitioner_demo.py
+++ b/exir/backend/test/op_partitioner_demo.py
@@ -156,7 +156,7 @@ class NonDecompTestPartitioner(Partitioner):
         )
 
     def ops_to_not_decompose(
-        self,
+        self, ep: ExportedProgram
     ) -> Tuple[List[torch._ops.OpOverload], Optional[Callable[[torch.fx.Node], bool]]]:
         def filter_ops(node: torch.fx.Node) -> bool:
             if node.op == "call_function" and node.target in ops_not_to_decompose:

--- a/exir/backend/test/op_partitioner_demo.py
+++ b/exir/backend/test/op_partitioner_demo.py
@@ -127,11 +127,13 @@ class AddAttributePartitionerDemo(Partitioner):
 ops_not_to_decompose = [
     torch.ops.aten.linear.default,
     torch.ops.aten.scaled_dot_product_attention.default,
+    torch.ops.aten.upsample_nearest2d.vec,
 ]
 
 edge_ops_non_decomposed = [
     exir_ops.edge.aten.linear.default,
     exir_ops.edge.aten.scaled_dot_product_attention.default,
+    exir_ops.edge.aten.upsample_nearest2d.vec,
 ]
 
 

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -808,7 +808,12 @@ def _register_no_decomp_op(op_aten):
         lib.define(op_schema)
         # Define the implementation of the op in the edge_no_decomp_namespace namespace.
         # Important to note that the implementation of the op is the same as the aten op.
+
+        overload_name = op_aten._schema.overload_name
+        if overload_name != "":
+            op_name += "." + overload_name
         lib.impl(op_name, op_aten, "CompositeExplicitAutograd")
+
         # Cache the aten op and transformed op in their corresponding tables for future use.
         aten_op_to_transform_op[op_aten] = _get_transformed_op(op_aten)
         transform_op_to_aten_op[str(aten_op_to_transform_op[op_aten])] = op_aten

--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -36,6 +36,70 @@ from torch.export import Dim, export, ExportedProgram
 from torch.export._trace import _export
 
 from torch.library import impl, Library
+from torch.nn import functional as F
+
+
+class TestLinear(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(32, 16, bias=True)
+
+    def forward(self, x):
+        return self.linear(x)
+
+    @classmethod
+    def _get_random_inputs(cls):
+        x = torch.rand(8, 32)
+        return (x,)
+
+
+class TestSDPA(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, query, key, value):
+        return torch.ops.aten.scaled_dot_product_attention.default(query, key, value)
+
+    @classmethod
+    def _get_random_inputs(cls):
+        d_k = 64
+        batch = 16
+        seq_len = 10
+        query = torch.rand(batch, seq_len, d_k)
+        key = torch.rand(batch, seq_len, d_k)
+        value = torch.rand(batch, seq_len, d_k)
+        return (query, key, value)
+
+
+class TestLinearSDPACombined(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(32, 16, bias=True)
+
+    def forward(self, x, query, key, value):
+        x = self.linear(x)
+        return (
+            x,
+            torch.ops.aten.scaled_dot_product_attention.default(query, key, value),
+        )
+
+    @classmethod
+    def _get_random_inputs(cls):
+        return TestLinear._get_random_inputs() + TestSDPA._get_random_inputs()
+
+
+class TestUpsample(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        x = F.interpolate(x, scale_factor=2, mode="nearest")
+        return x
+
+    @classmethod
+    def _get_random_inputs(cls):
+        x = torch.randn(1, 1, 8, 8)
+        return (x,)
 
 
 class WrapperModule(torch.nn.Module):
@@ -503,61 +567,13 @@ class TestProgramManagers(unittest.TestCase):
                 )
 
     def test_to_edge_transform_and_lower(self):
-        class TestLinear(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear = torch.nn.Linear(32, 16, bias=True)
-
-            def forward(self, x):
-                return self.linear(x)
-
-            @classmethod
-            def _get_random_inputs(cls):
-                x = torch.rand(8, 32)
-                return (x,)
-
-        class TestSDPA(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
-            def forward(self, query, key, value):
-                return torch.ops.aten.scaled_dot_product_attention.default(
-                    query, key, value
-                )
-
-            @classmethod
-            def _get_random_inputs(cls):
-                d_k = 64
-                batch = 16
-                seq_len = 10
-                query = torch.rand(batch, seq_len, d_k)
-                key = torch.rand(batch, seq_len, d_k)
-                value = torch.rand(batch, seq_len, d_k)
-                return (query, key, value)
-
-        class TestLinearSDPACombined(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear = torch.nn.Linear(32, 16, bias=True)
-
-            def forward(self, x, query, key, value):
-                x = self.linear(x)
-                return (
-                    x,
-                    torch.ops.aten.scaled_dot_product_attention.default(
-                        query, key, value
-                    ),
-                )
-
-            @classmethod
-            def _get_random_inputs(cls):
-                return TestLinear._get_random_inputs() + TestSDPA._get_random_inputs()
-
         self._test_model_with_non_decomp_partitioner(TestLinear())
 
         self._test_model_with_non_decomp_partitioner(TestSDPA())
 
         self._test_model_with_non_decomp_partitioner(TestLinearSDPACombined())
+
+        self._test_model_with_non_decomp_partitioner(TestUpsample())
 
     def test_to_edge_transform_and_lower_with_exception(self):
         class TestLinear(torch.nn.Module):


### PR DESCRIPTION
Summary: Adding ep as an input to the call to ops_to_not_decompose(). Based on the EP users want to modify the list they return e.g. mcr229 wants to determine whether or not nodes are parameters for which the EP is needed.

Differential Revision: D58833609


