### PR TITLE
add half dtype to slice_channel codegen

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/slice_channel.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/slice_channel.glsl
@@ -16,16 +16,10 @@ layout(std430) buffer;
 
 #include "indexing_utils.h"
 
-layout(set = 0, binding = 0, ${IMAGE_FORMAT[DTYPE]}) uniform PRECISION restrict writeonly ${IMAGE_T[NDIM][DTYPE]} image_out;
-layout(set = 0, binding = 1) uniform PRECISION sampler3D image_in;
-
-layout(set = 0, binding = 2) uniform PRECISION restrict OutSizes {
-  ivec4 out_sizes;
-};
-
-layout(set = 0, binding = 3) uniform PRECISION restrict InSizes {
-  ivec4 in_sizes;
-};
+${layout_declare_tensor(0, "w", "t_out", DTYPE, STORAGE)}
+${layout_declare_tensor(1, "r", "t_in", DTYPE, STORAGE)}
+${layout_declare_ubo(2, "ivec4", "out_sizes")}
+${layout_declare_ubo(3, "ivec4", "in_sizes")}
 
 layout(set = 0, binding = 4) uniform PRECISION restrict SliceArg {
   int offset;
@@ -65,9 +59,9 @@ void main() {
         in_sizes,
         packed_dim);
 
-      vec4 v = texelFetch(image_in, in_pow_elem.xyz, 0);
+      vec4 v = texelFetch(t_in, in_pow_elem.xyz, 0);
 
       outex[i] = v[in_pow_elem.w];
   }
-  imageStore(image_out, out_pos, outex);
+  imageStore(t_out, out_pos, outex);
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/slice_channel.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/slice_channel.yaml
@@ -2,8 +2,10 @@ slice_channel:
   parameter_names_with_default_values:
     DTYPE: float
     NDIM: 3
+    STORAGE: texture3d
   generate_variant_forall:
     DTYPE:
+      - VALUE: half
       - VALUE: float
   shader_variants:
     - NAME: slice_channel

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -526,7 +526,7 @@ def get_slice_inputs():
 
     test_suite = VkTestSuite([tuple(tc) for tc in test_cases])
 
-    test_suite.dtypes = ["at::kFloat"]
+    test_suite.dtypes = ["at::kFloat", "at::kHalf"]
     test_suite.layouts = ["api::kChannelsPacked"]
     test_suite.data_gen = "make_seq_tensor"
     return test_suite


### PR DESCRIPTION
Summary: slice_batch_height_width supports half but not slice_channel. Adding half dtype to the yaml + updating to use new layout declaration codegen method

Reviewed By: jorgep31415

Differential Revision: D58767453
