### PR TITLE
Add CMake option to override PAL default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,16 @@ else()
   set(_default_release_disabled_options ON)
 endif()
 
+# Let users override which PAL defaults to use.
+#
+# TODO(dbort): Add another option that lets users point to a specific source
+# file; if set, would override the default option.
+set(EXECUTORCH_PAL_DEFAULT
+    "posix"
+    CACHE STRING
+          "Which PAL default implementation to use: one of {posix, minimal}"
+)
+
 option(EXECUTORCH_ENABLE_LOGGING "Build with ET_LOG_ENABLED"
        ${_default_release_disabled_options}
 )
@@ -424,11 +434,31 @@ endif()
 add_subdirectory(schema)
 
 #
-# executorch: Core runtime library
+# executorch_no_prim_ops: Minimal runtime library
 #
-# Only contains primitive operators; does not contain portable kernels or other
-# full operators. Does not contain any backends.
+# The bare-minimum runtime library, supporting the Program and Method
+# interfaces. Does not contain any operators, including primitive ops. Does not
+# contain any backends.
 #
+
+# Remove any PAL-definition files from the sources.
+list(FILTER _executorch_no_prim_ops__srcs EXCLUDE REGEX
+     "runtime/platform/default/[^/]*.cpp$"
+)
+
+# Add the source file that maps to the requested default PAL implementation.
+if(EXECUTORCH_PAL_DEFAULT MATCHES "^(posix|minimal)$")
+  message(STATUS "executorch: Using PAL default '${EXECUTORCH_PAL_DEFAULT}'")
+  list(APPEND _executorch_no_prim_ops__srcs
+       "runtime/platform/default/${EXECUTORCH_PAL_DEFAULT}.cpp"
+  )
+else()
+  message(
+    FATAL_ERROR "Unknown EXECUTORCH_PAL_DEFAULT \"${EXECUTORCH_PAL_DEFAULT}\". "
+                "Expected one of {posix, minimal}."
+  )
+endif()
+
 add_library(executorch_no_prim_ops ${_executorch_no_prim_ops__srcs})
 target_link_libraries(executorch_no_prim_ops PRIVATE program_schema)
 # Check if dl exists for this toolchain and only then link it.
@@ -447,6 +477,13 @@ if(MAX_KERNEL_NUM)
   )
 endif()
 
+#
+# executorch: Primary runtime library with primitive operators.
+#
+# Provides the Program and Method interfaces, along with primitive operators.
+# Does not contain portable kernels or other full operators. Does not contain
+# any backends.
+#
 add_library(executorch ${_executorch__srcs})
 target_link_libraries(executorch PRIVATE executorch_no_prim_ops)
 target_include_directories(executorch PUBLIC ${_common_include_directories})

--- a/docs/source/runtime-platform-abstraction-layer.md
+++ b/docs/source/runtime-platform-abstraction-layer.md
@@ -32,7 +32,7 @@ definitions in the link order.
 If you run into build problems because your system doesn't support the functions
 called by `posix.cpp`, you can instead use the no-op minimal PAL at
 [`executorch/runtime/platform/default/minimal.cpp`](https://github.com/pytorch/executorch/blob/main/runtime/platform/default/minimal.cpp)
-by building with the `buck2` flag `-c executorch.pal_default=minimal`. This will
-avoid calling `fprintf()`, `std::chrono::steady_clock`, and anything else that
+by passing `-DEXECUTORCH_PAL_DEFAULT=minimal` to `cmake`. This will avoid
+calling `fprintf()`, `std::chrono::steady_clock`, and anything else that
 `posix.cpp` uses. But since the `minimal.cpp` `et_pal_*()` functions are no-ops,
 you will need to override all of them.


### PR DESCRIPTION
This was possible with buck but not with cmake.

Test Plan:
## Minimal PAL
```
(rm -rf cmake-out \
    && mkdir cmake-out \
    && cd cmake-out \
    && cmake -DEXECUTORCH_PAL_DEFAULT=minimal ..) \
&& cmake --build cmake-out -j32 --target executor_runner \
&& ./cmake-out/executor_runner --model_path ~/xtmp/ModuleLinear.pte
```
Output:
```
Output 0: tensor(sizes=[2, 2], [5., 5., 5., 5.])
```
As expected, none of the ET_LOG messages were printed because the minimal
PAL drops them.

## Posix PAL
```
(rm -rf cmake-out \
    && mkdir cmake-out \
    && cd cmake-out \
    && cmake -DEXECUTORCH_PAL_DEFAULT=posix ..) \
&& cmake --build cmake-out -j32 --target executor_runner \
&& ./cmake-out/executor_runner --model_path ~/xtmp/ModuleLinear.pte
```
Output:
```
I 00:00:00.001544 executorch:executor_runner.cpp:73] Model file /Users/dbort/xtmp/ModuleLinear.pte is loaded.
I 00:00:00.001556 executorch:executor_runner.cpp:82] Using method forward
I 00:00:00.001559 executorch:executor_runner.cpp:129] Setting up planned buffer 0, size 32.
I 00:00:00.001611 executorch:executor_runner.cpp:152] Method loaded.
I 00:00:00.001615 executorch:executor_runner.cpp:162] Inputs prepared.
I 00:00:00.001744 executorch:executor_runner.cpp:171] Model executed successfully.
I 00:00:00.001747 executorch:executor_runner.cpp:175] 1 outputs:
Output 0: tensor(sizes=[2, 2], [5., 5., 5., 5.])
```
As expected, the log messages are printed to stderr and the timestamps are
reasonable.

## Default PAL (defaults to `posix`)
```
(rm -rf cmake-out \
    && mkdir cmake-out \
    && cd cmake-out \
    && cmake ..) \
&& cmake --build cmake-out -j32 --target executor_runner \
&& ./cmake-out/executor_runner --model_path ~/xtmp/ModuleLinear.pte
```
Output is the same as the `posix` run, apart from the specific timestamps.

## Invalid PAL
```
(rm -rf cmake-out \
    && mkdir cmake-out \
    && cd cmake-out \
    && cmake -DEXECUTORCH_PAL_DEFAULT=somethinginvalid ..)
```
Output:
```
CMake Error at CMakeLists.txt:456 (message):
  Unknown EXECUTORCH_PAL_DEFAULT "somethinginvalid".  Expected one of {posix,
  minimal}.
```
