### PR TITLE
Update update_placeholder_tensor_specs to include lifted tensor constants

### DIFF
--- a/exir/passes/spec_prop_pass.py
+++ b/exir/passes/spec_prop_pass.py
@@ -78,6 +78,8 @@ class SpecPropPass(ExportPass):
                     node.target in exported_program.graph_signature.inputs_to_buffers
                     and not _is_mutable_buffer(node, exported_program.graph_signature)
                 )
+                or node.target
+                in exported_program.graph_signature.inputs_to_lifted_tensor_constants
             ):
                 spec.const = True
 


### PR DESCRIPTION
Summary: In `update_placeholder_tensor_specs` we're currently missing checking in `inputs_to_lifted_tensor_constants` to determine whether or not a placeholder is a constant. If this check is not performed, `spec.const` remains False, leading to the inclusion of this buffer size in the memory allocation for non_const_buffers, which will essentially force the runtime to allocate unneeded memory.

Differential Revision: D58712012


