### PR TITLE
[ET-VK] Standardize 2-space tabs in codegen

### DIFF
--- a/backends/vulkan/test/op_tests/utils/codegen.py
+++ b/backends/vulkan/test/op_tests/utils/codegen.py
@@ -612,36 +612,35 @@ for (int i=0; i<out.size(); i++) {{
 
 test_fixture_template = """
 class GeneratedOpsTest_{op_name} : public ::testing::TestWithParam< ::std::tuple<at::ScalarType, api::StorageType, api::GPUMemoryLayout>> {{
-  protected:
-    ComputeGraph* graph;
-    at::ScalarType test_dtype = at::kFloat;
-    float rtol = {rtol};
-    float atol = {atol};
+ protected:
+  ComputeGraph* graph;
+  at::ScalarType test_dtype = at::kFloat;
+  float rtol = {rtol};
+  float atol = {atol};
 
-    void SetUp() override {{
-        GraphConfig config;
-        api::StorageType default_storage_type;
-        api::GPUMemoryLayout default_memory_layout;
-        std::tie(test_dtype, default_storage_type, default_memory_layout) = GetParam();
-        config.set_storage_type_override(default_storage_type);
-        config.set_memory_layout_override(default_memory_layout);
-        graph = new ComputeGraph(config);
+  void SetUp() override {{
+    GraphConfig config;
+    api::StorageType default_storage_type;
+    api::GPUMemoryLayout default_memory_layout;
+    std::tie(test_dtype, default_storage_type, default_memory_layout) = GetParam();
+    config.set_storage_type_override(default_storage_type);
+    config.set_memory_layout_override(default_memory_layout);
+    graph = new ComputeGraph(config);
 
-        if (test_dtype == at::kHalf) {{
-            rtol = 1e-2;
-            atol = 1e-2;
-        }}
+    if (test_dtype == at::kHalf) {{
+      rtol = 1e-2;
+      atol = 1e-2;
     }}
+  }}
 
-    void TearDown() override {{
-        delete graph;
-        graph = nullptr;
-    }}
+  void TearDown() override {{
+    delete graph;
+    graph = nullptr;
+  }}
 
-    {check_fn}
+  {check_fn}
 
-    {prepacked_check_fn}
-
+  {prepacked_check_fn}
 }};
 """
 
@@ -676,13 +675,13 @@ class VkTestSuiteGen(TestSuiteGen):
         layouts = self.suite_def.layouts
 
         return f"""
-        INSTANTIATE_TEST_SUITE_P(
-            Combos_{self.op_name},
-            GeneratedOpsTest_{self.op_name},
-            ::testing::Combine(
-                ::testing::Values({', '.join(dtypes)}),
-                ::testing::Values({', '.join(storage_types)}),
-                ::testing::Values({', '.join(layouts)})));
+INSTANTIATE_TEST_SUITE_P(
+  Combos_{self.op_name},
+  GeneratedOpsTest_{self.op_name},
+    ::testing::Combine(
+      ::testing::Values({', '.join(dtypes)}),
+      ::testing::Values({', '.join(storage_types)}),
+      ::testing::Values({', '.join(layouts)})));
         """
 
 
@@ -701,20 +700,20 @@ using namespace vkcompute;
 using TensorOptions = at::TensorOptions;
 
 api::ScalarType from_at_scalartype(c10::ScalarType at_scalartype) {
-    switch(at_scalartype) {
-        case c10::kFloat:
-            return api::kFloat;
-        case c10::kHalf:
-            return api::kHalf;
-        case c10::kInt:
-            return api::kInt;
-        case c10::kLong:
-            return api::kInt;
-        case c10::kChar:
-            return api::kChar;
-        default:
-            VK_THROW("Unsupported at::ScalarType!");
-    }
+  switch (at_scalartype) {
+    case c10::kFloat:
+      return api::kFloat;
+    case c10::kHalf:
+      return api::kHalf;
+    case c10::kInt:
+      return api::kInt;
+    case c10::kLong:
+      return api::kInt;
+    case c10::kChar:
+      return api::kChar;
+    default:
+      VK_THROW("Unsupported at::ScalarType!");
+  }
 }
 
 #ifdef USE_VULKAN_FP16_INFERENCE
@@ -722,20 +721,20 @@ bool check_close(at::Tensor& t1, at::Tensor& t2, float rtol=1e-2, float atol=1e-
 #else
 bool check_close(at::Tensor& t1, at::Tensor& t2, float rtol=1e-5, float atol=1e-5) {
 #endif
-    // Skip checking index tensors
-    if (t1.scalar_type() == at::kLong || t2.scalar_type() == at::kLong) {
-        return true;
-    }
-    bool is_close = at::allclose(t1, t2, rtol, atol);
-    if (!is_close && t1.numel() < 500) {
-        std::cout << "reference: " << std::endl;
-        print(t1, 150);
-        std::cout << std::endl;
-        std::cout << "vulkan: " << std::endl;
-        print(t2, 150);
-        std::cout << std::endl;
-    }
-    return is_close;
+  // Skip checking index tensors
+  if (t1.scalar_type() == at::kLong || t2.scalar_type() == at::kLong) {
+    return true;
+  }
+  bool is_close = at::allclose(t1, t2, rtol, atol);
+  if (!is_close && t1.numel() < 500) {
+    std::cout << "reference: " << std::endl;
+    print(t1, 150);
+    std::cout << std::endl;
+    std::cout << "vulkan: " << std::endl;
+    print(t2, 150);
+    std::cout << std::endl;
+  }
+  return is_close;
 }
 """
 

--- a/backends/vulkan/test/op_tests/utils/codegen_base.py
+++ b/backends/vulkan/test/op_tests/utils/codegen_base.py
@@ -243,7 +243,7 @@ class TestSuiteGen:
             arg_data = get_or_return_default(arg, inputs, i)
             ref_code += self.create_input_data(arg, arg_data)
 
-        ref_code = re.sub(r"^", "    ", ref_code, flags=re.M)
+        ref_code = re.sub(r"^", "  ", ref_code, flags=re.M)
         return ref_code
 
     def gen_create_and_check_out(self, prepack=False) -> str:
@@ -254,7 +254,7 @@ class TestSuiteGen:
             arg = binding.argument
             test_str += f"{arg.name}, "
         test_str = test_str[:-2] + ");"
-        test_str = re.sub(r"^", "    ", test_str, flags=re.M)
+        test_str = re.sub(r"^", "  ", test_str, flags=re.M)
         return test_str
 
     def gen_parameterization(self) -> str:
@@ -272,7 +272,7 @@ class TestSuiteGen:
         )
 
     def generate_suite_cpp(self) -> str:
-        suite_cpp = self.generate_fixture_cpp() + "\n"
+        suite_cpp = self.generate_fixture_cpp()
         for inputs in self.suite_def.input_cases:
             if not self.suite_def.requires_prepack:
                 suite_cpp += self.generate_case_cpp(inputs)
@@ -295,19 +295,18 @@ cpp_test_template = """
 {preamble}
 
 at::Tensor make_rand_tensor(
-        std::vector<int64_t> sizes,
-        at::ScalarType dtype = at::kFloat,
-        float low = 0.0,
-        float high = 1.0) {{
-    if (high == 1.0 && low == 0.0)
-        return at::rand(sizes, at::device(at::kCPU).dtype(dtype));
+    std::vector<int64_t> sizes,
+    at::ScalarType dtype = at::kFloat,
+    float low = 0.0,
+    float high = 1.0) {{
+  if (high == 1.0 && low == 0.0)
+    return at::rand(sizes, at::device(at::kCPU).dtype(dtype));
     
-    if (dtype == at::kChar)
-        return at::randint(high, sizes, at::device(at::kCPU).dtype(dtype));
+  if (dtype == at::kChar)
+    return at::randint(high, sizes, at::device(at::kCPU).dtype(dtype));
 
-    return at::rand(sizes, at::device(at::kCPU).dtype(dtype)) * (high - low) + low;
+  return at::rand(sizes, at::device(at::kCPU).dtype(dtype)) * (high - low) + low;
 }}
-
 
 at::Tensor make_seq_tensor(
     std::vector<int64_t> sizes,
@@ -330,7 +329,6 @@ at::Tensor make_seq_tensor(
   // Clone as original data will be deallocated upon return.
   return at::from_blob(values.data(), sizes, at::kFloat).toType(dtype).detach().clone();
 }}
-
 
 at::Tensor make_index_tensor(std::vector<int64_t> indices) {{
   at::ScalarType dtype = at::kInt;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4044
* __->__ #4043

for consistently with the non-generated ET-VK code.

The new perf codegen will build off this existing correctness codegen and I want the generated code to be readable.

Differential Revision: [D58954596](https://our.internmc.facebook.com/intern/diff/D58954596/)