### PR TITLE
[ET-VK] Allow overwriting local workgroup size

### DIFF
--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -320,6 +320,10 @@ api::utils::uvec3 ComputeGraph::create_global_wg_size(const ValueRef idx) {
 }
 
 api::utils::uvec3 ComputeGraph::create_local_wg_size(const ValueRef idx) {
+  if (config_.enable_local_wg_size_override) {
+    return config_.local_wg_size_override;
+  }
+
   if (is_buffer_storage(idx)) {
     return {64u, 1u, 1u};
   }

--- a/backends/vulkan/runtime/graph/GraphConfig.cpp
+++ b/backends/vulkan/runtime/graph/GraphConfig.cpp
@@ -60,6 +60,9 @@ GraphConfig::GraphConfig() {
   // QueryPool objects are used to measure execution times of individual shader
   // dispatches. By default, this functionality is disabled.
   enable_querypool = false;
+
+  enable_local_wg_size_override = false;
+  local_wg_size_override = {};
 }
 
 void GraphConfig::set_storage_type_override(api::StorageType storage_type) {
@@ -71,6 +74,12 @@ void GraphConfig::set_memory_layout_override(
     api::GPUMemoryLayout memory_layout) {
   enable_memory_layout_override = true;
   memory_layout_override = memory_layout;
+}
+
+void GraphConfig::set_local_wg_size_override(
+    const api::utils::uvec3& local_wg_size) {
+  enable_local_wg_size_override = true;
+  local_wg_size_override = local_wg_size;
 }
 
 } // namespace vkcompute

--- a/backends/vulkan/runtime/graph/GraphConfig.h
+++ b/backends/vulkan/runtime/graph/GraphConfig.h
@@ -30,11 +30,15 @@ struct GraphConfig final {
 
   bool enable_querypool;
 
+  bool enable_local_wg_size_override;
+  api::utils::uvec3 local_wg_size_override;
+
   // Generate a default graph config with pre-configured settings
   explicit GraphConfig();
 
   void set_storage_type_override(api::StorageType storage_type);
   void set_memory_layout_override(api::GPUMemoryLayout memory_layout);
+  void set_local_wg_size_override(const api::utils::uvec3& local_wg_size);
 };
 
 } // namespace vkcompute


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4053
* __->__ #4046
* #4052
* #4045

Introduce a `GraphConfig` toggle following the convention of `storage_type` and `memory_layout`.

Differential Revision: [D58957058](https://our.internmc.facebook.com/intern/diff/D58957058/)