### PR TITLE
add support not decompose into vulkan_partition

### DIFF
--- a/backends/vulkan/partitioner/supported_ops.py
+++ b/backends/vulkan/partitioner/supported_ops.py
@@ -125,6 +125,7 @@ CREATION_OPS = [
     exir_ops.edge.aten.ones_like.default,
     exir_ops.edge.aten.zeros.default,
     exir_ops.edge.aten.zeros_like.default,
+    exir_ops.edge.aten.upsample_nearest2d.vec,
 ]
 
 


### PR DESCRIPTION
Summary:
Operator `aten.upsample_nearest2d.vec` will be decomposed into several operators when lowering to Vulkan delegation. While we already have the implementation of this op in Vulkan. Add support to disable decomposition in Vulkan Partitioner.

Follow usage in this [example](https://www.internalfb.com/code/fbsource/[697a6da34c78]/fbcode/executorch/exir/backend/test/op_partitioner_demo.py?lines=158).

Differential Revision: D58900868
