### PR TITLE
[ET-VK] Use macros for all shader codegen variables

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.glsl
@@ -12,6 +12,8 @@
 
 #define VEC4_T ${texel_type(DTYPE)}
 
+#define TILE_SIZE ${TILE_SIZE}
+
 #define op(X, A, B) ${OPERATOR}
 
 #include "indexing_utils.h"
@@ -73,8 +75,8 @@ void main() {
 
   VEC4_T sum = texelFetch(bias_in, ivec2(pos.z, 0), 0);
   int kx = 0;
-  for (int y = start.y, i = 0; i < ${TILE_SIZE}; y += dilation.y, i++) {
-    for (int x = start.x, j = 0; j < ${TILE_SIZE}; x += dilation.x, j++) {
+  for (int y = start.y, i = 0; i < TILE_SIZE; y += dilation.y, i++) {
+    for (int x = start.x, j = 0; j < TILE_SIZE; x += dilation.x, j++) {
       // The weight kernel was rearranged such that every NxN filter is
       // flattened to fit in one row. Each filter was then stacked on top of
       // each other vertically.

--- a/backends/vulkan/runtime/graph/ops/glsl/full.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/full.glsl
@@ -12,6 +12,8 @@
 
 #define VEC4_T ${texel_type(DTYPE)}
 
+#define POS ${get_pos[NDIM]("pos")}
+
 #include "indexing_utils.h"
 
 layout(std430) buffer;
@@ -48,5 +50,5 @@ void main() {
     outtex = outtex * valid_idx;
   }
 
-  imageStore(image_out, ${get_pos[NDIM]("pos")}, outtex);
+  imageStore(image_out, POS, outtex);
 }

--- a/backends/vulkan/test/glsl/idx_fill_texture.glsl
+++ b/backends/vulkan/test/glsl/idx_fill_texture.glsl
@@ -12,6 +12,8 @@
 
 #define VEC4_T ${texel_type(DTYPE)}
 
+#define POS ${get_pos[NDIM]("pos")}
+
 #include "indexing_utils.h"
 
 layout(std430) buffer;
@@ -36,5 +38,5 @@ void main() {
 
   const ivec4 buf_indices = get_texel_nchw_buffer_ixs(idx, sizes, packed_dim);
   VEC4_T texel = VEC4_T(buf_indices);
-  imageStore(image_out, ${get_pos[NDIM]("pos")}, texel);
+  imageStore(image_out, POS, texel);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4053
* #4046
* __->__ #4052
* #4045

TSIA

Differential Revision: [D58958385](https://our.internmc.facebook.com/intern/diff/D58958385/)