### PR TITLE
remove clone ops pass

### DIFF
--- a/backends/transforms/TARGETS
+++ b/backends/transforms/TARGETS
@@ -74,6 +74,19 @@ runtime.python_library(
 )
 
 runtime.python_library(
+    name = "remove_clone_ops",
+    srcs = ["remove_clone_ops.py"],
+    visibility = [
+        "//executorch/backends/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir:pass_base",
+        "//executorch/exir/dialects:lib",
+    ],
+)
+
+runtime.python_library(
     name = "mean_to_sum_div",
     srcs = ["mean_to_sum_div.py"],
     visibility = [

--- a/backends/transforms/remove_clone_ops.py
+++ b/backends/transforms/remove_clone_ops.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import torch
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+
+
+def remove_clone_ops(graph: torch.fx.Graph) -> torch.fx.Graph:
+    """
+    Remove clone op nodes and replace uses with parent node.
+    """
+    clone_op = exir_ops.edge.aten.clone.default
+    for node in graph.nodes:
+        if node.op == "call_function" and node.target == clone_op:
+            with graph.inserting_after(node):
+                node.replace_all_uses_with(node.args[0])
+
+    graph.eliminate_dead_code()
+    return graph
+
+
+class RemoveCloneOpsTransform(ExportPass):
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        graph_module.graph = remove_clone_ops(graph_module.graph)
+        return PassResult(graph_module, True)

--- a/backends/vulkan/TARGETS
+++ b/backends/vulkan/TARGETS
@@ -26,6 +26,7 @@ runtime.python_library(
         "//executorch/backends/transforms:fuse_batch_norm_with_conv",
         "//executorch/backends/transforms:fuse_conv_with_clamp",
         "//executorch/backends/transforms:fuse_view_copy",
+        "//executorch/backends/transforms:remove_clone_ops",
         "//executorch/exir:graph_module",
         "//executorch/exir/_serialize:_bindings",
         "//executorch/exir/_serialize:lib",

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -14,6 +14,7 @@ from executorch.backends.transforms.fuse_batch_norm_with_conv import (
 )
 from executorch.backends.transforms.fuse_conv_with_clamp import FuseClampPass
 from executorch.backends.transforms.fuse_view_copy import FuseViewCopyTransform
+from executorch.backends.transforms.remove_clone_ops import RemoveCloneOpsTransform
 
 from executorch.backends.vulkan.serialization.vulkan_graph_builder import VkGraphBuilder
 from executorch.backends.vulkan.serialization.vulkan_graph_serialize import (
@@ -47,6 +48,7 @@ class VulkanBackend(BackendDetails):
         module_compile_spec: List[CompileSpec],
     ) -> PreprocessResult:
         passes = [
+            RemoveCloneOpsTransform(),
             AddmmToLinearTransform(),
             FuseViewCopyTransform(),
             FuseBatchNormWithConvPass(program),


### PR DESCRIPTION
Summary:
In the Vulkan backend, we always create copies when running an op, so the clone op is effectively a no-op with extra memory read/writes.
Adding a pass to strip out clone ops.

Differential Revision: D58761417
