### PR TITLE
Support compute_uinit in coreml backend when calling ct.convert

### DIFF
--- a/backends/apple/coreml/compiler/coreml_preprocess.py
+++ b/backends/apple/coreml/compiler/coreml_preprocess.py
@@ -144,6 +144,19 @@ class CoreMLBackend(BackendDetails):
         return ct.target.iOS15
 
     @staticmethod
+    def compute_unit_from_compile_specs(
+        compile_specs: List[CompileSpec],
+    ) -> ct.ComputeUnit:
+        """
+        Returns the minimum deployment target by parsing the list of compile specs.
+        """
+        for compile_spec in compile_specs:
+            if compile_spec.key == COMPILE_SPEC_KEYS.COMPUTE_UNITS.value:
+                return ct.ComputeUnit[compile_spec.value.decode("utf-8").upper()]
+
+        return ct.ComputeUnit.ALL
+
+    @staticmethod
     def generate_compute_unit_compile_spec(
         compute_unit: ct.ComputeUnit,
     ) -> CompileSpec:
@@ -364,6 +377,10 @@ class CoreMLBackend(BackendDetails):
             CoreMLBackend.min_deployment_target_from_compile_specs(compile_specs)
         )
 
+        compute_units: ct.ComputeUnit = CoreMLBackend.compute_unit_from_compile_specs(
+            compile_specs
+        )
+
         mlmodel = ct.convert(
             model=edge_program,
             source="pytorch",
@@ -372,6 +389,7 @@ class CoreMLBackend(BackendDetails):
             skip_model_load=False,
             compute_precision=model_compute_precision,
             minimum_deployment_target=minimum_deployment_target,
+            compute_units=compute_units,
         )
 
         return CoreMLBackend.preprocess_model(mlmodel, model_type=model_type)


### PR DESCRIPTION
Summary:
It seems currently the compute unit value set in executorch/examples/models/llama2/lib/partitioner_lib.py?lines=74 is not used during the convert, adding the support in this change.

However to my surprise, the model name in the actual ios instrument result has the right suffix (see the image below), I couldn't find anywhere in the code how this is set and I have no way to validate if it's just part of the name or it's indeed set correctly through another path. I'll abandon this diff if it's not needed actually...

 {F1718372833}

Differential Revision: D58981934
