### PR TITLE
Make memory allocation macros windows-compatible

### DIFF
--- a/runtime/core/memory_allocator.h
+++ b/runtime/core/memory_allocator.h
@@ -14,6 +14,7 @@
 
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/platform/assert.h>
+#include <executorch/runtime/platform/compiler.h>
 #include <executorch/runtime/platform/log.h>
 #include <executorch/runtime/platform/profiler.h>
 
@@ -197,6 +198,7 @@ class MemoryAllocator {
   int32_t prof_id_ = -1;
 };
 
+#if __ET_HAVE_GNU_STATEMENT_EXPRESSIONS
 /**
  * Tries allocating from the specified MemoryAllocator*.
  *
@@ -218,26 +220,9 @@ class MemoryAllocator {
     if (et_try_allocate_result == nullptr) {                               \
       __VA_ARGS__                                                          \
       /* The args must return. */                                          \
-      __builtin_unreachable();                                             \
+      __ET_UNREACHABLE();                                                  \
     }                                                                      \
     et_try_allocate_result;                                                \
-  })
-
-/**
- * Tries allocating from the specified MemoryAllocator*.
- *
- * - On success, returns a pointer to the allocated buffer.
- * - On failure, returns `Error::MemoryAllocationFailed` from the calling
- *   function, which must be declared to return `torch::executor::Error`.
- *
- * Example:
- * @code
- *   char* buf = ET_ALLOCATE_OR_RETURN_ERROR(memory_allocator, bufsize);
- * @endcode
- */
-#define ET_ALLOCATE_OR_RETURN_ERROR(memory_allocator__, nbytes__) \
-  ET_TRY_ALLOCATE_OR(memory_allocator__, nbytes__, {              \
-    return torch::executor::Error::MemoryAllocationFailed;        \
   })
 
 /**
@@ -262,27 +247,9 @@ class MemoryAllocator {
     if (et_try_allocate_result == nullptr) {                         \
       __VA_ARGS__                                                    \
       /* The args must return. */                                    \
-      __builtin_unreachable();                                       \
+      __ET_UNREACHABLE();                                            \
     }                                                                \
     et_try_allocate_result;                                          \
-  })
-
-/**
- * Tries allocating an instance of type__ from the specified MemoryAllocator*.
- *
- * - On success, returns a pointer to the allocated buffer. Note that the memory
- *   will not be initialized.
- * - On failure, returns `Error::MemoryAllocationFailed` from the calling
- *   function, which must be declared to return `torch::executor::Error`.
- *
- * Example:
- * @code
- *   char* buf = ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(memory_allocator, MyType);
- * @endcode
- */
-#define ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(memory_allocator__, type__) \
-  ET_TRY_ALLOCATE_INSTANCE_OR(memory_allocator__, type__, {              \
-    return torch::executor::Error::MemoryAllocationFailed;               \
   })
 
 /**
@@ -308,9 +275,78 @@ class MemoryAllocator {
     if (et_try_allocate_result == nullptr) {                              \
       __VA_ARGS__                                                         \
       /* The args must return. */                                         \
-      __builtin_unreachable();                                            \
+      __ET_UNREACHABLE();                                                 \
     }                                                                     \
     et_try_allocate_result;                                               \
+  })
+#else // !__ET_HAVE_GNU_STATEMENT_EXPRESSIONS
+/**
+ * The recommended alternative for statement expression-incompatible compilers
+ * is to directly allocate the memory.
+ * e.g. memory_allocator__->allocate(nbytes__);
+ */
+#define ET_TRY_ALLOCATE_OR(memory_allocator__, nbytes__, ...) \
+  static_assert(                                              \
+      false,                                                  \
+      "ET_TRY_ALLOCATE_OR uses statement expressions and \
+      thus is not available for use with this compiler.");
+
+/**
+ * The recommended alternative for statement expression-incompatible compilers
+ * is to directly allocate the memory.
+ * e.g. memory_allocator__->allocateInstance<type__>();
+ */
+#define ET_TRY_ALLOCATE_INSTANCE_OR(memory_allocator__, type__, ...) \
+  static_assert(                                                     \
+      false,                                                         \
+      "ET_TRY_ALLOCATE_INSTANCE_OR uses statement \
+    expressions and thus is not available for use with this compiler.");
+
+/**
+ * The recommended alternative for statement expression-incompatible compilers
+ * is to directly use allocate the memory.
+ * e.g. memory_allocator__->allocateList<type__>(nelem__);
+ */
+#define ET_TRY_ALLOCATE_LIST_OR(memory_allocator__, type__, nelem__, ...) \
+  static_assert(                                                          \
+      false,                                                              \
+      "ET_TRY_ALLOCATE_LIST_OR uses statement \
+    expressions and thus is not available for use with this compiler.");
+#endif // !__ET_HAVE_GNU_STATEMENT_EXPRESSIONS
+
+/**
+ * Tries allocating from the specified MemoryAllocator*.
+ *
+ * - On success, returns a pointer to the allocated buffer.
+ * - On failure, returns `Error::MemoryAllocationFailed` from the calling
+ *   function, which must be declared to return `torch::executor::Error`.
+ *
+ * Example:
+ * @code
+ *   char* buf = ET_ALLOCATE_OR_RETURN_ERROR(memory_allocator, bufsize);
+ * @endcode
+ */
+#define ET_ALLOCATE_OR_RETURN_ERROR(memory_allocator__, nbytes__) \
+  ET_TRY_ALLOCATE_OR(memory_allocator__, nbytes__, {              \
+    return torch::executor::Error::MemoryAllocationFailed;        \
+  })
+
+/**
+ * Tries allocating an instance of type__ from the specified MemoryAllocator*.
+ *
+ * - On success, returns a pointer to the allocated buffer. Note that the memory
+ *   will not be initialized.
+ * - On failure, returns `Error::MemoryAllocationFailed` from the calling
+ *   function, which must be declared to return `torch::executor::Error`.
+ *
+ * Example:
+ * @code
+ *   char* buf = ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(memory_allocator, MyType);
+ * @endcode
+ */
+#define ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(memory_allocator__, type__) \
+  ET_TRY_ALLOCATE_INSTANCE_OR(memory_allocator__, type__, {              \
+    return torch::executor::Error::MemoryAllocationFailed;               \
   })
 
 /**

--- a/runtime/core/test/memory_allocator_test.cpp
+++ b/runtime/core/test/memory_allocator_test.cpp
@@ -195,6 +195,7 @@ TEST_F(MemoryAllocatorTest, AllocateListFailure) {
   EXPECT_EQ(p, nullptr);
 }
 
+#if __ET_HAVE_GNU_STATEMENT_EXPRESSIONS
 class HelperMacrosTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -402,3 +403,4 @@ TEST_F(HelperMacrosTest, AllocateListOrReturnFailure) {
       &allocator, allocator.size() * 2, &p);
   EXPECT_EQ(err, Error::MemoryAllocationFailed);
 }
+#endif // __ET_HAVE_GNU_STATEMENT_EXPRESSIONS

--- a/runtime/platform/compiler.h
+++ b/runtime/platform/compiler.h
@@ -47,6 +47,10 @@
 
 #define __ET_UNREACHABLE() __builtin_unreachable()
 
+#elif defined(_MSC_VER)
+
+#define __ET_UNREACHABLE() __assume(0)
+
 #else // defined(__GNUC__)
 
 #define __ET_UNREACHABLE() \
@@ -118,3 +122,13 @@
 #else
 #define __ET_FUNCTION __FUNCTION__
 #endif // __has_builtin(__builtin_FUNCTION)
+
+// Whether the compiler supports GNU statement expressions.
+// https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html
+#ifndef __ET_HAVE_GNU_STATEMENT_EXPRESSIONS
+#if (defined(__GNUC__) && __GNUC__ >= 3) || defined(__clang__)
+#define __ET_HAVE_GNU_STATEMENT_EXPRESSIONS 1
+#else
+#define __ET_HAVE_GNU_STATEMENT_EXPRESSIONS 0
+#endif
+#endif // ifndef


### PR DESCRIPTION
Summary:
Make `ET_TRY_ALLOCATE_OR`, `ET_TRY_ALLOCATE_INSTANCE_OR`, and `ET_TRY_ALLOCATE_LIST_OR` raise static assertion errors at compile time when compiled with statement expression-incompatible compilers (namely MSVC, among others).

The recommended alternative is to eschew the above macros in favor of directly allocating the memory, as hinted by the assertion comments.

The `memory_allocator_test.cpp` now only tests the macros if compiled using GCC 3.0+/Clang (statement expression-compatible). This is for backwards compatibility temporarily. Eventually the goal is remove all call-sites of `ET_TRY_ALLOCATE_OR`, `ET_TRY_ALLOCATE_INSTANCE_OR`, and `ET_TRY_ALLOCATE_LIST_OR` yet.

Differential Revision: D58850316
