### PR TITLE
Create exceptions for spec.const in verify_graph_input_output

### DIFF
--- a/exir/memory_planning.py
+++ b/exir/memory_planning.py
@@ -219,6 +219,9 @@ class Verifier:
                 if _is_mutable_buffer(nd, self.graph_signature):
                     continue
                 assert len(specs) > 0, "Expect tensor specs"
+                specs = list(filter(lambda spec: not spec.const, specs))
+                if len(specs) == 0:
+                    continue
                 allocated = any(
                     spec is None or spec.mem_offset is not None for spec in specs
                 )


### PR DESCRIPTION
Summary: The ASR model triggered an edge case where when we run constant_prop_pass it creates a constant in the placeholders which is then directly returned as an output of the model. When this is done the check in `verify_graph_input_output` fails because for the placeholder constant that is returned as an output we have no mem_offset (as expected). In order to handle this case we'll filter out specs from this list that are constants and then do the checks.

Differential Revision: D59140916
