### PR TITLE
Add Tiktoken v5 vision tokenizer

### DIFF
--- a/examples/models/llama2/tokenizer/test/test_tiktoken.cpp
+++ b/examples/models/llama2/tokenizer/test/test_tiktoken.cpp
@@ -30,6 +30,19 @@ class TiktokenExtensionTest : public Test {
   std::string modelPath_;
 };
 
+class MultimodalTiktokenV5ExtensionTest : public Test {
+ public:
+  void SetUp() override {
+    torch::executor::runtime_init();
+    tokenizer_ = std::make_unique<Tiktoken>(MULTIMODAL);
+    modelPath_ =
+        std::getenv("RESOURCES_PATH") + std::string("/tokenizer.model");
+  }
+
+  std::unique_ptr<Tokenizer> tokenizer_;
+  std::string modelPath_;
+};
+
 TEST_F(TiktokenExtensionTest, EncodeWithoutLoadFails) {
   Result<std::vector<uint64_t>> res = tokenizer_->encode("hello world", 0, 0);
   EXPECT_EQ(res.error(), Error::NotSupported);
@@ -41,6 +54,16 @@ TEST_F(TiktokenExtensionTest, DecodeWithoutLoadFails) {
 }
 
 TEST_F(TiktokenExtensionTest, TokenizerVocabSizeIsExpected) {
+  Error res = tokenizer_->load(modelPath_.c_str());
+  EXPECT_EQ(res, Error::Ok);
+  // test.bin has vocab size 0 but the tokenizer respects the vocab size being
+  // passed in and add placeholder tokens.
+  EXPECT_EQ(tokenizer_->vocab_size(), 128256);
+  EXPECT_EQ(tokenizer_->bos_tok(), 128000);
+  EXPECT_EQ(tokenizer_->eos_tok(), 128001);
+}
+
+TEST_F(MultimodalTiktokenV5ExtensionTest, TokenizerVocabSizeIsExpected) {
   Error res = tokenizer_->load(modelPath_.c_str());
   EXPECT_EQ(res, Error::Ok);
   // test.bin has vocab size 0 but the tokenizer respects the vocab size being
@@ -63,6 +86,29 @@ TEST_F(TiktokenExtensionTest, TokenizerEncodeCorrectly) {
   EXPECT_EQ(out.get()[2], 1917);
 }
 
+TEST_F(MultimodalTiktokenV5ExtensionTest, TokenizerEncodeCorrectly) {
+  Error res = tokenizer_->load(modelPath_.c_str());
+  EXPECT_EQ(res, Error::Ok);
+  // test.bin has vocab size 0 but the tokenizer respects the vocab size being
+  // passed in and add placeholder tokens.
+  Result<std::vector<uint64_t>> out = tokenizer_->encode(
+      "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n<|image|>What do you think is going on in this snapshot?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\nAmidst a scenic garden backdrop, a man dressed in a suit with a distinct button on its lower portion stands prominently.<|eom_id|>",
+      0,
+      0);
+  EXPECT_EQ(out.error(), Error::Ok);
+  EXPECT_EQ(out.get().size(), 48);
+  std::vector<uint64_t> expected_out = {
+      128000, 128006, 882,    128007, 271,    128010, 3923,  656,
+      499,    1781,   374,    2133,   389,    304,    420,   16694,
+      30,     128009, 128006, 78191,  128007, 271,    6219,  307,
+      267,    264,    62081,  13863,  39577,  11,     264,   893,
+      26435,  304,    264,    7937,   449,    264,    12742, 3215,
+      389,    1202,   4827,   13651,  13656,  74088,  13,    128008};
+  for (size_t i = 0; i < expected_out.size(); ++i) {
+    EXPECT_EQ(expected_out[i], out.get()[i]);
+  }
+}
+
 TEST_F(TiktokenExtensionTest, TokenizerDecodeCorrectly) {
   Error res = tokenizer_->load(modelPath_.c_str());
   EXPECT_EQ(res, Error::Ok);
@@ -70,6 +116,30 @@ TEST_F(TiktokenExtensionTest, TokenizerDecodeCorrectly) {
   // passed in and add placeholder tokens.
   std::vector<std::string> expected = {"<|begin_of_text|>", "hello", " world"};
   std::vector<uint64_t> tokens = {128000, 15339, 1917};
+  for (size_t i = 0; i < tokens.size(); i++) {
+    Result<std::string> out = tokenizer_->decode(0, tokens[i]);
+    EXPECT_EQ(out.error(), Error::Ok);
+    EXPECT_EQ(out.get(), expected[i]);
+  }
+}
+
+TEST_F(MultimodalTiktokenV5ExtensionTest, TokenizerDecodeCorrectly) {
+  Error res = tokenizer_->load(modelPath_.c_str());
+  EXPECT_EQ(res, Error::Ok);
+  // test.bin has vocab size 0 but the tokenizer respects the vocab size being
+  // passed in and add placeholder tokens.
+  std::vector<std::string> expected = {
+      "<|begin_of_text|>",
+      "<|start_header_id|>",
+      "user",
+      "<|end_header_id|>",
+      "<|image|>",
+      "<|image|>",
+      "hello",
+      "<|image|>",
+      "<|eom_id|>"};
+  std::vector<uint64_t> tokens = {
+      128000, 128006, 882, 128007, 128010, 128010, 15339, 128010, 128008};
   for (size_t i = 0; i < tokens.size(); i++) {
     Result<std::string> out = tokenizer_->decode(0, tokens[i]);
     EXPECT_EQ(out.error(), Error::Ok);
@@ -85,6 +155,5 @@ TEST_F(TiktokenExtensionTest, TokenizerDecodeOutOfRangeFails) {
   Result<std::string> out = tokenizer_->decode(0, 128256 + 256);
   EXPECT_EQ(out.error(), Error::NotSupported);
 }
-
 } // namespace executor
 } // namespace torch

--- a/examples/models/llama2/tokenizer/tiktoken.h
+++ b/examples/models/llama2/tokenizer/tiktoken.h
@@ -24,9 +24,17 @@ using Encoder = std::unordered_map<std::string, uint64_t>;
 using Decoder = std::unordered_map<uint64_t, std::string>;
 using Re2UPtr = std::unique_ptr<re2::RE2>;
 
+constexpr int32_t kSpecialTokensSize = 256;
+
+enum Version {
+  DEFAULT,
+  MULTIMODAL,
+};
+
 class Tiktoken : public Tokenizer {
  public:
-  explicit Tiktoken() : Tokenizer() {}
+  explicit Tiktoken(const Version& version = DEFAULT)
+      : Tokenizer(), _version(version) {}
   ~Tiktoken(){};
 
   Error load(const std::string& tokenizer_path) override;
@@ -38,24 +46,101 @@ class Tiktoken : public Tokenizer {
       const override;
 
  private:
-  static inline const Encoder _get_special_tokens(ssize_t num_base_tokens) {
+  static inline const Encoder _get_default_special_tokens(
+      ssize_t num_base_tokens) {
     Encoder special_tokens;
-    special_tokens.emplace("<|begin_of_text|>", num_base_tokens++);
-    special_tokens.emplace("<|end_of_text|>", num_base_tokens++);
-    special_tokens.emplace("<|reserved_special_token_0|>", num_base_tokens++);
-    special_tokens.emplace("<|reserved_special_token_1|>", num_base_tokens++);
-    special_tokens.emplace("<|reserved_special_token_2|>", num_base_tokens++);
-    special_tokens.emplace("<|reserved_special_token_3|>", num_base_tokens++);
-    special_tokens.emplace("<|start_header_id|>", num_base_tokens++);
-    special_tokens.emplace("<|end_header_id|>", num_base_tokens++);
-    special_tokens.emplace("<|reserved_special_token_4|>", num_base_tokens++);
-    special_tokens.emplace("<|eot_id|>", num_base_tokens++);
-    for (auto i = 5; i < 251; ++i) {
+    ssize_t special_token_count = 0;
+    special_tokens.emplace(
+        "<|begin_of_text|>", num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|end_of_text|>", num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|reserved_special_token_0|>",
+        num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|reserved_special_token_1|>",
+        num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|reserved_special_token_2|>",
+        num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|reserved_special_token_3|>",
+        num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|start_header_id|>", num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|end_header_id|>", num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|reserved_special_token_4|>",
+        num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|eot_id|>", num_base_tokens + special_token_count++);
+
+    // pad the rest of the special tokens with reserved tokens
+    ssize_t reserved_special_token_num = 5;
+    while (special_token_count < kSpecialTokensSize) {
       special_tokens.emplace(
-          "<|reserved_special_token_" + std::to_string(i) + "|>",
-          num_base_tokens++);
+          "<|reserved_special_token_" +
+              std::to_string(reserved_special_token_num++) + "|>",
+          num_base_tokens + special_token_count++);
     }
     return special_tokens;
+  }
+
+  static inline const Encoder _get_multimodal_special_tokens(
+      ssize_t num_base_tokens) {
+    ssize_t special_token_count = 0;
+    Encoder special_tokens;
+    special_tokens.emplace(
+        "<|begin_of_text|>", num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|end_of_text|>", num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|reserved_special_token_0|>",
+        num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|reserved_special_token_1|>",
+        num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|reserved_special_token_2|>",
+        num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|reserved_special_token_3|>",
+        num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|start_header_id|>", num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|end_header_id|>", num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|eom_id|>", num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|eot_id|>", num_base_tokens + special_token_count++);
+    special_tokens.emplace(
+        "<|image|>", num_base_tokens + special_token_count++);
+
+    // pad the rest of the special tokens with reserved tokens except the last
+    // one
+    ssize_t reserved_special_token_num = 4;
+    while (special_token_count < kSpecialTokensSize - 1) {
+      special_tokens.emplace(
+          "<|reserved_special_token_" +
+              std::to_string(reserved_special_token_num++) + "|>",
+          num_base_tokens + special_token_count++);
+    }
+
+    special_tokens.emplace(
+        "<|python_tag|>", num_base_tokens + special_token_count++);
+
+    return special_tokens;
+  }
+
+  inline const Encoder _get_special_tokens(ssize_t num_base_tokens) {
+    switch (_version) {
+      case MULTIMODAL:
+        return _get_multimodal_special_tokens(num_base_tokens);
+      default:
+        return _get_default_special_tokens(num_base_tokens);
+    }
   }
 
   template <typename T>
@@ -73,6 +158,8 @@ class Tiktoken : public Tokenizer {
   std::pair<std::vector<uint64_t>, uint64_t> _encode_with_special_token(
       const std::string& text,
       const T& allowed_special) const;
+
+  const Version _version;
 
   // Removed negative lookahead \s+(?!\S) since it's not supported by RE2.
   const std::string _pattern =


### PR DESCRIPTION
Summary:
Added a new param so that user can decide which version of tiktoken will be used. Refactored special tokens to be more streamlined and reserve 256 special tokens independent of Tiktoken version.


Differential Revision: D59074258
