### PR TITLE
Move partitioner and quantizer to export_lib

### DIFF
--- a/examples/models/llama2/TARGETS
+++ b/examples/models/llama2/TARGETS
@@ -67,8 +67,6 @@ runtime.python_library(
         "builder.py",
         "export_llama.py",
         "export_llama_lib.py",
-        "lib/partitioner_lib.py",
-        "lib/quant_lib.py",
         "model.py",
         "source_transformation/quantize.py",
         "source_transformation/rope.py",
@@ -84,17 +82,13 @@ runtime.python_library(
     ],
     deps = [
         "//caffe2:torch",
-        "//executorch/backends/apple/coreml:backend",
-        "//executorch/backends/apple/coreml:partitioner",
         "//executorch/backends/transforms:duplicate_dynamic_quant_chain",
-        "//executorch/backends/vulkan/partitioner:vulkan_partitioner",
-        "//executorch/backends/xnnpack:xnnpack_backend",
-        "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
         "//executorch/examples/models:model_base",
         "//executorch/examples/models:models",
         "//executorch/examples/models/llama2/custom_ops:custom_ops_aot_py",
         "//executorch/examples/portable:utils",
         "//executorch/exir:lib",
+        "//executorch/extension/llm/export:export_lib",
         # one definition has to be included in the user of the libarary
         # depending on what library the client wants to use
         # "//executorch/extension/pybindings:aten_lib",

--- a/extension/llm/export/TARGETS
+++ b/extension/llm/export/TARGETS
@@ -1,0 +1,33 @@
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()
+
+runtime.python_library(
+    name = "export_lib",
+    srcs = [
+        "partitioner_lib.py",
+        "quantizer_lib.py",
+    ],
+    _is_external_target = True,
+    base_module = "executorch.extension.llm.export",
+    visibility = [
+        "//bento/...",
+        "//bento_kernels/...",
+        "//executorch/examples/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/apple/coreml:backend",
+        "//executorch/backends/apple/coreml:partitioner",
+        "//executorch/backends/apple/mps:partitioner",
+        "//executorch/backends/vulkan/partitioner:vulkan_partitioner",
+        "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
+        "//executorch/exir/backend:backend_details",
+    ],
+)

--- a/extension/llm/export/partitioner_lib.py
+++ b/extension/llm/export/partitioner_lib.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Optional
+
 
 def get_xnnpack_partitioner():
     from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
@@ -17,12 +19,14 @@ def get_xnnpack_partitioner():
     return XnnpackDynamicallyQuantizedPartitioner()
 
 
-def get_vulkan_partitioner(args):
+def get_vulkan_partitioner(
+    dtype_override: Optional[str] = None, quantization_mode: Optional[str] = None
+):
     assert (
-        args.dtype_override == "fp32" or args.dtype_override is None
+        dtype_override == "fp32" or dtype_override is None
     ), "Vulkan backend does not support non fp32 dtypes at the moment"
     assert (
-        args.quantization_mode is None
+        quantization_mode is None
     ), "Vulkan backend does not support quantization at the moment"
     from executorch.backends.vulkan.partitioner.vulkan_partitioner import (
         VulkanPartitioner,
@@ -31,11 +35,11 @@ def get_vulkan_partitioner(args):
     return VulkanPartitioner({"require_dynamic_shapes": True})
 
 
-def get_mps_partitioner(args):
+def get_mps_partitioner(use_kv_cache: bool = False):
     from executorch.exir.backend.backend_details import CompileSpec
 
     assert (
-        args.use_kv_cache is True
+        use_kv_cache is True
     ), "MPS backend currently only supports static shape and use_kv_cache=True is the only way to support it at the moment"
     try:
         # pyre-ignore Undefined import [21]: Could not find a module corresponding to import `executorch.backends.apple.mps.partition.mps_partitioner`.
@@ -51,9 +55,9 @@ def get_mps_partitioner(args):
     return MPSPartitioner(compile_specs)
 
 
-def get_coreml_partitioner(args):
+def get_coreml_partitioner(use_kv_cache: bool = False):
     assert (
-        args.use_kv_cache is True
+        use_kv_cache is True
     ), "CoreML backend currently only supports static shape and use_kv_cache=True is the only way to support it at the moment"
     try:
         import coremltools as ct
@@ -79,9 +83,11 @@ def get_coreml_partitioner(args):
     )
 
 
-def get_qnn_partitioner(args, quant_dtype):
+def get_qnn_partitioner(
+    quant_dtype, use_kv_cache: bool = False, pt2e_quantize: Optional[str] = None
+):
     assert (
-        args.use_kv_cache is True
+        use_kv_cache is True
     ), "Qualcomm backend currently only supports static shape and use_kv_cache=True is the only way to support it at the moment"
     try:
         # pyre-ignore: Undefined import [21]: Could not find a module corresponding to import `executorch.backends.qualcomm.partition.qnn_partitioner`
@@ -109,7 +115,7 @@ def get_qnn_partitioner(args, quant_dtype):
 
     use_fp16 = True
     skip_node_op_set = {}
-    if args.pt2e_quantize:
+    if pt2e_quantize is not None:
         use_fp16 = False
         # TODO: fix the lowering error without skipping nodes
 

--- a/extension/llm/export/targets.bzl
+++ b/extension/llm/export/targets.bzl
@@ -1,0 +1,8 @@
+def define_common_targets():
+    """
+    Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+    pass


### PR DESCRIPTION
Summary: Per the refactor plan in this [doc](https://fburl.com/gdoc/myjb43fm), this PR moves `partitioner` and `quantizer` into `extension/llm/export:export_lib`.

Differential Revision: D59176274
