### PR TITLE
Introduce op_benchmark binary for matmul

### DIFF
--- a/backends/vulkan/runtime/api/QueryPool.cpp
+++ b/backends/vulkan/runtime/api/QueryPool.cpp
@@ -237,5 +237,15 @@ void QueryPool::print_results() {
   std::cout << generate_string_report() << std::endl;
 }
 
+unsigned long QueryPool::get_total_shader_ns(std::string kernel_name) {
+  for (ShaderDuration& entry : shader_durations_) {
+    if (entry.kernel_name == kernel_name) {
+      std::chrono::duration<size_t, std::nano> exec_duration_ns(
+          entry.execution_duration_ns);
+      return exec_duration_ns.count();
+    }
+  }
+  return 0;
+}
 } // namespace api
 } // namespace vkcompute

--- a/backends/vulkan/runtime/api/QueryPool.h
+++ b/backends/vulkan/runtime/api/QueryPool.h
@@ -101,6 +101,7 @@ class QueryPool final {
   get_shader_timestamp_data();
   std::string generate_string_report();
   void print_results();
+  unsigned long get_total_shader_ns(std::string kernel_name);
 
   operator bool() const {
     return querypool_ != VK_NULL_HANDLE;


### PR DESCRIPTION
Summary:
Usage: `./op_benchmark_matmul <n> <m> <p> <num_trials> --verbose`

Verbosity defines if the output of each execution should be printed.

Differential Revision: D59169305
