### PR TITLE
Check for 0 size allocation before erroring out in ET_TRY_ALLOCATE_*

### DIFF
--- a/runtime/core/memory_allocator.h
+++ b/runtime/core/memory_allocator.h
@@ -217,7 +217,7 @@ class MemoryAllocator {
 #define ET_TRY_ALLOCATE_OR(memory_allocator__, nbytes__, ...)              \
   ({                                                                       \
     void* et_try_allocate_result = memory_allocator__->allocate(nbytes__); \
-    if (et_try_allocate_result == nullptr) {                               \
+    if (et_try_allocate_result == nullptr && nbytes__ > 0) {               \
       __VA_ARGS__                                                          \
       /* The args must return. */                                          \
       __ET_UNREACHABLE();                                                  \
@@ -272,7 +272,7 @@ class MemoryAllocator {
   ({                                                                      \
     type__* et_try_allocate_result =                                      \
         memory_allocator__->allocateList<type__>(nelem__);                \
-    if (et_try_allocate_result == nullptr) {                              \
+    if (et_try_allocate_result == nullptr && nelem__ > 0) {               \
       __VA_ARGS__                                                         \
       /* The args must return. */                                         \
       __ET_UNREACHABLE();                                                 \


### PR DESCRIPTION
Summary:
malloc can return nullptr when the requested size is 0. When this is used with extension/memory_allocator/malloc_memory_allocator.h this line can fail:
https://github.com/pytorch/executorch/blob/8f12da1a34008c645d294843b13142959c6dab97/runtime/executor/method.cpp#L144

Differential Revision: D59232805
