### PR TITLE
add model sharding backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,6 +621,10 @@ if(EXECUTORCH_BUILD_QNN)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backends/qualcomm)
 endif()
 
+if(EXECUTORCH_BUILD_EXECUTOR_BACKEND)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/exir/backend/test/demos/rpc)
+endif()
+
 if(EXECUTORCH_BUILD_ARM_BAREMETAL)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backends/arm)
 endif()

--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -279,6 +279,22 @@ filters = [
   ".fbs$",
 ]
 # ---------------------------------- Vulkan end -----------------------------------
+# ---------------------------------- Executor Backend start ---------------------------------
+[targets.executor_backend]
+buck_targets = [
+  "//exir/backend/test/demos/rpc:executor_backend_register",
+]
+excludes = [
+  "^codegen",
+]
+deps = [
+  "executorch",
+  "executorch_no_prim_ops",
+  "portable_kernels",
+  "extension_runner_util",
+]
+
+# ---------------------------------- Executor Backend end -----------------------------------
 # ---------------------------------- LLama start ----------------------------------
 [targets.custom_ops]
 buck_targets = [

--- a/build/executorch-config.cmake
+++ b/build/executorch-config.cmake
@@ -58,6 +58,7 @@ set(lib_list
     quantized_kernels
     quantized_ops_lib
     quantized_ops_aot_lib
+    executor_backend
 )
 foreach(lib ${lib_list})
   # Name of the variable which stores result of the find_library search

--- a/exir/backend/test/demos/model_sharding/ExecutorShardedBackend.cpp
+++ b/exir/backend/test/demos/model_sharding/ExecutorShardedBackend.cpp
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib> /* strtol */
+#include <memory>
+
+#include <executorch/extension/data_loader/buffer_data_loader.h>
+#include <executorch/runtime/backend/interface.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/program.h>
+#include <executorch/util/util.h>
+#include <iostream>
+
+namespace torch {
+namespace executor {
+
+void print(EValue& x) {
+  switch (x.tag) {
+    case Tag::Tensor: {
+      auto a_tensor = x.toTensor();
+      ET_LOG(
+          Info,
+          " tensor data ptr: %p, dim is %zu",
+          a_tensor.data_ptr<float>(),
+          a_tensor.dim());
+      auto len = a_tensor.numel();
+      ET_LOG(Info, "tensor content, len is %ld", len);
+
+      // for (int i = 0; i < len; i++) {
+      //   std::cout << a_tensor.data_ptr<float>()[i] << std::endl;
+      // }
+      break;
+    }
+    default:
+      std::cout << "foo" << std::endl;
+  }
+}
+/**
+ * ExecutorShardedBackend is a backend to execute an executorch program via delegate.
+ * In preprocess, the preprocesed bytes (delegate blob) is an executorch
+ * program. In ExecutorShardedBackend, an executor backend is constructed in init and
+ * execute in execute. This backend can serve for 2 purposes
+ *
+ * 1. Serve as an RPC call to execute partial program on a different backend,
+ * for example, host executor in cpu and client executor in dsp.
+ * 2. Making incremental changes like experiment different different compiler
+ * front-end before having the actual backend ready.
+ */
+
+class ExecutorShardedBackend final : public PyTorchBackendInterface {
+ public:
+  ~ExecutorShardedBackend() = default;
+
+  bool is_available() const override {
+    return true;
+  }
+
+  Result<DelegateHandle*> init(
+      BackendInitContext& context,
+      FreeableBuffer* processed,
+      __ET_UNUSED ArrayRef<CompileSpec> compile_specs) const override {
+    return processed;
+  }
+
+  Error execute(
+      __ET_UNUSED BackendExecutionContext& context,
+      DelegateHandle* handle,
+      EValue** args) const override {
+    ET_LOG(Info, "ExecutorShardedBackend executing...");
+
+    FreeableBuffer* processed = static_cast<FreeableBuffer*>(handle);
+    // // `processed` contains an executorch program. Wrap it in a DataLoader
+    // that
+    // // will return the data directly without copying it.
+    MemoryAllocator* runtime_allocator = context.get_temp_allocator();
+    auto loader = ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(
+        runtime_allocator, util::BufferDataLoader);
+
+    new (loader) util::BufferDataLoader(processed->data(), processed->size());
+    // Can't free `processed` because the program will point into that
+    // memory.
+
+    // Try loading the program.
+    ET_LOG(Info, "ExecutorShardedBackend Program loading...");
+    Result<Program> program_result = Program::load(loader);
+    if (!program_result.ok()) {
+      return program_result.error();
+    }
+
+    // Move the Program off the stack.
+    auto client_program =
+        ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(runtime_allocator, Program);
+    new (client_program) Program(std::move(program_result.get()));
+
+    Result<MethodMeta> method_meta = client_program->method_meta("forward");
+    if (!method_meta.ok()) {
+      ET_LOG(Error, "error constructing method meta");
+      return method_meta.error();
+    }
+
+    // Building all different allocators for the client executor
+    auto num_memory_planned_buffers = method_meta->num_memory_planned_buffers();
+
+    Span<uint8_t>* memory_planned_buffers = ET_ALLOCATE_LIST_OR_RETURN_ERROR(
+        runtime_allocator, Span<uint8_t>, num_memory_planned_buffers);
+
+    for (size_t id = 0; id < num_memory_planned_buffers; ++id) {
+      size_t buffer_size = static_cast<size_t>(
+          method_meta->memory_planned_buffer_size(id).get());
+      uint8_t* buffer_i = ET_ALLOCATE_LIST_OR_RETURN_ERROR(
+          runtime_allocator, uint8_t, buffer_size);
+      memory_planned_buffers[id] = {buffer_i, buffer_size};
+    }
+
+    auto client_planned_memory = ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(
+        runtime_allocator, HierarchicalAllocator);
+    new (client_planned_memory) HierarchicalAllocator(
+        {memory_planned_buffers, num_memory_planned_buffers});
+
+    // Allocate some memory from runtime allocator for the client executor, in
+    // real case, like if it's an executor in dsp, it should allocate memory
+    // dedicated to this specific hardware
+    auto client_method_allocator = ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(
+        runtime_allocator, MemoryAllocator);
+    const size_t kClientRuntimeMemorySize = 2048 * 1024U;
+    auto runtime_pool = ET_ALLOCATE_OR_RETURN_ERROR(
+        runtime_allocator, kClientRuntimeMemorySize);
+    new (client_method_allocator) MemoryAllocator(
+        kClientRuntimeMemorySize, static_cast<uint8_t*>(runtime_pool));
+
+    auto client_memory_manager =
+        ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(runtime_allocator, MemoryManager);
+    new (client_memory_manager)
+        MemoryManager(client_method_allocator, client_planned_memory);
+
+    // Construct the client Method
+    Result<Method> method_res =
+        client_program->load_method("forward", client_memory_manager);
+    if (!method_res.ok()) {
+      ET_LOG(
+          Error,
+          "Failed to load client method: 0x%x",
+          (unsigned int)method_res.error());
+      return method_res.error();
+    }
+
+    auto client_method =
+        ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(runtime_allocator, Method);
+    new (client_method) Method(std::move(method_res.get()));
+
+    // Return the client method so it will be passed to `execute()` as
+    // `handle`.
+    // return client_method;
+    // Method* client_method = static_cast<Method*>(handle);
+    auto num_inputs = client_method->inputs_size();
+    auto output_sizes = client_method->outputs_size();
+    // ET_LOG(Info, "ExecutorShardedBackend inputs size: %zu", num_inputs);
+    // ET_LOG(Info, "ExecutorShardedBackend output [before execute]...");
+    // for (int i = 0; i < output_sizes; i++) {
+    //   ET_LOG(Info, "                     id %d is...", i);
+    //   print(*args[num_inputs + i]);
+    // }
+    Error status = Error::Ok;
+
+    // Receive client executor input
+    for (size_t input_idx = 0; input_idx < num_inputs; input_idx++) {
+      status = client_method->set_input(*args[input_idx], input_idx);
+    }
+    // Execute client executor
+    status = client_method->execute();
+    // ET_LOG(Info, "ExecutorShardedBackend outputs size: %zu", output_sizes);
+    // Send the client executor output
+    // status = client_method->get_outputs(args[num_inputs], output_sizes);
+
+    for (int i = 0; i < output_sizes; i++) {
+      EValue output = client_method->get_output(i);
+      if (output.tag == Tag::Tensor) {
+        Tensor t_src = output.toTensor();
+        Tensor t_dst = args[num_inputs + i]->toTensor();
+        status = internal::copy_tensor_data(t_dst, t_src);
+      }
+    }
+
+    // for (int i = 0; i < output_sizes; i++) {
+    //   EValue tmp_output = client_method->get_output(i);
+    //   EValue tmp_output_2 = EValue(client_method->get_output(i));
+    //   ET_LOG(Info, "ExecutorShardedBackend output at %d is...", i);
+    //   print(tmp_output);
+    //   print(tmp_output_2);
+    //   // args[num_inputs + i] = std::make_unique<EValue>(std::move(EValue))
+    // }
+    // ET_LOG(Info, "ExecutorShardedBackend output [after execute]...");
+    // for (int i = 0; i < output_sizes; i++) {
+    //   ET_LOG(Info, "                     id %d is...", i);
+    //   print(*args[num_inputs + i]);
+    // }
+
+    // ET_LOG(Info, "ExecutorShardedBackend output is...");
+    // for (int i = 0; i < output_sizes; i++) {
+    //   ET_LOG(Info, "                     id %d is...", i);
+    //   print(*args[num_inputs + i]);
+    // }
+    // processed->~FreeableBuffer();
+    client_method->~Method();
+    client_program->~Program();
+    // this->destroy(handle);
+    ET_LOG(Info, "ExecutorShardedBackend finish...");
+    return status;
+  }
+
+  void destroy(DelegateHandle* handle) const override {
+    ET_LOG(Info, "ExecutorShardedBackend destroy...");
+    if (handle != nullptr) {
+      ET_LOG(Info, "           ExecutorShardedBackend::handle is not null...");
+      Method* client_executor = static_cast<Method*>(handle);
+      if (client_executor != nullptr) {
+        ET_LOG(
+            Info,
+            "               ExecutorShardedBackend::client_executor is not null...");
+        client_executor->~Method();
+        ET_LOG(
+            Info,
+            "               ExecutorShardedBackend::client_executor ->~Method() finishes...");
+      }
+    }
+    ET_LOG(Info, "ExecutorShardedBackend destroy finish...");
+  }
+};
+
+namespace {
+auto cls = ExecutorShardedBackend();
+Backend backend{"ExecutorShardedBackend", &cls};
+static auto success_with_compiler = register_backend(backend);
+} // namespace
+
+} // namespace executor
+} // namespace torch

--- a/exir/backend/test/demos/model_sharding/TARGETS
+++ b/exir/backend/test/demos/model_sharding/TARGETS
@@ -1,0 +1,65 @@
+load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load(":targets.bzl", "define_common_targets")
+
+define_common_targets()
+
+runtime.python_library(
+    name = "executor_sharded_backend_preprocess",
+    srcs = [
+        "executor_sharded_backend_preprocess.py",
+    ],
+    visibility = [
+        "//executorch/exir/backend/test/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir:lib",
+        "//executorch/exir/backend:backend_details",
+        "//executorch/exir/backend:compile_spec_schema",
+        "//nodeapi/py:base",
+    ],
+)
+
+runtime.python_library(
+    name = "executor_sharded_backend_partitioner",
+    srcs = [
+        "executor_sharded_backend_partitioner.py",
+    ],
+    visibility = [
+        "//executorch/exir/backend/test/...",
+    ],
+    deps = [
+        ":executor_sharded_backend_preprocess",
+        "//caffe2:torch",
+        "//executorch/exir:graph_module",
+        "//executorch/exir:lib",
+        "//executorch/exir/backend:partitioner",
+        "//executorch/exir/backend/canonical_partitioners:canonical_partitioner_lib",
+        "//executorch/exir/backend/test:backend_with_compiler_demo",
+    ],
+)
+
+python_unittest(
+    name = "test_model_sharding",
+    srcs = [
+        "test_model_sharding.py",
+    ],
+    preload_deps = [
+        "//executorch/kernels/portable:custom_ops_generated_lib",
+        "//executorch/kernels/quantized:custom_ops_generated_lib",
+        # the executor backend is prebuilt and linked when building the unit test binary. When it's linked, it'll register the backend.
+        # It can also be loaded in PyThon runtime via torch.ops.load_library("//executorch/exir/backend/test/demos/model_sharding:executor_sharded_backend")
+        # However, it's a better practice to build/link everything at earlier stage, instead of during runtime
+        "//executorch/exir/backend/test/demos/model_sharding:executor_sharded_backend",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir:lib",
+        "//executorch/exir/backend:backend_api",
+        "//executorch/exir/backend/test:op_partitioner_demo",
+        "//executorch/exir/backend/test/demos/model_sharding:executor_sharded_backend_partitioner",
+        "//executorch/exir/backend/test/demos/model_sharding:executor_sharded_backend_preprocess",
+        "//executorch/extension/pybindings:portable_lib",  # @manual
+    ],
+)

--- a/exir/backend/test/demos/model_sharding/executor_sharded_backend_partitioner.py
+++ b/exir/backend/test/demos/model_sharding/executor_sharded_backend_partitioner.py
@@ -1,0 +1,74 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import typing
+from typing import final
+
+import torch
+from executorch.exir.backend.canonical_partitioners.pattern_op_partitioner import (
+    generate_pattern_op_partitions,
+)
+from executorch.exir.backend.partitioner import (
+    DelegationSpec,
+    Partitioner,
+    PartitionResult,
+)
+from executorch.exir.backend.test.backend_with_compiler_demo import (
+    BackendWithCompilerDemo,
+)
+from executorch.exir.backend.test.demos.model_sharding.executor_sharded_backend_preprocess import (
+    ExecutorShardedBackend,
+)
+from torch.export import ExportedProgram
+from torch.fx.passes.operator_support import any_chain, OperatorSupportBase
+
+
+class AnyOperatorSupport(OperatorSupportBase):
+    def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
+        return node.op == "call_function"
+
+
+class AnyDelegateSupport(OperatorSupportBase):
+    def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
+        if node.op == "call_method":
+            assert isinstance(
+                node.args[0], torch.fx.Node
+            ), "the first argument is not an fx Node, it's not a valid graph with delgates"
+            lowered_name = typing.cast(torch.fx.Node, node.args[0]).name
+            lowered_module = submodules[lowered_name]
+            return lowered_module.backend_id is BackendWithCompilerDemo.__name__
+        return False
+
+
+@final
+class ExecutorShardedBackendPartitioner(Partitioner):
+    """
+    Partitions all add/mul nodes regardless of order
+    """
+
+    def __init__(self) -> None:
+        self.op_support = any_chain(AnyOperatorSupport(), AnyDelegateSupport())
+        self.delegation_spec = DelegationSpec(ExecutorShardedBackend.__name__, [])
+
+    def partition(self, edge_exported_program: ExportedProgram) -> PartitionResult:
+        partition_tags = {}
+        partition_list = generate_pattern_op_partitions(
+            edge_exported_program.graph_module, op_support=self.op_support
+        )
+        for partition in partition_list:
+            for node in partition.nodes:
+                delegation_tag = f"tag{partition.id}"
+                node.meta["delegation_tag"] = delegation_tag
+                partition_tags[delegation_tag] = self.delegation_spec
+
+                # Tag the delegate submodules
+                if node.args[0].op == "get_attr":
+                    node.args[0].meta["delegation_tag"] = delegation_tag
+
+        return PartitionResult(
+            tagged_exported_program=edge_exported_program,
+            partition_tags=partition_tags,
+        )

--- a/exir/backend/test/demos/model_sharding/executor_sharded_backend_preprocess.py
+++ b/exir/backend/test/demos/model_sharding/executor_sharded_backend_preprocess.py
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import final, List
+
+from executorch.exir import ExirExportedProgram
+from executorch.exir.backend.backend_details import (
+    BackendDetails,
+    ExportedProgram,
+    PreprocessResult,
+)
+from executorch.exir.backend.compile_spec_schema import CompileSpec
+
+
+@final
+class ExecutorShardedBackend(BackendDetails):
+    @staticmethod
+    def preprocess(
+        edge_program: ExportedProgram,
+        compile_specs: List[CompileSpec],
+    ) -> PreprocessResult:
+        return PreprocessResult(
+            processed_bytes=ExirExportedProgram(
+                exported_program=edge_program,
+                # Indicates that edge_program is already in edge dialect.
+                after_to_edge_passes=True,
+            )
+            .to_executorch()
+            .buffer,
+        )

--- a/exir/backend/test/demos/model_sharding/targets.bzl
+++ b/exir/backend/test/demos/model_sharding/targets.bzl
@@ -1,0 +1,32 @@
+load(
+    "@fbsource//tools/build_defs:default_platform_defs.bzl",
+    "ANDROID",
+    "CXX",
+)
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load("@fbsource//xplat/executorch/extension/pybindings:pybindings.bzl", "MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    runtime.cxx_library(
+        name = "executor_sharded_backend",
+        srcs = [
+            "ExecutorShardedBackend.cpp",
+        ],
+        platforms = [ANDROID, CXX],
+        deps = [
+            "//executorch/runtime/executor:program",
+            "//executorch/kernels/portable:generated_lib",
+            "//executorch/runtime/backend:interface",
+            "//executorch/extension/data_loader:buffer_data_loader",
+            "//executorch/util:util",
+        ] + MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB,
+        exported_deps = [
+            "//executorch/runtime/core:core",
+        ],
+    )

--- a/exir/backend/test/demos/model_sharding/test_model_sharding.py
+++ b/exir/backend/test/demos/model_sharding/test_model_sharding.py
@@ -1,0 +1,91 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch import exir
+from executorch.exir import to_edge
+from executorch.exir.backend.backend_api import to_backend
+from executorch.exir.backend.test.demos.model_sharding.executor_sharded_backend_partitioner import (
+    ExecutorShardedBackendPartitioner,
+)
+from executorch.exir.backend.test.demos.model_sharding.executor_sharded_backend_preprocess import (
+    ExecutorShardedBackend,
+)
+from executorch.exir.backend.test.op_partitioner_demo import AddMulPartitionerDemo
+
+from executorch.extension.pybindings.portable_lib import (  # @manual
+    _load_for_executorch_from_buffer,
+)
+from torch.export import export
+from torch.utils._pytree import tree_flatten
+
+
+class TestModelShardingDemos(unittest.TestCase):
+    def get_a_simple_net(self) -> torch.nn.Module:
+        class Net(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = torch.nn.Linear(4, 25)
+                self.linear2 = torch.nn.Linear(25, 3)
+
+            def forward(self, x):
+                x = torch.sigmoid(self.linear1(x))
+                x = self.linear2(x)
+                return x
+
+            def get_example_inputs(self):
+                return (torch.randn(25, 4),)
+
+        return Net()
+
+    def test_delegate_whole_program(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, a, x, b):
+                a = x - b  # compute in dsp
+                y = torch.mm(a, x)  # compute in hta
+                z = y + b  # compute in hta
+                return z
+
+        model = Model()
+        inputs = (torch.ones(2, 2), torch.ones(2, 2), torch.ones(2, 2))
+
+        exported_program = to_edge(export(model, inputs))
+
+        # First lower to demo backend
+        demo_backend_lowered = exported_program.to_backend(AddMulPartitionerDemo())
+
+        # Then lower to executor backend
+        executor_backend_lowered = demo_backend_lowered.to_backend(
+            ExecutorShardedBackendPartitioner()
+        )
+
+        prog_buffer = executor_backend_lowered.to_executorch()
+        buffer = prog_buffer.buffer
+
+        with open(
+            "/data/users/chenlai/fbsource/fbcode/executorch/exir/backend/test/demos/model_sharding/shard.pte",
+            "wb",
+        ) as f:
+            f.write(buffer)
+
+        executorch_module = _load_for_executorch_from_buffer(buffer)
+
+        # Now client executor is instantiate
+        inputs_flattened, _ = tree_flatten(inputs)
+
+        # Send the input from server executor to client executor, and receive the result from client executor
+        model_output = executorch_module.run_method("forward", tuple(inputs_flattened))
+        ref_output = model(*inputs)
+
+        # Compare the server executor final result with eager model
+        self.assertTrue(
+            torch.allclose(model_output[0], ref_output, rtol=1e-03, atol=1e-03)
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4102

Add an Executor Sharded Backend. Every call_delegate is a .pte file and during execute, it will use the temp allocator to load the `.pte` file, run inference, and reset. If there are multiple call_delegate in the top level program, it means the nested `.pte` file will be loaded->unloaded->loaded for every inference. In this way, we can run large models on device by chunking to multiple shards.

Differential Revision: [D59237539](https://our.internmc.facebook.com/intern/diff/D59237539/)