### PR TITLE
[RELEASE-ONLY] Update vision when PyPi is released

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies=[
   "sympy",
   "tabulate",
   "torch==2.4",
-  "torchvision==0.19.0",
+  "torchvision==0.18.1",  # update to 0.19.0 once released.
   "torchaudio==2.4",
 ]
 


### PR DESCRIPTION
PyProject.toml may use the public pypi, which isn't released for torchvision 0.19.0. Move back to 0.18.1 and update when released.