### PR TITLE
tests remove run_decompositions from Export Stage

### DIFF
--- a/backends/xnnpack/test/ops/conv1d.py
+++ b/backends/xnnpack/test/ops/conv1d.py
@@ -104,7 +104,7 @@ class TestConv1d(unittest.TestCase):
                 else Tester(module, inputs)
             )
             .export()
-            .check_count({"torch.ops.aten.convolution.default": conv_count})
+            .check_count({"torch.ops.aten.conv1d.default": conv_count})
             .to_edge()
             .check_count(
                 {

--- a/backends/xnnpack/test/ops/conv2d.py
+++ b/backends/xnnpack/test/ops/conv2d.py
@@ -163,7 +163,7 @@ class TestConv2d(unittest.TestCase):
 
         (
             tester.export()
-            .check_count({"torch.ops.aten.convolution.default": conv_count})
+            .check_count({"torch.ops.aten.conv2d": conv_count})
             .to_edge()
             .check_count(
                 {

--- a/backends/xnnpack/test/ops/linear.py
+++ b/backends/xnnpack/test/ops/linear.py
@@ -832,7 +832,6 @@ class TestLinear(unittest.TestCase):
                 tester.quantize(Quantize(quantization_config=quant_config))
 
             tester.export()
-            tester.check_count({aten_op: 1})
             if quant:
                 tester.check(["torch.ops.quantized_decomposed"])
 
@@ -882,8 +881,6 @@ class TestLinear(unittest.TestCase):
         tester.quantize(Quantize(quantization_config=quant_config))
 
         tester.export()
-        tester.check_count({aten_op: linear_count})
-        tester.check(["torch.ops.quantized_decomposed"])
         tester.to_edge()
         tester.check_count({edge_op: linear_count})
 

--- a/backends/xnnpack/test/ops/maxpool2d.py
+++ b/backends/xnnpack/test/ops/maxpool2d.py
@@ -54,8 +54,7 @@ class TestMaxPool2d(unittest.TestCase):
         (
             Tester(self.MaxPool2d(3, 1, 0, 1), inputs)
             .export()
-            .check_count({"torch.ops.aten.max_pool2d_with_indices.default": 1})
-            .check(["getitem"])
+            .check_count({"torch.ops.aten.max_pool2d.default": 1})
             .to_edge()
             .check_count(
                 {
@@ -115,7 +114,7 @@ class TestMaxPool2d(unittest.TestCase):
         (
             Tester(self.MaxPool2dUnsupportedCeilMode(), inputs)
             .export()
-            .check_count({"torch.ops.aten.max_pool2d_with_indices.default": 1})
+            .check_count({"torch.ops.aten.max_pool2d.default": 1})
             .to_edge()
             .check_count(
                 {
@@ -152,7 +151,7 @@ class TestMaxPool2d(unittest.TestCase):
                 Tester(MaxPool(maxpool_params), inputs)
                 .quantize()
                 .export()
-                .check_count({"torch.ops.aten.max_pool2d_with_indices.default": 1})
+                .check_count({"torch.ops.aten.max_pool2d.default": 1})
                 .check(["torch.ops.quantized_decomposed"])
                 .to_edge()
                 .check_count(

--- a/backends/xnnpack/test/ops/softmax.py
+++ b/backends/xnnpack/test/ops/softmax.py
@@ -28,7 +28,7 @@ class TestSoftmax(unittest.TestCase):
             (
                 Tester(self.Softmax(dim), inputs)
                 .export()
-                .check_count({"torch.ops.aten._softmax.default": 1})
+                .check_count({"torch.ops.aten.softmax": 1})
                 .to_edge()
                 .check_count(
                     {"executorch_exir_dialects_edge__ops_aten__softmax_default": 1}
@@ -62,7 +62,7 @@ class TestSoftmax(unittest.TestCase):
             (
                 Tester(self.Softmax(dim), inputs)
                 .export()
-                .check_count({"torch.ops.aten._softmax.default": 1})
+                .check_count({"torch.ops.aten.softmax": 1})
                 .to_edge()
                 .check_count(
                     {"executorch_exir_dialects_edge__ops_aten__softmax_default": 1}

--- a/backends/xnnpack/test/ops/square.py
+++ b/backends/xnnpack/test/ops/square.py
@@ -27,7 +27,7 @@ class TestSquare(unittest.TestCase):
         (
             Tester(self.Square(), inputs)
             .export()
-            .check_count({"torch.ops.aten.pow.Tensor_Scalar": 1})
+            .check_count({"torch.ops.aten.square.default": 1})
             .to_edge()
             .check_count(
                 {"executorch_exir_dialects_edge__ops_aten_pow_Tensor_Scalar": 1}

--- a/backends/xnnpack/test/ops/static_constant_pad.py
+++ b/backends/xnnpack/test/ops/static_constant_pad.py
@@ -87,7 +87,7 @@ class TestStaticConstantPad(unittest.TestCase):
         (
             Tester(self.StaticConstantPadFunctional(), inputs)
             .export()
-            .check_count({"torch.ops.aten.constant_pad_nd.default": 8})
+            .check_count({"torch.ops.aten.pad.default": 8})
             .to_edge()
             .check_count(
                 {"executorch_exir_dialects_edge__ops_aten_constant_pad_nd_default": 8}
@@ -137,7 +137,7 @@ class TestStaticConstantPad(unittest.TestCase):
             Tester(Pad(), inputs)
             .quantize()
             .export()
-            .check_count({"torch.ops.aten.constant_pad_nd.default": 1})
+            .check_count({"torch.ops.aten.pad.default": 1})
             .check(["torch.ops.quantized_decomposed"])
             .to_edge()
             .check_count(
@@ -162,7 +162,7 @@ class TestStaticConstantPad(unittest.TestCase):
             Tester(self.StaticConstantPad2d(), inputs)
             .quantize()
             .export()
-            .check_count({"torch.ops.aten.constant_pad_nd.default": 1})
+            .check_count({"torch.ops.aten.pad.default": 1})
             .check(["torch.ops.quantized_decomposed"])
             .to_edge()
             .check_count(

--- a/backends/xnnpack/test/tester/tester.py
+++ b/backends/xnnpack/test/tester/tester.py
@@ -189,7 +189,7 @@ class Export(Stage):
     ) -> None:
         self.exported_program = export(
             artifact, inputs, dynamic_shapes=self.dynamic_shapes
-        ).run_decompositions()
+        )
 
     @property
     def artifact(self) -> ExportedProgram:


### PR DESCRIPTION
Summary:
https://fb.workplace.com/groups/257735836456307/permalink/704200805143139/

suggests we should not be running this in our tests, as our tests are meant to mimic the natural workflow of a user delegating to XNNPACK

Differential Revision: D59253645
