### PR TITLE
Delete inaccurate comments.

### DIFF
--- a/runtime/core/data_loader.h
+++ b/runtime/core/data_loader.h
@@ -19,8 +19,6 @@ namespace executor {
 
 /**
  * Loads from a data source.
- *
- * See //executorch/util for common implementations.
  */
 class DataLoader {
  public:


### PR DESCRIPTION
Summary:
This comment is not accurate anymore since D47523786.

Instead of fixing this comment, I think it is better to just delete it because it is error prone. It becomes inaccurate again if data loader implementation gets moved again.

Differential Revision: D59254811
