### PR TITLE
[ET-VK] Move `ParamsBindList` to `Descriptor.*`

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -274,16 +274,5 @@ UniformParamsBuffer& UniformParamsBuffer::operator=(
   return *this;
 }
 
-ParamsBindList::ParamsBindList(
-    std::initializer_list<const BufferBindInfo> init_list) {
-  bind_infos.resize(init_list.size());
-  std::copy(init_list.begin(), init_list.end(), bind_infos.begin());
-}
-
-void ParamsBindList::append(const ParamsBindList& other) {
-  bind_infos.insert(
-      bind_infos.end(), other.bind_infos.begin(), other.bind_infos.end());
-}
-
 } // namespace api
 } // namespace vkcompute

--- a/backends/vulkan/runtime/api/Context.h
+++ b/backends/vulkan/runtime/api/Context.h
@@ -266,14 +266,6 @@ class UniformParamsBuffer final {
   }
 };
 
-struct ParamsBindList final {
-  std::vector<BufferBindInfo> bind_infos;
-
-  ParamsBindList(std::initializer_list<const BufferBindInfo> init_list);
-
-  void append(const ParamsBindList& other);
-};
-
 class StorageBuffer final {
  private:
   Context* context_p_;

--- a/backends/vulkan/runtime/api/Descriptor.cpp
+++ b/backends/vulkan/runtime/api/Descriptor.cpp
@@ -16,7 +16,7 @@ namespace vkcompute {
 namespace api {
 
 //
-// BufferBinding
+// BufferBindInfo
 //
 
 BufferBindInfo::BufferBindInfo()
@@ -26,6 +26,21 @@ BufferBindInfo::BufferBindInfo(const VulkanBuffer& buffer_p)
     : handle(buffer_p.handle()),
       offset(buffer_p.mem_offset()),
       range(buffer_p.mem_range()) {}
+
+//
+// ParamsBindList
+//
+
+ParamsBindList::ParamsBindList(
+    std::initializer_list<const BufferBindInfo> init_list) {
+  bind_infos.resize(init_list.size());
+  std::copy(init_list.begin(), init_list.end(), bind_infos.begin());
+}
+
+void ParamsBindList::append(const ParamsBindList& other) {
+  bind_infos.insert(
+      bind_infos.end(), other.bind_infos.begin(), other.bind_infos.end());
+}
 
 //
 // DescriptorSet

--- a/backends/vulkan/runtime/api/Descriptor.h
+++ b/backends/vulkan/runtime/api/Descriptor.h
@@ -36,6 +36,14 @@ struct BufferBindInfo final {
   BufferBindInfo(const VulkanBuffer& buffer_p);
 };
 
+struct ParamsBindList final {
+  std::vector<BufferBindInfo> bind_infos;
+
+  ParamsBindList(std::initializer_list<const BufferBindInfo> init_list);
+
+  void append(const ParamsBindList& other);
+};
+
 class DescriptorSet final {
  public:
   explicit DescriptorSet(VkDevice, VkDescriptorSet, ShaderLayout::Signature);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4127
* #4125
* #4124
* #4123
* #4122
* #4121
* #4120
* __->__ #4119
* #4118
* #4117
* #4116
* #4115

`ParamsBindList` wraps a list of `BufferBindInfo`s, which is closely associated to Vulkan descriptor sets.

Differential Revision: [D59281547](https://our.internmc.facebook.com/intern/diff/D59281547/)