### PR TITLE
[ET-VK] Move `ParamsBuffer` and `StorageBuffer` to standalone files

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -8,11 +8,6 @@
 
 #include <executorch/backends/vulkan/runtime/api/Context.h>
 
-#include <cstdint>
-#include <cstring>
-#include <memory>
-#include <sstream>
-
 #ifndef VULKAN_DESCRIPTOR_POOL_SIZE
 #define VULKAN_DESCRIPTOR_POOL_SIZE 1024u
 #endif
@@ -218,60 +213,6 @@ Context* context() {
   }());
 
   return context.get();
-}
-
-//
-// UniformParamsBuffer
-//
-
-namespace {
-
-void memcpy_to_buffer(const VulkanBuffer& src, VulkanBuffer& dst) {
-  MemoryMap dst_mapping(dst, MemoryAccessType::WRITE);
-
-  MemoryMap src_mapping(src, MemoryAccessType::READ);
-  src_mapping.invalidate();
-
-  void* dst_ptr = dst_mapping.template data<void>();
-  void* src_ptr = src_mapping.template data<void>();
-
-  // @lint-ignore CLANGTIDY facebook-security-vulnerable-memcpy
-  memcpy(dst_ptr, src_ptr, src.mem_size());
-}
-
-} // namespace
-
-UniformParamsBuffer::UniformParamsBuffer(const UniformParamsBuffer& other)
-    : context_p_(other.context_p_), vulkan_buffer_{} {
-  if (other.vulkan_buffer_) {
-    vulkan_buffer_ = context_p_->adapter_ptr()->vma().create_uniform_buffer(
-        other.vulkan_buffer_.mem_size());
-
-    memcpy_to_buffer(other.vulkan_buffer_, vulkan_buffer_);
-  }
-}
-
-UniformParamsBuffer& UniformParamsBuffer::operator=(
-    const UniformParamsBuffer& other) {
-  if (&other != this) {
-    context_p_ = other.context_p_;
-
-    // Move vulkan_buffer_ to another VulkanBuffer for cleanup
-    if (vulkan_buffer_) {
-      VulkanBuffer temp_buffer(std::move(vulkan_buffer_));
-      context_p_->register_buffer_cleanup(temp_buffer);
-    }
-    // vulkan_buffer_ should now be empty
-
-    if (other.vulkan_buffer_) {
-      vulkan_buffer_ = context_p_->adapter_ptr()->vma().create_uniform_buffer(
-          other.vulkan_buffer_.mem_size());
-
-      memcpy_to_buffer(other.vulkan_buffer_, vulkan_buffer_);
-    }
-  }
-
-  return *this;
 }
 
 } // namespace api

--- a/backends/vulkan/runtime/api/ParamsBuffer.cpp
+++ b/backends/vulkan/runtime/api/ParamsBuffer.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/ParamsBuffer.h>
+
+#include <cstdint>
+#include <cstring>
+
+namespace vkcompute {
+namespace api {
+
+namespace {
+
+void memcpy_to_buffer(const VulkanBuffer& src, VulkanBuffer& dst) {
+  MemoryMap dst_mapping(dst, MemoryAccessType::WRITE);
+
+  MemoryMap src_mapping(src, MemoryAccessType::READ);
+  src_mapping.invalidate();
+
+  void* dst_ptr = dst_mapping.template data<void>();
+  void* src_ptr = src_mapping.template data<void>();
+
+  // @lint-ignore CLANGTIDY facebook-security-vulnerable-memcpy
+  memcpy(dst_ptr, src_ptr, src.mem_size());
+}
+
+} // namespace
+
+ParamsBuffer::ParamsBuffer(const ParamsBuffer& other)
+    : context_p_(other.context_p_), vulkan_buffer_{} {
+  if (other.vulkan_buffer_) {
+    vulkan_buffer_ = context_p_->adapter_ptr()->vma().create_uniform_buffer(
+        other.vulkan_buffer_.mem_size());
+
+    memcpy_to_buffer(other.vulkan_buffer_, vulkan_buffer_);
+  }
+}
+
+ParamsBuffer& ParamsBuffer::operator=(const ParamsBuffer& other) {
+  if (&other != this) {
+    context_p_ = other.context_p_;
+
+    // Move vulkan_buffer_ to another VulkanBuffer for cleanup
+    if (vulkan_buffer_) {
+      VulkanBuffer temp_buffer(std::move(vulkan_buffer_));
+      context_p_->register_buffer_cleanup(temp_buffer);
+    }
+    // vulkan_buffer_ should now be empty
+
+    if (other.vulkan_buffer_) {
+      vulkan_buffer_ = context_p_->adapter_ptr()->vma().create_uniform_buffer(
+          other.vulkan_buffer_.mem_size());
+
+      memcpy_to_buffer(other.vulkan_buffer_, vulkan_buffer_);
+    }
+  }
+
+  return *this;
+}
+
+} // namespace api
+} // namespace vkcompute

--- a/backends/vulkan/runtime/api/ParamsBuffer.cpp
+++ b/backends/vulkan/runtime/api/ParamsBuffer.cpp
@@ -8,7 +8,6 @@
 
 #include <executorch/backends/vulkan/runtime/api/ParamsBuffer.h>
 
-#include <cstdint>
 #include <cstring>
 
 namespace vkcompute {

--- a/backends/vulkan/runtime/api/ParamsBuffer.h
+++ b/backends/vulkan/runtime/api/ParamsBuffer.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#include <executorch/backends/vulkan/runtime/api/Context.h>
+
+#include <executorch/backends/vulkan/runtime/api/memory/Buffer.h>
+
+namespace vkcompute {
+namespace api {
+
+class ParamsBuffer final {
+ private:
+  Context* context_p_;
+  size_t nbytes_;
+  VulkanBuffer vulkan_buffer_;
+
+ public:
+  ParamsBuffer() : context_p_{nullptr}, vulkan_buffer_{} {}
+
+  template <typename Block>
+  ParamsBuffer(Context* context_p, const Block& block)
+      : context_p_(context_p),
+        nbytes_(sizeof(block)),
+        vulkan_buffer_(
+            context_p_->adapter_ptr()->vma().create_params_buffer(block)) {}
+
+  ParamsBuffer(const ParamsBuffer&);
+  ParamsBuffer& operator=(const ParamsBuffer&);
+
+  ParamsBuffer(ParamsBuffer&&) = default;
+  ParamsBuffer& operator=(ParamsBuffer&&) = default;
+
+  ~ParamsBuffer() {
+    if (vulkan_buffer_) {
+      context_p_->register_buffer_cleanup(vulkan_buffer_);
+    }
+  }
+
+  const VulkanBuffer& buffer() const {
+    return vulkan_buffer_;
+  }
+
+  template <typename Block>
+  void update(const Block& block) {
+    if (sizeof(block) != nbytes_) {
+      VK_THROW("Attempted to update ParamsBuffer with data of different size");
+    }
+    // Fill the uniform buffer with data in block
+    {
+      MemoryMap mapping(vulkan_buffer_, MemoryAccessType::WRITE);
+      Block* data_ptr = mapping.template data<Block>();
+
+      *data_ptr = block;
+    }
+  }
+};
+
+} // namespace api
+} // namespace vkcompute

--- a/backends/vulkan/runtime/api/StorageBuffer.h
+++ b/backends/vulkan/runtime/api/StorageBuffer.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#include <executorch/backends/vulkan/runtime/api/Context.h>
+
+#include <executorch/backends/vulkan/runtime/api/memory/Buffer.h>
+
+namespace vkcompute {
+namespace api {
+
+class StorageBuffer final {
+ private:
+  Context* context_p_;
+  ScalarType dtype_;
+  size_t numel_;
+  size_t nbytes_;
+  VulkanBuffer vulkan_buffer_;
+
+ public:
+  StorageBuffer(
+      Context* context_p,
+      const ScalarType dtype,
+      const size_t numel,
+      const bool gpuonly = false)
+      : context_p_(context_p),
+        dtype_(dtype),
+        numel_(numel),
+        nbytes_(element_size(dtype_) * numel_),
+        vulkan_buffer_(context_p_->adapter_ptr()->vma().create_storage_buffer(
+            nbytes_,
+            gpuonly)) {}
+
+  StorageBuffer(const StorageBuffer&) = delete;
+  StorageBuffer& operator=(const StorageBuffer&) = delete;
+
+  StorageBuffer(StorageBuffer&&) = default;
+  StorageBuffer& operator=(StorageBuffer&&) = default;
+
+  ~StorageBuffer() {
+    context_p_->register_buffer_cleanup(vulkan_buffer_);
+  }
+
+  inline ScalarType dtype() {
+    return dtype_;
+  }
+
+  inline VulkanBuffer& buffer() {
+    return vulkan_buffer_;
+  }
+
+  inline size_t numel() {
+    return numel_;
+  }
+
+  inline size_t nbytes() {
+    return nbytes_;
+  }
+};
+
+} // namespace api
+} // namespace vkcompute

--- a/backends/vulkan/runtime/api/Tensor.cpp
+++ b/backends/vulkan/runtime/api/Tensor.cpp
@@ -172,7 +172,7 @@ api::VulkanBuffer& vTensor::buffer(
 
 const api::BufferBindInfo vTensor::sizes_ubo() {
   if (!sizes_uniform_.buffer()) {
-    sizes_uniform_ = api::UniformParamsBuffer(
+    sizes_uniform_ = api::ParamsBuffer(
         storage_.context_, api::utils::make_whcn_ivec4(sizes_));
   }
   return api::BufferBindInfo(sizes_uniform_.buffer());
@@ -181,14 +181,14 @@ const api::BufferBindInfo vTensor::sizes_ubo() {
 const api::BufferBindInfo vTensor::texture_limits_ubo() {
   if (!texture_limits_uniform_.buffer()) {
     texture_limits_uniform_ =
-        api::UniformParamsBuffer(storage_.context_, texture_limits_);
+        api::ParamsBuffer(storage_.context_, texture_limits_);
   }
   return api::BufferBindInfo(texture_limits_uniform_.buffer());
 }
 
 const api::BufferBindInfo vTensor::texel_strides_ubo() {
   if (!texel_strides_uniform_.buffer()) {
-    texel_strides_uniform_ = api::UniformParamsBuffer(
+    texel_strides_uniform_ = api::ParamsBuffer(
         storage_.context_,
         api::utils::make_whcn_ivec4(
             calculate_strides(padded_sizes_, memory_layout_)));
@@ -198,8 +198,7 @@ const api::BufferBindInfo vTensor::texel_strides_ubo() {
 
 const api::BufferBindInfo vTensor::ntexels_ubo() {
   if (!ntexels_uniform_.buffer()) {
-    ntexels_uniform_ =
-        api::UniformParamsBuffer(storage_.context_, texel_numel());
+    ntexels_uniform_ = api::ParamsBuffer(storage_.context_, texel_numel());
   }
   return api::BufferBindInfo(ntexels_uniform_.buffer());
 }

--- a/backends/vulkan/runtime/api/Tensor.h
+++ b/backends/vulkan/runtime/api/Tensor.h
@@ -11,6 +11,7 @@
 // @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
 
 #include <executorch/backends/vulkan/runtime/api/Context.h>
+#include <executorch/backends/vulkan/runtime/api/ParamsBuffer.h>
 #include <executorch/backends/vulkan/runtime/api/Types.h>
 
 namespace vkcompute {
@@ -180,10 +181,10 @@ class vTensor final {
    * Refer to the comments for the corresponding *_ubo() functions for more
    * context about the data contained in each buffer.
    */
-  api::UniformParamsBuffer sizes_uniform_;
-  api::UniformParamsBuffer texture_limits_uniform_;
-  api::UniformParamsBuffer texel_strides_uniform_;
-  api::UniformParamsBuffer ntexels_uniform_;
+  api::ParamsBuffer sizes_uniform_;
+  api::ParamsBuffer texture_limits_uniform_;
+  api::ParamsBuffer texel_strides_uniform_;
+  api::ParamsBuffer ntexels_uniform_;
 
   vTensorStorage storage_;
 

--- a/backends/vulkan/runtime/api/api.h
+++ b/backends/vulkan/runtime/api/api.h
@@ -13,10 +13,12 @@
 #include <executorch/backends/vulkan/runtime/api/Context.h>
 #include <executorch/backends/vulkan/runtime/api/Descriptor.h>
 #include <executorch/backends/vulkan/runtime/api/Fence.h>
+#include <executorch/backends/vulkan/runtime/api/ParamsBuffer.h>
 #include <executorch/backends/vulkan/runtime/api/Pipeline.h>
 #include <executorch/backends/vulkan/runtime/api/Runtime.h>
 #include <executorch/backends/vulkan/runtime/api/Shader.h>
 #include <executorch/backends/vulkan/runtime/api/ShaderRegistry.h>
+#include <executorch/backends/vulkan/runtime/api/StorageBuffer.h>
 #include <executorch/backends/vulkan/runtime/api/Tensor.h>
 #include <executorch/backends/vulkan/runtime/api/Utils.h>
 

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -95,7 +95,7 @@ class ComputeGraph final {
   std::unique_ptr<api::Context> context_;
   std::vector<SharedObject> shared_objects_;
   std::vector<Value> values_;
-  std::vector<api::UniformParamsBuffer> param_ubos_;
+  std::vector<api::ParamsBuffer> param_ubos_;
 
   std::vector<std::unique_ptr<PrepackNode>> prepack_nodes_;
   std::vector<std::unique_ptr<ExecuteNode>> execute_nodes_;
@@ -382,7 +382,7 @@ class ComputeGraph final {
 
   template <typename Block>
   const api::BufferBindInfo create_params_buffer(const Block& data) {
-    param_ubos_.emplace_back(api::UniformParamsBuffer(context_.get(), data));
+    param_ubos_.emplace_back(api::ParamsBuffer(context_.get(), data));
     return api::BufferBindInfo(param_ubos_.back().buffer());
   }
 

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -126,7 +126,7 @@ void record_conv2d_prepack_weights_op(
   add_dtype_suffix(kernel_name, v_dst);
   api::ShaderInfo shader = VK_KERNEL_FROM_STR(kernel_name);
 
-  api::UniformParamsBuffer original_sizes_ubo(
+  api::ParamsBuffer original_sizes_ubo(
       context, api::utils::make_ivec4(original_sizes, /*reverse = */ true));
 
   api::SpecVarList specialization_constants = {};
@@ -217,7 +217,7 @@ void record_index_fill_buffer(api::Context* context, vTensor& v_ten) {
       break;
   }
 
-  api::UniformParamsBuffer params(api::context(), int32_t(v_ten.numel()));
+  api::ParamsBuffer params(api::context(), int32_t(v_ten.numel()));
 
   {
     api::PipelineBarrier pipeline_barrier{};

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -217,7 +217,7 @@ TEST_F(VulkanComputeAPITest, spec_var_shader_test) {
   float offset = 1.5f;
 
   {
-    api::UniformParamsBuffer params(api::context(), int32_t(len));
+    api::ParamsBuffer params(api::context(), int32_t(len));
     uint32_t len_div4 = api::utils::div_up(uint32_t(len), uint32_t(4));
     api::PipelineBarrier pipeline_barrier{};
     api::context()->submit_compute_job(
@@ -262,7 +262,7 @@ TEST_F(VulkanComputeAPITest, update_params_between_submit) {
       {5.0, 5.0, 5.0, 5.0},
   };
 
-  api::UniformParamsBuffer params(api::context(), block);
+  api::ParamsBuffer params(api::context(), block);
 
   {
     api::PipelineBarrier pipeline_barrier{};
@@ -323,7 +323,7 @@ void test_storage_buffer_type(const size_t len) {
       break;
   }
 
-  api::UniformParamsBuffer params(api::context(), int32_t(len));
+  api::ParamsBuffer params(api::context(), int32_t(len));
 
   {
     uint32_t len_div4 = api::utils::div_up(uint32_t(len), uint32_t(4));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4127
* #4125
* #4124
* #4123
* #4122
* #4121
* __->__ #4120
* #4119
* #4118
* #4117
* #4116
* #4115

Includes the renaming of `UniformParamsBuffer` to `ParamsBuffer` for brevity.

These objects aren't tightly coupled to `Context` and hence they are better placed in standalone files.

Differential Revision: [D59281543](https://our.internmc.facebook.com/intern/diff/D59281543/)