### PR TITLE
[ET-VK] Organize `StringUtil.h` and `Utils.h` into `utils/` and `VkUtils.h`

### DIFF
--- a/backends/vulkan/runtime/api/Adapter.h
+++ b/backends/vulkan/runtime/api/Adapter.h
@@ -14,7 +14,7 @@
 
 #include <executorch/backends/vulkan/runtime/api/Pipeline.h>
 #include <executorch/backends/vulkan/runtime/api/Shader.h>
-#include <executorch/backends/vulkan/runtime/api/Utils.h>
+#include <executorch/backends/vulkan/runtime/api/utils/VecUtils.h>
 
 #include <executorch/backends/vulkan/runtime/api/memory/Allocator.h>
 

--- a/backends/vulkan/runtime/api/Command.h
+++ b/backends/vulkan/runtime/api/Command.h
@@ -15,7 +15,7 @@
 #include <executorch/backends/vulkan/runtime/api/Descriptor.h>
 #include <executorch/backends/vulkan/runtime/api/Pipeline.h>
 #include <executorch/backends/vulkan/runtime/api/Shader.h>
-#include <executorch/backends/vulkan/runtime/api/Utils.h>
+#include <executorch/backends/vulkan/runtime/api/utils/VecUtils.h>
 
 #include <executorch/backends/vulkan/runtime/api/memory/Buffer.h>
 #include <executorch/backends/vulkan/runtime/api/memory/Image.h>

--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/backends/vulkan/runtime/api/Context.h>
+#include <executorch/backends/vulkan/runtime/api/VkUtils.h>
 
 #ifndef VULKAN_DESCRIPTOR_POOL_SIZE
 #define VULKAN_DESCRIPTOR_POOL_SIZE 1024u

--- a/backends/vulkan/runtime/api/Context.h
+++ b/backends/vulkan/runtime/api/Context.h
@@ -17,6 +17,8 @@
 #include <executorch/backends/vulkan/runtime/api/QueryPool.h>
 #include <executorch/backends/vulkan/runtime/api/Runtime.h>
 
+#include <executorch/backends/vulkan/runtime/api/utils/MacroUtils.h>
+
 namespace vkcompute {
 namespace api {
 

--- a/backends/vulkan/runtime/api/Descriptor.cpp
+++ b/backends/vulkan/runtime/api/Descriptor.cpp
@@ -7,7 +7,8 @@
  */
 
 #include <executorch/backends/vulkan/runtime/api/Descriptor.h>
-#include <executorch/backends/vulkan/runtime/api/Utils.h>
+
+#include <executorch/backends/vulkan/runtime/api/utils/VecUtils.h>
 
 #include <algorithm>
 #include <utility>

--- a/backends/vulkan/runtime/api/Exception.h
+++ b/backends/vulkan/runtime/api/Exception.h
@@ -11,21 +11,21 @@
 
 #include <executorch/backends/vulkan/runtime/api/vk_api.h>
 
-#include <executorch/backends/vulkan/runtime/api/StringUtil.h>
+#include <executorch/backends/vulkan/runtime/api/utils/StringUtils.h>
 
 #include <exception>
 #include <ostream>
 #include <string>
 #include <vector>
 
-#define VK_CHECK(function)                                                \
-  do {                                                                    \
-    const VkResult result = (function);                                   \
-    if (VK_SUCCESS != result) {                                           \
-      throw ::vkcompute::api::Error(                                      \
-          {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},          \
-          ::vkcompute::api::concat_str(#function, " returned ", result)); \
-    }                                                                     \
+#define VK_CHECK(function)                                                  \
+  do {                                                                      \
+    const VkResult result = (function);                                     \
+    if (VK_SUCCESS != result) {                                             \
+      throw ::vkcompute::api::Error(                                        \
+          {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},            \
+          ::vkcompute::utils::concat_str(#function, " returned ", result)); \
+    }                                                                       \
   } while (false)
 
 #define VK_CHECK_COND(cond, ...)                                 \
@@ -34,7 +34,7 @@
       throw ::vkcompute::api::Error(                             \
           {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
           #cond,                                                 \
-          ::vkcompute::api::concat_str(__VA_ARGS__));            \
+          ::vkcompute::utils::concat_str(__VA_ARGS__));          \
     }                                                            \
   } while (false)
 
@@ -42,7 +42,7 @@
   do {                                                         \
     throw ::vkcompute::api::Error(                             \
         {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
-        ::vkcompute::api::concat_str(__VA_ARGS__));            \
+        ::vkcompute::utils::concat_str(__VA_ARGS__));          \
   } while (false)
 
 namespace vkcompute {

--- a/backends/vulkan/runtime/api/QueryPool.cpp
+++ b/backends/vulkan/runtime/api/QueryPool.cpp
@@ -9,7 +9,7 @@
 // @lint-ignore-every CLANGTIDY facebook-hte-BadImplicitCast
 
 #include <executorch/backends/vulkan/runtime/api/QueryPool.h>
-#include <executorch/backends/vulkan/runtime/api/Utils.h>
+#include <executorch/backends/vulkan/runtime/api/utils/VecUtils.h>
 
 #include <cmath>
 #include <iomanip>

--- a/backends/vulkan/runtime/api/Shader.h
+++ b/backends/vulkan/runtime/api/Shader.h
@@ -13,7 +13,8 @@
 #include <executorch/backends/vulkan/runtime/api/vk_api.h>
 
 #include <executorch/backends/vulkan/runtime/api/Types.h>
-#include <executorch/backends/vulkan/runtime/api/Utils.h>
+
+#include <executorch/backends/vulkan/runtime/api/utils/VecUtils.h>
 
 #include <mutex>
 #include <unordered_map>

--- a/backends/vulkan/runtime/api/Tensor.cpp
+++ b/backends/vulkan/runtime/api/Tensor.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <executorch/backends/vulkan/runtime/api/Tensor.h>
-#include <executorch/backends/vulkan/runtime/api/Utils.h>
+#include <executorch/backends/vulkan/runtime/api/VkUtils.h>
 
 namespace vkcompute {
 

--- a/backends/vulkan/runtime/api/VkUtils.h
+++ b/backends/vulkan/runtime/api/VkUtils.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/backends/vulkan/runtime/api/vk_api.h>
+
+namespace vkcompute {
+namespace api {
+
+inline VkExtent3D create_extent3d(const utils::uvec3& extents) {
+  return VkExtent3D{extents.data[0u], extents.data[1u], extents.data[2u]};
+}
+
+} // namespace api
+} // namespace vkcompute

--- a/backends/vulkan/runtime/api/api.h
+++ b/backends/vulkan/runtime/api/api.h
@@ -20,7 +20,8 @@
 #include <executorch/backends/vulkan/runtime/api/ShaderRegistry.h>
 #include <executorch/backends/vulkan/runtime/api/StorageBuffer.h>
 #include <executorch/backends/vulkan/runtime/api/Tensor.h>
-#include <executorch/backends/vulkan/runtime/api/Utils.h>
+
+#include <executorch/backends/vulkan/runtime/api/utils/VecUtils.h>
 
 #include <executorch/backends/vulkan/runtime/api/memory/Allocation.h>
 #include <executorch/backends/vulkan/runtime/api/memory/Allocator.h>

--- a/backends/vulkan/runtime/api/memory/Allocator.h
+++ b/backends/vulkan/runtime/api/memory/Allocator.h
@@ -12,13 +12,13 @@
 
 #include <executorch/backends/vulkan/runtime/api/vk_api.h>
 
-#include <executorch/backends/vulkan/runtime/api/Utils.h>
-
 #include <executorch/backends/vulkan/runtime/api/memory/vma_api.h>
 
 #include <executorch/backends/vulkan/runtime/api/memory/Allocation.h>
 #include <executorch/backends/vulkan/runtime/api/memory/Buffer.h>
 #include <executorch/backends/vulkan/runtime/api/memory/Image.h>
+
+#include <executorch/backends/vulkan/runtime/api/utils/VecUtils.h>
 
 namespace vkcompute {
 namespace api {

--- a/backends/vulkan/runtime/api/memory/Buffer.h
+++ b/backends/vulkan/runtime/api/memory/Buffer.h
@@ -12,7 +12,7 @@
 
 #include <executorch/backends/vulkan/runtime/api/vk_api.h>
 
-#include <executorch/backends/vulkan/runtime/api/Utils.h>
+#include <executorch/backends/vulkan/runtime/api/utils/VecUtils.h>
 
 #include <executorch/backends/vulkan/runtime/api/memory/vma_api.h>
 

--- a/backends/vulkan/runtime/api/memory/Image.h
+++ b/backends/vulkan/runtime/api/memory/Image.h
@@ -12,7 +12,7 @@
 
 #include <executorch/backends/vulkan/runtime/api/vk_api.h>
 
-#include <executorch/backends/vulkan/runtime/api/Utils.h>
+#include <executorch/backends/vulkan/runtime/api/utils/VecUtils.h>
 
 #include <executorch/backends/vulkan/runtime/api/memory/vma_api.h>
 

--- a/backends/vulkan/runtime/api/utils/MacroUtils.h
+++ b/backends/vulkan/runtime/api/utils/MacroUtils.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// Suppress an unused variable. Copied from C10_UNUSED
+#if defined(_MSC_VER) && !defined(__clang__)
+#define VK_UNUSED __pragma(warning(suppress : 4100 4101))
+#else
+#define VK_UNUSED __attribute__((__unused__))
+#endif //_MSC_VER

--- a/backends/vulkan/runtime/api/utils/StringUtils.h
+++ b/backends/vulkan/runtime/api/utils/StringUtils.h
@@ -9,14 +9,12 @@
 #pragma once
 // @lint-ignore-every CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
 
-#include <exception>
 #include <ostream>
 #include <sstream>
 #include <string>
-#include <vector>
 
 namespace vkcompute {
-namespace api {
+namespace utils {
 
 namespace detail {
 
@@ -86,5 +84,5 @@ inline std::string concat_str(const Args&... args) {
       typename detail::CanonicalizeStrTypes<Args>::type...>::call(args...);
 }
 
-} // namespace api
+} // namespace utils
 } // namespace vkcompute

--- a/backends/vulkan/runtime/api/utils/VecUtils.h
+++ b/backends/vulkan/runtime/api/utils/VecUtils.h
@@ -17,15 +17,6 @@
 
 #include <executorch/backends/vulkan/runtime/api/Exception.h>
 
-// Compiler Macros
-
-// Suppress an unused variable. Copied from C10_UNUSED
-#if defined(_MSC_VER) && !defined(__clang__)
-#define VK_UNUSED __pragma(warning(suppress : 4100 4101))
-#else
-#define VK_UNUSED __attribute__((__unused__))
-#endif //_MSC_VER
-
 namespace vkcompute {
 namespace utils {
 
@@ -459,12 +450,4 @@ inline int64_t multiply_integers(Iter begin, Iter end) {
 }
 
 } // namespace utils
-
-namespace api {
-
-inline VkExtent3D create_extent3d(const utils::uvec3& extents) {
-  return VkExtent3D{extents.data[0u], extents.data[1u], extents.data[2u]};
-}
-
-} // namespace api
 } // namespace vkcompute

--- a/backends/vulkan/runtime/graph/Logging.h
+++ b/backends/vulkan/runtime/graph/Logging.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <executorch/backends/vulkan/runtime/api/Utils.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 #include <optional>
 #include <ostream>

--- a/backends/vulkan/runtime/graph/ops/impl/Arange.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Arange.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <executorch/backends/vulkan/runtime/api/Utils.h>
+#include <executorch/backends/vulkan/runtime/api/api.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4127
* #4125
* #4124
* __->__ #4123
* #4122
* #4121
* #4120
* #4119
* #4118
* #4117
* #4116
* #4115

Everything in `utils/` will take the `namespace vkcompute:::utils`; everything in `VkUtils.h` deals with the Vulkan API directly.

Differential Revision: [D59281548](https://our.internmc.facebook.com/intern/diff/D59281548/)