### PR TITLE
[ET-VK] Move `Tensor.*` to namespace `api`

### DIFF
--- a/backends/vulkan/runtime/api/Tensor.cpp
+++ b/backends/vulkan/runtime/api/Tensor.cpp
@@ -10,13 +10,13 @@
 #include <executorch/backends/vulkan/runtime/api/VkUtils.h>
 
 namespace vkcompute {
+namespace api {
 
 std::vector<int64_t> calculate_strides(
     const std::vector<int64_t>& sizes,
-    const api::GPUMemoryLayout memory_layout,
+    const GPUMemoryLayout memory_layout,
     const bool texel_strides) {
-  const int64_t dim_offset =
-      api::to_packed_dim_nchw_offset<int64_t>(memory_layout);
+  const int64_t dim_offset = to_packed_dim_nchw_offset<int64_t>(memory_layout);
   const int64_t last_dim = sizes.size() - dim_offset;
   VK_CHECK_COND(last_dim >= 0);
 
@@ -43,7 +43,7 @@ std::vector<int64_t> calculate_strides(
 
 std::vector<int64_t> calculate_padded_sizes(
     const std::vector<int64_t>& sizes,
-    const api::GPUMemoryLayout memory_layout) {
+    const GPUMemoryLayout memory_layout) {
   int64_t ndim = sizes.size();
   if (ndim == 0) {
     ndim = 1;
@@ -57,8 +57,7 @@ std::vector<int64_t> calculate_padded_sizes(
   }
 
   // Pad the packed dim to the next multiple of 4.
-  const int64_t dim_offset =
-      api::to_packed_dim_nchw_offset<int64_t>(memory_layout);
+  const int64_t dim_offset = to_packed_dim_nchw_offset<int64_t>(memory_layout);
   const int64_t padded_dim_size = utils::val_at(-dim_offset, sizes);
   padded_sizes.at(ndim_up4 - dim_offset) = utils::align_up_4(padded_dim_size);
 
@@ -67,7 +66,7 @@ std::vector<int64_t> calculate_padded_sizes(
 
 utils::uvec3 calculate_image_extents(
     const std::vector<int64_t>& padded_sizes,
-    const api::GPUMemoryLayout memory_layout) {
+    const GPUMemoryLayout memory_layout) {
   VK_CHECK_COND(padded_sizes.size() == 4);
 
   uint32_t N = utils::safe_downcast<uint32_t>(padded_sizes.at(0));
@@ -76,15 +75,15 @@ utils::uvec3 calculate_image_extents(
   uint32_t W = utils::safe_downcast<uint32_t>(padded_sizes.at(3));
 
   switch (memory_layout) {
-    case api::kWidthPacked:
+    case kWidthPacked:
       VK_CHECK_COND(W % 4 == 0);
       W /= 4;
       break;
-    case api::kHeightPacked:
+    case kHeightPacked:
       VK_CHECK_COND(H % 4 == 0);
       H /= 4;
       break;
-    case api::kChannelsPacked:
+    case kChannelsPacked:
       VK_CHECK_COND(C % 4 == 0);
       C /= 4;
       break;
@@ -98,11 +97,11 @@ utils::uvec3 calculate_image_extents(
 //
 
 vTensor::vTensor(
-    api::Context* const context,
+    Context* const context,
     const std::vector<int64_t>& sizes,
-    const api::ScalarType dtype,
-    const api::StorageType storage_type,
-    const api::GPUMemoryLayout memory_layout,
+    const ScalarType dtype,
+    const StorageType storage_type,
+    const GPUMemoryLayout memory_layout,
     const bool allocate_memory)
     : dtype_(dtype),
       memory_layout_(memory_layout),
@@ -123,14 +122,14 @@ vTensor::vTensor(
           padded_sizes_,
           dtype_,
           allocate_memory) {
-  if (storage_type != api::kBuffer) {
+  if (storage_type != kBuffer) {
     texture_limits_.limits = utils::ivec3{
         utils::safe_downcast<int32_t>(storage_.image_extents_.data[0]),
         utils::safe_downcast<int32_t>(storage_.image_extents_.data[1]),
         utils::safe_downcast<int32_t>(storage_.image_extents_.data[2])};
   }
 
-  if (dtype == api::kHalf) {
+  if (dtype == kHalf) {
     VK_CHECK_COND(
         api::context()->adapter_ptr()->has_16bit_storage(),
         "Half dtype is only available if the physical device supports float16 "
@@ -138,75 +137,74 @@ vTensor::vTensor(
   }
 }
 
-api::VulkanImage& vTensor::image(
-    api::PipelineBarrier& pipeline_barrier,
-    const api::PipelineStageFlags stage) & {
-  storage_.transition(pipeline_barrier, stage, api::MemoryAccessType::READ);
+VulkanImage& vTensor::image(
+    PipelineBarrier& pipeline_barrier,
+    const PipelineStageFlags stage) & {
+  storage_.transition(pipeline_barrier, stage, MemoryAccessType::READ);
   return storage_.image_;
 }
 
-api::VulkanImage& vTensor::image(
-    api::PipelineBarrier& pipeline_barrier,
-    const api::PipelineStageFlags stage,
-    const api::MemoryAccessFlags access) & {
+VulkanImage& vTensor::image(
+    PipelineBarrier& pipeline_barrier,
+    const PipelineStageFlags stage,
+    const MemoryAccessFlags access) & {
   storage_.transition(pipeline_barrier, stage, access);
   return storage_.image_;
 }
 
-api::VulkanBuffer& vTensor::buffer(
-    api::PipelineBarrier& pipeline_barrier,
-    const api::PipelineStageFlags stage) & {
-  storage_.transition(pipeline_barrier, stage, api::MemoryAccessType::READ);
+VulkanBuffer& vTensor::buffer(
+    PipelineBarrier& pipeline_barrier,
+    const PipelineStageFlags stage) & {
+  storage_.transition(pipeline_barrier, stage, MemoryAccessType::READ);
   return storage_.buffer_;
 }
 
-api::VulkanBuffer& vTensor::buffer(
-    api::PipelineBarrier& pipeline_barrier,
-    const api::PipelineStageFlags stage,
-    const api::MemoryAccessFlags access) & {
+VulkanBuffer& vTensor::buffer(
+    PipelineBarrier& pipeline_barrier,
+    const PipelineStageFlags stage,
+    const MemoryAccessFlags access) & {
   storage_.transition(pipeline_barrier, stage, access);
   return storage_.buffer_;
 }
 
-const api::BufferBindInfo vTensor::sizes_ubo() {
+const BufferBindInfo vTensor::sizes_ubo() {
   if (!sizes_uniform_.buffer()) {
     sizes_uniform_ =
-        api::ParamsBuffer(storage_.context_, utils::make_whcn_ivec4(sizes_));
+        ParamsBuffer(storage_.context_, utils::make_whcn_ivec4(sizes_));
   }
-  return api::BufferBindInfo(sizes_uniform_.buffer());
+  return BufferBindInfo(sizes_uniform_.buffer());
 }
 
-const api::BufferBindInfo vTensor::texture_limits_ubo() {
+const BufferBindInfo vTensor::texture_limits_ubo() {
   if (!texture_limits_uniform_.buffer()) {
-    texture_limits_uniform_ =
-        api::ParamsBuffer(storage_.context_, texture_limits_);
+    texture_limits_uniform_ = ParamsBuffer(storage_.context_, texture_limits_);
   }
-  return api::BufferBindInfo(texture_limits_uniform_.buffer());
+  return BufferBindInfo(texture_limits_uniform_.buffer());
 }
 
-const api::BufferBindInfo vTensor::texel_strides_ubo() {
+const BufferBindInfo vTensor::texel_strides_ubo() {
   if (!texel_strides_uniform_.buffer()) {
-    texel_strides_uniform_ = api::ParamsBuffer(
+    texel_strides_uniform_ = ParamsBuffer(
         storage_.context_,
         utils::make_whcn_ivec4(
             calculate_strides(padded_sizes_, memory_layout_)));
   }
-  return api::BufferBindInfo(texel_strides_uniform_.buffer());
+  return BufferBindInfo(texel_strides_uniform_.buffer());
 }
 
-const api::BufferBindInfo vTensor::ntexels_ubo() {
+const BufferBindInfo vTensor::ntexels_ubo() {
   if (!ntexels_uniform_.buffer()) {
-    ntexels_uniform_ = api::ParamsBuffer(storage_.context_, texel_numel());
+    ntexels_uniform_ = ParamsBuffer(storage_.context_, texel_numel());
   }
-  return api::BufferBindInfo(ntexels_uniform_.buffer());
+  return BufferBindInfo(ntexels_uniform_.buffer());
 }
 
 VmaAllocationCreateInfo vTensor::get_allocation_create_info() const {
   switch (storage_type()) {
-    case api::kBuffer:
+    case kBuffer:
       return storage_.buffer_.allocation_create_info();
-    case api::kTexture2D:
-    case api::kTexture3D:
+    case kTexture2D:
+    case kTexture3D:
       return storage_.image_.allocation_create_info();
   }
   return {};
@@ -214,22 +212,22 @@ VmaAllocationCreateInfo vTensor::get_allocation_create_info() const {
 
 VkMemoryRequirements vTensor::get_memory_requirements() const {
   switch (storage_type()) {
-    case api::kBuffer:
+    case kBuffer:
       return storage_.buffer_.get_memory_requirements();
-    case api::kTexture2D:
-    case api::kTexture3D:
+    case kTexture2D:
+    case kTexture3D:
       return storage_.image_.get_memory_requirements();
   }
   return {};
 }
 
-void vTensor::bind_allocation(const api::Allocation& allocation) {
+void vTensor::bind_allocation(const Allocation& allocation) {
   switch (storage_type()) {
-    case api::kBuffer:
+    case kBuffer:
       storage_.buffer_.bind_allocation(allocation);
       break;
-    case api::kTexture2D:
-    case api::kTexture3D:
+    case kTexture2D:
+    case kTexture3D:
       storage_.image_.bind_allocation(allocation);
       break;
   }
@@ -274,7 +272,7 @@ void vTensor::reallocate(const std::vector<int64_t>& new_sizes) {
 }
 
 void vTensor::virtual_resize(const std::vector<int64_t>& new_sizes) {
-  if (storage_type() != api::kBuffer) {
+  if (storage_type() != kBuffer) {
     // For texture storage check that the current texture is large enough for
     // the new sizes of the tensor.
     utils::uvec3 virtual_extents =
@@ -298,15 +296,15 @@ void vTensor::virtual_resize(const std::vector<int64_t>& new_sizes) {
 // vTensorStorage
 //
 
-api::VulkanImage allocate_image(
-    api::Context* const context_ptr,
+VulkanImage allocate_image(
+    Context* const context_ptr,
     utils::uvec3& image_extents,
-    const api::StorageType storage_type,
+    const StorageType storage_type,
     const VkFormat image_format,
     const bool allocate_memory) {
-  api::Adapter* adapter_ptr = context_ptr->adapter_ptr();
+  Adapter* adapter_ptr = context_ptr->adapter_ptr();
 
-  api::ImageSampler::Properties sampler_props{
+  ImageSampler::Properties sampler_props{
       VK_FILTER_NEAREST,
       VK_SAMPLER_MIPMAP_MODE_NEAREST,
       VK_SAMPLER_ADDRESS_MODE_REPEAT,
@@ -317,23 +315,23 @@ api::VulkanImage allocate_image(
   VkImageViewType image_view_type;
 
   switch (storage_type) {
-    case api::kTexture3D:
+    case kTexture3D:
       image_type = VK_IMAGE_TYPE_3D;
       image_view_type = VK_IMAGE_VIEW_TYPE_3D;
       break;
-    case api::kTexture2D:
+    case kTexture2D:
       image_type = VK_IMAGE_TYPE_2D;
       image_view_type = VK_IMAGE_VIEW_TYPE_2D;
       break;
     default:
       // Return an empty VulkanImage by default
-      return api::VulkanImage();
+      return VulkanImage();
   }
 
   VkSampler sampler = adapter_ptr->sampler_cache().retrieve(sampler_props);
 
   return adapter_ptr->vma().create_image(
-      api::create_extent3d(image_extents),
+      create_extent3d(image_extents),
       image_format,
       image_type,
       image_view_type,
@@ -343,32 +341,32 @@ api::VulkanImage allocate_image(
       /*allocate_memory = */ allocate_memory);
 }
 
-api::VulkanBuffer allocate_buffer(
-    api::Context* const context_ptr,
+VulkanBuffer allocate_buffer(
+    Context* const context_ptr,
     const int64_t numel,
-    const api::StorageType storage_type,
-    const api::ScalarType dtype,
+    const StorageType storage_type,
+    const ScalarType dtype,
     const bool allocate_memory) {
-  api::Adapter* adapter_ptr = context_ptr->adapter_ptr();
+  Adapter* adapter_ptr = context_ptr->adapter_ptr();
 
   switch (storage_type) {
-    case api::kBuffer:
+    case kBuffer:
       break;
     default:
       // Return an empty VulkanBuffer if Buffer storage is not used
-      return api::VulkanBuffer();
+      return VulkanBuffer();
   }
 
   return adapter_ptr->vma().create_storage_buffer(
-      api::element_size(dtype) * numel, /*gpu_only = */ true, allocate_memory);
+      element_size(dtype) * numel, /*gpu_only = */ true, allocate_memory);
 }
 
 vTensorStorage::vTensorStorage(
-    api::Context* const context,
-    const api::StorageType storage_type,
-    const api::GPUMemoryLayout gpu_memory_layout,
+    Context* const context,
+    const StorageType storage_type,
+    const GPUMemoryLayout gpu_memory_layout,
     const std::vector<int64_t>& padded_sizes,
-    const api::ScalarType dtype,
+    const ScalarType dtype,
     const bool allocate_memory)
     : context_(context),
       storage_type_{storage_type},
@@ -378,7 +376,7 @@ vTensorStorage::vTensorStorage(
           context_,
           image_extents_,
           storage_type_,
-          api::to_vkformat(dtype),
+          to_vkformat(dtype),
           allocate_memory)),
       buffer_(allocate_buffer(
           context_,
@@ -402,31 +400,31 @@ void vTensorStorage::flush() {
 }
 
 void vTensorStorage::transition(
-    api::PipelineBarrier& pipeline_barrier,
-    const api::PipelineStageFlags cur_stage,
-    const api::MemoryAccessFlags cur_access) {
+    PipelineBarrier& pipeline_barrier,
+    const PipelineStageFlags cur_stage,
+    const MemoryAccessFlags cur_access) {
   // Get last stage access
-  api::PipelineStageFlags prev_stage = last_access_.stage;
-  api::MemoryAccessFlags prev_access = last_access_.access;
+  PipelineStageFlags prev_stage = last_access_.stage;
+  MemoryAccessFlags prev_access = last_access_.access;
 
-  const bool prev_written = (prev_access & api::MemoryAccessType::WRITE) != 0;
+  const bool prev_written = (prev_access & MemoryAccessType::WRITE) != 0;
 
   VkImageLayout cur_layout = VK_IMAGE_LAYOUT_UNDEFINED;
   VkImageLayout new_layout = VK_IMAGE_LAYOUT_UNDEFINED;
   bool layout_changed = false;
   if (image_) {
     cur_layout = image_.layout();
-    new_layout = api::vk_layout(cur_stage, cur_access);
+    new_layout = vk_layout(cur_stage, cur_access);
 
     layout_changed = cur_layout != new_layout;
   }
 
   if (prev_written || layout_changed) {
-    VkPipelineStageFlags src_stage = api::vk_stage(prev_stage);
+    VkPipelineStageFlags src_stage = vk_stage(prev_stage);
     if (0u == src_stage) {
       src_stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
     }
-    VkPipelineStageFlags dst_stage = api::vk_stage(cur_stage);
+    VkPipelineStageFlags dst_stage = vk_stage(cur_stage);
     if (0u == dst_stage) {
       dst_stage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
     }
@@ -436,8 +434,8 @@ void vTensorStorage::transition(
 
     if (image_) {
       pipeline_barrier.images.emplace_back(
-          api::vk_access(prev_stage, prev_access),
-          api::vk_access(cur_stage, cur_access),
+          vk_access(prev_stage, prev_access),
+          vk_access(cur_stage, cur_access),
           cur_layout,
           new_layout,
           image_);
@@ -445,8 +443,8 @@ void vTensorStorage::transition(
       image_.set_layout(new_layout);
     } else if (buffer_) {
       pipeline_barrier.buffers.emplace_back(
-          api::vk_access(prev_stage, prev_access),
-          api::vk_access(cur_stage, cur_access),
+          vk_access(prev_stage, prev_access),
+          vk_access(cur_stage, cur_access),
           buffer_);
     }
   }
@@ -457,8 +455,8 @@ void vTensorStorage::transition(
 
 void vTensorStorage::discard_and_reallocate(
     const std::vector<int64_t>& padded_sizes,
-    const api::GPUMemoryLayout gpu_memory_layout,
-    const api::ScalarType dtype) {
+    const GPUMemoryLayout gpu_memory_layout,
+    const ScalarType dtype) {
   const bool image_owns_memory = image_.owns_memory();
   const bool buffer_owns_memory = buffer_.owns_memory();
 
@@ -469,7 +467,7 @@ void vTensorStorage::discard_and_reallocate(
       context_,
       image_extents_,
       storage_type_,
-      api::to_vkformat(dtype),
+      to_vkformat(dtype),
       image_owns_memory);
 
   buffer_length_ = utils::multiply_integers(padded_sizes);
@@ -477,4 +475,5 @@ void vTensorStorage::discard_and_reallocate(
       context_, buffer_length_, storage_type_, dtype, buffer_owns_memory);
 }
 
+} // namespace api
 } // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -36,7 +36,7 @@ namespace vkcompute {
     graph_->values_in_use_--;                                             \
   }
 
-VALUE_PTR_CLASS_IMPL(vTensorPtr, vTensor, Tensor)
+VALUE_PTR_CLASS_IMPL(vTensorPtr, api::vTensor, Tensor)
 VALUE_PTR_CLASS_IMPL(TensorRefPtr, TensorRef, TensorRef)
 VALUE_PTR_CLASS_IMPL(StagingPtr, api::StorageBuffer, Staging)
 VALUE_PTR_CLASS_IMPL(IntListPtr, std::vector<int64_t>, IntList)
@@ -151,7 +151,7 @@ ValueRef ComputeGraph::add_tensor(
 
   ValueRef idx(static_cast<int>(values_.size()));
   check_no_active_value_ptrs();
-  values_.emplace_back(vTensor(
+  values_.emplace_back(api::vTensor(
       context(), sizes, dtype, storage_type, memory_layout, allocate_memory));
 
   if (!allocate_memory) {

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -56,7 +56,7 @@ class ComputeGraph;
     ~classname();                                                      \
   };
 
-DECL_VALUE_PTR_CLASS(vTensorPtr, vTensor)
+DECL_VALUE_PTR_CLASS(vTensorPtr, api::vTensor)
 DECL_VALUE_PTR_CLASS(TensorRefPtr, TensorRef)
 DECL_VALUE_PTR_CLASS(StagingPtr, api::StorageBuffer)
 DECL_VALUE_PTR_CLASS(IntListPtr, std::vector<int64_t>)
@@ -262,8 +262,8 @@ class ComputeGraph final {
 
   /*
    * Returns a suggested storage type (i.e. buffer or texture) that can be used
-   * to construct `vTensor`s. The storage type is typically determined by the
-   * GPU reported by the Vulkan context, unless a storage type override is
+   * to construct `api::vTensor`s. The storage type is typically determined by
+   * the GPU reported by the Vulkan context, unless a storage type override is
    * defined in the graph configuration. Some GPU architectures work better with
    * buffer storage, and others with texture storage. Current only texture
    * storage is supported.
@@ -272,10 +272,10 @@ class ComputeGraph final {
 
   /*
    * Returns a suggested memory layout (i.e. channels, width, or height packed)
-   * that can be used to construct `vTensor`s. The memory layout impacts which
-   * dimension will be treated as the vectorized dimension. For texture storage,
-   * elements along the vectorized dimension are packed into texels. The
-   * suggested memory layout is determined based on the sizes of the tensor,
+   * that can be used to construct `api::vTensor`s. The memory layout impacts
+   * which dimension will be treated as the vectorized dimension. For texture
+   * storage, elements along the vectorized dimension are packed into texels.
+   * The suggested memory layout is determined based on the sizes of the tensor,
    * unless a memory layout override is defined in the graph configuration.
    */
   api::GPUMemoryLayout suggested_memory_layout(
@@ -290,8 +290,9 @@ class ComputeGraph final {
 
  public:
   /*
-   * Add a `vTensor` value to the graph with the specified properties. There are
-   * various convenience overloads of this function that may be used instead.
+   * Add a `api::vTensor` value to the graph with the specified properties.
+   * There are various convenience overloads of this function that may be used
+   * instead.
    */
   ValueRef add_tensor(
       const std::vector<int64_t>& sizes,
@@ -301,8 +302,8 @@ class ComputeGraph final {
       const int64_t shared_object_idx = -1);
 
   /*
-   * Add a `vTensor` value to the graph with the specified properties. The
-   * suggested memory layout will be used to construct the `vTensor`.
+   * Add a `api::vTensor` value to the graph with the specified properties. The
+   * suggested memory layout will be used to construct the `api::vTensor`.
    */
   ValueRef add_tensor(
       const std::vector<int64_t>& sizes,
@@ -311,8 +312,8 @@ class ComputeGraph final {
       const int64_t shared_object_idx = -1);
 
   /*
-   * Add a `vTensor` value to the graph with the specified properties. The
-   * suggested storage type will be used to construct the `vTensor`.
+   * Add a `api::vTensor` value to the graph with the specified properties. The
+   * suggested storage type will be used to construct the `api::vTensor`.
    */
   ValueRef add_tensor(
       const std::vector<int64_t>& sizes,
@@ -321,9 +322,9 @@ class ComputeGraph final {
       const int64_t shared_object_idx = -1);
 
   /*
-   * Add a `vTensor` value to the graph with the specified properties. The
+   * Add a `api::vTensor` value to the graph with the specified properties. The
    * suggested storage type and memory layout will be used to construct the
-   * `vTensor`.
+   * `api::vTensor`.
    */
   ValueRef add_tensor(
       const std::vector<int64_t>& sizes,
@@ -331,7 +332,7 @@ class ComputeGraph final {
       const int64_t shared_object_idx = -1);
 
   /*
-   * Add a `vTensor` value to the graph with the properties of `vref`.
+   * Add a `api::vTensor` value to the graph with the properties of `vref`.
    */
   ValueRef add_tensor_like(
       const ValueRef vref,
@@ -339,8 +340,8 @@ class ComputeGraph final {
       const api::GPUMemoryLayout memory_layout);
 
   /*
-   * Add a `vTensor` value to the graph with the properties of `vref`. The
-   * suggested storage type will be used to construct the `vTensor`.
+   * Add a `api::vTensor` value to the graph with the properties of `vref`. The
+   * suggested storage type will be used to construct the `api::vTensor`.
    */
   ValueRef add_tensor_like(
       const ValueRef vref,
@@ -348,7 +349,7 @@ class ComputeGraph final {
 
   /*
    * Add a `TensorRef` value to the graph with the specific properties. A
-   * `TensorRef` is a reference to a `vTensor` whose data is stored in an
+   * `TensorRef` is a reference to a `api::vTensor` whose data is stored in an
    * external CPU buffer.
    */
   ValueRef add_tensorref(
@@ -443,11 +444,12 @@ class ComputeGraph final {
   //
 
   /*
-   * Create a global workgroup size for a given `vTensor` value assuming that
-   * every shader invocation calculates one texel element of the output tensor.
+   * Create a global workgroup size for a given `api::vTensor` value assuming
+   * that every shader invocation calculates one texel element of the output
+   * tensor.
    *
-   * For tensors that use texture storage, the image extents of the `vTensor`
-   * will be used to set the global workgroup size.
+   * For tensors that use texture storage, the image extents of the
+   * `api::vTensor` will be used to set the global workgroup size.
    *
    * For tensor that use buffer storage, the number of texels in the texel
    * buffer will be used to set the x component of the global workgroup size.
@@ -457,8 +459,9 @@ class ComputeGraph final {
   utils::uvec3 create_global_wg_size(const ValueRef idx);
 
   /*
-   * Suggest a local workgroup size for a given `vTensor` value, assuming that
-   * every shader invocation calculates one texel element of the output tensor.
+   * Suggest a local workgroup size for a given `api::vTensor` value, assuming
+   * that every shader invocation calculates one texel element of the output
+   * tensor.
    *
    * The local workgroup size will be formed to try and minimize the number of
    * inactive invocations.

--- a/backends/vulkan/runtime/graph/Logging.cpp
+++ b/backends/vulkan/runtime/graph/Logging.cpp
@@ -81,7 +81,7 @@ void ComputeGraph::print_readable() {
     // sizes
     std::cout << std::setw(20);
     if (val.isTensor()) {
-      const vTensor& v_tensor = val.toTensor();
+      const api::vTensor& v_tensor = val.toTensor();
       std::stringstream ss;
       ss << v_tensor.sizes();
       std::cout << ss.str();

--- a/backends/vulkan/runtime/graph/containers/Value.h
+++ b/backends/vulkan/runtime/graph/containers/Value.h
@@ -53,7 +53,7 @@ struct Value final {
       bool as_bool;
     } u;
 
-    vTensor as_tensor;
+    api::vTensor as_tensor;
     api::StorageBuffer as_staging;
     TensorRef as_tensorref;
 
@@ -106,7 +106,8 @@ struct Value final {
       CASE_MOVE_TRIVIALLY_COPYABLE_TYPE(TypeTag::DOUBLE, as_double);
       CASE_MOVE_TRIVIALLY_COPYABLE_TYPE(TypeTag::BOOL, as_bool);
       // Tensor and tensor adjacent types
-      CASE_MOVE_MOVEABLE_TYPE(TypeTag::TENSOR, vTensor, as_tensor, vTensor);
+      CASE_MOVE_MOVEABLE_TYPE(
+          TypeTag::TENSOR, api::vTensor, as_tensor, vTensor);
       CASE_MOVE_MOVEABLE_TYPE(
           TypeTag::STAGING, api::StorageBuffer, as_staging, StorageBuffer);
       CASE_MOVE_MOVEABLE_TYPE(
@@ -240,7 +241,11 @@ struct Value final {
     return payload.member_name;                             \
   }
 
-  SUPPORT_TRIVIALLY_MOVEABLE_TYPE(vTensor, Tensor, TypeTag::TENSOR, as_tensor);
+  SUPPORT_TRIVIALLY_MOVEABLE_TYPE(
+      api::vTensor,
+      Tensor,
+      TypeTag::TENSOR,
+      as_tensor);
 
   SUPPORT_TRIVIALLY_MOVEABLE_TYPE(
       api::StorageBuffer,

--- a/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
@@ -49,7 +49,7 @@ api::StorageBuffer PrepackNode::create_staging_buffer(ComputeGraph* graph) {
   vTensorPtr packed = graph->get_tensor(packed_);
 
   // If no TensorRef is provided, create a staging buffer of zeros according to
-  // the vTensor metadata.
+  // the api::vTensor metadata.
   if (graph->val_is_none(tref_)) {
     size_t numel = utils::multiply_integers(packed->sizes());
     api::StorageBuffer staging(graph->context(), packed->dtype(), numel);

--- a/backends/vulkan/runtime/graph/ops/impl/BinaryOp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/BinaryOp.cpp
@@ -18,9 +18,9 @@
 namespace vkcompute {
 
 void check_binary_op_args(
-    const vTensor& self,
-    const vTensor& other,
-    const vTensor& out) {
+    const api::vTensor& self,
+    const api::vTensor& other,
+    const api::vTensor& out) {
   VK_CHECK_COND(check_same_memory_layout(self, other, out));
   std::vector<int64_t> broadcasted_sizes =
       calculate_broadcasted_output_size(self, other);

--- a/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
@@ -122,7 +122,7 @@ enum class Conv2dMethod : uint8_t {
 
 api::ShaderInfo get_conv2d_shader(
     ComputeGraph& graph,
-    const vTensor& t_out,
+    const api::vTensor& t_out,
     const bool prepack_weights,
     const Conv2dMethod method,
     const ValueRef weight,
@@ -218,7 +218,7 @@ ValueRef prepack_weights(
   return v;
 }
 
-void check_conv_args(const vTensor& in, const vTensor& out) {
+void check_conv_args(const api::vTensor& in, const api::vTensor& out) {
   VK_CHECK_COND(check_memory_layout_is(in, api::kChannelsPacked));
   VK_CHECK_COND(check_memory_layout_is(out, api::kChannelsPacked));
 }

--- a/backends/vulkan/runtime/graph/ops/impl/Embedding.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Embedding.cpp
@@ -18,9 +18,9 @@
 namespace vkcompute {
 
 void check_embedding_args(
-    const vTensor& weight,
-    const vTensor& in,
-    const vTensor& out) {
+    const api::vTensor& weight,
+    const api::vTensor& in,
+    const api::vTensor& out) {
   VK_CHECK_COND(check_memory_layout_is(weight, api::kChannelsPacked));
   VK_CHECK_COND(check_memory_layout_is(in, api::kChannelsPacked));
   VK_CHECK_COND(check_memory_layout_is(out, api::kChannelsPacked));

--- a/backends/vulkan/runtime/graph/ops/impl/IndexSelect.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/IndexSelect.cpp
@@ -18,9 +18,9 @@
 namespace vkcompute {
 
 void check_index_select_args(
-    const vTensor& in,
-    const vTensor& idx,
-    const vTensor& out) {
+    const api::vTensor& in,
+    const api::vTensor& idx,
+    const api::vTensor& out) {
   VK_CHECK_COND(check_memory_layout_is(in, api::kChannelsPacked));
   VK_CHECK_COND(check_memory_layout_is(idx, api::kChannelsPacked));
   VK_CHECK_COND(check_memory_layout_is(out, api::kChannelsPacked));
@@ -58,7 +58,7 @@ struct IndexSelectParams final {
 
 IndexSelectParams create_index_select_params(
     const int64_t dim_idx,
-    const vTensor& in) {
+    const api::vTensor& in) {
   if (dim_idx == kWidth4D) {
     return {0, 1};
   } else if (dim_idx == kHeight4D) {

--- a/backends/vulkan/runtime/graph/ops/impl/NativeLayerNorm.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/NativeLayerNorm.cpp
@@ -18,7 +18,7 @@
 namespace vkcompute {
 
 std::vector<int64_t> calc_out_mean_sizes(
-    vTensor& self,
+    api::vTensor& self,
     int64_t normalized_shape_dim) {
   std::vector<int64_t> output_size = self.sizes();
   int64_t self_dim = self.sizes().size();
@@ -48,7 +48,7 @@ void resize_native_layer_norm_node(
   rstd->virtual_resize(mean_size);
 }
 
-void check_args(const vTensor& in, const vTensor& out) {
+void check_args(const api::vTensor& in, const api::vTensor& out) {
   VK_CHECK_COND(check_memory_layout_is(in, api::kChannelsPacked));
   VK_CHECK_COND(check_memory_layout_is(out, api::kChannelsPacked));
 }

--- a/backends/vulkan/runtime/graph/ops/impl/Permute.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Permute.cpp
@@ -25,9 +25,9 @@ using utils::uvec4;
 namespace {
 
 void check_args(
-    const vTensor& in,
+    const api::vTensor& in,
     const std::vector<int64_t>& permute_dims,
-    const vTensor& out) {
+    const api::vTensor& out) {
   VK_CHECK_COND(check_memory_layout_is(in, api::kChannelsPacked));
   VK_CHECK_COND(check_memory_layout_is(out, api::kChannelsPacked));
 

--- a/backends/vulkan/runtime/graph/ops/impl/Pool.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Pool.cpp
@@ -17,7 +17,7 @@
 
 namespace vkcompute {
 
-void check_pool2d_args(const vTensor& in, const vTensor& out) {
+void check_pool2d_args(const api::vTensor& in, const api::vTensor& out) {
   VK_CHECK_COND(check_memory_layout_is(in, api::kChannelsPacked));
   VK_CHECK_COND(check_memory_layout_is(out, api::kChannelsPacked));
 }

--- a/backends/vulkan/runtime/graph/ops/impl/Repeat.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Repeat.cpp
@@ -20,9 +20,9 @@ namespace vkcompute {
 namespace {
 
 void check_args(
-    const vTensor& in,
+    const api::vTensor& in,
     const std::vector<int64_t>& repeats,
-    const vTensor& out) {
+    const api::vTensor& out) {
   VK_CHECK_COND(check_memory_layout_is(in, api::kChannelsPacked));
   VK_CHECK_COND(check_memory_layout_is(out, api::kChannelsPacked));
 

--- a/backends/vulkan/runtime/graph/ops/impl/Select.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Select.cpp
@@ -18,10 +18,10 @@
 namespace vkcompute {
 
 void check_args(
-    const vTensor& t_in,
+    const api::vTensor& t_in,
     int64_t dim,
     int64_t index,
-    const vTensor& t_out) {
+    const api::vTensor& t_out) {
   VK_CHECK_COND(check_memory_layout_is(t_in, api::kChannelsPacked));
   VK_CHECK_COND(check_memory_layout_is(t_out, api::kChannelsPacked));
 

--- a/backends/vulkan/runtime/graph/ops/impl/Sum.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Sum.cpp
@@ -19,7 +19,8 @@
 
 namespace vkcompute {
 
-std::vector<int64_t> calc_out_sizes(vTensor& self, int64_t dim, bool keepdim) {
+std::vector<int64_t>
+calc_out_sizes(api::vTensor& self, int64_t dim, bool keepdim) {
   std::vector<int64_t> output_size = self.sizes();
   if (keepdim) {
     output_size.at(dim) = 1;
@@ -45,7 +46,7 @@ void resize_sum_node(
   out->virtual_resize(output_size);
 }
 
-void check_sum_args(const vTensor& in, const vTensor& out) {
+void check_sum_args(const api::vTensor& in, const api::vTensor& out) {
   VK_CHECK_COND(check_memory_layout_is(in, api::kChannelsPacked));
   VK_CHECK_COND(check_memory_layout_is(out, api::kChannelsPacked));
 }

--- a/backends/vulkan/runtime/graph/ops/impl/utils/DimUtils.h
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/DimUtils.h
@@ -31,7 +31,7 @@ constexpr DimIndex kHeight4D = DimIndex::DIM_2ND_LAST;
 constexpr DimIndex kChannel4D = DimIndex::DIM_3RD_LAST;
 constexpr DimIndex kBatch4D = DimIndex::DIM_4TH_LAST;
 
-inline DimIndex normalize_to_dim_index(const vTensor& v_in, int32_t dim) {
+inline DimIndex normalize_to_dim_index(const api::vTensor& v_in, int32_t dim) {
   return static_cast<DimIndex>(dim - v_in.dim());
 }
 
@@ -83,11 +83,11 @@ int32_t dim_at(const std::vector<int64_t>& sizes) {
 }
 
 template <DimIndex DI>
-int32_t dim_at(const vTensor& v_in) {
+int32_t dim_at(const api::vTensor& v_in) {
   return dim_at(v_in.sizes(), DI);
 }
 
-inline int32_t dim_at(const vTensor& v_in, DimIndex dim_index) {
+inline int32_t dim_at(const api::vTensor& v_in, DimIndex dim_index) {
   return dim_at(v_in.sizes(), dim_index);
 }
 

--- a/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.cpp
@@ -15,8 +15,8 @@ namespace vkcompute {
 //
 
 std::vector<int64_t> calculate_broadcasted_output_size(
-    const vTensor& t1,
-    const vTensor& t2) {
+    const api::vTensor& t1,
+    const api::vTensor& t2) {
   std::vector<int64_t> out_sizes(
       std::max(t1.sizes().size(), t2.sizes().size()));
 
@@ -33,34 +33,36 @@ std::vector<int64_t> calculate_broadcasted_output_size(
 // Tensor property checking functions
 //
 
-bool check_ndim_is(const vTensor& t, size_t ndim) {
+bool check_ndim_is(const api::vTensor& t, size_t ndim) {
   return t.sizes().size() == ndim;
 }
 
 bool check_same_sizes_at(
-    const vTensor& t1,
+    const api::vTensor& t1,
     const int64_t d1,
-    const vTensor& t2,
+    const api::vTensor& t2,
     const int64_t d2) {
   return utils::val_at(d1, t1.sizes()) == utils::val_at(d2, t2.sizes());
 }
 
-bool check_memory_layout_is(const vTensor& t, api::GPUMemoryLayout layout) {
+bool check_memory_layout_is(
+    const api::vTensor& t,
+    api::GPUMemoryLayout layout) {
   return t.gpu_memory_layout() == layout;
 }
 
-bool check_same_ndim(const vTensor& t1, const vTensor& t2) {
+bool check_same_ndim(const api::vTensor& t1, const api::vTensor& t2) {
   return t1.sizes().size() == t2.sizes().size();
 }
 
-bool check_same_memory_layout(const vTensor& t1, const vTensor& t2) {
+bool check_same_memory_layout(const api::vTensor& t1, const api::vTensor& t2) {
   return t1.gpu_memory_layout() == t2.gpu_memory_layout();
 }
 
 bool check_same_memory_layout(
-    const vTensor& t1,
-    const vTensor& t2,
-    const vTensor& t3) {
+    const api::vTensor& t1,
+    const api::vTensor& t2,
+    const api::vTensor& t3) {
   if (t1.gpu_memory_layout() != t2.gpu_memory_layout()) {
     return false;
   }
@@ -71,7 +73,9 @@ bool check_same_memory_layout(
 // Broadcast flag functions
 //
 
-bool is_packed_dim_broadcasted(const vTensor& sndr, const vTensor& rcvr) {
+bool is_packed_dim_broadcasted(
+    const api::vTensor& sndr,
+    const api::vTensor& rcvr) {
   // We assume that the tensors are broadcastable. If values aren't equal at
   // some index, then the value of rcvr is 1 and hence should be broadcasted.
   switch (sndr.gpu_memory_layout()) {
@@ -84,7 +88,9 @@ bool is_packed_dim_broadcasted(const vTensor& sndr, const vTensor& rcvr) {
   }
 }
 
-utils::ivec2 create_broadcast_params(const vTensor& t1, const vTensor& t2) {
+utils::ivec2 create_broadcast_params(
+    const api::vTensor& t1,
+    const api::vTensor& t2) {
   return utils::make_ivec2(
       {is_packed_dim_broadcasted(t2, t1), is_packed_dim_broadcasted(t1, t2)});
 }

--- a/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h
@@ -17,37 +17,39 @@ namespace vkcompute {
 //
 
 std::vector<int64_t> calculate_broadcasted_output_size(
-    const vTensor& t1,
-    const vTensor& t2);
+    const api::vTensor& t1,
+    const api::vTensor& t2);
 
 //
 // Tensor property checking functions
 //
 
-bool check_ndim_is(const vTensor& t, size_t ndim);
+bool check_ndim_is(const api::vTensor& t, size_t ndim);
 
-bool check_same_ndim(const vTensor& t1, const vTensor& t2);
+bool check_same_ndim(const api::vTensor& t1, const api::vTensor& t2);
 
 bool check_same_sizes_at(
-    const vTensor& t1,
+    const api::vTensor& t1,
     int64_t d1,
-    const vTensor& t2,
+    const api::vTensor& t2,
     int64_t d2);
 
-bool check_memory_layout_is(const vTensor& t, api::GPUMemoryLayout layout);
+bool check_memory_layout_is(const api::vTensor& t, api::GPUMemoryLayout layout);
 
-bool check_same_memory_layout(const vTensor& t1, const vTensor& t2);
+bool check_same_memory_layout(const api::vTensor& t1, const api::vTensor& t2);
 
 bool check_same_memory_layout(
-    const vTensor& t1,
-    const vTensor& t2,
-    const vTensor& t3);
+    const api::vTensor& t1,
+    const api::vTensor& t2,
+    const api::vTensor& t3);
 
 //
 // Broadcast flag functions
 //
 
-utils::ivec2 create_broadcast_params(const vTensor& t1, const vTensor& t2);
+utils::ivec2 create_broadcast_params(
+    const api::vTensor& t1,
+    const api::vTensor& t2);
 
 //
 // Work group size calculation functions

--- a/backends/vulkan/runtime/graph/ops/utils/BindingUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/utils/BindingUtils.cpp
@@ -11,7 +11,7 @@
 namespace vkcompute {
 
 void bind_tensor_to_descriptor_set(
-    vTensor& tensor,
+    api::vTensor& tensor,
     api::PipelineBarrier& pipeline_barrier,
     const api::MemoryAccessType accessType,
     api::DescriptorSet& descriptor_set,

--- a/backends/vulkan/runtime/graph/ops/utils/BindingUtils.h
+++ b/backends/vulkan/runtime/graph/ops/utils/BindingUtils.h
@@ -17,7 +17,7 @@ namespace vkcompute {
 //
 
 void bind_tensor_to_descriptor_set(
-    vTensor& tensor,
+    api::vTensor& tensor,
     api::PipelineBarrier& pipeline_barrier,
     const api::MemoryAccessType accessType,
     api::DescriptorSet& descriptor_set,

--- a/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.cpp
@@ -26,7 +26,9 @@ void add_storage_type_suffix(
   }
 }
 
-void add_storage_type_suffix(std::string& kernel_name, const vTensor& tensor) {
+void add_storage_type_suffix(
+    std::string& kernel_name,
+    const api::vTensor& tensor) {
   return add_storage_type_suffix(kernel_name, tensor.storage_type());
 }
 
@@ -50,11 +52,11 @@ void add_dtype_suffix(std::string& kernel_name, const api::ScalarType dtype) {
   }
 }
 
-void add_dtype_suffix(std::string& kernel_name, const vTensor& tensor) {
+void add_dtype_suffix(std::string& kernel_name, const api::vTensor& tensor) {
   return add_dtype_suffix(kernel_name, tensor.dtype());
 }
 
-void add_ndim_suffix(std::string& kernel_name, const vTensor& tensor) {
+void add_ndim_suffix(std::string& kernel_name, const api::vTensor& tensor) {
   switch (tensor.storage_type()) {
     case api::kTexture3D:
       kernel_name += "_3d";
@@ -85,7 +87,9 @@ void add_memory_layout_suffix(
   }
 }
 
-void add_memory_layout_suffix(std::string& kernel_name, const vTensor& tensor) {
+void add_memory_layout_suffix(
+    std::string& kernel_name,
+    const api::vTensor& tensor) {
   return add_memory_layout_suffix(kernel_name, tensor.gpu_memory_layout());
 }
 

--- a/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h
+++ b/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h
@@ -19,17 +19,21 @@ constexpr size_t kShaderNameReserve = 64u;
 void add_storage_type_suffix(
     std::string& kernel_name,
     const api::StorageType storage_type);
-void add_storage_type_suffix(std::string& kernel_name, const vTensor& tensor);
+void add_storage_type_suffix(
+    std::string& kernel_name,
+    const api::vTensor& tensor);
 
 void add_dtype_suffix(std::string& kernel_name, const api::ScalarType dtype);
-void add_dtype_suffix(std::string& kernel_name, const vTensor& tensor);
+void add_dtype_suffix(std::string& kernel_name, const api::vTensor& tensor);
 
 void add_ndim_suffix(std::string& kernel_name, const size_t ndim);
-void add_ndim_suffix(std::string& kernel_name, const vTensor& tensor);
+void add_ndim_suffix(std::string& kernel_name, const api::vTensor& tensor);
 
 void add_memory_layout_suffix(
     std::string& kernel_name,
     const api::GPUMemoryLayout layout);
-void add_memory_layout_suffix(std::string& kernel_name, const vTensor& tensor);
+void add_memory_layout_suffix(
+    std::string& kernel_name,
+    const api::vTensor& tensor);
 
 } // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/utils/StagingUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/utils/StagingUtils.cpp
@@ -95,7 +95,7 @@ void set_staging_zeros(api::StorageBuffer& staging, const size_t nbytes) {
   memset(data_ptr, 0, staging.nbytes());
 }
 
-api::ShaderInfo get_nchw_to_tensor_shader(const vTensor& v_dst) {
+api::ShaderInfo get_nchw_to_tensor_shader(const api::vTensor& v_dst) {
   std::string kernel_name;
   kernel_name.reserve(kShaderNameReserve);
 
@@ -106,7 +106,7 @@ api::ShaderInfo get_nchw_to_tensor_shader(const vTensor& v_dst) {
   return VK_KERNEL_FROM_STR(kernel_name);
 }
 
-api::ShaderInfo get_tensor_to_nchw_shader(const vTensor& v_src) {
+api::ShaderInfo get_tensor_to_nchw_shader(const api::vTensor& v_src) {
   std::string kernel_name;
   kernel_name.reserve(kShaderNameReserve);
 

--- a/backends/vulkan/runtime/graph/ops/utils/StagingUtils.h
+++ b/backends/vulkan/runtime/graph/ops/utils/StagingUtils.h
@@ -31,7 +31,7 @@ void set_staging_zeros(api::StorageBuffer& staging, const size_t nbytes);
 // Functions to get shaders
 //
 
-api::ShaderInfo get_nchw_to_tensor_shader(const vTensor& v_dst);
-api::ShaderInfo get_tensor_to_nchw_shader(const vTensor& v_src);
+api::ShaderInfo get_nchw_to_tensor_shader(const api::vTensor& v_dst);
+api::ShaderInfo get_tensor_to_nchw_shader(const api::vTensor& v_src);
 
 } // namespace vkcompute

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -21,7 +21,7 @@
 void record_nchw_to_buffer_op(
     api::Context* const context,
     api::VulkanBuffer& src_buffer,
-    vTensor& v_dst) {
+    api::vTensor& v_dst) {
   api::PipelineBarrier pipeline_barrier{};
   api::SpecVarList specialization_constants = {SV(v_dst.packed_dim_whcn_idx())};
 
@@ -45,7 +45,7 @@ void record_nchw_to_buffer_op(
 
 void record_buffer_to_nchw_op(
     api::Context* const context,
-    vTensor& v_src,
+    api::vTensor& v_src,
     api::VulkanBuffer& dst_buffer) {
   api::PipelineBarrier pipeline_barrier{};
   api::SpecVarList specialization_constants = {SV(v_src.packed_dim_whcn_idx())};
@@ -68,7 +68,7 @@ void record_buffer_to_nchw_op(
 void record_nchw_to_image_op(
     api::Context* const context,
     api::VulkanBuffer& src_buffer,
-    vTensor& v_dst) {
+    api::vTensor& v_dst) {
   api::PipelineBarrier pipeline_barrier{};
   api::SpecVarList specialization_constants = {SV(v_dst.packed_dim_whcn_idx())};
 
@@ -90,7 +90,7 @@ void record_nchw_to_image_op(
 
 void record_image_to_nchw_op(
     api::Context* const context,
-    vTensor& v_src,
+    api::vTensor& v_src,
     api::VulkanBuffer& dst_buffer) {
   api::PipelineBarrier pipeline_barrier{};
   api::SpecVarList specialization_constants = {SV(v_src.packed_dim_whcn_idx())};
@@ -111,7 +111,7 @@ void record_image_to_nchw_op(
 void record_conv2d_prepack_weights_op(
     api::Context* const context,
     api::VulkanBuffer& src_buffer,
-    vTensor& v_dst,
+    api::vTensor& v_dst,
     const std::vector<int64_t>& original_sizes,
     const bool transposed) {
   api::PipelineBarrier pipeline_barrier{};
@@ -150,9 +150,9 @@ void record_conv2d_prepack_weights_op(
 void record_binary_op(
     api::Context* const context,
     const std::string& op_name,
-    vTensor& v_in1,
-    vTensor& v_in2,
-    vTensor& v_dst) {
+    api::vTensor& v_in1,
+    api::vTensor& v_in2,
+    api::vTensor& v_dst) {
   std::string kernel_name = "binary_" + op_name + "_nobroadcast__test";
   add_dtype_suffix(kernel_name, v_dst);
 
@@ -176,9 +176,9 @@ void record_binary_op(
 }
 
 void execute_and_check_add(
-    vTensor& a,
-    vTensor& b,
-    vTensor& c,
+    api::vTensor& a,
+    api::vTensor& b,
+    api::vTensor& c,
     float a_val,
     float b_val) {
   // Fill input tensors
@@ -197,7 +197,7 @@ void execute_and_check_add(
   }
 }
 
-void record_index_fill_buffer(api::Context* context, vTensor& v_ten) {
+void record_index_fill_buffer(api::Context* context, api::vTensor& v_ten) {
   std::string kernel_name("idx_fill_buffer");
   switch (v_ten.dtype()) {
     case api::kFloat:
@@ -240,7 +240,7 @@ void record_index_fill_buffer(api::Context* context, vTensor& v_ten) {
 
 void record_scalar_add_buffer(
     api::Context* context,
-    vTensor& v_ten,
+    api::vTensor& v_ten,
     float offset) {
   api::PipelineBarrier pipeline_barrier{};
   api::SpecVarList specialization_constants = {SV(offset)};
@@ -273,7 +273,7 @@ void record_scalar_add_buffer(
   _(float, Float)                 \
   _(int8_t, QInt8)
 
-void fill_vtensor(vTensor& vten, std::vector<float>& data) {
+void fill_vtensor(api::vTensor& vten, std::vector<float>& data) {
   api::StorageBuffer staging_buffer(api::context(), vten.dtype(), data.size());
 
 #define CASE(ctype, name)                                          \
@@ -302,7 +302,7 @@ void fill_vtensor(vTensor& vten, std::vector<float>& data) {
   }
 }
 
-void fill_vtensor(vTensor& vten, float val, bool iota) {
+void fill_vtensor(api::vTensor& vten, float val, bool iota) {
   std::vector<float> vten_data(vten.gpu_numel());
   if (iota) {
     std::iota(vten_data.begin(), vten_data.end(), val);
@@ -328,7 +328,7 @@ void fill_vtensor(
   graph.copy_into_staging(idx.staging, data.data(), data.size());
 }
 
-void extract_vtensor(vTensor& vten, std::vector<float>& data) {
+void extract_vtensor(api::vTensor& vten, std::vector<float>& data) {
   api::StorageBuffer staging_buffer(
       api::context(), vten.dtype(), vten.gpu_numel());
 
@@ -371,7 +371,7 @@ void submit_to_gpu() {
   fence.wait();
 }
 
-api::Allocation allocate_memory_for(const vTensor& vten) {
+api::Allocation allocate_memory_for(const api::vTensor& vten) {
   return api::context()->adapter_ptr()->vma().create_allocation(
       vten.get_memory_requirements(), vten.get_allocation_create_info());
 }

--- a/backends/vulkan/test/utils/test_utils.h
+++ b/backends/vulkan/test/utils/test_utils.h
@@ -19,7 +19,7 @@
 using namespace vkcompute;
 
 #define CREATE_FLOAT_TEXTURE(sizes, allocate_memory) \
-  vTensor(                                           \
+  api::vTensor(                                      \
       api::context(),                                \
       sizes,                                         \
       api::kFloat,                                   \
@@ -28,7 +28,7 @@ using namespace vkcompute;
       allocate_memory);
 
 #define CREATE_FLOAT_BUFFER(sizes, allocate_memory) \
-  vTensor(                                          \
+  api::vTensor(                                     \
       api::context(),                               \
       sizes,                                        \
       api::kFloat,                                  \
@@ -65,49 +65,49 @@ using namespace vkcompute;
 void record_nchw_to_buffer_op(
     api::Context* const context,
     api::VulkanBuffer& src_buffer,
-    vTensor& v_dst);
+    api::vTensor& v_dst);
 
 void record_buffer_to_nchw_op(
     api::Context* const context,
-    vTensor& v_src,
+    api::vTensor& v_src,
     api::VulkanBuffer& dst_buffer);
 
 void record_nchw_to_image_op(
     api::Context* const context,
     api::VulkanBuffer& src_buffer,
-    vTensor& v_dst);
+    api::vTensor& v_dst);
 
 void record_image_to_nchw_op(
     api::Context* const context,
-    vTensor& v_src,
+    api::vTensor& v_src,
     api::VulkanBuffer& dst_buffer);
 
 void record_conv2d_prepack_weights_op(
     api::Context* const context,
     api::VulkanBuffer& src_buffer,
-    vTensor& v_dst,
+    api::vTensor& v_dst,
     const std::vector<int64_t>& original_sizes,
     const bool transposed);
 
 void record_binary_op(
     api::Context* const context,
     const std::string& op_name,
-    vTensor& v_in1,
-    vTensor& v_in2,
-    vTensor& v_dst);
+    api::vTensor& v_in1,
+    api::vTensor& v_in2,
+    api::vTensor& v_dst);
 
 void execute_and_check_add(
-    vTensor& a,
-    vTensor& b,
-    vTensor& c,
+    api::vTensor& a,
+    api::vTensor& b,
+    api::vTensor& c,
     float a_val,
     float b_val);
 
-void record_index_fill_buffer(api::Context* const context, vTensor& v_ten);
+void record_index_fill_buffer(api::Context* const context, api::vTensor& v_ten);
 
 void record_scalar_add_buffer(
     api::Context* context,
-    vTensor& v_ten,
+    api::vTensor& v_ten,
     float offset);
 
 //
@@ -124,9 +124,9 @@ fill_staging(api::StorageBuffer& staging, float val, int numel = -1) {
   copy_ptr_to_staging(data.data(), staging, sizeof(float) * numel);
 }
 
-void fill_vtensor(vTensor& vten, std::vector<float>& data);
+void fill_vtensor(api::vTensor& vten, std::vector<float>& data);
 
-void fill_vtensor(vTensor& vten, float val, bool iota = false);
+void fill_vtensor(api::vTensor& vten, float val, bool iota = false);
 
 void fill_vtensor(
     ComputeGraph& graph,
@@ -134,9 +134,9 @@ void fill_vtensor(
     float val,
     bool iota = false);
 
-void extract_vtensor(vTensor& vten, std::vector<float>& data);
+void extract_vtensor(api::vTensor& vten, std::vector<float>& data);
 
-inline std::vector<float> extract_vtensor(vTensor& vten) {
+inline std::vector<float> extract_vtensor(api::vTensor& vten) {
   std::vector<float> data_out(vten.gpu_numel());
   extract_vtensor(vten, data_out);
   return data_out;
@@ -181,7 +181,7 @@ inline int64_t get_buf_idx(
 
 void submit_to_gpu();
 
-api::Allocation allocate_memory_for(const vTensor& vten);
+api::Allocation allocate_memory_for(const api::vTensor& vten);
 
 VmaTotalStatistics get_vma_stats();
 

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -245,7 +245,7 @@ TEST_F(VulkanComputeAPITest, spec_var_shader_test) {
 TEST_F(VulkanComputeAPITest, update_params_between_submit) {
   api::context()->set_cmd(/*reusable = */ true);
   std::vector<int64_t> sizes = {4, 4, 2};
-  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
 
   std::string kernel_name("fill_texture__test");
   add_dtype_suffix(kernel_name, a);
@@ -373,9 +373,9 @@ TEST_F(VulkanComputeAPITest, test_zero_size_tensor) {
   // Simple test that performs a + b -> c
 
   std::vector<int64_t> sizes = {0, 5, 7};
-  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
-  vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
-  vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
 
   // Fill input tensors
   fill_vtensor(a, 2.5f);
@@ -402,7 +402,7 @@ TEST_F(VulkanComputeAPITest, test_zero_size_tensor) {
 }
 
 template <typename T>
-void run_buffer_tensor_sanity_check(vTensor& tensor) {
+void run_buffer_tensor_sanity_check(api::vTensor& tensor) {
   fill_vtensor(tensor, 0.0f, true);
 
   record_scalar_add_buffer(api::context(), tensor, 2.0f);
@@ -433,7 +433,8 @@ TEST_F(VulkanComputeAPITest, buffer_tensor_sanity_check) {
       }
       for (const auto& layout :
            {api::kWidthPacked, api::kHeightPacked, api::kChannelsPacked}) {
-        vTensor a = vTensor(api::context(), sizes, dtype, api::kBuffer, layout);
+        api::vTensor a =
+            api::vTensor(api::context(), sizes, dtype, api::kBuffer, layout);
         switch (dtype) {
           case api::kFloat:
             run_buffer_tensor_sanity_check<float>(a);
@@ -456,9 +457,9 @@ TEST_F(VulkanComputeAPITest, texture_add_sanity_check) {
   // Simple test that performs a + b -> c
 
   std::vector<int64_t> sizes = {4, 4, 1};
-  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
-  vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
-  vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
 
   // Fill input tensors
   fill_vtensor(a, 2.5f);
@@ -481,9 +482,9 @@ TEST_F(VulkanComputeAPITest, texture_deferred_allocation_test) {
   // memory is allocated in a deferred fashion
 
   std::vector<int64_t> sizes = {4, 4, 1};
-  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
-  vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
-  vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  api::vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  api::vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  api::vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
 
   // No allocations made so far
   EXPECT_TRUE(get_vma_allocation_count() == 0);
@@ -524,11 +525,11 @@ TEST_F(VulkanComputeAPITest, texture_resource_aliasing_test) {
   // and share memory between tensors whenever possible.
 
   std::vector<int64_t> sizes = {4, 4, 1};
-  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
-  vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
-  vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
-  vTensor d = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
-  vTensor e = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  api::vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  api::vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  api::vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  api::vTensor d = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  api::vTensor e = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
 
   // No allocations made so far
   EXPECT_TRUE(get_vma_allocation_count() == 0);
@@ -584,7 +585,7 @@ TEST_F(VulkanComputeAPITest, resource_bind_twice_fails) {
   // fails
 
   std::vector<int64_t> sizes = {4, 4, 1};
-  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
 
   // Try to double bind a resource, which should fail
   api::Allocation a_mem = allocate_memory_for(a);
@@ -592,7 +593,7 @@ TEST_F(VulkanComputeAPITest, resource_bind_twice_fails) {
 }
 
 TEST_F(VulkanComputeAPITest, resource_destructor_non_owning_memory) {
-  // Check that the destructor of a vTensor that does not own its memory
+  // Check that the destructor of a api::vTensor that does not own its memory
   // does not free the memory
 
   api::Allocation memory;
@@ -602,7 +603,7 @@ TEST_F(VulkanComputeAPITest, resource_destructor_non_owning_memory) {
 
   std::vector<int64_t> sizes = {4, 4, 1};
   {
-    vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+    api::vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
 
     memory = allocate_memory_for(a);
     EXPECT_TRUE(get_vma_allocation_count() == 1);
@@ -614,10 +615,11 @@ TEST_F(VulkanComputeAPITest, resource_destructor_non_owning_memory) {
 }
 
 TEST_F(VulkanComputeAPITest, use_non_bound_textures_fails) {
-  // Try to encode a command buffer with a vTensor that does not have memory
+  // Try to encode a command buffer with a api::vTensor that does not have
+  // memory
 
   std::vector<int64_t> sizes = {4, 4, 1};
-  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  api::vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
 
   // No allocations yet
   EXPECT_TRUE(get_vma_allocation_count() == 0);
@@ -625,15 +627,15 @@ TEST_F(VulkanComputeAPITest, use_non_bound_textures_fails) {
   std::vector<float> data_a(a.gpu_numel());
   std::fill(data_a.begin(), data_a.end(), 2.5f);
 
-  // Encoding a command buffer with a vTensor without memory should throw
+  // Encoding a command buffer with a api::vTensor without memory should throw
   EXPECT_THROW(fill_vtensor(a, data_a), api::Error);
 }
 
 TEST_F(VulkanComputeAPITest, tensor_reallocation_test) {
   std::vector<int64_t> sizes = {4, 4, 1};
-  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
-  vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
-  vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
 
   execute_and_check_add(a, b, c, 3.0f, 5.0f);
 
@@ -653,9 +655,9 @@ TEST_F(
     VulkanComputeAPITest,
     tensor_reallocation_with_deferred_allocation_test) {
   std::vector<int64_t> sizes = {8, 8, 8};
-  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
-  vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
-  vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  api::vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  api::vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
+  api::vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ false);
 
   api::Allocation a_mem = allocate_memory_for(a);
   a.image().bind_allocation(a_mem);
@@ -690,9 +692,9 @@ TEST_F(
 TEST_F(VulkanComputeAPITest, texture_virtual_resize) {
   api::context()->set_cmd(/*reusable = */ true);
   std::vector<int64_t> sizes = {8, 12, 12};
-  vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
-  vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
-  vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor a = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor b = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
+  api::vTensor c = CREATE_FLOAT_TEXTURE(sizes, /*allocate_memory = */ true);
 
   DEFINE_STAGING_BUFFER_AND_RECORD_TO_GPU_FOR(a)
   DEFINE_STAGING_BUFFER_AND_RECORD_TO_GPU_FOR(b)
@@ -1694,8 +1696,8 @@ void run_from_gpu_test(
       !api::context()->adapter_ptr()->has_full_int8_buffers_support()) {
     return;
   }
-  vTensor vten =
-      vTensor(api::context(), sizes, dtype, storage_type, memory_layout);
+  api::vTensor vten =
+      api::vTensor(api::context(), sizes, dtype, storage_type, memory_layout);
 
   std::string kernel_name("idx_fill_texture");
   add_memory_layout_suffix(kernel_name, vten);
@@ -1749,8 +1751,8 @@ void run_to_gpu_test(
     return;
   }
 
-  vTensor vten =
-      vTensor(api::context(), sizes, dtype, storage_type, memory_layout);
+  api::vTensor vten =
+      api::vTensor(api::context(), sizes, dtype, storage_type, memory_layout);
 
   // Create and fill input staging buffer
   api::StorageBuffer staging_buffer_in(api::context(), dtype, vten.gpu_numel());
@@ -2145,7 +2147,7 @@ void test_conv2d(
     const std::vector<int64_t>& gpu_sizes,
     const bool transposed,
     const std::vector<float>& data_out_expected) {
-  vTensor vten = vTensor(
+  api::vTensor vten = api::vTensor(
       api::context(),
       gpu_sizes,
       api::kFloat,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4127
* #4125
* __->__ #4124
* #4123
* #4122
* #4121
* #4120
* #4119
* #4118
* #4117
* #4116
* #4115

Then, update usage via
```
find . -type f -exec sed -i 's/vTensor/api::vTensor/g' {} +
find . -type f -exec sed -i 's/api::vTensorPtr/vTensorPtr/g' {} +
```

Differential Revision: [D59281541](https://our.internmc.facebook.com/intern/diff/D59281541/)