### PR TITLE
Add `requires-python = ">=3.10"` to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,12 @@ classifiers = [
     "Programming Language :: Python :: 3",
     # Update this as we support more versions of python.
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 # Python dependencies required for use.
+requires-python = ">=3.10"
 dependencies=[
   "expecttest",
   "flatbuffers",
@@ -93,3 +96,9 @@ flatc = "executorch.data.bin:flatc"
 [tool.usort]
 # Do not try to put "first-party" imports in their own section.
 first_party_detection = false
+
+[tool.black]
+# Emit syntax compatible with older versions of python instead of only the range
+# specified by `requires-python`. TODO: Remove this once we support these older
+# versions of python and can expand the `requires-python` range.
+target-version = ["py38", "py39", "py310", "py311", "py312"]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ import setuptools  # noqa: F401 # usort: skip
 from distutils import log
 from distutils.sysconfig import get_python_lib
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from setuptools import Extension, setup
 from setuptools.command.build import build
@@ -82,23 +82,20 @@ class ShouldBuild:
         return True
 
     @classmethod
-    @property
     def pybindings(cls) -> bool:
         return cls._is_env_enabled("EXECUTORCH_BUILD_PYBIND", default=False)
 
     @classmethod
-    @property
     def llama_custom_ops(cls) -> bool:
         return cls._is_env_enabled("EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT", default=True)
 
     @classmethod
-    @property
     def flatc(cls) -> bool:
         return cls._is_env_enabled("EXECUTORCH_BUILD_FLATC", default=True)
 
 
 class Version:
-    """Static properties that describe the version of the pip package."""
+    """Static strings that describe the version of the pip package."""
 
     # Cached values returned by the properties.
     __root_dir_attr: Optional[str] = None
@@ -106,7 +103,6 @@ class Version:
     __git_hash_attr: Optional[str] = None
 
     @classmethod
-    @property
     def _root_dir(cls) -> str:
         """The path to the root of the git repo."""
         if cls.__root_dir_attr is None:
@@ -115,7 +111,6 @@ class Version:
         return str(cls.__root_dir_attr)
 
     @classmethod
-    @property
     def git_hash(cls) -> Optional[str]:
         """The current git hash, if known."""
         if cls.__git_hash_attr is None:
@@ -124,7 +119,7 @@ class Version:
             try:
                 cls.__git_hash_attr = (
                     subprocess.check_output(
-                        ["git", "rev-parse", "HEAD"], cwd=cls._root_dir
+                        ["git", "rev-parse", "HEAD"], cwd=cls._root_dir()
                     )
                     .decode("ascii")
                     .strip()
@@ -135,7 +130,6 @@ class Version:
         return cls.__git_hash_attr if cls.__git_hash_attr else None
 
     @classmethod
-    @property
     def string(cls) -> str:
         """The version string."""
         if cls.__string_attr is None:
@@ -147,10 +141,10 @@ class Version:
                 # Otherwise, read the version from a local file and add the git
                 # commit if available.
                 version = (
-                    open(os.path.join(cls._root_dir, "version.txt")).read().strip()
+                    open(os.path.join(cls._root_dir(), "version.txt")).read().strip()
                 )
-                if cls.git_hash:
-                    version += "+" + cls.git_hash[:7]
+                if cls.git_hash():
+                    version += "+" + cls.git_hash()[:7]
             cls.__string_attr = version
         return cls.__string_attr
 
@@ -160,9 +154,9 @@ class Version:
         lines = [
             "from typing import Optional",
             '__all__ = ["__version__", "git_version"]',
-            f'__version__ = "{cls.string}"',
+            f'__version__ = "{cls.string()}"',
             # A string or None.
-            f"git_version: Optional[str] = {repr(cls.git_hash)}",
+            f"git_version: Optional[str] = {repr(cls.git_hash())}",
         ]
         with open(path, "w") as fp:
             fp.write("\n".join(lines) + "\n")
@@ -480,7 +474,7 @@ class CustomBuild(build):
         # extension entries themselves instead of hard-coding them here.
         build_args += ["--target", "flatc"]
 
-        if ShouldBuild.pybindings:
+        if ShouldBuild.pybindings():
             cmake_args += [
                 "-DEXECUTORCH_BUILD_PYBIND=ON",
                 "-DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON",  # add quantized ops to pybindings.
@@ -491,7 +485,7 @@ class CustomBuild(build):
             # add entries like `-DEXECUTORCH_BUILD_XNNPACK=ON` to the CMAKE_ARGS
             # environment variable.
 
-        if ShouldBuild.llama_custom_ops:
+        if ShouldBuild.llama_custom_ops():
             cmake_args += [
                 "-DEXECUTORCH_BUILD_KERNELS_CUSTOM=ON",  # add llama sdpa ops to pybindings.
                 "-DEXECUTORCH_BUILD_KERNELS_CUSTOM_AOT=ON",
@@ -553,16 +547,16 @@ class CustomBuild(build):
         build.run(self)
 
 
-def get_ext_modules() -> list[Extension]:
+def get_ext_modules() -> List[Extension]:
     """Returns the set of extension modules to build."""
 
     ext_modules = []
-    if ShouldBuild.flatc:
+    if ShouldBuild.flatc():
         ext_modules.append(
             BuiltFile("third-party/flatbuffers/flatc", "executorch/data/bin/")
         )
 
-    if ShouldBuild.pybindings:
+    if ShouldBuild.pybindings():
         ext_modules.append(
             # Install the prebuilt pybindings extension wrapper for the runtime,
             # portable kernels, and a selection of backends. This lets users
@@ -571,7 +565,7 @@ def get_ext_modules() -> list[Extension]:
                 "_portable_lib.*", "executorch.extension.pybindings._portable_lib"
             )
         )
-    if ShouldBuild.llama_custom_ops:
+    if ShouldBuild.llama_custom_ops():
         ext_modules.append(
             # Install the prebuilt library for custom ops used in llama.
             BuiltFile(
@@ -588,7 +582,7 @@ def get_ext_modules() -> list[Extension]:
 
 
 setup(
-    version=Version.string,
+    version=Version.string(),
     # TODO(dbort): Could use py_modules to restrict the set of modules we
     # package, and package_data to restrict the set up non-python files we
     # include. See also setuptools/discovery.py for custom finders.


### PR DESCRIPTION
We only support python 3.10/3.11/3.12 right now, so make that explicit.

The last time I tried to do this, the linter tried to force us to use
new-in-3.10 syntax. I was able to avoid that this time by telling the
`black` formatter to use a larger range of python versions.

Also modify setup.py to be 3.8 and 3.13 compatible so that it can run
and complain about the version mismatch instead of just failing to run.

Then, to save users some time, check the version in
install_requirements.sh before doing any real work.

And `cd` to the script's directory before starting so that users can
invoke it like `/path/to/executorch/install_requirements.sh`.

Test Plan:
Built wheels in CI by adding the `ciflow/binaries/all` label.

Linted all python files:
```
find . -type f -name "*.py" | grep -vE 'third-party|cmake-out|pip-out' > /tmp/f
lintrunner --paths-cmd='cat /tmp/f'
```

Also created a conda environment with python 3.8 and ran
`install_requirements.sh` (without the fail-fast check). It used to
fail on syntax errors, but now it fails because the version can't be
satisfied.

To test the fail-fast logic, ran install_requirements.sh in 3.8 and 3.10
conda environments, and saw that it failed/passed as expected.

To test the failure cases, made some local modifications and saw that it
continued to build the wheel after printing a warning:
- Remove/rename pyproject.toml
- Remove the `requires-python` line from pyproject.toml
- Modify the `requires-python` line to contain an invalid range
- Import a missing module in the `python_is_compatible()` code

To test the new `cd` logic:
```
cd build
../install_requirements.sh  # This worked
```