### PR TITLE
Port ArchProbe as GPUInfo - Initial Skeleton

### DIFF
--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -1,3 +1,8 @@
+load("@fbsource//tools/build_defs:fb_xplat_cxx_binary.bzl", "fb_xplat_cxx_binary")
+load(
+    "@fbsource//tools/build_defs:platform_defs.bzl",
+    "ANDROID",
+)
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 def get_vulkan_compiler_flags():
@@ -216,4 +221,24 @@ def define_common_targets(is_fbcode = False):
         # VulkanBackend.cpp needs to compile with executor as whole
         # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
         link_whole = True,
+    )
+
+    fb_xplat_cxx_binary(
+        name = "vulkan_gpuinfo",
+        srcs = native.glob([
+            "tools/gpuinfo/**/*.cpp",
+        ]),
+        compiler_flags = get_vulkan_compiler_flags(),
+        raw_headers = native.glob([
+            "tools/gpuinfo/**/*.h",
+        ]),
+        headers = native.glob([
+            "tools/gpuinfo/**/*.h",
+        ]),
+        include_directories = ["tools/gpuinfo/include"],
+        header_namespace = "include",
+        platforms = ANDROID,
+        deps = [
+            "//xplat/executorch/backends/vulkan:vulkan_graph_runtime",
+        ],
     )

--- a/backends/vulkan/tools/gpuinfo/apps/app.cpp
+++ b/backends/vulkan/tools/gpuinfo/apps/app.cpp
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/microsoft/ArchProbe/blob/main/apps/archprobe/app.cpp
+// MIT-licensed by Rendong Liang.
+
+#include <signal.h>
+#include "args.h"
+#include "env.h"
+#include "stats.h"
+
+using namespace gpuinfo;
+using namespace gpuinfo::stats;
+
+namespace {
+
+void log_cb(log::LogLevel lv, const std::string& msg) {
+  using log::LogLevel;
+  switch (lv) {
+    case LogLevel::L_LOG_LEVEL_DEBUG:
+      printf("[\x1b[90mDEBUG\x1B[0m] %s\n", msg.c_str());
+      break;
+    case LogLevel::L_LOG_LEVEL_INFO:
+      printf("[\x1B[32mINFO\x1B[0m] %s\n", msg.c_str());
+      break;
+    case LogLevel::L_LOG_LEVEL_WARNING:
+      printf("[\x1B[33mWARN\x1B[0m] %s\n", msg.c_str());
+      break;
+    case LogLevel::L_LOG_LEVEL_ERROR:
+      printf("[\x1B[31mERROR\x1B[0m] %s\n", msg.c_str());
+      break;
+  }
+  std::fflush(stdout);
+}
+
+} // namespace
+
+namespace gpuinfo {
+
+std::string vec_name_by_ncomp(const char* scalar_name, uint32_t ncomp) {
+  return scalar_name + (ncomp == 1 ? "" : std::to_string(ncomp));
+}
+std::string vec_name_by_ncomp_log2(
+    const char* scalar_name,
+    uint32_t ncomp_log2) {
+  return vec_name_by_ncomp(scalar_name, 1 << ncomp_log2);
+}
+
+template <typename T>
+bool is_pow2(T x) {
+  return (x & (-x)) == x;
+}
+template <typename T>
+T next_pow2(T x) {
+  T y = 1;
+  for (; y < x; y <<= 1) {
+  }
+  return y;
+}
+
+// Power of integer.
+template <typename T>
+T powi(T x, T p) {
+  if (p == 0) {
+    return 1;
+  }
+  if (p == 1) {
+    return x;
+  }
+  return x * powi(x, p - 1);
+}
+// Log2 of integer. 0 is treated as two-to-the-zero.
+template <typename T>
+T log2i(T x) {
+  T counter = 0;
+  while (x >= 2) {
+    x >>= 1;
+    ++counter;
+  }
+  return counter;
+}
+
+using Aspect = std::function<void(Environment&)>;
+
+class GPUInfo {
+  Environment env_;
+
+ public:
+  GPUInfo(uint32_t idev) : env_(idev) {}
+
+  GPUInfo& with_aspect(const Aspect& aspect) {
+    aspect(env_);
+    return *this;
+  }
+
+  void clear_aspect_report(const std::string& aspect) {
+    env_.clear_aspect_report(aspect);
+  }
+};
+
+template <uint32_t NTap>
+struct DtJumpFinder {
+ private:
+  NTapAvgStats<double, NTap> time_avg_;
+  AvgStats<double> dtime_avg_;
+  double compensation_;
+  double threshold_;
+
+ public:
+  // Compensation is a tiny additive to give on delta time so that the algorithm
+  // works smoothly when a sequence of identical timing is ingested, which is
+  // pretty common in our tests. Threshold is simply how many times the new
+  // delta has to be to be recognized as a deviation.
+  DtJumpFinder(double compensation = 0.01, double threshold = 10)
+      : time_avg_(),
+        dtime_avg_(),
+        compensation_(compensation),
+        threshold_(threshold) {}
+
+  // Returns true if the delta time regarding to the last data point seems
+  // normal; returns false if it seems the new data point is too much away from
+  // the historical records.
+  bool push(double time) {
+    if (time_avg_.has_value()) {
+      double dtime = std::abs(time - time_avg_) + (compensation_ * time_avg_);
+      if (dtime_avg_.has_value()) {
+        double ddtime = std::abs(dtime - dtime_avg_);
+        if (ddtime > threshold_ * dtime_avg_) {
+          return true;
+        }
+      }
+      dtime_avg_.push(dtime);
+    }
+    time_avg_.push(time);
+    return false;
+  }
+
+  double dtime_avg() const {
+    return dtime_avg_;
+  }
+  double compensate_time() const {
+    return compensation_ * time_avg_;
+  }
+};
+
+namespace aspects {} // namespace aspects
+
+static std::unique_ptr<GPUInfo> APP = nullptr;
+
+void guarded_main(const std::string& clear_aspect) {
+  // TODO: Transcribe to Vulkan
+  /*
+  cl_int err;
+
+  gpuinfo::initialize();
+  */
+
+  APP = std::make_unique<GPUInfo>(0);
+  APP->clear_aspect_report(clear_aspect);
+  (*APP);
+
+  APP.reset();
+}
+
+void sigproc(int sig) {
+  const char* sig_name = "UNKNOWN SIGNAL";
+#ifdef _WIN32
+#define SIGHUP 1
+#define SIGQUIT 3
+#define SIGTRAP 5
+#define SIGKILL 9
+#endif
+  switch (sig) {
+    // When you interrupt adb, and adb kills GPUInfo in its SIGINT process.
+    case SIGHUP:
+      sig_name = "SIGHUP";
+      break;
+    // When you interrupt in an `adb shell` session.
+    case SIGINT:
+      sig_name = "SIGINT";
+      break;
+    // Other weird cases.
+    case SIGQUIT:
+      sig_name = "SIGQUIT";
+      break;
+    case SIGTRAP:
+      sig_name = "SIGTRAP";
+      break;
+    case SIGABRT:
+      sig_name = "SIGABRT";
+      break;
+    case SIGTERM:
+      sig_name = "SIGTERM";
+      break;
+    case SIGKILL:
+      sig_name = "SIGKILL";
+      break;
+  }
+  log::error("captured ", sig_name, "! progress is saved");
+  APP.reset();
+  std::exit(1);
+}
+
+} // namespace gpuinfo
+
+struct AppConfig {
+  bool verbose;
+  std::string clear_aspect;
+};
+
+AppConfig configurate(int argc, const char** argv) {
+  using namespace gpuinfo::args;
+  AppConfig cfg{};
+  init_arg_parse("GPUInfo", "Discover hardware details by micro-benchmarks.");
+  reg_arg<SwitchParser>(
+      "-v", "--verbose", cfg.verbose, "Print more detail for debugging.");
+  reg_arg<StringParser>(
+      "-c",
+      "--clear",
+      cfg.clear_aspect,
+      "Clear the results of specified aspect.");
+  parse_args(argc, argv);
+  return cfg;
+}
+
+int main(int argc, const char** argv) {
+  log::set_log_callback(log_cb);
+  AppConfig cfg = configurate(argc, argv);
+  if (cfg.verbose) {
+    log::set_log_filter_level(log::LogLevel::L_LOG_LEVEL_DEBUG);
+  } else {
+    log::set_log_filter_level(log::LogLevel::L_LOG_LEVEL_INFO);
+  }
+
+  signal(SIGHUP, gpuinfo::sigproc);
+  signal(SIGINT, gpuinfo::sigproc);
+  signal(SIGQUIT, gpuinfo::sigproc);
+  signal(SIGTRAP, gpuinfo::sigproc);
+  signal(SIGABRT, gpuinfo::sigproc);
+  signal(SIGTERM, gpuinfo::sigproc);
+  signal(SIGKILL, gpuinfo::sigproc);
+
+  try {
+    gpuinfo::guarded_main(cfg.clear_aspect);
+  } catch (const std::exception& e) {
+    log::error("application threw an exception");
+    log::error(e.what());
+    log::error("application cannot continue");
+  } catch (...) {
+    log::error("application threw an illiterate exception");
+  }
+
+  return 0;
+}

--- a/backends/vulkan/tools/gpuinfo/apps/env.cpp
+++ b/backends/vulkan/tools/gpuinfo/apps/env.cpp
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/microsoft/ArchProbe/blob/main/apps/archprobe/env.cpp
+// MIT-licensed by Rendong Liang.
+
+#include "env.h"
+
+namespace gpuinfo {
+
+std::string pretty_data_size(size_t size) {
+  const size_t K = 1024;
+  if (size < K) {
+    return util::format(size, "B");
+  }
+  size /= K;
+  if (size < K) {
+    return util::format(size, "KB");
+  }
+  size /= K;
+  if (size < K) {
+    return util::format(size, "MB");
+  }
+  size /= K;
+  if (size < K) {
+    return util::format(size, "GB");
+  }
+  size /= K;
+  if (size < K) {
+    return util::format(size, "TB");
+  }
+  size /= K;
+  gpuinfo::panic("unsupported data size");
+  return {};
+}
+
+json::JsonValue load_env_cfg(const char* path) {
+  try {
+    auto json_txt = util::load_text(path);
+    log::debug("loaded configuration '", json_txt, "'");
+    json::JsonValue out{};
+    if (json::try_parse(json_txt, out)) {
+      gpuinfo::assert(out.is_obj());
+      return out;
+    } else {
+      log::warn(
+          "failed to parse environment config from '",
+          path,
+          "', a default configuration will be created to overwrite it");
+      return json::JsonObject{};
+    }
+  } catch (gpuinfo::AssertionFailedException) {
+    log::warn(
+        "configuration file cannot be opened at '",
+        path,
+        "', a default configuration will be created");
+    return json::JsonObject{};
+  }
+}
+
+json::JsonValue load_report(const char* path) {
+  try {
+    auto json_txt = util::load_text(path);
+    log::debug("loaded report '", json_txt, "'");
+    json::JsonValue out{};
+    if (json::try_parse(json_txt, out)) {
+      gpuinfo::assert(out.is_obj());
+      return out;
+    } else {
+      log::warn(
+          "failed to parse report from '",
+          path,
+          "', a new report "
+          "will be created to overwrite it");
+      return json::JsonObject{};
+    }
+  } catch (gpuinfo::AssertionFailedException) {
+    log::warn(
+        "report file cannot be opened at '",
+        path,
+        "', a new "
+        "report will be created");
+    return json::JsonObject{};
+  }
+}
+
+void report_dev(Environment& env) {
+  if (env.report_started_lazy("Device")) {
+    return;
+  }
+  env.report_value("SmCount", env.dev_report.nsm);
+  env.report_value("LogicThreadCount", env.dev_report.nthread_logic);
+  env.report_value("MaxBufferSize", env.dev_report.buf_size_max);
+  env.report_value("MaxConstMemSize", env.dev_report.const_mem_size_max);
+  env.report_value("MaxLocalMemSize", env.dev_report.local_mem_size_max);
+  env.report_value("CacheSize", env.dev_report.buf_cache_size);
+  env.report_value("CachelineSize", env.dev_report.buf_cacheline_size);
+  if (env.dev_report.support_img) {
+    env.report_value("MaxImageWidth", env.dev_report.img_width_max);
+    env.report_value("MaxImageHeight", env.dev_report.img_height_max);
+  }
+  if (env.dev_report.has_page_size) {
+    env.report_value("PageSize_QCOM", env.dev_report.page_size);
+  }
+  env.report_ready(true);
+}
+
+Environment::Environment(
+    uint32_t idev,
+    const char* cfg_path,
+    const char* report_path)
+    : // TODO: Transcribe to Vulkan
+      /*
+        dev_(gpuinfo::select_dev(idev)),
+        ctxt_(gpuinfo::create_ctxt(dev_)),
+        cmd_queue_(gpuinfo::create_cmd_queue(ctxt_)),
+      */
+      aspects_started_(),
+      cur_aspect_(),
+      cur_table_(nullptr),
+      cfg_path_(cfg_path),
+      report_path_(report_path),
+      cfg_(load_env_cfg(cfg_path)),
+      report_(load_report(report_path)),
+      dev_report(/*collect_dev_report(dev_)*/),
+      my_report() {
+  report_dev(*this);
+}
+Environment::~Environment() {
+  util::save_text(cfg_path_.c_str(), json::print(cfg_));
+  log::info("saved configuration to '", cfg_path_, "'");
+  util::save_text(report_path_.c_str(), json::print(report_));
+  log::info("saved report to '", report_path_, "'");
+}
+
+void Environment::report_started(const std::string& aspect_name) {
+  gpuinfo::assert(!aspect_name.empty(), "aspect name cannot be empty");
+  aspects_started_.insert(aspect_name);
+  log::info("[", aspect_name, "]");
+  log::push_indent();
+  cur_aspect_ = aspect_name;
+}
+bool Environment::report_started_lazy(const std::string& aspect_name) {
+  auto aspect_it = report_.obj.find(aspect_name);
+  if (aspect_it == report_.obj.end() || !aspect_it->second.is_obj()) {
+    report_started(aspect_name);
+    return false;
+  }
+  auto done_it = aspect_it->second.obj.find("Done");
+  if (done_it == aspect_it->second.obj.end() || !done_it->second.is_bool()) {
+    report_started(aspect_name);
+    return false;
+  }
+  if (done_it->second.b) {
+    log::info("ignored aspect '", aspect_name, "' because it's done");
+    return true;
+  } else {
+    report_started(aspect_name);
+    return false;
+  }
+}
+void Environment::report_ready(bool done) {
+  gpuinfo::assert(
+      !cur_aspect_.empty(),
+      "announcing ready for an not-yet-started report is not allowed");
+  gpuinfo::assert(
+      aspects_started_.find(cur_aspect_) != aspects_started_.end(),
+      "aspect has not report to start yet");
+  report_value("Done", done);
+  if (cur_table_ != nullptr) {
+    auto csv = cur_table_->to_csv();
+    auto fname = util::format(cur_aspect_, ".csv");
+    util::save_text(fname.c_str(), csv);
+    log::info("saved data table to '", fname, "'");
+    cur_table_ = nullptr;
+  }
+  cur_aspect_ = {};
+  log::pop_indent();
+}
+void Environment::check_dep(const std::string& aspect_name) {
+  bool done = false;
+  gpuinfo::assert(
+      try_get_aspect_report(aspect_name, "Done", done) && done,
+      "aspect '",
+      aspect_name,
+      "' is required but is not ready yet");
+}
+
+table::Table& Environment::table() {
+  gpuinfo::assert(cur_table_ != nullptr, "requested table is not initialized");
+  return *cur_table_;
+}
+
+// Find the minimal number of iterations that a kernel can run up to
+// `min_time_us` microseconds.
+void Environment::ensure_min_niter(
+    double min_time_us,
+    uint32_t& niter,
+    std::function<double()> run) {
+  const uint32_t DEFAULT_NITER = 100;
+  niter = DEFAULT_NITER;
+  for (uint32_t i = 0; i < 100; ++i) {
+    double t = run();
+    if (t > min_time_us * 0.99) {
+      log::info("found minimal niter=", niter, " to take ", min_time_us, "us");
+      return;
+    }
+    log::debug(
+        "niter=",
+        niter,
+        " doesn't run long enough (",
+        t,
+        "us <= ",
+        min_time_us,
+        "us)");
+    niter = uint32_t(niter * min_time_us / t);
+  }
+  gpuinfo::panic(
+      "unable to find a minimal iteration number for ",
+      cur_aspect_,
+      "; is your code aggresively optimized by the compiler?");
+}
+
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/apps/env.h
+++ b/backends/vulkan/tools/gpuinfo/apps/env.h
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/microsoft/ArchProbe/blob/main/apps/archprobe/env.hpp
+// MIT-licensed by Rendong Liang.
+
+#pragma once
+#include <functional>
+#include <map>
+#include <memory>
+#include <set>
+#include "assert.h"
+#include "json.h"
+#include "log.h"
+#include "table.h"
+#define CL_TARGET_OPENCL_VERSION 200
+#define CL_HPP_TARGET_OPENCL_VERSION CL_TARGET_OPENCL_VERSION
+
+namespace gpuinfo {
+
+std::string pretty_data_size(size_t size);
+
+struct DeviceReport {
+  bool has_page_size;
+  size_t page_size;
+
+  size_t buf_cacheline_size;
+  size_t buf_size_max;
+  size_t buf_cache_size;
+
+  size_t const_mem_size_max;
+  size_t local_mem_size_max;
+
+  bool support_img;
+  uint32_t img_width_max;
+  uint32_t img_height_max;
+
+  uint32_t nsm;
+  uint32_t nthread_logic;
+};
+struct ProfiledReport {
+  double timing_std;
+
+  std::map<uint32_t, uint32_t> nthread_logic_for_nreg;
+
+  double gflops_fp16;
+  double gflops_fp32;
+  double gflops_int32;
+  uint32_t nmin_warp;
+  uint32_t nwarp;
+  uint32_t nthread_phys;
+  uint32_t nthread_warp;
+  uint32_t nthread_min_warp;
+
+  uint32_t buf_vec_width;
+  std::string buf_vec_ty;
+  uint32_t buf_cacheline_size;
+  std::vector<uint32_t> buf_cache_sizes;
+
+  uint32_t img_cacheline_size;
+  std::vector<uint32_t> img_cache_sizes;
+  double img_bandwidth;
+};
+class Environment {
+  // TODO: Transcribe to Vulkan
+  // cl::Device dev_;
+  // cl::Context ctxt_;
+  // cl::CommandQueue cmd_queue_;
+  std::set<std::string> aspects_started_;
+  std::string cur_aspect_;
+  std::unique_ptr<table::Table> cur_table_;
+  std::string cfg_path_;
+  std::string report_path_;
+  json::JsonValue cfg_;
+  json::JsonValue report_;
+
+ public:
+  const DeviceReport dev_report;
+  ProfiledReport my_report;
+
+  Environment(
+      uint32_t idev,
+      const char* cfg_path = "GPUInfo.json",
+      const char* report_path = "GPUInfoReport.json");
+  ~Environment();
+
+  void report_started(const std::string& aspect_name);
+  // Returns false if there is no existing report about the aspect to be started
+  // or such report is not yet marked with '"Done": true'. It means that when
+  // this method returns true, the aspect can return right a way.
+  bool report_started_lazy(const std::string& aspect_name);
+  void report_ready(bool done = false);
+  void check_dep(const std::string& aspect_name);
+
+  template <typename... TArgs>
+  void init_table(TArgs&&... args) {
+    gpuinfo::assert(
+        !cur_aspect_.empty(),
+        "table can only be initialized in scope of a report");
+    log::info("initialized table for aspect '", cur_aspect_, "'");
+    cur_table_ = std::make_unique<table::Table>(args...);
+  }
+  table::Table& table();
+
+  inline json::JsonValue& get_aspect_cfg(const std::string& aspect) {
+    auto it = cfg_.obj.find(aspect);
+    if (it == cfg_.obj.end() || !it->second.is_obj()) {
+      log::warn(
+          "aspect configuration ('",
+          cur_aspect_,
+          "') is invalid, "
+          "a new record is created");
+      cfg_.obj[aspect] = json::JsonObject{};
+    }
+    return cfg_.obj[aspect];
+  }
+  inline json::JsonValue& get_cfg() {
+    return get_aspect_cfg(cur_aspect_);
+  }
+  template <typename T>
+  inline T cfg_num(const std::string& name, T default_value) {
+    auto& cfg = get_cfg();
+    if (cfg.obj.find(name) == cfg_.obj.end() || !cfg.obj[name].is_num()) {
+      log::warn(
+          "record entry ('",
+          name,
+          "') is invalid, a new record "
+          "is created");
+      cfg.obj[name] = json::JsonValue(default_value);
+    }
+    return (T)cfg[name];
+  }
+
+  inline json::JsonValue& get_report() {
+    return get_aspect_report(cur_aspect_);
+  }
+  inline json::JsonValue& get_aspect_report(const std::string& aspect) {
+    auto it = report_.obj.find(aspect);
+    if (it == report_.obj.end() || !it->second.is_obj()) {
+      log::warn(
+          "aspect report ('",
+          aspect,
+          "') is invalid, a new record is "
+          "created");
+      report_.obj[aspect] = json::JsonObject{};
+    }
+    return report_.obj[aspect];
+  }
+  template <typename T>
+  inline bool try_get_report(const std::string& name, T& out) {
+    return try_get_aspect_report(cur_aspect_, name, out);
+  }
+  template <typename T>
+  inline bool try_get_aspect_report(
+      const std::string& aspect,
+      const std::string& name,
+      T& out) {
+    const auto& report = get_aspect_report(aspect);
+    auto it = report.obj.find(name);
+    if (it == report.obj.end()) {
+      return false;
+    } else {
+      out = (T)it->second;
+      log::info(
+          "already know that '", name, "' from aspect '", aspect, "' is ", out);
+      return true;
+    }
+  }
+  template <typename T>
+  inline T must_get_aspect_report(
+      const std::string& aspect,
+      const std::string& name) {
+    T out;
+    gpuinfo::assert(
+        try_get_aspect_report(aspect, name, out),
+        "cannot get report '",
+        name,
+        "' from aspect '",
+        aspect,
+        "'");
+    return out;
+  }
+  template <typename T>
+  inline void report_value(const std::string& name, T value) {
+    auto& report = get_report();
+    log::info("reported '", name, "' = '", value, "'");
+    report.obj[name] = json::JsonValue(value);
+  }
+
+  inline void clear_aspect_report(const std::string& aspect) {
+    if (!aspect.empty()) {
+      get_aspect_report(aspect) = json::JsonObject{};
+      log::info("cleared report of aspect '", aspect, "'");
+    }
+  }
+
+  void ensure_min_niter(
+      double min_time_us,
+      uint32_t& niter,
+      std::function<double()> run);
+};
+
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/build_gpuinfo.sh
+++ b/backends/vulkan/tools/gpuinfo/build_gpuinfo.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+buck2 build //xplat/executorch/backends/vulkan:vulkan_gpuinfo --target-platforms=ovr_config//platform/android:arm64-fbsource --show-output -c ndk.static_linking=true -c ndk.debug_info_level=1 -c executorch.event_tracer_enabled=true

--- a/backends/vulkan/tools/gpuinfo/include/args.h
+++ b/backends/vulkan/tools/gpuinfo/include/args.h
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/PENGUINLIONG/graphi-t/blob/da31ec530df07c9899e056eeced08a64062dcfce/args.hpp;
+// MIT-licensed by Rendong Liang.
+
+// Argument parsing utilities.
+// @PENGUINLIONG
+#pragma once
+#include <string>
+
+namespace gpuinfo {
+
+namespace args {
+
+struct ArgumentParseConfig {
+  // Expected number of arguments segments.
+  uint32_t narg;
+  // Returns true if the parsing is successful.
+  bool (*parser)(const char*[], void*);
+  // Returns the literal of default value.
+  std::string (*lit)(const void*);
+  // Destination to be written with parsed value.
+  void* dst;
+};
+
+// Optionally initialize argument parser with application name and usage
+// description.
+extern void init_arg_parse(const char* app_name, const char* desc);
+// Get the name of this app set by the user. Empty string is returned if this
+// function is called before `init_arg_parse`.
+extern const char* get_app_name();
+// Print help message to the standard output.
+extern void print_help();
+// Erase the type of argument parser and bind the type-erased parser to the
+// value destination. User code MUST ensure the `dst` buffer can contain the
+// parsing result.
+template <typename TTypedParser>
+ArgumentParseConfig make_parse_cfg(void* dst) {
+  ArgumentParseConfig parse_cfg;
+  parse_cfg.narg = TTypedParser::narg;
+  parse_cfg.dst = dst;
+  parse_cfg.parser = &TTypedParser::parse;
+  parse_cfg.lit = &TTypedParser::lit;
+  return parse_cfg;
+}
+// Register customized argument parsing.
+extern void reg_arg(
+    const char* short_flag,
+    const char* long_flag,
+    const ArgumentParseConfig& parse_cfg,
+    const char* help);
+// Register a structural argument parsing.
+template <typename TTypedParser>
+inline void reg_arg(
+    const char* short_flag,
+    const char* long_flag,
+    typename TTypedParser::arg_ty& dst,
+    const char* help) {
+  reg_arg(short_flag, long_flag, make_parse_cfg<TTypedParser>(&dst), help);
+}
+// Parse arguments. Arguments will be matched against argument parsers
+// registered before.
+extern void parse_args(int argc, const char** argv);
+
+//
+// Parsers.
+//
+
+template <typename T>
+struct TypedArgumentParser {
+  typedef struct {
+  } arg_ty;
+  // Number of argument entries needed for this argument.
+  static const uint32_t narg = -1;
+  // Parser function. Convert the literal in the first parameter into structured
+  // native representation. Return `true` on success.
+  static bool parse(const char* lit[], void* dst) {
+    return false;
+  }
+  static std::string lit(const void* src) {
+    return {};
+  }
+};
+template <>
+struct TypedArgumentParser<std::string> {
+  typedef std::string arg_ty;
+  static const uint32_t narg = 1;
+  static bool parse(const char* lit[], void* dst) {
+    *(std::string*)dst = lit[0];
+    return true;
+  }
+  static std::string lit(const void* src) {
+    return *(const std::string*)src;
+  }
+};
+template <>
+struct TypedArgumentParser<int32_t> {
+  typedef int arg_ty;
+  static const uint32_t narg = 1;
+  static bool parse(const char* lit[], void* dst) {
+    *(int32_t*)dst = std::atoi(lit[0]);
+    return true;
+  }
+  static std::string lit(const void* src) {
+    return std::to_string(*(const arg_ty*)src);
+  }
+};
+template <>
+struct TypedArgumentParser<uint32_t> {
+  typedef uint32_t arg_ty;
+  static const uint32_t narg = 1;
+  static bool parse(const char* lit[], void* dst) {
+    *(uint32_t*)dst = std::atoi(lit[0]);
+    return true;
+  }
+  static std::string lit(const void* src) {
+    return std::to_string(*(const arg_ty*)src);
+  }
+};
+template <>
+struct TypedArgumentParser<float> {
+  typedef float arg_ty;
+  static const uint32_t narg = 1;
+  static bool parse(const char* lit[], void* dst) {
+    *(float*)dst = std::atof(lit[0]);
+    return true;
+  }
+  static std::string lit(const void* src) {
+    return std::to_string(*(const arg_ty*)src);
+  }
+};
+// NOTE: This is used for arguments like `-f true` and `-f false`. If you need a
+// boolean argument that don't need to be set explicitly. Use
+// `SwitchArgumentParser` instead.
+template <>
+struct TypedArgumentParser<bool> {
+  typedef bool arg_ty;
+  static const uint32_t narg = 1;
+  static bool parse(const char* lit[], void* dst) {
+    if (strcmp(lit[0], "true") == 0 || strcmp(lit[0], "True") == 0) {
+      *(bool*)dst = true;
+      return true;
+    } else if (strcmp(lit[0], "false") == 0 || strcmp(lit[0], "False") == 0) {
+      *(bool*)dst = false;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  static std::string lit(const void* src) {
+    if (*(const arg_ty*)src) {
+      return "true";
+    } else {
+      return "false";
+    }
+  }
+};
+struct SwitchArgumentParser {
+  typedef bool arg_ty;
+  static const uint32_t narg = 0;
+  static bool parse(const char* lit[], void* dst) {
+    *(bool*)dst = true;
+    return true;
+  }
+  static std::string lit(const void* src) {
+    return {};
+  }
+};
+
+using IntParser = TypedArgumentParser<int32_t>;
+using UintParser = TypedArgumentParser<uint32_t>;
+using FloatParser = TypedArgumentParser<float>;
+using BoolParser = TypedArgumentParser<bool>;
+using StringParser = TypedArgumentParser<std::string>;
+using SwitchParser = SwitchArgumentParser;
+
+} // namespace args
+
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/include/assert.h
+++ b/backends/vulkan/tools/gpuinfo/include/assert.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/PENGUINLIONG/graphi-t/blob/d291c3d1ce3795fe4b305e5efd76b4f586d23e3b/assert.hpp;
+// MIT-licensed by Rendong Liang.
+
+// Assertion.
+// @PENGUINLIONG
+#pragma once
+#include "util.h"
+#undef assert
+
+namespace gpuinfo {
+
+class AssertionFailedException : public std::exception {
+  std::string msg;
+
+ public:
+  AssertionFailedException(const std::string& msg);
+
+  const char* what() const noexcept override;
+};
+
+template <typename... TArgs>
+inline void assert(bool pred, const TArgs&... args) {
+  if (!pred) {
+    throw AssertionFailedException(util::format(args...));
+  }
+}
+template <typename... TArgs>
+inline void panic(const TArgs&... args) {
+  assert<TArgs...>(false, args...);
+}
+template <typename... TArgs>
+inline void unreachable(const TArgs&... args) {
+  assert<const char*, TArgs...>(false, "reached unreachable code: ", args...);
+}
+
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/include/json.h
+++ b/backends/vulkan/tools/gpuinfo/include/json.h
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/PENGUINLIONG/graphi-t/blob/da31ec530df07c9899e056eeced08a64062dcfce/json.hpp;
+// MIT-licensed by Rendong Liang.
+
+// JSON serialization/deserialization.
+// @PENGUINLIONG
+#pragma once
+#include <map>
+#include <string>
+#include <vector>
+
+namespace gpuinfo {
+namespace json {
+
+// Any error occured during JSON serialization/deserialization.
+class JsonException : public std::exception {
+ private:
+  std::string msg;
+
+ public:
+  JsonException(const char* msg);
+  const char* what() const noexcept override;
+};
+
+// Type of JSON value.
+enum JsonType {
+  L_JSON_NULL,
+  L_JSON_BOOLEAN,
+  L_JSON_NUMBER,
+  L_JSON_STRING,
+  L_JSON_OBJECT,
+  L_JSON_ARRAY,
+};
+
+struct JsonValue;
+
+class JsonElementEnumerator {
+  std::vector<JsonValue>::const_iterator beg_, end_;
+
+ public:
+  JsonElementEnumerator(const std::vector<JsonValue>& arr)
+      : beg_(arr.cbegin()), end_(arr.cend()) {}
+
+  std::vector<JsonValue>::const_iterator begin() const {
+    return beg_;
+  }
+  std::vector<JsonValue>::const_iterator end() const {
+    return end_;
+  }
+};
+
+class JsonFieldEnumerator {
+  std::map<std::string, JsonValue>::const_iterator beg_, end_;
+
+ public:
+  JsonFieldEnumerator(const std::map<std::string, JsonValue>& obj)
+      : beg_(obj.cbegin()), end_(obj.cend()) {}
+
+  std::map<std::string, JsonValue>::const_iterator begin() const {
+    return beg_;
+  }
+  std::map<std::string, JsonValue>::const_iterator end() const {
+    return end_;
+  }
+};
+
+struct JsonObject;
+struct JsonArray;
+
+// Represent a abstract value in JSON representation.
+struct JsonValue {
+  JsonType ty;
+  bool b;
+  double num;
+  std::string str;
+  std::map<std::string, JsonValue> obj;
+  std::vector<JsonValue> arr;
+
+  inline JsonValue() : ty(L_JSON_NULL) {}
+  inline JsonValue(nullptr_t) : ty(L_JSON_NULL) {}
+  inline JsonValue(bool b) : ty(L_JSON_BOOLEAN), b(b) {}
+  inline JsonValue(double num) : ty(L_JSON_NUMBER), num(num) {}
+  inline JsonValue(float num) : ty(L_JSON_NUMBER), num(num) {}
+  inline JsonValue(int num) : ty(L_JSON_NUMBER), num(num) {}
+  inline JsonValue(unsigned int num) : ty(L_JSON_NUMBER), num(num) {}
+  inline JsonValue(long num) : ty(L_JSON_NUMBER), num(num) {}
+  inline JsonValue(unsigned long num) : ty(L_JSON_NUMBER), num(num) {}
+  inline JsonValue(const char* str) : ty(L_JSON_STRING), str(str) {}
+  inline JsonValue(const std::string& str) : ty(L_JSON_STRING), str(str) {}
+  inline JsonValue(std::string&& str)
+      : ty(L_JSON_STRING), str(std::forward<std::string>(str)) {}
+  JsonValue(JsonObject&& obj);
+  JsonValue(JsonArray&& arr);
+
+  inline JsonValue& operator[](const char* key) {
+    if (!is_obj()) {
+      throw JsonException("value is not an object");
+    }
+    return obj.at(key);
+  }
+  inline const JsonValue& operator[](const char* key) const {
+    if (!is_obj()) {
+      throw JsonException("value is not an object");
+    }
+    return obj.at(key);
+  }
+  inline JsonValue& operator[](const std::string& key) {
+    if (!is_obj()) {
+      throw JsonException("value is not an object");
+    }
+    return obj.at(key);
+  }
+  inline const JsonValue& operator[](const std::string& key) const {
+    if (!is_obj()) {
+      throw JsonException("value is not an object");
+    }
+    return obj.at(key);
+  }
+  inline JsonValue& operator[](size_t i) {
+    if (!is_arr()) {
+      throw JsonException("value is not an array");
+    }
+    return arr.at(i);
+  }
+  inline const JsonValue& operator[](size_t i) const {
+    if (!is_arr()) {
+      throw JsonException("value is not an array");
+    }
+    return arr.at(i);
+  }
+  inline operator bool() const {
+    if (!is_bool()) {
+      throw JsonException("value is not a bool");
+    }
+    return b;
+  }
+  inline operator double() const {
+    if (!is_num()) {
+      throw JsonException("value is not a number");
+    }
+    return num;
+  }
+  inline operator float() const {
+    if (!is_num()) {
+      throw JsonException("value is not a number");
+    }
+    return (float)num;
+  }
+  inline operator int() const {
+    if (!is_num()) {
+      throw JsonException("value is not a number");
+    }
+    return (int)num;
+  }
+  inline operator unsigned int() const {
+    if (!is_num()) {
+      throw JsonException("value is not a number");
+    }
+    return (unsigned int)num;
+  }
+  inline operator long() const {
+    if (!is_num()) {
+      throw JsonException("value is not a number");
+    }
+    return (long)num;
+  }
+  inline operator unsigned long() const {
+    if (!is_num()) {
+      throw JsonException("value is not a number");
+    }
+    return (unsigned long)num;
+  }
+  inline operator std::string() const {
+    if (!is_str()) {
+      throw JsonException("value is not a string");
+    }
+    return str;
+  }
+
+  inline bool is_null() const {
+    return ty == L_JSON_NULL;
+  }
+  inline bool is_bool() const {
+    return ty == L_JSON_BOOLEAN;
+  }
+  inline bool is_num() const {
+    return ty == L_JSON_NUMBER;
+  }
+  inline bool is_str() const {
+    return ty == L_JSON_STRING;
+  }
+  inline bool is_obj() const {
+    return ty == L_JSON_OBJECT;
+  }
+  inline bool is_arr() const {
+    return ty == L_JSON_ARRAY;
+  }
+
+  inline size_t size() const {
+    if (is_obj()) {
+      return obj.size();
+    } else if (is_arr()) {
+      return arr.size();
+    } else {
+      throw JsonException("only object and array can have size");
+    }
+  }
+  inline JsonElementEnumerator elems() const {
+    return JsonElementEnumerator(arr);
+  }
+  inline JsonFieldEnumerator fields() const {
+    return JsonFieldEnumerator(obj);
+  }
+};
+
+// JSON array builder.
+struct JsonArray {
+  std::vector<JsonValue> inner;
+
+  inline JsonArray() : inner() {}
+  JsonArray(std::initializer_list<JsonValue>&& elems);
+};
+// JSON object builder.
+struct JsonObject {
+  std::map<std::string, JsonValue> inner;
+
+  inline JsonObject() : inner() {}
+  JsonObject(
+      std::initializer_list<std::pair<const std::string, JsonValue>>&& entries);
+};
+
+// Parse JSON literal into and `JsonValue` object. If the JSON is invalid or
+// unsupported, `JsonException` will be raised.
+JsonValue parse(const std::string& json_lit);
+// Returns true when JSON parsing successfully finished and parsed value is
+// returned via `out`. Otherwise, false is returned and out contains incomplete
+// result.
+bool try_parse(const std::string& json_lit, JsonValue& out);
+
+std::string print(const JsonValue& json);
+
+} // namespace json
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/include/log.h
+++ b/backends/vulkan/tools/gpuinfo/include/log.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/PENGUINLIONG/graphi-t/blob/0e3c1394b493db3e3d5b443c869545cac712827a/log.hpp;
+// MIT-licensed by Rendong Liang.
+
+// Logging infrastructure.
+// @PENGUINLIONG
+#pragma once
+#include <cstdint>
+#include <string>
+#include "util.h"
+
+namespace gpuinfo {
+
+namespace log {
+// Logging infrastructure.
+
+enum class LogLevel {
+  L_LOG_LEVEL_DEBUG,
+  L_LOG_LEVEL_INFO,
+  L_LOG_LEVEL_WARNING,
+  L_LOG_LEVEL_ERROR,
+};
+
+namespace detail {
+
+extern void (*log_callback)(LogLevel lv, const std::string& msg);
+extern LogLevel filter_lv;
+extern uint32_t indent;
+
+} // namespace detail
+
+void set_log_callback(decltype(detail::log_callback) cb);
+void set_log_filter_level(LogLevel lv);
+template <typename... TArgs>
+void log(LogLevel lv, const TArgs&... msg) {
+  if (detail::log_callback != nullptr && lv >= detail::filter_lv) {
+    std::string indent(detail::indent, ' ');
+    detail::log_callback(lv, util::format(indent, msg...));
+  }
+}
+
+void push_indent();
+void pop_indent();
+
+template <typename... TArgs>
+inline void debug(const TArgs&... msg) {
+  log(LogLevel::L_LOG_LEVEL_DEBUG, msg...);
+}
+template <typename... TArgs>
+inline void info(const TArgs&... msg) {
+  log(LogLevel::L_LOG_LEVEL_INFO, msg...);
+}
+template <typename... TArgs>
+inline void warn(const TArgs&... msg) {
+  log(LogLevel::L_LOG_LEVEL_WARNING, msg...);
+}
+template <typename... TArgs>
+inline void error(const TArgs&... msg) {
+  log(LogLevel::L_LOG_LEVEL_ERROR, msg...);
+}
+} // namespace log
+
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/include/stats.h
+++ b/backends/vulkan/tools/gpuinfo/include/stats.h
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/microsoft/ArchProbe/blob/main/include/stats.hpp
+// MIT-licensed by Rendong Liang.
+
+// Tools for statistics.
+// @PENGUINLIONG
+#pragma once
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include "log.h"
+
+namespace gpuinfo {
+
+namespace stats {
+
+template <typename T>
+class MinStats {
+  T mn_ = std::numeric_limits<T>::max();
+
+ public:
+  typedef T value_t;
+
+  // Returns true if the value has been updated.
+  bool push(T value) {
+    if (mn_ > value) {
+      mn_ = value;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  inline bool has_value() const {
+    return mn_ != std::numeric_limits<T>::max();
+  }
+  operator T() const {
+    if (!has_value()) {
+      gpuinfo::log::warn("`MinStats` has not collected any data yet");
+    }
+    return mn_;
+  }
+  friend std::ostream& operator<<(std::ostream& out, const MinStats<T>& x) {
+    out << (T)(x);
+    return out;
+  }
+};
+template <typename T>
+class MaxStats {
+  T mx_ = -std::numeric_limits<T>::max();
+
+ public:
+  typedef T value_t;
+
+  // Returns true if the value has been updated.
+  bool push(T value) {
+    if (mx_ < value) {
+      mx_ = value;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  inline bool has_value() const {
+    return mx_ != -std::numeric_limits<T>::max();
+  }
+  operator T() const {
+    if (!has_value()) {
+      gpuinfo::log::warn("`MaxStats` has not collected any data yet");
+    }
+    return mx_;
+  }
+  friend std::ostream& operator<<(std::ostream& out, const MaxStats<T>& x) {
+    out << (T)(x);
+    return out;
+  }
+};
+template <typename T>
+class AvgStats {
+  T sum_ = 0;
+  uint64_t n_ = 0;
+
+ public:
+  typedef T value_t;
+
+  void push(T value) {
+    sum_ += value;
+    n_ += 1;
+  }
+  inline bool has_value() const {
+    return n_ != 0;
+  }
+  operator T() const {
+    if (!has_value()) {
+      gpuinfo::log::warn("`AvgStats` has not collected any data yet");
+    }
+    return sum_ / n_;
+  }
+  friend std::ostream& operator<<(std::ostream& out, const AvgStats<T>& x) {
+    out << (T)(x);
+    return out;
+  }
+};
+template <typename T, size_t NTap>
+class NTapAvgStats {
+  std::array<double, NTap> hist_;
+  size_t cur_idx_;
+  bool ready_;
+
+ public:
+  typedef T value_t;
+
+  void push(T value) {
+    hist_[cur_idx_++] = value;
+    if (cur_idx_ >= NTap) {
+      cur_idx_ = 0;
+      ready_ = true;
+    }
+  }
+  inline bool has_value() const {
+    return ready_;
+  }
+  operator T() const {
+    if (!has_value()) {
+      gpuinfo::log::warn("`NTapStats` has not collected any data yet");
+    }
+
+    double out = 0.0;
+    for (double x : hist_) {
+      out += x;
+    }
+    out /= NTap;
+    return out;
+  }
+  friend std::ostream& operator<<(
+      std::ostream& out,
+      const NTapAvgStats<T, NTap>& x) {
+    out << (T)(x);
+    return out;
+  }
+};
+template <typename T>
+class StdStats {
+  AvgStats<T> avg_{};
+  std::vector<T> values_{};
+
+ public:
+  typedef T value_t;
+
+  void push(T value) {
+    avg_.push(value);
+    values_.push_back(value);
+  }
+  inline bool has_value() const {
+    return avg_.has_value();
+  }
+  operator T() const {
+    if (!has_value()) {
+      gpuinfo::log::warn("`StdStats` has not collected any data yet");
+    }
+    T avg = avg_;
+    T sqr_sum = 0;
+    for (auto value : values_) {
+      auto temp = value - avg;
+      sqr_sum += temp * temp;
+    }
+    return std::sqrt(sqr_sum / values_.size());
+  }
+  friend std::ostream& operator<<(std::ostream& out, const StdStats<T>& x) {
+    out << (T)(x);
+    return out;
+  }
+};
+template <typename T>
+class MedianStats {
+  std::vector<T> values_{};
+
+ public:
+  typedef T value_t;
+
+  void push(T value) {
+    values_.push_back(value);
+  }
+  inline bool has_value() const {
+    return !values_.empty();
+  }
+  operator T() {
+    if (!has_value()) {
+      gpuinfo::log::warn("`MedianStats` has not collected any data yet");
+    }
+    std::sort(values_.begin(), values_.end());
+    size_t imid = values_.size() / 2;
+    if (values_.size() & 1) {
+      return values_[imid];
+    } else {
+      return (values_[imid] + values_[imid + 1]) / 2;
+    }
+  }
+  friend std::ostream& operator<<(std::ostream& out, const MedianStats<T>& x) {
+    out << (T)(x);
+    return out;
+  }
+};
+
+template <typename TStats>
+class GeomDeltaStats {
+  TStats stats_{};
+  bool has_ratio_ = false;
+  typename TStats::value_t ratio_{};
+
+ public:
+  typedef typename TStats::value_t value_t;
+
+  void push(value_t value) {
+    if (stats_.has_value()) {
+      ratio_ = value / (value_t)stats_;
+      has_ratio_ = true;
+    }
+    stats_.push(value);
+  }
+  inline bool has_value() const {
+    return has_ratio_;
+  }
+  operator value_t() const {
+    if (!has_value()) {
+      gpuinfo::log::warn("`GeomDeltaStats` has not collected enough data yet");
+    }
+    return ratio_;
+  }
+  friend std::ostream& operator<<(
+      std::ostream& out,
+      const GeomDeltaStats<TStats>& x) {
+    if (x.has_value()) {
+      out << (typename TStats::value_t)(x.ratio_);
+    }
+    return out;
+  }
+};
+template <typename TStats>
+class ArithDeltaStats {
+  TStats stats_{};
+  bool has_delta_ = false;
+  typename TStats::value_t delta_{};
+
+ public:
+  typedef typename TStats::value_t value_t;
+
+  void push(value_t value) {
+    if (stats_.has_value()) {
+      delta_ = value - (value_t)stats_;
+      has_delta_ = true;
+    }
+    stats_.push(value);
+  }
+  inline bool has_value() const {
+    return has_delta_;
+  }
+  operator value_t() const {
+    if (!has_value()) {
+      gpuinfo::log::warn("`ArithDeltaStats` has not collected enough data yet");
+    }
+    return delta_;
+  }
+  friend std::ostream& operator<<(
+      std::ostream& out,
+      const ArithDeltaStats<TStats>& x) {
+    if (x.has_value()) {
+      out << (typename TStats::value_t)(x.delta_);
+    }
+    return out;
+  }
+};
+
+} // namespace stats
+
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/include/table.h
+++ b/backends/vulkan/tools/gpuinfo/include/table.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/microsoft/ArchProbe/blob/main/include/table.hpp
+// MIT-licensed by Rendong Liang.
+
+// Numeric data table.
+// @PENGUINLIONG
+#include <string>
+#include <vector>
+#include "assert.h"
+
+namespace gpuinfo {
+namespace table {
+
+struct Table {
+  std::vector<std::string> headers;
+  std::vector<std::vector<double>> rows;
+
+  template <typename... THeaders>
+  Table(THeaders&&... headers)
+      : Table(std::vector<std::string>{std::string(headers)...}) {}
+  Table(std::vector<std::string>&& headers);
+  Table(
+      std::vector<std::string>&& headers,
+      std::vector<std::vector<double>>&& rows);
+
+  template <typename... TArgs>
+  void push(TArgs&&... values) {
+    std::vector<double> row{(double)values...};
+    gpuinfo::assert(
+        row.size() == headers.size(), "row length mismatches header length");
+    rows.emplace_back(std::move(row));
+  }
+
+  std::string to_csv(uint32_t nsig_digit = 6) const;
+  static Table from_csv(std::string csv);
+};
+
+} // namespace table
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/include/util.h
+++ b/backends/vulkan/tools/gpuinfo/include/util.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified exerpt of
+//  https://github.com/PENGUINLIONG/graphi-t/blob/da31ec530df07c9899e056eeced08a64062dcfce/util.hpp;
+// MIT-licensed by Rendong Liang.
+
+// HAL independent utilities.
+// @PENGUINLIONG
+#pragma once
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace gpuinfo {
+
+namespace util {
+
+namespace {
+
+template <typename... TArgs>
+struct format_impl_t;
+template <>
+struct format_impl_t<> {
+  static inline void format_impl(std::stringstream& ss) {}
+};
+template <typename T>
+struct format_impl_t<T> {
+  static inline void format_impl(std::stringstream& ss, const T& x) {
+    ss << x;
+  }
+};
+template <typename T, typename... TArgs>
+struct format_impl_t<T, TArgs...> {
+  static inline void
+  format_impl(std::stringstream& ss, const T& x, const TArgs&... others) {
+    format_impl_t<T>::format_impl(ss, x);
+    format_impl_t<TArgs...>::format_impl(ss, others...);
+  }
+};
+
+} // namespace
+
+template <typename... TArgs>
+inline std::string format(const TArgs&... args) {
+  std::stringstream ss{};
+  format_impl_t<TArgs...>::format_impl(ss, args...);
+  return ss.str();
+}
+
+extern std::vector<uint8_t> load_file(const char* path);
+extern std::string load_text(const char* path);
+extern void save_file(const char* path, const void* data, size_t size);
+extern void save_text(const char* path, const std::string& txt);
+
+} // namespace util
+
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/src/args.cpp
+++ b/backends/vulkan/tools/gpuinfo/src/args.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/PENGUINLIONG/graphi-t/blob/da31ec530df07c9899e056eeced08a64062dcfce/src/args.cpp;
+// MIT-licensed by Rendong Liang.
+#include <iostream>
+#include <map>
+#include <vector>
+
+#include "args.h"
+#include "assert.h"
+
+namespace gpuinfo {
+
+namespace args {
+
+struct ArgumentHelp {
+  std::string short_flag;
+  std::string long_flag;
+  std::string help;
+};
+struct ArgumentConfig {
+  std::string app_name = "[APPNAME]";
+  std::string desc;
+  // Short flag name -> ID.
+  std::map<char, size_t> short_map;
+  // Long flag name -> ID.
+  std::map<std::string, size_t> long_map;
+  // Argument parsing info.
+  std::vector<ArgumentParseConfig> parse_cfgs;
+  // Argument help info.
+  std::vector<ArgumentHelp> helps;
+} arg_cfg;
+
+void init_arg_parse(const char* app_name, const char* desc) {
+  arg_cfg.app_name = app_name;
+  arg_cfg.desc = desc;
+}
+const char* get_app_name() {
+  return arg_cfg.app_name.c_str();
+}
+void print_help() {
+  std::cout << "usage: " << arg_cfg.app_name << " [OPTIONS]" << std::endl;
+  if (!arg_cfg.desc.empty()) {
+    std::cout << arg_cfg.desc << std::endl;
+  }
+  for (const auto& help : arg_cfg.helps) {
+    std::cout << help.short_flag << "\t" << help.long_flag << "\t\t"
+              << help.help << std::endl;
+  }
+  std::cout << "-h\t--help\t\tPrint this message." << std::endl;
+  std::exit(0);
+}
+void report_unknown_arg(const char* arg) {
+  std::cout << "unknown argument: " << arg << std::endl;
+  print_help();
+}
+
+void reg_arg(
+    const char* short_flag,
+    const char* long_flag,
+    const ArgumentParseConfig& parse_cfg,
+    const char* help) {
+  using std::strlen;
+  size_t i = arg_cfg.parse_cfgs.size();
+  if (strlen(short_flag) == 2 && short_flag[0] == '-') {
+    arg_cfg.short_map[short_flag[1]] = i;
+  }
+  if (strlen(long_flag) > 3 && long_flag[1] == '-' && long_flag[0] == '-') {
+    arg_cfg.long_map[long_flag + 2] = i;
+  }
+  arg_cfg.parse_cfgs.emplace_back(parse_cfg);
+  std::string help_str = help;
+  auto lit = parse_cfg.lit(parse_cfg.dst);
+  if (!lit.empty()) {
+    help_str += " (default=" + lit + ")";
+  }
+  ArgumentHelp arg_help{short_flag, long_flag, help_str};
+  arg_cfg.helps.emplace_back(std::move(arg_help));
+}
+
+void parse_args(int argc, const char** argv) {
+  auto i = 1;
+  int iarg_entry = -1;
+  while (i < argc || iarg_entry >= 0) {
+    if (iarg_entry >= 0) {
+      auto& parse_cfg = arg_cfg.parse_cfgs[iarg_entry];
+      gpuinfo::assert(
+          parse_cfg.parser(argv + i, parse_cfg.dst),
+          "unable to parse argument");
+      gpuinfo::assert(
+          (argc - i >= parse_cfg.narg), "no enough argument segments");
+      i += parse_cfg.narg;
+      iarg_entry = -1;
+    } else {
+      const char* arg = argv[i];
+      if (arg[0] != '-') {
+        // Free argument.
+        gpuinfo::panic("free argument is currently unsupported");
+      } else if (arg[1] != '-') {
+        if (arg[1] == 'h') {
+          print_help();
+        }
+        // Short flag argument.
+        auto it = arg_cfg.short_map.find(arg[1]);
+        if (it != arg_cfg.short_map.end()) {
+          iarg_entry = it->second;
+        } else {
+          report_unknown_arg(arg);
+        }
+        ++i;
+      } else {
+        if (std::strcmp(arg + 2, "help") == 0) {
+          print_help();
+        }
+        // Long flag argument.
+        auto it = (arg_cfg.long_map.find(arg + 2));
+        if (it != arg_cfg.long_map.end()) {
+          iarg_entry = it->second;
+        } else {
+          report_unknown_arg(arg);
+        }
+        ++i;
+      }
+    }
+  }
+}
+
+} // namespace args
+
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/src/assert.cpp
+++ b/backends/vulkan/tools/gpuinfo/src/assert.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/PENGUINLIONG/graphi-t/blob/d291c3d1ce3795fe4b305e5efd76b4f586d23e3b/src/assert.cpp;
+// MIT-licensed by Rendong Liang.
+#include "assert.h"
+
+namespace gpuinfo {
+
+AssertionFailedException::AssertionFailedException(const std::string& msg)
+    : msg(msg) {}
+const char* AssertionFailedException::what() const noexcept {
+  return msg.c_str();
+}
+
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/src/json.cpp
+++ b/backends/vulkan/tools/gpuinfo/src/json.cpp
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/PENGUINLIONG/graphi-t/blob/da31ec530df07c9899e056eeced08a64062dcfce/src/json.cpp;
+// MIT-licensed by Rendong Liang.
+
+// JSON serialization/deserialization.
+// @PENGUINLIONG
+#include <sstream>
+
+#include "json.h"
+#include "log.h"
+
+namespace gpuinfo {
+namespace json {
+
+JsonException::JsonException(const char* msg) : msg(msg) {}
+const char* JsonException::what() const noexcept {
+  return msg.c_str();
+}
+
+JsonArray::JsonArray(std::initializer_list<JsonValue>&& elems) : inner(elems) {}
+JsonObject::JsonObject(
+    std::initializer_list<std::pair<const std::string, JsonValue>>&& entries)
+    : inner(std::forward<
+            std::initializer_list<std::pair<const std::string, JsonValue>>>(
+          entries)) {}
+JsonValue::JsonValue(JsonObject&& obj)
+    : ty(L_JSON_OBJECT),
+      obj(std::forward<std::map<std::string, JsonValue>>(obj.inner)) {}
+JsonValue::JsonValue(JsonArray&& arr)
+    : ty(L_JSON_ARRAY), arr(std::forward<std::vector<JsonValue>>(arr.inner)) {}
+
+enum JsonTokenType {
+  L_JSON_TOKEN_UNDEFINED,
+  L_JSON_TOKEN_NULL,
+  L_JSON_TOKEN_TRUE,
+  L_JSON_TOKEN_FALSE,
+  L_JSON_TOKEN_STRING,
+  L_JSON_TOKEN_NUMBER,
+  L_JSON_TOKEN_COLON,
+  L_JSON_TOKEN_COMMA,
+  L_JSON_TOKEN_OPEN_BRACE,
+  L_JSON_TOKEN_CLOSE_BRACE,
+  L_JSON_TOKEN_OPEN_BRACKET,
+  L_JSON_TOKEN_CLOSE_BRACKET,
+};
+struct JsonToken {
+  JsonTokenType ty;
+  double num;
+  std::string str;
+};
+
+struct Tokenizer {
+  std::string lit;
+  std::string::const_iterator pos;
+  std::string::const_iterator end;
+
+  Tokenizer(const std::string& json)
+      : lit(json), pos(lit.cbegin()), end(lit.cend()) {}
+
+  // Check the range first before calling this method.
+  bool unsafe_starts_with(const char* head) {
+    auto i = 0;
+    while (*head != '\0') {
+      if (pos[i++] != *(head++)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  bool next_token(JsonToken& out) {
+    std::stringstream ss;
+    while (pos != end) {
+      char c = *pos;
+
+      // Ignore whitespaces.
+      if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+        pos += 1;
+        continue;
+      }
+
+      // Try parse scope punctuations.
+      switch (c) {
+        case ':':
+          out.ty = L_JSON_TOKEN_COLON;
+          pos += 1;
+          return true;
+        case ',':
+          out.ty = L_JSON_TOKEN_COMMA;
+          pos += 1;
+          return true;
+        case '{':
+          out.ty = L_JSON_TOKEN_OPEN_BRACE;
+          pos += 1;
+          return true;
+        case '}':
+          out.ty = L_JSON_TOKEN_CLOSE_BRACE;
+          pos += 1;
+          return true;
+        case '[':
+          out.ty = L_JSON_TOKEN_OPEN_BRACKET;
+          pos += 1;
+          return true;
+        case ']':
+          out.ty = L_JSON_TOKEN_CLOSE_BRACKET;
+          pos += 1;
+          return true;
+      }
+
+      // Try parse numbers.
+      if (c == '+' || c == '-' || (c >= '0' && c <= '9')) {
+        out.ty = L_JSON_TOKEN_NUMBER;
+        const int STATE_INTEGRAL = 0;
+        const int STATE_FRACTION = 1;
+        const int STATE_EXPONENT = 2;
+        int state = STATE_INTEGRAL;
+        do {
+          c = *pos;
+          if (state == STATE_INTEGRAL) {
+            if (c == '.') {
+              state = STATE_FRACTION;
+              ss.put(c);
+              continue;
+            }
+            if (c == 'e') {
+              state = STATE_EXPONENT;
+              ss.put(c);
+              continue;
+            }
+            if (c != '+' && c != '-' && (c < '0' || c > '9')) {
+              break;
+            }
+          } else if (state == STATE_FRACTION) {
+            if (c == 'e') {
+              state = STATE_EXPONENT;
+              ss.put(c);
+              continue;
+            }
+            if (c < '0' || c > '9') {
+              break;
+            }
+          } else if (state == STATE_EXPONENT) {
+            if (c != '+' && c != '-' && (c < '0' || c > '9')) {
+              break;
+            }
+          }
+          ss.put(c);
+        } while (++pos != end);
+        out.num = std::atof(ss.str().c_str());
+        return true;
+      }
+
+      // Try parse strings.
+      if (c == '"') {
+        out.ty = L_JSON_TOKEN_STRING;
+        bool escape = false;
+        while (++pos != end) {
+          c = *pos;
+          if (escape) {
+            switch (c) {
+              case '"':
+              case '/':
+                break;
+              case 'b':
+                c = '\b';
+                break;
+              case 'f':
+                c = '\f';
+                break;
+              case 'n':
+                c = '\n';
+                break;
+              case 'r':
+                c = '\r';
+                break;
+              case 't':
+                c = '\t';
+                break;
+              case 'u':
+                throw JsonException("unicode escape is not supported");
+              default:
+                throw JsonException("invalid escape charater");
+            }
+            escape = false;
+          } else {
+            if (c == '\\') {
+              escape = true;
+              continue;
+            } else if (c == '"') {
+              if (escape != false) {
+                throw JsonException("incomplete escape sequence");
+              }
+              out.str = ss.str();
+              pos += 1;
+              return true;
+            }
+          }
+          ss.put(c);
+        }
+        throw JsonException("unexpected end of string");
+      }
+
+      // Try parse literals.
+      if (pos + 4 <= end) {
+        if (unsafe_starts_with("null")) {
+          out.ty = L_JSON_TOKEN_NULL;
+          pos += 4;
+          return true;
+        }
+        if (unsafe_starts_with("true")) {
+          out.ty = L_JSON_TOKEN_TRUE;
+          pos += 4;
+          return true;
+        }
+      }
+      if (pos + 5 <= end) {
+        if (unsafe_starts_with("false")) {
+          out.ty = L_JSON_TOKEN_FALSE;
+          pos += 5;
+          return true;
+        }
+      }
+    }
+    out.ty = L_JSON_TOKEN_UNDEFINED;
+    return false;
+  }
+};
+
+bool try_parse_impl(Tokenizer& tokenizer, JsonValue& out) {
+  JsonToken token;
+  while (tokenizer.next_token(token)) {
+    JsonValue val;
+    switch (token.ty) {
+      case L_JSON_TOKEN_TRUE:
+        out.ty = L_JSON_BOOLEAN;
+        out.b = true;
+        return true;
+      case L_JSON_TOKEN_FALSE:
+        out.ty = L_JSON_BOOLEAN;
+        out.b = false;
+        return true;
+      case L_JSON_TOKEN_NULL:
+        out.ty = L_JSON_NULL;
+        return true;
+      case L_JSON_TOKEN_STRING:
+        out.ty = L_JSON_STRING;
+        out.str = std::move(token.str);
+        return true;
+      case L_JSON_TOKEN_NUMBER:
+        out.ty = L_JSON_NUMBER;
+        out.num = token.num;
+        return true;
+      case L_JSON_TOKEN_OPEN_BRACKET:
+        out.ty = L_JSON_ARRAY;
+        for (;;) {
+          if (!try_parse_impl(tokenizer, val)) {
+            // When the array has no element.
+            break;
+          }
+          out.arr.emplace_back(std::move(val));
+          if (tokenizer.next_token(token)) {
+            if (token.ty == L_JSON_TOKEN_COMMA) {
+              continue;
+            } else if (token.ty == L_JSON_TOKEN_CLOSE_BRACKET) {
+              break;
+            } else {
+              throw JsonException("unexpected token in array");
+            }
+          } else {
+            throw JsonException("unexpected end of array");
+          }
+        }
+        return true;
+      case L_JSON_TOKEN_OPEN_BRACE:
+        out.ty = L_JSON_OBJECT;
+        for (;;) {
+          // Match the key.
+          std::string key;
+          if (tokenizer.next_token(token)) {
+            if (token.ty == L_JSON_TOKEN_STRING) {
+              key = std::move(token.str);
+            } else if (token.ty == L_JSON_TOKEN_CLOSE_BRACE) {
+              // The object has no field.
+              break;
+            } else {
+              throw JsonException("unexpected object field key type");
+            }
+          } else {
+            throw JsonException("unexpected end of object");
+          }
+          // Match the colon.
+          if (!tokenizer.next_token(token)) {
+            throw JsonException("unexpected end of object");
+          }
+          if (token.ty != L_JSON_TOKEN_COLON) {
+            throw JsonException("unexpected token in object");
+          }
+          // Match the value.
+          if (!try_parse_impl(tokenizer, val)) {
+            throw JsonException("unexpected end of object");
+          }
+          out.obj[key] = std::move(val);
+          // Should we head for another round?
+          if (tokenizer.next_token(token)) {
+            if (token.ty == L_JSON_TOKEN_COMMA) {
+              continue;
+            } else if (token.ty == L_JSON_TOKEN_CLOSE_BRACE) {
+              break;
+            } else {
+              throw JsonException("unexpected token in object");
+            }
+          } else {
+            throw JsonException("unexpected end of object");
+          }
+        }
+        return true;
+      case L_JSON_TOKEN_CLOSE_BRACE:
+      case L_JSON_TOKEN_CLOSE_BRACKET:
+        return false;
+      default:
+        throw JsonException("unexpected token");
+    }
+  }
+  throw JsonException("unexpected program state");
+}
+
+JsonValue parse(const std::string& json_lit) {
+  if (json_lit.empty()) {
+    throw JsonException("json text is empty");
+  }
+  JsonValue rv;
+  Tokenizer tokenizer(json_lit);
+  if (!try_parse_impl(tokenizer, rv)) {
+    throw JsonException("unexpected close token");
+  }
+  return rv;
+}
+bool try_parse(const std::string& json_lit, JsonValue& out) {
+  try {
+    out = parse(json_lit);
+  } catch (JsonException e) {
+    log::error("failed to parse json: ", e.what());
+    return false;
+  }
+  return true;
+}
+
+void print_impl(const JsonValue& json, std::stringstream& out) {
+  switch (json.ty) {
+    case L_JSON_NULL:
+      out << "null";
+      return;
+    case L_JSON_BOOLEAN:
+      out << (json.b ? "true" : "false");
+      return;
+    case L_JSON_NUMBER:
+      out << json.num;
+      return;
+    case L_JSON_STRING:
+      out << "\"" << json.str << "\"";
+      return;
+    case L_JSON_OBJECT:
+      out << "{";
+      {
+        bool is_first_iter = true;
+        for (const auto& pair : json.obj) {
+          if (is_first_iter) {
+            is_first_iter = false;
+          } else {
+            out << ",";
+          }
+          out << "\"" << pair.first << "\":";
+          print_impl(pair.second, out);
+        }
+      }
+      out << "}";
+      return;
+    case L_JSON_ARRAY:
+      out << "[";
+      {
+        bool is_first_iter = true;
+        for (const auto& elem : json.arr) {
+          if (is_first_iter) {
+            is_first_iter = false;
+          } else {
+            out << ",";
+          }
+          print_impl(elem, out);
+        }
+      }
+      out << "]";
+      return;
+  }
+}
+std::string print(const JsonValue& json) {
+  std::stringstream ss;
+  print_impl(json, ss);
+  return ss.str();
+}
+
+} // namespace json
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/src/log.cpp
+++ b/backends/vulkan/tools/gpuinfo/src/log.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/PENGUINLIONG/graphi-t/blob/0e3c1394b493db3e3d5b443c869545cac712827a/src/log.cpp;
+// MIT-licensed by Rendong Liang.
+#include "log.h"
+
+namespace gpuinfo {
+
+namespace log {
+
+namespace detail {
+
+decltype(log_callback) log_callback = nullptr;
+LogLevel filter_lv;
+uint32_t indent;
+
+} // namespace detail
+
+void set_log_callback(decltype(detail::log_callback) cb) {
+  detail::log_callback = cb;
+}
+void set_log_filter_level(LogLevel lv) {
+  detail::filter_lv = lv;
+}
+
+void push_indent() {
+  detail::indent += 4;
+}
+void pop_indent() {
+  detail::indent -= 4;
+}
+
+} // namespace log
+
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/src/table.cpp
+++ b/backends/vulkan/tools/gpuinfo/src/table.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/microsoft/ArchProbe/blob/main/src/table.cpp
+// MIT-licensed by Rendong Liang.
+
+#include <iomanip>
+
+#include "table.h"
+
+namespace gpuinfo {
+namespace table {
+
+Table::Table(std::vector<std::string>&& headers) : headers(headers), rows() {}
+Table::Table(
+    std::vector<std::string>&& headers,
+    std::vector<std::vector<double>>&& rows)
+    : headers(headers), rows(rows) {}
+
+std::string Table::to_csv(uint32_t nsig_digit) const {
+  std::stringstream ss;
+  ss << std::setprecision(nsig_digit);
+
+  {
+    bool first_col = true;
+    for (const auto& header : headers) {
+      if (first_col) {
+        first_col = false;
+      } else {
+        ss << ",";
+      }
+      ss << header;
+    }
+    // Enforce newline character to be `\n`.
+    ss << '\n';
+  }
+
+  {
+    for (const auto& row : rows) {
+      bool first_col = true;
+      for (const auto& cell : row) {
+        if (first_col) {
+          first_col = false;
+        } else {
+          ss << ",";
+        }
+        ss << cell;
+      }
+      ss << '\n';
+    }
+  }
+
+  return ss.str();
+}
+
+std::vector<std::string> parse_header_row(std::istringstream& ss) {
+  std::vector<std::string> out;
+  std::string buf;
+  while (ss.peek() != EOF) {
+    buf.clear();
+    std::getline(ss, buf, ',');
+    out.emplace_back(std::move(buf));
+  }
+  return out;
+}
+std::vector<double> parse_data_row(std::istringstream& ss) {
+  std::vector<double> out;
+  std::string buf;
+  while (ss.peek() != EOF) {
+    buf.clear();
+    std::getline(ss, buf, ',');
+    out.emplace_back(std::atof(buf.c_str()));
+  }
+  return out;
+}
+Table Table::from_csv(std::string csv) {
+  std::istringstream ss;
+  ss.str(csv);
+  std::string line;
+
+  // Capture the header.
+  std::vector<std::string> headers;
+  if (ss.peek() != EOF) {
+    line.clear();
+    std::getline(ss, line, '\n');
+
+    std::istringstream sss;
+    sss.str(line);
+    headers = parse_header_row(sss);
+  }
+
+  std::vector<std::vector<double>> data_rows;
+  while (ss.peek() != EOF) {
+    line.clear();
+    std::getline(ss, line, '\n');
+
+    std::istringstream sss;
+    sss.str(line);
+    data_rows.emplace_back(parse_data_row(sss));
+  }
+
+  return Table(std::move(headers), std::move(data_rows));
+}
+
+} // namespace table
+} // namespace gpuinfo

--- a/backends/vulkan/tools/gpuinfo/src/util.cpp
+++ b/backends/vulkan/tools/gpuinfo/src/util.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: This is a modified excerpt of
+//  https://github.com/PENGUINLIONG/graphi-t/blob/da31ec530df07c9899e056eeced08a64062dcfce/src/util.cpp;
+// MIT-licensed by Rendong Liang.
+
+#include <fstream>
+
+#include "assert.h"
+#include "util.h"
+
+namespace gpuinfo {
+
+namespace util {
+
+std::vector<uint8_t> load_file(const char* path) {
+  std::ifstream f(path, std::ios::ate | std::ios::binary | std::ios::in);
+  assert(f.is_open(), "unable to open file: ", path);
+  size_t size = f.tellg();
+  f.seekg(std::ios::beg);
+  std::vector<uint8_t> buf;
+  buf.resize(size);
+  f.read((char*)buf.data(), size);
+  f.close();
+  return buf;
+}
+std::string load_text(const char* path) {
+  std::ifstream f(path, std::ios::ate | std::ios::binary | std::ios::in);
+  assert(f.is_open(), "unable to open file: ", path);
+  size_t size = f.tellg();
+  f.seekg(std::ios::beg);
+  std::string buf;
+  buf.reserve(size + 1);
+  buf.resize(size);
+  f.read((char*)buf.data(), size);
+  f.close();
+  return buf;
+}
+void save_file(const char* path, const void* data, size_t size) {
+  std::ofstream f(path, std::ios::trunc | std::ios::out | std::ios::binary);
+  assert(f.is_open(), "unable to open file: ", path);
+  f.write((const char*)data, size);
+  f.close();
+}
+void save_text(const char* path, const std::string& txt) {
+  std::ofstream f(path, std::ios::trunc | std::ios::out | std::ios::binary);
+  assert(f.is_open(), "unable to open file: ", path);
+  f << txt;
+  f.close();
+}
+
+} // namespace util
+
+} // namespace gpuinfo


### PR DESCRIPTION
Summary: Port of https://github.com/microsoft/ArchProbe as an internal GPU profiling tool called GPUInfo. This initial diff introduces a skeleton with all of ArchProbe's non-OpenCL functionality. The following diffs will progressively add each of the profiling apps in Vulkan

Differential Revision: D59286665
