### PR TITLE
Inspector should allow explicit None for delegate_map

### DIFF
--- a/sdk/inspector/_inspector.py
+++ b/sdk/inspector/_inspector.py
@@ -892,7 +892,7 @@ class EventBlock:
 
             # For delegated events, handles are found via delegateMetadata
             event.delegate_backend_name = delegate_metadata.get("name", "")
-            delegate_metadata_delegate_map = delegate_metadata.get("delegate_map", {})
+            delegate_metadata_delegate_map = delegate_metadata.get("delegate_map") or {}
 
             # delegate_debug_id can be either int based or string based, therefore we need to check both
             debug_handles = delegate_metadata_delegate_map.get(


### PR DESCRIPTION
Summary:
The SDK inspector should allow parsing delegates that have a `None`
for their delegate_map. This is explicitly None, and not unspecified, which
is why the default of an empty dict didn't work.

Use `or {}` to instead detect None.

Differential Revision: D59298227
