### PR TITLE
Improve README page and Getting Started page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Key value propositions of ExecuTorch are:
 For a comprehensive technical overview of ExecuTorch and step-by-step tutorials,
 please visit our documentation website [for the latest release](https://pytorch.org/executorch/stable/index.html) (or the [main branch](https://pytorch.org/executorch/main/index.html)).
 
+Check out the [Getting Started](https://pytorch.org/executorch/stable/getting-started-setup.htmll#quick-setup-colab-jupyter-notebook-prototype) page for a quick spin.
+
 ## Feedback
 
 We welcome any feedback, suggestions, and bug reports from the community to help

--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -70,8 +70,12 @@ portability details.
 
 ## Quick Setup: Colab/Jupyter Notebook Prototype
 
-To utilize ExecuTorch to its fullest extent, please follow the setup instructions provided below. Alternatively, if you would like to experiment with ExecuTorch quickly and easily, we recommend using the following [colab notebook](https://colab.research.google.com/drive/1qpxrXC3YdJQzly3mRg-4ayYiOjC6rue3?usp=sharing) for prototyping purposes.
+To utilize ExecuTorch to its fullest extent, please follow the setup instructions provided below to install from source.
 
+Alternatively, if you would like to experiment with ExecuTorch quickly and easily, we recommend using the following [colab notebook](https://colab.research.google.com/drive/1qpxrXC3YdJQzly3mRg-4ayYiOjC6rue3?usp=sharing) for prototyping purposes. You can install directly via `pip` for basic functionality.
+  ```bash
+  pip install executorch
+  ```
 
 
 ## Environment Setup


### PR DESCRIPTION
Summary:
Minor improvements:

- Link directly to the Getting Started page from README.md. It's always a few clicks away.
- Besides the colab notebook, also explicitly mention `pip install executorch`

Differential Revision: D59329875
