### PR TITLE
Fix missing llama2 model on Device Farm

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -118,5 +118,6 @@ jobs:
       # The test spec can be downloaded from https://ossci-assets.s3.amazonaws.com/android-llama2-device-farm-test-spec.yml
       test-spec: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/abd86868-fa63-467e-a5c7-218194665a77
       # The exported llama2 model and its tokenizer, can be downloaded from https://ossci-assets.s3.amazonaws.com/executorch-android-llama2-7b.zip.
-      # Among the input, this is the biggest file and uploading it to AWS beforehand makes the test run much faster
-      extra-data: arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/30168984-65d3-4637-a54d-908649e70141
+      # Among the input, this is the biggest file, so it is cached on AWS to make the test faster. Note that the file is deleted by AWS after 30
+      # days and the job will automatically re-upload the file when that happens.
+      extra-data: https://ossci-assets.s3.amazonaws.com/executorch-android-llama2-7b.zip


### PR DESCRIPTION
This changes the input to upload the export llama2 model from S3, the caching logic will be implemented upstream in https://github.com/pytorch/test-infra/pull/5405.  Thus, this fixes the issue where the pre-uploaded model is deleted on AWS after 30 days.  In this case, `arn:aws:devicefarm:us-west-2:308535385114:upload:02a2cf0f-6d9b-45ee-ba1a-a086587469e6/30168984-65d3-4637-a54d-908649e70141` has been deleted and this fails the job.

@kirklandsign I see that running llama2 on S22 runs OOM now, do you have any insights on that?