### PR TITLE
Remove Duplicate Dequant Node Pass

### DIFF
--- a/backends/xnnpack/utils/TARGETS
+++ b/backends/xnnpack/utils/TARGETS
@@ -9,7 +9,6 @@ python_library(
         "//caffe2:torch",
         "//executorch/exir:lib",
         "//executorch/exir:pass_manager",
-        "//executorch/exir/backend/canonical_partitioners:canonical_partitioner_lib",
         "//executorch/exir/dialects:lib",
         "//pytorch/ao:torchao",  # @manual
     ],

--- a/backends/xnnpack/utils/configs.py
+++ b/backends/xnnpack/utils/configs.py
@@ -8,9 +8,6 @@ from typing import List, Optional
 
 import executorch.exir as exir
 from executorch.exir import CaptureConfig
-from executorch.exir.backend.canonical_partitioners.duplicate_dequant_node_pass import (
-    DuplicateDequantNodePass,
-)
 from executorch.exir.pass_manager import PassType
 
 
@@ -20,8 +17,7 @@ def get_xnnpack_edge_compile_config() -> exir.EdgeCompileConfig:
 
 
 def get_transform_passes(additional_passes=None) -> List[PassType]:
-    additional_passes = additional_passes if additional_passes else []
-    passes = additional_passes + [DuplicateDequantNodePass()]
+    passes = additional_passes if additional_passes else []
     return passes
 
 


### PR DESCRIPTION
Summary:
The original need for the DuplicateDequantNode pass was to correctly partition quantized ops. If the output of quantized ops were used twice, then a single dequant node would be reused by multiple ops. This made it impossible to partition for quantized ops using pattern based matching.

However, now that we have moved to source-based partitioner, we no longer need the dequant node pass before partitioning

Differential Revision: D46919620
