### PR TITLE
Use linux runner for Android Device Farm test job

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -106,7 +106,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/mobile_job.yml@main
     with:
       device-type: android
-      runner: ubuntu-latest
+      runner: linux.2xlarge
       test-infra-ref: ''
       # This is the ARN of ExecuTorch project on AWS
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6


### PR DESCRIPTION
I should have realized this earlier, but using our Linux runner is more efficient than GitHub runner when it comes to download from and upload large files to S3, i.e. the exported llama model, because the traffic is within AWS data center.