### PR TITLE
[ET-VK] Consolidate MeanToSumDiv export pass into VulkanPreprocess

### DIFF
--- a/backends/vulkan/TARGETS
+++ b/backends/vulkan/TARGETS
@@ -26,6 +26,7 @@ runtime.python_library(
         "//executorch/backends/transforms:fuse_batch_norm_with_conv",
         "//executorch/backends/transforms:fuse_conv_with_clamp",
         "//executorch/backends/transforms:fuse_view_copy",
+        "//executorch/backends/transforms:mean_to_sum_div",
         "//executorch/backends/transforms:remove_clone_ops",
         "//executorch/exir:graph_module",
         "//executorch/exir/_serialize:_bindings",

--- a/backends/vulkan/partitioner/supported_ops.py
+++ b/backends/vulkan/partitioner/supported_ops.py
@@ -84,9 +84,10 @@ CONVOLUTION_OPS = [
 ]
 
 REDUCTION_OPS = [
+    exir_ops.edge.aten.mean.dim,
     exir_ops.edge.aten.sum.dim_IntList,
-    exir_ops.edge.aten._softmax.default,
     exir_ops.edge.aten._log_softmax.default,
+    exir_ops.edge.aten._softmax.default,
 ]
 
 NORMALIZATION_OPS = [

--- a/backends/vulkan/test/TARGETS
+++ b/backends/vulkan/test/TARGETS
@@ -15,7 +15,6 @@ python_unittest(
     deps = [
         "//caffe2:torch",
         "//executorch/backends/transforms:convert_dtype_pass",
-        "//executorch/backends/transforms:mean_to_sum_div",
         "//executorch/backends/vulkan:vulkan_preprocess",
         "//executorch/backends/vulkan/partitioner:vulkan_partitioner",
         "//executorch/exir:lib",

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -15,7 +15,6 @@ import executorch.backends.vulkan.serialization.vulkan_graph_schema as vk_graph_
 import torch
 
 from executorch.backends.transforms.convert_dtype_pass import I64toI32
-from executorch.backends.transforms.mean_to_sum_div import MeanToSumDiv
 
 from executorch.backends.vulkan.partitioner.vulkan_partitioner import VulkanPartitioner
 from executorch.backends.vulkan.vulkan_preprocess import VulkanBackend
@@ -125,7 +124,6 @@ class TestBackends(unittest.TestCase):
                 program,
                 transform_passes=[
                     I64toI32(self._edge_compile_config._skip_dim_order),
-                    MeanToSumDiv(),
                 ],
                 partitioner=[VulkanPartitioner(compile_options)],
             )

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -14,8 +14,8 @@ from executorch.backends.transforms.fuse_batch_norm_with_conv import (
 )
 from executorch.backends.transforms.fuse_conv_with_clamp import FuseClampPass
 from executorch.backends.transforms.fuse_view_copy import FuseViewCopyTransform
-from executorch.backends.transforms.remove_clone_ops import RemoveCloneOpsTransform
 from executorch.backends.transforms.mean_to_sum_div import MeanToSumDiv
+from executorch.backends.transforms.remove_clone_ops import RemoveCloneOpsTransform
 
 from executorch.backends.vulkan.serialization.vulkan_graph_builder import VkGraphBuilder
 from executorch.backends.vulkan.serialization.vulkan_graph_serialize import (

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -15,6 +15,7 @@ from executorch.backends.transforms.fuse_batch_norm_with_conv import (
 from executorch.backends.transforms.fuse_conv_with_clamp import FuseClampPass
 from executorch.backends.transforms.fuse_view_copy import FuseViewCopyTransform
 from executorch.backends.transforms.remove_clone_ops import RemoveCloneOpsTransform
+from executorch.backends.transforms.mean_to_sum_div import MeanToSumDiv
 
 from executorch.backends.vulkan.serialization.vulkan_graph_builder import VkGraphBuilder
 from executorch.backends.vulkan.serialization.vulkan_graph_serialize import (
@@ -53,6 +54,7 @@ class VulkanBackend(BackendDetails):
             FuseViewCopyTransform(),
             FuseBatchNormWithConvPass(program),
             FuseClampPass(),
+            MeanToSumDiv(),
             SpecPropPass(),
             ConstraintBasedSymShapeEvalPass(),
             MemoryPlanningPass("greedy"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4187
* #4186
* #4182
* #4181
* #4180
* #4179
* __->__ #4178

Clean up time. Previous issue fixed by registering `aten.mean.dim` in `supported_ops.py`.

Differential Revision: [D59525641](https://our.internmc.facebook.com/intern/diff/D59525641/)