### PR TITLE
[ET-VK] Rename `RuntimeConfiguration` to `RuntimeConfig`

### DIFF
--- a/backends/vulkan/runtime/vk_api/Runtime.cpp
+++ b/backends/vulkan/runtime/vk_api/Runtime.cpp
@@ -78,7 +78,7 @@ void find_requested_layers_and_extensions(
   }
 }
 
-VkInstance create_instance(const RuntimeConfiguration& config) {
+VkInstance create_instance(const RuntimeConfig& config) {
   const VkApplicationInfo application_info{
       VK_STRUCTURE_TYPE_APPLICATION_INFO, // sType
       nullptr, // pNext
@@ -175,7 +175,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debug_report_callback_fn(
 
 VkDebugReportCallbackEXT create_debug_report_callback(
     VkInstance instance,
-    const RuntimeConfiguration config) {
+    const RuntimeConfig config) {
   if (VK_NULL_HANDLE == instance || !config.enable_validation_messages) {
     return VkDebugReportCallbackEXT{};
   }
@@ -256,7 +256,7 @@ std::unique_ptr<Runtime> init_global_vulkan_runtime() {
   const uint32_t num_requested_queues = 1; // TODO: raise this value
   const std::string cache_data_path = ""; // TODO: expose to client
 
-  const RuntimeConfiguration default_config{
+  const RuntimeConfig default_config{
       enable_validation_messages,
       init_default_device,
       AdapterSelector::First,
@@ -274,7 +274,7 @@ std::unique_ptr<Runtime> init_global_vulkan_runtime() {
 
 } // namespace
 
-Runtime::Runtime(const RuntimeConfiguration config)
+Runtime::Runtime(const RuntimeConfig config)
     : config_(config),
       instance_(create_instance(config_)),
       device_mappings_(create_physical_devices(instance_)),

--- a/backends/vulkan/runtime/vk_api/Runtime.h
+++ b/backends/vulkan/runtime/vk_api/Runtime.h
@@ -34,7 +34,7 @@ enum AdapterSelector {
   First,
 };
 
-struct RuntimeConfiguration final {
+struct RuntimeConfig final {
   bool enable_validation_messages;
   bool init_default_device;
   AdapterSelector default_selector;
@@ -44,7 +44,7 @@ struct RuntimeConfiguration final {
 
 class Runtime final {
  public:
-  explicit Runtime(const RuntimeConfiguration);
+  explicit Runtime(const RuntimeConfig);
 
   // Do not allow copying. There should be only one global instance of this
   // class.
@@ -60,7 +60,7 @@ class Runtime final {
   using AdapterPtr = std::unique_ptr<Adapter>;
 
  private:
-  RuntimeConfiguration config_;
+  RuntimeConfig config_;
 
   VkInstance instance_;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4187
* #4186
* __->__ #4182
* #4181
* #4180
* #4179
* #4178

Rest of the codebase uses `Config`, not `Configuration`.

```
find . -type f -exec sed -i 's/RuntimeConfiguration/RuntimeConfig/g' {} +
```

Differential Revision: [D59527914](https://our.internmc.facebook.com/intern/diff/D59527914/)