### PR TITLE
Expand verifier to be multiple on ExportedProgram

### DIFF
--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -1058,12 +1058,18 @@ class ExportedProgramSerializer:
             assert n not in constants
             constants[n] = t
 
+        additional_kwargs = {}
+        if hasattr(exported_program, "verifiers"):
+            additional_kwargs["verifiers"] = [
+                v.dialect for v in exported_program.verifiers
+            ]
         serialized_ep = ExportedProgram(
             graph_module=serialized_graph_module,
             opset_version=self.opset_version,
             range_constraints=serialized_range_constraints,
             schema_version=SchemaVersion(-1, -1),
             dialect=exported_program.dialect,
+            **additional_kwargs,
         )
 
         return SerializedArtifact(

--- a/exir/serde/serialize.py
+++ b/exir/serde/serialize.py
@@ -344,6 +344,11 @@ class ExportedProgramSerializer(export_serialize.ExportedProgramSerializer):
             assert n not in constants
             constants[n] = t
 
+        additional_kwargs = {}
+        if hasattr(exported_program, "verifiers"):
+            additional_kwargs["verifiers"] = [
+                v.dialect for v in exported_program.verifiers
+            ]
         return export_serialize.SerializedArtifact(
             schema.ExportedProgram(
                 graph_module=serialized_graph_module,
@@ -351,6 +356,7 @@ class ExportedProgramSerializer(export_serialize.ExportedProgramSerializer):
                 range_constraints=serialized_range_constraints,
                 schema_version=SchemaVersion(-1, -1),
                 dialect=exported_program.dialect,
+                **additional_kwargs,
             ),
             export_serialize.serialize_torch_artifact(exported_program.state_dict),
             export_serialize.serialize_torch_artifact(constants),


### PR DESCRIPTION
Summary: This diff updates the ExportedProgram class in PyTorch to allow for multiple verifiers to be attached to it. This is done by adding a new field to the ExportedProgram schema called "verifiers" which is a list of strings representing the names of the verifiers to be attached to the program. The verifiers are loaded using the "load_verifier" function which is defined in the "torch._export.serde.serialize" module. The "exported_program.dialect" field is also deprecated in favor of the "verifiers" field.

Differential Revision: D59408546
