### PR TITLE
[ET-VK] Convert `DeviceHandle` into a struct

### DIFF
--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -271,18 +271,13 @@ std::string get_queue_family_properties_str(const VkQueueFlags flags) {
 // DeviceHandle
 //
 
-DeviceHandle::DeviceHandle(VkDevice device) : handle_(device) {}
-
-DeviceHandle::DeviceHandle(DeviceHandle&& other) noexcept
-    : handle_(other.handle_) {
-  other.handle_ = VK_NULL_HANDLE;
-}
+DeviceHandle::DeviceHandle(VkDevice device) : handle(device) {}
 
 DeviceHandle::~DeviceHandle() {
-  if (VK_NULL_HANDLE == handle_) {
+  if (VK_NULL_HANDLE == handle) {
     return;
   }
-  vkDestroyDevice(handle_, nullptr);
+  vkDestroyDevice(handle, nullptr);
 }
 
 //
@@ -305,12 +300,12 @@ Adapter::Adapter(
           num_queues,
           queues_,
           queue_usage_)),
-      shader_layout_cache_(device_.handle_),
-      shader_cache_(device_.handle_),
-      pipeline_layout_cache_(device_.handle_),
-      compute_pipeline_cache_(device_.handle_, cache_data_path),
-      sampler_cache_(device_.handle_),
-      vma_(instance_, physical_device_.handle, device_.handle_) {}
+      shader_layout_cache_(device_.handle),
+      shader_cache_(device_.handle),
+      pipeline_layout_cache_(device_.handle),
+      compute_pipeline_cache_(device_.handle, cache_data_path),
+      sampler_cache_(device_.handle),
+      vma_(instance_, physical_device_.handle, device_.handle) {}
 
 Adapter::Queue Adapter::request_queue() {
   // Lock the mutex as multiple threads can request a queue at the same time
@@ -448,7 +443,7 @@ std::string Adapter::stringize() const {
        << std::endl;
   }
   ss << "  }" << std::endl;
-  ss << "  VkDevice: " << device_.handle_ << std::endl;
+  ss << "  VkDevice: " << device_.handle << std::endl;
   ss << "  Compute Queues [" << std::endl;
   for (const Adapter::Queue& compute_queue : queues_) {
     ss << "    Family " << compute_queue.family_index << ", Queue "

--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -53,22 +53,11 @@ struct PhysicalDevice final {
   explicit PhysicalDevice(VkPhysicalDevice);
 };
 
-class DeviceHandle final {
- public:
-  explicit DeviceHandle(VkDevice device);
+struct DeviceHandle final {
+  VkDevice handle;
 
-  DeviceHandle(const DeviceHandle&) = delete;
-  DeviceHandle& operator=(const DeviceHandle&) = delete;
-
-  DeviceHandle(DeviceHandle&&) noexcept;
-  DeviceHandle& operator=(DeviceHandle&&) = delete;
-
+  explicit DeviceHandle(VkDevice);
   ~DeviceHandle();
-
- private:
-  VkDevice handle_;
-
-  friend class Adapter;
 };
 
 //
@@ -150,7 +139,7 @@ class Adapter final {
   }
 
   inline VkDevice device_handle() const {
-    return device_.handle_;
+    return device_.handle;
   }
 
   inline bool has_unified_memory() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4187
* __->__ #4186
* #4182
* #4181
* #4180
* #4179
* #4178

We already expose the only private member `VkDevice` from Adapter's public function `device_handle()` so nothing's really private. This change also makes it consistent with the layout of `PhysicalDevice` and allows decoupling from Adapter in the next change.

Differential Revision: [D59540129](https://our.internmc.facebook.com/intern/diff/D59540129/)