### PR TITLE
Intermediate output logging enablement - Inspector logging

### DIFF
--- a/runtime/core/event_tracer.h
+++ b/runtime/core/event_tracer.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/runtime/core/array_ref.h>
 #include <executorch/runtime/core/evalue.h>
 #include <executorch/runtime/platform/platform.h>
 #include <stdlib.h>
@@ -255,6 +256,106 @@ class EventTracer {
   virtual void log_evalue(
       const EValue& evalue,
       LoggedEValueType evalue_type) = 0;
+
+  /**
+   * Log an intermediate tensor output from a delegate.
+   *
+   * @param[in] name Human readable name for the delegate event. This name has
+   * to be the same name that was passed in during the Debug delegate mapping
+   * generation in the export/ahead-of-time process. If indices and not names
+   * are used by this delegate to identify ops executed in the backend then
+   * nullptr can be passed in. Users calling this interface do not need to keep
+   * the memory pointed to by this pointer around. The string must be copied
+   * over into internal memory during this call.
+   * @param[in] delegate_debug_index The id of the delegate event. If string
+   * based names are used by this delegate to identify ops executed in the
+   * backend then kUnsetDebugHandle should be passed in here.
+   * @param[in] output The tensor type output to be logged.
+   */
+  virtual void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const Tensor& output) = 0;
+
+  /**
+   * Log an intermediate tensor array output from a delegate.
+   *
+   * @param[in] name Human readable name for the delegate event. This name has
+   * to be the same name that was passed in during the Debug delegate mapping
+   * generation in the export/ahead-of-time process. If indices and not names
+   * are used by this delegate to identify ops executed in the backend then
+   * nullptr can be passed in. Users calling this interface do not need to keep
+   * the memory pointed to by this pointer around. The string must be copied
+   * over into internal memory during this call.
+   * @param[in] delegate_debug_index The id of the delegate event. If string
+   * based names are used by this delegate to identify ops executed in the
+   * backend then kUnsetDebugHandle should be passed in here.
+   * @param[in] output The tensor array type output to be logged.
+   */
+  virtual void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const ArrayRef<Tensor> output) = 0;
+
+  /**
+   * Log an intermediate int output from a delegate.
+   *
+   * @param[in] name Human readable name for the delegate event. This name has
+   * to be the same name that was passed in during the Debug delegate mapping
+   * generation in the export/ahead-of-time process. If indices and not names
+   * are used by this delegate to identify ops executed in the backend then
+   * nullptr can be passed in. Users calling this interface do not need to keep
+   * the memory pointed to by this pointer around. The string must be copied
+   * over into internal memory during this call.
+   * @param[in] delegate_debug_index The id of the delegate event. If string
+   * based names are used by this delegate to identify ops executed in the
+   * backend then kUnsetDebugHandle should be passed in here.
+   * @param[in] output The int type output to be logged.
+   */
+  virtual void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const int& output) = 0;
+
+  /**
+   * Log an intermediate bool output from a delegate.
+   *
+   * @param[in] name Human readable name for the delegate event. This name has
+   * to be the same name that was passed in during the Debug delegate mapping
+   * generation in the export/ahead-of-time process. If indices and not names
+   * are used by this delegate to identify ops executed in the backend then
+   * nullptr can be passed in. Users calling this interface do not need to keep
+   * the memory pointed to by this pointer around. The string must be copied
+   * over into internal memory during this call.
+   * @param[in] delegate_debug_index The id of the delegate event. If string
+   * based names are used by this delegate to identify ops executed in the
+   * backend then kUnsetDebugHandle should be passed in here.
+   * @param[in] output The bool type output to be logged.
+   */
+  virtual void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const bool& output) = 0;
+
+  /**
+   * Log an intermediate double output from a delegate.
+   *
+   * @param[in] name Human readable name for the delegate event. This name has
+   * to be the same name that was passed in during the Debug delegate mapping
+   * generation in the export/ahead-of-time process. If indices and not names
+   * are used by this delegate to identify ops executed in the backend then
+   * nullptr can be passed in. Users calling this interface do not need to keep
+   * the memory pointed to by this pointer around. The string must be copied
+   * over into internal memory during this call.
+   * @param[in] delegate_debug_index The id of the delegate event. If string
+   * based names are used by this delegate to identify ops executed in the
+   * backend then kUnsetDebugHandle should be passed in here.
+   * @param[in] output The double type output to be logged.
+   */
+  virtual void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const double& output) = 0;
 
   /**
    * Helper function to set the chain id ands debug handle. Users have two

--- a/runtime/core/test/event_tracer_test.cpp
+++ b/runtime/core/test/event_tracer_test.cpp
@@ -88,6 +88,51 @@ class DummyEventTracer : public EventTracer {
     (void)metadata_len;
   }
 
+  void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const Tensor& output) override {
+    (void)name;
+    (void)delegate_debug_index;
+    (void)output;
+  }
+
+  void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const ArrayRef<Tensor> output) override {
+    (void)name;
+    (void)delegate_debug_index;
+    (void)output;
+  }
+
+  void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const int& output) override {
+    (void)name;
+    (void)delegate_debug_index;
+    (void)output;
+  }
+
+  virtual void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const bool& output) override {
+    (void)name;
+    (void)delegate_debug_index;
+    (void)output;
+  }
+
+  virtual void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const double& output) override {
+    (void)name;
+    (void)delegate_debug_index;
+    (void)output;
+  }
+
   void log_evalue(const EValue& evalue, LoggedEValueType evalue_type) override {
     logged_evalue_ = evalue;
     logged_evalue_type_ = evalue_type;

--- a/sdk/etdump/etdump_flatcc.h
+++ b/sdk/etdump/etdump_flatcc.h
@@ -97,6 +97,45 @@ class ETDumpGen : public EventTracer {
       const EValue& evalue,
       LoggedEValueType evalue_type =
           LoggedEValueType::kIntermediateOutput) override;
+  /**
+   * Log an intermediate tensor output from a delegate.
+   */
+  virtual void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const Tensor& output) override;
+
+  /**
+   * Log an intermediate tensor array output from a delegate.
+   */
+  virtual void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const ArrayRef<Tensor> output) override;
+
+  /**
+   * Log an intermediate int output from a delegate.
+   */
+  virtual void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const int& output) override;
+
+  /**
+   * Log an intermediate bool output from a delegate.
+   */
+  virtual void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const bool& output) override;
+
+  /**
+   * Log an intermediate double output from a delegate.
+   */
+  virtual void log_intermediate_output_delegate(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const double& output) override;
   void set_debug_buffer(Span<uint8_t> buffer);
   etdump_result get_etdump_data();
   size_t get_num_blocks();
@@ -115,6 +154,16 @@ class ETDumpGen : public EventTracer {
   void check_ready_to_add_events();
   int64_t create_string_entry(const char* name);
   size_t copy_tensor_to_debug_buffer(exec_aten::Tensor tensor);
+
+  /**
+   * Templated helper function used to log various types of intermediate output.
+   * Supported types include tensor, tensor array, int, bool and double.
+   */
+  template <typename T>
+  void log_intermediate_output_delegate_helper(
+      const char* name,
+      DebugHandle delegate_debug_index,
+      const T& output);
 };
 
 } // namespace executor

--- a/sdk/etdump/etdump_schema_flatcc.fbs
+++ b/sdk/etdump/etdump_schema_flatcc.fbs
@@ -70,6 +70,12 @@ table DebugEvent {
   // The order of these entries is expected to be the same as the parameters
   // that are passed into a operator.
   debug_entry:Value;
+
+  // Integer based delegate debug identifier.
+  delegate_debug_id_int:int = -1;
+
+  // String based delegate debug identifier.
+  delegate_debug_id_str:string;
 }
 
 // All the details pertaining to an allocation done in the runtime. The main

--- a/sdk/etdump/schema_flatcc.py
+++ b/sdk/etdump/schema_flatcc.py
@@ -95,6 +95,8 @@ class Value:
 class DebugEvent:
     chain_index: int
     instruction_id: int
+    delegate_debug_id_int: Optional[int]
+    delegate_debug_id_str: Optional[str]
     debug_entry: Value
 
 

--- a/sdk/etdump/tests/etdump_test.cpp
+++ b/sdk/etdump/tests/etdump_test.cpp
@@ -415,6 +415,148 @@ TEST_F(ProfilerETDumpTest, VerifyData) {
   }
 }
 
+TEST_F(ProfilerETDumpTest, LogDelegateIntermediateOutput) {
+  for (size_t i = 0; i < 2; i++) {
+    void* ptr = malloc(2048);
+    Span<uint8_t> buffer((uint8_t*)ptr, 2048);
+
+    etdump_gen[i]->create_event_block("test_block");
+    testing::TensorFactory<ScalarType::Float> tf;
+
+    ET_EXPECT_DEATH(
+        etdump_gen[i]->log_intermediate_output_delegate(
+            "test_event_tensor",
+            static_cast<torch::executor::DebugHandle>(-1),
+            tf.ones({3, 2})),
+        "Must pre-set debug buffer with set_debug_buffer()");
+    etdump_gen[i]->set_debug_buffer(buffer);
+
+    // Log a tensor
+    etdump_gen[i]->log_intermediate_output_delegate(
+        "test_event_tensor",
+        static_cast<torch::executor::DebugHandle>(-1),
+        tf.ones({3, 2}));
+
+    // Log a tensor list
+    std::vector<Tensor> tensors = {tf.ones({5, 4}), tf.ones({7, 6})};
+    etdump_gen[i]->log_intermediate_output_delegate(
+        "test_event_tensorlist",
+        static_cast<torch::executor::DebugHandle>(-1),
+        ArrayRef<Tensor>(tensors.data(), tensors.size()));
+
+    // Log an int
+    etdump_gen[i]->log_intermediate_output_delegate(
+        "test_event_tensorlist",
+        static_cast<torch::executor::DebugHandle>(-1),
+        10);
+
+    // Log a double
+    etdump_gen[i]->log_intermediate_output_delegate(
+        "test_event_tensorlist",
+        static_cast<torch::executor::DebugHandle>(-1),
+        20.75);
+
+    // Log a bool
+    etdump_gen[i]->log_intermediate_output_delegate(
+        "test_event_tensorlist",
+        static_cast<torch::executor::DebugHandle>(-1),
+        true);
+
+    etdump_result result = etdump_gen[i]->get_etdump_data();
+    ASSERT_TRUE(result.buf != nullptr);
+    ASSERT_TRUE(result.size != 0);
+
+    free(ptr);
+    if (!etdump_gen[i]->is_static_etdump()) {
+      free(result.buf);
+    }
+  }
+}
+
+TEST_F(ProfilerETDumpTest, VerifyDelegateIntermediateLogging) {
+  testing::TensorFactory<ScalarType::Float> tf;
+  EValue evalue(tf.ones({3, 2}));
+
+  for (size_t i = 0; i < 2; i++) {
+    etdump_gen[i]->create_event_block("test_block");
+
+    void* ptr = malloc(2048);
+    Span<uint8_t> buffer((uint8_t*)ptr, 2048);
+
+    etdump_gen[i]->set_debug_buffer(buffer);
+
+    // Event 0
+    etdump_gen[i]->log_intermediate_output_delegate(
+        nullptr, 257, tf.ones({3, 4}));
+    // Event 1
+    etdump_gen[i]->log_intermediate_output_delegate(
+        nullptr, 258, tf.ones({5, 6}));
+
+    etdump_result result = etdump_gen[i]->get_etdump_data();
+    ASSERT_TRUE(result.buf != nullptr);
+    ASSERT_TRUE(result.size != 0);
+
+    size_t size = 0;
+    void* buf = flatbuffers_read_size_prefix(result.buf, &size);
+    etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+        buf, etdump_ETDump_file_identifier);
+
+    etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+    ASSERT_EQ(etdump_RunData_vec_len(run_data_vec), 1);
+
+    etdump_Event_vec_t events =
+        etdump_RunData_events(etdump_RunData_vec_at(run_data_vec, 0));
+    ASSERT_EQ(etdump_Event_vec_len(events), 2);
+
+    // Verify Event 0
+    etdump_Event_table_t event_0 = etdump_Event_vec_at(events, 0);
+
+    etdump_DebugEvent_table_t single_debug_event =
+        etdump_Event_debug_event(event_0);
+    etdump_Value_table_t value =
+        etdump_DebugEvent_debug_entry(single_debug_event);
+    ASSERT_EQ(etdump_Value_tensor_is_present(value), true);
+
+    etdump_Tensor_table_t tensor = etdump_Value_tensor(value);
+    executorch_flatbuffer_ScalarType_enum_t scalar_enum =
+        etdump_Tensor_scalar_type(tensor);
+    ASSERT_EQ(scalar_enum, executorch_flatbuffer_ScalarType_FLOAT);
+    flatbuffers_int64_vec_t sizes = etdump_Tensor_sizes(tensor);
+    ASSERT_EQ(flatbuffers_int64_vec_len(sizes), 2);
+    ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 0), 3);
+    ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 1), 4);
+
+    // Verify Event 1
+    etdump_Event_table_t event_1 = etdump_Event_vec_at(events, 1);
+
+    single_debug_event = etdump_Event_debug_event(event_1);
+    value = etdump_DebugEvent_debug_entry(single_debug_event);
+
+    tensor = etdump_Value_tensor(value);
+    sizes = etdump_Tensor_sizes(tensor);
+    ASSERT_EQ(flatbuffers_int64_vec_len(sizes), 2);
+    ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 0), 5);
+    ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 1), 6);
+
+    // Event 1 should have a empty delegate_debug_id_str
+    flatbuffers_string_t delegate_debug_id_name =
+        etdump_DebugEvent_delegate_debug_id_str(
+            etdump_Event_debug_event(event_1));
+
+    EXPECT_EQ(delegate_debug_id_name, nullptr);
+    // Check for the correct delegate_debug_id_int
+    EXPECT_EQ(
+        etdump_DebugEvent_delegate_debug_id_int(
+            etdump_Event_debug_event(event_1)),
+        258);
+
+    free(ptr);
+    if (!etdump_gen[i]->is_static_etdump()) {
+      free(result.buf);
+    }
+  }
+}
+
 TEST_F(ProfilerETDumpTest, LogDelegateEvents) {
   for (size_t i = 0; i < 2; i++) {
     etdump_gen[i]->create_event_block("test_block");

--- a/sdk/etdump/tests/serialize_test.py
+++ b/sdk/etdump/tests/serialize_test.py
@@ -85,6 +85,8 @@ def get_sample_etdump_flatcc() -> flatcc.ETDumpFlatCC:
                         debug_event=flatcc.DebugEvent(
                             chain_index=1,
                             instruction_id=0,
+                            delegate_debug_id_str="56",
+                            delegate_debug_id_int=-1,
                             debug_entry=flatcc.Value(
                                 val=flatcc.ValueType.TENSOR.value,
                                 tensor=flatcc.Tensor(

--- a/sdk/inspector/tests/event_blocks_test.py
+++ b/sdk/inspector/tests/event_blocks_test.py
@@ -59,6 +59,55 @@ class TestEventBlock(unittest.TestCase):
         )
 
     @staticmethod
+    def _gen_sample_debug_event(
+        instruction_id: int,
+        delegate_debug_id: Optional[Union[int, str]] = None,
+    ) -> flatcc.DebugEvent:
+        """
+        Helper for generating test DebugEvents
+
+        Notably:
+        - delegate_debug_id takes either the str or int representation
+        """
+        delegate_debug_id_int = (
+            delegate_debug_id if isinstance(delegate_debug_id, int) else -1
+        )
+        delegate_debug_id_str = (
+            delegate_debug_id if isinstance(delegate_debug_id, str) else ""
+        )
+
+        return flatcc.DebugEvent(
+            chain_index=0,
+            instruction_id=instruction_id,
+            delegate_debug_id_int=delegate_debug_id_int,
+            delegate_debug_id_str=delegate_debug_id_str,
+            debug_entry=flatcc.Value(
+                val=flatcc.ValueType.TENSOR.value,
+                tensor=flatcc.Tensor(
+                    scalar_type=flatcc.ScalarType.INT,
+                    sizes=[1],
+                    strides=[1],
+                    offset=12345,
+                ),
+                tensor_list=flatcc.TensorList(
+                    [
+                        flatcc.Tensor(
+                            scalar_type=flatcc.ScalarType.INT,
+                            sizes=[1],
+                            strides=[1],
+                            offset=12345,
+                        )
+                    ]
+                ),
+                int_value=flatcc.Int(1),
+                float_value=flatcc.Float(1.0),
+                double_value=flatcc.Double(1.0),
+                bool_value=flatcc.Bool(False),
+                output=flatcc.Bool(True),
+            ),
+        )
+
+    @staticmethod
     def _get_sample_etdump_flatcc() -> flatcc.ETDumpFlatCC:
         """
         Helper for getting a sample ETDumpFlatCC object with 3 RunData:
@@ -123,17 +172,145 @@ class TestEventBlock(unittest.TestCase):
 
         return ETDumpFlatCC(version=0, run_data=[run_data_1, run_data_2, run_data_3])
 
+    @staticmethod
+    def _get_sample_etdump_flatcc_inconsistent_debug_data() -> flatcc.ETDumpFlatCC:
+        debug_event_1 = TestEventBlock._gen_sample_debug_event(
+            instruction_id=1, delegate_debug_id=100
+        )
+        run_data_1 = flatcc.RunData(
+            name="signature_a",
+            bundled_input_index=-1,
+            allocators=[],
+            events=[
+                flatcc.Event(
+                    allocation_event=None,
+                    debug_event=debug_event_1,
+                    profile_event=None,
+                ),
+            ],
+        )
+
+        debug_event_2 = TestEventBlock._gen_sample_debug_event(
+            instruction_id=1, delegate_debug_id=100
+        )
+        # Modify this debug event so it's different from debug_event_1
+        debug_event_2.debug_entry.tensor.sizes = [2]  # pyre-ignore
+        run_data_2 = flatcc.RunData(
+            name="signature_a",
+            bundled_input_index=-1,
+            allocators=[],
+            events=[
+                flatcc.Event(
+                    allocation_event=None,
+                    debug_event=debug_event_2,
+                    profile_event=None,
+                ),
+            ],
+        )
+        return ETDumpFlatCC(version=0, run_data=[run_data_1, run_data_2])
+
+    @staticmethod
+    def _get_sample_etdump_flatcc_profiling_and_debugging() -> flatcc.ETDumpFlatCC:
+        """
+        Helper for getting a sample ETDumpFlatCC object with 3 RunData:
+        - run_data_1 has signature_a with (debug_event_1, profile_event_1)
+        - run_data_2 has the same signature with run_data_1 and same debug event, but different profiling times
+        - run_data_3 has signature_b with (debug_event_3, profile_event_3) and (not debug event, profile_event_4)
+        """
+        profile_event_1 = TestEventBlock._gen_sample_profile_event(
+            name="profile_1", instruction_id=1, time=(0, 1), delegate_debug_id=100
+        )
+        debug_event_1 = TestEventBlock._gen_sample_debug_event(
+            instruction_id=1, delegate_debug_id=100
+        )
+        run_data_1 = flatcc.RunData(
+            name="signature_a",
+            bundled_input_index=-1,
+            allocators=[],
+            events=[
+                flatcc.Event(
+                    allocation_event=None,
+                    debug_event=None,
+                    profile_event=profile_event_1,
+                ),
+                flatcc.Event(
+                    allocation_event=None,
+                    debug_event=debug_event_1,
+                    profile_event=None,
+                ),
+            ],
+        )
+
+        profile_event_2 = TestEventBlock._gen_sample_profile_event(
+            name="profile_1", instruction_id=1, time=(2, 4), delegate_debug_id=100
+        )
+        debug_event_2 = TestEventBlock._gen_sample_debug_event(
+            instruction_id=1, delegate_debug_id=100
+        )
+        run_data_2 = flatcc.RunData(
+            name="signature_a",
+            bundled_input_index=-1,
+            allocators=[],
+            events=[
+                flatcc.Event(
+                    allocation_event=None,
+                    debug_event=None,
+                    profile_event=profile_event_2,
+                ),
+                flatcc.Event(
+                    allocation_event=None,
+                    debug_event=debug_event_2,
+                    profile_event=None,
+                ),
+            ],
+        )
+
+        profile_event_3 = TestEventBlock._gen_sample_profile_event(
+            name="profile_3", instruction_id=1, time=(5, 6), delegate_debug_id=100
+        )
+        debug_event_3 = TestEventBlock._gen_sample_debug_event(
+            instruction_id=1, delegate_debug_id=100
+        )
+        profile_event_4 = TestEventBlock._gen_sample_profile_event(
+            name="profile_4", instruction_id=2, time=(7, 8), delegate_debug_id=100
+        )
+        run_data_3 = flatcc.RunData(
+            name="signature_b",
+            bundled_input_index=-1,
+            allocators=[],
+            events=[
+                flatcc.Event(
+                    allocation_event=None,
+                    debug_event=debug_event_3,
+                    profile_event=None,
+                ),
+                flatcc.Event(
+                    allocation_event=None,
+                    debug_event=None,
+                    profile_event=profile_event_3,
+                ),
+                flatcc.Event(
+                    allocation_event=None,
+                    debug_event=None,
+                    profile_event=profile_event_4,
+                ),
+            ],
+        )
+
+        return ETDumpFlatCC(version=0, run_data=[run_data_1, run_data_2, run_data_3])
+
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tests ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     def test_gen_from_etdump(self) -> None:
         """
         Test "e2e" generation of EventBlocks given an ETDump
-            - Generated via EventBock.gen_from_etdump
+            - Generated via EventBlock.gen_from_etdump
 
         Specifically it tests for external correctness:
         - Correct number of EventBlocks
         - Correct number of Events and Raw Data values (iterations)
         """
+
         etdump: ETDumpFlatCC = TestEventBlock._get_sample_etdump_flatcc()
         blocks: List[EventBlock] = EventBlock._gen_from_etdump(etdump)
 
@@ -146,6 +323,48 @@ class TestEventBlock(unittest.TestCase):
             if (perf_data := block.events[0].perf_data) is not None:
                 run_counts.add((len(block.events), len(perf_data.raw)))
         self.assertSetEqual(run_counts, {(1, 2), (2, 1)})
+
+    def test_gen_from_etdump_profiling_and_debugging(self) -> None:
+        """
+        Test "e2e" generation of EventBlocks given an ETDump with both profiling and debugging events
+            - Generated via EventBlock.gen_from_etdump
+
+        Specifically it tests for external correctness:
+        - Correct number of EventBlocks
+        - Correct number of raw perf_data and debug_data for each Event
+        """
+        etdump: ETDumpFlatCC = (
+            TestEventBlock._get_sample_etdump_flatcc_profiling_and_debugging()
+        )
+        blocks: List[EventBlock] = EventBlock._gen_from_etdump(etdump)
+
+        self.assertEqual(len(blocks), 2, f"Expected 2 runs, got {len(blocks)}")
+
+        # One EventBlock should have 1 event with 2 iterations
+        # and 1 debug data (because we only populate debug data in the first iteration)
+        self.assertEqual(len(blocks[0].events), 1)
+        if (perf_data := blocks[0].events[0].perf_data) is not None:
+            self.assertEqual(len(perf_data.raw), 2)
+        self.assertEqual(len(blocks[0].events[0].debug_data), 1)
+        # The other EventBlock should have 2 events with 1 iterations, and only the fist event has debug data
+        self.assertEqual(len(blocks[1].events), 2)
+        if (perf_data := blocks[1].events[0].perf_data) is not None:
+            self.assertEqual(len(perf_data.raw), 1)
+        if (perf_data := blocks[1].events[1].perf_data) is not None:
+            self.assertEqual(len(perf_data.raw), 1)
+        self.assertEqual(len(blocks[1].events[0].debug_data), 1)
+        self.assertEqual(len(blocks[1].events[1].debug_data), 0)
+
+    def test_gen_from_etdump_inconsistent_debug_data(self) -> None:
+        """
+        Make sure AssertionError is thrown when intermediate outputs are different across
+        different iterations of a model run
+        """
+        etdump: ETDumpFlatCC = (
+            TestEventBlock._get_sample_etdump_flatcc_inconsistent_debug_data()
+        )
+        with self.assertRaises(AssertionError):
+            EventBlock._gen_from_etdump(etdump)
 
     def test_inspector_event_generation(self) -> None:
         """
@@ -187,7 +406,8 @@ class TestEventBlock(unittest.TestCase):
             self.assertEqual(profile_signature, expected_signature)
 
             event_signature = EventSignature(
-                instruction_id=instruction_id, profile_event_signature=profile_signature
+                instruction_id=instruction_id,
+                profile_event_signature=profile_signature,
             )
 
             # Test Event Generation

--- a/sdk/inspector/tests/inspector_test.py
+++ b/sdk/inspector/tests/inspector_test.py
@@ -283,6 +283,8 @@ class TestInspector(unittest.TestCase):
         debug_event_0 = flatcc.DebugEvent(
             chain_index=1,
             instruction_id=0,
+            delegate_debug_id_int=1,
+            delegate_debug_id_str=None,
             debug_entry=flatcc.Value(
                 val=flatcc.ValueType.TENSOR.value,
                 tensor=flatcc.Tensor(
@@ -304,6 +306,8 @@ class TestInspector(unittest.TestCase):
         debug_event_1 = flatcc.DebugEvent(
             chain_index=1,
             instruction_id=0,
+            delegate_debug_id_int=1,
+            delegate_debug_id_str=None,
             debug_entry=flatcc.Value(
                 val=flatcc.ValueType.TENSOR.value,
                 tensor=flatcc.Tensor(
@@ -346,6 +350,8 @@ class TestInspector(unittest.TestCase):
         debug_event_0 = flatcc.DebugEvent(
             chain_index=1,
             instruction_id=0,
+            delegate_debug_id_int=1,
+            delegate_debug_id_str=None,
             debug_entry=flatcc.Value(
                 val=flatcc.ValueType.TENSOR.value,
                 tensor=flatcc.Tensor(
@@ -367,6 +373,8 @@ class TestInspector(unittest.TestCase):
         debug_event_1 = flatcc.DebugEvent(
             chain_index=1,
             instruction_id=0,
+            delegate_debug_id_int=1,
+            delegate_debug_id_str=None,
             debug_entry=flatcc.Value(
                 val=flatcc.ValueType.TENSOR.value,
                 tensor=flatcc.Tensor(

--- a/sdk/inspector/tests/inspector_utils_test.py
+++ b/sdk/inspector/tests/inspector_utils_test.py
@@ -76,6 +76,8 @@ class TestInspectorUtils(unittest.TestCase):
         debug_event = flatcc.DebugEvent(
             chain_index=1,
             instruction_id=0,
+            delegate_debug_id_str="56",
+            delegate_debug_id_int=-1,
             debug_entry=flatcc.Value(
                 val=flatcc.ValueType.TENSOR.value,
                 tensor=flatcc.Tensor(


### PR DESCRIPTION
Summary:
This diff parses the logged intermediate outputs in etdump into Inspector objects.
Design doc: https://docs.google.com/document/d/1qGHsgd-roqtxPz4CrUlqGrKaAtbaf9bArziMuwHD0So/edit

Differential Revision: D59614926
