### PR TITLE
remove buck2 installation from setup page

### DIFF
--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -195,41 +195,6 @@ Output 0: tensor(sizes=[1], [2.])
 
 To learn how to build a similar program, visit the [Runtime APIs Tutorial](extension-module.md).
 
-### [Optional] Setting Up Buck2
-**Buck2** is an open-source build system that some of our examples currently utilize for building and running.
-
-However, please note that the installation of `Buck2` is optional for using ExecuTorch and we are in the process of transitioning away from `Buck2` and migrating all relevant sections to `cmake`. This section will be removed once we finish the migration.
-
-To set up `Buck2`, You will need the following prerequisits for this section:
-* The `zstd` command line tool — install by running
-   ```bash
-   pip3 install zstd
-   ```
-* Version `${executorch_version:buck2}` of the `buck2` commandline tool — you can download a
-  prebuilt archive for your system from [the Buck2
-  repo](https://github.com/facebook/buck2/releases/tag/2024-05-15). Note that
-  the version is important, and newer or older versions may not work with the
-  version of the buck2 prelude used by the ExecuTorch repo.
-
-Configure Buck2 by decompressing with the following command (filename depends
-   on your system, and the location of the binary can be different):
-
-   ```bash
-   # For example, buck2-x86_64-unknown-linux-musl.zst for Linux, or buck2-aarch64-apple-darwin.zst for Mac with Apple silicon.
-   zstd -cdq buck2-DOWNLOADED_FILENAME.zst > /tmp/buck2 && chmod +x /tmp/buck2
-   ```
-
-You may want to copy the `buck2` binary into your `$PATH` so you can run it
-   as `buck2`.
-
-After the installation, you can run the `add.pte` program by following `buck2` command:
-
-```bash
-/tmp/buck2 run //examples/portable/executor_runner:executor_runner -- --model_path add.pte
-```
-
-Note that the first run may take a while as it will have to complie the kernels from sources
-
 ## Next Steps
 
 Congratulations! You have successfully exported, built, and run your first


### PR DESCRIPTION
Summary: For alpha+, we need to remove all buck2 commands and buck2 dependencies from static doc and github readmes. This diff gets rid of the buck2 installation from set up page.

Differential Revision: D59642493
