### PR TITLE
Set FLATBUFFERS_MAX_ALIGNMENT=1024

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,11 @@ if(EXECUTORCH_BUILD_FLATC)
       CACHE BOOL ""
   )
   add_subdirectory(third-party/flatbuffers)
+
+  # exir lets users set the alignment of tensor data embedded in the flatbuffer,
+  # and some users need an alignment larger than the default, which is typically
+  # 32.
+  target_compile_definitions(flatc PRIVATE FLATBUFFERS_MAX_ALIGNMENT=1024)
 endif()
 if(NOT FLATC_EXECUTABLE)
   message(

--- a/schema/CMakeLists.txt
+++ b/schema/CMakeLists.txt
@@ -44,6 +44,13 @@ function(generate_program_schema _schema_srcs _schema_name)
 
   add_library(${_schema_name} INTERFACE ${_schema_outputs})
   set_target_properties(${_schema_name} PROPERTIES LINKER_LANGUAGE CXX)
+
+  # exir lets users set the alignment of tensor data embedded in the flatbuffer,
+  # and some users need an alignment larger than the default, which is typically
+  # 32.
+  target_compile_definitions(
+    ${_schema_name} INTERFACE FLATBUFFERS_MAX_ALIGNMENT=1024)
+
   target_include_directories(
     ${_schema_name}
     INTERFACE ${_program_schema__include_dir}


### PR DESCRIPTION
I noticed a [build failure](https://github.com/pytorch/executorch/actions/runs/9883069353/job/27297116628#step:12:12476) during a flatc execution step, complaining about a `force_align` value that was larger than FLATBUFFERS_MAX_ALIGNMENT (default 32):

```
Exported ModuleAddMul and wrote program data to cmake-out/ModuleAddMul.pte
Exported ModuleAddMul and wrote program data to cmake-out/ModuleAddMul-da1024.pte
Exported ModuleAddMul and wrote program data to cmake-out/ModuleAddMul-nosegments.pte

error:
  /tmp/tmpslmqnrmb/data.json:1: 2248: error: unexpected force_align value '1024', alignment must be a power of two integer ranging from the type's natural alignment 1 to 32
```
The error message is printed by https://github.com/google/flatbuffers/blob/fb9afbafc7dfe226b9db54d4923bfb8839635274/src/idl_parser.cpp#L1694

exir lets users set the alignment of tensor data embedded in the flatbuffer, and some users need an alignment larger than the default. So, increase the default to a "large" power of 2 when building `flatc` and when building the runtime.

Test Plan:
CI jobs pass.

I looked at the makefiles generated by cmake, and verified that FLATBUFFERS_MAX_ALIGNMENT is only being set while building `flatc` and `executorch_no_prim_ops`:
```
find . -name flags.make | xargs grep MAX_ALIGNMENT

./CMakeFiles/executorch_no_prim_ops.dir/flags.make:CXX_DEFINES = -DET_ENABLE_PROGRAM_VERIFICATION=0 -DET_MIN_LOG_LEVEL=Info -DFLATBUFFERS_MAX_ALIGNMENT=1024
./third-party/flatbuffers/CMakeFiles/flatc.dir/flags.make:CXX_DEFINES = -DET_ENABLE_PROGRAM_VERIFICATION=0 -DET_MIN_LOG_LEVEL=Info -DFLATBUFFERS_LOCALE_INDEPENDENT=0 -DFLATBUFFERS_MAX_ALIGNMENT=1024
```