### PR TITLE
remove buck2 from runtime overview

### DIFF
--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -195,41 +195,6 @@ Output 0: tensor(sizes=[1], [2.])
 
 To learn how to build a similar program, visit the [Runtime APIs Tutorial](extension-module.md).
 
-### [Optional] Setting Up Buck2
-**Buck2** is an open-source build system that some of our examples currently utilize for building and running.
-
-However, please note that the installation of `Buck2` is optional for using ExecuTorch and we are in the process of transitioning away from `Buck2` and migrating all relevant sections to `cmake`. This section will be removed once we finish the migration.
-
-To set up `Buck2`, You will need the following prerequisits for this section:
-* The `zstd` command line tool — install by running
-   ```bash
-   pip3 install zstd
-   ```
-* Version `${executorch_version:buck2}` of the `buck2` commandline tool — you can download a
-  prebuilt archive for your system from [the Buck2
-  repo](https://github.com/facebook/buck2/releases/tag/2024-05-15). Note that
-  the version is important, and newer or older versions may not work with the
-  version of the buck2 prelude used by the ExecuTorch repo.
-
-Configure Buck2 by decompressing with the following command (filename depends
-   on your system, and the location of the binary can be different):
-
-   ```bash
-   # For example, buck2-x86_64-unknown-linux-musl.zst for Linux, or buck2-aarch64-apple-darwin.zst for Mac with Apple silicon.
-   zstd -cdq buck2-DOWNLOADED_FILENAME.zst > /tmp/buck2 && chmod +x /tmp/buck2
-   ```
-
-You may want to copy the `buck2` binary into your `$PATH` so you can run it
-   as `buck2`.
-
-After the installation, you can run the `add.pte` program by following `buck2` command:
-
-```bash
-/tmp/buck2 run //examples/portable/executor_runner:executor_runner -- --model_path add.pte
-```
-
-Note that the first run may take a while as it will have to complie the kernels from sources
-
 ## Next Steps
 
 Congratulations! You have successfully exported, built, and run your first

--- a/docs/source/runtime-build-and-cross-compilation.md
+++ b/docs/source/runtime-build-and-cross-compilation.md
@@ -1,16 +1,13 @@
 # Building with CMake
 
-Although buck2 is the main build system for the ExecuTorch project, it's also
-possible to build core pieces of the runtime using [CMake](https://cmake.org/)
-for easier integration with other build systems. Even if you don't use CMake
-directly, CMake can emit scripts for other format like Make, Ninja or Xcode.
-For information, see [cmake-generators(7)](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
+ExecuTorch uses [CMake](https://cmake.org/)  as its primary build system.
+Even if you don't use CMake directly, CMake can emit scripts for other format
+like Make, Ninja or Xcode. For information, see [cmake-generators(7)](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 ## Targets Built by the CMake Build System
 
-ExecuTorch's CMake build system doesn't cover everything that the buck2 build
-system covers. It can only build pieces of the runtime that are likely to be
-useful to embedded systems users.
+ExecuTorch's CMake build system covers the pieces of the runtime that are
+likely to be useful to embedded systems users.
 
 - `libexecutorch.a`: The core of the ExecuTorch runtime. Does not contain any
   operator/kernel definitions or backend definitions.
@@ -31,17 +28,8 @@ useful to embedded systems users.
 
 Follow the steps below to have the tools ready before using CMake to build on your machine.
 
-1. Clone the repo and install buck2 as described in the "Building a Runtime" section
-   of [Setting Up ExecuTorch](getting-started-setup.md#building-a-runtime)
-   - `buck2` is necessary because the CMake build system runs `buck2` commands
-     to extract source lists from the primary build system. It will be possible
-     to configure the CMake system to avoid calling `buck2`, though.
-2. If your system's version of python3 is older than 3.11:
+1. If your system's version of python3 is older than 3.11:
    - Run `pip install tomli`
-   - This provides an import required by a script that the CMake build system
-     calls to extract source lists from `buck2`. Consider doing this `pip
-     install` inside your Python or Conda virtual environment if you created
-     one already by following [Setting up ExecuTorch](getting-started-setup.md#setting-up-executorch).
 3. Install CMake version 3.19 or later:
    - Run `conda install cmake` or `pip install cmake`.
 
@@ -57,9 +45,6 @@ cd executorch
 
 # Clean and configure the CMake build system. It's good practice to do this
 # whenever cloning or pulling the upstream repo.
-#
-# NOTE: If your `buck2` binary is not on the PATH, you can change this line to
-# say something like `-DBUCK2=/tmp/buck2` to point directly to the tool.
 (rm -rf cmake-out && mkdir cmake-out && cd cmake-out && cmake ..)
 ```
 
@@ -140,7 +125,6 @@ Assuming Android NDK is available, run:
 rm -rf cmake-android-out && mkdir cmake-android-out && cd cmake-android-out
 
 # point -DCMAKE_TOOLCHAIN_FILE to the location where ndk is installed
-# Run `which buck2`, if it returns empty (meaning the system doesn't know where buck2 is installed), pass in this flag `-DBUCK2=/path/to/buck2` pointing to buck2
 cmake -DCMAKE_TOOLCHAIN_FILE=/Users/{user_name}/Library/Android/sdk/ndk/25.2.9519653/build/cmake/android.toolchain.cmake  -DANDROID_ABI=arm64-v8a ..
 
 cd  ..

--- a/docs/source/runtime-overview.md
+++ b/docs/source/runtime-overview.md
@@ -101,8 +101,7 @@ can build it for a wide variety of target systems.
   to them.
 * The code is compatible with GCC and Clang, and has also been built with
   several proprietary embedded toolchains.
-* The repo provides both CMake and buck2 build systems to make integration
-  easier.
+* The repo provides CMake build system to make integration easier.
 
 #### Operating System Considerations
 


### PR DESCRIPTION
Summary:
For alpha+, we need to remove all buck2 commands and buck2 dependencies from static doc and github readmes.

 This diff gets rid of the buck2 from runtime overview.

Differential Revision: D59646100
