### PR TITLE
Duplicate dequant nodes for dq encoder

### DIFF
--- a/backends/transforms/TARGETS
+++ b/backends/transforms/TARGETS
@@ -120,6 +120,7 @@ runtime.python_library(
         "//executorch/backends/...",
         "//executorch/examples/...",
         "//executorch/extension/llm/...",
+        "@EXECUTORCH_CLIENTS",
     ],
     deps = [
         "//caffe2:torch",


### PR DESCRIPTION
Summary:
{F1749810435}

Here, slice_9 and slice_10 are nops. When eliminated, the graph reduces to

{F1749810958}

dequantize_per_tensor_tensor_3 becomes input to two linear ops, causing failure in dq partitioner. This diff creates duplicates of dequant nodes so that each linear has unique inputs for dq partitioner.

Differential Revision: D59647685


