### PR TITLE
Move SDPA decomp pass from Qualcomm's directory to be shareable and call it for Cadence backends

### DIFF
--- a/backends/cadence/aot/TARGETS
+++ b/backends/cadence/aot/TARGETS
@@ -34,6 +34,7 @@ python_library(
         "//caffe2:torch",
         "//executorch/backends/cadence/aot/quantizer:fusion_pass",
         "//executorch/backends/cadence/aot/quantizer:quantizer",
+        "//executorch/backends/transforms:decompose_sdpa",
         "//executorch/exir:lib",
     ],
 )

--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -23,6 +23,9 @@ from executorch.backends.cadence.aot.quantizer.quantizer import (
     CadenceQuantizer,
 )
 from executorch.backends.cadence.aot.utils import model_is_quantized
+from executorch.backends.transforms.decompose_sdpa import (
+    DecomposeScaledDotProductAttention,
+)
 from executorch.exir import EdgeCompileConfig, EdgeProgramManager, to_edge
 from pyre_extensions import assert_is_instance
 from torch._export import capture_pre_autograd_graph
@@ -46,6 +49,9 @@ def quantize_pt2(
 
     # Export with dynamo
     model_exp = capture_pre_autograd_graph(model, inputs)
+
+    # Decompose SDPA
+    DecomposeScaledDotProductAttention(False)(model_exp)
 
     # Prepare
     prepared_model = prepare_pt2e(model_exp, quantizer)

--- a/backends/qualcomm/quantizer/quantizer.py
+++ b/backends/qualcomm/quantizer/quantizer.py
@@ -7,9 +7,6 @@ from enum import IntEnum, unique
 from typing import Callable, Dict, Optional, Sequence, Set
 
 import torch
-from executorch.backends.qualcomm.passes.decompose_scaled_dot_product_attention import (
-    DecomposeScaledDotProductAttention,
-)
 from executorch.backends.qualcomm.passes.decompose_silu import DecomposeSilu
 from executorch.backends.qualcomm.passes.recompose_pixel_unshuffle import (
     RecomposePixelUnshuffle,
@@ -17,6 +14,9 @@ from executorch.backends.qualcomm.passes.recompose_pixel_unshuffle import (
 from executorch.backends.qualcomm.passes.reduce_dynamic_range import ReduceDynamicRange
 from executorch.backends.qualcomm.passes.remove_redundancy import RemoveRedundancy
 from executorch.backends.qualcomm.passes.replace_inf_buffer import ReplaceInfBuffer
+from executorch.backends.transforms.decompose_sdpa import (
+    DecomposeScaledDotProductAttention,
+)
 
 from torch._ops import OpOverload
 from torch.ao.quantization.quantizer import Quantizer

--- a/backends/transforms/TARGETS
+++ b/backends/transforms/TARGETS
@@ -30,6 +30,19 @@ runtime.python_library(
 )
 
 runtime.python_library(
+    name = "decompose_sdpa",
+    srcs = ["decompose_sdpa.py"],
+    visibility = [
+        "//executorch/backends/...",
+        "@EXECUTORCH_CLIENTS",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir:pass_base",
+    ],
+)
+
+runtime.python_library(
     name = "fuse_batch_norm_with_conv",
     srcs = ["fuse_batch_norm_with_conv.py"],
     visibility = [


### PR DESCRIPTION
Summary: Moving the pass to backends/transforms so that other backends can call it, and call it from the Cadence side so that we can quantize the bmm ops in SDPA.

Differential Revision: D59600486
