### PR TITLE
Add pyre-ignore to fix executorch for D59723984

### DIFF
--- a/exir/capture/_capture.py
+++ b/exir/capture/_capture.py
@@ -215,7 +215,7 @@ def capture(  # noqa: C901
             ep = _transform(ep, ReplaceViewOpsWithViewCopyOpsPass())
             if not config._unlift:
                 return ExirExportedProgram(ep, False)
-            graph_module = ep.module()
+            graph_module = cast(torch.fx.GraphModule, ep.module())
 
         elif config.enable_dynamic_shape:
             graph_module, _ = dynamo_trace(

--- a/exir/delegate.py
+++ b/exir/delegate.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import torch
 import torch.utils._pytree as pytree
@@ -38,7 +38,9 @@ def trace_call_delegate(proxy_mode, func_overload, lowered_module, *args):
     def _unwrap_proxy(e):
         if not isinstance(e, (torch.Tensor, torch.SymInt, torch.SymFloat)):
             return e
-        return get_proxy_slot(e, proxy_mode.tracer, e, lambda e: e.proxy)
+        return get_proxy_slot(
+            cast(torch.Tensor, e), proxy_mode.tracer, e, lambda e: e.proxy
+        )
 
     if not is_lowered_module(lowered_module):
         raise ValueError(


### PR DESCRIPTION
Summary: D59723984 improves some typing for pytorch proxy_tensor - but it causes executorch to get some minor type errors.  This should allow the subsequent diffs to pass.

Reviewed By: oulgen

Differential Revision: D59726906
