### PR TITLE
Add Buffer Memory Bandwidth profiler

### DIFF
--- a/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.glsl
+++ b/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.glsl
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+
+#define PRECISION ${PRECISION}
+
+layout(std430) buffer;
+
+${layout_declare_buffer(0, "r", "A", DTYPE, "PRECISION", False)}
+${layout_declare_buffer(1, "w", "B", DTYPE, "PRECISION", False)}
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+layout(constant_id = 3) const int niter = 1;
+layout(constant_id = 4) const int addr_mask = 1;
+layout(constant_id = 5) const int local_group_size = 1;
+
+void main() {
+    vec4 sum = vec4(0);
+    const uint workgroup_width = local_group_size * niter * ${NUNROLL};
+    uint offset = (gl_WorkGroupID[0] * workgroup_width  + gl_LocalInvocationID[0]) & addr_mask;
+
+    int i = 0;
+    for (; i < niter; ++i)
+    {
+      $for j in range(int(NUNROLL)):
+          sum *= A[offset];
+          offset = (offset + local_group_size) & addr_mask;
+    }
+
+    vec4 zero = vec4(i>>31);
+
+    B[gl_LocalInvocationID[0]] = sum + zero;
+}

--- a/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.yaml
+++ b/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+buf_bandwidth:
+  parameter_names_with_default_values:
+    DTYPE: float
+    STORAGE: buffer
+    NUNROLL: "16"
+  shader_variants:
+    - NAME: buf_bandwidth

--- a/backends/vulkan/tools/gpuinfo/include/stats.h
+++ b/backends/vulkan/tools/gpuinfo/include/stats.h
@@ -39,6 +39,61 @@
 #include <cstdint>
 
 template <typename T>
+class MinStats {
+  T mn_ = std::numeric_limits<T>::max();
+
+ public:
+  typedef T value_t;
+
+  // Returns true if the value has been updated.
+  bool push(T value) {
+    if (mn_ > value) {
+      mn_ = value;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  inline bool has_value() const {
+    return mn_ != std::numeric_limits<T>::max();
+  }
+  operator T() const {
+    return mn_;
+  }
+  friend std::ostream& operator<<(std::ostream& out, const MinStats<T>& x) {
+    out << (T)(x);
+    return out;
+  }
+};
+template <typename T>
+class MaxStats {
+  T mx_ = -std::numeric_limits<T>::max();
+
+ public:
+  typedef T value_t;
+
+  // Returns true if the value has been updated.
+  bool push(T value) {
+    if (mx_ < value) {
+      mx_ = value;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  inline bool has_value() const {
+    return mx_ != -std::numeric_limits<T>::max();
+  }
+  operator T() const {
+    return mx_;
+  }
+  friend std::ostream& operator<<(std::ostream& out, const MaxStats<T>& x) {
+    out << (T)(x);
+    return out;
+  }
+};
+
+template <typename T>
 class AvgStats {
   T sum_ = 0;
   uint64_t n_ = 0;


### PR DESCRIPTION
This diff introduces a profiler that obtains the maximum and minimum bandwidth for reading buffers from memory, using the following shader, where A and B are readonly and writeonly buffers, respectively.

```
  void main() {
    vec4 sum = vec4(0);
    const uint workgroup_width = local_group_size * niter * ${NUNROLL};
    uint offset = (gl_WorkGroupID[0] * workgroup_width  + gl_LocalInvocationID[0]) & addr_mask;

    int i = 0;
    for (; i < niter; ++i)
    {
        sum *= A[offset];
        offset = (offset + local_group_size) & addr_mask;
        ...
        ...
        sum *= A[offset];
        offset = (offset + local_group_size) & addr_mask;
    }

    vec4 zero = vec4(i>>31);

    B[gl_LocalInvocationID[0]] = sum + zero;
}
```

Through the WorkGroup and LocalInvocation IDs, we ensure that each run accesses its own block of memory. Then, we repeatedly access several unique address locations, using an address mask to wrap around if necessary.
Finally, we make sure to use the `sum` and `i	` variables so that the compiler's optimizer does not flatten the loops. 

For a Samsung S22, the bandwidth behaves like this. We can see a limitation when buffers reach 32 KB in size.

![image](https://github.com/user-attachments/assets/fca47b90-81d8-4c4d-9492-840c7ff77e65)

Differential Revision: D59687299
