### PR TITLE
Remove print statement in SPIR-V compilation scripts

### DIFF
--- a/backends/vulkan/runtime/gen_vulkan_spv.py
+++ b/backends/vulkan/runtime/gen_vulkan_spv.py
@@ -676,7 +676,6 @@ class SPVGenerator:
                     for arg in ["-I", src_dir_path]
                 ]
 
-                print("glslc cmd:", cmd)
                 subprocess.check_call(cmd)
 
                 return (spv_out_path, glsl_out_path)


### PR DESCRIPTION
Summary: Remove print statements in SPIR-V compilation script to fix CI errors.

Differential Revision: D59768872
