### PR TITLE
Add Local Memory Bandwidth Profiler

### DIFF
--- a/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.glsl
+++ b/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.glsl
@@ -12,7 +12,11 @@
 
 layout(std430) buffer;
 
-${layout_declare_buffer(0, "r", "A", DTYPE, "PRECISION", False)}
+$if MEMTYPE == "ubo":
+    ${layout_declare_ubo(0, "vec4", "A")}
+$else:
+    ${layout_declare_buffer(0, "r", "A", DTYPE, "PRECISION", False)}
+
 ${layout_declare_buffer(1, "w", "B", DTYPE, "PRECISION", False)}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;

--- a/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.glsl
+++ b/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.glsl
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+
+#define PRECISION ${PRECISION}
+
+layout(std430) buffer;
+
+${layout_declare_buffer(0, "r", "A", DTYPE, "PRECISION", False)}
+${layout_declare_buffer(1, "w", "B", DTYPE, "PRECISION", False)}
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+layout(constant_id = 3) const int niter = 1;
+layout(constant_id = 4) const int addr_mask = 1;
+layout(constant_id = 5) const int local_group_size = 1;
+
+void main() {
+    vec4 sum = vec4(0);
+    const uint workgroup_width = local_group_size * niter * ${NUNROLL};
+    uint offset = (gl_WorkGroupID[0] * workgroup_width  + gl_LocalInvocationID[0]) & addr_mask;
+
+    int i = 0;
+    for (; i < niter; ++i)
+    {
+      $for j in range(int(NUNROLL)):
+          sum *= A[offset];
+          offset = (offset + local_group_size) & addr_mask;
+    }
+
+    vec4 zero = vec4(i>>31);
+
+    B[gl_LocalInvocationID[0]] = sum + zero;
+}

--- a/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.glsl
+++ b/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.glsl
@@ -14,18 +14,29 @@ layout(std430) buffer;
 
 $if MEMTYPE == "ubo":
     ${layout_declare_ubo(0, "vec4", "A")}
-$else:
+$elif MEMTYPE == "buffer":
     ${layout_declare_buffer(0, "r", "A", DTYPE, "PRECISION", False)}
+$else:
+    ${layout_declare_buffer(0, "r", "_", DTYPE, "PRECISION", False)}
 
 ${layout_declare_buffer(1, "w", "B", DTYPE, "PRECISION", False)}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 layout(constant_id = 3) const int niter = 1;
-layout(constant_id = 4) const int addr_mask = 1;
+layout(constant_id = 4) const int nvec = 1;
 layout(constant_id = 5) const int local_group_size = 1;
 
+$if MEMTYPE == "shared":
+    shared vec4 A[nvec];
+
 void main() {
+
+    $if MEMTYPE == "shared":
+        A[gl_LocalInvocationID[0]][0] = gl_LocalInvocationID[0];
+        memoryBarrierShared();
+
+    const int addr_mask = nvec - 1;
     vec4 sum = vec4(0);
     const uint workgroup_width = local_group_size * niter * ${NUNROLL};
     uint offset = (gl_WorkGroupID[0] * workgroup_width  + gl_LocalInvocationID[0]) & addr_mask;

--- a/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.yaml
+++ b/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+buf_bandwidth:
+  parameter_names_with_default_values:
+    DTYPE: float
+    STORAGE: buffer
+    NUNROLL: "16"
+  shader_variants:
+    - NAME: buf_bandwidth

--- a/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.yaml
+++ b/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.yaml
@@ -9,5 +9,9 @@ buf_bandwidth:
     DTYPE: float
     STORAGE: buffer
     NUNROLL: "16"
+  generate_variant_forall:
+    MEMTYPE:
+      - VALUE: ubo
+      - VALUE: buffer
   shader_variants:
     - NAME: buf_bandwidth

--- a/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.yaml
+++ b/backends/vulkan/tools/gpuinfo/glsl/buf_bandwidth.yaml
@@ -13,5 +13,6 @@ buf_bandwidth:
     MEMTYPE:
       - VALUE: ubo
       - VALUE: buffer
+      - VALUE: shared
   shader_variants:
     - NAME: buf_bandwidth

--- a/backends/vulkan/tools/gpuinfo/include/stats.h
+++ b/backends/vulkan/tools/gpuinfo/include/stats.h
@@ -39,6 +39,61 @@
 #include <cstdint>
 
 template <typename T>
+class MinStats {
+  T mn_ = std::numeric_limits<T>::max();
+
+ public:
+  typedef T value_t;
+
+  // Returns true if the value has been updated.
+  bool push(T value) {
+    if (mn_ > value) {
+      mn_ = value;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  inline bool has_value() const {
+    return mn_ != std::numeric_limits<T>::max();
+  }
+  operator T() const {
+    return mn_;
+  }
+  friend std::ostream& operator<<(std::ostream& out, const MinStats<T>& x) {
+    out << (T)(x);
+    return out;
+  }
+};
+template <typename T>
+class MaxStats {
+  T mx_ = -std::numeric_limits<T>::max();
+
+ public:
+  typedef T value_t;
+
+  // Returns true if the value has been updated.
+  bool push(T value) {
+    if (mx_ < value) {
+      mx_ = value;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  inline bool has_value() const {
+    return mx_ != -std::numeric_limits<T>::max();
+  }
+  operator T() const {
+    return mx_;
+  }
+  friend std::ostream& operator<<(std::ostream& out, const MaxStats<T>& x) {
+    out << (T)(x);
+    return out;
+  }
+};
+
+template <typename T>
 class AvgStats {
   T sum_ = 0;
   uint64_t n_ = 0;

--- a/backends/vulkan/tools/gpuinfo/src/app.cpp
+++ b/backends/vulkan/tools/gpuinfo/src/app.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <executorch/backends/vulkan/runtime/api/api.h>
-#include <executorch/backends/vulkan/runtime/graph/ops/utils/StagingUtils.h>
 #include <iostream>
 
 #include "stats.h"
@@ -18,6 +17,7 @@ using namespace vkapi;
 class App {
  private:
   size_t buf_cache_size_;
+  uint32_t max_shared_mem_size_;
   uint32_t sm_count_;
   uint32_t nthread_logic_;
 
@@ -33,11 +33,12 @@ class App {
     sm_count_ = cl_device.getInfo<CL_DEVICE_MAX_COMPUTE_UNITS>();
     nthread_logic_ = cl_device.getInfo<CL_DEVICE_MAX_WORK_GROUP_SIZE>();
     buf_cache_size_ = cl_device.getInfo<CL_DEVICE_GLOBAL_MEM_CACHE_SIZE>();
-
+    max_shared_mem_size_ = cl_device.getInfo<CL_DEVICE_LOCAL_MEM_SIZE>();
     std::cout << std::endl;
     std::cout << "SM count," << sm_count_ << std::endl;
     std::cout << "Logic Thread Count," << nthread_logic_ << std::endl;
     std::cout << "Cache Size," << buf_cache_size_ << std::endl;
+    std::cout << "Shared Memory Size," << max_shared_mem_size_ << std::endl;
   }
 
   void reg_count() {
@@ -211,13 +212,8 @@ class App {
   }
 
  private:
-  void _bandwidth(std::string memtype) {
+  void _bandwidth(std::string memtype, size_t range) {
     // TODO: Make these values configurable
-
-    // Maximum memory space read - 128MB
-    // For regular devices, bandwidth plateaus at less memory than this, so more
-    // is not needed.
-    const size_t RANGE = 128 * 1024 * 1024;
     // Cache lines flushed
     const uint32_t NFLUSH = 4;
     // Number of loop unrolls. Changing this value requires an equal change in
@@ -230,11 +226,13 @@ class App {
     const uint32_t VEC_WIDTH = 4;
     const size_t VEC_SIZE = VEC_WIDTH * sizeof(float);
     // Number of vectors that fit in the selected memory space
-    const size_t NVEC = RANGE / VEC_SIZE;
+    const size_t NVEC = range / VEC_SIZE;
     // Number of memory reads per thread
     const uint32_t NREAD_PER_THREAD = NUNROLL * NITER;
-    // Number of threads needed to read all vectors
-    const int NTHREAD = NVEC / NREAD_PER_THREAD;
+    // Number of threads needed to read al l vectors
+    // The thread count doesn't divide by thread workload in shared memory
+    // because of the limited memory size.
+    const int NTHREAD = memtype == "Shared" ? NVEC : NVEC / NREAD_PER_THREAD;
     // Occupy all threads
     const uint local_x = nthread_logic_;
     // Ensure that global is a multiple of local, and distribute across all SMs
@@ -242,10 +240,10 @@ class App {
 
     auto bench = [&](size_t access_size) {
       // Number of vectors that fit in this iteration
-      const size_t nvec_access = access_size / VEC_SIZE;
-      const uint32_t addr_mask = nvec_access - 1;
+      const uint32_t nvec_access = access_size / VEC_SIZE;
 
-      StorageBuffer in_buf(context(), vkapi::kFloat, RANGE / sizeof(float));
+      StorageBuffer in_buf(
+          context(), vkapi::kFloat, range/ sizeof(float));
       StorageBuffer out_buf(
           context(), vkapi::kFloat, VEC_WIDTH * nthread_logic_);
       vkapi::PipelineBarrier pipeline_barrier{};
@@ -264,7 +262,7 @@ class App {
             pipeline_barrier,
             {global_x, 1, 1},
             {local_x, 1, 1},
-            {SV(NITER), SV(addr_mask), SV(local_x)},
+            {SV(NITER), SV(nvec_access), SV(local_x)},
             VK_NULL_HANDLE,
             0,
             in_buf.buffer(),
@@ -281,7 +279,7 @@ class App {
 
     MaxStats<double> max_bandwidth{};
     MinStats<double> min_bandwidth{};
-    for (size_t access_size = VEC_SIZE; access_size < RANGE; access_size *= 2) {
+    for (size_t access_size = VEC_SIZE; access_size < range; access_size *= 2) {
       double gbps = bench(access_size);
       max_bandwidth.push(gbps);
       min_bandwidth.push(gbps);
@@ -296,12 +294,22 @@ class App {
  public:
   void buf_bandwidth() {
     std::cout << "\n------ Memory Bandwidth ------" << std::endl;
-    _bandwidth("Buffer");
+    // Maximum memory space read - 128MB
+    // For regular devices, bandwidth plateaus at less memory than this, so more
+    // is not needed.
+    const size_t RANGE = 128 * 1024 * 1024;
+    _bandwidth("Buffer", RANGE);
   }
 
   void ubo_bandwidth() {
     std::cout << "\n------ UBO Bandwidth ------" << std::endl;
-    _bandwidth("UBO");
+    const size_t RANGE = 128 * 1024 * 1024;
+    _bandwidth("UBO", RANGE);
+  }
+  void shared_mem_bandwidth() {
+    std::cout << "\n------ Shared Bandwidth ------" << std::endl;
+    const size_t RANGE = max_shared_mem_size_;
+    _bandwidth("Shared", RANGE);
   }
 };
 
@@ -313,6 +321,7 @@ int main(int argc, const char** argv) {
   app.buf_cacheline_size();
   app.buf_bandwidth();
   app.ubo_bandwidth();
+  app.shared_mem_bandwidth();
 
   return 0;
 }


### PR DESCRIPTION
Pull Request resolved: https://github.com/pytorch/executorch/pull/4277

This diff introduces a profiler that obtains the maximum and minimum bandwidth for reading from the Shared memory space, using the following shader, where A is a shared buffer and B is a writeonly buffer. 

```
shared A[nvec];

void main() {
  vec4 sum = vec4(0);
  const uint workgroup_width = local_group_size * niter * ${NUNROLL};
  uint offset = (gl_WorkGroupID[0] * workgroup_width  + gl_LocalInvocationID[0]) & addr_mask;

  int i = 0;
  for (; i < niter; ++i)
  {
      sum *= A[offset];
      offset = (offset + local_group_size) & addr_mask;
      ...
      ...
      sum *= A[offset];
      offset = (offset + local_group_size) & addr_mask;
  }

  vec4 zero = vec4(i>>31);

  B[gl_LocalInvocationID[0]] = sum + zero;
}
```

Through the WorkGroup and LocalInvocation IDs, we ensure that each run accesses its own block of memory. Then, we repeatedly access several unique address locations, using an address mask to wrap around if necessary.
Finally, we make sure to use the `sum` and `i	` variables so that the compiler's optimizer does not flatten the loops. 

For a Samsung S22, the bandwidth behaves like this. We can see that accessing the shared memory has a constant latency, until it reaches the Maximum Shared Memory size, where it crashes (the profiler stops before crashing):

![image](https://github.com/user-attachments/assets/8043ab10-f21d-46ad-96c7-ea8da308da1a)

Comparing it to OpenCL, we can observe that, although the behavior is the same, Vulkan has an increased bandwidth.

![image](https://github.com/user-attachments/assets/b13290ff-f6b7-43c0-9335-d9c693a48509)