### PR TITLE
Use a more reliable way to get python library path

### DIFF
--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -78,7 +78,7 @@ function(generate_bindings_for_kernels)
   # Executorch runtime.
   execute_process(
     COMMAND
-      "${PYTHON_EXECUTABLE}" -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())"
+      "${PYTHON_EXECUTABLE}" -c "import sysconfig; lib_path = sysconfig.get_paths()['purelib']; print(lib_path)"
     OUTPUT_VARIABLE site-packages-out
     ERROR_VARIABLE site-packages-out-error
     RESULT_VARIABLE site-packages-result


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4281

Summary: In bento/colab environment, it is more accurate to use
sysconfig.get_paths() to access python library path.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: