### PR TITLE
Migrate all DataLoader::Load callsites

### DIFF
--- a/examples/apple/mps/executor_runner/mps_executor_runner.mm
+++ b/examples/apple/mps/executor_runner/mps_executor_runner.mm
@@ -134,7 +134,7 @@ int main(int argc, char** argv) {
       loader.ok(), "FileDataLoader::from() failed: 0x%" PRIx32, loader.error());
 
   // Read in the entire file.
-  Result<FreeableBuffer> file_data = loader->Load(0, loader->size().get());
+  Result<FreeableBuffer> file_data = loader->load(0, loader->size().get(), DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
   ET_CHECK_MSG(
       file_data.ok(),
       "Could not load contents of file '%s': 0x%x",

--- a/examples/sdk/sdk_example_runner/sdk_example_runner.cpp
+++ b/examples/sdk/sdk_example_runner/sdk_example_runner.cpp
@@ -103,7 +103,10 @@ int main(int argc, char** argv) {
       loader.ok(), "FileDataLoader::from() failed: 0x%" PRIx32, loader.error());
 
   // Read in the entire file.
-  Result<FreeableBuffer> file_data = loader->Load(0, loader->size().get());
+  Result<FreeableBuffer> file_data = loader->load(
+      0,
+      loader->size().get(),
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
   ET_CHECK_MSG(
       file_data.ok(),
       "Could not load contents of file '%s': 0x%x",

--- a/extension/data_loader/buffer_data_loader.h
+++ b/extension/data_loader/buffer_data_loader.h
@@ -29,8 +29,10 @@ class BufferDataLoader : public DataLoader {
   BufferDataLoader(const void* data, size_t size)
       : data_(reinterpret_cast<const uint8_t*>(data)), size_(size) {}
 
-  __ET_NODISCARD Result<FreeableBuffer> Load(size_t offset, size_t size)
-      override {
+  __ET_NODISCARD Result<FreeableBuffer> load(
+      size_t offset,
+      size_t size,
+      __ET_UNUSED const DataLoader::SegmentInfo& segment_info) override {
     ET_CHECK_OR_RETURN_ERROR(
         offset + size <= size_,
         InvalidArgument,

--- a/extension/data_loader/file_data_loader.cpp
+++ b/extension/data_loader/file_data_loader.cpp
@@ -118,7 +118,10 @@ void FreeSegment(void* context, void* data, __ET_UNUSED size_t size) {
 }
 } // namespace
 
-Result<FreeableBuffer> FileDataLoader::Load(size_t offset, size_t size) {
+Result<FreeableBuffer> FileDataLoader::load(
+    size_t offset,
+    size_t size,
+    __ET_UNUSED const DataLoader::SegmentInfo& segment_info) {
   ET_CHECK_OR_RETURN_ERROR(
       // Probably had its value moved to another instance.
       fd_ >= 0,

--- a/extension/data_loader/file_data_loader.h
+++ b/extension/data_loader/file_data_loader.h
@@ -23,7 +23,7 @@ namespace util {
  * with `malloc()`.
  *
  * Note that this will keep the file open for the duration of its lifetime, to
- * avoid the overhead of opening it again for every Load() call.
+ * avoid the overhead of opening it again for every load() call.
  */
 class FileDataLoader : public DataLoader {
  public:
@@ -65,8 +65,10 @@ class FileDataLoader : public DataLoader {
 
   ~FileDataLoader() override;
 
-  __ET_NODISCARD Result<FreeableBuffer> Load(size_t offset, size_t size)
-      override;
+  __ET_NODISCARD Result<FreeableBuffer> load(
+      size_t offset,
+      size_t size,
+      const DataLoader::SegmentInfo& segment_info) override;
 
   __ET_NODISCARD Result<size_t> size() const override;
 

--- a/extension/data_loader/mmap_data_loader.cpp
+++ b/extension/data_loader/mmap_data_loader.cpp
@@ -146,7 +146,10 @@ void MunmapSegment(void* context, void* data, size_t size) {
 }
 } // namespace
 
-Result<FreeableBuffer> MmapDataLoader::Load(size_t offset, size_t size) {
+Result<FreeableBuffer> MmapDataLoader::load(
+    size_t offset,
+    size_t size,
+    __ET_UNUSED const DataLoader::SegmentInfo& segment_info) {
   ET_CHECK_OR_RETURN_ERROR(
       // Probably had its value moved to another instance.
       fd_ >= 0,

--- a/extension/data_loader/mmap_data_loader.h
+++ b/extension/data_loader/mmap_data_loader.h
@@ -21,7 +21,7 @@ namespace util {
  * with `malloc()`.
  *
  * Note that this will keep the file open for the duration of its lifetime, to
- * avoid the overhead of opening it again for every Load() call.
+ * avoid the overhead of opening it again for every load() call.
  */
 class MmapDataLoader : public DataLoader {
  public:
@@ -47,7 +47,7 @@ class MmapDataLoader : public DataLoader {
    *
    * @param[in] file_name The path to the file to load from. The file will be
    *     kept open until the MmapDataLoader is destroyed, to avoid the
-   *     overhead of opening it again for every Load() call.
+   *     overhead of opening it again for every load() call.
    * @param[in] mlock_config How and whether to lock loaded pages with
    *     `mlock()`.
    */
@@ -86,8 +86,10 @@ class MmapDataLoader : public DataLoader {
 
   ~MmapDataLoader() override;
 
-  __ET_NODISCARD Result<FreeableBuffer> Load(size_t offset, size_t size)
-      override;
+  __ET_NODISCARD Result<FreeableBuffer> load(
+      size_t offset,
+      size_t size,
+      const DataLoader::SegmentInfo& segment_info) override;
 
   __ET_NODISCARD Result<size_t> size() const override;
 

--- a/extension/data_loader/shared_ptr_data_loader.h
+++ b/extension/data_loader/shared_ptr_data_loader.h
@@ -29,8 +29,10 @@ class SharedPtrDataLoader : public DataLoader {
   SharedPtrDataLoader(std::shared_ptr<void> data, size_t size)
       : data_(data), size_(size) {}
 
-  __ET_NODISCARD Result<FreeableBuffer> Load(size_t offset, size_t size)
-      override {
+  __ET_NODISCARD Result<FreeableBuffer> load(
+      size_t offset,
+      size_t size,
+      __ET_UNUSED const DataLoader::SegmentInfo& segment_info) override {
     ET_CHECK_OR_RETURN_ERROR(
         offset + size <= size_,
         InvalidArgument,

--- a/extension/data_loader/test/file_data_loader_test.cpp
+++ b/extension/data_loader/test/file_data_loader_test.cpp
@@ -18,6 +18,7 @@
 #include <executorch/test/utils/alignment.h>
 
 using namespace ::testing;
+using torch::executor::DataLoader;
 using torch::executor::Error;
 using torch::executor::FreeableBuffer;
 using torch::executor::Result;
@@ -59,7 +60,10 @@ TEST_P(FileDataLoaderTest, InBoundsLoadsSucceed) {
 
   // Load the first bytes of the data.
   {
-    Result<FreeableBuffer> fb = fdl->Load(/*offset=*/0, /*size=*/8);
+    Result<FreeableBuffer> fb = fdl->load(
+        /*offset=*/0,
+        /*size=*/8,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_ALIGNED(fb->data(), alignment());
     EXPECT_EQ(fb->size(), 8);
@@ -82,8 +86,10 @@ TEST_P(FileDataLoaderTest, InBoundsLoadsSucceed) {
 
   // Load the last few bytes of the data, a different size than the first time.
   {
-    Result<FreeableBuffer> fb =
-        fdl->Load(/*offset=*/sizeof(data) - 3, /*size=*/3);
+    Result<FreeableBuffer> fb = fdl->load(
+        /*offset=*/sizeof(data) - 3,
+        /*size=*/3,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_ALIGNED(fb->data(), alignment());
     EXPECT_EQ(fb->size(), 3);
@@ -92,7 +98,10 @@ TEST_P(FileDataLoaderTest, InBoundsLoadsSucceed) {
 
   // Loading all of the data succeeds.
   {
-    Result<FreeableBuffer> fb = fdl->Load(/*offset=*/0, /*size=*/sizeof(data));
+    Result<FreeableBuffer> fb = fdl->load(
+        /*offset=*/0,
+        /*size=*/sizeof(data),
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_ALIGNED(fb->data(), alignment());
     EXPECT_EQ(fb->size(), sizeof(data));
@@ -101,7 +110,10 @@ TEST_P(FileDataLoaderTest, InBoundsLoadsSucceed) {
 
   // Loading zero-sized data succeeds, even at the end of the data.
   {
-    Result<FreeableBuffer> fb = fdl->Load(/*offset=*/sizeof(data), /*size=*/0);
+    Result<FreeableBuffer> fb = fdl->load(
+        /*offset=*/sizeof(data),
+        /*size=*/0,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_EQ(fb->size(), 0);
   }
@@ -118,15 +130,19 @@ TEST_P(FileDataLoaderTest, OutOfBoundsLoadFails) {
 
   // Loading beyond the end of the data should fail.
   {
-    Result<FreeableBuffer> fb =
-        fdl->Load(/*offset=*/0, /*size=*/sizeof(data) + 1);
+    Result<FreeableBuffer> fb = fdl->load(
+        /*offset=*/0,
+        /*size=*/sizeof(data) + 1,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     EXPECT_NE(fb.error(), Error::Ok);
   }
 
   // Loading zero bytes still fails if it's past the end of the data.
   {
-    Result<FreeableBuffer> fb =
-        fdl->Load(/*offset=*/sizeof(data) + 1, /*size=*/0);
+    Result<FreeableBuffer> fb = fdl->load(
+        /*offset=*/sizeof(data) + 1,
+        /*size=*/0,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     EXPECT_NE(fb.error(), Error::Ok);
   }
 }
@@ -172,12 +188,21 @@ TEST_P(FileDataLoaderTest, MoveCtor) {
   FileDataLoader fdl2(std::move(*fdl));
 
   // Old loader should now be invalid.
-  EXPECT_EQ(fdl->Load(0, 0).error(), Error::InvalidState);
+  EXPECT_EQ(
+      fdl->load(
+             0,
+             0,
+             DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program))
+          .error(),
+      Error::InvalidState);
   EXPECT_EQ(fdl->size().error(), Error::InvalidState);
 
   // New loader should point to the file.
   EXPECT_EQ(fdl2.size().get(), contents.size());
-  Result<FreeableBuffer> fb = fdl2.Load(/*offset=*/0, contents.size());
+  Result<FreeableBuffer> fb = fdl2.load(
+      /*offset=*/0,
+      contents.size(),
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
   ASSERT_EQ(fb.error(), Error::Ok);
   EXPECT_ALIGNED(fb->data(), alignment());
   ASSERT_EQ(fb->size(), contents.size());

--- a/extension/data_loader/test/mmap_data_loader_test.cpp
+++ b/extension/data_loader/test/mmap_data_loader_test.cpp
@@ -19,6 +19,7 @@
 #include <executorch/runtime/platform/runtime.h>
 
 using namespace ::testing;
+using torch::executor::DataLoader;
 using torch::executor::Error;
 using torch::executor::FreeableBuffer;
 using torch::executor::Result;
@@ -72,7 +73,10 @@ void MmapDataLoaderTest::test_in_bounds_loads_succeed(
 
   // Load the first page of the file.
   {
-    Result<FreeableBuffer> fb = mdl->Load(/*offset=*/0, /*size=*/page_size_);
+    Result<FreeableBuffer> fb = mdl->load(
+        /*offset=*/0,
+        /*size=*/page_size_,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_EQ(fb->size(), page_size_);
     EXPECT_EQ(0, std::memcmp(fb->data(), &contents[0], fb->size()));
@@ -90,7 +94,10 @@ void MmapDataLoaderTest::test_in_bounds_loads_succeed(
   {
     const size_t size = page_size_ * 2;
     const size_t offset = contents_size - size;
-    Result<FreeableBuffer> fb = mdl->Load(offset, size);
+    Result<FreeableBuffer> fb = mdl->load(
+        offset,
+        size,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_EQ(fb->size(), size);
     EXPECT_EQ(0, std::memcmp(fb->data(), &contents[offset], fb->size()));
@@ -98,7 +105,10 @@ void MmapDataLoaderTest::test_in_bounds_loads_succeed(
 
   // Loading all of the data succeeds.
   {
-    Result<FreeableBuffer> fb = mdl->Load(/*offset=*/0, /*size=*/contents_size);
+    Result<FreeableBuffer> fb = mdl->load(
+        /*offset=*/0,
+        /*size=*/contents_size,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_EQ(fb->size(), contents_size);
     EXPECT_EQ(0, std::memcmp(fb->data(), &contents[0], fb->size()));
@@ -108,13 +118,19 @@ void MmapDataLoaderTest::test_in_bounds_loads_succeed(
   {
     const size_t offset1 = 0;
     const size_t size1 = page_size_ * 3;
-    Result<FreeableBuffer> fb1 = mdl->Load(offset1, size1);
+    Result<FreeableBuffer> fb1 = mdl->load(
+        offset1,
+        size1,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb1.error(), Error::Ok);
     EXPECT_EQ(fb1->size(), size1);
 
     const size_t offset2 = (offset1 + size1) - page_size_;
     const size_t size2 = page_size_ * 3;
-    Result<FreeableBuffer> fb2 = mdl->Load(offset2, size2);
+    Result<FreeableBuffer> fb2 = mdl->load(
+        offset2,
+        size2,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb2.error(), Error::Ok);
     EXPECT_EQ(fb2->size(), size2);
 
@@ -125,7 +141,10 @@ void MmapDataLoaderTest::test_in_bounds_loads_succeed(
 
   // Loading zero-sized data succeeds, even at the end of the data.
   {
-    Result<FreeableBuffer> fb = mdl->Load(/*offset=*/contents_size, /*size=*/0);
+    Result<FreeableBuffer> fb = mdl->load(
+        /*offset=*/contents_size,
+        /*size=*/0,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_EQ(fb->size(), 0);
   }
@@ -138,7 +157,10 @@ void MmapDataLoaderTest::test_in_bounds_loads_succeed(
   {
     const size_t offset = page_size_;
     const size_t size = page_size_ / 2;
-    Result<FreeableBuffer> fb = mdl->Load(offset, size);
+    Result<FreeableBuffer> fb = mdl->load(
+        offset,
+        size,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_EQ(fb->size(), size);
     EXPECT_EQ(0, std::memcmp(fb->data(), &contents[offset], fb->size()));
@@ -148,7 +170,10 @@ void MmapDataLoaderTest::test_in_bounds_loads_succeed(
   {
     const size_t offset = page_size_;
     const size_t size = page_size_ * 3 + page_size_ / 2 + 1; // Odd size
-    Result<FreeableBuffer> fb = mdl->Load(offset, size);
+    Result<FreeableBuffer> fb = mdl->load(
+        offset,
+        size,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_EQ(fb->size(), size);
     EXPECT_EQ(0, std::memcmp(fb->data(), &contents[offset], fb->size()));
@@ -164,7 +189,10 @@ void MmapDataLoaderTest::test_in_bounds_loads_succeed(
     const size_t offset = 128; // Small power of 2
     EXPECT_LT(offset, page_size_);
     const size_t size = page_size_ / 2;
-    Result<FreeableBuffer> fb = mdl->Load(offset, size);
+    Result<FreeableBuffer> fb = mdl->load(
+        offset,
+        size,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_EQ(fb->size(), size);
     EXPECT_EQ(0, std::memcmp(fb->data(), &contents[offset], fb->size()));
@@ -174,7 +202,10 @@ void MmapDataLoaderTest::test_in_bounds_loads_succeed(
   {
     const size_t offset = page_size_ + 128; // Small power of 2
     const size_t size = page_size_ * 3 + page_size_ / 2 + 1; // Odd size
-    Result<FreeableBuffer> fb = mdl->Load(offset, size);
+    Result<FreeableBuffer> fb = mdl->load(
+        offset,
+        size,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_EQ(fb->size(), size);
     EXPECT_EQ(0, std::memcmp(fb->data(), &contents[offset], fb->size()));
@@ -184,7 +215,10 @@ void MmapDataLoaderTest::test_in_bounds_loads_succeed(
   {
     const size_t offset = page_size_ * 2 + 3; // Not a power of 2
     const size_t size = page_size_ * 3 + page_size_ / 2 + 1; // Odd size
-    Result<FreeableBuffer> fb = mdl->Load(offset, size);
+    Result<FreeableBuffer> fb = mdl->load(
+        offset,
+        size,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_EQ(fb->size(), size);
     EXPECT_EQ(0, std::memcmp(fb->data(), &contents[offset], fb->size()));
@@ -240,7 +274,10 @@ TEST_F(MmapDataLoaderTest, FinalPageOfUnevenFileSucceeds) {
     ASSERT_NE(size % page_size_, 0);
 
     // Load and validate the final partial page.
-    Result<FreeableBuffer> fb = mdl->Load(offset, size);
+    Result<FreeableBuffer> fb = mdl->load(
+        offset,
+        size,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(fb.error(), Error::Ok);
     EXPECT_EQ(fb->size(), size);
     EXPECT_EQ(0, std::memcmp(fb->data(), &contents[offset], fb->size()));
@@ -259,8 +296,10 @@ TEST_F(MmapDataLoaderTest, OutOfBoundsLoadFails) {
 
   // Loading beyond the end of the data should fail.
   {
-    Result<FreeableBuffer> fb =
-        mdl->Load(/*offset=*/0, /*size=*/contents_size + 1);
+    Result<FreeableBuffer> fb = mdl->load(
+        /*offset=*/0,
+        /*size=*/contents_size + 1,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     EXPECT_NE(fb.error(), Error::Ok);
   }
 
@@ -270,7 +309,10 @@ TEST_F(MmapDataLoaderTest, OutOfBoundsLoadFails) {
     const size_t offset = contents_size + page_size_;
     ASSERT_EQ(offset % page_size_, 0);
 
-    Result<FreeableBuffer> fb = mdl->Load(offset, /*size=*/0);
+    Result<FreeableBuffer> fb = mdl->load(
+        offset,
+        /*size=*/0,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     EXPECT_NE(fb.error(), Error::Ok);
   }
 }
@@ -295,12 +337,21 @@ TEST_F(MmapDataLoaderTest, MoveCtor) {
   MmapDataLoader mdl2(std::move(*mdl));
 
   // Old loader should now be invalid.
-  EXPECT_EQ(mdl->Load(0, 0).error(), Error::InvalidState);
+  EXPECT_EQ(
+      mdl->load(
+             0,
+             0,
+             DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program))
+          .error(),
+      Error::InvalidState);
   EXPECT_EQ(mdl->size().error(), Error::InvalidState);
 
   // New loader should point to the file.
   EXPECT_EQ(mdl2.size().get(), contents.size());
-  Result<FreeableBuffer> fb = mdl2.Load(/*offset=*/0, contents.size());
+  Result<FreeableBuffer> fb = mdl2.load(
+      /*offset=*/0,
+      contents.size(),
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
   ASSERT_EQ(fb.error(), Error::Ok);
   ASSERT_EQ(fb->size(), contents.size());
   EXPECT_EQ(0, std::memcmp(fb->data(), contents.data(), fb->size()));

--- a/extension/data_loader/test/shared_ptr_data_loader_test.cpp
+++ b/extension/data_loader/test/shared_ptr_data_loader_test.cpp
@@ -17,6 +17,7 @@
 #include <executorch/runtime/platform/runtime.h>
 
 using namespace ::testing;
+using torch::executor::DataLoader;
 using torch::executor::Error;
 using torch::executor::FreeableBuffer;
 using torch::executor::Result;
@@ -50,7 +51,11 @@ TEST_F(SharedPtrDataLoaderTest, InBoundsLoadsSucceed) {
 
   // Load the first bytes of the data.
   {
-    Result<FreeableBuffer> fb = sbdl.Load(/*offset=*/0, /*size=*/8);
+    Result<FreeableBuffer> fb = sbdl.load(
+        /*offset=*/0,
+        /*size=*/8,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     EXPECT_TRUE(fb.ok());
     EXPECT_EQ(fb->size(), 8);
     EXPECT_EQ(
@@ -72,7 +77,11 @@ TEST_F(SharedPtrDataLoaderTest, InBoundsLoadsSucceed) {
 
   // Load the last few bytes of the data, a different size than the first time.
   {
-    Result<FreeableBuffer> fb = sbdl.Load(/*offset=*/SIZE - 3, /*size=*/3);
+    Result<FreeableBuffer> fb = sbdl.load(
+        /*offset=*/SIZE - 3,
+        /*size=*/3,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     EXPECT_TRUE(fb.ok());
     EXPECT_EQ(fb->size(), 3);
     EXPECT_EQ(0, std::memcmp(fb->data(), "\xfd\xfe\xff", fb->size()));
@@ -80,7 +89,11 @@ TEST_F(SharedPtrDataLoaderTest, InBoundsLoadsSucceed) {
 
   // Loading all of the data succeeds.
   {
-    Result<FreeableBuffer> fb = sbdl.Load(/*offset=*/0, /*size=*/SIZE);
+    Result<FreeableBuffer> fb = sbdl.load(
+        /*offset=*/0,
+        /*size=*/SIZE,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     EXPECT_TRUE(fb.ok());
     EXPECT_EQ(fb->size(), SIZE);
     EXPECT_EQ(0, std::memcmp(fb->data(), data.get(), fb->size()));
@@ -88,7 +101,11 @@ TEST_F(SharedPtrDataLoaderTest, InBoundsLoadsSucceed) {
 
   // Loading zero-sized data succeeds, even at the end of the data.
   {
-    Result<FreeableBuffer> fb = sbdl.Load(/*offset=*/SIZE, /*size=*/0);
+    Result<FreeableBuffer> fb = sbdl.load(
+        /*offset=*/SIZE,
+        /*size=*/0,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     EXPECT_TRUE(fb.ok());
     EXPECT_EQ(fb->size(), 0);
   }
@@ -105,13 +122,21 @@ TEST_F(SharedPtrDataLoaderTest, OutOfBoundsLoadFails) {
 
   // Loading beyond the end of the data should fail.
   {
-    Result<FreeableBuffer> fb = sbdl.Load(/*offset=*/0, /*size=*/SIZE + 1);
+    Result<FreeableBuffer> fb = sbdl.load(
+        /*offset=*/0,
+        /*size=*/SIZE + 1,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     EXPECT_NE(fb.error(), Error::Ok);
   }
 
   // Loading zero bytes still fails if it's past the end of the data.
   {
-    Result<FreeableBuffer> fb = sbdl.Load(/*offset=*/SIZE + 1, /*size=*/0);
+    Result<FreeableBuffer> fb = sbdl.load(
+        /*offset=*/SIZE + 1,
+        /*size=*/0,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     EXPECT_NE(fb.error(), Error::Ok);
   }
 }

--- a/runtime/core/data_loader.h
+++ b/runtime/core/data_loader.h
@@ -72,20 +72,6 @@ class DataLoader {
   virtual ~DataLoader() = default;
 
   /**
-   * DEPRECATED: Use `load()` going forward for access to segment info during
-   * the load.
-   *
-   * Loads `size` bytes at byte offset `offset` from the underlying data source
-   * into a `FreeableBuffer`, which owns the memory.
-   *
-   * NOTE: This must be thread-safe. If this call modifies common state, the
-   * implementation must do its own locking.
-   */
-  __ET_NODISCARD virtual Result<FreeableBuffer> Load(
-      size_t offset,
-      size_t size) = 0;
-
-  /**
    * Loads data from the underlying data source.
    *
    * NOTE: This must be thread-safe. If this call modifies common state, the
@@ -98,10 +84,7 @@ class DataLoader {
    * @returns a `FreeableBuffer` that owns the loaded data.
    */
   __ET_NODISCARD virtual Result<FreeableBuffer>
-  load(size_t offset, size_t size, const SegmentInfo& segment_info) {
-    (void)segment_info;
-    return Load(offset, size); // NOLINT(facebook-hte-Deprecated)
-  }
+  load(size_t offset, size_t size, const SegmentInfo& segment_info) = 0;
 
   /**
    * Returns the length of the underlying data source, typically the file size.

--- a/runtime/executor/test/program_test.cpp
+++ b/runtime/executor/test/program_test.cpp
@@ -50,8 +50,11 @@ class ProgramTest : public ::testing::Test {
     ASSERT_EQ(loader.error(), Error::Ok);
 
     // This file should always be compatible.
-    Result<FreeableBuffer> header =
-        loader->Load(/*offset=*/0, Program::kMinHeadBytes);
+    Result<FreeableBuffer> header = loader->load(
+        /*offset=*/0,
+        Program::kMinHeadBytes,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(header.error(), Error::Ok);
     EXPECT_EQ(
         Program::check_header(header->data(), header->size()),
@@ -65,8 +68,11 @@ class ProgramTest : public ::testing::Test {
     ASSERT_EQ(multi_loader.error(), Error::Ok);
 
     // This file should always be compatible.
-    Result<FreeableBuffer> multi_header =
-        multi_loader->Load(/*offset=*/0, Program::kMinHeadBytes);
+    Result<FreeableBuffer> multi_header = multi_loader->load(
+        /*offset=*/0,
+        Program::kMinHeadBytes,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(multi_header.error(), Error::Ok);
     EXPECT_EQ(
         Program::check_header(multi_header->data(), multi_header->size()),
@@ -126,7 +132,11 @@ TEST_F(ProgramTest, BadMagicFailsToLoad) {
   size_t data_len = add_loader_->size().get();
   auto data = std::make_unique<char[]>(data_len);
   {
-    Result<FreeableBuffer> src = add_loader_->Load(/*offset=*/0, data_len);
+    Result<FreeableBuffer> src = add_loader_->load(
+        /*offset=*/0,
+        data_len,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(src.error(), Error::Ok);
     ASSERT_EQ(src->size(), data_len);
     memcpy(data.get(), src->data(), data_len);
@@ -169,8 +179,11 @@ TEST_F(ProgramTest, BadMagicFailsToLoad) {
 TEST_F(ProgramTest, VerificationCatchesTruncation) {
   // Get the program data.
   size_t full_data_len = add_loader_->size().get();
-  Result<FreeableBuffer> full_data =
-      add_loader_->Load(/*offset=*/0, full_data_len);
+  Result<FreeableBuffer> full_data = add_loader_->load(
+      /*offset=*/0,
+      full_data_len,
+      /*segment_info=*/
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
   ASSERT_EQ(full_data.error(), Error::Ok);
 
   // Make a loader that only exposes half of the data.
@@ -187,7 +200,11 @@ TEST_F(ProgramTest, VerificationCatchesCorruption) {
   size_t data_len = add_loader_->size().get();
   auto data = std::make_unique<char[]>(data_len);
   {
-    Result<FreeableBuffer> src = add_loader_->Load(/*offset=*/0, data_len);
+    Result<FreeableBuffer> src = add_loader_->load(
+        /*offset=*/0,
+        data_len,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(src.error(), Error::Ok);
     ASSERT_EQ(src->size(), data_len);
     memcpy(data.get(), src->data(), data_len);
@@ -211,7 +228,11 @@ TEST_F(ProgramTest, UnalignedProgramDataFails) {
   size_t data_len = add_loader_->size().get();
   auto data = std::make_unique<char[]>(data_len + 1);
   {
-    Result<FreeableBuffer> src = add_loader_->Load(/*offset=*/0, data_len);
+    Result<FreeableBuffer> src = add_loader_->load(
+        /*offset=*/0,
+        data_len,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(src.error(), Error::Ok);
     ASSERT_EQ(src->size(), data_len);
     memcpy(data.get() + 1, src->data(), data_len);
@@ -244,8 +265,11 @@ TEST_F(ProgramTest, LoadSegmentWithNoSegments) {
 }
 
 TEST_F(ProgramTest, ShortDataHeader) {
-  Result<FreeableBuffer> header =
-      add_loader_->Load(/*offset=*/0, Program::kMinHeadBytes);
+  Result<FreeableBuffer> header = add_loader_->load(
+      /*offset=*/0,
+      Program::kMinHeadBytes,
+      /*segment_info=*/
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
   ASSERT_EQ(header.error(), Error::Ok);
 
   // Provide less than the required amount of data.
@@ -259,7 +283,11 @@ TEST_F(ProgramTest, IncompatibleHeader) {
   size_t data_len = Program::kMinHeadBytes;
   auto data = std::make_unique<char[]>(data_len);
   {
-    Result<FreeableBuffer> src = add_loader_->Load(/*offset=*/0, data_len);
+    Result<FreeableBuffer> src = add_loader_->load(
+        /*offset=*/0,
+        data_len,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(src.error(), Error::Ok);
     ASSERT_EQ(src->size(), data_len);
     memcpy(data.get(), src->data(), data_len);
@@ -291,7 +319,11 @@ TEST_F(ProgramTest, HeaderNotPresent) {
   size_t data_len = Program::kMinHeadBytes;
   auto data = std::make_unique<char[]>(data_len);
   {
-    Result<FreeableBuffer> src = add_loader_->Load(/*offset=*/0, data_len);
+    Result<FreeableBuffer> src = add_loader_->load(
+        /*offset=*/0,
+        data_len,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
     ASSERT_EQ(src.error(), Error::Ok);
     ASSERT_EQ(src->size(), data_len);
     memcpy(data.get(), src->data(), data_len);
@@ -345,8 +377,11 @@ TEST_F(ProgramTest, LoadConstantSegment) {
   ASSERT_EQ(linear_loader.error(), Error::Ok);
 
   // This file should always be compatible.
-  Result<FreeableBuffer> linear_header =
-      linear_loader->Load(/*offset=*/0, Program::kMinHeadBytes);
+  Result<FreeableBuffer> linear_header = linear_loader->load(
+      /*offset=*/0,
+      Program::kMinHeadBytes,
+      /*segment_info=*/
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
   ASSERT_EQ(linear_header.error(), Error::Ok);
   EXPECT_EQ(
       Program::check_header(linear_header->data(), linear_header->size()),
@@ -387,8 +422,11 @@ TEST_F(ProgramTest, LoadConstantSegmentWithNoConstantSegment) {
   ASSERT_EQ(linear_loader.error(), Error::Ok);
 
   // This file should always be compatible.
-  Result<FreeableBuffer> linear_header =
-      linear_loader->Load(/*offset=*/0, Program::kMinHeadBytes);
+  Result<FreeableBuffer> linear_header = linear_loader->load(
+      /*offset=*/0,
+      Program::kMinHeadBytes,
+      /*segment_info=*/
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
   ASSERT_EQ(linear_header.error(), Error::Ok);
   EXPECT_EQ(
       Program::check_header(linear_header->data(), linear_header->size()),


### PR DESCRIPTION
## Summary
Starts to completely deprecate DataLoader::Load by converting existing callsites to DataLoader::load, and making DataLoader::load pure virtual.

Searched for all relevant callsites by doing the following:
- Grep for all instances of `core/data_loader.h>` to find all direct imports of DataLoader, finding "Load(" in the file
- Grep for all instances of `executorch\/.*_data_loader.h>` to find all imports of subclasses derived from DataLoader, finding "Load(" in the file
- Grep for all instances of "->Load(" in files with "executorch" in the path
- Grep for all isntances of "loader->Load(" and "loader_->Load(" in the entire codebase

Differential Revision: D59767505
