### PR TITLE
Add Warp Size metric 

### DIFF
--- a/backends/vulkan/tools/gpuinfo/glsl/warp_size.glsl
+++ b/backends/vulkan/tools/gpuinfo/glsl/warp_size.glsl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+
+#define PRECISION ${PRECISION}
+
+layout(std430) buffer;
+
+${layout_declare_buffer(0, "w", "out_buff", DTYPE)}
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+layout(constant_id = 3) const int NITER = 1;
+
+void main() {
+    int sum = 0;
+    for (int j = 0; j < NITER; ++j) {
+        // Integer division is an exemplary multi-cycle instruction that can
+        // hardly be optimized, thus reducing the impact of latency hiding.
+        sum += j / 3;
+        barrier();
+    }
+    out_buff[gl_GlobalInvocationID[0]] = sum;
+}

--- a/backends/vulkan/tools/gpuinfo/glsl/warp_size.yaml
+++ b/backends/vulkan/tools/gpuinfo/glsl/warp_size.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+warp_size:
+  parameter_names_with_default_values:
+    DTYPE: int
+    STORAGE: buffer
+  shader_variants:
+    - NAME: warp_size


### PR DESCRIPTION
This very simple metric runs a kernel across an increasing number of workgroups, until there is a noticeable increase in latency, as seen in the following graph:

![image](https://github.com/user-attachments/assets/438deec3-7317-4835-aea4-e06722121852)

The shader uses an integer division as its metric, because it is a multi-cycle operation that puts the ALU to work and stops the SM from context switching.

As other metrics, we start by obtaining the minimum number of iterations, NITER, that can run in 1000us, as to have a baseline for comparison and reduce timing noise. With this number of iterations, we run the kernel with an increasing number of threads. We also use a multidimensional global workgroup with a Y size of 1024 in hopes of saturating the ALUs and have a better point of reference for the latency caused by adding warps.  

Once we detect a jump in latency, we can assume that that is the warp size.

More information can be found [here](https://www.microsoft.com/en-us/research/uploads/prod/2022/02/mobigpu_mobicom22_camera.pdf) on page 5. 

Differential Revision: D59920169
