### PR TITLE
Add weights to model outputs

### DIFF
--- a/exir/emit/_emit_program.py
+++ b/exir/emit/_emit_program.py
@@ -17,7 +17,8 @@ from executorch.exir.emit._emitter import (
     _TopLevelEmitter,
 )
 from executorch.exir.error import ExportError, ExportErrorType
-from executorch.exir.schema import Program, SubsegmentOffsets
+
+from executorch.exir.schema import Buffer, Program, SubsegmentOffsets
 from executorch.exir.version import EXECUTORCH_SCHEMA_VERSION
 from torch.export.exported_program import ExportedProgram, OutputKind
 from torch.utils import _pytree as pytree
@@ -43,6 +44,8 @@ class EmitterOutput:
     method_to_delegate_debug_id_map: Dict[
         str, Dict[int, Dict[str, Union[str, _DelegateDebugIdentifierMap]]]
     ]
+
+    mutable_data: List[Buffer]
 
 
 def _remove_non_user_outputs(exported_program: ExportedProgram) -> torch.fx.GraphModule:
@@ -156,5 +159,7 @@ def emit_program(
             segments=[],
             # Subsegment offsets may be added at serialization time.
             constant_segment=SubsegmentOffsets(segment_index=0, offsets=[]),
+            mutable_data_segments=None,  # Will be filled in during serialization
         ),
+        mutable_data=program_state.mutable_buffer,
     )

--- a/exir/memory_planning.py
+++ b/exir/memory_planning.py
@@ -427,7 +427,11 @@ def collect_specs_from_nodes(  # noqa: C901
                 continue
             if ignore_graph_output and spec in graph_output_tensors:
                 continue
-            if ignore_const and spec.const:
+            if (
+                ignore_const
+                and spec.const
+                and not node.meta.get("weight_has_gradient", False)
+            ):
                 continue
             if dedup:
                 if spec in unique_spec:

--- a/exir/passes/TARGETS
+++ b/exir/passes/TARGETS
@@ -25,6 +25,7 @@ python_library(
         ":spec_prop_pass",
         ":sym_shape_eval_pass",
         ":sym_to_tensor_pass",
+        ":weights_to_outputs_pass",
         "//caffe2:torch",
         "//executorch/exir:common",
         "//executorch/exir:control_flow",
@@ -56,6 +57,16 @@ python_library(
     name = "insert_write_back_for_buffers_pass",
     srcs = [
         "insert_write_back_for_buffers_pass.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+    ],
+)
+
+python_library(
+    name = "weights_to_outputs_pass",
+    srcs = [
+        "weights_to_outputs_pass.py",
     ],
     deps = [
         "//caffe2:torch",

--- a/exir/passes/__init__.py
+++ b/exir/passes/__init__.py
@@ -54,6 +54,7 @@ from executorch.exir.passes.scalar_to_tensor_pass import ScalarToTensorPass
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
 from executorch.exir.passes.sym_shape_eval_pass import HintBasedSymShapeEvalPass
 from executorch.exir.passes.sym_to_tensor_pass import SymToTensorPass
+from executorch.exir.passes.weights_to_outputs_pass import weights_to_outputs_pass
 from torch import fx
 from torch._subclasses import FakeTensor
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
@@ -69,6 +70,7 @@ __all__ = [
     "MemoryPlanningPass",
     "HintBasedSymShapeEvalPass",
     "insert_write_back_for_buffers_pass",
+    "weights_to_outputs_pass",
 ]
 
 Argument = Optional[

--- a/exir/passes/weights_to_outputs_pass.py
+++ b/exir/passes/weights_to_outputs_pass.py
@@ -1,0 +1,91 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from torch.export import ExportedProgram
+from torch.export.exported_program import OutputKind, OutputSpec, TensorArgument
+
+
+def weights_to_outputs_pass(
+    exported_program: ExportedProgram,
+) -> ExportedProgram:
+    """
+    This pass is for training graphs with gradients returned. It flags the weights as having a gradient attached,
+    and appends them to the outputs in order to make the weights easier to handle in memory planning and the emitter.
+
+    Args:
+        exported_program: The ExportedProgram to update.
+
+    Returns:
+        The modified ExportedProgram.
+    """
+    if (
+        len([node for node in exported_program.graph.nodes if node.op == "placeholder"])
+        == 0
+    ):
+        return exported_program
+
+    gs = exported_program.graph_signature
+    gm = exported_program.graph_module
+
+    # Check for/ get gradients
+    grad_targets = [
+        spec.target
+        for spec in gs.output_specs
+        if spec.kind == OutputKind.GRADIENT_TO_PARAMETER
+    ]
+
+    # If no gradients, return
+    if len(grad_targets) == 0:
+        return exported_program
+
+    inputs_to_params = gs.inputs_to_parameters
+
+    # Get output node
+    output_node = None
+    for node in gm.graph.nodes:
+        if node.op == "output":
+            output_node = node
+            break
+    assert output_node is not None
+
+    # Get place holder nodes with gradients
+    placeholder_nodes = [
+        node
+        for node in gm.graph.nodes
+        if node.op == "placeholder" and node.target in inputs_to_params.keys()
+    ]
+
+    # Flag these placeholder nodes as having a gradient attached so that memory planning will operate on them.
+    for node in placeholder_nodes:
+        node.meta["weight_has_gradient"] = True
+
+    # add to output node
+    new_output_nodes = []
+    new_output_nodes.extend(output_node.args[0])
+    new_output_nodes.extend(placeholder_nodes)
+    # Remove old outputs
+    new_output = gm.graph.output(tuple(new_output_nodes))
+    output_node.replace_all_uses_with(new_output)
+    gm.graph.erase_node(output_node)
+
+    # add to output signature
+    for node in placeholder_nodes:
+        gs.output_specs.append(
+            OutputSpec(
+                OutputKind.TOKEN,  # This is a hack. We are returning the raw weights here to make it easier for memory
+                # planning and the emitter. There is no outputkind.Parameter so I am using TOKEN which is currently unused in Edge.
+                TensorArgument(node.target),
+                None,
+            )
+        )
+
+    # Cleanup the graph.
+    exported_program.graph.eliminate_dead_code()
+    exported_program.graph_module.recompile()
+
+    return exported_program

--- a/exir/program/TARGETS
+++ b/exir/program/TARGETS
@@ -40,6 +40,7 @@ python_library(
         "//executorch/exir/passes:replace_aten_with_edge_pass",
         "//executorch/exir/passes:replace_view_copy_with_view_pass",
         "//executorch/exir/passes:spec_prop_pass",
+        "//executorch/exir/passes:weights_to_outputs_pass",
         "//executorch/exir/verification:verifier",
     ],
 )

--- a/exir/schema.py
+++ b/exir/schema.py
@@ -265,3 +265,4 @@ class Program:
     backend_delegate_data: List[BackendDelegateInlineData]
     segments: List[DataSegment]
     constant_segment: SubsegmentOffsets
+    mutable_data_segments: Optional[List[SubsegmentOffsets]] = None

--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -326,11 +326,6 @@ def make_tensor_value(
         else:
             return x
 
-    internal_assert(
-        not spec.const or not allocation_info,
-        "We only create non-constant tensors as the constant tensors are directly written to buffer",
-    )
-
     tensor_size = to_list(spec.shape)
     tensor_dim_order = to_list(spec.dim_order)
 

--- a/exir/tests/TARGETS
+++ b/exir/tests/TARGETS
@@ -102,6 +102,17 @@ python_unittest(
 )
 
 python_unittest(
+    name = "joint_graph",
+    srcs = [
+        "test_joint_graph.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir:lib",
+    ],
+)
+
+python_unittest(
     name = "error",
     srcs = [
         "test_error.py",

--- a/exir/tests/test_joint_graph.py
+++ b/exir/tests/test_joint_graph.py
@@ -1,0 +1,91 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import unittest
+
+import torch
+import torch._dynamo
+
+from executorch.exir import to_edge
+from torch.export._trace import _export
+from torch.export.experimental import _export_forward_backward
+from torch.export.exported_program import OutputKind
+
+
+class TestJointGraph(unittest.TestCase):
+    def test_joint_graph(self) -> None:
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(3, 3)
+                self.loss = torch.nn.CrossEntropyLoss()
+
+            def forward(self, x, y):
+                return self.loss(self.linear(x).softmax(dim=0), y)
+
+        m = Module()
+        example_inputs = (torch.ones(3), torch.tensor([1.0, 0.0, 0.0]))
+        m(*example_inputs)
+        ep = _export(m, example_inputs, pre_dispatch=True)
+        joint_ep = _export_forward_backward(ep)
+        edge = to_edge(joint_ep)
+
+        output_node = None
+        for node in edge.exported_program().graph.nodes:
+            if node.op == "output":
+                output_node = node
+                break
+
+        orig_outputs = len(output_node.args[0])
+
+        et = edge.to_executorch()
+
+        weight_output_specs = [
+            spec
+            for spec in et.exported_program().graph_signature.output_specs
+            if spec.kind == OutputKind.TOKEN
+        ]
+
+        output_node = None
+        for node in et.exported_program().graph.nodes:
+            if node.op == "output":
+                output_node = node
+                break
+
+        weight_outputs = len(output_node.args[0])
+
+        # make sure 2 new outputs are added to both the node and the spec
+        self.assertEqual(len(weight_output_specs), 2)  # linear layer weight and bias
+        self.assertEqual(
+            weight_outputs - orig_outputs, 2
+        )  # linear layer weight and bias
+
+        # assert that the weight and bias have proper data_buffer_idx and allocation_info
+        self.assertEqual(
+            et.executorch_program.execution_plan[0]  # pyre-ignore
+            .values[0]
+            .val.data_buffer_idx,
+            1,
+        )
+        self.assertEqual(
+            et.executorch_program.execution_plan[0]  # pyre-ignore
+            .values[1]
+            .val.data_buffer_idx,
+            2,
+        )
+        self.assertEqual(
+            et.executorch_program.execution_plan[0]  # pyre-ignore
+            .values[0]
+            .val.allocation_info.memory_offset_low,
+            0,
+        )
+        self.assertEqual(
+            et.executorch_program.execution_plan[0]  # pyre-ignore
+            .values[1]
+            .val.allocation_info.memory_offset_low,
+            48,
+        )


### PR DESCRIPTION
Summary: Added a pass that flags weights with associated gradients and adds them to the models outputs. Updated the emitter to handle that something could be both a 'constant' and have an allocation_info

Differential Revision: D59929421
