### PR TITLE
Add Warp Size metric for alternative SM workload distribution

### DIFF
--- a/backends/vulkan/tools/gpuinfo/glsl/warp_size.glsl
+++ b/backends/vulkan/tools/gpuinfo/glsl/warp_size.glsl
@@ -16,15 +16,28 @@ ${layout_declare_buffer(0, "w", "out_buff", DTYPE)}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
-layout(constant_id = 3) const int NITER = 1;
+$if METHOD == "scheduler":
+    shared int shared_counter;
+$elif METHOD == "physical":
+    layout(constant_id = 3) const int NITER = 1;
+$else:
+    $raise Exception("Unsupported value for warp_size")
 
 void main() {
-    int sum = 0;
-    for (int j = 0; j < NITER; ++j) {
-        // Integer division is an exemplary multi-cycle instruction that can
-        // hardly be optimized, thus reducing the impact of latency hiding.
-        sum += j / 3;
-        barrier();
-    }
-    out_buff[gl_GlobalInvocationID[0]] = sum;
+
+    $if METHOD == "scheduler":
+        shared_counter = 0;
+        memoryBarrierShared();
+        int i = atomicAdd(shared_counter, 1);
+        memoryBarrierShared();
+        out_buff[gl_GlobalInvocationID[0]] = i;
+    $else:
+        int sum = 0;
+        for (int j = 0; j < NITER; ++j) {
+            // Integer division is an exemplary multi-cycle instruction that can
+            // hardly be optimized, thus reducing the impact of latency hiding.
+            sum += j / 3;
+            barrier();
+        }
+        out_buff[gl_GlobalInvocationID[0]] = sum;
 }

--- a/backends/vulkan/tools/gpuinfo/glsl/warp_size.yaml
+++ b/backends/vulkan/tools/gpuinfo/glsl/warp_size.yaml
@@ -8,5 +8,9 @@ warp_size:
   parameter_names_with_default_values:
     DTYPE: int
     STORAGE: buffer
+  generate_variant_forall:
+    METHOD:
+      - VALUE: scheduler
+      - VALUE: physical
   shader_variants:
     - NAME: warp_size


### PR DESCRIPTION
Here's where things start to get a little bit tricky. As you can see in the graph below from an Adreno, looking only at the latency increases has the problem that there is actually two jumps: every 64 threads and every 128 threads. 
  
![image](https://github.com/user-attachments/assets/a20c5005-45eb-4f08-98f8-856c0fa363f2)

This may be due to the fact that, although the hardware has a limit of 64 threads per warp, each SM could potentially simulate concurrency of 128 threads. Also, as ArchProbe mentions, basing ourselves solely on latency can have issues due to how the SMs distribute workloads when there are fewer threads than the maximum:


In Case 1, like ARM Mali, the SM can assign dummy workloads to fill empty threads and maintain a uniform workload.
In Case 2, like in Adreno, the driver might decide to pack multiple works together and dispatch them at once.

Therefore we need two different methods for warp size calculation, one that evidences the physical limitations, and one that evidences the actual distribution by the driver.

This diff introduces a second alternative way to measure warp size that makes use of the scheduler. The kernel utilizes an atomic counter that is shared by all the threads of the warp, and each run will increase the counter by one and save its value in its corresponding spot. Since the scheduler will place the runs in ascending order, the output buffer should have its values filled in ascending order, i.e:
`  [0, 1, 2, 3, ... n]`

If we increase the warp size by one on each run, there should be a point where two warps are running at the same time. Since each warp has its own scheduler and shared variables, and each scheduler is not aware of each other, the buffer output will no longer be in ascending order at one point, i.e:

`  [... 126, 127, 0, 1, 2, ...]`

The point where the order resets should be the size of our warp.

On this chart we can see the warps racing each other with their own unique values for the counter, and this repeats every 128 threads.
![image](https://github.com/user-attachments/assets/3b98796a-15ff-43da-bb75-2141437f94d6)

More information can be found [here](https://www.microsoft.com/en-us/research/uploads/prod/2022/02/mobigpu_mobicom22_camera.pdf) on page 5.


Differential Revision: D59926726
