### PR TITLE
[executorch] Add simple op_fast_hadamard_transform implementation

### DIFF
--- a/examples/models/llama2/custom_ops/CMakeLists.txt
+++ b/examples/models/llama2/custom_ops/CMakeLists.txt
@@ -80,8 +80,10 @@ if(EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT)
   # Add a AOT library
   find_package(Torch CONFIG REQUIRED)
   add_library(
-    custom_ops_aot_lib SHARED ${_custom_ops__srcs}
-                              ${CMAKE_CURRENT_SOURCE_DIR}/op_sdpa_aot.cpp
+    custom_ops_aot_lib SHARED
+    ${_custom_ops__srcs}
+    ${CMAKE_CURRENT_SOURCE_DIR}/op_sdpa_aot.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/op_randomized_fast_hadamard_transform_aten.cpp
   )
   target_include_directories(
     custom_ops_aot_lib PUBLIC "${_common_include_directories}"

--- a/examples/models/llama2/custom_ops/op_randomized_fast_hadamard_transform.cpp
+++ b/examples/models/llama2/custom_ops/op_randomized_fast_hadamard_transform.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/kernel/kernel_includes.h>
+
+namespace torch {
+namespace executor {
+namespace native {
+
+template <typename T>
+void randomized_fast_hadamard_transform_impl(
+    const T* vec,
+    T* out,
+    const std::uint8_t* s,
+    int vec_size) {
+  if (vec_size == 0) {
+    return;
+  }
+
+  std::memcpy(out, vec, vec_size * sizeof(T));
+
+  int step = 1;
+  while (step < vec_size) {
+    for (int ii = 0; ii < vec_size; ii += step * 2) {
+      for (int jj = ii; jj < ii + step; ++jj) {
+        auto x = out[jj];
+        auto y = out[jj + step];
+        out[jj] = x + y;
+        out[jj + step] = x - y;
+      }
+    }
+    step *= 2;
+  }
+
+  // vec_size is a power of 2 so an optimized implementation could use
+  // 1) a lookup table and 2) potentially a faster instruction than
+  // multiply if vec_size is a square.
+  const T inv_sqrt = T(1) / std::sqrt(T(vec_size));
+  for (int ii = 0; ii < vec_size; ++ii) {
+    T adjusted_val = out[ii] * inv_sqrt;
+    // This conditional negation implements matrix multiplication by
+    // diag(s).
+    if ((s[ii / 8] & (1 << (ii % 8))) != 0) {
+      adjusted_val = -adjusted_val;
+    }
+    out[ii] = adjusted_val;
+  }
+}
+
+template void randomized_fast_hadamard_transform_impl<float>(
+    const float* vec,
+    float* out,
+    const std::uint8_t* randomization_bitvec,
+    int vec_size);
+
+Tensor& randomized_fast_hadamard_transform_out(
+    RuntimeContext& ctx,
+    const Tensor& vec,
+    const Tensor& randomization_bitvec,
+    Tensor& out) {
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, vec.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(
+      ctx, vec.scalar_type() == out.scalar_type(), InvalidArgument, out);
+
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      randomization_bitvec.scalar_type() == exec_aten::ScalarType::Byte,
+      InvalidArgument,
+      out,
+      "randomization_bitvec argument to randomized_fast_hadamard_transform_out must be a "
+      "bitvector stored as type Byte!");
+
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      vec.dim() == 1,
+      InvalidArgument,
+      out,
+      "The Hadamard transform expects a vector!");
+
+  const auto vec_numel = vec.numel();
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      (vec_numel & (vec_numel - 1)) == 0,
+      InvalidArgument,
+      out,
+      "This implementation requires power-of-2 input size!");
+  ET_SWITCH_FLOATH_TYPES(vec.scalar_type(), ctx, __func__, CTYPE, [&] {
+    randomized_fast_hadamard_transform_impl(
+        vec.const_data_ptr<CTYPE>(),
+        out.mutable_data_ptr<CTYPE>(),
+        randomization_bitvec.const_data_ptr<std::uint8_t>(),
+        vec.numel());
+  });
+  return out;
+}
+} // namespace native
+} // namespace executor
+} // namespace torch

--- a/examples/models/llama2/custom_ops/op_randomized_fast_hadamard_transform.h
+++ b/examples/models/llama2/custom_ops/op_randomized_fast_hadamard_transform.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/runtime/kernel/kernel_includes.h>
+
+namespace torch::executor::native {
+
+template <typename T>
+void randomized_fast_hadamard_transform_impl(
+    const T* vec,
+    T* out,
+    const std::uint8_t* randomization_bitvec,
+    int vec_size);
+
+// Compute the fast Walsh-Hadamard transform
+// (https://en.wikipedia.org/wiki/Fast_Walsh%E2%80%93Hadamard_transform)
+// of vec, randomized using the additional bitvector randomization_bitvec.
+// randomization_bitvec is a bitvector interpreted as a vector containing only
+// elements from the set {+1, -1} (where the bit 1 denotes -1 and the bit 0
+// denotes +1
+// -- this choice of convention allows straightforward efficient
+// implementation). Whereas the usual FWHT computes H @ vec for some
+// Hadamard matrix H, the randomized FWHT computes (H @ diag(s)) @
+// vec. (Note that the multiplication by diag(s) is equivalent to
+// flipping the sign bit for each output element where s contains a 1
+// bit in the corresponding position.)
+//
+// vec.size() is currently required to be a power of two.
+Tensor& randomized_fast_hadamard_transform_out(
+    RuntimeContext& ctx,
+    const Tensor& vec,
+    const Tensor& randomization_bitvec,
+    Tensor& out);
+} // namespace torch::executor::native

--- a/examples/models/llama2/custom_ops/op_randomized_fast_hadamard_transform_aten.cpp
+++ b/examples/models/llama2/custom_ops/op_randomized_fast_hadamard_transform_aten.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/examples/models/llama2/custom_ops/op_randomized_fast_hadamard_transform.h>
+#include <executorch/extension/aten_util/make_aten_functor_from_et_functor.h>
+
+#include <torch/library.h>
+
+namespace torch::executor::native {
+Tensor& randomized_fast_hadamard_transform_out_no_context(
+    const Tensor& vec,
+    const Tensor& s,
+    Tensor& out) {
+  exec_aten::RuntimeContext context;
+  return randomized_fast_hadamard_transform_out(context, vec, s, out);
+}
+at::Tensor randomized_fast_hadamard_transform_aten(
+    const at::Tensor& vec,
+    const at::Tensor& s) {
+  auto out = at::empty_like(vec);
+  WRAP_TO_ATEN(randomized_fast_hadamard_transform_out_no_context, 2)
+  (vec, s, out);
+  return out;
+}
+} // namespace torch::executor::native
+
+TORCH_LIBRARY_FRAGMENT(llama, m) {
+  m.def("randomized_fast_hadamard_transform(Tensor vec, Tensor s) -> Tensor");
+  m.def(
+      "randomized_fast_hadamard_transform.out(Tensor vec, Tensor s, Tensor(a!) out) -> Tensor(a!)");
+}
+
+TORCH_LIBRARY_IMPL(llama, CompositeExplicitAutograd, m) {
+  m.impl(
+      "randomized_fast_hadamard_transform",
+      torch::executor::native::randomized_fast_hadamard_transform_aten);
+  m.impl(
+      "randomized_fast_hadamard_transform.out",
+      WRAP_TO_ATEN(
+          torch::executor::native::
+              randomized_fast_hadamard_transform_out_no_context,
+          2));
+}

--- a/examples/models/llama2/custom_ops/op_randomized_fast_hadamard_transform_test.cpp
+++ b/examples/models/llama2/custom_ops/op_randomized_fast_hadamard_transform_test.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/examples/models/llama2/custom_ops/op_randomized_fast_hadamard_transform.h>
+
+#include <executorch/kernels/test/TestUtil.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <random>
+
+using exec_aten::Tensor;
+
+namespace {
+Tensor& randomized_fast_hadamard_transform_nocontext(
+    const Tensor& vec,
+    const Tensor& randomization_bitvec,
+    Tensor& out) {
+  exec_aten::RuntimeContext context;
+  return torch::executor::native::randomized_fast_hadamard_transform_out(
+      context, vec, randomization_bitvec, out);
+}
+
+// The following "dumb_fht" function is from
+// https://github.com/FALCONN-LIB/FFHT/blob/master/test_float.c . It
+// has the following required copyright notice:
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Alexandr Andoni, Piotr Indyk, Thijs Laarhoven, Ilya
+// Razenshteyn, Ludwig Schmidt
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+void dumb_fht(float* buf, int log_n) {
+  int n = 1 << log_n;
+  for (int i = 0; i < log_n; ++i) {
+    int s1 = 1 << i;
+    int s2 = s1 << 1;
+    for (int j = 0; j < n; j += s2) {
+      for (int k = 0; k < s1; ++k) {
+        float u = buf[j + k];
+        float v = buf[j + k + s1];
+        buf[j + k] = u + v;
+        buf[j + k + s1] = u - v;
+      }
+    }
+  }
+}
+
+void reference_fht_impl(float* buf, int n) {
+  dumb_fht(buf, std::log2<int>(n));
+  const auto root_n = std::sqrt(n);
+  for (int ii = 0; ii < n; ++ii) {
+    buf[ii] /= root_n;
+  }
+}
+} // namespace
+
+TEST(RandomizedFastHadamardTransformTest, EmptyInput) {
+  torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
+  torch::executor::testing::TensorFactory<exec_aten::ScalarType::Byte> tfByte;
+  auto vec = tfFloat.zeros({0});
+  auto randomization_bitvec = tfByte.zeros({0});
+  auto out = tfFloat.zeros({0});
+  auto result = randomized_fast_hadamard_transform_nocontext(
+      vec, randomization_bitvec, out);
+  EXPECT_EQ(result.numel(), 0);
+}
+
+TEST(RandomizedFastHadamardTransformTest, SingleElementInput) {
+  torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
+  torch::executor::testing::TensorFactory<exec_aten::ScalarType::Byte> tfByte;
+  auto vec = tfFloat.ones({1});
+  auto randomization_bitvec = tfByte.zeros({1});
+  auto out = tfFloat.zeros({1});
+  auto result = randomized_fast_hadamard_transform_nocontext(
+      vec, randomization_bitvec, out);
+  EXPECT_EQ(result.numel(), 1);
+  // FHT of a single element is a no-op.
+  EXPECT_EQ(result.const_data_ptr<float>()[0], 1);
+
+  vec.mutable_data_ptr<float>()[0] = 42;
+  result = randomized_fast_hadamard_transform_nocontext(
+      vec, randomization_bitvec, out);
+  EXPECT_EQ(result.const_data_ptr<float>()[0], 42);
+
+  randomization_bitvec.mutable_data_ptr<char>()[0] = 1;
+  result = randomized_fast_hadamard_transform_nocontext(
+      vec, randomization_bitvec, out);
+  EXPECT_EQ(result.const_data_ptr<float>()[0], -42);
+}
+
+TEST(RandomizedFastHadamardTransformTest, FourKInput) {
+  torch::executor::testing::TensorFactory<exec_aten::ScalarType::Float> tfFloat;
+  torch::executor::testing::TensorFactory<exec_aten::ScalarType::Byte> tfByte;
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::normal_distribution<float> dist;
+  std::vector<float> data(4096);
+  for (int ii = 0; ii < data.size(); ++ii) {
+    data[ii] = dist(gen);
+  }
+  auto vec = tfFloat.make({4096}, data);
+  auto randomization_bitvec = tfByte.full({4096 / 8}, 0xA5);
+  auto out = tfFloat.zeros({4096});
+  auto result = randomized_fast_hadamard_transform_nocontext(
+      vec, randomization_bitvec, out);
+
+  std::vector<float> reference_result = data;
+  reference_fht_impl(reference_result.data(), reference_result.size());
+
+  const float* const result_data = result.const_data_ptr<float>();
+  for (int ii = 0; ii < 4096; ++ii) {
+    const bool should_negate = (ii % 2) != (ii % 8 < 4);
+    EXPECT_FLOAT_EQ(
+        should_negate ? -result_data[ii] : result_data[ii],
+        reference_result[ii]);
+  }
+}

--- a/examples/models/llama2/custom_ops/targets.bzl
+++ b/examples/models/llama2/custom_ops/targets.bzl
@@ -8,8 +8,14 @@ def define_common_targets():
     """
     runtime.cxx_library(
         name = "custom_ops",
-        srcs = ["op_sdpa.cpp"],
-        exported_headers = ["op_sdpa.h"],
+        srcs = [
+            "op_randomized_fast_hadamard_transform.cpp",
+            "op_sdpa.cpp",
+        ],
+        exported_headers = [
+            "op_randomized_fast_hadamard_transform.h",
+            "op_sdpa.h",
+        ],
         exported_deps = [
             "//executorch/runtime/kernel:kernel_includes",
             "//executorch/kernels/portable/cpu:scalar_utils",
@@ -33,6 +39,7 @@ def define_common_targets():
     runtime.cxx_library(
         name = "custom_ops_aot_lib",
         srcs = [
+            "op_randomized_fast_hadamard_transform_aten.cpp",
             "op_sdpa_aot.cpp",
         ],
         visibility = [
@@ -56,6 +63,20 @@ def define_common_targets():
         visibility = ["//executorch/..."],
         deps = [
             "//caffe2:torch",
+        ],
+    )
+
+    runtime.cxx_test(
+        name = "op_randomized_fast_hadamard_transform_test",
+        srcs = [
+            "op_randomized_fast_hadamard_transform_test.cpp",
+        ],
+        visibility = ["//executorch/..."],
+        deps = [
+            "//executorch/runtime/core/exec_aten:lib",
+            "//executorch/runtime/core/exec_aten/testing_util:tensor_util",
+            "//executorch/kernels/test:test_util",
+            ":custom_ops",
         ],
     )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4310

This operator is needed to implement the techniques from
https://github.com/facebookresearch/SpinQuant/ . I expect to send 1 or
more follow-up diffs improving performance from this naive
implementation, but this diff is sent separately to allow review to
focus on everything else: the ExecuTorch integration, the test, the
benchmark, etc.

Differential Revision: [D59919954](https://our.internmc.facebook.com/intern/diff/D59919954/)