### PR TITLE
Make flatcc cross-compile deterministic

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -84,6 +84,9 @@ option(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT
 )
 
 if(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT)
+  # Add the host project. We build this separately so that we can generate
+  # headers on the host during the build, even if we're cross-compiling the
+  # flatcc runtime to a different architecture.
   execute_process(
     COMMAND ${CMAKE_COMMAND} ${_flatcc_source_dir}
     -DFLATCC_TEST=OFF -DFLATCC_REFLECTION=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON
@@ -93,9 +96,26 @@ if(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT)
     COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}/_host_build
   )
   set(_etdump_schema_gen_dep)
+  # TODO(dbort): flatcc installs its files directly in its source directory
+  # instead of under CMAKE_BINARY_DIR, and it has no options to avoid doing
+  # this. We build flatcc twice in the executorch build: once to get the
+  # `flatcc` host commandline tool, and once to get the (potentially
+  # cross-compiled) target runtime library. The host build will put its outputs
+  # in the source tree, making the cross-compiling target build think that the
+  # outputs have already been built. It will then try to link against the
+  # host-architecture libraries, failing when cross-compiling. To work around
+  # this, delete the host outputs after running this command (which only runs
+  # when setting up the cmake files, not when actually building). This leaves
+  # room for the target build to put its own files in the source tree. We should
+  # try to remove this hack, ideally by submitting an upstream PR that adds an
+  # option to change the installation location.
+  set(_etdump_schema_cleanup_paths ${_flatcc_source_dir}/bin/*
+                                   ${_flatcc_source_dir}/lib/*
+  )
 else()
   # If we're not cross-compiling, we can just use the plain commandline target.
   set(_etdump_schema_gen_dep flatcc_cli)
+  set(_etdump_schema_cleanup_paths "")
 endif()
 
 set(_etdump_schema__outputs)
@@ -140,9 +160,9 @@ add_custom_command(
     ${_flatcc_source_dir}/bin/flatcc -cwr -o
     ${_program_schema__include_dir}/executorch/sdk/etdump
     ${_etdump_schema__srcs}
+  COMMAND rm -f ${_etdump_schema_cleanup_paths}
   DEPENDS ${_etdump_schema_gen_dep}
   COMMENT "Generating etdump headers"
-  VERBATIM
 )
 
 add_custom_target(

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -89,7 +89,9 @@ if(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT)
   # flatcc runtime to a different architecture.
   execute_process(
     COMMAND ${CMAKE_COMMAND} ${_flatcc_source_dir}
-    -DFLATCC_TEST=OFF -DFLATCC_REFLECTION=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    -DFLATCC_TEST=OFF -DFLATCC_REFLECTION=OFF
+    # See above comment about POSITION_INDEPENDENT_CODE.
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     -B${CMAKE_BINARY_DIR}/_host_build
   )
   execute_process(

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -84,23 +84,15 @@ option(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT
 )
 
 if(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT)
-  # Add the host project. We build this separately so that we can generate
-  # headers on the host during the build, even if we're cross-compiling the
-  # flatcc runtime to a different architecture.
-
-  # lint_cmake: -readability/wonkycase
-  ExternalProject_Add(
-    flatcc_project
-    PREFIX ${CMAKE_BINARY_DIR}/_host_build
-    SOURCE_DIR ${_flatcc_source_dir}
-    BINARY_DIR ${CMAKE_BINARY_DIR}/_host_build
-    CMAKE_CACHE_ARGS
-      -DFLATCC_TEST:BOOL=OFF -DFLATCC_REFLECTION:BOOL=OFF
-      # See above comment about POSITION_INDEPENDENT_CODE.
-      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
-    INSTALL_COMMAND "" # Prevent the install step
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} ${_flatcc_source_dir}
+    -DFLATCC_TEST=OFF -DFLATCC_REFLECTION=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    -B${CMAKE_BINARY_DIR}/_host_build
   )
-  set(_etdump_schema_gen_dep flatcc_project)
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}/_host_build
+  )
+  set(_etdump_schema_gen_dep)
 else()
   # If we're not cross-compiling, we can just use the plain commandline target.
   set(_etdump_schema_gen_dep flatcc_cli)
@@ -134,41 +126,10 @@ add_library(
   bundled_program_schema INTERFACE ${_bundled_program_schema__outputs}
 )
 
-# Ensure the host tool is built before the main project
-add_dependencies(etdump_schema flatcc_cli)
-
 file(MAKE_DIRECTORY ${_program_schema__include_dir}/executorch/sdk/etdump)
 file(MAKE_DIRECTORY
      ${_program_schema__include_dir}/executorch/sdk/bundled_program
 )
-
-if(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT)
-  # If we cross-compiling, we need to use the version of the commandline tool
-  # built for the host.
-  set(_etdump_schema_gen_dep flatcc_project)
-
-  # TODO(dbort): flatcc installs its files directly in its source directory
-  # instead of under CMAKE_BINARY_DIR, and it has no options to avoid doing
-  # this. We build flatcc twice in the executorch build: once to get the
-  # `flatcc` host commandline tool, and once to get the (potentially
-  # cross-compiled) target runtime library. The host build will put its outputs
-  # in the source tree, making the cross-compiling target build think that the
-  # outputs have already been built. It will then try to link against the
-  # host-architecture libraries, failing when cross-compiling. To work around
-  # this, delete the host outputs after running this command (which only runs
-  # when setting up the cmake files, not when actually building). This leaves
-  # room for the target build to put its own files in the source tree. We should
-  # try to remove this hack, ideally by submitting an upstream PR that adds an
-  # option to change the installation location.
-  set(_etdump_schema_cleanup_paths ${_flatcc_source_dir}/bin/*
-                                   ${_flatcc_source_dir}/lib/*
-  )
-else()
-  # If we're not cross-compiling we can use the plain commandline target, and we
-  # don't need to delete any files.
-  set(_etdump_schema_gen_dep flatcc_cli)
-  set(_etdump_schema_cleanup_paths "")
-endif()
 
 add_custom_command(
   OUTPUT ${_etdump_schema__outputs}
@@ -179,12 +140,17 @@ add_custom_command(
     ${_flatcc_source_dir}/bin/flatcc -cwr -o
     ${_program_schema__include_dir}/executorch/sdk/etdump
     ${_etdump_schema__srcs}
-  COMMAND rm -f ${_etdump_schema_cleanup_paths}
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/sdk
   DEPENDS ${_etdump_schema_gen_dep}
   COMMENT "Generating etdump headers"
   VERBATIM
 )
+
+add_custom_target(
+  etdump_schema_generated
+  DEPENDS ${_etdump_schema__outputs}
+)
+
+add_dependencies(etdump_schema etdump_schema_generated)
 
 add_library(
   etdump ${CMAKE_CURRENT_SOURCE_DIR}/etdump/etdump_flatcc.cpp

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -165,13 +165,6 @@ add_custom_command(
   COMMENT "Generating etdump headers"
 )
 
-add_custom_target(
-  etdump_schema_generated
-  DEPENDS ${_etdump_schema__outputs}
-)
-
-add_dependencies(etdump_schema etdump_schema_generated)
-
 add_library(
   etdump ${CMAKE_CURRENT_SOURCE_DIR}/etdump/etdump_flatcc.cpp
          ${CMAKE_CURRENT_SOURCE_DIR}/etdump/emitter.cpp


### PR DESCRIPTION
As mentioned in https://github.com/pytorch/executorch/pull/4297, the original flow makes host / cross build happen concurrently. This change moves host build process into cmake configuring stage and refine related dependencies.

Test Plan:
- cross-compile > Through running `backends/qualcomm/script/build.sh --release`, we could check if the compiling process successfully finished.
- native-compile > Run following to check:
```shell
cmake \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
    -DQNN_SDK_ROOT=${QNN_SDK_ROOT} \
    -DEXECUTORCH_BUILD_QNN=ON \
    -DEXECUTORCH_BUILD_SDK=ON \
    -DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE \
    -S $EXECUTORCH_ROOT \
    -B $EXECUTORCH_ROOT/build_x86_64 \
```