### PR TITLE
Clean up llava deps and consolidate all HF deps

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -71,10 +71,9 @@ test_model() {
   if [[ "${MODEL_NAME}" == "llava" ]]; then
     # Install requirements for llava
     bash examples/models/llava/install_requirements.sh
-    STRICT="--no-strict"
   fi
   # python3 -m examples.portable.scripts.export --model_name="llama2" should works too
-  "${PYTHON_EXECUTABLE}" -m examples.portable.scripts.export --model_name="${MODEL_NAME}" "${STRICT}"
+  "${PYTHON_EXECUTABLE}" -m examples.portable.scripts.export --model_name="${MODEL_NAME}"
   run_portable_executor_runner
 }
 

--- a/examples/models/llava/README.md
+++ b/examples/models/llava/README.md
@@ -7,14 +7,13 @@ In this example, we initiate the process of running multi modality through Execu
 Note that this folder does not host the pretrained LLava model.
 - To have Llava available, follow the [Install instructions](https://github.com/haotian-liu/LLaVA?tab=readme-ov-file#install) in the LLava github. Follow the licence in the specific repo when using L
 - Since the pytorch model version may not be updated, `cd executorch`, run `./install_requirements.sh`.
-- If there is numpy compatibility issue, run `pip install bitsandbytes -I`.
-- Alternatively, run `examples/models/llava_encoder/install_requirements.sh`, to replace the steps above.
-- Run `python3 -m examples.portable.scripts.export --model_name="llava_encoder"`. The llava_encoder.pte file will be generated.
-- Run `./cmake-out/executor_runner --model_path ./llava_encoder.pte` to verify the exported model with ExecuTorch runtime with portable kernels. Note that the portable kernels are not performance optimized. Please refer to other examples like those in llama2 folder for optimization.
+- Run `examples/models/llava/install_requirements.sh`, to install llava specific deps.
+- Run `python3 -m examples.portable.scripts.export --model_name="llava"`. The llava.pte file will be generated.
+- Run `./cmake-out/executor_runner --model_path ./llava.pte` to verify the exported model with ExecuTorch runtime with portable kernels. Note that the portable kernels are not performance optimized. Please refer to other examples like those in llama2 folder for optimization.
 
 ## TODO
 - Write the pipeline in cpp
   - Have image and text prompts as inputs.
   - Call image processing functions to preprocess the image tensor.
-  - Load the llava_encoder.pte model, run it using the image tensor.
+  - Load the llava.pte model, run it using the image tensor.
   - The output of the encoder can be combined with the prompt, as inputs to the llama model. Call functions in llama_runner.cpp to run the llama model and get outputs. The ExecuTorch end to end flow for the llama model is located at `examples/models/llama2`.

--- a/examples/models/llava/install_requirements.sh
+++ b/examples/models/llava/install_requirements.sh
@@ -7,6 +7,6 @@
 
 set -x
 
-pip install transformers accelerate
+pip install accelerate
 
 pip list


### PR DESCRIPTION
`python3 -m examples.portable.scripts.export --model_name="llava"` works fine on my mac M1. No strict mode is needed. And can directly working on the most recent transformers lib. 

It seems like the old restriction about numpy and transformers are not longer true. If CI gives green light we can cleanup the stale setup for llava and use the root setup (executorch/install_requirements.sh) as the source of truth