### PR TITLE
Implement aten.meshgrid.default with 2 input tensors

### DIFF
--- a/backends/vulkan/partitioner/supported_ops.py
+++ b/backends/vulkan/partitioner/supported_ops.py
@@ -113,6 +113,7 @@ INDEXING_OPS = [
 
 ORCHESTRATION_OPS = [
     exir_ops.edge.aten.cat.default,
+    exir_ops.edge.aten.meshgrid.default,
     exir_ops.edge.aten.split_with_sizes_copy.default,
     exir_ops.edge.aten.split.Tensor,
     exir_ops.edge.aten.repeat.default,

--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -36,6 +36,7 @@ from torch.fx.passes.operator_support import OperatorSupportBase
 # pyre-ignore
 ops_not_to_decompose = [
     torch.ops.aten.upsample_nearest2d.vec,
+    torch.ops.aten.meshgrid.default,
 ]
 
 

--- a/backends/vulkan/runtime/graph/ops/glsl/meshgrid.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/meshgrid.glsl
@@ -1,0 +1,39 @@
+#version 450 core
+
+#define PRECISION ${PRECISION}
+
+#define VEC4_T ${texel_type(DTYPE)}
+
+layout(std430) buffer;
+
+#include "indexing_utils.h"
+
+${layout_declare_tensor(0, "w", "t_out_1", DTYPE, STORAGE)}
+${layout_declare_tensor(1, "w", "t_out_2", DTYPE, STORAGE)}
+${layout_declare_tensor(2, "r", "t_in_1", DTYPE, STORAGE)}
+${layout_declare_tensor(3, "r", "t_in_2", DTYPE, STORAGE)}
+${layout_declare_ubo(4, "ivec4", "out_sizes")}
+${layout_declare_ubo(5, "ivec4", "in_sizes_1")}
+${layout_declare_ubo(6, "ivec4", "in_sizes_2")}
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+layout(constant_id = 3) const int packed_dim = C_DIM;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  const ivec4 idx = to_tensor_idx(pos, out_sizes, packed_dim);
+
+  if (pos_out_of_bounds(pos, out_sizes, packed_dim)) {
+    return;
+  }
+
+  ivec4 in_idx_1 = idx;
+  in_idx_1.x = idx.y;
+  in_idx_1.y = 0;
+  imageStore(t_out_1, pos, texelFetch(t_in_1, to_texture_pos(in_idx_1, in_sizes_1, packed_dim), 0));
+
+  ivec4 in_idx_2 = idx;
+  in_idx_2.y = 0;
+  imageStore(t_out_2, pos, texelFetch(t_in_2, to_texture_pos(in_idx_2, in_sizes_2, packed_dim), 0));
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/meshgrid.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/meshgrid.yaml
@@ -1,0 +1,12 @@
+meshgrid:
+  parameter_names_with_default_values:
+    NDIM: 3
+    DTYPE: float
+    PACKING: C_packed
+    STORAGE: texture3d
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: float
+      - VALUE: half
+  shader_variants:
+    - NAME: meshgrid

--- a/backends/vulkan/runtime/graph/ops/impl/Meshgrid.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Meshgrid.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+namespace vkcompute {
+
+void resize_meshgrid(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& extra_args) {
+  (void)extra_args;
+  vTensorPtr out_1 = graph->get_tensor(args[0].refs[0]);
+  vTensorPtr out_2 = graph->get_tensor(args[1].refs[0]);
+  vTensorPtr in_1 = graph->get_tensor(args[2].refs[0]);
+  vTensorPtr in_2 = graph->get_tensor(args[3].refs[0]);
+
+  std::vector<int64_t> out_sizes = out_1->sizes();
+  out_sizes.at(2) = in_1->sizes().at(0);
+  out_sizes.at(3) = in_2->sizes().at(0);
+
+  out_1->virtual_resize(out_sizes);
+  out_2->virtual_resize(out_sizes);
+}
+
+void add_meshgrid_node(
+    ComputeGraph& graph,
+    const ValueRef& in,
+    const ValueRef& out) {
+  ValueListPtr input_list = graph.get_value_list(in);
+  ValueListPtr output_list = graph.get_value_list(out);
+  VK_CHECK_COND(input_list->size() == 2, "meshgrid only support 2 inputs");
+  VK_CHECK_COND(output_list->size() == 2, "meshgrid only support 2 outputs");
+
+  std::string kernel_name = "";
+  kernel_name = "meshgrid";
+  kernel_name.reserve(kShaderNameReserve);
+  add_dtype_suffix(kernel_name, *graph.get_tensor(output_list->at(0)));
+
+  graph.execute_nodes().emplace_back(new ExecuteNode(
+      graph,
+      VK_KERNEL_FROM_STR(kernel_name),
+      graph.create_global_wg_size(output_list->at(0)),
+      graph.create_local_wg_size(output_list->at(0)),
+      // Inputs and Outputs
+      {{{output_list->at(0), output_list->at(1)},
+        vkapi::MemoryAccessType::WRITE},
+       {{input_list->at(0), input_list->at(1)}, vkapi::MemoryAccessType::READ}},
+      // Shader params buffers
+      {
+          graph.get_tensor(output_list->at(0))->sizes_ubo(),
+          graph.get_tensor(input_list->at(0))->sizes_ubo(),
+          graph.get_tensor(input_list->at(1))->sizes_ubo(),
+      },
+      // Specialization Constants
+      {},
+      nullptr,
+      {}));
+}
+
+void meshgrid(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  return add_meshgrid_node(graph, args[0], args[1]);
+}
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(aten.meshgrid.default, meshgrid);
+}
+
+} // namespace vkcompute

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -1057,3 +1057,15 @@ def get_squeeze_copy_dim_inputs():
         ]
     )
     return test_suite
+
+
+@register_test_suite("aten.meshgrid.default")
+def get_meshgrid_inputs():
+    test_suite = VkTestSuite(
+        [
+            ([(S), (S1)],),
+            ([(M), (M1)],),
+            ([(L), (L)],),
+        ]
+    )
+    return test_suite

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -1632,3 +1632,22 @@ class TestBackends(unittest.TestCase):
             (torch.tensor([[[0, 1], [0, 1]], [[4, 2], [3, 3]]]),),
             memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
         )
+
+    def test_vulkan_backend_meshgrid(self):
+        class MeshgridModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                return torch.meshgrid(x, y, indexing="ij")
+
+        sample_inputs = (
+            torch.randn(size=(3,), dtype=torch.float32),
+            torch.randn(size=(2,), dtype=torch.float32),
+        )
+
+        self.lower_module_and_test_output(
+            MeshgridModule(),
+            sample_inputs,
+            memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
+        )


### PR DESCRIPTION
Summary:
Implement aten.meshgrid.default with 2 input tensors.
This op is compiled from [torch.meshgrid](https://pytorch.org/docs/stable/generated/torch.meshgrid.html#torch-meshgrid).

Also add it into `ops_not_to_decompose`, otherwise it will be decomposed to several ops. Test can be found at: N5626891

Differential Revision: D60067846
