### PR TITLE
Fix log.cpp when compiled with `executorch.enable_et_log=false`

### DIFF
--- a/runtime/platform/log.cpp
+++ b/runtime/platform/log.cpp
@@ -17,9 +17,6 @@ namespace torch {
 namespace executor {
 namespace internal {
 
-/// Maximum length of a log message.
-static constexpr size_t kMaxLogMessageLength = 256;
-
 /**
  * Get the current timestamp to construct a log event.
  *
@@ -85,6 +82,8 @@ void vlogf(
     va_list args) {
 #if ET_LOG_ENABLED
 
+  // Maximum length of a log message.
+  static constexpr size_t kMaxLogMessageLength = 256;
   char buf[kMaxLogMessageLength];
   size_t len = vsnprintf(buf, kMaxLogMessageLength, format, args);
   if (len >= kMaxLogMessageLength - 1) {


### PR DESCRIPTION
Summary:
Currently, the ASR execution fails with the following error: 
`xplat/executorch/runtime/platform/log.cpp:21:25: error: unused variable 'kMaxLogMessageLength' [-Werror,-Wunused-const-variable]` (P1484525874).

This diff marks kMaxLogMessageLength as `maybe_unused`.

Differential Revision: D59641404


