### PR TITLE
XNNPartitionerConfig + Config-Based XNNPACKPartitioner

### DIFF
--- a/backends/xnnpack/partition/TARGETS
+++ b/backends/xnnpack/partition/TARGETS
@@ -6,6 +6,7 @@ runtime.python_library(
     name = "xnnpack_partitioner",
     srcs = [
         "xnnpack_partitioner.py",
+        "xnnpack_partitioner2.py",
     ],
     visibility = [
         "//executorch/...",
@@ -15,6 +16,7 @@ runtime.python_library(
         ":configs",
         ":partitioner_graphs",
         "//executorch/backends/xnnpack:xnnpack_preprocess",
+        "//executorch/backends/xnnpack/partition/config:xnnpack_partitioner_configs",
         "//executorch/exir:delegate",
         "//executorch/exir:lib",
         "//executorch/exir/backend:partitioner",

--- a/backends/xnnpack/partition/config/TARGETS
+++ b/backends/xnnpack/partition/config/TARGETS
@@ -1,0 +1,20 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+oncall("executorch")
+
+runtime.python_library(
+    name = "xnnpack_partitioner_configs",
+    srcs = glob([
+        "*.py",
+    ]),
+    visibility = [
+        "//executorch/...",
+        "@EXECUTORCH_CLIENTS",
+    ],
+    deps = [
+        "//executorch/exir:lib",
+        "//executorch/exir/backend:partitioner",
+        "//executorch/exir/backend:utils",
+        "//executorch/exir/backend/canonical_partitioners:config_partitioner_lib",
+    ],
+)

--- a/backends/xnnpack/partition/config/__init__.py
+++ b/backends/xnnpack/partition/config/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import List, Type
+
+from executorch.backends.xnnpack.partition.config.xnnpack_config import (
+    XNNPartitionerConfig,
+)
+
+ALL_PARTITIONER_CONFIGS: List[Type[XNNPartitionerConfig]] = []

--- a/backends/xnnpack/partition/config/xnnpack_config.py
+++ b/backends/xnnpack/partition/config/xnnpack_config.py
@@ -1,0 +1,199 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import abstractmethod
+from enum import Enum
+from typing import List, Optional
+
+import torch
+from executorch.exir.backend.canonical_partitioners.config_partitioner import (
+    format_target_name,
+    PartitionerConfig,
+)
+from torch.export import ExportedProgram
+
+
+class ConfigPrecisionType(Enum):
+    FP32 = 1
+    STATIC_QUANT = 2
+    DYNAMIC_QUANT = 3
+
+
+# TODO: add WhyNotPartition to XNNPartitionerConfig
+class XNNPartitionerConfig(PartitionerConfig):
+    """
+    Base partitioner config for XNNPACK Partitioner Configs. Base wrapper class
+    for all XNNPACK Partitioner Configs allows us to apply control over
+    all PartitionerConfigs. XNNPACK Partitioner config also sets a property
+    for supported precision types. This allows partitioner configs to set
+    the precision types they support, and let users toggle which precision
+    types they want to enable
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.enabled_precision_types = self.supported_precision_types()
+
+    def get_partition(
+        self, node: torch.fx.Node, ep: ExportedProgram
+    ) -> List[torch.fx.Node]:
+        """
+        Overriding abstract method get_partition.
+
+        Returns the partitioned nodes from get_node_and_deps, but also labels them
+        with the name of the XNNPartitionerConfig class which return this set of nodes.
+        This enforces that all partitions returned by XNNPartitioner configs are labeled
+        with the partitioner config which returned them
+        """
+        partitioned_nodes = self.get_node_and_deps(node, ep)
+        # label partitioned nodes with the name of the partitioner config
+        for node in partitioned_nodes:
+            if "xnn_partitioner_config" in node.meta:
+                node.meta["xnn_partitioner_config"].append(self.__class__.__name__)
+            else:
+                node.meta["xnn_partitioner_config"] = [self.__class__.__name__]
+
+        return partitioned_nodes
+
+    @abstractmethod
+    def supported_precision_types(self) -> List[ConfigPrecisionType]:
+        """
+        Returns the supported PrecisionType of this partitioner config
+        """
+        pass
+
+    @abstractmethod
+    def get_node_and_deps(
+        self, node: torch.fx.Node, ep: ExportedProgram
+    ) -> List[torch.fx.Node]:
+        """
+        Takes in a node and its exported program and returns a list of nodes
+        and its dependencies that need to be partitioned together
+
+        Args:
+            node: Node to be partitioned
+            ep: Exported program of the graph module
+        Returns:
+            List of nodes that can be partitioned
+        """
+        pass
+
+    def set_enabled_precision_types(
+        self, precision_types: Optional[List[ConfigPrecisionType]]
+    ):
+        """
+        Set the enabled precisions.
+
+        We take the intersection of the precision_types we wish to enable with
+        the precision types that this config supports. If enabled_precisions is empty, i.e.
+        the config does not support any of the precision types we want to enable,
+        then we will not partition nothing and return false at the common constraints
+        """
+
+        if precision_types:
+            enabled_precisions = []
+            for precision in precision_types:
+                if precision in self.supported_precision_types():
+                    enabled_precisions.append(precision)
+
+            self.enabled_precision_types = enabled_precisions
+
+    def check_common_constraints(
+        self, node: torch.fx.Node, ep: ExportedProgram
+    ) -> bool:
+        """
+        Checks common xnnpack constraints
+
+        Args:
+            node (torch.fx.Node): Node to check common constraints against
+            ep (ExportedProgram): Exported Program to check constraints against
+
+        Returns:
+            True or False whether this node is partitionable
+        """
+        assert (
+            node.op == "call_function"
+            and format_target_name(node.target.__name__)  # pyre-ignore
+            == self.target_name
+        )
+
+        if len(self.enabled_precision_types) == 0:
+            return False
+
+        has_valid_dtypes = self._check_node_has_valid_dtype(node)
+        if not has_valid_dtypes:
+            return False
+
+        return True
+
+    def _check_inputs_are_valid_dtypes(self, node, valid_dtypes):
+        # Check inputs are valid dtypes
+        # Gather all args which are nodes
+        args_to_check = []
+        for arg in node.args:
+            if isinstance(arg, list) or isinstance(arg, tuple):
+                for item in arg:
+                    if isinstance(item, torch.fx.Node):
+                        args_to_check.append(item)
+
+            if isinstance(arg, torch.fx.Node):
+                args_to_check.append(arg)
+
+        for arg in args_to_check:
+            arg_val = arg.meta.get("val", None)
+
+            if arg_val is None or isinstance(arg_val, tuple):
+                continue
+
+            # Being conservative for now, UX >> Perf
+            # TODO: We need a pass to scrub these out.
+            if not isinstance(arg_val, torch.Tensor):
+                return False
+
+            # XNNPACK does not support empty tensors
+            if arg_val.numel() == 0:
+                return False
+
+            if arg_val.dtype not in valid_dtypes:
+                return False
+
+        return True
+
+    def _check_outputs_are_valid_dtypes(self, node, valid_dtypes):
+        # Check outputs are valid dtype
+        node_val = node.meta.get("val", None)
+        if node_val is None:
+            return True
+
+        if not isinstance(node_val, tuple):
+            node_val = (node_val,)
+
+        for val in node_val:
+            if not isinstance(val, torch.Tensor):
+                return False
+
+            if val.dtype not in valid_dtypes:
+                return False
+
+        return True
+
+    def _check_node_has_valid_dtype(self, node):
+        valid_dtypes = {
+            torch.float32,
+            torch.float16,
+            torch.int8,
+            torch.qint8,
+        }
+        if (
+            node.op != "placeholder"
+            and node.op != "call_function"
+            and node.op != "get_attr"
+        ):
+            return False
+
+        return self._check_inputs_are_valid_dtypes(
+            node, valid_dtypes
+        ) and self._check_outputs_are_valid_dtypes(node, valid_dtypes)

--- a/backends/xnnpack/partition/xnnpack_partitioner2.py
+++ b/backends/xnnpack/partition/xnnpack_partitioner2.py
@@ -1,0 +1,87 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+from typing import List, Optional, Type, Union
+
+from executorch.backends.xnnpack.partition.config import ALL_PARTITIONER_CONFIGS
+from executorch.backends.xnnpack.partition.config.xnnpack_config import (
+    ConfigPrecisionType,
+    XNNPartitionerConfig,
+)
+
+from executorch.backends.xnnpack.xnnpack_preprocess import XnnpackBackend
+from executorch.exir.backend.backend_details import ExportedProgram
+from executorch.exir.backend.canonical_partitioners.config_partitioner import (
+    ConfigerationBasedPartitioner,
+)
+from executorch.exir.backend.partitioner import DelegationSpec
+from torch.fx.passes.infra.partitioner import Partition
+
+
+class XnnpackPartitioner(ConfigerationBasedPartitioner):
+    def __init__(
+        self,
+        configs: Optional[List[Type[XNNPartitionerConfig]]] = None,
+        config_precisions: Optional[
+            Union[ConfigPrecisionType, List[ConfigPrecisionType]]
+        ] = None,
+        per_op_mode=False,
+    ):
+        delegation_spec = DelegationSpec(XnnpackBackend.__name__, [])
+        configs_to_use = configs or ALL_PARTITIONER_CONFIGS
+        # Can do logic and have extra args to filter/delete/select
+        # Certain configs based on user specification
+        initialized_configs = []
+        if isinstance(config_precisions, ConfigPrecisionType):
+            config_precisions = [config_precisions]
+
+        for config in configs_to_use:
+            # Config Classes given to XnnpackPartitioner should no longer be abstract
+            initialized = config()  #  pyre-ignore
+            initialized.set_enabled_precision_types(config_precisions)
+            initialized_configs.append(initialized)
+
+        # per_op_mode takes the first match from a partitioner config, any
+        # subsequent matches that overlap with the first match are not partitioned
+        self.per_op_mode = per_op_mode
+        super().__init__(delegation_spec, initialized_configs)
+
+    def generate_partitions(self, ep: ExportedProgram) -> List[Partition]:
+        """
+        generate_partitions is different if partitioner is set to per_op_mode
+        for per_op_mode we only need to generate unmerged partitions instead
+        of using the default generate_partitions method.
+        """
+        if self.per_op_mode:
+            return self.generate_per_op_partitions(ep)
+        else:
+            return super().generate_partitions(ep)
+
+    def generate_per_op_partitions(self, ep: ExportedProgram) -> List[Partition]:
+        """
+        Uses configs to generate per_op_partitions. That is no partitions are
+        merged together. All partitions (node + deps) returned by PartitionerConfigs
+        are put into their own partition.
+        """
+        partitions = []
+        matched_nodes = self.get_matched_nodes_from_configs(ep)
+        partition_id = itertools.count()
+        nodes_seen = set()
+        for match in matched_nodes:
+            match_set = set(match)
+            # We only create partitions from the first PartitionerConfig match
+            # if a subsequent partitioner match contains the same node, we do
+            # not create a partition for it
+            if match_set.isdisjoint(nodes_seen):
+                partitions.append(
+                    Partition(
+                        id=next(partition_id),
+                        nodes=match_set,
+                    )
+                )
+                nodes_seen.update(match_set)
+        return partitions

--- a/exir/backend/canonical_partitioners/TARGETS
+++ b/exir/backend/canonical_partitioners/TARGETS
@@ -36,3 +36,20 @@ runtime.python_library(
         "//executorch/exir/backend:partitioner",
     ],
 )
+
+runtime.python_library(
+    name = "config_partitioner_lib",
+    srcs = [
+        "config_partitioner.py",
+    ],
+    visibility = [
+        "//executorch/...",
+        "//executorch/exir/backend/...",
+        "//executorch/test/...",
+        "@EXECUTORCH_CLIENTS",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir/backend:partitioner",
+    ],
+)

--- a/exir/backend/canonical_partitioners/config_partitioner.py
+++ b/exir/backend/canonical_partitioners/config_partitioner.py
@@ -1,0 +1,204 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import ABC, abstractmethod
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+import torch
+from executorch.exir.backend.backend_details import ExportedProgram
+from executorch.exir.backend.canonical_partitioners.pattern_op_partitioner import (
+    generate_partitions_from_list_of_nodes,
+)
+from executorch.exir.backend.partitioner import (
+    DelegationSpec,
+    Partitioner,
+    PartitionResult,
+)
+from torch.fx.passes.infra.partitioner import Partition
+
+
+def format_target_name(target_name: str) -> str:
+    """
+    We remove the dialect name space from the target name. We generally
+    do not care for the op dialect specific name space ("aten.", "quantized_decomposed.")
+    but rather the op itself. Se remove the dialect-specific name space from the
+    name and return the op name itself
+    """
+    names = target_name.split(".")
+    if len(names) > 2:
+        names.pop(0)
+
+    return ".".join(names)
+
+
+class PartitionerConfig(ABC):
+    """
+    Class used to represent a PartitionerConfig.
+
+    PartitionerConfig is used by config-based partitioner to partition identify
+    nodes to be delegated. User overrides the methods:
+        - target_name
+        - check_constraints
+        - get_partition
+        - get_original_aten
+
+    The Config-Based Partitioner then uses these overridden methods to find nodes
+    which match target_name, check_constraints, and if true, returns the partition
+    (list of nodes) which represent the node and its dependencies. get_original_aten
+    is used to halt decomposition to edge_dialect if the node can be delegated by
+    the specified backend.
+    """
+
+    @classmethod
+    @property
+    @abstractmethod
+    def target_name(cls) -> str:
+        """
+        Target name for this partitioner config. When the Config-Based Partitioner
+        encounters a node with a matching target name, it uses this config's methods to
+        checks the constraints of this node and get all of its dependencies.
+        the target name is formatted to remove the dialect-specific name space.
+        i.e. linear.default
+        """
+        pass
+
+    @abstractmethod
+    def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
+        """
+        Takes in a node and returns true if the node is partitionable.
+
+        Args:
+            node: Node to be partitioned
+            ep: Exported program of the graph module
+        Returns:
+            True or False whether this node is partitionable
+        """
+        pass
+
+    @abstractmethod
+    def get_original_aten(self) -> Optional[torch._ops.OpOverload]:
+        """
+        Returns the original aten dialect op, this is for to_edge_transform_and_lower
+        API, so that this config can be used to stop decomposition of this original
+        aten op
+        """
+        pass
+
+    @abstractmethod
+    def get_partition(
+        self, node: torch.fx.Node, ep: ExportedProgram
+    ) -> List[torch.fx.Node]:
+        """
+        Returns the partitioned nodes from get_node_and_deps, but also labels them
+        with the name of the PartitionerConfig class which return this set of nodes.
+
+        Returns an empty list of the node and deps do not satisfy the checked constraints
+        """
+        pass
+
+
+class ConfigerationBasedPartitioner(Partitioner):
+    def __init__(
+        self,
+        delegation_spec: DelegationSpec,
+        partitioner_configs: Iterable[PartitionerConfig],
+    ):
+        """
+        Configeration based partitioner. We supply the partitioner with a set of configerations
+        which describe the node type, constraints, and any dependencies required to be partitioned
+        with the node. We use the configerations to partition the graph module.
+        """
+        super().__init__()
+        # Initialize partitioner configs map {"target_name": PartitionerConfig}
+        self.target_partitioner_configs: Dict[str, PartitionerConfig] = {}
+        for config in partitioner_configs:
+            target_name = config.target_name
+            if target_name in self.target_partitioner_configs:
+                other_config = self.target_partitioner_configs[target_name]
+                raise RuntimeError(
+                    f"PartitionerConfig: {config} and {other_config} have the same target_name: {target_name}"
+                )
+            else:
+                self.target_partitioner_configs[target_name] = config
+
+        self.delegation_spec = delegation_spec
+
+    def ops_to_not_decompose(
+        self,
+        ep: ExportedProgram,
+    ) -> Tuple[List[torch._ops.OpOverload], Optional[Callable[[torch.fx.Node], bool]]]:
+        def filter_fn(node: torch.fx.Node) -> bool:
+            """
+            The partitioner configs we initialize with have check_constraints function,
+            to determine if this op is indeed partitionable. We grab the check_constraint
+            function of this op from the config and use it to filter.
+            """
+            if node.op != "call_function":
+                return False
+            target_name = format_target_name(node.target.__name__)  # pyre-ignore
+
+            if target_name in self.target_partitioner_configs:
+                config = self.target_partitioner_configs[target_name]
+                # only filter_fn if config has original_aten
+                if config.get_original_aten():
+                    return self.target_partitioner_configs[
+                        target_name
+                    ].check_constraints(node, ep)
+
+            return False
+
+        # Get list of original aten targets which we do not want to decomp
+        do_not_decomp = []
+        for node_config in self.target_partitioner_configs.values():
+            original_aten = node_config.get_original_aten()
+            if original_aten is not None:
+                do_not_decomp.append(original_aten)
+
+        return (do_not_decomp, filter_fn)
+
+    def get_matched_nodes_from_configs(
+        self, ep: ExportedProgram
+    ) -> List[List[torch.fx.Node]]:
+        # gather supported nodes
+        matched_nodes = []
+        gm = ep.graph_module
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                target = format_target_name(node.target.__name__)
+                if target in self.target_partitioner_configs:
+                    node_config = self.target_partitioner_configs[target]
+                    if node_config.check_constraints(node, ep):
+                        matched_nodes.append(node_config.get_partition(node, ep))
+
+        return matched_nodes
+
+    def generate_partitions(self, ep: ExportedProgram) -> List[Partition]:
+        matched_nodes = self.get_matched_nodes_from_configs(ep)
+        # create partitions
+        partitions = generate_partitions_from_list_of_nodes(
+            ep.graph_module,
+            matched_nodes,
+        )
+        return partitions
+
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
+        partitions = self.generate_partitions(exported_program)
+
+        # tag nodes
+        partition_tags: Dict[str, DelegationSpec] = {}
+        for partition in partitions:
+            for node in partition.nodes:
+                delegation_tag = f"tag{partition.id}"
+                if "delegation_tag" in node.meta:
+                    raise RuntimeError(
+                        f"Partitioner Erro found node {node} in partition {node.meta['delegation_tag']} and partition {delegation_tag}"
+                    )
+                node.meta["delegation_tag"] = delegation_tag
+                partition_tags[delegation_tag] = self.delegation_spec
+
+        return PartitionResult(
+            tagged_exported_program=exported_program, partition_tags=partition_tags
+        )


### PR DESCRIPTION
Summary:
The following contains the base classes for the XnnpackPartitioner and XNN-Based Partitioner Config.

## XNNPartitionerConfig
The `XNNPartitionerConfig` inherits from the base partitioner config class and is meant to be the base class for all partitioner configs used by the new XnnpackPartitioner. The main things that this allows us to have is:
- Control Over Precision Types
    - We add an abstract `supported_precision_types` method for all XNNPartitionerConfigs to implement to indicate the precision types the support
    - we add an attribute `enabled_precision_types` which is a subset of the supported_precision_types. This attribute allows the user to configure which precision types the config is able to partition.

- Checking common constraints.
    - Some constraints such as dtype need be checked by all XNNPartitioner configs, so we add a method to check_common_constraints here
- Labeling partitioned configs
    - We add a abstract wrapper get_nodes_and_deps() function and override the `get_partition()` function to enforce that all nodes and deps returned by the partitioner config are labeled with the name of the PartitionerConfig class which returned them

## New XnnpackPartitioner
`XnnpackPartitioner` inherits from the `ConfigerationBasedPartitioner`. One of the main differences that the XnnpackPartitioner has from the base ConfigerationBasedPartitioner is that it takes in XNNPartitionerConfigs. XNNPartitionerConfigs allows the XnnpackPartitioner to enable/disable certain precision types like dynamic quant, floating point, static quant based on configs set at init time.

Another feature change is the configureability of per-op mode. Like the old XnnpackDynamicallyQuantizedPartitioner, this allows for partitions returned by XNNPartitionerConfigs to remain in their own delegate. Meaning the partitions returned will not be merged with other partitioned nodes which have connecting edge. This allows us to mimic the behavior of XnnpackDynamicallyQuantizedPartitioner.

Differential Revision: D58903233
