### PR TITLE
Add GEMM Config to partition Linear, QLinear, DQLinear, Addmm

### DIFF
--- a/backends/xnnpack/partition/TARGETS
+++ b/backends/xnnpack/partition/TARGETS
@@ -6,6 +6,7 @@ runtime.python_library(
     name = "xnnpack_partitioner",
     srcs = [
         "xnnpack_partitioner.py",
+        "xnnpack_partitioner2.py",
     ],
     visibility = [
         "//executorch/...",
@@ -15,6 +16,7 @@ runtime.python_library(
         ":configs",
         ":partitioner_graphs",
         "//executorch/backends/xnnpack:xnnpack_preprocess",
+        "//executorch/backends/xnnpack/partition/config:xnnpack_partitioner_configs",
         "//executorch/exir:delegate",
         "//executorch/exir:lib",
         "//executorch/exir/backend:partitioner",

--- a/backends/xnnpack/partition/config/TARGETS
+++ b/backends/xnnpack/partition/config/TARGETS
@@ -1,0 +1,20 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+oncall("executorch")
+
+runtime.python_library(
+    name = "xnnpack_partitioner_configs",
+    srcs = glob([
+        "*.py",
+    ]),
+    visibility = [
+        "//executorch/...",
+        "@EXECUTORCH_CLIENTS",
+    ],
+    deps = [
+        "//executorch/exir:lib",
+        "//executorch/exir/backend:partitioner",
+        "//executorch/exir/backend:utils",
+        "//executorch/exir/backend/canonical_partitioners:config_partitioner_lib",
+    ],
+)

--- a/backends/xnnpack/partition/config/__init__.py
+++ b/backends/xnnpack/partition/config/__init__.py
@@ -7,8 +7,24 @@
 
 from typing import List, Type
 
+from executorch.backends.xnnpack.partition.config.gemm_configs import (
+    AddmmConfig,
+    LinearConfig,
+)
+
+from executorch.backends.xnnpack.partition.config.single_node_configs import (
+    DeQuantizedPerTensorConfig,
+    QuantizedPerTensorConfig,
+)
 from executorch.backends.xnnpack.partition.config.xnnpack_config import (
     XNNPartitionerConfig,
 )
 
-ALL_PARTITIONER_CONFIGS: List[Type[XNNPartitionerConfig]] = []
+ALL_PARTITIONER_CONFIGS: List[Type[XNNPartitionerConfig]] = [
+    # Linear/Addmm Configs
+    AddmmConfig,
+    LinearConfig,
+    # Quantization Op Configs
+    QuantizedPerTensorConfig,
+    DeQuantizedPerTensorConfig,
+]

--- a/backends/xnnpack/partition/config/__init__.py
+++ b/backends/xnnpack/partition/config/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import List, Type
+
+from executorch.backends.xnnpack.partition.config.xnnpack_config import (
+    XNNPartitionerConfig,
+)
+
+ALL_PARTITIONER_CONFIGS: List[Type[XNNPartitionerConfig]] = []

--- a/backends/xnnpack/partition/config/gemm_configs.py
+++ b/backends/xnnpack/partition/config/gemm_configs.py
@@ -1,0 +1,264 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from itertools import chain
+from typing import List, Optional, Tuple
+
+import torch
+from executorch.backends.xnnpack.partition.config.xnnpack_config import (
+    ConfigPrecisionType,
+    XNNPartitionerConfig,
+)
+from executorch.backends.xnnpack.utils.quant_utils import (
+    is_dequant,
+    is_dynamic_qdq,
+    is_per_channel,
+    is_qparam,
+    is_quant,
+)
+from executorch.backends.xnnpack.utils.utils import (
+    get_input_node,
+    is_getitem,
+    is_node,
+    is_param_node,
+)
+from executorch.exir.backend.canonical_partitioners.config_partitioner import (
+    format_target_name,
+)
+from torch.export import ExportedProgram
+
+
+class GEMMConfig(XNNPartitionerConfig):
+    """
+    GEMM-like ops like Convolution, Addmm, Linear, mostly behave in the same way, in which we
+    have some weight, bias, and activation node. The only difference between these types
+    of ops are that the weight, bias, and activations are in different indicies of the
+    nodes arguments, this class helps to generalize the logic needed to partition these
+    different ops
+    """
+
+    def __init__(self, weight_idx, bias_idx, act_idx, fused_acts):
+        super().__init__()
+        self.weight_idx = weight_idx
+        self.bias_idx = bias_idx
+        self.act_idx = act_idx
+        self.fused_acts = fused_acts
+
+    def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
+        if not self.check_common_constraints(node, ep):
+            # short circuit if we don't pass common constraints
+            return False
+
+        precision = self._detect_precision(node)
+        if precision not in self.enabled_precision_types:
+            # detected precision but it is either disabled or not supported
+            return False
+
+        is_valid, _ = self.get_deps(node, ep, precision)
+        return is_valid
+
+    def get_node_and_deps(
+        self, node: torch.fx.Node, ep: ExportedProgram
+    ) -> List[torch.fx.Node]:
+        partition = [node]
+        precision = self._detect_precision(node)
+        _, deps = self.get_deps(node, ep, precision)
+        partition.extend(deps)
+
+        return partition
+
+    def get_original_aten(self) -> Optional[torch._ops.OpOverload]:
+        return None
+
+    def _detect_precision(self, node: torch.fx.Node) -> ConfigPrecisionType:
+        weight = get_input_node(node, self.weight_idx)
+
+        if not is_dequant(weight):
+            return ConfigPrecisionType.FP32
+
+        activation = get_input_node(node, self.act_idx)
+        if is_dynamic_qdq(activation):
+            return ConfigPrecisionType.DYNAMIC_QUANT
+
+        return ConfigPrecisionType.STATIC_QUANT
+
+    def get_deps(
+        self, node: torch.fx.Node, ep: ExportedProgram, precision: ConfigPrecisionType
+    ) -> Tuple[bool, List[torch.fx.Node]]:
+        """
+        Gets all dependencies for this gemm partition. Returns a tuple of
+        a bool indicating if the deps are valid and a list of all the
+        dep nodes
+        """
+        valid_bias, bias_deps = self._get_bias_deps(node, ep, precision)
+        valid_weight, weight_deps = self._get_weight_deps(node, ep, precision)
+        valid_act, act_deps = self._get_act_deps(node, ep, precision)
+        valid_output, output_deps = self._get_output_deps(node, ep, precision)
+
+        valid_deps = valid_bias and valid_weight and valid_act and valid_output
+        deps = list(chain(bias_deps, weight_deps, act_deps, output_deps))
+
+        return valid_deps, deps
+
+    def _get_weight_deps(
+        self, node: torch.fx.Node, ep: ExportedProgram, precision: ConfigPrecisionType
+    ) -> Tuple[bool, List[torch.fx.Node]]:
+        gemm_deps = []
+        if precision == ConfigPrecisionType.FP32:
+            # First find the weight
+            weight_node = get_input_node(node, self.weight_idx)
+            if not is_param_node(ep, weight_node):
+                return (False, [])  # weight must be a static param
+            gemm_deps.append(weight_node)
+
+            return (True, gemm_deps)
+        else:
+            # Quantized Weight deps
+            dequant_node = get_input_node(node, self.weight_idx)
+            if not is_dequant(dequant_node):
+                return False, []
+            gemm_deps.append(dequant_node)
+            weight = get_input_node(dequant_node, 0)
+            if not is_param_node(ep, weight):
+                return False, []
+            gemm_deps.append(weight)
+
+            if is_per_channel(dequant_node):
+                if len(dequant_node.all_input_nodes) < 2:
+                    # Expected channel quantized to have scale/zp nodes
+                    return False, []
+
+                gemm_deps.extend(dequant_node.all_input_nodes[1:3])
+            return (True, gemm_deps)
+
+    def _get_output_deps(
+        self, node: torch.fx.Node, ep: ExportedProgram, precision: ConfigPrecisionType
+    ) -> Tuple[bool, List[torch.fx.Node]]:
+        gemm_deps = []
+        if precision == ConfigPrecisionType.STATIC_QUANT:
+            # Look for fused activations and tail end quant node
+            node_users = list(node.users.keys())
+            if len(node_users) != 1:
+                # Expect quantized node to have a single output (fused act or dequant)
+                return False, []
+
+            # Check if the quantized pattern has a fused activation
+            n_output = node_users[0]
+            if (
+                n_output.op == "call_function"
+                and format_target_name(n_output.target.__name__) in self.fused_acts
+            ):
+                gemm_deps.append(n_output)
+                fused_out_users = list(n_output.users.keys())
+                if len(fused_out_users) == 1:
+                    n_output = fused_out_users[0]
+
+            if not is_quant(n_output):
+                # Expected gemm_node --> fused_act (optional) --> dequant
+                return (False, [])
+            gemm_deps.append(n_output)
+        elif precision == ConfigPrecisionType.FP32:
+            # Look for fused activations only, and partition with fp32 op
+            node_users = list(node.users.keys())
+            if len(node_users) == 1:
+                n_output = node_users[0]
+                if (
+                    n_output.op == "call_function"
+                    and format_target_name(n_output.target.__name__) in self.fused_acts
+                ):
+                    gemm_deps.append(n_output)
+
+        # FP32 and Dynamic Quant have no output dependencies
+        return (True, gemm_deps)
+
+    def _get_bias_deps(
+        self, node: torch.fx.Node, ep: ExportedProgram, precision: ConfigPrecisionType
+    ) -> Tuple[bool, List[torch.fx.Node]]:
+        gemm_deps = []
+        if len(node.all_input_nodes) > 2:
+            bias_node = get_input_node(node, self.bias_idx)
+            if bias_node:
+                if not is_param_node(ep, bias_node):
+                    return (False, [])  # bias node must be a static param
+                gemm_deps.append(bias_node)
+
+        return (True, gemm_deps)
+
+    def _get_act_deps(
+        self, node: torch.fx.Node, ep: ExportedProgram, precision: ConfigPrecisionType
+    ) -> Tuple[bool, List[torch.fx.Node]]:
+        gemm_deps = []
+        if precision == ConfigPrecisionType.FP32:
+            return (True, [])
+        else:
+            dq_input = get_input_node(node, self.act_idx)
+            if not is_dequant(dq_input):
+                # Expected static quant input to be dequant node
+                return False, []
+            gemm_deps.append(dq_input)
+            if precision == ConfigPrecisionType.STATIC_QUANT:
+                # if static quant we are done after finding first dq_input
+                return (True, gemm_deps)
+
+            # q input node
+            q_input = get_input_node(dq_input, 0)
+            if not is_quant(q_input):
+                return (False, [])
+
+            gemm_deps.append(q_input)
+            if not (is_node(q_input.args[1]) and is_node(q_input.args[2])):
+                # expected to find getitem node from choose qparam
+                return (False, [])
+
+            getitem1 = get_input_node(q_input, 1)
+            getitem2 = get_input_node(q_input, 2)
+
+            if not (is_getitem(getitem1) and is_getitem(getitem2)):
+                # expected getitem node from choose qparam
+                return (False, [])
+
+            gemm_deps.extend([getitem1, getitem2])
+            choose_qparam = get_input_node(getitem1, 0)
+            if not is_qparam(choose_qparam):
+                # expected to find choose_qparam node
+                return (False, [])
+            gemm_deps.append(choose_qparam)
+            return (True, gemm_deps)
+
+
+class LinearConfig(GEMMConfig):
+    target_name = "linear.default"
+
+    def __init__(self):
+        super().__init__(
+            weight_idx=1,
+            bias_idx=2,
+            act_idx=0,
+            fused_acts=["relu.default", "hardtanh.default"],
+        )
+
+    def get_original_aten(self) -> Optional[torch._ops.OpOverload]:
+        return torch.ops.aten.linear.default
+
+    def supported_precision_types(self):
+        return [
+            ConfigPrecisionType.DYNAMIC_QUANT,
+            ConfigPrecisionType.FP32,
+            ConfigPrecisionType.STATIC_QUANT,
+        ]
+
+
+class AddmmConfig(GEMMConfig):
+    target_name = "addmm.default"
+
+    def __init__(self):
+        super().__init__(weight_idx=2, bias_idx=0, act_idx=1, fused_acts=[])
+
+    def supported_precision_types(self):
+        return [
+            ConfigPrecisionType.FP32,
+            ConfigPrecisionType.STATIC_QUANT,
+        ]

--- a/backends/xnnpack/partition/config/single_node_configs.py
+++ b/backends/xnnpack/partition/config/single_node_configs.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional
+
+import torch
+from executorch.backends.xnnpack.partition.config.xnnpack_config import (
+    ConfigPrecisionType,
+    XNNPartitionerConfig,
+)
+from torch.export import ExportedProgram
+
+
+class SingleNodePartitionerConfig(XNNPartitionerConfig):
+    def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
+        return self.check_common_constraints(node, ep)
+
+    def get_node_and_deps(
+        self, node: torch.fx.Node, ep: ExportedProgram
+    ) -> List[torch.fx.Node]:
+        return [node]
+
+    def get_original_aten(self) -> Optional[torch._ops.OpOverload]:
+        return None
+
+
+class QuantizedPerTensorConfig(SingleNodePartitionerConfig):
+    target_name = "quantize_per_tensor.default"
+
+    def supported_precision_types(self) -> List[ConfigPrecisionType]:
+        return [ConfigPrecisionType.STATIC_QUANT]
+
+
+class DeQuantizedPerTensorConfig(SingleNodePartitionerConfig):
+    target_name = "dequantize_per_tensor.default"
+
+    def supported_precision_types(self) -> List[ConfigPrecisionType]:
+        return [ConfigPrecisionType.STATIC_QUANT]

--- a/backends/xnnpack/partition/config/xnnpack_config.py
+++ b/backends/xnnpack/partition/config/xnnpack_config.py
@@ -1,0 +1,199 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import abstractmethod
+from enum import Enum
+from typing import List, Optional
+
+import torch
+from executorch.exir.backend.canonical_partitioners.config_partitioner import (
+    format_target_name,
+    PartitionerConfig,
+)
+from torch.export import ExportedProgram
+
+
+class ConfigPrecisionType(Enum):
+    FP32 = 1
+    STATIC_QUANT = 2
+    DYNAMIC_QUANT = 3
+
+
+# TODO: add WhyNotPartition to XNNPartitionerConfig
+class XNNPartitionerConfig(PartitionerConfig):
+    """
+    Base partitioner config for XNNPACK Partitioner Configs. Base wrapper class
+    for all XNNPACK Partitioner Configs allows us to apply control over
+    all PartitionerConfigs. XNNPACK Partitioner config also sets a property
+    for supported precision types. This allows partitioner configs to set
+    the precision types they support, and let users toggle which precision
+    types they want to enable
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.enabled_precision_types = self.supported_precision_types()
+
+    def get_partition(
+        self, node: torch.fx.Node, ep: ExportedProgram
+    ) -> List[torch.fx.Node]:
+        """
+        Overriding abstract method get_partition.
+
+        Returns the partitioned nodes from get_node_and_deps, but also labels them
+        with the name of the XNNPartitionerConfig class which return this set of nodes.
+        This enforces that all partitions returned by XNNPartitioner configs are labeled
+        with the partitioner config which returned them
+        """
+        partitioned_nodes = self.get_node_and_deps(node, ep)
+        # label partitioned nodes with the name of the partitioner config
+        for node in partitioned_nodes:
+            if "xnn_partitioner_config" in node.meta:
+                node.meta["xnn_partitioner_config"].append(self.__class__.__name__)
+            else:
+                node.meta["xnn_partitioner_config"] = [self.__class__.__name__]
+
+        return partitioned_nodes
+
+    @abstractmethod
+    def supported_precision_types(self) -> List[ConfigPrecisionType]:
+        """
+        Returns the supported PrecisionType of this partitioner config
+        """
+        pass
+
+    @abstractmethod
+    def get_node_and_deps(
+        self, node: torch.fx.Node, ep: ExportedProgram
+    ) -> List[torch.fx.Node]:
+        """
+        Takes in a node and its exported program and returns a list of nodes
+        and its dependencies that need to be partitioned together
+
+        Args:
+            node: Node to be partitioned
+            ep: Exported program of the graph module
+        Returns:
+            List of nodes that can be partitioned
+        """
+        pass
+
+    def set_enabled_precision_types(
+        self, precision_types: Optional[List[ConfigPrecisionType]]
+    ):
+        """
+        Set the enabled precisions.
+
+        We take the intersection of the precision_types we wish to enable with
+        the precision types that this config supports. If enabled_precisions is empty, i.e.
+        the config does not support any of the precision types we want to enable,
+        then we will not partition nothing and return false at the common constraints
+        """
+
+        if precision_types:
+            enabled_precisions = []
+            for precision in precision_types:
+                if precision in self.supported_precision_types():
+                    enabled_precisions.append(precision)
+
+            self.enabled_precision_types = enabled_precisions
+
+    def check_common_constraints(
+        self, node: torch.fx.Node, ep: ExportedProgram
+    ) -> bool:
+        """
+        Checks common xnnpack constraints
+
+        Args:
+            node (torch.fx.Node): Node to check common constraints against
+            ep (ExportedProgram): Exported Program to check constraints against
+
+        Returns:
+            True or False whether this node is partitionable
+        """
+        assert (
+            node.op == "call_function"
+            and format_target_name(node.target.__name__)  # pyre-ignore
+            == self.target_name
+        )
+
+        if len(self.enabled_precision_types) == 0:
+            return False
+
+        has_valid_dtypes = self._check_node_has_valid_dtype(node)
+        if not has_valid_dtypes:
+            return False
+
+        return True
+
+    def _check_inputs_are_valid_dtypes(self, node, valid_dtypes):
+        # Check inputs are valid dtypes
+        # Gather all args which are nodes
+        args_to_check = []
+        for arg in node.args:
+            if isinstance(arg, list) or isinstance(arg, tuple):
+                for item in arg:
+                    if isinstance(item, torch.fx.Node):
+                        args_to_check.append(item)
+
+            if isinstance(arg, torch.fx.Node):
+                args_to_check.append(arg)
+
+        for arg in args_to_check:
+            arg_val = arg.meta.get("val", None)
+
+            if arg_val is None or isinstance(arg_val, tuple):
+                continue
+
+            # Being conservative for now, UX >> Perf
+            # TODO: We need a pass to scrub these out.
+            if not isinstance(arg_val, torch.Tensor):
+                return False
+
+            # XNNPACK does not support empty tensors
+            if arg_val.numel() == 0:
+                return False
+
+            if arg_val.dtype not in valid_dtypes:
+                return False
+
+        return True
+
+    def _check_outputs_are_valid_dtypes(self, node, valid_dtypes):
+        # Check outputs are valid dtype
+        node_val = node.meta.get("val", None)
+        if node_val is None:
+            return True
+
+        if not isinstance(node_val, tuple):
+            node_val = (node_val,)
+
+        for val in node_val:
+            if not isinstance(val, torch.Tensor):
+                return False
+
+            if val.dtype not in valid_dtypes:
+                return False
+
+        return True
+
+    def _check_node_has_valid_dtype(self, node):
+        valid_dtypes = {
+            torch.float32,
+            torch.float16,
+            torch.int8,
+            torch.qint8,
+        }
+        if (
+            node.op != "placeholder"
+            and node.op != "call_function"
+            and node.op != "get_attr"
+        ):
+            return False
+
+        return self._check_inputs_are_valid_dtypes(
+            node, valid_dtypes
+        ) and self._check_outputs_are_valid_dtypes(node, valid_dtypes)

--- a/backends/xnnpack/partition/xnnpack_partitioner2.py
+++ b/backends/xnnpack/partition/xnnpack_partitioner2.py
@@ -1,0 +1,87 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+from typing import List, Optional, Type, Union
+
+from executorch.backends.xnnpack.partition.config import ALL_PARTITIONER_CONFIGS
+from executorch.backends.xnnpack.partition.config.xnnpack_config import (
+    ConfigPrecisionType,
+    XNNPartitionerConfig,
+)
+
+from executorch.backends.xnnpack.xnnpack_preprocess import XnnpackBackend
+from executorch.exir.backend.backend_details import ExportedProgram
+from executorch.exir.backend.canonical_partitioners.config_partitioner import (
+    ConfigerationBasedPartitioner,
+)
+from executorch.exir.backend.partitioner import DelegationSpec
+from torch.fx.passes.infra.partitioner import Partition
+
+
+class XnnpackPartitioner(ConfigerationBasedPartitioner):
+    def __init__(
+        self,
+        configs: Optional[List[Type[XNNPartitionerConfig]]] = None,
+        config_precisions: Optional[
+            Union[ConfigPrecisionType, List[ConfigPrecisionType]]
+        ] = None,
+        per_op_mode=False,
+    ):
+        delegation_spec = DelegationSpec(XnnpackBackend.__name__, [])
+        configs_to_use = configs or ALL_PARTITIONER_CONFIGS
+        # Can do logic and have extra args to filter/delete/select
+        # Certain configs based on user specification
+        initialized_configs = []
+        if isinstance(config_precisions, ConfigPrecisionType):
+            config_precisions = [config_precisions]
+
+        for config in configs_to_use:
+            # Config Classes given to XnnpackPartitioner should no longer be abstract
+            initialized = config()  #  pyre-ignore
+            initialized.set_enabled_precision_types(config_precisions)
+            initialized_configs.append(initialized)
+
+        # per_op_mode takes the first match from a partitioner config, any
+        # subsequent matches that overlap with the first match are not partitioned
+        self.per_op_mode = per_op_mode
+        super().__init__(delegation_spec, initialized_configs)
+
+    def generate_partitions(self, ep: ExportedProgram) -> List[Partition]:
+        """
+        generate_partitions is different if partitioner is set to per_op_mode
+        for per_op_mode we only need to generate unmerged partitions instead
+        of using the default generate_partitions method.
+        """
+        if self.per_op_mode:
+            return self.generate_per_op_partitions(ep)
+        else:
+            return super().generate_partitions(ep)
+
+    def generate_per_op_partitions(self, ep: ExportedProgram) -> List[Partition]:
+        """
+        Uses configs to generate per_op_partitions. That is no partitions are
+        merged together. All partitions (node + deps) returned by PartitionerConfigs
+        are put into their own partition.
+        """
+        partitions = []
+        matched_nodes = self.get_matched_nodes_from_configs(ep)
+        partition_id = itertools.count()
+        nodes_seen = set()
+        for match in matched_nodes:
+            match_set = set(match)
+            # We only create partitions from the first PartitionerConfig match
+            # if a subsequent partitioner match contains the same node, we do
+            # not create a partition for it
+            if match_set.isdisjoint(nodes_seen):
+                partitions.append(
+                    Partition(
+                        id=next(partition_id),
+                        nodes=match_set,
+                    )
+                )
+                nodes_seen.update(match_set)
+        return partitions

--- a/backends/xnnpack/passes/tag_implicit_q_dq_pass.py
+++ b/backends/xnnpack/passes/tag_implicit_q_dq_pass.py
@@ -139,10 +139,8 @@ class TagImplicitQDqPass(XNNPACKPass):
             ):
                 return [next_node]
         elif self.is_output_node(next_node):
-            # Check if second_node (which is between dq and output nodes)
-            # is aten.linear.default
-            if self.is_dynamically_quantized(start_node):
-                return []
+            # if node following dq is output node
+            return None
         else:
             # Check if nodes between the dq node and the next q match
             # a supported quant chain
@@ -193,6 +191,9 @@ class TagImplicitQDqPass(XNNPACKPass):
 
             ending_implicit_q_nodes = []
             for user in first_node.users:
+                if self.is_dynamically_quantized(user):
+                    # if the dq is a dynamic dq, then it is implicit
+                    break
                 user_end_nodes = self.get_ending_implicit_q_nodes(user)
                 if user_end_nodes is None:
                     # This user isn't part of a "supported" group

--- a/backends/xnnpack/test/ops/linear.py
+++ b/backends/xnnpack/test/ops/linear.py
@@ -10,12 +10,21 @@ from itertools import product
 from typing import Optional, Tuple
 
 import torch
+from executorch.backends.xnnpack.partition.config.xnnpack_config import (
+    ConfigPrecisionType,
+)
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
     XnnpackDynamicallyQuantizedPartitioner,
 )
+from executorch.backends.xnnpack.partition.xnnpack_partitioner2 import (
+    XnnpackPartitioner,
+)
 
 from executorch.backends.xnnpack.test.tester import Quantize, Tester
-from executorch.backends.xnnpack.test.tester.tester import Partition
+from executorch.backends.xnnpack.test.tester.tester import (
+    Partition,
+    ToEdgeTransformAndLower,
+)
 
 from torch.ao.quantization.quantizer.xnnpack_quantizer import (
     get_symmetric_quantization_config,
@@ -68,11 +77,11 @@ class TestLinear(unittest.TestCase):
         class AddMMModule(torch.nn.Module):
             def __init__(self, in_size, out_size):
                 super().__init__()
-                self.mat = torch.nn.Parameter(torch.randn(out_size, in_size))
+                self.mat = torch.nn.Parameter(torch.randn(in_size, out_size))
                 self.bias = torch.nn.Parameter(torch.randn(1, out_size))
 
             def forward(self, x):
-                return torch.addmm(self.bias, x, torch.transpose(self.mat, 0, 1))
+                return torch.addmm(self.bias, x, self.mat)
 
         self._test_linear(
             lambda in_size, out_size: AddMMModule(in_size, out_size),
@@ -358,6 +367,223 @@ class TestLinear(unittest.TestCase):
             atol=1e-1,
         )
 
+    def test_qd8_fp32_per_token_weight_per_channel_int8(self):
+        self._run_manual_dqlinear_tests(8, torch.float)
+
+    def test_qd8_fp32_per_token_weight_per_channel_int4(self):
+        self._run_manual_dqlinear_tests(4, torch.float)
+
+    # This fails because the output tensor dtype is different, but if you squint and ignore that and look at the values,
+    # it is not too bad.
+    # Difference: max: 0.042601585388183594, abs: 0.042601585388183594.
+    # -- Model vs. Reference --
+    #  Numel: 68, 68
+    # Median: -0.7754800915718079, -0.7755751013755798
+    #   Mean: -0.6128872036933899, -0.6143574714660645
+    #    Max: 12.518657684326172, 12.516003608703613
+    #    Min: -20.070953369140625, -20.077701568603516
+    @unittest.skip("Need to fix the dq_per_channel output dtype")
+    def _test_qd8_fp16_per_token_weight_per_channel_int8(self):
+        self._run_manual_dqlinear_tests(8, torch.float16)
+
+    @unittest.skip("Need to fix the dq_per_channel output dtype")
+    def _test_qd8_fp16_per_token_weight_per_channel_int4(self):
+        self._run_manual_dqlinear_tests(4, torch.float16)
+
+    def test_qd8_fp32_per_token_weight_per_channel_group_int4(self):
+        M_sizes = [1, 2, 17, 31]
+        K_sizes = [8, 32, 64, 128]
+        bl_sizes = [8, 16, 16, 32]
+        N_sizes = [2, 17, 92, 128]
+
+        for use_bias in [True, False]:
+            for i, _ in enumerate(M_sizes):
+                M = int(M_sizes[i])
+                K = int(K_sizes[i])
+                N = int(N_sizes[i])
+                bl = int(bl_sizes[i])
+                mod = self.ManualDQLinear(
+                    input_channels=K,
+                    output_channels=N,
+                    weight_n_bit=4,
+                    dtype=torch.float,
+                    group_size=bl,
+                    force_groupwise_quant=True,
+                    use_bias=use_bias,
+                )
+
+                inputs = (torch.randn(1, M, K),)
+                self._test_manual_dq_linear(
+                    mod,
+                    inputs,
+                    weight_groupwise=True,
+                    use_bias=use_bias,
+                )
+
+    @unittest.skip("Need to fix the dq_per_channel_group output dtype")
+    def _test_qd8_fp16_per_token_weight_per_channel_group_int4(self):
+        M_sizes = [1, 2, 17, 31]
+        K_sizes = [8, 32, 64, 128]
+        bl_sizes = [8, 16, 16, 32]
+        N_sizes = [2, 17, 92, 128]
+
+        for use_bias in [True, False]:
+            for i, _ in enumerate(M_sizes):
+                M = int(M_sizes[i])
+                K = int(K_sizes[i])
+                N = int(N_sizes[i])
+                bl = int(bl_sizes[i])
+                mod = self.ManualDQLinear(
+                    input_channels=K,
+                    output_channels=N,
+                    weight_n_bit=4,
+                    dtype=torch.float16,
+                    group_size=bl,
+                    force_groupwise_quant=True,
+                    use_bias=use_bias,
+                )
+
+                inputs = (torch.randn(1, M, K, dtype=torch.float16),)
+                self._test_manual_dq_linear(
+                    mod,
+                    inputs,
+                    weight_groupwise=True,
+                    use_bias=use_bias,
+                    atol=0.1,
+                    rtol=0.1,
+                )
+
+    def _test_linear(
+        self,
+        make_module,
+        uses_bias,
+        num_batch_dims=1,
+        quant_type=None,
+        dtype: torch.dtype = torch.float,
+        atol=1e-03,
+    ):
+        edge_op = (
+            "executorch_exir_dialects_edge__ops_aten_addmm_default"
+            if uses_bias
+            else "executorch_exir_dialects_edge__ops_aten_mm_default"
+        )
+
+        in_sizes = [3, 4, 4]
+        input_sizes = [4, 37, 17]
+        output_sizes = [4, 17, 37]
+
+        quant = quant_type is not None
+
+        """
+        Note that torch.nn.Linear maps to aten.mm.default (no bias) or aten.addmm.default (bias),
+        which ares then transformed into aten.linear.default by the ConvertToLinear pass.
+        """
+        for i, _ in enumerate(in_sizes):
+            in_size = int(in_sizes[i])
+            input_size = int(input_sizes[i])
+            output_size = int(output_sizes[i])
+            input_shape = [in_size] * num_batch_dims + [input_size]
+            print(f"Testing input_shape {input_shape} with {output_size} out_channels")
+
+            module = make_module(input_size, output_size).eval().to(dtype)
+            inputs = (torch.randn(input_shape).to(dtype),)
+            dynamic_shape = {}
+            for i in range(num_batch_dims):
+                dynamic_shape[i] = torch.export.Dim(f"batch{i}", min=2, max=in_size)
+
+            dynamic_shape = (dynamic_shape,)
+            print(dynamic_shape)
+
+            tester = Tester(module, inputs, dynamic_shapes=dynamic_shape)
+
+            if quant:
+                if quant_type == "per_channel":
+                    quant_config = get_symmetric_quantization_config(
+                        is_per_channel=True,
+                        is_dynamic=False,
+                    )
+                elif quant_type == "per_tensor":
+                    quant_config = get_symmetric_quantization_config(
+                        is_per_channel=False,
+                        is_dynamic=False,
+                    )
+                else:
+                    raise ValueError(f"Unsupported quant type {quant_type}")
+                tester.quantize(Quantize(quantization_config=quant_config))
+
+            tester.export()
+            if quant:
+                tester.check(["torch.ops.quantized_decomposed"])
+
+            tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not([edge_op])
+
+            if quant:
+                tester.check_not([edge_op, "torch.ops.quantized_decomposed"])
+
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs(qtol=quant, atol=atol)
+
+    def _test_dqlinear(
+        self,
+        module,
+        inputs,
+        dynamic_shapes,
+        linear_count=1,
+        is_per_channel=False,
+        uses_bias=False,
+        qconfig: Optional[QuantizationConfig] = None,
+        atol=5e-02,
+    ):
+        edge_op = (
+            "executorch_exir_dialects_edge__ops_aten_addmm_default"
+            if uses_bias
+            else "executorch_exir_dialects_edge__ops_aten_mm_default"
+        )
+
+        quant_config = qconfig or get_symmetric_quantization_config(
+            is_per_channel=is_per_channel,
+            is_dynamic=True,
+        )
+        for legacy_partitioner in (True, False):
+            for per_op_mode in (True, False):
+                tester = Tester(module, inputs, dynamic_shapes=dynamic_shapes)
+                tester.quantize(Quantize(quantization_config=quant_config))
+
+                tester.export()
+
+                if legacy_partitioner:
+                    tester.to_edge()
+                    tester.partition(
+                        Partition(XnnpackDynamicallyQuantizedPartitioner())
+                    )
+                else:
+                    tester.to_edge_transform_and_lower(
+                        ToEdgeTransformAndLower(
+                            [
+                                XnnpackPartitioner(
+                                    config_precisions=ConfigPrecisionType.DYNAMIC_QUANT,
+                                    per_op_mode=per_op_mode,
+                                )
+                            ]
+                        )
+                    )
+                num_call_delegates = (
+                    linear_count if legacy_partitioner or per_op_mode else 1
+                )
+                tester.check_count(
+                    {
+                        "torch.ops.higher_order.executorch_call_delegate": num_call_delegates
+                    }
+                )
+                tester.check_not([edge_op])
+
+                tester.to_executorch()
+                tester.serialize()
+                tester.run_method_and_compare_outputs(atol=atol)
+
     class ManualDQLinear(torch.nn.Module):
         def __init__(
             self,
@@ -507,7 +733,6 @@ class TestLinear(unittest.TestCase):
         def fwd_input_per_token(self, input: torch.Tensor) -> torch.Tensor:
             ip_quant_min = -128
             ip_quant_max = 127
-            input = input.to(self.op_dtype)
             (
                 ip_scales,
                 ip_zero_points,
@@ -532,7 +757,6 @@ class TestLinear(unittest.TestCase):
                 torch.int8,
                 self.op_dtype,
             )
-            input = input.to(self.op_dtype)
             return input
 
         def quant_weight_per_channel(self):
@@ -596,14 +820,14 @@ class TestLinear(unittest.TestCase):
 
         def forward(self, input: torch.Tensor) -> torch.Tensor:
             # Input
-            input = self.fwd_input_per_token(input).to(self.op_dtype)
+            input = self.fwd_input_per_token(input)
 
             # Weights
             w = (
                 self.fwd_weight_per_channel_group()
                 if self.w_scales.ndim == 2
                 else self.fwd_weight_per_channel()
-            ).to(self.op_dtype)
+            )
             assert isinstance(w, torch.Tensor)
             return torch.nn.functional.linear(input, w, self.bias)
 
@@ -625,41 +849,65 @@ class TestLinear(unittest.TestCase):
         weight_dq_edge_op = (
             "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_channel_group_default"
             if weight_groupwise
-            else "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_channel_default"
+            else "torch.ops.quantized_decomposed.dequantize_per_channel.default"
         )
 
-        (
-            Tester(mod, inputs)
-            .export()
-            .to_edge()
-            .check_count(
-                {
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_choose_qparams_per_token_asymmetric_default": 1,
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_token_default": 1,
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_token_default": 1,
-                    weight_dq_edge_op: 1,
-                    linear_edge_op: 1,
-                }
-            )
-            .partition(Partition(partitioner=XnnpackDynamicallyQuantizedPartitioner()))
-            .check_count(
-                {
-                    "torch.ops.higher_order.executorch_call_delegate": 1,
-                }
-            )
-            .check_not(
-                [
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_choose_qparams_per_token_asymmetric_default",
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_token_default",
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_token_default",
-                    weight_dq_edge_op,
-                    linear_edge_op,
-                ]
-            )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs(atol=atol, rtol=rtol)
+        weight_dq_aten_op = (
+            "torch.ops.quantized_decomposed.dequantize_per_channel_group.default"
+            if weight_groupwise
+            else "torch.ops.quantized_decomposed.dequantize_per_channel.default"
         )
+        for legacy_partitioner in (True, False):
+            tester = (
+                Tester(mod, inputs)
+                .export()
+                .check_count(
+                    {
+                        "torch.ops.quantized_decomposed.choose_qparams_per_token_asymmetric.default": 1,
+                        "torch.ops.quantized_decomposed.quantize_per_token.default": 1,
+                        "torch.ops.quantized_decomposed.dequantize_per_token.default": 1,
+                        weight_dq_aten_op: 1,
+                        "torch.ops.aten.linear.default": 1,
+                    }
+                )
+            )
+
+            if legacy_partitioner:
+                tester.to_edge()
+                tester.partition(Partition(XnnpackDynamicallyQuantizedPartitioner()))
+            else:
+                (
+                    tester.to_edge_transform_and_lower(
+                        ToEdgeTransformAndLower(
+                            [
+                                XnnpackPartitioner(
+                                    config_precisions=ConfigPrecisionType.DYNAMIC_QUANT,
+                                    per_op_mode=True,
+                                )
+                            ]
+                        )
+                    )
+                )
+
+            (
+                tester.check_count(
+                    {
+                        "torch.ops.higher_order.executorch_call_delegate": 1,
+                    }
+                )
+                .check_not(
+                    [
+                        "executorch_exir_dialects_edge__ops_quantized_decomposed_choose_qparams_per_token_asymmetric_default",
+                        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_token_default",
+                        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_token_default",
+                        weight_dq_edge_op,
+                        linear_edge_op,
+                    ]
+                )
+                .to_executorch()
+                .serialize()
+                .run_method_and_compare_outputs(atol=atol, rtol=rtol)
+            )
 
     def _run_manual_dqlinear_tests(self, weight_n_bit: int, op_dtype: torch.dtype):
         in_sizes = [1, 4, 4]
@@ -681,215 +929,3 @@ class TestLinear(unittest.TestCase):
 
                 inputs = (torch.randn(1, in_size, input_size).to(op_dtype),)
                 self._test_manual_dq_linear(mod, inputs, use_bias=use_bias)
-
-    def test_qd8_fp32_per_token_weight_per_channel_int8(self):
-        self._run_manual_dqlinear_tests(8, torch.float)
-
-    def test_qd8_fp32_per_token_weight_per_channel_int4(self):
-        self._run_manual_dqlinear_tests(4, torch.float)
-
-    # This fails because the output tensor dtype is different, but if you squint and ignore that and look at the values,
-    # it is not too bad.
-    # Difference: max: 0.042601585388183594, abs: 0.042601585388183594.
-    # -- Model vs. Reference --
-    #  Numel: 68, 68
-    # Median: -0.7754800915718079, -0.7755751013755798
-    #   Mean: -0.6128872036933899, -0.6143574714660645
-    #    Max: 12.518657684326172, 12.516003608703613
-    #    Min: -20.070953369140625, -20.077701568603516
-    @unittest.skip("Need to fix the dq_per_channel output dtype")
-    def _test_qd8_fp16_per_token_weight_per_channel_int8(self):
-        self._run_manual_dqlinear_tests(8, torch.float16)
-
-    @unittest.skip("Need to fix the dq_per_channel output dtype")
-    def _test_qd8_fp16_per_token_weight_per_channel_int4(self):
-        self._run_manual_dqlinear_tests(4, torch.float16)
-
-    def test_qd8_fp32_per_token_weight_per_channel_group_int4(self):
-        M_sizes = [1, 2, 17, 31]
-        K_sizes = [8, 32, 64, 128]
-        bl_sizes = [8, 16, 16, 32]
-        N_sizes = [2, 17, 92, 128]
-
-        for use_bias in [True, False]:
-            for i, _ in enumerate(M_sizes):
-                M = int(M_sizes[i])
-                K = int(K_sizes[i])
-                N = int(N_sizes[i])
-                bl = int(bl_sizes[i])
-                mod = self.ManualDQLinear(
-                    input_channels=K,
-                    output_channels=N,
-                    weight_n_bit=4,
-                    dtype=torch.float,
-                    group_size=bl,
-                    force_groupwise_quant=True,
-                    use_bias=use_bias,
-                )
-
-                inputs = (torch.randn(1, M, K),)
-                self._test_manual_dq_linear(
-                    mod,
-                    inputs,
-                    weight_groupwise=True,
-                    use_bias=use_bias,
-                )
-
-    def test_qd8_fp16_per_token_weight_per_channel_group_int4(self):
-        M_sizes = [1, 2, 17, 31]
-        K_sizes = [8, 32, 64, 128]
-        bl_sizes = [8, 16, 16, 32]
-        N_sizes = [2, 17, 92, 128]
-
-        for use_bias in [True, False]:
-            for i, _ in enumerate(M_sizes):
-                M = int(M_sizes[i])
-                K = int(K_sizes[i])
-                N = int(N_sizes[i])
-                bl = int(bl_sizes[i])
-                mod = self.ManualDQLinear(
-                    input_channels=K,
-                    output_channels=N,
-                    weight_n_bit=4,
-                    dtype=torch.float16,
-                    group_size=bl,
-                    force_groupwise_quant=True,
-                    use_bias=use_bias,
-                )
-
-                inputs = (torch.randn(1, M, K, dtype=torch.float16),)
-                self._test_manual_dq_linear(
-                    mod,
-                    inputs,
-                    weight_groupwise=True,
-                    use_bias=use_bias,
-                    atol=0.1,
-                    rtol=0.1,
-                )
-
-    def _test_linear(
-        self,
-        make_module,
-        uses_bias,
-        num_batch_dims=1,
-        quant_type=None,
-        dtype: torch.dtype = torch.float,
-        atol=1e-03,
-    ):
-        aten_op, edge_op = (
-            (
-                "aten.addmm.default",
-                "executorch_exir_dialects_edge__ops_aten_addmm_default",
-            )
-            if uses_bias
-            else (
-                "aten.mm.default",
-                "executorch_exir_dialects_edge__ops_aten_mm_default",
-            )
-        )
-
-        in_sizes = [3, 4, 4]
-        input_sizes = [4, 37, 17]
-        output_sizes = [4, 17, 37]
-
-        quant = quant_type is not None
-
-        """
-        Note that torch.nn.Linear maps to aten.mm.default (no bias) or aten.addmm.default (bias),
-        which ares then transformed into aten.linear.default by the ConvertToLinear pass.
-        """
-        for i, _ in enumerate(in_sizes):
-            in_size = int(in_sizes[i])
-            input_size = int(input_sizes[i])
-            output_size = int(output_sizes[i])
-            input_shape = [in_size] * num_batch_dims + [input_size]
-            print(f"Testing input_shape {input_shape} with {output_size} out_channels")
-
-            module = make_module(input_size, output_size).eval().to(dtype)
-            inputs = (torch.randn(input_shape).to(dtype),)
-            dynamic_shape = {}
-            for i in range(num_batch_dims):
-                dynamic_shape[i] = torch.export.Dim(f"batch{i}", min=2, max=in_size)
-
-            dynamic_shape = (dynamic_shape,)
-            print(dynamic_shape)
-
-            tester = Tester(module, inputs, dynamic_shapes=dynamic_shape)
-
-            if quant:
-                if quant_type == "per_channel":
-                    quant_config = get_symmetric_quantization_config(
-                        is_per_channel=True,
-                        is_dynamic=False,
-                    )
-                elif quant_type == "per_tensor":
-                    quant_config = get_symmetric_quantization_config(
-                        is_per_channel=False,
-                        is_dynamic=False,
-                    )
-                else:
-                    raise ValueError(f"Unsupported quant type {quant_type}")
-                tester.quantize(Quantize(quantization_config=quant_config))
-
-            tester.export()
-            if quant:
-                tester.check(["torch.ops.quantized_decomposed"])
-
-            tester.to_edge()
-            tester.check_count({edge_op: 1})
-
-            tester.partition()
-            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            tester.check_not([edge_op])
-
-            if quant:
-                tester.check_not([edge_op, "torch.ops.quantized_decomposed"])
-
-            tester.to_executorch()
-            tester.serialize()
-            tester.run_method_and_compare_outputs(qtol=quant, atol=atol)
-
-    def _test_dqlinear(
-        self,
-        module,
-        inputs,
-        dynamic_shapes,
-        linear_count=1,
-        is_per_channel=False,
-        uses_bias=False,
-        qconfig: Optional[QuantizationConfig] = None,
-        atol=5e-02,
-    ):
-        aten_op, edge_op = (
-            (
-                "aten.addmm.default",
-                "executorch_exir_dialects_edge__ops_aten_addmm_default",
-            )
-            if uses_bias
-            else (
-                "aten.mm.default",
-                "executorch_exir_dialects_edge__ops_aten_mm_default",
-            )
-        )
-
-        quant_config = qconfig or get_symmetric_quantization_config(
-            is_per_channel=is_per_channel,
-            is_dynamic=True,
-        )
-
-        tester = Tester(module, inputs, dynamic_shapes=dynamic_shapes)
-        tester.quantize(Quantize(quantization_config=quant_config))
-
-        tester.export()
-        tester.to_edge()
-        tester.check_count({edge_op: linear_count})
-
-        tester.partition(
-            Partition(partitioner=XnnpackDynamicallyQuantizedPartitioner())
-        )
-        tester.check(["torch.ops.higher_order.executorch_call_delegate"])
-        tester.check_not([edge_op])
-
-        tester.to_executorch()
-        tester.serialize()
-        tester.run_method_and_compare_outputs(atol=atol)

--- a/backends/xnnpack/test/ops/quantize_per_tensor.py
+++ b/backends/xnnpack/test/ops/quantize_per_tensor.py
@@ -24,13 +24,7 @@ class TestQuantizePerTensor(unittest.TestCase):
         (
             Tester(Quant(), inputs)
             .export()
-            .to_edge()
-            .check_count(
-                {
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 1
-                }
-            )
-            .partition()
+            .to_edge_transform_and_lower()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .check_not(
                 [
@@ -60,13 +54,7 @@ class TestQuantizePerTensor(unittest.TestCase):
         (
             Tester(Dequant(), inputs)
             .export()
-            .to_edge()
-            .check_count(
-                {
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 1
-                }
-            )
-            .partition()
+            .to_edge_transform_and_lower()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .check_not(
                 [

--- a/backends/xnnpack/utils/TARGETS
+++ b/backends/xnnpack/utils/TARGETS
@@ -9,6 +9,7 @@ python_library(
         "//caffe2:torch",
         "//executorch/exir:lib",
         "//executorch/exir:pass_manager",
+        "//executorch/exir/backend/canonical_partitioners:config_partitioner_lib",
         "//executorch/exir/dialects:lib",
         "//pytorch/ao:torchao",  # @manual
     ],

--- a/backends/xnnpack/utils/utils.py
+++ b/backends/xnnpack/utils/utils.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import cast, Optional, Tuple
+from typing import Any, cast, Optional, Tuple
 
 import executorch.exir as exir
 import torch
@@ -60,6 +60,20 @@ def check_or_raise(condition: bool, err: str) -> None:
     """
     if not condition:
         raise RuntimeError(err)
+
+
+def is_node(node: Any) -> bool:
+    """
+    returns true if node is a torch.fx.Node, otherwise false
+    """
+    return isinstance(node, torch.fx.Node)
+
+
+def is_getitem(node: torch.fx.Node) -> bool:
+    if node.op != "call_function":
+        return False
+
+    return node.target.__name__ == "getitem"  # pyre-ignore
 
 
 def get_input_node(node: torch.fx.Node, input_index: int) -> torch.fx.Node:

--- a/exir/backend/canonical_partitioners/TARGETS
+++ b/exir/backend/canonical_partitioners/TARGETS
@@ -36,3 +36,20 @@ runtime.python_library(
         "//executorch/exir/backend:partitioner",
     ],
 )
+
+runtime.python_library(
+    name = "config_partitioner_lib",
+    srcs = [
+        "config_partitioner.py",
+    ],
+    visibility = [
+        "//executorch/...",
+        "//executorch/exir/backend/...",
+        "//executorch/test/...",
+        "@EXECUTORCH_CLIENTS",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir/backend:partitioner",
+    ],
+)

--- a/exir/backend/canonical_partitioners/config_partitioner.py
+++ b/exir/backend/canonical_partitioners/config_partitioner.py
@@ -1,0 +1,204 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import ABC, abstractmethod
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+import torch
+from executorch.exir.backend.backend_details import ExportedProgram
+from executorch.exir.backend.canonical_partitioners.pattern_op_partitioner import (
+    generate_partitions_from_list_of_nodes,
+)
+from executorch.exir.backend.partitioner import (
+    DelegationSpec,
+    Partitioner,
+    PartitionResult,
+)
+from torch.fx.passes.infra.partitioner import Partition
+
+
+def format_target_name(target_name: str) -> str:
+    """
+    We remove the dialect name space from the target name. We generally
+    do not care for the op dialect specific name space ("aten.", "quantized_decomposed.")
+    but rather the op itself. Se remove the dialect-specific name space from the
+    name and return the op name itself
+    """
+    names = target_name.split(".")
+    if len(names) > 2:
+        names.pop(0)
+
+    return ".".join(names)
+
+
+class PartitionerConfig(ABC):
+    """
+    Class used to represent a PartitionerConfig.
+
+    PartitionerConfig is used by config-based partitioner to partition identify
+    nodes to be delegated. User overrides the methods:
+        - target_name
+        - check_constraints
+        - get_partition
+        - get_original_aten
+
+    The Config-Based Partitioner then uses these overridden methods to find nodes
+    which match target_name, check_constraints, and if true, returns the partition
+    (list of nodes) which represent the node and its dependencies. get_original_aten
+    is used to halt decomposition to edge_dialect if the node can be delegated by
+    the specified backend.
+    """
+
+    @classmethod
+    @property
+    @abstractmethod
+    def target_name(cls) -> str:
+        """
+        Target name for this partitioner config. When the Config-Based Partitioner
+        encounters a node with a matching target name, it uses this config's methods to
+        checks the constraints of this node and get all of its dependencies.
+        the target name is formatted to remove the dialect-specific name space.
+        i.e. linear.default
+        """
+        pass
+
+    @abstractmethod
+    def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
+        """
+        Takes in a node and returns true if the node is partitionable.
+
+        Args:
+            node: Node to be partitioned
+            ep: Exported program of the graph module
+        Returns:
+            True or False whether this node is partitionable
+        """
+        pass
+
+    @abstractmethod
+    def get_original_aten(self) -> Optional[torch._ops.OpOverload]:
+        """
+        Returns the original aten dialect op, this is for to_edge_transform_and_lower
+        API, so that this config can be used to stop decomposition of this original
+        aten op
+        """
+        pass
+
+    @abstractmethod
+    def get_partition(
+        self, node: torch.fx.Node, ep: ExportedProgram
+    ) -> List[torch.fx.Node]:
+        """
+        Returns the partitioned nodes from get_node_and_deps, but also labels them
+        with the name of the PartitionerConfig class which return this set of nodes.
+
+        Returns an empty list of the node and deps do not satisfy the checked constraints
+        """
+        pass
+
+
+class ConfigerationBasedPartitioner(Partitioner):
+    def __init__(
+        self,
+        delegation_spec: DelegationSpec,
+        partitioner_configs: Iterable[PartitionerConfig],
+    ):
+        """
+        Configeration based partitioner. We supply the partitioner with a set of configerations
+        which describe the node type, constraints, and any dependencies required to be partitioned
+        with the node. We use the configerations to partition the graph module.
+        """
+        super().__init__()
+        # Initialize partitioner configs map {"target_name": PartitionerConfig}
+        self.target_partitioner_configs: Dict[str, PartitionerConfig] = {}
+        for config in partitioner_configs:
+            target_name = config.target_name
+            if target_name in self.target_partitioner_configs:
+                other_config = self.target_partitioner_configs[target_name]
+                raise RuntimeError(
+                    f"PartitionerConfig: {config} and {other_config} have the same target_name: {target_name}"
+                )
+            else:
+                self.target_partitioner_configs[target_name] = config
+
+        self.delegation_spec = delegation_spec
+
+    def ops_to_not_decompose(
+        self,
+        ep: ExportedProgram,
+    ) -> Tuple[List[torch._ops.OpOverload], Optional[Callable[[torch.fx.Node], bool]]]:
+        def filter_fn(node: torch.fx.Node) -> bool:
+            """
+            The partitioner configs we initialize with have check_constraints function,
+            to determine if this op is indeed partitionable. We grab the check_constraint
+            function of this op from the config and use it to filter.
+            """
+            if node.op != "call_function":
+                return False
+            target_name = format_target_name(node.target.__name__)  # pyre-ignore
+
+            if target_name in self.target_partitioner_configs:
+                config = self.target_partitioner_configs[target_name]
+                # only filter_fn if config has original_aten
+                if config.get_original_aten():
+                    return self.target_partitioner_configs[
+                        target_name
+                    ].check_constraints(node, ep)
+
+            return False
+
+        # Get list of original aten targets which we do not want to decomp
+        do_not_decomp = []
+        for node_config in self.target_partitioner_configs.values():
+            original_aten = node_config.get_original_aten()
+            if original_aten is not None:
+                do_not_decomp.append(original_aten)
+
+        return (do_not_decomp, filter_fn)
+
+    def get_matched_nodes_from_configs(
+        self, ep: ExportedProgram
+    ) -> List[List[torch.fx.Node]]:
+        # gather supported nodes
+        matched_nodes = []
+        gm = ep.graph_module
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                target = format_target_name(node.target.__name__)
+                if target in self.target_partitioner_configs:
+                    node_config = self.target_partitioner_configs[target]
+                    if node_config.check_constraints(node, ep):
+                        matched_nodes.append(node_config.get_partition(node, ep))
+
+        return matched_nodes
+
+    def generate_partitions(self, ep: ExportedProgram) -> List[Partition]:
+        matched_nodes = self.get_matched_nodes_from_configs(ep)
+        # create partitions
+        partitions = generate_partitions_from_list_of_nodes(
+            ep.graph_module,
+            matched_nodes,
+        )
+        return partitions
+
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
+        partitions = self.generate_partitions(exported_program)
+
+        # tag nodes
+        partition_tags: Dict[str, DelegationSpec] = {}
+        for partition in partitions:
+            for node in partition.nodes:
+                delegation_tag = f"tag{partition.id}"
+                if "delegation_tag" in node.meta:
+                    raise RuntimeError(
+                        f"Partitioner Erro found node {node} in partition {node.meta['delegation_tag']} and partition {delegation_tag}"
+                    )
+                node.meta["delegation_tag"] = delegation_tag
+                partition_tags[delegation_tag] = self.delegation_spec
+
+        return PartitionResult(
+            tagged_exported_program=exported_program, partition_tags=partition_tags
+        )


### PR DESCRIPTION
Summary:
Adding `GEMMConfig(XNNPartitionerConfig)`

This is a base class which handles grabbing all the dependencies of a gemm like node (conv, addmm, linear) and then validates that the node is a valid partition.

We modify all tests in the linear, and validate that to_edge_transform_and_lower with the new partitioner works with all nodes. Additionally, we add a `SingleNodePartitionerConfig` class for simple nodes like q_per_tensor and dq_per_tensor. This helps partition q_per_tensor/dq_per_tensor nodes which are actually explicilty converting the dtype of the input.

Differential Revision: D58903231
