### PR TITLE
Prepare the script to run tests on Android emulator

### DIFF
--- a/.ci/docker/common/install_android.sh
+++ b/.ci/docker/common/install_android.sh
@@ -31,6 +31,9 @@ install_prerequiresites() {
       # Cleanup package manager
       apt-get autoclean && apt-get clean
       rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+      update-java-alternatives -l
+      update-java-alternatives -s java-1.17.0-openjdk-amd64
     ;;
   esac
 }

--- a/.ci/docker/common/install_android.sh
+++ b/.ci/docker/common/install_android.sh
@@ -75,6 +75,7 @@ install_sdk() {
   yes | /opt/cmdline-tools/bin/sdkmanager --sdk_root="${SDK_INSTALLATION_DIR}" --install "tools"
 
   # Create a softlink to cmdline-tools
+  mkdir -p "${SDK_INSTALLATION_DIR}/cmdline-tools"
   ln -s /opt/cmdline-tools "${SDK_INSTALLATION_DIR}/cmdline-tools/latest"
 }
 

--- a/.ci/docker/common/install_android.sh
+++ b/.ci/docker/common/install_android.sh
@@ -73,6 +73,9 @@ install_sdk() {
   # And some more tools for future emulator tests
   yes | /opt/cmdline-tools/bin/sdkmanager --sdk_root="${SDK_INSTALLATION_DIR}" --install "platform-tools"
   yes | /opt/cmdline-tools/bin/sdkmanager --sdk_root="${SDK_INSTALLATION_DIR}" --install "tools"
+
+  # Create a softlink to cmdline-tools
+  ln -s /opt/cmdline-tools "${SDK_INSTALLATION_DIR}/cmdline-tools/latest"
 }
 
 install_prerequiresites

--- a/.ci/docker/common/install_android.sh
+++ b/.ci/docker/common/install_android.sh
@@ -14,9 +14,10 @@ install_prerequiresites() {
   OS=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
   case "$OS" in
     amzn)
-      yum install -y java-1.7.0-openjdk \
+      # https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/amazon-linux-install.html
+      yum install -y java-17-amazon-corretto \
         ca-certificates \
-        and
+        ant
       ;;
     *)
       apt-get update

--- a/.ci/docker/common/install_android.sh
+++ b/.ci/docker/common/install_android.sh
@@ -73,10 +73,6 @@ install_sdk() {
   # And some more tools for future emulator tests
   yes | /opt/cmdline-tools/bin/sdkmanager --sdk_root="${SDK_INSTALLATION_DIR}" --install "platform-tools"
   yes | /opt/cmdline-tools/bin/sdkmanager --sdk_root="${SDK_INSTALLATION_DIR}" --install "tools"
-
-  # Create a softlink to cmdline-tools
-  mkdir -p "${SDK_INSTALLATION_DIR}/cmdline-tools"
-  ln -s /opt/cmdline-tools "${SDK_INSTALLATION_DIR}/cmdline-tools/latest"
 }
 
 install_prerequiresites

--- a/.ci/docker/common/install_android.sh
+++ b/.ci/docker/common/install_android.sh
@@ -11,17 +11,27 @@ set -ex
 [ -n "${ANDROID_NDK_VERSION}" ]
 
 install_prerequiresites() {
-  apt-get update
+  OS=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+  case "$OS" in
+    amzn)
+      yum install -y java-1.7.0-openjdk \
+        ca-certificates \
+        and
+      ;;
+    *)
+      apt-get update
 
-  # NB: Need OpenJDK 17 at the minimum
-  apt-get install -y --no-install-recommends \
-    openjdk-17-jdk \
-    ca-certificates-java \
-    ant
+      # NB: Need OpenJDK 17 at the minimum
+      apt-get install -y --no-install-recommends \
+        openjdk-17-jdk \
+        ca-certificates-java \
+        ant
 
-  # Cleanup package manager
-  apt-get autoclean && apt-get clean
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+      # Cleanup package manager
+      apt-get autoclean && apt-get clean
+      rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    ;;
+  esac
 }
 
 install_ndk() {

--- a/.ci/docker/common/install_android.sh
+++ b/.ci/docker/common/install_android.sh
@@ -37,7 +37,7 @@ install_prerequiresites() {
 
 install_ndk() {
   NDK_INSTALLATION_DIR=/opt/ndk
-  mkdir -p "${NDK_INSTALLATION_DIR}"
+  rm -rf "${NDK_INSTALLATION_DIR}" && mkdir -p "${NDK_INSTALLATION_DIR}"
 
   pushd /tmp
   # The NDK installation is cached on ossci-android S3 bucket
@@ -65,7 +65,7 @@ install_cmdtools() {
 
 install_sdk() {
   SDK_INSTALLATION_DIR=/opt/android/sdk
-  mkdir -p "${SDK_INSTALLATION_DIR}"
+  rm -rf "${SDK_INSTALLATION_DIR}" && mkdir -p "${SDK_INSTALLATION_DIR}"
 
   # These are the tools needed to build Android apps
   yes | /opt/cmdline-tools/bin/sdkmanager --sdk_root="${SDK_INSTALLATION_DIR}" --install "platforms;android-34"

--- a/.ci/docker/common/install_android.sh
+++ b/.ci/docker/common/install_android.sh
@@ -73,9 +73,6 @@ install_sdk() {
   # And some more tools for future emulator tests
   yes | /opt/cmdline-tools/bin/sdkmanager --sdk_root="${SDK_INSTALLATION_DIR}" --install "platform-tools"
   yes | /opt/cmdline-tools/bin/sdkmanager --sdk_root="${SDK_INSTALLATION_DIR}" --install "tools"
-
-  # Install Android emulator package
-  yes | /opt/cmdline-tools/bin/sdkmanager --sdk_root="${SDK_INSTALLATION_DIR}" --install "system-images;android-34;google_apis;x86_64"
 }
 
 install_prerequiresites

--- a/.ci/docker/common/install_android.sh
+++ b/.ci/docker/common/install_android.sh
@@ -32,7 +32,6 @@ install_prerequiresites() {
       apt-get autoclean && apt-get clean
       rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-      update-java-alternatives -l
       update-java-alternatives -s java-1.17.0-openjdk-amd64
     ;;
   esac

--- a/.ci/docker/common/install_android.sh
+++ b/.ci/docker/common/install_android.sh
@@ -73,6 +73,9 @@ install_sdk() {
   # And some more tools for future emulator tests
   yes | /opt/cmdline-tools/bin/sdkmanager --sdk_root="${SDK_INSTALLATION_DIR}" --install "platform-tools"
   yes | /opt/cmdline-tools/bin/sdkmanager --sdk_root="${SDK_INSTALLATION_DIR}" --install "tools"
+
+  # Install Android emulator package
+  yes | /opt/cmdline-tools/bin/sdkmanager --sdk_root="${SDK_INSTALLATION_DIR}" --install "system-images;android-34;google_apis;x86_64"
 }
 
 install_prerequiresites

--- a/.ci/docker/common/install_android.sh
+++ b/.ci/docker/common/install_android.sh
@@ -31,8 +31,6 @@ install_prerequiresites() {
       # Cleanup package manager
       apt-get autoclean && apt-get clean
       rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-      update-java-alternatives -s java-1.17.0-openjdk-amd64
     ;;
   esac
 }

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -112,6 +112,14 @@ jobs:
           # Reuse the script that install Android on ET Docker image
           sudo -E bash .ci/docker/common/install_android.sh
 
+      - name: Run Android emulator
+        env:
+          ANDROID_HOME: /opt/android/sdk
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          script: ./build/run_android_emulator.sh
+
   # Let's see how expensive this job is, we might want to tone it down by running it periodically
   test-llama-app:
     needs: upload-artifacts

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -80,9 +80,8 @@ jobs:
 
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
-    # DEBUG
-    # needs: build-llm-demo
-    runs-on: amz2023.linux.12xlarge
+    needs: build-llm-demo
+    runs-on: amz2023.linux.4xlarge
     env:
       ANDROID_NDK_VERSION: r26c
     steps:
@@ -112,6 +111,7 @@ jobs:
           # Reuse the script that install Android on ET Docker image
           sudo -E bash .ci/docker/common/install_android.sh
 
+      # NB: It takes about 10m to cold boot the emulator here
       - name: Run Android emulator
         env:
           ANDROID_HOME: /opt/android/sdk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -82,7 +82,7 @@ jobs:
   run-emulator:
     # DEBUG
     # needs: build-llm-demo
-    runs-on: linux.4xlarge
+    runs-on: amz2023.linux.12xlarge
     env:
       ANDROID_NDK_VERSION: r26c
     steps:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -83,8 +83,6 @@ jobs:
     # DEBUG
     # needs: build-llm-demo
     runs-on: linux.4xlarge
-    env:
-      ANDROID_NDK_VERSION: r26c
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
@@ -95,14 +93,20 @@ jobs:
             All testing is done inside the container, to start an interactive session run:
               docker exec -it $(docker container ps --format '{{.ID}}') bash
 
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+      - uses: actions/checkout@v3
+        with:
+          submodules: false
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
       - name: Install Android dependencies
         shell: bash
         run: |
           set -eux
 
+          export ANDROID_NDK_VERSION=r26c
           # Reuse the script that install Android on ET Docker image
           sudo bash .ci/docker/common/install_android.sh
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -78,7 +78,7 @@ jobs:
           if-no-files-found: ignore
           path: ${{ runner.temp }}/artifacts/
 
-  # Running Android emulator directly on the runner, not using Docker
+  # Running Android emulator directly on the runner and not using Docker
   run-emulator:
     # DEBUG
     # needs: build-llm-demo

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -102,6 +102,12 @@ jobs:
         with:
           python-version: '3.10'
 
+      # NB: Need this to setup Java on GH runner
+      - uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 17
+
       - name: Install Android dependencies
         shell: bash
         run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -97,7 +97,8 @@ jobs:
         with:
           submodules: false
 
-      - uses: actions/setup-python@v4
+      - name: Setup conda
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
           python-version: '3.10'
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -80,19 +80,18 @@ jobs:
 
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
-    needs: build-llm-demo
-    runs-on: amz2023.linux.4xlarge
+    # needs: build-llm-demo
+    runs-on: ubuntu-22.04-4core
+    # runs-on: amz2023.linux.4xlarge
     env:
       ANDROID_NDK_VERSION: r26c
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
-        if: ${{ !contains(matrix.runner, 'gcp.a100') }}
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
           instructions: |
-            All testing is done inside the container, to start an interactive session run:
-              docker exec -it $(docker container ps --format '{{.ID}}') bash
+            This is used to run Android emulators, ANDROID_HOME is installed at /opt/android/sdk
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -81,10 +81,10 @@ jobs:
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
     # needs: build-llm-demo
-    runs-on: 4-core-ubuntu
-    # runs-on: amz2023.linux.4xlarge
+    runs-on: amz2023.linux.4xlarge
     env:
       ANDROID_NDK_VERSION: r26c
+      API_LEVEL: 34
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
@@ -102,12 +102,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      # NB: Need this to setup Java on GH runner
-      - uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: 17
-
       - name: Install Android dependencies
         shell: bash
         run: |
@@ -116,15 +110,34 @@ jobs:
           # Reuse the script that install Android on ET Docker image
           sudo -E bash .ci/docker/common/install_android.sh
 
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ env.API_LEVEL }}
+
       # NB: It takes about 10m to cold boot the emulator here
       - name: Run Android emulator
         env:
           ANDROID_HOME: /opt/android/sdk
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
+          api-level: ${{ env.API_LEVEL }}
           arch: x86_64
           script: ./build/run_android_emulator.sh
+          # NB: This is to boot the emulator faster following the instructions on
+          # https://github.com/ReactiveCircus/android-emulator-runner
+          cores: 8
+          ram-size: 12288M
+          force-avd-creation: false
+          disable-animations: true
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
 
   # Let's see how expensive this job is, we might want to tone it down by running it periodically
   test-llama-app:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -129,15 +129,21 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.API_LEVEL }}
-          arch: x86_64
+          # NB: x86_64 emulator is slow because the lack of KVM support on AWS, it
+          # seems that we can use metal instance for that but it hasn't been tried
+          # out yet
+          arch: arm64-v8a
           script: ./build/run_android_emulator.sh
           # NB: This is to boot the emulator faster following the instructions on
-          # https://github.com/ReactiveCircus/android-emulator-runner
-          cores: 8
+          # https://github.com/ReactiveCircus/android-emulator-runner. The max number
+          # of cores we can set is 6, any higher number will be reduced to 6.
+          cores: 6
           ram-size: 12288M
           force-avd-creation: false
           disable-animations: true
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          # This is to make sure that the job doesn't fail flakily
+          emulator-boot-timeout: 900
 
   # Let's see how expensive this job is, we might want to tone it down by running it periodically
   test-llama-app:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -81,7 +81,8 @@ jobs:
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
     # needs: build-llm-demo
-    runs-on: amz2023.linux.4xlarge
+    # runs-on: amz2023.linux.4xlarge
+    runs-on: amz2023.linux.arm64.2xlarge
     env:
       ANDROID_NDK_VERSION: r26c
       API_LEVEL: 34

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -80,8 +80,7 @@ jobs:
 
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
-    # DEBUG
-    # needs: build-llm-demo
+    needs: build-llm-demo
     runs-on: amz2023.linux.12xlarge
     env:
       ANDROID_NDK_VERSION: r26c

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -81,7 +81,7 @@ jobs:
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
     # needs: build-llm-demo
-    runs-on: ubuntu-22.04-4core
+    runs-on: 4-core-ubuntu
     # runs-on: amz2023.linux.4xlarge
     env:
       ANDROID_NDK_VERSION: r26c

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -80,7 +80,8 @@ jobs:
 
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
-    needs: build-llm-demo
+    # DEBUG
+    # needs: build-llm-demo
     # Should I use 12xlarge here?
     runs-on: amz2023.linux.4xlarge
     env:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -82,8 +82,7 @@ jobs:
   run-emulator:
     # DEBUG
     # needs: build-llm-demo
-    # Should I use 12xlarge here?
-    runs-on: amz2023.linux.4xlarge
+    runs-on: amz2023.linux.12xlarge
     env:
       ANDROID_NDK_VERSION: r26c
     steps:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,6 +45,7 @@ jobs:
 
         # Build LLM Demo for Android
         bash build/build_android_llm_demo.sh ${{ matrix.tokenizer }} ${ARTIFACTS_DIR_NAME}
+
   # Upload artifacts to S3. The artifacts are needed not only by the device farm but also TorchChat
   upload-artifacts:
     needs: build-llm-demo
@@ -76,6 +77,34 @@ jobs:
           retention-days: 14
           if-no-files-found: ignore
           path: ${{ runner.temp }}/artifacts/
+
+  # Running Android emulator directly on the runner, not using Docker
+  run-emulator:
+    # DEBUG
+    # needs: build-llm-demo
+    runs-on: linux.4xlarge
+    env:
+      ANDROID_NDK_VERSION: r26c
+    steps:
+      - name: Setup SSH (Click me for login details)
+        uses: pytorch/test-infra/.github/actions/setup-ssh@main
+        if: ${{ !contains(matrix.runner, 'gcp.a100') }}
+        with:
+          github-secret: ${{ secrets.GITHUB_TOKEN }}
+          instructions: |
+            All testing is done inside the container, to start an interactive session run:
+              docker exec -it $(docker container ps --format '{{.ID}}') bash
+
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+
+      - name: Install Android dependencies
+        shell: bash
+        run: |
+          set -eux
+
+          # Reuse the script that install Android on ET Docker image
+          sudo bash .ci/docker/common/install_android.sh
 
   # Let's see how expensive this job is, we might want to tone it down by running it periodically
   test-llama-app:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -83,6 +83,8 @@ jobs:
     # DEBUG
     # needs: build-llm-demo
     runs-on: linux.4xlarge
+    env:
+      ANDROID_NDK_VERSION: r26c
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
@@ -107,9 +109,8 @@ jobs:
         run: |
           set -eux
 
-          export ANDROID_NDK_VERSION=r26c
           # Reuse the script that install Android on ET Docker image
-          sudo bash .ci/docker/common/install_android.sh
+          sudo -E bash .ci/docker/common/install_android.sh
 
   # Let's see how expensive this job is, we might want to tone it down by running it periodically
   test-llama-app:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -81,8 +81,7 @@ jobs:
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
     # needs: build-llm-demo
-    # runs-on: amz2023.linux.4xlarge
-    runs-on: amz2023.linux.arm64.2xlarge
+    runs-on: amz2023.linux.4xlarge
     env:
       ANDROID_NDK_VERSION: r26c
       API_LEVEL: 34
@@ -132,8 +131,8 @@ jobs:
           api-level: ${{ env.API_LEVEL }}
           # NB: x86_64 emulator is slow because the lack of KVM support on AWS, it
           # seems that we can use metal instance for that but it hasn't been tried
-          # out yet
-          arch: arm64-v8a
+          # out yet. Also arm64-v8a arch requires an ARM runner
+          arch: x86_64
           script: ./build/run_android_emulator.sh
           # NB: This is to boot the emulator faster following the instructions on
           # https://github.com/ReactiveCircus/android-emulator-runner. The max number

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -118,6 +118,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
+          arch: x86_64
           script: ./build/run_android_emulator.sh
 
   # Let's see how expensive this job is, we might want to tone it down by running it periodically

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -81,7 +81,8 @@ jobs:
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
     needs: build-llm-demo
-    runs-on: amz2023.linux.12xlarge
+    # Should I use 12xlarge here?
+    runs-on: amz2023.linux.4xlarge
     env:
       ANDROID_NDK_VERSION: r26c
     steps:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -80,7 +80,7 @@ jobs:
 
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
-    # needs: build-llm-demo
+    needs: build-llm-demo
     runs-on: amz2023.linux.4xlarge
     env:
       ANDROID_NDK_VERSION: r26c

--- a/build/run_android_emulator.sh
+++ b/build/run_android_emulator.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -ex
+
+# This script is originally adopted from https://github.com/pytorch/pytorch/blob/main/android/run_tests.sh
+ADB_PATH=$ANDROID_HOME/platform-tools/adb
+
+echo "List all running emulators"
+$ADB_PATH devices
+
+DEVICES_COUNT=$($ADB_PATH devices | awk 'NF' | wc -l)
+echo "DEVICES_COUNT:$DEVICES_COUNT"
+
+if [ "$DEVICES_COUNT" -eq 1 ]; then
+  echo "Unable to found connected android emulators"
+  exit 1
+fi
+
+echo "Waiting for emulator boot completed"
+$ADB_PATH wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done;'

--- a/build/run_android_emulator.sh
+++ b/build/run_android_emulator.sh
@@ -10,17 +10,11 @@ set -ex
 # This script is originally adopted from https://github.com/pytorch/pytorch/blob/main/android/run_tests.sh
 ADB_PATH=$ANDROID_HOME/platform-tools/adb
 
+echo "Waiting for emulator boot to complete"
+$ADB_PATH wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 30; done;'
+
+# The device will be created by ReactiveCircus/android-emulator-runner GHA
 echo "List all running emulators"
 $ADB_PATH devices
 
-# These devices should have already been created by ReactiveCircus/android-emulator-runner GHA
-DEVICES_COUNT=$($ADB_PATH devices | awk 'NF' | wc -l)
-echo "DEVICES_COUNT:$DEVICES_COUNT"
-
-if [ "$DEVICES_COUNT" -eq 1 ]; then
-  echo "Unable to found connected android emulators"
-  exit 1
-fi
-
-echo "Waiting for emulator boot completed"
-$ADB_PATH wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done;'
+# TODO: Run tests on emulator here

--- a/build/run_android_emulator.sh
+++ b/build/run_android_emulator.sh
@@ -13,6 +13,7 @@ ADB_PATH=$ANDROID_HOME/platform-tools/adb
 echo "List all running emulators"
 $ADB_PATH devices
 
+# These devices should have already been created by ReactiveCircus/android-emulator-runner GHA
 DEVICES_COUNT=$($ADB_PATH devices | awk 'NF' | wc -l)
 echo "DEVICES_COUNT:$DEVICES_COUNT"
 

--- a/build/run_android_emulator.sh
+++ b/build/run_android_emulator.sh
@@ -17,4 +17,5 @@ $ADB_PATH wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; d
 echo "List all running emulators"
 $ADB_PATH devices
 
-# TODO: Run tests on emulator here
+# TODO: Run tests on emulator here, atm the script only boots up the emulator
+# and exits without doing anything yet

--- a/build/run_android_emulator.sh
+++ b/build/run_android_emulator.sh
@@ -12,7 +12,7 @@ ADB_PATH=$ANDROID_HOME/platform-tools/adb
 
 echo "Waiting for emulator boot to complete"
 # shellcheck disable=SC2016
-$ADB_PATH wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 30; done;'
+$ADB_PATH wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 5; done;'
 
 # The device will be created by ReactiveCircus/android-emulator-runner GHA
 echo "List all running emulators"

--- a/build/run_android_emulator.sh
+++ b/build/run_android_emulator.sh
@@ -11,6 +11,7 @@ set -ex
 ADB_PATH=$ANDROID_HOME/platform-tools/adb
 
 echo "Waiting for emulator boot to complete"
+# shellcheck disable=SC2016
 $ADB_PATH wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 30; done;'
 
 # The device will be created by ReactiveCircus/android-emulator-runner GHA


### PR DESCRIPTION
Unlike other Linux job where we can use Docker images,  Android emulator needs to be run directly on our Linux runner as I don't know if Docker supports KVM which is needed to emulate the devices.

* Requires Amazon Linux 2023 or GitHub ubuntu for node 20
* Use https://github.com/ReactiveCircus/android-emulator-runner GHA to simplify the setup of the emulator devices instead of writing our own script
* It takes about 10m to cold boot the emulator