### PR TITLE
Add docstrings to all unittest.TestCase:s

### DIFF
--- a/backends/arm/test/misc/test_debug_feats.py
+++ b/backends/arm/test/misc/test_debug_feats.py
@@ -41,6 +41,8 @@ class Linear(torch.nn.Module):
 
 
 class TestDumpPartitionedArtifact(unittest.TestCase):
+    """Tests dumping the partition artifact in ArmTester. Both to file and to stdout."""
+
     def _tosa_MI_pipeline(self, module: torch.nn.Module, dump_file=None):
         (
             ArmTester(
@@ -96,6 +98,8 @@ class TestDumpPartitionedArtifact(unittest.TestCase):
 
 
 class TestNumericalDiffPrints(unittest.TestCase):
+    """Tests trigging the exception printout from the ArmTester's run and compare function."""
+
     def test_numerical_diff_prints(self):
         model = Linear(20, 30)
         tester = (

--- a/backends/arm/test/models/test_mobilenet_v2_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v2_arm.py
@@ -22,8 +22,9 @@ logger.setLevel(logging.INFO)
 
 
 class TestMobileNetV2(unittest.TestCase):
+    """Tests MobileNetV2."""
 
-    mv2 = models.mobilenetv2.mobilenet_v2(weights=MobileNet_V2_Weights)
+    mv2 = models.mobilenetv2.mobilenet_v2(weights=MobileNet_V2_Weights.DEFAULT)
     mv2 = mv2.eval()
     normalize = transforms.Normalize(
         mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]

--- a/backends/arm/test/ops/test_add.py
+++ b/backends/arm/test/ops/test_add.py
@@ -21,6 +21,8 @@ logger.setLevel(logging.INFO)
 
 
 class TestSimpleAdd(unittest.TestCase):
+    """Tests a single add op, x+x and x+y."""
+
     class Add(torch.nn.Module):
         test_parameters = [
             (torch.FloatTensor([1, 2, 3, 5, 7]),),

--- a/backends/arm/test/ops/test_avg_pool.py
+++ b/backends/arm/test/ops/test_avg_pool.py
@@ -28,6 +28,8 @@ test_data_suite = [
 
 
 class TestAvgPool2d(unittest.TestCase):
+    """Tests AvgPool2d."""
+
     class AvgPool2d(torch.nn.Module):
         def __init__(
             self,

--- a/backends/arm/test/ops/test_batch_norm.py
+++ b/backends/arm/test/ops/test_batch_norm.py
@@ -497,6 +497,8 @@ test_no_stats_data_suite = [
 
 
 class TestBatchNorm2d(unittest.TestCase):
+    """Tests BatchNorm2d."""
+
     class BatchNorm2d(torch.nn.Module):
         def __init__(
             self,

--- a/backends/arm/test/ops/test_clone.py
+++ b/backends/arm/test/ops/test_clone.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 
 
 class TestSimpleClone(unittest.TestCase):
+    """Tests clone."""
+
     class Clone(torch.nn.Module):
         sizes = [10, 15, 50, 100]
         test_parameters = [(torch.ones(n),) for n in sizes]

--- a/backends/arm/test/ops/test_conv.py
+++ b/backends/arm/test/ops/test_conv.py
@@ -244,6 +244,8 @@ testsuite_u55.remove(("2x2_1x1x14x14_st2", conv2d_2x2_1x1x14x14_st2))
 
 
 class TestConv2D(unittest.TestCase):
+    """Tests Conv2D, both single ops and multiple Convolutions in series."""
+
     def _test_conv2d_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):

--- a/backends/arm/test/ops/test_conv_combos.py
+++ b/backends/arm/test/ops/test_conv_combos.py
@@ -154,6 +154,8 @@ class ComboConvRelu6(torch.nn.Module):
 
 
 class TestConvCombos(unittest.TestCase):
+    """Tests conv combined with other ops."""
+
     def _test_conv_combo_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):

--- a/backends/arm/test/ops/test_depthwise_conv.py
+++ b/backends/arm/test/ops/test_depthwise_conv.py
@@ -130,6 +130,9 @@ testsuite_u55.remove(("3x3_1x3x256x256_gp3_st1", dw_conv2d_3x3_1x3x256x256_gp3_s
 
 
 class TestDepthwiseConv2D(unittest.TestCase):
+    """Tests Conv2D where groups == in_channels and out_channels = K * in_channels. This
+    is a special case enables depthwise convolution."""
+
     def _test_dw_conv2d_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.Tensor]
     ):

--- a/backends/arm/test/ops/test_div.py
+++ b/backends/arm/test/ops/test_div.py
@@ -78,6 +78,8 @@ test_data_suite = [
 
 
 class TestDiv(unittest.TestCase):
+    """Tests division"""
+
     class Div(torch.nn.Module):
         def __init__(
             self,

--- a/backends/arm/test/ops/test_full.py
+++ b/backends/arm/test/ops/test_full.py
@@ -19,6 +19,8 @@ from parameterized import parameterized
 
 
 class TestFull(unittest.TestCase):
+    """Tests the full op which creates a tensor of a given shape filled with a given value."""
+
     class Full(torch.nn.Module):
         # A single full op
         def forward(self):

--- a/backends/arm/test/ops/test_linear.py
+++ b/backends/arm/test/ops/test_linear.py
@@ -91,6 +91,7 @@ test_data_suite_rank4 = [
 
 
 class TestLinear(unittest.TestCase):
+    """tests the linear operation y = Ax + b"""
 
     _edge_compile_config: EdgeCompileConfig = EdgeCompileConfig(
         _skip_dim_order=True,  # TODO(T182928844): Delegate dim order op to backend.

--- a/backends/arm/test/ops/test_mean_dim.py
+++ b/backends/arm/test/ops/test_mean_dim.py
@@ -40,6 +40,8 @@ test_data_suite = [
 
 
 class TestMeanDim(unittest.TestCase):
+    """Tests MeanDim, called AdaptiveAvgPool2d in Pytorch."""
+
     class MeanDim(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/arm/test/ops/test_softmax.py
+++ b/backends/arm/test/ops/test_softmax.py
@@ -28,6 +28,8 @@ test_data_suite = [
 
 
 class TestSoftmax(unittest.TestCase):
+    """Tests softmax."""
+
     class Softmax(torch.nn.Module):
         def __init__(self, dim: int = -1):
             super().__init__()

--- a/backends/arm/test/ops/test_view.py
+++ b/backends/arm/test/ops/test_view.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 
 
 class TestSimpleView(unittest.TestCase):
+    """Tests the view operation."""
+
     class View(torch.nn.Module):
 
         sizes = [10, 15, 50, 100]

--- a/backends/arm/test/passes/test_tag_io_quant_pass.py
+++ b/backends/arm/test/passes/test_tag_io_quant_pass.py
@@ -22,6 +22,7 @@ class Add(torch.nn.Module):
 
 
 class TestTagIOQuantPass(unittest.TestCase):
+    """Tests the TagIOQuantPass which tags q/dq nodes on model inputs and outputs to not include them in our partitions."""
 
     def _tosa_BI_u55_pipeline(self, module: torch.nn.Module):
         (


### PR DESCRIPTION
This avoids logging a long default docstring which makes the output of test collection a lot easier to read and thus debug.

I also updated the mv2net weight parameter as the current way of calling it is deprecated. This also removes a warning from test collection.


Change-Id: I05f000e9ef42ab9d63f234539da3309f69ccbe16