### PR TITLE
remove target_sdk_version attributes

### DIFF
--- a/backends/apple/mps/targets.bzl
+++ b/backends/apple/mps/targets.bzl
@@ -61,8 +61,6 @@ def define_common_targets(is_xplat = False, platforms = []):
             "MetalPerformanceShaders",
             "MetalPerformanceShadersGraph",
         ]
-        kwargs["fbobjc_ios_target_sdk_version"] = "17.0"
-        kwargs["fbobjc_macosx_target_sdk_version"] = "14.0"
         kwargs["platforms"] = platforms
 
     if runtime.is_oss or is_xplat:


### PR DESCRIPTION
Summary: These should be set on top level targets, not libraries.

Differential Revision: D60174978
