### PR TITLE
Allow us to move the proto files outside of fbcode

### DIFF
--- a/shim/shims.bzl
+++ b/shim/shims.bzl
@@ -351,13 +351,6 @@ def rust_protobuf_library(
         ] + (deps or []),
     )
 
-    # For python tests only
-    for proto in protos:
-        prelude.export_file(
-            name = proto,
-            visibility = ["PUBLIC"],
-        )
-
 def ocaml_binary(
         deps = [],
         visibility = ["PUBLIC"],


### PR DESCRIPTION
Summary: Allow `rust_protobuf_library` to take in a target or a source. This is an effort to move proto files to a standard, shareable location. The decision was made to make users of this macro to explicitly define the export file if they needed.

Reviewed By: ndmitchell

Differential Revision: D60187261
