### PR TITLE
Specify patch version for torch and torchaudio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,9 @@ dependencies=[
   "ruamel.yaml",
   "sympy",
   "tabulate",
-  "torch==2.4",
+  "torch==2.4.0",
   "torchvision==0.19.0",
-  "torchaudio==2.4",
+  "torchaudio==2.4.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Use 2.4.0 per suggestion from @atalman 