### PR TITLE
remove unused tensors from VK model's graph

### DIFF
--- a/backends/vulkan/serialization/vulkan_graph_builder.py
+++ b/backends/vulkan/serialization/vulkan_graph_builder.py
@@ -262,6 +262,9 @@ class VkGraphBuilder:
             raise RuntimeError(f"Cannot create value for arg of type {type(arg)}")
 
     def process_placeholder_node(self, node: Node) -> None:
+        # ignores any tensors that don't get used in any ops
+        if len(node.users) == 0:
+            return None
         ids = self.create_node_value(node)
         if not self.is_param_node(node):
             if isinstance(ids, int):


### PR DESCRIPTION
Summary:
We implemented [operators fusion](https://github.com/pytorch/executorch/pull/3769?fbclid=IwZXh0bgNhZW0CMTEAAR3kYya0wRrkupmV86OpPZZ9_QhqLYEmNrKcJk5Jj_4VSO_WqvFsbWNigTs_aem_gQeSu2zvazf_hpy3RsIXhg) (`conv+bn`) which fused `conv` and `bn`'s weights and biases, but the old parameters are not deleted. Hence we saw that VK model's size is nearly twice large as CPU's.

As regards mobilenet_v2, before this diff CPU vs VK: 14M vs 22M. After this diff, both of them have 14M.

Differential Revision: D60257047
