### PR TITLE
Remove pip-out before running smoke test

### DIFF
--- a/build/packaging/post_build_script.sh
+++ b/build/packaging/post_build_script.sh
@@ -7,4 +7,5 @@
 
 set -eux
 
+rm -rf pip-out/
 echo "This script is run after building ExecuTorch binaries"


### PR DESCRIPTION
So that we won't use .so files from there. This is what the user setup looks like.