### PR TITLE
FileDataLoader fails to read the file when size > INT32_MAX

### DIFF
--- a/extension/data_loader/file_data_loader.cpp
+++ b/extension/data_loader/file_data_loader.cpp
@@ -8,9 +8,11 @@
 
 #include <executorch/extension/data_loader/file_data_loader.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <cstddef>
 #include <cstring>
+#include <limits>
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -189,7 +191,12 @@ Result<FreeableBuffer> FileDataLoader::load(
   size_t needed = size;
   uint8_t* buf = reinterpret_cast<uint8_t*>(aligned_buffer);
   while (needed > 0) {
-    ssize_t nread = ::read(fd_, buf, needed);
+    // read on macos would fail with EINVAL if size > INT32_MAX
+    ssize_t nread = ::read(
+        fd_,
+        buf,
+        std::min<size_t>(
+            needed, static_cast<size_t>(std::numeric_limits<int32_t>::max())));
     if (nread < 0 && errno == EINTR) {
       // Interrupted by a signal; zero bytes read.
       continue;

--- a/extension/data_loader/file_data_loader.cpp
+++ b/extension/data_loader/file_data_loader.cpp
@@ -191,7 +191,7 @@ Result<FreeableBuffer> FileDataLoader::load(
   size_t needed = size;
   uint8_t* buf = reinterpret_cast<uint8_t*>(aligned_buffer);
   while (needed > 0) {
-    // read on macos would fail with EINVAL if size > INT32_MAX
+    // Reads on macos will fail with EINVAL if size > INT32_MAX.
     ssize_t nread = ::read(
         fd_,
         buf,


### PR DESCRIPTION
On macOS, the `read` function will fail with an `EINVAL` error if the size parameter exceeds `INT32_MAX`. This update addresses the issue by adding a check to ensure that the read size does not surpass `INT32_MAX`. On Linux, the maximum permissible read size is 2,147,479,552 bytes ( < `INT32_MAX`), so attempting to read beyond this limit is inconsequential. 

Test Plan:

Exporting llama3 with `python -m examples.models.llama2.export_llama --checkpoint examples/models/llama-2-7B/consolidated.00.pth --params examples/models/llama-2-7B/params.json --coreml --disable_dynamic_shape -kv `  

Without fix
Fails with `invalid argument` error.

With fix
Succeeds.
