### PR TITLE
nop validation during build

### DIFF
--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -169,7 +169,7 @@ rustyline = "11.0"
 scopeguard = "1.0.0"
 sequence_trie = "0.3.6"
 serde = { version = "1.0.173", features = ["derive", "rc"] }
-serde_json = "1.0.48"
+serde_json = { version = "1.0.48", features = ["raw_value"] }
 sha1 = "0.10"
 sha2 = "0.10"
 shlex = "1.3"


### PR DESCRIPTION
Summary:
Adding validation logic to "build targets" implementation. Actual validation is nop in this diff, implementaion is in next diffs in stack.

I need to use late bindings in order to keep validation logic in separate crate because `buck2_build_api` depends on validation, while validation depends on materialization from `buck2_build_api`.

Reviewed By: stepancheg

Differential Revision: D60238806
