### PR TITLE
Create a buck genrule for schema_generated.h

### DIFF
--- a/backends/qualcomm/targets.bzl
+++ b/backends/qualcomm/targets.bzl
@@ -1,0 +1,28 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+
+def generate_schema_header(rule_name, srcs, headers, default_header):
+    """Generate header file given flatbuffer schema
+    """
+    runtime.genrule(
+        name = rule_name,
+        srcs = srcs,
+        # We're only generating a single file, so it seems like we could use
+        # `out`, but `flatc` takes a directory as a parameter, not a single
+        # file. Use `outs` so that `${OUT}` is expanded as the containing
+        # directory instead of the file itself.
+        outs = {header: [header] for header in headers},
+        default_outs = [default_header],
+        cmd = " ".join([
+            "$(exe {})".format(runtime.external_dep_location("flatc")),
+            "--cpp",
+            "--cpp-std c++11",
+            "--gen-mutable",
+            "--scoped-enums",
+            "-o ${OUT}",
+            "${SRCS}",
+            # Let our infra know that the file was generated.
+            " ".join(["&& echo // @" + "generated >> ${OUT}/" + header for header in headers]),
+        ]),
+        visibility = [],  # Private
+    )


### PR DESCRIPTION
Summary:
Create a buck genrule for schema_generated.h
- Genrule example: https://www.internalfb.com/code/fbsource/[6e2ed7840cb2]/fbcode/executorch/schema/targets.bzl?lines=20-41


This is needed to add dependency of qualcomm/schema_generated.h into the ET-QNN for Meta Wearable app

Differential Revision: D60456032


