### PR TITLE
Fix overload name for prims ops used in `call_map` nodes.

### DIFF
--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -770,7 +770,7 @@ class _Emitter(torch.fx.Interpreter):
         # Increment iter_idx to mark that we have completed an iteration.
         op_index, op = self._get_operator(
             name="executorch_prim::add",
-            overload="int",
+            overload="Scalar",
         )
         kernel = Instruction(
             KernelCall(
@@ -787,7 +787,7 @@ class _Emitter(torch.fx.Interpreter):
         # section.
         op_index, op = self._get_operator(
             name="executorch_prim::eq",
-            overload="int",
+            overload="Scalar",
         )
         kernel = Instruction(
             KernelCall(
@@ -809,7 +809,7 @@ class _Emitter(torch.fx.Interpreter):
         # Reset iter_idx in case we plan to run the model again.
         op_index, op = self._get_operator(
             name="executorch_prim::sub",
-            overload="int",
+            overload="Scalar",
         )
         kernel = Instruction(
             KernelCall(

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -722,6 +722,23 @@ class TestEmit(unittest.TestCase):
             "executorch_prim::sub",
         )
 
+    def test_load_emit_map(self) -> None:
+        class Foo(torch.nn.Module):
+            def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                def map_fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                    return x + y
+
+                return control_flow.map(map_fn, x, y)
+
+        f = Foo()
+
+        inputs = (torch.ones(4, 4), torch.ones(4))
+        module = to_edge(
+            export(f, inputs),
+            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+        )
+        _load_for_executorch_from_buffer(module.to_executorch().buffer)
+
     def test_dim_order(self) -> None:
         class SimpleLinear(torch.nn.Module):
             def __init__(self) -> None:


### PR DESCRIPTION
Summary: Use the correct overloads for `add`, `sub`, and `eq` prims operators in _emitter.py.

Differential Revision: D60421727
