### PR TITLE
Filter aliasing nodes from memory timeline

### DIFF
--- a/util/activation_memory_profiler.py
+++ b/util/activation_memory_profiler.py
@@ -54,6 +54,8 @@ def create_tensor_allocation_info(graph: torch.fx.Graph) -> List[MemoryTimeline]
     nodes = graph.nodes
     memory_timeline = [None] * len(nodes)
     for i, node in enumerate(nodes):
+        if node.op == "output":
+            continue
         if node.target == memory.alloc:
             continue
         tensor_specs = get_node_tensor_specs(node)


### PR DESCRIPTION
Summary:
Through memory offset view, I noticed that we have a bunch of allocation objects that alias each other. These include:

- "output" nodes
- "aten._view_copy_nop.out" nodes

Making an attempt to filter these out so the visualization is more accurate

Reviewed By: hsharma35

Differential Revision: D55455168
