### PR TITLE
Add dim-order op revert pass for delegates

### DIFF
--- a/exir/passes/dim_order_ops_registry.py
+++ b/exir/passes/dim_order_ops_registry.py
@@ -45,3 +45,15 @@ Defines a map of aten or edge ops to the corresponding dim_order ops for quick l
 DimOrderOpsMap = {
     "aten._to_copy.default": exir_ops.edge.dim_order_ops._to_dim_order_copy.default,
 }
+
+"""
+Defines a map of aten or edge ops to the corresponding memory format ops for quick lookup
+"""
+MemoryFormatOpsMap = {
+    "dim_order_ops._to_dim_order_copy.default": exir_ops.edge.aten._to_copy.default,
+}
+
+# If we are replacing an aten op with a dim_order op, we must have a 1:1 mapping through these dicts.
+assert len(DimOrderOpsMap) == len(MemoryFormatOpsMap)
+
+# TODO stricter check for 1:1 mapping

--- a/exir/passes/memory_format_ops_pass.py
+++ b/exir/passes/memory_format_ops_pass.py
@@ -9,12 +9,18 @@ import logging
 
 import torch
 from executorch.exir.dialects.edge._ops import EdgeOpOverload
-from executorch.exir.dim_order_utils import get_dim_order
+from executorch.exir.dim_order_utils import get_dim_order, get_memory_format
 from executorch.exir.pass_base import ExportPass, ProxyValue
-from executorch.exir.passes.dim_order_ops_registry import DimOrderOpsMap
+from executorch.exir.passes.dim_order_ops_registry import (
+    DimOrderOpsMap,
+    MemoryFormatOpsMap,
+)
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
+
+# TODO - these passes are too specialized on a single to_copy op.
+# We should be able to replace (or revert) any of the dim_order ops in the future.
 
 
 class MemoryFormatOpsPass(ExportPass):
@@ -53,7 +59,55 @@ class MemoryFormatOpsPass(ExportPass):
             f" _to_dim_order_copy = dim_order: {nkwargs['dim_order']}"
         )
 
-        t = DimOrderOpsMap[op.__name__]
+        t = DimOrderOpsMap.get(op.__name__, None)
+        assert t is not None, f"{op.__name__} not found in DimOrderOpsMap"
+
+        return super().call_operator(
+            t,
+            args,
+            nkwargs,
+            meta,
+        )
+
+
+class DimOrderOpsRevertPass(ExportPass):
+    """
+    This pass is to revert the dim_order ops back to the memory format ops.
+    """
+
+    def call_operator(self, op, args, kwargs, meta):
+        if not (isinstance(op, EdgeOpOverload) and op.__name__ in MemoryFormatOpsMap):
+            return super().call_operator(
+                op,
+                args,
+                kwargs,
+                meta,
+            )
+
+        # new kwargs with dim_order, and no memory_format for the new op
+        nkwargs = dict(copy.deepcopy(kwargs))  # orig kwargs are immutable
+
+        # can always get the shape, assuming rank is specialized
+        if isinstance(args[0], ProxyValue) and args[0].is_tensor():
+            ndim = args[0].to_tensor().dim()
+        elif isinstance(args[0], torch.Tensor):
+            ndim = args[0].dim()
+        else:
+            assert 0, f"Expecting a Tensor or a ProxyValue buy got {type(args[0])}"
+
+        # get the "to" memory format for the EdgeOp
+        default_dim_order = list(range(ndim))
+        dim_order = nkwargs.pop("dim_order", default_dim_order)
+
+        nkwargs["memory_format"] = get_memory_format(dim_order)
+
+        logger.debug(
+            f" _to_dim_order_copy = dim_order: {dim_order}."
+            f"_to_copy = rank: {ndim}, memory_format: {nkwargs['memory_format']}."
+        )
+
+        t = MemoryFormatOpsMap.get(op.__name__, None)
+        assert t is not None, f"{op.__name__} not found in MemoryFormatOpsMap"
 
         return super().call_operator(
             t,


### PR DESCRIPTION
Summary:
As the title suggests, this brings back memory format ops replacing dim order ops.

Rationale
* DimOrder has to be introduced in the edge IR by ET Beta
* Delegates may need more time to handle this especially with BC and/or external repo update
* This will allow us to set `EdgeCompileConfig._skip_dim_order = False` by default and let delegate use this pass for their `preprocess` function for easy migration.

The expected net result is in the Edge dialect we will have memory_format removed for at least `to_copy` op and rest should be able to transparently removed gradually like full_op. While delegate can effectively live in the old edge dialect (technically illegal  - verifier will fail) with this pass. Once they are ready to accept the dim_order ops, they can drop this pass.

Differential Revision: D60431584
