### PR TITLE
Bugfixes to enable call_map.

### DIFF
--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -788,7 +788,7 @@ class _Emitter(torch.fx.Interpreter):
         # Increment iter_idx to mark that we have completed an iteration.
         op_index, op = self._get_operator(
             name="executorch_prim::add",
-            overload="int",
+            overload="Scalar",
         )
         kernel = Instruction(
             KernelCall(
@@ -805,7 +805,7 @@ class _Emitter(torch.fx.Interpreter):
         # section.
         op_index, op = self._get_operator(
             name="executorch_prim::eq",
-            overload="int",
+            overload="Scalar",
         )
         kernel = Instruction(
             KernelCall(
@@ -827,7 +827,7 @@ class _Emitter(torch.fx.Interpreter):
         # Reset iter_idx in case we plan to run the model again.
         op_index, op = self._get_operator(
             name="executorch_prim::sub",
-            overload="int",
+            overload="Scalar",
         )
         kernel = Instruction(
             KernelCall(

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -722,6 +722,23 @@ class TestEmit(unittest.TestCase):
             "executorch_prim::sub",
         )
 
+    def test_load_emit_map(self) -> None:
+        class Foo(torch.nn.Module):
+            def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                def map_fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                    return x + y
+
+                return control_flow.map(map_fn, x, y)
+
+        f = Foo()
+
+        inputs = (torch.ones(4, 4), torch.ones(4))
+        module = to_edge(
+            export(f, inputs),
+            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+        )
+        _load_for_executorch_from_buffer(module.to_executorch().buffer)
+
     def test_dim_order(self) -> None:
         class SimpleLinear(torch.nn.Module):
             def __init__(self) -> None:

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -739,6 +739,26 @@ class TestEmit(unittest.TestCase):
         )
         _load_for_executorch_from_buffer(module.to_executorch().buffer)
 
+    def test_run_emit_map(self) -> None:
+        class Foo(torch.nn.Module):
+            def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                def map_fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                    return x + y
+
+                return control_flow.map(map_fn, x, y)
+
+        f = Foo()
+
+        inputs = (torch.ones(4, 4), torch.ones(4))
+        module = to_edge(
+            export(f, inputs),
+            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+        )
+        buffer = module.to_executorch().buffer
+        loaded_model = _load_for_executorch_from_buffer(buffer)
+        outputs = loaded_model(inputs)[0]
+        torch.allclose(outputs, f(*inputs))
+
     def test_dim_order(self) -> None:
         class SimpleLinear(torch.nn.Module):
             def __init__(self) -> None:

--- a/kernels/prim_ops/et_copy_index.cpp
+++ b/kernels/prim_ops/et_copy_index.cpp
@@ -94,7 +94,8 @@ void et_copy_index(RuntimeContext& context, EValue** stack) {
     expected_output_size[i + 1] = copy_from.sizes()[i];
   }
 
-  if (copy_to.sizes()[0] != expected_output_size[0]) {
+  if (copy_to.sizes()[0] < expected_output_size[0]) {
+    // Resize `copy_to` to the expected output size.
     const void* data_ptr = copy_to.const_data_ptr();
     Error err =
         resize_tensor(copy_to, {expected_output_size, copy_to.sizes().size()});


### PR DESCRIPTION
Summary:
1. Allocate memory for call_map input.
    call_map uses `select_copy` to extract the input tensor from the original mapped input for each iteration. We would need to memory-plan this tensor. The newly added test `test_run_emit_map` would fail when the input tensor is not memory-planned.

2. Avoid resize inside `et_copy_index` operator when copy_to tensor is already large enough. This avoids the following error:

```
test_run_emit_map (executorch.exir.emit.test.test_emit.TestEmit) ... E 00:00:08.249223 executorch:tensor_impl.cpp:93] Attempted to resize a static tensor to a new shape at dimension 0 old_size: 4 new_size: 1
F 00:00:08.249282 executorch:et_copy_index.cpp:101] In function et_copy_index(), assert failed: err == Error::Ok
```

Differential Revision: D60468979
