### PR TITLE
Fix unsupported linker flag on Mac

### DIFF
--- a/examples/models/llama2/CMakeLists.txt
+++ b/examples/models/llama2/CMakeLists.txt
@@ -216,7 +216,11 @@ endif()
 
 add_executable(llama_main ${_srcs})
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  target_link_options(llama_main PRIVATE "LINKER:--gc-sections,-s")
+  if(APPLE)
+    target_link_options(llama_main PRIVATE "LINKER:-dead_strip")
+  else()
+    target_link_options(llama_main PRIVATE "LINKER:--gc-sections,-s")
+  endif()
 endif()
 
 target_include_directories(llama_main PUBLIC ${_common_include_directories})


### PR DESCRIPTION
Run into the following linker error on Mac:
```
[ 83%] Linking CXX executable llama_main
ld: warning: -s is obsolete
ld: unknown options: --gc-sections
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [llama_main] Error 1
make[1]: *** [CMakeFiles/llama_main.dir/all] Error 2
make: *** [all] Error 2
```
Env:
`clang --version`
```
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

Fix:
It turns out that Apple Clang linker doesn't support the `--gc-sections` options, where it instructs the linker to remove unused sections from the final executable or shared library. Use an equivalent flags `-dead_strip` instead on Mac.