### PR TITLE
Register grid_priors nn.Module test

### DIFF
--- a/backends/vulkan/partitioner/supported_ops.py
+++ b/backends/vulkan/partitioner/supported_ops.py
@@ -8,6 +8,8 @@
 
 import operator
 
+from executorch.backends.vulkan.passes.custom_ops_defs import grid_priors_op  # noqa
+
 from executorch.exir.dialects._ops import ops as exir_ops
 
 
@@ -129,6 +131,7 @@ CREATION_OPS = [
     exir_ops.edge.aten.upsample_nearest2d.vec,
     exir_ops.edge.aten.zeros.default,
     exir_ops.edge.aten.zeros_like.default,
+    exir_ops.edge.et_vk.grid_priors.default,
 ]
 
 

--- a/backends/vulkan/runtime/graph/ops/impl/GridPriors.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/GridPriors.cpp
@@ -74,6 +74,6 @@ void grid_priors(ComputeGraph& graph, const std::vector<ValueRef>& args) {
 }
 
 REGISTER_OPERATORS {
-  VK_REGISTER_OP(grid_priors.default, grid_priors);
+  VK_REGISTER_OP(et_vk.grid_priors.default, grid_priors);
 }
 } // namespace vkcompute

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -1632,3 +1632,21 @@ class TestBackends(unittest.TestCase):
             (torch.tensor([[[0, 1], [0, 1]], [[4, 2], [3, 3]]]),),
             memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
         )
+
+    def test_vulkan_backend_grid_priors(self):
+        class GridPriorsModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.ops.et_vk.grid_priors(
+                    x,
+                    stride=8,
+                    offset=0.5,
+                )
+
+        self.lower_module_and_test_output(
+            GridPriorsModule(),
+            (torch.rand(size=[1, 5, 2, 3]),),
+            memory_layouts=[vk_graph_schema.VkMemoryLayout.TENSOR_CHANNELS_PACKED],
+        )

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -2224,7 +2224,7 @@ void test_grid_priors(
       vkapi::kFloat,
       utils::GPUMemoryLayout::TENSOR_CHANNELS_PACKED);
 
-  VK_GET_OP_FN("grid_priors.default")
+  VK_GET_OP_FN("et_vk.grid_priors.default")
   (graph,
    {in.value,
     graph.add_scalar<int64_t>(stride),


### PR DESCRIPTION
Summary: Register customized op `grid_priors` in nn.Module test. Now it can be exported from PyTorch nn.module to Vulkan.

Differential Revision: D60474638
