### PR TITLE
Fix CI OOM issue

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -27,6 +27,7 @@ CUSTOM_RUNNERS = {
         # This one causes timeout on smaller runner, the root cause is unclear (T161064121)
         "dl3": "linux.12xlarge",
         "emformer_join": "linux.12xlarge",
+        "emformer_predict": "linux.12xlarge",
     }
 }
 


### PR DESCRIPTION
[OOM](https://github.com/pytorch/executorch/actions/runs/10202393165/job/28226397905) in CI. This model will require a larger runner 