### PR TITLE
Type Promote Div

### DIFF
--- a/exir/passes/remove_mixed_type_operators.py
+++ b/exir/passes/remove_mixed_type_operators.py
@@ -23,6 +23,7 @@ class RemoveMixedTypeOperators(ExportPass):
         promotion_type_allow_list = {
             torch.ops.aten.add.Tensor: ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
             torch.ops.aten.mul.Tensor: ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+            torch.ops.aten.div.Tensor: ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
             torch.ops.aten.minimum.default: ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
         }
 


### PR DESCRIPTION
Summary: In decomposition of Hardsigmoid, we see a divide by 6. When we lift this scalar to a tensor, we then see that the divisor is int64, and the dividend is float32. This allows us to remove the Mixed Dtype and also helps us delegate to XNNPACK

Reviewed By: tarun292, digantdesai

Differential Revision: D60492342
