### PR TITLE
fix forward _partition_and_lower_one_graph_module

### DIFF
--- a/exir/backend/backend_api.py
+++ b/exir/backend/backend_api.py
@@ -269,8 +269,7 @@ def _partition_and_lower_one_graph_module(
 
             if node.name in toplevel_signature.inputs_to_buffers:
                 # Delete the consumed buffers
-                buffer_name = toplevel_signature.inputs_to_buffers.pop(node.name)
-                toplevel_signature.buffers.remove(buffer_name)
+                buffer_name = toplevel_signature.inputs_to_buffers.get(node.name)
                 if buffer_name in owning_program.state_dict:
                     owning_program.state_dict.pop(buffer_name)
                 else:
@@ -278,8 +277,7 @@ def _partition_and_lower_one_graph_module(
                 tagged_graph_module.graph.erase_node(node)
             elif node.name in toplevel_signature.inputs_to_parameters:
                 # Delete the consumed parameters
-                param_name = toplevel_signature.inputs_to_parameters.pop(node.name)
-                toplevel_signature.parameters.remove(param_name)
+                param_name = toplevel_signature.inputs_to_parameters.get(node.name)
                 owning_program.state_dict.pop(param_name)
                 tagged_graph_module.graph.erase_node(node)
 


### PR DESCRIPTION
Summary:
D60296909 broke some executorch backend code.

Note that `inputs_to_buffers`, `buffers`, `inputs_to_parameters`, `parameters` on a graph signature were all property accessors even before that diff, so those mutating operations had no effect since a new list / dict was returned every time.
That diff makes them immutable so `pop()` and `remove()` are now errors.

Differential Revision: D60642036
