### PR TITLE
Fix Stats in jni_layer_llama.cpp

### DIFF
--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -73,7 +73,7 @@ class ExecuTorchLlamaCallbackJni
     method(self(), s);
   }
 
-  void onStats(const Runner::Stats& result) const {
+  void onStats(const Stats& result) const {
     static auto cls = ExecuTorchLlamaCallbackJni::javaClassStatic();
     static const auto method = cls->getMethod<void(jfloat)>("onStats");
     double eval_time =
@@ -132,7 +132,7 @@ class ExecuTorchLlamaJni
         prompt->toStdString(),
         128,
         [callback](std::string result) { callback->onResult(result); },
-        [callback](const Runner::Stats& result) { callback->onStats(result); });
+        [callback](const Stats& result) { callback->onStats(result); });
     return 0;
   }
 


### PR DESCRIPTION
In https://github.com/pytorch/executorch/pull/4499 `Runner::Stats` is moved to `Stats`. Fixing it in JNI.