### PR TITLE
Revert "Make flatcc cross-compile deterministic (#4312)"

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -87,37 +87,23 @@ if(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT)
   # Add the host project. We build this separately so that we can generate
   # headers on the host during the build, even if we're cross-compiling the
   # flatcc runtime to a different architecture.
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} ${_flatcc_source_dir}
-    -DFLATCC_TEST=OFF -DFLATCC_REFLECTION=OFF
-    # See above comment about POSITION_INDEPENDENT_CODE.
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-    -B${CMAKE_BINARY_DIR}/_host_build
+
+  # lint_cmake: -readability/wonkycase
+  ExternalProject_Add(
+    flatcc_project
+    PREFIX ${CMAKE_BINARY_DIR}/_host_build
+    SOURCE_DIR ${_flatcc_source_dir}
+    BINARY_DIR ${CMAKE_BINARY_DIR}/_host_build
+    CMAKE_CACHE_ARGS
+      -DFLATCC_TEST:BOOL=OFF -DFLATCC_REFLECTION:BOOL=OFF
+      # See above comment about POSITION_INDEPENDENT_CODE.
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+    INSTALL_COMMAND "" # Prevent the install step
   )
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}/_host_build
-  )
-  set(_etdump_schema_gen_dep)
-  # TODO(dbort): flatcc installs its files directly in its source directory
-  # instead of under CMAKE_BINARY_DIR, and it has no options to avoid doing
-  # this. We build flatcc twice in the executorch build: once to get the
-  # `flatcc` host commandline tool, and once to get the (potentially
-  # cross-compiled) target runtime library. The host build will put its outputs
-  # in the source tree, making the cross-compiling target build think that the
-  # outputs have already been built. It will then try to link against the
-  # host-architecture libraries, failing when cross-compiling. To work around
-  # this, delete the host outputs after running this command (which only runs
-  # when setting up the cmake files, not when actually building). This leaves
-  # room for the target build to put its own files in the source tree. We should
-  # try to remove this hack, ideally by submitting an upstream PR that adds an
-  # option to change the installation location.
-  set(_etdump_schema_cleanup_paths ${_flatcc_source_dir}/bin/*
-                                   ${_flatcc_source_dir}/lib/*
-  )
+  set(_etdump_schema_gen_dep flatcc_project)
 else()
   # If we're not cross-compiling, we can just use the plain commandline target.
   set(_etdump_schema_gen_dep flatcc_cli)
-  set(_etdump_schema_cleanup_paths "")
 endif()
 
 set(_etdump_schema__outputs)
@@ -148,10 +134,41 @@ add_library(
   bundled_program_schema INTERFACE ${_bundled_program_schema__outputs}
 )
 
+# Ensure the host tool is built before the main project
+add_dependencies(etdump_schema flatcc_cli)
+
 file(MAKE_DIRECTORY ${_program_schema__include_dir}/executorch/sdk/etdump)
 file(MAKE_DIRECTORY
      ${_program_schema__include_dir}/executorch/sdk/bundled_program
 )
+
+if(EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT)
+  # If we cross-compiling, we need to use the version of the commandline tool
+  # built for the host.
+  set(_etdump_schema_gen_dep flatcc_project)
+
+  # TODO(dbort): flatcc installs its files directly in its source directory
+  # instead of under CMAKE_BINARY_DIR, and it has no options to avoid doing
+  # this. We build flatcc twice in the executorch build: once to get the
+  # `flatcc` host commandline tool, and once to get the (potentially
+  # cross-compiled) target runtime library. The host build will put its outputs
+  # in the source tree, making the cross-compiling target build think that the
+  # outputs have already been built. It will then try to link against the
+  # host-architecture libraries, failing when cross-compiling. To work around
+  # this, delete the host outputs after running this command (which only runs
+  # when setting up the cmake files, not when actually building). This leaves
+  # room for the target build to put its own files in the source tree. We should
+  # try to remove this hack, ideally by submitting an upstream PR that adds an
+  # option to change the installation location.
+  set(_etdump_schema_cleanup_paths ${_flatcc_source_dir}/bin/*
+                                   ${_flatcc_source_dir}/lib/*
+  )
+else()
+  # If we're not cross-compiling we can use the plain commandline target, and we
+  # don't need to delete any files.
+  set(_etdump_schema_gen_dep flatcc_cli)
+  set(_etdump_schema_cleanup_paths "")
+endif()
 
 add_custom_command(
   OUTPUT ${_etdump_schema__outputs}
@@ -163,8 +180,10 @@ add_custom_command(
     ${_program_schema__include_dir}/executorch/sdk/etdump
     ${_etdump_schema__srcs}
   COMMAND rm -f ${_etdump_schema_cleanup_paths}
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/sdk
   DEPENDS ${_etdump_schema_gen_dep}
   COMMENT "Generating etdump headers"
+  VERBATIM
 )
 
 add_library(


### PR DESCRIPTION
This reverts commit 15815dd5cd58b6d250dc98f8a4b121c77c44dbed, which broke the test-coreml-delegate job. Details in https://github.com/pytorch/executorch/pull/4312#issuecomment-2266207512