### PR TITLE
[executorch] Suppress -Wglobal-constructors for llama example main

### DIFF
--- a/examples/models/llama2/targets.bzl
+++ b/examples/models/llama2/targets.bzl
@@ -10,6 +10,7 @@ def define_common_targets():
                 srcs = [
                     "main.cpp",
                 ],
+                compiler_flags = ["-Wno-global-constructors"],
                 preprocessor_flags = [
                     "-DUSE_ATEN_LIB",
                 ] if aten else [],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4547

Otherwise it can't be built for Mac internally because it uses gflags.

Differential Revision: [D60696277](https://our.internmc.facebook.com/intern/diff/D60696277/)