### PR TITLE
Skip computing capacity for dynamic tensor.

### DIFF
--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -47,9 +47,12 @@ TensorImpl::TensorImpl(
       data_(data),
       dim_(dim),
       numel_(compute_numel(sizes, dim)),
-      capacity_(numel_ * elementSize(type)),
+      numel_bound_(numel_),
       type_(type),
-      shape_dynamism_(dynamism) {}
+      shape_dynamism_(dynamism) {
+  ET_CHECK_MSG(
+      isValid(type_), "Invalid type %" PRId8, static_cast<int8_t>(type_));
+}
 
 size_t TensorImpl::nbytes() const {
   return numel_ * elementSize(type_);
@@ -96,22 +99,19 @@ Error TensorImpl::internal_resize_contiguous(ArrayRef<SizesType> new_sizes) {
     return Error::Ok;
   }
 
-  auto new_numel = compute_numel(new_sizes.data(), dim_);
+  const auto new_numel = compute_numel(new_sizes.data(), dim_);
 
-  // Upper bounded tensors can be reshaped but not beyond upper bound
+  // Bounded tensors can be reshaped, but not beyond the upper bound.
   if (shape_dynamism_ == TensorShapeDynamism::DYNAMIC_BOUND ||
-      // TODO(T175194371): Unbounded tensor resizing is not yet supported: treat
-      // them as upper-bounded.
+      // TODO(T175194371): Unbounded dynamic tensor resizing is not yet
+      // supported: treat them as upper-bounded.
       shape_dynamism_ == TensorShapeDynamism::DYNAMIC_UNBOUND) {
-    auto new_nbytes = new_numel * elementSize(type_);
     ET_CHECK_OR_RETURN_ERROR(
-        new_nbytes <= capacity_,
+        new_numel <= numel_bound_,
         NotSupported,
-        "Attempted to resize a tensor with dynamism %d "
-        "to %zu which is beyond its capacity %zu",
-        (int)shape_dynamism_,
-        new_nbytes,
-        capacity_);
+        "Attempted to resize a bounded tensor with capacity of %zu elements to %zu elements.",
+        new_numel,
+        numel_bound_);
   }
 
   // Copy sizes over

--- a/runtime/core/portable_type/tensor_impl.h
+++ b/runtime/core/portable_type/tensor_impl.h
@@ -241,8 +241,9 @@ class TensorImpl {
   /// Number of elements in the tensor.
   ssize_t numel_;
 
-  /// Underlying capacity of data_ in bytes. Used when resizing up and down.
-  size_t capacity_;
+  /// Maximum number of elements in the bounded tensor. Used when resizing up
+  /// and down.
+  size_t numel_bound_;
 
   /// Scalar type (int, float, bool, etc) of the tensor data.
   const ScalarType type_;


### PR DESCRIPTION
Summary: Keeping the original number of elements is enough, since the element size is constant.

Differential Revision: D60854862
