### PR TITLE
Skip checking for dim order and strindes if those are not provided explicitly.

### DIFF
--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -100,17 +100,11 @@ Error TensorImpl::internal_resize_contiguous(ArrayRef<SizesType> new_sizes) {
           "Attempted to resize a bounded tensor with capacity of %zu elements to %zu elements.",
           new_numel,
           numel_bound_);
-      ET_CHECK_OR_RETURN_ERROR(
-          strides_ != nullptr,
-          Internal,
-          "Strides cannot be nullptr for resize");
-      ET_CHECK_OR_RETURN_ERROR(
-          dim_order_ != nullptr,
-          Internal,
-          "Dim order cannot be nullptr for resize");
-      ET_CHECK_OK_OR_RETURN_ERROR(
-          dim_order_to_stride(new_sizes.data(), dim_order_, dim_, strides_));
 
+      if (strides_ && dim_order_) {
+        ET_CHECK_OK_OR_RETURN_ERROR(
+            dim_order_to_stride(new_sizes.data(), dim_order_, dim_, strides_));
+      }
       numel_ = new_numel;
       std::copy(new_sizes.begin(), new_sizes.end(), sizes_);
     }

--- a/runtime/core/portable_type/test/tensor_impl_test.cpp
+++ b/runtime/core/portable_type/test/tensor_impl_test.cpp
@@ -267,6 +267,93 @@ TEST_F(TensorImplTest, TestSetSizesContigUnbounded) {
   EXPECT_NE(err, Error::Ok);
 }
 
+TEST_F(TensorImplTest, TestDynamicTensorNoStridesDimOrder) {
+  SizesType sizes[3] = {2, 3, 4};
+  float data[24] = {0};
+  TensorImpl t(
+      ScalarType::Float,
+      3,
+      sizes,
+      data,
+      nullptr,
+      nullptr,
+      TensorShapeDynamism::DYNAMIC_BOUND);
+
+  EXPECT_EQ(t.dim(), 3);
+  EXPECT_EQ(t.numel(), 24);
+  EXPECT_EQ(t.nbytes(), 24 * sizeof(float));
+
+  SizesType new_sizes[3] = {3, 2, 4};
+  Error err = resize_tensor_impl(&t, {new_sizes, 3});
+  EXPECT_EQ(err, Error::Ok);
+  EXPECT_EQ(t.dim(), 3);
+  EXPECT_EQ(t.size(0), 3);
+  EXPECT_EQ(t.size(1), 2);
+  EXPECT_EQ(t.size(2), 4);
+  EXPECT_EQ(t.numel(), 3 * 2 * 4);
+
+  const float* y = t.data<float>();
+  EXPECT_EQ(y, data);
+}
+
+TEST_F(TensorImplTest, TestDynamicTensorNoStridesDimOrderResizeDown) {
+  SizesType sizes[3] = {4, 4, 4};
+  float data[64] = {0};
+  TensorImpl t(
+      ScalarType::Float,
+      3,
+      sizes,
+      data,
+      nullptr,
+      nullptr,
+      TensorShapeDynamism::DYNAMIC_BOUND);
+
+  EXPECT_EQ(t.dim(), 3);
+  EXPECT_EQ(t.numel(), 64);
+  EXPECT_EQ(t.nbytes(), 64 * sizeof(float));
+
+  SizesType new_sizes[3] = {2, 2, 2};
+  Error err = resize_tensor_impl(&t, {new_sizes, 3});
+  EXPECT_EQ(err, Error::Ok);
+  EXPECT_EQ(t.dim(), 3);
+  EXPECT_EQ(t.size(0), 2);
+  EXPECT_EQ(t.size(1), 2);
+  EXPECT_EQ(t.size(2), 2);
+  EXPECT_EQ(t.numel(), 2 * 2 * 2);
+
+  const float* y = t.data<float>();
+  EXPECT_EQ(y, data);
+}
+
+TEST_F(TensorImplTest, TestDynamicTensorNoStridesDimOrderResizeZeroDim) {
+  SizesType sizes[3] = {4, 4, 4};
+  float data[64] = {0};
+  TensorImpl t(
+      ScalarType::Float,
+      3,
+      sizes,
+      data,
+      nullptr,
+      nullptr,
+      TensorShapeDynamism::DYNAMIC_BOUND);
+
+  EXPECT_EQ(t.dim(), 3);
+  EXPECT_EQ(t.numel(), 64);
+  EXPECT_EQ(t.nbytes(), 64 * sizeof(float));
+
+  SizesType new_sizes[3] = {0, 4, 4};
+  Error err = resize_tensor_impl(&t, {new_sizes, 3});
+  EXPECT_EQ(err, Error::Ok);
+  EXPECT_EQ(t.dim(), 3);
+  EXPECT_EQ(t.size(0), 0);
+  EXPECT_EQ(t.size(1), 4);
+  EXPECT_EQ(t.size(2), 4);
+  EXPECT_EQ(t.numel(), 0);
+
+  const float* y = t.data<float>();
+  EXPECT_EQ(y, data);
+}
+
 TEST_F(TensorImplTest, TestWriteRead) {
   SizesType sizes[1] = {1};
   DimOrderType dim_order[1] = {0};


### PR DESCRIPTION
Summary: Those can be derived from the sizes array, no need to require that users store and provide them.

Differential Revision: D60854859
