### PR TITLE
[MPS] Add support for flatbuffer serialization > 4GB

### DIFF
--- a/backends/apple/mps/CMakeLists.txt
+++ b/backends/apple/mps/CMakeLists.txt
@@ -69,7 +69,7 @@ add_library(mpsdelegate ${_mps_backend__srcs})
 find_library(FOUNDATION_FRAMEWORK Foundation)
 find_library(METAL_FRAMEWORK Metal)
 find_library(MPS_FRAMEWORK MetalPerformanceShaders)
-find_library(MPS_GRAPG_FRAMEWORK MetalPerformanceShadersGraph)
+find_library(MPS_GRAPH_FRAMEWORK MetalPerformanceShadersGraph)
 
 target_link_libraries(
   mpsdelegate
@@ -79,7 +79,7 @@ target_link_libraries(
           ${FOUNDATION_FRAMEWORK}
           ${METAL_FRAMEWORK}
           ${MPS_FRAMEWORK}
-          ${MPS_GRAPG_FRAMEWORK}
+          ${MPS_GRAPH_FRAMEWORK}
 )
 
 target_link_options_shared_lib(mpsdelegate)

--- a/backends/apple/mps/mps_preprocess.py
+++ b/backends/apple/mps/mps_preprocess.py
@@ -2,9 +2,8 @@
 #  Copyright (c) 2023 Apple Inc. All rights reserved.
 #  Provided subject to the LICENSE file in the top level directory.
 #
-
 import logging
-from typing import Dict, final, List
+from typing import ClassVar, Dict, final, List, Tuple
 
 import torch
 
@@ -16,6 +15,8 @@ from executorch.backends.apple.mps.operators.node_visitor import (
 )
 
 from executorch.backends.apple.mps.serialization.mps_graph_schema import (
+    Buffer,
+    DataSegment,
     MPSGraph,
     MPSTensor,
     OpType,
@@ -25,6 +26,7 @@ from executorch.backends.apple.mps.serialization.mps_graph_serialize import (
     convert_to_flatbuffer,
 )
 from executorch.backends.apple.mps.utils.mps_utils import is_parameter
+from executorch.exir._serialize._program import Cord
 
 from executorch.exir.backend.backend_details import (
     BackendDetails,
@@ -39,6 +41,29 @@ logging.basicConfig(level=logging.INFO, format=FORMAT)
 
 @final
 class MPSBackend(BackendDetails):
+    @staticmethod
+    def slice_len_max(s):
+        assert s.start is not None
+        assert s.stop is not None
+        step = 1
+        if s.step is not None:
+            step = s.step
+        return max((s.stop - s.start) // step, 1)
+
+    MAGIC_IX: ClassVar[slice] = slice(4, 8)
+    DATA_SEGMENT_OFFSET_IX: ClassVar[slice] = slice(8, 16)
+    DATA_SEGMENT_SIZE_IX: ClassVar[slice] = slice(16, 24)
+
+    # magic bytes that should be at the beginning of the header
+    EXPECTED_MAGIC: ClassVar[bytes] = b"MP00"
+    # The length of the header in bytes
+    EXPECTED_LENGTH: ClassVar[int] = (
+        4
+        + slice_len_max(MAGIC_IX)
+        + slice_len_max(DATA_SEGMENT_OFFSET_IX)
+        + slice_len_max(DATA_SEGMENT_SIZE_IX)
+    )
+
     @staticmethod
     def preprocess(
         edge_program: ExportedProgram,
@@ -67,6 +92,7 @@ class MPSBackend(BackendDetails):
             output_ids=[],
             constant_ids=[],
             graph_type=OpType.mps_graph,
+            constant_segment=DataSegment(0, 0),
         )
 
         convert_model_to_fp16 = True
@@ -100,10 +126,44 @@ class MPSBackend(BackendDetails):
             else:
                 op_handler[node.op](edge_program, node_visitors, node, mps_graph)
 
+        segment_data, mps_graph = _extract_constant_segment(mps_graph)
+
+        # Add to aggregate segments cord with padding.
+        padding_length = _padding_required(len(segment_data), 16)
+        if padding_length > 0:
+            segment_data.append(b"\x00" * padding_length)
+
+        # Combine mps_graph with segment data
+        combined = Cord()
+        graph_bytes = convert_to_flatbuffer(mps_graph)
+
+        data_segment_offset: int = MPSBackend.EXPECTED_LENGTH
+        data_segment_offset = data_segment_offset + len(graph_bytes)
+
+        graph_padding_length = _padding_required(data_segment_offset, 16)
+        data_segment_offset = data_segment_offset + graph_padding_length
+        data_segment_size = len(segment_data)
+
+        data: bytes = (
+            b"\x00\x00\x00\x00"
+            + MPSBackend.EXPECTED_MAGIC
+            + data_segment_offset.to_bytes(8, byteorder="little")
+            + data_segment_size.to_bytes(8, byteorder="little")
+        )
+        assert len(data) == MPSBackend.EXPECTED_LENGTH
+
+        combined.append(data)
+        combined.append(graph_bytes)
+
+        if graph_padding_length > 0:
+            combined.append(b"\x00" * graph_padding_length)
+        # Append the segment data to the end of the mps graph
+        combined.append(segment_data)
+
         if logging.DEBUG >= logging.root.level:
             pretty_print(mps_graph)
 
-        return PreprocessResult(processed_bytes=convert_to_flatbuffer(mps_graph))
+        return PreprocessResult(processed_bytes=bytes(combined))
 
     @staticmethod
     def handle_call_function(
@@ -164,12 +224,42 @@ class MPSBackend(BackendDetails):
         pass
 
 
+def _padding_required(offset: int, alignment: int) -> int:
+    """Returns the padding required to align `offset` to `alignment`."""
+    remainder: int = offset % alignment
+    if remainder != 0:
+        return alignment - remainder
+    return 0
+
+
+def _extract_constant_segment(mps_graph: MPSGraph) -> Tuple[Cord, MPSGraph]:
+    """Extracts the constant segment from the MPSGraph and returns the updated MPSGraph along with the segment data."""
+    # Note that the beginning of the segment data is not aligned. Need to handle out of this call.
+    segment_data = Cord()
+    offset = 0
+    for i in range(len(mps_graph.mps_values)):
+        tensor = mps_graph.mps_values[i]
+        if tensor.constant_buffer_size > 0:
+            # Notice that buffer is already force aligned so we don't need to pad it
+            segment_data.append(tensor.constant_buffer.storage)
+
+            # Reset buffer to empty
+            tensor.constant_buffer = Buffer(storage=b"")
+            # Update segment offset
+            tensor.segment_offset = offset
+            offset += tensor.constant_buffer_size
+
+    return segment_data, mps_graph
+
+
 def tensor_to_str(mps_tensor: MPSTensor):
     tensor_str = "MPSTensor("
     tensor_str += "datatype=" + str(mps_tensor.datatype) + ", "
     tensor_str += "num_dims=" + str(mps_tensor.num_dims) + ", "
     tensor_str += "dims=" + str(mps_tensor.dims) + ", "
-    tensor_str += "constant_buffer_size=" + str(mps_tensor.constant_buffer_size)
+    tensor_str += "constant_buffer=" + str(mps_tensor.constant_buffer) + ", "
+    tensor_str += "constant_buffer_size=" + str(mps_tensor.constant_buffer_size) + ", "
+    tensor_str += "segment_offset=" + str(mps_tensor.segment_offset)
     tensor_str += ")"
 
     return tensor_str
@@ -193,3 +283,4 @@ def pretty_print(mps_graph: MPSGraph):
     logging.info(" Output ids:")
     for out_id in mps_graph.output_ids:
         logging.info(f"   {out_id}")
+    logging.info(f" Constant segment: {mps_graph.constant_segment}")

--- a/backends/apple/mps/runtime/MPSCompiler.mm
+++ b/backends/apple/mps/runtime/MPSCompiler.mm
@@ -43,7 +43,7 @@ __ET_NODISCARD Error MPSCompiler::compileModel(
   Error err = Error::Ok;
 
   std::unique_ptr<MPSGraphBuilder> mpsGraphBuilder(
-    new MPSGraphBuilder(buffer_pointer, executor->_mpsGraphTensorToId));
+    new MPSGraphBuilder(buffer_pointer, num_bytes, executor->_mpsGraphTensorToId));
   err = mpsGraphBuilder->compileModel();
   ET_CHECK_OR_RETURN_ERROR(
     err == Error::Ok, Internal, "Failed to construct the MPS graph object");

--- a/backends/apple/mps/runtime/MPSDelegateHeader.h
+++ b/backends/apple/mps/runtime/MPSDelegateHeader.h
@@ -1,0 +1,113 @@
+//
+//  Copyright (c) 2024 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#pragma once
+
+#include <executorch/runtime/core/result.h>
+
+namespace torch {
+namespace executor {
+namespace mps {
+namespace delegate {
+
+/**
+ * MPS-header that is embedded before the flatbuffer payload
+ *
+ */
+struct MPSDelegateHeader {
+  /**
+   * The minimum size of the MPSDelegateHeader. The caller should provide at
+   * least this many bytes of the head of the serialized MPS Data
+   */
+  static constexpr size_t kMinSize = 30;
+
+  /**
+   * The magic offset. This offset is the same as the offset for flatbuffer
+   * header so we will be able to check if the header is is either the
+   * flatbuffer head or the wrapper header we introduce here
+   */
+  static constexpr size_t kMagicOffset = 4;
+
+  /**
+   * The magic bytes that identify the header.
+   *
+   * This is the canonical definition of the expected value. If the header
+   * layout ever changes in a compatibility-breaking way, increment the digits
+   * in the magic. But, doing so will prevent older binaries from recognizing
+   * the presence of the header. The compatibility-preserving way to make
+   * changes is to increase the header's length field and add new fields at the
+   * end.
+   */
+  static constexpr size_t kMagicSize = 4;
+  static constexpr char kMagic[kMagicSize] = {'M', 'P', '0', '0'};
+
+  /**
+   * The size in bytes of the header length. We store 2 bytes for the header
+   * length
+   */
+  static constexpr size_t kHeaderLengthSize = 2;
+
+  /**
+   * The expected location of the header length field relative to the beginning
+   * of the header.
+   */
+  static constexpr size_t kHeaderLengthOffset =
+      MPSDelegateHeader::kMagicOffset + MPSDelegateHeader::kMagicSize;
+
+  /*
+   * The expected location of the constant data offset field relative to the
+   * beginning of the header.
+   */
+  static constexpr size_t kConstantDataSegmentOffset = kHeaderLengthOffset;
+
+  /*
+   * The expected location of the constant data size field relative to the
+   * beginning of the header.
+   */
+  static constexpr size_t kConstantDataSizeOffset =
+      kConstantDataSegmentOffset + sizeof(uint64_t);
+
+  /**
+   * The expected location of the flatbuffer data offset field relative to the
+   * beginning of the header.
+   */
+  static constexpr size_t kFlatbufferDataOffsetOffset =
+      kConstantDataSizeOffset + sizeof(uint64_t);
+
+  /**
+   * Look for and parse an ExtendedHeader in the provided data.
+   *
+   * @param[in] data The contents of the beginning of the serialized binary
+   *     Program data, starting at offset 0 (i.e., the head of the file).
+   * @param[in] size Length of `data` in bytes.
+   *
+   * @returns an MPSHeader if the header was found and is valid. Returns an
+   *     error if size was too short, if the header was not found, or if the
+   *     header appeared to be corrupt.
+   */
+  static Result<MPSDelegateHeader> Parse(const void* data, size_t size);
+
+  /**
+   * The offset in bytes to the beginning of the constant data.
+   */
+  uint64_t constant_data_offset;
+  /**
+   * The size in bytes of the constant data.
+   */
+  uint64_t constant_data_size;
+  /**
+   * The offset in bytes to the beginning of the flatbuffer data.
+   */
+  uint64_t flatbuffer_offset;
+  /**
+   * The size in bytes of the flatbuffer data.
+   */
+  uint64_t flatbuffer_size;
+};
+
+} // namespace delegate
+} // namespace mps
+} // namespace executor
+} // namespace torch

--- a/backends/apple/mps/runtime/MPSDelegateHeader.mm
+++ b/backends/apple/mps/runtime/MPSDelegateHeader.mm
@@ -1,0 +1,53 @@
+//
+//  Copyright (c) 2024 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include <executorch/backends/apple/mps/runtime/MPSDelegateHeader.h>
+
+#include <cstring>
+
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/result.h>
+
+namespace torch {
+namespace executor {
+namespace mps {
+namespace delegate {
+
+/// Interprets the 8 bytes at `data` as a little-endian uint64_t.
+uint64_t getUInt64LE(const uint8_t* data) {
+  return (uint64_t)data[0] | ((uint64_t)data[1] << 8) |
+      ((uint64_t)data[2] << 16) | ((uint64_t)data[3] << 24) |
+      ((uint64_t)data[4] << 32) | ((uint64_t)data[5] << 40) |
+      ((uint64_t)data[6] << 48) | ((uint64_t)data[7] << 56);
+}
+
+Result<MPSDelegateHeader> MPSDelegateHeader::Parse(const void* data, size_t size) {
+  const uint8_t* header_data = (const uint8_t*)data;
+
+  if (size < MPSDelegateHeader::kMinSize) {
+    return Error::InvalidArgument;
+  }
+
+  const uint8_t* magic_start = header_data + MPSDelegateHeader::kMagicOffset;
+  if (std::memcmp(magic_start, MPSDelegateHeader::kMagic, MPSDelegateHeader::kMagicSize) != 0) {
+    return Error::NotFound;
+  }
+
+  uint64_t constant_data_offset = getUInt64LE(header_data + MPSDelegateHeader::kConstantDataSegmentOffset);
+  uint64_t constant_data_size = getUInt64LE(header_data + MPSDelegateHeader::kConstantDataSizeOffset);
+  uint64_t flatbuffer_offset = MPSDelegateHeader::kFlatbufferDataOffsetOffset;
+  uint64_t flatbuffer_size = size - flatbuffer_offset;
+
+  return MPSDelegateHeader{
+      constant_data_offset,
+      constant_data_size,
+      flatbuffer_offset,
+      flatbuffer_size};
+}
+
+} // namespace delegate
+} // namespace mps
+} // namespace executor
+} // namespace torch

--- a/backends/apple/mps/runtime/MPSGraphBuilder.h
+++ b/backends/apple/mps/runtime/MPSGraphBuilder.h
@@ -40,7 +40,8 @@ using NodePtr = const mpsgraph::MPSNode *;
  */
 class MPSGraphBuilder {
 public:
-  MPSGraphBuilder(const void *buffer_pointer, std::unordered_map<MPSGraphTensor *, int32_t> &mpsGraphTensorToId);
+  MPSGraphBuilder(const void *buffer_pointer, size_t num_bytes,
+                  std::unordered_map<MPSGraphTensor *, int32_t> &mpsGraphTensorToId);
   ~MPSGraphBuilder() = default;
 
   Error compileModel();
@@ -178,12 +179,15 @@ private:
   const mpsgraph::MPSGraph *_flatBufferGraph;
   // FlatBuffer raw bytes of the serialized MPS model.
   const void *_buffer_pointer;
+  size_t _num_bytes;
 
   bool _metal_kernel;
   MPSGraph *_mpsGraph;
   MPSGraphExecutable *_mpsGraphExecutable;
   NSMutableDictionary<MPSGraphTensor *, MPSGraphShapedType *> *_feeds;
   NSMutableArray<MPSGraphTensor *> *_targetTensors;
+
+  const uint8_t *_constant_data_ptr;
 };
 
 #undef _DEFINE_MPS_OP

--- a/backends/apple/mps/runtime/MPSGraphBuilder.mm
+++ b/backends/apple/mps/runtime/MPSGraphBuilder.mm
@@ -5,13 +5,19 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 #include <executorch/backends/apple/mps/runtime/MPSDevice.h>
+#include <executorch/backends/apple/mps/runtime/MPSDelegateHeader.h>
 
 namespace torch {
 namespace executor {
 namespace mps {
 namespace delegate {
 
-MPSGraphBuilder::MPSGraphBuilder(const void* buffer_pointer, std::unordered_map<MPSGraphTensor*, int32_t>& mpsGraphTensorToId) : _mpsGraphTensorToId(mpsGraphTensorToId), _buffer_pointer(buffer_pointer) {
+MPSGraphBuilder::MPSGraphBuilder(
+  const void* buffer_pointer,
+  size_t num_bytes,
+  std::unordered_map<MPSGraphTensor*, int32_t>& mpsGraphTensorToId) :
+    _mpsGraphTensorToId(mpsGraphTensorToId), _buffer_pointer(buffer_pointer), _num_bytes(num_bytes) {
+
   _mpsGraph = [MPSGraph new];
   _feeds = [NSMutableDictionary dictionary];
   _targetTensors = [NSMutableArray new];
@@ -24,15 +30,36 @@ Error
 MPSGraphBuilder::compileModel() {
   Error err = Error::Ok;
 
-  ET_CHECK(_buffer_pointer != nullptr);
+  Result<MPSDelegateHeader> header = MPSDelegateHeader::Parse(_buffer_pointer, _num_bytes);
+  const uint8_t* flatbuffer_data_ptr = nullptr;
+
+  if (header.ok()) {
+    flatbuffer_data_ptr = reinterpret_cast<const uint8_t*>(_buffer_pointer) +
+        header->flatbuffer_offset;
+    _constant_data_ptr = reinterpret_cast<const uint8_t*>(_buffer_pointer) +
+        header->constant_data_offset;
+  } else if (header.error() == Error::NotFound) {
+    ET_LOG(
+        Error,
+        "MPSDelegateHeader version mismatch: '%.4s' != expected '%.4s'",
+        // Header Magic and FlatbufferIdentifier are same offset and size
+        flatbuffers::GetBufferIdentifier(_buffer_pointer),
+        MPSDelegateHeader::kMagic);
+    return header.error();
+  } else {
+    ET_LOG(Error, "MPSDelegateHeader may be corrupt");
+    return header.error();
+  }
+
+  ET_CHECK(flatbuffer_data_ptr != nullptr);
   ET_CHECK_OR_RETURN_ERROR(
-    mpsgraph::MPSGraphBufferHasIdentifier(_buffer_pointer),
+    mpsgraph::MPSGraphBufferHasIdentifier(flatbuffer_data_ptr),
     DelegateInvalidCompatibility,
     "MPS Delegate Serialization Format version identifier '%.4s' != expected '%.4s'",
-    flatbuffers::GetBufferIdentifier(_buffer_pointer),
+    flatbuffers::GetBufferIdentifier(flatbuffer_data_ptr),
     mpsgraph::MPSGraphIdentifier());
 
-  _flatBufferGraph = mpsgraph::GetMPSGraph(_buffer_pointer);
+  _flatBufferGraph = mpsgraph::GetMPSGraph(flatbuffer_data_ptr);
   switch (_flatBufferGraph->graph_type()) {
     case mpsgraph::OpType::metal_kernel:
     {

--- a/backends/apple/mps/runtime/operations/OperationUtils.mm
+++ b/backends/apple/mps/runtime/operations/OperationUtils.mm
@@ -88,10 +88,11 @@ MPSGraphBuilder::numel(const flatbuffers::Vector<int32_t>* shape) {
 NSData*
 MPSGraphBuilder::getConstantData(int32_t id) {
   TensorPtr mpsTensor = _flatBufferGraph->mps_values()->Get(id);
-  int32_t constantBufferSize = mpsTensor->constant_buffer_size();
-  const unsigned char* constantBuffer = mpsTensor->constant_buffer()->storage()->data();
+  uint64_t constantBufferSize = mpsTensor->constant_buffer_size();
+  uint64_t segmentOffset = mpsTensor->segment_offset();
+  const unsigned char* constantBuffer = _constant_data_ptr + segmentOffset;
   ET_CHECK_MSG(constantBufferSize > 0 && constantBuffer != nullptr, "[ERROR] Invalid constant buffer");
-  return [[NSData alloc] initWithBytes:constantBuffer
+  return [[NSData alloc] initWithBytesNoCopy:(void*)constantBuffer
                                 length:constantBufferSize];
 }
 

--- a/backends/apple/mps/serialization/mps_graph_schema.py
+++ b/backends/apple/mps/serialization/mps_graph_schema.py
@@ -763,7 +763,14 @@ class MPSTensor:
     num_dims: int
     dims: List[int]
     constant_buffer_size: int
-    constant_buffer: Buffer
+    constant_buffer: Buffer  # deprecated
+    segment_offset: int = 0
+
+
+@dataclass
+class DataSegment:
+    offset: int
+    size: int
 
 
 @dataclass
@@ -775,3 +782,4 @@ class MPSGraph:
     output_ids: List[int]
     constant_ids: List[int]
     graph_type: OpType
+    constant_segment: DataSegment

--- a/backends/apple/mps/serialization/schema.fbs
+++ b/backends/apple/mps/serialization/schema.fbs
@@ -450,6 +450,7 @@ table MPSNode {
 
 // taken from executorch
 // Data buffer abstraction.
+// Deprecated
 table Buffer {
   storage:[ubyte] (force_align: 16);
 }
@@ -458,8 +459,21 @@ table MPSTensor {
   datatype:MPSDataType;
   num_dims:int;
   dims:[int];
-  constant_buffer_size:int;
-  constant_buffer:Buffer;
+  constant_buffer_size:uint64;
+  constant_buffer:Buffer; // deprecated
+  segment_offset:uint64;
+}
+
+table DataSegment {
+  // Segment offsets are relative to the segment base offset provided in
+  // the extended file header. Segments will typically be aligned in a
+  // way to make it possible to use mmap() to load them.
+  offset: uint64;
+
+  // The size in bytes of valid data starting at the offset. The segment
+  // data may be followed by padding before the segment that follows it,
+  // to make it easier to use mmap().
+  size: uint64;
 }
 
 table MPSGraph {
@@ -473,6 +487,8 @@ table MPSGraph {
   constant_ids:[int];
 
   graph_type:OpType;
+
+  constant_segment:DataSegment;
 }
 
 root_type MPSGraph;

--- a/examples/apple/mps/CMakeLists.txt
+++ b/examples/apple/mps/CMakeLists.txt
@@ -107,6 +107,10 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*(iOS|ios\.toolchain)\.cmake$")
     set(FLATCC_LIB flatccrt)
   endif()
 
+  if(CMAKE_BUILD_TYPE MATCHES "Debug")
+    target_link_options(mps_executor_runner PUBLIC -fsanitize=undefined)
+  endif()
+
   target_link_libraries(
     mps_executor_runner
     bundled_program


### PR DESCRIPTION
Add support for serializing tensor weights > 4GB. 

This change mirrors https://github.com/pytorch/executorch/pull/1542 and https://github.com/pytorch/executorch/pull/1543 for the MPS delegate, which enables serialization of constant weight data outside the flatbuffer blob.

Final raw bytes packed in the PT file have the following format:
```
| MPS Header     |
| Flatbuffer     |
| Constant data  |
``` 
cc @cccclai, @larryliu0820, @kimishpatel 