### PR TITLE
don't deep copy program

### DIFF
--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -1200,7 +1200,7 @@ class EdgeProgramManager:
                 if name in partitioner.keys():
                     new_edge_programs[name] = to_backend(program, partitioner[name])
                 else:
-                    new_edge_programs[name] = copy.deepcopy(program)
+                    new_edge_programs[name] = program
 
         else:  # apply partitioner to every method
             for name, program in self._edge_programs.items():


### PR DESCRIPTION
Summary:
Lowering LLava Model to delegate complains at this point because of the deep copy. I remove it here.

If there is nothing is happening to this EP (no partitioner to delegate) then there is no need to deep copy in the first place

Differential Revision: D60156120
