### PR TITLE
Simplify prompt fields logic and added modelType selector

### DIFF
--- a/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/ModelType.java
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/ModelType.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.example.executorchllamademo;
+
+public enum ModelType {
+  LLAMA_3,
+  LLAMA_3_1,
+  LLAVA_1_5,
+}

--- a/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/PromptFormat.java
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/PromptFormat.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.example.executorchllamademo;
+
+public class PromptFormat {
+
+  public static final String SYSTEM_PLACEHOLDER = "{{ system_prompt }}";
+  public static final String USER_PLACEHOLDER = "{{ user_prompt }}";
+
+  public static String getSystemPromptTemplate(ModelType modelType) {
+    switch (modelType) {
+      case LLAMA_3:
+      case LLAMA_3_1:
+        return "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n"
+            + SYSTEM_PLACEHOLDER
+            + "<|eot_id|>";
+      case LLAVA_1_5:
+      default:
+        return SYSTEM_PLACEHOLDER;
+    }
+  }
+
+  public static String getUserPromptTemplate(ModelType modelType) {
+    switch (modelType) {
+      case LLAMA_3:
+      case LLAMA_3_1:
+        return "<|start_header_id|>user<|end_header_id|>\n"
+            + USER_PLACEHOLDER
+            + "<|eot_id|>\n"
+            + "<|start_header_id|>assistant<|end_header_id|>";
+      case LLAVA_1_5:
+      default:
+        return USER_PLACEHOLDER;
+    }
+  }
+}

--- a/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/SettingsFields.java
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/SettingsFields.java
@@ -9,17 +9,6 @@
 package com.example.executorchllamademo;
 
 public class SettingsFields {
-  private static final String SYSTEM_PLACEHOLDER = "{{ system_prompt }}";
-  private static final String USER_PLACEHOLDER = "{{ user_prompt }}";
-  private static String SYSTEM_PROMPT_TEMPLATE =
-      "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n"
-          + SYSTEM_PLACEHOLDER
-          + "<|eot_id|>";
-  private static String USER_PROMPT_TEMPLATE =
-      "<|start_header_id|>user<|end_header_id|>\n"
-          + USER_PLACEHOLDER
-          + "<|eot_id|>\n"
-          + "<|start_header_id|>assistant<|end_header_id|>";
 
   public String getModelFilePath() {
     return modelFilePath;
@@ -37,20 +26,25 @@ public class SettingsFields {
     return systemPrompt;
   }
 
+  public ModelType getModelType() {
+    return modelType;
+  }
+
   public String getUserPrompt() {
     return userPrompt;
   }
 
-  public String getEntirePrompt() {
-    return systemPrompt + userPrompt;
+  public String getFormattedSystemAndUserPrompt(String prompt) {
+    return getFormattedSystemPrompt() + getFormattedUserPrompt(prompt);
   }
 
-  public String getSystemPromptTemplate() {
-    return SYSTEM_PROMPT_TEMPLATE;
+  private String getFormattedSystemPrompt() {
+    return PromptFormat.getSystemPromptTemplate(modelType)
+        .replace(PromptFormat.SYSTEM_PLACEHOLDER, systemPrompt);
   }
 
-  public String getUserPromptTemplate() {
-    return USER_PROMPT_TEMPLATE;
+  private String getFormattedUserPrompt(String prompt) {
+    return userPrompt.replace(PromptFormat.USER_PLACEHOLDER, prompt);
   }
 
   public boolean getIsClearChatHistory() {
@@ -68,15 +62,19 @@ public class SettingsFields {
   private String userPrompt;
   private boolean isClearChatHistory;
   private boolean isLoadModel;
+  private ModelType modelType;
 
   public SettingsFields() {
+    ModelType DEFAULT_MODEL = ModelType.LLAMA_3;
+
     modelFilePath = "";
     tokenizerFilePath = "";
     temperature = SettingsActivity.TEMPERATURE_MIN_VALUE;
-    systemPrompt = SYSTEM_PROMPT_TEMPLATE;
-    userPrompt = USER_PROMPT_TEMPLATE;
+    systemPrompt = "";
+    userPrompt = PromptFormat.getUserPromptTemplate(DEFAULT_MODEL);
     isClearChatHistory = false;
     isLoadModel = false;
+    modelType = DEFAULT_MODEL;
   }
 
   public SettingsFields(SettingsFields settingsFields) {
@@ -87,6 +85,7 @@ public class SettingsFields {
     this.userPrompt = settingsFields.getUserPrompt();
     this.isClearChatHistory = settingsFields.getIsClearChatHistory();
     this.isLoadModel = settingsFields.getIsLoadModel();
+    this.modelType = settingsFields.modelType;
   }
 
   public void saveModelPath(String modelFilePath) {
@@ -95,6 +94,10 @@ public class SettingsFields {
 
   public void saveTokenizerPath(String tokenizerFilePath) {
     this.tokenizerFilePath = tokenizerFilePath;
+  }
+
+  public void saveModelType(ModelType modelType) {
+    this.modelType = modelType;
   }
 
   public void saveParameters(Double temperature) {
@@ -122,14 +125,7 @@ public class SettingsFields {
         && systemPrompt.equals(anotherSettingsFields.systemPrompt)
         && userPrompt.equals(anotherSettingsFields.userPrompt)
         && isClearChatHistory == anotherSettingsFields.isClearChatHistory
-        && isLoadModel == anotherSettingsFields.isLoadModel;
-  }
-
-  public boolean isSystemPromptChanged() {
-    return !systemPrompt.contains(SYSTEM_PLACEHOLDER);
-  }
-
-  public boolean isUserPromptChanged() {
-    return !userPrompt.contains(USER_PLACEHOLDER);
+        && isLoadModel == anotherSettingsFields.isLoadModel
+        && modelType == anotherSettingsFields.modelType;
   }
 }

--- a/examples/demo-apps/android/LlamaDemo/app/src/main/res/layout/activity_settings.xml
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/res/layout/activity_settings.xml
@@ -88,6 +88,37 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/modelTypeLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:gravity="center_vertical"
+                android:textSize="16sp"
+                android:text="Model Type" />
+
+            <TextView
+                android:id="@+id/modelTypeTextView"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center_vertical|end"
+                android:text="no model type selected" />
+
+            <ImageButton
+                android:id="@+id/modelTypeImageButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:background="#FFFFFF"
+                android:src="@drawable/outline_arrow_drop_down_circle_24" />
+
+        </LinearLayout>
         <Button
             android:id="@+id/loadModelButton"
             android:layout_width="wrap_content"
@@ -132,7 +163,7 @@
                 android:textAlignment="textEnd"
                 android:inputType="numberDecimal" />
         </LinearLayout>
-        
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -169,8 +200,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@drawable/prompt_shape"
-                android:textSize="16dp"
-                android:text = "SYS_INFO tags" />
+                android:textSize="16sp"
+                android:height="60dp"
+                android:hint="Type custom system prompt" />
         </LinearLayout>
 
         <LinearLayout
@@ -209,7 +241,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@drawable/prompt_shape"
-                android:textSize="16dp"
+                android:textSize="16sp"
                 android:text = "USER_PROMPT tags" />
         </LinearLayout>
 


### PR DESCRIPTION
Summary:
- Based on feedback, current system prompts field is a bit confusing. Hence I simplified it further and user can just type the plain system prompt they want, and internally upon calling generate() method, we will correctly append the system prompt token combinations based on ModelType that the user select.
- Added modelType fields and logic in Settings. This will be a centralized way for us to define and add more models support in the future. Why? Because different model might have different prompt format, etc. This structure will allow us to easily extend to various use cases.
- Removed the "instruct mode" logic in main activity. We will instead always allow users to type their prompt in main activity, and behind the scenes, we will append the right token format, etc before sending it to generate().

Differential Revision: D60840351
