### PR TITLE
[executorch] Migrate exec_aten utils to new namespace

### DIFF
--- a/extension/aten_util/make_aten_functor_from_et_functor.h
+++ b/extension/aten_util/make_aten_functor_from_et_functor.h
@@ -27,9 +27,6 @@
 namespace torch {
 namespace executor {
 
-class KernelRuntimeContext; // Forward declaration
-using RuntimeContext = KernelRuntimeContext; // TODO(T147221312): Remove
-
 // Map types from ETen to ATen.
 // This is used to convert ETen arguments into ATen.
 template <typename T>

--- a/runtime/backend/backend_execution_context.h
+++ b/runtime/backend/backend_execution_context.h
@@ -11,8 +11,8 @@
 #include <executorch/runtime/core/event_tracer.h>
 #include <executorch/runtime/core/memory_allocator.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 /**
  * BackendExecutionContext will be used to inject run time context.
@@ -57,5 +57,13 @@ class BackendExecutionContext final {
   MemoryAllocator* temp_allocator_ = nullptr;
 };
 
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::BackendExecutionContext;
 } // namespace executor
 } // namespace torch

--- a/runtime/backend/backend_init_context.h
+++ b/runtime/backend/backend_init_context.h
@@ -9,8 +9,8 @@
 #pragma once
 #include <executorch/runtime/core/memory_allocator.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 /**
  * BackendInitContext will be used to inject runtime info for to initialize
@@ -33,5 +33,13 @@ class BackendInitContext final {
   MemoryAllocator* runtime_allocator_ = nullptr;
 };
 
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::BackendInitContext;
 } // namespace executor
 } // namespace torch

--- a/runtime/backend/interface.cpp
+++ b/runtime/backend/interface.cpp
@@ -9,12 +9,12 @@
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/platform/assert.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 PyTorchBackendInterface::~PyTorchBackendInterface() {}
 
-// Task t128866626: Remove global static variables.
+// TODO(T128866626): Remove global static variables.
 // We want to be able to run multiple Executor instances
 // and having a global registration isn't a viable solution
 // in the long term.
@@ -56,5 +56,5 @@ Error BackendRegistry::register_backend(const Backend& backend) {
   return Error::Ok;
 }
 
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch

--- a/runtime/backend/interface.h
+++ b/runtime/backend/interface.h
@@ -20,8 +20,8 @@
 #include <executorch/runtime/core/result.h>
 #include <executorch/runtime/platform/compiler.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 struct SizedBuffer {
   void* buffer;
@@ -170,5 +170,21 @@ PyTorchBackendInterface* get_backend_class(const char* name);
  */
 ET_NODISCARD Error register_backend(const Backend& backend);
 
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::Backend;
+using ::executorch::runtime::BackendRegistry;
+using ::executorch::runtime::CompileSpec;
+using ::executorch::runtime::DelegateHandle;
+using ::executorch::runtime::get_backend_class;
+// using ::executorch::runtime::kRegistrationTableMaxSize;
+using ::executorch::runtime::PyTorchBackendInterface;
+using ::executorch::runtime::register_backend;
+using ::executorch::runtime::SizedBuffer;
 } // namespace executor
 } // namespace torch

--- a/runtime/core/exec_aten/testing_util/tensor_factory.h
+++ b/runtime/core/exec_aten/testing_util/tensor_factory.h
@@ -19,8 +19,8 @@
 #include <vector>
 #endif // !USE_ATEN_LIB
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 namespace testing {
 
 namespace internal {
@@ -269,7 +269,7 @@ class TensorFactory {
         data.size(),
         expected_numel);
 
-    Tensor t;
+    at::Tensor t;
     if (strides.empty()) {
       t = zeros(sizes);
     } else {
@@ -311,7 +311,7 @@ class TensorFactory {
         data.size(),
         expected_numel);
 
-    Tensor t;
+    at::Tensor t;
     if (dim_order.empty()) {
       t = zeros(sizes);
     } else {
@@ -417,7 +417,7 @@ class TensorFactory {
    * @return A new Tensor with the specified shape.
    */
   at::Tensor zeros_like(
-      const Tensor& input,
+      const at::Tensor& input,
       ET_UNUSED TensorShapeDynamism dynamism =
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     std::vector<int64_t> sizes64 = {input.sizes().begin(), input.sizes().end()};
@@ -432,7 +432,7 @@ class TensorFactory {
    * @return A new Tensor with the specified shape.
    */
   at::Tensor ones_like(
-      const Tensor& input,
+      const at::Tensor& input,
       ET_UNUSED TensorShapeDynamism dynamism =
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     std::vector<int64_t> sizes64 = {input.sizes().begin(), input.sizes().end()};
@@ -564,7 +564,8 @@ namespace internal {
 // values while using the defaults for everything else.
 template <torch::executor::ScalarType DTYPE>
 struct ScalarTypeToCppTypeWrapper {
-  using ctype = typename torch::executor::ScalarTypeToCppType<DTYPE>::type;
+  using ctype =
+      typename ::executorch::runtime::ScalarTypeToCppType<DTYPE>::type;
 };
 
 // Use a C type of `uint8_t` instead of `bool`. The C type will be used to
@@ -830,7 +831,7 @@ class TensorFactory {
    * @return A new Tensor with the specified shape.
    */
   torch::executor::Tensor zeros_like(
-      const Tensor& input,
+      const torch::executor::Tensor& input,
       TensorShapeDynamism dynamism = TensorShapeDynamism::STATIC) {
     std::vector<int32_t> sizes = {input.sizes().begin(), input.sizes().end()};
     return full(sizes, 0, dynamism);
@@ -844,7 +845,7 @@ class TensorFactory {
    * @return A new Tensor with the specified shape.
    */
   torch::executor::Tensor ones_like(
-      const Tensor& input,
+      const torch::executor::Tensor& input,
       TensorShapeDynamism dynamism = TensorShapeDynamism::STATIC) {
     std::vector<int32_t> sizes = {input.sizes().begin(), input.sizes().end()};
     return full(sizes, 1, dynamism);
@@ -878,7 +879,7 @@ class TensorFactory {
     std::vector<ctype> data_;
     std::vector<uint8_t> dim_order_;
     std::vector<int32_t> strides_;
-    TensorImpl impl_;
+    torch::executor::TensorImpl impl_;
   };
 
   /**
@@ -898,7 +899,7 @@ class TensorFactory {
  * (and Tensors they contain), and must live longer than those TensorLists and
  * Tensors.
  */
-template <ScalarType DTYPE>
+template <exec_aten::ScalarType DTYPE>
 class TensorListFactory final {
  public:
   TensorListFactory() = default;
@@ -909,13 +910,15 @@ class TensorListFactory final {
    * provided Tensors, but filled with zero elements. The dtypes of the template
    * entries are ignored.
    */
-  TensorList zeros_like(const std::vector<Tensor>& templates) {
-    memory_.emplace_back(std::make_unique<std::vector<Tensor>>());
+  exec_aten::TensorList zeros_like(
+      const std::vector<exec_aten::Tensor>& templates) {
+    memory_.emplace_back(std::make_unique<std::vector<exec_aten::Tensor>>());
     auto& vec = memory_.back();
-    std::for_each(templates.begin(), templates.end(), [&](const Tensor& t) {
-      vec->push_back(tf_.zeros_like(t));
-    });
-    return TensorList(vec->data(), vec->size());
+    std::for_each(
+        templates.begin(), templates.end(), [&](const exec_aten::Tensor& t) {
+          vec->push_back(tf_.zeros_like(t));
+        });
+    return exec_aten::TensorList(vec->data(), vec->size());
   }
 
  private:
@@ -925,9 +928,20 @@ class TensorListFactory final {
    * vector of pointers so that the elements won't move if the vector needs to
    * resize/realloc.
    */
-  std::vector<std::unique_ptr<std::vector<Tensor>>> memory_;
+  std::vector<std::unique_ptr<std::vector<exec_aten::Tensor>>> memory_;
 };
 
+} // namespace testing
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+namespace testing {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::testing::TensorFactory;
+using ::executorch::runtime::testing::TensorListFactory;
 } // namespace testing
 } // namespace executor
 } // namespace torch

--- a/runtime/core/exec_aten/testing_util/tensor_util.cpp
+++ b/runtime/core/exec_aten/testing_util/tensor_util.cpp
@@ -19,8 +19,8 @@
 using exec_aten::ScalarType;
 using exec_aten::Tensor;
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 namespace testing {
 
 namespace {
@@ -175,9 +175,18 @@ bool tensor_lists_are_close(
 }
 
 } // namespace testing
+} // namespace runtime
+} // namespace executorch
 
 // ATen already defines operator<<() for Tensor and ScalarType.
 #ifndef USE_ATEN_LIB
+
+/*
+ * These functions must be declared in the original namespaces of their
+ * associated types so that C++ can find them.
+ */
+namespace torch {
+namespace executor {
 
 /**
  * Prints the ScalarType to the stream as a human-readable string.
@@ -266,7 +275,7 @@ std::ostream& operator<<(std::ostream& os, const Tensor& t) {
   return os;
 }
 
-#endif // !USE_ATEN_LIB
-
 } // namespace executor
 } // namespace torch
+
+#endif // !USE_ATEN_LIB

--- a/runtime/core/exec_aten/testing_util/tensor_util.h
+++ b/runtime/core/exec_aten/testing_util/tensor_util.h
@@ -11,8 +11,8 @@
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <gmock/gmock.h> // For MATCHER_P
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 namespace testing {
 
 namespace internal {
@@ -213,110 +213,125 @@ MATCHER_P(IsListEqualTo, other, "") {
  * `bool`-returning operator.
  */
 #define EXPECT_TENSOR_EQ(t1, t2) \
-  EXPECT_THAT((t1), ::torch::executor::testing::IsEqualTo(t2))
+  EXPECT_THAT((t1), ::executorch::runtime::testing::IsEqualTo(t2))
 #define EXPECT_TENSOR_NE(t1, t2) \
-  EXPECT_THAT((t1), ::testing::Not(torch::executor::testing::IsEqualTo(t2)))
+  EXPECT_THAT((t1), ::testing::Not(executorch::runtime::testing::IsEqualTo(t2)))
 #define ASSERT_TENSOR_EQ(t1, t2) \
-  ASSERT_THAT((t1), ::torch::executor::testing::IsEqualTo(t2))
+  ASSERT_THAT((t1), ::executorch::runtime::testing::IsEqualTo(t2))
 #define ASSERT_TENSOR_NE(t1, t2) \
-  ASSERT_THAT((t1), ::testing::Not(torch::executor::testing::IsEqualTo(t2)))
+  ASSERT_THAT((t1), ::testing::Not(executorch::runtime::testing::IsEqualTo(t2)))
 
 #define EXPECT_TENSOR_CLOSE(t1, t2) \
-  EXPECT_THAT((t1), ::torch::executor::testing::IsCloseTo(t2))
+  EXPECT_THAT((t1), ::executorch::runtime::testing::IsCloseTo(t2))
 #define EXPECT_TENSOR_NOT_CLOSE(t1, t2) \
-  EXPECT_THAT((t1), ::testing::Not(torch::executor::testing::IsCloseTo(t2)))
+  EXPECT_THAT((t1), ::testing::Not(executorch::runtime::testing::IsCloseTo(t2)))
 #define ASSERT_TENSOR_CLOSE(t1, t2) \
-  ASSERT_THAT((t1), ::torch::executor::testing::IsCloseTo(t2))
+  ASSERT_THAT((t1), ::executorch::runtime::testing::IsCloseTo(t2))
 #define ASSERT_TENSOR_NOT_CLOSE(t1, t2) \
-  ASSERT_THAT((t1), ::testing::Not(torch::executor::testing::IsCloseTo(t2)))
+  ASSERT_THAT((t1), ::testing::Not(executorch::runtime::testing::IsCloseTo(t2)))
 
 #define EXPECT_TENSOR_CLOSE_WITH_TOL(t1, t2, rtol, atol) \
   EXPECT_THAT(                                           \
-      (t1), ::torch::executor::testing::IsCloseToWithTol(t2, rtol, atol))
+      (t1), ::executorch::runtime::testing::IsCloseToWithTol(t2, rtol, atol))
 #define EXPECT_TENSOR_NOT_CLOSE_WITH_TOL(t1, t2, rtol, atol) \
   EXPECT_THAT(                                               \
       (t1),                                                  \
       ::testing::Not(                                        \
-          torch::executor::testing::IsCloseToWithTol(t2, rtol, atol)))
+          executorch::runtime::testing::IsCloseToWithTol(t2, rtol, atol)))
 #define ASSERT_TENSOR_CLOSE_WITH_TOL(t1, t2, rtol, atol) \
   ASSERT_THAT(                                           \
-      (t1), ::torch::executor::testing::IsCloseToWithTol(t2, rtol, atol))
+      (t1), ::executorch::runtime::testing::IsCloseToWithTol(t2, rtol, atol))
 #define ASSERT_TENSOR_NOT_CLOSE_WITH_TOL(t1, t2, rtol, atol) \
   ASSERT_THAT(                                               \
       (t1),                                                  \
       ::testing::Not(                                        \
-          torch::executor::testing::IsCloseToWithTol(t2, rtol, atol)))
+          executorch::runtime::testing::IsCloseToWithTol(t2, rtol, atol)))
 
 #define EXPECT_TENSOR_DATA_EQ(t1, t2) \
-  EXPECT_THAT((t1), ::torch::executor::testing::IsDataEqualTo(t2))
+  EXPECT_THAT((t1), ::executorch::runtime::testing::IsDataEqualTo(t2))
 #define EXPECT_TENSOR_DATA_NE(t1, t2) \
-  EXPECT_THAT((t1), ::testing::Not(torch::executor::testing::IsDataEqualTo(t2)))
+  EXPECT_THAT(                        \
+      (t1), ::testing::Not(executorch::runtime::testing::IsDataEqualTo(t2)))
 #define ASSERT_TENSOR_DATA_EQ(t1, t2) \
-  ASSERT_THAT((t1), ::torch::executor::testing::IsDataEqualTo(t2))
+  ASSERT_THAT((t1), ::executorch::runtime::testing::IsDataEqualTo(t2))
 #define ASSERT_TENSOR_DATA_NE(t1, t2) \
-  ASSERT_THAT((t1), ::testing::Not(torch::executor::testing::IsDataEqualTo(t2)))
+  ASSERT_THAT(                        \
+      (t1), ::testing::Not(executorch::runtime::testing::IsDataEqualTo(t2)))
 
 #define EXPECT_TENSOR_DATA_CLOSE(t1, t2) \
-  EXPECT_THAT((t1), ::torch::executor::testing::IsDataCloseTo(t2))
+  EXPECT_THAT((t1), ::executorch::runtime::testing::IsDataCloseTo(t2))
 #define EXPECT_TENSOR_DATA_NOT_CLOSE(t1, t2) \
-  EXPECT_THAT((t1), ::testing::Not(torch::executor::testing::IsDataCloseTo(t2)))
+  EXPECT_THAT(                               \
+      (t1), ::testing::Not(executorch::runtime::testing::IsDataCloseTo(t2)))
 #define ASSERT_TENSOR_DATA_CLOSE(t1, t2) \
-  ASSERT_THAT((t1), ::torch::executor::testing::IsDataCloseTo(t2))
+  ASSERT_THAT((t1), ::executorch::runtime::testing::IsDataCloseTo(t2))
 #define ASSERT_TENSOR_DATA_NOT_CLOSE(t1, t2) \
-  ASSERT_THAT((t1), ::testing::Not(torch::executor::testing::IsDataCloseTo(t2)))
+  ASSERT_THAT(                               \
+      (t1), ::testing::Not(executorch::runtime::testing::IsDataCloseTo(t2)))
 
 #define EXPECT_TENSOR_DATA_CLOSE_WITH_TOL(t1, t2, rtol, atol) \
   EXPECT_THAT(                                                \
-      (t1), ::torch::executor::testing::IsDataCloseToWithTol(t2, rtol, atol))
+      (t1),                                                   \
+      ::executorch::runtime::testing::IsDataCloseToWithTol(t2, rtol, atol))
 #define EXPECT_TENSOR_DATA_NOT_CLOSE_WITH_TOL(t1, t2, rtol, atol) \
   EXPECT_THAT(                                                    \
       (t1),                                                       \
       ::testing::Not(                                             \
-          torch::executor::testing::IsDataCloseToWithTol(t2, rtol, atol)))
+          executorch::runtime::testing::IsDataCloseToWithTol(t2, rtol, atol)))
 #define ASSERT_TENSOR_DATA_CLOSE_WITH_TOL(t1, t2, rtol, atol) \
   ASSERT_THAT(                                                \
-      (t1), ::torch::executor::testing::IsDataCloseToWithTol(t2, rtol, atol))
+      (t1),                                                   \
+      ::executorch::runtime::testing::IsDataCloseToWithTol(t2, rtol, atol))
 #define ASSERT_TENSOR_DATA_NOT_CLOSE_WITH_TOL(t1, t2, rtol, atol) \
   ASSERT_THAT(                                                    \
       (t1),                                                       \
       ::testing::Not(                                             \
-          torch::executor::testing::IsDataCloseToWithTol(t2, rtol, atol)))
+          executorch::runtime::testing::IsDataCloseToWithTol(t2, rtol, atol)))
 
 /*
  * Helpers for comparing lists of Tensors.
  */
 
 #define EXPECT_TENSOR_LISTS_EQ(t1, t2) \
-  EXPECT_THAT((t1), ::torch::executor::testing::IsListEqualTo(t2))
+  EXPECT_THAT((t1), ::executorch::runtime::testing::IsListEqualTo(t2))
 #define EXPECT_TENSOR_LISTS_NE(t1, t2) \
-  EXPECT_THAT((t1), ::testing::Not(torch::executor::testing::IsListEqualTo(t2)))
+  EXPECT_THAT(                         \
+      (t1), ::testing::Not(executorch::runtime::testing::IsListEqualTo(t2)))
 #define ASSERT_TENSOR_LISTS_EQ(t1, t2) \
-  ASSERT_THAT((t1), ::torch::executor::testing::IsListEqualTo(t2))
+  ASSERT_THAT((t1), ::executorch::runtime::testing::IsListEqualTo(t2))
 #define ASSERT_TENSOR_LISTS_NE(t1, t2) \
-  ASSERT_THAT((t1), ::testing::Not(torch::executor::testing::IsListEqualTo(t2)))
+  ASSERT_THAT(                         \
+      (t1), ::testing::Not(executorch::runtime::testing::IsListEqualTo(t2)))
 
 #define EXPECT_TENSOR_LISTS_CLOSE(t1, t2) \
-  EXPECT_THAT((t1), ::torch::executor::testing::IsListCloseTo(t2))
+  EXPECT_THAT((t1), ::executorch::runtime::testing::IsListCloseTo(t2))
 #define EXPECT_TENSOR_LISTS_NOT_CLOSE(t1, t2) \
-  EXPECT_THAT((t1), ::testing::Not(torch::executor::testing::IsListCloseTo(t2)))
+  EXPECT_THAT(                                \
+      (t1), ::testing::Not(executorch::runtime::testing::IsListCloseTo(t2)))
 #define ASSERT_TENSOR_LISTS_CLOSE(t1, t2) \
-  ASSERT_THAT((t1), ::torch::executor::testing::IsListCloseTo(t2))
+  ASSERT_THAT((t1), ::executorch::runtime::testing::IsListCloseTo(t2))
 #define ASSERT_TENSOR_LISTS_NOT_CLOSE(t1, t2) \
-  ASSERT_THAT((t1), ::testing::Not(torch::executor::testing::IsListCloseTo(t2)))
+  ASSERT_THAT(                                \
+      (t1), ::testing::Not(executorch::runtime::testing::IsListCloseTo(t2)))
 
 } // namespace testing
+} // namespace runtime
+} // namespace executorch
 
+// ATen already defines operator<<() for Tensor and ScalarType.
 #ifndef USE_ATEN_LIB
 
 /*
  * These functions must be declared in the original namespaces of their
  * associated types so that C++ can find them.
  */
+namespace torch {
+namespace executor {
 
 /**
  * Prints the ScalarType to the stream as a human-readable string.
  *
- * See also torch::executor::toString(ScalarType t) in ScalarTypeUtil.h.
+ * See also executorch::runtime::toString(ScalarType t) in ScalarTypeUtil.h.
  */
 std::ostream& operator<<(std::ostream& os, const exec_aten::ScalarType& t);
 
@@ -325,7 +340,27 @@ std::ostream& operator<<(std::ostream& os, const exec_aten::ScalarType& t);
  */
 std::ostream& operator<<(std::ostream& os, const exec_aten::Tensor& t);
 
+} // namespace executor
+} // namespace torch
+
 #endif // !USE_ATEN_LIB
 
+namespace torch {
+namespace executor {
+namespace testing {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::testing::IsCloseTo;
+using ::executorch::runtime::testing::IsCloseToWithTol;
+using ::executorch::runtime::testing::IsDataCloseTo;
+using ::executorch::runtime::testing::IsDataCloseToWithTol;
+using ::executorch::runtime::testing::IsDataEqualTo;
+using ::executorch::runtime::testing::IsEqualTo;
+using ::executorch::runtime::testing::IsListCloseTo;
+using ::executorch::runtime::testing::IsListEqualTo;
+using ::executorch::runtime::testing::tensor_data_is_close;
+using ::executorch::runtime::testing::tensor_lists_are_close;
+using ::executorch::runtime::testing::tensors_are_close;
+} // namespace testing
 } // namespace executor
 } // namespace torch

--- a/runtime/core/exec_aten/testing_util/test/tensor_factory_test.cpp
+++ b/runtime/core/exec_aten/testing_util/test/tensor_factory_test.cpp
@@ -26,10 +26,11 @@ using exec_aten::SizesType;
 using exec_aten::StridesType;
 using exec_aten::Tensor;
 using exec_aten::TensorList;
-using torch::executor::Error;
-using torch::executor::resize_tensor;
-using torch::executor::testing::TensorFactory;
-using torch::executor::testing::TensorListFactory;
+using executorch::runtime::Error;
+using executorch::runtime::resize_tensor;
+using executorch::runtime::TensorShapeDynamism;
+using executorch::runtime::testing::TensorFactory;
+using executorch::runtime::testing::TensorListFactory;
 
 // The tensor under test will be modified so pass an rvalue ref
 void resize_tensor_to_assert_static(Tensor&& t) {
@@ -107,7 +108,7 @@ class TensorFactoryTest : public ::testing::Test {
   void SetUp() override {
     // Since these tests cause ET_LOG to be called, the PAL must be initialized
     // first.
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
   }
 };
 
@@ -963,138 +964,110 @@ TEST(TensorListFactoryTest, ZerosLikeEmpty) {
 
 TEST_F(TensorFactoryTest, ZerosDynamismParameter) {
   TensorFactory<ScalarType::Int> tf;
-  resize_tensor_to_assert_static(
-      tf.zeros({2, 2}, torch::executor::TensorShapeDynamism::STATIC));
+  resize_tensor_to_assert_static(tf.zeros({2, 2}, TensorShapeDynamism::STATIC));
   resize_tensor_to_assert_dynamic_bound(
-      tf.zeros({2, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND));
+      tf.zeros({2, 2}, TensorShapeDynamism::DYNAMIC_BOUND));
   resize_tensor_to_assert_dynamic_unbound(
-      tf.zeros({2, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND));
+      tf.zeros({2, 2}, TensorShapeDynamism::DYNAMIC_UNBOUND));
 
   // The tensor itself should be equal
   EXPECT_TENSOR_EQ(
-      tf.zeros({2, 2}, torch::executor::TensorShapeDynamism::STATIC),
-      tf.zeros({2, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND));
+      tf.zeros({2, 2}, TensorShapeDynamism::STATIC),
+      tf.zeros({2, 2}, TensorShapeDynamism::DYNAMIC_BOUND));
   EXPECT_TENSOR_EQ(
-      tf.zeros({2, 2}, torch::executor::TensorShapeDynamism::STATIC),
-      tf.zeros({2, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND));
+      tf.zeros({2, 2}, TensorShapeDynamism::STATIC),
+      tf.zeros({2, 2}, TensorShapeDynamism::DYNAMIC_UNBOUND));
 }
 
 TEST_F(TensorFactoryTest, ZerosLikeDynamismParameter) {
   TensorFactory<ScalarType::Int> tf;
   Tensor zeros = tf.zeros({2, 2});
   resize_tensor_to_assert_static(
-      tf.zeros_like(zeros, torch::executor::TensorShapeDynamism::STATIC));
-  resize_tensor_to_assert_dynamic_bound(tf.zeros_like(
-      zeros, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND));
-  resize_tensor_to_assert_dynamic_unbound(tf.zeros_like(
-      zeros, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND));
+      tf.zeros_like(zeros, TensorShapeDynamism::STATIC));
+  resize_tensor_to_assert_dynamic_bound(
+      tf.zeros_like(zeros, TensorShapeDynamism::DYNAMIC_BOUND));
+  resize_tensor_to_assert_dynamic_unbound(
+      tf.zeros_like(zeros, TensorShapeDynamism::DYNAMIC_UNBOUND));
 
   // The tensor itself should be equal
   EXPECT_TENSOR_EQ(
-      tf.zeros_like(zeros, torch::executor::TensorShapeDynamism::STATIC),
-      tf.zeros_like(
-          zeros, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND));
+      tf.zeros_like(zeros, TensorShapeDynamism::STATIC),
+      tf.zeros_like(zeros, TensorShapeDynamism::DYNAMIC_BOUND));
   EXPECT_TENSOR_EQ(
-      tf.zeros_like(zeros, torch::executor::TensorShapeDynamism::STATIC),
-      tf.zeros_like(
-          zeros, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND));
+      tf.zeros_like(zeros, TensorShapeDynamism::STATIC),
+      tf.zeros_like(zeros, TensorShapeDynamism::DYNAMIC_UNBOUND));
 }
 
 TEST_F(TensorFactoryTest, OnesDynamismParameter) {
   TensorFactory<ScalarType::Int> tf;
-  resize_tensor_to_assert_static(
-      tf.ones({2, 2}, torch::executor::TensorShapeDynamism::STATIC));
+  resize_tensor_to_assert_static(tf.ones({2, 2}, TensorShapeDynamism::STATIC));
   resize_tensor_to_assert_dynamic_bound(
-      tf.ones({2, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND));
+      tf.ones({2, 2}, TensorShapeDynamism::DYNAMIC_BOUND));
   resize_tensor_to_assert_dynamic_unbound(
-      tf.ones({2, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND));
+      tf.ones({2, 2}, TensorShapeDynamism::DYNAMIC_UNBOUND));
 
   // The tensor itself should be equal
   EXPECT_TENSOR_EQ(
-      tf.ones({2, 2}, torch::executor::TensorShapeDynamism::STATIC),
-      tf.ones({2, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND));
+      tf.ones({2, 2}, TensorShapeDynamism::STATIC),
+      tf.ones({2, 2}, TensorShapeDynamism::DYNAMIC_BOUND));
   EXPECT_TENSOR_EQ(
-      tf.ones({2, 2}, torch::executor::TensorShapeDynamism::STATIC),
-      tf.ones({2, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND));
+      tf.ones({2, 2}, TensorShapeDynamism::STATIC),
+      tf.ones({2, 2}, TensorShapeDynamism::DYNAMIC_UNBOUND));
 }
 
 TEST_F(TensorFactoryTest, OnesLikeDynamismParameter) {
   TensorFactory<ScalarType::Int> tf;
   Tensor ones = tf.ones({2, 2});
   resize_tensor_to_assert_static(
-      tf.ones_like(ones, torch::executor::TensorShapeDynamism::STATIC));
+      tf.ones_like(ones, TensorShapeDynamism::STATIC));
   resize_tensor_to_assert_dynamic_bound(
-      tf.ones_like(ones, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND));
-  resize_tensor_to_assert_dynamic_unbound(tf.ones_like(
-      ones, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND));
+      tf.ones_like(ones, TensorShapeDynamism::DYNAMIC_BOUND));
+  resize_tensor_to_assert_dynamic_unbound(
+      tf.ones_like(ones, TensorShapeDynamism::DYNAMIC_UNBOUND));
 
   // The tensor itself should be equal
   EXPECT_TENSOR_EQ(
-      tf.ones_like(ones, torch::executor::TensorShapeDynamism::STATIC),
-      tf.ones_like(ones, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND));
+      tf.ones_like(ones, TensorShapeDynamism::STATIC),
+      tf.ones_like(ones, TensorShapeDynamism::DYNAMIC_BOUND));
   EXPECT_TENSOR_EQ(
-      tf.ones_like(ones, torch::executor::TensorShapeDynamism::STATIC),
-      tf.ones_like(
-          ones, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND));
+      tf.ones_like(ones, TensorShapeDynamism::STATIC),
+      tf.ones_like(ones, TensorShapeDynamism::DYNAMIC_UNBOUND));
 }
 
 TEST_F(TensorFactoryTest, FullDynamismParameter) {
   TensorFactory<ScalarType::Int> tf;
   resize_tensor_to_assert_static(
-      tf.full({2, 2}, 1, torch::executor::TensorShapeDynamism::STATIC));
+      tf.full({2, 2}, 1, TensorShapeDynamism::STATIC));
   resize_tensor_to_assert_dynamic_bound(
-      tf.full({2, 2}, 1, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND));
-  resize_tensor_to_assert_dynamic_unbound(tf.full(
-      {2, 2}, 1, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND));
+      tf.full({2, 2}, 1, TensorShapeDynamism::DYNAMIC_BOUND));
+  resize_tensor_to_assert_dynamic_unbound(
+      tf.full({2, 2}, 1, TensorShapeDynamism::DYNAMIC_UNBOUND));
 
   // The tensor itself should be equal
   EXPECT_TENSOR_EQ(
-      tf.full({2, 2}, 1, torch::executor::TensorShapeDynamism::STATIC),
-      tf.full({2, 2}, 1, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND));
+      tf.full({2, 2}, 1, TensorShapeDynamism::STATIC),
+      tf.full({2, 2}, 1, TensorShapeDynamism::DYNAMIC_BOUND));
   EXPECT_TENSOR_EQ(
-      tf.full({2, 2}, 1, torch::executor::TensorShapeDynamism::STATIC),
-      tf.full(
-          {2, 2}, 1, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND));
+      tf.full({2, 2}, 1, TensorShapeDynamism::STATIC),
+      tf.full({2, 2}, 1, TensorShapeDynamism::DYNAMIC_UNBOUND));
 }
 
 TEST_F(TensorFactoryTest, MakeDynamismParameter) {
   TensorFactory<ScalarType::Int> tf;
-  resize_tensor_to_assert_static(tf.make(
-      {2, 2}, {1, 2, 3, 4}, {}, torch::executor::TensorShapeDynamism::STATIC));
-  resize_tensor_to_assert_dynamic_bound(tf.make(
-      {2, 2},
-      {1, 2, 3, 4},
-      {},
-      torch::executor::TensorShapeDynamism::DYNAMIC_BOUND));
-  resize_tensor_to_assert_dynamic_unbound(tf.make(
-      {2, 2},
-      {1, 2, 3, 4},
-      {},
-      torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND));
+  resize_tensor_to_assert_static(
+      tf.make({2, 2}, {1, 2, 3, 4}, {}, TensorShapeDynamism::STATIC));
+  resize_tensor_to_assert_dynamic_bound(
+      tf.make({2, 2}, {1, 2, 3, 4}, {}, TensorShapeDynamism::DYNAMIC_BOUND));
+  resize_tensor_to_assert_dynamic_unbound(
+      tf.make({2, 2}, {1, 2, 3, 4}, {}, TensorShapeDynamism::DYNAMIC_UNBOUND));
 
   // The tensor itself should be equal
   EXPECT_TENSOR_EQ(
-      tf.make(
-          {2, 2},
-          {1, 2, 3, 4},
-          {},
-          torch::executor::TensorShapeDynamism::STATIC),
-      tf.make(
-          {2, 2},
-          {1, 2, 3, 4},
-          {},
-          torch::executor::TensorShapeDynamism::DYNAMIC_BOUND));
+      tf.make({2, 2}, {1, 2, 3, 4}, {}, TensorShapeDynamism::STATIC),
+      tf.make({2, 2}, {1, 2, 3, 4}, {}, TensorShapeDynamism::DYNAMIC_BOUND));
   EXPECT_TENSOR_EQ(
-      tf.make(
-          {2, 2},
-          {1, 2, 3, 4},
-          {},
-          torch::executor::TensorShapeDynamism::STATIC),
-      tf.make(
-          {2, 2},
-          {1, 2, 3, 4},
-          {},
-          torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND));
+      tf.make({2, 2}, {1, 2, 3, 4}, {}, TensorShapeDynamism::STATIC),
+      tf.make({2, 2}, {1, 2, 3, 4}, {}, TensorShapeDynamism::DYNAMIC_UNBOUND));
 }
 
 #if !defined(USE_ATEN_LIB)
@@ -1107,7 +1080,7 @@ TEST_F(TensorFactoryTest, FullDynamic) {
   ET_EXPECT_DEATH(torch::executor::resize(out, new_sizes), "");
 
   out = tf.full(
-      /*sizes=*/{2, 2}, 5, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
+      /*sizes=*/{2, 2}, 5, TensorShapeDynamism::DYNAMIC_BOUND);
   new_sizes[1] = 2;
   EXPECT_EQ(
       torch::executor::resize_tensor(out, new_sizes),
@@ -1128,10 +1101,7 @@ TEST_F(TensorFactoryTest, MakeIntTensorDynamic) {
 
   std::vector<int32_t> data = {1, 2, 3, 4};
   out = tf.make(
-      /*sizes=*/{2, 2},
-      data,
-      {},
-      torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
+      /*sizes=*/{2, 2}, data, {}, TensorShapeDynamism::DYNAMIC_BOUND);
   new_sizes[1] = 2;
   EXPECT_EQ(
       torch::executor::resize_tensor(out, new_sizes),
@@ -1151,7 +1121,7 @@ TEST_F(TensorFactoryTest, MakeZerosDynamic) {
   ET_EXPECT_DEATH(torch::executor::resize(out, new_sizes), "");
 
   out = tf.zeros(
-      /*sizes=*/{2, 2}, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
+      /*sizes=*/{2, 2}, TensorShapeDynamism::DYNAMIC_BOUND);
   new_sizes[1] = 2;
   EXPECT_EQ(
       torch::executor::resize_tensor(out, new_sizes),
@@ -1165,7 +1135,7 @@ TEST_F(TensorFactoryTest, MakeZerosDynamic) {
   new_sizes[1] = 1;
   ET_EXPECT_DEATH(torch::executor::resize(out_like, new_sizes), "");
 
-  out = tf.zeros_like(out, torch::executor::TensorShapeDynamism::DYNAMIC_BOUND);
+  out = tf.zeros_like(out, TensorShapeDynamism::DYNAMIC_BOUND);
   new_sizes[1] = 2;
   EXPECT_EQ(
       torch::executor::resize_tensor(out, new_sizes),

--- a/runtime/core/exec_aten/testing_util/test/tensor_util_test.cpp
+++ b/runtime/core/exec_aten/testing_util/test/tensor_util_test.cpp
@@ -24,16 +24,16 @@ using namespace ::testing;
 using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using exec_aten::TensorList;
-using torch::executor::testing::IsCloseTo;
-using torch::executor::testing::IsDataCloseTo;
-using torch::executor::testing::IsDataEqualTo;
-using torch::executor::testing::IsEqualTo;
-using torch::executor::testing::IsListCloseTo;
-using torch::executor::testing::IsListEqualTo;
-using torch::executor::testing::tensor_data_is_close;
-using torch::executor::testing::tensor_lists_are_close;
-using torch::executor::testing::TensorFactory;
-using torch::executor::testing::tensors_are_close;
+using executorch::runtime::testing::IsCloseTo;
+using executorch::runtime::testing::IsDataCloseTo;
+using executorch::runtime::testing::IsDataEqualTo;
+using executorch::runtime::testing::IsEqualTo;
+using executorch::runtime::testing::IsListCloseTo;
+using executorch::runtime::testing::IsListEqualTo;
+using executorch::runtime::testing::tensor_data_is_close;
+using executorch::runtime::testing::tensor_lists_are_close;
+using executorch::runtime::testing::TensorFactory;
+using executorch::runtime::testing::tensors_are_close;
 
 // Exhaustively test all of our comparison functions every time. Also flip the
 // params around to demonstrate that the underlying checks are commutative.

--- a/runtime/core/exec_aten/util/dim_order_util.h
+++ b/runtime/core/exec_aten/util/dim_order_util.h
@@ -13,8 +13,9 @@
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/platform/assert.h>
 #include <executorch/runtime/platform/compiler.h>
-namespace torch {
-namespace executor {
+
+namespace executorch {
+namespace runtime {
 
 namespace {
 template <typename DimOrderType>
@@ -152,6 +153,8 @@ ET_NODISCARD inline Error dim_order_to_stride(
   return Error::Ok;
 }
 
+namespace internal {
+
 template <typename StridesType, typename DimOrderType>
 struct StrideDimOrder {
   StridesType stride;
@@ -201,6 +204,8 @@ struct Sorter {
   }
 };
 
+} // namespace internal
+
 /*
  * This utility translated strides to dimension order
  * information. Dimension order specifies how the dimensions are laid out in the
@@ -236,13 +241,14 @@ ET_NODISCARD inline Error stride_to_dim_order(
       "dims %zu exceeds maximum allowed %zu",
       dims,
       kMaxNumOfDimensions);
-  StrideDimOrder<StridesType, DimOrderType> array[kMaxNumOfDimensions];
+  internal::StrideDimOrder<StridesType, DimOrderType>
+      array[kMaxNumOfDimensions];
   for (DimOrderType i = 0; i < dims; i++) {
     array[i].dim_order = i;
     array[i].stride = strides[i];
   }
 
-  Sorter<StrideDimOrder<StridesType, DimOrderType>> sorter;
+  internal::Sorter<internal::StrideDimOrder<StridesType, DimOrderType>> sorter;
 
   sorter.quick_sort(array, 0, dims - 1);
 
@@ -251,5 +257,17 @@ ET_NODISCARD inline Error stride_to_dim_order(
   }
   return Error::Ok;
 }
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::dim_order_to_stride;
+using ::executorch::runtime::dim_order_to_stride_nocheck;
+using ::executorch::runtime::is_channels_last_dim_order;
+using ::executorch::runtime::is_contiguous_dim_order;
+using ::executorch::runtime::stride_to_dim_order;
 } // namespace executor
 } // namespace torch

--- a/runtime/core/exec_aten/util/tensor_util.h
+++ b/runtime/core/exec_aten/util/tensor_util.h
@@ -397,8 +397,8 @@
       extract_scalar_tensor(scalar_tensor, &out_val),    \
       #scalar_tensor " could not be extracted: wrong type or out of range");
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 //
 // Utility functions for checking tensor attributes
@@ -1165,5 +1165,58 @@ inline size_t calculate_linear_index(
   return index;
 }
 
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::calculate_linear_index;
+using ::executorch::runtime::coordinateToIndex;
+using ::executorch::runtime::dim_is_valid;
+using ::executorch::runtime::extract_scalar_tensor;
+using ::executorch::runtime::get_dim_order;
+using ::executorch::runtime::getLeadingDims;
+using ::executorch::runtime::getTrailingDims;
+using ::executorch::runtime::indexToCoordinate;
+using ::executorch::runtime::kTensorDimensionLimit;
+using ::executorch::runtime::nonempty_size;
+using ::executorch::runtime::nonzero_dim;
+using ::executorch::runtime::resize;
+using ::executorch::runtime::resize_tensor;
+using ::executorch::runtime::tensor_can_cast_to;
+using ::executorch::runtime::tensor_dim_has_index;
+using ::executorch::runtime::tensor_has_dim;
+using ::executorch::runtime::tensor_has_expected_size;
+using ::executorch::runtime::tensor_has_non_empty_dim;
+using ::executorch::runtime::tensor_has_rank_greater_or_equal_to;
+using ::executorch::runtime::tensor_has_rank_smaller_or_equal_to;
+using ::executorch::runtime::tensor_has_valid_dim_order;
+using ::executorch::runtime::tensor_is_bits_type;
+using ::executorch::runtime::tensor_is_bool_type;
+using ::executorch::runtime::tensor_is_complex_type;
+using ::executorch::runtime::tensor_is_contiguous;
+using ::executorch::runtime::tensor_is_default_or_channels_last_dim_order;
+using ::executorch::runtime::tensor_is_floating_type;
+using ::executorch::runtime::tensor_is_integral_type;
+using ::executorch::runtime::tensor_is_rank;
+using ::executorch::runtime::tensor_is_real_type;
+using ::executorch::runtime::tensor_is_realh_type;
+using ::executorch::runtime::tensor_is_realhb_type;
+using ::executorch::runtime::tensor_is_scalar;
+using ::executorch::runtime::tensors_have_same_dtype;
+using ::executorch::runtime::tensors_have_same_rank;
+using ::executorch::runtime::tensors_have_same_shape;
+using ::executorch::runtime::tensors_have_same_shape_and_dtype;
+using ::executorch::runtime::tensors_have_same_size_at_dims;
+using ::executorch::runtime::tensors_have_same_strides;
+namespace internal {
+using ::executorch::runtime::internal::copy_tensor_data;
+using ::executorch::runtime::internal::reset_data_ptr;
+using ::executorch::runtime::internal::resize_tensor_impl;
+using ::executorch::runtime::internal::set_tensor_data;
+using ::executorch::runtime::internal::share_tensor_data;
+} // namespace internal
 } // namespace executor
 } // namespace torch

--- a/runtime/core/exec_aten/util/tensor_util_aten.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_aten.cpp
@@ -11,8 +11,8 @@
 #include <ATen/Tensor.h> // @manual
 #include <executorch/runtime/platform/assert.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 /**
  * Implementation for ATen tensor util, should only be included in
  * `<target>_aten` target and only be used in ATen mode. Explicitly taking
@@ -95,7 +95,8 @@ Error share_tensor_data(const at::Tensor& t_dst, const at::Tensor& t_src) {
       InvalidArgument,
       "Source tensor should have data_ptr not being nullptr.");
   // Assign the dataptr as the input tensor dataptr
-  storage->set_data_ptr(at::DataPtr(t_src.mutable_data_ptr(), DeviceType::CPU));
+  storage->set_data_ptr(
+      at::DataPtr(t_src.mutable_data_ptr(), at::DeviceType::CPU));
   storage->set_nbytes(t_src.nbytes());
 
   return Error::Ok;
@@ -142,7 +143,7 @@ set_tensor_data(const at::Tensor& t, void* buffer, size_t buffer_size) {
       buffer_size,
       t.nbytes());
   t.unsafeGetTensorImpl()->unsafe_storage().set_data_ptr(
-      at::DataPtr(buffer, DeviceType::CPU));
+      at::DataPtr(buffer, at::DeviceType::CPU));
   return Error::Ok;
 }
 
@@ -174,5 +175,5 @@ Error resize_tensor_impl(
 
 } // namespace internal
 
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch

--- a/runtime/core/exec_aten/util/tensor_util_portable.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_portable.cpp
@@ -13,8 +13,8 @@
 #include <executorch/runtime/core/portable_type/tensor.h>
 #include <executorch/runtime/platform/assert.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 /**
  * Implementation for ExecuTorch tensor util, should only be included in
  * an target with ATen mode turned off. Explicitly taking
@@ -151,5 +151,5 @@ Error resize_tensor_impl(
 }
 } // namespace internal
 
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch

--- a/runtime/core/exec_aten/util/test/dim_order_util_test.cpp
+++ b/runtime/core/exec_aten/util/test/dim_order_util_test.cpp
@@ -6,12 +6,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
+
 #include <numeric>
 
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
-#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 
 #include <gtest/gtest.h>
+
+using executorch::runtime::dim_order_to_stride;
+using executorch::runtime::Error;
+using executorch::runtime::is_channels_last_dim_order;
+using executorch::runtime::is_contiguous_dim_order;
+using executorch::runtime::stride_to_dim_order;
 
 namespace {
 void check_strides_eq(
@@ -36,36 +43,32 @@ TEST(DimOrderUtilTest, DimOrderToStride) {
   exec_aten::SizesType dim_order_1[1] = {0};
   exec_aten::SizesType strides_1[1] = {0};
   exec_aten::SizesType expected_strides_1[1] = {1};
-  auto error =
-      torch::executor::dim_order_to_stride(sizes_1, dim_order_1, 1, strides_1);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  auto error = dim_order_to_stride(sizes_1, dim_order_1, 1, strides_1);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_1, 1}, {expected_strides_1, 1});
 
   exec_aten::SizesType sizes_2[2] = {2, 5};
   exec_aten::SizesType dim_order_2[2] = {0, 1};
   exec_aten::SizesType strides_2[2] = {0, 0};
   exec_aten::SizesType expected_strides_2[2] = {5, 1};
-  error =
-      torch::executor::dim_order_to_stride(sizes_2, dim_order_2, 2, strides_2);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error = dim_order_to_stride(sizes_2, dim_order_2, 2, strides_2);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_2, 2}, {expected_strides_2, 2});
 
   dim_order_2[0] = 1;
   dim_order_2[1] = 0;
   expected_strides_2[0] = 1;
   expected_strides_2[1] = 2;
-  error =
-      torch::executor::dim_order_to_stride(sizes_2, dim_order_2, 2, strides_2);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error = dim_order_to_stride(sizes_2, dim_order_2, 2, strides_2);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_2, 2}, {expected_strides_2, 2});
 
   exec_aten::SizesType sizes_3[3] = {2, 5, 7};
   exec_aten::SizesType dim_order_3[3] = {0, 1, 2};
   exec_aten::SizesType strides_3[3] = {0, 0, 0};
   exec_aten::SizesType expected_strides_3[3] = {35, 7, 1};
-  error =
-      torch::executor::dim_order_to_stride(sizes_3, dim_order_3, 3, strides_3);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error = dim_order_to_stride(sizes_3, dim_order_3, 3, strides_3);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_3, 3}, {expected_strides_3, 3});
 
   // {0, 2, 1}
@@ -73,9 +76,8 @@ TEST(DimOrderUtilTest, DimOrderToStride) {
   // Expected stride {35, 1, 5}
   expected_strides_3[0] = 35, expected_strides_3[1] = 1,
   expected_strides_3[2] = 5;
-  error =
-      torch::executor::dim_order_to_stride(sizes_3, dim_order_3, 3, strides_3);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error = dim_order_to_stride(sizes_3, dim_order_3, 3, strides_3);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_3, 3}, {expected_strides_3, 3});
 
   // {2, 5, 7}
@@ -84,18 +86,16 @@ TEST(DimOrderUtilTest, DimOrderToStride) {
   // Expected stride {35, 1, 5}
   expected_strides_3[0] = 1, expected_strides_3[1] = 14,
   expected_strides_3[2] = 2;
-  error =
-      torch::executor::dim_order_to_stride(sizes_3, dim_order_3, 3, strides_3);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error = dim_order_to_stride(sizes_3, dim_order_3, 3, strides_3);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_3, 3}, {expected_strides_3, 3});
 
   exec_aten::SizesType sizes_4[4] = {2, 5, 7, 8};
   exec_aten::SizesType dim_order_4[4] = {0, 1, 2, 3};
   exec_aten::SizesType strides_4[4] = {0, 0, 0, 0};
   exec_aten::SizesType expected_strides_4[4] = {280, 56, 8, 1};
-  error =
-      torch::executor::dim_order_to_stride(sizes_4, dim_order_4, 4, strides_4);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error = dim_order_to_stride(sizes_4, dim_order_4, 4, strides_4);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_4, 4}, {expected_strides_4, 4});
 
   // {2, 5, 7, 8}
@@ -109,9 +109,8 @@ TEST(DimOrderUtilTest, DimOrderToStride) {
   expected_strides_4[1] = 1;
   expected_strides_4[2] = 40;
   expected_strides_4[3] = 5;
-  error =
-      torch::executor::dim_order_to_stride(sizes_4, dim_order_4, 4, strides_4);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error = dim_order_to_stride(sizes_4, dim_order_4, 4, strides_4);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_4, 4}, {expected_strides_4, 4});
 
   // {2, 5, 7, 8}
@@ -125,18 +124,16 @@ TEST(DimOrderUtilTest, DimOrderToStride) {
   expected_strides_4[1] = 14;
   expected_strides_4[2] = 2;
   expected_strides_4[3] = 70;
-  error =
-      torch::executor::dim_order_to_stride(sizes_4, dim_order_4, 4, strides_4);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error = dim_order_to_stride(sizes_4, dim_order_4, 4, strides_4);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_4, 4}, {expected_strides_4, 4});
 
   exec_aten::SizesType sizes_5[5] = {2, 5, 7, 8, 9};
   exec_aten::SizesType dim_order_5[5] = {0, 1, 2, 3, 4};
   exec_aten::SizesType strides_5[5] = {0, 0, 0, 0, 0};
   exec_aten::SizesType expected_strides_5[5] = {2520, 504, 72, 9, 1};
-  error =
-      torch::executor::dim_order_to_stride(sizes_5, dim_order_5, 5, strides_5);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error = dim_order_to_stride(sizes_5, dim_order_5, 5, strides_5);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_5, 5}, {expected_strides_5, 5});
 
   // {2, 5, 7, 8, 9}
@@ -152,9 +149,8 @@ TEST(DimOrderUtilTest, DimOrderToStride) {
   expected_strides_5[2] = 360;
   expected_strides_5[3] = 45;
   expected_strides_5[4] = 5;
-  error =
-      torch::executor::dim_order_to_stride(sizes_5, dim_order_5, 5, strides_5);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error = dim_order_to_stride(sizes_5, dim_order_5, 5, strides_5);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_5, 5}, {expected_strides_5, 5});
 
   // {2, 5, 7, 8, 9}
@@ -170,9 +166,8 @@ TEST(DimOrderUtilTest, DimOrderToStride) {
   expected_strides_5[2] = 80;
   expected_strides_5[3] = 5;
   expected_strides_5[4] = 560;
-  error =
-      torch::executor::dim_order_to_stride(sizes_5, dim_order_5, 5, strides_5);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error = dim_order_to_stride(sizes_5, dim_order_5, 5, strides_5);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_5, 5}, {expected_strides_5, 5});
 
   // Check 0 sized dims
@@ -180,9 +175,9 @@ TEST(DimOrderUtilTest, DimOrderToStride) {
   exec_aten::SizesType dim_order_3_zero[3] = {0, 1, 2};
   exec_aten::SizesType strides_3_zero[3] = {0, 0, 0};
   exec_aten::SizesType expected_strides_3_zero[3] = {5, 1, 1};
-  error = torch::executor::dim_order_to_stride(
-      sizes_3_zero, dim_order_3_zero, 3, strides_3_zero);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error =
+      dim_order_to_stride(sizes_3_zero, dim_order_3_zero, 3, strides_3_zero);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_3_zero, 3}, {expected_strides_3_zero, 3});
 
   // {0, 2, 1}
@@ -191,9 +186,9 @@ TEST(DimOrderUtilTest, DimOrderToStride) {
   // Expected stride {5, 5, 1}
   expected_strides_3_zero[0] = 5, expected_strides_3_zero[1] = 1,
   expected_strides_3_zero[2] = 5;
-  error = torch::executor::dim_order_to_stride(
-      sizes_3_zero, dim_order_3_zero, 3, strides_3_zero);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error =
+      dim_order_to_stride(sizes_3_zero, dim_order_3_zero, 3, strides_3_zero);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_3_zero, 3}, {expected_strides_3_zero, 3});
 
   // {2, 0, 1}
@@ -202,9 +197,9 @@ TEST(DimOrderUtilTest, DimOrderToStride) {
   // Expected stride {10, 5, 1}
   expected_strides_3_zero[0] = 5, expected_strides_3_zero[1] = 1,
   expected_strides_3_zero[2] = 10;
-  error = torch::executor::dim_order_to_stride(
-      sizes_3_zero, dim_order_3_zero, 3, strides_3_zero);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  error =
+      dim_order_to_stride(sizes_3_zero, dim_order_3_zero, 3, strides_3_zero);
+  EXPECT_EQ(error, Error::Ok);
   check_strides_eq({strides_3_zero, 3}, {expected_strides_3_zero, 3});
 }
 
@@ -212,9 +207,9 @@ TEST(DimOrderUtilTest, StrideToDimOrder) {
   exec_aten::SizesType strides[3] = {5, 1, 15};
   exec_aten::DimOrderType dim_order[3] = {0, 0, 0};
 
-  auto error = torch::executor::stride_to_dim_order(strides, 3, dim_order);
+  auto error = stride_to_dim_order(strides, 3, dim_order);
 
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  EXPECT_EQ(error, Error::Ok);
 
   exec_aten::DimOrderType expected_dim_order[3] = {2, 0, 1};
   check_dim_order_eq(dim_order, expected_dim_order);
@@ -224,8 +219,8 @@ TEST(DimOrderUtilTest, StrideToDimOrderSameStrides) {
   exec_aten::SizesType strides[4] = {4, 3, 1, 1};
   exec_aten::DimOrderType dim_order[4] = {0, 0, 0, 0};
 
-  auto error = torch::executor::stride_to_dim_order(strides, 4, dim_order);
-  EXPECT_EQ(error, torch::executor::Error::Ok);
+  auto error = stride_to_dim_order(strides, 4, dim_order);
+  EXPECT_EQ(error, Error::Ok);
 
   exec_aten::DimOrderType expected_dim_order[4] = {0, 1, 2, 3};
   check_dim_order_eq(dim_order, expected_dim_order);
@@ -236,12 +231,11 @@ TEST(DimOrderUtilTest, IsDefaultDimOrderTest) {
     std::vector<exec_aten::DimOrderType> dim_order(i);
     std::iota(dim_order.begin(), dim_order.end(), 0);
 
-    EXPECT_TRUE(torch::executor::is_contiguous_dim_order(
-        dim_order.data(), dim_order.size()));
+    EXPECT_TRUE(is_contiguous_dim_order(dim_order.data(), dim_order.size()));
 
     // As a bonus, check that is_channels_last returns false
-    EXPECT_FALSE(torch::executor::is_channels_last_dim_order(
-        dim_order.data(), dim_order.size()));
+    EXPECT_FALSE(
+        is_channels_last_dim_order(dim_order.data(), dim_order.size()));
   }
 }
 
@@ -252,8 +246,7 @@ TEST(DimOrderUtilTest, IsDefaultDimOrderFailCasesTest) {
     std::iota(dim_order.begin(), dim_order.end(), 0);
     std::swap(dim_order[0], dim_order[1]);
 
-    EXPECT_FALSE(torch::executor::is_contiguous_dim_order(
-        dim_order.data(), dim_order.size()));
+    EXPECT_FALSE(is_contiguous_dim_order(dim_order.data(), dim_order.size()));
   }
 
   // Dims is default order but shifted by 1
@@ -263,8 +256,7 @@ TEST(DimOrderUtilTest, IsDefaultDimOrderFailCasesTest) {
       dim_order[d] = (d + 1) % i;
     }
 
-    EXPECT_FALSE(torch::executor::is_contiguous_dim_order(
-        dim_order.data(), dim_order.size()));
+    EXPECT_FALSE(is_contiguous_dim_order(dim_order.data(), dim_order.size()));
   }
 }
 
@@ -272,12 +264,12 @@ TEST(DimOrderUtilTest, IsChannelsLastDimOrderTest) {
   exec_aten::DimOrderType dim_order_4d[4] = {0, 2, 3, 1};
   exec_aten::DimOrderType dim_order_5d[5] = {0, 2, 3, 4, 1};
 
-  EXPECT_TRUE(torch::executor::is_channels_last_dim_order(dim_order_4d, 4));
-  EXPECT_TRUE(torch::executor::is_channels_last_dim_order(dim_order_5d, 5));
+  EXPECT_TRUE(is_channels_last_dim_order(dim_order_4d, 4));
+  EXPECT_TRUE(is_channels_last_dim_order(dim_order_5d, 5));
 
   // As a bonus, check that is_default returns false
-  EXPECT_FALSE(torch::executor::is_contiguous_dim_order(dim_order_4d, 4));
-  EXPECT_FALSE(torch::executor::is_contiguous_dim_order(dim_order_5d, 5));
+  EXPECT_FALSE(is_contiguous_dim_order(dim_order_4d, 4));
+  EXPECT_FALSE(is_contiguous_dim_order(dim_order_5d, 5));
 }
 
 TEST(DimOrderUtilTest, IsChannelsLastDimOrderFailCasesTest) {
@@ -285,12 +277,12 @@ TEST(DimOrderUtilTest, IsChannelsLastDimOrderFailCasesTest) {
   exec_aten::DimOrderType dim_order_3d[4] = {1, 2, 0};
   exec_aten::DimOrderType dim_order_6d[6] = {0, 2, 3, 4, 5, 1};
 
-  EXPECT_FALSE(torch::executor::is_channels_last_dim_order(dim_order_3d, 3));
-  EXPECT_FALSE(torch::executor::is_channels_last_dim_order(dim_order_6d, 6));
+  EXPECT_FALSE(is_channels_last_dim_order(dim_order_3d, 3));
+  EXPECT_FALSE(is_channels_last_dim_order(dim_order_6d, 6));
 
   exec_aten::DimOrderType dim_order_4d[4] = {0, 3, 2, 1};
   exec_aten::DimOrderType dim_order_5d[5] = {4, 3, 2, 0, 1};
 
-  EXPECT_FALSE(torch::executor::is_channels_last_dim_order(dim_order_4d, 4));
-  EXPECT_FALSE(torch::executor::is_channels_last_dim_order(dim_order_5d, 5));
+  EXPECT_FALSE(is_channels_last_dim_order(dim_order_4d, 4));
+  EXPECT_FALSE(is_channels_last_dim_order(dim_order_5d, 5));
 }

--- a/runtime/core/exec_aten/util/test/operator_impl_example_test.cpp
+++ b/runtime/core/exec_aten/util/test/operator_impl_example_test.cpp
@@ -23,7 +23,7 @@
 using namespace ::testing;
 using exec_aten::ScalarType;
 using exec_aten::Tensor;
-using torch::executor::testing::TensorFactory;
+using executorch::runtime::testing::TensorFactory;
 
 //
 // A sample implementation of a PyTorch operator using the utilities in this

--- a/runtime/core/exec_aten/util/test/tensor_util_test.cpp
+++ b/runtime/core/exec_aten/util/test/tensor_util_test.cpp
@@ -19,7 +19,8 @@
 using namespace ::testing;
 using exec_aten::ScalarType;
 using exec_aten::Tensor;
-using torch::executor::testing::TensorFactory;
+using executorch::runtime::extract_scalar_tensor;
+using executorch::runtime::testing::TensorFactory;
 
 class TensorUtilTest : public ::testing::Test {
  protected:
@@ -34,7 +35,7 @@ class TensorUtilTest : public ::testing::Test {
   void SetUp() override {
     // As some of these tests cause ET_LOG to be called, the PAL must be
     // initialized first by calling runtime_init();
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
   }
 };
 
@@ -149,13 +150,13 @@ TEST_F(TensorUtilTest, GetLeadingDimsSmokeTest) {
   Tensor t = tf_int_.ones({2, 3, 4});
 
   // getLeadingDims(t, 1) => t.size(0)
-  EXPECT_EQ(torch::executor::getLeadingDims(t, 1), 2);
+  EXPECT_EQ(executorch::runtime::getLeadingDims(t, 1), 2);
 
   // getLeadingDims(t, 2) => t.size(0) * t.size(1)
-  EXPECT_EQ(torch::executor::getLeadingDims(t, 2), 6);
+  EXPECT_EQ(executorch::runtime::getLeadingDims(t, 2), 6);
 
   // getLeadingDims(t, 3) => t.size(0) * t.size(1) * t.size(2)
-  EXPECT_EQ(torch::executor::getLeadingDims(t, 3), 24);
+  EXPECT_EQ(executorch::runtime::getLeadingDims(t, 3), 24);
 }
 
 TEST_F(TensorUtilTest, GetLeadingDimsInputOutOfBoundDies) {
@@ -163,9 +164,9 @@ TEST_F(TensorUtilTest, GetLeadingDimsInputOutOfBoundDies) {
   Tensor t = tf_int_.ones({2, 3, 4});
 
   // dim needs to be in the range [0, t.dim()]
-  ET_EXPECT_DEATH(torch::executor::getLeadingDims(t, -2), "");
-  ET_EXPECT_DEATH(torch::executor::getLeadingDims(t, -1), "");
-  ET_EXPECT_DEATH(torch::executor::getLeadingDims(t, 4), "");
+  ET_EXPECT_DEATH(executorch::runtime::getLeadingDims(t, -2), "");
+  ET_EXPECT_DEATH(executorch::runtime::getLeadingDims(t, -1), "");
+  ET_EXPECT_DEATH(executorch::runtime::getLeadingDims(t, 4), "");
 }
 
 TEST_F(TensorUtilTest, GetTrailingDimsSmokeTest) {
@@ -173,13 +174,13 @@ TEST_F(TensorUtilTest, GetTrailingDimsSmokeTest) {
   Tensor t = tf_int_.ones({2, 3, 4});
 
   // getTrailingDims(t, 1) => t.size(2)
-  EXPECT_EQ(torch::executor::getTrailingDims(t, 1), 4);
+  EXPECT_EQ(executorch::runtime::getTrailingDims(t, 1), 4);
 
   // getTrailingDims(t, 0) => t.size(1) * t.size(2)
-  EXPECT_EQ(torch::executor::getTrailingDims(t, 0), 12);
+  EXPECT_EQ(executorch::runtime::getTrailingDims(t, 0), 12);
 
   // getTrailingDims(t, -1) => t.size(0) * t.size(1) * t.size(2)
-  EXPECT_EQ(torch::executor::getTrailingDims(t, -1), 24);
+  EXPECT_EQ(executorch::runtime::getTrailingDims(t, -1), 24);
 }
 
 TEST_F(TensorUtilTest, GetTrailingDimsInputOutOfBoundDies) {
@@ -187,9 +188,9 @@ TEST_F(TensorUtilTest, GetTrailingDimsInputOutOfBoundDies) {
   Tensor t = tf_int_.ones({2, 3, 4});
 
   // dim needs to be in the range [-1, t.dim() - 1)
-  ET_EXPECT_DEATH(torch::executor::getTrailingDims(t, -2), "");
-  ET_EXPECT_DEATH(torch::executor::getTrailingDims(t, 3), "");
-  ET_EXPECT_DEATH(torch::executor::getTrailingDims(t, 4), "");
+  ET_EXPECT_DEATH(executorch::runtime::getTrailingDims(t, -2), "");
+  ET_EXPECT_DEATH(executorch::runtime::getTrailingDims(t, 3), "");
+  ET_EXPECT_DEATH(executorch::runtime::getTrailingDims(t, 4), "");
 }
 
 TEST_F(TensorUtilTest, ContiguousCheckSupported) {
@@ -271,10 +272,10 @@ TEST_F(TensorUtilTest, CheckSameContiguousStrideSupported) {
 TEST_F(TensorUtilTest, ExtractIntScalarTensorSmoke) {
   Tensor t = tf_int_.ones({1});
   bool ok;
-#define CASE_INT_DTYPE(ctype, unused)                           \
-  ctype out_##ctype;                                            \
-  ok = torch::executor::extract_scalar_tensor(t, &out_##ctype); \
-  ASSERT_TRUE(ok);                                              \
+#define CASE_INT_DTYPE(ctype, unused)          \
+  ctype out_##ctype;                           \
+  ok = extract_scalar_tensor(t, &out_##ctype); \
+  ASSERT_TRUE(ok);                             \
   EXPECT_EQ(out_##ctype, 1);
 
   ET_FORALL_INT_TYPES(CASE_INT_DTYPE);
@@ -284,10 +285,10 @@ TEST_F(TensorUtilTest, ExtractIntScalarTensorSmoke) {
 TEST_F(TensorUtilTest, ExtractFloatScalarTensorFloatingTypeSmoke) {
   Tensor t = tf_float_.ones({1});
   bool ok;
-#define CASE_FLOAT_DTYPE(ctype, unused)                         \
-  ctype out_##ctype;                                            \
-  ok = torch::executor::extract_scalar_tensor(t, &out_##ctype); \
-  ASSERT_TRUE(ok);                                              \
+#define CASE_FLOAT_DTYPE(ctype, unused)        \
+  ctype out_##ctype;                           \
+  ok = extract_scalar_tensor(t, &out_##ctype); \
+  ASSERT_TRUE(ok);                             \
   EXPECT_EQ(out_##ctype, 1.0);
 
   ET_FORALL_FLOAT_TYPES(CASE_FLOAT_DTYPE);
@@ -297,10 +298,10 @@ TEST_F(TensorUtilTest, ExtractFloatScalarTensorFloatingTypeSmoke) {
 TEST_F(TensorUtilTest, ExtractFloatScalarTensorIntegralTypeSmoke) {
   Tensor t = tf_int_.ones({1});
   bool ok;
-#define CASE_FLOAT_DTYPE(ctype, unused)                         \
-  ctype out_##ctype;                                            \
-  ok = torch::executor::extract_scalar_tensor(t, &out_##ctype); \
-  ASSERT_TRUE(ok);                                              \
+#define CASE_FLOAT_DTYPE(ctype, unused)        \
+  ctype out_##ctype;                           \
+  ok = extract_scalar_tensor(t, &out_##ctype); \
+  ASSERT_TRUE(ok);                             \
   EXPECT_EQ(out_##ctype, 1.0);
 
   ET_FORALL_INT_TYPES(CASE_FLOAT_DTYPE);
@@ -311,7 +312,7 @@ TEST_F(TensorUtilTest, ExtractBoolScalarTensorSmoke) {
   Tensor t = tf_bool_.ones({1});
   bool out;
   bool ok;
-  ok = torch::executor::extract_scalar_tensor(t, &out);
+  ok = extract_scalar_tensor(t, &out);
   ASSERT_TRUE(ok);
   EXPECT_EQ(out, true);
 }
@@ -322,19 +323,19 @@ TEST_F(TensorUtilTest, FloatScalarTensorStressTests) {
 
   // Case: Positive Infinity
   Tensor t_pos_inf = tf_double_.make({1}, {INFINITY});
-  ok = torch::executor::extract_scalar_tensor(t_pos_inf, &value);
+  ok = extract_scalar_tensor(t_pos_inf, &value);
   EXPECT_TRUE(ok);
   EXPECT_TRUE(std::isinf(value));
 
   // Case: Negative Infinity
   Tensor t_neg_inf = tf_double_.make({1}, {-INFINITY});
-  ok = torch::executor::extract_scalar_tensor(t_neg_inf, &value);
+  ok = extract_scalar_tensor(t_neg_inf, &value);
   EXPECT_TRUE(ok);
   EXPECT_TRUE(std::isinf(value));
 
   // Case: Not a Number (NaN) - ex: sqrt(-1.0)
   Tensor t_nan = tf_double_.make({1}, {NAN});
-  ok = torch::executor::extract_scalar_tensor(t_nan, &value);
+  ok = extract_scalar_tensor(t_nan, &value);
   EXPECT_TRUE(ok);
   EXPECT_TRUE(std::isnan(value));
 }
@@ -344,7 +345,7 @@ TEST_F(TensorUtilTest, IntScalarTensorNotIntegralTypeFails) {
   int64_t out;
   // Fails since tensor is floating type but attempting to extract integer
   // value.
-  bool ok = torch::executor::extract_scalar_tensor(t, &out);
+  bool ok = extract_scalar_tensor(t, &out);
   EXPECT_FALSE(ok);
 }
 
@@ -352,7 +353,7 @@ TEST_F(TensorUtilTest, FloatScalarTensorNotFloatingTypeFails) {
   Tensor t = tf_bool_.ones({1});
   double out;
   // Fails since tensor is boolean type but attempting to extract float value.
-  bool ok = torch::executor::extract_scalar_tensor(t, &out);
+  bool ok = extract_scalar_tensor(t, &out);
   EXPECT_FALSE(ok);
 }
 
@@ -360,7 +361,7 @@ TEST_F(TensorUtilTest, IntTensorNotScalarFails) {
   Tensor t = tf_int_.ones({2, 3});
   int64_t out;
   // Fails since tensor has multiple dims and values.
-  bool ok = torch::executor::extract_scalar_tensor(t, &out);
+  bool ok = extract_scalar_tensor(t, &out);
   EXPECT_FALSE(ok);
 }
 
@@ -368,7 +369,7 @@ TEST_F(TensorUtilTest, FloatTensorNotScalarFails) {
   Tensor t = tf_float_.ones({2, 3});
   double out;
   // Fails since tensor has multiple dims and values.
-  bool ok = torch::executor::extract_scalar_tensor(t, &out);
+  bool ok = extract_scalar_tensor(t, &out);
   EXPECT_FALSE(ok);
 }
 
@@ -376,7 +377,7 @@ TEST_F(TensorUtilTest, IntTensorOutOfBoundFails) {
   Tensor t = tf_int_.make({1}, {256});
   int8_t out;
   // Fails since 256 is out of bounds for `int8_t` (-128 to 127).
-  bool ok = torch::executor::extract_scalar_tensor(t, &out);
+  bool ok = extract_scalar_tensor(t, &out);
   EXPECT_FALSE(ok);
 }
 
@@ -385,9 +386,9 @@ TEST_F(TensorUtilTest, FloatTensorOutOfBoundFails) {
   float out;
   bool ok;
 
-#define CASE_FLOAT(value)                               \
-  t = tf_double_.make({1}, {value});                    \
-  ok = torch::executor::extract_scalar_tensor(t, &out); \
+#define CASE_FLOAT(value)              \
+  t = tf_double_.make({1}, {value});   \
+  ok = extract_scalar_tensor(t, &out); \
   EXPECT_FALSE(ok);
 
   // Float tensor can't handle double's largest negative value (note the use of
@@ -405,7 +406,7 @@ TEST_F(TensorUtilTest, BoolScalarTensorNotBooleanTypeFails) {
   bool out;
   // Fails since tensor is integral type but attempting to extract boolean
   // value.
-  bool ok = torch::executor::extract_scalar_tensor(c, &out);
+  bool ok = extract_scalar_tensor(c, &out);
   EXPECT_FALSE(ok);
 }
 
@@ -413,7 +414,7 @@ TEST_F(TensorUtilTest, BoolTensorNotScalarFails) {
   Tensor c = tf_bool_.ones({2, 3});
   bool out;
   // Fails since tensor has multiple dims and values.
-  bool ok = torch::executor::extract_scalar_tensor(c, &out);
+  bool ok = extract_scalar_tensor(c, &out);
   EXPECT_FALSE(ok);
 }
 
@@ -422,7 +423,7 @@ TEST_F(TensorUtilTest, BoolTensorNotScalarFails) {
 //
 
 TEST_F(TensorUtilTest, TensorIsRankTest) {
-  using namespace torch::executor;
+  using executorch::runtime::tensor_is_rank;
   Tensor a = tf_float_.ones({2, 3, 5});
 
   EXPECT_TRUE(tensor_is_rank(a, 3));
@@ -431,7 +432,7 @@ TEST_F(TensorUtilTest, TensorIsRankTest) {
 }
 
 TEST_F(TensorUtilTest, TensorHasDimTest) {
-  using namespace torch::executor;
+  using executorch::runtime::tensor_has_dim;
   Tensor a = tf_float_.ones({2, 3, 5});
 
   EXPECT_TRUE(tensor_has_dim(a, 2));
@@ -446,7 +447,7 @@ TEST_F(TensorUtilTest, TensorHasDimTest) {
 }
 
 TEST_F(TensorUtilTest, TensorsHaveSameDtypeTest) {
-  using namespace torch::executor;
+  using executorch::runtime::tensors_have_same_dtype;
   Tensor a = tf_float_.ones({2, 3});
   Tensor b = tf_float_.ones({2, 3});
   Tensor c = tf_float_.ones({3, 3});
@@ -459,7 +460,7 @@ TEST_F(TensorUtilTest, TensorsHaveSameDtypeTest) {
 }
 
 TEST_F(TensorUtilTest, TensorsHaveSameSizeAtDimTest) {
-  using namespace torch::executor;
+  using executorch::runtime::tensors_have_same_size_at_dims;
   Tensor a = tf_float_.ones({2, 3, 4, 5});
   Tensor b = tf_float_.ones({5, 4, 3, 2});
 
@@ -471,7 +472,7 @@ TEST_F(TensorUtilTest, TensorsHaveSameSizeAtDimTest) {
 }
 
 TEST_F(TensorUtilTest, TensorsHaveSameShapeTest) {
-  using namespace torch::executor;
+  using executorch::runtime::tensors_have_same_shape;
   Tensor a = tf_float_.ones({2, 3});
   Tensor b = tf_int_.ones({2, 3});
   Tensor c = tf_byte_.ones({2, 3});
@@ -494,7 +495,7 @@ TEST_F(TensorUtilTest, TensorsHaveSameShapeTest) {
 }
 
 TEST_F(TensorUtilTest, TensorsHaveSameShapeAndDtypeTest) {
-  using namespace torch::executor;
+  using executorch::runtime::tensors_have_same_shape_and_dtype;
   Tensor a = tf_float_.ones({2, 3});
   Tensor b = tf_float_.ones({2, 3});
   Tensor c = tf_float_.ones({2, 3});
@@ -516,7 +517,7 @@ TEST_F(TensorUtilTest, TensorsHaveSameShapeAndDtypeTest) {
 }
 
 TEST_F(TensorUtilTest, TensorsHaveSameStridesTest) {
-  using namespace torch::executor;
+  using executorch::runtime::tensors_have_same_strides;
   Tensor a = tf_float_.full_channels_last({4, 5, 2, 3}, 1);
   Tensor b = tf_float_.full_channels_last({4, 5, 2, 3}, 2);
   Tensor c = tf_float_.full_channels_last({4, 5, 2, 3}, 3);
@@ -531,7 +532,7 @@ TEST_F(TensorUtilTest, TensorsHaveSameStridesTest) {
 }
 
 TEST_F(TensorUtilTest, TensorIsContiguous) {
-  using namespace torch::executor;
+  using executorch::runtime::tensor_is_contiguous;
   // Note that the strides.size() == 0 case is not tested, since
   Tensor a = tf_float_.full_channels_last({4, 5, 2, 3}, 1);
   Tensor b = tf_float_.ones({4, 5, 2, 3});
@@ -545,9 +546,10 @@ TEST_F(TensorUtilTest, TensorIsContiguous) {
 }
 
 TEST_F(TensorUtilTest, ResizeZeroDimTensor) {
-  using namespace torch::executor;
   Tensor a = tf_float_.ones({});
 
-  EXPECT_EQ(resize_tensor(a, {}), Error::Ok);
+  EXPECT_EQ(
+      executorch::runtime::resize_tensor(a, {}),
+      executorch::runtime::Error::Ok);
   EXPECT_EQ(a.dim(), 0);
 }

--- a/runtime/core/portable_type/tensor_impl.h
+++ b/runtime/core/portable_type/tensor_impl.h
@@ -15,15 +15,19 @@
 #include <executorch/runtime/core/portable_type/scalar_type.h>
 #include <executorch/runtime/core/tensor_shape_dynamism.h>
 
-namespace torch {
-namespace executor {
-
 // Forward declaration of a helper that provides access to internal resizing
 // methods of TensorImpl. Real definition is in
 // executorch/runtime/core/exec_aten/tensor_util.h.
+namespace executorch {
+namespace runtime {
 namespace internal {
 class TensorResizerFriend;
 } // namespace internal
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
 
 /**
  * Manages the storage behind an ETensor (torch::executor::Tensor).
@@ -204,7 +208,7 @@ class TensorImpl {
 
  private:
   // For access to internal_resize_contiguous().
-  friend class internal::TensorResizerFriend;
+  friend class ::executorch::runtime::internal::TensorResizerFriend;
 
   /**
    * Set the sizes and strides of a tensor assuming contiguous strides.

--- a/runtime/core/test/evalue_test.cpp
+++ b/runtime/core/test/evalue_test.cpp
@@ -18,7 +18,7 @@ using exec_aten::ScalarType;
 using executorch::runtime::BoxedEvalueList;
 using executorch::runtime::EValue;
 using executorch::runtime::Tag;
-using torch::executor::testing::TensorFactory;
+using executorch::runtime::testing::TensorFactory;
 
 TEST(TestEValue, CopyTrivialType) {
   EValue a;

--- a/runtime/executor/memory_manager.h
+++ b/runtime/executor/memory_manager.h
@@ -11,8 +11,8 @@
 #include <executorch/runtime/core/hierarchical_allocator.h>
 #include <executorch/runtime/core/memory_allocator.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 /**
  * A container class for allocators used during Method load and execution.
@@ -113,5 +113,13 @@ class MemoryManager final {
   MemoryAllocator* temp_allocator_;
 };
 
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::MemoryManager;
 } // namespace executor
 } // namespace torch

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -26,8 +26,8 @@
 #include <executorch/runtime/platform/profiler.h>
 #include <executorch/schema/program_generated.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 /**
  * Runtime state for a backend delegate.
@@ -252,10 +252,10 @@ Result<bool> parse_cond_value(const EValue& cond_value) {
     // currently. If that's not the case then something is wrong in the model
     // and we should exit.
     ET_CHECK_OR_RETURN_ERROR(
-        ScalarType::Bool == cond_val.scalar_type(),
+        exec_aten::ScalarType::Bool == cond_val.scalar_type(),
         InvalidProgram,
         "Expected dtype of %" PRId8 " got %" PRId8,
-        static_cast<int8_t>(ScalarType::Bool),
+        static_cast<int8_t>(exec_aten::ScalarType::Bool),
         static_cast<int8_t>(cond_val.scalar_type()));
 
     const bool* cond_data = cond_val.const_data_ptr<bool>();
@@ -944,7 +944,7 @@ Method::set_output_data_ptr(void* buffer, size_t size, size_t output_idx) {
   //     allowed.");
   // TODO(T188740925): for now, return error without logs.
   if (pre_allocated_output_) {
-    return ::torch::executor::Error::InvalidState;
+    return Error::InvalidState;
   }
 
   // Check the args
@@ -1369,5 +1369,5 @@ Method::~Method() {
   }
   // All other fields are trivially destructible.
 }
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch

--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -24,8 +24,8 @@ struct ExecutionPlan;
 struct EValue;
 } // namespace executorch_flatbuffer
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 // Forward declare Program to avoid a circular reference.
 class Program;
@@ -350,5 +350,13 @@ class Method final {
   void log_outputs();
 };
 
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::Method;
 } // namespace executor
 } // namespace torch

--- a/runtime/executor/method_meta.cpp
+++ b/runtime/executor/method_meta.cpp
@@ -15,8 +15,8 @@
 #include <executorch/runtime/executor/method_meta.h>
 #include <executorch/schema/program_generated.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 namespace {
 Result<Tag> get_tag(
@@ -59,7 +59,8 @@ size_t calculate_nbytes(
   for (ssize_t i = 0; i < sizes.size(); i++) {
     n *= sizes[i];
   }
-  return n * torch::executor::elementSize(scalar_type);
+  // Use the full namespace to disambiguate from c10::elementSize.
+  return n * executorch::runtime::elementSize(scalar_type);
 }
 
 } // namespace
@@ -196,5 +197,5 @@ Result<int64_t> MethodMeta::memory_planned_buffer_size(size_t index) const {
   return s_plan_->non_const_buffer_sizes()->Get(index + 1);
 }
 
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch

--- a/runtime/executor/method_meta.h
+++ b/runtime/executor/method_meta.h
@@ -19,8 +19,8 @@ namespace executorch_flatbuffer {
 struct ExecutionPlan;
 } // namespace executorch_flatbuffer
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 /**
  * Metadata about a specific tensor of an ExecuTorch Program.
@@ -200,5 +200,14 @@ class MethodMeta final {
   const executorch_flatbuffer::ExecutionPlan* s_plan_;
 };
 
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::MethodMeta;
+using ::executorch::runtime::TensorInfo;
 } // namespace executor
 } // namespace torch

--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -29,8 +29,8 @@
 
 #pragma clang diagnostic ignored "-Wshadow"
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 namespace {
 
@@ -495,5 +495,5 @@ Error Program::load_mutable_subsegment_into(
       segment_base_offset_ + segment->offset() + offset, size, info, buffer);
 }
 
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch

--- a/runtime/executor/program.h
+++ b/runtime/executor/program.h
@@ -27,8 +27,8 @@ namespace executorch_flatbuffer {
 struct Program;
 } // namespace executorch_flatbuffer
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 namespace testing {
 // Provides test access to private Program methods.
@@ -290,5 +290,13 @@ class Program final {
   FreeableBuffer constant_segment_data_;
 };
 
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::Program;
 } // namespace executor
 } // namespace torch

--- a/runtime/executor/tensor_parser.h
+++ b/runtime/executor/tensor_parser.h
@@ -14,8 +14,8 @@
 #include <executorch/runtime/executor/program.h>
 #include <executorch/schema/program_generated.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 namespace deserialization {
 
 ET_NODISCARD Result<exec_aten::Tensor> parseTensor(
@@ -98,6 +98,19 @@ ET_NODISCARD Result<void*> getTensorDataPtr(
     size_t nbytes,
     HierarchicalAllocator* allocator);
 
+} // namespace deserialization
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+namespace deserialization {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::deserialization::getTensorDataPtr;
+using ::executorch::runtime::deserialization::parseListOptionalType;
+using ::executorch::runtime::deserialization::parseTensor;
+using ::executorch::runtime::deserialization::parseTensorList;
 } // namespace deserialization
 } // namespace executor
 } // namespace torch

--- a/runtime/executor/tensor_parser_aten.cpp
+++ b/runtime/executor/tensor_parser_aten.cpp
@@ -17,11 +17,9 @@
 
 #include <ATen/ATen.h> // @donotremove @manual=//caffe2/aten:ATen-core
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 namespace deserialization {
-
-using torch::executor::Error;
 
 namespace {
 
@@ -70,7 +68,7 @@ Result<at::Tensor> parseTensor(
   std::vector<int64_t> sizes(
       s_tensor->sizes()->begin(), s_tensor->sizes()->end());
   std::vector<int64_t> strides(ndim);
-  auto status = torch::executor::dim_order_to_stride(
+  auto status = dim_order_to_stride(
       s_tensor->sizes()->data(),
       s_tensor->dim_order()->data(),
       ndim,
@@ -96,7 +94,7 @@ Result<at::Tensor> parseTensor(
     // within aten kernels.
     auto impl = tensor.unsafeGetTensorImpl();
     at::StorageImpl* storage = impl->unsafe_storage().unsafeGetStorageImpl();
-    storage->set_allocator(getCPUAllocator());
+    storage->set_allocator(at::getCPUAllocator());
     storage->set_resizable(true);
     storage->set_nbytes(0);
     impl->set_sizes_contiguous(0);
@@ -113,12 +111,12 @@ Result<at::Tensor> parseTensor(
       return data_ptr.error();
     }
     tensor.unsafeGetTensorImpl()->unsafe_storage().set_data_ptr(
-        at::DataPtr(data_ptr.get(), DeviceType::CPU));
+        at::DataPtr(data_ptr.get(), c10::DeviceType::CPU));
   }
 
   return tensor;
 }
 
 } // namespace deserialization
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch

--- a/runtime/executor/tensor_parser_exec_aten.cpp
+++ b/runtime/executor/tensor_parser_exec_aten.cpp
@@ -15,8 +15,8 @@
 #include <executorch/runtime/platform/profiler.h>
 #include <executorch/schema/program_generated.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 namespace deserialization {
 
 // Provides access to private Program methods.
@@ -143,5 +143,5 @@ ET_NODISCARD Result<void*> getTensorDataPtr(
 }
 
 } // namespace deserialization
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch

--- a/runtime/executor/tensor_parser_portable.cpp
+++ b/runtime/executor/tensor_parser_portable.cpp
@@ -16,11 +16,15 @@
 #include <executorch/runtime/platform/profiler.h>
 #include <executorch/schema/program_generated.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 namespace deserialization {
 
-Result<torch::executor::Tensor> parseTensor(
+using torch::executor::ScalarType;
+using torch::executor::Tensor;
+using torch::executor::TensorImpl;
+
+Result<Tensor> parseTensor(
     const Program* program,
     MemoryManager* memory_manager,
     const executorch_flatbuffer::Tensor* s_tensor) {
@@ -103,18 +107,17 @@ Result<torch::executor::Tensor> parseTensor(
   // will introduce incompatible APIs between ATen Tensor and ETensor.
   exec_aten::StridesType* strides = ET_ALLOCATE_LIST_OR_RETURN_ERROR(
       method_allocator, exec_aten::StridesType, dim);
-  auto status =
-      torch::executor::dim_order_to_stride(sizes, dim_order, dim, strides);
+  auto status = dim_order_to_stride(sizes, dim_order, dim, strides);
   ET_CHECK_OR_RETURN_ERROR(
       status == Error::Ok,
       Internal,
       "dim_order_to_stride returned invalid status");
 
-  auto* tensor_impl = ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(
-      method_allocator, torch::executor::TensorImpl);
+  auto* tensor_impl =
+      ET_ALLOCATE_INSTANCE_OR_RETURN_ERROR(method_allocator, TensorImpl);
   // Placement new on the allocated memory space. Note that we create this first
   // with null data so we can find its expected size before getting its memory.
-  new (tensor_impl) torch::executor::TensorImpl(
+  new (tensor_impl) TensorImpl(
       scalar_type,
       dim,
       sizes,
@@ -138,9 +141,9 @@ Result<torch::executor::Tensor> parseTensor(
   }
   tensor_impl->set_data(data_ptr.get());
 
-  return torch::executor::Tensor(tensor_impl);
+  return Tensor(tensor_impl);
 }
 
 } // namespace deserialization
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch

--- a/runtime/executor/test/allocation_failure_stress_test.cpp
+++ b/runtime/executor/test/allocation_failure_stress_test.cpp
@@ -24,13 +24,13 @@ using namespace ::testing;
 using exec_aten::ArrayRef;
 using exec_aten::Scalar;
 using exec_aten::Tensor;
-using torch::executor::Error;
-using torch::executor::MemoryAllocator;
-using torch::executor::MemoryManager;
-using torch::executor::Method;
-using torch::executor::Program;
-using torch::executor::Result;
-using torch::executor::testing::ManagedMemoryManager;
+using executorch::runtime::Error;
+using executorch::runtime::MemoryAllocator;
+using executorch::runtime::MemoryManager;
+using executorch::runtime::Method;
+using executorch::runtime::Program;
+using executorch::runtime::Result;
+using executorch::runtime::testing::ManagedMemoryManager;
 using torch::executor::util::FileDataLoader;
 
 constexpr size_t kDefaultNonConstMemBytes = 32 * 1024U;
@@ -39,7 +39,7 @@ constexpr size_t kDefaultRuntimeMemBytes = 32 * 1024U;
 class AllocationFailureStressTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
 
     // Create a loader for the serialized ModuleAdd program.
     const char* path = std::getenv("ET_MODULE_ADD_PATH");

--- a/runtime/executor/test/backend_integration_test.cpp
+++ b/runtime/executor/test/backend_integration_test.cpp
@@ -29,20 +29,20 @@
 
 using namespace ::testing;
 using exec_aten::ArrayRef;
-using torch::executor::BackendExecutionContext;
-using torch::executor::BackendInitContext;
-using torch::executor::CompileSpec;
-using torch::executor::DataLoader;
-using torch::executor::DelegateHandle;
-using torch::executor::Error;
-using torch::executor::EValue;
-using torch::executor::FreeableBuffer;
-using torch::executor::MemoryAllocator;
-using torch::executor::Method;
-using torch::executor::Program;
-using torch::executor::PyTorchBackendInterface;
-using torch::executor::Result;
-using torch::executor::testing::ManagedMemoryManager;
+using executorch::runtime::BackendExecutionContext;
+using executorch::runtime::BackendInitContext;
+using executorch::runtime::CompileSpec;
+using executorch::runtime::DataLoader;
+using executorch::runtime::DelegateHandle;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::MemoryAllocator;
+using executorch::runtime::Method;
+using executorch::runtime::Program;
+using executorch::runtime::PyTorchBackendInterface;
+using executorch::runtime::Result;
+using executorch::runtime::testing::ManagedMemoryManager;
 using torch::executor::util::FileDataLoader;
 
 /**
@@ -135,7 +135,7 @@ class StubBackend final : public PyTorchBackendInterface {
   static Error register_singleton(const char* name = kName) {
     if (!registered_) {
       registered_ = true;
-      return torch::executor::register_backend({name, &singleton_});
+      return executorch::runtime::register_backend({name, &singleton_});
     }
     return Error::Ok;
   }
@@ -281,7 +281,7 @@ class BackendIntegrationTest : public ::testing::TestWithParam<bool> {
   void SetUp() override {
     // Since these tests cause ET_LOG to be called, the PAL must be initialized
     // first.
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
 
     // Make sure that the backend has been registered. Safe to call multiple
     // times. Doing this at runtime ensures that it's only registered if these
@@ -326,7 +326,7 @@ class BackendIntegrationTest : public ::testing::TestWithParam<bool> {
 
 TEST_P(BackendIntegrationTest, BackendIsPresent) {
   PyTorchBackendInterface* backend =
-      torch::executor::get_backend_class(StubBackend::kName);
+      executorch::runtime::get_backend_class(StubBackend::kName);
   ASSERT_EQ(backend, &StubBackend::singleton());
 }
 
@@ -548,7 +548,7 @@ class DelegateDataAlignmentTest : public ::testing::TestWithParam<bool> {
   void SetUp() override {
     // Since these tests cause ET_LOG to be called, the PAL must be initialized
     // first.
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
 
     // Make sure that the backend has been registered. Safe to call multiple
     // times. Doing this at runtime ensures that it's only registered if these

--- a/runtime/executor/test/executor_test.cpp
+++ b/runtime/executor/test/executor_test.cpp
@@ -22,19 +22,19 @@ using exec_aten::Scalar;
 using exec_aten::ScalarType;
 using exec_aten::SizesType;
 using exec_aten::Tensor;
-using torch::executor::Error;
-using torch::executor::EValue;
-using torch::executor::getOpsFn;
-using torch::executor::hasOpsFn;
-using torch::executor::Kernel;
-using torch::executor::KernelRuntimeContext;
-using torch::executor::register_kernels;
-using torch::executor::testing::TensorFactory;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::getOpsFn;
+using executorch::runtime::hasOpsFn;
+using executorch::runtime::Kernel;
+using executorch::runtime::KernelRuntimeContext;
+using executorch::runtime::register_kernels;
+using executorch::runtime::testing::TensorFactory;
 
 class ExecutorTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
   }
 };
 

--- a/runtime/executor/test/kernel_integration_test.cpp
+++ b/runtime/executor/test/kernel_integration_test.cpp
@@ -27,17 +27,17 @@
 #include <gtest/gtest.h>
 
 using namespace ::testing;
-using torch::executor::ArrayRef;
-using torch::executor::Error;
-using torch::executor::EValue;
-using torch::executor::FreeableBuffer;
-using torch::executor::Kernel;
-using torch::executor::KernelKey;
-using torch::executor::KernelRuntimeContext;
-using torch::executor::Method;
-using torch::executor::Program;
-using torch::executor::Result;
-using torch::executor::testing::ManagedMemoryManager;
+using executorch::runtime::ArrayRef;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::Kernel;
+using executorch::runtime::KernelKey;
+using executorch::runtime::KernelRuntimeContext;
+using executorch::runtime::Method;
+using executorch::runtime::Program;
+using executorch::runtime::Result;
+using executorch::runtime::testing::ManagedMemoryManager;
 using torch::executor::util::FileDataLoader;
 
 constexpr size_t kDefaultNonConstMemBytes = 32 * 1024U;
@@ -90,10 +90,11 @@ struct KernelControl {
     //     TensorMeta(ScalarType::Float, contiguous), // other
     //     TensorMeta(ScalarType::Float, contiguous), // out
     //     TensorMeta(ScalarType::Float, contiguous)}; // out (repeated)
-    KernelKey key = torch::executor::KernelKey("v1/6;0,1|6;0,1|6;0,1|6;0,1");
-    Kernel kernel = torch::executor::Kernel(
+    KernelKey key =
+        executorch::runtime::KernelKey("v1/6;0,1|6;0,1|6;0,1|6;0,1");
+    Kernel kernel = executorch::runtime::Kernel(
         "aten::add.out", key, KernelControl::kernel_hook);
-    Error err = torch::executor::register_kernels({kernel});
+    Error err = executorch::runtime::register_kernels({kernel});
     EXPECT_EQ(err, Error::Ok);
 
     registered_ = true;
@@ -128,7 +129,7 @@ KernelControl KernelControl::singleton_;
 class KernelIntegrationTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
 
     // Register the controllable kernel hook.
     KernelControl::register_singleton();

--- a/runtime/executor/test/kernel_resolution_test.cpp
+++ b/runtime/executor/test/kernel_resolution_test.cpp
@@ -25,19 +25,19 @@
 #include <gtest/gtest.h>
 
 using namespace ::testing;
-using torch::executor::Error;
-using torch::executor::EValue;
-using torch::executor::Kernel;
-using torch::executor::KernelKey;
-using torch::executor::KernelRuntimeContext;
-using torch::executor::Method;
-using torch::executor::Program;
-using torch::executor::register_kernels;
-using torch::executor::Result;
-using torch::executor::Scalar;
-using torch::executor::ScalarType;
-using torch::executor::TensorMeta;
-using torch::executor::testing::ManagedMemoryManager;
+using exec_aten::Scalar;
+using exec_aten::ScalarType;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::Kernel;
+using executorch::runtime::KernelKey;
+using executorch::runtime::KernelRuntimeContext;
+using executorch::runtime::Method;
+using executorch::runtime::Program;
+using executorch::runtime::register_kernels;
+using executorch::runtime::Result;
+using executorch::runtime::TensorMeta;
+using executorch::runtime::testing::ManagedMemoryManager;
 using torch::executor::util::FileDataLoader;
 
 constexpr size_t kDefaultNonConstMemBytes = 32 * 1024U;
@@ -48,7 +48,7 @@ class KernelResolutionTest : public ::testing::Test {
   void SetUp() override {
     // Since these tests cause ET_LOG to be called, the PAL must be initialized
     // first.
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
 
     // Create a loader for the serialized ModuleAdd program.
     const char* path = std::getenv("ET_MODULE_ADD_PATH");
@@ -78,7 +78,7 @@ TEST_F(KernelResolutionTest, InitExecutionPlanSuccess) {
         *(stack[0]) = Scalar(100);
       });
   auto s1 = register_kernels({kernel_1});
-  EXPECT_EQ(s1, torch::executor::Error::Ok);
+  EXPECT_EQ(s1, executorch::runtime::Error::Ok);
 
   ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
   auto method = program_->load_method("forward", &mmm.get());
@@ -110,7 +110,7 @@ TEST_F(KernelResolutionTest, ResolveKernelKeySuccess) {
         *(stack[0]) = Scalar(100);
       });
   auto s1 = register_kernels({kernel_1});
-  EXPECT_EQ(s1, torch::executor::Error::Ok);
+  EXPECT_EQ(s1, executorch::runtime::Error::Ok);
 
   ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
   auto method = program_->load_method("forward", &mmm.get());

--- a/runtime/executor/test/managed_memory_manager.h
+++ b/runtime/executor/test/managed_memory_manager.h
@@ -15,8 +15,8 @@
 #include <executorch/runtime/core/memory_allocator.h>
 #include <executorch/runtime/executor/memory_manager.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 namespace testing {
 
 /**
@@ -44,7 +44,7 @@ class ManagedMemoryManager {
  private:
   std::unique_ptr<uint8_t[]> planned_memory_buffer_;
   Span<uint8_t> planned_memory_span_;
-  torch::executor::HierarchicalAllocator planned_memory_;
+  HierarchicalAllocator planned_memory_;
 
   std::unique_ptr<uint8_t[]> method_allocator_pool_;
   MemoryAllocator method_allocator_;
@@ -52,6 +52,16 @@ class ManagedMemoryManager {
   MemoryManager memory_manager_;
 };
 
+} // namespace testing
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+namespace testing {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::testing::ManagedMemoryManager;
 } // namespace testing
 } // namespace executor
 } // namespace torch

--- a/runtime/executor/test/memory_manager_test.cpp
+++ b/runtime/executor/test/memory_manager_test.cpp
@@ -14,9 +14,9 @@
 #include <gtest/gtest.h>
 
 using namespace ::testing;
-
-namespace torch {
-namespace executor {
+using executorch::runtime::HierarchicalAllocator;
+using executorch::runtime::MemoryAllocator;
+using executorch::runtime::MemoryManager;
 
 TEST(MemoryManagerTest, MinimalCtor) {
   MemoryAllocator method_allocator(0, nullptr);
@@ -93,6 +93,3 @@ TEST(MemoryManagerTest, CtorWithSameAllocator) {
           /*temp_allocator=*/&method_allocator),
       "");
 }
-
-} // namespace executor
-} // namespace torch

--- a/runtime/executor/test/method_meta_test.cpp
+++ b/runtime/executor/test/method_meta_test.cpp
@@ -6,21 +6,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/runtime/executor/method_meta.h>
+
 #include <cstdlib>
 #include <filesystem>
 
 #include <executorch/extension/data_loader/file_data_loader.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
-#include <executorch/runtime/executor/method_meta.h>
 #include <executorch/runtime/executor/program.h>
 #include <gtest/gtest.h>
 
 using namespace ::testing;
-using torch::executor::Error;
-using torch::executor::MethodMeta;
-using torch::executor::Program;
-using torch::executor::Result;
-using torch::executor::TensorInfo;
+using executorch::runtime::Error;
+using executorch::runtime::MethodMeta;
+using executorch::runtime::Program;
+using executorch::runtime::Result;
+using executorch::runtime::TensorInfo;
 using torch::executor::util::FileDataLoader;
 
 class MethodMetaTest : public ::testing::Test {

--- a/runtime/executor/test/method_test.cpp
+++ b/runtime/executor/test/method_test.cpp
@@ -21,12 +21,12 @@
 
 using namespace ::testing;
 using exec_aten::ArrayRef;
-using torch::executor::Error;
-using torch::executor::EValue;
-using torch::executor::Method;
-using torch::executor::Program;
-using torch::executor::Result;
-using torch::executor::testing::ManagedMemoryManager;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::Method;
+using executorch::runtime::Program;
+using executorch::runtime::Result;
+using executorch::runtime::testing::ManagedMemoryManager;
 using torch::executor::util::FileDataLoader;
 
 constexpr size_t kDefaultNonConstMemBytes = 32 * 1024U;
@@ -52,7 +52,7 @@ class MethodTest : public ::testing::Test {
   }
 
   void SetUp() override {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
 
     load_program(std::getenv("ET_MODULE_ADD_PATH"), "add");
     load_program(std::getenv("ET_MODULE_INDEX_PATH"), "index");
@@ -220,10 +220,10 @@ TEST_F(MethodTest, AliasedIOTest) {
   int32_t sizes[2] = {2, 4};
   uint8_t dim_order[2] = {0, 1};
   int32_t strides[2] = {4, 1};
-  torch::executor::TensorImpl impl(
-      torch::executor::ScalarType::Float, 2, sizes, buffer, dim_order, strides);
+  exec_aten::TensorImpl impl(
+      exec_aten::ScalarType::Float, 2, sizes, buffer, dim_order, strides);
 
-  auto input_err = method->set_input(EValue(torch::executor::Tensor(&impl)), 0);
+  auto input_err = method->set_input(EValue(exec_aten::Tensor(&impl)), 0);
   ASSERT_EQ(input_err, Error::Ok);
 
   auto output_err = method->set_output_data_ptr(buffer, sizeof(buffer), 0);
@@ -250,9 +250,9 @@ TEST_F(MethodTest, AliasedIOTest) {
 
   // Set the input again to update the size.
   sizes[0] = output.toTensor().sizes()[0];
-  torch::executor::TensorImpl impl_2(
-      torch::executor::ScalarType::Float, 2, sizes, buffer, dim_order, strides);
-  input_err = method->set_input(EValue(torch::executor::Tensor(&impl_2)), 0);
+  exec_aten::TensorImpl impl_2(
+      exec_aten::ScalarType::Float, 2, sizes, buffer, dim_order, strides);
+  input_err = method->set_input(EValue(exec_aten::Tensor(&impl_2)), 0);
   ASSERT_EQ(input_err, Error::Ok);
 
   // Execute the method again. Cat a 1x4 to a 3x4.
@@ -308,7 +308,7 @@ TEST_F(MethodTest, ConstantBufferTest) {
 
 //   // Can execute the method.
 //   exec_aten::ArrayRef<void*> inputs =
-//       torch::executor::util::PrepareInputTensors(*method);
+//       executorch::runtime::util::PrepareInputTensors(*method);
 //   Error err = method->execute();
 //   ASSERT_EQ(err, Error::Ok);
 
@@ -320,5 +320,5 @@ TEST_F(MethodTest, ConstantBufferTest) {
 //   EXPECT_EQ(outputs.toTensor().size(1), 2);
 //   EXPECT_EQ(outputs.toTensor().size(2), 10);
 
-//   torch::executor::util::FreeInputs(inputs);
+//   executorch::runtime::util::FreeInputs(inputs);
 // }

--- a/runtime/executor/test/program_test.cpp
+++ b/runtime/executor/test/program_test.cpp
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/runtime/executor/program.h>
+
 #include <cctype>
 #include <filesystem>
 
@@ -16,7 +18,6 @@
 #include <executorch/extension/data_loader/file_data_loader.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/result.h>
-#include <executorch/runtime/executor/program.h>
 #include <executorch/runtime/platform/runtime.h>
 #include <executorch/schema/program_generated.h>
 #include <executorch/test/utils/DeathTest.h>
@@ -24,11 +25,11 @@
 #include <gtest/gtest.h>
 
 using namespace ::testing;
-using torch::executor::DataLoader;
-using torch::executor::Error;
-using torch::executor::FreeableBuffer;
-using torch::executor::Program;
-using torch::executor::Result;
+using executorch::runtime::DataLoader;
+using executorch::runtime::Error;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::Program;
+using executorch::runtime::Result;
 using torch::executor::util::BufferDataLoader;
 using torch::executor::util::FileDataLoader;
 
@@ -42,7 +43,7 @@ class ProgramTest : public ::testing::Test {
   void SetUp() override {
     // Since these tests cause ET_LOG to be called, the PAL must be initialized
     // first.
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
 
     // Load the serialized ModuleAdd data.
     const char* path = std::getenv("ET_MODULE_ADD_PATH");
@@ -86,8 +87,8 @@ class ProgramTest : public ::testing::Test {
   std::unique_ptr<FileDataLoader> multi_loader_;
 };
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 namespace testing {
 // Provides access to private Program methods.
 class ProgramTestFriend final {
@@ -114,10 +115,10 @@ class ProgramTestFriend final {
   }
 };
 } // namespace testing
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch
 
-using torch::executor::testing::ProgramTestFriend;
+using executorch::runtime::testing::ProgramTestFriend;
 
 TEST_F(ProgramTest, DataParsesWithMinimalVerification) {
   // Parse the Program from the data.

--- a/runtime/executor/test/tensor_parser_test.cpp
+++ b/runtime/executor/test/tensor_parser_test.cpp
@@ -6,23 +6,25 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/runtime/executor/tensor_parser.h>
+
 #include <executorch/extension/data_loader/file_data_loader.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
-#include <executorch/runtime/executor/tensor_parser.h>
 #include <executorch/runtime/executor/test/managed_memory_manager.h>
-#include <gtest/gtest.h>
-
 #include <executorch/schema/program_generated.h>
 
+#include <gtest/gtest.h>
+
 using namespace ::testing;
-using torch::executor::Error;
-using torch::executor::EValue;
-using torch::executor::FreeableBuffer;
-using torch::executor::Program;
-using torch::executor::Result;
-using torch::executor::Tensor;
-using torch::executor::deserialization::parseTensor;
-using torch::executor::testing::ManagedMemoryManager;
+using exec_aten::ScalarType;
+using exec_aten::Tensor;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::Program;
+using executorch::runtime::Result;
+using executorch::runtime::deserialization::parseTensor;
+using executorch::runtime::testing::ManagedMemoryManager;
 using torch::executor::util::FileDataLoader;
 
 constexpr size_t kDefaultNonConstMemBytes = 32 * 1024U;
@@ -50,8 +52,8 @@ class TensorParserTest : public ::testing::Test {
   std::unique_ptr<FileDataLoader> half_loader_;
 };
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 namespace testing {
 // Provides access to private Program methods.
 class ProgramTestFriend final {
@@ -62,14 +64,14 @@ class ProgramTestFriend final {
   }
 };
 } // namespace testing
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch
 
-using torch::executor::testing::ProgramTestFriend;
+using executorch::runtime::testing::ProgramTestFriend;
 
 void test_module_add(
     std::unique_ptr<FileDataLoader>& loader,
-    torch::executor::ScalarType scalar_type,
+    ScalarType scalar_type,
     int type_size) {
   Result<Program> program =
       Program::load(loader.get(), Program::Verification::Minimal);
@@ -91,9 +93,9 @@ void test_module_add(
     if (serialization_value->val_type() ==
         executorch_flatbuffer::KernelTypes::Tensor) {
       tensor_count++;
-      Result<torch::executor::Tensor> tensor = parseTensor(
+      Result<Tensor> tensor = parseTensor(
           program_, &mmm.get(), serialization_value->val_as_Tensor());
-      torch::executor::Tensor t = tensor.get();
+      Tensor t = tensor.get();
       ASSERT_EQ(scalar_type, t.scalar_type());
       ASSERT_EQ(2, t.dim()); // [2, 2]
       ASSERT_EQ(4, t.numel());
@@ -110,15 +112,11 @@ void test_module_add(
 }
 
 TEST_F(TensorParserTest, TestModuleAddFloat) {
-  test_module_add(
-      float_loader_, torch::executor::ScalarType::Float, sizeof(float));
+  test_module_add(float_loader_, ScalarType::Float, sizeof(float));
 }
 
 TEST_F(TensorParserTest, TestModuleAddHalf) {
-  test_module_add(
-      half_loader_,
-      torch::executor::ScalarType::Half,
-      sizeof(torch::executor::Half));
+  test_module_add(half_loader_, ScalarType::Half, sizeof(exec_aten::Half));
 }
 
 TEST_F(TensorParserTest, TestMutableState) {

--- a/runtime/executor/test/test_backend_compiler_lib.cpp
+++ b/runtime/executor/test/test_backend_compiler_lib.cpp
@@ -13,8 +13,18 @@
 #include <cstdio>
 #include <cstdlib> /* strtol */
 
-namespace torch {
-namespace executor {
+using executorch::runtime::ArrayRef;
+using executorch::runtime::Backend;
+using executorch::runtime::BackendExecutionContext;
+using executorch::runtime::BackendInitContext;
+using executorch::runtime::CompileSpec;
+using executorch::runtime::DelegateHandle;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::MemoryAllocator;
+using executorch::runtime::PyTorchBackendInterface;
+using executorch::runtime::Result;
 
 struct DemoOp {
   const char* name;
@@ -218,6 +228,3 @@ auto cls = BackendWithCompiler();
 Backend backend{"BackendWithCompilerDemo", &cls};
 static auto success_with_compiler = register_backend(backend);
 } // namespace
-
-} // namespace executor
-} // namespace torch

--- a/runtime/executor/test/test_backend_with_delegate_mapping.cpp
+++ b/runtime/executor/test/test_backend_with_delegate_mapping.cpp
@@ -14,8 +14,18 @@
 #include <cstdlib> /* strtol */
 #include <cstring>
 
-namespace torch {
-namespace executor {
+using executorch::runtime::ArrayRef;
+using executorch::runtime::Backend;
+using executorch::runtime::BackendExecutionContext;
+using executorch::runtime::BackendInitContext;
+using executorch::runtime::CompileSpec;
+using executorch::runtime::DelegateHandle;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::MemoryAllocator;
+using executorch::runtime::PyTorchBackendInterface;
+using executorch::runtime::Result;
 
 struct DemoOp {
   const char* name;
@@ -154,6 +164,3 @@ auto cls = BackendWithDelegateMapping();
 Backend backend{"BackendWithDelegateMappingDemo", &cls};
 static auto success_with_compiler = register_backend(backend);
 } // namespace
-
-} // namespace executor
-} // namespace torch

--- a/runtime/kernel/kernel_runtime_context.h
+++ b/runtime/kernel/kernel_runtime_context.h
@@ -14,8 +14,8 @@
 #include <executorch/runtime/core/result.h>
 #include <executorch/runtime/platform/compiler.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 /**
  * Runtime state and functionality for kernel implementations.
@@ -107,16 +107,24 @@ class KernelRuntimeContext {
   Error failure_state_ = Error::Ok;
 };
 
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::KernelRuntimeContext;
 } // namespace executor
 } // namespace torch
 
 // TODO(T147221312): Remove these aliases once all code uses
 // KernelRuntimeContext.
 namespace exec_aten {
-using RuntimeContext = torch::executor::KernelRuntimeContext;
+using RuntimeContext = ::executorch::runtime::KernelRuntimeContext;
 } // namespace exec_aten
 namespace torch {
 namespace executor {
-using RuntimeContext = torch::executor::KernelRuntimeContext;
+using RuntimeContext = ::executorch::runtime::KernelRuntimeContext;
 } // namespace executor
 } // namespace torch

--- a/runtime/kernel/operator_registry.cpp
+++ b/runtime/kernel/operator_registry.cpp
@@ -14,8 +14,8 @@
 
 #include <executorch/runtime/platform/assert.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 OperatorRegistry& getOperatorRegistry();
 OperatorRegistry& getOperatorRegistry() {
@@ -187,5 +187,5 @@ ArrayRef<Kernel> OperatorRegistry::get_kernels() {
   return ArrayRef<Kernel>(this->kernels_, this->num_kernels_);
 }
 
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch

--- a/runtime/kernel/operator_registry.h
+++ b/runtime/kernel/operator_registry.h
@@ -36,11 +36,10 @@
     ET_LOG(Error, "]");                                               \
   }
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 class KernelRuntimeContext; // Forward declaration
-using RuntimeContext = KernelRuntimeContext; // TODO(T147221312): Remove
 using OpFunction = void (*)(KernelRuntimeContext&, EValue**);
 
 /**
@@ -52,7 +51,9 @@ struct TensorMeta {
   ArrayRef<exec_aten::DimOrderType> dim_order_;
 
   TensorMeta() = default;
-  TensorMeta(ScalarType dtype, ArrayRef<exec_aten::DimOrderType> order)
+  TensorMeta(
+      exec_aten::ScalarType dtype,
+      ArrayRef<exec_aten::DimOrderType> order)
       : dtype_(dtype), dim_order_(order) {}
 
   bool operator==(const TensorMeta& other) const {
@@ -258,5 +259,23 @@ struct OperatorRegistry {
   uint32_t num_kernels_;
 };
 
+} // namespace runtime
+} // namespace executorch
+
+namespace torch {
+namespace executor {
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces.
+using ::executorch::runtime::get_kernels;
+using ::executorch::runtime::getOpsFn;
+using ::executorch::runtime::hasOpsFn;
+using ::executorch::runtime::Kernel;
+using ::executorch::runtime::KernelKey;
+using ::executorch::runtime::KernelRuntimeContext;
+using ::executorch::runtime::OperatorRegistry;
+using ::executorch::runtime::OpFunction;
+using ::executorch::runtime::register_kernels;
+using ::executorch::runtime::TensorMeta;
+using RuntimeContext = ::executorch::runtime::KernelRuntimeContext;
 } // namespace executor
 } // namespace torch

--- a/runtime/kernel/test/kernel_double_registration_test.cpp
+++ b/runtime/kernel/test/kernel_double_registration_test.cpp
@@ -15,13 +15,16 @@
 
 using namespace ::testing;
 
-namespace torch {
-namespace executor {
+using executorch::runtime::ArrayRef;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::Kernel;
+using executorch::runtime::KernelRuntimeContext;
 
 class KernelDoubleRegistrationTest : public ::testing::Test {
  public:
   void SetUp() override {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
   }
 };
 
@@ -29,7 +32,7 @@ TEST_F(KernelDoubleRegistrationTest, Basic) {
   Kernel kernels[] = {Kernel(
       "aten::add.out",
       "v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3",
-      [](RuntimeContext&, EValue**) {})};
+      [](KernelRuntimeContext&, EValue**) {})};
   ArrayRef<Kernel> kernels_array = ArrayRef<Kernel>(kernels);
   Error err = Error::InvalidArgument;
 
@@ -37,6 +40,3 @@ TEST_F(KernelDoubleRegistrationTest, Basic) {
       { auto res = register_kernels(kernels_array); },
       std::to_string(static_cast<uint32_t>(err)));
 }
-
-} // namespace executor
-} // namespace torch

--- a/runtime/kernel/test/kernel_runtime_context_test.cpp
+++ b/runtime/kernel/test/kernel_runtime_context_test.cpp
@@ -13,15 +13,15 @@
 #include <gtest/gtest.h>
 
 using namespace ::testing;
-using torch::executor::Error;
-using torch::executor::KernelRuntimeContext;
-using torch::executor::MemoryAllocator;
-using torch::executor::Result;
+using executorch::runtime::Error;
+using executorch::runtime::KernelRuntimeContext;
+using executorch::runtime::MemoryAllocator;
+using executorch::runtime::Result;
 
 class KernelRuntimeContextTest : public ::testing::Test {
  public:
   void SetUp() override {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
   }
 };
 

--- a/runtime/kernel/test/operator_registry_max_kernel_num_test.cpp
+++ b/runtime/kernel/test/operator_registry_max_kernel_num_test.cpp
@@ -16,20 +16,23 @@
 #include <executorch/test/utils/DeathTest.h>
 
 using namespace ::testing;
-
-namespace torch {
-namespace executor {
+using executorch::runtime::ArrayRef;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::hasOpsFn;
+using executorch::runtime::Kernel;
+using executorch::runtime::KernelRuntimeContext;
 
 class OperatorRegistryMaxKernelNumTest : public ::testing::Test {
  public:
   void SetUp() override {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
   }
 };
 
 // Register one kernel when max_kernel_num=1; success
 TEST_F(OperatorRegistryMaxKernelNumTest, RegisterOneOp) {
-  Kernel kernels[] = {Kernel("foo", [](RuntimeContext&, EValue**) {})};
+  Kernel kernels[] = {Kernel("foo", [](KernelRuntimeContext&, EValue**) {})};
   ArrayRef<Kernel> kernels_array = ArrayRef<Kernel>(kernels);
   auto s1 = register_kernels(kernels_array);
   EXPECT_EQ(s1, Error::Ok);
@@ -40,13 +43,10 @@ TEST_F(OperatorRegistryMaxKernelNumTest, RegisterOneOp) {
 // Register two kernels when max_kernel_num=1; fail
 TEST_F(OperatorRegistryMaxKernelNumTest, RegisterTwoOpsFail) {
   Kernel kernels[] = {
-      Kernel("foo1", [](RuntimeContext&, EValue**) {}),
-      Kernel("foo2", [](RuntimeContext&, EValue**) {})};
+      Kernel("foo1", [](KernelRuntimeContext&, EValue**) {}),
+      Kernel("foo2", [](KernelRuntimeContext&, EValue**) {})};
   ArrayRef<Kernel> kernels_array = ArrayRef<Kernel>(kernels);
   ET_EXPECT_DEATH(
-      { register_kernels(kernels_array); },
+      { (void)register_kernels(kernels_array); },
       "The total number of kernels to be registered is larger than the limit 1");
 }
-
-} // namespace executor
-} // namespace torch

--- a/runtime/kernel/test/test_util.h
+++ b/runtime/kernel/test/test_util.h
@@ -11,13 +11,19 @@
 #include <vector>
 
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/kernel/operator_registry.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
+
+// Defined in //executorch/runtime/kernel/operator_registry.cpp.
 void make_kernel_key_string(ArrayRef<TensorMeta> key, char* buf);
 
+namespace testing {
+
 inline void make_kernel_key(
-    std::vector<std::pair<ScalarType, std::vector<exec_aten::DimOrderType>>>
+    std::vector<
+        std::pair<exec_aten::ScalarType, std::vector<exec_aten::DimOrderType>>>
         tensors,
     char* buf) {
   std::vector<TensorMeta> meta;
@@ -30,5 +36,7 @@ inline void make_kernel_key(
   make_kernel_key_string(meatadata, buf);
 }
 
-} // namespace executor
-} // namespace torch
+} // namespace testing
+
+} // namespace runtime
+} // namespace executorch

--- a/schema/extended_header.cpp
+++ b/schema/extended_header.cpp
@@ -16,8 +16,8 @@
 
 #pragma clang diagnostic ignored "-Wdeprecated"
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 namespace {
 
@@ -96,5 +96,5 @@ uint64_t GetUInt64LE(const uint8_t* data) {
 // Define storage for the static.
 constexpr char ExtendedHeader::kMagic[kMagicSize];
 
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch

--- a/schema/extended_header.h
+++ b/schema/extended_header.h
@@ -10,8 +10,8 @@
 
 #include <executorch/runtime/core/result.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 
 /**
  * An extended, ExecuTorch-specific header that may be embedded in the
@@ -72,5 +72,5 @@ struct ExtendedHeader {
   uint64_t segment_base_offset;
 };
 
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch

--- a/schema/test/extended_header_test.cpp
+++ b/schema/test/extended_header_test.cpp
@@ -14,16 +14,16 @@
 #include <executorch/runtime/platform/runtime.h>
 
 using namespace ::testing;
-using torch::executor::Error;
-using torch::executor::ExtendedHeader;
-using torch::executor::Result;
+using executorch::runtime::Error;
+using executorch::runtime::ExtendedHeader;
+using executorch::runtime::Result;
 
 class ExtendedHeaderTest : public ::testing::Test {
  protected:
   void SetUp() override {
     // Since these tests cause ET_LOG to be called, the PAL must be initialized
     // first.
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
   }
 };
 


### PR DESCRIPTION
Migrate these headers to the new `::executorch::runtime` namespace. Add temporary aliases from the old `::torch::executor` namespace so we can migrate users incrementally.

Differential Revision: [D60532173](https://our.internmc.facebook.com/intern/diff/D60532173/)