### PR TITLE
[MPS] Add support for Int4 groupwise quantization

### DIFF
--- a/backends/apple/mps/operators/__init__.py
+++ b/backends/apple/mps/operators/__init__.py
@@ -4,9 +4,8 @@
 #
 
 from . import (  # noqa
-    # Activation ops
     activation_ops,
-    # binary ops
+    # Binary ops
     binary_ops,
     # Clamp ops
     clamp_ops,
@@ -22,6 +21,10 @@ from . import (  # noqa
     normalization_ops,
     op_clone,
     op_getitem,
+    # Quant-Dequant ops
+    op_quant_dequant,
+    # Skip ops
+    op_skip_ops,
     # Pad ops
     pad_ops,
     # Pooling ops
@@ -32,7 +35,7 @@ from . import (  # noqa
     reduce_ops,
     # Shape ops
     shape_ops,
-    # unary ops
+    # Unary ops
     unary_ops,
 )
 
@@ -41,8 +44,6 @@ __all__ = [
     op_clone,
     # Binary ops
     binary_ops,
-    # Unary ops
-    unary_ops,
     # Activation ops
     activation_ops,
     # Linear algebra ops
@@ -67,4 +68,10 @@ __all__ = [
     pad_ops,
     # Range ops
     range_ops,
+    # Unary ops
+    unary_ops,
+    # Quant-Dequant ops
+    op_quant_dequant,
+    # Skip ops
+    op_skip_ops,
 ]

--- a/backends/apple/mps/operators/node_visitor.py
+++ b/backends/apple/mps/operators/node_visitor.py
@@ -72,6 +72,7 @@ class NodeVisitor:
         self,
         node: torch.fx.Node,
         mps_graph: MPSGraph,
+        mps_data_type: MPSDataType = None,
     ) -> int:
         """Defines a tensor value into the MPSGraph serialization schema
 
@@ -89,7 +90,7 @@ class NodeVisitor:
         # Get a unique id for the node.
         id = self.get_serialized_id(node, mps_graph)
         cb_size, constant_buffer, mps_data_type = self.get_serialized_buffer(
-            node, mps_graph, id
+            node, mps_graph, id, mps_data_type
         )
         dims = get_shape(node)
 
@@ -143,6 +144,9 @@ class NodeVisitor:
             mps_graph.mps_values.append(mps_tensor)
         return self.tensor_to_id[node]
 
+    def hash_tensor(self, tensor):
+        return hash(tuple(tensor.reshape(-1).tolist()))
+
     def define_constant(
         self,
         constant_tensor: torch.tensor,
@@ -155,9 +159,12 @@ class NodeVisitor:
             mps_graph (MPSGraph): MPSGraph object for serializing into flatbuffer
         """
         constant_tensor = constant_tensor.contiguous()
-        # MPS TODO: cache these values
-        id = len(mps_graph.mps_values)
-        self.tensor_to_id[constant_tensor] = id
+        hash = self.hash_tensor(constant_tensor)
+        if hash in self.tensor_to_id:
+            return self.tensor_to_id[hash]
+
+        id = self.get_serialized_id(constant_tensor, mps_graph, hash)
+
         mps_data_type = edge_dtype_to_mps_dtype(constant_tensor.dtype)
         constant_buffer_size, constant_buffer, mps_data_type = self.get_serialized_data(
             constant_tensor, mps_graph, mps_data_type, id
@@ -189,9 +196,10 @@ class NodeVisitor:
         """
         assert isinstance(val, int) or isinstance(val, float)
 
-        # MPS TODO: cache these values
-        id = len(mps_graph.mps_values)
-        self.tensor_to_id[val] = id
+        if val in self.tensor_to_id:
+            return self.tensor_to_id[val]
+
+        id = self.get_serialized_id(val, mps_graph, val)
 
         tensor = torch.tensor(val)
         constant_buffer_size, constant_buffer, mps_data_type = self.get_serialized_data(
@@ -214,6 +222,7 @@ class NodeVisitor:
         node: torch.fx.Node,
         mps_graph: MPSGraph,
         node_id: int,
+        mps_data_type: MPSDataType = None,
     ) -> Tuple[int, Buffer, MPSDataType]:
         """
         If tensor holds some constant data, serialize it and return the
@@ -226,7 +235,9 @@ class NodeVisitor:
         Returns:
             _type_: _description_
         """
-        mps_data_type = self.get_serialized_dtype(node)
+        mps_data_type = (
+            self.get_serialized_dtype(node) if mps_data_type is None else mps_data_type
+        )
 
         # Check if this node is a lifted parameter
         if not is_parameter(self.exported_program, node):
@@ -255,6 +266,22 @@ class NodeVisitor:
         if id not in mps_graph.constant_ids:
             mps_graph.constant_ids.append(id)
 
+        if (
+            mps_data_type is MPSDataType.mps_data_type_int4
+            and tensor.dtype is torch.int8
+        ):
+            if tensor.dim() != 2:
+                raise RuntimeError(f"Unexpected tensor shape {tensor.shape}")
+
+            tensor = tensor.to(dtype=torch.int32)
+            tensor = (((tensor[::, ::2] & 0x0F) << 4) | (tensor[::, 1::2] & 0x0F)).to(
+                torch.uint8
+            )
+            tensor = (
+                torch._convert_weight_to_int4pack(tensor.to("mps"), 2)
+                .cpu()
+                .view(dtype=torch.uint8)
+            )
         array_type = ctypes.c_char * tensor.untyped_storage().nbytes()
         array = ctypes.cast(
             tensor.untyped_storage().data_ptr(),
@@ -265,7 +292,7 @@ class NodeVisitor:
         return tensor.untyped_storage().nbytes(), buffer, mps_data_type
 
     def get_serialized_id(
-        self, node: Union[torch.fx.Node, float, int], mps_graph: MPSGraph
+        self, node: Union[torch.fx.Node, float, int], mps_graph: MPSGraph, hash=None
     ) -> int:
         """
         Map a tensor to a unique id. If the tensor was already mapped, return
@@ -278,19 +305,27 @@ class NodeVisitor:
         Returns:
             int: _description_
         """
-        if node in self.tensor_to_id:
+        if hash is not None and hash in self.tensor_to_id:
+            return self.tensor_to_id[hash]
+        elif node in self.tensor_to_id:
             return self.tensor_to_id[node]
 
         id = len(mps_graph.mps_values)
-        self.tensor_to_id[node] = id
+        if hash is not None:
+            self.tensor_to_id[hash] = id
+        else:
+            self.tensor_to_id[node] = id
 
         return id
+
+    def torch_dtype_to_mps_dtype(self, torch_dtype: torch.dtype) -> MPSDataType:
+        return edge_dtype_to_mps_dtype(torch_dtype)
 
     def get_serialized_dtype(
         self,
         node: torch.fx.Node,
     ) -> MPSDataType:
-        return edge_dtype_to_mps_dtype(node.meta["val"].dtype)
+        return self.torch_dtype_to_mps_dtype(node.meta["val"].dtype)
 
     def create_tertiary_node(
         self, node: torch.fx.Node, mps_graph: MPSGraph, tertiary_op: MPSNodeUnion

--- a/backends/apple/mps/operators/op_quant_dequant.py
+++ b/backends/apple/mps/operators/op_quant_dequant.py
@@ -1,0 +1,142 @@
+#
+#  Copyright (c) 2024 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+import logging
+from typing import cast
+
+import torch
+from executorch.backends.apple.mps.operators.node_visitor import (
+    NodeVisitor,
+    register_node_visitor,
+)
+from executorch.backends.apple.mps.serialization.mps_graph_schema import (
+    MPSDataType,
+    MPSDequantizePerChannelGroup,
+    MPSGraph,
+    MPSNode,
+)
+from executorch.backends.apple.mps.utils.mps_utils import get_input_node
+
+FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
+logging.basicConfig(level=logging.DEBUG, format=FORMAT)
+
+
+@register_node_visitor
+class OpDequantizePerChannelGroupDefault(NodeVisitor):
+    target = "quantized_decomposed.dequantize_per_channel_group.default"
+
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        mps_graph: MPSGraph,
+    ) -> None:
+        # Weights placeholders shouldn't have been defined until this point
+        if get_input_node(node, 0) in self.tensor_to_id:
+            raise RuntimeError(
+                f"Placeholder for {node.target.__name__} already visited"
+            )
+        output_id = self.define_tensor(node, mps_graph)
+        input_id = self.define_tensor(
+            get_input_node(node, 0), mps_graph, MPSDataType.mps_data_type_int4
+        )
+        scales_id = self.define_tensor(get_input_node(node, 1), mps_graph)
+
+        # there are no zero points in this quantization method (node.args[2] is all zeros)
+        zero_points_id = -1
+        quant_min = cast(int, node.args[3])
+        quant_max = cast(int, node.args[4])
+        dtype = self.torch_dtype_to_mps_dtype(node.args[5])
+        group_size = cast(int, node.args[6])
+        output_dtype = self.torch_dtype_to_mps_dtype(node.args[7])
+
+        dequant_node = MPSNode(
+            mpsnode_union=MPSDequantizePerChannelGroup(
+                input1_id=input_id,
+                output_id=output_id,
+                scales_id=scales_id,
+                zero_points_id=zero_points_id,
+                quant_min=quant_min,
+                quant_max=quant_max,
+                dtype=dtype,
+                group_size=group_size,
+                output_dtype=output_dtype,
+            )
+        )
+        mps_graph.mps_nodes.append(dequant_node)
+
+
+@register_node_visitor
+class OpQuantizePerToken(NodeVisitor):
+    """
+    Dynamic Quantize Per Token Node visitor
+    """
+
+    target = "quantized_decomposed.quantize_per_token.default"
+
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        mps_graph: MPSGraph,
+    ) -> None:
+        """
+        Skip activation dynamic quantization for now.
+        Currently all matmuls are going through [FP16/BF16] @ [QInt4/QInt8].
+        Issue: #133407308
+        """
+        dq_input = self.define_tensor(get_input_node(node, 0), mps_graph)
+        self.tensor_to_id[node] = dq_input
+
+
+@register_node_visitor
+class OpDequantizePerToken(NodeVisitor):
+    """
+    Dequantize Per Token Node visitor
+    """
+
+    target = "quantized_decomposed.dequantize_per_token.default"
+
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        mps_graph: MPSGraph,
+    ) -> None:
+        """
+        Skip activation dynamic quantization for now.
+        Currently all matmuls are going through [FP16/BF16] @ [QInt4/QInt8].
+        Issue: #133407308
+        """
+        dq_input = self.define_tensor(get_input_node(node, 0), mps_graph)
+        self.tensor_to_id[node] = dq_input
+
+
+@register_node_visitor
+class OpChooseQparamsToken(NodeVisitor):
+    """
+    do nothing if node is choose_qparams_per_token_asymmetric.tensor
+    """
+
+    target = "quantized_decomposed.choose_qparams_per_token_asymmetric.default"
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        mps_graph: MPSGraph,
+    ) -> None:
+        """
+        Skip activation dynamic quantization for now.
+        Currently all matmuls are going through [FP16/BF16] @ [QInt4/QInt8].
+        Issue: #133407308
+        """
+        input_id = self.define_tensor(get_input_node(node, 0), mps_graph)
+        self.tensor_to_id[node] = [input_id, input_id]

--- a/backends/apple/mps/operators/op_skip_ops.py
+++ b/backends/apple/mps/operators/op_skip_ops.py
@@ -1,0 +1,24 @@
+#
+#  Copyright (c) 2024 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+import torch
+from executorch.backends.apple.mps.operators.node_visitor import NodeVisitor
+from executorch.backends.apple.mps.serialization.mps_graph_schema import MPSGraph
+
+
+class OpSkipOps(NodeVisitor):
+    """
+    Parent Class for handling Skip Ops
+    """
+
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        mps_graph: MPSGraph,
+    ) -> None:
+        return

--- a/backends/apple/mps/partition/mps_partitioner.py
+++ b/backends/apple/mps/partition/mps_partitioner.py
@@ -26,8 +26,7 @@ from torch.fx.passes.infra.partitioner import Partition
 from torch.fx.passes.operator_support import OperatorSupportBase
 
 FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
-logging.basicConfig(level=logging.DEBUG, format=FORMAT)
-
+logging.basicConfig(level=logging.INFO, format=FORMAT)
 
 # ops implemented as Metal kernels.
 METAL_KERNELS = [

--- a/backends/apple/mps/runtime/MPSDevice.h
+++ b/backends/apple/mps/runtime/MPSDevice.h
@@ -32,6 +32,7 @@ enum class MacOSVersion : uint32_t {
   MACOS_VER_13_2_PLUS,
   MACOS_VER_13_3_PLUS,
   MACOS_VER_14_0_PLUS,
+  MACOS_VER_15_0_PLUS,
 };
 
 enum class LibraryType : uint32_t {
@@ -82,7 +83,8 @@ class MPSDevice {
   MPSDevice();
 };
 
-bool isMacOS13OrNewer(MacOSVersion version = MacOSVersion::MACOS_VER_13_0_PLUS);
+bool is_macos_13_or_newer(
+    MacOSVersion version = MacOSVersion::MACOS_VER_13_0_PLUS);
 
 } // namespace delegate
 } // namespace mps

--- a/backends/apple/mps/runtime/MPSDevice.mm
+++ b/backends/apple/mps/runtime/MPSDevice.mm
@@ -76,7 +76,7 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
   static bool _macos_13_3_plus = [compileOptions respondsToSelector:@selector(maxTotalThreadsPerThreadgroup)] == YES;
 
   static bool _macos_14_0_plus = [mpsCD instancesRespondToSelector:@selector(conjugateWithTensor:name:)] == YES;
-
+  static bool _macos_15_0_plus = [mpsCD instancesRespondToSelector:@selector(scaledDotProductAttentionWithQueryTensor:keyTensor:valueTensor:maskTensor:scale:name:)] == YES;
   switch (version) {
     case MacOSVersion::MACOS_VER_13_0_PLUS:
       return _macos_13_0_plus;
@@ -88,6 +88,8 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
       return _macos_13_3_plus;
     case MacOSVersion::MACOS_VER_14_0_PLUS:
       return _macos_14_0_plus;
+    case MacOSVersion::MACOS_VER_15_0_PLUS:
+      return _macos_15_0_plus;
     default:
       return false;
   }
@@ -144,7 +146,7 @@ MPSDevice::compilePSO(LibraryType libraryType, const char* kernelName) {
   return err;
 }
 
-bool isMacOS13OrNewer(MacOSVersion version) {
+bool is_macos_13_or_newer(MacOSVersion version) {
   return MPSDevice::getInstance()->isMacOS13Plus(version);
 }
 

--- a/backends/apple/mps/runtime/MPSExecutor.mm
+++ b/backends/apple/mps/runtime/MPSExecutor.mm
@@ -29,7 +29,7 @@ MPSExecutor::MPSExecutor() {
 #if TARGET_OS_SIMULATOR or defined(__x86_64__)
   _use_shared_mem = false;
 #endif
-  if (!isMacOS13OrNewer(MacOSVersion::MACOS_VER_14_0_PLUS)) {
+  if (!is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS)) {
     _use_shared_mem = false;
   }
 

--- a/backends/apple/mps/runtime/MPSGraphBuilder.h
+++ b/backends/apple/mps/runtime/MPSGraphBuilder.h
@@ -16,6 +16,7 @@
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 
 // MPS headers
+#include <executorch/backends/apple/mps/runtime/operations/MPSGraphSequoiaOps.h>
 #include <executorch/backends/apple/mps/runtime/operations/MPSGraphVenturaOps.h>
 #include <executorch/backends/apple/mps/runtime/operations/OperationUtils.h>
 #include <executorch/backends/apple/mps/schema_generated.h>
@@ -155,6 +156,8 @@ private:
   _DEFINE_MPS_OP(ConstantPadND);
   // Range ops
   _DEFINE_MPS_OP(Arange);
+  // Quant-Dequant ops
+  _DEFINE_MPS_OP(DequantizePerChannelGroup);
 
   // Helper functions
   Error addNodeToMPSGraph(NodePtr nodePtr);

--- a/backends/apple/mps/runtime/operations/BinaryOps.mm
+++ b/backends/apple/mps/runtime/operations/BinaryOps.mm
@@ -119,7 +119,7 @@ auto graphNode = nodePtr->mpsnode_union_as_MPS##aot_name();                     
     graphNode->output_id()                                                         \
   );                                                                               \
   ET_CHECK_OR_RETURN_ERROR(                                                        \
-    isMacOS13OrNewer(), NotSupported,                                              \
+    is_macos_13_or_newer(), NotSupported,                                              \
     "%s supported by MPS on MacOS13.0+/iOS16.1+", #aot_name);                       \
                                                                                    \
   _idToMPSGraphTensor[graphNode->output_id()] = binaryOpTensor(                    \
@@ -176,7 +176,7 @@ MPSGraphTensor* mpsTruncTensor(MPSGraphTensor* inputTensor, MPSGraph* mpsGraph) 
     return inputTensor;
   }
 
-  if (!isMacOS13OrNewer(MacOSVersion::MACOS_VER_13_0_PLUS)) {
+  if (!is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_0_PLUS)) {
     MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputTensor.dataType];
     MPSGraphTensor* predicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
                                                           secondaryTensor:zeroTensor

--- a/backends/apple/mps/runtime/operations/MPSGraphSequoiaOps.h
+++ b/backends/apple/mps/runtime/operations/MPSGraphSequoiaOps.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+
+#if !defined(__MAC_15_0) && (!defined(MAC_OS_X_VERSION_15_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_15_0))
+
+#define MPSDataTypeInt4 ((MPSDataType)(MPSDataTypeSignedBit | 4))
+
+@interface MPSNDArrayIdentity : MPSNDArrayUnaryKernel
+- (MPSNDArray *__nullable)reshapeWithCommandBuffer:(__nullable id<MTLCommandBuffer>)cmdBuf
+                                       sourceArray:(MPSNDArray *__nonnull)sourceArray
+                                             shape:(MPSShape *__nonnull)shape
+                                  destinationArray:(MPSNDArray *__nullable)destinationArray;
+@end
+
+@interface MPSNDArrayDescriptor ()
+@property(readwrite, nonatomic) BOOL preferPackedRows;
+@end
+
+@interface MPSNDArray ()
+- (nonnull instancetype)initWithBuffer:(id<MTLBuffer> _Nonnull)buffer
+                                offset:(NSUInteger)offset
+                            descriptor:(MPSNDArrayDescriptor *_Nonnull)descriptor;
+- (MPSNDArray *__nullable)arrayViewWithShape:(MPSShape *_Nullable)shape strides:(MPSShape *_Nonnull)strides;
+@end
+
+@interface MPSNDArrayQuantizationDescriptor : NSObject<NSCopying>
+@end
+
+@interface MPSNDArrayQuantizedMatrixMultiplication : MPSNDArrayMatrixMultiplication
+- (nonnull instancetype)initWithDevice:(nonnull id<MTLDevice>)device
+            leftQuantizationDescriptor:(MPSNDArrayQuantizationDescriptor *_Nullable)leftQuantizationDescriptor
+           rightQuantizationDescriptor:(MPSNDArrayQuantizationDescriptor *_Nullable)rightQuantizationDescriptor;
+
+- (void)encodeToCommandEncoder:(id<MTLComputeCommandEncoder> _Nullable)encoder
+                 commandBuffer:(nonnull id<MTLCommandBuffer>)commandBuffer
+                  sourceArrays:(nonnull NSArray<MPSNDArray *> *)sourceArrays
+              destinationArray:(nonnull MPSNDArray *)destination;
+@end
+
+@interface MPSNDArrayAffineQuantizationDescriptor : MPSNDArrayQuantizationDescriptor
+- (nonnull instancetype)initWithDataType:(MPSDataType)quantizationDataType
+                            hasZeroPoint:(BOOL)hasZeroPoint
+                             hasMinValue:(BOOL)hasMinValue;
+@property(readwrite, nonatomic) bool implicitZeroPoint;
+@end
+
+@interface MPSGraph ()
+- (MPSGraphTensor *_Nonnull)dequantizeTensor:(MPSGraphTensor *_Nonnull)tensor
+                                 scaleTensor:(MPSGraphTensor *_Nonnull)scaleTensor
+                             zeroPointTensor:(MPSGraphTensor *_Nonnull)zeroPointTensor
+                                    dataType:(MPSDataType)dataType
+                                        name:(NSString *_Nullable)name;
+@end
+
+#endif

--- a/backends/apple/mps/runtime/operations/OperationUtils.mm
+++ b/backends/apple/mps/runtime/operations/OperationUtils.mm
@@ -27,9 +27,12 @@ MPSGraphBuilder::getMPSDataType(DataType serializedDataType) {
     case DataType::mps_data_type_float16:
       return MPSDataTypeFloat16;
     case DataType::mps_data_type_float32:
+    case DataType::mps_data_type_float64:
       return MPSDataTypeFloat32;
     case DataType::mps_data_type_int8:
       return MPSDataTypeInt8;
+    case DataType::mps_data_type_int4:
+      return MPSDataTypeInt4;
     case DataType::mps_data_type_int16:
       return MPSDataTypeInt16;
     case DataType::mps_data_type_int32:
@@ -217,6 +220,8 @@ MPSGraphBuilder::addNodeToMPSGraph(NodePtr nodePtr) {
     _DEFINE_MPS_NODE(ConstantPadND);
     // Range ops
     _DEFINE_MPS_NODE(Arange);
+    // Quant-Dequant ops
+    _DEFINE_MPS_NODE(DequantizePerChannelGroup);
 
     case mpsgraph::MPSNodeUnion::NONE:
     default:
@@ -314,32 +319,26 @@ void* pageAlignedBlockPtr(const void* ptr, NSUInteger size, NSUInteger* alignedB
 
 
 MPSGraphTensor* permuteTensor(MPSGraph* graph, MPSGraphTensor* inputTensor, NSArray* permuteOrder) {
-  if (isMacOS13OrNewer()) {
-   return [graph transposeTensor:inputTensor
-                     permutation:permuteOrder
-                            name:nil];
-  } else {
-    NSUInteger srcRank = [[inputTensor shape] count];
-    if (srcRank != [permuteOrder count]) {
-      return nil;
-    }
-
-    MPSGraphTensor* outputTensor = inputTensor;
-    std::vector<NSUInteger> dimensionOrder(srcRank);
-    std::iota(std::begin(dimensionOrder), std::end(dimensionOrder), 0);
-
-    for (int32_t i = 0; i < srcRank; i++) {
-      NSUInteger axis = [permuteOrder[i] integerValue];
-      auto axisIter = std::find(dimensionOrder.begin(), dimensionOrder.end(), axis);
-      NSUInteger axis1 = i;
-      NSUInteger axis2 = axisIter - dimensionOrder.begin();
-      iter_swap(dimensionOrder.begin() + i, axisIter);
-
-      outputTensor = [graph transposeTensor:outputTensor dimension:axis1 withDimension:axis2 name:nil];
-    }
-
-    return outputTensor;
+  NSUInteger srcRank = [[inputTensor shape] count];
+  if (srcRank != [permuteOrder count]) {
+    return nil;
   }
+
+  MPSGraphTensor* outputTensor = inputTensor;
+  std::vector<NSUInteger> dimensionOrder(srcRank);
+  std::iota(std::begin(dimensionOrder), std::end(dimensionOrder), 0);
+
+  for (int32_t i = 0; i < srcRank; i++) {
+    NSUInteger axis = [permuteOrder[i] integerValue];
+    auto axisIter = std::find(dimensionOrder.begin(), dimensionOrder.end(), axis);
+    NSUInteger axis1 = i;
+    NSUInteger axis2 = axisIter - dimensionOrder.begin();
+    iter_swap(dimensionOrder.begin() + i, axisIter);
+
+    outputTensor = [graph transposeTensor:outputTensor dimension:axis1 withDimension:axis2 name:nil];
+  }
+
+  return outputTensor;
 }
 
 

--- a/backends/apple/mps/runtime/operations/QuantDequant.mm
+++ b/backends/apple/mps/runtime/operations/QuantDequant.mm
@@ -1,0 +1,50 @@
+//
+//  Copyright (c) 2024 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
+
+namespace torch {
+namespace executor {
+namespace mps {
+namespace delegate {
+
+Error
+MPSGraphBuilder::mpsDequantizePerChannelGroupOp(NodePtr nodePtr) {
+  auto graphNode = nodePtr->mpsnode_union_as_MPSDequantizePerChannelGroup();
+  ET_LOG(
+    Debug, "%s: (%d, %d, %d) -> %d",
+    __FUNCTION__,
+    graphNode->input1_id(),
+    graphNode->scales_id(),
+    graphNode->zero_points_id(),
+    graphNode->output_id()
+  );
+
+  ET_CHECK_OR_RETURN_ERROR(
+    is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS),
+    NotImplemented,
+    "[ERROR] Operation %s is supported starting with macOS 15.0+ | iOS 18.0 + | iPadOS 18+ | tvOS 18+ | visionOS 2.0+ !",
+    mpsgraph::EnumNameMPSNodeUnion(nodePtr->mpsnode_union_type()));
+
+  MPSGraphTensor* inputTensor = getMPSGraphTensor(graphNode->input1_id());
+  MPSGraphTensor* scalesTensor = getMPSGraphTensor(graphNode->scales_id());
+
+  MPSGraphTensor *zpTensor = [_mpsGraph constantWithScalar:0
+                                                  dataType:MPSDataTypeInt4];
+
+  MPSGraphTensor *wDqTensor = [_mpsGraph dequantizeTensor:inputTensor
+                                              scaleTensor:scalesTensor
+                                          zeroPointTensor:zpTensor
+                                                dataType:MPSDataTypeFloat16
+                                                    name:nil];
+
+  _idToMPSGraphTensor[graphNode->output_id()] = wDqTensor;
+  return Error::Ok;
+}
+
+} // namespace delegate
+} // namespace mps
+} // namespace executor
+} // namespace torch

--- a/backends/apple/mps/runtime/operations/UnaryOps.mm
+++ b/backends/apple/mps/runtime/operations/UnaryOps.mm
@@ -33,7 +33,7 @@ MPSGraphBuilder::mpsBitwiseNotOp(NodePtr nodePtr) {
     _idToMPSGraphTensor[graphNode->output_id()] = [_mpsGraph notWithTensor:inputTensor name:nil];
   } else {
     ET_CHECK_OR_RETURN_ERROR(
-      isMacOS13OrNewer(), NotSupported,
+      is_macos_13_or_newer(), NotSupported,
       "mpsBitwiseNotOp supported by MPS on MacOS13.0+/iOS16.1+");
     _idToMPSGraphTensor[graphNode->output_id()] = [_mpsGraph bitwiseNOTWithTensor:inputTensor name:nil];
   }

--- a/backends/apple/mps/serialization/mps_graph_schema.py
+++ b/backends/apple/mps/serialization/mps_graph_schema.py
@@ -16,15 +16,27 @@ class MPSDataType(IntEnum):
     mps_data_type_invalid = 0
     mps_data_type_float16 = 1
     mps_data_type_float32 = 2
-    mps_data_type_bfloat16 = 3
-    mps_data_type_int8 = 4
-    mps_data_type_int16 = 5
-    mps_data_type_int32 = 6
-    mps_data_type_int64 = 7
-    mps_data_type_uint8 = 8
-    mps_data_type_bool = 9
-    mps_data_type_complex_float16 = 10
-    mps_data_type_complex_float32 = 11
+    mps_data_type_float64 = 3
+    mps_data_type_bfloat16 = 4
+
+    # Signed integers.
+    mps_data_type_int4 = 5
+    mps_data_type_int8 = 6
+    mps_data_type_int16 = 7
+    mps_data_type_int32 = 8
+    mps_data_type_int64 = 9
+
+    # Unsigned integers. range: [0, UTYPE_MAX]
+    mps_data_type_uint4 = 10
+    mps_data_type_uint8 = 11
+    mps_data_type_uint16 = 12
+    mps_data_type_uint32 = 13
+    mps_data_type_uint64 = 14
+
+    mps_data_type_bool = 15
+
+    mps_data_type_complex_float16 = 16
+    mps_data_type_complex_float32 = 17
 
 
 class OpType(IntEnum):
@@ -56,6 +68,12 @@ class MPSNode3x1:
     input2_id: int
     input3_id: int
     output_id: int
+
+
+@dataclass
+class MPSDequantizeNode(MPSNode1x1):
+    scales_id: int
+    zero_points_id: int
 
 
 @dataclass
@@ -640,6 +658,18 @@ class MPSArange:
     dtype: MPSDataType
 
 
+##
+## Quant - Dequant ops
+##
+@dataclass
+class MPSDequantizePerChannelGroup(MPSDequantizeNode):
+    quant_min: int
+    quant_max: int
+    dtype: MPSDataType
+    group_size: int
+    output_dtype: MPSDataType
+
+
 MPSNodeUnion = Union[
     # Activation ops
     MPSHardTanh,
@@ -743,6 +773,8 @@ MPSNodeUnion = Union[
     MPSConstantPadND,
     # Range ops
     MPSArange,
+    # Quant-Dequant ops
+    MPSDequantizePerChannelGroup,
 ]
 
 

--- a/backends/apple/mps/serialization/schema.fbs
+++ b/backends/apple/mps/serialization/schema.fbs
@@ -13,15 +13,28 @@ enum MPSDataType : short {
   mps_data_type_invalid = 0,
   mps_data_type_float16 = 1,
   mps_data_type_float32 = 2,
-  mps_data_type_bfloat16 = 3,
-  mps_data_type_int8 = 4,
-  mps_data_type_int16 = 5,
-  mps_data_type_int32 = 6,
-  mps_data_type_int64 = 7,
-  mps_data_type_uint8 = 8,
-  mps_data_type_bool = 9,
-  mps_data_type_complex_float16 = 10,
-  mps_data_type_complex_float32 = 11,
+  mps_data_type_float64 = 3,
+  mps_data_type_bfloat16 = 4,
+
+  // Signed integers.
+  mps_data_type_int4 = 5,
+  mps_data_type_int8 = 6,
+  mps_data_type_int16 = 7,
+  mps_data_type_int32 = 8,
+  mps_data_type_int64 = 9,
+
+
+  // Unsigned integers. range: [0, UTYPE_MAX]
+  mps_data_type_uint4 = 10,
+  mps_data_type_uint8 = 11,
+  mps_data_type_uint16 = 12,
+  mps_data_type_uint32 = 13,
+  mps_data_type_uint64 = 14,
+
+  mps_data_type_bool = 15,
+
+  mps_data_type_complex_float16 = 16,
+  mps_data_type_complex_float32 = 17,
 }
 
 // ops like index.Tensor and index.put are currentely implemented as
@@ -322,6 +335,19 @@ table MPSArange {
   dtype:MPSDataType;
 }
 
+// Quant - Dequant ops
+table MPSDequantizePerChannelGroup {
+  input1_id:int;
+  output_id:int;
+  scales_id:int;
+  zero_points_id:int;
+  quant_min:int;
+  quant_max:int;
+  dtype:MPSDataType;
+  group_size:int;
+  output_dtype:MPSDataType;
+}
+
 union MPSNodeUnion {
     // Activation ops
     MPSHardTanh,
@@ -441,6 +467,9 @@ union MPSNodeUnion {
 
     // Range ops
     MPSArange,
+
+    // Quant-Dequant ops
+    MPSDequantizePerChannelGroup,
 }
 
 table MPSNode {

--- a/backends/apple/mps/test/test_mps_linear.py
+++ b/backends/apple/mps/test/test_mps_linear.py
@@ -1,0 +1,523 @@
+#
+#  Copyright (c) 2024 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+import inspect
+
+import unittest
+
+from typing import Tuple
+
+import torch
+from executorch.backends.apple.mps.test.test_mps_utils import TestMPS
+
+
+class TestLinear(TestMPS):
+    @unittest.skip("Dynamic shapes not supported in MPS backend")
+    def test_fp16_linear(self):
+        for use_bias in (True, False):
+            for num_batch_dims in range(1, 3):
+                self._test_linear(
+                    lambda in_size, out_size: torch.nn.Linear(
+                        in_size, out_size, bias=use_bias  # noqa
+                    ),
+                    num_batch_dims=num_batch_dims,
+                    uses_bias=use_bias,
+                    dtype=torch.float16,
+                    atol=5e-2,
+                )
+
+    @unittest.skip("Dynamic shapes not supported in MPS backend")
+    def test_fp32_linear(self):
+        for use_bias in (True, False):
+            for num_batch_dims in range(1, 3):
+                self._test_linear(
+                    lambda in_size, out_size: torch.nn.Linear(
+                        in_size, out_size, bias=use_bias  # noqa
+                    ),
+                    uses_bias=use_bias,
+                    num_batch_dims=num_batch_dims,
+                )
+
+    @unittest.skip("Dynamic shapes not supported in MPS backend")
+    def test_qc8_linear(self):
+        for use_bias in (True, False):
+            for num_batch_dims in range(1, 3):
+                self._test_linear(
+                    lambda in_size, out_size: torch.nn.Linear(
+                        in_size, out_size, bias=use_bias  # noqa
+                    ),
+                    uses_bias=use_bias,
+                    quant_type="per_channel",
+                    num_batch_dims=num_batch_dims,
+                )
+
+    @unittest.skip("Dynamic shapes not supported in MPS backend")
+    def test_fp32_addmm(self):
+        """
+        Note that the ConvertToLinear pass requires the weight matrix to be transposed.
+        """
+
+        class AddMMModule(torch.nn.Module):
+            def __init__(self, in_size, out_size):
+                super().__init__()
+                self.mat = torch.nn.Parameter(torch.randn(in_size, out_size))
+                self.bias = torch.nn.Parameter(torch.randn(1, out_size))
+
+            def forward(self, x):
+                return torch.addmm(self.bias, x, self.mat)
+
+        self._test_linear(
+            lambda in_size, out_size: AddMMModule(in_size, out_size),
+            uses_bias=True,
+        )
+
+    @unittest.skip("Dynamic shapes not supported in MPS backend")
+    def test_fp32_linear_fused_relu(self):
+        class LinearReluModule(torch.nn.Module):
+            def __init__(self, in_size, out_size, use_bias):
+                super().__init__()
+                self.linear = torch.nn.Linear(in_size, out_size, bias=use_bias)
+
+            def forward(self, x):
+                return torch.nn.functional.relu(self.linear(x))
+
+        for use_bias in (True, False):
+            for num_batch_dims in range(1, 3):
+                self._test_linear(
+                    lambda in_size, out_size: LinearReluModule(
+                        in_size,
+                        out_size,
+                        use_bias,  # noqa
+                    ),
+                    uses_bias=use_bias,
+                    num_batch_dims=num_batch_dims,
+                )
+
+    @unittest.skip("Dynamic shapes not supported in MPS backend")
+    def test_qs8_linear_fused_relu(self):
+        class LinearReluModule(torch.nn.Module):
+            def __init__(self, in_size, out_size, use_bias):
+                super().__init__()
+                self.linear = torch.nn.Linear(in_size, out_size, bias=use_bias)
+
+            def forward(self, x):
+                return torch.nn.functional.relu(self.linear(x))
+
+        for use_bias in (True, False):
+            for num_batch_dims in range(1, 3):
+                self._test_linear(
+                    lambda in_size, out_size: LinearReluModule(
+                        in_size,
+                        out_size,
+                        use_bias,  # noqa
+                    ),
+                    num_batch_dims=num_batch_dims,
+                    uses_bias=use_bias,
+                    quant_type="per_tensor",
+                )
+
+    @unittest.skip("Dynamic shapes not supported in MPS backend")
+    def test_qs8_linear(self):
+        for use_bias in (True, False):
+            for num_batch_dims in range(1, 3):
+                self._test_linear(
+                    lambda in_size, out_size: torch.nn.Linear(
+                        in_size, out_size, bias=use_bias  # noqa
+                    ),
+                    uses_bias=use_bias,
+                    num_batch_dims=num_batch_dims,
+                    quant_type="per_tensor",
+                )
+
+    @unittest.skip(
+        "quantized_decomposed_dequantize_per_channel_default is not supported bt MPS delegate"
+    )
+    def test_qd8_fp32_per_token_weight_per_channel_int8(self):
+        self._run_manual_dqlinear_tests(8, torch.float)
+
+    @unittest.skip(
+        "quantized_decomposed_dequantize_per_channel_default is not supported bt MPS delegate"
+    )
+    def test_qd8_fp32_per_token_weight_per_channel_int4(self):
+        self._run_manual_dqlinear_tests(4, torch.float)
+
+    def test_qd8_fp32_per_token_weight_per_channel_group_int4(self):
+        M_sizes = [1]
+        K_sizes = [64]
+        bl_sizes = [64]
+        N_sizes = [32]
+
+        for use_bias in [True, False]:
+            for i, _ in enumerate(M_sizes):
+                M = int(M_sizes[i])
+                K = int(K_sizes[i])
+                N = int(N_sizes[i])
+                bl = int(bl_sizes[i])
+                mod = self.ManualDQLinear(
+                    input_channels=K,
+                    output_channels=N,
+                    weight_n_bit=4,
+                    dtype=torch.float,
+                    group_size=bl,
+                    force_groupwise_quant=True,
+                    use_bias=use_bias,
+                )
+
+                inputs = (torch.randn(1, M, K),)
+                self._test_manual_dq_linear(
+                    mod,
+                    inputs,
+                    weight_groupwise=True,
+                    use_bias=use_bias,
+                )
+
+    @unittest.skip("Need to fix the dq_per_channel_group output dtype")
+    def _test_qd8_fp16_per_token_weight_per_channel_group_int4(self):
+        M_sizes = [1, 2, 17, 31]
+        K_sizes = [8, 32, 64, 128]
+        bl_sizes = [8, 16, 16, 32]
+        N_sizes = [2, 17, 92, 128]
+
+        for use_bias in [True, False]:
+            for i, _ in enumerate(M_sizes):
+                M = int(M_sizes[i])
+                K = int(K_sizes[i])
+                N = int(N_sizes[i])
+                bl = int(bl_sizes[i])
+                mod = self.ManualDQLinear(
+                    input_channels=K,
+                    output_channels=N,
+                    weight_n_bit=4,
+                    dtype=torch.float16,
+                    group_size=bl,
+                    force_groupwise_quant=True,
+                    use_bias=use_bias,
+                )
+
+                inputs = (torch.randn(1, M, K, dtype=torch.float16),)
+                self._test_manual_dq_linear(
+                    mod,
+                    inputs,
+                    weight_groupwise=True,
+                    use_bias=use_bias,
+                    atol=0.1,
+                    rtol=0.1,
+                )
+
+    def _test_linear(
+        self,
+        make_module,
+        uses_bias,
+        num_batch_dims=1,
+        quant_type=None,
+        dtype: torch.dtype = torch.float,
+        atol=1e-03,
+    ):
+        in_sizes = [3, 4, 4]
+        input_sizes = [4, 37, 17]
+        output_sizes = [4, 17, 37]
+
+        for i, _ in enumerate(in_sizes):
+            in_size = int(in_sizes[i])
+            input_size = int(input_sizes[i])
+            output_size = int(output_sizes[i])
+            input_shape = [in_size] * num_batch_dims + [input_size]
+            print(f"Testing input_shape {input_shape} with {output_size} out_channels")
+
+            module = make_module(input_size, output_size).eval().to(dtype)
+            inputs = (torch.randn(input_shape).to(dtype),)
+            dynamic_shape = {}
+            for i in range(num_batch_dims):
+                dynamic_shape[i] = torch.export.Dim(f"batch{i}", min=2, max=in_size)
+
+            dynamic_shape = (dynamic_shape,)
+            print(dynamic_shape)
+            self.lower_and_test_without_partitioner(
+                module,
+                inputs,
+                func_name=inspect.stack()[0].function[5:],
+                dynamic_shapes=dynamic_shape,
+                atol=atol,
+                rtol=1e-03,
+            )
+
+    class ManualDQLinear(torch.nn.Module):
+        def __init__(
+            self,
+            input_channels: int = 4,
+            output_channels: int = 4,
+            dtype: torch.dtype = torch.float,
+            weight_n_bit: int = 4,
+            group_size: int = 0,
+            force_groupwise_quant: bool = False,
+            use_bias: bool = False,
+        ):
+            super().__init__()
+
+            self.ic = input_channels
+            self.oc = output_channels
+
+            assert dtype in [torch.float, torch.half], "Unsupported op dtype"
+            self.op_dtype = dtype
+
+            self.group_size = self.ic if group_size == 0 else group_size
+            self.num_groups = 1
+            if self.group_size != self.ic:
+                assert self.ic % self.group_size == 0
+                assert self.group_size % 8 == 0  # TODO make this 16
+                self.num_groups = self.ic // self.group_size
+
+            assert weight_n_bit in [4, 8], "Unsupported weight_n_bit"
+            self.w_n_bit = weight_n_bit
+            self.w_quant_min, self.w_quant_max = self.get_min_max(self.w_n_bit)
+
+            self.w = torch.nn.Parameter(
+                torch.randn(self.oc, self.ic), requires_grad=False
+            )
+            self.w_q = torch.nn.Parameter(
+                torch.zeros(self.oc, self.ic), requires_grad=False
+            )
+            # Quantize the weights as per folded setup
+            if self.group_size != self.ic or force_groupwise_quant:
+                self.w_scales = torch.nn.Parameter(
+                    torch.zeros(self.oc, self.num_groups), requires_grad=False
+                )
+                self.w_zero_points = torch.nn.Parameter(
+                    torch.zeros(self.oc, self.num_groups), requires_grad=False
+                )
+                self.quant_weight_per_channel_group()
+            else:  # per_channel quantization
+                self.w_scales = torch.nn.Parameter(
+                    torch.zeros(self.oc), requires_grad=False
+                )
+                self.w_zero_points = torch.nn.Parameter(
+                    torch.zeros(self.oc), requires_grad=False
+                )
+                self.quant_weight_per_channel()
+
+            self.bias = (
+                torch.nn.Parameter(
+                    torch.randn(self.oc).to(self.op_dtype), requires_grad=False
+                )
+                if use_bias
+                else None
+            )
+
+        def get_min_max(self, n_bit: int = 4):
+            max_int = 2 ** (n_bit - 1) - 1
+            min_int = -(2 ** (n_bit - 1))
+            return min_int, max_int
+
+        def get_channel_qparams_symmetric(
+            self,
+            w: torch.Tensor,
+            n_bit: int = 4,
+            precision: torch.dtype = torch.float32,
+        ):
+            assert w.dim() == 2
+
+            to_quant = w.to(precision)
+            assert torch.isnan(to_quant).sum() == 0
+
+            max_val = to_quant.amax(dim=1, keepdim=True)
+            min_val = to_quant.amin(dim=1, keepdim=True)
+            min_val_neg = torch.min(min_val, torch.zeros_like(min_val))
+            max_val_pos = torch.max(max_val, torch.zeros_like(max_val))
+
+            min_int, max_int = self.get_min_max(n_bit)
+
+            max_val_abs = torch.max(-min_val_neg, max_val_pos)
+            scales = max_val_abs / (float(max_int - min_int) / 2)
+            scales = torch.max(
+                scales, torch.full_like(scales, torch.finfo(torch.float32).eps)
+            )
+            zeros = torch.full_like(scales, 0)
+            return scales.to(precision).reshape(w.shape[0]), zeros.to(
+                precision
+            ).reshape(w.shape[0]).reshape(w.shape[0])
+
+        # Note: not using from torchao.quantization.quant_primitives because it will run into op registraion issues
+        def get_group_qparams_symmetric(
+            self, w, n_bit=4, groupsize=128, precision=torch.float32
+        ):
+            # needed for GPTQ with padding
+            if groupsize > w.shape[-1]:
+                groupsize = w.shape[-1]
+            assert groupsize > 1
+            assert w.shape[-1] % groupsize == 0
+            assert w.dim() == 2
+
+            to_quant = w.reshape(-1, groupsize)
+            assert torch.isnan(to_quant).sum() == 0
+
+            max_val = to_quant.amax(dim=1, keepdim=True)
+            min_val = to_quant.amin(dim=1, keepdim=True)
+            min_val_neg = torch.min(min_val, torch.zeros_like(min_val))
+            max_val_pos = torch.max(max_val, torch.zeros_like(max_val))
+
+            max_val_abs = torch.max(-min_val_neg, max_val_pos)
+            max_int = 2 ** (n_bit - 1) - 1
+            min_int = -(2 ** (n_bit - 1))
+
+            scales = max_val_abs / (float(max_int - min_int) / 2)
+            scales = torch.max(
+                scales, torch.full_like(scales, torch.finfo(torch.float32).eps)
+            )
+            # TODO: make sure abs(scales) is not too small?
+            zeros = torch.full_like(scales, 0)
+            return scales.to(precision).reshape(w.shape[0], -1), zeros.to(
+                precision
+            ).reshape(w.shape[0], -1)
+
+        # Note: not using from torchao.quantization.quant_primitives because it will run into op registraion issues
+        def group_quantize_tensor_symmetric(
+            self, w, n_bit=4, group_size=128, precision=torch.float32
+        ):
+            scales, zeros = self.get_group_qparams_symmetric(
+                w, n_bit, group_size, precision
+            )
+            n_bit = 4
+            max_int = 2 ** (n_bit - 1) - 1
+            min_int = -(2 ** (n_bit - 1))
+            # TODO: currently we don't know how to express torch.int4, we'll
+            # add torch.int4 to core later
+            w_int8 = torch.ops.quantized_decomposed.quantize_per_channel_group(
+                w, scales, zeros, min_int, max_int, torch.int8, group_size
+            )
+
+            return w_int8, scales, zeros
+
+        def fwd_input_per_token(self, input: torch.Tensor) -> torch.Tensor:
+            ip_quant_min = -128
+            ip_quant_max = 127
+            (
+                ip_scales,
+                ip_zero_points,
+            ) = torch.ops.quantized_decomposed.choose_qparams_per_token_asymmetric(
+                input, torch.int8
+            )
+
+            input = torch.ops.quantized_decomposed.quantize_per_token(
+                input,
+                ip_scales,
+                ip_zero_points,
+                ip_quant_min,
+                ip_quant_max,
+                torch.int8,
+            )
+            input = torch.ops.quantized_decomposed.dequantize_per_token(
+                input,
+                ip_scales,
+                ip_zero_points,
+                ip_quant_min,
+                ip_quant_max,
+                torch.int8,
+                self.op_dtype,
+            )
+            return input
+
+        def quant_weight_per_channel(self):
+            (
+                self.w_scales.data,
+                self.w_zero_points.data,
+            ) = self.get_channel_qparams_symmetric(
+                self.w, n_bit=self.w_n_bit, precision=self.op_dtype
+            )
+            self.w_q.data = torch.ops.quantized_decomposed.quantize_per_channel(
+                self.w,
+                self.w_scales,
+                self.w_zero_points,
+                axis=0,
+                quant_min=self.w_quant_min,
+                quant_max=self.w_quant_max,
+                dtype=torch.int8,
+            )
+
+        def quant_weight_per_channel_group(self):
+            self.w_q.data, w, zp = self.group_quantize_tensor_symmetric(
+                self.w,
+                n_bit=self.w_n_bit,
+                group_size=self.group_size,
+            )
+            expected_min, expected_max = self.get_min_max(self.w_n_bit)
+            assert (
+                torch.min(self.w_q.data) >= expected_min
+            ), "Found smaller than min element in quantized weight tensor"
+            assert (
+                torch.max(self.w_q.data) <= expected_max
+            ), "Found larger than max element in quantized weight tensor"
+            assert (
+                w.ndim == 2 and zp.ndim == 2
+            ), f"Expecting 2d scales and zp tensors, but got {w.shape}, {zp.shape}"
+            self.w_scales.data, self.w_zero_points.data = w, zp
+
+        def fwd_weight_per_channel(self) -> torch.Tensor:
+            # This is HACKY because the dequant will produce fp32
+            return torch.ops.quantized_decomposed.dequantize_per_channel(
+                self.w_q,
+                self.w_scales,
+                self.w_zero_points,
+                axis=0,
+                quant_min=self.w_quant_min,
+                quant_max=self.w_quant_max,
+                dtype=torch.int8,  # Regardless of w_n_bit, convert to 4b later
+            )
+
+        def fwd_weight_per_channel_group(self) -> torch.Tensor:
+            return torch.ops.quantized_decomposed.dequantize_per_channel_group(
+                self.w_q,
+                self.w_scales,
+                self.w_zero_points,
+                self.w_quant_min,
+                self.w_quant_max,
+                dtype=torch.int8,  # Regardless of w_n_bit, convert to 4b later
+                group_size=self.group_size,
+                output_dtype=self.op_dtype,
+            )
+
+        def forward(self, input: torch.Tensor) -> torch.Tensor:
+            # Input
+            input = self.fwd_input_per_token(input)
+
+            # Weights
+            w = (
+                self.fwd_weight_per_channel_group()
+                if self.w_scales.ndim == 2
+                else self.fwd_weight_per_channel()
+            )
+            assert isinstance(w, torch.Tensor)
+            return torch.nn.functional.linear(input, w, self.bias)
+
+    def _test_manual_dq_linear(
+        self,
+        mod: torch.nn.Module,
+        inputs: Tuple[torch.Tensor],
+        weight_groupwise: bool = False,
+        use_bias: bool = False,
+    ):
+        self.lower_and_test_without_partitioner(
+            mod, inputs, func_name=inspect.stack()[0].function[5:]
+        )
+
+    def _run_manual_dqlinear_tests(self, weight_n_bit: int, op_dtype: torch.dtype):
+        in_sizes = [1, 4, 4]
+        input_sizes = [4, 37, 17]
+        output_sizes = [4, 17, 37]
+
+        for use_bias in [True, False]:
+            for i, _ in enumerate(in_sizes):
+                in_size = int(in_sizes[i])
+                input_size = int(input_sizes[i])
+                output_size = int(output_sizes[i])
+                mod = self.ManualDQLinear(
+                    input_channels=input_size,
+                    output_channels=output_size,
+                    weight_n_bit=weight_n_bit,
+                    dtype=op_dtype,
+                    use_bias=use_bias,
+                )
+
+                inputs = (torch.randn(1, in_size, input_size).to(op_dtype),)
+                self._test_manual_dq_linear(mod, inputs, use_bias=use_bias)

--- a/backends/apple/mps/utils/mps_utils.py
+++ b/backends/apple/mps/utils/mps_utils.py
@@ -24,6 +24,7 @@ def edge_dtype_to_mps_dtype(dtype: torch.dtype):
         edge_dtype_to_mps_dtype.map = {
             torch.float16: MPSDataType.mps_data_type_float16,
             torch.float32: MPSDataType.mps_data_type_float32,
+            torch.float64: MPSDataType.mps_data_type_float32,
             torch.bfloat16: MPSDataType.mps_data_type_bfloat16,
             torch.int8: MPSDataType.mps_data_type_int8,
             torch.int16: MPSDataType.mps_data_type_int16,

--- a/backends/apple/mps/utils/quant_utils.py
+++ b/backends/apple/mps/utils/quant_utils.py
@@ -1,0 +1,41 @@
+#
+#  Copyright (c) 2024 Apple Inc. All rights reserved.
+#  Provided subject to the LICENSE file in the top level directory.
+#
+
+import torch
+from executorch.exir.dialects._ops import ops as exir_ops
+
+DQ_GROUP_TARGETS = {
+    exir_ops.edge.quantized_decomposed.dequantize_per_channel_group.default,
+}
+
+Q_GROUP_TARGETS = {
+    exir_ops.edge.quantized_decomposed.quantize_per_channel_group.default,
+}
+
+DQ_TARGETS = {
+    exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+    exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor,
+    exir_ops.edge.quantized_decomposed.dequantize_per_channel.default,
+    exir_ops.edge.quantized_decomposed.dequantize_per_token.default,
+}.union(DQ_GROUP_TARGETS)
+
+Q_TARGETS = {
+    exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+    exir_ops.edge.quantized_decomposed.quantize_per_tensor.tensor,
+    exir_ops.edge.quantized_decomposed.quantize_per_channel.default,
+    exir_ops.edge.quantized_decomposed.quantize_per_token.default,
+}.union(Q_GROUP_TARGETS)
+
+
+def is_quant(tensor: torch.fx.Node) -> bool:
+    return tensor.target in Q_TARGETS
+
+
+def is_dequant(tensor: torch.fx.Node) -> bool:
+    return tensor.target in DQ_TARGETS
+
+
+def is_groupwise_q_dq(tensor: torch.fx.Node) -> bool:
+    return tensor.target in [DQ_GROUP_TARGETS, Q_GROUP_TARGETS]

--- a/examples/apple/mps/scripts/mps_example.py
+++ b/examples/apple/mps/scripts/mps_example.py
@@ -155,6 +155,8 @@ if __name__ == "__main__":
     model, example_inputs, _ = EagerModelFactory.create_model(**model_config)
 
     model = model.eval()
+
+    # Deep copy the model inputs to check against PyTorch forward pass
     if args.check_correctness or args.bench_pytorch:
         model_copy = copy.deepcopy(model)
         inputs_copy = []
@@ -228,4 +230,6 @@ if __name__ == "__main__":
         bench_torch(executorch_program, model_copy, example_inputs, model_name)
 
     if args.check_correctness:
-        compare_outputs(executorch_program, model_copy, inputs_copy, model_name)
+        compare_outputs(
+            executorch_program, model_copy, inputs_copy, model_name, args.use_fp16
+        )


### PR DESCRIPTION
Add support for MPS Int4 per channel group-wise quantization through MPSGraph.

--- 

Testing: 
**AOT export**
```
python -m examples.models.llama2.export_llama --checkpoint /Volumes/Source/weights/llama2/llama2-7b/llama-2-7b/consolidated.00.pth --params /Volumes/Source/weights/llama2/llama2-7b/llama-2-7b/params.json -kv --use_sdpa_with_kv_cache --mps -d fp32 --disable_dynamic_shape -qmode 8da4w -G 32
```
**Runtime**  (note that macOS 15.0 (Sequoia) or iOS/iPadOS 18 for Int4 Quantization:
```
~/tools/buck2_old2 run examples/models/llama2:main -- --model_path=mps_llama2_q.pte --tokenizer_path=tokenizer_llama2.bin --prompt="What is the best place to visit in New York?"  --temperature=0
```
Answer:
```
What is the best place to visit in New York?
New York is a city that has something for everyone. Whether you’re looking for a place to relax and enjoy the sights, or you’re looking for a place to party and have a good time, New York has it all.
There are so many different places to visit in New York, it can be hard to decide where to go. But don’t worry, we’ve got you covered. We’ve compiled a list of the best
```
---

**Note: this is dependent of https://github.com/pytorch/executorch/pull/4574 to be merged first!**

cc: @cccclai, @larryliu0820, @kimishpatel 