### PR TITLE
[Draft] Qualcomm AI Engine Direct - Unexpected graph for mutable buffer in Quantization

### DIFF
--- a/backends/qualcomm/tests/models.py
+++ b/backends/qualcomm/tests/models.py
@@ -459,11 +459,12 @@ class IndexPut(torch.nn.Module):
         self.register_buffer(
             "k_cache",
             torch.zeros((1, 1024, 12, 64), dtype=torch.float32),
+            persistent=False,
         )
 
     def forward(self, input_pos, k_val):
         k_out = torch.ops.aten.index_put_(self.k_cache, [None, input_pos], k_val)
-        return k_out
+        return k_out + k_out
 
 
 class LayerNorm(torch.nn.Module):


### PR DESCRIPTION
Hi @cccclai,

We found that the graph with mutable buffer [after export API](https://github.com/pytorch/executorch/blob/192d463f3aef1a54882154cb591df895a02e1e42/extension/export_util/utils.py#L79) in quantization flow is not expected.
I expect that the mutable buffer is I/O, not a constant.
And we can find that the following message is in the FP flow, but not in the quantized flow.

```
[utils.py:362] The buffer node is a mutated buffer node, which is not constant.
```
The following results could be reproduced to generate graph by this PR.
In summary, there are two questions about the graph for the quantization flow in the export stage after convert_pt2e

1. past_k_cache is a frozen constant, not an input.
2. index_put is not the output of graph.

Do you know what might be wrong?

## Floating Point Flow
This is exactly what I expected. At runtime, k_cache will become the input and the result of index_put will be output.
![image](https://github.com/user-attachments/assets/191bd1e8-992e-45e3-938c-bef095a6d39b)

## ```torch._export.capture_pre_autograd_graph``` in Quantization Flow
There are two problems here.
1. b_k_cache is folded by [```convert_pt2e```](https://github.com/pytorch/executorch/blob/192d463f3aef1a54882154cb591df895a02e1e42/extension/llm/export/builder.py#L193) to frozem_param
3. index_put is not output of the graph.

As far as I know, [```torch._export.capture_pre_autograd_graph```](https://github.com/pytorch/executorch/blob/192d463f3aef1a54882154cb591df895a02e1e42/extension/llm/export/builder.py#L212)  will be replaced by ```torch.export```, right? But when I change to torch.export, the problem still exists.
![image](https://github.com/user-attachments/assets/79570a95-c5ab-4eba-9b97-66da646b9ddb)

## Replaced by ```torch.export``` in Quantization Flow
After ```torch.export```, it will insert a copy op for BUFFER_MUTATION in graph signature. Therefore, k_cache will not be a dead code after ```convert_pt2e``` but k_cache is not a input of index_put.

![image](https://github.com/user-attachments/assets/e996fdd9-d2c7-468e-9c30-890b6da5833a)

## Replaced by ```torch.export``` and ```convert_pt2e(m, fold_quantize=False​)``` in Quantization Flow
I think this graph is my expected, but we need to change some codes in our passes to get the correct qaunt_attr for each op.
![image](https://github.com/user-attachments/assets/0bb03ede-4de3-4312-a5ff-4c226a089ca9)

# Reproduce Command
```
python3 backends/qualcomm/tests/test_qnn_delegate.py TestQNNQuantizedOperator.test_qnn_backend_index_put -b build_android -s {device_id} -m SM8650  -a unit_test 

```