### PR TITLE
Buckify open sourced ET-QNN

### DIFF
--- a/backends/qualcomm/aot/ir/qcir_utils.h
+++ b/backends/qualcomm/aot/ir/qcir_utils.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "QnnTypes.h"
-#include "qcir_generated.h"
+#include <executorch/backends/qualcomm/aot/ir/qcir_generated.h>
 
 namespace torch {
 namespace executor {

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpContextCustomConfig.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpContextCustomConfig.h
@@ -39,7 +39,7 @@ class HtpContextCustomConfig {
     return htp_context_config_.back().get();
   }
 
-  const QnnContext* context_;
+  [[maybe_unused]] const QnnContext* context_;
   std::vector<std::unique_ptr<QnnHtpContext_CustomConfig_t>>
       htp_context_config_;
   [[maybe_unused]] const QnnExecuTorchHtpBackendOptions* htp_options_;


### PR DESCRIPTION
Summary:
Buckify open sourced ET-QNN
- Move each target into its own subfolder
- Tested on device, the "QnnBackend not registered" error is gone

bypass-github-pytorch-ci-checks
bypass-github-executorch-ci-checks

Differential Revision: D60971802
