### PR TITLE
[coreml] Remove references to build_apple_frameworks.sh "--Release" flag

### DIFF
--- a/backends/apple/coreml/setup.md
+++ b/backends/apple/coreml/setup.md
@@ -50,7 +50,7 @@ xcode-select --install
 
 ```bash
 cd executorch
-./build/build_apple_frameworks.sh --Release --coreml
+./build/build_apple_frameworks.sh --coreml
 ```
 5. Open the project in Xcode, and drag `executorch.xcframework` and `coreml_backend.xcframework` frameworks generated from Step 2 to Frameworks.
 

--- a/build/build_apple_frameworks.sh
+++ b/build/build_apple_frameworks.sh
@@ -76,7 +76,7 @@ usage() {
   echo
   echo "Options:"
   echo "  --output=DIR         Output directory. Default: 'cmake-out'"
-  echo "  --Debug              Use Debug build mode. Default: 'Release'"
+  echo "  --Debug              Use Debug build mode. Default: Uses Release build mode."
   echo "  --toolchain=FILE     Cmake toolchain file. Default: '\$SOURCE_ROOT_DIR/third-party/ios-cmake/ios.toolchain.cmake'"
   echo "  --buck2=FILE         Buck2 executable path. Default: Path of buck2 found in the current \$PATH"
   echo "  --python=FILE        Python executable path. Default: Path of python3 found in the current \$PATH"
@@ -90,7 +90,7 @@ usage() {
   echo "  --xnnpack            Include this flag to build the XNNPACK backend."
   echo
   echo "Example:"
-  echo "  $0 /path/to/source/root --output=cmake-out --Release --toolchain=/path/to/cmake/toolchain --buck2=/path/to/buck2 --python=/path/to/python3 --coreml --mps --xnnpack"
+  echo "  $0 /path/to/source/root --output=cmake-out --toolchain=/path/to/cmake/toolchain --buck2=/path/to/buck2 --python=/path/to/python3 --coreml --mps --xnnpack"
   exit 0
 }
 

--- a/docs/source/build-run-coreml.md
+++ b/docs/source/build-run-coreml.md
@@ -127,7 +127,7 @@ python examples/apple/coreml/scripts/inspector_cli.py --etdump_path etdump.etdp 
 1. Build frameworks, running the following will create a `executorch.xcframework` and `coreml_backend.xcframework` in the `cmake-out` directory.
 ```bash
 cd executorch
-./build/build_apple_frameworks.sh --Release --coreml
+./build/build_apple_frameworks.sh --coreml
 ```
 2. Create a new [Xcode project](https://developer.apple.com/documentation/xcode/creating-an-xcode-project-for-an-app#) or open an existing project.
 


### PR DESCRIPTION
build_apple_frameworks.sh doesn't actually support this flag, and interprets it as setting SOURCE_ROOT_DIR:

```
% ./build/build_apple_frameworks.sh --Release --coreml
Toolchain file --Release/third-party/ios-cmake/ios.toolchain.cmake does not exist.
```

Since `Release` is the default, remove references to it. Users can override it with the `--Debug` flag.