### PR TITLE
Add core.pyi to resolve pyre issue when importing from executorch.extension.pybindings.core

### DIFF
--- a/extension/pybindings/TARGETS
+++ b/extension/pybindings/TARGETS
@@ -30,9 +30,10 @@ runtime.genrule(
     srcs = [":pybinding_types"],
     outs = {
         "aten_lib.pyi": ["aten_lib.pyi"],
+        "core.pyi": ["core.pyi"],
         "_portable_lib.pyi": ["_portable_lib.pyi"],
     },
-    cmd = "cp $(location :pybinding_types)/* $OUT/_portable_lib.pyi && cp $(location :pybinding_types)/* $OUT/aten_lib.pyi",
+    cmd = "cp $(location :pybinding_types)/* $OUT/_portable_lib.pyi && cp $(location :pybinding_types)/* $OUT/aten_lib.pyi && cp $(location :pybinding_types)/* $OUT/core.pyi",
     visibility = ["//executorch/extension/pybindings/..."],
 )
 
@@ -40,6 +41,7 @@ executorch_pybindings(
     compiler_flags = ["-std=c++17"],
     cppdeps = PORTABLE_MODULE_DEPS,
     python_module_name = "core",
+    types = ["//executorch/extension/pybindings:pybindings_types_gen[core.pyi]"],
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
Summary:
This diff adds a new file `core.pyi` to the `pybinding_types` target in the `executorch/extension/pybindings` directory. This file is needed to resolve a pyre issue when importing from `executorch.extension.pybindings.core`.

`core` is needed to avoid loading any operator libraries from `aten` or `portable` lib

Differential Revision: D61044759
