### PR TITLE
Add llama sdpa to generation script

### DIFF
--- a/examples/models/llama2/runner/generation.py
+++ b/examples/models/llama2/runner/generation.py
@@ -17,6 +17,11 @@ from executorch.examples.models.llama2.llama_transformer import ModelArgs
 from executorch.examples.models.llama2.tokenizer.tiktoken import Tokenizer
 from executorch.extension.pybindings.portable_lib import _load_for_executorch
 
+from executorch.extension.pybindings import portable_lib  # noqa # usort: skip
+
+# Note: import this after portable_lib
+from executorch.extension.llm.custom_ops import sdpa_with_kv_cache  # noqa # usort: skip
+
 
 class CompletionPrediction(TypedDict, total=False):
     generation: str


### PR DESCRIPTION
After https://github.com/pytorch/executorch/pull/4024, sdpa is no longer in portable_lib by default, import separately.