### PR TITLE
Add 256 constraint executorch.max_kernel_num for

### DIFF
--- a/runtime/kernel/targets.bzl
+++ b/runtime/kernel/targets.bzl
@@ -7,6 +7,7 @@ def _operator_registry_preprocessor_flags():
     elif not runtime.is_oss:
         return select({
             "DEFAULT": [],
+            "fbsource//xplat/executorch/build/constraints:executorch-max-kernel-num-256": ["-DMAX_KERNEL_NUM=256"],
             "fbsource//xplat/executorch/build/constraints:executorch-max-kernel-num-64": ["-DMAX_KERNEL_NUM=64"],
         })
     else:


### PR DESCRIPTION
Summary: Select MAX_KERNEL_NUM value based on target constraints to support 256

Reviewed By: ravikh19, cmt0

Differential Revision: D60995174
