### PR TITLE
Fix return type in op_choose_qparams.cpp

### DIFF
--- a/kernels/quantized/cpu/op_choose_qparams.cpp
+++ b/kernels/quantized/cpu/op_choose_qparams.cpp
@@ -149,7 +149,7 @@ void choose_qparams(
 }
 } // namespace
 
-std::tuple<Tensor, Tensor> choose_qparams_tensor_out(
+std::tuple<Tensor&, Tensor&> choose_qparams_tensor_out(
     const Tensor& input,
     int64_t quant_min,
     int64_t quant_max,
@@ -164,7 +164,7 @@ std::tuple<Tensor, Tensor> choose_qparams_tensor_out(
   return {scale_out, zero_point_out};
 }
 
-::std::tuple<Tensor, Tensor> choose_qparams_tensor_out(
+::std::tuple<Tensor&, Tensor&> choose_qparams_tensor_out(
     RuntimeContext& context,
     const Tensor& input,
     int64_t quant_min,


### PR DESCRIPTION
Patch from @python3kgae https://github.com/pytorch/executorch/issues/4659 