### PR TITLE
Fix return type mismatch in choose_qparams_tensor_out

### DIFF
--- a/kernels/quantized/cpu/op_choose_qparams.cpp
+++ b/kernels/quantized/cpu/op_choose_qparams.cpp
@@ -149,7 +149,7 @@ void choose_qparams(
 }
 } // namespace
 
-std::tuple<Tensor, Tensor> choose_qparams_tensor_out(
+std::tuple<Tensor&, Tensor&> choose_qparams_tensor_out(
     const Tensor& input,
     int64_t quant_min,
     int64_t quant_max,
@@ -164,7 +164,7 @@ std::tuple<Tensor, Tensor> choose_qparams_tensor_out(
   return {scale_out, zero_point_out};
 }
 
-::std::tuple<Tensor, Tensor> choose_qparams_tensor_out(
+::std::tuple<Tensor&, Tensor&> choose_qparams_tensor_out(
     RuntimeContext& context,
     const Tensor& input,
     int64_t quant_min,


### PR DESCRIPTION
This fix addresses the undefined symbol error for torch::executor::native::choose_qparams_tensor_out when building on native Windows.

The root cause is a mismatch between the return types in the function declaration (std::tuple<Tensor &, Tensor &>) and the function definition (std::tuple<Tensor, Tensor>). Additionally, the function definition cannot see the function declaration, so the compiler cannot catch the issue. While the Linux linker seems to handle the return type mismatch, the Windows linker reports an undefined symbol.

This fix updates the return type in the function definition to match the function declaration. If possible, it would be beneficial to include the header of the function declaration so that the issue can be caught at compile time.

Fixes #4659