### PR TITLE
Use MmapDataLoader::MlockConfig::NoMlock for Module::LoadMode::Mmap

### DIFF
--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -72,12 +72,12 @@ Error Module::load(const Program::Verification verification) {
               ET_UNWRAP_UNIQUE(util::FileDataLoader::from(file_path_.c_str()));
           break;
         case LoadMode::Mmap:
-          data_loader_ =
-              ET_UNWRAP_UNIQUE(util::MmapDataLoader::from(file_path_.c_str()));
-          break;
-        case LoadMode::MmapUseMlock:
           data_loader_ = ET_UNWRAP_UNIQUE(util::MmapDataLoader::from(
               file_path_.c_str(), util::MmapDataLoader::MlockConfig::NoMlock));
+          break;
+        case LoadMode::MmapUseMlock:
+          data_loader_ =
+              ET_UNWRAP_UNIQUE(util::MmapDataLoader::from(file_path_.c_str()));
           break;
         case LoadMode::MmapUseMlockIgnoreErrors:
           data_loader_ = ET_UNWRAP_UNIQUE(util::MmapDataLoader::from(


### PR DESCRIPTION
Summary:
Previously D59498348 changed `nomlock` to `LoadMode::mmap`
https://www.internalfb.com/code/fbsource/[10ab96770d06]/xplat/executorch/extension/fb/dynamic_shim/dynamic_shim.cpp?lines=19-24

However in `module.cpp` they are mapped to wrong `MlockConfig`.
This diff fix the switch mapping.

`mlock` on Android 14 and 15 has new restrictions not sure how this related to increased failure rate of `mlock`
{F1804539420}

Differential Revision: D61251233


