### PR TITLE
[DO NOT MERGE] Demonstrate how to switch back to Amazon 2 runners

### DIFF
--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -16,7 +16,7 @@ jobs:
   linux:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: amz2.linux.2xlarge
+      runner: am2.linux.2xlarge
       docker-image: ${{ inputs.docker-image }}
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -16,7 +16,7 @@ jobs:
   linux:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux.2xlarge
+      runner: amz2.linux.2xlarge
       docker-image: ${{ inputs.docker-image }}
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
           tokenizer: [bpe, tiktoken]
     with:
-      runner: linux.2xlarge
+      runner: amz2.linux.2xlarge
       docker-image: executorch-ubuntu-22.04-clang12-android
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -161,7 +161,7 @@ jobs:
         tokenizer: [bpe]
     with:
       device-type: android
-      runner: linux.2xlarge
+      runner: amz2.linux.2xlarge
       test-infra-ref: ''
       # This is the ARN of ExecuTorch project on AWS
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
           tokenizer: [bpe, tiktoken]
     with:
-      runner: amz2.linux.2xlarge
+      runner: am2.linux.2xlarge
       docker-image: executorch-ubuntu-22.04-clang12-android
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -161,7 +161,7 @@ jobs:
         tokenizer: [bpe]
     with:
       device-type: android
-      runner: amz2.linux.2xlarge
+      runner: am2.linux.2xlarge
       test-infra-ref: ''
       # This is the ARN of ExecuTorch project on AWS
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6


### PR DESCRIPTION
If your jobs start failing once they start running on the Amazon 2023 AMI, this this PR demonstrates how to temporarily get them to run on the older Amazon 2 AMI again.  

Note that this should be considered a short term solution and the Amazon 2 AMI could stop working at anytime without warning.

If you need more examples, see [the PRs here](https://github.com/pulls?q=is%3Apr+author%3Ajeanschmidt+archived%3Afalse+%22Replace+runners+prefix+amz2023%22).  Wherever you see "amz2023" entered in them you'll want to use "am2" instead.
