### PR TITLE
Use the common return_type field to support ET-QNN internally and externally

### DIFF
--- a/backends/qualcomm/aot/ir/qcir_utils.h
+++ b/backends/qualcomm/aot/ir/qcir_utils.h
@@ -15,10 +15,10 @@ namespace torch {
 namespace executor {
 namespace qnn {
 
-typedef flatbuffers::Vector<::flatbuffers::Offset<qcir::Tensor>>::value_type
+typedef flatbuffers::Vector<::flatbuffers::Offset<qcir::Tensor>>::return_type
     tensor_type;
 typedef flatbuffers::Vector<
-    ::flatbuffers::Offset<qcir::QuantizeParam>>::value_type qparam_type;
+    ::flatbuffers::Offset<qcir::QuantizeParam>>::return_type qparam_type;
 
 qcir::TensorType ToTensorType(Qnn_TensorType_t type);
 Qnn_TensorType_t ToTensorType(qcir::TensorType type);


### PR DESCRIPTION
Summary:
Allow ET-QNN to support both versions of flatbuffers header definition internally and externally
- The internal [flatbuffers.h](https://www.internalfb.com/code/fbsource/[db7bb967be7e]/third-party/flatbuffers/flatbuffers/include/flatbuffers/flatbuffers.h?lines=258) and the external [flatbuffers.h](https://flatbuffers.dev/flatbuffers_8h_source.html) have minors differences due to version not in-sync. The external flatbuffers.h has a new line "typedef return_type value_type;" that current ET-QNN references the "value_type". It is safe to use the common "return_type" to define the tensor_type and qparam_type here for backward compatibility.

```
   typedef typename IndirectHelper<T>::return_type return_type;
   typedef typename IndirectHelper<T>::mutable_return_type mutable_return_type;
   typedef return_type value_type;
```

Differential Revision: D61288452
