### PR TITLE
fix eager_eval with kv cache and improve pybind eval speed

### DIFF
--- a/examples/models/llama2/eval_llama_lib.py
+++ b/examples/models/llama2/eval_llama_lib.py
@@ -54,12 +54,11 @@ class ETPybindEvalWrapper(EagerEvalWrapper):
         # inps: Tensor of shape (1, max_seq_len - 1)
         # logits: Tensor of shape (1, max_seq_len - 1, vocab_size)
         if self._use_kv_cache:
-            result_logits = []
-            for pos in range(self._max_seq_length):
-                pos_tensor = torch.tensor([pos], dtype=torch.int64)
-                logits = self._et_model.forward((inps[:, pos : pos + 1], pos_tensor))
-                result_logits.append(logits[0])
-            return torch.cat(result_logits, dim=1)
+            pos_tensor = torch.tensor([0], dtype=torch.int64, device=self.device)
+            result = self._et_model.forward(
+                (inps[:, : self._max_seq_length], pos_tensor)
+            )
+            return result[0]
         else:
             result = self._et_model.forward((inps,))
             return result[0]

--- a/examples/models/llama2/evaluate/eager_eval.py
+++ b/examples/models/llama2/evaluate/eager_eval.py
@@ -77,10 +77,7 @@ class EagerEvalWrapper(eval_wrapper):
 
     def _model_call(self, inps):
         if self._use_kv_cache:
-            pos_tensor = torch.arange(
-                self._max_seq_length, dtype=torch.int64, device=self.device
-            )
-
+            pos_tensor = torch.tensor([0], dtype=torch.int64, device=self.device)
             # Batch process the whole sequence.
             logits = self._model(inps[:, : self._max_seq_length], pos_tensor)
             return logits


### PR DESCRIPTION
The existing `eager_eval` fails to run when kv is enabled due to using the wrong `pos_tensor`. This PR fixes it.

The `pybind_eval` is extremely slow right now. This PR improves its speed based on https://github.com/pytorch/executorch/pull/3732.

Test Plan:
- before
```
2024-08-14:14:43:31,158 INFO     [task.py:395] Building contexts for wikitext on rank 0...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 949.71it/s]
2024-08-14:14:43:31,163 INFO     [evaluator.py:362] Running loglikelihood_rolling requests
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [35:57<00:00, 431.58s/it]
wikitext: {'word_perplexity,none': 48.05348672811993, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 2.130418826812418, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 1.0911370830175748, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
```
- after
```
2024-08-14:15:40:33,050 INFO     [task.py:395] Building contexts for wikitext on rank 0...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 890.17it/s]
2024-08-14:15:40:33,056 INFO     [evaluator.py:362] Running loglikelihood_rolling requests
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [01:53<00:00, 22.71s/it]
wikitext: {'word_perplexity,none': 48.0195983759526, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 2.13012529989619, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 1.0909382962830712, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
```