### PR TITLE
Add default dim_order asserts

### DIFF
--- a/backends/xnnpack/runtime/XNNExecutor.cpp
+++ b/backends/xnnpack/runtime/XNNExecutor.cpp
@@ -86,6 +86,11 @@ __ET_NODISCARD Error XNNExecutor::prepare_args(EValue** args) {
     // Reshape runtime inputs
     if (i < input_ids_.size()) {
       size_t num_dims = tensor->dim();
+      ET_CHECK_OR_RETURN_ERROR(
+          is_contiguous_dim_order(tensor->dim_order().data(), tensor->dim()),
+          Internal,
+          "Expecting default dim_order but got a non default dim_order tensor for external input %u",
+          i);
       size_t dims[XNN_MAX_TENSOR_DIMS];
       ET_CHECK_OR_RETURN_ERROR(
           num_dims <= XNN_MAX_TENSOR_DIMS,


### PR DESCRIPTION
Summary:
Add a couple of sanity checks to avoid accepting unsupported dim_order

* AoT: make sure all the inputs have default dim_order (=contiguous_format)
* Runtime: all the incoming etensors have default dim_order (=contiguous_format)

Differential Revision: D61311560
