### PR TITLE
Remove underscore prefixes from compiler.h macros

### DIFF
--- a/backends/apple/coreml/runtime/test/CoreMLBackendDelegateTests.mm
+++ b/backends/apple/coreml/runtime/test/CoreMLBackendDelegateTests.mm
@@ -32,7 +32,7 @@ public:
     {}
 
     Result<FreeableBuffer> load(
-        size_t offset, size_t size, __ET_UNUSED const DataLoader::SegmentInfo& segment_info) const override {
+        size_t offset, size_t size, ET_UNUSED const DataLoader::SegmentInfo& segment_info) const override {
         NSData *subdata = [data_ subdataWithRange:NSMakeRange(offset, size)];
         return FreeableBuffer(subdata.bytes, size, nullptr);
     }

--- a/backends/apple/mps/runtime/MPSBackend.mm
+++ b/backends/apple/mps/runtime/MPSBackend.mm
@@ -55,7 +55,7 @@ class MPSBackend final : public PyTorchBackendInterface {
 
   // Function that actually executes the model in the backend.
   Error execute(
-    __ET_UNUSED BackendExecutionContext& context,
+    ET_UNUSED BackendExecutionContext& context,
     DelegateHandle* handle,
     EValue** args) const override {
     auto executor = static_cast<mps::delegate::MPSExecutor*>(handle);

--- a/backends/apple/mps/runtime/MPSCompiler.h
+++ b/backends/apple/mps/runtime/MPSCompiler.h
@@ -24,7 +24,7 @@ class MPSCompiler {
   // Takes Flatbuffer Serialized MPS Model and rebuilds the MPSGraphExecutable
   // returns an executor object that holds the MPS runtime object which we
   // can then use to set inputs and run inference using the MPSGraphExecutable.
-  __ET_NODISCARD static Error compileModel(
+  ET_NODISCARD static Error compileModel(
       const void* buffer_pointer,
       size_t num_bytes,
       MPSExecutor* executor,

--- a/backends/apple/mps/runtime/MPSCompiler.mm
+++ b/backends/apple/mps/runtime/MPSCompiler.mm
@@ -32,7 +32,7 @@ namespace delegate {
 Builds the mps runtime object using the buffer pointer. The buffer pointer
 must be a valid pointer to the serialized mps object.
 */
-__ET_NODISCARD Error MPSCompiler::compileModel(
+ET_NODISCARD Error MPSCompiler::compileModel(
   const void* buffer_pointer,
   size_t num_bytes,
   MPSExecutor* executor,

--- a/backends/apple/mps/runtime/MPSExecutor.h
+++ b/backends/apple/mps/runtime/MPSExecutor.h
@@ -73,9 +73,9 @@ class MPSExecutor {
     return _executable;
   }
 
-  __ET_NODISCARD Error forward(std::vector<const Tensor*>& outputs);
+  ET_NODISCARD Error forward(std::vector<const Tensor*>& outputs);
 
-  __ET_NODISCARD Error
+  ET_NODISCARD Error
   set_inputs_outputs(std::vector<const Tensor*>& inputs, std::vector<const Tensor*>& outputs);
 
   Error initDataBuffers();

--- a/backends/apple/mps/runtime/MPSExecutor.mm
+++ b/backends/apple/mps/runtime/MPSExecutor.mm
@@ -37,7 +37,7 @@ MPSExecutor::MPSExecutor() {
   _outputsArray = [[NSMutableArray<MPSGraphTensorData *> alloc] initWithCapacity:getNumOutputs()];
 }
 
-__ET_NODISCARD Error
+ET_NODISCARD Error
 MPSExecutor::set_inputs_outputs(std::vector<const Tensor*>& inputs, std::vector<const Tensor*>& outputs) {
   ET_CHECK_OR_RETURN_ERROR(inputs.size() == getNumInputs(), Internal, "Inputs mismatch");
   ET_CHECK_OR_RETURN_ERROR(outputs.size() == getNumOutputs(), Internal, "Outputs mismatch");
@@ -61,7 +61,7 @@ MPSExecutor::set_inputs_outputs(std::vector<const Tensor*>& inputs, std::vector<
   return Error::Ok;
 }
 
-__ET_NODISCARD Error MPSExecutor::forward(std::vector<const Tensor*>& outputs) {
+ET_NODISCARD Error MPSExecutor::forward(std::vector<const Tensor*>& outputs) {
   Error err = Error::Ok;
   MPSStream* mpsStream = getDefaultMPSStream();
   if (mpsStream->commitAndContinueEnabled() || mpsStream->hasLiveCommandBuffer()) {

--- a/backends/apple/mps/runtime/MPSStream.h
+++ b/backends/apple/mps/runtime/MPSStream.h
@@ -63,7 +63,7 @@ class MPSStream {
   MPSCommandBuffer* commandBuffer();
   id<MTLComputeCommandEncoder> commandEncoder();
   void endKernelCoalescing();
-  __ET_NODISCARD Error synchronize(SyncType syncType);
+  ET_NODISCARD Error synchronize(SyncType syncType);
   bool commitAndContinueEnabled();
   void copy(
       id<MTLBuffer> srcBuffer,

--- a/backends/apple/mps/runtime/MPSStream.mm
+++ b/backends/apple/mps/runtime/MPSStream.mm
@@ -55,7 +55,7 @@ id<MTLComputeCommandEncoder> MPSStream::commandEncoder() {
   return _commandEncoder;
 }
 
-__ET_NODISCARD
+ET_NODISCARD
 Error MPSStream::synchronize(SyncType syncType) {
   endKernelCoalescing();
   switch(syncType) {
@@ -157,7 +157,7 @@ void MPSStream::copy(id<MTLBuffer> srcBuffer,
       endKernelCoalescing();
       if (@available(iOS 13.0, *)) {
         id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer() blitCommandEncoder];
-        
+
         [blitEncoder copyFromBuffer:srcBuffer
                        sourceOffset:(NSUInteger)srcOffset
                            toBuffer:dstBuffer

--- a/backends/cadence/executor_runner.cpp
+++ b/backends/cadence/executor_runner.cpp
@@ -83,10 +83,10 @@ void et_pal_emit_log_message(
     et_timestamp_t timestamp,
     et_pal_log_level_t level,
     const char* filename,
-    __ET_UNUSED const char* function,
+    ET_UNUSED const char* function,
     size_t line,
     const char* message,
-    __ET_UNUSED size_t length) {
+    ET_UNUSED size_t length) {
   PRINTF("\r%s\n", message);
 }
 

--- a/backends/mediatek/runtime/NeuronBackend.cpp
+++ b/backends/mediatek/runtime/NeuronBackend.cpp
@@ -67,7 +67,7 @@ Result<DelegateHandle*> NeuronBackend::init(
 }
 
 Error NeuronBackend::execute(
-    __ET_UNUSED BackendExecutionContext& context,
+    ET_UNUSED BackendExecutionContext& context,
     DelegateHandle* handle,
     EValue** args) const {
   NeuronExecuTorchDelegate* delegate =

--- a/backends/mediatek/runtime/include/NeuronBackend.h
+++ b/backends/mediatek/runtime/include/NeuronBackend.h
@@ -34,7 +34,7 @@ class NeuronBackend final : public PyTorchBackendInterface {
       ArrayRef<CompileSpec> compile_specs) const override;
 
   Error execute(
-      __ET_UNUSED BackendExecutionContext& context,
+      ET_UNUSED BackendExecutionContext& context,
       DelegateHandle* handle,
       EValue** args) const override;
 
@@ -111,7 +111,7 @@ class NeuronExecuTorchDelegate {
     return NEURON_NO_ERROR;
   }
 
-  Error execute(__ET_UNUSED BackendExecutionContext& context, EValue** args)
+  Error execute(ET_UNUSED BackendExecutionContext& context, EValue** args)
       const;
 
  private:

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.h
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.h
@@ -24,7 +24,7 @@ class QnnExecuTorchBackend final : public PyTorchBackendInterface {
       ArrayRef<CompileSpec> compile_specs) const override;
 
   Error execute(
-      __ET_UNUSED BackendExecutionContext& context,
+      ET_UNUSED BackendExecutionContext& context,
       DelegateHandle* handle,
       EValue** args) const override;
 

--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -421,7 +421,7 @@ class VulkanBackend final : public PyTorchBackendInterface {
     return true;
   }
 
-  __ET_NODISCARD Error
+  ET_NODISCARD Error
   compileModel(const void* buffer_pointer, ComputeGraph* compute_graph) const {
     Result<VulkanDelegateHeader> header =
         VulkanDelegateHeader::parse(buffer_pointer);
@@ -485,7 +485,7 @@ class VulkanBackend final : public PyTorchBackendInterface {
   }
 
   Error execute(
-      __ET_UNUSED BackendExecutionContext& context,
+      ET_UNUSED BackendExecutionContext& context,
       DelegateHandle* handle,
       EValue** args) const override {
     EXECUTORCH_SCOPE_PROF("VulkanBackend::execute");

--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -1608,7 +1608,7 @@ Builds the xnnpack runtime object using the buffer pointer. The buffer pointer
 must be a valid pointer to the serialized xnnpack object. It also fills the
 XNNExecutor object with the built xnn_runtime and the input/output ids.
 */
-__ET_NODISCARD Error XNNCompiler::compileModel(
+ET_NODISCARD Error XNNCompiler::compileModel(
     const void* buffer_pointer,
     size_t num_bytes,
     XNNExecutor* executor,

--- a/backends/xnnpack/runtime/XNNCompiler.h
+++ b/backends/xnnpack/runtime/XNNCompiler.h
@@ -25,7 +25,7 @@ class XNNCompiler {
   // Takes Flatbuffer Serialized XNNPACK Model and rebuilds the xnn-subgraph
   // returns an executor object that holds the xnn runtime object which we
   // can then use to set inputs and run inference using the xnn graph.
-  __ET_NODISCARD static Error compileModel(
+  ET_NODISCARD static Error compileModel(
       const void* buffer_pointer,
       size_t num_bytes,
       XNNExecutor* executor,

--- a/backends/xnnpack/runtime/XNNExecutor.cpp
+++ b/backends/xnnpack/runtime/XNNExecutor.cpp
@@ -22,7 +22,7 @@ using SizesType = exec_aten::SizesType;
  * inputs/outputs externals_ is resized to the total number of inputs and
  * outputs
  */
-__ET_NODISCARD Error XNNExecutor::initialize(
+ET_NODISCARD Error XNNExecutor::initialize(
     xnn_runtime_t runtime,
     std::vector<uint32_t>&& input_ids,
     std::vector<uint32_t>&& output_ids) {
@@ -62,7 +62,7 @@ __ET_NODISCARD Error XNNExecutor::initialize(
  * runtime correspond to their index in the list of arg passed into
  * delegate->execute()
  */
-__ET_NODISCARD Error XNNExecutor::prepare_args(EValue** args) {
+ET_NODISCARD Error XNNExecutor::prepare_args(EValue** args) {
   // Create xnn_externals_value from evalue args
   xnn_status status;
   for (uint32_t i = 0; i < externals_.size(); ++i) {
@@ -128,7 +128,7 @@ __ET_NODISCARD Error XNNExecutor::prepare_args(EValue** args) {
  * We first setup the runtime by feeding the externals_ to runtime setup.
  * After which we then execute the runtime through invoke_runtime.
  */
-__ET_NODISCARD Error XNNExecutor::forward(BackendExecutionContext& context) {
+ET_NODISCARD Error XNNExecutor::forward(BackendExecutionContext& context) {
   ET_CHECK_OR_RETURN_ERROR(
       runtime_ != nullptr,
       Internal,
@@ -180,7 +180,7 @@ __ET_NODISCARD Error XNNExecutor::forward(BackendExecutionContext& context) {
  * XNNPACK gives the index tensor to us as int32, we need to convert it
  * back to int64 for ExecuTorch.
  */
-__ET_NODISCARD Error XNNExecutor::resize_outputs(EValue** args) const {
+ET_NODISCARD Error XNNExecutor::resize_outputs(EValue** args) const {
   size_t output_idx_start = input_ids_.size();
   for (size_t i = output_idx_start; i < externals_.size(); ++i) {
     uint32_t ext_id = externals_[i].id;

--- a/backends/xnnpack/runtime/XNNExecutor.h
+++ b/backends/xnnpack/runtime/XNNExecutor.h
@@ -51,7 +51,7 @@ class XNNExecutor {
    * The input/output ids are expected to be sorted in order of their
    * flatbuffer id_outs
    */
-  __ET_NODISCARD Error initialize(
+  ET_NODISCARD Error initialize(
       xnn_runtime_t runtime,
       std::vector<uint32_t>&& input_ids,
       std::vector<uint32_t>&& output_ids);
@@ -62,19 +62,19 @@ class XNNExecutor {
    * input shapes will be propagated through the runtime, and perform
    * any additional memory planning as needed
    */
-  __ET_NODISCARD Error prepare_args(EValue** args);
+  ET_NODISCARD Error prepare_args(EValue** args);
 
   /**
    * Executes the graph using the args prepared at prepare_args().
    */
-  __ET_NODISCARD Error forward(BackendExecutionContext& context);
+  ET_NODISCARD Error forward(BackendExecutionContext& context);
 
   /**
    * Prepares the outputs to be returned by the delegate
    *
    * Performs any post processing of outputs like tensor resizing
    */
-  __ET_NODISCARD Error resize_outputs(EValue** args) const;
+  ET_NODISCARD Error resize_outputs(EValue** args) const;
 
   friend class XNNCompiler;
 };

--- a/backends/xnnpack/threadpool/threadpool.cpp
+++ b/backends/xnnpack/threadpool/threadpool.cpp
@@ -117,7 +117,7 @@ ThreadPool* get_threadpool() {
   // @lint-ignore CLANGTIDY facebook-hte-std::call_once
   std::call_once(
       flag, []() { pthread_atfork(nullptr, nullptr, child_atfork); });
-  if __ET_UNLIKELY (leak_corrupted_threadpool) {
+  if ET_UNLIKELY (leak_corrupted_threadpool) {
     leak_corrupted_threadpool = false;
     if (auto leaked = threadpool.release()) {
       auto t = leaked->get_thread_count();

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-# SPHINXOPTS    = -WT --keep-going TODO(T165752164) fix sphinx warnings around preprocess macros in cpp like __ET_DEPRECATED
+# SPHINXOPTS    = -WT --keep-going TODO(T165752164) fix sphinx warnings around preprocess macros in cpp like ET_DEPRECATED
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = ExecuTorch
 SOURCEDIR     = source

--- a/docs/source/api-life-cycle.md
+++ b/docs/source/api-life-cycle.md
@@ -113,11 +113,11 @@ usage</a>
    </td>
    <td>
 
-Use <code>__ET_DEPRECATED</code> macros. See <a href="https://github.com/pytorch/executorch/blob/8e0f856ee269b319ac4195509cf31e3f548aa0e8/runtime/executor/program.h#L81">example usage</a>
+Use <code>ET_DEPRECATED</code> macros. See <a href="https://github.com/pytorch/executorch/blob/8e0f856ee269b319ac4195509cf31e3f548aa0e8/runtime/executor/program.h#L81">example usage</a>
 
 <p>
 <p>
-Use <code>__ET_EXPERIMENTAL</code> macros (TODO not yet implemented)
+Use <code>ET_EXPERIMENTAL</code> macros (TODO not yet implemented)
 </ul>
    </td>
    <td>

--- a/docs/source/compiler-delegate-and-partitioner.md
+++ b/docs/source/compiler-delegate-and-partitioner.md
@@ -87,22 +87,22 @@ function which will be called when the program is out of its lifespan.
 
 ```cpp
 // Runtime check
-__ET_NODISCARD bool is_available();
+ET_NODISCARD bool is_available();
 
 // Runtime initialization
-__ET_NODISCARD virtual Result<DelegateHandle*> init(
+ET_NODISCARD virtual Result<DelegateHandle*> init(
     BackendInitContext& context,
     FreeableBuffer* processed,
     ArrayRef<CompileSpec> compile_specs);
 
 // Runtime execution
-__ET_NODISCARD virtual Error execute(
+ET_NODISCARD virtual Error execute(
     BackendExecutionContext& context,
     DelegateHandle* handle,
     EValue** args);
 
 // [optional] Runtime destroy. Destroy the resource held by the backend
-virtual void destroy(__ET_UNUSED DelegateHandle* handle);
+virtual void destroy(ET_UNUSED DelegateHandle* handle);
 ```
 
 The diagram looks like following
@@ -114,7 +114,7 @@ The diagram looks like following
 
 In order to make backend available to ExecuTorch runtime, it must be registered via the `register_backend` API:
 ```cpp
-__ET_NODISCARD Error register_backend(const Backend& backend);
+ET_NODISCARD Error register_backend(const Backend& backend);
 ```
 
 Static registeration, i.e., at libraray init or load time, of a backend can be achieved as follows:

--- a/docs/website/docs/tutorials/bundled_program.md
+++ b/docs/website/docs/tutorials/bundled_program.md
@@ -88,7 +88,7 @@ To execute the program on the bundled input, we need to load the bundled input i
  * @returns Return Error::Ok if load successfully, or the error happens during
  * execution.
  */
-__ET_NODISCARD Error LoadBundledInput(
+ET_NODISCARD Error LoadBundledInput(
     Method& method,
     serialized_bundled_program* bundled_program_ptr,
     size_t testset_idx);
@@ -111,7 +111,7 @@ We call `torch::executor::bundled_program::VerifyResultWithBundledExpectedOutput
  * @returns Return Error::Ok if two outputs match, or the error happens during
  * execution.
  */
-__ET_NODISCARD Error VerifyResultWithBundledExpectedOutput(
+ET_NODISCARD Error VerifyResultWithBundledExpectedOutput(
     Method& method,
     serialized_bundled_program* bundled_program_ptr,
     size_t testset_idx,

--- a/examples/apple/coreml/executor_runner/main.mm
+++ b/examples/apple/coreml/executor_runner/main.mm
@@ -160,7 +160,7 @@ public:
     :data_(read_data(filePath))
     {}
 
-    Result<FreeableBuffer> load(size_t offset, size_t size, __ET_UNUSED const DataLoader::SegmentInfo& segment_info) const override {
+    Result<FreeableBuffer> load(size_t offset, size_t size, ET_UNUSED const DataLoader::SegmentInfo& segment_info) const override {
         NSData *subdata = [data_ subdataWithRange:NSMakeRange(offset, size)];
         return FreeableBuffer(subdata.bytes, size, nullptr);
     }

--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -52,7 +52,7 @@ unsigned char __attribute__((
 
 void et_pal_init(void) {}
 
-__ET_NORETURN void et_pal_abort(void) {
+ET_NORETURN void et_pal_abort(void) {
 #ifndef SEMIHOSTING
   __builtin_trap();
 #else
@@ -64,13 +64,13 @@ __ET_NORETURN void et_pal_abort(void) {
  * Emit a log message via platform output (serial port, console, etc).
  */
 void et_pal_emit_log_message(
-    __ET_UNUSED et_timestamp_t timestamp,
+    ET_UNUSED et_timestamp_t timestamp,
     et_pal_log_level_t level,
     const char* filename,
-    __ET_UNUSED const char* function,
+    ET_UNUSED const char* function,
     size_t line,
     const char* message,
-    __ET_UNUSED size_t length) {
+    ET_UNUSED size_t length) {
   fprintf(stderr, "%c executorch:%s:%zu] %s\n", level, filename, line, message);
 }
 

--- a/exir/backend/test/demos/rpc/ExecutorBackend.cpp
+++ b/exir/backend/test/demos/rpc/ExecutorBackend.cpp
@@ -47,7 +47,7 @@ class ExecutorBackend final : public PyTorchBackendInterface {
   Result<DelegateHandle*> init(
       BackendInitContext& context,
       FreeableBuffer* processed,
-      __ET_UNUSED ArrayRef<CompileSpec> compile_specs) const override {
+      ET_UNUSED ArrayRef<CompileSpec> compile_specs) const override {
     // `processed` contains an executorch program. Wrap it in a DataLoader that
     // will return the data directly without copying it.
     MemoryAllocator* runtime_allocator = context.get_runtime_allocator();
@@ -129,7 +129,7 @@ class ExecutorBackend final : public PyTorchBackendInterface {
   }
 
   Error execute(
-      __ET_UNUSED BackendExecutionContext& context,
+      ET_UNUSED BackendExecutionContext& context,
       DelegateHandle* handle,
       EValue** args) const override {
     Method* client_method = static_cast<Method*>(handle);

--- a/extension/apple/ExecuTorch/Exported/ExecuTorchLog.mm
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchLog.mm
@@ -116,10 +116,10 @@
 void et_pal_emit_log_message(et_timestamp_t timestamp,
                              et_pal_log_level_t level,
                              const char *__nonnull filename,
-                             __ET_UNUSED const char *function,
+                             ET_UNUSED const char *function,
                              size_t line,
                              const char *__nonnull message,
-                             __ET_UNUSED size_t length) {
+                             ET_UNUSED size_t length) {
 #if ET_LOG_ENABLED
   NSTimeInterval timeInterval = timestamp / 1000000000.0;
   NSUInteger totalSeconds = (NSUInteger)timeInterval;

--- a/extension/data_loader/buffer_data_loader.h
+++ b/extension/data_loader/buffer_data_loader.h
@@ -30,10 +30,10 @@ class BufferDataLoader final : public DataLoader {
   BufferDataLoader(const void* data, size_t size)
       : data_(reinterpret_cast<const uint8_t*>(data)), size_(size) {}
 
-  __ET_NODISCARD Result<FreeableBuffer> load(
+  ET_NODISCARD Result<FreeableBuffer> load(
       size_t offset,
       size_t size,
-      __ET_UNUSED const DataLoader::SegmentInfo& segment_info) const override {
+      ET_UNUSED const DataLoader::SegmentInfo& segment_info) const override {
     ET_CHECK_OR_RETURN_ERROR(
         offset + size <= size_,
         InvalidArgument,
@@ -44,14 +44,14 @@ class BufferDataLoader final : public DataLoader {
     return FreeableBuffer(data_ + offset, size, /*free_fn=*/nullptr);
   }
 
-  __ET_NODISCARD Result<size_t> size() const override {
+  ET_NODISCARD Result<size_t> size() const override {
     return size_;
   }
 
-  __ET_NODISCARD Error load_into(
+  ET_NODISCARD Error load_into(
       size_t offset,
       size_t size,
-      __ET_UNUSED const SegmentInfo& segment_info,
+      ET_UNUSED const SegmentInfo& segment_info,
       void* buffer) const override {
     ET_CHECK_OR_RETURN_ERROR(
         buffer != nullptr,

--- a/extension/data_loader/file_data_loader.cpp
+++ b/extension/data_loader/file_data_loader.cpp
@@ -112,7 +112,7 @@ namespace {
  * `context` is actually a ptrdiff_t value (not a pointer) that contains the
  * offset in bytes between `data` and the actual pointer to free.
  */
-void FreeSegment(void* context, void* data, __ET_UNUSED size_t size) {
+void FreeSegment(void* context, void* data, ET_UNUSED size_t size) {
   ptrdiff_t offset = reinterpret_cast<ptrdiff_t>(context);
   ET_DCHECK_MSG(offset >= 0, "Unexpected offset %ld", (long int)offset);
   std::free(static_cast<uint8_t*>(data) - offset);
@@ -122,7 +122,7 @@ void FreeSegment(void* context, void* data, __ET_UNUSED size_t size) {
 Result<FreeableBuffer> FileDataLoader::load(
     size_t offset,
     size_t size,
-    __ET_UNUSED const DataLoader::SegmentInfo& segment_info) const {
+    ET_UNUSED const DataLoader::SegmentInfo& segment_info) const {
   ET_CHECK_OR_RETURN_ERROR(
       // Probably had its value moved to another instance.
       fd_ >= 0,
@@ -205,10 +205,10 @@ Result<size_t> FileDataLoader::size() const {
   return file_size_;
 }
 
-__ET_NODISCARD Error FileDataLoader::load_into(
+ET_NODISCARD Error FileDataLoader::load_into(
     size_t offset,
     size_t size,
-    __ET_UNUSED const SegmentInfo& segment_info,
+    ET_UNUSED const SegmentInfo& segment_info,
     void* buffer) const {
   ET_CHECK_OR_RETURN_ERROR(
       // Probably had its value moved to another instance.

--- a/extension/data_loader/file_data_loader.h
+++ b/extension/data_loader/file_data_loader.h
@@ -45,7 +45,7 @@ class FileDataLoader final : public DataLoader {
       size_t alignment = alignof(std::max_align_t));
 
   /// DEPRECATED: Use the lowercase `from()` instead.
-  __ET_DEPRECATED static Result<FileDataLoader> From(
+  ET_DEPRECATED static Result<FileDataLoader> From(
       const char* file_name,
       size_t alignment = alignof(std::max_align_t)) {
     return from(file_name, alignment);
@@ -65,17 +65,17 @@ class FileDataLoader final : public DataLoader {
 
   ~FileDataLoader() override;
 
-  __ET_NODISCARD Result<FreeableBuffer> load(
+  ET_NODISCARD Result<FreeableBuffer> load(
       size_t offset,
       size_t size,
       const DataLoader::SegmentInfo& segment_info) const override;
 
-  __ET_NODISCARD Result<size_t> size() const override;
+  ET_NODISCARD Result<size_t> size() const override;
 
-  __ET_NODISCARD Error load_into(
+  ET_NODISCARD Error load_into(
       size_t offset,
       size_t size,
-      __ET_UNUSED const SegmentInfo& segment_info,
+      ET_UNUSED const SegmentInfo& segment_info,
       void* buffer) const override;
 
  private:

--- a/extension/data_loader/mmap_data_loader.cpp
+++ b/extension/data_loader/mmap_data_loader.cpp
@@ -149,7 +149,7 @@ void MunmapSegment(void* context, void* data, size_t size) {
 Result<FreeableBuffer> MmapDataLoader::load(
     size_t offset,
     size_t size,
-    __ET_UNUSED const DataLoader::SegmentInfo& segment_info) const {
+    ET_UNUSED const DataLoader::SegmentInfo& segment_info) const {
   ET_CHECK_OR_RETURN_ERROR(
       // Probably had its value moved to another instance.
       fd_ >= 0,

--- a/extension/data_loader/mmap_data_loader.h
+++ b/extension/data_loader/mmap_data_loader.h
@@ -56,14 +56,14 @@ class MmapDataLoader final : public DataLoader {
       MlockConfig mlock_config = MlockConfig::UseMlock);
 
   /// DEPRECATED: Use the lowercase `from()` instead.
-  __ET_DEPRECATED static Result<MmapDataLoader> From(
+  ET_DEPRECATED static Result<MmapDataLoader> From(
       const char* file_name,
       MlockConfig mlock_config = MlockConfig::UseMlock) {
     return from(file_name, mlock_config);
   }
 
   /// DEPRECATED: Use the version of `from()` that takes an MlockConfig.
-  __ET_DEPRECATED
+  ET_DEPRECATED
   static Result<MmapDataLoader> From(const char* file_name, bool use_mlock) {
     MlockConfig mlock_config =
         use_mlock ? MlockConfig::UseMlock : MlockConfig::NoMlock;
@@ -86,12 +86,12 @@ class MmapDataLoader final : public DataLoader {
 
   ~MmapDataLoader() override;
 
-  __ET_NODISCARD Result<FreeableBuffer> load(
+  ET_NODISCARD Result<FreeableBuffer> load(
       size_t offset,
       size_t size,
       const DataLoader::SegmentInfo& segment_info) const override;
 
-  __ET_NODISCARD Result<size_t> size() const override;
+  ET_NODISCARD Result<size_t> size() const override;
 
  private:
   MmapDataLoader(

--- a/extension/data_loader/shared_ptr_data_loader.h
+++ b/extension/data_loader/shared_ptr_data_loader.h
@@ -29,10 +29,10 @@ class SharedPtrDataLoader final : public DataLoader {
   SharedPtrDataLoader(std::shared_ptr<void> data, size_t size)
       : data_(data), size_(size) {}
 
-  __ET_NODISCARD Result<FreeableBuffer> load(
+  ET_NODISCARD Result<FreeableBuffer> load(
       size_t offset,
       size_t size,
-      __ET_UNUSED const DataLoader::SegmentInfo& segment_info) const override {
+      ET_UNUSED const DataLoader::SegmentInfo& segment_info) const override {
     ET_CHECK_OR_RETURN_ERROR(
         offset + size <= size_,
         InvalidArgument,
@@ -44,7 +44,7 @@ class SharedPtrDataLoader final : public DataLoader {
         static_cast<uint8_t*>(data_.get()) + offset, size, /*free_fn=*/nullptr);
   }
 
-  __ET_NODISCARD Result<size_t> size() const override {
+  ET_NODISCARD Result<size_t> size() const override {
     return size_;
   }
 

--- a/extension/module/module.h
+++ b/extension/module/module.h
@@ -93,7 +93,7 @@ class Module final {
    *
    * @returns An Error to indicate success or failure of the loading process.
    */
-  __ET_NODISCARD
+  ET_NODISCARD
   Error load(
       const Program::Verification verification =
           Program::Verification::Minimal);
@@ -132,7 +132,7 @@ class Module final {
    *
    * @returns An Error to indicate success or failure.
    */
-  __ET_NODISCARD
+  ET_NODISCARD
   Error load_method(const std::string& method_name);
 
   /**
@@ -166,7 +166,7 @@ class Module final {
    * @returns A Result object containing either a vector of output values
    *          from the method or an error to indicate failure.
    */
-  __ET_NODISCARD
+  ET_NODISCARD
   Result<std::vector<EValue>> execute(
       const std::string& method_name,
       const std::vector<EValue>& input);
@@ -180,7 +180,7 @@ class Module final {
    * @returns A Result object containing either a vector of output values
    *          from the method or an error to indicate failure.
    */
-  __ET_NODISCARD
+  ET_NODISCARD
   Result<std::vector<EValue>> execute(const std::string& method_name) {
     return execute(method_name, {});
   }
@@ -195,7 +195,7 @@ class Module final {
    * @returns A Result object containing either the first output value from the
    * method or an error to indicate failure.
    */
-  __ET_NODISCARD
+  ET_NODISCARD
   Result<EValue> get(
       const std::string& method_name,
       const std::vector<EValue>& input) {
@@ -215,7 +215,7 @@ class Module final {
    * @returns A Result object containing either the first output value from the
    * method or an error to indicate failure.
    */
-  __ET_NODISCARD
+  ET_NODISCARD
   Result<EValue> get(const std::string& method_name) {
     return get(method_name, {});
   }
@@ -229,7 +229,7 @@ class Module final {
    * @returns A Result object containing either a vector of output values
    *          from the 'forward' method or an error to indicate failure.
    */
-  __ET_NODISCARD
+  ET_NODISCARD
   Result<std::vector<EValue>> forward(const std::vector<EValue>& input) {
     return execute("forward", input);
   }
@@ -241,7 +241,7 @@ class Module final {
    * @returns A Result object containing either a vector of output values
    *          from the 'forward' method or an error to indicate failure.
    */
-  __ET_NODISCARD
+  ET_NODISCARD
   Result<std::vector<EValue>> forward() {
     return forward({});
   }

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -64,10 +64,10 @@ void et_pal_emit_log_message(
     et_timestamp_t timestamp,
     et_pal_log_level_t level,
     const char* filename,
-    __ET_UNUSED const char* function,
+    ET_UNUSED const char* function,
     size_t line,
     const char* message,
-    __ET_UNUSED size_t length) {
+    ET_UNUSED size_t length) {
   std::cerr << "[" << filename << ":" << line << "] " << message << std::endl;
 }
 

--- a/kernels/optimized/cpu/moments_utils.h
+++ b/kernels/optimized/cpu/moments_utils.h
@@ -45,7 +45,7 @@ void AddMoments(
 }
 
 template <typename T>
-__ET_INLINE void AddMomentsVec(
+ET_INLINE void AddMomentsVec(
     int64_t m0_add,
     const executorch::vec::Vectorized<T>& m1_add,
     const executorch::vec::Vectorized<T>& m2_add,

--- a/kernels/optimized/lib_defs.bzl
+++ b/kernels/optimized/lib_defs.bzl
@@ -94,7 +94,7 @@ def define_libs():
             "@EXECUTORCH_CLIENTS",
         ],
         exported_deps = [
-            # Needed to access the __ET_INLINE macro
+            # Needed to access the ET_INLINE macro
             "//executorch/runtime/platform:compiler",
         ],
     )

--- a/kernels/optimized/utils/unroll.h
+++ b/kernels/optimized/utils/unroll.h
@@ -22,7 +22,7 @@ namespace utils {
 template <int n>
 struct ForcedUnroll {
   template <typename Func>
-  __ET_INLINE void operator()(const Func& f) const {
+  ET_INLINE void operator()(const Func& f) const {
     ForcedUnroll<n - 1>{}(f);
     f(n - 1);
   }
@@ -31,7 +31,7 @@ struct ForcedUnroll {
 template <>
 struct ForcedUnroll<1> {
   template <typename Func>
-  __ET_INLINE void operator()(const Func& f) const {
+  ET_INLINE void operator()(const Func& f) const {
     f(0);
   }
 };

--- a/kernels/portable/cpu/op_allclose.cpp
+++ b/kernels/portable/cpu/op_allclose.cpp
@@ -96,8 +96,8 @@ Tensor& allclose_out(
     const Tensor& other,
     double rtol,
     double atol,
-    __ET_UNUSED bool equal_nan,
-    __ET_UNUSED bool dummy_param,
+    ET_UNUSED bool equal_nan,
+    ET_UNUSED bool dummy_param,
     Tensor& out) {
   ET_CHECK_SAME_SHAPE_AND_DTYPE2(self, other);
   ET_CHECK_MSG(
@@ -126,12 +126,12 @@ Tensor& allclose_out(
  * ExecuTorch runtime.
  */
 Tensor allclose_tensor(
-    __ET_UNUSED const Tensor& self,
-    __ET_UNUSED const Tensor& other,
-    __ET_UNUSED double rtol,
-    __ET_UNUSED double atol,
-    __ET_UNUSED bool equal_nan,
-    __ET_UNUSED bool dummy_param) {
+    ET_UNUSED const Tensor& self,
+    ET_UNUSED const Tensor& other,
+    ET_UNUSED double rtol,
+    ET_UNUSED double atol,
+    ET_UNUSED bool equal_nan,
+    ET_UNUSED bool dummy_param) {
 #ifdef USE_ATEN_LIB
   Tensor out =
       torch::tensor({false}, c10::TensorOptions(c10::ScalarType::Bool));
@@ -148,8 +148,8 @@ Tensor& allclose_out(
     const Tensor& other,
     double rtol,
     double atol,
-    __ET_UNUSED bool equal_nan,
-    __ET_UNUSED bool dummy_param,
+    ET_UNUSED bool equal_nan,
+    ET_UNUSED bool dummy_param,
     Tensor& out) {
   (void)ctx;
   // TODO(larryliu): Add a context arg to the real op function and remove this
@@ -158,13 +158,13 @@ Tensor& allclose_out(
 }
 
 Tensor allclose_tensor(
-    __ET_UNUSED RuntimeContext& ctx,
-    __ET_UNUSED const Tensor& self,
-    __ET_UNUSED const Tensor& other,
-    __ET_UNUSED double rtol,
-    __ET_UNUSED double atol,
-    __ET_UNUSED bool equal_nan,
-    __ET_UNUSED bool dummy_param) {
+    ET_UNUSED RuntimeContext& ctx,
+    ET_UNUSED const Tensor& self,
+    ET_UNUSED const Tensor& other,
+    ET_UNUSED double rtol,
+    ET_UNUSED double atol,
+    ET_UNUSED bool equal_nan,
+    ET_UNUSED bool dummy_param) {
   // TODO(larryliu): Add a context arg to the real op function and remove this
   // wrapper
   ET_ASSERT_UNREACHABLE();

--- a/kernels/portable/cpu/op_clamp.cpp
+++ b/kernels/portable/cpu/op_clamp.cpp
@@ -35,7 +35,7 @@ bool is_out_of_bounds(CTYPE_VAL val) {
       val_cast > std::numeric_limits<CTYPE_OUT>::max();
 }
 
-__ET_NODISCARD bool check_bounds(
+ET_NODISCARD bool check_bounds(
     const Scalar& val_scalar,
     const torch::executor::native::ScalarType& val_type,
     const torch::executor::native::ScalarType& out_type,

--- a/kernels/portable/cpu/util/broadcast_util.cpp
+++ b/kernels/portable/cpu/util/broadcast_util.cpp
@@ -207,7 +207,7 @@ Tensor broadcast_tensor(
   return out;
 }
 
-__ET_NODISCARD Error get_broadcast_target_size(
+ET_NODISCARD Error get_broadcast_target_size(
     const exec_aten::ArrayRef<Tensor::SizesType> a_size,
     const exec_aten::ArrayRef<Tensor::SizesType> b_size,
     Tensor::SizesType* out_sizes,
@@ -248,7 +248,7 @@ __ET_NODISCARD Error get_broadcast_target_size(
   return Error::Ok;
 }
 
-__ET_NODISCARD Error get_broadcast_target_size(
+ET_NODISCARD Error get_broadcast_target_size(
     const Tensor& a,
     const Tensor& b,
     Tensor::SizesType* out_sizes,

--- a/kernels/portable/cpu/util/broadcast_util.h
+++ b/kernels/portable/cpu/util/broadcast_util.h
@@ -77,7 +77,7 @@ bool tensors_are_broadcastable_between(const Tensor& a, const Tensor& b);
  * repeated as appropriate. This tensor contains dynamically allocated memory
  * and must be freed using free_broadcast_tensor.
  */
-__ET_DEPRECATED exec_aten::Tensor broadcast_tensor(
+ET_DEPRECATED exec_aten::Tensor broadcast_tensor(
     const exec_aten::Tensor& broadcast_from,
     const exec_aten::Tensor& broadcast_to);
 
@@ -97,7 +97,7 @@ __ET_DEPRECATED exec_aten::Tensor broadcast_tensor(
  * @param[out] out_dim The dimension of the broadcasted target
  * tensor
  */
-__ET_NODISCARD Error get_broadcast_target_size(
+ET_NODISCARD Error get_broadcast_target_size(
     const exec_aten::ArrayRef<Tensor::SizesType> a_size,
     const exec_aten::ArrayRef<Tensor::SizesType> b_size,
     Tensor::SizesType* out_sizes,
@@ -115,7 +115,7 @@ __ET_NODISCARD Error get_broadcast_target_size(
  * @param[out] out_dim The dimension of the broadcasted target
  * tensor
  */
-__ET_NODISCARD Error get_broadcast_target_size(
+ET_NODISCARD Error get_broadcast_target_size(
     const Tensor& a,
     const Tensor& b,
     Tensor::SizesType* out_sizes,
@@ -130,7 +130,7 @@ __ET_NODISCARD Error get_broadcast_target_size(
  * @param[in] b The second tensor going to be broadcasted.
  * @param[out] out The output tensor that will be resized.
  */
-__ET_NODISCARD inline Error
+ET_NODISCARD inline Error
 resize_to_broadcast_target_size(const Tensor& a, const Tensor& b, Tensor& out) {
   Tensor::SizesType expected_output_size[kTensorDimensionLimit];
   size_t expected_output_dim = 0;
@@ -156,7 +156,7 @@ resize_to_broadcast_target_size(const Tensor& a, const Tensor& b, Tensor& out) {
  * @param[in] c The third tensor going to be broadcasted.
  * @param[out] out The output tensor that will be resized.
  */
-__ET_NODISCARD inline Error resize_to_broadcast_target_size(
+ET_NODISCARD inline Error resize_to_broadcast_target_size(
     const Tensor& a,
     const Tensor& b,
     const Tensor& c,
@@ -202,7 +202,7 @@ __ET_NODISCARD inline Error resize_to_broadcast_target_size(
  * broadcast_tensor.
  * @returns void
  */
-__ET_DEPRECATED void free_broadcast_tensor(
+ET_DEPRECATED void free_broadcast_tensor(
     const exec_aten::Tensor& broadcast_tensor);
 
 /**

--- a/kernels/portable/cpu/util/reduce_util.cpp
+++ b/kernels/portable/cpu/util/reduce_util.cpp
@@ -32,7 +32,7 @@ inline size_t _normalize_non_neg_d(ssize_t d, ssize_t in_dim) {
   return d;
 }
 
-__ET_NODISCARD bool check_dim_list_is_valid(
+ET_NODISCARD bool check_dim_list_is_valid(
     const exec_aten::Tensor& in,
     const exec_aten::optional<exec_aten::ArrayRef<int64_t>>& dim_list) {
   if (dim_list.has_value() && dim_list.value().size() != 0) {

--- a/kernels/portable/cpu/util/reduce_util.h
+++ b/kernels/portable/cpu/util/reduce_util.h
@@ -144,7 +144,7 @@ void apply_on_flat_ix_with_dim_mask_and_base(
 // Helper Functions
 //
 
-__ET_NODISCARD bool check_dim_list_is_valid(
+ET_NODISCARD bool check_dim_list_is_valid(
     const exec_aten::Tensor& in,
     const exec_aten::optional<exec_aten::ArrayRef<int64_t>>& dim_list);
 

--- a/kernels/quantized/cpu/op_choose_qparams.cpp
+++ b/kernels/quantized/cpu/op_choose_qparams.cpp
@@ -153,7 +153,7 @@ std::tuple<Tensor&, Tensor&> choose_qparams_tensor_out(
     const Tensor& input,
     int64_t quant_min,
     int64_t quant_max,
-    __ET_UNUSED double eps,
+    ET_UNUSED double eps,
     ScalarType dtype,
     Tensor& scale_out,
     Tensor& zero_point_out) {

--- a/runtime/backend/interface.h
+++ b/runtime/backend/interface.h
@@ -46,7 +46,7 @@ class PyTorchBackendInterface {
   /**
    * Returns true if the backend is available to process delegation calls.
    */
-  __ET_NODISCARD virtual bool is_available() const = 0;
+  ET_NODISCARD virtual bool is_available() const = 0;
 
   /**
    * Responsible to further process (compile/transform/optimize) the compiled
@@ -78,7 +78,7 @@ class PyTorchBackendInterface {
    *     Error::DelegateInvalidCompatibility. Other backend delegate
    *     specific error codes can be found in error.h.
    */
-  __ET_NODISCARD virtual Result<DelegateHandle*> init(
+  ET_NODISCARD virtual Result<DelegateHandle*> init(
       BackendInitContext& context,
       FreeableBuffer* processed,
       ArrayRef<CompileSpec> compile_specs) const = 0;
@@ -93,7 +93,7 @@ class PyTorchBackendInterface {
    * @param[in] args The method’s inputs and outputs.
    * @retval Error::Ok if successful.
    */
-  __ET_NODISCARD virtual Error execute(
+  ET_NODISCARD virtual Error execute(
       BackendExecutionContext& context,
       DelegateHandle* handle,
       EValue** args) const = 0;
@@ -107,7 +107,7 @@ class PyTorchBackendInterface {
    * @param[in] handle The handle to be destroyed. An opaque handle returned by
    *     `init()`.
    */
-  virtual void destroy(__ET_UNUSED DelegateHandle* handle) const {}
+  virtual void destroy(ET_UNUSED DelegateHandle* handle) const {}
 };
 
 struct Backend {
@@ -132,7 +132,7 @@ class BackendRegistry {
    * @param[in] backend Backend object of the user-defined backend delegate.
    * @retval Error code representing whether registration was successful.
    */
-  __ET_NODISCARD Error register_backend(const Backend& backend);
+  ET_NODISCARD Error register_backend(const Backend& backend);
 
   /**
    * Returns the corresponding object pointer for a given string name.
@@ -168,7 +168,7 @@ PyTorchBackendInterface* get_backend_class(const char* name);
  * @param[in] backend Backend object
  * @retval Error code representing whether registration was successful.
  */
-__ET_NODISCARD Error register_backend(const Backend& backend);
+ET_NODISCARD Error register_backend(const Backend& backend);
 
 } // namespace executor
 } // namespace torch

--- a/runtime/core/data_loader.h
+++ b/runtime/core/data_loader.h
@@ -87,7 +87,7 @@ class DataLoader {
    *
    * @returns a `FreeableBuffer` that owns the loaded data.
    */
-  __ET_NODISCARD virtual Result<FreeableBuffer>
+  ET_NODISCARD virtual Result<FreeableBuffer>
   load(size_t offset, size_t size, const SegmentInfo& segment_info) const = 0;
 
   /**
@@ -104,7 +104,7 @@ class DataLoader {
    *
    * @returns an Error indicating if the load was successful.
    */
-  __ET_NODISCARD virtual Error load_into(
+  ET_NODISCARD virtual Error load_into(
       size_t offset,
       size_t size,
       const SegmentInfo& segment_info,
@@ -122,7 +122,7 @@ class DataLoader {
   /**
    * Returns the length of the underlying data source, typically the file size.
    */
-  __ET_NODISCARD virtual Result<size_t> size() const = 0;
+  ET_NODISCARD virtual Result<size_t> size() const = 0;
 };
 
 } // namespace runtime

--- a/runtime/core/exec_aten/testing_util/tensor_factory.h
+++ b/runtime/core/exec_aten/testing_util/tensor_factory.h
@@ -259,7 +259,7 @@ class TensorFactory {
       const std::vector<int32_t>& sizes,
       const std::vector<ctype>& data,
       const std::vector<int32_t> strides = {},
-      __ET_UNUSED TensorShapeDynamism dynamism =
+      ET_UNUSED TensorShapeDynamism dynamism =
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     auto expected_numel = internal::sizes_to_numel(sizes);
     ET_CHECK_MSG(
@@ -301,7 +301,7 @@ class TensorFactory {
       const std::vector<int32_t>& sizes,
       const std::vector<ctype>& data,
       const std::vector<uint8_t> dim_order = {},
-      __ET_UNUSED TensorShapeDynamism dynamism =
+      ET_UNUSED TensorShapeDynamism dynamism =
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     auto expected_numel = internal::sizes_to_numel(sizes);
     ET_CHECK_MSG(
@@ -338,7 +338,7 @@ class TensorFactory {
   at::Tensor make_channels_last(
       const std::vector<int32_t>& sizes,
       const std::vector<ctype>& data,
-      __ET_UNUSED TensorShapeDynamism dynamism =
+      ET_UNUSED TensorShapeDynamism dynamism =
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     return make_with_dimorder(
         sizes, data, internal::channels_last_dim_order(sizes.size()), dynamism);
@@ -355,7 +355,7 @@ class TensorFactory {
   at::Tensor full(
       const std::vector<int32_t>& sizes,
       ctype value,
-      __ET_UNUSED TensorShapeDynamism dynamism =
+      ET_UNUSED TensorShapeDynamism dynamism =
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     auto sizes64 = vec_32_to_64(sizes);
     return at::full(at::IntArrayRef(sizes64), value, at::dtype(DTYPE));
@@ -372,7 +372,7 @@ class TensorFactory {
   at::Tensor full_channels_last(
       const std::vector<int32_t>& sizes,
       ctype value,
-      __ET_UNUSED TensorShapeDynamism dynamism =
+      ET_UNUSED TensorShapeDynamism dynamism =
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     auto sizes64 = vec_32_to_64(sizes);
     return at::full(at::IntArrayRef(sizes64), value, at::dtype(DTYPE))
@@ -388,7 +388,7 @@ class TensorFactory {
    */
   at::Tensor zeros(
       const std::vector<int32_t>& sizes,
-      __ET_UNUSED TensorShapeDynamism dynamism =
+      ET_UNUSED TensorShapeDynamism dynamism =
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     auto sizes64 = vec_32_to_64(sizes);
     return at::zeros(at::IntArrayRef(sizes64), at::dtype(DTYPE));
@@ -403,7 +403,7 @@ class TensorFactory {
    */
   at::Tensor ones(
       const std::vector<int32_t>& sizes,
-      __ET_UNUSED TensorShapeDynamism dynamism =
+      ET_UNUSED TensorShapeDynamism dynamism =
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     auto sizes64 = vec_32_to_64(sizes);
     return at::ones(at::IntArrayRef(sizes64), at::dtype(DTYPE));
@@ -418,7 +418,7 @@ class TensorFactory {
    */
   at::Tensor zeros_like(
       const Tensor& input,
-      __ET_UNUSED TensorShapeDynamism dynamism =
+      ET_UNUSED TensorShapeDynamism dynamism =
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     std::vector<int64_t> sizes64 = {input.sizes().begin(), input.sizes().end()};
     return at::full(at::IntArrayRef(sizes64), 0, at::dtype(DTYPE));
@@ -433,7 +433,7 @@ class TensorFactory {
    */
   at::Tensor ones_like(
       const Tensor& input,
-      __ET_UNUSED TensorShapeDynamism dynamism =
+      ET_UNUSED TensorShapeDynamism dynamism =
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     std::vector<int64_t> sizes64 = {input.sizes().begin(), input.sizes().end()};
     return at::full(at::IntArrayRef(sizes64), 1, at::dtype(DTYPE));
@@ -460,7 +460,7 @@ class TensorFactory {
   at::Tensor empty_strided(
       const std::vector<int32_t>& sizes,
       const std::vector<int32_t>& strides,
-      __ET_UNUSED TensorShapeDynamism dynamism =
+      ET_UNUSED TensorShapeDynamism dynamism =
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     auto sizes64 = vec_32_to_64(sizes);
     auto strides64 = vec_32_to_64(strides);

--- a/runtime/core/exec_aten/util/dim_order_util.h
+++ b/runtime/core/exec_aten/util/dim_order_util.h
@@ -133,7 +133,7 @@ inline void dim_order_to_stride_nocheck(
 }
 
 template <typename SizesType, typename DimOrderType, typename StridesType>
-__ET_NODISCARD inline Error dim_order_to_stride(
+ET_NODISCARD inline Error dim_order_to_stride(
     const SizesType* sizes,
     const DimOrderType* dim_order,
     const size_t dims,
@@ -221,7 +221,7 @@ struct Sorter {
  * TODO(T148342910)
  */
 template <typename DimOrderType, typename StridesType>
-__ET_NODISCARD inline Error stride_to_dim_order(
+ET_NODISCARD inline Error stride_to_dim_order(
     const StridesType* strides,
     const size_t dims,
     DimOrderType* dim_order) {

--- a/runtime/core/exec_aten/util/tensor_util.h
+++ b/runtime/core/exec_aten/util/tensor_util.h
@@ -1040,21 +1040,21 @@ namespace internal {
 /**
  * Share t_src's data_ptr with t_dst.
  */
-__ET_NODISCARD Error share_tensor_data(
+ET_NODISCARD Error share_tensor_data(
     const exec_aten::Tensor& t_dst,
     const exec_aten::Tensor& t_src);
 
 /**
  * Copy t_src's data_ptr to t_dst.
  */
-__ET_NODISCARD Error copy_tensor_data(
+ET_NODISCARD Error copy_tensor_data(
     const exec_aten::Tensor& t_dst,
     const exec_aten::Tensor& t_src);
 
 /**
  * Set the data_ptr of t to buffer.
  */
-__ET_NODISCARD Error
+ET_NODISCARD Error
 set_tensor_data(const exec_aten::Tensor& t, void* buffer, size_t buffer_size);
 
 /**
@@ -1065,7 +1065,7 @@ void reset_data_ptr(const exec_aten::Tensor& tensor);
 /**
  * Resize tensor impl
  */
-__ET_NODISCARD Error resize_tensor_impl(
+ET_NODISCARD Error resize_tensor_impl(
     exec_aten::TensorImpl* impl,
     exec_aten::ArrayRef<exec_aten::SizesType> new_sizes);
 
@@ -1080,7 +1080,7 @@ __ET_NODISCARD Error resize_tensor_impl(
  * will likely move to be a class method on a TensorResizer object passed in
  * through runtimeContext.
  */
-__ET_NODISCARD inline Error resize_tensor(
+ET_NODISCARD inline Error resize_tensor(
     exec_aten::Tensor t,
     exec_aten::ArrayRef<exec_aten::SizesType> new_sizes) {
   return internal::resize_tensor_impl(t.unsafeGetTensorImpl(), new_sizes);
@@ -1099,7 +1099,7 @@ template <
     typename T,
     typename std::
         enable_if<!std::is_same<exec_aten::SizesType, T>::value, int>::type = 0>
-__ET_NODISCARD inline Error resize_tensor(
+ET_NODISCARD inline Error resize_tensor(
     exec_aten::Tensor t,
     exec_aten::ArrayRef<T> new_sizes) {
   // Need to cast the input array to an array of Tensor::SizesType
@@ -1114,7 +1114,7 @@ __ET_NODISCARD inline Error resize_tensor(
 }
 
 /// DEPRECATED: Use `resize_tensor()` instead, which can fail non-fatally.
-__ET_DEPRECATED inline void resize(
+ET_DEPRECATED inline void resize(
     exec_aten::Tensor t,
     exec_aten::ArrayRef<exec_aten::SizesType> new_sizes) {
   Error err = resize_tensor(t, new_sizes);
@@ -1128,7 +1128,7 @@ __ET_DEPRECATED inline void resize(
  * order into it.
  * @param out_dim_order_size Size of the DimOrderType array.
  */
-__ET_NODISCARD Error get_dim_order(
+ET_NODISCARD Error get_dim_order(
     const exec_aten::Tensor& tensor,
     exec_aten::DimOrderType* out_dim_order,
     size_t out_dim_order_size);

--- a/runtime/core/exec_aten/util/tensor_util_aten.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_aten.cpp
@@ -133,7 +133,7 @@ Error copy_tensor_data(const at::Tensor& t_dst, const at::Tensor& t_src) {
   return Error::Ok;
 }
 
-__ET_NODISCARD Error
+ET_NODISCARD Error
 set_tensor_data(const at::Tensor& t, void* buffer, size_t buffer_size) {
   ET_CHECK_OR_RETURN_ERROR(
       buffer_size >= t.nbytes(),

--- a/runtime/core/exec_aten/util/tensor_util_portable.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_portable.cpp
@@ -116,7 +116,7 @@ Error copy_tensor_data(
   return Error::Ok;
 }
 
-__ET_NODISCARD Error set_tensor_data(
+ET_NODISCARD Error set_tensor_data(
     const torch::executor::Tensor& t,
     void* buffer,
     size_t buffer_size) {
@@ -137,7 +137,7 @@ void reset_data_ptr(const torch::executor::Tensor& tensor) {
 
 class TensorResizerFriend final {
  public:
-  __ET_NODISCARD static Error resize_tensor_impl(
+  ET_NODISCARD static Error resize_tensor_impl(
       exec_aten::TensorImpl* impl,
       exec_aten::ArrayRef<exec_aten::SizesType> new_sizes) {
     return impl->internal_resize_contiguous(new_sizes);

--- a/runtime/core/hierarchical_allocator.h
+++ b/runtime/core/hierarchical_allocator.h
@@ -38,7 +38,7 @@ class HierarchicalAllocator final {
   /**
    * DEPRECATED: Use spans instead.
    */
-  __ET_DEPRECATED HierarchicalAllocator(
+  ET_DEPRECATED HierarchicalAllocator(
       uint32_t n_allocators,
       MemoryAllocator* allocators)
       : buffers_(to_spans(n_allocators, allocators)) {}
@@ -55,7 +55,7 @@ class HierarchicalAllocator final {
    * @returns On success, the address of the requested byte offset into the
    *     specified buffer. On failure, a non-Ok Error.
    */
-  __ET_NODISCARD Result<void*> get_offset_address(
+  ET_NODISCARD Result<void*> get_offset_address(
       uint32_t memory_id,
       size_t offset_bytes,
       size_t size_bytes) {

--- a/runtime/core/memory_allocator.h
+++ b/runtime/core/memory_allocator.h
@@ -156,7 +156,7 @@ class MemoryAllocator {
     cur_ = begin_;
   }
 
-  void enable_profiling(__ET_UNUSED const char* name) {
+  void enable_profiling(ET_UNUSED const char* name) {
     prof_id_ = EXECUTORCH_TRACK_ALLOCATOR(name);
   }
 
@@ -198,7 +198,7 @@ class MemoryAllocator {
   int32_t prof_id_ = -1;
 };
 
-#if __ET_HAVE_GNU_STATEMENT_EXPRESSIONS
+#if ET_HAVE_GNU_STATEMENT_EXPRESSIONS
 /**
  * Tries allocating from the specified MemoryAllocator*.
  *
@@ -220,7 +220,7 @@ class MemoryAllocator {
     if (et_try_allocate_result == nullptr && nbytes__ > 0) {               \
       __VA_ARGS__                                                          \
       /* The args must return. */                                          \
-      __ET_UNREACHABLE();                                                  \
+      ET_UNREACHABLE();                                                    \
     }                                                                      \
     et_try_allocate_result;                                                \
   })
@@ -247,7 +247,7 @@ class MemoryAllocator {
     if (et_try_allocate_result == nullptr) {                         \
       __VA_ARGS__                                                    \
       /* The args must return. */                                    \
-      __ET_UNREACHABLE();                                            \
+      ET_UNREACHABLE();                                              \
     }                                                                \
     et_try_allocate_result;                                          \
   })
@@ -275,11 +275,11 @@ class MemoryAllocator {
     if (et_try_allocate_result == nullptr && nelem__ > 0) {               \
       __VA_ARGS__                                                         \
       /* The args must return. */                                         \
-      __ET_UNREACHABLE();                                                 \
+      ET_UNREACHABLE();                                                   \
     }                                                                     \
     et_try_allocate_result;                                               \
   })
-#else // !__ET_HAVE_GNU_STATEMENT_EXPRESSIONS
+#else // !ET_HAVE_GNU_STATEMENT_EXPRESSIONS
 /**
  * The recommended alternative for statement expression-incompatible compilers
  * is to directly allocate the memory.
@@ -312,7 +312,7 @@ class MemoryAllocator {
       false,                                                              \
       "ET_TRY_ALLOCATE_LIST_OR uses statement \
     expressions and thus is not available for use with this compiler.");
-#endif // !__ET_HAVE_GNU_STATEMENT_EXPRESSIONS
+#endif // !ET_HAVE_GNU_STATEMENT_EXPRESSIONS
 
 /**
  * Tries allocating from the specified MemoryAllocator*.

--- a/runtime/core/portable_type/tensor.h
+++ b/runtime/core/portable_type/tensor.h
@@ -130,12 +130,12 @@ class Tensor {
 
   /// DEPRECATED: Use const_data_ptr or mutable_data_ptr instead.
   template <typename T>
-  __ET_DEPRECATED inline T* data_ptr() const {
+  ET_DEPRECATED inline T* data_ptr() const {
     return impl_->mutable_data<T>();
   }
 
   /// DEPRECATED: Use const_data_ptr or mutable_data_ptr instead.
-  __ET_DEPRECATED inline void* data_ptr() const {
+  ET_DEPRECATED inline void* data_ptr() const {
     return impl_->mutable_data();
   }
 
@@ -145,7 +145,7 @@ class Tensor {
    * ptr. This api does not exist in at::Tensor so kernel developers should
    * avoid it.
    */
-  __ET_DEPRECATED void set_data(void* ptr) const {
+  ET_DEPRECATED void set_data(void* ptr) const {
     impl_->set_data(ptr);
   }
 

--- a/runtime/core/portable_type/tensor_impl.h
+++ b/runtime/core/portable_type/tensor_impl.h
@@ -195,7 +195,7 @@ class TensorImpl {
    * DEPRECATED: Use torch::executor::resize_tensor() or
    * torch::executor::resize_tensor_impl().
    */
-  __ET_DEPRECATED
+  ET_DEPRECATED
   void set_sizes_contiguous(ArrayRef<SizesType> new_sizes) {
     Error err = internal_resize_contiguous(new_sizes);
     ET_CHECK_MSG(
@@ -217,8 +217,7 @@ class TensorImpl {
    * error instead of panicking on failure. This is not part of the at::Tensor
    * API, and can only be used in lean mode.
    */
-  __ET_NODISCARD Error
-  internal_resize_contiguous(ArrayRef<SizesType> new_sizes);
+  ET_NODISCARD Error internal_resize_contiguous(ArrayRef<SizesType> new_sizes);
 
  private:
   // Keep fields arranged to avoid unnecessary alignment holes.

--- a/runtime/core/result.h
+++ b/runtime/core/result.h
@@ -92,7 +92,7 @@ class Result final {
    * If true, it is guaranteed that `error()` will return `Error::Ok`.
    * If false, it is guaranteed that `error()` will not return `Error::Ok`.
    */
-  __ET_NODISCARD bool ok() const {
+  ET_NODISCARD bool ok() const {
     return hasValue_;
   }
 
@@ -103,7 +103,7 @@ class Result final {
    * If this does not return `Error:Ok`, it is guaranteed that `ok()` will
    * return false.
    */
-  __ET_NODISCARD Error error() const {
+  ET_NODISCARD Error error() const {
     if (hasValue_) {
       return Error::Ok;
     } else {

--- a/runtime/core/test/event_tracer_test.cpp
+++ b/runtime/core/test/event_tracer_test.cpp
@@ -75,9 +75,9 @@ class DummyEventTracer : public EventTracer {
   }
 
   void end_profiling_delegate(
-      __ET_UNUSED EventTracerEntry event_tracer_entry,
-      __ET_UNUSED const void* metadata,
-      __ET_UNUSED size_t metadata_len) override {
+      ET_UNUSED EventTracerEntry event_tracer_entry,
+      ET_UNUSED const void* metadata,
+      ET_UNUSED size_t metadata_len) override {
     (void)event_tracer_entry;
     (void)metadata;
     (void)metadata_len;

--- a/runtime/core/test/memory_allocator_test.cpp
+++ b/runtime/core/test/memory_allocator_test.cpp
@@ -195,7 +195,7 @@ TEST_F(MemoryAllocatorTest, AllocateListFailure) {
   EXPECT_EQ(p, nullptr);
 }
 
-#if __ET_HAVE_GNU_STATEMENT_EXPRESSIONS
+#if ET_HAVE_GNU_STATEMENT_EXPRESSIONS
 class HelperMacrosTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -403,4 +403,4 @@ TEST_F(HelperMacrosTest, AllocateListOrReturnFailure) {
       &allocator, allocator.size() * 2, &p);
   EXPECT_EQ(err, Error::MemoryAllocationFailed);
 }
-#endif // __ET_HAVE_GNU_STATEMENT_EXPRESSIONS
+#endif // ET_HAVE_GNU_STATEMENT_EXPRESSIONS

--- a/runtime/executor/memory_manager.h
+++ b/runtime/executor/memory_manager.h
@@ -66,8 +66,8 @@ class MemoryManager final {
    *
    * TODO(T162089316): Remove this once all users migrate to the new ctor.
    */
-  __ET_DEPRECATED MemoryManager(
-      // We would normally use __ET_UNUSED here, but GCC older than 9.3 has a
+  ET_DEPRECATED MemoryManager(
+      // We would normally use ET_UNUSED here, but GCC older than 9.3 has a
       // bug that triggers a syntax error when using [[maybe_unused]] on the
       // first parameter of a constructor:
       // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81429

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -771,7 +771,7 @@ Error Method::init(executorch_flatbuffer::ExecutionPlan* s_plan) {
   return Error::Ok;
 }
 
-__ET_NODISCARD Error
+ET_NODISCARD Error
 Method::set_input(const EValue& input_evalue, size_t input_idx) {
   ET_CHECK_OR_RETURN_ERROR(
       initialized(),
@@ -900,7 +900,7 @@ Method::set_input(const EValue& input_evalue, size_t input_idx) {
   return Error::Ok;
 }
 
-__ET_NODISCARD Error
+ET_NODISCARD Error
 Method::set_inputs(const exec_aten::ArrayRef<EValue>& input_evalues) {
   ET_CHECK_OR_RETURN_ERROR(
       initialized(),
@@ -929,7 +929,7 @@ Method::set_inputs(const exec_aten::ArrayRef<EValue>& input_evalues) {
   return Error::Ok;
 }
 
-__ET_NODISCARD Error
+ET_NODISCARD Error
 Method::set_output_data_ptr(void* buffer, size_t size, size_t output_idx) {
   // Check method state
   ET_CHECK_OR_RETURN_ERROR(
@@ -979,8 +979,7 @@ Method::set_output_data_ptr(void* buffer, size_t size, size_t output_idx) {
   return internal::set_tensor_data(t, buffer, size);
 }
 
-__ET_NODISCARD Error
-Method::get_outputs(EValue* output_evalues, size_t length) {
+ET_NODISCARD Error Method::get_outputs(EValue* output_evalues, size_t length) {
   ET_CHECK_OR_RETURN_ERROR(
       initialized(),
       InvalidState,
@@ -1002,7 +1001,7 @@ Method::get_outputs(EValue* output_evalues, size_t length) {
   return Error::Ok;
 }
 
-__ET_NODISCARD Error Method::get_inputs(EValue* input_evalues, size_t length) {
+ET_NODISCARD Error Method::get_inputs(EValue* input_evalues, size_t length) {
   ET_CHECK_OR_RETURN_ERROR(
       initialized(),
       InvalidState,

--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -103,7 +103,7 @@ class Method final {
    *
    * @returns Error::Ok on success, non-Ok on failure.
    */
-  __ET_NODISCARD Error set_input(const EValue& input_evalue, size_t input_idx);
+  ET_NODISCARD Error set_input(const EValue& input_evalue, size_t input_idx);
 
   /**
    * Sets the values of all method inputs.
@@ -117,7 +117,7 @@ class Method final {
    *
    * @returns Error::Ok on success, non-Ok on failure.
    */
-  __ET_NODISCARD Error
+  ET_NODISCARD Error
   set_inputs(const exec_aten::ArrayRef<EValue>& input_evalues);
 
   /**
@@ -139,7 +139,7 @@ class Method final {
    *
    * @returns Error::Ok on success, non-Ok on failure.
    */
-  __ET_NODISCARD Error
+  ET_NODISCARD Error
   set_output_data_ptr(void* buffer, size_t size, size_t output_idx);
 
   /**
@@ -159,7 +159,7 @@ class Method final {
    *
    * @returns Error::Ok on success, non-Ok on failure.
    */
-  __ET_NODISCARD Error get_outputs(EValue* output_evalues, size_t length);
+  ET_NODISCARD Error get_outputs(EValue* output_evalues, size_t length);
 
   /**
    * Copies the method's inputs into the provided array.
@@ -175,7 +175,7 @@ class Method final {
    *
    * @returns Error::Ok on success, non-Ok on failure.
    */
-  __ET_NODISCARD Error get_inputs(EValue* input_evalues, size_t length);
+  ET_NODISCARD Error get_inputs(EValue* input_evalues, size_t length);
 
   /**
    * Execute the method.
@@ -185,7 +185,7 @@ class Method final {
    *
    * @returns Error::Ok on success, non-Ok on failure.
    */
-  __ET_NODISCARD Error execute();
+  ET_NODISCARD Error execute();
 
   /**
    * Advances/executes a single instruction in the method.
@@ -196,7 +196,7 @@ class Method final {
    * @retval non-Ok step failed
    * @retval Error::EndOfMethod method finished executing successfully
    */
-  __ET_NODISCARD Error experimental_step();
+  ET_NODISCARD Error experimental_step();
 
   /**
    * Resets execution state to the start of the Method. For use with the
@@ -209,7 +209,7 @@ class Method final {
    *     the end of the Method. This means it is not possible to recover a
    *     Method that failed mid-execution.
    */
-  __ET_NODISCARD Error experimental_reset_execution();
+  ET_NODISCARD Error experimental_reset_execution();
 
   /**
    * Returns the MethodMeta that corresponds to the calling Method.
@@ -235,13 +235,13 @@ class Method final {
 
   /// DEPRECATED: Use MethodMeta instead to access metadata, and set_input to
   /// update Method inputs.
-  __ET_DEPRECATED const EValue& get_input(size_t i) const;
+  ET_DEPRECATED const EValue& get_input(size_t i) const;
   /// DEPRECATED: Use MethodMeta instead to access metadata, and set_input to
   /// update Method inputs.
-  __ET_DEPRECATED EValue& mutable_input(size_t i);
+  ET_DEPRECATED EValue& mutable_input(size_t i);
   /// DEPRECATED: Use MethodMeta instead to access metadata, and get_output to
   /// retrieve Method outputs.
-  __ET_DEPRECATED EValue& mutable_output(size_t i);
+  ET_DEPRECATED EValue& mutable_output(size_t i);
 
   ~Method();
 
@@ -288,7 +288,7 @@ class Method final {
         pre_allocated_output_(false) {}
 
   /// Static factory used by Program.
-  __ET_NODISCARD static Result<Method> load(
+  ET_NODISCARD static Result<Method> load(
       executorch_flatbuffer::ExecutionPlan* s_plan,
       const Program* program,
       MemoryManager* memory_manager,
@@ -299,7 +299,7 @@ class Method final {
    *
    * @returns Error::Ok on success, non-Ok on failure.
    */
-  __ET_NODISCARD Error init(executorch_flatbuffer::ExecutionPlan* s_plan);
+  ET_NODISCARD Error init(executorch_flatbuffer::ExecutionPlan* s_plan);
 
   /// Returns true if the Method was successfully initialized.
   inline bool initialized() const {
@@ -312,7 +312,7 @@ class Method final {
   size_t get_output_index(size_t i) const;
 
   // Executes a single instruction using the state in step_state_
-  __ET_NODISCARD Error execute_instruction();
+  ET_NODISCARD Error execute_instruction();
 
   StepState step_state_;
   const Program* program_;
@@ -338,9 +338,9 @@ class Method final {
    * the number of successfully-initialized entries so that ~Method doesn't try
    * to clean up uninitialized entries.
    */
-  __ET_NODISCARD Error parse_values();
+  ET_NODISCARD Error parse_values();
 
-  __ET_NODISCARD Error resolve_operator(
+  ET_NODISCARD Error resolve_operator(
       int32_t op_index,
       OpFunction* kernels,
       size_t kernel_index,

--- a/runtime/executor/method_meta.h
+++ b/runtime/executor/method_meta.h
@@ -179,7 +179,7 @@ class MethodMeta final {
   /**
    * DEPRECATED: Use num_memory_planned_buffers() instead.
    */
-  __ET_DEPRECATED size_t num_non_const_buffers() const {
+  ET_DEPRECATED size_t num_non_const_buffers() const {
     return num_memory_planned_buffers();
   }
 

--- a/runtime/executor/program.h
+++ b/runtime/executor/program.h
@@ -78,12 +78,12 @@ class Program final {
    * @param[in] verification The type of verification to do before returning
    *     success.
    */
-  __ET_NODISCARD static Result<Program> load(
+  ET_NODISCARD static Result<Program> load(
       DataLoader* loader,
       Verification verification = Verification::Minimal);
 
   /// DEPRECATED: Use the lowercase `load()` instead.
-  __ET_DEPRECATED __ET_NODISCARD static Result<Program> Load(
+  ET_DEPRECATED ET_NODISCARD static Result<Program> Load(
       DataLoader* loader,
       Verification verification = Verification::Minimal) {
     return load(loader, verification);
@@ -148,7 +148,7 @@ class Program final {
    *
    * @return The pytree encoding string for the output
    */
-  __ET_DEPRECATED Result<const char*> get_output_flattening_encoding(
+  ET_DEPRECATED Result<const char*> get_output_flattening_encoding(
       const char* method_name = "forward") const;
 
   /**
@@ -226,7 +226,7 @@ class Program final {
    *     DataLoader: The Program.segment table is inconsistent, or the
    *     data cannot be accessed.
    */
-  __ET_NODISCARD Result<FreeableBuffer> LoadSegment(
+  ET_NODISCARD Result<FreeableBuffer> LoadSegment(
       const DataLoader::SegmentInfo& segment_info) const;
 
   /**
@@ -247,7 +247,7 @@ class Program final {
    *     DataLoader: The Program.segment table is inconsistent, or the
    *     data cannot be accessed.
    */
-  __ET_NODISCARD Error load_mutable_subsegment_into(
+  ET_NODISCARD Error load_mutable_subsegment_into(
       size_t mutable_data_segments_index,
       size_t offset_index,
       size_t size,

--- a/runtime/executor/tensor_parser.h
+++ b/runtime/executor/tensor_parser.h
@@ -18,12 +18,12 @@ namespace torch {
 namespace executor {
 namespace deserialization {
 
-__ET_NODISCARD Result<exec_aten::Tensor> parseTensor(
+ET_NODISCARD Result<exec_aten::Tensor> parseTensor(
     const Program* program,
     MemoryManager* memory_manager,
     const executorch_flatbuffer::Tensor* s_tensor);
 
-__ET_NODISCARD Result<BoxedEvalueList<exec_aten::Tensor>> parseTensorList(
+ET_NODISCARD Result<BoxedEvalueList<exec_aten::Tensor>> parseTensorList(
     const flatbuffers::Vector<int32_t>* tensor_indices,
     EValue* values_,
     MemoryManager* memory_manager);
@@ -32,7 +32,7 @@ __ET_NODISCARD Result<BoxedEvalueList<exec_aten::Tensor>> parseTensorList(
 // list of optionals: list of optional Tensor, list of optional float etc, so we
 // just use a template to avoid boilerplate.
 template <typename T>
-__ET_NODISCARD Result<BoxedEvalueList<exec_aten::optional<T>>>
+ET_NODISCARD Result<BoxedEvalueList<exec_aten::optional<T>>>
 parseListOptionalType(
     const flatbuffers::Vector<int32_t>* value_indices,
     EValue* values_,
@@ -92,7 +92,7 @@ parseListOptionalType(
  * @returns On success, the data pointer to use for the tensor. On failure, a
  *     non-Ok Error.
  */
-__ET_NODISCARD Result<void*> getTensorDataPtr(
+ET_NODISCARD Result<void*> getTensorDataPtr(
     const executorch_flatbuffer::Tensor* s_tensor,
     const Program* program,
     size_t nbytes,

--- a/runtime/executor/tensor_parser_exec_aten.cpp
+++ b/runtime/executor/tensor_parser_exec_aten.cpp
@@ -22,7 +22,7 @@ namespace deserialization {
 // Provides access to private Program methods.
 class TensorParser final {
  public:
-  __ET_NODISCARD static Error load_mutable_subsegment_into(
+  ET_NODISCARD static Error load_mutable_subsegment_into(
       const Program* program,
       size_t mutable_data_segments_index,
       size_t offset_index,
@@ -36,7 +36,7 @@ class TensorParser final {
 namespace {
 
 // Retrieve the buffer specified by the allocation_info
-__ET_NODISCARD Result<void*> getMemPlannedPtr(
+ET_NODISCARD Result<void*> getMemPlannedPtr(
     const executorch_flatbuffer::AllocationDetails* allocation_info,
     size_t nbytes,
     HierarchicalAllocator* allocator) {
@@ -68,7 +68,7 @@ __ET_NODISCARD Result<void*> getMemPlannedPtr(
 }
 } // namespace
 
-__ET_NODISCARD Result<BoxedEvalueList<exec_aten::Tensor>> parseTensorList(
+ET_NODISCARD Result<BoxedEvalueList<exec_aten::Tensor>> parseTensorList(
     const flatbuffers::Vector<int32_t>* tensor_indices,
     EValue* values_,
     MemoryManager* memory_manager) {
@@ -97,7 +97,7 @@ __ET_NODISCARD Result<BoxedEvalueList<exec_aten::Tensor>> parseTensorList(
       evalp_list, tensor_list, tensor_indices->size());
 }
 
-__ET_NODISCARD Result<void*> getTensorDataPtr(
+ET_NODISCARD Result<void*> getTensorDataPtr(
     const executorch_flatbuffer::Tensor* s_tensor,
     const Program* program,
     size_t nbytes,

--- a/runtime/executor/test/backend_integration_test.cpp
+++ b/runtime/executor/test/backend_integration_test.cpp
@@ -95,7 +95,7 @@ class StubBackend final : public PyTorchBackendInterface {
   }
 
   Error execute(
-      __ET_UNUSED BackendExecutionContext& context,
+      ET_UNUSED BackendExecutionContext& context,
       DelegateHandle* handle,
       EValue** args) const override {
     if (execute_fn_) {
@@ -350,8 +350,8 @@ TEST_P(BackendIntegrationTest, FreeingProcessedBufferSucceeds) {
   const void* processed_data = nullptr;
   StubBackend::singleton().install_init(
       [&](FreeableBuffer* processed,
-          __ET_UNUSED ArrayRef<CompileSpec> compile_specs,
-          __ET_UNUSED MemoryAllocator* runtime_allocator)
+          ET_UNUSED ArrayRef<CompileSpec> compile_specs,
+          ET_UNUSED MemoryAllocator* runtime_allocator)
           -> Result<DelegateHandle*> {
         init_called = true;
         processed_data = processed->data();
@@ -394,8 +394,8 @@ TEST_P(BackendIntegrationTest, EndToEndTestWithProcessedAsHandle) {
   FreeableBuffer* init_processed = nullptr;
   StubBackend::singleton().install_init(
       [&](FreeableBuffer* processed,
-          __ET_UNUSED ArrayRef<CompileSpec> compile_specs,
-          __ET_UNUSED MemoryAllocator* runtime_allocator)
+          ET_UNUSED ArrayRef<CompileSpec> compile_specs,
+          ET_UNUSED MemoryAllocator* runtime_allocator)
           -> Result<DelegateHandle*> {
         init_processed = processed;
         return processed;
@@ -405,7 +405,7 @@ TEST_P(BackendIntegrationTest, EndToEndTestWithProcessedAsHandle) {
   // FreeableBuffer.
   DelegateHandle* execute_handle = nullptr;
   StubBackend::singleton().install_execute(
-      [&](DelegateHandle* handle, __ET_UNUSED EValue** args) -> Error {
+      [&](DelegateHandle* handle, ET_UNUSED EValue** args) -> Error {
         execute_handle = handle;
         auto* processed = reinterpret_cast<FreeableBuffer*>(handle);
 
@@ -492,8 +492,8 @@ TEST_P(BackendIntegrationTest, SegmentInfoIsPassedIntoDataLoader) {
   const void* processed_data = nullptr;
   StubBackend::singleton().install_init(
       [&](FreeableBuffer* processed,
-          __ET_UNUSED ArrayRef<CompileSpec> compile_specs,
-          __ET_UNUSED MemoryAllocator* runtime_allocator)
+          ET_UNUSED ArrayRef<CompileSpec> compile_specs,
+          ET_UNUSED MemoryAllocator* runtime_allocator)
           -> Result<DelegateHandle*> {
         processed_data = processed->data();
         processed->Free();
@@ -606,8 +606,8 @@ TEST_P(DelegateDataAlignmentTest, ExpectedDataAlignment) {
   const void* processed_data = nullptr;
   StubBackend::singleton().install_init(
       [&](FreeableBuffer* processed,
-          __ET_UNUSED ArrayRef<CompileSpec> compile_specs,
-          __ET_UNUSED MemoryAllocator* runtime_allocator)
+          ET_UNUSED ArrayRef<CompileSpec> compile_specs,
+          ET_UNUSED MemoryAllocator* runtime_allocator)
           -> Result<DelegateHandle*> {
         processed_data = processed->data();
         return nullptr;

--- a/runtime/executor/test/kernel_integration_test.cpp
+++ b/runtime/executor/test/kernel_integration_test.cpp
@@ -110,7 +110,7 @@ struct KernelControl {
    */
   static void kernel_hook(
       KernelRuntimeContext& context,
-      __ET_UNUSED EValue** args) {
+      ET_UNUSED EValue** args) {
     auto* control = KernelControl::singleton();
     control->call_count++;
     if (control->call_context_fail) {

--- a/runtime/executor/test/program_test.cpp
+++ b/runtime/executor/test/program_test.cpp
@@ -92,13 +92,13 @@ namespace testing {
 // Provides access to private Program methods.
 class ProgramTestFriend final {
  public:
-  __ET_NODISCARD static Result<FreeableBuffer> LoadSegment(
+  ET_NODISCARD static Result<FreeableBuffer> LoadSegment(
       const Program* program,
       const DataLoader::SegmentInfo& segment_info) {
     return program->LoadSegment(segment_info);
   }
 
-  __ET_NODISCARD static Error load_mutable_subsegment_into(
+  ET_NODISCARD static Error load_mutable_subsegment_into(
       const Program* program,
       size_t mutable_data_segments_index,
       size_t offset_index,

--- a/runtime/executor/test/test_backend_compiler_lib.cpp
+++ b/runtime/executor/test/test_backend_compiler_lib.cpp
@@ -153,7 +153,7 @@ class BackendWithCompiler final : public PyTorchBackendInterface {
   // backend you can imagine how this function could be used to actually
   // dispatch the inputs to the relevant backend/device.
   Error execute(
-      __ET_UNUSED BackendExecutionContext& context,
+      ET_UNUSED BackendExecutionContext& context,
       DelegateHandle* handle,
       EValue** args) const override {
     EXECUTORCH_SCOPE_PROF("BackendWithCompiler::execute");

--- a/runtime/executor/test/test_backend_with_delegate_mapping.cpp
+++ b/runtime/executor/test/test_backend_with_delegate_mapping.cpp
@@ -114,7 +114,7 @@ class BackendWithDelegateMapping final : public PyTorchBackendInterface {
   // This function doesn't actually execute the op but just prints out the op
   // name and the corresponding delegate debug identifier.
   Error execute(
-      __ET_UNUSED BackendExecutionContext& context,
+      ET_UNUSED BackendExecutionContext& context,
       DelegateHandle* handle,
       EValue** args) const override {
     (void)args;

--- a/runtime/kernel/kernel_runtime_context.h
+++ b/runtime/kernel/kernel_runtime_context.h
@@ -58,7 +58,7 @@ class KernelRuntimeContext {
   }
 
   /// Returns the current failure state.
-  __ET_NODISCARD Error failure_state() const {
+  ET_NODISCARD Error failure_state() const {
     return failure_state_;
   }
 

--- a/runtime/kernel/operator_registry.h
+++ b/runtime/kernel/operator_registry.h
@@ -221,7 +221,7 @@ ArrayRef<Kernel> get_kernels();
  * object should be handled internally and the reason for keep returning is to
  * satisfy the requirement to run this in static initialization time.
  */
-__ET_NODISCARD Error register_kernels(const ArrayRef<Kernel>&);
+ET_NODISCARD Error register_kernels(const ArrayRef<Kernel>&);
 
 struct OperatorRegistry {
  public:
@@ -234,7 +234,7 @@ struct OperatorRegistry {
    * @param[in] kernels Kernel object
    * @retval Error code representing whether registration was successful.
    */
-  __ET_NODISCARD Error register_kernels(const ArrayRef<Kernel>&);
+  ET_NODISCARD Error register_kernels(const ArrayRef<Kernel>&);
 
   /**
    * Checks whether an operator with a given name and TensorMeta list.

--- a/runtime/platform/abort.cpp
+++ b/runtime/platform/abort.cpp
@@ -16,7 +16,7 @@ namespace runtime {
  * Trigger the ExecuTorch global runtime to immediately exit without cleaning
  * up, and set an abnormal exit status (platform-defined).
  */
-__ET_NORETURN void runtime_abort() {
+ET_NORETURN void runtime_abort() {
   et_pal_abort();
 }
 

--- a/runtime/platform/abort.h
+++ b/runtime/platform/abort.h
@@ -22,7 +22,7 @@ namespace runtime {
  * Trigger the ExecuTorch global runtime to immediately exit without cleaning
  * up, and set an abnormal exit status (platform-defined).
  */
-__ET_NORETURN void runtime_abort();
+ET_NORETURN void runtime_abort();
 
 } // namespace runtime
 } // namespace executorch

--- a/runtime/platform/assert.h
+++ b/runtime/platform/assert.h
@@ -22,7 +22,7 @@
   ET_LOG(                                        \
       Fatal,                                     \
       "In function %s(), assert failed" _format, \
-      __ET_FUNCTION,                             \
+      ET_FUNCTION,                               \
       ##__VA_ARGS__)
 
 /**
@@ -35,7 +35,7 @@
  */
 #define ET_CHECK_MSG(_cond, _format, ...)                               \
   ({                                                                    \
-    if __ET_UNLIKELY (!(_cond)) {                                       \
+    if ET_UNLIKELY (!(_cond)) {                                         \
       ET_ASSERT_MESSAGE_EMIT(" (%s): " _format, #_cond, ##__VA_ARGS__); \
       ::executorch::runtime::runtime_abort();                           \
     }                                                                   \
@@ -49,7 +49,7 @@
  */
 #define ET_CHECK(_cond)                       \
   ({                                          \
-    if __ET_UNLIKELY (!(_cond)) {             \
+    if ET_UNLIKELY (!(_cond)) {               \
       ET_ASSERT_MESSAGE_EMIT(": %s", #_cond); \
       ::executorch::runtime::runtime_abort(); \
     }                                         \
@@ -104,7 +104,7 @@
 #define ET_ASSERT_UNREACHABLE()                                   \
   ({                                                              \
     ET_CHECK_MSG(false, "Execution should not reach this point"); \
-    __ET_UNREACHABLE();                                           \
+    ET_UNREACHABLE();                                             \
   })
 
 /**
@@ -116,5 +116,5 @@
   ({                                                                   \
     ET_CHECK_MSG(                                                      \
         false, "Execution should not reach this point. %s", _message); \
-    __ET_UNREACHABLE();                                                \
+    ET_UNREACHABLE();                                                  \
   })

--- a/runtime/platform/compiler.h
+++ b/runtime/platform/compiler.h
@@ -39,71 +39,71 @@
  *   https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
  */
 
-#define __ET_NORETURN [[noreturn]]
-#define __ET_NOINLINE __attribute__((noinline))
-#define __ET_INLINE __attribute__((always_inline)) inline
+#define ET_NORETURN [[noreturn]]
+#define ET_NOINLINE __attribute__((noinline))
+#define ET_INLINE __attribute__((always_inline)) inline
 
 #if defined(__GNUC__)
 
-#define __ET_UNREACHABLE() __builtin_unreachable()
+#define ET_UNREACHABLE() __builtin_unreachable()
 
 #elif defined(_MSC_VER)
 
-#define __ET_UNREACHABLE() __assume(0)
+#define ET_UNREACHABLE() __assume(0)
 
 #else // defined(__GNUC__)
 
-#define __ET_UNREACHABLE() \
-  while (1)                \
+#define ET_UNREACHABLE() \
+  while (1)              \
     ;
 
 #endif // defined(__GNUC__)
 
 #if (__cplusplus) >= 201703L
 
-#define __ET_DEPRECATED [[deprecated]]
-#define __ET_FALLTHROUGH [[fallthrough]]
-#define __ET_NODISCARD [[nodiscard]]
-#define __ET_UNUSED [[maybe_unused]]
+#define ET_DEPRECATED [[deprecated]]
+#define ET_FALLTHROUGH [[fallthrough]]
+#define ET_NODISCARD [[nodiscard]]
+#define ET_UNUSED [[maybe_unused]]
 
 #else
 
-#define __ET_DEPRECATED __attribute__((deprecated))
-#define __ET_FALLTHROUGH __attribute__((fallthrough))
-#define __ET_NODISCARD __attribute__((warn_unused_result))
-#define __ET_UNUSED __attribute__((unused))
+#define ET_DEPRECATED __attribute__((deprecated))
+#define ET_FALLTHROUGH __attribute__((fallthrough))
+#define ET_NODISCARD __attribute__((warn_unused_result))
+#define ET_UNUSED __attribute__((unused))
 
 #endif // (__cplusplus) >= 201703L
 
 // UNLIKELY Macro
 // example
-// if __ET_UNLIKELY(a > 10 && b < 5) {
+// if ET_UNLIKELY(a > 10 && b < 5) {
 //   do something
 // }
 #if (__cplusplus) >= 202002L
 
-#define __ET_LIKELY(expr) (expr) [[likely]]
-#define __ET_UNLIKELY(expr) (expr) [[unlikely]]
+#define ET_LIKELY(expr) (expr) [[likely]]
+#define ET_UNLIKELY(expr) (expr) [[unlikely]]
 
 #else
 
-#define __ET_LIKELY(expr) (expr)
-#define __ET_UNLIKELY(expr) (expr)
+#define ET_LIKELY(expr) (expr)
+#define ET_UNLIKELY(expr) (expr)
 
 #endif // (__cplusplus) >= 202002L
 
 /// Define a C symbol with weak linkage.
-#define __ET_WEAK __attribute__((weak))
+#define ET_WEAK __attribute__((weak))
 
 /**
  * Annotation marking a function as printf-like, providing compiler support
  * for format string argument checking.
  */
-#define __ET_PRINTFLIKE(_string_index, _va_index) \
+#define ET_PRINTFLIKE(_string_index, _va_index) \
   __attribute__((format(printf, _string_index, _va_index)))
 
 /// Name of the source file without a directory string.
-#define __ET_SHORT_FILENAME (__builtin_strrchr("/" __FILE__, '/') + 1)
+#define ET_SHORT_FILENAME (__builtin_strrchr("/" __FILE__, '/') + 1)
 
 #ifndef __has_builtin
 #define __has_builtin(x) (0)
@@ -111,24 +111,43 @@
 
 #if __has_builtin(__builtin_LINE)
 /// Current line as an integer.
-#define __ET_LINE __builtin_LINE()
+#define ET_LINE __builtin_LINE()
 #else
-#define __ET_LINE __LINE__
+#define ET_LINE __LINE__
 #endif // __has_builtin(__builtin_LINE)
 
 #if __has_builtin(__builtin_FUNCTION)
 /// Name of the current function as a const char[].
-#define __ET_FUNCTION __builtin_FUNCTION()
+#define ET_FUNCTION __builtin_FUNCTION()
 #else
-#define __ET_FUNCTION __FUNCTION__
+#define ET_FUNCTION __FUNCTION__
 #endif // __has_builtin(__builtin_FUNCTION)
 
 // Whether the compiler supports GNU statement expressions.
 // https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html
-#ifndef __ET_HAVE_GNU_STATEMENT_EXPRESSIONS
+#ifndef ET_HAVE_GNU_STATEMENT_EXPRESSIONS
 #if (defined(__GNUC__) && __GNUC__ >= 3) || defined(__clang__)
-#define __ET_HAVE_GNU_STATEMENT_EXPRESSIONS 1
+#define ET_HAVE_GNU_STATEMENT_EXPRESSIONS 1
 #else
-#define __ET_HAVE_GNU_STATEMENT_EXPRESSIONS 0
+#define ET_HAVE_GNU_STATEMENT_EXPRESSIONS 0
 #endif
 #endif // ifndef
+
+// DEPRECATED: Use the non-underscore-prefixed versions instead.
+// TODO(T199005537): Remove these once all users have stopped using them.
+#define __ET_DEPRECATED ET_DEPRECATED
+#define __ET_FALLTHROUGH ET_FALLTHROUGH
+#define __ET_FUNCTION ET_FUNCTION
+#define __ET_HAVE_GNU_STATEMENT_EXPRESSIONS ET_HAVE_GNU_STATEMENT_EXPRESSIONS
+#define __ET_INLINE ET_INLINE
+#define __ET_LIKELY ET_LIKELY
+#define __ET_LINE ET_LINE
+#define __ET_NODISCARD ET_NODISCARD
+#define __ET_NOINLINE ET_NOINLINE
+#define __ET_NORETURN ET_NORETURN
+#define __ET_PRINTFLIKE ET_PRINTFLIKE
+#define __ET_SHORT_FILENAME ET_SHORT_FILENAME
+#define __ET_UNLIKELY ET_UNLIKELY
+#define __ET_UNREACHABLE ET_UNREACHABLE
+#define __ET_UNUSED ET_UNUSED
+#define __ET_WEAK ET_WEAK

--- a/runtime/platform/default/minimal.cpp
+++ b/runtime/platform/default/minimal.cpp
@@ -15,14 +15,14 @@
 // This cpp file will provide weak implementations of the symbols declared in
 // Platform.h. Client users can strongly define any or all of the functions to
 // override them.
-#define ET_INTERNAL_PLATFORM_WEAKNESS __ET_WEAK
+#define ET_INTERNAL_PLATFORM_WEAKNESS ET_WEAK
 #include <executorch/runtime/platform/platform.h>
 
 #include <executorch/runtime/platform/compiler.h>
 
 void et_pal_init(void) {}
 
-__ET_NORETURN void et_pal_abort(void) {
+ET_NORETURN void et_pal_abort(void) {
   __builtin_trap();
 }
 
@@ -40,10 +40,10 @@ et_tick_ratio_t et_pal_ticks_to_ns_multiplier(void) {
 }
 
 void et_pal_emit_log_message(
-    __ET_UNUSED et_timestamp_t timestamp,
-    __ET_UNUSED et_pal_log_level_t level,
-    __ET_UNUSED const char* filename,
-    __ET_UNUSED const char* function,
-    __ET_UNUSED size_t line,
-    __ET_UNUSED const char* message,
-    __ET_UNUSED size_t length) {}
+    ET_UNUSED et_timestamp_t timestamp,
+    ET_UNUSED et_pal_log_level_t level,
+    ET_UNUSED const char* filename,
+    ET_UNUSED const char* function,
+    ET_UNUSED size_t line,
+    ET_UNUSED const char* message,
+    ET_UNUSED size_t length) {}

--- a/runtime/platform/default/posix.cpp
+++ b/runtime/platform/default/posix.cpp
@@ -20,7 +20,7 @@
 // This cpp file will provide weak implementations of the symbols declared in
 // Platform.h. Client users can strongly define any or all of the functions to
 // override them.
-#define ET_INTERNAL_PLATFORM_WEAKNESS __ET_WEAK
+#define ET_INTERNAL_PLATFORM_WEAKNESS ET_WEAK
 #include <executorch/runtime/platform/platform.h>
 
 #include <chrono>
@@ -55,7 +55,7 @@
       fprintf(                                                      \
           ET_LOG_OUTPUT_FILE,                                       \
           "ExecuTorch PAL must be initialized before call to %s()", \
-          __ET_FUNCTION);                                           \
+          ET_FUNCTION);                                             \
       fflush(ET_LOG_OUTPUT_FILE);                                   \
       et_pal_abort();                                               \
     }                                                               \
@@ -88,7 +88,7 @@ void et_pal_init(void) {
  * Immediately abort execution, setting the device into an error state, if
  * available.
  */
-__ET_NORETURN void et_pal_abort(void) {
+ET_NORETURN void et_pal_abort(void) {
   std::abort();
 }
 
@@ -134,10 +134,10 @@ void et_pal_emit_log_message(
     et_timestamp_t timestamp,
     et_pal_log_level_t level,
     const char* filename,
-    __ET_UNUSED const char* function,
+    ET_UNUSED const char* function,
     size_t line,
     const char* message,
-    __ET_UNUSED size_t length) {
+    ET_UNUSED size_t length) {
   _ASSERT_PAL_INITIALIZED();
 
   // Not all platforms have ticks == nanoseconds, but this one does.

--- a/runtime/platform/log.cpp
+++ b/runtime/platform/log.cpp
@@ -73,10 +73,10 @@ static_assert(
  * @param[in] args Variable argument list.
  */
 void vlogf(
-    __ET_UNUSED LogLevel level,
+    ET_UNUSED LogLevel level,
     et_timestamp_t timestamp,
     const char* filename,
-    __ET_UNUSED const char* function,
+    ET_UNUSED const char* function,
     size_t line,
     const char* format,
     va_list args) {

--- a/runtime/platform/log.h
+++ b/runtime/platform/log.h
@@ -94,7 +94,7 @@ et_timestamp_t get_log_timestamp();
  * @param[in] format Format string.
  * @param[in] args Variable argument list.
  */
-__ET_PRINTFLIKE(6, 0)
+ET_PRINTFLIKE(6, 0)
 void vlogf(
     LogLevel level,
     et_timestamp_t timestamp,
@@ -116,7 +116,7 @@ void vlogf(
  * @param[in] line Source file line of the caller.
  * @param[in] format Format string.
  */
-__ET_PRINTFLIKE(6, 7)
+ET_PRINTFLIKE(6, 7)
 inline void logf(
     LogLevel level,
     et_timestamp_t timestamp,
@@ -165,9 +165,9 @@ using ::executorch::runtime::LogLevel;
       ::executorch::runtime::internal::logf(                         \
           _log_level,                                                \
           _timestamp,                                                \
-          __ET_SHORT_FILENAME,                                       \
-          __ET_FUNCTION,                                             \
-          __ET_LINE,                                                 \
+          ET_SHORT_FILENAME,                                         \
+          ET_FUNCTION,                                               \
+          ET_LINE,                                                   \
           _format,                                                   \
           ##__VA_ARGS__);                                            \
     }                                                                \

--- a/runtime/platform/platform.h
+++ b/runtime/platform/platform.h
@@ -58,7 +58,7 @@ void et_pal_init(void) ET_INTERNAL_PLATFORM_WEAKNESS;
  * Immediately abort execution, setting the device into an error state, if
  * available.
  */
-__ET_NORETURN void et_pal_abort(void) ET_INTERNAL_PLATFORM_WEAKNESS;
+ET_NORETURN void et_pal_abort(void) ET_INTERNAL_PLATFORM_WEAKNESS;
 
 /**
  * Return a monotonically non-decreasing timestamp in system ticks.

--- a/runtime/platform/test/stub_platform.cpp
+++ b/runtime/platform/test/stub_platform.cpp
@@ -28,13 +28,13 @@ void InterceptWith::install(PlatformIntercept* pi) {
 }
 
 /// Prints a message and aborts if an intercept is not installed.
-#define ASSERT_INTERCEPT_INSTALLED()                                   \
-  ({                                                                   \
-    if (platform_intercept == nullptr) {                               \
-      fprintf(stderr, "%s call was not intercepted\n", __ET_FUNCTION); \
-      fflush(stderr);                                                  \
-      __builtin_trap();                                                \
-    }                                                                  \
+#define ASSERT_INTERCEPT_INSTALLED()                                 \
+  ({                                                                 \
+    if (platform_intercept == nullptr) {                             \
+      fprintf(stderr, "%s call was not intercepted\n", ET_FUNCTION); \
+      fflush(stderr);                                                \
+      __builtin_trap();                                              \
+    }                                                                \
   })
 
 extern "C" {
@@ -44,7 +44,7 @@ void et_pal_init(void) {
   platform_intercept->init();
 }
 
-__ET_NORETURN void et_pal_abort(void) {
+ET_NORETURN void et_pal_abort(void) {
   ASSERT_INTERCEPT_INSTALLED();
   // We can't properly intercept this since it's marked NORETURN.
   fprintf(stderr, "StubPlatform et_pal_abort called\n");
@@ -66,10 +66,10 @@ void et_pal_emit_log_message(
     et_timestamp_t timestamp,
     et_pal_log_level_t level,
     const char* filename,
-    __ET_UNUSED const char* function,
+    ET_UNUSED const char* function,
     size_t line,
     const char* message,
-    __ET_UNUSED size_t length) {
+    ET_UNUSED size_t length) {
   ASSERT_INTERCEPT_INSTALLED();
   platform_intercept->emit_log_message(
       timestamp, level, filename, function, line, message, length);

--- a/runtime/platform/test/stub_platform.h
+++ b/runtime/platform/test/stub_platform.h
@@ -37,13 +37,13 @@ class PlatformIntercept {
 
   /// Called when et_pal_emit_log_message() is called.
   virtual void emit_log_message(
-      __ET_UNUSED et_timestamp_t timestamp,
-      __ET_UNUSED et_pal_log_level_t level,
-      __ET_UNUSED const char* filename,
-      __ET_UNUSED const char* function,
-      __ET_UNUSED size_t line,
-      __ET_UNUSED const char* message,
-      __ET_UNUSED size_t length) {}
+      ET_UNUSED et_timestamp_t timestamp,
+      ET_UNUSED et_pal_log_level_t level,
+      ET_UNUSED const char* filename,
+      ET_UNUSED const char* function,
+      ET_UNUSED size_t line,
+      ET_UNUSED const char* message,
+      ET_UNUSED size_t length) {}
 
   virtual ~PlatformIntercept() = default;
 };

--- a/sdk/bundled_program/bundled_program.cpp
+++ b/sdk/bundled_program/bundled_program.cpp
@@ -234,7 +234,7 @@ get_method_test_suite(
 } // namespace
 
 // Load testset_idx-th bundled data into the Method
-__ET_NODISCARD Error LoadBundledInput(
+ET_NODISCARD Error LoadBundledInput(
     Method& method,
     serialized_bundled_program* bundled_program_ptr,
     size_t testset_idx) {
@@ -329,7 +329,7 @@ __ET_NODISCARD Error LoadBundledInput(
   return Error::Ok;
 }
 
-__ET_NODISCARD Error VerifyResultWithBundledExpectedOutput(
+ET_NODISCARD Error VerifyResultWithBundledExpectedOutput(
     Method& method,
     serialized_bundled_program* bundled_program_ptr,
     size_t testset_idx,
@@ -390,7 +390,7 @@ __ET_NODISCARD Error VerifyResultWithBundledExpectedOutput(
   return Error::Ok;
 }
 
-__ET_NODISCARD Error GetProgramData(
+ET_NODISCARD Error GetProgramData(
     void* file_data,
     size_t file_data_len,
     const void** out_program_data,

--- a/sdk/bundled_program/bundled_program.h
+++ b/sdk/bundled_program/bundled_program.h
@@ -31,7 +31,7 @@ using serialized_bundled_program = const void;
  * @returns Return Error::Ok if load successfully, or the error happens during
  * execution.
  */
-__ET_NODISCARD Error LoadBundledInput(
+ET_NODISCARD Error LoadBundledInput(
     Method& method,
     serialized_bundled_program* bundled_program_ptr,
     size_t testset_idx);
@@ -49,7 +49,7 @@ __ET_NODISCARD Error LoadBundledInput(
  * @returns Return Error::Ok if two outputs match, or the error happens during
  * execution.
  */
-__ET_NODISCARD Error VerifyResultWithBundledExpectedOutput(
+ET_NODISCARD Error VerifyResultWithBundledExpectedOutput(
     Method& method,
     serialized_bundled_program* bundled_program_ptr,
     size_t testset_idx,
@@ -73,7 +73,7 @@ __ET_NODISCARD Error VerifyResultWithBundledExpectedOutput(
  * in it, and out_program_data/out_program_data_len point to the data. Other
  * values on failure.
  */
-__ET_NODISCARD Error GetProgramData(
+ET_NODISCARD Error GetProgramData(
     void* file_data,
     size_t file_data_len,
     const void** out_program_data,

--- a/shim/xplat/executorch/kernels/optimized/lib_defs.bzl
+++ b/shim/xplat/executorch/kernels/optimized/lib_defs.bzl
@@ -101,7 +101,7 @@ def define_libs():
             "@EXECUTORCH_CLIENTS",
         ],
         exported_deps = [
-            # Needed to access the __ET_INLINE macro
+            # Needed to access the ET_INLINE macro
             "//executorch/runtime/platform:compiler",
         ],
     )

--- a/test/utils/DeathTest.h
+++ b/test/utils/DeathTest.h
@@ -15,7 +15,7 @@
 
 #include <gtest/gtest.h>
 
-#if __ET_BUILD_MODE_COV
+#if ET_BUILD_MODE_COV
 
 /**
  * TODO(T124640221): Work around a seg fault when running death tests in
@@ -25,7 +25,7 @@
  */
 #define ET_EXPECT_DEATH(_statement, _matcher) ((void)0)
 
-#else // __ET_BUILD_MODE_COV
+#else // ET_BUILD_MODE_COV
 
 /**
  * Ensure the executable will abort when `_statement` is executed.
@@ -37,4 +37,4 @@
 #define ET_EXPECT_DEATH(_statement, _matcher) \
   EXPECT_DEATH_IF_SUPPORTED(_statement, _matcher)
 
-#endif // __ET_BUILD_MODE_COV
+#endif // ET_BUILD_MODE_COV

--- a/test/utils/UnitTestMain.cpp
+++ b/test/utils/UnitTestMain.cpp
@@ -16,7 +16,7 @@
 #include <gtest/gtest.h>
 
 // Define main as a weak symbol to allow trivial overriding.
-int main(int argc, char** argv) __ET_WEAK;
+int main(int argc, char** argv) ET_WEAK;
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/util/read_file.cpp
+++ b/util/read_file.cpp
@@ -17,7 +17,7 @@ namespace torch {
 namespace executor {
 namespace util {
 
-__ET_NODISCARD Error read_file_content(
+ET_NODISCARD Error read_file_content(
     const char* file_name,
     std::shared_ptr<char>* file_data,
     size_t* file_length) {
@@ -54,7 +54,7 @@ __ET_NODISCARD Error read_file_content(
   return Error::Ok;
 }
 
-__ET_DEPRECATED std::shared_ptr<char> read_file_content(const char* name) {
+ET_DEPRECATED std::shared_ptr<char> read_file_content(const char* name) {
   std::shared_ptr<char> file_data;
   size_t file_length;
   Error status = read_file_content(name, &file_data, &file_length);

--- a/util/read_file.h
+++ b/util/read_file.h
@@ -32,7 +32,7 @@ namespace util {
  * data and file_length is the correct length of file_data. Other values on
  * failure.
  */
-__ET_NODISCARD Error read_file_content(
+ET_NODISCARD Error read_file_content(
     const char* file_name,
     std::shared_ptr<char>* file_data,
     size_t* file_length);
@@ -49,7 +49,7 @@ __ET_NODISCARD Error read_file_content(
  *
  * @returns The pointer to file data, if read successfully. Otherwise null_ptr.
  */
-__ET_DEPRECATED std::shared_ptr<char> read_file_content(const char* name);
+ET_DEPRECATED std::shared_ptr<char> read_file_content(const char* name);
 
 } // namespace util
 } // namespace executor

--- a/util/util.h
+++ b/util/util.h
@@ -30,7 +30,7 @@ namespace util {
  * @returns An array of pointers that must be passed to `FreeInputs()` after
  *     the Method is no longer needed.
  */
-__ET_DEPRECATED
+ET_DEPRECATED
 inline exec_aten::ArrayRef<void*> PrepareInputTensors(Method& method) {
   Result<BufferCleanup> inputs = prepare_input_tensors(method);
   ET_CHECK(inputs.ok());
@@ -45,7 +45,7 @@ inline exec_aten::ArrayRef<void*> PrepareInputTensors(Method& method) {
  *
  * Frees memory that was allocated by `PrepareInputTensors()`.
  */
-__ET_DEPRECATED
+ET_DEPRECATED
 inline void FreeInputs(exec_aten::ArrayRef<void*> inputs) {
   ET_CHECK(inputs.size() == 1);
   // A hack to work with the deprecated signature. The ArrayRef points to a


### PR DESCRIPTION
Summary: The C++ standard reserves underscore-prefixed names for the compiler ([reference1](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#nl8-use-a-consistent-naming-style), [reference2](https://stackoverflow.com/a/228797)).

Differential Revision: D61346624
