### PR TITLE
Make the Module non-movable.

### DIFF
--- a/extension/module/module.h
+++ b/extension/module/module.h
@@ -65,8 +65,8 @@ class Module final {
       std::unique_ptr<EventTracer> event_tracer = nullptr);
   Module(const Module&) = delete;
   Module& operator=(const Module&) = delete;
-  Module(Module&&) = default;
-  Module& operator=(Module&&) = default;
+  Module(Module&&) = delete;
+  Module& operator=(Module&&) = delete;
 
   /**
    * Loads the program using the specified data loader and memory allocator.


### PR DESCRIPTION
Summary: Customers can always wrap it in a unique_ptr and move around, but moving the instance itself leads to tricky bugs if a methond has been loaded already.

Differential Revision: D61366181
