### PR TITLE
Add llava runner test binary and build script (#4667)

### DIFF
--- a/.ci/scripts/test_llava.sh
+++ b/.ci/scripts/test_llava.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -exu
+# shellcheck source=/dev/null
+
+if [[ -z "${PYTHON_EXECUTABLE:-}" ]]; then
+  PYTHON_EXECUTABLE=python3
+fi
+
+cmake_install_executorch_libraries() {
+    cmake                                               \
+        -DCMAKE_INSTALL_PREFIX=cmake-out                \
+        -DCMAKE_BUILD_TYPE=Debug                        \
+        -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON          \
+        -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON     \
+        -DEXECUTORCH_BUILD_KERNELS_CUSTOM=ON            \
+        -DEXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON         \
+        -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON         \
+        -DEXECUTORCH_BUILD_XNNPACK=ON                   \
+        -DEXECUTORCH_DO_NOT_USE_CXX11_ABI=ON            \
+        -Bcmake-out .
+
+
+    cmake --build cmake-out -j9 --target install --config Debug
+}
+
+cmake_build_llava_runner() {
+    dir=examples/models/llava
+    python_lib=$($PYTHON_EXECUTABLE -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')
+
+    cmake                                       \
+        -DCMAKE_INSTALL_PREFIX=cmake-out        \
+        -DCMAKE_BUILD_TYPE=Debug                \
+        -DEXECUTORCH_BUILD_KERNELS_CUSTOM=ON    \
+        -DEXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON \
+        -DEXECUTORCH_BUILD_XNNPACK=ON           \
+        -DCMAKE_PREFIX_PATH="$python_lib"       \
+        -Bcmake-out/${dir}                      \
+        ${dir}
+
+
+    cmake --build cmake-out/${dir} -j9 --config Debug
+}
+
+# only export the one without custom op for now since it's
+export_llava() {
+    echo "Starting to export Llava. This will take about 6 mins"
+    $PYTHON_EXECUTABLE -m executorch.examples.models.llava.export_llava --pte-name llava.pte --with-artifacts
+}
+
+run_and_verify() {
+    NOW=$(date +"%H:%M:%S")
+    echo "Starting to run llava runner at ${NOW}"
+    if [[ ! -f "llava.pte" ]]; then
+        echo "Export failed. Abort"
+        exit 1
+    fi
+    if [[ ! -f "image.pt" ]]; then
+        echo "image.pt is missing."
+        exit 1
+    fi
+    if [[ ! -f "tokenizer.bin" ]]; then
+        echo "tokenizer.bin is missing."
+        exit 1
+    fi
+    RUNTIME_ARGS="--model_path=llava.pte \
+     --tokenizer_path=tokenizer.bin \
+     --image_path=image.pt \
+     --prompt=ASSISTANT: \
+     --temperature=0 \
+     --seq_len=650"
+    cmake-out/examples/models/llava/llava_main ${RUNTIME_ARGS} > result.txt
+    # verify result.txt
+    RESULT=$(cat result.txt)
+    # set the expected prefix to be the same as prompt because there's a bug in sdpa_with_kv_cache that causes <unk> tokens.
+    EXPECTED_PREFIX="ASSISTANT:"
+    if [[ "${RESULT}" == *"${EXPECTED_PREFIX}"* ]]; then
+        echo "Expected result prefix: ${EXPECTED_PREFIX}"
+        echo "Actual result: ${RESULT}"
+        echo "Success"
+        exit 0
+    else
+        echo "Expected result prefix: ${EXPECTED_PREFIX}"
+        echo "Actual result: ${RESULT}"
+        echo "Failure; results not the same"
+        exit 1
+    fi
+}
+
+cmake_install_executorch_libraries
+cmake_build_llava_runner
+export_llava
+run_and_verify

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -187,7 +187,7 @@ jobs:
         # Test selective build
         PYTHON_EXECUTABLE=python bash examples/selective_build/test_selective_build.sh "${BUILD_TOOL}"
 
-  test-export-llava-linux:
+  test-llava-runner-linux:
     name: test-export-llava-linux
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     strategy:
@@ -214,6 +214,9 @@ jobs:
 
         # run python unittest
         python -m unittest examples.models.llava.test.test_llava
+
+        # run e2e (export, tokenizer and runner)
+        PYTHON_EXECUTABLE=python bash .ci/scripts/test_llava.sh
 
   test-quantized-aot-lib-linux:
     name: test-quantized-aot-lib-linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,12 @@ if(EXECUTORCH_ENABLE_EVENT_TRACER)
   add_definitions(-DET_EVENT_TRACER_ENABLED)
 endif()
 
+option(EXECUTORCH_DO_NOT_USE_CXX11_ABI "Define _GLIBCXX_USE_CXX11_ABI=0 if ON"
+       OFF
+)
+if(EXECUTORCH_DO_NOT_USE_CXX11_ABI)
+  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+endif()
 # -ffunction-sections -fdata-sections: breaks function and data into sections so
 # they can be properly gc'd. -s: strip symbol. -fno-exceptions -fno-rtti:
 # disables exceptions and runtime type.

--- a/examples/models/llava/CMakeLists.txt
+++ b/examples/models/llava/CMakeLists.txt
@@ -1,0 +1,218 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# Simple CMake build system for llava runner.
+#
+# ### Editing this file ###
+#
+# This file should be formatted with
+# ~~~
+# cmake-format -i CMakeLists.txt
+# ~~~
+# It should also be cmake-lint clean.
+#
+cmake_minimum_required(VERSION 3.19)
+project(llava)
+
+# Duplicating options as root CMakeLists.txt
+option(EXECUTORCH_BUILD_KERNELS_OPTIMIZED "Build the optimized kernels" OFF)
+
+
+include(CMakeDependentOption)
+#
+# pthreadpool: build pthreadpool library. Disable on unsupported platforms
+#
+cmake_dependent_option(
+  EXECUTORCH_BUILD_PTHREADPOOL "Build pthreadpool library." ON
+  "NOT EXECUTORCH_BUILD_ARM_BAREMETAL" OFF
+)
+#
+# cpuinfo: build cpuinfo library. Disable on unsupported platforms
+#
+cmake_dependent_option(
+  EXECUTORCH_BUILD_CPUINFO "Build cpuinfo library." ON
+  "NOT EXECUTORCH_BUILD_ARM_BAREMETAL" OFF
+)
+
+if(NOT PYTHON_EXECUTABLE)
+  set(PYTHON_EXECUTABLE python3)
+endif()
+
+set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+
+include(${EXECUTORCH_ROOT}/build/Utils.cmake)
+
+if(NOT PYTHON_EXECUTABLE)
+  resolve_python_executable()
+endif()
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  # Can't set to 11 due to executor_runner.cpp make_unique
+endif()
+
+if(CMAKE_TOOLCHAIN_FILE MATCHES ".*(iOS|ios\.toolchain)\.cmake$")
+  set(CMAKE_TOOLCHAIN_IOS ON)
+else()
+  set(CMAKE_TOOLCHAIN_IOS OFF)
+endif()
+
+set(_common_compile_options -Wno-deprecated-declarations -fPIC)
+
+# Let files say "include <executorch/path/to/header.h>".
+set(_common_include_directories ${EXECUTORCH_ROOT}/..)
+
+# For some reason android build is not able to find where gflags is and hence
+# cannot find corresponding .cmake file
+set(gflags_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party/gflags)
+find_package(gflags REQUIRED)
+
+find_package(Torch CONFIG REQUIRED)
+add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+
+#
+# llava_main: test binary to run llava, with tokenizer and sampler integrated
+#
+
+# find `executorch` libraries Same as for gflags
+set(executorch_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../lib/cmake/ExecuTorch)
+find_package(executorch CONFIG REQUIRED)
+if(CMAKE_TOOLCHAIN_IOS OR ANDROID)
+  target_link_options_shared_lib(executorch)
+endif()
+
+# custom ops library
+if(EXECUTORCH_BUILD_KERNELS_CUSTOM)
+  add_subdirectory(
+    ${EXECUTORCH_ROOT}/extension/llm/custom_ops
+    ${CMAKE_CURRENT_BINARY_DIR}/../../../extension/llm/custom_ops
+  )
+endif()
+
+# llava_runner library
+add_subdirectory(runner)
+
+set(link_libraries gflags torch)
+set(_srcs main.cpp)
+
+if(EXECUTORCH_BUILD_KERNELS_OPTIMIZED)
+  list(
+    APPEND
+    link_libraries
+    optimized_native_cpu_ops_lib
+    optimized_kernels
+    portable_kernels
+    cpublas
+    eigen_blas
+  )
+  target_link_options_shared_lib(optimized_native_cpu_ops_lib)
+else()
+  list(APPEND link_libraries portable_ops_lib portable_kernels)
+  target_link_options_shared_lib(portable_ops_lib)
+endif()
+
+# quantized_ops_lib: Register quantized op kernels into the runtime
+target_link_options_shared_lib(quantized_ops_lib)
+list(APPEND link_libraries quantized_kernels quantized_ops_lib)
+
+if(EXECUTORCH_BUILD_KERNELS_CUSTOM)
+  target_link_options_shared_lib(custom_ops)
+  list(APPEND link_libraries custom_ops)
+endif()
+
+set(XNNPACK_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../backends/xnnpack)
+# Extra compile option and include dir for pthreadpool
+if(EXECUTORCH_BUILD_PTHREADPOOL)
+  list(APPEND _common_compile_options -DET_USE_THREADPOOL)
+  list(APPEND link_libraries pthreadpool)
+  # These 2 source files are included in xnnpack_backend
+  if(NOT TARGET xnnpack_backend)
+    list(APPEND _srcs ${XNNPACK_ROOT}/threadpool/threadpool.cpp
+         ${XNNPACK_ROOT}/threadpool/threadpool_guard.cpp
+    )
+  endif()
+  list(APPEND _common_include_directories
+       ${XNNPACK_ROOT}/third-party/pthreadpool/include
+  )
+endif()
+
+# Extra sources for cpuinfo
+if(EXECUTORCH_BUILD_CPUINFO)
+  list(APPEND link_libraries cpuinfo)
+  list(APPEND _srcs ${XNNPACK_ROOT}/threadpool/cpuinfo_utils.cpp)
+  list(APPEND _common_include_directories
+       ${XNNPACK_ROOT}/third-party/cpuinfo/include
+  )
+endif()
+
+# XNNPACK
+if(TARGET xnnpack_backend)
+  set(xnnpack_backend_libs xnnpack_backend XNNPACK)
+  list(APPEND link_libraries ${xnnpack_backend_libs})
+  target_link_options_shared_lib(xnnpack_backend)
+endif()
+
+# Vulkan backend
+if(TARGET vulkan_backend)
+  list(APPEND link_libraries vulkan_backend)
+  target_link_options_shared_lib(vulkan_backend)
+endif()
+
+# Qnn backend
+if(TARGET qnn_executorch_backend)
+  list(APPEND link_libraries qnn_executorch_backend)
+  target_link_options_shared_lib(qnn_executorch_backend)
+endif()
+
+# MPS backend
+if(TARGET mpsdelegate)
+  list(
+    APPEND
+    link_libraries
+    mpsdelegate
+    "-framework Foundation"
+    "-weak_framework MetalPerformanceShaders"
+    "-weak_framework MetalPerformanceShadersGraph"
+    "-weak_framework Metal"
+  )
+  target_link_options_shared_lib(mpsdelegate)
+endif()
+
+if(TARGET coremldelegate)
+  find_library(SQLITE_LIBRARY sqlite3)
+  list(
+    APPEND
+    link_libraries
+    coremldelegate
+    sqlite3
+    "-framework Foundation"
+    "-framework CoreML"
+    "-framework Accelerate"
+  )
+  target_link_options_shared_lib(coremldelegate)
+endif()
+
+# This one is needed for cpuinfo where it uses android specific log lib
+if(ANDROID)
+  list(APPEND link_libraries log)
+endif()
+
+add_executable(llava_main ${_srcs})
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  target_link_options(llava_main PRIVATE "LINKER:--gc-sections,-s")
+endif()
+
+target_include_directories(llava_main PUBLIC ${_common_include_directories})
+target_link_libraries(llava_main PUBLIC llava_runner ${link_libraries})
+target_compile_options(llava_main PUBLIC ${_common_compile_options})
+
+if(APPLE)
+  target_link_options_shared_lib(executorch)
+endif()
+
+# Print all summary
+executorch_print_configuration_summary()

--- a/examples/models/llava/main.cpp
+++ b/examples/models/llava/main.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/examples/models/llava/runner/llava_runner.h>
+#include <gflags/gflags.h>
+#include <torch/torch.h>
+
+#if defined(ET_USE_THREADPOOL)
+#include <executorch/backends/xnnpack/threadpool/cpuinfo_utils.h>
+#include <executorch/backends/xnnpack/threadpool/threadpool.h>
+#endif
+
+DEFINE_string(
+    model_path,
+    "llava.pte",
+    "Model serialized in flatbuffer format.");
+
+DEFINE_string(tokenizer_path, "tokenizer.bin", "Tokenizer stuff.");
+
+DEFINE_string(prompt, "The answer to the ultimate question is", "Prompt.");
+
+DEFINE_string(
+    image_path,
+    "",
+    "The path to a .pt file, a serialized torch tensor for an image, longest edge resized to 336.");
+
+DEFINE_double(
+    temperature,
+    0.8f,
+    "Temperature; Default is 0.8f. 0 = greedy argmax sampling (deterministic). Lower temperature = more deterministic");
+
+DEFINE_int32(
+    seq_len,
+    1024,
+    "Total number of tokens to generate (prompt + output). Defaults to max_seq_len. If the number of input tokens + seq_len > max_seq_len, the output will be truncated to max_seq_len tokens.");
+
+DEFINE_int32(
+    cpu_threads,
+    -1,
+    "Number of CPU threads for inference. Defaults to -1, which implies we'll use a heuristic to derive the # of performant cores for a specific device.");
+
+int32_t main(int32_t argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  // Create a loader to get the data of the program file. There are other
+  // DataLoaders that use mmap() or point32_t to data that's already in memory,
+  // and users can create their own DataLoaders to load from arbitrary sources.
+  const char* model_path = FLAGS_model_path.c_str();
+
+  const char* tokenizer_path = FLAGS_tokenizer_path.c_str();
+
+  const char* prompt = FLAGS_prompt.c_str();
+
+  std::string image_path = FLAGS_image_path;
+
+  double temperature = FLAGS_temperature;
+
+  int32_t seq_len = FLAGS_seq_len;
+
+  int32_t cpu_threads = FLAGS_cpu_threads;
+
+#if defined(ET_USE_THREADPOOL)
+  uint32_t num_performant_cores = cpu_threads == -1
+      ? torch::executorch::cpuinfo::get_num_performant_cores()
+      : static_cast<uint32_t>(cpu_threads);
+  ET_LOG(
+      Info, "Resetting threadpool with num threads = %d", num_performant_cores);
+  if (num_performant_cores > 0) {
+    torch::executorch::threadpool::get_threadpool()->_unsafe_reset_threadpool(
+        num_performant_cores);
+  }
+#endif
+  // create llama runner
+  torch::executor::LlavaRunner runner(model_path, tokenizer_path, temperature);
+
+  // read image and resize the longest edge to 336
+  std::vector<uint8_t> image_data;
+  //   cv::Mat image = cv::imread(image_path, cv::IMREAD_COLOR);
+  //   int longest_edge = std::max(image.rows, image.cols);
+  //   float scale_factor = 336.0f / longest_edge;
+  //   cv::Size new_size(image.cols * scale_factor, image.rows * scale_factor);
+  //   cv::Mat resized_image;
+  //   cv::resize(image, resized_image, new_size);
+  //   image_data.assign(resized_image.datastart, resized_image.dataend);
+  torch::Tensor image_tensor;
+  torch::load(image_tensor, image_path); // CHW
+  ET_LOG(
+      Info,
+      "image size(0): %" PRId64 ", size(1): %" PRId64 ", size(2): %" PRId64,
+      image_tensor.size(0),
+      image_tensor.size(1),
+      image_tensor.size(2));
+  image_data.assign(
+      image_tensor.data_ptr<uint8_t>(),
+      image_tensor.data_ptr<uint8_t>() + image_tensor.numel());
+  std::vector<torch::executor::Image> images = {
+      {.data = image_data,
+       .width = static_cast<int32_t>(image_tensor.size(2)),
+       .height = static_cast<int32_t>(image_tensor.size(1))}};
+  // generate
+  runner.generate(images, prompt, seq_len);
+  return 0;
+}

--- a/examples/models/llava/runner/llava_image_prefiller.h
+++ b/examples/models/llava/runner/llava_image_prefiller.h
@@ -31,7 +31,7 @@ class LlavaImagePrefiller : public ImagePrefiller {
         image.data.data(), {3, image.height, image.width}, ScalarType::Byte);
     // Run image encoder
     std::vector<EValue> image_encoder_outputs = ET_UNWRAP(module_->execute(
-        "image_encoder", {managed_images.get_aliasing_tensor()}));
+        kImageEncoderMethod, {managed_images.get_aliasing_tensor()}));
 
     // inputs:[start_pos, embeds]
     ManagedTensor managed_start_pos(&start_pos, {1}, ScalarType::Long);
@@ -39,13 +39,57 @@ class LlavaImagePrefiller : public ImagePrefiller {
 
     // Run text model
     std::vector<EValue> outputs_res = ET_UNWRAP(module_->execute(
-        "text_decoder", {start_pos_tensor, image_encoder_outputs[0]}));
+        kTextModelMethod, {start_pos_tensor, image_encoder_outputs[0]}));
     ET_CHECK_MSG(
         outputs_res[0].isTensor(),
         "Non Tensor Output returned from executing image prefill");
 
     return outputs_res[0].toTensor();
   }
+
+  /**
+   * Load the Module for image prefill purpose.
+   * @return The error code.
+   */
+  inline Error load() override {
+    if (is_method_loaded()) {
+      return Error::Ok;
+    }
+    ET_CHECK_OK_OR_RETURN_ERROR(module_->load_method(kImageEncoderMethod));
+    ET_CHECK_OK_OR_RETURN_ERROR(module_->load_method(kTextModelMethod));
+    return Error::Ok;
+  }
+
+  /**
+   * Check if the required methods in the Module is loaded.
+   * @return True if the Module is loaded, false otherwise.
+   */
+  inline bool is_method_loaded() override {
+    Result<std::unordered_set<std::string>> methods_res =
+        module_->method_names();
+    if (methods_res.error() != Error::Ok) {
+      ET_CHECK_MSG(false, "Failed to get method names");
+    }
+    std::unordered_set<std::string> methods = methods_res.get();
+    bool methods_exist = methods.find(kImageEncoderMethod) != methods.end() &&
+        methods.find(kTextModelMethod) != methods.end();
+    if (!methods_exist) {
+      for (const auto& method : methods) {
+        ET_LOG(Error, "Method: %s", method.c_str());
+      }
+      ET_CHECK_MSG(
+          methods_exist,
+          "Missing required methods (%s, %s) in the model",
+          kImageEncoderMethod.c_str(),
+          kTextModelMethod.c_str());
+    }
+    bool methods_loaded = module_->is_method_loaded(kImageEncoderMethod) &&
+        module_->is_method_loaded(kTextModelMethod);
+    return methods_loaded;
+  }
+
+  inline static const std::string kImageEncoderMethod = "image_encoder";
+  inline static const std::string kTextModelMethod = "text_model";
 };
 
 } // namespace torch::executor

--- a/examples/models/llava/runner/llava_text_decoder_runner.h
+++ b/examples/models/llava/runner/llava_text_decoder_runner.h
@@ -19,19 +19,19 @@ class LlavaTextDecoderRunner : public TextDecoderRunner {
   LlavaTextDecoderRunner(Module* module, int32_t vocab_size, float temperature)
       : TextDecoderRunner(module, true, vocab_size, temperature){};
 
-  Result<exec_aten::Tensor> step(
+  inline Result<exec_aten::Tensor> step(
       ManagedTensor& managed_tokens,
-      ManagedTensor& managed_start_pos) {
+      ManagedTensor& managed_start_pos) override {
     auto tokens = managed_tokens.get_aliasing_tensor();
     auto start_pos = managed_start_pos.get_aliasing_tensor();
 
     // run token embedding
     std::vector<EValue> token_embedding_outputs =
-        ET_UNWRAP(module_->execute("token_embedding", {tokens}));
+        ET_UNWRAP(module_->execute(kTokenEmbeddingMethod, {tokens}));
 
     // run text model
     std::vector<EValue> outputs_res = ET_UNWRAP(module_->execute(
-        "text_decoder", {start_pos, token_embedding_outputs[0]}));
+        kTextModelMethod, {start_pos, token_embedding_outputs[0]}));
 
     ET_CHECK_MSG(
         outputs_res.size() == 1,
@@ -43,6 +43,50 @@ class LlavaTextDecoderRunner : public TextDecoderRunner {
     // Return the logits tensor
     return outputs_res[0].toTensor();
   }
+
+  /**
+   * Load the Module for text decode purpose.
+   * @return The error code.
+   */
+  inline Error load() override {
+    if (is_method_loaded()) {
+      return Error::Ok;
+    }
+    ET_CHECK_OK_OR_RETURN_ERROR(module_->load_method(kTokenEmbeddingMethod));
+    ET_CHECK_OK_OR_RETURN_ERROR(module_->load_method(kTextModelMethod));
+    return Error::Ok;
+  }
+
+  /**
+   * Check if the required methods in the Module is loaded.
+   * @return True if the Module is loaded, false otherwise.
+   */
+  inline bool is_method_loaded() override {
+    Result<std::unordered_set<std::string>> methods_res =
+        module_->method_names();
+    if (methods_res.error() != Error::Ok) {
+      ET_CHECK_MSG(false, "Failed to get method names");
+    }
+    std::unordered_set<std::string> methods = methods_res.get();
+    bool methods_exist = methods.find(kTokenEmbeddingMethod) != methods.end() &&
+        methods.find(kTextModelMethod) != methods.end();
+    if (!methods_exist) {
+      for (const auto& method : methods) {
+        ET_LOG(Error, "Method: %s", method.c_str());
+      }
+      ET_CHECK_MSG(
+          methods_exist,
+          "Missing required methods (%s, %s) in the model",
+          kTokenEmbeddingMethod.c_str(),
+          kTextModelMethod.c_str());
+    }
+    bool methods_loaded = module_->is_method_loaded(kTokenEmbeddingMethod) &&
+        module_->is_method_loaded(kTextModelMethod);
+    return methods_loaded;
+  }
+
+  inline static const std::string kTokenEmbeddingMethod = "token_embedding";
+  inline static const std::string kTextModelMethod = "text_model";
 };
 
 } // namespace torch::executor

--- a/examples/models/llava/test/test_pte.py
+++ b/examples/models/llava/test/test_pte.py
@@ -1,0 +1,86 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+
+import torch
+
+from executorch.examples.models.llava.model import LlavaModel
+from executorch.extension.pybindings.portable_lib import _load_for_executorch
+
+# Custom ops has to be loaded after portable_lib.
+# I don't know how to stop UFMT so I'm just using if True: to avoid lint error
+if True:
+    from executorch.extension.llm.custom_ops import sdpa_with_kv_cache  # noqa
+
+
+def main():
+    args = sys.argv[1:]
+    llava_module = _load_for_executorch(args[0])
+
+    llava_model = LlavaModel()
+
+    prompt_before_image, resized, prompt_after_image = (
+        llava_model.get_inputs_for_prefill()
+    )
+
+    start_pos = 0
+    # pte prefill prompt before img
+    pte_embeds_before_img = llava_module.run_method(
+        "token_embedding", (prompt_before_image,)
+    )[0]
+    pte_prefill_before_img = llava_module.run_method(
+        "text_model",
+        (torch.tensor([start_pos], dtype=torch.int64), pte_embeds_before_img),
+    )[0]
+    print(pte_prefill_before_img)
+
+    start_pos += pte_prefill_before_img.shape[1]
+
+    # pte prefill image
+    pte_embeds_img = llava_module.run_method("image_encoder", (resized,))[0]
+    pte_prefill_img = llava_module.run_method(
+        "text_model",
+        (
+            torch.tensor([start_pos], dtype=torch.int64),
+            pte_embeds_img,
+        ),
+    )[0]
+    print(pte_prefill_img)
+
+    start_pos += pte_prefill_img.shape[1]
+
+    # pte prefill prompt after img
+    pte_embeds_after_img = llava_module.run_method(
+        "token_embedding", (prompt_after_image,)
+    )[0]
+    pte_prefill_after_img = llava_module.run_method(
+        "text_model",
+        (torch.tensor([start_pos], dtype=torch.int64), pte_embeds_after_img),
+    )[0]
+    print(pte_prefill_after_img)
+
+    # being tested, using llama_transformer
+    new_tokens = [torch.argmax(pte_prefill_after_img[..., -1, :]).item()]
+    for i in range(4):
+        print(i, llava_model.tokenizer.decode(new_tokens[i]))
+        token_embeds = llava_module.run_method(
+            "token_embedding", (torch.tensor([[new_tokens[i]]], dtype=torch.int64),)
+        )[0]
+        logits = llava_module.run_method(
+            "text_model",
+            (torch.tensor([start_pos + i], dtype=torch.int64), token_embeds),
+        )[0]
+        new_tokens.append(torch.argmax(logits[..., -1, :]).item())
+
+    outputs = llava_model.tokenizer.batch_decode(
+        torch.tensor([new_tokens]), skip_special_tokens=True
+    )[0].strip()
+    print(outputs)
+
+
+if __name__ == "__main__":
+    main()

--- a/extension/llm/runner/image_prefiller.h
+++ b/extension/llm/runner/image_prefiller.h
@@ -29,6 +29,9 @@ class ImagePrefiller {
       Image& image,
       int64_t start_pos = 0) = 0;
 
+  virtual Error load() = 0;
+  virtual bool is_method_loaded() = 0;
+
  protected:
   Module* module_;
 };

--- a/extension/llm/runner/text_decoder_runner.h
+++ b/extension/llm/runner/text_decoder_runner.h
@@ -25,6 +25,9 @@ class TextDecoderRunner {
       bool use_kv_cache,
       int32_t vocab_size,
       float temperature);
+
+  virtual ~TextDecoderRunner() = default;
+
   /**
    * Run LLM text decoder with inputs to generate next token.
    * @param input The input to the LLM Module.
@@ -32,25 +35,24 @@ class TextDecoderRunner {
    * Module.
    * @return The output of the LLM Module. This will be a tensor of logits.
    */
-  Result<exec_aten::Tensor> step(
+  virtual Result<exec_aten::Tensor> step(
       ManagedTensor& input,
       ManagedTensor& start_pos);
 
   /**
-   * Load the Module for a given method name.
-   * @param method_name The name of the method to load.
+   * Load the Module for text decode purpose.
    * @return The error code.
    */
-  inline Error load(const std::string& method_name = "forward") {
-    return module_->load_method(method_name);
+  virtual Error load() {
+    return module_->load_method("forward");
   }
 
   /**
-   * Check if the Module is loaded.
+   * Check if the required methods in the Module is loaded.
    * @return True if the Module is loaded, false otherwise.
    */
-  inline bool is_method_loaded(const std::string& method_name = "forward") {
-    return module_->is_method_loaded(method_name);
+  virtual bool is_method_loaded() {
+    return module_->is_method_loaded("forward");
   }
 
   inline void stop() {

--- a/extension/llm/runner/text_prefiller.cpp
+++ b/extension/llm/runner/text_prefiller.cpp
@@ -61,7 +61,7 @@ Result<uint64_t> TextPrefiller::prefill(
     uint64_t cur;
     for (int i = 0; i < prompt_tokens.size(); i++) {
       cur = prompt_tokens[i];
-      if (cur != tokenizer_->bos_tok()) {
+      if (token_callback && cur != tokenizer_->bos_tok()) {
         token_callback(ET_UNWRAP(tokenizer_->decode(prev, cur)));
       }
       prev = cur;


### PR DESCRIPTION
Summary:


Add a `main.cpp` and CMakeLists.txt for llava runner. This runner takes in an image in the format of `.pt` (a serialized pytorch model) along with text prompt. It will generate text tokens in a way similar to llama runner.

Run `build.sh` to build the runner.

To serialize the image into a `.pt` file, run the following script:

```python
import torch
from torch import nn

copy = torch.tensor(resized)
m = nn.Module()
par = nn.Parameter(copy, requires_grad=False)
m.register_parameter("0",par)
tensors = torch.jit.script(m)
tensors.save("image.pt")
```

To run the runner, use the following command:

```
cmake-out/examples/models/llava/llava_main                                                               \
    --tokenizer_path tokenizer.bin                                                                                    \
    --model_path llava_kv_768.pte                                                                                  \
    --prompt "\nWhat are the things I should be cautious about when I visit here?"  \
    --image_path image.pt                                                                                                \
    --temperature 0
```


imported-using-ghimport

Test Plan: Imported from OSS

Reviewed By: kirklandsign

Differential Revision: D61146432

Pulled By: larryliu0820


