### PR TITLE
Fix copying of state dict

### DIFF
--- a/exir/program/_fake_program.py
+++ b/exir/program/_fake_program.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 import copy
 from typing import Dict, Union
 
@@ -61,4 +63,5 @@ def update_to_real_program(
     """Update the fake exported program to point to the real state dict. Modifies the
     fake exported program in-place.
     """
-    fake_exported_program._state_dict = real_exported_program.state_dict
+    for k, v in real_exported_program.state_dict.items():
+        fake_exported_program._state_dict[k] = v

--- a/exir/program/test/test_fake_program.py
+++ b/exir/program/test/test_fake_program.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
 
 import sys
 import unittest
@@ -73,4 +74,6 @@ class TestFakeProgram(unittest.TestCase):
 
         update_to_real_program(fake_program, exported_program)
         self.assertEqual(exported_program.state_dict, fake_program.state_dict)
-        self.assertEqual(id(exported_program.state_dict), id(fake_program.state_dict))
+        self.assertEqual(
+            exported_program.state_dict.keys(), fake_program.state_dict.keys()
+        )


### PR DESCRIPTION
Summary: We dont want to directly reference the original state dict, since delegation will remove values from this state dict when delegates consume params/buffers.

Differential Revision: D61400273
