### PR TITLE
Enable MKL on x86 to get around long-context discrepancies with torch.nn.functional.scaled_dot_product_attention

### DIFF
--- a/extension/llm/custom_ops/targets.bzl
+++ b/extension/llm/custom_ops/targets.bzl
@@ -6,47 +6,48 @@ def define_common_targets():
     The directory containing this targets.bzl file should also contain both
     TARGETS and BUCK files that call this function.
     """
-    runtime.cxx_library(
-        name = "custom_ops",
-        srcs = ["op_sdpa.cpp"],
-        exported_headers = ["op_sdpa.h"],
-        exported_deps = [
-            "//executorch/runtime/kernel:kernel_includes",
-            "//executorch/kernels/portable/cpu:scalar_utils",
-            "//executorch/kernels/optimized:libblas",
-            "//executorch/kernels/optimized:libvec",
-            "//executorch/extension/kernel_util:kernel_util",
-            "//executorch/extension/parallel:thread_parallel",
-            "//executorch/backends/xnnpack/threadpool:threadpool",
-        ],
-        compiler_flags = ["-Wno-missing-prototypes", "-Wno-global-constructors"],
-        visibility = [
-            "//executorch/...",
-            "//executorch/extension/llm/custom_ops/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
-        # @lint-ignore BUCKLINT link_whole
-        link_whole = True,
-        force_static = True,
-    )
+    for mkl_dep in ["", "_mkl_lp64_omp"]:
+        runtime.cxx_library(
+            name = "custom_ops" + mkl_dep,
+            srcs = ["op_sdpa.cpp"],
+            exported_headers = ["op_sdpa.h"],
+            exported_deps = [
+                "//executorch/runtime/kernel:kernel_includes",
+                "//executorch/kernels/portable/cpu:scalar_utils",
+                "//executorch/kernels/optimized:libblas{}".format(mkl_dep),
+                "//executorch/kernels/optimized:libvec",
+                "//executorch/extension/kernel_util:kernel_util",
+                "//executorch/extension/parallel:thread_parallel",
+                "//executorch/backends/xnnpack/threadpool:threadpool",
+            ],
+            compiler_flags = ["-Wno-missing-prototypes", "-Wno-global-constructors"],
+            visibility = [
+                "//executorch/...",
+                "//executorch/extension/llm/custom_ops/...",
+                "@EXECUTORCH_CLIENTS",
+            ],
+            # @lint-ignore BUCKLINT link_whole
+            link_whole = True,
+            force_static = True,
+        )
 
-    runtime.cxx_library(
-        name = "custom_ops_aot_lib",
-        srcs = [
-            "op_sdpa_aot.cpp",
-        ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
-        external_deps = [
-            "libtorch",
-        ],
-        deps = [
-            ":custom_ops",
-            "//executorch/extension/aten_util:aten_bridge",
-        ],
-    )
+        runtime.cxx_library(
+            name = "custom_ops_aot_lib" + mkl_dep,
+            srcs = [
+                "op_sdpa_aot.cpp",
+            ],
+            visibility = [
+                "//executorch/...",
+                "@EXECUTORCH_CLIENTS",
+            ],
+            external_deps = [
+                "libtorch",
+            ],
+            deps = [
+                ":custom_ops" + mkl_dep,
+                "//executorch/extension/aten_util:aten_bridge",
+            ],
+        )
 
     runtime.python_library(
         name = "custom_ops_aot_py",


### PR DESCRIPTION
Summary:
When used with longer kv caches with a wider dynamic range, sdpa_with_kv_cache produces a non-trivial numerical error on x86: ~2e-4 on the 130-length unit test, more with real-world tensors.

Switching ::executorch::cpublas::gemm to MKL reduces the error to ~3e-07 for mid-range context lengths (130 in these tests).

On the longer length llava tests there's still an error of 1.4e-4.

Differential Revision: D61290864
