### PR TITLE
[ET-VK] Introduce copy constructor for vTensor to allow for zero-copy operators

### DIFF
--- a/backends/vulkan/runtime/api/containers/Tensor.h
+++ b/backends/vulkan/runtime/api/containers/Tensor.h
@@ -87,7 +87,19 @@ class vTensorStorage final {
       const vkapi::ScalarType dtype,
       const bool allocate_memory = true);
 
-  vTensorStorage(const vTensorStorage& other) = delete;
+ protected:
+  /*
+   * This allows for creation of tensors that use the same underlying storage
+   * as another tensor. Note that this functionality is currently enabled for
+   * tensors that have buffer storage only. The created tensor will not have
+   * ownership of the underlying VkBuffer. This constructor is marked protected
+   * because this behaviour is unsafe, since the original tensor may be
+   * destroyed before the copy is destroyed.
+   */
+  vTensorStorage(const vTensorStorage& other, const size_t buffer_offset = 0);
+
+ public:
+  // To discourage creating copies, the assignment operator is still deleted.
   vTensorStorage& operator=(const vTensorStorage& other) = delete;
 
   vTensorStorage(vTensorStorage&& other) = default;
@@ -157,6 +169,22 @@ class vTensor final {
 
   vTensor(const vTensor& other) = delete;
   vTensor& operator=(const vTensor& other) = delete;
+
+  /*
+   * This constructor allows for the creation of a vTensor that references the
+   * same buffer resource of another vTensor, but with different sizes and
+   * strides metatdata. The created vTensor will not own the underlying
+   * resource. This is only applicable for buffer backed tensors at the moment.
+   *
+   * The offset_numel argument allows the aliased tensor's memory region to
+   * begin at an offset of N elements from the start of the original tensor's
+   * buffer.
+   */
+  vTensor(
+      const vTensor& other,
+      const std::vector<int64_t>& sizes,
+      const std::vector<int64_t>& strides,
+      const size_t offset_numel = 0);
 
   vTensor(vTensor&& other) = default;
   vTensor& operator=(vTensor&& other) = default;

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -203,6 +203,17 @@ ValueRef ComputeGraph::add_tensor(
       sizes, dtype, suggested_memory_layout(sizes), shared_object_idx);
 }
 
+ValueRef ComputeGraph::add_tensor_view(
+    const ValueRef vref,
+    const std::vector<int64_t>& sizes,
+    const std::vector<int64_t>& strides,
+    const size_t offset_numel) {
+  const vTensorPtr t = get_tensor(vref);
+  ValueRef idx(static_cast<int>(values_.size()));
+  values_.emplace_back(api::vTensor(*t, sizes, strides, offset_numel));
+  return idx;
+}
+
 ValueRef ComputeGraph::add_tensorref(
     const std::vector<int64_t>& sizes,
     const vkapi::ScalarType dtype,

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -352,6 +352,17 @@ class ComputeGraph final {
       const utils::GPUMemoryLayout memory_layout);
 
   /*
+   * Use the copy constructor of `api::vTensor` to create a "view" of the
+   * `vTensor` value at `vref`. See the copy constructor of `api::vTensor` for
+   * more details.
+   */
+  ValueRef add_tensor_view(
+      const ValueRef vref,
+      const std::vector<int64_t>& sizes,
+      const std::vector<int64_t>& strides,
+      const size_t offset_numel = 0);
+
+  /*
    * Add a `TensorRef` value to the graph with the specific properties. A
    * `TensorRef` is a reference to a `api::vTensor` whose data is stored in an
    * external CPU buffer.

--- a/backends/vulkan/runtime/vk_api/memory/Allocation.cpp
+++ b/backends/vulkan/runtime/vk_api/memory/Allocation.cpp
@@ -29,7 +29,8 @@ Allocation::Allocation()
     : memory_requirements{},
       create_info{},
       allocator(VK_NULL_HANDLE),
-      allocation(VK_NULL_HANDLE) {}
+      allocation(VK_NULL_HANDLE),
+      is_copy_(false) {}
 
 Allocation::Allocation(
     VmaAllocator vma_allocator,
@@ -38,16 +39,25 @@ Allocation::Allocation(
     : memory_requirements(mem_props),
       create_info(create_info),
       allocator(vma_allocator),
-      allocation(VK_NULL_HANDLE) {
+      allocation(VK_NULL_HANDLE),
+      is_copy_(false) {
   VK_CHECK(vmaAllocateMemory(
       allocator, &memory_requirements, &create_info, &allocation, nullptr));
 }
+
+Allocation::Allocation(const Allocation& other) noexcept
+    : memory_requirements(other.memory_requirements),
+      create_info(other.create_info),
+      allocator(other.allocator),
+      allocation(other.allocation),
+      is_copy_(true) {}
 
 Allocation::Allocation(Allocation&& other) noexcept
     : memory_requirements(other.memory_requirements),
       create_info(other.create_info),
       allocator(other.allocator),
-      allocation(other.allocation) {
+      allocation(other.allocation),
+      is_copy_(other.is_copy_) {
   other.allocation = VK_NULL_HANDLE;
 }
 
@@ -58,6 +68,7 @@ Allocation& Allocation::operator=(Allocation&& other) noexcept {
   create_info = other.create_info;
   allocator = other.allocator;
   allocation = other.allocation;
+  is_copy_ = other.is_copy_;
 
   other.allocation = tmp_allocation;
 
@@ -65,7 +76,10 @@ Allocation& Allocation::operator=(Allocation&& other) noexcept {
 }
 
 Allocation::~Allocation() {
-  if (VK_NULL_HANDLE != allocation) {
+  // Do not destroy the VmaAllocation if this class instance is a copy of some
+  // other class instance, since this means that this class instance does not
+  // have ownership of the underlying resource.
+  if (VK_NULL_HANDLE != allocation && !is_copy_) {
     vmaFreeMemory(allocator, allocation);
   }
 }

--- a/backends/vulkan/runtime/vk_api/memory/Allocation.h
+++ b/backends/vulkan/runtime/vk_api/memory/Allocation.h
@@ -31,7 +31,23 @@ struct Allocation final {
       const VkMemoryRequirements&,
       const VmaAllocationCreateInfo&);
 
-  Allocation(const Allocation&) = delete;
+ protected:
+  /*
+   * The Copy constructor allows for creation of a class instance that are
+   * "aliases" of another class instance. The resulting class instance will not
+   * have ownership of the underlying VmaAllocation.
+   *
+   * This behaviour is analogous to creating a copy of a pointer, thus it is
+   * unsafe, as the original class instance may be destroyed before the copy.
+   * These constructors are therefore marked protected so that they may be used
+   * only in situations where the lifetime of the original class instance is
+   * guaranteed to exceed, or at least be the same as, the lifetime of the
+   * copied class instance.
+   */
+  Allocation(const Allocation&) noexcept;
+
+ public:
+  // To discourage creating copies, the assignment operator is still deleted.
   Allocation& operator=(const Allocation&) = delete;
 
   Allocation(Allocation&&) noexcept;
@@ -47,9 +63,21 @@ struct Allocation final {
   // Handles to the allocated memory
   VmaAllocation allocation;
 
+ private:
+  // Indicates whether this class instance is a copy of another class instance,
+  // in which case it does not have ownership of the underlying VmaAllocation
+  bool is_copy_;
+
+ public:
   operator bool() const {
     return (allocation != VK_NULL_HANDLE);
   }
+
+  inline bool is_copy() const {
+    return is_copy_;
+  }
+
+  friend class VulkanBuffer;
 };
 
 } // namespace vkapi

--- a/backends/vulkan/test/glsl/reference_matmul.glsl
+++ b/backends/vulkan/test/glsl/reference_matmul.glsl
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+
+#define PRECISION highp
+
+layout(std430) buffer;
+
+${layout_declare_tensor(0, "w", "t_out", "float", "buffer")}
+${layout_declare_tensor(1, "r", "t_mat1", "float", "buffer")}
+${layout_declare_tensor(2, "r", "t_mat2", "float", "buffer")}
+${layout_declare_ubo(3, "ivec4", "out_sizes")}
+${layout_declare_ubo(4, "ivec4", "out_strides")}
+${layout_declare_ubo(5, "ivec4", "mat1_sizes")}
+${layout_declare_ubo(6, "ivec4", "mat1_strides")}
+${layout_declare_ubo(7, "ivec4", "mat2_sizes")}
+${layout_declare_ubo(8, "ivec4", "mat2_strides")}
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec2 out_idx = ivec2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y);
+  if (any(greaterThanEqual(out_idx, out_sizes.xy))) {
+    return;
+  }
+
+  // Initial idx for mat1 is (0, out_idx.y)
+  int mat1_id = out_idx.y * mat1_strides.y;
+  // Initial idx for mat2 is (out_idx.x, 0)
+  int mat2_id = out_idx.x * mat2_strides.x;
+
+  float sum = 0.0;
+  for (int i = 0; i < mat1_sizes.x; ++i) {
+    sum += t_mat1[mat1_id] * t_mat2[mat2_id];
+
+    mat1_id += mat1_strides.x;
+    mat2_id += mat2_strides.y;
+  }
+
+  const int out_id = out_idx.x * out_strides.x + out_idx.y * out_strides.y;
+  t_out[out_id] = sum;
+}

--- a/backends/vulkan/test/utils/test_utils.h
+++ b/backends/vulkan/test/utils/test_utils.h
@@ -115,6 +115,12 @@ void record_scalar_add_buffer(
     api::vTensor& v_ten,
     float offset);
 
+void record_reference_matmul(
+    api::Context* context,
+    api::vTensor& out,
+    api::vTensor& mat1,
+    api::vTensor& mat2);
+
 //
 // Input & Output Utilities
 //
@@ -132,6 +138,11 @@ fill_staging(api::StorageBuffer& staging, float val, int numel = -1) {
 void fill_vtensor(api::vTensor& vten, std::vector<float>& data);
 
 void fill_vtensor(api::vTensor& vten, float val, bool iota = false);
+
+std::vector<float> create_random_float_buffer(
+    const size_t numel,
+    const float min = 0,
+    const float max = 1);
 
 void fill_vtensor(
     ComputeGraph& graph,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4768

## Context

For buffer-backed tensors, orchestration operators such as slicing, transposition, views, etc. can be implemented by creating a new tensor that uses the same storage as another tensor, but with different metadata (i.e. sizes and strides).

This diff implements copy constructors for the `Allocation`, `VulkanBuffer`, and `vTensor` classes which enable the aforementioned behaviour. Class instances created from copy constructors do not own the underlying memory resource, hence the resource will not be freed upon destruction of the class instance. Note that this behaviour is similar to copying a pointer in C/C++, and is inherently unsafe because the original resource may be destroyed before the copy.

However, in practice this is not much of a concern, because tensors must be kept alive for the duration of inference, thus all tensors created during model inference will have the same lifetime. However, it does pose a problem for memory planned tensors, since from the memory planner's perspective the lifetime of the original tensor may be shorter than the aliased tensor, thus the shared memory may be overwritten by other tensors using the same allocation. **Therefore this behaviour is not yet safe to use when memory planning is enabled; additional work will be needed on the export side to make sure aliased tensors have the same lifetime as the original tensor**.

## Why not use shared_ptr?

In the past, this behaviour was enabled by `vTensor` instances storing their `vTensorStorage` classes via a `shared_ptr`. This was a safer design, since `shared_ptr` would handle resource management of the underlying buffer or texture resource.

However, I decided not to go with `shared_ptr` design because of the overhead involved in making a heap allocation whenever a vTensor is constructed, and the subsequent pointer chasing required whenever data is accessed from a vTensor. It seemed too big a cost to pay, especially considering tensor aliasing only really makes sense for buffer-backed tensors (thus it is not expected to be a common occurrence).

Also, as mentioned above the lifetime of all created `vTensor` instances tend to have the same lifetime in practice, especially in the context of the `ComputeGraph` class. Also, the `shared_ptr` design would still encounter the problem with memory planning.

Differential Revision: [D61395177](https://our.internmc.facebook.com/intern/diff/D61395177/)