### PR TITLE
Allow multiple eos ids

### DIFF
--- a/examples/models/llama2/README.md
+++ b/examples/models/llama2/README.md
@@ -127,7 +127,7 @@ You can export and run the original Llama 3 8B instruct model.
 
 2. Export model and generate `.pte` file
     ```
-    python -m examples.models.llama2.export_llama --checkpoint <consolidated.00.pth> -p <params.json> -kv --use_sdpa_with_kv_cache -X -qmode 8da4w  --group_size 128 -d fp32 --metadata '{"get_bos_id":128000, "get_eos_id":128001}' --embedding-quantize 4,32 --output_name="llama3_kv_sdpa_xnn_qe_4_32.pte"
+    python -m examples.models.llama2.export_llama --checkpoint <consolidated.00.pth> -p <params.json> -kv --use_sdpa_with_kv_cache -X -qmode 8da4w  --group_size 128 -d fp32 --metadata '{"get_bos_id":128000, "get_eos_ids":[128009, 128001]}' --embedding-quantize 4,32 --output_name="llama3_kv_sdpa_xnn_qe_4_32.pte"
     ```
 
     Due to the larger vocabulary size of Llama 3, we recommend quantizing the embeddings with `--embedding-quantize 4,32` as shown above to further reduce the model size.

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -562,16 +562,8 @@ def _load_llama_model_metadata(
     is_fairseq2 = weight_type == WeightType.FAIRSEQ2
     metadata = {
         "append_eos_to_prompt": is_fairseq2,  # For language llama, tell the runtime to always append EOS token(s) to prompt.
-        "get_bos_id": (
-            model_args.bos_idx
-            if model_args.bos_idx is not None
-            else (3 if is_fairseq2 else 1)
-        ),
-        "get_eos_id": (
-            model_args.eos_idx
-            if model_args.eos_idx is not None
-            else (3 if is_fairseq2 else 2)
-        ),
+        "get_bos_id": 3 if is_fairseq2 else 1,
+        "get_eos_ids": [3] if is_fairseq2 else [2],
         "get_max_seq_len": model_args.max_seq_len,
         "get_n_bos": 1,
         "get_n_eos": 2 if is_fairseq2 else 1,

--- a/examples/models/llama2/llama_transformer.py
+++ b/examples/models/llama2/llama_transformer.py
@@ -104,8 +104,8 @@ class ModelArgs:
     rope_freq_base: float = 10000.0  # The base frequency for RoPE. Keep it for BC.
     use_scaled_rope: bool = False  # Use scaled RoPE, introduced in llama3.1.
     # Additional Model Metadata needed at runtime
-    bos_idx: Optional[int] = None
-    eos_idx: Optional[int] = None
+    bos_idx: int = 1
+    eos_idx: int = 3
     bos_count: int = -1  # i.e., a single EOS is used as BOS
     eos_count: int = 2
 

--- a/examples/models/llava/runner/llava_runner.cpp
+++ b/examples/models/llava/runner/llava_runner.cpp
@@ -63,7 +63,8 @@ Error LlavaRunner::load() {
       tokenizer_.get(),
       text_decoder_runner_.get(),
       /*use_kv_cache=*/true,
-      tokenizer_->eos_tok(),
+      std::make_unique<std::unordered_set<uint64_t>>(
+          std::unordered_set<uint64_t>{tokenizer_->eos_tok()}),
       &stats_);
 
   stats_.model_load_end_ms = util::time_in_ms();

--- a/extension/llm/runner/text_token_generator.h
+++ b/extension/llm/runner/text_token_generator.h
@@ -22,11 +22,11 @@ class TextTokenGenerator {
       Tokenizer* tokenizer,
       TextDecoderRunner* text_decoder_runner,
       bool use_kv_cache,
-      uint64_t eos_id,
+      std::unique_ptr<std::unordered_set<uint64_t>>&& eos_ids,
       Stats* stats)
       : tokenizer_(tokenizer),
         text_decoder_runner_(text_decoder_runner),
-        eos_id_(eos_id),
+        eos_ids_(std::move(eos_ids)),
         use_kv_cache_(use_kv_cache),
         stats_(stats) {}
 
@@ -108,7 +108,7 @@ class TextTokenGenerator {
       }
 
       // data-dependent terminating condition: we have n_eos_ number of EOS
-      if (cur_token == eos_id_) {
+      if (eos_ids_->find(cur_token) != eos_ids_->end()) {
         printf("\n");
         ET_LOG(Info, "\nReached to the end of generation");
         break;
@@ -127,7 +127,7 @@ class TextTokenGenerator {
  private:
   Tokenizer* tokenizer_;
   TextDecoderRunner* text_decoder_runner_;
-  uint64_t eos_id_;
+  std::unique_ptr<std::unordered_set<uint64_t>> eos_ids_;
   bool use_kv_cache_;
 
   // state machine


### PR DESCRIPTION
Summary:
Since llama 3, it could have two eos ids:
```
<end_of_text>
<eot_id>
```
This PR updates the export and runner to allow passing multiple eos ids.

It also fixes `text_token_generator` to not print eos.

Differential Revision: D61420500
