### PR TITLE
prototype

### DIFF
--- a/examples/models/phi-3-mini/CMakeLists.txt
+++ b/examples/models/phi-3-mini/CMakeLists.txt
@@ -18,7 +18,7 @@ project(phi_3_mini_runner)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_BUILD_TYPE Debug)
 
 # Set options for executorch build.
 option(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER "" ON)

--- a/examples/models/phi-3-mini/example.py
+++ b/examples/models/phi-3-mini/example.py
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import argparse
+
+import torch.nn
+
+from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
+from executorch.backends.xnnpack.utils.configs import get_xnnpack_edge_compile_config
+from executorch.exir import ExecutorchBackendConfig, to_edge
+
+from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
+from executorch.exir.passes.memory_planning_pass import MemoryPlanningPass
+
+
+class ExampleModel(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(
+        self,
+        input_token: torch.LongTensor = None,
+        input_pos: torch.LongTensor = None,
+        kv_cache: torch.LongTensor = None,
+    ) -> torch.LongTensor:
+        pos = input_pos[-1].item()
+        torch._check_is_size(pos)
+        torch._check(pos < kv_cache.shape[1])
+        narrowed_kv_cache = kv_cache.narrow(1, pos, 1)
+        narrowed_kv_cache.copy_(input_token)
+        return narrowed_kv_cache
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    with torch.no_grad():
+        model = ExampleModel()
+        example_inputs = (
+            torch.tensor([[3]], dtype=torch.long),
+            torch.tensor([0], dtype=torch.long),
+            torch.tensor([[1, 2]], dtype=torch.long),
+        )
+        dynamic_shapes = {
+            "input_token": {
+                0: 1,
+                1: 1,
+            },
+            "input_pos": {0: 1},
+            "kv_cache": {1: torch.export.Dim("sequence_length", min=1, max=128)},
+        }
+
+        model = torch.export.export(
+            model, example_inputs, dynamic_shapes=dynamic_shapes
+        )
+        edge_manager = to_edge(model, compile_config=get_xnnpack_edge_compile_config())
+        edge_manager = edge_manager.to_backend(XnnpackPartitioner())
+        et_program = edge_manager.to_executorch(
+            config=ExecutorchBackendConfig(
+                sym_shape_eval_pass=ConstraintBasedSymShapeEvalPass(),
+                memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False)
+            )
+        )
+
+        with open("example.pte", "wb") as file:
+            file.write(et_program.buffer)
+
+
+def main2():
+    kv_cache = torch.zeros((1, 10), dtype=torch.long)
+    model = ExampleModel()
+    for i in range(10):
+        print(
+            model.forward(
+                input_token=torch.tensor([[i + 1]]),
+                input_pos=torch.tensor([i]),
+                kv_cache=kv_cache,
+            )
+        )
+    print(kv_cache)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-e",
+        "--export",
+        default=False,
+        action="store_true",
+        help="Whether or not to export",
+    )
+    args = parser.parse_args()
+    if args.export:
+        main()
+    else:
+        main2()

--- a/examples/models/phi-3-mini/example2.py
+++ b/examples/models/phi-3-mini/example2.py
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import argparse
+from pprint import pprint
+
+import torch.nn
+
+from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
+from executorch.backends.xnnpack.utils.configs import get_xnnpack_edge_compile_config
+from executorch.exir import to_edge, ExecutorchBackendConfig
+
+from executorch.exir.passes.memory_planning_pass import MemoryPlanningPass
+
+
+class ExampleModel(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(
+        self,
+        x: torch.LongTensor,
+        y: torch.LongTensor,
+    ):
+        x.copy_(y)
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    with torch.no_grad():
+        model = ExampleModel()
+        example_inputs = (
+            torch.zeros((1, 10), dtype=torch.long),
+            torch.ones((1, 10), dtype=torch.long)
+        )
+
+        model = torch.export.export(
+            model, example_inputs, strict=False
+        )
+        print(model)
+        edge_manager = to_edge(model, compile_config=get_xnnpack_edge_compile_config())
+        print("Graph:")
+        print(edge_manager.exported_program().graph_module.graph)
+        print("Graph signature:")
+        pprint(edge_manager.exported_program().graph_signature)
+        edge_manager = edge_manager.to_backend(XnnpackPartitioner())
+        et_program = edge_manager.to_executorch(
+            config=ExecutorchBackendConfig(
+                memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False)
+            )
+        )
+        print("ExecuTorch program:")
+        pprint(et_program.executorch_program)
+        print("Graph:")
+        print(et_program.exported_program().graph_module.graph)
+        print("Graph signature:")
+        pprint(et_program.exported_program().graph_signature)
+
+
+        with open("example2.pte", "wb") as file:
+            file.write(et_program.buffer)
+
+
+def main2():
+    x = torch.zeros((1, 10), dtype=torch.long)
+    y = torch.ones((1, 10), dtype=torch.long)
+    model = ExampleModel()
+    model.forward(x, y)
+    print(f"x: {x}")
+    print(f"y: {y}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-e",
+        "--export",
+        default=True,
+        action="store_true",
+        help="Whether or not to export",
+    )
+    args = parser.parse_args()
+    if args.export:
+        main()
+    else:
+        main2()

--- a/examples/models/phi-3-mini/main.cpp
+++ b/examples/models/phi-3-mini/main.cpp
@@ -6,45 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <gflags/gflags.h>
-
 #include <executorch/examples/models/phi-3-mini/runner.h>
 
-DEFINE_string(
-    model_path,
-    "phi-3-mini.pte",
-    "File path for model serialized in flatbuffer format.");
-
-DEFINE_string(tokenizer_path, "tokenizer.bin", "File path for tokenizer.");
-
-DEFINE_string(prompt, "Tell me a story", "Prompt.");
-
-DEFINE_double(
-    temperature,
-    0.8f,
-    "Temperature; Default is 0.8f. 0 = greedy argmax sampling (deterministic). Lower temperature = more deterministic");
-
-DEFINE_int32(
-    seq_len,
-    128,
-    "Total number of tokens to generate (prompt + output).");
-
 int main(int32_t argc, char** argv) {
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  const char* model_path =
+      "/home/lunwenh/executorch/examples/models/phi-3-mini/example.pte";
 
-  const char* model_path = FLAGS_model_path.c_str();
+  ::torch::executor::Runner runner(model_path);
 
-  const char* tokenizer_path = FLAGS_tokenizer_path.c_str();
-
-  const char* prompt = FLAGS_prompt.c_str();
-
-  double temperature = FLAGS_temperature;
-
-  int32_t seq_len = FLAGS_seq_len;
-
-  ::torch::executor::Runner runner(model_path, tokenizer_path, temperature);
-
-  runner.generate(prompt, seq_len);
+  runner.generate();
 
   return 0;
 }

--- a/examples/models/phi-3-mini/runner.cpp
+++ b/examples/models/phi-3-mini/runner.cpp
@@ -17,93 +17,100 @@
 
 namespace torch::executor {
 
-#define SAMPLER_TOP 0.9f
-#define ENDOFTEXT_TOKEN 32000
-#define VOCABULARY_SIZE 32064
-
-Runner::Runner(
-    const std::string& model_path,
-    const std::string& tokenizer_path,
-    const float temperature)
-    : module_(std::make_unique<Module>(model_path, Module::LoadMode::File)),
-      tokenizer_(std::make_unique<BPETokenizer>()),
-      sampler_(std::make_unique<Sampler>(
-          VOCABULARY_SIZE,
-          temperature,
-          SAMPLER_TOP,
-          static_cast<unsigned long long>(std::time(nullptr)))) {
-  ET_CHECK_MSG(
-      tokenizer_->load(tokenizer_path) == Error::Ok,
-      "Failed to load tokenizer at %s",
-      tokenizer_path.c_str());
-  ET_LOG(
-      Info,
-      "Created Phi-3-mini runner: model_path=%s, tokenizer_path=%s",
-      model_path.c_str(),
-      tokenizer_path.c_str());
+Runner::Runner(const std::string& model_path)
+    : module_(std::make_unique<Module>(model_path, Module::LoadMode::File)) {
+  ET_LOG(Info, "Created Phi-3-mini runner: model_path=%s", model_path.c_str());
 }
 
-void Runner::generate(const std::string& prompt, std::size_t max_seq_len) {
-  auto encode_res = tokenizer_->encode(prompt, 0, 0);
-  ET_CHECK_MSG(
-      encode_res.error() == Error::Ok, "Failed to encode %s", prompt.c_str());
-  auto input_tokens = encode_res.get();
+void Runner::generate() {
+  std::vector<uint64_t> kv_cache(10, 0);
 
-  std::cout << "Prefilling tokens ..." << std::endl;
-  for (auto token : input_tokens) {
-    std::cout << token << " ";
-  }
-  std::cout << std::endl;
-  std::cout.flush();
-  auto prev_token = input_tokens.back();
-  auto current_token = prefill(input_tokens);
-
-  std::cout << "Generating tokens ..." << std::endl;
-  std::cout << tokenizer_->decode(prev_token, current_token).get();
-  std::cout.flush();
-
-  std::size_t seq_len = input_tokens.size() + 1;
-
-  while (current_token != ENDOFTEXT_TOKEN && seq_len < max_seq_len) {
-    prev_token = current_token;
-    current_token = run_model_step(current_token);
-    std::cout << tokenizer_->decode(prev_token, current_token).get();
-    std::cout.flush();
-
-    ++seq_len;
+  for (uint64_t i = 0; i < 10; i++) {
+    auto input_token = i + 1;
+    ManagedTensor input_token_tensor(&input_token, {1, 1}, ScalarType::Long);
+    ManagedTensor pos_tensor(&i, {1}, ScalarType::Long);
+    ManagedTensor kv_cache_tensor(
+        kv_cache.data(),
+        {1, static_cast<exec_aten::SizesType>(kv_cache.size())},
+        ScalarType::Long);
+    std::vector<EValue> inputs = {
+        input_token_tensor.get_aliasing_tensor(),
+        pos_tensor.get_aliasing_tensor(),
+        kv_cache_tensor.get_aliasing_tensor()};
+    auto result = module_->forward(inputs);
+    ET_CHECK_MSG(result.error() == Error::Ok, "Failed to run forward");
+    ET_LOG(
+        Info,
+        "returned size %" PRIu64 " value %" PRIu64 " %" PRIu64,
+        result.get().size(),
+        result.get()[0].toTensor().data_ptr<uint64_t>()[0],
+        result.get()[1].toTensor().data_ptr<uint64_t>()[0]);
   }
 
-  std::cout << std::endl;
+  for (auto i : kv_cache) {
+    ET_LOG(Info, "kv_cache %" PRIu64, i);
+  }
+
+  ET_LOG(Info, "Resizing kv_cache");
+
+  kv_cache.resize(20, 0);
+
+  for (uint64_t i = 10; i < 15; i++) {
+    auto input_token = i + 1;
+    ManagedTensor input_token_tensor(&input_token, {1, 1}, ScalarType::Long);
+    ManagedTensor pos_tensor(&i, {1}, ScalarType::Long);
+    ManagedTensor kv_cache_tensor(
+        kv_cache.data(),
+        {1, static_cast<exec_aten::SizesType>(kv_cache.size())},
+        ScalarType::Long);
+    std::vector<EValue> inputs = {
+        input_token_tensor.get_aliasing_tensor(),
+        pos_tensor.get_aliasing_tensor(),
+        kv_cache_tensor.get_aliasing_tensor()};
+    auto result = module_->forward(inputs);
+    ET_CHECK_MSG(result.error() == Error::Ok, "Failed to run forward");
+    ET_LOG(
+        Info,
+        "returned size %" PRIu64 " value %" PRIu64 " %" PRIu64,
+        result.get().size(),
+        result.get()[0].toTensor().data_ptr<uint64_t>()[0],
+        result.get()[1].toTensor().data_ptr<uint64_t>()[0]);
+  }
+
+  for (auto i : kv_cache) {
+    ET_LOG(Info, "kv_cache %" PRIu64, i);
+  }
 }
 
-uint64_t Runner::logits_to_token(const exec_aten::Tensor& logits_tensor) {
-  return sampler_->sample(logits_tensor.data_ptr<float>());
-}
+void Runner::test_example() {
+  std::vector<uint64_t> x(10, 0);
+  std::vector<uint64_t> y(10, 1);
+  for (auto i : x) {
+    ET_LOG(Info, "Before forward x: %" PRIu64, i);
+  }
+  for (auto i : y) {
+    ET_LOG(Info, "Before forward y: %" PRIu64, i);
+  }
 
-uint64_t Runner::prefill(std::vector<uint64_t>& tokens) {
-  ManagedTensor input_tokens(
-      tokens.data(),
-      {1, static_cast<exec_aten::SizesType>(tokens.size())},
+  ManagedTensor x_tensor(
+      x.data(),
+      {1, static_cast<exec_aten::SizesType>(x.size())},
       ScalarType::Long);
-  std::vector<EValue> inputs = {input_tokens.get_aliasing_tensor()};
-
+  ManagedTensor y_tensor(
+      y.data(),
+      {1, static_cast<exec_aten::SizesType>(y.size())},
+      ScalarType::Long);
+  std::vector<EValue> inputs = {
+      x_tensor.get_aliasing_tensor(), y_tensor.get_aliasing_tensor()};
   auto result = module_->forward(inputs);
-  ET_CHECK_MSG(result.error() == Error::Ok, "Failed to prefill tokens");
+  ET_CHECK_MSG(result.error() == Error::Ok, "Failed to run forward");
 
-  return logits_to_token(result.get()[0].toTensor());
-}
-
-uint64_t Runner::run_model_step(uint64_t token) {
-  ManagedTensor input_token(&token, {1, 1}, ScalarType::Long);
-  std::vector<EValue> inputs = {input_token.get_aliasing_tensor()};
-
-  auto result = module_->forward(inputs);
-  ET_CHECK_MSG(
-      result.error() == Error::Ok,
-      "Failed to run forward() for token %" PRIu64,
-      token);
-
-  return logits_to_token(result.get()[0].toTensor());
+  for (auto i : x) {
+    ET_LOG(Info, "After forward x: %" PRIu64, i);
+  }
+  for (auto i : y) {
+    ET_LOG(Info, "After forward y: %" PRIu64, i);
+  }
 }
 
 } // namespace torch::executor

--- a/examples/models/phi-3-mini/runner.h
+++ b/examples/models/phi-3-mini/runner.h
@@ -23,10 +23,7 @@ namespace torch::executor {
 
 class Runner {
  public:
-  explicit Runner(
-      const std::string& model_path,
-      const std::string& tokenizer_path,
-      const float temperature = 0.8f);
+  explicit Runner(const std::string& model_path);
 
   /**
    * Generates response for a given prompt.
@@ -35,16 +32,12 @@ class Runner {
    * @param[in] max_seq_len The maximum length of the sequence to generate,
    * including prompt.
    */
-  void generate(const std::string& prompt, std::size_t max_seq_len);
+  void generate();
+
+  void test_example();
 
  private:
-  uint64_t logits_to_token(const exec_aten::Tensor& logits_tensor);
-  uint64_t prefill(std::vector<uint64_t>& tokens);
-  uint64_t run_model_step(uint64_t token);
-
   std::unique_ptr<Module> module_;
-  std::unique_ptr<Tokenizer> tokenizer_;
-  std::unique_ptr<Sampler> sampler_;
 };
 
 } // namespace torch::executor

--- a/exir/passes/insert_write_back_for_buffers_pass.py
+++ b/exir/passes/insert_write_back_for_buffers_pass.py
@@ -15,6 +15,7 @@ from torch.export.exported_program import (
     OutputKind,
     OutputSpec,
 )
+from torch.export.graph_signature import TensorArgument
 from torch.utils import _pytree as pytree
 
 
@@ -73,20 +74,14 @@ def insert_write_back_for_buffers_pass(
     ep: ExportedProgram,
 ) -> Tuple[torch.fx.GraphModule, ExportGraphSignature]:
     gm: torch.fx.GraphModule = ep.graph_module
-    lifted_inputs: List[Optional[str]] = [
-        (
-            in_spec.target
-            if in_spec.kind
-            in (
-                InputKind.BUFFER,
-                InputKind.CONSTANT_TENSOR,
-                InputKind.PARAMETER,
-                InputKind.CUSTOM_OBJ,
-            )
-            else None
-        )
-        for in_spec in ep.graph_signature.input_specs
-    ]
+    lifted_inputs: List[Optional[str]] = []
+    for in_spec in ep.graph_signature.input_specs:
+        if in_spec.kind is InputKind.BUFFER:
+            lifted_inputs.append(in_spec.target)
+        elif in_spec.kind is InputKind.USER_INPUT and isinstance(in_spec.arg, TensorArgument):
+            lifted_inputs.append(in_spec.arg.name)
+        else:
+            lifted_inputs.append(None)
 
     input_name_to_node: Dict[str, torch.fx.Node] = {}
 
@@ -101,7 +96,7 @@ def insert_write_back_for_buffers_pass(
     mutated_outputs: List[Optional[str]] = [
         (
             out_spec.target
-            if out_spec.kind in (OutputKind.BUFFER_MUTATION,)
+            if out_spec.kind in (OutputKind.BUFFER_MUTATION, OutputKind.USER_INPUT_MUTATION)
             and out_spec.arg.name
             not in {
                 val.name for val in input_name_to_node.values()
@@ -121,7 +116,7 @@ def insert_write_back_for_buffers_pass(
     new_output_specs: List[OutputSpec] = []
     i = 0
     for output_spec in ep.graph_signature.output_specs:
-        if output_spec.kind == OutputKind.BUFFER_MUTATION:
+        if output_spec.kind == OutputKind.BUFFER_MUTATION or output_spec.kind == OutputKind.USER_INPUT_MUTATION:
             output_spec.arg.name = buffer_output_nodes[i].name
             i += 1
         new_output_specs.append(output_spec)


### PR DESCRIPTION
This PR shows a simple repro that ET cannot mutate input tensor:
```
cd executorch/examples/models/phi-3-mini
```
- Run in eager mode:
```
(executorch) [lunwenh@devvm5021.ash0 ~/executorch/examples/models/phi-3-mini (dynamic_kv_cache_example)]$ python example2.py 
x: tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])
y: tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])
```
- export the model:
```
python example2.py -e
```
- run in ET:
```
update model_path in executorch/examples/models/phi-3-mini/main.cpp
makedir build
cd build
cmake ..
cd ..
cmake --build build -j10
./build/phi_3_mini_runner

I 00:00:00.001573 executorch:runner.cpp:22] Created Phi-3-mini runner: model_path=/home/lunwenh/executorch/examples/models/phi-3-mini/example2.pte
I 00:00:00.001615 executorch:runner.cpp:89] Before forward x: 0
I 00:00:00.001618 executorch:runner.cpp:89] Before forward x: 0
I 00:00:00.001619 executorch:runner.cpp:89] Before forward x: 0
I 00:00:00.001621 executorch:runner.cpp:89] Before forward x: 0
I 00:00:00.001623 executorch:runner.cpp:89] Before forward x: 0
I 00:00:00.001625 executorch:runner.cpp:89] Before forward x: 0
I 00:00:00.001627 executorch:runner.cpp:89] Before forward x: 0
I 00:00:00.001629 executorch:runner.cpp:89] Before forward x: 0
I 00:00:00.001631 executorch:runner.cpp:89] Before forward x: 0
I 00:00:00.001638 executorch:runner.cpp:89] Before forward x: 0
I 00:00:00.001640 executorch:runner.cpp:92] Before forward y: 1
I 00:00:00.001642 executorch:runner.cpp:92] Before forward y: 1
I 00:00:00.001644 executorch:runner.cpp:92] Before forward y: 1
I 00:00:00.001646 executorch:runner.cpp:92] Before forward y: 1
I 00:00:00.001650 executorch:runner.cpp:92] Before forward y: 1
I 00:00:00.001655 executorch:runner.cpp:92] Before forward y: 1
I 00:00:00.001657 executorch:runner.cpp:92] Before forward y: 1
I 00:00:00.001660 executorch:runner.cpp:92] Before forward y: 1
I 00:00:00.001663 executorch:runner.cpp:92] Before forward y: 1
I 00:00:00.001665 executorch:runner.cpp:92] Before forward y: 1
I 00:00:00.001838 executorch:runner.cpp:109] After forward x: 0
I 00:00:00.001847 executorch:runner.cpp:109] After forward x: 0
I 00:00:00.001849 executorch:runner.cpp:109] After forward x: 0
I 00:00:00.001851 executorch:runner.cpp:109] After forward x: 0
I 00:00:00.001853 executorch:runner.cpp:109] After forward x: 0
I 00:00:00.001854 executorch:runner.cpp:109] After forward x: 0
I 00:00:00.001857 executorch:runner.cpp:109] After forward x: 0
I 00:00:00.001859 executorch:runner.cpp:109] After forward x: 0
I 00:00:00.001861 executorch:runner.cpp:109] After forward x: 0
I 00:00:00.001863 executorch:runner.cpp:109] After forward x: 0
I 00:00:00.001866 executorch:runner.cpp:112] After forward y: 1
I 00:00:00.001868 executorch:runner.cpp:112] After forward y: 1
I 00:00:00.001872 executorch:runner.cpp:112] After forward y: 1
I 00:00:00.001873 executorch:runner.cpp:112] After forward y: 1
I 00:00:00.001877 executorch:runner.cpp:112] After forward y: 1
I 00:00:00.001879 executorch:runner.cpp:112] After forward y: 1
I 00:00:00.001881 executorch:runner.cpp:112] After forward y: 1
I 00:00:00.001884 executorch:runner.cpp:112] After forward y: 1
I 00:00:00.001890 executorch:runner.cpp:112] After forward y: 1
I 00:00:00.001893 executorch:runner.cpp:112] After forward y: 1
```