### PR TITLE
Add cat op to Arm backend

### DIFF
--- a/backends/arm/arm_partitioner.py
+++ b/backends/arm/arm_partitioner.py
@@ -39,6 +39,7 @@ class TOSASupportedOperators(OperatorSupportBase):
             exir_ops.edge.aten.add.Tensor,
             exir_ops.edge.aten.addmm.default,
             exir_ops.edge.aten.expand_copy.default,
+            exir_ops.edge.aten.cat.default,
             exir_ops.edge.aten.permute_copy.default,
             exir_ops.edge.aten.hardtanh.default,
             exir_ops.edge.aten.convolution.default,

--- a/backends/arm/operators/__init__.py
+++ b/backends/arm/operators/__init__.py
@@ -9,6 +9,7 @@ from . import (  # noqa
     op_addmm,
     op_avg_pool2d,
     op_batch_norm,
+    op_cat,
     op_conv2d,
     op_dequant,
     op_div,

--- a/backends/arm/operators/op_cat.py
+++ b/backends/arm/operators/op_cat.py
@@ -1,0 +1,45 @@
+# Copyright 2024 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List
+
+import serializer.tosa_serializer as ts
+from executorch.backends.arm.operators.node_visitor import (
+    NodeVisitor,
+    register_node_visitor,
+)
+from executorch.backends.arm.tosa_mapping import TosaArg
+from serializer.tosa_serializer import TosaOp
+from torch.fx import Node
+
+
+@register_node_visitor
+class CatVisitor(NodeVisitor):
+    target = "aten.cat.default"
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: Node,
+        tosa_graph: ts.TosaSerializer,
+        inputs: List[TosaArg],
+        output: TosaArg,
+        is_quant_node: bool,
+    ) -> None:
+
+        tensors = inputs[0].special
+        dim = 0 if len(inputs) < 2 else inputs[1].number
+        rank = len(output.shape)
+        dim = (dim + rank) % rank
+        dim = output.dim_order.index(dim)
+
+        attr = ts.TosaSerializerAttribute()
+        attr.AxisAttribute(dim)
+
+        tosa_graph.addOperator(
+            TosaOp.Op().CONCAT, [tensor.name for tensor in tensors], [output.name], attr
+        )

--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -266,6 +266,7 @@ class ArmQuantizer(Quantizer):
         "mul",
         "sigmoid",
         "mm",
+        "cat",
     ]
 
     def __init__(self) -> None:

--- a/backends/arm/quantizer/quantization_annotation/__init__.py
+++ b/backends/arm/quantizer/quantization_annotation/__init__.py
@@ -49,6 +49,7 @@ def register_annotator(op: str):
 from . import (  # noqa
     adaptive_ang_pool2d_annotator,
     add_annotator,
+    cat_annotator,
     conv_annotator,
     linear_annotator,
     max_pool2d_annotator,

--- a/backends/arm/quantizer/quantization_annotation/cat_annotator.py
+++ b/backends/arm/quantizer/quantization_annotation/cat_annotator.py
@@ -1,0 +1,66 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright 2024 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+from typing import Callable, List, Optional
+
+import torch.fx
+from executorch.backends.arm.quantizer import arm_quantizer_utils
+from executorch.backends.arm.quantizer.quantization_annotation import register_annotator
+from executorch.backends.arm.quantizer.quantization_config import QuantizationConfig
+from torch.ao.quantization.quantizer import (
+    QuantizationAnnotation,
+    SharedQuantizationSpec,
+)
+from torch.fx import Node
+from torch.fx.passes.utils.source_matcher_utils import get_source_partitions
+
+
+@register_annotator("cat")
+def _annotate_cat(
+    gm: torch.fx.GraphModule,
+    quantization_config: QuantizationConfig,
+    filter_fn: Optional[Callable[[Node], bool]] = None,
+) -> Optional[List[List[Node]]]:
+    cat_partitions = get_source_partitions(gm.graph, [torch.cat], filter_fn)
+    cat_partitions = list(itertools.chain.from_iterable(cat_partitions.values()))
+    annotated_partitions = []
+    for cat_partition in cat_partitions:
+        annotated_partitions.append(cat_partition.nodes)
+        cat_node = cat_partition.output_nodes[0]
+        if arm_quantizer_utils.is_annotated(cat_node):
+            continue
+
+        input_acts = cat_node.args[0]
+        input_act0 = input_acts[0]
+
+        input_act_qspec = quantization_config.get_input_act_qspec()
+        shared_with_input0_qspec = SharedQuantizationSpec((input_act0, cat_node))
+
+        input_qspec_map = {}
+
+        # First input is set to input qspec from the quantization config.
+        if isinstance(input_act0, Node):
+            if not arm_quantizer_utils.is_input_ok_for_quantization(input_act0, gm):
+                continue
+            input_qspec_map[input_act0] = input_act_qspec
+
+        # For the rest of the inputs, share qspec with first.
+        # If we can't quantize any of the inputs, abort annotation.
+        for input_act in input_acts[1:]:
+            if isinstance(input_act, Node):
+                if not arm_quantizer_utils.is_input_ok_for_quantization(input_act, gm):
+                    continue
+                if input_act is not input_act0:
+                    input_qspec_map[input_act] = shared_with_input0_qspec
+
+        if input_qspec_map is not None:
+            cat_node.meta["quantization_annotation"] = QuantizationAnnotation(
+                input_qspec_map=input_qspec_map,
+                output_qspec=shared_with_input0_qspec,
+                _annotated=True,
+            )
+    return annotated_partitions

--- a/backends/arm/test/ops/test_cat.py
+++ b/backends/arm/test/ops/test_cat.py
@@ -1,0 +1,131 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright 2024 Arm Limited and/or its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from typing import Tuple
+
+import torch
+from executorch.backends.arm.test import common
+
+from executorch.backends.arm.test.tester.arm_tester import ArmTester
+from parameterized import parameterized
+
+
+class TestCat(unittest.TestCase):
+
+    class Cat(torch.nn.Module):
+        test_parameters = [
+            ((torch.ones(1), torch.ones(1)), 0),
+            ((torch.ones(1, 2), torch.randn(1, 5), torch.randn(1, 1)), 1),
+            (
+                (
+                    torch.ones(1, 2, 5),
+                    torch.randn(1, 2, 4),
+                    torch.randn(1, 2, 2),
+                    torch.randn(1, 2, 1),
+                ),
+                -1,
+            ),
+            ((torch.randn(2, 2, 4, 4), torch.randn(2, 2, 4, 1)), 3),
+            (
+                (
+                    10000 * torch.randn(2, 3, 1, 4),
+                    torch.randn(2, 7, 1, 4),
+                    torch.randn(2, 1, 1, 4),
+                ),
+                -3,
+            ),
+        ]
+
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, tensors: tuple[torch.Tensor, ...], dim: int) -> torch.Tensor:
+            return torch.cat(tensors, dim=dim)
+
+    def _test_cat_tosa_MI_pipeline(
+        self, module: torch.nn.Module, test_data: Tuple[tuple[torch.Tensor, ...], int]
+    ):
+        (
+            ArmTester(
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_tosa_compile_spec(),
+            )
+            .export()
+            .check_count({"torch.ops.aten.cat.default": 1})
+            .check_not(["torch.ops.quantized_decomposed"])
+            .to_edge()
+            .partition()
+            .check_not(["executorch_exir_dialects_edge__ops_aten_cat_default"])
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+            .run_method_and_compare_outputs(inputs=test_data)
+        )
+
+    def _test_cat_tosa_BI_pipeline(
+        self, module: torch.nn.Module, test_data: Tuple[tuple[torch.Tensor, ...], int]
+    ):
+        (
+            ArmTester(
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_tosa_compile_spec(),
+            )
+            .quantize()
+            .export()
+            .check_count({"torch.ops.aten.cat.default": 1})
+            .check(["torch.ops.quantized_decomposed"])
+            .to_edge()
+            .partition()
+            .check_not(["executorch_exir_dialects_edge__ops_aten_cat_default"])
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+            .run_method_and_compare_outputs(inputs=test_data, qtol=1)
+        )
+
+    def _test_cat_u55_BI_pipeline(
+        self, module: torch.nn.Module, test_data: Tuple[tuple[torch.Tensor, ...], int]
+    ):
+        (
+            ArmTester(
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_u55_compile_spec(),
+            )
+            .quantize()
+            .export()
+            .check_count({"torch.ops.aten.cat.default": 1})
+            .check(["torch.ops.quantized_decomposed"])
+            .to_edge()
+            .partition()
+            .check_not(["executorch_exir_dialects_edge__ops_aten_cat_default"])
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+        )
+
+    @parameterized.expand(Cat.test_parameters)
+    def test_cat_tosa_MI(self, operands: tuple[torch.Tensor, ...], dim: int):
+        test_data = (operands, dim)
+        self._test_cat_tosa_MI_pipeline(self.Cat(), test_data)
+
+    def test_cat_4d_tosa_MI(self):
+        square = torch.ones((2, 2, 2, 2))
+        for dim in range(-3, 3):
+            test_data = ((square, square), dim)
+            self._test_cat_tosa_MI_pipeline(self.Cat(), test_data)
+
+    @parameterized.expand(Cat.test_parameters)
+    def test_cat_tosa_BI(self, operands: tuple[torch.Tensor, ...], dim: int):
+        test_data = (operands, dim)
+        self._test_cat_tosa_BI_pipeline(self.Cat(), test_data)
+
+    @parameterized.expand(Cat.test_parameters)
+    def test_cat_u55_BI(self, operands: tuple[torch.Tensor, ...], dim: int):
+        test_data = (operands, dim)
+        self._test_cat_u55_BI_pipeline(self.Cat(), test_data)


### PR DESCRIPTION
Implements node visitor, tests,
and a cat annotator that adds a
SharedQuantizationSpec to a list of
input nodes.

I had to adjust ArmTester to work with
inputs that are tuples of torch.Tensor:s.


Change-Id: I44a12711bd40461079348967d3d8772c21437f38