### PR TITLE
Fix the arg format passed to update-viablestrict

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           repository: pytorch/executorch
           stable-branch: viable/strict
-          requires: '[\"pull\", \"lint\", \"trunk\", \"Build documentation\", "^Android$", "^Apple$"]'
+          requires: '[\"pull\", \"lint\", \"trunk\", \"Build documentation\", \"^Android$\", \"^Apple$\"]'
           secret-bot-token: ${{ secrets.UPDATEBOT_TOKEN }}
           rockset-api-key: ${{ secrets.ROCKSET_API_KEY }}


### PR DESCRIPTION
The error is due to the incorrect args passed to the script as shown below:
```
python /home/runner/work/executorch/executorch/test-infra/.github/scripts/fetch_latest_green_commit.py --requires '["pull", "lint", "trunk", "Build documentation", ^Android, ^Apple]'
```

Added `\"` around the regex pattern strings.