### PR TITLE
Add unsqueeze op to Arm backend

### DIFF
--- a/backends/arm/arm_partitioner.py
+++ b/backends/arm/arm_partitioner.py
@@ -57,6 +57,7 @@ class TOSASupportedOperators(OperatorSupportBase):
             exir_ops.edge.aten.view_copy.default,
             exir_ops.edge.aten.clone.default,
             exir_ops.edge.aten.mean.dim,
+            exir_ops.edge.aten.unsqueeze_copy.default,
             operator.getitem,
             exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
             exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,

--- a/backends/arm/operators/__init__.py
+++ b/backends/arm/operators/__init__.py
@@ -25,5 +25,6 @@ from . import (  # noqa
     op_slice,
     op_softmax,
     op_sub,
+    op_unsqueeze,
     op_view,
 )

--- a/backends/arm/operators/op_unsqueeze.py
+++ b/backends/arm/operators/op_unsqueeze.py
@@ -1,0 +1,51 @@
+# Copyright 2024 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#  Follows this specification: https://pytorch.org/docs/stable/generated/torch.unsqueeze.html
+
+import serializer.tosa_serializer as ts
+import torch.fx
+from executorch.backends.arm.operators.node_visitor import (
+    NodeVisitor,
+    register_node_visitor,
+)
+from executorch.backends.arm.tosa_mapping import TosaArg
+from executorch.backends.arm.tosa_utils import tosa_shape
+from serializer.tosa_serializer import TosaOp
+
+
+@register_node_visitor
+class UnsqueezeVisitor(NodeVisitor):
+    target = "aten.unsqueeze_copy.default"
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        tosa_graph: ts.TosaSerializer,
+        inputs: list[TosaArg],
+        output: TosaArg,
+        is_quant_node: bool,
+    ) -> None:
+
+        dim = inputs[1].number
+        shape = inputs[0].shape
+        rank = len(shape)
+
+        assert -rank - 1 <= dim < rank + 1
+        if dim < 0:
+            dim = dim + rank + 1
+
+        new_shape = list(shape)
+        new_shape.insert(dim, 1)
+        new_shape = tosa_shape(new_shape, output.dim_order)
+
+        attr = ts.TosaSerializerAttribute()
+        attr.ReshapeAttribute(new_shape)
+        tosa_graph.addOperator(
+            TosaOp.Op().RESHAPE, [inputs[0].name], [output.name], attr
+        )

--- a/backends/arm/test/ops/test_unsqueeze.py
+++ b/backends/arm/test/ops/test_unsqueeze.py
@@ -1,0 +1,103 @@
+# Copyright 2024 Arm Limited and/or its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# Tests the unsqueeze op which copies the data of the input tensor (possibly with new data format)
+#
+
+import unittest
+from typing import Sequence, Tuple
+
+import torch
+
+from executorch.backends.arm.quantizer.arm_quantizer import (
+    ArmQuantizer,
+    get_symmetric_quantization_config,
+)
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.arm_tester import ArmTester
+
+from executorch.backends.xnnpack.test.tester.tester import Quantize
+from parameterized import parameterized
+
+
+class TestSimpleUnsqueeze(unittest.TestCase):
+    class Unsqueeze(torch.nn.Module):
+        shapes: list[int | Sequence[int]] = [5, (5, 5), (5, 5), (5, 5, 5)]
+        test_parameters: list[tuple[torch.Tensor]] = [(torch.ones(n),) for n in shapes]
+
+        def forward(self, x: torch.Tensor, dim):
+            return x.unsqueeze(dim)
+
+    def _test_unsqueeze_tosa_MI_pipeline(
+        self, module: torch.nn.Module, test_data: Tuple[torch.Tensor, int]
+    ):
+        (
+            ArmTester(
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_tosa_compile_spec(),
+            )
+            .export()
+            .check_count({"torch.ops.aten.unsqueeze.default": 1})
+            .to_edge()
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+            .run_method_and_compare_outputs(inputs=test_data)
+        )
+
+    def _test_unsqueeze_tosa_BI_pipeline(
+        self, module: torch.nn.Module, test_data: Tuple[torch.Tensor, int]
+    ):
+        quantizer = ArmQuantizer().set_io(get_symmetric_quantization_config())
+        (
+            ArmTester(
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_tosa_compile_spec(),
+            )
+            .quantize(Quantize(quantizer, get_symmetric_quantization_config()))
+            .export()
+            .check_count({"torch.ops.aten.unsqueeze.default": 1})
+            .to_edge()
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+            .run_method_and_compare_outputs(inputs=test_data, qtol=1)
+        )
+
+    def _test_unsqueeze_tosa_u55_pipeline(
+        self, module: torch.nn.Module, test_data: Tuple[torch.Tensor, int]
+    ):
+        quantizer = ArmQuantizer().set_io(get_symmetric_quantization_config())
+        (
+            ArmTester(
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_u55_compile_spec(),
+            )
+            .quantize(Quantize(quantizer, get_symmetric_quantization_config()))
+            .export()
+            .check_count({"torch.ops.aten.unsqueeze.default": 1})
+            .to_edge()
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+        )
+
+    @parameterized.expand(Unsqueeze.test_parameters)
+    def test_unsqueeze_tosa_MI(self, test_tensor: torch.Tensor):
+        for i in range(-test_tensor.dim() - 1, test_tensor.dim() + 1):
+            self._test_unsqueeze_tosa_MI_pipeline(self.Unsqueeze(), (test_tensor, i))
+
+    @parameterized.expand(Unsqueeze.test_parameters)
+    def test_unsqueeze_tosa_BI(self, test_tensor: torch.Tensor):
+        self._test_unsqueeze_tosa_BI_pipeline(self.Unsqueeze(), (test_tensor, 0))
+
+    @parameterized.expand(Unsqueeze.test_parameters)
+    def test_unsqueeze_u55_BI(self, test_tensor: torch.Tensor):
+        self._test_unsqueeze_tosa_u55_pipeline(self.Unsqueeze(), (test_tensor, 0))


### PR DESCRIPTION
Implements node visitor and tests.
Unsqueeze is quantized by forward_annotation.


Change-Id: If6e5737acc9bf2349f46534d5ef4a68692af0fc0