### PR TITLE
Move towards quantize_ api for blockwise

### DIFF
--- a/backends/xnnpack/operators/op_dynamic_dequantize_ops.py
+++ b/backends/xnnpack/operators/op_dynamic_dequantize_ops.py
@@ -12,7 +12,15 @@ from executorch.backends.xnnpack.operators.node_visitor import (
     register_node_visitor,
 )
 from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import XNNGraph
-from executorch.backends.xnnpack.utils.utils import get_input_node
+from executorch.backends.xnnpack.utils.quant_utils import (
+    is_per_channel_group,
+    is_per_token,
+)
+from executorch.backends.xnnpack.utils.utils import (
+    check_or_raise,
+    get_input_node,
+    is_param_node,
+)
 
 
 @register_node_visitor
@@ -62,6 +70,43 @@ class OpDynamicDequantizePerToken(NodeVisitor):
         """
         We always skip this node because we know it is implicit
         """
+        dq_input = get_input_node(node, 0)
+        if dq_input in vals_to_ids:
+            vals_to_ids[node] = vals_to_ids[dq_input]
+
+
+@register_node_visitor
+class OpDequantizeAffine(NodeVisitor):
+    target = "quant.dequantize_affine.default"
+
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        xnn_graph: XNNGraph,
+        vals_to_ids: Dict[torch.fx.Node, int],
+        debug_handle: int,
+    ) -> None:
+        """
+        We always define dequantize affine nodes because they are always explicit
+        """
+        if is_per_channel_group(node):
+            check_or_raise(
+                is_param_node(self._exported_program, node.all_input_nodes[0]),
+                f"Expected quantize affine node with per-token semantics to be used "
+                f"in front of a weight node, but found node {node.all_input_nodes[0]}",
+            )
+            # Affine dequantize was recognized as per channel group which means that it should
+            # be skipped as this means it is used in front of a weight node
+            return
+
+        check_or_raise(
+            is_per_token(node),
+            "Expecting Affine Dequantized Op to have per-token semantics",
+        )
+        # This must be a per-token affine dequantized node, so let us serialize as such
         dq_input = get_input_node(node, 0)
         if dq_input in vals_to_ids:
             vals_to_ids[node] = vals_to_ids[dq_input]

--- a/backends/xnnpack/operators/op_dynamic_quantize_ops.py
+++ b/backends/xnnpack/operators/op_dynamic_quantize_ops.py
@@ -17,6 +17,10 @@ from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
     XNNGraph,
     XNode,
 )
+from executorch.backends.xnnpack.utils.quant_utils import (
+    is_per_channel_group,
+    is_per_token,
+)
 from executorch.backends.xnnpack.utils.utils import check_or_raise, get_input_node
 
 
@@ -91,6 +95,59 @@ class OpDynamicQuantizePerToken(NodeVisitor):
         """
         We always define dynamic quantize per token nodes because they are always explicit
         """
+        q_input = get_input_node(node, 0)
+
+        # fp32 input
+        self.define_tensor(q_input, xnn_graph, vals_to_ids)
+        input_id = vals_to_ids[q_input]
+
+        # dynamic quantized output
+        input_quant_params = QuantParams.from_q_dq_node(node)
+        # qinput isn't needed for dynamically quantized nodes since it will always be
+        # the output of a convert node. Instead we set q_input to the node itself so
+        # we can extract the shape from the dq output
+        input_quant_params.q_input = node
+        input_quant_params.is_input = False
+        check_or_raise(
+            input_quant_params.is_dynamic,
+            "Internal Error, dynamically quantized node expected dynamic quantized params",
+        )
+        self.define_tensor(
+            node, xnn_graph, vals_to_ids, quant_params=input_quant_params
+        )
+        output_id = vals_to_ids[node]
+
+        ser_node = XNode(
+            xnode_union=XNNConvert(input_id=input_id, output_id=output_id, flags=0),
+            debug_handle=debug_handle,
+        )
+        xnn_graph.xnodes.append(ser_node)
+
+
+@register_node_visitor
+class OpQuantizeAffine(NodeVisitor):
+    target = "quant.quantize_affine.default"
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        xnn_graph: XNNGraph,
+        vals_to_ids: Dict[torch.fx.Node, int],
+        debug_handle: int,
+    ) -> None:
+        """
+        We always define quantize affine nodes because they are always explicit
+        """
+        if is_per_channel_group(node):
+            # Affine quantized was recognized as per channel group which means that it should
+            # be skipped as this means it is used in front of a weight node
+            return
+
+        check_or_raise(
+            is_per_token(node),
+            "Encountered affine quantized op which does not have per-token semantics",
+        )
+        # Treat this node as dynamic per-token quantization
         q_input = get_input_node(node, 0)
 
         # fp32 input

--- a/backends/xnnpack/operators/op_skip_ops.py
+++ b/backends/xnnpack/operators/op_skip_ops.py
@@ -98,6 +98,15 @@ class OpSymSizeInt(OpSkipOps):
 
 
 @register_node_visitor
+class OpChooseQparamsAffine(OpSkipOps):
+    """
+    do nothing if node is choose_qparams_affine.default
+    """
+
+    target = "quant.choose_qparams_affine.default"
+
+
+@register_node_visitor
 class OpChooseQparamsToken(OpSkipOps):
     """
     do nothing if node is choose_qparams_per_token_asymmetric.tensor

--- a/backends/xnnpack/operators/quant_params.py
+++ b/backends/xnnpack/operators/quant_params.py
@@ -10,7 +10,15 @@ from typing import cast, Optional, Union
 
 import torch
 from executorch.backends.xnnpack.passes.tag_implicit_q_dq_pass import TagImplicitQDqPass
-from executorch.backends.xnnpack.utils.quant_utils import is_dequant, is_quant
+from executorch.backends.xnnpack.utils.quant_utils import (
+    extract_qdq_affine_op_args_for_decomposed_ops,
+    is_affine_qdq,
+    is_dequant,
+    is_dynamic_qdq,
+    is_per_channel,
+    is_per_channel_group,
+    is_quant,
+)
 from executorch.backends.xnnpack.utils.utils import (
     check_or_raise,
     get_param_tensor,
@@ -154,30 +162,18 @@ class QuantParams:
         q_input = quant_node.all_input_nodes[0]
 
         # TODO: Use presence of choose_qparam node to determine if this is a dynamic quantization
-        if quant_node.target in [
-            exir_ops.edge.quantized_decomposed.quantize_per_tensor.tensor,
-            exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor,
-            exir_ops.edge.quantized_decomposed.quantize_per_token.default,
-            exir_ops.edge.quantized_decomposed.dequantize_per_token.default,
-        ]:
+        if is_dynamic_qdq(quant_node):
             return cls._from_dynamic_input_node(quant_node)
 
-        per_channel = quant_node.target in [
-            exir_ops.edge.quantized_decomposed.quantize_per_channel.default,
-            exir_ops.edge.quantized_decomposed.dequantize_per_channel.default,
-        ]
+        per_channel = is_per_channel(quant_node)
 
-        _groupwise = False
-        if quant_node.target in [
-            exir_ops.edge.quantized_decomposed.quantize_per_channel_group.default,
-            exir_ops.edge.quantized_decomposed.dequantize_per_channel_group.default,
-        ]:
-            # This is a sub-category of per channel quantization
-            per_channel = True
-            _groupwise = True
+        _groupwise = is_per_channel_group(quant_node)
+        quant_node_args = quant_node.args
+        if _groupwise and is_affine_qdq(quant_node):
+            quant_node_args = extract_qdq_affine_op_args_for_decomposed_ops(quant_node)
 
-        scale = quant_node.args[1]
-        zp = quant_node.args[2]
+        scale = quant_node_args[1]
+        zp = quant_node_args[2]
         axis = 0
         if per_channel:
             assert isinstance(scale, torch.fx.Node) and isinstance(scale.target, str)
@@ -193,10 +189,15 @@ class QuantParams:
 
             scale = _get_tensor(scale)
             zp = _get_tensor(zp)
-            axis = cast(int, quant_node.args[3])
+            axis = cast(int, quant_node_args[3])
 
             if _groupwise:
                 scale_tensor = cast(torch.Tensor, scale)
+                if scale_tensor.ndim == 1:
+                    scale_tensor = scale_tensor.reshape(-1, 1)
+                    zp = zp.reshape(-1, 1)
+                    scale = scale_tensor
+
                 assert (
                     scale_tensor.ndim == 2
                 ), "Weight scale must be 2D for per_channel_group [de]quant node, got {scale.ndim}D"
@@ -204,23 +205,23 @@ class QuantParams:
 
         check_or_raise(
             bool(
-                quant_node.args[-1] != torch.uint8
-                or quant_node.args[-1] != torch.quint8
+                quant_node_args[-1] != torch.uint8
+                or quant_node_args[-1] != torch.quint8
             ),
             "XNNPACK does not support unsigned quantization",
         )
 
         if _groupwise:
-            _ = quant_node.args[-1]  # output dtype - not used
-            group_size = cast(int, quant_node.args[-2])
-            dtype = cast(torch.dtype, quant_node.args[-3])
-            qmax = cast(int, quant_node.args[-4])
-            qmin = cast(int, quant_node.args[-5])
+            _ = quant_node_args[-1]  # output dtype - not used
+            group_size = cast(int, quant_node_args[-2])
+            dtype = cast(torch.dtype, quant_node_args[-3])
+            qmax = cast(int, quant_node_args[-4])
+            qmin = cast(int, quant_node_args[-5])
         else:
             group_size = 0
-            dtype = cast(torch.dtype, quant_node.args[-1])
-            qmax = cast(int, quant_node.args[-2])
-            qmin = cast(int, quant_node.args[-3])
+            dtype = cast(torch.dtype, quant_node_args[-1])
+            qmax = cast(int, quant_node_args[-2])
+            qmin = cast(int, quant_node_args[-3])
 
         is_output = any(
             user_node.op == "output" for user_node in quant_node.users.keys()
@@ -244,26 +245,14 @@ class QuantParams:
     def from_weights(
         cls, tensor_node: torch.fx.Node, ep: Optional[ExportedProgram] = None
     ) -> Optional[QuantParams]:
-        # Ignore transpose for weights
-        # TODO:T148540997 remove the t_copy/permute_copy check when convert addmm to linear
-        dq = (
-            tensor_node.all_input_nodes[0]
-            if tensor_node.target
-            in (
-                exir_ops.edge.aten.permute_copy.default,
-                exir_ops.edge.aten.t_copy.default,
-            )
-            else tensor_node
-        )
-        # check input of t_copy/permute_copy is dequant
-        if not is_dequant(dq):
+        if not is_dequant(tensor_node):
             return None
 
         # source node for quant params
-        src = dq
+        src = tensor_node
 
         # is input of dq is q?
-        dq_input = dq.all_input_nodes[0]
+        dq_input = src.all_input_nodes[0]
         if is_quant(dq_input):
             src = dq_input
 

--- a/backends/xnnpack/partition/config/__init__.py
+++ b/backends/xnnpack/partition/config/__init__.py
@@ -53,6 +53,11 @@ from executorch.backends.xnnpack.partition.config.node_configs import (
     MaxDimConfig,
     PreluConfig,
 )
+from executorch.backends.xnnpack.partition.config.quant_affine_configs import (
+    ChooseQParamsAffineConfig,
+    DeQuantizeAffineConfig,
+    QuantizeAffineConfig,
+)
 from executorch.backends.xnnpack.partition.config.xnnpack_config import (
     XNNPartitionerConfig,
 )
@@ -98,4 +103,8 @@ ALL_PARTITIONER_CONFIGS: List[Type[XNNPartitionerConfig]] = [
     # Quant/Dequant Op Configs
     QuantizedPerTensorConfig,
     DeQuantizedPerTensorConfig,
+    # Quant Affine Configs to preserve decomp
+    QuantizeAffineConfig,
+    DeQuantizeAffineConfig,
+    ChooseQParamsAffineConfig,
 ]

--- a/backends/xnnpack/partition/config/quant_affine_configs.py
+++ b/backends/xnnpack/partition/config/quant_affine_configs.py
@@ -1,0 +1,65 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional
+
+import torch
+from executorch.backends.xnnpack.partition.config.xnnpack_config import (
+    ConfigPrecisionType,
+    XNNPartitionerConfig,
+)
+from torch.export import ExportedProgram
+
+
+class QDQAffineConfigs(XNNPartitionerConfig):
+    def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
+        return True
+
+    def get_node_and_deps(
+        self, node: torch.fx.Node, ep: ExportedProgram
+    ) -> List[torch.fx.Node]:
+        # Do not return anything from this because we only use this to
+        # preserve the decomposition
+        return []
+
+    def supported_precision_types(self) -> List[ConfigPrecisionType]:
+        return [ConfigPrecisionType.DYNAMIC_QUANT]
+
+
+class QuantizeAffineConfig(QDQAffineConfigs):
+    target_name = "quantize_affine.default"
+
+    def get_original_aten(self) -> Optional[torch._ops.OpOverload]:
+        try:
+            import torchao.quantization.quant_primitives  # noqa
+
+            return torch.ops.quant.quantize_affine.default
+        except:
+            return None
+
+
+class DeQuantizeAffineConfig(QDQAffineConfigs):
+    target_name = "dequantize_affine.default"
+
+    def get_original_aten(self) -> Optional[torch._ops.OpOverload]:
+        try:
+            import torchao.quantization.quant_primitives  # noqa
+
+            return torch.ops.quant.dequantize_affine.default
+        except:
+            return None
+
+
+class ChooseQParamsAffineConfig(QDQAffineConfigs):
+    target_name = "choose_qparams_affine.default"
+
+    def get_original_aten(self) -> Optional[torch._ops.OpOverload]:
+        try:
+            import torchao.quantization.quant_primitives  # noqa
+
+            return torch.ops.quant.choose_qparams_affine.default
+        except:
+            return None

--- a/backends/xnnpack/passes/TARGETS
+++ b/backends/xnnpack/passes/TARGETS
@@ -30,6 +30,7 @@ python_library(
         "//executorch/exir:pass_base",
         "//executorch/exir/dialects:lib",
         "//executorch/exir/passes:const_prop_pass",
+        "//executorch/exir/passes:memory_format_ops_pass",
         "//executorch/exir/program:program",
     ],
 )

--- a/backends/xnnpack/passes/tag_implicit_q_dq_pass.py
+++ b/backends/xnnpack/passes/tag_implicit_q_dq_pass.py
@@ -12,7 +12,11 @@ from executorch.backends.xnnpack.partition.configs import (
     SUPPORTED_IMPLICIT_Q_DQ_OP_NAMES_SET,
 )
 from executorch.backends.xnnpack.passes.xnnpack_pass import XNNPACKPass
-from executorch.backends.xnnpack.utils.quant_utils import is_dequant, is_quant
+from executorch.backends.xnnpack.utils.quant_utils import (
+    is_dequant,
+    is_dynamic_qdq,
+    is_quant,
+)
 from executorch.backends.xnnpack.utils.utils import is_param_node
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import PassResult
@@ -76,18 +80,7 @@ class TagImplicitQDqPass(XNNPACKPass):
         return node.op == "output"
 
     def is_dynamically_quantized(self, node: torch.fx.Node) -> bool:
-        return any(
-            is_dequant(input_node)
-            and (
-                cast(
-                    torch._ops.OpOverload, input_node.target
-                )._schema.schema.overload_name
-                == "tensor"
-                or input_node.target
-                == exir_ops.edge.quantized_decomposed.dequantize_per_token.default
-            )
-            for input_node in node.all_input_nodes
-        )
+        return is_dynamic_qdq(node)
 
     def is_supported_quant_op(self, node: torch.fx.Node) -> bool:
         return (
@@ -191,7 +184,7 @@ class TagImplicitQDqPass(XNNPACKPass):
 
             ending_implicit_q_nodes = []
             for user in first_node.users:
-                if self.is_dynamically_quantized(user):
+                if self.is_dynamically_quantized(first_node):
                     # if the dq is a dynamic dq, then it is implicit
                     break
                 user_end_nodes = self.get_ending_implicit_q_nodes(user)

--- a/backends/xnnpack/test/ops/linear.py
+++ b/backends/xnnpack/test/ops/linear.py
@@ -26,8 +26,167 @@ from torch.ao.quantization.quantizer.xnnpack_quantizer import (
 )
 from torch.ao.quantization.quantizer.xnnpack_quantizer_utils import QuantizationConfig
 
+try:
+    from torchao.quantization.quant_api import (
+        int8_dynamic_activation_int4_weight,
+        quantize_,
+        unwrap_tensor_subclass,
+    )
+
+    torchao_installed = True
+except:
+    torchao_installed = False
+
+
+# Pytorch Modules Used for Testing
+class BaseLinear(torch.nn.Module):
+    def __init__(
+        self,
+        in_size: int = 2,
+        input_channels: int = 4,
+        output_channels: int = 4,
+        dtype: torch.dtype = torch.float,
+        use_bias: bool = False,
+    ):
+        super().__init__()
+        self.linear = torch.nn.Linear(
+            input_channels, output_channels, bias=use_bias
+        ).to(dtype=dtype)
+
+        self.ic = input_channels
+        self.oc = output_channels
+
+        assert dtype in [torch.float, torch.half], "Unsupported op dtype"
+        self.op_dtype = dtype
+        self.in_size = in_size
+
+    def forward(self, x):
+        return self.linear(x)
+
+    def get_inputs(self):
+        return (torch.randn(1, self.in_size, self.ic).to(self.op_dtype),)
+
+
+class AddMMModule(torch.nn.Module):
+    def __init__(self, in_size, out_size):
+        super().__init__()
+        self.mat = torch.nn.Parameter(torch.randn(in_size, out_size))
+        self.bias = torch.nn.Parameter(torch.randn(1, out_size))
+
+    def forward(self, x):
+        return torch.addmm(self.bias, x, self.mat)
+
+
+class LinearReluModule(torch.nn.Module):
+    def __init__(self, in_size, out_size, use_bias, dtype=torch.float):
+        super().__init__()
+        self.dtype = dtype
+        self.linear = torch.nn.Linear(in_size, out_size, bias=use_bias).to(dtype=dtype)
+
+    def forward(self, x):
+        return torch.nn.functional.relu(self.linear(x))
+
+    def get_inputs(self):
+        return (torch.randn(1, self.in_size, self.ic).to(self.op_dtype),)
+
+
+class LinearParallelSequentialModule(torch.nn.Module):
+    def __init__(
+        self,
+        in_size=2,
+        input_size=4,
+        intermediate_size=5,
+        output_size=3,
+        dtype=torch.float,
+    ):
+        super().__init__()
+        self.linear1_weight = torch.nn.Parameter(
+            torch.rand(intermediate_size, input_size)
+        )
+        self.linear1_bias = torch.nn.Parameter(torch.rand(intermediate_size))
+
+        self.linear2_weight = torch.nn.Parameter(
+            torch.rand(intermediate_size, input_size)
+        )
+        self.linear2_bias = torch.nn.Parameter(torch.rand(intermediate_size))
+
+        self.linear3_weight = torch.nn.Parameter(
+            torch.rand(output_size, intermediate_size)
+        )
+        self.linear3_bias = torch.nn.Parameter(torch.rand(output_size))
+        self.in_size = in_size
+        self.input_size = input_size
+        self.dtype = torch.float
+
+    def forward(self, x, y):
+        a = torch.nn.functional.linear(x, self.linear1_weight, self.linear1_bias)
+        b = torch.nn.functional.linear(y, self.linear2_weight, self.linear2_bias)
+        c = torch.nn.functional.linear(b, self.linear3_weight, self.linear3_bias)
+        return (a, c)
+
+    def get_inputs(self):
+        return (
+            torch.rand(self.in_size, self.input_size, dtype=self.dtype),
+            torch.rand(self.in_size, self.input_size, dtype=self.dtype),
+        )
+
+
+class LinearSequential(torch.nn.Module):
+    def __init__(
+        self,
+        in_size=2,
+        input_size=4,
+        intermediate_size=5,
+        output_size=3,
+        dtype=torch.float,
+    ):
+        super().__init__()
+        self.linear1_weight = torch.nn.Parameter(
+            torch.rand(intermediate_size, input_size)
+        )
+        self.linear1_bias = torch.nn.Parameter(torch.rand(intermediate_size))
+
+        self.linear2_weight = torch.nn.Parameter(
+            torch.rand(output_size, intermediate_size)
+        )
+        self.linear2_bias = torch.nn.Parameter(torch.rand(output_size))
+        self.in_size = in_size
+        self.input_size = input_size
+        self.dtype = torch.float
+
+    def forward(self, x):
+        a = torch.nn.functional.linear(x, self.linear1_weight, self.linear1_bias)
+        b = torch.nn.functional.linear(a, self.linear2_weight, self.linear2_bias)
+        return b
+
+    def get_inputs(self):
+        return (torch.rand(self.in_size, self.input_size, dtype=torch.float),)
+
 
 class TestLinear(unittest.TestCase):
+    """
+    Test Class for XNNPACK Linear Operators.
+
+    Notes:
+        - XNNPACK Does not support Per Tensor Quantized Weights with Dynamic Activations
+        - XNNPACK Only supports Per-Token Activation, so Dynamic per-tensor Quantization
+          As done by the default dynamic quantization flow does Per-Token Quantization
+          Activation under the hood, where the torch.nn.Module is doing Per-Tensor Quantization
+          on the Activation. This is sufficient because Per-Token Quantization on Activations
+          should produce strictly better results compared to Per-Tensor Quantization
+    """
+
+    @staticmethod
+    def _get_4b_dqconfig() -> QuantizationConfig:
+        # Returns a QuantizationConfig for 4b dynamic quantization for XNNPACK.
+        qconfig: QuantizationConfig = get_symmetric_quantization_config(
+            is_per_channel=True,
+            is_dynamic=True,
+            weight_qmin=-8,
+            weight_qmax=7,
+        )
+        return qconfig
+
     def test_fp16_linear(self):
         for use_bias in (True, False):
             for num_batch_dims in range(1, 3):
@@ -65,33 +224,13 @@ class TestLinear(unittest.TestCase):
                 )
 
     def test_fp32_addmm(self):
-        """
-        Note that the ConvertToLinear pass requires the weight matrix to be transposed.
-        """
-
-        class AddMMModule(torch.nn.Module):
-            def __init__(self, in_size, out_size):
-                super().__init__()
-                self.mat = torch.nn.Parameter(torch.randn(in_size, out_size))
-                self.bias = torch.nn.Parameter(torch.randn(1, out_size))
-
-            def forward(self, x):
-                return torch.addmm(self.bias, x, self.mat)
-
+        # Note that the ConvertToLinear pass requires the weight matrix to be transposed.
         self._test_linear(
             lambda in_size, out_size: AddMMModule(in_size, out_size),
             uses_bias=True,
         )
 
     def test_fp32_linear_fused_relu(self):
-        class LinearReluModule(torch.nn.Module):
-            def __init__(self, in_size, out_size, use_bias):
-                super().__init__()
-                self.linear = torch.nn.Linear(in_size, out_size, bias=use_bias)
-
-            def forward(self, x):
-                return torch.nn.functional.relu(self.linear(x))
-
         for use_bias in (True, False):
             for num_batch_dims in range(1, 3):
                 self._test_linear(
@@ -105,14 +244,6 @@ class TestLinear(unittest.TestCase):
                 )
 
     def test_qs8_linear_fused_relu(self):
-        class LinearReluModule(torch.nn.Module):
-            def __init__(self, in_size, out_size, use_bias):
-                super().__init__()
-                self.linear = torch.nn.Linear(in_size, out_size, bias=use_bias)
-
-            def forward(self, x):
-                return torch.nn.functional.relu(self.linear(x))
-
         for use_bias in (True, False):
             for num_batch_dims in range(1, 3):
                 self._test_linear(
@@ -138,21 +269,6 @@ class TestLinear(unittest.TestCase):
                     quant_type="per_tensor",
                 )
 
-    @unittest.skip("XNNPACK currently only supports per-channel dynamic quantization.")
-    def _test_qd8_per_tensor_linear(self):
-        for uses_bias in (False, True):
-            inputs = (torch.randn(2, 4),)
-            module = torch.nn.Linear(4, 5, bias=uses_bias)
-            dynamic_shapes = ({0: torch.export.Dim("batch", max=100)},)
-
-            self._test_dqlinear(
-                module,
-                inputs,
-                dynamic_shapes=dynamic_shapes,
-                is_per_channel=False,
-                uses_bias=uses_bias,
-            )
-
     def test_qd8_per_channel_linear(self):
         for uses_bias in (False, True):
             inputs = (torch.randn(2, 4),)
@@ -165,19 +281,6 @@ class TestLinear(unittest.TestCase):
                 is_per_channel=True,
                 uses_bias=uses_bias,
             )
-
-    @staticmethod
-    def _get_4b_dqconfig() -> QuantizationConfig:
-        """
-        Returns a QuantizationConfig for 4b dynamic quantization for XNNPACK.
-        """
-        qconfig: QuantizationConfig = get_symmetric_quantization_config(
-            is_per_channel=True,
-            is_dynamic=True,
-            weight_qmin=-8,
-            weight_qmax=7,
-        )
-        return qconfig
 
     def test_qd8_per_channel_4w_linear(self):
         qconfig = self._get_4b_dqconfig()
@@ -267,38 +370,12 @@ class TestLinear(unittest.TestCase):
         )
 
     def test_qd8_per_channel_linear_sequential(self):
-        in_size = 2
-        input_size = 4
-        intermediate_size = 5
-        output_size = 3
-
-        class LinearSequential(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear1_weight = torch.nn.Parameter(
-                    torch.rand(intermediate_size, input_size)
-                )
-                self.linear1_bias = torch.nn.Parameter(torch.rand(intermediate_size))
-
-                self.linear2_weight = torch.nn.Parameter(
-                    torch.rand(output_size, intermediate_size)
-                )
-                self.linear2_bias = torch.nn.Parameter(torch.rand(output_size))
-
-            def forward(self, x):
-                a = torch.nn.functional.linear(
-                    x, self.linear1_weight, self.linear1_bias
-                )
-                b = torch.nn.functional.linear(
-                    a, self.linear2_weight, self.linear2_bias
-                )
-                return b
-
-        inputs = (torch.rand(in_size, input_size, dtype=torch.float),)
+        lin_mod = LinearSequential()
+        inputs = lin_mod.get_inputs()
         dynamic_shapes = ({0: torch.export.Dim("batch", max=100)},)
 
         self._test_dqlinear(
-            LinearSequential(),
+            lin_mod,
             inputs,
             dynamic_shapes=dynamic_shapes,
             linear_count=2,
@@ -307,53 +384,16 @@ class TestLinear(unittest.TestCase):
             atol=1e-1,
         )
 
-    def test_qd8_per_channel_linear_parellel_and_sequential(self):
-        in_size = 2
-        input_size = 4
-        intermediate_size = 5
-        output_size = 3
-
-        class LinearModule(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear1_weight = torch.nn.Parameter(
-                    torch.rand(intermediate_size, input_size)
-                )
-                self.linear1_bias = torch.nn.Parameter(torch.rand(intermediate_size))
-
-                self.linear2_weight = torch.nn.Parameter(
-                    torch.rand(intermediate_size, input_size)
-                )
-                self.linear2_bias = torch.nn.Parameter(torch.rand(intermediate_size))
-
-                self.linear3_weight = torch.nn.Parameter(
-                    torch.rand(output_size, intermediate_size)
-                )
-                self.linear3_bias = torch.nn.Parameter(torch.rand(output_size))
-
-            def forward(self, x, y):
-                a = torch.nn.functional.linear(
-                    x, self.linear1_weight, self.linear1_bias
-                )
-                b = torch.nn.functional.linear(
-                    y, self.linear2_weight, self.linear2_bias
-                )
-                c = torch.nn.functional.linear(
-                    b, self.linear3_weight, self.linear3_bias
-                )
-                return (a, c)
-
-        inputs = (
-            torch.rand(in_size, input_size, dtype=torch.float),
-            torch.rand(in_size, input_size, dtype=torch.float),
-        )
+    def test_qd8_per_channel_linear_parallel_and_sequential(self):
+        lin_mod = LinearParallelSequentialModule()
+        inputs = lin_mod.get_inputs()
         dynamic_shapes = (
             {0: torch.export.Dim("batch", max=100)},
             {0: torch.export.Dim("batch2", max=100)},
         )
 
         self._test_dqlinear(
-            LinearModule(),
+            lin_mod,
             inputs,
             dynamic_shapes=dynamic_shapes,
             linear_count=3,
@@ -362,29 +402,9 @@ class TestLinear(unittest.TestCase):
             atol=1e-1,
         )
 
-    def test_qd8_fp32_per_token_weight_per_channel_int8(self):
-        self._run_manual_dqlinear_tests(8, torch.float)
-
-    def test_qd8_fp32_per_token_weight_per_channel_int4(self):
-        self._run_manual_dqlinear_tests(4, torch.float)
-
-    # This fails because the output tensor dtype is different, but if you squint and ignore that and look at the values,
-    # it is not too bad.
-    # Difference: max: 0.042601585388183594, abs: 0.042601585388183594.
-    # -- Model vs. Reference --
-    #  Numel: 68, 68
-    # Median: -0.7754800915718079, -0.7755751013755798
-    #   Mean: -0.6128872036933899, -0.6143574714660645
-    #    Max: 12.518657684326172, 12.516003608703613
-    #    Min: -20.070953369140625, -20.077701568603516
-    @unittest.skip("Need to fix the dq_per_channel output dtype")
-    def _test_qd8_fp16_per_token_weight_per_channel_int8(self):
-        self._run_manual_dqlinear_tests(8, torch.float16)
-
-    @unittest.skip("Need to fix the dq_per_channel output dtype")
-    def _test_qd8_fp16_per_token_weight_per_channel_int4(self):
-        self._run_manual_dqlinear_tests(4, torch.float16)
-
+    @unittest.skipIf(
+        not torchao_installed, "Per Channel Group Quantization Required TorchAO"
+    )
     def test_qd8_fp32_per_token_weight_per_channel_group_int4(self):
         M_sizes = [1, 2, 17, 31]
         K_sizes = [8, 32, 64, 128]
@@ -392,60 +412,49 @@ class TestLinear(unittest.TestCase):
         N_sizes = [2, 17, 92, 128]
 
         for use_bias in [True, False]:
-            for i, _ in enumerate(M_sizes):
-                M = int(M_sizes[i])
-                K = int(K_sizes[i])
-                N = int(N_sizes[i])
-                bl = int(bl_sizes[i])
-                mod = self.ManualDQLinear(
+            for M, K, bl, N in zip(M_sizes, K_sizes, bl_sizes, N_sizes):
+                lin_mod = BaseLinear(
                     input_channels=K,
                     output_channels=N,
-                    weight_n_bit=4,
                     dtype=torch.float,
-                    group_size=bl,
-                    force_groupwise_quant=True,
                     use_bias=use_bias,
                 )
 
                 inputs = (torch.randn(1, M, K),)
-                self._test_manual_dq_linear(
-                    mod,
-                    inputs,
-                    weight_groupwise=True,
-                    use_bias=use_bias,
+                self._test_groupwise_dq_linear(
+                    lin_mod, inputs, group_size=bl, use_bias=use_bias
                 )
 
-    @unittest.skip("Need to fix the dq_per_channel_group output dtype")
-    def _test_qd8_fp16_per_token_weight_per_channel_group_int4(self):
+    @unittest.skipIf(
+        not torchao_installed, "Per Channel Group Quantization Required TorchAO"
+    )
+    def test_qd8_fp16_per_token_weight_per_channel_group_int4(self):
         M_sizes = [1, 2, 17, 31]
         K_sizes = [8, 32, 64, 128]
         bl_sizes = [8, 16, 16, 32]
         N_sizes = [2, 17, 92, 128]
 
         for use_bias in [True, False]:
-            for i, _ in enumerate(M_sizes):
-                M = int(M_sizes[i])
-                K = int(K_sizes[i])
-                N = int(N_sizes[i])
-                bl = int(bl_sizes[i])
-                mod = self.ManualDQLinear(
+            for M, K, bl, N in zip(M_sizes, K_sizes, bl_sizes, N_sizes):
+                lin_mod = BaseLinear(
+                    in_size=M,
                     input_channels=K,
                     output_channels=N,
-                    weight_n_bit=4,
                     dtype=torch.float16,
-                    group_size=bl,
-                    force_groupwise_quant=True,
                     use_bias=use_bias,
                 )
 
-                inputs = (torch.randn(1, M, K, dtype=torch.float16),)
-                self._test_manual_dq_linear(
-                    mod,
-                    inputs,
-                    weight_groupwise=True,
-                    use_bias=use_bias,
-                    atol=0.1,
-                    rtol=0.1,
+                inputs = lin_mod.get_inputs()
+                # This requires slightly higher atol, but if you look at error it is not that bad:
+                # Difference: max: 0.00140380859375, abs: 0.00140380859375, mean abs error: 0.00042724609375.
+                # -- Model vs. Reference --
+                # Numel: 4, 4
+                # Median: -0.05023193359375, -0.0516357421875
+                # Mean: 0.2373046875, 0.237060546875
+                # Max: 1.0078125, 1.0078125
+                # Min: -0.08465576171875, -0.08441162109375
+                self._test_groupwise_dq_linear(
+                    lin_mod, inputs, group_size=bl, use_bias=use_bias, atol=1e-2
                 )
 
     def _test_linear(
@@ -467,7 +476,20 @@ class TestLinear(unittest.TestCase):
         input_sizes = [4, 37, 17]
         output_sizes = [4, 17, 37]
 
-        quant = quant_type is not None
+        quant_config = None
+        if quant_type is not None:
+            if quant_type == "per_channel":
+                quant_config = get_symmetric_quantization_config(
+                    is_per_channel=True,
+                    is_dynamic=False,
+                )
+            elif quant_type == "per_tensor":
+                quant_config = get_symmetric_quantization_config(
+                    is_per_channel=False,
+                    is_dynamic=False,
+                )
+            else:
+                raise ValueError(f"Unsupported quant type {quant_type}")
 
         """
         Note that torch.nn.Linear maps to aten.mm.default (no bias) or aten.addmm.default (bias),
@@ -478,7 +500,6 @@ class TestLinear(unittest.TestCase):
             input_size = int(input_sizes[i])
             output_size = int(output_sizes[i])
             input_shape = [in_size] * num_batch_dims + [input_size]
-            print(f"Testing input_shape {input_shape} with {output_size} out_channels")
 
             module = make_module(input_size, output_size).eval().to(dtype)
             inputs = (torch.randn(input_shape).to(dtype),)
@@ -487,28 +508,15 @@ class TestLinear(unittest.TestCase):
                 dynamic_shape[i] = torch.export.Dim(f"batch{i}", min=2, max=in_size)
 
             dynamic_shape = (dynamic_shape,)
-            print(dynamic_shape)
 
             for legacy_mode in (True, False):
                 tester = Tester(module, inputs, dynamic_shapes=dynamic_shape)
 
-                if quant:
-                    if quant_type == "per_channel":
-                        quant_config = get_symmetric_quantization_config(
-                            is_per_channel=True,
-                            is_dynamic=False,
-                        )
-                    elif quant_type == "per_tensor":
-                        quant_config = get_symmetric_quantization_config(
-                            is_per_channel=False,
-                            is_dynamic=False,
-                        )
-                    else:
-                        raise ValueError(f"Unsupported quant type {quant_type}")
+                if quant_config:
                     tester.quantize(Quantize(quantization_config=quant_config))
 
                 tester.export()
-                if quant:
+                if quant_config:
                     tester.check(["torch.ops.quantized_decomposed"])
 
                 if legacy_mode:
@@ -522,12 +530,19 @@ class TestLinear(unittest.TestCase):
                 )
                 tester.check_not([edge_op])
 
-                if quant:
-                    tester.check_not([edge_op, "torch.ops.quantized_decomposed"])
+                if quant_config:
+                    tester.check_not(
+                        [
+                            "executorch_exir_dialects_edge__ops_aten_mm_default",
+                            "executorch_exir_dialects_edge__ops_aten_addmm_default",
+                        ]
+                    )
 
                 tester.to_executorch()
                 tester.serialize()
-                tester.run_method_and_compare_outputs(qtol=quant, atol=atol)
+                tester.run_method_and_compare_outputs(
+                    qtol=bool(quant_config), atol=atol
+                )
 
     def _test_dqlinear(
         self,
@@ -540,24 +555,19 @@ class TestLinear(unittest.TestCase):
         qconfig: Optional[QuantizationConfig] = None,
         atol=5e-02,
     ):
-        edge_op = (
-            "executorch_exir_dialects_edge__ops_aten_addmm_default"
-            if uses_bias
-            else "executorch_exir_dialects_edge__ops_aten_mm_default"
-        )
-
         quant_config = qconfig or get_symmetric_quantization_config(
             is_per_channel=is_per_channel,
             is_dynamic=True,
         )
         for legacy_partitioner in (True, False):
             for per_op_mode in (True, False):
-                tester = Tester(module, inputs, dynamic_shapes=dynamic_shapes)
-                tester.quantize(Quantize(quantization_config=quant_config))
                 DynamicallyQuantizedPartitioner = XnnpackPartitioner(
                     config_precisions=ConfigPrecisionType.DYNAMIC_QUANT,
                     per_op_mode=per_op_mode,
                 )
+
+                tester = Tester(module, inputs, dynamic_shapes=dynamic_shapes)
+                tester.quantize(Quantize(quantization_config=quant_config))
                 tester.export()
 
                 if legacy_partitioner:
@@ -567,357 +577,74 @@ class TestLinear(unittest.TestCase):
                     tester.to_edge_transform_and_lower(
                         ToEdgeTransformAndLower([DynamicallyQuantizedPartitioner])
                     )
-                num_call_delegates = linear_count if per_op_mode else 1
                 tester.check_count(
                     {
-                        "torch.ops.higher_order.executorch_call_delegate": num_call_delegates
+                        "torch.ops.higher_order.executorch_call_delegate": (
+                            linear_count if per_op_mode else 1
+                        )
                     }
                 )
-                tester.check_not([edge_op])
+                tester.check_not(
+                    [
+                        "executorch_exir_dialects_edge__ops_aten_mm_default",
+                        "executorch_exir_dialects_edge__ops_aten_addmm_default",
+                    ]
+                )
 
                 tester.to_executorch()
                 tester.serialize()
                 tester.run_method_and_compare_outputs(atol=atol)
 
-    class ManualDQLinear(torch.nn.Module):
-        def __init__(
-            self,
-            input_channels: int = 4,
-            output_channels: int = 4,
-            dtype: torch.dtype = torch.float,
-            weight_n_bit: int = 4,
-            group_size: int = 0,
-            force_groupwise_quant: bool = False,
-            use_bias: bool = False,
-        ):
-            super().__init__()
-
-            self.ic = input_channels
-            self.oc = output_channels
-
-            assert dtype in [torch.float, torch.half], "Unsupported op dtype"
-            self.op_dtype = dtype
-
-            self.group_size = self.ic if group_size == 0 else group_size
-            self.num_groups = 1
-            if self.group_size != self.ic:
-                assert self.ic % self.group_size == 0
-                assert self.group_size % 8 == 0  # TODO make this 16
-                self.num_groups = self.ic // self.group_size
-
-            assert weight_n_bit in [4, 8], "Unsupported weight_n_bit"
-            self.w_n_bit = weight_n_bit
-            self.w_quant_min, self.w_quant_max = self.get_min_max(self.w_n_bit)
-
-            self.w = torch.nn.Parameter(
-                torch.randn(self.oc, self.ic), requires_grad=False
-            )
-            self.w_q = torch.nn.Parameter(
-                torch.zeros(self.oc, self.ic), requires_grad=False
-            )
-            # Quantize the weights as per folded setup
-            if self.group_size != self.ic or force_groupwise_quant:
-                self.w_scales = torch.nn.Parameter(
-                    torch.zeros(self.oc, self.num_groups), requires_grad=False
-                )
-                self.w_zero_points = torch.nn.Parameter(
-                    torch.zeros(self.oc, self.num_groups), requires_grad=False
-                )
-                self.quant_weight_per_channel_group()
-            else:  # per_channel quantization
-                self.w_scales = torch.nn.Parameter(
-                    torch.zeros(self.oc), requires_grad=False
-                )
-                self.w_zero_points = torch.nn.Parameter(
-                    torch.zeros(self.oc), requires_grad=False
-                )
-                self.quant_weight_per_channel()
-
-            self.bias = (
-                torch.nn.Parameter(
-                    torch.randn(self.oc).to(self.op_dtype), requires_grad=False
-                )
-                if use_bias
-                else None
-            )
-
-        def get_min_max(self, n_bit: int = 4):
-            max_int = 2 ** (n_bit - 1) - 1
-            min_int = -(2 ** (n_bit - 1))
-            return min_int, max_int
-
-        def get_channel_qparams_symmetric(
-            self,
-            w: torch.Tensor,
-            n_bit: int = 4,
-            precision: torch.dtype = torch.float32,
-        ):
-            assert w.dim() == 2
-
-            to_quant = w.to(precision)
-            assert torch.isnan(to_quant).sum() == 0
-
-            max_val = to_quant.amax(dim=1, keepdim=True)
-            min_val = to_quant.amin(dim=1, keepdim=True)
-            min_val_neg = torch.min(min_val, torch.zeros_like(min_val))
-            max_val_pos = torch.max(max_val, torch.zeros_like(max_val))
-
-            min_int, max_int = self.get_min_max(n_bit)
-
-            max_val_abs = torch.max(-min_val_neg, max_val_pos)
-            scales = max_val_abs / (float(max_int - min_int) / 2)
-            scales = torch.max(
-                scales, torch.full_like(scales, torch.finfo(torch.float32).eps)
-            )
-            zeros = torch.full_like(scales, 0)
-            return scales.to(precision).reshape(w.shape[0]), zeros.to(
-                precision
-            ).reshape(w.shape[0]).reshape(w.shape[0])
-
-        # Note: not using from torchao.quantization.quant_primitives because it will run into op registraion issues
-        def get_group_qparams_symmetric(
-            self, w, n_bit=4, groupsize=128, precision=torch.float32
-        ):
-            # needed for GPTQ with padding
-            if groupsize > w.shape[-1]:
-                groupsize = w.shape[-1]
-            assert groupsize > 1
-            assert w.shape[-1] % groupsize == 0
-            assert w.dim() == 2
-
-            to_quant = w.reshape(-1, groupsize)
-            assert torch.isnan(to_quant).sum() == 0
-
-            max_val = to_quant.amax(dim=1, keepdim=True)
-            min_val = to_quant.amin(dim=1, keepdim=True)
-            min_val_neg = torch.min(min_val, torch.zeros_like(min_val))
-            max_val_pos = torch.max(max_val, torch.zeros_like(max_val))
-
-            max_val_abs = torch.max(-min_val_neg, max_val_pos)
-            max_int = 2 ** (n_bit - 1) - 1
-            min_int = -(2 ** (n_bit - 1))
-
-            scales = max_val_abs / (float(max_int - min_int) / 2)
-            scales = torch.max(
-                scales, torch.full_like(scales, torch.finfo(torch.float32).eps)
-            )
-            # TODO: make sure abs(scales) is not too small?
-            zeros = torch.full_like(scales, 0)
-            return scales.to(precision).reshape(w.shape[0], -1), zeros.to(
-                precision
-            ).reshape(w.shape[0], -1)
-
-        # Note: not using from torchao.quantization.quant_primitives because it will run into op registraion issues
-        def group_quantize_tensor_symmetric(
-            self, w, n_bit=4, group_size=128, precision=torch.float32
-        ):
-            scales, zeros = self.get_group_qparams_symmetric(
-                w, n_bit, group_size, precision
-            )
-            n_bit = 4
-            max_int = 2 ** (n_bit - 1) - 1
-            min_int = -(2 ** (n_bit - 1))
-            # TODO: currently we don't know how to express torch.int4, we'll
-            # add torch.int4 to core later
-            w_int8 = torch.ops.quantized_decomposed.quantize_per_channel_group(
-                w, scales, zeros, min_int, max_int, torch.int8, group_size
-            )
-
-            return w_int8, scales, zeros
-
-        def fwd_input_per_token(self, input: torch.Tensor) -> torch.Tensor:
-            ip_quant_min = -128
-            ip_quant_max = 127
-            (
-                ip_scales,
-                ip_zero_points,
-            ) = torch.ops.quantized_decomposed.choose_qparams_per_token_asymmetric(
-                input, torch.int8
-            )
-
-            input = torch.ops.quantized_decomposed.quantize_per_token(
-                input,
-                ip_scales,
-                ip_zero_points,
-                ip_quant_min,
-                ip_quant_max,
-                torch.int8,
-            )
-            input = torch.ops.quantized_decomposed.dequantize_per_token(
-                input,
-                ip_scales,
-                ip_zero_points,
-                ip_quant_min,
-                ip_quant_max,
-                torch.int8,
-                self.op_dtype,
-            )
-            return input
-
-        def quant_weight_per_channel(self):
-            (
-                self.w_scales.data,
-                self.w_zero_points.data,
-            ) = self.get_channel_qparams_symmetric(
-                self.w, n_bit=self.w_n_bit, precision=self.op_dtype
-            )
-            self.w_q.data = torch.ops.quantized_decomposed.quantize_per_channel(
-                self.w,
-                self.w_scales,
-                self.w_zero_points,
-                axis=0,
-                quant_min=self.w_quant_min,
-                quant_max=self.w_quant_max,
-                dtype=torch.int8,
-            )
-
-        def quant_weight_per_channel_group(self):
-            self.w_q.data, w, zp = self.group_quantize_tensor_symmetric(
-                self.w,
-                n_bit=self.w_n_bit,
-                group_size=self.group_size,
-            )
-            expected_min, expected_max = self.get_min_max(self.w_n_bit)
-            assert (
-                torch.min(self.w_q.data) >= expected_min
-            ), "Found smaller than min element in quantized weight tensor"
-            assert (
-                torch.max(self.w_q.data) <= expected_max
-            ), "Found larger than max element in quantized weight tensor"
-            assert (
-                w.ndim == 2 and zp.ndim == 2
-            ), f"Expecting 2d scales and zp tensors, but got {w.shape}, {zp.shape}"
-            self.w_scales.data, self.w_zero_points.data = w, zp
-
-        def fwd_weight_per_channel(self) -> torch.Tensor:
-            # This is HACKY because the dequant will produce fp32
-            return torch.ops.quantized_decomposed.dequantize_per_channel(
-                self.w_q,
-                self.w_scales,
-                self.w_zero_points,
-                axis=0,
-                quant_min=self.w_quant_min,
-                quant_max=self.w_quant_max,
-                dtype=torch.int8,  # Regardless of w_n_bit, convert to 4b later
-            )
-
-        def fwd_weight_per_channel_group(self) -> torch.Tensor:
-            return torch.ops.quantized_decomposed.dequantize_per_channel_group(
-                self.w_q,
-                self.w_scales,
-                self.w_zero_points,
-                self.w_quant_min,
-                self.w_quant_max,
-                dtype=torch.int8,  # Regardless of w_n_bit, convert to 4b later
-                group_size=self.group_size,
-                output_dtype=self.op_dtype,
-            )
-
-        def forward(self, input: torch.Tensor) -> torch.Tensor:
-            # Input
-            input = self.fwd_input_per_token(input)
-
-            # Weights
-            w = (
-                self.fwd_weight_per_channel_group()
-                if self.w_scales.ndim == 2
-                else self.fwd_weight_per_channel()
-            )
-            assert isinstance(w, torch.Tensor)
-            return torch.nn.functional.linear(input, w, self.bias)
-
-    def _test_manual_dq_linear(
+    def _test_groupwise_dq_linear(
         self,
         mod: torch.nn.Module,
         inputs: Tuple[torch.Tensor],
-        weight_groupwise: bool = False,
         use_bias: bool = False,
+        group_size: int = 8,
+        num_linears: int = 1,
         atol: float = 1e-3,
         rtol: float = 1e-3,
     ):
-        linear_edge_op = (
-            "executorch_exir_dialects_edge__ops_aten_addmm_default"
-            if use_bias
-            else "executorch_exir_dialects_edge__ops_aten_mm_default"
+        quantize_(mod, int8_dynamic_activation_int4_weight(group_size=group_size))
+        unwrap_tensor_subclass(mod)
+        DynamicallyQuantizedPartitioner = XnnpackPartitioner(
+            config_precisions=ConfigPrecisionType.DYNAMIC_QUANT,
+            per_op_mode=True,
+        )
+        tester = (
+            Tester(mod, inputs)
+            .export()
+            .check_count(
+                {
+                    "torch.ops.quant.choose_qparams_affine.default": 1 * num_linears,
+                    "torch.ops.quant.quantize_affine.default": 1 * num_linears,
+                    "torch.ops.quant.dequantize_affine.default": 2 * num_linears,
+                    "torch.ops.aten.linear.default": 1 * num_linears,
+                }
+            )
+        )
+        (
+            tester.to_edge_transform_and_lower(
+                ToEdgeTransformAndLower([DynamicallyQuantizedPartitioner])
+            )
         )
 
-        weight_dq_edge_op = (
-            "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_channel_group_default"
-            if weight_groupwise
-            else "torch.ops.quantized_decomposed.dequantize_per_channel.default"
+        (
+            tester.check_count(
+                {
+                    "torch.ops.higher_order.executorch_call_delegate": 1,
+                }
+            )
+            .check_not(
+                [
+                    "executorch_exir_dialects_edge__ops_quant_choose_qparams_affine_default",
+                    "executorch_exir_dialects_edge__ops_quant_quantize_affine_default",
+                    "executorch_exir_dialects_edge__ops_quant_dequantize_affine_default",
+                    "executorch_exir_dialects_edge__ops_aten_mm_default",
+                    "executorch_exir_dialects_edge__ops_aten_addmm_default",
+                ]
+            )
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs(atol=atol, rtol=rtol)
         )
-
-        weight_dq_aten_op = (
-            "torch.ops.quantized_decomposed.dequantize_per_channel_group.default"
-            if weight_groupwise
-            else "torch.ops.quantized_decomposed.dequantize_per_channel.default"
-        )
-        for legacy_partitioner in (True, False):
-            tester = (
-                Tester(mod, inputs)
-                .export()
-                .check_count(
-                    {
-                        "torch.ops.quantized_decomposed.choose_qparams_per_token_asymmetric.default": 1,
-                        "torch.ops.quantized_decomposed.quantize_per_token.default": 1,
-                        "torch.ops.quantized_decomposed.dequantize_per_token.default": 1,
-                        weight_dq_aten_op: 1,
-                        "torch.ops.aten.linear.default": 1,
-                    }
-                )
-            )
-
-            DynamicallyQuantizedPartitioner = XnnpackPartitioner(
-                config_precisions=ConfigPrecisionType.DYNAMIC_QUANT,
-                per_op_mode=True,
-            )
-            if legacy_partitioner:
-                tester.to_edge()
-                tester.partition(Partition(DynamicallyQuantizedPartitioner))
-            else:
-                (
-                    tester.to_edge_transform_and_lower(
-                        ToEdgeTransformAndLower([DynamicallyQuantizedPartitioner])
-                    )
-                )
-
-            (
-                tester.check_count(
-                    {
-                        "torch.ops.higher_order.executorch_call_delegate": 1,
-                    }
-                )
-                .check_not(
-                    [
-                        "executorch_exir_dialects_edge__ops_quantized_decomposed_choose_qparams_per_token_asymmetric_default",
-                        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_token_default",
-                        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_token_default",
-                        weight_dq_edge_op,
-                        linear_edge_op,
-                    ]
-                )
-                .to_executorch()
-                .serialize()
-                .run_method_and_compare_outputs(atol=atol, rtol=rtol)
-            )
-
-    def _run_manual_dqlinear_tests(self, weight_n_bit: int, op_dtype: torch.dtype):
-        in_sizes = [1, 4, 4]
-        input_sizes = [4, 37, 17]
-        output_sizes = [4, 17, 37]
-
-        for use_bias in [True, False]:
-            for i, _ in enumerate(in_sizes):
-                in_size = int(in_sizes[i])
-                input_size = int(input_sizes[i])
-                output_size = int(output_sizes[i])
-                mod = self.ManualDQLinear(
-                    input_channels=input_size,
-                    output_channels=output_size,
-                    weight_n_bit=weight_n_bit,
-                    dtype=op_dtype,
-                    use_bias=use_bias,
-                )
-
-                inputs = (torch.randn(1, in_size, input_size).to(op_dtype),)
-                self._test_manual_dq_linear(mod, inputs, use_bias=use_bias)

--- a/backends/xnnpack/test/tester/tester.py
+++ b/backends/xnnpack/test/tester/tester.py
@@ -561,7 +561,8 @@ class Tester:
         if not to_edge_stage:
             to_edge_stage = ToEdge()
         to_edge_stage.edge_compile_conf._skip_dim_order = True
-        return self._run_stage(to_edge_stage)
+        res = self._run_stage(to_edge_stage)
+        return res
 
     def to_edge_transform_and_lower(
         self, to_edge_and_transform_stage: Optional[ToEdgeTransformAndLower] = None

--- a/backends/xnnpack/utils/quant_utils.py
+++ b/backends/xnnpack/utils/quant_utils.py
@@ -4,6 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import operator
+from itertools import accumulate
+from typing import cast
+
 import torch
 from executorch.exir.backend.canonical_partitioners.config_partitioner import (
     format_target_name,
@@ -15,6 +19,7 @@ _Q_OPS = {
     "quantize_per_channel.default",
     "quantize_per_channel_group.default",
     "quantize_per_token.default",
+    "quantize_affine.default",
 }
 
 _DQ_OPS = {
@@ -23,12 +28,14 @@ _DQ_OPS = {
     "dequantize_per_channel.default",
     "dequantize_per_channel_group.default",
     "dequantize_per_token.default",
+    "dequantize_affine.default",
 }
 
 
 _QPARAM_OPS = {
     "choose_qparams.tensor",
     "choose_qparams_per_token_asymmetric.default",
+    "choose_qparams_affine.default",
 }
 
 _DYNAMIC_OPS = {
@@ -43,8 +50,9 @@ def is_dynamic_qdq(node: torch.fx.Node) -> bool:
     if node.op != "call_function":
         return False
     node_name = format_target_name(node.target.__name__)  # pyre-ignore
+    is_dynamic_affine = is_per_token(node) and not is_per_channel_group(node)
 
-    return node_name in _DYNAMIC_OPS
+    return node_name in _DYNAMIC_OPS or is_dynamic_affine
 
 
 def is_qparam(node: torch.fx.Node) -> bool:
@@ -75,4 +83,106 @@ def is_per_channel(node: torch.fx.Node) -> bool:
     if not (is_quant(node) or is_dequant(node)):
         return False
 
-    return "per_channel" in node.target.__name__  # pyre-ignore
+    is_affine_per_channel_group = is_per_channel_group(node)
+    is_per_channel = "per_channel" in node.target.__name__  # pyre-ignore
+
+    return is_per_channel or is_affine_per_channel_group
+
+
+def is_affine_qdq(node: torch.fx.Node) -> bool:
+    if not (is_quant(node) or is_dequant(node)):
+        return False
+
+    return "quantize_affine" in node.target.__name__  # pyre-ignore
+
+
+def _get_block_size_input_scale(node: torch.fx.Node):
+    assert is_affine_qdq(node)
+    block_size = node.args[1]
+    input_val = node.all_input_nodes[0].meta["val"]
+    scale_val = node.all_input_nodes[1].meta["val"]
+    return block_size, input_val, scale_val
+
+
+def is_per_token(node: torch.fx.Node):
+    if not (is_quant(node) or is_dequant(node)):
+        return False
+
+    if "per_token" in node.target.__name__:  # pyre-ignore
+        return True
+    elif is_affine_qdq(node):
+        block_size, input_val, scale_val = _get_block_size_input_scale(node)
+        flag = True
+        scale_numel_expected = 1
+        for i in range(len(block_size) - 1):
+            flag &= block_size[i] == 1
+            scale_numel_expected *= input_val.shape[i]
+
+        flag &= block_size[-1] == input_val.shape[-1]
+        flag &= scale_val.numel() == scale_numel_expected
+        return flag
+
+    return False
+
+
+def is_per_channel_group(node: torch.fx.Node):
+    if not (is_quant(node) or is_dequant(node)):
+        return False
+
+    if "per_channel_group" in node.target.__name__:  # pyre-ignore
+        return True
+    elif is_affine_qdq(node):
+        block_size, input_val, scale_val = _get_block_size_input_scale(node)
+        flag = True
+        flag &= len(block_size) == 2
+        flag &= block_size[0] == 1
+        group_size = block_size[1]
+        scale_numel = list(accumulate(scale_val.shape, operator.mul))[-1]
+        input_numel = list(accumulate(input_val.shape, operator.mul))[-1]
+        flag &= input_numel == group_size * scale_numel
+        return flag
+
+    return False
+
+
+def extract_qdq_affine_op_args_for_decomposed_ops(node: torch.fx.Node):
+    if not is_affine_qdq(node):
+        return None, None
+    # make sure input_dtype and zero_point_domain have expected values
+    input_node = node.args[0]
+    scale_node = node.args[2]
+    zero_point_node = node.args[3]
+    args = [input_node, scale_node, zero_point_node]
+    assert (
+        len(node.args) > 4
+    ), f"expecting at least 6 args, got node: {node.format_node()}"
+
+    if node.args[4] != torch.int8:
+        return None, None
+    target_dtype = cast(torch.dtype, node.args[4])
+
+    if len(node.args) > 6:
+        # quant_min
+        args.append(node.args[5])
+        # quant_max
+        args.append(node.args[6])
+    else:
+        dtype_info = torch.iinfo(target_dtype)
+        quant_min = dtype_info.min
+        quant_max = dtype_info.max
+        args.append(quant_min)
+        args.append(quant_max)
+
+    # add target_dtype_node after quant_min/quant_max
+    args.append(target_dtype)
+    # zero_point_domain
+    if len(node.args) > 7 and node.args[7] != "INT":
+        return None, None
+
+    if is_per_channel_group(node):
+        block_sizes = cast(list[int], node.args[1])
+        args.append(block_sizes[-1])
+
+    args.append(node.args[-1])
+
+    return args


### PR DESCRIPTION
Summary:
In torchao we are moving to use more general quant_primitive ops like quant_affine/dequantize_affine etc.: https://github.com/pytorch/ao/blob/main/torchao/quantization/quant_primitives.py

while in xnnpack we are still using the more specialized ops like quantize_per_token, quantize_per_channel_group

In this diff, we introduce an extra pass to translate the general ops to specialized ops so that xnnpack lowering works for torchao quant flow as well,
so that torchao can remove these old quant flows (e.g. Int8DynActInt4WeightQuantizer)

Reviewed By: digantdesai

Differential Revision: D61363183
