### PR TITLE
Fix SDPA decomp problem

### DIFF
--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -18,12 +18,13 @@ from executorch.backends.cadence.aot.passes import (
     ReplaceLogicalNotBooleanWhereWithWherePass,
     ReplacePT2DequantWithCadenceDequantPass,
     ReplacePT2QuantWithCadenceQuantPass,
+    ReplaceSafeSoftmaxWithSoftmax,
     ReplaceScalarTensorWithFullPass,
     ReplaceSqueezeAndUnsqueezeWithViewPass,
 )
 from executorch.backends.cadence.aot.quantizer.fusion_pass import QuantFusion
 from executorch.backends.cadence.aot.quantizer.quantizer import CadenceQuantizer
-from executorch.backends.cadence.aot.utils import model_is_quantized
+from executorch.backends.cadence.aot.utils import model_gm_has_SDPA, model_is_quantized
 from executorch.backends.transforms.decompose_sdpa import (
     DecomposeScaledDotProductAttention,
 )
@@ -57,13 +58,20 @@ def convert_pt2(
     """
 
     # Export with dynamo
-    model_exp = capture_pre_autograd_graph(model, inputs)
+    model_gm = capture_pre_autograd_graph(model, inputs)
 
-    # Decompose SDPA
-    DecomposeScaledDotProductAttention(False)(model_exp)
+    if model_gm_has_SDPA(model_gm):
+        # Decompose SDPA
+        DecomposeScaledDotProductAttention(False)(model_gm)
+
+        # Swap _safe_softmax with _softmax (see https://github.com/pytorch/pytorch/pull/133882
+        # for details).
+        result = ReplaceSafeSoftmaxWithSoftmax()(model_gm)
+        assert result is not None
+        model_gm = result.graph_module
 
     # Prepare
-    prepared_model = prepare_pt2e(model_exp, quantizer)
+    prepared_model = prepare_pt2e(model_gm, quantizer)
 
     # Calibrate
     prepared_model(*inputs)

--- a/backends/cadence/aot/utils.py
+++ b/backends/cadence/aot/utils.py
@@ -177,3 +177,11 @@ def print_ops_info(
                 tablefmt="outline",
             )
         )
+
+
+def model_gm_has_SDPA(model_gm: torch.fx.GraphModule) -> bool:
+    for node in model_gm.graph.nodes:
+        if node.op == "call_function":
+            if node.target == torch.ops.aten.scaled_dot_product_attention.default:
+                return True
+    return False


### PR DESCRIPTION
Summary:
As titled. The new `_safe_softmax` function is meant to avoid NaN issues mostly in training. For inference, we shouldn't need it so we swap with the regular softmax, which will prevent the decomposition that introduces the unsupported ops (`eq`, `logical_not` and `any`). See https://www.internalfb.com/code/fbsource/fbcode/caffe2/torch/_decomp/decompositions.py?lines=425.

Note that it needed some changes to `run_and_verify` since we now need some aten IR changes. I will fix it in another diff, where `run_and_verify` will use a nop quantizer instead. This way the code path will be the same for fp32 and quantized. But let's make CI green first!

We will also need to formalize better how to apply passes on the initial graph module (aten IR passes as opposed to edge IR passes). Seems like lifted constants and other things like that can create issues, but unless we see errors, let's wait until the IR changes from PT/ET are in first.

Reviewed By: hsharma35

Differential Revision: D61639074


