### PR TITLE
[Build] Define ssize_t for windows build.

### DIFF
--- a/runtime/core/portable_type/tensor.h
+++ b/runtime/core/portable_type/tensor.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <executorch/runtime/platform/compiler.h>
-#include <sys/types.h> // TODO(T126923429): Include size_t, ssize_t
 
 #include <executorch/runtime/core/portable_type/tensor_impl.h>
 

--- a/runtime/core/portable_type/tensor_impl.h
+++ b/runtime/core/portable_type/tensor_impl.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <sys/types.h> // TODO(T126923429): Include size_t, ssize_t
-
 #include <executorch/runtime/core/array_ref.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/portable_type/scalar_type.h>

--- a/runtime/platform/compiler.h
+++ b/runtime/platform/compiler.h
@@ -138,6 +138,14 @@
 #endif
 #endif // ifndef
 
+// Define size_t and ssize_t.
+#ifndef _WIN32
+#include <sys/types.h>
+#else
+#include <stddef.h>
+using ssize_t = ptrdiff_t;
+#endif
+
 // DEPRECATED: Use the non-underscore-prefixed versions instead.
 // TODO(T199005537): Remove these once all users have stopped using them.
 #define __ET_DEPRECATED ET_DEPRECATED


### PR DESCRIPTION
Move size_t and ssize_t header to runtime/platform/compiler.h. Define ssize_t for windows as ptrdiff_t.

For #4661