### PR TITLE
Adding sdpa_with_attn_bias

### DIFF
--- a/extension/llm/custom_ops/op_sdpa.h
+++ b/extension/llm/custom_ops/op_sdpa.h
@@ -31,6 +31,17 @@ Tensor& sdpa_with_kv_cache_out(
     const optional<double> scale,
     Tensor& output);
 
+Tensor& sdpa_with_attn_bias_out(
+    RuntimeContext& ctx,
+    const Tensor& q_projected,
+    const Tensor& k_projected,
+    const Tensor& v_projected,
+    const optional<Tensor>& attn_bias,
+    const double dropout_p,
+    // @lint-ignore CLANGTIDY facebook-hte-ParameterMightThrowOnCopy
+    const optional<double> scale,
+    Tensor& output);
+
 Tensor& flash_attention_kernel_out(
     KernelRuntimeContext& ctx,
     const Tensor& query,


### PR DESCRIPTION
Summary:
This adds a custom sdpa_with_attn_bias kernel, which performs full bidirectional attention (i.e. not causal) and introduces a bias before the softmax operation.

This diff implements the skeleton and calls cpu_flash_attention, which needs further modifications to the attention mask (in a following diff in the stack)

Differential Revision: D61691209
