### PR TITLE
[Build] Add install_requirements.bat for windows build

### DIFF
--- a/install_requirements.bat
+++ b/install_requirements.bat
@@ -1,0 +1,21 @@
+@ECHO OFF
+
+rem Copyright (c) Meta Platforms, Inc. and affiliates.
+rem All rights reserved.
+
+rem This batch file provides a basic functionality similar to the bash script.
+
+cd /d "%~dp0"
+
+rem Find the names of the python tools to use (replace with your actual python installation)
+if "%PYTHON_EXECUTABLE%"=="" (
+  if "%CONDA_DEFAULT_ENV%"=="" OR "%CONDA_DEFAULT_ENV%"=="base" OR NOT EXIST "python" (
+    set PYTHON_EXECUTABLE=python3
+  ) else (
+    set PYTHON_EXECUTABLE=python
+  )
+)
+
+"%PYTHON_EXECUTABLE%" install_requirements.py %*
+
+exit /b %ERRORLEVEL%

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -83,6 +83,12 @@ for arg in sys.argv[1:]:
         print(f"Error: Unknown option {arg}")
         sys.exit(1)
 
+# Use ClangCL on Windows.
+# ClangCL is an alias to Clang that configures it to work in an MSVC-compatible
+# mode. Using it on Windows to avoid compiler compatibility issues for MSVC.
+if os.name == "nt":
+    CMAKE_ARGS += " -T ClangCL"
+
 # Since ExecuTorch often uses main-branch features of pytorch, only the nightly
 # pip versions will have the required features.
 #


### PR DESCRIPTION
Add install_requirements.bat on windows like install_requirements.sh.
Also force use ClangCL on windows in install_requirements.py.

For #4661