### PR TITLE
[Build] Remove .exe suffix on windows

### DIFF
--- a/build/pip_data_bin_init.py.in
+++ b/build/pip_data_bin_init.py.in
@@ -21,7 +21,9 @@ def _find_executable_files_under(dir):
     for filename in os.listdir(dir):
         filepath = os.path.join(dir, filename)
         if os.path.isfile(filepath) and os.access(filepath, os.X_OK):
-            bin_names.append(filename)
+            # Remove .exe suffix on windows.
+            filename_without_ext = os.path.splitext(filename)[0]
+            bin_names.append(filename_without_ext)
     return bin_names
 
 # The list of binaries to create wrapper functions for.


### PR DESCRIPTION
Windows executables will have .exe suffix.
It will cause illegal python code `def flat.exe():` generated.

This change fixes the issue by removing the suffix.

For #4661