### PR TITLE
[ET-VK] Set export log level INFO

### DIFF
--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -38,6 +38,9 @@ ops_not_to_decompose = [
     torch.ops.aten.upsample_nearest2d.vec,
 ]
 
+logger: logging.Logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 
 class VulkanSupportedOperators(OperatorSupportBase):
     _ops: OpList = enumerate_supported_ops()
@@ -110,7 +113,7 @@ class VulkanSupportedOperators(OperatorSupportBase):
     ) -> bool:
         r = self._is_node_supported(submodules, node)
         if not r and node.op == "call_function":
-            logging.info(f"Skipping node in Vulkan partitioning: {node.format_node()}")
+            logger.info(f"Skipping node in Vulkan partitioning: {node.format_node()}")
         return r
 
     def _is_node_supported(
@@ -179,9 +182,9 @@ class VulkanPartitioner(Partitioner):
 
         pl = len(partition_list)
         if pl == 0:
-            logging.warning("No Vulkan subgraphs can be partitioned!")
+            logger.warning("No Vulkan subgraphs can be partitioned!")
         else:
-            logging.info(f"Found {pl} Vulkan subgraphs to be partitioned.")
+            logger.info(f"Found {pl} Vulkan subgraphs to be partitioned.")
 
         tag_constant_data(exported_program)
 

--- a/backends/vulkan/serialization/vulkan_graph_builder.py
+++ b/backends/vulkan/serialization/vulkan_graph_builder.py
@@ -24,6 +24,9 @@ _Argument = Union[
     Node, NoneType, _ScalarType, TensorSpec, List[_ScalarType], List[Node], str
 ]
 
+logger: logging.Logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 
 class VkGraphBuilder:
     def __init__(
@@ -351,9 +354,9 @@ class VkGraphBuilder:
             self.process_node(node, call_node_debug_hdl)
             call_node_debug_hdl += 1
 
-        logging.info("Operators included in this Vulkan partition: ")
+        logger.info("Operators included in this Vulkan partition: ")
         for op in self.seen_ops:
-            logging.info(f"    {op.__name__}")
+            logger.info(f"    {op.__name__}")
 
         return vk_graph_schema.VkGraph(
             version="0",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4870

The internal global `logging` level was changed such that INFO logs were no longer printed. This change explicitly sets the `logging` level to see Vulkan logs again.

Differential Revision: [D61723563](https://our.internmc.facebook.com/intern/diff/D61723563/)