### PR TITLE
WhyNoPartition

### DIFF
--- a/backends/xnnpack/partition/config/node_configs.py
+++ b/backends/xnnpack/partition/config/node_configs.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
 import operator
 from typing import List, Optional
 
@@ -19,7 +20,11 @@ from executorch.backends.xnnpack.utils.utils import is_param_node
 from executorch.exir.backend.canonical_partitioners.config_partitioner import (
     format_target_name,
 )
+from executorch.exir.backend.utils import WhyNoPartition
 from torch.export import ExportedProgram
+
+logger = logging.getLogger(__name__)
+why = WhyNoPartition(logger=logger)
 
 
 class BatchNormConfig(XNNPartitionerConfig):
@@ -38,9 +43,15 @@ class BatchNormConfig(XNNPartitionerConfig):
         conv_name = format_target_name(conv.target.__name__)  # pyre-ignore
 
         if conv_name not in ["convolution.default"]:
+            why(node, f"Invalid conv target {conv_name}")
             return False
 
-        return FuseBatchNormWithConvPass.can_fuse(conv, bn, ep)
+        can_fuse = FuseBatchNormWithConvPass.can_fuse(conv, bn, ep)
+        if not can_fuse:
+            why(node, "BatchNorm cannot be fused with Convolution")
+            return False
+
+        return True
 
     def get_node_and_deps(
         self, node: torch.fx.Node, ep: ExportedProgram
@@ -76,15 +87,18 @@ class MaxDimConfig(XNNPartitionerConfig):
         output_0 = node_val[0]
         # Don't check indicies dtype
         if output_0.dtype not in supported_dtypes:
+            why(node, f"Unsupported output dtype {output_0.dtype}")
             return False
 
         max_input = node.all_input_nodes[0]
         if max_input.meta.get("val").dtype not in supported_dtypes:
+            why(node, f"Unsupported input dtype {max_input.meta.get('val').dtype}")
             return False
 
         # Make sure that all users are getitems of the first output
         for user in node.users:
             if not (user.target == operator.getitem and user.args[1] == 0):
+                why(node, "Unsupported user of max.dim")
                 return False
 
         return True
@@ -111,7 +125,11 @@ class PreluConfig(XNNPartitionerConfig):
             return False
 
         weight = node.all_input_nodes[1]
-        return is_param_node(ep, weight)
+        is_param = is_param_node(ep, weight)
+        if not is_param:
+            why(node, "Prelu weight must be a parameter")
+            return False
+        return True
 
     def get_original_aten(self) -> Optional[torch._ops.OpOverload]:
         return torch.ops.aten.prelu.default

--- a/backends/xnnpack/partition/xnnpack_partitioner.py
+++ b/backends/xnnpack/partition/xnnpack_partitioner.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
+
+import logging
 from typing import List, Optional, Type, Union
 
 from executorch.backends.xnnpack.partition.config import ALL_PARTITIONER_CONFIGS
@@ -21,6 +23,9 @@ from executorch.exir.backend.canonical_partitioners.config_partitioner import (
 from executorch.exir.backend.partitioner import DelegationSpec
 from torch.fx.passes.infra.partitioner import Partition
 
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(__name__)
+
 
 class XnnpackPartitioner(ConfigerationBasedPartitioner):
     def __init__(
@@ -30,7 +35,16 @@ class XnnpackPartitioner(ConfigerationBasedPartitioner):
             Union[ConfigPrecisionType, List[ConfigPrecisionType]]
         ] = None,
         per_op_mode=False,
+        verbose: bool = False,
     ):
+        """
+        @verbose: if True, print out more information about the partitioner.
+            Default level is WARNING. If verbose is True, level is set to DEBUG.
+        """
+        if verbose:
+            logger.setLevel(logging.DEBUG)
+            logger.debug("Verbose logging enabled for XNNPACK partitioner.")
+
         delegation_spec = DelegationSpec(XnnpackBackend.__name__, [])
         configs_to_use = configs or ALL_PARTITIONER_CONFIGS
         # Can do logic and have extra args to filter/delete/select

--- a/backends/xnnpack/test/ops/mean_dim.py
+++ b/backends/xnnpack/test/ops/mean_dim.py
@@ -56,6 +56,19 @@ class TestMeanDim(unittest.TestCase):
             .check_count({"executorch_exir_dialects_edge__ops_aten_mean_dim": 1})
         )
 
+    def test_fp32_mean_dim_unsupported_3d(self):
+        """
+        XNNPack mean.dim implementation only supports 4D tensors.
+        """
+        inputs = (torch.randn(1, 5, 4),)
+        (
+            Tester(self.MeanDim((-1, -2)), inputs)
+            .export()
+            .check_count({"torch.ops.aten.mean.dim": 1})
+            .to_edge_transform_and_lower()
+            .check_count({"executorch_exir_dialects_edge__ops_aten_mean_dim": 1})
+        )
+
     def test_qs8_mean_dim(self):
         inputs = (torch.randn(1, 5, 4, 4),)
         (


### PR DESCRIPTION
Summary:
Makes partitioner lowering failures more visible.

This doesn't improve the end user experience much but it's a start.

* Right now we are dumpling it on a logger which can be improved. It takes logger instance as input to init for exactly this reason and not using __name__ based logger.
* Alternative to logger based stuff is, PartitionerResults can be overloaded to carry a diagnostic copy the original graph whose nodes carry whyNoPartition object in their meta. Then users can call a `PartitionReport()` like method (yet to be implemented) for much richer output.

Reviewed By: metascroy

Differential Revision: D61418620
