### PR TITLE
Remove torch:: references from examples/portable

### DIFF
--- a/examples/portable/custom_ops/custom_ops_1_out.cpp
+++ b/examples/portable/custom_ops/custom_ops_1_out.cpp
@@ -13,7 +13,7 @@ namespace native {
 
 using exec_aten::ScalarType;
 using exec_aten::Tensor;
-using torch::executor::RuntimeContext;
+using executorch::runtime::KernelRuntimeContext;
 
 namespace {
 void check_preconditions(const Tensor& in, Tensor& out) {
@@ -35,10 +35,13 @@ void check_preconditions(const Tensor& in, Tensor& out) {
       ssize_t(in.numel()));
 }
 } // namespace
-// mul3.out(Tensor input, *, Tensor(a!) output) -> Tensor(a!)
-Tensor& mul3_out_impl(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  (void)ctx;
 
+// mul3.out(Tensor input, *, Tensor(a!) output) -> Tensor(a!)
+// ExecuTorch-compatible function signature, with a KernelRuntimeContext.
+Tensor& mul3_out_impl(
+    ET_UNUSED KernelRuntimeContext& ctx,
+    const Tensor& in,
+    Tensor& out) {
   check_preconditions(in, out);
   float* out_data = out.mutable_data_ptr<float>();
   const float* in_data = in.const_data_ptr<float>();
@@ -47,5 +50,6 @@ Tensor& mul3_out_impl(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
   }
   return out;
 }
+
 } // namespace native
 } // namespace custom

--- a/examples/portable/custom_ops/custom_ops_2_out.cpp
+++ b/examples/portable/custom_ops/custom_ops_2_out.cpp
@@ -13,7 +13,7 @@ namespace native {
 
 using exec_aten::ScalarType;
 using exec_aten::Tensor;
-using torch::executor::RuntimeContext;
+using executorch::runtime::KernelRuntimeContext;
 
 namespace {
 void check_preconditions(const Tensor& in, Tensor& out) {
@@ -35,7 +35,9 @@ void check_preconditions(const Tensor& in, Tensor& out) {
       ssize_t(in.numel()));
 }
 } // namespace
+
 // mul4.out(Tensor input, *, Tensor(a!) output) -> Tensor(a!)
+// ATen-compatible function signature, without a KernelRuntimeContext.
 Tensor& mul4_out_impl(const Tensor& in, Tensor& out) {
   check_preconditions(in, out);
   float* out_data = out.mutable_data_ptr<float>();
@@ -46,8 +48,12 @@ Tensor& mul4_out_impl(const Tensor& in, Tensor& out) {
   return out;
 }
 
-Tensor& mul4_out_impl(RuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  (void)ctx;
+// mul4.out(Tensor input, *, Tensor(a!) output) -> Tensor(a!)
+// ExecuTorch-compatible function signature, with a KernelRuntimeContext.
+Tensor& mul4_out_impl(
+    ET_UNUSED KernelRuntimeContext& ctx,
+    const Tensor& in,
+    Tensor& out) {
   mul4_out_impl(in, out);
   return out;
 }

--- a/examples/portable/executor_runner/executor_runner.cpp
+++ b/examples/portable/executor_runner/executor_runner.cpp
@@ -37,11 +37,20 @@ DEFINE_string(
     "model.pte",
     "Model serialized in flatbuffer format.");
 
-using namespace torch::executor;
-using torch::executor::util::FileDataLoader;
+using executorch::extension::FileDataLoader;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::HierarchicalAllocator;
+using executorch::runtime::MemoryAllocator;
+using executorch::runtime::MemoryManager;
+using executorch::runtime::Method;
+using executorch::runtime::MethodMeta;
+using executorch::runtime::Program;
+using executorch::runtime::Result;
+using executorch::runtime::Span;
 
 int main(int argc, char** argv) {
-  runtime_init();
+  executorch::runtime::runtime_init();
 
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   if (argc != 1) {
@@ -154,7 +163,7 @@ int main(int argc, char** argv) {
   // Allocate input tensors and set all of their elements to 1. The `inputs`
   // variable owns the allocated memory and must live past the last call to
   // `execute()`.
-  auto inputs = util::prepare_input_tensors(*method);
+  auto inputs = executorch::extension::prepare_input_tensors(*method);
   ET_CHECK_MSG(
       inputs.ok(),
       "Could not prepare inputs: 0x%" PRIx32,
@@ -176,7 +185,7 @@ int main(int argc, char** argv) {
   status = method->get_outputs(outputs.data(), outputs.size());
   ET_CHECK(status == Error::Ok);
   // Print the first and last 100 elements of long lists of scalars.
-  std::cout << torch::executor::util::evalue_edge_items(100);
+  std::cout << executorch::extension::evalue_edge_items(100);
   for (int i = 0; i < outputs.size(); ++i) {
     std::cout << "Output " << i << ": " << outputs[i] << std::endl;
   }


### PR DESCRIPTION
Summary:
Update these files to use the new `executorch::` namespaces.

No more uses of the `torch::` namespace:
```
find executorch/examples/portable -type f | xargs grep "\btorch::"

(no output)
```

Differential Revision: D61742292
