### PR TITLE
[llm_manual] Use the new namespace, and clean up headers

### DIFF
--- a/docs/source/llm/getting-started.md
+++ b/docs/source/llm/getting-started.md
@@ -198,25 +198,21 @@ Create a file called main.cpp with the following contents:
 // main.cpp
 
 #include <cstdint>
-#include <functional>
-#include <memory>
-#include <unordered_map>
 
-#include "basic_tokenizer.h"
 #include "basic_sampler.h"
+#include "basic_tokenizer.h"
 #include "managed_tensor.h"
 
 #include <executorch/extension/module/module.h>
-#include <executorch/extension/evalue_util/print_evalue.h>
+#include <executorch/runtime/core/evalue.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
-#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
-#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
+#include <executorch/runtime/core/result.h>
 
-using namespace torch::executor;
-
-using SizesType = exec_aten::SizesType;
-using DimOrderType = exec_aten::DimOrderType;
-using StridesType = exec_aten::StridesType;
+using exec_aten::ScalarType;
+using exec_aten::Tensor;
+using executorch::extension::Module;
+using executorch::runtime::EValue;
+using executorch::runtime::Result;
 ```
 
 The model inputs and outputs take the form of tensors. A tensor can be thought of as an multi-dimensional array.

--- a/examples/llm_manual/basic_sampler.h
+++ b/examples/llm_manual/basic_sampler.h
@@ -6,12 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <algorithm>
 #include <vector>
+
 class BasicSampler {
  public:
-  BasicSampler() {}
-  int64_t sample(std::vector<float> logits) {
+  int64_t sample(const std::vector<float>& logits) {
     // Find the token with the highest log probability.
     int64_t max_index =
         std::max_element(logits.begin(), logits.end()) - logits.begin();

--- a/examples/llm_manual/basic_tokenizer.h
+++ b/examples/llm_manual/basic_tokenizer.h
@@ -6,21 +6,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 class BasicTokenizer {
  public:
-  BasicTokenizer(const std::string& filePath) {
-    std::ifstream file(filePath);
+  explicit BasicTokenizer(const std::string& file_path) {
+    std::ifstream file(file_path);
 
     if (!file) {
-      std::cerr << "Unable to open file";
-      exit(9); // return with error code
+      std::cerr << "Unable to open file " << file_path << "\n";
+      exit(9);
     }
     std::string str(
         (std::istreambuf_iterator<char>(file)),

--- a/examples/llm_manual/main.cpp
+++ b/examples/llm_manual/main.cpp
@@ -6,31 +6,24 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// main.cpp
-
 #include <cstdint>
-#include <functional>
-#include <memory>
-#include <unordered_map>
 
 #include "basic_sampler.h"
 #include "basic_tokenizer.h"
 #include "managed_tensor.h"
 
-#include <executorch/extension/evalue_util/print_evalue.h>
 #include <executorch/extension/module/module.h>
+#include <executorch/runtime/core/evalue.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
-#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
-#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
+#include <executorch/runtime/core/result.h>
 
-using namespace torch::executor;
+using exec_aten::ScalarType;
+using exec_aten::Tensor;
+using executorch::extension::Module;
+using executorch::runtime::EValue;
+using executorch::runtime::Result;
 
-using SizesType = exec_aten::SizesType;
-using DimOrderType = exec_aten::DimOrderType;
-using StridesType = exec_aten::StridesType;
-
-// main.cpp
-
+// The value of the gpt2 `<|endoftext|>` token.
 #define ENDOFTEXT 50256
 
 std::string generate(

--- a/examples/llm_manual/managed_tensor.h
+++ b/examples/llm_manual/managed_tensor.h
@@ -6,59 +6,39 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <executorch/runtime/core/exec_aten/exec_aten.h>
-#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
-#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
-#include <executorch/runtime/platform/assert.h>
-
-#include <executorch/runtime/core/portable_type/tensor.h>
-
 #pragma once
 
-namespace torch {
-namespace executor {
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
 
 /**
- * A tensor wrapper takes ownership of all the memory of the necessary metadata
- * for torch::executor::Tensor. Note that it doesn't own the data memory.
+ * Creates and owns the necessary metadata for a Tensor instance. Does not own
+ * the data pointer.
  */
 class ManagedTensor {
  public:
-  /// The type used for elements of `sizes()`.
-  using SizesType = exec_aten::SizesType;
-  /// The type used for elements of `dim_order()`.
-  using DimOrderType = exec_aten::DimOrderType;
-  /// The type used for elements of `strides()`.
-  using StridesType = exec_aten::StridesType;
-
-  ManagedTensor() = delete;
-
-  explicit ManagedTensor(
+  ManagedTensor(
       void* data,
-      const std::vector<SizesType>& sizes,
-      ScalarType dtype)
-      : sizes_(sizes) {
-    tensor_impl_ = std::make_unique<TensorImpl>(
-        dtype,
-        sizes_.size(),
-        sizes_.data(),
-        data,
-        nullptr,
-        nullptr,
-        TensorShapeDynamism::DYNAMIC_BOUND);
-  }
+      const std::vector<exec_aten::SizesType>& sizes,
+      exec_aten::ScalarType dtype)
+      : sizes_(sizes),
+        tensor_impl_(
+            /*type=*/dtype,
+            /*dim=*/sizes_.size(),
+            /*sizes=*/sizes_.data(),
+            /*data=*/data,
+            /*dim_order=*/nullptr,
+            /*strides=*/nullptr,
+            /*dynamism=*/
+            executorch::runtime::TensorShapeDynamism::DYNAMIC_BOUND) {}
 
   /**
    * Get the Tensor object managed by this class.
    */
-  Tensor get_tensor() {
-    return Tensor(tensor_impl_.get());
+  exec_aten::Tensor get_tensor() {
+    return exec_aten::Tensor(&tensor_impl_);
   }
 
  private:
-  std::unique_ptr<TensorImpl> tensor_impl_;
-  std::vector<SizesType> sizes_;
+  std::vector<exec_aten::SizesType> sizes_;
+  exec_aten::TensorImpl tensor_impl_;
 };
-
-} // namespace executor
-} // namespace torch


### PR DESCRIPTION
Update these files to use the new `executorch::` namespace.

While I was here:
- Remove unnecessary includes
- Remove an unnecessary unique_ptr layer from ManagedTensor
- Remove the namespace from ManagedTensor since the other headers don't use one
- Use a reference for the sampler vector
- Add `#pragma once` to the headers
- Avoid a `using namespace`, which violates our style guide

Update the docs to reflect these changes.

Test Plan:
Followed the instructions at
https://pytorch.org/executorch/main/llm/getting-started.html to build and run the executable.