### PR TITLE
fold quantize in convert

### DIFF
--- a/examples/models/phi-3-mini/export_phi-3-mini.py
+++ b/examples/models/phi-3-mini/export_phi-3-mini.py
@@ -69,7 +69,7 @@ def export(args) -> None:
         )
         model = prepare_pt2e(model, xnnpack_quantizer)
         model(*example_inputs)
-        model = convert_pt2e(model, fold_quantize=False)
+        model = convert_pt2e(model)
         DuplicateDynamicQuantChainPass()(model)
         # TODO(lunwenh): update it to use export once
         # https://github.com/pytorch/pytorch/issues/128394 is resolved.


### PR DESCRIPTION
We should be folding the quantize nodes on the weights. I didn't add that logic to the new partitioner since the default case for quantizer is now to fold the quantize node for weights.