### PR TITLE
enable parallel prefill again

### DIFF
--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -126,7 +126,7 @@ Error Runner::load() {
       tokenizer_.get(),
       text_decoder_runner_.get(),
       metadata_.at(kUseKVCache),
-      enable_parallel_prefill_);
+      metadata_.at(kEnableDynamicShape));
 
   text_token_generator_ = std::make_unique<TextTokenGenerator>(
       tokenizer_.get(),

--- a/examples/models/llama2/runner/runner.h
+++ b/examples/models/llama2/runner/runner.h
@@ -45,7 +45,6 @@ class Runner {
 
  private:
   float temperature_;
-  bool enable_parallel_prefill_;
   bool shouldStop_{false};
 
   // model


### PR DESCRIPTION
Summary:
Accidentally the parallel prefill enablement logic fell through the cracks
before

 {F1823815458}

after

 {F1823818585}

Observe the calls to 4x8 kernels

Reviewed By: swolchok

Differential Revision: D61751873
