### PR TITLE
Add pass for adjusting conv2d input shape to parameters

### DIFF
--- a/backends/arm/operators/op_conv2d.py
+++ b/backends/arm/operators/op_conv2d.py
@@ -40,7 +40,7 @@ class Conv2dVisitor(NodeVisitor):
 
         if mod_remainder > pad:
             raise RuntimeError(
-                f"ignoring input element is not currently supported, got a large stride {stride}"
+                "This case should be handled by the SizeAdjustConv2d pass, is it enabled?"
             )
         return pad - mod_remainder
 

--- a/backends/arm/passes/annotate_channels_last_dim_order_pass.py
+++ b/backends/arm/passes/annotate_channels_last_dim_order_pass.py
@@ -46,7 +46,9 @@ class AnnotateChannelsLastDimOrder(ExportPass):
         NHWC_Order = (0, 2, 3, 1)
         HWCM_Order = (2, 3, 0, 1)
         for node in graph_module.graph.nodes:
-            if isinstance(node.meta["val"], tuple):
+            if isinstance(
+                node.meta["val"], (tuple, torch.fx.immutable_collections.immutable_list)
+            ):
                 node_data = node.meta["val"][0].data
             else:
                 node_data = node.meta["val"].data

--- a/backends/arm/passes/arm_pass_manager.py
+++ b/backends/arm/passes/arm_pass_manager.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.passes.convert_split_to_slice import (
     ConvertSplitToSlicePass,
 )
 from executorch.backends.arm.passes.remove_clone_pass import RemoveClonePass
+from executorch.backends.arm.passes.size_adjust_conv2d_pass import SizeAdjustConv2DPass
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.pass_manager import PassManager
 
@@ -29,6 +30,7 @@ class ArmPassManager(PassManager):
         self, graph_module: torch.fx.Graph, compile_spec: CompileSpec
     ):
         """Apply passes before transforming program to backend"""
+        self.add_pass(SizeAdjustConv2DPass())
         self.add_pass(RemoveClonePass())
         self.add_pass(ConvertExpandCopyToRepeatPass())
         self.add_pass(ConvertSplitToSlicePass())

--- a/backends/arm/passes/size_adjust_conv2d_pass.py
+++ b/backends/arm/passes/size_adjust_conv2d_pass.py
@@ -1,0 +1,129 @@
+# Copyright 2024 Arm Limited and/or its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import cast, Optional
+
+import torch.fx
+from executorch.backends.arm.tosa_quant_utils import is_quant_node
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+from torch._ops import OpOverload
+
+
+def conv_remainder(input_length, pad, dilation, weight, stride):
+    """
+    Returns the size
+    """
+    return (input_length + 2 * pad - dilation * (weight - 1) - 1) % stride
+
+
+def insert_q_dq_pair(
+    graph: torch.fx.Graph,
+    anchor: torch.fx.Node,
+    q_params: tuple,
+):
+    with graph.inserting_after(anchor):
+        q = create_node(
+            graph=graph,
+            op_target=exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+            args=(),  # We add the argument last
+        )
+        q.meta = anchor.meta
+
+    with graph.inserting_after(q):
+        dq = create_node(
+            graph=graph,
+            op_target=exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+            args=(q,) + q_params,
+        )
+        dq.meta = q.meta
+
+    anchor.replace_all_uses_with(dq)
+    # We add this last so the replace all uses above does not replace the quantized
+    # node's first use
+    q.args = (anchor,) + q_params
+    return dq
+
+
+def create_node(
+    graph: torch.fx.Graph,
+    op_target: OpOverload,
+    args: tuple = (),
+    kwargs: Optional[dict] = None,
+):
+    return graph.create_node(
+        "call_function",
+        op_target,
+        args=args,
+        kwargs=kwargs or {},
+    )
+
+
+class SizeAdjustConv2DPass(ExportPass):
+    """
+    Adjust the convolution input size to match perfectly with the
+    weight size, padding, stride and dilation parameters.
+    This is done by inserting a slice op to remove the uneven end of the input.
+    """
+
+    conv2d_op = exir_ops.edge.aten.convolution.default
+    slice_op = exir_ops.edge.aten.slice_copy.Tensor
+
+    def call(self, graph_module: torch.fx.GraphModule):
+        graph = graph_module.graph
+        modified_graph = False
+        for node in graph.nodes:
+            if node.op != "call_function":
+                continue
+            if node.target != self.conv2d_op:
+                continue
+
+            conv_node = cast(torch.fx.Node, node)
+            input_node, weight, _, stride_hw, pad_hw, dilation_hw, _, _, _ = (
+                conv_node.args
+            )
+            weight_shape = weight.meta["val"].shape
+            input_shape = input_node.meta["val"].shape
+
+            slice_args = []
+            for stride, pad, dilation, dim in zip(
+                cast(list, stride_hw),
+                cast(list, pad_hw),
+                cast(list, dilation_hw),
+                (2, 3),
+            ):
+                remainder = conv_remainder(
+                    input_shape[dim], pad, dilation, weight_shape[dim], stride
+                )
+                if remainder > pad:
+                    adjustment = remainder - pad
+                    args = (dim, 0, input_shape[dim] - adjustment)
+                    slice_args.append(args)
+            if len(slice_args) == 0:
+                continue
+
+            with graph_module.graph.inserting_before(node):
+                last_node = cast(torch.fx.Node, input_node)
+                for args in slice_args:
+                    slice_node = graph.create_node(
+                        "call_function", self.slice_op, (last_node,) + args
+                    )
+                    if is_quant_node(last_node):
+                        q_params = last_node.args[1:]
+                        dq_node = insert_q_dq_pair(
+                            graph_module.graph, slice_node, q_params
+                        )
+                        last_node = dq_node
+                    else:
+                        last_node = slice_node
+                conv_node.replace_input_with(input_node, last_node)
+                modified_graph = True
+
+        if modified_graph:
+            graph_module = super().call(graph_module).graph_module
+            graph.eliminate_dead_code()
+            graph_module.recompile()
+        return PassResult(graph_module, True)

--- a/backends/arm/test/ops/test_conv.py
+++ b/backends/arm/test/ops/test_conv.py
@@ -159,14 +159,14 @@ conv2d_1x1_1x2x128x128_st1 = Conv2d(
     batches=1,
 )
 
-conv2d_2x2_1x1x14x14_st2 = Conv2d(
+conv2d_2x2_1x1x14x13_st2 = Conv2d(
     in_channels=1,
     out_channels=1,
     kernel_size=(2, 2),
     stride=2,
     padding=0,
     width=14,
-    height=14,
+    height=13,
     batches=1,
 )
 
@@ -191,6 +191,18 @@ conv2d_3x3_1x3x224x224_st2_pd1 = Conv2d(
     height=224,
     batches=1,
 )
+
+conv2d_5x5_1x3x14x15_st3_pd1 = Conv2d(
+    in_channels=3,
+    out_channels=16,
+    kernel_size=(5, 5),
+    stride=3,
+    padding=1,
+    width=14,
+    height=15,
+    batches=1,
+)
+
 
 two_conv2d_nobias = Conv2d(
     nbr_conv=2,
@@ -225,7 +237,8 @@ testsuite = [
     ("3x3_1x3x256x256_st1", conv2d_3x3_1x3x256x256_st1),
     ("3x3_1x3x12x12_st2_pd1", conv2d_3x3_1x3x12x12_st2_pd1),
     ("1x1_1x2x128x128_st1", conv2d_1x1_1x2x128x128_st1),
-    ("2x2_1x1x14x14_st2", conv2d_2x2_1x1x14x14_st2),
+    ("2x2_1x1x14x13_st2_needs_adjust_pass", conv2d_2x2_1x1x14x13_st2),
+    ("conv2d_5x5_1x3x14x15_st3_pd1_needs_adjust_pass", conv2d_5x5_1x3x14x15_st3_pd1),
     ("5x5_3x2x128x128_st1", conv2d_5x5_3x2x128x128_st1),
     ("3x3_1x3x224x224_st2_pd1", conv2d_3x3_1x3x224x224_st2_pd1),
     ("two_conv2d_nobias", two_conv2d_nobias),
@@ -240,7 +253,10 @@ testsuite_u55.remove(("2x2_3x2x40x40_nobias", conv2d_2x2_3x2x40x40_nobias))
 testsuite_u55.remove(("5x5_3x2x128x128_st1", conv2d_5x5_3x2x128x128_st1))
 
 # Fails when enabling CompileSpec.set_quantize_io(True). MLETORCH-191.
-testsuite_u55.remove(("2x2_1x1x14x14_st2", conv2d_2x2_1x1x14x14_st2))
+testsuite_u55.remove(("2x2_1x1x14x13_st2_needs_adjust_pass", conv2d_2x2_1x1x14x13_st2))
+testsuite_u55.remove(
+    ("conv2d_5x5_1x3x14x15_st3_pd1_needs_adjust_pass", conv2d_5x5_1x3x14x15_st3_pd1)
+)
 
 
 class TestConv2D(unittest.TestCase):


### PR DESCRIPTION
While Pytorch accepts conv parameters such
that the sampling does not align perfectly with the input, TOSA has this as a requirement. This pass adds slice ops if the input shape needs adjustment.


Change-Id: I81ad6f172a946644092363eb0ace1d53979090d4