### PR TITLE
[module] Change the deleter of Program in Module to make android happy

### DIFF
--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -123,8 +123,9 @@ Error Module::load(const Program::Verification verification) {
         ET_UNWRAP_UNIQUE(Program::load(data_loader_.get(), verification));
     program_ = std::shared_ptr<Program>(
         program.release(),
-        [data_loader = std::move(data_loader_)](Program* pointer) {
+        [this](Program* pointer) {
           delete pointer;
+          data_loader_.reset();
         });
   }
   return Error::Ok;

--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -121,9 +121,8 @@ Error Module::load(const Program::Verification verification) {
     };
     auto program =
         ET_UNWRAP_UNIQUE(Program::load(data_loader_.get(), verification));
-    program_ = std::shared_ptr<Program>(
-        program.release(),
-        [this](Program* pointer) {
+    program_ =
+        std::shared_ptr<Program>(program.release(), [this](Program* pointer) {
           delete pointer;
           data_loader_.reset();
         });

--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -121,11 +121,8 @@ Error Module::load(const Program::Verification verification) {
     };
     auto program =
         ET_UNWRAP_UNIQUE(Program::load(data_loader_.get(), verification));
-    program_ =
-        std::shared_ptr<Program>(program.release(), [this](Program* pointer) {
-          delete pointer;
-          data_loader_.reset();
-        });
+    program_ = std::shared_ptr<Program>(
+        program.release(), [](Program* pointer) { delete pointer; });
   }
   return Error::Ok;
 }


### PR DESCRIPTION
Summary:

When building the Android demo app I got:

```
> bash build/build_android_llm_demo.sh

/data/users/larryliu/android/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/memory:4013:39: error: call to implicitly-deleted copy constructor of '(lambda at /data/users/larryliu/executorch/extension/module/module.cpp:126:9)'
        __cntrl_ = new _CntrlBlk(__p, __d, _AllocT());
                                      ^~~
/data/users/larryliu/executorch/extension/module/module.cpp:124:16: note: in instantiation of function template specialization 'std::shared_ptr<executorch::runtime::Program>::shared_ptr<executorch::runtime::Program, (lambda at /data/users/larryliu/executorch/extension/module/module.cpp:126:9)>' requested here
    program_ = std::shared_ptr<Program>(
               ^
/data/users/larryliu/executorch/extension/module/module.cpp:126:10: note: copy constructor of '' is implicitly deleted because field '' has a deleted copy constructor
        [data_loader = std::move(data_loader_)](Program* pointer) {
         ^
/data/users/larryliu/android/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/memory:2577:3: note: copy constructor is implicitly deleted because 'unique_ptr<executorch::runtime::DataLoader>' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
/data/users/larryliu/android/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/memory:3575:39: note: passing argument to parameter '__d' here
    __shared_ptr_pointer(_Tp __p, _Dp __d, _Alloc __a)
```

To fix this I am changing the deleter of Program to be capturing `this` (Module) assuming the lifespan of `Module` is always longer than `Program`.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: