### PR TITLE
Move executorch exclusions to third-party

### DIFF
--- a/backends/apple/coreml/TARGETS
+++ b/backends/apple/coreml/TARGETS
@@ -14,10 +14,10 @@ runtime.python_library(
         "@EXECUTORCH_CLIENTS",
     ],
     deps = [
+        "fbsource//third-party/pypi/coremltools:coremltools",
         ":executorchcoreml",
         "//executorch/exir/backend:backend_details",
         "//executorch/exir/backend:compile_spec_schema",
-        "fbsource//third-party/pypi/coremltools:coremltools",
     ],
 )
 
@@ -30,13 +30,13 @@ runtime.python_library(
         "@EXECUTORCH_CLIENTS",
     ],
     deps = [
+        "fbsource//third-party/pypi/coremltools:coremltools",
         ":backend",
         "//caffe2:torch",
         "//executorch/exir:lib",
         "//executorch/exir/backend:compile_spec_schema",
         "//executorch/exir/backend:partitioner",
         "//executorch/exir/backend:utils",
-        "fbsource//third-party/pypi/coremltools:coremltools",
     ],
 )
 
@@ -64,24 +64,24 @@ runtime.cxx_python_extension(
     headers = glob([
         "runtime/inmemoryfs/**/*.hpp",
     ]),
+    base_module = "",
+    compiler_flags = [
+        "-std=c++17",
+    ],
     preprocessor_flags = [
         "-Iexecutorch/backends/apple/coreml/runtime/util",
     ],
     types = [
         "executorchcoreml.pyi",
     ],
-    compiler_flags = [
-        "-std=c++17",
-    ],
-    base_module = "",
     visibility = [
         "//executorch/examples/apple/coreml/...",
     ],
-    external_deps = [
-        "pybind11",
-    ],
     deps = [
         "fbsource//third-party/nlohmann-json:nlohmann-json",
+    ],
+    external_deps = [
+        "pybind11",
     ],
 )
 
@@ -91,10 +91,10 @@ runtime.python_test(
         "test/*.py",
     ]),
     deps = [
+        "fbsource//third-party/pypi/pytest:pytest",
         ":partitioner",
         ":quantizer",
         "//caffe2:torch",
         "//pytorch/vision:torchvision",
-        "fbsource//third-party/pypi/pytest:pytest",
     ],
 )

--- a/backends/apple/mps/TARGETS
+++ b/backends/apple/mps/TARGETS
@@ -89,14 +89,14 @@ runtime.python_test(
         "test/*.py",
     ]),
     deps = [
+        "fbsource//third-party/pypi/pytest:pytest",
         ":backend",
         ":partitioner",
         "//caffe2:torch",
+        "//executorch/devtools:lib",
+        "//executorch/devtools/bundled_program/serialize:lib",
         "//executorch/examples/models:models",
         "//executorch/exir/tests:models",
         "//executorch/extension/export_util:export_util",
-        "//executorch/devtools:lib",
-        "//executorch/devtools/bundled_program/serialize:lib",
-        "fbsource//third-party/pypi/pytest:pytest",
     ],
 )

--- a/backends/apple/mps/targets.bzl
+++ b/backends/apple/mps/targets.bzl
@@ -12,7 +12,6 @@ def define_common_targets(is_xplat = False, platforms = []):
     TARGETS and BUCK files that call this function.
     """
     kwargs = {
-        "name": "mps",
         "compiler_flags": [
             "-DEXIR_MPS_DELEGATE=1",
             "-Wno-global-constructors",
@@ -37,6 +36,8 @@ def define_common_targets(is_xplat = False, platforms = []):
             "runtime/*.h",
             "runtime/operations/*.h",
         ]),
+        "link_whole": True,
+        "name": "mps",
         "srcs": native.glob([
             "runtime/*.mm",
             "runtime/operations/*.mm",
@@ -51,7 +52,6 @@ def define_common_targets(is_xplat = False, platforms = []):
             "//executorch/test/...",
             "@EXECUTORCH_CLIENTS",
         ],
-        "link_whole": True,
     }
 
     if is_xplat:

--- a/backends/qualcomm/aot/ir/targets.bzl
+++ b/backends/qualcomm/aot/ir/targets.bzl
@@ -2,8 +2,8 @@ load(
     "@fbsource//tools/build_defs:default_platform_defs.bzl",
     "ANDROID",
 )
-load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbsource//xplat/executorch/backends/qualcomm:targets.bzl", "generate_schema_header")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 QCIR_NAME = "qcir"
 INPUT_QCIR = QCIR_NAME + ".fbs"
@@ -41,7 +41,6 @@ def define_common_targets():
         define_static_target = True,
         platforms = [ANDROID],
     )
-
 
     runtime.cxx_library(
         name = "qcir_utils",

--- a/backends/qualcomm/targets.bzl
+++ b/backends/qualcomm/targets.bzl
@@ -4,7 +4,6 @@ load(
 )
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-
 # Construct the input and output file names. All input and output files rely on scalar_type file.
 SCHEMA_NAME = "schema"
 
@@ -55,6 +54,7 @@ def define_common_targets():
         [OUTPUT_SCHEMA_HEADER],
         OUTPUT_SCHEMA_HEADER,
     )
+
     # Header-only library target with the generate executorch program schema header.
     runtime.cxx_library(
         name = "schema",
@@ -75,7 +75,6 @@ def define_common_targets():
         define_static_target = True,
         platforms = [ANDROID],
     )
-
 
     runtime.cxx_library(
         name = "qnn_executorch_backend",


### PR DESCRIPTION
Summary:
These files are not dirsyncs, and not synced to github. They should be
excluded using the third-party filter rather than the dirsync filter so
that the buck files (which are internal) are linted.

    hg files \
      fbcode/executorch/backends/apple \
      fbcode/executorch/backends/arm \
      fbcode/executorch/backends/mediatek \
      fbcode/executorch/backends/qualcomm \
      fbcode/executorch/examples/apple \
      fbcode/executorch/examples/arm \
      fbcode/executorch/examples/mediatek \
      fbcode/executorch/examples/qualcomm \
      fbcode/executorch/oss/.ci/scripts \
      fbcode/executorch/oss/.github/scripts \
    | arc lint -a -

See https://www.internalfb.com/diff/D61222020?dst_version_fbid=1902845210231553&transaction_fbid=1044942633762597

Differential Revision: D61850342
