### PR TITLE
[executorch] Increase mac capacity / fix conda for llava test on trunk

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -276,7 +276,7 @@ jobs:
     strategy:
       fail-fast: false
     with:
-      runner: macos-13-xlarge
+      runner: macos-14-xlarge
       python-version: '3.11'
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -282,11 +282,8 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 900
       script: |
-        # The generic Linux job chooses to use base env, not the one setup by the image
-        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-        conda activate "${CONDA_ENV}"
-
-        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-macos.sh "cmake"
+        bash .ci/scripts/setup-conda.sh
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "cmake"
 
         # install Llava requirements
         bash examples/models/llama2/install_requirements.sh

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -273,6 +273,8 @@ jobs:
   test-llava-runner-macos:
     name: test-llava-runner-macos
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    with:
+      python-version: "3.10"
     strategy:
       fail-fast: false
     with:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -273,12 +273,10 @@ jobs:
   test-llava-runner-macos:
     name: test-llava-runner-macos
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
-    with:
-      python-version: "3.10"
     strategy:
       fail-fast: false
     with:
-      runner: macos-14-xlarge
+      runner: macos-13-xlarge
       python-version: '3.11'
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -270,33 +270,34 @@ jobs:
         # Test llama2
         PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/test_llama.sh stories110M "${BUILD_TOOL}" "${DTYPE}" "${MODE}"
 
-  test-llava-runner-macos:
-    name: test-llava-runner-macos
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
-    strategy:
-      fail-fast: false
-    with:
-      runner: macos-14-xlarge
-      python-version: '3.11'
-      submodules: 'true'
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      timeout: 900
-      script: |
-        BUILD_TOOL=cmake
+  # # TODO(jackzhxng): Runner consistently runs out of memory before test finishes. Try to find a more powerful runner.
+  # test-llava-runner-macos:
+  #   name: test-llava-runner-macos
+  #   uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+  #   strategy:
+  #     fail-fast: false
+  #   with:
+  #     runner: macos-14-xlarge
+  #     python-version: '3.11'
+  #     submodules: 'true'
+  #     ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+  #     timeout: 900
+  #     script: |
+  #       BUILD_TOOL=cmake
 
-        bash .ci/scripts/setup-conda.sh
-        # Setup MacOS dependencies as there is no Docker support on MacOS atm
-        GITHUB_RUNNER=1 PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
+  #       bash .ci/scripts/setup-conda.sh
+  #       # Setup MacOS dependencies as there is no Docker support on MacOS atm
+  #       GITHUB_RUNNER=1 PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
 
-        # install Llava requirements
-        ${CONDA_RUN} bash examples/models/llama2/install_requirements.sh
-        ${CONDA_RUN} bash examples/models/llava/install_requirements.sh
+  #       # install Llava requirements
+  #       ${CONDA_RUN} bash examples/models/llama2/install_requirements.sh
+  #       ${CONDA_RUN} bash examples/models/llava/install_requirements.sh
 
-        # run python unittest
-        ${CONDA_RUN} python -m unittest examples.models.llava.test.test_llava
+  #       # run python unittest
+  #       ${CONDA_RUN} python -m unittest examples.models.llava.test.test_llava
 
-        # run e2e (export, tokenizer and runner)
-        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/test_llava.sh Release
+  #       # run e2e (export, tokenizer and runner)
+  #       PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/test_llava.sh Release
 
   test-qnn-model:
     name: test-qnn-model

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -276,7 +276,7 @@ jobs:
     strategy:
       fail-fast: false
     with:
-      runner: macos-m1-stable
+      runner: macos-14-xlarge
       python-version: '3.11'
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -282,18 +282,21 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 900
       script: |
+        BUILD_TOOL=cmake
+
         bash .ci/scripts/setup-conda.sh
-        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "cmake"
+        # Setup MacOS dependencies as there is no Docker support on MacOS atm
+        GITHUB_RUNNER=1 PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
 
         # install Llava requirements
-        bash examples/models/llama2/install_requirements.sh
-        bash examples/models/llava/install_requirements.sh
+        ${CONDA_RUN} bash examples/models/llama2/install_requirements.sh
+        ${CONDA_RUN} bash examples/models/llava/install_requirements.sh
 
         # run python unittest
-        python -m unittest examples.models.llava.test.test_llava
+        ${CONDA_RUN} python -m unittest examples.models.llava.test.test_llava
 
         # run e2e (export, tokenizer and runner)
-        PYTHON_EXECUTABLE=python bash .ci/scripts/test_llava.sh Release
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/test_llava.sh Release
 
   test-qnn-model:
     name: test-qnn-model


### PR DESCRIPTION
Trunk test was running out of memory during build: https://github.com/pytorch/executorch/actions/runs/10582601952/job/29322708154

Also fixes conda-related issues.

UPDATE: comment out for now in absence of a more powerful runner. The `xlarge` `mac`s are not getting the job done.