### PR TITLE
[llava] Enable memory profiling

### DIFF
--- a/examples/models/llava/export_llava.py
+++ b/examples/models/llava/export_llava.py
@@ -285,7 +285,7 @@ def main():
 
     # memory profiling
     if args.profile_memory:
-        for method_name in ["image_encoder", "token_embedding", "text_model"]:
+        for method_name in executorch_program.methods():
             generate_memory_trace(
                 executorch_program,
                 f"{args.pte_name}_{method_name}.json",

--- a/examples/models/llava/export_llava.py
+++ b/examples/models/llava/export_llava.py
@@ -36,11 +36,11 @@ from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEv
 
 from executorch.extension.llm.export.builder import DType, LLMEdgeManager
 from executorch.extension.llm.tokenizer.tokenizer import Tokenizer
+from executorch.util.activation_memory_profiler import generate_memory_trace
 from torch.ao.quantization.quantizer.xnnpack_quantizer import (
     get_symmetric_quantization_config,
     XNNPACKQuantizer,
 )
-from executorch.util.activation_memory_profiler import generate_memory_trace
 from torch.export import Dim
 from torch.nn.attention import SDPBackend
 
@@ -285,7 +285,12 @@ def main():
 
     # memory profiling
     if args.profile_memory:
-        generate_memory_trace(executorch_program, f"{args.pte_name}.json")
+        for method_name in ["image_encoder", "token_embedding", "text_model"]:
+            generate_memory_trace(
+                executorch_program,
+                f"{args.pte_name}_{method_name}.json",
+                method_name=method_name,
+            )
 
     with open(args.pte_name, "wb") as f:
         executorch_program.write_to_file(f)

--- a/examples/models/llava/export_llava.py
+++ b/examples/models/llava/export_llava.py
@@ -285,7 +285,7 @@ def main():
 
     # memory profiling
     if args.profile_memory:
-        for method_name in executorch_program.methods():
+        for method_name in executorch_program.methods:
             generate_memory_trace(
                 executorch_program,
                 f"{args.pte_name}_{method_name}.json",

--- a/util/activation_memory_profiler.py
+++ b/util/activation_memory_profiler.py
@@ -123,7 +123,7 @@ def generate_memory_trace(
             f"generate_memory_trace expects ExecutorchProgramManager instance but got {type(executorch_program_manager)}"
         )
 
-    exported_program = executorch_program_manager.exported_program()
+    exported_program = executorch_program_manager.exported_program(method_name)
     if not _validate_memory_planning_is_done(exported_program):
         raise ValueError("Executorch program does not have memory planning.")
 

--- a/util/activation_memory_profiler.py
+++ b/util/activation_memory_profiler.py
@@ -106,6 +106,7 @@ def generate_memory_trace(
     executorch_program_manager: ExecutorchProgramManager,
     chrome_trace_filename: str,
     enable_memory_offsets: bool = False,
+    method_name: str = "forward",
 ):
     """
     Generate the memory timeline from the given ExecuTorch program.


### PR DESCRIPTION
Summary: As titled. Now if we run
```
python examples/models/llava/export_llava.py --pte-name llava_768.pte --profile_memory
```

We will get:

* `llava_768.pte_image_encoder.json`
* `llava_768.pte_token_embedding.json`
* `llava_768.pte_text_model.json`

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: