### PR TITLE
Qualcomm AI Engine Direct - Refine Llama3 Tokenizer

### DIFF
--- a/backends/qualcomm/scripts/build.sh
+++ b/backends/qualcomm/scripts/build.sh
@@ -70,7 +70,7 @@ if [ "$BUILD_AARCH64" = true ]; then
         rm -rf $BUILD_ROOT && mkdir $BUILD_ROOT
     else
         # Force rebuild flatccrt for the correct platform
-        cd $BUILD_ROOT/sdk && make clean
+        cd $BUILD_ROOT/devtools && make clean
     fi
 
     cd $BUILD_ROOT
@@ -112,7 +112,7 @@ if [ "$BUILD_X86_64" = true ]; then
         rm -rf $BUILD_ROOT && mkdir $BUILD_ROOT
     else
         # Force rebuild flatccrt for the correct platform
-        cd $BUILD_ROOT/sdk && make clean
+        cd $BUILD_ROOT/devtools && make clean
     fi
 
     cd $BUILD_ROOT

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -1996,7 +1996,12 @@ class TestExampleQaihubScript(TestQNN):
                 self.fail(msg["Error"])
             else:
                 model_out = msg["result"]
-                self.assertTrue(model_out.startswith(prompt))
+                expected_result = (
+                    "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n"
+                    + prompt
+                    + "<|eot_id|><|start_header_id|>assistant<|end_header_id|>"
+                )
+                self.assertTrue(model_out.startswith(expected_result))
 
     def test_stable_diffusion(self):
         if not self.required_envs():

--- a/docs/source/build-run-qualcomm-ai-engine-direct-backend.md
+++ b/docs/source/build-run-qualcomm-ai-engine-direct-backend.md
@@ -126,8 +126,8 @@ Python APIs on x64 are required to compile models to Qualcomm AI Engine Direct b
 
 ```bash
 cd $EXECUTORCH_ROOT
-mkdir cmake-out
-cd cmake-out
+mkdir build-x86
+cd build-x86
 # Note that the below command might change.
 # Please refer to the above build.sh for latest workable commands.
 cmake .. \
@@ -158,8 +158,8 @@ Commands to build `qnn_executor_runner` for Android:
 
 ```bash
 cd $EXECUTORCH_ROOT
-mkdir cmake-out-android
-cd cmake-out-android
+mkdir build-android
+cd build-android
 # build executorch & qnn_executorch_backend
 cmake .. \
     -DCMAKE_INSTALL_PREFIX=$PWD \
@@ -189,7 +189,7 @@ cmake ../examples/qualcomm \
 cmake --build examples/qualcomm -j$(nproc)
 
 # qnn_executor_runner can be found under examples/qualcomm
-# The full path is $EXECUTORCH_ROOT/cmake-out-android/examples/qualcomm/qnn_executor_runner
+# The full path is $EXECUTORCH_ROOT/build-android/examples/qualcomm/qnn_executor_runner
 ls examples/qualcomm
 ```
 
@@ -209,7 +209,7 @@ cd $EXECUTORCH_ROOT
 cp schema/program.fbs exir/_serialize/program.fbs
 cp schema/scalar_type.fbs exir/_serialize/scalar_type.fbs
 
-python -m examples.qualcomm.scripts.deeplab_v3 -b cmake-out-android -m SM8550 --compile_only --download
+python -m examples.qualcomm.scripts.deeplab_v3 -b build-android -m SM8550 --compile_only --download
 ```
 
 You might see something like below:
@@ -239,7 +239,7 @@ We can test model inferences before deploying it to a device by HTP emulator.
 Let's build `qnn_executor_runner` for a x64 host:
 ```bash
 # assuming the AOT component is built.
-cd $EXECUTORCH_ROOT/cmake-out
+cd $EXECUTORCH_ROOT/build-x86
 cmake ../examples/qualcomm \
   -DCMAKE_PREFIX_PATH="$PWD/lib/cmake/ExecuTorch;$PWD/third-party/gflags;" \
   -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
@@ -249,14 +249,14 @@ cmake ../examples/qualcomm \
 cmake --build examples/qualcomm -j$(nproc)
 
 # qnn_executor_runner can be found under examples/qualcomm
-# The full path is $EXECUTORCH_ROOT/cmake-out/examples/qualcomm/qnn_executor_runner
+# The full path is $EXECUTORCH_ROOT/build-x86/examples/qualcomm/qnn_executor_runner
 ls examples/qualcomm/
 ```
 
 To run the HTP emulator, the dynamic linker need to access QNN libraries and `libqnn_executorch_backend.so`.
 We set the below two paths to `LD_LIBRARY_PATH` environment variable:
   1. `$QNN_SDK_ROOT/lib/x86_64-linux-clang/`
-  2. `$EXECUTORCH_ROOT/cmake-out/lib/`
+  2. `$EXECUTORCH_ROOT/build-x86/lib/`
 
 The first path is for QNN libraries including HTP emulator. It has been configured in the AOT compilation section.
 
@@ -264,8 +264,8 @@ The second path is for `libqnn_executorch_backend.so`.
 
 So, we can run `./deeplab_v3/dlv3_qnn.pte` by:
 ```bash
-cd $EXECUTORCH_ROOT/cmake-out
-export LD_LIBRARY_PATH=$EXECUTORCH_ROOT/cmake-out/lib/:$LD_LIBRARY_PATH
+cd $EXECUTORCH_ROOT/build-x86
+export LD_LIBRARY_PATH=$EXECUTORCH_ROOT/build-x86/lib/:$LD_LIBRARY_PATH
 examples/qualcomm/qnn_executor_runner --model_path ../deeplab_v3/dlv3_qnn.pte
 ```
 
@@ -308,8 +308,8 @@ So, we can run `qnn_executor_runner` like
 
 ```bash
 adb push ./deeplab_v3/dlv3_qnn.pte ${DEVICE_DIR}
-adb push ${EXECUTORCH_ROOT}/cmake-out-android/examples/qualcomm/executor_runner/qnn_executor_runner ${DEVICE_DIR}
-adb push ${EXECUTORCH_ROOT}/cmake-out-android/lib/libqnn_executorch_backend.so ${DEVICE_DIR}
+adb push ${EXECUTORCH_ROOT}/build-android/examples/qualcomm/executor_runner/qnn_executor_runner ${DEVICE_DIR}
+adb push ${EXECUTORCH_ROOT}/build-android/lib/libqnn_executorch_backend.so ${DEVICE_DIR}
 adb shell "cd ${DEVICE_DIR} \
            && export LD_LIBRARY_PATH=${DEVICE_DIR} \
            && export ADSP_LIBRARY_PATH=${DEVICE_DIR} \
@@ -333,7 +333,7 @@ I 00:00:00.364875 executorch:qnn_executor_runner.cpp:425] Write etdump to etdump
 The model is merely executed. If we want to feed real inputs and get model outputs, we can use
 ```bash
 cd $EXECUTORCH_ROOT
-python -m examples.qualcomm.scripts.deeplab_v3 -b cmake-out-android -m SM8550 --download -s <device_serial>
+python -m examples.qualcomm.scripts.deeplab_v3 -b build-android -m SM8550 --download -s <device_serial>
 ```
 The `<device_serial>` can be found by `adb devices` command.
 

--- a/examples/demo-apps/android/ExecuTorchDemo/README.md
+++ b/examples/demo-apps/android/ExecuTorchDemo/README.md
@@ -53,7 +53,7 @@ For delegating to Qualcomm Hexagon NPU, please follow the tutorial [here](build-
 After generating the model, copy the model to `assets` directory.
 
 ```bash
-python -m examples.qualcomm.scripts.deeplab_v3 -b cmake-out-android -m SM8450 -s <adb_connected_device_serial>
+python -m examples.qualcomm.scripts.deeplab_v3 -b build-android -m SM8450 -s <adb_connected_device_serial>
 cp deeplab_v3/dlv3_qnn.pte examples/demo-apps/android/ExecuTorchDemo/app/src/main/assets/
 ```
 

--- a/examples/qualcomm/README.md
+++ b/examples/qualcomm/README.md
@@ -53,12 +53,12 @@ cd $EXECUTORCH_ROOT/examples/qualcomm/scripts
 
 #### For MobileNet_v2
 ```bash
-python mobilenet_v2.py -s <device_serial> -m "SM8550" -b path/to/cmake-out-android/ -d /path/to/imagenet-mini/val
+python mobilenet_v2.py -s <device_serial> -m "SM8550" -b path/to/build-android/ -d /path/to/imagenet-mini/val
 ```
 
 #### For DeepLab_v3
 ```bash
-python deeplab_v3.py -s <device_serial> -m "SM8550" -b path/to/cmake-out-android/ --download
+python deeplab_v3.py -s <device_serial> -m "SM8550" -b path/to/build-android/ --download
 ```
 
 #### Check context binary version

--- a/examples/qualcomm/oss_scripts/llama2/README.md
+++ b/examples/qualcomm/oss_scripts/llama2/README.md
@@ -32,7 +32,7 @@ echo '{"dim": 768, "multiple_of": 32, "n_heads": 12, "n_layers": 12, "norm_eps":
 Default example generates the story based on the given prompt, "Once".
 ```bash
 # 16a4w quant:
-python examples/qualcomm/oss_scripts/llama2/llama.py -a ${ARTIFACTS} -b cmake-out-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --ptq 16a4w --checkpoint stories110M --params params.json --tokenizer_model tokenizer.model --tokenizer_bin tokenizer.bin --prompt "Once"
+python examples/qualcomm/oss_scripts/llama2/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --ptq 16a4w --checkpoint stories110M --params params.json --tokenizer_model tokenizer.model --tokenizer_bin tokenizer.bin --prompt "Once"
 ```
 
 #### (Note) Customized PTQ data set

--- a/examples/qualcomm/qaihub_scripts/llama/README.md
+++ b/examples/qualcomm/qaihub_scripts/llama/README.md
@@ -27,7 +27,7 @@ python -m examples.models.llama2.tokenizer.tokenizer -t tokenizer.model -o token
 #### Step3: Run default examples
 ```bash
 # AIHUB_CONTEXT_BINARIES: ${PATH_TO_AIHUB_WORKSPACE}/build/llama_v2_7b_chat_quantized
-python examples/qualcomm/qaihub_scripts/llama/llama2/qaihub_llama2_7b.py -a ${ARTIFACTS} -b cmake-out-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --context_binaries ${AIHUB_CONTEXT_BINARIES} --tokenizer_bin tokenizer.bin --prompt "What is Python?"
+python examples/qualcomm/qaihub_scripts/llama/llama2/qaihub_llama2_7b.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --context_binaries ${AIHUB_CONTEXT_BINARIES} --tokenizer_bin tokenizer.bin --prompt "What is Python?"
 ```
 
 ## Llama-3-8b-chat-hf
@@ -48,5 +48,5 @@ Note that the pre-compiled context binaries could not be futher fine-tuned for o
 #### Step3: Run default examples
 ```bash
 # AIHUB_CONTEXT_BINARIES: ${PATH_TO_AIHUB_WORKSPACE}/build/llama_v3_8b_chat_quantized
-python examples/qualcomm/qaihub_scripts/llama/llama3/qaihub_llama3_8b.py -a ${ARTIFACTS} -b cmake-out-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --context_binaries ${AIHUB_CONTEXT_BINARIES} --tokenizer_model tokenizer.model --prompt "What is baseball?"
+python examples/qualcomm/qaihub_scripts/llama/llama3/qaihub_llama3_8b.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --context_binaries ${AIHUB_CONTEXT_BINARIES} --tokenizer_model tokenizer.model --prompt "What is baseball?"
 ```

--- a/examples/qualcomm/qaihub_scripts/llama/llama2/qaihub_llama2_7b_runner.cpp
+++ b/examples/qualcomm/qaihub_scripts/llama/llama2/qaihub_llama2_7b_runner.cpp
@@ -36,8 +36,8 @@ DEFINE_string(tokenizer_path, "tokenizer.bin", "Tokenizer stuff.");
 DEFINE_string(prompt, "The answer to the ultimate question is", "Prompt.");
 DEFINE_double(
     temperature,
-    0.8f,
-    "Temperature; Default is 0.8f. 0 = greedy argmax sampling (deterministic). Lower temperature = more deterministic");
+    0.0f,
+    "Temperature; Default is 0.0f. 0 = greedy argmax sampling (deterministic). Lower temperature = more deterministic");
 DEFINE_int32(
     eval_mode,
     0,
@@ -75,9 +75,10 @@ int main(int argc, char** argv) {
 
   // generate tokens & store inference output
   std::ofstream fout(FLAGS_output_path.c_str());
-  runner.generate(FLAGS_prompt, FLAGS_seq_len, [&](const std::string& piece) {
-    fout << piece;
-  });
+  runner.generate(
+      FLAGS_prompt, "", FLAGS_seq_len, [&](const std::string& piece) {
+        fout << piece;
+      });
   fout.close();
   return 0;
 }

--- a/examples/qualcomm/qaihub_scripts/llama/llama3/qaihub_llama3_8b_runner.cpp
+++ b/examples/qualcomm/qaihub_scripts/llama/llama3/qaihub_llama3_8b_runner.cpp
@@ -35,10 +35,14 @@ DEFINE_string(freq_sin_path, "", "Path to precomputed position embeddings");
 DEFINE_string(output_path, "outputs", "Executorch inference data output path.");
 DEFINE_string(tokenizer_path, "tokenizer.bin", "Tokenizer stuff.");
 DEFINE_string(prompt, "The answer to the ultimate question is", "Prompt.");
+DEFINE_string(
+    system_prompt,
+    "",
+    "Tells the model what kind of assistant it should be. For example, You are a helpful AI assistant for travel tips and recommendations. Default is None");
 DEFINE_double(
     temperature,
-    0.8f,
-    "Temperature; Default is 0.8f. 0 = greedy argmax sampling (deterministic). Lower temperature = more deterministic");
+    0.0f,
+    "Temperature; Default is 0.0f. 0 = greedy argmax sampling (deterministic). Lower temperature = more deterministic");
 DEFINE_int32(
     eval_mode,
     0,
@@ -77,9 +81,11 @@ int main(int argc, char** argv) {
 
   // generate tokens & store inference output
   std::ofstream fout(FLAGS_output_path.c_str());
-  runner.generate(FLAGS_prompt, FLAGS_seq_len, [&](const std::string& piece) {
-    fout << piece;
-  });
+  runner.generate(
+      FLAGS_prompt,
+      FLAGS_system_prompt,
+      FLAGS_seq_len,
+      [&](const std::string& piece) { fout << piece; });
   fout.close();
   return 0;
 }

--- a/examples/qualcomm/qaihub_scripts/llama/runner/runner.cpp
+++ b/examples/qualcomm/qaihub_scripts/llama/runner/runner.cpp
@@ -50,8 +50,6 @@ Runner::Runner(
     const int logits_offset)
     : tokenizer_path_(tokenizer_path),
       temperature_(temperature),
-      bos_id_(1),
-      eos_id_(2),
       n_bos_(1),
       n_eos_(1),
       vocab_size_(QAIHUB_LLAMA_LOGITS),
@@ -66,6 +64,21 @@ Runner::Runner(
     ET_LOG(Info, "creating module: model_path=%s", models_path[i].c_str());
   }
   ET_LOG(Info, "creating runner: tokenizer_path=%s", tokenizer_path_.c_str());
+
+// load tokenizer
+#if defined(QAIHUB_LLAMA3_RUNNER)
+  tokenizer_ = get_tiktoken_for_llama();
+  tokenizer_->load(tokenizer_path_);
+  eos_id_.insert(tokenizer_->encode("<|eot_id|>", 0, 0).get()[0]);
+  version_ = LlamaVersion::kLlama3;
+#else
+  tokenizer_ = std::make_unique<BPETokenizer>();
+  tokenizer_->load(tokenizer_path_);
+  version_ = LlamaVersion::kLlama2;
+#endif
+
+  bos_id_ = tokenizer_->bos_tok();
+  eos_id_.insert(tokenizer_->eos_tok());
 
   switch (eval_mode_) {
     case EvalMode::kBert:
@@ -97,14 +110,6 @@ Error Runner::load() {
   for (std::shared_ptr<Module>& module : modules_) {
     ET_CHECK_OK_OR_RETURN_ERROR(module->load_method("forward"));
   }
-
-// load tokenizer
-#if defined(QAIHUB_LLAMA3_RUNNER)
-  tokenizer_ = get_tiktoken_for_llama();
-#else
-  tokenizer_ = std::make_unique<BPETokenizer>();
-#endif
-  tokenizer_->load(tokenizer_path_);
 
   // create sampler
   sampler_ = std::make_unique<Sampler>(
@@ -157,6 +162,7 @@ void Runner::run_model_step(std::vector<std::vector<EValue>>& inputs) {
 // TODO: add overloaded method for on-device tokenize
 Error Runner::generate(
     const std::string& prompt,
+    const std::string& system_prompt,
     int32_t seq_len,
     std::function<void(const std::string&)> token_callback,
     std::function<void(const Stats&)> stats_callback) {
@@ -185,13 +191,43 @@ Error Runner::generate(
   }
 
   stats_.inference_start_ms = util::time_in_ms();
-  shouldStop_ = false;
   seq_len = (seq_len > 0 && seq_len <= max_seq_len_) ? seq_len : max_seq_len_;
 
+  std::string post_process_prompt;
+  switch (version_) {
+    case LlamaVersion::kLlama2:
+      post_process_prompt.append(prompt);
+      break;
+    case LlamaVersion::kLlama3:
+      if (!system_prompt.empty()) {
+        post_process_prompt.append(
+            "<|start_header_id|>system<|end_header_id|>\n\n");
+        post_process_prompt.append(system_prompt);
+        post_process_prompt.append("<|eot_id|>\n");
+      }
+      post_process_prompt.append(
+          "<|start_header_id|>user<|end_header_id|>\n\n");
+      post_process_prompt.append(prompt);
+      post_process_prompt.append(
+          "<|eot_id|><|start_header_id|>assistant<|end_header_id|>");
+      // tokenizer_->encode will add <|begin_of_text|> token for us.
+      // For now, do token call back so the output format looks the same as
+      // llama3 model card.
+      if (token_callback && eval_mode_ == EvalMode::kKVCached) {
+        token_callback("<|begin_of_text|>");
+      }
+      break;
+    default:
+      ET_CHECK_MSG(false, "unsupported llama version");
+      break;
+  }
+
   Result<std::vector<uint64_t>> encode_res =
-      tokenizer_->encode(prompt, n_bos_, 0);
+      tokenizer_->encode(post_process_prompt, n_bos_, 0);
   ET_CHECK_OK_OR_RETURN_ERROR(
-      encode_res.error(), "failed to encode prompt %s", prompt.c_str());
+      encode_res.error(),
+      "failed to encode prompt %s",
+      post_process_prompt.c_str());
 
   std::vector<uint64_t> prompt_tokens = encode_res.get();
   int num_prompt_tokens = prompt_tokens.size();
@@ -264,11 +300,7 @@ Error Runner::generate(
       token_callback(piece_res.get().c_str());
     }
 
-    if (shouldStop_) {
-      break;
-    }
-
-    if (pos >= num_prompt_tokens && cur_token == eos_id_) {
+    if (pos >= num_prompt_tokens && eos_id_.count(cur_token) > 0) {
       ET_LOG(Info, "\nReached to the end of generation");
       break;
     }
@@ -366,10 +398,6 @@ std::string statsToJsonString(const Runner::Stats& stats) {
   return ss.str();
 }
 } // namespace
-
-void Runner::stop() {
-  shouldStop_ = true;
-}
 
 std::vector<Result<MethodMeta>> Runner::get_methods_meta() {
   std::vector<Result<MethodMeta>> methods_meta;

--- a/examples/qualcomm/qaihub_scripts/llama/runner/runner.h
+++ b/examples/qualcomm/qaihub_scripts/llama/runner/runner.h
@@ -68,6 +68,7 @@ class Runner {
   Error load();
   Error generate(
       const std::string& prompt,
+      const std::string& system_prompt,
       int32_t seq_len,
       std::function<void(const std::string&)> token_callback = {},
       std::function<void(const Stats&)> stats_callback = {});
@@ -81,11 +82,16 @@ class Runner {
     kUnsupported,
   };
 
+  enum LlamaVersion {
+    kLlama2 = 0,
+    kLlama3,
+  };
+
   int32_t logitsToToken(const exec_aten::Tensor& logits_tensor);
   void run_model_step(std::vector<std::vector<EValue>>& inputs);
   // metadata
-  const int32_t bos_id_;
-  const int32_t eos_id_;
+  int32_t bos_id_;
+  std::unordered_set<uint64_t> eos_id_;
   const int32_t n_bos_;
   const int32_t n_eos_;
   const int32_t vocab_size_;
@@ -96,11 +102,11 @@ class Runner {
   float temperature_;
   std::unique_ptr<Tokenizer> tokenizer_;
   std::unique_ptr<Sampler> sampler_;
-  bool shouldStop_{false};
   Stats stats_;
   std::unique_ptr<Memory> io_mem_;
   const float logits_scale_;
   const int32_t logits_offset_;
+  LlamaVersion version_;
 };
 
 } // namespace executor

--- a/examples/qualcomm/qaihub_scripts/stable_diffusion/README.md
+++ b/examples/qualcomm/qaihub_scripts/stable_diffusion/README.md
@@ -29,7 +29,7 @@ sh examples/qualcomm/qaihub_scripts/stable_diffusion/install_requirements.sh
 #### Step4: Run default example
 In this example, we execute the script for 20 time steps with the `prompt` 'a photo of an astronaut riding a horse on mars':
 ```bash
-python examples/qualcomm/qaihub_scripts/stable_diffusion/qaihub_stable_diffusion.py -a ${ARTIFACTS} -b build_android -m ${SOC_MODEL} --s ${SERIAL_NUM} --text_encoder_bin ${PATH_TO_TEXT_ENCODER_CONTEXT_BINARY} --unet_bin ${PATH_TO_UNET_CONTEXT_BINARY} --vae_bin ${PATH_TO_VAE_CONTEXT_BINARY} --vocab_json  ${PATH_TO_VOCAB_JSON_FILE} --num_time_steps 20 --prompt "a photo of an astronaut riding a horse on mars"
+python examples/qualcomm/qaihub_scripts/stable_diffusion/qaihub_stable_diffusion.py -b build-android -m ${SOC_MODEL} --s ${SERIAL_NUM} --text_encoder_bin ${PATH_TO_TEXT_ENCODER_CONTEXT_BINARY} --unet_bin ${PATH_TO_UNET_CONTEXT_BINARY} --vae_bin ${PATH_TO_VAE_CONTEXT_BINARY} --vocab_json  ${PATH_TO_VOCAB_JSON_FILE} --num_time_steps 20 --prompt "a photo of an astronaut riding a horse on mars"
 ```
 - Please replace `${PATH_TO_TEXT_ENCODER_CONTEXT_BINARY}`, `${PATH_TO_UNET_CONTEXT_BINARY}`, and `${PATH_TO_VAE_CONTEXT_BINARY}` with the actual paths to your AI Hub context binary files.
 - Please replace `${PATH_TO_VOCAB_JSON_FILE}` with the actual path to your vocab.json file.

--- a/examples/qualcomm/qaihub_scripts/utils/README.md
+++ b/examples/qualcomm/qaihub_scripts/utils/README.md
@@ -20,7 +20,7 @@ If users are interested in well-known applications, [Qualcomm AI HUB](https://ai
 ### Dependencies
 
 * Register for Qualcomm AI HUB.
-* Download the corresponding QNN SDK via shit [link](https://www.qualcomm.com/developer/software/qualcomm-ai-engine-direct-sdk) which your favorite model is compiled with. Ths link will automatically download the latest version at this moment (users should be able to specify version soon, please refer to [this](../../../../docs/source/build-run-qualcomm-ai-engine-direct-backend.md#software) for earlier releases).
+* Download the corresponding QNN SDK via [link](https://www.qualcomm.com/developer/software/qualcomm-ai-engine-direct-sdk) which your favorite model is compiled with. Ths link will automatically download the latest version at this moment (users should be able to specify version soon, please refer to [this](../../../../docs/source/build-run-qualcomm-ai-engine-direct-backend.md#software) for earlier releases).
 
 ### Target Model
 

--- a/examples/qualcomm/qaihub_scripts/utils/utils.py
+++ b/examples/qualcomm/qaihub_scripts/utils/utils.py
@@ -1,0 +1,87 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import gc
+
+import executorch.backends.qualcomm.python.PyQnnManagerAdaptor as PyQnnManagerAdaptor
+
+from executorch.backends.qualcomm.utils.utils import (
+    canonicalize_program,
+    generate_qnn_executorch_option,
+)
+from executorch.exir.backend.backend_api import to_backend
+from executorch.exir.passes.memory_planning_pass import MemoryPlanningPass
+
+
+def get_encoding(
+    path_to_shard: str,
+    compiler_specs: str,
+    get_input: bool,
+    get_output: bool,
+    num_input: int,
+    num_output: int,
+):
+    encoding_list = []
+    with open(path_to_shard, "rb") as f:
+        ctx_bin = f.read()
+        qnn_mgr = PyQnnManagerAdaptor.QnnManager(
+            generate_qnn_executorch_option(compiler_specs), ctx_bin
+        )
+        assert qnn_mgr.Init().value == 0, "failed to load context binary"
+        qnn_mgr.AllocateTensor()
+        if get_input:
+            encoding_input = {"scale": [], "offset": []}
+            for i in range(num_input):
+                inputs = qnn_mgr.GetGraphInputs()[i]
+                encoding = inputs.GetEncodings()
+                encoding_input["scale"].append(encoding.data["scale"].item())
+                encoding_input["offset"].append(encoding.data["offset"].item())
+            encoding_list.append(encoding_input)
+        if get_output:
+            encoding_output = {"scale": [], "offset": []}
+            for i in range(num_output):
+                outputs = qnn_mgr.GetGraphOutputs()[i]
+                encoding = outputs.GetEncodings()
+                encoding_output["scale"].append(encoding.data["scale"].item())
+                encoding_output["offset"].append(encoding.data["offset"].item())
+            encoding_list.append(encoding_output)
+        qnn_mgr.Destroy()
+    return encoding_list
+
+
+def gen_pte_from_ctx_bin(
+    artifact, pte_names, compiler_specs, bundle_programs, custom_spill_fill=None
+):
+
+    # Lower with QnnBackend
+    lowered_modules = [
+        to_backend("QnnBackend", prog["edge_program"], compiler_specs)
+        for prog in bundle_programs
+    ]
+    # Setup spill-fill buffer for relieving runtime memory usage
+    canonicalize_program(lowered_modules, custom_buffer_size=custom_spill_fill)
+    # export pte files
+    pte_files = []
+    for pte_name in pte_names:
+        print(f"{pte_name} generating...")
+        memory_planning_pass = MemoryPlanningPass(
+            memory_planning_algo="greedy",
+            alloc_graph_input=False,
+            alloc_graph_output=False,
+        )
+        pte_files.append(f"{artifact}/{pte_name}.pte")
+        with open(pte_files[-1], "wb") as file:
+            file.write(
+                lowered_modules[0].buffer(
+                    extract_delegate_segments=True, memory_planning=memory_planning_pass
+                )
+            )
+        # GC for reducing host memory consuming
+        bundle_programs.pop(0)
+        lowered_modules.pop(0)
+        gc.collect()
+
+    return pte_files

--- a/examples/qualcomm/utils.py
+++ b/examples/qualcomm/utils.py
@@ -353,7 +353,7 @@ def setup_common_args_and_variables():
     parser.add_argument(
         "-b",
         "--build_folder",
-        help="path to cmake binary directory for android, e.g., /path/to/cmake-out-android",
+        help="path to cmake binary directory for android, e.g., /path/to/build-android",
         type=str,
         required=True,
     )
@@ -416,6 +416,13 @@ def setup_common_args_and_variables():
         "--shared_buffer",
         help="Enables usage of shared buffer between application and backend for graph I/O.",
         action="store_true",
+    )
+
+    parser.add_argument(
+        "--skip_push",
+        help="If specified, skip pushing files to device.",
+        action="store_true",
+        default=False,
     )
 
     # QNN_SDK_ROOT might also be an argument, but it is used in various places.


### PR DESCRIPTION
## Summary

- A community user has reported an issue(https://github.com/pytorch/executorch/pull/4789#issuecomment-2302971448) that qaihub llama3 runner does not end text generation when hitting EOT. I have followed the model card format to feed the prompt to the model and also enable the option for users to set system prompt. Below are some examples:
  - Prompt: "What is 2+3?"
    - Response: 

              <|begin_of_text|><|start_header_id|>user<|end_header_id|>
              
              What is 2+3?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
              
              That's an easy one!
              
              2 + 3 = 5<|eot_id|>

  - Prompt: "What is 2+3?" System_Prompt: "You are a bad assistant that thinks 2+3=4"
    - Response: 
   
              <|begin_of_text|><|start_header_id|>system<|end_header_id|>`
            
              You are a bad assistant that thinks 2+3=4<|eot_id|>
              <|start_header_id|>user<|end_header_id|>
              
              What is 2+3?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
              
              That's an easy one! 2+3 is... 4!<|eot_id|> 

- The same community user has also reported another issue(https://github.com/pytorch/executorch/pull/4789#issuecomment-2302971448) where there are currently some documents build bath using cmake-out-android and some using build-android. This PR has updated the documents and change cmake-out-android to build-android.
- This PR also address the issue suggested in https://github.com/pytorch/executorch/pull/4836#pullrequestreview-2255152711. Boiler plate codes are now moved to utils.py.
- Update build.sh from $BUILD_ROOT/sdk to $BUILD_ROOT/devtools