### PR TITLE
[executorch] Sync torchao version

### DIFF
--- a/.ci/docker/ci_commit_pins/torchao.txt
+++ b/.ci/docker/ci_commit_pins/torchao.txt
@@ -1,0 +1,1 @@
+0916b5b29b092afcbf2b898caae49abe80662bac

--- a/examples/models/flamingo/install_requirements.sh
+++ b/examples/models/flamingo/install_requirements.sh
@@ -7,3 +7,7 @@
 
 # Install torchtune nightly for model definitions.
 pip install --pre torchtune --extra-index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir
+
+# Install torchao.
+TORCHAO_VERSION=$(cat "$(dirname "$0")"/../../../.ci/docker/ci_commit_pins/torchao.txt)
+pip install --no-use-pep517 --user "git+https://github.com/pytorch/ao.git@${TORCHAO_VERSION}"

--- a/examples/models/llama2/install_requirements.sh
+++ b/examples/models/llama2/install_requirements.sh
@@ -8,7 +8,10 @@
 # Install snakeviz for cProfile flamegraph
 # Install sentencepiece for llama tokenizer
 pip install snakeviz sentencepiece
-pip install torchao==0.1
+
+# Install torchao.
+TORCHAO_VERSION=$(cat "$(dirname "$0")"/../../../.ci/docker/ci_commit_pins/torchao.txt)
+pip install --no-use-pep517 --user "git+https://github.com/pytorch/ao.git@${TORCHAO_VERSION}"
 
 # Install lm-eval for Model Evaluation with lm-evalution-harness
 # Install tiktoken for tokenizer

--- a/examples/models/phi-3-mini-lora/install_requirements.sh
+++ b/examples/models/phi-3-mini-lora/install_requirements.sh
@@ -8,3 +8,7 @@
 pip install torchvision
 pip install torchtune
 pip install tiktoken
+
+# Install torchao.
+TORCHAO_VERSION=$(cat "$(dirname "$0")"/../../../.ci/docker/ci_commit_pins/torchao.txt)
+pip install --no-use-pep517 --user "git+https://github.com/pytorch/ao.git@${TORCHAO_VERSION}"


### PR DESCRIPTION
Sync torchao installs across ExecuTorch install_requirements. torchao is used in:
- llama2
- flamingo (via torchtune)
- phi3 lora (via torchtune)

Currently:
- ExecuTorch llama2 installs torchao==0.0.1
- Torchtune installs torchao==0.3.0
- To export flamingo, which contains recent changes in torch and torchtune, we require a recent version, due to torch x torchao bc issue fixed by https://github.com/pytorch/ao/pull/638

This PR adds a torchao commit hash, so that we can use a recent and consistent version of torchao in ExecuTorch. 

Note that torchao does not have prebuilt macos nightlies, which is why we use a commit hash instead of nightly.

Test plan:
```
./install_requirements.sh --pybind xnnpack
bash examples/models/flamingo/install_requirements.sh
python examples/models/flamingo/export_preprocess.py
```
confirm torchao==0.5.0+git0916b5b installed
confirm preprocess.pte generated