### PR TITLE
[ET] Introduce `TensorInfo::is_memory_planned`` API

### DIFF
--- a/runtime/executor/method_meta.cpp
+++ b/runtime/executor/method_meta.cpp
@@ -73,8 +73,8 @@ TensorInfo::TensorInfo(
     : sizes_(sizes),
       dim_order_(dim_order),
       scalar_type_(scalar_type),
-      nbytes_(calculate_nbytes(sizes_, scalar_type_)),
-      is_memory_planned_(is_memory_planned) {}
+      is_memory_planned_(is_memory_planned),
+      nbytes_(calculate_nbytes(sizes_, scalar_type_)) {}
 
 Span<const int32_t> TensorInfo::sizes() const {
   return sizes_;
@@ -88,12 +88,12 @@ exec_aten::ScalarType TensorInfo::scalar_type() const {
   return scalar_type_;
 }
 
-size_t TensorInfo::nbytes() const {
-  return nbytes_;
-}
-
 bool TensorInfo::is_memory_planned() const {
   return is_memory_planned_;
+}
+
+size_t TensorInfo::nbytes() const {
+  return nbytes_;
 }
 
 MethodMeta::MethodMeta(const executorch_flatbuffer::ExecutionPlan* s_plan)

--- a/runtime/executor/method_meta.cpp
+++ b/runtime/executor/method_meta.cpp
@@ -197,5 +197,22 @@ Result<int64_t> MethodMeta::memory_planned_buffer_size(size_t index) const {
   return s_plan_->non_const_buffer_sizes()->Get(index + 1);
 }
 
+Result<bool> MethodMeta::is_output_tensor_memory_planned(size_t index) const {
+  auto tag = this->output_tag(index);
+  if (!tag.ok()) {
+    return tag.error();
+  }
+  ET_CHECK_OR_RETURN_ERROR(
+      tag.get() == Tag::Tensor,
+      InvalidArgument,
+      "Tag: %zu output: %zu is not Tensor",
+      (size_t)tag.get(),
+      index);
+  auto input_index = s_plan_->outputs()->Get(index);
+  auto tensor_value = s_plan_->values()->Get(input_index)->val_as_Tensor();
+
+  return tensor_value->allocation_info() != nullptr;
+}
+
 } // namespace runtime
 } // namespace executorch

--- a/runtime/executor/method_meta.h
+++ b/runtime/executor/method_meta.h
@@ -53,14 +53,14 @@ class TensorInfo final {
   exec_aten::ScalarType scalar_type() const;
 
   /**
-   * Returns the size of the tensor in bytes.
-   */
-  size_t nbytes() const;
-
-  /**
    * Returns whether the tensor's memory was planned during export.
    */
   bool is_memory_planned() const;
+
+  /**
+   * Returns the size of the tensor in bytes.
+   */
+  size_t nbytes() const;
 
  private:
   // Let MethodMeta create TensorInfo.
@@ -91,11 +91,11 @@ class TensorInfo final {
   /// The scalar type of the tensor.
   exec_aten::ScalarType scalar_type_;
 
+  /// Whether the tensor's memory was planned during export.
+  bool is_memory_planned_;
+
   /// The size in bytes of the tensor.
   size_t nbytes_;
-
-  /// Whether the tensor's memory was planned during export.
-  const bool is_memory_planned_;
 };
 
 /**

--- a/runtime/executor/method_meta.h
+++ b/runtime/executor/method_meta.h
@@ -177,6 +177,13 @@ class MethodMeta final {
   Result<int64_t> memory_planned_buffer_size(size_t index) const;
 
   /**
+   * Get whether the specified tensor is memory planned.
+   *
+   * @returns True if the tensor is memory planned.
+   */
+  Result<bool> is_output_tensor_memory_planned(size_t index) const;
+
+  /**
    * DEPRECATED: Use num_memory_planned_buffers() instead.
    */
   ET_DEPRECATED size_t num_non_const_buffers() const {

--- a/runtime/executor/method_meta.h
+++ b/runtime/executor/method_meta.h
@@ -57,6 +57,11 @@ class TensorInfo final {
    */
   size_t nbytes() const;
 
+  /**
+   * Returns whether the tensor's memory was planned during export.
+   */
+  bool is_memory_planned() const;
+
  private:
   // Let MethodMeta create TensorInfo.
   friend class MethodMeta;
@@ -64,7 +69,8 @@ class TensorInfo final {
   TensorInfo(
       Span<const int32_t> sizes,
       Span<const uint8_t> dim_order,
-      exec_aten::ScalarType scalar_type);
+      exec_aten::ScalarType scalar_type,
+      const bool is_memory_planned);
 
   /**
    * The sizes of the tensor.
@@ -87,6 +93,9 @@ class TensorInfo final {
 
   /// The size in bytes of the tensor.
   size_t nbytes_;
+
+  /// Whether the tensor's memory was planned during export.
+  const bool is_memory_planned_;
 };
 
 /**
@@ -175,13 +184,6 @@ class MethodMeta final {
    * @returns The size in bytes on success, or an error on failure.
    */
   Result<int64_t> memory_planned_buffer_size(size_t index) const;
-
-  /**
-   * Get whether the specified tensor is memory planned.
-   *
-   * @returns True if the tensor is memory planned.
-   */
-  Result<bool> is_output_tensor_memory_planned(size_t index) const;
 
   /**
    * DEPRECATED: Use num_memory_planned_buffers() instead.

--- a/runtime/executor/test/method_meta_test.cpp
+++ b/runtime/executor/test/method_meta_test.cpp
@@ -61,6 +61,7 @@ void check_tensor(const TensorInfo& tensor_info) {
   EXPECT_EQ(dim_order.size(), 2);
   EXPECT_EQ(dim_order[0], 0);
   EXPECT_EQ(dim_order[1], 1);
+  EXPECT_EQ(tensor_info.is_memory_planned(), true);
   EXPECT_EQ(tensor_info.nbytes(), 16);
 }
 } // namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4946

Currently, we can achieve this behavior with `set_output_data_ptr()`:
- If the tensor is mem-planned, returns error.
- If the tensor isn't mem-planned, succeeds.

But that's a waste of allocating and de-allocating a buffer in the mem-planned case.

Hence, introducing this cleaner API.

Differential Revision: [D61923695](https://our.internmc.facebook.com/intern/diff/D61923695/)