### PR TITLE
Hide and simplify backend registry internals

### DIFF
--- a/runtime/backend/interface.cpp
+++ b/runtime/backend/interface.cpp
@@ -14,45 +14,44 @@ namespace runtime {
 
 PyTorchBackendInterface::~PyTorchBackendInterface() {}
 
-// TODO(T128866626): Remove global static variables.
-// We want to be able to run multiple Executor instances
-// and having a global registration isn't a viable solution
-// in the long term.
-BackendRegistry& getBackendRegistry();
-BackendRegistry& getBackendRegistry() {
-  static BackendRegistry backend_reg;
-  return backend_reg;
-}
+namespace {
+
+// The max number of backends that can be registered globally.
+constexpr size_t kMaxRegisteredBackends = 16;
+
+// TODO(T128866626): Remove global static variables. We want to be able to run
+// multiple Executor instances and having a global registration isn't a viable
+// solution in the long term.
+
+/// Global table of registered backends.
+Backend registered_backends[kMaxRegisteredBackends];
+
+/// The number of backends registered in the table.
+size_t num_registered_backends = 0;
+
+} // namespace
 
 PyTorchBackendInterface* get_backend_class(const char* name) {
-  return getBackendRegistry().get_backend_class(name);
-}
-
-PyTorchBackendInterface* BackendRegistry::get_backend_class(const char* name) {
-  for (size_t idx = 0; idx < registrationTableSize_; idx++) {
-    Backend backend = backend_table_[idx];
-    if (strcmp(backend.name_, name) == 0) {
-      return backend.interface_ptr_;
+  for (size_t i = 0; i < num_registered_backends; i++) {
+    Backend backend = registered_backends[i];
+    if (strcmp(backend.name, name) == 0) {
+      return backend.backend;
     }
   }
   return nullptr;
 }
 
 Error register_backend(const Backend& backend) {
-  return getBackendRegistry().register_backend(backend);
-}
-
-Error BackendRegistry::register_backend(const Backend& backend) {
-  if (registrationTableSize_ >= kRegistrationTableMaxSize) {
+  if (num_registered_backends >= kMaxRegisteredBackends) {
     return Error::Internal;
   }
 
   // Check if the name already exists in the table
-  if (this->get_backend_class(backend.name_) != nullptr) {
+  if (get_backend_class(backend.name) != nullptr) {
     return Error::InvalidArgument;
   }
 
-  backend_table_[registrationTableSize_++] = backend;
+  registered_backends[num_registered_backends++] = backend;
   return Error::Ok;
 }
 


### PR DESCRIPTION
Summary:
All users of the backend registry use the global functions, so we can hide the class.

And since there's only one registry instance, we don't need the class.

Differential Revision: D61928651
