### PR TITLE
Enable MKL on x86 to get around long-context discrepancies with torch.nn.functional.scaled_dot_product_attention

### DIFF
--- a/extension/llm/custom_ops/TARGETS
+++ b/extension/llm/custom_ops/TARGETS
@@ -14,7 +14,7 @@ runtime.python_test(
         "test_sdpa_with_kv_cache.py",
     ],
     preload_deps = [
-        ":custom_ops_aot_lib",
+        ":custom_ops_aot_lib_mkl_noomp",
         ":custom_ops_aot_py",
     ],
     deps = [

--- a/extension/llm/custom_ops/targets.bzl
+++ b/extension/llm/custom_ops/targets.bzl
@@ -6,47 +6,48 @@ def define_common_targets():
     The directory containing this targets.bzl file should also contain both
     TARGETS and BUCK files that call this function.
     """
-    runtime.cxx_library(
-        name = "custom_ops",
-        srcs = ["op_sdpa.cpp", "op_fallback.cpp"],
-        exported_headers = ["op_sdpa.h", "op_fallback.h"],
-        exported_deps = [
-            "//executorch/runtime/kernel:kernel_includes",
-            "//executorch/kernels/portable/cpu:scalar_utils",
-            "//executorch/kernels/optimized:libblas",
-            "//executorch/kernels/optimized:libvec",
-            "//executorch/extension/kernel_util:kernel_util",
-            "//executorch/extension/parallel:thread_parallel",
-            "//executorch/extension/threadpool:threadpool",
-        ],
-        compiler_flags = ["-Wno-missing-prototypes", "-Wno-global-constructors"],
-        visibility = [
-            "//executorch/...",
-            "//executorch/extension/llm/custom_ops/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
-        # @lint-ignore BUCKLINT link_whole
-        link_whole = True,
-        force_static = True,
-    )
+    for mkl_dep in ["", "_mkl_noomp"]:
+        runtime.cxx_library(
+            name = "custom_ops" + mkl_dep,
+            srcs = ["op_sdpa.cpp", "op_fallback.cpp"],
+            exported_headers = ["op_sdpa.h", "op_fallback.h"],
+            exported_deps = [
+                "//executorch/runtime/kernel:kernel_includes",
+                "//executorch/kernels/portable/cpu:scalar_utils",
+                "//executorch/kernels/optimized:libblas{}".format(mkl_dep),
+                "//executorch/kernels/optimized:libvec",
+                "//executorch/extension/kernel_util:kernel_util",
+                "//executorch/extension/parallel:thread_parallel",
+                "//executorch/extension/threadpool:threadpool",
+            ],
+            compiler_flags = ["-Wno-missing-prototypes", "-Wno-global-constructors"],
+            visibility = [
+                "//executorch/...",
+                "//executorch/extension/llm/custom_ops/...",
+                "@EXECUTORCH_CLIENTS",
+            ],
+            # @lint-ignore BUCKLINT link_whole
+            link_whole = True,
+            force_static = True,
+        )
 
-    runtime.cxx_library(
-        name = "custom_ops_aot_lib",
-        srcs = [
-            "op_sdpa_aot.cpp",
-        ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
-        external_deps = [
-            "libtorch",
-        ],
-        deps = [
-            ":custom_ops",
-            "//executorch/extension/aten_util:aten_bridge",
-        ],
-    )
+        runtime.cxx_library(
+            name = "custom_ops_aot_lib" + mkl_dep,
+            srcs = [
+                "op_sdpa_aot.cpp",
+            ],
+            visibility = [
+                "//executorch/...",
+                "@EXECUTORCH_CLIENTS",
+            ],
+            external_deps = [
+                "libtorch",
+            ],
+            deps = [
+                ":custom_ops" + mkl_dep,
+                "//executorch/extension/aten_util:aten_bridge",
+            ],
+        )
 
     runtime.python_library(
         name = "custom_ops_aot_py",

--- a/kernels/optimized/lib_defs.bzl
+++ b/kernels/optimized/lib_defs.bzl
@@ -1,4 +1,5 @@
 load("@fbsource//tools/build_defs:default_platform_defs.bzl", "DEVSERVER_PLATFORM_REGEX")
+load("@fbsource//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 # Because vec exists as a collection of header files, compile and preprocessor
@@ -99,44 +100,64 @@ def define_libs():
         ],
     )
 
-    runtime.cxx_library(
-        name = "libblas",
-        srcs = native.glob([
-            "blas/**/*.cpp",
-        ]),
-        exported_headers = native.glob([
-            "blas/**/*.h",
-        ]),
-        header_namespace = "executorch/kernels/optimized",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
-        fbandroid_platform_preprocessor_flags = [
-            (
-                "^android-arm64.*$",
-                [
-                    "-DET_BUILD_WITH_BLAS",
-                ],
-            ),
-        ],
-        fbandroid_platform_deps = [
-            (
-                "^android-arm64.*$",
-                [
-                    "fbsource//third-party/openblas:openblas",
-                ],
-            ),
-        ],
-        fbobjc_exported_preprocessor_flags = [
-            "-DET_BUILD_WITH_BLAS",
-            "-DET_BUILD_FOR_APPLE",
-        ],
-        fbobjc_frameworks = [
-            "Accelerate",
-        ],
-        exported_deps = [
-            "//executorch/kernels/optimized:libutils",
-            "//executorch/runtime/core/exec_aten:lib",
+    # OSS doesn't have ovr_config//os:linux-x86_64
+    fb_native.config_setting(
+        name = "linux-x86_64",
+        constraint_values = [
+            "ovr_config//os/constraints:linux",
+            "ovr_config//cpu/constraints:x86_64",
         ],
     )
+
+    for libblas_name, mkl_dep in [("libblas", "fbsource//third-party/mkl:mkl_lp64_omp"), ("libblas_mkl_noomp", "fbsource//third-party/mkl:mkl")]:
+        runtime.cxx_library(
+            name = libblas_name,
+            srcs = native.glob([
+                "blas/**/*.cpp",
+            ]),
+            exported_headers = native.glob([
+                "blas/**/*.h",
+            ]),
+            header_namespace = "executorch/kernels/optimized",
+            visibility = [
+                "//executorch/...",
+                "@EXECUTORCH_CLIENTS",
+            ],
+            preprocessor_flags = select({
+                ":linux-x86_64": [
+                    "-DET_BUILD_WITH_BLAS",
+                ] if not runtime.is_oss else [],
+                "DEFAULT": [],
+            }),
+            fbandroid_platform_preprocessor_flags = [
+                (
+                    "^android-arm64.*$",
+                    [
+                        "-DET_BUILD_WITH_BLAS",
+                    ],
+                ),
+            ],
+            fbandroid_platform_deps = [
+                (
+                    "^android-arm64.*$",
+                    [
+                        "fbsource//third-party/openblas:openblas",
+                    ],
+                ),
+            ],
+            fbobjc_exported_preprocessor_flags = [
+                "-DET_BUILD_WITH_BLAS",
+                "-DET_BUILD_FOR_APPLE",
+            ],
+            fbobjc_frameworks = [
+                "Accelerate",
+            ],
+            deps = select({
+                ":linux-x86_64": [mkl_dep] if not runtime.is_oss else [],
+                "DEFAULT": [],
+            }),
+            exported_deps = [
+                "//executorch/kernels/optimized:libutils",
+                "//executorch/runtime/core/exec_aten:lib",
+            ],
+        )

--- a/shim/tools/build_defs/fb_native_wrapper.bzl
+++ b/shim/tools/build_defs/fb_native_wrapper.bzl
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+fb_native = struct(
+    config_setting = native.config_setting,
+)


### PR DESCRIPTION
Summary:
When used with longer kv caches with a wider dynamic range, sdpa_with_kv_cache produces a non-trivial numerical error on x86: ~2e-4 on the 130-length unit test, more with real-world tensors.

Switching ::executorch::cpublas::gemm to MKL reduces the error to ~3e-07 for mid-range context lengths (130 in these tests).

On the longer length llava tests there's still an error of 1.4e-4.

OSS doesn't have MKL, so for now this is fbcode only.

Differential Revision: D61931885
