### PR TITLE
Add int4pack_mm shader and operator

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/q_4w_linear.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q_4w_linear.glsl
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+
+#include "indexing_utils.h"
+
+#define PRECISION ${PRECISION}
+
+#define FLOAT_T ${buffer_scalar_type(DTYPE)}
+
+${define_active_storage_type(STORAGE)}
+
+${define_required_extensions(DTYPE)}
+${define_required_extensions("int8")}
+
+layout(std430) buffer;
+
+${layout_declare_tensor(0, "w", "t_out", DTYPE, STORAGE)}
+${layout_declare_tensor(1, "r", "t_mat1", DTYPE, STORAGE)}
+${layout_declare_tensor(2, "r", "t_mat2", "int8", STORAGE)}
+${layout_declare_tensor(3, "r", "t_scales_and_zeros", DTYPE, STORAGE)}
+
+${layout_declare_ubo(4, "ivec4", "out_sizes")}
+${layout_declare_ubo(5, "ivec4", "out_strides")}
+${layout_declare_ubo(6, "ivec4", "mat1_strides")}
+${layout_declare_ubo(7, "ivec4", "mat2_sizes")}
+${layout_declare_ubo(8, "ivec4", "mat2_strides")}
+${layout_declare_ubo(9, "ivec4", "scales_strides")}
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+layout(constant_id = 3) const int group_size = 1;
+
+void main() {
+
+    const ivec4 out_pos = ivec4(
+      gl_GlobalInvocationID.x, // n = 0..N-1
+      gl_GlobalInvocationID.y, // m = 0..M-1
+      gl_GlobalInvocationID.z % out_sizes.z,
+      gl_GlobalInvocationID.z / out_sizes.z);
+
+    if (any(greaterThanEqual(out_pos, out_sizes))) {
+      return;
+    }
+
+    const uint K = mat2_sizes.x * 2;
+    const uint N = mat2_sizes.y;
+    const uint n = out_pos.x;
+    const uint m = out_pos.y;
+    const uint k_block = (K + group_size - 1) / group_size;
+    const uint mask = uint(0x0f);
+    ivec4 mat1_pos = ivec4(0, m, out_pos.z, out_pos.w);
+    ivec4 mat2_pos = ivec4(0, n, out_pos.z, out_pos.w);
+    ivec4 scale_pos = ivec4(0, n, 0, out_pos.w);
+    ivec4 zero_pos = ivec4(0, n, 1, out_pos.w);
+
+    float rc = 0.0;
+    int k = 0;
+
+    for (int kb = 0; kb < k_block; kb++) {
+      scale_pos.x = kb;
+      const int scale_id = to_buffer_id(scale_pos, scales_strides);
+      const float scale = float(t_scales_and_zeros[scale_id]);
+
+      zero_pos.x = kb;
+      const int zero_id = to_buffer_id(zero_pos, scales_strides);
+      const float zero = float(t_scales_and_zeros[zero_id]) - scale * 8.0;
+
+      for(uint idx = 0; idx < group_size && k < K; idx++, k++) {
+        mat1_pos.x = k;
+        const int mat1_id = to_buffer_id(mat1_pos, mat1_strides);
+        const float mat1_val = float(t_mat1[mat1_id]);
+
+        mat2_pos.x = k / 2;
+        const int mat2_id = to_buffer_id(mat2_pos, mat2_strides);
+        // Bitwise op treats sign bit from int8 as a value bit instead,
+        // since there is no uint8_t datatype
+        uint mat2_val = (t_mat2[mat2_id] & 0xFF);
+        mat2_val = (k & 1) == 0 ? mat2_val & mask : (mat2_val >> 4);
+
+        rc += mat1_val * (scale * float(mat2_val) + zero);
+      }
+    }
+
+    const int out_id = to_buffer_id(out_pos, out_strides);
+    t_out[out_id] = FLOAT_T(rc);
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/q_4w_linear.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/q_4w_linear.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+q_4w_linear:
+  parameter_names_with_default_values:
+    DTYPE: float
+    STORAGE: buffer
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: float
+      - VALUE: half
+  shader_variants:
+    - NAME: q_4w_linear

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedMatMul.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedMatMul.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+namespace vkcompute {
+
+void check_q_matmul_args(
+    ComputeGraph& graph,
+    const ValueRef mat1,
+    const ValueRef mat2_data,
+    const ValueRef group_size_data,
+    const ValueRef scales_and_zeros,
+    const ValueRef out) {
+  const std::vector<int64_t> mat1_sizes = graph.sizes_of(mat1);
+  const std::vector<int64_t> mat2_sizes = graph.sizes_of(mat2_data);
+  const std::vector<int64_t> scales_and_zeros_sizes =
+      graph.sizes_of(scales_and_zeros);
+
+  const uint32_t group_size = graph.extract_scalar<uint32_t>(group_size_data);
+
+  VK_CHECK_COND(mat1_sizes.size() == 2);
+  VK_CHECK_COND(mat1_sizes.size() == mat2_sizes.size());
+
+  VK_CHECK_COND(graph.memory_layout_of(mat1) == graph.memory_layout_of(out));
+
+  const int mat1_K = utils::val_at(-1, mat1_sizes);
+  const int mat2_K = utils::val_at(-1, mat2_sizes) * 2;
+  const int N = utils::val_at(-2, mat2_sizes);
+
+  VK_CHECK_COND(mat1_K == mat2_K);
+
+  VK_CHECK_COND(mat2_K % group_size == 0);
+
+  const uint32_t k_groups = mat2_K / group_size;
+
+  VK_CHECK_COND(scales_and_zeros_sizes.size() == 3);
+  VK_CHECK_COND(utils::val_at(-1, scales_and_zeros_sizes) == k_groups);
+  VK_CHECK_COND(utils::val_at(-2, scales_and_zeros_sizes) == N);
+  VK_CHECK_COND(utils::val_at(-3, scales_and_zeros_sizes) == 2);
+
+  // Match https://fburl.com/code/6ostkknm
+  std::vector<uint32_t> valid_group_sizes = {32, 64, 128, 256};
+
+  bool is_valid_group_size = false;
+  for (auto valid_group_size : valid_group_sizes) {
+    if (group_size == valid_group_size) {
+      is_valid_group_size = true;
+      break;
+    }
+  }
+
+  VK_CHECK_COND(is_valid_group_size);
+}
+
+void resize_q_matmul_node(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& extra_args) {
+  (void)extra_args;
+
+  vTensorPtr out = graph->get_tensor(args[0].refs[0]);
+  vTensorPtr mat1 = graph->get_tensor(args[1].refs[0]);
+  vTensorPtr mat2 = graph->get_tensor(args[1].refs[1]);
+
+  const int out_cols = utils::val_at(-2, mat1->sizes());
+  const int out_rows = utils::val_at(-2, mat2->sizes());
+
+  std::vector<int64_t> new_out_sizes(3);
+  if (mat1->sizes().size() == 2) {
+    new_out_sizes.resize(2);
+    new_out_sizes.at(0) = out_cols;
+    new_out_sizes.at(1) = out_rows;
+  } else {
+    new_out_sizes.at(0) = mat1->sizes().at(0);
+    new_out_sizes.at(1) = out_cols;
+    new_out_sizes.at(2) = out_rows;
+  }
+
+  out->virtual_resize(new_out_sizes);
+}
+
+void add_q_matmul_node(
+    ComputeGraph& graph,
+    const ValueRef mat1,
+    const ValueRef mat2_data,
+    const ValueRef group_size,
+    const ValueRef scales_and_zeros_data,
+    const ValueRef out) {
+  ValueRef mat2 =
+      prepack_buffer_if_tensor_ref(graph, mat2_data, utils::kWidthPacked);
+  ValueRef scales_and_zeros =
+      prepack_if_tensor_ref(graph, scales_and_zeros_data, utils::kWidthPacked);
+
+  std::string kernel_name = "q_4w_linear";
+
+  add_dtype_suffix(kernel_name, graph.dtype_of(out));
+
+  const uint32_t group_size_val = graph.extract_scalar<uint32_t>(group_size);
+
+  vkapi::ParamsBindList ubos({});
+  ubos.append(graph.sizes_ubo(out));
+  ubos.append(graph.strides_ubo(out));
+  ubos.append(graph.strides_ubo(mat1));
+  ubos.append(graph.sizes_ubo(mat2));
+  ubos.append(graph.strides_ubo(mat2));
+  ubos.append(graph.strides_ubo(scales_and_zeros));
+
+  auto out_sizes = graph.sizes_of(out);
+  uint32_t N = utils::val_at(-1, out_sizes);
+  uint32_t M = utils::val_at(-2, out_sizes);
+
+  utils::uvec3 global_wg_size = {N, M, 1};
+
+  utils::uvec3 local_wg_size = adaptive_work_group_size(global_wg_size);
+
+  graph.execute_nodes().emplace_back(new ExecuteNode(
+      graph,
+      VK_KERNEL_FROM_STR(kernel_name),
+      global_wg_size,
+      local_wg_size,
+      // Inputs and Outputs
+      {{out, vkapi::MemoryAccessType::WRITE},
+       {{mat1, mat2, scales_and_zeros}, vkapi::MemoryAccessType::READ}},
+      // Shader params buffers
+      ubos,
+      // Specialization Constants
+      {SV(group_size_val)},
+      // Resizing Logic
+      resize_q_matmul_node,
+      {}));
+}
+
+void int4pack_mm(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  check_q_matmul_args(graph, args[0], args[1], args[2], args[3], args[4]);
+  return add_q_matmul_node(
+      graph,
+      args[0], // mat1
+      args[1], // mat2
+      args[2], // group_size
+      args[3], // scales_and_zeros
+      args[4] // out
+  );
+}
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(aten._weight_int4pack_mm.default, int4pack_mm);
+}
+
+} // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/impl/Staging.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Staging.cpp
@@ -136,7 +136,7 @@ ValueRef prepack_buffer(
     ComputeGraph& graph,
     const ValueRef vref,
     const utils::GPUMemoryLayout layout) {
-  ValueRef v = graph.add_tensor_like(vref, layout);
+  ValueRef v = graph.add_tensor_like(vref, utils::kBuffer, layout);
 
   vkapi::ShaderInfo shader = VK_KERNEL_FROM_STR("buffer_to_buffer");
 

--- a/backends/vulkan/runtime/graph/ops/impl/utils/QPackUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/QPackUtils.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/QPackUtils.h>
+
+namespace vkcompute {
+
+void pack4(const uint8_t* w_ptr, uint8_t* b_ptr, uint32_t N, uint32_t K) {
+  for (int32_t n = 0; n < N; n++) {
+    for (int32_t k2 = 0; k2 < K / 2; k2++) {
+      uint8_t src_val0 = w_ptr[n * K + k2 * 2];
+      uint8_t src_val1 = w_ptr[n * K + k2 * 2 + 1];
+      b_ptr[n * (K / 2) + k2] = (uint8_t(src_val1) << 4) | uint8_t(src_val0);
+    }
+  }
+}
+
+std::vector<uint8_t> int4mm_pack_weights(
+    const std::vector<int64_t>& W_sizes,
+    const uint8_t* w_ptr) {
+  const int32_t N = utils::val_at(-1, W_sizes);
+  const int32_t K = utils::val_at(-2, W_sizes);
+
+  const auto numel = K * N;
+  std::vector<uint8_t> w_ptr_T(numel);
+  std::vector<uint8_t> b_ptr(utils::div_up(numel, 2));
+
+  // Transpose the weights
+  for (int32_t k = 0; k < K; k++) {
+    for (int32_t n = 0; n < N; n++) {
+      w_ptr_T[n * K + k] = w_ptr[k * N + n];
+    }
+  }
+
+  // Pack two int4s into each int8
+  pack4(w_ptr_T.data(), b_ptr.data(), N, K);
+
+  return b_ptr;
+}
+
+std::vector<float> int4mm_dequantize_weights(
+    const std::vector<int64_t>& W_sizes,
+    const uint8_t* w_ptr,
+    const uint32_t group_size,
+    const float* scales_and_zeros) {
+  const int64_t N = utils::val_at(-1, W_sizes);
+  const int64_t K = utils::val_at(-2, W_sizes);
+
+  std::vector<float> w_ptr_deq(K * N);
+  const int k_groups = K / group_size;
+  const int zeros_stride = k_groups * N;
+
+  for (int k = 0; k < K; k++) {
+    for (int n = 0; n < N; n++) {
+      const int kb = k / group_size;
+      const int scale_idx = k_groups * n + kb;
+      const float scale = scales_and_zeros[scale_idx];
+      const float zero =
+          scales_and_zeros[scale_idx + zeros_stride] - scale * 8.0;
+      w_ptr_deq[k * N + n] = w_ptr[k * N + n] * scale + zero;
+    }
+  }
+
+  return w_ptr_deq;
+}
+
+} // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/impl/utils/QPackUtils.h
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/QPackUtils.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/backends/vulkan/runtime/graph/ComputeGraph.h>
+
+namespace vkcompute {
+
+std::vector<uint8_t> int4mm_pack_weights(
+    const std::vector<int64_t>& W_sizes,
+    const uint8_t* w_ptr);
+
+std::vector<float> int4mm_dequantize_weights(
+    const std::vector<int64_t>& W_sizes,
+    const uint8_t* w_ptr,
+    const uint32_t group_size,
+    const float* scales_and_zeros);
+
+} // namespace vkcompute

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -377,6 +377,20 @@ std::vector<float> create_random_float_buffer(
   return data;
 }
 
+std::vector<uint8_t> create_random_uint8_buffer(
+    const size_t numel,
+    const uint8_t min,
+    const uint8_t max) {
+  std::vector<uint8_t> data(numel);
+  std::default_random_engine rng;
+  std::uniform_real_distribution<float> dist(min, max);
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    data[i] = (uint8_t)dist(rng);
+  }
+  return data;
+}
+
 void fill_vtensor(
     ComputeGraph& graph,
     const IOValueRef idx,

--- a/backends/vulkan/test/utils/test_utils.h
+++ b/backends/vulkan/test/utils/test_utils.h
@@ -144,6 +144,11 @@ std::vector<float> create_random_float_buffer(
     const float min = 0,
     const float max = 1);
 
+std::vector<uint8_t> create_random_uint8_buffer(
+    const size_t numel,
+    const uint8_t min = 0,
+    const uint8_t max = 255);
+
 void fill_vtensor(
     ComputeGraph& graph,
     const IOValueRef idx,

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -21,6 +21,8 @@
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h>
 
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/QPackUtils.h>
+
 #include <executorch/backends/vulkan/test/utils/test_utils.h>
 
 using namespace vkcompute::api;
@@ -2658,4 +2660,120 @@ TEST(VulkanComputeGraphOpsTest, grid_priors_test) {
       /*stride = */ 8,
       /*offset = */ 0.5,
       /*data_out_expected = */ {4, 4, 12, 4, 20, 4, 4, 12, 12, 12, 20, 12});
+}
+
+void test_int4pack_mm(std::vector<uint32_t> MKN, uint32_t group_size) {
+  GraphConfig config;
+  ComputeGraph graph(config);
+
+  const uint32_t M = MKN[0];
+  const uint32_t K = MKN[1];
+  const uint32_t N = MKN[2];
+
+  const std::vector<int64_t> mat1_size = {M, K};
+  const std::vector<int64_t> mat2_size = {K, N};
+  const std::vector<int64_t> mat2_q_size = {N, K / 2}; // Transposed and packed
+  const std::vector<int64_t> out_size = {M, N};
+
+  std::vector<float> A_data = create_random_float_buffer(M * K);
+  IOValueRef A =
+      graph.add_input_tensor(mat1_size, vkapi::kFloat, utils::kBuffer);
+  graph.copy_into_staging(A.staging, A_data.data(), A_data.size());
+
+  // Quantized but un-packed weights
+  std::vector<uint8_t> B_quant_data = create_random_uint8_buffer(K * N, 0, 16);
+
+  // Pack and transpose weights to correspond to int4 weight format
+  std::vector<uint8_t> B_int4_data =
+      int4mm_pack_weights(mat2_size, B_quant_data.data());
+
+  IOValueRef B_int4 =
+      graph.add_input_tensor(mat2_q_size, vkapi::kQInt8, utils::kBuffer);
+  graph.copy_into_staging(
+      B_int4.staging, B_int4_data.data(), B_int4_data.size());
+
+  const int k_groups = K / group_size;
+
+  // Random scales and zeroes. Keep scales small to avoid overflow and zeroes in
+  // int4 range
+  IOValueRef scales_and_zeros =
+      graph.add_input_tensor({2, N, k_groups}, vkapi::kFloat, utils::kBuffer);
+  std::vector<float> s_data(graph.numel_of(scales_and_zeros.value));
+  const int zeros_stride = s_data.size() / 2;
+  for (size_t i = 0; i < zeros_stride; i++) {
+    s_data[i] = rand() % 100;
+    s_data[i + zeros_stride] = rand() % 16;
+  }
+
+  graph.copy_into_staging(
+      scales_and_zeros.staging, s_data.data(), s_data.size());
+
+  IOValueRef out_int4;
+  out_int4.value = graph.add_tensor(out_size, vkapi::kFloat, utils::kBuffer);
+
+  VK_GET_OP_FN("aten._weight_int4pack_mm.default")
+  (graph,
+   {A.value,
+    B_int4.value,
+    graph.add_scalar<int64_t>(group_size),
+    scales_and_zeros.value,
+    out_int4.value});
+
+  out_int4.staging = graph.set_output_tensor(out_int4.value);
+
+  // Dequantized matmul for comparison
+  IOValueRef B_deq =
+      graph.add_input_tensor(mat2_size, vkapi::kFloat, utils::kBuffer);
+  std::vector<float> B_deq_data = int4mm_dequantize_weights(
+      mat2_size, B_quant_data.data(), group_size, s_data.data());
+  graph.copy_into_staging(B_deq.staging, B_deq_data.data(), B_deq_data.size());
+
+  IOValueRef out_deq;
+  out_deq.value = graph.add_tensor(out_size, vkapi::kFloat, utils::kBuffer);
+
+  VK_GET_OP_FN("aten.mm.default")
+  (graph, {A.value, B_deq.value, out_deq.value});
+
+  out_deq.staging = graph.set_output_tensor(out_deq.value);
+
+  graph.prepare();
+  graph.encode_prepack();
+  graph.prepack();
+  graph.encode_execute();
+  graph.propagate_resize();
+  graph.execute();
+
+  // Compare outputs
+  std::vector<float> out_int4_data(graph.numel_of(out_int4.value));
+  graph.copy_from_staging(
+      out_int4.staging, out_int4_data.data(), out_int4_data.size());
+
+  std::vector<float> out_deq_data(graph.numel_of(out_deq.value));
+  graph.copy_from_staging(
+      out_deq.staging, out_deq_data.data(), out_deq_data.size());
+
+  for (int i = 0; i < out_int4_data.size(); i++) {
+    CHECK_VALUE(out_int4_data, i, out_deq_data[i]);
+  }
+}
+
+TEST(VulkanComputeGraphOpsTest, int4pack_mm_test) {
+  if (!context()->adapter_ptr()->has_full_int8_buffers_support()) {
+    GTEST_SKIP();
+  }
+
+  // Vector multiplication, single group per row
+  test_int4pack_mm({1, 32, 1}, 32);
+
+  // Vector multiplication, multiple groups per row
+  test_int4pack_mm({1, 256, 1}, 64);
+
+  // Square matrices, single group per row
+  test_int4pack_mm({32, 32, 32}, 32);
+
+  // Irregular matrices, single group per row
+  test_int4pack_mm({37, 32, 19}, 32);
+
+  // Irregular matrices, multiple groups per row
+  test_int4pack_mm({37, 256, 19}, 64);
 }


### PR DESCRIPTION
Summary:
Adds matrix multiplication for weight matrices quantized with Int4

Inputs are:

**Mat1:** Float | Buffer | Size of `(K, M)`
**Mat2:** QInt8 | Buffer | Size of `(K / 2, N)` | Already quantized, transposed and packed two int4s per int8
**groupSize**: Int | 32, 64, 128 or 256 | Divisor of K
**scalesAndZeros**: Float | Buffer | Size of `(K / group_size, N, 2)`
**Output:** Float | Buffer | Size of `(N, M)`

Differential Revision: D61669488
