### PR TITLE
[llava] Quantize embedding

### DIFF
--- a/.ci/scripts/test_llava.sh
+++ b/.ci/scripts/test_llava.sh
@@ -91,7 +91,7 @@ run_and_verify() {
     RESULT=$(cat result.txt)
     # set the expected prefix to be the same as prompt because there's a bug in sdpa_with_kv_cache that causes <unk> tokens.
     if [[ "$(uname)" == "Darwin" ]]; then
-        EXPECTED_PREFIX="ASSISTANT: image captures a basketball game in progress on a basketball court. There are several players on the court, with one player in the foreground holding a basketball, and"
+        EXPECTED_PREFIX="ASSISTANT: image captures a basketball game in progress, with several players on the court. One of the players is dribbling the ball, while the others are in various"
     else
         # set the expected prefix to be the same as prompt because there's a bug in sdpa_with_kv_cache that causes <unk> tokens.
         EXPECTED_PREFIX="ASSISTANT:"

--- a/examples/models/llama2/source_transformation/quantize.py
+++ b/examples/models/llama2/source_transformation/quantize.py
@@ -399,6 +399,7 @@ def replace_embedding_weight_only_grouped_int8_per_channel(
                     vocab_size=child.weight.shape[0],
                     embedding_dim=child.weight.shape[1],
                     group_size=group_size,
+                    dtype=child.weight.dtype,
                     packed=packed,
                 ),
             )

--- a/examples/models/llava/export_llava.py
+++ b/examples/models/llava/export_llava.py
@@ -17,6 +17,7 @@ from executorch.examples.models.llama2.export_llama_lib import (
     get_quantizer_and_quant_params,
 )
 from executorch.examples.models.llama2.source_transformation.quantize import (
+    EmbeddingQuantHandler,
     get_quant_weight_transform,
 )
 from executorch.examples.models.llama2.source_transformation.sdpa import (
@@ -156,12 +157,20 @@ def export_image_encoder(llava, resized, dynamic_shapes):
 
 
 def export_token_embedding(llava, prompt):
-    embed = llava.embed_tokens
-    token_dim_1 = Dim("token_dim_1", min=2, max=3518)
+    def quant_embedding(model):
+        return EmbeddingQuantHandler(
+            model,
+            bitwidth=8,
+            group_size=32,
+            packed=False,
+        ).quantized_model()
+
+    quantized_token_embed = quant_embedding(llava.model_.language_model.model)
+    token_dim_1 = Dim("token_dim_1", min=2, max=llava.text_model_args.max_seq_len)
     dynamic_shapes = [{1: token_dim_1}]
     with torch.no_grad():
         token_embedding_ep = torch.export.export(
-            embed, (prompt,), dynamic_shapes=dynamic_shapes
+            quantized_token_embed.embed_tokens, (prompt,), dynamic_shapes=dynamic_shapes
         )
     return token_embedding_ep
 

--- a/examples/models/llava/test/test_llava.py
+++ b/examples/models/llava/test/test_llava.py
@@ -15,12 +15,11 @@ from executorch.examples.models.llava.model import LlavaModel
 # import order matters. We need to import portable_lib first since it contains the static op registry
 # which will be used in the import of custom ops. Otherwise, the registration of custom ops will be skipped.
 # I don't know how to mute UFMT so I'm just using if True: to avoid the error
-if True:
-    from executorch.extension.pybindings.portable_lib import (
-        _load_for_executorch_from_buffer,
-    )
-from executorch.extension.llm.custom_ops import sdpa_with_kv_cache  # noqa: F401
-
+from executorch.extension.pybindings.portable_lib import (
+    _load_for_executorch_from_buffer,
+)
+from executorch.extension.llm.custom_ops import sdpa_with_kv_cache  # noqa # usort: skip
+from executorch.kernels import quantized  # noqa # usort: skip
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/examples/models/llava/test/test_pte.py
+++ b/examples/models/llava/test/test_pte.py
@@ -14,10 +14,8 @@ from executorch.extension.pybindings.portable_lib import _load_for_executorch
 from PIL import Image
 
 # Custom ops has to be loaded after portable_lib.
-# I don't know how to stop UFMT so I'm just using if True: to avoid lint error
-if True:
-    from executorch.extension.llm.custom_ops import sdpa_with_kv_cache  # noqa
-    from executorch.kernels import quantized  # noqa
+from executorch.extension.llm.custom_ops import sdpa_with_kv_cache  # noqa # usort: skip
+from executorch.kernels import quantized  # noqa # usort: skip
 
 FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
 logging.basicConfig(level=logging.DEBUG, format=FORMAT)

--- a/examples/models/llava/test/test_pte.py
+++ b/examples/models/llava/test/test_pte.py
@@ -17,7 +17,7 @@ from PIL import Image
 # I don't know how to stop UFMT so I'm just using if True: to avoid lint error
 if True:
     from executorch.extension.llm.custom_ops import sdpa_with_kv_cache  # noqa
-
+    from executorch.kernels import quantized  # noqa
 
 FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
 logging.basicConfig(level=logging.DEBUG, format=FORMAT)
@@ -54,7 +54,7 @@ def main():
     )[0]
     print(pte_prefill_before_img)
 
-    start_pos += pte_prefill_before_img.shape[1]
+    start_pos += prompt_before_image.shape[1]
 
     # pte prefill image
     logging.warning("Image encoder started")
@@ -71,7 +71,7 @@ def main():
     logging.warning("Image token prefill finished")
     print(pte_prefill_img)
 
-    start_pos += pte_prefill_img.shape[1]
+    start_pos += pte_embeds_img.shape[1]
 
     # pte prefill prompt after img
     logging.warning("Text token prefill started")


### PR DESCRIPTION
Using int8 quantization with group size 32 for best accuracy. This brings down the .pte size from 4.1GB to 3.7GB.

To test:

```
python examples/models/llava/export_llava.py --pte-name llava_768_quant_emb.pte
python examples/models/llava/test/test_pte.py llava_768_quant_emb.pte

/Users/larryliu/miniconda3/envs/executorch/lib/python3.11/site-packages/tensorflow/python/keras/engine/training_arrays_v1.py:37: UserWarning: A NumPy version >=1.23.5 and <2.3.0 is required for this version of SciPy (detected version 1.23.2)
  from scipy.sparse import issparse  # pylint: disable=g-import-not-at-top
[INFO 2024-08-28 14:23:46,428 utils.py:148] Note: NumExpr detected 10 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
[INFO 2024-08-28 14:23:46,429 utils.py:161] NumExpr defaulting to 8 threads.
/Users/larryliu/miniconda3/envs/executorch/lib/python3.11/site-packages/bitsandbytes/cextension.py:34: UserWarning: The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers, 8-bit multiplication, and GPU quantization are unavailable.
  warn("The installed version of bitsandbytes was compiled without GPU support. "
'NoneType' object has no attribute 'cadam32bit_grad_fp32'
[INFO 2024-08-28 14:23:51,415 sdpa_with_kv_cache.py:26] Loading custom ops library: /Users/larryliu/miniconda3/envs/executorch/lib/python3.11/site-packages/executorch/extension/llm/custom_ops/libcustom_ops_aot_lib.dylib
[program.cpp:134] InternalConsistency verification requested but not available
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
/Users/larryliu/miniconda3/envs/executorch/lib/python3.11/site-packages/transformers/models/llava/configuration_llava.py:100: FutureWarning: The `vocab_size` argument is deprecated and will be removed in v4.42, since it can be inferred from the `text_config`. Passing this argument has no effect
  warnings.warn(
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████| 3/3 [00:17<00:00,  5.73s/it]
tensor([[-4.9629, -2.5187,  4.3486,  ..., -0.1673, -0.1425, -0.1129]])
[WARNING 2024-08-28 14:24:21,843 test_pte.py:60] Image encoder started
[WARNING 2024-08-28 14:24:23,034 test_pte.py:62] Image encoder finished
[WARNING 2024-08-28 14:24:23,034 test_pte.py:63] Image token prefill started
> /Users/larryliu/CLionProjects/executorch/examples/models/llava/test/test_pte.py(65)main()
-> pte_prefill_img = llava_module.run_method(
(Pdb) c
[WARNING 2024-08-28 14:24:40,596 test_pte.py:72] Image token prefill finished
tensor([[-2.4272e-05,  6.4470e-05,  1.4342e-06,  ...,  7.3784e-06,
          4.2599e-06, -1.4221e-06]])
[WARNING 2024-08-28 14:24:40,597 test_pte.py:78] Text token prefill started
[WARNING 2024-08-28 14:24:41,326 test_pte.py:86] Text token prefill finished
tensor([[-6.1245, -4.7936,  8.6515,  ...,  0.3368,  0.2976,  0.3470]])
0 The
1 water
2 is
3 green
The water is green.
```