### PR TITLE
Let Module set_output_data_ptr accept an EValue.

### DIFF
--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -197,8 +197,9 @@ Result<std::vector<EValue>> Module::execute(
   return outputs;
 }
 
-Error Module::set_output_data_ptr(Tensor& output_tensor, size_t output_index) {
+Error Module::set_output_data_ptr(EValue output_value, size_t output_index) {
   ET_CHECK_OK_OR_RETURN_ERROR(load_method("forward"));
+  auto& output_tensor = output_value.toTensor();
   auto& method = methods_.at("forward").method;
   return method->set_output_data_ptr(
       output_tensor.mutable_data_ptr(), output_tensor.nbytes(), output_index);

--- a/extension/module/module.h
+++ b/extension/module/module.h
@@ -330,13 +330,13 @@ class Module final {
   /**
    * Set output data pointer for forward method.
    *
-   * @param[in] output_tensor A Tensor for the output of 'forward' method.
+   * @param[in] output_value A Tensor for the output of 'forward' method.
    * @param[in] output_index Index of the output in 'forward' method.
    *
    * @returns An Error to indicate success or failure of the loading process.
    */
   ::executorch::runtime::Error set_output_data_ptr(
-      exec_aten::Tensor& output_tensor,
+      ::executorch::runtime::EValue output_value,
       size_t output_index);
 
  private:


### PR DESCRIPTION
Summary: This should facilitate callsites to allow passing a tensor-like objects that can implicitly convert to EValue.

Differential Revision: D61957435
