### PR TITLE
Update default segment alignment to 128

### DIFF
--- a/exir/_serialize/_program.py
+++ b/exir/_serialize/_program.py
@@ -348,7 +348,7 @@ def serialize_pte_binary(
     mutable_data: Optional[List[Buffer]] = None,
     extract_delegate_segments: bool = False,
     extract_constant_segment: bool = False,
-    segment_alignment: int = 4096,
+    segment_alignment: int = 128,
     constant_tensor_alignment: Optional[int] = None,
     delegate_alignment: Optional[int] = None,
 ) -> Cord:

--- a/exir/_serialize/test/test_program.py
+++ b/exir/_serialize/test/test_program.py
@@ -5,6 +5,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import copy
 import difflib
 import json
@@ -36,7 +38,7 @@ from executorch.exir.schema import (
 )
 from executorch.exir.tests.common import get_test_program
 
-SEGMENT_ALIGNMENT: int = 4096
+SEGMENT_ALIGNMENT: int = 128
 
 CONSTANT_TENSOR_ALIGNMENT: int = 16
 

--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -73,7 +73,7 @@ class ExecutorchBackendConfig:
 
     # When extracting segments, the starting offset of each segment will be
     # aligned to this value (in bytes). Must be a power of two.
-    segment_alignment: int = 4096
+    segment_alignment: int = 128
 
     # If provided, the minimum alignment of tensor buffers in the program. Must
     # be a power of 2. If not provided, uses the value in the schema file.

--- a/exir/lowered_backend_module.py
+++ b/exir/lowered_backend_module.py
@@ -137,7 +137,7 @@ class LoweredBackendModule(torch.nn.Module):
     def buffer(
         self,
         extract_delegate_segments: bool = False,
-        segment_alignment: int = 4096,
+        segment_alignment: int = 128,
         constant_tensor_alignment: Optional[int] = None,
         delegate_alignment: Optional[int] = None,
         memory_planning: MemoryPlanningPass = None,  # pyre-fixme[9]


### PR DESCRIPTION
Summary:
Previous segment alignment=4096.

This means models with small constant data will have .pte files filled mostly with padding.

Update segment alignment=128 to ensure small models retain small binary size.

Differential Revision: D61104820
