### PR TITLE
Fix export vit w/ QNN delegate

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -170,6 +170,9 @@ test_model_with_qnn() {
   elif [[ "${MODEL_NAME}" == "ic3" ]]; then
     EXPORT_SCRIPT=inception_v3
     EXPORTED_MODEL_NAME=ic3_qnn.pte
+  elif [[ "${MODEL_NAME}" == "vit" ]]; then
+    EXPORT_SCRIPT=torchvision_vit
+    EXPORTED_MODEL_NAME=vit_qnn.pte
   fi
 
   "${PYTHON_EXECUTABLE}" -m examples.qualcomm.scripts.${EXPORT_SCRIPT} -b ${CMAKE_OUTPUT_DIR} -m SM8550 --compile_only

--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -84,7 +84,7 @@ jobs:
           # Separate default values from the workflow dispatch. To ensure defaults are accessible
           # during scheduled runs and to provide flexibility for different defaults between
           # on-demand and periodic benchmarking.
-          CRON_DEFAULT_MODELS: "stories110M,dl3,mv3,mv2,ic4,ic3"
+          CRON_DEFAULT_MODELS: "stories110M,dl3,mv3,mv2,ic4,ic3,vit"
           CRON_DEFAULT_DEVICES: "samsung_galaxy_s2x"
           CRON_DEFAULT_DELEGATES: "xnnpack,qnn"
         run: |

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -305,7 +305,7 @@ jobs:
     strategy:
       matrix:
         dtype: [fp32]
-        model: [dl3, mv3, mv2, ic4, ic3]
+        model: [dl3, mv3, mv2, ic4, ic3, vit]
       fail-fast: false
     with:
       runner: linux.2xlarge

--- a/backends/qualcomm/partition/common_defs.py
+++ b/backends/qualcomm/partition/common_defs.py
@@ -17,7 +17,11 @@ not_supported_operator = [
 ]
 
 to_be_implemented_operator = [
-    exir_ops.edge.aten.where.default,
+    exir_ops.edge.aten.any.dim,
+    exir_ops.edge.aten.eq.Scalar,
+    exir_ops.edge.aten.full_like.default,
+    exir_ops.edge.aten.logical_not.default,
+    exir_ops.edge.aten.where.self,
 ]
 
 allow_list_operator = [

--- a/examples/qualcomm/scripts/torchvision_vit.py
+++ b/examples/qualcomm/scripts/torchvision_vit.py
@@ -6,6 +6,7 @@
 
 import json
 import os
+import sys
 from multiprocessing.connection import Client
 
 import numpy as np
@@ -61,10 +62,14 @@ def main(args):
     os.makedirs(args.artifact, exist_ok=True)
 
     data_num = 100
-    inputs, targets, input_list = get_dataset(
-        dataset_path=f"{args.dataset}",
-        data_size=data_num,
-    )
+    if args.compile_only:
+        inputs = [(torch.rand(1, 3, 224, 224),)]
+    else:
+        inputs, targets, input_list = get_dataset(
+            dataset_path=f"{args.dataset}",
+            data_size=data_num,
+        )
+
     pte_filename = "vit_qnn"
     instance = TorchVisionViTModel()
     build_executorch_binary(
@@ -76,6 +81,9 @@ def main(args):
         quant_dtype=QuantDtype.use_8a8w,
         shared_buffer=args.shared_buffer,
     )
+
+    if args.compile_only:
+        sys.exit(0)
 
     adb = SimpleADB(
         qnn_sdk=os.getenv("QNN_SDK_ROOT"),
@@ -126,13 +134,14 @@ if __name__ == "__main__":
             "for https://www.kaggle.com/datasets/ifigotin/imagenetmini-1000)"
         ),
         type=str,
-        required=True,
+        required=False,
     )
     parser.add_argument(
         "-a",
         "--artifact",
-        help="path for storing generated artifacts by this example. " "Default ./vit",
-        default="./vit",
+        help="path for storing generated artifacts by this example. "
+        "Default ./torchvision_vit",
+        default="./torchvision_vit",
         type=str,
     )
 


### PR DESCRIPTION
 - Squeezed several minor bug fixes for torchvision_vit w/ QNN delegates.
 - Made torchvision_vit support `compile_only` w/o downloading dataset.
 - Added torchvision_vit to CIs.

`python -m examples.qualcomm.scripts.torchvision_vit -b cmake-out-android -m SM8550 --compile_only`
```
torchvision_vit/
└── vit_qnn.pte
```