### PR TITLE
[codegen] Change cmake file to take CMAKE_CURRENT_SOURCE_DIR and add logging

### DIFF
--- a/codegen/tools/gen_oplist.py
+++ b/codegen/tools/gen_oplist.py
@@ -300,14 +300,33 @@ def main(args: List[Any]) -> None:
     )
     options = parser.parse_args(args)
 
-    gen_oplist(
-        output_path=options.output_path,
-        model_file_path=options.model_file_path,
-        ops_schema_yaml_path=options.ops_schema_yaml_path,
-        root_ops=options.root_ops,
-        ops_dict=options.ops_dict,
-        include_all_operators=options.include_all_operators,
-    )
+    try:
+        gen_oplist(
+            output_path=options.output_path,
+            model_file_path=options.model_file_path,
+            ops_schema_yaml_path=options.ops_schema_yaml_path,
+            root_ops=options.root_ops,
+            ops_dict=options.ops_dict,
+            include_all_operators=options.include_all_operators,
+        )
+    except Exception as e:
+        command = ["python codegen/tools/gen_oplist.py"]
+        if options.model_file_path:
+            command.append(f"--model_file_path {options.model_file_path}")
+        if options.ops_schema_yaml_path:
+            command.append(f"--ops_schema_yaml_path {options.ops_schema_yaml_path}")
+        if options.root_ops:
+            command.append(f"--root_ops {options.root_ops}")
+        if options.ops_dict:
+            command.append(f"--ops_dict {options.ops_dict}")
+        if options.include_all_operators:
+            command.append("--include-all-operators")
+        repro_command = " ".join(command)
+        raise RuntimeError(
+            f"""Failed to generate selected_operators.yaml. Repro command:
+            {repro_command}
+            """
+        ) from e
 
 
 if __name__ == "__main__":

--- a/codegen/tools/gen_oplist.py
+++ b/codegen/tools/gen_oplist.py
@@ -230,7 +230,7 @@ def gen_oplist(
     if model_file_path:
         assert os.path.isfile(
             model_file_path
-        ), "The value for --model_file_path needs to be a valid file."
+        ), f"The value for --model_file_path needs to be a valid file, got {model_file_path}"
         op_set.update(_get_operators(model_file_path))
         source_name = model_file_path
         et_kernel_metadata = merge_et_kernel_metadata(
@@ -239,7 +239,7 @@ def gen_oplist(
     if ops_schema_yaml_path:
         assert os.path.isfile(
             ops_schema_yaml_path
-        ), "The value for --ops_schema_yaml_path needs to be a valid file."
+        ), f"The value for --ops_schema_yaml_path needs to be a valid file, got {ops_schema_yaml_path}"
         et_kernel_metadata = merge_et_kernel_metadata(
             et_kernel_metadata,
             _get_et_kernel_metadata_from_ops_yaml(ops_schema_yaml_path),

--- a/codegen/tools/test/test_gen_oplist.py
+++ b/codegen/tools/test/test_gen_oplist.py
@@ -42,7 +42,7 @@ class TestGenOpList(unittest.TestCase):
         mock_get_operators: NonCallableMock,
     ) -> None:
         args = ["--output_path=wrong_path", "--model_file_path=path2"]
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(RuntimeError):
             gen_oplist.main(args)
 
     @patch("executorch.codegen.tools.gen_oplist._get_kernel_metadata_for_model")

--- a/kernels/portable/CMakeLists.txt
+++ b/kernels/portable/CMakeLists.txt
@@ -38,12 +38,11 @@ list(FILTER _portable_kernels__srcs EXCLUDE REGEX "test/*.cpp")
 list(FILTER _portable_kernels__srcs EXCLUDE REGEX "codegen")
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and
 # Executorch (for runtime). Here select all ops in functions.yaml
-set(_yaml "${CMAKE_CURRENT_LIST_DIR}/functions.yaml")
+set(_yaml "${CMAKE_CURRENT_SOURCE_DIR}/functions.yaml")
 gen_selected_ops(LIB_NAME "portable_ops_lib" OPS_SCHEMA_YAML "${_yaml}")
 # Expect gen_selected_ops output file to be selected_operators.yaml
 generate_bindings_for_kernels(
-  LIB_NAME "portable_ops_lib" FUNCTIONS_YAML
-  ${CMAKE_CURRENT_SOURCE_DIR}/functions.yaml
+  LIB_NAME "portable_ops_lib" FUNCTIONS_YAML "${_yaml}"
 )
 message("Generated files ${gen_command_sources}")
 


### PR DESCRIPTION
Summary: in this issue
[#4629](https://github.com/pytorch/executorch/issues/4629) installation failed because the yaml file is invalid. I suspect this is because the difference between `CMAKE_CURRENT_LIST_DIR` to `CMAKE_CURRENT_SOURCE_DIR`, that `CMAKE_CURRENT_LIST_DIR` does work in some build environment. Also adding logs to print out the actual file path.

Test Plan:

```
$ python codegen/tools/gen_oplist.py --ops_schema_yaml_path /non_exist.yaml --output_path ./
Traceback (most recent call last):
  File "/home/larryliu/executorch/codegen/tools/gen_oplist.py", line 304, in main
    gen_oplist(
  File "/home/larryliu/executorch/codegen/tools/gen_oplist.py", line 240, in gen_oplist
    assert os.path.isfile(
           ^^^^^^^^^^^^^^^
AssertionError: The value for --ops_schema_yaml_path needs to be a valid file, got /non_exist.yaml

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/larryliu/executorch/codegen/tools/gen_oplist.py", line 333, in <module>
    main(sys.argv[1:])
  File "/home/larryliu/executorch/codegen/tools/gen_oplist.py", line 325, in main
    raise RuntimeError(
RuntimeError: Failed to generate selected_operators.yaml. Repro command:
            python codegen/tools/gen_oplist.py --ops_schema_yaml_path /non_exist.yaml
```

Reviewers:

Subscribers:

Tasks:

Tags: