### PR TITLE
Add Echo parameter to llama runner, jni+java layer, and demo app

### DIFF
--- a/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/MainActivity.java
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/MainActivity.java
@@ -73,8 +73,15 @@ public class MainActivity extends AppCompatActivity implements Runnable, LlamaCa
 
   @Override
   public void onResult(String result) {
-    mResultMessage.appendText(result);
-    run();
+    if(result.equals("\n\n")) {
+      if(!mResultMessage.getText().isEmpty()) {
+        mResultMessage.appendText(result);
+        run();
+      }
+    } else {
+      mResultMessage.appendText(result);
+      run();
+    }
   }
 
   @Override

--- a/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/MainActivity.java
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/MainActivity.java
@@ -614,6 +614,7 @@ public class MainActivity extends AppCompatActivity implements Runnable, LlamaCa
                           ModelUtils.VISION_MODEL_IMAGE_CHANNELS,
                           prompt,
                           ModelUtils.VISION_MODEL_SEQ_LEN,
+                          false,
                           MainActivity.this);
                     } else {
                       // no image selected, we pass in empty int array
@@ -624,10 +625,12 @@ public class MainActivity extends AppCompatActivity implements Runnable, LlamaCa
                           ModelUtils.VISION_MODEL_IMAGE_CHANNELS,
                           prompt,
                           ModelUtils.VISION_MODEL_SEQ_LEN,
+                          false,
                           MainActivity.this);
                     }
                   } else {
-                    mModule.generate(prompt, ModelUtils.TEXT_MODEL_SEQ_LEN, MainActivity.this);
+                    mModule.generate(
+                        prompt, ModelUtils.TEXT_MODEL_SEQ_LEN, false, MainActivity.this);
                   }
 
                   long generateDuration = System.currentTimeMillis() - generateStartTime;

--- a/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/MainActivity.java
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/MainActivity.java
@@ -73,8 +73,8 @@ public class MainActivity extends AppCompatActivity implements Runnable, LlamaCa
 
   @Override
   public void onResult(String result) {
-    if(result.equals("\n\n")) {
-      if(!mResultMessage.getText().isEmpty()) {
+    if (result.equals("\n\n")) {
+      if (!mResultMessage.getText().isEmpty()) {
         mResultMessage.appendText(result);
         run();
       }

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -319,7 +319,6 @@ def build_args_parser() -> argparse.ArgumentParser:
 
 
 def canonical_path(path: Union[str, Path], *, dir: bool = False) -> str:
-
     path = str(path)
 
     if verbose_export():

--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -142,6 +142,7 @@ Error Runner::load() {
 Error Runner::generate(
     const std::string& prompt,
     int32_t seq_len,
+    bool echo,
     std::function<void(const std::string&)> token_callback,
     std::function<void(const Stats&)> stats_callback) {
   // Prepare the inputs.
@@ -212,7 +213,9 @@ Error Runner::generate(
   uint64_t cur_token = prefill_res.get();
 
   // print the first token from prefill. No prev_token so use cur_token for it.
-  wrapped_callback(ET_UNWRAP(tokenizer_->decode(cur_token, cur_token)));
+  if (echo) {
+    wrapped_callback(ET_UNWRAP(tokenizer_->decode(cur_token, cur_token)));
+  }
 
   // start the main loop
   prompt_tokens.push_back(cur_token);

--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -213,9 +213,7 @@ Error Runner::generate(
   uint64_t cur_token = prefill_res.get();
 
   // print the first token from prefill. No prev_token so use cur_token for it.
-  if (echo) {
-    wrapped_callback(ET_UNWRAP(tokenizer_->decode(cur_token, cur_token)));
-  }
+  wrapped_callback(ET_UNWRAP(tokenizer_->decode(cur_token, cur_token)));
 
   // start the main loop
   prompt_tokens.push_back(cur_token);

--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -142,9 +142,9 @@ Error Runner::load() {
 Error Runner::generate(
     const std::string& prompt,
     int32_t seq_len,
-    bool echo,
     std::function<void(const std::string&)> token_callback,
-    std::function<void(const Stats&)> stats_callback) {
+    std::function<void(const Stats&)> stats_callback,
+    bool echo) {
   // Prepare the inputs.
   // Use ones-initialized inputs.
   ET_CHECK_MSG(!prompt.empty(), "Prompt cannot be null");

--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -204,7 +204,9 @@ Error Runner::generate(
   // after the prompt. After that we will enter generate loop.
 
   // print prompts
-  wrapped_callback(prompt);
+  if (echo) {
+    wrapped_callback(prompt);
+  }
   int64_t pos = 0;
   auto prefill_res = text_prefiller_->prefill(prompt_tokens, pos);
   stats_.first_token_ms = util::time_in_ms();

--- a/examples/models/llama2/runner/runner.h
+++ b/examples/models/llama2/runner/runner.h
@@ -39,9 +39,9 @@ class Runner {
   Error generate(
       const std::string& prompt,
       int32_t seq_len = 128,
-      bool echo = true,
       std::function<void(const std::string&)> token_callback = {},
-      std::function<void(const Stats&)> stats_callback = {});
+      std::function<void(const Stats&)> stats_callback = {},
+      bool echo = true);
   void stop();
 
  private:

--- a/examples/models/llama2/runner/runner.h
+++ b/examples/models/llama2/runner/runner.h
@@ -39,6 +39,7 @@ class Runner {
   Error generate(
       const std::string& prompt,
       int32_t seq_len = 128,
+      bool echo = true,
       std::function<void(const std::string&)> token_callback = {},
       std::function<void(const Stats&)> stats_callback = {});
   void stop();

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -175,9 +175,9 @@ class ExecuTorchLlamaJni
       runner_->generate(
           prompt->toStdString(),
           seq_len,
-          echo,
           [callback](std::string result) { callback->onResult(result); },
-          [callback](const Stats& result) { callback->onStats(result); });
+          [callback](const Stats& result) { callback->onStats(result); },
+          echo);
     }
     return 0;
   }

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -150,6 +150,7 @@ class ExecuTorchLlamaJni
       jint channels,
       facebook::jni::alias_ref<jstring> prompt,
       jint seq_len,
+      jboolean echo,
       facebook::jni::alias_ref<ExecuTorchLlamaCallbackJni> callback) {
     if (model_type_category_ == MODEL_TYPE_CATEGORY_MULTIMODAL) {
       auto image_size = image->size();
@@ -174,6 +175,7 @@ class ExecuTorchLlamaJni
       runner_->generate(
           prompt->toStdString(),
           seq_len,
+          echo,
           [callback](std::string result) { callback->onResult(result); },
           [callback](const Stats& result) { callback->onStats(result); });
     }

--- a/extension/android/src/main/java/org/pytorch/executorch/LlamaModule.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/LlamaModule.java
@@ -33,6 +33,7 @@ public class LlamaModule {
 
   private final HybridData mHybridData;
   private static final int DEFAULT_SEQ_LEN = 128;
+  private static final boolean DEFAULT_ECHO = true;
 
   @DoNotStrip
   private static native HybridData initHybrid(
@@ -59,7 +60,7 @@ public class LlamaModule {
    * @param llamaCallback callback object to receive results.
    */
   public int generate(String prompt, LlamaCallback llamaCallback) {
-    return generate(prompt, DEFAULT_SEQ_LEN, llamaCallback);
+    return generate(prompt, DEFAULT_SEQ_LEN, DEFAULT_ECHO, llamaCallback);
   }
 
   /**
@@ -70,7 +71,30 @@ public class LlamaModule {
    * @param llamaCallback callback object to receive results.
    */
   public int generate(String prompt, int seqLen, LlamaCallback llamaCallback) {
-    return generate(null, 0, 0, 0, prompt, seqLen, llamaCallback);
+    return generate(null, 0, 0, 0, prompt, seqLen, DEFAULT_ECHO, llamaCallback);
+  }
+
+  /**
+   * Start generating tokens from the module.
+   *
+   * @param prompt Input prompt
+   * @param echo indicate whether to echo the input prompt or not (text completion vs chat)
+   * @param llamaCallback callback object to receive results.
+   */
+  public int generate(String prompt, boolean echo, LlamaCallback llamaCallback) {
+    return generate(null, 0, 0, 0, prompt, DEFAULT_SEQ_LEN, echo, llamaCallback);
+  }
+
+  /**
+   * Start generating tokens from the module.
+   *
+   * @param prompt Input prompt
+   * @param seqLen sequence length
+   * @param echo indicate whether to echo the input prompt or not (text completion vs chat)
+   * @param llamaCallback callback object to receive results.
+   */
+  public int generate(String prompt, int seqLen, boolean echo, LlamaCallback llamaCallback) {
+    return generate(null, 0, 0, 0, prompt, seqLen, echo, llamaCallback);
   }
 
   /**
@@ -82,6 +106,7 @@ public class LlamaModule {
    * @param channels Input image number of channels
    * @param prompt Input prompt
    * @param seqLen sequence length
+   * @param echo indicate whether to echo the input prompt or not (text completion vs chat)
    * @param llamaCallback callback object to receive results.
    */
   @DoNotStrip
@@ -92,6 +117,7 @@ public class LlamaModule {
       int channels,
       String prompt,
       int seqLen,
+      boolean echo,
       LlamaCallback llamaCallback);
 
   /** Stop current generate() before it finishes. */


### PR DESCRIPTION
To allow the developer to set whether the response should echo (i.e. include) the input prompt.
 - echo = true then token_callback for output will also include input (i.e. Text Completion).
 - echo = false then token_callback for output will not include input (i.e. Chat generation).

We'll default to true since that will maintain the existing flow.