### PR TITLE
[ET-VK] Rename `StorageBuffer` to `StagingBuffer`

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -189,7 +189,7 @@ Context* context() {
       const vkapi::DescriptorPoolConfig descriptor_pool_config{
           VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorPoolMaxSets
           VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorUniformBufferCount
-          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorStagingBufferCount
+          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorStorageBufferCount
           VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorCombinedSamplerCount
           VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorStorageImageCount
           32u, // descriptorPileSizes

--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -189,7 +189,7 @@ Context* context() {
       const vkapi::DescriptorPoolConfig descriptor_pool_config{
           VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorPoolMaxSets
           VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorUniformBufferCount
-          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorStorageBufferCount
+          VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorStagingBufferCount
           VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorCombinedSamplerCount
           VULKAN_DESCRIPTOR_POOL_SIZE, // descriptorStorageImageCount
           32u, // descriptorPileSizes

--- a/backends/vulkan/runtime/api/api.h
+++ b/backends/vulkan/runtime/api/api.h
@@ -12,7 +12,7 @@
 #include <executorch/backends/vulkan/runtime/api/ShaderRegistry.h>
 
 #include <executorch/backends/vulkan/runtime/api/containers/ParamsBuffer.h>
-#include <executorch/backends/vulkan/runtime/api/containers/StorageBuffer.h>
+#include <executorch/backends/vulkan/runtime/api/containers/StagingBuffer.h>
 #include <executorch/backends/vulkan/runtime/api/containers/Tensor.h>
 
 #include <executorch/backends/vulkan/runtime/utils/VecUtils.h>

--- a/backends/vulkan/runtime/api/containers/StagingBuffer.h
+++ b/backends/vulkan/runtime/api/containers/StagingBuffer.h
@@ -17,7 +17,7 @@
 namespace vkcompute {
 namespace api {
 
-class StorageBuffer final {
+class StagingBuffer final {
  private:
   Context* context_p_;
   vkapi::ScalarType dtype_;
@@ -26,7 +26,7 @@ class StorageBuffer final {
   vkapi::VulkanBuffer vulkan_buffer_;
 
  public:
-  StorageBuffer(
+  StagingBuffer(
       Context* context_p,
       const vkapi::ScalarType dtype,
       const size_t numel,
@@ -39,13 +39,13 @@ class StorageBuffer final {
             nbytes_,
             gpuonly)) {}
 
-  StorageBuffer(const StorageBuffer&) = delete;
-  StorageBuffer& operator=(const StorageBuffer&) = delete;
+  StagingBuffer(const StagingBuffer&) = delete;
+  StagingBuffer& operator=(const StagingBuffer&) = delete;
 
-  StorageBuffer(StorageBuffer&&) = default;
-  StorageBuffer& operator=(StorageBuffer&&) = default;
+  StagingBuffer(StagingBuffer&&) = default;
+  StagingBuffer& operator=(StagingBuffer&&) = default;
 
-  ~StorageBuffer() {
+  ~StagingBuffer() {
     context_p_->register_buffer_cleanup(vulkan_buffer_);
   }
 

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -38,7 +38,7 @@ namespace vkcompute {
 
 VALUE_PTR_CLASS_IMPL(vTensorPtr, api::vTensor, Tensor)
 VALUE_PTR_CLASS_IMPL(TensorRefPtr, TensorRef, TensorRef)
-VALUE_PTR_CLASS_IMPL(StagingPtr, api::StorageBuffer, Staging)
+VALUE_PTR_CLASS_IMPL(StagingPtr, api::StagingBuffer, Staging)
 VALUE_PTR_CLASS_IMPL(IntListPtr, std::vector<int64_t>, IntList)
 VALUE_PTR_CLASS_IMPL(DoubleListPtr, std::vector<double>, DoubleList)
 VALUE_PTR_CLASS_IMPL(BoolListPtr, std::vector<bool>, BoolList)
@@ -236,7 +236,7 @@ ValueRef ComputeGraph::add_staging(
     const size_t numel) {
   ValueRef idx(static_cast<int>(values_.size()));
   check_no_active_value_ptrs();
-  values_.emplace_back(api::StorageBuffer(context(), dtype, numel));
+  values_.emplace_back(api::StagingBuffer(context(), dtype, numel));
   return idx;
 }
 

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -58,7 +58,7 @@ class ComputeGraph;
 
 DECL_VALUE_PTR_CLASS(vTensorPtr, api::vTensor)
 DECL_VALUE_PTR_CLASS(TensorRefPtr, TensorRef)
-DECL_VALUE_PTR_CLASS(StagingPtr, api::StorageBuffer)
+DECL_VALUE_PTR_CLASS(StagingPtr, api::StagingBuffer)
 DECL_VALUE_PTR_CLASS(IntListPtr, std::vector<int64_t>)
 DECL_VALUE_PTR_CLASS(DoubleListPtr, std::vector<double>)
 DECL_VALUE_PTR_CLASS(BoolListPtr, std::vector<bool>)

--- a/backends/vulkan/runtime/graph/containers/Value.h
+++ b/backends/vulkan/runtime/graph/containers/Value.h
@@ -53,7 +53,7 @@ struct Value final {
     } u;
 
     api::vTensor as_tensor;
-    api::StorageBuffer as_staging;
+    api::StagingBuffer as_staging;
     TensorRef as_tensorref;
 
     std::vector<int64_t> as_int_list;
@@ -108,7 +108,7 @@ struct Value final {
       CASE_MOVE_MOVEABLE_TYPE(
           TypeTag::TENSOR, api::vTensor, as_tensor, vTensor);
       CASE_MOVE_MOVEABLE_TYPE(
-          TypeTag::STAGING, api::StorageBuffer, as_staging, StorageBuffer);
+          TypeTag::STAGING, api::StagingBuffer, as_staging, StagingBuffer);
       CASE_MOVE_MOVEABLE_TYPE(
           TypeTag::TENSORREF, TensorRef, as_tensorref, TensorRef);
       // Scalar lists
@@ -152,7 +152,7 @@ struct Value final {
         payload.as_tensor.~vTensor();
         break;
       case TypeTag::STAGING:
-        payload.as_staging.~StorageBuffer();
+        payload.as_staging.~StagingBuffer();
         break;
       case TypeTag::TENSORREF:
         payload.as_tensorref.~TensorRef();
@@ -247,7 +247,7 @@ struct Value final {
       as_tensor);
 
   SUPPORT_TRIVIALLY_MOVEABLE_TYPE(
-      api::StorageBuffer,
+      api::StagingBuffer,
       Staging,
       TypeTag::STAGING,
       as_staging);

--- a/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
@@ -45,14 +45,14 @@ PrepackNode::PrepackNode(
   graph.update_descriptor_counts(noop_shader_, /*execute = */ false);
 }
 
-api::StorageBuffer PrepackNode::create_staging_buffer(ComputeGraph* graph) {
+api::StagingBuffer PrepackNode::create_staging_buffer(ComputeGraph* graph) {
   vTensorPtr packed = graph->get_tensor(packed_);
 
   // If no TensorRef is provided, create a staging buffer of zeros according to
   // the vkapi::vTensor metadata.
   if (graph->val_is_none(tref_)) {
     size_t numel = utils::multiply_integers(packed->sizes());
-    api::StorageBuffer staging(graph->context(), packed->dtype(), numel);
+    api::StagingBuffer staging(graph->context(), packed->dtype(), numel);
     size_t nbytes = numel * vkapi::element_size(packed->dtype());
     set_staging_zeros(staging, nbytes);
     return staging;
@@ -60,7 +60,7 @@ api::StorageBuffer PrepackNode::create_staging_buffer(ComputeGraph* graph) {
 
   TensorRefPtr tref = graph->get_tref(tref_);
   size_t numel = utils::multiply_integers(tref->sizes);
-  api::StorageBuffer staging(graph->context(), tref->dtype, numel);
+  api::StagingBuffer staging(graph->context(), tref->dtype, numel);
   size_t nbytes = numel * vkapi::element_size(tref->dtype);
   copy_ptr_to_staging(tref->data, staging, nbytes);
   return staging;
@@ -70,7 +70,7 @@ void PrepackNode::encode(ComputeGraph* graph) {
   api::Context* const context = graph->context();
 
   vTensorPtr packed = graph->get_tensor(packed_);
-  api::StorageBuffer staging = create_staging_buffer(graph);
+  api::StagingBuffer staging = create_staging_buffer(graph);
 
   std::unique_lock<std::mutex> cmd_lock = context->dispatch_lock();
 

--- a/backends/vulkan/runtime/graph/ops/PrepackNode.h
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.h
@@ -56,7 +56,7 @@ class PrepackNode final {
   const vkapi::SpecVarList spec_vars_;
 
  private:
-  api::StorageBuffer create_staging_buffer(ComputeGraph* graph);
+  api::StagingBuffer create_staging_buffer(ComputeGraph* graph);
 };
 
 } // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/utils/BindingUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/utils/BindingUtils.cpp
@@ -66,7 +66,7 @@ uint32_t bind_params_to_descriptor_set(
 }
 
 void bind_staging_to_descriptor_set(
-    api::StorageBuffer& staging,
+    api::StagingBuffer& staging,
     vkapi::DescriptorSet& descriptor_set,
     const uint32_t idx) {
   descriptor_set.bind(idx, staging.buffer());

--- a/backends/vulkan/runtime/graph/ops/utils/BindingUtils.h
+++ b/backends/vulkan/runtime/graph/ops/utils/BindingUtils.h
@@ -40,7 +40,7 @@ uint32_t bind_params_to_descriptor_set(
     const uint32_t base_idx);
 
 void bind_staging_to_descriptor_set(
-    api::StorageBuffer& staging,
+    api::StagingBuffer& staging,
     vkapi::DescriptorSet& descriptor_set,
     const uint32_t idx);
 

--- a/backends/vulkan/runtime/graph/ops/utils/StagingUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/utils/StagingUtils.cpp
@@ -73,7 +73,7 @@ void memcpy_from_mapping(
 
 void copy_ptr_to_staging(
     const void* src,
-    api::StorageBuffer& staging,
+    api::StagingBuffer& staging,
     const size_t nbytes) {
   vkapi::MemoryMap mapping(staging.buffer(), vkapi::MemoryAccessType::WRITE);
   mapping.invalidate();
@@ -81,7 +81,7 @@ void copy_ptr_to_staging(
 }
 
 void copy_staging_to_ptr(
-    api::StorageBuffer& staging,
+    api::StagingBuffer& staging,
     void* dst,
     const size_t nbytes) {
   vkapi::MemoryMap mapping(staging.buffer(), vkapi::MemoryAccessType::READ);
@@ -89,7 +89,7 @@ void copy_staging_to_ptr(
   memcpy_from_mapping(mapping, dst, nbytes, staging.dtype());
 }
 
-void set_staging_zeros(api::StorageBuffer& staging, const size_t nbytes) {
+void set_staging_zeros(api::StagingBuffer& staging, const size_t nbytes) {
   vkapi::MemoryMap mapping(staging.buffer(), vkapi::MemoryAccessType::WRITE);
   uint8_t* data_ptr = mapping.template data<uint8_t>();
   memset(data_ptr, 0, staging.nbytes());

--- a/backends/vulkan/runtime/graph/ops/utils/StagingUtils.h
+++ b/backends/vulkan/runtime/graph/ops/utils/StagingUtils.h
@@ -18,14 +18,14 @@ namespace vkcompute {
 
 void copy_ptr_to_staging(
     const void* src,
-    api::StorageBuffer& staging,
+    api::StagingBuffer& staging,
     const size_t nbytes);
 void copy_staging_to_ptr(
-    api::StorageBuffer& staging,
+    api::StagingBuffer& staging,
     void* dst,
     const size_t nbytes);
 
-void set_staging_zeros(api::StorageBuffer& staging, const size_t nbytes);
+void set_staging_zeros(api::StagingBuffer& staging, const size_t nbytes);
 
 //
 // Functions to get shaders

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -112,7 +112,7 @@ void record_image_to_nchw_op(
 void record_int8_image_to_nchw_noint8_op(
     api::Context* const context,
     api::vTensor& v_src,
-    api::StorageBuffer& dst_buffer) {
+    api::StagingBuffer& dst_buffer) {
   vkapi::PipelineBarrier pipeline_barrier{};
   uint32_t buffer_len = utils::safe_downcast<uint32_t>(dst_buffer.numel() / 4);
   utils::uvec3 global_wg_size = {buffer_len, 1, 1};
@@ -324,7 +324,7 @@ void record_reference_matmul(
   _(int8_t, QInt8)
 
 void fill_vtensor(api::vTensor& vten, std::vector<float>& data) {
-  api::StorageBuffer staging_buffer(api::context(), vten.dtype(), data.size());
+  api::StagingBuffer staging_buffer(api::context(), vten.dtype(), data.size());
 
 #define CASE(ctype, name)                                                     \
   case vkapi::ScalarType::name: {                                             \
@@ -411,7 +411,7 @@ void fill_vtensor(
 }
 
 void extract_vtensor(api::vTensor& vten, std::vector<float>& data) {
-  api::StorageBuffer staging_buffer(
+  api::StagingBuffer staging_buffer(
       api::context(), vten.dtype(), vten.staging_buffer_numel());
 
   if (vten.storage_type() == utils::StorageType::BUFFER) {

--- a/backends/vulkan/test/utils/test_utils.h
+++ b/backends/vulkan/test/utils/test_utils.h
@@ -37,13 +37,13 @@ using namespace vkcompute;
       allocate_memory);
 
 #define DEFINE_STAGING_BUFFER_AND_RECORD_TO_GPU_FOR(tensor)          \
-  api::StorageBuffer staging_buffer_##tensor(                        \
+  api::StagingBuffer staging_buffer_##tensor(                        \
       api::context(), vkapi::kFloat, tensor.staging_buffer_numel()); \
   record_nchw_to_image_op(                                           \
       api::context(), staging_buffer_##tensor.buffer(), tensor);
 
 #define DEFINE_STAGING_BUFFER_AND_RECORD_FROM_GPU_FOR(tensor)        \
-  api::StorageBuffer staging_buffer_##tensor(                        \
+  api::StagingBuffer staging_buffer_##tensor(                        \
       api::context(), vkapi::kFloat, tensor.staging_buffer_numel()); \
   record_image_to_nchw_op(                                           \
       api::context(), tensor, staging_buffer_##tensor.buffer());
@@ -85,7 +85,7 @@ void record_image_to_nchw_op(
 void record_int8_image_to_nchw_noint8_op(
     api::Context* const context,
     api::vTensor& v_src,
-    api::StorageBuffer& dst_buffer);
+    api::StagingBuffer& dst_buffer);
 
 void record_conv2d_prepack_weights_op(
     api::Context* const context,
@@ -126,7 +126,7 @@ void record_reference_matmul(
 //
 
 inline void
-fill_staging(api::StorageBuffer& staging, float val, int numel = -1) {
+fill_staging(api::StagingBuffer& staging, float val, int numel = -1) {
   if (numel < 0) {
     numel = staging.numel();
   }
@@ -164,7 +164,7 @@ inline std::vector<float> extract_vtensor(api::vTensor& vten) {
 }
 
 inline void
-check_staging_buffer(api::StorageBuffer& staging, float val, int numel = -1) {
+check_staging_buffer(api::StagingBuffer& staging, float val, int numel = -1) {
   if (numel < 0) {
     numel = staging.numel();
   }

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -336,7 +336,7 @@ TEST_F(VulkanComputeAPITest, spec_var_classes_test) {
 
 TEST_F(VulkanComputeAPITest, spec_var_shader_test) {
   size_t len = 16;
-  StorageBuffer buffer(context(), vkapi::kFloat, len);
+  StagingBuffer buffer(context(), vkapi::kFloat, len);
 
   float scale = 3.0f;
   float offset = 1.5f;
@@ -407,7 +407,7 @@ TEST_F(VulkanComputeAPITest, update_params_between_submit) {
         params.buffer());
   }
 
-  StorageBuffer staging_buffer(
+  StagingBuffer staging_buffer(
       context(), vkapi::kFloat, a.staging_buffer_numel());
   record_image_to_nchw_op(context(), a, staging_buffer.buffer());
 
@@ -428,7 +428,7 @@ TEST_F(VulkanComputeAPITest, update_params_between_submit) {
 
 template <typename T, vkapi::ScalarType dtype>
 void test_storage_buffer_type(const size_t len) {
-  StorageBuffer buffer(context(), dtype, len);
+  StagingBuffer buffer(context(), dtype, len);
 
   std::string kernel_name("idx_fill_buffer");
   switch (dtype) {
@@ -2040,7 +2040,7 @@ void run_from_gpu_test(
         vten.sizes_ubo());
   }
 
-  StorageBuffer staging_buffer(context(), dtype, vten.staging_buffer_numel());
+  StagingBuffer staging_buffer(context(), dtype, vten.staging_buffer_numel());
 
   if (dtype == vkapi::kChar &&
       !context()->adapter_ptr()->has_full_int8_buffers_support()) {
@@ -2073,7 +2073,7 @@ void round_trip_test(
   vTensor vten = vTensor(context(), sizes, dtype, storage_type, memory_layout);
 
   // Create and fill input staging buffer
-  StorageBuffer staging_buffer_in(
+  StagingBuffer staging_buffer_in(
       context(), dtype, vten.staging_buffer_numel());
 
   std::vector<T> data_in(staging_buffer_in.numel());
@@ -2084,7 +2084,7 @@ void round_trip_test(
       data_in.data(), staging_buffer_in, vten.staging_buffer_nbytes());
 
   // Output staging buffer
-  StorageBuffer staging_buffer_out(
+  StagingBuffer staging_buffer_out(
       context(), dtype, vten.staging_buffer_numel());
 
   record_nchw_to_image_op(context(), staging_buffer_in.buffer(), vten);
@@ -2538,7 +2538,7 @@ void test_conv2d(
 
   // Create and fill input staging buffer
   const int64_t in_numel = utils::multiply_integers(original_sizes);
-  StorageBuffer staging_buffer_in(context(), vkapi::kFloat, in_numel);
+  StagingBuffer staging_buffer_in(context(), vkapi::kFloat, in_numel);
 
   std::vector<float> data_in(in_numel);
   for (int i = 0; i < in_numel; i++) {
@@ -2550,7 +2550,7 @@ void test_conv2d(
   // Output staging buffer
   const int64_t out_numel =
       padded_sizes[0] * padded_sizes[1] * original_sizes[2] * original_sizes[3];
-  StorageBuffer staging_buffer_out(context(), vkapi::kFloat, out_numel);
+  StagingBuffer staging_buffer_out(context(), vkapi::kFloat, out_numel);
 
   // Copy data in and out of the tensor
   record_conv2d_prepack_weights_op(

--- a/backends/vulkan/tools/gpuinfo/include/architecture.h
+++ b/backends/vulkan/tools/gpuinfo/include/architecture.h
@@ -40,7 +40,7 @@ void reg_count(const App& app) {
   uint32_t NITER;
 
   auto bench = [&](uint32_t ngrp, uint32_t nreg) {
-    StorageBuffer buffer(context(), vkapi::kFloat, 1);
+    StagingBuffer buffer(context(), vkapi::kFloat, 1);
     vkapi::PipelineBarrier pipeline_barrier{};
 
     auto shader_name = "reg_count_" + std::to_string(nreg);
@@ -164,7 +164,7 @@ void warp_size(const App& app, const bool verbose = false) {
   uint32_t NITER;
 
   auto bench = [&](uint32_t nthread) {
-    StorageBuffer out_buf(context(), vkapi::kInt, app.nthread_logic);
+    StagingBuffer out_buf(context(), vkapi::kInt, app.nthread_logic);
     vkapi::PipelineBarrier pipeline_barrier{};
 
     auto shader_name = "warp_size_physical";
@@ -224,7 +224,7 @@ void warp_size(const App& app, const bool verbose = false) {
   // doesn't depend on kernel timing, so the extra wait time doesn't lead to
   // inaccuracy.
   auto bench_sm = [&](uint32_t nthread) {
-    StorageBuffer out_buf(context(), vkapi::kInt, app.nthread_logic);
+    StagingBuffer out_buf(context(), vkapi::kInt, app.nthread_logic);
     vkapi::PipelineBarrier pipeline_barrier{};
 
     auto shader_name = "warp_size_scheduler";

--- a/backends/vulkan/tools/gpuinfo/include/buffers.h
+++ b/backends/vulkan/tools/gpuinfo/include/buffers.h
@@ -35,8 +35,8 @@ void buf_cacheline_size(const App& app) {
   uint32_t NITER;
 
   auto bench = [&](int stride) {
-    StorageBuffer in_buf(context(), vkapi::kFloat, BUF_SIZE);
-    StorageBuffer out_buf(context(), vkapi::kFloat, 1);
+    StagingBuffer in_buf(context(), vkapi::kFloat, BUF_SIZE);
+    StagingBuffer out_buf(context(), vkapi::kFloat, 1);
     vkapi::PipelineBarrier pipeline_barrier{};
 
     auto shader_name = "buf_cacheline_size";
@@ -132,8 +132,8 @@ void _bandwidth(
     // workgroups, once the size of the access excedes the workgroup width.
     const uint32_t workgroup_width = local_x * NITER * NUNROLL;
 
-    StorageBuffer in_buf(context(), vkapi::kFloat, range / sizeof(float));
-    StorageBuffer out_buf(
+    StagingBuffer in_buf(context(), vkapi::kFloat, range / sizeof(float));
+    StagingBuffer out_buf(
         context(), vkapi::kFloat, VEC_WIDTH * app.nthread_logic);
     vkapi::PipelineBarrier pipeline_barrier{};
 

--- a/backends/vulkan/tools/gpuinfo/include/textures.h
+++ b/backends/vulkan/tools/gpuinfo/include/textures.h
@@ -61,7 +61,7 @@ void tex_cacheline_concurr(const App& app) {
       vTensor in_tensor =
           api::vTensor(api::context(), sizes_nchw, vkapi::kFloat);
 
-      StorageBuffer out_buf(context(), vkapi::kFloat, TEXEL_WIDTH);
+      StagingBuffer out_buf(context(), vkapi::kFloat, TEXEL_WIDTH);
 
       vkapi::PipelineBarrier pipeline_barrier{};
 
@@ -173,7 +173,7 @@ void tex_bandwidth(const App& app) {
       // workgroups, once the size of the access excedes the workgroup width.
       const uint32_t workgroup_width = local_x * NITER * NUNROLL;
 
-      StorageBuffer out_buf(
+      StagingBuffer out_buf(
           context(), vkapi::kFloat, VEC_WIDTH * app.nthread_logic);
       vkapi::PipelineBarrier pipeline_barrier{};
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5021
* #5014
* #5013
* __->__ #5012

1. Tensors accessible to both CPU and GPU use `StorageBuffer`.
2. Tensors accessible to GPU only use `vTensorStorage`.

Since `StorageBuffer` is only used for [staging buffers](https://vulkan-tutorial.com/Vertex_buffers/Staging_buffer), i.e., buffers accessible to both CPU and GPU, `StagingBuffer` is a fitting name for (1) that decreases confusion between (1) and (2).

Differential Revision: [D62049779](https://our.internmc.facebook.com/intern/diff/D62049779/)