### PR TITLE
[runner] Print prompt before call into text prefiller

### DIFF
--- a/examples/models/llama2/runner/runner.cpp
+++ b/examples/models/llama2/runner/runner.cpp
@@ -124,7 +124,6 @@ Error Runner::load() {
       metadata_.at(kVocabSize),
       temperature_);
   text_prefiller_ = std::make_unique<TextPrefiller>(
-      tokenizer_.get(),
       text_decoder_runner_.get(),
       metadata_.at(kUseKVCache),
       metadata_.at(kEnableDynamicShape));
@@ -201,8 +200,11 @@ Error Runner::generate(
   // Prefill first
   // Here feed all tokens to the model and get the next predicted token
   // after the prompt. After that we will enter generate loop.
-  auto prefill_res =
-      text_prefiller_->prefill(prompt_tokens, 0, wrapped_callback);
+
+  // print prompts
+  wrapped_callback(prompt);
+
+  auto prefill_res = text_prefiller_->prefill(prompt_tokens, 0);
   stats_.first_token_ms = util::time_in_ms();
   stats_.prompt_eval_end_ms = util::time_in_ms();
   ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());

--- a/examples/models/llava/runner/llava_runner.cpp
+++ b/examples/models/llava/runner/llava_runner.cpp
@@ -51,7 +51,6 @@ Error LlavaRunner::load() {
 
   // Load the text prefiller
   text_prefiller_ = std::make_unique<TextPrefiller>(
-      tokenizer_.get(),
       text_decoder_runner_.get(),
       /*use_kv_cache=*/true,
       /*enable_parallel_prefill=*/true);
@@ -111,12 +110,14 @@ Error LlavaRunner::generate(
   }
 
   // prefill user prompt. No BOS because preset prompt already has it.
+  wrapped_callback(prompt);
+
   std::vector<uint64_t> user_prompt_tokens =
       ET_UNWRAP(tokenizer_->encode(prompt, /*bos=*/0, /*eos=*/0));
   size_t num_user_tokens = user_prompt_tokens.size();
 
-  uint64_t prefill_next_token = ET_UNWRAP(
-      text_prefiller_->prefill(user_prompt_tokens, pos, wrapped_callback));
+  uint64_t prefill_next_token =
+      ET_UNWRAP(text_prefiller_->prefill(user_prompt_tokens, pos));
   pos += num_user_tokens;
 
   // Generate tokens

--- a/extension/llm/runner/text_prefiller.h
+++ b/extension/llm/runner/text_prefiller.h
@@ -23,7 +23,6 @@ namespace llm {
 class TextPrefiller {
  public:
   TextPrefiller(
-      Tokenizer* tokenizer,
       TextDecoderRunner* text_decoder_runner,
       bool use_kv_cache_,
       bool enable_parallel_prefill);
@@ -33,17 +32,13 @@ class TextPrefiller {
    * tokenizer.
    * @param start_pos The starting position in KV cache of the input in the LLM
    * Module.
-   * @param token_callback A callback function that will be called for each
-   * token in the prompt.
    * @return The next token of the LLM Module after prefill.
    */
   ::executorch::runtime::Result<uint64_t> prefill(
       std::vector<uint64_t>& prompt_tokens,
-      int64_t start_pos = 0,
-      std::function<void(const std::string&)> token_callback = {});
+      int64_t start_pos = 0);
 
  private:
-  Tokenizer* tokenizer_;
   TextDecoderRunner* text_decoder_runner_;
   bool use_kv_cache_;
   bool enable_parallel_prefill_;


### PR DESCRIPTION
Summary: Currently we are printing out prompt token by token in `TextPrefiller.prefill()`. This is unnecessary and slow things down. Moving it out of text prefiller and print the prompt in runner.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: