### PR TITLE
Add possibility to collect all TOSA tests to a specified path

### DIFF
--- a/backends/arm/test/misc/test_debug_feats.py
+++ b/backends/arm/test/misc/test_debug_feats.py
@@ -175,10 +175,13 @@ class TestCollateTosaTests(unittest.TestCase):
         )
         # test that the output directory is created and contains the expected files
         assert os.path.exists(
-            "test_collate_tosa_tests/tosa-bi/TestCollateTosaTests/test_collate_tosa_BI_tests/output.tosa"
+            "test_collate_tosa_tests/tosa-bi/TestCollateTosaTests/test_collate_tosa_BI_tests"
         )
         assert os.path.exists(
-            "test_collate_tosa_tests/tosa-bi/TestCollateTosaTests/test_collate_tosa_BI_tests/desc.json"
+            "test_collate_tosa_tests/tosa-bi/TestCollateTosaTests/test_collate_tosa_BI_tests/output_tag8.tosa"
+        )
+        assert os.path.exists(
+            "test_collate_tosa_tests/tosa-bi/TestCollateTosaTests/test_collate_tosa_BI_tests/desc_tag8.json"
         )
 
         os.environ.pop("TOSA_TESTCASES_BASE_PATH")


### PR DESCRIPTION
Done in order to collect test vectors for backend compilers.

Signed-off-by: Per Åstrand <per.astrand@arm.com>

Change-Id: I0fc6e4d6bfcccd6aae18847a9a33f76d3d19fe5f