### PR TITLE
Migrate executorch examples to use export_for_training

### DIFF
--- a/examples/models/test/test_export.py
+++ b/examples/models/test/test_export.py
@@ -29,7 +29,7 @@ class ExportTest(unittest.TestCase):
         Returns a tuple containing the outputs of the eager mode model and the executorch mode model.
         """
         eager_model = eager_model.eval()
-        model = torch._export.capture_pre_autograd_graph(eager_model, example_inputs)
+        model = torch.export.export_for_training(eager_model, example_inputs).module()
         edge_model = export_to_edge(model, example_inputs)
 
         executorch_prog = edge_model.to_executorch()


### PR DESCRIPTION
Differential Revision: D62142608


