### PR TITLE
Remove expensive print from lowered_backend_module.py

### DIFF
--- a/exir/lowered_backend_module.py
+++ b/exir/lowered_backend_module.py
@@ -696,9 +696,6 @@ def create_exported_program_from_submodule(
     in_spec = pytree.tree_flatten((tuple(subgraph_signature.user_inputs), {}))[1]
     out_spec = pytree.tree_flatten(subgraph_signature.user_outputs)[1]
 
-    print(submodule.graph)
-    print(subgraph_signature)
-
     return (
         ExportedProgram(
             root=submodule,


### PR DESCRIPTION
Summary:
This one print was taking over 900 seconds (15 minutes) in `to_backend`.
This was in a resnet152 test we were trying.

Move this to logging.debug which won't materialize the string by default.
I can also consider just removing this print if nobody needs it, a debugger
might be a better way to access this info.

I can also consider just deleting this instead if people don't need it.

Differential Revision: D62155526
