### PR TITLE
Migrate //executorch/... from PyTorchBackendInterface to BackendInterface

### DIFF
--- a/backends/apple/coreml/runtime/include/coreml_backend/delegate.h
+++ b/backends/apple/coreml/runtime/include/coreml_backend/delegate.h
@@ -20,7 +20,7 @@ class BackendDelegate;
 namespace torch {
 namespace executor {
 
-class CoreMLBackendDelegate final : public PyTorchBackendInterface {
+class CoreMLBackendDelegate final : public ::executorch::runtime::BackendInterface {
 public:
     CoreMLBackendDelegate() noexcept;
     ~CoreMLBackendDelegate() = default;

--- a/backends/apple/mps/runtime/MPSBackend.mm
+++ b/backends/apple/mps/runtime/MPSBackend.mm
@@ -19,7 +19,7 @@
 namespace torch {
 namespace executor {
 
-class MPSBackend final : public PyTorchBackendInterface {
+class MPSBackend final : public ::executorch::runtime::BackendInterface {
  public:
   ~MPSBackend() = default;
 

--- a/backends/arm/README.md
+++ b/backends/arm/README.md
@@ -33,7 +33,7 @@ Quantization:
 - `arm_quantizer_utils.py` - Utilities for quantization
 
 Runtime:
-- `runtime/ArmBackendEthosU.cpp` - The Arm backend implementation of the ExecuTorch runtime backend (PyTorchBackendInterface) for Ethos-U
+- `runtime/ArmBackendEthosU.cpp` - The Arm backend implementation of the ExecuTorch runtime backend (BackendInterface) for Ethos-U
 
 Other:
 - `third-party/` - Dependencies on other code - in particular the TOSA serialization_lib for compiling to TOSA and the ethos-u-core-driver for the bare-metal backend supporting Ethos-U

--- a/backends/arm/runtime/ArmBackendEthosU.cpp
+++ b/backends/arm/runtime/ArmBackendEthosU.cpp
@@ -46,7 +46,7 @@ class ArmBackendExecuteCallbacks {
   }
 };
 
-class ArmBackend final : public PyTorchBackendInterface {
+class ArmBackend final : public ::executorch::runtime::BackendInterface {
  public:
   ArmBackend() {}
 

--- a/backends/mediatek/runtime/include/NeuronBackend.h
+++ b/backends/mediatek/runtime/include/NeuronBackend.h
@@ -26,7 +26,7 @@
 namespace torch {
 namespace executor {
 
-class NeuronBackend final : public PyTorchBackendInterface {
+class NeuronBackend final : public ::executorch::runtime::BackendInterface {
  public:
   Result<DelegateHandle*> init(
       BackendInitContext& context,

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.h
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.h
@@ -14,7 +14,8 @@
 namespace torch {
 namespace executor {
 
-class QnnExecuTorchBackend final : public PyTorchBackendInterface {
+class QnnExecuTorchBackend final
+    : public ::executorch::runtime::BackendInterface {
  public:
   ~QnnExecuTorchBackend(){};
 

--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -412,7 +412,7 @@ void maybe_resize_output(
 // VulkanBackend class
 //
 
-class VulkanBackend final : public PyTorchBackendInterface {
+class VulkanBackend final : public ::executorch::runtime::BackendInterface {
  public:
   ~VulkanBackend() override = default;
 

--- a/backends/xnnpack/runtime/XNNPACKBackend.cpp
+++ b/backends/xnnpack/runtime/XNNPACKBackend.cpp
@@ -20,7 +20,7 @@
 namespace torch {
 namespace executor {
 
-class XnnpackBackend final : public PyTorchBackendInterface {
+class XnnpackBackend final : public ::executorch::runtime::BackendInterface {
  public:
   ~XnnpackBackend() = default;
 

--- a/exir/backend/test/demos/rpc/ExecutorBackend.cpp
+++ b/exir/backend/test/demos/rpc/ExecutorBackend.cpp
@@ -35,7 +35,7 @@ namespace executor {
  * front-end before having the actual backend ready.
  */
 
-class ExecutorBackend final : public PyTorchBackendInterface {
+class ExecutorBackend final : public ::executorch::runtime::BackendInterface {
  public:
   ~ExecutorBackend() = default;
 


### PR DESCRIPTION
Summary: Update all of ET to use the new backend name.

Reviewed By: mergennachin

Differential Revision: D61927046
