### PR TITLE
Add a default delegate time scale converter

### DIFF
--- a/devtools/inspector/_inspector_utils.py
+++ b/devtools/inspector/_inspector_utils.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import math
 from enum import Enum
 from typing import Dict, List, Mapping, Optional, Tuple, TypeAlias, Union
@@ -61,6 +63,15 @@ TIME_SCALE_DICT = {
     TimeScale.S: 1,
     TimeScale.CYCLES: 1,
 }
+
+
+def calculate_time_scale_factor(
+    source_time_scale: TimeScale, target_time_scale: TimeScale
+) -> float:
+    """
+    Calculate the factor (source divided by target) between two time scales
+    """
+    return TIME_SCALE_DICT[source_time_scale] / TIME_SCALE_DICT[target_time_scale]
 
 
 # Model Debug Output

--- a/devtools/inspector/tests/inspector_utils_test.py
+++ b/devtools/inspector/tests/inspector_utils_test.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import tempfile
 import unittest
 from typing import Dict, Tuple
@@ -23,11 +25,13 @@ from executorch.devtools.etdump import schema_flatcc as flatcc
 
 from executorch.devtools.etrecord.tests.etrecord_test import TestETRecord
 from executorch.devtools.inspector._inspector_utils import (
+    calculate_time_scale_factor,
     create_debug_handle_to_op_node_mapping,
     EDGE_DIALECT_GRAPH_KEY,
     find_populated_event,
     gen_graphs_from_etrecord,
     is_inference_output_equal,
+    TimeScale,
 )
 
 
@@ -168,6 +172,19 @@ class TestInspectorUtils(unittest.TestCase):
                 "value_string",
                 "value_string",
             )
+        )
+
+    def test_calculate_time_scale_factor_second_based(self):
+        self.assertEqual(
+            calculate_time_scale_factor(TimeScale.NS, TimeScale.MS), 1000000
+        )
+        self.assertEqual(
+            calculate_time_scale_factor(TimeScale.MS, TimeScale.NS), 1 / 1000000
+        )
+
+    def test_calculate_time_scale_factor_cycles(self):
+        self.assertEqual(
+            calculate_time_scale_factor(TimeScale.CYCLES, TimeScale.CYCLES), 1
         )
 
 


### PR DESCRIPTION
Summary:
Because the unit of delegate ops are different from non-delegates, this has caused confusion for users: [post](https://fb.workplace.com/groups/pytorch.edge.users/permalink/1562687731268181/), [Issue #4504](https://github.com/pytorch/executorch/issues/4504).

This diff gives a quick solution for the problem to unblock Beta. The rationale is that since for non-delegated ops, we have the default time scale:
```
source_time_scale: TimeScale = TimeScale.NS,
target_time_scale: TimeScale = TimeScale.MS,
```
And the conversion rate is 10^6 (because 1 MS = 10^6 NS), so it makes sense to set a default converter function for delegated ops to be `input_time/(1000 * 1000)` as well. Similar converter functions have been used by [coreml](https://www.internalfb.com/code/fbsource/[76be64aab17c]/fbcode/executorch/examples/apple/coreml/scripts/inspector_utils.py?lines=259-262) and [vulkan](https://fburl.com/code/5cu6fx2b) already.

The proper solution to write the convertion in etdump is tracked by T198369344 and T198369419

Differential Revision: D62160650
