### PR TITLE
Format cmake files.

### DIFF
--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -133,7 +133,9 @@ endif()
 # The arm_executor_runner executable
 add_executable(arm_executor_runner)
 
-target_sources(arm_executor_runner PRIVATE arm_executor_runner.cpp arm_perf_monitor.cpp)
+target_sources(
+  arm_executor_runner PRIVATE arm_executor_runner.cpp arm_perf_monitor.cpp
+)
 
 # Include the target's bare-metal linker script
 ethosu_eval_link_options(arm_executor_runner)

--- a/extension/parallel/test/CMakeLists.txt
+++ b/extension/parallel/test/CMakeLists.txt
@@ -21,12 +21,16 @@ set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
 include(${EXECUTORCH_ROOT}/build/Test.cmake)
 
-set(_test_srcs
-    thread_parallel_test.cpp ../thread_parallel.cpp
-)
+set(_test_srcs thread_parallel_test.cpp ../thread_parallel.cpp)
 
 et_cxx_test(
-  extension_parallel_test SOURCES ${_test_srcs} EXTRA_LIBS pthreadpool cpuinfo extension_threadpool
+  extension_parallel_test
+  SOURCES
+  ${_test_srcs}
+  EXTRA_LIBS
+  pthreadpool
+  cpuinfo
+  extension_threadpool
 )
 target_include_directories(
   extension_parallel_test

--- a/extension/threadpool/CMakeLists.txt
+++ b/extension/threadpool/CMakeLists.txt
@@ -20,16 +20,17 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 
-add_library(extension_threadpool threadpool.cpp threadpool_guard.cpp cpuinfo_utils.cpp)
+add_library(
+  extension_threadpool threadpool.cpp threadpool_guard.cpp cpuinfo_utils.cpp
+)
 target_link_libraries(
   extension_threadpool PUBLIC executorch_no_prim_ops cpuinfo pthreadpool
 )
 target_include_directories(extension_threadpool PUBLIC ${EXECUTORCH_ROOT}/..)
 target_include_directories(
   extension_threadpool
-  PUBLIC
-    ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/cpuinfo/include
-    ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/pthreadpool/include
+  PUBLIC ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/cpuinfo/include
+         ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/pthreadpool/include
 )
 target_compile_options(extension_threadpool PUBLIC ${_common_compile_options})
 


### PR DESCRIPTION
Summary:
```
find . -name 'CMakeLists.txt' -o -name '*.cmake' | xargs cmake-format -i
```

Reviewed By: kirklandsign

Differential Revision: D62168513
