### PR TITLE
Remove usages of extract_constant_segment=True

### DIFF
--- a/examples/mediatek/model_export_scripts/llama.py
+++ b/examples/mediatek/model_export_scripts/llama.py
@@ -369,7 +369,6 @@ def export_to_et_ir(
                     alloc_graph_input=False,
                     alloc_graph_output=False,
                 ),
-                extract_constant_segment=True,
                 extract_delegate_segments=True,
             )
         )

--- a/examples/portable/scripts/export.py
+++ b/examples/portable/scripts/export.py
@@ -62,7 +62,7 @@ def main() -> None:
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 
-    backend_config = ExecutorchBackendConfig(extract_constant_segment=True)
+    backend_config = ExecutorchBackendConfig()
     if args.segment_alignment is not None:
         backend_config.segment_alignment = int(args.segment_alignment, 16)
     if (

--- a/exir/_serialize/_program.py
+++ b/exir/_serialize/_program.py
@@ -347,7 +347,7 @@ def serialize_pte_binary(
     *,
     mutable_data: Optional[List[Buffer]] = None,
     extract_delegate_segments: bool = False,
-    extract_constant_segment: bool = False,
+    extract_constant_segment: bool = True,
     segment_alignment: int = 128,
     constant_tensor_alignment: Optional[int] = None,
     delegate_alignment: Optional[int] = None,

--- a/exir/_serialize/test/test_program.py
+++ b/exir/_serialize/test/test_program.py
@@ -169,7 +169,6 @@ class TestProgram(unittest.TestCase):
         pte_data = bytes(
             serialize_pte_binary(
                 program,
-                extract_constant_segment=True,
                 segment_alignment=SEGMENT_ALIGNMENT,
                 constant_tensor_alignment=constant_tensor_alignment,
             )
@@ -427,16 +426,12 @@ class TestProgram(unittest.TestCase):
 
     def test_round_trip_no_segments_and_no_header(self) -> None:
         """Tests that a Program serialized with extract_delegate_segments=True
-        or extract_constant_segment=True, when there are no segments, does not
-        contain an extended header, constant segment, or delegate segments. Confirm
-        that a Program remains the same after serializing and deserializing.
+        when there are no segments does not contain an extended header,
+        constant segment, or delegate segments. Confirm that a Program remains
+        the same after serializing and deserializing.
         """
         program = get_test_program()
-        pte_data = bytes(
-            serialize_pte_binary(
-                program, extract_delegate_segments=True, extract_constant_segment=True
-            )
-        )
+        pte_data = bytes(serialize_pte_binary(program, extract_delegate_segments=True))
         self.assertGreater(len(pte_data), 16)
 
         # File magic should be present at the expected offset.
@@ -637,7 +632,6 @@ class TestProgram(unittest.TestCase):
         with self.assertRaises(ValueError):
             serialize_pte_binary(
                 program,
-                extract_constant_segment=True,
                 segment_alignment=SEGMENT_ALIGNMENT,
                 constant_tensor_alignment=constant_tensor_alignment,
             )
@@ -662,7 +656,6 @@ class TestProgram(unittest.TestCase):
             serialize_pte_binary(
                 program,
                 extract_delegate_segments=True,
-                extract_constant_segment=True,
                 segment_alignment=SEGMENT_ALIGNMENT,
                 constant_tensor_alignment=CONSTANT_TENSOR_ALIGNMENT,
             )

--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -261,7 +261,6 @@ class LLMEdgeManager:
         assert self.edge_manager, "Need to run export_to_edge() first"
         self.export_program = self.edge_manager.to_executorch(
             ExecutorchBackendConfig(
-                extract_constant_segment=True,
                 extract_delegate_segments=True,
                 passes=[
                     QuantFusionPass(),


### PR DESCRIPTION
Summary:
Remove usages before deprecation.

default `serialize_pte_binary` to set `extract_constant_segment` to true, which is the default set in the config. Now that we're removing usages, we no longer explicitly set it to true.

Note that the `extract_constant_segment` argument will be removed in the next diff in the stack.

Reviewed By: dbort

Differential Revision: D61995885
