### PR TITLE
Update Android build for MTK

### DIFF
--- a/backends/mediatek/CMakeLists.txt
+++ b/backends/mediatek/CMakeLists.txt
@@ -25,6 +25,7 @@ include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/include)
 
 # targets
 add_library(neuron_backend SHARED)
+target_compile_options(neuron_backend PRIVATE "-frtti" "-fexceptions")
 target_link_libraries(
   neuron_backend PRIVATE executorch_no_prim_ops portable_ops_lib android log
                          ${NEURON_BUFFER_ALLOCATOR_LIB}

--- a/build/build_android_llm_demo.sh
+++ b/build/build_android_llm_demo.sh
@@ -47,7 +47,7 @@ build_android_native_library() {
   cmake examples/models/llama2 \
     -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
     -DANDROID_ABI="$ANDROID_ABI" \
-    -DANDROID_PLATFORM=android-23 \
+    -DANDROID_PLATFORM=android-26 \
     -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
     -DEXECUTORCH_BUILD_KERNELS_CUSTOM=ON \
     -DEXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON \
@@ -61,7 +61,7 @@ build_android_native_library() {
   cmake extension/android \
     -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
     -DANDROID_ABI="${ANDROID_ABI}" \
-    -DANDROID_PLATFORM=android-23 \
+    -DANDROID_PLATFORM=android-26 \
     -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
     -DEXECUTORCH_ENABLE_LOGGING=ON \
     -DEXECUTORCH_LOG_LEVEL=Info \

--- a/build/build_android_llm_demo.sh
+++ b/build/build_android_llm_demo.sh
@@ -23,7 +23,7 @@ build_android_native_library() {
   cmake . -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
     -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
     -DANDROID_ABI="${ANDROID_ABI}" \
-    -DANDROID_PLATFORM=android-23 \
+    -DANDROID_PLATFORM=android-26 \
     -DEXECUTORCH_ENABLE_LOGGING=ON \
     -DEXECUTORCH_LOG_LEVEL=Info \
     -DEXECUTORCH_BUILD_XNNPACK=ON \

--- a/build/executorch-config.cmake
+++ b/build/executorch-config.cmake
@@ -41,6 +41,7 @@ set(lib_list
     ${FLATCCRT_LIB}
     coremldelegate
     mpsdelegate
+    neuron_backend
     qnn_executorch_backend
     portable_ops_lib
     extension_module


### PR DESCRIPTION
1. MTK requires rtti and exceptions
2. MTK requires Android 26+

Note: libneuron related libs are linked dynamically. So we need to push these libs libneuron_buffer_allocator.so and libneuron_backend.so to jnilibs as well