### PR TITLE
Try migrating llama2 to the new subclass based API from old API (Int8DynActInt4WeightQuantizer)

### DIFF
--- a/examples/models/llama2/source_transformation/quantize.py
+++ b/examples/models/llama2/source_transformation/quantize.py
@@ -72,11 +72,17 @@ def quantize(
         # Check for required args
         if group_size is None:
             raise Exception("For 8da4w quantization, group size must be specified.")
-        from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
 
-        model = Int8DynActInt4WeightQuantizer(
-            precision=torch_dtype, groupsize=group_size
-        ).quantize(model)
+        from torchao.quantization.quant_api import (
+            int8_dynamic_activation_int4_weight,
+            quantize_,
+        )
+
+        quantize_(
+            model,
+            int8_dynamic_activation_int4_weight(group_size=group_size),
+        )
+
         if verbose:
             print("quantized model:", model)
         return model


### PR DESCRIPTION
Summary:
Not for land just yet, but trying to see if CI passes/fails

Before landing, we need to make sure idempotency is still there.

Differential Revision: D62223540
