### PR TITLE
Use metal instance for Android emulator for KVM support

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -80,7 +80,8 @@ jobs:
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
     needs: build-llm-demo
-    runs-on: amz2023.linux.4xlarge
+    # NB: Use metal install for KVM support to run the emulator faster
+    runs-on: linux.24xl.spr-metal
     env:
       ANDROID_NDK_VERSION: r26c
       API_LEVEL: 34
@@ -128,9 +129,6 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.API_LEVEL }}
-          # NB: x86_64 emulator is slow because the lack of KVM support on AWS, it
-          # seems that we can use metal instance for that but it hasn't been tried
-          # out yet. Also arm64-v8a arch requires an ARM runner
           arch: x86_64
           script: ./build/run_android_emulator.sh
           # NB: This is to boot the emulator faster following the instructions on


### PR DESCRIPTION
A known issue when running Android emulator test on our Linux runner is that the runner, already a virtual machine, doesn't support KVM/hardware accelerator, for example https://github.com/pytorch/executorch/actions/runs/10732304130/job/29764671347#step:9:37.  It means that emulating anything takes longer.

There are some metal Linux runners around in our infra that folks uses for CPU benchmarking.  I think we can try to use them as there are still spare capacity and the current Android emulator job is relatively small to squeeze in. AWS metal runners are "real" and supports KVM.

### Testing

The current emulator job takes around 7 to 10m https://hud.pytorch.org/hud/pytorch/executorch/main/1?per_page=50&name_filter=emulator

After running on metal instance, it takes https://github.com/pytorch/executorch/actions/runs/10732098391/job/29764069309?pr=5127, the emulator job takes around 2m