### PR TITLE
[ExecuTorch] disable text animation in iOS Llama demo app

### DIFF
--- a/examples/demo-apps/apple_ios/LLaMA/LLaMA/Application/ContentView.swift
+++ b/examples/demo-apps/apple_ios/LLaMA/LLaMA/Application/ContentView.swift
@@ -220,13 +220,11 @@ struct ContentView: View {
             let count = tokens.count
             tokens = []
             DispatchQueue.main.async {
-              withAnimation {
-                var message = messages.removeLast()
-                message.text += text
-                message.tokenCount += count
-                message.dateUpdated = Date()
-                messages.append(message)
-              }
+              var message = messages.removeLast()
+              message.text += text
+              message.tokenCount += count
+              message.dateUpdated = Date()
+              messages.append(message)
             }
           }
           if shouldStopGenerating {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5134

We observed poor performance during generation, decreasing as
the response got longer. Profiling revealed a lot of time spent in
CoreAnimation on the main thread, which went away when I disabled this
animation.

Differential Revision: [D62308551](https://our.internmc.facebook.com/intern/diff/D62308551/)