### PR TITLE
Disable fail_fast for benchmark jobs

### DIFF
--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -279,6 +279,7 @@ jobs:
         model: ${{ fromJson(needs.set-parameters.outputs.models) }}
         delegate: ${{ fromJson(needs.set-parameters.outputs.delegates) }}
         device: ${{ fromJson(needs.set-parameters.outputs.devices) }}
+      fail-fast: false
     with:
       device-type: android
       runner: linux.2xlarge

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -290,6 +290,7 @@ jobs:
         model: ${{ fromJson(needs.set-parameters.outputs.models) }}
         delegate: ${{ fromJson(needs.set-parameters.outputs.delegates) }}
         device: ${{ fromJson(needs.set-parameters.outputs.devices) }}
+      fail-fast: false
     with:
       device-type: ios
       # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS


### PR DESCRIPTION
Notice an issue when running w/ multiple models that all benchmark jobs will be cancelled when the one hits an error first. An example job: https://github.com/pytorch/executorch/actions/runs/10730195824