### PR TITLE
[CoreML] Add support for running statefule model.

### DIFF
--- a/backends/apple/coreml/runtime/delegate/ETCoreMLDefaultModelExecutor.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLDefaultModelExecutor.mm
@@ -29,9 +29,10 @@
     if (self.ignoreOutputBackings) {
         predictionOptions.outputBackings = @{};
     }
-    id<MLFeatureProvider> outputs = [self.model.mlModel predictionFromFeatures:inputs
-                                                                       options:predictionOptions
-                                                                         error:error];
+
+    id<MLFeatureProvider> outputs = [self.model predictionFromFeatures:inputs
+                                                               options:predictionOptions
+                                                                 error:error];
     if (!outputs) {
         return nil;
     }

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModel.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModel.h
@@ -8,6 +8,10 @@
 #import <CoreML/CoreML.h>
 #import <vector>
 
+#if !defined(MODEL_STATE_IS_SUPPORTED) && __has_include(<CoreML/MLModel+MLState.h>)
+#define MODEL_STATE_IS_SUPPORTED 1
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class ETCoreMLAsset;
@@ -37,14 +41,11 @@ __attribute__((objc_subclassing_restricted))
                     orderedOutputNames:(NSOrderedSet<NSString*>*)orderedOutputNames
                                  error:(NSError* __autoreleasing*)error NS_DESIGNATED_INITIALIZER;
 
-- (nullable NSArray<MLMultiArray*>*)prepareInputs:(const std::vector<executorchcoreml::MultiArray>&)inputs
-                                            error:(NSError* __autoreleasing*)error;
-
-- (nullable NSArray<MLMultiArray*>*)prepareOutputBackings:(const std::vector<executorchcoreml::MultiArray>&)outputs
-                                                    error:(NSError* __autoreleasing*)error;
-
 /// The underlying MLModel.
 @property (strong, readonly, nonatomic) MLModel* mlModel;
+
+/// The model state.
+@property (strong, readonly, nonatomic) id state API_AVAILABLE(macos(15.0), ios(18.0), tvos(18.0), watchos(11.0));
 
 /// The asset from which the model is loaded.
 @property (strong, readonly, nonatomic) ETCoreMLAsset* asset;
@@ -57,6 +58,19 @@ __attribute__((objc_subclassing_restricted))
 
 /// The ordered output names of the model.
 @property (copy, readonly, nonatomic) NSOrderedSet<NSString*>* orderedOutputNames;
+
+
+- (nullable id<MLFeatureProvider>)predictionFromFeatures:(id<MLFeatureProvider>)input
+                                                 options:(MLPredictionOptions*)options
+                                                   error:(NSError* __autoreleasing*)error;
+
+- (nullable NSArray<MLMultiArray*>*)prepareInputs:(const std::vector<executorchcoreml::MultiArray>&)inputs
+                                            error:(NSError* __autoreleasing*)error;
+
+- (nullable NSArray<MLMultiArray*>*)prepareOutputBackings:(const std::vector<executorchcoreml::MultiArray>&)outputs
+                                                    error:(NSError* __autoreleasing*)error;
+
+- (BOOL)prewarmAndReturnError:(NSError* __autoreleasing*)error;
 
 @end
 

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
@@ -598,21 +598,8 @@ ETCoreMLModelDebugInfo * _Nullable get_model_debug_info(const inmemoryfs::InMemo
     if (!model) {
         return NO;
     }
-    
-    NSError *localError = nil;
-    BOOL result = [model.mlModel prewarmAndReturnError:&localError];
-    if (!result) {
-        ETCoreMLLogError(localError,
-                         "%@: Failed to prewarm model with identifier = %@",
-                         NSStringFromClass(self.assetManager.class),
-                         model.identifier);
-    }
-    
-    if (error) {
-        *error = localError;
-    }
-    
-    return result;
+
+    return [model prewarmAndReturnError:error];
 }
 
 - (void)prewarmRecentlyUsedAssetsWithMaxCount:(NSUInteger)maxCount {

--- a/backends/apple/coreml/runtime/delegate/MLModel_Prewarm.mm
+++ b/backends/apple/coreml/runtime/delegate/MLModel_Prewarm.mm
@@ -77,7 +77,7 @@ id<MLFeatureProvider> _Nullable get_zeroed_inputs(MLModel *model, NSError * __au
         if (!inputs) {
             return NO;
         }
-        
+
         id<MLFeatureProvider> outputs = [self predictionFromFeatures:inputs error:error];
         return outputs != nil;
     }

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.mm
@@ -88,10 +88,9 @@ static constexpr NSInteger MAX_MODEL_OUTPUTS_COUNT = 50;
                                                  eventLogger:(const executorchcoreml::ModelEventLogger *)eventLogger
                                                        error:(NSError * __autoreleasing *)error {
     if (self.profiler == nil) {
-        ETCoreMLModelProfiler *profiler = [[ETCoreMLModelProfiler alloc] initWithCompiledModelAsset:self.model.asset
-                                                                                        outputNames:self.model.orderedOutputNames
-                                                                                      configuration:self.configuration
-                                                                                              error:error];
+        ETCoreMLModelProfiler *profiler = [[ETCoreMLModelProfiler alloc] initWithModel:self.model
+                                                                         configuration:self.configuration
+                                                                                 error:error];
         self.profiler = profiler;
     }
        

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.h
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.h
@@ -31,14 +31,12 @@ __attribute__((objc_subclassing_restricted))
 
 /// Constructs an `ETCoreMLModelProfiler` instance.
 ///
-/// @param compiledModelAsset The compiled model asset (mlmodelc).
-/// @param outputNames The model output names.
+/// @param model The model.
 /// @param configuration The model configuration.
 /// @param error   On failure, error is filled with the failure information.
-- (nullable instancetype)initWithCompiledModelAsset:(ETCoreMLAsset*)compiledModelAsset
-                                        outputNames:(NSOrderedSet<NSString*>*)outputNames
-                                      configuration:(MLModelConfiguration*)configuration
-                                              error:(NSError* __autoreleasing*)error NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithModel:(ETCoreMLModel*)model
+                         configuration:(MLModelConfiguration*)configuration
+                                 error:(NSError* __autoreleasing*)error NS_DESIGNATED_INITIALIZER;
 
 /// Returns profiling info of operations at the specified paths.
 ///

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.mm
@@ -8,6 +8,7 @@
 #import "ETCoreMLModelProfiler.h"
 
 #import "ETCoreMLAsset.h"
+#import "ETCoreMLModel.h"
 #import "ETCoreMLLogging.h"
 #import "ETCoreMLModelStructurePath.h"
 #import "ETCoreMLOperationProfilingInfo.h"
@@ -221,8 +222,8 @@ void set_model_outputs(id<MLFeatureProvider> output_features,
 }
 
 @interface ETCoreMLModelProfiler ()
-/// The CoreML model.
-@property (readonly, strong, nonatomic) MLModel *model;
+/// The model.
+@property (readonly, strong, nonatomic) ETCoreMLModel *model;
 /// The model output names.
 @property (readonly, copy, nonatomic) NSOrderedSet<NSString *> *outputNames;
 #if MODEL_PROFILING_IS_AVAILABLE
@@ -240,25 +241,19 @@ void set_model_outputs(id<MLFeatureProvider> output_features,
 
 @implementation ETCoreMLModelProfiler
 
-- (nullable instancetype)initWithCompiledModelAsset:(ETCoreMLAsset *)compiledModelAsset
-                                        outputNames:(NSOrderedSet<NSString *> *)outputNames
-                                      configuration:(MLModelConfiguration *)configuration
-                                              error:(NSError * __autoreleasing *)error  {
+- (nullable instancetype)initWithModel:(ETCoreMLModel *)model
+                         configuration:(MLModelConfiguration *)configuration
+                                 error:(NSError * __autoreleasing *)error  {
 #if MODEL_PROFILING_IS_AVAILABLE
     if (@available(macOS 14.4, iOS 17.4, tvOS 17.4, watchOS 10.4, *)) {
-        NSURL *compiledModelURL = compiledModelAsset.contentURL;
+        NSURL *compiledModelURL = model.asset.contentURL;
         MLComputePlan *computePlan = get_compute_plan_of_model_at_url(compiledModelURL,
                                                                       configuration,
                                                                       error);
         if (!computePlan) {
             return nil;
         }
-        
-        MLModel *model = [MLModel modelWithContentsOfURL:compiledModelURL error:error];
-        if (!model) {
-            return nil;
-        }
-        
+
         __block NSMutableArray<ETCoreMLModelStructurePath *> *operationPaths = [NSMutableArray array];
         __block NSMutableDictionary<NSValue *, ETCoreMLModelStructurePath *> *operationToPathMap = [NSMutableDictionary dictionary];
         __block NSMutableArray<MLModelStructureProgramOperation *> *topologicallySortedOperations = [NSMutableArray new];
@@ -280,7 +275,6 @@ void set_model_outputs(id<MLFeatureProvider> output_features,
         
         self = [super init];
         if (self) {
-            _outputNames = [outputNames copy];
             _model = model;
             _computePlan = computePlan;
             _operationToPathMap = operationToPathMap;


### PR DESCRIPTION
Add support for running stateful model. On iOS18 CoreML has a new API `predictionFromFeatures:usingState:options:error` that supports model state. The runtime change makes sure to call the new API if the model has state otherwise it uses the old API.  

Testing:
Did local testing. To generate the test model I am waiting on the coremltools change to be publicly available.