### PR TITLE
[Android Java] Get rid of forwardOnes

### DIFF
--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -297,6 +297,9 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
 
     // If no inputs is given, it will run with sample inputs (ones)
     if (jinputs->size() == 0) {
+      if (module_->load_method(method) != Error::Ok) {
+        return {};
+      }
       auto&& underlying_method = module_->methods_[method].method;
       auto&& buf = prepare_input_tensors(*underlying_method);
       auto result = underlying_method->execute();

--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -294,7 +294,6 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
       facebook::jni::alias_ref<
           facebook::jni::JArrayClass<JEValue::javaobject>::javaobject>
           jinputs) {
-
     // If no inputs is given, it will run with sample inputs (ones)
     if (jinputs->size() == 0) {
       if (module_->load_method(method) != Error::Ok) {
@@ -307,10 +306,12 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
         return {};
       }
       facebook::jni::local_ref<facebook::jni::JArrayClass<JEValue>> jresult =
-        facebook::jni::JArrayClass<JEValue>::newArray(underlying_method->outputs_size());
+          facebook::jni::JArrayClass<JEValue>::newArray(
+              underlying_method->outputs_size());
 
       for (int i = 0; i < underlying_method->outputs_size(); i++) {
-        auto jevalue = JEValue::newJEValueFromEValue(underlying_method->get_output(i));
+        auto jevalue =
+            JEValue::newJEValueFromEValue(underlying_method->get_output(i));
         jresult->setElement(i, *jevalue);
       }
       return jresult;

--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -377,7 +377,6 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
         makeNativeMethod("forward", ExecuTorchJni::forward),
         makeNativeMethod("execute", ExecuTorchJni::execute),
         makeNativeMethod("loadMethod", ExecuTorchJni::load_method),
-        makeNativeMethod("forwardOnes", ExecuTorchJni::forward_ones),
     });
   }
 };

--- a/extension/android/src/main/java/org/pytorch/executorch/Module.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/Module.java
@@ -79,9 +79,9 @@ public class Module {
   /**
    * Runs the 'forward' method of this module with the specified arguments.
    *
-   * @param inputs arguments for the ExecuTorch module's 'forward' method.
-   * Note: if method 'forward' requires inputs but no inputs are given, the
-   * function will not error out, but run 'forward' with sample inputs.
+   * @param inputs arguments for the ExecuTorch module's 'forward' method. Note: if method 'forward'
+   *     requires inputs but no inputs are given, the function will not error out, but run 'forward'
+   *     with sample inputs.
    * @return return value from the 'forward' method.
    */
   public EValue[] forward(EValue... inputs) {

--- a/extension/android/src/main/java/org/pytorch/executorch/Module.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/Module.java
@@ -80,15 +80,11 @@ public class Module {
    * Runs the 'forward' method of this module with the specified arguments.
    *
    * @param inputs arguments for the ExecuTorch module's 'forward' method.
+   * Note: if method 'forward' requires inputs but no inputs are given, the
+   * function will not error out, but run 'forward' with sample inputs.
    * @return return value from the 'forward' method.
    */
   public EValue[] forward(EValue... inputs) {
-    if (inputs.length == 0) {
-      // forward default args (ones)
-      mNativePeer.forwardOnes();
-      // discard the return value
-      return null;
-    }
     return mNativePeer.forward(inputs);
   }
 

--- a/extension/android/src/main/java/org/pytorch/executorch/NativePeer.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/NativePeer.java
@@ -43,15 +43,6 @@ class NativePeer {
   @DoNotStrip
   public native EValue[] forward(EValue... inputs);
 
-  /**
-   * Run a "forward" call with the sample inputs (ones) to test a module
-   *
-   * @return the outputs of the forward call
-   * @apiNote This is experimental and test-only API
-   */
-  @DoNotStrip
-  public native int forwardOnes();
-
   /** Run an arbitrary method on the module */
   @DoNotStrip
   public native EValue[] execute(String methodName, EValue... inputs);


### PR DESCRIPTION
Instead, infer from empty inputs. In that case, use default parameters (ones). Return the actual result evalues. This is useful for benchmarking.