### PR TITLE
print tensor storage bytes in print_readable value list section

### DIFF
--- a/backends/vulkan/runtime/graph/Logging.cpp
+++ b/backends/vulkan/runtime/graph/Logging.cpp
@@ -71,8 +71,8 @@ void ComputeGraph::print_readable() {
             << std::setfill(' ') << std::endl;
 
   std::cout << std::setw(6) << "idx" << std::setw(10) << "type" << std::setw(20)
-            << "sizes" << std::setw(10) << "node_type" << std::setw(10)
-            << "so_idx" << std::endl;
+            << "sizes" << std::setw(10) << "node_type" << std::setw(15)
+            << "storage_bytes" << std::setw(10) << "so_idx" << std::endl;
 
   size_t value_idx = 0;
   for (Value& val : values_) {
@@ -106,6 +106,16 @@ void ComputeGraph::print_readable() {
       } else {
         std::cout << "";
       }
+    }
+
+    // Actual storage bytes used
+    std::cout << std::setw(15);
+    if (val.isTensor()) {
+      const api::vTensor& v_tensor = val.toTensor();
+      auto memory_reqs = v_tensor.get_memory_requirements();
+      std::cout << memory_reqs.size;
+    } else {
+      std::cout << "";
     }
 
     std::cout << std::setw(10);


### PR DESCRIPTION
Summary:
The byte size of shared objects is printed under the Shared Object List for models loaded from flatbuffer with memory planning annotations, but
1. is not printed in compute api tests where the graph is manually constructed
2. requires looking up the corresponding idx value in the Shared Object List and Value List to compare tensor sizes against real bytes used.

Adding a column in the Value List to print out the bytes used, for better readability & memory usage analysis.

Sample output from compute graph op test binary:
```
==================== Shared Object List ====================
   idx               sizes                   users
==================== Value List ============================
   idx      type               sizes node_type  storage_bytes    so_idx
     0 TENSORREF            [89,17,]   PREPACK
     1    TENSOR            [13,89,]     INPUT          18512
     2   STAGING
     3    TENSOR            [13,17,]    OUTPUT           3536
     4      BOOL
     5    TENSOR            [89,17,]   PREPACK           6256
     6   STAGING
```

Differential Revision: D62327284
