### PR TITLE
[flamingo] Update preproc imports

### DIFF
--- a/examples/models/flamingo/preprocess/export_preprocess_lib.py
+++ b/examples/models/flamingo/preprocess/export_preprocess_lib.py
@@ -14,7 +14,7 @@ from executorch.exir.program._program import ExecutorchProgramManager
 from executorch.extension.llm.custom_ops import preprocess_custom_ops  # noqa
 
 from torch.export import Dim, ExportedProgram
-from torchtune.models.clip.inference._transforms import _CLIPImageTransform
+from torchtune.models.clip.inference._transform import _CLIPImageTransform
 
 
 def get_example_inputs() -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:

--- a/examples/models/flamingo/preprocess/test_preprocess.py
+++ b/examples/models/flamingo/preprocess/test_preprocess.py
@@ -22,7 +22,7 @@ from executorch.extension.pybindings.portable_lib import (
 from parameterized import parameterized
 from PIL import Image
 
-from torchtune.models.clip.inference._transforms import (
+from torchtune.models.clip.inference._transform import (
     _CLIPImageTransform,
     CLIPImageTransform,
 )


### PR DESCRIPTION
After torchtune changes.

Test Plan:
```
./install_requirements.sh --pybind xnnpack
sh examples/models/flamingo/install_requirements.sh 
python examples/models/flamingo/preprocess/export_preprocess.py
python -m unittest examples/models/flamingo/preprocess/test_preprocess.py
```