### PR TITLE
Partition Mutable Buffer as Core ML State

### DIFF
--- a/backends/apple/coreml/partition/coreml_partitioner.py
+++ b/backends/apple/coreml/partition/coreml_partitioner.py
@@ -92,6 +92,13 @@ class CoreMLPartitioner(Partitioner):
 
         tag_constant_data(exported_program)
         if self.take_over_mutable_buffer:
+            logger.info(
+                "Core ML partitioner will take over torch mutable buffer as Core ML state, "
+                "so if your model contains mutable buffer, "
+                "then you will need MacOS15+/iOS18+ to execute. "
+                "If you want your mutable buffer model to be compatible with older OS, "
+                "then please set `take_over_mutable_buffer=False`"
+            )
             tag_mutated_buffer(exported_program)
 
         return PartitionResult(

--- a/backends/apple/coreml/scripts/install_requirements.sh
+++ b/backends/apple/coreml/scripts/install_requirements.sh
@@ -47,6 +47,11 @@ cmake --build "$COREMLTOOLS_DIR_PATH/build" --parallel
 
 echo "${green}ExecuTorch: Installing coremltools."
 pip install "$COREMLTOOLS_DIR_PATH"
+# CoreMLTools have started supporting numpy 2.0,
+# but ExecuTorch example model test env is still using older transformers,
+# so for now we will need to downgrade numpy to 1.x
+# TODO: Remove this numpy downgrade once later transformers starts to be used
+pip install numpy==1.26.4
 STATUS=$?
 if [ $STATUS -ne 0 ]; then
     echo "${red}ExecuTorch: Failed to install coremltools."

--- a/backends/apple/coreml/scripts/install_requirements.sh
+++ b/backends/apple/coreml/scripts/install_requirements.sh
@@ -24,7 +24,7 @@ rm -rf "$COREML_DIR_PATH/third-party"
 mkdir "$COREML_DIR_PATH/third-party"
 
 echo "${green}ExecuTorch: Cloning coremltools."
-git clone --depth 1 --branch 8.0b1 "https://github.com/apple/coremltools.git" $COREMLTOOLS_DIR_PATH
+git clone --depth 1 --branch 8.0b2 "https://github.com/apple/coremltools.git" $COREMLTOOLS_DIR_PATH
 cd $COREMLTOOLS_DIR_PATH
 
 STATUS=$?

--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -2,13 +2,17 @@
 #
 # Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
+import pytest
 import unittest
+
+import coremltools as ct
 
 import executorch.exir
 
 import torch
 import torchvision
 
+from executorch.backends.apple.coreml.compiler import CoreMLBackend
 from executorch.backends.apple.coreml.partition import CoreMLPartitioner
 
 
@@ -86,8 +90,53 @@ class TestCoreMLPartitioner(unittest.TestCase):
             if node.op == "call_function"
         ] == total
 
+    @pytest.mark.skipif(
+        "b" in ct.__version__ or ct.__version__ < "8.0",
+        reason="coremltools 8.0 or higher is required"
+    )
+    def test_buffer(self):
+        embedding_dim = 3
+        max_seq_len = 2
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros((max_seq_len, embedding_dim), dtype=torch.float32))
+
+            def forward(self, q, k_val, input_pos):
+                q_T = q.transpose(0, 1)
+                k = torch.ops.aten.index_put_(self.cache, [input_pos, None], k_val)
+                attn = k.mm(q_T)
+                return attn
+
+        model = Model()
+        model.eval()
+
+        q = torch.randn((1, embedding_dim))
+        k_val = torch.randn((1, embedding_dim))
+        input_pos = torch.tensor([0])
+        example_inputs = (q, k_val, input_pos)
+        exir_program_aten = torch.export.export(model, example_inputs)
+
+        compile_specs = CoreMLBackend.generate_compile_specs(minimum_deployment_target=ct.target.iOS18)
+        partitioner = CoreMLPartitioner(compile_specs=compile_specs)
+        edge_program_manager = executorch.exir.to_edge(
+            exir_program_aten, compile_config=self.edge_compile_config
+        )
+        delegated_program_manager = edge_program_manager.to_backend(partitioner)
+
+        assert [
+            node.target.__name__
+            for node in delegated_program_manager.exported_program().graph.nodes
+            if node.op == "call_function"
+        ] == [
+            "executorch_call_delegate",
+            "getitem",
+        ]
+
 
 if __name__ == "__main__":
     test_runner = TestCoreMLPartitioner()
     test_runner.test_add_sub_skip_mm()
     test_runner.test_vit_skip_conv()
+    test_runner.test_buffer()

--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -8,8 +8,6 @@ import coremltools as ct
 
 import executorch.exir
 
-import pytest
-
 import torch
 import torchvision
 
@@ -91,10 +89,6 @@ class TestCoreMLPartitioner(unittest.TestCase):
             if node.op == "call_function"
         ] == total
 
-    @pytest.mark.skipif(
-        "b" in ct.__version__ or ct.__version__ < "8.0",
-        reason="coremltools 8.0 or higher is required",
-    )
     def test_buffer(self):
         embedding_dim = 3
         max_seq_len = 2

--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -2,12 +2,13 @@
 #
 # Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
-import pytest
 import unittest
 
 import coremltools as ct
 
 import executorch.exir
+
+import pytest
 
 import torch
 import torchvision
@@ -92,7 +93,7 @@ class TestCoreMLPartitioner(unittest.TestCase):
 
     @pytest.mark.skipif(
         "b" in ct.__version__ or ct.__version__ < "8.0",
-        reason="coremltools 8.0 or higher is required"
+        reason="coremltools 8.0 or higher is required",
     )
     def test_buffer(self):
         embedding_dim = 3
@@ -101,7 +102,10 @@ class TestCoreMLPartitioner(unittest.TestCase):
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("cache", torch.zeros((max_seq_len, embedding_dim), dtype=torch.float32))
+                self.register_buffer(
+                    "cache",
+                    torch.zeros((max_seq_len, embedding_dim), dtype=torch.float32),
+                )
 
             def forward(self, q, k_val, input_pos):
                 q_T = q.transpose(0, 1)
@@ -118,7 +122,9 @@ class TestCoreMLPartitioner(unittest.TestCase):
         example_inputs = (q, k_val, input_pos)
         exir_program_aten = torch.export.export(model, example_inputs)
 
-        compile_specs = CoreMLBackend.generate_compile_specs(minimum_deployment_target=ct.target.iOS18)
+        compile_specs = CoreMLBackend.generate_compile_specs(
+            minimum_deployment_target=ct.target.iOS18
+        )
         partitioner = CoreMLPartitioner(compile_specs=compile_specs)
         edge_program_manager = executorch.exir.to_edge(
             exir_program_aten, compile_config=self.edge_compile_config

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -281,13 +281,7 @@ def build_args_parser() -> argparse.ArgumentParser:
     parser.add_argument("-V", "--vulkan", action="store_true")
     parser.add_argument("--mps", action="store_true")
     parser.add_argument("--coreml", action="store_true")
-    parser.add_argument(
-        "--coreml-disable-state",
-        dest="coreml_enable_state",
-        default=True,  # Enable this by default
-        action="store_false",
-        help="Delegate mutable buffer to Core ML state",
-    )
+    parser.add_argument("--coreml-enable-state", action="store_true")
     parser.add_argument(
         "--qnn",
         action="store_true",

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -282,6 +282,13 @@ def build_args_parser() -> argparse.ArgumentParser:
     parser.add_argument("--mps", action="store_true")
     parser.add_argument("--coreml", action="store_true")
     parser.add_argument(
+        "--coreml-disable-state",
+        dest="coreml_enable_state",
+        default=True,  # Enable this by default
+        action="store_false",
+        help="Delegate mutable buffer to Core ML state",
+    )
+    parser.add_argument(
         "--qnn",
         action="store_true",
         help="Delegate llama2 to qnn backend (Qualcomm), please use it --kv_cahce=True",
@@ -504,7 +511,7 @@ def _export_llama(modelname, args) -> LLMEdgeManager:  # noqa: C901
 
     if args.coreml:
         coreml_partitioner = get_coreml_partitioner(
-            args.use_kv_cache, args.pt2e_quantize
+            args.use_kv_cache and args.coreml_enable_state, args.pt2e_quantize
         )
         partitioners.append(coreml_partitioner)
         modelname = f"coreml_{modelname}"

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -511,7 +511,9 @@ def _export_llama(modelname, args) -> LLMEdgeManager:  # noqa: C901
 
     if args.coreml:
         coreml_partitioner = get_coreml_partitioner(
-            args.use_kv_cache and args.coreml_enable_state, args.pt2e_quantize
+            args.use_kv_cache and args.coreml_enable_state,
+            args.embedding_quantize,
+            args.pt2e_quantize,
         )
         partitioners.append(coreml_partitioner)
         modelname = f"coreml_{modelname}"

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -281,7 +281,11 @@ def build_args_parser() -> argparse.ArgumentParser:
     parser.add_argument("-V", "--vulkan", action="store_true")
     parser.add_argument("--mps", action="store_true")
     parser.add_argument("--coreml", action="store_true")
-    parser.add_argument("--coreml-enable-state", action="store_true")
+    parser.add_argument(
+        "--coreml-enable-state",
+        action="store_true",
+        help="This option is only for coreml, and is only supported for MacOS15+/iOS18+",
+    )
     parser.add_argument(
         "--qnn",
         action="store_true",


### PR DESCRIPTION
https://github.com/pytorch/executorch/pull/4830 opens the door toward delegate mutable buffer. Now in this PR, we tag the mutable buffers in Core ML partitioner, to delegate them as Core ML state

With https://github.com/pytorch/executorch/pull/5143, we are able to run the stateful Core ML delegate