### PR TITLE
[ExecuTorch] Use parallel_for in bfloat16 gemm_transa_ kernel

### DIFF
--- a/kernels/optimized/lib_defs.bzl
+++ b/kernels/optimized/lib_defs.bzl
@@ -155,7 +155,9 @@ def define_libs():
             deps = select({
                 ":linux-x86_64": [mkl_dep] if not runtime.is_oss else [],
                 "DEFAULT": [],
-            }),
+            }) + [
+                "//executorch/extension/parallel:thread_parallel",
+            ],
             exported_deps = [
                 "//executorch/kernels/optimized:libutils",
                 "//executorch/runtime/core/exec_aten:lib",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5197
* __->__ #5196
* #5195
* #5194
* #5193
* #5192
* #5124
* #5123

The upstream kernel uses this, I just didn't port it at first.

Differential Revision: [D62154262](https://our.internmc.facebook.com/intern/diff/D62154262/)