### PR TITLE
Make `compare_results()` import path public

### DIFF
--- a/devtools/inspector/TARGETS
+++ b/devtools/inspector/TARGETS
@@ -26,8 +26,8 @@ python_binary(
     main_function = ".inspector_cli.main",
     main_src = "inspector_cli.py",
     deps = [
-        ":inspector_utils",
         "//executorch/devtools:lib",
+        "//executorch/devtools/inspector:lib",
     ],
 )
 

--- a/devtools/inspector/__init__.py
+++ b/devtools/inspector/__init__.py
@@ -4,12 +4,21 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 from executorch.devtools.inspector._inspector import (
     Event,
     EventBlock,
     Inspector,
     PerfData,
 )
-from executorch.devtools.inspector._inspector_utils import TimeScale
+from executorch.devtools.inspector._inspector_utils import compare_results, TimeScale
 
-__all__ = ["Event", "EventBlock", "Inspector", "PerfData", "TimeScale"]
+__all__ = [
+    "Event",
+    "EventBlock",
+    "Inspector",
+    "PerfData",
+    "compare_results",
+    "TimeScale",
+]

--- a/devtools/inspector/inspector_cli.py
+++ b/devtools/inspector/inspector_cli.py
@@ -4,10 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import argparse
 
 from executorch.devtools import Inspector
-from executorch.devtools.inspector._inspector_utils import compare_results, TimeScale
+from executorch.devtools.inspector import compare_results, TimeScale
 
 
 def main() -> None:

--- a/docs/source/sdk-debugging.md
+++ b/docs/source/sdk-debugging.md
@@ -67,7 +67,7 @@ We've also provided a simple set of utilities that let users perform quality ana
 
 
 ```python
-from executorch.devtools.inspector._inspector_utils import compare_results
+from executorch.devtools.inspector import compare_results
 
 # Run a simple quality analysis between the model outputs sourced from the
 # runtime and a set of reference outputs.

--- a/examples/apple/coreml/scripts/inspector_cli.py
+++ b/examples/apple/coreml/scripts/inspector_cli.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 
 from executorch.devtools import Inspector
-from executorch.devtools.inspector._inspector_utils import compare_results
+from executorch.devtools.inspector import compare_results
 
 
 def get_root_dir_path() -> Path:


### PR DESCRIPTION
Summary: `compare_results()` is a util function that is used outside of the inspector tool itself. We will also probably mention it in PTC as a public util function. This diff makes it "public" aka removes the underscore prefix in the import paths.

Differential Revision: D62450959
