### PR TITLE
Fix off-by-1 issue in ET kv cache

### DIFF
--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -151,7 +151,7 @@ class LLMEdgeManager:
         if self.dynamic_shapes:
             return self.dynamic_shapes
 
-        dim = torch.export.Dim("token_dim", max=self.max_seq_len - 1)
+        dim = torch.export.Dim("token_dim", max=self.max_seq_len)
 
         if not self.use_kv_cache:
             # Only one input argument: tokens


### PR DESCRIPTION
Summary: We saw an issue where lowering a model with sequence length L and kv cache enabled triggered a runtime error for input sequence of length L.

Differential Revision: D62450769
