### PR TITLE
Adding per-method tracers to the module utility. Changing set_output_data_ptr to take in a method name.

### DIFF
--- a/extension/module/module.h
+++ b/extension/module/module.h
@@ -136,7 +136,9 @@ class Module {
    * @returns An Error to indicate success or failure.
    */
   ET_NODISCARD
-  runtime::Error load_method(const std::string& method_name);
+  runtime::Error load_method(
+      const std::string& method_name,
+      torch::executor::EventTracer* tracer = nullptr);
 
   /**
    * Checks if a specific method is loaded.
@@ -318,7 +320,8 @@ class Module {
    */
   runtime::Error set_output_data_ptr(
       runtime::EValue output_value,
-      size_t output_index);
+      size_t output_index,
+      const std::string& method_name = "forward");
 
  private:
   struct MethodHolder {


### PR DESCRIPTION
Summary:
* Adding per-method tracers to the executorch module utilty to be able to profile/trace methods individually
* Enabling per-method output data pointers to be able to use per-method input/output memory planning through the module.

Differential Revision: D62520386
