### PR TITLE
Just print Android instrument log when the test passes

### DIFF
--- a/examples/demo-apps/android/LlamaDemo/android-llm-device-farm-test-spec.yml
+++ b/examples/demo-apps/android/LlamaDemo/android-llm-device-farm-test-spec.yml
@@ -63,14 +63,7 @@ phases:
         # Check for this last to make sure that there is no failure
         elif [ $TESTS_PASSED -ne 0 ];
         then
-          OBSERVED_TPS=$(grep "INSTRUMENTATION_STATUS: TPS=" $INSTRUMENT_LOG | tail -n 1)
-
-          if [ -n "${OBSERVED_TPS}" ];
-          then
-            echo "[PyTorch] ${OBSERVED_TPS}";
-          else
-            echo "[PyTorch] Test passes but couldn't find the observed TPS from instrument log";
-          fi
+          cat "${INSTRUMENT_LOG}"
         fi;
 
       # Run the new generic benchmark activity https://developer.android.com/tools/adb#am


### PR DESCRIPTION
This should make it easier to reuse the test spec on Minibench where we don't need to rely on instrument tests to run the benchmark anymore while just keeping it to satisfy AWS as one of its required input.