### PR TITLE
Use Apple perf workflow to validate the test spec

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -19,15 +19,6 @@ on:
       - extension/apple/**
       - extension/module/**
   workflow_dispatch:
-  # TODO (huydhn): This is used to validate the test spec. Eventually, we need a proper
-  # perf benchmark workflow like android-perf. This can be cleaned up once that workflow
-  # is ready
-  workflow_call:
-    inputs:
-      test_spec:
-        description: The test spec to drive the test on AWS devices
-        required: false
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
@@ -116,7 +107,7 @@ jobs:
       # Uploaded to S3 from the previous job
       ios-ipa-archive: https://gha-artifacts.s3.amazonaws.com/${{ github.repository }}/${{ github.run_id }}/artifact/ExecuTorchDemo.ipa
       ios-xctestrun-zip: https://gha-artifacts.s3.amazonaws.com/${{ github.repository }}/${{ github.run_id }}/artifact/ExecuTorchDemo.xctestrun.zip
-      test-spec: ${{ inputs.test_spec || 'https://ossci-ios.s3.amazonaws.com/executorch/default-ios-device-farm-appium-test-spec.yml' }}
+      test-spec: https://ossci-ios.s3.amazonaws.com/executorch/default-ios-device-farm-appium-test-spec.yml
 
   build-frameworks-ios:
     name: build-frameworks-ios

--- a/.github/workflows/upload-android-test-specs.yml
+++ b/.github/workflows/upload-android-test-specs.yml
@@ -13,7 +13,9 @@ on:
       - examples/demo-apps/android/LlamaDemo/android-llm-device-farm-test-spec.yml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  # NB: This concurency group needs to be different than the one used in android-perf, otherwise
+  # GH complains about concurrency deadlock
+  group: android-spec-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/upload-apple-test-specs.yml
+++ b/.github/workflows/upload-apple-test-specs.yml
@@ -32,16 +32,18 @@ jobs:
           if-no-files-found: error
           path: examples/demo-apps/apple_ios/default-ios-device-farm-appium-test-spec.yml
 
-  # TODO (huydhn): An example on how to validate the test spec using the iOS demo app, but we need a proper
-  # perf benchmark workflow like android-perf
   validate-apple-test-spec:
     needs: upload-apple-test-spec-for-validation
-    uses: ./.github/workflows/apple.yml
+    uses: ./.github/workflows/apple-perf.yml
     secrets: inherit
     permissions:
       id-token: write
       contents: read
     with:
+      # Just use a small model here with a minimal amount of configuration to test the spec
+      models: stories110M
+      devices: apple_iphone_15
+      delegates: xnnpack
       test_spec: https://gha-artifacts.s3.amazonaws.com/${{ github.repository }}/${{ github.run_id }}/artifact/default-ios-device-farm-appium-test-spec.yml
 
   upload-apple-test-spec:

--- a/.github/workflows/upload-apple-test-specs.yml
+++ b/.github/workflows/upload-apple-test-specs.yml
@@ -13,7 +13,9 @@ on:
       - examples/demo-apps/apple_ios/default-ios-device-farm-appium-test-spec.yml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  # NB: This concurency group needs to be different than the one used in android-perf, otherwise
+  # GH complains about concurrency deadlock
+  group: apple-spec-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/upload-apple-test-specs.yml
+++ b/.github/workflows/upload-apple-test-specs.yml
@@ -13,7 +13,7 @@ on:
       - examples/demo-apps/apple_ios/default-ios-device-farm-appium-test-spec.yml
 
 concurrency:
-  # NB: This concurency group needs to be different than the one used in android-perf, otherwise
+  # NB: This concurency group needs to be different than the one used in apple-perf, otherwise
   # GH complains about concurrency deadlock
   group: apple-spec-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true


### PR DESCRIPTION
This PR has 2 fixes:

* Use Apple perf workflow to validate the iOS test spec in the same way that we are doing for Android spec
* I also attempt to fix this concurrency deadlock when running the upload test spec workflow in trunk https://github.com/pytorch/executorch/actions/runs/10820832880.  This can only be tested once the PR lands though