### PR TITLE
Rename exec_aten:: to executorch::aten::

### DIFF
--- a/backends/qualcomm/runtime/QnnExecuTorch.h
+++ b/backends/qualcomm/runtime/QnnExecuTorch.h
@@ -44,7 +44,7 @@ struct CustomMemTensorInfo {
   size_t tensor_bytes;
   uint32_t* shape;
   uint32_t rank;
-  torch::executor::ScalarType dtype;
+  exec_aten::ScalarType dtype;
 };
 
 /// Allocate specific tensors (usually graph inputs and outputs) on shared

--- a/backends/qualcomm/runtime/SharedBuffer.cpp
+++ b/backends/qualcomm/runtime/SharedBuffer.cpp
@@ -25,7 +25,7 @@ std::size_t std::hash<CustomMemTensorInfo>::operator()(
     hash_val ^= info.shape[i];
   }
   hash_val ^= std::hash<uint32_t>()(info.rank);
-  hash_val ^= std::hash<torch::executor::ScalarType>()(info.dtype);
+  hash_val ^= std::hash<exec_aten::ScalarType>()(info.dtype);
   return hash_val;
 }
 

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -8,7 +8,7 @@
 
 #include <executorch/backends/vulkan/test/utils/test_utils.h>
 
-#include <executorch/runtime/core/portable_type/half.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h>
 
@@ -322,7 +322,7 @@ void record_reference_matmul(
   _(uint8_t, Byte)                \
   _(int8_t, Char)                 \
   _(int32_t, Int)                 \
-  _(torch::executor::Half, Half)  \
+  _(exec_aten::Half, Half)        \
   _(float, Float)                 \
   _(int8_t, QInt8)
 

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#include <executorch/runtime/core/portable_type/half.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
 
 #include <executorch/backends/vulkan/runtime/api/api.h>
 
@@ -485,7 +485,7 @@ TEST_F(VulkanComputeAPITest, test_buffer_float16) {
   if (!context()->adapter_ptr()->has_full_float16_buffers_support()) {
     GTEST_SKIP();
   }
-  test_storage_buffer_type<torch::executor::Half, vkapi::kHalf>(16);
+  test_storage_buffer_type<exec_aten::Half, vkapi::kHalf>(16);
 }
 
 TEST_F(VulkanComputeAPITest, test_buffer_int8) {
@@ -567,7 +567,7 @@ TEST_F(VulkanComputeAPITest, buffer_tensor_sanity_check) {
             run_buffer_tensor_sanity_check<float>(a);
             break;
           case vkapi::kHalf:
-            run_buffer_tensor_sanity_check<torch::executor::Half>(a);
+            run_buffer_tensor_sanity_check<exec_aten::Half>(a);
             break;
           case vkapi::kChar:
             run_buffer_tensor_sanity_check<int8_t>(a);
@@ -2395,7 +2395,7 @@ TEST(VulkanToFromGPUShaderTest, round_trip_tests) {
 
   for (auto& sizes : to_test) {
     RUN_TESTS(float, vkapi::kFloat)
-    RUN_TESTS(torch::executor::Half, vkapi::kHalf)
+    RUN_TESTS(exec_aten::Half, vkapi::kHalf)
   }
 
   for (auto& sizes : to_test_int8) {

--- a/examples/models/flamingo/cross_attention/cross_attention_mask_test.cpp
+++ b/examples/models/flamingo/cross_attention/cross_attention_mask_test.cpp
@@ -11,9 +11,9 @@
 #include <gtest/gtest.h>
 
 using namespace ::testing;
-using torch::executor::ScalarType;
-using torch::executor::Tensor;
-using torch::executor::TensorImpl;
+using exec_aten::ScalarType;
+using exec_aten::Tensor;
+using exec_aten::TensorImpl;
 
 TEST(CrossAttentxnMaskTest, TestCrossAttentionMask) {
   std::vector<int> tokens = {

--- a/examples/qualcomm/oss_scripts/llama2/runner/runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama2/runner/runner.cpp
@@ -135,7 +135,7 @@ int32_t Runner::logitsToToken(const exec_aten::Tensor& logits_tensor) {
 
 // Given an input token. Set up the inputs for the model and execute a single
 // step. Returning the logits tensor.
-Result<torch::executor::Tensor> Runner::run_model_step(
+Result<exec_aten::Tensor> Runner::run_model_step(
     int64_t input_token,
     TensorPtr& token,
     TensorPtr& start_pos,

--- a/examples/qualcomm/oss_scripts/llama2/runner/runner.h
+++ b/examples/qualcomm/oss_scripts/llama2/runner/runner.h
@@ -120,7 +120,7 @@ class IoMemMgr {
     std::vector<uint32_t> shape;
     uint32_t rank;
     size_t element_size;
-    torch::executor::ScalarType dtype;
+    exec_aten::ScalarType dtype;
   };
 
   struct IoInfo {

--- a/extension/android/jni/jni_layer_constants.h
+++ b/extension/android/jni/jni_layer_constants.h
@@ -8,7 +8,7 @@
 
 #include <unordered_map>
 
-#include <executorch/runtime/core/portable_type/scalar_type.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
 
 namespace executorch::extension {
 
@@ -37,7 +37,7 @@ constexpr static int kTensorDTypeBits4x2 = 20;
 constexpr static int kTensorDTypeBits8 = 21;
 constexpr static int kTensorDTypeBits16 = 22;
 
-using torch::executor::ScalarType;
+using exec_aten::ScalarType;
 
 const std::unordered_map<ScalarType, int> scalar_type_to_java_dtype = {
     {ScalarType::Byte, kTensorDTypeUInt8},

--- a/extension/android/src/main/java/org/pytorch/executorch/DType.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/DType.java
@@ -17,51 +17,51 @@ public enum DType {
   // NOTE: "jniCode" must be kept in sync with scalar_type.h.
   // NOTE: Never serialize "jniCode", because it can change between releases.
 
-  /** Code for dtype torch::executor::Byte */
+  /** Code for dtype ScalarType::Byte */
   UINT8(0),
-  /** Code for dtype torch::executor::Char */
+  /** Code for dtype ScalarType::Char */
   INT8(1),
-  /** Code for dtype torch::executor::Short */
+  /** Code for dtype ScalarType::Short */
   INT16(2),
-  /** Code for dtype torch::executor::Int */
+  /** Code for dtype ScalarType::Int */
   INT32(3),
-  /** Code for dtype torch::executor::Long */
+  /** Code for dtype ScalarType::Long */
   INT64(4),
-  /** Code for dtype torch::executor::Half */
+  /** Code for dtype ScalarType::Half */
   HALF(5),
-  /** Code for dtype torch::executor::Float */
+  /** Code for dtype ScalarType::Float */
   FLOAT(6),
-  /** Code for dtype torch::executor::Double */
+  /** Code for dtype ScalarType::Double */
   DOUBLE(7),
-  /** Code for dtype torch::executor::ComplexHalf */
+  /** Code for dtype ScalarType::ComplexHalf */
   COMPLEX_HALF(8),
-  /** Code for dtype torch::executor::ComplexFloat */
+  /** Code for dtype ScalarType::ComplexFloat */
   COMPLEX_FLOAT(9),
-  /** Code for dtype torch::executor::ComplexDouble */
+  /** Code for dtype ScalarType::ComplexDouble */
   COMPLEX_DOUBLE(10),
-  /** Code for dtype torch::executor::Bool */
+  /** Code for dtype ScalarType::Bool */
   BOOL(11),
-  /** Code for dtype torch::executor::QInt8 */
+  /** Code for dtype ScalarType::QInt8 */
   QINT8(12),
-  /** Code for dtype torch::executor::QUInt8 */
+  /** Code for dtype ScalarType::QUInt8 */
   QUINT8(13),
-  /** Code for dtype torch::executor::QInt32 */
+  /** Code for dtype ScalarType::QInt32 */
   QINT32(14),
-  /** Code for dtype torch::executor::BFloat16 */
+  /** Code for dtype ScalarType::BFloat16 */
   BFLOAT16(15),
-  /** Code for dtype torch::executor::QUInt4x2 */
+  /** Code for dtype ScalarType::QUInt4x2 */
   QINT4X2(16),
-  /** Code for dtype torch::executor::QUInt2x4 */
+  /** Code for dtype ScalarType::QUInt2x4 */
   QINT2X4(17),
-  /** Code for dtype torch::executor::Bits1x8 */
+  /** Code for dtype ScalarType::Bits1x8 */
   BITS1X8(18),
-  /** Code for dtype torch::executor::Bits2x4 */
+  /** Code for dtype ScalarType::Bits2x4 */
   BITS2X4(19),
-  /** Code for dtype torch::executor::Bits4x2 */
+  /** Code for dtype ScalarType::Bits4x2 */
   BITS4X2(20),
-  /** Code for dtype torch::executor::Bits8 */
+  /** Code for dtype ScalarType::Bits8 */
   BITS8(21),
-  /** Code for dtype torch::executor::Bits16 */
+  /** Code for dtype ScalarType::Bits16 */
   BITS16(22),
   ;
 

--- a/kernels/optimized/blas/CPUBlas.cpp
+++ b/kernels/optimized/blas/CPUBlas.cpp
@@ -24,7 +24,8 @@ extern "C" void sgemm_(char *transa, char *transb, int *m, int *n, int *k, float
 namespace executorch {
 namespace cpublas {
 
-// using Half = exec_aten::Half;
+using exec_aten::BFloat16;
+using exec_aten::Half;
 
 #ifdef ET_BUILD_WITH_BLAS
 #ifdef ET_BUILD_FOR_APPLE

--- a/kernels/optimized/blas/CPUBlas.h
+++ b/kernels/optimized/blas/CPUBlas.h
@@ -17,9 +17,6 @@
 namespace executorch {
 namespace cpublas {
 
-using BFloat16 = torch::executor::BFloat16;
-using Half = torch::executor::Half;
-
 enum class TransposeType {
   NoTranspose,
   Transpose,
@@ -100,20 +97,20 @@ void gemm(
 void gemm(
     TransposeType transa, TransposeType transb,
     int64_t m, int64_t n, int64_t k,
-    const Half alpha,
-    const Half *a, int64_t lda,
-    const Half *b, int64_t ldb,
-    const Half beta,
-    Half *c, int64_t ldc);
+    const exec_aten::Half alpha,
+    const exec_aten::Half *a, int64_t lda,
+    const exec_aten::Half *b, int64_t ldb,
+    const exec_aten::Half beta,
+    exec_aten::Half *c, int64_t ldc);
 
 void gemm(
     TransposeType transa, TransposeType transb,
     int64_t m, int64_t n, int64_t k,
-    const BFloat16 alpha,
-    const BFloat16 *a, int64_t lda,
-    const BFloat16 *b, int64_t ldb,
-    const BFloat16 beta,
-    BFloat16 *c, int64_t ldc);
+    const exec_aten::BFloat16 alpha,
+    const exec_aten::BFloat16 *a, int64_t lda,
+    const exec_aten::BFloat16 *b, int64_t ldb,
+    const exec_aten::BFloat16 beta,
+    exec_aten::BFloat16 *c, int64_t ldc);
 // clang-format on
 
 // clang-format off

--- a/kernels/optimized/cpu/op_exp.cpp
+++ b/kernels/optimized/cpu/op_exp.cpp
@@ -27,8 +27,8 @@ template <
     typename CTYPE_OUT,
     typename std::enable_if<
         std::is_same<CTYPE_IN, CTYPE_OUT>::value &&
-            !std::is_same<CTYPE_IN, torch::executor::Half>::value &&
-            !std::is_same<CTYPE_OUT, torch::executor::Half>::value,
+            !std::is_same<CTYPE_IN, exec_aten::Half>::value &&
+            !std::is_same<CTYPE_OUT, exec_aten::Half>::value,
         int>::type = 0>
 void exp_data(
     const CTYPE_IN* in_data,
@@ -47,8 +47,8 @@ template <
     typename CTYPE_OUT,
     typename std::enable_if<
         !std::is_same<CTYPE_IN, CTYPE_OUT>::value ||
-            std::is_same<CTYPE_IN, torch::executor::Half>::value ||
-            std::is_same<CTYPE_OUT, torch::executor::Half>::value,
+            std::is_same<CTYPE_IN, exec_aten::Half>::value ||
+            std::is_same<CTYPE_OUT, exec_aten::Half>::value,
         int>::type = 0>
 void exp_data(
     const CTYPE_IN* in_data,

--- a/kernels/portable/cpu/op_empty.cpp
+++ b/kernels/portable/cpu/op_empty.cpp
@@ -26,7 +26,7 @@ using exec_aten::Tensor;
 Tensor& empty_out(
     RuntimeContext& context,
     IntArrayRef size,
-    torch::executor::optional<torch::executor::MemoryFormat> memory_format,
+    exec_aten::optional<exec_aten::MemoryFormat> memory_format,
     Tensor& out) {
   (void)context;
 

--- a/kernels/portable/cpu/test/scalar_utils_test.cpp
+++ b/kernels/portable/cpu/test/scalar_utils_test.cpp
@@ -16,7 +16,7 @@ struct promote_type_with_scalar_type_is_valid
           (std::is_same<T2, torch::executor::internal::B1>::value ||
            std::is_same<T2, torch::executor::internal::I8>::value ||
            std::is_same<T2, torch::executor::internal::F8>::value) &&
-              !std::is_same<T1, torch::executor::BFloat16>::value &&
+              !std::is_same<T1, exec_aten::BFloat16>::value &&
               !torch::executor::is_qint_type<T1>::value &&
               !torch::executor::is_bits_type<T1>::value> {};
 

--- a/kernels/portable/cpu/util/math_util.h
+++ b/kernels/portable/cpu/util/math_util.h
@@ -96,9 +96,8 @@ INT_T max_override(INT_T a, INT_T b) {
 
 template <
     typename T,
-    typename std::enable_if<
-        std::is_same<T, torch::executor::Half>::value,
-        bool>::type = true>
+    typename std::enable_if<std::is_same<T, exec_aten::Half>::value, bool>::
+        type = true>
 T min_override(T a, T b) {
   const auto float_a = static_cast<float>(a);
   if (std::isnan(float_a)) {
@@ -117,9 +116,8 @@ T min_override(T a, T b) {
 
 template <
     typename T,
-    typename std::enable_if<
-        std::is_same<T, torch::executor::Half>::value,
-        bool>::type = true>
+    typename std::enable_if<std::is_same<T, exec_aten::Half>::value, bool>::
+        type = true>
 T max_override(T a, T b) {
   const auto float_a = static_cast<float>(a);
   if (std::isnan(float_a)) {

--- a/kernels/portable/cpu/util/test/broadcast_test.cpp
+++ b/kernels/portable/cpu/util/test/broadcast_test.cpp
@@ -20,8 +20,8 @@
 using namespace ::testing;
 using exec_aten::ScalarType;
 using exec_aten::Tensor;
-using torch::executor::ArrayRef;
-using torch::executor::testing::TensorFactory;
+using executorch::runtime::ArrayRef;
+using executorch::runtime::testing::TensorFactory;
 
 TEST(BroadcastUtilTest, BroadcastTensor) {
   TensorFactory<ScalarType::Int> tf;
@@ -112,17 +112,17 @@ TEST(BroadcastUtilTest, GetBroadcastTargetSize) {
   Tensor a = tf.zeros({2, 1});
   Tensor b = tf.zeros({5, 1, 2});
 
-  get_broadcast_target_size(
+  executorch::runtime::Error err = get_broadcast_target_size(
       a,
       b,
       expected_output_size,
       torch::executor::kTensorDimensionLimit,
       &expected_output_dim);
+  EXPECT_EQ(err, torch::executor::Error::Ok);
 
   EXPECT_TRUE(
-      torch::executor::ArrayRef<Tensor::SizesType>(
-          expected_output_size, expected_output_dim)
-          .equals(torch::executor::ArrayRef<Tensor::SizesType>({5, 2, 2})));
+      ArrayRef<Tensor::SizesType>(expected_output_size, expected_output_dim)
+          .equals(ArrayRef<Tensor::SizesType>({5, 2, 2})));
 }
 
 size_t linearize_indexes(size_t* indexes, size_t indexes_len, const Tensor& t) {

--- a/kernels/portable/test/op_mul_test.cpp
+++ b/kernels/portable/test/op_mul_test.cpp
@@ -36,19 +36,18 @@ class OpMulOutKernelTest : public OperatorTest {
 TEST_F(OpMulOutKernelTest, UnhandledDtypeDies) {
   // mul_out() doesn't handle QInt8.
   // TensorFactory cannot be used with ScalarType::QInt8 since
-  // torch::executor::qint8 does not have a default constructor. It must be
+  // exec_aten::qint8 does not have a default constructor. It must be
   // initialized with an explicit value. So, we need to manually create the
   // underlying data without default construction and then the tensors from that
   // data via TensorImpl.
 
   std::vector<SizesType> sizes = {2, 2};
 
-  std::vector<torch::executor::qint8> a_data{};
-  std::generate_n(std::back_inserter(a_data), 4, []() {
-    return torch::executor::qint8{0};
-  });
-  std::vector<torch::executor::qint8> b_data(a_data);
-  std::vector<torch::executor::qint8> out_data(a_data);
+  std::vector<exec_aten::qint8> a_data{};
+  std::generate_n(
+      std::back_inserter(a_data), 4, []() { return exec_aten::qint8{0}; });
+  std::vector<exec_aten::qint8> b_data(a_data);
+  std::vector<exec_aten::qint8> out_data(a_data);
 
   auto a_impl = torch::executor::TensorImpl(
       ScalarType::QInt8, 2, sizes.data(), a_data.data());

--- a/kernels/prim_ops/register_prim_ops.cpp
+++ b/kernels/prim_ops/register_prim_ops.cpp
@@ -12,7 +12,6 @@
 #include <executorch/runtime/kernel/kernel_includes.h>
 #include <executorch/runtime/kernel/operator_registry.h>
 
-using KernelArrayRef = ::torch::executor::ArrayRef<::torch::executor::Kernel>;
 using torch::executor::function::et_copy_index;
 
 namespace torch {
@@ -294,13 +293,14 @@ static Kernel prim_ops[] = {
 
 };
 
-static KernelArrayRef kernel_array_ref(
+executorch::runtime::Span<const executorch::runtime::Kernel> kernel_span(
     prim_ops,
     prim_ops + sizeof(prim_ops) / sizeof(Kernel));
 
 // Return value not used. Keep the static variable assignment to register
 // operators in static initialization time.
-static auto success_with_kernel_reg = register_kernels(kernel_array_ref);
+auto success_with_kernel_reg =
+    executorch::runtime::register_kernels(kernel_span);
 
 } // namespace
 } // namespace function

--- a/runtime/core/exec_aten/exec_aten.h
+++ b/runtime/core/exec_aten/exec_aten.h
@@ -46,9 +46,10 @@
 
 #endif
 
-namespace exec_aten {
+namespace executorch {
+namespace aten {
 
-using TensorShapeDynamism = torch::executor::TensorShapeDynamism;
+using TensorShapeDynamism = executorch::runtime::TensorShapeDynamism;
 
 #ifdef USE_ATEN_LIB
 
@@ -134,13 +135,17 @@ using OptionalArrayRef =
 
 using torch::executor::compute_numel;
 
-#endif // Use executor types
+#endif // Use ExecuTorch types
 
-} // namespace exec_aten
+} // namespace aten
+} // namespace executorch
+
+// DEPRECATED: The exec_aten:: namespace is deprecated. Use executorch::aten::
+// instead.
+namespace exec_aten = executorch::aten;
 
 namespace torch {
 namespace executor {
 using TensorList = exec_aten::TensorList;
-
 } // namespace executor
 } // namespace torch

--- a/runtime/core/exec_aten/util/scalar_type_util.h
+++ b/runtime/core/exec_aten/util/scalar_type_util.h
@@ -37,17 +37,24 @@
 // here.
 #define ET_FORALL_SCALAR_TYPES AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS
 #include <c10/core/ScalarType.h>
-namespace exec_aten {
+namespace executorch {
+namespace aten {
 using ScalarType = at::ScalarType;
-}
+} // namespace aten
+} // namespace executorch
 #else // !USE_ATEN_LIB
 #include <executorch/runtime/core/portable_type/scalar_type.h>
 #include <executorch/runtime/core/portable_type/string_view.h>
-namespace exec_aten {
+namespace executorch {
+namespace aten {
 using ScalarType = torch::executor::ScalarType;
 using string_view = torch::executor::string_view;
-} // namespace exec_aten
+} // namespace aten
+} // namespace executorch
 #endif // USE_ATEN_LIB
+// DEPRECATED: The exec_aten:: namespace is deprecated. Use executorch::aten::
+// instead.
+namespace exec_aten = ::executorch::aten;
 
 namespace executorch {
 namespace runtime {
@@ -80,13 +87,13 @@ constexpr bool is_reduced_floating_point_v =
 #endif
 
 /// Maps ScalarTypes to C++ types.
-template <exec_aten::ScalarType N>
+template <::executorch::aten::ScalarType N>
 struct ScalarTypeToCppType;
 
-#define SPECIALIZE_ScalarTypeToCppType(cpp_type, scalar_type)      \
-  template <>                                                      \
-  struct ScalarTypeToCppType<exec_aten::ScalarType::scalar_type> { \
-    using type = cpp_type;                                         \
+#define SPECIALIZE_ScalarTypeToCppType(cpp_type, scalar_type)               \
+  template <>                                                               \
+  struct ScalarTypeToCppType<::executorch::aten::ScalarType::scalar_type> { \
+    using type = cpp_type;                                                  \
   };
 
 ET_FORALL_SCALAR_TYPES(SPECIALIZE_ScalarTypeToCppType)
@@ -101,8 +108,8 @@ struct CppTypeToScalarType;
   template <>                                                 \
   struct CppTypeToScalarType<cpp_type>                        \
       : std::integral_constant<                               \
-            exec_aten::ScalarType,                            \
-            exec_aten::ScalarType::scalar_type> {};
+            ::executorch::aten::ScalarType,                   \
+            ::executorch::aten::ScalarType::scalar_type> {};
 
 ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
 
@@ -147,14 +154,14 @@ ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
   _(ANOTHER_INPUT1, ANOTHER_INPUT2, int32_t, Int)                    \
   _(ANOTHER_INPUT1, ANOTHER_INPUT2, int64_t, Long)
 
-#define ET_FORALL_INT_TYPES_AND(SCALARTYPE, _)      \
-  _(uint8_t, Byte)                                  \
-  _(int8_t, Char)                                   \
-  _(int16_t, Short)                                 \
-  _(int32_t, Int)                                   \
-  _(int64_t, Long)                                  \
-  _(::executorch::runtime::ScalarTypeToCppType<     \
-        ::exec_aten::ScalarType::SCALARTYPE>::type, \
+#define ET_FORALL_INT_TYPES_AND(SCALARTYPE, _)             \
+  _(uint8_t, Byte)                                         \
+  _(int8_t, Char)                                          \
+  _(int16_t, Short)                                        \
+  _(int32_t, Int)                                          \
+  _(int64_t, Long)                                         \
+  _(::executorch::runtime::ScalarTypeToCppType<            \
+        ::executorch::aten::ScalarType::SCALARTYPE>::type, \
     SCALARTYPE)
 
 // In this context, "FLOAT" means float C types, which is why BFloat16 is not
@@ -163,21 +170,21 @@ ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
   _(float, Float)                \
   _(double, Double)
 
-#define ET_FORALL_FLOAT_TYPES_AND(SCALARTYPE, _)    \
-  _(float, Float)                                   \
-  _(double, Double)                                 \
-  _(::executorch::runtime::ScalarTypeToCppType<     \
-        ::exec_aten::ScalarType::SCALARTYPE>::type, \
+#define ET_FORALL_FLOAT_TYPES_AND(SCALARTYPE, _)           \
+  _(float, Float)                                          \
+  _(double, Double)                                        \
+  _(::executorch::runtime::ScalarTypeToCppType<            \
+        ::executorch::aten::ScalarType::SCALARTYPE>::type, \
     SCALARTYPE)
 
 #define ET_FORALL_FLOAT_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, _) \
   _(float, Float)                                               \
   _(double, Double)                                             \
   _(::executorch::runtime::ScalarTypeToCppType<                 \
-        ::exec_aten::ScalarType::SCALARTYPE1>::type,            \
+        ::executorch::aten::ScalarType::SCALARTYPE1>::type,     \
     SCALARTYPE1)                                                \
   _(::executorch::runtime::ScalarTypeToCppType<                 \
-        ::exec_aten::ScalarType::SCALARTYPE2>::type,            \
+        ::executorch::aten::ScalarType::SCALARTYPE2>::type,     \
     SCALARTYPE2)
 
 #define ET_FORALL_FLOATH_TYPES(_) ET_FORALL_FLOAT_TYPES_AND(Half, _)
@@ -199,8 +206,8 @@ ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
 #define ET_FORALL_FLOATHBF16_TYPES_WITH2(ANOTHER_INPUT1, ANOTHER_INPUT2, _) \
   _(ANOTHER_INPUT1, ANOTHER_INPUT2, float, Float)                           \
   _(ANOTHER_INPUT1, ANOTHER_INPUT2, double, Double)                         \
-  _(ANOTHER_INPUT1, ANOTHER_INPUT2, ::exec_aten::Half, Half)                \
-  _(ANOTHER_INPUT1, ANOTHER_INPUT2, ::exec_aten::BFloat16, BFloat16)
+  _(ANOTHER_INPUT1, ANOTHER_INPUT2, ::executorch::aten::Half, Half)         \
+  _(ANOTHER_INPUT1, ANOTHER_INPUT2, ::executorch::aten::BFloat16, BFloat16)
 
 // In this context, "REAL" means integer/float C types, which is why BFloat16
 // and Half are not included.
@@ -242,21 +249,21 @@ ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
   _(ANOTHER_INPUT1, ANOTHER_INPUT2, int64_t, Long)                         \
   _(ANOTHER_INPUT1, ANOTHER_INPUT2, float, Float)                          \
   _(ANOTHER_INPUT1, ANOTHER_INPUT2, double, Double)                        \
-  _(ANOTHER_INPUT1, ANOTHER_INPUT2, exec_aten::Half, Half)                 \
-  _(ANOTHER_INPUT1, ANOTHER_INPUT2, exec_aten::BFloat16, BFloat16)
+  _(ANOTHER_INPUT1, ANOTHER_INPUT2, ::executorch::aten::Half, Half)        \
+  _(ANOTHER_INPUT1, ANOTHER_INPUT2, ::executorch::aten::BFloat16, BFloat16)
 
 // For macros that take `SCALARTYPEn` parameters, those parameters should be
 // an unquoted/unqualified enumerator name like `Int` or `Float`.
-#define ET_FORALL_REAL_TYPES_AND(SCALARTYPE, _)     \
-  _(uint8_t, Byte)                                  \
-  _(int8_t, Char)                                   \
-  _(int16_t, Short)                                 \
-  _(int32_t, Int)                                   \
-  _(int64_t, Long)                                  \
-  _(float, Float)                                   \
-  _(double, Double)                                 \
-  _(::executorch::runtime::ScalarTypeToCppType<     \
-        ::exec_aten::ScalarType::SCALARTYPE>::type, \
+#define ET_FORALL_REAL_TYPES_AND(SCALARTYPE, _)            \
+  _(uint8_t, Byte)                                         \
+  _(int8_t, Char)                                          \
+  _(int16_t, Short)                                        \
+  _(int32_t, Int)                                          \
+  _(int64_t, Long)                                         \
+  _(float, Float)                                          \
+  _(double, Double)                                        \
+  _(::executorch::runtime::ScalarTypeToCppType<            \
+        ::executorch::aten::ScalarType::SCALARTYPE>::type, \
     SCALARTYPE)
 
 #define ET_FORALL_REAL_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, _) \
@@ -268,10 +275,10 @@ ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
   _(float, Float)                                              \
   _(double, Double)                                            \
   _(::executorch::runtime::ScalarTypeToCppType<                \
-        ::exec_aten::ScalarType::SCALARTYPE1>::type,           \
+        ::executorch::aten::ScalarType::SCALARTYPE1>::type,    \
     SCALARTYPE1)                                               \
   _(::executorch::runtime::ScalarTypeToCppType<                \
-        ::exec_aten::ScalarType::SCALARTYPE2>::type,           \
+        ::executorch::aten::ScalarType::SCALARTYPE2>::type,    \
     SCALARTYPE2)
 
 #define ET_FORALL_REALH_TYPES(_) ET_FORALL_REAL_TYPES_AND(Half, _)
@@ -292,7 +299,7 @@ ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
   _(ANOTHER_INPUT, double, Double)                                  \
   _(ANOTHER_INPUT,                                                  \
     ::executorch::runtime::ScalarTypeToCppType<                     \
-        ::exec_aten::ScalarType::SCALARTYPE>::type,                 \
+        ::executorch::aten::ScalarType::SCALARTYPE>::type,          \
     SCALARTYPE)
 
 #define ET_FORALL_REAL_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, _) \
@@ -304,10 +311,10 @@ ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
   _(float, Float)                                              \
   _(double, Double)                                            \
   _(::executorch::runtime::ScalarTypeToCppType<                \
-        ::exec_aten::ScalarType::SCALARTYPE1>::type,           \
+        ::executorch::aten::ScalarType::SCALARTYPE1>::type,    \
     SCALARTYPE1)                                               \
   _(::executorch::runtime::ScalarTypeToCppType<                \
-        ::exec_aten::ScalarType::SCALARTYPE2>::type,           \
+        ::executorch::aten::ScalarType::SCALARTYPE2>::type,    \
     SCALARTYPE2)
 
 #define ET_FORALL_REAL_TYPES_AND3(SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, _) \
@@ -319,13 +326,13 @@ ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
   _(float, Float)                                                           \
   _(double, Double)                                                         \
   _(::executorch::runtime::ScalarTypeToCppType<                             \
-        ::exec_aten::ScalarType::SCALARTYPE1>::type,                        \
+        ::executorch::aten::ScalarType::SCALARTYPE1>::type,                 \
     SCALARTYPE1)                                                            \
   _(::executorch::runtime::ScalarTypeToCppType<                             \
-        ::exec_aten::ScalarType::SCALARTYPE2>::type,                        \
+        ::executorch::aten::ScalarType::SCALARTYPE2>::type,                 \
     SCALARTYPE2)                                                            \
   _(::executorch::runtime::ScalarTypeToCppType<                             \
-        ::exec_aten::ScalarType::SCALARTYPE3>::type,                        \
+        ::executorch::aten::ScalarType::SCALARTYPE3>::type,                 \
     SCALARTYPE3)
 
 #define ET_FORALL_QINT_TYPES(_)            \
@@ -349,10 +356,10 @@ ET_FORALL_SCALAR_TYPES(SPECIALIZE_CppTypeToScalarType)
  * Returns true if the parameter is one of the values covered by
  * ET_FORALL_SCALAR_TYPES.
  */
-inline bool isValid(exec_aten::ScalarType type) {
+inline bool isValid(::executorch::aten::ScalarType type) {
   return static_cast<int8_t>(type) >= 0 &&
-      type < exec_aten::ScalarType::NumOptions &&
-      type != exec_aten::ScalarType::Undefined;
+      type < ::executorch::aten::ScalarType::NumOptions &&
+      type != ::executorch::aten::ScalarType::Undefined;
 }
 
 /**
@@ -361,14 +368,14 @@ inline bool isValid(exec_aten::ScalarType type) {
  * @param[in] t The type to get the name of.
  * @return The name of the type, or "UNKNOWN_SCALAR" if the type is not known.
  */
-inline const char* toString(exec_aten::ScalarType t) {
-#define DEFINE_CASE(_, name)        \
-  case exec_aten::ScalarType::name: \
+inline const char* toString(::executorch::aten::ScalarType t) {
+#define DEFINE_CASE(_, name)                 \
+  case ::executorch::aten::ScalarType::name: \
     return #name;
 
   switch (t) {
     ET_FORALL_SCALAR_TYPES(DEFINE_CASE)
-    case exec_aten::ScalarType::Undefined:
+    case ::executorch::aten::ScalarType::Undefined:
       return "Undefined";
     default:
       return "UNKNOWN_SCALAR";
@@ -384,9 +391,9 @@ inline const char* toString(exec_aten::ScalarType t) {
  * @param[in] t The type to get the underlying C type size of.
  * @return The size of the associated C type in bytes.
  */
-inline size_t elementSize(exec_aten::ScalarType t) {
-#define CASE_ELEMENTSIZE_CASE(ctype, name) \
-  case exec_aten::ScalarType::name:        \
+inline size_t elementSize(::executorch::aten::ScalarType t) {
+#define CASE_ELEMENTSIZE_CASE(ctype, name)   \
+  case ::executorch::aten::ScalarType::name: \
     return sizeof(ctype);
 
   switch (t) {
@@ -398,12 +405,14 @@ inline size_t elementSize(exec_aten::ScalarType t) {
 }
 
 inline constexpr bool isIntegralType(
-    exec_aten::ScalarType t,
+    ::executorch::aten::ScalarType t,
     bool includeBool) {
-  return (includeBool && t == exec_aten::ScalarType::Bool) ||
-      (t == exec_aten::ScalarType::Byte || t == exec_aten::ScalarType::Char ||
-       t == exec_aten::ScalarType::Int || t == exec_aten::ScalarType::Long ||
-       t == exec_aten::ScalarType::Short);
+  return (includeBool && t == ::executorch::aten::ScalarType::Bool) ||
+      (t == ::executorch::aten::ScalarType::Byte ||
+       t == ::executorch::aten::ScalarType::Char ||
+       t == ::executorch::aten::ScalarType::Int ||
+       t == ::executorch::aten::ScalarType::Long ||
+       t == ::executorch::aten::ScalarType::Short);
 }
 
 template <typename T, bool includeBool>
@@ -412,41 +421,50 @@ struct is_integral_type
           bool,
           isIntegralType(CppTypeToScalarType<T>::value, includeBool)> {};
 
-inline constexpr bool isFloatingType(exec_aten::ScalarType t) {
+inline constexpr bool isFloatingType(::executorch::aten::ScalarType t) {
   return (
-      t == exec_aten::ScalarType::Double || t == exec_aten::ScalarType::Float ||
-      t == exec_aten::ScalarType::Half || t == exec_aten::ScalarType::BFloat16);
+      t == ::executorch::aten::ScalarType::Double ||
+      t == ::executorch::aten::ScalarType::Float ||
+      t == ::executorch::aten::ScalarType::Half ||
+      t == ::executorch::aten::ScalarType::BFloat16);
 }
 
-inline bool isRealType(exec_aten::ScalarType t) {
+inline bool isRealType(::executorch::aten::ScalarType t) {
   return (
-      t == exec_aten::ScalarType::Byte || t == exec_aten::ScalarType::Char ||
-      t == exec_aten::ScalarType::Short || t == exec_aten::ScalarType::Int ||
-      t == exec_aten::ScalarType::Long || t == exec_aten::ScalarType::Float ||
-      t == exec_aten::ScalarType::Double);
+      t == ::executorch::aten::ScalarType::Byte ||
+      t == ::executorch::aten::ScalarType::Char ||
+      t == ::executorch::aten::ScalarType::Short ||
+      t == ::executorch::aten::ScalarType::Int ||
+      t == ::executorch::aten::ScalarType::Long ||
+      t == ::executorch::aten::ScalarType::Float ||
+      t == ::executorch::aten::ScalarType::Double);
 }
 
-inline bool isRealHType(exec_aten::ScalarType t) {
+inline bool isRealHType(::executorch::aten::ScalarType t) {
   return (
-      t == exec_aten::ScalarType::Byte || t == exec_aten::ScalarType::Char ||
-      t == exec_aten::ScalarType::Short || t == exec_aten::ScalarType::Int ||
-      t == exec_aten::ScalarType::Long || t == exec_aten::ScalarType::Float ||
-      t == exec_aten::ScalarType::Double || t == exec_aten::ScalarType::Half);
+      t == ::executorch::aten::ScalarType::Byte ||
+      t == ::executorch::aten::ScalarType::Char ||
+      t == ::executorch::aten::ScalarType::Short ||
+      t == ::executorch::aten::ScalarType::Int ||
+      t == ::executorch::aten::ScalarType::Long ||
+      t == ::executorch::aten::ScalarType::Float ||
+      t == ::executorch::aten::ScalarType::Double ||
+      t == ::executorch::aten::ScalarType::Half);
 }
 
-inline bool isRealHBType(exec_aten::ScalarType t) {
-  return (isRealHType(t) || t == exec_aten::ScalarType::Bool);
+inline bool isRealHBType(::executorch::aten::ScalarType t) {
+  return (isRealHType(t) || t == ::executorch::aten::ScalarType::Bool);
 }
 
-inline bool isRealHBBF16Type(exec_aten::ScalarType t) {
-  return (isRealHBType(t) || t == exec_aten::ScalarType::BFloat16);
+inline bool isRealHBBF16Type(::executorch::aten::ScalarType t) {
+  return (isRealHBType(t) || t == ::executorch::aten::ScalarType::BFloat16);
 }
 
-inline constexpr bool isComplexType(exec_aten::ScalarType t) {
+inline constexpr bool isComplexType(::executorch::aten::ScalarType t) {
   return (
-      t == exec_aten::ScalarType::ComplexHalf ||
-      t == exec_aten::ScalarType::ComplexFloat ||
-      t == exec_aten::ScalarType::ComplexDouble);
+      t == ::executorch::aten::ScalarType::ComplexHalf ||
+      t == ::executorch::aten::ScalarType::ComplexFloat ||
+      t == ::executorch::aten::ScalarType::ComplexDouble);
 }
 
 template <typename T>
@@ -454,11 +472,12 @@ struct is_complex_type : std::integral_constant<
                              bool,
                              isComplexType(CppTypeToScalarType<T>::value)> {};
 
-constexpr bool isBitsType(exec_aten::ScalarType t) {
-  return t == exec_aten::ScalarType::Bits1x8 ||
-      t == exec_aten::ScalarType::Bits2x4 ||
-      t == exec_aten::ScalarType::Bits4x2 ||
-      t == exec_aten::ScalarType::Bits8 || t == exec_aten::ScalarType::Bits16;
+constexpr bool isBitsType(::executorch::aten::ScalarType t) {
+  return t == ::executorch::aten::ScalarType::Bits1x8 ||
+      t == ::executorch::aten::ScalarType::Bits2x4 ||
+      t == ::executorch::aten::ScalarType::Bits4x2 ||
+      t == ::executorch::aten::ScalarType::Bits8 ||
+      t == ::executorch::aten::ScalarType::Bits16;
 }
 
 template <typename T>
@@ -466,13 +485,13 @@ struct is_bits_type
     : std::integral_constant<bool, isBitsType(CppTypeToScalarType<T>::value)> {
 };
 
-constexpr bool isQIntType(exec_aten::ScalarType t) {
+constexpr bool isQIntType(::executorch::aten::ScalarType t) {
   // Don't forget to extend this when adding new QInt types
-  return t == exec_aten::ScalarType::QInt8 ||
-      t == exec_aten::ScalarType::QUInt8 ||
-      t == exec_aten::ScalarType::QInt32 ||
-      t == exec_aten::ScalarType::QUInt4x2 ||
-      t == exec_aten::ScalarType::QUInt2x4;
+  return t == ::executorch::aten::ScalarType::QInt8 ||
+      t == ::executorch::aten::ScalarType::QUInt8 ||
+      t == ::executorch::aten::ScalarType::QInt32 ||
+      t == ::executorch::aten::ScalarType::QUInt4x2 ||
+      t == ::executorch::aten::ScalarType::QUInt2x4;
 }
 
 template <typename T>
@@ -480,49 +499,51 @@ struct is_qint_type
     : std::integral_constant<bool, isQIntType(CppTypeToScalarType<T>::value)> {
 };
 
-inline exec_aten::ScalarType toQIntType(exec_aten::ScalarType t) {
+inline ::executorch::aten::ScalarType toQIntType(
+    ::executorch::aten::ScalarType t) {
   switch (t) {
-    case exec_aten::ScalarType::Byte:
-      return exec_aten::ScalarType::QUInt8;
-    case exec_aten::ScalarType::Char:
-      return exec_aten::ScalarType::QInt8;
-    case exec_aten::ScalarType::Int:
-      return exec_aten::ScalarType::QInt32;
+    case ::executorch::aten::ScalarType::Byte:
+      return ::executorch::aten::ScalarType::QUInt8;
+    case ::executorch::aten::ScalarType::Char:
+      return ::executorch::aten::ScalarType::QInt8;
+    case ::executorch::aten::ScalarType::Int:
+      return ::executorch::aten::ScalarType::QInt32;
     default:
       return t;
   }
 }
 
-inline exec_aten::ScalarType toUnderlying(exec_aten::ScalarType t) {
+inline ::executorch::aten::ScalarType toUnderlying(
+    ::executorch::aten::ScalarType t) {
   switch (t) {
-    case exec_aten::ScalarType::QUInt8:
-      return exec_aten::ScalarType::Byte;
-    case exec_aten::ScalarType::QInt8:
-      return exec_aten::ScalarType::Char;
-    case exec_aten::ScalarType::QInt32:
-      return exec_aten::ScalarType::Int;
-    case exec_aten::ScalarType::QUInt4x2:
-      return exec_aten::ScalarType::Byte;
-    case exec_aten::ScalarType::QUInt2x4:
-      return exec_aten::ScalarType::Byte;
+    case ::executorch::aten::ScalarType::QUInt8:
+      return ::executorch::aten::ScalarType::Byte;
+    case ::executorch::aten::ScalarType::QInt8:
+      return ::executorch::aten::ScalarType::Char;
+    case ::executorch::aten::ScalarType::QInt32:
+      return ::executorch::aten::ScalarType::Int;
+    case ::executorch::aten::ScalarType::QUInt4x2:
+      return ::executorch::aten::ScalarType::Byte;
+    case ::executorch::aten::ScalarType::QUInt2x4:
+      return ::executorch::aten::ScalarType::Byte;
     default:
       return t;
   }
 }
 
-inline bool isSignedType(exec_aten::ScalarType t) {
+inline bool isSignedType(::executorch::aten::ScalarType t) {
   ET_CHECK_MSG(
-      !executorch::runtime::isQIntType(t),
+      !::executorch::runtime::isQIntType(t),
       "isSignedType not supported for quantized types like %" PRId8,
       static_cast<int8_t>(t));
-#define CASE_SIGNED(ctype, name)    \
-  case exec_aten::ScalarType::name: \
+#define CASE_SIGNED(ctype, name)             \
+  case ::executorch::aten::ScalarType::name: \
     return std::numeric_limits<ctype>::is_signed;
 
   switch (t) {
-    case exec_aten::ScalarType::ComplexHalf:
-    case exec_aten::ScalarType::ComplexFloat:
-    case exec_aten::ScalarType::ComplexDouble:
+    case ::executorch::aten::ScalarType::ComplexHalf:
+    case ::executorch::aten::ScalarType::ComplexFloat:
+    case ::executorch::aten::ScalarType::ComplexDouble:
       return true;
       ET_FORALL_REAL_TYPES_AND3(Half, Bool, BFloat16, CASE_SIGNED)
     default:
@@ -532,42 +553,44 @@ inline bool isSignedType(exec_aten::ScalarType t) {
 }
 
 inline bool isUnderlying(
-    exec_aten::ScalarType type,
-    exec_aten::ScalarType qtype) {
-  return type == executorch::runtime::toUnderlying(qtype);
+    ::executorch::aten::ScalarType type,
+    ::executorch::aten::ScalarType qtype) {
+  return type == ::executorch::runtime::toUnderlying(qtype);
 }
 
-inline exec_aten::ScalarType toRealValueType(exec_aten::ScalarType t) {
+inline ::executorch::aten::ScalarType toRealValueType(
+    ::executorch::aten::ScalarType t) {
   switch (t) {
-    case exec_aten::ScalarType::ComplexHalf:
-      return exec_aten::ScalarType::Half;
-    case exec_aten::ScalarType::ComplexFloat:
-      return exec_aten::ScalarType::Float;
-    case exec_aten::ScalarType::ComplexDouble:
-      return exec_aten::ScalarType::Double;
+    case ::executorch::aten::ScalarType::ComplexHalf:
+      return ::executorch::aten::ScalarType::Half;
+    case ::executorch::aten::ScalarType::ComplexFloat:
+      return ::executorch::aten::ScalarType::Float;
+    case ::executorch::aten::ScalarType::ComplexDouble:
+      return ::executorch::aten::ScalarType::Double;
     default:
       return t;
   }
 }
 
-inline exec_aten::ScalarType toComplexType(exec_aten::ScalarType t) {
+inline ::executorch::aten::ScalarType toComplexType(
+    ::executorch::aten::ScalarType t) {
   switch (t) {
-    case exec_aten::ScalarType::BFloat16:
+    case ::executorch::aten::ScalarType::BFloat16:
       // BFloat16 has range equivalent to Float,
       // so we map it to ComplexFloat.
-      return exec_aten::ScalarType::ComplexFloat;
-    case exec_aten::ScalarType::Half:
-      return exec_aten::ScalarType::ComplexHalf;
-    case exec_aten::ScalarType::Float:
-      return exec_aten::ScalarType::ComplexFloat;
-    case exec_aten::ScalarType::Double:
-      return exec_aten::ScalarType::ComplexDouble;
-    case exec_aten::ScalarType::ComplexHalf:
-      return exec_aten::ScalarType::ComplexHalf;
-    case exec_aten::ScalarType::ComplexFloat:
-      return exec_aten::ScalarType::ComplexFloat;
-    case exec_aten::ScalarType::ComplexDouble:
-      return exec_aten::ScalarType::ComplexDouble;
+      return ::executorch::aten::ScalarType::ComplexFloat;
+    case ::executorch::aten::ScalarType::Half:
+      return ::executorch::aten::ScalarType::ComplexHalf;
+    case ::executorch::aten::ScalarType::Float:
+      return ::executorch::aten::ScalarType::ComplexFloat;
+    case ::executorch::aten::ScalarType::Double:
+      return ::executorch::aten::ScalarType::ComplexDouble;
+    case ::executorch::aten::ScalarType::ComplexHalf:
+      return ::executorch::aten::ScalarType::ComplexHalf;
+    case ::executorch::aten::ScalarType::ComplexFloat:
+      return ::executorch::aten::ScalarType::ComplexFloat;
+    case ::executorch::aten::ScalarType::ComplexDouble:
+      return ::executorch::aten::ScalarType::ComplexDouble;
     default:
       ET_CHECK_MSG(
           false,
@@ -580,17 +603,17 @@ inline exec_aten::ScalarType toComplexType(exec_aten::ScalarType t) {
  * Encodes type casting rules that are consistent with ATen behaviour.
  */
 inline constexpr bool canCast(
-    const exec_aten::ScalarType from,
-    const exec_aten::ScalarType to) {
+    const ::executorch::aten::ScalarType from,
+    const ::executorch::aten::ScalarType to) {
   // Disallow complex -> non-complex
-  return !(executorch::runtime::isComplexType(from) &&
-           !executorch::runtime::isComplexType(to)) &&
+  return !(::executorch::runtime::isComplexType(from) &&
+           !::executorch::runtime::isComplexType(to)) &&
       // Disallow float -> integral
-      !(executorch::runtime::isFloatingType(from) &&
-        executorch::runtime::isIntegralType(to, /*includeBool=*/false)) &&
+      !(::executorch::runtime::isFloatingType(from) &&
+        ::executorch::runtime::isIntegralType(to, /*includeBool=*/false)) &&
       // Treat bool as a special category. Disallow non-bool -> bool
-      !(from != exec_aten::ScalarType::Bool &&
-        to == exec_aten::ScalarType::Bool);
+      !(from != ::executorch::aten::ScalarType::Bool &&
+        to == ::executorch::aten::ScalarType::Bool);
 }
 
 template <typename T1, typename T2>
@@ -635,22 +658,32 @@ struct promote_types_lookup<T1, T1> {
   using type = T1;
 };
 
-using U1 = typename ScalarTypeToCppType<exec_aten::ScalarType::Byte>::type;
-using I1 = typename ScalarTypeToCppType<exec_aten::ScalarType::Char>::type;
-using I2 = typename ScalarTypeToCppType<exec_aten::ScalarType::Short>::type;
-using I4 = typename ScalarTypeToCppType<exec_aten::ScalarType::Int>::type;
-using I8 = typename ScalarTypeToCppType<exec_aten::ScalarType::Long>::type;
-using F2 = typename ScalarTypeToCppType<exec_aten::ScalarType::Half>::type;
-using F4 = typename ScalarTypeToCppType<exec_aten::ScalarType::Float>::type;
-using F8 = typename ScalarTypeToCppType<exec_aten::ScalarType::Double>::type;
-using C2 =
-    typename ScalarTypeToCppType<exec_aten::ScalarType::ComplexHalf>::type;
-using C4 =
-    typename ScalarTypeToCppType<exec_aten::ScalarType::ComplexFloat>::type;
-using C8 =
-    typename ScalarTypeToCppType<exec_aten::ScalarType::ComplexDouble>::type;
-using B1 = typename ScalarTypeToCppType<exec_aten::ScalarType::Bool>::type;
-using BF = typename ScalarTypeToCppType<exec_aten::ScalarType::BFloat16>::type;
+using U1 =
+    typename ScalarTypeToCppType<::executorch::aten::ScalarType::Byte>::type;
+using I1 =
+    typename ScalarTypeToCppType<::executorch::aten::ScalarType::Char>::type;
+using I2 =
+    typename ScalarTypeToCppType<::executorch::aten::ScalarType::Short>::type;
+using I4 =
+    typename ScalarTypeToCppType<::executorch::aten::ScalarType::Int>::type;
+using I8 =
+    typename ScalarTypeToCppType<::executorch::aten::ScalarType::Long>::type;
+using F2 =
+    typename ScalarTypeToCppType<::executorch::aten::ScalarType::Half>::type;
+using F4 =
+    typename ScalarTypeToCppType<::executorch::aten::ScalarType::Float>::type;
+using F8 =
+    typename ScalarTypeToCppType<::executorch::aten::ScalarType::Double>::type;
+using C2 = typename ScalarTypeToCppType<
+    ::executorch::aten::ScalarType::ComplexHalf>::type;
+using C4 = typename ScalarTypeToCppType<
+    ::executorch::aten::ScalarType::ComplexFloat>::type;
+using C8 = typename ScalarTypeToCppType<
+    ::executorch::aten::ScalarType::ComplexDouble>::type;
+using B1 =
+    typename ScalarTypeToCppType<::executorch::aten::ScalarType::Bool>::type;
+using BF = typename ScalarTypeToCppType<
+    ::executorch::aten::ScalarType::BFloat16>::type;
 
 #define TABLE_ENTRY(key1, key2, value)      \
   template <>                               \
@@ -856,12 +889,12 @@ struct promote_types {
           (std::is_same<
                promoted_type_not_respecting_half_to_float,
                typename ScalarTypeToCppType<
-                   exec_aten::ScalarType::Half>::type>::value ||
+                   ::executorch::aten::ScalarType::Half>::type>::value ||
            std::is_same<
                promoted_type_not_respecting_half_to_float,
                typename ScalarTypeToCppType<
-                   exec_aten::ScalarType::BFloat16>::type>::value),
-      typename ScalarTypeToCppType<exec_aten::ScalarType::Float>::type,
+                   ::executorch::aten::ScalarType::BFloat16>::type>::value),
+      typename ScalarTypeToCppType<::executorch::aten::ScalarType::Float>::type,
       promoted_type_not_respecting_half_to_float>::type;
 };
 
@@ -871,56 +904,57 @@ struct promote_types {
  * If half_to_float is set to true, then half and bfloat16 will be promoted to
  * float instead
  */
-inline exec_aten::ScalarType promoteTypes(
-    exec_aten::ScalarType a,
-    exec_aten::ScalarType b,
+inline ::executorch::aten::ScalarType promoteTypes(
+    ::executorch::aten::ScalarType a,
+    ::executorch::aten::ScalarType b,
     bool half_to_float = false) {
   // This is generated according to NumPy's promote_types
-  constexpr auto u1 = exec_aten::ScalarType::Byte;
-  constexpr auto i1 = exec_aten::ScalarType::Char;
-  constexpr auto i2 = exec_aten::ScalarType::Short;
-  constexpr auto i4 = exec_aten::ScalarType::Int;
-  constexpr auto i8 = exec_aten::ScalarType::Long;
-  constexpr auto f2 = exec_aten::ScalarType::Half;
-  constexpr auto f4 = exec_aten::ScalarType::Float;
-  constexpr auto f8 = exec_aten::ScalarType::Double;
-  constexpr auto c2 = exec_aten::ScalarType::ComplexHalf;
-  constexpr auto c4 = exec_aten::ScalarType::ComplexFloat;
-  constexpr auto c8 = exec_aten::ScalarType::ComplexDouble;
-  constexpr auto b1 = exec_aten::ScalarType::Bool;
-  constexpr auto bf = exec_aten::ScalarType::BFloat16;
+  constexpr auto u1 = ::executorch::aten::ScalarType::Byte;
+  constexpr auto i1 = ::executorch::aten::ScalarType::Char;
+  constexpr auto i2 = ::executorch::aten::ScalarType::Short;
+  constexpr auto i4 = ::executorch::aten::ScalarType::Int;
+  constexpr auto i8 = ::executorch::aten::ScalarType::Long;
+  constexpr auto f2 = ::executorch::aten::ScalarType::Half;
+  constexpr auto f4 = ::executorch::aten::ScalarType::Float;
+  constexpr auto f8 = ::executorch::aten::ScalarType::Double;
+  constexpr auto c2 = ::executorch::aten::ScalarType::ComplexHalf;
+  constexpr auto c4 = ::executorch::aten::ScalarType::ComplexFloat;
+  constexpr auto c8 = ::executorch::aten::ScalarType::ComplexDouble;
+  constexpr auto b1 = ::executorch::aten::ScalarType::Bool;
+  constexpr auto bf = ::executorch::aten::ScalarType::BFloat16;
 
   // For QInt types, only allow exact match
-  if (executorch::runtime::isQIntType(a) && a == b) {
+  if (::executorch::runtime::isQIntType(a) && a == b) {
     return a;
   }
-  if (executorch::runtime::isQIntType(a) ||
-      executorch::runtime::isQIntType(b)) {
+  if (::executorch::runtime::isQIntType(a) ||
+      ::executorch::runtime::isQIntType(b)) {
     ET_CHECK_MSG(false, "promoteTypes not valid for quantized dtypes");
   }
 
   // For Bits types, only allow exact match
-  if (executorch::runtime::isBitsType(a) && a == b) {
+  if (::executorch::runtime::isBitsType(a) && a == b) {
     return a;
   }
-  if (executorch::runtime::isBitsType(a) ||
-      executorch::runtime::isBitsType(b)) {
+  if (::executorch::runtime::isBitsType(a) ||
+      ::executorch::runtime::isBitsType(b)) {
     ET_CHECK_MSG(false, "promoteTypes not valid for bits dtypes");
   }
 
   // 12 types are handled by this function, see the constexpr definitions above
   const int NUM_PROMOTE_TYPES = 13;
 
-  static constexpr std::array<int, int(exec_aten::ScalarType::NumOptions)>
-      dtype2index = {{
-          0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
-          -1, -1, -1, 12, -1, -1, -1, -1, -1, -1, -1, -1,
-      }};
+  static constexpr std::
+      array<int, int(::executorch::aten::ScalarType::NumOptions)>
+          dtype2index = {{
+              0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+              -1, -1, -1, 12, -1, -1, -1, -1, -1, -1, -1, -1,
+          }};
   auto ix_a = dtype2index[(int)a];
   ET_CHECK(ix_a != -1);
   auto ix_b = dtype2index[(int)b];
   ET_CHECK(ix_b != -1);
-  static constexpr exec_aten::ScalarType
+  static constexpr ::executorch::aten::ScalarType
       _promoteTypesLookup[NUM_PROMOTE_TYPES][NUM_PROMOTE_TYPES] = {
           /*        u1  i1  i2  i4  i8  f2  f4  f8  c2  c4  c8  b1  bf*/
           /* u1 */ {u1, i2, i2, i4, i8, f2, f4, f8, c2, c4, c8, u1, bf},
@@ -938,12 +972,13 @@ inline exec_aten::ScalarType promoteTypes(
           /* bf */ {bf, bf, bf, bf, bf, f4, f4, f8, c4, c4, c8, bf, bf},
       };
 
-  exec_aten::ScalarType promoted_type = _promoteTypesLookup[ix_a][ix_b];
+  ::executorch::aten::ScalarType promoted_type =
+      _promoteTypesLookup[ix_a][ix_b];
 
   if (half_to_float &&
-      (promoted_type == exec_aten::ScalarType::Half ||
-       promoted_type == exec_aten::ScalarType::BFloat16)) {
-    promoted_type = exec_aten::ScalarType::Float;
+      (promoted_type == ::executorch::aten::ScalarType::Half ||
+       promoted_type == ::executorch::aten::ScalarType::BFloat16)) {
+    promoted_type = ::executorch::aten::ScalarType::Float;
   }
 
   return promoted_type;
@@ -989,166 +1024,168 @@ inline exec_aten::ScalarType promoteTypes(
     }                                                \
   }()
 
-#define ET_INTERNAL_SWITCH_CASE_ALL_TYPES(CTYPE_ALIAS, ...)           \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Byte, CTYPE_ALIAS, __VA_ARGS__)          \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Char, CTYPE_ALIAS, __VA_ARGS__)          \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Short, CTYPE_ALIAS, __VA_ARGS__)         \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Int, CTYPE_ALIAS, __VA_ARGS__)           \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Long, CTYPE_ALIAS, __VA_ARGS__)          \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Half, CTYPE_ALIAS, __VA_ARGS__)          \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Float, CTYPE_ALIAS, __VA_ARGS__)         \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Double, CTYPE_ALIAS, __VA_ARGS__)        \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::ComplexHalf, CTYPE_ALIAS, __VA_ARGS__)   \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::ComplexFloat, CTYPE_ALIAS, __VA_ARGS__)  \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::ComplexDouble, CTYPE_ALIAS, __VA_ARGS__) \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Bool, CTYPE_ALIAS, __VA_ARGS__)          \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::QInt8, CTYPE_ALIAS, __VA_ARGS__)         \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::QUInt8, CTYPE_ALIAS, __VA_ARGS__)        \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::QInt32, CTYPE_ALIAS, __VA_ARGS__)        \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::BFloat16, CTYPE_ALIAS, __VA_ARGS__)      \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::QUInt4x2, CTYPE_ALIAS, __VA_ARGS__)      \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::QUInt2x4, CTYPE_ALIAS, __VA_ARGS__)      \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Bits1x8, CTYPE_ALIAS, __VA_ARGS__)       \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Bits2x4, CTYPE_ALIAS, __VA_ARGS__)       \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Bits4x2, CTYPE_ALIAS, __VA_ARGS__)       \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Bits8, CTYPE_ALIAS, __VA_ARGS__)         \
-  ET_INTERNAL_SWITCH_CASE(                                            \
-      exec_aten::ScalarType::Bits16, CTYPE_ALIAS, __VA_ARGS__)
+#define ET_INTERNAL_SWITCH_CASE_ALL_TYPES(CTYPE_ALIAS, ...)                    \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Byte, CTYPE_ALIAS, __VA_ARGS__)          \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Char, CTYPE_ALIAS, __VA_ARGS__)          \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Short, CTYPE_ALIAS, __VA_ARGS__)         \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Int, CTYPE_ALIAS, __VA_ARGS__)           \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Long, CTYPE_ALIAS, __VA_ARGS__)          \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Half, CTYPE_ALIAS, __VA_ARGS__)          \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Float, CTYPE_ALIAS, __VA_ARGS__)         \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Double, CTYPE_ALIAS, __VA_ARGS__)        \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::ComplexHalf, CTYPE_ALIAS, __VA_ARGS__)   \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::ComplexFloat, CTYPE_ALIAS, __VA_ARGS__)  \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::ComplexDouble, CTYPE_ALIAS, __VA_ARGS__) \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Bool, CTYPE_ALIAS, __VA_ARGS__)          \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::QInt8, CTYPE_ALIAS, __VA_ARGS__)         \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::QUInt8, CTYPE_ALIAS, __VA_ARGS__)        \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::QInt32, CTYPE_ALIAS, __VA_ARGS__)        \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::BFloat16, CTYPE_ALIAS, __VA_ARGS__)      \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::QUInt4x2, CTYPE_ALIAS, __VA_ARGS__)      \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::QUInt2x4, CTYPE_ALIAS, __VA_ARGS__)      \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Bits1x8, CTYPE_ALIAS, __VA_ARGS__)       \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Bits2x4, CTYPE_ALIAS, __VA_ARGS__)       \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Bits4x2, CTYPE_ALIAS, __VA_ARGS__)       \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Bits8, CTYPE_ALIAS, __VA_ARGS__)         \
+  ET_INTERNAL_SWITCH_CASE(                                                     \
+      ::executorch::aten::ScalarType::Bits16, CTYPE_ALIAS, __VA_ARGS__)
 
-#define ET_INTERNAL_SWITCH_CASE_REAL_TYPES(CTYPE_ALIAS, ...)  \
-  ET_INTERNAL_SWITCH_CASE(                                    \
-      exec_aten::ScalarType::Byte, CTYPE_ALIAS, __VA_ARGS__)  \
-  ET_INTERNAL_SWITCH_CASE(                                    \
-      exec_aten::ScalarType::Char, CTYPE_ALIAS, __VA_ARGS__)  \
-  ET_INTERNAL_SWITCH_CASE(                                    \
-      exec_aten::ScalarType::Short, CTYPE_ALIAS, __VA_ARGS__) \
-  ET_INTERNAL_SWITCH_CASE(                                    \
-      exec_aten::ScalarType::Int, CTYPE_ALIAS, __VA_ARGS__)   \
-  ET_INTERNAL_SWITCH_CASE(                                    \
-      exec_aten::ScalarType::Long, CTYPE_ALIAS, __VA_ARGS__)  \
-  ET_INTERNAL_SWITCH_CASE(                                    \
-      exec_aten::ScalarType::Float, CTYPE_ALIAS, __VA_ARGS__) \
-  ET_INTERNAL_SWITCH_CASE(                                    \
-      exec_aten::ScalarType::Double, CTYPE_ALIAS, __VA_ARGS__)
+#define ET_INTERNAL_SWITCH_CASE_REAL_TYPES(CTYPE_ALIAS, ...)           \
+  ET_INTERNAL_SWITCH_CASE(                                             \
+      ::executorch::aten::ScalarType::Byte, CTYPE_ALIAS, __VA_ARGS__)  \
+  ET_INTERNAL_SWITCH_CASE(                                             \
+      ::executorch::aten::ScalarType::Char, CTYPE_ALIAS, __VA_ARGS__)  \
+  ET_INTERNAL_SWITCH_CASE(                                             \
+      ::executorch::aten::ScalarType::Short, CTYPE_ALIAS, __VA_ARGS__) \
+  ET_INTERNAL_SWITCH_CASE(                                             \
+      ::executorch::aten::ScalarType::Int, CTYPE_ALIAS, __VA_ARGS__)   \
+  ET_INTERNAL_SWITCH_CASE(                                             \
+      ::executorch::aten::ScalarType::Long, CTYPE_ALIAS, __VA_ARGS__)  \
+  ET_INTERNAL_SWITCH_CASE(                                             \
+      ::executorch::aten::ScalarType::Float, CTYPE_ALIAS, __VA_ARGS__) \
+  ET_INTERNAL_SWITCH_CASE(                                             \
+      ::executorch::aten::ScalarType::Double, CTYPE_ALIAS, __VA_ARGS__)
 
 #define ET_INTERNAL_SWITCH_CASE_REAL_TYPES_AND(ADDITIONAL, CTYPE_ALIAS, ...) \
   ET_INTERNAL_SWITCH_CASE_REAL_TYPES(CTYPE_ALIAS, __VA_ARGS__)               \
   ET_INTERNAL_SWITCH_CASE(                                                   \
-      exec_aten::ScalarType::ADDITIONAL, CTYPE_ALIAS, __VA_ARGS__)
+      ::executorch::aten::ScalarType::ADDITIONAL, CTYPE_ALIAS, __VA_ARGS__)
 
-#define ET_INTERNAL_SWITCH_CASE_REAL_TYPES_AND2(                    \
-    ADDITIONAL1, ADDITIONAL2, CTYPE_ALIAS, ...)                     \
-  ET_INTERNAL_SWITCH_CASE_REAL_TYPES(CTYPE_ALIAS, __VA_ARGS__)      \
-  ET_INTERNAL_SWITCH_CASE(                                          \
-      exec_aten::ScalarType::ADDITIONAL1, CTYPE_ALIAS, __VA_ARGS__) \
-  ET_INTERNAL_SWITCH_CASE(                                          \
-      exec_aten::ScalarType::ADDITIONAL2, CTYPE_ALIAS, __VA_ARGS__)
+#define ET_INTERNAL_SWITCH_CASE_REAL_TYPES_AND2(                             \
+    ADDITIONAL1, ADDITIONAL2, CTYPE_ALIAS, ...)                              \
+  ET_INTERNAL_SWITCH_CASE_REAL_TYPES(CTYPE_ALIAS, __VA_ARGS__)               \
+  ET_INTERNAL_SWITCH_CASE(                                                   \
+      ::executorch::aten::ScalarType::ADDITIONAL1, CTYPE_ALIAS, __VA_ARGS__) \
+  ET_INTERNAL_SWITCH_CASE(                                                   \
+      ::executorch::aten::ScalarType::ADDITIONAL2, CTYPE_ALIAS, __VA_ARGS__)
 
 #define ET_INTERNAL_SWITCH_CASE_REAL_TYPES_AND3(             \
     ADDITIONAL1, ADDITIONAL2, ADDITIONAL3, CTYPE_ALIAS, ...) \
   ET_INTERNAL_SWITCH_CASE_REAL_TYPES_AND2(                   \
       ADDITIONAL1, ADDITIONAL2, CTYPE_ALIAS, __VA_ARGS__)    \
   ET_INTERNAL_SWITCH_CASE(                                   \
-      exec_aten::ScalarType::ADDITIONAL3, CTYPE_ALIAS, __VA_ARGS__)
+      ::executorch::aten::ScalarType::ADDITIONAL3, CTYPE_ALIAS, __VA_ARGS__)
 
-#define ET_INTERNAL_SWITCH_CASE_INT_TYPES(CTYPE_ALIAS, ...)   \
-  ET_INTERNAL_SWITCH_CASE(                                    \
-      exec_aten::ScalarType::Byte, CTYPE_ALIAS, __VA_ARGS__)  \
-  ET_INTERNAL_SWITCH_CASE(                                    \
-      exec_aten::ScalarType::Char, CTYPE_ALIAS, __VA_ARGS__)  \
-  ET_INTERNAL_SWITCH_CASE(                                    \
-      exec_aten::ScalarType::Short, CTYPE_ALIAS, __VA_ARGS__) \
-  ET_INTERNAL_SWITCH_CASE(                                    \
-      exec_aten::ScalarType::Int, CTYPE_ALIAS, __VA_ARGS__)   \
-  ET_INTERNAL_SWITCH_CASE(exec_aten::ScalarType::Long, CTYPE_ALIAS, __VA_ARGS__)
+#define ET_INTERNAL_SWITCH_CASE_INT_TYPES(CTYPE_ALIAS, ...)            \
+  ET_INTERNAL_SWITCH_CASE(                                             \
+      ::executorch::aten::ScalarType::Byte, CTYPE_ALIAS, __VA_ARGS__)  \
+  ET_INTERNAL_SWITCH_CASE(                                             \
+      ::executorch::aten::ScalarType::Char, CTYPE_ALIAS, __VA_ARGS__)  \
+  ET_INTERNAL_SWITCH_CASE(                                             \
+      ::executorch::aten::ScalarType::Short, CTYPE_ALIAS, __VA_ARGS__) \
+  ET_INTERNAL_SWITCH_CASE(                                             \
+      ::executorch::aten::ScalarType::Int, CTYPE_ALIAS, __VA_ARGS__)   \
+  ET_INTERNAL_SWITCH_CASE(                                             \
+      ::executorch::aten::ScalarType::Long, CTYPE_ALIAS, __VA_ARGS__)
 
 #define ET_INTERNAL_SWITCH_CASE_INT_TYPES_AND(ADDITIONAL, CTYPE_ALIAS, ...) \
   ET_INTERNAL_SWITCH_CASE_INT_TYPES(CTYPE_ALIAS, __VA_ARGS__)               \
   ET_INTERNAL_SWITCH_CASE(                                                  \
-      exec_aten::ScalarType::ADDITIONAL, CTYPE_ALIAS, __VA_ARGS__)
+      ::executorch::aten::ScalarType::ADDITIONAL, CTYPE_ALIAS, __VA_ARGS__)
 
-#define ET_INTERNAL_SWITCH_CASE_FLOAT_TYPES(CTYPE_ALIAS, ...)  \
-  ET_INTERNAL_SWITCH_CASE(                                     \
-      exec_aten::ScalarType::Double, CTYPE_ALIAS, __VA_ARGS__) \
-  ET_INTERNAL_SWITCH_CASE(                                     \
-      exec_aten::ScalarType::Float, CTYPE_ALIAS, __VA_ARGS__)
+#define ET_INTERNAL_SWITCH_CASE_FLOAT_TYPES(CTYPE_ALIAS, ...)           \
+  ET_INTERNAL_SWITCH_CASE(                                              \
+      ::executorch::aten::ScalarType::Double, CTYPE_ALIAS, __VA_ARGS__) \
+  ET_INTERNAL_SWITCH_CASE(                                              \
+      ::executorch::aten::ScalarType::Float, CTYPE_ALIAS, __VA_ARGS__)
 
 #define ET_INTERNAL_SWITCH_CASE_FLOAT_TYPES_AND(ADDITIONAL, CTYPE_ALIAS, ...) \
   ET_INTERNAL_SWITCH_CASE_FLOAT_TYPES(CTYPE_ALIAS, __VA_ARGS__)               \
   ET_INTERNAL_SWITCH_CASE(                                                    \
-      exec_aten::ScalarType::ADDITIONAL, CTYPE_ALIAS, __VA_ARGS__)
+      ::executorch::aten::ScalarType::ADDITIONAL, CTYPE_ALIAS, __VA_ARGS__)
 
 #define ET_INTERNAL_SWITCH_CASE_FLOAT_TYPES_AND2( \
     ADDITIONAL1, ADDITIONAL2, CTYPE_ALIAS, ...)   \
   ET_INTERNAL_SWITCH_CASE_FLOAT_TYPES_AND(        \
       ADDITIONAL1, CTYPE_ALIAS, __VA_ARGS__)      \
   ET_INTERNAL_SWITCH_CASE(                        \
-      exec_aten::ScalarType::ADDITIONAL2, CTYPE_ALIAS, __VA_ARGS__)
+      ::executorch::aten::ScalarType::ADDITIONAL2, CTYPE_ALIAS, __VA_ARGS__)
 
-#define ET_INTERNAL_SWITCH_CASE_QINT_TYPES(CTYPE_ALIAS, ...)     \
-  ET_INTERNAL_SWITCH_CASE(                                       \
-      exec_aten::ScalarType::QInt8, CTYPE_ALIAS, __VA_ARGS__)    \
-  ET_INTERNAL_SWITCH_CASE(                                       \
-      exec_aten::ScalarType::QUInt8, CTYPE_ALIAS, __VA_ARGS__)   \
-  ET_INTERNAL_SWITCH_CASE(                                       \
-      exec_aten::ScalarType::QInt32, CTYPE_ALIAS, __VA_ARGS__)   \
-  ET_INTERNAL_SWITCH_CASE(                                       \
-      exec_aten::ScalarType::QUInt4x2, CTYPE_ALIAS, __VA_ARGS__) \
-  ET_INTERNAL_SWITCH_CASE(                                       \
-      exec_aten::ScalarType::QUInt2x4, CTYPE_ALIAS, __VA_ARGS__)
+#define ET_INTERNAL_SWITCH_CASE_QINT_TYPES(CTYPE_ALIAS, ...)              \
+  ET_INTERNAL_SWITCH_CASE(                                                \
+      ::executorch::aten::ScalarType::QInt8, CTYPE_ALIAS, __VA_ARGS__)    \
+  ET_INTERNAL_SWITCH_CASE(                                                \
+      ::executorch::aten::ScalarType::QUInt8, CTYPE_ALIAS, __VA_ARGS__)   \
+  ET_INTERNAL_SWITCH_CASE(                                                \
+      ::executorch::aten::ScalarType::QInt32, CTYPE_ALIAS, __VA_ARGS__)   \
+  ET_INTERNAL_SWITCH_CASE(                                                \
+      ::executorch::aten::ScalarType::QUInt4x2, CTYPE_ALIAS, __VA_ARGS__) \
+  ET_INTERNAL_SWITCH_CASE(                                                \
+      ::executorch::aten::ScalarType::QUInt2x4, CTYPE_ALIAS, __VA_ARGS__)
 
-#define ET_INTERNAL_SWITCH_CASE_COMPLEX_TYPES(CTYPE_ALIAS, ...)      \
-  ET_INTERNAL_SWITCH_CASE(                                           \
-      exec_aten::ScalarType::ComplexFloat, CTYPE_ALIAS, __VA_ARGS__) \
-  ET_INTERNAL_SWITCH_CASE(                                           \
-      exec_aten::ScalarType::ComplexDouble, CTYPE_ALIAS, __VA_ARGS__)
+#define ET_INTERNAL_SWITCH_CASE_COMPLEX_TYPES(CTYPE_ALIAS, ...)               \
+  ET_INTERNAL_SWITCH_CASE(                                                    \
+      ::executorch::aten::ScalarType::ComplexFloat, CTYPE_ALIAS, __VA_ARGS__) \
+  ET_INTERNAL_SWITCH_CASE(                                                    \
+      ::executorch::aten::ScalarType::ComplexDouble, CTYPE_ALIAS, __VA_ARGS__)
 
-#define ET_INTERNAL_SWITCH_CASE_SCALAR_OBJ_TYPES(CTYPE_ALIAS, ...) \
-  ET_INTERNAL_SWITCH_CASE(                                         \
-      exec_aten::ScalarType::Bool, CTYPE_ALIAS, __VA_ARGS__)       \
-  ET_INTERNAL_SWITCH_CASE(                                         \
-      exec_aten::ScalarType::Long, CTYPE_ALIAS, __VA_ARGS__)       \
-  ET_INTERNAL_SWITCH_CASE(                                         \
-      exec_aten::ScalarType::Double, CTYPE_ALIAS, __VA_ARGS__)
+#define ET_INTERNAL_SWITCH_CASE_SCALAR_OBJ_TYPES(CTYPE_ALIAS, ...)    \
+  ET_INTERNAL_SWITCH_CASE(                                            \
+      ::executorch::aten::ScalarType::Bool, CTYPE_ALIAS, __VA_ARGS__) \
+  ET_INTERNAL_SWITCH_CASE(                                            \
+      ::executorch::aten::ScalarType::Long, CTYPE_ALIAS, __VA_ARGS__) \
+  ET_INTERNAL_SWITCH_CASE(                                            \
+      ::executorch::aten::ScalarType::Double, CTYPE_ALIAS, __VA_ARGS__)
 
 #define ET_INTERNAL_SWITCH_CASE_SCALAR_OBJ_REAL_TYPES(CTYPE_ALIAS, ...) \
   ET_INTERNAL_SWITCH_CASE(                                              \
-      exec_aten::ScalarType::Long, CTYPE_ALIAS, __VA_ARGS__)            \
+      ::executorch::aten::ScalarType::Long, CTYPE_ALIAS, __VA_ARGS__)   \
   ET_INTERNAL_SWITCH_CASE(                                              \
-      exec_aten::ScalarType::Double, CTYPE_ALIAS, __VA_ARGS__)
+      ::executorch::aten::ScalarType::Double, CTYPE_ALIAS, __VA_ARGS__)
 
 #define ET_INTERNAL_SWITCH_CASE_SCALAR_OBJ_INTB_TYPES(CTYPE_ALIAS, ...) \
   ET_INTERNAL_SWITCH_CASE(                                              \
-      exec_aten::ScalarType::Bool, CTYPE_ALIAS, __VA_ARGS__)            \
-  ET_INTERNAL_SWITCH_CASE(exec_aten::ScalarType::Long, CTYPE_ALIAS, __VA_ARGS__)
+      ::executorch::aten::ScalarType::Bool, CTYPE_ALIAS, __VA_ARGS__)   \
+  ET_INTERNAL_SWITCH_CASE(                                              \
+      ::executorch::aten::ScalarType::Long, CTYPE_ALIAS, __VA_ARGS__)
 
 #define ET_INTERNAL_SWITCH_CASE_SCALAR_OBJ_FLOATB_TYPES(CTYPE_ALIAS, ...) \
   ET_INTERNAL_SWITCH_CASE(                                                \
-      exec_aten::ScalarType::Bool, CTYPE_ALIAS, __VA_ARGS__)              \
+      ::executorch::aten::ScalarType::Bool, CTYPE_ALIAS, __VA_ARGS__)     \
   ET_INTERNAL_SWITCH_CASE(                                                \
-      exec_aten::ScalarType::Double, CTYPE_ALIAS, __VA_ARGS__)
+      ::executorch::aten::ScalarType::Double, CTYPE_ALIAS, __VA_ARGS__)
 
 //
 // Switch case macros
@@ -1346,33 +1383,37 @@ inline exec_aten::ScalarType promoteTypes(
       CONTEXT,                                                             \
       NAME,                                                                \
       ET_INTERNAL_SWITCH_CASE(                                             \
-          exec_aten::ScalarType::T1, CTYPE_ALIAS, __VA_ARGS__)             \
+          ::executorch::aten::ScalarType::T1, CTYPE_ALIAS, __VA_ARGS__)    \
           ET_INTERNAL_SWITCH_CASE(                                         \
-              exec_aten::ScalarType::T2, CTYPE_ALIAS, __VA_ARGS__))
+              ::executorch::aten::ScalarType::T2, CTYPE_ALIAS, __VA_ARGS__))
 
-#define ET_SWITCH_THREE_TYPES(                                     \
-    T1, T2, T3, TYPE, CONTEXT, NAME, CTYPE_ALIAS, ...)             \
-  ET_INTERNAL_SWITCH(                                              \
-      TYPE,                                                        \
-      CONTEXT,                                                     \
-      NAME,                                                        \
-      ET_INTERNAL_SWITCH_CASE(                                     \
-          exec_aten::ScalarType::T1, CTYPE_ALIAS, __VA_ARGS__)     \
-          ET_INTERNAL_SWITCH_CASE(                                 \
-              exec_aten::ScalarType::T2, CTYPE_ALIAS, __VA_ARGS__) \
-              ET_INTERNAL_SWITCH_CASE(                             \
-                  exec_aten::ScalarType::T3, CTYPE_ALIAS, __VA_ARGS__))
+#define ET_SWITCH_THREE_TYPES(                                              \
+    T1, T2, T3, TYPE, CONTEXT, NAME, CTYPE_ALIAS, ...)                      \
+  ET_INTERNAL_SWITCH(                                                       \
+      TYPE,                                                                 \
+      CONTEXT,                                                              \
+      NAME,                                                                 \
+      ET_INTERNAL_SWITCH_CASE(                                              \
+          ::executorch::aten::ScalarType::T1, CTYPE_ALIAS, __VA_ARGS__)     \
+          ET_INTERNAL_SWITCH_CASE(                                          \
+              ::executorch::aten::ScalarType::T2, CTYPE_ALIAS, __VA_ARGS__) \
+              ET_INTERNAL_SWITCH_CASE(                                      \
+                  ::executorch::aten::ScalarType::T3,                       \
+                  CTYPE_ALIAS,                                              \
+                  __VA_ARGS__))
 
 } // namespace runtime
 } // namespace executorch
 
-namespace exec_aten {
+namespace executorch {
+namespace aten {
 #ifdef USE_ATEN_LIB
 using ::at::elementSize;
 #else // USE_ATEN_LIB
 using ::executorch::runtime::elementSize;
 #endif // USE_ATEN_LIB
-} // namespace exec_aten
+} // namespace aten
+} // namespace executorch
 
 namespace torch {
 namespace executor {

--- a/runtime/kernel/kernel_runtime_context.h
+++ b/runtime/kernel/kernel_runtime_context.h
@@ -110,21 +110,22 @@ class KernelRuntimeContext {
 } // namespace runtime
 } // namespace executorch
 
-namespace torch {
-namespace executor {
 // TODO(T197294990): Remove these deprecated aliases once all users have moved
 // to the new `::executorch` namespaces.
-using ::executorch::runtime::KernelRuntimeContext;
-} // namespace executor
-} // namespace torch
-
-// TODO(T147221312): Remove these aliases once all code uses
-// KernelRuntimeContext.
-namespace exec_aten {
-using RuntimeContext = ::executorch::runtime::KernelRuntimeContext;
-} // namespace exec_aten
 namespace torch {
 namespace executor {
+/// DEPRECATED: Use ::executorch::runtime::KernelRuntimeContext instead.
+using ::executorch::runtime::KernelRuntimeContext;
+/// DEPRECATED: Use ::executorch::runtime::KernelRuntimeContext instead.
 using RuntimeContext = ::executorch::runtime::KernelRuntimeContext;
 } // namespace executor
 } // namespace torch
+namespace executorch {
+namespace aten {
+/// DEPRECATED: Use ::executorch::runtime::KernelRuntimeContext instead.
+using RuntimeContext = ::executorch::runtime::KernelRuntimeContext;
+} // namespace aten
+} // namespace executorch
+// DEPRECATED: The exec_aten:: namespace is deprecated. Use executorch::aten::
+// instead.
+namespace exec_aten = ::executorch::aten;


### PR DESCRIPTION
Summary: Modify any files that declare a `namespace exec_aten` to use the new `executorch::aten` namespace, and add an alias for the old namespace. Migration of users will happen in later diffs.

Differential Revision: D62528437
