### PR TITLE
Fix Hard Fault in arm_executor_runner

### DIFF
--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -52,6 +52,11 @@ unsigned char __attribute__((
     section("network_model_sec"),
     aligned(16))) method_allocation_pool[METHOD_ALLOCATOR_POOL_SIZE];
 
+const size_t temp_allocation_pool_size = 1 * 1024 * 1024;
+unsigned char __attribute__((
+    section("network_model_sec"),
+    aligned(16))) temp_allocation_pool[temp_allocation_pool_size];
+
 void et_pal_init(void) {}
 
 ET_NORETURN void et_pal_abort(void) {
@@ -323,8 +328,11 @@ int main(int argc, const char* argv[]) {
   torch::executor::HierarchicalAllocator planned_memory(
       {planned_spans.data(), planned_spans.size()});
 
+  torch::executor::MemoryAllocator temp_allocator(
+      temp_allocation_pool_size, temp_allocation_pool);
+
   torch::executor::MemoryManager memory_manager(
-      &method_allocator, &planned_memory);
+      &method_allocator, &planned_memory, &temp_allocator);
 
   Result<torch::executor::Method> method =
       program->load_method(method_name, &memory_manager);


### PR DESCRIPTION
The introduction of the PlatformMemoryAllocator in https://github.com/pytorch/executorch/pull/5121 introduced a hard fault in arm_executor_runner when not supplying the temp_allocator in the MemoryManager, so add it to get tests running again.


Change-Id: I357244a15c1b1fdee567ad828e09e3607e43e2e7