### PR TITLE
Standardize backend target names

### DIFF
--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -112,34 +112,36 @@ set(PROTOBUF_SOURCES
 )
 
 # Define the delegate library
-add_library(coremldelegate)
+add_library(coreml_backend)
+# Preserve old name for backwards compatability
+add_library(coremldelegate ALIAS coreml_backend)
 target_sources(
-  coremldelegate PRIVATE ${INMEMORYFS_SOURCES} ${KVSTORE_SOURCES}
+  coreml_backend PRIVATE ${INMEMORYFS_SOURCES} ${KVSTORE_SOURCES}
                          ${DELEGATE_SOURCES} ${UTIL_SOURCES}
 )
 
 target_include_directories(
-  coremldelegate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/include
+  coreml_backend PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/include
 )
 target_include_directories(
-  coremldelegate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/kvstore
+  coreml_backend PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/kvstore
 )
 target_include_directories(
-  coremldelegate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/inmemoryfs
+  coreml_backend PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/inmemoryfs
 )
 target_include_directories(
-  coremldelegate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/delegate
+  coreml_backend PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/delegate
 )
 target_include_directories(
-  coremldelegate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/util
+  coreml_backend PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/util
 )
-target_include_directories(coremldelegate PRIVATE ${EXECUTORCH_ROOT}/..)
-target_link_libraries(coremldelegate PRIVATE executorch_core)
+target_include_directories(coreml_backend PRIVATE ${EXECUTORCH_ROOT}/..)
+target_link_libraries(coreml_backend PRIVATE executorch_core)
 
 if(EXECUTORCH_BUILD_DEVTOOLS)
-  target_sources(coremldelegate PRIVATE ${SDK_SOURCES} ${PROTOBUF_SOURCES})
+  target_sources(coreml_backend PRIVATE ${SDK_SOURCES} ${PROTOBUF_SOURCES})
   target_include_directories(
-    coremldelegate
+    coreml_backend
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/runtime/sdk
       ${CMAKE_CURRENT_SOURCE_DIR}/third-party/coremltools/deps/protobuf/src
@@ -149,7 +151,7 @@ if(EXECUTORCH_BUILD_DEVTOOLS)
   )
 
   target_link_options_shared_lib(libprotobuf-lite)
-  target_link_libraries(coremldelegate PRIVATE libprotobuf-lite)
+  target_link_libraries(coreml_backend PRIVATE libprotobuf-lite)
 endif()
 
 find_library(ACCELERATE_FRAMEWORK Accelerate)
@@ -158,46 +160,46 @@ find_library(FOUNDATION_FRAMEWORK Foundation)
 find_library(SQLITE_LIBRARY sqlite3)
 
 target_link_libraries(
-  coremldelegate
+  coreml_backend
   PRIVATE executorch_core ${ACCELERATE_FRAMEWORK} ${COREML_FRAMEWORK}
           ${FOUNDATION_FRAMEWORK} ${SQLITE_LIBRARY}
 )
 
-target_link_options_shared_lib(coremldelegate)
+target_link_options_shared_lib(coreml_backend)
 
 if(COREML_BUILD_EXECUTOR_RUNNER)
   target_link_libraries(
-    coremldelegate PRIVATE portable_ops_lib portable_kernels
+    coreml_backend PRIVATE portable_ops_lib portable_kernels
   )
 endif()
 
-target_compile_options(coremldelegate PRIVATE "-fobjc-arc")
-target_compile_options(coremldelegate PRIVATE "-fno-exceptions")
+target_compile_options(coreml_backend PRIVATE "-fobjc-arc")
+target_compile_options(coreml_backend PRIVATE "-fno-exceptions")
 
 if(EXECUTORCH_BUILD_DEVTOOLS)
   target_compile_options(
     executorch_core PUBLIC -DET_EVENT_TRACER_ENABLED
   )
-  target_compile_options(coremldelegate PRIVATE "-frtti")
+  target_compile_options(coreml_backend PRIVATE "-frtti")
   target_compile_options(libprotobuf-lite PRIVATE "-frtti")
 else()
-  target_compile_options(coremldelegate PRIVATE "-fno-rtti")
+  target_compile_options(coreml_backend PRIVATE "-fno-rtti")
 endif()
 
-set(TARGET coremldelegate APPEND_STRING PROPERTY COMPILE_FLAGS
+set(TARGET coreml_backend APPEND_STRING PROPERTY COMPILE_FLAGS
            "-x objective-c++"
 )
 
-set(TARGET coremldelegate APPEND_STRING PROPERTY COMPILE_FLAGS
+set(TARGET coreml_backend APPEND_STRING PROPERTY COMPILE_FLAGS
            "-Wno-null-character"
 )
 
-set(TARGET coremldelegate APPEND_STRING PROPERTY COMPILE_FLAGS
+set(TARGET coreml_backend APPEND_STRING PROPERTY COMPILE_FLAGS
            "-Wno-receiver-expr"
 )
 
 install(
-  TARGETS coremldelegate
+  TARGETS coreml_backend
   DESTINATION lib
   INCLUDES
   DESTINATION ${_common_include_directories}

--- a/backends/apple/coreml/README.md
+++ b/backends/apple/coreml/README.md
@@ -119,9 +119,9 @@ The `converted_graph` is the quantized torch model, and can be delegated to **Co
 
 ## Runtime
 
-To execute a Core ML delegated program, the application must link to the `coremldelegate` library. Once linked there are no additional steps required, ExecuTorch when running the program would call the Core ML runtime to execute the Core ML delegated part of the program.
+To execute a Core ML delegated program, the application must link to the `coreml_backend` library. Once linked there are no additional steps required, ExecuTorch when running the program would call the Core ML runtime to execute the Core ML delegated part of the program.
 
-Please follow the instructions described in the [Core ML setup](/backends/apple/coreml/setup.md) to link the `coremldelegate` library.
+Please follow the instructions described in the [Core ML setup](/backends/apple/coreml/setup.md) to link the `coreml_backend` library.
 
 ## Help & Improvements
 If you have problems or questions or have suggestions for ways to make

--- a/backends/apple/mps/CMakeLists.txt
+++ b/backends/apple/mps/CMakeLists.txt
@@ -64,7 +64,8 @@ target_include_directories(
 )
 
 list(TRANSFORM _mps_backend__srcs PREPEND "${EXECUTORCH_ROOT}/")
-add_library(mpsdelegate ${_mps_backend__srcs})
+add_library(mps_backend ${_mps_backend__srcs})
+add_library(mpsdelegate ALIAS mps_backend)
 
 find_library(FOUNDATION_FRAMEWORK Foundation)
 find_library(METAL_FRAMEWORK Metal)
@@ -72,7 +73,7 @@ find_library(MPS_FRAMEWORK MetalPerformanceShaders)
 find_library(MPS_GRAPH_FRAMEWORK MetalPerformanceShadersGraph)
 
 target_link_libraries(
-  mpsdelegate
+  mps_backend
   PRIVATE bundled_program
           mps_schema
           executorch_core
@@ -82,12 +83,12 @@ target_link_libraries(
           ${MPS_GRAPH_FRAMEWORK}
 )
 
-target_link_options_shared_lib(mpsdelegate)
-target_compile_options(mpsdelegate PUBLIC ${_common_compile_options})
-target_compile_options(mpsdelegate PRIVATE "-fno-objc-arc")
+target_link_options_shared_lib(mps_backend)
+target_compile_options(mps_backend PUBLIC ${_common_compile_options})
+target_compile_options(mps_backend PRIVATE "-fno-objc-arc")
 
 install(
-  TARGETS mpsdelegate
+  TARGETS mps_backend
   DESTINATION lib
   INCLUDES
   DESTINATION ${_common_include_directories}

--- a/backends/arm/CMakeLists.txt
+++ b/backends/arm/CMakeLists.txt
@@ -26,10 +26,11 @@ set(_arm_baremetal_sources backends/arm/runtime/ArmBackendEthosU.cpp
 )
 list(TRANSFORM _arm_baremetal_sources PREPEND "${EXECUTORCH_ROOT}/")
 
-add_library(executorch_delegate_ethos_u STATIC ${_arm_baremetal_sources})
+add_library(ethos_u_backend STATIC ${_arm_baremetal_sources})
+add_library(executorch_delegate_ethos_u ALIAS ethos_u_backend)
 target_include_directories(
-  executorch_delegate_ethos_u PUBLIC ${_common_include_directories}
+  ethos_u_backend PUBLIC ${_common_include_directories}
 )
 target_include_directories(
-  executorch_delegate_ethos_u PUBLIC ${DRIVER_ETHOSU_INCLUDE_DIR}
+  ethos_u_backend PUBLIC ${DRIVER_ETHOSU_INCLUDE_DIR}
 )

--- a/build/build_apple_frameworks.sh
+++ b/build/build_apple_frameworks.sh
@@ -37,11 +37,11 @@ libextension_tensor.a,\
 :$HEADERS_PATH"
 
 FRAMEWORK_BACKEND_COREML="backend_coreml:\
-libcoremldelegate.a,\
+libcoreml_backend.a,\
 :"
 
 FRAMEWORK_BACKEND_MPS="backend_mps:\
-libmpsdelegate.a,\
+libmps_backend.a,\
 :"
 
 FRAMEWORK_BACKEND_XNNPACK="backend_xnnpack:\

--- a/build/executorch-config.cmake
+++ b/build/executorch-config.cmake
@@ -39,8 +39,8 @@ set(lib_list
     bundled_program
     extension_data_loader
     ${FLATCCRT_LIB}
-    coremldelegate
-    mpsdelegate
+    coreml_backend
+    mps_backend
     qnn_executorch_backend
     portable_ops_lib
     extension_module
@@ -87,3 +87,9 @@ foreach(lib ${lib_list})
     target_include_directories(${lib} INTERFACE ${_root})
   endif()
 endforeach()
+
+# Legacy target names.
+add_library(executorch_no_prim_ops ALIAS executorch_core)
+add_library(coremldelegate ALIAS coreml_backend)
+add_library(mpsdelegate ALIAS mps_backend)
+

--- a/build/executorch-config.cmake
+++ b/build/executorch-config.cmake
@@ -90,6 +90,9 @@ endforeach()
 
 # Legacy target names.
 add_library(executorch_no_prim_ops ALIAS executorch_core)
-add_library(coremldelegate ALIAS coreml_backend)
-add_library(mpsdelegate ALIAS mps_backend)
-
+if(TARGET coreml_backend)
+  add_library(coremldelegate ALIAS coreml_backend)
+endif()
+if(TARGET mps_backend)
+  add_library(mpsdelegate ALIAS mps_backend)
+endif()

--- a/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.pbxproj
+++ b/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		C94D51622ACFCBBA00AF47FD /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51612ACFCBBA00AF47FD /* libsqlite3.tbd */; };
 		C94D51642ACFCBC500AF47FD /* CoreML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51632ACFCBC500AF47FD /* CoreML.framework */; };
 		C94D51662ACFCBCB00AF47FD /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51652ACFCBCB00AF47FD /* Accelerate.framework */; };
-		C94D51682ACFCC7100AF47FD /* libcoremldelegate.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51672ACFCC7100AF47FD /* libcoremldelegate.a */; };
+		C94D51682ACFCC7100AF47FD /* libcoreml_backend.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C94D51672ACFCC7100AF47FD /* libcoreml_backend.a */; };
 		C97BFFA42BC0C17300F55BAC /* libportable_kernels.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C97BFFA32BC0C17300F55BAC /* libportable_kernels.a */; };
 		C97BFFA62BC0C1F200F55BAC /* libportable_ops_lib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C97BFFA52BC0C1F200F55BAC /* libportable_ops_lib.a */; };
 		C988D69D2B998CDE00979CF6 /* libprotobuf-lite.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C988D69C2B998CD700979CF6 /* libprotobuf-lite.a */; };
@@ -42,7 +42,7 @@
 		C94D51612ACFCBBA00AF47FD /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		C94D51632ACFCBC500AF47FD /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = System/Library/Frameworks/CoreML.framework; sourceTree = SDKROOT; };
 		C94D51652ACFCBCB00AF47FD /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
-		C94D51672ACFCC7100AF47FD /* libcoremldelegate.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcoremldelegate.a; path = libraries/libcoremldelegate.a; sourceTree = "<group>"; };
+		C94D51672ACFCC7100AF47FD /* libcoreml_backend.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcoreml_backend.a; path = libraries/libcoreml_backend.a; sourceTree = "<group>"; };
 		C97BFFA32BC0C17300F55BAC /* libportable_kernels.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libportable_kernels.a; path = libraries/libportable_kernels.a; sourceTree = "<group>"; };
 		C97BFFA52BC0C1F200F55BAC /* libportable_ops_lib.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libportable_ops_lib.a; path = libraries/libportable_ops_lib.a; sourceTree = "<group>"; };
 		C988D69C2B998CD700979CF6 /* libprotobuf-lite.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libprotobuf-lite.a"; path = "libraries/libprotobuf-lite.a"; sourceTree = "<group>"; };
@@ -57,7 +57,7 @@
 				38626BB52B225A890059413D /* libetdump.a in Frameworks */,
 				F24817E72BC65B2000E80D98 /* libexecutorch_core.a in Frameworks */,
 				38626BB42B225A560059413D /* libflatccrt.a in Frameworks */,
-				C94D51682ACFCC7100AF47FD /* libcoremldelegate.a in Frameworks */,
+				C94D51682ACFCC7100AF47FD /* libcoreml_backend.a in Frameworks */,
 				C94D51662ACFCBCB00AF47FD /* Accelerate.framework in Frameworks */,
 				C988D69D2B998CDE00979CF6 /* libprotobuf-lite.a in Frameworks */,
 				C97BFFA62BC0C1F200F55BAC /* libportable_ops_lib.a in Frameworks */,
@@ -98,7 +98,7 @@
 				C94D51632ACFCBC500AF47FD /* CoreML.framework */,
 				C94D515C2ACFCBA000AF47FD /* libexecutorch.a */,
 				C94D51612ACFCBBA00AF47FD /* libsqlite3.tbd */,
-				C94D51672ACFCC7100AF47FD /* libcoremldelegate.a */,
+				C94D51672ACFCC7100AF47FD /* libcoreml_backend.a */,
 				F24817E62BC65B2000E80D98 /* libexecutorch_core.a */,
 				C97BFFA32BC0C17300F55BAC /* libportable_kernels.a */,
 				C97BFFA52BC0C1F200F55BAC /* libportable_ops_lib.a */,

--- a/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/xcshareddata/xcschemes/coreml_executor_runner.xcscheme
+++ b/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/xcshareddata/xcschemes/coreml_executor_runner.xcscheme
@@ -40,7 +40,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
-      internalIOSLaunchStyle = "3"
       viewDebuggingEnabled = "No">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">


### PR DESCRIPTION
Rename backends to standardize on [name]_backend. Add alias targets to preserve backwards compatibility for existing users.