### PR TITLE
Set EXECUTORCH_BUILD_QNN=ON for benchmarking app build

### DIFF
--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -227,11 +227,9 @@ jobs:
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh cmake
         export ARTIFACTS_DIR_NAME=artifacts-to-be-uploaded
 
-        if [[ ${{ matrix.delegate }} == "qnn" ]]; then
-            PYTHON_EXECUTABLE=python bash .ci/scripts/setup-qnn-deps.sh
-            PYTHON_EXECUTABLE=python bash .ci/scripts/build-qnn-sdk.sh
-            export EXECUTORCH_BUILD_QNN=ON
-        fi
+        PYTHON_EXECUTABLE=python bash .ci/scripts/setup-qnn-deps.sh
+        PYTHON_EXECUTABLE=python bash .ci/scripts/build-qnn-sdk.sh
+        export EXECUTORCH_BUILD_QNN=ON
 
         export ANDROID_ABIS="arm64-v8a"
         bash build/build_android_llm_demo.sh ${ARTIFACTS_DIR_NAME}

--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -230,10 +230,9 @@ jobs:
         if [[ ${{ matrix.delegate }} == "qnn" ]]; then
             PYTHON_EXECUTABLE=python bash .ci/scripts/setup-qnn-deps.sh
             PYTHON_EXECUTABLE=python bash .ci/scripts/build-qnn-sdk.sh
+            export EXECUTORCH_BUILD_QNN=ON
         fi
 
-        # TODO: This needs to be replaced with a generic loader .apk
-        # Build LLM Demo for Android
         export ANDROID_ABIS="arm64-v8a"
         bash build/build_android_llm_demo.sh ${ARTIFACTS_DIR_NAME}
 


### PR DESCRIPTION
Runtime change. When we build the minibench app (the AAR component) we always integrate QNN backend support into it