### PR TITLE
Enable optimized build for portable configuration of test-models

### DIFF
--- a/.ci/scripts/test_model.sh
+++ b/.ci/scripts/test_model.sh
@@ -54,6 +54,7 @@ build_cmake_executor_runner() {
     && mkdir ${CMAKE_OUTPUT_DIR} \
     && cd ${CMAKE_OUTPUT_DIR} \
     && retry cmake -DCMAKE_BUILD_TYPE=Release \
+      -DEXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON \
       -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
 
   cmake --build ${CMAKE_OUTPUT_DIR} -j4


### PR DESCRIPTION
Summary: #5244 probably broke it, because it makes optimized ops a requirement to run llama without xnnpack.

Test Plan: `bash .ci/scripts/test_model.sh llama2 cmake portable` was broken and now succeeds
