### PR TITLE
Increase timeout threshold for on-device benchmarking

### DIFF
--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -278,6 +278,7 @@ jobs:
         delegate: ${{ fromJson(needs.set-parameters.outputs.delegates) }}
         device: ${{ fromJson(needs.set-parameters.outputs.devices) }}
       fail-fast: false
+    timeout: 120 # Due to scheduling a job may be pushed beyond the default 60m threshold
     with:
       device-type: android
       runner: linux.2xlarge

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -317,6 +317,7 @@ jobs:
         delegate: ${{ fromJson(needs.set-parameters.outputs.delegates) }}
         device: ${{ fromJson(needs.set-parameters.outputs.devices) }}
       fail-fast: false
+    timeout: 120 # Due to scheduling a job may be pushed beyond the default 60m threshold
     with:
       device-type: ios
       # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS


### PR DESCRIPTION
Seeing timeout issue in iOS workflow due to queueing/scheduling. We will increase the timeout threshold to 120mins (from 60mins).