### PR TITLE
[ET-VK] Enable tensor aliases with texture storage

### DIFF
--- a/backends/vulkan/runtime/api/containers/Tensor.cpp
+++ b/backends/vulkan/runtime/api/containers/Tensor.cpp
@@ -682,12 +682,9 @@ vTensorStorage::vTensorStorage(
       image_extents_(other.image_extents_),
       buffer_length_{other.buffer_length_},
       buffer_offset_{buffer_offset},
-      image_(),
+      image_(other.image_),
       buffer_(other.buffer_, buffer_offset),
       last_access_{other.last_access_} {
-  if (other.storage_type_ != utils::kBuffer) {
-    VK_THROW("Tensors with texture storage cannot be copied!");
-  }
 }
 
 vTensorStorage::~vTensorStorage() {
@@ -758,14 +755,10 @@ void vTensorStorage::transition(
 }
 
 bool vTensorStorage::is_copy_of(const vTensorStorage& other) const {
-  if (storage_type_ != other.storage_type_) {
-    return false;
+  if (storage_type_ == utils::kBuffer) {
+    return buffer_.is_copy_of(other.buffer_);
   }
-  // Copies are only enabled for buffer storage at the moment
-  if (storage_type_ != utils::kBuffer) {
-    return false;
-  }
-  return buffer_.is_copy_of(other.buffer_);
+  return image_.is_copy_of(other.image_);
 }
 
 void vTensorStorage::discard_and_reallocate(

--- a/backends/vulkan/runtime/vk_api/memory/Allocation.h
+++ b/backends/vulkan/runtime/vk_api/memory/Allocation.h
@@ -80,6 +80,7 @@ struct Allocation final {
   }
 
   friend class VulkanBuffer;
+  friend class VulkanImage;
 };
 
 } // namespace vkapi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5326
* #5277

## Context

Allow aliasing for `VulkanImage` objects, and by extension texture backed Tensors.

Essentially just a re-application/extension of what was done in https://github.com/pytorch/executorch/pull/4769.

Differential Revision: [D62606929](https://our.internmc.facebook.com/intern/diff/D62606929/)