### PR TITLE
[MPS] Fix API warning for older SDKs

### DIFF
--- a/backends/apple/mps/runtime/operations/QuantDequant.mm
+++ b/backends/apple/mps/runtime/operations/QuantDequant.mm
@@ -30,17 +30,19 @@ MPSGraphBuilder::mpsDequantizePerChannelGroupOp(NodePtr nodePtr) {
 
   MPSGraphTensor* inputTensor = getMPSGraphTensor(graphNode->input1_id());
   MPSGraphTensor* scalesTensor = getMPSGraphTensor(graphNode->scales_id());
-
-  MPSGraphTensor *zpTensor = [_mpsGraph constantWithScalar:0
+  if (@available(macOS 15.0, iOS 18.0, tvOS 18.0, *)) {
+    MPSGraphTensor *zpTensor = [_mpsGraph constantWithScalar:0
                                                   dataType:MPSDataTypeInt4];
+    MPSGraphTensor *wDqTensor = [_mpsGraph dequantizeTensor:inputTensor
+                                                scaleTensor:scalesTensor
+                                            zeroPointTensor:zpTensor
+                                                  dataType:MPSDataTypeFloat16
+                                                      name:nil];
+    _idToMPSGraphTensor[graphNode->output_id()] = wDqTensor;
+  } else {
+    _idToMPSGraphTensor[graphNode->output_id()] = nil;
+  }
 
-  MPSGraphTensor *wDqTensor = [_mpsGraph dequantizeTensor:inputTensor
-                                              scaleTensor:scalesTensor
-                                          zeroPointTensor:zpTensor
-                                                dataType:MPSDataTypeFloat16
-                                                    name:nil];
-
-  _idToMPSGraphTensor[graphNode->output_id()] = wDqTensor;
   return Error::Ok;
 }
 


### PR DESCRIPTION
Fixes warnings when building on macOS Sequoia with an older iOS SDK, e.g
```
executorch/backends/apple/mps/runtime/operations/QuantDequant.mm:35:60: error: 'MPSDataTypeInt4' is only available on iOS 18.0 or newer [-Werror,-Wunguarded-availability-new]
[CONTEXT]    35 |                                                   dataType:MPSDataTypeInt4];
[CONTEXT]       |                                                            ^~~~~~~~~~~~~~~
executorch/backends/apple/mps/runtime/operations/QuantDequant.mm:37:42: error: 'dequantizeTensor:scaleTensor:zeroPointTensor:dataType:name:' is only available on iOS 18.0 or newer [-Werror,-Wunguarded-availability-new]
[CONTEXT]    37 |   MPSGraphTensor *wDqTensor = [_mpsGraph dequantizeTensor:inputTensor
[CONTEXT]       |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

cc @shoumikhin, @cccclai 