### PR TITLE
[BE] Add --clean option to install_requirements.py

### DIFF
--- a/install_requirements.py
+++ b/install_requirements.py
@@ -78,6 +78,14 @@ for arg in sys.argv[1:]:
         else:
             print(f"Error: {arg} must follow --pybind")
             sys.exit(1)
+    elif arg == "--clean":
+        print(f"Cleaning build artifacts...")
+        if sys.platform == "win32":
+            subprocess.run(["rmdir", "/s", "cmake-out*/"], check=True)
+            subprocess.run(["rmdir", "/s", "pip-out/"], check=True)
+        else:
+            subprocess.run(["rm", "-rf", "cmake-out*/"], check=True)
+            subprocess.run(["rm", "-rf", "pip-out/"], check=True)
     else:
         print(f"Error: Unknown option {arg}")
         sys.exit(1)

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -5,9 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import glob
 import os
 import platform
 import re
+import shutil
 import subprocess
 import sys
 
@@ -80,12 +82,14 @@ for arg in sys.argv[1:]:
             sys.exit(1)
     elif arg == "--clean":
         print(f"Cleaning build artifacts...")
-        if sys.platform == "win32":
-            subprocess.run(["rmdir", "/s", "cmake-out*/"], check=True)
-            subprocess.run(["rmdir", "/s", "pip-out/"], check=True)
-        else:
-            subprocess.run(["rm", "-rf", "cmake-out*/"], check=True)
-            subprocess.run(["rm", "-rf", "pip-out/"], check=True)
+        print("Cleaning pip-out/...")
+        shutil.rmtree("pip-out/", ignore_errors=True)
+        dirs = glob.glob("cmake-out*/")
+        for d in dirs:
+            print(f"Cleaning {d}...")
+            shutil.rmtree(d, ignore_errors=True)
+        print("Done cleaning build artifacts.")
+        sys.exit(0)
     else:
         print(f"Error: Unknown option {arg}")
         sys.exit(1)

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -81,7 +81,7 @@ for arg in sys.argv[1:]:
             print(f"Error: {arg} must follow --pybind")
             sys.exit(1)
     elif arg == "--clean":
-        print(f"Cleaning build artifacts...")
+        print("Cleaning build artifacts...")
         print("Cleaning pip-out/...")
         shutil.rmtree("pip-out/", ignore_errors=True)
         dirs = glob.glob("cmake-out*/")


### PR DESCRIPTION
Summary: as titled. remove `cmake-out/` and `pip-out/` before installing ExecuTorch. Android is creating directory name such as `cmake-out-armv8` so removing those as well.

Test Plan: Tried on my machine

```
$ bash install_requirements.sh --clean
Cleaning build artifacts...
Cleaning pip-out/...
Cleaning cmake-out-android-arm64-v8a/...
Cleaning cmake-out-android-x86_64/...
Done cleaning build artifacts.
```
Reviewers:

Subscribers:

Tasks:

Tags: