### PR TITLE
Export aoti for preprocess

### DIFF
--- a/examples/models/flamingo/preprocess/export_preprocess.py
+++ b/examples/models/flamingo/preprocess/export_preprocess.py
@@ -4,15 +4,29 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from export_preprocess_lib import export_preprocess, lower_to_executorch_preprocess
+import torch
+from executorch.examples.models.flamingo.preprocess.export_preprocess_lib import (
+    export_preprocess,
+    get_example_inputs,
+    lower_to_executorch_preprocess,
+)
 
 
 def main():
+    # Export
     ep = export_preprocess()
-    et = lower_to_executorch_preprocess(ep)
 
-    with open("preprocess.pte", "wb") as file:
+    # ExecuTorch
+    et = lower_to_executorch_preprocess(ep)
+    with open("preprocess_et.pte", "wb") as file:
         et.write_to_file(file)
+
+    # AOTInductor
+    torch._inductor.aot_compile(
+        ep.module(),
+        get_example_inputs(),
+        options={"aot_inductor.output_path": "preprocess_aoti.so"},
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Export AOTI for preprocess.

Test Plan:
```
python -m unittest examples/models/flamingo/preprocess/test_preprocess.py
```