### PR TITLE
Fix EValue construction from a smart pointer.

### DIFF
--- a/runtime/core/evalue.h
+++ b/runtime/core/evalue.h
@@ -248,7 +248,9 @@ struct EValue {
           decltype(*std::forward<T>(value)),
           EValue>::value>::type* = 0) {
     ET_CHECK_MSG(value != nullptr, "Pointer is null.");
-    *this = EValue(*std::forward<T>(value));
+    // Note that this ctor does not initialize this->tag directly; it is set by
+    // moving in the new value.
+    moveFrom(*std::forward<T>(value));
   }
 
   // Delete constructor for raw pointers to ensure they cannot be used.


### PR DESCRIPTION
Summary: The move constructor invoked by `*this =` expression tries to `destroy()` the `this` first, but it's not yet initialized.

Differential Revision: D62658327
