### PR TITLE
[Android] Use ms for number report

### DIFF
--- a/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/LlmBenchmarkRunner.java
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/LlmBenchmarkRunner.java
@@ -105,14 +105,14 @@ public class LlmBenchmarkRunner extends Activity implements ModelRunnerCallback 
     results.add(
         new BenchmarkMetric(
             benchmarkModel,
-            "model_load_time(ns)",
+            "model_load_time(ms)",
             (mStatsDump.loadEnd - mStatsDump.loadStart) * 1e-6,
             0.0f));
     // LLM generate time
     results.add(
         new BenchmarkMetric(
             benchmarkModel,
-            "generate_time(ns)",
+            "generate_time(ms)",
             (mStatsDump.generateEnd - mStatsDump.generateStart) * 1e-6,
             0.0f));
     // Token per second

--- a/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/LlmBenchmarkRunner.java
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/LlmBenchmarkRunner.java
@@ -106,14 +106,14 @@ public class LlmBenchmarkRunner extends Activity implements ModelRunnerCallback 
         new BenchmarkMetric(
             benchmarkModel,
             "model_load_time(ns)",
-            mStatsDump.loadEnd - mStatsDump.loadStart,
+            (mStatsDump.loadEnd - mStatsDump.loadStart) * 1e-6,
             0.0f));
     // LLM generate time
     results.add(
         new BenchmarkMetric(
             benchmarkModel,
             "generate_time(ns)",
-            mStatsDump.generateEnd - mStatsDump.generateStart,
+            (mStatsDump.generateEnd - mStatsDump.generateStart) * 1e-6,
             0.0f));
     // Token per second
     results.add(

--- a/extension/android/benchmark/app/src/main/java/org/pytorch/minibench/BenchmarkActivity.java
+++ b/extension/android/benchmark/app/src/main/java/org/pytorch/minibench/BenchmarkActivity.java
@@ -56,7 +56,7 @@ public class BenchmarkActivity extends Activity {
     for (int i = 0; i < numIter; i++) {
       long start = System.nanoTime();
       module.forward();
-      long forwardMs = System.nanoTime() - start;
+      double forwardMs = (System.nanoTime() - start) * 1e-6;
       stats.latency.add(forwardMs);
     }
 
@@ -68,13 +68,13 @@ public class BenchmarkActivity extends Activity {
     results.add(
         new BenchmarkMetric(
             benchmarkModel,
-            "avg_inference_latency(ns)",
+            "avg_inference_latency(ms)",
             stats.latency.stream().mapToDouble(l -> l).average().orElse(0.0f),
             0.0f));
     // Model load time
     results.add(
         new BenchmarkMetric(
-            benchmarkModel, "model_load_time(ns)", stats.loadEnd - stats.loadStart, 0.0f));
+            benchmarkModel, "model_load_time(ms)", (stats.loadEnd - stats.loadStart) * 1e-6, 0.0f));
     // Load status
     results.add(new BenchmarkMetric(benchmarkModel, "load_status", stats.errorCode, 0));
 
@@ -90,7 +90,7 @@ public class BenchmarkActivity extends Activity {
 class Stats {
   long loadStart;
   long loadEnd;
-  List<Long> latency = new ArrayList<>();
+  List<double> latency = new ArrayList<>();
   int errorCode = 0;
 
   @Override

--- a/extension/android/benchmark/app/src/main/java/org/pytorch/minibench/BenchmarkActivity.java
+++ b/extension/android/benchmark/app/src/main/java/org/pytorch/minibench/BenchmarkActivity.java
@@ -90,7 +90,7 @@ public class BenchmarkActivity extends Activity {
 class Stats {
   long loadStart;
   long loadEnd;
-  List<double> latency = new ArrayList<>();
+  List<Double> latency = new ArrayList<>();
   int errorCode = 0;
 
   @Override

--- a/extension/android/benchmark/app/src/main/java/org/pytorch/minibench/LlmBenchmarkActivity.java
+++ b/extension/android/benchmark/app/src/main/java/org/pytorch/minibench/LlmBenchmarkActivity.java
@@ -97,15 +97,15 @@ public class LlmBenchmarkActivity extends Activity implements ModelRunnerCallbac
     results.add(
         new BenchmarkMetric(
             benchmarkModel,
-            "model_load_time(ns)",
-            mStatsInfo.loadEnd - mStatsInfo.loadStart,
+            "model_load_time(ms)",
+            (mStatsInfo.loadEnd - mStatsInfo.loadStart) * 1e-6,
             0.0f));
     // LLM generate time
     results.add(
         new BenchmarkMetric(
             benchmarkModel,
-            "generate_time(ns)",
-            mStatsInfo.generateEnd - mStatsInfo.generateStart,
+            "generate_time(ms)",
+            (mStatsInfo.generateEnd - mStatsInfo.generateStart) * 1e-6,
             0.0f));
     // Token per second
     results.add(


### PR DESCRIPTION
ns * 1e-6 = ms

Example output: 
(9.36ms inference mv2_xnnpack)
```
[{"actualValue":9.3611927,"benchmarkModel":{"backend":"","name":"mv2_xnnpack","quantization":""},"deviceInfo":{"arch":"SM-S926U1","availMem":0,"device":"samsung","os":"Android 14","totalMem":0},"metric":"avg_inference_latency(ms)","targetValue":0.0},{"actualValue":27.418698,"benchmarkModel":{"backend":"","name":"mv2_xnnpack","quantization":""},"deviceInfo":{"arch":"SM-S926U1","availMem":0,"device":"samsung","os":"Android 14","totalMem":0},"metric":"model_load_time(ms)","targetValue":0.0},{"actualValue":0.0,"benchmarkModel":{"backend":"","name":"mv2_xnnpack","quantization":""},"deviceInfo":{"arch":"SM-S926U1","availMem":0,"device":"samsung","os":"Android 14","totalMem":0},"metric":"load_status","targetValue":0.0}]
```

and for LLM
(12.34 tps mocked number)
```
[{"actualValue":0.0,"benchmarkModel":{"backend":"","name":"et_exported_llama","quantization":""},"deviceInfo":{"arch":"SM-S926U1","availMem":0,"device":"samsung","os":"Android 14","totalMem":0},"metric":"load_status","targetValue":0.0},{"actualValue":3375.450312,"benchmarkModel":{"backend":"","name":"et_exported_llama","quantization":""},"deviceInfo":{"arch":"SM-S926U1","availMem":0,"device":"samsung","os":"Android 14","totalMem":0},"metric":"model_load_time(ms)","targetValue":0.0},{"actualValue":8220.467966,"benchmarkModel":{"backend":"","name":"et_exported_llama","quantization":""},"deviceInfo":{"arch":"SM-S926U1","availMem":0,"device":"samsung","os":"Android 14","totalMem":0},"metric":"generate_time(ms)","targetValue":0.0},{"actualValue":12.3456,"benchmarkModel":{"backend":"","name":"et_exported_llama","quantization":""},"deviceInfo":{"arch":"SM-S926U1","availMem":0,"device":"samsung","os":"Android 14","totalMem":0},"metric":"token_per_sec","targetValue":0.0}]
```
