### PR TITLE
Properly kill the buck2 daemon

### DIFF
--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -247,15 +247,14 @@ function(resolve_buck2)
     OUTPUT_VARIABLE resolve_buck2_output
     ERROR_VARIABLE resolve_buck2_error
     RESULT_VARIABLE resolve_buck2_exit_code
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${executorch_root}
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
+  # $BUCK2 is a copy of the var from the parent scope. This block will set
+  # $buck2 to the value we want to return.
   if(resolve_buck2_exit_code EQUAL 0)
-    set(BUCK2
-        ${resolve_buck2_output}
-        PARENT_SCOPE
-    )
+    set(buck2 ${resolve_buck2_output})
     message(STATUS "Resolved buck2 as ${resolve_buck2_output}.")
   elseif(resolve_buck2_exit_code EQUAL 2)
     # Wrong buck version used. Stop here to ensure that the user sees the error.
@@ -266,17 +265,22 @@ function(resolve_buck2)
     message(WARNING "${resolve_buck2_error}")
 
     if("${BUCK2}" STREQUAL "")
-      set(BUCK2
-          "buck2"
-          PARENT_SCOPE
-      )
+      set(buck2 "buck2")
     endif()
   endif()
+
+  # Update the var in the parent scope. Note that this does not modify our
+  # local $BUCK2 value.
+  set(BUCK2 "${buck2}" PARENT_SCOPE)
 
   # The buck2 daemon can get stuck. Killing it can help.
   message(STATUS "Killing buck2 daemon")
   execute_process(
-    COMMAND "${BUCK2} kill" WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    # Note that we need to use the local buck2 variable. BUCK2 is only set in
+    # the parent scope, and can still be empty in this scope.
+    COMMAND "${buck2} kill"
+    WORKING_DIRECTORY ${executorch_root}
+    COMMAND_ECHO STDOUT
   )
 endfunction()
 


### PR DESCRIPTION
Fix the `buck2 kill` command. Because of scoping issues, in some cases we only ran "` kill`" because the local value of `$BUCK2` was empty.

This should help avoid failures like

```
  Error validating working directory
  Caused by:
      0: Failed to stat `/home/ubuntu/cmodi/executorch/buck-out/v2`
      1: ENOENT: No such file or directory
```

which are typically fixed by running `buck2 kill`.

Add "COMMAND_ECHO" to the kill command to show what we're running.

Also, make the function consistently use `executorch_root` as the working directory. We should always run buck2 from the ET repo.

Test Plan:

```
rm -rf buck-out
(rm -rf cmake-out \
    && mkdir cmake-out \
    && cd cmake-out \
    && cmake ..)
```

Output showed that the local variable works:
```
-- Resolved buck2 as /Users/***/local/executorch/cmake-out/buck2-bin/buck2-99773fe6f7963a72ae5f7b737c02836e.
-- Killing buck2 daemon
'/Users/***/local/executorch/cmake-out/buck2-bin/buck2-99773fe6f7963a72ae5f7b737c02836e kill'
```

And that the parent variable still works:
```
-- ******** Summary ********
...
--   BUCK2                         : /Users/***/local/executorch/cmake-out/buck2-bin/buck2-99773fe6f7963a72ae5f7b737c02836e
```