### PR TITLE
Fix fbcode//executorch/backends/arm/quantizer:arm_quantizer type checking test

### DIFF
--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -59,6 +59,7 @@ __all__ = [
 
 
 def _supported_symmetric_quantized_operators() -> Dict[str, List[OperatorPatternType]]:
+    # pyre-fixme[9]: supported_operators has type `Dict[str, List[List[typing.Callabl...
     supported_operators: Dict[str, List[OperatorPatternType]] = {
         # Both conv and linear should be able to handle relu + hardtanh fusion since
         # those are clamp ops


### PR DESCRIPTION
Summary: This fixes type errors resulting from a recent pyre upgrade.

Reviewed By: stroxler

Differential Revision: D62688063


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai