### PR TITLE
[ExecuTorch] Check for contiguous dim order in op_fast_hadamard_transform

### DIFF
--- a/extension/llm/custom_ops/op_fast_hadamard_transform.cpp
+++ b/extension/llm/custom_ops/op_fast_hadamard_transform.cpp
@@ -34,6 +34,18 @@ Tensor& fast_hadamard_transform_out(
     return out;
   }
 
+  ET_KERNEL_CHECK(
+      ctx,
+      is_contiguous_dim_order(mat.dim_order().data(), mat.dim()),
+      InvalidArgument,
+      out);
+
+  ET_KERNEL_CHECK(
+      ctx,
+      is_contiguous_dim_order(out.dim_order().data(), out.dim()),
+      InvalidArgument,
+      out);
+
   ET_KERNEL_CHECK_MSG(
       ctx,
       mat.strides().back() == 1,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5419
* #5291
* #5388
* #5369

Lunwen pointed out we didn't handle this case.

Differential Revision: [D62788230](https://our.internmc.facebook.com/intern/diff/D62788230/)