### PR TITLE
[ExecuTorch] Unbreak Intel Apple Buck builds

### DIFF
--- a/kernels/optimized/lib_defs.bzl
+++ b/kernels/optimized/lib_defs.bzl
@@ -156,8 +156,11 @@ def define_libs():
                     ],
                 ),
             ],
-            fbobjc_compiler_flags = [
-                "-march=armv8+bf16",
+            fbobjc_platform_compiler_flags = [
+                (
+                    ".*arm64.*",
+                    ["-march=armv8+bf16"],
+                ),
             ],
             fbobjc_exported_preprocessor_flags = [
                 "-DET_BUILD_WITH_BLAS",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5431

The code is gated on `#ifdef __aarch64__`, but the `-march` flag wasn't.

Differential Revision: [D62884370](https://our.internmc.facebook.com/intern/diff/D62884370/)