### PR TITLE
Integrate axis mapping in embedding op

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/embedding.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/embedding.glsl
@@ -16,10 +16,13 @@ layout(std430) buffer;
 
 #include "indexing_utils.h"
 
-${layout_declare_tensor(0, "w", "t_out", DTYPE, STORAGE)}
-${layout_declare_tensor(1, "r", "t_in", "int", STORAGE)}
-${layout_declare_tensor(2, "r", "t_weight", DTYPE, STORAGE)}
-${layout_declare_ubo(3, "ivec4", "sizes")}
+${layout_declare_tensor(B, "w", "t_out", DTYPE, STORAGE)}
+${layout_declare_tensor(B, "r", "t_in", "int", STORAGE)}
+${layout_declare_tensor(B, "r", "t_weight", DTYPE, STORAGE)}
+${layout_declare_ubo(B, "ivec4", "sizes")}
+${layout_declare_ubo(B, "ivec4", "out_axis_map")}
+${layout_declare_ubo(B, "ivec4", "in_axis_map")}
+${layout_declare_ubo(B, "ivec4", "weight_axis_map")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
@@ -27,22 +30,21 @@ layout(constant_id = 3) const int packed_dim = C_DIM;
 
 void main() {
   const ivec3 out_pos = ivec3(gl_GlobalInvocationID);
-
-  if (pos_out_of_bounds(out_pos, sizes, packed_dim)) {
+  const ivec4 out_idx = to_tensor_idx(out_pos, sizes, out_axis_map, packed_dim);
+  if (any(greaterThanEqual(out_idx, sizes))) {
     return;
   }
-
-  const ivec4 out_idx = to_tensor_idx(out_pos, sizes, packed_dim);
   VEC4_T out_texel;
 
   // Consider optimizing via W-packing format for t_in and t_weight.
   for (int i = 0; i < 4; ++i) {
     // Read input tensor for embedding index.
-    const ivec3 in_pos = ivec3(out_pos.y, out_idx.z * 4 + i, out_idx.w / 4);
-    const int in_texel_elem = texelFetch(t_in, in_pos, 0)[out_idx.w % 4];
+    const ivec3 in_pos = to_texture_pos(ivec3(out_idx.y, out_idx.z * 4 + i, out_idx.w / 4), in_axis_map);
+    const int in_texel_elem = load_texel(t_in, in_pos)[out_idx.w % 4];
 
     // Read weight tensor for embedding.
-    out_texel[i] = texelFetch(t_weight, ivec3(out_pos.x, in_texel_elem, 0), 0).x;
+    const ivec3 weight_pos = to_texture_pos(ivec3(out_idx.x, in_texel_elem, 0), weight_axis_map);
+    out_texel[i] = load_texel(t_weight, weight_pos).x;
   }
 
   imageStore(t_out, out_pos, out_texel);

--- a/backends/vulkan/runtime/graph/ops/impl/Embedding.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Embedding.cpp
@@ -48,7 +48,12 @@ void add_embedding_node(
       graph.create_local_wg_size(out),
       {{out, vkapi::MemoryAccessType::WRITE},
        {{in, weight}, vkapi::MemoryAccessType::READ}},
-      {t_out->sizes_ubo()}));
+      {
+          t_out->sizes_ubo(),
+          t_out->axis_map_ubo(),
+          t_in->axis_map_ubo(),
+          t_weight->axis_map_ubo(),
+      }));
 }
 
 void embedding(ComputeGraph& graph, const std::vector<ValueRef>& args) {


### PR DESCRIPTION
Summary: Update embedding op to support axis mapped textures.

Differential Revision: D62897503
