### PR TITLE
Add an error message to help debug issue when accessing secrets in CI

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -392,6 +392,10 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Set up HuggingFace Dependencies"
+        if [ -z "$SECRET_EXECUTORCH_HF_TOKEN" ]; then
+          echo "::error::SECRET_EXECUTORCH_HF_TOKEN is empty. For security reason secrets won't be accessible on forked PRs. Please make sure you submit a non-forked PR."
+          exit 1
+        fi
         pip install -U "huggingface_hub[cli]"
         huggingface-cli login --token $SECRET_EXECUTORCH_HF_TOKEN
         pip install accelerate sentencepiece


### PR DESCRIPTION
What shows here (https://github.com/pytorch/executorch/pull/5428#issuecomment-2356732094) seems to be a common issue especially for people who are exporting the Diff to GitHub from Phabricator. Added an error message when secret is empty.