### PR TITLE
Training demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,8 @@ option(EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL "Build the Runner Util extension"
 
 option(EXECUTORCH_BUILD_EXTENSION_TENSOR "Build the Tensor extension" OFF)
 
+option(EXECUTORCH_BUILD_EXTENSION_TRAINING "Build the training extension" OFF)
+
 option(EXECUTORCH_BUILD_GTESTS "Build googletest based test binaries" OFF)
 
 option(EXECUTORCH_BUILD_MPS "Build the MPS backend" OFF)
@@ -634,6 +636,10 @@ endif()
 
 if(EXECUTORCH_BUILD_EXTENSION_MODULE)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/module)
+endif()
+
+if(EXECUTORCH_BUILD_EXTENSION_TRAINING)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/training)
 endif()
 
 if(EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL)

--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -68,6 +68,9 @@ function(executorch_print_configuration_summary)
   message(STATUS "  EXECUTORCH_BUILD_EXTENSION_TENSOR      : "
                  "${EXECUTORCH_BUILD_EXTENSION_TENSOR}"
   )
+  message(STATUS "  EXECUTORCH_BUILD_EXTENSION_TRAINING      : "
+                 "${EXECUTORCH_BUILD_EXTENSION_TRAINING}"
+  )
   message(
     STATUS
       "  EXECUTORCH_BUILD_FLATC                 : ${EXECUTORCH_BUILD_FLATC}"

--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -210,6 +210,34 @@ deps = [
   "executorch",
   "executorch_no_prim_ops",
 ]
+
+[targets.extension_training]
+buck_targets = [
+  "//extension/training/module:training_module",
+  "//extension/training/optimizer:sgd",
+]
+filters = [
+  ".cpp$",
+]
+deps = [
+  "executorch_no_prim_ops",
+]
+
+[targets.train_xor]
+buck_targets = [
+  "//extension/training/examples/XOR:train_xor",
+]
+filters = [
+  ".cpp$",
+]
+excludes = [
+  "^codegen",
+]
+deps = [
+  "executorch",
+  "executorch_no_prim_ops",
+  "portable_kernels",
+]
 # ---------------------------------- extension end ----------------------------------
 # ---------------------------------- binary start ----------------------------------
 

--- a/build/executorch-config.cmake
+++ b/build/executorch-config.cmake
@@ -48,6 +48,7 @@ set(lib_list
     extension_runner_util
     extension_tensor
     extension_threadpool
+    extension_training
     xnnpack_backend
     XNNPACK
     cpuinfo

--- a/extension/training/CMakeLists.txt
+++ b/extension/training/CMakeLists.txt
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Please this file formatted by running:
+# ~~~
+# cmake-format -i CMakeLists.txt
+# ~~~
+
+cmake_minimum_required(VERSION 3.19)
+
+# Source root directory for executorch.
+if(NOT EXECUTORCH_ROOT)
+  set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+endif()
+
+list(TRANSFORM _extension_training__srcs PREPEND "${EXECUTORCH_ROOT}/")
+
+add_library(extension_training ${_extension_training__srcs})
+target_include_directories(
+  extension_training PUBLIC ${_common_include_directories}
+)
+
+target_include_directories(extension_training PUBLIC ${EXECUTORCH_ROOT}/..)
+target_compile_options(extension_training PUBLIC ${_common_compile_options})
+target_link_libraries(extension_training executorch_no_prim_ops
+    extension_data_loader extension_module extension_tensor)
+
+
+list(TRANSFORM _train_xor__srcs PREPEND "${EXECUTORCH_ROOT}/")
+add_executable(train_xor ${_train_xor__srcs})
+target_include_directories(
+  train_xor PUBLIC ${_common_include_directories}
+)
+target_link_libraries(
+train_xor gflags executorch_no_prim_ops portable_ops_lib extension_tensor
+    extension_training program_schema
+)
+target_compile_options(train_xor PUBLIC ${_common_compile_options})
+
+# Install libraries
+install(
+  TARGETS extension_training
+  DESTINATION lib
+  INCLUDES
+  DESTINATION ${_common_include_directories}
+)

--- a/extension/training/examples/XOR/TARGETS
+++ b/extension/training/examples/XOR/TARGETS
@@ -1,40 +1,8 @@
 # Any targets that should be shared between fbcode and xplat must be defined in
 # targets.bzl. This file can contain fbcode-only targets.
 
-load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
-load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 load(":targets.bzl", "define_common_targets")
 
 oncall("executorch")
 
 define_common_targets()
-
-python_library(
-    name = "model",
-    srcs = ["model.py"],
-    visibility = [],  # Private
-    deps = [
-        "//caffe2:torch",
-    ],
-)
-
-python_library(
-    name = "export_model_lib",
-    srcs = ["export_model_lib.py"],
-    visibility = [],
-    deps = [
-        ":model",
-        "//caffe2:torch",
-        "//executorch/exir:lib",
-    ],
-)
-
-python_binary(
-    name = "export_model",
-    main_function = ".export_model.main",
-    main_src = "export_model.py",
-    deps = [
-        ":export_model_lib",
-        "//caffe2:torch",
-    ],
-)

--- a/extension/training/examples/XOR/targets.bzl
+++ b/extension/training/examples/XOR/targets.bzl
@@ -21,3 +21,31 @@ def define_common_targets():
         external_deps = ["gflags"],
         define_static_target = True,
     )
+
+    runtime.python_library(
+        name = "model",
+        srcs = ["model.py"],
+        visibility = [],  # Private
+        deps = [
+            "//caffe2:torch",
+        ],
+    )
+
+    runtime.python_library(
+        name = "export_model_lib",
+        srcs = ["export_model_lib.py", "export_model.py"],
+        visibility = [],
+        deps = [
+            ":model",
+            "//caffe2:torch",
+            "//executorch/exir:lib",
+        ],
+    )
+
+    runtime.python_binary(
+        name = "export_model",
+        main_module = "executorch.extension.training.examples.XOR.export_model",
+        deps = [
+            ":export_model_lib",
+        ],
+    )

--- a/extension/training/examples/XOR/train.cpp
+++ b/extension/training/examples/XOR/train.cpp
@@ -54,16 +54,16 @@ int main(int argc, char** argv) {
       data_set;
   data_set.push_back( // XOR(1, 1) = 0
       {executorch::extension::make_tensor_ptr<float>({1, 2}, {1, 1}),
-       executorch::extension::make_tensor_ptr<long>({1}, {0})});
+       executorch::extension::make_tensor_ptr<int64_t>({1}, {0})});
   data_set.push_back( // XOR(0, 0) = 0
       {executorch::extension::make_tensor_ptr<float>({1, 2}, {0, 0}),
-       executorch::extension::make_tensor_ptr<long>({1}, {0})});
+       executorch::extension::make_tensor_ptr<int64_t>({1}, {0})});
   data_set.push_back( // XOR(1, 0) = 1
       {executorch::extension::make_tensor_ptr<float>({1, 2}, {1, 0}),
-       executorch::extension::make_tensor_ptr<long>({1}, {1})});
+       executorch::extension::make_tensor_ptr<int64_t>({1}, {1})});
   data_set.push_back( // XOR(0, 1) = 1
       {executorch::extension::make_tensor_ptr<float>({1, 2}, {0, 1}),
-       executorch::extension::make_tensor_ptr<long>({1}, {1})});
+       executorch::extension::make_tensor_ptr<int64_t>({1}, {1})});
 
   // Create optimizer.
   // Get the params and names

--- a/extension/training/optimizer/targets.bzl
+++ b/extension/training/optimizer/targets.bzl
@@ -10,20 +10,19 @@ def define_common_targets():
     for aten_mode in (True, False):
         aten_suffix = "_aten" if aten_mode else ""
 
-        if aten_mode:
-            kernel_deps = [
-                "//executorch/kernels/aten:generated_lib",
-                "//executorch/kernels/aten:generated_lib_headers",
-                "//executorch/kernels/test:function_header_wrapper_aten",
-            ]
-        else:
-            kernel_deps = [
-                "//executorch/kernels/portable/cpu:op_add",
-                "//executorch/kernels/portable/cpu:op_mul",
-                "//executorch/kernels/portable/cpu:op_clone",
-                "//executorch/kernels/portable:generated_lib_headers",
-                "//executorch/kernels/test:function_header_wrapper_portable",
-            ]
+        # if aten_mode:
+        #     kernel_deps = [
+        #         "//executorch/kernels/aten:generated_lib",
+        #         "//executorch/kernels/aten:generated_lib_headers",
+        #         "//executorch/kernels/test:function_header_wrapper_aten",
+        #     ]
+        # else:
+        #     kernel_deps = [
+        #         "//executorch/kernels/portable/cpu:op_add",
+        #         "//executorch/kernels/portable/cpu:op_mul",
+        #         "//executorch/kernels/portable/cpu:op_clone",
+        #         "//executorch/kernels/portable:generated_lib_headers",
+        #     ]
 
         runtime.cxx_library(
             name = "sgd" + aten_suffix,
@@ -34,9 +33,9 @@ def define_common_targets():
                 "sgd.h",
             ],
             exported_deps = [
-                "//executorch/runtime/kernel:kernel_runtime_context" + aten_suffix,
+                "//executorch/runtime/core:core",
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
-            ] + kernel_deps,
+            ],  # + kernel_deps,
             visibility = [
                 "@EXECUTORCH_CLIENTS",
             ],


### PR DESCRIPTION
Allows the XOR model training demo to be runnable in OSS. Will follow up with a documentation PR about training and how to run this demo.

Im sure my cmakelist.txt changes have issues so if anyone sees ways to improve them please let me know.

Only hack I had to do was the optimizer was calling an ET op directly. I don't think we have enabled this in OSS yet so I will follow up with @larryliu0820 when hes back and in the meantime open up an issue. 

Repro of demo:
python3 extension/training/examples/XOR/export_model.py --outdir /tmp/xor

rm -rf cmake-out           

mkdir cmake-out      
    
cmake \                                                                   
    -DCMAKE_INSTALL_PREFIX=cmake-out \
    -DCMAKE_BUILD_TYPE=Release \
    -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
    -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
    -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
    -DEXECUTORCH_BUILD_EXTENSION_TRAINING=ON \
    -DEXECUTORCH_ENABLE_LOGGING=ON \
    -DPYTHON_EXECUTABLE=python \
    -Bcmake-out .

cmake --build cmake-out -j9 --target install --config Release         

./cmake-out/extension/training/train_xor --model_path=/tmp/xor/xor.pte
