### PR TITLE
Remove _preserve_ops from export

### DIFF
--- a/exir/program/TARGETS
+++ b/exir/program/TARGETS
@@ -20,6 +20,7 @@ python_library(
     ],
     deps = [
         "//caffe2:torch",
+        "//executorch/exir:_warnings",
         "//executorch/exir:error",
         "//executorch/exir:graph_module",
         "//executorch/exir:pass_base",

--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -573,10 +573,13 @@ class TestProgramManagers(unittest.TestCase):
         # which pass the filter_ops fn given by the partitioner
         reference_ep = copy.deepcopy(ep)
         aten_ops_not_decomposed, filter_ops = partitioner.ops_to_not_decompose(ep)
-        reference_decomp_ep = reference_ep.run_decompositions(
-            decomp_table=_default_decomposition_table(),
-            _preserve_ops=tuple(aten_ops_not_decomposed),
-        )
+        decomp_table = _default_decomposition_table()
+
+        for op in list(decomp_table.keys()):
+            if op in aten_ops_not_decomposed:
+                del decomp_table[op]
+
+        reference_decomp_ep = reference_ep.run_decompositions(decomp_table=decomp_table)
         num_non_decomposed_aten_ops = 0
         for node in reference_decomp_ep.graph.nodes:
             if (

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -94,14 +94,14 @@ if os.name == "nt":
 # NOTE: If a newly-fetched version of the executorch repo changes the value of
 # NIGHTLY_VERSION, you should re-run this script to install the necessary
 # package versions.
-NIGHTLY_VERSION = "dev20240901"
+NIGHTLY_VERSION = "dev20240917"
 
 # The pip repository that hosts nightly torch packages.
 TORCH_NIGHTLY_URL = "https://download.pytorch.org/whl/nightly/cpu"
 
 # pip packages needed by exir.
 EXIR_REQUIREMENTS = [
-    f"torch==2.5.0.{NIGHTLY_VERSION}",
+    f"torch==2.6.0.{NIGHTLY_VERSION}",
     f"torchvision==0.20.0.{NIGHTLY_VERSION}",  # For testing.
     "typing-extensions",
 ]


### PR DESCRIPTION
Summary: I couldn't remove it before PTC due to time constraints, but since we have the proper way of handling decomp_table, we remove this option from export

Differential Revision: D62906375


