### PR TITLE
Add definition to `etrecord_path` to the devtools tutorial

### DIFF
--- a/docs/source/tutorials_source/devtools-integration-tutorial.py
+++ b/docs/source/tutorials_source/devtools-integration-tutorial.py
@@ -196,6 +196,7 @@ inspector_patch_print = patch.object(Inspector, "print_data_tabular", return_val
 inspector_patch.start()
 inspector_patch_print.start()
 # sphinx_gallery_end_ignore
+etrecord_path = "etrecord.bin"
 etdump_path = "etdump.etdp"
 inspector = Inspector(etdump_path=etdump_path, etrecord=etrecord_path)
 # sphinx_gallery_start_ignore


### PR DESCRIPTION
Summary: This diff adds the definition for variable `etrecord_path`. `etrecord_path` was defined in previous steps in the tutorial, but when user gets to this step, they would usually start a new script, so we should define this variable again.

Differential Revision: D62921869
