### PR TITLE
We want to ensure that all python targets are autodeps compliant

### DIFF
--- a/backends/arm/passes/TARGETS
+++ b/backends/arm/passes/TARGETS
@@ -5,8 +5,13 @@ python_library(
     srcs = glob(["*.py"]),
     typing = True,
     deps = [
+        "//caffe2:torch",
+        "//executorch/backends/arm:tosa_mapping",
         "//executorch/backends/arm:tosa_quant_utils",
         "//executorch/backends/arm:tosa_utils",
-        "//executorch/exir:lib",
+        "//executorch/exir:pass_base",
+        "//executorch/exir:pass_manager",
+        "//executorch/exir/backend:compile_spec_schema",
+        "//executorch/exir/dialects:lib",
     ],
 )


### PR DESCRIPTION
Summary:
In an effort to increase accuracy in dependency analysis and expand automatic target management, we are enforcing dependency correctness in the Python & C++ fbcode dependency graph. This means autodeps must be running on all targets and must not produce any suggestions on master.
                    For any questions, please post it to https://fb.workplace.com/groups/fbpython.

Differential Revision: D62936782
