### PR TITLE
Qualcomm AI Engine Direct - Fix aihub path failing due to memory planning pass

### DIFF
--- a/examples/qualcomm/qaihub_scripts/utils/utils.py
+++ b/examples/qualcomm/qaihub_scripts/utils/utils.py
@@ -68,7 +68,6 @@ def gen_pte_from_ctx_bin(
     for pte_name in pte_names:
         print(f"{pte_name} generating...")
         memory_planning_pass = MemoryPlanningPass(
-            memory_planning_algo="greedy",
             alloc_graph_input=False,
             alloc_graph_output=False,
         )


### PR DESCRIPTION
## Summary
Update MemoryPlanningPass to use default greedy algo.