### PR TITLE
[ET-VK][BE][ez] vTensor cleanup 7/N - Blanket replacement of `packed_dim_whcn_idx` with `packed_dim`

### DIFF
--- a/backends/vulkan/runtime/api/containers/Tensor.h
+++ b/backends/vulkan/runtime/api/containers/Tensor.h
@@ -26,7 +26,7 @@ namespace api {
  */
 std::vector<int64_t> calculate_dim_order(
     const size_t ndim,
-    const int32_t packed_dim_whcn_idx);
+    const int32_t packed_dim);
 
 /*
  * Given the sizes of a tensor and the dim order of the tensor (both in NCHW)
@@ -57,7 +57,7 @@ std::vector<int64_t> unsqueeze_strides(
  */
 std::vector<int64_t> calculate_padded_sizes(
     const std::vector<int64_t>& sizes,
-    const int32_t packed_dim_whcn_idx);
+    const int32_t packed_dim);
 
 /*
  * Calculate the image extents required of a texture backed tensor.
@@ -65,7 +65,7 @@ std::vector<int64_t> calculate_padded_sizes(
 utils::uvec3 calculate_image_extents(
     const std::vector<int64_t>& padded_sizes,
     const std::vector<int64_t>& axis_map,
-    const int32_t packed_dim_whcn_idx);
+    const int32_t packed_dim);
 
 struct LastAccess {
   vkapi::PipelineStageFlags stage;
@@ -90,7 +90,7 @@ class vTensorStorage final {
       Context* context,
       const utils::StorageType storage_type,
       const std::vector<int64_t>& axis_map,
-      const int32_t packed_dim_whcn_idx,
+      const int32_t packed_dim,
       const std::vector<int64_t>& padded_sizes,
       const vkapi::ScalarType dtype,
       const bool allocate_memory = true);
@@ -228,7 +228,7 @@ class vTensor final {
   // which dimension is packed along a texel. For buffer backed tensors, this
   // describes which dimension has a stride of 1 (i.e. is last in the dim
   // order).
-  int32_t packed_dim_whcn_idx_;
+  int32_t packed_dim_;
 
   /*
    * "Layout" metadata. These describe with further detail how tensor data is
@@ -378,12 +378,12 @@ class vTensor final {
    * tensor. In some scenarios, the exact layout of the tensor may not be able
    * to be replicated due to calling `virtual_*()` functions after construction;
    * however, this function will provide a memory layout that will produce the
-   * same `packed_dim_whcn_idx` as this tensor.
+   * same `packed_dim` as this tensor.
    */
   utils::GPUMemoryLayout estimate_memory_layout() const;
 
-  inline int32_t packed_dim_whcn_idx() const {
-    return packed_dim_whcn_idx_;
+  inline int32_t packed_dim() const {
+    return packed_dim_;
   }
 
   inline const std::vector<int64_t>& sizes() const {

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -312,8 +312,8 @@ class ComputeGraph final {
     return values_.at(idx).toConstTensor().estimate_memory_layout();
   }
 
-  inline int32_t packed_dim_whcn_idx_of(const ValueRef idx) const {
-    return values_.at(idx).toConstTensor().packed_dim_whcn_idx();
+  inline int32_t packed_dim_of(const ValueRef idx) const {
+    return values_.at(idx).toConstTensor().packed_dim();
   }
 
   inline vkapi::BufferBindInfo sizes_ubo(const ValueRef idx) {

--- a/backends/vulkan/runtime/graph/ops/impl/BinaryOp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/BinaryOp.cpp
@@ -93,7 +93,7 @@ void add_binary_op_node(
        graph.create_params_buffer(broadcast_params),
        graph.create_params_buffer(alpha_val)},
       // Specialization Constants
-      {SV(t_out->packed_dim_whcn_idx())},
+      {SV(t_out->packed_dim())},
       // Resizing Logic
       resize_binary_op_node,
       {}));

--- a/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
@@ -108,7 +108,7 @@ ValueRef prepack_biases(
       v,
       {t->sizes_ubo(), t->axis_map_ubo()},
       // Specialization constants
-      {SV(t->packed_dim_whcn_idx())}));
+      {SV(t->packed_dim())}));
 
   return v;
 }
@@ -216,7 +216,7 @@ ValueRef prepack_weights(
        graph.create_params_buffer(
            utils::make_ivec4(original_sizes, /*reverse = */ true))},
       // Specialization constants
-      {SV(t->packed_dim_whcn_idx())}));
+      {SV(t->packed_dim())}));
 
   return v;
 }

--- a/backends/vulkan/runtime/graph/ops/impl/Full.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Full.cpp
@@ -54,7 +54,7 @@ void add_full_node(
       // Shader params buffers
       {t_out->sizes_ubo(), graph.create_params_buffer(fill_value_val)},
       // Specialization Constants
-      {SV(t_out->packed_dim_whcn_idx())},
+      {SV(t_out->packed_dim())},
       // Resizing Logic
       resize_full_node,
       {size_or_in}));

--- a/backends/vulkan/runtime/graph/ops/impl/Linear.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Linear.cpp
@@ -36,8 +36,7 @@ void check_addmm_args(
   VK_CHECK_COND(mat1_sizes.size() == 2 || mat1_sizes.size() == 3);
   VK_CHECK_COND(mat1_sizes.size() == mat2_sizes.size());
 
-  VK_CHECK_COND(
-      graph.packed_dim_whcn_idx_of(mat1) == graph.packed_dim_whcn_idx_of(out));
+  VK_CHECK_COND(graph.packed_dim_of(mat1) == graph.packed_dim_of(out));
 
   VK_CHECK_COND(utils::val_at(-1, mat1_sizes) == utils::val_at(-2, mat2_sizes));
 
@@ -127,10 +126,10 @@ void add_addmm_naive_node(
           graph.create_params_buffer(params),
       },
       // Specialization Constants
-      {graph.packed_dim_whcn_idx_of(out),
-       graph.packed_dim_whcn_idx_of(mat1),
-       graph.packed_dim_whcn_idx_of(mat2),
-       graph.packed_dim_whcn_idx_of(self)},
+      {graph.packed_dim_of(out),
+       graph.packed_dim_of(mat1),
+       graph.packed_dim_of(mat2),
+       graph.packed_dim_of(self)},
       // Resizing Logic
       resize_addmm_node,
       {mat2_is_transposed}));
@@ -221,7 +220,7 @@ void add_addmm_optimized_node(
           graph.create_params_buffer(params),
       },
       // Specialization Constants
-      {graph.packed_dim_whcn_idx_of(out)},
+      {graph.packed_dim_of(out)},
       // Resizing Logic
       resize_addmm_node,
       {mat2_is_transposed}));
@@ -247,10 +246,10 @@ void add_addmm_node(
   }
 
   Params params = {alpha_val, beta_val};
-  if (graph.packed_dim_whcn_idx_of(mat1) == WHCN::kChannelsDim) {
+  if (graph.packed_dim_of(mat1) == WHCN::kChannelsDim) {
     add_addmm_optimized_node(
         graph, self, mat1, mat2, beta, alpha, out, params, mat2_is_transposed);
-  } else if (graph.packed_dim_whcn_idx_of(mat1) == WHCN::kWidthDim) {
+  } else if (graph.packed_dim_of(mat1) == WHCN::kWidthDim) {
     add_addmm_naive_node(
         graph, self, mat1, mat2, beta, alpha, out, params, mat2_is_transposed);
   } else {

--- a/backends/vulkan/runtime/graph/ops/impl/MatMul.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/MatMul.cpp
@@ -29,8 +29,7 @@ void check_matmul_args(
   VK_CHECK_COND(mat1_sizes.size() == 2 || mat1_sizes.size() == 3);
   VK_CHECK_COND(mat1_sizes.size() == mat2_sizes.size());
 
-  VK_CHECK_COND(
-      graph.packed_dim_whcn_idx_of(mat1) == graph.packed_dim_whcn_idx_of(out));
+  VK_CHECK_COND(graph.packed_dim_of(mat1) == graph.packed_dim_of(out));
 
   VK_CHECK_COND(utils::val_at(-1, mat1_sizes) == utils::val_at(-2, mat2_sizes));
 }
@@ -139,9 +138,9 @@ void add_matmul_naive_texture3d_node(
           graph.axis_map_ubo(mat2),
       },
       // Specialization Constants
-      {graph.packed_dim_whcn_idx_of(out),
-       graph.packed_dim_whcn_idx_of(mat1),
-       graph.packed_dim_whcn_idx_of(mat2)},
+      {graph.packed_dim_of(out),
+       graph.packed_dim_of(mat1),
+       graph.packed_dim_of(mat2)},
       // Resizing Logic
       resize_matmul_node,
       {mat2_is_transposed}));
@@ -223,7 +222,7 @@ void add_matmul_optimized_node(
           graph.axis_map_ubo(mat2_packed),
       },
       // Specialization Constants
-      {graph.packed_dim_whcn_idx_of(out)},
+      {graph.packed_dim_of(out)},
       // Resizing Logic
       resize_matmul_node,
       {mat2_is_transposed}));
@@ -238,9 +237,9 @@ void add_matmul_node(
   if (graph.is_buffer_storage(out)) {
     add_matmul_naive_buffer_node(
         graph, mat1, mat2_data, out, mat2_is_transposed);
-  } else if (graph.packed_dim_whcn_idx_of(mat1) == WHCN::kChannelsDim) {
+  } else if (graph.packed_dim_of(mat1) == WHCN::kChannelsDim) {
     add_matmul_optimized_node(graph, mat1, mat2_data, out, mat2_is_transposed);
-  } else if (graph.packed_dim_whcn_idx_of(mat1) == WHCN::kWidthDim) {
+  } else if (graph.packed_dim_of(mat1) == WHCN::kWidthDim) {
     add_matmul_naive_texture3d_node(
         graph, mat1, mat2_data, out, mat2_is_transposed);
   } else {

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
@@ -30,8 +30,7 @@ void check_qlinear_args(
   VK_CHECK_COND(qmat2_sizes.size() == 2);
   VK_CHECK_COND(scales_sizes.size() == 1);
 
-  VK_CHECK_COND(
-      graph.packed_dim_whcn_idx_of(mat1) == graph.packed_dim_whcn_idx_of(out));
+  VK_CHECK_COND(graph.packed_dim_of(mat1) == graph.packed_dim_of(out));
 
   VK_CHECK_COND(
       utils::val_at(-1, mat1_sizes) == utils::val_at(-1, qmat2_sizes));
@@ -79,8 +78,8 @@ void add_q_8w_linear_node(
 
   std::string kernel_name = "q_8w_linear";
   kernel_name.reserve(kShaderNameReserve);
-  add_packed_dim_suffix(kernel_name, graph.packed_dim_whcn_idx_of(mat1));
-  add_packed_dim_suffix(kernel_name, graph.packed_dim_whcn_idx_of(q_mat2));
+  add_packed_dim_suffix(kernel_name, graph.packed_dim_of(mat1));
+  add_packed_dim_suffix(kernel_name, graph.packed_dim_of(q_mat2));
   add_dtype_suffix(kernel_name, graph.dtype_of(out));
   add_storage_type_suffix(kernel_name, graph.storage_type_of(out));
 

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedMatMul.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedMatMul.cpp
@@ -31,14 +31,14 @@ void check_q_matmul_args(
   VK_CHECK_COND(mat1_sizes.size() == mat2_sizes.size());
 
   using namespace WHCN;
-  VK_CHECK_COND(graph.packed_dim_whcn_idx_of(mat1) == kWidthDim);
-  VK_CHECK_COND(graph.packed_dim_whcn_idx_of(mat2_data) == kWidthDim);
-  VK_CHECK_COND(graph.packed_dim_whcn_idx_of(scales_and_zeros) == kWidthDim);
+  VK_CHECK_COND(graph.packed_dim_of(mat1) == kWidthDim);
+  VK_CHECK_COND(graph.packed_dim_of(mat2_data) == kWidthDim);
+  VK_CHECK_COND(graph.packed_dim_of(scales_and_zeros) == kWidthDim);
 
   if (graph.storage_type_of(out) == utils::kBuffer) {
-    VK_CHECK_COND(graph.packed_dim_whcn_idx_of(out) == kWidthDim);
+    VK_CHECK_COND(graph.packed_dim_of(out) == kWidthDim);
   } else {
-    VK_CHECK_COND(graph.packed_dim_whcn_idx_of(out) == kChannelsDim);
+    VK_CHECK_COND(graph.packed_dim_of(out) == kChannelsDim);
   }
 
   const int mat1_K = utils::val_at(-1, mat1_sizes);

--- a/backends/vulkan/runtime/graph/ops/impl/Repeat.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Repeat.cpp
@@ -108,7 +108,7 @@ void add_repeat_channel_node(
       // Parameter buffers
       {graph.create_params_buffer(repeat_channel_args)},
       // Specialization Constants
-      {SV(t_out->packed_dim_whcn_idx())}));
+      {SV(t_out->packed_dim())}));
 }
 
 void add_repeat_node(

--- a/backends/vulkan/runtime/graph/ops/impl/Staging.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Staging.cpp
@@ -45,7 +45,7 @@ void add_staging_to_tensor_node(
       // Parameter Buffers
       ubos,
       // Specialization Constants
-      {SV(graph.packed_dim_whcn_idx_of(out_tensor))},
+      {SV(graph.packed_dim_of(out_tensor))},
       // Resizing Logic
       nullptr,
       {}));
@@ -97,7 +97,7 @@ void add_tensor_to_staging_node(
       // Parameter Buffers
       ubos,
       // Specialization Constants
-      {SV(graph.packed_dim_whcn_idx_of(in_tensor))}));
+      {SV(graph.packed_dim_of(in_tensor))}));
 }
 
 ValueRef prepack(
@@ -127,7 +127,7 @@ ValueRef prepack(
       // Parameter Buffers
       ubos,
       // Specialization Constants
-      {SV(graph.packed_dim_whcn_idx_of(v))}));
+      {SV(graph.packed_dim_of(v))}));
 
   return v;
 }

--- a/backends/vulkan/runtime/graph/ops/impl/View.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/View.cpp
@@ -76,7 +76,7 @@ void add_view_node(
       // Parameter Buffers
       {t_out->sizes_ubo(), t_in->sizes_ubo()},
       // Specialization Constants
-      {SV(t_in->packed_dim_whcn_idx()), SV(t_out->packed_dim_whcn_idx())},
+      {SV(t_in->packed_dim()), SV(t_out->packed_dim())},
       // Resizing Logic
       resize_view_node,
       {sizes}));

--- a/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.cpp
@@ -46,7 +46,7 @@ bool check_same_sizes_at(
 }
 
 bool check_packed_dim_is(const api::vTensor& t, const int32_t packed_dim) {
-  return t.packed_dim_whcn_idx() == packed_dim;
+  return t.packed_dim() == packed_dim;
 }
 
 bool check_same_ndim(const api::vTensor& t1, const api::vTensor& t2) {
@@ -54,17 +54,17 @@ bool check_same_ndim(const api::vTensor& t1, const api::vTensor& t2) {
 }
 
 bool check_same_packed_dim(const api::vTensor& t1, const api::vTensor& t2) {
-  return t1.packed_dim_whcn_idx() == t2.packed_dim_whcn_idx();
+  return t1.packed_dim() == t2.packed_dim();
 }
 
 bool check_same_packed_dim(
     const api::vTensor& t1,
     const api::vTensor& t2,
     const api::vTensor& t3) {
-  if (t1.packed_dim_whcn_idx() != t2.packed_dim_whcn_idx()) {
+  if (t1.packed_dim() != t2.packed_dim()) {
     return false;
   }
-  return (t1.packed_dim_whcn_idx() == t3.packed_dim_whcn_idx());
+  return (t1.packed_dim() == t3.packed_dim());
 }
 
 //
@@ -76,7 +76,7 @@ bool is_packed_dim_broadcasted(
     const api::vTensor& rcvr) {
   // We assume that the tensors are broadcastable. If values aren't equal at
   // some index, then the value of rcvr is 1 and hence should be broadcasted.
-  switch (sndr.packed_dim_whcn_idx()) {
+  switch (sndr.packed_dim()) {
     case WHCN::kChannelsDim:
       return utils::val_at(-3, sndr.sizes()) > utils::val_at(-3, rcvr.sizes());
     case WHCN::kHeightDim:

--- a/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.cpp
@@ -88,7 +88,7 @@ void add_packed_dim_suffix(std::string& kernel_name, const int32_t packed_dim) {
 void add_packed_dim_suffix(
     std::string& kernel_name,
     const api::vTensor& tensor) {
-  return add_packed_dim_suffix(kernel_name, tensor.packed_dim_whcn_idx());
+  return add_packed_dim_suffix(kernel_name, tensor.packed_dim());
 }
 
 } // namespace vkcompute

--- a/backends/vulkan/runtime/utils/StorageUtils.h
+++ b/backends/vulkan/runtime/utils/StorageUtils.h
@@ -87,7 +87,7 @@ T to_packed_dim_nchw_offset(const GPUMemoryLayout layout) {
 }
 
 template <typename T>
-T to_packed_dim_whcn_idx(const GPUMemoryLayout layout) {
+T to_packed_dim(const GPUMemoryLayout layout) {
   switch (layout) {
     case kWidthPacked:
       return 0;

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -70,8 +70,7 @@ void record_nchw_to_image_op(
     vkapi::VulkanBuffer& src_buffer,
     api::vTensor& v_dst) {
   vkapi::PipelineBarrier pipeline_barrier{};
-  vkapi::SpecVarList specialization_constants = {
-      SV(v_dst.packed_dim_whcn_idx())};
+  vkapi::SpecVarList specialization_constants = {SV(v_dst.packed_dim())};
 
   context->submit_compute_job(
       get_nchw_to_tensor_shader(
@@ -96,8 +95,7 @@ void record_image_to_nchw_op(
     api::vTensor& v_src,
     vkapi::VulkanBuffer& dst_buffer) {
   vkapi::PipelineBarrier pipeline_barrier{};
-  vkapi::SpecVarList specialization_constants = {
-      SV(v_src.packed_dim_whcn_idx())};
+  vkapi::SpecVarList specialization_constants = {SV(v_src.packed_dim())};
 
   context->submit_compute_job(
       get_tensor_to_nchw_shader(v_src),
@@ -125,7 +123,7 @@ void record_int8_image_to_nchw_noint8_op(
       pipeline_barrier,
       global_wg_size,
       adaptive_work_group_size(global_wg_size),
-      {v_src.packed_dim_whcn_idx()},
+      {v_src.packed_dim()},
       VK_NULL_HANDLE,
       0,
       dst_buffer.buffer(),
@@ -334,9 +332,7 @@ void record_matmul_texture3d(
       pipeline_barrier,
       global_wg_size,
       {8, 8, 1},
-      {out.packed_dim_whcn_idx(),
-       mat1.packed_dim_whcn_idx(),
-       mat2.packed_dim_whcn_idx()},
+      {out.packed_dim(), mat1.packed_dim(), mat2.packed_dim()},
       VK_NULL_HANDLE,
       0,
       out.image(

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -296,7 +296,7 @@ TEST_F(VulkanComputeAPITest, virtual_transpose_test) {
       a_texture.virtual_transpose(dim0, dim1);
       EXPECT_TRUE(a_texture.sizes() == expected_sizes);
       EXPECT_TRUE(a_texture.axis_map() == expected_axis_map);
-      EXPECT_TRUE(a_texture.packed_dim_whcn_idx() == expected_packed_dim);
+      EXPECT_TRUE(a_texture.packed_dim() == expected_packed_dim);
     }
   }
 }
@@ -753,7 +753,7 @@ TEST_F(VulkanComputeAPITest, tensor_no_copy_transpose_test) {
     // Update sizes and strides of mat2_t to be that of a transposed tensor
     mat2_t.virtual_transpose(0, 1);
 
-    EXPECT_TRUE(mat2_t.packed_dim_whcn_idx() == WHCN::kHeightDim);
+    EXPECT_TRUE(mat2_t.packed_dim() == WHCN::kHeightDim);
 
     std::vector<float> mat2_t_data = transpose_matrix(mat2_data, N, K);
     std::vector<float> ref_out =
@@ -2276,7 +2276,7 @@ void run_from_gpu_test(
         pipeline_barrier,
         vten.logical_limits(),
         {4, 4, 4},
-        {vten.packed_dim_whcn_idx(), offset},
+        {vten.packed_dim(), offset},
         VK_NULL_HANDLE,
         0,
         vten.image(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5484
* #5479

## Context

`packed_dim_whcn_idx` is a bit too verbose. Replace it with `packed_dim` for brevity.

Differential Revision: [D63032323](https://our.internmc.facebook.com/intern/diff/D63032323/)