### PR TITLE
[ET-VK][ez] Fix underflow error in `calculate_dim_order()`

### DIFF
--- a/backends/vulkan/runtime/api/containers/Tensor.cpp
+++ b/backends/vulkan/runtime/api/containers/Tensor.cpp
@@ -21,7 +21,8 @@ std::vector<int64_t> calculate_dim_order(
     return {0};
   }
   std::vector<int64_t> dim_order(ndim);
-  int64_t last_dim = ndim - 1 - packed_dim;
+  // Explicitly convert ndim to signed to prevent underflow
+  int64_t last_dim = int64_t(ndim) - 1 - packed_dim;
 
   int64_t cur_dim = 0;
   for (int d = 0; d < ndim; ++d) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5498

## Context

FIx an underflow error. The issue is that `ndim` is unsigned, therefore if it is `0` when it gets subtracted by one it underflows. Not sure why this wasn't caught by CI tests before.

Differential Revision: [D63050011](https://our.internmc.facebook.com/intern/diff/D63050011/)