### PR TITLE
Android custom lib

### DIFF
--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -58,13 +58,21 @@ else()
   list(APPEND link_libraries portable_ops_lib portable_kernels)
   target_link_options_shared_lib(portable_ops_lib)
 endif()
+
+if(TARGET quantized_kernels)
+  list(APPEND link_libraries quantized_kernels quantized_ops_lib)
+  target_link_options_shared_lib(quantized_ops_lib)
+endif()
+
 if(TARGET qnn_executorch_backend)
   list(APPEND link_libraries qnn_executorch_backend)
 endif()
+
 if(TARGET xnnpack_backend)
   target_link_options_shared_lib(xnnpack_backend)
   list(APPEND link_libraries xnnpack_backend XNNPACK pthreadpool cpuinfo)
 endif()
+
 if(TARGET vulkan_backend)
   target_link_options_shared_lib(vulkan_backend)
   list(APPEND link_libraries vulkan_backend)
@@ -77,6 +85,20 @@ if(EXECUTORCH_BUILD_KERNELS_CUSTOM)
   )
   list(APPEND link_libraries custom_ops)
   target_link_options_shared_lib(custom_ops)
+endif()
+
+if(TARGET pthreadpool)
+  target_compile_definitions(executorch_jni PRIVATE ET_USE_THREADPOOL=1)
+  target_include_directories(
+    executorch_jni
+    PUBLIC
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../backends/xnnpack/third-party/cpuinfo/include
+  )
+  target_include_directories(
+    executorch_jni
+    PUBLIC
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../backends/xnnpack/third-party/pthreadpool/include
+  )
 endif()
 
 add_library(executorch_jni SHARED jni/jni_layer.cpp)
@@ -96,11 +118,6 @@ if(EXECUTORCH_BUILD_LLAMA_JNI)
   )
 endif()
 
-if(TARGET quantized_kernels)
-  list(APPEND link_libraries quantized_kernels quantized_ops_lib)
-  target_link_options_shared_lib(quantized_ops_lib)
-endif()
-
 target_include_directories(
   executorch_jni PRIVATE ${_common_include_directories}
 )
@@ -108,17 +125,3 @@ target_include_directories(
 target_compile_options(executorch_jni PUBLIC ${_common_compile_options})
 
 target_link_libraries(executorch_jni ${link_libraries})
-
-if(TARGET pthreadpool)
-  target_compile_definitions(executorch_jni PRIVATE ET_USE_THREADPOOL=1)
-  target_include_directories(
-    executorch_jni
-    PUBLIC
-      ${CMAKE_CURRENT_SOURCE_DIR}/../../backends/xnnpack/third-party/cpuinfo/include
-  )
-  target_include_directories(
-    executorch_jni
-    PUBLIC
-      ${CMAKE_CURRENT_SOURCE_DIR}/../../backends/xnnpack/third-party/pthreadpool/include
-  )
-endif()

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -103,6 +103,10 @@ if(TARGET pthreadpool)
   )
 endif()
 
+if(EXECUTORCH_JNI_CUSTOM_LIBRARY)
+  list(APPEND link_libraries ${EXECUTORCH_JNI_CUSTOM_LIBRARY})
+  target_link_libraries(executorch_jni -Wl,--whole-archive ${EXECUTORCH_JNI_CUSTOM_LIBRARY} -Wl,--no-whole-archive)
+endif()
 
 if(EXECUTORCH_BUILD_LLAMA_JNI)
   target_sources(executorch_jni PRIVATE jni/jni_layer_llama.cpp)

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -105,7 +105,10 @@ endif()
 
 if(EXECUTORCH_JNI_CUSTOM_LIBRARY)
   list(APPEND link_libraries ${EXECUTORCH_JNI_CUSTOM_LIBRARY})
-  target_link_libraries(executorch_jni -Wl,--whole-archive ${EXECUTORCH_JNI_CUSTOM_LIBRARY} -Wl,--no-whole-archive)
+  target_link_libraries(
+    executorch_jni -Wl,--whole-archive ${EXECUTORCH_JNI_CUSTOM_LIBRARY}
+    -Wl,--no-whole-archive
+  )
 endif()
 
 if(EXECUTORCH_BUILD_LLAMA_JNI)

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -30,6 +30,8 @@ set(executorch_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../lib/cmake/ExecuTorch)
 find_package(executorch CONFIG REQUIRED)
 target_link_options_shared_lib(executorch)
 
+add_library(executorch_jni SHARED jni/jni_layer.cpp)
+
 set(link_libraries)
 list(
   APPEND
@@ -101,7 +103,6 @@ if(TARGET pthreadpool)
   )
 endif()
 
-add_library(executorch_jni SHARED jni/jni_layer.cpp)
 
 if(EXECUTORCH_BUILD_LLAMA_JNI)
   target_sources(executorch_jni PRIVATE jni/jni_layer_llama.cpp)


### PR DESCRIPTION
1. Clean up the file to group all deps libs together.
2. Add an option `EXECUTORCH_JNI_CUSTOM_LIBRARY` for user to pass in their own library.

Example:
```
echo "int my_function() { return 0; }" > my_source.cpp
echo "int my_function2() { return 0; }" > my_source2.cpp

${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android27-clang -c my_source.cpp -o file1.o
${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android27-clang -c my_source2.cpp -o file2.o

ar rcs libmystaticlib.a file1.o
ar rcs libmystaticlib2.a file2.o

rm my_source.cpp my_source2.cpp file1.o file2.o

cmake extension/android \
    -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
    -DANDROID_ABI=arm64-v8a \
    -DANDROID_PLATFORM=android-23 \
    -DCMAKE_INSTALL_PREFIX=cmake-out-android-arm64-v8a \
    -DEXECUTORCH_ENABLE_LOGGING=ON \
    -DEXECUTORCH_LOG_LEVEL=Info \
    -DEXECUTORCH_BUILD_KERNELS_CUSTOM=ON \
    -DEXECUTORCH_BUILD_LLAMA_JNI=ON \
    -DEXECUTORCH_JNI_CUSTOM_LIBRARY="/home/hsz/executorch/libmystaticlib.a;/home/hsz/executorch/libmystaticlib2.a" \
    -DCMAKE_BUILD_TYPE=Release \
    -Bcmake-out-android-arm64-v8a/extension/android

cmake --build cmake-out-android-arm64-v8a/extension/android -j 10 --config Release

nm -gDC ./cmake-out-android-arm64-v8a/extension/android/libexecutorch_jni.so | grep my_function

```

and you will see
```
00000000001d1ff0 T my_function()
00000000001d1ff8 T my_function2()
```