### PR TITLE
Remove stray uses of `torch::executor::` from examples/...

### DIFF
--- a/examples/devtools/README.md
+++ b/examples/devtools/README.md
@@ -64,7 +64,7 @@ Once an `ETDump` has been generated, it can be viewed using the CLI inspector. T
 ETDump profiling can also be used in a custom C++ program. `ETDumpGen` is an implementation of the abstract `EventTracer` class.  Include the header file located at `devtools/etdump/etdump_flatcc.h`. To initialize the ETDump generator, construct it before loading the method from the program.
 
 ```cpp
-   torch::executor::ETDumpGen etdump_gen = torch::executor::ETDumpGen();
+   executorch::etdump::ETDumpGen etdump_gen;
    Result<Method> method =
       program->load_method(method_name, &memory_manager, &etdump_gen);
    ```

--- a/examples/models/llava/main.cpp
+++ b/examples/models/llava/main.cpp
@@ -48,6 +48,8 @@ DEFINE_int32(
     -1,
     "Number of CPU threads for inference. Defaults to -1, which implies we'll use a heuristic to derive the # of performant cores for a specific device.");
 
+using executorch::extension::llm::Image;
+
 int32_t main(int32_t argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
@@ -90,7 +92,7 @@ int32_t main(int32_t argc, char** argv) {
   image_data.resize(3 * 240 * 336);
   std::fill(image_data.begin(), image_data.end(), 0); // black
   std::array<int32_t, 3> image_shape = {3, 240, 336};
-  std::vector<torch::executor::Image> images = {
+  std::vector<Image> images = {
       {.data = image_data, .width = image_shape[2], .height = image_shape[1]}};
 #else //  LLAVA_NO_TORCH_DUMMY_IMAGE
   //   cv::Mat image = cv::imread(image_path, cv::IMREAD_COLOR);
@@ -111,7 +113,7 @@ int32_t main(int32_t argc, char** argv) {
   image_data.assign(
       image_tensor.data_ptr<uint8_t>(),
       image_tensor.data_ptr<uint8_t>() + image_tensor.numel());
-  std::vector<torch::executor::Image> images = {
+  std::vector<Image> images = {
       {.data = image_data,
        .width = static_cast<int32_t>(image_tensor.size(2)),
        .height = static_cast<int32_t>(image_tensor.size(1))}};


### PR DESCRIPTION
Example code should use the new `executorch::` namespace wherever possible, and should not define code under the `torch::` namespace.

Test Plan:
- Built llava changes with `bash .ci/scripts/test_llava.sh`