### PR TITLE
[ExecuTorch] Include optimized kernels in pybindings' portable_lib if building them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,10 +680,15 @@ if(EXECUTORCH_BUILD_PYBIND)
       etdump
       executorch
       extension_data_loader
-      portable_ops_lib
       util
       torch
   )
+
+  if(EXECUTORCH_BUILD_KERNELS_OPTIMIZED)
+    list(APPEND _dep_libs optimized_native_cpu_ops_lib)
+  else()
+    list(APPEND _dep_libs portable_ops_lib)
+  endif()
 
   if(EXECUTORCH_BUILD_COREML)
     list(APPEND _dep_libs coremldelegate)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5520
* #5519
* #5500
* #5499

reserved

Differential Revision: [D63147278](https://our.internmc.facebook.com/intern/diff/D63147278/)