### PR TITLE
Fix duplicating latest prompt

### DIFF
--- a/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/MainActivity.java
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/MainActivity.java
@@ -661,7 +661,14 @@ public class MainActivity extends AppCompatActivity implements Runnable, LlamaCa
     mSendButton.setOnClickListener(
         view -> {
           addSelectedImagesToChatThread(mSelectedImageUri);
+          String finalPrompt;
           String rawPrompt = mEditTextMessage.getText().toString();
+          if (ModelUtils.getModelCategory(mCurrentSettingsFields.getModelType())
+              == ModelUtils.VISION_MODEL) {
+            finalPrompt = mCurrentSettingsFields.getFormattedSystemAndUserPrompt(rawPrompt);
+          } else {
+            finalPrompt = getTotalFormattedPrompt(getConversationHistory(), rawPrompt);
+          }
           // We store raw prompt into message adapter, because we don't want to show the extra
           // tokens from system prompt
           mMessageAdapter.add(new Message(rawPrompt, true, MessageType.TEXT, promptID));
@@ -692,14 +699,12 @@ public class MainActivity extends AppCompatActivity implements Runnable, LlamaCa
                   if (ModelUtils.getModelCategory(mCurrentSettingsFields.getModelType())
                       == ModelUtils.VISION_MODEL) {
                     mModule.generateFromPos(
-                        mCurrentSettingsFields.getFormattedSystemAndUserPrompt(rawPrompt),
+                        finalPrompt,
                         ModelUtils.VISION_MODEL_SEQ_LEN,
                         startPos,
                         MainActivity.this,
                         false);
                   } else {
-                    String finalPrompt =
-                        getTotalFormattedPrompt(getConversationHistory(), rawPrompt);
                     ETLogging.getInstance().log("Running inference.. prompt=" + finalPrompt);
                     mModule.generate(
                         finalPrompt,


### PR DESCRIPTION
Summary:
The last prompt sent would be included in `getConversationHistory()` + adding it prior to sending it with the generate(). It looks like this got move during the rebasing.

To fix this we now call `getConversationHistory()` prior to adding the rawPrompt to a Message.

In regards to model response, I noticed that it did not really change the quality of the response. (tested with Llama 3.1)

Reviewed By: Riandy

Differential Revision: D62761977


