### PR TITLE
Transform embedding from SpinQuant checkpoint

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -371,6 +371,28 @@ def build_args_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--spin_qmode",
+        type=str,
+        default=None,
+        choices=["8da4w"],
+        help="Quantization mode for SpinQuant. Only support 8da4w right now.",
+    )
+
+    parser.add_argument(
+        "--spin_group_size",
+        type=int,
+        default=32,
+        help="group_size for SpinQuant weight quantization",
+    )
+
+    parser.add_argument(
+        "--spin_embedding_quantize",
+        default="8,0",
+        type=str,
+        help="type of embedding quantization for SpinQuant, '<bitwidth>,<groupsize>', e.g., '8,1024'.",
+    )
+
+    parser.add_argument(
         "--output_prune_map",
         default=None,
         help="path to the output pruning token mapping file (token_map.json)",
@@ -466,10 +488,10 @@ def _prepare_for_llama_export(modelname: str, args) -> LLMEdgeManager:
             max_seq_len=args.max_seq_length,
             output_prune_map_path=args.output_prune_map,
             metadata_str=args.metadata,
+            dtype_override=dtype_override,
             args=args,
         )
         .set_output_dir(output_dir_path)
-        .to_dtype(dtype_override)
         .source_transform(_get_source_transforms(modelname, dtype_override, args))
     )
 
@@ -691,6 +713,7 @@ def _load_llama_model(
     max_seq_len: int = 128,
     output_prune_map_path: Optional[str] = None,
     metadata_str: Optional[str] = None,
+    dtype_override: Optional[DType] = None,
     args,
 ) -> "LLMEdgeManager":
     """
@@ -720,23 +743,32 @@ def _load_llama_model(
         output_prune_map_path=output_prune_map_path,
         args=args,
     )
-    state_dict = model.state_dict()
-    dtype = state_dict[next(iter(state_dict))].dtype
-    assert dtype in [
-        torch.bfloat16,
-        torch.float16,
-        torch.float32,
-    ], f"Only support bfloat16, fp16 or fp32 got {dtype}"
-    logging.info(f"Loaded model with dtype={dtype}")
-
-    if dtype == torch.bfloat16:
-        dtype = DType.bf16
-    elif dtype == torch.float16:
-        dtype = DType.fp16
-    elif dtype == torch.float32:
-        dtype = DType.fp32
+    if dtype_override:
+        assert isinstance(
+            dtype_override, DType
+        ), "Override dtype needs to be of type <DType>"
+        torch_dtype = dtype_override.to_torch_dtype()
+        logging.info(f"model.to {torch_dtype}")
+        model = model.to(dtype=torch_dtype)
+        dtype = dtype_override
     else:
-        raise ValueError(f"Unsupported dtype {dtype}")
+        state_dict = model.state_dict()
+        dtype = state_dict[next(iter(state_dict))].dtype
+        assert dtype in [
+            torch.bfloat16,
+            torch.float16,
+            torch.float32,
+        ], f"Only support bfloat16, fp16 or fp32 got {dtype}"
+        logging.info(f"Loaded model with dtype={dtype}")
+
+        if dtype == torch.bfloat16:
+            dtype = DType.bf16
+        elif dtype == torch.float16:
+            dtype = DType.fp16
+        elif dtype == torch.float32:
+            dtype = DType.fp32
+        else:
+            raise ValueError(f"Unsupported dtype {dtype}")
 
     return LLMEdgeManager(
         model=model,
@@ -769,21 +801,9 @@ def _get_source_transforms(  # noqa
     modelname: str, dtype_override: Optional[DType], args
 ) -> List[Callable[[torch.nn.Module], torch.nn.Module]]:
     transforms = []
-    if args.quantization_mode:
-        modelname = f"{modelname}_q"
-        if args.use_spin_quant is None:
-            transforms.append(
-                get_quant_weight_transform(args, dtype_override, verbose_export())
-            )
-        # For SpinQuant, the checkpoints are already quantized
-        # aka the weights have corresponding scales value,
-        # So that means, we don't need to apply quantization
-        # transform. However, we will still need to apply
-        # transformations that change the model structure to
-        # match the checkpoint format.
-        # transform_for_spinquant() will apply these transformations
-        # later in model.py file.
-        elif args.use_spin_quant == "cuda":
+
+    if args.use_spin_quant:
+        if args.use_spin_quant == "cuda":
             from .source_transformation.spin_quant import (
                 inject_fast_hadamard_transform_cuda_for_spin_quant,
             )
@@ -796,7 +816,35 @@ def _get_source_transforms(  # noqa
 
             transforms.append(inject_fast_hadamard_transform_native_for_spin_quant)
 
+    if args.quantization_mode:
+        """
+        When this option is selected, it finds all linear layers and transforms
+        into quantized linear equivalent module.
+
+        There are cases where the checkpoint is already quantized, for example
+        on use_spin_quant is enabled. In that case, it will do the appropriate
+        transformations based on the given checkpoint first. In those cases,
+        if quantization_mode is enabled, it will quantize any remaining linear
+        ops that is not quantized.
+
+        There are cases where this may be a no-op, namely, if all linears are
+        quantized in the checkpoint.
+        """
+        modelname = f"{modelname}_q"
+        transforms.append(
+            get_quant_weight_transform(args, dtype_override, verbose_export())
+        )
+
     if args.embedding_quantize:
+        """
+        When this option is selected, it finds all embedding layers and transforms
+        into quantized embedding equivalent module.
+
+        There are cases where the checkpoint is already quantized, for example
+        on use_spin_quant is enabled. In that case, it will do the appropriate
+        transformations based on the given checkpoint first. In those cases,
+        this wil be a no-op.
+        """
         modelname = f"{modelname}_e"
         transforms.append(get_quant_embedding_transform(args))
 

--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -191,16 +191,16 @@ the checkpoint format to avoid generating faulty models.
             )
         elif hasattr(self.args, "use_spin_quant") and self.args.use_spin_quant:
             print("Using SPIN quantization.")
-            assert hasattr(self.args, "group_size"), "group_size must be specified"
+            assert hasattr(self.args, "spin_qmode"), "spin_qmode must be specified"
             assert hasattr(
-                self.args, "quantization_mode"
-            ), "quantization_mode must be specified"
+                self.args, "spin_group_size"
+            ), "spin_group_size must be specified"
             assert hasattr(
                 self.args, "dtype_override"
             ), "dtype_override must be specified"
             from .source_transformation.spin_quant import (
                 sanitize_checkpoint_from_spinquant,
-                transform_for_spinquant,
+                transform_linear_for_spinquant,
             )
 
             mapping = {
@@ -209,17 +209,45 @@ the checkpoint format to avoid generating faulty models.
                 "bf16": torch.bfloat16,
             }
 
-            self.model_ = transform_for_spinquant(
+            self.model_ = transform_linear_for_spinquant(
                 self.model_,
                 checkpoint,
-                self.args.group_size,
-                self.args.quantization_mode,
+                self.args.spin_group_size,
+                self.args.spin_qmode,
                 mapping[self.args.dtype_override],
             )
 
+            embedding_bit_width, embedding_group_size = None, None
+            if hasattr(self.args, "spin_embedding_quantize"):
+                embedding_bit_width, embedding_group_size = (
+                    self.args.spin_embedding_quantize.split(",")
+                )
+                from .source_transformation.spin_quant import (
+                    transform_embedding_for_spinquant,
+                )
+
+                if (
+                    embedding_group_size == "none"
+                    or embedding_group_size == "None"
+                    or embedding_group_size == "0"
+                ):
+                    embedding_group_size = None
+                else:
+                    embedding_group_size = int(embedding_group_size)
+
+                self.model_ = transform_embedding_for_spinquant(
+                    self.model_,
+                    checkpoint,
+                    mapping[self.args.dtype_override],
+                    int(embedding_bit_width),
+                    embedding_group_size,
+                )
+
             sanitize_checkpoint_from_spinquant(
-                checkpoint,
-                self.args.group_size,
+                module=self.model_,
+                checkpoint=checkpoint,
+                linear_group_size=self.args.spin_group_size,
+                embedding_group_size=embedding_group_size,
             )
 
         # assign=True: load params/buffers by assignment instead of performing an in-place copy.

--- a/examples/models/llama2/tests/test_spinquant_transforms.py
+++ b/examples/models/llama2/tests/test_spinquant_transforms.py
@@ -10,24 +10,15 @@ import torch
 from executorch.examples.models.llama2.llama_transformer import ModelArgs, Transformer
 from executorch.examples.models.llama2.source_transformation.spin_quant import (
     sanitize_checkpoint_from_spinquant,
-    transform_for_spinquant,
+    transform_embedding_for_spinquant,
+    transform_linear_for_spinquant,
 )
 from torchao.quantization.utils import group_quantize_tensor_symmetric
 
 
 class SpinQuantTests(unittest.TestCase):
-    def test_transforms_for_spinquant(self):
 
-        # Step 1: Create llama class with dummy weights
-        params = {
-            "dim": 768,
-            "multiple_of": 32,
-            "n_heads": 12,
-            "n_layers": 12,
-            "norm_eps": 1e-05,
-            "vocab_size": 32000,
-        }
-
+    def _prepare_dummy_model(self) -> Transformer:
         model_args = ModelArgs(
             max_seq_len=2048,
             max_batch_size=1,
@@ -35,10 +26,22 @@ class SpinQuantTests(unittest.TestCase):
             use_sdpa_with_kv_cache_op=False,
             generate_full_logits=False,
             enable_dynamic_shape=True,
-            **params,
+            dim=768,
+            multiple_of=32,
+            n_heads=12,
+            n_layers=12,
+            norm_eps=1e-05,
+            vocab_size=32000,
         )
 
         model = Transformer(model_args)
+
+        return model
+
+    def test_transform_linear_for_spinquant(self):
+
+        # Step 1: Create llama class with dummy weights
+        model = self._prepare_dummy_model()
         checkpoint = model.state_dict()
 
         # Step 2:
@@ -63,7 +66,7 @@ class SpinQuantTests(unittest.TestCase):
 
         # Step 3:
         # Transform the model so that it is compatible with the new checkpoint
-        transform_for_spinquant(
+        transform_linear_for_spinquant(
             model,
             checkpoint,
             32,
@@ -71,8 +74,64 @@ class SpinQuantTests(unittest.TestCase):
             torch.float32,
         )
         sanitize_checkpoint_from_spinquant(
+            model,
             checkpoint,
             -1,
+        )
+
+        model.load_state_dict(
+            checkpoint,
+            strict=False,
+            assign=True,
+        )
+
+        new_checkpoint = model.state_dict()
+
+        for k, v in checkpoint.items():
+            # The new_checkpoint contains zeros so
+            # have to iterate over the keys.
+            self.assertTrue(torch.allclose(new_checkpoint[k], v))
+
+    def test_transform_embedding_for_spinquant(self):
+
+        # Step 1: Create llama class with dummy weights
+        model = self._prepare_dummy_model()
+        checkpoint = model.state_dict()
+
+        # Step 2:
+        # Do group-wise quantization and amend the checkpoints with
+        # int8 weight and fp32 scales
+        group_size = 32
+        n_bit = 4
+        scales_precision = torch.float32
+        for fqn, mod in model.named_modules():
+            # Quantize everything except the last layer
+            if isinstance(mod, torch.nn.Embedding):
+                weight = mod.weight.data
+                (
+                    weight_int8,
+                    scales,
+                    zeros,
+                ) = group_quantize_tensor_symmetric(
+                    weight.to(torch.float32), n_bit, group_size, scales_precision
+                )
+                checkpoint[f"{fqn}.weight"] = weight_int8.to("cpu")
+                checkpoint[f"{fqn}.scale"] = scales.to("cpu")
+
+        # Step 3:
+        # Transform the model so that it is compatible with the new checkpoint
+        transform_embedding_for_spinquant(
+            model,
+            checkpoint,
+            torch.float32,
+            n_bit,
+            group_size,
+        )
+        sanitize_checkpoint_from_spinquant(
+            module=model,
+            checkpoint=checkpoint,
+            linear_group_size=-1,
+            embedding_group_size=-1,
         )
 
         model.load_state_dict(


### PR DESCRIPTION
Summary: This diff updates the llama export part to be able to load SpinQuant checkpoint which has all linear layers and embedding table quantized.

Differential Revision: D62665632
