### PR TITLE
Add CastInt64ToInt32Pass

### DIFF
--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -217,7 +217,7 @@ class ArmBackend(BackendDetails):
         # const data directly. Path created and data written only in debug builds.
         tosa_graph = ts.TosaSerializer(artifact_path)
         graph_module = ArmPassManager().transform_to_backend_pipeline(
-            graph_module=edge_program.graph_module, compile_spec=compile_spec
+            exported_program=edge_program, compile_spec=compile_spec
         )
 
         node_visitors = get_node_visitors(edge_program)

--- a/backends/arm/arm_partitioner.py
+++ b/backends/arm/arm_partitioner.py
@@ -57,6 +57,7 @@ class TOSASupportedOperators(OperatorSupportBase):
             exir_ops.edge.aten.sigmoid.default,
             exir_ops.edge.aten.mm.default,
             exir_ops.edge.aten.repeat.default,
+            exir_ops.edge.aten.reciprocal.default,
             exir_ops.edge.aten.relu.default,
             exir_ops.edge.aten._softmax.default,
             exir_ops.edge.aten.slice_copy.Tensor,

--- a/backends/arm/operators/__init__.py
+++ b/backends/arm/operators/__init__.py
@@ -15,7 +15,6 @@ from . import (  # noqa
     op_cat,
     op_conv2d,
     op_dequant,
-    op_div,
     op_exp,
     op_full,
     op_get_item,

--- a/backends/arm/operators/__init__.py
+++ b/backends/arm/operators/__init__.py
@@ -26,6 +26,7 @@ from . import (  # noqa
     op_mul,
     op_permute,
     op_quant,
+    op_reciprocal,
     op_relu,
     op_repeat,
     op_sigmoid,

--- a/backends/arm/operators/op_reciprocal.py
+++ b/backends/arm/operators/op_reciprocal.py
@@ -1,0 +1,80 @@
+# Copyright 2023-2024 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import List
+
+import numpy as np
+
+import serializer.tosa_serializer as ts
+import torch
+from executorch.backends.arm.operators.node_visitor import (
+    NodeVisitor,
+    register_node_visitor,
+)
+from executorch.backends.arm.tosa_mapping import TosaArg
+from executorch.backends.arm.tosa_quant_utils import (
+    dequantize_value,
+    get_quant_node_args,
+    QuantArgs,
+    quantize_value,
+)
+from serializer.tosa_serializer import TosaOp
+
+
+@register_node_visitor
+class DivVisitor(NodeVisitor):
+    target = "aten.reciprocal.default"
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        tosa_graph: ts.TosaSerializer,
+        inputs: List[TosaArg],
+        output: TosaArg,
+        is_quant_node: bool,
+    ) -> None:
+        # 1/X
+
+        if is_quant_node:
+            input = inputs[0]
+            input_qargs = get_quant_node_args(node.args[0])
+            output_qargs = get_quant_node_args(list(node.users)[0])
+
+            div_table = div_table_8bit(input_qargs, output_qargs)
+
+            table_attr = ts.TosaSerializerAttribute()
+            table_attr.TableAttribute(div_table)
+            tosa_graph.addOperator(
+                TosaOp.Op().TABLE, [input.name], [output.name], table_attr
+            )
+
+        else:
+            tosa_graph.addOperator(
+                TosaOp.Op().RECIPROCAL, [inputs[0].name], [output.name]
+            )
+
+
+def div_table_8bit(in_quantargs: QuantArgs, out_quantargs: QuantArgs):
+    """
+    Returns a table mapping 256 entries to div([qmin,qmax])
+    """
+
+    def div(x):
+        # Convert quantized input to floating point div input space.
+        v1 = dequantize_value(x, in_quantargs)
+        # Compute div.
+        v2 = 1.0 / v1
+        # Convert div output back to quantized space.
+        v3 = quantize_value(v2, out_quantargs)
+
+        # print(f"{v1} -> {v2} -> {v3}")
+        return v3
+
+    return [
+        div(x)
+        for x in np.linspace(in_quantargs.qmin, in_quantargs.qmax, 256, dtype=np.int8)
+    ]

--- a/backends/arm/passes/arm_pass_manager.py
+++ b/backends/arm/passes/arm_pass_manager.py
@@ -18,6 +18,7 @@ from executorch.backends.arm.passes.convert_split_to_slice import (
     ConvertSplitToSlicePass,
 )
 from executorch.backends.arm.passes.decompose_div_pass import DecomposeDivPass
+from executorch.backends.arm.passes.cast_int64_pass import CastInt64ToInt32Pass
 from executorch.backends.arm.passes.meandim_to_averagepool_pass import (
     ConvertMeanDimToAveragePool,
 )
@@ -40,6 +41,7 @@ class ArmPassManager(PassManager):
         self, exported_program: ExportedProgram, compile_spec: list[CompileSpec]
     ):
         """Apply passes before transforming program to backend"""
+        self.add_pass(CastInt64ToInt32Pass(exported_program))
         self.add_pass(SizeAdjustConv2DPass())
         self.add_pass(RemoveClonePass())
         self.add_pass(ConvertExpandCopyToRepeatPass())

--- a/backends/arm/passes/arm_pass_manager.py
+++ b/backends/arm/passes/arm_pass_manager.py
@@ -26,6 +26,7 @@ from executorch.backends.arm.passes.scalars_to_attribute_pass import (
     ScalarsToAttributePass,
 )
 from executorch.backends.arm.passes.size_adjust_conv2d_pass import SizeAdjustConv2DPass
+from executorch.exir import ExportedProgram
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.pass_manager import PassManager
 
@@ -36,7 +37,7 @@ class ArmPassManager(PassManager):
         return self(graph_module).graph_module
 
     def transform_to_backend_pipeline(
-        self, graph_module: torch.fx.GraphModule, compile_spec: list[CompileSpec]
+        self, exported_program: ExportedProgram, compile_spec: list[CompileSpec]
     ):
         """Apply passes before transforming program to backend"""
         self.add_pass(SizeAdjustConv2DPass())
@@ -51,7 +52,7 @@ class ArmPassManager(PassManager):
                 if memory_format == "nhwc":
                     self.add_pass(AnnotateChannelsLastDimOrder())
 
-        return self._transform(graph_module)
+        return self._transform(exported_program.graph_module)
 
     def transform_for_annotation_pipeline(self, graph_module: torch.fx.GraphModule):
         self.add_pass(DecomposeDivPass())

--- a/backends/arm/passes/arm_pass_manager.py
+++ b/backends/arm/passes/arm_pass_manager.py
@@ -17,10 +17,14 @@ from executorch.backends.arm.passes.convert_expand_copy_to_repeat import (
 from executorch.backends.arm.passes.convert_split_to_slice import (
     ConvertSplitToSlicePass,
 )
+from executorch.backends.arm.passes.decompose_div_pass import DecomposeDivPass
 from executorch.backends.arm.passes.meandim_to_averagepool_pass import (
     ConvertMeanDimToAveragePool,
 )
 from executorch.backends.arm.passes.remove_clone_pass import RemoveClonePass
+from executorch.backends.arm.passes.scalars_to_attribute_pass import (
+    ScalarsToAttributePass,
+)
 from executorch.backends.arm.passes.size_adjust_conv2d_pass import SizeAdjustConv2DPass
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.pass_manager import PassManager
@@ -39,6 +43,7 @@ class ArmPassManager(PassManager):
         self.add_pass(RemoveClonePass())
         self.add_pass(ConvertExpandCopyToRepeatPass())
         self.add_pass(ConvertMeanDimToAveragePool())
+        self.add_pass(DecomposeDivPass())
         self.add_pass(ConvertSplitToSlicePass())
         for spec in compile_spec:
             if spec.key == "permute_memory_format":
@@ -46,4 +51,9 @@ class ArmPassManager(PassManager):
                 if memory_format == "nhwc":
                     self.add_pass(AnnotateChannelsLastDimOrder())
 
+        return self._transform(graph_module)
+
+    def transform_for_annotation_pipeline(self, graph_module: torch.fx.GraphModule):
+        self.add_pass(DecomposeDivPass())
+        self.add_pass(ScalarsToAttributePass())
         return self._transform(graph_module)

--- a/backends/arm/passes/cast_int64_pass.py
+++ b/backends/arm/passes/cast_int64_pass.py
@@ -1,0 +1,28 @@
+# Copyright 2024 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.exir.pass_base import ExportPass, PassResult
+
+class CastInt64ToInt32Pass(ExportPass):
+    def __init__(self, exported_program: torch.export.ExportedProgram):
+        super(CastInt64ToInt32Pass, self).__init__()
+        self.exported_program = exported_program
+
+    def _to_int32(self, graph_module: torch.fx.GraphModule):
+        for node in graph_module.graph.nodes:
+            fake_tensor = node.meta["val"]
+            if isinstance(fake_tensor,torch._subclasses.fake_tensor.FakeTensor):
+                if node.meta["val"].dtype == torch.int64:
+                    node.meta["val"] = node.meta["val"].to(torch.int32)
+                    buffer_name = self.exported_program.graph_signature.inputs_to_buffers[node.name]
+                    new_tensor = self.exported_program.state_dict[buffer_name].to(torch.int32)
+                    self.exported_program.state_dict[buffer_name] = new_tensor
+
+    def call(self, graph_module: torch.fx.GraphModule):
+        self._to_int32(graph_module)
+        graph_module.recompile()
+        graph_module = super().call(graph_module).graph_module
+        return PassResult(graph_module, True)

--- a/backends/arm/passes/decompose_div_pass.py
+++ b/backends/arm/passes/decompose_div_pass.py
@@ -1,0 +1,45 @@
+# Copyright 2024 Arm Limited and/or its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
+
+
+def get_div_decomposition(op) -> tuple:
+    """
+    Returns the the (reciprocal_op, mul_op), where the ops depends on if
+    the div op is in exir_ops torch.ops.aten.
+    """
+    if op == exir_ops.edge.aten.div.Tensor:
+        return (exir_ops.edge.aten.reciprocal.default, exir_ops.edge.aten.mul.Tensor)
+    if op == torch.ops.aten.div.Tensor:
+        return (torch.ops.aten.reciprocal.default, torch.ops.aten.mul.Tensor)
+    raise RuntimeError(f"Can't get div decomposition for op {op}")
+
+
+class DecomposeDivPass(ExportPass):
+    """
+    This pass decomposes div into a mul and a reciprocal node.
+
+    Example:
+        y = div(a,b)
+    Becomes:
+        x = reciprocal(b)
+        y = mul(a,x)
+    """
+
+    def call_operator(self, op, args, kwargs, meta):
+        if op not in (exir_ops.edge.aten.div.Tensor, torch.ops.aten.div.Tensor):
+            return super().call_operator(op, args, kwargs, meta)
+
+        reciprocal_op, mul_op = get_div_decomposition(op)
+
+        numerator = args[0]
+        denominator = args[1]
+        reciprocal = super().call_operator(reciprocal_op, (denominator,), {}, meta)
+
+        return super().call_operator(mul_op, (numerator, reciprocal), {}, meta)

--- a/backends/arm/passes/scalars_to_attribute_pass.py
+++ b/backends/arm/passes/scalars_to_attribute_pass.py
@@ -1,0 +1,69 @@
+# Copyright 2024 Arm Limited and/or its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import cast, Union
+
+import torch
+from executorch.backends.arm.tosa_mapping import extract_tensor_meta
+
+from executorch.exir.pass_base import ExportPass, PassResult
+from torch.ao.quantization.fx.utils import get_new_attr_name_with_prefix
+from torch.fx import GraphModule, Node
+
+
+class ScalarsToAttributePass(ExportPass):
+    """
+    For ops in 'targeted_ops', convert inputs that are scalar values
+    to attribute Nodes that output the same value.
+    """
+
+    targeted_ops = [
+        torch.ops.aten.add.Tensor,
+        torch.ops.aten.sub.Tensor,
+        torch.ops.aten.sub_.Tensor,
+        torch.ops.aten.mul.Tensor,
+        torch.ops.aten.div.Tensor
+    ]
+
+    def call(self, graph_module: GraphModule) -> GraphModule:
+        for n in graph_module.graph.nodes:
+            n = cast(Node, n)
+            if n.op != "call_function" or n.target not in self.targeted_ops:
+                continue
+
+            biggest_rank = 1
+            for arg in n.args:
+                if isinstance(arg, Node):
+                    _, shape, _ = extract_tensor_meta(arg.meta)
+                    biggest_rank = max(biggest_rank, len(shape))
+
+            new_args = []
+            for arg in n.args:
+                if isinstance(arg, Node):
+                    new_args.append(arg)
+                    continue
+
+                prefix = "_tensor_constant_"
+                get_new_attr_name = get_new_attr_name_with_prefix(prefix)
+                tensor_constant_name = get_new_attr_name(graph_module)
+                float_tensor = torch.tensor(
+                    float(cast(Union[int, float], arg))
+                ).reshape((1,) * biggest_rank)
+                graph_module.register_buffer(tensor_constant_name, float_tensor)
+                fake_mode = n.meta["val"].fake_mode
+
+                with graph_module.graph.inserting_before(n):
+                    get_attr_node = graph_module.graph.create_node(
+                        "get_attr", tensor_constant_name, (), {}
+                    )
+                    get_attr_node.meta["val"] = fake_mode.from_tensor(
+                        float_tensor, static_shapes=True
+                    )
+                    new_args.append(get_attr_node)
+            n.args = tuple(new_args)
+
+        graph_module.recompile()
+        return PassResult(graph_module, True)

--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -19,10 +19,10 @@ from typing import Any, Callable, Dict, List, Optional, Set
 
 import torch
 import torch.nn.functional as F
+from executorch.backends.arm.passes.arm_pass_manager import ArmPassManager
 
 from executorch.backends.arm.quantizer import arm_quantizer_utils
 from executorch.backends.arm.quantizer.arm_quantizer_utils import (
-    convert_scalars_to_attrs,
     mark_nodes_as_annotated,
     propagate_annotation,
 )
@@ -317,7 +317,8 @@ class ArmQuantizer(Quantizer):
         """An initial pass for transforming the graph to prepare it for annotation.
         Currently transforms scalar values to tensor attributes.
         """
-        return convert_scalars_to_attrs(model)
+
+        return ArmPassManager().transform_for_annotation_pipeline(graph_module=model)
 
     def annotate(self, model: GraphModule) -> GraphModule:
         """Performs the quantization annotation on the graph.

--- a/backends/arm/quantizer/arm_quantizer_utils.py
+++ b/backends/arm/quantizer/arm_quantizer_utils.py
@@ -12,12 +12,11 @@
 #
 
 import operator
-from typing import Callable, cast, List, Union
+from typing import Callable, cast, List
 
 import torch
 from executorch.backends.arm.quantizer.quantization_config import QuantizationConfig
 from torch._subclasses import FakeTensor
-from torch.ao.quantization.fx.utils import get_new_attr_name_with_prefix
 
 from torch.ao.quantization.quantizer import (
     QuantizationAnnotation,
@@ -196,42 +195,3 @@ def propagate_annotation(model: GraphModule) -> None:
             output_qspec=shared_qspec,
             _annotated=True,
         )
-
-
-def convert_scalars_to_attrs(model: GraphModule) -> GraphModule:
-    """For ops in 'targeted_ops', convert inputs that are scalar values
-    to attribute Nodes that output the same value.
-    #TODO Seems like this should be a pass.
-    """
-    targeted_ops = [
-        torch.ops.aten.add.Tensor,
-        torch.ops.aten.sub.Tensor,
-        torch.ops.aten.mul.Tensor,
-    ]
-    for n in model.graph.nodes:
-        n = cast(Node, n)
-        if n.op != "call_function" or n.target not in targeted_ops:
-            continue
-        args = list(n.args)
-        new_args = []
-        for i in range(len(args)):
-            if isinstance(args[i], Node):
-                new_args.append(args[i])
-                continue
-            prefix = "_tensor_constant_"
-            get_new_attr_name = get_new_attr_name_with_prefix(prefix)
-            tensor_constant_name = get_new_attr_name(model)
-            float_tensor = torch.tensor(float(cast(Union[int, float], args[i])))
-            model.register_buffer(tensor_constant_name, float_tensor)
-            fake_mode = n.meta["val"].fake_mode
-            with model.graph.inserting_before(n):
-                get_attr_node = model.graph.create_node(
-                    "get_attr", tensor_constant_name, (), {}
-                )
-                get_attr_node.meta["val"] = fake_mode.from_tensor(
-                    float_tensor, static_shapes=True
-                )
-                new_args.append(get_attr_node)
-        n.args = tuple(new_args)
-    model.recompile()
-    return model

--- a/backends/arm/quantizer/quantization_annotation/one_to_one_annotator.py
+++ b/backends/arm/quantizer/quantization_annotation/one_to_one_annotator.py
@@ -35,7 +35,11 @@ def _annotate_one_to_one(
     Typical ops are ops implemented with a lookup table.
     """
     annotated_partitions = []
-    one_to_one_ops = (torch.ops.aten.exp.default, torch.ops.aten.log.default)
+    one_to_one_ops = (
+        torch.ops.aten.exp.default,
+        torch.ops.aten.log.default,
+        torch.ops.aten.reciprocal.default,
+    )
     for node in gm.graph.nodes:
         if node.op != "call_function" or node.target not in one_to_one_ops:
             continue

--- a/backends/arm/test/ops/test_div.py
+++ b/backends/arm/test/ops/test_div.py
@@ -28,8 +28,8 @@ test_data_suite = [
     ),
     (
         "op_div_rank1_rand",
-        torch.rand(5),
-        torch.rand(5),
+        torch.rand(5) * 5,
+        torch.rand(5) * 5,
         None,
     ),
     (
@@ -70,8 +70,8 @@ test_data_suite = [
     ),
     (
         "op_div_rank4_large_randn",
-        200 * torch.randn(5, 10, 25, 20),
-        torch.rand(5, 10, 25, 20),
+        200 * torch.randn(5, 10, 25, 20) + 1,
+        torch.rand(5, 10, 25, 20) + 1,
         None,
     ),
 ]
@@ -81,14 +81,6 @@ class TestDiv(unittest.TestCase):
     """Tests division"""
 
     class Div(torch.nn.Module):
-        def __init__(
-            self,
-            input_: Union[torch.Tensor, torch.types.Number],
-            other_: Union[torch.Tensor, torch.types.Number],
-            rounding_mode: Optional[str] = None,
-        ):
-            super().__init__()
-            self.rounding_mode = rounding_mode
 
         def forward(
             self,
@@ -96,11 +88,11 @@ class TestDiv(unittest.TestCase):
             other_: Union[torch.Tensor, torch.types.Number],
             rounding_mode: Optional[str] = None,
         ):
-            if self.rounding_mode is None:
+            if rounding_mode is None:
                 return torch.div(input=input_, other=other_)
             else:
                 return torch.div(
-                    input=input_, other=other_, rounding_mode=self.rounding_mode
+                    input=input_, other=other_, rounding_mode=rounding_mode
                 )
 
     def _test_div_tosa_MI_pipeline(
@@ -133,13 +125,15 @@ class TestDiv(unittest.TestCase):
             )
             .quantize()
             .export()
-            .check_count({"torch.ops.aten.div.Tensor": 1})
+            .check_count(
+                {"torch.ops.aten.reciprocal.default": 1, "torch.ops.aten.mul.Tensor": 1}
+            )
             .check(["torch.ops.quantized_decomposed"])
             .to_edge()
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(inputs=test_data)
+            .run_method_and_compare_outputs(inputs=test_data, atol=1, rtol=0.1)
         )
 
     def _test_div_u55_BI_pipeline(
@@ -153,7 +147,9 @@ class TestDiv(unittest.TestCase):
             )
             .quantize()
             .export()
-            .check_count({"torch.ops.aten.div.Tensor": 1})
+            .check_count(
+                {"torch.ops.aten.reciprocal.default": 1, "torch.ops.aten.mul.Tensor": 1}
+            )
             .check(["torch.ops.quantized_decomposed"])
             .to_edge()
             .partition()
@@ -170,14 +166,9 @@ class TestDiv(unittest.TestCase):
         rounding_mode: Optional[str] = None,
     ):
         test_data = (input_, other_)
-        self._test_div_tosa_MI_pipeline(
-            self.Div(input_, other_, rounding_mode=rounding_mode), test_data
-        )
+        self._test_div_tosa_MI_pipeline(self.Div(), test_data)
 
-    # Expected to fail since ArmQuantizer cannot quantize a Div layer
-    # TODO(MLETORCH-129)
     @parameterized.expand(test_data_suite)
-    @unittest.expectedFailure
     def test_div_tosa_BI(
         self,
         test_name: str,
@@ -187,12 +178,9 @@ class TestDiv(unittest.TestCase):
     ):
 
         test_data = (input_, other_)
-        self._test_div_tosa_BI_pipeline(
-            self.Div(input=input_, other=other_, rounding_mode=rounding_mode), test_data
-        )
+        self._test_div_tosa_BI_pipeline(self.Div(), test_data)
 
-    # Expected to fail since ArmQuantizer cannot quantize a Div layer
-    # TODO(MLETORCH-129)
+    # Fails due to Vela error.
     @parameterized.expand(test_data_suite)
     @unittest.expectedFailure
     def test_div_u55_BI(
@@ -203,6 +191,4 @@ class TestDiv(unittest.TestCase):
         rounding_mode: Optional[str] = None,
     ):
         test_data = (input_, other_)
-        self._test_div_u55_BI_pipeline(
-            self.Div(input=input_, other=other_, rounding_mode=rounding_mode), test_data
-        )
+        self._test_div_u55_BI_pipeline(self.Div(), test_data)

--- a/backends/arm/test/ops/test_reciprocal.py
+++ b/backends/arm/test/ops/test_reciprocal.py
@@ -1,0 +1,118 @@
+# Copyright 2024 Arm Limited and/or its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.arm_tester import ArmTester
+from parameterized import parameterized
+
+test_data_t = tuple[str, torch.Tensor]
+test_data_suite: list[test_data_t] = [
+    (
+        "op_reciprocal_rank1_ones",
+        torch.ones(5),
+    ),
+    (
+        "op_reciprocal_rank1_rand",
+        torch.rand(5) * 5,
+    ),
+    ("op_reciprocal_rank1_negative_ones", torch.ones(5) * (-1)),
+    ("op_reciprocal_rank4_ones", torch.ones(5, 10, 25, 20)),
+    ("op_reciprocal_rank4_negative_ones", (-1) * torch.ones(5, 10, 25, 20)),
+    ("op_reciprocal_rank4_ones_reciprocal_negative", torch.ones(5, 10, 25, 20)),
+    ("op_reciprocal_rank4_large_rand", 200 * torch.rand(5, 10, 25, 20)),
+    ("op_reciprocal_rank4_negative_large_rand", (-200) * torch.rand(5, 10, 25, 20)),
+    ("op_reciprocal_rank4_large_randn", 200 * torch.randn(5, 10, 25, 20) + 1),
+]
+
+
+class TestReciprocal(unittest.TestCase):
+    """Tests reciprocal"""
+
+    class Reciprocal(torch.nn.Module):
+
+        def forward(self, input_: torch.Tensor):
+            return input_.reciprocal()
+
+    def _test_reciprocal_tosa_MI_pipeline(
+        self, module: torch.nn.Module, test_data: tuple[torch.Tensor]
+    ):
+        (
+            ArmTester(
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_tosa_compile_spec(),
+            )
+            .export()
+            .check_count({"torch.ops.aten.reciprocal.default": 1})
+            .check_not(["torch.ops.quantized_decomposed"])
+            .to_edge()
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+            .run_method_and_compare_outputs(inputs=test_data)
+        )
+
+    def _test_reciprocal_tosa_BI_pipeline(
+        self, module: torch.nn.Module, test_data: tuple[torch.Tensor]
+    ):
+        (
+            ArmTester(
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_tosa_compile_spec(),
+            )
+            .quantize()
+            .export()
+            .check_count({"torch.ops.aten.reciprocal.default": 1})
+            .check(["torch.ops.quantized_decomposed"])
+            .to_edge()
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+            .run_method_and_compare_outputs(inputs=test_data)
+        )
+
+    def _test_reciprocal_u55_BI_pipeline(
+        self, module: torch.nn.Module, test_data: tuple[torch.Tensor]
+    ):
+        (
+            ArmTester(
+                module,
+                example_inputs=test_data,
+                compile_spec=common.get_u55_compile_spec(),
+            )
+            .quantize()
+            .export()
+            .check_count({"torch.ops.aten.reciprocal.default": 1})
+            .check(["torch.ops.quantized_decomposed"])
+            .to_edge()
+            .partition()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+        )
+
+    @parameterized.expand(test_data_suite)
+    def test_reciprocal_tosa_MI(self, test_name: str, input_: torch.Tensor):
+        test_data = (input_,)
+        self._test_reciprocal_tosa_MI_pipeline(self.Reciprocal(), test_data)
+
+    # Expected to fail since ArmQuantizer cannot quantize a Reciprocal layer
+    # TODO(MLETORCH-129)
+    @parameterized.expand(test_data_suite)
+    def test_reciprocal_tosa_BI(self, test_name: str, input_: torch.Tensor):
+
+        test_data = (input_,)
+        self._test_reciprocal_tosa_BI_pipeline(self.Reciprocal(), test_data)
+
+    # Expected to fail since Vela does not support TABLE
+    @parameterized.expand(test_data_suite)
+    @unittest.expectedFailure
+    def test_reciprocal_u55_BI(self, test_name: str, input_: torch.Tensor):
+        test_data = (input_,)
+        self._test_reciprocal_u55_BI_pipeline(self.Reciprocal(), test_data)


### PR DESCRIPTION
Integer placeholders, for example in this example,
x = torch.Tensor([1.]) + 1
are by default lowered as int64 tensors. 
As int64 is not a valid TOSA dtype, we cast these tensors to int32.

Reference: https://www.mlplatform.org/tosa/tosa_spec.html#_supported_number_formats
