### PR TITLE
[ET-VK][ez] Use `MemoryAccessFlags` instead of `MemoryAccessType` when binding

### DIFF
--- a/backends/vulkan/runtime/graph/ops/ExecuteNode.h
+++ b/backends/vulkan/runtime/graph/ops/ExecuteNode.h
@@ -21,16 +21,16 @@ class ComputeGraph;
  * access permission.
  */
 struct ArgGroup {
-  ArgGroup(const ValueRef ref, const vkapi::MemoryAccessType access)
+  ArgGroup(const ValueRef ref, const vkapi::MemoryAccessFlags access)
       : refs{ref}, access(access) {}
 
   ArgGroup(
       const std::vector<ValueRef>& refs,
-      const vkapi::MemoryAccessType access)
+      const vkapi::MemoryAccessFlags access)
       : refs(refs), access(access) {}
 
   const std::vector<ValueRef> refs;
-  const vkapi::MemoryAccessType access;
+  const vkapi::MemoryAccessFlags access;
 };
 
 /*

--- a/backends/vulkan/runtime/graph/ops/utils/BindingUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/utils/BindingUtils.cpp
@@ -13,7 +13,7 @@ namespace vkcompute {
 void bind_tensor_to_descriptor_set(
     api::vTensor& tensor,
     vkapi::PipelineBarrier& pipeline_barrier,
-    const vkapi::MemoryAccessType accessType,
+    const vkapi::MemoryAccessFlags accessType,
     vkapi::DescriptorSet& descriptor_set,
     const uint32_t idx) {
   if (tensor.buffer()) {

--- a/backends/vulkan/runtime/graph/ops/utils/BindingUtils.h
+++ b/backends/vulkan/runtime/graph/ops/utils/BindingUtils.h
@@ -19,7 +19,7 @@ namespace vkcompute {
 void bind_tensor_to_descriptor_set(
     api::vTensor& tensor,
     vkapi::PipelineBarrier& pipeline_barrier,
-    const vkapi::MemoryAccessType accessType,
+    const vkapi::MemoryAccessFlags accessType,
     vkapi::DescriptorSet& descriptor_set,
     const uint32_t idx);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5592
* __->__ #5591
* #5590
* #5589

## Context

Correct `ComputeGraph` functions to accept `MemoryAccessFlags` instead of `MemoryAccessType`. `MemoryAccessType` correspond to only a single bit, i.e. `READ` or `WRITE` but `MemoryAccessFlags` allows us to express a combination of bits which is the intended behaviour.

Differential Revision: [D63327080](https://our.internmc.facebook.com/intern/diff/D63327080/)