### PR TITLE
Fix unary op unit test

### DIFF
--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -894,6 +894,10 @@ def get_unary_ops_inputs():
     test_suite.storage_types = ["utils::kTexture3D", "utils::kBuffer"]
     test_suite.atol = "1e-4"
     test_suite.rtol = "1e-4"
+    test_suite.layouts = [
+        "utils::kWidthPacked",
+        "utils::kChannelsPacked",
+    ]
     return test_suite
 
 


### PR DESCRIPTION
Summary: The test did not catch errors in y,z,w dimensions.

Differential Revision: D63337549
