### PR TITLE
add option to quantize output layer perchannel for SpinQuant

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -374,8 +374,8 @@ def build_args_parser() -> argparse.ArgumentParser:
         "--spin_qmode",
         type=str,
         default=None,
-        choices=["8da4w"],
-        help="Quantization mode for SpinQuant. Only support 8da4w right now.",
+        choices=["8da4w", "8da4w_output_8da8w"],
+        help="Quantization mode for SpinQuant. Only support 8da4w and 8da4w_output_8da8w right now.",
     )
 
     parser.add_argument(

--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -192,6 +192,10 @@ the checkpoint format to avoid generating faulty models.
         elif hasattr(self.args, "use_spin_quant") and self.args.use_spin_quant:
             print("Using SPIN quantization.")
             assert hasattr(self.args, "spin_qmode"), "spin_qmode must be specified"
+            assert self.args.spin_qmode in [
+                "8da4w",
+                "8da4w_output_8da8w",
+            ], f"Quantization mode {self.args.spin_qmode} is not compatible with SpinQuant."
             assert hasattr(
                 self.args, "spin_group_size"
             ), "spin_group_size must be specified"
@@ -209,11 +213,22 @@ the checkpoint format to avoid generating faulty models.
                 "bf16": torch.bfloat16,
             }
 
+            # Transform the output layer first if needed.
+            if self.args.spin_qmode == "8da4w_output_8da8w":
+                from .source_transformation.spin_quant import (
+                    transform_output_linear_for_spinquant,
+                )
+
+                self.model_ = transform_output_linear_for_spinquant(
+                    module=self.model_,
+                    checkpoint=checkpoint,
+                    dtype=mapping[self.args.dtype_override],
+                )
+
             self.model_ = transform_linear_for_spinquant(
                 self.model_,
                 checkpoint,
                 self.args.spin_group_size,
-                self.args.spin_qmode,
                 mapping[self.args.dtype_override],
             )
 


### PR DESCRIPTION
Summary: Add an option to optionally quantize the output layer int8 per-channel

Reviewed By: mergennachin

Differential Revision: D62787491
