### PR TITLE
Add a script to help user enable ccache

### DIFF
--- a/build/use_ccache.sh
+++ b/build/use_ccache.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+# Ccache (https://ccache.dev/) is used for compiler cache and could make
+# ExecuTorch build faster.
+# Since CMake 3.17, simply export CMAKE_C_COMPILER_LAUNCHER and CMAKE_CXX_COMPILER_LAUNCHER
+# to ccache path and all invocations will use Ccache automatically.
+
+if ! command -v "ccache"; then
+  echo "Ccache not found. Installing from Conda." \
+       "You can also install from apt, dnf, brew, or official website for latest version"
+  conda install -y ccache
+fi
+export CMAKE_C_COMPILER_LAUNCHER=ccache
+export CMAKE_CXX_COMPILER_LAUNCHER=ccache


### PR DESCRIPTION
Use ccache to accelerate build.

Reference improvement:
Command:
```
  cmake . \
    -DCMAKE_INSTALL_PREFIX=cmake-out \
    -DEXECUTORCH_USE_CPP_CODE_COVERAGE=ON \
    -DEXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON \
    -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON \
    -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
    -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
    -DEXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL=ON \
    -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
    -DEXECUTORCH_BUILD_DEVTOOLS=ON \
    -DEXECUTORCH_BUILD_XNNPACK=ON \
    -Bcmake-out
  cmake --build cmake-out -j8 --target install
```
First time, clean build
```
real    5m52.049s

cache hit (direct)                     0
cache hit (preprocessed)               0
cache miss                          9516
cache hit rate                      0.00 %
called for link                       25
called for preprocessing            4576
no input file                          7
cleanups performed                     1
files in cache                     33079
cache size                           2.3 GB
max cache size                       5.0 GB
```
Then we `rm -rf cmake-out` and run again
```
real    0m44.498s

cache hit (direct)                  4856
cache hit (preprocessed)              50
cache miss                          9587
cache hit rate                     33.85 %
called for link                       50
called for preprocessing            4643
cache file missing                     1
no input file                         14
cleanups performed                     2
files in cache                     32113
cache size                           2.2 GB
max cache size                       5.0 GB
```
Third time,
```
real    2m6.749s

cache hit (direct)                  9647
cache hit (preprocessed)             170
cache miss                          9715
cache hit rate                     50.26 %
called for link                       75
called for preprocessing            4837
cache file missing                     2
no input file                         21
cleanups performed                     2
files in cache                     32610
cache size                           2.2 GB
max cache size                       5.0 GB
```

There are variance but the result is good