### PR TITLE
update export SpinQuant checkpoint to align with the new format

### DIFF
--- a/examples/models/llama2/model.py
+++ b/examples/models/llama2/model.py
@@ -258,12 +258,7 @@ the checkpoint format to avoid generating faulty models.
                     embedding_group_size,
                 )
 
-            sanitize_checkpoint_from_spinquant(
-                module=self.model_,
-                checkpoint=checkpoint,
-                linear_group_size=self.args.spin_group_size,
-                embedding_group_size=embedding_group_size,
-            )
+            sanitize_checkpoint_from_spinquant(checkpoint)
 
         # assign=True: load params/buffers by assignment instead of performing an in-place copy.
         # Because we are using device="meta", tensors do not have memory associated with them

--- a/examples/models/llama2/tests/test_spinquant_transforms.py
+++ b/examples/models/llama2/tests/test_spinquant_transforms.py
@@ -65,7 +65,7 @@ class SpinQuantTests(unittest.TestCase):
                     weight.to(torch.float32), n_bit, group_size, scales_precision
                 )
                 checkpoint[f"{fqn}.weight"] = weight_int8.to("cpu")
-                checkpoint[f"{fqn}.scale"] = scales.to("cpu")
+                checkpoint[f"{fqn}.scales"] = scales.to("cpu")
 
         # Step 3:
         # Transform the model so that it is compatible with the new checkpoint
@@ -76,11 +76,7 @@ class SpinQuantTests(unittest.TestCase):
             "8da4w",
             torch.float32,
         )
-        sanitize_checkpoint_from_spinquant(
-            model,
-            checkpoint,
-            -1,
-        )
+        sanitize_checkpoint_from_spinquant(checkpoint)
 
         model.load_state_dict(
             checkpoint,
@@ -114,7 +110,7 @@ class SpinQuantTests(unittest.TestCase):
                     scales_dtype=torch.float32,
                 )
                 checkpoint[f"{fqn}.weight"] = weight_int8.to("cpu")
-                checkpoint[f"{fqn}.scale"] = scales.to("cpu")
+                checkpoint[f"{fqn}.scales"] = scales.to("cpu")
 
         # Step 3:
         # Transform the model so that it is compatible with the new checkpoint
@@ -123,11 +119,7 @@ class SpinQuantTests(unittest.TestCase):
             checkpoint,
             torch.float32,
         )
-        sanitize_checkpoint_from_spinquant(
-            model,
-            checkpoint,
-            -1,
-        )
+        sanitize_checkpoint_from_spinquant(checkpoint)
 
         model.load_state_dict(
             checkpoint,
@@ -166,7 +158,7 @@ class SpinQuantTests(unittest.TestCase):
                     weight.to(torch.float32), n_bit, group_size, scales_precision
                 )
                 checkpoint[f"{fqn}.weight"] = weight_int8.to("cpu")
-                checkpoint[f"{fqn}.scale"] = scales.to("cpu")
+                checkpoint[f"{fqn}.scales"] = scales.to("cpu")
 
         # Step 3:
         # Transform the model so that it is compatible with the new checkpoint
@@ -177,12 +169,7 @@ class SpinQuantTests(unittest.TestCase):
             n_bit,
             group_size,
         )
-        sanitize_checkpoint_from_spinquant(
-            module=model,
-            checkpoint=checkpoint,
-            linear_group_size=-1,
-            embedding_group_size=-1,
-        )
+        sanitize_checkpoint_from_spinquant(checkpoint)
 
         model.load_state_dict(
             checkpoint,


### PR DESCRIPTION
Summary:
Per our new aligned checkpoint format with SpinQuant:
- Original weights: drop it from the checkpoint
- Int4 or int8 weight: .weight
- Scales: .scales, grouped by group size for attention linear layers, grouped by per channel for embedding and output layer.

This PR updates the export flow to follow this new format.

Differential Revision: D63402708
