### PR TITLE
[Executorch] Update EXECUTORCH_LIBRARY macro

### DIFF
--- a/extension/kernel_util/make_boxed_from_unboxed_functor.h
+++ b/extension/kernel_util/make_boxed_from_unboxed_functor.h
@@ -173,10 +173,19 @@ static executorch::runtime::Kernel make_boxed_kernel(
 } // namespace extension
 } // namespace executorch
 
-#define EXECUTORCH_LIBRARY(ns, op_name, func)                    \
-  static auto res_##ns = ::executorch::runtime::register_kernel( \
-      ::executorch::extension::make_boxed_kernel(                \
-          #ns "::" op_name, EXECUTORCH_FN(func)))
+// Inspired from C10_CONCATENATE
+#define ET_CONCATENATE_IMPL(s1, s2) s1##s2
+#define ET_CONCATENATE(s1, s2) ET_CONCATENATE_IMPL(s1, s2)
+#define ET_UID __LINE__
+
+#define EXECUTORCH_LIBRARY(ns, op_name, func) \
+  _EXECUTORCH_LIBRARY_IMPL(ns, op_name, func, ET_UID)
+
+#define _EXECUTORCH_LIBRARY_IMPL(ns, op_name, func, uid) \
+  static auto ET_CONCATENATE(res_##ns##_, uid) =         \
+      ::executorch::runtime::register_kernel(            \
+          ::executorch::extension::make_boxed_kernel(    \
+              #ns "::" op_name, EXECUTORCH_FN(func)))
 
 namespace torch {
 namespace executor {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5656
* #5655
* __->__ #5654
* #5653
* #5652
* #5527
* #5651
* #5650
* #5524
* #5649

Change it to generate unique static variable name. Otherwise we cant register
two ops from the same file.

Also dont know what happens when two files have the same static variable.
Probably nothing unless you are trying to refer to it from some other file.

Differential Revision: [D62623240](https://our.internmc.facebook.com/intern/diff/D62623240/)