### PR TITLE
[ExecuTorch] Remove TensorPtr::get()

### DIFF
--- a/extension/tensor/tensor_ptr.h
+++ b/extension/tensor/tensor_ptr.h
@@ -39,17 +39,13 @@ class TensorPtr {
     return static_cast<bool>(tensor_impl_);
   }
 
-  exec_aten::Tensor* get() const {
-    return tensor_impl_ ? &tensor_ : nullptr;
-  }
-
   exec_aten::Tensor* operator->() const {
-    return get();
+    return tensor_impl_ ? &tensor_ : nullptr;
   }
 
   exec_aten::Tensor& operator*() const {
     ET_DCHECK(*this != nullptr);
-    return *get();
+    return *operator->();
   }
 
   void reset() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Intermediate step before shrinking TensorPtr to 16 bytes instead of the current 24.

Differential Revision: [D63470105](https://our.internmc.facebook.com/intern/diff/D63470105/)