### PR TITLE
Fix linker flags.

### DIFF
--- a/extension/apple/Benchmark/Tests/Tests.xcconfig
+++ b/extension/apple/Benchmark/Tests/Tests.xcconfig
@@ -4,7 +4,7 @@ OTHER_LDFLAGS[sdk=iphonesimulator*] = $(inherited) \
 -force_load $(BUILT_PRODUCTS_DIR)/libbackend_mps-simulator-release.a \
 -force_load $(BUILT_PRODUCTS_DIR)/libbackend_xnnpack-simulator-release.a \
 -force_load $(BUILT_PRODUCTS_DIR)/libkernels_custom-simulator-release.a \
--force_load $(BUILT_PRODUCTS_DIR)/libkernels_portable-simulator-release.a \
+-force_load $(BUILT_PRODUCTS_DIR)/libkernels_optimized-simulator-release.a \
 -force_load $(BUILT_PRODUCTS_DIR)/libkernels_quantized-simulator-release.a
 
 OTHER_LDFLAGS[sdk=iphoneos*] = $(inherited) \
@@ -13,7 +13,7 @@ OTHER_LDFLAGS[sdk=iphoneos*] = $(inherited) \
 -force_load $(BUILT_PRODUCTS_DIR)/libbackend_mps-ios-release.a \
 -force_load $(BUILT_PRODUCTS_DIR)/libbackend_xnnpack-ios-release.a \
 -force_load $(BUILT_PRODUCTS_DIR)/libkernels_custom-ios-release.a \
--force_load $(BUILT_PRODUCTS_DIR)/libkernels_portable-ios-release.a \
+-force_load $(BUILT_PRODUCTS_DIR)/libkernels_optimized-ios-release.a \
 -force_load $(BUILT_PRODUCTS_DIR)/libkernels_quantized-ios-release.a
 
 OTHER_LDFLAGS[sdk=macos*] = $(inherited) \
@@ -22,5 +22,5 @@ OTHER_LDFLAGS[sdk=macos*] = $(inherited) \
 -force_load $(BUILT_PRODUCTS_DIR)/libbackend_mps-macos-release.a \
 -force_load $(BUILT_PRODUCTS_DIR)/libbackend_xnnpack-macos-release.a \
 -force_load $(BUILT_PRODUCTS_DIR)/libkernels_custom-macos-release.a \
--force_load $(BUILT_PRODUCTS_DIR)/libkernels_portable-macos-release.a \
+-force_load $(BUILT_PRODUCTS_DIR)/libkernels_optimized-macos-release.a \
 -force_load $(BUILT_PRODUCTS_DIR)/libkernels_quantized-macos-release.a


### PR DESCRIPTION
Summary: We have to force load the optimized kernels first to avoid conflicts with portable.

Differential Revision: D63473757
