### PR TITLE
Show loading model UI during model switch

### DIFF
--- a/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/MainActivity.java
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/MainActivity.java
@@ -107,10 +107,6 @@ public class MainActivity extends AppCompatActivity implements Runnable, LlamaCa
   }
 
   private void setLocalModel(String modelPath, String tokenizerPath, float temperature) {
-    if (mModule != null) {
-      mModule.resetNative();
-      mModule = null;
-    }
     Message modelLoadingMessage = new Message("Loading model...", false, MessageType.SYSTEM, 0);
     ETLogging.getInstance().log("Loading model " + modelPath + " with tokenizer " + tokenizerPath);
     runOnUiThread(
@@ -119,6 +115,12 @@ public class MainActivity extends AppCompatActivity implements Runnable, LlamaCa
           mMessageAdapter.add(modelLoadingMessage);
           mMessageAdapter.notifyDataSetChanged();
         });
+    if (mModule != null) {
+      ETLogging.getInstance().log("Start deallocating existing module instance");
+      mModule.resetNative();
+      mModule = null;
+      ETLogging.getInstance().log("Completed deallocating existing module instance");
+    }
     long runStartTime = System.currentTimeMillis();
     mModule =
         new LlamaModule(


### PR DESCRIPTION
Summary:
Destructing a model takes about 5 seconds of time. Previously, if the user switched models then "loading model..." would only show 5 seconds after the model was destructed.

To help UX we will show "loading model..." before we we destroy the model. This way the user will know that app has ack'd that a model refresh needs to happen.

Reviewed By: kirklandsign

Differential Revision: D62512275


