### PR TITLE
Fix unknown type name 'intmax_t'

### DIFF
--- a/kernels/optimized/vec/vec_base.h
+++ b/kernels/optimized/vec/vec_base.h
@@ -9,6 +9,7 @@
 #include <type_traits>
 #include <bitset>
 #include <climits>
+#include <cstdint>
 
 // These macros helped us unify vec_base.h
 #ifdef CPU_CAPABILITY_AVX512


### PR DESCRIPTION
Fix build error.
```
error: unknown type name 'intmax_t'; did you mean '__intmax_t'?
```