### PR TITLE
Add Buck config to disable XNNPACK Workspace Sharing

### DIFF
--- a/backends/xnnpack/targets.bzl
+++ b/backends/xnnpack/targets.bzl
@@ -1,6 +1,17 @@
 load("@fbsource//xplat/executorch/backends/xnnpack/third-party:third_party_libs.bzl", "third_party_dep")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+def _get_preprocessor_flags():
+    """
+    Disable if someone explictly specified a config option,
+    else Enable otherwise
+    """
+    if native.read_config("executorch", "xnnpack_workspace_sharing", "1") == "0":
+        return []
+
+    # Enable if not disabled through config
+    return ["-DENABLE_XNNPACK_SHARED_WORKSPACE"]
+
 def define_common_targets():
     runtime.cxx_library(
         name = "dynamic_quant_utils",
@@ -36,11 +47,9 @@ def define_common_targets():
             "@EXECUTORCH_CLIENTS",
         ],
         preprocessor_flags = [
-            # Enable workspace sharing across delegates
-            "-DENABLE_XNNPACK_SHARED_WORKSPACE",
             # Uncomment to enable per operator timings
             # "-DENABLE_XNNPACK_PROFILING",
-        ],
+        ] + _get_preprocessor_flags(),
         exported_deps = [
             "//executorch/runtime/backend:interface",
         ],


### PR DESCRIPTION
Summary: XNNPACK Workspace sharing is enabled by default. Use this config to disable it.

Reviewed By: gordonliu

Differential Revision: D63437983
