### PR TITLE
Fix unqualified uses of executorch functions

### DIFF
--- a/backends/cadence/reference/operators/quantized_layer_norm.cpp
+++ b/backends/cadence/reference/operators/quantized_layer_norm.cpp
@@ -11,7 +11,8 @@
 
 #include <cmath>
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::Tensor;
+using executorch::runtime::getLeadingDims;
 using executorch::runtime::KernelRuntimeContext;
 
 namespace impl {

--- a/backends/cadence/reference/operators/quantized_linear_out.cpp
+++ b/backends/cadence/reference/operators/quantized_linear_out.cpp
@@ -13,7 +13,8 @@ namespace impl {
 namespace reference {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::Tensor;
+using executorch::runtime::getLeadingDims;
 using executorch::runtime::KernelRuntimeContext;
 
 void quantized_linear_out(

--- a/backends/cadence/reference/operators/quantized_matmul_out.cpp
+++ b/backends/cadence/reference/operators/quantized_matmul_out.cpp
@@ -13,7 +13,8 @@ namespace impl {
 namespace reference {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::Tensor;
+using executorch::runtime::getLeadingDims;
 using executorch::runtime::KernelRuntimeContext;
 
 // The quantized matmul. The quantized matmul accumulates in a wider register,

--- a/kernels/portable/cpu/util/test/broadcast_test.cpp
+++ b/kernels/portable/cpu/util/test/broadcast_test.cpp
@@ -22,6 +22,12 @@ using exec_aten::ScalarType;
 using exec_aten::Tensor;
 using executorch::runtime::ArrayRef;
 using executorch::runtime::testing::TensorFactory;
+using torch::executor::broadcast_tensor;
+using torch::executor::delinearize_index;
+using torch::executor::get_broadcast_target_size;
+using torch::executor::linearize_access_indexes;
+using torch::executor::tensor_is_broadcastable_to;
+using torch::executor::tensors_are_broadcastable_between;
 
 TEST(BroadcastUtilTest, BroadcastTensor) {
   TensorFactory<ScalarType::Int> tf;

--- a/kernels/portable/cpu/util/test/reduce_test.cpp
+++ b/kernels/portable/cpu/util/test/reduce_test.cpp
@@ -19,7 +19,10 @@ using exec_aten::ArrayRef;
 using exec_aten::optional;
 using exec_aten::ScalarType;
 using exec_aten::Tensor;
-using torch::executor::testing::TensorFactory;
+using executorch::runtime::testing::TensorFactory;
+using torch::executor::apply_over_dim;
+using torch::executor::apply_over_dim_list;
+using torch::executor::get_out_numel;
 
 void _apply_over_dim(const Tensor& in, const optional<int64_t>& dim) {
   int64_t* in_data = in.mutable_data_ptr<int64_t>();

--- a/kernels/test/custom_kernel_example/my_functions.yaml
+++ b/kernels/test/custom_kernel_example/my_functions.yaml
@@ -5,4 +5,4 @@
 - op: relu.out
   kernels:
     - arg_meta: null
-      kernel_name: torch::my_custom_kernel::my_relu_out
+      kernel_name: my_custom_kernels::my_relu_out

--- a/kernels/test/custom_kernel_example/op_relu.cpp
+++ b/kernels/test/custom_kernel_example/op_relu.cpp
@@ -12,14 +12,15 @@
 #include <executorch/runtime/kernel/kernel_includes.h>
 #include <executorch/runtime/platform/assert.h>
 
-namespace torch {
-namespace my_custom_kernel {
+namespace my_custom_kernels {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
-using ScalarType = exec_aten::ScalarType;
-using executor::Error;
+using exec_aten::ScalarType;
+using exec_aten::Tensor;
+using executorch::runtime::Error;
 using executorch::runtime::KernelRuntimeContext;
+using executorch::runtime::resize_tensor;
+using executorch::runtime::tensors_have_same_shape_and_dtype;
 
 namespace {
 
@@ -67,7 +68,7 @@ my_relu_out(KernelRuntimeContext& context, const Tensor& input, Tensor& out) {
   resize(out, input.sizes());
   ET_KERNEL_CHECK(
       context,
-      executor::tensors_have_same_shape_and_dtype(input, out),
+      tensors_have_same_shape_and_dtype(input, out),
       InvalidArgument,
       out);
 
@@ -94,5 +95,4 @@ my_relu_out(KernelRuntimeContext& context, const Tensor& input, Tensor& out) {
 }
 
 } // namespace native
-} // namespace my_custom_kernel
-} // namespace torch
+} // namespace my_custom_kernels

--- a/kernels/test/op_add_test.cpp
+++ b/kernels/test/op_add_test.cpp
@@ -18,11 +18,12 @@
 #include <iostream>
 
 using namespace ::testing;
-using exec_aten::Scalar;
-using exec_aten::ScalarType;
-using exec_aten::Tensor;
+using executorch::aten::Scalar;
+using executorch::aten::ScalarType;
+using executorch::aten::Tensor;
+using executorch::runtime::testing::TensorFactory;
 using torch::executor::testing::SupportedFeatures;
-using torch::executor::testing::TensorFactory;
+namespace etrt = executorch::runtime;
 
 class OpAddOutKernelTest : public OperatorTest {
  protected:
@@ -63,7 +64,8 @@ class OpAddOutKernelTest : public OperatorTest {
     test_add<DTYPE_A, DTYPE_B, ScalarType::Float>();
     test_add<DTYPE_A, DTYPE_B, ScalarType::Double>();
     // Integral out type is only allowed if both inputs are integral types
-    if (isIntegralType(DTYPE_A, false) && isIntegralType(DTYPE_B, false)) {
+    if (etrt::isIntegralType(DTYPE_A, false) &&
+        etrt::isIntegralType(DTYPE_B, false)) {
       test_add<DTYPE_A, DTYPE_B, ScalarType::Int>();
       test_add<DTYPE_A, DTYPE_B, ScalarType::Long>();
     }

--- a/kernels/test/op_mul_test.cpp
+++ b/kernels/test/op_mul_test.cpp
@@ -17,11 +17,12 @@
 #include <gtest/gtest.h>
 
 using namespace ::testing;
-using exec_aten::Scalar;
-using exec_aten::ScalarType;
-using exec_aten::Tensor;
+using executorch::aten::Scalar;
+using executorch::aten::ScalarType;
+using executorch::aten::Tensor;
+using executorch::runtime::testing::TensorFactory;
 using torch::executor::testing::SupportedFeatures;
-using torch::executor::testing::TensorFactory;
+namespace etrt = executorch::runtime;
 
 class OpMulOutTest : public OperatorTest {
  protected:
@@ -61,7 +62,8 @@ class OpMulOutTest : public OperatorTest {
     test_mul<DTYPE_A, DTYPE_B, ScalarType::Float>();
     test_mul<DTYPE_A, DTYPE_B, ScalarType::Double>();
     // Integral out type is only allowed if both inputs are integral types
-    if (isIntegralType(DTYPE_A, false) && isIntegralType(DTYPE_B, false)) {
+    if (etrt::isIntegralType(DTYPE_A, false) &&
+        etrt::isIntegralType(DTYPE_B, false)) {
       test_mul<DTYPE_A, DTYPE_B, ScalarType::Int>();
       test_mul<DTYPE_A, DTYPE_B, ScalarType::Long>();
     }

--- a/kernels/test/op_sub_test.cpp
+++ b/kernels/test/op_sub_test.cpp
@@ -16,11 +16,12 @@
 #include <gtest/gtest.h>
 
 using namespace ::testing;
-using exec_aten::Scalar;
-using exec_aten::ScalarType;
-using exec_aten::Tensor;
+using executorch::aten::Scalar;
+using executorch::aten::ScalarType;
+using executorch::aten::Tensor;
+using executorch::runtime::testing::TensorFactory;
 using torch::executor::testing::SupportedFeatures;
-using torch::executor::testing::TensorFactory;
+namespace etrt = executorch::runtime;
 
 class OpSubOutTest : public OperatorTest {
  protected:
@@ -60,7 +61,8 @@ class OpSubOutTest : public OperatorTest {
     test_sub<DTYPE_A, DTYPE_B, ScalarType::Float>();
     test_sub<DTYPE_A, DTYPE_B, ScalarType::Double>();
     // Integral out type is only allowed if both inputs are integral types
-    if (isIntegralType(DTYPE_A, false) && isIntegralType(DTYPE_B, false)) {
+    if (etrt::isIntegralType(DTYPE_A, false) &&
+        etrt::isIntegralType(DTYPE_B, false)) {
       test_sub<DTYPE_A, DTYPE_B, ScalarType::Int>();
       test_sub<DTYPE_A, DTYPE_B, ScalarType::Long>();
     }


### PR DESCRIPTION
Summary:
I'm not sure how this worked before, but these sites called functions under torch::executor without actually qualifying them. Qualify them explicitly, because the "can call without qualification" magic stops working when we move the etensor types in D63294217.

In a few places I used `namespace etrt = executorch::runtime;` instead of a using statement for a particular function, like `etrt::isIntegralType`. If I just say `using executorch::runtime::isIntegralType`, those files fail in aten mode because the unqualified call to `isIntegralType()` is deemed ambiguous in the presence of `c10::isIntegralType()` -- but afaict that `c10` version isn't `using`'d into the global namespace, so I don't know why it conflicts. It'd be good to figure that out at some point, but this works for now.

Differential Revision: D63476419
