### PR TITLE
[ExecuTorch] Avoid some extra heap allocations for TensorImplPtr

### DIFF
--- a/extension/tensor/test/tensor_impl_ptr_test.cpp
+++ b/extension/tensor/test/tensor_impl_ptr_test.cpp
@@ -23,6 +23,31 @@ class TensorImplPtrTest : public ::testing::Test {
   }
 };
 
+TEST_F(TensorImplPtrTest, BasicSmartPointerAccess) {
+  TensorImplPtr p;
+  EXPECT_FALSE(p);
+  EXPECT_EQ(p, nullptr);
+  TensorImplPtr p2 = make_tensor_impl_ptr({1}, nullptr);
+  EXPECT_TRUE(p2);
+  EXPECT_NE(p2, nullptr);
+  EXPECT_EQ(p2->dim(), 1);
+  EXPECT_EQ((*p2).dim(), 1);
+  EXPECT_NE(p, p2);
+  p2.reset();
+  EXPECT_FALSE(p2);
+  EXPECT_EQ(p2, nullptr);
+  EXPECT_EQ(p, p2);
+}
+
+TEST_F(TensorImplPtrTest, Swap) {
+  TensorImplPtr p;
+  TensorImplPtr p2 = make_tensor_impl_ptr({1}, nullptr);
+  p.swap(p2);
+  EXPECT_FALSE(p2);
+  EXPECT_TRUE(p);
+  EXPECT_EQ(p->dim(), 1);
+}
+
 TEST_F(TensorImplPtrTest, ScalarTensorCreation) {
   float scalar_data = 3.14f;
   auto tensor_impl = make_tensor_impl_ptr({}, &scalar_data);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5711
* #5688
* #5687
* #5684

With the previous approach, we put the sizes, dim_order, and
strides vectors onto the heap, make_shared was forced to separately
allocate the control block for the TensorImpl because it used a custom
deleter, and then of course the TensorImpl itself is on the heap
(total of 5 allocations). Now, we combine the vectors (but not their
pointed-to data), deleter, control block, and TensorImpl into a single
allocation, saving 4 allocations.

Differential Revision: [D63493196](https://our.internmc.facebook.com/intern/diff/D63493196/)