### PR TITLE
[ExecuTorch] Fix non-reentrant threadpool

### DIFF
--- a/extension/threadpool/threadpool.cpp
+++ b/extension/threadpool/threadpool.cpp
@@ -86,6 +86,7 @@ void ThreadPool::run(
       // pthreadpool_parallelize_1d() cannot go out of scope until
       // pthreadpool_parallelize_1d() returns.
       [](void* const context, const size_t item) {
+        NoThreadPoolGuard guard;
         reinterpret_cast<Context*>(context)->fn(item);
       },
       &context,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5714

If we tried to reenter parallel_for, we would deadlock due to trying to acquire the threadpool mutex, which was already held. Removing the mutex (which is unnecessary) didn't fix the problem because pthreadpool has its own internal mutex.

Differential Revision: [D62052200](https://our.internmc.facebook.com/intern/diff/D62052200/)