### PR TITLE
Add warmup for Llama

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .hypothesis
 buck-out/
-cmake-out/
+cmake-out*
+.DS_Store
 cmake-android-out/
 cmake-out-android/
 cmake-ios-out/

--- a/examples/models/llama2/main.cpp
+++ b/examples/models/llama2/main.cpp
@@ -39,6 +39,8 @@ DEFINE_int32(
     -1,
     "Number of CPU threads for inference. Defaults to -1, which implies we'll use a heuristic to derive the # of performant cores for a specific device.");
 
+DEFINE_bool(warmup, false, "Whether to run a warmup run.");
+
 int32_t main(int32_t argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
@@ -57,6 +59,8 @@ int32_t main(int32_t argc, char** argv) {
 
   int32_t cpu_threads = FLAGS_cpu_threads;
 
+  bool warmup = FLAGS_warmup;
+
 #if defined(ET_USE_THREADPOOL)
   uint32_t num_performant_cores = cpu_threads == -1
       ? torch::executorch::cpuinfo::get_num_performant_cores()
@@ -71,6 +75,9 @@ int32_t main(int32_t argc, char** argv) {
   // create llama runner
   example::Runner runner(model_path, tokenizer_path, temperature);
 
+  if (warmup) {
+    runner.warmup(prompt, seq_len);
+  }
   // generate
   runner.generate(prompt, seq_len);
 

--- a/examples/models/llama2/runner/runner.h
+++ b/examples/models/llama2/runner/runner.h
@@ -41,7 +41,11 @@ class Runner {
       std::function<void(const std::string&)> token_callback = {},
       std::function<void(const ::executorch::extension::llm::Stats&)>
           stats_callback = {},
-      bool echo = true);
+      bool echo = true,
+      bool warming = false);
+  ::executorch::runtime::Error warmup(
+      const std::string& prompt,
+      int32_t seq_len = 128);
   void stop();
 
  private:

--- a/extension/llm/runner/stats.h
+++ b/extension/llm/runner/stats.h
@@ -52,6 +52,19 @@ struct Stats {
     aggregate_sampling_timer_start_timestamp = 0;
   }
 
+  void reset() {
+    model_load_start_ms = 0;
+    model_load_end_ms = 0;
+    inference_start_ms = 0;
+    prompt_eval_end_ms = 0;
+    first_token_ms = 0;
+    inference_end_ms = 0;
+    aggregate_sampling_time_ms = 0;
+    num_prompt_tokens = 0;
+    num_generated_tokens = 0;
+    aggregate_sampling_timer_start_timestamp = 0;
+  }
+
  private:
   long aggregate_sampling_timer_start_timestamp = 0;
 };


### PR DESCRIPTION
Load the model. Run the everything twice. Reset stats in between two runs. Also decrease logging level for warm up.

Notes:
- Tested on Android and Mac. With Llama2 and Llama3 - with temperature=0 produces same output.
- This warm up option is disabled by default.
- This is inspired from llama.cpp options [[1](https://github.com/ggerganov/llama.cpp/blob/ea9c32be71b91b42ecc538bd902e93cbb5fb36cb/common/common.cpp#L897-L929), [2](https://github.com/ggerganov/llama.cpp/blob/ea9c32be71b91b42ecc538bd902e93cbb5fb36cb/examples/llama-bench/llama-bench.cpp#L1595-L1602)].
- Sample [runs](https://www.internalfb.com/phabricator/paste/view/P1613261035)

