### PR TITLE
Adding executorch_prim::mod.Scalar

### DIFF
--- a/examples/selective_build/test_selective_build.sh
+++ b/examples/selective_build/test_selective_build.sh
@@ -48,9 +48,9 @@ test_buck2_select_ops_in_list() {
     ${PYTHON_EXECUTABLE} -m examples.portable.scripts.export --model_name="add_mul"
 
     echo "Running selective build test"
-    # set max_kernel_num=21: 19 primops, add, mul
+    # set max_kernel_num=22: 19 primops, add, mul
     $BUCK run //examples/selective_build:selective_build_test \
-        --config=executorch.max_kernel_num=21 \
+        --config=executorch.max_kernel_num=22 \
         --config=executorch.select_ops=list \
         -- --model_path=./add_mul.pte
 
@@ -117,11 +117,11 @@ test_cmake_select_ops_in_list() {
 
     local example_dir=examples/selective_build
     local build_dir=cmake-out/${example_dir}
-    # set MAX_KERNEL_NUM=21: 19 primops, add, mul
+    # set MAX_KERNEL_NUM=22: 19 primops, add, mul
     rm -rf ${build_dir}
     retry cmake -DBUCK2="$BUCK" \
             -DCMAKE_BUILD_TYPE=Release \
-            -DMAX_KERNEL_NUM=21 \
+            -DMAX_KERNEL_NUM=22 \
             -DEXECUTORCH_SELECT_OPS_LIST="aten::convolution.out,\
 aten::_native_batch_norm_legit_no_training.out,aten::hardtanh.out,aten::add.out,\
 aten::mean.out,aten::view_copy.out,aten::permute_copy.out,aten::addmm.out,\

--- a/kernels/prim_ops/register_prim_ops.cpp
+++ b/kernels/prim_ops/register_prim_ops.cpp
@@ -286,6 +286,21 @@ static Kernel prim_ops[] = {
           out = EValue(a.toInt() % b.toInt());
         }),
 
+    // executorch_prim::mod.Scalar(Scalar, Scalar) -> Scalar
+    Kernel(
+        "executorch_prim::mod.Scalar",
+        [](KernelRuntimeContext& context, EValue** stack) {
+          (void)context;
+          EValue& a = *stack[0];
+          EValue& b = *stack[1];
+          EValue& out = *stack[2];
+          if (a.isInt() && b.isInt()) {
+            out = EValue(a.toInt() % b.toInt());
+          } else {
+            ET_CHECK_MSG(false, "%zu, %zu", (size_t)a.tag, (size_t)b.tag);
+          }
+        }),
+
     // executorch_prim::et_copy_index.tensor(tensor, tensor) -> tensor
     Kernel("executorch_prim::et_copy_index.tensor", &et_copy_index),
     // executorch_prim::et_view.default(Tensor, int[]) -> Tensor

--- a/kernels/prim_ops/test/prim_ops_test.cpp
+++ b/kernels/prim_ops/test/prim_ops_test.cpp
@@ -115,6 +115,9 @@ TEST_F(RegisterPrimOpsTest, TestAlgebraOps) {
   getOpsFn("executorch_prim::mod.int")(context, stack);
   EXPECT_EQ(stack[2]->toInt(), 3);
 
+  getOpsFn("executorch_prim::mod.Scalar")(context, stack);
+  EXPECT_EQ(stack[2]->toInt(), 3);
+
   getOpsFn("executorch_prim::sym_float.Scalar")(context, stack);
   EXPECT_FLOAT_EQ(stack[1]->toDouble(), 3.0);
 }


### PR DESCRIPTION
Summary: Adding mod.Scalar required by the Seamless ASR model example.

Differential Revision: D63518182


