### PR TITLE
Add model files support for android tokenizer

### DIFF
--- a/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/SettingsActivity.java
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/SettingsActivity.java
@@ -315,7 +315,7 @@ public class SettingsActivity extends AppCompatActivity {
       }
       return result;
     }
-    return null;
+    return new String[] {};
   }
 
   private void setupModelTypeSelectorDialog() {
@@ -343,8 +343,10 @@ public class SettingsActivity extends AppCompatActivity {
 
   private void setupTokenizerSelectorDialog() {
     String[] binFiles = listLocalFile("/data/local/tmp/llama/", ".bin");
-    String[] tokenizerFiles = new String[binFiles.length];
+    String[] modelFiles = listLocalFile("/data/local/tmp/llama/", ".model");
+    String[] tokenizerFiles = new String[binFiles.length + modelFiles.length];
     System.arraycopy(binFiles, 0, tokenizerFiles, 0, binFiles.length);
+    System.arraycopy(modelFiles, 0, tokenizerFiles, binFiles.length, modelFiles.length);
     AlertDialog.Builder tokenizerPathBuilder = new AlertDialog.Builder(this);
     tokenizerPathBuilder.setTitle("Select tokenizer path");
     tokenizerPathBuilder.setSingleChoiceItems(


### PR DESCRIPTION
Summary: Add model files support for android tokenizer. Previously we only support .bin files, but since the runner also supports .model now, updating the app side logic to allow .model tokenizer files.

Differential Revision: D63491811
