### PR TITLE
[4/n][ET-VK] Enable AHB extension for Android builds

### DIFF
--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -70,6 +70,9 @@ VkDevice create_logical_device(
 #ifdef VK_KHR_portability_subset
       VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME,
 #endif /* VK_KHR_portability_subset */
+#ifdef VK_ANDROID_external_memory_android_hardware_buffer
+      VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME,
+#endif /* VK_ANDROID_external_memory_android_hardware_buffer */
       VK_KHR_16BIT_STORAGE_EXTENSION_NAME,
       VK_KHR_8BIT_STORAGE_EXTENSION_NAME,
       VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME,

--- a/backends/vulkan/runtime/vk_api/vk_api.h
+++ b/backends/vulkan/runtime/vk_api/vk_api.h
@@ -10,6 +10,12 @@
 
 #ifdef USE_VULKAN_WRAPPER
 #ifdef USE_VULKAN_VOLK
+#ifdef VK_ANDROID_external_memory_android_hardware_buffer
+#include <android/hardware_buffer.h>
+#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_android.h>
+#endif /* VK_ANDROID_external_memory_android_hardware_buffer */
+
 #include <volk.h>
 #else
 #include <vulkan_wrapper.h>

--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -142,10 +142,18 @@ def define_common_targets(is_fbcode = False):
         VK_API_DEPS += [
             "fbsource//third-party/volk:volk",
         ]
+        VK_API_DEPS += select({
+            "DEFAULT": [],
+            "ovr_config//os:android": ["fbsource//third-party/toolchains:android"],
+        })
         VK_API_PREPROCESSOR_FLAGS += [
             "-DUSE_VULKAN_WRAPPER",
             "-DUSE_VULKAN_VOLK",
         ]
+        VK_API_PREPROCESSOR_FLAGS += select({
+            "DEFAULT": [],
+            "ovr_config//os:android": ["-DVK_ANDROID_external_memory_android_hardware_buffer"],
+        })
     else:
         VK_API_DEPS += [
             "fbsource//third-party/swiftshader:swiftshader_vk_headers",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5733
* __->__ #5729

Upcoming changes will allow using the ET-VK runtime for Vulkan buffer/image creation around AHardwareBuffers.

Differential Revision: [D63327846](https://our.internmc.facebook.com/intern/diff/D63327846/)