### PR TITLE
[ET-VK] Fix `VK_NULL_HANDLE` comparison style

### DIFF
--- a/backends/vulkan/runtime/vk_api/Command.cpp
+++ b/backends/vulkan/runtime/vk_api/Command.cpp
@@ -247,7 +247,7 @@ CommandPool::CommandPool(
 }
 
 CommandPool::~CommandPool() {
-  if (VK_NULL_HANDLE == pool_) {
+  if (pool_ == VK_NULL_HANDLE) {
     return;
   }
   vkDestroyCommandPool(device_, pool_, nullptr);

--- a/backends/vulkan/runtime/vk_api/Command.h
+++ b/backends/vulkan/runtime/vk_api/Command.h
@@ -99,7 +99,7 @@ class CommandBuffer final {
   VkCommandBuffer get_submit_handle(const bool final_use = false);
 
   inline operator bool() const {
-    return VK_NULL_HANDLE != handle_;
+    return handle_ != VK_NULL_HANDLE;
   }
 };
 

--- a/backends/vulkan/runtime/vk_api/Descriptor.cpp
+++ b/backends/vulkan/runtime/vk_api/Descriptor.cpp
@@ -261,7 +261,7 @@ DescriptorPool::DescriptorPool(
 }
 
 DescriptorPool::~DescriptorPool() {
-  if (VK_NULL_HANDLE == pool_) {
+  if (pool_ == VK_NULL_HANDLE) {
     return;
   }
   vkDestroyDescriptorPool(device_, pool_, nullptr);

--- a/backends/vulkan/runtime/vk_api/Device.cpp
+++ b/backends/vulkan/runtime/vk_api/Device.cpp
@@ -84,7 +84,7 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
 DeviceHandle::DeviceHandle(VkDevice device) : handle(device) {}
 
 DeviceHandle::~DeviceHandle() {
-  if (VK_NULL_HANDLE == handle) {
+  if (handle == VK_NULL_HANDLE) {
     return;
   }
   vkDestroyDevice(handle, nullptr);

--- a/backends/vulkan/runtime/vk_api/Fence.cpp
+++ b/backends/vulkan/runtime/vk_api/Fence.cpp
@@ -44,7 +44,7 @@ VulkanFence& VulkanFence::operator=(VulkanFence&& other) noexcept {
 }
 
 VulkanFence::~VulkanFence() {
-  if (VK_NULL_HANDLE == handle_) {
+  if (handle_ == VK_NULL_HANDLE) {
     return;
   }
   vkDestroyFence(device_, handle_, nullptr);

--- a/backends/vulkan/runtime/vk_api/Fence.h
+++ b/backends/vulkan/runtime/vk_api/Fence.h
@@ -62,7 +62,7 @@ class VulkanFence final {
   }
 
   operator bool() const {
-    return (VK_NULL_HANDLE != handle_);
+    return (handle_ != VK_NULL_HANDLE);
   }
 };
 

--- a/backends/vulkan/runtime/vk_api/Pipeline.cpp
+++ b/backends/vulkan/runtime/vk_api/Pipeline.cpp
@@ -228,7 +228,7 @@ PipelineLayout::PipelineLayout(PipelineLayout&& other) noexcept
 }
 
 PipelineLayout::~PipelineLayout() {
-  if (VK_NULL_HANDLE == handle_) {
+  if (handle_ == VK_NULL_HANDLE) {
     return;
   }
   vkDestroyPipelineLayout(device_, handle_, nullptr);
@@ -300,7 +300,7 @@ ComputePipeline::ComputePipeline(ComputePipeline&& other) noexcept
 }
 
 ComputePipeline::~ComputePipeline() {
-  if (VK_NULL_HANDLE == handle_) {
+  if (handle_ == VK_NULL_HANDLE) {
     return;
   }
   vkDestroyPipeline(device_, handle_, nullptr);
@@ -402,7 +402,7 @@ ComputePipelineCache::ComputePipelineCache(
 ComputePipelineCache::~ComputePipelineCache() {
   purge();
 
-  if (VK_NULL_HANDLE == pipeline_cache_) {
+  if (pipeline_cache_ == VK_NULL_HANDLE) {
     return;
   }
 

--- a/backends/vulkan/runtime/vk_api/QueryPool.cpp
+++ b/backends/vulkan/runtime/vk_api/QueryPool.cpp
@@ -30,7 +30,7 @@ constexpr int64_t kDefaultNsPerTick = 52; // lround(52.08f);
 } // namespace
 
 #define EARLY_RETURN_IF_UNINITIALIZED() \
-  if (VK_NULL_HANDLE == querypool_) {   \
+  if (querypool_ == VK_NULL_HANDLE) {   \
     return;                             \
   }
 
@@ -178,7 +178,7 @@ std::string stringize(const VkExtent3D& extents) {
 }
 std::vector<std::tuple<std::string, uint32_t, uint64_t, uint64_t>>
 QueryPool::get_shader_timestamp_data() {
-  if (VK_NULL_HANDLE == querypool_) {
+  if (querypool_ == VK_NULL_HANDLE) {
     return {};
   }
   std::lock_guard<std::mutex> lock(mutex_);

--- a/backends/vulkan/runtime/vk_api/Runtime.cpp
+++ b/backends/vulkan/runtime/vk_api/Runtime.cpp
@@ -134,7 +134,7 @@ VkInstance create_instance(const RuntimeConfig& config) {
 
 std::vector<Runtime::DeviceMapping> create_physical_devices(
     VkInstance instance) {
-  if (VK_NULL_HANDLE == instance) {
+  if (instance == VK_NULL_HANDLE) {
     return std::vector<Runtime::DeviceMapping>();
   }
 
@@ -176,7 +176,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debug_report_callback_fn(
 VkDebugReportCallbackEXT create_debug_report_callback(
     VkInstance instance,
     const RuntimeConfig config) {
-  if (VK_NULL_HANDLE == instance || !config.enable_validation_messages) {
+  if (instance == VK_NULL_HANDLE || !config.enable_validation_messages) {
     return VkDebugReportCallbackEXT{};
   }
 
@@ -296,7 +296,7 @@ Runtime::Runtime(const RuntimeConfig config)
 }
 
 Runtime::~Runtime() {
-  if (VK_NULL_HANDLE == instance_) {
+  if (instance_ == VK_NULL_HANDLE) {
     return;
   }
 

--- a/backends/vulkan/runtime/vk_api/Shader.cpp
+++ b/backends/vulkan/runtime/vk_api/Shader.cpp
@@ -83,7 +83,7 @@ ShaderLayout::ShaderLayout(ShaderLayout&& other) noexcept
 }
 
 ShaderLayout::~ShaderLayout() {
-  if (VK_NULL_HANDLE == handle_) {
+  if (handle_ == VK_NULL_HANDLE) {
     return;
   }
   vkDestroyDescriptorSetLayout(device_, handle_, nullptr);
@@ -128,7 +128,7 @@ ShaderModule::ShaderModule(ShaderModule&& other) noexcept
 }
 
 ShaderModule::~ShaderModule() {
-  if (VK_NULL_HANDLE == handle_) {
+  if (handle_ == VK_NULL_HANDLE) {
     return;
   }
   vkDestroyShaderModule(device_, handle_, nullptr);

--- a/backends/vulkan/runtime/vk_api/memory/Allocation.cpp
+++ b/backends/vulkan/runtime/vk_api/memory/Allocation.cpp
@@ -65,7 +65,7 @@ Allocation::~Allocation() {
   // Do not destroy the VmaAllocation if this class instance is a copy of some
   // other class instance, since this means that this class instance does not
   // have ownership of the underlying resource.
-  if (VK_NULL_HANDLE != allocation && !is_copy_) {
+  if (allocation != VK_NULL_HANDLE && !is_copy_) {
     vmaFreeMemory(allocator, allocation);
   }
 }

--- a/backends/vulkan/runtime/vk_api/memory/Allocator.cpp
+++ b/backends/vulkan/runtime/vk_api/memory/Allocator.cpp
@@ -52,7 +52,7 @@ Allocator::Allocator(Allocator&& other) noexcept
 }
 
 Allocator::~Allocator() {
-  if (VK_NULL_HANDLE == allocator_) {
+  if (allocator_ == VK_NULL_HANDLE) {
     return;
   }
   vmaDestroyAllocator(allocator_);

--- a/backends/vulkan/runtime/vk_api/memory/Buffer.cpp
+++ b/backends/vulkan/runtime/vk_api/memory/Buffer.cpp
@@ -122,7 +122,7 @@ VulkanBuffer::~VulkanBuffer() {
   // Do not destroy the VkBuffer if this class instance is a copy of another
   // class instance, since this means that this class instance does not have
   // ownership of the underlying resource.
-  if (VK_NULL_HANDLE != handle_ && !is_copy_) {
+  if (handle_ != VK_NULL_HANDLE && !is_copy_) {
     if (owns_memory_) {
       vmaDestroyBuffer(allocator_, handle_, memory_.allocation);
     } else {

--- a/backends/vulkan/runtime/vk_api/memory/Image.cpp
+++ b/backends/vulkan/runtime/vk_api/memory/Image.cpp
@@ -57,7 +57,7 @@ ImageSampler::ImageSampler(ImageSampler&& other) noexcept
 }
 
 ImageSampler::~ImageSampler() {
-  if (VK_NULL_HANDLE == handle_) {
+  if (handle_ == VK_NULL_HANDLE) {
     return;
   }
   vkDestroySampler(device_, handle_, nullptr);
@@ -232,11 +232,11 @@ VulkanImage::~VulkanImage() {
     return;
   }
 
-  if (VK_NULL_HANDLE != handles_.image_view) {
+  if (handles_.image_view != VK_NULL_HANDLE) {
     vkDestroyImageView(this->device(), handles_.image_view, nullptr);
   }
 
-  if (VK_NULL_HANDLE != handles_.image) {
+  if (handles_.image != VK_NULL_HANDLE) {
     if (owns_memory_) {
       vmaDestroyImage(allocator_, handles_.image, memory_.allocation);
     } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5731
* #5729

`VK_NULL_HANDLE` is a constant and should hence be the right hand side of the expression. Fixing the instances where it's on the left hand side.

Differential Revision: [D63560116](https://our.internmc.facebook.com/intern/diff/D63560116/)