### PR TITLE
Add OptionalIntArrayRef used by torchgen.

### DIFF
--- a/runtime/core/exec_aten/exec_aten.h
+++ b/runtime/core/exec_aten/exec_aten.h
@@ -87,6 +87,7 @@ using IntArrayRef = at::IntArrayRef;
 
 template <typename T>
 using OptionalArrayRef = c10::OptionalArrayRef<T>;
+using OptionalIntArrayRef = OptionalArrayRef<int64_t>;
 
 inline ssize_t compute_numel(const SizesType* sizes, ssize_t dim) {
   return static_cast<ssize_t>(
@@ -132,6 +133,7 @@ using IntArrayRef = torch::executor::IntArrayRef;
 template <typename T>
 using OptionalArrayRef =
     torch::executor::optional<torch::executor::ArrayRef<T>>;
+using OptionalIntArrayRef = OptionalArrayRef<int64_t>;
 
 using torch::executor::compute_numel;
 


### PR DESCRIPTION
Summary:
Adds OptionalIntArrayRef for generated cpp using torchgen.

Generated code with torchgen.api.types.CppSignatureGroup uses additional aliases that are not currently defined in exec_aten.h. This diff adds support for OptionalIntArrayRef.

Example: aten::mean.dim uses an optional int array that would end up using `OptionalIntArrayRef`.

Differential Revision: D63568016
