### PR TITLE
add command_alias in runtime_wrapper

### DIFF
--- a/shim/xplat/executorch/build/env_interface.bzl
+++ b/shim/xplat/executorch/build/env_interface.bzl
@@ -202,6 +202,8 @@ def _struct_to_json(object):
 
 env = struct(
     # @lint-ignore BUCKLINT: native and fb_native are explicitly forbidden in fbcode.
+    command_alias = native.command_alias,
+    # @lint-ignore BUCKLINT: native and fb_native are explicitly forbidden in fbcode.
     cxx_binary = native.cxx_binary,
     # @lint-ignore BUCKLINT: native and fb_native are explicitly forbidden in fbcode.
     cxx_library = native.cxx_library,

--- a/shim/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim/xplat/executorch/build/runtime_wrapper.bzl
@@ -301,6 +301,10 @@ def _filegroup(*args, **kwargs):
     _patch_kwargs_common(kwargs)
     env.filegroup(*args, **kwargs)
 
+def _command_alias(*args, **kwargs):
+    _patch_kwargs_common(kwargs)
+    env.command_alias(*args, **kwargs)
+
 def _genrule(*args, **kwargs):
     _patch_kwargs_common(kwargs)
     env.patch_platforms(kwargs)
@@ -345,6 +349,7 @@ def get_oss_build_kwargs():
 # see the "Build Rules" section in the sidebar of
 # https://buck.build/concept/build_rule.html.
 runtime = struct(
+    command_alias = _command_alias,
     cxx_binary = _cxx_binary,
     cxx_library = _cxx_library,
     cxx_python_extension = _cxx_python_extension,


### PR DESCRIPTION
Summary: As title, expand the runtime wrapper to support `command_alias` so we can use it to set env_variable. Test in D63556730

Differential Revision: D63570326
