### PR TITLE
[ExecuTorch] Fix missing cstdint in vec_base.h

### DIFF
--- a/kernels/optimized/vec/vec_base.h
+++ b/kernels/optimized/vec/vec_base.h
@@ -3,6 +3,7 @@
 // @nolint PATTERNLINT <functional> is required for std::equal_to, etc.
 
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <cmath>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5747

This header uses int32_t etc and doesn't have this include.

Differential Revision: [D63638423](https://our.internmc.facebook.com/intern/diff/D63638423/)