### PR TITLE
Integrating Axis Mapping into Quantized Linear Texture Implementation

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/q_8w_linear.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q_8w_linear.glsl
@@ -26,9 +26,9 @@ ${layout_declare_tensor(0, "w", "t_out", DTYPE, STORAGE)}
 ${layout_declare_tensor(1, "r", "t_mat1", DTYPE, STORAGE)}
 ${layout_declare_tensor(2, "r", "t_qmat2", "int8", STORAGE)}
 ${layout_declare_tensor(3, "r", "t_scales", DTYPE, STORAGE)}
+${layout_declare_ubo(4, "ivec4", "out_sizes")}
 
 $if STORAGE == "buffer":
-  ${layout_declare_ubo(4, "ivec4", "out_sizes")}
   ${layout_declare_ubo(5, "ivec4", "out_strides")}
   ${layout_declare_ubo(6, "int", "out_numel")}
   ${layout_declare_ubo(7, "ivec4", "mat1_sizes")}
@@ -36,10 +36,14 @@ $if STORAGE == "buffer":
   ${layout_declare_ubo(9, "ivec4", "qmat2_strides")}
   ${layout_declare_ubo(10, "ivec4", "scales_strides")}
 $else:
-  ${layout_declare_ubo(4, "ivec3", "out_limits")}
-  ${layout_declare_ubo(5, "ivec4", "mat1_sizes")}
+  ${layout_declare_ubo(5, "ivec3", "out_limits")}
+  ${layout_declare_ubo(6, "ivec4", "out_axis_map")}
+  ${layout_declare_ubo(7, "ivec4", "mat1_sizes")}
+  ${layout_declare_ubo(8, "ivec4", "mat1_axis_map")}
+  ${layout_declare_ubo(9, "ivec4", "qmat2_axis_map")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+layout(constant_id = 3) const int out_packed_dim = W_DIM;
 
 // This header file must be defined after the layout descriptors have been
 // declared because the functions in the header assume some variables have been
@@ -62,13 +66,14 @@ void main() {
 #else // USING_TEXTURE
 
 void main() {
-  const ivec3 out_pos = ivec3(gl_GlobalInvocationID);
-  if (any(greaterThanEqual(out_pos, out_limits))) {
+  const ivec3 out_lpos = ivec3(gl_GlobalInvocationID);
+  if (any(greaterThanEqual(out_lpos, out_limits))) {
     return;
   }
 
-  VEC4_T outtex = q_8w_linear(out_pos, mat1_sizes.x);
-  write_texel(t_out, out_pos, outtex);
+  vec4 texel = q_8w_linear(out_lpos);
+
+  write_texel_lpos(t_out, out_lpos, texel, out_axis_map);
 }
 
 #endif

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
@@ -94,7 +94,20 @@ void add_q_8w_linear_node(
          graph.strides_ubo(q_mat2),
          graph.strides_ubo(scales)});
   } else {
-    ubos.append({graph.logical_limits_ubo(out), graph.sizes_ubo(mat1)});
+    ubos.append(
+        {graph.sizes_ubo(out),
+         graph.logical_limits_ubo(out),
+         graph.axis_map_ubo(out),
+         graph.sizes_ubo(mat1),
+         graph.axis_map_ubo(mat1),
+         graph.axis_map_ubo(q_mat2)});
+  }
+
+  vkapi::SpecVarList spec_vars;
+  if (graph.is_buffer_storage(out)) {
+    spec_vars = {};
+  } else {
+    spec_vars = {graph.packed_dim_of(out)};
   }
 
   graph.execute_nodes().emplace_back(new ExecuteNode(
@@ -108,7 +121,7 @@ void add_q_8w_linear_node(
       // Shader params buffers
       ubos,
       // Specialization Constants
-      {},
+      spec_vars,
       // Resizing Logic
       resize_qlinear_node));
 }


### PR DESCRIPTION
Summary:
# Summary
Integrating Axis Mapping into Quantized Linear texture implementation following D62518403. This updates the Quantized Linear shader to map the virtual texture axis to the logical texture axis.

[TO-DO] Add Mat Mul Benchmark Info (asking Stephen for command)

Differential Revision: D63614693
