### PR TITLE
Clean up Outdated Args from Llama Export Script

### DIFF
--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -312,16 +312,6 @@ def build_args_parser() -> argparse.ArgumentParser:
     parser.add_argument("--mps", action="store_true")
     parser.add_argument("--coreml", action="store_true")
     parser.add_argument(
-        "--coreml-enable-state",
-        action="store_true",
-        help="This option is only for coreml, and is only supported for MacOS15+/iOS18+",
-    )
-    parser.add_argument(
-        "--coreml-preserve-sdpa",
-        action="store_true",
-        help="This option is only for coreml: Preserve sdpa in torch edge program to use coreml iOS18.sdpa op",
-    )
-    parser.add_argument(
         "--coreml-quantize",
         default=None,
         choices=["b4w"],


### PR DESCRIPTION
2 coreml-specific args were introduced to llama export script
1. https://github.com/pytorch/executorch/pull/5165 introduced `--coreml-enable-state`
2. https://github.com/pytorch/executorch/pull/5258 introduced `--coreml-preserve-sdpa`

Since users would want to target iOS version rather than tune optimizations, https://github.com/pytorch/executorch/pull/5319 introduced `--coreml-ios 18`. However, https://github.com/pytorch/executorch/pull/5319 forgot to remove the outdated `--coreml-enable-state` and `--coreml-preserve-sdpa`