### PR TITLE
Add kwarg example inputs to eager model base

### DIFF
--- a/examples/apple/coreml/scripts/debugger_cli.py
+++ b/examples/apple/coreml/scripts/debugger_cli.py
@@ -149,7 +149,7 @@ def main() -> None:
         root_dir_path=get_root_dir_path(), conda_env_name=args.conda_environment_name
     )
 
-    model, example_inputs, _ = EagerModelFactory.create_model(
+    model, example_inputs, _, _ = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 

--- a/examples/apple/coreml/scripts/export.py
+++ b/examples/apple/coreml/scripts/export.py
@@ -158,7 +158,7 @@ def main():
             f"Valid compute units are {valid_compute_units}."
         )
 
-    model, example_inputs, _ = EagerModelFactory.create_model(
+    model, example_inputs, _, _ = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 

--- a/examples/apple/mps/scripts/mps_example.py
+++ b/examples/apple/mps/scripts/mps_example.py
@@ -152,7 +152,7 @@ if __name__ == "__main__":
         raise RuntimeError(f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}.")
 
     model_config = get_model_config(args)
-    model, example_inputs, _ = EagerModelFactory.create_model(**model_config)
+    model, example_inputs, _, _ = EagerModelFactory.create_model(**model_config)
 
     model = model.eval()
 

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -50,7 +50,7 @@ def get_model_and_inputs_from_name(model_name: str):
         logging.warning(
             "Using a model from examples/models not all of these are currently supported"
         )
-        model, example_inputs, _ = EagerModelFactory.create_model(
+        model, example_inputs, _, _ = EagerModelFactory.create_model(
             *MODEL_NAME_TO_MODEL[model_name]
         )
     # Case 3: Model is in an external python file loaded as a module.

--- a/examples/devtools/scripts/export_bundled_program.py
+++ b/examples/devtools/scripts/export_bundled_program.py
@@ -139,7 +139,7 @@ def main() -> None:
             f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}."
         )
 
-    model, example_inputs, _ = EagerModelFactory.create_model(
+    model, example_inputs, _, _ = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 

--- a/examples/devtools/scripts/gen_sample_etrecord.py
+++ b/examples/devtools/scripts/gen_sample_etrecord.py
@@ -74,7 +74,7 @@ def main() -> None:
             f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}."
         )
 
-    model, example_inputs, _ = EagerModelFactory.create_model(
+    model, example_inputs, _, _ = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -774,7 +774,7 @@ def _load_llama_model(
     logging.info(
         f"Loading model with checkpoint={checkpoint}, params={params_path}, use_kv_cache={use_kv_cache}, weight_type={weight_type}"
     )
-    model, example_inputs, _ = EagerModelFactory.create_model(
+    model, example_inputs, example_kwarg_inputs, _ = EagerModelFactory.create_model(
         "llama2",
         "Llama2Model",
         checkpoint=checkpoint,
@@ -824,6 +824,7 @@ def _load_llama_model(
         use_kv_cache=use_kv_cache,
         generate_full_logits=generate_full_logits,
         example_inputs=example_inputs,
+        example_kwarg_inputs=example_kwarg_inputs,
         enable_dynamic_shape=enable_dynamic_shape,
         calibration_tasks=calibration_tasks,
         calibration_limit=calibration_limit,

--- a/examples/models/llama2/runner/eager.py
+++ b/examples/models/llama2/runner/eager.py
@@ -31,7 +31,7 @@ class EagerLlamaRunner(LlamaRunner):
             **params,
         )
         super().__init__(tokenizer_path=args.tokenizer, model_args=model_args)
-        self.model, _, _ = EagerModelFactory.create_model(
+        self.model, _, _, _ = EagerModelFactory.create_model(
             "llama2",
             "Llama2Model",
             checkpoint=args.checkpoint,

--- a/examples/models/model_factory.py
+++ b/examples/models/model_factory.py
@@ -6,7 +6,7 @@
 
 import importlib
 import os
-from typing import Any, Tuple
+from typing import Any, Dict, Tuple
 
 import torch
 
@@ -19,7 +19,7 @@ class EagerModelFactory:
     @staticmethod
     def create_model(
         module_name, model_class_name, **kwargs
-    ) -> Tuple[torch.nn.Module, Any, Any]:
+    ) -> Tuple[torch.nn.Module, Tuple[Any], Dict[str, Any], Any]:
         """
         Create an instance of a model class that implements EagerModelBase and retrieve related data.
 
@@ -42,14 +42,18 @@ class EagerModelFactory:
         if hasattr(module, model_class_name):
             model_class = getattr(module, model_class_name)
             model = model_class(**kwargs)
+            example_kwarg_inputs = None
+            dynamic_shapes = None
+            if hasattr(model, "get_example_kwarg_inputs()"):
+                example_kwarg_inputs = model.get_example_kwarg_inputs()
             if hasattr(model, "get_dynamic_shapes"):
-                return (
-                    model.get_eager_model(),
-                    model.get_example_inputs(),
-                    model.get_dynamic_shapes(),
-                )
-            else:
-                return model.get_eager_model(), model.get_example_inputs(), None
+                dynamic_shapes = model.get_dynamic_shapes()
+            return (
+                model.get_eager_model(),
+                model.get_example_inputs(),
+                example_kwarg_inputs,
+                dynamic_shapes,
+            )
 
         raise ValueError(
             f"Model class '{model_class_name}' not found in module '{module_name}'."

--- a/examples/models/test/test_export.py
+++ b/examples/models/test/test_export.py
@@ -69,7 +69,7 @@ class ExportTest(unittest.TestCase):
         return self.assertTrue(result)
 
     def test_mv3_export_to_executorch(self):
-        eager_model, example_inputs, _ = EagerModelFactory.create_model(
+        eager_model, example_inputs, _, _ = EagerModelFactory.create_model(
             *MODEL_NAME_TO_MODEL["mv3"]
         )
         eager_output, executorch_output = self.collect_executorch_and_eager_outputs(
@@ -81,7 +81,7 @@ class ExportTest(unittest.TestCase):
         )
 
     def test_mv2_export_to_executorch(self):
-        eager_model, example_inputs, _ = EagerModelFactory.create_model(
+        eager_model, example_inputs, _, _ = EagerModelFactory.create_model(
             *MODEL_NAME_TO_MODEL["mv2"]
         )
         eager_output, executorch_output = self.collect_executorch_and_eager_outputs(
@@ -90,7 +90,7 @@ class ExportTest(unittest.TestCase):
         self.validate_tensor_allclose(eager_output, executorch_output[0])
 
     def test_vit_export_to_executorch(self):
-        eager_model, example_inputs, _ = EagerModelFactory.create_model(
+        eager_model, example_inputs, _, _ = EagerModelFactory.create_model(
             *MODEL_NAME_TO_MODEL["vit"]
         )
         eager_output, executorch_output = self.collect_executorch_and_eager_outputs(
@@ -102,7 +102,7 @@ class ExportTest(unittest.TestCase):
         )
 
     def test_w2l_export_to_executorch(self):
-        eager_model, example_inputs, _ = EagerModelFactory.create_model(
+        eager_model, example_inputs, _, _ = EagerModelFactory.create_model(
             *MODEL_NAME_TO_MODEL["w2l"]
         )
         eager_output, executorch_output = self.collect_executorch_and_eager_outputs(
@@ -111,7 +111,7 @@ class ExportTest(unittest.TestCase):
         self.validate_tensor_allclose(eager_output, executorch_output[0])
 
     def test_ic3_export_to_executorch(self):
-        eager_model, example_inputs, _ = EagerModelFactory.create_model(
+        eager_model, example_inputs, _, _ = EagerModelFactory.create_model(
             *MODEL_NAME_TO_MODEL["ic3"]
         )
         eager_output, executorch_output = self.collect_executorch_and_eager_outputs(
@@ -123,7 +123,7 @@ class ExportTest(unittest.TestCase):
         )
 
     def test_resnet18_export_to_executorch(self):
-        eager_model, example_inputs, _ = EagerModelFactory.create_model(
+        eager_model, example_inputs, _, _ = EagerModelFactory.create_model(
             *MODEL_NAME_TO_MODEL["resnet18"]
         )
         eager_output, executorch_output = self.collect_executorch_and_eager_outputs(
@@ -132,7 +132,7 @@ class ExportTest(unittest.TestCase):
         self.validate_tensor_allclose(eager_output, executorch_output[0])
 
     def test_resnet50_export_to_executorch(self):
-        eager_model, example_inputs, _ = EagerModelFactory.create_model(
+        eager_model, example_inputs, _, _ = EagerModelFactory.create_model(
             *MODEL_NAME_TO_MODEL["resnet50"]
         )
         eager_output, executorch_output = self.collect_executorch_and_eager_outputs(
@@ -141,7 +141,7 @@ class ExportTest(unittest.TestCase):
         self.validate_tensor_allclose(eager_output, executorch_output[0])
 
     def test_dl3_export_to_executorch(self):
-        eager_model, example_inputs, _ = EagerModelFactory.create_model(
+        eager_model, example_inputs, _, _ = EagerModelFactory.create_model(
             *MODEL_NAME_TO_MODEL["dl3"]
         )
         eager_output, executorch_output = self.collect_executorch_and_eager_outputs(

--- a/examples/portable/scripts/export.py
+++ b/examples/portable/scripts/export.py
@@ -58,7 +58,7 @@ def main() -> None:
             f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}."
         )
 
-    model, example_inputs, dynamic_shapes = EagerModelFactory.create_model(
+    model, example_inputs, _, dynamic_shapes = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 

--- a/examples/portable/scripts/export_and_delegate.py
+++ b/examples/portable/scripts/export_and_delegate.py
@@ -57,7 +57,7 @@ def export_composite_module_with_lower_graph():
         "Running the example to export a composite module with lowered graph..."
     )
 
-    m, m_inputs, _ = EagerModelFactory.create_model(*MODEL_NAME_TO_MODEL["add_mul"])
+    m, m_inputs, _, _ = EagerModelFactory.create_model(*MODEL_NAME_TO_MODEL["add_mul"])
     m_compile_spec = m.get_compile_spec()
 
     # pre-autograd export. eventually this will become torch.export
@@ -166,7 +166,7 @@ def export_and_lower_the_whole_graph():
     """
     logging.info("Running the example to export and lower the whole graph...")
 
-    m, m_inputs, _ = EagerModelFactory.create_model(*MODEL_NAME_TO_MODEL["add_mul"])
+    m, m_inputs, _, _ = EagerModelFactory.create_model(*MODEL_NAME_TO_MODEL["add_mul"])
     m_compile_spec = m.get_compile_spec()
 
     m_inputs = m.get_example_inputs()

--- a/examples/qualcomm/scripts/export_example.py
+++ b/examples/qualcomm/scripts/export_example.py
@@ -58,7 +58,7 @@ def main() -> None:
             f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}."
         )
 
-    model, example_inputs, _ = EagerModelFactory.create_model(
+    model, example_inputs, _, _ = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
             f"Available models are {list(MODEL_NAME_TO_OPTIONS.keys())}."
         )
 
-    model, example_inputs, _ = EagerModelFactory.create_model(
+    model, example_inputs, _, _ = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
 

--- a/examples/xnnpack/quantization/example.py
+++ b/examples/xnnpack/quantization/example.py
@@ -162,7 +162,7 @@ def main() -> None:
         )
 
     start = time.perf_counter()
-    model, example_inputs, _ = EagerModelFactory.create_model(
+    model, example_inputs, _, _ = EagerModelFactory.create_model(
         *MODEL_NAME_TO_MODEL[args.model_name]
     )
     end = time.perf_counter()


### PR DESCRIPTION
### Summary
For situations where the forward has non-position arguments, such as https://github.com/pytorch/torchtune/blob/3c450ef5f1fbe8237f899e942fd5222491a47ca7/torchtune/modules/transformer.py#L519

PR chain:
- **YOU ARE HERE ~>** [Add kwarg example inputs to eager model base](https://github.com/pytorch/executorch/pull/5765)
- [Llama2 model cleanup](https://github.com/pytorch/executorch/pull/5859)
- [Accept model type parameter in export_llama](https://github.com/pytorch/executorch/pull/5910)
- [Export TorchTune llama3_2_vision in ET](https://github.com/pytorch/executorch/pull/5911)

### Test plan
Exported Stories110M model.
```
wget "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories110M.pt"
echo '{"dim": 768, "multiple_of": 32, "n_heads": 12, "n_layers": 12, "norm_eps": 1e-05, "vocab_size": 32000}' > params.json
python -m examples.models.llama2.export_llama -c stories110M.pt -p params.json -X -kv
```