### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 
 [PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.
 
-[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add the following "Release notes: <area>" label.
+[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label.
 
 ### Test plan
 [PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+### Description
+
+### Test plan
+
+### Issue(s) fixed
+
+### Changelog

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,11 @@
-### Description
+### Summary
 [PLEASE REMOVE] Describe the goal of this PR and any add any relevant context.
 
 ### Test plan
 [PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written.
 
 ### Issue(s) fixed
-[PLEASE REMOVE] List all issues, separate by newlines, that this PR addresses.
+[PLEASE REMOVE] List all issues fixed (e.g. "closes #ISSUE_NUMBER"), separate by newlines, that this PR addresses.
 
 ### Changelog
 [PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add the following line below - `+changelog: <description of feature>`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,4 +8,4 @@
 [PLEASE REMOVE] List all issues fixed (e.g. "closes #ISSUE_NUMBER"), separate by newlines, that this PR addresses.
 
 ### Changelog
-[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add the following line below - `+changelog: <description of feature>`
+[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add the following "Release notes: <area>" label.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,11 @@
 ### Description
+[PLEASE REMOVE] Describe the goal of this PR and any add any relevant context.
 
 ### Test plan
+[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written.
 
 ### Issue(s) fixed
+[PLEASE REMOVE] List all issues, separate by returns, that this PR addresses.
 
 ### Changelog
+[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add the following line below - `+changelog: <description of feature>`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ### Summary
 [PLEASE REMOVE] Describe the goal of this PR and any add any relevant context.
 
-[PLEASE REMOVE] If this PR closes an issue, please add a `Closes #<issue-id>` line.
+[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.
 
 [PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add the following "Release notes: <area>" label.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,9 @@
 ### Summary
 [PLEASE REMOVE] Describe the goal of this PR and any add any relevant context.
 
+[PLEASE REMOVE] If this PR closes an issue, please add a `Closes #<issue-id>` line.
+
+[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add the following "Release notes: <area>" label.
+
 ### Test plan
 [PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written.
-
-### Issue(s) fixed
-[PLEASE REMOVE] List all issues fixed (e.g. "closes #ISSUE_NUMBER"), separate by newlines, that this PR addresses.
-
-### Changelog
-[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add the following "Release notes: <area>" label.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 [PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written.
 
 ### Issue(s) fixed
-[PLEASE REMOVE] List all issues, separate by returns, that this PR addresses.
+[PLEASE REMOVE] List all issues, separate by newlines, that this PR addresses.
 
 ### Changelog
 [PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add the following line below - `+changelog: <description of feature>`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,4 +7,3 @@
 
 ### Test plan
 [PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,10 @@
 ### Summary
-[PLEASE REMOVE] Describe the goal of this PR and any add any relevant context.
+[PLEASE REMOVE] Describe the goal of this PR and add any relevant context.
 
 [PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.
 
 [PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label.
 
 ### Test plan
-[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written.
+[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
 ### Summary
-[PLEASE REMOVE] Describe the goal of this PR and add any relevant context.
+[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.
 
 [PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.
 
-[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label.
+[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).
 
 ### Test plan
 [PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,8 +250,8 @@ for basics.
        future editor understand how to test the code that you're modifying
        today.
    - If your PR contains or is representative of a feature/bug fix that should be
-     called out in the release notes, please add a label for "Release notes: <area>",
-	 where <area> describes which part of ExecuTorch the change pertains to, e.g.
+     called out in the release notes, please add a label for "Release notes: \<area\>",
+	 where \<area\> describes which part of ExecuTorch the change pertains to, e.g.
 	 "Release notes: runtime". A few of these areas include  "runtime", "backends",
 	 and "build". If you aren't sure whether to add a release label, you should
 	 probably still add one since it immensely facilitates release management.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,14 +242,19 @@ for basics.
    - Give the PR a clear and thorough description. Don't just describe what the PR
      does: the diff will do that. Explain *why* you are making this change, in a
      way that will make sense to someone years from now.
-   - Add the line `Test Plan:` (with that spelling, capitalization, and trailing
-     colon character), followed by lines containing repeatable instructions for
+   - Explain how you have tested your changes by including repeatable instructions for
      testing the PR.
      - If you added tests, this can be as simple as the command you used to run the
        tests.
      - If you tested the PR manually, include the steps and the outputs. Help a
        future editor understand how to test the code that you're modifying
        today.
+   - If your PR contains or is representative of a feature/bug fix that should be
+     called out in the release notes, please add a label for "Release notes: <area>",
+	 where <area> describes which part of ExecuTorch the change pertains to, e.g.
+	 "Release notes: runtime". A few of these areas include  "runtime", "backends",
+	 and "build". If you aren't sure whether to add a release label, you should
+	 probably still add one since it immensely facilitates release management.
    - See https://github.com/pytorch/executorch/pull/3612 for an example PR that
      follows this advice.
 1. Before asking for a review, ensure that all [CI (continuous integration)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,9 +252,17 @@ for basics.
    - If your PR contains or is representative of a feature/bug fix that should be
      called out in the release notes, please add a label for "Release notes: \<area\>",
 	 where \<area\> describes which part of ExecuTorch the change pertains to, e.g.
-	 "Release notes: runtime". A few of these areas include  "runtime", "backends",
-	 and "build". If you aren't sure whether to add a release label, you should
-	 probably still add one since it immensely facilitates release management.
+	 "Release notes: runtime". Here are all of the categories:
+     - `Release notes: runtime`: changes related to the core runtime which loads the program methods, initializes delegates, and runs the lowered graph.
+     - `Release notes: exir`: changes to any internal representations, such as any edge-related dialects. Also any changes to passes that may modify the exir, such as memory planning.
+     - `Release notes: quantization`: changes to quantization.
+     - `Release notes: ops & kernels`: changes to the opset and any new / changed kernel implementations.
+     - `Release notes: api`: changes to public facing apis (any interfaces, pybinded runtime methods, etc.).
+     - `Release notes: backends`: changes to any of the backend delegates.
+     - `Release notes: build`: changes related to the build system, including major dependency upgrades, notable build flags, optimizations, etc.
+     - `Release notes: SDK`: changes to any of ExecuTorch's SDKs, for example the debugger & profiler.
+     - `Release notes: examples`: changes to any of our example LLMs integrations, such as Llama3 and Llava.
+     - `Release notes: misc`: anything notable that doesn't belong in the above categories.
    - See https://github.com/pytorch/executorch/pull/3612 for an example PR that
      follows this advice.
 1. Before asking for a review, ensure that all [CI (continuous integration)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,8 +260,8 @@ for basics.
      - `Release notes: api`: changes to public facing apis (any interfaces, pybinded runtime methods, etc.).
      - `Release notes: backends`: changes to any of the backend delegates.
      - `Release notes: build`: changes related to the build system, including major dependency upgrades, notable build flags, optimizations, etc.
-     - `Release notes: SDK`: changes to any of ExecuTorch's SDKs, for example the debugger & profiler.
-     - `Release notes: examples`: changes to any of our example LLMs integrations, such as Llama3 and Llava.
+     - `Release notes: devtools`: changes to any of ExecuTorch's developer tools, for example the debugger & profiler.
+     - `Release notes: examples`: changes to any code under `examples/`.
      - `Release notes: misc`: anything notable that doesn't belong in the above categories.
    - See https://github.com/pytorch/executorch/pull/3612 for an example PR that
      follows this advice.


### PR DESCRIPTION
### Summary
Adds a default pull request template. Follows how PyTorch tracks changelogs for release notes, which is adding "Release notes: <area>" labels, e.g. [this](https://github.com/pytorch/pytorch/pull/137289) PyTorch PR.

PyTorch also has a bot to remind people to add Release Notes tags, which we can try to integrate later:
<img width="967" alt="image" src="https://github.com/user-attachments/assets/e7086fe8-4fdb-4432-bbb4-affa38483f98">

Fixes #5793

### Test plan
Mock pull request to check if the summary and test plan are formatted into phabricator correctly: https://github.com/pytorch/executorch/pull/5790 -> D63709392.
