### PR TITLE
Arm backend: Make slice-op work without end index

### DIFF
--- a/backends/arm/operators/op_slice.py
+++ b/backends/arm/operators/op_slice.py
@@ -41,9 +41,10 @@ class SliceVisitor(NodeVisitor):
         # Translate and check parameters in Pytorch dim order.
         shape = input_node.shape
         dim = dim.number
-        end = (shape[dim] + end.number) % shape[dim]
-        if end == 0:
-            end = shape[dim]
+        if end.number < 0:
+            end = end.number % shape[dim]
+        else:
+            end = min(end.number, shape[dim])
         size = end - start.number
         assert size > 0
         assert size <= shape[dim]

--- a/backends/arm/test/ops/test_slice.py
+++ b/backends/arm/test/ops/test_slice.py
@@ -30,11 +30,11 @@ class TestSimpleSlice(unittest.TestCase):
             if x.dim() == 1:
                 return x[3:-3]
             elif x.dim() == 2:
-                return x[1:3, 3:5]
+                return x[1:3, 3:]
             elif x.dim() == 3:
-                return x[0:7, 0:1, 0:8]
+                return x[0:7, 0:, 0:8]
             elif x.dim() == 4:
-                return x[:, 2:5, 3:5, 4:10]
+                return x[:, :5, 3:5, 4:10]
 
     def _test_slice_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: torch.Tensor


### PR DESCRIPTION
If no end index is provided to slice, end index will become huge. Make slice-op handle this by taking min of end and shape[dim] to calculate size attribute.