### PR TITLE
[ExecuTorch] Rework apply_ternary_elementwise_fn to allow fixing op_clamp build time (1/2)

### DIFF
--- a/kernels/portable/cpu/op_clamp.cpp
+++ b/kernels/portable/cpu/op_clamp.cpp
@@ -218,30 +218,36 @@ Tensor& clamp_tensor_out(
     ET_SWITCH_REALHB_TYPES(min_type, ctx, name, CTYPE_MIN, [&]() {
       ET_SWITCH_REALHB_TYPES(max_type, ctx, name, CTYPE_MAX, [&]() {
         ET_SWITCH_REALHB_TYPES(out_type, ctx, name, CTYPE_OUT, [&]() {
-          apply_ternary_elementwise_fn<
-              CTYPE_IN,
-              CTYPE_MIN,
-              CTYPE_MAX,
-              CTYPE_OUT>(
+          apply_ternary_elementwise_fn<CTYPE_OUT>(
               [has_min, has_max](
-                  const CTYPE_IN val_in,
-                  const CTYPE_MIN val_min,
-                  const CTYPE_MAX val_max) {
-                CTYPE_OUT val_out = static_cast<CTYPE_OUT>(val_in);
+                  const CTYPE_OUT val_in,
+                  const CTYPE_OUT val_min,
+                  const CTYPE_OUT val_max) {
+                CTYPE_OUT val_out = val_in;
                 if (has_min) {
-                  val_out = utils::max_override(
-                      val_out, static_cast<CTYPE_OUT>(val_min));
+                  val_out = utils::max_override(val_out, val_min);
                 }
                 if (has_max) {
-                  val_out = utils::min_override(
-                      val_out, static_cast<CTYPE_OUT>(val_max));
+                  val_out = utils::min_override(val_out, val_max);
                 }
                 return val_out;
               },
               in,
               min,
               max,
-              out);
+              out,
+              [](const void* inPtr) {
+                return static_cast<CTYPE_OUT>(
+                    *reinterpret_cast<const CTYPE_IN*>(inPtr));
+              },
+              [](const void* minPtr) {
+                return static_cast<CTYPE_OUT>(
+                    *reinterpret_cast<const CTYPE_MIN*>(minPtr));
+              },
+              [](const void* maxPtr) {
+                return static_cast<CTYPE_OUT>(
+                    *reinterpret_cast<const CTYPE_MAX*>(maxPtr));
+              });
         });
       });
     });

--- a/kernels/portable/cpu/op_where.cpp
+++ b/kernels/portable/cpu/op_where.cpp
@@ -48,16 +48,26 @@ Tensor& where_out(
     ET_SWITCH_REALHBBF16_TYPES(b_type, ctx, name, CTYPE_B, [&]() {
       using CTYPE_OUT =
           typename torch::executor::promote_types<CTYPE_A, CTYPE_B>::type;
-      apply_ternary_elementwise_fn<CTYPE_A, CTYPE_B, uint8_t, CTYPE_OUT>(
-          [](const CTYPE_A val_a, const CTYPE_B val_b, const uint8_t val_c) {
-            CTYPE_OUT a_casted = static_cast<CTYPE_OUT>(val_a);
-            CTYPE_OUT b_casted = static_cast<CTYPE_OUT>(val_b);
-            return val_c ? a_casted : b_casted;
-          },
+      apply_ternary_elementwise_fn<CTYPE_OUT>(
+          [](const CTYPE_OUT val_a,
+             const CTYPE_OUT val_b,
+             const CTYPE_OUT val_c) { return val_c ? val_a : val_b; },
           a,
           b,
           cond,
-          out);
+          out,
+          [](const void* aPtr) {
+            return static_cast<CTYPE_OUT>(
+                *reinterpret_cast<const CTYPE_A*>(aPtr));
+          },
+          [](const void* bPtr) {
+            return static_cast<CTYPE_OUT>(
+                *reinterpret_cast<const CTYPE_B*>(bPtr));
+          },
+          [](const void* cPtr) {
+            return static_cast<CTYPE_OUT>(
+                *reinterpret_cast<const uint8_t*>(cPtr));
+          });
     });
   });
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5784
* __->__ #5783

This diff is a simple refactor that shouldn't materially
change the generated code -- we still create a "kernel" for each
combination of input1/input2/input3/output dtypes. The following diff
will use this to improve op_clamp (but not op_where, because one of
the input types is fixed, so it's not as bad a build time outlier)
build time.

Differential Revision: [D63681033](https://our.internmc.facebook.com/intern/diff/D63681033/)