### PR TITLE
Split up split test to collect artifacts correctly

### DIFF
--- a/backends/arm/test/ops/test_split.py
+++ b/backends/arm/test/ops/test_split.py
@@ -124,8 +124,11 @@ class TestSimpleSplit(unittest.TestCase):
         self._test_split_tosa_MI_pipeline(self.SplitWithSizes(), test_data)
 
     @parameterized.expand(Split.test_data)
-    def test_split_n_out_tosa_MI(self, test_data: test_data_t):
+    def test_split_one_out_tosa_MI(self, test_data: test_data_t):
         self._test_split_tosa_MI_pipeline(self.SplitSingleOut(), test_data)
+
+    @parameterized.expand(Split.test_data)
+    def test_split_two_out_tosa_MI(self, test_data: test_data_t):
         self._test_split_tosa_MI_pipeline(self.SplitTwoOut(), test_data)
 
     @parameterized.expand(Split.test_data)


### PR DESCRIPTION
Running two sets of test with the same name produces artefacts within the same directory,
which causes problems when collating the tests to folders.

Change-Id: I5da1b20ead1419c7593247aeb23ea560f33a575b