### PR TITLE
Add support for Arm tests on MacOS

### DIFF
--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -57,11 +58,17 @@ def pytest_collection_modifyitems(config, items):
 
 
 def load_libquantized_ops_aot_lib():
+    so_ext = {
+        "Darwin": "dylib",
+        "Linux": "so",
+        "Windows": "dll",
+    }.get(platform.system(), None)
+
     find_lib_cmd = [
         "find",
         "cmake-out-aot-lib",
         "-name",
-        "libquantized_ops_aot_lib.so",
+        f"libquantized_ops_aot_lib.{so_ext}",
     ]
     res = subprocess.run(find_lib_cmd, capture_output=True)
     if res.returncode == 0:

--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -92,8 +92,9 @@ function generate_pte_file() {
     pte_file=$(realpath ${output_folder}/${model_filename})
     rm -f "${pte_file}"
 
+    SO_EXT=$(python3 -c 'import platform; print({"Darwin": "dylib", "Linux": "so", "Windows": "dll"}.get(platform.system(), None))')
     # We are using the aot_lib from build_quantization_aot_lib below
-    SO_LIB=$(find cmake-out-aot-lib -name libquantized_ops_aot_lib.so)
+    SO_LIB=$(find cmake-out-aot-lib -name libquantized_ops_aot_lib.${SO_EXT})
 
     python3 -m examples.arm.aot_arm_compiler --model_name="${model}" --target=${target} ${model_compiler_flags} --output ${output_folder} --so_library="$SO_LIB" 1>&2
     [[ -f ${pte_file} ]] || { >&2 echo "Failed to generate a pte file - ${pte_file}"; exit 1; }

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -101,6 +101,8 @@ root_dir=$(realpath ${root_dir})
 function setup_fvp() {
     if [[ "${OS}" != "Linux" ]]; then
         echo "[${FUNCNAME[0]}] Warning: FVP only supported with Linux OS, skipping FVP setup..."
+        echo "[${FUNCNAME[0]}] Warning: For MacOS, using https://github.com/Arm-Examples/FVPs-on-Mac is recommended."
+        echo "[${FUNCNAME[0]}] Warning:   Follow the instructions and make sure the path is set correctly." 
         return 1
     fi
 


### PR DESCRIPTION
Check which platform is used for the extension of the quantization lib and select extensions for dynamic libraries accordingly.

Change-Id: I7e4afcccf7f7d8de7416a83e9bfe4511a6540912