### PR TITLE
add microkernels-prod to backend_xnnpack in build_apple_frameworks

### DIFF
--- a/build/build_apple_frameworks.sh
+++ b/build/build_apple_frameworks.sh
@@ -49,6 +49,7 @@ libXNNPACK.a,\
 libcpuinfo.a,\
 libpthreadpool.a,\
 libxnnpack_backend.a,\
+libmicrokernels-prod.a,\
 :"
 
 FRAMEWORK_KERNELS_CUSTOM="kernels_custom:\


### PR DESCRIPTION
Recently, previous xnnpack update includes a cmake refactor in which microkernels-prod is separated out as a static library. When we install the xnnpack_backend, we must remember to install microkernels-prod and xnnpack to make sure that it is correctly linkd with xnnpack_backend