### PR TITLE
Arm backend: Mark test_block_bottleneck_residual_tosa_BI unit test flaky

### DIFF
--- a/backends/arm/test/ops/test_conv_combos.py
+++ b/backends/arm/test/ops/test_conv_combos.py
@@ -9,6 +9,8 @@ import unittest
 
 from typing import Tuple
 
+import pytest
+
 import torch
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.arm_tester import ArmTester
@@ -311,6 +313,8 @@ class TestConvCombos(unittest.TestCase):
         model = ComboBlockBottleneckResidual()
         self._test_conv_combo_tosa_MI_pipeline(model, model.get_inputs())
 
+    # TODO: Investigate flakyness (MLTORCH-307)
+    @pytest.mark.flaky(reruns=3)
     def test_block_bottleneck_residual_tosa_BI(self):
         model = ComboBlockBottleneckResidual()
         self._test_conv_combo_tosa_BI_pipeline(model, model.get_inputs())


### PR DESCRIPTION
This makes the test rerun and getting green CI for now later we need to investigate if the accuracy is a problem or OK.

The tests fail rate is about 1-2% and the reported error is low 
Difference: max: 0.06028306484222412, abs: 0.06028306484222412, mean abs error: 9.008637425722554e-05.
