### PR TITLE
[ExecuTorch] Disable animation in hot path of iOS example again

### DIFF
--- a/examples/demo-apps/apple_ios/LLaMA/LLaMA/Application/ContentView.swift
+++ b/examples/demo-apps/apple_ios/LLaMA/LLaMA/Application/ContentView.swift
@@ -402,13 +402,11 @@ struct ContentView: View {
                   let count = tokens.count
                   tokens = []
                   DispatchQueue.main.async {
-                    withAnimation {
-                      var message = messages.removeLast()
-                      message.text += text
-                      message.tokenCount += count
-                      message.dateUpdated = Date()
-                      messages.append(message)
-                    }
+                    var message = messages.removeLast()
+                    message.text += text
+                    message.tokenCount += count
+                    message.dateUpdated = Date()
+                    messages.append(message)
                   }
                 }
                 if shouldStopGenerating {
@@ -435,13 +433,11 @@ struct ContentView: View {
                   let count = tokens.count
                   tokens = []
                   DispatchQueue.main.async {
-                    withAnimation {
-                      var message = messages.removeLast()
-                      message.text += text
-                      message.tokenCount += count
-                      message.dateUpdated = Date()
-                      messages.append(message)
-                    }
+                    var message = messages.removeLast()
+                    message.text += text
+                    message.tokenCount += count
+                    message.dateUpdated = Date()
+                    messages.append(message)
                   }
                 }
                 if shouldStopGenerating {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5821

D62675017 put the animations back after D62308551 removed them, presumably due to a bad rebase.

Differential Revision: [D63774734](https://our.internmc.facebook.com/intern/diff/D63774734/)