### PR TITLE
Don't automatically backup settings in Android demo apps

### DIFF
--- a/examples/demo-apps/android/ExecuTorchDemo/app/src/main/AndroidManifest.xml
+++ b/examples/demo-apps/android/ExecuTorchDemo/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/examples/demo-apps/android/LlamaDemo/app/src/main/AndroidManifest.xml
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
 
     <application
         android:name=".ETLogging"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:extractNativeLibs="true"
         android:fullBackupContent="@xml/backup_rules"


### PR DESCRIPTION
When re-installing the android demo apps, the OS caches and re-populates values in the settings pane. 

I think this might cause some confusion for people trying out the demos but who aren't experienced native app devs (like me 🙂). 

specifically for me, the settings caching made me think that old files that i had pushed, removed, and then replaced with other files were still on the device somehow. eg, i replaced a `tokenizer.bin` with a `tokenizer.model`, and the settings still said `tokenizer.bin`... this made me think maybe the old tokenizer was still floating around in app storage or something.

to change the behavior is 1 loc for each demo app. in `examples/demo-apps/android/*Demo/app/src/main/AndroidManifest.xml`, 

```
-        android:allowBackup="true"
+        android:allowBackup="false"
```

i made a PR for personal glory but no worries if you want to do something else.