### PR TITLE
Use new threadpool namespace for all of //executorch/...

### DIFF
--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -1783,14 +1783,14 @@ ET_NODISCARD Error XNNCompiler::compileModel(
       subgraph.get(),
       /*weight_cache=*/nullptr, // TODO - support weight cache
       workspace,
-      torch::executorch::threadpool::get_pthreadpool(),
+      ::executorch::extension::threadpool::get_pthreadpool(),
       runtime_flags,
       &runtime_ptr);
 #else
   status = xnn_create_runtime_v3(
       subgraph.get(),
       /*weight_cache=*/nullptr, // TODO - support weight cache
-      torch::executorch::threadpool::get_pthreadpool(),
+      ::executorch::extension::threadpool::get_pthreadpool(),
       runtime_flags,
       &runtime_ptr);
 #endif

--- a/examples/models/llama2/main.cpp
+++ b/examples/models/llama2/main.cpp
@@ -63,13 +63,13 @@ int32_t main(int32_t argc, char** argv) {
 
 #if defined(ET_USE_THREADPOOL)
   uint32_t num_performant_cores = cpu_threads == -1
-      ? torch::executorch::cpuinfo::get_num_performant_cores()
+      ? ::executorch::extension::cpuinfo::get_num_performant_cores()
       : static_cast<uint32_t>(cpu_threads);
   ET_LOG(
       Info, "Resetting threadpool with num threads = %d", num_performant_cores);
   if (num_performant_cores > 0) {
-    torch::executorch::threadpool::get_threadpool()->_unsafe_reset_threadpool(
-        num_performant_cores);
+    ::executorch::extension::threadpool::get_threadpool()
+        ->_unsafe_reset_threadpool(num_performant_cores);
   }
 #endif
   // create llama runner

--- a/examples/models/llava/main.cpp
+++ b/examples/models/llava/main.cpp
@@ -72,13 +72,13 @@ int32_t main(int32_t argc, char** argv) {
 
 #if defined(ET_USE_THREADPOOL)
   uint32_t num_performant_cores = cpu_threads == -1
-      ? torch::executorch::cpuinfo::get_num_performant_cores()
+      ? ::executorch::extension::cpuinfo::get_num_performant_cores()
       : static_cast<uint32_t>(cpu_threads);
   ET_LOG(
       Info, "Resetting threadpool with num threads = %d", num_performant_cores);
   if (num_performant_cores > 0) {
-    torch::executorch::threadpool::get_threadpool()->_unsafe_reset_threadpool(
-        num_performant_cores);
+    ::executorch::extension::threadpool::get_threadpool()
+        ->_unsafe_reset_threadpool(num_performant_cores);
   }
 #endif
   // create llama runner

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -95,11 +95,11 @@ class ExecuTorchLlamaJni
 #if defined(ET_USE_THREADPOOL)
     // Reserve 1 thread for the main thread.
     uint32_t num_performant_cores =
-        torch::executorch::cpuinfo::get_num_performant_cores() - 1;
+        ::executorch::extension::cpuinfo::get_num_performant_cores() - 1;
     if (num_performant_cores > 0) {
       ET_LOG(Info, "Resetting threadpool to %d threads", num_performant_cores);
-      torch::executorch::threadpool::get_threadpool()->_unsafe_reset_threadpool(
-          num_performant_cores);
+      ::executorch::extension::threadpool::get_threadpool()
+          ->_unsafe_reset_threadpool(num_performant_cores);
     }
 #endif
 

--- a/extension/llm/custom_ops/op_sdpa.cpp
+++ b/extension/llm/custom_ops/op_sdpa.cpp
@@ -367,7 +367,7 @@ void cpu_flash_attention(
   int64_t qSlice = (qSize - 1) / qSplitSize + 1;
 #ifdef ET_USE_THREADPOOL
   int64_t num_thread =
-      torch::executorch::threadpool::get_threadpool()->get_thread_count();
+      ::executorch::extension::threadpool::get_threadpool()->get_thread_count();
 #else
   int64_t num_thread = 1;
 #endif

--- a/extension/parallel/thread_parallel.cpp
+++ b/extension/parallel/thread_parallel.cpp
@@ -20,7 +20,7 @@ namespace {
 thread_local int64_t thread_num_ = 0;
 }
 
-using namespace torch::executorch::threadpool;
+using namespace ::executorch::extension::threadpool;
 
 inline int64_t divup(int64_t x, int64_t y) {
   return (x + y - 1) / y;

--- a/extension/threadpool/cpuinfo_utils.cpp
+++ b/extension/threadpool/cpuinfo_utils.cpp
@@ -6,17 +6,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <executorch/runtime/platform/assert.h>
+#include <executorch/extension/threadpool/cpuinfo_utils.h>
+
 #include <fstream>
 #include <mutex>
 #include <string>
 #include <vector>
 
-#include "cpuinfo_utils.h"
+#include <executorch/runtime/platform/assert.h>
 
-namespace torch {
-namespace executorch {
-namespace cpuinfo {
+namespace executorch::extension::cpuinfo {
 
 // Ignore revisions (last digit (4 LSBs))
 #define CPUINFO_ARM_MIDR_CORTEX_A520 UINT32_C(0x410FD800)
@@ -171,6 +170,4 @@ uint32_t get_num_performant_cores() {
   }
 }
 
-} // namespace cpuinfo
-} // namespace executorch
-} // namespace torch
+} // namespace executorch::extension::cpuinfo

--- a/extension/threadpool/cpuinfo_utils.h
+++ b/extension/threadpool/cpuinfo_utils.h
@@ -10,12 +10,15 @@
 
 #include <cpuinfo.h>
 
-namespace torch {
-namespace executorch {
-namespace cpuinfo {
+namespace executorch::extension::cpuinfo {
 
 uint32_t get_num_performant_cores();
 
-} // namespace cpuinfo
-} // namespace executorch
-} // namespace torch
+} // namespace executorch::extension::cpuinfo
+
+namespace torch::executorch::cpuinfo { // DEPRECATED
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces. Note that threadpool incorrectly used
+// the namespace `torch::executorch` instead of `torch::executor`.
+using ::executorch::extension::cpuinfo::get_num_performant_cores; // DEPRECATED
+} // namespace torch::executorch::cpuinfo

--- a/extension/threadpool/threadpool.cpp
+++ b/extension/threadpool/threadpool.cpp
@@ -7,18 +7,17 @@
  */
 
 #include <executorch/extension/threadpool/threadpool.h>
-#include <executorch/extension/threadpool/threadpool_guard.h>
-#include <executorch/runtime/platform/assert.h>
+
 #include <algorithm>
-
-#include <cpuinfo.h>
-
 #include <atomic>
 #include <memory>
 
-namespace torch {
-namespace executorch {
-namespace threadpool {
+#include <executorch/extension/threadpool/threadpool_guard.h>
+#include <executorch/runtime/platform/assert.h>
+
+#include <cpuinfo.h>
+
+namespace executorch::extension::threadpool {
 
 #if !(defined(WIN32))
 namespace {
@@ -139,6 +138,4 @@ pthreadpool_t get_pthreadpool() {
   return threadpool->threadpool_.get();
 }
 
-} // namespace threadpool
-} // namespace executorch
-} // namespace torch
+} // namespace executorch::extension::threadpool

--- a/extension/threadpool/threadpool.h
+++ b/extension/threadpool/threadpool.h
@@ -1,17 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
 
 #include <pthreadpool.h>
 
-// @nolint PATTERNLINT Ok to use stdlib for this optional library
-#include <functional>
-// @nolint PATTERNLINT Ok to use stdlib for this optional library
-#include <memory>
-// @nolint PATTERNLINT Ok to use stdlib for this optional library
-#include <mutex>
-
-namespace torch {
-namespace executorch {
-namespace threadpool {
+namespace executorch::extension::threadpool {
 
 class ThreadPool final {
  public:
@@ -26,55 +29,64 @@ class ThreadPool final {
   ThreadPool& operator=(const ThreadPool&) = delete;
 
   // Make threadpool non-movable.
-  // For now this is non-movable, but if we want to have clients
-  // such as say torch::executorch::Executor, to be able to own
-  // threadpool, then we will have to make this movable.
   ThreadPool(ThreadPool&&) = delete;
   ThreadPool& operator=(ThreadPool&&) = delete;
 
   size_t get_thread_count() const;
 
-  /*
-   * Resets the threadpool by creating a new threadpool with requested # of
-   * threads. This is not a thread safe call. When calling this method, threads
-   * of the threadpool might be doing some work. Some other code may also be
-   * holding on to the threadpool pointer, that is no longer valid. This is a
-   * private API, which will later be replaced by something that allows creating
-   * of threadpool with requested size and use such a threadpool with backend
-   * delegates, custom ops or optimized lib.
+  /**
+   * INTERNAL: Resets the threadpool by creating a new threadpool with requested
+   * # of threads. This is not a thread safe call. When calling this method,
+   * threads of the threadpool might be doing some work. Some other code may
+   * also be holding on to the threadpool pointer, that is no longer valid. This
+   * is a private API, which will later be replaced by something that allows
+   * creating of threadpool with requested size and use such a threadpool with
+   * backend delegates, custom ops or optimized lib.
    */
+  [[deprecated("This API is experimental and may change without notice.")]]
   bool _unsafe_reset_threadpool(uint32_t num_threads);
 
-  // Run, in parallel, function fn(task_id) over task_id in range [0, range).
-  // This function is blocking.  All input is processed by the time it returns.
-  // NoThreadPoolGuard (see threadpool_guard.h) can used to disable
-  // use of multiple threads with the scope of the guard
-  // When NoThreadPoolGuard is not used all calls to run method are serialized.
+  /**
+   * Run, in parallel, function fn(task_id) over task_id in range [0, range).
+   * This function is blocking.  All input is processed by the time it returns.
+   * NoThreadPoolGuard (see threadpool_guard.h) can used to disable use of
+   * multiple threads with the scope of the guard When NoThreadPoolGuard is not
+   * used all calls to run method are serialized.
+   */
   void run(const std::function<void(size_t)>& fn, size_t range);
 
  private:
   friend pthreadpool_t get_pthreadpool();
 
  private:
-  // This mutex is used inside get_thread_count API but it is not
-  // really needed. Since data members of ThreadPool objects are not
-  // really mutable.
-  // Figure out if we will allow set_num_threads API, in which mutex
-  // will be useful. Otherwise remove it.
-  // TODO(kimishpatel)
+  // This mutex is used inside get_thread_count API but it is not really needed
+  // since data members of ThreadPool objects are not really mutable.
+  // TODO(kimishpatel): Figure out if we will allow set_num_threads API, in
+  // which case this mutex will be useful. Otherwise remove it.
   mutable std::mutex mutex_;
   std::unique_ptr<pthreadpool, decltype(&pthreadpool_destroy)> threadpool_;
 };
 
-// Return a singleton instance of ThreadPool for ATen/TH multithreading.
+/**
+ * Returns the singleton instance of ThreadPool for ATen/TH multithreading.
+ */
 ThreadPool* get_threadpool();
 
-// Exposes the underlying implementation of ThreadPool.
-// Only for use in external libraries so as to unify threading across
-// internal (i.e. ATen, etc.) and external (e.g. NNPACK, QNNPACK, XNNPACK)
-// use cases.
+/**
+ * Returns the underlying pthreadpool instance used by the implementation of
+ * ThreadPool returned by `get_threadpool()`. Only for use in external libraries
+ * so as to unify threading across internal (i.e. ATen, etc.) and external (e.g.
+ * NNPACK, QNNPACK, XNNPACK) use cases.
+ */
 pthreadpool_t get_pthreadpool();
 
-} // namespace threadpool
-} // namespace executorch
-} // namespace torch
+} // namespace executorch::extension::threadpool
+
+namespace torch::executorch::threadpool { // DEPRECATED
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces. Note that threadpool incorrectly used
+// the namespace `torch::executorch` instead of `torch::executor`.
+using ::executorch::extension::threadpool::get_pthreadpool; // DEPRECATED
+using ::executorch::extension::threadpool::get_threadpool; // DEPRECATED
+using ::executorch::extension::threadpool::ThreadPool; // DEPRECATED
+} // namespace torch::executorch::threadpool

--- a/extension/threadpool/threadpool_guard.cpp
+++ b/extension/threadpool/threadpool_guard.cpp
@@ -8,9 +8,7 @@
 
 #include <executorch/extension/threadpool/threadpool_guard.h>
 
-namespace torch {
-namespace executorch {
-namespace threadpool {
+namespace executorch::extension::threadpool {
 
 thread_local bool NoThreadPoolGuard_enabled = false;
 
@@ -22,6 +20,4 @@ void NoThreadPoolGuard::set_enabled(bool enabled) {
   NoThreadPoolGuard_enabled = enabled;
 }
 
-} // namespace threadpool
-} // namespace executorch
-} // namespace torch
+} // namespace executorch::extension::threadpool

--- a/extension/threadpool/threadpool_guard.h
+++ b/extension/threadpool/threadpool_guard.h
@@ -8,9 +8,7 @@
 
 #pragma once
 
-namespace torch {
-namespace executorch {
-namespace threadpool {
+namespace executorch::extension::threadpool {
 
 // A RAII, thread local (!) guard that enables or disables guard upon
 // construction, and sets it back to the original value upon destruction.
@@ -29,6 +27,11 @@ struct NoThreadPoolGuard {
   const bool prev_mode_;
 };
 
-} // namespace threadpool
-} // namespace executorch
-} // namespace torch
+} // namespace executorch::extension::threadpool
+
+namespace torch::executorch::threadpool { // DEPRECATED
+// TODO(T197294990): Remove these deprecated aliases once all users have moved
+// to the new `::executorch` namespaces. Note that threadpool incorrectly used
+// the namespace `torch::executorch` instead of `torch::executor`.
+using ::executorch::extension::threadpool::NoThreadPoolGuard; // DEPRECATED
+} // namespace torch::executorch::threadpool


### PR DESCRIPTION
Summary: Migrate all `//executorch/...` code to use the new threadpool namespace.

Differential Revision: D63783748


