### PR TITLE
[ET-VK] Fix tensor views with tensors that use deferred memory allocation

### DIFF
--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -300,6 +300,11 @@ ValueRef ComputeGraph::add_tensor_view(const ValueRef vref) {
   const vTensorPtr t = get_tensor(vref);
   ValueRef idx(static_cast<int>(values_.size()));
   values_.emplace_back(api::vTensor(*t));
+  for (SharedObject& sobj : shared_objects_) {
+    if (sobj.has_user(vref)) {
+      sobj.add_user(this, idx);
+    }
+  }
   return idx;
 }
 
@@ -311,6 +316,11 @@ ValueRef ComputeGraph::add_tensor_view(
   const vTensorPtr t = get_tensor(vref);
   ValueRef idx(static_cast<int>(values_.size()));
   values_.emplace_back(api::vTensor(*t, sizes, strides, offset_numel));
+  for (SharedObject& sobj : shared_objects_) {
+    if (sobj.has_user(vref)) {
+      sobj.add_user(this, idx);
+    }
+  }
   return idx;
 }
 

--- a/backends/vulkan/runtime/graph/containers/SharedObject.cpp
+++ b/backends/vulkan/runtime/graph/containers/SharedObject.cpp
@@ -12,6 +12,10 @@
 
 namespace vkcompute {
 
+bool SharedObject::has_user(const ValueRef idx) const {
+  return std::find(users.begin(), users.end(), idx) != users.end();
+}
+
 void SharedObject::add_user(ComputeGraph* const graph, const ValueRef idx) {
   vTensorPtr t = graph->get_tensor(idx);
 

--- a/backends/vulkan/runtime/graph/containers/SharedObject.h
+++ b/backends/vulkan/runtime/graph/containers/SharedObject.h
@@ -31,6 +31,7 @@ struct SharedObject {
   std::vector<ValueRef> users;
   vkapi::Allocation allocation;
 
+  bool has_user(const ValueRef idx) const;
   void add_user(ComputeGraph* const graph, const ValueRef idx);
   void allocate(ComputeGraph* const graph);
   void bind_users(ComputeGraph* const graph);

--- a/backends/vulkan/runtime/vk_api/memory/Buffer.h
+++ b/backends/vulkan/runtime/vk_api/memory/Buffer.h
@@ -161,7 +161,9 @@ class VulkanBuffer final {
 
   inline void bind_allocation(const Allocation& memory) {
     VK_CHECK_COND(!memory_, "Cannot bind an already bound allocation!");
-    VK_CHECK(vmaBindBufferMemory(allocator_, memory.allocation, handle_));
+    if (!is_copy_) {
+      VK_CHECK(vmaBindBufferMemory(allocator_, memory.allocation, handle_));
+    }
     memory_.allocation = memory.allocation;
   }
 

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -3146,12 +3146,12 @@ void test_transpose_view_mm(
     mat2_t_small_size = {B, N - 1, K - 3};
   }
 
-  // Build graph
+  // Build graph; use shared objects to test views of shared objects
 
   IOValueRef mat1 =
-      graph.add_input_tensor(mat1_size, vkapi::kFloat, utils::kWidthPacked);
-  IOValueRef mat2_transpose =
-      graph.add_input_tensor(mat2_t_size, vkapi::kFloat, utils::kWidthPacked);
+      graph.add_input_tensor(mat1_size, vkapi::kFloat, utils::kWidthPacked, 0);
+  IOValueRef mat2_transpose = graph.add_input_tensor(
+      mat2_t_size, vkapi::kFloat, utils::kWidthPacked, 1);
 
   ValueRef mat2 = graph.add_tensor_view(mat2_transpose.value);
 
@@ -3167,7 +3167,7 @@ void test_transpose_view_mm(
   }
 
   IOValueRef out;
-  out.value = graph.add_tensor(out_size, vkapi::kFloat, utils::kWidthPacked);
+  out.value = graph.add_tensor(out_size, vkapi::kFloat, utils::kWidthPacked, 2);
 
   VK_GET_OP_FN("aten.transpose.int")
   (graph, {mat2_transpose.value, dim0, dim1, mat2});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5799
* __->__ #5831
* #5830

## Context

Fix one (hopefully) final kink with tensor views.

### The issue

When creating a tensor view of a tensor that uses deferred memory allocation, at the time the view is created, it will copy the handle of the original tensor's `VkImage`. However, since the `VkImage` is not yet bounded to memory, it will have have a `VkImageView` associated with it, and the tensor view will copy the `VkImageView` handle and `VK_NULL_HANDLE`.

Later, the original tensor is expected to be bound to an allocation, at which point it will create an image view and bind the `VkImage` to memory. However, this does not update its views, which will still have a null `VkImageView`.

If the tensor view is also bound to the allocation, then the same `VkImage` will be bound to the same memory multiple times which is against the Vulkan spec.

### The fix

Allow binding of `VulkanImage` and `VulkanBuffer` copies to only call the binding function if it is not  a copy; assume that the original tensor is responsible for binding to memory.

In `ComputeGraph`, when adding a tensor view, add the created `Value` as a user of any `SharedObject` of which the original tensor is also a user.

Differential Revision: [D63790718](https://our.internmc.facebook.com/intern/diff/D63790718/)