### PR TITLE
MIgrate some random files away from the torch:: namespace

### DIFF
--- a/exir/backend/test/demos/rpc/ExecutorBackend.h
+++ b/exir/backend/test/demos/rpc/ExecutorBackend.h
@@ -10,10 +10,8 @@
 
 #include <executorch/runtime/core/error.h>
 
-namespace torch {
-namespace executor {
+namespace example {
 
-Error registerExecutorBackend();
+::executorch::runtime::Error register_executor_backend();
 
-} // namespace executor
-} // namespace torch
+} // namespace example

--- a/exir/backend/test/demos/rpc/ExecutorBackendRegister.cpp
+++ b/exir/backend/test/demos/rpc/ExecutorBackendRegister.cpp
@@ -10,10 +10,9 @@
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
 
-namespace torch {
-namespace executor {
+namespace example {
 namespace {
-static Error register_success = registerExecutorBackend();
+static ::executorch::runtime::Error register_success =
+    register_executor_backend();
 } // namespace
-} // namespace executor
-} // namespace torch
+} // namespace example

--- a/runtime/core/test/evalue_test.cpp
+++ b/runtime/core/test/evalue_test.cpp
@@ -16,9 +16,6 @@
 
 using namespace ::testing;
 
-namespace torch {
-namespace executor {
-
 using exec_aten::ScalarType;
 using executorch::runtime::BoxedEvalueList;
 using executorch::runtime::EValue;
@@ -30,7 +27,7 @@ class EValueTest : public ::testing::Test {
   void SetUp() override {
     // Since these tests cause ET_LOG to be called, the PAL must be initialized
     // first.
-    runtime_init();
+    executorch::runtime::runtime_init();
   }
 };
 
@@ -276,6 +273,3 @@ TEST_F(EValueTest, ConstructFromNullPtrAborts) {
 
   ET_EXPECT_DEATH({ EValue evalue(null_ptr); }, "");
 }
-
-} // namespace executor
-} // namespace torch

--- a/test/utils/alignment.h
+++ b/test/utils/alignment.h
@@ -12,8 +12,8 @@
 
 #include <gmock/gmock.h> // For MATCHER_P
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace runtime {
 namespace testing {
 
 /**
@@ -28,7 +28,7 @@ inline bool is_aligned(const void* ptr, size_t alignment) {
  * Lets gtest users write `EXPECT_THAT(ptr, IsAlignedTo(alignment))` or
  * `EXPECT_THAT(ptr, Not(IsAlignedTo(alignment)))`.
  *
- * See also `EXPECT_POINTER_IS_ALIGNED_TO()`.
+ * See also `EXPECT_ALIGNED()`.
  */
 MATCHER_P(IsAlignedTo, other, "") {
   return is_aligned(arg, other);
@@ -39,10 +39,10 @@ MATCHER_P(IsAlignedTo, other, "") {
  */
 
 #define EXPECT_ALIGNED(ptr, alignment) \
-  EXPECT_THAT((ptr), torch::executor::testing::IsAlignedTo((alignment)))
+  EXPECT_THAT((ptr), executorch::runtime::testing::IsAlignedTo((alignment)))
 #define ASSERT_ALIGNED(ptr, alignment) \
-  ASSERT_THAT((ptr), torch::executor::testing::IsAlignedTo((alignment)))
+  ASSERT_THAT((ptr), executorch::runtime::testing::IsAlignedTo((alignment)))
 
 } // namespace testing
-} // namespace executor
-} // namespace torch
+} // namespace runtime
+} // namespace executorch


### PR DESCRIPTION
Summary:
A couple tests and helpers that my previous passes didn't catch.

After this, the only remaining `//executorch/...` code under the `torch::` namespace is under `backends/...` and `kernels/...` (and in some other places that define kernels).

Differential Revision: D63797660


