### PR TITLE
ArmQuantizer: Quantize AvgPool2d

### DIFF
--- a/backends/arm/quantizer/arm_quantizer_utils.py
+++ b/backends/arm/quantizer/arm_quantizer_utils.py
@@ -152,6 +152,7 @@ def is_share_obs_or_fq_op(op: Callable) -> bool:
         torch.ops.aten.unsqueeze.default,
         # TODO: remove?
         torch.ops.aten.adaptive_avg_pool2d.default,
+        torch.ops.aten.avg_pool2d.default,
         torch.ops.aten.view_copy.default,
         torch.ops.aten.view.default,
         torch.ops.aten.slice.Tensor,

--- a/backends/arm/test/ops/test_conv_combos.py
+++ b/backends/arm/test/ops/test_conv_combos.py
@@ -156,6 +156,32 @@ class ComboConvRelu6(torch.nn.Module):
         return x
 
 
+class ComboConvAvgPool2d(torch.nn.Module):
+    edge_op_list = [
+        "executorch_exir_dialects_edge__ops_aten_convolution_default",
+        "executorch_exir_dialects_edge__ops_aten_avg_pool2d_default",
+    ]
+
+    test_data = [
+        (20 * torch.randn(1, 3, 64, 32),),
+        (torch.randn(1, 3, 100, 200),),
+        (5 * torch.randn(1, 3, 256, 256),),
+        (torch.rand(1, 3, 512, 128),),
+    ]
+
+    def __init__(self):
+        super().__init__()
+        self.conv2d = torch.nn.Conv2d(
+            in_channels=3, out_channels=3, kernel_size=3, stride=1, groups=1
+        )
+        self.avg_pool2d = torch.nn.AvgPool2d(kernel_size=(2, 2))
+
+    def forward(self, x):
+        x = self.conv2d(x)
+        x = self.avg_pool2d(x)
+        return x
+
+
 class TestConvCombos(unittest.TestCase):
     """Tests conv combined with other ops."""
 
@@ -333,4 +359,39 @@ class TestConvCombos(unittest.TestCase):
             model,
             common.get_u85_compile_spec(permute_memory_to_nhwc=True),
             model.get_inputs(),
+        )
+
+    ######################
+    ## Conv + AvgPool2d ##
+    ######################
+    @parameterized.expand(ComboConvAvgPool2d.test_data)
+    def test_conv_avgpool2d_tosa_MI(self, test_data: torch.Tensor):
+        model = ComboConvAvgPool2d()
+        test_data = (test_data,)
+        self._test_conv_combo_tosa_MI_pipeline(model, test_data)
+
+    @parameterized.expand(ComboConvAvgPool2d.test_data)
+    def test_conv_avgpool2d_tosa_BI(self, test_data: torch.Tensor):
+        model = ComboConvAvgPool2d()
+        test_data = (test_data,)
+        self._test_conv_combo_tosa_BI_pipeline(model, test_data)
+
+    @parameterized.expand(ComboConvAvgPool2d.test_data)
+    def test_conv_avgpool2d_u55_BI(self, test_data: torch.Tensor):
+        model = ComboConvAvgPool2d()
+        test_data = (test_data,)
+        self._test_conv_combo_ethos_BI_pipeline(
+            model,
+            common.get_u55_compile_spec(),
+            test_data,
+        )
+
+    @parameterized.expand(ComboConvAvgPool2d.test_data)
+    def test_conv_avgpool2d_u85_BI(self, test_data: torch.Tensor):
+        model = ComboConvAvgPool2d()
+        test_data = (test_data,)
+        self._test_conv_combo_ethos_BI_pipeline(
+            model,
+            common.get_u85_compile_spec(),
+            test_data,
         )


### PR DESCRIPTION
- AvgPool2d is quantized by propagating the parent nodes output quantization spec using a shared quantization spec.
- Adds Conv2D + AvgPool2d unittest.
- Enables AvgPool2d BI unittests.