### PR TITLE
Migrate backends/apple to the new namespace

### DIFF
--- a/backends/apple/mps/runtime/MPSBackend.mm
+++ b/backends/apple/mps/runtime/MPSBackend.mm
@@ -16,8 +16,20 @@
 #include <string>
 #include <iostream>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
+
+using executorch::aten::Tensor;
+using executorch::runtime::ArrayRef;
+using executorch::runtime::Backend;
+using executorch::runtime::BackendExecutionContext;
+using executorch::runtime::BackendInitContext;
+using executorch::runtime::CompileSpec;
+using executorch::runtime::DelegateHandle;
+using executorch::runtime::EValue;
+using executorch::runtime::Error;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::Result;
 
 class MPSBackend final : public ::executorch::runtime::BackendInterface {
  public:
@@ -81,7 +93,7 @@ class MPSBackend final : public ::executorch::runtime::BackendInterface {
           output_pointers.push_back(&args[i]->toTensor());
         }
       } else if (args[i]->isTensorList()) {
-        const exec_aten::ArrayRef<exec_aten::Tensor>& tensorList = args[i]->toTensorList();
+        const executorch::aten::ArrayRef<executorch::aten::Tensor>& tensorList = args[i]->toTensorList();
         for (auto& tensor_ : tensorList) {
           if (input_pointers.size() < executor->getNumInputs()) {
             input_pointers.push_back(&tensor_);
@@ -122,5 +134,5 @@ Backend backend{"MPSBackend", &cls};
 static auto success_with_compiler = register_backend(backend);
 } // namespace
 
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/MPSCompiler.h
+++ b/backends/apple/mps/runtime/MPSCompiler.h
@@ -14,8 +14,8 @@
 #include <memory>
 #include <vector>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -24,15 +24,16 @@ class MPSCompiler {
   // Takes Flatbuffer Serialized MPS Model and rebuilds the MPSGraphExecutable
   // returns an executor object that holds the MPS runtime object which we
   // can then use to set inputs and run inference using the MPSGraphExecutable.
-  ET_NODISCARD static Error compileModel(
+  ET_NODISCARD static executorch::runtime::Error compileModel(
       const void* buffer_pointer,
       size_t num_bytes,
       MPSExecutor* executor,
-      MemoryAllocator* runtime_allocator,
-      ArrayRef<CompileSpec> compile_specs);
+      executorch::runtime::MemoryAllocator* runtime_allocator,
+      executorch::runtime::ArrayRef<executorch::runtime::CompileSpec>
+          compile_specs);
 };
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/MPSCompiler.mm
+++ b/backends/apple/mps/runtime/MPSCompiler.mm
@@ -23,10 +23,15 @@
 
 #define MPS_UNUSED(x) ( (void)(x) )
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
+
+using executorch::runtime::ArrayRef;
+using executorch::runtime::CompileSpec;
+using executorch::runtime::Error;
+using executorch::runtime::MemoryAllocator;
 
 /*
 Builds the mps runtime object using the buffer pointer. The buffer pointer
@@ -66,5 +71,5 @@ ET_NODISCARD Error MPSCompiler::compileModel(
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/MPSDelegateHeader.h
+++ b/backends/apple/mps/runtime/MPSDelegateHeader.h
@@ -7,8 +7,8 @@
 
 #include <executorch/runtime/core/result.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -87,7 +87,9 @@ struct MPSDelegateHeader {
    *     error if size was too short, if the header was not found, or if the
    *     header appeared to be corrupt.
    */
-  static Result<MPSDelegateHeader> Parse(const void* data, size_t size);
+  static executorch::runtime::Result<MPSDelegateHeader> Parse(
+      const void* data,
+      size_t size);
 
   /**
    * The offset in bytes to the beginning of the constant data.
@@ -109,5 +111,5 @@ struct MPSDelegateHeader {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/MPSDelegateHeader.mm
+++ b/backends/apple/mps/runtime/MPSDelegateHeader.mm
@@ -10,10 +10,13 @@
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/result.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
+
+using executorch::runtime::Error;
+using executorch::runtime::Result;
 
 /// Interprets the 8 bytes at `data` as a little-endian uint64_t.
 uint64_t getUInt64LE(const uint8_t* data) {
@@ -49,5 +52,5 @@ Result<MPSDelegateHeader> MPSDelegateHeader::Parse(const void* data, size_t size
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/MPSDevice.h
+++ b/backends/apple/mps/runtime/MPSDevice.h
@@ -20,8 +20,8 @@
 
 #define MB(x) (x * 1048576UL)
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -72,8 +72,10 @@ class MPSDevice {
    * Compile a PSO for a given library type.
    * Once compiled, the library and PSOs are cached.
    */
-  Error compilePSO(LibraryType libraryType, const char* kernelName);
-  Error compileLibrary(LibraryType);
+  executorch::runtime::Error compilePSO(
+      LibraryType libraryType,
+      const char* kernelName);
+  executorch::runtime::Error compileLibrary(LibraryType);
 
  private:
   static MPSDevice* _device;
@@ -88,5 +90,5 @@ bool is_macos_13_or_newer(
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/MPSDevice.mm
+++ b/backends/apple/mps/runtime/MPSDevice.mm
@@ -8,10 +8,12 @@
 #include <memory>
 #include <mutex>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
+
+using executorch::runtime::Error;
 
 static std::unique_ptr<MPSDevice> mps_device;
 static std::once_flag mpsdev_init;
@@ -152,5 +154,5 @@ bool is_macos_13_or_newer(MacOSVersion version) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/MPSExecutor.h
+++ b/backends/apple/mps/runtime/MPSExecutor.h
@@ -16,8 +16,8 @@
 #include <memory>
 #include <vector>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -73,20 +73,20 @@ class MPSExecutor {
     return _executable;
   }
 
-  ET_NODISCARD Error forward(std::vector<const Tensor*>& outputs);
+  ET_NODISCARD executorch::runtime::Error forward(std::vector<const executorch::aten::Tensor*>& outputs);
 
-  ET_NODISCARD Error
-  set_inputs_outputs(std::vector<const Tensor*>& inputs, std::vector<const Tensor*>& outputs);
+  ET_NODISCARD executorch::runtime::Error
+  set_inputs_outputs(std::vector<const executorch::aten::Tensor*>& inputs, std::vector<const executorch::aten::Tensor*>& outputs);
 
-  Error initDataBuffers();
-  Error updateDataBuffers(std::vector<const Tensor*>& inputs, std::vector<const Tensor*>& outputs);
-  Error syncOutputBuffers(std::vector<const Tensor*>& outputs);
+  executorch::runtime::Error initDataBuffers();
+  executorch::runtime::Error updateDataBuffers(std::vector<const executorch::aten::Tensor*>& inputs, std::vector<const executorch::aten::Tensor*>& outputs);
+  executorch::runtime::Error syncOutputBuffers(std::vector<const executorch::aten::Tensor*>& outputs);
 
   friend class MPSCompiler;
 };
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch
 // clang-format on

--- a/backends/apple/mps/runtime/MPSExecutor.mm
+++ b/backends/apple/mps/runtime/MPSExecutor.mm
@@ -17,10 +17,13 @@
 @end
 
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
+
+using executorch::runtime::Error;
+using executorch::aten::Tensor;
 
 MPSExecutor::MPSExecutor() {
   _use_shared_mem = true;
@@ -239,5 +242,5 @@ MPSExecutor::syncOutputBuffers(
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/MPSGraphBuilder.h
+++ b/backends/apple/mps/runtime/MPSGraphBuilder.h
@@ -24,11 +24,12 @@
 #include <unordered_map>
 #include <vector>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
+using Error = executorch::runtime::Error;
 using DataType = mpsgraph::MPSDataType;
 using TensorPtr = const mpsgraph::MPSTensor *;
 using NodePtr = const mpsgraph::MPSNode *;
@@ -197,5 +198,5 @@ private:
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/MPSGraphBuilder.mm
+++ b/backends/apple/mps/runtime/MPSGraphBuilder.mm
@@ -7,10 +7,12 @@
 #include <executorch/backends/apple/mps/runtime/MPSDevice.h>
 #include <executorch/backends/apple/mps/runtime/MPSDelegateHeader.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
+
+using executorch::runtime::Result;
 
 MPSGraphBuilder::MPSGraphBuilder(
   const void* buffer_pointer,
@@ -186,5 +188,5 @@ MPSGraphBuilder::getMPSGraphExecutable() {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/MPSStream.h
+++ b/backends/apple/mps/runtime/MPSStream.h
@@ -17,8 +17,8 @@
 
 #include <unordered_map>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -63,7 +63,7 @@ class MPSStream {
   MPSCommandBuffer* commandBuffer();
   id<MTLComputeCommandEncoder> commandEncoder();
   void endKernelCoalescing();
-  ET_NODISCARD Error synchronize(SyncType syncType);
+  ET_NODISCARD executorch::runtime::Error synchronize(SyncType syncType);
   bool commitAndContinueEnabled();
   void copy(
       id<MTLBuffer> srcBuffer,
@@ -135,5 +135,5 @@ class MPSStreamImpl {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/MPSStream.mm
+++ b/backends/apple/mps/runtime/MPSStream.mm
@@ -11,10 +11,12 @@
 @property (readwrite, atomic) BOOL enableCommitAndContinue;
 @end
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
+
+using executorch::runtime::Error;
 
 //-----------------------------------------------------------------
 //  MPSStream
@@ -258,5 +260,5 @@ MPSStream* getDefaultMPSStream() {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/ActivationOps.mm
+++ b/backends/apple/mps/runtime/operations/ActivationOps.mm
@@ -6,8 +6,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -151,5 +151,5 @@ MPSGraphBuilder::mpsLogSoftmaxOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/BinaryOps.mm
+++ b/backends/apple/mps/runtime/operations/BinaryOps.mm
@@ -6,10 +6,12 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
+
+using executorch::aten::ScalarType;
 
 MPSGraphTensor*
 binaryOpTensor(
@@ -20,12 +22,12 @@ binaryOpTensor(
   MPSDataType mpsInputDataType = [primaryTensor dataType];
   MPSDataType mpsOtherDataType = [secondaryTensor dataType];
 
-  exec_aten::ScalarType inputDataType = getScalarType(mpsInputDataType);
-  exec_aten::ScalarType otherDataType = getScalarType(mpsOtherDataType);
+  ScalarType inputDataType = getScalarType(mpsInputDataType);
+  ScalarType otherDataType = getScalarType(mpsOtherDataType);
 
   MPSGraphTensor* primaryCastTensor = primaryTensor;
   MPSGraphTensor* secondaryCastTensor = secondaryTensor;
-  exec_aten::ScalarType commonDataType = promoteTypes(inputDataType, otherDataType);
+  ScalarType commonDataType = executorch::runtime::promoteTypes(inputDataType, otherDataType);
   if (inputDataType != commonDataType) {
     primaryCastTensor = castMPSTensor(mpsGraph, primaryTensor, commonDataType);
   }
@@ -119,8 +121,8 @@ auto graphNode = nodePtr->mpsnode_union_as_MPS##aot_name();                     
     graphNode->output_id()                                                         \
   );                                                                               \
   ET_CHECK_OR_RETURN_ERROR(                                                        \
-    is_macos_13_or_newer(), NotSupported,                                              \
-    "%s supported by MPS on MacOS13.0+/iOS16.1+", #aot_name);                       \
+    is_macos_13_or_newer(), NotSupported,                                          \
+    "%s supported by MPS on MacOS13.0+/iOS16.1+", #aot_name);                      \
                                                                                    \
   _idToMPSGraphTensor[graphNode->output_id()] = binaryOpTensor(                    \
     getMPSGraphTensor(graphNode->input1_id()),                                     \
@@ -292,5 +294,5 @@ REGISTER_DIV_OP(Remainder, "floor")
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/ClampOps.mm
+++ b/backends/apple/mps/runtime/operations/ClampOps.mm
@@ -6,8 +6,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -90,5 +90,5 @@ MPSGraphBuilder::mpsWhereOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/ConstantOps.mm
+++ b/backends/apple/mps/runtime/operations/ConstantOps.mm
@@ -6,8 +6,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -59,5 +59,5 @@ MPSGraphBuilder::mpsFullLikeOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/ConvolutionOps.mm
+++ b/backends/apple/mps/runtime/operations/ConvolutionOps.mm
@@ -6,8 +6,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -139,5 +139,5 @@ MPSGraphBuilder::mpsConv2DOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/IndexingOps.mm
+++ b/backends/apple/mps/runtime/operations/IndexingOps.mm
@@ -6,8 +6,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -230,5 +230,5 @@ MPSGraphBuilder::mpsScatterOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/LinearAlgebra.mm
+++ b/backends/apple/mps/runtime/operations/LinearAlgebra.mm
@@ -7,8 +7,8 @@
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 #include <iostream>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -82,5 +82,5 @@ MPSGraphBuilder::mpsAddmmOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/NormalizationOps.mm
+++ b/backends/apple/mps/runtime/operations/NormalizationOps.mm
@@ -6,8 +6,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -125,5 +125,5 @@ MPSGraphBuilder::mpsLayerNormOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/OperationUtils.h
+++ b/backends/apple/mps/runtime/operations/OperationUtils.h
@@ -11,16 +11,16 @@
 #include <executorch/backends/apple/mps/runtime/MPSDevice.h>
 #include <executorch/backends/apple/mps/schema_generated.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
 #define INF std::numeric_limits<float>::infinity()
 
-MPSDataType getMPSScalarType(exec_aten::ScalarType scalar_type);
-exec_aten::ScalarType getScalarType(MPSDataType mpsDataType);
-MPSGraphTensor *castMPSTensor(MPSGraph *mpsGraph, MPSGraphTensor *tensor, exec_aten::ScalarType toType);
+MPSDataType getMPSScalarType(executorch::aten::ScalarType scalar_type);
+executorch::aten::ScalarType getScalarType(MPSDataType mpsDataType);
+MPSGraphTensor *castMPSTensor(MPSGraph *mpsGraph, MPSGraphTensor *tensor, executorch::aten::ScalarType toType);
 MPSGraphTensor *castMPSTensor(MPSGraph *mpsGraph, MPSGraphTensor *tensor, MPSDataType toType);
 std::vector<int64_t> getMPSShapeVec(const MPSShape *shape);
 
@@ -33,12 +33,12 @@ template <typename T = size_t> std::vector<T> flatbufferDimsToVector(const flatb
   return dimsData;
 }
 
-id<MTLBuffer> getMTLBufferStorage(const Tensor &tensor);
+id<MTLBuffer> getMTLBufferStorage(const executorch::aten::Tensor &tensor);
 void *pageAlignedBlockPtr(const void *ptr, NSUInteger size, NSUInteger *alignedBlockSize);
 
 MPSGraphTensor *permuteTensor(MPSGraph *graph, MPSGraphTensor *inputTensor, NSArray *permuteOrder);
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/OperationUtils.mm
+++ b/backends/apple/mps/runtime/operations/OperationUtils.mm
@@ -11,8 +11,8 @@
 #define PAGE_SIZE 4096
 #endif
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -250,41 +250,41 @@ MPSGraphBuilder::getMPSGraphTensor(int32_t id) {
   return _idToMPSGraphTensor[id];
 }
 
-MPSDataType getMPSScalarType(exec_aten::ScalarType scalar_type) {
+MPSDataType getMPSScalarType(executorch::aten::ScalarType scalar_type) {
   switch (scalar_type) {
     // This is an intentional fallthrough supporting Double for Scalar
     // types as they are casted to Float32 currently.
-    case exec_aten::ScalarType::Float:
+    case executorch::aten::ScalarType::Float:
       return MPSDataTypeFloat32;
-    case exec_aten::ScalarType::Half:
+    case executorch::aten::ScalarType::Half:
       return MPSDataTypeFloat16;
     default:
       ET_CHECK_MSG(false, "Unhandled ExecuTorch scalar type!");
   }
 }
 
-exec_aten::ScalarType getScalarType(MPSDataType mpsDataType) {
+executorch::aten::ScalarType getScalarType(MPSDataType mpsDataType) {
   switch (mpsDataType) {
     case MPSDataTypeFloat16:
-      return exec_aten::ScalarType::Half;
+      return executorch::aten::ScalarType::Half;
     case MPSDataTypeFloat32:
-      return exec_aten::ScalarType::Float;
+      return executorch::aten::ScalarType::Float;
     case MPSDataTypeInt8:
-      return exec_aten::ScalarType::Char;
+      return executorch::aten::ScalarType::Char;
     case MPSDataTypeInt16:
-      return exec_aten::ScalarType::Short;
+      return executorch::aten::ScalarType::Short;
     case MPSDataTypeInt32:
-      return exec_aten::ScalarType::Int;
+      return executorch::aten::ScalarType::Int;
     case MPSDataTypeInt64:
-      return exec_aten::ScalarType::Long;
+      return executorch::aten::ScalarType::Long;
     case MPSDataTypeBool:
-      return exec_aten::ScalarType::Bool;
+      return executorch::aten::ScalarType::Bool;
     default:
       ET_CHECK_MSG(false, "Unhandled MPS data type!");
   }
 }
 
-MPSGraphTensor* castMPSTensor(MPSGraph* mpsGraph, MPSGraphTensor* tensor, exec_aten::ScalarType toType) {
+MPSGraphTensor* castMPSTensor(MPSGraph* mpsGraph, MPSGraphTensor* tensor, executorch::aten::ScalarType toType) {
   return castMPSTensor(mpsGraph, tensor, getMPSScalarType(toType));
 }
 
@@ -301,7 +301,7 @@ std::vector<int64_t> getMPSShapeVec(const MPSShape* shape) {
   return shapeVec;
 }
 
-id<MTLBuffer> getMTLBufferStorage(const Tensor &tensor) {
+id<MTLBuffer> getMTLBufferStorage(const executorch::aten::Tensor &tensor) {
   uint8_t *data = tensor.mutable_data_ptr<uint8_t>();
   return [MPSDevice::getInstance()->device() newBufferWithBytesNoCopy:data
                                                                length:tensor.nbytes()
@@ -349,5 +349,5 @@ MPSGraphTensor* permuteTensor(MPSGraph* graph, MPSGraphTensor* inputTensor, NSAr
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/PadOps.mm
+++ b/backends/apple/mps/runtime/operations/PadOps.mm
@@ -6,8 +6,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -148,5 +148,5 @@ MPSGraphBuilder::mpsConstantPadNDOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/PoolingOps.mm
+++ b/backends/apple/mps/runtime/operations/PoolingOps.mm
@@ -6,8 +6,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -106,5 +106,5 @@ MPSGraphBuilder::mpsAvgPool2DOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/QuantDequant.mm
+++ b/backends/apple/mps/runtime/operations/QuantDequant.mm
@@ -5,8 +5,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -48,5 +48,5 @@ MPSGraphBuilder::mpsDequantizePerChannelGroupOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/RangeOps.mm
+++ b/backends/apple/mps/runtime/operations/RangeOps.mm
@@ -6,8 +6,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -49,5 +49,5 @@ MPSGraphBuilder::mpsArangeOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/ReduceOps.mm
+++ b/backends/apple/mps/runtime/operations/ReduceOps.mm
@@ -6,8 +6,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -55,5 +55,5 @@ MPSGraphBuilder::mpsMeanOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/ShapeOps.mm
+++ b/backends/apple/mps/runtime/operations/ShapeOps.mm
@@ -6,8 +6,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -267,5 +267,5 @@ MPSGraphBuilder::mpsCastOp(NodePtr nodePtr) {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/mps/runtime/operations/UnaryOps.mm
+++ b/backends/apple/mps/runtime/operations/UnaryOps.mm
@@ -6,8 +6,8 @@
 
 #include <executorch/backends/apple/mps/runtime/MPSGraphBuilder.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace mps {
 namespace delegate {
 
@@ -29,7 +29,7 @@ MPSGraphBuilder::mpsBitwiseNotOp(NodePtr nodePtr) {
 
   MPSGraphTensor* inputTensor = getMPSGraphTensor(graphNode->input1_id());
   MPSDataType mpsInputDataType = [inputTensor dataType];
-  if (getScalarType(mpsInputDataType) == ScalarType::Bool) {
+  if (getScalarType(mpsInputDataType) == executorch::aten::ScalarType::Bool) {
     _idToMPSGraphTensor[graphNode->output_id()] = [_mpsGraph notWithTensor:inputTensor name:nil];
   } else {
     ET_CHECK_OR_RETURN_ERROR(
@@ -134,5 +134,5 @@ MPSGraphBuilder::mpsNormCdfOp(NodePtr nodePtr)  {
 
 } // namespace delegate
 } // namespace mps
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch


### PR DESCRIPTION
Summary: Move the Apple backends out of the `torch::` namespace, and update to avoid using the `torch::` or `exec_aten::` namespaces.

Differential Revision: D63908530
