### PR TITLE
Migrate backends/arm to the new namespace

### DIFF
--- a/backends/arm/runtime/ArmBackendEthosU.cpp
+++ b/backends/arm/runtime/ArmBackendEthosU.cpp
@@ -15,17 +15,31 @@
 
 #include <ethosu_driver.h>
 
-#include "executorch/backends/arm/runtime/VelaBinStream.h"
-#include "executorch/runtime/backend/interface.h"
-#include "executorch/runtime/core/error.h"
-#include "executorch/runtime/core/evalue.h"
-#include "executorch/runtime/core/exec_aten/util/dim_order_util.h"
-#include "executorch/runtime/core/exec_aten/util/scalar_type_util.h"
+#include <executorch/backends/arm/runtime/VelaBinStream.h>
+#include <executorch/runtime/backend/interface.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 
 using namespace std;
 
-namespace torch {
-namespace executor {
+using executorch::aten::ScalarType;
+using executorch::runtime::ArrayRef;
+using executorch::runtime::Backend;
+using executorch::runtime::BackendExecutionContext;
+using executorch::runtime::BackendInitContext;
+using executorch::runtime::CompileSpec;
+using executorch::runtime::DelegateHandle;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::MemoryAllocator;
+using executorch::runtime::Result;
+
+namespace executorch {
+namespace backends {
+namespace arm {
 
 typedef struct {
   FreeableBuffer* processed;
@@ -142,10 +156,10 @@ class ArmBackend final : public ::executorch::runtime::BackendInterface {
             Error,
             "Input %d expected Integer (4 byte) or Char (1 byte) integer inputs, got ScalarType id %s",
             i,
-            toString(tensor_in.scalar_type()));
+            executorch::runtime::toString(tensor_in.scalar_type()));
         return Error::InvalidProgram;
       }
-      supported = is_contiguous_dim_order(
+      supported = executorch::runtime::is_contiguous_dim_order(
           tensor_in.dim_order().data(), tensor_in.dim());
       if (!supported) {
         ET_LOG(
@@ -268,7 +282,7 @@ class ArmBackend final : public ::executorch::runtime::BackendInterface {
  private:
   Error check_requires_permute(
       int index,
-      const exec_aten::Tensor tensor,
+      const executorch::aten::Tensor tensor,
       VelaIO* io,
       bool permuted_io_flag,
       bool* is_permuted) const {
@@ -343,5 +357,6 @@ Backend backend_id{"ArmBackend", &backend};
 static auto registered = register_backend(backend_id);
 } // namespace
 
-} // namespace executor
-} // namespace torch
+} // namespace arm
+} // namespace backends
+} // namespace executorch

--- a/backends/arm/runtime/VelaBinStream.cpp
+++ b/backends/arm/runtime/VelaBinStream.cpp
@@ -10,10 +10,15 @@
  *          as that function emits this format and the two need to align.
  */
 
+#include <executorch/backends/arm/runtime/VelaBinStream.h>
+
 #include <cstring>
 
-#include "executorch/backends/arm/runtime/VelaBinStream.h"
-#include "executorch/runtime/core/error.h"
+#include <executorch/runtime/core/error.h>
+
+namespace executorch {
+namespace backends {
+namespace arm {
 
 // get next mul of 16 ptr, return n if already aligned
 static uintptr_t next_mul_16(uintptr_t n) {
@@ -91,3 +96,7 @@ bool vela_bin_read(const char* data, VelaHandles* handles, int size) {
   // We've fallen off the end without finding vela_end_stream
   return false;
 }
+
+} // namespace arm
+} // namespace backends
+} // namespace executorch

--- a/backends/arm/runtime/VelaBinStream.h
+++ b/backends/arm/runtime/VelaBinStream.h
@@ -18,6 +18,10 @@
 #include <cstddef>
 #include <cstdint>
 
+namespace executorch {
+namespace backends {
+namespace arm {
+
 // Standard block name size
 const uint32_t kVelaBlockNameLength = 16;
 
@@ -67,3 +71,7 @@ bool vela_bin_read(const char* data, VelaHandles* handles, int size);
  * on the Ethos-U.
  */
 bool vela_bin_validate(const char* data, int size);
+
+} // namespace arm
+} // namespace backends
+} // namespace executorch


### PR DESCRIPTION
Summary:
Move the Arm backend out of the `torch::` namespace, and update to avoid using the `torch::` or `exec_aten::` namespaces.

Also, move the VelaBinStream code into a namespace to avoid declaring symbols in the global namespace.

Differential Revision: D63923290


