### PR TITLE
Migrate backends/cadence away from deprecated namespaces

### DIFF
--- a/backends/cadence/hifi/operators/dequantize_per_tensor.cpp
+++ b/backends/cadence/hifi/operators/dequantize_per_tensor.cpp
@@ -14,9 +14,9 @@ namespace impl {
 namespace HiFi {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::ScalarType;
+using executorch::aten::Tensor;
 using executorch::runtime::KernelRuntimeContext;
-using ScalarType = exec_aten::ScalarType;
 
 void dequantize_per_tensor_out(
     KernelRuntimeContext& context,

--- a/backends/cadence/hifi/operators/quantize_per_tensor.cpp
+++ b/backends/cadence/hifi/operators/quantize_per_tensor.cpp
@@ -14,9 +14,9 @@ namespace impl {
 namespace HiFi {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::ScalarType;
+using executorch::aten::Tensor;
 using executorch::runtime::KernelRuntimeContext;
-using ScalarType = exec_aten::ScalarType;
 
 // Quantize the input tensor (PT2 version). Note that quant_<min,max> are not
 // used in any computation.

--- a/backends/cadence/hifi/operators/quantized_layer_norm.cpp
+++ b/backends/cadence/hifi/operators/quantized_layer_norm.cpp
@@ -12,7 +12,7 @@
 #include <cmath>
 #include <tuple>
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::Tensor;
 using executorch::runtime::KernelRuntimeContext;
 
 namespace impl {
@@ -119,14 +119,14 @@ void quantized_layer_norm_out(
     const Tensor& input,
     const Tensor& in_scale,
     const Tensor& in_zero_point,
-    const exec_aten::IntArrayRef normalized_shape,
+    const executorch::aten::IntArrayRef normalized_shape,
     const Tensor& weight,
     const Tensor& bias,
     double eps,
     double output_scale,
     int64_t output_zero_point,
     Tensor& out) {
-  if (input.scalar_type() == exec_aten::ScalarType::Byte) {
+  if (input.scalar_type() == executorch::aten::ScalarType::Byte) {
     quantized_layer_norm_<uint8_t>(
         input,
         in_scale,
@@ -137,7 +137,7 @@ void quantized_layer_norm_out(
         output_scale,
         output_zero_point,
         out);
-  } else if (input.scalar_type() == exec_aten::ScalarType::Char) {
+  } else if (input.scalar_type() == executorch::aten::ScalarType::Char) {
     quantized_layer_norm_<int8_t>(
         input,
         in_scale,

--- a/backends/cadence/hifi/operators/quantized_linear_out.cpp
+++ b/backends/cadence/hifi/operators/quantized_linear_out.cpp
@@ -15,7 +15,7 @@ namespace impl {
 namespace HiFi {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::Tensor;
 using executorch::runtime::KernelRuntimeContext;
 
 void quantized_linear_out(
@@ -28,7 +28,7 @@ void quantized_linear_out(
     const Tensor& out_multiplier,
     const Tensor& out_shift,
     int64_t out_zero_point,
-    const exec_aten::optional<Tensor>& offset,
+    const executorch::aten::optional<Tensor>& offset,
     Tensor& out) {
   // input comes in shape [leading_dims, in_dim]
   // weight comes in shape [out_dim, in_dim]

--- a/backends/cadence/reference/operators/dequantize_per_tensor.cpp
+++ b/backends/cadence/reference/operators/dequantize_per_tensor.cpp
@@ -13,9 +13,9 @@ namespace impl {
 namespace reference {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::ScalarType;
+using executorch::aten::Tensor;
 using executorch::runtime::KernelRuntimeContext;
-using ScalarType = exec_aten::ScalarType;
 
 void dequantize_per_tensor_out(
     KernelRuntimeContext& context,

--- a/backends/cadence/reference/operators/op_embedding.cpp
+++ b/backends/cadence/reference/operators/op_embedding.cpp
@@ -12,7 +12,7 @@ namespace torch {
 namespace executor {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::Tensor;
 using executorch::runtime::KernelRuntimeContext;
 
 void embedding_out(

--- a/backends/cadence/reference/operators/op_full.cpp
+++ b/backends/cadence/reference/operators/op_full.cpp
@@ -13,8 +13,8 @@ namespace torch {
 namespace executor {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
-using ScalarType = exec_aten::ScalarType;
+using executorch::aten::ScalarType;
+using executorch::aten::Tensor;
 
 Tensor& full_out(
     KernelRuntimeContext& ctx,

--- a/backends/cadence/reference/operators/op_view_copy.cpp
+++ b/backends/cadence/reference/operators/op_view_copy.cpp
@@ -12,7 +12,7 @@ namespace torch {
 namespace executor {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::Tensor;
 using executorch::runtime::KernelRuntimeContext;
 
 Tensor& view_copy_out(

--- a/backends/cadence/reference/operators/quantize_per_tensor.cpp
+++ b/backends/cadence/reference/operators/quantize_per_tensor.cpp
@@ -13,9 +13,9 @@ namespace impl {
 namespace reference {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::ScalarType;
+using executorch::aten::Tensor;
 using executorch::runtime::KernelRuntimeContext;
-using ScalarType = exec_aten::ScalarType;
 
 // Quantize the input tensor (PT2 version). Note that quant_<min,max> are not
 // used in any computation.

--- a/backends/cadence/reference/operators/quantized_conv_out.cpp
+++ b/backends/cadence/reference/operators/quantized_conv_out.cpp
@@ -14,7 +14,7 @@ namespace impl {
 namespace reference {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::Tensor;
 using executorch::runtime::KernelRuntimeContext;
 
 // This implements a generic 2d conv kernel that operates on raw pointers.
@@ -158,9 +158,9 @@ void quantized_conv_out(
     const Tensor& input,
     const Tensor& weight,
     const Tensor& bias,
-    exec_aten::IntArrayRef stride,
-    exec_aten::IntArrayRef padding,
-    exec_aten::IntArrayRef dilation,
+    executorch::aten::IntArrayRef stride,
+    executorch::aten::IntArrayRef padding,
+    executorch::aten::IntArrayRef dilation,
     int64_t groups,
     int64_t in_zero_point,
     const Tensor& weight_zero_point,

--- a/backends/cadence/reference/operators/quantized_layer_norm.cpp
+++ b/backends/cadence/reference/operators/quantized_layer_norm.cpp
@@ -115,14 +115,14 @@ void quantized_layer_norm_out(
     const Tensor& input,
     const Tensor& in_scale,
     const Tensor& in_zero_point,
-    const exec_aten::IntArrayRef normalized_shape,
+    const executorch::aten::IntArrayRef normalized_shape,
     const Tensor& weight,
     const Tensor& bias,
     double eps,
     double output_scale,
     int64_t output_zero_point,
     Tensor& out) {
-  if (input.scalar_type() == exec_aten::ScalarType::Byte) {
+  if (input.scalar_type() == executorch::aten::ScalarType::Byte) {
     quantized_layer_norm_<uint8_t>(
         input,
         in_scale,
@@ -133,7 +133,7 @@ void quantized_layer_norm_out(
         output_scale,
         output_zero_point,
         out);
-  } else if (input.scalar_type() == exec_aten::ScalarType::Char) {
+  } else if (input.scalar_type() == executorch::aten::ScalarType::Char) {
     quantized_layer_norm_<int8_t>(
         input,
         in_scale,

--- a/backends/cadence/reference/operators/quantized_linear_out.cpp
+++ b/backends/cadence/reference/operators/quantized_linear_out.cpp
@@ -27,7 +27,7 @@ void quantized_linear_out(
     const Tensor& out_multiplier,
     const Tensor& out_shift,
     int64_t out_zero_point,
-    const exec_aten::optional<Tensor>& offset,
+    const executorch::aten::optional<Tensor>& offset,
     Tensor& out) {
   // Assuming uint8_t for now, but needs to be updated for other quantization
   // types

--- a/backends/cadence/reference/operators/quantized_matmul_out.cpp
+++ b/backends/cadence/reference/operators/quantized_matmul_out.cpp
@@ -60,7 +60,7 @@ void inline _typed_quantized_matmul(
     int64_t X_zero_point,
     const Tensor& Y,
     int64_t Y_zero_point,
-    const exec_aten::optional<Tensor>& bias,
+    const executorch::aten::optional<Tensor>& bias,
     int64_t out_multiplier,
     int64_t out_shift,
     int64_t out_zero_point,
@@ -114,13 +114,13 @@ void quantized_matmul_out(
     int64_t X_zero_point,
     const Tensor& Y,
     int64_t Y_zero_point,
-    const exec_aten::optional<Tensor>& bias,
+    const executorch::aten::optional<Tensor>& bias,
     int64_t out_multiplier,
     int64_t out_shift,
     int64_t out_zero_point,
     bool transposed,
     Tensor& out) {
-  if (out.scalar_type() == exec_aten::ScalarType::Byte) {
+  if (out.scalar_type() == executorch::aten::ScalarType::Byte) {
     _typed_quantized_matmul<uint8_t>(
         X,
         X_zero_point,
@@ -132,7 +132,7 @@ void quantized_matmul_out(
         out_zero_point,
         transposed,
         out);
-  } else if (out.scalar_type() == exec_aten::ScalarType::Char) {
+  } else if (out.scalar_type() == executorch::aten::ScalarType::Char) {
     _typed_quantized_matmul<int8_t>(
         X,
         X_zero_point,

--- a/backends/cadence/reference/operators/quantized_relu_out.cpp
+++ b/backends/cadence/reference/operators/quantized_relu_out.cpp
@@ -13,7 +13,7 @@ namespace impl {
 namespace reference {
 namespace native {
 
-using Tensor = exec_aten::Tensor;
+using executorch::aten::Tensor;
 using executorch::runtime::KernelRuntimeContext;
 
 template <typename T>
@@ -51,7 +51,7 @@ void quantized_relu_out(
     const Tensor& out_multiplier,
     const Tensor& out_shift,
     Tensor& output) {
-  if (input.scalar_type() == exec_aten::ScalarType::Byte) {
+  if (input.scalar_type() == executorch::aten::ScalarType::Byte) {
     quantized_relu_<uint8_t>(
         input,
         in_zero_point,
@@ -59,7 +59,7 @@ void quantized_relu_out(
         out_multiplier,
         out_shift,
         output);
-  } else if (input.scalar_type() == exec_aten::ScalarType::Char) {
+  } else if (input.scalar_type() == executorch::aten::ScalarType::Char) {
     quantized_relu_<int8_t>(
         input,
         in_zero_point,


### PR DESCRIPTION
Summary:
Stop using the `torch::` namespace where possible.

For now, ops still live under `torch::executor::`.

Differential Revision: D63924099


