### PR TITLE
Handle empty Android benchmark results

### DIFF
--- a/.github/scripts/extract_benchmark_results.py
+++ b/.github/scripts/extract_benchmark_results.py
@@ -129,6 +129,10 @@ def extract_android_benchmark_results(
     except error.HTTPError:
         warning(f"Fail to {artifact_type} {artifact_s3_url}")
         return []
+    except json.decoder.JSONDecodeError:
+        # This is to handle the case where there is no benchmark results
+        warning(f"Fail to load the benchmark results from {artifact_s3_url}")
+        return []
 
 
 def extract_job_id(artifacts_filename: str) -> int:


### PR DESCRIPTION
The script didn't handle invalid JSON well when the benchmark results is empty https://github.com/pytorch/executorch/actions/runs/11197448597/job/31128464106.  It's better to upload whatever it finds instead of crashing in this case.

Looking a bit close at the benchmark jobs, there are some cases where the `benchmark_results.json` file is empty.  I'm not sure why yet, but it can be fixed in another PR:

* https://github.com/pytorch/executorch/actions/runs/11197448597/job/31127998979#step:15:286 (stories110M, qnn)
* https://github.com/pytorch/executorch/actions/runs/11197448597/job/31127999221#step:15:946 (vit, xnnpack)

The test spec already waits for 3 minutes to see if the file is there before giving up