### PR TITLE
Rename executorch_no_prim_ops to executorch_core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,7 +456,7 @@ endif()
 add_subdirectory(schema)
 
 #
-# executorch_no_prim_ops: Minimal runtime library
+# executorch_core: Minimal runtime library
 #
 # The bare-minimum runtime library, supporting the Program and Method
 # interfaces. Does not contain any operators, including primitive ops. Does not
@@ -464,14 +464,14 @@ add_subdirectory(schema)
 #
 
 # Remove any PAL-definition files from the sources.
-list(FILTER _executorch_no_prim_ops__srcs EXCLUDE REGEX
+list(FILTER _executorch_core__srcs EXCLUDE REGEX
      "runtime/platform/default/[^/]*.cpp$"
 )
 
 # Add the source file that maps to the requested default PAL implementation.
 if(EXECUTORCH_PAL_DEFAULT MATCHES "^(posix|minimal)$")
   message(STATUS "executorch: Using PAL default '${EXECUTORCH_PAL_DEFAULT}'")
-  list(APPEND _executorch_no_prim_ops__srcs
+  list(APPEND _executorch_core__srcs
        "runtime/platform/default/${EXECUTORCH_PAL_DEFAULT}.cpp"
   )
 else()
@@ -481,45 +481,49 @@ else()
   )
 endif()
 
-add_library(executorch_no_prim_ops ${_executorch_no_prim_ops__srcs})
-target_link_libraries(executorch_no_prim_ops PRIVATE program_schema)
+add_library(executorch_core ${_executorch_core__srcs})
+
+# Legacy name alias.
+add_library(executorch_no_prim_ops ALIAS executorch_core)
+
+target_link_libraries(executorch_core PRIVATE program_schema)
 if(EXECUTORCH_USE_DL)
   # Check if dl exists for this toolchain and only then link it.
   find_library(DL_LIBRARY_EXISTS NAMES dl)
   # Check if the library was found
   if(DL_LIBRARY_EXISTS)
-    target_link_libraries(executorch_no_prim_ops PRIVATE dl) # For dladdr()
+    target_link_libraries(executorch_core PRIVATE dl) # For dladdr()
   endif()
 endif()
 target_include_directories(
-  executorch_no_prim_ops PUBLIC ${_common_include_directories}
+  executorch_core PUBLIC ${_common_include_directories}
 )
-target_compile_options(executorch_no_prim_ops PUBLIC ${_common_compile_options})
+target_compile_options(executorch_core PUBLIC ${_common_compile_options})
 if(MAX_KERNEL_NUM)
   target_compile_definitions(
-    executorch_no_prim_ops PRIVATE MAX_KERNEL_NUM=${MAX_KERNEL_NUM}
+    executorch_core PRIVATE MAX_KERNEL_NUM=${MAX_KERNEL_NUM}
   )
 endif()
 
 if(EXECUTORCH_BUILD_PYBIND AND APPLE)
   # shared version
   add_library(
-    executorch_no_prim_ops_shared SHARED ${_executorch_no_prim_ops__srcs}
+    executorch_core_shared SHARED ${_executorch_core__srcs}
   )
-  target_link_libraries(executorch_no_prim_ops_shared PRIVATE program_schema)
+  target_link_libraries(executorch_core_shared PRIVATE program_schema)
   if(DL_LIBRARY_EXISTS)
     # For dladdr()
-    target_link_libraries(executorch_no_prim_ops_shared PRIVATE dl)
+    target_link_libraries(executorch_core_shared PRIVATE dl)
   endif()
   target_include_directories(
-    executorch_no_prim_ops_shared PUBLIC ${_common_include_directories}
+    executorch_core_shared PUBLIC ${_common_include_directories}
   )
   target_compile_options(
-    executorch_no_prim_ops_shared PUBLIC ${_common_compile_options}
+    executorch_core_shared PUBLIC ${_common_compile_options}
   )
   if(MAX_KERNEL_NUM)
     target_compile_definitions(
-      executorch_no_prim_ops_shared PRIVATE MAX_KERNEL_NUM=${MAX_KERNEL_NUM}
+      executorch_core_shared PRIVATE MAX_KERNEL_NUM=${MAX_KERNEL_NUM}
     )
   endif()
 endif()
@@ -532,7 +536,7 @@ endif()
 # any backends.
 #
 add_library(executorch ${_executorch__srcs})
-target_link_libraries(executorch PRIVATE executorch_no_prim_ops)
+target_link_libraries(executorch PRIVATE executorch_core)
 target_include_directories(executorch PUBLIC ${_common_include_directories})
 target_compile_options(executorch PUBLIC ${_common_compile_options})
 target_link_options_shared_lib(executorch)
@@ -568,7 +572,7 @@ endif()
 # Install `executorch` library as well as `executorch-config.cmake` under
 # ${CMAKE_INSTALL_PREFIX}/
 install(
-  TARGETS executorch executorch_no_prim_ops
+  TARGETS executorch executorch_core
   DESTINATION lib
   INCLUDES
   DESTINATION ${_common_include_directories}

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -134,7 +134,7 @@ target_include_directories(
   coremldelegate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/util
 )
 target_include_directories(coremldelegate PRIVATE ${EXECUTORCH_ROOT}/..)
-target_link_libraries(coremldelegate PRIVATE executorch_no_prim_ops)
+target_link_libraries(coremldelegate PRIVATE executorch_core)
 
 if(EXECUTORCH_BUILD_DEVTOOLS)
   target_sources(coremldelegate PRIVATE ${SDK_SOURCES} ${PROTOBUF_SOURCES})
@@ -159,7 +159,7 @@ find_library(SQLITE_LIBRARY sqlite3)
 
 target_link_libraries(
   coremldelegate
-  PRIVATE executorch_no_prim_ops ${ACCELERATE_FRAMEWORK} ${COREML_FRAMEWORK}
+  PRIVATE executorch_core ${ACCELERATE_FRAMEWORK} ${COREML_FRAMEWORK}
           ${FOUNDATION_FRAMEWORK} ${SQLITE_LIBRARY}
 )
 
@@ -176,7 +176,7 @@ target_compile_options(coremldelegate PRIVATE "-fno-exceptions")
 
 if(EXECUTORCH_BUILD_DEVTOOLS)
   target_compile_options(
-    executorch_no_prim_ops PUBLIC -DET_EVENT_TRACER_ENABLED
+    executorch_core PUBLIC -DET_EVENT_TRACER_ENABLED
   )
   target_compile_options(coremldelegate PRIVATE "-frtti")
   target_compile_options(libprotobuf-lite PRIVATE "-frtti")

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
@@ -105,7 +105,7 @@
 		C9E7D7962AB3F9BF00CCAE5D /* KeyValueStoreTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D78E2AB3F9BF00CCAE5D /* KeyValueStoreTests.mm */; };
 		C9E7D7A22AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9E7D7A12AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm */; };
 		C9EC7E1B2BC73B3200A6B166 /* MultiArrayTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9EC7E1A2BC73B3200A6B166 /* MultiArrayTests.mm */; };
-		F24817E52BC655E100E80D98 /* libexecutorch_no_prim_ops.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F24817E42BC655E100E80D98 /* libexecutorch_no_prim_ops.a */; };
+		F24817E52BC655E100E80D98 /* libexecutorch_core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F24817E42BC655E100E80D98 /* libexecutorch_core.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -310,7 +310,7 @@
 		C9EA3FE52B73EF6300B7D7BD /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		C9EC7E092BC662A300A6B166 /* objc_array_util.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = objc_array_util.h; path = ../util/objc_array_util.h; sourceTree = "<group>"; };
 		C9EC7E1A2BC73B3200A6B166 /* MultiArrayTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MultiArrayTests.mm; path = ../test/MultiArrayTests.mm; sourceTree = "<group>"; };
-		F24817E42BC655E100E80D98 /* libexecutorch_no_prim_ops.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libexecutorch_no_prim_ops.a; path = ../libraries/libexecutorch_no_prim_ops.a; sourceTree = "<group>"; };
+		F24817E42BC655E100E80D98 /* libexecutorch_core.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libexecutorch_core.a; path = ../libraries/libexecutorch_core.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -319,7 +319,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C94D510F2ABDF87500AF47FD /* Accelerate.framework in Frameworks */,
-				F24817E52BC655E100E80D98 /* libexecutorch_no_prim_ops.a in Frameworks */,
+				F24817E52BC655E100E80D98 /* libexecutorch_core.a in Frameworks */,
 				C94D510E2ABDF86800AF47FD /* libsqlite3.tbd in Frameworks */,
 				C94D50D92ABD7B2400AF47FD /* CoreML.framework in Frameworks */,
 				C99883862B95AD7D000953A3 /* libprotobuf-lite.a in Frameworks */,
@@ -540,7 +540,7 @@
 				C96560942AABFDCE005F8126 /* libsqlite3.tbd */,
 				C96560922AABF992005F8126 /* CoreML.framework */,
 				C96560902AABF982005F8126 /* Accelerate.framework */,
-				F24817E42BC655E100E80D98 /* libexecutorch_no_prim_ops.a */,
+				F24817E42BC655E100E80D98 /* libexecutorch_core.a */,
 				C965608D2AABF72A005F8126 /* libexecutorch.a */,
 			);
 			name = "Recovered References";

--- a/backends/apple/coreml/scripts/build_tests.sh
+++ b/backends/apple/coreml/scripts/build_tests.sh
@@ -59,7 +59,7 @@ cmake --build "$CMAKE_PROTOBUF_BUILD_DIR_PATH"  -j9 -t libprotobuf-lite
 echo "ExecuTorch: Copying libraries"
 mkdir "$LIBRARIES_DIR_PATH"
 cp -f "$CMAKE_EXECUTORCH_BUILD_DIR_PATH/libexecutorch.a" "$LIBRARIES_DIR_PATH"
-cp -f "$CMAKE_EXECUTORCH_BUILD_DIR_PATH/libexecutorch_no_prim_ops.a" "$LIBRARIES_DIR_PATH"
+cp -f "$CMAKE_EXECUTORCH_BUILD_DIR_PATH/libexecutorch_core.a" "$LIBRARIES_DIR_PATH"
 cp -f "$CMAKE_PROTOBUF_BUILD_DIR_PATH/libprotobuf-lite.a" "$LIBRARIES_DIR_PATH"
 
 #Copy ExecuTorch headers

--- a/backends/apple/mps/CMakeLists.txt
+++ b/backends/apple/mps/CMakeLists.txt
@@ -75,7 +75,7 @@ target_link_libraries(
   mpsdelegate
   PRIVATE bundled_program
           mps_schema
-          executorch_no_prim_ops
+          executorch_core
           ${FOUNDATION_FRAMEWORK}
           ${METAL_FRAMEWORK}
           ${MPS_FRAMEWORK}

--- a/backends/mediatek/CMakeLists.txt
+++ b/backends/mediatek/CMakeLists.txt
@@ -27,7 +27,7 @@ include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/runtime/include)
 add_library(neuron_backend SHARED)
 target_link_libraries(neuron_backend
     PRIVATE
-    executorch_no_prim_ops
+    executorch_core
     portable_ops_lib
     android
     log

--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -181,7 +181,7 @@ target_link_libraries(
 )
 target_link_libraries(
   qnn_executorch_backend PRIVATE qnn_executorch_header qnn_schema qnn_manager
-                                 executorch_no_prim_ops qcir_utils extension_tensor
+                                 executorch_core qcir_utils extension_tensor
 )
 set_target_properties(
   qnn_executorch_backend PROPERTIES LINK_FLAGS "-Wl,-rpath='$ORIGIN'"

--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -93,7 +93,7 @@ include(cmake/Dependencies.cmake)
 list(TRANSFORM _xnnpack_backend__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(xnnpack_backend STATIC ${_xnnpack_backend__srcs})
 target_link_libraries(
-  xnnpack_backend PRIVATE ${xnnpack_third_party} executorch_no_prim_ops
+  xnnpack_backend PRIVATE ${xnnpack_third_party} executorch_core
                           xnnpack_schema
 )
 

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -154,7 +154,7 @@ function(gen_custom_ops_aot_lib)
   if(TARGET portable_lib)
     target_link_libraries(${GEN_LIB_NAME} PRIVATE portable_lib)
   else()
-    target_link_libraries(${GEN_LIB_NAME} PRIVATE executorch_no_prim_ops)
+    target_link_libraries(${GEN_LIB_NAME} PRIVATE executorch_core)
   endif()
 endfunction()
 

--- a/build/build_apple_frameworks.sh
+++ b/build/build_apple_frameworks.sh
@@ -29,7 +29,7 @@ PLATFORM_TARGET=("17.0" "17.0" "10.15")
 
 FRAMEWORK_EXECUTORCH="executorch:\
 libexecutorch.a,\
-libexecutorch_no_prim_ops.a,\
+libexecutorch_core.a,\
 libextension_apple.a,\
 libextension_data_loader.a,\
 libextension_module.a,\

--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -20,14 +20,14 @@ buck_targets = [
   "//runtime/executor:program",
 ]
 deps = [
-  "executorch_no_prim_ops",
+  "executorch_core",
 ]
 filters = [
   ".cpp$",
 ]
 
 
-[targets.executorch_no_prim_ops]
+[targets.executorch_core]
 buck_targets = [
   "//runtime/executor:program_no_prim_ops",
 ]
@@ -55,7 +55,7 @@ excludes = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
 ]
 
 [targets.optimized_kernels]
@@ -72,7 +72,7 @@ excludes = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
   "extension_threadpool",
   "portable_kernels",
 ]
@@ -91,7 +91,7 @@ excludes = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
   "portable_kernels",
 ]
 
@@ -113,7 +113,7 @@ filters = [
 excludes = [
 ]
 deps = [
-  "executorch_no_prim_ops",
+  "executorch_core",
   "executorch",
 ]
 
@@ -127,7 +127,7 @@ filters = [
 excludes = [
 ]
 deps = [
-  "executorch_no_prim_ops",
+  "executorch_core",
   "executorch",
   "portable_kernels",
 ]
@@ -144,7 +144,7 @@ filters = [
   ".cpp$",
 ]
 deps = [
-  "executorch_no_prim_ops",
+  "executorch_core",
   "executorch",
 ]
 
@@ -157,7 +157,7 @@ filters = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
   "extension_data_loader",
 ]
 
@@ -170,7 +170,7 @@ filters = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
 ]
 
 [targets.extension_llm_runner]
@@ -182,7 +182,7 @@ filters = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
   "extension_module",
   "extension_runner_util",
 ]
@@ -196,7 +196,7 @@ filters = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
 ]
 
 [targets.extension_threadpool]
@@ -208,8 +208,9 @@ filters = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
 ]
+
 # ---------------------------------- extension end ----------------------------------
 # ---------------------------------- binary start ----------------------------------
 
@@ -225,7 +226,7 @@ excludes = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
   "portable_kernels",
   "quantized_kernels",
 ]
@@ -241,7 +242,7 @@ excludes = [
   "^codegen",
 ]
 deps = [
-  "executorch_no_prim_ops",
+  "executorch_core",
   "executorch",
 ]
 # ---------------------------------- binary end ----------------------------------
@@ -258,7 +259,7 @@ excludes = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
   "portable_kernels",
 ]
 
@@ -271,7 +272,7 @@ filters = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
 ]
 
 [targets.mps_schema]
@@ -297,7 +298,7 @@ excludes = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
   "xnnpack_backend",
   "portable_kernels",
 ]
@@ -311,7 +312,7 @@ filters = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
 ]
 
 [targets.xnnpack_schema]
@@ -344,7 +345,7 @@ excludes = [
 ]
 deps = [
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
   "optimized_kernels",
   "extension_threadpool",
   "xnnpack_backend",
@@ -363,7 +364,7 @@ excludes = [
 deps = [
   "custom_ops",
   "executorch",
-  "executorch_no_prim_ops",
+  "executorch_core",
   "extension_data_loader",
   "extension_module",
   "portable_kernels",

--- a/build/executorch-config.cmake
+++ b/build/executorch-config.cmake
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.19)
 
 set(_root "${CMAKE_CURRENT_LIST_DIR}/../..")
-set(required_lib_list executorch executorch_no_prim_ops portable_kernels)
+set(required_lib_list executorch executorch_core portable_kernels)
 foreach(lib ${required_lib_list})
   set(lib_var "LIB_${lib}")
   add_library(${lib} STATIC IMPORTED)
@@ -26,7 +26,7 @@ foreach(lib ${required_lib_list})
   target_include_directories(${lib} INTERFACE ${_root})
 endforeach()
 
-target_link_libraries(executorch INTERFACE executorch_no_prim_ops)
+target_link_libraries(executorch INTERFACE executorch_core)
 
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(FLATCCRT_LIB flatccrt_d)

--- a/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.pbxproj
+++ b/examples/apple/coreml/executor_runner/coreml_executor_runner.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		C97BFFA42BC0C17300F55BAC /* libportable_kernels.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C97BFFA32BC0C17300F55BAC /* libportable_kernels.a */; };
 		C97BFFA62BC0C1F200F55BAC /* libportable_ops_lib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C97BFFA52BC0C1F200F55BAC /* libportable_ops_lib.a */; };
 		C988D69D2B998CDE00979CF6 /* libprotobuf-lite.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C988D69C2B998CD700979CF6 /* libprotobuf-lite.a */; };
-		F24817E72BC65B2000E80D98 /* libexecutorch_no_prim_ops.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F24817E62BC65B2000E80D98 /* libexecutorch_no_prim_ops.a */; };
+		F24817E72BC65B2000E80D98 /* libexecutorch_core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F24817E62BC65B2000E80D98 /* libexecutorch_core.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -46,7 +46,7 @@
 		C97BFFA32BC0C17300F55BAC /* libportable_kernels.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libportable_kernels.a; path = libraries/libportable_kernels.a; sourceTree = "<group>"; };
 		C97BFFA52BC0C1F200F55BAC /* libportable_ops_lib.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libportable_ops_lib.a; path = libraries/libportable_ops_lib.a; sourceTree = "<group>"; };
 		C988D69C2B998CD700979CF6 /* libprotobuf-lite.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libprotobuf-lite.a"; path = "libraries/libprotobuf-lite.a"; sourceTree = "<group>"; };
-		F24817E62BC65B2000E80D98 /* libexecutorch_no_prim_ops.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libexecutorch_no_prim_ops.a; path = libraries/libexecutorch_no_prim_ops.a; sourceTree = "<group>"; };
+		F24817E62BC65B2000E80D98 /* libexecutorch_core.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libexecutorch_core.a; path = libraries/libexecutorch_core.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,7 +55,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				38626BB52B225A890059413D /* libetdump.a in Frameworks */,
-				F24817E72BC65B2000E80D98 /* libexecutorch_no_prim_ops.a in Frameworks */,
+				F24817E72BC65B2000E80D98 /* libexecutorch_core.a in Frameworks */,
 				38626BB42B225A560059413D /* libflatccrt.a in Frameworks */,
 				C94D51682ACFCC7100AF47FD /* libcoremldelegate.a in Frameworks */,
 				C94D51662ACFCBCB00AF47FD /* Accelerate.framework in Frameworks */,
@@ -99,7 +99,7 @@
 				C94D515C2ACFCBA000AF47FD /* libexecutorch.a */,
 				C94D51612ACFCBBA00AF47FD /* libsqlite3.tbd */,
 				C94D51672ACFCC7100AF47FD /* libcoremldelegate.a */,
-				F24817E62BC65B2000E80D98 /* libexecutorch_no_prim_ops.a */,
+				F24817E62BC65B2000E80D98 /* libexecutorch_core.a */,
 				C97BFFA32BC0C17300F55BAC /* libportable_kernels.a */,
 				C97BFFA52BC0C1F200F55BAC /* libportable_ops_lib.a */,
 			);

--- a/examples/apple/coreml/scripts/build_executor_runner.sh
+++ b/examples/apple/coreml/scripts/build_executor_runner.sh
@@ -63,7 +63,7 @@ cp -rf "$COREML_DIR_PATH/runtime/include/" "$INCLUDE_DIR_PATH"
 echo "ExecuTorch: Copying libraries"
 mkdir "$LIBRARIES_DIR_PATH"
 find "$CMAKE_BUILD_DIR_PATH/" -name 'libexecutorch.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libexecutorch.a"  \;
-find "$CMAKE_BUILD_DIR_PATH/" -name 'libexecutorch_no_prim_ops.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libexecutorch_no_prim_ops.a"  \;
+find "$CMAKE_BUILD_DIR_PATH/" -name 'libexecutorch_core.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libexecutorch_core.a"  \;
 find "$CMAKE_BUILD_DIR_PATH/" -name 'libprotobuf-lite.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libprotobuf-lite.a"  \;
 find "$CMAKE_BUILD_DIR_PATH/" -name 'libprotobuf-lited.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libprotobuf-lite.a"  \;
 find "$CMAKE_BUILD_DIR_PATH/" -name 'libetdump.a' -exec cp -f "{}" "$LIBRARIES_DIR_PATH/libetdump.a"  \;

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -67,12 +67,12 @@ set_property(
                              "${ET_BUILD_DIR_PATH}/libexecutorch.a"
 )
 
-add_library(executorch_no_prim_ops STATIC IMPORTED)
+add_library(executorch_core STATIC IMPORTED)
 set_property(
-  TARGET executorch_no_prim_ops
-  PROPERTY IMPORTED_LOCATION "${ET_BUILD_DIR_PATH}/libexecutorch_no_prim_ops.a"
+  TARGET executorch_core
+  PROPERTY IMPORTED_LOCATION "${ET_BUILD_DIR_PATH}/libexecutorch_core.a"
 )
-target_link_libraries(executorch INTERFACE executorch_no_prim_ops)
+target_link_libraries(executorch INTERFACE executorch_core)
 
 add_library(executorch_delegate_ethos_u STATIC IMPORTED)
 set_property(

--- a/examples/qualcomm/qaihub_scripts/llama/CMakeLists.txt
+++ b/examples/qualcomm/qaihub_scripts/llama/CMakeLists.txt
@@ -32,7 +32,7 @@ target_include_directories(
 target_link_libraries(
   qaihub_llama2_7b_runner
   qnn_executorch_backend
-  executorch_no_prim_ops
+  executorch_core
   extension_data_loader
   extension_module
   extension_tensor
@@ -90,7 +90,7 @@ target_include_directories(
 target_link_libraries(
   qaihub_llama3_8b_runner
   qnn_executorch_backend
-  executorch_no_prim_ops
+  executorch_core
   extension_data_loader
   extension_module
   extension_tensor

--- a/examples/qualcomm/qaihub_scripts/stable_diffusion/CMakeLists.txt
+++ b/examples/qualcomm/qaihub_scripts/stable_diffusion/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(
 target_link_libraries(
   qaihub_stable_diffusion_runner
   qnn_executorch_backend
-  executorch_no_prim_ops
+  executorch_core
   extension_data_loader
   extension_module
   extension_tensor

--- a/exir/backend/test/demos/rpc/CMakeLists.txt
+++ b/exir/backend/test/demos/rpc/CMakeLists.txt
@@ -29,7 +29,7 @@ set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 add_library(
   executor_backend STATIC ExecutorBackendRegister.cpp ExecutorBackend.cpp
 )
-target_link_libraries(executor_backend PRIVATE executorch_no_prim_ops)
+target_link_libraries(executor_backend PRIVATE executorch_core)
 
 target_include_directories(
   executor_backend PUBLIC ${_common_include_directories}

--- a/extension/llm/custom_ops/CMakeLists.txt
+++ b/extension/llm/custom_ops/CMakeLists.txt
@@ -60,7 +60,7 @@ target_include_directories(
   custom_ops PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../../../include"
 )
 target_link_libraries(
-  custom_ops PUBLIC ${custom_ops_libs} executorch_no_prim_ops
+  custom_ops PUBLIC ${custom_ops_libs} executorch_core
 )
 
 target_compile_options(
@@ -90,7 +90,7 @@ if(EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT)
   else()
     # If no portable_lib, custom_ops_aot_lib still gives the ability to use the
     # ops in PyTorch
-    target_link_libraries(custom_ops_aot_lib PUBLIC executorch_no_prim_ops)
+    target_link_libraries(custom_ops_aot_lib PUBLIC executorch_core)
   endif()
 
   target_link_libraries(

--- a/extension/tensor/CMakeLists.txt
+++ b/extension/tensor/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 list(TRANSFORM _extension_tensor__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(extension_tensor ${_extension_tensor__srcs})
-target_link_libraries(extension_tensor executorch_no_prim_ops)
+target_link_libraries(extension_tensor executorch_core)
 target_include_directories(extension_tensor PUBLIC ${EXECUTORCH_ROOT}/..)
 target_compile_options(extension_tensor PUBLIC ${_common_compile_options})
 

--- a/extension/threadpool/CMakeLists.txt
+++ b/extension/threadpool/CMakeLists.txt
@@ -24,7 +24,7 @@ add_library(
   extension_threadpool threadpool.cpp threadpool_guard.cpp cpuinfo_utils.cpp
 )
 target_link_libraries(
-  extension_threadpool PUBLIC executorch_no_prim_ops cpuinfo pthreadpool
+  extension_threadpool PUBLIC executorch_core cpuinfo pthreadpool
 )
 target_include_directories(extension_threadpool PUBLIC ${EXECUTORCH_ROOT}/..)
 target_include_directories(

--- a/kernels/optimized/CMakeLists.txt
+++ b/kernels/optimized/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 list(TRANSFORM _optimized_cpublas__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(cpublas STATIC ${_optimized_cpublas__srcs})
 target_link_libraries(
-  cpublas PRIVATE executorch_no_prim_ops eigen_blas extension_threadpool
+  cpublas PRIVATE executorch_core eigen_blas extension_threadpool
 )
 target_compile_options(cpublas PUBLIC ${_common_compile_options})
 
@@ -61,7 +61,7 @@ message("Generated files ${gen_command_sources}")
 list(TRANSFORM _optimized_kernels__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(optimized_kernels ${_optimized_kernels__srcs})
 target_link_libraries(
-  optimized_kernels PRIVATE executorch_no_prim_ops cpublas extension_threadpool
+  optimized_kernels PRIVATE executorch_core cpublas extension_threadpool
 )
 target_compile_options(optimized_kernels PUBLIC ${_common_compile_options})
 # Build a library for _optimized_kernels_srcs


### PR DESCRIPTION
Manually cherry-picked to resolve a merge conflict (training extension CMake build not present on release branch?).

Original PR: https://github.com/pytorch/executorch/pull/5740