### PR TITLE
[5/n][ET-VK] Enable `uint8` dtype in shaders

### DIFF
--- a/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.cpp
@@ -47,6 +47,10 @@ void add_dtype_suffix(std::string& kernel_name, const vkapi::ScalarType dtype) {
     case vkapi::kQInt8:
       kernel_name += "_int8";
       break;
+    case vkapi::kByte:
+    case vkapi::kQUInt8:
+      kernel_name += "_uint8";
+      break;
     default:
       break;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5934
* #5933
* #5879
* __->__ #5932

TSIA

Differential Revision: [D63918660](https://our.internmc.facebook.com/intern/diff/D63918660/)