### PR TITLE
Migrate backends/apple/coreml to the new namespace

### DIFF
--- a/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
@@ -25,8 +25,21 @@
 #endif
 
 namespace {
-using namespace torch::executor;
 using namespace executorchcoreml;
+
+using executorch::aten::ScalarType;
+using executorch::runtime::ArrayRef;
+using executorch::runtime::Backend;
+using executorch::runtime::BackendExecutionContext;
+using executorch::runtime::BackendInitContext;
+using executorch::runtime::CompileSpec;
+using executorch::runtime::DelegateHandle;
+using executorch::runtime::EValue;
+using executorch::runtime::Error;
+using executorch::runtime::EventTracerDebugLogLevel;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::get_backend_class;
+using executorch::runtime::Result;
 
 std::optional<MultiArray::DataType> get_data_type(ScalarType scalar_type) {
     switch (scalar_type) {
@@ -60,14 +73,14 @@ std::optional<MultiArray> get_multi_array(EValue *eValue, ArgType argType) {
     if (!eValue->isTensor()) {
         return std::nullopt;
     }
-    
+
     auto tensor = eValue->toTensor();
     auto dataType = get_data_type(tensor.scalar_type());
     if (!dataType.has_value()) {
         ET_LOG(Error, "%s: DataType=%d is not supported", ETCoreMLStrings.delegateIdentifier.UTF8String, (int)tensor.scalar_type());
         return std::nullopt;
     }
-    
+
     std::vector<ssize_t> strides(tensor.strides().begin(), tensor.strides().end());
     std::vector<size_t> shape(tensor.sizes().begin(), tensor.sizes().end());
     MultiArray::MemoryLayout layout(dataType.value(), std::move(shape), std::move(strides));
@@ -86,7 +99,7 @@ std::optional<BackendDelegate::Config> parse_config(NSURL *plistURL) {
     if (!dict) {
         return std::nullopt;
     }
-    
+
     BackendDelegate::Config config;
     {
         NSNumber *should_prewarm_model = SAFE_CAST(dict[@"shouldPrewarmModel"], NSNumber);
@@ -94,21 +107,21 @@ std::optional<BackendDelegate::Config> parse_config(NSURL *plistURL) {
             config.should_prewarm_model = static_cast<bool>(should_prewarm_model.boolValue);
         }
     }
-    
+
     {
         NSNumber *should_prewarm_asset = SAFE_CAST(dict[@"shouldPrewarmAsset"], NSNumber);
         if (should_prewarm_asset) {
             config.should_prewarm_asset = static_cast<bool>(should_prewarm_asset.boolValue);
         }
     }
-    
+
     {
         NSNumber *max_models_cache_size_in_bytes = SAFE_CAST(dict[@"maxModelsCacheSizeInBytes"], NSNumber);
         if (max_models_cache_size_in_bytes) {
             config.max_models_cache_size = max_models_cache_size_in_bytes.unsignedLongLongValue;
         }
     }
-    
+
     return config;
 }
 
@@ -127,14 +140,15 @@ ModelLoggingOptions get_logging_options(BackendExecutionContext& context) {
         auto debug_level = event_tracer->event_tracer_debug_level();
         options.log_intermediate_tensors = (debug_level >= EventTracerDebugLogLevel::kIntermediateOutputs);
     }
-    
+
     return options;
 }
 
 } //namespace
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
+namespace coreml {
 
 using namespace executorchcoreml;
 
@@ -154,7 +168,7 @@ CoreMLBackendDelegate::init(BackendInitContext& context,
         auto buffer = Buffer(spec.value.buffer, spec.value.nbytes);
         specs_map.emplace(spec.key, std::move(buffer));
     }
-    
+
     auto buffer = Buffer(processed->data(), processed->size());
     std::error_code error;
     auto handle = impl_->init(std::move(buffer), specs_map);
@@ -173,7 +187,7 @@ Error CoreMLBackendDelegate::execute(BackendExecutionContext& context,
     size_t nInputs = nArgs.first;
     size_t nOutputs = nArgs.second;
     delegate_args.reserve(nInputs + nOutputs);
-    
+
     // inputs
     for (size_t i = 0; i < nInputs; i++) {
         auto multi_array = get_multi_array(args[i], ArgType::Input);
@@ -182,7 +196,7 @@ Error CoreMLBackendDelegate::execute(BackendExecutionContext& context,
                                  "%s: Failed to create multiarray from input at args[%zu]", ETCoreMLStrings.delegateIdentifier.UTF8String, i);
         delegate_args.emplace_back(std::move(multi_array.value()));
     }
-    
+
     // outputs
     for (size_t i = nInputs; i < nInputs + nOutputs; i++) {
         auto multi_array = get_multi_array(args[i], ArgType::Output);
@@ -191,7 +205,7 @@ Error CoreMLBackendDelegate::execute(BackendExecutionContext& context,
                                  "%s: Failed to create multiarray from output at args[%zu]", ETCoreMLStrings.delegateIdentifier.UTF8String, i);
         delegate_args.emplace_back(std::move(multi_array.value()));
     }
-    
+
     auto logging_options = get_logging_options(context);
     std::error_code ec;
 #ifdef ET_EVENT_TRACER_ENABLED
@@ -206,7 +220,7 @@ Error CoreMLBackendDelegate::execute(BackendExecutionContext& context,
                              "%s: Failed to run the model.",
                              ETCoreMLStrings.delegateIdentifier.UTF8String);
 #endif
-    
+
     return Error::Ok;
 }
 
@@ -235,5 +249,6 @@ Backend backend{ETCoreMLStrings.delegateIdentifier.UTF8String, &cls};
 static auto success_with_compiler = register_backend(backend);
 }
 
-} // namespace executor
-} // namespace torch
+} // namespace coreml
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/coreml/runtime/include/coreml_backend/delegate.h
+++ b/backends/apple/coreml/runtime/include/coreml_backend/delegate.h
@@ -17,8 +17,9 @@ namespace executorchcoreml {
 class BackendDelegate;
 }
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
+namespace coreml {
 
 class CoreMLBackendDelegate final : public ::executorch::runtime::BackendInterface {
 public:
@@ -34,8 +35,10 @@ public:
     /// produce `processed`.
     /// @retval On success, an opaque handle representing the loaded model
     /// otherwise  an`Error` case.
-    Result<DelegateHandle*>
-    init(BackendInitContext& context, FreeableBuffer* processed, ArrayRef<CompileSpec> compileSpecs) const override;
+    executorch::runtime::Result<executorch::runtime::DelegateHandle*>
+    init(executorch::runtime::BackendInitContext& context,
+         executorch::runtime::FreeableBuffer* processed,
+         executorch::runtime::ArrayRef<executorch::runtime::CompileSpec> compileSpecs) const override;
 
     /// Executes the loaded model.
     ///
@@ -43,7 +46,9 @@ public:
     /// @param handle The handle returned by an earlier call to `init`.
     /// @param args The models inputs and outputs.
     /// @retval On success, `Error::Ok` otherwise any other `Error` case.
-    Error execute(BackendExecutionContext& context, DelegateHandle* handle, EValue** args) const override;
+    executorch::runtime::Error execute(executorch::runtime::BackendExecutionContext& context,
+                                       executorch::runtime::DelegateHandle* handle,
+                                       executorch::runtime::EValue** args) const override;
 
     /// Returns `true` if the delegate is available otherwise `false`.
     bool is_available() const override;
@@ -51,7 +56,7 @@ public:
     /// Unloads the loaded CoreML model with the  specified handle.
     ///
     /// @param handle The handle returned by an earlier call to `init`.
-    void destroy(DelegateHandle* handle) const override;
+    void destroy(executorch::runtime::DelegateHandle* handle) const override;
 
     /// Returns the registered `CoreMLBackendDelegate` instance.
     static CoreMLBackendDelegate* get_registered_delegate() noexcept;
@@ -65,5 +70,7 @@ public:
 private:
     std::shared_ptr<executorchcoreml::BackendDelegate> impl_;
 };
-} // namespace executor
-} // namespace torch
+
+} // namespace coreml
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/coreml/runtime/test/BackendDelegateTests.mm
+++ b/backends/apple/coreml/runtime/test/BackendDelegateTests.mm
@@ -60,7 +60,7 @@ std::vector<MultiArray> to_multiarrays(NSArray<MLMultiArray *> *ml_multiarrays) 
 }
 
 + (void)setUp {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
 }
 
 - (void)setUp {

--- a/backends/apple/coreml/runtime/test/CoreMLBackendDelegateTests.mm
+++ b/backends/apple/coreml/runtime/test/CoreMLBackendDelegateTests.mm
@@ -17,8 +17,8 @@
 
 static constexpr size_t kRuntimeMemorySize = 50 * 1024U * 1024U; // 50 MB
 
-using namespace torch::executor;
-using torch::executor::testing::TensorFactory;
+using namespace executorch::runtime;
+using executorch::runtime::testing::TensorFactory;
 
 namespace {
 // TODO: Move the following methods to a utility class, so that it can be shared with `executor_runner.main.mm`
@@ -107,8 +107,8 @@ Result<std::vector<Buffer>> prepare_input_tensors(Method& method) {
          }
          Buffer buffer(tensor_meta->nbytes(), 0);
          auto sizes = tensor_meta->sizes();
-         exec_aten::TensorImpl tensor_impl(tensor_meta->scalar_type(), std::size(sizes), const_cast<int *>(sizes.data()), buffer.data());
-         exec_aten::Tensor tensor(&tensor_impl);
+         executorch::aten::TensorImpl tensor_impl(tensor_meta->scalar_type(), std::size(sizes), const_cast<int *>(sizes.data()), buffer.data());
+         executorch::aten::Tensor tensor(&tensor_impl);
          EValue input_value(std::move(tensor));
          Error err = method.set_input(input_value, i);
          if (err != Error::Ok) {
@@ -129,7 +129,7 @@ Result<std::vector<Buffer>> prepare_input_tensors(Method& method) {
 @implementation CoreMLBackendDelegateTests
 
 + (void)setUp {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
 }
 
 + (nullable NSURL *)bundledResourceWithName:(NSString *)name extension:(NSString *)extension {

--- a/backends/apple/coreml/runtime/test/ETCoreMLAssetManagerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLAssetManagerTests.mm
@@ -23,7 +23,7 @@
 @implementation ETCoreMLAssetManagerTests
 
 + (void)setUp {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
 }
 
 - (void)setUp {

--- a/backends/apple/coreml/runtime/test/ETCoreMLModelDebuggerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLModelDebuggerTests.mm
@@ -70,7 +70,7 @@ void add_debugging_result(NSDictionary<ETCoreMLModelStructurePath *, MLMultiArra
 @implementation ETCoreMLModelDebuggerTests
 
 + (void)setUp {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
 }
 
 + (nullable NSURL *)bundledResourceWithName:(NSString *)name extension:(NSString *)extension {

--- a/backends/apple/coreml/runtime/test/ETCoreMLModelManagerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLModelManagerTests.mm
@@ -32,7 +32,7 @@
 }
 
 - (void)setUp {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
     @autoreleasepool {
         NSError *localError = nil;
         self.fileManager = [[NSFileManager alloc] init];

--- a/backends/apple/coreml/runtime/test/ETCoreMLModelProfilerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLModelProfilerTests.mm
@@ -59,7 +59,7 @@ ETCoreMLModelStructurePath *make_path_with_output_name(const std::string& output
 @implementation ETCoreMLModelProfilerTests
 
 + (void)setUp {
-    torch::executor::runtime_init();
+    executorch::runtime::runtime_init();
 }
 
 + (nullable NSURL *)bundledResourceWithName:(NSString *)name extension:(NSString *)extension {

--- a/examples/apple/coreml/executor_runner/main.mm
+++ b/examples/apple/coreml/executor_runner/main.mm
@@ -24,12 +24,13 @@ static inline id check_class(id obj, Class cls) {
 
 #define SAFE_CAST(Object, Type) ((Type *)check_class(Object, [Type class]))
 
+using executorch::backends::coreml::CoreMLBackendDelegate;
 using executorch::etdump::ETDumpGen;
 using executorch::etdump::ETDumpResult;
 using executorch::extension::FileDataLoader;
 using executorch::runtime::DataLoader;
-using executorch::runtime::EValue;
 using executorch::runtime::Error;
+using executorch::runtime::EValue;
 using executorch::runtime::EventTracer;
 using executorch::runtime::EventTracerDebugLogLevel;
 using executorch::runtime::FreeableBuffer;
@@ -42,7 +43,6 @@ using executorch::runtime::Program;
 using executorch::runtime::Result;
 using executorch::runtime::Span;
 using executorch::runtime::TensorInfo;
-using torch::executor::CoreMLBackendDelegate;
 
 static constexpr size_t kRuntimeMemorySize = 16 * 1024U * 1024U; // 16 MB
 


### PR DESCRIPTION
Summary: Move the Core ML backend out of the `torch::` namespace, and update to avoid using the `torch::` or `exec_aten::` namespaces.

Differential Revision: D63995558


