### PR TITLE
Migrate backends/mediatek to the new namespace

### DIFF
--- a/backends/mediatek/runtime/NeuronBackend.cpp
+++ b/backends/mediatek/runtime/NeuronBackend.cpp
@@ -19,8 +19,20 @@
 #include <new>
 #include <unordered_set>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
+namespace neuron {
+
+using executorch::runtime::ArrayRef;
+using executorch::runtime::BackendExecutionContext;
+using executorch::runtime::BackendInitContext;
+using executorch::runtime::CompileSpec;
+using executorch::runtime::DelegateHandle;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::MemoryAllocator;
+using executorch::runtime::Result;
 
 const char kHighAddrKey[] = "HighAddr";
 const char kImportForeverKey[] = "ImportForever";
@@ -94,8 +106,8 @@ Error NeuronExecuTorchDelegate::execute(
     return Error::InvalidState;
   };
 
-  auto allocator =
-      dynamic_cast<neuron::BufferAllocator*>(context.get_temp_allocator());
+  auto allocator = dynamic_cast<torch::executor::neuron::BufferAllocator*>(
+      context.get_temp_allocator());
   size_t inputCount = mInputSizes.size(), outputCount = mOutputSizes.size();
 
   for (int i = 0; i < inputCount; i++) {
@@ -175,11 +187,13 @@ int NeuronExecuTorchDelegate::HintNeuronBackend(EValue** args) const {
   return NEURON_NO_ERROR;
 }
 
-} // namespace executor
-} // namespace torch
+} // namespace neuron
+} // namespace backends
+} // namespace executorch
 
 namespace {
-auto cls = torch::executor::NeuronBackend();
-torch::executor::Backend backend{"NeuropilotBackend", &cls};
-static auto success_with_compiler = register_backend(backend);
+auto cls = executorch::backends::neuron::NeuronBackend();
+executorch::runtime::Backend backend{"NeuropilotBackend", &cls};
+static auto success_with_compiler =
+    executorch::runtime::register_backend(backend);
 } // namespace

--- a/backends/mediatek/runtime/NeuronExecutor.cpp
+++ b/backends/mediatek/runtime/NeuronExecutor.cpp
@@ -17,8 +17,8 @@
 #define RESTORE_DLA_EXTENSION_OPERATION_TYPE 0x0000
 #define RESTORE_DLA_EXTENSION_NAME "com.mediatek.compiled_network"
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace neuron {
 
 NeuronExecutor::NeuronExecutor(){};
@@ -164,5 +164,5 @@ int NeuronExecutor::LoadFromCompiledNetwork(
 }
 
 } // namespace neuron
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/mediatek/runtime/include/NeuronBackend.h
+++ b/backends/mediatek/runtime/include/NeuronBackend.h
@@ -23,22 +23,24 @@
 #include <unordered_map>
 #include <unordered_set>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
+namespace neuron {
 
 class NeuronBackend final : public ::executorch::runtime::BackendInterface {
  public:
-  Result<DelegateHandle*> init(
-      BackendInitContext& context,
-      FreeableBuffer* processed,
-      ArrayRef<CompileSpec> compile_specs) const override;
+  ::executorch::runtime::Result<::executorch::runtime::DelegateHandle*> init(
+      ::executorch::runtime::BackendInitContext& context,
+      ::executorch::runtime::FreeableBuffer* processed,
+      ::executorch::runtime::ArrayRef<::executorch::runtime::CompileSpec>
+          compile_specs) const override;
 
-  Error execute(
-      ET_UNUSED BackendExecutionContext& context,
-      DelegateHandle* handle,
-      EValue** args) const override;
+  ::executorch::runtime::Error execute(
+      ET_UNUSED ::executorch::runtime::BackendExecutionContext& context,
+      ::executorch::runtime::DelegateHandle* handle,
+      ::executorch::runtime::EValue** args) const override;
 
-  void destroy(DelegateHandle* handle) const override;
+  void destroy(::executorch::runtime::DelegateHandle* handle) const override;
 
   bool is_available() const override;
 };
@@ -111,8 +113,9 @@ class NeuronExecuTorchDelegate {
     return NEURON_NO_ERROR;
   }
 
-  Error execute(ET_UNUSED BackendExecutionContext& context, EValue** args)
-      const;
+  ::executorch::runtime::Error execute(
+      ET_UNUSED ::executorch::runtime::BackendExecutionContext& context,
+      ::executorch::runtime::EValue** args) const;
 
  private:
   template <bool isInput>
@@ -145,7 +148,7 @@ class NeuronExecuTorchDelegate {
     return NEURON_NO_ERROR;
   }
 
-  int HintNeuronBackend(EValue** args) const;
+  int HintNeuronBackend(::executorch::runtime::EValue** args) const;
 
  private:
   std::vector<size_t> mInputSizes;
@@ -168,5 +171,6 @@ class NeuronExecuTorchDelegate {
   NeuronExecuTorchDelegate operator=(const NeuronExecuTorchDelegate&);
 };
 
-} // namespace executor
-} // namespace torch
+} // namespace neuron
+} // namespace backends
+} // namespace executorch

--- a/backends/mediatek/runtime/include/NeuronBufferAllocator.h
+++ b/backends/mediatek/runtime/include/NeuronBufferAllocator.h
@@ -24,6 +24,8 @@
 #define GET_NEURON_ALLOCATOR \
   ::torch::executor::neuron::BufferAllocator::GetInstance()
 
+// TODO: Move this code to the executorch::backends::neuron namespace.
+// The torch:: namespace is deprecated for ExecuTorch code.
 namespace torch {
 namespace executor {
 namespace neuron {
@@ -82,7 +84,9 @@ class MemoryUnit {
     NeuronMemory* memory = nullptr;
     NeuronMemory_createFromAHardwareBuffer(Abuffer, &memory);
     CHECK_VALID_PTR(memory);
-    mNeuronMemory = std::unique_ptr<NeuronMemory, NeuronDeleter>(memory);
+    mNeuronMemory = std::
+        unique_ptr<NeuronMemory, executorch::backends::neuron::NeuronDeleter>(
+            memory);
 
     AHardwareBuffer_lock(Abuffer, mAhwbType, -1, nullptr, &mAddress);
     CHECK_VALID_PTR(mAddress);
@@ -90,7 +94,8 @@ class MemoryUnit {
   }
 
  private:
-  std::unique_ptr<NeuronMemory, NeuronDeleter> mNeuronMemory;
+  std::unique_ptr<NeuronMemory, executorch::backends::neuron::NeuronDeleter>
+      mNeuronMemory;
 
   std::unique_ptr<AHardwareBuffer, BufferDeleter> mAhwb;
 
@@ -102,7 +107,7 @@ class MemoryUnit {
   size_t mSize = 0;
 };
 
-class BufferAllocator : public MemoryAllocator {
+class BufferAllocator : public executorch::runtime::MemoryAllocator {
  public:
   static BufferAllocator& GetInstance();
 
@@ -119,7 +124,7 @@ class BufferAllocator : public MemoryAllocator {
   void Clear();
 
  private:
-  BufferAllocator() : MemoryAllocator(0, nullptr) {}
+  BufferAllocator() : executorch::runtime::MemoryAllocator(0, nullptr) {}
 
   BufferAllocator(const BufferAllocator&) = delete;
 

--- a/backends/mediatek/runtime/include/NeuronExecutor.h
+++ b/backends/mediatek/runtime/include/NeuronExecutor.h
@@ -18,8 +18,8 @@
 #include <string>
 #include <vector>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace neuron {
 
 struct NeuronDeleter {
@@ -119,5 +119,5 @@ class NeuronExecutor {
 };
 
 } // namespace neuron
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/mediatek/runtime/include/NeuronLog.h
+++ b/backends/mediatek/runtime/include/NeuronLog.h
@@ -16,8 +16,8 @@
 #include <cstdlib>
 #include <string>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace neuron {
 
 #define AndroidLog(priority, tag, format, ...) \
@@ -83,5 +83,5 @@ inline int ReadSystemProperty(std::string& property) {
 }
 
 } // namespace neuron
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch


### PR DESCRIPTION
Summary: Move the mediatek backend out of the torch:: namespace, and update to avoid using the torch:: or exec_aten:: namespaces.

Differential Revision: D63928380


