### PR TITLE
Support selector for functions.yaml and custom_ops.yaml targets in et_operator_library

### DIFF
--- a/shim/xplat/executorch/codegen/codegen.bzl
+++ b/shim/xplat/executorch/codegen/codegen.bzl
@@ -1,4 +1,5 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "get_default_executorch_platforms", "is_xplat", "runtime", "struct_to_json")
+load("@fbsource//xplat/executorch/build:selects.bzl", "selects")
 load("@fbsource//xplat/executorch/kernels/portable:op_registration_util.bzl", "portable_header_list", "portable_source_list")
 
 # Headers that declare the function signatures of the C++ functions that
@@ -261,8 +262,13 @@ def _prepare_custom_ops_genrule_and_lib(
             "headers": [],
             "srcs": custom_ops_sources,
         }
+        my_cmd = ""
+        for rule_substr in genrule_cmd:
+            if my_cmd != "":
+                my_cmd += " "
+            my_cmd += rule_substr
         genrules[genrule_name] = {
-            "cmd": " ".join(genrule_cmd),
+            "cmd": my_cmd,
             "outs": {out: [out] for out in CUSTOM_OPS_NATIVE_FUNCTION_HEADER + custom_ops_sources},
         }
     return genrules, libs
@@ -294,7 +300,7 @@ def exir_custom_ops_aot_lib(
     """
     genrules, libs = _prepare_custom_ops_genrule_and_lib(
         name = name,
-        custom_ops_yaml_path = "$(location {})".format(yaml_target),
+        custom_ops_yaml_path = selects.apply(yaml_target, lambda y: "$(location {})".format(y)),
         kernels = kernels,
         deps = deps,
     )
@@ -495,9 +501,8 @@ def executorch_generated_lib(
     # merge functions.yaml with fallback yaml
     if functions_yaml_target:
         merge_yaml_name = name + "_merge_yaml"
-        cmd = ("$(exe fbsource//xplat/executorch/codegen/tools:merge_yaml) " +
-               "--functions_yaml_path=$(location {}) ".format(functions_yaml_target) +
-               "--output_dir=$OUT ")
+        cmd = selects.apply(functions_yaml_target, lambda value: "$(exe fbsource//xplat/executorch/codegen/tools:merge_yaml) " +
+                                                                 "--functions_yaml_path=$(location {}) --output_dir=$OUT ".format(value))
         if fallback_yaml_target:
             cmd = cmd + "--fallback_yaml_path=$(location {}) ".format(fallback_yaml_target)
         runtime.genrule(
@@ -512,7 +517,7 @@ def executorch_generated_lib(
     else:
         functions_yaml_path = None
     if custom_ops_yaml_target:
-        custom_ops_yaml_path = "$(location {})".format(custom_ops_yaml_target)
+        custom_ops_yaml_path = selects.apply(custom_ops_yaml_target, lambda value: "$(location {})".format(value))
     else:
         custom_ops_yaml_path = None
 
@@ -559,9 +564,14 @@ def executorch_generated_lib(
         genrules[genrule_name]["cmd"].append(
             "--op_selection_yaml_path=$(location :{}[selected_operators.yaml])".format(oplist_dir_name),
         )
+        my_cmd = ""
+        for rule_substr in genrules[genrule_name]["cmd"]:
+            if my_cmd != "":
+                my_cmd += " "
+            my_cmd += rule_substr
         runtime.genrule(
             name = genrule_name,
-            cmd = " ".join(genrules[genrule_name]["cmd"]),
+            cmd = my_cmd,
             outs = {f: [f] for f in genrules[genrule_name]["outs"]},
             default_outs = ["."],
             platforms = platforms,


### PR DESCRIPTION
Summary:
executorch_generated_library accepts

	
        functions_yaml_target: A Buck target pointing to the `functions.yaml`
            file to use. Optional, but at least one of `functions_yaml_target`
            and `custom_ops_yaml_target` must be specified.

        custom_ops_yaml_target: A Buck target pointing to the `custom_ops.yaml`
            file to use. Optional, but at least one of `functions_yaml_target`
            and `custom_ops_yaml_target` must be specified.

However the rule expects these targets to be the string of the exact target "//xplat/..../functions_yaml:functions.yaml"
and had issues with the parameter being of type 'selector'
select({"//arvr:my_constraint": "//xplat/..../functions_yaml:functions.yaml", ....})

Selectively providing this target based off of config/constraint can be helpful, and it seems like the limitation was the formatting done on the strings prior to calling genrules inside of the rule.

What this enables:
Building the same et_operator_library target while specifying the functions.yaml and custom_ops.yaml targets as a function of a constraint, like processor type.

Example: D64004596

Reviewed By: larryliu0820

Differential Revision: D63043331


