### PR TITLE
filter gif from lint rules

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -180,6 +180,7 @@ exclude_patterns = [
     '**/*.bat',
     '**/*.jpg',
     '**/*.jar',
+    '**/*.gif',
     # File contains @generated
     'extension/llm/custom_ops/spinquant/fast_hadamard_transform_special.h',
     'extension/llm/custom_ops/spinquant/test/fast_hadamard_transform_special_unstrided_cpu.h',


### PR DESCRIPTION
Summary:
when running `lintrunner -a`, it shows
```
(executorch) chenlai@chenlai-mbp executorch % lintrunner -a
Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.
  UFMT success!
  CLANGFORMAT success!
  FLAKE8 success!
  NEWLINE failure
  CMAKE success!
  ETCAPITAL success!


>>> Lint for examples/models/llama2/Android3_2_1B_bf16.gif:

  Error (NEWLINE) Decoding failure
    utf-8 decoding failed due to UnicodeDecodeError:
    'utf-8' codec can't decode byte 0xf7 in position 10: invalid start byte


>>> Lint for examples/models/llama2/Android3_2_3B_SpinQuant.gif:

  Error (NEWLINE) Decoding failure
    utf-8 decoding failed due to UnicodeDecodeError:
    'utf-8' codec can't decode byte 0xf7 in position 10: invalid start byte


>>> Lint for examples/models/llama2/llama_via_xnnpack.gif:

  Error (NEWLINE) Decoding failure
    utf-8 decoding failed due to UnicodeDecodeError:
    'utf-8' codec can't decode byte 0xf7 in position 10: invalid start byte


>>> Lint for examples/models/llava/llava_via_xnnpack.gif:

  Error (NEWLINE) Decoding failure
    utf-8 decoding failed due to UnicodeDecodeError:
    'utf-8' codec can't decode byte 0xd0 in position 6: invalid continuation
    byte
Successfully applied all patches.
```
Thanks kirklandsign for identifying the root cause!

Differential Revision: D64059251


