### PR TITLE
add missing namespace of getLeadingDims in hifi

### DIFF
--- a/backends/cadence/hifi/operators/quantized_layer_norm.cpp
+++ b/backends/cadence/hifi/operators/quantized_layer_norm.cpp
@@ -13,6 +13,7 @@
 #include <tuple>
 
 using executorch::aten::Tensor;
+using executorch::runtime::getLeadingDims;
 using executorch::runtime::KernelRuntimeContext;
 
 namespace impl {

--- a/backends/cadence/hifi/operators/quantized_linear_out.cpp
+++ b/backends/cadence/hifi/operators/quantized_linear_out.cpp
@@ -16,6 +16,7 @@ namespace HiFi {
 namespace native {
 
 using executorch::aten::Tensor;
+using executorch::runtime::getLeadingDims;
 using executorch::runtime::KernelRuntimeContext;
 
 void quantized_linear_out(


### PR DESCRIPTION
Summary: ~

Differential Revision: D64063692


