### PR TITLE
[ET][Portable][Build Size] Introduce uni-tensor and bi-tensor equivalents

### DIFF
--- a/shim/xplat/executorch/kernels/portable/op_registration_util.bzl
+++ b/shim/xplat/executorch/kernels/portable/op_registration_util.bzl
@@ -214,7 +214,7 @@ ATEN_OPS = (
         name = "op_add",
         deps = [
             "//executorch/kernels/portable/cpu/util:broadcast_util",
-            "//executorch/kernels/portable/cpu/util:functional_util",
+            "//executorch/kernels/portable/cpu/util:elementwise_util",
             "//executorch/kernels/portable/cpu/util:kernel_ops_util",
             ":scalar_utils",
         ],
@@ -392,7 +392,6 @@ ATEN_OPS = (
             ":scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
             "//executorch/kernels/portable/cpu/util:elementwise_util",
-            "//executorch/kernels/portable/cpu/util:functional_util",
             "//executorch/kernels/portable/cpu/util:math_util",
         ],
     ),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #6021
* #6020
* #6019
* #6018
* #6017
* #6016
* #6015
* #6014
* #6013
* #6012
* #6011
* #6010
* #6009
* #6008
* #6007
* __->__ #6006
* #6005

This introduces unitensor and bitensor equivalents to the tritensor template introduced by @swolchok.
They are applied to add.Scalar_out and add.out respectively, reducing op_add's build size.
The unitensor template is applied to clamp.Scalar_out, reducing op_clamp's build size further.

Build size reduction:
- add: 484K -> 21K
- clamp: 119K -> 28K

Differential Revision: [D63838076](https://our.internmc.facebook.com/intern/diff/D63838076/)