### PR TITLE
[ET][Portable][Build Size] Introduce notion of compute type. Refactor add/clamp/where

### DIFF
--- a/kernels/portable/cpu/op_add.cpp
+++ b/kernels/portable/cpu/op_add.cpp
@@ -24,36 +24,43 @@ Tensor& add_out(
     Tensor& out) {
   ET_KERNEL_CHECK(
       ctx,
-      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
-      InvalidArgument,
-      out);
-
-  ET_KERNEL_CHECK(
-      ctx,
       (executorch::runtime::tensor_is_realhbbf16_type(a) &&
        executorch::runtime::tensor_is_realhbbf16_type(b) &&
        executorch::runtime::tensor_is_realhbbf16_type(out)),
       InvalidArgument,
       out);
+
+  // Common Dtype
+  ScalarType common_type = promoteTypes(a.scalar_type(), b.scalar_type());
+
+  // Check Common Dtype
+  ET_KERNEL_CHECK(
+      ctx,
+      (canCast(common_type, out.scalar_type()) &&
+       check_alpha_type(utils::get_scalar_dtype(alpha), common_type)),
+      InvalidArgument,
+      out);
+
+  // Check Dim Order
   ET_KERNEL_CHECK(
       ctx, tensors_have_same_dim_order(a, b, out), InvalidArgument, out);
 
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
-  ScalarType alpha_type = utils::get_scalar_dtype(alpha);
-  ScalarType common_type = promoteTypes(a_type, b_type, /*half_to_float*/ true);
-  ScalarType out_type = out.scalar_type();
-
-  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
+  // Resize
   ET_KERNEL_CHECK(
-      ctx, check_alpha_type(alpha_type, common_type), InvalidArgument, out);
+      ctx,
+      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
+      InvalidArgument,
+      out);
+
+  // Compute Dtype
+  ScalarType compute_type = utils::get_compute_type(common_type);
 
   static constexpr const char op_name[] = "add.out";
 
-  ET_SWITCH_REALB_TYPES(common_type, ctx, op_name, CTYPE_COMMON, [&]() {
-    utils::apply_bitensor_elementwise_fn<CTYPE_COMMON, op_name>(
-        [alpha](const CTYPE_COMMON val_a, const CTYPE_COMMON val_b) {
-          CTYPE_COMMON val_alpha = utils::scalar_to<CTYPE_COMMON>(alpha);
+  ET_SWITCH_REALB_TYPES(compute_type, ctx, op_name, CTYPE_COMPUTE, [&]() {
+    const CTYPE_COMPUTE val_alpha = utils::scalar_to<CTYPE_COMPUTE>(alpha);
+    utils::apply_bitensor_elementwise_fn<CTYPE_COMPUTE, op_name>(
+        [val_alpha](const CTYPE_COMPUTE val_a, const CTYPE_COMPUTE val_b) {
           return val_a + val_alpha * val_b;
         },
         a,
@@ -73,52 +80,48 @@ Tensor& add_scalar_out(
     const Scalar& b,
     const Scalar& alpha,
     Tensor& out) {
-  (void)ctx;
-
-  // Resize for dynamic shape
-  ET_KERNEL_CHECK_MSG(
-      ctx,
-      resize_tensor(out, a.sizes()) == Error::Ok,
-      InvalidArgument,
-      out,
-      "Failed to resize output tensor.");
-
   ET_KERNEL_CHECK(
       ctx,
       (executorch::runtime::tensor_is_realhbbf16_type(a) &&
        executorch::runtime::tensor_is_realhbbf16_type(out)),
       InvalidArgument,
       out);
+
+  // Common Dtype
+  ScalarType common_type = utils::promote_type_with_scalar(a.scalar_type(), b);
+
+  // Check Common Dtype
+  ET_KERNEL_CHECK(
+      ctx,
+      (common_type == out.scalar_type() &&
+       check_alpha_type(utils::get_scalar_dtype(alpha), common_type)),
+      InvalidArgument,
+      out);
+
+  // Check Dim Order
   ET_KERNEL_CHECK(
       ctx, tensors_have_same_dim_order(a, out), InvalidArgument, out);
 
-  ScalarType a_type = a.scalar_type();
-  ScalarType alpha_type = utils::get_scalar_dtype(alpha);
-  ScalarType common_type =
-      utils::promote_type_with_scalar(a_type, b, /*half_to_float*/ false);
-  ScalarType out_type = out.scalar_type();
-
-  ET_KERNEL_CHECK(ctx, common_type == out_type, InvalidArgument, out);
+  // Resize
   ET_KERNEL_CHECK(
-      ctx, check_alpha_type(alpha_type, common_type), InvalidArgument, out);
+      ctx, resize_tensor(out, a.sizes()) == Error::Ok, InvalidArgument, out);
 
-  if (common_type == ScalarType::Half || common_type == ScalarType::BFloat16) {
-    common_type = ScalarType::Float;
-  }
+  // Compute Dtype
+  ScalarType compute_type = utils::get_compute_type(common_type);
 
   static constexpr const char op_name[] = "add.Scalar_out";
 
-  ET_SWITCH_REALB_TYPES(common_type, ctx, op_name, CTYPE_COMMON, [&]() {
-    utils::apply_unitensor_elementwise_fn<CTYPE_COMMON, op_name>(
-        [b, alpha](const CTYPE_COMMON val_a) {
-          CTYPE_COMMON val_b = utils::scalar_to<CTYPE_COMMON>(b);
-          CTYPE_COMMON val_alpha = utils::scalar_to<CTYPE_COMMON>(alpha);
+  ET_SWITCH_REALB_TYPES(compute_type, ctx, op_name, CTYPE_COMPUTE, [&]() {
+    utils::apply_unitensor_elementwise_fn<CTYPE_COMPUTE, op_name>(
+        [b, alpha](const CTYPE_COMPUTE val_a) {
+          CTYPE_COMPUTE val_b = utils::scalar_to<CTYPE_COMPUTE>(b);
+          CTYPE_COMPUTE val_alpha = utils::scalar_to<CTYPE_COMPUTE>(alpha);
           return val_a + val_alpha * val_b;
         },
         a,
         utils::SupportedTensorDtypes::REALHBBF16,
         out,
-        utils::SupportedTensorDtypes::REALHBBF16);
+        utils::SupportedTensorDtypes::SAME_AS_COMMON);
   });
 
   return out;

--- a/kernels/portable/cpu/op_where.cpp
+++ b/kernels/portable/cpu/op_where.cpp
@@ -19,36 +19,43 @@ Tensor& where_out(
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  ScalarType cond_type = cond.scalar_type();
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
-  ScalarType common_type = promoteTypes(a_type, b_type);
-  ScalarType out_type = out.scalar_type();
+  ET_KERNEL_CHECK(
+      ctx,
+      ((cond.scalar_type() == ScalarType::Bool ||
+        cond.scalar_type() == ScalarType::Byte) &&
+       executorch::runtime::tensor_is_realhbbf16_type(a) &&
+       executorch::runtime::tensor_is_realhbbf16_type(b) &&
+       executorch::runtime::tensor_is_realhbbf16_type(out)),
+      InvalidArgument,
+      out);
 
-  ET_KERNEL_CHECK(ctx, common_type == out_type, InvalidArgument, out);
+  // Common Dtype
+  ScalarType common_type = promoteTypes(a.scalar_type(), b.scalar_type());
 
-  // Determine output size and resize for dynamic shapes
+  // Check Common Dtype
+  ET_KERNEL_CHECK(ctx, common_type == out.scalar_type(), InvalidArgument, out);
+
+  // Check Dim Order
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_dim_order(cond, a, b, out), InvalidArgument, out);
+
+  // Resize
   ET_KERNEL_CHECK(
       ctx,
       resize_to_broadcast_target_size(a, b, cond, out) == Error::Ok,
       InvalidArgument,
       out);
 
-  ET_KERNEL_CHECK(
-      ctx, tensors_have_same_dim_order(cond, a, b, out), InvalidArgument, out);
+  // Compute Dtype
+  ScalarType compute_type = utils::get_compute_type(common_type);
 
   static constexpr const char op_name[] = "where.self_out";
 
-  ET_CHECK_MSG(
-      cond_type == ScalarType::Bool || cond_type == ScalarType::Byte,
-      "Unhandled dtype %s for where.self_out",
-      torch::executor::toString(cond_type));
-
-  ET_SWITCH_REALHBBF16_TYPES(common_type, ctx, op_name, CTYPE_COMMON, [&]() {
-    utils::apply_tritensor_elementwise_fn<CTYPE_COMMON, op_name>(
-        [](const CTYPE_COMMON val_a,
-           const CTYPE_COMMON val_b,
-           const CTYPE_COMMON val_c) { return val_c ? val_a : val_b; },
+  ET_SWITCH_REALB_TYPES(compute_type, ctx, op_name, CTYPE_COMPUTE, [&]() {
+    utils::apply_tritensor_elementwise_fn<CTYPE_COMPUTE, op_name>(
+        [](const CTYPE_COMPUTE val_a,
+           const CTYPE_COMPUTE val_b,
+           const CTYPE_COMPUTE val_c) { return val_c ? val_a : val_b; },
         a,
         utils::SupportedTensorDtypes::REALHBBF16,
         b,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #6021
* #6020
* #6019
* #6018
* #6017
* #6016
* #6015
* #6014
* #6013
* #6012
* #6011
* #6010
* #6009
* #6008
* __->__ #6007
* #6006
* #6005

Introduced notion of compute type. We now perform the computation over `CTYPE_COMP` (the compute type) rather than `CTYPE_COMMON` (the common type)

All of the occurrences of `CTYPE_COMMON` in elementwise_util.h need to be replaced with `CTYPE_COMP`, to properly reflect that we are dealing with the computation type, and not the common type. But we don't do that in this diff, to facilitate review.

The previous `SupportedTensorDtypes::SAME_AS_COMMON` is transformed into `SupportedTensorDtypes::SAME_AS_COMP` and a newer `SupportedTensorDtypes::SAME_AS_COMMON` is written.

`SupportedTensorDtypes::SAME_AS_COMMON` should perform the reverse mapping than get_compute_type(). In this case, this means that when `CTYPE_COMP` is anything but float, `SAME_AS_COMMON` is effectively the same as `SAME_AS_COMP`. But when `CTYPE_COMP` is float, `SAME_AS_COMMON` switches over `Float`, `Half` and `BFloat16`

Build size reduction:
- add: 21K -> 18K
- clamp: 28K -> 23K
- where: 16K -> 12K

Differential Revision: [D63860791](https://our.internmc.facebook.com/intern/diff/D63860791/)