### PR TITLE
[ET][Portable][Build Size] Rewrite bitwise op pattern. Binary ops: bitwise_and, bitwise_or, bitwise_xor

### DIFF
--- a/kernels/portable/cpu/op_bitwise_and.cpp
+++ b/kernels/portable/cpu/op_bitwise_and.cpp
@@ -6,68 +6,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// patternlint-disable-next-line executorch-cpp-nostdinc
-#include <functional>
-
 #include <executorch/kernels/portable/cpu/pattern/bitwise_op.h>
-#include <executorch/kernels/portable/cpu/scalar_utils.h>
-#include <executorch/kernels/portable/cpu/util/broadcast_util.h>
-#include <executorch/kernels/portable/cpu/util/functional_util.h>
-#include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
 namespace executor {
 namespace native {
-
-using Tensor = exec_aten::Tensor;
 
 Tensor& bitwise_and_Tensor_out(
     KernelRuntimeContext& ctx,
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  ET_KERNEL_CHECK(
-      ctx,
-      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
-      InvalidArgument,
-      out);
-
-  ET_KERNEL_CHECK(
-      ctx, tensors_have_same_dim_order(a, b, out), InvalidArgument, out);
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
-  ScalarType common_type = promoteTypes(a_type, b_type);
-  ScalarType out_type = out.scalar_type();
-
-  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
-
-  ET_SWITCH_INT_TYPES_AND(
-      Bool, a_type, ctx, "bitwise_and.Tensor_out", CTYPE_A, [&]() {
-        ET_SWITCH_INT_TYPES_AND(
-            Bool, b_type, ctx, "bitwise_and.Tensor_out", CTYPE_B, [&]() {
-              using CTYPE_IN = typename torch::executor::
-                  promote_types<CTYPE_A, CTYPE_B>::type;
-              ET_DCHECK(CppTypeToScalarType<CTYPE_IN>::value == common_type);
-              ET_SWITCH_REAL_TYPES_AND(
-                  Bool,
-                  out_type,
-                  ctx,
-                  "bitwise_and.Tensor_out",
-                  CTYPE_OUT,
-                  [&]() {
-                    internal::BitwiseOpInner<
-                        can_cast<CTYPE_IN, CTYPE_OUT>::value,
-                        std::bit_and,
-                        CTYPE_A,
-                        CTYPE_B,
-                        CTYPE_IN,
-                        CTYPE_OUT>::run(a, b, out);
-                  });
-            });
-      });
-
-  return out;
+  static constexpr const char op_name[] = "bitwise_and.Tensor_out";
+  return internal::bitwise_tensor_out<op_name>(ctx, a, b, out);
 }
 
 Tensor& bitwise_and_Scalar_out(
@@ -75,66 +26,8 @@ Tensor& bitwise_and_Scalar_out(
     const Tensor& a,
     const Scalar& b,
     Tensor& out) {
-  (void)ctx;
-
-  // Resize for dynamic shape
-  ET_KERNEL_CHECK_MSG(
-      ctx,
-      resize_tensor(out, a.sizes()) == Error::Ok,
-      InvalidArgument,
-      out,
-      "Failed to resize output tensor.");
-
-  ET_KERNEL_CHECK(
-      ctx, tensors_have_same_dim_order(a, out), InvalidArgument, out);
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = utils::get_scalar_dtype(b);
-  ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
-  ScalarType out_type = out.scalar_type();
-
-  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
-
-  ET_SWITCH_INT_TYPES_AND(
-      Bool, a_type, ctx, "bitwise_and.Scalar_out", CTYPE_A, [&]() {
-        ET_SWITCH_SCALAR_OBJ_INTB_TYPES(
-            b_type, ctx, "bitwise_and.Scalar_out", CTYPE_B, [&]() {
-              CTYPE_B val_b = 0;
-              utils::extract_scalar(b, &val_b);
-              ET_SWITCH_INT_TYPES_AND(
-                  Bool,
-                  common_type,
-                  ctx,
-                  "bitwise_and.Scalar_out",
-                  CTYPE_IN,
-                  [&]() {
-                    ET_SWITCH_REAL_TYPES_AND(
-                        Bool,
-                        out_type,
-                        ctx,
-                        "bitwise_and.Scalar_out",
-                        CTYPE_OUT,
-                        [&]() {
-                          apply_unary_map_fn(
-                              [val_b](const CTYPE_A val_a) {
-                                CTYPE_IN a_casted =
-                                    static_cast<CTYPE_IN>(val_a);
-                                CTYPE_IN b_casted =
-                                    static_cast<CTYPE_IN>(val_b);
-                                CTYPE_IN value = std::bit_and<CTYPE_IN>()(
-                                    a_casted, b_casted);
-
-                                return static_cast<CTYPE_OUT>(value);
-                              },
-                              a.const_data_ptr<CTYPE_A>(),
-                              out.mutable_data_ptr<CTYPE_OUT>(),
-                              out.numel());
-                        });
-                  });
-            });
-      });
-
-  return out;
+  static constexpr const char op_name[] = "bitwise_and.Scalar_out";
+  return internal::bitwise_scalar_out<op_name>(ctx, a, b, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_bitwise_or.cpp
+++ b/kernels/portable/cpu/op_bitwise_or.cpp
@@ -6,68 +6,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// patternlint-disable-next-line executorch-cpp-nostdinc
-#include <functional>
-
 #include <executorch/kernels/portable/cpu/pattern/bitwise_op.h>
-#include <executorch/kernels/portable/cpu/scalar_utils.h>
-#include <executorch/kernels/portable/cpu/util/broadcast_util.h>
-#include <executorch/kernels/portable/cpu/util/functional_util.h>
-#include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
 namespace executor {
 namespace native {
-
-using Tensor = exec_aten::Tensor;
 
 Tensor& bitwise_or_Tensor_out(
     KernelRuntimeContext& ctx,
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  ET_KERNEL_CHECK(
-      ctx,
-      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
-      InvalidArgument,
-      out);
-
-  ET_KERNEL_CHECK(
-      ctx, tensors_have_same_dim_order(a, b, out), InvalidArgument, out);
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
-  ScalarType common_type = promoteTypes(a_type, b_type);
-  ScalarType out_type = out.scalar_type();
-
-  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
-
-  ET_SWITCH_INT_TYPES_AND(
-      Bool, a_type, ctx, "bitwise_or.Tensor_out", CTYPE_A, [&]() {
-        ET_SWITCH_INT_TYPES_AND(
-            Bool, b_type, ctx, "bitwise_or.Tensor_out", CTYPE_B, [&]() {
-              using CTYPE_IN = typename torch::executor::
-                  promote_types<CTYPE_A, CTYPE_B>::type;
-              ET_DCHECK(CppTypeToScalarType<CTYPE_IN>::value == common_type);
-              ET_SWITCH_REAL_TYPES_AND(
-                  Bool,
-                  out_type,
-                  ctx,
-                  "bitwise_or.Tensor_out",
-                  CTYPE_OUT,
-                  [&]() {
-                    internal::BitwiseOpInner<
-                        can_cast<CTYPE_IN, CTYPE_OUT>::value,
-                        std::bit_or,
-                        CTYPE_A,
-                        CTYPE_B,
-                        CTYPE_IN,
-                        CTYPE_OUT>::run(a, b, out);
-                  });
-            });
-      });
-
-  return out;
+  static constexpr const char op_name[] = "bitwise_or.Tensor_out";
+  return internal::bitwise_tensor_out<op_name>(ctx, a, b, out);
 }
 
 Tensor& bitwise_or_Scalar_out(
@@ -75,66 +26,8 @@ Tensor& bitwise_or_Scalar_out(
     const Tensor& a,
     const Scalar& b,
     Tensor& out) {
-  (void)ctx;
-
-  ET_KERNEL_CHECK(
-      ctx, tensors_have_same_dim_order(a, out), InvalidArgument, out);
-
-  // Resize for dynamic shape
-  ET_KERNEL_CHECK_MSG(
-      ctx,
-      resize_tensor(out, a.sizes()) == Error::Ok,
-      InvalidArgument,
-      out,
-      "Failed to resize output tensor.");
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = utils::get_scalar_dtype(b);
-  ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
-  ScalarType out_type = out.scalar_type();
-
-  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
-
-  ET_SWITCH_INT_TYPES_AND(
-      Bool, a_type, ctx, "bitwise_or.Scalar_out", CTYPE_A, [&]() {
-        ET_SWITCH_SCALAR_OBJ_INTB_TYPES(
-            b_type, ctx, "bitwise_or.Scalar_out", CTYPE_B, [&]() {
-              CTYPE_B val_b = 0;
-              utils::extract_scalar(b, &val_b);
-              ET_SWITCH_INT_TYPES_AND(
-                  Bool,
-                  common_type,
-                  ctx,
-                  "bitwise_or.Scalar_out",
-                  CTYPE_IN,
-                  [&]() {
-                    ET_SWITCH_REAL_TYPES_AND(
-                        Bool,
-                        out_type,
-                        ctx,
-                        "bitwise_or.Scalar_out",
-                        CTYPE_OUT,
-                        [&]() {
-                          apply_unary_map_fn(
-                              [val_b](const CTYPE_A val_a) {
-                                CTYPE_IN a_casted =
-                                    static_cast<CTYPE_IN>(val_a);
-                                CTYPE_IN b_casted =
-                                    static_cast<CTYPE_IN>(val_b);
-                                CTYPE_IN value =
-                                    std::bit_or<CTYPE_IN>()(a_casted, b_casted);
-
-                                return static_cast<CTYPE_OUT>(value);
-                              },
-                              a.const_data_ptr<CTYPE_A>(),
-                              out.mutable_data_ptr<CTYPE_OUT>(),
-                              out.numel());
-                        });
-                  });
-            });
-      });
-
-  return out;
+  static constexpr const char op_name[] = "bitwise_or.Scalar_out";
+  return internal::bitwise_scalar_out<op_name>(ctx, a, b, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_bitwise_xor.cpp
+++ b/kernels/portable/cpu/op_bitwise_xor.cpp
@@ -6,68 +6,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// patternlint-disable-next-line executorch-cpp-nostdinc
-#include <functional>
-
 #include <executorch/kernels/portable/cpu/pattern/bitwise_op.h>
-#include <executorch/kernels/portable/cpu/scalar_utils.h>
-#include <executorch/kernels/portable/cpu/util/broadcast_util.h>
-#include <executorch/kernels/portable/cpu/util/functional_util.h>
-#include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
 namespace executor {
 namespace native {
-
-using Tensor = exec_aten::Tensor;
 
 Tensor& bitwise_xor_Tensor_out(
     KernelRuntimeContext& ctx,
     const Tensor& a,
     const Tensor& b,
     Tensor& out) {
-  ET_KERNEL_CHECK(
-      ctx,
-      resize_to_broadcast_target_size(a, b, out) == Error::Ok,
-      InvalidArgument,
-      out);
-
-  ET_KERNEL_CHECK(
-      ctx, tensors_have_same_dim_order(a, b, out), InvalidArgument, out);
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
-  ScalarType common_type = promoteTypes(a_type, b_type);
-  ScalarType out_type = out.scalar_type();
-
-  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
-
-  ET_SWITCH_INT_TYPES_AND(
-      Bool, a_type, ctx, "bitwise_xor.Tensor_out", CTYPE_A, [&]() {
-        ET_SWITCH_INT_TYPES_AND(
-            Bool, b_type, ctx, "bitwise_xor.Tensor_out", CTYPE_B, [&]() {
-              using CTYPE_IN = typename torch::executor::
-                  promote_types<CTYPE_A, CTYPE_B>::type;
-              ET_DCHECK(CppTypeToScalarType<CTYPE_IN>::value == common_type);
-              ET_SWITCH_REAL_TYPES_AND(
-                  Bool,
-                  out_type,
-                  ctx,
-                  "bitwise_xor.Tensor_out",
-                  CTYPE_OUT,
-                  [&]() {
-                    internal::BitwiseOpInner<
-                        can_cast<CTYPE_IN, CTYPE_OUT>::value,
-                        std::bit_xor,
-                        CTYPE_A,
-                        CTYPE_B,
-                        CTYPE_IN,
-                        CTYPE_OUT>::run(a, b, out);
-                  });
-            });
-      });
-
-  return out;
+  static constexpr const char op_name[] = "bitwise_xor.Tensor_out";
+  return internal::bitwise_tensor_out<op_name>(ctx, a, b, out);
 }
 
 Tensor& bitwise_xor_Scalar_out(
@@ -75,66 +26,8 @@ Tensor& bitwise_xor_Scalar_out(
     const Tensor& a,
     const Scalar& b,
     Tensor& out) {
-  (void)ctx;
-
-  // Resize for dynamic shape
-  ET_KERNEL_CHECK_MSG(
-      ctx,
-      resize_tensor(out, a.sizes()) == Error::Ok,
-      InvalidArgument,
-      out,
-      "Failed to resize output tensor.");
-
-  ET_KERNEL_CHECK(
-      ctx, tensors_have_same_dim_order(a, out), InvalidArgument, out);
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = utils::get_scalar_dtype(b);
-  ScalarType common_type = utils::promote_type_with_scalar(a_type, b);
-  ScalarType out_type = out.scalar_type();
-
-  ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
-
-  ET_SWITCH_INT_TYPES_AND(
-      Bool, a_type, ctx, "bitwise_xor.Scalar_out", CTYPE_A, [&]() {
-        ET_SWITCH_SCALAR_OBJ_INTB_TYPES(
-            b_type, ctx, "bitwise_xor.Scalar_out", CTYPE_B, [&]() {
-              CTYPE_B val_b = 0;
-              utils::extract_scalar(b, &val_b);
-              ET_SWITCH_INT_TYPES_AND(
-                  Bool,
-                  common_type,
-                  ctx,
-                  "bitwise_xor.Scalar_out",
-                  CTYPE_IN,
-                  [&]() {
-                    ET_SWITCH_REAL_TYPES_AND(
-                        Bool,
-                        out_type,
-                        ctx,
-                        "bitwise_xor.Scalar_out",
-                        CTYPE_OUT,
-                        [&]() {
-                          apply_unary_map_fn(
-                              [val_b](const CTYPE_A val_a) {
-                                CTYPE_IN a_casted =
-                                    static_cast<CTYPE_IN>(val_a);
-                                CTYPE_IN b_casted =
-                                    static_cast<CTYPE_IN>(val_b);
-                                CTYPE_IN value = std::bit_xor<CTYPE_IN>()(
-                                    a_casted, b_casted);
-
-                                return static_cast<CTYPE_OUT>(value);
-                              },
-                              a.const_data_ptr<CTYPE_A>(),
-                              out.mutable_data_ptr<CTYPE_OUT>(),
-                              out.numel());
-                        });
-                  });
-            });
-      });
-
-  return out;
+  static constexpr const char op_name[] = "bitwise_xor.Scalar_out";
+  return internal::bitwise_scalar_out<op_name>(ctx, a, b, out);
 }
 
 } // namespace native

--- a/kernels/portable/cpu/pattern/targets.bzl
+++ b/kernels/portable/cpu/pattern/targets.bzl
@@ -25,9 +25,6 @@ def define_common_targets():
             "bitwise_op.h",
         ],
         compiler_flags = [],
-        deps = [
-            "//executorch/runtime/kernel:kernel_includes",
-        ],
         visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
     )
 

--- a/kernels/portable/cpu/util/elementwise_util.cpp
+++ b/kernels/portable/cpu/util/elementwise_util.cpp
@@ -26,6 +26,8 @@ bool check_tensor_dtype(
       return executorch::runtime::tensor_is_realhbf16_type(t);
     case SupportedTensorDtypes::FLOATHBF16:
       return executorch::runtime::tensor_is_floating_type(t);
+    case SupportedTensorDtypes::INTB:
+      return executorch::runtime::tensor_is_integral_type(t, true);
     case SupportedTensorDtypes::BOOL_OR_BYTE:
       return (
           executorch::runtime::tensor_is_type(t, ScalarType::Bool) ||

--- a/kernels/portable/cpu/util/elementwise_util.h
+++ b/kernels/portable/cpu/util/elementwise_util.h
@@ -92,6 +92,16 @@ load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn_floathbf16(
 }
 
 template <typename CTYPE_COMMON, const char* op_name>
+load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn_intb(const Tensor& t) {
+  CTYPE_COMMON (*result)(const void*) = nullptr;
+  ET_SWITCH_INT_TYPES_AND(
+      Bool, t.scalar_type(), unused, op_name, TENSOR_CTYPE, [&]() {
+        result = internal::load_and_convert<CTYPE_COMMON, TENSOR_CTYPE>;
+      });
+  return result;
+}
+
+template <typename CTYPE_COMMON, const char* op_name>
 load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn_bool_or_byte(
     const Tensor& t) {
   CTYPE_COMMON (*result)(const void*) = nullptr;
@@ -174,6 +184,17 @@ get_store_common_to_tensor_fn_floathbf16(const Tensor& t) {
 }
 
 template <typename CTYPE_COMMON, const char* op_name>
+store_common_to_tensor_fn<CTYPE_COMMON> get_store_common_to_tensor_fn_intb(
+    const Tensor& t) {
+  void (*result)(CTYPE_COMMON, void*) = nullptr;
+  ET_SWITCH_INT_TYPES_AND(
+      Bool, t.scalar_type(), unused, op_name, TENSOR_CTYPE, [&]() {
+        result = internal::convert_and_store<TENSOR_CTYPE, CTYPE_COMMON>;
+      });
+  return result;
+}
+
+template <typename CTYPE_COMMON, const char* op_name>
 store_common_to_tensor_fn<CTYPE_COMMON>
 get_store_common_to_tensor_fn_bool_or_byte(const Tensor& t) {
   void (*result)(CTYPE_COMMON, void*) = nullptr;
@@ -226,6 +247,7 @@ enum class SupportedTensorDtypes {
   REALHBBF16,
   REALHBF16,
   FLOATHBF16,
+  INTB,
   BOOL_OR_BYTE,
   SAME_AS_COMPUTE,
   SAME_AS_COMMON,
@@ -244,6 +266,8 @@ load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn(
       return get_load_to_common_fn_realhbf16<CTYPE_COMMON, op_name>(t);
     case SupportedTensorDtypes::FLOATHBF16:
       return get_load_to_common_fn_realhbf16<CTYPE_COMMON, op_name>(t);
+    case SupportedTensorDtypes::INTB:
+      return get_load_to_common_fn_intb<CTYPE_COMMON, op_name>(t);
     case SupportedTensorDtypes::BOOL_OR_BYTE:
       return get_load_to_common_fn_bool_or_byte<CTYPE_COMMON, op_name>(t);
     case SupportedTensorDtypes::SAME_AS_COMPUTE:
@@ -266,6 +290,8 @@ store_common_to_tensor_fn<CTYPE_COMMON> get_store_common_to_tensor_fn(
       return get_store_common_to_tensor_fn_realhbf16<CTYPE_COMMON, op_name>(t);
     case SupportedTensorDtypes::FLOATHBF16:
       return get_store_common_to_tensor_fn_floathbf16<CTYPE_COMMON, op_name>(t);
+    case SupportedTensorDtypes::INTB:
+      return get_store_common_to_tensor_fn_intb<CTYPE_COMMON, op_name>(t);
     case SupportedTensorDtypes::BOOL_OR_BYTE:
       return get_store_common_to_tensor_fn_bool_or_byte<CTYPE_COMMON, op_name>(
           t);

--- a/shim/xplat/executorch/kernels/portable/op_registration_util.bzl
+++ b/shim/xplat/executorch/kernels/portable/op_registration_util.bzl
@@ -322,12 +322,10 @@ ATEN_OPS = (
     op_target(
         name = "op_bitwise_and",
         deps = [
-            "//executorch/runtime/core/exec_aten/util:scalar_type_util",
-            "//executorch/runtime/core/exec_aten/util:tensor_util",
+            ":scalar_utils",
             "//executorch/kernels/portable/cpu/pattern:bitwise_op",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
-            "//executorch/kernels/portable/cpu/util:functional_util",
-            ":scalar_utils",
+            "//executorch/kernels/portable/cpu/util:elementwise_util",
         ],
     ),
     op_target(
@@ -341,23 +339,19 @@ ATEN_OPS = (
     op_target(
         name = "op_bitwise_or",
         deps = [
-            "//executorch/runtime/core/exec_aten/util:scalar_type_util",
-            "//executorch/runtime/core/exec_aten/util:tensor_util",
+            ":scalar_utils",
             "//executorch/kernels/portable/cpu/pattern:bitwise_op",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
-            "//executorch/kernels/portable/cpu/util:functional_util",
-            ":scalar_utils",
+            "//executorch/kernels/portable/cpu/util:elementwise_util",
         ],
     ),
     op_target(
         name = "op_bitwise_xor",
         deps = [
-            "//executorch/runtime/core/exec_aten/util:scalar_type_util",
-            "//executorch/runtime/core/exec_aten/util:tensor_util",
+            ":scalar_utils",
             "//executorch/kernels/portable/cpu/pattern:bitwise_op",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
-            "//executorch/kernels/portable/cpu/util:functional_util",
-            ":scalar_utils",
+            "//executorch/kernels/portable/cpu/util:elementwise_util",
         ],
     ),
     op_target(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #6021
* #6020
* #6019
* #6018
* #6017
* #6016
* #6015
* __->__ #6014
* #6013
* #6012
* #6011
* #6010
* #6009
* #6008
* #6007
* #6006
* #6005

- bitwise_or:    417 K -> 12 K
- bitwise_xor:  416 K -> 12 K
- bitwise_and: 406 K -> 12 K

Differential Revision: [D63933330](https://our.internmc.facebook.com/intern/diff/D63933330/)