### PR TITLE
Migrate backends/qualcomm to the new namespace

### DIFF
--- a/backends/qualcomm/aot/ir/qcir_utils.cpp
+++ b/backends/qualcomm/aot/ir/qcir_utils.cpp
@@ -11,8 +11,8 @@
 
 #include <unordered_map>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 
 qcir::TensorType ToTensorType(Qnn_TensorType_t type) {
@@ -278,5 +278,5 @@ Qnn_Tensor_t ToTensor(const tensor_type& tensor) {
 }
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/ir/qcir_utils.h
+++ b/backends/qualcomm/aot/ir/qcir_utils.h
@@ -11,8 +11,8 @@
 #include <executorch/backends/qualcomm/aot/ir/qcir_generated.h>
 #include "QnnTypes.h"
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 
 typedef flatbuffers::Vector<::flatbuffers::Offset<qcir::Tensor>>::return_type
@@ -36,5 +36,5 @@ flatbuffers::Offset<qcir::Tensor> ToTensor(
 Qnn_Tensor_t ToTensor(const tensor_type& tensor);
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/python/PyQnnManagerAdaptor.cpp
+++ b/backends/qualcomm/aot/python/PyQnnManagerAdaptor.cpp
@@ -9,9 +9,12 @@
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
+
 PYBIND11_MODULE(PyQnnManagerAdaptor, m) {
   // TODO: Add related documents for configurations listed below
   using namespace qnn_delegate;
@@ -39,5 +42,5 @@ PYBIND11_MODULE(PyQnnManagerAdaptor, m) {
       .def("GetSpillFillBufferSize", &PyQnnManager::GetSpillFillBufferSize);
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/python/PyQnnManagerAdaptor.h
+++ b/backends/qualcomm/aot/python/PyQnnManagerAdaptor.h
@@ -19,8 +19,8 @@
 #include <string_view>
 
 namespace py = pybind11;
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class PyQnnManager {
  public:
@@ -48,7 +48,7 @@ class PyQnnManager {
         qnn_executorch_options, qnn_executorch_context_binary_);
   }
 
-  Error Init() {
+  executorch::runtime::Error Init() {
     return qnn_manager_->Init();
   }
   bool IsNodeSupportedByBackend(
@@ -97,8 +97,8 @@ class PyQnnManager {
             wrapper->SetName(param->GetName());
             set_tensor(wrapper, params);
           } else {
-            Error err = param->PopulateQnnParam();
-            if (err != Error::Ok) {
+            executorch::runtime::Error err = param->PopulateQnnParam();
+            if (err != executorch::runtime::Error::Ok) {
               QNN_EXECUTORCH_LOG_ERROR(
                   "Fail to get scalar parameter in online prepare stage");
               return py::array_t<char>(0);
@@ -131,7 +131,8 @@ class PyQnnManager {
       context_binary.buffer = builder.GetBufferPointer();
       context_binary.nbytes = builder.GetSize();
     } else if (
-        qnn_manager_->Compile(op_wrappers, context_binary) != Error::Ok) {
+        qnn_manager_->Compile(op_wrappers, context_binary) !=
+        executorch::runtime::Error::Ok) {
       return py::array_t<char>(0);
     }
 
@@ -155,7 +156,7 @@ class PyQnnManager {
     return qnn_manager_->IsTensorDump();
   }
 
-  Error AllocateTensor() {
+  executorch::runtime::Error AllocateTensor() {
     return qnn_manager_->AllocateTensor();
   }
 
@@ -189,5 +190,5 @@ class PyQnnManager {
   std::shared_ptr<QnnManager> qnn_manager_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/python/PyQnnWrapperAdaptor.cpp
+++ b/backends/qualcomm/aot/python/PyQnnWrapperAdaptor.cpp
@@ -15,8 +15,8 @@
 #include <string>
 
 namespace py = pybind11;
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 std::unique_ptr<QuantizeParamsWrapper> CreateQuantizationParamWrapper(
     const Qnn_QuantizationEncoding_t& encoding,
@@ -250,5 +250,5 @@ PYBIND11_MODULE(PyQnnWrapperAdaptor, m) {
       .def("GetEncodings", &PyQnnTensorWrapper::GetEncodings);
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/python/PyQnnWrapperAdaptor.h
+++ b/backends/qualcomm/aot/python/PyQnnWrapperAdaptor.h
@@ -14,8 +14,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 namespace py = pybind11;
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class PyQnnOpWrapper {
  public:
@@ -183,5 +183,5 @@ class PyQnnTensorWrapper {
   std::shared_ptr<TensorWrapper> tensor_wrapper_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/wrappers/OpWrapper.cpp
+++ b/backends/qualcomm/aot/wrappers/OpWrapper.cpp
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <executorch/backends/qualcomm/aot/wrappers/OpWrapper.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 Qnn_OpConfig_t OpWrapper::GetOpConfig() {
   param_types_.clear();
@@ -44,5 +44,5 @@ Qnn_OpConfig_t OpWrapper::GetOpConfig() {
   return ret;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/wrappers/OpWrapper.h
+++ b/backends/qualcomm/aot/wrappers/OpWrapper.h
@@ -17,8 +17,8 @@
 #include <memory>
 #include <sstream>
 #include <typeinfo>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class OpWrapper final {
  public:
@@ -116,5 +116,5 @@ class OpWrapper final {
   std::vector<Qnn_Param_t> param_types_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/wrappers/ParamWrapper.h
+++ b/backends/qualcomm/aot/wrappers/ParamWrapper.h
@@ -13,14 +13,17 @@
 #include <utility>
 
 #include "QnnTypes.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
+
 class ParamWrapper {
  public:
   // Populate Qnn_Param_t. Return an error code Error::Ok if succeeded,
   // Error::Internal if failed
-  virtual Error PopulateQnnParam() = 0;
+  virtual executorch::runtime::Error PopulateQnnParam() = 0;
   virtual ~ParamWrapper() = default;
 
   ParamWrapper(const ParamWrapper& rhs) = default;
@@ -50,5 +53,5 @@ class ParamWrapper {
   std::string name_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/wrappers/QuantizeParamsWrapper.cpp
+++ b/backends/qualcomm/aot/wrappers/QuantizeParamsWrapper.cpp
@@ -7,8 +7,8 @@
  */
 #include <executorch/backends/qualcomm/aot/wrappers/QuantizeParamsWrapper.h>
 #include <executorch/backends/qualcomm/runtime/Logging.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 std::unique_ptr<QuantizeParamsWrapper> CreateQuantizationParamWrapper(
     const Qnn_QuantizeParams_t& quantization) {
@@ -69,5 +69,5 @@ std::unique_ptr<QuantizeParamsWrapper> CreateQuantizationParamWrapper(
   return quantize_param_wrapper;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/wrappers/QuantizeParamsWrapper.h
+++ b/backends/qualcomm/aot/wrappers/QuantizeParamsWrapper.h
@@ -12,8 +12,8 @@
 #include <vector>
 
 #include "QnnTypes.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class QuantizeParamsWrapper {
  public:
@@ -285,5 +285,5 @@ class AxisScaleOffsetQuantizeParamsWrapper final
 std::unique_ptr<QuantizeParamsWrapper> CreateQuantizationParamWrapper(
     const Qnn_QuantizeParams_t& quantization);
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/wrappers/ScalarParamWrapper.h
+++ b/backends/qualcomm/aot/wrappers/ScalarParamWrapper.h
@@ -9,8 +9,8 @@
 
 #include <executorch/backends/qualcomm/aot/wrappers/ParamWrapper.h>
 #include <executorch/runtime/core/error.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 template <typename T>
 class ScalarParamWrapper final : public ParamWrapper {
@@ -25,7 +25,7 @@ class ScalarParamWrapper final : public ParamWrapper {
 
   // Populate appropriate field in Qnn scalarParam depending on the datatype
   // of the scalar
-  Error PopulateQnnParam() override {
+  executorch::runtime::Error PopulateQnnParam() override {
     qnn_param_.scalarParam.dataType = data_type_;
     switch (data_type_) {
       case QNN_DATATYPE_BOOL_8:
@@ -57,9 +57,9 @@ class ScalarParamWrapper final : public ParamWrapper {
             "ScalarParamWrapper failed to assign scalarParam value - "
             "invalid datatype %d",
             data_type_);
-        return Error::Internal;
+        return executorch::runtime::Error::Internal;
     }
-    return Error::Ok;
+    return executorch::runtime::Error::Ok;
   }
 
   const T& GetData() const {
@@ -71,5 +71,5 @@ class ScalarParamWrapper final : public ParamWrapper {
   T data_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/wrappers/TensorParamWrapper.h
+++ b/backends/qualcomm/aot/wrappers/TensorParamWrapper.h
@@ -13,8 +13,8 @@
 
 #include <memory>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class TensorParamWrapper final : public ParamWrapper {
  public:
@@ -24,12 +24,12 @@ class TensorParamWrapper final : public ParamWrapper {
       : ParamWrapper(QNN_PARAMTYPE_TENSOR, std::move(name)),
         static_tensor_wrapper_(std::move(static_tensor)) {}
   // Populate Qnn tensorParam with tensor wrapper
-  Error PopulateQnnParam() override {
-    // Error out if underlying tensor is not static:
+  executorch::runtime::Error PopulateQnnParam() override {
+    // executorch::runtime::Error out if underlying tensor is not static:
     if (!static_tensor_wrapper_->IsTensorStatic())
-      return Error::Internal;
+      return executorch::runtime::Error::Internal;
     qnn_param_.tensorParam = static_tensor_wrapper_->CloneTensorStruct();
-    return Error::Ok;
+    return executorch::runtime::Error::Ok;
   }
 
   // Accessor functions:
@@ -45,5 +45,5 @@ class TensorParamWrapper final : public ParamWrapper {
   std::shared_ptr<TensorWrapper> static_tensor_wrapper_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/wrappers/TensorWrapper.cpp
+++ b/backends/qualcomm/aot/wrappers/TensorWrapper.cpp
@@ -12,9 +12,12 @@
 #include <cstring>
 #include <limits>
 #include <numeric>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
+
 std::uint32_t GetDataTypeSize(Qnn_DataType_t data_type) {
   std::uint32_t size = 0;
 
@@ -214,5 +217,5 @@ std::shared_ptr<TensorWrapper> CreateTensorWrapper(const Qnn_Tensor_t& tensor) {
       QNN_VER_PTR(tensor)->clientBuf.data);
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/aot/wrappers/TensorWrapper.h
+++ b/backends/qualcomm/aot/wrappers/TensorWrapper.h
@@ -17,8 +17,8 @@
 #include "QnnTypes.h"
 
 #define QNN_VER_PTR(x) (&((x).v1))
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class TensorWrapper {
  public:
@@ -33,9 +33,11 @@ class TensorWrapper {
       const void* data = nullptr,
       bool copy_data = false);
 
-  Error FillDataBuffer(const void* data, bool copy_data = false);
+  executorch::runtime::Error FillDataBuffer(
+      const void* data,
+      bool copy_data = false);
 
-  Error AllocateDataBuffer();
+  executorch::runtime::Error AllocateDataBuffer();
 
   // update qnn tensor meta
   // this function is used to recover metadata from QNN context binary.
@@ -95,9 +97,9 @@ class TensorWrapper {
     return QNN_VER_PTR(tensor_)->clientBuf.data;
   };
 
-  Error SetName(const std::string& name);
+  executorch::runtime::Error SetName(const std::string& name);
 
-  Error SetMemHandle(Qnn_MemHandle_t mem_handle);
+  executorch::runtime::Error SetMemHandle(Qnn_MemHandle_t mem_handle);
 
  private:
   // need this to handle QNN_TENSOR_ERROR_NAME_HASH_COLLISION
@@ -138,5 +140,5 @@ std::shared_ptr<TensorWrapper> CreateTensorWrapper(const Qnn_Tensor_t& tensor);
 // Utility to get size in bytes of QNN data type
 std::uint32_t GetDataTypeSize(Qnn_DataType_t data_type);
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/Logging.cpp
+++ b/backends/qualcomm/runtime/Logging.cpp
@@ -11,8 +11,8 @@
 #ifdef __ANDROID__
 #include <android/log.h>
 #endif
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 void Log(QnnExecuTorchLogLevel log_level, const char* format, ...) {
   va_list args;
@@ -64,5 +64,5 @@ void Log(QnnExecuTorchLogLevel log_level, const char* format, ...) {
   fputc('\n', stderr);
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/Logging.h
+++ b/backends/qualcomm/runtime/Logging.h
@@ -9,8 +9,8 @@
 
 #include <executorch/backends/qualcomm/schema_generated.h>
 #include <executorch/runtime/core/error.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 using namespace qnn_delegate;
 
@@ -33,5 +33,5 @@ void Log(QnnExecuTorchLogLevel log_level, const char* format, ...);
 #define QNN_EXECUTORCH_LOG_DEBUG(fmt, ...) \
   QNN_EXECUTORCH_LOG(QnnExecuTorchLogLevel::kLogLevelDebug, fmt, ##__VA_ARGS__)
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/QnnExecuTorch.h
+++ b/backends/qualcomm/runtime/QnnExecuTorch.h
@@ -44,7 +44,7 @@ struct CustomMemTensorInfo {
   size_t tensor_bytes;
   uint32_t* shape;
   uint32_t rank;
-  exec_aten::ScalarType dtype;
+  executorch::aten::ScalarType dtype;
 };
 
 /// Allocate specific tensors (usually graph inputs and outputs) on shared

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
@@ -11,11 +11,20 @@
 #include <executorch/backends/qualcomm/runtime/QnnExecuTorchBackend.h>
 #include <executorch/backends/qualcomm/runtime/QnnManager.h>
 #include <executorch/backends/qualcomm/schema_generated.h>
-namespace torch {
-namespace executor {
-// ========== Public method implementations =========================
-using namespace qnn;
+namespace executorch {
+namespace backends {
+namespace qnn {
 using namespace qnn_delegate;
+using executorch::runtime::ArrayRef;
+using executorch::runtime::BackendExecutionContext;
+using executorch::runtime::BackendInitContext;
+using executorch::runtime::CompileSpec;
+using executorch::runtime::DelegateHandle;
+using executorch::runtime::EValue;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::MemoryAllocator;
+using executorch::runtime::Result;
+// ========== Public method implementations =========================
 constexpr const char* QNN_COMPILE_SPEC = "qnn_compile_spec";
 Result<DelegateHandle*> QnnExecuTorchBackend::init(
     BackendInitContext& context,
@@ -240,8 +249,9 @@ bool QnnExecuTorchBackend::is_available() const {
 
 namespace {
 auto cls = QnnExecuTorchBackend();
-Backend backend{"QnnBackend", &cls};
+executorch::runtime::Backend backend{"QnnBackend", &cls};
 static auto success_with_compiler = register_backend(backend);
 } // namespace
-} // namespace executor
-} // namespace torch
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.h
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.h
@@ -11,28 +11,31 @@
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/evalue.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
+namespace qnn {
 
 class QnnExecuTorchBackend final
     : public ::executorch::runtime::BackendInterface {
  public:
   ~QnnExecuTorchBackend(){};
 
-  Result<DelegateHandle*> init(
-      BackendInitContext& context,
-      FreeableBuffer* processed,
-      ArrayRef<CompileSpec> compile_specs) const override;
+  executorch::runtime::Result<executorch::runtime::DelegateHandle*> init(
+      executorch::runtime::BackendInitContext& context,
+      executorch::runtime::FreeableBuffer* processed,
+      executorch::runtime::ArrayRef<executorch::runtime::CompileSpec>
+          compile_specs) const override;
 
-  Error execute(
-      ET_UNUSED BackendExecutionContext& context,
-      DelegateHandle* handle,
-      EValue** args) const override;
+  executorch::runtime::Error execute(
+      ET_UNUSED executorch::runtime::BackendExecutionContext& context,
+      executorch::runtime::DelegateHandle* handle,
+      executorch::runtime::EValue** args) const override;
 
-  void destroy(DelegateHandle* handle) const override;
+  void destroy(executorch::runtime::DelegateHandle* handle) const override;
 
   bool is_available() const override;
 };
 
-} // namespace executor
-} // namespace torch
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/QnnManager.cpp
+++ b/backends/qualcomm/runtime/QnnManager.cpp
@@ -17,9 +17,11 @@
 #include <fstream>
 #include <string>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
 
 bool CompareExportedInput(
     const std::shared_ptr<TensorWrapper>& a,
@@ -370,7 +372,7 @@ Error QnnManager::AllocateTensor(
 Error QnnManager::Execute(
     const std::vector<Qnn_Tensor_t>& input_tensor_structs,
     std::vector<Qnn_Tensor_t>& output_tensor_structs,
-    EventTracer* event_tracer) {
+    executorch::runtime::EventTracer* event_tracer) {
   Qnn_ErrorHandle_t error = QNN_SUCCESS;
 
   error = backend_params_ptr_->qnn_graph_ptr_->GraphExecute(
@@ -387,7 +389,7 @@ Error QnnManager::Execute(
     for (std::size_t out_idx = 0; out_idx < output_tensor_structs.size();
          ++out_idx) {
       const Qnn_Tensor_t& output_tensor = output_tensor_structs[out_idx];
-      std::vector<exec_aten::SizesType> sizes(
+      std::vector<executorch::aten::SizesType> sizes(
           QNN_VER_PTR(output_tensor)->dimensions,
           QNN_VER_PTR(output_tensor)->dimensions +
               QNN_VER_PTR(output_tensor)->rank);
@@ -397,10 +399,12 @@ Error QnnManager::Execute(
           sizes,
           qnn_dtype_to_scalar_type_[QNN_VER_PTR(output_tensor)->dataType]);
 
-      torch::executor::event_tracer_log_output_delegate<exec_aten::Tensor>(
+      executorch::runtime::event_tracer_log_output_delegate<
+          executorch::aten::Tensor>(
           event_tracer,
           QNN_VER_PTR(output_tensor)->name,
-          /*delegate_debug_id=*/static_cast<torch::executor::DebugHandle>(-1),
+          /*delegate_debug_id=*/
+          static_cast<executorch::runtime::DebugHandle>(-1),
           *dump_tensor);
     }
   }
@@ -408,7 +412,8 @@ Error QnnManager::Execute(
   return Error::Ok;
 }
 
-Error QnnManager::ProfileExecuteData(EventTracer* event_tracer) {
+Error QnnManager::ProfileExecuteData(
+    executorch::runtime::EventTracer* event_tracer) {
   Qnn_ErrorHandle_t error = QNN_SUCCESS;
   if (options_->profile_level() != QnnExecuTorchProfileLevel::kProfileOff) {
     error =
@@ -530,26 +535,26 @@ Error QnnManager::Compile(
   return Error::Ok;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch
 void* QnnExecuTorchAllocCustomMem(size_t bytes, size_t alignment) {
   void* buffer_ptr =
-      torch::executor::qnn::SharedBuffer::GetSharedBufferManager().AllocMem(
-          bytes, alignment);
+      executorch::backends::qnn::SharedBuffer::GetSharedBufferManager()
+          .AllocMem(bytes, alignment);
   return buffer_ptr;
 }
 
 void QnnExecuTorchFreeCustomMem(void* buffer_ptr) {
-  torch::executor::qnn::SharedBuffer::GetSharedBufferManager().FreeMem(
+  executorch::backends::qnn::SharedBuffer::GetSharedBufferManager().FreeMem(
       buffer_ptr);
 }
 
 void QnnExecuTorchAddCustomMemTensorAddr(void* tensor_addr, void* custom_mem) {
-  torch::executor::qnn::SharedBuffer::GetSharedBufferManager()
+  executorch::backends::qnn::SharedBuffer::GetSharedBufferManager()
       .AddCusomMemTensorAddr(tensor_addr, custom_mem);
 }
 
 void QnnExecuTorchAddCustomMemTensorInfo(const CustomMemTensorInfo& info) {
-  torch::executor::qnn::SharedBuffer::GetSharedBufferManager()
+  executorch::backends::qnn::SharedBuffer::GetSharedBufferManager()
       .AddCusomMemTensorInfo(info);
 }

--- a/backends/qualcomm/runtime/QnnManager.h
+++ b/backends/qualcomm/runtime/QnnManager.h
@@ -18,8 +18,8 @@
 #include <memory>
 #include <unordered_map>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class QnnManager {
  public:
@@ -29,18 +29,19 @@ class QnnManager {
       const QnnExecuTorchContextBinary& qnn_executorch_context_binary);
 
   ~QnnManager();
-  Error Init();
-  Error AllocateTensor();
-  Error AllocateTensor(
+  executorch::runtime::Error Init();
+  executorch::runtime::Error AllocateTensor();
+  executorch::runtime::Error AllocateTensor(
       std::vector<std::shared_ptr<TensorWrapper>>& inputs,
       std::vector<std::shared_ptr<TensorWrapper>>& outputs);
 
-  Error Execute(
+  executorch::runtime::Error Execute(
       const std::vector<Qnn_Tensor_t>& input_tensor_structs,
       std::vector<Qnn_Tensor_t>& output_tensor_structs,
-      EventTracer* event_tracer);
+      executorch::runtime::EventTracer* event_tracer);
 
-  Error ProfileExecuteData(EventTracer* event_tracer);
+  executorch::runtime::Error ProfileExecuteData(
+      executorch::runtime::EventTracer* event_tracer);
 
   void Destroy();
 
@@ -59,16 +60,16 @@ class QnnManager {
   bool IsNodeSupportedByBackend(
       std::vector<std::shared_ptr<OpWrapper>>& op_wrappers);
 
-  Error Compile(
+  executorch::runtime::Error Compile(
       std::vector<std::shared_ptr<OpWrapper>>& op_wrappers,
       QnnExecuTorchContextBinary& qnn_executorch_context_binary);
 
-  Error RegisterMem(
+  executorch::runtime::Error RegisterMem(
       void* data_ptr,
       const std::shared_ptr<TensorWrapper>& tensor_wrapper);
 
   // Pre-register custom memory handle from the SharedBuffer before execution
-  Error PreRegisterMem();
+  executorch::runtime::Error PreRegisterMem();
 
   uint64_t GetSpillFillBufferSize() {
     auto* htp_backend_cache_ptr = static_cast<HtpBackendCache*>(
@@ -84,7 +85,7 @@ class QnnManager {
   }
 
  private:
-  Error LoadQnnLibrary();
+  executorch::runtime::Error LoadQnnLibrary();
 
   static constexpr const char* htp_library_name_ = "libQnnHtp.so";
   static constexpr const char* gpu_library_name_ = "libQnnGpu.so";
@@ -97,22 +98,29 @@ class QnnManager {
   const QnnExecuTorchOptions* options_;
   std::vector<std::shared_ptr<TensorWrapper>> input_tensors_;
   std::vector<std::shared_ptr<TensorWrapper>> output_tensors_;
-  Error RegisterIonMem(
+  executorch::runtime::Error RegisterIonMem(
       void* data_ptr,
       const std::shared_ptr<TensorWrapper>& tensor_wrapper);
-  Error RegisterCustomMem(
+  executorch::runtime::Error RegisterCustomMem(
       void* data_ptr,
       void* custom_mem_base,
       const std::shared_ptr<TensorWrapper>& tensor_wrapper);
-  std::unordered_map<Qnn_DataType_t, ScalarType> qnn_dtype_to_scalar_type_ = {
-      {Qnn_DataType_t::QNN_DATATYPE_INT_32, ScalarType::Int},
-      {Qnn_DataType_t::QNN_DATATYPE_FLOAT_32, ScalarType::Float},
-      {Qnn_DataType_t::QNN_DATATYPE_SFIXED_POINT_8, ScalarType::Char},
-      {Qnn_DataType_t::QNN_DATATYPE_SFIXED_POINT_16, ScalarType::Short},
-      {Qnn_DataType_t::QNN_DATATYPE_UFIXED_POINT_8, ScalarType::Byte},
-      {Qnn_DataType_t::QNN_DATATYPE_UFIXED_POINT_16, ScalarType::Bits16},
+  std::unordered_map<Qnn_DataType_t, executorch::aten::ScalarType>
+      qnn_dtype_to_scalar_type_ = {
+          {Qnn_DataType_t::QNN_DATATYPE_INT_32,
+           executorch::aten::ScalarType::Int},
+          {Qnn_DataType_t::QNN_DATATYPE_FLOAT_32,
+           executorch::aten::ScalarType::Float},
+          {Qnn_DataType_t::QNN_DATATYPE_SFIXED_POINT_8,
+           executorch::aten::ScalarType::Char},
+          {Qnn_DataType_t::QNN_DATATYPE_SFIXED_POINT_16,
+           executorch::aten::ScalarType::Short},
+          {Qnn_DataType_t::QNN_DATATYPE_UFIXED_POINT_8,
+           executorch::aten::ScalarType::Byte},
+          {Qnn_DataType_t::QNN_DATATYPE_UFIXED_POINT_16,
+           executorch::aten::ScalarType::Bits16},
   };
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/SharedBuffer.cpp
+++ b/backends/qualcomm/runtime/SharedBuffer.cpp
@@ -25,7 +25,7 @@ std::size_t std::hash<CustomMemTensorInfo>::operator()(
     hash_val ^= info.shape[i];
   }
   hash_val ^= std::hash<uint32_t>()(info.rank);
-  hash_val ^= std::hash<exec_aten::ScalarType>()(info.dtype);
+  hash_val ^= std::hash<executorch::aten::ScalarType>()(info.dtype);
   return hash_val;
 }
 
@@ -42,9 +42,11 @@ bool operator==(
   return is_same;
 }
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
 
 namespace {
 
@@ -200,5 +202,5 @@ Error SharedBuffer::UnLoad() {
   return Error::Ok;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/SharedBuffer.h
+++ b/backends/qualcomm/runtime/SharedBuffer.h
@@ -27,8 +27,8 @@ struct std::hash<CustomMemTensorInfo> {
   std::size_t operator()(const CustomMemTensorInfo& info) const noexcept;
 };
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 
 class SharedBuffer final {
@@ -76,9 +76,9 @@ class SharedBuffer final {
   SharedBuffer() = default;
 
   // dlopen RPCMem library and dlysm required functions
-  Error Load();
+  executorch::runtime::Error Load();
 
-  Error UnLoad();
+  executorch::runtime::Error UnLoad();
 
   // Pointer to the dlopen'd libcdsprpc.so shared library which contains
   // rpcmem_alloc, rpcmem_free, rpcmem_to_fd APIs
@@ -99,5 +99,5 @@ class SharedBuffer final {
 };
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/Utils.cpp
+++ b/backends/qualcomm/runtime/Utils.cpp
@@ -8,8 +8,8 @@
 #include <executorch/backends/qualcomm/runtime/Logging.h>
 #include <executorch/backends/qualcomm/runtime/Utils.h>
 #include <sys/stat.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 
 void CreateDirectory(const std::string& path) {
@@ -32,5 +32,5 @@ void CreateDirectory(const std::string& path) {
 }
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/Utils.h
+++ b/backends/qualcomm/runtime/Utils.h
@@ -9,12 +9,12 @@
 
 #include <string>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 // Create Directory
 void CreateDirectory(const std::string& path);
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnBackendCache.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendCache.cpp
@@ -7,9 +7,12 @@
  */
 #include <executorch/backends/qualcomm/aot/ir/qcir_utils.h>
 #include <executorch/backends/qualcomm/runtime/backends/QnnBackendCache.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
+
 Error QnnBackendCache::GetQnnGraphInfoFromBinary() {
   const QnnSystemInterface& qnn_sys_interface =
       qnn_sys_impl_.GetQnnSystemInterface();
@@ -170,5 +173,5 @@ std::vector<Qnn_Tensor_t> QnnBackendCache::GetGraphOutputs() {
   return output_tensor_structs_;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnBackendCache.h
+++ b/backends/qualcomm/runtime/backends/QnnBackendCache.h
@@ -12,8 +12,8 @@
 
 #include <string>
 #include <vector>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class QnnBackendCache {
  public:
@@ -51,16 +51,16 @@ class QnnBackendCache {
     return graph_name_;
   }
 
-  Error Configure();
+  executorch::runtime::Error Configure();
 
  protected:
-  virtual Error RetrieveBackendBinaryInfo(
+  virtual executorch::runtime::Error RetrieveBackendBinaryInfo(
       __ET_UNUSED const QnnSystemContext_BinaryInfo_t* binaryinfo) {
-    return Error::Ok;
+    return executorch::runtime::Error::Ok;
   }
 
  private:
-  Error GetQnnGraphInfoFromBinary();
+  executorch::runtime::Error GetQnnGraphInfoFromBinary();
 
   CacheState state_{INVALID};
 
@@ -72,5 +72,5 @@ class QnnBackendCache {
   std::vector<Qnn_Tensor_t> output_tensor_structs_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnBackendCommon.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendCommon.cpp
@@ -6,9 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <executorch/backends/qualcomm/runtime/backends/QnnBackendCommon.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
+
 QnnBackend::~QnnBackend() {
   const QnnInterface& qnn_interface = implementation_.GetQnnInterface();
   Qnn_ErrorHandle_t error = QNN_SUCCESS;
@@ -133,5 +136,5 @@ Error QnnBackend::VersionChecker(
   return Error::Ok;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnBackendCommon.h
+++ b/backends/qualcomm/runtime/backends/QnnBackendCommon.h
@@ -17,8 +17,8 @@
 #include "QnnBackend.h"
 #include "QnnCommon.h"
 #include "QnnTypes.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 // qnn backend
 class QnnBackend {
@@ -34,7 +34,7 @@ class QnnBackend {
     return false;
   }
 
-  Error Configure();
+  executorch::runtime::Error Configure();
 
   Qnn_ErrorHandle_t BackendValidateOpConfig(const Qnn_OpConfig_t& op_config) {
     return implementation_.GetQnnInterface().qnn_backend_validate_op_config(
@@ -45,23 +45,25 @@ class QnnBackend {
     return handle_;
   }
 
-  Error VerifyQNNSDKVersion(const QnnExecuTorchBackendType backend_id);
+  executorch::runtime::Error VerifyQNNSDKVersion(
+      const QnnExecuTorchBackendType backend_id);
 
  protected:
   virtual Qnn_Version_t GetExpectedBackendVersion() const = 0;
-  virtual Error MakeConfig(std::vector<const QnnBackend_Config_t*>& config) {
-    return Error::Ok;
+  virtual executorch::runtime::Error MakeConfig(
+      std::vector<const QnnBackend_Config_t*>& config) {
+    return executorch::runtime::Error::Ok;
   };
 
  private:
   Qnn_BackendHandle_t handle_;
   const QnnImplementation& implementation_;
   QnnLogger* logger_;
-  Error VersionChecker(
+  executorch::runtime::Error VersionChecker(
       const Qnn_Version_t& qnn_version,
       const Qnn_Version_t& expected,
       const std::string& prefix);
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnBackendFactory.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendFactory.cpp
@@ -7,9 +7,12 @@
  */
 #include <executorch/backends/qualcomm/runtime/Logging.h>
 #include <executorch/backends/qualcomm/runtime/backends/QnnBackendFactory.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
+
 std::unique_ptr<BackendConfigParameters> QnnBackendFactory::Create(
     const QnnImplementation& implementation,
     QnnLogger* logger,
@@ -93,5 +96,5 @@ std::unique_ptr<BackendConfigParameters> QnnBackendFactory::Create(
   return nullptr;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnBackendFactory.h
+++ b/backends/qualcomm/runtime/backends/QnnBackendFactory.h
@@ -24,8 +24,8 @@
 #include <executorch/backends/qualcomm/schema_generated.h>
 
 #include <memory>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 typedef enum { UNINITIALIZED, INITIALIZED } BackendInitializeState;
 
@@ -70,5 +70,5 @@ class QnnBackendFactory {
       const QnnExecuTorchOptions* options);
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnContextCommon.cpp
+++ b/backends/qualcomm/runtime/backends/QnnContextCommon.cpp
@@ -7,9 +7,12 @@
  */
 
 #include <executorch/backends/qualcomm/runtime/backends/QnnContextCommon.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
+
 QnnContext::~QnnContext() {
   const QnnInterface& qnn_interface = implementation_.GetQnnInterface();
   Qnn_ErrorHandle_t error = QNN_SUCCESS;
@@ -120,5 +123,5 @@ Error QnnContext::GetContextBinary(
   return Error::Ok;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnContextCommon.h
+++ b/backends/qualcomm/runtime/backends/QnnContextCommon.h
@@ -13,8 +13,8 @@
 #include <executorch/backends/qualcomm/runtime/backends/QnnDeviceCommon.h>
 
 #include <memory>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class QnnContext {
  public:
@@ -30,7 +30,7 @@ class QnnContext {
         cache_(cache) {}
 
   virtual ~QnnContext();
-  Error Configure();
+  executorch::runtime::Error Configure();
 
   Qnn_ContextHandle_t GetHandle() const {
     return handle_;
@@ -50,15 +50,16 @@ class QnnContext {
     return cache_->GetCacheState();
   };
 
-  Error GetContextBinary(
+  executorch::runtime::Error GetContextBinary(
       QnnExecuTorchContextBinary& qnn_executorch_context_binary);
 
  protected:
-  virtual Error MakeConfig(std::vector<const QnnContext_Config_t*>& config) {
-    return Error::Ok;
+  virtual executorch::runtime::Error MakeConfig(
+      std::vector<const QnnContext_Config_t*>& config) {
+    return executorch::runtime::Error::Ok;
   };
-  virtual Error AfterConfigure() {
-    return Error::Ok;
+  virtual executorch::runtime::Error AfterConfigure() {
+    return executorch::runtime::Error::Ok;
   };
 
  private:
@@ -70,5 +71,5 @@ class QnnContext {
   std::vector<char> binary_buffer_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnDeviceCommon.cpp
+++ b/backends/qualcomm/runtime/backends/QnnDeviceCommon.cpp
@@ -6,9 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <executorch/backends/qualcomm/runtime/backends/QnnDeviceCommon.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
+
 QnnDevice::~QnnDevice() {
   const QnnInterface& qnn_interface = implementation_.GetQnnInterface();
   Qnn_ErrorHandle_t error = QNN_SUCCESS;
@@ -60,5 +63,5 @@ Error QnnDevice::Configure() {
   return Error::Ok;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnDeviceCommon.h
+++ b/backends/qualcomm/runtime/backends/QnnDeviceCommon.h
@@ -15,8 +15,8 @@
 #include <vector>
 
 #include "QnnDevice.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class QnnDevice {
  public:
@@ -29,15 +29,16 @@ class QnnDevice {
     return handle_;
   }
 
-  Error Configure();
+  executorch::runtime::Error Configure();
 
  protected:
-  virtual Error MakeConfig(std::vector<const QnnDevice_Config_t*>& config) {
-    return Error::Ok;
+  virtual executorch::runtime::Error MakeConfig(
+      std::vector<const QnnDevice_Config_t*>& config) {
+    return executorch::runtime::Error::Ok;
   };
 
-  virtual Error AfterCreateDevice() {
-    return Error::Ok;
+  virtual executorch::runtime::Error AfterCreateDevice() {
+    return executorch::runtime::Error::Ok;
   };
   const QnnImplementation& implementation_;
 
@@ -46,5 +47,5 @@ class QnnDevice {
   QnnLogger* logger_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnFunctionInterface.h
+++ b/backends/qualcomm/runtime/backends/QnnFunctionInterface.h
@@ -18,8 +18,8 @@
     return (qnn_interface_->QNN_INTERFACE_VER_NAME.pointer_name)( \
         std::forward<Args>(args)...);                             \
   }
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 using QnnInterfaceGetProvidersFn = decltype(QnnInterface_getProviders);
 using QnnSaverInitializeFn = decltype(QnnSaver_initialize);
@@ -106,5 +106,5 @@ class QnnInterface {
   const QnnInterface_t* qnn_interface_{nullptr};
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnGraphCommon.cpp
+++ b/backends/qualcomm/runtime/backends/QnnGraphCommon.cpp
@@ -6,9 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <executorch/backends/qualcomm/runtime/backends/QnnGraphCommon.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
+
 Error QnnGraph::Configure() {
   // create qnn backend
   const QnnInterface& qnn_interface = implementation_.GetQnnInterface();
@@ -104,5 +107,5 @@ Error QnnGraph::EnsureTensorInQnnGraph(
   return Error::Ok;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnGraphCommon.h
+++ b/backends/qualcomm/runtime/backends/QnnGraphCommon.h
@@ -16,8 +16,8 @@
 #include <vector>
 
 #include "QnnCommon.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 // qnn graph
 class QnnGraph {
@@ -37,7 +37,7 @@ class QnnGraph {
 
   virtual ~QnnGraph(){};
 
-  Error Configure();
+  executorch::runtime::Error Configure();
 
   Qnn_ErrorHandle_t GraphExecute(
       const std::vector<Qnn_Tensor_t>& input_tensor_structs,
@@ -47,14 +47,15 @@ class QnnGraph {
     return implementation_.GetQnnInterface().qnn_graph_add_node(
         handle_, op_config);
   };
-  Error EnsureTensorInQnnGraph(
+  executorch::runtime::Error EnsureTensorInQnnGraph(
       const std::shared_ptr<TensorWrapper>& tensor_wrapper);
 
   Qnn_ErrorHandle_t GraphFinalize() {
     return implementation_.GetQnnInterface().qnn_graph_finalize(
         handle_, nullptr /* profile_handle */, nullptr /* signal_handle */);
   };
-  Qnn_ErrorHandle_t ProfileExecuteData(EventTracer* event_tracer) {
+  Qnn_ErrorHandle_t ProfileExecuteData(
+      executorch::runtime::EventTracer* event_tracer) {
     return profile_->ProfileData(event_tracer);
   };
   Qnn_GraphHandle_t GetHandle() {
@@ -62,8 +63,9 @@ class QnnGraph {
   }
 
  protected:
-  virtual Error MakeConfig(std::vector<const QnnGraph_Config_t*>& config) {
-    return Error::Ok;
+  virtual executorch::runtime::Error MakeConfig(
+      std::vector<const QnnGraph_Config_t*>& config) {
+    return executorch::runtime::Error::Ok;
   };
 
  private:
@@ -76,5 +78,5 @@ class QnnGraph {
   std::unique_ptr<QnnProfile> profile_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnImplementation.cpp
+++ b/backends/qualcomm/runtime/backends/QnnImplementation.cpp
@@ -9,9 +9,12 @@
 #include <executorch/backends/qualcomm/runtime/backends/QnnImplementation.h>
 
 #include "QnnInterface.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
+
 template <typename Fn>
 Fn loadQnnFunction(void* handle, const char* function_name) {
   return reinterpret_cast<Fn>(dlsym(handle, function_name)); // NOLINT
@@ -216,5 +219,5 @@ const QnnInterface& QnnImplementation::GetQnnInterface() const {
   return qnn_interface_;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnImplementation.h
+++ b/backends/qualcomm/runtime/backends/QnnImplementation.h
@@ -13,8 +13,8 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class QnnImplementation {
  public:
@@ -23,20 +23,20 @@ class QnnImplementation {
   explicit QnnImplementation(std::string lib_path)
       : lib_path_(std::move(lib_path)){};
 
-  Error Load(const QnnSaver_Config_t** saver_config);
+  executorch::runtime::Error Load(const QnnSaver_Config_t** saver_config);
 
   const QnnInterface& GetQnnInterface() const;
 
-  Error TerminateAllBackends();
+  executorch::runtime::Error TerminateAllBackends();
 
  private:
   static constexpr const int required_num_providers_{1};
 
-  static Error StartBackend(
+  static executorch::runtime::Error StartBackend(
       const std::string& lib_path,
       const QnnSaver_Config_t** saver_config);
 
-  static Error InitBackend(
+  static executorch::runtime::Error InitBackend(
       void* const lib_handle,
       const QnnSaver_Config_t** saver_config);
 
@@ -50,5 +50,5 @@ class QnnImplementation {
   static std::mutex be_init_mutex_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnLogger.cpp
+++ b/backends/qualcomm/runtime/backends/QnnLogger.cpp
@@ -14,8 +14,8 @@
 #include <memory>
 
 #include "QnnLog.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 void LoggingCallback(
     const char* fmt,
@@ -101,5 +101,5 @@ QnnLogger::~QnnLogger() {
   }
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnLogger.h
+++ b/backends/qualcomm/runtime/backends/QnnLogger.h
@@ -9,8 +9,8 @@
 
 #include <executorch/backends/qualcomm/runtime/backends/QnnImplementation.h>
 #include <executorch/backends/qualcomm/schema_generated.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 void LoggingCallback(
     const char* fmt,
@@ -35,5 +35,5 @@ class QnnLogger {
   const QnnImplementation& implementation_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnMemManager.cpp
+++ b/backends/qualcomm/runtime/backends/QnnMemManager.cpp
@@ -7,9 +7,11 @@
  */
 #include <executorch/backends/qualcomm/runtime/backends/QnnMemManager.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
 
 bool QnnMemManager::IsRegistered(Qnn_MemHandle_t handle, void* mem_ptr) {
   auto it = registered_map_.find(handle);
@@ -169,5 +171,5 @@ void QnnMemManager::DeRegisterMem() {
 }
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnMemManager.h
+++ b/backends/qualcomm/runtime/backends/QnnMemManager.h
@@ -13,8 +13,8 @@
 #include <unordered_map>
 #include "HTP/QnnHtpMem.h"
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 
 class QnnMemManager {
@@ -27,12 +27,12 @@ class QnnMemManager {
     DeRegisterMem();
   }
 
-  Error RegisterIonMem(
+  executorch::runtime::Error RegisterIonMem(
       const std::shared_ptr<TensorWrapper>& tensor_wrapper,
       int32_t mem_fd,
       void* mem_ptr);
 
-  Error RegisterCustomMem(
+  executorch::runtime::Error RegisterCustomMem(
       const std::shared_ptr<TensorWrapper>& tensor_wrapper,
       int32_t mem_fd,
       void* mem_ptr,
@@ -42,7 +42,7 @@ class QnnMemManager {
 
   // Pre-register custom mem handle from SharedBuffer. Bring forward the
   // memHandle creating time from execution to initialization.
-  Error PreRegisterCustomMemHandle(
+  executorch::runtime::Error PreRegisterCustomMemHandle(
       int32_t mem_fd,
       void* unaligned_custom_mem_base,
       size_t total_custom_mem_size,
@@ -53,7 +53,7 @@ class QnnMemManager {
 
   void* GetPreRegisteredHandle(const CustomMemTensorInfo& info);
 
-  Error SetMemHandle(
+  executorch::runtime::Error SetMemHandle(
       const std::shared_ptr<TensorWrapper>& tensor_wrapper,
       void* mem_ptr,
       Qnn_MemHandle_t handle);
@@ -65,15 +65,22 @@ class QnnMemManager {
   QnnContext* context_;
   std::unordered_map<Qnn_MemHandle_t, void*> registered_map_;
   std::unordered_map<CustomMemTensorInfo, void*> pre_registered_handles_;
-  std::unordered_map<ScalarType, Qnn_DataType_t> scalar_type_to_qnn_dtype_ = {
-      {ScalarType::Int, Qnn_DataType_t::QNN_DATATYPE_INT_32},
-      {ScalarType::Float, Qnn_DataType_t::QNN_DATATYPE_FLOAT_32},
-      {ScalarType::Char, Qnn_DataType_t::QNN_DATATYPE_SFIXED_POINT_8},
-      {ScalarType::Short, Qnn_DataType_t::QNN_DATATYPE_SFIXED_POINT_16},
-      {ScalarType::Byte, Qnn_DataType_t::QNN_DATATYPE_UFIXED_POINT_8},
-      {ScalarType::Bits16, Qnn_DataType_t::QNN_DATATYPE_UFIXED_POINT_16},
+  std::unordered_map<executorch::aten::ScalarType, Qnn_DataType_t>
+      scalar_type_to_qnn_dtype_ = {
+          {executorch::aten::ScalarType::Int,
+           Qnn_DataType_t::QNN_DATATYPE_INT_32},
+          {executorch::aten::ScalarType::Float,
+           Qnn_DataType_t::QNN_DATATYPE_FLOAT_32},
+          {executorch::aten::ScalarType::Char,
+           Qnn_DataType_t::QNN_DATATYPE_SFIXED_POINT_8},
+          {executorch::aten::ScalarType::Short,
+           Qnn_DataType_t::QNN_DATATYPE_SFIXED_POINT_16},
+          {executorch::aten::ScalarType::Byte,
+           Qnn_DataType_t::QNN_DATATYPE_UFIXED_POINT_8},
+          {executorch::aten::ScalarType::Bits16,
+           Qnn_DataType_t::QNN_DATATYPE_UFIXED_POINT_16},
   };
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnProfiler.cpp
+++ b/backends/qualcomm/runtime/backends/QnnProfiler.cpp
@@ -8,8 +8,8 @@
 
 #include <executorch/backends/qualcomm/runtime/backends/QnnProfiler.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 
 QnnProfile::QnnProfile(
@@ -34,7 +34,8 @@ QnnProfile::QnnProfile(
   }
 }
 
-Qnn_ErrorHandle_t QnnProfile::ProfileData(EventTracer* event_tracer) {
+Qnn_ErrorHandle_t QnnProfile::ProfileData(
+    executorch::runtime::EventTracer* event_tracer) {
   const QnnInterface& qnn_interface = implementation_.GetQnnInterface();
   const QnnProfile_EventId_t* events_ptr = nullptr;
   const QnnProfile_EventId_t* sub_events_ptr = nullptr;
@@ -88,11 +89,11 @@ Qnn_ErrorHandle_t QnnProfile::ProfileData(EventTracer* event_tracer) {
         if (sub_event_data.type == QNN_PROFILE_EVENTTYPE_NODE &&
             (sub_event_data.unit == QNN_PROFILE_EVENTUNIT_MICROSEC ||
              sub_event_data.unit == QNN_PROFILE_EVENTUNIT_CYCLES)) {
-          torch::executor::event_tracer_log_profiling_delegate(
+          executorch::runtime::event_tracer_log_profiling_delegate(
               event_tracer,
               sub_event_data.identifier,
               /*delegate_debug_id=*/
-              static_cast<torch::executor::DebugHandle>(-1),
+              static_cast<executorch::runtime::DebugHandle>(-1),
               0,
               sub_event_data.value);
         }
@@ -117,5 +118,5 @@ QnnProfile::~QnnProfile() {
   }
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnProfiler.h
+++ b/backends/qualcomm/runtime/backends/QnnProfiler.h
@@ -12,8 +12,8 @@
 #include <executorch/backends/qualcomm/runtime/backends/QnnImplementation.h>
 #include <executorch/runtime/core/event_tracer_hooks_delegate.h>
 #include "QnnProfile.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 
 class QnnProfile {
@@ -23,7 +23,7 @@ class QnnProfile {
       QnnBackend* backend,
       const QnnExecuTorchProfileLevel& profile_level);
   ~QnnProfile();
-  Qnn_ErrorHandle_t ProfileData(EventTracer* event_tracer);
+  Qnn_ErrorHandle_t ProfileData(executorch::runtime::EventTracer* event_tracer);
 
   Qnn_ProfileHandle_t GetHandle() {
     return handle_;
@@ -35,5 +35,5 @@ class QnnProfile {
   QnnBackend* backend_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnSysFunctionInterface.h
+++ b/backends/qualcomm/runtime/backends/QnnSysFunctionInterface.h
@@ -17,8 +17,8 @@
     return (qnn_sys_interface_->QNN_SYSTEM_INTERFACE_VER_NAME.pointer_name)( \
         std::forward<Args>(args)...);                                        \
   }
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 using QnnSystemInterfaceGetProvidersFn =
     decltype(QnnSystemInterface_getProviders);
@@ -47,5 +47,5 @@ class QnnSystemInterface {
   const QnnSystemInterface_t* qnn_sys_interface_{nullptr};
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnSysImplementation.cpp
+++ b/backends/qualcomm/runtime/backends/QnnSysImplementation.cpp
@@ -8,9 +8,12 @@
 
 #include <dlfcn.h>
 #include <executorch/backends/qualcomm/runtime/backends/QnnSysImplementation.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
+
 Error QnnSystemImplementation::Load() {
   Qnn_ErrorHandle_t error = QNN_SUCCESS;
 
@@ -86,5 +89,5 @@ const QnnSystemInterface& QnnSystemImplementation::GetQnnSystemInterface()
   return qnn_sys_interface_;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/QnnSysImplementation.h
+++ b/backends/qualcomm/runtime/backends/QnnSysImplementation.h
@@ -11,19 +11,19 @@
 #include <executorch/backends/qualcomm/runtime/backends/QnnSysFunctionInterface.h>
 
 #include <string>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class QnnSystemImplementation {
  public:
   explicit QnnSystemImplementation(std::string lib_path)
       : lib_path_(std::move(lib_path)){};
 
-  Error Load();
+  executorch::runtime::Error Load();
 
   const QnnSystemInterface& GetQnnSystemInterface() const;
 
-  Error Unload();
+  executorch::runtime::Error Unload();
 
  private:
   static constexpr const int required_num_providers_{1};
@@ -33,5 +33,5 @@ class QnnSystemImplementation {
   void* lib_handle_{nullptr};
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpBackend.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpBackend.h
@@ -11,8 +11,8 @@
 #include "HTP/QnnHtpCommon.h"
 #include "HTP/QnnHtpProfile.h"
 #include "QnnTypes.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class HtpBackend : public QnnBackend {
  public:
@@ -35,10 +35,11 @@ class HtpBackend : public QnnBackend {
   }
 
  protected:
-  Error MakeConfig(std::vector<const QnnBackend_Config_t*>& config) override {
-    return Error::Ok;
+  executorch::runtime::Error MakeConfig(
+      std::vector<const QnnBackend_Config_t*>& config) override {
+    return executorch::runtime::Error::Ok;
   }
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpBackendCache.cpp
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpBackendCache.cpp
@@ -8,9 +8,12 @@
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpBackendCache.h>
 #include "HTP/QnnHtpSystemContext.h"
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
+
 Error HtpBackendCache::RetrieveBackendBinaryInfo(
     const QnnSystemContext_BinaryInfo_t* binaryinfo) {
   QnnHtpSystemContext_HwBlobInfo_t* htp_hwblobinfo = nullptr;
@@ -47,5 +50,5 @@ Error HtpBackendCache::RetrieveBackendBinaryInfo(
 }
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpBackendCache.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpBackendCache.h
@@ -8,8 +8,8 @@
 #pragma once
 #include <executorch/backends/qualcomm/runtime/backends/QnnBackendCache.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class HtpBackendCache : public QnnBackendCache {
  public:
@@ -22,12 +22,12 @@ class HtpBackendCache : public QnnBackendCache {
   }
 
  protected:
-  Error RetrieveBackendBinaryInfo(
+  executorch::runtime::Error RetrieveBackendBinaryInfo(
       const QnnSystemContext_BinaryInfo_t* binaryinfo) override;
 
  private:
   uint64_t spill_fill_buf_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpContext.cpp
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpContext.cpp
@@ -12,9 +12,11 @@
 #include "HTP/QnnHtpCommon.h"
 #include "Saver/QnnSaverCommon.h"
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
 
 Error HtpContext::MakeConfig(std::vector<const QnnContext_Config_t*>& config) {
   const std::vector<QnnContext_CustomConfig_t>& context_custom_config =
@@ -45,5 +47,5 @@ Error HtpContext::AfterConfigure() {
 }
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpContext.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpContext.h
@@ -12,8 +12,8 @@
 #include <executorch/backends/qualcomm/runtime/backends/QnnContextCommon.h>
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpContextCustomConfig.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 
 class HtpContext : public QnnContext {
@@ -35,8 +35,9 @@ class HtpContext : public QnnContext {
   }
 
  protected:
-  Error MakeConfig(std::vector<const QnnContext_Config_t*>& config) override;
-  Error AfterConfigure() override;
+  executorch::runtime::Error MakeConfig(
+      std::vector<const QnnContext_Config_t*>& config) override;
+  executorch::runtime::Error AfterConfigure() override;
 
  private:
   std::vector<QnnContext_Config_t> context_config_;
@@ -46,5 +47,5 @@ class HtpContext : public QnnContext {
 };
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpContextCustomConfig.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpContextCustomConfig.h
@@ -16,8 +16,8 @@
 
 #include "HTP/QnnHtpContext.h"
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 
 using namespace qnn_delegate;
@@ -46,5 +46,5 @@ class HtpContextCustomConfig {
 };
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpDevice.cpp
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpDevice.cpp
@@ -12,9 +12,11 @@
 #include "HTP/QnnHtpCommon.h"
 #include "Saver/QnnSaverCommon.h"
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
 
 // constexpr config values
 constexpr const int kSleepMinLatency = 40;
@@ -425,5 +427,5 @@ Error HtpDevice::AfterCreateDevice() {
 }
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpDevice.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpDevice.h
@@ -17,8 +17,8 @@
 #define QNN_HTP_DEPRECATED_HTP_ARCH_VERSION_MAJOR 5
 #define QNN_HTP_DEPRECATED_HTP_ARCH_VERSION_MINOR 14
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class HtpDevice : public QnnDevice {
  public:
@@ -45,9 +45,10 @@ class HtpDevice : public QnnDevice {
   };
 
  protected:
-  Error MakeConfig(std::vector<const QnnDevice_Config_t*>& config) override;
+  executorch::runtime::Error MakeConfig(
+      std::vector<const QnnDevice_Config_t*>& config) override;
 
-  Error AfterCreateDevice() override;
+  executorch::runtime::Error AfterCreateDevice() override;
 
  private:
   void PerformanceVote();
@@ -92,5 +93,5 @@ class HtpDevice : public QnnDevice {
   const QnnExecuTorchHtpBackendOptions* htp_options_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpDeviceCustomConfig.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpDeviceCustomConfig.h
@@ -13,8 +13,8 @@
 #include <vector>
 
 #include "HTP/QnnHtpDevice.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 using namespace qnn_delegate;
 class HtpDeviceCustomConfig {
@@ -37,5 +37,5 @@ class HtpDeviceCustomConfig {
   std::vector<std::unique_ptr<QnnHtpDevice_CustomConfig_t>> htp_device_config_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpDevicePlatformInfoConfig.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpDevicePlatformInfoConfig.h
@@ -13,8 +13,8 @@
 #include <vector>
 
 #include "HTP/QnnHtpDevice.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 using namespace qnn_delegate;
 class HtpDevicePlatformInfoConfig {
@@ -65,5 +65,5 @@ class HtpDevicePlatformInfoConfig {
       htp_device_info_extension_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpGraph.cpp
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpGraph.cpp
@@ -7,9 +7,11 @@
  */
 
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpGraph.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
+
+using executorch::runtime::Error;
 
 Error HtpGraph::MakeConfig(std::vector<const QnnGraph_Config_t*>& config) {
   const std::vector<QnnGraph_CustomConfig_t>& graph_custom_config =
@@ -31,5 +33,5 @@ Error HtpGraph::MakeConfig(std::vector<const QnnGraph_Config_t*>& config) {
   return Error::Ok;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpGraph.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpGraph.h
@@ -13,8 +13,8 @@
 #include <memory>
 
 #include "HTP/QnnHtpGraph.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 class HtpGraph : public QnnGraph {
  public:
@@ -35,7 +35,8 @@ class HtpGraph : public QnnGraph {
   ~HtpGraph() {}
 
  protected:
-  Error MakeConfig(std::vector<const QnnGraph_Config_t*>& config) override;
+  executorch::runtime::Error MakeConfig(
+      std::vector<const QnnGraph_Config_t*>& config) override;
 
  private:
   std::vector<QnnGraph_Config_t> graph_config_;
@@ -44,5 +45,5 @@ class HtpGraph : public QnnGraph {
   [[maybe_unused]] const QnnExecuTorchHtpBackendOptions* htp_options_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpGraphCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpGraphCustomConfig.cpp
@@ -8,8 +8,8 @@
 #include <executorch/backends/qualcomm/runtime/Logging.h>
 #include <executorch/backends/qualcomm/runtime/backends/QnnBackendCache.h>
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpGraphCustomConfig.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 std::vector<QnnGraph_CustomConfig_t>
 HtpGraphCustomConfig::CreateGraphCustomConfig(
@@ -74,5 +74,5 @@ HtpGraphCustomConfig::CreateGraphCustomConfig(
   return ret;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpGraphCustomConfig.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpGraphCustomConfig.h
@@ -14,8 +14,8 @@
 #include <vector>
 
 #include "HTP/QnnHtpGraph.h"
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 using namespace qnn_delegate;
 class HtpGraphCustomConfig {
@@ -41,5 +41,5 @@ class HtpGraphCustomConfig {
   const QnnContext* context_;
 };
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/aarch64/HtpContextCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/htpbackend/aarch64/HtpContextCustomConfig.cpp
@@ -9,8 +9,8 @@
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpContext.h>
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpContextCustomConfig.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 
 std::vector<QnnContext_CustomConfig_t>
@@ -35,5 +35,5 @@ HtpContextCustomConfig::CreateContextCustomConfig() {
 }
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/aarch64/HtpDeviceCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/htpbackend/aarch64/HtpDeviceCustomConfig.cpp
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpDeviceCustomConfig.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 std::vector<QnnDevice_CustomConfig_t>
 HtpDeviceCustomConfig::CreateDeviceCustomConfig(
@@ -15,5 +15,5 @@ HtpDeviceCustomConfig::CreateDeviceCustomConfig(
   return {};
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/aarch64/HtpDevicePlatformInfoConfig.cpp
+++ b/backends/qualcomm/runtime/backends/htpbackend/aarch64/HtpDevicePlatformInfoConfig.cpp
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpDevicePlatformInfoConfig.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 std::vector<QnnDevice_PlatformInfo_t*>
 HtpDevicePlatformInfoConfig::CreateDevicePlatformInfo(
@@ -15,5 +15,5 @@ HtpDevicePlatformInfoConfig::CreateDevicePlatformInfo(
   return {};
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/x86_64/HtpContextCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/htpbackend/x86_64/HtpContextCustomConfig.cpp
@@ -8,8 +8,8 @@
 
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpContextCustomConfig.h>
 
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 
 std::vector<QnnContext_CustomConfig_t>
@@ -18,5 +18,5 @@ HtpContextCustomConfig::CreateContextCustomConfig() {
 }
 
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/x86_64/HtpDeviceCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/htpbackend/x86_64/HtpDeviceCustomConfig.cpp
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpDeviceCustomConfig.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 std::vector<QnnDevice_CustomConfig_t>
 HtpDeviceCustomConfig::CreateDeviceCustomConfig(
@@ -24,5 +24,5 @@ HtpDeviceCustomConfig::CreateDeviceCustomConfig(
   return ret;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/htpbackend/x86_64/HtpDevicePlatformInfoConfig.cpp
+++ b/backends/qualcomm/runtime/backends/htpbackend/x86_64/HtpDevicePlatformInfoConfig.cpp
@@ -7,8 +7,8 @@
  */
 #include <executorch/backends/qualcomm/runtime/Logging.h>
 #include <executorch/backends/qualcomm/runtime/backends/htpbackend/HtpDevicePlatformInfoConfig.h>
-namespace torch {
-namespace executor {
+namespace executorch {
+namespace backends {
 namespace qnn {
 std::vector<QnnDevice_PlatformInfo_t*>
 HtpDevicePlatformInfoConfig::CreateDevicePlatformInfo(
@@ -57,5 +57,5 @@ HtpDevicePlatformInfoConfig::CreateDevicePlatformInfo(
   return ret;
 }
 } // namespace qnn
-} // namespace executor
-} // namespace torch
+} // namespace backends
+} // namespace executorch


### PR DESCRIPTION
Summary: Move the qualcomm backend out of the `torch::` namespace, and update to avoid using the `torch::` or `exec_aten::` namespaces.

Differential Revision: D64073805
