### PR TITLE
s/exec_aten::/executorch::aten::/ for extension/**/*.h

### DIFF
--- a/extension/android/jni/jni_layer_constants.h
+++ b/extension/android/jni/jni_layer_constants.h
@@ -37,7 +37,7 @@ constexpr static int kTensorDTypeBits4x2 = 20;
 constexpr static int kTensorDTypeBits8 = 21;
 constexpr static int kTensorDTypeBits16 = 22;
 
-using exec_aten::ScalarType;
+using executorch::aten::ScalarType;
 
 const std::unordered_map<ScalarType, int> scalar_type_to_java_dtype = {
     {ScalarType::Byte, kTensorDTypeUInt8},

--- a/extension/kernel_util/make_boxed_from_unboxed_functor.h
+++ b/extension/kernel_util/make_boxed_from_unboxed_functor.h
@@ -66,12 +66,12 @@ struct decay_if_not_tensor final {
   using type = std::decay_t<T>;
 };
 template <>
-struct decay_if_not_tensor<exec_aten::Tensor&> final {
-  using type = exec_aten::Tensor&;
+struct decay_if_not_tensor<executorch::aten::Tensor&> final {
+  using type = executorch::aten::Tensor&;
 };
 template <>
-struct decay_if_not_tensor<const exec_aten::Tensor&> final {
-  using type = const exec_aten::Tensor&;
+struct decay_if_not_tensor<const executorch::aten::Tensor&> final {
+  using type = const executorch::aten::Tensor&;
 };
 
 template <class T>
@@ -82,29 +82,30 @@ struct evalue_to_arg final {
 };
 
 template <>
-struct evalue_to_arg<exec_aten::Tensor&> final {
-  static exec_aten::Tensor& call(executorch::runtime::EValue& v) {
+struct evalue_to_arg<executorch::aten::Tensor&> final {
+  static executorch::aten::Tensor& call(executorch::runtime::EValue& v) {
     return v.toTensor();
   }
 };
 
 template <>
-struct evalue_to_arg<const exec_aten::Tensor&> final {
-  static const exec_aten::Tensor& call(executorch::runtime::EValue& v) {
+struct evalue_to_arg<const executorch::aten::Tensor&> final {
+  static const executorch::aten::Tensor& call(executorch::runtime::EValue& v) {
     return v.toTensor();
   }
 };
 
 template <class T>
-struct evalue_to_arg<exec_aten::optional<T>> final {
-  static exec_aten::optional<T> call(executorch::runtime::EValue& v) {
+struct evalue_to_arg<executorch::aten::optional<T>> final {
+  static executorch::aten::optional<T> call(executorch::runtime::EValue& v) {
     return v.toOptional<T>();
   }
 };
 
 template <class T>
-struct evalue_to_arg<exec_aten::ArrayRef<exec_aten::optional<T>>> final {
-  static exec_aten::ArrayRef<exec_aten::optional<T>> call(
+struct evalue_to_arg<executorch::aten::ArrayRef<executorch::aten::optional<T>>>
+    final {
+  static executorch::aten::ArrayRef<executorch::aten::optional<T>> call(
       executorch::runtime::EValue& v) {
     return v.toListOptionalTensor();
   }

--- a/extension/llm/runner/image_prefiller.h
+++ b/extension/llm/runner/image_prefiller.h
@@ -30,7 +30,7 @@ class ImagePrefiller {
    * It's passed as reference and will be updated inside this function.
    * @return The next token of the LLM Module after prefill.
    */
-  virtual ::executorch::runtime::Result<exec_aten::Tensor> prefill(
+  virtual ::executorch::runtime::Result<executorch::aten::Tensor> prefill(
       Image& image,
       int64_t& start_pos) = 0;
 

--- a/extension/llm/runner/text_decoder_runner.h
+++ b/extension/llm/runner/text_decoder_runner.h
@@ -37,7 +37,7 @@ class TextDecoderRunner {
    * Module.
    * @return The output of the LLM Module. This will be a tensor of logits.
    */
-  virtual ::executorch::runtime::Result<exec_aten::Tensor> step(
+  virtual ::executorch::runtime::Result<executorch::aten::Tensor> step(
       TensorPtr& input,
       TensorPtr& start_pos);
 
@@ -66,7 +66,8 @@ class TextDecoderRunner {
    * @param logits_tensor The logits tensor.
    * @return The next token.
    */
-  inline int32_t logits_to_token(const exec_aten::Tensor& logits_tensor) {
+  inline int32_t logits_to_token(
+      const executorch::aten::Tensor& logits_tensor) {
     int32_t result = 0;
     ET_SWITCH_THREE_TYPES(
         Float,

--- a/extension/llm/runner/text_token_generator.h
+++ b/extension/llm/runner/text_token_generator.h
@@ -53,7 +53,7 @@ class TextTokenGenerator {
     int64_t pos = start_pos; // position in the sequence
 
     std::vector<uint64_t> token_data; // allocate space for the tokens
-    std::vector<exec_aten::SizesType> token_shape;
+    std::vector<executorch::aten::SizesType> token_shape;
 
     // Token after prefill
     uint64_t cur_token = tokens.back();
@@ -70,9 +70,10 @@ class TextTokenGenerator {
     }
 
     // initialize tensor wrappers
-    auto tokens_managed =
-        from_blob(token_data.data(), token_shape, exec_aten::ScalarType::Long);
-    auto start_pos_managed = from_blob(&pos, {1}, exec_aten::ScalarType::Long);
+    auto tokens_managed = from_blob(
+        token_data.data(), token_shape, executorch::aten::ScalarType::Long);
+    auto start_pos_managed =
+        from_blob(&pos, {1}, executorch::aten::ScalarType::Long);
 
     should_stop_ = false;
 
@@ -83,7 +84,7 @@ class TextTokenGenerator {
           text_decoder_runner_->step(tokens_managed, start_pos_managed);
 
       ET_CHECK_OK_OR_RETURN_ERROR(logits_res.error());
-      exec_aten::Tensor& logits_tensor = logits_res.get();
+      executorch::aten::Tensor& logits_tensor = logits_res.get();
 
       prev_token = cur_token;
 

--- a/extension/tensor/tensor_ptr.h
+++ b/extension/tensor/tensor_ptr.h
@@ -22,7 +22,7 @@ namespace extension {
 /**
  * A smart pointer type for managing the lifecycle of a Tensor.
  */
-using TensorPtr = std::shared_ptr<exec_aten::Tensor>;
+using TensorPtr = std::shared_ptr<executorch::aten::Tensor>;
 
 /**
  * Creates a TensorPtr that manages a Tensor with the specified properties.
@@ -39,13 +39,14 @@ using TensorPtr = std::shared_ptr<exec_aten::Tensor>;
  * @return A TensorPtr that manages the newly created Tensor.
  */
 TensorPtr make_tensor_ptr(
-    std::vector<exec_aten::SizesType> sizes,
+    std::vector<executorch::aten::SizesType> sizes,
     void* data,
-    std::vector<exec_aten::DimOrderType> dim_order,
-    std::vector<exec_aten::StridesType> strides,
-    const exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    const exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND,
+    std::vector<executorch::aten::DimOrderType> dim_order,
+    std::vector<executorch::aten::StridesType> strides,
+    const executorch::aten::ScalarType type =
+        executorch::aten::ScalarType::Float,
+    const executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
     std::function<void(void*)> deleter = nullptr);
 
 /**
@@ -61,11 +62,12 @@ TensorPtr make_tensor_ptr(
  * @return A TensorPtr that manages the newly created Tensor.
  */
 inline TensorPtr make_tensor_ptr(
-    std::vector<exec_aten::SizesType> sizes,
+    std::vector<executorch::aten::SizesType> sizes,
     void* data,
-    const exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    const exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND,
+    const executorch::aten::ScalarType type =
+        executorch::aten::ScalarType::Float,
+    const executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
     std::function<void(void*)> deleter = nullptr) {
   return make_tensor_ptr(
       std::move(sizes), data, {}, {}, type, dynamism, std::move(deleter));
@@ -93,15 +95,16 @@ inline TensorPtr make_tensor_ptr(
  */
 template <
     typename T = float,
-    exec_aten::ScalarType deduced_type = runtime::CppTypeToScalarType<T>::value>
+    executorch::aten::ScalarType deduced_type =
+        runtime::CppTypeToScalarType<T>::value>
 inline TensorPtr make_tensor_ptr(
-    std::vector<exec_aten::SizesType> sizes,
+    std::vector<executorch::aten::SizesType> sizes,
     std::vector<T> data,
-    std::vector<exec_aten::DimOrderType> dim_order = {},
-    std::vector<exec_aten::StridesType> strides = {},
-    exec_aten::ScalarType type = deduced_type,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    std::vector<executorch::aten::DimOrderType> dim_order = {},
+    std::vector<executorch::aten::StridesType> strides = {},
+    executorch::aten::ScalarType type = deduced_type,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   if (type != deduced_type) {
     ET_CHECK_MSG(
         runtime::canCast(deduced_type, type),
@@ -157,13 +160,15 @@ inline TensorPtr make_tensor_ptr(
  */
 template <
     typename T = float,
-    exec_aten::ScalarType deduced_type = runtime::CppTypeToScalarType<T>::value>
+    executorch::aten::ScalarType deduced_type =
+        runtime::CppTypeToScalarType<T>::value>
 inline TensorPtr make_tensor_ptr(
     std::vector<T> data,
-    exec_aten::ScalarType type = deduced_type,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
-  std::vector<exec_aten::SizesType> sizes{exec_aten::SizesType(data.size())};
+    executorch::aten::ScalarType type = deduced_type,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+  std::vector<executorch::aten::SizesType> sizes{
+      executorch::aten::SizesType(data.size())};
   return make_tensor_ptr(
       std::move(sizes), std::move(data), {0}, {1}, type, dynamism);
 }
@@ -192,15 +197,16 @@ inline TensorPtr make_tensor_ptr(
  */
 template <
     typename T = float,
-    exec_aten::ScalarType deduced_type = runtime::CppTypeToScalarType<T>::value>
+    executorch::aten::ScalarType deduced_type =
+        runtime::CppTypeToScalarType<T>::value>
 inline TensorPtr make_tensor_ptr(
-    std::vector<exec_aten::SizesType> sizes,
+    std::vector<executorch::aten::SizesType> sizes,
     std::initializer_list<T> list,
-    std::vector<exec_aten::DimOrderType> dim_order = {},
-    std::vector<exec_aten::StridesType> strides = {},
-    exec_aten::ScalarType type = deduced_type,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    std::vector<executorch::aten::DimOrderType> dim_order = {},
+    std::vector<executorch::aten::StridesType> strides = {},
+    executorch::aten::ScalarType type = deduced_type,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return make_tensor_ptr(
       std::move(sizes),
       std::vector<T>(std::move(list)),
@@ -231,13 +237,15 @@ inline TensorPtr make_tensor_ptr(
  */
 template <
     typename T = float,
-    exec_aten::ScalarType deduced_type = runtime::CppTypeToScalarType<T>::value>
+    executorch::aten::ScalarType deduced_type =
+        runtime::CppTypeToScalarType<T>::value>
 inline TensorPtr make_tensor_ptr(
     std::initializer_list<T> list,
-    exec_aten::ScalarType type = deduced_type,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
-  std::vector<exec_aten::SizesType> sizes{exec_aten::SizesType(list.size())};
+    executorch::aten::ScalarType type = deduced_type,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+  std::vector<executorch::aten::SizesType> sizes{
+      executorch::aten::SizesType(list.size())};
   return make_tensor_ptr(
       std::move(sizes), std::move(list), {0}, {1}, type, dynamism);
 }
@@ -270,13 +278,13 @@ inline TensorPtr make_tensor_ptr(T value) {
  * @return A TensorPtr managing the newly created Tensor.
  */
 TensorPtr make_tensor_ptr(
-    std::vector<exec_aten::SizesType> sizes,
+    std::vector<executorch::aten::SizesType> sizes,
     std::vector<uint8_t> data,
-    std::vector<exec_aten::DimOrderType> dim_order,
-    std::vector<exec_aten::StridesType> strides,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND);
+    std::vector<executorch::aten::DimOrderType> dim_order,
+    std::vector<executorch::aten::StridesType> strides,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND);
 
 /**
  * Creates a TensorPtr that manages a Tensor with the specified properties.
@@ -292,11 +300,11 @@ TensorPtr make_tensor_ptr(
  * @return A TensorPtr managing the newly created Tensor.
  */
 inline TensorPtr make_tensor_ptr(
-    std::vector<exec_aten::SizesType> sizes,
+    std::vector<executorch::aten::SizesType> sizes,
     std::vector<uint8_t> data,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return make_tensor_ptr(
       std::move(sizes), std::move(data), {}, {}, type, dynamism);
 }
@@ -309,21 +317,21 @@ inline TensorPtr make_tensor_ptr(
  * @return A new TensorPtr managing a Tensor with the same properties as the
  * original.
  */
-inline TensorPtr make_tensor_ptr(const exec_aten::Tensor& tensor) {
+inline TensorPtr make_tensor_ptr(const executorch::aten::Tensor& tensor) {
   return make_tensor_ptr(
-      std::vector<exec_aten::SizesType>(
+      std::vector<executorch::aten::SizesType>(
           tensor.sizes().begin(), tensor.sizes().end()),
       tensor.mutable_data_ptr(),
 #ifndef USE_ATEN_LIB
-      std::vector<exec_aten::DimOrderType>(
+      std::vector<executorch::aten::DimOrderType>(
           tensor.dim_order().begin(), tensor.dim_order().end()),
-      std::vector<exec_aten::StridesType>(
+      std::vector<executorch::aten::StridesType>(
           tensor.strides().begin(), tensor.strides().end()),
       tensor.scalar_type(),
       tensor.shape_dynamism()
 #else // USE_ATEN_LIB
       {},
-      std::vector<exec_aten::StridesType>(
+      std::vector<executorch::aten::StridesType>(
           tensor.strides().begin(), tensor.strides().end()),
       tensor.scalar_type()
 #endif // USE_ATEN_LIB
@@ -339,7 +347,7 @@ inline TensorPtr make_tensor_ptr(const exec_aten::Tensor& tensor) {
  * @return A new TensorPtr that manages a Tensor with the same properties as the
  * original but with copied data.
  */
-TensorPtr clone_tensor_ptr(const exec_aten::Tensor& tensor);
+TensorPtr clone_tensor_ptr(const executorch::aten::Tensor& tensor);
 
 /**
  * Creates a new TensorPtr by cloning the given TensorPtr, copying the
@@ -363,7 +371,7 @@ inline TensorPtr clone_tensor_ptr(const TensorPtr& tensor) {
 ET_NODISCARD
 runtime::Error resize_tensor_ptr(
     TensorPtr& tensor,
-    const std::vector<exec_aten::SizesType>& sizes);
+    const std::vector<executorch::aten::SizesType>& sizes);
 
 } // namespace extension
 } // namespace executorch

--- a/extension/tensor/tensor_ptr_maker.h
+++ b/extension/tensor/tensor_ptr_maker.h
@@ -38,7 +38,7 @@ class TensorPtrMaker final {
    * @param type The scalar type (e.g., float, int, bool).
    * @return Rvalue to this TensorPtrMaker for method chaining.
    */
-  TensorPtrMaker&& type(exec_aten::ScalarType type) {
+  TensorPtrMaker&& type(executorch::aten::ScalarType type) {
     type_ = type;
     return std::move(*this);
   }
@@ -49,7 +49,8 @@ class TensorPtrMaker final {
    * @param dim_order A vector specifying the dimension order.
    * @return Rvalue to this TensorPtrMaker for method chaining.
    */
-  TensorPtrMaker&& dim_order(std::vector<exec_aten::DimOrderType> dim_order) {
+  TensorPtrMaker&& dim_order(
+      std::vector<executorch::aten::DimOrderType> dim_order) {
     dim_order_ = std::move(dim_order);
     return std::move(*this);
   }
@@ -60,7 +61,7 @@ class TensorPtrMaker final {
    * @param strides A vector specifying the stride for each dimension.
    * @return Rvalue to this TensorPtrMaker for method chaining.
    */
-  TensorPtrMaker&& strides(std::vector<exec_aten::StridesType> strides) {
+  TensorPtrMaker&& strides(std::vector<executorch::aten::StridesType> strides) {
     strides_ = std::move(strides);
     return std::move(*this);
   }
@@ -72,7 +73,7 @@ class TensorPtrMaker final {
    * bounded.
    * @return Rvalue to this TensorPtrMaker for method chaining.
    */
-  TensorPtrMaker&& dynamism(exec_aten::TensorShapeDynamism dynamism) {
+  TensorPtrMaker&& dynamism(executorch::aten::TensorShapeDynamism dynamism) {
     dynamism_ = dynamism;
     return std::move(*this);
   }
@@ -120,26 +121,26 @@ class TensorPtrMaker final {
  private:
   TensorPtrMaker(
       void* data,
-      std::vector<exec_aten::SizesType> sizes,
-      exec_aten::ScalarType type)
+      std::vector<executorch::aten::SizesType> sizes,
+      executorch::aten::ScalarType type)
       : sizes_(std::move(sizes)), data_(data), type_(type) {}
 
  private:
   // The following properties are required to create a Tensor.
   friend TensorPtrMaker for_blob(
       void* data,
-      std::vector<exec_aten::SizesType> sizes,
-      exec_aten::ScalarType type);
+      std::vector<executorch::aten::SizesType> sizes,
+      executorch::aten::ScalarType type);
 
  private:
-  std::vector<exec_aten::SizesType> sizes_;
-  std::vector<exec_aten::StridesType> strides_;
-  std::vector<exec_aten::DimOrderType> dim_order_;
+  std::vector<executorch::aten::SizesType> sizes_;
+  std::vector<executorch::aten::StridesType> strides_;
+  std::vector<executorch::aten::DimOrderType> dim_order_;
   std::function<void(void*)> deleter_ = nullptr;
   void* data_ = nullptr;
-  exec_aten::ScalarType type_ = exec_aten::ScalarType::Float;
-  exec_aten::TensorShapeDynamism dynamism_ =
-      exec_aten::TensorShapeDynamism::DYNAMIC_BOUND;
+  executorch::aten::ScalarType type_ = executorch::aten::ScalarType::Float;
+  executorch::aten::TensorShapeDynamism dynamism_ =
+      executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND;
 };
 
 /**
@@ -158,8 +159,8 @@ class TensorPtrMaker final {
  */
 inline TensorPtrMaker for_blob(
     void* data,
-    std::vector<exec_aten::SizesType> sizes,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float) {
+    std::vector<executorch::aten::SizesType> sizes,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float) {
   return TensorPtrMaker(data, std::move(sizes), type);
 }
 
@@ -180,10 +181,10 @@ inline TensorPtrMaker for_blob(
  */
 inline TensorPtr from_blob(
     void* data,
-    std::vector<exec_aten::SizesType> sizes,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    std::vector<executorch::aten::SizesType> sizes,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return for_blob(data, std::move(sizes), type)
       .dynamism(dynamism)
       .make_tensor_ptr();
@@ -208,11 +209,11 @@ inline TensorPtr from_blob(
  */
 inline TensorPtr from_blob(
     void* data,
-    std::vector<exec_aten::SizesType> sizes,
-    std::vector<exec_aten::StridesType> strides,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    std::vector<executorch::aten::SizesType> sizes,
+    std::vector<executorch::aten::StridesType> strides,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return for_blob(data, std::move(sizes), type)
       .strides(std::move(strides))
       .dynamism(dynamism)
@@ -237,11 +238,11 @@ inline TensorPtr from_blob(
  */
 inline TensorPtr from_blob(
     void* data,
-    std::vector<exec_aten::SizesType> sizes,
-    exec_aten::ScalarType type,
+    std::vector<executorch::aten::SizesType> sizes,
+    executorch::aten::ScalarType type,
     std::function<void(void*)>&& deleter,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return for_blob(data, std::move(sizes), type)
       .deleter(std::move(deleter))
       .dynamism(dynamism)
@@ -267,12 +268,12 @@ inline TensorPtr from_blob(
  */
 inline TensorPtr from_blob(
     void* data,
-    std::vector<exec_aten::SizesType> sizes,
-    std::vector<exec_aten::StridesType> strides,
-    exec_aten::ScalarType type,
+    std::vector<executorch::aten::SizesType> sizes,
+    std::vector<executorch::aten::StridesType> strides,
+    executorch::aten::ScalarType type,
     std::function<void(void*)>&& deleter,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return for_blob(data, std::move(sizes), type)
       .strides(std::move(strides))
       .deleter(std::move(deleter))
@@ -294,11 +295,11 @@ inline TensorPtr from_blob(
  * @return A TensorPtr instance managing the newly created Tensor.
  */
 TensorPtr empty_strided(
-    std::vector<exec_aten::SizesType> sizes,
-    std::vector<exec_aten::StridesType> strides,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND);
+    std::vector<executorch::aten::SizesType> sizes,
+    std::vector<executorch::aten::StridesType> strides,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND);
 
 /**
  * Creates an empty TensorPtr with the same size and properties as the given
@@ -316,10 +317,10 @@ TensorPtr empty_strided(
  */
 inline TensorPtr empty_like(
     const TensorPtr& other,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Undefined,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
-  if (type == exec_aten::ScalarType::Undefined) {
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Undefined,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+  if (type == executorch::aten::ScalarType::Undefined) {
     type = other->scalar_type();
   }
   return empty_strided(
@@ -341,10 +342,10 @@ inline TensorPtr empty_like(
  * @return A TensorPtr instance managing the newly created Tensor.
  */
 inline TensorPtr empty(
-    std::vector<exec_aten::SizesType> sizes,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    std::vector<executorch::aten::SizesType> sizes,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return empty_strided(std::move(sizes), {}, type, dynamism);
 }
 
@@ -359,12 +360,12 @@ inline TensorPtr empty(
  * @return A TensorPtr instance managing the newly created Tensor.
  */
 TensorPtr full_strided(
-    std::vector<exec_aten::SizesType> sizes,
-    std::vector<exec_aten::StridesType> strides,
-    exec_aten::Scalar fill_value,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND);
+    std::vector<executorch::aten::SizesType> sizes,
+    std::vector<executorch::aten::StridesType> strides,
+    executorch::aten::Scalar fill_value,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND);
 
 /**
  * Creates a TensorPtr filled with the specified value, with the same size and
@@ -380,11 +381,11 @@ TensorPtr full_strided(
  */
 inline TensorPtr full_like(
     const TensorPtr& other,
-    exec_aten::Scalar fill_value,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Undefined,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
-  if (type == exec_aten::ScalarType::Undefined) {
+    executorch::aten::Scalar fill_value,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Undefined,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+  if (type == executorch::aten::ScalarType::Undefined) {
     type = other->scalar_type();
   }
   return full_strided(
@@ -405,11 +406,11 @@ inline TensorPtr full_like(
  * @return A TensorPtr instance managing the newly created Tensor.
  */
 inline TensorPtr full(
-    std::vector<exec_aten::SizesType> sizes,
-    exec_aten::Scalar fill_value,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    std::vector<executorch::aten::SizesType> sizes,
+    executorch::aten::Scalar fill_value,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return full_strided(std::move(sizes), {}, fill_value, type, dynamism);
 }
 
@@ -421,8 +422,8 @@ inline TensorPtr full(
  * @return A TensorPtr instance managing the newly created scalar Tensor.
  */
 inline TensorPtr scalar_tensor(
-    exec_aten::Scalar value,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float) {
+    executorch::aten::Scalar value,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float) {
   return full({}, value, type);
 }
 
@@ -439,9 +440,9 @@ inline TensorPtr scalar_tensor(
  */
 inline TensorPtr ones_like(
     const TensorPtr& other,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Undefined,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Undefined,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return full_like(other, 1, type, dynamism);
 }
 
@@ -454,10 +455,10 @@ inline TensorPtr ones_like(
  * @return A TensorPtr instance managing the newly created Tensor.
  */
 inline TensorPtr ones(
-    std::vector<exec_aten::SizesType> sizes,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    std::vector<executorch::aten::SizesType> sizes,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return full(std::move(sizes), 1, type, dynamism);
 }
 
@@ -474,9 +475,9 @@ inline TensorPtr ones(
  */
 inline TensorPtr zeros_like(
     const TensorPtr& other,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Undefined,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Undefined,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return full_like(other, 0, type, dynamism);
 }
 
@@ -489,10 +490,10 @@ inline TensorPtr zeros_like(
  * @return A TensorPtr instance managing the newly created Tensor.
  */
 inline TensorPtr zeros(
-    std::vector<exec_aten::SizesType> sizes,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    std::vector<executorch::aten::SizesType> sizes,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return full(std::move(sizes), 0, type, dynamism);
 }
 
@@ -506,11 +507,11 @@ inline TensorPtr zeros(
  * @return A TensorPtr instance managing the newly created Tensor.
  **/
 TensorPtr rand_strided(
-    std::vector<exec_aten::SizesType> sizes,
-    std::vector<exec_aten::StridesType> strides,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND);
+    std::vector<executorch::aten::SizesType> sizes,
+    std::vector<executorch::aten::StridesType> strides,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND);
 
 /**
  * Creates a TensorPtr filled with random values between 0 and 1.
@@ -524,10 +525,10 @@ TensorPtr rand_strided(
  */
 inline TensorPtr rand_like(
     const TensorPtr& other,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Undefined,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
-  if (type == exec_aten::ScalarType::Undefined) {
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Undefined,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+  if (type == executorch::aten::ScalarType::Undefined) {
     type = other->scalar_type();
   }
   return rand_strided(
@@ -546,10 +547,10 @@ inline TensorPtr rand_like(
  * @return A TensorPtr instance managing the newly created Tensor.
  */
 inline TensorPtr rand(
-    std::vector<exec_aten::SizesType> sizes,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    std::vector<executorch::aten::SizesType> sizes,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return rand_strided(std::move(sizes), {}, type, dynamism);
 }
 
@@ -564,11 +565,11 @@ inline TensorPtr rand(
  * @return A TensorPtr instance managing the newly created Tensor.
  */
 TensorPtr randn_strided(
-    std::vector<exec_aten::SizesType> sizes,
-    std::vector<exec_aten::StridesType> strides,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND);
+    std::vector<executorch::aten::SizesType> sizes,
+    std::vector<executorch::aten::StridesType> strides,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND);
 
 /**
  * Creates a TensorPtr filled with random values from a normal distribution.
@@ -582,10 +583,10 @@ TensorPtr randn_strided(
  */
 inline TensorPtr randn_like(
     const TensorPtr& other,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Undefined,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
-  if (type == exec_aten::ScalarType::Undefined) {
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Undefined,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+  if (type == executorch::aten::ScalarType::Undefined) {
     type = other->scalar_type();
   }
   return randn_strided(
@@ -605,10 +606,10 @@ inline TensorPtr randn_like(
  * @return A TensorPtr instance managing the newly created Tensor.
  */
 inline TensorPtr randn(
-    std::vector<exec_aten::SizesType> sizes,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Float,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    std::vector<executorch::aten::SizesType> sizes,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return randn_strided(std::move(sizes), {}, type, dynamism);
 }
 
@@ -626,11 +627,11 @@ inline TensorPtr randn(
 TensorPtr randint_strided(
     int64_t low,
     int64_t high,
-    std::vector<exec_aten::SizesType> sizes,
-    std::vector<exec_aten::StridesType> strides,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Int,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND);
+    std::vector<executorch::aten::SizesType> sizes,
+    std::vector<executorch::aten::StridesType> strides,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Int,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND);
 
 /**
  * Creates a TensorPtr filled with random integer values in the given range.
@@ -648,10 +649,10 @@ inline TensorPtr randint_like(
     const TensorPtr& other,
     int64_t low,
     int64_t high,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Undefined,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
-  if (type == exec_aten::ScalarType::Undefined) {
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Undefined,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+  if (type == executorch::aten::ScalarType::Undefined) {
     type = other->scalar_type();
   }
   return randint_strided(
@@ -677,10 +678,10 @@ inline TensorPtr randint_like(
 inline TensorPtr randint(
     int64_t low,
     int64_t high,
-    std::vector<exec_aten::SizesType> sizes,
-    exec_aten::ScalarType type = exec_aten::ScalarType::Int,
-    exec_aten::TensorShapeDynamism dynamism =
-        exec_aten::TensorShapeDynamism::DYNAMIC_BOUND) {
+    std::vector<executorch::aten::SizesType> sizes,
+    executorch::aten::ScalarType type = executorch::aten::ScalarType::Int,
+    executorch::aten::TensorShapeDynamism dynamism =
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return randint_strided(low, high, std::move(sizes), {}, type, dynamism);
 }
 

--- a/extension/training/module/training_module.h
+++ b/extension/training/module/training_module.h
@@ -71,7 +71,8 @@ class ET_EXPERIMENTAL TrainingModule final : executorch::extension::Module {
    * parameter tensor, or an error if the method is not a joint graph.
    */
   ET_EXPERIMENTAL
-  runtime::Result<const std::map<exec_aten::string_view, exec_aten::Tensor>>
+  runtime::Result<
+      const std::map<executorch::aten::string_view, executorch::aten::Tensor>>
   named_parameters(const std::string& method_name);
 
   /**
@@ -86,13 +87,14 @@ class ET_EXPERIMENTAL TrainingModule final : executorch::extension::Module {
    * or has not been executed yet.
    */
   ET_EXPERIMENTAL
-  runtime::Result<const std::map<exec_aten::string_view, exec_aten::Tensor>>
+  runtime::Result<
+      const std::map<executorch::aten::string_view, executorch::aten::Tensor>>
   named_gradients(const std::string& method_name);
 
  private:
   std::unordered_map<
       std::string,
-      std::map<exec_aten::string_view, exec_aten::Tensor>>
+      std::map<executorch::aten::string_view, executorch::aten::Tensor>>
       method_named_gradients_;
 };
 

--- a/extension/training/optimizer/sgd.h
+++ b/extension/training/optimizer/sgd.h
@@ -40,15 +40,15 @@ class ET_EXPERIMENTAL SGDParamState {
    * @param[in] momentum_buffer A tensor that stores the momentum at the last
    * epoch.
    */
-  explicit SGDParamState(exec_aten::Tensor& momentum_buffer)
+  explicit SGDParamState(executorch::aten::Tensor& momentum_buffer)
       : momentum_buffer_(momentum_buffer) {}
 
-  exec_aten::Tensor& momentum_buffer() {
+  executorch::aten::Tensor& momentum_buffer() {
     return momentum_buffer_;
   }
 
  private:
-  exec_aten::Tensor momentum_buffer_;
+  executorch::aten::Tensor momentum_buffer_;
 };
 
 /**
@@ -151,11 +151,11 @@ class ET_EXPERIMENTAL SGDParamGroup {
    * qualified names.
    */
   /* implicit */ SGDParamGroup(
-      const std::map<exec_aten::string_view, exec_aten::Tensor>&
+      const std::map<executorch::aten::string_view, executorch::aten::Tensor>&
           named_parameters)
       : named_parameters_(named_parameters) {}
   SGDParamGroup(
-      const std::map<exec_aten::string_view, exec_aten::Tensor>&
+      const std::map<executorch::aten::string_view, executorch::aten::Tensor>&
           named_parameters,
       std::unique_ptr<SGDOptions> options)
       : named_parameters_(named_parameters), options_(std::move(options)) {}
@@ -164,11 +164,12 @@ class ET_EXPERIMENTAL SGDParamGroup {
   SGDOptions& options();
   const SGDOptions& options() const;
   void set_options(std::unique_ptr<SGDOptions> options);
-  const std::map<exec_aten::string_view, exec_aten::Tensor>& named_parameters()
-      const;
+  const std::map<executorch::aten::string_view, executorch::aten::Tensor>&
+  named_parameters() const;
 
  private:
-  std::map<exec_aten::string_view, exec_aten::Tensor> named_parameters_;
+  std::map<executorch::aten::string_view, executorch::aten::Tensor>
+      named_parameters_;
   std::unique_ptr<SGDOptions> options_;
 };
 
@@ -188,7 +189,7 @@ class ET_EXPERIMENTAL SGD {
   }
 
   explicit SGD(
-      const std::map<exec_aten::string_view, exec_aten::Tensor>&
+      const std::map<executorch::aten::string_view, executorch::aten::Tensor>&
           named_parameters,
       SGDOptions defaults)
       : SGD({SGDParamGroup(named_parameters)}, defaults) {}
@@ -205,7 +206,7 @@ class ET_EXPERIMENTAL SGD {
    * fully qualified name.
    */
   ::executorch::runtime::Error step(
-      const std::map<exec_aten::string_view, exec_aten::Tensor>&
+      const std::map<executorch::aten::string_view, executorch::aten::Tensor>&
           named_gradients);
 
  private:


### PR DESCRIPTION
Summary: Migrate all extension headers to use the new aten namespace, so that they act as good examples for users. The .cpp code can migrate later.

Differential Revision: D64079593


