### PR TITLE
Centralize soc_to_chipset map

### DIFF
--- a/backends/qualcomm/tests/utils.py
+++ b/backends/qualcomm/tests/utils.py
@@ -26,7 +26,10 @@ from executorch.backends.qualcomm.quantizer.quantizer import (
 from executorch.backends.qualcomm.serialization.qnn_compile_spec_schema import (
     QcomChipset,
 )
-from executorch.backends.qualcomm.utils.utils import capture_program
+from executorch.backends.qualcomm.utils.utils import (
+    capture_program,
+    get_soc_to_chipset_map,
+)
 from executorch.devtools import generate_etrecord, Inspector
 from executorch.examples.qualcomm.utils import (
     generate_inputs,
@@ -117,13 +120,7 @@ class TestQNN(unittest.TestCase):
     build_folder: Literal = ""
     model: QcomChipset = None
     compiler_specs: List[CompileSpec] = None
-    arch_table = {
-        "SSG2115P": QcomChipset.SSG2115P,
-        "SM8650": QcomChipset.SM8650,
-        "SM8550": QcomChipset.SM8550,
-        "SM8475": QcomChipset.SM8475,
-        "SM8450": QcomChipset.SM8450,
-    }
+    arch_table = get_soc_to_chipset_map()
     error_only = False
     ip = "localhost"
     port = 8080

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -850,3 +850,13 @@ def generate_qnn_executorch_compiler_spec(
             QCOM_QNN_COMPILE_SPEC, convert_to_flatbuffer(qnn_executorch_options)
         )
     ]
+
+
+def get_soc_to_chipset_map():
+    return {
+        "SSG2115P": QcomChipset.SSG2115P,
+        "SM8650": QcomChipset.SM8650,
+        "SM8550": QcomChipset.SM8550,
+        "SM8475": QcomChipset.SM8475,
+        "SM8450": QcomChipset.SM8450,
+    }

--- a/examples/qualcomm/oss_scripts/llama2/llama.py
+++ b/examples/qualcomm/oss_scripts/llama2/llama.py
@@ -26,6 +26,7 @@ from executorch.backends.qualcomm.utils.utils import (
     convert_linear_to_conv2d,
     generate_htp_compiler_spec,
     generate_qnn_executorch_compiler_spec,
+    get_soc_to_chipset_map,
 )
 from executorch.examples.qualcomm.oss_scripts.llama2.model.static_llama import (
     LlamaModel,
@@ -45,15 +46,6 @@ from executorch.extension.llm.export.builder import DType
 from sentencepiece import SentencePieceProcessor
 from torch.ao.quantization.observer import MinMaxObserver
 from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
-
-
-soc_to_chipset_map = {
-    "SSG2115P": QcomChipset.SSG2115P,
-    "SM8650": QcomChipset.SM8650,
-    "SM8550": QcomChipset.SM8550,
-    "SM8475": QcomChipset.SM8475,
-    "SM8450": QcomChipset.SM8450,
-}
 
 
 pte_filename = "llama2_qnn"
@@ -402,7 +394,7 @@ def compile(args):
     end_quantize_ts = time.time()
     print("single_llama.quantize(quant_dtype)", end_quantize_ts - start_quantize_ts)
     single_llama.lowering_modules(
-        args.artifact, kv_type=kv_type, soc_model=soc_to_chipset_map[args.model]
+        args.artifact, kv_type=kv_type, soc_model=get_soc_to_chipset_map[args.model]
     )
     end_lowering_ts = time.time()
     print("Complete Compile", end_lowering_ts - end_quantize_ts)

--- a/examples/qualcomm/utils.py
+++ b/examples/qualcomm/utils.py
@@ -30,6 +30,7 @@ from executorch.backends.qualcomm.utils.utils import (
     capture_program,
     generate_htp_compiler_spec,
     generate_qnn_executorch_compiler_spec,
+    get_soc_to_chipset_map,
 )
 from executorch.exir import EdgeCompileConfig, EdgeProgramManager, to_edge
 from executorch.exir.backend.backend_api import to_backend
@@ -82,14 +83,7 @@ class SimpleADB:
         self.dump_intermediate_outputs = dump_intermediate_outputs
         self.debug_output_path = f"{self.workspace}/debug_output.bin"
         self.output_folder = f"{self.workspace}/outputs"
-        self.arch_table = {
-            "SSG2115P": "73",
-            "SM8650": "75",
-            "SM8550": "73",
-            "SM8475": "69",
-            "SM8450": "69",
-        }
-        self.soc_model = self.arch_table[soc_model]
+        self.soc_model = get_soc_to_chipset_map()[soc_model]
         self.error_only = error_only
         self.shared_buffer = shared_buffer
         self.runner = runner


### PR DESCRIPTION
Summary: We have multiple copy of the maps in the codebase and it's error prone. Provide a util function for the map so we can get the map from the same function

Differential Revision: D64080089


