### PR TITLE
Enable export_for_training for all executorch/backends

### DIFF
--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
             _skip_dim_order=True,  # TODO(T182187531): enable dim order in xnnpack
         ),
     )
-    logging.info(f"Exported graph:\n{edge.exported_program().graph}")
+    logging.critical(f"Exported graph:\n{edge.exported_program().graph}")
 
     # this is needed for the ETRecord as lowering modifies the graph in-place
     edge_copy = copy.deepcopy(edge)


### PR DESCRIPTION
Summary:
Extend the infra to handle all backend unittests in executorch
#buildall

Reviewed By: tarun292

Differential Revision: D64063682


