### PR TITLE
Default to cores/2 threads in JNI layer

### DIFF
--- a/extension/android/jni/BUCK
+++ b/extension/android/jni/BUCK
@@ -1,4 +1,5 @@
 load("@fbsource//tools/build_defs/android:fb_android_cxx_library.bzl", "fb_android_cxx_library")
+load("@fbsource//xplat/executorch/backends/xnnpack/third-party:third_party_libs.bzl", "third_party_dep")
 load("@fbsource//xplat/executorch/codegen:codegen.bzl", "executorch_generated_lib")
 
 oncall("executorch")
@@ -41,6 +42,8 @@ fb_android_cxx_library(
         "//xplat/executorch/extension/module:module_static",
         "//xplat/executorch/extension/runner_util:inputs_static",
         "//xplat/executorch/extension/tensor:tensor_static",
+        "//xplat/executorch/extension/threadpool:threadpool_static",
+        third_party_dep("cpuinfo"),
     ],
 )
 


### PR DESCRIPTION
Summary:
Default to using cores/2 threadpool threads. The long-term plan is to
improve performant core detection in CPUInfo, but for now we can use cores/2 as a sane default.

Based on testing, this is almost universally faster than using all cores, as efficiency cores can be quite slow. In extreme cases, using 
all cores can be 10x slower than using cores/2.

This also matches Lite Interpreter's default behavior when it doesn't have a more precise heuristic for the target hardware.

Differential Revision: D64107326


