### PR TITLE
Aten _To_Copy

### DIFF
--- a/backends/vulkan/partitioner/supported_ops.py
+++ b/backends/vulkan/partitioner/supported_ops.py
@@ -77,6 +77,7 @@ SUPPORTS_DYNAMIC_SHAPE = [
     exir_ops.edge.aten.sin.default,
     exir_ops.edge.aten.sqrt.default,
     exir_ops.edge.aten.tanh.default,
+    exir_ops.edge.aten._to_copy.default,
     # Matrix Multiplication
     exir_ops.edge.aten.bmm.default,
     exir_ops.edge.aten.mm.default,

--- a/backends/vulkan/runtime/graph/ops/impl/ToCopy.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/ToCopy.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/BlitNode.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+#include <set>
+
+namespace vkcompute {
+
+void resize_to_copy_op_node(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& extra_args) {
+  (void)extra_args;
+  vTensorPtr out = graph->get_tensor(args[0].refs[0]);
+  vTensorPtr self = graph->get_tensor(args[1].refs[0]);
+
+  out->virtual_resize(self->sizes());
+}
+
+void add_to_copy_node(ComputeGraph& graph, ValueRef in, ValueRef out) {
+  static std::set<vkapi::ScalarType> supported_types = {
+      vkapi::ScalarType::Float, vkapi::ScalarType::Half};
+
+  VK_CHECK_COND(
+      supported_types.find(graph.dtype_of(in)) != supported_types.end() &&
+          supported_types.find(graph.dtype_of(out)) != supported_types.end(),
+      "Unsupported dtype for to_copy, only Float and Half are currently supported, recieved ",
+      vkapi::to_string(graph.dtype_of(in)),
+      " <-> ",
+      vkapi::to_string(graph.dtype_of(out)));
+
+  graph.execute_nodes().emplace_back(
+      new BlitNode(graph, prepack_if_tensor_ref(graph, in), out));
+}
+
+void to_copy(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  return add_to_copy_node(graph, args[0], args[7]);
+}
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(aten._to_copy.default, to_copy);
+}
+} // namespace vkcompute


### PR DESCRIPTION
Summary:
Implement aten._to_copy. Currently we are only interested in fp32 <-> fp16 conversions, but it should theoritically support other dtype conversions too. I noticed an issue with int conversions so limited it to just fp32 and fp16 for now.

Note: Most driver implementations of fp16 cast does not "round up" the result, therefore there might be 1 bit difference between vulkan output and cpu torch.to. Explained in greater detail in the comments.

Differential Revision: D64080303


