### PR TITLE
[ET-VK] Support serializing scalar tensors as SymInt values

### DIFF
--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -248,6 +248,12 @@ class GraphBuilder {
     ref_mapping_[fb_id] = ref;
   }
 
+  void add_symint_to_graph(const uint32_t fb_id, VkValuePtr value) {
+    const int32_t fb_symint = value->value_as_SymInt()->value();
+    ValueRef ref = compute_graph_->add_symint(fb_symint);
+    ref_mapping_[fb_id] = ref;
+  }
+
   void add_value_to_graph(const uint32_t fb_id, VkValuePtr value) {
     ET_CHECK_MSG(
         !fb_id_exists(fb_id),
@@ -299,6 +305,9 @@ class GraphBuilder {
         break;
       case vkgraph::GraphTypes::String:
         add_string_to_graph(fb_id, value);
+        break;
+      case vkgraph::GraphTypes::SymInt:
+        add_symint_to_graph(fb_id, value);
         break;
       default:
         ET_CHECK_MSG(false, "Unsupported value type.");

--- a/backends/vulkan/serialization/schema.fbs
+++ b/backends/vulkan/serialization/schema.fbs
@@ -89,6 +89,10 @@ table ValueList {
   items:[int];
 }
 
+table SymInt {
+  value:int;
+}
+
 union GraphTypes {
   Null,
   Int,
@@ -100,6 +104,7 @@ union GraphTypes {
   BoolList,
   ValueList,
   String,
+  SymInt,
 }
 
 table VkValue {

--- a/backends/vulkan/serialization/vulkan_graph_schema.py
+++ b/backends/vulkan/serialization/vulkan_graph_schema.py
@@ -100,6 +100,11 @@ class String:
     string_val: str
 
 
+@dataclass
+class SymInt:
+    value: int
+
+
 GraphTypes = Union[
     Null,
     Int,
@@ -111,6 +116,7 @@ GraphTypes = Union[
     DoubleList,
     ValueList,
     String,
+    SymInt,
 ]
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #6070
* #6069

## Context

* Add `SymInt` to serialization schema
* Make the serializer serialize scalar tensors as `SymInt` instead of `VkTensor`
* Add support for `SymInt` in `VulkanBackend.cpp`

Differential Revision: [D64139868](https://our.internmc.facebook.com/intern/diff/D64139868/)