### PR TITLE
Revert "Qualcomm AI Engine Direct - Fix aihub path failing due to memory planning pass"

### DIFF
--- a/examples/qualcomm/qaihub_scripts/utils/utils.py
+++ b/examples/qualcomm/qaihub_scripts/utils/utils.py
@@ -68,6 +68,7 @@ def gen_pte_from_ctx_bin(
     for pte_name in pte_names:
         print(f"{pte_name} generating...")
         memory_planning_pass = MemoryPlanningPass(
+            memory_planning_algo="greedy",
             alloc_graph_input=False,
             alloc_graph_output=False,
         )


### PR DESCRIPTION
Reverts pytorch/executorch#5748, it broke `pull / unittest-arm (buck2) / linux-job` (https://github.com/pytorch/executorch/actions/runs/11283289096/job/31382443033)