### PR TITLE
[Arm] Fix tosa-reference model upstream tracking

### DIFF
--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -86,6 +86,10 @@ fi
 ethos_u_repo_url="https://review.mlplatform.org/ml/ethos-u/ethos-u"
 ethos_u_base_rev="24.08"
 
+# tosa reference model
+tosa_reference_model_url="https://review.mlplatform.org/tosa/reference_model"
+tosa_reference_model_rev="444eb365d92774430006e56a8c20161be2f2674f"
+ 
 ########
 ### Mandatory user args
 ########
@@ -219,8 +223,9 @@ function setup_tosa_reference_model() {
     # errors for the early codebase
     cd "${root_dir}"
     if [[ ! -e reference_model ]]; then
-        git clone https://review.mlplatform.org/tosa/reference_model -b v0.80
+        git clone ${tosa_reference_model_url}
         cd reference_model
+        git checkout ${tosa_reference_model_rev}
         git submodule update --init --recursive
         cd ..
     fi


### PR DESCRIPTION
It appears that upstream updates to branch tosa_reference_model/v0.8 which we used to track broke ET CI. Hard coding it to a known good version for now.

* Failed CI job - https://github.com/pytorch/executorch/actions/runs/11283289096/job/31382443033#step:12:26700

* Upstream branch updates - https://review.mlplatform.org/q/project:tosa%252Freference_model+branch:v0.80 Potentially culprit gerrit ids - 12676, 12677, 12678 updated today