### PR TITLE
Use fbjni from maven

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,6 @@
 [submodule "backends/xnnpack/third-party/pthreadpool"]
 	path = backends/xnnpack/third-party/pthreadpool
 	url = https://github.com/Maratyszcza/pthreadpool.git
-[submodule "examples/third-party/fbjni"]
-	path = examples/third-party/fbjni
-	url = https://github.com/facebookincubator/fbjni.git
 [submodule "extension/llm/third-party/abseil-cpp"]
 	path = extension/llm/third-party/abseil-cpp
 	url = https://github.com/abseil/abseil-cpp.git

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -21,9 +21,33 @@ include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 
-add_subdirectory(
-  ${EXECUTORCH_ROOT}/examples/third-party/fbjni
-  ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni
+if(NOT FBJNI_VERSION)
+  set(FBJNI_VERSION 0.5.2)
+endif()
+set(FBJNI_AAR_URL https://repo1.maven.org/maven2/com/facebook/fbjni/fbjni/${FBJNI_VERSION}/fbjni-${FBJNI_VERSION}.aar)
+set(FBJNI_DOWNLOAD_PATH ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/fbjni.aar)
+
+if (NOT EXISTS "${FBJNI_DOWNLOAD_PATH}")
+    file(DOWNLOAD "${FBJNI_AAR_URL}" "${FBJNI_DOWNLOAD_PATH}")
+endif()
+
+add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/include/" "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/libs/android.${ANDROID_ABI}/libfbjni.so"
+    COMMAND unzip -o ${FBJNI_DOWNLOAD_PATH} -d ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni
+    DEPENDS "${FBJNI_DOWNLOAD_PATH}")
+
+add_custom_target(
+  fbjni_prefab
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/include/" "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/libs/android.${ANDROID_ABI}/libfbjni.so"
+)
+
+add_library(fbjni SHARED IMPORTED)
+add_dependencies(fbjni fbjni_prefab)
+set_target_properties(fbjni PROPERTIES
+  IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/libs/android.${ANDROID_ABI}/libfbjni.so"
+)
+list(APPEND
+  _common_include_directories "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/include/"
 )
 
 set(executorch_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../lib/cmake/ExecuTorch)

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -43,7 +43,8 @@ endif()
 add_custom_command(
   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/include/" "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/libs/android.${ANDROID_ABI}/libfbjni.so"
   COMMAND unzip -o ${FBJNI_DOWNLOAD_PATH} -d ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni
-  DEPENDS "${FBJNI_DOWNLOAD_PATH}")
+  DEPENDS "${FBJNI_DOWNLOAD_PATH}"
+)
 
 add_custom_target(
   fbjni_prefab

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -21,9 +21,18 @@ include(${EXECUTORCH_ROOT}/build/Utils.cmake)
 set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 
+# We need to download fbjni library from maven, and use its "prefab" library
+# and headers, and link executorch library against that fbjni library.
+# We don't know which NDK is used to compile fbjni, and we need to link our
+# executorch library to the version which Android APK links against for runtime
+# to ensure the libc++ dependencies are consistent.
+# WARNING #
+# Users need to use the SAME fbjni version here and in app gradle dependency
+# for runtime compatibility!
 if(NOT FBJNI_VERSION)
   set(FBJNI_VERSION 0.5.1)
 endif()
+
 set(FBJNI_AAR_URL https://repo1.maven.org/maven2/com/facebook/fbjni/fbjni/${FBJNI_VERSION}/fbjni-${FBJNI_VERSION}.aar)
 set(FBJNI_DOWNLOAD_PATH ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/fbjni.aar)
 
@@ -45,9 +54,6 @@ add_library(fbjni SHARED IMPORTED)
 add_dependencies(fbjni fbjni_prefab)
 set_target_properties(fbjni PROPERTIES
   IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/libs/android.${ANDROID_ABI}/libfbjni.so"
-)
-list(APPEND
-  _common_include_directories
 )
 
 set(executorch_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../lib/cmake/ExecuTorch)

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -22,7 +22,7 @@ set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 
 if(NOT FBJNI_VERSION)
-  set(FBJNI_VERSION 0.5.2)
+  set(FBJNI_VERSION 0.5.1)
 endif()
 set(FBJNI_AAR_URL https://repo1.maven.org/maven2/com/facebook/fbjni/fbjni/${FBJNI_VERSION}/fbjni-${FBJNI_VERSION}.aar)
 set(FBJNI_DOWNLOAD_PATH ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/fbjni.aar)

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 set(FBJNI_AAR_URL https://repo1.maven.org/maven2/com/facebook/fbjni/fbjni/${FBJNI_VERSION}/fbjni-${FBJNI_VERSION}.aar)
 set(FBJNI_DOWNLOAD_PATH ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/fbjni.aar)
 
-if (NOT EXISTS "${FBJNI_DOWNLOAD_PATH}")
+if(NOT EXISTS "${FBJNI_DOWNLOAD_PATH}")
   file(DOWNLOAD "${FBJNI_AAR_URL}" "${FBJNI_DOWNLOAD_PATH}")
 endif()
 

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -28,13 +28,13 @@ set(FBJNI_AAR_URL https://repo1.maven.org/maven2/com/facebook/fbjni/fbjni/${FBJN
 set(FBJNI_DOWNLOAD_PATH ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/fbjni.aar)
 
 if (NOT EXISTS "${FBJNI_DOWNLOAD_PATH}")
-    file(DOWNLOAD "${FBJNI_AAR_URL}" "${FBJNI_DOWNLOAD_PATH}")
+  file(DOWNLOAD "${FBJNI_AAR_URL}" "${FBJNI_DOWNLOAD_PATH}")
 endif()
 
 add_custom_command(
-    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/include/" "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/libs/android.${ANDROID_ABI}/libfbjni.so"
-    COMMAND unzip -o ${FBJNI_DOWNLOAD_PATH} -d ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni
-    DEPENDS "${FBJNI_DOWNLOAD_PATH}")
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/include/" "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/libs/android.${ANDROID_ABI}/libfbjni.so"
+  COMMAND unzip -o ${FBJNI_DOWNLOAD_PATH} -d ${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni
+  DEPENDS "${FBJNI_DOWNLOAD_PATH}")
 
 add_custom_target(
   fbjni_prefab
@@ -47,7 +47,7 @@ set_target_properties(fbjni PROPERTIES
   IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/libs/android.${ANDROID_ABI}/libfbjni.so"
 )
 list(APPEND
-  _common_include_directories "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/include/"
+  _common_include_directories
 )
 
 set(executorch_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../lib/cmake/ExecuTorch)
@@ -152,6 +152,7 @@ endif()
 
 target_include_directories(
   executorch_jni PRIVATE ${_common_include_directories}
+  "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/include/"
 )
 
 target_compile_options(executorch_jni PUBLIC ${_common_compile_options})


### PR DESCRIPTION
TL;DR: We need to make sure the runtime so deps is the same as compile time so library. We can't build the so from source, because runtime uses another one.

Instead of importing fbjni repo into executorch, and building from executorch as a subdir, we need to use a pre-built (on maven repo) fbjni.so together with its headers. We need to link our executorch JNI library against that fbjni.so. We can't link against fbjni as a static library, because the Java layer needs to load it, and we can't have duplicated symbol from static and shared lib.

For Android apk developer, they need to import executorch as AAR, as well as fbjni AAR from maven. Inside fbjni AAR, we don't know which NDK is the fbjni.so built. If the NDK version between executorch and fbjni is different, we may have incompatible c++ library. This caused issues like 
```
java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "_ZTVNSt6__ndk114basic_ifstreamIcNS_11char_traitsIcEEEE" referenced by "/data/app/~~enBXzd5mY8qQNSRdnGW4vg==/com.example.executorchllamademo-u8anctHQVTL1jVJsZsEqRQ==/lib/arm64/libexecutorch.so"...
``` 
in the past.

Therefore, we need to always make sure we have a specific fbjni version for a given executorch release (say 0.5.1 for 20241010). We download the AAR from maven, which provides "prefab" artifacts, including the so library and header for us to compile ET jni code.

With this change, we can build ET JNI with any NDK version, regardless of how fbjni built their library.