### PR TITLE
Remove test on FakeProgram reducing size

### DIFF
--- a/exir/program/test/test_fake_program.py
+++ b/exir/program/test/test_fake_program.py
@@ -62,8 +62,8 @@ class TestFakeProgram(unittest.TestCase):
         self.assertEqual(exported_program.verifier, fake_program.verifier)
         self.assertEqual(id(exported_program.verifier), id(fake_program.verifier))
 
-        # Fake program uses fake tensors for the state dict. Size should be smaller.
-        self.assertLess(
+        # Fake program uses fake tensors for the state dict. Size should be not be larger.
+        self.assertLessEqual(
             sys.getsizeof(fake_program.state_dict),
             sys.getsizeof(exported_program.state_dict),
         )


### PR DESCRIPTION
Summary: Original exported_program outputs an OrderedDict, but now it just outputs an regular python dict. The size does not gets smaller anymore.

Differential Revision: D64260573


