### PR TITLE
Clean up Android prebuilt artifact path and verification

### DIFF
--- a/docs/source/android-prebuilt-library.md
+++ b/docs/source/android-prebuilt-library.md
@@ -4,18 +4,17 @@ We provide two prebuilt Android libraries (AAR), `executorch.aar` for generic us
 
 ## Contents of libraries
 - `executorch.aar`
-  - [Java library](https://github.com/pytorch/executorch/tree/release/0.3/extension/android/src/main/java/org/pytorch/executorch)
-  - JNI contains the JNI binding for [NativePeer.java](https://github.com/pytorch/executorch/blob/release/0.3/extension/android/src/main/java/org/pytorch/executorch/NativePeer.java) and ExecuTorch native library, including core ExecuTorch runtime libraries, XNNPACK backend, Portable kernels, Optimized kernels, and Quantized kernels.
+  - [Java library](https://github.com/pytorch/executorch/tree/main/extension/android/src/main/java/org/pytorch/executorch)
+  - JNI contains the JNI binding for [NativePeer.java](https://github.com/pytorch/executorch/blob/main/extension/android/src/main/java/org/pytorch/executorch/NativePeer.java) and ExecuTorch native library, including core ExecuTorch runtime libraries, XNNPACK backend, Portable kernels, Optimized kernels, and Quantized kernels.
     - Comes with two ABI variants, arm64-v8a and x86_64.
 - `executorch_llama.aar`
-  - [Java library](https://github.com/pytorch/executorch/tree/release/0.3/extension/android/src/main/java/org/pytorch/executorch) (Note: it contains the same Java classes as the previous Java, but it does not contain the JNI binding for generic Module/NativePeer Java code).
-  - JNI contains the JNI binding for [LlamaModule.java](https://github.com/pytorch/executorch/blob/release/0.3/extension/android/src/main/java/org/pytorch/executorch/LlamaModule.java) and ExecuTorch native library, including core ExecuTorch runtime libraries, XNNPACK backend, Portable kernels, Optimized kernels, Quantized kernels, and LLAMA-specific Custom ops library.
+  - [Java library](https://github.com/pytorch/executorch/tree/main/extension/android/src/main/java/org/pytorch/executorch) (Note: it contains the same Java classes as the previous Java, but it does not contain the JNI binding for generic Module/NativePeer Java code).
+  - JNI contains the JNI binding for [LlamaModule.java](https://github.com/pytorch/executorch/blob/main/extension/android/src/main/java/org/pytorch/executorch/LlamaModule.java) and ExecuTorch native library, including core ExecuTorch runtime libraries, XNNPACK backend, Portable kernels, Optimized kernels, Quantized kernels, and LLAMA-specific Custom ops library.
     - Comes with two ABI variants, arm64-v8a and x86_64.
 
 ## Downloading AAR
-[executorch.aar](https://ossci-android.s3.us-west-1.amazonaws.com/executorch/release/0.3/executorch.aar)
-[executorch_llama.aar](https://ossci-android.s3.us-west-1.amazonaws.com/executorch/release/0.3/executorch-llama.aar)
-[SHA1SUMS](https://ossci-android.s3.us-west-1.amazonaws.com/executorch/release/0.3/SHA1SUMS)
+[executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/executorch-241002/executorch.aar)
+[executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/executorch-241002/executorch.aar.sha256sums)
 
 ## Using prebuilt libraries
 
@@ -24,7 +23,7 @@ To add the Java library to your app, simply download the AAR, and add it to your
 In your app working directory, such as example executorch/examples/demo-apps/android/LlamaDemo,
 ```
 mkdir -p app/libs
-curl https://ossci-android.s3.us-west-1.amazonaws.com/executorch/release/0.3/executorch-llama.aar -o app/libs/executorch.aar
+curl https://ossci-android.s3.amazonaws.com/executorch/release/executorch-241002/executorch.aar -o app/libs/executorch-llama.aar
 ```
 
 And include it in gradle:

--- a/examples/demo-apps/android/LlamaDemo/download_prebuilt_lib.sh
+++ b/examples/demo-apps/android/LlamaDemo/download_prebuilt_lib.sh
@@ -7,14 +7,14 @@
 
 set -eu
 
-AAR_URL="https://ossci-android.s3.us-west-1.amazonaws.com/executorch/release/0.3/executorch-llama.aar"
-AAR_SHASUM="f06cc1606e5e05f00fd0ae721f5d37d56124fd28"
-
+AAR_URL="https://ossci-android.s3.us-west-1.amazonaws.com/executorch/release/executorch-241002/executorch.aar"
+AAR_SHASUM_URL="https://ossci-android.s3.us-west-1.amazonaws.com/executorch/release/executorch-241002/executorch.aar.sha256sums"
 LIBS_PATH="$(dirname "$0")/app/libs"
-AAR_PATH="${LIBS_PATH}/executorch-llama.aar"
 
 mkdir -p "$LIBS_PATH"
 
-if [[ ! -f "${AAR_PATH}" || "${AAR_SHASUM}" != $(shasum "${AAR_PATH}" | awk '{print $1}') ]]; then
-  curl "${AAR_URL}" -o "${AAR_PATH}"
-fi
+pushd "$LIBS_PATH"
+curl -O "${AAR_SHASUM_URL}"
+sed -i -e 's/executorch.aar/executorch-llama.aar/g' executorch.aar.sha256sums
+shasum --check --status executorch.aar.sha256sums || curl "${AAR_URL}" -o executorch-llama.aar
+popd


### PR DESCRIPTION
In main branch, use dated artifacts like https://ossci-android.s3.amazonaws.com/executorch/release/executorch-241002/executorch.aar In release branch, use something like release/0.4

Automate shasum check