### PR TITLE
fixed empty output from runtime executor in CPU flow

### DIFF
--- a/backends/cadence/aot/TARGETS
+++ b/backends/cadence/aot/TARGETS
@@ -43,6 +43,7 @@ python_library(
         "//executorch/backends/transforms:decompose_sdpa",
         "//executorch/backends/transforms:remove_clone_ops",
         "//executorch/exir:lib",
+        "//executorch/devtools:lib",
     ],
 )
 

--- a/backends/cadence/aot/export_example.py
+++ b/backends/cadence/aot/export_example.py
@@ -14,7 +14,7 @@ from typing import Any, Tuple
 
 from executorch.backends.cadence.aot.compiler import (
     convert_pt2,
-    export_to_cadence,
+    export_to_cadence_edge_executorch,
     fuse_pt2,
 )
 from executorch.backends.cadence.aot.quantizer.quantizer import CadenceQuantizer
@@ -53,10 +53,9 @@ def export_model(
     quantized_model = fuse_pt2(converted_model, quantizer)
 
     # Get edge program after Cadence specific passes
-    cadence_prog_manager = export_to_cadence(quantized_model, example_inputs)
-
-    # Get executorch program after Cadence specific passes
-    exec_prog: ExecutorchProgramManager = cadence_prog_manager.to_executorch()
+    exec_prog: ExecutorchProgramManager = export_to_cadence_edge_executorch(
+        quantized_model, example_inputs, working_dir
+    )
 
     logging.info("Final exported graph:\n")
     exec_prog.exported_program().graph_module.graph.print_tabular()

--- a/backends/cadence/build_cadence_runner.sh
+++ b/backends/cadence/build_cadence_runner.sh
@@ -25,6 +25,7 @@ main() {
     -DCMAKE_BUILD_TYPE=Release \
     -DEXECUTORCH_BUILD_DEVTOOLS=ON \
     -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \
+    -DEXECUTORCH_ENABLE_LOGGING=ON \
     -Bcmake-out .
   cmake --build cmake-out --target install --config Release -j16
 
@@ -35,6 +36,7 @@ main() {
   cmake -DCMAKE_PREFIX_PATH="${cmake_prefix_path}" \
     -DCMAKE_BUILD_TYPE=Release \
     -DEXECUTORCH_CADENCE_CPU_RUNNER=ON \
+    -DEXECUTORCH_ENABLE_LOGGING=ON \
     -B"${build_dir}" \
     "${example_dir}"
   cmake --build "${build_dir}" --config Release -j16

--- a/backends/cadence/reference/operators/CMakeLists.txt
+++ b/backends/cadence/reference/operators/CMakeLists.txt
@@ -27,6 +27,7 @@ set(_aten_ops__srcs
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/activation_ops_util.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/copy_ops_util.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/broadcast_util.cpp"
+    "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/dtype_util.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/index_util.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/kernel_ops_util.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/matmul_ops_util.cpp"

--- a/backends/cadence/runtime/executor.py
+++ b/backends/cadence/runtime/executor.py
@@ -123,6 +123,7 @@ class Executor:
             ),
             "etdump_path": os.path.join(self.working_dir, "etdump.etdp"),
             "debug_output_path": os.path.join(self.working_dir, "debug_output.bin"),
+            "dump_outputs": "true",
         }
         args = self.get_bash_command(self.execute_runner, cmd_args)
         logging.info(f"\33[33m{' '.join(args)}\33[0m")


### PR DESCRIPTION
Summary:
- add missing dependency dtype_util.cpp
- it was missing etrecord. And dump-output is not toggled in executor.
- Also enable runtime logging

Differential Revision: D64272605


