### PR TITLE
Handle output from TOSA reference model being int8

### DIFF
--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -439,6 +439,9 @@ class RunnerUtil:
 
             if self.is_quantized:
                 # Need to dequant back to FP32 for comparison with torch output
+                # Convert to int32 prior to dequantize the output
+                if tosa_ref_output.dtype == np.int8:
+                    tosa_ref_output = tosa_ref_output.astype(np.int32)
                 quant_param = self.qp_output
                 assert (
                     quant_param is not None

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -88,7 +88,7 @@ ethos_u_base_rev="24.08"
 
 # tosa reference model
 tosa_reference_model_url="https://review.mlplatform.org/tosa/reference_model"
-tosa_reference_model_rev="444eb365d92774430006e56a8c20161be2f2674f"
+tosa_reference_model_rev="f9ea4ab7da19318fe36b1c34d68a3e40fd6e56c5"
  
 ########
 ### Mandatory user args


### PR DESCRIPTION
Move TOSA reference model pin. This adds bugfix for .npy array to now be aligned to output int8 for BI models.

Make sure the dequantization not overflows by adding a cast to int32.


Change-Id: I2274955bc02a6f3a75687bb2f731b2058834c44f