### PR TITLE
Unify the qnn version definition

### DIFF
--- a/backends/qualcomm/runtime/targets.bzl
+++ b/backends/qualcomm/runtime/targets.bzl
@@ -3,6 +3,7 @@ load(
     "ANDROID",
 )
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load("@fbsource//xplat/executorch/backends/qualcomm/qnn_version.bzl", "get_qnn_library_verision")
 
 def define_common_targets():
     """Defines targets that should be shared between fbcode and xplat.
@@ -56,10 +57,10 @@ def define_common_targets():
         platforms = [ANDROID],
         visibility = ["@EXECUTORCH_CLIENTS"],
         resources = {
-            "qnn_lib": "fbsource//third-party/qualcomm/qnn/qnn-2.25:qnn_offline_compile_libs",
+            "qnn_lib": "fbsource//third-party/qualcomm/qnn/qnn-{0}:qnn_offline_compile_libs".format(get_qnn_library_verision()),
         },
         deps = [
-            "fbsource//third-party/qualcomm/qnn:api",
+            "fbsource//third-party/qualcomm/qnn/qnn-{0}:api".format(get_qnn_library_verision()),
             ":logging",
             "//executorch/backends/qualcomm:schema",
             "//executorch/backends/qualcomm/aot/ir:qcir_utils",

--- a/backends/qualcomm/targets.bzl
+++ b/backends/qualcomm/targets.bzl
@@ -92,3 +92,6 @@ def define_common_targets():
             ":schema",
         ],
     )
+
+def get_qnn_library_verision():
+    return "2.26"

--- a/examples/models/llama2/TARGETS
+++ b/examples/models/llama2/TARGETS
@@ -3,6 +3,7 @@
 
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load(":targets.bzl", "define_common_targets")
+load("@fbsource//xplat/executorch/backends/qualcomm/qnn_version.bzl", "get_qnn_library_verision")
 
 oncall("executorch")
 
@@ -69,7 +70,7 @@ runtime.python_binary(
 runtime.command_alias(
     name = "export_llama_qnn",
     env = {
-        "LD_LIBRARY_PATH": "$(location fbsource//third-party/qualcomm/qnn/qnn-2.25:qnn_offline_compile_libs)",
+        "LD_LIBRARY_PATH": "$(location fbsource//third-party/qualcomm/qnn/qnn-{0}:qnn_offline_compile_libs)".format(get_qnn_library_verision()),
     },
     exe = ":export_llama",
 )

--- a/shim/xplat/executorch/backends/qualcomm/qnn_version.bzl
+++ b/shim/xplat/executorch/backends/qualcomm/qnn_version.bzl
@@ -1,0 +1,2 @@
+def get_qnn_library_verision():
+    return "2.26"


### PR DESCRIPTION
Summary: As title, the qnn version is harded across the repro, and we have unify way to config them in case mis-use

Differential Revision: D64334993


