### PR TITLE
[ExecuTorch][Llama] Use Eigen blas for custom sdpa

### DIFF
--- a/kernels/optimized/lib_defs.bzl
+++ b/kernels/optimized/lib_defs.bzl
@@ -144,7 +144,7 @@ def define_libs():
                 (
                     "^android-arm64.*$",
                     [
-                        "fbsource//third-party/openblas:openblas",
+                        "fbsource//arvr/third-party/eigen:eigen3_blas",
                     ],
                 ),
             ],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #6197

OpenBlas's implementation is not thread safe. Thus when used within
parallel_for, it produces incorrect output. This has been documented in a few
places like here https://github.com/OpenMathLib/OpenBLAS/issues/1441 and
https://github.com/OpenMathLib/OpenBLAS/issues/2543.

I tried few options to disable openblas's multithreading but none of them
seemed to work.

It is possible that upstream openblas has fixed this. Will validate this by
pulling in latest, but in the meanwhile using eigen_blas to unblock.

Differential Revision: [D64334733](https://our.internmc.facebook.com/intern/diff/D64334733/)