### PR TITLE
Disable XNNPACK workspace sharing by default

### DIFF
--- a/backends/xnnpack/targets.bzl
+++ b/backends/xnnpack/targets.bzl
@@ -6,7 +6,7 @@ def _get_preprocessor_flags():
     Disable if someone explictly specified a config option,
     else Enable otherwise
     """
-    if native.read_config("executorch", "xnnpack_workspace_sharing", "1") == "0":
+    if native.read_config("executorch", "xnnpack_workspace_sharing", "0") == "0":
         return []
 
     # Enable if not disabled through config


### PR DESCRIPTION
Summary: Disable workspace sharing by default. There is currently a crash that occurs when workspace sharing is enabled when freeing the delegate. This change will increase ET memory usage, but needs to be done until we address the root cause. After we are confident that it is fixed, we will revert this change.

Differential Revision: D64352037


