### PR TITLE
Populates EXECUTORCH_LIBRARIES and other variables in executorch-config.cmake

### DIFF
--- a/build/executorch-config.cmake
+++ b/build/executorch-config.cmake
@@ -10,11 +10,26 @@
 # is:
 #
 # find_package(executorch REQUIRED)
+# -------
+#
+# Finds the ExecuTorch library
+#
+# This will define the following variables:
+#
+#   EXECUTORCH_FOUND        -- True if the system has the ExecuTorch library
+#   EXECUTORCH_INCLUDE_DIRS -- The include directories for ExecuTorch
+#   EXECUTORCH_LIBRARIES    -- Libraries to link against
+#
+# The actual values for these variables will be different from what executorch-config.cmake
+# in executorch pip package gives, but we wanted to keep the contract of exposing these
+# CMake variables.
 
 cmake_minimum_required(VERSION 3.19)
 
 set(_root "${CMAKE_CURRENT_LIST_DIR}/../..")
 set(required_lib_list executorch executorch_core portable_kernels)
+set(EXECUTORCH_LIBRARIES)
+set(EXECUTORCH_INCLUDE_DIRS ${_root})
 foreach(lib ${required_lib_list})
   set(lib_var "LIB_${lib}")
   add_library(${lib} STATIC IMPORTED)
@@ -25,7 +40,11 @@ foreach(lib ${required_lib_list})
   )
   set_target_properties(${lib} PROPERTIES IMPORTED_LOCATION "${${lib_var}}")
   target_include_directories(${lib} INTERFACE ${_root})
+  list(APPEND EXECUTORCH_LIBRARIES ${lib})
 endforeach()
+
+# If we reach here, ET required libraries are found.
+set(EXECUTORCH_FOUND ON)
 
 target_link_libraries(executorch INTERFACE executorch_core)
 
@@ -90,5 +109,6 @@ foreach(lib ${lib_list})
     endif()
     set_target_properties(${lib} PROPERTIES IMPORTED_LOCATION "${${lib_var}}")
     target_include_directories(${lib} INTERFACE ${_root})
+    list(APPEND EXECUTORCH_LIBRARIES ${lib})
   endif()
 endforeach()


### PR DESCRIPTION
executorch-config.cmake

Summary: As titled. This PR aligns the behavior of `executorch-config.cmake` (being used by building ET from source) and the behavior of `executorch-wheel-config.cmake` (being used by installing ET from pip), by exposing these variables:
* `EXECUTORCH_FOUND` set to `ON` when required libraries are found
* `EXECUTORCH_LIBRARIES` a list of targets for installed ET libraries
* `EXECUTORCH_INCLUDE_DIRS` a list of directory paths to headers

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: