### PR TITLE
[Release] Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ dependencies=[
   "ruamel.yaml",
   "sympy",
   "tabulate",
+  "torch==2.5.0",
+  "torchaudio==2.5.0",
+  "torchvision==0.20.0",
   "typing-extensions",
 ]
 


### PR DESCRIPTION
`torch`, `torchvision`, and `torchaudio` are not in the `pyproject.toml` in main because we need nightly installs on main.