### PR TITLE
Update landing page to include Llama (#6218)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,13 +55,12 @@ Topics in this section will help you get started with ExecuTorch.
         ExecuTorch.
 
      .. grid-item-card:: :octicon:`file-code;1em`
-        ExecuTorch Intermediate Representation API
+        ExecuTorch Llama
         :img-top: _static/img/card-background.svg
-        :link: ir-exir.html
+        :link: llm/llama.html
         :link-type: url
 
-        Learn about EXIR, a graph-based intermediate
-        representation (IR) of PyTorch programs.
+        Learn about running Llama models via ExecuTorch
 
 .. toctree::
    :glob:
@@ -117,10 +116,11 @@ Topics in this section will help you get started with ExecuTorch.
    :caption: Working with LLMs
    :hidden:
 
-   llm/getting-started
-   llm/llama-demo-android
-   llm/build-run-llama3-qualcomm-ai-engine-direct-backend
-   llm/llama-demo-ios
+   Llama <llm/llama>
+   Llama on Android <llm/llama-demo-android>
+   Llama on iOS <llm/llama-demo-ios>
+   Llama on Android via Qualcomm backend <llm/build-run-llama3-qualcomm-ai-engine-direct-backend>
+   Gentle guide to LLMs via ExecuTorch <llm/getting-started>
 
 .. toctree::
    :glob:

--- a/docs/source/llm/getting-started.md
+++ b/docs/source/llm/getting-started.md
@@ -1,4 +1,4 @@
-# Getting Started with LLMs via ExecuTorch
+# Gentle guide to LLMs via ExecuTorch
 
 Welcome to LLM Manual! This manual is designed to provide a practical example to leverage
 ExecuTorch in onboarding your own Large Language Models (LLMs). Our primary goal is to offer
@@ -12,6 +12,8 @@ Consequently, the results produced by the model may vary and might not always be
 We encourage users to use this project as a starting point and adapt it to their specific needs,
 which includes creating your own versions of the tokenizer, sampler, acceleration backends, and
 other components. We hope this project serves as a useful guide in your journey with LLMs and ExecuTorch.
+
+For deploying llama with optimal performance, please see [Llama guide](./llama.md).
 
 ### Table Of Contents
 

--- a/docs/source/llm/llama.md
+++ b/docs/source/llm/llama.md
@@ -1,0 +1,5 @@
+# Llama on ExecuTorch
+
+See
+[llama readme](https://github.com/pytorch/executorch/blob/main/examples/models/llama2/README.md)
+for detailed information about running Llama on ExecuTorch.


### PR DESCRIPTION
Summary:

We should promote llama page more and demote the LLM Manual.

allow-large-files

Differential Revision: D64375318


