### PR TITLE
Convert directory fbcode/executorch to use the Ruff Formatter

### DIFF
--- a/examples/apple/coreml/scripts/export.py
+++ b/examples/apple/coreml/scripts/export.py
@@ -14,8 +14,10 @@ import executorch.exir as exir
 
 import torch
 
+# pyre-fixme[21]: Could not find module `executorch.backends.apple.coreml.compiler`.
 from executorch.backends.apple.coreml.compiler import CoreMLBackend
 
+# pyre-fixme[21]: Could not find module `executorch.backends.apple.coreml.partition`.
 from executorch.backends.apple.coreml.partition import CoreMLPartitioner
 from executorch.devtools.etrecord import generate_etrecord
 from executorch.exir import to_edge
@@ -76,6 +78,7 @@ def parse_args() -> argparse.ArgumentParser:
     parser.add_argument("--save_processed_bytes", action=argparse.BooleanOptionalAction)
 
     args = parser.parse_args()
+    # pyre-fixme[7]: Expected `ArgumentParser` but got `Namespace`.
     return args
 
 

--- a/examples/models/llama2/export_llama_lib.py
+++ b/examples/models/llama2/export_llama_lib.py
@@ -650,6 +650,7 @@ def _export_llama(modelname, args) -> LLMEdgeManager:  # noqa: C901
         if args.num_sharding > 0:
             model_sharding.split_graph(
                 builder_exported_to_edge.edge_manager.exported_program(),
+                # pyre-fixme[16]: `Optional` has no attribute `__getitem__`.
                 builder_exported_to_edge.metadata["get_n_layers"],
                 shares=args.num_sharding,
             )
@@ -669,6 +670,7 @@ def _export_llama(modelname, args) -> LLMEdgeManager:  # noqa: C901
         if args.num_sharding > 0 and args.qnn:
             from executorch.backends.qualcomm.utils.utils import canonicalize_program
 
+            # pyre-fixme[16]: Module `backends` has no attribute `qualcomm`.
             canonicalize_program(builder.edge_manager.exported_program())
 
         builder = builder.to_executorch()
@@ -686,6 +688,7 @@ def _export_llama(modelname, args) -> LLMEdgeManager:  # noqa: C901
         if args.num_sharding > 0 and args.qnn:
             from executorch.backends.qualcomm.utils.utils import canonicalize_program
 
+            # pyre-fixme[16]: Module `backends` has no attribute `qualcomm`.
             canonicalize_program(builder.edge_manager.exported_program())
 
         builder = builder.to_executorch()
@@ -912,7 +915,6 @@ def _get_source_transforms(  # noqa
 
     if args.use_kv_cache:
         if args.qnn:
-            # pyre-ignore: Undefined import [21]: Could not find a module corresponding to import `executorch.backends.qualcomm.utils.utils`
             from executorch.backends.qualcomm.utils.utils import (
                 convert_linear_to_conv2d,
             )
@@ -924,6 +926,7 @@ def _get_source_transforms(  # noqa
             if args.optimized_rotation_path:
                 transforms.append(fuse_layer_norms)
                 transforms.append(get_model_with_r1_r2(args.optimized_rotation_path))
+            # pyre-fixme[16]: Module `backends` has no attribute `qualcomm`.
             transforms.append(convert_linear_to_conv2d)
 
         elif args.mps:

--- a/examples/models/phi-3-mini/phi_3_mini.py
+++ b/examples/models/phi-3-mini/phi_3_mini.py
@@ -17,17 +17,22 @@ class Phi3Mini(torch.nn.Module):
         super().__init__()
         self.model = model
         self.cache = ETStaticCache(
+            # pyre-fixme[16]: `Phi3ForCausalLM` has no attribute `config`.
             config=model.config,
             max_batch_size=max_batch_size,
             max_cache_len=max_seq_len,
+            # pyre-fixme[16]: `Phi3ForCausalLM` has no attribute `device`.
             device=self.model.device,
+            # pyre-fixme[16]: `Phi3ForCausalLM` has no attribute `dtype`.
             dtype=self.model.dtype,
         )
 
     def forward(
         self,
+        # pyre-fixme[9]: input_ids has type `LongTensor`; used as `None`.
         input_ids: torch.LongTensor = None,
     ) -> torch.FloatTensor:
+        # pyre-fixme[16]: `Phi3ForCausalLM` has no attribute `forward`.
         return self.model.forward(
             input_ids=input_ids,
             use_cache=True,

--- a/examples/models/phi-3-mini/static_cache.py
+++ b/examples/models/phi-3-mini/static_cache.py
@@ -34,6 +34,7 @@ class ETStaticCache(StaticCache):
         )
 
     def get_seq_length(self, layer_idx: Optional[int] = 0) -> int:
+        # pyre-fixme[16]: `ETStaticCache` has no attribute `key_cache`.
         return (self.key_cache[layer_idx][0, 0].any(dim=-1)).sum().item()
 
     def get_usable_length(

--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -181,10 +181,11 @@ class LLMEdgeManager:
         # 1. torch.nn.attention.sdpa_kernel([SDPBackend.MATH]) is for bypassing the dynamo error when tracing
         # 2. torch.no_grad() is for getting rid of the dropout (not sure why training ops will show up)
         with torch.nn.attention.sdpa_kernel([SDPBackend.MATH]), torch.no_grad():
-            # pyre-fixme[8]
             if hasattr(self.args, "qnn") and self.args.qnn:
                 # TODO: this is temporary and export_for_training doesn't work with qnn either. We need a
                 # functional graph. See issue https://github.com/pytorch/executorch/pull/4627 for more details
+                # pyre-fixme[8]: Attribute has type `Optional[GraphModule]`; used as
+                #  `Module`.
                 self.pre_autograd_graph_module = torch.export.export(
                     self.model,
                     self.example_inputs,
@@ -193,6 +194,8 @@ class LLMEdgeManager:
                     strict=True,
                 ).module()
             else:
+                # pyre-fixme[8]: Attribute has type `Optional[GraphModule]`; used as
+                #  `Module`.
                 self.pre_autograd_graph_module = export_for_training(
                     self.model,
                     self.example_inputs,

--- a/extension/llm/tokenizer/utils.py
+++ b/extension/llm/tokenizer/utils.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-ignore: Undefined import [21]: Could not find a module corresponding to import `executorch.examples.models.llama2.tokenizer.tiktoken`.
 from executorch.examples.models.llama2.tokenizer.tiktoken import Tokenizer as Tiktoken
 from executorch.extension.llm.tokenizer.tokenizer import (
     Tokenizer as SentencePieceTokenizer,


### PR DESCRIPTION
Summary:
Converts the directory specified to use the Ruff formatter in pyfmt

ruff_dog

If this diff causes merge conflicts when rebasing, please run
`hg status -n -0 --change . -I '**/*.{py,pyi}' | xargs -0 arc pyfmt`
on your diff, and amend any changes before rebasing onto latest.
That should help reduce or eliminate any merge conflicts.

allow-large-files
bypass-github-export-checks

Reviewed By: amyreese

Differential Revision: D64264425


