### PR TITLE
Add tests to Cadence examples

### DIFF
--- a/examples/cadence/models/deepfilternet.py
+++ b/examples/cadence/models/deepfilternet.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Example script for exporting simple models to flatbuffer
+
+import logging
+
+from executorch.backends.cadence.aot.ops_registrations import *  # noqa
+
+import torch
+from df.enhance import init_df
+
+from executorch.backends.cadence.aot.export_example import export_model
+
+FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+
+
+def main() -> None:
+    logging.info("DeepFilterNet requires pip install -q -U deepfilternet")
+    model, _, _= init_df()
+    model.eval()
+
+    spec = torch.randn(1, 1, 1061, 481, 2)
+    spec_feat = torch.randn(1, 1, 1061, 96, 2)
+    erb_feat = torch.randn(1, 1, 1061, 32)
+
+    example_inputs = (
+        spec,
+        erb_feat,
+        spec_feat,
+    )
+
+    export_model(model, example_inputs)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cadence/models/encodec.py
+++ b/examples/cadence/models/encodec.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Example script for exporting simple models to flatbuffer
+
+import logging
+
+from executorch.backends.cadence.aot.ops_registrations import *  # noqa
+
+import torch
+from encodec import EncodecModel
+
+from executorch.backends.cadence.aot.export_example import export_model
+
+FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+
+
+def main() -> None:
+    logging.info("Encodec requires pip install -U encodec")
+    model = EncodecModel.encodec_model_24khz()
+    model.set_target_bandwidth(6.0)
+    model.eval()
+
+    wav = torch.randn(1, 1, 144000)
+
+    example_inputs = (wav,)
+
+    export_model(model, example_inputs)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cadence/models/tacotron2.py
+++ b/examples/cadence/models/tacotron2.py
@@ -1,0 +1,44 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Example script for exporting simple models to flatbuffer
+
+import logging
+
+from executorch.backends.cadence.aot.ops_registrations import *  # noqa
+
+import torchaudio
+
+from executorch.backends.cadence.aot.export_example import export_model
+
+FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+
+
+def main() -> None:
+    text = "Hello world! T T S stands for Text to Speech!"
+
+    bundle = torchaudio.pipelines.TACOTRON2_WAVERNN_CHAR_LJSPEECH
+    processor = bundle.get_text_processor()
+    model = bundle.get_tacotron2()
+    model.eval()
+
+    tokens, tokens_length = processor(text)
+    specgram, specgram_lengths, _ = model.infer(tokens, tokens_length)
+
+    inputs = (
+        tokens,
+        tokens_length,
+        specgram,
+        specgram_lengths,
+    )
+
+    # Full model
+    export_model(model, inputs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary: As titled. Adds deepfilternet, encodec and tacotron. Note that some of them cannot run yet and are under investigation, checking them in so that Cadence can see it on their side.

Differential Revision: D64404190


