### PR TITLE
Update extension-module.md to avoid extraneous header

### DIFF
--- a/docs/source/extension-module.md
+++ b/docs/source/extension-module.md
@@ -240,6 +240,6 @@ if (auto* etdump = dynamic_cast<ETDumpGen*>(module.event_tracer())) {
 }
 ```
 
-# Conclusion
+## Conclusion
 
 The `Module` APIs provide a simplified interface for running ExecuTorch models in C++, closely resembling the experience of PyTorch's eager mode. By abstracting away the complexities of the lower-level runtime APIs, developers can focus on model execution without worrying about the underlying details.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b76c18ba-615d-4758-9443-f5d0e98b6b1c)

Getting rid of the `Conclusion` header here