### PR TITLE
Enable quantization as default for XNNPack for previous failing models

### DIFF
--- a/examples/xnnpack/__init__.py
+++ b/examples/xnnpack/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 from dataclasses import dataclass
 
 
@@ -24,14 +26,14 @@ MODEL_NAME_TO_OPTIONS = {
     "mv3": XNNPACKOptions(True, True),
     "resnet18": XNNPACKOptions(True, True),
     "resnet50": XNNPACKOptions(True, True),
-    "vit": XNNPACKOptions(False, True),  # T161242362
+    "vit": XNNPACKOptions(True, True),
     "w2l": XNNPACKOptions(True, True),
     "edsr": XNNPACKOptions(True, True),
-    "mobilebert": XNNPACKOptions(False, True),  # T197452682
+    "mobilebert": XNNPACKOptions(True, True),
     "llama2": XNNPACKOptions(False, True),
     "emformer_join": XNNPACKOptions(True, True),
-    "emformer_predict": XNNPACKOptions(False, True),  # T197457838
-    "emformer_transcribe": XNNPACKOptions(False, True),  # T197449765
+    "emformer_predict": XNNPACKOptions(True, True),
+    "emformer_transcribe": XNNPACKOptions(True, True),
 }
 
 


### PR DESCRIPTION
Summary:
Since master has migrated aot_compiler to use to_edge_transform_and_lower in a previous change https://github.com/pytorch/executorch/pull/6026, quantization XNNPack options can be enabled by default for the following models:

- Quantized ViT
- Quantized Mobilebert
- Quantized Emformer Predict
- Quantized Emformer Transcribe

Differential Revision: D64081319


