### PR TITLE
Fix script export_hf_model.py

### DIFF
--- a/extension/export_util/export_hf_model.py
+++ b/extension/export_util/export_hf_model.py
@@ -12,7 +12,7 @@ import torch.export._trace
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
 from executorch.exir import EdgeCompileConfig, ExecutorchBackendConfig, to_edge
 from torch.nn.attention import SDPBackend
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForCausalLM
 from transformers.generation.configuration_utils import GenerationConfig
 from transformers.integrations.executorch import convert_and_export_with_cache
 from transformers.modeling_utils import PreTrainedModel
@@ -73,12 +73,11 @@ def main() -> None:
     print(f"{model.config}")
     print(f"{model.generation_config}")
 
-    tokenizer = AutoTokenizer.from_pretrained(args.hf_model_repo)
-    input_ids = tokenizer([""], return_tensors="pt").to(device)["input_ids"]
+    input_ids = torch.tensor([[1]], dtype=torch.long)
     cache_position = torch.tensor([0], dtype=torch.long)
 
     def _get_constant_methods(model: PreTrainedModel):
-        return {
+        metadata = {
             "get_dtype": 5 if model.config.torch_dtype == torch.float16 else 6,
             "get_bos_id": model.config.bos_token_id,
             "get_eos_id": model.config.eos_token_id,
@@ -90,6 +89,7 @@ def main() -> None:
             "get_vocab_size": model.config.vocab_size,
             "use_kv_cache": model.generation_config.use_cache,
         }
+        return {k: v for k, v in metadata.items() if v is not None}
 
     with torch.nn.attention.sdpa_kernel([SDPBackend.MATH]), torch.no_grad():
 


### PR DESCRIPTION
Having `bos_token_id = None` (and other fields) will cause an emitter error for models that doesn't define that field, for example, [olmo-1b](https://huggingface.co/allenai/OLMo-1B-hf/blob/main/config.json#L8). 
```
    raise ExportError(
executorch.exir.error.ExportError: [ExportErrorType.NOT_SUPPORTED]: Error emitting get_bos_id which returns a value of type <class 'NoneType'>. which is not a supported primitive
```

This PR avoids emitting with unsupported primitive type by removing the `None` fields out from the model metadata. The ExecuTorch runtime will assume the default value for those unspecified fields.