### PR TITLE
Do not raise error when there is mixed dtype in the checkpoint

### DIFF
--- a/examples/models/checkpoint.py
+++ b/examples/models/checkpoint.py
@@ -67,7 +67,7 @@ def get_checkpoint_dtype(checkpoint: Dict[str, Any]) -> Optional[str]:
             if value.dtype != dtype
         ]
         if len(mismatched_dtypes) > 0:
-            raise ValueError(
+            print(
                 f"Mixed dtype model. Dtype of {first_key}: {first.dtype}. Mismatches in the checkpoint: {mismatched_dtypes}"
             )
     return dtype


### PR DESCRIPTION
Summary: This warning message got turned into an exception during the refactor of D64145852. It fails our export flow for llama 3.2 1B/3B. This diff fixes it.

Differential Revision: D64438373


