### PR TITLE
android-release-artifact only trigger if AAR doesn't exist

### DIFF
--- a/.github/workflows/android-release-artifacts.yml
+++ b/.github/workflows/android-release-artifacts.yml
@@ -13,8 +13,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-if-aar-exists:
+    name: check-if-aar-exists
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Check if this RC version is already in S3
+        shell: bash
+        run: |
+          VERSION="${{ inputs.version }}"
+          if curl -I "https://ossci-android.s3.amazonaws.com/executorch/release/${VERSION}/executorch.aar" | grep "200 OK"; then
+            echo "AAR already exists at https://ossci-android.s3.amazonaws.com/executorch/release/${VERSION}/executorch.aar"
+            echo "Will skip build/upload"
+            exit 1
+          fi
+
   build-aar:
     name: build-aar
+    needs: check-if-aar-exists
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.2xlarge


### PR DESCRIPTION
Test: attempt 1, https://github.com/pytorch/executorch/actions/runs/11356171402, passed. attempt 2 https://github.com/pytorch/executorch/actions/runs/11356452635, correctly stopped.