### PR TITLE
fix event tracer usage for shader profiling

### DIFF
--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -600,7 +600,7 @@ class VulkanBackend final : public ::executorch::runtime::BackendInterface {
     }
 
 #ifdef ET_EVENT_TRACER_ENABLED
-    EventTracer* event_tracer = context.event_tracer();
+    runtime::EventTracer* event_tracer = context.event_tracer();
     compute_graph->context()->querypool().extract_results();
     for (const auto& tup :
          compute_graph->context()->querypool().get_shader_timestamp_data()) {


### PR DESCRIPTION
Summary:
Seems there was a breaking change recently which went unnoticed.

Building with event tracing turned on for shader profiling uncovers this compile error:
```
error: unknown type name 'EventTracer'; did you mean 'runtime::EventTracer'?
  603 |     EventTracer* event_tracer = context.event_tracer();
      |     ^~~~~~~~~~~
      |     runtime::EventTracer
executorch/runtime/core/event_tracer.h:115:7: note: 'runtime::EventTracer' declared here
  115 | class EventTracer {
      |       ^
1 error generated.
```

Differential Revision: D64440795


