### PR TITLE
Script to ghstack land

### DIFF
--- a/.github/scripts/propose_ghstack_orig_pr.py
+++ b/.github/scripts/propose_ghstack_orig_pr.py
@@ -1,0 +1,135 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+import re
+
+from typing import List
+
+# Provided by the PyGithub pip package.
+from github import Auth, Github
+from github.Repository import Repository
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--repo",
+        type=str,
+        help='The github repo to modify: e.g. "pytorch/executorch".',
+        required=True,
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        help="Number of the PR in the stack to check and create corresponding PR",
+        required=True,
+    )
+    return parser.parse_args()
+
+
+def extract_stack_from_body(pr_body: str) -> List[int]:
+    """Extracts a list of PR numbers from a ghexport-generated PR body.
+
+    The base of the stack is in index 0.
+    """
+
+    # Expected format. The `__->__` could appear on any line. Stop parsing
+    # after the blank line. This would return [1, 2, 3].
+    """
+    Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
+    * #3
+    * __->__ #2
+    * #1
+
+    <PR description details>
+    """
+
+    prs = []
+    ghstack_begin = (
+        "Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):"
+    )
+    ghstack_begin_seen = False
+    for line in pr_body.splitlines():
+        if ghstack_begin in line:
+            ghstack_begin_seen = True
+        if not ghstack_begin_seen:
+            continue
+        match = re.match(r"\*(?:.*?)? #(\d+)", line)
+        if match:
+            # It's a bullet followed by an integer.
+            prs.append(int(match.group(1)))
+    return list(reversed(prs))
+
+
+def get_pr_stack_from_number(pr_number: int, repo: Repository) -> List[int]:
+    pr_stack = extract_stack_from_body(repo.get_pull(pr_number).body)
+
+    if not pr_stack:
+        raise Exception(
+            f"Could not find PR stack in body of #{pr_number}. "
+            + "Please make sure that the PR was created with ghstack."
+        )
+
+    return pr_stack
+
+
+def create_prs_for_orig_branch(pr_stack: List[int], repo: Repository):
+    # For the first PR, we want to merge to `main` branch, and we will update
+    # as we go through the stack
+    orig_branch_merge_base = "main"
+    for i in range(len(pr_stack)):
+        pr = repo.get_pull(pr_stack[i])
+        if not pr.is_merged():
+            print("The PR (and stack above) is not merged yet, skipping")
+            return
+        # Check for invariant: For the current PR, it must be gh/user/x/base <- gh/user/x/head
+        assert pr.base.ref.replace("base", "head") == pr.head.ref
+        # The PR we want to create is then "branch_to_merge" <- gh/user/x/orig
+        # gh/user/x/orig is the clean diff between gh/user/x/base <- gh/user/x/head
+        orig_branch_merge_head = pr.base.ref.replace("base", "orig")
+        bot_metadata = f"""This PR was created by the merge bot to help merge the original PR into the main branch.
+ghstack PR number: https://github.com/pytorch/executorch/pull/{pr.number}
+^ Please use this as the source of truth for the PR details, comments, and reviews
+ghstack PR base: https://github.com/pytorch/executorch/tree/{pr.base.ref}
+ghstack PR head: https://github.com/pytorch/executorch/tree/{pr.head.ref}
+Merge bot PR base: https://github.com/pytorch/executorch/tree/{orig_branch_merge_base}
+Merge bot PR head: https://github.com/pytorch/executorch/tree/{orig_branch_merge_head}"""
+
+        existing_orig_pr = repo.get_pulls(
+            head="pytorch:" + orig_branch_merge_head,
+            base=orig_branch_merge_base,
+            state="open",
+        )
+        if existing_orig_pr.totalCount > 0:
+            print(
+                f"PR for {orig_branch_merge_head} already exists {existing_orig_pr[0]}"
+            )
+            # We don't need to create/edit because the head PR is merged and orig is finalized.
+        else:
+            repo.create_pull(
+                base=orig_branch_merge_base,
+                head=orig_branch_merge_head,
+                title=pr.title,
+                body=bot_metadata,
+            )
+        # Advance the base for the next PR
+        orig_branch_merge_base = orig_branch_merge_head
+
+
+def main():
+    args = parse_args()
+
+    with Github(auth=Auth.Token(os.environ["GITHUB_TOKEN"])) as gh:
+        repo = gh.get_repo(args.repo)
+        create_prs_for_orig_branch(get_pr_stack_from_number(args.pr, repo), repo)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ghstack_land.yml
+++ b/.github/workflows/ghstack_land.yml
@@ -1,0 +1,40 @@
+name: Propose to merge ghstack orig PRs to main
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'gh/cccclai/[0-9]+/base'
+      - 'gh/dbort/[0-9]+/base'
+      - 'gh/guangy10/[0-9]+/base'
+      - 'gh/helunwencser/[0-9]+/base'
+      - 'gh/jorgep31415/[0-9]+/base'
+      - 'gh/kimishpatel/[0-9]+/base'
+      - 'gh/kirklandsign/[0-9]+/base'
+      - 'gh/larryliu0820/[0-9]+/base'
+      - 'gh/manuelcandales/[0-9]+/base'
+      - 'gh/mcr229/[0-9]+/base'
+      - 'gh/swolchok/[0-9]+/base'
+      - 'gh/SS-JIA/[0-9]+/base'
+
+jobs:
+  ghstack_merge_to_main:
+    name: Try to create a PR with ghstack /orig branch
+    runs-on: ubuntu-22.04
+    environment: cherry-pick-bot
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Try to merge PR to main
+      run: |
+        pip install pygithub
+
+        PR_NUMBER=$(echo "$GITHUB_REF" | grep -oE '[0-9]+')
+
+        python .github/scripts/propose_ghstack_orig_pr.py --pr $PR_NUMBER --repo pytorch/executorch
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_PYTORCHBOT_CHERRY_PICK_TOKEN }}
+        GITHUB_REF: ${{ github.ref }}


### PR DESCRIPTION
Per ghstack [tutorial](https://github.com/ezyang/ghstack/blob/master/README.md#structure-of-submitted-pull-requests) for a PR exported by ghstack, it will have two diff sets:
- `gh/user/1/base <- gh/user/1/head` where the PR is created like [this](https://github.com/pytorch/executorch/pull/6265) 
- `main <- gh/user/1/orig`

The purpose of this bot is, when the ghstack PR is merged, automatically create another PR to do this merge `main <- gh/user/1/orig`. Then we just merge the newly created PR so that `main` has that change.

Missing piece: token from pytorch bot to create PR.

If this goes well, we can either `git merge` the commit from gh/user/1/orig into main directly, without going through the new PR; or auto approve and merge the PR.

Test: You can test locally with `export GITHUB_TOKEN=ghpxyz; python .github/scripts/propose_ghstack_orig_pr.py --pr 6265 --repo pytorch/executorch`
Note that between /orig merges, there is never a merge conflict.

The invariant is guaranteed that gh/user/1/orig contains the exact same change between `gh/user/1/base <- gh/user/1/head` by ghstack tool.
