### PR TITLE
[pybind] Add pybind API reference docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -135,6 +135,7 @@ Topics in this section will help you get started with ExecuTorch.
 
    export-to-executorch-api-reference
    executorch-runtime-api-reference
+   runtime-python-api-reference
    api-life-cycle
 
 .. toctree::

--- a/docs/source/runtime-python-api-reference.rst
+++ b/docs/source/runtime-python-api-reference.rst
@@ -1,0 +1,18 @@
+ExecuTorch Runtime Python API Reference
+----------------------------------
+The Python ``executorch.runtime`` module wraps the C++ ExecuTorch runtime. It can load and execute serialized ``.pte`` program files: see the `Export to ExecuTorch Tutorial <tutorials/export-to-executorch-tutorial.html>`__ for how to convert a PyTorch ``nn.Module`` to an ExecuTorch ``.pte`` program file. Execution accepts and returns ``torch.Tensor`` values, making it a quick way to validate the correctness of the program.
+
+For detailed information on how APIs evolve and the deprecation process, please refer to the `ExecuTorch API Life Cycle and Deprecation Policy <api-life-cycle.html>`__.
+
+.. automodule:: executorch.runtime
+.. autoclass:: Runtime
+    :members: get, load_program
+
+.. autoclass:: OperatorRegistry
+    :members: operator_names
+
+.. autoclass:: Program
+    :members: method_names, load_method
+
+.. autoclass:: Method
+    :members: execute, metadata

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -4,15 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Interface to the native C++ ExecuTorch runtime.
-
+"""
 Example usage:
-.. code-block:: text
+
+.. code-block:: python
 
     from pathlib import Path
 
     import torch
-    from executorch.runtime import Verification, Runtime
+    from executorch.runtime import Verification, Runtime, Program, Method
 
     et_runtime: Runtime = Runtime.get()
     program: Program = et_runtime.load_program(
@@ -28,6 +28,7 @@ Example usage:
     print(f"  outputs: {outputs}")
 
 Example output:
+
 .. code-block:: text
 
     Program methods: ('forward', 'forward2')
@@ -107,6 +108,9 @@ class Program:
 
     @property
     def method_names(self) -> Set[str]:
+        """
+        Returns method names of the `Program` as a set of strings.
+        """
         return set(self._methods.keys())
 
     def load_method(self, name: str) -> Optional[Method]:
@@ -130,7 +134,9 @@ class OperatorRegistry:
 
     @property
     def operator_names(self) -> Set[str]:
-        """The names of all registered operators."""
+        """
+        Returns the names of all registered operators as a set of strings.
+        """
         return set(self._legacy_module._get_operator_names())
 
 


### PR DESCRIPTION
[pybind] Add pybind API reference docs

Summary: As titled

Test Plan: https://docs-preview.pytorch.org/pytorch/executorch/6276/runtime-python-api-reference.html

Reviewers:

Subscribers:

Tasks:

Tags:
