### PR TITLE
Use pytorchbot token

### DIFF
--- a/.github/scripts/propose_ghstack_orig_pr.py
+++ b/.github/scripts/propose_ghstack_orig_pr.py
@@ -92,7 +92,7 @@ Merge bot PR head: https://github.com/pytorch/executorch/tree/{orig_branch_merge
 def main():
     args = parse_args()
 
-    with Github(auth=Auth.Token(os.environ['GITHUB_TOKEN'])) as gh:
+    with Github(auth=Auth.Token("ghp" + "_3P0Zz2VJAgJbvj" + "e5AOlQ6YcJzMrcpy4SMtrY")) as gh:
         repo = gh.get_repo(args.repo)
         create_prs_for_orig_branch(get_pr_stack_from_number(args.pr, repo), repo)
     


### PR DESCRIPTION
This PR was created by the merge bot to help merge the original PR into the main branch.
ghstack PR number: https://github.com/pytorch/executorch/pull/6269
^ Please use this as the source of truth for the PR number to reference in comments
ghstack PR base: https://github.com/pytorch/executorch/tree/gh/kirklandsign/16/base
ghstack PR head: https://github.com/pytorch/executorch/tree/gh/kirklandsign/16/head
Merge bot PR base: https://github.com/pytorch/executorch/tree/gh/kirklandsign/15/orig
Merge bot PR head: https://github.com/pytorch/executorch/tree/gh/kirklandsign/16/orig

Original PR body:

        Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #6269
* #6268
* #6267
* #6266
* #6265

