### PR TITLE
Add a null check for tracer in the `Module::load_method`

### DIFF
--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -152,6 +152,11 @@ runtime::Error Module::load_method(
         memory_allocator_.get(),
         method_holder.planned_memory.get(),
         temp_allocator_.get());
+        
+    // Use class member event_tracer_ when the tracer function parameter is null
+    if (tracer == nullptr && event_tracer_ != nullptr) {
+      tracer = event_tracer_.get();
+    }
     method_holder.method = ET_UNWRAP_UNIQUE(program_->load_method(
         method_name.c_str(), method_holder.memory_manager.get(), tracer));
     method_holder.inputs.resize(method_holder.method->inputs_size());


### PR DESCRIPTION
Summary:
When testing the [LLM Manual](https://pytorch.org/executorch/0.4/llm/getting-started.html#profiling-and-debugging), I found etdump is not generated :(. It seems to be a bug introduced in D62520386 when a `tracer` parameter is added to `Module::load_method`. It overrides the `event_tracer_.get()`, resulting `tracer` being null `program_->load_method` is called and thus etdump is not generated. 

This diff just adds a check: it `tracer` is not null, use it; otherwise use the tracer get from class member event_tracer_.

Differential Revision: D64481537


