### PR TITLE
Increase benchmark iters for Android jobs

### DIFF
--- a/extension/benchmark/android/benchmark/app/src/main/java/org/pytorch/minibench/BenchmarkActivity.java
+++ b/extension/benchmark/android/benchmark/app/src/main/java/org/pytorch/minibench/BenchmarkActivity.java
@@ -42,7 +42,7 @@ public class BenchmarkActivity extends Activity {
             .findFirst()
             .get();
 
-    int numIter = intent.getIntExtra("num_iter", 50);
+    int numIter = intent.getIntExtra("num_iter", 2000);
 
     // TODO: Format the string with a parsable format
     Stats stats = new Stats();


### PR DESCRIPTION
Per the test [here](https://hud.pytorch.org/benchmark/llms?startTime=Wed%2C%2009%20Oct%202024%2017%3A24%3A45%20GMT&stopTime=Wed%2C%2016%20Oct%202024%2017%3A24%3A45%20GMT&granularity=hour&lBranch=add-memory-metric-ios&lCommit=37a00ca41c98ebbd97e060d11987f00918b67037&rBranch=add-memory-metric-ios&rCommit=37a00ca41c98ebbd97e060d11987f00918b67037&repoName=pytorch%2Fexecutorch&modelName=All%20Models&dtypeName=All%20DType&deviceName=All%20Devices) the data variance from run-to-run are still very large on Android.


Test several runs from different commits: 
 - 1k iter (2336f0d): https://github.com/pytorch/executorch/actions/runs/11375393544
 - 1k iter ([529c161](https://github.com/pytorch/executorch/commit/529c1619ef609aeda14f1724d20733b5c57dbbfc)): https://github.com/pytorch/executorch/actions/runs/11376915381
 - 2k iter ([7723492](https://github.com/pytorch/executorch/commit/77234926324c418dfdb961bb1263d669e6338409)): https://github.com/pytorch/executorch/actions/runs/11379065750
 - 2k iter ([df0db16](https://github.com/pytorch/executorch/commit/df0db16ab3b075832be14fcf171ea40ce210b317)): https://github.com/pytorch/executorch/actions/runs/11379252072
 
 Metrics Comparison on the dashboard:
 - https://hud.pytorch.org/benchmark/llms?startTime=Thu%2C%2010%20Oct%202024%2005%3A31%3A43%20GMT&stopTime=Thu%2C%2017%20Oct%202024%2005%3A31%3A43%20GMT&granularity=hour&lBranch=increase_benchmark_iter&lCommit=529c1619ef609aeda14f1724d20733b5c57dbbfc&rBranch=increase_benchmark_iter&rCommit=2336f0d4a1046c5a37861623ac19cf075109a852&repoName=pytorch%2Fexecutorch&modelName=All%20Models&dtypeName=All%20DType&deviceName=All%20Devices