### PR TITLE
Add a null check for `tracer` in the `Module::load_method`

### DIFF
--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -125,7 +125,7 @@ runtime::Result<std::unordered_set<std::string>> Module::method_names() {
 
 runtime::Error Module::load_method(
     const std::string& method_name,
-    torch::executor::EventTracer* tracer) {
+    torch::executor::EventTracer* event_tracer) {
   if (!is_method_loaded(method_name)) {
     ET_CHECK_OK_OR_RETURN_ERROR(load());
 
@@ -153,7 +153,9 @@ runtime::Error Module::load_method(
         method_holder.planned_memory.get(),
         temp_allocator_.get());
     method_holder.method = ET_UNWRAP_UNIQUE(program_->load_method(
-        method_name.c_str(), method_holder.memory_manager.get(), tracer));
+        method_name.c_str(),
+        method_holder.memory_manager.get(),
+        event_tracer ? event_tracer : this->event_tracer()));
     method_holder.inputs.resize(method_holder.method->inputs_size());
     methods_.emplace(method_name, std::move(method_holder));
   }

--- a/extension/module/module.h
+++ b/extension/module/module.h
@@ -133,7 +133,10 @@ class Module {
    * needed. The loaded method is cached to reuse the next time it's executed.
    *
    * @param[in] method_name The name of the method to load.
-   * @param[in] event_tracer A EventTracer used for tracking and logging events.
+   * @param[in] event_tracer Per-method event tracer to profile/trace methods
+   * individually. When not given, the event tracer passed to the Module
+   * constructor is used. Otherwise, this per-method event tracer takes
+   * precedence.
    *
    * @returns An Error to indicate success or failure.
    */


### PR DESCRIPTION
Summary:
When testing the [LLM Manual](https://pytorch.org/executorch/0.4/llm/getting-started.html#profiling-and-debugging), I found etdump is not generated :(. It seems to be a bug introduced in D62520386 when a `tracer` parameter was added to `Module::load_method`. It overrides the `event_tracer_.get()`, resulting `tracer` being null `program_->load_method` is called and thus etdump is not generated. 

This diff just adds a check: it `tracer` is not null, use it; otherwise use the tracer get from class member event_tracer_.

Differential Revision: D64481537


