### PR TITLE
Add placeholder runtime/COMPATIBILITY.md

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,12 +4,16 @@ Welcome to the ExecuTorch Documentation
 =======================================
 
 .. important::
-   This is a beta release. As of this ExecuTorch beta release, the API
-   will follow the `lifecycle and deprecation policy <api-life-cycle.html.html>`__
-   and ``.pte`` binary format will comply with the *runtime compatibility policy* (TODO: add link).
-   This ensures that application developers can update to the latest version of ExecuTorch
-   without breaking existing integration code, in accordance with these policies.
-   If any issues arise or compatibility breaks occur, please `report them in GitHub <https://github.com/pytorch/executorch/issues/new/choose>`__.
+   v0.4.0 is a beta release of ExecuTorch. As of this release, the API will
+   follow the `API Lifecycle and Deprecation Policy <api-life-cycle.html>`__,
+   and the ``.pte`` binary format will comply with the `Runtime Compatibility
+   Policy
+   <https://github.com/pytorch/executorch/tree/main/runtime/COMPATIBILITY.md>`__.
+   This helps ensure that application developers can update to the latest
+   version of ExecuTorch without breaking existing integration code, in
+   accordance with these policies. If any issues arise or compatibility breaks
+   occur, please `report them in GitHub
+   <https://github.com/pytorch/executorch/issues/new/choose>`__.
 
    We welcome any feedback, suggestions, and bug reports from the community
    to help us improve the technology. Please use the `PyTorch Forums

--- a/docs/source/pte-file-format.md
+++ b/docs/source/pte-file-format.md
@@ -31,6 +31,13 @@ Optional ─┤  ├────────────────────
           └─ └───────────────────────────────────┘
 ```
 
+## Compatibility
+
+See the [Runtime Compatibility Policy](
+https://github.com/pytorch/executorch/tree/main/runtime/COMPATIBILITY.md) for
+details about the compatibility guarantees between the `.pte` format and the
+ExecuTorch runtime.
+
 ## Headers
 
 Program files can be recognized by the magic string at byte offset 4, beginning

--- a/runtime/COMPATIBILITY.md
+++ b/runtime/COMPATIBILITY.md
@@ -1,0 +1,9 @@
+# Runtime Compatibility Policy
+
+This document will describe the compatibility guarantees between the [`.pte` file
+format](https://pytorch.org/executorch/stable/pte-file-format.html) and the
+ExecuTorch runtime.
+
+> [!IMPORTANT]
+> The [canonical version of this document](https://github.com/pytorch/executorch/tree/main/runtime/COMPATIBILITY.md)
+> is in the `main` branch of the `pytorch/executorch` GitHub repo.


### PR DESCRIPTION
This file will contain the details of the PTE-to-runtime compatibility policy.

Update the appropriate docs to point to this file. Note that even release branches should point to the `main` branch version of this file, because the latest version is always the official policy.