### PR TITLE
Rename executorch-llama.aar to executorch.aar

### DIFF
--- a/build/build_android_llm_demo.sh
+++ b/build/build_android_llm_demo.sh
@@ -115,13 +115,12 @@ build_aar() {
   find jni -type f -name "libexecutorch_jni.so" -exec bash -c 'mv "$1" "${1/_jni/}"' bash {} \;
   # Zip all necessary files into the AAR file
   zip -r executorch.aar libs jni/*/libexecutorch.so jni/*/libqnn*.so jni/*/libQnn*.so jni/*/libneuron_backend.so jni/*/libneuron_buffer_allocator.so jni/*/libneuronusdk_adapter.mtk.so AndroidManifest.xml
-  cp executorch.aar executorch-llama.aar
   popd
 }
 
 build_android_demo_apps() {
   mkdir -p examples/demo-apps/android/LlamaDemo/app/libs
-  cp ${BUILD_AAR_DIR}/executorch-llama.aar examples/demo-apps/android/LlamaDemo/app/libs
+  cp ${BUILD_AAR_DIR}/executorch.aar examples/demo-apps/android/LlamaDemo/app/libs
   pushd examples/demo-apps/android/LlamaDemo
   ANDROID_HOME="${ANDROID_SDK:-/opt/android/sdk}" ./gradlew build assembleAndroidTest
   popd

--- a/docs/source/android-prebuilt-library.md
+++ b/docs/source/android-prebuilt-library.md
@@ -23,14 +23,14 @@ To add the Java library to your app, simply download the AAR, and add it to your
 In your app working directory, such as example executorch/examples/demo-apps/android/LlamaDemo,
 ```
 mkdir -p app/libs
-curl https://ossci-android.s3.amazonaws.com/executorch/release/executorch-241002/executorch.aar -o app/libs/executorch-llama.aar
+curl https://ossci-android.s3.amazonaws.com/executorch/release/executorch-241002/executorch.aar -o app/libs/executorch.aar
 ```
 
 And include it in gradle:
 ```
 # app/build.grardle.kts
 dependencies {
-    implementation(files("libs/executorch-llama.aar"))
+    implementation(files("libs/executorch.aar"))
 }
 ```
 

--- a/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
+++ b/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
   implementation("androidx.constraintlayout:constraintlayout:2.2.0-alpha12")
   implementation("com.facebook.fbjni:fbjni:0.5.1")
   implementation("com.google.code.gson:gson:2.8.6")
-  implementation(files("libs/executorch-llama.aar"))
+  implementation(files("libs/executorch.aar"))
   implementation("com.google.android.material:material:1.12.0")
   implementation("androidx.activity:activity:1.9.0")
   testImplementation("junit:junit:4.13.2")

--- a/examples/demo-apps/android/LlamaDemo/docs/delegates/xnnpack_README.md
+++ b/examples/demo-apps/android/LlamaDemo/docs/delegates/xnnpack_README.md
@@ -159,7 +159,7 @@ sh examples/demo-apps/android/LlamaDemo/setup.sh
 
 This is running the shell script which configures the required core ExecuTorch, Llama2/3, and Android libraries, builds them, and copies them to jniLibs.
 
-**Output**: The executorch-llama.aar file will be generated in a newly created folder in the example/demo-apps/android/LlamaDemo/app/libs directory. This is the path that the Android app expects it to be in.
+**Output**: The executorch.aar file will be generated in a newly created folder in the example/demo-apps/android/LlamaDemo/app/libs directory. This is the path that the Android app expects it to be in.
 
 **Note**: If you are building the Android app mentioned in the next section on a separate machine (i.e. MacOS but building and exporting on Linux), make sure you copy the aar file generated from setup script to “examples/demo-apps/android/LlamaDemo/app/libs” before building the Android app.
 

--- a/examples/demo-apps/android/LlamaDemo/download_prebuilt_lib.sh
+++ b/examples/demo-apps/android/LlamaDemo/download_prebuilt_lib.sh
@@ -15,6 +15,5 @@ mkdir -p "$LIBS_PATH"
 
 pushd "$LIBS_PATH"
 curl -O "${AAR_SHASUM_URL}"
-sed -i -e 's/executorch.aar/executorch-llama.aar/g' executorch.aar.sha256sums
-shasum --check --status executorch.aar.sha256sums || curl "${AAR_URL}" -o executorch-llama.aar
+shasum --check --status executorch.aar.sha256sums || curl "${AAR_URL}" -o executorch.aar
 popd

--- a/examples/demo-apps/android/LlamaDemo/setup-with-qnn.sh
+++ b/examples/demo-apps/android/LlamaDemo/setup-with-qnn.sh
@@ -22,4 +22,4 @@ build_jar
 build_android_native_library "arm64-v8a"
 build_aar
 mkdir -p "$BASEDIR"/app/libs
-cp "$BUILD_AAR_DIR/executorch.aar" "$BASEDIR"/app/libs/executorch-llama.aar
+cp "$BUILD_AAR_DIR/executorch.aar" "$BASEDIR"/app/libs/executorch.aar

--- a/examples/demo-apps/android/LlamaDemo/setup.sh
+++ b/examples/demo-apps/android/LlamaDemo/setup.sh
@@ -18,4 +18,4 @@ build_android_native_library "arm64-v8a"
 build_android_native_library "x86_64"
 build_aar
 mkdir -p "$BASEDIR"/app/libs
-cp "$BUILD_AAR_DIR/executorch.aar" "$BASEDIR"/app/libs/executorch-llama.aar
+cp "$BUILD_AAR_DIR/executorch.aar" "$BASEDIR"/app/libs/executorch.aar


### PR DESCRIPTION
Let's use a uniform name. It's easier to maintain and less error prone.

It won't cause BC issue. All renaming are happening within this repo, this version. For user apps, after they download or build the AAR, they can rename in their build.gradle.kts.

Test:
1. `sh examples/demo-apps/android/LlamaDemo/download_prebuilt_lib.sh` run twice!
2. `sh build/build_android_llm_demo.sh`
3. `sh examples/demo-apps/android/LlamaDemo/setup.sh`
4. `sh examples/demo-apps/android/LlamaDemo/setup-with-qnn.sh`