### PR TITLE
executorch/backends/cadence/reference/operators: fix llvm-17-exposed format mismatches

### DIFF
--- a/backends/cadence/reference/operators/dequantize_per_tensor.cpp
+++ b/backends/cadence/reference/operators/dequantize_per_tensor.cpp
@@ -42,7 +42,7 @@ void dequantize_per_tensor_out(
     impl::reference::kernels::dequantize<int32_t>(
         out_data, input_data, scale, zero_point, numel);
   } else {
-    ET_CHECK_MSG(false, "Unhandled input dtype %hhd", input.scalar_type());
+    ET_CHECK_MSG(false, "Unhandled input dtype %hhd", static_cast<int8_t>(input.scalar_type()));
   }
 }
 

--- a/backends/cadence/reference/operators/quantize_per_tensor.cpp
+++ b/backends/cadence/reference/operators/quantize_per_tensor.cpp
@@ -44,7 +44,7 @@ void quantize_per_tensor_out(
     impl::reference::kernels::quantize<int32_t>(
         out_data, input_data, 1. / scale, zero_point, numel);
   } else {
-    ET_CHECK_MSG(false, "Unhandled input dtype %hhd", out.scalar_type());
+    ET_CHECK_MSG(false, "Unhandled input dtype %hhd", static_cast<int8_t>(out.scalar_type()));
   }
 }
 

--- a/backends/cadence/reference/operators/quantized_layer_norm.cpp
+++ b/backends/cadence/reference/operators/quantized_layer_norm.cpp
@@ -145,7 +145,7 @@ void quantized_layer_norm_out(
         output_zero_point,
         out);
   } else {
-    ET_CHECK_MSG(false, "Unhandled input dtype %hhd", input.scalar_type());
+    ET_CHECK_MSG(false, "Unhandled input dtype %hhd", static_cast<int8_t>(input.scalar_type()));
   }
 }
 

--- a/backends/cadence/reference/operators/quantized_relu_out.cpp
+++ b/backends/cadence/reference/operators/quantized_relu_out.cpp
@@ -68,7 +68,7 @@ void quantized_relu_out(
         out_shift,
         output);
   } else {
-    ET_CHECK_MSG(false, "Unhandled input dtype %hhd", input.scalar_type());
+    ET_CHECK_MSG(false, "Unhandled input dtype %hhd", static_cast<int8_t>(input.scalar_type()));
   }
 }
 


### PR DESCRIPTION
Summary:
This avoids errors like the following:

  executorch/backends/cadence/reference/operators/quantized_layer_norm.cpp:148:55: error: format specifies type 'char' but the argument has type 'ScalarType' [-Werror,-Wformat]

Differential Revision: D64548206


