### PR TITLE
executorch/examples/portable/custom_ops/custom_ops_1_out.cpp: fix llvm-17-exposed format mismatches

### DIFF
--- a/examples/portable/custom_ops/custom_ops_1_out.cpp
+++ b/examples/portable/custom_ops/custom_ops_1_out.cpp
@@ -20,11 +20,11 @@ void check_preconditions(const Tensor& in, Tensor& out) {
   ET_CHECK_MSG(
       out.scalar_type() == ScalarType::Float,
       "Expected out tensor to have dtype Float, but got %hhd instead",
-      out.scalar_type());
+      static_cast<int8_t>(out.scalar_type()));
   ET_CHECK_MSG(
       in.scalar_type() == ScalarType::Float,
       "Expected in tensor to have dtype Float, but got %hhd instead",
-      in.scalar_type());
+      static_cast<int8_t>(in.scalar_type()));
   ET_CHECK_MSG(
       out.dim() == in.dim(),
       "Number of dims of out tensor is not compatible with inputs");

--- a/kernels/test/custom_kernel_example/op_relu.cpp
+++ b/kernels/test/custom_kernel_example/op_relu.cpp
@@ -87,7 +87,7 @@ my_relu_out(KernelRuntimeContext& context, const Tensor& input, Tensor& out) {
           InvalidArgument,
           out,
           "Unhandled dtype %hhd",
-          input.scalar_type());
+          static_cast<int8_t>(input.scalar_type()));
   }
 #undef RELU
 


### PR DESCRIPTION
Summary:
This avoids the following errors:

  executorch/examples/portable/custom_ops/custom_ops_1_out.cpp:23:7: error: format specifies type 'char' but the argument has type 'ScalarType' [-Werror,-Wformat]
  executorch/examples/portable/custom_ops/custom_ops_1_out.cpp:27:7: error: format specifies type 'char' but the argument has type 'ScalarType' [-Werror,-Wformat]
  xplat/executorch/kernels/test/custom_kernel_example/op_relu.cpp:90:11: error: format specifies type 'char' but the argument has type 'ScalarType' [-Werror,-Wformat]

Differential Revision: D64577370


