### PR TITLE
Qualcomm AI Engine Direct - Reduce redundant observers

### DIFF
--- a/examples/qualcomm/utils.py
+++ b/examples/qualcomm/utils.py
@@ -348,7 +348,9 @@ def segmentation_metrics(predictions, targets, classes):
     return (pa, mpa, miou, cls_iou)
 
 
-def get_imagenet_dataset(dataset_path, data_size, image_shape, crop_size=None):
+def get_imagenet_dataset(
+    dataset_path, data_size, image_shape, crop_size=None, shuffle=True
+):
     from torchvision import datasets, transforms
 
     def get_data_loader():
@@ -365,7 +367,7 @@ def get_imagenet_dataset(dataset_path, data_size, image_shape, crop_size=None):
         imagenet_data = datasets.ImageFolder(dataset_path, transform=preprocess)
         return torch.utils.data.DataLoader(
             imagenet_data,
-            shuffle=True,
+            shuffle=shuffle,
         )
 
     # prepare input data


### PR DESCRIPTION
## Summary

- Current observer flow checks min/max/axis values to determine whether 2 observer is same. If same, it would only keep 1 observer. Providing these values helps observers to properly compare with other nodes observer, which helps reducing the number of observers, which further helps reducing time to quantize the model.

Before:
![image](https://github.com/user-attachments/assets/b8e766a1-9cdf-4b10-a8c7-7b5ed52b1069)

___
After:
![image](https://github.com/user-attachments/assets/d815d0e8-2792-4429-a233-b8e2e114c277)
