### PR TITLE
[Core ML] Update Partitioner Test as Torch.Any Supported

### DIFF
--- a/backends/apple/coreml/scripts/install_requirements.sh
+++ b/backends/apple/coreml/scripts/install_requirements.sh
@@ -24,7 +24,7 @@ rm -rf "$COREML_DIR_PATH/third-party"
 mkdir "$COREML_DIR_PATH/third-party"
 
 echo "${green}ExecuTorch: Cloning coremltools."
-git clone --depth 1 --branch 8.0 "https://github.com/apple/coremltools.git" $COREMLTOOLS_DIR_PATH
+git clone --depth 1 --branch 8.1 "https://github.com/apple/coremltools.git" $COREMLTOOLS_DIR_PATH
 cd $COREMLTOOLS_DIR_PATH
 
 STATUS=$?

--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -71,23 +71,15 @@ class TestCoreMLPartitioner(unittest.TestCase):
             )
         )
 
-        conv_block = ["aten.convolution.default", "executorch_call_delegate"]
-        safe_softmax_block = [
-            "getitem",
-            "getitem",
-            "getitem",
-            "getitem",
-            "aten.any.dim",
-            "executorch_call_delegate",
-        ]
-        final_block = ["getitem"]
-        total = conv_block + 12 * safe_softmax_block + final_block
-
         assert [
             node.target.__name__
             for node in delegated_program_manager.exported_program().graph.nodes
             if node.op == "call_function"
-        ] == total
+        ] == [
+            "aten.convolution.default",
+            "executorch_call_delegate",
+            "getitem",
+        ]
 
     def test_buffer(self):
         embedding_dim = 3


### PR DESCRIPTION
## Motivation
In https://github.com/pytorch/executorch/pull/4772, the partitioner test case was updated to have graph breaks, because https://github.com/pytorch/pytorch/pull/131863 introduced safe softmax which involves torch.any op that was not supported in Core ML

## Solution
In [coremltools 8.1 release](https://github.com/apple/coremltools/releases/tag/8.1), [torch.any support](https://github.com/apple/coremltools/blob/8.1/coremltools/converters/mil/frontend/torch/ops.py#L1927-L1942) has been included, so
1. We upgrade executorch pinned coremltools to 8.1
2. We will no longer have graph breaks in the partitioner test case

## Other Fixes
https://github.com/pytorch/executorch/issues/5157 and https://github.com/pytorch/executorch/issues/6201 are also resolved in coremltools 8.1