### PR TITLE
[pybind] Add back extension suffix for portable lib shared object in pip wheel

### DIFF
--- a/build/executorch-wheel-config.cmake
+++ b/build/executorch-wheel-config.cmake
@@ -21,9 +21,20 @@
 #
 cmake_minimum_required(VERSION 3.19)
 
-# Find prebuilt _portable_lib.so. This file should be installed under
+# Find prebuilt _portable_lib.<EXT_SUFFIX>.so. This file should be installed under
 # <site-packages>/executorch/share/cmake
-find_library(_portable_lib_LIBRARY _portable_lib.so PATHS "${CMAKE_CURRENT_LIST_DIR}/../../extension/pybindings/")
+
+# Get the Python version and platform information
+execute_process(
+    COMMAND python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"
+    OUTPUT_VARIABLE EXT_SUFFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+find_library(
+  _portable_lib_LIBRARY
+  NAMES _portable_lib${EXT_SUFFIX}
+  PATHS "${CMAKE_CURRENT_LIST_DIR}/../../extension/pybindings/"
+)
 set(EXECUTORCH_LIBRARIES)
 set(EXECUTORCH_FOUND OFF)
 if(_portable_lib_LIBRARY)

--- a/setup.py
+++ b/setup.py
@@ -687,10 +687,6 @@ def get_ext_modules() -> List[Extension]:
     return ext_modules
 
 
-# Override extension suffix to be ".so", skipping package info such as
-# "cpython-311-darwin"
-os.environ["SETUPTOOLS_EXT_SUFFIX"] = ".so"
-
 setup(
     version=Version.string(),
     # TODO(dbort): Could use py_modules to restrict the set of modules we


### PR DESCRIPTION
Summary: Initially our portable lib prebuilt library is named as:

```
_portable_lib.cpython-310-x86_64-linux-gnu.so
```
Where it includes an `EXT_SUFFIX` `cpython-310-x86_64-linux-gnu` consists of architecture and build OS information.

This is enforced by `setuptools` following PEP 3149 and there's no good way to change this behavior.

#5961 was an attempt to rename the .so filename at **packaging** stage to `_portable_lib.so`, so that it is easier to be found by `find_package()` macro in CMake.

However #5961 is breaking the other prebuilt libraries such as `libcustom_ops_aot_lib.so` which depends on the original `_portable_lib.cpython-310-x86_64-linux-gnu.so` name in its RPATH.

This PR is a fix that reverts #5961 and restore the full name during packaging, but try to match the `EXT_SUFFIX` in CMake to be able to find the .so file.

Test Plan:

```bash
EXECUTORCH_BUILD_PYBIND=ON python setup.py bdist_wheel # build wheel including _portable_lib.*.so
pip install dist/executorch-0.5.0a0+7510f8c-cp310-cp310-linux_x86_64.whl
python -c "from executorch.extension.llm.custom_ops import sdpa_with_kv_cache"

# Run torchao script to make sure find_package() works
push ao/torchao/experimental
bash build_torchao_ops.sh executorch
```

Does not throw `_portable_lib.cpython-310-x86_64-linux-gnu.so` not found error.

Reviewers:

Subscribers:

Tasks:

Tags: