### PR TITLE
executorch/examples/portable/custom_ops/custom_ops_2_out.cpp: fix llvm-17-exposed format mismatches

### DIFF
--- a/examples/portable/custom_ops/custom_ops_2_out.cpp
+++ b/examples/portable/custom_ops/custom_ops_2_out.cpp
@@ -19,12 +19,12 @@ namespace {
 void check_preconditions(const Tensor& in, Tensor& out) {
   ET_CHECK_MSG(
       out.scalar_type() == ScalarType::Float,
-      "Expected out tensor to have dtype Float, but got %hhd instead",
-      out.scalar_type());
+      "Expected out tensor to have dtype Float, but got %d instead",
+      static_cast<int>(out.scalar_type()));
   ET_CHECK_MSG(
       in.scalar_type() == ScalarType::Float,
-      "Expected in tensor to have dtype Float, but got %hhd instead",
-      in.scalar_type());
+      "Expected in tensor to have dtype Float, but got %d instead",
+      static_cast<int>(in.scalar_type()));
   ET_CHECK_MSG(
       out.dim() == in.dim(),
       "Number of dims of out tensor is not compatible with inputs");


### PR DESCRIPTION
Summary:
This avoids the following errors:

  executorch/examples/portable/custom_ops/custom_ops_2_out.cpp:23:7: error: format specifies type 'char' but the argument has type 'ScalarType' [-Werror,-Wformat]
  executorch/examples/portable/custom_ops/custom_ops_2_out.cpp:27:7: error: format specifies type 'char' but the argument has type 'ScalarType' [-Werror,-Wformat]

Differential Revision: D64656845


