### PR TITLE
`c10::optional` -> `std::optional` in executorch/backends/vulkan/test/op_tests/sdpa_test.cpp

### DIFF
--- a/backends/vulkan/test/op_tests/sdpa_test.cpp
+++ b/backends/vulkan/test/op_tests/sdpa_test.cpp
@@ -159,10 +159,10 @@ at::Tensor sdpa_reference_impl(
     at::Tensor& value_cache,
     const int64_t start_pos,
     const int64_t seq_len,
-    const c10::optional<at::Tensor> __attn_mask_ignored,
+    const std::optional<at::Tensor> __attn_mask_ignored,
     const double dropout_p,
     const bool is_causal,
-    const c10::optional<double> scale) {
+    const std::optional<double> scale) {
   at::Tensor attn_mask =
       construct_attention_mask(q_projected, key_cache, start_pos);
 


### PR DESCRIPTION
Summary: `c10::optional` is just an alias for `std::optional`. We are removing that alias, so we need to fix all instances where it is used.

Differential Revision: D64648340


