### PR TITLE
`c10::optional` -> `std::optional` in executorch/runtime/core/exec_aten/exec_aten.h

### DIFF
--- a/runtime/core/exec_aten/exec_aten.h
+++ b/runtime/core/exec_aten/exec_aten.h
@@ -60,7 +60,7 @@ using string_view = c10::string_view;
 template <typename T>
 using ArrayRef = c10::ArrayRef<T>;
 template <typename T>
-using optional = c10::optional<T>;
+using optional = std::optional<T>;
 using nullopt_t = c10::nullopt_t;
 using c10::nullopt;
 using ScalarType = at::ScalarType;


### PR DESCRIPTION
Summary: `c10::optional` is just an alias for `std::optional`. We are removing that alias, so we need to fix all instances where it is used.

Differential Revision: D64648339


