### PR TITLE
Redirect stdout and stderr from C++ stream to Python stream

### DIFF
--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -974,6 +974,18 @@ py::list get_operator_names() {
   return res;
 }
 
+// Redirect std::cout to sys.stdout
+py::scoped_ostream_redirect stdout_redirect(
+    std::cout,                               // C++ stream
+    py::module_::import("sys").attr("stdout") // Python stream
+);
+
+// Redirect std::cerr to sys.stderr
+py::scoped_estream_redirect stderr_redirect(
+    std::cerr,                               // C++ error stream
+    py::module_::import("sys").attr("stderr") // Python error stream
+);
+
 } // namespace
 
 PYBIND11_MODULE(EXECUTORCH_PYTHON_MODULE_NAME, m) {


### PR DESCRIPTION
Summary: When using ExecuTorch pybindings in notebooks users are unable to see the C++ logs in the notebook itself. This diff fixes that by redirecting the C++ stdout and stderr streams to the Python streams.

Differential Revision: D64696334


