### PR TITLE
[ET-VK] Fix int8 buffers support detection

### DIFF
--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -182,7 +182,7 @@ class Adapter final {
   }
 
   inline bool has_full_int8_buffers_support() {
-    return supports_16bit_storage_buffers() && supports_int8_shader_types();
+    return supports_8bit_storage_buffers() && supports_int8_shader_types();
   }
 
   // Command Buffer Submission


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

## Context

As title. Fixes a small type which prevented us from detecting that int8 buffers are not supported.

Differential Revision: [D64703949](https://our.internmc.facebook.com/intern/diff/D64703949/)