### PR TITLE
ghstack bot skip if a corresponding PR is merged

### DIFF
--- a/.github/scripts/propose_ghstack_orig_pr.py
+++ b/.github/scripts/propose_ghstack_orig_pr.py
@@ -112,9 +112,9 @@ Merge bot PR head: https://github.com/pytorch/executorch/tree/{orig_branch_merge
         existing_orig_pr = repo.get_pulls(
             head="pytorch:" + orig_branch_merge_head,
             base=orig_branch_merge_base,
-            state="open",
+            state="all",
         )
-        if existing_orig_pr.totalCount > 0:
+        if existing_orig_pr.totalCount > 0 and existing_orig_pr[0].title == pr.title:
             print(
                 f"PR for {orig_branch_merge_head} already exists {existing_orig_pr[0]}"
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #6426

If a corresponding fixup PR is merged, the bot should not attempt to create a duplicated one