### PR TITLE
[Android] Strip .so for Release build

### DIFF
--- a/build/build_android_llm_demo.sh
+++ b/build/build_android_llm_demo.sh
@@ -112,6 +112,9 @@ build_aar() {
   # Rename libexecutorch_jni.so to libexecutorch.so for soname consistency
   # between Java and JNI
   find jni -type f -name "libexecutorch_jni.so" -exec bash -c 'mv "$1" "${1/_jni/}"' bash {} \;
+  if [ "$EXECUTORCH_CMAKE_BUILD_TYPE" == "Release" ]; then
+    find jni -type f -name "*.so" -exec "$ANDROID_NDK"/toolchains/llvm/prebuilt/*/bin/llvm-strip {} \;
+  fi
   # Zip all necessary files into the AAR file
   zip -r executorch.aar libs jni/*/libexecutorch.so jni/*/libqnn*.so jni/*/libQnn*.so jni/*/libneuron_backend.so jni/*/libneuron_buffer_allocator.so jni/*/libneuronusdk_adapter.mtk.so AndroidManifest.xml
   popd


### PR DESCRIPTION
If the user wants to use unstripped .so for debugging, use debug build by
```
export EXECUTORCH_CMAKE_BUILD_TYPE=Debug
sh build/build_android_llm_demo.sh
```


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #6441
* #6440

