### PR TITLE
Move android.yml to pull.yml

### DIFF
--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -36,7 +36,7 @@ jobs:
   run-emulator:
     needs: build-llm-demo
     # NB: Use metal install for KVM support to run the emulator faster
-    runs-on: linux.24xl.spr-metal
+    runs-on: linux.4xlarge
     env:
       ANDROID_NDK_VERSION: r27b
       API_LEVEL: 34

--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -36,7 +36,7 @@ jobs:
   run-emulator:
     needs: build-llm-demo
     # NB: Use metal install for KVM support to run the emulator faster
-    runs-on: linux.4xlarge
+    runs-on: linux.12xlarge
     env:
       ANDROID_NDK_VERSION: r27b
       API_LEVEL: 34

--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -1,22 +1,7 @@
 name: Android
 
 on:
-  push:
-    branches:
-      - main
-      - release/*
-    tags:
-      - ciflow/android/*
-  pull_request:
-    paths:
-      - .ci/docker/**
-      - .github/workflows/android.yml
-      - build/*android*.sh
-      - install_requirements.sh
-      - examples/demo-apps/android/**
-      - extension/android/**
-      - extension/benchmark/android/**
-      - extension/module/**
+  workflow_call:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -347,6 +347,9 @@ jobs:
           exit 1
         fi
 
+  android:
+    uses: ./.github/workflows/_android.yml
+
   unittest:
     uses: ./.github/workflows/_unittest.yml
     with:


### PR DESCRIPTION
Add workflow_call trigger.

android.yml takes about 20 minutes and it's not expensive as before

Later we are [considering use a matcher to check whether we should bypass](https://github.com/pytorch/executorch/pull/6448/files)

Later we plan to upload exported models and use it on Android E2E