### PR TITLE
Android emulator job should use linux.24xl.spr-metal

### DIFF
--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -32,7 +32,7 @@ jobs:
   run-emulator:
     needs: build-llm-demo
     # NB: Use metal install for KVM support to run the emulator faster
-    runs-on: linux.12xlarge
+    runs-on: linux.24xl.spr-metal
     env:
       ANDROID_NDK_VERSION: r27b
       API_LEVEL: 34


### PR DESCRIPTION
It's flaky and we don't have a good solution.