### PR TITLE
Replace torch.empty with torch.zeros

### DIFF
--- a/examples/models/llama/source_transformation/lora.py
+++ b/examples/models/llama/source_transformation/lora.py
@@ -70,6 +70,8 @@ class Int8DynActInt4WeightLinearLoRA(Int8DynActInt4WeightLinear):
             precision=precision,
             scales_precision=scales_precision,
         )
+        # TODO(lunwenh): Remove this once TorchAO's commit pin in ExecuTorch is updated to include this PR
+        self.zeros = torch.zeros_like(self.zeros)
         self.adaptor = LoRAAdaptorLinear(
             in_features,
             out_features,

--- a/examples/models/llama/source_transformation/pre_quantization.py
+++ b/examples/models/llama/source_transformation/pre_quantization.py
@@ -46,6 +46,8 @@ def _replace_linear_with_linear_8da4w_for_pre_quantization(
             precision=precision,
             scales_precision=scales_precision,
         )
+        # TODO(lunwenh): Remove this once TorchAO's commit pin in ExecuTorch is updated to include this PR
+        new_linear.zeros = torch.zeros_like(new_linear.zeros)
         return new_linear
 
     _replace_with_custom_fn_if_matches_filter(module, replacement_fn, filter_fn)

--- a/examples/models/llama/source_transformation/quantize.py
+++ b/examples/models/llama/source_transformation/quantize.py
@@ -375,7 +375,7 @@ class WeightOnlyInt8Linear(torch.nn.Module):
         self.in_features = in_features
         self.out_features = out_features
         self.register_buffer(
-            "weight", torch.empty((out_features, in_features), dtype=torch.int8)
+            "weight", torch.zeros((out_features, in_features), dtype=torch.int8)
         )
         self.register_buffer("scales", torch.ones(out_features, dtype=torch.bfloat16))
 
@@ -448,18 +448,18 @@ class Int8DynActInt8WeightLinear(torch.nn.Module):
         # currently storing unpacked int8 weights
         self.register_buffer(
             "weight",
-            torch.empty((out_features, in_features), dtype=torch.int8),
+            torch.zeros((out_features, in_features), dtype=torch.int8),
         )
         self.register_buffer(
             "scales",
-            torch.empty(
+            torch.zeros(
                 (out_features),
                 dtype=torch.float32,
             ),
         )
         self.register_buffer(
             "zeros",
-            torch.empty(
+            torch.zeros(
                 (out_features),
                 dtype=torch.float32,
             ),
@@ -632,7 +632,7 @@ class QuantizedGroupEmbedding(torch.nn.Module):
         if not packed:
             self.register_buffer(
                 "weight",
-                torch.empty(
+                torch.zeros(
                     (vocab_size, embedding_dim), dtype=torch.int8, device=device
                 ),
             )
@@ -640,7 +640,7 @@ class QuantizedGroupEmbedding(torch.nn.Module):
             if bitwidth == 2:
                 self.register_buffer(
                     "weight",
-                    torch.empty(
+                    torch.zeros(
                         (vocab_size, embedding_dim // 4),
                         dtype=torch.uint8,
                         device=device,
@@ -649,7 +649,7 @@ class QuantizedGroupEmbedding(torch.nn.Module):
             elif bitwidth == 4:
                 self.register_buffer(
                     "weight",
-                    torch.empty(
+                    torch.zeros(
                         (vocab_size, embedding_dim // 2),
                         dtype=torch.uint8,
                         device=device,


### PR DESCRIPTION
Summary:
It turns out that it is unsafe to use `torch.empty` in oss environment because `torch.empty` creates tensor with uninitialized data. That means the buffer could be initialized with random values depends on what is left on that piece of memory. This causes code to generate inconsistent behavior.

This PR replaces `torch.empty` with `torch.zeros` to make sure that they are properly initialized and avoid inconsistent behaviors.

Differential Revision: D64875312


