### PR TITLE
Assert that the repo directory is named `executorch`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,19 @@ message(STATUS "Using python executable '${PYTHON_EXECUTABLE}'")
 set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 
 # Let files say "include <executorch/path/to/header.h>".
+# TODO(#6475): This requires/assumes that the repo lives in a directory named
+# exactly `executorch`. Check the assumption first. Remove this check once we
+# stop relying on the assumption.
+cmake_path(GET CMAKE_CURRENT_SOURCE_DIR FILENAME _repo_dir_name)
+if(NOT "${_repo_dir_name}" STREQUAL "executorch")
+  message(
+    FATAL_ERROR
+      "The ExecuTorch repo must be cloned into a directory named exactly "
+      "`executorch`; found `${_repo_dir_name}`. See "
+      "https://github.com/pytorch/executorch/issues/6475 for progress on a "
+      "fix for this restriction."
+  )
+endif()
 set(_common_include_directories ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 #


### PR DESCRIPTION
Our C++ include path assumes that the repo lives in a directory named exactly `executorch`. Users who name it something else run into hard-to-debug issues (see #6475).

Since we require it, add an explicit check and point users to the issue that tracks the fix.

## Test Plan

Tried generating cmake files under a directory named `executorch` and named `not-executorch`:

```
(rm -rf cmake-out \
    && mkdir cmake-out \
    && cd cmake-out \
    && cmake ../)
```

Note that I added a trailing slash just in case CMAKE_CURRENT_SOURCE_DIR included that slash and might confuse `cmake_path()`. (note that CMAKE_CURRENT_SOURCE_DIR does not include the trailing slash in this case)

This command succeeded when the directory is named `executorch`.

Under `not-executorch` it failed with the error:

```
CMake Error at CMakeLists.txt:332 (message):
  The ExecuTorch repo must be cloned into a directory named exactly
  `executorch`; found `not-executorch`.  See
  https://github.com/pytorch/executorch/issues/6475 for progress on a fix for
  this restriction.
```

Also tested with the instructions at [pytorch.org/executorch/main/llm/getting-started.html](https://pytorch.org/executorch/main/llm/getting-started.html), where executorch is a sub-repo of the top project. It builds when following the directions, but if I rename the repo to third-party/not-executorch then I see the expected error.