### PR TITLE
Cleanup executorch::aten::... for cadence operators.

### DIFF
--- a/backends/cadence/hifi/operators/targets.bzl
+++ b/backends/cadence/hifi/operators/targets.bzl
@@ -17,7 +17,8 @@ def define_common_targets():
         ]),
         platforms = CXX,
         deps = [
-            "//executorch/kernels/portable/cpu/util:broadcast_util",
+            "//executorch/kernels/portable/cpu/util:all_deps",
+            "//executorch/kernels/portable/cpu/pattern:all_deps",
             "//executorch/runtime/kernel:kernel_includes",
             "//executorch/kernels/portable/cpu:scalar_utils",
             "fbsource//third-party/nnlib-hifi4/xa_nnlib:libxa_nnlib",


### PR DESCRIPTION
Summary:
1. Remove all using-declarations and `namespace at/c10 = ...` from headers.
2. Use `::executorch::aten::...` instead of `at::...` or `c10::...` in cpp files.

Reviewed By: dbort

Differential Revision: D64864409


