### PR TITLE
Update Hugging Face version

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -411,8 +411,6 @@ jobs:
         pip install -U "huggingface_hub[cli]"
         huggingface-cli login --token $SECRET_EXECUTORCH_HF_TOKEN
         pip install accelerate sentencepiece
-        # TODO(guangyang): Switch to use released transformers library after all required patches are included
-        pip install "git+https://github.com/huggingface/transformers.git@6cc4dfe3f1e8d421c6d6351388e06e9b123cbfe1"
         pip list
         echo "::endgroup::"
 

--- a/examples/models/llama/install_requirements.sh
+++ b/examples/models/llama/install_requirements.sh
@@ -16,6 +16,8 @@ pip install "$(dirname "$0")/../../../third-party/ao"
 # Install tiktoken for tokenizer
 pip install lm_eval==0.4.5
 pip install tiktoken blobfile
+# Restore numpy if >= 2.0
+pip install "numpy<2.0"
 
 # Call the install helper for further setup
 python examples/models/llama/install_requirement_helper.py

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -137,7 +137,7 @@ EXAMPLES_REQUIREMENTS = [
     "timm==1.0.7",
     f"torchaudio==2.5.0.{NIGHTLY_VERSION}" if USE_PYTORCH_NIGHTLY else "torchaudio",
     "torchsr==1.0.4",
-    "transformers==4.42.4",
+    "transformers==4.46.1",
 ]
 
 # pip packages needed for development.


### PR DESCRIPTION
Bump version to [v4.46.0](https://github.com/huggingface/transformers/releases/tag/v4.46.0) where more `transformers` models are compatible with ExecuTorch out-of-the-box.
Consolidate to use a single version of `transformers` in anywhere in the codebase, e.g. `examples/`, `.workflow/`

~~However, we are hardcode `lm_eval` to a very old version `0.4.2` which is not compatible with `transformers >= 4.45` (actually incompatible with `tokenizers >= 0.20`). It must be upgraded, but not in this PR. Since the eval is using the tinyllama in the CI, the version of `transformers` doesn't matter. The workaround is to force reinstall a lower version in the CI.~~