### PR TITLE
Remove ET_ALLOCATE_LIST_OR_RETURN_ERROR from all core code for MSVC windows

### DIFF
--- a/runtime/executor/tensor_parser.h
+++ b/runtime/executor/tensor_parser.h
@@ -37,13 +37,18 @@ parseListOptionalType(
     const flatbuffers::Vector<int32_t>* value_indices,
     EValue* values_,
     MemoryManager* memory_manager) {
-  auto* evalp_list = ET_ALLOCATE_LIST_OR_RETURN_ERROR(
-      memory_manager->method_allocator(), EValue*, value_indices->size());
-
-  auto* optional_tensor_list = ET_ALLOCATE_LIST_OR_RETURN_ERROR(
-      memory_manager->method_allocator(),
-      executorch::aten::optional<T>,
+  auto* evalp_list = memory_manager->method_allocator()->allocateList<EValue*>(
       value_indices->size());
+  if (evalp_list == nullptr) {
+    return Error::MemoryAllocationFailed;
+  }
+
+  auto* optional_tensor_list =
+      memory_manager->method_allocator()
+          ->allocateList<executorch::aten::optional<T>>(value_indices->size());
+  if (optional_tensor_list == nullptr) {
+    return Error::MemoryAllocationFailed;
+  }
 
   size_t output_idx = 0;
   // For each index look up the corresponding EValue (which has been

--- a/runtime/executor/tensor_parser_exec_aten.cpp
+++ b/runtime/executor/tensor_parser_exec_aten.cpp
@@ -74,12 +74,17 @@ ET_NODISCARD Result<BoxedEvalueList<exec_aten::Tensor>> parseTensorList(
     MemoryManager* memory_manager) {
   EXECUTORCH_SCOPE_PROF("TensorParser::parseTensorList");
 
-  auto* tensor_list = ET_ALLOCATE_LIST_OR_RETURN_ERROR(
-      memory_manager->method_allocator(),
-      exec_aten::Tensor,
+  auto* tensor_list =
+      memory_manager->method_allocator()->allocateList<exec_aten::Tensor>(
+          tensor_indices->size());
+  if (tensor_list == nullptr) {
+    return Error::MemoryAllocationFailed;
+  }
+  auto* evalp_list = memory_manager->method_allocator()->allocateList<EValue*>(
       tensor_indices->size());
-  auto* evalp_list = ET_ALLOCATE_LIST_OR_RETURN_ERROR(
-      memory_manager->method_allocator(), EValue*, tensor_indices->size());
+  if (evalp_list == nullptr) {
+    return Error::MemoryAllocationFailed;
+  }
 
   // For each tensor index look up the corresponding Tensor (which has been
   // already allocated) and stick it in the list.


### PR DESCRIPTION
Summary: Remove all instances of `ET_ALLOCATE_LIST_OR_RETURN_ERROR` from the core code and instead allocate and check for a null-pointer which is MSVC compatible.

Differential Revision: D64952858


