### PR TITLE
Get rid of statement expressions from all core code for MSVC windows

### DIFF
--- a/examples/qualcomm/oss_scripts/llama2/runner/runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama2/runner/runner.cpp
@@ -654,7 +654,7 @@ Error Runner::mem_alloc(size_t alignment, size_t seq_len) {
   // Reset and re-init again to trigger registered function
   module_.reset();
   module_ = std::make_unique<Module>(
-      model_path_, Module::LoadMode::MmapUseMlockIgnoreErrors),
+      model_path_, Module::LoadMode::MmapUseMlockIgnoreErrors);
   ET_CHECK_MSG(load() == Error::Ok, "Runner failed to load method");
 
   return Error::Ok;

--- a/runtime/platform/assert.h
+++ b/runtime/platform/assert.h
@@ -34,12 +34,12 @@
  * @param[in] ... Format string arguments.
  */
 #define ET_CHECK_MSG(_cond, _format, ...)                               \
-  ({                                                                    \
+  do {                                                                  \
     if ET_UNLIKELY (!(_cond)) {                                         \
       ET_ASSERT_MESSAGE_EMIT(" (%s): " _format, #_cond, ##__VA_ARGS__); \
       ::executorch::runtime::runtime_abort();                           \
     }                                                                   \
-  })
+  } while (0)
 
 /**
  * Abort the runtime if the condition is not true.
@@ -48,12 +48,12 @@
  * @param[in] _cond Condition asserted as true.
  */
 #define ET_CHECK(_cond)                       \
-  ({                                          \
+  do {                                        \
     if ET_UNLIKELY (!(_cond)) {               \
       ET_ASSERT_MESSAGE_EMIT(": %s", #_cond); \
       ::executorch::runtime::runtime_abort(); \
     }                                         \
-  })
+  } while (0)
 
 #ifdef NDEBUG
 
@@ -102,10 +102,10 @@
  * Assert that this code location is unreachable during execution.
  */
 #define ET_ASSERT_UNREACHABLE()                                   \
-  ({                                                              \
+  do {                                                            \
     ET_CHECK_MSG(false, "Execution should not reach this point"); \
     ET_UNREACHABLE();                                             \
-  })
+  } while (0)
 
 /**
  * Assert that this code location is unreachable during execution.

--- a/runtime/platform/default/posix.cpp
+++ b/runtime/platform/default/posix.cpp
@@ -50,7 +50,7 @@
  * Assert that the PAL has been initialized.
  */
 #define _ASSERT_PAL_INITIALIZED()                                   \
-  ({                                                                \
+  do {                                                              \
     if (!initialized) {                                             \
       fprintf(                                                      \
           ET_LOG_OUTPUT_FILE,                                       \
@@ -59,7 +59,7 @@
       fflush(ET_LOG_OUTPUT_FILE);                                   \
       et_pal_abort();                                               \
     }                                                               \
-  })
+  } while (0)
 
 #endif // NDEBUG
 

--- a/runtime/platform/log.h
+++ b/runtime/platform/log.h
@@ -155,7 +155,7 @@ using ::executorch::runtime::LogLevel;
  * @param[in] _format Log message format string.
  */
 #define ET_LOG(_level, _format, ...)                                 \
-  ({                                                                 \
+  do {                                                               \
     const auto _log_level = ::executorch::runtime::LogLevel::_level; \
     if (static_cast<uint32_t>(_log_level) >=                         \
         static_cast<uint32_t>(                                       \
@@ -171,8 +171,7 @@ using ::executorch::runtime::LogLevel;
           _format,                                                   \
           ##__VA_ARGS__);                                            \
     }                                                                \
-  })
-
+  } while (0)
 #else // ET_LOG_ENABLED
 
 /**

--- a/runtime/platform/profiler.h
+++ b/runtime/platform/profiler.h
@@ -248,20 +248,29 @@ using ::executorch::runtime::track_allocator;
 
 #else
 
-#define EXECUTORCH_PROFILE_CREATE_BLOCK(name) ({ (void)(name); })
+#define EXECUTORCH_PROFILE_CREATE_BLOCK(name) \
+  do {                                        \
+    (void)(name);                             \
+  } while (0)
 
 #define EXECUTORCH_BEGIN_PROF(name) \
   {}
 
-#define EXECUTORCH_END_PROF(token_id) ({ (void)(token_id); })
+#define EXECUTORCH_END_PROF(token_id) \
+  do {                                \
+    (void)(token_id);                 \
+  } while (0)
 
-#define EXECUTORCH_SCOPE_PROF(name) ({ (void)(name); })
+#define EXECUTORCH_SCOPE_PROF(name) \
+  do {                              \
+    (void)(name);                   \
+  } while (0)
 
 #define EXECUTORCH_PROFILE_INSTRUCTION_SCOPE(chain_idx, instruction_idx) \
-  ({                                                                     \
+  do {                                                                   \
     (void)(chain_idx);                                                   \
     (void)(instruction_idx);                                             \
-  })
+  } while (0)
 
 #define EXECUTORCH_DUMP_PROFILE_RESULTS(prof_result_test) \
   memset(prof_result_test, 0, sizeof(::executorch::runtime::prof_result_t));
@@ -269,16 +278,12 @@ using ::executorch::runtime::track_allocator;
 #define EXECUTORCH_RESET_PROFILE_RESULTS() \
   {}
 
-#define EXECUTORCH_TRACK_ALLOCATOR(name) \
-  ({                                     \
-    (void)(name);                        \
-    -1;                                  \
-  })
+#define EXECUTORCH_TRACK_ALLOCATOR(name) ((void)(name), -1)
 
 #define EXECUTORCH_TRACK_ALLOCATION(id, size) \
-  ({                                          \
+  do {                                        \
     (void)(id);                               \
     (void)(size);                             \
-  })
+  } while (0)
 
 #endif


### PR DESCRIPTION
Summary: Statement expressions are supported in GCC but not in MSVC, so re-writing the macros in core that use statement expressions into expressions that use `do{}while(0)`.

Differential Revision: D64953673


