### PR TITLE
Add ScalarType 22 `BITS16` support in etdump gen and deserialization

### DIFF
--- a/devtools/bundled_program/schema/scalar_type.fbs
+++ b/devtools/bundled_program/schema/scalar_type.fbs
@@ -24,9 +24,14 @@ enum ScalarType : byte {
   QINT32 = 14,
   QUINT4X2 = 16,
   QUINT2X4 = 17,
+  BITS16 = 22,
   // Types currently not implemented.
   // COMPLEXHALF = 8,
   // COMPLEXFLOAT = 9,
   // COMPLEXDOUBLE = 10,
   // BFLOAT16 = 15,
+  // BITS1x8 = 18,
+  // BITS2x4 = 19,
+  // BITS4x2 = 20,
+  // BITS8 = 21,
 }

--- a/devtools/etdump/etdump_flatcc.cpp
+++ b/devtools/etdump/etdump_flatcc.cpp
@@ -55,6 +55,8 @@ executorch_flatbuffer_ScalarType_enum_t get_flatbuffer_scalar_type(
       return executorch_flatbuffer_ScalarType_DOUBLE;
     case exec_aten::ScalarType::Bool:
       return executorch_flatbuffer_ScalarType_BOOL;
+    case exec_aten::ScalarType::Bits16:
+      return executorch_flatbuffer_ScalarType_BITS16;
     default:
       ET_CHECK_MSG(
           0,

--- a/devtools/etdump/scalar_type.fbs
+++ b/devtools/etdump/scalar_type.fbs
@@ -24,9 +24,14 @@ enum ScalarType : byte {
   QINT32 = 14,
   QUINT4X2 = 16,
   QUINT2X4 = 17,
+  BITS16 = 22,
   // Types currently not implemented.
   // COMPLEXHALF = 8,
   // COMPLEXFLOAT = 9,
   // COMPLEXDOUBLE = 10,
   // BFLOAT16 = 15,
+  // BITS1x8 = 18,
+  // BITS2x4 = 19,
+  // BITS4x2 = 20,
+  // BITS8 = 21,
 }

--- a/exir/scalar_type.py
+++ b/exir/scalar_type.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 from enum import IntEnum
 
 
@@ -26,4 +28,4 @@ class ScalarType(IntEnum):
     BFLOAT16 = 15
     QUINT4x2 = 16
     QUINT2x4 = 17
-    Bits16 = 22
+    BITS16 = 22

--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -262,7 +262,7 @@ scalar_type_table: Dict[torch.dtype, ScalarType] = {
     torch.qint32: ScalarType.QINT32,
     torch.bfloat16: ScalarType.BFLOAT16,
     torch.quint4x2: ScalarType.QUINT4x2,
-    torch.uint16: ScalarType.Bits16,
+    torch.uint16: ScalarType.BITS16,
 }
 
 

--- a/schema/scalar_type.fbs
+++ b/schema/scalar_type.fbs
@@ -24,9 +24,14 @@ enum ScalarType : byte {
   QINT32 = 14,
   QUINT4X2 = 16,
   QUINT2X4 = 17,
+  BITS16 = 22,
   // Types currently not implemented.
   // COMPLEXHALF = 8,
   // COMPLEXFLOAT = 9,
   // COMPLEXDOUBLE = 10,
   // BFLOAT16 = 15,
+  // BITS1x8 = 18,
+  // BITS2x4 = 19,
+  // BITS4x2 = 20,
+  // BITS8 = 21,
 }


### PR DESCRIPTION
Summary:
Add support in etdump gen and etdump parsing for ScalarType 22 `BITS16`.

Note: fbcode/executorch/schema/scalar_type.fbs and fbcode/executorch/devtools/etdump/scalar_type.fbs are copies of each other for historical reasons.

Differential Revision: D64812253


