### PR TITLE
[ET-VK] Fix op benchmarks code generation

### DIFF
--- a/backends/vulkan/test/op_tests/utils/gen_computegraph.py
+++ b/backends/vulkan/test/op_tests/utils/gen_computegraph.py
@@ -448,7 +448,7 @@ ValueRef out_ref = {self.graph}{self.dot}add_value_list(std::move({ref.value_lis
         if isinstance(ref, list):
             ret_str = ""
             for r in ref[:-1]:
-                ret_str += self.set_output(r)
+                ret_str += self.set_output(r, include_declarations)
             return ret_str
         elif ref.src_cpp_type == TENSOR_VECTOR:
             assert ref.is_out


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #6527

## Context

As title. There was a small error in the operator benchmark code generation which impacted operators which return a collection of tensors (e.g. layer norm). The issue was that the generated code would store the output `ValueRefs` in variables that shadowed class variables of the benchmark.

Differential Revision: [D65071024](https://our.internmc.facebook.com/intern/diff/D65071024/)