### PR TITLE
upgrade lm_eval to 0.4.5

### DIFF
--- a/examples/models/llama/evaluate/eager_eval.py
+++ b/examples/models/llama/evaluate/eager_eval.py
@@ -31,7 +31,7 @@ class EagerEvalWrapper(eval_wrapper):
         use_kv_cache: bool = False,
     ):
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        super().__init__(device=device)
+        super().__init__(device=device, pretrained="gpt2")
         self._model = model
         self._tokenizer = tokenizer
         self._device = torch.device(device)

--- a/examples/models/llama/install_requirements.sh
+++ b/examples/models/llama/install_requirements.sh
@@ -15,7 +15,7 @@ pip install --no-use-pep517 "git+https://github.com/pytorch/ao.git@${TORCHAO_VER
 
 # Install lm-eval for Model Evaluation with lm-evalution-harness
 # Install tiktoken for tokenizer
-pip install lm_eval==0.4.2
+pip install lm_eval==0.4.5
 pip install tiktoken blobfile
 
 # Call the install helper for further setup


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #6533

We have been using a pretty old `lm_eval` version. This is blocking us from upgrading other libraries like `transformers` and blocking some others work. For example, https://github.com/pytorch/executorch/pull/6489.

In newer versions `lm_eval`, `pretrainedModel` becomes a required parameter. In 0.4.2, it defaults to `gpt2` if not provided. This PR upgrades our `lm_eval` version to the latest version 0.4.5 and set `pretrainedModel` to its original default value `gpt2`.

Test Plan:
Run eval before and after this PR. Make sure the perplexity number stays around the same.
<img width="682" alt="Screenshot 2024-10-28 at 12 22 45 PM" src="https://github.com/user-attachments/assets/f7bccc55-ad5a-4f90-8eae-eefdd8e9997a">

Differential Revision: [D65079913](https://our.internmc.facebook.com/intern/diff/D65079913)