### PR TITLE
Fix op not found issue in smoke test for pip wheel

### DIFF
--- a/build/packaging/smoke_test.py
+++ b/build/packaging/smoke_test.py
@@ -85,8 +85,8 @@ def main():
 
     # Make sure custom ops are registered.
     assert (
-        "llama::sdpa_with_kv_cache" in ops
-    ), f"sdpa_with_kv_cache not registered, Got ops: {ops}"
+        "llama::sdpa_with_kv_cache.out" in ops
+    ), f"llama::sdpa_with_kv_cache.out not registered, Got ops: {ops}"
 
     # Make sure quantized ops are registered.
     assert (


### PR DESCRIPTION
As titled. Fixing https://github.com/pytorch/executorch/actions/runs/11573027936/job/32214255958