### PR TITLE
read meta["val"]  from arg for place holders instead of generating a fake tensor using fake_tensor_mode.from_real_tensor

### DIFF
--- a/exir/pass_base.py
+++ b/exir/pass_base.py
@@ -453,7 +453,7 @@ class _ExportPassBase(PassBase):
     def placeholder(self, name: str, arg: Argument, meta: NodeMetadata) -> ProxyValue:
         arg_proxy = self.tracer.create_proxy("placeholder", name, (), {})
         arg_proxy.node.meta = meta.data
-        self.tracer.set_metadata(arg_proxy.node, arg)
+        arg_proxy.node.meta["val"] = arg
         return ProxyValue(arg, arg_proxy)
 
     def call_operator(


### PR DESCRIPTION
Summary:
re-generating the inputs (the fake tensors from real tensors) can change some dimension from static to dynamic, this does not sounds to me to be part of the intention of those custom passes .
But this can have complication, for details of the issue read below, what i suggest here is just read the meta['val'] from the input graph instead of regenerating a new fake tensor. 

a failure here https://www.internalfb.com/diff/D65023233 that is related to executorch. 

0) one of the passes changes the dimension of the one of the inputs from [2, 2, 3, 1] to f32[s0, 2, 7 - s2] (because calling from fake_tensor_mode.from_real_tensor can do that)

1) after running passes execuotorch revert the changes of the meta['val] values for all inputs to match the old graph values before the pass did run. (https://www.internalfb.com/code/fbsource/[92156447ae2c]/xplat/executorch/exir/pass_base.py?lines=688)

2) But executorch only do that for inputs and not for the internal nodes of the graph.

3) in this case that one of the inputs from:
   
``` def forward(self, p_conv1_bias: "f32[2]", p_conv2_bias: "f32[2]", `b__frozen_param0: "i8[2, 2, s2, 1]", b__frozen_param1: "i8[2, 2, s2, 1]", x: "f32[s0, 2, 4]"):```

to 
    ```def forward(self, p_conv1_bias: "f32[2]", p_conv2_bias: "f32[2]", b__frozen_param0: "i8[2, 2, 3, 1]", b__frozen_param1: "i8[2, 2, 3, 1]", x: "f32[s0, 2, 4]"):```

replacing every s2 with 3 in the place holders only **but executorch do not apply the changes back to internal nodes** we we still have i8[s0, 2, 7 - s2, 1] in the graph (s2 coming from no where now!)
5) executorch runs more passes on this (ruined graph) 
6) we get an error in one internal node operation that checks that the a dimension have only one dynamic shape.
        quantized_decomposed_quantize_per_tensor_default_4: "i8[s0, 2, 7 - s2, 1]" = executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default(aten_unsqueeze_copy_default_1, 0.012759864330291748, 55, -128, 127, torch.int8);  aten_unsqueeze_copy_default_1 = None

which is right since s2 was replaced with 3, but the change was not propagated to all internal nodes.

Differential Revision: D65120377


