### PR TITLE
Remove deprecated InstructTemplate from llm_pte_finetuning example

### DIFF
--- a/examples/llm_pte_finetuning/phi3_alpaca_code_config.yaml
+++ b/examples/llm_pte_finetuning/phi3_alpaca_code_config.yaml
@@ -4,15 +4,8 @@ tokenizer:
   max_seq_len: 1024
 
 dataset:
-  _component_: torchtune.datasets.instruct_dataset
-  template: papaya.toolkit.experimental.llm_pte_finetuning.utils.DatabricksDolly
-  source: iamtarun/python_code_instructions_18k_alpaca
-  split: train
-  column_map:
-    instruction: instruction
-    prompt: prompt
-    input: input
-    output: output
+  _component_: executorch.examples.llm_pte_finetuning.training_lib.python_code_instructions_alpaca
+
 seed: null
 shuffle: True
 batch_size: 1


### PR DESCRIPTION
See #6552 for context.

Here, we remove the InstructTemplate classes and instead directly replace with a dataset builder that uses the necessary torchtune data components. The associated config is also updated.

Closes #6552.