### PR TITLE
Fix circular import for lm_eval

### DIFF
--- a/examples/models/llama/eval_llama_lib.py
+++ b/examples/models/llama/eval_llama_lib.py
@@ -20,7 +20,6 @@ from executorch.extension.llm.tokenizer.tokenizer import (
     Tokenizer as SentencePieceTokenizer,
 )
 from executorch.extension.llm.tokenizer.utils import get_tokenizer
-from lm_eval.api.model import LM
 from lm_eval.evaluator import simple_evaluate
 
 from .evaluate.eager_eval import EagerEvalWrapper
@@ -159,7 +158,7 @@ class ETRunnerEvalWrapper(EagerEvalWrapper):
 def gen_eval_wrapper(
     model_name: str,
     args: argparse.ArgumentParser,
-) -> LM:
+):
     """
     Generates a wrapper interface around the provided model and tokenizer for
     the lm-evaluation-harness library.


### PR DESCRIPTION
Issue:
```
2024-10-29T23:30:30.1159011Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/lm_eval/api/metrics.py", line 12, in <module>
2024-10-29T23:30:30.1159914Z     from lm_eval.api.registry import register_aggregation, register_metric
2024-10-29T23:30:30.1160902Z   File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/lm_eval/api/registry.py", line 6, in <module>
2024-10-29T23:30:30.1161635Z     from lm_eval.api.model import LM
2024-10-29T23:30:30.1163006Z ImportError: cannot import name 'LM' from partially initialized module 'lm_eval.api.model' (most likely due to a circular import) (/opt/conda/envs/py_3.10/lib/python3.10/site-packages/lm_eval/api/model.py)
2024-10-29T23:30:30.1181885Z ##[error]Process completed with exit code 1.
```
Errors in CI: https://github.com/pytorch/executorch/actions/runs/11583907843/job/32250015409