### PR TITLE
Executorch ops fail to build on macbook M1 due to bad formatting

### DIFF
--- a/kernels/quantized/cpu/embeddingxb.cpp
+++ b/kernels/quantized/cpu/embeddingxb.cpp
@@ -134,7 +134,7 @@ void check_embedding_xbit_args(
     for (int32_t i = 0; i < weight_scales.dim(); ++i) {
       ET_CHECK_MSG(
           opt_weight_zero_points.value().size(i) == weight_scales.size(i),
-          "Dimension size misatch at dim %" PRId8
+          "Dimension size misatch at dim %" PRIi32
           "Weight_zero_point size = %zd"
           ", weight_scales size = %zd.",
           i,

--- a/kernels/quantized/cpu/op_embedding.cpp
+++ b/kernels/quantized/cpu/op_embedding.cpp
@@ -93,7 +93,7 @@ void check_embedding_byte_args(
     for (int32_t i = 0; i < weight_scales.dim(); ++i) {
       ET_CHECK_MSG(
           opt_weight_zero_points.value().size(i) == weight_scales.size(i),
-          "Dimension size misatch at dim %" PRId8
+          "Dimension size misatch at dim %" PRIi32
           "Weight_zero_point size = %zd"
           ", weight_scales size = %zd.",
           i,


### PR DESCRIPTION
Summary:
```
....
executorch/kernels/quantized/cpu/embeddingxb.cpp:140:11: error: format specifies type 'char' but the argument has type 'int32_t' (aka 'int') [-Werror,-Wformat]
          i,
          ^~
executorch/runtime/platform/assert.h:39:59: note: expanded from macro 'ET_CHECK_MSG'
      ET_ASSERT_MESSAGE_EMIT(" (%s): " _format, #_cond, ##__VA_ARGS__); \
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
executorch/runtime/platform/assert.h:26:9: note: expanded from macro 'ET_ASSERT_MESSAGE_EMIT'
      ##__VA_ARGS__)
      ~~^~~~~~~~~~~~
executorch/runtime/platform/log.h:172:13: note: expanded from macro 'ET_LOG'
          ##__VA_ARGS__);                                            \
            ^~~~~~~~~~~
1 warning and 1 error generated.
```

Reviewed By: dongpujin, manuelcandales

Differential Revision: D65156573
