### PR TITLE
Fix find_package(executorch) failure

### DIFF
--- a/build/executorch-wheel-config.cmake
+++ b/build/executorch-wheel-config.cmake
@@ -44,7 +44,7 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-if(RESULT_VARIABLE EQUAL 0)
+if(SYSCONFIG_RESULT EQUAL 0)
   message(STATUS "Sysconfig extension suffix: ${EXT_SUFFIX}")
 else()
   message(FATAL_ERROR "Failed to retrieve sysconfig config var EXT_SUFFIX: ${SYSCONFIG_ERROR}")


### PR DESCRIPTION
Need to check `SYSCONFIG_RESULT` instead of `RESULT_VARIABLE`.