### PR TITLE
port add ops, create new 3p buck targets, add op_add kernel modification

### DIFF
--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -235,12 +235,12 @@ def quantize_and_export_to_cadence(
 def export_to_executorch_gen_etrecord(
     model: torch.nn.Module,
     inputs: tuple[object, ...],
-    dump_graphs: bool = False,
     output_dir: Optional[str] = None,
     opt_level: int = 1,
+    dump_graphs: bool = False,
 ) -> ExecutorchProgramManager:
-    edge_prog_manager = export_to_edge(model, inputs)
     cadence_passes = get_cadence_passes(opt_level)
+    edge_prog_manager = export_to_edge(model, inputs, dump_graphs)
 
     # Run a couple required passes for quant/dequant ops
     cadence_prog_manager = edge_prog_manager.transform(

--- a/backends/cadence/hifi/operators/op_add.cpp
+++ b/backends/cadence/hifi/operators/op_add.cpp
@@ -9,6 +9,8 @@
 #include <executorch/backends/cadence/hifi/kernels/kernels.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
+#include <executorch/kernels/portable/cpu/util/dtype_util.h>
+#include <executorch/kernels/portable/cpu/util/elementwise_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
 #include <executorch/kernels/portable/cpu/util/kernel_ops_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
@@ -121,7 +123,7 @@ Tensor& add_out(
   float alpha_val;
   torch::executor::native::utils::extract_scalar(alpha, &alpha_val);
 
-  constexpr auto name = "add.out";
+  static constexpr const char op_name[] = "add.out";
   constexpr int kNnlibMaxDim = 4; /*fallback if broadcast and dim > 4 */
 
   int a_dim = a.dim(), b_dim = b.dim(), out_dim = out.dim();
@@ -178,23 +180,25 @@ Tensor& add_out(
     return out;
   }
 
-  ET_SWITCH_REALHBBF16_TYPES(a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_REALHBBF16_TYPES(b_type, ctx, name, CTYPE_B, [&]() {
-      using CTYPE_IN = typename torch::executor::
-          promote_types<CTYPE_A, CTYPE_B, /*half_to_float*/ true>::type;
-      ET_DCHECK(CppTypeToScalarType<CTYPE_IN>::value == common_type);
-      CTYPE_IN alpha_val;
-      torch::executor::native::utils::extract_scalar(alpha, &alpha_val);
+  // Compute Dtype
+  ScalarType compute_type =
+      torch::executor::native::utils::get_compute_type(common_type);
 
-      ET_SWITCH_REALHBBF16_TYPES(out_type, ctx, name, CTYPE_OUT, [&]() {
-        AddInner<
-            can_cast<CTYPE_IN, CTYPE_OUT>::value,
-            CTYPE_A,
-            CTYPE_B,
-            CTYPE_IN,
-            CTYPE_OUT>::run(a, b, alpha_val, out);
-      });
-    });
+  ET_SWITCH_REALB_TYPES(compute_type, ctx, op_name, CTYPE_COMPUTE, [&]() {
+    const CTYPE_COMPUTE val_alpha =
+        torch::executor::native::utils::scalar_to<CTYPE_COMPUTE>(alpha);
+    torch::executor::native::utils::
+        apply_bitensor_elementwise_fn<CTYPE_COMPUTE, op_name>(
+            [val_alpha](const CTYPE_COMPUTE val_a, const CTYPE_COMPUTE val_b) {
+              return val_a + val_alpha * val_b;
+            },
+            ctx,
+            a,
+            torch::executor::native::utils::SupportedTensorDtypes::REALHBBF16,
+            b,
+            torch::executor::native::utils::SupportedTensorDtypes::REALHBBF16,
+            out,
+            torch::executor::native::utils::SupportedTensorDtypes::REALHBBF16);
   });
 
   return out;

--- a/backends/cadence/hifi/operators/op_mean.cpp
+++ b/backends/cadence/hifi/operators/op_mean.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/kernels/portable/cpu/util/dtype_util.h>
 #include <executorch/kernels/portable/cpu/util/kernel_ops_util.h>
 #include <executorch/kernels/portable/cpu/util/reduce_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
@@ -141,11 +142,11 @@ Tensor& mean_dim_out(
     return out;
   }
 
-  ET_SWITCH_REALHB_TYPES(in.scalar_type(), ctx, name, CTYPE_IN, [&] {
-    ET_SWITCH_FLOATH_TYPES(out.scalar_type(), ctx, name, CTYPE_OUT, [&] {
+  ET_SWITCH_REALHB_TYPES(in.scalar_type(), ctx, "mean.out", CTYPE_IN, [&] {
+    ET_SWITCH_FLOATH_TYPES(out.scalar_type(), ctx, "mean.out", CTYPE_OUT, [&] {
       CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
-      const size_t num = torch::executor::get_reduced_dim_product(in, dim_list);
-
+      const size_t num =
+          torch::executor::exeget_reduced_dim_product(in, dim_list);
       for (size_t out_ix = 0; out_ix < out.numel(); ++out_ix) {
         CTYPE_OUT sum = 0;
         if (in.numel() > 0) {

--- a/backends/cadence/hifi/operators/targets.bzl
+++ b/backends/cadence/hifi/operators/targets.bzl
@@ -11,20 +11,230 @@ def define_common_targets():
     # Define build targets for all operators registered in the tables above.
 
     runtime.cxx_library(
-        name = "cadence_hifi_ops",
-        srcs = glob([
-            "*.cpp",
-        ]),
-        exported_headers = glob(["*.h"]),
+        name = "quantize_per_tensor",
+        srcs = [
+            "quantize_per_tensor.cpp"
+        ],
         platforms = CXX,
         deps = [
             "//executorch/kernels/portable/cpu/util:all_deps",
             "//executorch/kernels/portable/cpu/pattern:all_deps",
             "//executorch/runtime/kernel:kernel_includes",
             "//executorch/kernels/portable/cpu:scalar_utils",
-            "fbsource//third-party/nnlib-hifi4/xa_nnlib:libxa_nnlib",
-            "fbsource//third-party/nnlib-hifi4/xa_nnlib:libxa_nnlib_common",
             "//executorch/backends/cadence/hifi/kernels:kernels",
+            "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions"
+        ],
+        visibility = [
+            "//executorch/backends/cadence/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+    )
+
+    runtime.cxx_library(
+        name = "dequantize_per_tensor",
+        srcs = [
+            "dequantize_per_tensor.cpp"
+        ],
+        platforms = CXX,
+        deps = [
+            "//executorch/kernels/portable/cpu/util:all_deps",
+            "//executorch/kernels/portable/cpu/pattern:all_deps",
+            "//executorch/runtime/kernel:kernel_includes",
+            "//executorch/kernels/portable/cpu:scalar_utils",
+            "//executorch/backends/cadence/hifi/kernels:kernels",
+            "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions"
+        ],
+        visibility = [
+            "//executorch/backends/cadence/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+    )
+
+    runtime.cxx_library(
+        name = "quantized_layer_norm",
+        srcs = [
+            "quantized_layer_norm.cpp"
+        ],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = [
+            "//executorch/kernels/portable/cpu/util:all_deps",
+            "//executorch/kernels/portable/cpu/pattern:all_deps",
+            "//executorch/runtime/kernel:kernel_includes",
+            "//executorch/kernels/portable/cpu:scalar_utils",
+            "//executorch/backends/cadence/hifi/kernels:kernels",
+            "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions"
+        ],
+        visibility = [
+            "//executorch/backends/cadence/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+    )
+
+    runtime.cxx_library(
+        name = "quantized_linear_out",
+        srcs = [
+            "quantized_linear_out.cpp"
+        ],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = [
+            "//executorch/kernels/portable/cpu/util:all_deps",
+            "//executorch/kernels/portable/cpu/pattern:all_deps",
+            "//executorch/runtime/kernel:kernel_includes",
+            "//executorch/kernels/portable/cpu:scalar_utils",
+            "//executorch/backends/cadence/hifi/kernels:kernels",
+            "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions"
+        ],
+        visibility = [
+            "//executorch/backends/cadence/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+    )
+
+    runtime.cxx_library(
+        name = "op_add",
+        srcs = [
+            "op_add.cpp",
+        ],
+        platforms = CXX,
+        deps = [
+            "//executorch/kernels/portable/cpu/util:all_deps",
+            "//executorch/kernels/portable/cpu/pattern:all_deps",
+            "//executorch/runtime/kernel:kernel_includes",
+            "//executorch/kernels/portable/cpu:scalar_utils",
+            "//executorch/backends/cadence/hifi/kernels:kernels",
+            "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions",
+            "//executorch/kernels/portable/cpu/util:dtype_util",
+            "//executorch/kernels/portable/cpu/util:elementwise_util",
+        ],
+        visibility = [
+            "//executorch/backends/cadence/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+    )
+
+
+    runtime.cxx_library(
+        name = "op_mul",
+        srcs = [
+            "op_mul.cpp",
+        ],
+        platforms = CXX,
+        deps = [
+            "//executorch/kernels/portable/cpu/util:all_deps",
+            "//executorch/kernels/portable/cpu/pattern:all_deps",
+            "//executorch/runtime/kernel:kernel_includes",
+            "//executorch/kernels/portable/cpu:scalar_utils",
+            "//executorch/backends/cadence/hifi/kernels:kernels",
+            "//executorch/kernels/portable/cpu/util:dtype_util",
+            "//executorch/kernels/portable/cpu/util:elementwise_util",
+            "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions"
+        ],
+        visibility = [
+            "//executorch/backends/cadence/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+    )
+
+    runtime.cxx_library(
+        name = "op_sub",
+        srcs = [
+            "op_sub.cpp",
+        ],
+        platforms = CXX,
+        deps = [
+            "//executorch/kernels/portable/cpu/util:all_deps",
+            "//executorch/kernels/portable/cpu/pattern:all_deps",
+            "//executorch/runtime/kernel:kernel_includes",
+            "//executorch/kernels/portable/cpu:scalar_utils",
+            "//executorch/backends/cadence/hifi/kernels:kernels",
+            "//executorch/kernels/portable/cpu/util:dtype_util",
+            "//executorch/kernels/portable/cpu/util:elementwise_util",
+            "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions"
+        ],
+        visibility = [
+            "//executorch/backends/cadence/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+    )
+
+    runtime.cxx_library(
+        name = "op_div",
+        srcs = [
+            "op_div.cpp",
+        ],
+        platforms = CXX,
+        deps = [
+            "//executorch/kernels/portable/cpu/util:all_deps",
+            "//executorch/kernels/portable/cpu/pattern:all_deps",
+            "//executorch/runtime/kernel:kernel_includes",
+            "//executorch/kernels/portable/cpu:scalar_utils",
+            "//executorch/backends/cadence/hifi/kernels:kernels",
+            "//executorch/kernels/portable/cpu/util:dtype_util",
+            "//executorch/kernels/portable/cpu/util:elementwise_util",
+            "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions"
+        ],
+        visibility = [
+            "//executorch/backends/cadence/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+    )
+
+    runtime.cxx_library(
+        name = "op_sigmoid",
+        srcs = [
+            "op_sigmoid.cpp",
+        ],
+        platforms = CXX,
+        deps = [
+            "//executorch/kernels/portable/cpu/util:all_deps",
+            "//executorch/kernels/portable/cpu/pattern:all_deps",
+            "//executorch/runtime/kernel:kernel_includes",
+            "//executorch/backends/cadence/hifi/kernels:kernels",
+            "//executorch/kernels/portable/cpu/util:dtype_util",
+            "//executorch/kernels/portable/cpu/util:elementwise_util",
+            "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions"
+        ],
+        visibility = [
+            "//executorch/backends/cadence/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+    )
+
+    runtime.cxx_library(
+        name = "op_tanh",
+        srcs = [
+            "op_tanh.cpp",
+        ],
+        platforms = CXX,
+        deps = [
+            "//executorch/kernels/portable/cpu/util:all_deps",
+            "//executorch/kernels/portable/cpu/pattern:all_deps",
+            "//executorch/runtime/kernel:kernel_includes",
+            "//executorch/backends/cadence/hifi/kernels:kernels",
+            "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions"
+        ],
+        visibility = [
+            "//executorch/backends/cadence/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+    )
+
+    
+    runtime.cxx_library(
+        name = "op_where",
+        srcs = [
+            "op_where.cpp",
+        ],
+        platforms = CXX,
+        deps = [
+            "//executorch/kernels/portable/cpu/util:all_deps",
+            "//executorch/kernels/portable/cpu/pattern:all_deps",
+            "//executorch/runtime/kernel:kernel_includes",
+            "//executorch/backends/cadence/hifi/kernels:kernels",
+            "//executorch/kernels/portable/cpu/util:elementwise_util",
+            "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions"
         ],
         visibility = [
             "//executorch/backends/cadence/...",

--- a/backends/cadence/hifi/third-party/nnlib/TARGETS
+++ b/backends/cadence/hifi/third-party/nnlib/TARGETS
@@ -1,0 +1,5 @@
+load("targets.bzl", "define_common_targets")
+
+oncall("odai_jarvis")
+
+define_common_targets()

--- a/backends/cadence/hifi/third-party/nnlib/targets.bzl
+++ b/backends/cadence/hifi/third-party/nnlib/targets.bzl
@@ -1,0 +1,18 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+load("@fbsource//tools/build_defs:platform_defs.bzl", "CXX")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    runtime.cxx_library(
+        name = "nnlib-extensions",
+        srcs = native.glob(["*.c", "*.cpp"]),
+        exported_headers = glob(["*.h"]),
+        visibility = [
+            "//executorch/backends/cadence/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+        deps = [
+            "fbsource//third-party/nnlib-hifi4/xa_nnlib:libxa_nnlib",
+        ],
+    )

--- a/backends/cadence/hifi/third-party/nnlib/xa_nn_elm_add_f32_broadcast.c
+++ b/backends/cadence/hifi/third-party/nnlib/xa_nn_elm_add_f32_broadcast.c
@@ -25,7 +25,6 @@
 #include "xa_nnlib_err_chk.h"
 #include "xa_nnlib_kernels_api.h"
 
-
 #if HAVE_VFPU
 static void internal_elm_add_broadcast_2D_f32xf32_f32(FLOAT32 * __restrict__ p_out,
                     const    FLOAT32 * __restrict__ p_inp1,
@@ -425,4 +424,3 @@ WORD32 xa_nn_elm_add_broadcast_4D_f32xf32_f32(FLOAT32 * __restrict__ p_out,
   return 0;
 
 }
-

--- a/backends/cadence/hifi/third-party/nnlib/xa_nn_elm_mul_f32_broadcast.c
+++ b/backends/cadence/hifi/third-party/nnlib/xa_nn_elm_mul_f32_broadcast.c
@@ -20,11 +20,10 @@
 
 ******************************************************************************/
 #include "xa_type_def.h"
-#include "nnlib-hifi4/xa_nnlib/algo/common/include/xa_nnlib_common_fpu.h"
-#include "nnlib-hifi4/xa_nnlib/algo/common/include/xa_nn_common.h"
-#include "nnlib-hifi4/xa_nnlib/algo/common/include/xa_nnlib_err_chk.h"
-#include "nnlib-hifi4/xa_nnlib/algo/kernels/basic/hifi4/xa_nn_basic_state.h"
-#include "nnlib-hifi4/xa_nnlib/include/nnlib/xa_nnlib_kernels_api.h"
+#include "xa_nnlib_common_fpu.h"
+#include "xa_nn_common.h"
+#include "xa_nnlib_err_chk.h"
+#include "xa_nnlib_kernels_api.h"
 
 #if HAVE_VFPU
 static void internal_elm_mul_broadcast_2D_f32xf32_f32(FLOAT32 * __restrict__ p_out,

--- a/backends/cadence/hifi/third-party/nnlib/xa_nn_elm_where_f32xf32_f32.c
+++ b/backends/cadence/hifi/third-party/nnlib/xa_nn_elm_where_f32xf32_f32.c
@@ -20,10 +20,10 @@
 
 ******************************************************************************/
 #include "xa_type_def.h"
-#include "nnlib-hifi4/xa_nnlib/algo/common/include/xa_nnlib_common_fpu.h"
-#include "nnlib-hifi4/xa_nnlib/algo/common/include/xa_nn_common.h"
-#include "nnlib-hifi4/xa_nnlib/algo/common/include/xa_nnlib_err_chk.h"
-#include "nnlib-hifi4/xa_nnlib/algo/kernels/basic/hifi4/xa_nn_basic_state.h"
+#include "xa_nnlib_common_fpu.h"
+#include "xa_nn_common.h"
+#include "xa_nnlib_err_chk.h"
+// #include "xa_nn_basic_state.h"
 #include "xa_nnlib_kernels_api.h"
 
 

--- a/backends/cadence/hifi/third-party/nnlib/xa_nn_reduce_32_32.c
+++ b/backends/cadence/hifi/third-party/nnlib/xa_nn_reduce_32_32.c
@@ -428,7 +428,7 @@ static inline void xa_nn_reduce_sum_4D_f32_f32(const FLOAT32 * __restrict__ p_in
               p_wsrc2 = (xtfloatx2 *)(p_scr_in + (itr_n * plane_size) + (itr_h * wc_plane_size) + (itr_w * temp_inp_c));
               p_dst = (xtfloatx2 *)(p_scratch + (itr_n * hw_plane_size) + (itr_h * temp_inp_w) + itr_w);
               align_src = AE_LA64_PP(p_wsrc2);
-              xtfloatx2 i1 = AE_MOVXTFLOATX2_FROMF32X2(AE_MOVDA32(0));
+              xtfloatx2 i1 = XT_AE_MOVXTFLOATX2_FROMF32X2(AE_MOVDA32(0));
               for(itr_c = 0; itr_c < (temp_inp_c >> 2); itr_c++)
               {
                 xtfloatx2 j1, j2;

--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -88,7 +88,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/...", "@EXECUTORCH_CLIENTS"],
     )
 
     runtime.cxx_library(
@@ -103,7 +103,7 @@ def define_common_targets():
             "//executorch/kernels/portable/cpu:scalar_utils",
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/...", "@EXECUTORCH_CLIENTS"],
     )
 
     runtime.cxx_library(


### PR DESCRIPTION
Summary:
Done the three things as titled
- create buck targets for add mul sub div sigmoid and tanh
- create new thirdparty buck targets for internal use: the OSS version is unique and leading to the GH version. by buckify the “staging” targets it’s much faster for us to get to the latest kernels.
- modified cadence kernels to use the XT_ APIs

Differential Revision: D65300260


