### PR TITLE
[Executorch] Revert compile optimizatin flags for op libs

### DIFF
--- a/shim/xplat/executorch/kernels/portable/op_registration_util.bzl
+++ b/shim/xplat/executorch/kernels/portable/op_registration_util.bzl
@@ -2,21 +2,7 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "is_xplat", "runti
 load("@fbsource//xplat/executorch/build:selects.bzl", "selects")
 
 def get_compiler_optimization_flags():
-    # various ovr_configs are not available in oss
-    if not runtime.is_oss:
-      compiler_flags = select({
-        "DEFAULT": [],
-        "ovr_config//os:android-arm64": [
-              "-O2",
-        ],
-        "ovr_config//os:iphoneos": [
-            "-O2",
-        ],
-        "ovr_config//os:macos-arm64": [
-            "-O2",
-        ],
-      })
-      return compiler_flags
+    # App size regressons requires this to be baktraced until I have a better solution
     return []
 
 def op_target(name, deps = [], android_deps = [], _allow_third_party_deps = False, _aten_mode_deps = []):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #6609

Reverting https://github.com/pytorch/executorch/pull/6517 for now due to app size regression

Differential Revision: [D65336831](https://our.internmc.facebook.com/intern/diff/D65336831/)