### PR TITLE
[AOSP] add file descriptor support to file_data_loader

### DIFF
--- a/examples/portable/executor_runner/executor_runner.cpp
+++ b/examples/portable/executor_runner/executor_runner.cpp
@@ -22,6 +22,9 @@
 
 #include <gflags/gflags.h>
 
+#include <fcntl.h>
+#include <unistd.h>
+
 #include <executorch/extension/data_loader/file_data_loader.h>
 #include <executorch/extension/evalue_util/print_evalue.h>
 #include <executorch/extension/runner_util/inputs.h>
@@ -36,6 +39,10 @@ DEFINE_string(
     model_path,
     "model.pte",
     "Model serialized in flatbuffer format.");
+DEFINE_bool(
+    is_fd_uri,
+    false,
+    "True if the model_path passed is a file descriptor with the prefix \"fd:///\".");
 
 using executorch::extension::FileDataLoader;
 using executorch::runtime::Error;
@@ -66,7 +73,12 @@ int main(int argc, char** argv) {
   // DataLoaders that use mmap() or point to data that's already in memory, and
   // users can create their own DataLoaders to load from arbitrary sources.
   const char* model_path = FLAGS_model_path.c_str();
-  Result<FileDataLoader> loader = FileDataLoader::from(model_path);
+  const bool is_fd_uri = FLAGS_is_fd_uri;
+
+  Result<FileDataLoader> loader = is_fd_uri
+      ? FileDataLoader::fromFileDescriptorUri(model_path)
+      : FileDataLoader::from(model_path);
+
   ET_CHECK_MSG(
       loader.ok(),
       "FileDataLoader::from() failed: 0x%" PRIx32,

--- a/examples/portable/executor_runner/open_file_by_fd.sh
+++ b/examples/portable/executor_runner/open_file_by_fd.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-FILENAME="$1"
-exec {FD}<${FILENAME}     # open file for read, assign descriptor
-echo "Opened ${FILENAME} for read using descriptor ${FD}"
-out/host/linux-x86/bin/executor_runner --model_path fd:///${FD} --is_fd_uri=true
-exec {FD}<&-    # close file

--- a/examples/portable/executor_runner/open_file_by_fd.sh
+++ b/examples/portable/executor_runner/open_file_by_fd.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+FILENAME="$1"
+exec {FD}<${FILENAME}     # open file for read, assign descriptor
+echo "Opened ${FILENAME} for read using descriptor ${FD}"
+out/host/linux-x86/bin/executor_runner --model_path fd:///${FD} --is_fd_uri=true
+exec {FD}<&-    # close file

--- a/extension/data_loader/file_data_loader.h
+++ b/extension/data_loader/file_data_loader.h
@@ -27,7 +27,10 @@ namespace extension {
 class FileDataLoader final : public executorch::runtime::DataLoader {
  public:
   /**
-   * Creates a new FileDataLoader that wraps the named file descriptor.
+   * Creates a new FileDataLoader that wraps the named file descriptor, and the
+   * ownership of the file descriptor is passed. This helper is used when ET is
+   * running in a process that does not have access to the filesystem, and the
+   * caller is able to open the file and pass the file descriptor.
    *
    * @param[in] file_descriptor_uri File descriptor with the prefix "fd:///",
    *     followed by the file descriptor number.

--- a/extension/data_loader/file_data_loader.h
+++ b/extension/data_loader/file_data_loader.h
@@ -27,6 +27,24 @@ namespace extension {
 class FileDataLoader final : public executorch::runtime::DataLoader {
  public:
   /**
+   * Creates a new FileDataLoader that wraps the named file descriptor.
+   *
+   * @param[in] file_descriptor_uri File descriptor with the prefix "fd:///",
+   *     followed by the file descriptor number.
+   * @param[in] alignment Alignment in bytes of pointers returned by this
+   *     instance. Must be a power of two.
+   *
+   * @returns A new FileDataLoader on success.
+   * @retval Error::InvalidArgument `alignment` is not a power of two.
+   * @retval Error::AccessFailed `file_name` could not be opened, or its size
+   *     could not be found.
+   * @retval Error::MemoryAllocationFailed Internal memory allocation failure.
+   */
+  static executorch::runtime::Result<FileDataLoader> fromFileDescriptorUri(
+      const char* file_descriptor_uri,
+      size_t alignment = alignof(std::max_align_t));
+
+  /**
    * Creates a new FileDataLoader that wraps the named file.
    *
    * @param[in] file_name Path to the file to read from.

--- a/extension/data_loader/file_data_loader.h
+++ b/extension/data_loader/file_data_loader.h
@@ -100,6 +100,11 @@ class FileDataLoader final : public executorch::runtime::DataLoader {
       void* buffer) const override;
 
  private:
+  static executorch::runtime::Result<FileDataLoader> fromFileDescriptor(
+      const char* file_name,
+      const int fd,
+      size_t alignment = alignof(std::max_align_t));
+
   FileDataLoader(
       int fd,
       size_t file_size,

--- a/extension/data_loader/test/file_data_loader_test.cpp
+++ b/extension/data_loader/test/file_data_loader_test.cpp
@@ -40,6 +40,103 @@ class FileDataLoaderTest : public ::testing::TestWithParam<size_t> {
   }
 };
 
+TEST_P(FileDataLoaderTest, InBoundsFileDescriptorLoadsSucceed) {
+  // Write some heterogeneous data to a file.
+  uint8_t data[256];
+  for (int i = 0; i < sizeof(data); ++i) {
+    data[i] = i;
+  }
+  TempFile tf(data, sizeof(data));
+
+  int fd = ::open(tf.path().c_str(), O_RDONLY);
+
+  // Wrap it in a loader.
+  Result<FileDataLoader> fdl = FileDataLoader::fromFileDescriptorUri(
+      ("fd:///" + std::to_string(fd)).c_str(), alignment());
+  ASSERT_EQ(fdl.error(), Error::Ok);
+
+  // size() should succeed and reflect the total size.
+  Result<size_t> size = fdl->size();
+  ASSERT_EQ(size.error(), Error::Ok);
+  EXPECT_EQ(*size, sizeof(data));
+
+  // Load the first bytes of the data.
+  {
+    Result<FreeableBuffer> fb = fdl->load(
+        /*offset=*/0,
+        /*size=*/8,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
+    ASSERT_EQ(fb.error(), Error::Ok);
+    EXPECT_ALIGNED(fb->data(), alignment());
+    EXPECT_EQ(fb->size(), 8);
+    EXPECT_EQ(
+        0,
+        std::memcmp(
+            fb->data(),
+            "\x00\x01\x02\x03"
+            "\x04\x05\x06\x07",
+            fb->size()));
+
+    // Freeing should release the buffer and clear out the segment.
+    fb->Free();
+    EXPECT_EQ(fb->size(), 0);
+    EXPECT_EQ(fb->data(), nullptr);
+
+    // Safe to call multiple times.
+    fb->Free();
+  }
+
+  // Load the last few bytes of the data, a different size than the first time.
+  {
+    Result<FreeableBuffer> fb = fdl->load(
+        /*offset=*/sizeof(data) - 3,
+        /*size=*/3,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
+    ASSERT_EQ(fb.error(), Error::Ok);
+    EXPECT_ALIGNED(fb->data(), alignment());
+    EXPECT_EQ(fb->size(), 3);
+    EXPECT_EQ(0, std::memcmp(fb->data(), "\xfd\xfe\xff", fb->size()));
+  }
+
+  // Loading all of the data succeeds.
+  {
+    Result<FreeableBuffer> fb = fdl->load(
+        /*offset=*/0,
+        /*size=*/sizeof(data),
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
+    ASSERT_EQ(fb.error(), Error::Ok);
+    EXPECT_ALIGNED(fb->data(), alignment());
+    EXPECT_EQ(fb->size(), sizeof(data));
+    EXPECT_EQ(0, std::memcmp(fb->data(), data, fb->size()));
+  }
+
+  // Loading zero-sized data succeeds, even at the end of the data.
+  {
+    Result<FreeableBuffer> fb = fdl->load(
+        /*offset=*/sizeof(data),
+        /*size=*/0,
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
+    ASSERT_EQ(fb.error(), Error::Ok);
+    EXPECT_EQ(fb->size(), 0);
+  }
+}
+
+TEST_P(FileDataLoaderTest, FileDescriptorLoadPrefixFail) {
+  // Write some heterogeneous data to a file.
+  uint8_t data[256];
+  for (int i = 0; i < sizeof(data); ++i) {
+    data[i] = i;
+  }
+  TempFile tf(data, sizeof(data));
+
+  int fd = ::open(tf.path().c_str(), O_RDONLY);
+
+  // Wrap it in a loader.
+  Result<FileDataLoader> fdl = FileDataLoader::fromFileDescriptorUri(
+      std::to_string(fd).c_str(), alignment());
+  ASSERT_EQ(fdl.error(), Error::InvalidArgument);
+}
+
 TEST_P(FileDataLoaderTest, InBoundsLoadsSucceed) {
   // Write some heterogeneous data to a file.
   uint8_t data[256];


### PR DESCRIPTION
Summary:
For Google's ODP, the model will execute in a process that does not have access to the file system. Instead, the caller must open the file then pass ownership of the FD to the model executor.

1. Added support for reading files by FD passed by the prefix "fd:///" (copied from tensorflow https://cs.android.com/android/platform/superproject/main/+/main:external/federated-compute/fcp/tensorflow/file_descriptor_filesystem.cc;l=41;bpv=1;bpt=1) into `file_data_loader`.
2. Added test cases by opening file first and passing the FD to the data loader

Test Plan:
1. run C++ tests
2. use script with following instruction:
```
$ cd aosp
$ source build/envsetup.sh
$ lunch aosp_arm64-trunk_staging-userdebug
$ m executor_runner
$ FILENAME="<model_path>"
$ exec {FD}<${FILENAME}     # open file for read, assign descriptor
$ echo "Opened ${FILENAME} for read using descriptor ${FD}"
$ out/host/linux-x86/bin/executor_runner --model_path fd:///${FD} --is_fd_uri=true
$ exec {FD}<&-    # close file
```
result:
```
Opened out/host/linux-x86/bin/add.pte for read using descriptor 10
I 00:00:00.000256 executorch:executor_runner.cpp:94] Model file fd:///10 is loaded.
I 00:00:00.000279 executorch:executor_runner.cpp:103] Using method forward
I 00:00:00.000282 executorch:executor_runner.cpp:150] Setting up planned buffer 0, size 48.
I 00:00:00.000294 executorch:executor_runner.cpp:173] Method loaded.
I 00:00:00.000310 executorch:executor_runner.cpp:183] Inputs prepared.
I 00:00:00.000336 executorch:executor_runner.cpp:192] Model executed successfully.
I 00:00:00.000345 executorch:executor_runner.cpp:196] 1 outputs: 
Output 0: tensor(sizes=[1], [2.])
```