### PR TITLE
Remove typing true flag from executorch

### DIFF
--- a/backends/arm/quantizer/TARGETS
+++ b/backends/arm/quantizer/TARGETS
@@ -3,7 +3,6 @@ load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 python_library(
     name = "arm_quantizer",
     srcs = ["arm_quantizer.py"],
-    typing = True,
     deps = [
         ":arm_quantizer_utils",
         "//caffe2:torch",
@@ -15,7 +14,6 @@ python_library(
 python_library(
     name = "quantization_config",
     srcs = ["quantization_config.py"],
-    typing = True,
     deps = [
         "//caffe2:torch",
     ],
@@ -24,7 +22,6 @@ python_library(
 python_library(
     name = "arm_quantizer_utils",
     srcs = ["arm_quantizer_utils.py"],
-    typing = True,
     deps = [
         ":quantization_config",
     ],


### PR DESCRIPTION
Summary: This is on our blocklist - it shouldn't be opted into PTT typing

Reviewed By: grievejia

Differential Revision: D65343496


