### PR TITLE
Remove assert for ArgSchema

### DIFF
--- a/exir/pass_base.py
+++ b/exir/pass_base.py
@@ -726,7 +726,6 @@ def map_args(
         args[key] = fn(args[key], schema)
 
     for i, schema in enumerate(op._schema.arguments):
-        assert isinstance(schema, ArgSchema)
         if schema.name in kwargs:
             update(schema.name, kwargs, schema)
         elif not schema.kwarg_only and i < len(args):


### PR DESCRIPTION
Summary:
In python 3.12, there were a few changes to runtime_checkable:
https://docs.python.org/3/whatsnew/3.12.html#typing
> The members of a runtime-checkable protocol are now considered “frozen” at runtime as soon as the class has been created. Monkey-patching attributes onto a runtime-checkable protocol will still work, but will have no impact on isinstance() checks comparing objects to the protocol

I'm not sure what was monkey-patched here, but EdgeDialectOverloadPacket
no longer passes the assert.
I'm not sure how to fix this for real, but I just deleted it under the assumption
it's not helpful enough to be worth breaking tests.

Differential Revision: D65316894


