### PR TITLE
[Java] add missing optional tensor list functions

### DIFF
--- a/extension/android/src/main/java/org/pytorch/executorch/EValue.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/EValue.java
@@ -61,7 +61,7 @@ public class EValue {
     "ListInt",
     "ListTensor",
     "ListScalar",
-    "ListOptionalScalar",
+    "ListOptionalTensor",
   };
 
   @DoNotStrip private final int mTypeCode;
@@ -265,6 +265,12 @@ public class EValue {
   public Tensor[] toTensorList() {
     preconditionType(TYPE_CODE_LIST_TENSOR, mTypeCode);
     return (Tensor[]) mData;
+  }
+
+  @DoNotStrip
+  public Optional<Tensor>[] toOptionalTensorList() {
+    preconditionType(TYPE_CODE_LIST_OPTIONAL_TENSOR, mTypeCode);
+    return (Optional<Tensor>[]) mData;
   }
 
   private void preconditionType(int typeCodeExpected, int typeCode) {


### PR DESCRIPTION
Rename 'ListOptionalScalar' -> 'ListOptionalTensor' and add missing 'toOptionalTensorList' function in preparation for JUnit test