### PR TITLE
Add in-memory log buffer in Android JNI

### DIFF
--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -190,4 +190,4 @@ target_include_directories(
 
 target_compile_options(executorch_jni PUBLIC ${_common_compile_options})
 
-target_link_libraries(executorch_jni ${link_libraries})
+target_link_libraries(executorch_jni ${link_libraries} log)

--- a/extension/android/src/main/java/org/pytorch/executorch/Module.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/Module.java
@@ -99,6 +99,11 @@ public class Module {
     return mNativePeer.loadMethod(methodName);
   }
 
+  /** Retrieve the in-memory log buffer, containing the most recent ExecuTorch log entries. */
+  public String[] readLogBuffer() {
+    return mNativePeer.readLogBuffer();
+  }
+
   /**
    * Explicitly destroys the native torch::jit::Module. Calling this method is not required, as the
    * native object will be destroyed when this object is garbage-collected. However, the timing of

--- a/extension/android/src/main/java/org/pytorch/executorch/NativePeer.java
+++ b/extension/android/src/main/java/org/pytorch/executorch/NativePeer.java
@@ -54,4 +54,8 @@ class NativePeer {
    */
   @DoNotStrip
   public native int loadMethod(String methodName);
+
+  /** Retrieve the in-memory log buffer, containing the most recent ExecuTorch log entries. */
+  @DoNotStrip
+  public native String[] readLogBuffer();
 }


### PR DESCRIPTION
### Summary
Add an in-memory log buffer implementation for Android JNI. This is an experimental feature intended to allow developers easier access to ET log strings at runtime.

The new API is availble on the JNI Module class:
```java
public class Module {
  ...
  /** Retrieve the in-memory log buffer, containing the most recent ExecuTorch log entries. */
  public String[] readLogBuffer() 
 ...
}
```

### Test plan
Added temporary test code to Android demo app (not committed):
```java
Log.i("ETTEST", "Reading log buffer after inference");
final String[] logBufferEntries = mModule.readLogBuffer();
for (String log : logBufferEntries) {
  Log.i("ETTEST", log);
}
```

Output:
```
2024-11-05 01:55:08.261  9429-10130 ETTEST                  com.example.executorchdemo           I  Reading log buffer after inference
2024-11-05 01:55:08.265  9429-10130 ETTEST                  com.example.executorchdemo           I  [19307862871 resize_outputs XNNExecutor.cpp:215] D Resizing output tensor to a new shape
2024-11-05 01:55:08.265  9429-10130 ETTEST                  com.example.executorchdemo           I  [21851302330 resize_outputs XNNExecutor.cpp:215] D Resizing output tensor to a new shape
2024-11-05 01:55:08.265  9429-10130 ETTEST                  com.example.executorchdemo           I  [21851522561 resize_outputs XNNExecutor.cpp:215] D Resizing output tensor to a new shape
2024-11-05 01:55:08.265  9429-10130 ETTEST                  com.example.executorchdemo           I  [21851558907 resize_outputs XNNExecutor.cpp:215] D Resizing output tensor to a new shape
2024-11-05 01:55:08.265  9429-10130 ETTEST                  com.example.executorchdemo           I  [21851574830 resize_outputs XNNExecutor.cpp:215] D Resizing output tensor to a new shape
2024-11-05 01:55:08.265  9429-10130 ETTEST                  com.example.executorchdemo           I  [21851596754 resize_outputs XNNExecutor.cpp:215] D Resizing output tensor to a new shape
2024-11-05 01:55:08.265  9429-10130 ETTEST                  com.example.executorchdemo           I  [21851610484 resize_outputs XNNExecutor.cpp:215] D Resizing output tensor to a new shape
2024-11-05 01:55:08.265  9429-10130 ETTEST                  com.example.executorchdemo           I  [21851623254 resize_outputs XNNExecutor.cpp:215] D Resizing output tensor to a new shape
2024-11-05 01:55:08.265  9429-10130 ETTEST                  com.example.executorchdemo           I  [21851635407 internal_resize_contiguous tensor_impl.cpp:98] E Attempted to resize a static tensor
2024-11-05 01:55:08.265  9429-10130 ETTEST                  com.example.executorchdemo           I  [21851659792 resize_outputs XNNExecutor.cpp:218] E Failed to resize output tensor for XNNExecutor
2024-11-05 01:55:08.265  9429-10130 ETTEST                  com.example.executorchdemo           I  [21851672369 execute_instruction method.cpp:1110] E CALL_DELEGATE execute failed at instruction 7: 0x10
2024-11-05 01:55:08.280  9429-10130 AndroidRuntime          com.example.executorchdemo           E  FATAL EXCEPTION: Thread-2
```

Also, I added quick code to ET_LOG 10000 times to sanity check log buffer wrapping. Also, in the medium-term, it would be nice to invest in unit-level tests for the JNI layer.