### PR TITLE
Fix broken apple tests

### DIFF
--- a/extension/data_loader/file_data_loader.cpp
+++ b/extension/data_loader/file_data_loader.cpp
@@ -76,7 +76,7 @@ FileDataLoader::~FileDataLoader() {
   ::close(fd_);
 }
 
-Result<int> getFDFromUri(const char* file_descriptor_uri) {
+static Result<int> getFDFromUri(const char* file_descriptor_uri) {
   // check if the uri starts with the prefix "fd://"
   ET_CHECK_OR_RETURN_ERROR(
       strncmp(


### PR DESCRIPTION
Summary: https://github.com/pytorch/executorch/pull/6611 causes internal builds to break due to missing static qualifier. adding it here

Differential Revision: D65490319
