### PR TITLE
[ExecuTorch] Proof-of-concept: use c10/macros in ExecuTorch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,9 @@ message(STATUS "Using python executable '${PYTHON_EXECUTABLE}'")
 set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 
 # Let files say "include <executorch/path/to/header.h>".
-set(_common_include_directories ${CMAKE_CURRENT_SOURCE_DIR}/..)
+find_package(Torch CONFIG REQUIRED)
+
+set(_common_include_directories ${CMAKE_CURRENT_SOURCE_DIR}/.. ${TORCH_INCLUDE_DIRS})
 
 #
 # The `_<target>_srcs` lists are defined by including ${EXECUTORCH_SRCS_FILE}.
@@ -507,9 +509,6 @@ endif()
 target_include_directories(
   executorch_core PUBLIC ${_common_include_directories}
 )
-target_include_directories(
-  executorch_core INTERFACE ${TORCH_INCLUDE_DIRS}
-)
 target_compile_options(executorch_core PUBLIC ${_common_compile_options})
 if(MAX_KERNEL_NUM)
   target_compile_definitions(
@@ -670,8 +669,6 @@ if(EXECUTORCH_BUILD_PTHREADPOOL
 )
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/threadpool)
 endif()
-
-find_package(Torch CONFIG REQUIRED)
 
 if(EXECUTORCH_BUILD_PYBIND)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/pybind11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,9 @@ endif()
 target_include_directories(
   executorch_core PUBLIC ${_common_include_directories}
 )
+target_include_directories(
+  executorch_core INTERFACE ${TORCH_INCLUDE_DIRS}
+)
 target_compile_options(executorch_core PUBLIC ${_common_compile_options})
 if(MAX_KERNEL_NUM)
   target_compile_definitions(
@@ -668,6 +671,8 @@ if(EXECUTORCH_BUILD_PTHREADPOOL
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/threadpool)
 endif()
 
+find_package(Torch CONFIG REQUIRED)
+
 if(EXECUTORCH_BUILD_PYBIND)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/pybind11)
 
@@ -680,7 +685,6 @@ if(EXECUTORCH_BUILD_PYBIND)
   endif()
 
   # find pytorch lib, to allow pybind to take at::Tensor as input/output
-  find_package(Torch CONFIG REQUIRED)
   find_library(
     TORCH_PYTHON_LIBRARY torch_python PATHS "${TORCH_INSTALL_PREFIX}/lib"
   )

--- a/runtime/platform/compiler.h
+++ b/runtime/platform/compiler.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <c10/macros/Macros.h>
+
 /*
  * Compiler support checks. Follows the logic used by pytorch/c10/util/C++17.h
  * but may support older versions.
@@ -55,9 +57,9 @@
  */
 
 #define ET_NORETURN [[noreturn]]
-#define ET_NOINLINE __attribute__((noinline))
-#define ET_INLINE __attribute__((always_inline)) inline
-#define ET_INLINE_ATTRIBUTE __attribute__((always_inline))
+#define ET_NOINLINE C10_NOINLINE
+#define ET_INLINE C10_ALWAYS_INLINE
+#define ET_INLINE_ATTRIBUTE C10_ALWAYS_INLINE_ATTRIBUTE
 
 #if defined(__GNUC__)
 
@@ -88,14 +90,14 @@
 //   do something
 // }
 #if (__cplusplus) >= 202002L
-
+// TODO: backport these to c10 and remove ET definition
 #define ET_LIKELY(expr) (expr) [[likely]]
 #define ET_UNLIKELY(expr) (expr) [[unlikely]]
 
 #else
 
-#define ET_LIKELY(expr) (expr)
-#define ET_UNLIKELY(expr) (expr)
+#define ET_LIKELY(expr) C10_LIKELY(expr)
+#define ET_UNLIKELY(expr) C10_UNLIKELY(expr)
 
 #endif // (__cplusplus) >= 202002L
 

--- a/runtime/platform/targets.bzl
+++ b/runtime/platform/targets.bzl
@@ -122,6 +122,9 @@ def define_common_targets():
         exported_headers = [
             "compiler.h",
         ],
+        exported_deps = [
+            "//caffe2/c10:c10",
+        ] if not runtime.is_oss else [],
         visibility = [
             "//executorch/...",
             "@EXECUTORCH_CLIENTS",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #6665

Step 0 for code sharing: can we use c10 Macros?

This needs a guardrail to prevent breaking the ExecuTorch core
requirements before we can ship it. What's our current guard against
accidentally including streams/heap allocation/etc. in core at runtime?

Differential Revision: [D65241695](https://our.internmc.facebook.com/intern/diff/D65241695/)