### PR TITLE
Remove IR check after aten in arm

### DIFF
--- a/backends/arm/test/ops/test_batch_norm.py
+++ b/backends/arm/test/ops/test_batch_norm.py
@@ -536,9 +536,6 @@ class TestBatchNorm2d(unittest.TestCase):
                 compile_spec=common.get_tosa_compile_spec(),
             )
             .export()
-            .check_count(
-                {"torch.ops.aten._native_batch_norm_legit_no_training.default": 1}
-            )
             .check_not(["torch.ops.quantized_decomposed"])
             .to_edge()
             .check_count(


### PR DESCRIPTION
Summary: Export is switching to non-functional training IR, as a result, some checks after second export can fail due to difference in the IR. We remove those checks as this IR doesn't really matter to backends

Differential Revision: D65504497


