### PR TITLE
Revert changes to executor_runner

### DIFF
--- a/examples/portable/executor_runner/targets.bzl
+++ b/examples/portable/executor_runner/targets.bzl
@@ -15,7 +15,6 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/executor:program",
             "//executorch/extension/data_loader:file_data_loader",
-            "//executorch/extension/data_loader:file_descriptor_data_loader",
             "//executorch/extension/evalue_util:print_evalue",
             "//executorch/extension/runner_util:inputs",
         ],


### PR DESCRIPTION
Seg fault was introduced to https://github.com/pytorch/executorch/pull/6682 due to moving logic to a helper function and variable lifetimes changing.

Revert executor_runner and fix seg fault tests.