### PR TITLE
Add support for bits16 in ETDump

### DIFF
--- a/devtools/inspector/_inspector_utils.py
+++ b/devtools/inspector/_inspector_utils.py
@@ -112,6 +112,7 @@ def _parse_tensor_value(
             ScalarType.BYTE: (torch.uint8, 1),
             ScalarType.CHAR: (torch.int8, 1),
             ScalarType.BOOL: (torch.bool, 1),
+            ScalarType.BITS16: (torch.uint16, 2),
             ScalarType.SHORT: (torch.int16, 2),
             ScalarType.HALF: (torch.float16, 2),
             ScalarType.INT: (torch.int, 4),


### PR DESCRIPTION
Summary:
Bits16 is a newer scalar type, and some backends (like Cadence) use it
for quantize and dequantize kernels. In case ETDump is turned on for
intermediate tensors, it needs to know the size and the corresponding torch
dtype.

Differential Revision: D65552835


