### PR TITLE
Update backend execute args in test

### DIFF
--- a/runtime/executor/test/backend_integration_test.cpp
+++ b/runtime/executor/test/backend_integration_test.cpp
@@ -56,7 +56,8 @@ class StubBackend final : public BackendInterface {
       FreeableBuffer*,
       ArrayRef<CompileSpec>,
       BackendInitContext&)>;
-  using ExecuteFn = std::function<Error(DelegateHandle*, EValue**)>;
+  using ExecuteFn =
+      std::function<Error(BackendExecutionContext&, DelegateHandle*, EValue**)>;
   using DestroyFn = std::function<void(DelegateHandle*)>;
 
   // Default name that this backend is registered as.
@@ -98,7 +99,7 @@ class StubBackend final : public BackendInterface {
       DelegateHandle* handle,
       EValue** args) const override {
     if (execute_fn_) {
-      return execute_fn_.value()(handle, args);
+      return execute_fn_.value()(context, handle, args);
     }
     // Return a benign value otherwise.
     return Error::Ok;
@@ -404,7 +405,9 @@ TEST_P(BackendIntegrationTest, EndToEndTestWithProcessedAsHandle) {
   // FreeableBuffer.
   DelegateHandle* execute_handle = nullptr;
   StubBackend::singleton().install_execute(
-      [&](DelegateHandle* handle, ET_UNUSED EValue** args) -> Error {
+      [&](ET_UNUSED BackendExecutionContext& backend_execution_context,
+          DelegateHandle* handle,
+          ET_UNUSED EValue** args) -> Error {
         execute_handle = handle;
         auto* processed = reinterpret_cast<FreeableBuffer*>(handle);
 


### PR DESCRIPTION
Summary:
Similar to https://github.com/pytorch/executorch/pull/6673, we update the execute args the same as the actual interface

https://github.com/pytorch/executorch/blob/836d5561a61877507b6d5891485725996bb6b32c/runtime/backend/interface.h?fbclid=IwZXh0bgNhZW0CMTEAAR37pGH_HbSLZTCatfjnXGr_CLc8Th-SpoS4CeKb00z1ngNBJd6OdniK19Q_aem_xk7M6diLe_FAsplz8BZRQg#L96-L99

Differential Revision: D65585157


