### PR TITLE
Arm backend: execute_runner link in portable_kernels

### DIFF
--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -220,8 +220,8 @@ target_link_libraries(
   arm_executor_runner
   extension_runner_util
   ethosu_target_init
-  executorch
   "-Wl,--whole-archive"
+  executorch
   executorch_delegate_ethos_u
   quantized_ops_lib
   portable_ops_lib


### PR DESCRIPTION
Moving linking of libexecutorch.a to after "-Wl,--whole-archive" This adds executorch_prim::* to the build as the executorch_prim ops are added with a c++ static initialize that get optimized away by the linker as the variable in never used in the normal linking. See docs/source/runtime-build-and-cross-compilation.md

Tested on Arm backend using a non delegated view. Without this non of the executorch_prim::<OPS> can be found/used during runtime.