### PR TITLE
[ET-VK][ez] properly parse skip memory metadata pass

### DIFF
--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -251,6 +251,10 @@ def parse_compile_options(compile_options: Dict[str, Any]) -> List[CompileSpec]:
         if isinstance(value, (VkStorageType, VkMemoryLayout)):
             value_bytes = int(value).to_bytes(4, byteorder="little")
             compile_specs.append(CompileSpec(key, value_bytes))
+        
+        if isinstance(value, bool):
+            value_bytes = value.to_bytes(1, byteorder="little")
+            compile_specs.append(CompileSpec(key, value_bytes))
 
         if key == "texture_limits":
             compile_specs.append(

--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -251,7 +251,7 @@ def parse_compile_options(compile_options: Dict[str, Any]) -> List[CompileSpec]:
         if isinstance(value, (VkStorageType, VkMemoryLayout)):
             value_bytes = int(value).to_bytes(4, byteorder="little")
             compile_specs.append(CompileSpec(key, value_bytes))
-        
+
         if isinstance(value, bool):
             value_bytes = value.to_bytes(1, byteorder="little")
             compile_specs.append(CompileSpec(key, value_bytes))

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -98,6 +98,10 @@ def parse_compile_spec(compile_specs: List[CompileSpec]) -> Dict[str, Any]:
             )
         if spec.key in {"texture_limits_x", "texture_limits_y", "texture_limits_z"}:
             options[spec.key] = int.from_bytes(spec.value, byteorder="little")
+        
+        if spec.key == "skip_tag_memory_metadata":
+            options[spec.key] = bool.from_bytes(spec.value, byteorder="little")
+
         # Unhandled options are ignored
 
     return options

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -98,7 +98,7 @@ def parse_compile_spec(compile_specs: List[CompileSpec]) -> Dict[str, Any]:
             )
         if spec.key in {"texture_limits_x", "texture_limits_y", "texture_limits_z"}:
             options[spec.key] = int.from_bytes(spec.value, byteorder="little")
-        
+
         if spec.key == "skip_tag_memory_metadata":
             options[spec.key] = bool.from_bytes(spec.value, byteorder="little")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #6712

As title. Currently, the compile option to skip memory metadata tagging is not being passed correctly to `vulkan_preprocess`.

Differential Revision: [D65600049](https://our.internmc.facebook.com/intern/diff/D65600049/)