### PR TITLE
Qualcomm AI Engine Direct - Optimize QNN embedding op for llama

### DIFF
--- a/examples/models/llama/runner/runner.cpp
+++ b/examples/models/llama/runner/runner.cpp
@@ -34,6 +34,7 @@ static constexpr auto kMaxSeqLen = "get_max_seq_len";
 static constexpr auto kVocabSize = "get_vocab_size";
 static constexpr auto kUseKVCache = "use_kv_cache";
 static constexpr auto kUseSDPAWithKVCache = "use_sdpa_with_kv_cache";
+static constexpr auto kUseInt32Token = "use_int32_token";
 } // namespace
 
 Runner::Runner(
@@ -51,6 +52,7 @@ Runner::Runner(
           {kMaxSeqLen, 128},
           {kUseKVCache, true},
           {kUseSDPAWithKVCache, false},
+          {kUseInt32Token, true},
       }) {
   ET_LOG(
       Info,
@@ -127,12 +129,14 @@ Error Runner::load() {
       temperature_);
   text_prefiller_ = std::make_unique<llm::TextPrefiller>(
       text_decoder_runner_.get(),
+      metadata_.at(kUseInt32Token),
       metadata_.at(kUseKVCache),
       metadata_.at(kEnableDynamicShape));
 
   text_token_generator_ = std::make_unique<llm::TextTokenGenerator>(
       tokenizer_.get(),
       text_decoder_runner_.get(),
+      metadata_.at(kUseInt32Token),
       metadata_.at(kUseKVCache),
       std::move(eos_ids),
       &stats_);

--- a/examples/models/llama/runner/runner.cpp
+++ b/examples/models/llama/runner/runner.cpp
@@ -129,17 +129,17 @@ Error Runner::load() {
       temperature_);
   text_prefiller_ = std::make_unique<llm::TextPrefiller>(
       text_decoder_runner_.get(),
-      metadata_.at(kUseInt32Token),
       metadata_.at(kUseKVCache),
-      metadata_.at(kEnableDynamicShape));
+      metadata_.at(kEnableDynamicShape),
+      metadata_.at(kUseInt32Token));
 
   text_token_generator_ = std::make_unique<llm::TextTokenGenerator>(
       tokenizer_.get(),
       text_decoder_runner_.get(),
-      metadata_.at(kUseInt32Token),
       metadata_.at(kUseKVCache),
       std::move(eos_ids),
-      &stats_);
+      &stats_,
+      metadata_.at(kUseInt32Token));
 
   return Error::Ok;
 }

--- a/extension/llm/runner/text_prefiller.cpp
+++ b/extension/llm/runner/text_prefiller.cpp
@@ -17,9 +17,9 @@ namespace llm {
 
 TextPrefiller::TextPrefiller(
     TextDecoderRunner* text_decoder_runner,
-    bool use_int32_token,
     bool use_kv_cache,
-    bool enable_parallel_prefill)
+    bool enable_parallel_prefill,
+    bool use_int32_token)
     : text_decoder_runner_(text_decoder_runner),
       use_int32_token_(use_int32_token),
       use_kv_cache_(use_kv_cache),

--- a/extension/llm/runner/text_prefiller.h
+++ b/extension/llm/runner/text_prefiller.h
@@ -24,6 +24,7 @@ class ET_EXPERIMENTAL TextPrefiller {
  public:
   TextPrefiller(
       TextDecoderRunner* text_decoder_runner,
+      bool use_int32_token,
       bool use_kv_cache_,
       bool enable_parallel_prefill);
   /**
@@ -40,6 +41,7 @@ class ET_EXPERIMENTAL TextPrefiller {
 
  private:
   TextDecoderRunner* text_decoder_runner_;
+  bool use_int32_token_;
   bool use_kv_cache_;
   bool enable_parallel_prefill_;
 };

--- a/extension/llm/runner/text_prefiller.h
+++ b/extension/llm/runner/text_prefiller.h
@@ -24,9 +24,9 @@ class ET_EXPERIMENTAL TextPrefiller {
  public:
   TextPrefiller(
       TextDecoderRunner* text_decoder_runner,
-      bool use_int32_token,
       bool use_kv_cache_,
-      bool enable_parallel_prefill);
+      bool enable_parallel_prefill,
+      bool use_int32_token = false);
   /**
    * Prefill an LLM Module with the given text input.
    * @param prompt_tokens The text prompt tokens to the LLM Module. Encoded by

--- a/extension/llm/runner/text_token_generator.h
+++ b/extension/llm/runner/text_token_generator.h
@@ -23,10 +23,10 @@ class ET_EXPERIMENTAL TextTokenGenerator {
   TextTokenGenerator(
       Tokenizer* tokenizer,
       TextDecoderRunner* text_decoder_runner,
-      bool use_int32_token,
       bool use_kv_cache,
       std::unique_ptr<std::unordered_set<uint64_t>>&& eos_ids,
-      Stats* stats)
+      Stats* stats,
+      bool use_int32_token = false)
       : tokenizer_(tokenizer),
         text_decoder_runner_(text_decoder_runner),
         eos_ids_(std::move(eos_ids)),


### PR DESCRIPTION
summary:
- Change the dtype of the token from int64 to in32 since Int32 is Qnn HTP friendly. It will allow the embedding op to run into backend optimizations to significantly speed up qnn embedding operations.

Test the PR for llama 3.2 1B instruct with seq_len=512 on SM8650
<img width="844" alt="image" src="https://github.com/user-attachments/assets/1b9ff3db-0160-4f10-b089-38c2c9efb9e7">
Test the mainline
<img width="625" alt="image" src="https://github.com/user-attachments/assets/c835c096-070b-4234-9bca-70864a469656">
