### PR TITLE
Add platform-specific configurations for iOS and macOS ARM64 to prevent AVX code compilation on x64 macOS

### DIFF
--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -206,6 +206,8 @@ function(extract_sources sources_file)
     if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
       if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
         set(target_platforms_arg "--target-platforms=shim//:macos-arm64")
+      elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        set(target_platforms_arg "--target-platforms=shim//:macos-x86_64")
       endif()
     endif()
 

--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -196,6 +196,19 @@ function(extract_sources sources_file)
         message(FATAL_ERROR "Unsupported ANDROID_ABI setting ${ANDROID_ABI}. Please add it here!")
       endif()
     endif()
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+      if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+        set(target_platforms_arg "--target-platforms=shim//:ios-arm64")
+      endif()
+    endif()
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+      if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+        set(target_platforms_arg "--target-platforms=shim//:macos-arm64")
+      endif()
+    endif()
+
     execute_process(
       COMMAND
         ${PYTHON_EXECUTABLE} ${executorch_root}/build/extract_sources.py

--- a/shim/BUCK
+++ b/shim/BUCK
@@ -90,3 +90,11 @@ execution_platform(
     use_windows_path_separators = False,
     visibility = ["PUBLIC"],
 )
+
+execution_platform(
+    name = "macos-x86_64",
+    cpu_configuration = "prelude//cpu:x86_64",
+    os_configuration = "prelude//os:macos",
+    use_windows_path_separators = False,
+    visibility = ["PUBLIC"],
+)

--- a/shim/BUCK
+++ b/shim/BUCK
@@ -74,3 +74,19 @@ execution_platform(
     use_windows_path_separators = host_info().os.is_windows,
     visibility = ["PUBLIC"],
 )
+
+execution_platform(
+    name = "ios-arm64",
+    cpu_configuration = "prelude//cpu:arm64",
+    os_configuration = "prelude//os:ios",
+    use_windows_path_separators = False,
+    visibility = ["PUBLIC"],
+)
+
+execution_platform(
+    name = "macos-arm64",
+    cpu_configuration = "prelude//cpu:arm64",
+    os_configuration = "prelude//os:macos",
+    use_windows_path_separators = False,
+    visibility = ["PUBLIC"],
+)


### PR DESCRIPTION

- Updated `Utils.cmake` to set appropriate `target_platforms_arg` for iOS and macOS when building on ARM64.
- Added execution platforms `ios-arm64` and `macos-arm64` in `shim/BUCK` for specifying CPU and OS configurations.
- fix #6691


