### PR TITLE
Extend torch_to_executorch_scalar_type for uint16

### DIFF
--- a/extension/aten_util/aten_bridge.cpp
+++ b/extension/aten_util/aten_bridge.cpp
@@ -71,6 +71,8 @@ torch::executor::ScalarType torch_to_executorch_scalar_type(
       return torch::executor::ScalarType::Char;
     case c10::ScalarType::Short:
       return torch::executor::ScalarType::Short;
+    case c10::ScalarType::UInt16:
+      return torch::executor::ScalarType::Bits16;
     case c10::ScalarType::Half:
       return torch::executor::ScalarType::Half;
     case c10::ScalarType::BFloat16:
@@ -103,6 +105,8 @@ c10::ScalarType executorch_to_torch_scalar_type(
       return c10::ScalarType::Char;
     case torch::executor::ScalarType::Short:
       return c10::ScalarType::Short;
+    case torch::executor::ScalarType::Bits16:
+      return c10::ScalarType::UInt16;
     case torch::executor::ScalarType::Half:
       return c10::ScalarType::Half;
     case torch::executor::ScalarType::BFloat16:


### PR DESCRIPTION
Summary:
The aten_bridge didn't have a way to map a torch.Tensor of uint16 into
the Executorch Bits16 type.
Added this for both round-trips. This is likely only relevant for users of
the python bindings to Executorch.

Differential Revision: D65681731


