### PR TITLE
Fix missing header `<algorithm>` in tensor_ptr.h

### DIFF
--- a/extension/tensor/tensor_ptr.h
+++ b/extension/tensor/tensor_ptr.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
This commit import header <algorithm> explictly in extension/tensor/tensor_ptr.h, which uses `std::transfrom` defined in the header.

Some recent compilers emits error (I checked gcc 14.1.0 / clang 18.1.6):
```
.../executorch/extension/tensor/tensor_ptr.h:114:12: error: no member named
'transform' in namespace 'std'
```
