### PR TITLE
[ET-VK] Replace `uint16_t` with `int` for swiftshader

### DIFF
--- a/backends/vulkan/runtime/gen_vulkan_spv.py
+++ b/backends/vulkan/runtime/gen_vulkan_spv.py
@@ -721,6 +721,7 @@ class SPVGenerator:
             return input_text
 
         input_text = input_text.replace("u16vec", "ivec")
+        input_text = input_text.replace("uint16_t", "int")
         return input_text
 
     def generateSPV(self, output_dir: str) -> Dict[str, str]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #6781

As title. This is a follow up from https://github.com/pytorch/executorch/pull/6675. Replace `uint16_t` with `int` as well as 16 bit vectorized types.

Differential Revision: [D65824204](https://our.internmc.facebook.com/intern/diff/D65824204/)