### PR TITLE
remove extra torchao commit pin

### DIFF
--- a/.ci/docker/ci_commit_pins/torchao.txt
+++ b/.ci/docker/ci_commit_pins/torchao.txt
@@ -1,1 +1,0 @@
-0916b5b29b092afcbf2b898caae49abe80662bac


### PR DESCRIPTION
In https://github.com/pytorch/executorch/pull/6195/, we removed references to the torchao commit pin and used a submodule instead.  This removes the commit pin from the repo.
