### PR TITLE
Add a test to ensure that PT built from the pinned commit is used

### DIFF
--- a/.ci/scripts/setup-linux.sh
+++ b/.ci/scripts/setup-linux.sh
@@ -23,3 +23,4 @@ fi
 # of nightly. This allows CI to test against latest commits from PyTorch
 install_executorch "use-pt-pinned-commit"
 build_executorch_runner "${BUILD_TOOL}"
+do_not_use_nightly_on_ci

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -124,7 +124,7 @@ download_stories_model_artifacts() {
 do_not_use_nightly_on_ci() {
   # An assert to make sure that we are not using PyTorch nightly on CI to prevent
   # regression as documented in https://github.com/pytorch/executorch/pull/6564
-  TORCH_VERSION=$(pip freeze | grep -w torch= | awk -F '==' {'print $2'} | tr -d '\n')
+  TORCH_VERSION=$(pip list | grep -w 'torch ' | awk -F ' ' {'print $2'} | tr -d '\n')
 
   pushd .ci/docker || return
   EXPECTED_TORCH_VERSION=$(cat ci_commit_pins/pytorch.txt)

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -126,15 +126,13 @@ do_not_use_nightly_on_ci() {
   # regression as documented in https://github.com/pytorch/executorch/pull/6564
   TORCH_VERSION=$(pip list | grep -w 'torch ' | awk -F ' ' {'print $2'} | tr -d '\n')
 
-  pushd .ci/docker || return
-  EXPECTED_TORCH_VERSION=$(cat ci_commit_pins/pytorch.txt)
-  popd || return
-
   # The version of PyTorch building from source looks like 2.6.0a0+gitc8a648d that
   # includes the commit while nightly (2.6.0.dev20241019+cpu) or release (2.6.0)
-  # won't have that
-  if [[ "${TORCH_VERSION}" != *"+git${EXPECTED_TORCH_VERSION:0:7}"* ]]; then
-    echo "Unexpected torch version. Expected ${EXPECTED_TORCH_VERSION:0:7} from .ci/docker/ci_commit_pins/pytorch.txt, got ${TORCH_VERSION}"
+  # won't have that. Note that we couldn't check for the exact commit from the pin
+  # ci_commit_pins/pytorch.txt here because the value will be different when running
+  # this on PyTorch CI
+  if [[ "${TORCH_VERSION}" != *"+git"* ]]; then
+    echo "Unexpected torch version. Expected binary built from source, got ${TORCH_VERSION}"
     exit 1
   fi
 }

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -113,10 +113,28 @@ cmake_install_executorch_lib() {
 }
 
 download_stories_model_artifacts() {
-    # Download stories110M.pt and tokenizer from Github
+  # Download stories110M.pt and tokenizer from Github
   curl -Ls "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories110M.pt" --output stories110M.pt
   curl -Ls "https://raw.githubusercontent.com/karpathy/llama2.c/master/tokenizer.model" --output tokenizer.model
   # Create params.json file
   touch params.json
   echo '{"dim": 768, "multiple_of": 32, "n_heads": 12, "n_layers": 12, "norm_eps": 1e-05, "vocab_size": 32000}' > params.json
+}
+
+do_not_use_nightly_on_ci() {
+  # An assert to make sure that we are not using PyTorch nightly on CI to prevent
+  # regression as documented in https://github.com/pytorch/executorch/pull/6564
+  TORCH_VERSION=$(pip freeze | grep -w torch= | awk -F '==' {'print $2'} | tr -d '\n')
+
+  pushd .ci/docker || return
+  EXPECTED_TORCH_VERSION=$(cat ci_commit_pins/pytorch.txt)
+  popd || return
+
+  # The version of PyTorch building from source looks like 2.6.0a0+gitc8a648d that
+  # includes the commit while nightly (2.6.0.dev20241019+cpu) or release (2.6.0)
+  # won't have that
+  if [[ "${TORCH_VERSION}" != *"+git${EXPECTED_TORCH_VERSION:0:7}"* ]]; then
+    echo "Unexpected torch version. Expected ${EXPECTED_TORCH_VERSION:0:7} from .ci/docker/ci_commit_pins/pytorch.txt, got ${TORCH_VERSION}"
+    exit 1
+  fi
 }


### PR DESCRIPTION
This is to prevent regression like https://github.com/pytorch/executorch/pull/6564.  If nightly is accidentally used on CI instead of PT built from the pinned commit at `ci_commit_pins/pytorch.txt`.  The check will fail.

Because `setup-linux` script is used on both ET and PT CI, the latter will also have this check in place after the next ET pin commit update.