### PR TITLE
Remove .ci/docker trigger on Apple workflows

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -7,7 +7,6 @@ on:
       - release/*
   pull_request:
     paths:
-      - .ci/docker/**
       - .ci/scripts/setup-ios.sh
       - .github/workflows/apple.yml
       - install_requirements.sh


### PR DESCRIPTION
Reported by @metascroy on https://github.com/pytorch/executorch/pull/6784, we shouldn't need to run Apple worklows when `.ci/docker` folder is updated because there is no docker at all on MacOS.