### PR TITLE
Temporarily ignore flaky mha test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -39,6 +39,7 @@ addopts =
     backends/xnnpack/test
     # extension/
     extension/llm/modules/test
+    --ignore=extension/llm/modules/test/test_mha.py
     extension/pybindings/test
     # Runtime
     runtime


### PR DESCRIPTION
### Summary
Temporarily remove [flaky mha test](https://hud.pytorch.org/failure?name=pull%20%2F%20unittest%20%2F%20linux%20%2F%20linux-job&jobName=undefined&failureCaptures=%5B%22extension%2Fllm%2Fmodules%2Ftest%2Ftest_mha.py%3A%3AAttentionTest%3A%3Atest_attention_executorch%22%5D).

### Test plan
N/A
