### PR TITLE
Pin TorchTune

### DIFF
--- a/examples/models/llama3_2_vision/install_requirements.sh
+++ b/examples/models/llama3_2_vision/install_requirements.sh
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-NIGHTLY_VERSION="dev20241106"
+NIGHTLY_VERSION="dev20241112"
 
 # Install torchtune nightly for model definitions.
 pip install --pre torchtune==0.4.0.${NIGHTLY_VERSION} --extra-index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir

--- a/examples/models/llama3_2_vision/install_requirements.sh
+++ b/examples/models/llama3_2_vision/install_requirements.sh
@@ -5,8 +5,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+NIGHTLY_VERSION="dev20241106"
+
 # Install torchtune nightly for model definitions.
-pip install --pre torchtune --extra-index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir
+pip install --pre torchtune==0.4.0.${NIGHTLY_VERSION} --extra-index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir
 
 # Install torchao.
 pip install "$(dirname "$0")/../../../third-party/ao"


### PR DESCRIPTION
### Summary
Freeze TorchTune dependency since files like changes to files like [attention.py](https://github.com/pytorch/torchtune/blob/main/torchtune/modules/attention.py) can break tests like [this](https://github.com/pytorch/executorch/blob/main/extension/llm/modules/test/test_mha.py) and modules like [this](https://github.com/pytorch/executorch/blob/main/extension/llm/modules/mha.py).

### Test plan
Installed locally
