### PR TITLE
Fix flaky ET attention test

### DIFF
--- a/extension/llm/modules/test/test_attention.py
+++ b/extension/llm/modules/test/test_attention.py
@@ -95,11 +95,7 @@ class AttentionTest(unittest.TestCase):
         et_res = self.et_mha(self.x, self.x)  # Self attention.
         tt_res = self.tt_mha(self.x, self.x)  # Self attention.
 
-        assert_close(
-            et_res,
-            tt_res,
-            msg=f"TorchTune output is not close to ET output.\n\nTorchTune: {tt_res}\nET output: {et_res}",
-        )
+        assert_close(et_res, tt_res)
 
         # test with kv cache
         self.et_mha.setup_cache(1, dtype=torch.float32, max_seq_len=20)
@@ -130,11 +126,7 @@ class AttentionTest(unittest.TestCase):
             self.x, self.x, input_pos=next_input_pos
         )  # Self attention with input pos.
 
-        assert_close(
-            et_res,
-            tt_res,
-            msg=f"TorchTune output is not close to ET output.\n\nTorchTune: {tt_res}\nET output: {et_res}",
-        )
+        assert_close(et_res, tt_res)
 
     def test_attention_export(self):
         # Self attention.
@@ -147,11 +139,7 @@ class AttentionTest(unittest.TestCase):
         et_res = et_mha_ep.module()(self.x, self.x, input_pos=self.input_pos)
         tt_res = self.tt_mha(self.x, self.x, input_pos=self.input_pos)
 
-        assert_close(
-            et_res,
-            tt_res,
-            msg=f"TorchTune output is not close to ET output.\n\nTorchTune: {tt_res}\nET output: {et_res}",
-        )
+        assert_close(et_res, tt_res)
 
         # TODO: KV cache.
 
@@ -177,10 +165,6 @@ class AttentionTest(unittest.TestCase):
         et_res = method.execute((self.x, self.x, self.input_pos))
         tt_res = self.tt_mha(self.x, self.x, input_pos=self.input_pos)
 
-        assert_close(
-            et_res[0],
-            tt_res,
-            msg=f"TorchTune output is not close to ET output.\n\nTorchTune: {tt_res}\nET output: {et_res[0]}",
-        )
+        assert_close(et_res[0], tt_res)
 
         # TODO: KV cache.

--- a/extension/llm/modules/test/test_attention.py
+++ b/extension/llm/modules/test/test_attention.py
@@ -13,6 +13,7 @@ from executorch.extension.llm.modules.attention import (
     MultiHeadAttention as ETMultiHeadAttention,
 )
 from executorch.runtime import Runtime
+from torch.testing import assert_close
 from torchtune.models.llama3_1._position_embeddings import Llama3ScaledRoPE
 from torchtune.modules.attention import MultiHeadAttention as TTMultiHeadAttention
 
@@ -94,8 +95,9 @@ class AttentionTest(unittest.TestCase):
         et_res = self.et_mha(self.x, self.x)  # Self attention.
         tt_res = self.tt_mha(self.x, self.x)  # Self attention.
 
-        self.assertTrue(
-            torch.allclose(et_res, tt_res),
+        assert_close(
+            et_res,
+            tt_res,
             msg=f"TorchTune output is not close to ET output.\n\nTorchTune: {tt_res}\nET output: {et_res}",
         )
 
@@ -127,7 +129,12 @@ class AttentionTest(unittest.TestCase):
         tt_res = self.tt_mha(
             self.x, self.x, input_pos=next_input_pos
         )  # Self attention with input pos.
-        self.assertTrue(torch.allclose(et_res, tt_res))
+
+        assert_close(
+            et_res,
+            tt_res,
+            msg=f"TorchTune output is not close to ET output.\n\nTorchTune: {tt_res}\nET output: {et_res}",
+        )
 
     def test_attention_export(self):
         # Self attention.
@@ -139,8 +146,10 @@ class AttentionTest(unittest.TestCase):
         )
         et_res = et_mha_ep.module()(self.x, self.x, input_pos=self.input_pos)
         tt_res = self.tt_mha(self.x, self.x, input_pos=self.input_pos)
-        self.assertTrue(
-            torch.allclose(et_res, tt_res),
+
+        assert_close(
+            et_res,
+            tt_res,
             msg=f"TorchTune output is not close to ET output.\n\nTorchTune: {tt_res}\nET output: {et_res}",
         )
 
@@ -168,8 +177,9 @@ class AttentionTest(unittest.TestCase):
         et_res = method.execute((self.x, self.x, self.input_pos))
         tt_res = self.tt_mha(self.x, self.x, input_pos=self.input_pos)
 
-        self.assertTrue(
-            torch.allclose(et_res[0], tt_res, atol=1e-05),
+        assert_close(
+            et_res[0],
+            tt_res,
             msg=f"TorchTune output is not close to ET output.\n\nTorchTune: {tt_res}\nET output: {et_res[0]}",
         )
 

--- a/extension/llm/modules/test/test_attention.py
+++ b/extension/llm/modules/test/test_attention.py
@@ -94,7 +94,10 @@ class AttentionTest(unittest.TestCase):
         et_res = self.et_mha(self.x, self.x)  # Self attention.
         tt_res = self.tt_mha(self.x, self.x)  # Self attention.
 
-        self.assertTrue(torch.allclose(et_res, tt_res))
+        self.assertTrue(
+            torch.allclose(et_res, tt_res),
+            msg=f"TorchTune output is not close to ET output.\n\nTorchTune: {tt_res}\nET output: {et_res}",
+        )
 
         # test with kv cache
         self.et_mha.setup_cache(1, dtype=torch.float32, max_seq_len=20)
@@ -136,7 +139,10 @@ class AttentionTest(unittest.TestCase):
         )
         et_res = et_mha_ep.module()(self.x, self.x, input_pos=self.input_pos)
         tt_res = self.tt_mha(self.x, self.x, input_pos=self.input_pos)
-        self.assertTrue(torch.allclose(et_res, tt_res))
+        self.assertTrue(
+            torch.allclose(et_res, tt_res),
+            msg=f"TorchTune output is not close to ET output.\n\nTorchTune: {tt_res}\nET output: {et_res}",
+        )
 
         # TODO: KV cache.
 
@@ -162,6 +168,9 @@ class AttentionTest(unittest.TestCase):
         et_res = method.execute((self.x, self.x, self.input_pos))
         tt_res = self.tt_mha(self.x, self.x, input_pos=self.input_pos)
 
-        self.assertTrue(torch.allclose(et_res[0], tt_res, atol=1e-06))
+        self.assertTrue(
+            torch.allclose(et_res[0], tt_res, atol=1e-05),
+            msg=f"TorchTune output is not close to ET output.\n\nTorchTune: {tt_res}\nET output: {et_res[0]}",
+        )
 
         # TODO: KV cache.

--- a/pytest.ini
+++ b/pytest.ini
@@ -39,7 +39,6 @@ addopts =
     backends/xnnpack/test
     # extension/
     extension/llm/modules/test
-    --ignore=extension/llm/modules/test/test_mha.py
     extension/pybindings/test
     # Runtime
     runtime


### PR DESCRIPTION
### Summary
Torch's manual seed is environment-based, ~~loosen the tol for torch.allclose~~ use assert_close instead which sets an appropriate atol and rtol based on the dtype, since the previous tol was too strict.

Fixes [flaky mha test](https://hud.pytorch.org/failure?name=pull%20%2F%20unittest%20%2F%20linux%20%2F%20linux-job&jobName=undefined&failureCaptures=%5B%22extension%2Fllm%2Fmodules%2Ftest%2Ftest_mha.py%3A%3AAttentionTest%3A%3Atest_attention_executorch%22%5D) and reverts https://github.com/pytorch/executorch/pull/6790.

### Test plan
Confirmed and reproduced locally by altering the manual seed until there was an issue. Modified unit test to pass locally.
