### PR TITLE
Fix imports to use torchao public api

### DIFF
--- a/backends/vulkan/_passes/int4_weight_only_quantizer.py
+++ b/backends/vulkan/_passes/int4_weight_only_quantizer.py
@@ -1,3 +1,4 @@
+# pyre-unsafe
 import logging
 from typing import Any, Callable, Dict, Optional, Type
 
@@ -35,7 +36,7 @@ class VkWeightOnlyInt4Linear(torch.nn.Module):
         super().__init__()
         self.padding = not _check_linear_int4_k(in_features, groupsize, inner_k_tiles)
         if self.padding:
-            from torchao.quantization.utils import find_multiple
+            from torchao.utils import find_multiple
 
             self.origin_in_features = in_features
             in_features = find_multiple(in_features, (1024,))
@@ -203,7 +204,7 @@ class VkInt4WeightOnlyQuantizer(Quantizer):
                     if self.padding_allowed:
                         import torch.nn.functional as F
 
-                        from torchao.quantization.utils import find_multiple
+                        from torchao.utils import find_multiple
 
                         logging.warn(
                             f"warning: {fqn} is padded to satisfy in_features % 1024 == 0"

--- a/backends/xnnpack/test/ops/linear.py
+++ b/backends/xnnpack/test/ops/linear.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+# pyre-unsafe
 
 import unittest
 
@@ -30,8 +31,8 @@ try:
     from torchao.quantization.quant_api import (
         int8_dynamic_activation_int4_weight,
         quantize_,
-        unwrap_tensor_subclass,
     )
+    from torchao.utils import unwrap_tensor_subclass
 
     torchao_installed = True
 except:


### PR DESCRIPTION
Summary: Fixing imports to use torchao.utils API, instead of a nested call from torchao.quantization API.

Differential Revision: D65843742


