### PR TITLE
Improve ET_ASSERT_UNREACHABLE_MSG to use formatting

### DIFF
--- a/extension/aten_util/aten_bridge.cpp
+++ b/extension/aten_util/aten_bridge.cpp
@@ -90,7 +90,9 @@ torch::executor::ScalarType torch_to_executorch_scalar_type(
     case c10::ScalarType::QUInt8:
       return torch::executor::ScalarType::QUInt8;
     default:
-      ET_ASSERT_UNREACHABLE();
+      ET_ASSERT_UNREACHABLE_MSG(
+          "Unrecognized dtype: %hhd",
+          static_cast<int8_t>(c10::typeMetaToScalarType(type)));
   }
 }
 
@@ -122,7 +124,8 @@ c10::ScalarType executorch_to_torch_scalar_type(
     case torch::executor::ScalarType::QUInt8:
       return c10::ScalarType::QUInt8;
     default:
-      ET_ASSERT_UNREACHABLE();
+      ET_ASSERT_UNREACHABLE_MSG(
+          "Unrecognized dtype: %hhd", static_cast<int8_t>(type));
   }
 }
 

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -745,8 +745,7 @@ struct PyModule final {
       } else if (py::isinstance<py::int_>(python_input)) {
         cpp_inputs.push_back(EValue(py::cast<int64_t>(python_input)));
       } else {
-        // Unsupported pytype
-        ET_ASSERT_UNREACHABLE_MSG(type_str.c_str());
+        ET_ASSERT_UNREACHABLE_MSG("Unsupported pytype: %s", type_str.c_str());
       }
     }
 

--- a/runtime/platform/assert.h
+++ b/runtime/platform/assert.h
@@ -114,9 +114,11 @@
  *
  * @param[in] _message Message on how to avoid this assertion error.
  */
-#define ET_ASSERT_UNREACHABLE_MSG(_message)                            \
-  ({                                                                   \
-    ET_CHECK_MSG(                                                      \
-        false, "Execution should not reach this point. %s", _message); \
-    ET_UNREACHABLE();                                                  \
-  })
+#define ET_ASSERT_UNREACHABLE_MSG(_format, ...)            \
+  do {                                                     \
+    ET_CHECK_MSG(                                          \
+        false,                                             \
+        "Execution should not reach this point. " _format, \
+        ##__VA_ARGS__);                                    \
+    ET_UNREACHABLE();                                      \
+  } while (0)


### PR DESCRIPTION
Summary:
The macro `ET_ASSERT_UNREACHABLE_MSG` didn't allow for format
strings unlike the other `ET_CHECK` macros.
Add this capability and fix any users of it.

Reviewed By: dbort

Differential Revision: D65693396


