### PR TITLE
Arm Backend: Place pte file/data in DDR area

### DIFF
--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -63,6 +63,9 @@ endif()
 if(TARGET_BOARD STREQUAL "corstone-300")
   add_subdirectory(${ETHOS_SDK_PATH}/core_platform/targets/corstone-300 target)
   target_compile_definitions(ethosu_target_common INTERFACE
+      # ETHOSU_MODEL=0 place pte file/data in SRAM area
+      # ETHOSU_MODEL=1 place pte file/data in DDR area
+      ETHOSU_MODEL=1
       # Configure NPU architecture timing adapters
       # Ethos_U55_High_End_Embedded
       # This is just example numbers and you should make this match your hardware
@@ -98,6 +101,9 @@ if(TARGET_BOARD STREQUAL "corstone-300")
 elseif(TARGET_BOARD STREQUAL "corstone-320")
   add_subdirectory(${ETHOS_SDK_PATH}/core_platform/targets/corstone-320 target)
   target_compile_definitions(ethosu_target_common INTERFACE
+      # ETHOSU_MODEL=0 place pte file/data in SRAM area
+      # ETHOSU_MODEL=1 place pte file/data in DDR area
+      ETHOSU_MODEL=1
       # Configure NPU architecture timing adapters
       # Ethos_U85_SYS_DRAM_Mid
       # This is just example numbers and you should make this match your hardware


### PR DESCRIPTION
As some bigger model don't fit in the SRAM area in the Corstone 3x0 FVP setup lets default to useing the DDR area.