### PR TITLE
Remove unused-variable in ods3/services/storage/gorilla/lib3/gorilla/micro_shard/GmscQuery.h

### DIFF
--- a/runtime/platform/assert.h
+++ b/runtime/platform/assert.h
@@ -74,6 +74,7 @@
  * @param[in] _cond Condition asserted as true.
  */
 #define ET_DCHECK(_cond) ((void)0)
+#define ET_DEBUG_ONLY [[maybe_unused]]
 
 #else // NDEBUG
 
@@ -95,6 +96,7 @@
  * @param[in] _cond Condition asserted as true.
  */
 #define ET_DCHECK(_cond) ET_CHECK(_cond)
+#define ET_DEBUG_ONLY
 
 #endif // NDEBUG
 


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D65859992


