### PR TITLE
Fix broken trunk test_model.sh

### DIFF
--- a/.ci/scripts/test_model.sh
+++ b/.ci/scripts/test_model.sh
@@ -77,7 +77,7 @@ test_model() {
     # Install requirements for export_llama
     bash examples/models/llama/install_requirements.sh
     # Test export_llama script: python3 -m examples.models.llama.export_llama
-    "${PYTHON_EXECUTABLE}" -m examples.models.llama.export_llama -c examples/models/llama/params/demo_rand_params.pth -p examples/models/llama/params/demo_config.json
+    "${PYTHON_EXECUTABLE}" -m examples.models.llama.export_llama --model "${MODEL_NAME}" -c examples/models/llama/params/demo_rand_params.pth -p examples/models/llama/params/demo_config.json
     run_portable_executor_runner
     rm "./${MODEL_NAME}.pte"
   fi


### PR DESCRIPTION
### Summary
Fixes [pull / test-models-linux (cmake, llama2, portable, linux.2xlarge, 90) / linux-job](https://github.com/pytorch/executorch/actions/runs/11810302726/job/32902052832) (which didn't run on the original offending PR pre-merge and only ran post-merge) and [trunk / test-models-macos (cmake, llama2, portable, macos-m1-stable, 90) / macos-job](https://github.com/pytorch/executorch/actions/runs/11810302716/job/32902052792).

### Test Plan
`ciflow/trunk` to test the broken test on gh actions, if this passes then the pull test should also be fixed.
