### PR TITLE
Fix arm dep for jarvis test

### DIFF
--- a/backends/arm/TARGETS
+++ b/backends/arm/TARGETS
@@ -26,9 +26,24 @@ python_library(
         "fbsource//third-party/serialization_lib/python/serializer:serializer",
         "fbsource//third-party/serialization_lib/python/tosa:tosa",
         ":arm_vela",
+        ":process_node",
         "//executorch/backends/arm/operators:lib",
         "//executorch/backends/arm/operators:node_visitor",
         "//executorch/backends/arm/_passes:passes",
+    ],
+)
+
+python_library(
+    name = "process_node",
+    srcs = ["process_node.py"],
+    typing = True,
+    deps = [
+        "fbsource//third-party/serialization_lib/python/tosa:tosa",
+        "//executorch/backends/arm/operators:node_visitor",
+        "//executorch/backends/arm:tosa_mapping",
+        "//executorch/backends/arm:tosa_quant_utils",
+        "//executorch/backends/arm:tosa_utils",
+        "//executorch/exir:lib",
     ],
 )
 


### PR DESCRIPTION
Summary:
D65876547, https://github.com/pytorch/executorch/pull/6810

broke internal tests. This diff adds the missing buck dependencies.

Differential Revision: D65901748
