### PR TITLE
[pybind] Do not set output data pointer if the output is memory planned

### DIFF
--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -151,8 +151,13 @@ void setup_output_storage(
       // and memory planned outputs.
       continue;
     }
-    Error output_status = method.set_output_data_ptr(
+    // Assuming non-Tensor output `is_memory_planned` is false
+    auto output_meta = method.method_meta().output_tensor_meta(i);
+    Error output_status = Error::Ok;
+    if (!output_meta->is_memory_planned()) {
+      output_status = method.set_output_data_ptr(
         output_storages[i].data(), output_storages[i].size(), i);
+    }
     // We already should be skipping non-tensor outputs, and memory planned
     // outputs so any error is real.
     THROW_IF_ERROR(


### PR DESCRIPTION
### Summary

This is the same logic in method.cpp:set_output_data_ptr() but add the check in pybindings.cpp to avoid excessive logging and failure.
```
[method.cpp:941] Output 0 is memory planned, or is a constant. Cannot override         the existing data pointer.
```
### Test plan

Pending
