### PR TITLE
Arm backend: Set default allocation pool to 20MB

### DIFF
--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -85,7 +85,7 @@ using executorch::runtime::TensorInfo;
  * availible memory.
  */
 #ifndef ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE
-#define ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE (60 * 1024 * 1024)
+#define ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE (20 * 1024 * 1024)
 #endif
 const size_t method_allocation_pool_size =
     ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE;


### PR DESCRIPTION
This is making memory fit on more targets. The intention is for this is to be easier to change from the run.sh flow and then this value will probably be bumped back to the bigger value out of the box again to make large model testing more convenient.
