### PR TITLE
Install requirements for llama vision

### DIFF
--- a/.ci/scripts/test_model.sh
+++ b/.ci/scripts/test_model.sh
@@ -87,6 +87,10 @@ test_model() {
     bash examples/models/llava/install_requirements.sh
     STRICT="--no-strict"
   fi
+  if [[ "$MODEL_NAME" == "llama3_2_vision_encoder" ]]; then
+    # Install requirements for llama vision
+    bash examples/models/llama3_2_vision/install_requirements.sh
+  fi
   # python3 -m examples.portable.scripts.export --model_name="llama2" should works too
   "${PYTHON_EXECUTABLE}" -m examples.portable.scripts.export --model_name="${MODEL_NAME}" "${STRICT}"
   run_portable_executor_runner

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -72,10 +72,6 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         MODEL_NAME=${{ matrix.model }}
-        # Install requirements for llama vision
-        if [[ "$MODEL_NAME" == "llama3_2_vision_encoder" ]]; then
-          bash examples/models/llama3_2_vision/install_requirements.sh
-        fi
         BUILD_TOOL=${{ matrix.build-tool }}
         BACKEND=${{ matrix.backend }}
         DEMO_BACKEND_DELEGATION=${{ matrix.demo_backend_delegation }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -58,10 +58,6 @@ jobs:
         bash .ci/scripts/setup-conda.sh
         # Setup MacOS dependencies as there is no Docker support on MacOS atm
         PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/setup-macos.sh "${BUILD_TOOL}"
-        # Install requirements for llama vision
-        if [[ "$MODEL_NAME" == "llama3_2_vision_encoder" ]]; then
-          ${CONDA_RUN} bash examples/models/llama3_2_vision/install_requirements.sh
-        fi
         # Build and test executorch
         PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/test_model.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${BACKEND}" "${DEMO_BACKEND_DELEGATION}"
 


### PR DESCRIPTION
Enabling llama vision test in https://github.com/pytorch/executorch/pull/6842 broke periodic test because torchtune deps not installed. 
test:
[test-models-linux (cmake, llama3_2_vision_encoder, portable, linux.12xlarge, 90) / linux-job](https://github.com/pytorch/executorch/actions/runs/11833732103/job/32994359384#logs)