### PR TITLE
remove codegen-nosub from q_8w

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/q_8w_linear.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q_8w_linear.glsl
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// codegen-nosub
-
 #version 450 core
 
 #define PRECISION ${PRECISION}


### PR DESCRIPTION
Summary: After https://github.com/pytorch/executorch/pull/6781 the 8-bit linear shader can run on swiftshader.

Differential Revision: D65951046


