### PR TITLE
Bump runner memory for llama3_2 torchtune test_model

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -25,7 +25,7 @@ CUSTOM_RUNNERS = {
         "resnet50": "linux.12xlarge",
         "llava": "linux.12xlarge",
         "llama3_2_vision_encoder": "linux.12xlarge",
-        "llama3_2_text_decoder": "linux.12xlarge",
+        "llama3_2_text_decoder": "linux.24xlarge",
         # This one causes timeout on smaller runner, the root cause is unclear (T161064121)
         "dl3": "linux.12xlarge",
         "emformer_join": "linux.12xlarge",
@@ -88,7 +88,7 @@ def model_should_run_on_event(model: str, event: str) -> bool:
     We put higher priority and fast models to pull request and rest to push.
     """
     if event == "pull_request":
-        return model in ["mv3", "vit"]
+        return model in ["mv3", "vit", "llama_3_2_text_decoder"]
     elif event == "push":
         # These are super slow. Only run it periodically
         return model not in ["dl3", "edsr", "emformer_predict"]


### PR DESCRIPTION
### Summary
Bump memory and disk space for TorchTune llama3_2 text decoder, since the test may have previously been OOMing.

### Test plan
Ran the test locally with:
```
rm -rf cmake-out
cmake -DCMAKE_BUILD_TYPE=Debug -DEXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON -DPYTHON_EXECUTABLE=python -Bcmake-out .
cmake --build cmake-out -j4 --config Debug
./cmake-out/executor_runner --model_path ./llama3_2_text_decoder.pte
```

Which passes because my local machine is very powerful, now temporarily enabling this test on pull to see if passes on CI.

