### PR TITLE
Temporarily disable OOMing llama vision decoder test

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -25,7 +25,7 @@ CUSTOM_RUNNERS = {
         "resnet50": "linux.12xlarge",
         "llava": "linux.12xlarge",
         "llama3_2_vision_encoder": "linux.12xlarge",
-        "llama3_2_text_decoder": "linux.12xlarge",
+        # "llama3_2_text_decoder": "linux.12xlarge",  # TODO: re-enable test when Huy's change is in / model gets smaller.
         # This one causes timeout on smaller runner, the root cause is unclear (T161064121)
         "dl3": "linux.12xlarge",
         "emformer_join": "linux.12xlarge",

--- a/examples/models/__init__.py
+++ b/examples/models/__init__.py
@@ -19,7 +19,7 @@ MODEL_NAME_TO_MODEL = {
     "llama2": ("llama", "Llama2Model"),
     "llama": ("llama", "Llama2Model"),
     "llama3_2_vision_encoder": ("llama3_2_vision", "FlamingoVisionEncoderModel"),
-    "llama3_2_text_decoder": ("llama3_2_vision", "Llama3_2Decoder"),
+    # "llama3_2_text_decoder": ("llama3_2_vision", "Llama3_2Decoder"),
     "lstm": ("lstm", "LSTMModel"),
     "mobilebert": ("mobilebert", "MobileBertModelExample"),
     "mv2": ("mobilenet_v2", "MV2Model"),


### PR DESCRIPTION
### Summary
Test is either OOMing / running out of disk space, https://github.com/pytorch/test-infra/pull/5923#pullrequestreview-2439655838 when in will give us the runners necessary to run the test. The real problem is that the model is currently 60 GB+ of memory and 30 GB of disk space, I am currently working on reducing those numbers.

### Test plan
Locally and enabling ciflow/trunk on this pr
