### PR TITLE
Set weights_only=False in export_serialize.deserialize_torch_artifact

### DIFF
--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -327,7 +327,7 @@ def deserialize_torch_artifact(
         return {}
     buffer = io.BytesIO(serialized)
     buffer.seek(0)
-    artifact = torch.load(buffer)
+    artifact = torch.load(buffer, weights_only=False)
     assert isinstance(artifact, (tuple, dict))
     return artifact
 


### PR DESCRIPTION
To be consistent with [the file in pytorch/export where this file was copied from](https://github.com/pytorch/pytorch/blob/main/torch/_export/serde/serialize.py?fbclid=IwZXh0bgNhZW0CMTEAAR1aHdG_syGngXZkU-afQkN9YwnZlqyzuvLnPIn1EP9ggQYjucmlUWzFmHc_aem_6sOk267yBc_Mhe8k8FYSiA#L330-L331) out of an abundance of caution to make sure` weights_only` flip didn't break this line (although nothing fails in CI)

Some tests failed in pytorch CI with weights_only=True here as ScriptObjects were being loaded

cc @tarun292 