### PR TITLE
[llama-mm] Fix AOTI test for attention

### DIFF
--- a/extension/llm/modules/test/test_attention.py
+++ b/extension/llm/modules/test/test_attention.py
@@ -156,7 +156,9 @@ class AttentionTest(unittest.TestCase):
 
         assert_close(et_res, tt_res)
 
-    @unittest.skip(reason="TODO(T207740932): test is flaky")
+    @unittest.skipIf(
+        int(os.getenv("RUN_SKIPPED", 0)) < 1, reason="TODO(T207740932): test is flaky"
+    )
     def test_attention_aoti(self):
         # Self attention.
 
@@ -168,7 +170,10 @@ class AttentionTest(unittest.TestCase):
                 self.et_mha,
                 args=(self.x, self.x),
                 kwargs={"input_pos": self.input_pos},
-                options={"aot_inductor.package": True},
+                options={
+                    "aot_inductor.package": True,
+                    "reorder_for_peak_memory": False,
+                },
                 dynamic_shapes=self.dynamic_shapes,
             )
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
Summary: Disable `reorder_for_peak_memory` because it moves `_local_dense_scalar` codegen to after subgraphs.

Test Plan: As titled.

```
RUN_SKIPPED=1 pytorch -m unittest
extension.llm.modules.test.test_attention -k test_attention_aoti
```

Need to address the flaky test later.

Reviewers:

Subscribers:

Tasks:

Tags:

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
