### PR TITLE
[EE/BE] Adding legacy partitioner tests

### DIFF
--- a/backends/xnnpack/test/ops/avgpool2d.py
+++ b/backends/xnnpack/test/ops/avgpool2d.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/bilinear2d.py
+++ b/backends/xnnpack/test/ops/bilinear2d.py
@@ -78,43 +78,74 @@ class TestUpsampleBilinear2d(unittest.TestCase):
         "executorch_exir_dialects_edge__ops_aten_clamp_default",
     }
 
+    @unittest.skip('Expected to not find "aten_index_Tensor"')
+    def test_fp32_static_resize_bilinear2d_legacy(self):
+        example_inputs = (torch.randn(2, 3, 4, 5),)
+        tester = Tester(self.StaticResizeBilinear2dModule(), example_inputs)
+        tester.export()
+        tester.to_edge()
+        tester.partition()
+        tester.check_not(self.ops)
+        tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+        tester.to_executorch()
+        tester.serialize()
+        tester.run_method_and_compare_outputs()
+
     def test_fp32_static_resize_bilinear2d(self):
         example_inputs = (torch.randn(2, 3, 4, 5),)
-        (
-            Tester(self.StaticResizeBilinear2dModule(), example_inputs)
-            .export()
-            .to_edge_transform_and_lower()
-            .check_not(self.ops)
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        tester = Tester(self.StaticResizeBilinear2dModule(), example_inputs)
+        tester.export()
+        tester.to_edge_transform_and_lower()
+        tester.check_not(self.ops)
+        tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+        tester.to_executorch()
+        tester.serialize()
+        tester.run_method_and_compare_outputs()
+
+    @unittest.skip('Expected to not find "aten_index_Tensor"')
+    def test_fp32_static_resize_bilinear2d_with_align_corners_legacy(self):
+        example_inputs = (torch.randn(2, 3, 4, 5),)
+        for legacy in (True, False):
+            tester = Tester(
+                self.StaticResizeBilinear2dModuleWithAlignCorners(), example_inputs
+            )
+            tester.export()
+            tester.to_edge()
+            tester.partition()
+            tester.to_edge_transform_and_lower()
+            tester.check_not(self.ops)
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_fp32_static_resize_bilinear2d_with_align_corners(self):
         example_inputs = (torch.randn(2, 3, 4, 5),)
-        (
-            Tester(self.StaticResizeBilinear2dModuleWithAlignCorners(), example_inputs)
-            .export()
-            .to_edge_transform_and_lower()
-            .check_not(self.ops)
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
+        tester = Tester(
+            self.StaticResizeBilinear2dModuleWithAlignCorners(), example_inputs
         )
+        tester.export()
+        tester.to_edge_transform_and_lower()
+        tester.check_not(self.ops)
+        tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+        tester.to_executorch()
+        tester.serialize()
+        tester.run_method_and_compare_outputs()
 
     def test_fp32_static_resize_bilinear2d_antialiased(self):
         # Check bilinear2d_aa is not partitioned
         example_inputs = (torch.randn(2, 3, 4, 5),)
-        (
-            Tester(self.Bilinear2dAntiAlias(), example_inputs)
-            .export()
-            .to_edge_transform_and_lower()
-            .check_count(
+        for legacy in (True, False):
+            tester = Tester(self.Bilinear2dAntiAlias(), example_inputs)
+            tester.export()
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count(
                 {
                     "executorch_exir_dialects_edge__ops_aten__upsample_bilinear2d_aa_default": 2
                 }
             )
-            .check_not(["torch.ops.higher_order.executorch_call_delegate"])
-        )
+            tester.check_not(["torch.ops.higher_order.executorch_call_delegate"])

--- a/backends/xnnpack/test/ops/bilinear2d.py
+++ b/backends/xnnpack/test/ops/bilinear2d.py
@@ -105,19 +105,17 @@ class TestUpsampleBilinear2d(unittest.TestCase):
     @unittest.skip('Expected to not find "aten_index_Tensor"')
     def test_fp32_static_resize_bilinear2d_with_align_corners_legacy(self):
         example_inputs = (torch.randn(2, 3, 4, 5),)
-        for legacy in (True, False):
-            tester = Tester(
-                self.StaticResizeBilinear2dModuleWithAlignCorners(), example_inputs
-            )
-            tester.export()
-            tester.to_edge()
-            tester.partition()
-            tester.to_edge_transform_and_lower()
-            tester.check_not(self.ops)
-            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            tester.to_executorch()
-            tester.serialize()
-            tester.run_method_and_compare_outputs()
+        tester = Tester(
+            self.StaticResizeBilinear2dModuleWithAlignCorners(), example_inputs
+        )
+        tester.export()
+        tester.to_edge()
+        tester.partition()
+        tester.check_not(self.ops)
+        tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+        tester.to_executorch()
+        tester.serialize()
+        tester.run_method_and_compare_outputs()
 
     def test_fp32_static_resize_bilinear2d_with_align_corners(self):
         example_inputs = (torch.randn(2, 3, 4, 5),)

--- a/backends/xnnpack/test/ops/bmm.py
+++ b/backends/xnnpack/test/ops/bmm.py
@@ -19,17 +19,20 @@ class TestBMM(unittest.TestCase):
             return torch.bmm(x, y)
 
     def _test_bmm(self, inputs):
-        (
-            Tester(self.BMM(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.bmm.default": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_bmm_default"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.BMM(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.bmm.default": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(["executorch_exir_dialects_edge__ops_aten_bmm_default"])
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_fp16_bmm(self):
         inputs = (

--- a/backends/xnnpack/test/ops/ceil.py
+++ b/backends/xnnpack/test/ops/ceil.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/ceil.py
+++ b/backends/xnnpack/test/ops/ceil.py
@@ -7,6 +7,8 @@
 import unittest
 
 import torch
+
+from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 
@@ -20,17 +22,20 @@ class TestCeil(unittest.TestCase):
             return z
 
     def _test_ceil(self, inputs):
-        (
-            Tester(self.Ceil(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.ceil.default": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_ceil_default"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.Ceil(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.ceil.default": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(["executorch_exir_dialects_edge__ops_aten_ceil_default"])
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_fp16_ceil(self):
         inputs = (

--- a/backends/xnnpack/test/ops/conv2d.py
+++ b/backends/xnnpack/test/ops/conv2d.py
@@ -10,7 +10,6 @@ from typing import Optional
 
 import torch
 
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.test_xnnpack_utils import randomize_bn
 from executorch.backends.xnnpack.test.tester import Quantize, Tester
 from torch.ao.quantization.quantizer.xnnpack_quantizer import (

--- a/backends/xnnpack/test/ops/conv2d.py
+++ b/backends/xnnpack/test/ops/conv2d.py
@@ -9,6 +9,8 @@ import unittest
 from typing import Optional
 
 import torch
+
+from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.test_xnnpack_utils import randomize_bn
 from executorch.backends.xnnpack.test.tester import Quantize, Tester
 from torch.ao.quantization.quantizer.xnnpack_quantizer import (
@@ -155,27 +157,32 @@ class TestConv2d(unittest.TestCase):
         conv_count=1,
         dtype: torch.dtype = torch.float,
     ):
-        tester = Tester(m.eval(), m.get_inputs())
-
-        if quant_config is not None:
-            tester = tester.quantize(Quantize(quantization_config=quant_config))
-            tester.check(["torch.ops.quantized_decomposed"])
-
-        (
-            tester.export()
-            .check_count({"torch.ops.aten.conv2d": conv_count})
-            .to_edge_transform_and_lower()
-            .check_not(["executorch_exir_dialects_edge__ops_aten_convolution_default"])
-            .check_not(
-                [
-                    "executorch_exir_dialects_edge__ops__native_batch_norm_legit_no_training_default"
-                ]
-            )
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs(qtol=1)
-        )
+        for legacy in (True, False):
+            if quant_config is not None:
+                tester = Tester(m.eval(), m.get_inputs())
+                tester = tester.quantize(Quantize(quantization_config=quant_config))
+                tester.check(["torch.ops.quantized_decomposed"])
+                tester.export()
+                tester.check_count({"torch.ops.aten.conv2d": conv_count})
+                if legacy:
+                    tester.to_edge()
+                    tester.partition()
+                else:
+                    tester.to_edge_transform_and_lower()
+                tester.check_not(
+                    ["executorch_exir_dialects_edge__ops_aten_convolution_default"]
+                )
+                tester.check_not(
+                    [
+                        "executorch_exir_dialects_edge__ops__native_batch_norm_legit_no_training_default"
+                    ]
+                )
+                tester.check_count(
+                    {"torch.ops.higher_order.executorch_call_delegate": 1}
+                )
+                tester.to_executorch()
+                tester.serialize()
+                tester.run_method_and_compare_outputs(qtol=1)
 
     def test_fp16_conv2d(self) -> None:
         for has_bias in (True, False):

--- a/backends/xnnpack/test/ops/div.py
+++ b/backends/xnnpack/test/ops/div.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/div.py
+++ b/backends/xnnpack/test/ops/div.py
@@ -7,6 +7,8 @@
 import unittest
 
 import torch
+
+from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 
@@ -28,17 +30,20 @@ class TestDiv(unittest.TestCase):
             return z
 
     def _test_div(self, inputs):
-        (
-            Tester(self.Div(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.div.Tensor": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_div_Tensor"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.Div(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.div.Tensor": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(["executorch_exir_dialects_edge__ops_aten_div_Tensor"])
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_fp16_div(self):
         # Adding 4 to move distribution away from 0, 4 Std Dev should be far enough
@@ -56,14 +61,17 @@ class TestDiv(unittest.TestCase):
     def test_fp32_div_single_input(self):
         # Adding 4 to move distribution away from 0, 4 Std Dev should be far enough
         inputs = (torch.randn(1) + 4,)
-        (
-            Tester(self.DivSingleInput(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.div.Tensor": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_div_Tensor"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.DivSingleInput(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.div.Tensor": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(["executorch_exir_dialects_edge__ops_aten_div_Tensor"])
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()

--- a/backends/xnnpack/test/ops/elu.py
+++ b/backends/xnnpack/test/ops/elu.py
@@ -24,21 +24,24 @@ class TestElu(unittest.TestCase):
             return torch.nn.functional.elu(x, alpha=1.2)
 
     def _test_elu(self, inputs):
-        (
-            Tester(self.ELU(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.elu.default": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(
+        for legacy in (True, False):
+            tester = Tester(self.ELU(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.elu.default": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
                 [
                     "executorch_exir_dialects_edge__ops_aten_elu_default",
                 ]
             )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     @unittest.skip("PyTorch Pin Update Required")
     def _test_fp16_elu(self):
@@ -53,43 +56,49 @@ class TestElu(unittest.TestCase):
     @unittest.skip("Update Quantizer to quantize Elu")
     def _test_qs8_elu(self):
         inputs = (torch.randn(1, 3, 4, 4),)
-        (
-            Tester(self.ELU(), inputs)
-            .quantize()
-            .export()
-            .check_count({"torch.ops.aten.elu.default": 1})
-            .check(["torch.ops.quantized_decomposed"])
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(
+        for legacy in (True, False):
+            tester = Tester(self.ELU(), inputs)
+            tester.quantize()
+            tester.export()
+            tester.check_count({"torch.ops.aten.elu.default": 1})
+            tester.check(["torch.ops.quantized_decomposed"])
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
                 [
                     "executorch_exir_dialects_edge__ops_aten_elu_default",
                     "torch.ops.quantized_decomposed",
                 ]
             )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     @unittest.skip("Update Quantizer to quantize Elu")
     def _test_qs8_elu_functional(self):
         inputs = (torch.randn(1, 3, 4, 4),)
-        (
-            Tester(self.ELU(), inputs)
-            .quantize()
-            .export()
-            .check_count({"torch.ops.aten.elu.default": 1})
-            .check(["torch.ops.quantized_decomposed"])
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(
+        for legacy in (True, False):
+            tester = Tester(self.ELU(), inputs)
+            tester.quantize()
+            tester.export()
+            tester.check_count({"torch.ops.aten.elu.default": 1})
+            tester.check(["torch.ops.quantized_decomposed"])
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
                 [
                     "executorch_exir_dialects_edge__ops_aten_elu_default",
                     "torch.ops.quantized_decomposed",
                 ]
             )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()

--- a/backends/xnnpack/test/ops/hardswish.py
+++ b/backends/xnnpack/test/ops/hardswish.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/hardtanh.py
+++ b/backends/xnnpack/test/ops/hardtanh.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/lstm.py
+++ b/backends/xnnpack/test/ops/lstm.py
@@ -24,7 +24,7 @@ class TestLSTM(unittest.TestCase):
             self.linear2 = torch.nn.Linear(hidden_size, out_size)
 
         def forward(self, x):
-            x, hs = self.lstm(x)
+            x, _ = self.lstm(x)
             x = self.linear(x[:, -1, :])
             x = self.linear2(x)
             return torch.nn.functional.log_softmax(x, dim=1)

--- a/backends/xnnpack/test/ops/lstm.py
+++ b/backends/xnnpack/test/ops/lstm.py
@@ -30,34 +30,52 @@ class TestLSTM(unittest.TestCase):
             return torch.nn.functional.log_softmax(x, dim=1)
 
     def test_fp32_lstm(self):
-        (
-            Tester(self.LSTMLinear(32, 32, 10), (torch.rand(1, 32, 32),))
-            .export()
-            .to_edge_transform_and_lower()
-            .check_not(["executorch_exir_dialects_edge__ops_aten_addmm_default"])
-            .check_not(
-                ["p_lstm_weight", "p_lstm_bias"]
-            )  # These Should be Consumed by Delegate
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.LSTMLinear(32, 32, 10), (torch.rand(1, 32, 32),))
+            tester.export()
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+                tester.check_not(
+                    ["executorch_exir_dialects_edge__ops_aten_addmm_default"]
+                )
+                tester.check_not(
+                    ["p_lstm_weight", "p_lstm_bias"]
+                )  # These Should be Consumed by Delegate
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_fp32_lstm_force_dynamic_linear(self):
-        (
-            Tester(self.LSTMLinear(32, 32, 10), (torch.rand(1, 32, 32),))
-            .export()
-            .to_edge_transform_and_lower(
-                ToEdgeTransformAndLower(
-                    partitioners=[XnnpackPartitioner(force_fp32_dynamic_linear=True)]
-                )
+        tester = Tester(self.LSTMLinear(32, 32, 10), (torch.rand(1, 32, 32),))
+        tester.export()
+        tester.to_edge_transform_and_lower(
+            ToEdgeTransformAndLower(
+                partitioners=[XnnpackPartitioner(force_fp32_dynamic_linear=True)]
             )
-            .check_not(["executorch_exir_dialects_edge__ops_aten_addmm_default"])
-            # Weights are supplied as input to linears
-            .check(["p_lstm_weight_hh_l0", "p_lstm_weight_ih_l0"])
-            # Biases are owned by delegates
-            .check_not(["p_lstm_bias"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
         )
+        tester.check_not(["executorch_exir_dialects_edge__ops_aten_addmm_default"])
+        # Weights are supplied as input to linears
+        tester.check(["p_lstm_weight_hh_l0", "p_lstm_weight_ih_l0"])
+        # Biases are owned by delegates
+        tester.check_not(["p_lstm_bias"])
+        tester.to_executorch()
+        tester.serialize()
+        tester.run_method_and_compare_outputs()
+
+    @unittest.skip('Expected to not find "aten_addmm_default"')
+    def test_fp32_lstm_force_dynamic_linear_legacy(self):
+        tester = Tester(self.LSTMLinear(32, 32, 10), (torch.rand(1, 32, 32),))
+        tester.export()
+        tester.to_edge()
+        tester.partition()
+        tester.check_not(["executorch_exir_dialects_edge__ops_aten_addmm_default"])
+        # Weights are supplied as input to linears
+        tester.check(["p_lstm_weight_hh_l0", "p_lstm_weight_ih_l0"])
+        # Biases are owned by delegates
+        tester.check_not(["p_lstm_bias"])
+        tester.to_executorch()
+        tester.serialize()
+        tester.run_method_and_compare_outputs()

--- a/backends/xnnpack/test/ops/max_dim.py
+++ b/backends/xnnpack/test/ops/max_dim.py
@@ -24,27 +24,33 @@ class TestMaxDim(unittest.TestCase):
             return (max_values_1, max_values_2)
 
     def _test_max_dim(self, inputs):
-        (
-            Tester(self.Max(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.max.dim": 2})
-            .to_edge_transform_and_lower()
-            .check_not(["torch.ops.higher_order.executorch_call_delegate"])
-            .check_count({"executorch_exir_dialects_edge__ops_aten_max_dim": 2})
-        )
+        for legacy in (True, False):
+            tester = Tester(self.Max(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.max.dim": 2})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_not(["torch.ops.higher_order.executorch_call_delegate"])
+            tester.check_count({"executorch_exir_dialects_edge__ops_aten_max_dim": 2})
 
     def _test_max_dim_no_indicies(self, inputs):
-        (
-            Tester(self.MaxNoIndices(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.max.dim": 2})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_max_dim"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.MaxNoIndices(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.max.dim": 2})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(["executorch_exir_dialects_edge__ops_aten_max_dim"])
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_fp16_max_dim_with_indicies(self):
         inputs = (torch.randn(16, 3, 12, 12).to(torch.float16),)

--- a/backends/xnnpack/test/ops/maximum.py
+++ b/backends/xnnpack/test/ops/maximum.py
@@ -19,17 +19,22 @@ class TestMaximum(unittest.TestCase):
             return torch.maximum(x, y)
 
     def _test_maximum(self, inputs):
-        (
-            Tester(self.Maximum(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.maximum.default": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_maximum_default"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.Maximum(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.maximum.default": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
+                ["executorch_exir_dialects_edge__ops_aten_maximum_default"]
+            )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_fp16_maximum(self):
         inputs = (
@@ -50,14 +55,19 @@ class TestMaximum(unittest.TestCase):
             torch.randn(2, 3, 4),
             torch.randn(2, 1, 4),
         )
-        (
-            Tester(self.Maximum(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.maximum.default": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_maximum_default"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.Maximum(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.maximum.default": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
+                ["executorch_exir_dialects_edge__ops_aten_maximum_default"]
+            )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()

--- a/backends/xnnpack/test/ops/mean_dim.py
+++ b/backends/xnnpack/test/ops/mean_dim.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 
@@ -92,7 +90,11 @@ class TestMeanDim(unittest.TestCase):
                     torch.ops.quantized_decomposed.quantize_per_tensor.default: 3,
                 }
             )
-            tester.to_edge_transform_and_lower()
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
             tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             tester.check_not(
                 [

--- a/backends/xnnpack/test/ops/minimum.py
+++ b/backends/xnnpack/test/ops/minimum.py
@@ -7,6 +7,8 @@
 import unittest
 
 import torch
+
+from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 
@@ -19,17 +21,22 @@ class TestMinimum(unittest.TestCase):
             return torch.minimum(x, y)
 
     def _test_minimum(self, inputs):
-        (
-            Tester(self.Minimum(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.minimum.default": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_minimum_default"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.Minimum(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.minimum.default": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
+                ["executorch_exir_dialects_edge__ops_aten_minimum_default"]
+            )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_fp16_minimum(self):
         inputs = (

--- a/backends/xnnpack/test/ops/minimum.py
+++ b/backends/xnnpack/test/ops/minimum.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/multiply.py
+++ b/backends/xnnpack/test/ops/multiply.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/multiply.py
+++ b/backends/xnnpack/test/ops/multiply.py
@@ -7,6 +7,8 @@
 import unittest
 
 import torch
+
+from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 
@@ -32,17 +34,20 @@ class TestMul(unittest.TestCase):
             return torch.nn.functional.relu(z)
 
     def _test_mul(self, inputs):
-        (
-            Tester(self.Mul(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.mul.Tensor": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_mul_Tensor"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.Mul(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.mul.Tensor": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(["executorch_exir_dialects_edge__ops_aten_mul_Tensor"])
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_fp16_mul(self):
         inputs = (
@@ -57,90 +62,102 @@ class TestMul(unittest.TestCase):
 
     def test_qs8_mul(self):
         inputs = (torch.randn(1, 1, 4, 4), torch.randn(1, 1, 4, 1))
-        (
-            Tester(self.Mul(), inputs)
-            .quantize()
-            .export()
-            .check_count({"torch.ops.aten.mul.Tensor": 1})
-            .check(["torch.ops.quantized_decomposed"])
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(
+        for legacy in (True, False):
+            tester = Tester(self.Mul(), inputs)
+            tester.quantize()
+            tester.export()
+            tester.check_count({"torch.ops.aten.mul.Tensor": 1})
+            tester.check(["torch.ops.quantized_decomposed"])
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
                 [
                     "executorch_exir_dialects_edge__ops_aten_mul_Tensor",
                     "torch.ops.quantized_decomposed",
                 ]
             )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_qs8_mul2(self):
         inputs = (torch.randn(1, 1, 4, 4),)
-        (
-            Tester(self.Mul2(), inputs)
-            .quantize()
-            .export()
-            .check_count({"torch.ops.aten.mul.Tensor": 1})
-            .check(["torch.ops.quantized_decomposed"])
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(
+        for legacy in (True, False):
+            tester = Tester(self.Mul2(), inputs)
+            tester.quantize()
+            tester.export()
+            tester.check_count({"torch.ops.aten.mul.Tensor": 1})
+            tester.check(["torch.ops.quantized_decomposed"])
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
                 [
                     "executorch_exir_dialects_edge__ops_aten_mul_Tensor",
                     "torch.ops.quantized_decomposed",
                 ]
             )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_qs8_mul_functional(self):
         inputs = (torch.randn(1, 1, 4, 4), torch.randn(1, 1, 4, 4))
-        (
-            Tester(self.MulFunctional(), inputs)
-            .quantize()
-            .export()
-            .check_count({"torch.ops.aten.mul.Tensor": 3})
-            .check(["torch.ops.quantized_decomposed"])
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(
+        for legacy in (True, False):
+            tester = Tester(self.MulFunctional(), inputs)
+            tester.quantize()
+            tester.export()
+            tester.check_count({"torch.ops.aten.mul.Tensor": 3})
+            tester.check(["torch.ops.quantized_decomposed"])
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
                 [
                     "executorch_exir_dialects_edge__ops_aten_mul_Tensor",
                     "torch.ops.quantized_decomposed",
                 ]
             )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_qs8_mul_relu(self):
         inputs = (torch.randn(1, 1, 4, 4), torch.randn(1, 1, 4, 4))
-        (
-            Tester(self.MulRelu(), inputs)
-            .quantize()
-            .export()
-            .check_count(
+        for legacy in (True, False):
+            tester = Tester(self.MulRelu(), inputs)
+            tester.quantize()
+            tester.export()
+            tester.check_count(
                 {
                     "torch.ops.aten.mul.Tensor": 1,
                     "torch.ops.aten.relu.default": 1,
                 }
             )
-            .check(["torch.ops.quantized_decomposed"])
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(
+            tester.check(["torch.ops.quantized_decomposed"])
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
                 [
                     "executorch_exir_dialects_edge__ops_aten_mul_Tensor",
                     "executorch_exir_dialects_edge__ops_aten_relu_default",
                     "torch.ops.quantized_decomposed",
                 ]
             )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()

--- a/backends/xnnpack/test/ops/permute.py
+++ b/backends/xnnpack/test/ops/permute.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/permute.py
+++ b/backends/xnnpack/test/ops/permute.py
@@ -7,6 +7,8 @@
 import unittest
 
 import torch
+
+from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 
@@ -32,17 +34,22 @@ class TestPermute(unittest.TestCase):
             return z
 
     def _test_permute(self, inputs):
-        (
-            Tester(self.Permute([0, 2, 3, 1]), inputs)
-            .export()
-            .check_count({"torch.ops.aten.permute.default": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_permute_copy_default"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.Permute([0, 2, 3, 1]), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.permute.default": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
+                ["executorch_exir_dialects_edge__ops_aten_permute_copy_default"]
+            )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_fp16_permute(self):
         inputs = (torch.randn(1, 1, 4, 4).to(torch.float16),)
@@ -54,64 +61,75 @@ class TestPermute(unittest.TestCase):
 
     def test_fp32_permute_copy(self):
         inputs = (torch.randn(1, 1, 4, 4),)
-        (
-            Tester(self.PermuteCopy([0, 2, 3, 1]), inputs)
-            .export()
-            .check_count({"torch.ops.aten.permute_copy.default": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_permute_copy_default"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.PermuteCopy([0, 2, 3, 1]), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.permute_copy.default": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
+                ["executorch_exir_dialects_edge__ops_aten_permute_copy_default"]
+            )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_qs8_permute(self):
         inputs = (torch.randn(1, 1, 4, 4),)
-        (
-            Tester(self.Permute([0, 2, 3, 1]), inputs)
-            .quantize()
-            .export()
-            .check_node_count(
+        for legacy in (True, False):
+            tester = Tester(self.Permute([0, 2, 3, 1]), inputs)
+            tester.quantize()
+            tester.export()
+            tester.check_node_count(
                 {
                     torch.ops.aten.permute.default: 1,
                     torch.ops.quantized_decomposed.quantize_per_tensor.default: 3,
                 }
             )
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
                 [
                     "executorch_exir_dialects_edge__ops_aten_permute_copy_default",
                     "torch.ops.quantized_decomposed",
                 ]
             )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_qs8_permute_copy(self):
         inputs = (torch.randn(1, 1, 4, 4),)
-        (
-            Tester(self.PermuteCopy([0, 2, 3, 1]), inputs)
-            .quantize()
-            .export()
-            .check_node_count(
+        for legacy in (True, False):
+            tester = Tester(self.PermuteCopy([0, 2, 3, 1]), inputs)
+            tester.quantize()
+            tester.export()
+            tester.check_node_count(
                 {
                     torch.ops.aten.permute_copy.default: 1,
                     torch.ops.quantized_decomposed.quantize_per_tensor.default: 3,
                 }
             )
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
                 [
                     "executorch_exir_dialects_edge__ops_aten_permute_copy_default",
                     "torch.ops.quantized_decomposed",
                 ]
             )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()

--- a/backends/xnnpack/test/ops/pow.py
+++ b/backends/xnnpack/test/ops/pow.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 
@@ -27,7 +25,11 @@ class TestPow(unittest.TestCase):
             tester = Tester(self.Pow(2), inputs)
             tester.export()
             tester.check_count({"torch.ops.aten.pow.Tensor_Scalar": 1})
-            tester.to_edge_transform_and_lower()
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
             tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             tester.check_not(
                 ["executorch_exir_dialects_edge__ops_aten_pow_Tensor_Scalar"]

--- a/backends/xnnpack/test/ops/prelu.py
+++ b/backends/xnnpack/test/ops/prelu.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/quantize_per_tensor.py
+++ b/backends/xnnpack/test/ops/quantize_per_tensor.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 from executorch.exir.dialects._ops import ops as exir_ops

--- a/backends/xnnpack/test/ops/relu.py
+++ b/backends/xnnpack/test/ops/relu.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/relu.py
+++ b/backends/xnnpack/test/ops/relu.py
@@ -7,6 +7,8 @@
 import unittest
 
 import torch
+
+from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 
@@ -22,14 +24,17 @@ class TestRelu(unittest.TestCase):
 
     def test_fp32_relu(self):
         inputs = (torch.randn(8),)
-        (
-            Tester(self.Relu(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.relu.default": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_relu_default"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.Relu(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.relu.default": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(["executorch_exir_dialects_edge__ops_aten_relu_default"])
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()

--- a/backends/xnnpack/test/ops/sdpa.py
+++ b/backends/xnnpack/test/ops/sdpa.py
@@ -64,9 +64,13 @@ class TestSDPA(unittest.TestCase):
         for legacy in (True, False):
             tester = Tester(module, inputs)
             tester.export()
-            tester.to_edge_transform_and_lower(
-                ToEdgeTransformAndLower([XnnpackPartitioner(configs=[SDPAConfig])])
-            )
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower(
+                    ToEdgeTransformAndLower([XnnpackPartitioner(configs=[SDPAConfig])])
+                )
             tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             tester.check_not(
                 ["executorch_exir_dialects_edge__ops_aten_bmm_default"],

--- a/backends/xnnpack/test/ops/sdpa.py
+++ b/backends/xnnpack/test/ops/sdpa.py
@@ -10,8 +10,6 @@ from typing import Optional
 import torch
 from executorch.backends.xnnpack.partition.config.generic_node_configs import SDPAConfig
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 from executorch.backends.xnnpack.test.tester.tester import ToEdgeTransformAndLower
 

--- a/backends/xnnpack/test/ops/sigmoid.py
+++ b/backends/xnnpack/test/ops/sigmoid.py
@@ -21,17 +21,22 @@ class TestSigmoid(unittest.TestCase):
             return z
 
     def _test_sigmoid(self, inputs):
-        (
-            Tester(self.Sigmoid(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.sigmoid.default": 1})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(["executorch_exir_dialects_edge__ops_aten_sigmoid_default"])
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+        for legacy in (True, False):
+            tester = Tester(self.Sigmoid(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.sigmoid.default": 1})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
+                ["executorch_exir_dialects_edge__ops_aten_sigmoid_default"]
+            )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_fp16_sigmoid(self):
         inputs = (torch.randn(4).to(torch.float16),)

--- a/backends/xnnpack/test/ops/slice_copy.py
+++ b/backends/xnnpack/test/ops/slice_copy.py
@@ -131,7 +131,11 @@ class TestSliceCopy(unittest.TestCase):
                 dynamic_shapes=({2: torch.export.Dim("dim_2", min=4, max=100)},),
             )
             tester.export()
-            tester.to_edge_transform_and_lower()
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
             tester.check_not(["torch.ops.higher_order.executorch_call_delegate"])
 
     # Note: Slice ends up as slice_copy later in the process, but during quantization,

--- a/backends/xnnpack/test/ops/softmax.py
+++ b/backends/xnnpack/test/ops/softmax.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/softmax.py
+++ b/backends/xnnpack/test/ops/softmax.py
@@ -7,6 +7,8 @@
 import unittest
 
 import torch
+
+from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 
@@ -25,17 +27,24 @@ class TestSoftmax(unittest.TestCase):
         valid_dims = [len(inputs[0]) - 1, -1]
 
         for dim in valid_dims:
-            (
-                Tester(self.Softmax(dim), inputs)
-                .export()
-                .check_count({"torch.ops.aten.softmax": 1})
-                .to_edge_transform_and_lower()
-                .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-                .check_not(["executorch_exir_dialects_edge__ops_aten__softmax_default"])
-                .to_executorch()
-                .serialize()
-                .run_method_and_compare_outputs()
-            )
+            for legacy in (True, False):
+                tester = Tester(self.Softmax(dim), inputs)
+                tester.export()
+                tester.check_count({"torch.ops.aten.softmax": 1})
+                if legacy:
+                    tester.to_edge()
+                    tester.partition()
+                else:
+                    tester.to_edge_transform_and_lower()
+                tester.check_count(
+                    {"torch.ops.higher_order.executorch_call_delegate": 1}
+                )
+                tester.check_not(
+                    ["executorch_exir_dialects_edge__ops_aten__softmax_default"]
+                )
+                tester.to_executorch()
+                tester.serialize()
+                tester.run_method_and_compare_outputs()
 
     def test_fp16_softmax(self):
         inputs = (torch.rand((3, 5, 7)).to(torch.float16),)
@@ -55,11 +64,16 @@ class TestSoftmax(unittest.TestCase):
         invalid_dims = range(len(inputs) - 1)
 
         for dim in invalid_dims:
-            (
-                Tester(self.Softmax(dim), inputs)
-                .export()
-                .check_count({"torch.ops.aten.softmax": 1})
-                .to_edge_transform_and_lower()
+            for legacy in (True, False):
+                tester = Tester(self.Softmax(dim), inputs)
+                tester.export()
+                tester.check_count({"torch.ops.aten.softmax": 1})
+                if legacy:
+                    tester.to_edge()
+                    tester.partition()
+                else:
+                    tester.to_edge_transform_and_lower()
                 # Should not be delegated
-                .check(["executorch_exir_dialects_edge__ops_aten__softmax_default"])
-            )
+                tester.check(
+                    ["executorch_exir_dialects_edge__ops_aten__softmax_default"]
+                )

--- a/backends/xnnpack/test/ops/sqrt.py
+++ b/backends/xnnpack/test/ops/sqrt.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/square.py
+++ b/backends/xnnpack/test/ops/square.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 

--- a/backends/xnnpack/test/ops/static_constant_pad.py
+++ b/backends/xnnpack/test/ops/static_constant_pad.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 
@@ -164,7 +162,11 @@ class TestStaticConstantPad(unittest.TestCase):
             tester.export()
             tester.check_count({"torch.ops.aten.pad.default": 1})
             tester.check(["torch.ops.quantized_decomposed"])
-            tester.to_edge_transform_and_lower()
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
             tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             tester.check_not(
                 [

--- a/backends/xnnpack/test/ops/static_constant_pad.py
+++ b/backends/xnnpack/test/ops/static_constant_pad.py
@@ -7,6 +7,8 @@
 import unittest
 
 import torch
+
+from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 
@@ -84,19 +86,22 @@ class TestStaticConstantPad(unittest.TestCase):
             return z
 
     def _test_static_constant_pad_functional(self, inputs):
-        (
-            Tester(self.StaticConstantPadFunctional(), inputs)
-            .export()
-            .check_count({"torch.ops.aten.pad.default": 8})
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(
+        for legacy in (True, False):
+            tester = Tester(self.StaticConstantPadFunctional(), inputs)
+            tester.export()
+            tester.check_count({"torch.ops.aten.pad.default": 8})
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
                 ["executorch_exir_dialects_edge__ops_aten_constant_pad_nd_default"]
             )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_fp16_static_constant_pad_functional(self):
         inputs = (
@@ -129,42 +134,44 @@ class TestStaticConstantPad(unittest.TestCase):
                 return z + z
 
         inputs = (torch.randn(size=(1, 2)),)
-        (
-            Tester(Pad(), inputs)
-            .quantize()
-            .export()
-            .check_count({"torch.ops.aten.pad.default": 1})
-            .check(["torch.ops.quantized_decomposed"])
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(
+        for legacy in (True, False):
+            tester = Tester(Pad(), inputs)
+            tester.quantize()
+            tester.export()
+            tester.check_count({"torch.ops.aten.pad.default": 1})
+            tester.check(["torch.ops.quantized_decomposed"])
+            if legacy:
+                tester.to_edge()
+                tester.partition()
+            else:
+                tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
                 [
                     "executorch_exir_dialects_edge__ops_aten_constant_pad_nd_default"
                     "torch.ops.quantized_decomposed",
                 ]
             )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()
 
     def test_qs8_static_constant_pad_2d(self):
         inputs = (torch.randn(size=(5, 4, 3, 2)),)
-        (
-            Tester(self.StaticConstantPad2d(), inputs)
-            .quantize()
-            .export()
-            .check_count({"torch.ops.aten.pad.default": 1})
-            .check(["torch.ops.quantized_decomposed"])
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .check_not(
+        for legacy in (True, False):
+            tester = Tester(self.StaticConstantPad2d(), inputs)
+            tester.quantize()
+            tester.export()
+            tester.check_count({"torch.ops.aten.pad.default": 1})
+            tester.check(["torch.ops.quantized_decomposed"])
+            tester.to_edge_transform_and_lower()
+            tester.check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            tester.check_not(
                 [
                     "executorch_exir_dialects_edge__ops_aten_constant_pad_nd_default",
                     "torch.ops.quantized_decomposed",
                 ]
             )
-            .to_executorch()
-            .serialize()
-            .run_method_and_compare_outputs()
-        )
+            tester.to_executorch()
+            tester.serialize()
+            tester.run_method_and_compare_outputs()

--- a/backends/xnnpack/test/ops/sub.py
+++ b/backends/xnnpack/test/ops/sub.py
@@ -7,8 +7,6 @@
 import unittest
 
 import torch
-
-from executorch.backends.xnnpack.test import tester
 from executorch.backends.xnnpack.test.tester import Tester
 
 


### PR DESCRIPTION
### Summary
- Adds the rest of the legacy to_edge and partition tests back. 
- bilinear and maxpool2d are the 2 ops where we seem to have problems and have skipped tests as a result. 
### Test plan
> python -m unittest backends/xnnpack/test/ops/*py