### PR TITLE
Export Stories110M model to compare on-device numerics

### DIFF
--- a/backends/qualcomm/_passes/replace_inf_buffer.py
+++ b/backends/qualcomm/_passes/replace_inf_buffer.py
@@ -18,8 +18,8 @@ class ReplaceInfBuffer(ExportPass):
     def call(self, graph_module: torch.fx.GraphModule):
         for buf_name, tensor in graph_module.named_buffers():
             if tensor.is_floating_point():
-                tensor[tensor == float("inf")] = 255
-                tensor[tensor == float("-inf")] = -255
+                tensor[tensor == float("inf")] = 65535
+                tensor[tensor == float("-inf")] = -65535
                 setattr(graph_module, buf_name, tensor)
 
         graph_module.recompile()

--- a/backends/qualcomm/quantizer/quantizer.py
+++ b/backends/qualcomm/quantizer/quantizer.py
@@ -19,6 +19,7 @@ from executorch.backends.transforms.decompose_sdpa import (
 )
 
 from torch._ops import OpOverload
+from torch.ao.quantization.observer import MinMaxObserver
 from torch.ao.quantization.quantizer import Quantizer
 from torch.fx import GraphModule
 
@@ -75,7 +76,7 @@ quant_config_dict = {
     ),
     (QuantDtype.use_16a4w, False): (
         get_16a4w_qnn_ptq_config,
-        get_ptq_per_channel_quant_config(torch.uint16, "int4"),
+        get_ptq_per_channel_quant_config(torch.uint16, "int4", act_observer=MinMaxObserver),
     ),
     (QuantDtype.use_8a8w, False): (
         get_8a8w_qnn_ptq_config,
@@ -84,7 +85,7 @@ quant_config_dict = {
     # QAT,
     (QuantDtype.use_16a4w, True): (
         get_16a4w_qnn_qat_config,
-        get_qat_per_channel_quant_config(torch.uint16, "int4"),
+        get_qat_per_channel_quant_config(torch.uint16, "int4", act_observer=MinMaxObserver),
     ),
     (QuantDtype.use_8a8w, True): (
         get_8a8w_qnn_qat_config,

--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -574,7 +574,7 @@ def get_quantizer_and_quant_params(args):
     if args.qnn and args.pt2e_quantize:
         assert len(quantizers) == 0, "Should not enable both xnnpack and qnn"
         qnn_quantizer, quant_dtype = get_qnn_quantizer(
-            args.pt2e_quantize, args.quantization_mode
+            args.pt2e_quantize, args.quantization_mode, is_qat=True
         )
         quantizers.append(qnn_quantizer)
     if args.coreml and args.pt2e_quantize:


### PR DESCRIPTION
Summary:
- Replace inf (-inf) to 64k (-64k) as we use int16 for activations.
- For int16 activations, "MinMaxObserver" is recommended, updated quantizer to reflect this change.

Repro command:
python -m executorch.examples.models.llama.export_llama --disable_dynamic_shape --qnn --pt2e_quantize qnn_16a4w -v -kv -p ~/pllm/stories110M/params.json -c ~/pllm/stories110M/stories_110M.pt --soc_model SM8650 -n ~/pllm/stories110M/exported_models/sm8650.pte --max_seq_len 512 --tokenizer_path ~/pllm/stories110M/tokenizer.model  2>&1 | tee ~/pllm/stories110M/exported_models/export_log.txt

Differential Revision: D66037630


