### PR TITLE
Move the rest qnn model jobs to the new qnn sdk docker

### DIFF
--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -136,7 +136,7 @@ jobs:
       fail-fast: false
     with:
       runner: linux.4xlarge
-      docker-image: executorch-ubuntu-22.04-clang12-android
+      docker-image: executorch-ubuntu-22.04-qnn-sdk
       submodules: 'true'
       timeout: 60
       upload-artifact: android-models

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -302,7 +302,7 @@ jobs:
       fail-fast: false
     with:
       runner: linux.2xlarge
-      docker-image: executorch-ubuntu-22.04-clang12-android
+      docker-image: executorch-ubuntu-22.04-qnn-sdk
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 900


### PR DESCRIPTION
Summary: A new qnn sdk docker is added https://github.com/pytorch/executorch/pull/6796 and we move jobs to the new docker to avoid flaky CI

Differential Revision: D65886140
