### PR TITLE
Fix ARM submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "backends/arm/third-party/ethos-u-core-driver"]
 	path = backends/arm/third-party/ethos-u-core-driver
-	url = https://review.mlplatform.org/ml/ethos-u/ethos-u-core-driver
+	url = https://git.mlplatform.org/ml/ethos-u/ethos-u-core-driver.git/
 [submodule "backends/arm/third-party/serialization_lib"]
 	path = backends/arm/third-party/serialization_lib
-	url = https://review.mlplatform.org/tosa/serialization_lib
+	url = https://git.mlplatform.org/tosa/serialization_lib.git/
 [submodule "backends/vulkan/third-party/Vulkan-Headers"]
 	path = backends/vulkan/third-party/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers


### PR DESCRIPTION
Looks like review.mlplatform.org is no longer hosting these things and these are the new URLs.

Test Plan: git submodule update --init (did nothing in my existing checkout)