### PR TITLE
Fix custom annotation

### DIFF
--- a/backends/qualcomm/quantizer/custom_annotation.py
+++ b/backends/qualcomm/quantizer/custom_annotation.py
@@ -78,7 +78,7 @@ def annotate_matmul_16a8w(gm: torch.fx.GraphModule) -> None:
         )
 
     def annotate_matmul_input1(node: Node):
-        quantization_config_8a8w = get_default_8bit_qnn_ptq_config(
+        quantization_config_8a8w = get_8a8w_qnn_ptq_config(
             act_symmetric=True, act_observer=MinMaxObserver
         )
         while isinstance(node, Node) and node.op == "call_function":


### PR DESCRIPTION
Summary: Looks like it's added in  https://github.com/pytorch/executorch/pull/6849, maybe it was using the old api for the default 8bit quantization

Differential Revision: D66219251


