### PR TITLE
Revert "Fix ARM submodule URLs (#6973)"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "backends/arm/third-party/ethos-u-core-driver"]
 	path = backends/arm/third-party/ethos-u-core-driver
-	url = https://git.mlplatform.org/ml/ethos-u/ethos-u-core-driver.git/
+	url = https://review.mlplatform.org/ml/ethos-u/ethos-u-core-driver
 [submodule "backends/arm/third-party/serialization_lib"]
 	path = backends/arm/third-party/serialization_lib
-	url = https://git.mlplatform.org/tosa/serialization_lib.git/
+	url = https://review.mlplatform.org/tosa/serialization_lib
 [submodule "backends/vulkan/third-party/Vulkan-Headers"]
 	path = backends/vulkan/third-party/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #6968
* __->__ #6987

The `review.` URLs are preferred due to lower resource usage per https://github.com/pytorch/executorch/pull/6973#issuecomment-2489210155

Differential Revision: [D66247100](https://our.internmc.facebook.com/intern/diff/D66247100/)