### PR TITLE
Clear out Dynamo cache in between tests

### DIFF
--- a/backends/xnnpack/test/ops/linear.py
+++ b/backends/xnnpack/test/ops/linear.py
@@ -497,6 +497,7 @@ class TestLinear(unittest.TestCase):
         which ares then transformed into aten.linear.default by the ConvertToLinear pass.
         """
         for i, _ in enumerate(in_sizes):
+            torch._dynamo.reset()
             in_size = int(in_sizes[i])
             input_size = int(input_sizes[i])
             output_size = int(output_sizes[i])


### PR DESCRIPTION
Summary: This issue was discovered when we tried to land https://www.internalfb.com/diff/D66189091. There is nothing wrong with D66189091, it just changes the way Dynamo invalidates its cache entry. However, it upsets these tests because they unintentionally rely on the Dynamo old behavior of invalidting cache entries.

Reviewed By: kimishpatel

Differential Revision: D66255174


