### PR TITLE
Enable bool type for _local_scalar_dense

### DIFF
--- a/kernels/prim_ops/register_prim_ops.cpp
+++ b/kernels/prim_ops/register_prim_ops.cpp
@@ -90,7 +90,8 @@ static Kernel prim_ops[] = {
           EValue& self = *stack[0];
           EValue& out = *stack[1];
           exec_aten::Tensor self_tensor = self.to<exec_aten::Tensor>();
-          ET_SWITCH_REAL_TYPES(
+          ET_SWITCH_REAL_TYPES_AND(
+              Bool,
               self_tensor.scalar_type(),
               context,
               "_local_scalar_dense",


### PR DESCRIPTION
### Summary
Add bool support for `_local_scalar_dense`

### Test plan
Manually tested through by running this test with kv cache enabled, which introduces `_local_scalar_dense` ops
