### PR TITLE
Figure out target-board from compile spec

### DIFF
--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -310,3 +310,14 @@ def _clean_dir(dir: Path, filter: str, num_save=10):
         for remove in sorted_files[0 : len(sorted_files) - num_save]:
             file = remove[1]
             file.unlink()
+
+
+def get_target_board(compile_spec: list[CompileSpec]) -> str | None:
+    for spec in compile_spec:
+        if spec.key == "compile_flags":
+            flags = spec.value.decode()
+            if "u55" in flags:
+                return "corstone-300"
+            elif "u85" in flags:
+                return "corstone-320"
+    return None

--- a/backends/arm/test/ops/test_add.py
+++ b/backends/arm/test/ops/test_add.py
@@ -115,6 +115,8 @@ class TestSimpleAdd(unittest.TestCase):
             .to_executorch()
             .serialize()
         )
+        if common.is_option_enabled("corstone300"):
+            tester.run_method_and_compare_outputs(qtol=1, inputs=test_data)
 
         return tester
 
@@ -131,28 +133,20 @@ class TestSimpleAdd(unittest.TestCase):
     @parameterized.expand(Add.test_parameters)
     def test_add_u55_BI(self, test_data: torch.Tensor):
         test_data = (test_data,)
-        tester = self._test_add_ethos_BI_pipeline(
+        self._test_add_ethos_BI_pipeline(
             self.Add(),
             common.get_u55_compile_spec(permute_memory_to_nhwc=True),
             test_data,
         )
-        if common.is_option_enabled("corstone300"):
-            tester.run_method_and_compare_outputs(
-                qtol=1, inputs=test_data, target_board="corstone-300"
-            )
 
     @parameterized.expand(Add.test_parameters)
     def test_add_u85_BI(self, test_data: torch.Tensor):
         test_data = (test_data,)
-        tester = self._test_add_ethos_BI_pipeline(
+        self._test_add_ethos_BI_pipeline(
             self.Add(),
             common.get_u85_compile_spec(permute_memory_to_nhwc=True),
             test_data,
         )
-        if common.is_option_enabled("corstone300"):
-            tester.run_method_and_compare_outputs(
-                qtol=1, inputs=test_data, target_board="corstone-320"
-            )
 
     @parameterized.expand(Add2.test_parameters)
     def test_add2_tosa_MI(self, operand1: torch.Tensor, operand2: torch.Tensor):
@@ -167,21 +161,13 @@ class TestSimpleAdd(unittest.TestCase):
     @parameterized.expand(Add2.test_parameters)
     def test_add2_u55_BI(self, operand1: torch.Tensor, operand2: torch.Tensor):
         test_data = (operand1, operand2)
-        tester = self._test_add_ethos_BI_pipeline(
+        self._test_add_ethos_BI_pipeline(
             self.Add2(), common.get_u55_compile_spec(), test_data
         )
-        if common.is_option_enabled("corstone300"):
-            tester.run_method_and_compare_outputs(
-                qtol=1, inputs=test_data, target_board="corstone-300"
-            )
 
     @parameterized.expand(Add2.test_parameters)
     def test_add2_u85_BI(self, operand1: torch.Tensor, operand2: torch.Tensor):
         test_data = (operand1, operand2)
-        tester = self._test_add_ethos_BI_pipeline(
+        self._test_add_ethos_BI_pipeline(
             self.Add2(), common.get_u85_compile_spec(), test_data
         )
-        if common.is_option_enabled("corstone300"):
-            tester.run_method_and_compare_outputs(
-                qtol=1, inputs=test_data, target_board="corstone-320"
-            )

--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -191,9 +191,6 @@ class RunnerUtil:
         target_board: str,
     ):
 
-        if target_board not in ["corstone-300", "corstone-320"]:
-            raise RuntimeError(f"Unknown target board: {target_board}")
-
         self.input_names = _get_input_names(edge_program)
         self.output_node = _get_output_node(exported_program)
         self.output_name = self.output_node.name
@@ -222,6 +219,8 @@ class RunnerUtil:
         assert (
             self._has_init_run
         ), "RunnerUtil needs to be initialized using init_run() before running Corstone300."
+        if self.target_board not in ["corstone-300", "corstone-320"]:
+            raise RuntimeError(f"Unknown target board: {self.target_board}")
 
         pte_path = os.path.join(self.intermediate_path, "program.pte")
         assert os.path.exists(pte_path), f"Pte path '{pte_path}' not found."

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -26,6 +26,7 @@ from executorch.backends.arm.test.common import (
     arm_test_options,
     current_time_formated,
     get_option,
+    get_target_board,
 )
 
 from executorch.backends.arm.test.runner_utils import (
@@ -267,7 +268,7 @@ class ArmTester(Tester):
         self,
         inputs: Optional[Tuple[torch.Tensor]] = None,
         stage: Optional[str] = None,
-        target_board: Optional[str] = "corstone-300",
+        target_board: Optional[str] = None,
         num_runs=1,
         atol=1e-03,
         rtol=1e-03,
@@ -300,6 +301,9 @@ class ArmTester(Tester):
         stage = stage or self.cur
         test_stage = self.stages[stage]
         is_quantized = self.stages[self.stage_name(tester.Quantize)] is not None
+
+        if target_board is None:
+            target_board = get_target_board(self.compile_spec)
 
         exported_program = self.stages[self.stage_name(tester.Export)].artifact
         edge_program = edge_stage.artifact.exported_program()


### PR DESCRIPTION
Reduces boilerplate in FVP tests


Change-Id: I7b4cdec6ba3da91e9f510830d6d817acaf18c53e
