### PR TITLE
Revert "update sccache to latest version (#6837)"

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -12,26 +12,6 @@ set -ex
 # shellcheck source=/dev/null
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
-install_ubuntu() {
-  echo "Preparing to build sccache from source"
-  apt-get update
-  # libssl-dev will not work as it is upgraded to libssl3 in Ubuntu-22.04.
-  # Instead use lib and headers from OpenSSL1.1 installed in `install_openssl.sh``
-  apt-get install -y cargo
-  echo "Checking out sccache repo"
-  git clone https://github.com/mozilla/sccache -b v0.8.2
-
-  cd sccache
-  echo "Building sccache"
-  cargo build --release
-  cp target/release/sccache /opt/cache/bin
-  echo "Cleaning up"
-  cd ..
-  rm -rf sccache
-  apt-get remove -y cargo rustc
-  apt-get autoclean && apt-get clean
-}
-
 install_binary() {
   echo "Downloading sccache binary from S3 repo"
   curl --retry 3 https://s3.amazonaws.com/ossci-linux/sccache -o /opt/cache/bin/sccache
@@ -42,33 +22,15 @@ mkdir -p /opt/cache/bin
 sed -e 's|PATH="\(.*\)"|PATH="/opt/cache/bin:\1"|g' -i /etc/environment
 export PATH="/opt/cache/bin:$PATH"
 
-install_ubuntu
+# NB: Install the pre-built binary from S3 as building from source
+# https://github.com/pytorch/sccache has started failing mysteriously
+# in which sccache server couldn't start with the following error:
+#   sccache: error: Invalid argument (os error 22)
+install_binary
 
 function write_sccache_stub() {
   BINARY=$1
-  if [ $1 == "gcc" ]; then
-    # Do not call sccache recursively when dumping preprocessor argument
-    # For some reason it's very important for the first cached nvcc invocation
-    cat >"/opt/cache/bin/$1" <<EOF
-#!/bin/sh
-if [ "\$1" = "-E" ] || [ "\$2" = "-E" ]; then
-  exec $(which $1) "\$@"
-elif [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then
-  exec sccache $(which $1) "\$@"
-else
-  exec $(which $1) "\$@"
-fi
-EOF
-  else
-    cat >"/opt/cache/bin/$1" <<EOF
-#!/bin/sh
-if [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then
-  exec sccache $(which $1) "\$@"
-else
-  exec $(which $1) "\$@"
-fi
-EOF
-  fi
+  printf "#!/bin/sh\nif [ \$(env -u LD_PRELOAD ps -p \$PPID -o comm=) != sccache ]; then\n  exec sccache %s \"\$@\"\nelse\n  exec %s \"\$@\"\nfi" "$(which "${BINARY}")" "$(which "${BINARY}")" > "/opt/cache/bin/${BINARY}"
   chmod a+x "/opt/cache/bin/${BINARY}"
 }
 
@@ -82,7 +44,7 @@ init_sccache() {
 
   # NB: This function is adopted from PyTorch core at
   # https://github.com/pytorch/pytorch/blob/main/.ci/pytorch/common-build.sh
-  as_ci_user sccache --stop-server >/dev/null 2>&1 || true
+  as_ci_user sccache --stop-server > /dev/null 2>&1 || true
   rm -f "${SCCACHE_ERROR_LOG}" || true
 
   # Clear sccache stats before using it

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -57,7 +57,6 @@ COPY ./common/utils.sh utils.sh
 RUN bash ./install_cache.sh && rm install_cache.sh utils.sh
 ENV SCCACHE_BUCKET ossci-compiler-cache-circleci-v2
 ENV SCCACHE_S3_KEY_PREFIX executorch
-ENV SCCACHE_REGION us-east-1
 
 ARG TORCH_VERSION
 COPY ./common/install_pytorch.sh install_pytorch.sh

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -1,5 +1,5 @@
 # From https://github.com/pytorch/test-infra/wiki/Using-Nova-Reusable-Build-Workflows
-# kicking build of this workflow
+# kicking build of this workflow again
 name: Build M1 Wheels
 
 on:

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -1,4 +1,5 @@
 # From https://github.com/pytorch/test-infra/wiki/Using-Nova-Reusable-Build-Workflows
+# kicking build of this workflow
 name: Build M1 Wheels
 
 on:

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -26,9 +26,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
-env:
-  AWS_DEFAULT_REGION: us-east-1
-
 jobs:
   docker-build:
     runs-on: [self-hosted, linux.2xlarge]


### PR DESCRIPTION
This reverts commit 727851945b526be32fc38a430ce8e31fd910fef6.

Nightly macos wheel builds are failing to link; seeing if this fixes
it after inspecting commits between last good build
(https://github.com/pytorch/executorch/actions/runs/11891594679) and
first bad build
(https://github.com/pytorch/executorch/actions/runs/11912200383)