### PR TITLE
Trigger wheel builds when modifying setup.py or pyproject.toml

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -4,8 +4,10 @@ name: Build Linux Wheels
 on:
   pull_request:
     paths:
-      - build/packaging/**
       - .github/workflows/build-wheels-linux.yml
+      - build/packaging/**
+      - pyproject.toml
+      - setup.py
   push:
     branches:
       - nightly

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -4,8 +4,10 @@ name: Build M1 Wheels
 on:
   pull_request:
     paths:
-      - build/packaging/**
       - .github/workflows/build-wheels-m1.yml
+      - build/packaging/**
+      - pyproject.toml
+      - setup.py
   push:
     branches:
       - nightly


### PR DESCRIPTION
These two files are the core of the wheel configs, so it makes sense to try building wheels when they change.

Sort the path entries now that the list is getting longer.
