### PR TITLE
Add HardTanh to RemovePermutesAroundElementwiseOps (#6992)

### DIFF
--- a/backends/cadence/aot/remove_ops.py
+++ b/backends/cadence/aot/remove_ops.py
@@ -561,6 +561,7 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
         exir_ops.edge.aten.mul.Tensor,
         exir_ops.edge.aten.mean.dim,
         exir_ops.edge.aten.cat.default,
+        exir_ops.edge.aten.hardtanh.default,
         exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
         exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
     }


### PR DESCRIPTION
Summary:

This diff adds `hardtanh` to the list of elementwise ops that we consider for permute elimination.

- Fixing logging issue in summary dump that results in some delegate size metrics being reported incorrectly.

Reviewed By: zonglinpeng

Differential Revision: D66187338


