### PR TITLE
Add quantize_per_channel and dequantize_per_channel to q_dq_ops target

### DIFF
--- a/kernels/quantized/targets.bzl
+++ b/kernels/quantized/targets.bzl
@@ -69,6 +69,8 @@ def define_common_targets():
                 "quantized_decomposed::dequantize_per_tensor.Tensor_out",
                 "quantized_decomposed::quantize_per_tensor.out",
                 "quantized_decomposed::quantize_per_tensor.Tensor_out",
+                "quantized_decomposed::dequantize_per_channel.out",
+                "quantized_decomposed::quantize_per_channel.out",
             ],
     )
 


### PR DESCRIPTION
Summary: These ops are needed by the Semantic flow model and also are compilable on Windows.

Differential Revision: D66400800


