### PR TITLE
[Executorch][CI] Fix qnn runner ci job scripts

### DIFF
--- a/.ci/scripts/build-qnn-sdk.sh
+++ b/.ci/scripts/build-qnn-sdk.sh
@@ -12,7 +12,12 @@ build_qnn_backend() {
   echo "Start building qnn backend."
   export ANDROID_NDK_ROOT=/opt/ndk
   export QNN_SDK_ROOT=/tmp/qnn/2.25.0.240728
-  export EXECUTORCH_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+  export EXECUTORCH_ROOT="$(python -c 'import executorch; print(executorch.__path__[0])')"
+  if [ "$EXECUTORCH_ROOT" == "" ]; then
+    echo "Failed to find where executorch package is installed."
+    echo "import executorch failed"
+    exit -1
+  fi
 
   bash backends/qualcomm/scripts/build.sh --skip_aarch64 --job_number 2 --release
 }

--- a/.ci/scripts/test_llama.sh
+++ b/.ci/scripts/test_llama.sh
@@ -107,7 +107,6 @@ if [[ "${MODE}" =~ .*qnn.* ]]; then
   export EXECUTORCH_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
   export QNN_SDK_ROOT=/tmp/qnn/2.25.0.240728
   export LD_LIBRARY_PATH="${QNN_SDK_ROOT}/lib/x86_64-linux-clang"
-  export PYTHONPATH=".."
   cp schema/program.fbs exir/_serialize/program.fbs
   cp schema/scalar_type.fbs exir/_serialize/scalar_type.fbs
   cp -f build-x86/backends/qualcomm/PyQnnManagerAdaptor.cpython-310-x86_64-linux-gnu.so backends/qualcomm/python


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #6997
* __->__ #7049
* #7038
* #6996
* #6914
* #5715
* #5670

QNN backend's AOT artifacts were being copied in the source directory instead of
them being installed, as build artifacts, in appropriate package directory.

As a result we had to use PYTHON_PATH=".." in test_llama.sh CI script when
running CI for qnn. This results in executorch having two locations as where
the package is installed. This PR fixes that.

Differential Revision: [D66406274](https://our.internmc.facebook.com/intern/diff/D66406274/)