### PR TITLE
[ET-VK] Deserialize VkGraph in ET-VK

### DIFF
--- a/backends/vulkan/serialization/vulkan_graph_serialize.py
+++ b/backends/vulkan/serialization/vulkan_graph_serialize.py
@@ -41,6 +41,8 @@ def convert_to_flatbuffer(vk_graph: VkGraph) -> bytes:
 
 
 def flatbuffer_to_vk_graph(flatbuffers: bytes) -> VkGraph:
+    # Following similar (de)serialization logic on other backends:
+    # https://github.com/pytorch/executorch/blob/main/backends/qualcomm/serialization/qc_schema_serialize.py#L33
     with tempfile.TemporaryDirectory() as d:
         schema_path = os.path.join(d, "schema.fbs")
         with open(schema_path, "wb") as schema_file:

--- a/backends/vulkan/test/test_serialization.py
+++ b/backends/vulkan/test/test_serialization.py
@@ -11,9 +11,17 @@ from typing import List
 
 import torch
 
-from executorch.backends.vulkan.serialization.vulkan_graph_schema import VkGraph
+from executorch.backends.vulkan.serialization.vulkan_graph_schema import (
+    IntList,
+    OperatorCall,
+    String,
+    VkGraph,
+    VkValue,
+)
 
 from executorch.backends.vulkan.serialization.vulkan_graph_serialize import (
+    convert_to_flatbuffer,
+    flatbuffer_to_vk_graph,
     serialize_vulkan_graph,
     VulkanDelegateHeader,
 )
@@ -93,3 +101,33 @@ class TestSerialization(unittest.TestCase):
 
             tensor_bytes = bytes(array)
             self.assertEqual(constant_data_bytes, tensor_bytes)
+
+    def test_serialize_deserialize_vkgraph(self):
+        in_vk_graph = VkGraph(
+            version="1",
+            chain=[
+                OperatorCall(node_id=1, name="foo", args=[1, 2, 3]),
+                OperatorCall(node_id=2, name="bar", args=[]),
+            ],
+            values=[
+                VkValue(
+                    value=String(
+                        string_val="abc",
+                    ),
+                ),
+                VkValue(
+                    value=IntList(
+                        items=[-1, -4, 2],
+                    ),
+                ),
+            ],
+            input_ids=[],
+            output_ids=[],
+            constants=[],
+            shaders=[],
+        )
+
+        bs = convert_to_flatbuffer(in_vk_graph)
+        out_vk_graph = flatbuffer_to_vk_graph(bs)
+
+        self.assertEqual(in_vk_graph, out_vk_graph)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #7068

Add logic to deserialize a VkGraph blob back python object. This allows us to get a implement debugging / visualization directly on the vulkan-exported program.  Still extra works need to be done: From the entire bundle, need to extract the specific vulkan delegate first.

Differential Revision: [D66443780](https://our.internmc.facebook.com/intern/diff/D66443780/)