### PR TITLE
Make inputs actually contiguously laid out in memory

### DIFF
--- a/examples/models/llama3_2_vision/text_decoder/model.py
+++ b/examples/models/llama3_2_vision/text_decoder/model.py
@@ -167,11 +167,22 @@ class Llama3_2Decoder(EagerModelBase):
     def get_example_kwarg_inputs(self):
         # For export we must use the prefill versions of the
         # causal mask and input_pos.
+
+        # Make input_pos and mask contiguous in memory.
+        input_pos = self.input_pos[None, : self.n_tokens]
+        mask = self.causal_mask[None, : self.n_tokens]
+        contiguous_input_pos = torch.empty_like(
+            input_pos, memory_format=torch.contiguous_format
+        )
+        contiguous_input_pos.data.copy_(input_pos.data)
+        contiguous_mask = torch.empty_like(mask, memory_format=torch.contiguous_format)
+        contiguous_mask.data.copy_(mask.data)
+
         # Hardcoding # of tiles to be 2. image tokens per tile is 1601.
         if self.use_kv_cache:
             return {
-                "input_pos": self.input_pos[None, : self.n_tokens],
-                "mask": self.causal_mask[None, : self.n_tokens],
+                "input_pos": contiguous_input_pos,
+                "mask": contiguous_mask,
                 "encoder_input": torch.randn(
                     1, self.encoder_max_seq_len, self.model_.dim, dtype=self.dtype
                 ),


### PR DESCRIPTION
### Summary
The previously passed in input `input_pos` and `mask` had memory layouts resulting in weird strides after slicing, even though `is_contiguous()` returned true. As an example, the mask which had a shape of [1, 32, 64] resulted in stride of [4096, 32, 1] instead of [2048, 32, 1]. This resulted in weird things happening during tracing, such as the stride and shape being represented by different symints which led to issues during `ConstraintBasedSymEvalPass`.

`clone()` and `contiguous()` didn't solve the issue, but doing it this way did.

Addresses but doesn't fix https://github.com/pytorch/pytorch/issues/141051

### Test plan
Export Llama3_2_Decoder to ExecuTorch
