### PR TITLE
Fix unpending unbacked symbols from torch.cond

### DIFF
--- a/examples/models/llama3_2_vision/text_decoder/model.py
+++ b/examples/models/llama3_2_vision/text_decoder/model.py
@@ -108,6 +108,7 @@ class Llama3_2Decoder(EagerModelBase):
             rope_base=params["rope_theta"],
             intermediate_dim=params["intermediate_dim"],
         )
+        self.model_.requires_grad_(False)
 
         # Source transformation for MultiHeadAttention
         self.model_ = replace_mha_with_inference_mha(self.model_)


### PR DESCRIPTION
### Summary
Marks the model parameters with `requires_grad = False` so that autograd is not triggered during intepreter pass through `torch.cond`, which was causing `PendingUnbackedSymbol` issues during `to_edge` by creating extra unbacked symbols that were not getting resolved against the export-created ones.

### Test plan
Export Llama3_2_Decoder to ExecuTorch with [custom attention module swap](https://github.com/pytorch/executorch/blob/main/extension/llm/modules/attention.py#L407).
