### PR TITLE
Kill all running buck2 daemon before starting MacOS jobs

### DIFF
--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -49,6 +49,9 @@ install_buck() {
 
   rm "${BUCK2}"
   popd
+
+  # Kill all running buck2 daemon for a fresh start
+  buck2 killall || true
 }
 
 function write_sccache_stub() {


### PR DESCRIPTION
I'm seeing lots of flaky buck2 showing up in trunk.  I'm not sure if this help, but this should do no harm neither