### PR TITLE
pip install reference_model and use pybind

### DIFF
--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -284,6 +284,12 @@ class ArmBackend(BackendDetails):
                 # any checking of compatibility.
                 dbg_fail(node, tosa_graph, artifact_path)
 
+        if len(input_order) > 0:
+            if input_count != len(input_order):
+                raise RuntimeError(
+                    "The rank of the input order is not equal to amount of input tensors"
+                )
+
         if artifact_path:
             tag = _get_first_delegation_tag(graph_module)
             dbg_tosa_dump(

--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -13,7 +13,7 @@
 
 import logging
 import os
-from typing import final, List, Optional
+from typing import cast, final, List, Optional
 
 import serializer.tosa_serializer as ts
 from executorch.backends.arm.arm_vela import vela_compile
@@ -32,6 +32,7 @@ from executorch.backends.arm.tosa_utils import dbg_fail, dbg_tosa_dump
 from executorch.exir.backend.backend_details import BackendDetails, PreprocessResult
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from torch.export.exported_program import ExportedProgram
+from torch.fx import Node
 
 # TOSA backend debug functionality
 logger = logging.getLogger(__name__)
@@ -269,6 +270,7 @@ class ArmBackend(BackendDetails):
         node_visitors = get_node_visitors(edge_program, tosa_spec)
         input_count = 0
         for node in graph_module.graph.nodes:
+            node = cast(Node, node)
             if node.op == "call_function":
                 process_call_function(node, tosa_graph, node_visitors, tosa_spec)
             elif node.op == "placeholder":
@@ -282,15 +284,6 @@ class ArmBackend(BackendDetails):
                 # any checking of compatibility.
                 dbg_fail(node, tosa_graph, artifact_path)
 
-        if len(input_order) > 0:
-            if input_count != len(input_order):
-                raise RuntimeError(
-                    "The rank of the input order is not equal to amount of input tensors"
-                )
-
-        # TODO: It would be awesome if this dump could somehow be done on top level and not here.
-        # Problem is that the desc.json has to be created on the tosa_graph object, which we can't
-        # access from top level.
         if artifact_path:
             tag = _get_first_delegation_tag(graph_module)
             dbg_tosa_dump(
@@ -311,6 +304,4 @@ class ArmBackend(BackendDetails):
         else:
             raise RuntimeError(f"Unknown format {output_format}")
 
-        # Continueing from above. Can I put tosa_graph into this function?
-        # debug_handle_map = ...
         return PreprocessResult(processed_bytes=binary)

--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -76,7 +76,7 @@ def get_tosa_compile_spec_unbuilt(
     if not custom_path:
         custom_path = maybe_get_tosa_collate_path()
 
-    if custom_path is not None and not os.path.exists(custom_path):
+    if custom_path is not None:
         os.makedirs(custom_path, exist_ok=True)
     compile_spec_builder = (
         ArmCompileSpecBuilder()

--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -74,19 +74,15 @@ def get_tosa_compile_spec_unbuilt(
     the compile spec before calling .build() to finalize it.
     """
     if not custom_path:
-        intermediate_path = maybe_get_tosa_collate_path() or tempfile.mkdtemp(
-            prefix="arm_tosa_"
-        )
-    else:
-        intermediate_path = custom_path
+        custom_path = maybe_get_tosa_collate_path()
 
-    if not os.path.exists(intermediate_path):
-        os.makedirs(intermediate_path, exist_ok=True)
+    if custom_path is not None and not os.path.exists(custom_path):
+        os.makedirs(custom_path, exist_ok=True)
     compile_spec_builder = (
         ArmCompileSpecBuilder()
         .tosa_compile_spec(tosa_version)
         .set_permute_memory_format(permute_memory_to_nhwc)
-        .dump_intermediate_artifacts_to(intermediate_path)
+        .dump_intermediate_artifacts_to(custom_path)
     )
 
     return compile_spec_builder

--- a/backends/arm/test/misc/test_debug_feats.py
+++ b/backends/arm/test/misc/test_debug_feats.py
@@ -111,7 +111,9 @@ class TestNumericalDiffPrints(unittest.TestCase):
                 model,
                 example_inputs=model.get_inputs(),
                 compile_spec=common.get_tosa_compile_spec(
-                    "TOSA-0.80.0+MI", permute_memory_to_nhwc=True
+                    "TOSA-0.80.0+MI",
+                    permute_memory_to_nhwc=True,
+                    custom_path=tempfile.mkdtemp("diff_print_test"),
                 ),
             )
             .export()

--- a/backends/arm/test/ops/test_cat.py
+++ b/backends/arm/test/ops/test_cat.py
@@ -124,7 +124,7 @@ class TestCat(unittest.TestCase):
     def test_cat_4d_tosa_MI(self):
         square = torch.ones((2, 2, 2, 2))
         for dim in range(-3, 3):
-            test_data = ((square, square), dim)
+            test_data = ((square, square.clone()), dim)
             self._test_cat_tosa_MI_pipeline(self.Cat(), test_data)
 
     @parameterized.expand(Cat.test_parameters)

--- a/backends/arm/test/ops/test_scalars.py
+++ b/backends/arm/test/ops/test_scalars.py
@@ -157,7 +157,7 @@ class TestScalars(unittest.TestCase):
     def test_MI(self, test_name: str, op: torch.nn.Module, x, y):
         expected_exception = None
         if any(token in test_name for token in ("Sub_int", "Sub__int")):
-            expected_exception = RuntimeError
+            expected_exception = ValueError
         elif test_name.endswith("_st"):
             expected_exception = AttributeError
 

--- a/backends/arm/test/ops/test_select.py
+++ b/backends/arm/test/ops/test_select.py
@@ -93,8 +93,6 @@ class TestSelect(unittest.TestCase):
             .check(["torch.ops.quantized_decomposed"])
             .to_edge()
             .partition()
-            .dump_artifact()
-            .dump_operator_distribution()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
             .run_method_and_compare_outputs(inputs=test_data)

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -226,7 +226,7 @@ function setup_tosa_reference_model() {
     
     # reference_model flatbuffers version clashes with Vela.
     # go with Vela's since it newer.
-    # Could cause issues down the line, beware..
+    # Vela's flatbuffer requirement is expected to loosen, then remove this. MLETORCH-565
     pip install tosa-tools@git+${tosa_reference_model_url}@${tosa_reference_model_rev} --no-dependencies flatbuffers
 
 }

--- a/setup.py
+++ b/setup.py
@@ -706,10 +706,6 @@ setup(
         "executorch/devtools/bundled_program": "devtools/bundled_program",
         "executorch/runtime": "runtime",
         "executorch/util": "util",
-        # Note: This will install a top-level module called "serializer",
-        # which seems too generic and might conflict with other pip packages.
-        "serializer": "backends/arm/third-party/serialization_lib/python/serializer",
-        "tosa": "backends/arm/third-party/serialization_lib/python/tosa",
     },
     cmdclass={
         "build": CustomBuild,


### PR DESCRIPTION
The reference model is pip installed in setup.sh.
Also install vela similarly.
Since the installation contains serialization_lib, we don't have to include it as a package
in Executorch's setup.py. The serialization_lib
is still needed as a submodule in the arm backend
to find the tosa.fbs for deserialization.

Change-Id: I24fff6c00a3961444de5d878ab169d5ba4c9156d