### PR TITLE
Migrate arm jobs to linux_job_v2 due to manywheel 2.28 migration

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -332,7 +332,7 @@ jobs:
       docker-image: executorch-ubuntu-22.04-clang12
 
   unittest-arm:
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.2xlarge
       docker-image: executorch-ubuntu-22.04-arm-sdk

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -131,7 +131,7 @@ jobs:
 
   test-arm-backend-delegation:
     name: test-arm-backend-delegation
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.2xlarge
       docker-image: executorch-ubuntu-22.04-arm-sdk
@@ -157,7 +157,7 @@ jobs:
 
   test-arm-reference-delegation:
     name: test-arm-reference-delegation
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.2xlarge
       docker-image: executorch-ubuntu-22.04-arm-sdk


### PR DESCRIPTION
PyTorch is moving to manywheel 2.28 and the new wheel can't be used on older OS.  I'm seeing failures from arm jobs starting to show up on trunk.

* https://github.com/pytorch/executorch/actions/runs/12029832291/job/33535944410
* https://github.com/pytorch/executorch/actions/runs/12029832290/job/33535941849
* https://github.com/pytorch/executorch/actions/runs/12029832290/job/33535943845

So, I follow the guide to update the job to https://github.com/pytorch/test-infra/blob/main/.github/workflows/linux_job_v2.yml.  As the migration is still in progress and some steps could be rolled back.  Let's just migrate those that are failing, not every job.