### PR TITLE
Update training module to have super class methods accessible

### DIFF
--- a/extension/training/module/training_module.h
+++ b/extension/training/module/training_module.h
@@ -26,7 +26,8 @@ namespace training {
  * A facade class for loading programs for on-device training and executing
  * methods within them.
  */
-class ET_EXPERIMENTAL TrainingModule final : executorch::extension::Module {
+class ET_EXPERIMENTAL TrainingModule final
+    : public executorch::extension::Module {
  public:
   explicit TrainingModule(
       std::unique_ptr<runtime::DataLoader> data_loader,


### PR DESCRIPTION
Summary: This is needed so the training module has access to non-training methods (e.g. constant string return methods).

Differential Revision: D66419247


