### PR TITLE
Remove offline compile resources from the production runtime target

### DIFF
--- a/backends/qualcomm/runtime/targets.bzl
+++ b/backends/qualcomm/runtime/targets.bzl
@@ -35,45 +35,49 @@ def define_common_targets():
         ],
     )
 
-    runtime.cxx_library(
-        name = "runtime",
-        srcs = glob(
-            [
-                "*.cpp",
-                "backends/*.cpp",
-                "backends/htpbackend/*.cpp",
-                "backends/htpbackend/aarch64/*.cpp",
+    # "runtime" target is used for offline compile, can be renamed to runtime_aot_build as a BE.
+    for include_aot_qnn_lib in (True, False):
+        qnn_build_suffix = ("" if include_aot_qnn_lib else "_android_build")
+        runtime.cxx_library(
+            name = "runtime" + qnn_build_suffix,
+            srcs = glob(
+                [
+                    "*.cpp",
+                    "backends/*.cpp",
+                    "backends/htpbackend/*.cpp",
+                    "backends/htpbackend/aarch64/*.cpp",
+                ],
+                exclude = ["Logging.cpp"],
+            ),
+            exported_headers = glob(
+                [
+                    "*.h",
+                    "backends/*.h",
+                    "backends/htpbackend/*.h",
+                ],
+                exclude = ["Logging.h"],
+            ),
+            define_static_target = True,
+            link_whole = True,  # needed for executorch/examples/models/llama:main to register QnnBackend
+            platforms = [ANDROID],
+            visibility = ["@EXECUTORCH_CLIENTS"],
+            resources = ({
+                "qnn_lib": "fbsource//third-party/qualcomm/qnn/qnn-{0}:qnn_offline_compile_libs".format(get_qnn_library_verision()),
+                } if include_aot_qnn_lib else {
+            }),
+            deps = [
+                "fbsource//third-party/qualcomm/qnn/qnn-{0}:api".format(get_qnn_library_verision()),
+                ":logging",
+                "//executorch/backends/qualcomm:schema",
+                "//executorch/backends/qualcomm:qc_binary_info_schema",
+                "//executorch/backends/qualcomm/aot/ir:qcir_utils",
+                "//executorch/backends/qualcomm/aot/wrappers:wrappers",
+                "//executorch/runtime/backend:interface",
+                "//executorch/runtime/core:core",
+                "//executorch/extension/tensor:tensor",
             ],
-            exclude = ["Logging.cpp"],
-        ),
-        exported_headers = glob(
-            [
-                "*.h",
-                "backends/*.h",
-                "backends/htpbackend/*.h",
+            exported_deps = [
+                "//executorch/runtime/core/exec_aten/util:scalar_type_util",
+                "//executorch/runtime/core:event_tracer",
             ],
-            exclude = ["Logging.h"],
-        ),
-        define_static_target = True,
-        link_whole = True,  # needed for executorch/examples/models/llama:main to register QnnBackend
-        platforms = [ANDROID],
-        visibility = ["@EXECUTORCH_CLIENTS"],
-        resources = {
-            "qnn_lib": "fbsource//third-party/qualcomm/qnn/qnn-{0}:qnn_offline_compile_libs".format(get_qnn_library_verision()),
-        },
-        deps = [
-            "fbsource//third-party/qualcomm/qnn/qnn-{0}:api".format(get_qnn_library_verision()),
-            ":logging",
-            "//executorch/backends/qualcomm:schema",
-            "//executorch/backends/qualcomm:qc_binary_info_schema",
-            "//executorch/backends/qualcomm/aot/ir:qcir_utils",
-            "//executorch/backends/qualcomm/aot/wrappers:wrappers",
-            "//executorch/runtime/backend:interface",
-            "//executorch/runtime/core:core",
-            "//executorch/extension/tensor:tensor",
-        ],
-        exported_deps = [
-            "//executorch/runtime/core/exec_aten/util:scalar_type_util",
-            "//executorch/runtime/core:event_tracer",
-        ],
-    )
+        )

--- a/backends/qualcomm/targets.bzl
+++ b/backends/qualcomm/targets.bzl
@@ -120,7 +120,7 @@ def define_common_targets():
             "fbsource//third-party/qualcomm/qnn/qnn-{0}:api".format(get_qnn_library_verision()),
             "//executorch/runtime/backend:interface",
             "//executorch/runtime/core:core",
-            "//executorch/backends/qualcomm/runtime:runtime",
+            "//executorch/backends/qualcomm/runtime:runtime_android_build",
         ],
         exported_deps = [
             ":schema",


### PR DESCRIPTION
Summary:
Remove offline compile resources from the production runtime target
- Including those x86 increased 50MB MWA app size: T208844791

Differential Revision: D66508062


