### PR TITLE
[ET-VK] Deserialize VkGraph in ET-VK

### DIFF
--- a/backends/vulkan/serialization/vulkan_graph_serialize.py
+++ b/backends/vulkan/serialization/vulkan_graph_serialize.py
@@ -1,6 +1,8 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #
+# pyre-strict
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
@@ -19,9 +21,9 @@ from executorch.backends.vulkan.serialization.vulkan_graph_schema import (
     VkBytes,
     VkGraph,
 )
-from executorch.exir._serialize._dataclass import _DataclassEncoder
+from executorch.exir._serialize._dataclass import _DataclassEncoder, _json_to_dataclass
 
-from executorch.exir._serialize._flatbuffer import _flatc_compile
+from executorch.exir._serialize._flatbuffer import _flatc_compile, _flatc_decompile
 
 
 def convert_to_flatbuffer(vk_graph: VkGraph) -> bytes:
@@ -38,6 +40,25 @@ def convert_to_flatbuffer(vk_graph: VkGraph) -> bytes:
         output_path = os.path.join(d, "schema.bin")
         with open(output_path, "rb") as output_file:
             return output_file.read()
+
+
+def flatbuffer_to_vk_graph(flatbuffers: bytes) -> VkGraph:
+    # Following similar (de)serialization logic on other backends:
+    # https://github.com/pytorch/executorch/blob/main/backends/qualcomm/serialization/qc_schema_serialize.py#L33
+    with tempfile.TemporaryDirectory() as d:
+        schema_path = os.path.join(d, "schema.fbs")
+        with open(schema_path, "wb") as schema_file:
+            schema_file.write(pkg_resources.resource_string(__name__, "schema.fbs"))
+
+        bin_path = os.path.join(d, "schema.bin")
+        with open(bin_path, "wb") as bin_file:
+            bin_file.write(flatbuffers)
+
+        _flatc_decompile(d, schema_path, bin_path, ["--raw-binary"])
+
+        json_path = os.path.join(d, "schema.json")
+        with open(json_path, "rb") as output_file:
+            return _json_to_dataclass(json.load(output_file), VkGraph)
 
 
 @dataclass


### PR DESCRIPTION
Pull Request resolved: https://github.com/pytorch/executorch/pull/7068

Add logic to deserialize a VkGraph blob back python object. This allows us to get a implement debugging / visualization directly on the vulkan-exported program.  Still extra works need to be done: From the entire bundle, need to extract the specific vulkan delegate first.

Differential Revision: [D66443780](https://our.internmc.facebook.com/intern/diff/D66443780/)