### PR TITLE
[Reland] Skip building Apple demo app on fork PRs

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -42,6 +42,8 @@ jobs:
 
   build-demo-ios:
     name: build-demo-ios
+    # NB: Don't run this on fork PRs because they won't have access to the secret and would fail anyway
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     secrets: inherit
     with:
@@ -190,6 +192,8 @@ jobs:
         ) done
 
   upload-frameworks-ios:
+    # NB: Don't run this on fork PRs because they won't have access to the secret and would fail anyway
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-22.04
     needs: [build-frameworks-ios, set-version]
     timeout-minutes: 30
@@ -278,6 +282,8 @@ jobs:
 
   build-benchmark-app:
     name: build-benchmark-app
+    # NB: Don't run this on fork PRs because they won't have access to the secret and would fail anyway
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -351,6 +351,8 @@ jobs:
         done
 
   test-huggingface-transformers:
+    # NB: Don't run this on fork PRs because they won't have access to the secret and would fail anyway
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     name: test-huggingface-transformers
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     secrets: inherit


### PR DESCRIPTION
Relanding https://github.com/pytorch/executorch/pull/6865 as it has been reverted by https://github.com/pytorch/executorch/pull/6868 probably due to a land race.

As pointed out by @swolchok in https://github.com/pytorch/executorch/pull/6538#issuecomment-2501958309, I also include `test-huggingface-transformers` here as it looks simple enough.  Different cases, same root cause about missing secrets on forks.