### PR TITLE
Fix shared library rpath once for all

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -682,6 +682,22 @@ if(EXECUTORCH_BUILD_PTHREADPOOL
 endif()
 
 if(EXECUTORCH_BUILD_PYBIND)
+  # Setup RPATH.
+  # See https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+  if(APPLE)
+    set(CMAKE_MACOSX_RPATH ON)
+    set(_rpath_portable_origin "@loader_path")
+  else()
+    set(_rpath_portable_origin $ORIGIN)
+  endif(APPLE)
+  # Use separate rpaths during build and install phases
+  set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+  # Don't use the install-rpath during the build phase
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+  set(CMAKE_INSTALL_RPATH "${_rpath_portable_origin}")
+  # Automatically add all linked folders that are NOT in the build directory to
+  # the rpath (per library?)
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/pybind11)
 
   if(NOT EXECUTORCH_BUILD_EXTENSION_DATA_LOADER)
@@ -765,46 +781,6 @@ if(EXECUTORCH_BUILD_PYBIND)
   target_include_directories(portable_lib PRIVATE ${TORCH_INCLUDE_DIRS})
   target_compile_options(portable_lib PUBLIC ${_pybind_compile_options})
   target_link_libraries(portable_lib PRIVATE ${_dep_libs})
-  if(APPLE)
-    # pip wheels will need to be able to find the torch libraries. On Linux, the
-    # .so has non-absolute dependencies on libs like "libtorch.so" without
-    # paths; as long as we `import torch` first, those dependencies will work.
-    # But Apple dylibs do not support non-absolute dependencies, so we need to
-    # tell the loader where to look for its libraries. The LC_LOAD_DYLIB entries
-    # for the torch libraries will look like "@rpath/libtorch.dylib", so we can
-    # add an LC_RPATH entry to look in a directory relative to the installed
-    # location of our _portable_lib.so file. To see these LC_* values, run
-    # `otool -l _portable_lib*.so`.
-    set_target_properties(
-      portable_lib
-      PROPERTIES # Assume that this library will be installed in
-                 # `site-packages/executorch/extension/pybindings`, and that
-                 # the torch libs are in `site-packages/torch/lib`.
-                 BUILD_RPATH "@loader_path/../../../torch/lib"
-                 INSTALL_RPATH "@loader_path/../../../torch/lib"
-                 # Assume <executorch> is the root `site-packages/executorch`
-                 # Need to add <executorch>/extension/llm/custom_ops for
-                 # libcustom_ops_aot_lib.dylib
-                 BUILD_RPATH "@loader_path/../../extension/llm/custom_ops"
-                 INSTALL_RPATH "@loader_path/../../extension/llm/custom_ops"
-                 # Need to add <executorch>/kernels/quantized for
-                 # libquantized_ops_aot_lib.dylib
-                 BUILD_RPATH "@loader_path/../../kernels/quantized"
-                 INSTALL_RPATH "@loader_path/../../kernels/quantized"
-    )
-  else()
-    set_target_properties(
-      portable_lib
-      PROPERTIES
-        # Assume <executorch> is the root `site-packages/executorch`
-        # Need to add <executorch>/extension/llm/custom_ops for
-        # libcustom_ops_aot_lib
-        # Need to add <executorch>/kernels/quantized for
-        # libquantized_ops_aot_lib
-        BUILD_RPATH
-        "$ORIGIN:$ORIGIN/../../extension/llm/custom_ops:$ORIGIN/../../kernels/quantized"
-    )
-  endif()
 
   install(TARGETS portable_lib
           LIBRARY DESTINATION executorch/extension/pybindings

--- a/extension/llm/custom_ops/CMakeLists.txt
+++ b/extension/llm/custom_ops/CMakeLists.txt
@@ -109,26 +109,5 @@ if(EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT)
            ${_common_compile_options} -DET_USE_THREADPOOL
   )
 
-  # pip wheels will need to be able to find the dependent libraries. On Linux,
-  # the .so has non-absolute dependencies on libs like "_portable_lib.so"
-  # without paths; as long as we `import torch` first, those dependencies will
-  # work. But Apple dylibs do not support non-absolute dependencies, so we need
-  # to tell the loader where to look for its libraries. The LC_LOAD_DYLIB
-  # entries for the portable_lib libraries will look like
-  # "@rpath/_portable_lib.cpython-310-darwin.so", so we can add an LC_RPATH
-  # entry to look in a directory relative to the installed location of our
-  # _portable_lib.so file. To see these LC_* values, run `otool -l
-  # libcustom_ops_aot_lib.dylib`.
-  if(APPLE)
-    set_target_properties(
-      custom_ops_aot_lib
-      PROPERTIES # Assume this library will be installed in
-                 # <site-packages>/executorch/extension/llm/custom_ops/, and the
-                 # _portable_lib.so is installed in
-                 # <site-packages>/executorch/extension/pybindings/
-                 BUILD_RPATH "@loader_path/../../pybindings"
-                 INSTALL_RPATH "@loader_path/../../pybindings"
-    )
-  endif()
   install(TARGETS custom_ops_aot_lib DESTINATION lib)
 endif()


### PR DESCRIPTION
Summary: 
Fixes #7086
Based on this wiki:

https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling

Takeaway of reading this doc:

* Set `CMAKE_BUILD_WITH_INSTALL_RPATH` to False so that we don't add install path (`pip-out`, `cmake-out`) into RPATH.
* Set `CMAKE_INSTALL_RPATH` to be able to refer to libraries in the same install directory if any.
* Set `CMAKE_INSTALL_RPATH_USE_LINK_PATH` to True so that we include other so files outside of the build tree can be added to RPATH.

Test Plan:

Tested on Colab:

```
!mkdir et; cd et; git clone https://github.com/pytorch/executorch.git
!cd et/executorch; git submodule update --init

# need to modify Codegen.cmake to make the following working
!cd et/executorch; bash install_requirements.sh
!cd et/executorch; CMAKE_INSTALL_PREFIX=/usr/local/lib/python3.10/dist-packages python setup.py bdist_wheel
```
Reviewers:

Subscribers:

Tasks:

Tags:

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
