### PR TITLE
Back out "use ovrsource libtorch in executorch"

### DIFF
--- a/extension/pytree/aten_util/targets.bzl
+++ b/extension/pytree/aten_util/targets.bzl
@@ -20,7 +20,13 @@ def define_common_targets():
             "//executorch/runtime/platform:platform",
         ],
         compiler_flags = ["-Wno-missing-prototypes"],
-        external_deps = [
-            "torch-core-cpp",
+        fbcode_deps = [
+            "//caffe2:ATen-core",
+            "//caffe2:ATen-cpu",
+            "//caffe2/c10:c10",
+        ],
+        xplat_deps = [
+            "//xplat/caffe2:torch_mobile_core",
+            "//xplat/caffe2/c10:c10",
         ],
     )


### PR DESCRIPTION
Summary: This is causing linker errors internally.

Differential Revision: D66570005


