### PR TITLE
Exclude upsample_bilinear2d.vec from default core ATen decomposition table (#141791)

### DIFF
--- a/backends/xnnpack/_passes/__init__.py
+++ b/backends/xnnpack/_passes/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 from typing import List, Optional, Type
 
 from executorch.backends.xnnpack._passes.channels_last_tagged_reshape_pass import (
@@ -14,9 +16,6 @@ from executorch.backends.xnnpack._passes.conv1d_unsqueeze_pass import (
 )
 from executorch.backends.xnnpack._passes.convert_to_linear import ConvertToLinearPass
 from executorch.backends.xnnpack._passes.convert_to_sdpa import ConvertToSDPAPass
-from executorch.backends.xnnpack._passes.convert_to_upsample_bilinear2d import (
-    ConvertToUpsampleBilinear2d,
-)
 from executorch.backends.xnnpack._passes.fuse_activation_pass import FuseActivationPass
 from executorch.backends.xnnpack._passes.fuse_batch_norm_with_conv import (
     FuseBatchNormWithConvPass,
@@ -57,7 +56,6 @@ class XNNPACKPassManager:
             self.passes = [
                 # TODO - remove this pass once we have a better support for dim_order ops lowering
                 DimOrderOpsRevertPass,
-                ConvertToUpsampleBilinear2d,
                 ConvertToLinearPass,
                 ConvertToSDPAPass,
                 ConstPropPass,


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/141791

Differential Revision: D66575454


