### PR TITLE
Check the total dim size of output tensors in ArmBackend

### DIFF
--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -172,11 +172,21 @@ class SoftmaxModule(torch.nn.Module):
     can_delegate = False
 
 
+class MultipleOutputsModule(torch.nn.Module):
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor):
+        return (x * y, x.sum(dim=-1, keepdim=True))
+
+    example_input = (torch.randn(10, 4, 5), torch.randn(10, 4, 5))
+    can_delegate = True
+
+
 models = {
     "add": AddModule,
     "add2": AddModule2,
     "add3": AddModule3,
     "softmax": SoftmaxModule,
+    "MultipleOutputsModule": MultipleOutputsModule,
 }
 
 calibration_data = {


### PR DESCRIPTION
### Summary

* Update ArmBackend to calculate the total amount of dimensions for the output tensors
* Adding multiple output sample model to arm_aot_compiler

