### PR TITLE
Fix XNN partitioning dynamic upsample with constant scales

### DIFF
--- a/backends/xnnpack/partition/config/generic_node_configs.py
+++ b/backends/xnnpack/partition/config/generic_node_configs.py
@@ -303,6 +303,21 @@ class MaxPool2dConfig(GenericNodePartitionerConfig):
 class UpsampleBilinear2dConfig(GenericNodePartitionerConfig):
     target_name = "upsample_bilinear2d.vec"
 
+    def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
+        """
+        XNNPACK's static_resize_bilinear does not support dynamic output sizes
+        """
+        if not self.check_common_constraints(node, ep):
+            return False
+
+        is_output_dynamic = "val" in node.meta and any(
+            isinstance(d, torch.SymInt) for d in node.meta["val"].shape
+        )
+        if is_output_dynamic:
+            why(node, reason="dynamic output sizes are not supported")
+            return False
+        return True
+
     def supported_precision_types(self) -> List[ConfigPrecisionType]:
         return [ConfigPrecisionType.FP32]
 


### PR DESCRIPTION
Summary:
The XNNPACK library only supports bilinear upsampling with static output sizes. The partitioner will not partition upsample ops with an explicit dynamic output_size arg, but will attempt to partition dynamic upsample ops that take constant scale_factor args (upsample takes either an explicit output size or a scale arg). It will fail attempting to serialize a symint value:
```
Non serializable type SymInt found at type XNNGraph.<list>xnodes[1].<XNNStaticResizeBilinear2D>xnode_union.<SymInt>new_height
```

This change adds a constraint to the partitioner node config for upsample bilinear2d to prevent partitioning nodes that have symbolic size outputs, which handles this case.

Differential Revision: D66611750


