### PR TITLE
Don't apply path rewriting rules for //executorch_models

### DIFF
--- a/shim/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim/xplat/executorch/build/runtime_wrapper.bzl
@@ -59,7 +59,7 @@ def _patch_executorch_references(targets, use_static_deps = False):
         return targets
     out_targets = []
     for target in targets:
-        if target.startswith("//xplat/executorch"):
+        if target.startswith("//xplat/executorch/") or target.startswith("//xplat/executorch:"):
             fail("References to executorch build targets must use " +
                  "`//executorch`, not `//xplat/executorch`")
 


### PR DESCRIPTION
Summary: ExecuTorch buck targets have rules to avoid explicit //xplat/executorch references. Due to the way this works, it is also blocking references to //xplat/executorch_models, but does not properly rewrite paths for this case. This change updates the //executorch check to //executorch/ or //executorch:, allowing the executorch_models deps to be used.

Differential Revision: D66685959


