### PR TITLE
Correct the build for the ninja generator

### DIFF
--- a/devtools/CMakeLists.txt
+++ b/devtools/CMakeLists.txt
@@ -166,7 +166,7 @@ add_custom_command(
     ${_flatcc_source_dir}/bin/flatcc -cwr -o
     ${_program_schema__include_dir}/executorch/devtools/etdump
     ${_etdump_schema__srcs}
-  COMMAND rm -f ${_etdump_schema_cleanup_paths}
+  COMMAND rm -rf ${_etdump_schema_cleanup_paths}
   DEPENDS ${_etdump_schema_gen_dep}
   COMMENT "Generating etdump headers"
 )


### PR DESCRIPTION
### Summary

The devtools build fails when run with ninja multi-config generator. 

The problem comes from the generated command that contains `rm -f` for the bid dir that in case of using ninja generator will contain several directories

```
FAILED: devtools/include/executorch/devtools/etdump/etdump_schema_flatcc_reader.h devtools/include/executorch/devtools/etdump/etdump_schema_flatcc_builder.h devtools/include/executorch/devtools/etdump/scalar_type_reader.h devtools/include/executorch/devtools/etdump/scalar_type_builder.h /Volumes/workplace/sample-project/build/default/devtools/include/executorch/devtools/etdump/etdump_schema_flatcc_reader.h /Volumes/workplace/sample-project/build/default/devtools/include/executorch/devtools/etdump/etdump_schema_flatcc_builder.h /Volumes/workplace/sample-project/build/default/devtools/include/executorch/devtools/etdump/scalar_type_reader.h /Volumes/workplace/sample-project/build/default/devtools/include/executorch/devtools/etdump/scalar_type_builder.h
cd /Volumes/workplace/sample-project/build/default/vendor/executorch/devtools && /Volumes/workplace/sample-project/vendor/executorch/devtools/../third-party/flatcc/bin/flatcc -cwr -o /Volumes/workplace/sample-project/build/default/devtools/include/executorch/devtools/etdump /Volumes/workplace/sample-project/vendor/executorch/devtools/etdump/etdump_schema_flatcc.fbs /Volumes/workplace/sample-project/vendor/executorch/devtools/etdump/scalar_type.fbs && rm -f /Volumes/workplace/sample-project/vendor/executorch/devtools/../third-party/flatcc/bin/* /Volumes/workplace/sample-project/vendor/executorch/devtools/../third-party/flatcc/lib/*

rm: /Volumes/workplace/sample-project/vendor/executorch/devtools/../third-party/flatcc/bin/Debug: is a directory
rm: /Volumes/workplace/sample-project/vendor/executorch/devtools/../third-party/flatcc/bin/RelWithDebInfo: is a directory
rm: /Volumes/workplace/sample-project/vendor/executorch/devtools/../third-party/flatcc/bin/Release: is a directory
rm: /Volumes/workplace/sample-project/vendor/executorch/devtools/../third-party/flatcc/lib/Debug: is a directory
rm: /Volumes/workplace/sample-project/vendor/executorch/devtools/../third-party/flatcc/lib/RelWithDebInfo: is a directory
rm: /Volumes/workplace/sample-project/vendor/executorch/devtools/../third-party/flatcc/lib/Release: is a directory
```

Note the lines
```
rm: /Volumes/workplace/sample-project/vendor/executorch/devtools/../third-party/flatcc/bin/Debug: is a directory
```

### Test plan

The CI will show the compatibility with the existing cmake intergations.

The way to check it works for ninja
```
cmake -S . -B build -G "Ninja Multi-Config" -DEXECUTORCH_BUILD_DEVTOOLS=ON 
cmake --build build --config Release
```



