### PR TITLE
Arm backend : Back Ethos-U Vela compiler to working version

### DIFF
--- a/backends/arm/test/ops/test_depthwise_conv.py
+++ b/backends/arm/test/ops/test_depthwise_conv.py
@@ -260,7 +260,6 @@ class TestDepthwiseConv(unittest.TestCase):
     )  # Works
 
     @parameterized.expand(testsuite_conv2d, skip_on_empty=True)
-    @unittest.expectedFailure
     def test_dw_conv2d_u55_BI(
         self, test_name: str, model: torch.nn.Module, set_quantize_io: bool = False
     ):

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -273,7 +273,7 @@ def get_compile_spec(
                 target,
                 system_config="Ethos_U55_High_End_Embedded",
                 memory_mode="Shared_Sram",
-                extra_flags="--debug-force-regor --output-format=raw --verbose-operators --verbose-cycle-estimate",
+                extra_flags="--debug-force-regor --output-format=raw",
             )
             .set_permute_memory_format(True)
             .set_quantize_io(True)
@@ -286,7 +286,7 @@ def get_compile_spec(
                 target,
                 system_config="Ethos_U85_SYS_DRAM_Mid",
                 memory_mode="Shared_Sram",
-                extra_flags="--output-format=raw --verbose-operators --verbose-cycle-estimate",
+                extra_flags="--output-format=raw",
             )
             .set_permute_memory_format(True)
             .set_quantize_io(True)

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -92,7 +92,7 @@ tosa_reference_model_rev="f9ea4ab7da19318fe36b1c34d68a3e40fd6e56c5"
 
 # vela
 vela_repo_url="https://review.mlplatform.org/ml/ethos-u/ethos-u-vela"
-vela_rev="a08fc18780827b5fefc814dd0162ee6317ce0ae7"
+vela_rev="49d0ae16bafd1db0fcb6790f12b7f249acf1974d"
 
 ########
 ### Mandatory user args


### PR DESCRIPTION
Latest Ethos-U Vela compiler version 4.1.0 unfortunately generates output size/shapes not matching the expected output. Moving the version back to a working version until this is investigated/fixed.

