### PR TITLE
Handle existing directory when extracting benchmark result

### DIFF
--- a/.github/scripts/extract_benchmark_results.py
+++ b/.github/scripts/extract_benchmark_results.py
@@ -451,7 +451,7 @@ def main() -> None:
             continue
 
         output_dir = os.path.join(args.output_dir, schema)
-        os.mkdir(output_dir)
+        os.makedirs(output_dir, exist_ok=True)
 
         output_file = os.path.basename(args.artifacts)
         with open(f"{output_dir}/{output_file}", "w") as f:


### PR DESCRIPTION
I made a mistake in https://github.com/pytorch/executorch/pull/7117 and didn't handle the case where the output directory already exists.  This happens when there are multiple models to test and the upload job handles all of them in one go, for example https://github.com/pytorch/executorch/actions/runs/12151259880/job/33888145249#step:7:55

### Testing

https://github.com/pytorch/executorch/actions/runs/12155146995 with 2 models running in parallel to confirm that an existing output directory is handled correctly.