### PR TITLE
Add switch for android arvr mode

### DIFF
--- a/extension/pytree/aten_util/targets.bzl
+++ b/extension/pytree/aten_util/targets.bzl
@@ -20,13 +20,7 @@ def define_common_targets():
             "//executorch/runtime/platform:platform",
         ],
         compiler_flags = ["-Wno-missing-prototypes"],
-        fbcode_deps = [
-            "//caffe2:ATen-core",
-            "//caffe2:ATen-cpu",
-            "//caffe2/c10:c10",
-        ],
-        xplat_deps = [
-            "//xplat/caffe2:torch_mobile_core",
-            "//xplat/caffe2/c10:c10",
+        external_deps = [
+            "torch-core-cpp",
         ],
     )


### PR DESCRIPTION
Summary:
In ARVR repo Linux/Windows etc. targets generally tend to use torch deps that are appended with `ovrsource` whereas mobile targets don't use them.

In order to avoid multiple symbol definitions we add another level of platform specification called `ARVR_ANDROID` which will allow us to specify a dep for ARVR Android build modes.

Reviewed By: larryliu0820

Differential Revision: D66737951


