### PR TITLE
Arm backend: Fix bug in ConvertExpandCopyToRepeatPass

### DIFF
--- a/backends/arm/_passes/convert_expand_copy_to_repeat.py
+++ b/backends/arm/_passes/convert_expand_copy_to_repeat.py
@@ -36,9 +36,11 @@ class ConvertExpandCopyToRepeatPass(ExportPass):
         ]
 
         # To convert expand arg to repeat arg, non-repeated dims should have
-        # multiples[dim] = 1.
+        # multiples[dim] = 1. Passing -1 to expand arg means
+        # not changing the size of that dimension.
         multiples = [
-            multiples[i] if extended_shape[i] == 1 else 1 for i in range(expanded_rank)
+            multiples[i] if multiples[i] != -1 and extended_shape[i] == 1 else 1
+            for i in range(expanded_rank)
         ]
         return super().call_operator(
             op=self.repeat, args=(args[0], multiples), kwargs=kwargs, meta=meta

--- a/backends/arm/test/ops/test_expand.py
+++ b/backends/arm/test/ops/test_expand.py
@@ -36,6 +36,7 @@ class TestSimpleExpand(unittest.TestCase):
             (torch.ones(1, 1, 2, 2), (4, 3, -1, 2)),
             (torch.ones(1), (2, 2, 4)),
             (torch.ones(3, 2, 4, 1), (-1, -1, -1, 3)),
+            (torch.ones(1, 1, 192), (1, -1, -1)),
         ]
 
         def forward(self, x: torch.Tensor, multiples: Sequence):


### PR DESCRIPTION
In the ConvertExpandCopyToRepeatPass the arguments for the repeat operation are formed incorrectly. For the [torch.Tensor.expand](https://pytorch.org/docs/stable/generated/torch.Tensor.expand.html) operation passing -1 as the size for a dimension means that the size of that dimension does not change. For the [DeiT-tiny](https://huggingface.co/facebook/deit-tiny-patch16-224) case, torch.ones(1, 1, 192).expand(1, -1, -1) the pass will prepare arguments to the repeat operation as [1, -1, 1] which will cause an error, in this case the arguments should be [1, 1, 1].
