### PR TITLE
Add util function in etdump to get debug buffer size

### DIFF
--- a/devtools/etdump/etdump_flatcc.cpp
+++ b/devtools/etdump/etdump_flatcc.cpp
@@ -635,5 +635,9 @@ bool ETDumpGen::is_static_etdump() {
   return alloc_.data != nullptr;
 }
 
+size_t ETDumpGen::get_debug_buffer_size() const {
+  return debug_buffer_.size();
+}
+
 } // namespace etdump
 } // namespace executorch

--- a/devtools/etdump/etdump_flatcc.h
+++ b/devtools/etdump/etdump_flatcc.h
@@ -138,6 +138,7 @@ class ETDumpGen : public ::executorch::runtime::EventTracer {
       const double& output) override;
   void set_debug_buffer(::executorch::runtime::Span<uint8_t> buffer);
   ETDumpResult get_etdump_data();
+  size_t get_debug_buffer_size() const;
   size_t get_num_blocks();
   bool is_static_etdump();
   void reset();


### PR DESCRIPTION
Summary: Add util function `get_debug_buffer_size` in `ETDumpGen` to get debug buffer size in backend execution.

Differential Revision: D66855639


