### PR TITLE
Remove args to aoti_compile_and_package

### DIFF
--- a/examples/models/llama3_2_vision/text_decoder/test/test_text_decoder.py
+++ b/examples/models/llama3_2_vision/text_decoder/test/test_text_decoder.py
@@ -74,8 +74,6 @@ class TextDecoderTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = torch._inductor.aoti_compile_and_package(
                 ep,
-                model.get_example_inputs(),
-                kwargs=model.get_example_kwarg_inputs(),
                 package_path=os.path.join(tmpdir, "text_decoder.pt2"),
             )
             encoder_aoti = torch._inductor.aoti_load_package(path)

--- a/examples/models/llama3_2_vision/vision_encoder/test/test_vision_encoder.py
+++ b/examples/models/llama3_2_vision/vision_encoder/test/test_vision_encoder.py
@@ -36,7 +36,6 @@ class FlamingoVisionEncoderTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = torch._inductor.aoti_compile_and_package(
                 ep,
-                model.get_example_inputs(),
                 package_path=os.path.join(tmpdir, "vision_encoder.pt2"),
             )
             print(path)

--- a/extension/llm/modules/test/test_position_embeddings.py
+++ b/extension/llm/modules/test/test_position_embeddings.py
@@ -177,7 +177,6 @@ class TiledTokenPositionalEmbeddingTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = torch._inductor.aoti_compile_and_package(
                 tpe_ep,
-                (self.x, self.aspect_ratio),
                 package_path=os.path.join(tmpdir, "tpe.pt2"),
             )
             tpe_aoti = load_package(path)


### PR DESCRIPTION
Summary: The args were removed in https://github.com/pytorch/pytorch/pull/140991

Differential Revision: D66907029


