### PR TITLE
[llava] Enable "--xnnpack-extended-ops" option in the CI

### DIFF
--- a/examples/models/llava/export_llava.py
+++ b/examples/models/llava/export_llava.py
@@ -95,7 +95,7 @@ def export_text_model(llava, embeddings, dynamic_shapes):
     dtype_override = DType.fp32
     parser = build_args_parser()
     args = parser.parse_args(
-        ["-X", "-qmode", "8da4w", "--group_size", "128", "--embedding-quantize", "4,32"]
+        ["-X", "--xnnpack-extended-ops", "-qmode", "8da4w", "--group_size", "128", "--embedding-quantize", "4,32"]
     )
     quant_transform = get_quant_weight_transform(args, dtype_override, False)
     _, quantizers, _ = get_quantizer_and_quant_params(args)


### PR DESCRIPTION
### Summary
Add this option in CI to make sure we don't break it.

### Test plan
CI job for LLava
