### PR TITLE
[dim order] reenbale dim order as default

### DIFF
--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -122,6 +122,7 @@ class TestBackends(unittest.TestCase):
 
             edge_program = to_edge_transform_and_lower(
                 program,
+                compile_config=self._edge_compile_config,
                 transform_passes=[
                     I64toI32(self._edge_compile_config._skip_dim_order),
                 ],

--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -45,8 +45,7 @@ class EdgeCompileConfig:
     )
     _skip_type_promotion: bool = False
     # TODO(gasoonjia): remove this
-    # TODO(T192537614): reenanle dim order as default
-    _skip_dim_order: bool = True
+    _skip_dim_order: bool = False
 
 
 @compatibility(is_backward_compatible=False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #7252

This diff reenable dim order as default feature in ExecuTorch stack.

Differential Revision: [D66970153](https://our.internmc.facebook.com/intern/diff/D66970153/)