### PR TITLE
Remove unused pyre ignores

### DIFF
--- a/devtools/bundled_program/core.py
+++ b/devtools/bundled_program/core.py
@@ -204,9 +204,6 @@ class BundledProgram:
             core_schema.Bool: bool,
             core_schema.Double: float,
         }
-        # pyre-fixme[6]: Incompatible parameter type [6]: In call `dict.__getitem__`, for 1st positional only parameter
-        # expected `Type[Union[core_schema.Bool, core_schema.Double, core_schema.Int]]` but got `Type[Union[core_schema.Bool, core_schema.Double, core_schema.Int, core_schema.Tensor, BoolList, DoubleList,
-        # IntList, Null, OptionalTensorList, String, TensorList]]`.
         return type_lookup[type(self._get_program_input(program, plan_idx, input_idx))]
 
     def _get_output_dtype(

--- a/devtools/inspector/_inspector.py
+++ b/devtools/inspector/_inspector.py
@@ -939,13 +939,13 @@ class EventBlock:
 
             # delegate_debug_id can be either int based or string based, therefore we need to check both
             debug_handles = delegate_metadata_delegate_map.get(
-                delegate_debug_id  # pyre-ignore
+                delegate_debug_id
             )
             if debug_handles is not None:
                 event.debug_handles = debug_handles
             else:
                 event.debug_handles = delegate_metadata_delegate_map.get(
-                    str(delegate_debug_id)  # pyre-ignore
+                    str(delegate_debug_id)
                 )
                 for key, value in delegate_metadata_delegate_map.items():
                     if key in str(delegate_debug_id):

--- a/devtools/inspector/tests/event_blocks_test.py
+++ b/devtools/inspector/tests/event_blocks_test.py
@@ -647,7 +647,7 @@ class TestEventBlock(unittest.TestCase):
                 self.assertEqual(event.delegate_backend_name, metadata["name"])
                 self.assertEqual(
                     event.debug_handles,
-                    metadata["delegate_map"][delegate_debug_identifier],  # pyre-ignore
+                    metadata["delegate_map"][delegate_debug_identifier],
                 )
             else:
                 # Non Delegated

--- a/exir/memory_planning.py
+++ b/exir/memory_planning.py
@@ -586,8 +586,6 @@ def greedy(
         for mem_id in shared_objects:
             input_total_size = 0
             if bufsizes := getattr(graph_module, "input_mem_buffer_sizes", None):
-                # pyre-fixme[6]: For 1st argument expected
-                #  `pyre_extensions.ReadOnly[Sized]` but got `Union[Tensor, Module]`.
                 if len(bufsizes) > mem_id:
                     # pyre-fixme[29]: `Union[BoundMethod[typing.Callable(torch._C.Ten...
                     input_total_size = bufsizes[mem_id]


### PR DESCRIPTION
Summary: Removes pyre error suppressions that are no longer needed after a pyre-extensions upgrade.

Reviewed By: stroxler

Differential Revision: D66401217


