### PR TITLE
Remove to_copy reference in the test

### DIFF
--- a/backends/arm/test/ops/test_to_copy.py
+++ b/backends/arm/test/ops/test_to_copy.py
@@ -56,7 +56,6 @@ class TestToCopy(unittest.TestCase):
             )
             .export()
             .dump_artifact()
-            .check_count({"torch.ops.aten._to_copy.default": 1})
             .to_edge()
             .dump_artifact()
             .partition()


### PR DESCRIPTION
Summary: Export is switching to non functional training IR, as a result, we will capture aten.to at a little higher level. This diff makes it so that we don't check for wrong aten.to here. We can't replace it with the correct op because OSS is still running on old IR and being blocked by some other test failures. But i guess that is ok because to_edge still works to get the right delegate op.

Differential Revision: D67055703


