### PR TITLE
Support to init BundledProgram from pte file

### DIFF
--- a/devtools/bundled_program/core.py
+++ b/devtools/bundled_program/core.py
@@ -9,6 +9,7 @@ import typing
 from typing import Dict, List, Optional, Sequence, Type, Union
 
 import executorch.devtools.bundled_program.schema as bp_schema
+from pyre_extensions import none_throws
 
 import executorch.exir.schema as core_schema
 
@@ -19,7 +20,7 @@ from executorch.devtools.bundled_program.config import ConfigValue, MethodTestSu
 from executorch.devtools.bundled_program.version import BUNDLED_PROGRAM_SCHEMA_VERSION
 
 from executorch.exir import ExecutorchProgram, ExecutorchProgramManager
-from executorch.exir._serialize import _serialize_pte_binary
+from executorch.exir._serialize import _deserialize_pte_binary, _serialize_pte_binary
 from executorch.exir.tensor import get_scalar_type, scalar_type_enum, TensorSpec
 
 # pyre-ignore
@@ -43,23 +44,35 @@ class BundledProgram:
 
     def __init__(
         self,
-        executorch_program: Union[
+        executorch_program: Optional[Union[
             ExecutorchProgram,
             ExecutorchProgramManager,
-        ],
+        ]],
         method_test_suites: Sequence[MethodTestSuite],
+        pte_file_path: Optional[str] = None,
     ):
         """Create BundledProgram by bundling the given program and method_test_suites together.
 
         Args:
             executorch_program: The program to be bundled.
             method_test_suites: The testcases for certain methods to be bundled.
+            pte_file_path: The path to pte file to deserialize program if executorch_program is not provided.
         """
+        if not executorch_program and not pte_file_path:
+            raise RuntimeError("Either executorch_program or pte_file_path must be provided")
+
+        if executorch_program and pte_file_path:
+            raise RuntimeError("Only one of executorch_program or pte_file_path can be used")
 
         method_test_suites = sorted(method_test_suites, key=lambda x: x.method_name)
-        self._assert_valid_bundle(executorch_program, method_test_suites)
+        if executorch_program:
+            self._assert_valid_bundle(executorch_program, method_test_suites)
+        self.executorch_program: Optional[Union[
+            ExecutorchProgram,
+            ExecutorchProgramManager,
+        ]] = executorch_program
+        self._pte_file_path: Optional[str] = pte_file_path
 
-        self.executorch_program = executorch_program
         self.method_test_suites = method_test_suites
 
         # This is the cache for bundled program in schema type.
@@ -72,7 +85,13 @@ class BundledProgram:
         if self._bundled_program_in_schema is not None:
             return self._bundled_program_in_schema
 
-        program = self._extract_program(self.executorch_program)
+        if self.executorch_program:
+            program = self._extract_program(self.executorch_program)
+        else:
+            with open(none_throws(self._pte_file_path), "rb") as f:
+                p_bytes = f.read()
+            program = _deserialize_pte_binary(p_bytes)
+
         bundled_method_test_suites: List[bp_schema.BundledMethodTestSuite] = []
 
         # Emit data and metadata of bundled tensor


### PR DESCRIPTION
Summary: Added an optional `pte_file_path` arg to BundledProgram's init function. This is to allow users to create bundled program with varied inputs after exporting.

Differential Revision: D67013542


