### PR TITLE
Arm backend: Explicitly convert quantized value to int64

### DIFF
--- a/backends/arm/tosa_quant_utils.py
+++ b/backends/arm/tosa_quant_utils.py
@@ -71,7 +71,7 @@ def quantize_value(x, qargs: QuantArgs, dtype=np.int8):
 
 
 def dequantize_value(qx, qargs: QuantArgs):
-    return (qx - qargs.zp) * qargs.scale
+    return (np.int64(qx) - qargs.zp) * qargs.scale
 
 
 def qargs_from_qnode(node: torch.fx.Node):


### PR DESCRIPTION
Previously, dequantizing a value with dequantize_value() in backends/arm/tosa_quant_utils.py could result in integer overflow when using numpy 2.1.3. The offending part of the formula is `qx - qargs.zp`. If the subtraction results in a value outside of the range of the dtype of `qx` the following warning is printed:

"RuntimeWarning: overflow encountered in scalar subtract"

With numpy 1.21.3 the dtype is implicitly convert to a dtype that can store the correct value. However, in numpy 2.1.3 there's no such conversion, leading the function to return an incorrect value.

Here's a concrete example:

```
import numpy as np

a = np.int8(127)
b = -128

print(a-b)

```

Numpy 1.21.3: a - b = 255
Numpy 2.1.3: a - b = -1

To remedy this, explicitly convert qx to int64.

Signed-off-by: Sebastian Larsson <sebastian.larsson@arm.com>