### PR TITLE
[Not for landing] coreml llama model

### DIFF
--- a/backends/apple/coreml/compiler/coreml_preprocess.py
+++ b/backends/apple/coreml/compiler/coreml_preprocess.py
@@ -449,5 +449,8 @@ class CoreMLBackend(BackendDetails):
                 op_type_configs={"gather": None},
             )
             mlmodel = cto.coreml.linear_quantize_weights(mlmodel, config=config)
+        
+        print("MIL program:")
+        print(mlmodel._mil_program)
 
         return CoreMLBackend.preprocess_model(mlmodel, model_type=model_type)

--- a/combine_coreml_models.py
+++ b/combine_coreml_models.py
@@ -1,0 +1,48 @@
+import coremltools as ct
+import argparse
+
+
+if __name__ == "__main__":
+    """
+    Combines two CoreML models together
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-m1",
+        "--model1_path",
+        type=str,
+        help="Model1 path.",
+    )
+    parser.add_argument(
+        "-m2",
+        "--model2_path",
+        type=str,
+        help="Model2 path.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output_path",
+        type=str,
+        help="Output path to save combined model",
+    )
+
+    args = parser.parse_args()
+    model1_path = str(args.model1_path)
+    model2_path = str(args.model2_path)
+    output_path = str(args.output_path)
+
+
+    desc = ct.utils.MultiFunctionDescriptor()
+
+    desc.add_function(
+        model1_path,
+        src_function_name="main",
+        target_function_name="model1"
+    )
+    desc.add_function(
+        model2_path,
+        src_function_name="main",
+        target_function_name="model2"
+    )
+    desc.default_function_name = "model1"
+    ct.utils.save_multifunction(desc, output_path)

--- a/examples/apple/coreml/scripts/extract_coreml_models.py
+++ b/examples/apple/coreml/scripts/extract_coreml_models.py
@@ -23,7 +23,7 @@ from executorch.exir.schema import (
 )
 
 
-def extract_coreml_models(pte_data: bytes):
+def extract_coreml_models(pte_data: bytes, output_dir: str = "."):
     program = deserialize_pte_binary(pte_data)
     delegates: List[BackendDelegate] = sum(
         [execution_plan.delegates for execution_plan in program.execution_plan], []
@@ -45,7 +45,7 @@ def extract_coreml_models(pte_data: bytes):
                 AssertionError("The loaded Program must have inline data.")
 
         model_name: str = f"model_{model_index}"
-        model_path: Path = Path() / "extracted_coreml_models" / model_name
+        model_path: Path = Path() / output_dir / "extracted_coreml_models" / model_name
         if model_path.exists():
             shutil.rmtree(model_path.absolute())
         os.makedirs(model_path.absolute())
@@ -72,9 +72,15 @@ if __name__ == "__main__":
         required=True,
         help="Input must be a .pte file.",
     )
+    parser.add_argument(
+        "-o",
+        "--output_dir",
+        default=".",
+        help="Output directory to save the extracted Core ML models.",
+    )
 
     args = parser.parse_args()
     model_path = str(args.model_path)
     with open(model_path, mode="rb") as pte_file:
         pte_data = pte_file.read()
-        extract_coreml_models(pte_data)
+        extract_coreml_models(pte_data, args.output_dir)

--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -353,8 +353,8 @@ def build_args_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--coreml-quantize",
         default=None,
-        choices=["b4w"],
-        help="This option is only for coreml: Use coreml quantization, e.g. b4w (for blockwise 4 bit weight)",
+        choices=["b4w", "c4w"],
+        help="This option is only for coreml: Use coreml quantization, e.g. b4w (for blockwise 4 bit weight), c4w (for channelwise 4 bit weight)",
     )
     parser.add_argument(
         "--coreml-ios",

--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -230,6 +230,18 @@ def build_args_parser() -> argparse.ArgumentParser:
         help="Whether or not to export a model using kv cache",
     )
     parser.add_argument(
+        "--prefill_return_kv",
+        default=False,
+        action="store_true",
+        help="Whether or not to return kv values from prefill model",
+    )
+    parser.add_argument(
+        "--prefill_seq_length",
+        default=False,
+        action="store_true",
+        help="Sequence length for prefill model",
+    )
+    parser.add_argument(
         "--quantize_kv_cache",
         default=False,
         action="store_true",

--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -364,6 +364,13 @@ def build_args_parser() -> argparse.ArgumentParser:
         help="This option is only for coreml: The minimum iOS version to deploy",
     )
     parser.add_argument(
+        "--coreml-compute-units",
+        type=str,
+        default="cpu_only",
+        choices=("cpu_only", "cpu_and_gpu", "cpu_and_ne", "all"),
+        help="This option is only for coreml: the compute units to use when running the model",
+    )
+    parser.add_argument(
         "--qnn",
         action="store_true",
         help="Delegate llama2 to qnn backend (Qualcomm), please use it --kv_cahce=True",
@@ -703,6 +710,7 @@ def _export_llama(args) -> LLMEdgeManager:  # noqa: C901
             args.embedding_quantize,
             args.pt2e_quantize,
             args.coreml_quantize,
+            args.coreml_compute_units,
         )
         partitioners.append(coreml_partitioner)
         modelname = f"coreml_{modelname}"

--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -22,7 +22,7 @@ from typing import Callable, List, Optional, Union
 import pkg_resources
 import torch
 
-from executorch.devtools.etrecord import generate_etrecord
+
 
 from executorch.extension.llm.export.builder import DType, LLMEdgeManager
 
@@ -237,8 +237,8 @@ def build_args_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--prefill_seq_length",
-        default=False,
-        action="store_true",
+        type=int,
+        default=32,
         help="Sequence length for prefill model",
     )
     parser.add_argument(
@@ -781,6 +781,7 @@ def _export_llama(args) -> LLMEdgeManager:  # noqa: C901
         logging.info(f"--> {partitioner.__class__.__name__}")
 
     if args.generate_etrecord:
+        from executorch.devtools.etrecord import generate_etrecord
         if not builder_exported_to_edge.edge_manager:
             raise ValueError("Unable to generate etrecord due to missing edge manager.")
 

--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -230,6 +230,18 @@ def build_args_parser() -> argparse.ArgumentParser:
         help="Whether or not to export a model using kv cache",
     )
     parser.add_argument(
+        "--decode_kv_cache_as_io",
+        default=False,
+        action="store_true",
+        help="Whether decode models accepts KV cache as IO",
+    )
+    parser.add_argument(
+        "--use_additive_kv_cache_update",
+        default=False,
+        action="store_true",
+        help="Whether use additive KV cache updates",
+    )
+    parser.add_argument(
         "--prefill_return_kv",
         default=False,
         action="store_true",

--- a/examples/models/llama/llama_transformer.py
+++ b/examples/models/llama/llama_transformer.py
@@ -479,6 +479,37 @@ class Attention(nn.Module):
                 v = v_cache + v_update
                 assert k.shape == k_cache.shape
                 assert v.shape == v_cache.shape
+
+
+                # # Attempt 1 to use torch.cat:
+                # # This fails to lower to ET during to_executorch due to a dynamo error related to the
+                # # delegate call.  We can talk to compiler about this, but the bigger issue is although
+                # # the CoreML mlpackage lowers, it fails at runtime on CPU/ANE with "input data broken / unsupported
+                # # model (model code -7)".  It does run on GPU.
+                # # I suspect it is related to the data-dependent / dynamic shape of k, v, and mask
+
+                # buffer = 2 # needed to make dynamo happy
+                # input_pos_item = input_pos[0].item()
+                # torch._check_is_size(input_pos_item)
+                # torch._check(input_pos_item + seqlen <= self.max_seq_len - buffer)
+                # mask = torch.narrow(mask, dim=3, start=0, length=input_pos_item + seqlen)
+                
+                # k = torch.cat([torch.narrow(k_cache, dim=2, start=0, length=input_pos_item), k], axis=2)
+                # v = torch.cat([torch.narrow(v_cache, dim=2, start=0, length=input_pos_item), v], axis=2)
+
+
+                # # Attempt 2 to use torch.cat
+                # # Dynamo fails with "expand: attempting to expand a dimension of length u0 + 1024!"
+                # # I'm not confident this variant will work in CoreML if we can export it, though.
+                # buffer = 2
+                # input_pos_item = input_pos[0].item()
+                # torch._check_is_size(input_pos_item)
+                # torch._check(input_pos_item + seqlen <= self.max_seq_len - buffer)
+                
+                # k = torch.cat([torch.narrow(k_cache, dim=2, start=0, length=input_pos_item), k], axis=2)
+                # k = k.expand(k_cache.size())
+                # v = torch.cat([torch.narrow(v_cache, dim=2, start=0, length=input_pos_item), v], axis=2)
+                # v = v.expand(v_cache.size())
             else:
                 k = torch.ops.aten.index_put(k_cache, [None, None, input_pos, None], k)
                 v = torch.ops.aten.index_put(v_cache, [None, None, input_pos, None], v)

--- a/examples/models/llama/model.py
+++ b/examples/models/llama/model.py
@@ -273,7 +273,7 @@ the checkpoint format to avoid generating faulty models.
         else:
             return (
                 torch.tensor(
-                    [[1, 2, 3]], dtype=torch.long
+                    [[0 for _ in range(self.args.get("prefill_seq_length", 3))]], dtype=torch.long
                 ),  # tokens, with kv cache our input token length is always just 1 token.
             )
 

--- a/examples/models/llama/model.py
+++ b/examples/models/llama/model.py
@@ -53,6 +53,8 @@ class Llama2Model(EagerModelBase):
         self.output_prune_map_path = kwargs.get("output_prune_map_path", None)
         self.max_seq_len = kwargs.get("max_seq_len", 128)
         self.args = kwargs.get("args", None)
+        self.prefill_seq_length = self.args.prefill_seq_length
+        self.prefill_return_kv = self.args.prefill_return_kv
 
         # The example is using a dummy small model with random weights for demo purpose only.
         # Follow the instruction in https://github.com/facebookresearch/llama to download the model.
@@ -143,6 +145,7 @@ the checkpoint format to avoid generating faulty models.
             input_prune_map=input_prune_map,
             output_prune_map=output_prune_map,
             enable_dynamic_shape=self.enable_dynamic_shape,
+            prefill_return_kv=self.prefill_return_kv,
             **params,
         )
 
@@ -273,7 +276,7 @@ the checkpoint format to avoid generating faulty models.
         else:
             return (
                 torch.tensor(
-                    [[0 for _ in range(self.args.get("prefill_seq_length", 3))]], dtype=torch.long
+                    [[0 for _ in range(self.prefill_seq_length)]], dtype=torch.long
                 ),  # tokens, with kv cache our input token length is always just 1 token.
             )
 

--- a/extension/benchmark/apple/Benchmark/Tests/CoreMLTests.mm
+++ b/extension/benchmark/apple/Benchmark/Tests/CoreMLTests.mm
@@ -11,42 +11,42 @@
 #import <CoreML/CoreML.h>
 
 static MLMultiArray *DummyMultiArrayForFeature(MLFeatureDescription *feature, NSError **error) {
-  MLMultiArray *array = [[MLMultiArray alloc] initWithShape:feature.multiArrayConstraint.shape
-                                                   dataType:feature.multiArrayConstraint.dataType == MLMultiArrayDataTypeInt32 ? MLMultiArrayDataTypeInt32 : MLMultiArrayDataTypeDouble
-                                                      error:error];
-  for (auto index = 0; index < array.count; ++index) {
-    array[index] = feature.multiArrayConstraint.dataType == MLMultiArrayDataTypeInt32 ? @1 : @1.0;
-  }
-  return array;
+    MLMultiArray *array = [[MLMultiArray alloc] initWithShape:feature.multiArrayConstraint.shape
+                                                     dataType:feature.multiArrayConstraint.dataType == MLMultiArrayDataTypeInt32 ? MLMultiArrayDataTypeInt32 : MLMultiArrayDataTypeDouble
+                                                        error:error];
+    for (auto index = 0; index < array.count; ++index) {
+        array[index] = feature.multiArrayConstraint.dataType == MLMultiArrayDataTypeInt32 ? @1 : @1.0;
+    }
+    return array;
 }
 
 static NSMutableDictionary *DummyInputsForModel(MLModel *model, NSError **error) {
-  NSMutableDictionary *inputs = [NSMutableDictionary dictionary];
-  NSDictionary<NSString *, MLFeatureDescription *> *inputDescriptions = model.modelDescription.inputDescriptionsByName;
+    NSMutableDictionary *inputs = [NSMutableDictionary dictionary];
+    NSDictionary<NSString *, MLFeatureDescription *> *inputDescriptions = model.modelDescription.inputDescriptionsByName;
 
-  for (NSString *inputName in inputDescriptions) {
-    MLFeatureDescription *feature = inputDescriptions[inputName];
+    for (NSString *inputName in inputDescriptions) {
+        MLFeatureDescription *feature = inputDescriptions[inputName];
 
-    switch (feature.type) {
-      case MLFeatureTypeMultiArray: {
-        MLMultiArray *array = DummyMultiArrayForFeature(feature, error);
-        inputs[inputName] = [MLFeatureValue featureValueWithMultiArray:array];
-        break;
-      }
-      case MLFeatureTypeInt64:
-        inputs[inputName] = [MLFeatureValue featureValueWithInt64:1];
-        break;
-      case MLFeatureTypeDouble:
-        inputs[inputName] = [MLFeatureValue featureValueWithDouble:1.0];
-        break;
-      case MLFeatureTypeString:
-        inputs[inputName] = [MLFeatureValue featureValueWithString:@"1"];
-        break;
-      default:
-        break;
+        switch (feature.type) {
+            case MLFeatureTypeMultiArray: {
+                MLMultiArray *array = DummyMultiArrayForFeature(feature, error);
+                inputs[inputName] = [MLFeatureValue featureValueWithMultiArray:array];
+                break;
+            }
+            case MLFeatureTypeInt64:
+                inputs[inputName] = [MLFeatureValue featureValueWithInt64:1];
+                break;
+            case MLFeatureTypeDouble:
+                inputs[inputName] = [MLFeatureValue featureValueWithDouble:1.0];
+                break;
+            case MLFeatureTypeString:
+                inputs[inputName] = [MLFeatureValue featureValueWithString:@"1"];
+                break;
+            default:
+                break;
+        }
     }
-  }
-  return inputs;
+    return inputs;
 }
 
 @interface CoreMLTests : ResourceTestCase
@@ -55,51 +55,93 @@ static NSMutableDictionary *DummyInputsForModel(MLModel *model, NSError **error)
 @implementation CoreMLTests
 
 + (NSArray<NSString *> *)directories {
-  return @[@"Resources"];
+    return @[@"Resources"];
 }
 
 + (NSDictionary<NSString *, BOOL (^)(NSString *)> *)predicates {
-  return @{ @"model" : ^BOOL(NSString *filename) {
-    return [filename hasSuffix:@".mlpackage"];
-  }};
+    return @{ @"model" : ^BOOL(NSString *filename) {
+        return [filename hasSuffix:@"combined.mlpackage"];
+    }};
 }
 
 + (NSDictionary<NSString *, void (^)(XCTestCase *)> *)dynamicTestsForResources:(NSDictionary<NSString *, NSString *> *)resources {
-  NSString *modelPath = resources[@"model"];
+    NSString *modelPath = resources[@"model"];
 
-  return @{
-    @"prediction" : ^(XCTestCase *testCase) {
-      NSError *error = nil;
-      NSURL *compiledModelURL = [MLModel compileModelAtURL:[NSURL fileURLWithPath:modelPath] error:&error];
-      if (error || !compiledModelURL) {
-        XCTFail(@"Failed to compile model: %@", error.localizedDescription);
-        return;
-      }
-      MLModel *model = [MLModel modelWithContentsOfURL:compiledModelURL error:&error];
-      if (error || !model) {
-        XCTFail(@"Failed to load model: %@", error.localizedDescription);
-        return;
-      }
-      NSMutableDictionary *inputs = DummyInputsForModel(model, &error);
-      if (error || !inputs) {
-        XCTFail(@"Failed to prepare inputs: %@", error.localizedDescription);
-        return;
-      }
-      MLDictionaryFeatureProvider *featureProvider = [[MLDictionaryFeatureProvider alloc] initWithDictionary:inputs error:&error];
-      if (error || !featureProvider) {
-        XCTFail(@"Failed to create input provider: %@", error.localizedDescription);
-        return;
-      }
-      [testCase measureWithMetrics:@[[XCTClockMetric new], [XCTMemoryMetric new]]
-                             block:^{
-        NSError *error = nil;
-        id<MLFeatureProvider> prediction = [model predictionFromFeatures:featureProvider error:&error];
-        if (error || !prediction) {
-          XCTFail(@"Prediction failed: %@", error.localizedDescription);
+    return @{
+        @"prediction" : ^(XCTestCase *testCase) {
+
+            NSError *error = nil;
+            NSURL *compiledModelURL = [MLModel compileModelAtURL:[NSURL fileURLWithPath:modelPath] error:&error];
+            if (error || !compiledModelURL) {
+                XCTFail(@"Failed to compile model: %@", error.localizedDescription);
+                return;
+            }
+
+            // Model1
+            MLModelConfiguration *config = [[MLModelConfiguration alloc] init];
+            config.computeUnits = MLComputeUnitsCPUAndNeuralEngine;
+            config.functionName = @"model1";
+            MLModel *model = [MLModel modelWithContentsOfURL:compiledModelURL configuration:config error:&error];
+            if (error || !model) {
+                XCTFail(@"Failed to load model: %@", error.localizedDescription);
+                return;
+            }
+            NSMutableDictionary *inputs = DummyInputsForModel(model, &error);
+            if (error || !inputs) {
+                XCTFail(@"Failed to prepare inputs: %@", error.localizedDescription);
+                return;
+            }
+            MLDictionaryFeatureProvider *featureProvider = [[MLDictionaryFeatureProvider alloc] initWithDictionary:inputs error:&error];
+            if (error || !featureProvider) {
+                XCTFail(@"Failed to create input provider: %@", error.localizedDescription);
+                return;
+            }
+
+
+            // Model2
+            MLModelConfiguration *config2 = [[MLModelConfiguration alloc] init];
+            config2.computeUnits = MLComputeUnitsCPUOnly;
+            config2.functionName = @"model2";
+            MLModel *model2 = [MLModel modelWithContentsOfURL:compiledModelURL configuration:config2 error:&error];
+            if (error || !model2) {
+                XCTFail(@"Failed to load model: %@", error.localizedDescription);
+                return;
+            }
+            NSMutableDictionary *inputs2 = DummyInputsForModel(model2, &error);
+            if (error || !inputs2) {
+                XCTFail(@"Failed to prepare inputs: %@", error.localizedDescription);
+                return;
+            }
+            MLDictionaryFeatureProvider *featureProvider2 = [[MLDictionaryFeatureProvider alloc] initWithDictionary:inputs2 error:&error];
+            if (error || !featureProvider) {
+                XCTFail(@"Failed to create input provider: %@", error.localizedDescription);
+                return;
+            }
+
+
+            MLState *state = [model2 newState];
+            [testCase measureWithMetrics:@[[XCTClockMetric new], [XCTMemoryMetric new]]
+                                   block:^{
+                NSError *error = nil;
+
+                // Prefill
+                id<MLFeatureProvider> prediction;
+                prediction = [model predictionFromFeatures:featureProvider error:&error];
+                if (error) {
+                    XCTFail(@"Prediction failed: %@", error.localizedDescription);
+                }
+
+                // Decode
+                id<MLFeatureProvider> prediction2;
+                for (int i = 0; i < 128; i++) {
+                    prediction2 = [model2 predictionFromFeatures:featureProvider2 usingState:state error:&error];
+                    if (error) {
+                        XCTFail(@"Prediction failed: %@", error.localizedDescription);
+                    }
+                }
+            }];
         }
-      }];
-    }
-  };
+    };
 }
 
 @end

--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -160,8 +160,11 @@ class LLMEdgeManager:
         dim = torch.export.Dim("token_dim", max=self.max_seq_len - 1)
 
         if not self.use_kv_cache:
-            # Only one input argument: tokens
-            self.dynamic_shapes = ({1: dim},)
+            if not self.enable_dynamic_shape:
+                self.dynamic_shapes = None
+            else:
+                # Only one input argument: tokens
+                self.dynamic_shapes = ({1: dim},)
         elif self.enable_dynamic_shape:
             # Two input arguments: tokens and input_pos but input_pos is static shape
             self.dynamic_shapes = ({1: dim}, {0: 1})

--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -201,6 +201,7 @@ class LLMEdgeManager:
                 logging.info(f"inputs: {self.example_inputs}")
                 logging.info(f"kwargs: {self.example_kwarg_inputs}")
                 logging.info(f"dynamic shapes: {dynamic_shape}")
+                print("EVALUATED", self.model(*self.example_inputs))
                 exported_module = export_for_training(
                     self.model,
                     self.example_inputs,

--- a/extension/llm/export/partitioner_lib.py
+++ b/extension/llm/export/partitioner_lib.py
@@ -152,7 +152,7 @@ def get_coreml_partitioner(
     compile_specs = CoreMLBackend.generate_compile_specs(  # pyre-fixme[16]
         minimum_deployment_target=minimum_deployment_target,
         compute_precision=ct.precision(ct.precision.FLOAT16.value),
-        compute_units=coreml_compute_units,
+        compute_unit=coreml_compute_units,
         model_type=CoreMLBackend.MODEL_TYPE.MODEL,  # pyre-fixme[16]
         op_linear_quantizer_config=op_linear_quantizer_config,
     )

--- a/extension/llm/export/partitioner_lib.py
+++ b/extension/llm/export/partitioner_lib.py
@@ -69,6 +69,7 @@ def get_coreml_partitioner(
     embedding_quantize: Optional[str] = None,
     pt2e_quantize: Optional[str] = None,
     coreml_quantize: Optional[str] = None,
+    coreml_compute_units: Optional[str] = None,
 ):
     try:
         import coremltools as ct
@@ -119,6 +120,19 @@ def get_coreml_partitioner(
         17: ct.target.iOS17,
         18: ct.target.iOS18,
     }[ios]
+
+    if coreml_compute_units is None:
+        # using `ComputeUnit.ALL` can increase the model load time
+        # On iPhone 15 Pro, CPU decode model is over 8x faster than GPU for stories110M,
+        # so default to CPU_ONLY
+        coreml_compute_units = "cpu_only"
+    coreml_compute_units = {
+        "cpu_only": ct.ComputeUnit.CPU_ONLY,
+        "cpu_and_ne": ct.ComputeUnit.CPU_AND_NE,
+        "cpu_and_gpu": ct.ComputeUnit.CPU_AND_GPU,
+        "all": ct.ComputeUnit.ALL,
+    }[coreml_compute_units.lower()]
+
     op_linear_quantizer_config = None
     if coreml_quantize == "b4w":
         op_linear_quantizer_config = {
@@ -128,17 +142,22 @@ def get_coreml_partitioner(
             "block_size": 32,
             "weight_threshold": 512,
         }
+    elif coreml_quantize == "c4w":
+        op_linear_quantizer_config = {
+            "mode": "linear_symmetric",
+            "dtype": "int4",
+            "granularity": "per_channel",
+        }
+
     compile_specs = CoreMLBackend.generate_compile_specs(  # pyre-fixme[16]
         minimum_deployment_target=minimum_deployment_target,
         compute_precision=ct.precision(ct.precision.FLOAT16.value),
-        # using `ComputeUnit.ALL` can increase the model load time, default to `ComputeUnit.CPU_AND_GPU`
-        compute_unit=ct.ComputeUnit[ct.ComputeUnit.CPU_AND_GPU.name.upper()],
+        compute_units=coreml_compute_units,
         model_type=CoreMLBackend.MODEL_TYPE.MODEL,  # pyre-fixme[16]
         op_linear_quantizer_config=op_linear_quantizer_config,
     )
 
     take_over_mutable_buffer = minimum_deployment_target >= ct.target.iOS18
-
     return CoreMLPartitioner(  # pyre-fixme[16]
         compile_specs=compile_specs,
         take_over_mutable_buffer=take_over_mutable_buffer,

--- a/model_export_script.sh
+++ b/model_export_script.sh
@@ -1,0 +1,18 @@
+set -e
+
+export MODEL_IN=$HOME/models/stories110M/stories110M.pt
+export TOKENIZER=$HOME/models/stories110M/tokenizer.bin
+export PARAMS=$HOME/models/stories110M/params.json
+export MODEL_OUT_DIR=$HOME/models/stories110M
+export MODEL_OUT_PREFILL=$MODEL_OUT_DIR/prefill_model.pte
+export MODEL_OUT_DECODE=$MODEL_OUT_DIR/decode_model.pte
+
+python -m examples.models.llama.export_llama -c $MODEL_IN -p $PARAMS --output_name=$MODEL_OUT_PREFILL -E "4,32" --prefill_seq_length 512 --disable_dynamic_shape --coreml --coreml-ios 18 --coreml-quantize c4w --coreml-compute-units cpu_only --max_seq_length 1024 --prefill_return_kv --dtype fp16
+
+python -m examples.models.llama.export_llama -c $MODEL_IN -p $PARAMS --output_name=$MODEL_OUT_DECODE -E "4,32" -kv --disable_dynamic_shape --coreml --coreml-ios 18 --coreml-quantize c4w --coreml-compute-units cpu_only --max_seq_length 1024
+
+
+python examples/apple/coreml/scripts/extract_coreml_models.py -m $MODEL_OUT_PREFILL -o "${MODEL_OUT_DIR}/prefill"
+python examples/apple/coreml/scripts/extract_coreml_models.py -m $MODEL_OUT_DECODE -o "${MODEL_OUT_DIR}/decode"
+
+python combine_coreml_models.py -m1 "${MODEL_OUT_DIR}/prefill/extracted_coreml_models/model_1/lowered_module/model.mlpackage" -m2 "${MODEL_OUT_DIR}/decode/extracted_coreml_models/model_1/lowered_module/model.mlpackage" -o "${MODEL_OUT_DIR}/combined.mlpackage"

--- a/model_export_script.sh
+++ b/model_export_script.sh
@@ -6,13 +6,19 @@ export PARAMS=$HOME/models/stories110M/params.json
 export MODEL_OUT_DIR=$HOME/models/stories110M
 export MODEL_OUT_PREFILL=$MODEL_OUT_DIR/prefill_model.pte
 export MODEL_OUT_DECODE=$MODEL_OUT_DIR/decode_model.pte
+export MODEL_OUT_DECODE_KV_IO=$MODEL_OUT_DIR/decode_kv_io_model.pte
+export MODEL_OUT_DECODE_KV_IO_ADDITIVE=$MODEL_OUT_DIR/decode_kv_io_additive_model.pte
 
-python -m examples.models.llama.export_llama -c $MODEL_IN -p $PARAMS --output_name=$MODEL_OUT_PREFILL -E "4,32" --prefill_seq_length 512 --disable_dynamic_shape --coreml --coreml-ios 18 --coreml-quantize c4w --coreml-compute-units cpu_only --max_seq_length 1024 --prefill_return_kv --dtype fp16
 
-python -m examples.models.llama.export_llama -c $MODEL_IN -p $PARAMS --output_name=$MODEL_OUT_DECODE -E "4,32" -kv --disable_dynamic_shape --coreml --coreml-ios 18 --coreml-quantize c4w --coreml-compute-units cpu_only --max_seq_length 1024
+python -m examples.models.llama.export_llama -c $MODEL_IN -p $PARAMS --output_name=$MODEL_OUT_PREFILL -E "4,32" --prefill_seq_length 512 --disable_dynamic_shape --coreml --coreml-ios 18 --coreml-quantize c4w --coreml-compute-units cpu_and_ne --max_seq_length 1024 --prefill_return_kv --dtype fp16
+python -m examples.models.llama.export_llama -c $MODEL_IN -p $PARAMS --output_name=$MODEL_OUT_DECODE -E "4,32" -kv --disable_dynamic_shape --coreml --coreml-ios 18 --coreml-quantize c4w --coreml-compute-units cpu_and_ne --max_seq_length 1024
+python -m examples.models.llama.export_llama -c $MODEL_IN -p $PARAMS --output_name=$MODEL_OUT_DECODE_KV_IO -E "4,32" -kv --disable_dynamic_shape --coreml --coreml-ios 18 --coreml-quantize c4w --coreml-compute-units cpu_and_ne --max_seq_length 1024 --decode_kv_cache_as_io --dtype fp16
+python -m examples.models.llama.export_llama -c $MODEL_IN -p $PARAMS --output_name=$MODEL_OUT_DECODE_KV_IO_ADDITIVE -E "4,32" -kv --disable_dynamic_shape --coreml --coreml-ios 18 --coreml-quantize c4w --coreml-compute-units cpu_and_ne --max_seq_length 1024 --decode_kv_cache_as_io --use_additive_kv_cache_update --dtype fp16
 
 
 python examples/apple/coreml/scripts/extract_coreml_models.py -m $MODEL_OUT_PREFILL -o "${MODEL_OUT_DIR}/prefill"
 python examples/apple/coreml/scripts/extract_coreml_models.py -m $MODEL_OUT_DECODE -o "${MODEL_OUT_DIR}/decode"
+python examples/apple/coreml/scripts/extract_coreml_models.py -m $MODEL_OUT_DECODE_KV_IO -o "${MODEL_OUT_DIR}/decode_kv_io"
+python examples/apple/coreml/scripts/extract_coreml_models.py -m $MODEL_OUT_DECODE_KV_IO_ADDITIVE -o "${MODEL_OUT_DIR}/decode_kv_io_additive"
 
 python combine_coreml_models.py -m1 "${MODEL_OUT_DIR}/prefill/extracted_coreml_models/model_1/lowered_module/model.mlpackage" -m2 "${MODEL_OUT_DIR}/decode/extracted_coreml_models/model_1/lowered_module/model.mlpackage" -o "${MODEL_OUT_DIR}/combined.mlpackage"


### PR DESCRIPTION
Checkout this branch, install executorch, and then run model_export_script.sh to export a combined prefill/decode model using CoreML.

Before running model_export_script.sh, edit the defined paths:
```
export MODEL_IN=$HOME/models/stories110M/stories110M.pt
export TOKENIZER=$HOME/models/stories110M/tokenizer.bin
export PARAMS=$HOME/models/stories110M/params.json
export MODEL_OUT_DIR=$HOME/models/stories110M
export MODEL_OUT_PREFILL=$MODEL_OUT_DIR/prefill_model.pte
export MODEL_OUT_DECODE=$MODEL_OUT_DIR/decode_model.pte
```

You can also modify the examples.models.llama.export_llama commands in the script to control the prefill/decode models.  By default, the prefill model will use sequence length 512 and return the computed KV-values.

The decode model will use KV-cache as a state and decode 1 token at a time.

Both models quantize embeddings and weights to 4 bits.

The script will output pte files:
* $MODEL_OUT_PREFILL
* $MODEL_OUT_DECODE

It will also extract the mlpackage files from the pte files at the locations:
* ${MODEL_OUT_DIR}/prefill
* ${MODEL_OUT_DIR}/decode

It will also output a combined (weight shared model) here:
* ${MODEL_OUT_DIR}/combined.mlpackage

In the combined model, model1 is prefill and model2 is decode.