### PR TITLE
Fix name of const tensors in const_prop_pass.py

### DIFF
--- a/exir/tests/TARGETS
+++ b/exir/tests/TARGETS
@@ -221,6 +221,7 @@ python_unittest(
         "//executorch/exir/passes:sym_to_tensor_pass",
         "//executorch/exir/program:program",
         "//executorch/extension/pybindings:portable_lib",  # @manual
+        "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
     ],
 )
 


### PR DESCRIPTION
Summary:
After XNNPack delegation, for llama predictor, some const tensors in the exported program are eliminated, e.g., c__prop_tensor_constant32 in P1688172607. 
If we run constant_prop_pass after this point, the const tensor naming logic in the implementation is incorrect, and could create redefinition of const tensors (error in P1687944413). 

This diff fixes the naming logic of const tensors in the pass.

Differential Revision: D66568874


