### PR TITLE
Refer "./install_requirements.sh --clean" in documents

### DIFF
--- a/backends/vulkan/docs/android_demo.md
+++ b/backends/vulkan/docs/android_demo.md
@@ -81,7 +81,8 @@ First, build and install ExecuTorch libraries, then build the LLaMA runner
 binary using the Android NDK toolchain.
 
 ```shell
-(rm -rf cmake-android-out && \
+./install_requirements.sh --clean
+(mkdir cmake-android-out && \
   cmake . -DCMAKE_INSTALL_PREFIX=cmake-android-out \
     -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
     -DANDROID_ABI=$ANDROID_ABI \

--- a/backends/xnnpack/README.md
+++ b/backends/xnnpack/README.md
@@ -98,7 +98,7 @@ After exporting the XNNPACK Delegated model, we can now try running it with exam
 cd executorch
 
 # Get a clean cmake-out directory
-rm -rf cmake-out
+./install_requirements.sh --clean
 mkdir cmake-out
 
 # Configure cmake

--- a/docs/source/build-run-xtensa.md
+++ b/docs/source/build-run-xtensa.md
@@ -162,7 +162,8 @@ In order to run the CMake build, you need the path to the following:
 
 ```bash
 cd executorch
-rm -rf cmake-out
+./install_requirements.sh --clean
+mkdir cmake-out
 # prebuild and install executorch library
 cmake -DCMAKE_TOOLCHAIN_FILE=<path_to_executorch>/backends/cadence/cadence.cmake \
     -DCMAKE_INSTALL_PREFIX=cmake-out \

--- a/docs/source/llm/getting-started.md
+++ b/docs/source/llm/getting-started.md
@@ -396,7 +396,8 @@ At this point, the working directory should contain the following files:
 
 If all of these are present, you can now build and run:
 ```bash
-(rm -rf cmake-out && mkdir cmake-out && cd cmake-out && cmake ..)
+./install_requirements.sh --clean
+(mkdir cmake-out && cd cmake-out && cmake ..)
 cmake --build cmake-out -j10
 ./cmake-out/nanogpt_runner
 ```

--- a/docs/source/tutorial-xnnpack-delegate-lowering.md
+++ b/docs/source/tutorial-xnnpack-delegate-lowering.md
@@ -147,7 +147,7 @@ After exporting the XNNPACK Delegated model, we can now try running it with exam
 cd executorch
 
 # Get a clean cmake-out directory
-rm -rf cmake-out
+./install_requirements.sh --clean
 mkdir cmake-out
 
 # Configure cmake

--- a/examples/demo-apps/android/ExecuTorchDemo/README.md
+++ b/examples/demo-apps/android/ExecuTorchDemo/README.md
@@ -115,7 +115,7 @@ export ANDROID_ABI=arm64-v8a
 export QNN_SDK_ROOT=<path-to-qnn-sdk>
 
 ./install_requirements.sh --clean
-mkdir cmake-android-out && cd cmake-android-out
+mkdir cmake-android-out
 cmake . -DCMAKE_INSTALL_PREFIX=cmake-android-out \
     -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
     -DANDROID_ABI="${ANDROID_ABI}" \

--- a/examples/models/llama/README.md
+++ b/examples/models/llama/README.md
@@ -440,9 +440,8 @@ This example tries to reuse the Python code, with minimal modifications to make 
 ```
 git clean -xfd
 pip uninstall executorch
+./install_requirements.sh --clean
 ./install_requirements.sh --pybind xnnpack
-
-rm -rf cmake-out
 ```
 - If you encounter `pthread` related issues during link time, add `pthread` in `target_link_libraries` in `CMakeLists.txt`
 - On Mac, if there is linking error in Step 4 with error message like

--- a/examples/models/phi-3-mini-lora/README.md
+++ b/examples/models/phi-3-mini-lora/README.md
@@ -19,7 +19,8 @@ python export_model.py
 2. Run the inference model using an example runtime. For more detailed steps on this, check out [Build & Run](https://pytorch.org/executorch/stable/getting-started-setup.html#build-run).
 ```
 # Clean and configure the CMake build system. Compiled programs will appear in the executorch/cmake-out directory we create here.
-(rm -rf cmake-out && mkdir cmake-out && cd cmake-out && cmake ..)
+./install_requirements.sh --clean
+(mkdir cmake-out && cd cmake-out && cmake ..)
 
 # Build the executor_runner target
 cmake --build cmake-out --target executor_runner -j9

--- a/examples/portable/README.md
+++ b/examples/portable/README.md
@@ -45,8 +45,8 @@ Use `-h` (or `--help`) to see all the supported models.
 
 ```bash
 # Build the tool from the top-level `executorch` directory.
-(rm -rf cmake-out \
-    && mkdir cmake-out \
+./install_requirements.sh --clean
+(mkdir cmake-out \
     && cd cmake-out \
     && cmake -DEXECUTORCH_PAL_DEFAULT=posix ..) \
   && cmake --build cmake-out -j32 --target executor_runner

--- a/examples/xnnpack/README.md
+++ b/examples/xnnpack/README.md
@@ -31,7 +31,7 @@ Once we have the model binary (pte) file, then let's run it with ExecuTorch runt
 cd executorch
 
 # Get a clean cmake-out directory
-rm -rf cmake-out
+./install_requiements.sh --clean
 mkdir cmake-out
 
 # Configure cmake
@@ -86,7 +86,7 @@ After exporting the XNNPACK Delegated model, we can now try running it with exam
 cd executorch
 
 # Get a clean cmake-out directory
-rm -rf cmake-out
+./install_requirements.sh --clean
 mkdir cmake-out
 
 # Configure cmake

--- a/extension/training/README.md
+++ b/extension/training/README.md
@@ -230,7 +230,7 @@ After exporting the model for training, we can now try learning using CMake. We 
 cd executorch
 
 # Get a clean cmake-out directory
-rm -rf cmake-out
+./install_requirements.sh --clean
 mkdir cmake-out
 
 # Configure cmake


### PR DESCRIPTION
### Summary 

Currently, most documents will explicitly ask users to run "rm -rf"

But we have a dedicated command that does the cleanup.

Fixes #7083

### Test plan

Reproduced all the commands in the .md file. Fixed some of the existing bugs, for instance, in QNN command.

