### PR TITLE
Cleanup buck during installation

### DIFF
--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -278,7 +278,7 @@ function(resolve_buck2)
   execute_process(
     # Note that we need to use the local buck2 variable. BUCK2 is only set in
     # the parent scope, and can still be empty in this scope.
-    COMMAND "${buck2} kill"
+    COMMAND "${buck2} killall"
     WORKING_DIRECTORY ${executorch_root}
     COMMAND_ECHO STDOUT
   )


### PR DESCRIPTION
### Summary

Sometimes there are multiple buck processes running and some of them hanging. See sub issues in here https://github.com/pytorch/executorch/issues/7085

Let's do `killall` (it kills all buck processes).

### Test plan

CI