### PR TITLE
Fix CI for build-llm-demo

### DIFF
--- a/.ci/scripts/test_llama.sh
+++ b/.ci/scripts/test_llama.sh
@@ -149,7 +149,7 @@ which "${PYTHON_EXECUTABLE}"
 
 cmake_install_executorch_libraries() {
     echo "Installing libexecutorch.a, libextension_module.so, libportable_ops_lib.a"
-    clean_executorch_install_folders
+    rm -rf cmake-out
     retry cmake \
         -DCMAKE_INSTALL_PREFIX=cmake-out \
         -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" \


### PR DESCRIPTION
### Summary

After https://github.com/pytorch/executorch/pull/7108 landed, it broke CI, in particular build-llm-demo test.

Here's an example:

https://github.com/pytorch/executorch/actions/runs/12301283060/job/34332275511#logs

It removed a folder than contained android artifacts.

Let's just revert back to 'rm -rf cmake-out'

### Test plan

CI
