### PR TITLE
Set output buffer in devtools/fb/runner for models with non-memory-planned outputs

### DIFF
--- a/kernels/quantized/cpu/op_dequantize.cpp
+++ b/kernels/quantized/cpu/op_dequantize.cpp
@@ -272,7 +272,10 @@ Tensor& dequantize_per_tensor_out(
 
   check_dequantize_per_tensor_args(
       input, quant_min, quant_max, dtype, out_dtype, out);
-
+      
+  if (out.mutable_data_ptr() == nullptr) {
+    ET_CHECK_MSG(false, "out must have non-null data pointer");
+  }
   // calculate the dequantized output, cast scale to float to match fbgemm
   // behavior
 #define DEQUANTIZE_IMPL(IN_CTYPE, OUT_CTYPE, out_dtype)                        \


### PR DESCRIPTION
Summary: As titled. BoltNN is using this runner to profiling and debug ET models so it's important to fix it for them. Implementation mostly copied from https://www.internalfb.com/code/fbsource/[ecdad1c2a91acadf96073ed2f3e89319b3be7593]/fbcode/executorch/extension/pybindings/pybindings.cpp?lines=138.

Differential Revision: D65766614


