### PR TITLE
Update target path for CI macros 1/N

### DIFF
--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -1,4 +1,4 @@
-load("@fbcode//target_determinator/macros:ci.bzl", "ci")
+load("@fbsource//tools/target_determinator/macros:ci.bzl", "ci")
 load("@fbcode_macros//build_defs:native_rules.bzl", "buck_genrule")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "CXX", "FBCODE")

--- a/backends/vulkan/test/compute_api_tests.bzl
+++ b/backends/vulkan/test/compute_api_tests.bzl
@@ -1,4 +1,4 @@
-load("@fbcode//target_determinator/macros:ci.bzl", "ci")
+load("@fbsource//tools/target_determinator/macros:ci.bzl", "ci")
 load("@fbsource//tools/build_defs:fb_xplat_cxx_binary.bzl", "fb_xplat_cxx_binary")
 load("@fbsource//tools/build_defs:fb_xplat_cxx_test.bzl", "fb_xplat_cxx_test")
 load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "MACOSX", "CXX")


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/buck2/pull/823

We moved CI macros from /fbcode to /tools https://fb.workplace.com/groups/1243087773044302/posts/1477603662926044

Reviewed By: zertosh

Differential Revision: D67352185


