### PR TITLE
Add stride constraint to XNN MaxPool

### DIFF
--- a/backends/xnnpack/partition/config/generic_node_configs.py
+++ b/backends/xnnpack/partition/config/generic_node_configs.py
@@ -19,7 +19,7 @@ from executorch.backends.xnnpack.utils.utils import get_input_node
 from executorch.exir.backend.canonical_partitioners.config_partitioner import (
     format_target_name,
 )
-from executorch.exir.backend.utils import WhyNoPartition
+from executorch.exir.backend.utils import is_shape_dynamic, WhyNoPartition
 from torch.export import ExportedProgram
 
 logger = logging.getLogger(__name__)
@@ -284,19 +284,27 @@ class MaxPool2dConfig(GenericNodePartitionerConfig):
 
     def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
         """
-        XNNPACK's maxpool2d does not support ceil mode
+        XNNPACK's maxpool2d does not support ceil mode and requires stride <= kernel_size
         """
         if not self.check_common_constraints(node, ep):
             return False
 
-        # Ceil mode is supported via op padding, which must be statically known.
+        kernel_size = node.args[1]
+        stride = node.args[2]
         is_ceil_mode = len(node.args) >= 6 and cast(bool, node.args[5])
-        is_dynamic = "val" in node.meta and any(
-            isinstance(d, torch.SymInt) for d in node.meta["val"].shape
-        )
-        if is_ceil_mode and is_dynamic:
+
+        # Ceil mode is supported via op padding, which must be statically known.
+        if is_ceil_mode and is_shape_dynamic(node):
             why(node, reason="ceil mode is not supported for dynamic shapes")
             return False
+
+        if stride[0] > kernel_size[0] or stride[1] > kernel_size[1]:  # pyre-ignore[16]
+            why(
+                node,
+                reason=f"stride ({stride}) must be less than or equal to kernel size ({kernel_size})",
+            )
+            return False
+
         return True
 
     def supported_precision_types(self) -> List[ConfigPrecisionType]:
@@ -316,10 +324,7 @@ class UpsampleBilinear2dConfig(GenericNodePartitionerConfig):
         if not self.check_common_constraints(node, ep):
             return False
 
-        is_output_dynamic = "val" in node.meta and any(
-            isinstance(d, torch.SymInt) for d in node.meta["val"].shape
-        )
-        if is_output_dynamic:
+        if is_shape_dynamic(node):
             why(node, reason="dynamic output sizes are not supported")
             return False
         return True

--- a/exir/backend/utils.py
+++ b/exir/backend/utils.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import logging
 import operator
 from collections import defaultdict
@@ -415,6 +417,17 @@ def tag_mutated_buffer(edge_program: ExportedProgram) -> None:
             # tag the data node with the same tag as the last user
             if len(user_tags) > 0:
                 node.meta["delegation_tag"] = user_tags.pop()
+
+
+def is_shape_dynamic(node: torch.fx.Node) -> bool:
+    """
+    Check if the node shape is dynamic.
+    """
+
+    # Shape is dynamic if any of the dimensions don't evaluate to a static value
+    return "val" in node.meta and any(
+        isinstance(d, torch.SymInt) for d in node.meta["val"].shape
+    )
 
 
 # TODO - style: use templated types


### PR DESCRIPTION
Summary:
Add an XNNPACK partitioner constraint for MaxPool2d to enforce stride <= kernel_size.

See https://github.com/google/XNNPACK/blob/860f2b9ad9d3602599aff49a41d0131d2a350e00/src/subgraph/max-pooling-2d.c#L327.

Differential Revision: D67380978


