### PR TITLE
Support 5-input concat in XNNPACK delegate

### DIFF
--- a/backends/xnnpack/operators/op_cat.py
+++ b/backends/xnnpack/operators/op_cat.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 from typing import cast, Dict, List
 
 import torch
@@ -17,6 +19,7 @@ from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
     XNNConcatenate2,
     XNNConcatenate3,
     XNNConcatenate4,
+    XNNConcatenate5,
     XNNGraph,
     XNode,
 )
@@ -71,6 +74,7 @@ class CatVisitor(NodeVisitor):
                 input2_id=vals_to_ids[list_of_tensors[1]],
                 input3_id=XNN_INVALID_VALUE_ID,
                 input4_id=XNN_INVALID_VALUE_ID,
+                input5_id=XNN_INVALID_VALUE_ID,
                 output_id=vals_to_ids[node],
                 flags=0,
             )
@@ -81,6 +85,7 @@ class CatVisitor(NodeVisitor):
                 input2_id=vals_to_ids[list_of_tensors[1]],
                 input3_id=vals_to_ids[list_of_tensors[2]],
                 input4_id=XNN_INVALID_VALUE_ID,
+                input5_id=XNN_INVALID_VALUE_ID,
                 output_id=vals_to_ids[node],
                 flags=0,
             )
@@ -91,6 +96,18 @@ class CatVisitor(NodeVisitor):
                 input2_id=vals_to_ids[list_of_tensors[1]],
                 input3_id=vals_to_ids[list_of_tensors[2]],
                 input4_id=vals_to_ids[list_of_tensors[3]],
+                input5_id=XNN_INVALID_VALUE_ID,
+                output_id=vals_to_ids[node],
+                flags=0,
+            )
+        elif num_tensors_to_cat == 5:
+            xnode = XNNConcatenate5(
+                axis=axis,
+                input1_id=vals_to_ids[list_of_tensors[0]],
+                input2_id=vals_to_ids[list_of_tensors[1]],
+                input3_id=vals_to_ids[list_of_tensors[2]],
+                input4_id=vals_to_ids[list_of_tensors[3]],
+                input5_id=vals_to_ids[list_of_tensors[4]],
                 output_id=vals_to_ids[node],
                 flags=0,
             )

--- a/backends/xnnpack/partition/config/generic_node_configs.py
+++ b/backends/xnnpack/partition/config/generic_node_configs.py
@@ -174,17 +174,17 @@ class CatConfig(GenericNodePartitionerConfig):
 
     def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
         """
-        Only support concatenation of 2 - 4 tensors
+        Only support concatenation of 2 - 5 tensors
         """
         if not self.check_common_constraints(node, ep):
             return False
 
         num_tensors = len(node.all_input_nodes)
 
-        if not (num_tensors >= 2 and num_tensors <= 4):
+        if not (num_tensors >= 2 and num_tensors <= 5):
             why(
                 node,
-                reason=f"only support concatenation of 2 - 4 tensors, got {num_tensors} tensors",
+                reason=f"only support concatenation of 2 - 5 tensors, got {num_tensors} tensors",
             )
             return False
 

--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -1600,7 +1600,7 @@ Error defineConcatenate2Node(
 }
 
 /*
-Defines serialized concatenate2 node into the subgraph,
+Defines serialized concatenate3 node into the subgraph,
 using the remapped ids to map the serialized ids,
 to the new ids generated when defining the tensor value
 */
@@ -1633,7 +1633,7 @@ Error defineConcatenate3Node(
 }
 
 /*
-Defines serialized concatenate2 node into the subgraph,
+Defines serialized concatenate4 node into the subgraph,
 using the remapped ids to map the serialized ids,
 to the new ids generated when defining the tensor value
 */
@@ -1660,6 +1660,41 @@ Error defineConcatenate4Node(
       status == xnn_status_success,
       Internal,
       "Failed to create cat4 node %i with code: %s",
+      node->debug_handle(),
+      xnn_status_to_string(status));
+
+  return Error::Ok;
+}
+
+/*
+Defines serialized concatenate5 node into the subgraph,
+using the remapped ids to map the serialized ids,
+to the new ids generated when defining the tensor value
+*/
+Error defineConcatenate5Node(
+    xnn_subgraph_t subgraph_ptr,
+    const std::unordered_map<uint32_t, uint32_t>& remapped_ids,
+    const NodePtr node,
+    const fb_xnnpack::XNNGraph* graph) noexcept {
+  MAYBE_UNUSED(graph);
+
+  auto graph_node = node->xnode_union_as_XNNConcatenate5();
+
+  xnn_status status = xnn_define_concatenate5(
+      subgraph_ptr,
+      graph_node->axis(),
+      remapped_ids.at(graph_node->input1_id()),
+      remapped_ids.at(graph_node->input2_id()),
+      remapped_ids.at(graph_node->input3_id()),
+      remapped_ids.at(graph_node->input4_id()),
+      remapped_ids.at(graph_node->input5_id()),
+      remapped_ids.at(graph_node->output_id()),
+      graph_node->flags());
+
+  ET_CHECK_OR_RETURN_ERROR(
+      status == xnn_status_success,
+      Internal,
+      "Failed to create cat5 node %i with code: %s",
       node->debug_handle(),
       xnn_status_to_string(status));
 
@@ -1832,6 +1867,7 @@ DefineNodeFunc getDefineNodeFunc(fb_xnnpack::XNodeUnion nodeType) {
     _DEFINE(Concatenate2)
     _DEFINE(Concatenate3)
     _DEFINE(Concatenate4)
+    _DEFINE(Concatenate5)
     _DEFINE(StaticSlice)
     _DEFINE(ScaledDotProductAttention)
     _DEFINE(BatchMatrixMultiply)

--- a/backends/xnnpack/serialization/runtime_schema.fbs
+++ b/backends/xnnpack/serialization/runtime_schema.fbs
@@ -136,6 +136,7 @@ union XNodeUnion {
   XNNStaticSlice,
   XNNScaledDotProductAttention,
   XNNBatchMatrixMultiply: _XNNNode2x1,
+  XNNConcatenate5: _XNNCat,
 }
 
 union XValueUnion {
@@ -209,6 +210,7 @@ table _XNNCat {
   input4_id: uint;
   output_id: uint;
   flags: uint;
+  input5_id: uint;
 }
 
 table XNNELU {

--- a/backends/xnnpack/serialization/schema.fbs
+++ b/backends/xnnpack/serialization/schema.fbs
@@ -132,6 +132,7 @@ union XNodeUnion {
   XNNStaticSlice,
   XNNScaledDotProductAttention,
   XNNBatchMatrixMultiply: _XNNNode2x1,
+  XNNConcatenate5: _XNNCat,
 }
 
 union XValueUnion {
@@ -205,6 +206,7 @@ table _XNNCat {
   input4_id: uint;
   output_id: uint;
   flags: uint;
+  input5_id: uint;
 }
 
 table XNNELU {

--- a/backends/xnnpack/serialization/xnnpack_graph_schema.py
+++ b/backends/xnnpack/serialization/xnnpack_graph_schema.py
@@ -42,6 +42,7 @@ class XNNCat:
     input4_id: int
     output_id: int
     flags: int
+    input5_id: int
 
 
 # Generic node data class for convolution type nodes
@@ -174,6 +175,11 @@ class XNNConcatenate3(XNNCat):
 
 @dataclass
 class XNNConcatenate4(XNNCat):
+    pass
+
+
+@dataclass
+class XNNConcatenate5(XNNCat):
     pass
 
 
@@ -357,6 +363,7 @@ XNodeUnion = Union[
     XNNConcatenate2,
     XNNConcatenate3,
     XNNConcatenate4,
+    XNNConcatenate5,
     XNNStaticSlice,
     XNNScaledDotProductAttention,
     XNNBatchMatrixMultiply,


### PR DESCRIPTION
Summary: I noticed that support for 5-input concatenate ops was added to the XNNPACK library subgraph layer. We can support this in the delegate.

Differential Revision: D67439458


