### PR TITLE
Add additional default decompositions for upsample operators

### DIFF
--- a/exir/tracer.py
+++ b/exir/tracer.py
@@ -64,6 +64,16 @@ Value: TypeAlias = Union[
 
 torchdynamo_enabled = False
 
+"""
+Additional decompositions to apply by during to_edge or 
+to to_edge_transform_and_lower in addition to the default decompositions from 
+PyTorch export.
+"""
+EXECUTORCH_ADDITIONAL_DECOMPOSITIONS = [
+    torch.ops.aten.upsample_bilinear2d.vec,
+    torch.ops.aten.upsample_nearest2d.vec,
+]
+
 
 def get_stacktrace() -> List[Dict[str, str]]:
     """
@@ -631,8 +641,12 @@ def _default_decomposition_table(
         ]
         # pyre-fixme[7]: Expected `Dict[OpOverload, typing.Callable[..., executorch.e...
         return get_decompositions(decomp_opset)
+
     # pyre-fixme[7]: Expected `Dict[OpOverload, typing.Callable[..., executorch.exir....
-    return default_decompositions()
+    table = default_decompositions()
+    additional_decompositions = get_decompositions(EXECUTORCH_ADDITIONAL_DECOMPOSITIONS)    
+    table.decomp_table.update(additional_decompositions)
+    return table
 
 
 def dynamo_trace(


### PR DESCRIPTION
Summary:
There are several core ATen ops that are not yet supported on ExecuTorch, including upsample_bilinear2d.vec and upsample_nearest2d.vec. These ops are currently not decomposed by default with PyTorch export default decompositions, but should be. Existing ET consumers rely on this behavior, so we need to preserve it until we have upsample kernels ready.

This change allows ET to opt-into decomposing these ops, regardless of the PyTorch default export decomposition table. This will unblock updating PyTorch with the correct behavior (see https://github.com/pytorch/pytorch/issues/116684).

Once the upsample kernels land in ET, we can remove these decompositions. This is currently blocked by pin bumps, which may take a while to resolve.

Differential Revision: D67443180


