### PR TITLE
Arm backend: Fix memory mode for Ethos-U85

### DIFF
--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -114,7 +114,7 @@ then
     memory_mode="Shared_Sram"
     if [[ ${target} =~ "ethos-u85" ]]
     then
-        system_config="Sram_Only"
+        memory_mode="Sram_Only"
     fi
 fi
 


### PR DESCRIPTION
This fix a minor typo that made run.sh not work for Ethos-U85 if no --memory_mode was specified.
