### PR TITLE
Handle benchmark configs when extracting benchmark results

### DIFF
--- a/.github/scripts/extract_benchmark_results.py
+++ b/.github/scripts/extract_benchmark_results.py
@@ -24,7 +24,7 @@ logging.basicConfig(level=logging.INFO)
 BENCHMARK_RESULTS_FILENAME = "benchmark_results.json"
 ARTIFACTS_FILENAME_REGEX = re.compile(r"(android|ios)-artifacts-(?P<job_id>\d+).json")
 BENCHMARK_CONFIG_REGEX = re.compile(
-    r"# The benchmark config is (?P<benchmark_config>.+)"
+    r"The benchmark config is (?P<benchmark_config>.+)"
 )
 
 # iOS-related regexes and variables
@@ -337,7 +337,8 @@ def read_benchmark_config(
     try:
         with request.urlopen(artifact_s3_url) as data:
             for line in data.read().decode("utf8").splitlines():
-                m = IOS_TEST_SPEC_REGEX.match(line)
+                print(line)
+                m = BENCHMARK_CONFIG_REGEX.match(line)
                 if not m:
                     continue
 
@@ -356,6 +357,7 @@ def read_benchmark_config(
                     except json.JSONDecodeError as e:
                         warning(f"Fail to load benchmark config {filename}: {e}")
 
+        print(">>>>>>>")
     except error.HTTPError:
         warning(f"Fail to read the test spec output at {artifact_s3_url}")
 
@@ -484,6 +486,9 @@ def main() -> None:
                 benchmark_config = read_benchmark_config(
                     artifact_s3_url, args.benchmark_configs
                 )
+                print(benchmark_config)
+
+            continue
 
             if app_type == "ANDROID_APP":
                 benchmark_results = extract_android_benchmark_results(

--- a/.github/scripts/extract_benchmark_results.py
+++ b/.github/scripts/extract_benchmark_results.py
@@ -23,9 +23,7 @@ logging.basicConfig(level=logging.INFO)
 
 BENCHMARK_RESULTS_FILENAME = "benchmark_results.json"
 ARTIFACTS_FILENAME_REGEX = re.compile(r"(android|ios)-artifacts-(?P<job_id>\d+).json")
-BENCHMARK_CONFIG_REGEX = re.compile(
-    r"The benchmark config is (?P<benchmark_config>.+)"
-)
+BENCHMARK_CONFIG_REGEX = re.compile(r"The benchmark config is (?P<benchmark_config>.+)")
 
 # iOS-related regexes and variables
 IOS_TEST_SPEC_REGEX = re.compile(

--- a/.github/scripts/extract_benchmark_results.py
+++ b/.github/scripts/extract_benchmark_results.py
@@ -51,7 +51,7 @@ class ValidateArtifacts(Action):
         parser.error(f"{values} is not a valid JSON file (*.json)")
 
 
-class ValidateOutputDir(Action):
+class ValidateDir(Action):
     def __call__(
         self,
         parser: ArgumentParser,
@@ -81,7 +81,7 @@ def parse_args() -> Any:
         "--output-dir",
         type=str,
         required=True,
-        action=ValidateOutputDir,
+        action=ValidateDir,
         help="the directory to keep the benchmark results",
     )
     parser.add_argument(
@@ -113,6 +113,13 @@ def parse_args() -> Any:
         type=int,
         required=True,
         help="which retry of the workflow this is",
+    )
+    parser.add_argument(
+        "--benchmark-configs",
+        type=str,
+        required=True,
+        action=ValidateDir,
+        help="the directory to keep the benchmark configs",
     )
 
     return parser.parse_args()

--- a/.github/scripts/extract_benchmark_results.py
+++ b/.github/scripts/extract_benchmark_results.py
@@ -337,7 +337,6 @@ def read_benchmark_config(
     try:
         with request.urlopen(artifact_s3_url) as data:
             for line in data.read().decode("utf8").splitlines():
-                print(line)
                 m = BENCHMARK_CONFIG_REGEX.match(line)
                 if not m:
                     continue
@@ -356,8 +355,6 @@ def read_benchmark_config(
                         return json.load(f)
                     except json.JSONDecodeError as e:
                         warning(f"Fail to load benchmark config {filename}: {e}")
-
-        print(">>>>>>>")
     except error.HTTPError:
         warning(f"Fail to read the test spec output at {artifact_s3_url}")
 
@@ -486,9 +483,6 @@ def main() -> None:
                 benchmark_config = read_benchmark_config(
                     artifact_s3_url, args.benchmark_configs
                 )
-                print(benchmark_config)
-
-            continue
 
             if app_type == "ANDROID_APP":
                 benchmark_results = extract_android_benchmark_results(

--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Prepare the spec
         shell: bash
         env:
-          BENCHMARK_CONFIGS: ${{ toJSON(matrix) }}
+          BENCHMARK_CONFIG: ${{ toJSON(matrix) }}
         working-directory: extension/benchmark/android/benchmark
         run: |
           set -eux
@@ -110,13 +110,18 @@ jobs:
           # We could write a script to properly use jinja here, but there is only one variable,
           # so let's just sed it
           sed -i -e 's,{{ model_path }},'"${MODEL_PATH}"',g' android-llm-device-farm-test-spec.yml.j2
-          cp android-llm-device-farm-test-spec.yml.j2 android-llm-device-farm-test-spec.yml
 
+          BENCHMARK_CONFIG_ID="${{ matrix.model }}_${{ matrix.config }}"
+          # The config for this benchmark runs, we save it in the test spec so that it can be fetched
+          # later by the upload script
+          sed -i -e 's,{{ benchmark_config_id }},'"${BENCHMARK_CONFIG_ID}"',g' android-llm-device-farm-test-spec.yml.j2
+
+          cp android-llm-device-farm-test-spec.yml.j2 android-llm-device-farm-test-spec.yml
           # Just print the test spec for debugging
           cat android-llm-device-farm-test-spec.yml
 
-          # Also dump the benchmark configs so that we can use it later in the dashboard
-          echo "${BENCHMARK_CONFIGS}" > ${{ matrix.model }}_${{ matrix.config }}.json
+          # Save the benchmark configs so that we can use it later in the dashboard
+          echo "${BENCHMARK_CONFIG}" > "${BENCHMARK_CONFIG_ID}.json"
 
       - name: Upload the spec
         uses: seemethere/upload-artifact-s3@v5
@@ -414,14 +419,14 @@ jobs:
 
       - name: Download the list of benchmark configs from S3
         env:
-          BENCHMARK_CONFIGS_S3_DIR: s3://gha-artifacts/${{ github.repository }}/${{ github.run_id }}/artifacts/benchmark-configs/
+          BENCHMARK_CONFIGS_DIR: s3://gha-artifacts/${{ github.repository }}/${{ github.run_id }}/artifacts/benchmark-configs/
         shell: bash
         run: |
           set -eux
 
           mkdir -p benchmark-configs
           pushd benchmark-configs
-          ${CONDA_RUN} aws s3 sync "${BENCHMARK_CONFIGS_S3_DIR}" .
+          ${CONDA_RUN} aws s3 sync "${BENCHMARK_CONFIGS_DIR}" .
           popd
 
           ls -lah benchmark-configs

--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -412,7 +412,7 @@ jobs:
 
           ls -lah artifacts
 
-      - name: Download the list of benchmark artifacts from S3
+      - name: Download the list of benchmark configs from S3
         env:
           BENCHMARK_CONFIGS_S3_DIR: s3://gha-artifacts/${{ github.repository }}/${{ github.run_id }}/artifacts/benchmark-configs/
         shell: bash

--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -99,6 +99,8 @@ jobs:
 
       - name: Prepare the spec
         shell: bash
+        env:
+          BENCHMARK_CONFIGS: ${{ toJSON(matrix) }}
         working-directory: extension/benchmark/android/benchmark
         run: |
           set -eux
@@ -113,6 +115,9 @@ jobs:
           # Just print the test spec for debugging
           cat android-llm-device-farm-test-spec.yml
 
+          # Also dump the benchmark configs so that we can use it later in the dashboard
+          echo "${BENCHMARK_CONFIGS}" > ${{ matrix.model }}_${{ matrix.config }}.json
+
       - name: Upload the spec
         uses: seemethere/upload-artifact-s3@v5
         with:
@@ -122,6 +127,16 @@ jobs:
           retention-days: 1
           if-no-files-found: error
           path: extension/benchmark/android/benchmark/android-llm-device-farm-test-spec.yml
+
+      - name: Update the benchmark configs
+        uses: seemethere/upload-artifact-s3@v5
+        with:
+          s3-bucket: gha-artifacts
+          s3-prefix: |
+            ${{ github.repository }}/${{ github.run_id }}/artifacts/benchmark-configs/
+          retention-days: 1
+          if-no-files-found: error
+          path: extension/benchmark/android/benchmark/${{ matrix.model }}_${{ matrix.config }}.json
 
   export-models:
     name: export-models
@@ -397,6 +412,20 @@ jobs:
 
           ls -lah artifacts
 
+      - name: Download the list of benchmark artifacts from S3
+        env:
+          BENCHMARK_CONFIGS_S3_DIR: s3://gha-artifacts/${{ github.repository }}/${{ github.run_id }}/artifacts/benchmark-configs/
+        shell: bash
+        run: |
+          set -eux
+
+          mkdir -p benchmark-configs
+          pushd benchmark-configs
+          ${CONDA_RUN} aws s3 sync "${BENCHMARK_CONFIGS_S3_DIR}" .
+          popd
+
+          ls -lah benchmark-configs
+
       - name: Extract the benchmark results JSON
         shell: bash
         run: |
@@ -414,7 +443,8 @@ jobs:
               --head-branch ${{ github.head_ref || github.ref_name }} \
               --workflow-name "${{ github.workflow }}" \
               --workflow-run-id ${{ github.run_id }} \
-              --workflow-run-attempt ${{ github.run_attempt }}
+              --workflow-run-attempt ${{ github.run_attempt }} \
+              --benchmark-configs benchmark-configs
           done
 
           for SCHEMA in v2 v3; do

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -101,19 +101,29 @@ jobs:
 
       - name: Prepare the spec
         shell: bash
+        env:
+          BENCHMARK_CONFIG: ${{ toJSON(matrix) }}
         working-directory: extension/benchmark/apple/Benchmark
         run: |
           set -eux
 
-          echo "DEBUG: ${{ matrix.model }}"
           # The model will be exported in the next step to this S3 path
           MODEL_PATH="https://gha-artifacts.s3.amazonaws.com/${{ github.repository }}/${{ github.run_id }}/artifacts/${{ matrix.model }}_${{ matrix.config }}/model.zip"
           # We could write a script to properly use jinja here, but there is only one variable,
           # so let's just sed it
           sed -i -e 's,{{ model_path }},'"${MODEL_PATH}"',g' default-ios-device-farm-appium-test-spec.yml.j2
+
+          BENCHMARK_CONFIG_ID="${{ matrix.model }}_${{ matrix.config }}"
+          # The config for this benchmark runs, we save it in the test spec so that it can be fetched
+          # later by the upload script
+          sed -i -e 's,{{ benchmark_config_id }},'"${BENCHMARK_CONFIG_ID}"',g' default-ios-device-farm-appium-test-spec.yml.j2
+
           cp default-ios-device-farm-appium-test-spec.yml.j2 default-ios-device-farm-appium-test-spec.yml
           # Just print the test spec for debugging
           cat default-ios-device-farm-appium-test-spec.yml
+
+          # Save the benchmark configs so that we can use it later in the dashboard
+          echo "${BENCHMARK_CONFIG}" > "${BENCHMARK_CONFIG_ID}.json"
 
       - name: Upload the spec
         uses: seemethere/upload-artifact-s3@v5
@@ -124,6 +134,16 @@ jobs:
           retention-days: 1
           if-no-files-found: error
           path: extension/benchmark/apple/Benchmark/default-ios-device-farm-appium-test-spec.yml
+
+      - name: Update the benchmark configs
+        uses: seemethere/upload-artifact-s3@v5
+        with:
+          s3-bucket: gha-artifacts
+          s3-prefix: |
+            ${{ github.repository }}/${{ github.run_id }}/artifacts/benchmark-configs/
+          retention-days: 1
+          if-no-files-found: error
+          path: extension/benchmark/apple/Benchmark/${{ matrix.model }}_${{ matrix.config }}.json
 
   export-models:
     name: export-models
@@ -481,6 +501,18 @@ jobs:
 
           ls -lah artifacts
 
+      - name: Download the list of benchmark configs from S3
+        env:
+          BENCHMARK_CONFIGS_DIR: s3://gha-artifacts/${{ github.repository }}/${{ github.run_id }}/artifacts/benchmark-configs/
+        shell: bash
+        run: |
+          set -eux
+          mkdir -p benchmark-configs
+          pushd benchmark-configs
+          ${CONDA_RUN} aws s3 sync "${BENCHMARK_CONFIGS_DIR}" .
+          popd
+          ls -lah benchmark-configs
+
       - name: Extract the benchmark results JSON
         shell: bash
         run: |
@@ -498,7 +530,8 @@ jobs:
               --head-branch ${{ github.head_ref || github.ref_name }} \
               --workflow-name "${{ github.workflow }}" \
               --workflow-run-id ${{ github.run_id }} \
-              --workflow-run-attempt ${{ github.run_attempt }}
+              --workflow-run-attempt ${{ github.run_attempt }} \
+              --benchmark-configs benchmark-configs
           done
 
           for SCHEMA in v2 v3; do

--- a/extension/benchmark/android/benchmark/android-llm-device-farm-test-spec.yml.j2
+++ b/extension/benchmark/android/benchmark/android-llm-device-farm-test-spec.yml.j2
@@ -9,7 +9,7 @@ phases:
   pre_test:
     commands:
       # Print this so that the upload script can read and process the benchmark config
-      echo "The benchmark config is {{ benchmark_config_id }}"
+      - echo "The benchmark config is {{ benchmark_config_id }}"
 
       # Download the model from S3
       - curl -s --fail '{{ model_path }}' -o model.zip

--- a/extension/benchmark/android/benchmark/android-llm-device-farm-test-spec.yml.j2
+++ b/extension/benchmark/android/benchmark/android-llm-device-farm-test-spec.yml.j2
@@ -8,6 +8,8 @@ phases:
 
   pre_test:
     commands:
+      # The benchmark config is {{ benchmark_config_id }}
+
       # Download the model from S3
       - curl -s --fail '{{ model_path }}' -o model.zip
       - unzip model.zip && ls -la

--- a/extension/benchmark/android/benchmark/android-llm-device-farm-test-spec.yml.j2
+++ b/extension/benchmark/android/benchmark/android-llm-device-farm-test-spec.yml.j2
@@ -8,7 +8,8 @@ phases:
 
   pre_test:
     commands:
-      # The benchmark config is {{ benchmark_config_id }}
+      # Print this so that the upload script can read and process the benchmark config
+      echo "The benchmark config is {{ benchmark_config_id }}"
 
       # Download the model from S3
       - curl -s --fail '{{ model_path }}' -o model.zip

--- a/extension/benchmark/apple/Benchmark/default-ios-device-farm-appium-test-spec.yml.j2
+++ b/extension/benchmark/apple/Benchmark/default-ios-device-farm-appium-test-spec.yml.j2
@@ -10,6 +10,9 @@ phases:
   # The pre-test phase includes commands that setup your test environment.
   pre_test:
     commands:
+      # Print this so that the upload script can read and process the benchmark config
+      - echo "The benchmark config is {{ benchmark_config_id }}"
+
       # Download the model from S3
       - curl -s --fail '{{ model_path }}' -o model.zip
       - unzip model.zip && ls -la


### PR DESCRIPTION
The benchmark configs JSON are uploaded as artifacts and can be used later to populate the benchmark results with the model name and configs before uploading to the database.

* I'll submit another PR to clean up the script later because the v2 schema is not used anymore after this.
* We also need a corresponding PR on the dashboard side https://github.com/pytorch/test-infra/pull/6110

### Testing

https://torchci-git-fork-huydhn-add-executorch-backend-fbopensource.vercel.app/benchmark/llms?startTime=Tue%2C%2017%20Dec%202024%2019%3A05%3A31%20GMT&stopTime=Tue%2C%2024%20Dec%202024%2019%3A05%3A31%20GMT&granularity=hour&lBranch=handle-benchmark-config-dashboard&lCommit=c48da2bd2c9a32705db9b1adf638344474c275a4&rBranch=handle-benchmark-config-dashboard&rCommit=c33f815eff17c8890f2c8527dc0f0dbca50b4397&repoName=pytorch%2Fexecutorch&modelName=All%20Models&backendName=All%20Backends&dtypeName=All%20DType&deviceName=All%20Devices
