### PR TITLE
Enable kwarg inputs for pt2e quantize

### DIFF
--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -360,7 +360,10 @@ class LLMEdgeManager:
                     logging.info(
                         "No calibration provided, using dummy input to calibrate..."
                     )
-                    m(*self.example_inputs)
+                    if self.example_kwarg_inputs:
+                        m(*self.example_inputs, **self.example_kwarg_inputs)
+                    else:
+                        m(*self.example_inputs)
                 m = convert_pt2e(m)
                 DuplicateDynamicQuantChainPass()(m)
                 self.pre_autograd_graph_module = m


### PR DESCRIPTION
### Summary
For quantizing models that have kwarg forward() inputs, such as TorchTune Llama models

### Test plan
N/A