### PR TITLE
Update lintrunner configs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,8 +80,8 @@ We use [`lintrunner`](https://pypi.org/project/lintrunner/) to help make sure th
 code follows our standards. Set it up with:
 
 ```
-pip install lintrunner==0.11.0
-pip install lintrunner-adapters==0.11.0
+pip install lintrunner==0.12.7
+pip install lintrunner-adapters==0.12.4
 lintrunner init
 ```
 

--- a/examples/models/llama/experimental/generate.py
+++ b/examples/models/llama/experimental/generate.py
@@ -67,8 +67,8 @@ def decode_n_tokens(
     print(f"cur_token: {cur_token}")
     new_tokens, new_probs = [], []
     for _ in range(num_new_tokens):
-        with torch.backends.cuda.sdp_kernel(
-            enable_flash=False, enable_mem_efficient=False, enable_math=True
+        with torch.nn.attention.sdpa_kernel(
+            torch.nn.attention.SDPBackend.MATH
         ):  # Actually better for Inductor to codegen attention here
             next_token, next_prob = decode_one_token(
                 model, cur_token.view(1, -1), **sampling_kwargs

--- a/exir/dialects/edge/spec/gen.py
+++ b/exir/dialects/edge/spec/gen.py
@@ -327,14 +327,14 @@ class EdgeOpYamlInfo:
                 "type_constraint": type_constraint_yaml,
             }
             return yaml_dict
-        except BaseException:
+        except BaseException as e:
             print(
                 "Operator {} inherited from {} failed convert to yaml".format(
                     self.func_name, self.inherits
                 )
             )
             print(self)
-            return {}
+            raise e
 
     def __str__(self) -> str:
         my_str: str = "\nop_yaml_info: \n"
@@ -440,7 +440,8 @@ def gen_op_yaml(op_name: str) -> Optional[EdgeOpYamlInfo]:
     except BaseException as e:
         # Can not find operator schema, or can not find operator based on op_name.
         # Return None to append it into unsupport_funcs and skip.
-        raise RuntimeError(f"Can not find operator schema for {op_name}") from e
+        print(f"Can not find operator schema for {op_name}")
+        raise e
 
     valid_type_combinations = try_all_dtypes_input_samples(op_name)
 
@@ -465,7 +466,7 @@ def gen_op_yaml(op_name: str) -> Optional[EdgeOpYamlInfo]:
         # Append it to unsupported_funcs.
         print("Failed to create yaml file for current function:", op_name)
         print("Error msg:", str(e))
-        return
+        raise e
 
     return op_yaml_info
 

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -1,21 +1,21 @@
 # Lintrunner itself
-lintrunner==0.11.0
-lintrunner-adapters==0.11.0
+lintrunner==0.12.7
+lintrunner-adapters==0.12.4
 
 # Flake 8 and its dependencies
 flake8==6.1.0
 flake8-breakpoint==1.1.0
-flake8-bugbear==23.9.16
+flake8-bugbear==24.4.26
 flake8-comprehensions==3.14.0
 flake8-pyi==23.5.0
 mccabe==0.7.0
 pycodestyle==2.11.1
-torchfix==0.5.0
+torchfix==0.6.0
 
 # UFMT
 black==24.4.2
-ufmt==2.6.0
-usort==1.0.5
+ufmt==2.8.0
+usort==1.0.8.post1
 
 # Other linters
 clang-format==18.1.3


### PR DESCRIPTION
Updated lintrunner versions and as well as sub libraries to the latest versions

Had to fix two new warnings: 

- deprecated sdpa kernel library (via torchfix=0.6)

- and catching base exception and not reraising them.