### PR TITLE
Fix NATIVE_FP16 macro in our fork of half.h

### DIFF
--- a/runtime/core/portable_type/half.h
+++ b/runtime/core/portable_type/half.h
@@ -15,7 +15,7 @@
 #include <ostream>
 
 #if defined(__GNUC__) || defined(__clang__)
-#if defined(__aarch64__)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC)
 #ifndef __ARM_V8_ONLY__
 #define NATIVE_FP16 1
 #endif // __ARM_V8_ONLY__


### PR DESCRIPTION
Simple build unbreak for Raspberry Pi 5 -- fp16 is an optional aarch64 feature.
