### PR TITLE
Remove path that is not needed for SDPA decomp

### DIFF
--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -18,16 +18,10 @@ from executorch.backends.cadence.aot.memory_planning import (
 )
 from executorch.backends.cadence.aot.quantizer.fusion_pass import QuantFusion
 from executorch.backends.cadence.aot.quantizer.quantizer import CadenceQuantizer
-
-from executorch.backends.cadence.aot.replace_ops import ReplaceSafeSoftmaxWithSoftmax
 from executorch.backends.cadence.aot.utils import (
     get_default_memory_config,
     MemoryConfig,
-    model_gm_has_SDPA,
     model_is_quantized,
-)
-from executorch.backends.transforms.decompose_sdpa import (
-    DecomposeScaledDotProductAttention,
 )
 from executorch.devtools import generate_etrecord
 from executorch.exir import (
@@ -90,16 +84,6 @@ def convert_pt2(
         .run_decompositions(decomp_table)
         .module()
     )
-
-    if model_gm_has_SDPA(model_gm):
-        # Decompose SDPA
-        DecomposeScaledDotProductAttention(False)(model_gm)
-
-        # Swap _safe_softmax with _softmax (see https://github.com/pytorch/pytorch/pull/133882
-        # for details).
-        result = ReplaceSafeSoftmaxWithSoftmax()(model_gm)
-        assert result is not None
-        model_gm = result.graph_module
 
     # Prepare
     prepared_model = prepare_pt2e(model_gm, quantizer)

--- a/backends/cadence/aot/utils.py
+++ b/backends/cadence/aot/utils.py
@@ -235,14 +235,6 @@ def print_ops_info(
         )
 
 
-def model_gm_has_SDPA(model_gm: torch.fx.GraphModule) -> bool:
-    for node in model_gm.graph.nodes:
-        if node.op == "call_function":
-            if node.target == torch.ops.aten.scaled_dot_product_attention.default:
-                return True
-    return False
-
-
 def save_pte_program(
     prog: ExecutorchProgramManager, model_name: str, output_dir: str = ""
 ) -> None:


### PR DESCRIPTION
Summary:
Since we changed the flow to run decomps before the quantizer, we don't need the extra SDPA path now (which was one of the points!). Remove it here.
`ReplaceSafeSoftmaxWithSoftmax` is retained since it's used by Helios for now.

Differential Revision: D67561688


