### PR TITLE
release notes: Updated README.md installation for MacOS

### DIFF
--- a/examples/demo-apps/apple_ios/LLaMA/docs/delegates/xnnpack_README.md
+++ b/examples/demo-apps/apple_ios/LLaMA/docs/delegates/xnnpack_README.md
@@ -34,7 +34,10 @@ Install dependencies
 ```
 ./install_requirements.sh
 ```
-
+Optional: Use the --pybind flag to install with pybindings.
+```
+./install_requirements.sh --pybind xnnpack
+```
 ## Prepare Models
 In this demo app, we support text-only inference with up-to-date Llama models and image reasoning inference with LLaVA 1.5.
 * You can request and download model weights for Llama through Meta official [website](https://llama.meta.com/).


### PR DESCRIPTION
To install XNNPACK on macOS, you need to run the ./install_requirements.sh script with the --pybind xnnpack option. This ensures that the necessary dependencies are correctly configured for your environment. 
`@pytorchbot label "topic: not user facing"`
