### PR TITLE
Handle illegal character in benchmark configs filename

### DIFF
--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -111,7 +111,7 @@ jobs:
           # so let's just sed it
           sed -i -e 's,{{ model_path }},'"${MODEL_PATH}"',g' android-llm-device-farm-test-spec.yml.j2
 
-          BENCHMARK_CONFIG_ID="${{ matrix.model }}_${{ matrix.config }}"
+          BENCHMARK_CONFIG_ID=$(echo "${{ matrix.model }}_${{ matrix.config }}" | sed -e 's/[^A-Za-z0-9._-]/_/g')
           # The config for this benchmark runs, we save it in the test spec so that it can be fetched
           # later by the upload script
           sed -i -e 's,{{ benchmark_config_id }},'"${BENCHMARK_CONFIG_ID}"',g' android-llm-device-farm-test-spec.yml.j2

--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -112,7 +112,7 @@ jobs:
           # so let's just sed it
           sed -i -e 's,{{ model_path }},'"${MODEL_PATH}"',g' android-llm-device-farm-test-spec.yml.j2
 
-          BENCHMARK_CONFIG_ID="${{ matrix.model }}_${{ matrix.config }}"
+          BENCHMARK_CONFIG_ID=$(echo "${{ matrix.model }}_${{ matrix.config }}" | sed -e 's/[^A-Za-z0-9._-]/_/g')
           # The config for this benchmark runs, we save it in the test spec so that it can be fetched
           # later by the upload script
           sed -i -e 's,{{ benchmark_config_id }},'"${BENCHMARK_CONFIG_ID}"',g' android-llm-device-farm-test-spec.yml.j2
@@ -121,10 +121,9 @@ jobs:
           # Just print the test spec for debugging
           cat android-llm-device-farm-test-spec.yml
 
-          BENCHMARK_CONFIG_FILENAME=$(echo "${BENCHMARK_CONFIG_ID}" | sed -e 's/[^A-Za-z0-9._-]/_/g')
           # Save the benchmark configs so that we can use it later in the dashboard
-          echo "${BENCHMARK_CONFIG}" > "${BENCHMARK_CONFIG_FILENAME}.json"
-          echo "benchmark-config-filename=${BENCHMARK_CONFIG_FILENAME}" >> $GITHUB_OUTPUT
+          echo "${BENCHMARK_CONFIG}" > "${BENCHMARK_CONFIG_ID}.json"
+          echo "benchmark-config-id=${BENCHMARK_CONFIG_ID}" >> $GITHUB_OUTPUT
 
       - name: Upload the spec
         uses: seemethere/upload-artifact-s3@v5
@@ -144,7 +143,7 @@ jobs:
             ${{ github.repository }}/${{ github.run_id }}/artifacts/benchmark-configs/
           retention-days: 1
           if-no-files-found: error
-          path: extension/benchmark/android/benchmark/${{ steps.prepare.outputs.benchmark-config-filename }}.json
+          path: extension/benchmark/android/benchmark/${{ steps.prepare.outputs.benchmark-config-id }}.json
 
   export-models:
     name: export-models

--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -111,7 +111,7 @@ jobs:
           # so let's just sed it
           sed -i -e 's,{{ model_path }},'"${MODEL_PATH}"',g' android-llm-device-farm-test-spec.yml.j2
 
-          BENCHMARK_CONFIG_ID=$(echo "${{ matrix.model }}_${{ matrix.config }}" | sed -e 's/[^A-Za-z0-9._-]/_/g')
+          BENCHMARK_CONFIG_ID="${{ matrix.model }}_${{ matrix.config }}"
           # The config for this benchmark runs, we save it in the test spec so that it can be fetched
           # later by the upload script
           sed -i -e 's,{{ benchmark_config_id }},'"${BENCHMARK_CONFIG_ID}"',g' android-llm-device-farm-test-spec.yml.j2
@@ -120,8 +120,9 @@ jobs:
           # Just print the test spec for debugging
           cat android-llm-device-farm-test-spec.yml
 
+          BENCHMARK_CONFIG_FILENAME=$(echo "${BENCHMARK_CONFIG_ID}" | sed -e 's/[^A-Za-z0-9._-]/_/g')
           # Save the benchmark configs so that we can use it later in the dashboard
-          echo "${BENCHMARK_CONFIG}" > "${BENCHMARK_CONFIG_ID}.json"
+          echo "${BENCHMARK_CONFIG}" > "${BENCHMARK_CONFIG_FILENAME}.json"
 
       - name: Upload the spec
         uses: seemethere/upload-artifact-s3@v5

--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -98,6 +98,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Prepare the spec
+        id: prepare
         shell: bash
         env:
           BENCHMARK_CONFIG: ${{ toJSON(matrix) }}
@@ -123,6 +124,7 @@ jobs:
           BENCHMARK_CONFIG_FILENAME=$(echo "${BENCHMARK_CONFIG_ID}" | sed -e 's/[^A-Za-z0-9._-]/_/g')
           # Save the benchmark configs so that we can use it later in the dashboard
           echo "${BENCHMARK_CONFIG}" > "${BENCHMARK_CONFIG_FILENAME}.json"
+          echo "benchmark-config-filename=${BENCHMARK_CONFIG_FILENAME}" >> $GITHUB_OUTPUT
 
       - name: Upload the spec
         uses: seemethere/upload-artifact-s3@v5
@@ -142,7 +144,7 @@ jobs:
             ${{ github.repository }}/${{ github.run_id }}/artifacts/benchmark-configs/
           retention-days: 1
           if-no-files-found: error
-          path: extension/benchmark/android/benchmark/${{ matrix.model }}_${{ matrix.config }}.json
+          path: extension/benchmark/android/benchmark/${{ steps.prepare.outputs.benchmark-config-filename }}.json
 
   export-models:
     name: export-models

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -125,6 +125,7 @@ jobs:
           BENCHMARK_CONFIG_FILENAME=$(echo "${BENCHMARK_CONFIG_ID}" | sed -e 's/[^A-Za-z0-9._-]/_/g')
           # Save the benchmark configs so that we can use it later in the dashboard
           echo "${BENCHMARK_CONFIG}" > "${BENCHMARK_CONFIG_FILENAME}.json"
+          echo "benchmark-config-filename=${BENCHMARK_CONFIG_FILENAME}" >> $GITHUB_OUTPUT
 
       - name: Upload the spec
         uses: seemethere/upload-artifact-s3@v5
@@ -144,7 +145,7 @@ jobs:
             ${{ github.repository }}/${{ github.run_id }}/artifacts/benchmark-configs/
           retention-days: 1
           if-no-files-found: error
-          path: extension/benchmark/apple/Benchmark/${{ matrix.model }}_${{ matrix.config }}.json
+          path: extension/benchmark/apple/Benchmark/${{ steps.prepare.outputs.benchmark-config-filename }}.json
 
   export-models:
     name: export-models

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -114,7 +114,7 @@ jobs:
           # so let's just sed it
           sed -i -e 's,{{ model_path }},'"${MODEL_PATH}"',g' default-ios-device-farm-appium-test-spec.yml.j2
 
-          BENCHMARK_CONFIG_ID="${{ matrix.model }}_${{ matrix.config }}"
+          BENCHMARK_CONFIG_ID=$(echo "${{ matrix.model }}_${{ matrix.config }}" | sed -e 's/[^A-Za-z0-9._-]/_/g')
           # The config for this benchmark runs, we save it in the test spec so that it can be fetched
           # later by the upload script
           sed -i -e 's,{{ benchmark_config_id }},'"${BENCHMARK_CONFIG_ID}"',g' default-ios-device-farm-appium-test-spec.yml.j2
@@ -123,10 +123,9 @@ jobs:
           # Just print the test spec for debugging
           cat default-ios-device-farm-appium-test-spec.yml
 
-          BENCHMARK_CONFIG_FILENAME=$(echo "${BENCHMARK_CONFIG_ID}" | sed -e 's/[^A-Za-z0-9._-]/_/g')
           # Save the benchmark configs so that we can use it later in the dashboard
-          echo "${BENCHMARK_CONFIG}" > "${BENCHMARK_CONFIG_FILENAME}.json"
-          echo "benchmark-config-filename=${BENCHMARK_CONFIG_FILENAME}" >> $GITHUB_OUTPUT
+          echo "${BENCHMARK_CONFIG}" > "${BENCHMARK_CONFIG_ID}.json"
+          echo "benchmark-config-id=${BENCHMARK_CONFIG_ID}" >> $GITHUB_OUTPUT
 
       - name: Upload the spec
         uses: seemethere/upload-artifact-s3@v5
@@ -146,7 +145,7 @@ jobs:
             ${{ github.repository }}/${{ github.run_id }}/artifacts/benchmark-configs/
           retention-days: 1
           if-no-files-found: error
-          path: extension/benchmark/apple/Benchmark/${{ steps.prepare.outputs.benchmark-config-filename }}.json
+          path: extension/benchmark/apple/Benchmark/${{ steps.prepare.outputs.benchmark-config-id }}.json
 
   export-models:
     name: export-models

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -113,7 +113,7 @@ jobs:
           # so let's just sed it
           sed -i -e 's,{{ model_path }},'"${MODEL_PATH}"',g' default-ios-device-farm-appium-test-spec.yml.j2
 
-          BENCHMARK_CONFIG_ID=$(echo "${{ matrix.model }}_${{ matrix.config }}" | sed -e 's/[^A-Za-z0-9._-]/_/g')
+          BENCHMARK_CONFIG_ID="${{ matrix.model }}_${{ matrix.config }}"
           # The config for this benchmark runs, we save it in the test spec so that it can be fetched
           # later by the upload script
           sed -i -e 's,{{ benchmark_config_id }},'"${BENCHMARK_CONFIG_ID}"',g' default-ios-device-farm-appium-test-spec.yml.j2
@@ -122,8 +122,9 @@ jobs:
           # Just print the test spec for debugging
           cat default-ios-device-farm-appium-test-spec.yml
 
+          BENCHMARK_CONFIG_FILENAME=$(echo "${BENCHMARK_CONFIG_ID}" | sed -e 's/[^A-Za-z0-9._-]/_/g')
           # Save the benchmark configs so that we can use it later in the dashboard
-          echo "${BENCHMARK_CONFIG}" > "${BENCHMARK_CONFIG_ID}.json"
+          echo "${BENCHMARK_CONFIG}" > "${BENCHMARK_CONFIG_FILENAME}.json"
 
       - name: Upload the spec
         uses: seemethere/upload-artifact-s3@v5

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -113,7 +113,7 @@ jobs:
           # so let's just sed it
           sed -i -e 's,{{ model_path }},'"${MODEL_PATH}"',g' default-ios-device-farm-appium-test-spec.yml.j2
 
-          BENCHMARK_CONFIG_ID="${{ matrix.model }}_${{ matrix.config }}"
+          BENCHMARK_CONFIG_ID=$(echo "${{ matrix.model }}_${{ matrix.config }}" | sed -e 's/[^A-Za-z0-9._-]/_/g')
           # The config for this benchmark runs, we save it in the test spec so that it can be fetched
           # later by the upload script
           sed -i -e 's,{{ benchmark_config_id }},'"${BENCHMARK_CONFIG_ID}"',g' default-ios-device-farm-appium-test-spec.yml.j2

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -100,6 +100,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Prepare the spec
+        id: prepare
         shell: bash
         env:
           BENCHMARK_CONFIG: ${{ toJSON(matrix) }}


### PR DESCRIPTION
As reported by https://github.com/pytorch/executorch/actions/runs/12540463242/job/34967784456 that after https://github.com/pytorch/executorch/pull/7433#issuecomment-2565870028 landed, exporting some spec files are failing because of invalid filename, for example `meta-llama/Llama-3.2-1B`.  The fix here is just to remove the illegal characters from the filename.  Tthe upload script will use the JSON content, not the filename anyway.

### Testing

Testing `meta-llama/Llama-3.2-1B` model on:

* Android https://github.com/pytorch/executorch/actions/runs/12553877667
* iOS https://github.com/pytorch/executorch/actions/runs/12553882773

