### PR TITLE
Install torchao by default

### DIFF
--- a/examples/models/llama/install_requirements.sh
+++ b/examples/models/llama/install_requirements.sh
@@ -9,9 +9,6 @@
 # Install sentencepiece for llama tokenizer
 pip install snakeviz sentencepiece
 
-# Install torchao.
-pip install "$(dirname "$0")/../../../third-party/ao"
-
 # Install lm-eval for Model Evaluation with lm-evalution-harness
 # Install tiktoken for tokenizer
 pip install lm_eval==0.4.5

--- a/examples/models/llama3_2_vision/install_requirements.sh
+++ b/examples/models/llama3_2_vision/install_requirements.sh
@@ -9,6 +9,3 @@ NIGHTLY_VERSION="dev20241112"
 
 # Install torchtune nightly for model definitions.
 pip install --pre torchtune==0.4.0.${NIGHTLY_VERSION} --extra-index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir
-
-# Install torchao.
-pip install "$(dirname "$0")/../../../third-party/ao"

--- a/examples/models/phi-3-mini-lora/install_requirements.sh
+++ b/examples/models/phi-3-mini-lora/install_requirements.sh
@@ -8,6 +8,3 @@
 pip install torchvision
 pip install torchtune
 pip install tiktoken
-
-# Install torchao.
-pip install "$(dirname "$0")/../../../third-party/ao"

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -170,6 +170,23 @@ subprocess.run(
     check=True,
 )
 
+LOCAL_REQUIREMENTS = [
+    "third-party/ao",  # We need the latest kernels for fast iteration, so not relying on pypi.
+]
+
+# Install packages directly from local copy instead of pypi.
+# This is usually not recommended.
+subprocess.run(
+    [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        *LOCAL_REQUIREMENTS,
+    ],
+    check=True,
+)
+
 #
 # Install executorch pip package. This also makes `flatc` available on the path.
 # The --extra-index-url may be necessary if pyproject.toml has a dependency on a


### PR DESCRIPTION
Summary:

Now that torchao is not experimental anymore, we can rely on torchao directly via git submodule.

Part of #7460 

### Test plan

CI
