### PR TITLE
Update install_requirements to install --pybind xnnpack by default.

### DIFF
--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -98,7 +98,19 @@ Alternatively, if you would like to experiment with ExecuTorch quickly and easil
    Use the [`--pybind` flag](https://github.com/pytorch/executorch/blob/main/install_requirements.sh#L26-L29) to install with pybindings and dependencies for other backends.
    ```bash
    ./install_requirements.sh --pybind <coreml | mps | xnnpack>
+
+   # Example: pybindings with CoreML *only*
+   ./install_requirements.sh --pybind coreml
+
+   # Example: pybinds with CoreML *and* XNNPACK
+   ./install_requirements.sh --pybind coreml xnnpack
    ```
+
+   By default, `./install_requirements.sh` command installs pybindings for XNNPACK. To disable any pybindings altogether:
+   ```bash
+   ./install_requirements.sh --pybind off
+   ```
+
 After setting up your environment, you are ready to convert your PyTorch programs
 to ExecuTorch.
 

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -66,21 +66,34 @@ if not python_is_compatible():
     sys.exit(1)
 
 # Parse options.
-EXECUTORCH_BUILD_PYBIND = "OFF"
+
+EXECUTORCH_BUILD_PYBIND = ""
 CMAKE_ARGS = os.getenv("CMAKE_ARGS", "")
 CMAKE_BUILD_ARGS = os.getenv("CMAKE_BUILD_ARGS", "")
 USE_PYTORCH_NIGHTLY = True
 
-for arg in sys.argv[1:]:
+args = sys.argv[1:]
+for arg in args:
     if arg == "--pybind":
-        EXECUTORCH_BUILD_PYBIND = "ON"
+        pass
     elif arg in ["coreml", "mps", "xnnpack"]:
-        if EXECUTORCH_BUILD_PYBIND == "ON":
+        if "--pybind" in args:
             arg_upper = arg.upper()
+            EXECUTORCH_BUILD_PYBIND = "ON"
             CMAKE_ARGS += f" -DEXECUTORCH_BUILD_{arg_upper}=ON"
         else:
             print(f"Error: {arg} must follow --pybind")
             sys.exit(1)
+    elif arg == "off":
+        if "--pybind" in args:
+            if EXECUTORCH_BUILD_PYBIND == "ON":
+                print("Cannot turnoff pybind option as it is already set.")
+                sys.exit(1)
+            EXECUTORCH_BUILD_PYBIND = "OFF"
+        else:
+            print(f"Error: {arg} must follow --pybind")
+            sys.exit(1)
+
     elif arg == "--clean":
         print("Cleaning build artifacts...")
         print("Cleaning pip-out/...")
@@ -99,6 +112,13 @@ for arg in sys.argv[1:]:
     else:
         print(f"Error: Unknown option {arg}")
         sys.exit(1)
+
+# If --pybind is not set explicitly for backends (e.g., --pybind xnnpack)
+# or is not turned off explicitly (--pybind off)
+# then install XNNPACK by default.
+if EXECUTORCH_BUILD_PYBIND == "":
+    EXECUTORCH_BUILD_PYBIND = "ON"
+    CMAKE_ARGS += " -DEXECUTORCH_BUILD_XNNPACK=ON"
 
 # Use ClangCL on Windows.
 # ClangCL is an alias to Clang that configures it to work in an MSVC-compatible


### PR DESCRIPTION
### Summary:

Regular ./install_requirements.sh will install pybind xnnpack by default. It is necessary for Llama for instance.

It is still backwards compatible with './install_requirements.sh --pybind xnnpack'

One can also turn off explicitly by calling './install_requirement.sh --pybind off'

### Test Plan:

Test valid options:

./install_requirements.sh
./install_requirements.sh --pybind xnnpack
./install_requirements.sh --pybind coreml
./install_requirements.sh --pybind coreml xnnpack
./install_requirements.sh --pybind off

Invalid options:

./install_requirements.sh xnnpack
./install_requirements.sh --pybind coreml off
./install_requirements.sh --pybind coreml xnnpack off
./install_requirements.sh off

Partially fixes https://github.com/pytorch/executorch/issues/7460
