### PR TITLE
Build executorch Sphinx docs internally and link to static docs

### DIFF
--- a/docs/TARGETS
+++ b/docs/TARGETS
@@ -1,0 +1,46 @@
+load("@fbcode_macros//build_defs:native_rules.bzl", "buck_filegroup", "buck_sh_test")
+load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
+
+oncall("pytorch_r2p")
+
+python_binary(
+    name = "sphinx",
+    main_module = "sphinx.cmd.build",
+    par_style = "xar",
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir:lib",
+        "//executorch/devtools:lib",
+        "//executorch/exir/backend/test:backend_with_compiler_demo",
+        "//executorch/exir/backend/test:op_partitioner_demo",
+        "//executorch/devtools/bundled_program/serialize:lib",
+        "fbsource//third-party/pypi/ipykernel:ipykernel",
+        "fbsource//third-party/pypi/jupyter-client:jupyter-client",
+        "fbsource//third-party/pypi/jupytext:jupytext",
+        "fbsource//third-party/pypi/nbsphinx:nbsphinx",
+        "fbsource//third-party/pypi/pytorch-sphinx-theme:pytorch-sphinx-theme",
+        "fbsource//third-party/pypi/sphinx:sphinx",
+        "fbsource//third-party/pypi/breathe:breathe",
+        "fbsource//third-party/pypi/sphinx-copybutton:sphinx-copybutton",
+        "fbsource//third-party/pypi/sphinx-design:sphinx-design",
+        "fbsource//third-party/pypi/sphinx-gallery:sphinx-gallery",
+        "fbsource//third-party/pypi/matplotlib:matplotlib",
+        "fbsource//third-party/pypi/myst-parser:myst-parser",
+    ],
+)
+
+buck_filegroup(
+    name = "source",
+    srcs = glob(["source/**/*"]),
+)
+
+buck_sh_test(
+    name = "doctest",
+    args = [
+        "-M",
+        "doctest",
+        "$(location :source)/source/",
+        "/tmp/sphinxbuild",
+    ],
+    test = ":sphinx",
+)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,8 @@ author = "ExecuTorch Contributors"
 import os
 import sys
 
+FBCODE = "fbcode" in os.getcwd()
+
 extensions = [
     "breathe",
     "sphinx.ext.autodoc",
@@ -59,8 +61,12 @@ extensions = [
     "myst_parser",
     "sphinx_design",
     "sphinx_gallery.gen_gallery",
-    "executorch_custom_versions",
 ]
+
+if not FBCODE:
+    extensions += [
+        "executorch_custom_versions",
+    ]
 
 this_file_dir = os.path.abspath(os.path.dirname(__file__))
 doxygen_xml_dir = os.path.join(


### PR DESCRIPTION
Summary: This diff builds the OSS ET Sphinx docs internally and then hosts them on the static docs ExecuTorch site internally. Any documentation put under an `executorch/docs/fb` folder will be available only internally and not visible in the OSS documentation.

Differential Revision: D58986545


