### PR TITLE
Add uint16 to supported dtypes in exir/dialects

### DIFF
--- a/exir/dialects/edge/dtype/supported.py
+++ b/exir/dialects/edge/dtype/supported.py
@@ -25,6 +25,7 @@ regular_tensor_dtypes_to_str = {
     torch.float16: "Half",
     torch.float: "Float",
     torch.double: "Double",
+    torch.uint16: "UInt16",
 }
 
 regular_tensor_str_to_dtypes = {


### PR DESCRIPTION
Summary: Add `uint16_t` to the supported dtypes here so that the verifier doesn't fail when one of the dtypes for an op is `uint16_t`.

Differential Revision: D67803963


