### PR TITLE
Fixed always rebuild issue in cmake.

### DIFF
--- a/schema/CMakeLists.txt
+++ b/schema/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 # The include directory that will contain the generated schema headers.
 set(_program_schema__include_dir "${CMAKE_BINARY_DIR}/schema/include")
-
+set(_program_schema__output_dir "${_program_schema__include_dir}/executorch/schema")
 # Source root directory for executorch.
 if(NOT EXECUTORCH_ROOT)
   set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
@@ -26,16 +26,16 @@ function(generate_program_schema _schema_srcs _schema_name)
   foreach(fbs_file ${_schema_srcs})
     string(REGEX REPLACE "[.]fbs$" "_generated.h" generated "${fbs_file}")
     list(APPEND _schema_outputs
-         "${_program_schema__include_dir}/executorch/schema/${generated}"
+         "${_program_schema__output_dir}/${generated}"
     )
   endforeach()
-  
+
   # Generate the headers from the .fbs files.
   add_custom_command(
     OUTPUT ${_schema_outputs}
     COMMAND
       ${FLATC_EXECUTABLE} --cpp --cpp-std c++11 --gen-mutable --scoped-enums -o
-      "${_program_schema__include_dir}/executorch/schema" ${_schema_srcs}
+      "${_program_schema__output_dir}" ${_schema_srcs}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${FLATC_EXECUTABLE} ${_schema_srcs}
     COMMENT "Generating ${_schema_name} headers"

--- a/schema/CMakeLists.txt
+++ b/schema/CMakeLists.txt
@@ -26,10 +26,10 @@ function(generate_program_schema _schema_srcs _schema_name)
   foreach(fbs_file ${_schema_srcs})
     string(REGEX REPLACE "[.]fbs$" "_generated.h" generated "${fbs_file}")
     list(APPEND _schema_outputs
-         "${_program_schema__include_dir}/executorch/${generated}"
+         "${_program_schema__include_dir}/executorch/schema/${generated}"
     )
   endforeach()
-
+  
   # Generate the headers from the .fbs files.
   add_custom_command(
     OUTPUT ${_schema_outputs}


### PR DESCRIPTION

### Summary
Fixes #7511 

CMake generates different files than expected, thus the incremental builds always rebuild.

The generated files were located in include/executorch/schema/program_generated.h CMake was expecting files in include/executorch/program_generated.h

This causes cmake to always regenerate the files, as the expected artifacts are never there.
 
Presumably this was a change at some point, and the expected output from CMake never got updated.


### Test plan
Fixes the build issue, but I only tested it with ninja single config generator, behavior should be the same on all others though.
