### PR TITLE
Fix the logging format string for the negative zero point in XNNCompiler.cpp

### DIFF
--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -342,7 +342,7 @@ Error defineTensor(
         auto qparams = qtensor_value->quant_params_as_PerTensorQuant();
         ET_LOG(
             Debug,
-            "define quant tensor (per tensor): buffer_ptr: %p, scale: %f, zp: %u\n",
+            "define quant tensor (per tensor): buffer_ptr: %p, scale: %f, zp: %d\n",
             buffer_ptr,
             qparams->scale(),
             qparams->zero_point());


### PR DESCRIPTION
The zero point can be negative.