### PR TITLE
Create a separate header for macros used with nnlib kernel calls.

### DIFF
--- a/backends/cadence/fusion_g3/operators/op_add.cpp
+++ b/backends/cadence/fusion_g3/operators/op_add.cpp
@@ -10,6 +10,7 @@
 
 #include <xa_nnlib_kernels_api.h>
 
+#include <executorch/backends/cadence/fusion_g3/operators/xt_macros.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/elementwise_util.h>
 #include <executorch/kernels/portable/cpu/util/kernel_ops_util.h>
@@ -27,15 +28,6 @@ namespace cadence {
 namespace impl {
 namespace G3 {
 namespace native {
-
-#define XT_KERNEL_CHECK(ctx, out, kernel, ...) \
-  const auto ret = kernel(__VA_ARGS__);        \
-  ET_KERNEL_CHECK_MSG(                         \
-      ctx,                                     \
-      ret == 0,                                \
-      InvalidArgument,                         \
-      out,                                     \
-      "Failed to run kernel: " #kernel "(" #__VA_ARGS__ ")");
 
 Tensor& add_out(
     KernelRuntimeContext& ctx,

--- a/backends/cadence/fusion_g3/operators/targets.bzl
+++ b/backends/cadence/fusion_g3/operators/targets.bzl
@@ -27,6 +27,7 @@ def define_operator(name: str, deps: list[str] | None = None) -> None:
         deps = deps + common_deps,
         exported_deps = [
             ":operators_header",
+            ":xt_macros",
         ],
     )
 
@@ -52,6 +53,18 @@ def define_common_targets():
     runtime.cxx_library(
         name = "operators_header",
         exported_headers = ["operators.h"],
+        visibility = [
+            "//executorch/backends/cadence/...",
+        ],
+        exported_deps = [
+            "//executorch/runtime/core/exec_aten:lib",
+            "//executorch/runtime/kernel:kernel_runtime_context",
+        ],
+    )
+
+    runtime.cxx_library(
+        name = "xt_macros",
+        exported_headers = ["xt_macros.h"],
         visibility = [
             "//executorch/backends/cadence/...",
         ],

--- a/backends/cadence/fusion_g3/operators/xt_macros.h
+++ b/backends/cadence/fusion_g3/operators/xt_macros.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
+
+#define XT_KERNEL_CHECK(ctx, out, kernel, ...) \
+  const auto ret = kernel(__VA_ARGS__);        \
+  ET_KERNEL_CHECK_MSG(                         \
+      ctx,                                     \
+      ret == 0,                                \
+      InvalidArgument,                         \
+      out,                                     \
+      "Failed to run kernel: " #kernel "(" #__VA_ARGS__ ")");


### PR DESCRIPTION
Summary: Moves the `XT_KERNEL_CHECK` to a separate header.

Differential Revision: D67839291


