### PR TITLE
fix the qnn sdk env issue

### DIFF
--- a/examples/qualcomm/oss_scripts/llama3_2/TARGETS
+++ b/examples/qualcomm/oss_scripts/llama3_2/TARGETS
@@ -30,6 +30,8 @@ runtime.command_alias(
     name = "llama_qnn",
     env = {
         "LD_LIBRARY_PATH": "$(location fbsource//third-party/qualcomm/qnn/qnn-{0}:qnn_offline_compile_libs)".format(get_qnn_library_verision()),
+        # Place holder to pass the QNN_SDK_ROOT check in executorch/examples/qualcomm/utils.py
+        "QNN_SDK_ROOT": "",
     },
     exe = ":llama",
 )


### PR DESCRIPTION
Summary:
`executorch/examples/qualcomm/utils.py` will check if `QNN_SDK_ROOT` is set. This is helpful for oss, but internally we rely on buck to set the deps. Currently we just set `QNN_SDK_ROOT` to empty to bypass the issue.

```
buck run mode/dev-nosan //executorch/examples/qualcomm/oss_scripts/llama3_2:llama_qnn -- --compile_only --ptq 16a4w --checkpoint /home/chenlai/local//consolidated.00.pth --params /home/chenlai/local//params.json --tokenizer_model /home/chenlai/local//tokenizer.model --prompt "Once" -m SM8650 --model_size 1B --model_mode hybrid --build_folder /home/chenlai/local   2>&1 | tee static_llama.log
```
bypass-github-export-checks

Reviewed By: billmguo

Differential Revision: D67814838


