### PR TITLE
update oncall from torchx to executorch

### DIFF
--- a/docs/TARGETS
+++ b/docs/TARGETS
@@ -1,7 +1,7 @@
 load("@fbcode_macros//build_defs:native_rules.bzl", "buck_filegroup", "buck_sh_test")
 load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
 
-oncall("pytorch_r2p")
+oncall("executorch")
 
 python_binary(
     name = "sphinx",


### PR DESCRIPTION
Summary: fix oncall ownership issue. failed test should not direct to torchx team: https://www.internalfb.com/intern/test/562950144401585

Differential Revision: D67859613


