### PR TITLE
Fix mypy lintrunner

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -321,6 +321,7 @@ command = [
     '--config=.mypy.ini',
     '--show-disable',
     '--',
+    '--explicit-package-bases',
     '@{{PATHSFILE}}'
 ]
 init_command = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -197,7 +197,7 @@ intersphinx_mapping = {
 
 # Custom directives defintions to create cards on main landing page
 
-from custom_directives import (
+from custom_directives import (  # type: ignore[import-not-found]
     CustomCardEnd,
     CustomCardItem,
     CustomCardStart,


### PR DESCRIPTION
Sometimes we have duplicate subpackage names (e.g., backends/arm/quantizer, backends/qualcomm/quantizer)

If __init__.py is not given in parent directories, it doesn't resolve the packages unambiguously unless "explicit-package-bases" option is set.

https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-paths-to-modules

Issue: https://github.com/pytorch/executorch/issues/7441

### Test Plan

Before
Comment out `backends/**/*.py*`, it was silently failing. 

After
It is failing, but with actual typechecker errors.