### PR TITLE
Add support to export XNNPACK based static_llama

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -79,7 +79,14 @@ pkg_name = __name__
 verbosity_setting = None
 
 
-EXECUTORCH_DEFINED_MODELS = ["stories110m", "llama2", "llama3", "llama3_1", "llama3_2"]
+EXECUTORCH_DEFINED_MODELS = [
+    "stories110m",
+    "llama2",
+    "llama3",
+    "llama3_1",
+    "llama3_2",
+    "static_llama",
+]
 TORCHTUNE_DEFINED_MODELS = ["llama3_2_vision"]
 
 


### PR DESCRIPTION
Summary:
Add support to export XNNPACK based static_llama
- static_llama is the QNN backend hybrid/prefill+decode model with KV cache as the inference input
  - https://www.internalfb.com/code/fbsource/fbcode/executorch/examples/qualcomm/oss_scripts/llama2/model/static_llama.py

Differential Revision: D67867190


