### PR TITLE
[DRAFT] Use mask instead of cond for attention conditional logic

### DIFF
--- a/extension/llm/modules/attention.py
+++ b/extension/llm/modules/attention.py
@@ -246,6 +246,7 @@ class MultiHeadAttention(nn.Module):
         # x has shape [b, s_x, d]
         # y has shape [b, s_y, d]
         b, s_x, _ = x.shape
+        s_y = y.shape[1] if y is not None else 0
 
         # q has shape [b, s_x, num_heads * head_dim]
         q = self.q_proj(x)
@@ -262,9 +263,16 @@ class MultiHeadAttention(nn.Module):
         if self.q_norm is not None:
             q = self.q_norm(q)
 
-        def calculate_kv(y):
+        if y is None:
+            if self.kv_cache is None:
+                raise ValueError(
+                    "Must provide y input or use kv_cache to enable streaming decoding"
+                )
+            k = self.kv_cache.k_cache
+            v = self.kv_cache.v_cache
+        else:
             # Update k and v shape, positional embeddings, and normalization
-            s_y = y.shape[1]
+
             # k has shape [b, s_y, num_kv_heads * head_dim]
             # v has shape [b, s_y, num_kv_heads * head_dim]
             k = self.k_proj(y)
@@ -280,37 +288,12 @@ class MultiHeadAttention(nn.Module):
             # Normalize k
             if self.k_norm is not None:
                 k = self.k_norm(k)
-            return k, v
 
-        def true_fn(y):
-            kv_cache = self.kv_cache.clone()
-            return kv_cache.k_cache, kv_cache.v_cache, kv_cache.cache_pos
-
-        def false_fn(y):
-            k, v = calculate_kv(y)
-            kv_cache = self.kv_cache.clone()
-            kv_cache.update(k, v)
-            return kv_cache.k_cache, kv_cache.v_cache, kv_cache.cache_pos
-
-        # If kv cache is None, we expect y to be provided
-        if self.kv_cache is None:
-            assert (
-                y is not None
-            ), "Must provide y input or use kv_cache to enable streaming decoding"
-            k, v = calculate_kv(y)
-        else:
-            # Expecting the k, v returning here to be the same size of self.kv_cache
-            # In eager, we expect this predicate to specialize. In export, this will
-            # become a SymBool so it's not specialized.
-            k, v, cache_pos = torch.cond(
-                torch.isnan(y).all().item(), true_fn, false_fn, (y,)
-            )
             # Update key-value cache
-            self.kv_cache.k_cache.copy_(k)
-            self.kv_cache.v_cache.copy_(v)
-            self.kv_cache.cache_pos.copy_(cache_pos)
+            if self.kv_cache is not None and self.cache_enabled:
+                k, v = self.kv_cache.update(k, v)
 
-        output = self._sdpa(q, k, v, b, s_x, mask=mask)
+        output = self._sdpa(q, k, v, b, s_x)
         return self.output_proj(output)
 
 
@@ -352,17 +335,25 @@ class SDPA(nn.Module):
         # View + expand + reshape bring num_kv_heads to num_heads for k and v
         # to match q.
 
-        # [bsz, n_h, s, h_d]
-        q = q.transpose(1, 2)
-        k = k.transpose(1, 2)
-        v = v.transpose(1, 2)
+        # k: [bsz, seq_len, n_kv, 1, h_d]
+        # v: [bsz, seq_len, n_kv, 1, h_d]
+        k = k.view(bsz, -1, self.num_kv_heads, 1, self.head_dim)
+        v = v.view(bsz, -1, self.num_kv_heads, 1, self.head_dim)
 
         # Expand the key and value tensors to have the same shape
         # as the query tensor by copying values across the relevant dim
         if self.num_heads != self.num_kv_heads:
-            expand_shape = (-1, -1, self.q_per_kv, -1, -1)
-            k = k.unsqueeze(2).expand(expand_shape).flatten(1, 2)
-            v = v.unsqueeze(2).expand(expand_shape).flatten(1, 2)
+            k = k.expand(bsz, -1, self.num_kv_heads, self.q_per_kv, self.head_dim)
+            v = v.expand(bsz, -1, self.num_kv_heads, self.q_per_kv, self.head_dim)
+
+        # [bsz, s, n_h, h_d]
+        k = k.reshape(bsz, -1, self.num_heads, self.head_dim)
+        v = v.reshape(bsz, -1, self.num_heads, self.head_dim)
+
+        # [bsz, n_h, s, h_d]
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
 
         output = self._attention_fn(
             q,


### PR DESCRIPTION
### Summary
Use masking to avoid resorting to `torch.cond`, which prevents us from mutating inside branches thereby forcing us to clone the kv cache and create lots of unnecessary copies.

Also gets past the current limitation that the partitioners don't automatically recursively partition conditional subgraphs, allowing us to directly partition Llama 3.2 MM with XNNPack.

#### Llama 3.2 MM comparison against XNNPack + KV cache + custom SDPA
| **Metric** | **Before** | **After** |
| --- | --- | --- |
| Activations | 0.95 GB | **0.27 GB** |
| .pte size | 60 GB | **30 GB** |
| Prefill | 20.91 s | **0.86 s** |
| Generation | 0.28 tok/s | **6.26 tok/s** |

### Test plan
Rely on existing regression tests ([test_attention](https://github.com/pytorch/executorch/blob/main/extension/llm/modules/test/test_attention.py) and [test_kv_cache](https://github.com/pytorch/executorch/pull/7279/files#diff-a5fcc5119e8382e6f3fcf84b47014736440253c9c56216a617b40de4b750cc2c) - about to be merged), which have adequate coverage over kv cache and multi-head attention edge cases.
