### PR TITLE
Log dtype names on input dtype mismatch

### DIFF
--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -830,14 +830,14 @@ Method::set_input(const EValue& input_evalue, size_t input_idx) {
   if (e.isTensor()) {
     const auto& t_dst = e.toTensor();
     const auto& t_src = input_evalue.toTensor();
+
     ET_CHECK_OR_RETURN_ERROR(
         t_dst.scalar_type() == t_src.scalar_type(),
         InvalidArgument,
-        "The %zu-th input tensor's scalartype does not meet requirement: found %" PRId8
-        " but expected %" PRId8,
+        "Input %zu has unexpected scalar type: expected %s but was %s.",
         input_idx,
-        static_cast<int8_t>(t_src.scalar_type()),
-        static_cast<int8_t>(t_dst.scalar_type()));
+        executorch::runtime::toString(t_dst.scalar_type()),
+        executorch::runtime::toString(t_src.scalar_type()));
     // Reset the shape for the Method's input as the size of forwarded input
     // tensor for shape dynamism. Also is a safety check if need memcpy.
     Error err = resize_tensor(t_dst, t_src.sizes());

--- a/runtime/executor/targets.bzl
+++ b/runtime/executor/targets.bzl
@@ -82,6 +82,7 @@ def define_common_targets():
                 "//executorch/runtime/core:evalue" + aten_suffix,
                 "//executorch/runtime/core:event_tracer" + aten_suffix,
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
+                "//executorch/runtime/core/exec_aten/util:scalar_type_util" + aten_suffix,
                 "//executorch/runtime/core/exec_aten/util:tensor_util" + aten_suffix,
                 "//executorch/runtime/kernel:kernel_runtime_context" + aten_suffix,
                 "//executorch/runtime/kernel:operator_registry",


### PR DESCRIPTION
Summary:
Update the error message when input tensor scalar type is incorrect. We've seen this get hit a few times and it should be easier to debug than it is.

New Message:
```
[method.cpp:825] Input 0 has unexpected scalar type: expected Byte but was Float.
```
Old Message:
```
[method.cpp:826] The 0-th input tensor's scalartype does not meet requirement: found 0 but expected 6
```

Differential Revision: D67887770


