### PR TITLE
module example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,16 +181,16 @@ option(EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT "Build the custom ops lib for AOT"
 )
 
 option(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER "Build the Data Loader extension"
-       OFF
+       ON
 )
 
-option(EXECUTORCH_BUILD_EXTENSION_MODULE "Build the Module extension" OFF)
+option(EXECUTORCH_BUILD_EXTENSION_MODULE "Build the Module extension" ON)
 
 option(EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL "Build the Runner Util extension"
        OFF
 )
 
-option(EXECUTORCH_BUILD_EXTENSION_TENSOR "Build the Tensor extension" OFF)
+option(EXECUTORCH_BUILD_EXTENSION_TENSOR "Build the Tensor extension" ON)
 
 option(EXECUTORCH_BUILD_EXTENSION_TRAINING "Build the training extension" OFF)
 
@@ -832,6 +832,23 @@ if(EXECUTORCH_BUILD_EXECUTOR_RUNNER)
   endif()
   target_link_libraries(executor_runner ${_executor_runner_libs})
   target_compile_options(executor_runner PUBLIC ${_common_compile_options})
+endif()
+
+if(TRUE)
+  # Build Module
+  set(_module_libs executorch gflags)
+  list(APPEND _module_libs
+    portable_ops_lib
+    portable_kernels
+    extension_data_loader
+    extension_tensor
+    extension_module_static
+  )
+
+  add_executable(module_runner examples/portable/module/module.cpp)
+  target_link_libraries(module_runner ${_module_libs})
+  target_compile_options(module_runner PUBLIC ${_common_compile_options})
+
 endif()
 
 if(EXECUTORCH_BUILD_VULKAN)

--- a/examples/portable/module/module.cpp
+++ b/examples/portable/module/module.cpp
@@ -1,0 +1,28 @@
+#include <executorch/extension/module/module.h>
+#include <executorch/extension/tensor/tensor.h>
+
+#include <iostream>
+using namespace ::executorch::extension;
+
+int main(int argc, char** argv) {
+  // Create a Module.
+  Module module(
+      "/data/users/lfq/executorch/extension/module/test/resources/add.pte");
+
+  // Wrap the input data with a Tensor.
+  float input[1] = {4.f};
+  auto tensor = from_blob(input, {1});
+
+  auto err = module.set_inputs({tensor, tensor});
+
+  // Perform an inference.
+  const auto result = module.forward();
+
+  // Check for success or failure.
+  if (result.ok()) {
+    // Retrieve the output data.
+    const auto output = result->at(0).toTensor().const_data_ptr<float>();
+    std::cout << "Output: " << output[0] << std::endl;
+  }
+  return 0;
+}


### PR DESCRIPTION
Example for: https://discuss.pytorch.org/t/use-executorchs-module-extension-api-on-arm64-mac/215068/3

Build
```
./install_requirements.sh --clean

(mkdir cmake-out     && cd cmake-out     && cmake -DEXECUTORCH_PAL_DEFAULT=posix ..)   && cmake --build cmake-out -j32 --target module_runner

```
Run:
```
./cmake-out/module_runner 
```

Output:
```
(executorch) [lfq@devvm20128.prn0 /data/users/lfq/executorch (lfq.module_example)]$ ./cmake-out/module_runner 
Output: 8
```