### PR TITLE
Fix the use of PyTorch pin commit in MacOS

### DIFF
--- a/.ci/docker/conda-env-ci.txt
+++ b/.ci/docker/conda-env-ci.txt
@@ -1,2 +1,4 @@
 cmake=3.22.1
 ninja=1.10.2
+libuv
+pkg-config

--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -131,6 +131,7 @@ if [[ -z "${GITHUB_RUNNER:-}" ]]; then
 fi
 
 print_cmake_info
+install_pytorch_and_domains
 # We build PyTorch from source here instead of using nightly. This allows CI to test against
 # the pinned commit from PyTorch
 install_executorch "use-pt-pinned-commit"

--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -131,7 +131,7 @@ if [[ -z "${GITHUB_RUNNER:-}" ]]; then
 fi
 
 print_cmake_info
-# We use PyTorch build from source here instead of nightly. This allows CI to test against
+# We build PyTorch from source here instead of using nightly. This allows CI to test against
 # the pinned commit from PyTorch
 install_executorch "use-pt-pinned-commit"
 build_executorch_runner "${BUILD_TOOL}"

--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -131,5 +131,8 @@ if [[ -z "${GITHUB_RUNNER:-}" ]]; then
 fi
 
 print_cmake_info
-install_executorch
+# We use PyTorch build from source here instead of nightly. This allows CI to test against
+# the pinned commit from PyTorch
+install_executorch "use-pt-pinned-commit"
 build_executorch_runner "${BUILD_TOOL}"
+do_not_use_nightly_on_ci

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -58,7 +58,10 @@ install_pytorch_and_domains() {
   git checkout "${TORCH_VERSION}"
   git submodule update --init --recursive
 
-  export _GLIBCXX_USE_CXX11_ABI=1
+  export USE_PYTORCH_METAL_EXPORT=1
+  export USE_COREML_DELEGATE=1
+  export USE_DISTRIBUTED=0
+
   # Then build and install PyTorch
   python setup.py bdist_wheel
   pip install "$(echo dist/*.whl)"

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -58,6 +58,7 @@ install_pytorch_and_domains() {
   git checkout "${TORCH_VERSION}"
   git submodule update --init --recursive
 
+  export _GLIBCXX_USE_CXX11_ABI=1
   # Then build and install PyTorch
   python setup.py bdist_wheel
   pip install "$(echo dist/*.whl)"

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -58,10 +58,7 @@ install_pytorch_and_domains() {
   git checkout "${TORCH_VERSION}"
   git submodule update --init --recursive
 
-  export USE_PYTORCH_METAL_EXPORT=1
-  export USE_COREML_DELEGATE=1
-  export USE_DISTRIBUTED=0
-
+  export _GLIBCXX_USE_CXX11_ABI=1
   # Then build and install PyTorch
   python setup.py bdist_wheel
   pip install "$(echo dist/*.whl)"

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -58,7 +58,7 @@ install_pytorch_and_domains() {
   git checkout "${TORCH_VERSION}"
   git submodule update --init --recursive
 
-  export _GLIBCXX_USE_CXX11_ABI=1
+  export USE_DISTRIBUTED=1
   # Then build and install PyTorch
   python setup.py bdist_wheel
   pip install "$(echo dist/*.whl)"


### PR DESCRIPTION
I missed this in https://github.com/pytorch/executorch/pull/6564, we need to apply the same fix for MacOS and add a test to make sure that PyTorch built from the pin commit is used instead of nightly.