### PR TITLE
Clean up executorch_print_configuration_summary

### DIFF
--- a/build/Utils.cmake
+++ b/build/Utils.cmake
@@ -46,12 +46,20 @@ function(executorch_print_configuration_summary)
   message(STATUS "  EXECUTORCH_BUILD_ARM_BAREMETAL         : "
                  "${EXECUTORCH_BUILD_ARM_BAREMETAL}"
   )
+  message(STATUS "  EXECUTORCH_BUILD_CADENCE               : "
+                 "${EXECUTORCH_BUILD_CADENCE}"
+  )
   message(
     STATUS
       "  EXECUTORCH_BUILD_COREML                : ${EXECUTORCH_BUILD_COREML}"
   )
-  message(STATUS "  EXECUTORCH_BUILD_KERNELS_CUSTOM        : "
-                 "${EXECUTORCH_BUILD_KERNELS_CUSTOM}"
+  message(
+    STATUS
+      "  EXECUTORCH_BUILD_CPUINFO               : ${EXECUTORCH_BUILD_CPUINFO}"
+  )
+  message(
+    STATUS
+      "  EXECUTORCH_BUILD_DEVTOOLS              : ${EXECUTORCH_BUILD_DEVTOOLS}"
   )
   message(STATUS "  EXECUTORCH_BUILD_EXECUTOR_RUNNER       : "
                  "${EXECUTORCH_BUILD_EXECUTOR_RUNNER}"
@@ -68,7 +76,7 @@ function(executorch_print_configuration_summary)
   message(STATUS "  EXECUTORCH_BUILD_EXTENSION_TENSOR      : "
                  "${EXECUTORCH_BUILD_EXTENSION_TENSOR}"
   )
-  message(STATUS "  EXECUTORCH_BUILD_EXTENSION_TRAINING      : "
+  message(STATUS "  EXECUTORCH_BUILD_EXTENSION_TRAINING    : "
                  "${EXECUTORCH_BUILD_EXTENSION_TRAINING}"
   )
   message(
@@ -79,22 +87,14 @@ function(executorch_print_configuration_summary)
     STATUS
       "  EXECUTORCH_BUILD_GFLAGS                : ${EXECUTORCH_BUILD_GFLAGS}"
   )
-  message(
-    STATUS
-      "  EXECUTORCH_BUILD_GTESTS                : ${EXECUTORCH_BUILD_GTESTS}"
-  )
   message(STATUS "  EXECUTORCH_BUILD_HOST_TARGETS          : "
                  "${EXECUTORCH_BUILD_HOST_TARGETS}"
   )
-  message(
-    STATUS "  EXECUTORCH_BUILD_MPS                   : ${EXECUTORCH_BUILD_MPS}"
+  message(STATUS "  EXECUTORCH_BUILD_KERNELS_CUSTOM        : "
+                 "${EXECUTORCH_BUILD_KERNELS_CUSTOM}"
   )
-  message(
-    STATUS
-      "  EXECUTORCH_BUILD_PYBIND                : ${EXECUTORCH_BUILD_PYBIND}"
-  )
-  message(
-    STATUS "  EXECUTORCH_BUILD_QNN                   : ${EXECUTORCH_BUILD_QNN}"
+  message(STATUS "  EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT    : "
+                 "${EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT}"
   )
   message(STATUS "  EXECUTORCH_BUILD_KERNELS_OPTIMIZED     : "
                  "${EXECUTORCH_BUILD_KERNELS_OPTIMIZED}"
@@ -103,19 +103,11 @@ function(executorch_print_configuration_summary)
                  "${EXECUTORCH_BUILD_KERNELS_QUANTIZED}"
   )
   message(
-    STATUS "  EXECUTORCH_BUILD_DEVTOOLS              : ${EXECUTORCH_BUILD_DEVTOOLS}"
+    STATUS "  EXECUTORCH_BUILD_MPS                   : ${EXECUTORCH_BUILD_MPS}"
   )
   message(
     STATUS
-      "  EXECUTORCH_BUILD_SIZE_TEST             : ${EXECUTORCH_BUILD_SIZE_TEST}"
-  )
-  message(
-    STATUS
-      "  EXECUTORCH_BUILD_XNNPACK               : ${EXECUTORCH_BUILD_XNNPACK}"
-  )
-  message(
-    STATUS
-      "  EXECUTORCH_BUILD_VULKAN                : ${EXECUTORCH_BUILD_VULKAN}"
+      "  EXECUTORCH_BUILD_NEURON                : ${EXECUTORCH_BUILD_NEURON}"
   )
   message(
     STATUS
@@ -123,7 +115,26 @@ function(executorch_print_configuration_summary)
   )
   message(
     STATUS
-      "  EXECUTORCH_BUILD_CPUINFO               : ${EXECUTORCH_BUILD_CPUINFO}"
+      "  EXECUTORCH_BUILD_PYBIND                : ${EXECUTORCH_BUILD_PYBIND}"
+  )
+  message(
+    STATUS "  EXECUTORCH_BUILD_QNN                   : ${EXECUTORCH_BUILD_QNN}"
+  )
+  message(
+    STATUS
+      "  EXECUTORCH_BUILD_SIZE_TEST             : ${EXECUTORCH_BUILD_SIZE_TEST}"
+  )
+  message(
+    STATUS
+      "  EXECUTORCH_BUILD_TESTS                 : ${EXECUTORCH_BUILD_TESTS}"
+  )
+  message(
+    STATUS
+      "  EXECUTORCH_BUILD_VULKAN                : ${EXECUTORCH_BUILD_VULKAN}"
+  )
+  message(
+    STATUS
+      "  EXECUTORCH_BUILD_XNNPACK               : ${EXECUTORCH_BUILD_XNNPACK}"
   )
 
 endfunction()
@@ -193,7 +204,10 @@ function(extract_sources sources_file)
       elseif("${ANDROID_ABI}" STREQUAL "x86_64")
         set(target_platforms_arg "--target-platforms=shim//:android-x86_64")
       else()
-        message(FATAL_ERROR "Unsupported ANDROID_ABI setting ${ANDROID_ABI}. Please add it here!")
+        message(
+          FATAL_ERROR
+            "Unsupported ANDROID_ABI setting ${ANDROID_ABI}. Please add it here!"
+        )
       endif()
     endif()
     execute_process(
@@ -269,9 +283,12 @@ function(resolve_buck2)
     endif()
   endif()
 
-  # Update the var in the parent scope. Note that this does not modify our
-  # local $BUCK2 value.
-  set(BUCK2 "${buck2}" PARENT_SCOPE)
+  # Update the var in the parent scope. Note that this does not modify our local
+  # $BUCK2 value.
+  set(BUCK2
+      "${buck2}"
+      PARENT_SCOPE
+  )
 
   # The buck2 daemon can get stuck. Killing it can help.
   message(STATUS "Killing buck2 daemon")
@@ -279,8 +296,7 @@ function(resolve_buck2)
     # Note that we need to use the local buck2 variable. BUCK2 is only set in
     # the parent scope, and can still be empty in this scope.
     COMMAND "${buck2} killall"
-    WORKING_DIRECTORY ${executorch_root}
-    COMMAND_ECHO STDOUT
+    WORKING_DIRECTORY ${executorch_root} COMMAND_ECHO STDOUT
   )
 endfunction()
 


### PR DESCRIPTION
### Summary

Add missing `EXECUTORCH_BUILD_` options. `s/EXECUTORCH_BUILD_GTESTS/EXECUTORCH_BUILD_TESTS/` . Sort them. Run cmake-format.

### Test plan

`cmake -S . -B cmake-out -DCMAKE_BUILD_TYPE=Release`
inspect result
compare to `cd cmake-out; cmake -LH ..` to make sure we aren't missing more `EXECUTORCH_BUILD_` options
