### PR TITLE
[ET-VK] Parse required extensions of shaders and check capabilities during dispatch

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -87,6 +87,27 @@ void Context::report_shader_dispatch_end() {
   }
 }
 
+void Context::check_device_capabilities(const vkapi::ShaderInfo& shader) {
+  if (shader.requires_shader_int16) {
+    if (!adapter_p_->supports_int16_shader_types()) {
+      throw vkapi::ShaderNotSupportedError(
+          shader.kernel_name, vkapi::VulkanExtension::SHADER_INT16);
+    }
+  }
+  if (shader.requires_16bit_storage) {
+    if (!adapter_p_->supports_16bit_storage_buffers()) {
+      throw vkapi::ShaderNotSupportedError(
+          shader.kernel_name, vkapi::VulkanExtension::INT16_STORAGE);
+    }
+  }
+  if (shader.requires_8bit_storage) {
+    if (!adapter_p_->supports_8bit_storage_buffers()) {
+      throw vkapi::ShaderNotSupportedError(
+          shader.kernel_name, vkapi::VulkanExtension::INT8_STORAGE);
+    }
+  }
+}
+
 vkapi::DescriptorSet Context::get_descriptor_set(
     const vkapi::ShaderInfo& shader_descriptor,
     const utils::uvec3& local_workgroup_size,

--- a/backends/vulkan/runtime/api/Context.h
+++ b/backends/vulkan/runtime/api/Context.h
@@ -185,6 +185,8 @@ class Context final {
     }
   }
 
+  void check_device_capabilities(const vkapi::ShaderInfo& shader);
+
   vkapi::DescriptorSet get_descriptor_set(
       const vkapi::ShaderInfo&,
       const utils::uvec3&,

--- a/backends/vulkan/runtime/graph/ops/DispatchNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/DispatchNode.cpp
@@ -58,6 +58,8 @@ void DispatchNode::encode(ComputeGraph* graph) {
   api::Context* const context = graph->context();
   vkapi::PipelineBarrier pipeline_barrier{};
 
+  context->check_device_capabilities(shader_);
+
   std::unique_lock<std::mutex> cmd_lock = context->dispatch_lock();
 
   std::array<uint8_t, kMaxPushConstantSize> push_constants_data;

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.glsl
@@ -34,8 +34,6 @@ ${layout_declare_ubo(8, "float", "out_min", "float", "out_max")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
-#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
-
 /*
  * Computes a depthwise convolution. Each shader invocation calculates the
  * output at a single output location.

--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -256,6 +256,9 @@ std::string Adapter::stringize() const {
   ss << "    deviceType:    " << device_type << std::endl;
   ss << "    deviceName:    " << properties.deviceName << std::endl;
 
+#define PRINT_BOOL(value, name) \
+  ss << "      " << std::left << std::setw(36) << #name << value << std::endl;
+
 #define PRINT_PROP(struct, name)                                       \
   ss << "      " << std::left << std::setw(36) << #name << struct.name \
      << std::endl;
@@ -298,12 +301,13 @@ std::string Adapter::stringize() const {
   ss << "    }" << std::endl;
 #endif /* VK_KHR_8bit_storage */
 
-#ifdef VK_KHR_shader_float16_int8
   ss << "    Shader 16bit and 8bit Features {" << std::endl;
+  PRINT_BOOL(physical_device_.supports_int16_shader_types, shaderInt16)
+#ifdef VK_KHR_shader_float16_int8
   PRINT_PROP(physical_device_.shader_float16_int8_types, shaderFloat16);
   PRINT_PROP(physical_device_.shader_float16_int8_types, shaderInt8);
-  ss << "    }" << std::endl;
 #endif /* VK_KHR_shader_float16_int8 */
+  ss << "    }" << std::endl;
 
   const VkPhysicalDeviceMemoryProperties& mem_props =
       physical_device_.memory_properties;

--- a/backends/vulkan/runtime/vk_api/Exception.cpp
+++ b/backends/vulkan/runtime/vk_api/Exception.cpp
@@ -77,5 +77,36 @@ Error::Error(SourceLocation source_location, const char* cond, std::string msg)
   what_ = oss.str();
 }
 
+//
+// ShaderNotSupportedError
+//
+
+std::ostream& operator<<(std::ostream& out, const VulkanExtension result) {
+  switch (result) {
+    case VulkanExtension::SHADER_INT16:
+      out << "shaderInt16";
+      break;
+    case VulkanExtension::INT16_STORAGE:
+      out << "VK_KHR_16bit_storage";
+      break;
+    case VulkanExtension::INT8_STORAGE:
+      out << "VK_KHR_8bit_storage";
+      break;
+  }
+  return out;
+}
+
+ShaderNotSupportedError::ShaderNotSupportedError(
+    std::string shader_name,
+    VulkanExtension extension)
+    : shader_name_(std::move(shader_name)), extension_{extension} {
+  std::ostringstream oss;
+  oss << "Shader " << shader_name_ << " ";
+  oss << "not compatible with device. ";
+  oss << "Missing support for extension or physical device feature: ";
+  oss << extension_;
+  what_ = oss.str();
+}
+
 } // namespace vkapi
 } // namespace vkcompute

--- a/backends/vulkan/runtime/vk_api/Exception.h
+++ b/backends/vulkan/runtime/vk_api/Exception.h
@@ -78,5 +78,26 @@ class Error : public std::exception {
   }
 };
 
+enum class VulkanExtension : uint8_t {
+  SHADER_INT16,
+  INT16_STORAGE,
+  INT8_STORAGE,
+};
+
+class ShaderNotSupportedError : public std::exception {
+ public:
+  ShaderNotSupportedError(std::string shader_name, VulkanExtension extension);
+
+ private:
+  std::string shader_name_;
+  VulkanExtension extension_;
+  std::string what_;
+
+ public:
+  const char* what() const noexcept override {
+    return what_.c_str();
+  }
+};
+
 } // namespace vkapi
 } // namespace vkcompute

--- a/backends/vulkan/runtime/vk_api/Shader.cpp
+++ b/backends/vulkan/runtime/vk_api/Shader.cpp
@@ -28,14 +28,20 @@ ShaderInfo::ShaderInfo(
     const uint32_t* const spirv_bin,
     const uint32_t size,
     std::vector<VkDescriptorType>  layout,
-    const utils::uvec3 tile_size)
+    const utils::uvec3 tile_size,
+    const bool requires_shader_int16_ext,
+    const bool requires_16bit_storage_ext,
+    const bool requires_8bit_storage_ext)
     : src_code{
           spirv_bin,
           size,
       },
       kernel_name{std::move(name)},
       kernel_layout{std::move(layout)},
-      out_tile_size(tile_size) {
+      out_tile_size(tile_size),
+      requires_shader_int16(requires_shader_int16_ext),
+      requires_16bit_storage(requires_16bit_storage_ext),
+      requires_8bit_storage(requires_8bit_storage_ext) {
 }
 
 bool operator==(const ShaderInfo& _1, const ShaderInfo& _2) {

--- a/backends/vulkan/runtime/vk_api/Shader.h
+++ b/backends/vulkan/runtime/vk_api/Shader.h
@@ -62,6 +62,9 @@ struct ShaderInfo final {
 
   // Shader Metadata
   utils::uvec3 out_tile_size{1u, 1u, 1u};
+  bool requires_shader_int16 = false;
+  bool requires_16bit_storage = false;
+  bool requires_8bit_storage = false;
 
   explicit ShaderInfo();
 
@@ -70,7 +73,10 @@ struct ShaderInfo final {
       const uint32_t*,
       const uint32_t,
       std::vector<VkDescriptorType>,
-      const utils::uvec3 tile_size);
+      const utils::uvec3 tile_size,
+      const bool requires_shader_int16_ext,
+      const bool requires_16bit_storage_ext,
+      const bool requires_8bit_storage_ext);
 
   operator bool() const {
     return src_code.bin != nullptr;

--- a/backends/vulkan/test/op_tests/utils/gen_correctness_base.py
+++ b/backends/vulkan/test/op_tests/utils/gen_correctness_base.py
@@ -45,7 +45,12 @@ class GeneratedOpsTest_{op_name} : public ::testing::Test {{
 test_suite_template = """
 TEST_P(GeneratedOpsTest_{op_name}, {case_name}) {{
 {create_ref_data}
+try {{
 {create_and_check_out}
+}}
+catch (const vkcompute::vkapi::ShaderNotSupportedError& e) {{
+    GTEST_SKIP() << e.what();
+}}
 }}
 """
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #7577
* __->__ #7576

## Context

Now that we are using GLSL/SPIR-V extensions more heavily in our shaders, there is a risk that a particular shader uses an extension that is not supported by the physical device.

It is tedious to manually check that all the extensions required by a shader is supported by the device; it would be much more convenient for developers if there was an automated way to perform this check. This diff provides a solution for this.

Materially, this has manifested into an issue with our internal CI tests that run on Android emulator (which uses swiftshader under the hood). If the emulator tries to compile a shader that requires the `shaderInt16` feature, then the emulator will crash.

## Solution

1. Update `ShaderInfo` to have fields indicating whether certain extensions that require device support is required.
2. Update the `gen_vulkan_spv.py` shader compilation script to parse the GLSL code and log whether aforemention extensions are needed in the generated `ShaderInfo`.
3. Introduce a new exception class, `ShaderNotSupportedError`.
4. Before dispatching, check that all extensions required by the shader is supported by the device. If not, throw the new exception class.
4. In the generated operator correctness tests, skip the test if `ShaderNotSupportedError` is thrown.

Differential Revision: [D67992067](https://our.internmc.facebook.com/intern/diff/D67992067/)