### PR TITLE
Typo in coreml README.md

### DIFF
--- a/backends/apple/coreml/README.md
+++ b/backends/apple/coreml/README.md
@@ -99,8 +99,8 @@ quantization_config = LinearQuantizerConfig.from_dict(
     {
         "global_config": {
             "quantization_scheme": QuantizationScheme.symmetric,
-            "activation_dtype": torch.uint8,
-            "weight_dtype": torch.int8,
+            "activation_dtype": torch.quint8,
+            "weight_dtype": torch.qint8,
             "weight_per_channel": True,
         }
     }

--- a/backends/apple/coreml/README.md
+++ b/backends/apple/coreml/README.md
@@ -93,7 +93,7 @@ class Model(torch.nn.Module):
 source_model = Model()
 example_inputs = (torch.randn((1, 3, 256, 256)), )
 
-pre_autograd_aten_dialect = export_for_training(model, example_inputs).module()
+pre_autograd_aten_dialect = export_for_training(source_model, example_inputs).module()
 
 quantization_config = LinearQuantizerConfig.from_dict(
     {


### PR DESCRIPTION
### Summary

Fixed typos in the coreml README.md:
* `model` -> `source_model`
* `torch.int8` -> `torch.qint8`
* `torch.uint8` -> `torch.quint8`