### PR TITLE
[ET-VK] Tuning conv2d dw op batching size for improved performance.

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.yaml
@@ -10,7 +10,7 @@ conv2d_dw_output_tile:
     NDIM: 3
     DTYPE: float
     TILE_SIZE: 3
-    BATCH_SIZE_X: 4
+    BATCH_SIZE_X: 8
     BATCH_SIZE_Y: 2
   generate_variant_forall:
     DTYPE:
@@ -22,6 +22,10 @@ conv2d_dw_output_tile:
       OPERATOR: clamp(X, A, B)
     - NAME: conv2d_dw_output_tile_5x5
       TILE_SIZE: 5
+      BATCH_SIZE_X: 4
+      BATCH_SIZE_Y: 2
     - NAME: conv2d_dw_output_tile_5x5_clamp
       OPERATOR: clamp(X, A, B)
       TILE_SIZE: 5
+      BATCH_SIZE_X: 4
+      BATCH_SIZE_Y: 2

--- a/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
@@ -293,7 +293,7 @@ Conv2dMethod get_conv2d_method(
 utils::uvec2 get_conv2d_dw_dispatch_divisor(
     const std::vector<int64_t>& weight_sizes) {
   if (weight_sizes.at(2) == 3 && weight_sizes.at(3) == 3) {
-    return {4u, 2u};
+    return {8u, 2u};
   }
   if (weight_sizes.at(2) == 5 && weight_sizes.at(3) == 5) {
     return {4u, 2u};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #7597
* #7596
* #7595

This diff makes changes make stride equals dilation the default mode for conv2d dw output op.
Adds a different source file to handle stride not equal dilation case.

Differential Revision: [D68026015](https://our.internmc.facebook.com/intern/diff/D68026015/)