### PR TITLE
[ET-VK][ez] Fix 8-bit linear shaders extension requirement

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/q_8w_linear.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q_8w_linear.glsl
@@ -16,7 +16,8 @@
 ${define_active_storage_type(STORAGE)}
 
 ${define_required_extensions(DTYPE)}
-${define_required_extensions("int8")}
+$if STORAGE == "buffer":
+  ${define_required_extensions("int8")}
 
 #include "indexing_utils.h"
 

--- a/backends/vulkan/runtime/graph/ops/glsl/q_8w_linear_optimized.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q_8w_linear_optimized.glsl
@@ -16,7 +16,8 @@
 ${define_active_storage_type(STORAGE)}
 
 ${define_required_extensions(DTYPE)}
-${define_required_extensions("int8")}
+$if STORAGE == "buffer":
+  ${define_required_extensions("int8")}
 
 
 $if BATCH_MODE:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #7601
* __->__ #7600

## Context

8-bit linear compute shaders only require the 8bit_storage extension for buffer tensors. Now that we are checking that the GPU supports required extensions, we need to be more careful about declaring that a extensions as required.

Differential Revision: [D68035429](https://our.internmc.facebook.com/intern/diff/D68035429/)