### PR TITLE
Fix duplication of  classes in modules

### DIFF
--- a/extension/android/BUCK
+++ b/extension/android/BUCK
@@ -23,18 +23,13 @@ fb_android_library(
 fb_android_library(
     name = "executorch_llama",
     srcs = [
-        "src/main/java/org/pytorch/executorch/DType.java",
-        "src/main/java/org/pytorch/executorch/EValue.java",
         "src/main/java/org/pytorch/executorch/LlamaCallback.java",
         "src/main/java/org/pytorch/executorch/LlamaModule.java",
-        "src/main/java/org/pytorch/executorch/Module.java",
-        "src/main/java/org/pytorch/executorch/NativePeer.java",
-        "src/main/java/org/pytorch/executorch/Tensor.java",
-        "src/main/java/org/pytorch/executorch/annotations/Experimental.java",
     ],
     autoglob = False,
     language = "JAVA",
     deps = [
+        ":executorch",
         "//fbandroid/java/com/facebook/jni:jni",
         "//fbandroid/libraries/soloader/java/com/facebook/soloader/nativeloader:nativeloader",
     ],


### PR DESCRIPTION
Summary: If both the executorch and executorch_llama modules are included, this could cause class duplication errors. This fixes it by reorganizing the modules.

Differential Revision: D68027619


