### PR TITLE
[not for landing] coreml llama

### DIFF
--- a/examples/apple/coreml/scripts/extract_coreml_models.py
+++ b/examples/apple/coreml/scripts/extract_coreml_models.py
@@ -23,7 +23,7 @@ from executorch.exir.schema import (
 )
 
 
-def extract_coreml_models(pte_data: bytes):
+def extract_coreml_models(pte_data: bytes, output_dir: str = "."):
     program = deserialize_pte_binary(pte_data)
     delegates: List[BackendDelegate] = sum(
         [execution_plan.delegates for execution_plan in program.execution_plan], []
@@ -45,7 +45,7 @@ def extract_coreml_models(pte_data: bytes):
                 AssertionError("The loaded Program must have inline data.")
 
         model_name: str = f"model_{model_index}"
-        model_path: Path = Path() / "extracted_coreml_models" / model_name
+        model_path: Path = Path() / output_dir / "extracted_coreml_models" / model_name
         if model_path.exists():
             shutil.rmtree(model_path.absolute())
         os.makedirs(model_path.absolute())
@@ -72,9 +72,15 @@ if __name__ == "__main__":
         required=True,
         help="Input must be a .pte file.",
     )
+    parser.add_argument(
+        "-o",
+        "--output_dir",
+        default=".",
+        help="Output directory to save the extracted Core ML models.",
+    )
 
     args = parser.parse_args()
     model_path = str(args.model_path)
     with open(model_path, mode="rb") as pte_file:
         pte_data = pte_file.read()
-        extract_coreml_models(pte_data)
+        extract_coreml_models(pte_data, args.output_dir)

--- a/examples/models/llama/model.py
+++ b/examples/models/llama/model.py
@@ -52,6 +52,7 @@ class Llama2Model(EagerModelBase):
         self.input_prune_map_path = kwargs.get("input_prune_map_path", None)
         self.output_prune_map_path = kwargs.get("output_prune_map_path", None)
         self.max_seq_len = kwargs.get("max_seq_len", 128)
+        self.static_seq_length = kwargs.get("static_seq_length", 1)
         self.args = kwargs.get("args", None)
 
         # The example is using a dummy small model with random weights for demo purpose only.
@@ -281,7 +282,9 @@ the checkpoint format to avoid generating faulty models.
     def get_example_inputs_kvcache_sdpa(self):
         if self.enable_dynamic_shape:
             return (
-                torch.tensor([[2, 3, 4]], dtype=torch.long),
+                torch.tensor(
+                    [[0 for _ in range(self.static_seq_length)]], dtype=torch.long
+                ),
                 torch.tensor([0], dtype=torch.long),
             )
         else:

--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -157,6 +157,10 @@ class LLMEdgeManager:
         return self
 
     def _get_dynamic_shape(self) -> Any:
+        print("OVERRIDING DYNAMIC SHAPE TO NONE!!!!!")
+        self.dynamic_shapes = None
+        return None
+
         if self.dynamic_shapes:
             return self.dynamic_shapes
 

--- a/extension/llm/export/partitioner_lib.py
+++ b/extension/llm/export/partitioner_lib.py
@@ -166,6 +166,10 @@ def get_coreml_partitioner(
     return CoreMLPartitioner(  # pyre-fixme[16]
         compile_specs=compile_specs,
         take_over_mutable_buffer=take_over_mutable_buffer,
+        skip_ops_for_coreml_delegation=[
+            "quantized_decomposed.embedding_4bit.dtype",
+            "aten.select_copy.int",
+        ],
     )
 
 

--- a/model_export_script.sh
+++ b/model_export_script.sh
@@ -1,0 +1,13 @@
+set -e
+
+export MODEL_IN=$HOME/models/stories110M/stories110M.pt
+export TOKENIZER=$HOME/models/stories110M/tokenizer.bin
+export PARAMS=$HOME/models/stories110M/params.json
+export MODEL_OUT_DIR=$HOME/models/stories110M
+
+export STATIC_SEQ_LENGTH=500
+
+export MODEL_OUT_DECODE=${MODEL_OUT_DIR}/decode_model_${STATIC_SEQ_LENGTH}.pte
+
+python -m examples.models.llama.export_llama -c $MODEL_IN -p $PARAMS --output_name=$MODEL_OUT_DECODE -E "4,32" -kv --use_sdpa_with_kv_cache --coreml --coreml-ios 18 --coreml-quantize c4w --coreml-compute-units cpu_and_ne --max_seq_length 1024 --verbose -d "fp16" --static_seq_length $STATIC_SEQ_LENGTH
+python examples/apple/coreml/scripts/extract_coreml_models.py -m $MODEL_OUT_DECODE -o "${MODEL_OUT_DIR}/decode_${STATIC_SEQ_LENGTH}"


### PR DESCRIPTION
This is a version of llama that delegates to ANE and can handle a fixed sequence length (e.g., prefill) with input_pos >= 0.  To export the model, run `model_export_script.sh`.  In the script, modify the variables:

```
export MODEL_IN=$HOME/models/stories110M/stories110M.pt
export TOKENIZER=$HOME/models/stories110M/tokenizer.bin
export PARAMS=$HOME/models/stories110M/params.json
export MODEL_OUT_DIR=$HOME/models/stories110M
export STATIC_SEQ_LENGTH=500  
```

to appropriate values for the model you are trying to export.  If STATIC_SEQ_LENGTH=1, the model can be used for decoding.  If STATIC_SEQ_LENGTH > 1, it can be used for static prefill.

Note that although the arg enable_dynamic_shape is set, dynamic_shapes are overridden to be None.  The reason for setting enable_dynamic_shape is because this is how to handle seq_lengh > 1 in llama_transformer.py.

To avoid issues with CoreML delegation, we do the following:
* Run SDPA/KV-cache ops outside of CoreML by skipping them in the partitioner.  The ops required to update KV-cache are not supported on ANE.
* We also skip any node that is a symbolic int or has a symbolic int arg (which is not supported by CoreML).
* Finally, we skip the embedding op because coreml converts the token to uint16 when running on ANE, which will not work with llama3-type models.

For stories110M, I get:

* 163 tokens/sec decode on iPhone 15 Pro
* 56ms for 500 token prefill

(I get a segfault in SDPA op when STATIC_SEQ_LENGTH >= 512, which requires investigation).

**Note: you will encounter an error during CoreML conversion when running export_model_script.sh.  You must first make the change below so that CoreML tools can handle negative infinity in sympy_numbers.**

Update the function _map_sympy_number_to_int in coremltools/converters/mil/frontend/torch/exir_utils.py as follows:
```
def _map_sympy_number_to_int(sympy_number: sympy.core.numbers.Number) -> int:
    MAX_DIM = 2**31 - 1
    MIN_DIM = -2**31
    if sympy_number == sympy.oo or sympy_number > MAX_DIM:
        return MAX_DIM
    elif sympy_number == -sympy.oo or sympy_number < MIN_DIM:
        return MIN_DIM
    else:
        return int(sympy_number)
```