### PR TITLE
Fix broken QNN models on benchmarks

### DIFF
--- a/.ci/scripts/test_model.sh
+++ b/.ci/scripts/test_model.sh
@@ -169,6 +169,13 @@ test_model_with_qnn() {
     EXPORT_SCRIPT=inception_v3
   elif [[ "${MODEL_NAME}" == "vit" ]]; then
     EXPORT_SCRIPT=torchvision_vit
+  elif [[ "${MODEL_NAME}" == "edsr" ]]; then
+    EXPORT_SCRIPT=edsr
+    # Additional deps for edsr
+    pip install piq
+  else
+    echo "Unsupported model $MODEL_NAME"
+    exit 1
   fi
 
   # Use SM8450 for S22, SM8550 for S23, and SM8560 for S24

--- a/examples/qualcomm/scripts/edsr.py
+++ b/examples/qualcomm/scripts/edsr.py
@@ -102,14 +102,17 @@ def main(args):
             "Please specify a device serial by -s/--device argument."
         )
 
-    dataset = get_dataset(
-        args.hr_ref_dir, args.lr_dir, args.default_dataset, args.artifact
-    )
-
-    inputs, targets, input_list = dataset.lr, dataset.hr, dataset.get_input_list()
-    pte_filename = "edsr_qnn_q8"
     instance = EdsrModel()
+    if args.compile_only:
+        inputs = instance.get_example_inputs()
+    else:
+        dataset = get_dataset(
+            args.hr_ref_dir, args.lr_dir, args.default_dataset, args.artifact
+        )
 
+        inputs, targets, input_list = dataset.lr, dataset.hr, dataset.get_input_list()
+
+    pte_filename = "edsr_qnn_q8"
     build_executorch_binary(
         instance.get_eager_model().eval(),
         (inputs[0],),


### PR DESCRIPTION
Fixed edsr that have been failing on nightly benchmark runs: https://github.com/pytorch/executorch/actions/runs/12898498585

Test ad-hoc run for edsr+qnn: https://github.com/pytorch/executorch/actions/runs/12919532695