### PR TITLE
[0.5 release] Update version references for release

### DIFF
--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -80,9 +80,7 @@ Alternatively, if you would like to experiment with ExecuTorch quickly and easil
 
    ```bash
    # Clone the ExecuTorch repo from GitHub
-   # 'main' branch is the primary development branch where you see the latest changes.
-   # 'viable/strict' contains all of the commits on main that pass all of the necessary CI checks.
-   git clone --branch viable/strict https://github.com/pytorch/executorch.git
+   git clone --branch release/0.5 https://github.com/pytorch/executorch.git
    cd executorch
 
    # Update and pull submodules


### PR DESCRIPTION
Copying PRs from the 0.4 release for  the 0.5 release

* https://github.com/pytorch/executorch/pull/6323 to update getting started tutorial to clone from release branch instead of viable/strict