### PR TITLE
Make kv cache pos buffer name more specific

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -778,7 +778,7 @@ def _export_llama(args) -> LLMEdgeManager:  # noqa: C901
 
     additional_passes = []
     if args.model in TORCHTUNE_DEFINED_MODELS:
-        additional_passes = [InitializedMutableBufferPass(["cache_pos"])]
+        additional_passes = [InitializedMutableBufferPass(["kv_cache_pos"])]
     if args.generate_etrecord:
         if not builder_exported_to_edge.edge_manager:
             raise ValueError("Unable to generate etrecord due to missing edge manager.")

--- a/extension/llm/modules/attention.py
+++ b/extension/llm/modules/attention.py
@@ -284,13 +284,13 @@ class MultiHeadAttention(nn.Module):
 
         def true_fn(y):
             kv_cache = self.kv_cache.clone()
-            return kv_cache.k_cache, kv_cache.v_cache, kv_cache.cache_pos
+            return kv_cache.k_cache, kv_cache.v_cache, kv_cache.kv_cache_pos
 
         def false_fn(y):
             k, v = calculate_kv(y)
             kv_cache = self.kv_cache.clone()
             kv_cache.update(k, v)
-            return kv_cache.k_cache, kv_cache.v_cache, kv_cache.cache_pos
+            return kv_cache.k_cache, kv_cache.v_cache, kv_cache.kv_cache_pos
 
         # If kv cache is None, we expect y to be provided
         if self.kv_cache is None:
@@ -308,7 +308,7 @@ class MultiHeadAttention(nn.Module):
             # Update key-value cache
             self.kv_cache.k_cache.copy_(k)
             self.kv_cache.v_cache.copy_(v)
-            self.kv_cache.cache_pos.copy_(cache_pos)
+            self.kv_cache.kv_cache_pos.copy_(cache_pos)
 
         output = self._sdpa(q, k, v, b, s_x, mask=mask)
         return self.output_proj(output)

--- a/extension/llm/modules/test/test_attention.py
+++ b/extension/llm/modules/test/test_attention.py
@@ -219,7 +219,7 @@ class AttentionTest(unittest.TestCase):
             ),
         ).to_executorch(
             config=ExecutorchBackendConfig(
-                passes=[InitializedMutableBufferPass(["cache_pos"])],
+                passes=[InitializedMutableBufferPass(["kv_cache_pos"])],
             )
         )
 
@@ -330,7 +330,7 @@ class AttentionTest(unittest.TestCase):
             ),
         ).to_executorch(
             config=ExecutorchBackendConfig(
-                passes=[InitializedMutableBufferPass(["cache_pos"])],
+                passes=[InitializedMutableBufferPass(["kv_cache_pos"])],
             )
         )
 

--- a/extension/llm/modules/test/test_kv_cache.py
+++ b/extension/llm/modules/test/test_kv_cache.py
@@ -174,7 +174,7 @@ class KVCacheTest(unittest.TestCase):
             ),
         )
         et_config = ExecutorchBackendConfig(
-            passes=[InitializedMutableBufferPass(["cache_pos"])],
+            passes=[InitializedMutableBufferPass(["kv_cache_pos"])],
         )
         et_program = edge_program.to_executorch(config=et_config)
 
@@ -198,7 +198,7 @@ class KVCacheTest(unittest.TestCase):
             ),
         )
         et_config = ExecutorchBackendConfig(
-            passes=[InitializedMutableBufferPass(["cache_pos"])],
+            passes=[InitializedMutableBufferPass(["kv_cache_pos"])],
         )
         et_program = edge_program.to_executorch(config=et_config)
 


### PR DESCRIPTION
### Summary
Doing this now just in case later on there appears another module in TorchTune that:
- Uses "cache_pos" as a buffer name
- Appears frequently
- Doesn't require initial state

In this situation we prevent the pte size from blowing up. `kv_cache_pos` is specific enough that it probably will never appear as the name for another buffer.

### Test plan
- Existing unit tests for kv_cache and attention
- E2E
  - `python -m examples.models.llama.export_llama --model llama3_2_vision --checkpoint /tmp/Llama-3.2-11B-Vision-Instruct/original/consolidated.pth --params examples/models/llama3_2_vision/text_decoder/params/demo_config.json  --metadata '{"append_eos_to_prompt": 0, "get_bos_id":128000, "get_eos_ids":[128009, 128001], "get_n_bos": 0, "get_n_eos": 0}' --output_name="llama3_2_vision.pte" -d fp32 --verbose --max_seq_length 64 -kv`
  - `python -m examples.models.llama3_2_vision.runner.native --model llama3_2_vision --pte llama3_2_vision.pte  --tokenizer /tmp/Llama-3.2-11B-Vision-Instruct/original/tokenizer.model --prompt "Who is the founder of Meta?" --params examples/models/llama3_2_vision/text_decoder/params/demo_config.json --max_len 64 --temperature 0 -kv`

Note: I'll make a ci test soon 😅
