### PR TITLE
Improve error message in method.cpp

### DIFF
--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -833,11 +833,10 @@ Method::set_input(const EValue& input_evalue, size_t input_idx) {
     ET_CHECK_OR_RETURN_ERROR(
         t_dst.scalar_type() == t_src.scalar_type(),
         InvalidArgument,
-        "The %zu-th input tensor's scalartype does not meet requirement: found %" PRId8
-        " but expected %" PRId8,
+        "The %zu-th input tensor's scalartype does not meet requirement: found %s but expected %s",
         input_idx,
-        static_cast<int8_t>(t_src.scalar_type()),
-        static_cast<int8_t>(t_dst.scalar_type()));
+        ::executorch::runtime::toString(t_src.scalar_type()),
+        ::executorch::runtime::toString(t_dst.scalar_type()));
     // Reset the shape for the Method's input as the size of forwarded input
     // tensor for shape dynamism. Also is a safety check if need memcpy.
     Error err = resize_tensor(t_dst, t_src.sizes());


### PR DESCRIPTION
Summary: Use `::executorch::runtime::toString` to print string scalar type instead of a number.

Differential Revision: D68130648


