### PR TITLE
Remove quantize_io from compile_spec

### DIFF
--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -49,8 +49,7 @@ class ArmCompileSpecBuilder:
         self.compiler_flags = []
         self.output_format = None
         self.path_for_intermediates = None
-        self.quantize_io = False
-        self.tosa_spec = None
+        self.tosa_version = None
         self.input_order = None
 
     def ethosu_compile_spec(
@@ -123,14 +122,6 @@ class ArmCompileSpecBuilder:
         self.path_for_intermediates = output_path
         return self
 
-    def set_quantize_io(self, quantize_io: bool = False) -> "ArmCompileSpecBuilder":
-        """
-        Quantization of inputs and dequantization of outputs for cases where
-        whole graph is quantized and method signature is not of quantized type.
-        """
-        self.quantize_io = quantize_io
-        return self
-
     def set_input_order(
         self, input_order: Optional[str] = None
     ) -> "ArmCompileSpecBuilder":
@@ -170,9 +161,6 @@ class ArmCompileSpecBuilder:
                 )
             )
 
-        if self.quantize_io:
-            self.compile_spec.append(CompileSpec("quantize_io", "True".encode()))
-
         return self.compile_spec
 
 
@@ -180,13 +168,6 @@ def is_tosa(compile_spec: List[CompileSpec]) -> bool:
     for spec in compile_spec:
         if spec.key == "output_format":
             return spec.value.decode() == "tosa"
-    return False
-
-
-def is_quantize_io(compile_specs: List[CompileSpec]) -> bool:
-    for spec in compile_specs:
-        if spec.key == "quantize_io" and spec.value.decode() == "True":
-            return True
     return False
 
 

--- a/backends/arm/arm_partitioner.py
+++ b/backends/arm/arm_partitioner.py
@@ -12,7 +12,6 @@ from typing import Callable, final, List, Optional, Tuple
 import torch
 from executorch.backends.arm.arm_backend import (
     ArmBackend,
-    is_quantize_io,
 )  # usort: skip
 from executorch.backends.arm.operator_support.tosa_supported_operators import (
     TOSASupportedOperators,
@@ -88,9 +87,6 @@ class ArmPartitioner(Partitioner):
             for node in partition.nodes:
                 node.meta["delegation_tag"] = tag
                 partition_tags[tag] = self.delegation_spec
-
-            if not is_quantize_io(self.delegation_spec.compile_specs):
-                continue
 
             # De-tag outmost q-nodes upwards and dq-nodes downwards.
             # De-tag if at least one input/ output is not part of partition.

--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -78,14 +78,12 @@ def get_tosa_compile_spec_unbuilt(
         ArmCompileSpecBuilder()
         .tosa_compile_spec(tosa_spec)
         .dump_intermediate_artifacts_to(custom_path)
-        .set_quantize_io(True)
     )
 
     return compile_spec_builder
 
 
 def get_u55_compile_spec(
-    quantize_io=True,
     custom_path=None,
     reorder_inputs=None,
 ) -> list[CompileSpec]:
@@ -93,14 +91,12 @@ def get_u55_compile_spec(
     Default compile spec for Ethos-U55 tests.
     """
     return get_u55_compile_spec_unbuilt(
-        quantize_io=quantize_io,
         custom_path=custom_path,
         reorder_inputs=reorder_inputs,
     ).build()
 
 
 def get_u85_compile_spec(
-    quantize_io=True,
     custom_path=None,
     reorder_inputs=None,
 ) -> list[CompileSpec]:
@@ -108,14 +104,12 @@ def get_u85_compile_spec(
     Default compile spec for Ethos-U85 tests.
     """
     return get_u85_compile_spec_unbuilt(
-        quantize_io=quantize_io,
         custom_path=custom_path,
         reorder_inputs=reorder_inputs,
     ).build()
 
 
 def get_u55_compile_spec_unbuilt(
-    quantize_io=True,
     custom_path=None,
     reorder_inputs=None,
 ) -> ArmCompileSpecBuilder:
@@ -133,7 +127,6 @@ def get_u55_compile_spec_unbuilt(
             memory_mode="Shared_Sram",
             extra_flags="--debug-force-regor --output-format=raw",
         )
-        .set_quantize_io(quantize_io)
         .dump_intermediate_artifacts_to(artifact_path)
         .set_input_order(reorder_inputs)
     )
@@ -141,7 +134,6 @@ def get_u55_compile_spec_unbuilt(
 
 
 def get_u85_compile_spec_unbuilt(
-    quantize_io=True,
     custom_path=None,
     reorder_inputs=None,
 ) -> list[CompileSpec]:
@@ -157,7 +149,6 @@ def get_u85_compile_spec_unbuilt(
             memory_mode="Shared_Sram",
             extra_flags="--output-format=raw",
         )
-        .set_quantize_io(quantize_io)
         .dump_intermediate_artifacts_to(artifact_path)
         .set_input_order(reorder_inputs)
     )

--- a/backends/arm/test/ops/test_depthwise_conv.py
+++ b/backends/arm/test/ops/test_depthwise_conv.py
@@ -259,46 +259,38 @@ class TestDepthwiseConv(unittest.TestCase):
 
     @parameterized.expand(testsuite_conv2d[:4], skip_on_empty=True)
     @pytest.mark.corstone_fvp
-    def test_dw_conv2d_u55_BI(
-        self, test_name: str, model: torch.nn.Module, set_quantize_io: bool = True
-    ):
+    def test_dw_conv2d_u55_BI(self, test_name: str, model: torch.nn.Module):
         self._test_dw_conv_ethos_BI_pipeline(
             model,
-            common.get_u55_compile_spec(quantize_io=set_quantize_io),
+            common.get_u55_compile_spec(),
             model.get_inputs(),
         )
 
     @parameterized.expand(testsuite_conv2d[4:], skip_on_empty=True)
     @pytest.mark.corstone_fvp
     @conftest.expectedFailureOnFVP  # TODO: MLETORCH-516
-    def test_dw_conv2d_u55_BI_xfails(
-        self, test_name: str, model: torch.nn.Module, set_quantize_io: bool = False
-    ):
+    def test_dw_conv2d_u55_BI_xfails(self, test_name: str, model: torch.nn.Module):
         self._test_dw_conv_ethos_BI_pipeline(
             model,
-            common.get_u55_compile_spec(quantize_io=set_quantize_io),
+            common.get_u55_compile_spec(),
             model.get_inputs(),
         )
 
     @parameterized.expand(testsuite_conv1d, skip_on_empty=True)
     @pytest.mark.corstone_fvp
-    def test_dw_conv1d_u55_BI(
-        self, test_name: str, model: torch.nn.Module, set_quantize_io: bool = True
-    ):
+    def test_dw_conv1d_u55_BI(self, test_name: str, model: torch.nn.Module):
         self._test_dw_conv_ethos_BI_pipeline(
             model,
-            common.get_u55_compile_spec(quantize_io=set_quantize_io),
+            common.get_u55_compile_spec(),
             model.get_inputs(),
         )
 
     @parameterized.expand(testsuite_conv1d + testsuite_conv2d_u85)
     @pytest.mark.corstone_fvp
-    def test_dw_conv_u85_BI(
-        self, test_name: str, model: torch.nn.Module, set_quantize_io: bool = True
-    ):
+    def test_dw_conv_u85_BI(self, test_name: str, model: torch.nn.Module):
         self._test_dw_conv_ethos_BI_pipeline(
             model,
-            common.get_u85_compile_spec(quantize_io=set_quantize_io),
+            common.get_u85_compile_spec(),
             model.get_inputs(),
         )
 
@@ -306,11 +298,9 @@ class TestDepthwiseConv(unittest.TestCase):
     @parameterized.expand(testsuite_conv2d_u85_xfails)
     @pytest.mark.corstone_fvp
     @conftest.expectedFailureOnFVP
-    def test_dw_conv_u85_BI_xfails(
-        self, test_name: str, model: torch.nn.Module, set_quantize_io: bool = True
-    ):
+    def test_dw_conv_u85_BI_xfails(self, test_name: str, model: torch.nn.Module):
         self._test_dw_conv_ethos_BI_pipeline(
             model,
-            common.get_u85_compile_spec(quantize_io=set_quantize_io),
+            common.get_u85_compile_spec(),
             model.get_inputs(),
         )

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -275,7 +275,6 @@ def get_compile_spec(
                 memory_mode=memory_mode,
                 extra_flags="--debug-force-regor --output-format=raw --verbose-operators --verbose-cycle-estimate",
             )
-            .set_quantize_io(True)
             .set_input_order(reorder_inputs)
         )
     elif "ethos-u85" in target:
@@ -287,7 +286,6 @@ def get_compile_spec(
                 memory_mode=memory_mode,
                 extra_flags="--output-format=raw --verbose-operators --verbose-cycle-estimate",
             )
-            .set_quantize_io(True)
             .set_input_order(reorder_inputs)
         )
 


### PR DESCRIPTION
quantize_io was only used in arm_partitioner
and is not needed there anymore when
running the delegate in the graph (https://github.com/pytorch/executorch/pull/7552).