### PR TITLE
Update torchtune pin

### DIFF
--- a/examples/models/llama3_2_vision/install_requirements.sh
+++ b/examples/models/llama3_2_vision/install_requirements.sh
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-NIGHTLY_VERSION="dev20241112"
+NIGHTLY_VERSION="dev20250115"
 
 # Install torchtune nightly for model definitions.
-pip install --pre torchtune==0.4.0.${NIGHTLY_VERSION} --extra-index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir
+pip install --pre torchtune==0.6.0.${NIGHTLY_VERSION} --extra-index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir


### PR DESCRIPTION
### Summary 

Current torchtune pin is not in the S3 bucket anymore. https://download.pytorch.org/whl/nightly/torchtune/

Updating to latest

### Test

CI