### PR TITLE
Move ai-edge-model-explorer into devtools/install_requirements.sh

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -294,6 +294,7 @@ include_patterns = [
     'build/**/*.py',
     'codegen/**/*.py',
     # 'devtools/**/*.py',
+    'devtools/visualization/**/*.py',
     'docs/**/*.py',
     # 'examples/**/*.py',
     # 'exir/**/*.py',

--- a/devtools/install_requirements.sh
+++ b/devtools/install_requirements.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Conflict: this requires numpy<2 whereas ExecuTorch core requires numpy>=2
+# Follow https://github.com/google-ai-edge/model-explorer/issues/277 for potential
+# resolution
+pip install ai-edge-model-explorer>=0.1.16

--- a/devtools/visualization/visualization_utils.py
+++ b/devtools/visualization/visualization_utils.py
@@ -8,8 +8,15 @@ import subprocess
 import time
 
 from executorch.exir import EdgeProgramManager, ExecutorchProgramManager
-from model_explorer import config, consts, visualize_from_config  # type: ignore
 from torch.export.exported_program import ExportedProgram
+
+try:
+    from model_explorer import config, consts, visualize_from_config  # type: ignore
+except ImportError:
+    print(
+        "Error: 'model_explorer' is not installed. Install using devtools/install_requirement.sh"
+    )
+    raise
 
 
 class SingletonModelExplorerServer:

--- a/devtools/visualization/visualization_utils_test.py
+++ b/devtools/visualization/visualization_utils_test.py
@@ -17,7 +17,14 @@ from executorch.devtools.visualization import (
     visualize,
 )
 from executorch.exir import ExportedProgram
-from model_explorer.config import ModelExplorerConfig  # type: ignore
+
+try:
+    from model_explorer.config import ModelExplorerConfig  # type: ignore
+except ImportError:
+    print(
+        "Error: 'model_explorer' is not installed. Install using devtools/install_requirement.sh"
+    )
+    raise
 
 
 @pytest.fixture

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -170,7 +170,6 @@ DEVEL_REQUIREMENTS = [
     "tomli",  # Imported by extract_sources.py when using python < 3.11.
     "wheel",  # For building the pip package archive.
     "zstd",  # Imported by resolve_buck.py.
-    "ai-edge-model-explorer>=0.1.16",  # For visualizing ExportedPrograms
 ]
 
 # Assemble the list of requirements to actually install.

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,7 @@ addopts =
     # explicitly list out tests that are running successfully in oss
     examples/models/test
     devtools/
+    --ignore=devtools/visualization/visualization_utils_test.py
     # examples
     examples/models/llama/tests
     examples/models/llama3_2_vision/preprocess


### PR DESCRIPTION
### Summary

From top-level requirements, move to devtools/install_requirement.sh instead.

ai-edge-model-explorer is too new and currently requires numpy<2 (https://github.com/google-ai-edge/model-explorer/blob/main/src/server/package/pyproject.toml#L26) which conflicts with our recent upgrade (https://github.com/pytorch/executorch/pull/7599)

Let's not take core dependency on this tool yet.

### Test Plan

python devtools/visualization/visualization_utils_test.py

make sure error is thrown

run `sh devtools/install_requirement.sh`

make sure the script is successfully run.
