### PR TITLE
[ET-VK][ez] Add print operator for `StorageType` enum

### DIFF
--- a/backends/vulkan/runtime/utils/StorageUtils.h
+++ b/backends/vulkan/runtime/utils/StorageUtils.h
@@ -114,6 +114,23 @@ T to_packed_dim(const GPUMemoryLayout layout) {
 
 inline std::ostream& operator<<(
     std::ostream& os,
+    const StorageType storage_type) {
+  switch (storage_type) {
+    case kBuffer:
+      os << "BUFFER";
+      break;
+    case kTexture3D:
+      os << "TEXTURE_3D";
+      break;
+    case kTexture2D:
+      os << "TEXTURE_2D";
+      break;
+  }
+  return os;
+}
+
+inline std::ostream& operator<<(
+    std::ostream& os,
     const GPUMemoryLayout layout) {
   switch (layout) {
     case kWidthPacked:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #7685

## Context

As title. Add a long overdue print operator for the `StorageType` enum, similar to the one that already exists for the `GPUMemoryLayout` enum.

Differential Revision: [D68237420](https://our.internmc.facebook.com/intern/diff/D68237420/)