### PR TITLE
Arm backend: Remove the reordering of inputs flag

### DIFF
--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -131,16 +131,6 @@ class ArmCompileSpecBuilder:
         self.quantize_io = quantize_io
         return self
 
-    def set_input_order(
-        self, input_order: Optional[str] = None
-    ) -> "ArmCompileSpecBuilder":
-        """
-        Reorder the inputs coming in. This may be required when inputs > 1.
-        And while using the U55/U85 CompileSpec.
-        """
-        self.input_order = input_order
-        return self
-
     def build(self) -> List[CompileSpec]:
         """
         Generate a list of compile spec objects from the builder

--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -87,7 +87,6 @@ def get_tosa_compile_spec_unbuilt(
 def get_u55_compile_spec(
     quantize_io=True,
     custom_path=None,
-    reorder_inputs=None,
 ) -> list[CompileSpec]:
     """
     Default compile spec for Ethos-U55 tests.
@@ -95,14 +94,12 @@ def get_u55_compile_spec(
     return get_u55_compile_spec_unbuilt(
         quantize_io=quantize_io,
         custom_path=custom_path,
-        reorder_inputs=reorder_inputs,
     ).build()
 
 
 def get_u85_compile_spec(
     quantize_io=True,
     custom_path=None,
-    reorder_inputs=None,
 ) -> list[CompileSpec]:
     """
     Default compile spec for Ethos-U85 tests.
@@ -110,14 +107,12 @@ def get_u85_compile_spec(
     return get_u85_compile_spec_unbuilt(
         quantize_io=quantize_io,
         custom_path=custom_path,
-        reorder_inputs=reorder_inputs,
     ).build()
 
 
 def get_u55_compile_spec_unbuilt(
     quantize_io=True,
     custom_path=None,
-    reorder_inputs=None,
 ) -> ArmCompileSpecBuilder:
     """Get the ArmCompileSpecBuilder for the Ethos-U55 tests, to modify
     the compile spec before calling .build() to finalize it.
@@ -135,7 +130,6 @@ def get_u55_compile_spec_unbuilt(
         )
         .set_quantize_io(quantize_io)
         .dump_intermediate_artifacts_to(artifact_path)
-        .set_input_order(reorder_inputs)
     )
     return compile_spec
 
@@ -143,7 +137,6 @@ def get_u55_compile_spec_unbuilt(
 def get_u85_compile_spec_unbuilt(
     quantize_io=True,
     custom_path=None,
-    reorder_inputs=None,
 ) -> list[CompileSpec]:
     """Get the ArmCompileSpecBuilder for the Ethos-U85 tests, to modify
     the compile spec before calling .build() to finalize it.
@@ -159,7 +152,6 @@ def get_u85_compile_spec_unbuilt(
         )
         .set_quantize_io(quantize_io)
         .dump_intermediate_artifacts_to(artifact_path)
-        .set_input_order(reorder_inputs)
     )
     return compile_spec
 

--- a/backends/arm/test/test_arm_baremetal.sh
+++ b/backends/arm/test/test_arm_baremetal.sh
@@ -96,12 +96,12 @@ test_run_ethosu_fvp() { # End to End model tests
     # Ethos-U55
     echo "${TEST_SUITE_NAME}: Test ethos-u target Ethos-U55"
     examples/arm/run.sh --target=ethos-u55-128 --model_name=mv2
-    examples/arm/run.sh --target=ethos-u55-128 --model_name=lstm --reorder_inputs=1,0,2
+    examples/arm/run.sh --target=ethos-u55-128 --model_name=lstm
 
     # Ethos-U85
     echo "${TEST_SUITE_NAME}: Test ethos-u target Ethos-U85"
     examples/arm/run.sh --target=ethos-u85-128 --model_name=mv2
-    examples/arm/run.sh --target=ethos-u85-128 --model_name=lstm --reorder_inputs=1,0,2
+    examples/arm/run.sh --target=ethos-u85-128 --model_name=lstm
     }
 
 ${TEST_SUITE}

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -259,7 +259,6 @@ def get_calibration_data(
 def get_compile_spec(
     target: str,
     intermediates: Optional[str] = None,
-    reorder_inputs: Optional[str] = None,
     system_config: Optional[str] = None,
     memory_mode: Optional[str] = None,
 ) -> list[CompileSpec]:
@@ -276,7 +275,6 @@ def get_compile_spec(
                 extra_flags="--debug-force-regor --output-format=raw --verbose-operators --verbose-cycle-estimate",
             )
             .set_quantize_io(True)
-            .set_input_order(reorder_inputs)
         )
     elif "ethos-u85" in target:
         spec_builder = (
@@ -288,7 +286,6 @@ def get_compile_spec(
                 extra_flags="--output-format=raw --verbose-operators --verbose-cycle-estimate",
             )
             .set_quantize_io(True)
-            .set_input_order(reorder_inputs)
         )
 
     if intermediates is not None:
@@ -432,14 +429,6 @@ def get_args():
         help="Location for outputs, if not the default of cwd.",
     )
     parser.add_argument(
-        "-r",
-        "--reorder_inputs",
-        type=str,
-        required=False,
-        default=None,
-        help="Provide the order of the inputs. This can be required when inputs > 1.",
-    )
-    parser.add_argument(
         "--system_config",
         required=False,
         default=None,
@@ -521,7 +510,6 @@ if __name__ == "__main__":
         compile_spec = get_compile_spec(
             args.target,
             args.intermediates,
-            args.reorder_inputs,
             args.system_config,
             args.memory_mode,
         )

--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -29,7 +29,6 @@ build_with_etdump=false
 build_type="Release"
 extra_build_flags=""
 build_only=false
-reorder_inputs=""
 system_config=""
 memory_mode=""
 
@@ -46,7 +45,6 @@ help() {
     echo "  --extra_build_flags                    Extra flags to pass to cmake like -DET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE=60000 Default: none "
     echo "  --build_only                           Only build, don't run FVP"
     echo "  --scratch-dir=<FOLDER>                 Path to your Ethos-U scrach dir if you not using default"
-    echo "  --reorder_inputs=<FLAGS>               Reorder the inputs. This can be required when inputs > 1."
     echo "  --system_config=<CONFIG>               System configuration to select from the Vela configuration file (see vela.ini). Default: Ethos_U55_High_End_Embedded for EthosU55 targets, Ethos_U85_SYS_DRAM_Mid for EthosU85 targets."
     echo "                                            NOTE: If given, this option must match the given target. This option also sets timing adapter values customized for specific hardware, see ./executor_runner/CMakeLists.txt."
     echo "  --memory_mode=<MODE>                   Memory mode to select from the Vela configuration file (see vela.ini), e.g. Shared_Sram/Sram_Only. Default: 'Shared_Sram' for Ethos-U55 targets, 'Sram_Only' for Ethos-U85 targets"
@@ -66,7 +64,6 @@ for arg in "$@"; do
       --extra_build_flags=*) extra_build_flags="${arg#*=}";;
       --build_only) build_only=true ;;
       --scratch-dir=*) root_dir="${arg#*=}";;
-      --reorder_inputs=*) reorder_inputs="${arg#*=}";;
       --system_config=*) system_config="${arg#*=}";;
       --memory_mode=*) memory_mode="${arg#*=}";;
       *)
@@ -151,7 +148,7 @@ function generate_pte_file() {
     # We are using the aot_lib from build_quantization_aot_lib below
     SO_LIB=$(find cmake-out-aot-lib -name libquantized_ops_aot_lib.${SO_EXT})
 
-    local ARM_AOT_CMD="python3 -m examples.arm.aot_arm_compiler --model_name=${model} --target=${target} ${model_compiler_flags} --reorder_inputs=${reorder_inputs} --output ${output_folder} --so_library=$SO_LIB --system_config=${system_config} --memory_mode=${memory_mode}"
+    local ARM_AOT_CMD="python3 -m examples.arm.aot_arm_compiler --model_name=${model} --target=${target} ${model_compiler_flags} --output ${output_folder} --so_library=$SO_LIB --system_config=${system_config} --memory_mode=${memory_mode}"
     echo "CALL ${ARM_AOT_CMD}" >&2
     ${ARM_AOT_CMD} 1>&2
 
@@ -372,7 +369,6 @@ if [[ -z "$model_name" ]]; then
 else
     test_model=( "$model_name" )
     model_compiler_flags=( "$aot_arm_compiler_flags" )
-    reorder_inputs=( "$reorder_inputs" )
 fi
 
 # loop over running the AoT flow and executing the model on device


### PR DESCRIPTION
### Summary
- With updated Vela version input/output order is now preserved.
- Remove re-order of inputs in compile spec
- Remove re-order of inputs in aot_arm_compiler
