### PR TITLE
[xnnpack] Reexport after quantize in aot_compiler

### DIFF
--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -92,6 +92,7 @@ if __name__ == "__main__":
         logging.info("Quantizing Model...")
         # TODO(T165162973): This pass shall eventually be folded into quantizer
         model = quantize(model, example_inputs)
+        ep = torch.export.export_for_training(model, example_inputs)
 
     edge = to_edge_transform_and_lower(
         ep,


### PR DESCRIPTION
### Summary
It was not using quantized model even when quantize flag, this fixes that.

### Test plan
local tests and ci.

* Before 
```
-rw-r--r--  1 digantdesai  staff  13974408 Jan 16 15:44 mv2_xnnpack_fp32.pte
-rw-r--r--  1 digantdesai  staff  13974408 Jan 16 15:45 mv2_xnnpack_q8.pte
```

* After
```
-rw-r--r--  1 digantdesai  staff  13974408 Jan 16 15:44 mv2_xnnpack_fp32.pte
-rw-r--r--  1 digantdesai  staff   3572400 Jan 16 16:05 mv2_xnnpack_q8.pte
```


cc @mcr229