### PR TITLE
Example xor model training bugfix

### DIFF
--- a/extension/training/examples/XOR/export_model.py
+++ b/extension/training/examples/XOR/export_model.py
@@ -31,6 +31,7 @@ def _export_model():
     ep = to_edge(ep)
     # Lower the graph to executorch.
     ep = ep.to_executorch()
+    return ep
 
 
 def main() -> None:


### PR DESCRIPTION
Summary: Fails without return - no model returned from `_export_model()`

Differential Revision: D68233527


