### PR TITLE
Update XNN delegate to handle non-decomposed upsample ops

### DIFF
--- a/backends/xnnpack/_passes/convert_to_upsample_bilinear2d.py
+++ b/backends/xnnpack/_passes/convert_to_upsample_bilinear2d.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import torch
 from executorch.backends.xnnpack._passes.xnnpack_pass import XNNPACKPass
 from executorch.backends.xnnpack.partition.graphs import bilinear_2d
@@ -23,6 +25,10 @@ class ConvertToUpsampleBilinear2d(XNNPACKPass):
         align_corners: bool,
     ):
         output = internal_match.returning_nodes[0]
+        if output.target == exir_ops.edge.aten.upsample_bilinear2d.vec:
+            # Op was not decomposed, do nothing
+            return
+
         output_shape = output.meta["val"].shape
         output_h = output_shape[-2]
         output_w = output_shape[-1]

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -642,7 +642,7 @@ class TestEmit(unittest.TestCase):
             def forward(self, x):
                 return torch.nn.functional.interpolate(x, scale_factor=2)
 
-        x = (torch.randn(1, 1, 2, 2),)
+        x = (torch.randn(1, 1, 2, 2, 2),)
         program = (
             to_edge(export(M(), x, strict=True)).to_executorch().executorch_program
         )


### PR DESCRIPTION
Differential Revision: D68374352

I'm preparing to disable decomposition by default for core upsample ops in https://github.com/pytorch/pytorch/pull/141791. This PR makes changes to ExecuTorch to handle non-decomposed upsample_bilinear2d. There are tests that expect the decomposition when not delegated, as well as a recomposition pass in the XNNPACK delegate which need updates to function.

The changes in this PR are intended to work with both the decomposed and non-decomposed upsample ops. After the decomposition change lands in PyTorch, I will clean up the remaining ExecuTorch usages.