### PR TITLE
Add build-time config for threadpool size

### DIFF
--- a/extension/threadpool/targets.bzl
+++ b/extension/threadpool/targets.bzl
@@ -1,6 +1,16 @@
 load("@fbsource//xplat/executorch/backends/xnnpack/third-party:third_party_libs.bzl", "third_party_dep")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+def get_threadpool_size():
+    return native.read_config("executorch", "threadpool_size")
+
+def get_threadpool_flags():
+    flags = []
+    threadpool_size = get_threadpool_size()
+    if threadpool_size != None:
+        flags += ["-DET_THREADPOOL_SIZE=" + threadpool_size]
+    return flags
+
 def define_common_targets():
     """Defines targets that should be shared between fbcode and xplat.
 
@@ -32,6 +42,7 @@ def define_common_targets():
         exported_preprocessor_flags = [
             "-DET_USE_THREADPOOL",
         ],
+        preprocessor_flags = get_threadpool_flags(),
         visibility = [
             "//executorch/...",
             "//executorch/backends/...",

--- a/extension/threadpool/threadpool.cpp
+++ b/extension/threadpool/threadpool.cpp
@@ -97,7 +97,13 @@ void ThreadPool::run(
 // Make this part threadsafe: TODO(kimishpatel)
 ThreadPool* get_threadpool() {
   ET_CHECK_MSG(cpuinfo_initialize(), "cpuinfo initialization failed");
+
+#ifdef ET_THREADPOOL_SIZE
+  int num_threads = ET_THREADPOOL_SIZE;
+#else
   int num_threads = cpuinfo_get_processors_count();
+#endif
+
   /*
    * For llvm-tsan, holding limit for the number of locks for a single thread
    * is 63 (because of comparison < 64 instead of <=). pthreadpool's worst


### PR DESCRIPTION
Summary:
Add a preprocessor flag (ET_THREADPOOL_SIZE) and corresponding buck config ("executorch.threadpool_size") to set the default ET threadpool size.

The intent of this change is to allow users in very memory-constrained environments to opt in to a smaller threadpool to shave a small amount of additional memory. Even when measuring resident set size, the addition threads can add more than a Mb of peak memory.

I considered making this a parameter to get_threadpool, but it is not consistently usable, as it depends on who first instantiates the threadpool. As it's a shared resource, it seemed more prudent to make it a build-time configuration.

Differential Revision: D68401795


