### PR TITLE
Buck Fix to enable opt level = 3 for internal model export

### DIFF
--- a/backends/qualcomm/runtime/targets.bzl
+++ b/backends/qualcomm/runtime/targets.bzl
@@ -44,8 +44,7 @@ def define_common_targets():
                     "*.cpp",
                     "backends/*.cpp",
                     "backends/htpbackend/*.cpp",
-                    "backends/htpbackend/aarch64/*.cpp",
-                ],
+                ] + (["backends/htpbackend/x86_64/*.cpp"] if include_aot_qnn_lib else ["backends/htpbackend/aarch64/*.cpp"]),
                 exclude = ["Logging.cpp"],
             ),
             exported_headers = glob(


### PR DESCRIPTION
Summary: [OSS ET] Buck Fix to enable opt level = 3 for internal model export

Differential Revision: D68446241

@pytorchbot label "topic: not user facing"


