### PR TITLE
[0.5 Release] Clarify banner on main docs page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,9 +4,9 @@ Welcome to the ExecuTorch Documentation
 =======================================
 
 .. important::
-   v0.4.0 is a beta release of ExecuTorch. As of this release, the API will
-   follow the `API Lifecycle and Deprecation Policy <api-life-cycle.html>`__,
-   and the ``.pte`` binary format will comply with the `Runtime Compatibility
+   v0.4.0 was the beta release of ExecuTorch. Starting from v0.4.0, the API
+   follows the `API Lifecycle and Deprecation Policy <api-life-cycle.html>`__,
+   and the ``.pte`` binary format complies with the `Runtime Compatibility
    Policy
    <https://github.com/pytorch/executorch/tree/main/runtime/COMPATIBILITY.md>`__.
    This helps ensure that application developers can update to the latest


### PR DESCRIPTION
### Summary

As title. Now that we are nearing the release of `v0.5.0`, the banner on the main page of the documentation can be a bit confusing since the mentioned version will not match. Rather than just updating `v0.4.0` to `v0.5.0`, I believe the banner is trying to convey that our API lifecycle and deprecation policy is in effect as of v0.4.0 which was the beta release of ExecuTorch.

To account for this, I've updated the banner to be more clear on why v0.4.0 is mentioned specifically.
