### PR TITLE
Add method variants in dynamic shim to use core tensor/evalue/result types

### DIFF
--- a/runtime/core/portable_type/targets.bzl
+++ b/runtime/core/portable_type/targets.bzl
@@ -25,6 +25,7 @@ def define_common_targets():
         # mean I cant just expose visibility to a single rule.
         visibility = [
             "//executorch/backends/...",
+            "//executorch/extension/fb/dynamic_shim/...",
             "//executorch/runtime/core/exec_aten/...",
             "//executorch/runtime/core/portable_type/test/...",
         ],


### PR DESCRIPTION
Summary:
This change adds forward and execute methods to the dynamic shim interface that make use of the core executorch tensor, evalue, and result types. The intent is to allow users to use the "real" ET types, rather than TensorWrapper/EValueWrapper. There are several reasons to do this:

1) Wrapper types are limited in functionality compared to the core types.
2) We need to add more functionality to the wrappers as we support more models, leading to duplicated effort.
3) API surface is inconsistent with ET documentation, which uses the core types.

This change should not introduce significant binary size changes, as these new methods are not currently used and are thus optimized out in release builds. When updating call sites to use the new methods and core ET types, impact is <= 5kB (see diffs in this stack). The ET core runtime is designed to be small, so directly including these types should not carry significant size overhead.

Differential Revision: D67650320


