### PR TITLE
Fix install not finding zstd

### DIFF
--- a/install_requirements.py
+++ b/install_requirements.py
@@ -102,6 +102,8 @@ def install_requirements(use_pytorch_nightly):
             "install",
             "-r",
             "requirements-examples.txt",
+            "-r",
+            "requirements-dev.txt",
             *REQUIREMENTS_TO_INSTALL,
             "--extra-index-url",
             TORCH_NIGHTLY_URL,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+cmake  # For building binary targets in the wheel.
+pip>=23  # For building the pip package.
+pyyaml  # Imported by the kernel codegen tools.
+setuptools>=63  # For building the pip package contents.
+tomli  # Imported by extract_sources.py when using python < 3.11.
+wheel  # For building the pip package archive.
+zstd  # Imported by resolve_buck.py.


### PR DESCRIPTION
Installation apparently couldn't resolve buck from a clean checkout. (I'm not sure how it managed to work for anybody who hadn't installed prior to the breakage, actually.)

Fixes #7711.

Test Plan: ./install_executorch.sh --clean
rm -rf buck2-bin buck-out
./install_executorch.sh --pybind xnnpack
