### PR TITLE
Revert #7714 to check if CI passes

### DIFF
--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -92,7 +92,6 @@ if __name__ == "__main__":
         logging.info("Quantizing Model...")
         # TODO(T165162973): This pass shall eventually be folded into quantizer
         model = quantize(model, example_inputs)
-        ep = torch.export.export_for_training(model, example_inputs)
 
     edge = to_edge_transform_and_lower(
         ep,


### PR DESCRIPTION
@digantdesai the recent fix seems to cause one issue, can you please take a look?

```sh
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/shoumikhin/Temp/executorch/examples/xnnpack/aot_compiler.py", line 110, in <module>
    exec_prog = edge.to_executorch(
                ^^^^^^^^^^^^^^^^^^^
  File "/Users/shoumikhin/Temp/executorch/.venv/lib/python3.12/site-packages/executorch/exir/program/_program.py", line 99, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shoumikhin/Temp/executorch/.venv/lib/python3.12/site-packages/executorch/exir/program/_program.py", line 1385, in to_executorch
    new_gm_res = p(new_gm)
                 ^^^^^^^^^
  File "/Users/shoumikhin/Temp/executorch/.venv/lib/python3.12/site-packages/torch/fx/passes/infra/pass_base.py", line 44, in __call__
    res = self.call(graph_module)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shoumikhin/Temp/executorch/.venv/lib/python3.12/site-packages/executorch/exir/passes/__init__.py", line 427, in call
    raise RuntimeError(f"Missing out variants: {missing_out_vars}")
RuntimeError: Missing out variants: {'quantized_decomposed::dequantize_per_tensor', 'quantized_decomposed::quantize_per_tensor'}
```

Here's how you can reproduce it on the latest main branch:

```sh
git clone https://github.com/pytorch/executorch.git --depth 1 --recurse-submodules --shallow-submodules
cd executorch

python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip

./install_executorch.sh --pybind xnnpack # install any missing pip dep manually if this script currently fails

python3 -m examples.xnnpack.aot_compiler --model_name=emformer_transcribe --delegate --quantize
```

For context, our [CI signals](https://hud.pytorch.org/hud/pytorch/executorch/main) were lagging at the time this PR landed, so we couldn't catch it earlier, and now they're back.

Thanks!