### PR TITLE
Run ctest with --output-on-failure in test script

### DIFF
--- a/test/run_oss_cpp_tests.sh
+++ b/test/run_oss_cpp_tests.sh
@@ -69,7 +69,7 @@ report_coverage() {
 
 run_ctest() {
   pushd cmake-out/
-  ctest
+  ctest --output-on-failure
   popd
 }
 


### PR DESCRIPTION
Otherwise there's no debugging information in CI failures.