### PR TITLE
Commands needs to be all strings

### DIFF
--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -270,7 +270,7 @@ def run_corstone(
                 "-C",
                 f"cpu0.semihosting-cmd_line='{cmd_line}'",
                 "-a",
-                elf_path,
+                str(elf_path),
                 "--timelimit",
                 f"{timeout}",
             ]
@@ -302,7 +302,7 @@ def run_corstone(
                 "-C",
                 f"mps4_board.subsystem.cpu0.semihosting-cmd_line='{cmd_line}'",
                 "-a",
-                elf_path,
+                str(elf_path),
                 "--timelimit",
                 f"{timeout}",
             ]


### PR DESCRIPTION
Mixing Path with strings makes the RuntimeError string creation fail on line 318 below in case of a failed run.


cc @digantdesai @freddan80 @zingo @oscarandersson8218