### PR TITLE
Optimized axis map

### DIFF
--- a/backends/vulkan/runtime/api/containers/Tensor.h
+++ b/backends/vulkan/runtime/api/containers/Tensor.h
@@ -183,14 +183,16 @@ class vTensor final {
       const vkapi::ScalarType dtype,
       const utils::StorageType storage_type = utils::kTexture3D,
       const utils::GPUMemoryLayout memory_layout = utils::kChannelsPacked,
-      const bool allocate_memory = true);
+      const bool allocate_memory = true,
+      const utils::AxisMapLayout axis_map_layout = utils::kDefaultAxisMap);
 
   vTensor(const vTensor& other) = delete;
 
   explicit vTensor(
       Context* context,
       const vkapi::VulkanImage& image,
-      const utils::GPUMemoryLayout memory_layout = utils::kChannelsPacked);
+      const utils::GPUMemoryLayout memory_layout = utils::kChannelsPacked,
+      const utils::AxisMapLayout axis_map_layout = utils::kDefaultAxisMap);
 
   /*
    * This constructor allows for the creation of a vTensor that references the

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -239,13 +239,20 @@ ValueRef ComputeGraph::add_tensor(
     const vkapi::ScalarType dtype,
     const utils::StorageType storage_type,
     const utils::GPUMemoryLayout memory_layout,
-    const int64_t shared_object_idx) {
+    const int64_t shared_object_idx,
+    const utils::AxisMapLayout axis_map_layout) {
   bool allocate_memory = shared_object_idx < 0;
 
   ValueRef idx(static_cast<int>(values_.size()));
   check_no_active_value_ptrs();
   values_.emplace_back(api::vTensor(
-      context(), sizes, dtype, storage_type, memory_layout, allocate_memory));
+      context(),
+      sizes,
+      dtype,
+      storage_type,
+      memory_layout,
+      allocate_memory,
+      axis_map_layout));
 
   if (!allocate_memory) {
     get_shared_object(shared_object_idx).add_user(this, idx);
@@ -257,44 +264,70 @@ ValueRef ComputeGraph::add_tensor(
     const std::vector<int64_t>& sizes,
     const vkapi::ScalarType dtype,
     const utils::StorageType storage_type,
-    const int64_t shared_object_idx) {
+    const int64_t shared_object_idx,
+    const utils::AxisMapLayout axis_map_layout) {
   return add_tensor(
       sizes,
       dtype,
       storage_type,
       suggested_memory_layout(sizes),
-      shared_object_idx);
+      shared_object_idx,
+      axis_map_layout);
 }
 
 ValueRef ComputeGraph::add_tensor(
     const std::vector<int64_t>& sizes,
     const vkapi::ScalarType dtype,
     const utils::GPUMemoryLayout memory_layout,
-    const int64_t shared_object_idx) {
+    const int64_t shared_object_idx,
+    const utils::AxisMapLayout axis_map_layout) {
   return add_tensor(
-      sizes, dtype, suggested_storage_type(), memory_layout, shared_object_idx);
+      sizes,
+      dtype,
+      suggested_storage_type(),
+      memory_layout,
+      shared_object_idx,
+      axis_map_layout);
 }
 
 ValueRef ComputeGraph::add_tensor_like(
     const ValueRef idx,
     const utils::StorageType storage_type,
-    const utils::GPUMemoryLayout memory_layout) {
-  return add_tensor(sizes_of(idx), dtype_of(idx), storage_type, memory_layout);
+    const utils::GPUMemoryLayout memory_layout,
+    const utils::AxisMapLayout axis_map_layout) {
+  return add_tensor(
+      sizes_of(idx),
+      dtype_of(idx),
+      storage_type,
+      memory_layout,
+      -1,
+      axis_map_layout);
 }
 
 ValueRef ComputeGraph::add_tensor_like(
     const ValueRef idx,
-    const utils::GPUMemoryLayout memory_layout) {
+    const utils::GPUMemoryLayout memory_layout,
+    const utils::AxisMapLayout axis_map_layout) {
   return add_tensor(
-      sizes_of(idx), dtype_of(idx), storage_type_of(idx), memory_layout);
+      sizes_of(idx),
+      dtype_of(idx),
+      storage_type_of(idx),
+      memory_layout,
+      -1,
+      axis_map_layout);
 }
 
 ValueRef ComputeGraph::add_tensor(
     const std::vector<int64_t>& sizes,
     const vkapi::ScalarType dtype,
-    const int64_t shared_object_idx) {
+    const int64_t shared_object_idx,
+    const utils::AxisMapLayout axis_map_layout) {
   return add_tensor(
-      sizes, dtype, suggested_memory_layout(sizes), shared_object_idx);
+      sizes,
+      dtype,
+      suggested_memory_layout(sizes),
+      shared_object_idx,
+      axis_map_layout);
 }
 
 ValueRef ComputeGraph::add_tensor(const vkapi::VulkanImage& image) {

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -461,7 +461,8 @@ class ComputeGraph final {
       const vkapi::ScalarType dtype,
       const utils::StorageType storage_type,
       const utils::GPUMemoryLayout memory_layout,
-      const int64_t shared_object_idx = -1);
+      const int64_t shared_object_idx = -1,
+      const utils::AxisMapLayout axis_map_layout = utils::kDefaultAxisMap);
 
   /*
    * Add a `api::vTensor` value to the graph with the specified properties. The
@@ -471,7 +472,8 @@ class ComputeGraph final {
       const std::vector<int64_t>& sizes,
       const vkapi::ScalarType dtype,
       const utils::StorageType storage_type,
-      const int64_t shared_object_idx = -1);
+      const int64_t shared_object_idx = -1,
+      const utils::AxisMapLayout axis_map_layout = utils::kDefaultAxisMap);
 
   /*
    * Add a `api::vTensor` value to the graph with the specified properties. The
@@ -481,7 +483,8 @@ class ComputeGraph final {
       const std::vector<int64_t>& sizes,
       const vkapi::ScalarType dtype,
       const utils::GPUMemoryLayout memory_layout,
-      const int64_t shared_object_idx = -1);
+      const int64_t shared_object_idx = -1,
+      const utils::AxisMapLayout axis_map_layout = utils::kDefaultAxisMap);
 
   /*
    * Add a `api::vTensor` value to the graph with the specified properties. The
@@ -491,7 +494,8 @@ class ComputeGraph final {
   ValueRef add_tensor(
       const std::vector<int64_t>& sizes,
       const vkapi::ScalarType dtype,
-      const int64_t shared_object_idx = -1);
+      const int64_t shared_object_idx = -1,
+      const utils::AxisMapLayout axis_map_layout = utils::kDefaultAxisMap);
 
   /*
    * Add a `api::vTensor` value to the graph with the specified image.
@@ -504,7 +508,8 @@ class ComputeGraph final {
   ValueRef add_tensor_like(
       const ValueRef vref,
       const utils::StorageType storage_type,
-      const utils::GPUMemoryLayout memory_layout);
+      const utils::GPUMemoryLayout memory_layout,
+      const utils::AxisMapLayout axis_map_layout = utils::kDefaultAxisMap);
 
   /*
    * Add a `api::vTensor` value to the graph with the properties of `vref`. The
@@ -512,7 +517,8 @@ class ComputeGraph final {
    */
   ValueRef add_tensor_like(
       const ValueRef vref,
-      const utils::GPUMemoryLayout memory_layout);
+      const utils::GPUMemoryLayout memory_layout,
+      const utils::AxisMapLayout axis_map_layout = utils::kDefaultAxisMap);
 
   /*
    * Use the copy constructor of `api::vTensor` to create a "view" of the

--- a/backends/vulkan/runtime/graph/ops/impl/Staging.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Staging.cpp
@@ -146,12 +146,14 @@ ValueRef prepack_standard(
     const ValueRef tensor_data,
     const utils::StorageType storage_type,
     const utils::GPUMemoryLayout layout,
-    const bool passthrough) {
+    const bool passthrough,
+    const utils::AxisMapLayout axis_map_layout) {
   if (passthrough && graph.val_is_tensor(tensor_data)) {
     return tensor_data;
   }
   VK_CHECK_COND(graph.val_is_tref(tensor_data));
-  ValueRef tensor = graph.add_tensor_like(tensor_data, storage_type, layout);
+  ValueRef tensor =
+      graph.add_tensor_like(tensor_data, storage_type, layout, axis_map_layout);
   add_prepack_standard_node(graph, tensor_data, tensor);
   return tensor;
 }

--- a/backends/vulkan/runtime/graph/ops/impl/Staging.h
+++ b/backends/vulkan/runtime/graph/ops/impl/Staging.h
@@ -48,7 +48,8 @@ ValueRef prepack_standard(
     const ValueRef tensor_data,
     const utils::StorageType storage_type,
     const utils::GPUMemoryLayout layout,
-    const bool passthrough = false);
+    const bool passthrough = false,
+    const utils::AxisMapLayout axis_map_layout = utils::kDefaultAxisMap);
 
 /*
  * Equivalent to `prepack_standard()` function, except the `storage_type` and

--- a/backends/vulkan/runtime/utils/StorageUtils.h
+++ b/backends/vulkan/runtime/utils/StorageUtils.h
@@ -146,5 +146,14 @@ inline std::ostream& operator<<(
   return os;
 }
 
+enum class AxisMapLayout : uint8_t {
+  DEFAULT = 0u,
+  OPTIMIZED = 1u,
+};
+
+constexpr AxisMapLayout kDefaultAxisMap = AxisMapLayout::DEFAULT;
+
+constexpr AxisMapLayout kOptimizedAxisMap = AxisMapLayout::OPTIMIZED;
+
 } // namespace utils
 } // namespace vkcompute


### PR DESCRIPTION
Summary: Add a flag to optimize the axis map layout to be in descending order of axis size. The default is still the same.

Differential Revision: D67692960


