### PR TITLE
Add more context for buck users on the coreml pte2 quantization errors

### DIFF
--- a/extension/llm/export/partitioner_lib.py
+++ b/extension/llm/export/partitioner_lib.py
@@ -82,6 +82,7 @@ def get_coreml_partitioner(
     except ImportError:
         raise ImportError(
             "Please install the CoreML backend follwing https://pytorch.org/executorch/main/build-run-coreml.html"
+            + "; for buck users, please add example dependancies: //executorch/backends/apple/coreml:backend, and etc"
         )
 
     def _validate_ios_version() -> None:


### PR DESCRIPTION
Summary:
Add more context for buck users on the coreml pte2 quantization errors
- See D68569845 for details

Differential Revision: D68569845


