### PR TITLE
Update flat tensor flatbuffer namespace

### DIFF
--- a/extension/flat_tensor/serialize/flat_tensor.fbs
+++ b/extension/flat_tensor/serialize/flat_tensor.fbs
@@ -1,7 +1,7 @@
 // Schema for flatbuffer-serialized tensors.
 
 include "scalar_type.fbs";
-namespace flat_tensor;
+namespace flat_tensor_flatbuffer;
 
 // Update after BC breaking changes.
 file_identifier "FT01";


### PR DESCRIPTION
Summary: Change `flat_tensor` --> `flat_tensor_flatbuffer` to differentiate from the namespace in cpp.

Differential Revision: D68581839


