### PR TITLE
Make the quantized path the main compilation path

### DIFF
--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -142,8 +142,8 @@ def quantize_pt2(
     Prepare, convert and fuse the model using the given quantizer.
     Returns a GraphModule with the quantized model.
     """
-    # Make the model inference mode by calling model.eval()
-    model.eval()
+    # # Make the model inference mode by calling model.eval()
+    # model.eval()
 
     # Instantiate the quantizer to CadenceQuantizer if not supplied
     if not quantizer:


### PR DESCRIPTION
Summary:
This diff propagates the changes to the testing APIs to the regular (e.g. used in Bento or standalone) APIs.
It introduces `quantize_and_export_to_executorch`, and makes `export_to_executorch` call it.

Differential Revision: D67646596


