### PR TITLE
remove reduntant check_valid_op in EdgeDialectVerifier

### DIFF
--- a/exir/verification/verifier.py
+++ b/exir/verification/verifier.py
@@ -129,7 +129,7 @@ There are a few things to try:
 
 2. Sometimes inference and training gives slightly different op set. Try adding `with torch.no_grad():` context manager if you are export for inference only.
 
-3. If the error persists after 2, this is likely caused by torch.export() + core ATen decomposition producing unexpected operators for your model. 
+3. If the error persists after 2, this is likely caused by torch.export() + core ATen decomposition producing unexpected operators for your model.
    If you believe this operator should be included into core ATen opset, please create an issue in https://github.com/pytorch/pytorch/issues and add `module: core aten` tag.
                         """
                     )
@@ -273,31 +273,6 @@ def EXIREdgeDialectVerifier(  # noqa: C901
             if self.check_edge_ops:
                 _check_tensors_are_contiguous(gm)
                 _check_tensor_args_matching_op_allowed_dtype(gm)
-
-        def check_valid_op(self, op):
-            if isinstance(op, OpOverload):
-                # TODO These special ops should be removable easily.
-                if op.namespace in (
-                    "quantized_decomposed",
-                    "boltnn_nimble",
-                    "nimble",
-                    "quantized",
-                    "dim_order_ops",
-                ) or op in (
-                    torch.ops.aten.mkldnn_rnn_layer.default,
-                    torch.ops.aten._upsample_bilinear2d_aa.default,
-                    torch.ops.aten.quantize_per_tensor.default,
-                    torch.ops.aten.dequantize.self,
-                    torch.ops.aten.max.default,
-                    torch.ops.aten.full_like.default,  # TODO(T183507359)
-                ):
-                    return
-                if torch.Tag.core not in op.tags and torch.Tag.view_copy not in op.tags:
-                    # NOTE(qihan): whether view_copy operators are marked as canonical is still under
-                    #            discussion.
-                    raise SpecViolationError(
-                        f"Operator {op.__module__}.{op.__name__} is not Aten Canonical."
-                    )
 
         def is_valid(self, gm: GraphModule) -> bool:
             try:


### PR DESCRIPTION
Summary:
check_valid_op member function in EXIREdgeDialectVerifier is actually never used: it has been overrided in the EXIREdgeDialectVerifier constructor.
 Remove it for better structure.

Differential Revision: D68611967


