### PR TITLE
Disable broken job from continuous benchmark

### DIFF
--- a/.ci/scripts/gather_benchmark_configs.py
+++ b/.ci/scripts/gather_benchmark_configs.py
@@ -71,6 +71,10 @@ DISABLED_CONFIGS: Dict[str, List[DisabledConfig]] = {
             config_name="mps",
             github_issue="https://github.com/pytorch/executorch/issues/7904",
         ),
+        DisabledConfig(
+            config_name="qnn_q8",
+            github_issue="https://github.com/pytorch/executorch/issues/7946",
+        ),
     ],
     "edsr": [
         DisabledConfig(


### PR DESCRIPTION
### Summary
As titled. The bug is tracked in the GitHub Issue.

### Test plan
Android ad-hoc run: https://github.com/pytorch/executorch/actions/runs/12956451497
QNN is skipped.