### PR TITLE
[ET-VK][mac] Allow vulkan binaries to work with Vulkan SDK + fixes to enable debugPrintf extension

### DIFF
--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -142,18 +142,30 @@ def define_common_targets(is_fbcode = False):
                 "fbsource//third-party/swiftshader/lib/linux-x64:libvk_swiftshader_so",
             ]
         else:
+            link_moltenvk = read_config("etvk", "link_moltenvk", "1") == "1"
+            mac_deps = default_deps
+            if link_moltenvk:
+                mac_deps = [
+                    "//third-party/khronos:moltenVK_static"
+                ]
+            mac_flags = default_flags
+            if link_moltenvk:
+                mac_flags = []
+
             VK_API_DEPS += select({
                 "DEFAULT": default_deps,
                 "ovr_config//os:android": android_deps,
-                "ovr_config//os:macos": [
-                    "//third-party/khronos:moltenVK_static"
-                ],
+                "ovr_config//os:macos": mac_deps,
             })
             VK_API_PREPROCESSOR_FLAGS += select({
                 "DEFAULT": default_flags,
                 "ovr_config//os:android": android_flags,
-                "ovr_config//os:macos": []
+                "ovr_config//os:macos": mac_flags,
             })
+
+            debug_mode = read_config("etvk", "debug", "0") == "1"
+            if debug_mode:
+                VK_API_PREPROCESSOR_FLAGS += ["-DVULKAN_DEBUG"]
 
         runtime.cxx_library(
             name = "vulkan_compute_api{}".format(suffix),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #7957

## Context

Add a buck config option to prevent linking against MoltenVK when building for MacOS, instead opting to use volk. This is useful for seeing debug print statments from GLSL code.

Also implement some fixes to make things work when using system-installed Vulkan SDK, and some fixes to enable using debug Printf extension on Mac.

Specifically, the fixes are as follows:

* On newer versions of the Vulkan SDK, a portability instance extension needs to be explicitly enabled, otherwise creating the Vulkan instance will complain about the driver being incompatible. [source](https://stackoverflow.com/questions/58732459/vk-error-incompatible-driver-with-mac-os-and-vulkan-moltenvk)
* VkConfig on Mac doesn't show options to enable debugprintf, therefore it has to be enabled programmatically.

Differential Revision: [D68650936](https://our.internmc.facebook.com/intern/diff/D68650936/)

cc @manuelcandales