### PR TITLE
Add view_copy/static_reshape support to XNNPACK delegate

### DIFF
--- a/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
+++ b/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 from enum import Enum
 from typing import Optional, Tuple
 
@@ -161,6 +163,9 @@ class ChannelsLastTaggedReshapePass(XNNPACKPass):
         return node.target in self.memory_sensitive_ops_nhwc
 
     def requires_nchw_inputs(self, node: torch.fx.Node) -> bool:
+        if node.target == exir_ops.edge.aten.view_copy.default:
+            return True
+
         return node.target in self.memory_sensitive_ops_nchw
 
     def can_be_converted_to_nhwc(self, node: torch.fx.Node) -> bool:

--- a/backends/xnnpack/operators/__init__.py
+++ b/backends/xnnpack/operators/__init__.py
@@ -56,4 +56,5 @@ from . import (  # noqa
     op_sub,
     op_tanh,
     op_to_copy,
+    op_view_copy,
 )

--- a/backends/xnnpack/operators/op_skip_ops.py
+++ b/backends/xnnpack/operators/op_skip_ops.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 from typing import Dict
 
 import torch
@@ -57,16 +59,6 @@ class OpTCopyDefault(OpSkipOps):
     """
 
     target = "aten.t_copy.default"
-
-
-@register_node_visitor
-class OpViewCopyDefault(OpSkipOps):
-    """
-    currently, do nothing if node is view_copy.default
-    need to handle this later on, currently view it as one of skip ops
-    """
-
-    target = "aten.view_copy.default"
 
 
 @register_node_visitor

--- a/backends/xnnpack/operators/op_view_copy.py
+++ b/backends/xnnpack/operators/op_view_copy.py
@@ -1,0 +1,96 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from typing import Dict
+
+import torch
+from executorch.backends.xnnpack.operators.node_visitor import (
+    NodeVisitor,
+    register_node_visitor,
+)
+from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
+    XNNGraph,
+    XNNStaticReshape,
+    XNode,
+)
+from executorch.backends.xnnpack.utils.utils import (
+    check_or_raise,
+    get_input_node,
+    PERM_NCHW_TO_NHWC,
+)
+
+
+@register_node_visitor
+class ViewCopyVisitor(NodeVisitor):
+    target = "aten.view_copy.default"
+
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+        xnn_graph: XNNGraph,
+        vals_to_ids: Dict[torch.fx.Node, int],
+        debug_handle: int,
+    ) -> None:
+        self.define_nodes_tensor_inputs_outputs(node, xnn_graph, vals_to_ids)
+
+        input_node = get_input_node(node, 0)
+
+        # input
+        input_id = vals_to_ids[input_node]
+
+        # output
+        output_id = vals_to_ids[node]
+
+        # input shape
+        check_or_raise(
+            "val" in input_node.meta,
+            "Missing val in tensor metadata for input when serializing XNNStaticReshape",
+        )
+
+        # output shape
+        check_or_raise(
+            "val" in node.meta,
+            "Missing val in tensor metadata for input when serializing XNNStaticReshape",
+        )
+
+        new_shape = node.args[1]
+        check_or_raise(
+            all(isinstance(d, int) for d in new_shape),
+            "Symbolic reshape parameter is not supported in XNNStaticReshape",
+        )
+
+        # PyTorch uses -1 for inferred dims, whereas XNNPACK expects 0.
+        new_shape = tuple(d if d != -1 else 0 for d in new_shape)
+
+        # Handle NCHW dim order - if this op is in NCHW order, we need to permute the
+        # view shape correspondingly.
+        if "XNN_NHWC_NODE" in node.meta:
+            check_or_raise(len(new_shape) == 4, "Invalid NCHW shape")
+            new_shape = [new_shape[PERM_NCHW_TO_NHWC[n]] for n in range(4)]
+
+        num_dynamic_dims = sum(1 for d in new_shape if d == 0)
+
+        check_or_raise(
+            num_dynamic_dims <= 1,
+            "XNNPACK reshape only supports 1 dynamic dimension.",
+        )
+
+        ser_node = XNode(
+            xnode_union=XNNStaticReshape(
+                num_dims=len(new_shape),
+                new_shape=new_shape,
+                input_id=input_id,
+                output_id=output_id,
+                flags=0,
+            ),
+            debug_handle=debug_handle,
+        )
+        xnn_graph.xnodes.append(ser_node)

--- a/backends/xnnpack/partition/config/__init__.py
+++ b/backends/xnnpack/partition/config/__init__.py
@@ -55,6 +55,7 @@ from executorch.backends.xnnpack.partition.config.generic_node_configs import (
     TanhConfig,
     ToDimOrderCopyConfig,
     UpsampleBilinear2dConfig,
+    ViewCopyConfig,
 )
 from executorch.backends.xnnpack.partition.config.node_configs import (
     BatchNormConfig,
@@ -115,6 +116,7 @@ ALL_PARTITIONER_CONFIGS: List[Type[XNNPartitionerConfig]] = [
     SquareRootConfig,
     SubConfig,
     UpsampleBilinear2dConfig,
+    ViewCopyConfig,
     # Quant/Dequant Op Configs
     QuantizedPerTensorConfig,
     DeQuantizedPerTensorConfig,

--- a/backends/xnnpack/partition/config/generic_node_configs.py
+++ b/backends/xnnpack/partition/config/generic_node_configs.py
@@ -380,6 +380,43 @@ class ExpConfig(GenericNodePartitionerConfig):
         return [ConfigPrecisionType.FP32]
 
 
+class ViewCopyConfig(GenericNodePartitionerConfig):
+    target_name = "view_copy.default"
+
+    def supported_precision_types(self) -> List[ConfigPrecisionType]:
+        return [ConfigPrecisionType.FP32]
+
+    def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
+        """
+        XNNPACK's static_reshape only supports 1 dynamic dimension.
+        """
+        if not self.check_common_constraints(node, ep):
+            return False
+
+        new_shape = node.args[1]
+
+        # Check for symbolic dims. They aren't lowerable to XNNPACK currently.
+        symbolic_dim_indices = [
+            i for i, d in enumerate(new_shape) if not isinstance(d, int)
+        ]
+        if not all(isinstance(n, int) for n in new_shape):
+            why(
+                node,
+                reason=f"Symbolic reshape is not supported. Output shape is {new_shape} and dims at {symbolic_dim_indices} are symbolic.",
+            )
+            return False
+
+        dynamic_dim_indices = [i for i, d in enumerate(new_shape) if d == -1]
+        if len(dynamic_dim_indices) > 1:
+            why(
+                node,
+                reason=f"Only a single inferred dimension is supported. Output shape is {new_shape} and dims {dynamic_dim_indices} are inferred.",
+            )
+            return False
+
+        return True
+
+
 class FloorConfig(GenericNodePartitionerConfig):
     target_name = "floor.default"
 

--- a/backends/xnnpack/test/ops/test_view_copy.py
+++ b/backends/xnnpack/test/ops/test_view_copy.py
@@ -1,0 +1,290 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack.test.tester import Export, Tester
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch.export import Dim
+
+
+class TestViewCopy(unittest.TestCase):
+    class View(torch.nn.Module):
+        def __init__(self, new_shape):
+            super().__init__()
+            self.new_shape = new_shape
+
+        def forward(self, x):
+            z = x.view(self.new_shape)
+            return z
+
+    def test_fp16_view_copy(self):
+        inputs = (torch.randn(4, 4).to(torch.float16),)
+        (
+            Tester(self.View((2, 8)), inputs)
+            .export()
+            .check_node_count({torch.ops.aten.view.default: 1})
+            .to_edge_transform_and_lower()
+            .check_node_count(
+                {
+                    torch.ops.higher_order.executorch_call_delegate: 1,
+                    exir_ops.edge.aten.view_copy.default: 0,
+                }
+            )
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_view_copy(self):
+        inputs = (torch.randn(4, 4),)
+        (
+            Tester(self.View((2, 8)), inputs)
+            .export()
+            .check_node_count({torch.ops.aten.view.default: 1})
+            .to_edge_transform_and_lower()
+            .check_node_count(
+                {
+                    torch.ops.higher_order.executorch_call_delegate: 1,
+                    exir_ops.edge.aten.view_copy.default: 0,
+                }
+            )
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_view_copy_inferred_dim(self):
+        inputs = (torch.randn(4, 4),)
+        (
+            Tester(self.View((-1, 8)), inputs)
+            .export()
+            .check_node_count({torch.ops.aten.view.default: 1})
+            .to_edge_transform_and_lower()
+            .check_node_count(
+                {
+                    torch.ops.higher_order.executorch_call_delegate: 1,
+                    exir_ops.edge.aten.view_copy.default: 0,
+                }
+            )
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_view_copy_dynamic_shape(self):
+        inputs = (torch.randn(4, 4, 6),)
+        for dynamic_dim_index in range(len(inputs[0].shape)):
+            dynamic_shapes = {
+                "x": {dynamic_dim_index: Dim("x", min=1, max=10) * 2},
+            }
+
+            # Test as min and max bounds.
+            test_inputs = [
+                (inputs[0].clone(),),
+                (inputs[0].clone(),),
+            ]
+            test_inputs[0][0][dynamic_dim_index] = 2
+            test_inputs[1][0][dynamic_dim_index] = 20
+
+            # Non-dynamic dimensions are halved in the view.
+            view_size = [n // 2 for n in inputs[0].shape]
+            view_size[dynamic_dim_index] = -1
+
+            tester = (
+                Tester(self.View(view_size), inputs)
+                .export(Export(dynamic_shapes=dynamic_shapes))
+                .check_node_count({torch.ops.aten.view.default: 1})
+                .to_edge_transform_and_lower()
+                .check_node_count(
+                    {
+                        torch.ops.higher_order.executorch_call_delegate: 1,
+                        exir_ops.edge.aten.view_copy.default: 0,
+                    }
+                )
+                .to_executorch()
+                .serialize()
+                .run_method_and_compare_outputs()
+            )
+
+            for test_input in test_inputs:
+                tester.run_method_and_compare_outputs(inputs=test_input)
+
+    def test_fp32_view_copy_unsupported_dynamism(self):
+        class SymbolicView(torch.nn.Module):
+            def forward(self, x):
+                return x.view(x.shape[0] // 2, x.shape[1] * 2)
+
+        inputs = (torch.randn(4, 4),)
+        dynamic_shapes = {
+            "x": {1: Dim("x", min=1, max=10) * 2},
+        }
+        (
+            Tester(SymbolicView(), inputs)
+            .export(Export(dynamic_shapes=dynamic_shapes))
+            .check_node_count({torch.ops.aten.view.default: 1})
+            .to_edge_transform_and_lower()
+            .check_node_count(
+                {  # Expect no delegation as the view has two dynamic dimensions.
+                    torch.ops.higher_order.executorch_call_delegate: 0,
+                    exir_ops.edge.aten.view_copy.default: 1,
+                }
+            )
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_view_copy_static_symbolic_arg(self):
+        class SymbolicView(torch.nn.Module):
+            def forward(self, x):
+                return x.view(x.shape[0] // 2, x.shape[1] * 2)
+
+        inputs = (torch.randn(4, 4),)
+        (
+            Tester(SymbolicView(), inputs)
+            .export()
+            .check_node_count({torch.ops.aten.view.default: 1})
+            .to_edge_transform_and_lower()
+            .check_node_count(
+                {
+                    # Expect delegatation, as the the symbolic shape expressions will
+                    # be resolved to static values in the absense of dynamic shapes.
+                    torch.ops.higher_order.executorch_call_delegate: 1,
+                    exir_ops.edge.aten.view_copy.default: 0,
+                }
+            )
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_view_copy_increase_rank(self):
+        inputs = (torch.randn(4, 4),)
+        (
+            Tester(self.View((1, 2, 4, 2)), inputs)
+            .export()
+            .check_node_count({torch.ops.aten.view.default: 1})
+            .to_edge_transform_and_lower()
+            .check_node_count(
+                {
+                    torch.ops.higher_order.executorch_call_delegate: 1,
+                    exir_ops.edge.aten.view_copy.default: 0,
+                }
+            )
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_view_copy_increase_rank_dynamic(self):
+        test_inputs = (
+            (torch.randn(2, 4),),
+            (torch.randn(10, 4),),
+        )
+        dynamic_shapes = {
+            "x": {0: Dim("x", min=1, max=10) * 2},
+        }
+        inputs = (torch.randn(4, 4),)
+        tester = (
+            Tester(self.View((1, 2, 4, -1)), inputs)
+            .export(Export(dynamic_shapes=dynamic_shapes))
+            .check_node_count({torch.ops.aten.view.default: 1})
+            .to_edge_transform_and_lower()
+            .check_node_count(
+                {
+                    torch.ops.higher_order.executorch_call_delegate: 1,
+                    exir_ops.edge.aten.view_copy.default: 0,
+                }
+            )
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+        for test_input in test_inputs:
+            tester.run_method_and_compare_outputs(inputs=test_input)
+
+    def test_fp32_view_copy_decrease_rank(self):
+        inputs = (torch.randn(4, 4),)
+        (
+            Tester(self.View((-1)), inputs)
+            .export()
+            .check_node_count({torch.ops.aten.view.default: 1})
+            .to_edge_transform_and_lower()
+            .check_node_count(
+                {
+                    torch.ops.higher_order.executorch_call_delegate: 1,
+                    exir_ops.edge.aten.view_copy.default: 0,
+                }
+            )
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_view_copy_decrease_rank_dynamic(self):
+        test_inputs = (
+            (torch.randn(2, 2, 4),),
+            (torch.randn(2, 10, 4),),
+        )
+        dynamic_shapes = {
+            "x": {1: Dim("x", min=1, max=10) * 2},
+        }
+        inputs = (torch.randn(2, 4, 4),)
+        tester = (
+            Tester(self.View((-1)), inputs)
+            .export(Export(dynamic_shapes=dynamic_shapes))
+            .check_node_count({torch.ops.aten.view.default: 1})
+            .to_edge_transform_and_lower()
+            .check_node_count(
+                {
+                    torch.ops.higher_order.executorch_call_delegate: 1,
+                    exir_ops.edge.aten.view_copy.default: 0,
+                }
+            )
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+        for test_input in test_inputs:
+            tester.run_method_and_compare_outputs(inputs=test_input)
+
+    def test_fp32_view_copy_nhwc(self):
+        class ViewNHWC(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1 = torch.nn.Conv2d(3, 3, 3)
+                self.conv2 = torch.nn.Conv2d(3, 3, 3)
+
+            def forward(self, x):
+                y = self.conv1(x)
+                y = y.view(1, 3, 3, -1)
+                y = self.conv2(y)
+                return y.view(1, 3, 2, -1)
+
+        inputs = (torch.randn(1, 3, 8, 8),)
+        (
+            Tester(ViewNHWC(), inputs)
+            .export()
+            .dump_artifact()
+            .check_node_count({torch.ops.aten.view.default: 2})
+            .to_edge_transform_and_lower()
+            .dump_artifact()
+            .check_node_count(
+                {
+                    torch.ops.higher_order.executorch_call_delegate: 1,
+                    exir_ops.edge.aten.view_copy.default: 0,
+                }
+            )
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )


### PR DESCRIPTION
### Summary
Add support for delegating view_copy in the XNNPACK delegate via the XNN static_reshape operator. This includes support for up to one dynamic dimension. It also includes conditional support for NHWC, so long as batch and channel are fixed (if batch or channel is modified, the reshape has to be done in the native dim order).

Add support for delegating view_copy in the XNNPACK delegate via the XNN static_reshape operator. This includes support for up to one dynamic dimension.

### Test plan
I've added test coverage for view_copy, including dynamic shape support and practitioner constraints, to backends/xnnpack/test/ops/test_view_copy.py.If also added additional tests to cover the new view logic in channels_last_tagged_reshape_pass.