### PR TITLE
[ez] Add `delegation_info` dep to buck target

### DIFF
--- a/examples/models/llama/TARGETS
+++ b/examples/models/llama/TARGETS
@@ -117,6 +117,7 @@ runtime.python_library(
         # "//executorch/extension/pybindings:aten_lib",
         # "//executorch/extension/pybindings:portable_lib",
         # "//executorch/extension/pybindings:portable_lib_plus_custom",
+        "//executorch/devtools/backend_debug:delegation_info",
         "//executorch/devtools/etrecord:etrecord",
         "//executorch/util:memory_profiler",
         "//executorch/util:python_profiler",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #7963

## Context

https://github.com/pytorch/executorch/pull/7803 added an import to export_llama but did not add it to the buck target.

Differential Revision: [D68716129](https://our.internmc.facebook.com/intern/diff/D68716129/)