### PR TITLE
Add missing dtypes to gen_selected_op_variants.py

### DIFF
--- a/codegen/tools/gen_selected_op_variants.py
+++ b/codegen/tools/gen_selected_op_variants.py
@@ -59,6 +59,13 @@ dtype_enum_to_type = {
     "20": "Bits4x2",
     "21": "Bits8",
     "22": "Bits16",
+    "23": "Float8_e5m2",
+    "24": "Float8_e4m3fn",
+    "25": "Float8_e5m2fnuz",
+    "26": "Float8_e4m3fnuz",
+    "27": "UInt16",
+    "28": "UInt32",
+    "29": "Uint64",
 }
 
 


### PR DESCRIPTION
Summary: These were in scalar_type.h but not here. We should be able to understand all dtypes in this script even if they're not all implemented, because a custom op might support them.

Differential Revision: D68714101


