### PR TITLE
Mark call as deprecated

### DIFF
--- a/exir/passes/memory_planning_pass.py
+++ b/exir/passes/memory_planning_pass.py
@@ -9,6 +9,7 @@ import warnings
 from typing import Callable, List, Optional
 
 import torch
+from executorch.exir._warnings import deprecated
 from executorch.exir.error import internal_assert
 from executorch.exir.memory import alloc
 from executorch.exir.memory_planning import (
@@ -83,6 +84,11 @@ class MemoryPlanningPass(PassBase):
                         )
                         out_alloc_node.meta["spec"] = specs[i]
 
+    @deprecated(
+        "MemoryPlanningPass.call() is deprecated as it does not handle graphs \
+        with mutation, please use MemoryPlanningPass.run() instead",
+        category=FutureWarning,
+    )
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
         return self.run(graph_module)
 


### PR DESCRIPTION
Summary: call is deprecated since it cant handle mutation. This is a no op for people using the default memory planning stuff today, but want to call out louder to people implementing their own not to do call.

Differential Revision: D68726718


