### PR TITLE
Fix pyre failure in ARM tests

### DIFF
--- a/backends/arm/operator_support/to_copy_support.py
+++ b/backends/arm/operator_support/to_copy_support.py
@@ -125,6 +125,7 @@ class ToCopySupported(SupportedTOSAOperatorCheck):
         # Check dim_order (to_dim_order_copy)
         if "dim_order" in node.kwargs:
             dim_order = node.kwargs["dim_order"]
+            # pyre-ignore[6]
             if dim_order != list(range(len(dim_order))):
                 logger.info(
                     f"Argument {dim_order=} is not supported for "


### PR DESCRIPTION
Summary: Fix a pyre failure by ignoring it. Looking at the source, it's not trivial to fix this typecheck due to the way kwargs work, so I'm just going to add an ignore.

Differential Revision: D68737338


