### PR TITLE
Arm backend: manually annotate metadata of inserted transposes

### DIFF
--- a/backends/arm/_passes/annotate_channels_last_dim_order_pass.py
+++ b/backends/arm/_passes/annotate_channels_last_dim_order_pass.py
@@ -129,6 +129,7 @@ class AnnotateChannelsLastDimOrder(ExportPass):
             permute_node.meta["tosa_dim_order"] = tuple(
                 range(len(input_node.meta["val"].size()))
             )
+            permute_node.meta["val"] = input_node.meta["val"]
 
     @staticmethod
     def insert_output_transpose(node, graph_module):
@@ -139,6 +140,9 @@ class AnnotateChannelsLastDimOrder(ExportPass):
                 args=(node, list(AnnotateChannelsLastDimOrder.NHWC_order)),
             )
             permute_node.meta["tosa_dim_order"] = (
+                AnnotateChannelsLastDimOrder.NHWC_order
+            )
+            permute_node.meta["val"] = node.meta["val"].permute(
                 AnnotateChannelsLastDimOrder.NHWC_order
             )
             node.meta["tosa_dim_order"] = (0, 1, 2, 3)


### PR DESCRIPTION
### Summary
Manually annotate node.meta["val"] of inserted transposes.


cc @digantdesai @freddan80 @per @zingo