### PR TITLE
Added better error messages for type validators (stack trace)

### DIFF
--- a/exir/tests/test_arg_validator.py
+++ b/exir/tests/test_arg_validator.py
@@ -64,7 +64,7 @@ class TestArgValidator(unittest.TestCase):
             ops.edge.aten._log_softmax.default.name(),
         )
         self.assertDictEqual(
-            validator.violating_ops[key],
+            validator.violating_ops[key][0],
             {
                 "self": torch.bfloat16,
                 "__ret_0": torch.bfloat16,

--- a/exir/verification/arg_validator.py
+++ b/exir/verification/arg_validator.py
@@ -37,9 +37,9 @@ class EdgeOpArgValidator(torch.fx.Interpreter):
 
     def __init__(self, graph_module: torch.fx.GraphModule) -> None:
         super().__init__(graph_module)
-        self.violating_ops: Dict[EdgeOpOverload, Tuple[Dict[str, Optional[torch.dtype]], torch.fx.Node]] = (
-            defaultdict(dict)
-        )
+        self.violating_ops: Dict[
+            EdgeOpOverload, Tuple[Dict[str, Optional[torch.dtype]], torch.fx.Node]
+        ] = defaultdict(dict)
 
     def run_node(self, n: torch.fx.Node) -> None:
         self.node = n

--- a/exir/verification/arg_validator.py
+++ b/exir/verification/arg_validator.py
@@ -37,7 +37,7 @@ class EdgeOpArgValidator(torch.fx.Interpreter):
 
     def __init__(self, graph_module: torch.fx.GraphModule) -> None:
         super().__init__(graph_module)
-        self.violating_ops: Dict[EdgeOpOverload, Dict[str, Optional[torch.dtype]]] = (
+        self.violating_ops: Dict[EdgeOpOverload, Tuple[Dict[str, Optional[torch.dtype]], torch.fx.Node]] = (
             defaultdict(dict)
         )
 
@@ -125,5 +125,5 @@ class EdgeOpArgValidator(torch.fx.Interpreter):
 
         valid = target._schema.dtype_constraint.validate(tensor_arg_types)
         if not valid:
-            self.violating_ops[target] = tensor_arg_types
+            self.violating_ops[target] = (tensor_arg_types, self.node)
         return super().call_function(target, args, kwargs)  # pyre-fixme[6]

--- a/exir/verification/verifier.py
+++ b/exir/verification/verifier.py
@@ -192,11 +192,11 @@ def _check_tensor_args_matching_op_allowed_dtype(gm: GraphModule) -> None:
         error_msg = ""
         for op, node in validator.violating_ops.items():
             # error_msg += f"#####################################################\n"
-            error_msg += f"Operator: {op} with args: {node[0]}\n"
-            error_msg += f"stack trace: {node[1].stack_trace}\n\n"
+            error_msg += f"\nOperator: {op} with args: {node[0]}\n"
+            error_msg += f"stack trace: {node[1].stack_trace}\n"
             # error_msg += f"#####################################################\n"
         raise SpecViolationError(
-            f"These operators are taking Tensor inputs with mismatched dtypes:\n{error_msg}\n"
+            f"These operators are taking Tensor inputs with mismatched dtypes:\n{error_msg}"
             "Please make sure the dtypes of the Tensor inputs are the same as the dtypes of the corresponding outputs."
         )
 

--- a/exir/verification/verifier.py
+++ b/exir/verification/verifier.py
@@ -189,9 +189,15 @@ def _check_tensor_args_matching_op_allowed_dtype(gm: GraphModule) -> None:
         return
 
     if validator.violating_ops:
+        error_msg = ""
+        for op, node in validator.violating_ops.items():
+            # error_msg += f"#####################################################\n"
+            error_msg += f"Operator: {op} with args: {node[0]}\n"
+            error_msg += f"stack trace: {node[1].stack_trace}\n\n"
+            # error_msg += f"#####################################################\n"
         raise SpecViolationError(
-            f"These operators are taking Tensor inputs with mismatched dtypes: {validator.violating_ops}"
-            "Please make sure the dtypes of the Tensor inputs are the same as the dtypes of the corresponding "
+            f"These operators are taking Tensor inputs with mismatched dtypes:\n{error_msg}\n"
+            "Please make sure the dtypes of the Tensor inputs are the same as the dtypes of the corresponding outputs."
         )
 
 


### PR DESCRIPTION
### Summary
As I have been using executorch, I have run into issues with dtypes conflict during export, I end up with dtype mismatch during the to_edge process in exir. Unfortunately the current error message is less than clear, this change adds the stack trace from the nodes that have the issues, making it easier to find in your code where the type mismatch is.

#### Original Error Message:
```
    raise SpecViolationError(
torch._export.verifier.SpecViolationError: These operators are taking Tensor inputs with mismatched dtypes: defaultdict(<class 'dict'>, {<EdgeOpOverload: aten.cat.default>: schema = aten::cat(Tensor[] tensors, int dim=0) -> Tensor: {'tensors': torch.int32, '__ret_0': torch.int64}})Please make sure the dtypes of the Tensor inputs are the same as the dtypes of the corresponding 
```




#### New Error Message:
```
    raise SpecViolationError(
torch._export.verifier.SpecViolationError: These operators are taking Tensor inputs with mismatched dtypes:

Operator: <EdgeOpOverload: aten.cat.default>: schema = aten::cat(Tensor[] tensors, int dim=0) -> Tensor with args: {'tensors': torch.int32, '__ret_0': torch.int64}
stack trace:   File "/home/nlong/execu-tools/python/execu_tools/encoder_decoder_export.py", line 280, in reset_encode_prefill
    new_tokens = torch.cat((past_decoder_outputs, next_tokens), dim=1)

Please make sure the dtypes of the Tensor inputs are the same as the dtypes of the corresponding outputs.
```
### Changes:
Internally the validator is collecting the errors as they come up into a list, then later if that list is not empty an exception is made.

The only change is that during the collection process I also collect self.node, which happens to be the current node we are evaluating, and add that to the list (as the second item of a tuple). Then when raising the exception we have access to not just the op/args but also the node that was being evaluated.

Makes tracking these down _much_ easier.  
 
### Test plan
No testing, aside from being able to use it to fix my problems, it should not have any issues. 
self.node is already used to access the "meta" field, needed for the arg validation.