### PR TITLE
fix missing `if constexpr` in optimized gelu (unbreak sync of D68745515/#7987)

### DIFF
--- a/kernels/optimized/cpu/op_gelu.cpp
+++ b/kernels/optimized/cpu/op_gelu.cpp
@@ -69,7 +69,7 @@ void gelu(
     }
 #else
     size_t i = 0;
-    if (std::is_same<CTYPE, float>::value) {
+    if constexpr (std::is_same_v<CTYPE, float>) {
       for (; i + 4 < lim; i += 4) {
         const float32x4_t in =
             vld1q_f32(static_cast<const float*>(&in_data[i]));


### PR DESCRIPTION
The code gated under this `if` does disallowed static_casts if the `if` condition doesn't pass; this is what `if constexpr` is for.