### PR TITLE
Save XOR weights in .ptd

### DIFF
--- a/extension/training/examples/XOR/targets.bzl
+++ b/extension/training/examples/XOR/targets.bzl
@@ -17,6 +17,7 @@ def define_common_targets():
             "//executorch/runtime/executor:program",
             "//executorch/extension/data_loader:file_data_loader",
             "//executorch/kernels/portable:generated_lib",
+            "//executorch/extension/flat_tensor/serialize:serialize_cpp"
         ],
         external_deps = ["gflags"],
         define_static_target = True,

--- a/extension/training/examples/XOR/test/test_export.py
+++ b/extension/training/examples/XOR/test/test_export.py
@@ -13,6 +13,7 @@ from executorch.extension.training.examples.XOR.export_model import _export_mode
 
 class TestXORExport(unittest.TestCase):
     def test(self):
-        _ = _export_model()
+        ep = _export_model()
+        self.assertTrue(ep is not None)
         # Expect that we reach this far without an exception being thrown.
         self.assertTrue(True)

--- a/extension/training/examples/XOR/train.cpp
+++ b/extension/training/examples/XOR/train.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/extension/data_loader/file_data_loader.h>
+#include <executorch/extension/flat_tensor/serialize/serialize.h>
 #include <executorch/extension/tensor/tensor.h>
 #include <executorch/extension/training/module/training_module.h>
 #include <executorch/extension/training/optimizer/sgd.h>
@@ -105,4 +106,11 @@ int main(int argc, char** argv) {
     }
     optimizer.step(mod.named_gradients("forward").get());
   }
+  std::map<std::string, exec_aten::Tensor> param_map;
+  for (auto& param : param_res.get()) {
+    param_map.insert(std::pair<std::string, exec_aten::Tensor>{
+        std::string(param.first.data()), param.second});
+  }
+
+  executorch::extension::flat_tensor::save_ptd("xor.ptd", param_map, 16);
 }


### PR DESCRIPTION
Summary: Save the weights in a .ptd instead of one bundled program, Update the training script

Differential Revision: D68785514


