### PR TITLE
Fix linux_job_2.yml on pull

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -357,10 +357,16 @@ jobs:
 
   android:
     uses: ./.github/workflows/_android.yml
+    permissions:
+      id-token: write
+      contents: read
     needs: test-llama-runner-linux
 
   unittest:
     uses: ./.github/workflows/_unittest.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       docker-image: executorch-ubuntu-22.04-clang12
 


### PR DESCRIPTION
### Summary
`pull.yml` had some jobs that were missing some permissions

### Test plan
Pass CI
