### PR TITLE
remove the exec_aten namespace

### DIFF
--- a/runtime/core/exec_aten/exec_aten.h
+++ b/runtime/core/exec_aten/exec_aten.h
@@ -143,10 +143,6 @@ using torch::executor::compute_numel;
 } // namespace aten
 } // namespace executorch
 
-// DEPRECATED: The exec_aten:: namespace is deprecated. Use executorch::aten::
-// instead.
-namespace exec_aten = executorch::aten;
-
 namespace torch {
 namespace executor {
 using TensorList = ::executorch::aten::TensorList;


### PR DESCRIPTION
Following up on #7950, it was deprecated and appears to now be unused.