### PR TITLE
set lintrunner merge_base_with main instead of origin/main

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1,4 +1,4 @@
-merge_base_with = "origin/main"
+merge_base_with = "main"
 
 [[linter]]
 code = 'FLAKE8'


### PR DESCRIPTION
If origin points to a fork that you haven't updated in a while, lintrunner will be very slow. Similarly, if you're working in a branch off main and have fetched origin/main but not updated main, lintrunner will lint excess files.