### PR TITLE
Add configurable event tracing names for method execution

### DIFF
--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -184,10 +184,11 @@ runtime::Result<std::vector<runtime::EValue>> Module::execute(
     ET_CHECK_OR_RETURN_ERROR(
         !inputs[i].isNone(), InvalidArgument, "input %zu is none", i);
   }
-  ET_CHECK_OK_OR_RETURN_ERROR(
-      method->set_inputs(executorch::aten::ArrayRef<runtime::EValue>(
-          inputs.data(), inputs.size())));
-  ET_CHECK_OK_OR_RETURN_ERROR(method->execute());
+  auto block_name = std::string("Execute::" + method_name);
+  auto profile_event_name = std::string("Method::execute::" + method_name);
+  ET_CHECK_OK_OR_RETURN_ERROR(method->set_inputs(
+      executorch::aten::ArrayRef<runtime::EValue>(inputs.data(), inputs.size())));
+  ET_CHECK_OK_OR_RETURN_ERROR(method->execute(block_name.c_str(), profile_event_name.c_str()));
 
   const auto outputs_size = method->outputs_size();
   std::vector<runtime::EValue> outputs(outputs_size);

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -1332,11 +1332,11 @@ Error Method::experimental_step() {
   return step();
 }
 
-Error Method::execute() {
-  internal::event_tracer_create_event_block(event_tracer_, "Execute");
+Error Method::execute(char const* block_name, char const* profile_event_name) {
+  internal::event_tracer_create_event_block(event_tracer_, block_name);
   EventTracerEntry event_tracer_entry =
       internal::event_tracer_begin_profiling_event(
-          event_tracer_, "Method::execute");
+          event_tracer_, profile_event_name);
   EXECUTORCH_SCOPE_PROF("Method::execute");
   ET_CHECK_OR_RETURN_ERROR(
       initialized(),

--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -180,9 +180,14 @@ class Method final {
    * NOTE: Will fail if the method has been partially executed using the
    * `step()` api.
    *
+   * @param[in] block_name The name of the block to create in the event tracer.
+   * @param[in] profile_event_name The name of the event to create in the event tracer.
+   *
    * @returns Error::Ok on success, non-Ok on failure.
    */
-  ET_NODISCARD Error execute();
+  ET_NODISCARD Error execute(
+      char const* block_name = "Method::execute",
+      const char* profile_event_name = "Method::execute");
 
   /**
    * EXPERIMENTAL: Advances/executes a single instruction in the method.


### PR DESCRIPTION
### Summary
This is kind of a quality of life thing when working with exported modules with multiple methods.


### The Issue:
By default, all methods of a module use the same profiling event and event block. This is fine, when one only has a single method exported, however the profiling data becomes less meaningful if there are multiple methods.

This is related to #8030 where I am exporting multiple methods on a single module and having them all share internal state.

### The change:
In Method::execute, allow the caller to optionally pass in `const char*` block name and profiling event name. 

```c++
Error execute(
      char const* block_name = "Method::execute",
      const char* profile_event_name = "Method::execute");
```

By default these are the same as what was hardcoded internally.

Additionally change the behavior of Module::execute to pass in the name of the current method. 
```cpp
  auto block_name = std::string("Execute::" + method_name);
  auto profile_event_name = std::string("Method::execute::" + method_name);
```

This does change the current behavior of Module, as anyone using that api will no longer get the previous hardcoded  "Method::execute" names.

cc @JacobSzwejbka @dbort