### PR TITLE
[docs][ez] Fix doc build workflow

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -85,7 +85,6 @@ jobs:
     if: github.repository == 'pytorch/executorch' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
       contents: write
-      contents: read
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       repository: pytorch/executorch


### PR DESCRIPTION
[Doc build](https://github.com/pytorch/executorch/actions/workflows/doc-build.yml) workflows have been failing for a while due to [redefinition of the `contents:` field](https://github.com/pytorch/executorch/actions/runs/13037800951/workflow) in the workflow file. This is a simple fix for that.

cc @mergennachin @byjlw