### PR TITLE
Adjust tolerance for quantized XNN conv1d tests

### DIFF
--- a/backends/xnnpack/test/ops/test_conv1d.py
+++ b/backends/xnnpack/test/ops/test_conv1d.py
@@ -122,9 +122,13 @@ class TestConv1d(unittest.TestCase):
         # For some tests we want to skip to_executorch because otherwise it will require the
         # quantized operators to be loaded and we don't want to do that in the test.
         if not skip_to_executorch:
-            tester.to_executorch().serialize().run_method_and_compare_outputs(
-                num_runs=10, atol=0.01, rtol=0.01
-            )
+            tester.to_executorch().serialize()
+            if quantized:
+                tester.run_method_and_compare_outputs(
+                    num_runs=10, atol=0.025, rtol=0.01
+                )
+            else:
+                tester.run_method_and_compare_outputs()
 
     def test_fp16_conv1d(self):
         inputs = (torch.randn(2, 2, 4).to(torch.float16),)


### PR DESCRIPTION
### Summary
Quantized conv1d tests are flaky due to tolerance being too low. This PR bumps the tolerance slightly. This should be safe, as the underlying kernels are believed to be correct and this issue has been observed for some time (not a recent regression in kernel accuracy).

### Test plan
Ran tests locally for 1000 iterations and did not observe any failures.
