### PR TITLE
Increase the tolerance of  test_conv1d

### DIFF
--- a/backends/xnnpack/test/ops/test_conv1d.py
+++ b/backends/xnnpack/test/ops/test_conv1d.py
@@ -123,7 +123,7 @@ class TestConv1d(unittest.TestCase):
         # quantized operators to be loaded and we don't want to do that in the test.
         if not skip_to_executorch:
             tester.to_executorch().serialize().run_method_and_compare_outputs(
-                num_runs=10, atol=0.01, rtol=0.01
+                num_runs=10, atol=0.02, rtol=0.02
             )
 
     def test_fp16_conv1d(self):


### PR DESCRIPTION
It's flaky in the CI test. Double the tolerance to avoid it.

### Test plan
CI