### PR TITLE
Add buck file for unit test

### DIFF
--- a/backends/qualcomm/tests/TARGETS
+++ b/backends/qualcomm/tests/TARGETS
@@ -1,0 +1,39 @@
+load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
+load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
+load("@fbsource//xplat/executorch/backends/qualcomm/qnn_version.bzl", "get_qnn_library_verision")
+
+python_library(
+    name = "models",
+    srcs = ["models.py"],
+    deps = [
+        "//caffe2:torch",
+    ]
+)
+
+python_library(
+    name = "test_qnn_delegate",
+    srcs = [
+        "test_qnn_delegate.py",
+        "utils.py",
+    ],
+    # env = {
+    #     "LD_LIBRARY_PATH": "$(location fbsource//third-party/qualcomm/qnn/qnn-{0}:qnn_offline_compile_libs)".format(get_qnn_library_verision()),
+    # },
+    deps = [
+        ":models",
+        "//caffe2:torch",
+        "//caffe2/functorch:functorch_src",
+        "//executorch/exir/backend:partitioner",
+        "//executorch/exir/dialects:lib",
+        "//executorch/extension/pybindings:portable_lib",  # @manual
+        "//executorch/extension/pytree:pylib",
+        "//executorch/backends/qualcomm/partition:partition",
+        "//executorch/backends/qualcomm/quantizer:quantizer",
+        "//executorch/backends/qualcomm/serialization:serialization",
+        "//executorch/backends/qualcomm/utils:utils",
+        "//executorch/devtools:lib",
+        "//executorch/examples/qualcomm:utils",
+        "//executorch/examples/models:models",
+        "//executorch/backends/qualcomm/debugger:utils",
+    ],
+)

--- a/backends/qualcomm/tests/utils.py
+++ b/backends/qualcomm/tests/utils.py
@@ -190,6 +190,7 @@ class TestQNN(unittest.TestCase):
     compile_only: bool = False
     pre_gen_pte: str = ""
     llama_artifacts: str = ""
+    dump_intermediate_outputs: bool = False
 
     def _assert_outputs_equal(self, model_output, ref_output):
         self.assertTrue(len(ref_output) == len(model_output))


### PR DESCRIPTION
Summary:
```
buck2 test 'fbcode//mode/dev-nosan' fbcode//executorch/backends/qualcomm/tests/fb:test_qnn_delegate_simulator -- --exact 'executorch/backends/qualcomm/tests/fb:test_qnn_delegate_simulator - test_qnn_backend_mha (executorch.backends.qualcomm.tests.fb.test_qnn_delegate_simulator.TestQNNQuantizedOperatorSimulator)'
```

Differential Revision: D67463640


