### PR TITLE
[executorch] Create target for named_data_map

### DIFF
--- a/runtime/core/targets.bzl
+++ b/runtime/core/targets.bzl
@@ -41,7 +41,6 @@ def define_common_targets():
             "defines.h",
             "error.h",
             "freeable_buffer.h",
-            "named_data_map.h",
             "result.h",
             "span.h",
         ],
@@ -133,6 +132,20 @@ def define_common_targets():
         ],
     )
 
+    runtime.cxx_library(
+        name = "named_data_map",
+        exported_headers = [
+            "named_data_map.h",
+        ],
+        visibility = [
+            "//executorch/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+        exported_deps = [
+            ":tensor_layout",
+        ],
+    )
+    
     runtime.cxx_library(
         name = "tensor_layout",
         srcs = ["tensor_layout.cpp"],

--- a/runtime/core/tensor_layout.cpp
+++ b/runtime/core/tensor_layout.cpp
@@ -30,7 +30,7 @@ Result<size_t> calculate_nbytes(
 }
 } // namespace
 
-Result<TensorLayout> TensorLayout::create(
+Result<const TensorLayout> TensorLayout::create(
     Span<const int32_t> sizes,
     Span<const uint8_t> dim_order,
     executorch::aten::ScalarType scalar_type) {

--- a/runtime/core/tensor_layout.h
+++ b/runtime/core/tensor_layout.h
@@ -33,7 +33,7 @@ class ET_EXPERIMENTAL TensorLayout final {
    * @param[in] scalar_type The scalar type of the tensor.
    * @return A Result containing the TensorLayout on success, or an error.
    */
-  static executorch::runtime::Result<TensorLayout> create(
+  static executorch::runtime::Result<const TensorLayout> create(
       Span<const int32_t> sizes,
       Span<const uint8_t> dim_order,
       executorch::aten::ScalarType scalar_type);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

^

named_data_map depends on tensor_layout, which depends on exec_lib.

Move it out from core, as we have a circular dep when exec_lib is part of core.

Also make TensorLayout::create return a const.

Differential Revision: [D68972364](https://our.internmc.facebook.com/intern/diff/D68972364/)