### PR TITLE
Remove empty line

### DIFF
--- a/backends/cadence/hifi/third-party/nnlib/xa_nn_elm_minimum_maximum_f32.c
+++ b/backends/cadence/hifi/third-party/nnlib/xa_nn_elm_minimum_maximum_f32.c
@@ -843,4 +843,3 @@ WORD32 xa_nn_elm_minimum_broadcast_4D_f32xf32_f32(FLOAT32 * __restrict__ p_out,
 }
 
 #endif
-


### PR DESCRIPTION
### Summary
Remove a trailing empty line

@diff-train-skip-merge
In internal repo, it's already removed