### PR TITLE
Fix doc build workflow

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -84,8 +84,8 @@ jobs:
     needs: build
     if: github.repository == 'pytorch/executorch' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
+      id-token: write
       contents: write
-      contents: read
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       repository: pytorch/executorch


### PR DESCRIPTION
### Summary
The doc build job has been broken for a few days since the workflow files were updated. It is currently failing with the following error:
```
The workflow is not valid. .github/workflows/doc-build.yml (Line: 88, Col: 7): 'contents' is already defined
```
I copied the pattern used in the rest of the workflow files updated with the ci linux job v2 change. It looks like this one might have just not been fully updated?

### Test plan
Testing on local PR CI. If it passes here, it should pass on trunk.
