### PR TITLE
Add a pass to replace nodes with empty tensors with full.

### DIFF
--- a/backends/cadence/aot/graph_builder.py
+++ b/backends/cadence/aot/graph_builder.py
@@ -6,10 +6,16 @@ import logging
 from typing import Optional, Sequence, Union
 
 import torch
-from executorch.exir.pass_base import ExportPass, NodeMetadata, PassResult, ProxyValue
+from executorch.exir.pass_base import (
+    Argument,
+    ExportPass,
+    NodeMetadata,
+    PassResult,
+    ProxyValue,
+)
 from torch._dispatch.python import enable_python_dispatcher
 from torch._subclasses import FakeTensor, FakeTensorMode
-from torch.fx.node import Argument, Target
+from torch.fx.node import Target
 from torch.utils import _pytree as pytree
 
 

--- a/backends/cadence/aot/tests/test_graph_builder.py
+++ b/backends/cadence/aot/tests/test_graph_builder.py
@@ -26,7 +26,6 @@ class TestGraphBuilder(TestCase):
         channels_last = False
         im2row = builder.call_operator(
             exir_ops.edge.cadence.im2row.default,
-            # pyre-ignore
             (
                 x,
                 (2, 2),
@@ -80,7 +79,7 @@ class TestHigherOrderOps(TestCase):
         x = builder.placeholder("x", torch.randn(*x_shape))
         add = builder.call_operator(
             exir_ops.edge.aten.add.Tensor,
-            (x, x),  # pyre-ignore
+            (x, x),
         )
         builder.output([x, add])
         gm = builder.get_graph_module()


### PR DESCRIPTION
Summary: Remove subgraphs of ops that produce empty tensors at the end. `ReplaceEmptyTensorsWithFullPass` both does the replacement and dead code elimination.

Reviewed By: zonglinpeng

Differential Revision: D68907459


