### PR TITLE
Add tosa serializer to .mypy.ini

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -77,6 +77,9 @@ ignore_missing_imports = True
 [mypy-ruamel]
 ignore_missing_imports = True
 
+[mypy-serializer.*]
+ignore_missing_imports = True
+
 [mypy-setuptools.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
As suggested in a previous discussion the tosa serializer should go into .mypy.ini for a project wide ignore on missing imports instead of doing inline annotations in every file.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218