### PR TITLE
Prioritise FuseBatchnorm2D over DecomposeBatchNormPass

### DIFF
--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -123,6 +123,7 @@ class ArmPassManager(PassManager):
         self.add_pass(FuseQuantizedActivationPass())
         self.add_pass(RemoveGetItemPass())
         self.add_pass(ConvertSplitToSlicePass())
+        self.add_pass(FuseBatchnorm2DPass(exported_program))
         self.add_pass(ConvertMmToBmmPass())
         self.add_pass(DecomposeLinearPass())
         self.add_pass(DecomposeBatchNormPass())
@@ -132,7 +133,6 @@ class ArmPassManager(PassManager):
         self.add_pass(ConvertMeanDimToAveragePoolPass())
         self.add_pass(DecomposeDivPass())
         self.add_pass(DecomposeSoftmaxesPass())
-        self.add_pass(FuseBatchnorm2DPass(exported_program))
 
         self.add_pass(AnnotateDecomposedMatmulPass())
         self.add_pass(QuantizeOperatorArguments())


### PR DESCRIPTION
* As it is preferable to fuse batch_norm over decomposing it, prioritise this pass higher

Change-Id: I353d324ca31b85f1c62c866c93b49253ab7b4014



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218