### PR TITLE
[executorch] Create target for named_data_map

### DIFF
--- a/runtime/core/targets.bzl
+++ b/runtime/core/targets.bzl
@@ -41,7 +41,6 @@ def define_common_targets():
             "defines.h",
             "error.h",
             "freeable_buffer.h",
-            "named_data_map.h",
             "result.h",
             "span.h",
         ],
@@ -133,6 +132,20 @@ def define_common_targets():
         ],
     )
 
+    runtime.cxx_library(
+        name = "named_data_map",
+        exported_headers = [
+            "named_data_map.h",
+        ],
+        visibility = [
+            "//executorch/...",
+            "@EXECUTORCH_CLIENTS",
+        ],
+        exported_deps = [
+            ":tensor_layout",
+        ],
+    )
+    
     runtime.cxx_library(
         name = "tensor_layout",
         srcs = ["tensor_layout.cpp"],

--- a/runtime/core/tensor_layout.cpp
+++ b/runtime/core/tensor_layout.cpp
@@ -30,7 +30,7 @@ Result<size_t> calculate_nbytes(
 }
 } // namespace
 
-Result<TensorLayout> TensorLayout::create(
+Result<const TensorLayout> TensorLayout::create(
     Span<const int32_t> sizes,
     Span<const uint8_t> dim_order,
     executorch::aten::ScalarType scalar_type) {

--- a/runtime/core/tensor_layout.h
+++ b/runtime/core/tensor_layout.h
@@ -33,7 +33,7 @@ class ET_EXPERIMENTAL TensorLayout final {
    * @param[in] scalar_type The scalar type of the tensor.
    * @return A Result containing the TensorLayout on success, or an error.
    */
-  static executorch::runtime::Result<TensorLayout> create(
+  static executorch::runtime::Result<const TensorLayout> create(
       Span<const int32_t> sizes,
       Span<const uint8_t> dim_order,
       executorch::aten::ScalarType scalar_type);
@@ -77,16 +77,16 @@ class ET_EXPERIMENTAL TensorLayout final {
         scalar_type_(scalar_type),
         nbytes_(nbytes) {}
   /// The sizes of the tensor.
-  Span<const int32_t> sizes_;
+  const Span<const int32_t> sizes_;
 
   /// The dim order of the tensor.
-  Span<const uint8_t> dim_order_;
+  const Span<const uint8_t> dim_order_;
 
   /// The scalar type of the tensor.
-  executorch::aten::ScalarType scalar_type_;
+  const executorch::aten::ScalarType scalar_type_;
 
   /// The size in bytes of the tensor.
-  size_t nbytes_;
+  const size_t nbytes_;
 };
 
 } // namespace runtime

--- a/runtime/core/test/tensor_layout_test.cpp
+++ b/runtime/core/test/tensor_layout_test.cpp
@@ -26,7 +26,7 @@ TEST(TestTensorLayout, Ctor) {
   Span<const int32_t> sizes_span = {sizes.data(), sizes.size()};
   Span<const uint8_t> dim_order_span = {dim_order.data(), dim_order.size()};
 
-  Result<TensorLayout> layout_res =
+  Result<const TensorLayout> layout_res =
       TensorLayout::create(sizes_span, dim_order_span, ScalarType::Float);
   EXPECT_TRUE(layout_res.ok());
 
@@ -50,7 +50,7 @@ TEST(TestTensorLayout, Ctor_InvalidDimOrder) {
   Span<const int32_t> sizes_span = {sizes.data(), sizes.size()};
   Span<const uint8_t> dim_order_span = {dim_order.data(), dim_order.size()};
 
-  Result<TensorLayout> layout_res =
+  Result<const TensorLayout> layout_res =
       TensorLayout::create(sizes_span, dim_order_span, ScalarType::Float);
   EXPECT_EQ(layout_res.error(), Error::InvalidArgument);
 }
@@ -61,7 +61,7 @@ TEST(TestTensorLayout, Ctor_InvalidSizes) {
   Span<const int32_t> sizes_span = {sizes.data(), sizes.size()};
   Span<const uint8_t> dim_order_span = {dim_order.data(), dim_order.size()};
 
-  Result<TensorLayout> layout_res =
+  Result<const TensorLayout> layout_res =
       TensorLayout::create(sizes_span, dim_order_span, ScalarType::Float);
   EXPECT_EQ(layout_res.error(), Error::InvalidArgument);
 }
@@ -72,7 +72,7 @@ TEST(TestTensorLayout, Ctor_SizesDimOrderMismatch) {
   Span<const int32_t> sizes_span = {sizes.data(), sizes.size()};
   Span<const uint8_t> dim_order_span = {dim_order.data(), dim_order.size()};
 
-  Result<TensorLayout> layout_res =
+  Result<const TensorLayout> layout_res =
       TensorLayout::create(sizes_span, dim_order_span, ScalarType::Float);
   EXPECT_EQ(layout_res.error(), Error::InvalidArgument);
 }


### PR DESCRIPTION
### Summary
named_data_map depends on tensor_layout, which depends on exec_lib.
Move it out from core, as we have a circular dep when exec_lib is part of core.
Also make TensorLayout::create return a const.
