### PR TITLE
Error out if registering prim ops multiple times

### DIFF
--- a/shim/xplat/executorch/codegen/codegen.bzl
+++ b/shim/xplat/executorch/codegen/codegen.bzl
@@ -692,6 +692,7 @@ def executorch_ops_check(
                "--model_file_list_path $(@query_outputs \"filter('.*_et_oplist', deps(set({deps})))\") " +
                "--allow_include_all_overloads " +
                "--check_ops_not_overlapping " +
+               "--DEBUG_ONLY_check_prim_ops $(@query_targets \"filter('prim_ops_registry(?:_static|_aten)?$', deps(set({deps})))\") " +
                "--output_dir $OUT ").format(deps = " ".join(["\'{}\'".format(d) for d in deps])),
         define_static_target = False,
         platforms = kwargs.pop("platforms", get_default_executorch_platforms()),


### PR DESCRIPTION
Summary:
Using `executorch_ops_check` should error out if the dependencies includes 2 libraries of `prim_op_registry`. For example:

The target `//arvr/libraries/wristband/tsn/transformers:TorchstreamTransformerTest` depends on both `prim_ops_registry` and `prim_ops_registry_aten`. BUCK query:

```
buck2 uquery "filter('prim_ops_registry(?:_static|_aten)?$', deps(//arvr/libraries/wristband/tsn/transformers:
TorchstreamTransformerTest))"
Buck UI: https://www.internalfb.com/buck2/1401c12c-0ef2-4ba8-8d4e-6b86871d708f
Network: Up: 0B  Down: 0B
Command: uquery.
Time elapsed: 3.6s
fbcode//executorch/kernels/prim_ops:prim_ops_registry
fbcode//executorch/kernels/prim_ops:prim_ops_registry_aten
fbsource//xplat/executorch/kernels/prim_ops:prim_ops_registry
fbsource//xplat/executorch/kernels/prim_ops:prim_ops_registry_aten
```

This will cause the error like this:

```
E 00:00:00.032942 executorch:operator_registry.cpp:86] Re-registering aten::sym_size.int, from /data/users/larryliu/fbsource/buck-out/v2/gen/fbsource/cfdc20bd56300721/arvr/libraries/wristband/tsn/transformers/__TorchstreamTransformerTest__/./__TorchstreamTransformerTest__shared_libs_symlink_tree/libexecutorc$
E 00:00:00.033022 executorch:operator_registry.cpp:87] key: (null), is_fallback: true
F 00:00:00.033033 executorch:operator_registry.cpp:111] In function register_kernels(), assert failed (false): Kernel registration failed with error 18, see error log for details.
```

To catch issues like this, we should error out when user uses `executorch_ops_check` to debug.

```
executorch_ops_check(
    name = "my_executorch_test_check",
    deps = [":TorchstreamTransformerTest"],
)
```

Fixing the internal portion of [#8171](https://github.com/pytorch/executorch/issues/8171)

Differential Revision: D69090850


