### PR TITLE
try to use 48xlarge runners for llava-runner and eval_llama-mmlu

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -208,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
     with:
-      runner: linux.24xlarge
+      runner: linux.48xlarge
       docker-image: executorch-ubuntu-22.04-clang12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -531,7 +531,7 @@ jobs:
     strategy:
       fail-fast: false
     with:
-      runner: linux.24xlarge
+      runner: linux.48xlarge
       docker-image: executorch-ubuntu-22.04-clang12
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
These jobs are timing out. I found big gaps in the timestamps of the logs even before the blame PR, which to me suggests swapping. Let's try bigger runners and see what happens on this PR.

Fixes #8180 (if it lands)