### PR TITLE
Trial revert of --use-pt-pinned-commit for llava

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -221,7 +221,7 @@ jobs:
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh "cmake"
 
         # install pybind
-        bash install_executorch.sh --pybind xnnpack --use-pt-pinned-commit
+        bash install_executorch.sh --pybind xnnpack
 
         # install Llava requirements
         bash examples/models/llama/install_requirements.sh


### PR DESCRIPTION
Now that we've bumped the nightly version, let's make sure that --use-pt-pinned-commit is definitely causing the long running times here (#8180).