### PR TITLE
Warn if wrong type is given for Llama export for XNNPACK

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -674,6 +674,12 @@ def _validate_args(args):
                 "If you need this feature, please file an issue."
             )
 
+    if args.xnnpack:
+        if args.dtype_override not in ["fp32", "fp16"]:
+            raise ValueError(
+                f"XNNPACK supports either fp32 or fp16 dtypes only for now. Given {args.dtype_override}."
+            )
+
 
 def _export_llama(args) -> LLMEdgeManager:  # noqa: C901
     _validate_args(args)


### PR DESCRIPTION
Followup to https://github.com/pytorch/executorch/issues/7775

Test Plan:

```
(executorch) mnachin@mnachin-mbp executorch % python -m examples.models.llama.export_llama \
    --checkpoint /Users/mnachin/models/Llama-3.2-1B/original/consolidated.00.pth \
        -p /Users/mnachin/models/Llama-3.2-1B/original/params.json \
        -kv \
        --use_sdpa_with_kv_cache \
        -X \
        -qmode 8da4w \
        --group_size 128 \
        -d bf16 \
        --metadata '{"get_bos_id":128000, "get_eos_ids":[128009, 128001]}' \
        --embedding-quantize 4,32 \
        --output_name="Llama-8B.pte"
```

```
import error: No module named 'triton'
Traceback (most recent call last):
  File "/Users/mnachin/miniconda/envs/executorch/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/mnachin/miniconda/envs/executorch/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/mnachin/executorch/examples/models/llama/export_llama.py", line 32, in <module>
    main()  # pragma: no cover
  File "/Users/mnachin/executorch/examples/models/llama/export_llama.py", line 28, in main
    export_llama(args)
  File "/Users/mnachin/executorch/examples/models/llama/export_llama_lib.py", line 542, in export_llama
    builder = _export_llama(args)
  File "/Users/mnachin/executorch/examples/models/llama/export_llama_lib.py", line 685, in _export_llama
    _validate_args(args)
  File "/Users/mnachin/executorch/examples/models/llama/export_llama_lib.py", line 679, in _validate_args
    raise ValueError(
ValueError: XNNPACK supports either fp32 or fp16 dtypes only for now. Given bf16.
```