### PR TITLE
Elide static view copies

### DIFF
--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -87,6 +87,7 @@ class ExecutorchBackendConfig:
 
     # If set to true, view_copy operations will be converted to lightweight
     # view operations in the ET runtime
+    # Moreover, static views will be elided from the ExecuTorch graph
     remove_view_copy: bool = True
 
     # If set to true, all constant tensors will be stored in a separate file,

--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -943,6 +943,16 @@ class _Emitter(torch.fx.Interpreter):
     def _emit_view(self, args: Tuple[_Argument, ...]) -> _EmitterValue:
         assert len(args) == 2
 
+        # Elide the view if it is static and memory planned
+        spec = self.node.meta["spec"]
+        is_static = spec.is_static_shape_tensor
+        is_memory_planned = (spec.mem_id is not None) and (spec.mem_offset is not None)
+        is_memory_planned = is_memory_planned or (
+            spec.const and spec.storage is not None
+        )
+        if is_static and is_memory_planned:
+            return self._emit_spec(spec)
+
         self_arg = self._emit_argument(args[0], torch.TensorType)  # pyre-ignore[6]
         size_arg = self._emit_argument(args[1], torch.ListType.ofInts())
         out_arg = self._emit_argument(


### PR DESCRIPTION
Summary: This adds an ExecuTorch config option to to elide static views.

Differential Revision: D68984189


