### PR TITLE
[BE] Remind users to update submodule

### DIFF
--- a/build/extract_sources.py
+++ b/build/extract_sources.py
@@ -138,7 +138,8 @@ class Target:
                 "to missing git submodules or outdated CMake cache. "
                 "Please run the following before retry:\033[0m\n\n"
                 "    \033[32;1m./install_executorch.sh --clean\033[0m\n"
-                "    \033[32;1mgit submodule update --init --recursive\033[0m\n"
+                "    \033[32;1mgit submodule sync\033[0m\n"
+                "    \033[32;1mgit submodule update --init\033[0m\n"
             )
             raise e
 

--- a/build/extract_sources.py
+++ b/build/extract_sources.py
@@ -7,6 +7,7 @@
 
 import argparse
 import copy
+import logging
 import os
 import re
 
@@ -18,7 +19,7 @@ from buck_util import Buck2Runner
 try:
     import tomllib  # Standard in 3.11 and later
 except ModuleNotFoundError:
-    import tomli as tomllib
+    import tomli as tomllib  # type: ignore[no-redef]
 
 """Extracts source lists from the buck2 build system and writes them to a file.
 
@@ -65,6 +66,12 @@ Example config:
     ".cpp$",
     ]
 """
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [ExecuTorch] %(levelname)s: %(message)s"
+)
+logger = logging.getLogger()
 
 
 class Target:
@@ -118,7 +125,22 @@ class Target:
         )
 
         # Get the complete list of source files that this target depends on.
-        sources: set[str] = set(runner.run(["cquery", query] + buck_args))
+        # If user doesn't setup their git submodules correctly, this will fail.
+        # If we hit here, setup.py:check_submodule() should have already run
+        # but it could be that the submodules are not synced or there's local changes.
+        try:
+            sources: set[str] = set(runner.run(["cquery", query] + buck_args))
+        except RuntimeError as e:
+            logger.error(
+                f"\033[31;1mFailed to query buck for sources. Failed command:\n\n"
+                f"   buck2 cquery {query} {' '.join(buck_args)}\n\n"
+                "This is likely due "
+                "to missing git submodules or outdated CMake cache. "
+                "Please run the following before retry:\033[0m\n\n"
+                "    \033[32;1m./install_executorch.sh --clean\033[0m\n"
+                "    \033[32;1mgit submodule update --init --recursive\033[0m\n"
+            )
+            raise e
 
         # Keep entries that match all of the filters.
         filters = [re.compile(p) for p in self._config.get("filters", [])]

--- a/setup.py
+++ b/setup.py
@@ -740,7 +740,8 @@ class CustomBuild(build):
                         "\033[31;1mEither CMake cache is outdated or git submodules are not synced.\n"
                         "Please run the following before retry:\033[0m\n"
                         "    \033[32;1m./install_executorch.sh --clean\033[0m\n"
-                        "    \033[32;1mgit submodule update --init --recursive\033[0m\n"
+                        "    \033[32;1mgit submodule sync\033[0m\n"
+                        "    \033[32;1mgit submodule update --init\033[0m\n"
                     )
                 raise Exception(error + "\n" + additional_log) from e
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ import logging
 import subprocess
 
 from distutils import log
+from distutils.errors import DistutilsExecError
 from distutils.sysconfig import get_python_lib
 from pathlib import Path
 from typing import List, Optional
@@ -89,56 +90,55 @@ logger = logging.getLogger()
 # too restrictive for users who modifies and tests the dependencies locally.
 
 # keep sorted
-REQUIRED_SUBMODULES = [
-    "ao",
-    "cpuinfo",
-    "eigen",
-    "flatbuffers",
-    "FP16",
-    "FXdiv",
-    "gflags",
-    "prelude",
-    "pthreadpool",
-    "pybind11",
-    "XNNPACK",
-]
+REQUIRED_SUBMODULES = {
+    "ao": "LICENSE",  # No CMakeLists.txt, choose a sort of stable file to check.
+    "cpuinfo": "CMakeLists.txt",
+    "eigen": "CMakeLists.txt",
+    "flatbuffers": "CMakeLists.txt",
+    "FP16": "CMakeLists.txt",
+    "FXdiv": "CMakeLists.txt",
+    "gflags": "CMakeLists.txt",
+    "prelude": "BUCK",
+    "pthreadpool": "CMakeLists.txt",
+    "pybind11": "CMakeLists.txt",
+    "XNNPACK": "CMakeLists.txt",
+}
 
 
 def get_required_submodule_paths():
-    gitsubmodule_path = os.path.join(os.getcwd(), ".gitsubmodule")
+    gitmodules_path = os.path.join(os.getcwd(), ".gitmodules")
 
-    if not os.path.isfile(gitsubmodule_path):
-        print("Error: .gitsubmodule file not found.")
+    if not os.path.isfile(gitmodules_path):
+        logger.error(".gitmodules file not found.")
         exit(1)
 
-    with open(gitsubmodule_path, "r") as file:
+    with open(gitmodules_path, "r") as file:
         lines = file.readlines()
 
     # Extract paths of required submodules
-    required_paths = []
+    required_paths = {}
     for line in lines:
         if line.strip().startswith("path ="):
             path = line.split("=")[1].strip()
-            if any(submodule in path for submodule in REQUIRED_SUBMODULES):
-                required_paths.append(path)
+            for submodule, file_name in REQUIRED_SUBMODULES.items():
+                if submodule in path:
+                    required_paths[path] = file_name
     return required_paths
 
 
 def check_and_update_submodules():
-    def check_folder(folder: str) -> bool:
-        return os.path.isdir(folder) and os.path.isfile(
-            os.path.join(folder, "CMakeLists.txt")
-        )
+    def check_folder(folder: str, file: str) -> bool:
+        return os.path.isdir(folder) and os.path.isfile(os.path.join(folder, file))
 
     # Check if the directories exist for each required submodule
-    missing_submodules = []
-    for path in get_required_submodule_paths():
-        if not check_folder(path):
-            missing_submodules.append(path)
+    missing_submodules = {}
+    for path, file in get_required_submodule_paths().items():
+        if not check_folder(path, file):
+            missing_submodules[path] = file
 
     # If any required submodule directories are missing, update them
     if missing_submodules:
-        logger.warn("Some required submodules are missing. Updating submodules...")
+        logger.warning("Some required submodules are missing. Updating submodules...")
         try:
             subprocess.check_call(
                 ["git", "submodule", "update", "--init", "--recursive"]
@@ -148,12 +148,12 @@ def check_and_update_submodules():
             exit(1)
 
         # After updating submodules, check again
-        for path in missing_submodules:
-            if not check_folder(path):
-                logger.error(f"Error: CMakeLists.txt not found in {path}.")
+        for path, file in missing_submodules.items():
+            if not check_folder(path, file):
+                logger.error(f"{file} not found in {path}.")
                 logger.error("Please run `git submodule update --init --recursive`.")
                 exit(1)
-    logger.info("All required submodules are present and contain CMakeLists.txt.")
+    logger.info("All required submodules are present.")
 
 
 class ShouldBuild:
@@ -724,7 +724,27 @@ class CustomBuild(build):
             # lists.
 
             # Generate the build system files.
-            self.spawn(["cmake", "-S", repo_root, "-B", cmake_cache_dir, *cmake_args])
+            try:
+                subprocess.run(
+                    ["cmake", "-S", repo_root, "-B", cmake_cache_dir, *cmake_args],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as e:
+                error = str(e.stderr)
+                # Our educated guesses from parsing the error message.
+                # Missing source file, could be related to git submodules not synced or cmake cache is outdated
+                additional_log = ""
+                if "Cannot find source file" in error:
+                    additional_log = (
+                        "\033[31;1mEither CMake cache is outdated or git submodules are not synced.\n"
+                        "Please run the following before retry:\033[0m\n"
+                        "    \033[32;1m./install_executorch.sh --clean\033[0m\n"
+                        "    \033[32;1mgit submodule update --init --recursive\033[0m\n"
+                    )
+                raise Exception(error + "\n" + additional_log) from e
 
         # Build the system.
         self.spawn(["cmake", "--build", cmake_cache_dir, *build_args])

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ import logging
 import subprocess
 
 from distutils import log
-from distutils.errors import DistutilsExecError
 from distutils.sysconfig import get_python_lib
 from pathlib import Path
 from typing import List, Optional
@@ -140,9 +139,8 @@ def check_and_update_submodules():
     if missing_submodules:
         logger.warning("Some required submodules are missing. Updating submodules...")
         try:
-            subprocess.check_call(
-                ["git", "submodule", "update", "--init", "--recursive"]
-            )
+            subprocess.check_call(["git", "submodule", "sync"])
+            subprocess.check_call(["git", "submodule", "update", "--init"])
         except subprocess.CalledProcessError as e:
             logger.error(f"Error updating submodules: {e}")
             exit(1)
@@ -151,7 +149,7 @@ def check_and_update_submodules():
         for path, file in missing_submodules.items():
             if not check_folder(path, file):
                 logger.error(f"{file} not found in {path}.")
-                logger.error("Please run `git submodule update --init --recursive`.")
+                logger.error("Please run `git submodule update --init`.")
                 exit(1)
     logger.info("All required submodules are present.")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8203

Summary: 

Fixing #7243

As titled. This PR adds 2 things:
1. `check_and_update_submodule()` check if required submodule folders exist and at least contains a CMakeLists.txt file.
2. Give useful error when the submodule is corrupted (most likely missing a file, caused by submodule out of sync).

Test Plan: 

1. Test if we can still install, if submodule is not updated

```
rm -rf third-party/prelude
./install_executorch.sh
```
See the following log

```
...
Processing /data/users/larryliu/executorch
  Preparing metadata (pyproject.toml): started
  Running command Preparing metadata (pyproject.toml)
  2025-02-05 11:28:46,430 [ExecuTorch] WARNING: Some required submodules are missing. Updating submodules...
  Submodule path 'third-party/prelude': checked out '851d3f09c452937fc5adef27e2c50f7f304f1646'
  2025-02-05 11:28:46,748 [ExecuTorch] INFO: All required submodules are present.
  2025-02-05 11:28:47,018 [ExecuTorch] INFO: running dist_info
...
```
This proves that we can update submodule for the user.

2. Test if we can give useful error message, if we are missing a file.

```
rm third-party/gflags/src/gflags.cc
./install_executorch.sh --clean
./install_executorch.sh
```

See the following error:

```
  2025-02-05 12:08:56,889 [ExecuTorch] ERROR: Failed to query buck for sources. Failed command:

     buck2 cquery inputs(deps('//runtime/executor:program'))

  This is likely due to missing git submodules or outdated CMake cache. Please run the following before retry:

      ./install_executorch.sh --clean
      git submodule update --init --recursive

```
Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D69156975](https://our.internmc.facebook.com/intern/diff/D69156975)