### PR TITLE
Increase string buffer size for tensor size errors

### DIFF
--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -95,7 +95,7 @@ Error TensorImpl::internal_resize_contiguous(ArrayRef<SizesType> new_sizes) {
     case TensorShapeDynamism::STATIC:
       if (!std::equal(sizes_, sizes_ + dim_, new_sizes.begin())) {
 #ifdef ET_LOG_ENABLED
-        std::array<char, 5> old_sizes_str, new_sizes_str;
+        std::array<char, 16> old_sizes_str, new_sizes_str;
 
         executorch::runtime::sizes_to_string(
             old_sizes_str.data(),


### PR DESCRIPTION
Summary: When improving the tensor resize error messages (D67665846), I accidentally left the string buffer size smaller than intended. This is not a memory safety issue, it just leads to the error messages being truncated. This change increases the buffer size back to the intended length.

Differential Revision: D69170272


