### PR TITLE
aten.leakyrelu.default Op registery

### DIFF
--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -277,6 +277,7 @@ def register_binary_op(features: OpFeatures):
         exir_ops.edge.aten.rsqrt.default,
         exir_ops.edge.aten.tanh.default,
         exir_ops.edge.aten.round.default,
+        exir_ops.edge.aten.leaky_relu.default,
     ]
 )
 def register_unary_op(features: OpFeatures):


### PR DESCRIPTION
Summary: leaky_relu op registery was missing from D68688186.

Differential Revision: D69199644


