### PR TITLE
Delete the ramaining empty folder

### DIFF
--- a/examples/qualcomm/oss_scripts/llama3_2/targets.bzl
+++ b/examples/qualcomm/oss_scripts/llama3_2/targets.bzl
@@ -1,2 +1,0 @@
-def define_common_targets():
-    return None


### PR DESCRIPTION
Summary: It was kept to make CI green. Since https://github.com/pytorch/executorch/pull/8004 is merged now, no need to keep this empty folder

Differential Revision: D69202927


