### PR TITLE
Use STDOUT fallback after FileNotFoundError in gather benchmarks

### DIFF
--- a/.ci/scripts/gather_benchmark_configs.py
+++ b/.ci/scripts/gather_benchmark_configs.py
@@ -238,7 +238,7 @@ def set_output(name: str, val: Any) -> None:
     try:
         with open(github_output, "a") as env:
             env.write(f"{name}={val}\n")
-    except PermissionError:
+    except (PermissionError, FileNotFoundError):
         # Fall back to printing in case of permission error in unit tests
         print(f"::set-output name={name}::{val}")
 


### PR DESCRIPTION
### Summary
The gather_benchmarks job is currently failing on PyTorch Core when running ET CI. This change allows the gather_benchmarks job to gracefully fall back to logging to STDOUT when not running in the expected ET CI environment. This should unblock the ET pin bump in PyTorch.

This is a based on @guangy10's suggestion on https://github.com/pytorch/pytorch/pull/145831#issuecomment-2638605169.

### Test plan
Validating via CI run.
