### PR TITLE
[ET-VK] support biases in buffer-based linear shader

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/addmm_naive_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/addmm_naive_buffer.yaml
@@ -4,13 +4,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-matmul_naive_buffer:
+addmm_naive_buffer:
   parameter_names_with_default_values:
     DTYPE: float
     STORAGE: buffer
+    HAS_BIAS: false
   generate_variant_forall:
     DTYPE:
       - VALUE: float
       - VALUE: half
   shader_variants:
     - NAME: matmul_naive_buffer
+    - NAME: addmm_naive_buffer
+      HAS_BIAS: true

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -126,7 +126,8 @@ common_MKN_list = [
 ]
 
 
-def get_linear_texture_inputs():
+@register_test_suite("aten.linear.default")
+def get_linear_inputs():
     MKN_list = common_MKN_list
 
     inputs_list = [((M, K), (N, K), None) for M, K, N in MKN_list]
@@ -141,30 +142,8 @@ def get_linear_texture_inputs():
         "utils::kWidthPacked",
         "utils::kChannelsPacked",
     ]
-    test_suite.test_name_suffix = "texture"
+    test_suite.storage_types = ["utils::kBuffer", "utils::kTexture3D"]
     return test_suite
-
-
-def get_linear_buffer_inputs():
-    MKN_list = common_MKN_list
-
-    inputs_list = [((M, K), (N, K), None) for M, K, N in MKN_list]
-    inputs_list += [((3, M, K), (N, K), None) for M, K, N in MKN_list]
-
-    test_suite = VkTestSuite(inputs_list)
-    test_suite.dtypes = ["at::kFloat"]
-    test_suite.layouts = [
-        "utils::kWidthPacked",
-        "utils::kChannelsPacked",
-    ]
-    test_suite.storage_types = ["utils::kBuffer"]
-    test_suite.test_name_suffix = "buffer"
-    return test_suite
-
-
-@register_test_suite("aten.linear.default")
-def get_linear_test_suites():
-    return [get_linear_texture_inputs(), get_linear_buffer_inputs()]
 
 
 @register_test_suite("aten._weight_int8pack_mm.default")

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -1711,3 +1711,26 @@ class TestBackends(unittest.TestCase):
             (torch.ones(size=[5, 4, 1, 2, 6]),),
             expect_no_delegates=True,
         )
+
+    def test_vulkan_backend_large_linear_layer(self):
+        class LinearModel(torch.nn.Module):
+            def __init__(
+                self, n_pca_basis: int, n_sh_basis: int, n_gaussians: int
+            ) -> None:
+                super(LinearModel, self).__init__()
+                self.fc1 = torch.nn.Linear(
+                    n_pca_basis, (n_sh_basis + 3 + 3 + 4) * n_gaussians
+                )
+
+            def forward(self, x: torch.Tensor):
+                out = self.fc1(x)
+                return out
+
+        n_pca_basis = 64
+        n_sh_basis = 6
+        n_gaussians = 2**16
+
+        self.lower_module_and_test_output(
+            LinearModel(n_pca_basis, n_sh_basis, n_gaussians),
+            (torch.ones(n_pca_basis),),
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8284

## Context

As title. Add support for biases in the buffer-based addmm and linear implementation.

Differential Revision: [D69247282](https://our.internmc.facebook.com/intern/diff/D69247282/)