### PR TITLE
[Not for Commit] Example use of new dim_order api

### DIFF
--- a/exir/tests/test_memory_format_ops_pass.py
+++ b/exir/tests/test_memory_format_ops_pass.py
@@ -109,6 +109,7 @@ class TestMemoryFormatOpsPass(unittest.TestCase):
         )
 
     def test_op_dim_order_propagation(self) -> None:
+        print("test_op_dim_order_propagation: unambiguous path")
         MemoryFormatOpsPassTestUtils.memory_format_test_runner(
             self,
             MemoryFormatTestSet(
@@ -117,6 +118,24 @@ class TestMemoryFormatOpsPass(unittest.TestCase):
                 sample_input=(
                     torch.rand_like(
                         torch.zeros([2, 2, 2, 2]),
+                        dtype=torch.float32,
+                        memory_format=torch.contiguous_format,
+                    ),
+                ),
+                target_memory_format=torch.channels_last,
+                _load_for_executorch_from_buffer=_load_for_executorch_from_buffer,
+            ),
+        )
+
+        print("test_op_dim_order_propagation: ambiguous path")
+        MemoryFormatOpsPassTestUtils.memory_format_test_runner(
+            self,
+            MemoryFormatTestSet(
+                module=PropagateToCopyChannalsLastModule().eval(),
+                op=torch.ops.aten._to_copy.default,
+                sample_input=(
+                    torch.rand_like(
+                        torch.zeros([2, 1, 2, 2]),
                         dtype=torch.float32,
                         memory_format=torch.contiguous_format,
                     ),


### PR DESCRIPTION
Just for API usage illustration purposes

```
❯ python -m unittest exir.tests.test_memory_format_ops_pass.TestMemoryFormatOpsPass.test_op_dim_order_propagation

test_op_dim_order_propagation: unambiguous path
node: dim_order_ops__to_dim_order_copy_default, shape: torch.Size([2, 2, 2, 2]), dim_order: (0, 2, 3, 1)
node: aten_add_tensor, shape: torch.Size([2, 2, 2, 2]), dim_order: (0, 2, 3, 1)
node: aten_mul_tensor, shape: torch.Size([2, 2, 2, 2]), dim_order: (0, 2, 3, 1)

test_op_dim_order_propagation: ambiguous path
node: dim_order_ops__to_dim_order_copy_default, shape: torch.Size([2, 1, 2, 2]), 
E
======================================================================
ERROR: test_op_dim_order_propagation (exir.tests.test_memory_format_ops_pass.TestMemoryFormatOpsPass)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "[...]executorch/exir/tests/test_memory_format_ops_pass_utils.py", line 137, in detect_ambiguity
    dim_order = tensor.dim_order(
  File "[...]]/executorch/lib/python3.10/site-packages/torch/_tensor.py", line 1614, in dim_order
    raise RuntimeError(
RuntimeError: The tensor does not have unique dim order, or cannot map to exact one of the given memory formats.
...
```
