### PR TITLE
update emitter default evalue to have dim order match size

### DIFF
--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -1189,7 +1189,7 @@ class _Emitter(torch.fx.Interpreter):
                     # The runtime currently only supports tensors with offset 0.
                     storage_offset=0,
                     sizes=[0],
-                    dim_order=[],
+                    dim_order=[0],
                     requires_grad=False,
                     layout=0,
                     data_buffer_idx=0,


### PR DESCRIPTION
Summary: Its rare for an emitted tensor to be default but it can happen with placeholders. When it happens we need to serialize dim order too since we check that its == in length to size at deserialization.

Differential Revision: D69211447


