### PR TITLE
oss qnn bug fix

### DIFF
--- a/backends/qualcomm/_passes/annotate_and_quant_scalar.py
+++ b/backends/qualcomm/_passes/annotate_and_quant_scalar.py
@@ -36,6 +36,7 @@ class AnnotateAndQuantScalar(ExportPass):
         torch.ops.aten.sub.Scalar,
         torch.ops.aten.mul.Scalar,
         torch.ops.aten.div.Scalar,
+        torch.ops.aten.mul.Tensor,
         "add",
         "sub",
         "mul",

--- a/backends/qualcomm/_passes/decompose_silu.py
+++ b/backends/qualcomm/_passes/decompose_silu.py
@@ -22,7 +22,9 @@ class DecomposeSilu(ExportPass):
 
     def call(self, graph_module: torch.fx.GraphModule):
         graph = graph_module.graph
-        partitions = get_source_partitions(graph, [torch.nn.functional.silu])
+        partitions = get_source_partitions(
+            graph, [torch.nn.functional.silu, torch.ops.aten.silu.default]
+        )
         for _, src_partitions in partitions.items():
             for src_partition in src_partitions:
 


### PR DESCRIPTION
Summary:
1. the graph actually include the torch.ops.aten.silu.default not the torch.nn.functional.silu
2. the aten.mul.tensor is arg is scalar, this could apply to other ops

Differential Revision: D69286388


