### PR TITLE
Add safety checks when rendering kernel key strings

### DIFF
--- a/runtime/kernel/test/test_util.h
+++ b/runtime/kernel/test/test_util.h
@@ -18,19 +18,20 @@ namespace runtime {
 
 namespace testing {
 
-inline void make_kernel_key(
-    std::vector<std::pair<
+inline Error make_kernel_key(
+    const std::vector<std::pair<
         executorch::aten::ScalarType,
-        std::vector<executorch::aten::DimOrderType>>> tensors,
-    char* buf) {
+        std::vector<executorch::aten::DimOrderType>>>& tensors,
+    char* buf,
+    size_t buf_size) {
   std::vector<TensorMeta> meta;
   for (auto& t : tensors) {
     Span<executorch::aten::DimOrderType> dim_order(
-        t.second.data(), t.second.size());
+        const_cast<unsigned char*>(t.second.data()), t.second.size());
     meta.emplace_back(t.first, dim_order);
   }
   Span<const TensorMeta> metadata(meta.data(), meta.size());
-  internal::make_kernel_key_string(metadata, buf);
+  return internal::make_kernel_key_string(metadata, buf, buf_size);
 }
 
 } // namespace testing


### PR DESCRIPTION
Summary:
The old code assumed that it was handed a MAX_SIZE buffer, and that the list of TensorMeta values would never generate a string longer than that size.

This PR adds explicit size tracking and an error code to the API, and now returns an error if the buffer is too small for the provided values.

While I'm here, move MAX_SIZE out of the public API, since it's not an intrinsic aspect of kernel keys. This is technically a BC-breaking change, but I don't expect that any users are actually depending on it.

Also:
 - Fix some unused var warnings, which uncovered a couple places where we ignored an Error. Along similar lines, replaced EXPECT with ASSERT when validating kernel registration so we don't try to run the rest of the test after a registration error.
- Silence the Meta-internal linter by moving to std::array in several code chunks I needed to touch anyway because of the new `make_kernel_key` parameter.

Add unit tests for all modified code.

Differential Revision: D69324821


