### PR TITLE
Add XNN U8 op support via quantization

### DIFF
--- a/backends/xnnpack/_passes/__init__.py
+++ b/backends/xnnpack/_passes/__init__.py
@@ -24,6 +24,9 @@ from executorch.backends.xnnpack._passes.fuse_batch_norm_with_conv import (
 )
 from executorch.backends.xnnpack._passes.prelu_reshape_pass import PReLUReshapePass
 from executorch.backends.xnnpack._passes.remove_getitem_op import RemoveGetItemPass
+from executorch.backends.xnnpack._passes.replace_u8_convert_with_dq_pass import (
+    ReplaceU8ConvertWithDqPass,
+)
 from executorch.backends.xnnpack._passes.tag_implicit_q_dq_pass import (
     TagImplicitQDqPass,
 )
@@ -70,6 +73,7 @@ class XNNPACKPassManager:
                 PReLUReshapePass,
                 ChannelsLastTaggedReshapePass,
                 TagImplicitQDqPass,
+                ReplaceU8ConvertWithDqPass,
             ]
         else:
             self.passes = passes

--- a/backends/xnnpack/_passes/replace_u8_convert_with_dq_pass.py
+++ b/backends/xnnpack/_passes/replace_u8_convert_with_dq_pass.py
@@ -1,0 +1,88 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.backends.xnnpack._passes.xnnpack_pass import XNNPACKPass
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import PassResult
+
+
+class ReplaceU8ConvertWithDqPass(XNNPACKPass):
+    """
+    Support for U8 tensors in the XNNPACK delegate is done by treating U8
+    tensors as asymmetric quantized U8 tensors with a zero-point of zero and
+    a scale of 1. To handle convert ops from U8 to F32, conversion is replaced
+    with a dequantize operation. This pass is responsible for perfoming this
+    replacement.
+    """
+
+    @staticmethod
+    def can_replace_to_copy_node(node: torch.fx.Node):
+        """
+        Returns true if the _to_copy node can be replaced with a dequantize
+        operation. This is possible if the input dtype is u8, the output dtype
+        is f32, and the dim order is not changed.
+        """
+        if node.op != "call_function" or node.target not in [
+            exir_ops.edge.aten._to_copy.default,
+            exir_ops.edge.dim_order_ops._to_dim_order_copy.default,
+        ]:
+            return False
+
+        if node.kwargs.get("dtype", None) != torch.float:
+            return False
+
+        input_node = node.args[0]
+        if (
+            not isinstance(input_node, torch.fx.Node)
+            or "val" not in input_node.meta
+            or input_node.meta["val"].dtype != torch.uint8
+        ):
+            return False
+
+        if node.target == exir_ops.edge.aten._to_copy.default:
+            # TODO Don't don't assume channels_first?
+            if node.kwargs.get("memory_format", torch.preserve_format) not in [
+                torch.preserve_format,
+                torch.contiguous_format,
+            ]:
+                return False
+        elif node.target == exir_ops.edge.dim_order_ops._to_dim_order_copy.default:
+            default_dim_order = list(range(len(node.meta["val"].shape)))
+            if node.kwargs.get("dim_order", default_dim_order) != default_dim_order:
+                return False
+
+        return True
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        graph = graph_module.graph
+        node_list = list(graph.nodes)
+        for node in node_list:
+            if (
+                node.op == "call_function"
+                and node.target == exir_ops.edge.aten._to_copy.default
+            ):
+                if not ReplaceU8ConvertWithDqPass.can_replace_to_copy_node(node):
+                    continue
+
+                with graph.inserting_before(node):
+                    dq_node = graph.call_function(
+                        exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+                        (
+                            node.args[0],  # Tensor
+                            1.0,  # Scale
+                            0,  # Zero point
+                            0,  # Qmin
+                            255,  # Qmax
+                            torch.uint8,  # Dtype
+                        ),
+                    )
+
+                    node.replace_all_uses_with(dq_node)
+                    graph.erase_node(node)
+
+        graph_module = super().call(graph_module).graph_module
+        return PassResult(graph_module, True)

--- a/backends/xnnpack/partition/config/__init__.py
+++ b/backends/xnnpack/partition/config/__init__.py
@@ -47,6 +47,7 @@ from executorch.backends.xnnpack.partition.config.generic_node_configs import (
     SoftmaxConfig,
     SquareRootConfig,
     SubConfig,
+    ToDimOrderCopyConfig,
     UpsampleBilinear2dConfig,
 )
 from executorch.backends.xnnpack.partition.config.node_configs import (
@@ -101,6 +102,7 @@ ALL_PARTITIONER_CONFIGS: List[Type[XNNPartitionerConfig]] = [
     SoftmaxConfig,
     SquareRootConfig,
     SubConfig,
+    ToDimOrderCopyConfig,
     UpsampleBilinear2dConfig,
     # Quant/Dequant Op Configs
     QuantizedPerTensorConfig,

--- a/backends/xnnpack/partition/config/xnnpack_config.py
+++ b/backends/xnnpack/partition/config/xnnpack_config.py
@@ -25,6 +25,7 @@ class ConfigPrecisionType(Enum):
     FP32 = 1
     STATIC_QUANT = 2
     DYNAMIC_QUANT = 3
+    U8 = 4
 
 
 class XNNPartitionerConfig(PartitionerConfig):
@@ -170,6 +171,9 @@ class XNNPartitionerConfig(PartitionerConfig):
                 return False
 
             if arg_val.dtype not in valid_dtypes:
+                logger.warn(
+                    f"Input {node} has invalid dtype {arg_val.dtype} ({valid_dtypes})"
+                )
                 return False
 
         return True
@@ -188,6 +192,9 @@ class XNNPartitionerConfig(PartitionerConfig):
                 return False
 
             if val.dtype not in valid_dtypes:
+                logger.warn(
+                    f"Output {node} has invalid dtype {val.dtype} ({valid_dtypes})"
+                )
                 return False
 
         return True
@@ -199,6 +206,10 @@ class XNNPartitionerConfig(PartitionerConfig):
             torch.int8,
             torch.qint8,
         }
+
+        if ConfigPrecisionType.U8 in self.enabled_precision_types:
+            valid_dtypes.add(torch.uint8)
+
         if (
             node.op != "placeholder"
             and node.op != "call_function"

--- a/backends/xnnpack/test/models/mobilenet_v3.py
+++ b/backends/xnnpack/test/models/mobilenet_v3.py
@@ -6,10 +6,43 @@
 
 import unittest
 
+from typing import Sequence
+
 import torch
+import torchvision
 from executorch.backends.xnnpack.test.tester import Tester
 from executorch.backends.xnnpack.test.tester.tester import Quantize
 from torchvision import models
+
+
+class ResizeAndCropWrapper(torch.nn.Module):
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        resize_shape: Sequence[int],
+        crop_shape: Sequence[int],
+    ):
+        super().__init__()
+        self.resize_shape = resize_shape
+        self.crop = torchvision.transforms.CenterCrop(crop_shape)
+        # Simplified ImageNet normalization expected by pre-trained weights
+        self.normalize_mean = 0.456
+        self.normalize_std = 0.225
+        self.model = model
+
+    def forward(self, image):
+        resized = torch.nn.functional.interpolate(
+            image,
+            size=self.resize_shape,
+            mode="bilinear",
+            align_corners=False,
+            antialias=False,
+        )
+        cropped = self.crop(resized)
+        image_f32 = cropped.to(torch.float) / 255.0
+        normalized = (image_f32 - self.normalize_mean) / self.normalize_std
+
+        return self.model(normalized / 255.0)
 
 
 class TestMobileNetV3(unittest.TestCase):
@@ -34,6 +67,8 @@ class TestMobileNetV3(unittest.TestCase):
         "executorch_exir_dialects_edge__ops_aten_mul_Tensor",
         "executorch_exir_dialects_edge__ops_aten_div_Tensor",
         "executorch_exir_dialects_edge__ops_aten_mean_dim",
+        "executorch_exir_dialects_edge__ops_aten_slice_copy_Tensor",
+        "executorch_exir_dialects_edge__ops_aten_upsample_bilinear2d_vec",
     }
 
     def test_fp32_mv3(self):
@@ -46,6 +81,34 @@ class TestMobileNetV3(unittest.TestCase):
             .to_executorch()
             .serialize()
             .run_method_and_compare_outputs(num_runs=5)
+        )
+
+    def test_fp32_mv3_with_u8_resize(self):
+        dynamic_shapes = (
+            {
+                2: torch.export.Dim("height", min=260, max=1024),
+                3: torch.export.Dim("width", min=260, max=1024),
+            },
+        )
+        wrapped_model = ResizeAndCropWrapper(
+            self.mv3,
+            (260, 260),
+            (224, 224),
+        )
+        u8_inputs = (torch.randint(0, 255, (1, 3, 512, 512)).to(torch.uint8),)
+        (
+            Tester(wrapped_model, u8_inputs, dynamic_shapes=dynamic_shapes)
+            .export()
+            .dump_artifact()
+            .to_edge_transform_and_lower()
+            .dump_artifact()
+            .check(["torch.ops.higher_order.executorch_call_delegate"])
+            .check_not(list(self.all_operators))
+            .to_executorch()
+            .serialize()
+            # XNN u8 reshape can differ by 1 from eager mode, leading to a very
+            # small increase in tolerance.
+            .run_method_and_compare_outputs(num_runs=5, atol=0.002)
         )
 
     @unittest.skip("T187799178: Debugging Numerical Issues with Calibration")

--- a/backends/xnnpack/test/ops/test_cat.py
+++ b/backends/xnnpack/test/ops/test_cat.py
@@ -249,3 +249,10 @@ class TestCat(unittest.TestCase):
     def _test_qs8_cat_nhwc2(self):
         inputs = (torch.randn(1, 1, 3, 3), torch.randn(1, 1, 3, 3))
         self._test_cat(self.CatNhwc(), inputs, quant=True, quant_ops=4)
+
+    def test_u8_cat2(self):
+        inputs = (
+            torch.randint(0, 255, (3, 2, 3)).to(torch.uint8),
+            torch.randint(0, 255, (1, 2, 3)).to(torch.uint8),
+        )
+        self._test_cat(self.Cat(), inputs)

--- a/backends/xnnpack/test/ops/test_slice_copy.py
+++ b/backends/xnnpack/test/ops/test_slice_copy.py
@@ -46,6 +46,14 @@ class TestSliceCopy(unittest.TestCase):
         inputs = (torch.randn(5, 5, 5),)
         self._test_slice_copy(SliceCopy(), inputs, 3, 3)
 
+    def test_u8_slice_copy(self):
+        class SliceCopy(torch.nn.Module):
+            def forward(self, x):
+                return x[1:3, -2:, :-1]
+
+        inputs = (torch.randint(0, 255, (5, 5, 5)).to(torch.uint8),)
+        self._test_slice_copy(SliceCopy(), inputs, 3, 3)
+
     def test_fp32_slice_copy_memory_format(self):
         class ConvSlice(torch.nn.Module):
             def __init__(self):

--- a/backends/xnnpack/test/ops/test_to_copy.py
+++ b/backends/xnnpack/test/ops/test_to_copy.py
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack.test.tester import Tester
+from executorch.exir.dialects._ops import ops as exir_ops
+
+# Note: to_copy is currently only partitioned when converting u8 to f32. Other to_copy
+# nodes are introduced for NCHW <-> HHWC conversion, but these are introduced post-partitioning.
+
+
+class TestToCopy(unittest.TestCase):
+    def test_u8_f32_to_copy(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x.to(torch.float)
+
+        inputs = (torch.randint(0, 255, (1, 13, 16, 16)).to(torch.uint8),)
+        (
+            Tester(Model(), inputs)
+            .export()
+            .dump_artifact()
+            .check_node_count({torch.ops.aten.to.dtype: 1})
+            .to_edge_transform_and_lower()
+            .dump_artifact()
+            .check_node_count(
+                {
+                    exir_ops.edge.aten._to_copy.default: 0,
+                    torch._higher_order_ops.executorch_call_delegate: 1,
+                }
+            )
+            .to_executorch()
+            .run_method_and_compare_outputs()
+        )

--- a/backends/xnnpack/test/passes/test_replace_u8_convert_with_dq_pass.py
+++ b/backends/xnnpack/test/passes/test_replace_u8_convert_with_dq_pass.py
@@ -1,0 +1,196 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack._passes.replace_u8_convert_with_dq_pass import (
+    ReplaceU8ConvertWithDqPass,
+)
+from executorch.backends.xnnpack.test.tester import RunPasses, Tester
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.passes.memory_format_ops_pass import DimOrderOpsRevertPass
+
+
+class TestReplaceU8ConvertWithDqPass(unittest.TestCase):
+    PassStage = RunPasses(
+        [
+            DimOrderOpsRevertPass,
+            ReplaceU8ConvertWithDqPass,
+        ]
+    )
+
+    def test_single_op_convert(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x.to(torch.float)
+
+        inputs = (torch.randint(0, 255, (1, 3, 16, 16)).to(torch.uint8),)
+        (
+            Tester(Model(), inputs)
+            .export()
+            .to_edge()
+            .check_node_count(
+                {
+                    exir_ops.edge.dim_order_ops._to_dim_order_copy.default: 1,
+                }
+            )
+            .run_passes(self.PassStage)
+            .check_node_count(
+                {
+                    exir_ops.edge.aten._to_copy.default: 0,
+                    exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default: 1,
+                }
+            )
+            .run_method_and_compare_outputs()
+        )
+
+    # TODO(gjcomer) Switch these tests to check nodes direct after removing the default decomposition for
+    # upsample_bilinear2d in PyTorch. Because of the way to_edge works, we can't
+    # easily enable these tests without it, since we can't opt out of the decomp
+    # without using to_edge_transform_and_lower. The recompose pass for blinear
+    # is also only written for f32 and it's throwaway work to enable u8.
+    def test_convert_with_nchw_before(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                y = torch.nn.functional.interpolate(x, mode="bilinear", scale_factor=2)
+                return y.to(torch.float)
+
+        inputs = (torch.randint(0, 255, (1, 3, 16, 16)).to(torch.uint8),)
+        (
+            Tester(Model(), inputs)
+            .export()
+            .to_edge_transform_and_lower()
+            .to_executorch()
+            .run_method_and_compare_outputs()
+        )
+
+        """
+        .check_node_count({
+            exir_ops.edge.dim_order_ops._to_dim_order_copy.default: 1,
+        })
+        .run_passes(self.PassStage)
+        .check_node_count({
+            exir_ops.edge.aten._to_copy.default: 0,
+            exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default: 1,
+        })
+        .run_method_and_compare_outputs()
+        """
+
+    def test_convert_with_nchw_after(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 3, 3)
+
+            def forward(self, x):
+                y = x.to(torch.float)
+                return self.conv(y)
+
+        inputs = (torch.randint(0, 255, (1, 3, 16, 16)).to(torch.uint8),)
+        (
+            Tester(Model(), inputs)
+            .export()
+            .to_edge()
+            .check_node_count(
+                {
+                    exir_ops.edge.dim_order_ops._to_dim_order_copy.default: 1,
+                }
+            )
+            .run_passes(self.PassStage)
+            .check_node_count(
+                {
+                    exir_ops.edge.aten._to_copy.default: 0,
+                    exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default: 1,
+                }
+            )
+            .run_method_and_compare_outputs()
+        )
+
+    def test_convert_between_nchw(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 3, 3)
+
+            def forward(self, x):
+                y = torch.nn.functional.interpolate(x, mode="bilinear", scale_factor=2)
+                y = y.to(torch.float)
+                return self.conv(y)
+
+        inputs = (torch.randint(0, 255, (1, 3, 16, 16)).to(torch.uint8),)
+        (
+            Tester(Model(), inputs)
+            .export()
+            .to_edge_transform_and_lower()
+            .to_executorch()
+            .run_method_and_compare_outputs()
+        )
+
+        """
+        .to_edge()
+        .check_node_count({
+            exir_ops.edge.dim_order_ops._to_dim_order_copy.default: 1,
+        })
+        .run_passes(self.PassStage)
+        .check_node_count({
+            exir_ops.edge.aten._to_copy.default: 0,
+            exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default: 1,
+        })
+        .run_method_and_compare_outputs()
+        """
+
+    def test_fp16_convert_not_modified(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                y = x.to(torch.float16)
+                y = y
+                return y.to(torch.float)
+
+        inputs = (torch.randint(0, 255, (1, 3, 16, 16)).to(torch.uint8),)
+        (
+            Tester(Model(), inputs)
+            .export()
+            .to_edge()
+            .check_node_count(
+                {
+                    exir_ops.edge.dim_order_ops._to_dim_order_copy.default: 2,
+                }
+            )
+            .run_passes(self.PassStage)
+            .check_node_count(
+                {
+                    exir_ops.edge.aten._to_copy.default: 2,
+                    exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default: 0,
+                }
+            )
+            .run_method_and_compare_outputs()
+        )
+
+    def test_dim_order_convert_not_modified(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x.to(memory_format=torch.channels_last)
+
+        inputs = (torch.randint(0, 255, (1, 3, 16, 16)).to(torch.uint8),)
+        (
+            Tester(Model(), inputs)
+            .export()
+            .to_edge()
+            .check_node_count(
+                {
+                    exir_ops.edge.dim_order_ops._to_dim_order_copy.default: 1,
+                }
+            )
+            .run_passes(self.PassStage)
+            .check_node_count(
+                {
+                    exir_ops.edge.aten._to_copy.default: 1,
+                    exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default: 0,
+                }
+            )
+            .run_method_and_compare_outputs()
+        )

--- a/backends/xnnpack/test/tester/tester.py
+++ b/backends/xnnpack/test/tester/tester.py
@@ -470,6 +470,13 @@ class Tester:
         # Artifact output from stage
         self.stage_output = None
 
+    @staticmethod
+    def generate_random_input(shape: Sequence[int], dtype: torch.dtype) -> torch.Tensor:
+        if dtype == torch.uint8:
+            return torch.randint(0, 255, shape).to(dtype)
+        else:
+            return torch.randn(shape).to(dtype)
+
     def generate_random_inputs(self):
         # Get shapes of inputs
         input_shapes = []
@@ -518,8 +525,8 @@ class Tester:
         random_inputs = []
         for arg_idx in range(len(self.example_inputs)):
             random_inputs.append(
-                torch.randn(input_shapes[arg_idx]).to(
-                    dtype=self.example_inputs[arg_idx].dtype
+                Tester.generate_random_input(
+                    input_shapes[arg_idx], self.example_inputs[arg_idx].dtype
                 )
             )
 
@@ -695,6 +702,13 @@ class Tester:
         for i in range(len(model_output)):
             model = model_output[i]
             ref = ref_output[i]
+
+            # Convert U8 to float so we can compute mean.
+            if model.dtype == torch.uint8:
+                model = model.to(torch.float)
+            if ref.dtype == torch.uint8:
+                ref = ref.to(torch.float)
+
             assert (
                 ref.shape == model.shape
             ), f"Output {i} shape {model.shape} does not match reference output shape {ref.shape}"


### PR DESCRIPTION
### Summary
Support U8 ops in the XNNPACK delegate by treating the input and output tensors as u8 asymmetric-quantized tensors with scale=1 and zero_point=0. This PR adds U8 support for upsample_bilinear2d, cat, slice, and _to_copy (when used to convert u8 to f32). More ops are possible with this method.

Conversion from u8 to f32 is done via transformation into a dequantize op. This is implemented in a new pass - ReplaceU8ConvertWithDqPass. The general U8 to quantized U8 transformation is done in `define_tensor` in `node_visitor.py`. U8 inputs are created as quantized tensors with the appropriate qparams (scale=1, zp=0).

### Test plan
I've added op-level u8 tests to each of the new ops, as well as tests for the ReplaceU8ConvertWithDqPass. I've also added an end-to-end test for MobileNetV3 with a wrapper to take U8 inputs, resize and crop, and then convert to f32 and run the model.