### PR TITLE
make et program serialization in bp in line with et program manager

### DIFF
--- a/devtools/bundled_program/TARGETS
+++ b/devtools/bundled_program/TARGETS
@@ -21,7 +21,6 @@ runtime.python_library(
         "//executorch/devtools/bundled_program/schema:bundled_program_schema_py",
         "//executorch/exir:schema",
         "//executorch/exir:tensor",
-        "//executorch/exir/_serialize:lib",
     ],
 )
 

--- a/devtools/bundled_program/test/test_bundle_data.py
+++ b/devtools/bundled_program/test/test_bundle_data.py
@@ -115,7 +115,7 @@ class TestBundle(unittest.TestCase):
 
             self.assertEqual(
                 bundled_program.serialize_to_schema().program,
-                bytes(_serialize_pte_binary(executorch_program.executorch_program)),
+                executorch_program.buffer,
             )
 
     def test_bundled_miss_methods(self) -> None:


### PR DESCRIPTION
Summary: This change ensures that the serialization of bundled programs is consistent with the serialization of programs in the `et` program manager.

Differential Revision: D69395142


