### PR TITLE
Squeeze on the dimension we have selected 

### DIFF
--- a/backends/arm/_passes/decompose_select.py
+++ b/backends/arm/_passes/decompose_select.py
@@ -37,14 +37,13 @@ class DecomposeSelectPass(ExportPass):
             rank = len(input_node.meta["val"].size())
             dim = dim % rank if dim < 0 else dim
             index = index % rank if index < 0 else index
-            dim_list = list(range(rank))
 
             with graph_module.graph.inserting_before(node):
                 slice_node = create_node(
                     graph_module.graph, slice_op, (input_node, dim, index, index + 1)
                 )
                 squeeze_node = create_node(
-                    graph_module.graph, squeeze_op, (slice_node, dim_list)
+                    graph_module.graph, squeeze_op, (slice_node, [dim])
                 )
 
             node.replace_all_uses_with(squeeze_node)


### PR DESCRIPTION

### Summary
- In decompose_select.py - a squeeze op is used to get final output shape. If we squeeze using the input rank and batch_size==1 this dimension will also be removed.
- Changed this to only squeeze on dimension selected.



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218