### PR TITLE
Unbreak some buck builds (tensor_dimension_limit)

### DIFF
--- a/runtime/core/exec_aten/testing_util/targets.bzl
+++ b/runtime/core/exec_aten/testing_util/targets.bzl
@@ -43,6 +43,7 @@ def define_common_targets():
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
                 "//executorch/runtime/core/exec_aten/util:scalar_type_util" + aten_suffix,
                 "//executorch/runtime/core/exec_aten/util:tensor_util" + aten_suffix,
+                "//executorch/runtime/core/exec_aten/util:tensor_dimension_limit",
             ],
             exported_external_deps = [
                 "gmock" + aten_suffix,

--- a/runtime/core/exec_aten/util/targets.bzl
+++ b/runtime/core/exec_aten/util/targets.bzl
@@ -60,6 +60,7 @@ def define_common_targets():
             ],
             exported_preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],
             exported_deps = [
+                ":tensor_dimension_limit",
                 "//executorch/runtime/core:core",
             ] + [
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,


### PR DESCRIPTION
Looks like I forgot to add these deps to a couple targets.

Test Plan: buck2 build //runtime/core/exec_aten/util:
buck2 build //runtime/core/exec_aten/testing_util: