### PR TITLE
Refactor Arm backend pass unittests

### DIFF
--- a/backends/arm/test/passes/test_cast_int64_pass.py
+++ b/backends/arm/test/passes/test_cast_int64_pass.py
@@ -1,17 +1,16 @@
 # Copyright 2025 Arm Limited and/or its affiliates.
-# All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
+from typing import Tuple
 
 import torch
 from executorch.backends.arm._passes.cast_int64_pass import CastInt64ToInt32Pass
 
-from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.test_pipeline import TestPassPipeline
 
-from executorch.backends.arm.test.tester.arm_tester import ArmTester, RunPasses
+input_t = Tuple[torch.Tensor]  # Input x
 
 
 class Int64Model(torch.nn.Module):
@@ -19,26 +18,27 @@ class Int64Model(torch.nn.Module):
     def forward(self, x: torch.Tensor):
         return x + 3
 
-    def get_inputs(self):
+    def get_inputs(self) -> input_t:
         return (torch.rand(4),)
 
 
-class TestCastInt64Pass(unittest.TestCase):
+def test_int64_model_tosa_BI():
+    module = Int64Model()
+    op_checks = {
+        "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_add_Tensor": 1,
+    }
+    pipeline = TestPassPipeline[input_t](
+        module,
+        module.get_inputs(),
+        tosa_version="TOSA-0.80+BI",
+        ops_before_pass=op_checks,
+        ops_after_pass=op_checks,
+        passes_with_exported_program=[CastInt64ToInt32Pass],
+    )
+    pipeline.pop_stage("quantize")
+    pipeline.run()
 
-    def test_int64_model(self):
-        module = Int64Model()
-        test_pass_stage = RunPasses(passes_with_exported_program=[CastInt64ToInt32Pass])
-        tester = (
-            ArmTester(
-                module,
-                example_inputs=module.get_inputs(),
-                compile_spec=common.get_tosa_compile_spec("TOSA-0.80+BI"),
-            )
-            .export()
-            .to_edge()
-            .run_passes(test_pass_stage)
-            .run_method_and_compare_outputs()
-        )
-        exported_program = tester.get_artifact("RunPasses").exported_program()
-        for state in exported_program.state_dict:
-            assert exported_program.state_dict[state].dtype != torch.int64
+    exported_program = pipeline.tester.get_artifact("RunPasses").exported_program()
+    for state in exported_program.state_dict:
+        assert exported_program.state_dict[state].dtype == torch.int32

--- a/backends/arm/test/passes/test_insert_table_ops_pass.py
+++ b/backends/arm/test/passes/test_insert_table_ops_pass.py
@@ -1,20 +1,19 @@
 # Copyright 2025 Arm Limited and/or its affiliates.
-# All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
+
+from typing import Tuple
 
 import torch
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     FoldAndAnnotateQParamsPass,
 )
 from executorch.backends.arm._passes.insert_table_ops import InsertTableOpsPass
+from executorch.backends.arm.test.tester.test_pipeline import TestPassPipeline
 
-from executorch.backends.arm.test import common
-
-from executorch.backends.arm.test.tester.arm_tester import ArmTester, RunPasses
+input_t = Tuple[torch.Tensor]  # Input x
 
 
 class Sigmoid(torch.nn.Module):
@@ -22,34 +21,26 @@ class Sigmoid(torch.nn.Module):
     def forward(self, x: torch.Tensor):
         return x.sigmoid()
 
-    def get_inputs(self):
+    def get_inputs(self) -> input_t:
         return (torch.rand(4),)
 
 
-class TestInsertTablePass(unittest.TestCase):
+def test_insert_table_tosa_BI():
+    module = Sigmoid()
+    pipeline = TestPassPipeline[input_t](
+        module,
+        module.get_inputs(),
+        tosa_version="TOSA-0.80+BI",
+        ops_before_pass={},
+        ops_after_pass={
+            "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 1,
+            "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 1,
+            "tosa._table": 1,
+        },
+        ops_not_after_pass=["aten_sigmoid_default"],
+        pass_list=[FoldAndAnnotateQParamsPass],
+        passes_with_exported_program=[InsertTableOpsPass],
+    )
+    pipeline.pop_stage(-1)  # Do not compare output
 
-    def test_insert_table_tosa_BI(self):
-        module = Sigmoid()
-        test_pass_stage = RunPasses(
-            [FoldAndAnnotateQParamsPass],
-            passes_with_exported_program=[InsertTableOpsPass],
-        )
-        (
-            ArmTester(
-                module,
-                example_inputs=module.get_inputs(),
-                compile_spec=common.get_tosa_compile_spec("TOSA-0.80+BI"),
-            )
-            .quantize()
-            .export()
-            .to_edge()
-            .run_passes(test_pass_stage)
-            .check("tosa._table")
-            .check_count(
-                {
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 1,
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 1,
-                }
-            )
-            .check_not(["aten_sigmoid_default"])
-        )
+    pipeline.run()

--- a/backends/arm/test/passes/test_ioquantization_pass.py
+++ b/backends/arm/test/passes/test_ioquantization_pass.py
@@ -1,10 +1,8 @@
 # Copyright 2025 Arm Limited and/or its affiliates.
-# All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
 
 import torch
 
@@ -24,47 +22,43 @@ class SimpleModel(torch.nn.Module):
         return (a, b)
 
 
-class TestIOQuantizationPass(unittest.TestCase):
+def test_ioquantisation_pass_u55_BI():
     """
     Test the executorch/exir/passes/quanize_io_pass pass works(meaning we don't get Q/DQ nodes) on a simple model
     """
-
-    def test_ioquantisation_pass(self):
-        model = SimpleModel()
-        tester = (
-            ArmTester(
-                model,
-                example_inputs=model.get_inputs(),
-                compile_spec=common.get_u55_compile_spec(),
-            )
-            .quantize()
-            .export()
-            .to_edge()
-            .check_count(
-                {
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 3
-                }
-            )
-            .check_count(
-                {
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 3
-                }
-            )
-            .partition()
-            .check_count(
-                {
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 2
-                }
-            )
-            .check_count(
-                {
-                    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 1
-                }
-            )
+    model = SimpleModel()
+    tester = (
+        ArmTester(
+            model,
+            example_inputs=model.get_inputs(),
+            compile_spec=common.get_u55_compile_spec(),
         )
-        edge = tester.get_artifact()
-        edge.transform(
-            passes=[QuantizeInputs(edge, [0, 1]), QuantizeOutputs(edge, [0])]
+        .quantize()
+        .export()
+        .to_edge()
+        .check_count(
+            {
+                "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 3
+            }
         )
-        tester.check_not(["edge__ops_quantized_decomposed_quantize_per_tensor"])
-        tester.check_not(["edge__ops_quantized_decomposed_dequantize_per_tensor"])
+        .check_count(
+            {
+                "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 3
+            }
+        )
+        .partition()
+        .check_count(
+            {
+                "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 2
+            }
+        )
+        .check_count(
+            {
+                "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 1
+            }
+        )
+    )
+    edge = tester.get_artifact()
+    edge.transform(passes=[QuantizeInputs(edge, [0, 1]), QuantizeOutputs(edge, [0])])
+    tester.check_not(["edge__ops_quantized_decomposed_quantize_per_tensor"])
+    tester.check_not(["edge__ops_quantized_decomposed_dequantize_per_tensor"])

--- a/backends/arm/test/passes/test_unsqueeze_before_repeat_pass.py
+++ b/backends/arm/test/passes/test_unsqueeze_before_repeat_pass.py
@@ -1,17 +1,20 @@
-# Copyright 2024 Arm Limited and/or its affiliates.
-# All rights reserved.
+# Copyright 2024-2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-import unittest
+
+from typing import Dict, Tuple
 
 import torch
 from executorch.backends.arm._passes.unsqueeze_before_repeat_pass import (
     UnsqueezeBeforeRepeatPass,
 )
 from executorch.backends.arm.test import common
-from executorch.backends.arm.test.tester.arm_tester import ArmTester
-from executorch.backends.xnnpack.test.tester.tester import RunPasses
+from executorch.backends.arm.test.tester.test_pipeline import TestPassPipeline
+
+input_t = Tuple[
+    torch.Tensor, Dict[str, int], list[str]
+]  # Input x, ops_after_pass, ops_not_after_pass
 
 
 class Repeat(torch.nn.Module):
@@ -22,53 +25,37 @@ class Repeat(torch.nn.Module):
     def forward(self, x: torch.Tensor):
         return x.repeat(2, 2, 2, 2)
 
+    test_data: Dict[str, input_t] = {
+        "insert_view": (
+            (torch.rand((2, 3, 4)),),
+            {"aten_repeat_default": 3, "aten_view_copy_default": 4},
+            [],
+        ),
+        "dont_insert_view": (
+            (torch.rand((2, 3, 4, 1)),),
+            {"aten_repeat_default": 3},
+            ["aten_view_copy_default"],
+        ),
+    }
 
-class TestUnsqueezeBeforeRepeatPass(unittest.TestCase):
-    def test_tosa_MI_insert_view(self):
-        """
-        When rank(input) != number of repeated dimensions (=4 in Repeat module),
-        insert view.
-        """
-        module = Repeat()
-        inputs = (torch.rand((2, 3, 4)),)
-        test_pass_stage = RunPasses([UnsqueezeBeforeRepeatPass])
-        (
-            (
-                ArmTester(
-                    module,
-                    example_inputs=inputs,
-                    compile_spec=common.get_tosa_compile_spec("TOSA-0.80+MI"),
-                )
-                .export()
-                .to_edge()
-                .check(["aten_repeat_default"])
-                .check_not(["aten_view_copy_default"])
-                .run_passes(test_pass_stage)
-                .check(["aten_repeat_default", "aten_view_copy_default"])
-            )
-        )
 
-    def test_tosa_MI_dont_insert_view(self):
-        """
-        When rank(input) == number of repeated dimensions (=4 in Repeat module),
-        DON'T insert view.
-        """
-        module = Repeat()
-        inputs = (torch.rand((2, 3, 4, 1)),)
-        test_pass_stage = RunPasses([UnsqueezeBeforeRepeatPass])
-        (
-            (
-                ArmTester(
-                    module,
-                    example_inputs=inputs,
-                    compile_spec=common.get_tosa_compile_spec("TOSA-0.80+MI"),
-                )
-                .export()
-                .to_edge()
-                .check(["aten_repeat_default"])
-                .check_not(["aten_view_copy_default"])
-                .run_passes(test_pass_stage)
-                .check(["aten_repeat_default"])
-                .check_not(["aten_view_copy_default"])
-            )
-        )
+@common.parametrize("test_data", Repeat.test_data)
+def test_unsqueeze_before_repeat_tosa_MI(test_data):
+    """
+    When rank(input) != number of repeated dimensions (=4 in Repeat module),
+    insert view.
+    """
+    module = Repeat()
+    data, ops_after_pass, ops_not_after_pass = test_data
+    pipeline = TestPassPipeline(
+        module,
+        data,
+        tosa_version="TOSA-0.80+MI",
+        ops_before_pass={"aten_repeat_default": 3},
+        ops_not_before_pass=["aten_view_copy_default"],
+        ops_after_pass=ops_after_pass,
+        ops_not_after_pass=ops_not_after_pass,
+        pass_list=[UnsqueezeBeforeRepeatPass],
+    )
+    pipeline.pop_stage(-1)  # Do not compare output
+    pipeline.run()


### PR DESCRIPTION
Adds a new TestPassPipeline for testing single passes and updates pass test to use the new pipeline. test_ioquantisation_pass_u55_BI does not use the pipeline as a special case, since it differs substantially from the other tests.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218