### PR TITLE
remove autogenerated portable op test for fft_r2c

### DIFF
--- a/kernels/test/targets.bzl
+++ b/kernels/test/targets.bzl
@@ -17,8 +17,11 @@ def make_example_generated_op_test_target():
     """
     op_test_cpp_files = native.glob(
         ["op_*_test.cpp"],
-        # linear has no portable op.
-        exclude = ["op_linear_test.cpp"],
+        # These tests have no portable op.
+        exclude = [
+            "op_fft_r2c_test.cpp",
+            "op_linear_test.cpp",
+        ],
     )
 
     # The op name is from the beginning to the part without `_test.cpp` (:-9)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8375

We autogenerate an extra portable mode test for every op. I didn't notice and forgot to opt this op out. (also looking into simply not doing this generation anymore)

Differential Revision: [D69469532](https://our.internmc.facebook.com/intern/diff/D69469532/)