### PR TITLE
Remove duplicated portable test targets

### DIFF
--- a/kernels/test/targets.bzl
+++ b/kernels/test/targets.bzl
@@ -1,5 +1,5 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
-load("@fbsource//xplat/executorch/kernels/test:util.bzl", "codegen_function_header_wrapper", "generated_op_test", "op_test")
+load("@fbsource//xplat/executorch/kernels/test:util.bzl", "codegen_function_header_wrapper", "op_test")
 
 def _common_op_test(name, kernels):
     """
@@ -9,28 +9,6 @@ def _common_op_test(name, kernels):
     for kernel in kernels:
         deps = [":function_header_wrapper_{}".format(kernel)]
         op_test(name, kernel_name = kernel, use_kernel_prefix = True, deps = deps)
-
-def make_example_generated_op_test_target():
-    """
-    Makes a test for kernels/test/util generated_op_test() helper
-    Here we use portable kernel. Try with `buck test xplat/executorch/kernels/test:op_<>_test`
-    """
-    op_test_cpp_files = native.glob(
-        ["op_*_test.cpp"],
-        # linear has no portable op.
-        exclude = ["op_linear_test.cpp"],
-    )
-
-    # The op name is from the beginning to the part without `_test.cpp` (:-9)
-    op_to_test = [f[:-9] for f in op_test_cpp_files]
-    for op_name in op_to_test:
-        generated_op_test(
-            op_name + "_test",
-            "//executorch/kernels/portable/cpu:{}".format(op_name),
-            "//executorch/kernels/portable:generated_lib_headers",
-            "//executorch/kernels/portable/test:supported_features",
-            "//executorch/kernels/test:function_header_wrapper_portable",
-        )
 
 def define_common_targets():
     """Defines targets that should be shared between fbcode and xplat.
@@ -353,5 +331,3 @@ def define_common_targets():
     _common_op_test("op_view_copy_test", ["aten", "portable"])
     _common_op_test("op_where_test", ["aten", "portable"])
     _common_op_test("op_zeros_test", ["aten", "portable"])
-
-    make_example_generated_op_test_target()


### PR DESCRIPTION

### Summary
`_common_op_test` already generates portable test targets.

### Test plan
CI