### PR TITLE
Mention the PR author in mergebot PRs

### DIFF
--- a/.github/scripts/propose_ghstack_orig_pr.py
+++ b/.github/scripts/propose_ghstack_orig_pr.py
@@ -101,7 +101,7 @@ def create_prs_for_orig_branch(pr_stack: List[int], repo: Repository):
         # gh/user/x/orig is the clean diff between gh/user/x/base <- gh/user/x/head
         orig_branch_merge_head = pr.base.ref.replace("base", "orig")
         bot_metadata = f"""This PR was created by the merge bot to help merge the original PR into the main branch.
-ghstack PR number: https://github.com/pytorch/executorch/pull/{pr.number}
+ghstack PR number: https://github.com/pytorch/executorch/pull/{pr.number} by @{pr.user.login}
 ^ Please use this as the source of truth for the PR details, comments, and reviews
 ghstack PR base: https://github.com/pytorch/executorch/tree/{pr.base.ref}
 ghstack PR head: https://github.com/pytorch/executorch/tree/{pr.head.ref}


### PR DESCRIPTION
Hopefully, this should help prevent mergebot PRs from being unnoticed by generating a GitHub notification to the author.

Test Plan: Use ghstack to push a PR (get something like gh/kirklandsign/17/head).
 In `.github/scripts/propose_ghstack_orig_pr.py`, remove `print("The PR (and stack above) is not merged yet, skipping")` and `return` after it.
 Then `export GITHUB_TOKEN=` `python .github/scripts/propose_ghstack_orig_pr.py --repo pytorch/executorch --ref refs/heads/gh/kirklandsign/17/head`