### PR TITLE
Enable pybind with mps

### DIFF
--- a/install_executorch.py
+++ b/install_executorch.py
@@ -165,6 +165,8 @@ def main(args):
                 if pybind_arg == "training":
                     CMAKE_ARGS += " -DEXECUTORCH_BUILD_EXTENSION_TRAINING=ON"
                     os.environ["EXECUTORCH_BUILD_TRAINING"] = "ON"
+                elif pybind_arg == "mps":
+                    CMAKE_ARGS += " -DEXECUTORCH_BUILD_MPS=ON"
                 else:
                     CMAKE_ARGS += f" -DEXECUTORCH_BUILD_{pybind_arg.upper()}=ON"
                 EXECUTORCH_BUILD_PYBIND = "ON"


### PR DESCRIPTION
Summary:
install executorch with mps
```
./install_executorch.sh --pybind mps
```
test the mps .pte file can run with
```
executorch_module = _load_for_executorch(filename)
out = executorch_module.forward(list(inputs))

print("output: ", out)
```

Differential Revision: D69497059


