### PR TITLE
executorch-the-CMake-target should re-export executorch_core, shouldn't it?

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,7 +596,7 @@ endif()
 # any backends.
 #
 add_library(executorch ${_executorch__srcs})
-target_link_libraries(executorch PRIVATE executorch_core)
+target_link_libraries(executorch PUBLIC executorch_core)
 target_include_directories(executorch PUBLIC ${_common_include_directories})
 target_compile_definitions(executorch PUBLIC C10_USING_CUSTOM_GENERATED_MACROS)
 target_compile_options(executorch PUBLIC ${_common_compile_options})

--- a/kernels/portable/cpu/util/advanced_index_util.cpp
+++ b/kernels/portable/cpu/util/advanced_index_util.cpp
@@ -51,7 +51,7 @@ bool check_mask_indices(const Tensor& in, TensorOptList indices) {
             index.dim() > 0, "Zero-dimensional mask index not allowed");
         for (auto j = 0; j < index.dim(); j++) {
           if (index.size(j) != in.size(in_i + j)) {
-#ifdef ET_LOG_ENABLED
+#if ET_LOG_ENABLED
             auto mask_shape = executorch::runtime::tensor_shape_to_c_string(
                 executorch::runtime::Span<const Tensor::SizesType>(
                     index.sizes().data(), index.sizes().size()));

--- a/kernels/portable/cpu/util/broadcast_util.cpp
+++ b/kernels/portable/cpu/util/broadcast_util.cpp
@@ -214,7 +214,7 @@ ET_NODISCARD Error get_broadcast_target_size(
     const size_t out_sizes_len,
     size_t* out_dim) {
   if ET_UNLIKELY (!tensors_are_broadcastable_between(a_size, b_size)) {
-#ifdef ET_LOG_ENABLED
+#if ET_LOG_ENABLED
     executorch::runtime::Span<const Tensor::SizesType> a_size_span(
         a_size.data(), a_size.size());
     executorch::runtime::Span<const Tensor::SizesType> b_size_span(

--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -95,7 +95,7 @@ Error TensorImpl::internal_resize_contiguous(ArrayRef<SizesType> new_sizes) {
   switch (shape_dynamism_) {
     case TensorShapeDynamism::STATIC:
       if (!std::equal(sizes_, sizes_ + dim_, new_sizes.begin())) {
-#ifdef ET_LOG_ENABLED
+#if ET_LOG_ENABLED
         executorch::runtime::Span<const SizesType> sizes_span(
             sizes().data(), sizes().size());
         executorch::runtime::Span<const SizesType> new_sizes_span(


### PR DESCRIPTION
This seems to fix QNN build failures, and it doesn't make sense to me that every executorch (the CMake target) consumer should also have to explicitly link executorch_core