### PR TITLE
[ExecuTorch] Arm Ethos Bento Kernel

### DIFF
--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -10,13 +10,19 @@ import re
 import shutil
 import subprocess
 import tempfile
+from logging import logger
 from pathlib import Path
 
 from typing import cast, Dict, List, Literal, Optional, Tuple
 
 import numpy as np
 import torch
-import tosa_reference_model
+
+try:
+    import tosa_reference_model
+except ImportError:
+    logger.warning("tosa_reference_model not found, can't run reference model tests")
+    tosa_reference_model = None
 from executorch.backends.arm.arm_backend import get_tosa_version, is_tosa
 
 from executorch.backends.arm.test.conftest import is_option_enabled

--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -10,7 +10,7 @@ import re
 import shutil
 import subprocess
 import tempfile
-from logging import logger
+
 from pathlib import Path
 
 from typing import cast, Dict, List, Literal, Optional, Tuple
@@ -18,6 +18,7 @@ from typing import cast, Dict, List, Literal, Optional, Tuple
 import numpy as np
 import torch
 
+logger = logging.getLogger(__name__)
 try:
     import tosa_reference_model
 except ImportError:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #8406
* __->__ #8405

Add a bento-kernel with basic functionality to lower PyTorch programs to ET PTE with Ethos cmd stream in it.

* Known issues
     * We haven't yet buckified `tosa_reference_model` - those tests will fail
     * No e2e tests yet, need to wire-up FVP with this kernel

Differential Revision: [D69496532](https://our.internmc.facebook.com/intern/diff/D69496532/)

cc @freddan80 @per @zingo @oscarandersson8218