### PR TITLE
Fix multiple find_package(Torch) calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,7 +750,9 @@ if(EXECUTORCH_BUILD_PYBIND)
   endif()
 
   # find pytorch lib, to allow pybind to take at::Tensor as input/output
-  find_package(Torch CONFIG REQUIRED)
+  if(NOT TARGET torch)
+    find_package(Torch CONFIG REQUIRED)
+  endif()
   find_library(
     TORCH_PYTHON_LIBRARY torch_python PATHS "${TORCH_INSTALL_PREFIX}/lib"
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,13 +603,6 @@ target_compile_options(executorch PUBLIC ${_common_compile_options})
 target_link_options_shared_lib(executorch)
 
 #
-# find pytorch lib here to make it available to all sub-directories, trying to
-# call find_package(Torch) multiple times doesn't work because it brings in MKL
-# which is defined once globally
-#
-find_package(Torch CONFIG REQUIRED)
-
-#
 # portable_ops_lib: A library to register core ATen ops using portable kernels,
 # see kernels/portable/CMakeLists.txt.
 #
@@ -756,7 +749,8 @@ if(EXECUTORCH_BUILD_PYBIND)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/devtools)
   endif()
 
-  # to allow pybind to take at::Tensor as input/output
+  # find pytorch lib, to allow pybind to take at::Tensor as input/output
+  find_package(Torch CONFIG REQUIRED)
   find_library(
     TORCH_PYTHON_LIBRARY torch_python PATHS "${TORCH_INSTALL_PREFIX}/lib"
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,6 +603,13 @@ target_compile_options(executorch PUBLIC ${_common_compile_options})
 target_link_options_shared_lib(executorch)
 
 #
+# find pytorch lib here to make it available to all sub-directories, trying to
+# call find_package(Torch) multiple times doesn't work because it brings in MKL
+# which is defined once globally
+#
+find_package(Torch CONFIG REQUIRED)
+
+#
 # portable_ops_lib: A library to register core ATen ops using portable kernels,
 # see kernels/portable/CMakeLists.txt.
 #
@@ -749,8 +756,7 @@ if(EXECUTORCH_BUILD_PYBIND)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/devtools)
   endif()
 
-  # find pytorch lib, to allow pybind to take at::Tensor as input/output
-  find_package(Torch CONFIG REQUIRED)
+  # to allow pybind to take at::Tensor as input/output
   find_library(
     TORCH_PYTHON_LIBRARY torch_python PATHS "${TORCH_INSTALL_PREFIX}/lib"
   )

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -146,9 +146,7 @@ function(gen_custom_ops_aot_lib)
     ${_out_dir}/CustomOpsNativeFunctions.h "${GEN_KERNEL_SOURCES}"
   )
   # Find `Torch`.
-  if(NOT TARGET torch)
-    find_package(Torch REQUIRED)
-  endif()
+  find_package(Torch REQUIRED)
   # This lib uses ATen lib, so we explicitly enable rtti and exceptions.
   target_compile_options(${GEN_LIB_NAME} PRIVATE -frtti -fexceptions)
   target_compile_definitions(${GEN_LIB_NAME} PRIVATE USE_ATEN_LIB=1)

--- a/build/Codegen.cmake
+++ b/build/Codegen.cmake
@@ -146,7 +146,9 @@ function(gen_custom_ops_aot_lib)
     ${_out_dir}/CustomOpsNativeFunctions.h "${GEN_KERNEL_SOURCES}"
   )
   # Find `Torch`.
-  find_package(Torch REQUIRED)
+  if(NOT TARGET torch)
+    find_package(Torch REQUIRED)
+  endif()
   # This lib uses ATen lib, so we explicitly enable rtti and exceptions.
   target_compile_options(${GEN_LIB_NAME} PRIVATE -frtti -fexceptions)
   target_compile_definitions(${GEN_LIB_NAME} PRIVATE USE_ATEN_LIB=1)

--- a/extension/llm/custom_ops/CMakeLists.txt
+++ b/extension/llm/custom_ops/CMakeLists.txt
@@ -69,7 +69,9 @@ install(TARGETS custom_ops DESTINATION lib)
 
 if(EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT)
   # Add a AOT library
-  find_package(Torch CONFIG REQUIRED)
+  if(NOT TARGET torch)
+    find_package(Torch CONFIG REQUIRED)
+  endif()
   add_library(
     custom_ops_aot_lib SHARED
     ${_custom_ops__srcs}

--- a/extension/llm/custom_ops/CMakeLists.txt
+++ b/extension/llm/custom_ops/CMakeLists.txt
@@ -69,9 +69,7 @@ install(TARGETS custom_ops DESTINATION lib)
 
 if(EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT)
   # Add a AOT library
-  if(NOT TARGET torch)
-    find_package(Torch CONFIG REQUIRED)
-  endif()
+  find_package(Torch CONFIG REQUIRED)
   add_library(
     custom_ops_aot_lib SHARED
     ${_custom_ops__srcs}


### PR DESCRIPTION
While debugging the build issue on https://github.com/pytorch/executorch/pull/8322 w.r.t mkl, I undercover a complex interaction between https://github.com/pytorch/executorch/pull/8322, https://github.com/pytorch/executorch/pull/8248 (to install mkl), and https://github.com/pytorch/pytorch/blob/main/cmake/public/mkl.cmake from PyTorch.  The error is as follows:

```
CMake Error at /opt/conda/envs/py_3.10/lib/cmake/mkl/MKLConfig.cmake:744 (add_library): <-- This file comes from conda mkl
  add_library cannot create imported target "MKL::MKL" because another target
  with the same name already exists.
Call Stack (most recent call first):
  /opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/share/cmake/Caffe2/public/mkl.cmake:1 (find_package) <-- this is from PyTorch
  /opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/share/cmake/Caffe2/Caffe2Config.cmake:106 (include)
  /opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/share/cmake/Torch/TorchConfig.cmake:68 (find_package)
  CMakeLists.txt:753 (find_package)
```

The conclusion is that, with mkl installed, there should be just one `find_package(Torch)` call because the mkl target is defined globally.  The `torch` target, on the other hand, is only defined locally.

So, this change adds `if(NOT TARGET torch)` check to only call `find_package(Torch)` if needed.

### Testing

The change on top of https://github.com/pytorch/executorch/pull/8322 looks like this https://github.com/pytorch/executorch/pull/8399/commits/f705b01a51486e1cbe318d142015da35a83e2578

https://github.com/pytorch/executorch/actions/runs/13278590926?pr=8399