### PR TITLE
Buckify tokenizers

### DIFF
--- a/shim/xplat/executorch/build/env_interface.bzl
+++ b/shim/xplat/executorch/build/env_interface.bzl
@@ -39,9 +39,12 @@ _EXTERNAL_DEPS = {
     "gtest_aten": "//third-party:gtest_aten",
     "libtorch": "//third-party:libtorch",
     "libtorch_python": "//third-party:libtorch_python",
+    # Huggingface Tokenizer
+    "nlohmann_json": [], # Intentionally not supporting OSS buck build HF tokenizer.
     "prettytable": "//third-party:prettytable",
     "pybind11": "//third-party:pybind11",
     "re2": "//extension/llm/third-party:re2",
+    "sentencepiece": [], # Intentionally not supporting OSS buck build of sentencepiece.
     "sentencepiece-py": [],
     # Core C++ PyTorch functionality like Tensor and ScalarType.
     "torch-core-cpp": "//third-party:libtorch",


### PR DESCRIPTION
Summary: So that it can be used by ET internally

Differential Revision: D69509028
