### PR TITLE
Add -Wno-global-constructors -Wno-shadow to fft_r2c op target

### DIFF
--- a/kernels/optimized/cpu/targets.bzl
+++ b/kernels/optimized/cpu/targets.bzl
@@ -27,6 +27,10 @@ _OPTIMIZED_ATEN_OPS = (
     op_target(name = "op_exp"),
     op_target(
         name = "op_fft_r2c",
+        compiler_flags = [] if runtime.is_oss else [
+            "-Wno-global-constructors",
+            "-Wno-shadow",
+        ],
         deps = [] if runtime.is_oss else ["fbsource//third-party/pocket_fft:pocketfft"],
     ),
     op_target(name = "op_sigmoid"),

--- a/kernels/optimized/op_registration_util.bzl
+++ b/kernels/optimized/op_registration_util.bzl
@@ -10,7 +10,7 @@ load(
     "get_compiler_optimization_flags",
 )
 
-def op_target(name, deps = []):
+def op_target(name, deps = [], compiler_flags = []):
     """Registers an optimized implementation for an operator overload group.
 
     An operator overload group is a set of operator overloads with a common
@@ -37,11 +37,13 @@ def op_target(name, deps = []):
               dependencies manageable. If two op targets would like to share
               code, define a separate runtime.cxx_library that they both depend
               on.
+        compiler_flags: Optional compiler flags to add to the cxx_library().
     """
 
     # Note that this doesn't actually define the target, but helps register
     # it in a table that's used to define the target.
     return {
+        "compiler_flags": compiler_flags,
         "deps": deps,
         "name": name,
     }
@@ -64,7 +66,7 @@ def _enforce_deps(deps, name):
                 dep,
             ))
 
-def define_op_library(name, deps):
+def define_op_library(name, compiler_flags, deps):
     """Defines a cxx_library target for the named operator overload group.
 
     Args:
@@ -97,7 +99,7 @@ def define_op_library(name, deps):
             # pragma unroll fails with -Os, don't need to warn us and
             # fail Werror builds; see https://godbolt.org/z/zvf85vTsr
             "-Wno-pass-failed",
-        ] + get_compiler_optimization_flags(),
+        ] + compiler_flags + get_compiler_optimization_flags(),
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ] + augmented_deps + get_vec_deps(),
@@ -119,7 +121,7 @@ def define_op_library(name, deps):
         link_whole = True,
     )
 
-def define_op_target(name, deps):
+def define_op_target(name, compiler_flags, deps):
     """Possibly defines cxx_library targets for the named operator group.
 
     Args:
@@ -132,6 +134,7 @@ def define_op_target(name, deps):
     # versions defined here.
     define_op_library(
         name = name,
+        compiler_flags = compiler_flags,
         deps = deps,
     )
 

--- a/shim/xplat/executorch/kernels/optimized/op_registration_util.bzl
+++ b/shim/xplat/executorch/kernels/optimized/op_registration_util.bzl
@@ -12,7 +12,7 @@ load(
     "get_vec_preprocessor_flags",
 )
 
-def op_target(name, deps = []):
+def op_target(name, deps = [], compiler_flags = []):
     """Registers an optimized implementation for an operator overload group.
 
     An operator overload group is a set of operator overloads with a common
@@ -39,11 +39,13 @@ def op_target(name, deps = []):
               dependencies manageable. If two op targets would like to share
               code, define a separate runtime.cxx_library that they both depend
               on.
+        compiler_flags: Optional compiler flags to add to the cxx_library().
     """
 
     # Note that this doesn't actually define the target, but helps register
     # it in a table that's used to define the target.
     return {
+        "compiler_flags": compiler_flags,
         "deps": deps,
         "name": name,
     }
@@ -66,7 +68,7 @@ def _enforce_deps(deps, name):
                 dep,
             ))
 
-def define_op_library(name, deps):
+def define_op_library(name, compiler_flags, deps):
     """Defines a cxx_library target for the named operator overload group.
 
     Args:
@@ -116,7 +118,7 @@ def define_op_library(name, deps):
         link_whole = True,
     )
 
-def define_op_target(name, deps):
+def define_op_target(name, compiler_flags, deps):
     """Possibly defines cxx_library targets for the named operator group.
 
     Args:
@@ -129,6 +131,7 @@ def define_op_target(name, deps):
     # versions defined here.
     define_op_library(
         name = name,
+        compiler_flags = compiler_flags,
         deps = deps,
     )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8427

Need to suppress these warnings to unbreak builds; looks like this is what PyTorch core does.

Differential Revision: [D69470437](https://our.internmc.facebook.com/intern/diff/D69470437/)