### PR TITLE
Fix TrainingModule Parameter Bug

### DIFF
--- a/extension/training/pybindings/test/test.py
+++ b/extension/training/pybindings/test/test.py
@@ -28,20 +28,19 @@ class TestTraining(unittest.TestCase):
         def forward(self, x, y):
             return self.loss(self.linear(x).softmax(dim=0), y)
 
-        def get_random_inputs(self):
-            return (torch.randn(3), torch.tensor([1.0, 0.0, 0.0]))
+        def get_inputs(self):
+            return (torch.ones(3, dtype=torch.float32), torch.tensor([1.0, 0.0, 0.0]))
 
     def test(self):
         m = self.ModuleSimpleTrain()
-        ep = torch.export.export(m, m.get_random_inputs(), strict=True)
+        ep = torch.export.export(m, m.get_inputs(), strict=True)
         ep = _export_forward_backward(ep)
         ep = to_edge(ep)
         ep = ep.to_executorch()
         buffer = ep.buffer
         tm = _load_for_executorch_for_training_from_buffer(buffer)
 
-        tm.forward_backward("forward", m.get_random_inputs())
-        orig_param = list(tm.named_parameters().values())[0].clone()
+        orig_loss = tm.forward_backward("forward", m.get_inputs())
         optimizer = get_sgd_optimizer(
             tm.named_parameters(),
             0.1,
@@ -50,7 +49,19 @@ class TestTraining(unittest.TestCase):
             0,
             False,
         )
+
+        cloned_params = list(tm.named_parameters().values())
+        cloned_params = [p.clone() for p in cloned_params]
+
         optimizer.step(tm.named_gradients())
-        self.assertFalse(
-            torch.allclose(orig_param, list(tm.named_parameters().values())[0])
-        )
+
+        # The python module caches the param tensors after the first
+        # inference. So this doesn't test if the params are actually
+        # updated in cpp world.
+        for p, cloned_p in zip(tm.named_parameters().values(), cloned_params):
+            self.assertFalse(torch.allclose(p, cloned_p))
+
+        # Test that the params actually changed in cpp by running against
+        # the same inputs again and seeing that the loss is different.
+        second_loss = tm.forward_backward("forward", m.get_inputs())
+        self.assertFalse(torch.allclose(orig_loss[0], second_loss[0]))


### PR DESCRIPTION
Summary: The params were being cloned and then cached so in python we observed them changing but the actual cpp weights being run against were not.

Differential Revision: D69568035


