### PR TITLE
[BE] Cmake clean up

### DIFF
--- a/extension/flat_tensor/CMakeLists.txt
+++ b/extension/flat_tensor/CMakeLists.txt
@@ -19,11 +19,13 @@ endif()
 list(TRANSFORM _extension_flat_tensor__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(extension_flat_tensor ${_extension_flat_tensor__srcs})
 target_link_libraries(extension_flat_tensor executorch extension_data_loader)
-target_include_directories(extension_flat_tensor PUBLIC
-  ${EXECUTORCH_ROOT}/..
-  "${CMAKE_BINARY_DIR}/extension/flat_tensor/include"
-  "${EXECUTORCH_ROOT}/third-party/flatbuffers/include"
-  ${_common_include_directories})
+target_include_directories(
+  extension_flat_tensor
+  PUBLIC ${EXECUTORCH_ROOT}/..
+         "${CMAKE_BINARY_DIR}/extension/flat_tensor/include"
+         "${EXECUTORCH_ROOT}/third-party/flatbuffers/include"
+         ${_common_include_directories}
+)
 target_compile_options(extension_flat_tensor PUBLIC ${_common_compile_options})
 
 # Install libraries

--- a/extension/flat_tensor/test/CMakeLists.txt
+++ b/extension/flat_tensor/test/CMakeLists.txt
@@ -21,27 +21,31 @@ include(${EXECUTORCH_ROOT}/build/Test.cmake)
 add_custom_command(
   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ModuleLinearProgram.pte"
          "${CMAKE_CURRENT_BINARY_DIR}/_default_external_constant.ptd"
-
   COMMAND
-    python -m test.models.export_program --modules "ModuleLinear" --external-constants --outdir "${CMAKE_CURRENT_BINARY_DIR}" 2> /dev/null
-
+    python -m test.models.export_program --modules "ModuleLinear"
+    --external-constants --outdir "${CMAKE_CURRENT_BINARY_DIR}" 2> /dev/null
   WORKING_DIRECTORY ${EXECUTORCH_ROOT}
 )
 
 add_custom_target(
-  program_data_files
+  extension_flat_tensor_test_resources
   DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/ModuleLinearProgram.pte"
           "${CMAKE_CURRENT_BINARY_DIR}/_default_external_constant.ptd"
 )
 
-set(test_env_
+set(test_env
     "ET_MODULE_LINEAR_PROGRAM_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleLinearProgram.pte"
     "ET_MODULE_LINEAR_DATA_PATH=${CMAKE_CURRENT_BINARY_DIR}/_default_external_constant.ptd"
 )
 
 set(_test_srcs flat_tensor_data_map_test.cpp flat_tensor_header_test.cpp)
 
-et_cxx_test(extension_flat_tensor_test SOURCES ${_test_srcs} EXTRA_LIBS extension_flat_tensor extension_data_loader)
+et_cxx_test(
+  extension_flat_tensor_test SOURCES ${_test_srcs} EXTRA_LIBS
+  extension_flat_tensor extension_data_loader
+)
 
-add_dependencies(extension_flat_tensor_test program_data_files)
-set_property(TEST extension_flat_tensor_test PROPERTY ENVIRONMENT ${test_env_})
+add_dependencies(
+  extension_flat_tensor_test extension_flat_tensor_test_resources
+)
+set_property(TEST extension_flat_tensor_test PROPERTY ENVIRONMENT ${test_env})

--- a/extension/runner_util/test/CMakeLists.txt
+++ b/extension/runner_util/test/CMakeLists.txt
@@ -17,6 +17,20 @@ set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
 include(${EXECUTORCH_ROOT}/build/Test.cmake)
 
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ModuleAdd.pte"
+  COMMAND python3 -m test.models.export_program --modules "ModuleAdd" --outdir
+          "${CMAKE_CURRENT_BINARY_DIR}" 2> /dev/null
+  WORKING_DIRECTORY ${EXECUTORCH_ROOT}
+)
+
+add_custom_target(
+  executorch_runner_util_test_resources
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/ModuleAdd.pte"
+)
+
+set(test_env "ET_MODULE_ADD_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleAdd.pte")
+
 set(_test_srcs inputs_test.cpp)
 
 et_cxx_test(
@@ -29,7 +43,6 @@ et_cxx_test(
   portable_kernels
   portable_ops_lib
 )
-set_property(
-  TEST extension_runner_util_test
-  PROPERTY ENVIRONMENT "ET_MODULE_ADD_PATH=${CMAKE_BINARY_DIR}/ModuleAdd.pte"
-)
+
+add_dependencies(extension_runner_util_test executorch_runner_util_test_resources)
+set_property(TEST extension_runner_util_test PROPERTY ENVIRONMENT ${test_env})

--- a/runtime/executor/test/CMakeLists.txt
+++ b/runtime/executor/test/CMakeLists.txt
@@ -18,53 +18,52 @@ set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 include(${EXECUTORCH_ROOT}/build/Test.cmake)
 
 add_custom_command(
-  OUTPUT "${CMAKE_BINARY_DIR}/ModuleAddHalf.pte"
-         "${CMAKE_BINARY_DIR}/ModuleAdd.pte"
-         "${CMAKE_BINARY_DIR}/ModuleDynamicCatUnallocatedIO.pte"
-         "${CMAKE_BINARY_DIR}/ModuleIndex.pte"
-         "${CMAKE_BINARY_DIR}/ModuleLinear.pte"
-         "${CMAKE_BINARY_DIR}/ModuleLinearProgram.pte"
-         "${CMAKE_BINARY_DIR}/_default_external_constant.ptd"
-         "${CMAKE_BINARY_DIR}/ModuleMultipleEntry.pte"
-         "${CMAKE_BINARY_DIR}/ModuleSimpleTrain.pte"
-  COMMAND
-    python -m test.models.export_program --modules
-    "ModuleAdd,ModuleAddHalf,ModuleDynamicCatUnallocatedIO,ModuleIndex,ModuleLinear,ModuleMultipleEntry,ModuleSimpleTrain"
-    --outdir "${CMAKE_BINARY_DIR}" 2> /dev/null
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ModuleAddHalf.pte"
+         "${CMAKE_CURRENT_BINARY_DIR}/ModuleAdd.pte"
+         "${CMAKE_CURRENT_BINARY_DIR}/ModuleDynamicCatUnallocatedIO.pte"
+         "${CMAKE_CURRENT_BINARY_DIR}/ModuleIndex.pte"
+         "${CMAKE_CURRENT_BINARY_DIR}/ModuleLinear.pte"
+         "${CMAKE_CURRENT_BINARY_DIR}/ModuleLinearProgram.pte"
+         "${CMAKE_CURRENT_BINARY_DIR}/_default_external_constant.ptd"
+         "${CMAKE_CURRENT_BINARY_DIR}/ModuleMultipleEntry.pte"
+         "${CMAKE_CURRENT_BINARY_DIR}/ModuleSimpleTrain.pte"
   COMMAND
     python3 -m test.models.export_program --modules
-    "ModuleLinear" --external-constants
-    --outdir "${CMAKE_BINARY_DIR}" 2> /dev/null
+    "ModuleAdd,ModuleAddHalf,ModuleDynamicCatUnallocatedIO,ModuleIndex,ModuleLinear,ModuleMultipleEntry,ModuleSimpleTrain"
+    --outdir "${CMAKE_CURRENT_BINARY_DIR}" 2> /dev/null
   COMMAND
-    python -m test.models.export_delegated_program --modules "ModuleAddMul"
-    --backend_id "StubBackend" --outdir "${CMAKE_BINARY_DIR}" || true
+    python3 -m test.models.export_program --modules "ModuleLinear"
+    --external-constants --outdir "${CMAKE_CURRENT_BINARY_DIR}" 2> /dev/null
+  COMMAND
+    python3 -m test.models.export_delegated_program --modules "ModuleAddMul"
+    --backend_id "StubBackend" --outdir "${CMAKE_CURRENT_BINARY_DIR}" || true
   WORKING_DIRECTORY ${EXECUTORCH_ROOT}
 )
 
 add_custom_target(
   generated_pte_files
-  DEPENDS "${CMAKE_BINARY_DIR}/ModuleAddHalf.pte"
-          "${CMAKE_BINARY_DIR}/ModuleAdd.pte"
-          "${CMAKE_BINARY_DIR}/ModuleDynamicCatUnallocatedIO.pte"
-          "${CMAKE_BINARY_DIR}/ModuleIndex.pte"
-          "${CMAKE_BINARY_DIR}/ModuleLinear.pte"
-          "${CMAKE_BINARY_DIR}/ModuleLinearProgram.pte"
-          "${CMAKE_BINARY_DIR}/_default_external_constant.ptd"
-          "${CMAKE_BINARY_DIR}/ModuleMultipleEntry.pte"
-          "${CMAKE_BINARY_DIR}/ModuleSimpleTrain.pte"
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/ModuleAddHalf.pte"
+          "${CMAKE_CURRENT_BINARY_DIR}/ModuleAdd.pte"
+          "${CMAKE_CURRENT_BINARY_DIR}/ModuleDynamicCatUnallocatedIO.pte"
+          "${CMAKE_CURRENT_BINARY_DIR}/ModuleIndex.pte"
+          "${CMAKE_CURRENT_BINARY_DIR}/ModuleLinear.pte"
+          "${CMAKE_CURRENT_BINARY_DIR}/ModuleLinearProgram.pte"
+          "${CMAKE_CURRENT_BINARY_DIR}/_default_external_constant.ptd"
+          "${CMAKE_CURRENT_BINARY_DIR}/ModuleMultipleEntry.pte"
+          "${CMAKE_CURRENT_BINARY_DIR}/ModuleSimpleTrain.pte"
 )
 
 set(test_env
     "DEPRECATED_ET_MODULE_LINEAR_CONSTANT_BUFFER_PATH=${EXECUTORCH_ROOT}/test/models/deprecated/ModuleLinear-no-constant-segment.pte"
-    "ET_MODULE_ADD_HALF_PATH=${CMAKE_BINARY_DIR}/ModuleAddHalf.pte"
-    "ET_MODULE_ADD_PATH=${CMAKE_BINARY_DIR}/ModuleAdd.pte"
-    "ET_MODULE_DYNAMIC_CAT_UNALLOCATED_IO_PATH=${CMAKE_BINARY_DIR}/ModuleDynamicCatUnallocatedIO.pte"
-    "ET_MODULE_INDEX_PATH=${CMAKE_BINARY_DIR}/ModuleIndex.pte"
-    "ET_MODULE_LINEAR_PATH=${CMAKE_BINARY_DIR}/ModuleLinear.pte"
-    "ET_MODULE_LINEAR_PROGRAM_PATH=${CMAKE_BINARY_DIR}/ModuleLinearProgram.pte"
-    "ET_MODULE_LINEAR_DATA_PATH=${CMAKE_BINARY_DIR}/_default_external_constant.ptd"
-    "ET_MODULE_MULTI_ENTRY_PATH=${CMAKE_BINARY_DIR}/ModuleMultipleEntry.pte"
-    "ET_MODULE_SIMPLE_TRAIN_PATH=${CMAKE_BINARY_DIR}/ModuleSimpleTrain.pte"
+    "ET_MODULE_ADD_HALF_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleAddHalf.pte"
+    "ET_MODULE_ADD_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleAdd.pte"
+    "ET_MODULE_DYNAMIC_CAT_UNALLOCATED_IO_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleDynamicCatUnallocatedIO.pte"
+    "ET_MODULE_INDEX_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleIndex.pte"
+    "ET_MODULE_LINEAR_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleLinear.pte"
+    "ET_MODULE_LINEAR_PROGRAM_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleLinearProgram.pte"
+    "ET_MODULE_LINEAR_DATA_PATH=${CMAKE_CURRENT_BINARY_DIR}/_default_external_constant.ptd"
+    "ET_MODULE_MULTI_ENTRY_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleMultipleEntry.pte"
+    "ET_MODULE_SIMPLE_TRAIN_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleSimpleTrain.pte"
 )
 
 et_cxx_test(


### PR DESCRIPTION
### Summary
1. CMAKE_BINARY_DIR --> CMAKE_CURRENT_BINARY_DIR in `runtime/executor/test/CMakeLists.txt`. Test artifacts should be placed in the test directory (instead of the root)
2. Generate ModuleAdd artifact for extension_runner_util test (currently relying on the artifact generated by runtime/executor/test/CMakeLists.txt`
3. run `cmake-format -i CMakeLists.txt` on the above CMake files and the flat_tensor CMake files.

### Test plan
ci