### PR TITLE
[ArmBackend] Minor improvements to model unit tests

### DIFF
--- a/backends/arm/test/models/test_conformer.py
+++ b/backends/arm/test/models/test_conformer.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+def get_test_inputs(dim, lengths, num_examples):
+    return (torch.rand(num_examples, int(lengths.max()), dim), lengths)
+
+
 class TestConformer(unittest.TestCase):
     """Tests Torchaudio Conformer"""
 
@@ -41,8 +45,9 @@ class TestConformer(unittest.TestCase):
     }
 
     dim = 16
-    lengths = torch.randint(1, 100, (10,), dtype=torch.int32)
-    input_data = torch.rand(10, int(lengths.max()), dim)
+    num_examples = 10
+    lengths = torch.randint(1, 100, (num_examples,), dtype=torch.int32)
+    model_example_inputs = get_test_inputs(dim, lengths, num_examples)
     conformer = Conformer(
         input_dim=dim,
         num_heads=4,
@@ -56,7 +61,7 @@ class TestConformer(unittest.TestCase):
         (
             ArmTester(
                 self.conformer,
-                example_inputs=(self.input_data, self.lengths),
+                example_inputs=self.model_example_inputs,
                 compile_spec=common.get_tosa_compile_spec(tosa_spec="TOSA-0.80+MI"),
             )
             .export()
@@ -66,7 +71,9 @@ class TestConformer(unittest.TestCase):
             .to_executorch()
             # TODO(MLETORCH-632): Fix numerical errors
             .run_method_and_compare_outputs(
-                inputs=(self.input_data, self.lengths), rtol=1, atol=5
+                rtol=1.0,
+                atol=5.0,
+                inputs=get_test_inputs(self.dim, self.lengths, self.num_examples),
             )
         )
 
@@ -75,7 +82,7 @@ class TestConformer(unittest.TestCase):
         (
             ArmTester(
                 self.conformer,
-                example_inputs=(self.input_data, self.lengths),
+                example_inputs=self.model_example_inputs,
                 compile_spec=common.get_tosa_compile_spec(tosa_spec="TOSA-0.80+BI"),
             )
             .quantize()
@@ -83,7 +90,10 @@ class TestConformer(unittest.TestCase):
             .to_edge_transform_and_lower()
             .to_executorch()
             .run_method_and_compare_outputs(
-                qtol=1, rtol=1, atol=5, inputs=(self.input_data, self.lengths)
+                qtol=1.0,
+                rtol=1.0,
+                atol=5.0,
+                inputs=get_test_inputs(self.dim, self.lengths, self.num_examples),
             )
         )
 
@@ -92,7 +102,7 @@ class TestConformer(unittest.TestCase):
         tester = (
             ArmTester(
                 self.conformer,
-                example_inputs=(self.input_data, self.lengths),
+                example_inputs=self.model_example_inputs,
                 compile_spec=common.get_u55_compile_spec(),
             )
             .quantize()
@@ -103,7 +113,10 @@ class TestConformer(unittest.TestCase):
         )
         if conftest.is_option_enabled("corstone_fvp"):
             tester.run_method_and_compare_outputs(
-                atol=1.0, qtol=1, inputs=(self.input_data, self.lengths)
+                qtol=1.0,
+                rtol=1.0,
+                atol=5.0,
+                inputs=get_test_inputs(self.dim, self.lengths, self.num_examples),
             )
 
     @unittest.expectedFailure  # TODO(MLETORCH-635)
@@ -111,7 +124,7 @@ class TestConformer(unittest.TestCase):
         tester = (
             ArmTester(
                 self.conformer,
-                example_inputs=(self.input_data, self.lengths),
+                example_inputs=self.model_example_inputs,
                 compile_spec=common.get_u85_compile_spec(),
             )
             .quantize()
@@ -122,5 +135,8 @@ class TestConformer(unittest.TestCase):
         )
         if conftest.is_option_enabled("corstone_fvp"):
             tester.run_method_and_compare_outputs(
-                atol=1.0, qtol=1, inputs=(self.input_data, self.lengths)
+                qtol=1.0,
+                rtol=1.0,
+                atol=5.0,
+                inputs=get_test_inputs(self.dim, self.lengths, self.num_examples),
             )

--- a/backends/arm/test/models/test_dl3_arm.py
+++ b/backends/arm/test/models/test_dl3_arm.py
@@ -17,7 +17,7 @@ class TestDl3(unittest.TestCase):
     """Tests DeepLabv3."""
 
     dl3 = deeplab_v3.DeepLabV3ResNet50Model()
-    model_inputs = dl3.get_example_inputs()
+    model_example_inputs = dl3.get_example_inputs()
     dl3 = dl3.get_eager_model()
 
     @unittest.expectedFailure
@@ -25,13 +25,13 @@ class TestDl3(unittest.TestCase):
         (
             ArmTester(
                 self.dl3,
-                example_inputs=self.model_inputs,
+                example_inputs=self.model_example_inputs,
                 compile_spec=common.get_tosa_compile_spec("TOSA-0.80+MI"),
             )
             .export()
             .to_edge_transform_and_lower()
             .to_executorch()
-            .run_method_and_compare_outputs(self.model_inputs)
+            .run_method_and_compare_outputs(inputs=self.dl3.get_example_inputs())
         )
 
     @unittest.expectedFailure
@@ -39,14 +39,16 @@ class TestDl3(unittest.TestCase):
         (
             ArmTester(
                 self.dl3,
-                example_inputs=self.model_inputs,
+                example_inputs=self.model_example_inputs,
                 compile_spec=common.get_tosa_compile_spec("TOSA-0.80+BI"),
             )
             .quantize()
             .export()
             .to_edge_transform_and_lower()
             .to_executorch()
-            .run_method_and_compare_outputs(atol=1.0, qtol=1, inputs=self.model_inputs)
+            .run_method_and_compare_outputs(
+                atol=1.0, qtol=1, inputs=self.dl3.get_example_inputs()
+            )
         )
 
     @pytest.mark.slow
@@ -56,7 +58,7 @@ class TestDl3(unittest.TestCase):
         tester = (
             ArmTester(
                 self.dl3,
-                example_inputs=self.model_inputs,
+                example_inputs=self.model_example_inputs,
                 compile_spec=common.get_u55_compile_spec(),
             )
             .quantize()
@@ -67,7 +69,7 @@ class TestDl3(unittest.TestCase):
         )
         if conftest.is_option_enabled("corstone_fvp"):
             tester.run_method_and_compare_outputs(
-                atol=1.0, qtol=1, inputs=self.model_inputs
+                atol=1.0, qtol=1, inputs=self.dl3.get_example_inputs()
             )
 
     @pytest.mark.slow
@@ -77,7 +79,7 @@ class TestDl3(unittest.TestCase):
         tester = (
             ArmTester(
                 self.dl3,
-                example_inputs=self.model_inputs,
+                example_inputs=self.model_example_inputs,
                 compile_spec=common.get_u85_compile_spec(),
             )
             .quantize()
@@ -88,5 +90,5 @@ class TestDl3(unittest.TestCase):
         )
         if conftest.is_option_enabled("corstone_fvp"):
             tester.run_method_and_compare_outputs(
-                atol=1.0, qtol=1, inputs=self.model_inputs
+                atol=1.0, qtol=1, inputs=self.dl3.get_example_inputs()
             )

--- a/backends/arm/test/models/test_lstm_arm.py
+++ b/backends/arm/test/models/test_lstm_arm.py
@@ -16,6 +16,13 @@ from executorch.backends.arm.test.tester.arm_tester import ArmTester
 from torch.nn.quantizable.modules import rnn
 
 
+def get_test_inputs():
+    return (
+        torch.randn(5, 3, 10),  # input
+        (torch.randn(2, 3, 20), torch.randn(2, 3, 20)),  # (h0, c0)
+    )
+
+
 class TestLSTM(unittest.TestCase):
     """Tests quantizable LSTM module."""
 
@@ -27,31 +34,28 @@ class TestLSTM(unittest.TestCase):
     lstm = rnn.LSTM(10, 20, 2)
     lstm = lstm.eval()
 
-    input_tensor = torch.randn(5, 3, 10)
-    h0 = torch.randn(2, 3, 20)
-    c0 = torch.randn(2, 3, 20)
-
-    model_inputs = (input_tensor, (h0, c0))
+    # Used e.g. for quantization calibration and shape extraction in the tester
+    model_example_inputs = get_test_inputs()
 
     def test_lstm_tosa_MI(self):
         (
             ArmTester(
                 self.lstm,
-                example_inputs=self.model_inputs,
+                example_inputs=self.model_example_inputs,
                 compile_spec=common.get_tosa_compile_spec("TOSA-0.80+MI"),
             )
             .export()
             .to_edge_transform_and_lower()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(inputs=self.model_inputs)
+            .run_method_and_compare_outputs(inputs=get_test_inputs())
         )
 
     def test_lstm_tosa_BI(self):
         (
             ArmTester(
                 self.lstm,
-                example_inputs=self.model_inputs,
+                example_inputs=self.model_example_inputs,
                 compile_spec=common.get_tosa_compile_spec("TOSA-0.80+BI"),
             )
             .quantize()
@@ -59,14 +63,14 @@ class TestLSTM(unittest.TestCase):
             .to_edge_transform_and_lower()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(atol=3e-1, qtol=1, inputs=self.model_inputs)
+            .run_method_and_compare_outputs(atol=3e-1, qtol=1, inputs=get_test_inputs())
         )
 
     def test_lstm_u55_BI(self):
         tester = (
             ArmTester(
                 self.lstm,
-                example_inputs=self.model_inputs,
+                example_inputs=self.model_example_inputs,
                 compile_spec=common.get_u55_compile_spec(),
             )
             .quantize()
@@ -78,14 +82,14 @@ class TestLSTM(unittest.TestCase):
         )
         if conftest.is_option_enabled("corstone_fvp"):
             tester.run_method_and_compare_outputs(
-                atol=3e-1, qtol=1, inputs=self.model_inputs
+                atol=3e-1, qtol=1, inputs=get_test_inputs()
             )
 
     def test_lstm_u85_BI(self):
         tester = (
             ArmTester(
                 self.lstm,
-                example_inputs=self.model_inputs,
+                example_inputs=self.model_example_inputs,
                 compile_spec=common.get_u85_compile_spec(),
             )
             .quantize()
@@ -97,5 +101,5 @@ class TestLSTM(unittest.TestCase):
         )
         if conftest.is_option_enabled("corstone_fvp"):
             tester.run_method_and_compare_outputs(
-                atol=3e-1, qtol=1, inputs=self.model_inputs
+                atol=3e-1, qtol=1, inputs=get_test_inputs()
             )


### PR DESCRIPTION
* Tighten numerical tolerance for MobileNetV2 test and ensure randomness by using test fwk for generating test vectors
* Make sure to calibrate and test model with different data

Signed-off-by: Fredrik Knutsson <fredrik.knutsson@arm.com>



cc @digantdesai @per @zingo @oscarandersson8218