### PR TITLE
Add performance benchmark config: MPS 8da4w

### DIFF
--- a/.ci/scripts/gather_benchmark_configs.py
+++ b/.ci/scripts/gather_benchmark_configs.py
@@ -43,6 +43,7 @@ BENCHMARK_CONFIGS = {
         "coreml_fp16",
         "mps",
         "llama3_coreml_ane",
+        "llama3_mps_8da4w",
     ],
 }
 

--- a/.ci/scripts/tests/test_gather_benchmark_configs.py
+++ b/.ci/scripts/tests/test_gather_benchmark_configs.py
@@ -44,6 +44,7 @@ class TestGatehrBenchmarkConfigs(unittest.TestCase):
         self.assertIn("llama3_coreml_ane", ios_configs)
         self.assertIn("llama3_spinquant", ios_configs)
         self.assertIn("llama3_qlora", ios_configs)
+        self.assertIn("llama3_mps_8da4w", ios_configs)
 
     def test_skip_disabled_configs(self):
         # Use patch as a context manager to avoid modifying DISABLED_CONFIGS and BENCHMARK_CONFIGS
@@ -110,7 +111,7 @@ class TestGatehrBenchmarkConfigs(unittest.TestCase):
         result = self.gather_benchmark_configs.generate_compatible_configs(
             model_name, target_os
         )
-        expected = ["llama3_fb16", "llama3_coreml_ane"]
+        expected = ["llama3_fb16", "llama3_coreml_ane", "llama3_mps_8da4w"]
         self.assertEqual(result, expected)
 
         target_os = "android"

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -475,7 +475,7 @@ jobs:
       fail-fast: false
     with:
       # Due to scheduling a job may be pushed beyond the default 60m threshold
-      timeout: 120
+      timeout: 240
       device-type: ios
       # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS
       runner: linux.2xlarge

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -298,6 +298,23 @@ jobs:
                 --coreml-compute-units cpu_and_ne \
                 --output_name="${OUT_ET_MODEL_NAME}.pte"
               ls -lh "${OUT_ET_MODEL_NAME}.pte"
+            elif [[ ${{ matrix.config }} == "llama3_mps_8da4w" ]]; then
+              # MPS 8da4w
+              DOWNLOADED_PATH=$(bash .ci/scripts/download_hf_hub.sh --model_id "${HF_MODEL_REPO}" --subdir "original" --files "tokenizer.model" "params.json" "consolidated.00.pth")
+              ${CONDA_RUN} python -m examples.models.llama.export_llama \
+                --model "llama3_2" \
+                --checkpoint "${DOWNLOADED_PATH}/consolidated.00.pth" \
+                --params "${DOWNLOADED_PATH}/params.json" \
+                -kv \
+                --use_sdpa_with_kv_cache \
+                --disable_dynamic_shape \
+                --metadata '{"get_bos_id":128000, "get_eos_ids":[128009, 128001]}' \
+                --mps \
+                -qmode 8da4w \
+                --group_size 32 \
+                --embedding-quantize 4,32 \
+                --output_name="${OUT_ET_MODEL_NAME}.pte"
+              ls -lh "${OUT_ET_MODEL_NAME}.pte"
             else
               # By default, test with the Hugging Face model and the xnnpack recipe
               DOWNLOADED_PATH=$(bash .ci/scripts/download_hf_hub.sh --model_id "${HF_MODEL_REPO}" --subdir "original" --files "tokenizer.model")


### PR DESCRIPTION
Adds a new performance benchmark config to keep track of performance on MPS backend when running Llama 3.2 1B inference with 8da4w quantization
