### PR TITLE
[executorch][flat tensor] Store number of external tensors in flatbuffer

### DIFF
--- a/exir/emit/_emit_program.py
+++ b/exir/emit/_emit_program.py
@@ -163,6 +163,7 @@ def emit_program(
             operator_cache={},
             delegate_cache={},
             emit_stacktrace=emit_stacktrace,
+            num_external_constants=0,
         )
 
         gm = _remove_non_user_outputs(exported_program)

--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -143,6 +143,7 @@ class _EmitterState:
     """
 
     values: List[EValue]
+    num_external_constants: int
     operators: List[Operator]
     delegates: List[BackendDelegate]
     operator_cache: Dict[Tuple[str, str], int]
@@ -407,6 +408,7 @@ class _Emitter(torch.fx.Interpreter):
             self.program_state.external_constant_map[constant_tag][
                 spec.extra_tensor_info.fully_qualified_name  # pyre-ignore Undefined attribute [16]: `Optional` has no attribute `fully_qualified_name`.
             ] = buffer_idx
+            self.emitter_state.num_external_constants += 1
         # Tensor is mutable with initial state. Place into mutable segment
         elif allocation_info:
             buffer_idx = len(self.program_state.mutable_buffer)
@@ -1358,6 +1360,7 @@ class _Emitter(torch.fx.Interpreter):
                     delegates=[],
                     non_const_buffer_sizes=[0],
                     container_meta_type=ContainerMetadata("", spec),
+                    num_external_constants=0,
                 )
             )
         return plans
@@ -1739,4 +1742,5 @@ class _TopLevelEmitter(_Emitter):
                 self.module.meta["non_const_buffer_sizes"],
             ),
             container_meta_type=self.container_meta_type,
+            num_external_constants=self.emitter_state.num_external_constants,
         )

--- a/exir/schema.py
+++ b/exir/schema.py
@@ -276,6 +276,7 @@ class ExecutionPlan:
     # Runtime should use the len(constant_buffer) as the ground truch of
     # constant memory buffer size, and ignore non_const_buffer_sizes[0].
     non_const_buffer_sizes: List[int]
+    num_external_constants: int
 
 
 @dataclass

--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -359,11 +359,6 @@ class Method final {
   size_t num_external_constants_ = 0;
 
   /**
-   * Counts the number of external constants for this method.
-   */
-  ET_NODISCARD Result<size_t> get_num_external_constants();
-
-  /**
    * Parses the flatbuffer for constant tensors tagged as EXTERNAL.
    * Retrieves the external constants using the named_data_map and places them
    * into `external_constants_`.

--- a/schema/program.fbs
+++ b/schema/program.fbs
@@ -386,6 +386,8 @@ table ExecutionPlan {
   // constants memory buffer size, and ignore non_const_buffer_sizes[0].
   non_const_buffer_sizes: [int64];
 
+  // Number of external constants used in this ExecutionPlan.
+  num_external_constants: uint32;
 }
 
 // Constant tensor data stored directly in the flatbuffer.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8483
* #8447
* #8437

Store the number of external tensors in each ExecutionPlan.

This saves time during loading, as we can directly allocate memory for external tensors without doing a pass to count how many external tensors require allocation.

Differential Revision: [D69618283](https://our.internmc.facebook.com/intern/diff/D69618283/)