### PR TITLE
fix missing Buck dep for tensor_shape_to_c_string_test

### DIFF
--- a/runtime/core/exec_aten/util/test/targets.bzl
+++ b/runtime/core/exec_aten/util/test/targets.bzl
@@ -52,5 +52,6 @@ def define_common_targets():
         srcs = ["tensor_shape_to_c_string_test.cpp"],
         deps = [
             "//executorch/runtime/core/exec_aten/util:tensor_shape_to_c_string",
+            "//executorch/runtime/core/exec_aten/util:tensor_util",
         ],
     )


### PR DESCRIPTION
Test Plan: buck2 test //runtime/core/exec_aten/util/test:tensor_shape_to_c_string_test