### PR TITLE
patch op name discrepancy in oss

### DIFF
--- a/backends/cadence/aot/functions_hifi.yaml
+++ b/backends/cadence/aot/functions_hifi.yaml
@@ -204,10 +204,20 @@
     - arg_meta: null
       kernel_name: cadence::impl::HiFi::quantized_linear_out
 
+- func: cadence::quantized_linear.per_tensor_out(Tensor src, Tensor weight, Tensor bias, SymInt src_zero_point, SymInt weight_zero_point, SymInt out_multiplier, SymInt out_shift, SymInt out_zero_point, Tensor? offset, *, Tensor(a!) out) -> Tensor(a!)
+  kernels:
+    - arg_meta: null
+      kernel_name: cadence::impl::HiFi::quantized_linear_per_tensor_out
+
 - func: cadence::quantized_relu.out(Tensor X, Tensor X_zero_point, int out_zero_point, Tensor out_multiplier, Tensor out_shift, *, Tensor(a!) out) -> Tensor(a!)
   kernels:
     - arg_meta: null
       kernel_name: cadence::impl::HiFi::quantized_relu_out
+
+- func: cadence::quantized_relu.per_tensor_out(Tensor X, int X_zero_point, int out_zero_point, int out_multiplier, int out_shift, *, Tensor(a!) out) -> Tensor(a!)
+  kernels:
+    - arg_meta: null
+      kernel_name: cadence::impl::HiFi::quantized_relu_per_tensor_out
 
 - func: cadence::quantized_linear.per_tensor_out(Tensor src, Tensor weight, Tensor bias, SymInt src_zero_point, SymInt weight_zero_point, SymInt out_multiplier, SymInt out_shift, SymInt out_zero_point, Tensor? offset, *, Tensor(a!) out) -> Tensor(a!)
   kernels:

--- a/backends/cadence/hifi/operators/CMakeLists.txt
+++ b/backends/cadence/hifi/operators/CMakeLists.txt
@@ -76,8 +76,8 @@ target_include_directories(
 
 # Custom ops that are needed to run the test model.
 add_library(
-  custom_ops "quantized_linear_out.cpp" "quantized_layer_norm.cpp"
-             "quantize_per_tensor.cpp" "quantized_relu_out.cpp" "dequantize_per_tensor.cpp"
+  custom_ops "op_quantized_linear_out.cpp" "op_quantized_layer_norm.cpp"
+             "op_quantize_per_tensor.cpp" "op_quantized_relu_out.cpp" "op_dequantize_per_tensor.cpp"
 )
 target_include_directories(
   custom_ops PUBLIC ${ROOT_DIR}/.. ${CMAKE_BINARY_DIR}

--- a/backends/cadence/hifi/operators/op_clamp.cpp
+++ b/backends/cadence/hifi/operators/op_clamp.cpp
@@ -321,6 +321,16 @@ Tensor& clamp_Tensor_out(
 
   return out;
 }
+
+Tensor& clamp_tensor_out(
+    RuntimeContext& ctx,
+    const Tensor& in,
+    const executorch::aten::optional<Tensor>& min_opt,
+    const executorch::aten::optional<Tensor>& max_opt,
+    Tensor& out) {
+  clamp_Tensor_out(ctx, in, min_opt, max_opt, out);
+}
+
 } // namespace native
 } // namespace HiFi
 } // namespace impl

--- a/backends/cadence/hifi/operators/op_mean.cpp
+++ b/backends/cadence/hifi/operators/op_mean.cpp
@@ -168,6 +168,16 @@ Tensor& mean_out(
   return out;
 }
 
+Tensor& mean_dim_out(
+    RuntimeContext& ctx,
+    const Tensor& in,
+    optional<ArrayRef<int64_t>> dim_list,
+    bool keepdim,
+    optional<ScalarType> dtype,
+    Tensor& out) {
+  mean_out(ctx, in, dim_list, keepdim, dtype, out);
+}
+
 } // namespace native
 } // namespace HiFi
 } // namespace impl

--- a/backends/cadence/hifi/operators/op_quantized_relu_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_relu_out.cpp
@@ -75,6 +75,46 @@ void quantized_relu_per_tensor_out(
   }
 }
 
+void quantized_relu_per_tensor_out(
+    KernelRuntimeContext& ctx,
+    const Tensor& input,
+    const Tensor& in_zero_point,
+    const int64_t out_zero_point,
+    const Tensor& out_multiplier,
+    const Tensor& out_shift,
+    Tensor& output) {
+  int8_t _in_zero_point = in_zero_point.const_data_ptr<int8_t>()[0];
+  int32_t _out_multiplier = out_multiplier.const_data_ptr<int32_t>()[0];
+  int32_t _out_shift = out_shift.const_data_ptr<int32_t>()[0];
+
+  quantized_relu_per_tensor_out(
+      ctx,
+      input,
+      _in_zero_point,
+      out_zero_point,
+      _out_multiplier,
+      _out_shift,
+      output);
+}
+
+void quantized_relu_out(
+    KernelRuntimeContext& ctx,
+    const Tensor& input,
+    const int64_t in_zero_point,
+    const int64_t out_zero_point,
+    const int64_t out_multiplier,
+    const int64_t out_shift,
+    Tensor& output) {
+  quantized_relu_per_tensor_out(
+      ctx,
+      input,
+      in_zero_point,
+      out_zero_point,
+      out_multiplier,
+      out_shift,
+      output);
+}
+
 } // namespace native
 } // namespace HiFi
 } // namespace impl

--- a/backends/cadence/hifi/operators/op_softmax.cpp
+++ b/backends/cadence/hifi/operators/op_softmax.cpp
@@ -194,6 +194,15 @@ Tensor& _softmax_out(
   return out;
 }
 
+Tensor& softmax_out(
+    KernelRuntimeContext& ctx,
+    const Tensor& in,
+    int64_t dim,
+    bool half_to_float,
+    Tensor& out) {
+  _softmax_out(ctx, in, dim, half_to_float, out);
+}
+
 } // namespace native
 } // namespace HiFi
 } // namespace impl


### PR DESCRIPTION
Summary:
1. Few of the operators are renamed:

quantized_relu_out --> quantized_relu_per_tensor_out
where_out --> where_self_out
mean_dim_out --> mean
softmax_out --> __softmax_out
clamp_tensor_out --> clamp_Tensor_out
corresponding .yml (functions_hifi.yaml)   needs to be updated.

2. Name changes of quantize files from

quantized_linear_out.cpp, quantized_layer_norm.cpp,quantized_fully_connected_out.cpp,
quantize_per_tensor.cpp,quantized_relu_out.cpp,dequantize_per_tensor.cpp
to
op_quantized_linear_out.cpp, op_quantized_layer_norm.cpp,op_quantized_fully_connected_out.cpp,
op_quantize_per_tensor.cpp,op_quantized_relu_out.cpp,op_dequantize_per_tensor.cpp 

CMakeLists.txt has to be changed to change the file names.

3. yml file has to be changed for quantized kernels to use per_tensor_out versions.

Differential Revision: D69568677


