### PR TITLE
Add python-dev install to FAQ

### DIFF
--- a/docs/source/getting-started-faqs.md
+++ b/docs/source/getting-started-faqs.md
@@ -4,6 +4,16 @@ This page summarizes frequently asked questions and provides guidance on issues 
 
 If a specific issue is not covered here, consider searching for or creating an issue on GitHub under [Issues](https://github.com/pytorch/executorch/issues) or [Discussions](https://github.com/pytorch/executorch/discussions).
 
+## Installation
+
+### Missing /usr/include/python3.x
+
+Most likely `python-dev` library needs to be installed. Please run
+```
+sudo apt install python<version>-dev
+```
+if you are using Ubuntu, or use an equivalent install command.
+
 ## Export
 
 ### Missing out variants: { _ }


### PR DESCRIPTION
Summary:
#8489
Adding instructions for users to install python-dev library as a prerequisite of installing ExecuTorch

Differential Revision: D69680232




cc @mergennachin @byjlw