### PR TITLE
Enable dtype selective build by default

### DIFF
--- a/shim/xplat/executorch/codegen/codegen.bzl
+++ b/shim/xplat/executorch/codegen/codegen.bzl
@@ -488,7 +488,7 @@ def executorch_generated_lib(
         platforms = get_default_executorch_platforms(),
         compiler_flags = [],
         kernel_deps = [],
-        dtype_selective_build = False,
+        dtype_selective_build = True,
         feature = None,
         expose_operator_symbols = False,
         support_exceptions = True):


### PR DESCRIPTION
Summary: Now that dtype selective build is relatively mature and well-supported, let's try enabling it by default. There have been a few cases where operator libs in production were built without dtype selective build and ended up much larger than they need to be.

Differential Revision: D69686466


