### PR TITLE
Move iOS docs to top, add Android placeholders

### DIFF
--- a/docs/source/using-executorch-android.md
+++ b/docs/source/using-executorch-android.md
@@ -1,3 +1,23 @@
 # Using ExecuTorch on Android
 
-Placeholder for top-level Android documentation
+To use from Android, ExecuTorch provides Java API bindings and Android platform integration, available as a AAR file. The ExecuTorch C++ APIs can also be used from Android native.
+
+## Installation
+
+TODO Instructions on downloading the pre-built AAR. Replace with Maven/Gradle package management when available.
+
+### Building from Source
+
+TODO Instructions on re-creating and customizing the Android AAR.
+
+## Android Backends
+
+TODO Describe commonly used backends, including XNN, Vulkan, and NPUs.
+
+## Runtime Integration
+
+TODO Code sample in Java
+
+## Next Steps
+
+TODO Link to Java API reference and other relevant material

--- a/docs/source/using-executorch-ios.md
+++ b/docs/source/using-executorch-ios.md
@@ -1,3 +1,0 @@
-# Using ExecuTorch on iOS
-
-Placeholder for top-level iOS documentation

--- a/docs/source/using-executorch-ios.md
+++ b/docs/source/using-executorch-ios.md
@@ -1,6 +1,8 @@
-# Integrating and Running ExecuTorch on Apple Platforms
+# Using ExecuTorch on iOS
 
-**Author:** [Anthony Shoumikhin](https://github.com/shoumikhin)
+ExecuTorch supports both iOS and macOS via Objective-C, Swift, and C++. ExecuTorch also provides backends to leverage Core ML and Metal Performance Shaders (MPS) for hardware-accelerated execution on Apple platforms.
+
+## Integration
 
 The ExecuTorch Runtime for iOS and macOS is distributed as a collection of prebuilt [.xcframework](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle) binary targets. These targets are compatible with both iOS and macOS devices and simulators and are available in both release and debug modes:
 
@@ -16,8 +18,6 @@ The ExecuTorch Runtime for iOS and macOS is distributed as a collection of prebu
 Link your binary with the ExecuTorch runtime and any backends or kernels used by the exported ML model. It is recommended to link the core runtime to the components that use ExecuTorch directly, and link kernels and backends against the main app target.
 
 **Note:** To access logs, link against the Debug build of the ExecuTorch runtime, i.e., the `executorch_debug` framework. For optimal performance, always link against the Release version of the deliverables (those without the `_debug` suffix), which have all logging overhead removed.
-
-## Integration
 
 ### Swift Package Manager
 
@@ -84,9 +84,9 @@ swift package resolve
 swift build
 ```
 
-### Local Build
+### Building from Source
 
-Another way to integrate the ExecuTorch runtime is to build the necessary components from sources locally and link against them. This route is more involved but certainly doable.
+Another way to integrate the ExecuTorch runtime is to build the necessary components from sources locally and link against them. This is useful when customizing the runtime.
 
 1. Install [Xcode](https://developer.apple.com/xcode/resources/) 15+ and Command Line Tools:
 
@@ -195,7 +195,7 @@ import ExecuTorch
 
 ### Logging
 
-We provide extra APIs for logging in Objective-C and Swift as a lightweight wrapper of the internal ExecuTorch machinery. To use it, just import the main framework header in Objective-C. Then use the `ExecuTorchLog` interface (or the `Log` class in Swift) to subscribe your own implementation of the `ExecuTorchLogSink` protocol (or `LogSink` in Swift) to listen to log events.
+ExecuTorch provides extra APIs for logging in Objective-C and Swift as a lightweight wrapper of the internal ExecuTorch machinery. To use it, just import the main framework header in Objective-C. Then use the `ExecuTorchLog` interface (or the `Log` class in Swift) to subscribe your own implementation of the `ExecuTorchLogSink` protocol (or `LogSink` in Swift) to listen to log events.
 
 ```objectivec
 #import <ExecuTorch/ExecuTorch.h>


### PR DESCRIPTION
### Summary
Move Apple platform docs up to the top level. Add Android doc placeholders.

### Test plan
Built docs locally.