### PR TITLE
Allow getting all backend names

### DIFF
--- a/extension/pybindings/portable_lib.py
+++ b/extension/pybindings/portable_lib.py
@@ -38,6 +38,7 @@ from executorch.extension.pybindings._portable_lib import (  # noqa: F401
     _create_profile_block,  # noqa: F401
     _dump_profile_results,  # noqa: F401
     _get_operator_names,  # noqa: F401
+    _get_registered_backend_names,  # noqa: F401
     _load_bundled_program_from_buffer,  # noqa: F401
     _load_for_executorch,  # noqa: F401
     _load_for_executorch_from_buffer,  # noqa: F401

--- a/extension/pybindings/pybindings.pyi
+++ b/extension/pybindings/pybindings.pyi
@@ -221,6 +221,15 @@ def _get_operator_names() -> List[str]:
     ...
 
 @experimental("This API is experimental and subject to change without notice.")
+def _get_registered_backend_names() -> List[str]:
+    """
+    .. warning::
+
+        This API is experimental and subject to change without notice.
+    """
+    ...
+
+@experimental("This API is experimental and subject to change without notice.")
 def _create_profile_block(name: str) -> None:
     """
     .. warning::

--- a/extension/pybindings/test/TARGETS
+++ b/extension/pybindings/test/TARGETS
@@ -47,3 +47,11 @@ runtime.python_test(
         "//executorch/kernels/quantized:aot_lib",
     ],
 )
+
+runtime.python_test(
+    name = "test_backend_pybinding",
+    srcs = ["test_backend_pybinding.py"],
+    deps = [
+        "//executorch/runtime:runtime",
+    ],
+)

--- a/extension/pybindings/test/test_backend_pybinding.py
+++ b/extension/pybindings/test/test_backend_pybinding.py
@@ -1,0 +1,14 @@
+import unittest
+
+from executorch.runtime import Runtime
+
+
+class TestBackendsPybinding(unittest.TestCase):
+    def test_backend_name_list(
+        self,
+    ) -> None:
+
+        runtime = Runtime.get()
+        registered_backend_names = runtime.backend_registry.registered_backend_names
+        self.assertGreaterEqual(len(registered_backend_names), 1)
+        self.assertIn("XnnpackBackend", registered_backend_names)

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -42,7 +42,7 @@ Example output:
 import functools
 from pathlib import Path
 from types import ModuleType
-from typing import Any, BinaryIO, Dict, Optional, Sequence, Set, Union
+from typing import Any, BinaryIO, Dict, List, Optional, Sequence, Set, Union
 
 try:
     from executorch.extension.pybindings.portable_lib import (
@@ -125,6 +125,21 @@ class Program:
         return self._methods.get(name, None)
 
 
+class BackendRegistry:
+    """The registry of backends that are available to the runtime."""
+
+    def __init__(self, legacy_module: ModuleType) -> None:
+        # TODO: Expose the kernel callables to Python.
+        self._legacy_module = legacy_module
+
+    @property
+    def registered_backend_names(self) -> List[str]:
+        """
+        Returns the names of all registered backends as a list of strings.
+        """
+        return self._legacy_module._get_registered_backend_names()
+
+
 class OperatorRegistry:
     """The registry of operators that are available to the runtime."""
 
@@ -157,6 +172,7 @@ class Runtime:
 
     def __init__(self, *, legacy_module: ModuleType) -> None:
         # Public attributes.
+        self.backend_registry = BackendRegistry(legacy_module)
         self.operator_registry = OperatorRegistry(legacy_module)
         # Private attributes.
         self._legacy_module = legacy_module

--- a/runtime/backend/interface.cpp
+++ b/runtime/backend/interface.cpp
@@ -55,5 +55,16 @@ Error register_backend(const Backend& backend) {
   return Error::Ok;
 }
 
+size_t get_num_registered_backends() {
+  return num_registered_backends;
+}
+
+Result<const char*> get_backend_name(size_t index) {
+  if (index >= num_registered_backends) {
+    return Error::InvalidArgument;
+  }
+  return registered_backends[index].name;
+}
+
 } // namespace runtime
 } // namespace executorch

--- a/runtime/backend/interface.h
+++ b/runtime/backend/interface.h
@@ -139,6 +139,16 @@ struct Backend {
  */
 ET_NODISCARD Error register_backend(const Backend& backend);
 
+/**
+ * Returns the number of registered backends.
+ */
+size_t get_num_registered_backends();
+
+/**
+ * Returns the backend name at the given index.
+ */
+Result<const char*> get_backend_name(size_t index);
+
 } // namespace runtime
 } // namespace executorch
 


### PR DESCRIPTION
Summary: Allow getting all backends name in both python and c++

Differential Revision: D69691354


