### PR TITLE
Allow querying all backends registered with the executorch runtime

### DIFF
--- a/runtime/backend/interface.cpp
+++ b/runtime/backend/interface.cpp
@@ -41,6 +41,14 @@ BackendInterface* get_backend_class(const char* name) {
   return nullptr;
 }
 
+std::vector<BackendInterface*> get_all_backend_classes() {
+  std::vector<BackendInterface*> backends(num_registered_backends);
+  for (size_t i = 0; i < num_registered_backends; i++) {
+    backends[i] = registered_backends[i].backend;
+  }
+  return backends;
+}
+
 Error register_backend(const Backend& backend) {
   if (num_registered_backends >= kMaxRegisteredBackends) {
     return Error::Internal;

--- a/runtime/backend/interface.h
+++ b/runtime/backend/interface.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstring>
+#include <vector>
 
 #include <executorch/runtime/backend/backend_execution_context.h>
 #include <executorch/runtime/backend/backend_init_context.h>
@@ -119,6 +120,12 @@ class BackendInterface {
  *         Nullptr if it can't find anything with the given name.
  */
 BackendInterface* get_backend_class(const char* name);
+
+/**
+ * Returns the vector of pointers to all the registered backends.
+ * The mapping is populated using register_backend method.
+ */
+std::vector<BackendInterface*> get_all_backend_classes();
 
 /**
  * A named instance of a backend.

--- a/runtime/executor/test/backend_integration_test.cpp
+++ b/runtime/executor/test/backend_integration_test.cpp
@@ -330,6 +330,13 @@ TEST_P(BackendIntegrationTest, BackendIsPresent) {
   ASSERT_EQ(backend, &StubBackend::singleton());
 }
 
+TEST_P(BackendIntegrationTest, BackendIsPresentInAll) {
+  std::vector<BackendInterface*> backends =
+      executorch::runtime::get_all_backend_classes();
+  ASSERT_EQ(backends.size(), 1);
+  ASSERT_EQ(backends[0], &StubBackend::singleton());
+}
+
 // Demonstrate that installed StubBackend initializes successfully by default.
 TEST_P(BackendIntegrationTest, BasicInitSucceeds) {
   Result<FileDataLoader> loader = FileDataLoader::from(program_path());


### PR DESCRIPTION
Summary: Partially resolves: https://github.com/pytorch/executorch/issues/8267

Differential Revision: D69754074


