### PR TITLE
Re-sync c10 to runtime/core/portable_type

### DIFF
--- a/runtime/core/portable_type/c10/c10/macros/Export.h
+++ b/runtime/core/portable_type/c10/c10/macros/Export.h
@@ -139,8 +139,10 @@
 #endif
 
 #if defined(TORCH_HIP_BUILD_MAIN_LIB)
+#define TORCH_HIP_CPP_API C10_EXPORT
 #define TORCH_HIP_API C10_EXPORT
 #else
+#define TORCH_HIP_CPP_API C10_IMPORT
 #define TORCH_HIP_API C10_IMPORT
 #endif
 

--- a/runtime/core/portable_type/c10/c10/util/BFloat16.h
+++ b/runtime/core/portable_type/c10/c10/util/BFloat16.h
@@ -8,9 +8,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iosfwd>
-#ifndef C10_EMBEDDED
 #include <ostream>
-#endif // C10_EMBEDDED
 
 #if defined(__CUDACC__) && !defined(USE_ROCM)
 #include <cuda_bf16.h>
@@ -116,14 +114,12 @@ struct alignas(2) BFloat16 {
 #endif
 };
 
-#ifndef C10_EMBEDDED
 C10_API inline std::ostream& operator<<(
     std::ostream& out,
     const BFloat16& value) {
   out << (float)value;
   return out;
 }
-#endif // C10_EMBEDDED
 
 } // namespace c10
 

--- a/runtime/core/portable_type/c10/c10/util/Half.h
+++ b/runtime/core/portable_type/c10/c10/util/Half.h
@@ -29,9 +29,7 @@
 #include <cstring>
 #include <iosfwd>
 #include <limits>
-#ifndef C10_EMBEDDED
 #include <ostream>
-#endif // C10_EMBEDDED
 
 #ifdef __CUDACC__
 #include <cuda_fp16.h>
@@ -411,12 +409,10 @@ struct alignas(2) Half {
 #endif
 };
 
-#ifndef C10_EMBEDDED
 C10_API inline std::ostream& operator<<(std::ostream& out, const Half& value) {
   out << (float)value;
   return out;
 }
-#endif // C10_EMBEDDED
 
 } // namespace c10
 


### PR DESCRIPTION
No material changes, but let's keep it in sync