### PR TITLE
Fix unsqueeze optimize pass

### DIFF
--- a/backends/transforms/view_copy_to_squeeze_unsqueeze.py
+++ b/backends/transforms/view_copy_to_squeeze_unsqueeze.py
@@ -75,7 +75,11 @@ class ViewCopyToSqueezeUnsqueezePass(ExportPass):
         j = 0
         idx = -1
         while j < len(view_shape):
-            if input_shape[i] != view_shape[j]:
+            # account for added dim being last dim in view_shape
+            if i == j and j == len(input_shape):
+                if view_shape[j] != 1:
+                    return None
+            elif input_shape[i] != view_shape[j]:
                 if view_shape[j] == 1:
                     idx = j
                     i -= 1


### PR DESCRIPTION
Summary:

When exporting one of my models, I got an expection in `find_unsqueeze_dim`. Debugging showed that this happened with `input_shape=[256]` and `view_shape=[256, 1]` (i.e. when we want to unsqueeze the last dimension). I modified the code to account for this.

Reviewed By: nathanaelsee

Differential Revision: D69812661


