### PR TITLE
Fix XNN backend in pybindings by not linking backend runtime targets in AOT lib

### DIFF
--- a/backends/backends.bzl
+++ b/backends/backends.bzl
@@ -9,7 +9,7 @@ def get_all_cpu_backend_targets():
         "//executorch/backends/fb/qnnpack:qnnpack_backend",
     ]
 
-def get_all_cpu_aot_and_backend_targets():
+def get_all_cpu_aot_targets():
     """Returns a list of all CPU backend targets with aot (ahead of time).
 
     For experimenting and testing, not for production, since it will typically
@@ -20,4 +20,7 @@ def get_all_cpu_aot_and_backend_targets():
         "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
         "//executorch/backends/fb/qnnpack:qnnpack_preprocess",
         "//executorch/backends/fb/qnnpack/partition:qnnpack_partitioner",
-    ] + get_all_cpu_backend_targets()
+    ]
+
+def get_all_cpu_aot_and_backend_targets():
+    return get_all_cpu_aot_targets() + get_all_cpu_backend_targets()

--- a/exir/backend/TARGETS
+++ b/exir/backend/TARGETS
@@ -1,7 +1,7 @@
 # Any targets that should be shared between fbcode and xplat must be defined in
 # targets.bzl. This file can contain fbcode-only targets.
 
-load("@fbsource//xplat/executorch/backends:backends.bzl", "get_all_cpu_aot_and_backend_targets")
+load("@fbsource//xplat/executorch/backends:backends.bzl", "get_all_cpu_aot_targets")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load(":targets.bzl", "define_common_targets")
 
@@ -91,7 +91,7 @@ runtime.python_library(
         ":backend_details",
         ":utils",
         "//executorch/exir/backend/canonical_partitioners:canonical_partitioner_lib",
-    ] + get_all_cpu_aot_and_backend_targets(),
+    ] + get_all_cpu_aot_targets(),
 )
 
 runtime.python_library(


### PR DESCRIPTION
Summary:
The XNNPACK backend is getting optimized out in bento kernel builds. This is primarily due to the static registration mechanism getting stripped out, I believe due to nothing referencing the static registration. I don't fully understand why link_whole isn't solving this in fbcode bento kernel builds - is it ignoring it? I found that the xnnpack_backend target is getting linked as part of a python target (exir/backend:backend_lib), which doesn't seem to do anything, but does cause the xnnpack_backend target to get built as a shared lib on fbcode, presumably because it's linked in multiple places.

It's a bit fragile still, but removing the unused runtime deps from the exir backend target resolves this and allows for use of backends from optimized bento kernel builds. Ideally, we'll have a better solution for this in the long term, but fbcode doesn't seem to expose as many build configurations - which makes it hard to cleanly fix without tearing out the entire static registration system. We could also do something hacky where we add a direct reference to each backend in pybindings.cpp, but hopefully we don't have to do that.

Differential Revision: D69849562


