### PR TITLE
Arm: Add aten.relu_.default to quantization_annotator

### DIFF
--- a/backends/arm/quantizer/quantization_annotator.py
+++ b/backends/arm/quantizer/quantization_annotator.py
@@ -183,6 +183,7 @@ _parent_shared_qspec = [
     torch.ops.aten.hardtanh.default,
     torch.ops.aten.hardtanh_.default,
     torch.ops.aten.relu.default,
+    torch.ops.aten.relu_.default,
     torch.ops.aten.mean.default,
     torch.ops.aten.mean.dim,
     torch.ops.aten.permute.default,


### PR DESCRIPTION
* The inplace version of relu (aten.relu_.default) was missing

Signed-off-by: Tom Allsop <tom.allsop@arm.com>

Change-Id: I08ae3fdc88b7fe569833a6111ab254ec8780fb14

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218