### PR TITLE
Arm: support files with prefix "ops_"

### DIFF
--- a/backends/arm/operators/TARGETS
+++ b/backends/arm/operators/TARGETS
@@ -13,7 +13,7 @@ python_library(
 
 python_library(
     name = "ops",
-    srcs = glob(["op_*.py"]),
+    srcs = glob(["op_*.py", "ops_*.py"]),
     typing = True,
     deps = [
         "fbsource//third-party/serialization_lib/python/tosa:tosa",


### PR DESCRIPTION
Summary:
D69765254 (#8518) adds a file named `ops_binary.py` which doesn't match the current pattern of `op_*.py` files in this directory.

Update the glob so that this new file will be picked up by the buck2 build, silencing a type-checking issue.

Differential Revision: D69878804


