### PR TITLE
Arm backend: Add missing __init__.py to passes

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -1,0 +1,47 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from . import arm_pass_utils  # noqa
+from .annotate_channels_last_dim_order_pass import AnnotateChannelsLastDimOrder  # noqa
+from .annotate_decomposed_matmul import AnnotateDecomposedMatmulPass  # noqa
+from .cast_int64_pass import CastInt64ToInt32Pass  # noqa
+from .conv1d_unsqueeze_pass import Conv1dUnsqueezePass  # noqa
+from .convert_any_default_dim_dims_pass import ConvertAnyDefaultDimDimsPass  # noqa
+from .convert_expand_copy_to_repeat import ConvertExpandCopyToRepeatPass  # noqa
+from .convert_full_like_to_full_pass import ConvertFullLikeToFullPass  # noqa
+from .convert_minmax_pass import ConvertMinMaxPass  # noqa
+from .convert_split_to_slice import ConvertSplitToSlicePass  # noqa
+from .convert_squeezes_to_view import ConvertSqueezesToViewPass  # noqa
+from .convert_to_clamp import ConvertToClampPass  # noqa
+from .decompose_batchnorm_pass import DecomposeBatchNormPass  # noqa
+from .decompose_div_pass import DecomposeDivPass  # noqa
+from .decompose_layernorm_pass import DecomposeLayerNormPass  # noqa
+from .decompose_linear_pass import DecomposeLinearPass  # noqa
+from .decompose_meandim_pass import DecomposeMeanDimPass  # noqa
+from .decompose_select import DecomposeSelectPass  # noqa
+from .decompose_softmax_pass import DecomposeSoftmaxPass  # noqa
+from .decompose_softmax_unstable_pass import DecomposeSoftmaxUnstablePass  # noqa
+from .decompose_var_pass import DecomposeVarPass  # noqa
+from .fold_qdq_with_annotated_qparams_pass import (  # noqa
+    FoldAndAnnotateQParamsPass,
+    QuantizeOperatorArguments,
+    RetraceFoldedDtypesPass,
+)
+from .fuse_batchnorm2d_pass import FuseBatchnorm2DPass  # noqa
+from .fuse_constant_ops_pass import ComputeConstantOpsAOT, FuseConstantArgsPass  # noqa
+from .fuse_quantized_activation_pass import FuseQuantizedActivationPass  # noqa
+from .insert_rescales_pass import InsertRescalePass  # noqa
+from .insert_table_ops import InsertTableOpsPass  # noqa
+from .keep_dims_false_to_squeeze_pass import KeepDimsFalseToSqueezePass  # noqa
+from .match_arg_ranks_pass import MatchArgRanksPass  # noqa
+from .meandim_to_averagepool_pass import ConvertMeanDimToAveragePoolPass  # noqa
+from .mm_to_bmm_pass import ConvertMmToBmmPass  # noqa
+from .remove_clone_pass import RemoveClonePass  # noqa
+from .scalars_to_attribute_pass import ScalarsToAttributePass  # noqa
+from .size_adjust_conv2d_pass import SizeAdjustConv2DPass  # noqa
+from .unsqueeze_before_repeat_pass import UnsqueezeBeforeRepeatPass  # noqa
+from .unsqueeze_scalar_placeholders_pass import UnsqueezeScalarPlaceholdersPass  # noqa
+from .arm_pass_manager import ArmPassManager  # noqa  # usort: skip

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -7,82 +7,44 @@
 
 # pyre-unsafe
 
-from executorch.backends.arm._passes.annotate_channels_last_dim_order_pass import (
+from executorch.backends.arm._passes import (
     AnnotateChannelsLastDimOrder,
-)
-from executorch.backends.arm._passes.annotate_decomposed_matmul import (
     AnnotateDecomposedMatmulPass,
-)
-from executorch.backends.arm._passes.cast_int64_pass import CastInt64ToInt32Pass
-from executorch.backends.arm._passes.conv1d_unsqueeze_pass import Conv1dUnsqueezePass
-from executorch.backends.arm._passes.convert_any_default_dim_dims_pass import (
-    ConvertAnyDefaultDimDimsPass,
-)
-from executorch.backends.arm._passes.convert_expand_copy_to_repeat import (
-    ConvertExpandCopyToRepeatPass,
-)
-from executorch.backends.arm._passes.convert_full_like_to_full_pass import (
-    ConvertFullLikeToFullPass,
-)
-from executorch.backends.arm._passes.convert_minmax_pass import ConvertMinMaxPass
-from executorch.backends.arm._passes.convert_split_to_slice import (
-    ConvertSplitToSlicePass,
-)
-from executorch.backends.arm._passes.convert_squeezes_to_view import (  # type: ignore[import-not-found]
-    ConvertSqueezesToViewPass,
-)
-from executorch.backends.arm._passes.convert_to_clamp import ConvertToClampPass
-from executorch.backends.arm._passes.decompose_batchnorm_pass import (
-    DecomposeBatchNormPass,
-)
-from executorch.backends.arm._passes.decompose_div_pass import DecomposeDivPass
-from executorch.backends.arm._passes.decompose_layernorm_pass import (
-    DecomposeLayerNormPass,
-)
-from executorch.backends.arm._passes.decompose_linear_pass import DecomposeLinearPass
-from executorch.backends.arm._passes.decompose_meandim_pass import DecomposeMeanDimPass
-from executorch.backends.arm._passes.decompose_select import (  # type: ignore[import-not-found]
-    DecomposeSelectPass,
-)
-from executorch.backends.arm._passes.decompose_softmax_pass import DecomposeSoftmaxPass
-from executorch.backends.arm._passes.decompose_softmax_unstable_pass import (
-    DecomposeSoftmaxUnstablePass,
-)
-from executorch.backends.arm._passes.decompose_var_pass import DecomposeVarPass
-from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
-    FoldAndAnnotateQParamsPass,
-    QuantizeOperatorArguments,
-    RetraceFoldedDtypesPass,
-)
-from executorch.backends.arm._passes.fuse_batchnorm2d_pass import FuseBatchnorm2DPass
-from executorch.backends.arm._passes.fuse_constant_ops_pass import (
+    CastInt64ToInt32Pass,
     ComputeConstantOpsAOT,
-    FuseConstantArgsPass,
-)
-from executorch.backends.arm._passes.fuse_quantized_activation_pass import (  # type: ignore[import-not-found]
-    FuseQuantizedActivationPass,
-)
-from executorch.backends.arm._passes.insert_rescales_pass import InsertRescalePass
-from executorch.backends.arm._passes.insert_table_ops import InsertTableOpsPass
-from executorch.backends.arm._passes.keep_dims_false_to_squeeze_pass import (
-    KeepDimsFalseToSqueezePass,
-)
-from executorch.backends.arm._passes.match_arg_ranks_pass import MatchArgRanksPass
-from executorch.backends.arm._passes.meandim_to_averagepool_pass import (  # type: ignore[attr-defined]
+    Conv1dUnsqueezePass,
+    ConvertAnyDefaultDimDimsPass,
+    ConvertExpandCopyToRepeatPass,
+    ConvertFullLikeToFullPass,
     ConvertMeanDimToAveragePoolPass,
-)
-from executorch.backends.arm._passes.mm_to_bmm_pass import (  # type: ignore[import-not-found]
+    ConvertMinMaxPass,
     ConvertMmToBmmPass,
-)
-from executorch.backends.arm._passes.remove_clone_pass import RemoveClonePass
-from executorch.backends.arm._passes.scalars_to_attribute_pass import (
+    ConvertSplitToSlicePass,
+    ConvertSqueezesToViewPass,
+    ConvertToClampPass,
+    DecomposeBatchNormPass,
+    DecomposeDivPass,
+    DecomposeLayerNormPass,
+    DecomposeLinearPass,
+    DecomposeMeanDimPass,
+    DecomposeSelectPass,
+    DecomposeSoftmaxPass,
+    DecomposeSoftmaxUnstablePass,
+    DecomposeVarPass,
+    FoldAndAnnotateQParamsPass,
+    FuseBatchnorm2DPass,
+    FuseConstantArgsPass,
+    FuseQuantizedActivationPass,
+    InsertRescalePass,
+    InsertTableOpsPass,
+    KeepDimsFalseToSqueezePass,
+    MatchArgRanksPass,
+    QuantizeOperatorArguments,
+    RemoveClonePass,
+    RetraceFoldedDtypesPass,
     ScalarsToAttributePass,
-)
-from executorch.backends.arm._passes.size_adjust_conv2d_pass import SizeAdjustConv2DPass
-from executorch.backends.arm._passes.unsqueeze_before_repeat_pass import (
+    SizeAdjustConv2DPass,
     UnsqueezeBeforeRepeatPass,
-)
-from executorch.backends.arm._passes.unsqueeze_scalar_placeholders_pass import (
     UnsqueezeScalarPlaceholdersPass,
 )
 from executorch.backends.arm.tosa_specification import Tosa_0_80, TosaSpecification

--- a/backends/arm/operators/op_avg_pool2d.py
+++ b/backends/arm/operators/op_avg_pool2d.py
@@ -9,7 +9,6 @@ from typing import List
 import serializer.tosa_serializer as ts  # type: ignore
 import torch
 
-# pyre-fixme[21]: ' Could not find a module corresponding to import `executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass`
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_input_qparams,
     get_output_qparams,
@@ -88,10 +87,10 @@ class AvgPool2dVisitor_0_80_BI(NodeVisitor):
 
         accumulator_type = ts.DType.INT32
 
-        input_qargs = get_input_qparams(node)  # pyre-ignore[16]
+        input_qargs = get_input_qparams(node)
         input_zp = input_qargs[0].zp
 
-        output_qargs = get_output_qparams(node)  # pyre-ignore[16]
+        output_qargs = get_output_qparams(node)
         output_zp = output_qargs[0].zp
 
         self._build_generic_avgpool2d(

--- a/backends/arm/operators/op_bmm.py
+++ b/backends/arm/operators/op_bmm.py
@@ -10,7 +10,6 @@ from typing import List
 import serializer.tosa_serializer as ts  # type: ignore
 import torch
 
-# pyre-fixme[21]: 'Could not find a module corresponding to import `executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass`.'
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_input_qparams,
     get_output_qparams,
@@ -51,7 +50,7 @@ class BMMVisitor(NodeVisitor):
         # for a later rescale.
 
         if inputs[0].dtype == ts.DType.INT8:
-            input_qparams = get_input_qparams(node)  # pyre-ignore[16]
+            input_qparams = get_input_qparams(node)
             input0_zp = input_qparams[0].zp
             input1_zp = input_qparams[1].zp
             bmm_result = tosa_graph.addIntermediate(output.shape, ts.DType.INT32)
@@ -73,7 +72,7 @@ class BMMVisitor(NodeVisitor):
 
         # As INT8 accumulates into INT32, we need to rescale it back to INT8
         if output.dtype == ts.DType.INT8:
-            output_qparams = get_output_qparams(node)[0]  # pyre-ignore[16]
+            output_qparams = get_output_qparams(node)[0]
             final_output_scale = (
                 input_qparams[0].scale * input_qparams[1].scale  # type: ignore[possibly-undefined]  # pyre-ignore[61]
             ) / output_qparams.scale

--- a/backends/arm/operators/op_conv2d.py
+++ b/backends/arm/operators/op_conv2d.py
@@ -9,7 +9,6 @@ from typing import List
 import serializer.tosa_serializer as ts  # type: ignore
 import torch
 
-# pyre-fixme[21]: 'Could not find a module corresponding to import `executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass`.'
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_input_qparams,
     get_output_qparams,
@@ -85,7 +84,7 @@ class Conv2dVisitor(NodeVisitor):
         input_zp = 0
         if inputs[0].dtype == ts.DType.INT8:
             # int8 input requires quantization information
-            input_qparams = get_input_qparams(node)  # pyre-ignore[16]
+            input_qparams = get_input_qparams(node)
             input_zp = input_qparams[0].zp
 
         attr.ConvAttribute(
@@ -169,7 +168,7 @@ class Conv2dVisitor(NodeVisitor):
             # Get scale_factor from input, weight, and output.
             input_scale = input_qparams[0].scale  # type: ignore[possibly-undefined]  # pyre-ignore [61]
             weight_scale = input_qparams[1].scale  # pyre-ignore [61]
-            output_qargs = get_output_qparams(node)  # pyre-ignore [16]
+            output_qargs = get_output_qparams(node)
             build_rescale_conv_output(
                 tosa_graph,
                 # pyre-fixme[61]: Uninitialized local [61]: Local variable `conv2d_res` is undefined, or not always defined.

--- a/backends/arm/operators/op_max_pool2d.py
+++ b/backends/arm/operators/op_max_pool2d.py
@@ -9,7 +9,6 @@ from typing import List
 import serializer.tosa_serializer as ts  # type: ignore
 import torch
 
-# pyre-fixme[21]: 'Could not find a module corresponding to import `executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass`.'
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_input_qparams,
     get_output_qparams,
@@ -57,12 +56,12 @@ class MaxPool2dVisitor(NodeVisitor):
         # Initilize zero point to zero.
         input_zp = 0
         if inputs[0].dtype == ts.DType.INT8:
-            input_qparams = get_input_qparams(node)  # pyre-ignore[16]
+            input_qparams = get_input_qparams(node)
             input_zp = input_qparams[0].zp
 
         output_zp = 0
         if output.dtype == ts.DType.INT8:
-            output_qparams = get_output_qparams(node)  # pyre-ignore[16]
+            output_qparams = get_output_qparams(node)
             output_zp = output_qparams[0].zp
 
         attr = ts.TosaSerializerAttribute()

--- a/backends/arm/operators/op_maximum.py
+++ b/backends/arm/operators/op_maximum.py
@@ -10,7 +10,6 @@ from typing import List
 import executorch.backends.arm.tosa_quant_utils as tqutils
 import serializer.tosa_serializer as ts  # type: ignore
 
-# pyre-fixme[21]: 'Could not find a module corresponding to import `executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass`.'
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_input_qparams,
 )
@@ -44,9 +43,7 @@ class MaxVisitor(NodeVisitor):
         scale_back = 1.0
         max_output = output
         if inputs[0].dtype == ts.DType.INT8:
-            input_qparams = get_input_qparams(  # pyre-ignore[16]: 'Module `executorch.backends.arm` has no attribute `_passes`.'
-                node
-            )
+            input_qparams = get_input_qparams(node)
             assert (
                 len(input_qparams) == 2
             ), f"Both inputs needs to have quantization information for {node}"

--- a/backends/arm/operators/op_minimum.py
+++ b/backends/arm/operators/op_minimum.py
@@ -11,7 +11,6 @@ import executorch.backends.arm.tosa_quant_utils as tqutils
 
 import serializer.tosa_serializer as ts  # type: ignore
 
-# pyre-fixme[21]: 'Could not find a module corresponding to import `executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass`.'
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_input_qparams,
 )
@@ -45,9 +44,7 @@ class MinVisitor(NodeVisitor):
         scale_back = 1.0
         min_output = output
         if inputs[0].dtype == ts.DType.INT8:
-            input_qparams = get_input_qparams(  # pyre-ignore[16]: 'Module `executorch.backends.arm` has no attribute `_passes`.'
-                node
-            )
+            input_qparams = get_input_qparams(node)
             assert (
                 len(input_qparams) == 2
             ), f"Both inputs needs to have quantization information for {node}"

--- a/backends/arm/operators/op_mul.py
+++ b/backends/arm/operators/op_mul.py
@@ -13,7 +13,6 @@ import executorch.backends.arm.tosa_utils as tutils
 import serializer.tosa_serializer as ts  # type: ignore
 import torch
 
-# pyre-fixme[21]: 'Could not find a module corresponding to import `executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass`.'
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_input_qparams,
 )
@@ -52,7 +51,7 @@ class MulVisitor_080_BI(NodeVisitor):
         )
         input_A = inputs[0]
         input_B = inputs[1]
-        input_qparams = get_input_qparams(node)  # pyre-ignore[16]
+        input_qparams = get_input_qparams(node)
         input_A_qargs = input_qparams[0]
         input_B_qargs = input_qparams[1]
         input_A.shape = tutils.tosa_shape(input_A.shape, input_A.dim_order)

--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -17,7 +17,7 @@ import functools
 from typing import Any, Callable, Dict, List, Optional
 
 import torch
-from executorch.backends.arm._passes.arm_pass_manager import ArmPassManager
+from executorch.backends.arm._passes import ArmPassManager
 
 from executorch.backends.arm.quantizer import arm_quantizer_utils
 from executorch.backends.arm.quantizer.arm_quantizer_utils import (  # type: ignore[attr-defined]

--- a/backends/arm/test/passes/test_fold_qdq_pass.py
+++ b/backends/arm/test/passes/test_fold_qdq_pass.py
@@ -6,9 +6,7 @@
 from typing import Tuple
 
 import torch
-from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
-    FoldAndAnnotateQParamsPass,
-)
+from executorch.backends.arm._passes import FoldAndAnnotateQParamsPass
 from executorch.backends.arm.test.tester.test_pipeline import PassPipeline
 
 

--- a/backends/arm/test/passes/test_meandim_to_averagepool2d.py
+++ b/backends/arm/test/passes/test_meandim_to_averagepool2d.py
@@ -7,9 +7,7 @@
 from typing import Tuple
 
 import torch
-from executorch.backends.arm._passes.meandim_to_averagepool_pass import (
-    ConvertMeanDimToAveragePoolPass,
-)
+from executorch.backends.arm._passes import ConvertMeanDimToAveragePoolPass
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import PassPipeline
 

--- a/backends/arm/test/passes/test_unsqueeze_before_repeat_pass.py
+++ b/backends/arm/test/passes/test_unsqueeze_before_repeat_pass.py
@@ -6,9 +6,7 @@
 from typing import Dict, Tuple
 
 import torch
-from executorch.backends.arm._passes.unsqueeze_before_repeat_pass import (
-    UnsqueezeBeforeRepeatPass,
-)
+from executorch.backends.arm._passes import UnsqueezeBeforeRepeatPass
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import PassPipeline
 

--- a/backends/arm/tosa_backend.py
+++ b/backends/arm/tosa_backend.py
@@ -18,7 +18,7 @@ import serializer.tosa_serializer as ts  # type: ignore
 
 from executorch.backends.arm.arm_backend import get_tosa_spec
 from executorch.backends.arm.operators.node_visitor import get_node_visitors
-from executorch.backends.arm._passes.arm_pass_manager import (
+from executorch.backends.arm._passes import (
     ArmPassManager,
 )  # usort: skip
 from executorch.backends.arm.process_node import (

--- a/backends/arm/tosa_quant_utils.py
+++ b/backends/arm/tosa_quant_utils.py
@@ -42,7 +42,6 @@ def insert_rescale_ops_to_int32(
     in the node meta dict.
     """
 
-    # pyre-fixme[21]: 'Could not find a module corresponding to import `executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass`.'
     from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
         get_input_qparams,
     )
@@ -54,7 +53,7 @@ def insert_rescale_ops_to_int32(
         dim_order = tensor.dim_order
         tensor.shape = [tensor.shape[i] for i in dim_order]
 
-    input_qparams = get_input_qparams(node)  # pyre-ignore[16]
+    input_qparams = get_input_qparams(node)
     qargs = input_qparams.values()
 
     # Scale the int8 quantized input to a common scale in the integer
@@ -92,12 +91,11 @@ def insert_rescale_op_to_int8(
     handled by the DQ/D folding pass, which stores the quantization parameters
     in the node meta dict.
     """
-    # pyre-fixme[21]: 'Could not find a module corresponding to import `executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass`.'
     from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
         get_output_qparams,
     )
 
-    output_qparams = get_output_qparams(node)  # pyre-ignore[16]
+    output_qparams = get_output_qparams(node)
     assert len(output_qparams) == 1, "More than one output not supported"
 
     qargs_out = output_qparams[0]


### PR DESCRIPTION
### Summary
backends/arm/_passes missed an init file which caused pyre to not find imports from _passes.


cc @digantdesai @freddan80 @per @zingo