### PR TITLE
Re-enable optimized log_softmax test in CMake

### DIFF
--- a/kernels/test/CMakeLists.txt
+++ b/kernels/test/CMakeLists.txt
@@ -278,9 +278,6 @@ set(_optimized_kernels_test_sources
     ${CMAKE_CURRENT_BINARY_DIR}/include/portable/executorch/kernels/test/supported_features.cpp
 )
 
-# We don't have sleef on OSS so we don't have log_softmax
-list(REMOVE_ITEM _optimized_kernels_test_sources "op_log_softmax_test.cpp")
-
 et_cxx_test(
   optimized_kernels_test
   SOURCES


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8598
* #8597
* #8595

I missed this line disabling the test.

Differential Revision: [D69929180](https://our.internmc.facebook.com/intern/diff/D69929180/)