### PR TITLE
Arm backend: Enable FVP tests for ops lowered to REDUCE_SUM

### DIFF
--- a/backends/arm/test/misc/test_multiple_outputs.py
+++ b/backends/arm/test/misc/test_multiple_outputs.py
@@ -76,18 +76,6 @@ class TestMultipleOutputs(unittest.TestCase):
             tester.run_method_and_compare_outputs(qtol=1, inputs=test_data)
 
     @pytest.mark.corstone_fvp
-    def test_u85_BI(self):
-        module = self.MultipleOutputsModule()
-        test_data = module.get_inputs()
-        self._test_ethosu_BI_pipeline(
-            module,
-            test_data,
-            common.get_u85_compile_spec(),
-        )
-
-    @pytest.mark.corstone_fvp
-    @conftest.expectedFailureOnFVP
-    # TODO MLETORCH-598
     def test_u55_BI(self):
         module = self.MultipleOutputsModule()
         test_data = module.get_inputs()
@@ -95,4 +83,14 @@ class TestMultipleOutputs(unittest.TestCase):
             module,
             test_data,
             common.get_u55_compile_spec(),
+        )
+
+    @pytest.mark.corstone_fvp
+    def test_u85_BI(self):
+        module = self.MultipleOutputsModule()
+        test_data = module.get_inputs()
+        self._test_ethosu_BI_pipeline(
+            module,
+            test_data,
+            common.get_u85_compile_spec(),
         )

--- a/backends/arm/test/ops/test_bmm.py
+++ b/backends/arm/test/ops/test_bmm.py
@@ -150,9 +150,10 @@ class TestBMM(unittest.TestCase):
         test_data = test_data_generator()
         self._test_bmm_tosa_BI_pipeline(self.BMMSingleInput(), test_data)
 
+    # Expected to fail on FVP as TOSA.MATMUL is not supported on U55
     @parameterized.expand(BMM.test_data_generators)
     @pytest.mark.corstone_fvp
-    @unittest.expectedFailure
+    @conftest.expectedFailureOnFVP
     def test_bmm_u55_BI_xfails(self, test_data_generator: Callable[[], Tuple]):
         test_data = test_data_generator()
         self._test_bmm_ethosu_BI_pipeline(
@@ -167,10 +168,10 @@ class TestBMM(unittest.TestCase):
             self.BMM(), common.get_u85_compile_spec(), test_data
         )
 
-    # Expected to fail with error: Warning, unsupported fusing of TOSA Rescale previous operator is of type: Memcpy
+    # Expected to fail on FVP as TOSA.MATMUL is not supported on U55
     @parameterized.expand(BMMSingleInput.test_data_generators)
     @pytest.mark.corstone_fvp
-    @unittest.expectedFailure
+    @conftest.expectedFailureOnFVP
     def test_bmm_single_input_u55_BI_xfails(
         self, test_data_generator: Callable[[], Tuple]
     ):

--- a/backends/arm/test/ops/test_layer_norm.py
+++ b/backends/arm/test/ops/test_layer_norm.py
@@ -158,7 +158,7 @@ class TestLayerNorm(unittest.TestCase):
             self.LayerNorm(*model_params), (test_data,)
         )
 
-    @parameterized.expand(test_data_suite[4:])
+    @parameterized.expand(test_data_suite)
     @pytest.mark.corstone_fvp
     def test_layer_norm_u55_BI(
         self,
@@ -170,36 +170,7 @@ class TestLayerNorm(unittest.TestCase):
             self.LayerNorm(*model_params), common.get_u55_compile_spec(), (test_data,)
         )
 
-    # Numerical issues on FVP likely due to mul op, MLETORCH-521
-    # Skip tests that require transposes.
-    @parameterized.expand(test_data_suite[:4])
-    @pytest.mark.corstone_fvp
-    @conftest.expectedFailureOnFVP
-    def test_layer_norm_u55_BI_xfails(
-        self,
-        test_name: str,
-        test_data: torch.Tensor,
-        model_params,
-    ):
-        self._test_layernorm_ethosu_BI_pipeline(
-            self.LayerNorm(*model_params), common.get_u55_compile_spec(), (test_data,)
-        )
-
-    # Numerical issues on FVP likely due to mul op, MLETORCH-521
-    @parameterized.expand(test_data_suite[:-2])
-    @pytest.mark.corstone_fvp
-    @conftest.expectedFailureOnFVP
-    def test_layer_norm_u85_BI_xfails(
-        self,
-        test_name: str,
-        test_data: torch.Tensor,
-        model_params,
-    ):
-        self._test_layernorm_ethosu_BI_pipeline(
-            self.LayerNorm(*model_params), common.get_u85_compile_spec(), (test_data,)
-        )
-
-    @parameterized.expand(test_data_suite[-2:])
+    @parameterized.expand(test_data_suite)
     @pytest.mark.corstone_fvp
     def test_layer_norm_u85_BI(
         self,

--- a/backends/arm/test/ops/test_logsoftmax.py
+++ b/backends/arm/test/ops/test_logsoftmax.py
@@ -11,7 +11,7 @@ from typing import Callable, Tuple
 import pytest
 
 import torch
-from executorch.backends.arm.test import common
+from executorch.backends.arm.test import common, conftest
 from executorch.backends.arm.test.tester.arm_tester import ArmTester
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from parameterized import parameterized
@@ -28,16 +28,17 @@ test_data_generators = [
     lambda: ("randn", torch.randn(10, 10, 10, 10), 3),
     lambda: ("randn_neg_dim", torch.randn(10, 5, 8, 7), -3),
 ]
-test_data_generators_u55 = [
+
+test_data_generators_FVP = [
     # (test_name, test_data, dim)
     lambda: ("ones", torch.ones(10, 10), 1),
     lambda: ("ones_neg_dim", torch.ones(10, 3, 4), -1),
-    lambda: ("randn_neg_dim", torch.randn(10, 5, 8, 7), -3),
-    lambda: ("zeros", torch.zeros(10, 8, 5, 2), 0),
-    lambda: ("zeros_neg_dim", torch.zeros(10, 7, 8, 9), -4),
+    lambda: ("randn_neg_dim", torch.randn(1, 5, 8, 7), -3),
+    lambda: ("zeros", torch.zeros(1, 8, 5, 2), 0),
+    lambda: ("zeros_neg_dim", torch.zeros(1, 7, 8, 9), -4),
     lambda: ("rand", torch.rand(1, 2, 5, 8), 2),
-    lambda: ("rand_neg_dim", torch.rand(2, 10, 8, 10), -2),
-    lambda: ("randn", torch.randn(10, 10, 10, 10), 3),
+    lambda: ("rand_neg_dim", torch.rand(1, 10, 8, 10), -2),
+    lambda: ("randn", torch.randn(1, 10, 10, 10), 3),
 ]
 
 
@@ -99,7 +100,7 @@ class TestLogSoftmax(unittest.TestCase):
         module: torch.nn.Module,
         test_data: Tuple[torch.tensor],
     ):
-        (
+        tester = (
             ArmTester(
                 module,
                 example_inputs=test_data,
@@ -114,21 +115,10 @@ class TestLogSoftmax(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten__logsoftmax_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .serialize()
         )
-
-    def _test_logsoftmax_tosa_u55_BI_pipeline(
-        self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
-    ):
-        self._test_logsoftmax_tosa_ethos_BI_pipeline(
-            common.get_u55_compile_spec(), module, test_data
-        )
-
-    def _test_logsoftmax_tosa_u85_BI_pipeline(
-        self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
-    ):
-        self._test_logsoftmax_tosa_ethos_BI_pipeline(
-            common.get_u85_compile_spec(), module, test_data
-        )
+        if conftest.is_option_enabled("corstone_fvp"):
+            tester.run_method_and_compare_outputs(inputs=test_data, qtol=1)
 
     @parameterized.expand(test_data_generators)
     def test_logsoftmax_tosa_MI(self, test_data_generator: Callable[[], Tuple]):
@@ -141,18 +131,18 @@ class TestLogSoftmax(unittest.TestCase):
         test_name, test_data, dim = test_data_generator()
         self._test_logsoftmax_tosa_BI_pipeline(self.LogSoftmax(dim=dim), (test_data,))
 
-    @parameterized.expand(test_data_generators_u55)
+    @parameterized.expand(test_data_generators_FVP)
     @pytest.mark.flaky  # TODO: MLETORCH-460 - Numerically stabler (log)softmax implementation
     def test_logsoftmax_tosa_u55_BI(self, test_data_generator: Callable[[], Tuple]):
         test_name, test_data, dim = test_data_generator()
-        self._test_logsoftmax_tosa_u55_BI_pipeline(
-            self.LogSoftmax(dim=dim), (test_data,)
+        self._test_logsoftmax_tosa_ethos_BI_pipeline(
+            common.get_u55_compile_spec(), self.LogSoftmax(dim=dim), (test_data,)
         )
 
-    @parameterized.expand(test_data_generators)
+    @parameterized.expand(test_data_generators_FVP)
     @pytest.mark.flaky  # TODO: MLETORCH-460 - Numerically stabler (log)softmax implementation
     def test_logsoftmax_tosa_u85_BI(self, test_data_generator: Callable[[], Tuple]):
         test_name, test_data, dim = test_data_generator()
-        self._test_logsoftmax_tosa_u85_BI_pipeline(
-            self.LogSoftmax(dim=dim), (test_data,)
+        self._test_logsoftmax_tosa_ethos_BI_pipeline(
+            common.get_u85_compile_spec(), self.LogSoftmax(dim=dim), (test_data,)
         )

--- a/backends/arm/test/ops/test_mean_dim.py
+++ b/backends/arm/test/ops/test_mean_dim.py
@@ -10,7 +10,7 @@ import unittest
 from typing import Tuple
 
 import torch
-from executorch.backends.arm.test import common
+from executorch.backends.arm.test import common, conftest
 from executorch.backends.arm.test.tester.arm_tester import ArmTester
 from executorch.exir.backend.backend_details import CompileSpec
 from parameterized import parameterized
@@ -121,7 +121,7 @@ class TestMeanDim(unittest.TestCase):
         compile_spec: CompileSpec,
         test_data: Tuple[torch.tensor],
     ):
-        (
+        tester = (
             ArmTester(
                 module,
                 example_inputs=test_data,
@@ -141,7 +141,10 @@ class TestMeanDim(unittest.TestCase):
             )
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .serialize()
         )
+        if conftest.is_option_enabled("corstone_fvp"):
+            tester.run_method_and_compare_outputs(inputs=test_data)
 
     def _test_meandim_tosa_MI_pipeline(
         self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
@@ -188,7 +191,7 @@ class TestMeanDim(unittest.TestCase):
         compile_spec: CompileSpec,
         test_data: Tuple[torch.tensor],
     ):
-        (
+        tester = (
             ArmTester(
                 module,
                 example_inputs=test_data,
@@ -207,7 +210,10 @@ class TestMeanDim(unittest.TestCase):
             )
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .serialize()
         )
+        if conftest.is_option_enabled("corstone_fvp"):
+            tester.run_method_and_compare_outputs(inputs=test_data, qtol=1)
 
     @parameterized.expand(AdaptiveAveragePool2d.test_data_suite)
     def test_adaptive_avg_pool2d_tosa_MI(

--- a/backends/arm/test/ops/test_mm.py
+++ b/backends/arm/test/ops/test_mm.py
@@ -132,18 +132,16 @@ class TestMM(unittest.TestCase):
         test_data = test_data_generator()
         self._test_mm_tosa_BI_pipeline(self.MMSingleInput(), test_data)
 
-    # Expected to fail with error: CPU performance estimation for "MatMul" not implemented
+    # TODO: Enable numerical testing
     @parameterized.expand(MM.test_data_generators)
-    @unittest.expectedFailure
     def test_mm_u55_BI(self, test_data_generator: Callable[[], Tuple]):
         test_data = test_data_generator()
         self._test_mm_ethosu_BI_pipeline(
             common.get_u55_compile_spec(), self.MM(), test_data
         )
 
-    # Expected to fail with error: Warning, unsupported fusing of TOSA Rescale previous operator is of type: Memcpy
+    # TODO: Enable numerical testing
     @parameterized.expand(MMSingleInput.test_data_generators)
-    @unittest.expectedFailure
     def test_mm_single_input_u55_BI(self, test_data_generator: Callable[[], Tuple]):
         test_data = test_data_generator()
         self._test_mm_ethosu_BI_pipeline(

--- a/backends/arm/test/ops/test_softmax.py
+++ b/backends/arm/test/ops/test_softmax.py
@@ -12,7 +12,7 @@ from typing import Callable, Tuple
 import pytest
 
 import torch
-from executorch.backends.arm.test import common
+from executorch.backends.arm.test import common, conftest
 from executorch.backends.arm.test.tester.arm_tester import ArmTester
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from parameterized import parameterized
@@ -30,16 +30,16 @@ test_data_generators = [
     lambda: ("randn_neg_dim", torch.randn(10, 5, 8, 7), -3),
 ]
 
-test_data_generators_u55 = [
+test_data_generators_FVP = [
     # (test_name, test_data, dim)
     lambda: ("ones", torch.ones(10, 10), 1),
-    lambda: ("ones_neg_dim", torch.ones(10, 3, 4), -1),
-    lambda: ("randn_neg_dim", torch.randn(10, 5, 8, 7), -3),
-    lambda: ("zeros", torch.zeros(10, 8, 5, 2), 0),
-    lambda: ("zeros_neg_dim", torch.zeros(10, 7, 8, 9), -4),
+    lambda: ("ones_neg_dim", torch.ones(1, 3, 4), -1),
+    lambda: ("randn_neg_dim", torch.randn(1, 5, 8, 7), -3),
+    lambda: ("zeros", torch.zeros(1, 8, 5, 2), 0),
+    lambda: ("zeros_neg_dim", torch.zeros(1, 7, 8, 9), -4),
     lambda: ("rand", torch.rand(1, 2, 5, 8), 2),
-    lambda: ("rand_neg_dim", torch.rand(2, 10, 8, 10), -2),
-    lambda: ("randn", torch.randn(10, 10, 10, 10), 3),
+    lambda: ("rand_neg_dim", torch.rand(1, 10, 8, 10), -2),
+    lambda: ("randn", torch.randn(1, 10, 10, 10), 3),
 ]
 
 
@@ -95,13 +95,13 @@ class TestSoftmax(unittest.TestCase):
             .run_method_and_compare_outputs(inputs=test_data)
         )
 
-    def _test_softmax_tosa_ethos_BI_pipeline(
+    def _test_softmax_ethosu_BI_pipeline(
         self,
         compile_spec: list[CompileSpec],
         module: torch.nn.Module,
         test_data: Tuple[torch.tensor],
     ):
-        (
+        tester = (
             ArmTester(
                 module,
                 example_inputs=test_data,
@@ -116,21 +116,10 @@ class TestSoftmax(unittest.TestCase):
             .check_not(["executorch_exir_dialects_edge__ops_aten__softmax_default"])
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
+            .serialize()
         )
-
-    def _test_softmax_tosa_u55_BI_pipeline(
-        self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
-    ):
-        self._test_softmax_tosa_ethos_BI_pipeline(
-            common.get_u55_compile_spec(), module, test_data
-        )
-
-    def _test_softmax_tosa_u85_BI_pipeline(
-        self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
-    ):
-        self._test_softmax_tosa_ethos_BI_pipeline(
-            common.get_u85_compile_spec(), module, test_data
-        )
+        if conftest.is_option_enabled("corstone_fvp"):
+            tester.run_method_and_compare_outputs(inputs=test_data, qtol=1)
 
     @parameterized.expand(test_data_generators)
     def test_softmax_tosa_MI(self, test_data_generator: Callable[[], Tuple]):
@@ -143,14 +132,18 @@ class TestSoftmax(unittest.TestCase):
         test_name, test_data, dim = test_data_generator()
         self._test_softmax_tosa_BI_pipeline(self.Softmax(dim=dim), (test_data,))
 
-    @parameterized.expand(test_data_generators_u55)
+    @parameterized.expand(test_data_generators_FVP)
     @pytest.mark.flaky  # TODO: MLETORCH-460 - Numerically stabler (log)softmax implementation
-    def test_softmax_tosa_u55_BI(self, test_data_generator: Callable[[], Tuple]):
+    def test_softmax_u55_BI(self, test_data_generator: Callable[[], Tuple]):
         test_name, test_data, dim = test_data_generator()
-        self._test_softmax_tosa_u55_BI_pipeline(self.Softmax(dim=dim), (test_data,))
+        self._test_softmax_ethosu_BI_pipeline(
+            common.get_u55_compile_spec(), self.Softmax(dim=dim), (test_data,)
+        )
 
-    @parameterized.expand(test_data_generators)
+    @parameterized.expand(test_data_generators_FVP)
     @pytest.mark.flaky  # TODO: MLETORCH-460 - Numerically stabler (log)softmax implementation
-    def test_softmax_tosa_u85_BI(self, test_data_generator: Callable[[], Tuple]):
+    def test_softmax_u85_BI(self, test_data_generator: Callable[[], Tuple]):
         test_name, test_data, dim = test_data_generator()
-        self._test_softmax_tosa_u85_BI_pipeline(self.Softmax(dim=dim), (test_data,))
+        self._test_softmax_ethosu_BI_pipeline(
+            common.get_u85_compile_spec(), self.Softmax(dim=dim), (test_data,)
+        )

--- a/backends/arm/test/ops/test_sum.py
+++ b/backends/arm/test/ops/test_sum.py
@@ -9,7 +9,7 @@ import unittest
 from typing import Tuple
 
 import torch
-from executorch.backends.arm.test import common
+from executorch.backends.arm.test import common, conftest
 from executorch.backends.arm.test.tester.arm_tester import ArmTester
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from parameterized import parameterized
@@ -29,7 +29,7 @@ class TestSum(unittest.TestCase):
             ((torch.rand(10), 0, True),),
             ((torch.rand(10, 10), 1, False),),
             ((torch.rand(10, 10, 10), [-3, 1], True),),
-            ((torch.rand(2, 1, 5, 8), 1, False),),
+            ((torch.rand(1, 1, 5, 8), 1, False),),
             ((torch.rand(1, 2, 3, 4), 3, True),),
             ((torch.rand(1, 2, 8, 8), [2, 3, 0], True),),
         ]
@@ -39,7 +39,7 @@ class TestSum(unittest.TestCase):
             ((torch.rand(10, 10), 1, False),),
             ((torch.rand(1, 2, 3, 4), 3, True),),
             ((torch.rand(10, 10, 10), [-3, 1], True),),
-            ((torch.rand(2, 1, 5, 8), 1, False),),
+            ((torch.rand(1, 1, 5, 8), 1, False),),
             ((torch.rand(1, 2, 8, 8), [2, 3, 0], True),),
         ]
 
@@ -82,7 +82,7 @@ class TestSum(unittest.TestCase):
             .partition()
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
-            .run_method_and_compare_outputs(inputs=test_data, qtol=1)
+            .run_method_and_compare_outputs(inputs=test_data)
         )
 
     def _test_sum_ethosu_BI_pipeline(
@@ -91,7 +91,7 @@ class TestSum(unittest.TestCase):
         test_data: tuple[exampledata_t],
         compile_spec: CompileSpec,
     ):
-        (
+        tester = (
             ArmTester(
                 module,
                 example_inputs=test_data,
@@ -107,6 +107,8 @@ class TestSum(unittest.TestCase):
             .to_executorch()
             .serialize()
         )
+        if conftest.is_option_enabled("corstone_fvp"):
+            tester.run_method_and_compare_outputs(inputs=test_data, qtol=1)
 
     @parameterized.expand(Sum.test_parameters)
     def test_sum_tosa_MI(self, test_data: tuple[exampledata_t]):

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -65,8 +65,7 @@ tosa_reference_model_rev="70ed0b40fa831387e36abdb4f7fb9670a3464f5a"
 
 # vela
 vela_repo_url="https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-vela"
-vela_rev="e131bf4f528f0d461868229972e07f371dcbc881"
-
+vela_rev="46d88f56902be0706e051c10153ffb7620e01ee3"
 
 ########
 ### Optional user args


### PR DESCRIPTION
### Summary
vela version is stepped to fix numerical issues with REDUCE_SUM.



cc @digantdesai @freddan80 @per @zingo