### PR TITLE
Expose executorchcoreml target to ExecuTorch-clients

### DIFF
--- a/backends/apple/coreml/TARGETS
+++ b/backends/apple/coreml/TARGETS
@@ -76,6 +76,7 @@ runtime.cxx_python_extension(
     base_module = "",
     visibility = [
         "//executorch/examples/apple/coreml/...",
+        "@EXECUTORCH_CLIENTS",
     ],
     external_deps = [
         "pybind11",


### PR DESCRIPTION
Summary:
Expose executorchcoreml target to ExecuTorch-clients
- This is for the buck build tool to extract ExecuTorch-coreML to mlpackage

Differential Revision: D69996302


