### PR TITLE
Arm backend: add passes buck dep for #8593

### DIFF
--- a/backends/arm/operator_support/TARGETS
+++ b/backends/arm/operator_support/TARGETS
@@ -5,8 +5,9 @@ python_library(
     srcs = glob(["*.py"]),
     typing = True,
     deps = [
+        "//executorch/backends/arm/_passes:passes",
+        "//executorch/backends/arm:tosa_specification",
         "//executorch/backends/xnnpack/_passes:xnnpack_passes",
         "//executorch/exir:lib",
-        "//executorch/backends/arm:tosa_specification"
     ],
 )


### PR DESCRIPTION
Summary: #8593 (D69921367) adds new imports to tosa_supported_operators.py. Add the necessary buck deps for it.

Differential Revision: D70003345
