### PR TITLE
Revert D68939461 'fix memory planning API to use run()'

### DIFF
--- a/backends/cadence/aot/memory_planning.py
+++ b/backends/cadence/aot/memory_planning.py
@@ -46,7 +46,6 @@ def get_aligned_offset(pre_aligned_offset: int, alignment: int) -> int:
 
 def collect_specs_from_graph_module(
     graph_module: torch.fx.GraphModule,
-    graph_signature: ExportGraphSignature,
     alloc_graph_input: bool,
     alloc_graph_output: bool,
 ) -> Iterable[TensorSpec]:
@@ -57,7 +56,6 @@ def collect_specs_from_graph_module(
     # Collect the specs from all the nodes in the graph module, and return it
     return collect_specs_from_nodes(
         graph_module.graph.nodes,
-        graph_signature,
         ignore_graph_input=not alloc_graph_input,
         ignore_graph_output=not alloc_graph_output,
     )
@@ -109,7 +107,7 @@ def position_based_greedy_with_hierarchy(
     # Iterate over all the specs in sorted order
     for spec in sorted(
         collect_specs_from_graph_module(
-            graph_module, graph_signature, alloc_graph_input, alloc_graph_output
+            graph_module, alloc_graph_input, alloc_graph_output
         ),
         key=lambda spec: spec.allocated_memory,
         reverse=True,
@@ -184,7 +182,7 @@ def greedy_by_size_for_offset_calculation_with_hierarchy(
     # Iterate over all the specs in sorted order
     for spec in sorted(
         collect_specs_from_graph_module(
-            graph_module, graph_signature, alloc_graph_input, alloc_graph_output
+            graph_module, alloc_graph_input, alloc_graph_output
         ),
         key=lambda spec: spec.allocated_memory,
         reverse=True,
@@ -252,7 +250,6 @@ def greedy_by_size_for_offset_calculation_with_hierarchy(
 
 def find_peak_memory_usages_per_memory(
     graph_module: torch.fx.GraphModule,
-    graph_signature: ExportGraphSignature,
     alloc_graph_input: bool,
     alloc_graph_output: bool,
     mem_constraints: Optional[MemConstraints] = None,
@@ -268,7 +265,7 @@ def find_peak_memory_usages_per_memory(
 
     # go through all nodes in the graph, collect memory usage per spec.mem_id
     for spec in collect_specs_from_graph_module(
-        graph_module, graph_signature, alloc_graph_input, alloc_graph_output
+        graph_module, alloc_graph_input, alloc_graph_output
     ):
         if mem_constraints is not None and mem_constraints.skipped_spec(spec):
             continue
@@ -291,7 +288,6 @@ def find_peak_memory_usages_per_memory(
 
 def find_peak_memory_usage(
     graph_module: torch.fx.GraphModule,
-    graph_signature: ExportGraphSignature,
     alloc_graph_input: bool,
     alloc_graph_output: bool,
     mem_constraints: Optional[MemConstraints] = None,
@@ -307,7 +303,7 @@ def find_peak_memory_usage(
 
     # Iterate over all the node specs
     for spec in collect_specs_from_graph_module(
-        graph_module, graph_signature, alloc_graph_input, alloc_graph_output
+        graph_module, alloc_graph_input, alloc_graph_output
     ):
         if spec.lifetime[0] is None or (
             mem_constraints is not None and mem_constraints.skipped_spec(spec)
@@ -362,7 +358,6 @@ def print_memory_planning_info(
     # Get the peak memory usages per memory space
     peak_memory_usages_per_memory = find_peak_memory_usages_per_memory(
         executorch_prog.exported_program().graph_module,
-        executorch_prog.exported_program().graph_signature,
         alloc_graph_input,
         alloc_graph_output,
         mem_constraints,
@@ -398,7 +393,6 @@ def print_memory_planning_info(
     # Get the total peak memory usage across all memory spaces
     total_peak_memory_usage = find_peak_memory_usage(
         executorch_prog.exported_program().graph_module,
-        executorch_prog.exported_program().graph_signature,
         alloc_graph_input,
         alloc_graph_output,
         mem_constraints,
@@ -459,17 +453,7 @@ class CadenceMemoryPlanning:
             greedy_by_size_for_offset_calculation_with_hierarchy,
         ]
 
-    def __call__(
-        self,
-        graph_module: torch.fx.GraphModule,
-    ) -> PassResult:
-        return self.run(graph_module)
-
-    def run(
-        self,
-        graph_module: torch.fx.GraphModule,
-        graph_signature: Optional[ExportGraphSignature] = None,
-    ) -> PassResult:
+    def __call__(self, graph_module: torch.fx.GraphModule) -> PassResult:
         mem_constraints = MemConstraints(
             opt_level=self.opt_level,
             alloc_graph_input=self.alloc_graph_input,
@@ -491,6 +475,6 @@ class CadenceMemoryPlanning:
             alloc_graph_output=self.alloc_graph_output,
             alignment=self.mem_alignment,
         )
-        mem_planning.run(graph_module, graph_signature)
+        mem_planning(graph_module)
 
         return PassResult(graph_module, True)

--- a/backends/cadence/aot/tests/test_memory_passes.py
+++ b/backends/cadence/aot/tests/test_memory_passes.py
@@ -46,13 +46,14 @@ class TestMemPlanningPasses(unittest.TestCase):
         inputs = (torch.ones(batch_size, input_dim),)
         model = PeakMemoryTestModel(input_dim, hidden_dim, output_dim)
 
-        exported_program = compiler.export_to_executorch_gen_etrecord(
-            model, inputs
-        ).exported_program()
+        graph_module = (
+            compiler.export_to_executorch_gen_etrecord(model, inputs)
+            .exported_program()
+            .graph_module
+        )
 
         peak_usage, _ = find_peak_memory_usage(
-            exported_program.graph_module,
-            exported_program.graph_signature,
+            graph_module,
             mem_constraints=None,
             alloc_graph_input=True,
             alloc_graph_output=True,
@@ -72,13 +73,14 @@ class TestMemPlanningPasses(unittest.TestCase):
             input_dim, hidden_dim, hidden_dim, hidden_dim, output_dim
         )
 
-        exported_program = compiler.export_to_executorch_gen_etrecord(
-            model, inputs
-        ).exported_program()
+        graph_module = (
+            compiler.export_to_executorch_gen_etrecord(model, inputs)
+            .exported_program()
+            .graph_module
+        )
 
         peak_usage, _ = find_peak_memory_usage(
-            exported_program.graph_module,
-            exported_program.graph_signature,
+            graph_module,
             mem_constraints=None,
             alloc_graph_input=True,
             alloc_graph_output=True,
@@ -109,7 +111,6 @@ class TestMemPlanningPasses(unittest.TestCase):
         graph_module.graph.eliminate_dead_code()
         peak_usage, _ = find_peak_memory_usage(
             graph_module,
-            executorch_prog.exported_program().graph_signature,
             alloc_graph_input=False,
             alloc_graph_output=False,
             mem_constraints=None,


### PR DESCRIPTION
Summary:
This diff reverts D68939461, "fix memory planning API to use run()" which was a fix for:
https://github.com/pytorch/executorch/pull/8622

Planning to redo this change but need to revert for now, as it breaks some of our virtual platform testing - multisected to 8 test fails in T216023551, and also larger set of failures tracked in T216134349.

Differential Revision: D70103236
