### PR TITLE
Arm backend: Add support for DevTools BundleIO

### DIFF
--- a/backends/arm/scripts/build_executorch.sh
+++ b/backends/arm/scripts/build_executorch.sh
@@ -16,18 +16,17 @@ et_root_dir=$(realpath ${et_root_dir})
 toolchain_cmake=${script_dir}/../../../examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake
 toolchain_cmake=$(realpath ${toolchain_cmake})
 
-
-
 et_build_root="${et_root_dir}/arm_test"
 build_type="Release"
+build_devtools=false
 build_with_etdump=false
-
 
 help() {
     echo "Usage: $(basename $0) [options]"
     echo "Options:"
     echo "  --et_build_root=<FOLDER>  Build output root folder to use, defaults to ${et_build_root}"
     echo "  --build_type=<TYPE>       Build with Release, Debug or RelWithDebInfo, default is ${build_type}"
+    echo "  --devtools                Build Devtools libs"
     echo "  --etdump                  Adds Devtools etdump support to track timing, etdump area will be base64 encoded in the log"
     exit 0
 }
@@ -37,6 +36,7 @@ for arg in "$@"; do
       -h|--help) help ;;
       --et_build_root=*) et_build_root="${arg#*=}";;
       --build_type=*) build_type="${arg#*=}";;
+      --devtools) build_devtools=true ;;
       --etdump) build_with_etdump=true ;;
       *)
       ;;
@@ -44,25 +44,25 @@ for arg in "$@"; do
 done
 
 et_build_dir="${et_build_root}/cmake-out"
+
+# Used for flatcc host excutable if Devtools is used
 et_build_host_dir=${et_build_root}/cmake-out-host-tools
 
 set -x
 cd "${et_root_dir}"
 
-build_with_etdump_flags=""
 if [ "$build_with_etdump" = true ] ; then
     ( set +x ;
         echo "--------------------------------------------------------------------------------" ;
-        echo "Build ExecuTorch Libraries host flatcc bin ${build_type} into ${et_build_host_dir} - ${et_build_host_dir}/bin/flatcc" ;
+        echo "Build ExecuTorch Libraries host flatcc bin ${build_type} into ${et_build_host_dir}/bin/flatcc" ;
         echo "--------------------------------------------------------------------------------" )
-
 
     # Build host flatcc bin
     # This is a way to work around that the flatcc executable get build for target (e.g. Arm) later
     # and get replaced. flatcc is a tool used on the host for etdump and BundleIO handling.
     # The way to solve this is to generate it once for the host, then copy it to ${et_build_host_dir}/bin
     # and later point that out with -DFLATCC_EXECUTABLE=${et_build_host_dir}/bin/flatcc later.
-    mkdir -p ${et_build_host_dir}
+
     cmake                                                 \
         -DCMAKE_INSTALL_PREFIX=${et_build_host_dir}       \
         -DCMAKE_BUILD_TYPE=${build_type}                  \
@@ -79,24 +79,38 @@ if [ "$build_with_etdump" = true ] ; then
         -B"${et_build_host_dir}"                          \
         "${et_root_dir}"
 
-    # Copy host flatcc excutable to it's saved when we build for target (Arm) later
+    # third-party/flatcc/bin/flatcc gets build already in the in the cmake config step above
+    # so there is no cmake building step done
+
+    # Copy host flatcc excutable so it's saved when we build for target (Arm) later
+    et_build_host_dir=$(realpath ${et_build_host_dir})
     mkdir -p ${et_build_host_dir}/bin
     cp third-party/flatcc/bin/flatcc ${et_build_host_dir}/bin
-
-    # Add DevTools flags use in the Target build below
-    build_with_etdump_flags="-DEXECUTORCH_BUILD_DEVTOOLS=ON                    \
-                                -DEXECUTORCH_ENABLE_EVENT_TRACER=ON               \
-                                -DEXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT=OFF     \
-                                -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=OFF      \
-                                -DFLATCC_ALLOW_WERROR=OFF                         \
-                                -DFLATCC_EXECUTABLE=${et_build_host_dir}/bin/flatcc "
-    echo "build_with_etdump_flags=$build_with_etdump_flags"
 fi
 
 ( set +x ;
     echo "--------------------------------------------------------------------------------" ;
     echo "Build ExecuTorch target libs ${build_type} into '${et_build_dir}'" ;
     echo "--------------------------------------------------------------------------------" )
+
+build_devtools_flags=" -DEXECUTORCH_BUILD_DEVTOOLS=OFF "
+if [ "$build_devtools" = true ] ; then
+    build_devtools_flags=" -DEXECUTORCH_BUILD_DEVTOOLS=ON "
+fi
+
+build_with_etdump_flags=" -DEXECUTORCH_ENABLE_EVENT_TRACER=OFF "
+if [ "$build_with_etdump" = true ] ; then
+    # Add DevTools flags use in the Target build below
+    build_with_etdump_flags="-DEXECUTORCH_BUILD_DEVTOOLS=ON                    \
+                            -DEXECUTORCH_ENABLE_EVENT_TRACER=ON               \
+                            -DEXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT=OFF     \
+                            -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=OFF      \
+                            -DFLATCC_ALLOW_WERROR=OFF                         \
+                            -DFLATCC_EXECUTABLE=${et_build_host_dir}/bin/flatcc "
+fi
+
+echo "Building with Devtools: ${build_devtools_flags} ${build_with_etdump_flags}"
+
 
 # Build
 cmake                                                 \
@@ -108,6 +122,7 @@ cmake                                                 \
     -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON           \
     -DEXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL=ON       \
     -DEXECUTORCH_ENABLE_LOGGING=ON                    \
+    ${build_devtools_flags}                           \
     ${build_with_etdump_flags}                        \
     -DFLATC_EXECUTABLE="$(which flatc)"               \
     -B"${et_build_dir}"                               \

--- a/backends/arm/test/test_arm_baremetal.sh
+++ b/backends/arm/test/test_arm_baremetal.sh
@@ -92,18 +92,18 @@ test_run_ethosu_fvp() { # End to End model tests using run.sh
 
     # TOSA quantized
     echo "${TEST_SUITE_NAME}: Test ethos-u target TOSA"
-    examples/arm/run.sh --target=TOSA --model_name=add
-    examples/arm/run.sh --target=TOSA --model_name=mul
+    examples/arm/run.sh --et_build_root=arm_test/test_run --target=TOSA --model_name=add
+    examples/arm/run.sh --et_build_root=arm_test/test_run --target=TOSA --model_name=mul
 
     # Ethos-U55
     echo "${TEST_SUITE_NAME}: Test ethos-u target Ethos-U55"
-    examples/arm/run.sh --target=ethos-u55-128 --model_name=add
-    examples/arm/run.sh --target=ethos-u55-128 --model_name=mul
+    examples/arm/run.sh --et_build_root=arm_test/test_run --target=ethos-u55-128 --model_name=add
+    examples/arm/run.sh --et_build_root=arm_test/test_run --target=ethos-u55-128 --model_name=mul
 
     # Ethos-U85
     echo "${TEST_SUITE_NAME}: Test ethos-u target Ethos-U85"
-    examples/arm/run.sh --target=ethos-u85-128 --model_name=add
-    examples/arm/run.sh --target=ethos-u85-128 --model_name=mul
+    examples/arm/run.sh --et_build_root=arm_test/test_run --target=ethos-u85-128 --model_name=add
+    examples/arm/run.sh --et_build_root=arm_test/test_run --target=ethos-u85-128 --model_name=mul
     echo "${TEST_SUITE_NAME}: PASS"
     }
 
@@ -113,26 +113,26 @@ test_models_ethosu_fvp() { # End to End model tests using model_test.py
     source examples/arm/ethos-u-scratch/setup_path.sh
 
     # Build common libs once
-    python3 backends/arm/test/test_model.py --build_libs
+    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --build_libs
 
     # TOSA quantized
     echo "${TEST_SUITE_NAME}: Test ethos-u target TOSA"
-    python3 backends/arm/test/test_model.py --target=TOSA --model=mv2
-    python3 backends/arm/test/test_model.py --target=TOSA --model=mv3
-    python3 backends/arm/test/test_model.py --target=TOSA --model=lstm
-    python3 backends/arm/test/test_model.py --target=TOSA --model=edsr
+    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --target=TOSA --model=mv2
+    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --target=TOSA --model=mv3
+    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --target=TOSA --model=lstm
+    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --target=TOSA --model=edsr
 
     # Ethos-U55
     echo "${TEST_SUITE_NAME}: Test ethos-u target Ethos-U55"
-    python3 backends/arm/test/test_model.py --target=ethos-u55-128 --model=mv2
-    python3 backends/arm/test/test_model.py --target=ethos-u55-64 --model=mv3
-    python3 backends/arm/test/test_model.py --target=ethos-u55-256 --model=lstm
+    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --target=ethos-u55-128 --model=mv2  --extra_flags="-DET_ATOL=1.20 -DET_RTOL=1.20"
+    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --target=ethos-u55-64  --model=mv3  --extra_flags="-DET_ATOL=5.00 -DET_RTOL=5.00"
+    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --target=ethos-u55-256 --model=lstm --extra_flags="-DET_ATOL=0.02 -DET_RTOL=0.02"
 
     # Ethos-U85
     echo "${TEST_SUITE_NAME}: Test ethos-u target Ethos-U85"
-    python3 backends/arm/test/test_model.py --target=ethos-u85-256 --model=mv2
-    python3 backends/arm/test/test_model.py --target=ethos-u85-1024 --model=mv3
-    python3 backends/arm/test/test_model.py --target=ethos-u85-128 --model=lstm
+    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --target=ethos-u85-256  --model=mv2  --extra_flags="-DET_ATOL=1.20 -DET_RTOL=1.20"
+    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --target=ethos-u85-1024 --model=mv3  --extra_flags="-DET_ATOL=5.00 -DET_RTOL=5.00"
+    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --target=ethos-u85-128  --model=lstm --extra_flags="-DET_ATOL=0.02 -DET_RTOL=0.02"
     echo "${TEST_SUITE_NAME}: PASS"
     }
 

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -13,9 +13,10 @@ import logging
 import os
 
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
+from examples.devtools.scripts.export_bundled_program import save_bundled_program
 from executorch.backends.arm.arm_backend import (
     ArmCompileSpecBuilder,
     get_tosa_spec,
@@ -36,6 +37,8 @@ from executorch.backends.arm.util.arm_model_evaluator import (
     MobileNetV2Evaluator,
 )
 from executorch.devtools.backend_debug import get_delegation_info
+from executorch.devtools.bundled_program.config import MethodTestCase, MethodTestSuite
+
 from executorch.exir import (
     EdgeCompileConfig,
     ExecutorchBackendConfig,
@@ -56,27 +59,50 @@ FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
 logging.basicConfig(level=logging.WARNING, format=FORMAT)
 
 
-def get_model_and_inputs_from_name(model_name: str) -> Tuple[torch.nn.Module, Any]:
+def get_model_and_inputs_from_name(
+    model_name: str, model_input: str | None
+) -> Tuple[torch.nn.Module, Any]:
     """Given the name of an example pytorch model, return it and example inputs.
 
     Raises RuntimeError if there is no example model corresponding to the given name.
     """
+    example_inputs = None
+    if model_input is not None:
+        logging.info(f"Load model input from {model_input}")
+        if model_input.endswith(".pt"):
+            example_inputs = torch.load(model_input, weights_only=False)
+        else:
+            raise RuntimeError(
+                f"Model input data '{model_input}' is not a valid name. Use --model_input <FILE>.pt e.g. saved with torch.save()"
+            )
+
     # Case 1: Model is defined in this file
     if model_name in models.keys():
+        logging.info(f"Internal model {model_name}")
         model = models[model_name]()
-        example_inputs = models[model_name].example_input
+        if example_inputs is None:
+            example_inputs = models[model_name].example_input
     # Case 2: Model is defined in examples/models/
     elif model_name in MODEL_NAME_TO_MODEL.keys():
         logging.warning(
             "Using a model from examples/models not all of these are currently supported"
         )
-        model, example_inputs, _, _ = EagerModelFactory.create_model(
+        logging.info(
+            f"Load {model_name} -> {MODEL_NAME_TO_MODEL[model_name]} from examples/models"
+        )
+
+        model, tmp_example_inputs, _, _ = EagerModelFactory.create_model(
             *MODEL_NAME_TO_MODEL[model_name]
         )
+        if example_inputs is None:
+            example_inputs = tmp_example_inputs
     # Case 3: Model is in an external python file loaded as a module.
     #         ModelUnderTest should be a torch.nn.module instance
     #         ModelInputs should be a tuple of inputs to the forward function
     elif model_name.endswith(".py"):
+        logging.info(
+            f"Load model file {model_name}   Variable ModelUnderTest=<Model> ModelInputs=<ModelInput>"
+        )
         import importlib.util
 
         # load model's module and add it
@@ -84,13 +110,22 @@ def get_model_and_inputs_from_name(model_name: str) -> Tuple[torch.nn.Module, An
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         model = module.ModelUnderTest
-        example_inputs = module.ModelInputs
-
+        if example_inputs is None:
+            example_inputs = module.ModelInputs
+    # Case 4: Model is in an saved model file torch.save(model)
+    elif model_name.endswith(".pth") or model_name.endswith(".pt"):
+        logging.info(f"Load model file {model_name}")
+        model = torch.load(model_name, weights_only=False)
+        if example_inputs is None:
+            raise RuntimeError(
+                f"Model '{model_name}' requires input data specify --model_input <FILE>.pt"
+            )
     else:
         raise RuntimeError(
             f"Model '{model_name}' is not a valid name. Use --help for a list of available models."
         )
-
+    logging.debug(f"Loaded model: {model}")
+    logging.debug(f"Loaded input: {example_inputs}")
     return model, example_inputs
 
 
@@ -107,7 +142,7 @@ def quantize(
     logging.debug(f"Original model: {model}")
     quantizer = None
     if is_ethosu(compile_specs):
-        quantizer = EthosUQuantizer(compile_spec)
+        quantizer = EthosUQuantizer(compile_specs)
     elif is_tosa(compile_specs):
         quantizer = TOSAQuantizer(get_tosa_spec(compile_specs))
     else:
@@ -365,13 +400,19 @@ def dump_delegation_info(edge, intermediate_files_folder: Optional[str] = None):
             file.write(delegation_info_string)
 
 
-def get_args():  # noqa C901
+def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-m",
         "--model_name",
         required=True,
-        help=f"Provide model name. Valid ones: {set(list(models.keys())+list(MODEL_NAME_TO_MODEL.keys()))}",
+        help=f"Model file .py/.pth/.pt, builtin model or a model from examples/models. Valid names: {set(list(models.keys())+list(MODEL_NAME_TO_MODEL.keys()))}",
+    )
+    parser.add_argument(
+        "--model_input",
+        required=False,
+        default=None,
+        help="Provide model input .pt file, or python variable name",
     )
     parser.add_argument(
         "-d",
@@ -380,6 +421,13 @@ def get_args():  # noqa C901
         required=False,
         default=False,
         help="Flag for producing ArmBackend delegated model",
+    )
+    parser.add_argument(
+        "--bundleio",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Flag for producing BundleIO bpte file with input/output test/ref data.",
     )
     parser.add_argument(
         "-t",
@@ -436,7 +484,7 @@ def get_args():  # noqa C901
         "--output",
         action="store",
         required=False,
-        help="Location for outputs, if not the default of cwd.",
+        help="Filename (if .pte or .bpte is used) or a folder for outputs, if not specified the default is to place files in cwd.",
     )
     parser.add_argument(
         "--system_config",
@@ -467,10 +515,6 @@ def get_args():  # noqa C901
             "Quantization enabled without supplying path to libcustom_ops_aot_lib using -s flag."
             + "This is required for running quantized models with unquantized input."
         )
-
-    if args.quantize and not args.delegate:
-        logging.error("--delegate must be set when using --quanitze flag.")
-        exit(1)
 
     # if we have custom ops, register them before processing the model
     if args.so_library is not None:
@@ -503,12 +547,136 @@ def get_args():  # noqa C901
     return args
 
 
-if __name__ == "__main__":
+def save_bpte_program(exec_prog, original_model: torch.nn.Module, output_name: str):
+    # Construct MethodTestSuite for Each Method
+
+    # Generate Test Suites
+    method_names = [
+        method.name for method in exec_prog.executorch_program.execution_plan
+    ]
+
+    program_inputs = {m_name: [example_inputs] for m_name in method_names}
+
+    method_test_suites: List[MethodTestSuite] = []
+    for m_name in method_names:
+        method_inputs = program_inputs[m_name]
+
+        # To create a bundled program, we first create every test cases from input. We leverage eager model
+        # to generate expected output for each test input, and use MethodTestCase to hold the information of
+        # each test case. We gather all MethodTestCase for same method into one MethodTestSuite, and generate
+        # bundled program by all MethodTestSuites.
+        method_test_cases: List[MethodTestCase] = []
+
+        if args.intermediates:
+            # Save model.pth
+            intermediates_path = Path(args.intermediates)
+            model_path = os.path.join(intermediates_path, "model.pth")
+            try:
+                torch.save(original_model, model_path)
+            except:
+                logging.warning(f"Could not torch.save(model, {model_path})")
+        method_index = 0
+        for method_input in method_inputs:
+            output_ref = original_model(*method_input)
+
+            logging.debug(f"input_{method_index}: {method_input}")
+            logging.debug(f"output_ref_{method_index}: {output_ref}")
+
+            if args.intermediates:
+                # Save model input and referece output
+                input_path = os.path.join(
+                    intermediates_path, f"input_{method_index}.pt"
+                )
+                try:
+                    torch.save(method_input, input_path)
+                except:
+                    logging.warning(
+                        f"Could not torch.save(input_{method_index}, {input_path})"
+                    )
+                refoutput_path = os.path.join(
+                    intermediates_path, f"output_ref_{method_index}.pt"
+                )
+                try:
+                    torch.save(output_ref, refoutput_path)
+                except:
+                    logging.warning(
+                        f"Could not torch.save(output_ref_{method_index}, {refoutput_path})"
+                    )
+
+            method_test_cases.append(
+                MethodTestCase(
+                    inputs=method_input,
+                    expected_outputs=output_ref,
+                )
+            )
+
+            method_index = method_index + 1
+
+        method_test_suites.append(
+            MethodTestSuite(
+                method_name=m_name,
+                test_cases=method_test_cases,
+            )
+        )
+
+    # Generate BundledProgram
+    save_bundled_program(exec_prog, method_test_suites, output_name)
+
+
+def to_edge_TOSA_delegate(
+    args,
+    model: torch.nn.Module,
+):
+    model_int8 = None
+    # As we can target multiple output encodings, one must
+    # be specified.
+    compile_spec = get_compile_spec(
+        args.target,
+        args.intermediates,
+        args.system_config,
+        args.memory_mode,
+    )
+    if args.quantize:
+        model = quantize(
+            model,
+            args.model_name,
+            compile_spec,
+            example_inputs,
+            args.evaluate,
+            args.evaluate_config,
+        )
+        model_int8 = model
+        # Wrap quantized model back into an exported_program
+        exported_program = torch.export.export_for_training(model, example_inputs)
+
+        if args.intermediates:
+            os.makedirs(args.intermediates, exist_ok=True)
+
+    if is_ethosu(compile_spec):
+        partitioner = EthosUPartitioner(compile_spec)
+    elif is_tosa(compile_spec):
+        partitioner = TOSAPartitioner(compile_spec)
+    else:
+        raise RuntimeError(f"Unhandled compile spec: {compile_spec}")
+
+    edge = to_edge_transform_and_lower(
+        exported_program,
+        partitioner=[partitioner],
+        compile_config=EdgeCompileConfig(
+            _check_ir_validity=False,
+        ),
+    )
+    return model_int8, edge
+
+
+if __name__ == "__main__":  # noqa: C901
     args = get_args()
 
     # Pick model from one of the supported lists
-    model, example_inputs = get_model_and_inputs_from_name(args.model_name)
-    model = model.eval()
+    original_model, example_inputs = get_model_and_inputs_from_name(
+        args.model_name, args.model_input
+    )
+    model = original_model.eval()
 
     # export_for_training under the assumption we quantize, the exported form also works
     # in to_edge if we don't quantize
@@ -519,44 +687,7 @@ if __name__ == "__main__":
     # Quantize if required
     model_int8 = None
     if args.delegate:
-        # As we can target multiple output encodings, one must
-        # be specified.
-        compile_spec = get_compile_spec(
-            args.target,
-            args.intermediates,
-            args.system_config,
-            args.memory_mode,
-        )
-        if args.quantize:
-            model = quantize(
-                model,
-                args.model_name,
-                compile_spec,
-                example_inputs,
-                args.evaluate,
-                args.evaluate_config,
-            )
-            model_int8 = model
-            # Wrap quantized model back into an exported_program
-            exported_program = torch.export.export_for_training(model, example_inputs)
-
-            if args.intermediates:
-                os.makedirs(args.intermediates, exist_ok=True)
-
-        if is_ethosu(compile_spec):
-            partitioner = EthosUPartitioner(compile_spec)
-        elif is_tosa(compile_spec):
-            partitioner = TOSAPartitioner(compile_spec)
-        else:
-            raise RuntimeError(f"Unhandled compile spec: {compile_spec}")
-
-        edge = to_edge_transform_and_lower(
-            exported_program,
-            partitioner=[partitioner],
-            compile_config=EdgeCompileConfig(
-                _check_ir_validity=False,
-            ),
-        )
+        model_int8, edge = to_edge_TOSA_delegate(args, model)
     else:
         edge = to_edge_transform_and_lower(
             exported_program,
@@ -587,11 +718,33 @@ if __name__ == "__main__":
         else f"_arm_{args.target}"
     )
 
-    if args.output is not None:
-        output_name = os.path.join(args.output, output_name)
+    if args.bundleio:
+        output_name = f"{output_name}.bpte"
+    else:
+        output_name = f"{output_name}.pte"
 
-    save_pte_program(exec_prog, output_name)
-    print(f"PTE file saved as {output_name}.pte")
+    if args.output is not None:
+        if args.output.endswith(".pte") or args.output.endswith(".bpte"):
+            # --output is a pte or bundle pte filename use it as output name
+            if args.bundleio and not args.output.endswith(".bpte"):
+                raise RuntimeError(
+                    f"--bundleio expects a .bpte file ending to --output and not .pte {args.output}"
+                )
+            if not args.bundleio and not args.output.endswith(".pte"):
+                raise RuntimeError(
+                    f"When not using --bundleio a .bpte file should not be use as --output {args.output}"
+                )
+            output_name = args.output
+        else:
+            # --output is a folder
+            output_name = os.path.join(args.output, output_name)
+
+    if args.bundleio:
+        save_bpte_program(exec_prog, original_model, output_name)
+        print(f"Bundle PTE file saved as {output_name}")
+    else:
+        save_pte_program(exec_prog, output_name)
+        print(f"PTE file saved as {output_name}")
 
     if args.evaluate:
         evaluate_model(

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -9,11 +9,14 @@ project(arm_executor_runner)
 option(SEMIHOSTING "Enable semihosting" OFF)
 option(ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE "Set ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE to specify memory alloction pool size" OFF)
 option(ET_ARM_BAREMETAL_TEMP_ALLOCATOR_POOL_SIZE "Set ET_ARM_BAREMETAL_TEMP_ALLOCATOR_POOL_SIZE to specify temp alloction pool size" OFF)
+option(ET_BUNDLE_IO "Set to compile in BundleIO support" OFF)
+option(ET_ATOL "Set atol to use for BundleIO testing" OFF)
+option(ET_RTOL "Set rtol to use for BundleIO testing" OFF)
 
 if(NOT DEFINED ET_PTE_FILE_PATH AND NOT ${SEMIHOSTING})
   message(
     FATAL_ERROR
-      "ET_PTE_FILE_PATH must specify a model .pte, for bare metal systems the "
+      "ET_PTE_FILE_PATH must specify a model .pte or .bpte, for bare metal systems the "
       "model is built into the binary."
   )
 endif()
@@ -373,6 +376,18 @@ if(EXECUTORCH_ENABLE_EVENT_TRACER)
   )
 endif()
 
+if(ET_BUNDLE_IO)
+  add_library(bundled_program STATIC IMPORTED)
+  set_property(
+    TARGET bundled_program
+    PROPERTY IMPORTED_LOCATION
+        "${ET_BUILD_DIR_PATH}/lib/libbundled_program.a"
+  )
+  list(APPEND arm_executor_runner_link
+    bundled_program
+  )
+endif()
+
 # Need whole-archive to ensure C++ ctor's are called - this may be wasteful for
 # bin size as we link in a number of other symbols
 target_link_libraries(
@@ -400,6 +415,18 @@ endif()
 
 if(ET_ARM_BAREMETAL_TEMP_ALLOCATOR_POOL_SIZE)
   target_compile_definitions(arm_executor_runner PUBLIC ET_ARM_BAREMETAL_TEMP_ALLOCATOR_POOL_SIZE=${ET_ARM_BAREMETAL_TEMP_ALLOCATOR_POOL_SIZE})
+endif()
+
+if(ET_BUNDLE_IO)
+  target_compile_definitions(arm_executor_runner PUBLIC -DET_BUNDLE_IO)
+endif()
+
+if(ET_ATOL)
+  target_compile_definitions(arm_executor_runner PUBLIC ET_ATOL=${ET_ATOL})
+endif()
+
+if(ET_RTOL)
+  target_compile_definitions(arm_executor_runner PUBLIC ET_RTOL=${ET_RTOL})
 endif()
 
 # Fixup compilation of retarget.c

--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -18,11 +18,14 @@ et_root_dir=$(realpath ${et_root_dir})
 
 
 model_name=""
+model_input_set=false
+model_input=""
 aot_arm_compiler_flags="--delegate --quantize"
 portable_kernels="aten::_softmax.out"
 target="ethos-u55-128"
 output_folder_set=false
 output_folder="."
+bundleio=false
 build_with_etdump=false
 build_type="Release"
 extra_build_flags=""
@@ -35,11 +38,13 @@ ethos_u_scratch_dir=${script_dir}/ethos-u-scratch
 function help() {
     echo "Usage: $(basename $0) [options]"
     echo "Options:"
-    echo "  --model_name=<MODEL>                   Model to run, can be a builtin, examples/models or a filename Default to all builtin models"
+    echo "  --model_name=<MODEL>                   Model file .py/.pth/.pt, builtin model or a model from examples/models. Passed to aot_arm_compiler"
+    echo "  --model_input=<INPUT>                  Provide model input .pt file to override the input in the model file.  Passed to aot_arm_compiler"
     echo "  --aot_arm_compiler_flags=<FLAGS>       Only used if --model_name is used Default: ${aot_arm_compiler_flags}"
     echo "  --portable_kernels=<OPS>               Comma separated list of portable (non delagated) kernels to include Default: ${portable_kernels}"
     echo "  --target=<TARGET>                      Target to build and run for Default: ${target}"
     echo "  --output=<FOLDER>                      Target build output folder Default: ${output_folder}"
+    echo "  --bundleio                             Create Bundled pte using Devtools BundelIO with Input/RefOutput included"
     echo "  --etdump                               Adds Devtools etdump support to track timing, etdump area will be base64 encoded in the log"
     echo "  --build_type=<TYPE>                    Build with Release, Debug or RelWithDebInfo, default is ${build_type}"
     echo "  --extra_build_flags=<FLAGS>            Extra flags to pass to cmake like -DET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE=60000 Default: none "
@@ -56,10 +61,12 @@ for arg in "$@"; do
     case $arg in
       -h|--help) help ;;
       --model_name=*) model_name="${arg#*=}";;
+      --model_input=*) model_input="${arg#*=}" ; model_input_set=true  ;;
       --aot_arm_compiler_flags=*) aot_arm_compiler_flags="${arg#*=}";;
       --portable_kernels=*) portable_kernels="${arg#*=}";;
       --target=*) target="${arg#*=}";;
       --output=*) output_folder="${arg#*=}" ; output_folder_set=true ;;
+      --bundleio) bundleio=true ;;
       --etdump) build_with_etdump=true ;;
       --build_type=*) build_type="${arg#*=}";;
       --extra_build_flags=*) extra_build_flags="${arg#*=}";;
@@ -121,13 +128,21 @@ hash arm-none-eabi-gcc \
 
 # Build executorch libraries
 cd $et_root_dir
+devtools_flag=""
+bundleio_flag=""
+et_dump_flag=""
 if [ "$build_with_etdump" = true ] ; then
+    devtools_flag="--devtools --etdump"
     et_dump_flag="--etdump"
-else
-    et_dump_flag=""
 fi
 
-backends/arm/scripts/build_executorch.sh --et_build_root="${et_build_root}" --build_type=$build_type $et_dump_flag
+if [ "$bundleio" = true ] ; then
+    devtools_flag="--devtools --etdump"
+    bundleio_flag="--bundleio"
+    et_dump_flag="--etdump"
+fi
+
+backends/arm/scripts/build_executorch.sh --et_build_root="${et_build_root}" --build_type=$build_type $devtools_flag
 backends/arm/scripts/build_portable_kernels.sh --et_build_root="${et_build_root}" --build_type=$build_type --portable_kernels=$portable_kernels
 
 # Build a lib quantized_ops_aot_lib
@@ -157,12 +172,21 @@ for i in "${!test_model[@]}"; do
     echo "--------------------------------------------------------------------------------"
 
     cd $et_root_dir
-    model_short_name=$(basename -- "${model}" ".py")
-    model_filename=${model_short_name}_arm_${target}.pte
+    # Remove path and file exetension to get model_short_name
+    ext=${model##*.}
+    model_short_name=$(basename -- "${model}" .$ext)
+    model_filename=${model_short_name}_arm_${target}
 
     if [[ "${model_compiler_flags}" == *"--delegate"* ]]; then
         # Name aligned with default aot_arm_compiler output
-        model_filename=${model_short_name}_arm_delegate_${target}.pte
+        model_filename=${model_short_name}_arm_delegate_${target}
+    fi
+    elf_folder=${model_filename}
+
+    if [ "$bundleio" = true ] ; then
+        model_filename=${model_filename}.bpte
+    else
+        model_filename=${model_filename}.pte
     fi
 
     if [ "$output_folder_set" = false ] ; then
@@ -170,14 +194,18 @@ for i in "${!test_model[@]}"; do
     fi
 
     output_folder=$(realpath ${output_folder})
+    pte_file="${output_folder}/${model_filename}"
+
     mkdir -p ${output_folder}
-    pte_file=$(realpath -m ${output_folder}/${model_filename})
 
-    rm -f "${pte_file}"
-
-    ARM_AOT_CMD="python3 -m examples.arm.aot_arm_compiler --model_name=${model} --target=${target} ${model_compiler_flags} --intermediate=${output_folder} --output=${output_folder} --so_library=$SO_LIB --system_config=${system_config} --memory_mode=${memory_mode}"
+    # Remove old pte files
+    rm -f "${output_folder}/${model_filename}"
+    
+    ARM_AOT_CMD="python3 -m examples.arm.aot_arm_compiler --model_name=${model} --target=${target} ${model_compiler_flags} --intermediate=${output_folder} --output=${pte_file} --so_library=$SO_LIB --system_config=${system_config} --memory_mode=${memory_mode} $bundleio_flag"
     echo "CALL ${ARM_AOT_CMD}" >&2
     ${ARM_AOT_CMD} 1>&2
+
+    pte_file=$(realpath ${pte_file})
 
     [[ -f ${pte_file} ]] || { >&2 echo "Failed to generate a pte file - ${pte_file}"; exit 1; }
     echo "pte_data_size: $(wc -c ${pte_file})"
@@ -188,10 +216,11 @@ for i in "${!test_model[@]}"; do
     else
         set -x
         # Rebuild the application as the pte is imported as a header/c array
-        backends/arm/scripts/build_executorch_runner.sh "--pte=${pte_file}" --build_type=$build_type --target=$target --system_config=$system_config  $et_dump_flag --extra_build_flags="$extra_build_flags" --ethosu_tools_dir="$ethos_u_scratch_dir" --output="${output_folder}"
+        backends/arm/scripts/build_executorch_runner.sh --et_build_root="${et_build_root}" --pte="${pte_file}" --build_type=${build_type} --target=${target} --system_config=${system_config} ${bundleio_flag} ${et_dump_flag} --extra_build_flags="${extra_build_flags}" --ethosu_tools_dir="${ethos_u_scratch_dir}"
         if [ "$build_only" = false ] ; then
             # Execute the executor_runner on FVP Simulator
-            backends/arm/scripts/run_fvp.sh --elf=${output_folder}/cmake-out/arm_executor_runner --target=$target
+            elf_file="${output_folder}/${elf_folder}/cmake-out/arm_executor_runner"
+            backends/arm/scripts/run_fvp.sh --elf=${elf_file} --target=$target
         fi
         set +x
     fi


### PR DESCRIPTION
Add support for input and output testing using BundleIO in devtools.

Can be tested with:
run.sh --model_name=add --target=ethos-u85-128 --bundleio

aot_arm_compiler.py changes:
--bundleio      - Will generate a bundle .bpte file with input and reference output data
--model_name    - now also support .pt/.pth files e.g. a torch.save():ed model
--model_input   - If supplied will overried the model input data supply a torch.save():ed data
--intermediates - Will now save model.pth, input_xx.pt and output_ref_xx.pt files so testing can be reproduced

arm_executor_runner.cpp - can be build with ET_BUNDLE_IO to enable a .bpte and a input/output_ref testing flow

test_model.py script uses bundleio to verify input/output

test_arm_baremetal.sh script now tests models with BundleIO so output is compared to ref output


cc @digantdesai @freddan80 @per @oscarandersson8218