### PR TITLE
Remove tombstone messages proactively

### DIFF
--- a/examples/demo-apps/android/LlamaDemo/app/src/main/BUCK
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/BUCK
@@ -1,16 +1,17 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("@fbsource//tools/build_defs/android:fb_android_binary.bzl", "fb_android_binary")
 load("@fbsource//tools/build_defs/android:fb_android_library.bzl", "fb_android_library")
 load("@fbsource//tools/build_defs/android:fb_android_resource.bzl", "fb_android_resource")
 
 oncall("executorch")
 
-fb_android_resource(
+non_fbcode_target(_kind = fb_android_resource,
     name = "app_res",
     package = "com.example.executorchllamademo",
     res = "res",
 )
 
-fb_android_library(
+non_fbcode_target(_kind = fb_android_library,
     name = "app_lib",
     srcs = [
         "java/com/example/executorchllamademo/AppLog.java",
@@ -43,7 +44,7 @@ fb_android_library(
     ],
 )
 
-fb_android_binary(
+non_fbcode_target(_kind = fb_android_binary,
     name = "ExecuTorchLlamaDemo",
     keystore = "//fbandroid/keystores:debug",
     manifest = "AndroidManifest.xml",

--- a/examples/demo-apps/android/LlamaDemo/app/src/main/TARGETS
+++ b/examples/demo-apps/android/LlamaDemo/app/src/main/TARGETS
@@ -1,1 +1,0 @@
-# This file needs to exist to avoid build system breakage, see https://fburl.com/workplace/jtdlgdmd

--- a/extension/android/BUCK
+++ b/extension/android/BUCK
@@ -1,8 +1,9 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("@fbsource//tools/build_defs/android:fb_android_library.bzl", "fb_android_library")
 
 oncall("executorch")
 
-fb_android_library(
+non_fbcode_target(_kind = fb_android_library,
     name = "executorch",
     srcs = [
         "executorch_android/src/main/java/org/pytorch/executorch/DType.java",
@@ -20,7 +21,7 @@ fb_android_library(
     ],
 )
 
-fb_android_library(
+non_fbcode_target(_kind = fb_android_library,
     name = "executorch_llama",
     srcs = [
         "executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmCallback.java",

--- a/extension/android/TARGETS
+++ b/extension/android/TARGETS
@@ -1,1 +1,0 @@
-# This file needs to exist to avoid build system breakage, see https://fburl.com/workplace/jtdlgdmd

--- a/extension/android/jni/BUCK
+++ b/extension/android/jni/BUCK
@@ -1,3 +1,4 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("@fbsource//tools/build_defs/android:fb_android_cxx_library.bzl", "fb_android_cxx_library")
 load("@fbsource//xplat/executorch/backends/xnnpack/third-party:third_party_libs.bzl", "third_party_dep")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
@@ -5,7 +6,7 @@ load("@fbsource//xplat/executorch/codegen:codegen.bzl", "executorch_generated_li
 
 oncall("executorch")
 
-executorch_generated_lib(
+non_fbcode_target(_kind = executorch_generated_lib,
     name = "generated_op_lib_optimized",
     custom_ops_aten_kernel_deps = [
         "//executorch/kernels/portable:operators_aten",
@@ -24,7 +25,7 @@ executorch_generated_lib(
     ],
 )
 
-fb_android_cxx_library(
+non_fbcode_target(_kind = fb_android_cxx_library,
     name = "executorch_jni",
     srcs = ["jni_layer.cpp", "log.cpp"],
     headers = ["jni_layer_constants.h"],
@@ -49,7 +50,7 @@ fb_android_cxx_library(
     ],
 )
 
-fb_android_cxx_library(
+non_fbcode_target(_kind = fb_android_cxx_library,
     name = "executorch_jni_full",
     srcs = ["jni_layer.cpp", "log.cpp"],
     headers = ["jni_layer_constants.h"],
@@ -74,7 +75,7 @@ fb_android_cxx_library(
     ],
 )
 
-fb_android_cxx_library(
+non_fbcode_target(_kind = fb_android_cxx_library,
     name = "executorch_llama_jni",
     srcs = [
         "jni_layer.cpp",
@@ -106,7 +107,7 @@ fb_android_cxx_library(
     ],
 )
 
-runtime.cxx_library(
+non_fbcode_target(_kind = runtime.cxx_library,
     name = "log_provider",
     srcs = ["log.cpp"],
     exported_headers = ["log.h"],

--- a/extension/android/jni/TARGETS
+++ b/extension/android/jni/TARGETS
@@ -1,1 +1,0 @@
-# This file needs to exist to avoid build system breakage, see https://fburl.com/workplace/jtdlgdmd

--- a/extension/apple/ExecuTorch/TARGETS
+++ b/extension/apple/ExecuTorch/TARGETS
@@ -1,1 +1,0 @@
-# This file needs to exist to avoid build system breakage, see https://fburl.com/workplace/jtdlgdmd

--- a/extension/apple/TARGETS
+++ b/extension/apple/TARGETS
@@ -1,1 +1,0 @@
-# This file needs to exist to avoid build system breakage, see https://fburl.com/workplace/jtdlgdmd


### PR DESCRIPTION
Summary:
Originally we created a bunch of empty `TARGETS` files to allow us to enable `BUCK` files in fbcode by hiding the existing BUCK file. These files were subsequently merged together using `non_fbcode_target` so these tombstones are no longer necessary.

This diff fixes all files that WOULD have had the useless tombstone merged into them. To create this diff, I just ran the merger script that Codemod Service is using and then deleted the "merged from" and tombstone lines with `sed`, `arc f` and reverted any lines that didn't make sense

Differential Revision: D69994481


