### PR TITLE
[devtool] introduce sanity check when creating bufferdatasink

### DIFF
--- a/devtools/etdump/buffer_data_sink.cpp
+++ b/devtools/etdump/buffer_data_sink.cpp
@@ -11,9 +11,21 @@
 
 using ::executorch::runtime::Error;
 using ::executorch::runtime::Result;
+using ::executorch::runtime::Span;
 
 namespace executorch {
 namespace etdump {
+
+Result<BufferDataSink> BufferDataSink::create(
+    Span<uint8_t> buffer,
+    size_t alignment) noexcept {
+  // Check if alignment is a power of two and greater than 0
+  if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
+    return Error::InvalidArgument;
+  }
+
+  return BufferDataSink(buffer, alignment);
+}
 
 Result<size_t> BufferDataSink::write(const void* ptr, size_t length) {
   if (length == 0) {

--- a/devtools/etdump/buffer_data_sink.h
+++ b/devtools/etdump/buffer_data_sink.h
@@ -24,17 +24,20 @@ namespace etdump {
 class BufferDataSink : public DataSinkBase {
  public:
   /**
-   * Constructs a BufferDataSink with a given buffer.
+   * Creates a BufferDataSink with a given span buffer.
    *
    * @param[in] buffer A Span object representing the buffer where data will be
    * stored.
    * @param[in] alignment The alignment requirement for the buffer. It must be
-   * a power of two. Default is 64.
+   * a power of two and greater than zero. Default is 64.
+   * @return A Result object containing either:
+   *         - A BufferDataSink object if succees, or
+   *         - An error code indicating the failure reason, if any issue
+   *           occurs during the creation process.
    */
-  explicit BufferDataSink(
+  static ::executorch::runtime::Result<BufferDataSink> create(
       ::executorch::runtime::Span<uint8_t> buffer,
-      size_t alignment = 64)
-      : debug_buffer_(buffer), offset_(0), alignment_(alignment) {}
+      size_t alignment = 64) noexcept;
 
   // Uncopiable and unassignable to avoid double assignment and free of the
   // internal buffer.
@@ -77,6 +80,19 @@ class BufferDataSink : public DataSinkBase {
   size_t get_used_bytes() const override;
 
  private:
+  /**
+   * Constructs a BufferDataSink with a given buffer.
+   *
+   * @param[in] buffer A Span object representing the buffer where data will be
+   * stored.
+   * @param[in] alignment The alignment requirement for the buffer. It must be
+   * a power of two. Default is 64.
+   */
+  explicit BufferDataSink(
+      ::executorch::runtime::Span<uint8_t> buffer,
+      size_t alignment)
+      : debug_buffer_(buffer), offset_(0), alignment_(alignment) {}
+
   // A Span object representing the buffer used for storing debug data.
   ::executorch::runtime::Span<uint8_t> debug_buffer_;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This diff introduces sanity check on data alignment when creating buffer_data_sink. Also, for better control the raised error, we changed to use static function instead of constructor for constuction.

Differential Revision: [D70190912](https://our.internmc.facebook.com/intern/diff/D70190912/)