### PR TITLE
make ETDumpGen use bufferdatasink

### DIFF
--- a/devtools/CMakeLists.txt
+++ b/devtools/CMakeLists.txt
@@ -176,6 +176,8 @@ add_custom_command(
 add_library(
   etdump ${CMAKE_CURRENT_SOURCE_DIR}/etdump/etdump_flatcc.cpp
          ${CMAKE_CURRENT_SOURCE_DIR}/etdump/emitter.cpp
+         ${CMAKE_CURRENT_SOURCE_DIR}/etdump/buffer_data_sink.cpp
+         ${CMAKE_CURRENT_SOURCE_DIR}/etdump/buffer_data_sink.h
 )
 
 target_link_libraries(

--- a/devtools/etdump/buffer_data_sink.cpp
+++ b/devtools/etdump/buffer_data_sink.cpp
@@ -27,6 +27,11 @@ Result<BufferDataSink> BufferDataSink::create(
   return BufferDataSink(buffer, alignment);
 }
 
+Result<BufferDataSink>
+BufferDataSink::create(void* ptr, size_t size, size_t alignment) noexcept {
+  return BufferDataSink::create({(uint8_t*)ptr, size}, alignment);
+}
+
 Result<size_t> BufferDataSink::write(const void* ptr, size_t length) {
   if (length == 0) {
     return offset_;

--- a/devtools/etdump/buffer_data_sink.h
+++ b/devtools/etdump/buffer_data_sink.h
@@ -39,6 +39,26 @@ class BufferDataSink : public DataSinkBase {
       ::executorch::runtime::Span<uint8_t> buffer,
       size_t alignment = 64) noexcept;
 
+  /**
+   * Creates a BufferDataSink with a given span buffer.
+   *
+   * @param[in] ptr A pointer to the data blob where data will be stored.
+   * @param[in] size The size of the data blob in bytes.
+   * @param[in] alignment The alignment requirement for the buffer. It must be
+   * a power of two and greater than zero. Default is 64.
+   * @return A Result object containing either:
+   *         - A BufferDataSink object if succees, or
+   *         - An error code indicating the failure reason, if any issue
+   *           occurs during the creation process.
+   */
+  static ::executorch::runtime::Result<BufferDataSink>
+  create(void* ptr, size_t size, size_t alignment = 64) noexcept;
+
+  /**
+   * Creates a empty BufferDataSink;
+   */
+  BufferDataSink() = default;
+
   // Uncopiable and unassignable to avoid double assignment and free of the
   // internal buffer.
   BufferDataSink(const BufferDataSink&) = delete;

--- a/devtools/etdump/etdump_flatcc.h
+++ b/devtools/etdump/etdump_flatcc.h
@@ -9,7 +9,10 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 
+#include <executorch/devtools/etdump/buffer_data_sink.h>
+#include <executorch/devtools/etdump/data_sink_base.h>
 #include <executorch/runtime/core/event_tracer.h>
 #include <executorch/runtime/core/span.h>
 #include <executorch/runtime/platform/platform.h>
@@ -141,9 +144,10 @@ class ETDumpGen : public ::executorch::runtime::EventTracer {
       ::executorch::runtime::DebugHandle delegate_debug_index,
       const double& output) override;
   void set_debug_buffer(::executorch::runtime::Span<uint8_t> buffer);
+  void set_data_sink(DataSinkBase* data_sink);
   ETDumpResult get_etdump_data();
-  size_t get_debug_buffer_size() const;
   size_t get_num_blocks();
+  DataSinkBase* get_data_sink();
   bool is_static_etdump();
   void reset();
 
@@ -158,7 +162,6 @@ class ETDumpGen : public ::executorch::runtime::EventTracer {
 
   void check_ready_to_add_events();
   int64_t create_string_entry(const char* name);
-  size_t copy_tensor_to_debug_buffer(executorch::aten::Tensor tensor);
 
   /**
    * Templated helper function used to log various types of intermediate output.
@@ -170,10 +173,15 @@ class ETDumpGen : public ::executorch::runtime::EventTracer {
       ::executorch::runtime::DebugHandle delegate_debug_index,
       const T& output);
 
+  long write_tensor_or_raise_error(executorch::aten::Tensor tensor);
+
   struct flatcc_builder* builder_;
   size_t num_blocks_ = 0;
-  ::executorch::runtime::Span<uint8_t> debug_buffer_;
-  size_t debug_buffer_offset_ = 0;
+  DataSinkBase* data_sink_;
+
+  // It is only for set_debug_buffer function.
+  BufferDataSink buffer_data_sink_;
+
   int bundled_input_index_ = -1;
   State state_ = State::Init;
   struct internal::ETDumpStaticAllocator alloc_;

--- a/devtools/etdump/targets.bzl
+++ b/devtools/etdump/targets.bzl
@@ -117,7 +117,7 @@ def define_common_targets():
 
         runtime.cxx_library(
             name = "buffer_data_sink" + aten_suffix,
-            headers = [
+            exported_headers = [
                 "buffer_data_sink.h",
             ],
             srcs = [
@@ -153,6 +153,8 @@ def define_common_targets():
             exported_deps = [
                 ":etdump_schema_flatcc",
                 ":utils",
+                ":data_sink_base" + aten_suffix,
+                ":buffer_data_sink" + aten_suffix,
                 "//executorch/runtime/core:event_tracer" + aten_suffix,
                 "//executorch/runtime/core/exec_aten/util:scalar_type_util" + aten_suffix,
             ],

--- a/devtools/etdump/tests/etdump_test.cpp
+++ b/devtools/etdump/tests/etdump_test.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 #include <cstdio>
 
+#include <executorch/devtools/etdump/buffer_data_sink.h>
 #include <executorch/devtools/etdump/etdump_flatcc.h>
 #include <executorch/devtools/etdump/etdump_schema_flatcc_builder.h>
 #include <executorch/devtools/etdump/etdump_schema_flatcc_reader.h>
@@ -18,7 +19,6 @@
 #include <executorch/test/utils/DeathTest.h>
 #include <cstdint>
 #include <cstring>
-#include <memory>
 
 using ::executorch::aten::ScalarType;
 using ::executorch::aten::Tensor;
@@ -34,6 +34,8 @@ using ::executorch::runtime::LoggedEValueType;
 using ::executorch::runtime::Span;
 using ::executorch::runtime::Tag;
 using ::executorch::runtime::testing::TensorFactory;
+
+using ::executorch::etdump::BufferDataSink;
 
 class ProfilerETDumpTest : public ::testing::Test {
  protected:
@@ -175,54 +177,78 @@ TEST_F(ProfilerETDumpTest, AllocationEvents) {
 
 TEST_F(ProfilerETDumpTest, DebugEvent) {
   for (size_t i = 0; i < 2; i++) {
-    TensorFactory<ScalarType::Float> tf;
-    EValue evalue(tf.ones({3, 2}));
+    for (size_t j = 0; j < 2; j++) {
+      TensorFactory<ScalarType::Float> tf;
+      EValue evalue(tf.ones({3, 2}));
 
-    etdump_gen[i]->create_event_block("test_block");
+      etdump_gen[i]->create_event_block("test_block");
 
-    void* ptr = malloc(2048);
-    Span<uint8_t> buffer((uint8_t*)ptr, 2048);
+      void* ptr = malloc(2048);
+      Span<uint8_t> buffer((uint8_t*)ptr, 2048);
 
-    etdump_gen[i]->set_debug_buffer(buffer);
-    etdump_gen[i]->log_evalue(evalue);
-    etdump_gen[i]->log_evalue(evalue, LoggedEValueType::kProgramOutput);
+      auto buffer_data_sink = BufferDataSink::create(ptr, 2048);
 
-    EValue evalue_int((int64_t)5);
-    etdump_gen[i]->log_evalue(evalue_int);
+      // using span to record debug data
+      if (j == 0) {
+        etdump_gen[i]->set_debug_buffer(buffer);
+      }
+      // using data sink to record debug data
+      else {
+        etdump_gen[i]->set_data_sink(&buffer_data_sink.get());
+      }
 
-    EValue evalue_double((double)1.5);
-    etdump_gen[i]->log_evalue(evalue_double);
+      etdump_gen[i]->log_evalue(evalue);
+      etdump_gen[i]->log_evalue(evalue, LoggedEValueType::kProgramOutput);
 
-    EValue evalue_bool(true);
-    etdump_gen[i]->log_evalue(evalue_bool);
+      EValue evalue_int((int64_t)5);
+      etdump_gen[i]->log_evalue(evalue_int);
 
-    etdump_gen[i]->log_evalue(evalue_bool);
+      EValue evalue_double((double)1.5);
+      etdump_gen[i]->log_evalue(evalue_double);
 
-    free(ptr);
+      EValue evalue_bool(true);
+      etdump_gen[i]->log_evalue(evalue_bool);
+
+      etdump_gen[i]->log_evalue(evalue_bool);
+
+      free(ptr);
+    }
   }
 }
 
 TEST_F(ProfilerETDumpTest, DebugEventTensorList) {
   for (size_t i = 0; i < 2; i++) {
-    TensorFactory<ScalarType::Int> tf;
-    executorch::aten::Tensor storage[2] = {tf.ones({3, 2}), tf.ones({3, 2})};
-    EValue evalue_1(storage[0]);
-    EValue evalue_2(storage[1]);
-    EValue* values_p[2] = {&evalue_1, &evalue_2};
+    for (size_t j = 0; j < 2; j++) {
+      TensorFactory<ScalarType::Int> tf;
+      executorch::aten::Tensor storage[2] = {tf.ones({3, 2}), tf.ones({3, 2})};
+      EValue evalue_1(storage[0]);
+      EValue evalue_2(storage[1]);
+      EValue* values_p[2] = {&evalue_1, &evalue_2};
 
-    BoxedEvalueList<executorch::aten::Tensor> a_box(values_p, storage, 2);
-    EValue evalue(a_box);
-    evalue.tag = Tag::ListTensor;
+      BoxedEvalueList<executorch::aten::Tensor> a_box(values_p, storage, 2);
+      EValue evalue(a_box);
+      evalue.tag = Tag::ListTensor;
 
-    etdump_gen[i]->create_event_block("test_block");
+      etdump_gen[i]->create_event_block("test_block");
 
-    void* ptr = malloc(2048);
-    Span<uint8_t> buffer((uint8_t*)ptr, 2048);
+      void* ptr = malloc(2048);
+      Span<uint8_t> buffer((uint8_t*)ptr, 2048);
 
-    etdump_gen[i]->set_debug_buffer(buffer);
-    etdump_gen[i]->log_evalue(evalue);
+      auto buffer_data_sink = BufferDataSink::create(ptr, 2048);
 
-    free(ptr);
+      // using span to record debug data
+      if (j == 0) {
+        etdump_gen[i]->set_debug_buffer(buffer);
+      }
+      // using data sink to record debug data
+      else {
+        etdump_gen[i]->set_data_sink(&buffer_data_sink.get());
+      }
+
+      etdump_gen[i]->log_evalue(evalue);
+
+      free(ptr);
+    }
   }
 }
 
@@ -231,61 +257,73 @@ TEST_F(ProfilerETDumpTest, VerifyLogging) {
   EValue evalue(tf.ones({3, 2}));
 
   for (size_t i = 0; i < 2; i++) {
-    etdump_gen[i]->create_event_block("test_block");
+    for (size_t j = 0; j < 2; j++) {
+      etdump_gen[i]->create_event_block("test_block");
 
-    void* ptr = malloc(2048);
-    Span<uint8_t> buffer((uint8_t*)ptr, 2048);
+      void* ptr = malloc(2048);
+      Span<uint8_t> buffer((uint8_t*)ptr, 2048);
 
-    etdump_gen[i]->set_debug_buffer(buffer);
-    etdump_gen[i]->log_evalue(evalue);
-    etdump_gen[i]->log_evalue(evalue, LoggedEValueType::kProgramOutput);
+      auto buffer_data_sink = BufferDataSink::create(ptr, 2048);
 
-    ETDumpResult result = etdump_gen[i]->get_etdump_data();
-    ASSERT_TRUE(result.buf != nullptr);
-    ASSERT_TRUE(result.size != 0);
+      // using span to record debug data
+      if (j == 0) {
+        etdump_gen[i]->set_debug_buffer(buffer);
+      }
+      // using data sink to record debug data
+      else {
+        etdump_gen[i]->set_data_sink(&buffer_data_sink.get());
+      }
 
-    size_t size = 0;
-    void* buf = flatbuffers_read_size_prefix(result.buf, &size);
-    etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
-        buf, etdump_ETDump_file_identifier);
+      etdump_gen[i]->log_evalue(evalue);
+      etdump_gen[i]->log_evalue(evalue, LoggedEValueType::kProgramOutput);
 
-    etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
-    ASSERT_EQ(etdump_RunData_vec_len(run_data_vec), 1);
+      ETDumpResult result = etdump_gen[i]->get_etdump_data();
+      ASSERT_TRUE(result.buf != nullptr);
+      ASSERT_TRUE(result.size != 0);
 
-    etdump_Event_vec_t events =
-        etdump_RunData_events(etdump_RunData_vec_at(run_data_vec, 0));
-    ASSERT_EQ(etdump_Event_vec_len(events), 2);
+      size_t size = 0;
+      void* buf = flatbuffers_read_size_prefix(result.buf, &size);
+      etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+          buf, etdump_ETDump_file_identifier);
 
-    etdump_Event_table_t event = etdump_Event_vec_at(events, 0);
+      etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+      ASSERT_EQ(etdump_RunData_vec_len(run_data_vec), 1);
 
-    etdump_DebugEvent_table_t single_debug_event =
-        etdump_Event_debug_event(event);
-    etdump_Value_table_t value =
-        etdump_DebugEvent_debug_entry(single_debug_event);
-    ASSERT_EQ(etdump_Value_tensor_is_present(value), true);
-    ASSERT_EQ(etdump_Value_output_is_present(value), false);
+      etdump_Event_vec_t events =
+          etdump_RunData_events(etdump_RunData_vec_at(run_data_vec, 0));
+      ASSERT_EQ(etdump_Event_vec_len(events), 2);
 
-    etdump_Tensor_table_t tensor = etdump_Value_tensor(value);
-    executorch_flatbuffer_ScalarType_enum_t scalar_enum =
-        etdump_Tensor_scalar_type(tensor);
-    ASSERT_EQ(scalar_enum, executorch_flatbuffer_ScalarType_FLOAT);
-    flatbuffers_int64_vec_t sizes = etdump_Tensor_sizes(tensor);
-    ASSERT_EQ(flatbuffers_int64_vec_len(sizes), 2);
-    ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 0), 3);
-    ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 1), 2);
+      etdump_Event_table_t event = etdump_Event_vec_at(events, 0);
 
-    event = etdump_Event_vec_at(events, 1);
-    single_debug_event = etdump_Event_debug_event(event);
-    value = etdump_DebugEvent_debug_entry(single_debug_event);
-    ASSERT_EQ(etdump_Value_tensor_is_present(value), true);
-    ASSERT_EQ(etdump_Value_output_is_present(value), true);
-    etdump_Bool_table_t bool_val = etdump_Value_output_get(value);
-    bool bool_val_from_table = etdump_Bool_bool_val(bool_val);
-    ASSERT_EQ(bool_val_from_table, true);
+      etdump_DebugEvent_table_t single_debug_event =
+          etdump_Event_debug_event(event);
+      etdump_Value_table_t value =
+          etdump_DebugEvent_debug_entry(single_debug_event);
+      ASSERT_EQ(etdump_Value_tensor_is_present(value), true);
+      ASSERT_EQ(etdump_Value_output_is_present(value), false);
 
-    free(ptr);
-    if (!etdump_gen[i]->is_static_etdump()) {
-      free(result.buf);
+      etdump_Tensor_table_t tensor = etdump_Value_tensor(value);
+      executorch_flatbuffer_ScalarType_enum_t scalar_enum =
+          etdump_Tensor_scalar_type(tensor);
+      ASSERT_EQ(scalar_enum, executorch_flatbuffer_ScalarType_FLOAT);
+      flatbuffers_int64_vec_t sizes = etdump_Tensor_sizes(tensor);
+      ASSERT_EQ(flatbuffers_int64_vec_len(sizes), 2);
+      ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 0), 3);
+      ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 1), 2);
+
+      event = etdump_Event_vec_at(events, 1);
+      single_debug_event = etdump_Event_debug_event(event);
+      value = etdump_DebugEvent_debug_entry(single_debug_event);
+      ASSERT_EQ(etdump_Value_tensor_is_present(value), true);
+      ASSERT_EQ(etdump_Value_output_is_present(value), true);
+      etdump_Bool_table_t bool_val = etdump_Value_output_get(value);
+      bool bool_val_from_table = etdump_Bool_bool_val(bool_val);
+      ASSERT_EQ(bool_val_from_table, true);
+
+      free(ptr);
+      if (!etdump_gen[i]->is_static_etdump()) {
+        free(result.buf);
+      }
     }
   }
 }
@@ -432,58 +470,70 @@ TEST_F(ProfilerETDumpTest, VerifyData) {
 
 TEST_F(ProfilerETDumpTest, LogDelegateIntermediateOutput) {
   for (size_t i = 0; i < 2; i++) {
-    void* ptr = malloc(2048);
-    Span<uint8_t> buffer((uint8_t*)ptr, 2048);
+    for (size_t j = 0; j < 2; j++) {
+      void* ptr = malloc(2048);
+      Span<uint8_t> buffer((uint8_t*)ptr, 2048);
 
-    etdump_gen[i]->create_event_block("test_block");
-    TensorFactory<ScalarType::Float> tf;
+      auto buffer_data_sink = BufferDataSink::create(ptr, 2048);
 
-    ET_EXPECT_DEATH(
-        etdump_gen[i]->log_intermediate_output_delegate(
-            "test_event_tensor",
-            static_cast<torch::executor::DebugHandle>(-1),
-            tf.ones({3, 2})),
-        "Must pre-set debug buffer with set_debug_buffer()");
-    etdump_gen[i]->set_debug_buffer(buffer);
+      etdump_gen[i]->create_event_block("test_block");
+      TensorFactory<ScalarType::Float> tf;
 
-    // Log a tensor
-    etdump_gen[i]->log_intermediate_output_delegate(
-        "test_event_tensor",
-        static_cast<torch::executor::DebugHandle>(-1),
-        tf.ones({3, 2}));
+      // using span to record debug data
+      if (j == 0) {
+        // TODO(gasoonjia): add similar ET_EXPECT_DEATH on BufferDataSink branch
+        ET_EXPECT_DEATH(
+            etdump_gen[i]->log_intermediate_output_delegate(
+                "test_event_tensor",
+                static_cast<torch::executor::DebugHandle>(-1),
+                tf.ones({3, 2})),
+            "Must pre-set data sink before logging evalue with set_data_sink");
+        etdump_gen[i]->set_debug_buffer(buffer);
+      }
+      // using data sink to record debug data
+      else {
+        etdump_gen[i]->set_data_sink(&buffer_data_sink.get());
+      }
 
-    // Log a tensor list
-    std::vector<Tensor> tensors = {tf.ones({5, 4}), tf.ones({7, 6})};
-    etdump_gen[i]->log_intermediate_output_delegate(
-        "test_event_tensorlist",
-        static_cast<torch::executor::DebugHandle>(-1),
-        ArrayRef<Tensor>(tensors.data(), tensors.size()));
+      // Log a tensor
+      etdump_gen[i]->log_intermediate_output_delegate(
+          "test_event_tensor",
+          static_cast<torch::executor::DebugHandle>(-1),
+          tf.ones({3, 2}));
 
-    // Log an int
-    etdump_gen[i]->log_intermediate_output_delegate(
-        "test_event_tensorlist",
-        static_cast<torch::executor::DebugHandle>(-1),
-        10);
+      // Log a tensor list
+      std::vector<Tensor> tensors = {tf.ones({5, 4}), tf.ones({7, 6})};
+      etdump_gen[i]->log_intermediate_output_delegate(
+          "test_event_tensorlist",
+          static_cast<torch::executor::DebugHandle>(-1),
+          ArrayRef<Tensor>(tensors.data(), tensors.size()));
 
-    // Log a double
-    etdump_gen[i]->log_intermediate_output_delegate(
-        "test_event_tensorlist",
-        static_cast<torch::executor::DebugHandle>(-1),
-        20.75);
+      // Log an int
+      etdump_gen[i]->log_intermediate_output_delegate(
+          "test_event_tensorlist",
+          static_cast<torch::executor::DebugHandle>(-1),
+          10);
 
-    // Log a bool
-    etdump_gen[i]->log_intermediate_output_delegate(
-        "test_event_tensorlist",
-        static_cast<torch::executor::DebugHandle>(-1),
-        true);
+      // Log a double
+      etdump_gen[i]->log_intermediate_output_delegate(
+          "test_event_tensorlist",
+          static_cast<torch::executor::DebugHandle>(-1),
+          20.75);
 
-    ETDumpResult result = etdump_gen[i]->get_etdump_data();
-    ASSERT_TRUE(result.buf != nullptr);
-    ASSERT_TRUE(result.size != 0);
+      // Log a bool
+      etdump_gen[i]->log_intermediate_output_delegate(
+          "test_event_tensorlist",
+          static_cast<torch::executor::DebugHandle>(-1),
+          true);
 
-    free(ptr);
-    if (!etdump_gen[i]->is_static_etdump()) {
-      free(result.buf);
+      ETDumpResult result = etdump_gen[i]->get_etdump_data();
+      ASSERT_TRUE(result.buf != nullptr);
+      ASSERT_TRUE(result.size != 0);
+
+      free(ptr);
+      if (!etdump_gen[i]->is_static_etdump()) {
+        free(result.buf);
+      }
     }
   }
 }
@@ -493,81 +543,92 @@ TEST_F(ProfilerETDumpTest, VerifyDelegateIntermediateLogging) {
   EValue evalue(tf.ones({3, 2}));
 
   for (size_t i = 0; i < 2; i++) {
-    etdump_gen[i]->create_event_block("test_block");
+    for (size_t j = 0; j < 2; j++) {
+      etdump_gen[i]->create_event_block("test_block");
 
-    void* ptr = malloc(2048);
-    Span<uint8_t> buffer((uint8_t*)ptr, 2048);
+      void* ptr = malloc(2048);
+      Span<uint8_t> buffer((uint8_t*)ptr, 2048);
+      ;
+      auto buffer_data_sink = BufferDataSink::create(ptr, 2048);
 
-    etdump_gen[i]->set_debug_buffer(buffer);
+      // using span to record debug data
+      if (j == 0) {
+        etdump_gen[i]->set_debug_buffer(buffer);
+      }
+      // using data sink to record debug data
+      else {
+        etdump_gen[i]->set_data_sink(&buffer_data_sink.get());
+      }
 
-    // Event 0
-    etdump_gen[i]->log_intermediate_output_delegate(
-        nullptr, 257, tf.ones({3, 4}));
-    // Event 1
-    etdump_gen[i]->log_intermediate_output_delegate(
-        nullptr, 258, tf.ones({5, 6}));
+      // Event 0
+      etdump_gen[i]->log_intermediate_output_delegate(
+          nullptr, 257, tf.ones({3, 4}));
+      // Event 1
+      etdump_gen[i]->log_intermediate_output_delegate(
+          nullptr, 258, tf.ones({5, 6}));
 
-    ETDumpResult result = etdump_gen[i]->get_etdump_data();
-    ASSERT_TRUE(result.buf != nullptr);
-    ASSERT_TRUE(result.size != 0);
+      ETDumpResult result = etdump_gen[i]->get_etdump_data();
+      ASSERT_TRUE(result.buf != nullptr);
+      ASSERT_TRUE(result.size != 0);
 
-    size_t size = 0;
-    void* buf = flatbuffers_read_size_prefix(result.buf, &size);
-    etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
-        buf, etdump_ETDump_file_identifier);
+      size_t size = 0;
+      void* buf = flatbuffers_read_size_prefix(result.buf, &size);
+      etdump_ETDump_table_t etdump = etdump_ETDump_as_root_with_identifier(
+          buf, etdump_ETDump_file_identifier);
 
-    etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
-    ASSERT_EQ(etdump_RunData_vec_len(run_data_vec), 1);
+      etdump_RunData_vec_t run_data_vec = etdump_ETDump_run_data(etdump);
+      ASSERT_EQ(etdump_RunData_vec_len(run_data_vec), 1);
 
-    etdump_Event_vec_t events =
-        etdump_RunData_events(etdump_RunData_vec_at(run_data_vec, 0));
-    ASSERT_EQ(etdump_Event_vec_len(events), 2);
+      etdump_Event_vec_t events =
+          etdump_RunData_events(etdump_RunData_vec_at(run_data_vec, 0));
+      ASSERT_EQ(etdump_Event_vec_len(events), 2);
 
-    // Verify Event 0
-    etdump_Event_table_t event_0 = etdump_Event_vec_at(events, 0);
+      // Verify Event 0
+      etdump_Event_table_t event_0 = etdump_Event_vec_at(events, 0);
 
-    etdump_DebugEvent_table_t single_debug_event =
-        etdump_Event_debug_event(event_0);
-    etdump_Value_table_t value =
-        etdump_DebugEvent_debug_entry(single_debug_event);
-    ASSERT_EQ(etdump_Value_tensor_is_present(value), true);
+      etdump_DebugEvent_table_t single_debug_event =
+          etdump_Event_debug_event(event_0);
+      etdump_Value_table_t value =
+          etdump_DebugEvent_debug_entry(single_debug_event);
+      ASSERT_EQ(etdump_Value_tensor_is_present(value), true);
 
-    etdump_Tensor_table_t tensor = etdump_Value_tensor(value);
-    executorch_flatbuffer_ScalarType_enum_t scalar_enum =
-        etdump_Tensor_scalar_type(tensor);
-    ASSERT_EQ(scalar_enum, executorch_flatbuffer_ScalarType_FLOAT);
-    flatbuffers_int64_vec_t sizes = etdump_Tensor_sizes(tensor);
-    ASSERT_EQ(flatbuffers_int64_vec_len(sizes), 2);
-    ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 0), 3);
-    ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 1), 4);
+      etdump_Tensor_table_t tensor = etdump_Value_tensor(value);
+      executorch_flatbuffer_ScalarType_enum_t scalar_enum =
+          etdump_Tensor_scalar_type(tensor);
+      ASSERT_EQ(scalar_enum, executorch_flatbuffer_ScalarType_FLOAT);
+      flatbuffers_int64_vec_t sizes = etdump_Tensor_sizes(tensor);
+      ASSERT_EQ(flatbuffers_int64_vec_len(sizes), 2);
+      ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 0), 3);
+      ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 1), 4);
 
-    // Verify Event 1
-    etdump_Event_table_t event_1 = etdump_Event_vec_at(events, 1);
+      // Verify Event 1
+      etdump_Event_table_t event_1 = etdump_Event_vec_at(events, 1);
 
-    single_debug_event = etdump_Event_debug_event(event_1);
-    value = etdump_DebugEvent_debug_entry(single_debug_event);
+      single_debug_event = etdump_Event_debug_event(event_1);
+      value = etdump_DebugEvent_debug_entry(single_debug_event);
 
-    tensor = etdump_Value_tensor(value);
-    sizes = etdump_Tensor_sizes(tensor);
-    ASSERT_EQ(flatbuffers_int64_vec_len(sizes), 2);
-    ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 0), 5);
-    ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 1), 6);
+      tensor = etdump_Value_tensor(value);
+      sizes = etdump_Tensor_sizes(tensor);
+      ASSERT_EQ(flatbuffers_int64_vec_len(sizes), 2);
+      ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 0), 5);
+      ASSERT_EQ(flatbuffers_int64_vec_at(sizes, 1), 6);
 
-    // Event 1 should have a empty delegate_debug_id_str
-    flatbuffers_string_t delegate_debug_id_name =
-        etdump_DebugEvent_delegate_debug_id_str(
-            etdump_Event_debug_event(event_1));
+      // Event 1 should have a empty delegate_debug_id_str
+      flatbuffers_string_t delegate_debug_id_name =
+          etdump_DebugEvent_delegate_debug_id_str(
+              etdump_Event_debug_event(event_1));
 
-    EXPECT_EQ(delegate_debug_id_name, nullptr);
-    // Check for the correct delegate_debug_id_int
-    EXPECT_EQ(
-        etdump_DebugEvent_delegate_debug_id_int(
-            etdump_Event_debug_event(event_1)),
-        258);
+      EXPECT_EQ(delegate_debug_id_name, nullptr);
+      // Check for the correct delegate_debug_id_int
+      EXPECT_EQ(
+          etdump_DebugEvent_delegate_debug_id_int(
+              etdump_Event_debug_event(event_1)),
+          258);
 
-    free(ptr);
-    if (!etdump_gen[i]->is_static_etdump()) {
-      free(result.buf);
+      free(ptr);
+      if (!etdump_gen[i]->is_static_etdump()) {
+        free(result.buf);
+      }
     }
   }
 }

--- a/devtools/etdump/utils.h
+++ b/devtools/etdump/utils.h
@@ -13,7 +13,8 @@ namespace internal {
  * Aligns a pointer to the next multiple of `alignment`.
  *
  * @param[in] ptr Pointer to align.
- * @param[in] alignment Alignment to align to. Must be a power of 2.
+ * @param[in] alignment Alignment to align to. Must be a power of 2 and cannot
+ * be 0.
  *
  * @returns A pointer aligned to `alignment`.
  */


### PR DESCRIPTION
Summary:
This diff enables customized debug data pipeline by making ETDumpGen leverage user-provided datasink.

Details can be found in https://docs.google.com/document/d/1y_m32mKdj-OgLcLUz9TKhBW3PC3bBDYSBbeAH544EfM/edit?tab=t.0#heading=h.jlkcrurw482r

Reviewed By: tarun292, YIWENX14

Differential Revision: D69647096


