### PR TITLE
update python_* usage

### DIFF
--- a/backends/xnnpack/test/TARGETS
+++ b/backends/xnnpack/test/TARGETS
@@ -53,7 +53,7 @@ runtime.python_test(
     srcs = glob([
         "models/*.py",
     ]),
-    tags = ["long_running"],
+    labels = ["long_running"],
     deps = [
         "fbsource//third-party/pypi/timm:timm",
         "fbsource//third-party/pypi/torchsr:torchsr",  # @manual

--- a/exir/dialects/edge/test/TARGETS
+++ b/exir/dialects/edge/test/TARGETS
@@ -10,7 +10,7 @@ python_unittest(
     resources = {
         "//executorch/exir/dialects/edge:edge_yaml": "edge.yaml",
     },
-    tags = ["long_running"],
+    labels = ["long_running"],
     deps = [
         "fbsource//third-party/pypi/expecttest:expecttest",  # @manual
         "//caffe2:torch",


### PR DESCRIPTION
Summary: As part of tags and labels unification we are getting rid of tags  across all of fbcode_macro_layer and replacing them with labels.

Differential Revision: D70201831


