### PR TITLE
Allow complex dtypes during tensor parsing

### DIFF
--- a/runtime/executor/tensor_parser_portable.cpp
+++ b/runtime/executor/tensor_parser_portable.cpp
@@ -43,11 +43,7 @@ Result<Tensor> parseTensor(
 
   ScalarType scalar_type = static_cast<ScalarType>(s_tensor->scalar_type());
   ET_CHECK_OR_RETURN_ERROR(
-      isValid(scalar_type) &&
-          // Types that do not yet have deserialization support.
-          scalar_type != executorch::aten::ScalarType::ComplexHalf &&
-          scalar_type != executorch::aten::ScalarType::ComplexFloat &&
-          scalar_type != executorch::aten::ScalarType::ComplexDouble,
+      isValid(scalar_type),
       InvalidProgram,
       "Invalid or unsupported ScalarType %" PRId8,
       static_cast<int8_t>(scalar_type));


### PR DESCRIPTION
Summary: Given that we now support ops like fft_r2c we should allow complex dtypes during tensor parsing when the program is loaded. In order to support this we need to remove an assert that prevents these dtypes from being present in the program.

Differential Revision: D70268416


