### PR TITLE
Arm backend: Remove arm_test folder build and test output from git radar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 __pycache__/
 
 # Build and tool-generated files
+arm_test/
 buck-out/
 buck2-bin/
 cmake-android-out/


### PR DESCRIPTION
This adds the arm_test folder used as default build and test output by the arm scripts to .gitignore


cc @digantdesai @freddan80 @per @oscarandersson8218