### PR TITLE
Fix error in export example script

### DIFF
--- a/docs/source/using-executorch-export.md
+++ b/docs/source/using-executorch-export.md
@@ -58,7 +58,7 @@ class Model(torch.nn.Module):
             torch.nn.ReLU(),
             torch.nn.Conv2d(8, 16, 3),
             torch.nn.ReLU(),
-            torch.nn.AdaptiveAvgPool2d([[1,1]])
+            torch.nn.AdaptiveAvgPool2d((1,1))
         )
         self.linear = torch.nn.Linear(16, 10)
     


### PR DESCRIPTION
### Summary
Fix an error in the export example script, preventing users from running it successfully. Fixes https://github.com/pytorch/executorch/issues/8782.

### Test plan
I was able to copy the contents out to a python file and run successfully with this change.