### PR TITLE
Fail the benchmark job if the export step fails

### DIFF
--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -173,9 +173,6 @@ jobs:
       upload-artifact-to-s3: true
       secrets-env: EXECUTORCH_HF_TOKEN
       script: |
-        # TESTING
-        exit 1
-
         # The generic Linux job chooses to use base env, not the one setup by the image
         echo "::group::Setting up dev environment"
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")

--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -20,7 +20,7 @@ on:
         description: Models to be benchmarked
         required: false
         type: string
-        default: stories110M
+        default: llama
       devices:
         description: Target devices to run benchmark
         required: false
@@ -36,7 +36,7 @@ on:
         description: Models to be benchmarked
         required: false
         type: string
-        default: stories110M
+        default: llama
       devices:
         description: Target devices to run benchmark
         required: false
@@ -173,6 +173,9 @@ jobs:
       upload-artifact-to-s3: true
       secrets-env: EXECUTORCH_HF_TOKEN
       script: |
+        # TESTING
+        exit 1
+
         # The generic Linux job chooses to use base env, not the one setup by the image
         echo "::group::Setting up dev environment"
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -175,9 +175,6 @@ jobs:
       script: |
         set -eux
 
-        # TESTING
-        exit 1
-
         echo "::group::Setting up CI environment"
         .ci/scripts/setup-conda.sh
 

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -20,7 +20,7 @@ on:
         description: Models to be benchmarked
         required: false
         type: string
-        default: stories110M
+        default: llama
       devices:
         description: Target devices to run benchmark
         required: false
@@ -36,7 +36,7 @@ on:
         description: Models to be benchmarked
         required: false
         type: string
-        default: stories110M
+        default: llama
       devices:
         description: Target devices to run benchmark
         required: false
@@ -174,6 +174,9 @@ jobs:
       secrets-env: EXECUTORCH_HF_TOKEN
       script: |
         set -eux
+
+        # TESTING
+        exit 1
 
         echo "::group::Setting up CI environment"
         .ci/scripts/setup-conda.sh

--- a/extension/benchmark/android/benchmark/android-llm-device-farm-test-spec.yml.j2
+++ b/extension/benchmark/android/benchmark/android-llm-device-farm-test-spec.yml.j2
@@ -12,7 +12,7 @@ phases:
       - echo "The benchmark config is {{ benchmark_config_id }}"
 
       # Download the model from S3
-      - curl -s --fail '{{ model_path }}' -o model.zip || false
+      - curl -s --fail '{{ model_path }}' -o model.zip
       - unzip model.zip && ls -la
 
       # Copy the model to sdcard. This prints too much progress info when the files
@@ -35,6 +35,10 @@ phases:
 
   test:
     commands:
+      # Fail the test if the model doesn't exist, doing it here so that AWS can report the status back
+      - echo "Verify model"
+      - curl -I --fail '{{ model_path }}' || false
+
       # By default, the following ADB command is used by Device Farm to run your Instrumentation test.
       # Please refer to Android's documentation for more options on running instrumentation tests with adb:
       # https://developer.android.com/studio/test/command-line#run-tests-with-adb

--- a/extension/benchmark/android/benchmark/android-llm-device-farm-test-spec.yml.j2
+++ b/extension/benchmark/android/benchmark/android-llm-device-farm-test-spec.yml.j2
@@ -12,7 +12,7 @@ phases:
       - echo "The benchmark config is {{ benchmark_config_id }}"
 
       # Download the model from S3
-      - curl -s --fail '{{ model_path }}' -o model.zip
+      - curl -s --fail '{{ model_path }}' -o model.zip || false
       - unzip model.zip && ls -la
 
       # Copy the model to sdcard. This prints too much progress info when the files

--- a/extension/benchmark/apple/Benchmark/default-ios-device-farm-appium-test-spec.yml.j2
+++ b/extension/benchmark/apple/Benchmark/default-ios-device-farm-appium-test-spec.yml.j2
@@ -14,7 +14,7 @@ phases:
       - echo "The benchmark config is {{ benchmark_config_id }}"
 
       # Download the model from S3
-      - curl -s --fail '{{ model_path }}' -o model.zip
+      - curl -s --fail '{{ model_path }}' -o model.zip || false
       - unzip model.zip && ls -la
 
       # Extract the app

--- a/extension/benchmark/apple/Benchmark/default-ios-device-farm-appium-test-spec.yml.j2
+++ b/extension/benchmark/apple/Benchmark/default-ios-device-farm-appium-test-spec.yml.j2
@@ -14,7 +14,7 @@ phases:
       - echo "The benchmark config is {{ benchmark_config_id }}"
 
       # Download the model from S3
-      - curl -s --fail '{{ model_path }}' -o model.zip || false
+      - curl -s --fail '{{ model_path }}' -o model.zip
       - unzip model.zip && ls -la
 
       # Extract the app
@@ -34,6 +34,11 @@ phases:
   # The test phase includes commands that run your test suite execution.
   test:
     commands:
+      # Fail the test if the model doesn't exist, doing it here so that AWS can report the status back
+      - echo "Verify model"
+      - curl -I --fail '{{ model_path }}' || false
+
+      # Run the benchmark
       - xcodebuild test-without-building -destination id=$DEVICEFARM_DEVICE_UDID -xctestrun $DEVICEFARM_TEST_PACKAGE_PATH/*.xctestrun -derivedDataPath $DEVICEFARM_LOG_DIR
 
   # The post test phase includes are commands that are run after your tests are executed.


### PR DESCRIPTION
In this example, https://github.com/pytorch/executorch/actions/runs/13511586696/job/37752729714, `mv3` with `mps` backend failed to export, but its corresponding benchmark job was green.  The benchmark app didn't consider this as a failure when it didn't run any benchmark. IMO, if there was no model, it would be clearer to fail the job instead.

(also fix the default model from `stories110M` to `llama` as the former isn't a valid name anymore)

cc @yangw-dev 

### Testing

https://github.com/pytorch/executorch/actions/runs/13577012355/job/37956751928#step:16:1126 where the corresponding benchmark jobs failed when there was no exported model