### PR TITLE
Make flat_tensor depend on generated schema

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -724,7 +724,6 @@ endif()
 
 if(EXECUTORCH_BUILD_EXTENSION_FLAT_TENSOR)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/flat_tensor)
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/flat_tensor/serialize)
 endif()
 
 if(EXECUTORCH_BUILD_EXTENSION_LLM)

--- a/extension/flat_tensor/CMakeLists.txt
+++ b/extension/flat_tensor/CMakeLists.txt
@@ -36,6 +36,9 @@ install(
   DESTINATION ${_common_include_directories}
 )
 
+add_subdirectory(serialize)
+add_dependencies(extension_flat_tensor flat_tensor_schema)
+
 if(BUILD_TESTING)
   add_subdirectory(test)
 endif()


### PR DESCRIPTION
When passing -GNinja to cmake to build with Ninja, I was frequently getting errors that executorch/extension/flat_tensor/serialize/flat_tensor_generated.h was not found. This seems to fix them?