### PR TITLE
[build] Fix flatc

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -79,6 +79,7 @@ jobs:
         PYTHON_EXECUTABLE=python bash ./install_executorch.sh --editable --pybind xnnpack --use-pt-pinned-commit
         # Try to import extension library
         python -c "from executorch.extension.llm.custom_ops import custom_ops"
+        python -c "from executorch.data.bin import flatc"
 
   test-models-linux:
     name: test-models-linux

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -60,6 +60,7 @@ jobs:
         PYTHON_EXECUTABLE=python ${CONDA_RUN} bash ./install_executorch.sh --editable --pybind xnnpack
         # Try to import extension library
         python -c "from executorch.extension.llm.custom_ops import custom_ops"
+        python -c "from executorch.data.bin import flatc"
 
   test-models-macos:
     name: test-models-macos

--- a/data/bin/README.md
+++ b/data/bin/README.md
@@ -1,0 +1,31 @@
+## PLEASE DO NOT REMOVE THIS DIRECTORY!
+
+This directory is used to host binaries installed during pip wheel build time.
+
+## How to add a binary into pip wheel
+
+1. Update `[project.scripts]` section of `pyproject.toml` file. Add the new binary name and it's corresponding module name similar to:
+
+```
+flatc = "executorch.data.bin:flatc"
+```
+
+For example, `flatc` is built during wheel packaging, we first build `flatc` through CMake and copy the file to `<executorch root>/data/bin/flatc` and ask `setuptools` to generate a commandline wrapper for `flatc`, then route it to `<executorch root>/data/bin/flatc`.
+
+This way after installing `executorch`, a user will be able to call `flatc` directly in commandline and it points to `<executorch root>/data/bin/flatc`
+
+2. Update `setup.py` to include the logic of building the new binary and copying the binary to this directory.
+
+```python
+BuiltFile(
+    src_dir="%CMAKE_CACHE_DIR%/third-party/flatbuffers/%BUILD_TYPE%/",
+    src_name="flatc",
+    dst="executorch/data/bin/",
+    is_executable=True,
+),
+```
+This means find `flatc` in `CMAKE_CACHE_DIR` and copy it to `<executorch root>/data/bin`. Notice that this works for both pip wheel packaging as well as editable mode install.
+
+## Why we can't create this directory at wheel build time?
+
+The reason is without `data/bin/` present in source file, we can't tell `setuptools` to generate a module `executorch.data.bin` in editable mode, partially because we don't have a good top level module `executorch` and have to enumerate all the second level modules, including `executorch.data.bin`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ flatc = "executorch.data.bin:flatc"
 [tool.setuptools.package-dir]
 "executorch.backends" = "backends"
 "executorch.codegen" = "codegen"
+"executorch.data.bin" = "data/bin"
 # TODO(mnachin T180504136): Do not put examples/models
 # into core pip packages. Refactor out the necessary utils
 # or core models files into a separate package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ flatc = "executorch.data.bin:flatc"
 [tool.setuptools.package-dir]
 "executorch.backends" = "backends"
 "executorch.codegen" = "codegen"
-"executorch.data.bin" = "data/bin"
 # TODO(mnachin T180504136): Do not put examples/models
 # into core pip packages. Refactor out the necessary utils
 # or core models files into a separate package.

--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,7 @@ class BuiltExtension(_BaseExtension):
             "/" not in modpath
         ), f"modpath must be a dotted python module path: saw '{modpath}'"
         # This is a real extension, so use the modpath as the name.
-        super().__init__(src=src, dst=modpath, name=modpath)
+        super().__init__(src=f"%CMAKE_CACHE_DIR%/{src}", dst=modpath, name=modpath)
 
     def src_path(self, installer: "InstallerBuildExt") -> Path:
         """Returns the path to the source file, resolving globs.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8816
* #8817


Fixes #8784

1. We need to install `build/pip_data_bin_init.py.in` into `<executorch
root>/data/bin/__init__.py`. This PR rewrite the logic into a
`BuiltFile` so that it works well in editable mode.

2. Since `BuiltFile` by default looks into cmake cache directory, this PR adds a placeholder `%CMAKE_CACHE_DIR%` for those are actually built by CMake and for `build/pip_data_bin_init.py.in` we don't add this placeholder.
3. Since editable mode doesn't support creating a directory in `build` command and install it as a new module, I need to create `executorch/data/bin/` and add it to the `pyproject.toml` file, so that `executorch.data.bin` can be installed by editable mode.

Test:

```
python -c "from executorch.data.bin import flatc"
```
Added `unittest-editable` for Linux and Mac