### PR TITLE
Migrate pybind11 external deps to regular third-party deps

### DIFF
--- a/backends/apple/coreml/TARGETS
+++ b/backends/apple/coreml/TARGETS
@@ -14,10 +14,10 @@ runtime.python_library(
         "@EXECUTORCH_CLIENTS",
     ],
     deps = [
+        "fbsource//third-party/pypi/coremltools:coremltools",
         ":executorchcoreml",
         "//executorch/exir/backend:backend_details",
         "//executorch/exir/backend:compile_spec_schema",
-        "fbsource//third-party/pypi/coremltools:coremltools",
     ],
 )
 
@@ -30,13 +30,13 @@ runtime.python_library(
         "@EXECUTORCH_CLIENTS",
     ],
     deps = [
+        "fbsource//third-party/pypi/coremltools:coremltools",
         ":backend",
         "//caffe2:torch",
         "//executorch/exir:lib",
         "//executorch/exir/backend:compile_spec_schema",
         "//executorch/exir/backend:partitioner",
         "//executorch/exir/backend:utils",
-        "fbsource//third-party/pypi/coremltools:coremltools",
     ],
 )
 
@@ -64,25 +64,23 @@ runtime.cxx_python_extension(
     headers = glob([
         "runtime/inmemoryfs/**/*.hpp",
     ]),
+    base_module = "",
+    compiler_flags = [
+        "-std=c++17",
+    ],
     preprocessor_flags = [
         "-Iexecutorch/backends/apple/coreml/runtime/util",
     ],
     types = [
         "executorchcoreml.pyi",
     ],
-    compiler_flags = [
-        "-std=c++17",
-    ],
-    base_module = "",
     visibility = [
         "//executorch/examples/apple/coreml/...",
         "@EXECUTORCH_CLIENTS",
     ],
-    external_deps = [
-        "pybind11",
-    ],
     deps = [
         "fbsource//third-party/nlohmann-json:nlohmann-json",
+        "fbsource//third-party/pybind11:pybind11",
     ],
 )
 
@@ -92,10 +90,10 @@ runtime.python_test(
         "test/*.py",
     ]),
     deps = [
+        "fbsource//third-party/pypi/pytest:pytest",
         ":partitioner",
         ":quantizer",
         "//caffe2:torch",
         "//pytorch/vision:torchvision",
-        "fbsource//third-party/pypi/pytest:pytest",
     ],
 )

--- a/backends/qualcomm/aot/python/targets.bzl
+++ b/backends/qualcomm/aot/python/targets.bzl
@@ -33,10 +33,10 @@ def define_common_targets():
             "//executorch/backends/qualcomm:schema",
             "//executorch/backends/qualcomm/aot/ir:qcir_utils",
             "//executorch/backends/qualcomm/runtime:runtime",
+            "fbsource//third-party/pybind11:pybind11",
             "fbsource//third-party/qualcomm/qnn/qnn-{0}:api".format(get_qnn_library_verision()),
         ],
         external_deps = [
-            "pybind11",
             "libtorch_python",
         ],
         use_static_deps = True,
@@ -66,10 +66,10 @@ def define_common_targets():
             "//executorch/backends/qualcomm:schema",
             "//executorch/backends/qualcomm/aot/ir:qcir_utils",
             "//executorch/backends/qualcomm/runtime:runtime",
+            "fbsource//third-party/pybind11:pybind11",
             "fbsource//third-party/qualcomm/qnn/qnn-{0}:api".format(get_qnn_library_verision()),
         ],
         external_deps = [
-            "pybind11",
             "libtorch_python",
         ],
         use_static_deps = True,
@@ -93,9 +93,7 @@ def define_common_targets():
             "//executorch/backends/qualcomm:schema",
             "//executorch/backends/qualcomm/aot/ir:qcir_utils",
             "//executorch/backends/qualcomm/runtime:runtime",
+            "fbsource//third-party/pybind11:pybind11",
             "fbsource//third-party/qualcomm/qnn/qnn-{0}:api".format(get_qnn_library_verision()),
-        ],
-        external_deps = [
-            "pybind11",
         ],
     )

--- a/exir/verification/TARGETS
+++ b/exir/verification/TARGETS
@@ -10,12 +10,10 @@ cpp_python_extension(
         "bindings.cpp",
     ],
     deps = [
+        "fbsource//third-party/pybind11:pybind11",
         "//caffe2:torch-cpp-cpu",
         "//caffe2:torch_extension",
         "//caffe2/c10:c10",
-    ],
-    external_deps = [
-        "pybind11",
     ],
 )
 

--- a/extension/pytree/TARGETS
+++ b/extension/pytree/TARGETS
@@ -16,10 +16,8 @@ cpp_python_extension(
     ],
     base_module = "executorch.extension.pytree",
     deps = [
+        "fbsource//third-party/pybind11:pybind11",
         ":pytree",
-    ],
-    external_deps = [
-        "pybind11",
     ],
 )
 
@@ -30,10 +28,8 @@ cpp_python_extension(
     ],
     base_module = "executorch.extension.pytree",
     deps = [
+        "fbsource//third-party/pybind11:pybind11",
         ":pytree",
-    ],
-    external_deps = [
-        "pybind11",
     ],
 )
 

--- a/extension/training/pybindings/TARGETS
+++ b/extension/training/pybindings/TARGETS
@@ -17,13 +17,11 @@ runtime.cxx_python_extension(
     types = ["_training_lib.pyi"],
     visibility = ["//executorch/extension/training/..."],
     deps = [
+        "fbsource//third-party/pybind11:pybind11",
         "//executorch/extension/aten_util:aten_bridge",
         "//executorch/extension/training/optimizer:sgd",
     ],
-    external_deps = [
-        "pybind11",
-        "libtorch_python",
-    ],
+    external_deps = ["libtorch_python"],
 )
 
 runtime.python_library(


### PR DESCRIPTION
Summary:
```
)>pylot run fbcode//scripts/yilei/codemods:replace_tp2_deps --tp2_project=pybind11 --replacement=fbsource//third-party/pybind11:pybind11
E0226 10:26:07.491569 2744864 Config.cpp:1179] For smc tier ''. Encountered an exception while parsing 'weight_mode'. Failed to parse WeightMode: Unknown WeightMode value 'default_sr'. Using 'LEGACY_DEFAULT'.
E0226 10:26:07.493572 2744864 Config.cpp:1179] For smc tier ''. Encountered an exception while parsing 'weight_mode'. Failed to parse WeightMode: Unknown WeightMode value 'default_sr'. Using 'LEGACY_DEFAULT'.
E0226 10:26:07.493769 2744864 Config.cpp:1179] For smc tier ''. Encountered an exception while parsing 'weight_mode'. Failed to parse WeightMode: Unknown WeightMode value 'default_sr'. Using 'LEGACY_DEFAULT'.
E0226 10:26:07.550289 2745009 Config.cpp:1179] For smc tier 'biggrep.master.trusted'. Encountered an exception while parsing 'weight_mode'. Failed to parse WeightMode: Unknown WeightMode value 'default_sr'. Using 'LEGACY_DEFAULT'.
E0226 10:26:07.556802 2745009 Config.cpp:1179] For smc tier 'biggrep.aggregator.interactive.v1'. Encountered an exception while parsing 'weight_mode'. Failed to parse WeightMode: Unknown WeightMode value 'default_sr'. Using 'LEGACY_DEFAULT'.
Found 163 TARGETS files using tp2 pybind11
  [######------------------------------]   19%  00:01:39WARNING: Y2_MAGIC_STRING_FOR_BUILDOZER found in fbcode/bolt/nn/executorch/backends/targets.bzl
  [###########-------------------------]   32%  00:01:28WARNING: Y2_MAGIC_STRING_FOR_BUILDOZER found in fbcode/executorch/backends/qualcomm/aot/python/targets.bzl
  [###########-------------------------]   33%  00:01:27WARNING: Y2_MAGIC_STRING_FOR_BUILDOZER found in fbcode/executorch/codegen/tools/fb/targets.bzl
  [####################################]  100%
```

Reviewed By: dtolnay

Differential Revision: D70261352


