### PR TITLE
[executorch][runtime] Add get_named_data_map to Program

### DIFF
--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -373,6 +373,13 @@ Result<const void*> Program::get_constant_buffer_data(
   }
 }
 
+Result<const NamedDataMap*> Program::get_named_data_map() const {
+  if (core_data_map_.has_value()) {
+    return &core_data_map_.value();
+  }
+  return Error::NotFound;
+}
+
 Result<const char*> Program::get_output_flattening_encoding(
     const char* method_name) const {
   auto plan = get_execution_plan(internal_program_, method_name);

--- a/runtime/executor/program.h
+++ b/runtime/executor/program.h
@@ -108,6 +108,12 @@ class Program final {
       const;
 
   /**
+   * Get the named data map from the program.
+   * @return The named data map.
+   */
+  Result<const NamedDataMap*> get_named_data_map() const;
+
+  /**
    * Returns the number of methods in the program.
    */
   size_t num_methods() const;

--- a/runtime/executor/test/program_test.cpp
+++ b/runtime/executor/test/program_test.cpp
@@ -371,6 +371,18 @@ TEST_F(ProgramTest, getMethods) {
   EXPECT_EQ(strcmp(res2.get(), "forward2"), 0);
 }
 
+TEST_F(ProgramTest, GetNamedDataMap_Fail) {
+  Result<Program> program =
+      Program::load(add_loader_.get(), kDefaultVerification);
+  ASSERT_EQ(program.error(), Error::Ok);
+
+  // Get the named data map. Expect to fail, as add.pte does not have any
+  // named data segments.
+  Result<const executorch::runtime::NamedDataMap*> named_data_map =
+      program->get_named_data_map();
+  EXPECT_EQ(named_data_map.error(), Error::NotFound);
+}
+
 // Test that the deprecated Load method (capital 'L') still works.
 TEST_F(ProgramTest, DEPRECATEDLoad) {
   // Parse the Program from the data.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8849
* #8848
* #8835

Add to the program interface, to allow users to retrieve the NDM.

Differential Revision: [D70276106](https://our.internmc.facebook.com/intern/diff/D70276106/)