### PR TITLE
Add missing dep to executorch/extensin/pybindings:portable_lib

### DIFF
--- a/extension/pybindings/TARGETS
+++ b/extension/pybindings/TARGETS
@@ -70,5 +70,8 @@ runtime.python_library(
         "//executorch/runtime/...",
         "@EXECUTORCH_CLIENTS",
     ],
-    deps = [":_portable_lib"],
+    deps = [
+        ":_portable_lib",
+        "//executorch/exir:_warnings",
+    ],
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8871

This file clearly imports executorch.exir._warnings and thus it should have the dep.

Differential Revision: [D70451304](https://our.internmc.facebook.com/intern/diff/D70451304/)