### PR TITLE
Arm backend: Enable test_w2l_u85_BI

### DIFF
--- a/backends/arm/test/models/test_w2l_arm.py
+++ b/backends/arm/test/models/test_w2l_arm.py
@@ -131,7 +131,6 @@ class TestW2L(unittest.TestCase):
 
     @pytest.mark.slow
     @pytest.mark.corstone_fvp
-    @unittest.skip("Blocked by MLBEDSW-10420")
     @conftest.expectedFailureOnFVP  # TODO: MLBEDSW-10093
     def test_w2l_u85_BI(self):
         tester = self._test_w2l_ethos_BI_pipeline(


### PR DESCRIPTION
The TOSA compiler previously had a bug that caused a segmentation fault when loading the Wav2Letter model on Ethos-U85. This issue has now been fixed.

Enable the test that previously failed due to this bug.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218