### PR TITLE
[Windows] don't use invalid flags on Windows

### DIFF
--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -5,7 +5,13 @@ load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "CXX", "FBCODE"
 
 
 def get_vulkan_compiler_flags():
-    return ["-Wno-missing-prototypes", "-Wno-global-constructors"]
+    return select({
+        "DEFAULT": [
+            "-Wno-global-constructors",
+            "-Wno-missing-prototypes",
+        ],
+        "ovr_config//os:windows": [],
+    })
 
 def get_labels(no_volk):
     if no_volk:

--- a/runtime/core/named_data_map.h
+++ b/runtime/core/named_data_map.h
@@ -7,9 +7,12 @@
  */
 
 #pragma once
+
+#ifdef __GNUC__
 // Disable -Wdeprecated-declarations, as some builds use 'Werror'.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/freeable_buffer.h>
@@ -78,4 +81,6 @@ class ET_EXPERIMENTAL NamedDataMap {
 } // namespace runtime
 } // namespace executorch
 
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif

--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -7,9 +7,12 @@
  */
 
 #pragma once
+
+#ifdef __GNUC__
 // Disable -Wdeprecated-declarations, as some builds use 'Werror'.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 #include <executorch/runtime/core/evalue.h>
 #include <executorch/runtime/core/event_tracer.h>
@@ -402,4 +405,6 @@ using ::executorch::runtime::Method;
 } // namespace executor
 } // namespace torch
 
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif

--- a/runtime/executor/program.h
+++ b/runtime/executor/program.h
@@ -7,9 +7,12 @@
  */
 
 #pragma once
+
+#ifdef __GNUC__
 // Disable -Wdeprecated-declarations, as some builds use 'Werror'.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 #include <cinttypes>
 #include <cstdint>
@@ -308,4 +311,6 @@ using ::executorch::runtime::Program;
 } // namespace executor
 } // namespace torch
 
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif

--- a/runtime/executor/tensor_parser.h
+++ b/runtime/executor/tensor_parser.h
@@ -7,9 +7,12 @@
  */
 
 #pragma once
+
+#ifdef __GNUC__
 // Disable -Wdeprecated-declarations, as some builds use 'Werror'.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 #include <executorch/runtime/core/evalue.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
@@ -154,4 +157,7 @@ using ::executorch::runtime::deserialization::parseTensorList;
 } // namespace deserialization
 } // namespace executor
 } // namespace torch
+
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
### Summary
This is the fourth PR in my attempt to get Windows builds working.  Since "-Wno-missing-prototypes", `#pragma GCC diagnostic push`, etc. aren't valid with non-gcc compilers, let's wrap them so we are only doing them on non-Windows platforms.

### Test plan
Since we aren't actually building on Windows yet, this should have no effect on existing platforms, so just confirm that everything builds.