### PR TITLE
fix head_dim in metadata

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/model/static_llama.py
+++ b/examples/qualcomm/oss_scripts/llama/model/static_llama.py
@@ -461,7 +461,7 @@ class LlamaModel(nn.Module):
             "get_bos_id": 1,
             "get_eos_id": 2,
             "get_dim": self.dim,
-            "get_head_dim": self.dim // self.n_heads,
+            "get_head_dim": self.head_dim,
             "get_max_batch_size": self.max_batch_size,
             "get_max_seq_len": self.max_seq_len,
             "get_n_bos": 1,


### PR DESCRIPTION
Summary: After https://github.com/pytorch/executorch/pull/8846, the models exported correctly, but failed to run on-device with segmentation error. This diff fixes that error.

Reviewed By: sxu, billmguo

Differential Revision: D70538475


