### PR TITLE
Add proper CMake build for extension_parallel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -749,9 +749,9 @@ endif()
 
 if(EXECUTORCH_BUILD_PTHREADPOOL
    AND EXECUTORCH_BUILD_CPUINFO
-   AND CMAKE_CXX_STANDARD GREATER_EQUAL 14
 )
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/threadpool)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/parallel)
 endif()
 
 if(EXECUTORCH_BUILD_PYBIND)

--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -449,6 +449,7 @@ deps = [
   "executorch_core",
   "extension_data_loader",
   "extension_module",
+  "extension_parallel",
   "portable_kernels",
   "quantized_kernels",
   "xnnpack_backend",

--- a/build/cmake_deps.toml
+++ b/build/cmake_deps.toml
@@ -73,6 +73,7 @@ excludes = [
 deps = [
   "executorch",
   "executorch_core",
+  "extension_parallel",
   "extension_threadpool",
   "portable_kernels",
 ]
@@ -115,6 +116,7 @@ excludes = [
 deps = [
   "executorch_core",
   "executorch",
+  "extension_parallel",
 ]
 
 [targets.optimized_native_cpu_ops]
@@ -129,6 +131,8 @@ excludes = [
 deps = [
   "executorch_core",
   "executorch",
+  "extension_parallel",
+  "extension_threadpool",
   "portable_kernels",
 ]
 # ---------------------------------- core end ----------------------------------
@@ -206,6 +210,19 @@ deps = [
   "executorch_core",
   "extension_module",
   "extension_runner_util",
+]
+
+[targets.extension_parallel]
+buck_targets = [
+  "//extension/parallel:thread_parallel",
+]
+filters = [
+  ".cpp$",
+]
+deps = [
+  "executorch",
+  "executorch_core",
+  "extension_threadpool",
 ]
 
 [targets.extension_tensor]
@@ -395,6 +412,7 @@ deps = [
   "executorch",
   "executorch_core",
   "optimized_kernels",
+  "extension_parallel",
   "extension_threadpool",
   "xnnpack_backend",
 ]

--- a/build/executorch-config.cmake
+++ b/build/executorch-config.cmake
@@ -67,6 +67,7 @@ set(lib_list
     portable_ops_lib
     extension_module
     extension_module_static
+    extension_parallel
     extension_runner_util
     extension_tensor
     extension_threadpool
@@ -114,3 +115,7 @@ foreach(lib ${lib_list})
     list(APPEND EXECUTORCH_LIBRARIES ${lib})
   endif()
 endforeach()
+
+# TODO: investigate use of install(EXPORT) to cleanly handle
+# target_compile_options/target_compile_definitions for everything.
+target_link_libraries(cpublas INTERFACE extension_parallel)

--- a/build/executorch-config.cmake
+++ b/build/executorch-config.cmake
@@ -118,6 +118,8 @@ endforeach()
 
 # TODO: investigate use of install(EXPORT) to cleanly handle
 # target_compile_options/target_compile_definitions for everything.
-set_target_properties(
-  cpublas PROPERTIES INTERFACE_LINK_LIBRARIES extension_parallel
-)
+if (TARGET cpublas)
+  set_target_properties(
+    cpublas PROPERTIES INTERFACE_LINK_LIBRARIES extension_parallel
+  )
+endif()

--- a/build/executorch-config.cmake
+++ b/build/executorch-config.cmake
@@ -118,7 +118,12 @@ endforeach()
 
 # TODO: investigate use of install(EXPORT) to cleanly handle
 # target_compile_options/target_compile_definitions for everything.
-if (TARGET cpublas)
+if(TARGET extension_parallel)
+  set_target_properties(
+    extension_parallel PROPERTIES INTERFACE_LINK_LIBRARIES extension_threadpool
+  )
+endif()
+if(TARGET cpublas)
   set_target_properties(
     cpublas PROPERTIES INTERFACE_LINK_LIBRARIES extension_parallel
   )

--- a/extension/parallel/CMakeLists.txt
+++ b/extension/parallel/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Please keep this file formatted by running:
+# ~~~
+# cmake-format -i CMakeLists.txt
+# ~~~
+
+if(NOT (EXECUTORCH_BUILD_PTHREADPOOL AND EXECUTORCH_BUILD_CPUINFO))
+  message(FATAL_ERROR "extension/parallel requires extension/threadpool")
+endif()
+
+add_library(extension_parallel thread_parallel.cpp)
+
+target_link_libraries(extension_parallel PUBLIC executorch_core extension_threadpool)
+target_compile_options(extension_parallel PUBLIC ${_common_compile_options})
+
+install(
+  TARGETS extension_parallel
+  DESTINATION lib
+  INCLUDES
+  DESTINATION ${_common_include_directories})

--- a/kernels/optimized/CMakeLists.txt
+++ b/kernels/optimized/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 list(TRANSFORM _optimized_cpublas__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(cpublas STATIC ${_optimized_cpublas__srcs})
 target_link_libraries(
-  cpublas PRIVATE executorch_core eigen_blas extension_threadpool
+  cpublas PRIVATE executorch_core eigen_blas extension_parallel extension_threadpool
 )
 target_compile_options(cpublas PUBLIC ${_common_compile_options})
 


### PR DESCRIPTION
Previously it was copied in several places per executorch_srcs.cmake.

Needed for #8932

Test Plan: Compare cmake-out/executorch_srcs.cmake before/after for my usual testing cmake config with "all the CPU stuff" on; found that thread_parallel.cpp is now duplicated only in one place instead of multiple (it's in llama_runner, which needs a general fixup because it's duplicating several extensions).