### PR TITLE
Add optimized kernels to executorch pybindings

### DIFF
--- a/exir/backend/test/TARGETS
+++ b/exir/backend/test/TARGETS
@@ -107,7 +107,7 @@ python_unittest(
         "test_backends.py",
     ],
     preload_deps = [
-        "//executorch/kernels/portable:custom_ops_generated_lib",
+        "//executorch/configurations:optimized_native_cpu_ops",
         "//executorch/kernels/quantized:custom_ops_generated_lib",
         "//executorch/runtime/executor/test:test_backend_compiler_lib",
     ],

--- a/exir/backend/test/demos/rpc/TARGETS
+++ b/exir/backend/test/demos/rpc/TARGETS
@@ -47,7 +47,7 @@ python_unittest(
         "test_rpc.py",
     ],
     preload_deps = [
-        "//executorch/kernels/portable:custom_ops_generated_lib",
+        "//executorch/configurations:optimized_native_cpu_ops",
         "//executorch/kernels/quantized:custom_ops_generated_lib",
         # the executor backend is prebuilt and linked when building the unit test binary. When it's linked, it'll register the backend.
         # It can also be loaded in PyThon runtime via torch.ops.load_library("//executorch/exir/backend/test/demos/rpc:executor_backend")

--- a/exir/backend/test/demos/rpc/targets.bzl
+++ b/exir/backend/test/demos/rpc/targets.bzl
@@ -23,9 +23,9 @@ def define_common_targets():
         ],
         platforms = [ANDROID, CXX],
         deps = [
-            "//executorch/runtime/executor:program",
-            "//executorch/kernels/portable:generated_lib",
+            "//executorch/configurations:optimized_native_cpu_ops",
             "//executorch/runtime/backend:interface",
+            "//executorch/runtime/executor:program",
             "//executorch/extension/data_loader:buffer_data_loader",
         ] + MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB,
         exported_deps = [

--- a/shim_et/xplat/executorch/extension/pybindings/pybindings.bzl
+++ b/shim_et/xplat/executorch/extension/pybindings/pybindings.bzl
@@ -3,7 +3,7 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 # Aten ops with portable kernel
 MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB = [
-    "//executorch/kernels/portable:generated_lib",
+    "//executorch/configurations:optimized_native_cpu_ops",
     "//executorch/kernels/quantized:generated_lib",
 ]
 
@@ -41,6 +41,7 @@ MODELS_ATEN_OPS_ATEN_MODE_GENERATED_LIB = [
 
 def executorch_pybindings(python_module_name, srcs = [], cppdeps = [], visibility = ["//executorch/..."], types = [], compiler_flags = []):
     runtime.cxx_python_extension(
+        # @autodeps-skip
         name = python_module_name,
         srcs = [
             "//executorch/extension/pybindings:pybindings.cpp",


### PR DESCRIPTION
Summary:
As titled. This adds
```
//executorch/configurations:optimized_native_cpu_ops
```
target to

```
//executorch/extension/pybindings:_portable_lib
```
And also added to `preload_deps` of `executorch_llama` so that the bento kernel can use these ops.

Reviewed By: iseeyuan

Differential Revision: D70540908


