### PR TITLE
Add support for ptd in runner

### DIFF
--- a/examples/models/llama/runner/runner.h
+++ b/examples/models/llama/runner/runner.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -32,7 +33,8 @@ class ET_EXPERIMENTAL Runner : public executorch::extension::llm::IRunner {
   explicit Runner(
       const std::string& model_path,
       const std::string& tokenizer_path,
-      const float temperature = 0.8f);
+      const float temperature = 0.8f,
+      std::optional<const std::string> data_path = std::nullopt);
 
   bool is_loaded() const;
   ::executorch::runtime::Error load();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8953

partner engineers are calling ET via LlamaModule: https://github.com/pytorch/executorch/blob/main/extension/android/src/main/java/org/pytorch/executorch/LlamaModule.java

This is a wrapper around the runner: https://www.internalfb.com/code/fbsource/[90d251fc01a84871b679406d6dc855eb5ded82fd]/fbcode/executorch/examples/models/llama/runner/runner.cpp?lines=47

Differential Revision: [D70596210](https://our.internmc.facebook.com/intern/diff/D70596210/)