### PR TITLE
Default ExecuTorch targets to ExecuTorch-wide Buck visibility

### DIFF
--- a/shim_et/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim_et/xplat/executorch/build/runtime_wrapper.bzl
@@ -187,6 +187,9 @@ def _patch_kwargs_common(kwargs):
     for dep_type in ("deps", "exported_deps"):
         env.patch_deps(kwargs, dep_type)
 
+    if "visibility" not in kwargs:
+        kwargs["visibility"] = ["//executorch/..."]
+
     # Patch up references to "//executorch/..." in lists of build targets,
     # if necessary.
     use_static_deps = kwargs.pop("use_static_deps", False)
@@ -201,10 +204,6 @@ def _patch_kwargs_common(kwargs):
                 obj = kwargs.get(dep_type),
                 function = native.partial(_patch_executorch_references, use_static_deps = use_static_deps),
             )
-
-    # Make all targets private by default, like in xplat.
-    if "visibility" not in kwargs:
-        kwargs["visibility"] = []
 
     # If we see certain strings in the "visibility" list, expand them.
     if "@EXECUTORCH_CLIENTS" in kwargs["visibility"]:


### PR DESCRIPTION
IMO, Buck visibility is just inverse deps. We should trust that people have a good reason to add deps rather than attempt to police them and require double entry in both `deps` and `visibility`, especially since we seem to be committed to APIs by default in OSS anyway.

Specific motivation is that #8712 would otherwise have to ad-hoc slap ExecuTorch-wide visibility on a lot of targets, but I've held this view for a long time.

Differential Revision: [D70647462](https://our.internmc.facebook.com/intern/diff/D70647462)