### PR TITLE
Fix flatcc path for Windows

### DIFF
--- a/devtools/CMakeLists.txt
+++ b/devtools/CMakeLists.txt
@@ -20,7 +20,11 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(NOT FLATCC_EXECUTABLE)
-  set(FLATCC_EXECUTABLE ${_flatcc_source_dir}/bin/flatcc)
+  if(WIN32)
+    set(FLATCC_EXECUTABLE ${_flatcc_source_dir}/bin/${CMAKE_BUILD_TYPE}/flatcc)
+  else()
+    set(FLATCC_EXECUTABLE ${_flatcc_source_dir}/bin/flatcc)
+  endif()
 endif()
 
 # Source root directory for executorch.
@@ -159,6 +163,12 @@ file(MAKE_DIRECTORY
      ${_program_schema__include_dir}/executorch/devtools/bundled_program
 )
 
+if(WIN32)
+  set(RM_COMMAND rmdir /s /q)
+else()
+  set(RM_COMMAND rm -rf)
+endif()
+
 add_custom_command(
   OUTPUT ${_etdump_schema__outputs}
   COMMAND
@@ -168,10 +178,12 @@ add_custom_command(
     ${FLATCC_EXECUTABLE} -cwr -o
     ${_program_schema__include_dir}/executorch/devtools/etdump
     ${_etdump_schema__srcs}
-  COMMAND rm -rf ${_etdump_schema_cleanup_paths}
+  COMMAND ${RM_COMMAND} ${_etdump_schema_cleanup_paths}
   DEPENDS ${_etdump_schema_gen_dep}
   COMMENT "Generating etdump headers"
 )
+
+unset(RM_COMMAND)
 
 add_library(
   etdump ${CMAKE_CURRENT_SOURCE_DIR}/etdump/etdump_flatcc.cpp


### PR DESCRIPTION
### Summary
This PR is based on https://github.com/pytorch/executorch/pull/4993 but includes an additional fix to use the correct equivalent of the `rm -rf` command for Windows.

### Test plan

Built ExecuTorch for Windows using the following command:

```
del -Recurse -Force cmake-out; `
  cmake . `
  -DCMAKE_INSTALL_PREFIX=cmake-out `
  -DPYTHON_EXECUTABLE=C:\\Users\\ssjia\\AppData\\Local\\miniconda3\\python.exe `
  -DCMAKE_PREFIX_PATH=C:\\Users\\ssjia\\AppData\\Local\\miniconda3\\Lib\\site-packages `
  -DCMAKE_BUILD_TYPE=Release `
  -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON `
  -T ClangCL `
  -Bcmake-out; `
  cmake --build cmake-out -j64 --target install
```