### PR TITLE
[Fix bug] always run prepare-test-spec

### DIFF
--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -279,6 +279,7 @@ jobs:
         echo "::endgroup::"
 
   prepare-test-specs:
+    if: always()
     runs-on: linux.2xlarge
     needs:
       - set-parameters

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -288,6 +288,7 @@ jobs:
         echo "::endgroup::"
 
   prepare-test-specs:
+    if: always()
     runs-on: linux.2xlarge
     needs:
       - set-parameters


### PR DESCRIPTION
Follow up with https://github.com/pytorch/executorch/issues/8125

Example of failed benchmark run: https://github.com/pytorch/executorch/actions/runs/13666476394

We made prepare-test-spec have dependency on export-model, it seems like when there is any failure happens in the export model step, it will skip the whole prepare-test-spec. We want to always run prepare-test-spec.

in step prepare-test-spec, we will check wether the export-model successfully build the model, if not, no test-spec will be uploaded. This makes the final step mobile-on-device step fails early at verify-test-spec part


