### PR TITLE
[Portable] Easy fix of unfold_copy_out function signature

### DIFF
--- a/kernels/portable/cpu/op_unfold_copy.cpp
+++ b/kernels/portable/cpu/op_unfold_copy.cpp
@@ -11,7 +11,7 @@ using Tensor = executorch::aten::Tensor;
 
 // unfold_copy(Tensor self, int dimension, int size, int step, *, Tensor(a!)
 // out) -> Tensor(a!)
-Tensor unfold_copy_out(
+Tensor& unfold_copy_out(
     KernelRuntimeContext& ctx,
     const Tensor& self,
     int64_t dim,


### PR DESCRIPTION
### Summary
Return type should be `Tensor&`, instead of `Tensor` as it is for other operator signatures. This was causing symbol not found linker error on Windows.