### PR TITLE
fix mman header issues

### DIFF
--- a/extension/data_loader/targets.bzl
+++ b/extension/data_loader/targets.bzl
@@ -71,11 +71,18 @@ def define_common_targets():
         name = "mmap_data_loader",
         srcs = [
             "mmap_data_loader.cpp"
-        ] + (["mman_windows.cpp"] if host_info().os.is_windows else []),
-        headers = [
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//os:windows": ["mman_windows.cpp"],
+        }),
+        headers = select({
+            "DEFAULT": [],
+            "ovr_config//os:windows": ["mman_windows.h"],
+        }),
+        exported_headers = [
             "mman.h",
-        ] + (["mman_windows.h"] if host_info().os.is_windows else []),
-        exported_headers = ["mmap_data_loader.h"],
+            "mmap_data_loader.h"
+        ],
         visibility = [
             "//executorch/test/...",
             "//executorch/extension/pybindings/...",


### PR DESCRIPTION
### Summary
#8916 broke tests.  mman.h is needed by mmap_data_loader_test.cpp, and we need to use select

### Test plan
Unit tests - not sure why this didn't show on the first PR?