### PR TITLE
Do not export autogenerated headers.

### DIFF
--- a/runtime/executor/targets.bzl
+++ b/runtime/executor/targets.bzl
@@ -57,6 +57,8 @@ def define_common_targets():
         exported_deps = [
             "//executorch/runtime/core:core",
             "//executorch/runtime/core:named_data_map",
+        ],
+        deps = [
             "//executorch/schema:program",
         ],
         exported_preprocessor_flags = [] if runtime.is_oss else ["-DEXECUTORCH_INTERNAL_FLATBUFFERS=1"],


### PR DESCRIPTION
Program schema should stay a private dep.
Otherwise it'll try to become a part of a prebuilt Apple framework and essentially fail the build.