### PR TITLE
[ET-VK] Fix debug build + print maximum storage buffer size with device limits

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -274,13 +274,13 @@ VkPipeline Context::get_shader_pipeline(
   VkPipelineLayout pipeline_layout =
       pipeline_layout_cache().retrieve(shader_layout, push_constants_size);
 
-  vkapi::SpecVarList spec_constants_full_list = {4u, 4u, 1u};
-  spec_constants_full_list.append(spec_constants);
+  const utils::WorkgroupSize local_workgroup_size(4u, 4u, 1u);
 
   VkPipeline pipeline = pipeline_cache().retrieve(
       {pipeline_layout,
        shader_cache().retrieve(shader),
-       spec_constants_full_list});
+       spec_constants,
+       local_workgroup_size});
 
   return pipeline;
 }

--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -274,6 +274,7 @@ std::string Adapter::stringize() const {
   PRINT_PROP(limits, maxImageDimension1D);
   PRINT_PROP(limits, maxImageDimension2D);
   PRINT_PROP(limits, maxImageDimension3D);
+  PRINT_PROP(limits, maxStorageBufferRange);
   PRINT_PROP(limits, maxTexelBufferElements);
   PRINT_PROP(limits, maxPushConstantsSize);
   PRINT_PROP(limits, maxMemoryAllocationCount);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #9016

## Context

Two simple fixes/improvements.

1. Recently the interface to retrieve a `VkPipeline` from a pipeline cache was updated. Some code hidden behind debug compile flags was not updated. Updating the call site fixes building Vulkan with `etvk.debug = 1`.
2. Print the maximum storage buffer size when printing out the physical device limits. This is useful information to have.

Differential Revision: [D70718388](https://our.internmc.facebook.com/intern/diff/D70718388/)