### PR TITLE
Enable xnnpack in aten mode

### DIFF
--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -23,10 +23,10 @@ namespace backends {
 namespace xnnpack {
 namespace delegate {
 
+using executorch::ET_RUNTIME_NAMESPACE::NamedDataMap;
 using executorch::runtime::Error;
 using executorch::runtime::FreeableBuffer;
 using executorch::runtime::MemoryAllocator;
-using executorch::runtime::NamedDataMap;
 using executorch::runtime::Result;
 
 /*

--- a/backends/xnnpack/runtime/XNNExecutor.cpp
+++ b/backends/xnnpack/runtime/XNNExecutor.cpp
@@ -16,7 +16,7 @@ namespace delegate {
 using executorch::aten::ScalarType;
 using executorch::aten::SizesType;
 using executorch::aten::Tensor;
-using executorch::runtime::BackendExecutionContext;
+using executorch::ET_RUNTIME_NAMESPACE::BackendExecutionContext;
 using executorch::runtime::Error;
 using executorch::runtime::EValue;
 using executorch::runtime::is_contiguous_dim_order;
@@ -95,11 +95,19 @@ ET_NODISCARD Error XNNExecutor::prepare_args(EValue** args) {
     Tensor* tensor = &args[ext_id]->toTensor();
     externals_[i].data = tensor->mutable_data_ptr<float>();
 
+    executorch::aten::DimOrderType dim_order[kTensorDimensionLimit];
+
     // Reshape runtime inputs
     if (i < input_ids_.size()) {
       size_t num_dims = tensor->dim();
+      Error err =
+          ET_RUNTIME_NAMESPACE::get_dim_order(*tensor, dim_order, num_dims);
       ET_CHECK_OR_RETURN_ERROR(
-          is_contiguous_dim_order(tensor->dim_order().data(), tensor->dim()),
+          err == Error::Ok,
+          Internal,
+          "Failed to retrieve dim order from tensor!");
+      ET_CHECK_OR_RETURN_ERROR(
+          is_contiguous_dim_order(dim_order, tensor->dim()),
           Internal,
           "Expecting default dim_order but got a non default dim_order tensor for external input %u",
           i);
@@ -220,7 +228,7 @@ ET_NODISCARD Error XNNExecutor::resize_outputs(EValue** args) const {
         expected_output_size, static_cast<size_t>(num_dim)};
 
     ET_LOG(Debug, "Resizing output tensor to a new shape");
-    Error err = resize_tensor(*out_tensor, output_size);
+    Error err = ET_RUNTIME_NAMESPACE::resize_tensor(*out_tensor, output_size);
     if (err != Error::Ok) {
       ET_LOG(Error, "Failed to resize output tensor for XNNExecutor");
       return err;

--- a/backends/xnnpack/runtime/XNNExecutor.h
+++ b/backends/xnnpack/runtime/XNNExecutor.h
@@ -75,7 +75,7 @@ class XNNExecutor {
    * Executes the graph using the args prepared at prepare_args().
    */
   ET_NODISCARD executorch::runtime::Error forward(
-      executorch::runtime::BackendExecutionContext& context);
+      executorch::ET_RUNTIME_NAMESPACE::BackendExecutionContext& context);
 
   /**
    * Prepares the outputs to be returned by the delegate

--- a/backends/xnnpack/runtime/XNNPACKBackend.cpp
+++ b/backends/xnnpack/runtime/XNNPACKBackend.cpp
@@ -22,19 +22,20 @@ namespace executorch {
 namespace backends {
 
 using executorch::backends::xnnpack::delegate::XNNWeightsCache;
+using executorch::ET_RUNTIME_NAMESPACE::Backend;
+using executorch::ET_RUNTIME_NAMESPACE::BackendExecutionContext;
+using executorch::ET_RUNTIME_NAMESPACE::BackendInitContext;
+using executorch::ET_RUNTIME_NAMESPACE::CompileSpec;
+using executorch::ET_RUNTIME_NAMESPACE::DelegateHandle;
+using executorch::ET_RUNTIME_NAMESPACE::NamedDataMap;
 using executorch::runtime::ArrayRef;
-using executorch::runtime::Backend;
-using executorch::runtime::BackendExecutionContext;
-using executorch::runtime::BackendInitContext;
-using executorch::runtime::CompileSpec;
-using executorch::runtime::DelegateHandle;
 using executorch::runtime::Error;
 using executorch::runtime::EValue;
 using executorch::runtime::FreeableBuffer;
-using executorch::runtime::NamedDataMap;
 using executorch::runtime::Result;
 
-class XnnpackBackend final : public ::executorch::runtime::BackendInterface {
+class XnnpackBackend final
+    : public ::executorch::ET_RUNTIME_NAMESPACE::BackendInterface {
  public:
   ~XnnpackBackend() = default;
 

--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -19,8 +19,8 @@ namespace backends {
 namespace xnnpack {
 namespace delegate {
 
+using executorch::ET_RUNTIME_NAMESPACE::NamedDataMap;
 using executorch::runtime::MemoryAllocator;
-using executorch::runtime::NamedDataMap;
 
 XNNWeightsCache::XNNWeightsCache() {
   weights_cache_.context = this;

--- a/backends/xnnpack/runtime/XNNWeightsCache.h
+++ b/backends/xnnpack/runtime/XNNWeightsCache.h
@@ -23,10 +23,10 @@ namespace backends {
 namespace xnnpack {
 namespace delegate {
 
+using executorch::ET_RUNTIME_NAMESPACE::NamedDataMap;
 using executorch::runtime::Error;
 using executorch::runtime::FreeableBuffer;
 using executorch::runtime::MemoryAllocator;
-using executorch::runtime::NamedDataMap;
 using executorch::runtime::Result;
 
 struct PackedDataMeta {

--- a/backends/xnnpack/targets.bzl
+++ b/backends/xnnpack/targets.bzl
@@ -1,5 +1,5 @@
 load("@fbsource//xplat/executorch/backends/xnnpack/third-party:third_party_libs.bzl", "third_party_dep")
-load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "get_aten_mode_options", "runtime")
 
 def _get_preprocessor_flags():
     """
@@ -33,40 +33,42 @@ def define_common_targets():
         ],
     )
 
-    runtime.cxx_library(
-        name = "xnnpack_backend",
-        srcs = native.glob([
-            "runtime/*.cpp",
-            "runtime/profiling/*.cpp",
-        ]),
-        headers = native.glob([
-            "runtime/*.h",
-            "runtime/profiling/*.h",
-        ]),
-        visibility = [
-            "//executorch/exir/backend:backend_lib",
-            "//executorch/exir/backend/test/...",
-            "//executorch/backends/xnnpack/test/...",
-            "//executorch/extension/pybindings/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
-        preprocessor_flags = [
-            # Uncomment to enable per operator timings
-            # "-DENABLE_XNNPACK_PROFILING",
-            # Uncomment to enable using KleidiAI Kernels
-            # "-DENABLE_XNNPACK_KLEIDI"
-        ] + _get_preprocessor_flags(),
-        exported_deps = [
-            "//executorch/runtime/backend:interface",
-        ],
-        deps = [
-            third_party_dep("XNNPACK"),
-            "//executorch/backends/xnnpack/serialization:xnnpack_flatbuffer_header",
-            "//executorch/extension/threadpool:threadpool",
-            "//executorch/runtime/core/exec_aten/util:tensor_util",
-            "//executorch/runtime/executor:pte_data_map"
-        ],
-        # XnnpackBackend.cpp needs to compile with executor as whole
-        # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
-        link_whole = True,
-    )
+    for aten_mode in get_aten_mode_options():
+        aten_suffix = "_aten" if aten_mode else ""
+        runtime.cxx_library(
+            name = "xnnpack_backend" + aten_suffix,
+            srcs = native.glob([
+                "runtime/*.cpp",
+                "runtime/profiling/*.cpp",
+            ]),
+            headers = native.glob([
+                "runtime/*.h",
+                "runtime/profiling/*.h",
+            ]),
+            visibility = [
+                "//executorch/exir/backend:backend_lib",
+                "//executorch/exir/backend/test/...",
+                "//executorch/backends/xnnpack/test/...",
+                "//executorch/extension/pybindings/...",
+                "@EXECUTORCH_CLIENTS",
+            ],
+            preprocessor_flags = [
+                # Uncomment to enable per operator timings
+                # "-DENABLE_XNNPACK_PROFILING",
+                # Uncomment to enable using KleidiAI Kernels
+                # "-DENABLE_XNNPACK_KLEIDI"
+            ] + _get_preprocessor_flags(),
+            exported_deps = [
+                "//executorch/runtime/backend:interface" + aten_suffix,
+            ],
+            deps = [
+                third_party_dep("XNNPACK"),
+                "//executorch/backends/xnnpack/serialization:xnnpack_flatbuffer_header",
+                "//executorch/extension/threadpool:threadpool",
+                "//executorch/runtime/core/exec_aten/util:tensor_util" + aten_suffix,
+                "//executorch/runtime/executor:pte_data_map" + aten_suffix,
+            ],
+            # XnnpackBackend.cpp needs to compile with executor as whole
+            # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
+            link_whole = True,
+        )


### PR DESCRIPTION
Summary: This diff enables XNNPack delegate in ATen mode resolving some compilation issues and also making sure that the deps that XNNPack depends on are portable + aten friendly.

Differential Revision: D70704202


