### PR TITLE
[ET-VK][ez] Log GLSL file path on compile error

### DIFF
--- a/backends/vulkan/runtime/gen_vulkan_spv.py
+++ b/backends/vulkan/runtime/gen_vulkan_spv.py
@@ -769,7 +769,12 @@ class SPVGenerator:
                     + self.glslc_flags.split()
                 )
 
-                subprocess.check_call(cmd)
+                try:
+                    subprocess.check_call(cmd)
+                except subprocess.CalledProcessError as e:
+                    raise RuntimeError(
+                        f"Failed to compile {os.getcwd()}/{glsl_out_path}"
+                    ) from e
 
                 return (spv_out_path, glsl_out_path)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #9050

## Context

Make it much easier to debug GLSL compile errors by logging the path of the GLSL file when it fails to compile.

This makes it easy to quickly open up the generated GLSL and see what the compiler is complaining about.

Differential Revision: [D70795732](https://our.internmc.facebook.com/intern/diff/D70795732/)