### PR TITLE
mkdir when destination directory doesn't exist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -464,10 +464,8 @@ class InstallerBuildExt(build_ext):
 
         # Ensure that the destination directory exists.
         if not dst_file.parent.exists():
-            print(f"DEBUG 1: dest parent directory {dst_file.parent}, exists? {dst_file.parent.exists()}")
             self.mkpath(os.fspath(dst_file.parent))
-            print(f"DEBUG 2: dest parent directory {dst_file.parent}, exists? {dst_file.parent.exists()}")
-            
+
         # Copy the file.
         self.copy_file(os.fspath(src_file), os.fspath(dst_file))
 

--- a/setup.py
+++ b/setup.py
@@ -463,8 +463,11 @@ class InstallerBuildExt(build_ext):
         dst_file: Path = ext.dst_path(self)
 
         # Ensure that the destination directory exists.
-        self.mkpath(os.fspath(dst_file.parent))
-
+        if not dst_file.parent.exists():
+            print(f"DEBUG 1: dest parent directory {dst_file.parent}, exists? {dst_file.parent.exists()}")
+            self.mkpath(os.fspath(dst_file.parent))
+            print(f"DEBUG 2: dest parent directory {dst_file.parent}, exists? {dst_file.parent.exists()}")
+            
         # Copy the file.
         self.copy_file(os.fspath(src_file), os.fspath(dst_file))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #9055

Fixes #8980

Make sure we mkdir if destination directory doesn't exist. I have no
idea why it doesn't work before

cc @lucylq