### PR TITLE
Enable aten.upsample_nearest2d.vec

### DIFF
--- a/backends/qualcomm/_passes/layout_transform.py
+++ b/backends/qualcomm/_passes/layout_transform.py
@@ -42,6 +42,7 @@ class LayoutTransform(ExportPass):
         exir_ops.edge.aten.pixel_unshuffle.default,
         exir_ops.edge.aten.upsample_bilinear2d.default,
         exir_ops.edge.aten.upsample_nearest2d.default,
+        exir_ops.edge.aten.upsample_nearest2d.vec,
     }
 
     layout_agnostic_ops = {

--- a/backends/qualcomm/builders/op_upsample_nearest2d.py
+++ b/backends/qualcomm/builders/op_upsample_nearest2d.py
@@ -16,7 +16,7 @@ from .qnn_constants import OpResizeNearestNeighbor, QNN_OP_PACKAGE_NAME_QTI_AISW
 
 @register_node_visitor
 class ResizeBilinear(NodeVisitor):
-    target = ["aten.upsample_nearest2d.default"]
+    target = ["aten.upsample_nearest2d.default", "aten.upsample_nearest2d.vec"]
 
     def __init__(self, *args) -> None:
         super().__init__(*args)

--- a/backends/qualcomm/tests/models.py
+++ b/backends/qualcomm/tests/models.py
@@ -1201,6 +1201,17 @@ class ResizeNearest2D(torch.nn.Module):
         )
 
 
+class UpsampleNearest2D(torch.nn.Module):
+    def __init__(self, sizes=None, scale_factor=None):
+        super().__init__()
+        self.upsample_neareast_2d = torch.nn.UpsamplingNearest2d(  # noqa: TOR101
+            size=sizes, scale_factor=scale_factor
+        )
+
+    def forward(self, x):
+        return self.upsample_neareast_2d(x)
+
+
 class RmsNorm(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -502,6 +502,16 @@ class TestQNNFloatingPointOperator(TestQNN):
         sample_input = (torch.randn(2, 3, 4, 5),)
         self.lower_module_and_test_output(module, sample_input)
 
+    def test_qnn_backend_up_sampling_nearest_2d_with_scale_factor(self):
+        module = UpsampleNearest2D(scale_factor=2)  # noqa: F405
+        sample_input = (torch.randn(1, 16, 72, 104),)
+        self.lower_module_and_test_output(module, sample_input)
+
+    def test_qnn_backend_up_sampling_nearest_2d_with_size(self):
+        module = UpsampleNearest2D(sizes=(144, 208))  # noqa: F405
+        sample_input = (torch.randn(1, 16, 72, 104),)
+        self.lower_module_and_test_output(module, sample_input)
+
     def test_qnn_backend_layer_norm(self):
         modules = [LayerNorm(), LayerNorm(bias=False)]  # noqa: F405
         sample_input = (torch.randn(196, 768),)
@@ -1482,6 +1492,18 @@ class TestQNNQuantizedOperator(TestQNN):
         # TODO: Fix op not supported KeyError: 'aten.randn.default'
         module = ResizeNearest2D()  # noqa: F405
         sample_input = (torch.randn(2, 3, 4, 5),)
+        module = self.get_qdq_module(module, sample_input)
+        self.lower_module_and_test_output(module, sample_input)
+
+    def test_qnn_backend_up_sampling_nearest_2d_with_scale_factor(self):
+        module = UpsampleNearest2D(scale_factor=2)  # noqa: F405
+        sample_input = (torch.randn(1, 16, 72, 104),)
+        module = self.get_qdq_module(module, sample_input)
+        self.lower_module_and_test_output(module, sample_input)
+
+    def test_qnn_backend_up_sampling_nearest_2d_with_size(self):
+        module = UpsampleNearest2D(sizes=(144, 208))  # noqa: F405
+        sample_input = (torch.randn(1, 16, 72, 104),)
         module = self.get_qdq_module(module, sample_input)
         self.lower_module_and_test_output(module, sample_input)
 


### PR DESCRIPTION
Summary:
As title, fix some edge cases and add two unit tests
```
buck test 'fbcode//mode/dev-nosan' fbcode//executorch/backends/qualcomm/tests/fb:test_qnn_delegate_simulator -- --exact 'executorch/backends/qualcomm/tests/fb:test_qnn_delegate_simulator - test_qnn_backend_up_sampling_nearest_2d_with_size (executorch.backends.qualcomm.tests.fb.test_qnn_delegate_simulator.TestQNNQuantizedOperatorSimulator)'
buck test 'fbcode//mode/dev-nosan' fbcode//executorch/backends/qualcomm/tests/fb:test_qnn_delegate_simulator -- --exact 'executorch/backends/qualcomm/tests/fb:test_qnn_delegate_simulator - test_qnn_backend_up_sampling_nearest_2d_with_size (executorch.backends.qualcomm.tests.fb.test_qnn_delegate_simulator.TestQNNFloatingPointOperatorSimulator)'
```

Differential Revision: D70796006


