### PR TITLE
Add the execution permission after the runner file copied to android device.

### DIFF
--- a/examples/qualcomm/utils.py
+++ b/examples/qualcomm/utils.py
@@ -205,6 +205,7 @@ class SimpleADB:
             qnn_executor_runner_cmds = " ".join(
                 [
                     f"cd {self.workspace} &&",
+                    f"chmod +x ./qnn_executor_runner &&",
                     f"./qnn_executor_runner {qnn_executor_runner_args}",
                 ]
             )


### PR DESCRIPTION
### Summary
Fixes #9072

The executable file: qnn_executor_runner executable permission is removed on the mobile device (I tested on one plus phone, os 15) after it's copied to the mobile device;

The attributes of the original file:
**-rwxr-xr-x 1 . . 53039224 Mar  9 13:38 examples/qualcomm/executor_runner/qnn_executor_runner***

The attributes of the copied file on the mobile device:
**-rw-rw-rw- 1 . . 53039224 2025-03-09 00:38 executorch/dl3_qnn_q8/qnn_executor_runner**

The step of qnn example is failed by the following error messages:
```
/system/bin/sh: ./qnn_executor_runner: can't execute: Permission denied
/data/local/tmp/executorch/dl3_qnn_q8/outputs/: 0 files pulled, 0 skipped.
Traceback (most recent call last):
  File "executorch/examples/qualcomm/scripts/deeplab_v3.py", line 200, in <module>
    main(args)
  File "executorch/examples/qualcomm/scripts/deeplab_v3.py", line 161, in main
    np.fromfile(
FileNotFoundError: [Errno 2] No such file or directory: './deeplab_v3/outputs/output_0_0.raw'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "executorch/examples/qualcomm/scripts/deeplab_v3.py", line 206, in <module>
    raise Exception(e)
Exception: [Errno 2] No such file or directory: './deeplab_v3/outputs/output_0_0.raw'
```

So, for running example easily, I added the "chmod +x ./qnn_executor_runner" before running it.
Local test is successful, after adding this line the runner is running successfully on the device.

I found a solution, that need the root privilege to run the adb command, I think use the `chmod +x` is the lite method.

### Test plan
1. Connect to the android device with debug mode.
2. Compile and run the android example by referencing the tutorial:
https://pytorch.org/executorch/main/backends-qualcomm.html