### PR TITLE
Fix missing algorithm header in thread_parallel

### DIFF
--- a/extension/parallel/thread_parallel.cpp
+++ b/extension/parallel/thread_parallel.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <algorithm>
 #include <cinttypes>
 #include <tuple>
 


### PR DESCRIPTION
This is causing build errors:

```bash
$ cmake . -DCMAKE_INSTALL_PREFIX="cmake-out-android-x86_64" \
  -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
  -DANDROID_ABI="x86_64" \
  -DANDROID_PLATFORM=android-26 \
  -DEXECUTORCH_BUILD_FLATC=ON \
  -DEXECUTORCH_BUILD_XNNPACK=ON \
  -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
  -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
  -DEXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL=ON \
  -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
  -B"cmake-out-android-x86_64"

$ cmake --build "cmake-out-android-x86_64" -j $(sysctl -n hw.ncpu) --target install

/Users/jathu/executorch/extension/parallel/thread_parallel.cpp:42:36: error: no member named 'max' in namespace 'std'
    return std::make_tuple(1, std::max((int64_t)0, end - begin));
                              ~~~~~^
/Users/jathu/executorch/extension/parallel/thread_parallel.cpp:48:21: error: no member named 'max' in namespace 'std'
  chunk_size = std::max(grain_size, chunk_size);
               ~~~~~^
/Users/jathu/executorch/extension/parallel/thread_parallel.cpp:72:32: error: no member named 'min' in namespace 'std'
      int64_t local_end = std::min(end, (int64_t)(chunk_size + local_start));
                          ~~~~~^
3 errors generated.
make[2]: *** [extension/parallel/CMakeFiles/extension_parallel.dir/thread_parallel.cpp.o] Error 1
make[1]: *** [extension/parallel/CMakeFiles/extension_parallel.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

Including [algorithm](https://en.cppreference.com/w/cpp/algorithm/max) will fix it.