### PR TITLE
Arm backend: Re-enable Corstone FVP test

### DIFF
--- a/backends/arm/test/conftest.py
+++ b/backends/arm/test/conftest.py
@@ -31,10 +31,8 @@ This file contains the pytest hooks, fixtures etc. for the Arm test suite.
 def pytest_configure(config):
     pytest._test_options = {}  # type: ignore[attr-defined]
     pytest._test_options["corstone_fvp"] = False  # type: ignore[attr-defined]
-    if (
-        getattr(config.option, "arm_run_corestoneFVP", False)
-        and config.option.arm_run_corstoneFVP
-    ):
+
+    if config.option.arm_run_corstoneFVP:
         corstone300_exists = shutil.which("FVP_Corstone_SSE-300_Ethos-U55")
         corstone320_exists = shutil.which("FVP_Corstone_SSE-320")
         if not (corstone300_exists and corstone320_exists):

--- a/backends/arm/test/models/test_w2l_arm.py
+++ b/backends/arm/test/models/test_w2l_arm.py
@@ -131,7 +131,7 @@ class TestW2L(unittest.TestCase):
 
     @pytest.mark.slow
     @pytest.mark.corstone_fvp
-    @conftest.expectedFailureOnFVP  # TODO: MLBEDSW-10093
+    @conftest.expectedFailureOnFVP  # TODO: MLETORCH-761
     def test_w2l_u85_BI(self):
         tester = self._test_w2l_ethos_BI_pipeline(
             self.w2l,


### PR DESCRIPTION
Because of a bug tests where not run when given --arm_run_corstoneFVP to pytest.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218