### PR TITLE
Arm backend: Make build script source the generated setup_path.sh

### DIFF
--- a/backends/arm/scripts/build_executorch.sh
+++ b/backends/arm/scripts/build_executorch.sh
@@ -15,6 +15,8 @@ et_root_dir=$(cd ${script_dir}/../../.. && pwd)
 et_root_dir=$(realpath ${et_root_dir})
 toolchain_cmake=${script_dir}/../../../examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake
 toolchain_cmake=$(realpath ${toolchain_cmake})
+setup_path_script=${et_root_dir}/examples/arm/ethos-u-scratch/setup_path.sh
+_setup_msg="please refer to ${et_root_dir}/examples/arm/setup.sh to properly install necessary tools."
 
 et_build_root="${et_root_dir}/arm_test"
 build_type="Release"
@@ -42,6 +44,13 @@ for arg in "$@"; do
       ;;
     esac
 done
+
+# Source the tools
+# This should be prepared by the setup.sh
+[[ -f ${setup_path_script} ]] \
+    || { echo "Missing ${setup_path_script}. ${_setup_msg}"; exit 1; }
+
+source ${setup_path_script}
 
 et_build_dir="${et_build_root}/cmake-out"
 

--- a/backends/arm/scripts/build_executorch_runner.sh
+++ b/backends/arm/scripts/build_executorch_runner.sh
@@ -10,6 +10,8 @@ script_dir=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 et_root_dir=$(cd ${script_dir}/../../.. && pwd)
 et_root_dir=$(realpath ${et_root_dir})
 toolchain_cmake=${et_root_dir}/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake
+setup_path_script=${et_root_dir}/examples/arm/ethos-u-scratch/setup_path.sh
+_setup_msg="please refer to ${et_root_dir}/examples/arm/setup.sh to properly install necessary tools."
 
 pte_file=""
 target="ethos-u55-128"
@@ -65,6 +67,13 @@ for arg in "$@"; do
       ;;
     esac
 done
+
+# Source the tools
+# This should be prepared by the setup.sh
+[[ -f ${setup_path_script} ]] \
+    || { echo "Missing ${setup_path_script}. ${_setup_msg}"; exit 1; }
+
+source ${setup_path_script}
 
 pte_file=$(realpath ${pte_file})
 ethosu_tools_dir=$(realpath ${ethosu_tools_dir})

--- a/backends/arm/scripts/build_portable_kernels.sh
+++ b/backends/arm/scripts/build_portable_kernels.sh
@@ -15,6 +15,8 @@ et_root_dir=$(cd ${script_dir}/../../.. && pwd)
 et_root_dir=$(realpath ${et_root_dir})
 toolchain_cmake=${script_dir}/../../../examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake
 toolchain_cmake=$(realpath ${toolchain_cmake})
+setup_path_script=${et_root_dir}/examples/arm/ethos-u-scratch/setup_path.sh
+_setup_msg="please refer to ${et_root_dir}/examples/arm/setup.sh to properly install necessary tools."
 
 
 et_build_root="${et_root_dir}/arm_test"
@@ -40,6 +42,13 @@ for arg in "$@"; do
       ;;
     esac
 done
+
+# Source the tools
+# This should be prepared by the setup.sh
+[[ -f ${setup_path_script} ]] \
+    || { echo "Missing ${setup_path_script}. ${_setup_msg}"; exit 1; }
+
+source ${setup_path_script}
 
 et_build_dir=${et_build_root}/cmake-out
 


### PR DESCRIPTION
This makes it more easy to run the scripts from various tools like your editor.



cc @digantdesai @freddan80 @per @oscarandersson8218