### PR TITLE
Set oss.folly_cxx_tests buckconfig to false

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -39,3 +39,6 @@
 
 [buck2]
 restarter=true
+
+[oss]
+folly_cxx_tests = False


### PR DESCRIPTION
This is an option in the Buck shims that controls whether cxx_tests automatically depend on folly. ExecuTorch doesn't use folly.