### PR TITLE
Bump memory for phi-4-mini test_model

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -30,6 +30,7 @@ CUSTOM_RUNNERS = {
         "dl3": "linux.4xlarge.memory",
         "emformer_join": "linux.4xlarge.memory",
         "emformer_predict": "linux.4xlarge.memory",
+        "phi-4-mini": "linux.4xlarge.memory",
     }
 }
 


### PR DESCRIPTION
Attempt to fix test on trunk where mac is passing but linux is failing, e.g. https://github.com/pytorch/executorch/actions/runs/13770685177/job/38508355264