### PR TITLE
Don't use designated initializers in QueryPool.cpp

### DIFF
--- a/backends/vulkan/runtime/vk_api/QueryPool.cpp
+++ b/backends/vulkan/runtime/vk_api/QueryPool.cpp
@@ -185,19 +185,20 @@ std::vector<ShaderResult> QueryPool::get_shader_timestamp_data() {
   std::vector<ShaderResult> shader_result;
   for (ShaderDuration& entry : shader_durations_) {
     shader_result.push_back(ShaderResult{
-        .kernel_name = entry.kernel_name,
-        .dispatch_id = entry.dispatch_id,
-        .start_time_ns = entry.start_time_ns,
-        .end_time_ns = entry.end_time_ns,
-        .metadata = ShaderMetadata{
-            .global_workgroup_size =
-                {entry.global_workgroup_size.width,
-                 entry.global_workgroup_size.height,
-                 entry.global_workgroup_size.depth},
-            .local_workgroup_size =
-                {entry.local_workgroup_size.width,
-                 entry.local_workgroup_size.height,
-                 entry.local_workgroup_size.depth},
+        /* .kernel_name = */ entry.kernel_name,
+        /* .dispatch_id = */ entry.dispatch_id,
+        /* .start_time_ns = */ entry.start_time_ns,
+        /* .end_time_ns = */ entry.end_time_ns,
+        /* .metadata = */
+        ShaderMetadata{
+            /* .global_workgroup_size = */
+            {entry.global_workgroup_size.width,
+             entry.global_workgroup_size.height,
+             entry.global_workgroup_size.depth},
+            /* .local_workgroup_size = */
+            {entry.local_workgroup_size.width,
+             entry.local_workgroup_size.height,
+             entry.local_workgroup_size.depth},
         }});
   }
   return shader_result;


### PR DESCRIPTION
Summary: This is a c++20 feature, but not all clients are on c++20.

Differential Revision: D70933388


