### PR TITLE
Fix pre-autograd transforms not getting persisted during xnnpack export

### DIFF
--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -89,7 +89,9 @@ class LLMEdgeManager:
         dynamic_shapes: Optional[Any] = None,
     ):
         self.model = model
-        self.pre_autograd_exported_program: Optional[ExportedProgram] = None
+        self.exported_program: Optional[ExportedProgram] = None
+        # Self.exported_program's pre-autograd graph module, for running
+        # transform passes on the graph prior to torch.export().
         self.pre_autograd_graph_module: Optional[torch.nn.Module] = None
         self.modelname = modelname
         self.max_seq_len = max_seq_len
@@ -184,7 +186,21 @@ class LLMEdgeManager:
         )
         return edge_config
 
-    def export(self) -> "LLMEdgeManager":
+    def export(self, module: Optional[torch.nn.Module] = None) -> "LLMEdgeManager":
+        """
+        Exports the model pre-autograd. This is not a full export, since it uses
+        torch.export_for_training() to keep autograd-safe ops from getting decomposed.
+        The full torch.export() if called later on during to_edge() or
+        to_edge_transform_and_lower().
+
+        The optional `module` argument is included so that the user can re-export
+        an already-exported module's ExportedProgram's graph module, to persiste
+        the changes into a new ExportedProgram.
+
+        Args:
+            module (Optional[torch.nn.Module]): module to export.
+
+        """
         dynamic_shape = self._get_dynamic_shape()
         # 1. torch.nn.attention.sdpa_kernel([SDPBackend.MATH]) is for bypassing the dynamo error when tracing
         # 2. torch.no_grad() is for getting rid of the dropout (not sure why training ops will show up)
@@ -201,25 +217,30 @@ class LLMEdgeManager:
                     # TODO: this is temporary and export_for_training doesn't work with qnn either. We need a
                     # functional graph. See issue https://github.com/pytorch/executorch/pull/4627 for more details
                     exported_module = torch.export.export(
-                        self.model,
+                        self.model if not module else module,
                         self.example_inputs,
                         self.example_kwarg_inputs,
                         dynamic_shapes=dynamic_shape,
                         strict=True,
                     )
             else:
-                logging.info("Exporting with:")
+                if module:
+                    logging.info("Re-exporting with:")
+                else:
+                    logging.info("Exporting with:")
                 logging.info(f"inputs: {self.example_inputs}")
                 logging.info(f"kwargs: {self.example_kwarg_inputs}")
                 logging.info(f"dynamic shapes: {dynamic_shape}")
                 exported_module = export_for_training(
-                    self.model,
+                    self.model if not module else module,
                     self.example_inputs,
                     kwargs=self.example_kwarg_inputs,
                     dynamic_shapes=dynamic_shape,
                 )
-            #  `Module`.
-            self.pre_autograd_exported_program = exported_module
+            self.exported_program = exported_module
+            # Need to store the graph module to record transformation passes.
+            # Persisting those changes back to the ExportedProgram will require
+            # an additional export().
             self.pre_autograd_graph_module = exported_module.module()
             if hasattr(self.args, "export_only") and self.args.export_only:
                 torch.export.save(exported_module, self.args.output_name)
@@ -382,7 +403,7 @@ class LLMEdgeManager:
         # 1. torch.nn.attention.sdpa_kernel([SDPBackend.MATH]) is for bypassing the dynamo error when tracing
         # 2. torch.no_grad() is for getting rid of the dropout (not sure why training ops will show up)
         with torch.nn.attention.sdpa_kernel([SDPBackend.MATH]), torch.no_grad():
-            if self.pre_autograd_graph_module is None:
+            if self.exported_program is None:
                 # Run export() if it didn't run
                 self.export()
 
@@ -394,9 +415,12 @@ class LLMEdgeManager:
                     return_value=False,
                 )
 
+            # Prior to export, persist the changes to the pre autograd
+            # graph module back to the source-of-truth ExportedProgram.
+            self.export(self.pre_autograd_graph_module)
             with override_export_behaviour:
                 self.edge_manager = export_to_edge(
-                    self.pre_autograd_graph_module,  # pyre-fixme[6]
+                    self.exported_program.module(),  # pyre-fixme[6]
                     self.example_inputs,
                     example_kwarg_inputs=self.example_kwarg_inputs,
                     dynamic_shapes=dynamic_shape,
@@ -441,9 +465,14 @@ class LLMEdgeManager:
     ) -> "LLMEdgeManager":
         if partitioners is None:
             logging.info("No partitioner provided, skipping backend lowering...")
+
+        # Prior to export, persist the changes to the pre autograd
+        # graph module back to the source-of-truth ExportedProgram.
+        self.export(self.pre_autograd_graph_module)
+
         edge_config = self._get_edge_config()
         self.edge_manager = to_edge_transform_and_lower(
-            self.pre_autograd_exported_program,
+            self.exported_program,
             partitioner=partitioners,
             compile_config=edge_config,
             constant_methods=self.metadata,


### PR DESCRIPTION
### Summary
After moving to `to_edge_transform_and_lower` for the XNNPack export route in https://github.com/pytorch/executorch/pull/8624, we were discarding all of the transforms made to the pre-autograd graph module stored in `LLMEdgeManager`, since the new `to_edge_transform_and_lower` took in an `ExportedProgram` instead of a `nn.Module` as an argument. To solve this, we re-run export for training right before each `LLMEdgeManager` API that runs the full non-autograd safe `torch.export()`.

### Test plan
Tested manually on Llama3.2 1B export:
```
python -m examples.models.llama.export_llama --checkpoint ~/hf/models--meta-llama--Llama-3.2-1B-Instruct/snapshots/9213176726f574b556790deb65791e0c5aa438b6/original/consolidated.00.pth -p ~/hf/models--meta-llama--Llama-3.2-1B-Instruct/snapshots/9213176726f574b556790deb65791e0c5aa438b6/original/params.json -d fp32 -kv -X --use_sdpa_with_kv_cache -n llama3_1b_regression.pte --verbose
```

Before ops (contains permute_copy): 
```
Total delegated subgraphs: 113
Number of delegated nodes: 113
Number of non-delegated nodes: 1447
╒════╤══════════════════════════════╤═══════════════════════════════════╤═══════════════════════════════════════╕
│    │ op_type                      │   occurrences_in_delegated_graphs │   occurrences_in_non_delegated_graphs │
╞════╪══════════════════════════════╪═══════════════════════════════════╪═══════════════════════════════════════╡
│  0 │ _assert_scalar               │                                 0 │                                    67 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  1 │ _local_scalar_dense          │                                 0 │                                    33 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  2 │ add                          │                                 0 │                                    17 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  3 │ aten_add_tensor              │                                 0 │                                    97 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  4 │ aten_cat_default             │                                 0 │                                    32 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  5 │ aten_embedding_default       │                                 0 │                                     1 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  6 │ aten_linear_default          │                               113 │                                     0 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  7 │ aten_mean_dim                │                                 0 │                                    33 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  8 │ aten_mul_tensor              │                                 0 │                                   259 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  9 │ aten_permute_copy_default    │                                 0 │                                   160 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 10 │ aten_rsqrt_default           │                                 0 │                                    33 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 11 │ aten_select_copy_int         │                                 0 │                                    34 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 12 │ aten_sigmoid_default         │                                 0 │                                    16 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 13 │ aten_slice_copy_tensor       │                                 0 │                                    67 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 14 │ aten_squeeze_copy_dims       │                                 0 │                                    64 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 15 │ aten_sub_tensor              │                                 0 │                                    32 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 16 │ aten_unsqueeze_copy_default  │                                 0 │                                    64 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 17 │ aten_view_copy_default       │                                 0 │                                   160 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 18 │ auto_functionalized          │                                 0 │                                    32 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 19 │ ge                           │                                 0 │                                    17 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 20 │ getitem                      │                                 0 │                                   145 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 21 │ le                           │                                 0 │                                    17 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 22 │ llama_custom_sdpa_default    │                                 0 │                                    16 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 23 │ lt                           │                                 0 │                                    33 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 24 │ sym_constrain_range_for_size │                                 0 │                                    17 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 25 │ sym_size                     │                                 0 │                                     1 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 26 │ Total                        │                               113 │                                  1447 │
╘════╧══════════════════════════════╧═══════════════════════════════════╧═══════════════════════════════════════╛
```

After ops (no permute_copy):
```
Total delegated subgraphs: 113
Number of delegated nodes: 113
Number of non-delegated nodes: 1253

╒════╤══════════════════════════════╤═══════════════════════════════════╤═══════════════════════════════════════╕
│    │ op_type                      │   occurrences_in_delegated_graphs │   occurrences_in_non_delegated_graphs │
╞════╪══════════════════════════════╪═══════════════════════════════════╪═══════════════════════════════════════╡
│  0 │ _assert_scalar               │                                 0 │                                    50 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  1 │ _local_scalar_dense          │                                 0 │                                    33 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  2 │ add                          │                                 0 │                                    17 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  3 │ aten_add_tensor              │                                 0 │                                    97 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  4 │ aten_cat_default             │                                 0 │                                    32 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  5 │ aten_embedding_default       │                                 0 │                                     1 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  6 │ aten_linear_default          │                               113 │                                     0 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  7 │ aten_mean_dim                │                                 0 │                                    33 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  8 │ aten_mul_tensor              │                                 0 │                                   259 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│  9 │ aten_rsqrt_default           │                                 0 │                                    33 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 10 │ aten_select_copy_int         │                                 0 │                                    34 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 11 │ aten_sigmoid_default         │                                 0 │                                    16 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 12 │ aten_slice_copy_tensor       │                                 0 │                                    67 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 13 │ aten_squeeze_copy_dims       │                                 0 │                                    64 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 14 │ aten_sub_tensor              │                                 0 │                                    32 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 15 │ aten_unsqueeze_copy_default  │                                 0 │                                    64 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 16 │ aten_view_copy_default       │                                 0 │                                   160 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 17 │ auto_functionalized          │                                 0 │                                    32 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 18 │ ge                           │                                 0 │                                    17 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 19 │ getitem                      │                                 0 │                                   145 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 20 │ le                           │                                 0 │                                    17 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 21 │ llama_custom_sdpa_default    │                                 0 │                                    16 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 22 │ lt                           │                                 0 │                                    16 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 23 │ sym_constrain_range_for_size │                                 0 │                                    17 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 24 │ sym_size                     │                                 0 │                                     1 │
├────┼──────────────────────────────┼───────────────────────────────────┼───────────────────────────────────────┤
│ 25 │ Total                        │                               113 │                                  1253 │
╘════╧══════════════════════════════╧═══════════════════════════════════╧═══════════════════════════════════════╛
```
