### PR TITLE
Add buck to build binary for Android

### DIFF
--- a/examples/xnnpack/executor_runner/TARGETS
+++ b/examples/xnnpack/executor_runner/TARGETS
@@ -1,0 +1,8 @@
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/examples/xnnpack/executor_runner/targets.bzl
+++ b/examples/xnnpack/executor_runner/targets.bzl
@@ -1,0 +1,20 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "get_oss_build_kwargs", "runtime")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    # executor_runner for XNNPACK Backend and portable kernels.
+    runtime.cxx_binary(
+        name = "xnn_executor_runner",
+        deps = [
+            "//executorch/examples/portable/executor_runner:executor_runner_lib",
+            "//executorch/backends/xnnpack:xnnpack_backend",
+            "//executorch/kernels/portable:generated_lib",
+        ],
+        define_static_target = True,
+        **get_oss_build_kwargs()
+    )


### PR DESCRIPTION
Summary:
Build the binary for Android requires a BUCK file. However, it can't be added under `executorch/examples/xnnpack` directly, as `aot_compiler` in target.bzl cannot be built on Linux.

Create a standalone dir for xnn_executor_runner build.

Differential Revision: D70936105


