### PR TITLE
Do auto redirect for old getting started page

### DIFF
--- a/docs/source/getting-started-setup.md
+++ b/docs/source/getting-started-setup.md
@@ -1,6 +1,0 @@
-# Setting Up ExecuTorch
-
-This page is re-organized into the following pages:
-
-* [Getting Started with ExecuTorch](getting-started.md)
-* [Building from Source](using-executorch-building-from-source.md)

--- a/docs/source/getting-started-setup.rst
+++ b/docs/source/getting-started-setup.rst
@@ -1,0 +1,13 @@
+Setting Up ExecuTorch
+=====================
+
+This page is re-organized into the following pages:
+
+* `Getting Started with ExecuTorch <getting-started.html>`_
+* `Building from Source <using-executorch-building-from-source.html>`_
+
+It will redirect in 3 seconds
+
+.. raw:: html
+
+   <meta http-equiv="Refresh" content="3; url='./getting-started.html'" />


### PR DESCRIPTION
The new page name (getting-started.html) is strictly better than the old one (getting-started-setup.html)

Let's make a redirect so that we don't force users to make an unnecessary click.

Test Plan: 

https://docs-preview.pytorch.org/pytorch/executorch/9135/getting-started-setup.html