### PR TITLE
Move ModelDataKit to ExecuTorch directory

### DIFF
--- a/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/ModelRuntime.swift
+++ b/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/ModelRuntime.swift
@@ -1,0 +1,14 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import Foundation
+
+public enum ModelRuntimeError: Error {
+  case unsupportedInputType
+}
+
+public protocol ModelRuntime {
+  func infer(input: [ModelRuntimeValue]) throws -> [ModelRuntimeValue]
+
+  func getModelValueFactory() -> ModelRuntimeValueFactory
+  func getModelTensorFactory() -> ModelRuntimeTensorValueFactory
+}

--- a/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/ModelRuntimeValueError.swift
+++ b/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/ModelRuntimeValueError.swift
@@ -1,0 +1,27 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import Foundation
+
+public enum ModelRuntimeValueError: Error, CustomStringConvertible {
+  case unsupportedType(String)
+  case invalidType(String, String)
+
+  public var description: String {
+    switch self {
+    case .unsupportedType(let type):
+      return "Unsupported type: \(type)"
+    case .invalidType(let expectedType, let type):
+      return "Invalid type: \(type), expected \(expectedType)"
+    }
+  }
+}
+
+@objc public class ModelRuntimeValueErrorFactory: NSObject {
+  @objc public class func unsupportedType(_ type: String) -> Error {
+    return ModelRuntimeValueError.unsupportedType(type)
+  }
+
+  @objc public class func invalidType(_ actualType: String, expectedType: String) -> Error {
+    return ModelRuntimeValueError.invalidType(expectedType, actualType)
+  }
+}

--- a/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/Tensor/ModelRuntimeTensorValue.swift
+++ b/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/Tensor/ModelRuntimeTensorValue.swift
@@ -1,0 +1,17 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import Foundation
+
+public class ModelRuntimeTensorValue {
+  public let innerValue: ModelRuntimeTensorValueBridging
+  public init(innerValue: ModelRuntimeTensorValueBridging) {
+    self.innerValue = innerValue
+  }
+
+  public func floatRepresentation() throws -> (floatArray: [Float], shape: [Int]) {
+    let value = try innerValue.floatRepresentation()
+    let data = value.floatArray
+    let shape = value.shape
+    return (data.compactMap { $0.floatValue }, shape.compactMap { $0.intValue })
+  }
+}

--- a/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/Tensor/ModelRuntimeTensorValueBridging.swift
+++ b/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/Tensor/ModelRuntimeTensorValueBridging.swift
@@ -1,0 +1,16 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import Foundation
+
+public class ModelRuntimeTensorValueBridgingTuple: NSObject {
+  @objc public let floatArray: [NSNumber]
+  @objc public let shape: [NSNumber]
+  @objc public init(floatArray: [NSNumber], shape: [NSNumber]) {
+    self.floatArray = floatArray
+    self.shape = shape
+  }
+}
+
+@objc public protocol ModelRuntimeTensorValueBridging {
+  func floatRepresentation() throws -> ModelRuntimeTensorValueBridgingTuple
+}

--- a/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/Tensor/ModelRuntimeTensorValueFactory.swift
+++ b/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/Tensor/ModelRuntimeTensorValueFactory.swift
@@ -1,0 +1,7 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import Foundation
+
+public protocol ModelRuntimeTensorValueFactory {
+  func createFloatTensor(value: [Float], shape: [Int]) -> ModelRuntimeTensorValue
+}

--- a/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/Value/ModelRuntimeValue.swift
+++ b/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/Value/ModelRuntimeValue.swift
@@ -1,0 +1,22 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import Foundation
+
+public class ModelRuntimeValue {
+  public let value: ModelRuntimeValueBridging
+  public init(innerValue: ModelRuntimeValueBridging) {
+    self.value = innerValue
+  }
+
+  public func stringValue() throws -> String {
+    return try value.stringValue()
+  }
+
+  public func tensorValue() throws -> ModelRuntimeTensorValue {
+    return try ModelRuntimeTensorValue(innerValue: value.tensorValue())
+  }
+
+  public func arrayValue() throws -> [ModelRuntimeValue] {
+    return try value.arrayValue().map { ModelRuntimeValue(innerValue: $0) }
+  }
+}

--- a/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/Value/ModelRuntimeValueBridging.swift
+++ b/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/Value/ModelRuntimeValueBridging.swift
@@ -1,0 +1,9 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import Foundation
+
+@objc public protocol ModelRuntimeValueBridging {
+  func stringValue() throws -> String
+  func tensorValue() throws -> ModelRuntimeTensorValueBridging
+  func arrayValue() throws -> [ModelRuntimeValueBridging]
+}

--- a/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/Value/ModelRuntimeValueFactory.swift
+++ b/extension/apple/ModelRunnerDataKit/ModelRunnerDataKit/Value/ModelRuntimeValueFactory.swift
@@ -1,0 +1,8 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import Foundation
+
+public protocol ModelRuntimeValueFactory {
+  func createString(value: String) throws -> ModelRuntimeValue
+  func createTensor(value: ModelRuntimeTensorValue) throws -> ModelRuntimeValue
+}


### PR DESCRIPTION
Summary: Adding the scaffolding for the Swift Bridging API for ExecuTorch

Differential Revision: D70825994
