### PR TITLE
Fix LLM fine-tuning examples import error on OSS

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/BinaryOp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/BinaryOp.cpp
@@ -132,18 +132,21 @@ void add_binary_op_buffer_node(
       // Shader params buffers
       {},
       // Specialization Constants
-      {graph.packed_dim_of(out), graph.packed_dim_of(in1), graph.packed_dim_of(in2)},
+      {graph.packed_dim_of(out),
+       graph.packed_dim_of(in1),
+       graph.packed_dim_of(in2)},
       // Resizing Logic
       resize_binary_op_node,
       {},
-      {{graph.sizes_pc_of(in1),
-        graph.sizes_pc_of(in2),
-        graph.strides_pc_of(out),
-        graph.strides_pc_of(in1),
-        graph.strides_pc_of(in2),
-        graph.numel_pc_of(out),
-        PushConstantDataInfo(&alpha_val, sizeof(float)),
-        }}));
+      {{
+          graph.sizes_pc_of(in1),
+          graph.sizes_pc_of(in2),
+          graph.strides_pc_of(out),
+          graph.strides_pc_of(in1),
+          graph.strides_pc_of(in2),
+          graph.numel_pc_of(out),
+          PushConstantDataInfo(&alpha_val, sizeof(float)),
+      }}));
 }
 
 void add_binary_op_node(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ flatc = "executorch.data.bin:flatc"
 # into core pip packages. Refactor out the necessary utils
 # or core models files into a separate package.
 "executorch.examples.apple.coreml.llama" = "examples/apple/coreml/llama"
+"executorch.examples.llm_pte_finetuning" = "examples/llm_pte_finetuning"
 "executorch.examples.models" = "examples/models"
 "executorch.exir" = "exir"
 "executorch.extension" = "extension"


### PR DESCRIPTION
Summary: Fixes the module import error on `import executorch.examples.llm_pte_finetuning`

Differential Revision: D71001041


