### PR TITLE
cover //kernels/prim_ops/... in unittest-buck

### DIFF
--- a/.ci/scripts/unittest-buck2.sh
+++ b/.ci/scripts/unittest-buck2.sh
@@ -19,8 +19,11 @@ buck2 query "//backends/apple/... + //backends/example/... + \
 
 UNBUILDABLE_OPTIMIZED_OPS_REGEX="gelu|fft_r2c|log_softmax"
 BUILDABLE_OPTIMIZED_OPS=$(buck2 query //kernels/optimized/cpu/... | grep -E -v $UNBUILDABLE_OPTIMIZED_OPS_REGEX)
+
+BUILDABLE_KERNELS_PRIM_OPS_TARGETS=$(buck2 query //kernels/prim_ops/... | grep -v prim_ops_test_py)
 # TODO: expand the covered scope of Buck targets.
 # //runtime/kernel/... is failing because //third-party:torchgen_files's shell script can't find python on PATH.
 # //runtime/test/... requires Python torch, which we don't have in our OSS buck setup.
-buck2 test $BUILDABLE_OPTIMIZED_OPS //kernels/portable/... //runtime/backend/... //runtime/core/... \
+buck2 test $BUILDABLE_OPTIMIZED_OPS //kernels/portable/... \
+      $BUILDABLE_KERNELS_PRIM_OPS_TARGETS //runtime/backend/... //runtime/core/... \
       //runtime/executor: //runtime/kernel/... //runtime/platform/...

--- a/kernels/prim_ops/test/TARGETS
+++ b/kernels/prim_ops/test/TARGETS
@@ -1,4 +1,4 @@
-load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 # Any targets that should be shared between fbcode and xplat must be defined in
 # targets.bzl. This file can contain fbcode-only targets.
@@ -17,7 +17,7 @@ python_unittest(
     ],
 )
 
-cpp_unittest(
+runtime.cxx_test(
     name = "prim_ops_test_cpp",
     srcs = [
         "prim_ops_test.cpp",
@@ -31,6 +31,6 @@ cpp_unittest(
         "//executorch/runtime/kernel:kernel_runtime_context",  # @manual
         "//executorch/runtime/kernel:operator_registry",
         "//executorch/runtime/platform:platform",
-        "//executorch/test/utils:utils_aten",
+        "//executorch/test/utils:utils",
     ],
 )


### PR DESCRIPTION
Everything but the Python test (which depends on //caffe2:torch) is fine.