### PR TITLE
Convert dataclasses mutable default values to use default_factory [2/12]

### DIFF
--- a/backends/qualcomm/serialization/qc_schema.py
+++ b/backends/qualcomm/serialization/qc_schema.py
@@ -8,7 +8,7 @@
 Please refer to executorch/backends/qualcomm/serialization/schema.fbs for the schema definitions
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum, unique
 
 
@@ -52,7 +52,7 @@ class QcomChipset(IntEnum):
 @dataclass
 class SocInfo:
     soc_model: QcomChipset = QcomChipset.UNKNOWN_SM
-    htp_info: HtpInfo = HtpInfo()
+    htp_info: HtpInfo = field(default_factory=HtpInfo)
 
 
 _soc_info_table = {


### PR DESCRIPTION
Summary:
By using [Devmate](https://fb.workplace.com/groups/1205375940786433/permalink/1312459706744722/), this codemod attempts to automatically convert mutable defaults to use `default_factory`.

> As of [Python 3.11](https://docs.python.org/3.11/whatsnew/3.11.html#dataclasses), dataclasses now only allow defaults that are hashable. Using mutable (non-hashable) default values under Python 3.11+ will cause a runtime error:
```
ValueError: mutable default <class 'problematic.ClassName'> for field <field> is not allowed: use default_factory
```

NOTE: The change is not semantically equivalent to before the change. Before, all dataclass instances with a mutable default value were sharing the same instance. This change results each dataclass instance using a new instance of the mutable value. It is likely that the before state was a latent bug, but it's still a behavior change!

NOTE: For questions or assistance regarding this codemod, please reach out via the [Python Upgrades and Rollout](https://fb.workplace.com/groups/pyupgrades) workplace group

All changes were generated by [Devmate](https://www.internalfb.com/devmate)

Devmate Benchmark Run ID: [2025-03-05-vicmont-python312-v18-promptv1-allexamples1](https://www.internalfb.com/intern/devai/devmate/search/?benchmark_run_id=2025-03-05-vicmont-python312-v18-promptv1-allexamples1)

Files to trajectory mapping: [P1747095547](https://www.internalfb.com/intern/phabricator/paste/markdown/P1747095547/)

Differential Revision: D70643265


