### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -234,7 +234,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
       runner: macos-m1-stable
-      python-version: '3.11'
+      python-version: "3.11"
       submodules: 'true'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |


### PR DESCRIPTION
CI is assigning Python 3.9 machines, but ET requires 3.10.
