### PR TITLE
Enable model based selective build on xplat

### DIFF
--- a/codegen/tools/targets.bzl
+++ b/codegen/tools/targets.bzl
@@ -28,6 +28,7 @@ def define_common_targets(is_fbcode = False):
         deps = [
             ":gen_oplist_lib",
         ],
+        preload_deps = [] if runtime.is_oss else ["//executorch/codegen/tools/fb:selective_build"],  # TODO(larryliu0820) :selective_build doesn't build in OSS yet
         package_style = "inplace",
         visibility = [
             "//executorch/...",

--- a/shim_et/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim_et/xplat/executorch/build/runtime_wrapper.bzl
@@ -193,7 +193,7 @@ def _patch_kwargs_common(kwargs):
     # Patch up references to "//executorch/..." in lists of build targets,
     # if necessary.
     use_static_deps = kwargs.pop("use_static_deps", False)
-    for dep_type in ("deps", "exported_deps", "visibility"):
+    for dep_type in ("deps", "exported_deps", "visibility", "preload_deps"):
         if kwargs.get(dep_type):
             # deps may contain select() elements, dicts that map names to lists
             # of targets. selects.apply() will run the provided function on all


### PR DESCRIPTION
Summary:
As titled. This is to be able to build things like:


```
 manifold_get(
        name = "asr_cpu_model",
        out = "asr.ff",
        api_key = "speech_pytorch_edge_models-key",
        artifact_path = "tree/resources/asr/speech_tuna_supernova_ondevice_en_us_fakequant_9647d4e983236f0769d804556f648380/1740444706624/asr.ff",
        bucket_name = "speech_pytorch_edge_models",
        sha1 = "4104089609f4d73f7c5d44d33f3a0e86636bd526",
        timeout_msec = 100000000,
        visibility = ["PUBLIC"],
    )

    # This should give you a list of operators that are being used in model.pte, along with dtype information.
    et_operator_library(
        name = "asr_model_ops",
        model = ":asr_cpu_model",
    )
```

In xplat.

Reviewed By: seayoung1112

Differential Revision: D71070646


