### PR TITLE
Modify minibench SDK

### DIFF
--- a/extension/benchmark/android/benchmark/app/build.gradle.kts
+++ b/extension/benchmark/android/benchmark/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
 
   defaultConfig {
     applicationId = "org.pytorch.minibench"
-    minSdk = 34
-    targetSdk = 34
+    minSdk = 28
+    targetSdk = 33
     versionCode = 1
     versionName = "1.0"
 


### PR DESCRIPTION

### Summary
Use old one. No need to use new API

### Test plan
CI
