### PR TITLE
Modifying permute op to support all tensor packing.

### DIFF
--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -522,9 +522,6 @@ def register_view_op(features: OpFeatures):
 @update_features(
     [
         # Shape Manipulation
-        exir_ops.edge.aten.squeeze_copy.dims,
-        exir_ops.edge.aten.unsqueeze_copy.default,
-        exir_ops.edge.aten.permute_copy.default,
         exir_ops.edge.aten.t_copy.default,
         # Indexing and lookup
         exir_ops.edge.aten.flip.default,
@@ -556,10 +553,15 @@ def register_ported_op(features: OpFeatures):
     return features
 
 
+# Ops ported from PyTorch Vulkan backend. These ops are in a separate registry becasue they support all packed dimensions
 @update_features(
     [
         # Indexing and lookup
         exir_ops.edge.aten.slice_copy.Tensor,
+        # Shape Manipulation
+        exir_ops.edge.aten.squeeze_copy.dims,
+        exir_ops.edge.aten.unsqueeze_copy.default,
+        exir_ops.edge.aten.permute_copy.default,
     ]
 )
 def register_ported_op_all_packed_dims(features: OpFeatures):

--- a/backends/vulkan/runtime/graph/ops/glsl/permute.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/permute.glsl
@@ -21,56 +21,61 @@ layout(set = 0, binding = 1) uniform PRECISION ${SAMPLER_T[NDIM][DTYPE]} image_i
 
 layout(push_constant) uniform PRECISION restrict Block {
   ivec4 out_limits;
-  ivec4 sizes;
+  ivec4 in_sizes;
   // output dims
   ivec4 out_ndims;
   // x = output channels aligned to 4, y = input channels aligned to 4
-  ivec2 ch_info;
+  ivec2 channel_info;
 };
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+layout(constant_id = 3) const int packed_dim = C_DIM;
 
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 
 void main() {
-  const u16vec3 pos = u16vec3(gl_GlobalInvocationID);
+  u16vec3 pos = u16vec3(gl_GlobalInvocationID);
 
   if (any(greaterThanEqual(pos, out_limits.xyz))) {
     return;
   }
 
-  const int out_channel_4up = int(ch_info.x);
-  const int in_channel_4up = int(ch_info.y);
-  const int out_batch = int(sizes[3]);
   VEC4_T outval = VEC4_T(0.0);
-  ivec4 v = ivec4(0); // holds b,c,h,w
 
-  v[out_ndims[2]] = pos.y;
-  v[out_ndims[3]] = pos.x;
+  // scale up output position's packed dim
+  pos[packed_dim] <<= 2;
 
-  const int dst_index = pos.z << 2;
-  int dst_out_index = dst_index / out_channel_4up;
-  int dst_out_lane = dst_index % out_channel_4up;
+  // index of packed dim in bchw format
+  const int in_packed_dim_bchw_index = 3 - packed_dim;
 
-  for (int j = 0; j < 4; ++j, ++dst_out_lane) {
-    if (dst_out_index >= out_batch) {
-      // out of range
+  for (int j = 0; j < 4; ++j, pos[packed_dim]++) {
+    ivec4 in_bchw_pos = ivec4(0); // holds b,c,h,w
+    // determine input position based on output position and permute map
+    // out_ndims is in BCHW format
+    in_bchw_pos[out_ndims[0]] = (pos.z / channel_info.x);
+    in_bchw_pos[out_ndims[1]] = (pos.z % channel_info.x);
+    in_bchw_pos[out_ndims[2]] = pos.y;
+    in_bchw_pos[out_ndims[3]] = pos.x;
+
+    if (any(greaterThanEqual(in_bchw_pos.wzyx, in_sizes.xyzw))) {
       break;
     }
 
-    if (dst_out_lane == out_channel_4up) {
-      dst_out_lane = 0;
-      dst_out_index++;
-    }
+    // input tensor's packed dim pos (in xyz format) corresponding to output tensor's pos (which is also in xyz format)
+    const int in_packed_dim_pos = in_bchw_pos[in_packed_dim_bchw_index];
 
-    v[out_ndims[0]] = dst_out_index;
-    v[out_ndims[1]] = dst_out_lane;
+    // calculate input position in y axis using batch and channel index which is in_bchw_pos.x and in_bchw_pos.y respectively
+    in_bchw_pos.y = in_bchw_pos.y + in_bchw_pos.x * channel_info.y;
 
-    int src_index = v[0] * in_channel_4up + v[1];
+    // scale down input tensor's packed dim pos to perform fetch
+    in_bchw_pos[in_packed_dim_bchw_index] >>= 2;
 
-    VEC4_T inval = VEC4_T(texelFetch(image_in, u16vec3(v[3], v[2], src_index >> 2), 0));
-    outval[j] = inval[src_index & 0x3];
+    // fetch input texel
+    VEC4_T inval = VEC4_T(texelFetch(image_in, u16vec3(in_bchw_pos.wzy), 0));
+    outval[j] = inval[in_packed_dim_pos & 0x3];
   }
+
+  pos[packed_dim] = uint16_t(gl_GlobalInvocationID[packed_dim]);
 
   imageStore(image_out, pos, outval);
 }

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import itertools
+
 from collections import namedtuple
 from typing import Callable
 
@@ -457,26 +459,20 @@ def get_select_int_inputs():
 
 @register_test_suite(["aten.permute.default", "aten.permute_copy.default"])
 def get_permute_inputs():
-    test_suite = VkTestSuite(
-        [
-            ((9, 2, 9, 4), [0, 1, 2, 3]),
-            ((9, 2, 9, 4), [0, 1, 3, 2]),
-            ((9, 2, 9, 4), [0, 2, 1, 3]),
-            ((9, 2, 9, 4), [0, 2, 3, 1]),
-            ((9, 2, 9, 4), [0, 3, 1, 2]),
-            ((9, 2, 9, 4), [0, 3, 2, 1]),
-            ((9, 2, 9, 4), [3, 0, 1, 2]),
-            ((9, 2, 9, 4), [3, 2, 0, 1]),
-            ((9, 2, 9, 4), [2, 3, 0, 1]),
-            ((9, 2, 9, 4), [2, 0, 3, 1]),
-            ((9, 2, 9), [2, 0, 1]),
-            ((9, 2, 9), [1, 2, 0]),
-            ((9, 2), [0, 1]),
-            ((9, 2), [1, 0]),
-        ]
-    )
+    batch_tests = [
+        ((9, 2, 5, 7), out_axis) for out_axis in itertools.permutations([0, 1, 2, 3])
+    ]
+    channel_tests = [
+        ((9, 2, 5), out_axis) for out_axis in itertools.permutations([0, 1, 2])
+    ]
+    wh_tests = [((9, 2), out_axis) for out_axis in itertools.permutations([0, 1])]
+    test_suite = VkTestSuite(batch_tests + channel_tests + wh_tests)
 
-    test_suite.layouts = ["utils::kChannelsPacked"]
+    test_suite.layouts = [
+        "utils::kWidthPacked",
+        "utils::kHeightPacked",
+        "utils::kChannelsPacked",
+    ]
     return test_suite
 
 


### PR DESCRIPTION
Summary:
This diff updates Executorch Vulkan backend's `permute` operation to support width, height and channel packed tensors.
It also updates the op_registry.py file to register the `permute` operation and adds a new test case to the cases.py file to test the operation.
Additionally, it updates the Permute.cpp file to check for the same packed dimension in the input and output tensors, and updates the cases.py file to include the utils::kWidthPacked, utils::kHeightPacked, and utils::kChannelsPacked layouts.

Reviewed By: SS-JIA

Differential Revision: D70587814


