### PR TITLE
Make oss Coreml Llama supports both list and tensor KV cache inputs

### DIFF
--- a/examples/apple/coreml/llama/utils.py
+++ b/examples/apple/coreml/llama/utils.py
@@ -21,11 +21,11 @@ class SplitLinearModule(torch.nn.Module):
         self.out_split_sizes = self._get_split_sizes(
             out_features, out_target_split_size, out_max_splits
         )
-        self.in_split_sizes = self._get_split_sizes(
-            in_features, in_target_split_size, in_max_splits
-        )
         print(
             f"Splitting out_features={out_features} into {len(self.out_split_sizes)} of size {self.out_split_sizes[0]}."
+        )
+        self.in_split_sizes = self._get_split_sizes(
+            in_features, in_target_split_size, in_max_splits
         )
         print(
             f"Splitting in_features={in_features} into {len(self.in_split_sizes)} of size {self.in_split_sizes[0]}."


### PR DESCRIPTION
Summary:
Make oss Coreml Llama supports both list and tensor KV cache inputs

- reorder input args sequence to match with other code
- Make optional static_seq_len for the input tokens/static_seq_len

Differential Revision: D71081340


