### PR TITLE
Fix missing buck dep for op_where

### DIFF
--- a/kernels/optimized/cpu/targets.bzl
+++ b/kernels/optimized/cpu/targets.bzl
@@ -99,6 +99,7 @@ _OPTIMIZED_ATEN_OPS = (
         name = "op_where",
         deps = [
             "//executorch/kernels/portable/cpu/util:elementwise_util",
+            "//executorch/runtime/kernel:thread_parallel_interface",
         ],
     ),
 )


### PR DESCRIPTION
It includes thread_parallel_interface.h, so it should have a corresponding Buck dep.