### PR TITLE
Adding dummy coreml backend to silence uquery failures

### DIFF
--- a/backends/apple/coreml/TARGETS
+++ b/backends/apple/coreml/TARGETS
@@ -5,6 +5,14 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
+# TODO: this is a placeholder to support internal fbcode build. We should add the coreml backend target properly.
+runtime.python_library(
+    name = "coreml",
+    visibility = [
+        "@EXECUTORCH_CLIENTS",
+    ],
+)
+
 runtime.python_library(
     name = "backend",
     srcs = glob([


### PR DESCRIPTION
Summary: This diff adds a dummy target in the coreml backend to prevent failures from uquery rules

Reviewed By: metascroy

Differential Revision: D70645217


