### PR TITLE
solve example_runner.sh compile error

### DIFF
--- a/examples/devtools/example_runner/example_runner.cpp
+++ b/examples/devtools/example_runner/example_runner.cpp
@@ -17,6 +17,7 @@
  * all fp32 tensors.
  */
 
+#include <array>
 #include <fstream>
 #include <memory>
 


### PR DESCRIPTION
Summary:
this update solves the issue mentioned in https://github.com/pytorch/executorch/issues/7078.
Great thanks BmanClark for proposing the issue as well as the fix!

Differential Revision: D71177698


