### PR TITLE
Use non-fatal input checks for view operator

### DIFF
--- a/kernels/prim_ops/et_view.cpp
+++ b/kernels/prim_ops/et_view.cpp
@@ -102,7 +102,7 @@ void et_view(KernelRuntimeContext& context, EValue** stack) {
           out,
           /*buffer=*/self.mutable_data_ptr(),
           /*buffer_size=*/out.nbytes()) == Error::Ok,
-      InvalidArgument,
+      Internal,
       ,
       "Failed to set data_ptr for out to self.");
 }

--- a/kernels/prim_ops/et_view.cpp
+++ b/kernels/prim_ops/et_view.cpp
@@ -88,7 +88,7 @@ void et_view(KernelRuntimeContext& context, EValue** stack) {
       resize_tensor(
           out, {expected_output_size, static_cast<size_t>(out.dim())}) ==
           Error::Ok,
-      InvalidArgument,
+      Internal,
       ,
       "Failed to resize output tensor.");
 

--- a/kernels/prim_ops/et_view.cpp
+++ b/kernels/prim_ops/et_view.cpp
@@ -72,28 +72,38 @@ void et_view(KernelRuntimeContext& context, EValue** stack) {
   auto size = (*stack[1]).toIntList();
   auto out = (*stack[2]).toTensor();
 
-  ET_CHECK(tensors_have_same_dtype(self, out));
+  ET_KERNEL_CHECK(
+      context, tensors_have_same_dtype(self, out), InvalidArgument, );
 
   // Compute output size
   SizesType expected_output_size[kTensorDimensionLimit];
-  ET_CHECK(get_view_target_size(self, size, out.dim(), expected_output_size));
+  ET_KERNEL_CHECK(
+      context,
+      get_view_target_size(self, size, out.dim(), expected_output_size),
+      InvalidArgument, );
 
   // Resize for dynamic shape
-  ET_CHECK_MSG(
+  ET_KERNEL_CHECK_MSG(
+      context,
       resize_tensor(
           out, {expected_output_size, static_cast<size_t>(out.dim())}) ==
           Error::Ok,
+      InvalidArgument,
+      ,
       "Failed to resize output tensor.");
 
   // Do some checks
-  ET_CHECK(self.numel() == out.numel());
+  ET_KERNEL_CHECK(context, self.numel() == out.numel(), InvalidArgument, );
 
   // Update data ptr
-  ET_CHECK_MSG(
+  ET_KERNEL_CHECK_MSG(
+      context,
       internal::set_tensor_data(
           out,
           /*buffer=*/self.mutable_data_ptr(),
           /*buffer_size=*/out.nbytes()) == Error::Ok,
+      InvalidArgument,
+      ,
       "Failed to set data_ptr for out to self.");
 }
 

--- a/kernels/prim_ops/test/TARGETS
+++ b/kernels/prim_ops/test/TARGETS
@@ -24,6 +24,7 @@ runtime.cxx_test(
     ],
     deps = [
         "//executorch/kernels/prim_ops:prim_ops_registry",  # @manual
+        "//executorch/kernels/test:test_util",  # @manual
         "//executorch/runtime/core:evalue",  # @manual
         "//executorch/runtime/core/exec_aten:lib",  # @manual
         "//executorch/runtime/core/exec_aten/testing_util:tensor_util",  # @manual


### PR DESCRIPTION
### Summary
Fixes #9130

Use non-fatal input checks for view operator, just like https://github.com/pytorch/executorch/pull/2115/files, since there are existing cases that an internal app crashed due to a check failure.

Test is updated as well for `RegisterPrimOpsTest`.

### Test plan
Pass updated test:
```
mkdir cmake-out && cd cmake-out && cmake -DEXECUTORCH_BUILD_TESTS=ON .. && cmake --build . --target kernels_prim_ops_test -j9 && ctest -R kernels_prim_ops_test
```

Pass existing CI/CD.

cc @GregoryComer 