### PR TITLE
Add null runtime check for XNNExecutor::prepare_args

### DIFF
--- a/backends/xnnpack/runtime/XNNExecutor.cpp
+++ b/backends/xnnpack/runtime/XNNExecutor.cpp
@@ -68,6 +68,11 @@ ET_NODISCARD Error XNNExecutor::initialize(
  * delegate->execute()
  */
 ET_NODISCARD Error XNNExecutor::prepare_args(EValue** args) {
+  ET_CHECK_OR_RETURN_ERROR(
+      runtime_ != nullptr,
+      Internal,
+      "XNNPACK Delegate did not compile correctly");
+
   // Create xnn_externals_value from evalue args
   xnn_status status;
   for (uint32_t i = 0; i < externals_.size(); ++i) {


### PR DESCRIPTION
### Summary
Fixes https://github.com/pytorch/executorch/issues/9131

In the event that an XNNPACK-delegated model is freed right when inference happens, `XNNExecutor::prepare_args` can crash accessing the runtime. Hence we need to check for null runtime for it, similar to what we are already doing for `XNNExecutor::forward`.

### Test plan
Pass all CI/CD.
