### PR TITLE
Arm backend: Fix output_folder not created issue in scripts

### DIFF
--- a/backends/arm/scripts/build_executorch_runner.sh
+++ b/backends/arm/scripts/build_executorch_runner.sh
@@ -78,6 +78,7 @@ source ${setup_path_script}
 pte_file=$(realpath ${pte_file})
 ethosu_tools_dir=$(realpath ${ethosu_tools_dir})
 ethos_u_root_dir="$ethosu_tools_dir/ethos-u"
+mkdir -p "${ethos_u_root_dir}"
 ethosu_tools_dir=$(realpath ${ethos_u_root_dir})
 
 et_build_dir=${et_build_root}/cmake-out
@@ -106,6 +107,7 @@ then
     fi
 fi
 
+mkdir -p "${output_folder}"
 output_folder=$(realpath ${output_folder})
 
 if [[ ${target} == *"ethos-u55"*  ]]; then
@@ -128,7 +130,6 @@ if [ "$build_with_etdump" = true ] ; then
 fi
 
 echo "Building with BundleIO/etdump/extra flags: ${build_bundleio_flags} ${build_with_etdump_flags} ${extra_build_flags}"
-mkdir -p "${output_folder}"
 
 cmake \
     -DCMAKE_BUILD_TYPE=${build_type}            \

--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -194,10 +194,9 @@ for i in "${!test_model[@]}"; do
         output_folder=${et_build_root}/${model_short_name}
     fi
 
+    mkdir -p ${output_folder}
     output_folder=$(realpath ${output_folder})
     pte_file="${output_folder}/${model_filename}"
-
-    mkdir -p ${output_folder}
 
     # Remove old pte files
     rm -f "${output_folder}/${model_filename}"


### PR DESCRIPTION
In files build_executorch_runner.sh and examples/arm/run.sh, realpath command is called on output_folder before checking whether the directory already exists. This will trigger the error like "realpath: ${output_folder}: No such file or directory."

Fix it by moving mkdir forward.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218