### PR TITLE
Add linter for LICENSE

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -343,3 +343,29 @@ init_command = [
     '--dry-run={{DRYRUN}}',
     '--requirement=requirements-lintrunner.txt',
 ]
+
+[[linter]]
+code = 'LICENSELINT'
+include_patterns = [
+    '**/*',
+]
+exclude_patterns = [
+    '**/fb/**',
+    '.lintrunner.toml',
+]
+command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'grep_linter',
+    '--pattern=Confidential and proprietary',
+    '--linter-name=LICENSELINT',
+    '--error-name=Wrong license',
+    """--error-description=\
+        Code contributed to ExecuTorch open source repo should have \
+        BSD-license header \
+    """,
+    '--',
+    '@{{PATHSFILE}}',
+]


### PR DESCRIPTION
We mistakenly include wrong headers to files. Let's catch them in lintrunner. 

Partially fixes https://github.com/pytorch/executorch/issues/8418


