### PR TITLE
Move ExecutorchRuntime to xplat

### DIFF
--- a/extension/apple/ExecutorchRuntime/ExecutorchRuntime/ExecutorchRuntime.swift
+++ b/extension/apple/ExecutorchRuntime/ExecutorchRuntime/ExecutorchRuntime.swift
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@_implementationOnly import ExecutorchRuntimeBridge
+@_implementationOnly import ExecutorchRuntimeValueSupport
+import Foundation
+import ModelRunnerDataKit
+
+public class ExecutorchRuntime: ModelRuntime {
+  private let engine: ExecutorchRuntimeEngine
+  public init(modelPath: String, modelMethodName: String) throws {
+    self.engine = try ExecutorchRuntimeEngine(modelPath: modelPath, modelMethodName: modelMethodName)
+  }
+  public func infer(input: [ModelRuntimeValue]) throws -> [ModelRuntimeValue] {
+    let modelInput = input.compactMap { $0.value as? ExecutorchRuntimeValue }
+    // Not all values were of type ExecutorchRuntimeValue
+    guard input.count == modelInput.count else {
+      throw ModelRuntimeError.unsupportedInputType
+    }
+    return try engine.infer(input: modelInput).compactMap { ModelRuntimeValue(innerValue: $0) }
+  }
+
+  public func getModelValueFactory() -> ModelRuntimeValueFactory {
+    return ExecutorchRuntimeValueSupport()
+  }
+  public func getModelTensorFactory() -> ModelRuntimeTensorValueFactory {
+    return ExecutorchRuntimeValueSupport()
+  }
+}

--- a/extension/apple/ExecutorchRuntime/ExecutorchRuntime/__tests__/ExecutorchRuntimeTests.swift
+++ b/extension/apple/ExecutorchRuntime/ExecutorchRuntime/__tests__/ExecutorchRuntimeTests.swift
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@testable import ExecutorchRuntime
+import ExecutorchRuntimeValueSupport
+import XCTest
+
+class ExecutorchRuntimeTests: XCTestCase {
+  func testRuntimeWithAddPTE() throws {
+    let bundle = Bundle(for: type(of: self))
+    let modelPath = try XCTUnwrap(bundle.path(forResource: "add", ofType: "pte"))
+    let runtime = try XCTUnwrap(ExecutorchRuntime(modelPath: modelPath, modelMethodName: "forward"))
+
+    let tensorInput = try XCTUnwrap(runtime.getModelTensorFactory().createFloatTensor(value: [2.0], shape: [1]))
+    let input = try runtime.getModelValueFactory().createTensor(value: tensorInput)
+
+    let output = try XCTUnwrap(runtime.infer(input: [input, input]))
+
+    let tensorOutput = try output.first?.tensorValue().floatRepresentation()
+    XCTAssertEqual(tensorOutput?.floatArray.count, 1)
+    XCTAssertEqual(tensorOutput?.shape.count, 1)
+    XCTAssertEqual(tensorOutput?.shape.first, 1)
+    XCTAssertEqual(tensorOutput?.floatArray.first, 4.0)
+  }
+}


### PR DESCRIPTION
Summary:
- Moving ExecutorchRuntime to xplat

These are the initial libraries to get ExecuTorch exposed to swift.

Differential Revision: D70826477


