### PR TITLE
Git ignore dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ cmake-android-out/
 cmake-ios-out/
 cmake-out*
 cmake-out-android/
+dist/
 ethos-u-scratch/
 executorch.egg-info
 pip-out/


### PR DESCRIPTION
### Summary
The default wheel gets built in `dist/`, so let's ignore it.

### Test plan

```bash
$ python setup.py bdist_wheel

# dist/ should not show up
$ git status
```

cc @larryliu0820 @lucylq