### PR TITLE
Add et_dump related API to module

### DIFF
--- a/extension/module/module.h
+++ b/extension/module/module.h
@@ -478,6 +478,11 @@ class Module {
     return event_tracer_.get();
   }
 
+  ET_NODISCARD
+  runtime::Span<uint8_t> debug_buffer() {
+    return runtime::Span<uint8_t>(debug_buffer_.data(), debug_buffer_.size());
+  }
+
  private:
   struct MethodHolder {
     std::vector<std::vector<uint8_t>> planned_buffers;
@@ -498,6 +503,7 @@ class Module {
   std::unique_ptr<runtime::EventTracer> event_tracer_;
   std::unique_ptr<runtime::DataLoader> data_map_loader_;
   std::unique_ptr<NamedDataMap> data_map_;
+  std::vector<uint8_t> debug_buffer_;
 
  protected:
   std::unordered_map<std::string, MethodHolder> methods_;


### PR DESCRIPTION
Summary: It is for reusing the exention/module in the module definition in pybindings https://github.com/pytorch/executorch/blob/1a918c779e16c0ee903a08b30c1c666d1efb2c57/extension/pybindings/pybindings.cpp#L172

Differential Revision: D71135352


