### PR TITLE
Simplify Android build script

### DIFF
--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -30,7 +30,7 @@ jobs:
 
         # Build LLM Demo for Android
         bash build/build_android_library.sh ${ARTIFACTS_DIR_NAME}
-        bash build/build_android_instrumentation.sh
+        bash build/build_android_instrumentation.sh ${ARTIFACTS_DIR_NAME}
 
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:

--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -33,6 +33,9 @@ jobs:
         bash build/build_android_library.sh ${ARTIFACTS_DIR_NAME}
         bash build/build_android_instrumentation.sh ${ARTIFACTS_DIR_NAME}
 
+        mkdir -p ${ARTIFACTS_DIR_NAME}/fp32-xnnpack-custom
+        bash ".ci/scripts/test_llama.sh" -model stories110M -build_tool cmake -dty pe fp16 -mode portable -upload ${ARTIFACTS_DIR_NAME}/fp32-xnnpack-custom
+
         mkdir -p examples/demo-apps/android/LlamaDemo/app/libs
         cp aar-out/executorch.aar examples/demo-apps/android/LlamaDemo/app/libs
         pushd examples/demo-apps/android/LlamaDemo

--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -29,15 +29,22 @@ jobs:
         export ARTIFACTS_DIR_NAME=artifacts-to-be-uploaded
 
         # Build LLM Demo for Android
+        export BUILD_AAR_DIR=aar-out
         bash build/build_android_library.sh ${ARTIFACTS_DIR_NAME}
         bash build/build_android_instrumentation.sh ${ARTIFACTS_DIR_NAME}
 
         mkdir -p examples/demo-apps/android/LlamaDemo/app/libs
-        cp ${BUILD_AAR_DIR}/executorch.aar examples/demo-apps/android/LlamaDemo/app/libs
+        cp aar-out/executorch.aar examples/demo-apps/android/LlamaDemo/app/libs
         pushd examples/demo-apps/android/LlamaDemo
         ANDROID_HOME="${ANDROID_SDK:-/opt/android/sdk}" ./gradlew build assembleAndroidTest
         popd
 
+        DEMO_APP_DIR="${ARTIFACTS_DIR_NAME}/llm_demo"
+        # The app directory is named using its build flavor as a suffix.
+        mkdir -p "${DEMO_APP_DIR}"
+        # Collect the app and its test suite
+        cp examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/debug/*.apk "${DEMO_APP_DIR}"
+        cp examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/androidTest/debug/*.apk "${DEMO_APP_DIR}"
 
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:

--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -32,6 +32,13 @@ jobs:
         bash build/build_android_library.sh ${ARTIFACTS_DIR_NAME}
         bash build/build_android_instrumentation.sh ${ARTIFACTS_DIR_NAME}
 
+        mkdir -p examples/demo-apps/android/LlamaDemo/app/libs
+        cp ${BUILD_AAR_DIR}/executorch.aar examples/demo-apps/android/LlamaDemo/app/libs
+        pushd examples/demo-apps/android/LlamaDemo
+        ANDROID_HOME="${ANDROID_SDK:-/opt/android/sdk}" ./gradlew build assembleAndroidTest
+        popd
+
+
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
     needs: build-llm-demo

--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -34,7 +34,7 @@ jobs:
         bash build/build_android_instrumentation.sh ${ARTIFACTS_DIR_NAME}
 
         mkdir -p ${ARTIFACTS_DIR_NAME}/fp32-xnnpack-custom
-        bash ".ci/scripts/test_llama.sh" -model stories110M -build_tool cmake -dty pe fp16 -mode portable -upload ${ARTIFACTS_DIR_NAME}/fp32-xnnpack-custom
+        bash ".ci/scripts/test_llama.sh" -model stories110M -build_tool cmake -dtype fp16 -mode portable -upload ${ARTIFACTS_DIR_NAME}/fp32-xnnpack-custom
 
         mkdir -p examples/demo-apps/android/LlamaDemo/app/libs
         cp aar-out/executorch.aar examples/demo-apps/android/LlamaDemo/app/libs

--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -374,14 +374,6 @@ jobs:
         cp extension/benchmark/android/benchmark/app/build/outputs/apk/debug/*.apk "${MINIBENCH_APP_DIR}"
         cp extension/benchmark/android/benchmark/app/build/outputs/apk/androidTest/debug/*.apk "${MINIBENCH_APP_DIR}"
 
-        DEMO_APP_DIR="${ARTIFACTS_DIR_NAME}/llm_demo"
-        # The app directory is named using its build flavor as a suffix.
-        mkdir -p "${DEMO_APP_DIR}"
-        # Collect the app and its test suite
-        cp examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/debug/*.apk "${DEMO_APP_DIR}"
-        cp examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/androidTest/debug/*.apk "${DEMO_APP_DIR}"
-
-
   # Let's see how expensive this job is, we might want to tone it down by running it periodically
   benchmark-on-device:
     if: always()

--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -362,8 +362,25 @@ jobs:
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-qnn-deps.sh
         PYTHON_EXECUTABLE=python bash .ci/scripts/build-qnn-sdk.sh
 
-        export ANDROID_ABIS="arm64-v8a"
-        PYTHON_EXECUTABLE=python EXECUTORCH_BUILD_QNN=ON QNN_SDK_ROOT=/tmp/qnn/2.28.0.241029 bash build/build_android_library.sh ${ARTIFACTS_DIR_NAME}
+        mkdir -p aar-out
+        PYTHON_EXECUTABLE=python ANDROID_ABIS="arm64-v8a" BUILD_AAR_DIR=aar-out EXECUTORCH_BUILD_QNN=ON QNN_SDK_ROOT=/tmp/qnn/2.28.0.241029 bash build/build_android_library.sh
+        mkdir -p extension/benchmark/android/benchmark/app/libs
+        cp aar-out/executorch.aar extension/benchmark/android/benchmark/app/libs
+        pushd extension/benchmark/android/benchmark
+        ANDROID_HOME="${ANDROID_SDK:-/opt/android/sdk}" ./gradlew build assembleAndroidTest
+        popd
+        MINIBENCH_APP_DIR="${ARTIFACTS_DIR_NAME}/minibench"
+        mkdir -p "${MINIBENCH_APP_DIR}"
+        cp extension/benchmark/android/benchmark/app/build/outputs/apk/debug/*.apk "${MINIBENCH_APP_DIR}"
+        cp extension/benchmark/android/benchmark/app/build/outputs/apk/androidTest/debug/*.apk "${MINIBENCH_APP_DIR}"
+
+        DEMO_APP_DIR="${ARTIFACTS_DIR_NAME}/llm_demo"
+        # The app directory is named using its build flavor as a suffix.
+        mkdir -p "${DEMO_APP_DIR}"
+        # Collect the app and its test suite
+        cp examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/debug/*.apk "${DEMO_APP_DIR}"
+        cp examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/androidTest/debug/*.apk "${DEMO_APP_DIR}"
+
 
   # Let's see how expensive this job is, we might want to tone it down by running it periodically
   benchmark-on-device:

--- a/.github/workflows/android-release-artifacts.yml
+++ b/.github/workflows/android-release-artifacts.yml
@@ -52,8 +52,11 @@ jobs:
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh --build-tool buck2
         export ARTIFACTS_DIR_NAME=artifacts-to-be-uploaded
 
-        # Build LLM Demo for Android
-        bash build/build_android_library.sh ${ARTIFACTS_DIR_NAME}
+        # Build AAR Package
+        mkdir aar-out
+        export BUILD_AAR_DIR=aar-out
+        bash build/build_android_library.sh
+        cp aar-out/executorch.aar "${ARTIFACTS_DIR_NAME}/llm_demo/executorch.aar"
 
         shasum -a 256 "${ARTIFACTS_DIR_NAME}/llm_demo/executorch.aar"
 

--- a/.github/workflows/android-release-artifacts.yml
+++ b/.github/workflows/android-release-artifacts.yml
@@ -56,6 +56,7 @@ jobs:
         mkdir aar-out
         export BUILD_AAR_DIR=aar-out
         bash build/build_android_library.sh
+        mkdir -p "${ARTIFACTS_DIR_NAME}/llm_demo"
         cp aar-out/executorch.aar "${ARTIFACTS_DIR_NAME}/llm_demo/executorch.aar"
 
         shasum -a 256 "${ARTIFACTS_DIR_NAME}/llm_demo/executorch.aar"

--- a/build/build_android_library.sh
+++ b/build/build_android_library.sh
@@ -137,37 +137,6 @@ build_aar() {
   popd
 }
 
-build_android_demo_apps() {
-  mkdir -p examples/demo-apps/android/LlamaDemo/app/libs
-  cp ${BUILD_AAR_DIR}/executorch.aar examples/demo-apps/android/LlamaDemo/app/libs
-  pushd examples/demo-apps/android/LlamaDemo
-  ANDROID_HOME="${ANDROID_SDK:-/opt/android/sdk}" ./gradlew build assembleAndroidTest
-  popd
-
-  mkdir -p extension/benchmark/android/benchmark/app/libs
-  cp ${BUILD_AAR_DIR}/executorch.aar extension/benchmark/android/benchmark/app/libs
-  pushd extension/benchmark/android/benchmark
-  ANDROID_HOME="${ANDROID_SDK:-/opt/android/sdk}" ./gradlew build assembleAndroidTest
-  popd
-}
-
-collect_artifacts_to_be_uploaded() {
-  ARTIFACTS_DIR_NAME="$1"
-  DEMO_APP_DIR="${ARTIFACTS_DIR_NAME}/llm_demo"
-  # The app directory is named using its build flavor as a suffix.
-  mkdir -p "${DEMO_APP_DIR}"
-  # Collect the app and its test suite
-  cp examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/debug/*.apk "${DEMO_APP_DIR}"
-  cp examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/androidTest/debug/*.apk "${DEMO_APP_DIR}"
-  # Collect AAR
-  cp "${BUILD_AAR_DIR}/executorch.aar" "${DEMO_APP_DIR}"
-  # Collect MiniBench APK
-  MINIBENCH_APP_DIR="${ARTIFACTS_DIR_NAME}/minibench"
-  mkdir -p "${MINIBENCH_APP_DIR}"
-  cp extension/benchmark/android/benchmark/app/build/outputs/apk/debug/*.apk "${MINIBENCH_APP_DIR}"
-  cp extension/benchmark/android/benchmark/app/build/outputs/apk/androidTest/debug/*.apk "${MINIBENCH_APP_DIR}"
-}
-
 main() {
   if [[ -z "${BUILD_AAR_DIR:-}" ]]; then
     BUILD_AAR_DIR="$(mktemp -d)"
@@ -185,10 +154,6 @@ main() {
     build_android_native_library ${ANDROID_ABI}
   done
   build_aar
-  # build_android_demo_apps
-  # if [ -n "$ARTIFACTS_DIR_NAME" ]; then
-    # collect_artifacts_to_be_uploaded ${ARTIFACTS_DIR_NAME}
-  # fi
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/build/build_android_library.sh
+++ b/build/build_android_library.sh
@@ -159,9 +159,8 @@ collect_artifacts_to_be_uploaded() {
   # Collect the app and its test suite
   cp examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/debug/*.apk "${DEMO_APP_DIR}"
   cp examples/demo-apps/android/LlamaDemo/app/build/outputs/apk/androidTest/debug/*.apk "${DEMO_APP_DIR}"
-  # Collect JAR and AAR
-  cp extension/android/build/libs/executorch.jar "${DEMO_APP_DIR}"
-  find "${BUILD_AAR_DIR}/" -name 'executorch*.aar' -exec cp {} "${DEMO_APP_DIR}" \;
+  # Collect AAR
+  cp "${BUILD_AAR_DIR}/executorch.aar" "${DEMO_APP_DIR}"
   # Collect MiniBench APK
   MINIBENCH_APP_DIR="${ARTIFACTS_DIR_NAME}/minibench"
   mkdir -p "${MINIBENCH_APP_DIR}"
@@ -186,10 +185,10 @@ main() {
     build_android_native_library ${ANDROID_ABI}
   done
   build_aar
-  build_android_demo_apps
-  if [ -n "$ARTIFACTS_DIR_NAME" ]; then
-    collect_artifacts_to_be_uploaded ${ARTIFACTS_DIR_NAME}
-  fi
+  # build_android_demo_apps
+  # if [ -n "$ARTIFACTS_DIR_NAME" ]; then
+    # collect_artifacts_to_be_uploaded ${ARTIFACTS_DIR_NAME}
+  # fi
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/examples/demo-apps/android/LlamaDemo/setup-with-qnn.sh
+++ b/examples/demo-apps/android/LlamaDemo/setup-with-qnn.sh
@@ -13,13 +13,7 @@ if [ -z "$QNN_SDK_ROOT" ]; then
 fi
 
 BASEDIR=$(dirname "$0")
-source "$BASEDIR"/../../../../build/build_android_library.sh
+ANDROID_ABIS="arm64-v8a" bash "$BASEDIR"/setup.sh
 
 BUILD_AAR_DIR="$(mktemp -d)"
 export BUILD_AAR_DIR
-
-build_jar
-build_android_native_library "arm64-v8a"
-build_aar
-mkdir -p "$BASEDIR"/app/libs
-cp "$BUILD_AAR_DIR/executorch.aar" "$BASEDIR"/app/libs/executorch.aar

--- a/examples/demo-apps/android/LlamaDemo/setup.sh
+++ b/examples/demo-apps/android/LlamaDemo/setup.sh
@@ -7,15 +7,11 @@
 
 set -eu
 
-BASEDIR=$(dirname "$0")
-source "$BASEDIR"/../../../../build/build_android_library.sh
-
 BUILD_AAR_DIR="$(mktemp -d)"
 export BUILD_AAR_DIR
 
-build_jar
-build_android_native_library "arm64-v8a"
-build_android_native_library "x86_64"
-build_aar
+BASEDIR=$(dirname "$0")
 mkdir -p "$BASEDIR"/app/libs
+bash "$BASEDIR"/../../../../build/build_android_library.sh
+
 cp "$BUILD_AAR_DIR/executorch.aar" "$BASEDIR"/app/libs/executorch.aar

--- a/extension/android_test/setup.sh
+++ b/extension/android_test/setup.sh
@@ -56,7 +56,7 @@ build_native_library "arm64-v8a"
 build_native_library "x86_64"
 build_aar
 bash examples/models/llama/install_requirements.sh
-source ".ci/scripts/test_llama.sh" -model stories110M -build_tool cmake -dty pe fp16 -mode portable -upload ${BUILD_AAR_DIR}
+source ".ci/scripts/test_llama.sh" -model stories110M -build_tool cmake -dtype fp16 -mode portable -upload ${BUILD_AAR_DIR}
 popd
 mkdir -p "$BASEDIR"/src/libs
 cp "$BUILD_AAR_DIR/executorch.aar" "$BASEDIR"/src/libs/executorch.aar

--- a/extension/android_test/setup.sh
+++ b/extension/android_test/setup.sh
@@ -56,15 +56,10 @@ build_native_library "arm64-v8a"
 build_native_library "x86_64"
 build_aar
 bash examples/models/llama/install_requirements.sh
-source ".ci/scripts/test_llama.sh" -model stories110M -build_tool cmake -dtype fp16 -mode portable -upload ${BUILD_AAR_DIR}
+source ".ci/scripts/test_llama.sh" -model stories110M -build_tool cmake -dty pe fp16 -mode portable -upload ${BUILD_AAR_DIR}
 popd
 mkdir -p "$BASEDIR"/src/libs
 cp "$BUILD_AAR_DIR/executorch.aar" "$BASEDIR"/src/libs/executorch.aar
 python add_model.py
 mv "add.pte" "$BASEDIR"/src/androidTest/resources/add.pte
 unzip -o "$BUILD_AAR_DIR"/model.zip -d "$BASEDIR"/src/androidTest/resources
-
-if [ -n "$ARTIFACTS_DIR_NAME" ]; then
-  mkdir -p ${ARTIFACTS_DIR_NAME}/fp32-xnnpack-custom/
-  cp "$BUILD_AAR_DIR"/model.zip ${ARTIFACTS_DIR_NAME}/fp32-xnnpack-custom/model.zip
-fi

--- a/extension/android_test/setup.sh
+++ b/extension/android_test/setup.sh
@@ -63,3 +63,8 @@ cp "$BUILD_AAR_DIR/executorch.aar" "$BASEDIR"/src/libs/executorch.aar
 python add_model.py
 mv "add.pte" "$BASEDIR"/src/androidTest/resources/add.pte
 unzip -o "$BUILD_AAR_DIR"/model.zip -d "$BASEDIR"/src/androidTest/resources
+
+if [ -n "$ARTIFACTS_DIR_NAME" ]; then
+  mkdir -p ${ARTIFACTS_DIR_NAME}/fp32-xnnpack-custom/
+  cp "$BUILD_AAR_DIR"/model.zip ${ARTIFACTS_DIR_NAME}/fp32-xnnpack-custom/model.zip
+fi


### PR DESCRIPTION
Don't build these bundled apps (benchmark and llm demo) from build_android_library.sh. That's for library build only. We can make release artifact about 10 minutes faster. We also have better local build experience.

Also fix the CI

