### PR TITLE
fix reduce_util.h ATen mode build

### DIFF
--- a/kernels/portable/cpu/util/reduce_util.h
+++ b/kernels/portable/cpu/util/reduce_util.h
@@ -843,7 +843,7 @@ template <typename Func>
 template <typename Func>
 [[nodiscard]] bool parallel_for_each_reduce_over_dim_list_output_index(
     const Tensor& in,
-    optional<ArrayRef<int64_t>> dim_list,
+    executorch::aten::optional<ArrayRef<int64_t>> dim_list,
     const Tensor& out,
     const Func& func) {
 #ifdef ET_UE_THREADPOOL


### PR DESCRIPTION
This line is in namespace torch::executor, and torch::executor::optional exists in regular mode but not ATen mode. whoops.