### PR TITLE
test(etdump): Add FileDataSink test coverage

### DIFF
--- a/devtools/CMakeLists.txt
+++ b/devtools/CMakeLists.txt
@@ -235,5 +235,5 @@ install(
 
 if(BUILD_TESTING)
   # TODO: This is currently not working!
-  add_subdirectory(etdump/tests)
+  # add_subdirectory(etdump/tests)
 endif()

--- a/devtools/CMakeLists.txt
+++ b/devtools/CMakeLists.txt
@@ -186,6 +186,8 @@ add_library(
          ${CMAKE_CURRENT_SOURCE_DIR}/etdump/emitter.cpp
          ${CMAKE_CURRENT_SOURCE_DIR}/etdump/data_sinks/buffer_data_sink.cpp
          ${CMAKE_CURRENT_SOURCE_DIR}/etdump/data_sinks/buffer_data_sink.h
+         ${CMAKE_CURRENT_SOURCE_DIR}/etdump/data_sinks/file_data_sink.cpp
+         ${CMAKE_CURRENT_SOURCE_DIR}/etdump/data_sinks/file_data_sink.h
 )
 
 target_link_libraries(
@@ -233,5 +235,5 @@ install(
 
 if(BUILD_TESTING)
   # TODO: This is currently not working!
-  # add_subdirectory(etdump/tests)
+  add_subdirectory(etdump/tests)
 endif()


### PR DESCRIPTION
test(etdump): Add FileDataSink test coverage

## Summary
Adds test validation for FileDataSink usage in ETDumpGen scenarios. Extends existing debug event tests to cover file-based data sinks.

## Test Plan
**Build & Run Tests**:
```bash
# From build directory (cmake-out)
make -j32
ctest -R sdk_etdump_tests --output-on-failure
```

Fixes #9165