### PR TITLE
don't copy input std::function in thread_parallel

### DIFF
--- a/extension/threadpool/thread_parallel.cpp
+++ b/extension/threadpool/thread_parallel.cpp
@@ -65,7 +65,7 @@ bool parallel_for(
   std::tie(num_tasks, chunk_size) =
       calc_num_tasks_and_chunk_size(begin, end, grain_size);
 
-  auto task = [f, begin, end, chunk_size](size_t task_id) {
+  auto task = [&f, begin, end, chunk_size](size_t task_id) {
     set_thread_num(task_id);
     int64_t local_start = begin + static_cast<int64_t>(task_id) * chunk_size;
     if (local_start < end) {


### PR DESCRIPTION
There doesn't seem to be any reason to copy this, and it's inefficient to do so.