### PR TITLE
raise reasonable error when verifing program w/o expected outputs

### DIFF
--- a/devtools/bundled_program/bundled_program.cpp
+++ b/devtools/bundled_program/bundled_program.cpp
@@ -361,6 +361,11 @@ ET_NODISCARD Error verify_method_outputs(
   auto bundled_expected_outputs =
       method_test.get()->test_cases()->Get(testset_idx)->expected_outputs();
 
+  if (bundled_expected_outputs->size() == 0) {
+    // No bundled expected outputs, so we can't verify the method outputs.
+    return Error::NotSupported;
+  }
+
   for (size_t output_idx = 0; output_idx < method.outputs_size();
        output_idx++) {
     auto bundled_expected_output =


### PR DESCRIPTION
Summary:
Currently we can not raise reasonable error when verifying program with bunded program w/o expected output. 

This update makes bp return reasonable error and et_runner print out human-readable error msg.

Differential Revision: D71361076


