### PR TITLE
Add config system to export_llama

### DIFF
--- a/.ci/scripts/tests/test_llama_config.py
+++ b/.ci/scripts/tests/test_llama_config.py
@@ -1,0 +1,197 @@
+import os
+import pytest
+from pathlib import Path
+from argparse import Namespace
+from examples.models.llama.config.loader import create_config, merge_configs
+from examples.models.llama.config.validation import ConfigValidationError
+
+def test_basic_config_validation():
+    """Test basic configuration validation."""
+    # Valid config
+    valid_config = {
+        "model": {
+            "name": "llama3",
+            "type": "LLAMA"
+        },
+        "architecture": {
+            "dim": 4096,
+            "n_layers": 32,
+            "n_heads": 32,
+            "vocab_size": 32000,
+            "multiple_of": 256,
+            "norm_eps": 1.0e-5
+        },
+        "limits": {
+            "max_batch_size": 32,
+            "max_seq_len": 2048,
+            "max_context_len": 2048
+        },
+        "export": {
+            "output_dir": "output"
+        }
+    }
+    
+    try:
+        create_config(cli_args=None, model_args=None, params_json_path=None)
+    except ConfigValidationError as e:
+        assert "Missing required 'model' section" in str(e)
+    
+    # Test invalid model name
+    invalid_config = valid_config.copy()
+    invalid_config["model"]["name"] = "invalid_model"
+    with pytest.raises(ConfigValidationError) as exc:
+        create_config(config_dict=invalid_config)
+    assert "Invalid model name" in str(exc.value)
+    
+    # Test invalid architecture values
+    invalid_config = valid_config.copy()
+    invalid_config["architecture"]["dim"] = -1
+    with pytest.raises(ConfigValidationError) as exc:
+        create_config(config_dict=invalid_config)
+    assert "architecture.dim must be a positive integer" in str(exc.value)
+
+def test_config_merging():
+    """Test configuration merging logic."""
+    base_config = {
+        "model": {
+            "name": "llama3",
+            "type": "LLAMA"
+        },
+        "architecture": {
+            "dim": 4096,
+            "n_layers": 32
+        }
+    }
+    
+    override_config = {
+        "architecture": {
+            "dim": 2048,
+            "n_heads": 16
+        }
+    }
+    
+    merged = merge_configs(base_config, override_config)
+    assert merged["architecture"]["dim"] == 2048  # Override wins
+    assert merged["architecture"]["n_layers"] == 32  # Base preserved
+    assert merged["architecture"]["n_heads"] == 16  # New value added
+
+def test_cli_override():
+    """Test CLI argument overrides."""
+    base_config = {
+        "model": {
+            "name": "llama3",
+            "type": "LLAMA"
+        },
+        "quantization": {
+            "pt2e_quantize": "xnnpack_dynamic"
+        }
+    }
+    
+    cli_args = Namespace(
+        pt2e_quantize="xnnpack_dynamic_qc4",
+        config=None
+    )
+    
+    config = create_config(config_dict=base_config, cli_args=cli_args)
+    assert config["quantization"]["pt2e_quantize"] == "xnnpack_dynamic_qc4"
+
+def test_backend_compatibility():
+    """Test backend compatibility validations."""
+    config = {
+        "model": {
+            "name": "llama3",
+            "type": "LLAMA"
+        },
+        "architecture": {
+            "dim": 4096,
+            "n_layers": 32,
+            "n_heads": 32
+        },
+        "limits": {
+            "max_batch_size": 32,
+            "max_seq_len": 2048,
+            "max_context_len": 2048
+        },
+        "export": {
+            "output_dir": "output",
+            "enable_dynamic_shape": True
+        },
+        "kv_cache": {
+            "enabled": True
+        },
+        "backends": {
+            "coreml": {
+                "enabled": True
+            }
+        }
+    }
+    
+    # Should raise error due to dynamic shape + CoreML + KV cache incompatibility
+    with pytest.raises(ConfigValidationError) as exc:
+        create_config(config_dict=config)
+    assert "Dynamic shape is not supported with CoreML" in str(exc.value)
+
+def test_quantization_validation():
+    """Test quantization configuration validation."""
+    config = {
+        "model": {
+            "name": "llama3",
+            "type": "LLAMA"
+        },
+        "architecture": {
+            "dim": 4096,
+            "n_layers": 32,
+            "n_heads": 32
+        },
+        "limits": {
+            "max_batch_size": 32,
+            "max_seq_len": 2048,
+            "max_context_len": 2048
+        },
+        "export": {
+            "output_dir": "output"
+        },
+        "quantization": {
+            "pt2e_quantize": "invalid_quantizer",
+            "embedding_quantize": "invalid_format"
+        }
+    }
+    
+    # Test invalid quantizer
+    with pytest.raises(ConfigValidationError) as exc:
+        create_config(config_dict=config)
+    assert "quantization.pt2e_quantize must be one of" in str(exc.value)
+    
+    # Test invalid embedding quantization format
+    config["quantization"]["pt2e_quantize"] = "xnnpack_dynamic"
+    with pytest.raises(ConfigValidationError) as exc:
+        create_config(config_dict=config)
+    assert "quantization.embedding_quantize must be in format" in str(exc.value)
+
+def test_path_validation():
+    """Test path validation in configuration."""
+    config = {
+        "model": {
+            "name": "llama3",
+            "type": "LLAMA"
+        },
+        "architecture": {
+            "dim": 4096,
+            "n_layers": 32,
+            "n_heads": 32
+        },
+        "limits": {
+            "max_batch_size": 32,
+            "max_seq_len": 2048,
+            "max_context_len": 2048
+        },
+        "export": {
+            "output_dir": "output",
+            "checkpoint": 123,  # Should be string
+            "checkpoint_dir": True  # Should be string
+        }
+    }
+    
+    with pytest.raises(ConfigValidationError) as exc:
+        create_config(config_dict=config)
+    assert "checkpoint must be a string path" in str(exc.value) 

--- a/examples/models/llama/config/default.yaml
+++ b/examples/models/llama/config/default.yaml
@@ -1,0 +1,131 @@
+# Model Identification and Type
+model:
+  name: "llama3"  # From --model default, choices: stories110m, llama2, llama3, llama3_1, llama3_2, etc.
+  type: "LLAMA"  # From --fairseq2 default (false), choices: LLAMA or FAIRSEQ2
+
+# Core Model Architecture
+architecture:
+  dim: 4096
+  n_layers: 32
+  n_heads: 32
+  n_kv_heads: null  # defaults to n_heads if not specified
+  vocab_size: -1  # defined later by tokenizer
+  hidden_dim: null  # calculated if not specified
+  head_dim: null  # calculated as dim/n_heads if not specified
+  multiple_of: 256  # make SwiGLU hidden layer size multiple of large power of 2
+  ffn_dim_multiplier: null
+  norm_eps: 1.0e-5
+
+# Sequence and Batch Settings
+limits:
+  max_batch_size: 32
+  max_seq_len: 128  # From --max_seq_length default, maximum length sequence to evaluate
+  max_context_len: 128  # From --max_context_length default, maximum length of context for model to remember
+
+# Attention Configuration
+attention:
+  type: "mha"  # Attention type, registered in attention.py
+  qkv_bias: false
+  use_qk_norm: false
+
+# RoPE (Rotary Position Embedding) Settings
+rope:
+  use_hf_rope: false  # From --use_hf_rope default, Use HuggingFace's RoPE implementation
+  theta: null  # overrides freq_base if set
+  freq_base: 10000.0
+  use_scaled_rope: false  # From --use_scaled_rope default
+  scale_factor: 8  # From --rope_scale_factor default
+  expand_rope_table: false  # From --expand_rope_table default, [Temp workaround] Expand sin/cos table in head dim to take vectorized path in optimized kernels
+
+# Mixture of Experts Configuration
+moe:
+  enabled: false  # From --moe default
+  num_experts: 8
+  num_activated_experts: 2
+
+# KV Cache Settings
+kv_cache:
+  enabled: false  # From --use_kv_cache default, Whether or not to export a model using kv cache
+  quantize: false  # From --quantize_kv_cache default, Whether or not to export a model using int8 per token quantized kv cache
+  use_sdpa: false  # From --use_sdpa_with_kv_cache default, Whether to use sdpa_with_kv_cache update op when using kv cache
+
+# Token Pruning
+pruning:
+  input_map: null  # From --input_prune_map default, path to the input pruning token mapping file (token_map.json)
+  output_map: null  # From --output_prune_map default, path to the output pruning token mapping file (token_map.json)
+
+# Model Special Tokens
+special_tokens:
+  bos_idx: 1
+  eos_idx: 3
+  bos_count: -1  # i.e., a single EOS is used as BOS
+  eos_count: 2
+
+# Export Settings
+export:
+  output_dir: "."  # From --output-dir default, output directory
+  checkpoint: null
+  checkpoint_dir: null  # takes precedence over checkpoint if both set
+  tokenizer_path: null  # From --tokenizer_path default, Note: .model not .bin
+  output_name: null  # From --output_name default, Override output filename of the saved pte model file
+  enable_dynamic_shape: true  # From --enable_dynamic_shape default, Enable dynamic shape along seq dim. Used for faster prefill
+  generate_full_logits: false  # From --generate_full_logits default, Generate logits for all inputs
+  apply_embedding: true
+  apply_output: true
+  profile_memory: false  # From --profile_memory default, Generate chrome trace of activation memory for intermediate tensors
+  profile_path: null  # From --profile_path default, Use cProfile to profile model export
+  num_sharding: 0  # From --num_sharding default, Number of splits for fallback custom op
+  dtype_override: "fp32"  # From --dtype-override default, choices: fp32, fp16, bf16
+  export_only: false  # From --export_only default, If true, stops right after torch.export() and saves the exported model
+  generate_etrecord: false  # From --generate_etrecord default, Generate the ETRecord debug artifact
+  params: null  # From --params default, config.json file path
+
+# Quantization Settings
+quantization:
+  pt2e_quantize: null  # From --pt2e_quantize default, choices: xnnpack_dynamic, xnnpack_dynamic_qc4, qnn_8a8w, etc.
+  embedding_quantize: null  # From --embedding-quantize default, format: <bitwidth>,<groupsize>, e.g., 8,1024
+  quantization_mode: null  # From --quantization_mode default, type of quantization
+  group_size: null  # From --group_size default, group_size for weight quantization
+  use_qnn_sha: false  # From --use_qnn_sha default, Change multi head attention to multiple single head attention for QNN backend
+  use_spin_quant: null  # From --use_spin_quant default, choices: cuda, native, Use SpinQuant for better quantization performance
+  use_qat: false  # From --use_qat default, Whether the checkpoint is pre-quantized with QAT or not
+  preq_mode: null  # From --preq_mode default, choices: 8da4w, 8da4w_output_8da8w
+  preq_group_size: 32  # From --preq_group_size default, group_size for pre-quantized checkpoint weight quantization
+  preq_embedding_quantize: "8,0"  # From --preq_embedding_quantize default, type of embedding quantization for pre-quantized checkpoint
+
+# Calibration Settings
+calibration:
+  tasks: null  # From --calibration_tasks default, List of tasks for GPTQ calibration from lm_eval
+  limit: null  # From --calibration_limit default, Number of samples for calibration
+  seq_length: null  # From --calibration_seq_length default, Sequence length for calibration
+  data: "Once upon a time"  # From --calibration_data default, Calibration prompts from users
+
+# Backend Selection
+backends:
+  xnnpack:
+    enabled: false  # From --xnnpack default, Delegate to DQLinear ops to the xnnpack backend
+    extended_ops: false  # From --xnnpack-extended-ops default, Delegate more operators beyond DQLinear
+  vulkan:
+    enabled: false  # From --vulkan default
+  mps:
+    enabled: false  # From --mps default
+  coreml:
+    enabled: false  # From --coreml default
+    enable_state: false  # From --coreml-enable-state default, Supported for MacOS15+/iOS18+
+    preserve_sdpa: false  # From --coreml-preserve-sdpa default, Use coreml iOS18.sdpa op
+    ios_version: 15  # From --coreml-ios default, choices: 15, 16, 17, 18
+    compute_units: "cpu_only"  # From --coreml-compute-units default, choices: cpu_only, cpu_and_gpu, cpu_and_ne, all
+    quantize: null  # From --coreml-quantize default, choices: b4w, c4w
+  qnn:
+    enabled: false  # From --qnn default, Delegate llama2 to qnn backend (Qualcomm)
+    soc_model: "SM8650"  # From --soc_model default, SoC model of current device (e.g. SM8650 for Snapdragon 8 Gen 3)
+
+# Additional Settings
+misc:
+  verbose: false  # From --verbose default
+  fairseq2: false  # From --fairseq2 default
+  use_lora: 0  # From --use_lora default, Whether the checkpoint contains LoRA adaptors (0: no LoRA adaptors)
+  optimized_rotation_path: null  # From --optimized_rotation_path default, [QNN backend] Optimized rotation checkpoint path
+  metadata: null  # From --metadata default, metadata string in json format
+  so_library: null  # From --so_library default, shared library for quantized operators
+  use_attention_sink: null  # From --use_attention_sink default, format: <sink_size>,<window_size>,<batch_eviction_size>, e.g., 4,2044,1024 

--- a/examples/models/llama/config/examples/custom_model.yaml
+++ b/examples/models/llama/config/examples/custom_model.yaml
@@ -1,0 +1,55 @@
+# Example configuration for using a custom model
+model:
+  # Custom model configuration
+  custom_model: "mymodule.CustomLLM"  # Replace with your model's import path
+  custom_model_kwargs:
+    hidden_size: 768
+    num_layers: 12
+    num_attention_heads: 12
+    intermediate_size: 3072
+    max_position_embeddings: 512
+    vocab_size: 50257
+    layer_norm_eps: 1e-5
+    initializer_range: 0.02
+    use_cache: true
+
+# Export settings
+export:
+  output_dir: "exported_model"
+  checkpoint: null  # Not used with custom model
+  params: null  # Not used with custom model
+  tokenizer_path: "path/to/tokenizer"  # Update with your tokenizer path
+  use_kv_cache: true
+  use_sdpa_with_kv_cache: true
+  generate_full_logits: false
+  weight_type: "LLAMA"
+  enable_dynamic_shape: false
+
+# Sequence and batch settings
+sequence:
+  max_seq_len: 512
+  max_batch_size: 1
+  max_context_len: 512
+
+# RoPE settings
+rope:
+  scaling_factor: 1.0
+  traditional: false
+  dynamic: false
+
+# KV cache settings
+kv_cache:
+  enabled: true
+  block_size: 16
+  cache_dtype: "fp16"
+
+# Quantization settings
+quantization:
+  embedding_quantize: null
+  pt2e_quantize: null
+
+# Backend selection
+backend:
+  use_cuda: true
+  use_cpu: false
+  use_vulkan: false 

--- a/examples/models/llama/config/examples/stories.yaml
+++ b/examples/models/llama/config/examples/stories.yaml
@@ -1,0 +1,104 @@
+architecture:
+  dim: 768
+  ffn_dim_multiplier: null
+  head_dim: null
+  hidden_dim: null
+  multiple_of: 32
+  n_heads: 12
+  n_kv_heads: null
+  n_layers: 12
+  norm_eps: 1.0e-05
+  vocab_size: 32000
+attention:
+  qkv_bias: false
+  type: mha
+  use_qk_norm: false
+backends:
+  coreml:
+    compute_units: cpu_only
+    enable_state: false
+    enabled: false
+    ios_version: 15
+    preserve_sdpa: false
+    quantize: null
+  mps:
+    enabled: false
+  qnn:
+    enabled: false
+    soc_model: SM8650
+  vulkan:
+    enabled: false
+  xnnpack:
+    enabled: true
+    extended_ops: true
+calibration:
+  data: Once upon a time
+  limit: null
+  seq_length: null
+  tasks: null
+export:
+  apply_embedding: true
+  apply_output: true
+  checkpoint: stories110M.pt
+  checkpoint_dir: null
+  dtype_override: fp32
+  enable_dynamic_shape: true
+  export_only: false
+  generate_etrecord: false
+  generate_full_logits: false
+  num_sharding: 0
+  output_dir: tmp
+  output_name: tinyllama_xnnpack+custom_fp32_test.pte
+  params: params.json
+  profile_memory: false
+  profile_path: null
+  tokenizer_path: null
+kv_cache:
+  enabled: true
+  quantize: false
+  use_sdpa: true
+limits:
+  max_batch_size: 32
+  max_context_len: 128
+  max_seq_len: 128
+misc:
+  fairseq2: false
+  metadata: null
+  optimized_rotation_path: null
+  so_library: null
+  use_attention_sink: null
+  use_lora: 0
+  verbose: false
+model:
+  name: llama3
+  type: LLAMA
+moe:
+  enabled: false
+  num_activated_experts: 2
+  num_experts: 8
+pruning:
+  input_map: null
+  output_map: null
+quantization:
+  embedding_quantize: null
+  group_size: 128
+  preq_embedding_quantize: 8,0
+  preq_group_size: 32
+  preq_mode: null
+  pt2e_quantize: null
+  quantization_mode: 8da4w
+  use_qat: false
+  use_qnn_sha: false
+  use_spin_quant: null
+rope:
+  expand_rope_table: false
+  freq_base: 10000.0
+  scale_factor: 8
+  theta: null
+  use_hf_rope: false
+  use_scaled_rope: false
+special_tokens:
+  bos_count: -1
+  bos_idx: 1
+  eos_count: 2
+  eos_idx: 3

--- a/examples/models/llama/config/loader.py
+++ b/examples/models/llama/config/loader.py
@@ -1,0 +1,344 @@
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+import yaml
+from argparse import Namespace
+import sys
+
+from .validation import validate_config, ConfigValidationError
+
+def _flatten_dict(d: Dict[str, Any], parent_key: str = '', sep: str = '.') -> Dict[str, Any]:
+    """Flatten a nested dictionary using dot notation."""
+    items: list = []
+    for k, v in d.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.extend(_flatten_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)
+
+def _unflatten_dict(d: Dict[str, Any], sep: str = '.') -> Dict[str, Any]:
+    """Convert a flattened dictionary back to nested format."""
+    result: Dict[str, Any] = {}
+    for key, value in d.items():
+        parts = key.split(sep)
+        target = result
+        for part in parts[:-1]:
+            target = target.setdefault(part, {})
+        target[parts[-1]] = value
+    return result
+
+def _convert_cli_to_config_format(args: Namespace) -> Dict[str, Any]:
+    """Convert CLI arguments to config format."""
+    config = {}
+    
+    # Get only arguments that were explicitly set on command line
+    specified_args = {}
+    # _get_kwargs() returns list of (key, value) tuples for all arguments
+    for key, value in args._get_kwargs():
+        # Check if this argument was explicitly set on command line
+        if value is not None:
+            # Skip if it's False, assuming all bool args are with
+            # action="store_true"
+            if isinstance(value, bool) and value == False:
+                continue
+            specified_args[key] = value
+    
+    # Only set sections if they have specified values
+    model_config = {}
+    if 'model' in specified_args:
+        model_config['name'] = specified_args['model']
+    if 'fairseq2' in specified_args:
+        model_config['type'] = 'FAIRSEQ2' if specified_args['fairseq2'] else 'LLAMA'
+    if model_config:
+        config['model'] = model_config
+    
+    # Export settings
+    export_config = {}
+    export_mappings = {
+        'output_dir': 'output_dir',
+        'checkpoint': 'checkpoint',
+        'checkpoint_dir': 'checkpoint_dir',
+        'tokenizer_path': 'tokenizer_path',
+        'output_name': 'output_name',
+        'enable_dynamic_shape': 'enable_dynamic_shape',
+        'generate_full_logits': 'generate_full_logits',
+        'dtype_override': 'dtype_override',
+        'profile_memory': 'profile_memory',
+        'profile_path': 'profile_path',
+        'num_sharding': 'num_sharding',
+        'params': 'params'  # Add params to export settings
+    }
+    for config_key, arg_key in export_mappings.items():
+        if arg_key in specified_args:
+            export_config[config_key] = specified_args[arg_key]
+    if export_config:
+        config['export'] = export_config
+    
+    # KV Cache settings
+    kv_cache_config = {}
+    kv_cache_mappings = {
+        'enabled': 'use_kv_cache',
+        'quantize': 'quantize_kv_cache',
+        'use_sdpa': 'use_sdpa_with_kv_cache'
+    }
+    for config_key, arg_key in kv_cache_mappings.items():
+        if arg_key in specified_args:
+            kv_cache_config[config_key] = specified_args[arg_key]
+    if kv_cache_config:
+        config['kv_cache'] = kv_cache_config
+    
+    # Quantization settings
+    quant_config = {}
+    quant_mappings = {
+        'pt2e_quantize': 'pt2e_quantize',
+        'embedding_quantize': 'embedding_quantize',
+        'quantization_mode': 'quantization_mode',
+        'group_size': 'group_size',
+        'use_qnn_sha': 'use_qnn_sha'
+    }
+    for config_key, arg_key in quant_mappings.items():
+        if arg_key in specified_args:
+            quant_config[config_key] = specified_args[arg_key]
+    if quant_config:
+        config['quantization'] = quant_config
+    
+    # Backend settings
+    backend_config = {}
+    if 'xnnpack' in specified_args or 'xnnpack_extended_ops' in specified_args:
+        backend_config['xnnpack'] = {}
+        if 'xnnpack' in specified_args:
+            backend_config['xnnpack']['enabled'] = specified_args['xnnpack']
+        if 'xnnpack_extended_ops' in specified_args:
+            backend_config['xnnpack']['extended_ops'] = specified_args['xnnpack_extended_ops']
+    
+    if 'vulkan' in specified_args:
+        backend_config['vulkan'] = {'enabled': specified_args['vulkan']}
+    
+    if 'mps' in specified_args:
+        backend_config['mps'] = {'enabled': specified_args['mps']}
+    
+    if any(k in specified_args for k in ['coreml', 'coreml_enable_state', 'coreml_preserve_sdpa']):
+        backend_config['coreml'] = {}
+        if 'coreml' in specified_args:
+            backend_config['coreml']['enabled'] = specified_args['coreml']
+        if 'coreml_enable_state' in specified_args:
+            backend_config['coreml']['enable_state'] = specified_args['coreml_enable_state']
+        if 'coreml_preserve_sdpa' in specified_args:
+            backend_config['coreml']['preserve_sdpa'] = specified_args['coreml_preserve_sdpa']
+    
+    if backend_config:
+        config['backends'] = backend_config
+    
+    # Misc settings
+    misc_config = {}
+    misc_mappings = {
+        'verbose': 'verbose',
+        'fairseq2': 'fairseq2',
+        'optimized_rotation_path': 'optimized_rotation_path',
+        'metadata': 'metadata',
+        'so_library': 'so_library'
+    }
+    for config_key, arg_key in misc_mappings.items():
+        if arg_key in specified_args:
+            misc_config[config_key] = specified_args[arg_key]
+    if misc_config:
+        config['misc'] = misc_config
+    
+    return config
+
+def load_yaml_config(config_path: Union[str, Path]) -> Dict[str, Any]:
+    """Load configuration from YAML file."""
+    with open(config_path, 'r') as f:
+        return yaml.safe_load(f)
+
+def load_json_params(params_path: Union[str, Path]) -> Dict[str, Any]:
+    """Load model parameters from JSON file."""
+    with open(params_path, 'r') as f:
+        return json.load(f)
+
+def _convert_params_to_config_format(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert params.json format to our config structure."""
+    # Mapping from params.json keys to config keys
+    params_mapping = {
+        'dim': 'architecture.dim',
+        'n_layers': 'architecture.n_layers',
+        'n_heads': 'architecture.n_heads',
+        'n_kv_heads': 'architecture.n_kv_heads',
+        'vocab_size': 'architecture.vocab_size',
+        'hidden_dim': 'architecture.hidden_dim',
+        'head_dim': 'architecture.head_dim',
+        'multiple_of': 'architecture.multiple_of',
+        'ffn_dim_multiplier': 'architecture.ffn_dim_multiplier',
+        'norm_eps': 'architecture.norm_eps',
+        'max_batch_size': 'limits.max_batch_size',
+        'max_seq_len': 'limits.max_seq_len',
+        'max_context_len': 'limits.max_context_len',
+        'moe': 'moe.enabled',
+        'num_experts': 'moe.num_experts',
+        'num_activated_experts': 'moe.num_activated_experts',
+        'use_kv_cache': 'kv_cache.enabled',
+        'use_sdpa_with_kv_cache': 'kv_cache.use_sdpa',
+        'generate_full_logits': 'export.generate_full_logits',
+        'enable_dynamic_shape': 'export.enable_dynamic_shape',
+        'use_hf_rope': 'rope.use_hf_rope',
+        'rope_theta': 'rope.theta',
+        'rope_freq_base': 'rope.freq_base',
+        'use_scaled_rope': 'rope.use_scaled_rope',
+        'rope_scale_factor': 'rope.scale_factor',
+        'bos_idx': 'special_tokens.bos_idx',
+        'eos_idx': 'special_tokens.eos_idx',
+        'bos_count': 'special_tokens.bos_count',
+        'eos_count': 'special_tokens.eos_count',
+    }
+    
+    # Convert flattened params to nested config
+    mapped_dict = {}
+    for param_key, value in params.items():
+        config_key = params_mapping.get(param_key)
+        if config_key:
+            mapped_dict[config_key] = value
+        else:
+            # For any params not in our mapping, put them in a special section
+            mapped_dict[f'additional_params.{param_key}'] = value
+    
+    return _unflatten_dict(mapped_dict)
+
+def save_yaml_config(config: Dict[str, Any], config_path: Union[str, Path]) -> None:
+    with open(config_path, 'w') as f:
+        yaml.dump(config, f, default_flow_style=False, sort_keys=True)
+
+def merge_configs(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge two config dictionaries."""
+    merged = base.copy()
+    
+    for key, value in override.items():
+        if (
+            key in merged and 
+            isinstance(merged[key], dict) and 
+            isinstance(value, dict)
+        ):
+            merged[key] = merge_configs(merged[key], value)
+        elif value is not None:  # Only override if value is not None
+            merged[key] = value
+            
+    return merged
+
+def create_config(
+    yaml_path: Optional[Union[str, Path]] = None,
+    cli_args: Optional[Namespace] = None,
+    model_args: Optional[Any] = None,
+    params_json_path: Optional[Union[str, Path]] = None,
+) -> Dict[str, Any]:
+    """
+    Create configuration from multiple sources.
+    Priority (highest to lowest):
+    1. CLI arguments
+    2. params.json file (for model architecture)
+    3. YAML config file
+    4. Default values
+    """
+    # Start with default config
+    config = load_yaml_config(Path(__file__).parent / "default.yaml")
+    
+    # Load from YAML if provided
+    if yaml_path:
+        yaml_config = load_yaml_config(yaml_path)
+        config = merge_configs(config, yaml_config)
+    
+    # Load and apply params.json if provided
+    if params_json_path:
+        params = load_json_params(params_json_path)
+        params_config = _convert_params_to_config_format(params)
+        # Params override YAML config for architecture settings
+        config = merge_configs(config, params_config)
+    
+    # Override with ModelArgs if provided
+    if model_args:
+        model_config = {
+            "architecture": {
+                "dim": model_args.dim,
+                "n_layers": model_args.n_layers,
+                "n_heads": model_args.n_heads,
+                "n_kv_heads": model_args.n_kv_heads,
+                "vocab_size": model_args.vocab_size,
+                "hidden_dim": model_args.hidden_dim,
+                "head_dim": model_args.head_dim,
+                "multiple_of": model_args.multiple_of,
+                "ffn_dim_multiplier": model_args.ffn_dim_multiplier,
+                "norm_eps": model_args.norm_eps,
+            },
+            "limits": {
+                "max_batch_size": model_args.max_batch_size,
+                "max_seq_len": model_args.max_seq_len,
+                "max_context_len": model_args.max_context_len,
+            },
+            "moe": {
+                "enabled": model_args.moe,
+                "num_experts": model_args.num_experts,
+                "num_activated_experts": model_args.num_activated_experts,
+            },
+            "rope": {
+                "use_hf_rope": model_args.use_hf_rope,
+                "theta": model_args.rope_theta,
+                "freq_base": model_args.rope_freq_base,
+                "use_scaled_rope": model_args.use_scaled_rope,
+                "scale_factor": model_args.rope_scale_factor,
+            },
+            "special_tokens": {
+                "bos_idx": model_args.bos_idx,
+                "eos_idx": model_args.eos_idx,
+                "bos_count": model_args.bos_count,
+                "eos_count": model_args.eos_count,
+            },
+        }
+        config = merge_configs(config, model_config)
+    
+    # Override with CLI args if provided
+    if cli_args:
+        cli_config = _convert_cli_to_config_format(cli_args)
+        config = merge_configs(config, cli_config)
+    
+    # Validate the final configuration
+    try:
+        validate_config(config)
+    except ConfigValidationError as e:
+        raise ConfigValidationError(f"Configuration validation failed: {str(e)}")
+    
+    return config
+
+def get_model_args_from_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert config back to ModelArgs format."""
+    return {
+        'dim': config['architecture']['dim'],
+        'n_layers': config['architecture']['n_layers'],
+        'n_heads': config['architecture']['n_heads'],
+        'n_kv_heads': config['architecture']['n_kv_heads'],
+        'vocab_size': config['architecture']['vocab_size'],
+        'hidden_dim': config['architecture']['hidden_dim'],
+        'head_dim': config['architecture']['head_dim'],
+        'multiple_of': config['architecture']['multiple_of'],
+        'ffn_dim_multiplier': config['architecture']['ffn_dim_multiplier'],
+        'norm_eps': config['architecture']['norm_eps'],
+        'max_batch_size': config['limits']['max_batch_size'],
+        'max_seq_len': config['limits']['max_seq_len'],
+        'max_context_len': config['limits']['max_context_len'],
+        'moe': config['moe']['enabled'],
+        'num_experts': config['moe']['num_experts'],
+        'num_activated_experts': config['moe']['num_activated_experts'],
+        'use_kv_cache': config['kv_cache']['enabled'],
+        'use_sdpa_with_kv_cache': config['kv_cache']['use_sdpa'],
+        'generate_full_logits': config['export']['generate_full_logits'],
+        'enable_dynamic_shape': config['export']['enable_dynamic_shape'],
+        'use_hf_rope': config['rope']['use_hf_rope'],
+        'rope_theta': config['rope']['theta'],
+        'rope_freq_base': config['rope']['freq_base'],
+        'use_scaled_rope': config['rope']['use_scaled_rope'],
+        'rope_scale_factor': config['rope']['scale_factor'],
+        'bos_idx': config['special_tokens']['bos_idx'],
+        'eos_idx': config['special_tokens']['eos_idx'],
+        'bos_count': config['special_tokens']['bos_count'],
+        'eos_count': config['special_tokens']['eos_count'],
+    } 

--- a/examples/models/llama/config/validation.py
+++ b/examples/models/llama/config/validation.py
@@ -1,0 +1,198 @@
+from typing import Any, Dict, List, Optional, Union
+from pathlib import Path
+import re
+
+class ConfigValidationError(Exception):
+    """Raised when configuration validation fails."""
+    pass
+
+def validate_model_config(config: Dict[str, Any]) -> None:
+    """Validate model section of config."""
+    if "model" not in config:
+        raise ConfigValidationError("Missing required 'model' section")
+    
+    model = config["model"]
+    if "name" not in model:
+        raise ConfigValidationError("Missing required 'model.name' field")
+    if "type" not in model:
+        raise ConfigValidationError("Missing required 'model.type' field")
+        
+    valid_models = [
+        "stories110m", "llama2", "llama3", "llama3_1", "llama3_2", 
+        "static_llama", "qwen2_5", "phi-4-mini", "llama3_2_vision"
+    ]
+    if model["name"] not in valid_models:
+        raise ConfigValidationError(f"Invalid model name. Must be one of: {valid_models}")
+        
+    valid_types = ["LLAMA", "FAIRSEQ2"]
+    if model["type"] not in valid_types:
+        raise ConfigValidationError(f"Invalid model type. Must be one of: {valid_types}")
+
+def validate_architecture_config(config: Dict[str, Any]) -> None:
+    """Validate architecture section of config."""
+    if "architecture" not in config:
+        raise ConfigValidationError("Missing required 'architecture' section")
+    
+    arch = config["architecture"]
+    required_fields = ["dim", "n_layers", "n_heads"]
+    for field in required_fields:
+        if field not in arch:
+            raise ConfigValidationError(f"Missing required 'architecture.{field}' field")
+    
+    # Validate numeric values
+    if not isinstance(arch["dim"], int) or arch["dim"] <= 0:
+        raise ConfigValidationError("architecture.dim must be a positive integer")
+    if not isinstance(arch["n_layers"], int) or arch["n_layers"] <= 0:
+        raise ConfigValidationError("architecture.n_layers must be a positive integer")
+    if not isinstance(arch["n_heads"], int) or arch["n_heads"] <= 0:
+        raise ConfigValidationError("architecture.n_heads must be a positive integer")
+    
+    # Validate optional fields
+    if "multiple_of" in arch and (not isinstance(arch["multiple_of"], int) or arch["multiple_of"] <= 0):
+        raise ConfigValidationError("architecture.multiple_of must be a positive integer")
+    if "norm_eps" in arch and (not isinstance(arch["norm_eps"], float) or arch["norm_eps"] <= 0):
+        raise ConfigValidationError("architecture.norm_eps must be a positive float")
+
+def validate_limits_config(config: Dict[str, Any]) -> None:
+    """Validate limits section of config."""
+    if "limits" not in config:
+        raise ConfigValidationError("Missing required 'limits' section")
+    
+    limits = config["limits"]
+    required_fields = ["max_batch_size", "max_seq_len", "max_context_len"]
+    for field in required_fields:
+        if field not in limits:
+            raise ConfigValidationError(f"Missing required 'limits.{field}' field")
+    
+    # Validate numeric values
+    if not isinstance(limits["max_batch_size"], int) or limits["max_batch_size"] <= 0:
+        raise ConfigValidationError("limits.max_batch_size must be a positive integer")
+    if not isinstance(limits["max_seq_len"], int) or limits["max_seq_len"] <= 0:
+        raise ConfigValidationError("limits.max_seq_len must be a positive integer")
+    if not isinstance(limits["max_context_len"], int) or limits["max_context_len"] <= 0:
+        raise ConfigValidationError("limits.max_context_len must be a positive integer")
+    
+    # Validate relationships
+    if limits["max_context_len"] < limits["max_seq_len"]:
+        raise ConfigValidationError("limits.max_context_len must be >= limits.max_seq_len")
+
+def validate_rope_config(config: Dict[str, Any]) -> None:
+    """Validate RoPE section of config."""
+    if "rope" not in config:
+        return  # Optional section
+    
+    rope = config["rope"]
+    if "freq_base" in rope and (not isinstance(rope["freq_base"], float) or rope["freq_base"] <= 0):
+        raise ConfigValidationError("rope.freq_base must be a positive float")
+    if "scale_factor" in rope and (not isinstance(rope["scale_factor"], (int, float)) or rope["scale_factor"] <= 0):
+        raise ConfigValidationError("rope.scale_factor must be a positive number")
+    
+    # Validate boolean fields
+    bool_fields = ["use_hf_rope", "use_scaled_rope"]
+    for field in bool_fields:
+        if field in rope and not isinstance(rope[field], bool):
+            raise ConfigValidationError(f"rope.{field} must be a boolean")
+
+def validate_kv_cache_config(config: Dict[str, Any]) -> None:
+    """Validate KV cache section of config."""
+    if "kv_cache" not in config:
+        return  # Optional section
+    
+    kv_cache = config["kv_cache"]
+    bool_fields = ["enabled", "quantize", "use_sdpa"]
+    for field in bool_fields:
+        if field in kv_cache and not isinstance(kv_cache[field], bool):
+            raise ConfigValidationError(f"kv_cache.{field} must be a boolean")
+
+def validate_export_config(config: Dict[str, Any]) -> None:
+    """Validate export section of config."""
+    if "export" not in config:
+        raise ConfigValidationError("Missing required 'export' section")
+    
+    export = config["export"]
+    required_fields = ["output_dir"]
+    for field in required_fields:
+        if field not in export:
+            raise ConfigValidationError(f"Missing required 'export.{field}' field")
+    
+    # Validate paths
+    if "checkpoint" in export and export["checkpoint"]:
+        if not isinstance(export["checkpoint"], str):
+            raise ConfigValidationError("export.checkpoint must be a string path")
+    
+    if "checkpoint_dir" in export and export["checkpoint_dir"]:
+        if not isinstance(export["checkpoint_dir"], str):
+            raise ConfigValidationError("export.checkpoint_dir must be a string path")
+    
+    # Validate dtype_override
+    valid_dtypes = ["fp32", "fp16", "bf16"]
+    if "dtype_override" in export and export["dtype_override"] not in valid_dtypes:
+        raise ConfigValidationError(f"export.dtype_override must be one of: {valid_dtypes}")
+
+def validate_quantization_config(config: Dict[str, Any]) -> None:
+    """Validate quantization section of config."""
+    if "quantization" not in config:
+        return  # Optional section
+    
+    quant = config["quantization"]
+    
+    # Validate pt2e_quantize
+    valid_pt2e = [
+        "xnnpack_dynamic", "xnnpack_dynamic_qc4", "qnn_8a8w", "qnn_16a16w",
+        "qnn_16a4w", "coreml_c4w", "coreml_8a_c8w", "coreml_8a_c4w",
+        "coreml_baseline_8a_c8w", "coreml_baseline_8a_c4w", "vulkan_8w", None,
+    ]
+    if "pt2e_quantize" in quant and quant["pt2e_quantize"] not in valid_pt2e:
+        raise ConfigValidationError(f"quantization.pt2e_quantize must be one of: {valid_pt2e}")
+    
+    # Validate embedding_quantize format
+    if "embedding_quantize" in quant and quant["embedding_quantize"]:
+        pattern = r'^\d+,\d+$'
+        if not re.match(pattern, quant["embedding_quantize"]):
+            raise ConfigValidationError("quantization.embedding_quantize must be in format 'bitwidth,groupsize' (e.g., '8,1024')")
+
+def validate_backends_config(config: Dict[str, Any]) -> None:
+    """Validate backends section of config."""
+    if "backends" not in config:
+        return  # Optional section
+    
+    backends = config["backends"]
+    
+    # Validate backend-specific settings
+    for backend in ["xnnpack", "vulkan", "mps", "coreml"]:
+        if backend in backends:
+            if not isinstance(backends[backend], dict):
+                raise ConfigValidationError(f"backends.{backend} must be a dictionary")
+            if "enabled" in backends[backend]:
+                if not isinstance(backends[backend]["enabled"], bool):
+                    raise ConfigValidationError(f"backends.{backend}.enabled must be a boolean")
+
+    # Validate CoreML specific settings
+    if "coreml" in backends and backends["coreml"].get("enabled"):
+        coreml = backends["coreml"]
+        if "ios_version" in coreml and coreml["ios_version"] not in [15, 16, 17, 18]:
+            raise ConfigValidationError("backends.coreml.ios_version must be one of: 15, 16, 17, 18")
+        if "compute_units" in coreml and coreml["compute_units"] not in ["cpu_only", "cpu_and_gpu", "cpu_and_ne", "all"]:
+            raise ConfigValidationError("backends.coreml.compute_units must be one of: cpu_only, cpu_and_gpu, cpu_and_ne, all")
+
+def validate_config(config: Dict[str, Any]) -> None:
+    """Validate entire configuration."""
+    validators = [
+        validate_model_config,
+        validate_architecture_config,
+        validate_limits_config,
+        validate_rope_config,
+        validate_kv_cache_config,
+        validate_export_config,
+        validate_quantization_config,
+        validate_backends_config
+    ]
+    
+    for validator in validators:
+        validator(config)
+    
+    # Cross-section validations
+    if config.get("kv_cache", {}).get("enabled"):
+        if config.get("export", {}).get("enable_dynamic_shape"):
+            if any(config.get("backends", {}).get(b, {}).get("enabled") for b in ["coreml", "mps"]):
+                raise ConfigValidationError("Dynamic shape is not supported with CoreML or MPS backends when KV cache is enabled") 

--- a/examples/models/llama/export_llama.py
+++ b/examples/models/llama/export_llama.py
@@ -19,6 +19,8 @@ import torch
 
 from .export_llama_lib import build_args_parser, export_llama
 
+from pathlib import Path
+
 sys.setrecursionlimit(4096)
 
 
@@ -27,7 +29,81 @@ def main() -> None:
     torch.manual_seed(seed)
     parser = build_args_parser()
     args = parser.parse_args()
+    # Create config from all sources
+    from .config.loader import create_config, get_model_args_from_config
+    from .config.validation import ConfigValidationError
+
+    try:
+        config = create_config(
+            yaml_path=args.config,
+            cli_args=args,
+            params_json_path=args.params  # Include params.json
+        )
+    except ConfigValidationError as e:
+        logging.error(f"Configuration validation failed: {str(e)}")
+        logging.error("Please check your configuration and try again.")
+        return 1
+    except Exception as e:
+        logging.error(f"Error loading configuration: {str(e)}")
+        return 1
+
+    # Convert config back to args format for backward compatibility
+    args_dict = {
+        'model': config['model']['name'],
+        'output_dir': config['export']['output_dir'],
+        'checkpoint': config['export']['checkpoint'],
+        'checkpoint_dir': config['export']['checkpoint_dir'],
+        'params': config['export']['params'],
+        'tokenizer_path': config['export']['tokenizer_path'],
+        'pt2e_quantize': config['quantization']['pt2e_quantize'],
+        'embedding_quantize': config['quantization']['embedding_quantize'],
+        'quantization_mode': config['quantization']['quantization_mode'],
+        'group_size': config['quantization']['group_size'],
+        'use_qnn_sha': config['quantization']['use_qnn_sha'],
+        'use_kv_cache': config['kv_cache']['enabled'],
+        'quantize_kv_cache': config['kv_cache']['quantize'],
+        'use_sdpa_with_kv_cache': config['kv_cache']['use_sdpa'],
+        'enable_dynamic_shape': config['export']['enable_dynamic_shape'],
+        'generate_full_logits': config['export']['generate_full_logits'],
+        'dtype_override': config['export']['dtype_override'],
+        'output_name': config['export']['output_name'],
+        'profile_memory': config['export']['profile_memory'],
+        'profile_path': config['export']['profile_path'],
+        'num_sharding': config['export']['num_sharding'],
+        'xnnpack': config['backends']['xnnpack']['enabled'],
+        'xnnpack_extended_ops': config['backends']['xnnpack']['extended_ops'],
+        'vulkan': config['backends']['vulkan']['enabled'],
+        'mps': config['backends']['mps']['enabled'],
+        'coreml': config['backends']['coreml']['enabled'],
+        'coreml-enable-state': config['backends']['coreml']['enable_state'],
+        'coreml-preserve-sdpa': config['backends']['coreml']['preserve_sdpa'],
+        'verbose': config['misc']['verbose'],
+        'fairseq2': config['model']['type'] == 'FAIRSEQ2',
+        'optimized_rotation_path': config['misc']['optimized_rotation_path'],
+        'metadata': config['misc']['metadata'],
+        'so_library': config['misc']['so_library'],
+        'max_context_length': config['limits']['max_context_len'],
+        'max_seq_length': config['limits']['max_seq_len'],
+    }
+
+    # Update args with config values
+    for k, v in args_dict.items():
+        setattr(args, k, v)
+
+    # # Create ModelArgs from config
+    # model_args_dict = get_model_args_from_config(config)
+
     export_llama(args)
+
+    # import json
+    # with open("tmp/args_test.json", "w") as f:
+    #     json.dump(vars(args), f, indent=4)
+
+    if args.output_dir:
+        final_config_path = Path(args.output_dir) / "used_config.yaml"
+        from .config.loader import save_yaml_config
+        save_yaml_config(config, final_config_path)
+        logging.info(f"Saved final configuration to: {final_config_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary
The configuration system in export_llama is limited
- only via cli command. There's no python API. We cannot export an arbitrary nn.Module
- the cli args are complicated. It's hard for users to get what can be configured

Add yaml file option for export_llama configuration. 
- Move all default values from command line args to config/default.yaml
- Add `--config` option to load user defined configuration yaml file
- To keep it backward compatible, allow cli args override the configs in the yaml file

### Test plan
Reference run:
```
python3 -m examples.models.llama.export_llama -c stories110M.pt -p params.json -d fp32 -n tinyllama_xnnpack+custom_fp32_main.pte -kv -X --xnnpack-extended-ops -qmode 8da4w -G 128 --use_sdpa_with_kv_cache --output-dir tmp
```
With config:
```
python3 -m examples.models.llama.export_llama --config examples/models/llama/config/examples/stories.yaml
```
Those two commands should provide the same .pte file and used_config.yaml
