### PR TITLE
Unbreak BroadcastIndexesRange::operator+= when there is no broadcasting

### DIFF
--- a/kernels/portable/cpu/util/broadcast_indexes_range.h
+++ b/kernels/portable/cpu/util/broadcast_indexes_range.h
@@ -122,6 +122,11 @@ class BroadcastIndexesIterator {
     }
 
     output_index() += n;
+    if (output_dim_or_zero_if_no_broadcasting_ == 0) {
+      std::fill(
+          current_indexes_.begin() + 1, current_indexes_.end(), output_index());
+      return *this;
+    }
     delinearize_index(
         output_index(),
         output_shape_,

--- a/kernels/portable/cpu/util/test/broadcast_indexes_range_test.cpp
+++ b/kernels/portable/cpu/util/test/broadcast_indexes_range_test.cpp
@@ -44,7 +44,9 @@ TEST(BroadcastIndexesRangeTest, OneDNotBroadcasted) {
 
   Tensor out = tf.zeros({5});
   int idx = 0;
-  for (const auto& elem : range_to_vec(BroadcastIndexesRange<1>(out, out))) {
+  const auto range = BroadcastIndexesRange<1>(out, out);
+  for (const auto& elem : range_to_vec(range)) {
+    EXPECT_EQ(*(range.begin() + idx), elem);
     EXPECT_EQ(elem[0], idx++);
     EXPECT_EQ(elem[0], elem[1]);
   }
@@ -71,7 +73,7 @@ TEST(BroadcastIndexesRangeTest, ScalarBroadcastToOneD) {
 template <typename Range>
 void test_operator_plus(const Range& range) {
   size_t idx = 0;
-  for (const auto indexes : range) {
+  for (const auto& indexes : range) {
     EXPECT_EQ(*(range.begin() + idx), indexes);
     idx++;
   }


### PR DESCRIPTION
operator+= had a loop over 0 elements in this case, resulting in the indices array being full of zeros. Added a += test to our test case that covers this.