### PR TITLE
Create the foundation for testing CoreML export for wheels

### DIFF
--- a/.ci/scripts/wheel/test_macos.py
+++ b/.ci/scripts/wheel/test_macos.py
@@ -14,6 +14,12 @@ if __name__ == "__main__":
             test_base.ModelTest(
                 model=Model.Mv3,
                 backend=Backend.XnnpackQuantizationDelegation,
-            )
+            ),
+            # Enable this once CoreML is suppported out-of-the-box
+            # https://github.com/pytorch/executorch/issues/9019
+            # test_base.ModelTest(
+            #     model=Model.Mv3,
+            #     backend=Backend.CoreMlTest,
+            # )
         ]
     )

--- a/examples/apple/coreml/scripts/build_executor_runner.sh
+++ b/examples/apple/coreml/scripts/build_executor_runner.sh
@@ -78,4 +78,11 @@ XCODE_WORKSPACE_DIR_PATH="$EXAMPLES_COREML_DIR_PATH/executor_runner"
 XCODE_BUILD_DIR_PATH="$EXAMPLES_COREML_DIR_PATH/xcode-build"
 
 xcodebuild build -workspace "$XCODE_WORKSPACE_DIR_PATH/coreml_executor_runner.xcworkspace" -scheme coreml_executor_runner BUILD_DIR="$XCODE_BUILD_DIR_PATH"
-cp -f "$XCODE_BUILD_DIR_PATH/DEBUG/coreml_executor_runner" "$PWD"
+
+if [[ -z "${COREML_EXECUTOR_RUNNER_OUT_DIR:-}" ]]; then
+    COREML_EXECUTOR_RUNNER_OUT_DIR=$(pwd)
+elif [[ ! -d "${COREML_EXECUTOR_RUNNER_OUT_DIR}" ]]; then
+    mkdir -p "${COREML_EXECUTOR_RUNNER_OUT_DIR}"
+fi
+cp -f "$XCODE_BUILD_DIR_PATH/DEBUG/coreml_executor_runner" "${COREML_EXECUTOR_RUNNER_OUT_DIR}"
+echo "created ${COREML_EXECUTOR_RUNNER_OUT_DIR}/coreml_executor_runner"

--- a/examples/models/__init__.py
+++ b/examples/models/__init__.py
@@ -44,6 +44,7 @@ class Model(str, Enum):
 
 class Backend(str, Enum):
     XnnpackQuantizationDelegation = "xnnpack-quantization-delegation"
+    CoreMlTest = "coreml-test"
 
     def __str__(self) -> str:
         return self.value


### PR DESCRIPTION
### Summary
As part of https://github.com/pytorch/executorch/issues/9019, this will allow us to test CoreML support for wheels.

#### Why are we only selectively running the executor test? 

Our `macos-*-stable` runners do not have xcode, which is required to build and run these tests. Only GitHub's `macos-*-xlarge` runners have xcode. We currently run these CoreML tests on [trunk](https://github.com/pytorch/executorch/blob/7c6d2f332861907391450974a481b6d8e04732ed/.github/workflows/trunk.yml#L444-L477), which would be way too expensive to use GitHub's runner given the frequency. So let's limit the runner tests to just the wheel jobs. I will work with Test Infra to get Xcode into our runners.

### Test plan

* Wheel tests shouldn't change
* Test locally

```bash
$ GITHUB_WORKSPACE=$(dirname $(pwd)) REPOSITORY=$(basename $(pwd)) python .ci/scripts/wheel/test_macos.py
```
