### PR TITLE
install android ndk for mediatek docker

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -48,6 +48,7 @@ case "${IMAGE_NAME}" in
   executorch-ubuntu-22.04-mediatek-sdk)
     MEDIATEK_SDK=yes
     CLANG_VERSION=12
+    ANDROID_NDK_VERSION=r27b
     ;;
   executorch-ubuntu-22.04-clang12-android)
     LINTRUNNER=""


### PR DESCRIPTION
Summary: Looks like MTK CI flow requires android ndk, adding it to the docker

Reviewed By: kirklandsign

Differential Revision: D71492015


