### PR TITLE
Bump HF version

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -536,9 +536,8 @@ jobs:
         git clone https://github.com/huggingface/optimum-executorch
         cd optimum-executorch
         # There is no release yet, for CI stability, always test from the same commit on main
-        git checkout 6a7e83f3eee2976fa809335bfb78a45b1ea1cb25
-        pip install .
-        pip install accelerate sentencepiece
+        git checkout 1907349524b5f2d61f9c04d2e985da826d4308ba
+        pip install .[tests]
         pip list
         echo "::endgroup::"
 

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -2,4 +2,4 @@
 # TODO: Make each example publish its own requirements.txt
 timm == 1.0.7
 torchsr == 1.0.4
-transformers ==4.47.1
+transformers ==4.50.1


### PR DESCRIPTION
HF version bump. Ensure `optimum-executorch` can work on new `transformers` models with `executorch==0.6.0`

### Test plan
CI to test HF models