### PR TITLE
Arm backend: Limit number of build jobs

### DIFF
--- a/backends/arm/scripts/build_executorch_runner.sh
+++ b/backends/arm/scripts/build_executorch_runner.sh
@@ -150,7 +150,7 @@ cmake \
 
 echo "[${BASH_SOURCE[0]}] Configured CMAKE"
 
-cmake --build ${output_folder}/cmake-out --parallel -- arm_executor_runner
+cmake --build ${output_folder}/cmake-out -j$(nproc) -- arm_executor_runner
 
 echo "[${BASH_SOURCE[0]}] Generated baremetal elf file:"
 find ${output_folder}/cmake-out -name "arm_executor_runner"

--- a/backends/arm/test/setup_testing.sh
+++ b/backends/arm/test/setup_testing.sh
@@ -47,7 +47,7 @@ function build_semihosting_executorch_runner() {
     echo "[${FUNCNAME[0]}] Configured CMAKE"
 
     n=$(nproc)
-    cmake --build ${build_test_dir} -- -j"$((n - 5))" arm_executor_runner
+    cmake --build ${build_test_dir} -j"$((n - 5))" -- arm_executor_runner
     echo "[${FUNCNAME[0]}] Generated baremetal elf file: with semihosting enabled"
     find ${build_test_dir} -name "arm_executor_runner"
 }


### PR DESCRIPTION
In certain build environments, without limiting the number of build jobs, build may abort because memory is running low.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218