### PR TITLE
Arm backend: Make setup.sh handle unset EULA variable

### DIFF
--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -84,8 +84,10 @@ function setup_fvp() {
 
     # Mandatory user arg --i-agree-to-the-contained-eula
     eula_acceptance="${1:-'.'}"
+    eula_acceptance_by_variable="${ARM_FVP_INSTALL_I_AGREE_TO_THE_CONTAINED_EULA:-False}"
+
     if [[ "${eula_acceptance}" != "--i-agree-to-the-contained-eula" ]]; then
-        if [[ ${ARM_FVP_INSTALL_I_AGREE_TO_THE_CONTAINED_EULA} != "True" ]]; then
+        if [[ ${eula_acceptance_by_variable} != "True" ]]; then
         echo "Must pass first positional argument '--i-agree-to-the-contained-eula' to agree to EULA associated with downloading the FVP. Exiting!"
         exit 1
         else


### PR DESCRIPTION
If setup.sh was called without --i-agree-to-the-contained-eula or with ARM_FVP_INSTALL_I_AGREE_TO_THE_CONTAINED_EULA unset all you would get back is the error message:

"examples/arm/setup.sh: line 88:
ARM_FVP_INSTALL_I_AGREE_TO_THE_CONTAINED_EULA: unbound variable"

This is not a good error message. This commit adds handling of this variable being unset and gives a proper error message on how to accept the EULA.

Change-Id: I2fd85ff136f708f91836fae32e4e402d0557fa25


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218