### PR TITLE
Arm backend: Add info about setup_path.sh and arm-none-eabi-gcc

### DIFF
--- a/docs/source/backends-arm-ethos-u.md
+++ b/docs/source/backends-arm-ethos-u.md
@@ -114,6 +114,25 @@ At the end of the setup, if everything goes well, your top level devlopement dir
 └── setup_path.sh
 ```
 
+### Notes:
+
+The `setup.sh` script has generated a `setup_path.sh` script that you need to source everytime you restart you shell.
+
+e.g. run
+`source  executorch/examples/arm/ethos-u-scratch/setup_path.sh`
+
+As `setup.sh` will download and setup the needed Arm toolchain make sure it is used by calling
+
+`which arm-none-eabi-gcc`
+
+It should show `arm-none-eabi-gcc` in the `executorch` project and not anything in `/usr/bin` something like:
+
+`<EXECUTORCH_ROOT>/examples/arm/ethos-u-scratch/arm-gnu-toolchain-13.3.rel1-aarch64-arm-none-eabi/bin/arm-none-eabi-gcc`
+or
+`<EXECUTORCH_ROOT>/examples/arm/ethos-u-scratch/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-gcc`
+
+If not you might need to uninstall `arm-none-eabi-gcc` or make sure its picked after the one in the project in your $PATH env varable.
+
 ## Convert the PyTorch Model to the `.pte` File
 
 `.pte` is a binary file produced by ExecuTorch Ahead-of-Time (AoT) pipeline by taking in a PyTorch Model (a torch.nn.Module), exporting it, running a variety of passes, and finally serializing it to a `.pte` file format. This binary file is typically consumed by the ExecuTorch Runtime. This [document](https://github.com/pytorch/executorch/blob/main/docs/source/getting-started-architecture.md) goes in much more depth about the ExecuTorch software stack for both AoT as well as Runtime.

--- a/examples/arm/README.md
+++ b/examples/arm/README.md
@@ -21,14 +21,19 @@ build artifacts. If supplied, the same argument must be supplied to both the scr
 To run these scripts. On a Linux system, in a terminal, with a working internet connection,
 ```
 # Step [1] - setup necessary tools
-$ ./setup.sh --i-agree-to-the-contained-eula [optional-scratch-dir]
+$ cd <EXECUTORCH-ROOT-FOLDER>
+$ executorch/examples/arm/setup.sh --i-agree-to-the-contained-eula [optional-scratch-dir]
 
-# Step [2] - build + run ExecuTorch and executor_runner baremetal application
+# Step [2] - Setup Patch to tools, The `setup.sh` script has generated a script that you need to source everytime you restart you shell. 
+$ source  executorch/examples/arm/ethos-u-scratch/setup_path.sh
+
+# Step [3] - build + run ExecuTorch and executor_runner baremetal application
 # suited for Corstone FVP's to run a simple PyTorch model.
-$ ./run.sh [--scratch-dir=same-optional-scratch-dir-as-before]
+$ executorch/examples/arm/run.sh --model_name=mv2 --target=ethos-u85-128 [--scratch-dir=same-optional-scratch-dir-as-before]
 ```
+
 ### Online Tutorial
 
 We also have a [tutorial](https://pytorch.org/executorch/stable/executorch-arm-delegate-tutorial.html) explaining the steps performed in these
-scripts, expected results, and more. It is a step-by-step guide
+scripts, expected results, possible problems and more. It is a step-by-step guide
 you can follow to better understand this delegate.


### PR DESCRIPTION
Describe that you need to run setup_path.sh when starting a new shell and that you might want to make sure the right arm-none-eabi-gcc is used.



cc @digantdesai @freddan80 @per @oscarandersson8218