### PR TITLE
[ET-VK][ez] Make sure vTensor is not referencing the global context

### DIFF
--- a/backends/vulkan/runtime/api/containers/Tensor.cpp
+++ b/backends/vulkan/runtime/api/containers/Tensor.cpp
@@ -674,7 +674,8 @@ utils::GPUMemoryLayout vTensor::estimate_memory_layout() const {
 }
 
 const vkapi::BufferBindInfo vTensor::sizes_ubo() {
-  const size_t size_per_ubo = context()->adapter_ptr()->min_ubo_alignment();
+  const size_t size_per_ubo =
+      storage_.context_->adapter_ptr()->min_ubo_alignment();
   const size_t max_ubo_size = kMaxMetadataFieldCount * size_per_ubo;
   if (!uniforms_.buffer()) {
     uniforms_ = ParamsBuffer(storage_.context_, max_ubo_size, true);
@@ -692,7 +693,8 @@ const vkapi::BufferBindInfo vTensor::sizes_ubo() {
 }
 
 const vkapi::BufferBindInfo vTensor::strides_ubo() {
-  const size_t size_per_ubo = context()->adapter_ptr()->min_ubo_alignment();
+  const size_t size_per_ubo =
+      storage_.context_->adapter_ptr()->min_ubo_alignment();
   const size_t max_ubo_size = kMaxMetadataFieldCount * size_per_ubo;
   if (!uniforms_.buffer()) {
     uniforms_ = ParamsBuffer(storage_.context_, max_ubo_size, true);
@@ -712,7 +714,8 @@ const vkapi::BufferBindInfo vTensor::strides_ubo() {
 }
 
 const vkapi::BufferBindInfo vTensor::logical_limits_ubo() {
-  const size_t size_per_ubo = context()->adapter_ptr()->min_ubo_alignment();
+  const size_t size_per_ubo =
+      storage_.context_->adapter_ptr()->min_ubo_alignment();
   const size_t max_ubo_size = kMaxMetadataFieldCount * size_per_ubo;
   if (!uniforms_.buffer()) {
     uniforms_ = ParamsBuffer(storage_.context_, max_ubo_size, true);
@@ -730,7 +733,8 @@ const vkapi::BufferBindInfo vTensor::logical_limits_ubo() {
 }
 
 const vkapi::BufferBindInfo vTensor::numel_ubo() {
-  const size_t size_per_ubo = context()->adapter_ptr()->min_ubo_alignment();
+  const size_t size_per_ubo =
+      storage_.context_->adapter_ptr()->min_ubo_alignment();
   const size_t max_ubo_size = kMaxMetadataFieldCount * size_per_ubo;
   if (!uniforms_.buffer()) {
     uniforms_ = ParamsBuffer(storage_.context_, max_ubo_size, true);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #9458

## Context

Some functions in `vTensor` accidentally referenced the global context by calling `context()`; the correct thing to do is to use the context pointer associated with the `vTensor` by using `storage_.context_` instead.

Differential Revision: [D71560884](https://our.internmc.facebook.com/intern/diff/D71560884/)