### PR TITLE
Use xplat/caffe2:ovrsource_aten_Config.h for arvr build modes

### DIFF
--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -1,4 +1,4 @@
-load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime", "is_arvr_mode")
 
 def get_sleef_preprocessor_flags():
     if runtime.is_oss:
@@ -78,9 +78,8 @@ def define_common_targets():
         ] + get_sleef_preprocessor_flags(),
         xplat_exported_deps = [
             "//xplat/caffe2:aten_header",
-            "//xplat/caffe2:generated_aten_config_header",
             "//xplat/caffe2/c10:c10_headers",
-        ],
+        ] + ["//xplat/caffe2:ovrsource_aten_Config.h" if is_arvr_mode() else "//xplat/caffe2:generated_aten_config_header",],
         exported_preprocessor_flags = select({
             # Intentionally punting on non-fbcode x86 sleef support
             # for now because of fbsource//third-party/sleef:sleef

--- a/shim_et/xplat/executorch/build/env_interface.bzl
+++ b/shim_et/xplat/executorch/build/env_interface.bzl
@@ -234,6 +234,7 @@ env = struct(
     genrule = native.genrule,
     is_oss = True,
     is_xplat = lambda: False,
+    is_arvr_mode = lambda: False,
     patch_deps = _patch_deps,
     patch_cxx_compiler_flags = _patch_cxx_compiler_flags,
     patch_executorch_genrule_cmd = _patch_executorch_genrule_cmd,

--- a/shim_et/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim_et/xplat/executorch/build/runtime_wrapper.bzl
@@ -29,6 +29,9 @@ use TARGETS files normally. Same for xplat-only directories and BUCK files.
 load(":env_interface.bzl", "env")
 load(":selects.bzl", "selects")
 
+def is_arvr_mode():
+    return env.is_arvr_mode()
+
 def is_xplat():
     return env.is_xplat()
 


### PR DESCRIPTION
Summary: For arvr modes we should use `//xplat/caffe2:ovrsource_aten_Config.h` to get the ATen config headers as the `ovrsource` variants are what's used in arvr repos and using ``"//xplat/caffe2:ovrsource_aten_Config.h"` causes the ovrsource ones to get overwritten and hence results in build failures.

Differential Revision: D71506180


