### PR TITLE
[Proposal] Support Multiple Prefill + Decode in a loop

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/qnn_llama_runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama/qnn_llama_runner.cpp
@@ -76,7 +76,11 @@ int main(int argc, char** argv) {
   std::vector<char> buf;
   buf.reserve(5 * FLAGS_seq_len); // assume each token is around 5 char
   std::ofstream fout(FLAGS_output_path.c_str());
-  auto callback = [&](const std::string& piece) {
+
+  int32_t num_total_tokens = 0;
+
+  auto callback = [&](const std::string& piece, int32_t tokens_generated) {
+    num_total_tokens += tokens_generated;
     for (const char c : piece) {
       buf.push_back(c);
     }
@@ -85,6 +89,7 @@ int main(int argc, char** argv) {
   for (int i = 0; i < FLAGS_num_iters; i++) {
     runner.generate(
         FLAGS_seq_len,
+        num_total_tokens,
         FLAGS_prompt.c_str(),
         FLAGS_system_prompt.c_str(),
         callback);

--- a/examples/qualcomm/oss_scripts/llama/runner/io_manager.h
+++ b/examples/qualcomm/oss_scripts/llama/runner/io_manager.h
@@ -48,9 +48,13 @@ class IoMgrBase {
           executorch::runtime::Result<executorch::runtime::MethodMeta>>&
           methods_meta) = 0;
   virtual void fill_prefill_toks(
-      int64_t start_pos,
+      int64_t num_prev_tokens,
+      int64_t prompt_pos,
       std::vector<uint64_t>& prompt_tokens) = 0;
   virtual void fill_kv_tok_mask(int64_t pos, int64_t cur_token) = 0;
+  virtual void update_kv_to_prefill_io(
+      int64_t pos,
+      std::vector<std::vector<executorch::aten::Tensor>>& output_tensors) = 0;
   virtual void update_prefill_to_kv_io(
       int64_t cur_token,
       int64_t pos,
@@ -118,9 +122,13 @@ class ShiftPointerIoMgr : public IoMgrBase {
           executorch::runtime::Result<executorch::runtime::MethodMeta>>&
           methods_meta) override;
   void fill_prefill_toks(
-      int64_t start_pos,
+      int64_t num_prev_tokens,
+      int64_t prompt_pos,
       std::vector<uint64_t>& prompt_tokens) override;
   void fill_kv_tok_mask(int64_t pos, int64_t cur_token) override;
+  void update_kv_to_prefill_io(
+      int64_t pos,
+      std::vector<std::vector<executorch::aten::Tensor>>& output_tensors) override;
   void update_prefill_to_kv_io(
       int64_t cur_token,
       int64_t pos,
@@ -190,6 +198,8 @@ class ShiftPointerIoMgr : public IoMgrBase {
   std::string kv_forward_name_;
   const bool use_int64_token_{false};
   const bool is_bert_{false};
+
+  int64_t last_pos_{0};
 };
 
 class SmartMaskIoMgr : public IoMgrBase {
@@ -226,9 +236,13 @@ class SmartMaskIoMgr : public IoMgrBase {
           executorch::runtime::Result<executorch::runtime::MethodMeta>>&
           methods_meta) override;
   void fill_prefill_toks(
-      int64_t start_pos,
+      int64_t num_prev_tokens,
+      int64_t prompt_pos,
       std::vector<uint64_t>& prompt_tokens) override;
   void fill_kv_tok_mask(int64_t pos, int64_t cur_token) override;
+  void update_kv_to_prefill_io(
+      int64_t pos,
+      std::vector<std::vector<executorch::aten::Tensor>>& output_tensors) override;
   void update_prefill_to_kv_io(
       int64_t cur_token,
       int64_t pos,

--- a/examples/qualcomm/oss_scripts/llama/runner/runner.h
+++ b/examples/qualcomm/oss_scripts/llama/runner/runner.h
@@ -67,9 +67,10 @@ class Runner {
   executorch::runtime::Error load();
   executorch::runtime::Error generate(
       int32_t seq_len,
+      int32_t num_prev_tokens,
       const std::string& prompt,
       const std::string& system_prompt,
-      std::function<void(const std::string&)> token_callback = {},
+      std::function<void(const std::string&, int32_t)> token_callback = {},
       std::function<void(const Stats&)> stats_callback = {});
   void stop();
   std::vector<executorch::runtime::Result<executorch::runtime::MethodMeta>>


### PR DESCRIPTION
We would like to support multi-turn conversations with the AR-N model by allowing prefill + decode to be called in a loop without resetting the internal KV cache state.

Example:
_Initialize Runner and KV Cache_
Prompt: "Call David"
Response: "Okay, Call David Lee?"
Prompt: "No, call David Smith"
Response: "Okay, Calling David Smith, not David Lee"
_Clear KV Cache_

Assumptions:
- The assumption here is that to support multiple prefill + decode in a loop, we need to update the prefill_input_pos and prefill_attention_mask to reflect the previously decoded tokens + new prompt tokens.
- An additional assumption is that we need to update the pointers for k_cache and v_cache for prefill

What this PR does:
- Add a function `update_kv_to_prefill_io` to advance prefill pointers for v_cache. Also sets attention_mask up to pos (to cover tokens generated during decode).
- Update fill_prefill_toks to take in previous tokens prefilled + generated so far and using this to set input_pos and attention mask
- Updates test runner to save number of tokens generated and pass to IO Manager. Also comments out resetting KV Cache state so it gets re-used.

Current State:
The code does not crash, but also does not produce proper input. Tested on Samsung S24 with QNN 2.28 binaries

`./qnn_llama3_2_runner --model_path hybrid_llama_qnn.pte    --tokenizer_path tiktokenizer.bin  --eval_mode 1 --prompt "Call David" --kv_updater "ShiftPointer" --logits_scale 0.1 --output_path output.txt --num_iters 2`

Example with a model trained for communication:
<|begin_of_text|><|start_header_id|>user<|end_header_id|>

Call David<|eot_id|><|start_header_id|>assistant<|end_header_id|>

Okay, call David
<|begin_of_text|><|start_header_id|>user<|end_header_id|>

Call David<|eot_id|><|start_header_id|>assistant<|end_header_id|>

renamerenamerenamehabihabihabihabihabihabihabihabi date date date date date date握 culturesogh MMI MMI MMIhabihabihabihabihabislidesванetus Tangourt Abrams datefeedingfeedinghabi Date dateolved MMIhabihabihabihabihabihabihabihabihabihabihabihabi族OGLEalse date date date dateucusucusucushabihabi
