### PR TITLE
Upgrade cmake on CI

### DIFF
--- a/.ci/docker/conda-env-ci.txt
+++ b/.ci/docker/conda-env-ci.txt
@@ -1,4 +1,4 @@
-cmake=3.24
+cmake=3.26.4
 ninja=1.10.2
 libuv
 llvm-openmp

--- a/.ci/docker/conda-env-ci.txt
+++ b/.ci/docker/conda-env-ci.txt
@@ -1,4 +1,4 @@
-cmake=3.22.1
+cmake=3.24
 ninja=1.10.2
 libuv
 llvm-openmp


### PR DESCRIPTION
This is the minimum version `cmake_minimum_required(VERSION 3.24)` set by https://github.com/pytorch/executorch/pull/9248.  Android jobs are failing https://github.com/pytorch/executorch/actions/runs/13959323278/job/39077616882#step:15:753 after https://github.com/pytorch/executorch/pull/9248 lands