### PR TITLE
Applied quantization for linear with bias=True in pre_quantization

### DIFF
--- a/examples/models/llama/source_transformation/pre_quantization.py
+++ b/examples/models/llama/source_transformation/pre_quantization.py
@@ -44,7 +44,7 @@ def _replace_linear_with_linear_8da4w_for_pre_quantization(
             # pyre-fixme[6]: For 2nd argument expected `int` but got `Union[Module,
             #  Tensor]`.
             child.out_features,
-            bias=False,
+            bias=child.bias is not None,
             device=child.weight.device,
             groupsize=group_size,
             precision=precision,


### PR DESCRIPTION
Summary: Applied quantization for linear with bias=True in pre_quantization and checkpoint conversion. Verified small checkpoint of speech encoder eager model.

Differential Revision: D71573144


