### PR TITLE
Create a CoreML inmemoryfs pybinding target

### DIFF
--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -234,7 +234,9 @@ install(
 
 # We only care about building the pybinding when building for macOS wheels.
 if(EXECUTORCH_BUILD_COREML AND EXECUTORCH_BUILD_PYBIND)
-  add_subdirectory(${EXECUTORCH_ROOT}/third-party/pybind11 ${CMAKE_CURRENT_BINARY_DIR}/pybind11)
+  if(NOT TARGET pybind11::pybind11)
+    add_subdirectory(${EXECUTORCH_ROOT}/third-party/pybind11 ${CMAKE_CURRENT_BINARY_DIR}/pybind11)
+  endif()
 
   pybind11_add_module(executorchcoreml SHARED runtime/inmemoryfs/inmemory_filesystem_py.cpp)
 

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -25,6 +25,8 @@ endif()
 
 option(COREML_BUILD_EXECUTOR_RUNNER "Build CoreML executor runner." OFF)
 
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
+
 # inmemoryfs sources
 set(INMEMORYFS_SOURCES
     runtime/inmemoryfs/inmemory_filesystem.cpp
@@ -230,7 +232,8 @@ install(
   DESTINATION ${_common_include_directories}
 )
 
-if(EXECUTORCH_BUILD_COREML)
+# We only care about building the pybinding when building for macOS wheels.
+if(EXECUTORCH_BUILD_COREML AND EXECUTORCH_BUILD_PYBIND)
   add_subdirectory(${EXECUTORCH_ROOT}/third-party/pybind11 ${CMAKE_CURRENT_BINARY_DIR}/pybind11)
 
   pybind11_add_module(executorchcoreml SHARED runtime/inmemoryfs/inmemory_filesystem_py.cpp)
@@ -239,6 +242,5 @@ if(EXECUTORCH_BUILD_COREML)
   if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     target_compile_options(executorchcoreml PRIVATE -g)
   endif()
-  target_link_libraries(executorchcoreml PRIVATE coreml_util)
-  target_link_libraries(executorchcoreml PRIVATE coreml_inmemoryfs)
+  target_link_libraries(executorchcoreml PRIVATE coreml_util coreml_inmemoryfs)
 endif()

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -25,6 +25,8 @@ endif()
 
 option(COREML_BUILD_EXECUTOR_RUNNER "Build CoreML executor runner." OFF)
 
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
+
 # inmemoryfs sources
 set(INMEMORYFS_SOURCES
     runtime/inmemoryfs/inmemory_filesystem.cpp
@@ -229,3 +231,16 @@ install(
   INCLUDES
   DESTINATION ${_common_include_directories}
 )
+
+if(EXECUTORCH_BUILD_COREML)
+  add_subdirectory(${EXECUTORCH_ROOT}/third-party/pybind11 ${CMAKE_CURRENT_BINARY_DIR}/pybind11)
+
+  pybind11_add_module(executorchcoreml SHARED runtime/inmemoryfs/inmemory_filesystem_py.cpp)
+
+  target_compile_options(executorchcoreml PRIVATE -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET})
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    target_compile_options(executorchcoreml PRIVATE -g)
+  endif()
+  target_link_libraries(executorchcoreml PRIVATE coreml_util)
+  target_link_libraries(executorchcoreml PRIVATE coreml_inmemoryfs)
+endif()

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -25,8 +25,6 @@ endif()
 
 option(COREML_BUILD_EXECUTOR_RUNNER "Build CoreML executor runner." OFF)
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
-
 # inmemoryfs sources
 set(INMEMORYFS_SOURCES
     runtime/inmemoryfs/inmemory_filesystem.cpp


### PR DESCRIPTION
### Summary
Context: https://github.com/pytorch/executorch/pull/9481

We now create the pybinding target for inmemoryfs. Note that the build recipe is from the wheel builder:

https://github.com/pytorch/executorch/blob/5fdfa511966208c7e237a9e920a7c63f513b4fb7/backends/apple/coreml/runtime/inmemoryfs/setup.py#L17-L38

### Test plan
```
$ cmake -B cmake-out -S . -DEXECUTORCH_BUILD_PYBIND=ON -DEXECUTORCH_BUILD_COREML=ON
$ cmake --build cmake-out -j$(sysctl -n hw.ncpu) --target executorchcoreml

$ ./install_executorch.sh --pybind coreml
```

cc @larryliu0820 @lucylq