### PR TITLE
Fix exir.load/save to handle named data store map

### DIFF
--- a/exir/serde/schema.py
+++ b/exir/serde/schema.py
@@ -402,3 +402,4 @@ class LoweredBackendModule:
     original_module: export_schema.ExportedProgram
     original_state_dict: str
     original_constants: str
+    named_data_store: Optional[bytes] = None

--- a/exir/serde/serialize.py
+++ b/exir/serde/serialize.py
@@ -22,6 +22,7 @@ import executorch.exir.serde.schema as schema
 import torch
 import torch.export.exported_program as ep
 from executorch.exir import delegate
+from executorch.exir._serialize._named_data_store import NamedDataStoreOutput
 from executorch.exir.backend.compile_spec_schema import (
     CompileSpec as delegate_CompileSpec,
 )
@@ -268,6 +269,7 @@ class GraphModuleSerializer(export_serialize.GraphModuleSerializer):
         assert isinstance(serialized_artifact.exported_program, schema.ExportedProgram)
 
         serialized_processed_bytes = serialize_bytes(lowered_module.processed_bytes)
+        named_data_store = json.dumps(export_serialize._dataclass_to_dict(lowered_module.named_data_store_output),cls=export_serialize.EnumEncoder) if lowered_module.named_data_store_output else None
 
         serialized_lowered_module = SerdeLoweredBackendModule(
             original_module=serialized_artifact.exported_program,
@@ -276,6 +278,7 @@ class GraphModuleSerializer(export_serialize.GraphModuleSerializer):
             processed_bytes=serialized_processed_bytes,
             compile_specs=serialized_compile_spec,
             backend_id=lowered_module.backend_id,
+            named_data_store=named_data_store,
         )
 
         json_lowered_module = json.dumps(
@@ -556,11 +559,19 @@ class GraphModuleDeserializer(export_serialize.GraphModuleDeserializer):
             None,
         )
 
+        if serialized_lowered_module.named_data_store is None:
+            named_data_store = None
+        else:
+            named_data_store = export_serialize._dict_to_dataclass(NamedDataStoreOutput, json.loads(serialized_lowered_module.named_data_store))
+            for buffer in named_data_store.buffers:
+                buffer.buffer = base64.b64decode(buffer.buffer.encode("ascii"))
+
         lowered_module = ExirLoweredBackendModule(
             original_module,
             backend_id,
             processed_bytes,
             compile_specs,
+            named_data_store
         )
         self.module.register_module(serialized_lowered_module_arg.name, lowered_module)
         return self.graph.get_attr(serialized_lowered_module_arg.name)

--- a/exir/tests/TARGETS
+++ b/exir/tests/TARGETS
@@ -98,6 +98,7 @@ python_unittest(
         "//executorch/exir/backend/test:backend_with_compiler_demo",
         "//executorch/exir/backend/test:op_partitioner_demo",
         "//executorch/exir/serde:serialize",
+        "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
     ],
 )
 


### PR DESCRIPTION
Summary: After named data store map was added recently to edge dialect the support for serializing/deserializing named data store map was missing in exir.load/save. This diff adds that and also adds a test to check for this.

Differential Revision: D71601647


