### PR TITLE
updte the return type of log_delegation_intermediate_output

### DIFF
--- a/devtools/etdump/etdump_flatcc.cpp
+++ b/devtools/etdump/etdump_flatcc.cpp
@@ -307,39 +307,44 @@ void ETDumpGen::log_profiling_delegate(
   etdump_RunData_events_push_end(builder_);
 }
 
-void ETDumpGen::log_intermediate_output_delegate(
+Result<bool> ETDumpGen::log_intermediate_output_delegate(
     const char* name,
     DebugHandle delegate_debug_index,
     const Tensor& output) {
   log_intermediate_output_delegate_helper(name, delegate_debug_index, output);
+  return true;
 }
 
-void ETDumpGen::log_intermediate_output_delegate(
+Result<bool> ETDumpGen::log_intermediate_output_delegate(
     const char* name,
     DebugHandle delegate_debug_index,
     const ArrayRef<Tensor> output) {
   log_intermediate_output_delegate_helper(name, delegate_debug_index, output);
+  return true;
 }
 
-void ETDumpGen::log_intermediate_output_delegate(
+Result<bool> ETDumpGen::log_intermediate_output_delegate(
     const char* name,
     DebugHandle delegate_debug_index,
     const int& output) {
   log_intermediate_output_delegate_helper(name, delegate_debug_index, output);
+  return true;
 }
 
-void ETDumpGen::log_intermediate_output_delegate(
+Result<bool> ETDumpGen::log_intermediate_output_delegate(
     const char* name,
     DebugHandle delegate_debug_index,
     const bool& output) {
   log_intermediate_output_delegate_helper(name, delegate_debug_index, output);
+  return true;
 }
 
-void ETDumpGen::log_intermediate_output_delegate(
+Result<bool> ETDumpGen::log_intermediate_output_delegate(
     const char* name,
     DebugHandle delegate_debug_index,
     const double& output) {
   log_intermediate_output_delegate_helper(name, delegate_debug_index, output);
+  return true;
 }
 
 template <typename T>

--- a/devtools/etdump/etdump_flatcc.h
+++ b/devtools/etdump/etdump_flatcc.h
@@ -14,6 +14,7 @@
 #include <executorch/devtools/etdump/data_sinks/buffer_data_sink.h>
 #include <executorch/devtools/etdump/data_sinks/data_sink_base.h>
 #include <executorch/runtime/core/event_tracer.h>
+#include <executorch/runtime/core/result.h>
 #include <executorch/runtime/core/span.h>
 #include <executorch/runtime/platform/platform.h>
 
@@ -23,6 +24,8 @@ struct flatcc_builder;
 
 namespace executorch {
 namespace etdump {
+
+using ::executorch::runtime::Result;
 
 namespace internal {
 struct ETDumpStaticAllocator {
@@ -106,7 +109,7 @@ class ETDumpGen : public ::executorch::runtime::EventTracer {
   /**
    * Log an intermediate tensor output from a delegate.
    */
-  virtual void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       ::executorch::runtime::DebugHandle delegate_debug_index,
       const executorch::aten::Tensor& output) override;
@@ -114,7 +117,7 @@ class ETDumpGen : public ::executorch::runtime::EventTracer {
   /**
    * Log an intermediate tensor array output from a delegate.
    */
-  virtual void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       ::executorch::runtime::DebugHandle delegate_debug_index,
       const ::executorch::runtime::ArrayRef<executorch::aten::Tensor> output)
@@ -123,7 +126,7 @@ class ETDumpGen : public ::executorch::runtime::EventTracer {
   /**
    * Log an intermediate int output from a delegate.
    */
-  virtual void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       ::executorch::runtime::DebugHandle delegate_debug_index,
       const int& output) override;
@@ -131,7 +134,7 @@ class ETDumpGen : public ::executorch::runtime::EventTracer {
   /**
    * Log an intermediate bool output from a delegate.
    */
-  virtual void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       ::executorch::runtime::DebugHandle delegate_debug_index,
       const bool& output) override;
@@ -139,7 +142,7 @@ class ETDumpGen : public ::executorch::runtime::EventTracer {
   /**
    * Log an intermediate double output from a delegate.
    */
-  virtual void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       ::executorch::runtime::DebugHandle delegate_debug_index,
       const double& output) override;

--- a/runtime/core/event_tracer.h
+++ b/runtime/core/event_tracer.h
@@ -321,8 +321,12 @@ class EventTracer {
    * based names are used by this delegate to identify ops executed in the
    * backend then kUnsetDebugHandle should be passed in here.
    * @param[in] output The tensor type output to be logged.
+   * @return A Result<bool> indicating the status of the logging operation.
+   *         - True if the tensor type output was successfully logged.
+   *         - False if the tensor type output was filtered out and not logged.
+   *         - An error code if an error occurs during logging.
    */
-  virtual void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       DebugHandle delegate_debug_index,
       const executorch::aten::Tensor& output) = 0;
@@ -341,8 +345,13 @@ class EventTracer {
    * based names are used by this delegate to identify ops executed in the
    * backend then kUnsetDebugHandle should be passed in here.
    * @param[in] output The tensor array type output to be logged.
+   * @return A Result<bool> indicating the status of the logging operation.
+   *         - True if the tensor array type output was successfully logged.
+   *         - False if the tensor array type output was filtered out and not
+   * logged.
+   *         - An error code if an error occurs during logging.
    */
-  virtual void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       DebugHandle delegate_debug_index,
       const ArrayRef<executorch::aten::Tensor> output) = 0;
@@ -361,8 +370,12 @@ class EventTracer {
    * based names are used by this delegate to identify ops executed in the
    * backend then kUnsetDebugHandle should be passed in here.
    * @param[in] output The int type output to be logged.
+   * @return A Result<bool> indicating the status of the logging operation.
+   *         - True if the int type output was successfully logged.
+   *         - False if the int type output was filtered out and not logged.
+   *         - An error code if an error occurs during logging.
    */
-  virtual void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       DebugHandle delegate_debug_index,
       const int& output) = 0;
@@ -381,8 +394,12 @@ class EventTracer {
    * based names are used by this delegate to identify ops executed in the
    * backend then kUnsetDebugHandle should be passed in here.
    * @param[in] output The bool type output to be logged.
+   * @return A Result<bool> indicating the status of the logging operation.
+   *         - True if the bool type output was successfully logged.
+   *         - False if the bool type output was filtered out and not logged.
+   *         - An error code if an error occurs during logging.
    */
-  virtual void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       DebugHandle delegate_debug_index,
       const bool& output) = 0;
@@ -401,8 +418,12 @@ class EventTracer {
    * based names are used by this delegate to identify ops executed in the
    * backend then kUnsetDebugHandle should be passed in here.
    * @param[in] output The double type output to be logged.
+   * @return A Result<bool> indicating the status of the logging operation.
+   *         - True if the double type output was successfully logged.
+   *         - False if the double type output was filtered out and not logged.
+   *         - An error code if an error occurs during logging.
    */
-  virtual void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       DebugHandle delegate_debug_index,
       const double& output) = 0;

--- a/runtime/core/test/event_tracer_test.cpp
+++ b/runtime/core/test/event_tracer_test.cpp
@@ -12,6 +12,7 @@
 #include <executorch/runtime/core/array_ref.h>
 #include <executorch/runtime/core/evalue.h>
 #include <executorch/runtime/core/event_tracer.h>
+#include <executorch/runtime/core/result.h>
 // Enable flag for test
 #define ET_EVENT_TRACER_ENABLED
 #include <executorch/runtime/core/event_tracer_hooks.h>
@@ -29,6 +30,7 @@ using executorch::runtime::EventTracerEntry;
 using executorch::runtime::kUnsetChainId;
 using executorch::runtime::kUnsetDebugHandle;
 using executorch::runtime::LoggedEValueType;
+using executorch::runtime::Result;
 
 class DummyEventTracer : public EventTracer {
  public:
@@ -101,49 +103,54 @@ class DummyEventTracer : public EventTracer {
     (void)metadata_len;
   }
 
-  void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       DebugHandle delegate_debug_index,
       const Tensor& output) override {
     (void)name;
     (void)delegate_debug_index;
     (void)output;
+    return true;
   }
 
-  void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       DebugHandle delegate_debug_index,
       const ArrayRef<Tensor> output) override {
     (void)name;
     (void)delegate_debug_index;
     (void)output;
+    return true;
   }
 
-  void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       DebugHandle delegate_debug_index,
       const int& output) override {
     (void)name;
     (void)delegate_debug_index;
     (void)output;
+    return true;
   }
 
-  virtual void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       DebugHandle delegate_debug_index,
       const bool& output) override {
     (void)name;
     (void)delegate_debug_index;
     (void)output;
+    return true;
   }
 
-  virtual void log_intermediate_output_delegate(
+  virtual Result<bool> log_intermediate_output_delegate(
       const char* name,
       DebugHandle delegate_debug_index,
       const double& output) override {
     (void)name;
     (void)delegate_debug_index;
     (void)output;
+    return true;
   }
 
   void log_evalue(const EValue& evalue, LoggedEValueType evalue_type) override {


### PR DESCRIPTION
Summary:
Update the return type pf event_tracer::log_intermediate_output_delegate from void to Result<bool> to:
1. indicate the filter status
2. make the error raised gracefully.

The whole design can be found here https://github.com/pytorch/executorch/discussions/9260

Reviewed By: YIWENX14

Differential Revision: D71591385


