### PR TITLE
Fix lint violation from #9073

### DIFF
--- a/examples/qualcomm/utils.py
+++ b/examples/qualcomm/utils.py
@@ -205,7 +205,7 @@ class SimpleADB:
             qnn_executor_runner_cmds = " ".join(
                 [
                     f"cd {self.workspace} &&",
-                    f"chmod +x ./qnn_executor_runner &&",
+                    "chmod +x ./qnn_executor_runner &&",
                     f"./qnn_executor_runner {qnn_executor_runner_args}",
                 ]
             )


### PR DESCRIPTION
### Summary
Main is failing lint tests introduced in https://github.com/pytorch/executorch/pull/9073.


### Test plan

```
$ lintrunner -a
```
