### PR TITLE
Arm backend: Refactor any, bitwise, logical tests

### DIFF
--- a/backends/arm/test/ops/test_any.py
+++ b/backends/arm/test/ops/test_any.py
@@ -6,6 +6,7 @@
 
 from typing import List, Tuple
 
+import pytest
 import torch
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import (
@@ -117,25 +118,6 @@ test_data = {
 }
 
 
-fvp_xfails = {
-    "any_rank1": "MLETORCH-706 Support ScalarType::Bool in EthosUBackend.",
-    "any_rank1_squeeze": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank2": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank2_squeeze": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank2_dims": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank2_dims_squeeze": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank3_dims_squeeze": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank4": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank4_squeeze": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank4_dims": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank4_dims_squeeze": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank1_reduce_all": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank2_reduce_all": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank3_reduce_all": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "any_rank4_reduce_all": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-}
-
-
 @common.parametrize("test_data", test_data)
 def test_any_tosa_MI(test_data: input_t1):
     op, test_input = test_data
@@ -147,13 +129,13 @@ def test_any_tosa_MI(test_data: input_t1):
 def test_any_tosa_BI(test_data: input_t1):
     op, test_input = test_data
     pipeline = TosaPipelineBI[input_t1](op, test_input, op.aten_op, op.exir_op)
-    pipeline.pop_stage(pipeline.find_pos("quantize") + 1)
     pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data)
-def test_logical_u55_BI(test_data: input_t1):
+def test_any_u55_BI(test_data: input_t1):
     # Tests that we don't delegate these ops since they are not supported on U55.
     op, test_input = test_data
     pipeline = OpNotSupportedPipeline[input_t1](
@@ -163,23 +145,13 @@ def test_logical_u55_BI(test_data: input_t1):
 
 
 @common.parametrize("test_data", test_data)
-def test_floor_u85_BI(test_data: input_t1):
-    op, test_input = test_data
-    pipeline = EthosU85PipelineBI[input_t1](
-        op, test_input, op.aten_op, op.exir_op, run_on_fvp=False
-    )
-    pipeline.pop_stage(pipeline.find_pos("quantize") + 1)
-    pipeline.pop_stage("quantize")
-    pipeline.run()
-
-
-@common.parametrize("test_data", test_data, fvp_xfails)
-@common.SkipIfNoCorstone320
-def test_floor_u85_BI_on_fvp(test_data: input_t1):
+@pytest.mark.xfail(reason="MLETORCH-706: Support ScalarType::Bool in EthosUBackend.")
+@common.XfailIfNoCorstone320
+def test_any_u85_BI(test_data: input_t1):
     op, test_input = test_data
     pipeline = EthosU85PipelineBI[input_t1](
         op, test_input, op.aten_op, op.exir_op, run_on_fvp=True
     )
-    pipeline.pop_stage(pipeline.find_pos("quantize") + 1)
     pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
     pipeline.run()

--- a/backends/arm/test/ops/test_bitwise.py
+++ b/backends/arm/test/ops/test_bitwise.py
@@ -3,193 +3,168 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
 
-from typing import Callable, NamedTuple, Tuple
+from typing import Tuple
 
+import pytest
 import torch
-from executorch.backends.arm.test import common, conftest
-from executorch.backends.arm.test.tester.arm_tester import ArmTester
-from parameterized import parameterized
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU85PipelineBI,
+    OpNotSupportedPipeline,
+    TosaPipelineBI,
+    TosaPipelineMI,
+)
 
 
-class DataTuple(NamedTuple):
-    name: str
-    tensor1: torch.Tensor
-    tensor2: torch.Tensor
+input_t2 = Tuple[torch.Tensor, torch.Tensor]  # Input x, y
 
 
-class OpTuple(NamedTuple):
-    name: str
-    operator: torch.nn.Module
+class BitwiseBinary(torch.nn.Module):
+    test_data: dict[input_t2] = {
+        "zeros": (
+            torch.zeros(1, 10, 10, 10, dtype=torch.int32),
+            torch.zeros(1, 10, 10, 10, dtype=torch.int32),
+        ),
+        "ones": (
+            torch.ones(10, 10, 10, dtype=torch.int8),
+            torch.ones(10, 10, 10, dtype=torch.int8),
+        ),
+        "rand_rank2": (
+            torch.randint(-128, 127, (10, 10), dtype=torch.int8),
+            torch.randint(-128, 127, (10, 10), dtype=torch.int8),
+        ),
+        "rand_rank4": (
+            torch.randint(-128, -127, (1, 10, 10, 10), dtype=torch.int8),
+            torch.randint(-128, 127, (1, 10, 10, 10), dtype=torch.int8),
+        ),
+    }
 
 
-class And(torch.nn.Module):
+class And(BitwiseBinary):
+    aten_op = "torch.ops.aten.bitwise_and.Tensor"
+    exir_op = "executorch_exir_dialects_edge__ops_aten_bitwise_and_Tensor"
+
     def forward(self, tensor1: torch.Tensor, tensor2: torch.Tensor):
         return tensor1.bitwise_and(tensor2)
 
 
-class Xor(torch.nn.Module):
+class Xor(BitwiseBinary):
+    aten_op = "torch.ops.aten.bitwise_xor.Tensor"
+    exir_op = "executorch_exir_dialects_edge__ops_aten_bitwise_xor_Tensor"
+
     def forward(self, tensor1: torch.Tensor, tensor2: torch.Tensor):
         return tensor1.bitwise_xor(tensor2)
 
 
-class Or(torch.nn.Module):
+class Or(BitwiseBinary):
+    aten_op = "torch.ops.aten.bitwise_or.Tensor"
+    exir_op = "executorch_exir_dialects_edge__ops_aten_bitwise_or_Tensor"
+
     def forward(self, tensor1: torch.Tensor, tensor2: torch.Tensor):
         return tensor1.bitwise_or(tensor2)
 
 
-test_data_suite: list[DataTuple] = [
-    DataTuple(
-        "zeros",
-        torch.zeros(1, 10, 10, 10, dtype=torch.int32),
-        torch.zeros(1, 10, 10, 10, dtype=torch.int32),
-    ),
-    DataTuple(
-        "ones",
-        torch.ones(10, 10, 10, dtype=torch.int8),
-        torch.ones(10, 10, 10, dtype=torch.int8),
-    ),
-    DataTuple(
-        "rand_rank2",
-        torch.randint(-128, 127, (10, 10), dtype=torch.int8),
-        torch.randint(-128, 127, (10, 10), dtype=torch.int8),
-    ),
-    DataTuple(
-        "rand_rank4",
-        torch.randint(-128, -127, (1, 10, 10, 10), dtype=torch.int8),
-        torch.randint(-128, 127, (1, 10, 10, 10), dtype=torch.int8),
-    ),
-]
+@common.parametrize("test_data", And().test_data)
+def test_bitwise_and_tensor_tosa_MI(test_data: input_t2):
+    pipeline = TosaPipelineMI[input_t2](And(), test_data, And().aten_op, And().exir_op)
+    pipeline.run()
 
 
-ops: list[OpTuple] = [
-    OpTuple("and", And()),
-    OpTuple("or", Or()),
-    OpTuple("xor", Xor()),
-]
-
-full_test_suite = []
-for op in ops:
-    for test_data in test_data_suite:
-        full_test_suite.append(
-            (
-                f"{op.name}_{test_data.name}",
-                op.operator,
-                test_data.tensor1,
-                test_data.tensor2,
-            )
-        )
-
-del test_data
-del ops
+@common.parametrize("test_data", And().test_data)
+def test_bitwise_and_tensor_tosa_BI(test_data: input_t2):
+    pipeline = TosaPipelineBI[input_t2](And(), test_data, And().aten_op, And().exir_op)
+    pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
+    pipeline.run()
 
 
-class TestBitwise(unittest.TestCase):
+@common.parametrize("test_data", And().test_data)
+def test_bitwise_and_tensor_u55_BI(test_data: input_t2):
+    # Tests that we don't delegate these ops since they are not supported on U55.
+    pipeline = OpNotSupportedPipeline[input_t2](
+        And(), test_data, "TOSA-0.80+BI+u55", {And().exir_op: 1}
+    )
+    pipeline.run()
 
-    def _test_bitwise_tosa_MI_pipeline(
-        self, module: torch.nn.Module, test_data: Tuple[torch.tensor, torch.tensor]
-    ):
-        (
-            ArmTester(
-                module,
-                example_inputs=test_data,
-                compile_spec=common.get_tosa_compile_spec("TOSA-0.80+MI"),
-            )
-            .export()
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .to_executorch()
-            .run_method_and_compare_outputs(inputs=test_data)
-        )
 
-    def _test_bitwise_tosa_BI_pipeline(
-        self, module: torch.nn.Module, test_data: Tuple[torch.tensor, torch.tensor]
-    ):
-        (
-            ArmTester(
-                module,
-                example_inputs=test_data,
-                compile_spec=common.get_tosa_compile_spec(
-                    "TOSA-0.80+BI", custom_path="local_bin/bitwise"
-                ),
-            )
-            .export()
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .to_executorch()
-            .run_method_and_compare_outputs(inputs=test_data)
-        )
+@common.parametrize("test_data", And().test_data)
+@pytest.mark.xfail(reason="MLETORCH-706: Support ScalarType::Bool in EthosUBackend.")
+@common.XfailIfNoCorstone320
+def test_bitwise_and_tensor_u85_BI(test_data: input_t2):
+    pipeline = EthosU85PipelineBI[input_t2](
+        And(), test_data, And().aten_op, And().exir_op, run_on_fvp=True
+    )
+    pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
+    pipeline.run()
 
-    def _test_bitwise_tosa_u55_BI_pipeline(
-        self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
-    ):
-        # Tests that we don't delegate these ops since they are not supported on U55.
-        (
-            ArmTester(
-                module,
-                example_inputs=test_data,
-                compile_spec=common.get_u55_compile_spec(),
-            )
-            .export()
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 0})
-        )
 
-    def _test_bitwise_tosa_u85_BI_pipeline(
-        self, module: torch.nn.Module, test_data: Tuple[torch.tensor]
-    ):
-        tester = (
-            ArmTester(
-                module,
-                example_inputs=test_data,
-                compile_spec=common.get_u85_compile_spec(),
-            )
-            .export()
-            .to_edge_transform_and_lower()
-            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
-            .to_executorch()
-            .serialize()
-        )
-        if conftest.is_option_enabled("corstone_fvp"):
-            tester.run_method_and_compare_outputs(inputs=test_data)
+@common.parametrize("test_data", Xor().test_data)
+def test_bitwise_xor_tensor_tosa_MI(test_data: input_t2):
+    pipeline = TosaPipelineMI[input_t2](Xor(), test_data, Xor().aten_op, Xor().exir_op)
+    pipeline.run()
 
-    @parameterized.expand(full_test_suite)
-    def test_tosa_MI(
-        self,
-        test_name: str,
-        operator: Callable,
-        tensor1: torch.Tensor,
-        tensor2: torch.Tensor,
-    ):
-        self._test_bitwise_tosa_MI_pipeline(operator, (tensor1, tensor2))
 
-    @parameterized.expand(full_test_suite)
-    def test_tosa_BI(
-        self,
-        test_name: str,
-        operator: Callable,
-        tensor1: torch.Tensor,
-        tensor2: torch.Tensor,
-    ):
-        self._test_bitwise_tosa_BI_pipeline(operator, (tensor1, tensor2))
+@common.parametrize("test_data", Xor().test_data)
+def test_bitwise_xor_tensor_tosa_BI(test_data: input_t2):
+    pipeline = TosaPipelineBI[input_t2](Xor(), test_data, Xor().aten_op, Xor().exir_op)
+    pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
+    pipeline.run()
 
-    @parameterized.expand(full_test_suite)
-    def test_tosa_u55_BI(
-        self,
-        test_name: str,
-        operator: Callable,
-        tensor1: torch.Tensor,
-        tensor2: torch.Tensor,
-    ):
-        self._test_bitwise_tosa_u55_BI_pipeline(operator, (tensor1, tensor2))
 
-    @parameterized.expand(full_test_suite)
-    def test_tosa_u85_BI(
-        self,
-        test_name: str,
-        operator: Callable,
-        tensor1: torch.Tensor,
-        tensor2: torch.Tensor,
-    ):
-        self._test_bitwise_tosa_u85_BI_pipeline(operator, (tensor1, tensor2))
+@common.parametrize("test_data", Xor().test_data)
+def test_bitwise_xor_tensor_u55_BI(test_data: input_t2):
+    # Tests that we don't delegate these ops since they are not supported on U55.
+    pipeline = OpNotSupportedPipeline[input_t2](
+        Xor(), test_data, "TOSA-0.80+BI+u55", {Xor().exir_op: 1}
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", Xor().test_data)
+@pytest.mark.xfail(reason="MLETORCH-706: Support ScalarType::Bool in EthosUBackend.")
+@common.XfailIfNoCorstone320
+def test_bitwise_xor_tensor_u85_BI(test_data: input_t2):
+    pipeline = EthosU85PipelineBI[input_t2](
+        Xor(), test_data, Xor().aten_op, Xor().exir_op, run_on_fvp=True
+    )
+    pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
+    pipeline.run()
+
+
+@common.parametrize("test_data", Or().test_data)
+def test_bitwise_or_tensor_tosa_MI(test_data: input_t2):
+    pipeline = TosaPipelineMI[input_t2](Or(), test_data, Or().aten_op, Or().exir_op)
+    pipeline.run()
+
+
+@common.parametrize("test_data", Or().test_data)
+def test_bitwise_or_tensor_tosa_BI(test_data: input_t2):
+    pipeline = TosaPipelineBI[input_t2](Or(), test_data, Or().aten_op, Or().exir_op)
+    pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
+    pipeline.run()
+
+
+@common.parametrize("test_data", Or().test_data)
+def test_bitwise_or_tensor_u55_BI(test_data: input_t2):
+    # Tests that we don't delegate these ops since they are not supported on U55.
+    pipeline = OpNotSupportedPipeline[input_t2](
+        Or(), test_data, "TOSA-0.80+BI+u55", {Or().exir_op: 1}
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", Or().test_data)
+@pytest.mark.xfail(reason="MLETORCH-706: Support ScalarType::Bool in EthosUBackend.")
+@common.XfailIfNoCorstone320
+def test_bitwise_or_tensor_u85_BI(test_data: input_t2):
+    pipeline = EthosU85PipelineBI[input_t2](
+        Or(), test_data, Or().aten_op, Or().exir_op, run_on_fvp=True
+    )
+    pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
+    pipeline.run()

--- a/backends/arm/test/ops/test_logical.py
+++ b/backends/arm/test/ops/test_logical.py
@@ -6,6 +6,7 @@
 
 from typing import Tuple
 
+import pytest
 import torch
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import (
@@ -16,7 +17,32 @@ from executorch.backends.arm.test.tester.test_pipeline import (
 )
 
 
-class And(torch.nn.Module):
+input_t2 = Tuple[torch.Tensor, torch.Tensor]  # Input x, y
+input_t1 = Tuple[torch.Tensor]  # Input x
+
+
+class LogicalBinary(torch.nn.Module):
+    test_data: dict[input_t2] = {
+        "rank1": (
+            torch.tensor([True, True, False, False], dtype=torch.bool),
+            torch.tensor([True, False, True, False], dtype=torch.bool),
+        ),
+        "rand_rank2": (
+            torch.randint(0, 2, (10, 10), dtype=torch.bool),
+            torch.randint(0, 2, (10, 10), dtype=torch.bool),
+        ),
+        "rand_rank3": (
+            torch.randint(0, 2, (10, 10, 10), dtype=torch.bool),
+            torch.randint(0, 2, (10, 10, 10), dtype=torch.bool),
+        ),
+        "rand_rank4": (
+            torch.randint(0, 2, (1, 10, 10, 10), dtype=torch.bool),
+            torch.randint(0, 2, (1, 10, 10, 10), dtype=torch.bool),
+        ),
+    }
+
+
+class And(LogicalBinary):
     aten_op = "torch.ops.aten.logical_and.default"
     exir_op = "executorch_exir_dialects_edge__ops_aten_logical_and_default"
 
@@ -24,7 +50,7 @@ class And(torch.nn.Module):
         return tensor1.logical_and(tensor2)
 
 
-class Xor(torch.nn.Module):
+class Xor(LogicalBinary):
     aten_op = "torch.ops.aten.logical_xor.default"
     exir_op = "executorch_exir_dialects_edge__ops_aten_logical_xor_default"
 
@@ -32,7 +58,7 @@ class Xor(torch.nn.Module):
         return tensor1.logical_xor(tensor2)
 
 
-class Or(torch.nn.Module):
+class Or(LogicalBinary):
     aten_op = "torch.ops.aten.logical_or.default"
     exir_op = "executorch_exir_dialects_edge__ops_aten_logical_or_default"
 
@@ -41,6 +67,13 @@ class Or(torch.nn.Module):
 
 
 class Not(torch.nn.Module):
+    test_data: dict[input_t1] = {
+        "rank1": (torch.tensor([True, True, False, False], dtype=torch.bool),),
+        "rand_rank2": (torch.randint(0, 2, (10, 10), dtype=torch.bool),),
+        "rand_rank3": (torch.randint(0, 2, (10, 10, 10), dtype=torch.bool),),
+        "rand_rank4": (torch.randint(0, 2, (1, 10, 10, 10), dtype=torch.bool),),
+    }
+
     aten_op = "torch.ops.aten.logical_not.default"
     exir_op = "executorch_exir_dialects_edge__ops_aten_logical_not_default"
 
@@ -48,113 +81,141 @@ class Not(torch.nn.Module):
         return torch.logical_not(tensor)
 
 
-input_t2 = Tuple[torch.Tensor, torch.Tensor]  # Input x, y
-
-
-test_input: dict[input_t2] = {
-    "rank1": (
-        torch.tensor([True, True, False, False], dtype=torch.bool),
-        torch.tensor([True, False, True, False], dtype=torch.bool),
-    ),
-    "rand_rank2": (
-        torch.randint(0, 2, (10, 10), dtype=torch.bool),
-        torch.randint(0, 2, (10, 10), dtype=torch.bool),
-    ),
-    "rand_rank3": (
-        torch.randint(0, 2, (10, 10, 10), dtype=torch.bool),
-        torch.randint(0, 2, (10, 10, 10), dtype=torch.bool),
-    ),
-    "rand_rank4": (
-        torch.randint(0, 2, (1, 10, 10, 10), dtype=torch.bool),
-        torch.randint(0, 2, (1, 10, 10, 10), dtype=torch.bool),
-    ),
-}
-
-
-test_data = {
-    "not_rank1": (Not(), test_input["rank1"][:-1]),
-    "not_rand_rank2": (Not(), test_input["rand_rank2"][:-1]),
-    "not_rand_rank3": (Not(), test_input["rand_rank3"][:-1]),
-    "not_rand_rank4": (Not(), test_input["rand_rank4"][:-1]),
-    "and_rank1": (And(), test_input["rank1"]),
-    "and_rand_rank2": (And(), test_input["rand_rank2"]),
-    "and_rand_rank3": (And(), test_input["rand_rank3"]),
-    "and_rand_rank4": (And(), test_input["rand_rank4"]),
-    "xor_rank1": (Xor(), test_input["rank1"]),
-    "xor_rand_rank2": (Xor(), test_input["rand_rank2"]),
-    "xor_rand_rank3": (Xor(), test_input["rand_rank3"]),
-    "xor_rand_rank4": (Xor(), test_input["rand_rank4"]),
-    "or_rank1": (Or(), test_input["rank1"]),
-    "or_rand_rank2": (Or(), test_input["rand_rank2"]),
-    "or_rand_rank3": (Or(), test_input["rand_rank3"]),
-    "or_rand_rank4": (Or(), test_input["rand_rank4"]),
-}
-
-
-fvp_xfails = {
-    "not_rank1": "MLETORCH-706 Support ScalarType::Bool in EthosUBackend.",
-    "not_rand_rank2": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "not_rand_rank3": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "not_rand_rank4": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "and_rank1": "MLETORCH-706 Support ScalarType::Bool in EthosUBackend.",
-    "and_rand_rank2": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "and_rand_rank3": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "and_rand_rank4": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "xor_rank1": "MLETORCH-706 Support ScalarType::Bool in EthosUBackend.",
-    "xor_rand_rank2": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "xor_rand_rank3": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "xor_rand_rank4": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "or_rank1": "MLETORCH-706 Support ScalarType::Bool in EthosUBackend.",
-    "or_rand_rank2": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "or_rand_rank3": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-    "or_rand_rank4": "MLETORCH-706: Support ScalarType::Bool in EthosUBackend.",
-}
-
-
-@common.parametrize("test_data", test_data)
-def test_logical_tosa_MI(test_data: input_t2):
-    op, test_input = test_data
-    pipeline = TosaPipelineMI[input_t2](op, test_input, op.aten_op, op.exir_op)
+@common.parametrize("test_data", And().test_data)
+def test_logical_and_tosa_MI(test_data: input_t2):
+    pipeline = TosaPipelineMI[input_t2](And(), test_data, And().aten_op, And().exir_op)
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data)
-def test_logical_tosa_BI(test_data: input_t2):
-    op, test_input = test_data
-    pipeline = TosaPipelineBI[input_t2](op, test_input, op.aten_op, op.exir_op)
-    pipeline.pop_stage(pipeline.find_pos("quantize") + 1)
+@common.parametrize("test_data", And().test_data)
+def test_logical_and_tosa_BI(test_data: input_t2):
+    pipeline = TosaPipelineBI[input_t2](And(), test_data, And().aten_op, And().exir_op)
     pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data)
-def test_logical_u55_BI(test_data: input_t2):
+@common.parametrize("test_data", And().test_data)
+def test_logical_and_u55_BI(test_data: input_t2):
     # Tests that we don't delegate these ops since they are not supported on U55.
-    op, test_input = test_data
     pipeline = OpNotSupportedPipeline[input_t2](
-        op, test_input, "TOSA-0.80+BI+u55", {op.exir_op: 1}
+        And(), test_data, "TOSA-0.80+BI+u55", {And().exir_op: 1}
     )
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data)
-def test_logical_u85_BI(test_data: input_t2):
-    op, test_input = test_data
+@common.parametrize("test_data", And().test_data)
+@pytest.mark.xfail(reason="MLETORCH-706: Support ScalarType::Bool in EthosUBackend.")
+@common.XfailIfNoCorstone320
+def test_logical_and_u85_BI(test_data: input_t2):
     pipeline = EthosU85PipelineBI[input_t2](
-        op, test_input, op.aten_op, op.exir_op, run_on_fvp=False
+        And(), test_data, And().aten_op, And().exir_op, run_on_fvp=True
     )
-    pipeline.pop_stage(pipeline.find_pos("quantize") + 1)
     pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data, fvp_xfails)
-@common.SkipIfNoCorstone320
-def test_logical_u85_BI_on_fvp(test_data: input_t2):
-    op, test_input = test_data
-    pipeline = EthosU85PipelineBI[input_t2](
-        op, test_input, op.aten_op, op.exir_op, run_on_fvp=True
-    )
-    pipeline.pop_stage(pipeline.find_pos("quantize") + 1)
+@common.parametrize("test_data", Xor().test_data)
+def test_logical_xor_tosa_MI(test_data: input_t2):
+    pipeline = TosaPipelineMI[input_t2](Xor(), test_data, Xor().aten_op, Xor().exir_op)
+    pipeline.run()
+
+
+@common.parametrize("test_data", Xor().test_data)
+def test_logical_xor_tosa_BI(test_data: input_t2):
+    pipeline = TosaPipelineBI[input_t2](Xor(), test_data, Xor().aten_op, Xor().exir_op)
     pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
+    pipeline.run()
+
+
+@common.parametrize("test_data", Xor().test_data)
+def test_logical_xor_u55_BI(test_data: input_t2):
+    # Tests that we don't delegate these ops since they are not supported on U55.
+    pipeline = OpNotSupportedPipeline[input_t2](
+        Xor(), test_data, "TOSA-0.80+BI+u55", {Xor().exir_op: 1}
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", Xor().test_data)
+@pytest.mark.xfail(reason="MLETORCH-706: Support ScalarType::Bool in EthosUBackend.")
+@common.XfailIfNoCorstone320
+def test_logical_xor_u85_BI(test_data: input_t2):
+    pipeline = EthosU85PipelineBI[input_t2](
+        Xor(), test_data, Xor().aten_op, Xor().exir_op, run_on_fvp=True
+    )
+    pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
+    pipeline.run()
+
+
+@common.parametrize("test_data", Or().test_data)
+def test_logical_or_tosa_MI(test_data: input_t2):
+    pipeline = TosaPipelineMI[input_t2](Or(), test_data, Or().aten_op, Or().exir_op)
+    pipeline.run()
+
+
+@common.parametrize("test_data", Or().test_data)
+def test_logical_or_tosa_BI(test_data: input_t2):
+    pipeline = TosaPipelineBI[input_t2](Or(), test_data, Or().aten_op, Or().exir_op)
+    pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
+    pipeline.run()
+
+
+@common.parametrize("test_data", Or().test_data)
+def test_logical_or_u55_BI(test_data: input_t2):
+    # Tests that we don't delegate these ops since they are not supported on U55.
+    pipeline = OpNotSupportedPipeline[input_t2](
+        Or(), test_data, "TOSA-0.80+BI+u55", {Or().exir_op: 1}
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", Or().test_data)
+@pytest.mark.xfail(reason="MLETORCH-706: Support ScalarType::Bool in EthosUBackend.")
+@common.XfailIfNoCorstone320  # TODO: Refactor to use XfailIfNoCorstone320 once MLETORCH-706 is done
+def test_logical_or_u85_BI(test_data: input_t2):
+    pipeline = EthosU85PipelineBI[input_t2](
+        Or(), test_data, Or().aten_op, Or().exir_op, run_on_fvp=True
+    )
+    pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
+    pipeline.run()
+
+
+@common.parametrize("test_data", Not().test_data)
+def test_logical_not_tosa_MI(test_data: input_t2):
+    pipeline = TosaPipelineMI[input_t2](Not(), test_data, Not().aten_op, Not().exir_op)
+    pipeline.run()
+
+
+@common.parametrize("test_data", Not().test_data)
+def test_logical_not_tosa_BI(test_data: input_t2):
+    pipeline = TosaPipelineBI[input_t2](Not(), test_data, Not().aten_op, Not().exir_op)
+    pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
+    pipeline.run()
+
+
+@common.parametrize("test_data", Not().test_data)
+def test_logical_not_u55_BI(test_data: input_t2):
+    # Tests that we don't delegate these ops since they are not supported on U55.
+    pipeline = OpNotSupportedPipeline[input_t2](
+        Not(), test_data, "TOSA-0.80+BI+u55", {Not().exir_op: 1}
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", Not().test_data)
+@pytest.mark.xfail(reason="MLETORCH-706: Support ScalarType::Bool in EthosUBackend.")
+@common.XfailIfNoCorstone320
+def test_logical_not_u85_BI(test_data: input_t2):
+    pipeline = EthosU85PipelineBI[input_t2](
+        Not(), test_data, Not().aten_op, Not().exir_op, run_on_fvp=True
+    )
+    pipeline.pop_stage("quantize")
+    pipeline.pop_stage("check.quant_nodes")
     pipeline.run()


### PR DESCRIPTION
- Rename bitwise and logical tests with full aten op name
- Refactor the tests with test_pipeline and new Xfail decorator
- Fix the naming error in test_any

Change-Id: I9b281f0a224280dca7609321594d0ed2f4fdb63c


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218