### PR TITLE
Run setup-macos.sh in unittest-macos even in Buck mode

### DIFF
--- a/.ci/scripts/unittest-macos.sh
+++ b/.ci/scripts/unittest-macos.sh
@@ -19,14 +19,14 @@ export TMP_DIR=$(mktemp -d)
 export PATH="${TMP_DIR}:$PATH"
 trap 'rm -rfv ${TMP_DIR}' EXIT
 
-if [[ "$BUILD_TOOL" == "cmake" ]]; then
-    # Setup MacOS dependencies as there is no Docker support on MacOS atm
-    PYTHON_EXECUTABLE=python \
-    EXECUTORCH_BUILD_PYBIND=ON \
-    CMAKE_ARGS="-DEXECUTORCH_BUILD_COREML=ON -DEXECUTORCH_BUILD_MPS=ON -DEXECUTORCH_BUILD_XNNPACK=ON -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON" \
-    ${CONDA_RUN} --no-capture-output \
-    .ci/scripts/setup-macos.sh "$@"
+# Setup MacOS dependencies as there is no Docker support on MacOS atm
+PYTHON_EXECUTABLE=python \
+EXECUTORCH_BUILD_PYBIND=ON \
+CMAKE_ARGS="-DEXECUTORCH_BUILD_COREML=ON -DEXECUTORCH_BUILD_MPS=ON -DEXECUTORCH_BUILD_XNNPACK=ON -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON" \
+${CONDA_RUN} --no-capture-output \
+.ci/scripts/setup-macos.sh "$@"
 
+if [[ "$BUILD_TOOL" == "cmake" ]]; then
     # Install llama3_2_vision dependencies.
     PYTHON_EXECUTABLE=python \
     ${CONDA_RUN} --no-capture-output \
@@ -34,10 +34,6 @@ if [[ "$BUILD_TOOL" == "cmake" ]]; then
 
     .ci/scripts/unittest-macos-cmake.sh
 elif [[ "$BUILD_TOOL" == "buck2" ]]; then
-    (
-        source .ci/scripts/utils.sh
-        install_pytorch_and_domains
-    )
     .ci/scripts/unittest-buck2.sh
     # .ci/scripts/unittest-macos-buck2.sh
 else

--- a/.ci/scripts/unittest-macos.sh
+++ b/.ci/scripts/unittest-macos.sh
@@ -34,6 +34,10 @@ if [[ "$BUILD_TOOL" == "cmake" ]]; then
 
     .ci/scripts/unittest-macos-cmake.sh
 elif [[ "$BUILD_TOOL" == "buck2" ]]; then
+    (
+        source .ci/scripts/utils.sh
+        install_pytorch_and_domains
+    )
     .ci/scripts/unittest-buck2.sh
     # .ci/scripts/unittest-macos-buck2.sh
 else


### PR DESCRIPTION
We've been seeing flakes due to missing torchgen that have become more common. After some investigation, it appears that #8688 was probably overzealous: installing pytorch was probably also installing torchgen, so let's ~~install pytorch~~just run the macos setup script to avoid proliferating configurations.

Test Plan: unittest-buck / macos on this PR, monitor to see if failures go away.