### PR TITLE
Remove NTSTATUS cast

### DIFF
--- a/extension/data_loader/mman_windows.cpp
+++ b/extension/data_loader/mman_windows.cpp
@@ -24,7 +24,7 @@
 #include <windows.h>
 
 #ifndef STATUS_SECTION_TOO_BIG
-#define STATUS_SECTION_TOO_BIG ((NTSTATUS)0xC0000040L)
+#define STATUS_SECTION_TOO_BIG 0xC0000040L
 #endif
 
 #ifndef FILE_MAP_EXECUTE


### PR DESCRIPTION
Summary: This cast isn't necessary and is breaking some Windows builds as this type isn't actually exposed.

Differential Revision: D70995368


