### PR TITLE
Support channels_last format in portable upsample kernels

### DIFF
--- a/kernels/portable/cpu/op_upsample_bilinear2d.cpp
+++ b/kernels/portable/cpu/op_upsample_bilinear2d.cpp
@@ -20,7 +20,7 @@ using executorch::aten::SizesType;
 
 namespace {
 template <typename CTYPE>
-void upsample_bilinear2d_kernel_impl(
+void upsample_bilinear2d_kernel_impl_nchw(
     const Tensor& in,
     bool align_corners,
     const float scale_h,
@@ -86,6 +86,99 @@ void upsample_bilinear2d_kernel_impl(
     }
   }
 }
+
+template <typename CTYPE>
+void upsample_bilinear2d_kernel_impl_nhwc(
+    const Tensor& in,
+    bool align_corners,
+    const float scale_h,
+    const float scale_w,
+    Tensor& out) {
+  auto in_data = in.const_data_ptr<CTYPE>();
+  auto out_data = out.mutable_data_ptr<CTYPE>();
+
+  for ([[maybe_unused]] const auto n : c10::irange(out.size(0))) {
+    for (const auto h : c10::irange(out.size(2))) {
+      // Compute source index and weights.
+      int64_t in_h1, in_h2;
+      float weight_h, inv_weight_h;
+
+      compute_source_index_and_lambda(
+          in_h1,
+          in_h2,
+          weight_h,
+          inv_weight_h,
+          scale_h,
+          h,
+          in.sizes()[2],
+          out.sizes()[2],
+          align_corners);
+
+      for (const auto w : c10::irange(out.size(3))) {
+        int64_t in_w1, in_w2;
+        float weight_w, inv_weight_w;
+
+        compute_source_index_and_lambda(
+            in_w1,
+            in_w2,
+            weight_w,
+            inv_weight_w,
+            scale_w,
+            w,
+            in.sizes()[3],
+            out.sizes()[3],
+            align_corners);
+
+        for ([[maybe_unused]] const auto c : c10::irange(out.size(1))) {
+          const auto top_left = in_data
+              [in_h1 * in.strides()[2] + in_w1 * in.strides()[3] +
+               c * in.strides()[1]];
+          const auto top_right = in_data
+              [in_h1 * in.strides()[2] + in_w2 * in.strides()[3] +
+               c * in.strides()[1]];
+          const auto bottom_left = in_data
+              [in_h2 * in.strides()[2] + in_w1 * in.strides()[3] +
+               c * in.strides()[1]];
+          const auto bottom_right = in_data
+              [in_h2 * in.strides()[2] + in_w2 * in.strides()[3] +
+               c * in.strides()[1]];
+
+          const auto top = top_left * weight_w + top_right * inv_weight_w;
+          const auto bottom =
+              bottom_left * weight_w + bottom_right * inv_weight_w;
+          const auto val = top * weight_h + bottom * inv_weight_h;
+
+          *out_data = val;
+          out_data++;
+        }
+      }
+    }
+
+    in_data += in.strides()[0];
+  }
+}
+
+template <typename CTYPE>
+void upsample_bilinear2d_kernel_impl(
+    KernelRuntimeContext& ctx,
+    const Tensor& in,
+    bool align_corners,
+    const float scale_h,
+    const float scale_w,
+    Tensor& out) {
+  if (is_contiguous_dim_order(in.dim_order().data(), in.dim_order().size())) {
+    upsample_bilinear2d_kernel_impl_nchw<CTYPE>(
+        in, align_corners, scale_h, scale_w, out);
+  } else if (is_channels_last_dim_order(
+                 in.dim_order().data(), in.dim_order().size())) {
+    upsample_bilinear2d_kernel_impl_nhwc<CTYPE>(
+        in, align_corners, scale_h, scale_w, out);
+  } else {
+    // Shouldn't be reachable because of args checks, but just in case.
+    ET_LOG(Error, "Unsupported dim order");
+    ctx.fail(Error::InvalidArgument);
+  }
+}
 } // namespace
 
 // Signatures are auto-generated, so disable pass-by-value lint.
@@ -101,7 +194,7 @@ Tensor& upsample_bilinear2d_vec_out(
   // Preconditions (checked in check_..._args):
   //  In and out tensors have same dtype.
   //  In and out tensors are rank 4 and have same dim[0] and dim[1].
-  //  In and out tensors are default dim order (NCHW).
+  //  In and out tensors are NHWC or NCHW dim order.
   ET_KERNEL_CHECK(
       ctx,
       check_upsample_bilinear2d_args(
@@ -127,7 +220,7 @@ Tensor& upsample_bilinear2d_vec_out(
   ET_SWITCH_REALHBF16_TYPES(
       in.scalar_type(), ctx, "upsample_bilinear2d.out", CTYPE, [&]() {
         upsample_bilinear2d_kernel_impl<CTYPE>(
-            in, align_corners, kernel_scale_h, kernel_scale_w, out);
+            ctx, in, align_corners, kernel_scale_h, kernel_scale_w, out);
       });
 
   return out;

--- a/kernels/portable/cpu/util/upsample_util.cpp
+++ b/kernels/portable/cpu/util/upsample_util.cpp
@@ -18,10 +18,11 @@ bool check_upsample_2d_common_args(
     const executorch::aten::OptionalArrayRef<double>& scale_factors,
     Tensor& out) {
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, out));
+  ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dim_order(in, out));
   ET_LOG_AND_RETURN_IF_FALSE(in.dim() == 4);
   ET_LOG_AND_RETURN_IF_FALSE(out.dim() == 4);
-  ET_LOG_AND_RETURN_IF_FALSE(tensor_is_default_dim_order(in));
-  ET_LOG_AND_RETURN_IF_FALSE(tensor_is_default_dim_order(out));
+  ET_LOG_AND_RETURN_IF_FALSE(tensor_is_default_or_channels_last_dim_order(in));
+  ET_LOG_AND_RETURN_IF_FALSE(tensor_is_default_or_channels_last_dim_order(out));
   ET_LOG_AND_RETURN_IF_FALSE(
       output_size.has_value() ^ scale_factors.has_value());
   if (scale_factors.has_value()) {

--- a/kernels/test/op_upsample_nearest2d_test.cpp
+++ b/kernels/test/op_upsample_nearest2d_test.cpp
@@ -411,3 +411,37 @@ TEST_F(OpUpsampleNearest2dTest, ZeroComputedOutputSizeDies) {
               {scale_factors.data(), scale_factors.size()}),
           out));
 }
+
+TEST_F(OpUpsampleNearest2dTest, SmokeTestChannelsLast) {
+  TensorFactory<ScalarType::Float> tf;
+
+  const auto input = tf.make_channels_last(
+      {1, 2, 2, 2},
+      {
+          0.1,
+          2.1,
+          0.2,
+          2.2,
+          1.1,
+          3.1,
+          1.2,
+          3.2,
+      });
+  std::array<int64_t, 2> output_size = {4, 4};
+  auto out = tf.zeros_channels_last({1, 2, 4, 4});
+
+  op_upsample_nearest2d_out(
+      input,
+      OptionalArrayRef<int64_t>({output_size.data(), output_size.size()}),
+      {},
+      out);
+
+  const auto expected = tf.make_channels_last(
+      {1, 2, 4, 4},
+      {0.1000, 2.1000, 0.1000, 2.1000, 0.2000, 2.2000, 0.2000, 2.2000,
+       0.1000, 2.1000, 0.1000, 2.1000, 0.2000, 2.2000, 0.2000, 2.2000,
+       1.1000, 3.1000, 1.1000, 3.1000, 1.2000, 3.2000, 1.2000, 3.2000,
+       1.1000, 3.1000, 1.1000, 3.1000, 1.2000, 3.2000, 1.2000, 3.2000});
+
+  EXPECT_TENSOR_EQ(out, expected);
+}

--- a/runtime/core/exec_aten/testing_util/tensor_factory.h
+++ b/runtime/core/exec_aten/testing_util/tensor_factory.h
@@ -452,8 +452,8 @@ class TensorFactory {
   }
 
   /**
-   * Returns a new Tensor with the specified shape, containing contiguous data
-   * with all `0` elements.
+   * Returns a new Tensor with the specified shape, containing channels-last
+   * contiguous data with all `0` elements.
    *
    * @param[in] sizes The sizes of the dimensions of the Tensor.
    * @return A new Tensor with the specified shape.
@@ -464,6 +464,22 @@ class TensorFactory {
           TensorShapeDynamism::DYNAMIC_UNBOUND) {
     auto sizes64 = vec_32_to_64(sizes);
     return at::zeros(at::IntArrayRef(sizes64), at::dtype(DTYPE));
+  }
+
+  /**
+   * Returns a new Tensor with the specified shape, containing contiguous data
+   * with all `0` elements.
+   *
+   * @param[in] sizes The sizes of the dimensions of the Tensor.
+   * @return A new Tensor with the specified shape.
+   */
+  at::Tensor zeros_channels_last(
+      const std::vector<int32_t>& sizes,
+      ET_UNUSED TensorShapeDynamism dynamism =
+          TensorShapeDynamism::DYNAMIC_UNBOUND) {
+    auto sizes64 = vec_32_to_64(sizes);
+    return at::zeros(at::IntArrayRef(sizes64), at::dtype(DTYPE))
+        .to(at::MemoryFormat::ChannelsLast);
   }
 
   /**


### PR DESCRIPTION
Summary:
Support channels_last input format in portable CPU upsample_bilinear2d and upsample_nearest2d kernels. This is useful for resize-in-model patterns when the user wants to pass inputs in channels_last format. It also (theoretically) allows for more effective auto-vectorization when vectorizing along the channels dim when there are a larger number of channels.

I considered generalizing the kernel to handle arbitrary dim order, but having a specialized channels last version allows for traversing the output in contiguous order. I could add a separate, arbitrarily-strided variant, but we can take that as a follow-up if needed.

To accomplish this, this PR makes the following changes:
- Update `check_upsample_2d_common_args` to relax the dim order restriction. It now allows for both default and channels_last dim order and verifies that the output dim order matches the input.
- In the upsample kernels (bilinear and nearest), split out NCHW and NHWC variants. The NHWC variant interchanges the loop order as to maintain contiguous output accesses.
- Add test coverage to ensure ATen numerical parity.

Differential Revision: D71690379




cc @larryliu0820 @manuelcandales