### PR TITLE
[build Folder Migration] Alert for core scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ __pycache__/
 arm_test/
 buck-out/
 buck2-bin/
-build/
+# build/
 cmake-android-out/
 cmake-ios-out/
 cmake-out*

--- a/build/build_android_library.sh
+++ b/build/build_android_library.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eu
+
+current_file=$(basename "$0")
+echo -e "\033[31m[error] $0 has moved to:\033[0m scripts/${current_file}"
+exit 1

--- a/build/build_apple_frameworks.sh
+++ b/build/build_apple_frameworks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eu
+
+current_file=$(basename "$0")
+echo -e "\033[31m[error] $0 has moved to:\033[0m scripts/${current_file}"
+exit 1

--- a/build/build_apple_llm_demo.sh
+++ b/build/build_apple_llm_demo.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eu
+
+current_file=$(basename "$0")
+echo -e "\033[31m[error] $0 has moved to:\033[0m scripts/${current_file}"
+exit 1

--- a/build/create_frameworks.sh
+++ b/build/create_frameworks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eu
+
+current_file=$(basename "$0")
+echo -e "\033[31m[error] $0 has moved to:\033[0m scripts/${current_file}"
+exit 1

--- a/build/print_exported_headers.py
+++ b/build/print_exported_headers.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+
+current_file=os.path.basename(__file__)
+print(f"\033[31m[error] build/{current_file} has moved to:\033[0m scripts/{current_file}")
+sys.exit(1)

--- a/build/run_android_emulator.sh
+++ b/build/run_android_emulator.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eu
+
+current_file=$(basename "$0")
+echo -e "\033[31m[error] $0 has moved to:\033[0m scripts/${current_file}"
+exit 1

--- a/build/test_ios.sh
+++ b/build/test_ios.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eu
+
+current_file=$(basename "$0")
+echo -e "\033[31m[error] $0 has moved to:\033[0m scripts/${current_file}"
+exit 1


### PR DESCRIPTION
### Summary
Given the move in https://github.com/pytorch/executorch/pull/9434, lets keep the scripts around for a week before deleting them.

### Test plan
Ran them.

```
$ build/build_android_library.sh

[error] build/build_android_library.sh has moved to: scripts/build_android_library.sh
```