### PR TITLE
Add missing etdump dependency

### DIFF
--- a/examples/portable/executor_runner/targets.bzl
+++ b/examples/portable/executor_runner/targets.bzl
@@ -15,6 +15,7 @@ def define_common_targets():
         srcs = ["executor_runner.cpp"],
         deps = [
             "//executorch/runtime/executor:program",
+            "//executorch/devtools/etdump:etdump_flatcc",
             "//executorch/extension/data_loader:file_data_loader",
             "//executorch/extension/evalue_util:print_evalue",
             "//executorch/extension/runner_util:inputs",

--- a/tools/cmake/cmake_deps.toml
+++ b/tools/cmake/cmake_deps.toml
@@ -296,6 +296,7 @@ deps = [
   "executorch_core",
   "portable_kernels",
   "quantized_kernels",
+  "etdump_flatcc",
 ]
 
 [targets.size_test]
@@ -369,6 +370,7 @@ deps = [
   "extension_threadpool",
   "xnnpack_backend",
   "portable_kernels",
+  "etdump_flatcc",
 ]
 
 [targets.xnnpack_backend]
@@ -462,3 +464,12 @@ deps = [
   "optimized_native_cpu_ops",
 ]
 # ---------------------------------- LLama end ----------------------------------
+# ---------------------------------- devtools start ----------------------------------
+[targets.etdump_flatcc]
+buck_targets = [
+  "//devtools/etdump:etdump_flatcc",
+]
+filters = [
+  ".cpp$",
+]
+# ---------------------------------- devtools end ----------------------------------


### PR DESCRIPTION
Summary: etdump was enabled by OSS change D62419385 but BUCK dependency is missing.

Differential Revision: D71742532


