### PR TITLE
Reset Dynamo at Setup for all tests

### DIFF
--- a/backends/xnnpack/test/models/deeplab_v3.py
+++ b/backends/xnnpack/test/models/deeplab_v3.py
@@ -23,6 +23,9 @@ class DL3Wrapper(torch.nn.Module):
 
 
 class TestDeepLabV3(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     dl3 = DL3Wrapper()
     dl3 = dl3.eval()
     model_inputs = (torch.randn(1, 3, 224, 224),)

--- a/backends/xnnpack/test/models/edsr.py
+++ b/backends/xnnpack/test/models/edsr.py
@@ -14,6 +14,9 @@ from torchsr.models import edsr_r16f64
 
 
 class TestEDSR(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     edsr = edsr_r16f64(2, False).eval()  # noqa
     model_inputs = (torch.randn(1, 3, 224, 224),)
 

--- a/backends/xnnpack/test/models/emformer_rnnt.py
+++ b/backends/xnnpack/test/models/emformer_rnnt.py
@@ -13,6 +13,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestEmformerModel(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class EmformerRnnt(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/models/inception_v3.py
+++ b/backends/xnnpack/test/models/inception_v3.py
@@ -13,6 +13,9 @@ from torchvision import models
 
 
 class TestInceptionV3(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     ic3 = models.inception_v3(weights="IMAGENET1K_V1").eval()  # noqa
     model_inputs = (torch.randn(1, 3, 224, 224),)
 

--- a/backends/xnnpack/test/models/inception_v4.py
+++ b/backends/xnnpack/test/models/inception_v4.py
@@ -12,6 +12,9 @@ from timm.models import inception_v4
 
 
 class TestInceptionV4(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     ic4 = inception_v4(pretrained=False).eval()
     model_inputs = (torch.randn(3, 299, 299).unsqueeze(0),)
 

--- a/backends/xnnpack/test/models/llama2_et_example.py
+++ b/backends/xnnpack/test/models/llama2_et_example.py
@@ -13,6 +13,9 @@ from executorch.examples.models.llama.model import Llama2Model
 
 
 class TestLlama2ETExample(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     def test_f32(self):
         self._test()
 

--- a/backends/xnnpack/test/models/mobilebert.py
+++ b/backends/xnnpack/test/models/mobilebert.py
@@ -12,6 +12,9 @@ from transformers import MobileBertConfig, MobileBertModel  # @manual
 
 
 class TestMobilebert(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     # pyre-ignore
     mobilebert = MobileBertModel(MobileBertConfig()).eval()
     example_inputs = (torch.tensor([[101, 7592, 1010, 2026, 3899, 2003, 10140, 102]]),)

--- a/backends/xnnpack/test/models/mobilenet_v2.py
+++ b/backends/xnnpack/test/models/mobilenet_v2.py
@@ -14,6 +14,9 @@ from torchvision.models.mobilenetv2 import MobileNet_V2_Weights
 
 
 class TestMobileNetV2(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     mv2 = models.mobilenetv2.mobilenet_v2(weights=MobileNet_V2_Weights)
     mv2 = mv2.eval()
     model_inputs = (torch.randn(1, 3, 224, 224),)

--- a/backends/xnnpack/test/models/mobilenet_v3.py
+++ b/backends/xnnpack/test/models/mobilenet_v3.py
@@ -13,6 +13,9 @@ from torchvision import models
 
 
 class TestMobileNetV3(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     mv3 = models.mobilenetv3.mobilenet_v3_small(pretrained=True)
     mv3 = mv3.eval()
     model_inputs = (torch.randn(1, 3, 224, 224),)

--- a/backends/xnnpack/test/models/resnet.py
+++ b/backends/xnnpack/test/models/resnet.py
@@ -13,6 +13,9 @@ from executorch.backends.xnnpack.test.tester import Quantize, Tester
 
 
 class TestResNet18(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     inputs = (torch.randn(1, 3, 224, 224),)
     dynamic_shapes = (
         {

--- a/backends/xnnpack/test/models/torchvision_vit.py
+++ b/backends/xnnpack/test/models/torchvision_vit.py
@@ -12,6 +12,9 @@ from torchvision import models
 
 
 class TestViT(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     vit = models.vision_transformer.vit_b_16(weights="IMAGENET1K_V1")
     vit = vit.eval()
     model_inputs = (torch.randn(1, 3, 224, 224),)

--- a/backends/xnnpack/test/models/very_big_model.py
+++ b/backends/xnnpack/test/models/very_big_model.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestVeryBigModel(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class BigModel(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/models/w2l.py
+++ b/backends/xnnpack/test/models/w2l.py
@@ -12,6 +12,9 @@ from torchaudio import models
 
 
 class TestW2L(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     batch_size = 10
     input_frames = 700
     vocab_size = 4096

--- a/backends/xnnpack/test/ops/test_abs.py
+++ b/backends/xnnpack/test/ops/test_abs.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestAbs(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Abs(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_add.py
+++ b/backends/xnnpack/test/ops/test_add.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Quantize, Tester
 
 
 class TestAdd(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Add(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_avgpool2d.py
+++ b/backends/xnnpack/test/ops/test_avgpool2d.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestAvgPool2d(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class AvgPool2d(torch.nn.Module):
         def __init__(
             self, count_include_pad=False, ceil_mode=False, divisor_override=None

--- a/backends/xnnpack/test/ops/test_bilinear2d.py
+++ b/backends/xnnpack/test/ops/test_bilinear2d.py
@@ -14,6 +14,9 @@ from executorch.backends.xnnpack.test.tester.tester import Export
 
 
 class TestUpsampleBilinear2d(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class StaticResizeBilinear2dModule(torch.nn.Module):
         def forward(self, x):
             a = torch.nn.functional.interpolate(

--- a/backends/xnnpack/test/ops/test_bmm.py
+++ b/backends/xnnpack/test/ops/test_bmm.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestBMM(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class BMM(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_cat.py
+++ b/backends/xnnpack/test/ops/test_cat.py
@@ -13,6 +13,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestCat(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Cat(torch.nn.Module):
         def __init__(self, dim=0):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_ceil.py
+++ b/backends/xnnpack/test/ops/test_ceil.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestCeil(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Ceil(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_check_quant_params.py
+++ b/backends/xnnpack/test/ops/test_check_quant_params.py
@@ -49,6 +49,7 @@ class TestCheckQuantParams(unittest.TestCase):
         return inject_invalid_scale_in_per_tensor
 
     def _test_check_quant_message(self, ep_modifier, expected_message):
+        torch._dynamo.reset()
         mod = torch.nn.Linear(10, 10)
         quantizer = XNNPACKQuantizer()
         captured = export_for_training(mod, (torch.randn(1, 10),)).module()

--- a/backends/xnnpack/test/ops/test_check_quant_params.py
+++ b/backends/xnnpack/test/ops/test_check_quant_params.py
@@ -14,6 +14,9 @@ from torch.export import export_for_training
 
 
 class TestCheckQuantParams(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     def create_invalid_value_injector(
         self, invalid_value, is_per_channel=False, is_zp=False
     ):

--- a/backends/xnnpack/test/ops/test_clamp.py
+++ b/backends/xnnpack/test/ops/test_clamp.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestClamp(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Clamp(torch.nn.Module):
         def __init__(self, min_val=None, max_val=None):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_conv1d.py
+++ b/backends/xnnpack/test/ops/test_conv1d.py
@@ -19,6 +19,9 @@ from executorch.exir.passes.constant_prop_pass import constant_prop_pass
 
 
 class TestConv1d(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Conv1d(torch.nn.Module):
         def __init__(self, dtype: torch.dtype = torch.float):
             groups = 1

--- a/backends/xnnpack/test/ops/test_conv2d.py
+++ b/backends/xnnpack/test/ops/test_conv2d.py
@@ -170,6 +170,9 @@ class Conv2dPermute(torch.nn.Module):
 
 
 class TestConv2d(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     def _test(
         self,
         m: torch.nn.Module,

--- a/backends/xnnpack/test/ops/test_div.py
+++ b/backends/xnnpack/test/ops/test_div.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestDiv(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Div(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_elu.py
+++ b/backends/xnnpack/test/ops/test_elu.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestElu(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class ELU(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_floor.py
+++ b/backends/xnnpack/test/ops/test_floor.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestFloor(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Floor(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_hardswish.py
+++ b/backends/xnnpack/test/ops/test_hardswish.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestHardswish(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Hardswish(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_hardtanh.py
+++ b/backends/xnnpack/test/ops/test_hardtanh.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestHardTanh(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class HardTanh(torch.nn.Module):
         def __init__(self, min_val=-1.0, max_val=1.0):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_leaky_relu.py
+++ b/backends/xnnpack/test/ops/test_leaky_relu.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestLeakyRelu(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class LeakyReLU(torch.nn.Module):
         def __init__(self, **kwargs):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_linear.py
+++ b/backends/xnnpack/test/ops/test_linear.py
@@ -219,6 +219,9 @@ class TestLinear(unittest.TestCase):
           should produce strictly better results compared to Per-Tensor Quantization
     """
 
+    def setUp(self):
+        torch._dynamo.reset()
+
     @staticmethod
     def _get_4b_dqconfig() -> QuantizationConfig:
         # Returns a QuantizationConfig for 4b dynamic quantization for XNNPACK.

--- a/backends/xnnpack/test/ops/test_lstm.py
+++ b/backends/xnnpack/test/ops/test_lstm.py
@@ -14,6 +14,9 @@ from executorch.backends.xnnpack.test.tester.tester import ToEdgeTransformAndLow
 
 
 class TestLSTM(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class LSTMLinear(torch.nn.Module):
         def __init__(self, input_size, hidden_size, out_size):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_max_dim.py
+++ b/backends/xnnpack/test/ops/test_max_dim.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestMaxDim(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Max(torch.nn.Module):
         def forward(self, x):
             max_values_1, max_indices_1 = torch.max(x, dim=2, keepdim=True)

--- a/backends/xnnpack/test/ops/test_maximum.py
+++ b/backends/xnnpack/test/ops/test_maximum.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestMaximum(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Maximum(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_maxpool2d.py
+++ b/backends/xnnpack/test/ops/test_maxpool2d.py
@@ -15,6 +15,9 @@ from torch.export.dynamic_shapes import Dim
 
 
 class TestMaxPool2d(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class MaxPool2d(torch.nn.Module):
         def __init__(self, kernel_size=3, stride=1, padding=0, dilation=1):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_mean_dim.py
+++ b/backends/xnnpack/test/ops/test_mean_dim.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestMeanDim(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class MeanDim(torch.nn.Module):
         def __init__(self, dims):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_minimum.py
+++ b/backends/xnnpack/test/ops/test_minimum.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestMinimum(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Minimum(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_multiply.py
+++ b/backends/xnnpack/test/ops/test_multiply.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestMul(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Mul(torch.nn.Module):
         def forward(self, x, y):
             z = x * y

--- a/backends/xnnpack/test/ops/test_negate.py
+++ b/backends/xnnpack/test/ops/test_negate.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestNegate(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Negate(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_permute.py
+++ b/backends/xnnpack/test/ops/test_permute.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestPermute(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Permute(torch.nn.Module):
         def __init__(self, dims):
             self.dims = dims

--- a/backends/xnnpack/test/ops/test_pow.py
+++ b/backends/xnnpack/test/ops/test_pow.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestPow(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Pow(torch.nn.Module):
         def __init__(self, exp):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_prelu.py
+++ b/backends/xnnpack/test/ops/test_prelu.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestPrelu(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class PReLU(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_quantize_per_tensor.py
+++ b/backends/xnnpack/test/ops/test_quantize_per_tensor.py
@@ -13,6 +13,9 @@ from executorch.exir.dialects._ops import ops as exir_ops
 
 
 class TestQuantizePerTensor(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     def test_qs8_quantize_per_tensor(self):
         class Quant(torch.nn.Module):
             def forward(self, x):

--- a/backends/xnnpack/test/ops/test_relu.py
+++ b/backends/xnnpack/test/ops/test_relu.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestRelu(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Relu(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_rsqrt.py
+++ b/backends/xnnpack/test/ops/test_rsqrt.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestRsqrt(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Rsqrt(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_sdpa.py
+++ b/backends/xnnpack/test/ops/test_sdpa.py
@@ -15,6 +15,9 @@ from executorch.backends.xnnpack.test.tester.tester import ToEdgeTransformAndLow
 
 
 class TestSDPA(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class SDPA(torch.nn.Module):
         def __init__(self, scale: Optional[float] = None):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_sigmoid.py
+++ b/backends/xnnpack/test/ops/test_sigmoid.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestSigmoid(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Sigmoid(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_slice_copy.py
+++ b/backends/xnnpack/test/ops/test_slice_copy.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestSliceCopy(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     def _test_slice_copy(self, module, inputs, copy_count=1, edge_copy_count=1):
         (
             Tester(module, inputs)

--- a/backends/xnnpack/test/ops/test_softmax.py
+++ b/backends/xnnpack/test/ops/test_softmax.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestSoftmax(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Softmax(torch.nn.Module):
         def __init__(self, dim):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_sqrt.py
+++ b/backends/xnnpack/test/ops/test_sqrt.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestSqrt(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Sqrt(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_square.py
+++ b/backends/xnnpack/test/ops/test_square.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestSquare(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Square(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_static_constant_pad.py
+++ b/backends/xnnpack/test/ops/test_static_constant_pad.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestStaticConstantPad(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class StaticConstantPadFunctional(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/ops/test_sub.py
+++ b/backends/xnnpack/test/ops/test_sub.py
@@ -11,6 +11,9 @@ from executorch.backends.xnnpack.test.tester import Tester
 
 
 class TestSub(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Sub(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/passes/test_activation_fusion.py
+++ b/backends/xnnpack/test/passes/test_activation_fusion.py
@@ -16,6 +16,9 @@ from executorch.exir.dialects._ops import ops as exir_ops
 class TestActivationFusion(unittest.TestCase):
     PassStage = RunPasses([ConvertToLinearPass, FuseActivationPass])
 
+    def setUp(self):
+        torch._dynamo.reset()
+
     def check_node_has_tag(self, graph_module, node_target, tag):
         for n in graph_module.graph.nodes:
             if n.op == "call_function" and n.target == node_target:

--- a/backends/xnnpack/test/passes/test_batch_norm_fusion.py
+++ b/backends/xnnpack/test/passes/test_batch_norm_fusion.py
@@ -18,6 +18,9 @@ class TestBatchNormFusion(unittest.TestCase):
     PassStage = RunPasses([FuseBatchNormWithConvPass])
     bn_name = "executorch_exir_dialects_edge__ops_aten__native_batch_norm_legit_no_training_default"
 
+    def setUp(self):
+        torch._dynamo.reset()
+
     class ModelConvBN(torch.nn.Module):
         def __init__(
             self,

--- a/backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py
+++ b/backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py
@@ -17,6 +17,9 @@ from executorch.backends.xnnpack.test.tester import RunPasses, Tester
 
 
 class TestChannelsLastTaggedReshapePass(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
     PassStage = RunPasses([ChannelsLastTaggedReshapePass])
     # Dictionary mapping modules to expected number of reshapes
     modules = {

--- a/backends/xnnpack/test/passes/test_convert_to_linear.py
+++ b/backends/xnnpack/test/passes/test_convert_to_linear.py
@@ -24,6 +24,7 @@ class TestConvertToLinear(unittest.TestCase):
         bias_vals = [True, True, False]
 
         for i, _ in enumerate(in_sizes):
+            torch._dynamo.reset()
             in_size = int(in_sizes[i])
             input_size = int(input_sizes[i])
             output_size = int(output_sizes[i])

--- a/backends/xnnpack/test/passes/test_convert_to_linear.py
+++ b/backends/xnnpack/test/passes/test_convert_to_linear.py
@@ -14,6 +14,9 @@ from executorch.backends.xnnpack.test.tester import RunPasses, Tester
 class TestConvertToLinear(unittest.TestCase):
     PassStage = RunPasses([ConvertToLinearPass])
 
+    def setUp(self):
+        torch._dynamo.reset()
+
     def test_fp32_convert_to_linear(self):
         in_sizes = [1, 4, 4]
         input_sizes = [4, 37, 17]

--- a/backends/xnnpack/test/passes/test_decompose_cat_pass.py
+++ b/backends/xnnpack/test/passes/test_decompose_cat_pass.py
@@ -16,6 +16,9 @@ class TestDecomposeCatPass(unittest.TestCase):
     PassStage = RunPasses([DecomposeConcatenate])
     cat_name = "executorch_exir_dialects_edge__ops_aten_cat_default"
 
+    def setUp(self):
+        torch._dynamo.reset()
+
     class Cat(torch.nn.Module):
         def forward(self, *args):
             xs = [*args]

--- a/backends/xnnpack/test/passes/test_remove_get_item_pass.py
+++ b/backends/xnnpack/test/passes/test_remove_get_item_pass.py
@@ -16,6 +16,9 @@ class TestRemoveGetItemPass(unittest.TestCase):
     max_pool2d_name = "executorch_exir_dialects_edge__ops_aten_max_pool2d_default"
     amax_name = "executorch_exir_dialects_edge__ops_aten_amax_default"
 
+    def setUp(self):
+        torch._dynamo.reset()
+
     class MaxPool2dModule(torch.nn.Module):
         def __init__(
             self,

--- a/backends/xnnpack/test/passes/test_tag_implicit_q_dq_pass.py
+++ b/backends/xnnpack/test/passes/test_tag_implicit_q_dq_pass.py
@@ -20,6 +20,9 @@ from executorch.exir.dialects._ops import ops as exir_ops
 class TestTagImplicitQDq(unittest.TestCase):
     PassStage = RunPasses([DuplicateDequantNodePass, TagImplicitQDqPass])
 
+    def setUp(self):
+        torch._dynamo.reset()
+
     class QDqModule(torch.nn.Module):
         def __init__(self):
             super().__init__()


### PR DESCRIPTION
https://github.com/pytorch/executorch/actions/runs/14047575373/job/39331644423

There seems to be some CI issues with:
```
torch._dynamo.exc.FailOnRecompileLimitHit: recompile_limit reached with one_graph=True. Excessive recompilations can degrade performance due to the compilation overhead of each recompilation. To monitor recompilations, enable TORCH_LOGS=recompiles. If recompilations are expected, consider increasing
```

To help resolve this we reset dynamo at setup for all unittests. Let's see if this helps

