### PR TITLE
Turn on EXECUTORCH_BUILD_PYBIND when implicitly wanted

### DIFF
--- a/install_executorch.py
+++ b/install_executorch.py
@@ -52,6 +52,7 @@ def clean():
     print("Done cleaning build artifacts.")
 
 
+# Please keep this insync with `ShouldBuild.pybindings` in setup.py.
 VALID_PYBINDS = ["coreml", "mps", "xnnpack", "training"]
 
 
@@ -205,10 +206,8 @@ def main(args):
     cmake_args = [os.getenv("CMAKE_ARGS", "")]
     use_pytorch_nightly = True
 
-    has_pybindings = False
     wants_pybindings_off, pybind_defines = _list_pybind_defines(args)
     if not wants_pybindings_off:
-        has_pybindings = True
         if len(pybind_defines) > 0:
             # If the user explicitly provides a list of bindings, just use them
             cmake_args += pybind_defines
@@ -216,9 +215,6 @@ def main(args):
             # If the user has not set pybindings off but also has not provided
             # a list, then turn on xnnpack by default
             cmake_args.append("-DEXECUTORCH_BUILD_XNNPACK=ON")
-
-    if has_pybindings:
-        cmake_args.append("-DEXECUTORCH_BUILD_PYBIND=ON")
 
     if args.clean:
         clean()

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,33 @@ class ShouldBuild:
 
     @classmethod
     def pybindings(cls) -> bool:
-        return cls._is_cmake_arg_enabled("EXECUTORCH_BUILD_PYBIND", default=False)
+        return cls._is_cmake_arg_enabled(
+            "EXECUTORCH_BUILD_PYBIND",
+            # If the user hasn't specified anything, we want to turn this on if any
+            # bindings are requested explicitly.
+            #
+            # Please keep this in sync with `VALID_PYBINDS` in install_executorch.py.
+            default=any(
+                [
+                    cls.coreml(),
+                    cls.mps(),
+                    cls.xnnpack(),
+                    cls.training(),
+                ]
+            ),
+        )
+
+    @classmethod
+    def coreml(cls) -> bool:
+        return cls._is_cmake_arg_enabled("EXECUTORCH_BUILD_COREML", default=False)
+
+    @classmethod
+    def mps(cls) -> bool:
+        return cls._is_cmake_arg_enabled("EXECUTORCH_BUILD_MPS", default=False)
+
+    @classmethod
+    def xnnpack(cls) -> bool:
+        return cls._is_cmake_arg_enabled("EXECUTORCH_BUILD_XNNPACK", default=False)
 
     @classmethod
     def training(cls) -> bool:


### PR DESCRIPTION
### Summary

We want `EXECUTORCH_BUILD_PYBIND` enabled if the user wants to build the bindings — so let's just do it. Unless of course, they explicitly choose not to by defining the arg themselves.

### Test plan

CI


cc @larryliu0820 @lucylq