### PR TITLE
Deprecate non-internal elementwise_util APIs

### DIFF
--- a/kernels/portable/cpu/op_convolution.cpp
+++ b/kernels/portable/cpu/op_convolution.cpp
@@ -414,7 +414,7 @@ Tensor& convolution_out(
 
   ET_SWITCH_REALH_TYPES(in.scalar_type(), ctx, name, CTYPE, [&]() {
     const auto load_bias = bias.has_value()
-        ? utils::internal::get_load_to_common_fn<CTYPE, name>(
+        ? utils::internal::get_load_to_compute_fn<CTYPE, name>(
               bias.value(), utils::SupportedTensorDtypes::REALHBF16)
         : nullptr;
     convolution_wrapper<CTYPE>(

--- a/kernels/portable/cpu/op_cumsum.cpp
+++ b/kernels/portable/cpu/op_cumsum.cpp
@@ -113,7 +113,7 @@ Tensor& cumsum_out(
 
   ET_SWITCH_REALHBBF16_TYPES(out.scalar_type(), ctx, op_name, CTYPE_OUT, [&] {
     const auto load_self =
-        utils::internal::get_load_to_common_fn<CTYPE_OUT, op_name>(
+        utils::internal::get_load_to_compute_fn<CTYPE_OUT, op_name>(
             self, utils::SupportedTensorDtypes::REALHBBF16);
     cumsum_tensors<CTYPE_OUT>(self, load_self, dim, out);
   });

--- a/kernels/portable/cpu/util/dtype_util.h
+++ b/kernels/portable/cpu/util/dtype_util.h
@@ -26,189 +26,189 @@ void convert_and_store(From f, void* dst) {
   *reinterpret_cast<To*>(dst) = static_cast<To>(f);
 }
 
-template <typename CTYPE_COMMON>
-using load_to_common_fn = CTYPE_COMMON (*)(const void*);
+template <typename CTYPE_COMPUTE>
+using load_to_compute_fn = CTYPE_COMPUTE (*)(const void*);
 
-template <typename CTYPE_COMMON, const char* op_name>
-load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn_realhbbf16(
+template <typename CTYPE_COMPUTE, const char* op_name>
+load_to_compute_fn<CTYPE_COMPUTE> get_load_to_compute_fn_realhbbf16(
     const Tensor& t) {
-  CTYPE_COMMON (*result)(const void*) = nullptr;
+  CTYPE_COMPUTE (*result)(const void*) = nullptr;
   ET_SWITCH_REALHBBF16_TYPES(
       t.scalar_type(), unused, op_name, TENSOR_CTYPE, [&]() {
-        result = internal::load_and_convert<CTYPE_COMMON, TENSOR_CTYPE>;
+        result = internal::load_and_convert<CTYPE_COMPUTE, TENSOR_CTYPE>;
       });
   return result;
 }
 
-template <typename CTYPE_COMMON, const char* op_name>
-load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn_realhbf16(
+template <typename CTYPE_COMPUTE, const char* op_name>
+load_to_compute_fn<CTYPE_COMPUTE> get_load_to_compute_fn_realhbf16(
     const Tensor& t) {
-  CTYPE_COMMON (*result)(const void*) = nullptr;
+  CTYPE_COMPUTE (*result)(const void*) = nullptr;
   ET_SWITCH_REALHBF16_TYPES(
       t.scalar_type(), unused, op_name, TENSOR_CTYPE, [&]() {
-        result = internal::load_and_convert<CTYPE_COMMON, TENSOR_CTYPE>;
+        result = internal::load_and_convert<CTYPE_COMPUTE, TENSOR_CTYPE>;
       });
   return result;
 }
 
-template <typename CTYPE_COMMON, const char* op_name>
-load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn_floathbf16(
+template <typename CTYPE_COMPUTE, const char* op_name>
+load_to_compute_fn<CTYPE_COMPUTE> get_load_to_compute_fn_floathbf16(
     const Tensor& t) {
-  CTYPE_COMMON (*result)(const void*) = nullptr;
+  CTYPE_COMPUTE (*result)(const void*) = nullptr;
   ET_SWITCH_FLOATHBF16_TYPES(
       t.scalar_type(), unused, op_name, TENSOR_CTYPE, [&]() {
-        result = internal::load_and_convert<CTYPE_COMMON, TENSOR_CTYPE>;
+        result = internal::load_and_convert<CTYPE_COMPUTE, TENSOR_CTYPE>;
       });
   return result;
 }
 
-template <typename CTYPE_COMMON, const char* op_name>
-load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn_intb(const Tensor& t) {
-  CTYPE_COMMON (*result)(const void*) = nullptr;
+template <typename CTYPE_COMPUTE, const char* op_name>
+load_to_compute_fn<CTYPE_COMPUTE> get_load_to_compute_fn_intb(const Tensor& t) {
+  CTYPE_COMPUTE (*result)(const void*) = nullptr;
   ET_SWITCH_INT_TYPES_AND(
       Bool, t.scalar_type(), unused, op_name, TENSOR_CTYPE, [&]() {
-        result = internal::load_and_convert<CTYPE_COMMON, TENSOR_CTYPE>;
+        result = internal::load_and_convert<CTYPE_COMPUTE, TENSOR_CTYPE>;
       });
   return result;
 }
 
-template <typename CTYPE_COMMON, const char* op_name>
-load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn_bool_or_byte(
+template <typename CTYPE_COMPUTE, const char* op_name>
+load_to_compute_fn<CTYPE_COMPUTE> get_load_to_compute_fn_bool_or_byte(
     const Tensor& t) {
-  CTYPE_COMMON (*result)(const void*) = nullptr;
+  CTYPE_COMPUTE (*result)(const void*) = nullptr;
   ET_SWITCH_TWO_TYPES(
       Bool, Byte, t.scalar_type(), unused, op_name, TENSOR_CTYPE, [&]() {
-        result = internal::load_and_convert<CTYPE_COMMON, TENSOR_CTYPE>;
+        result = internal::load_and_convert<CTYPE_COMPUTE, TENSOR_CTYPE>;
       });
   return result;
 }
 
-template <typename CTYPE_COMMON, const char* op_name>
-load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn_same_as_compute(
+template <typename CTYPE_COMPUTE, const char* op_name>
+load_to_compute_fn<CTYPE_COMPUTE> get_load_to_compute_fn_same_as_compute(
     const Tensor& t) {
-  constexpr auto common_scalar_type = CppTypeToScalarType<CTYPE_COMMON>::value;
+  constexpr auto common_scalar_type = CppTypeToScalarType<CTYPE_COMPUTE>::value;
   ET_CHECK_MSG(
       t.scalar_type() == common_scalar_type,
       "Unhandled dtype %s for %s",
       ::executorch::runtime::toString(common_scalar_type),
       op_name);
-  return internal::load_and_convert<CTYPE_COMMON, CTYPE_COMMON>;
+  return internal::load_and_convert<CTYPE_COMPUTE, CTYPE_COMPUTE>;
 }
 
 template <
-    typename CTYPE_COMMON,
+    typename CTYPE_COMPUTE,
     const char* op_name,
-    std::enable_if_t<std::is_same_v<CTYPE_COMMON, float>, bool> = true>
-load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn_same_as_common(
+    std::enable_if_t<std::is_same_v<CTYPE_COMPUTE, float>, bool> = true>
+load_to_compute_fn<CTYPE_COMPUTE> get_load_to_compute_fn_same_as_common(
     const Tensor& t) {
-  CTYPE_COMMON (*result)(const void*) = nullptr;
+  CTYPE_COMPUTE (*result)(const void*) = nullptr;
   ET_SWITCH_THREE_TYPES(
       Float, Half, BFloat16, t.scalar_type(), unused, op_name, T, [&]() {
-        result = internal::load_and_convert<CTYPE_COMMON, T>;
+        result = internal::load_and_convert<CTYPE_COMPUTE, T>;
       });
   return result;
 }
 
 template <
-    typename CTYPE_COMMON,
+    typename CTYPE_COMPUTE,
     const char* op_name,
-    std::enable_if_t<!std::is_same_v<CTYPE_COMMON, float>, bool> = true>
-load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn_same_as_common(
+    std::enable_if_t<!std::is_same_v<CTYPE_COMPUTE, float>, bool> = true>
+load_to_compute_fn<CTYPE_COMPUTE> get_load_to_compute_fn_same_as_common(
     const Tensor& t) {
-  return get_load_to_common_fn_same_as_compute<CTYPE_COMMON, op_name>(t);
+  return get_load_to_compute_fn_same_as_compute<CTYPE_COMPUTE, op_name>(t);
 }
 
-template <typename CTYPE_COMMON>
-using store_common_to_tensor_fn = void (*)(CTYPE_COMMON, void*);
+template <typename CTYPE_COMPUTE>
+using store_compute_to_tensor_fn = void (*)(CTYPE_COMPUTE, void*);
 
-template <typename CTYPE_COMMON, const char* op_name>
-store_common_to_tensor_fn<CTYPE_COMMON>
-get_store_common_to_tensor_fn_realhbbf16(const Tensor& t) {
-  void (*result)(CTYPE_COMMON, void*) = nullptr;
+template <typename CTYPE_COMPUTE, const char* op_name>
+store_compute_to_tensor_fn<CTYPE_COMPUTE>
+get_store_compute_to_tensor_fn_realhbbf16(const Tensor& t) {
+  void (*result)(CTYPE_COMPUTE, void*) = nullptr;
   ET_SWITCH_REALHBBF16_TYPES(
       t.scalar_type(), unused, op_name, TENSOR_CTYPE, [&]() {
-        result = internal::convert_and_store<TENSOR_CTYPE, CTYPE_COMMON>;
+        result = internal::convert_and_store<TENSOR_CTYPE, CTYPE_COMPUTE>;
       });
   return result;
 }
 
-template <typename CTYPE_COMMON, const char* op_name>
-store_common_to_tensor_fn<CTYPE_COMMON> get_store_common_to_tensor_fn_realhbf16(
-    const Tensor& t) {
-  void (*result)(CTYPE_COMMON, void*) = nullptr;
+template <typename CTYPE_COMPUTE, const char* op_name>
+store_compute_to_tensor_fn<CTYPE_COMPUTE>
+get_store_compute_to_tensor_fn_realhbf16(const Tensor& t) {
+  void (*result)(CTYPE_COMPUTE, void*) = nullptr;
   ET_SWITCH_REALHBF16_TYPES(
       t.scalar_type(), unused, op_name, TENSOR_CTYPE, [&]() {
-        result = internal::convert_and_store<TENSOR_CTYPE, CTYPE_COMMON>;
+        result = internal::convert_and_store<TENSOR_CTYPE, CTYPE_COMPUTE>;
       });
   return result;
 }
 
-template <typename CTYPE_COMMON, const char* op_name>
-store_common_to_tensor_fn<CTYPE_COMMON>
-get_store_common_to_tensor_fn_floathbf16(const Tensor& t) {
-  void (*result)(CTYPE_COMMON, void*) = nullptr;
+template <typename CTYPE_COMPUTE, const char* op_name>
+store_compute_to_tensor_fn<CTYPE_COMPUTE>
+get_store_compute_to_tensor_fn_floathbf16(const Tensor& t) {
+  void (*result)(CTYPE_COMPUTE, void*) = nullptr;
   ET_SWITCH_FLOATHBF16_TYPES(
       t.scalar_type(), unused, op_name, TENSOR_CTYPE, [&]() {
-        result = internal::convert_and_store<TENSOR_CTYPE, CTYPE_COMMON>;
+        result = internal::convert_and_store<TENSOR_CTYPE, CTYPE_COMPUTE>;
       });
   return result;
 }
 
-template <typename CTYPE_COMMON, const char* op_name>
-store_common_to_tensor_fn<CTYPE_COMMON> get_store_common_to_tensor_fn_intb(
+template <typename CTYPE_COMPUTE, const char* op_name>
+store_compute_to_tensor_fn<CTYPE_COMPUTE> get_store_compute_to_tensor_fn_intb(
     const Tensor& t) {
-  void (*result)(CTYPE_COMMON, void*) = nullptr;
+  void (*result)(CTYPE_COMPUTE, void*) = nullptr;
   ET_SWITCH_INT_TYPES_AND(
       Bool, t.scalar_type(), unused, op_name, TENSOR_CTYPE, [&]() {
-        result = internal::convert_and_store<TENSOR_CTYPE, CTYPE_COMMON>;
+        result = internal::convert_and_store<TENSOR_CTYPE, CTYPE_COMPUTE>;
       });
   return result;
 }
 
-template <typename CTYPE_COMMON, const char* op_name>
-store_common_to_tensor_fn<CTYPE_COMMON>
-get_store_common_to_tensor_fn_bool_or_byte(const Tensor& t) {
-  void (*result)(CTYPE_COMMON, void*) = nullptr;
+template <typename CTYPE_COMPUTE, const char* op_name>
+store_compute_to_tensor_fn<CTYPE_COMPUTE>
+get_store_compute_to_tensor_fn_bool_or_byte(const Tensor& t) {
+  void (*result)(CTYPE_COMPUTE, void*) = nullptr;
   ET_SWITCH_TWO_TYPES(
       Bool, Byte, t.scalar_type(), unused, op_name, TENSOR_CTYPE, [&]() {
-        result = internal::convert_and_store<TENSOR_CTYPE, CTYPE_COMMON>;
+        result = internal::convert_and_store<TENSOR_CTYPE, CTYPE_COMPUTE>;
       });
   return result;
 }
 
-template <typename CTYPE_COMMON, const char* op_name>
-store_common_to_tensor_fn<CTYPE_COMMON>
-get_store_common_to_tensor_fn_same_as_compute(const Tensor& t) {
-  constexpr auto common_scalar_type = CppTypeToScalarType<CTYPE_COMMON>::value;
+template <typename CTYPE_COMPUTE, const char* op_name>
+store_compute_to_tensor_fn<CTYPE_COMPUTE>
+get_store_compute_to_tensor_fn_same_as_compute(const Tensor& t) {
+  constexpr auto common_scalar_type = CppTypeToScalarType<CTYPE_COMPUTE>::value;
   ET_CHECK_MSG(
       t.scalar_type() == common_scalar_type,
       "Unhandled dtype %s for %s",
       ::executorch::runtime::toString(common_scalar_type),
       op_name);
-  return internal::convert_and_store<CTYPE_COMMON, CTYPE_COMMON>;
+  return internal::convert_and_store<CTYPE_COMPUTE, CTYPE_COMPUTE>;
 }
 
 template <
-    typename CTYPE_COMMON,
+    typename CTYPE_COMPUTE,
     const char* op_name,
-    std::enable_if_t<std::is_same_v<CTYPE_COMMON, float>, bool> = true>
-store_common_to_tensor_fn<CTYPE_COMMON>
-get_store_common_to_tensor_fn_same_as_common(const Tensor& t) {
-  void (*result)(CTYPE_COMMON, void*) = nullptr;
+    std::enable_if_t<std::is_same_v<CTYPE_COMPUTE, float>, bool> = true>
+store_compute_to_tensor_fn<CTYPE_COMPUTE>
+get_store_compute_to_tensor_fn_same_as_common(const Tensor& t) {
+  void (*result)(CTYPE_COMPUTE, void*) = nullptr;
   ET_SWITCH_THREE_TYPES(
       Float, Half, BFloat16, t.scalar_type(), unused, op_name, CTYPE, [&]() {
-        result = internal::convert_and_store<CTYPE, CTYPE_COMMON>;
+        result = internal::convert_and_store<CTYPE, CTYPE_COMPUTE>;
       });
   return result;
 }
 
 template <
-    typename CTYPE_COMMON,
+    typename CTYPE_COMPUTE,
     const char* op_name,
-    std::enable_if_t<!std::is_same_v<CTYPE_COMMON, float>, bool> = true>
-store_common_to_tensor_fn<CTYPE_COMMON>
-get_store_common_to_tensor_fn_same_as_common(const Tensor& t) {
-  return get_store_common_to_tensor_fn_same_as_compute<CTYPE_COMMON, op_name>(
+    std::enable_if_t<!std::is_same_v<CTYPE_COMPUTE, float>, bool> = true>
+store_compute_to_tensor_fn<CTYPE_COMPUTE>
+get_store_compute_to_tensor_fn_same_as_common(const Tensor& t) {
+  return get_store_compute_to_tensor_fn_same_as_compute<CTYPE_COMPUTE, op_name>(
       t);
 }
 
@@ -220,59 +220,64 @@ enum class SupportedTensorDtypes {
   FLOATHBF16,
   INTB,
   BOOL_OR_BYTE,
+  // DEPRECATED: not likely to be correct; use SAME_AS_COMMON.
   SAME_AS_COMPUTE,
   SAME_AS_COMMON,
 };
 
 namespace internal {
 
-template <typename CTYPE_COMMON, const char* op_name>
-load_to_common_fn<CTYPE_COMMON> get_load_to_common_fn(
+template <typename CTYPE_COMPUTE, const char* op_name>
+load_to_compute_fn<CTYPE_COMPUTE> get_load_to_compute_fn(
     const Tensor& t,
     SupportedTensorDtypes dtypes) {
   switch (dtypes) {
     case SupportedTensorDtypes::REALHBBF16:
-      return get_load_to_common_fn_realhbbf16<CTYPE_COMMON, op_name>(t);
+      return get_load_to_compute_fn_realhbbf16<CTYPE_COMPUTE, op_name>(t);
     case SupportedTensorDtypes::REALHBF16:
-      return get_load_to_common_fn_realhbf16<CTYPE_COMMON, op_name>(t);
+      return get_load_to_compute_fn_realhbf16<CTYPE_COMPUTE, op_name>(t);
     case SupportedTensorDtypes::FLOATHBF16:
-      return get_load_to_common_fn_realhbf16<CTYPE_COMMON, op_name>(t);
+      return get_load_to_compute_fn_realhbf16<CTYPE_COMPUTE, op_name>(t);
     case SupportedTensorDtypes::INTB:
-      return get_load_to_common_fn_intb<CTYPE_COMMON, op_name>(t);
+      return get_load_to_compute_fn_intb<CTYPE_COMPUTE, op_name>(t);
     case SupportedTensorDtypes::BOOL_OR_BYTE:
-      return get_load_to_common_fn_bool_or_byte<CTYPE_COMMON, op_name>(t);
+      return get_load_to_compute_fn_bool_or_byte<CTYPE_COMPUTE, op_name>(t);
     case SupportedTensorDtypes::SAME_AS_COMPUTE:
-      return get_load_to_common_fn_same_as_compute<CTYPE_COMMON, op_name>(t);
+      return get_load_to_compute_fn_same_as_compute<CTYPE_COMPUTE, op_name>(t);
     case SupportedTensorDtypes::SAME_AS_COMMON:
-      return get_load_to_common_fn_same_as_common<CTYPE_COMMON, op_name>(t);
+      return get_load_to_compute_fn_same_as_common<CTYPE_COMPUTE, op_name>(t);
   }
   ET_CHECK(false);
   return nullptr;
 }
 
-template <typename CTYPE_COMMON, const char* op_name>
-store_common_to_tensor_fn<CTYPE_COMMON> get_store_common_to_tensor_fn(
+template <typename CTYPE_COMPUTE, const char* op_name>
+store_compute_to_tensor_fn<CTYPE_COMPUTE> get_store_compute_to_tensor_fn(
     const Tensor& t,
     SupportedTensorDtypes dtypes) {
   switch (dtypes) {
     case SupportedTensorDtypes::REALHBBF16:
-      return get_store_common_to_tensor_fn_realhbbf16<CTYPE_COMMON, op_name>(t);
-    case SupportedTensorDtypes::REALHBF16:
-      return get_store_common_to_tensor_fn_realhbf16<CTYPE_COMMON, op_name>(t);
-    case SupportedTensorDtypes::FLOATHBF16:
-      return get_store_common_to_tensor_fn_floathbf16<CTYPE_COMMON, op_name>(t);
-    case SupportedTensorDtypes::INTB:
-      return get_store_common_to_tensor_fn_intb<CTYPE_COMMON, op_name>(t);
-    case SupportedTensorDtypes::BOOL_OR_BYTE:
-      return get_store_common_to_tensor_fn_bool_or_byte<CTYPE_COMMON, op_name>(
+      return get_store_compute_to_tensor_fn_realhbbf16<CTYPE_COMPUTE, op_name>(
           t);
+    case SupportedTensorDtypes::REALHBF16:
+      return get_store_compute_to_tensor_fn_realhbf16<CTYPE_COMPUTE, op_name>(
+          t);
+    case SupportedTensorDtypes::FLOATHBF16:
+      return get_store_compute_to_tensor_fn_floathbf16<CTYPE_COMPUTE, op_name>(
+          t);
+    case SupportedTensorDtypes::INTB:
+      return get_store_compute_to_tensor_fn_intb<CTYPE_COMPUTE, op_name>(t);
+    case SupportedTensorDtypes::BOOL_OR_BYTE:
+      return get_store_compute_to_tensor_fn_bool_or_byte<
+          CTYPE_COMPUTE,
+          op_name>(t);
     case SupportedTensorDtypes::SAME_AS_COMPUTE:
-      return get_store_common_to_tensor_fn_same_as_compute<
-          CTYPE_COMMON,
+      return get_store_compute_to_tensor_fn_same_as_compute<
+          CTYPE_COMPUTE,
           op_name>(t);
     case SupportedTensorDtypes::SAME_AS_COMMON: {
-      return get_store_common_to_tensor_fn_same_as_common<
-          CTYPE_COMMON,
+      return get_store_compute_to_tensor_fn_same_as_common<
+          CTYPE_COMPUTE,
           op_name>(t);
     }
   }

--- a/kernels/portable/cpu/util/elementwise_util.h
+++ b/kernels/portable/cpu/util/elementwise_util.h
@@ -119,7 +119,6 @@ inline void apply_elementwise_fn(
         }
       });
 }
-} // namespace internal
 
 template <typename CTYPE_COMPUTE, const char* op_name, typename Op>
 inline void apply_unitensor_elementwise_fn(
@@ -206,6 +205,14 @@ inline ScalarType get_compute_type(ScalarType& common_type) {
   }
   return compute_type;
 }
+} // namespace internal
+
+// DEPRECATED: these APIs should not have been stabilized for external
+// use as they are undergoing active development.
+using internal::apply_bitensor_elementwise_fn;
+using internal::apply_tritensor_elementwise_fn;
+using internal::apply_unitensor_elementwise_fn;
+using internal::get_compute_type;
 
 } // namespace utils
 } // namespace native


### PR DESCRIPTION
As the code comment says, these APIs are undergoing development (see e.g. https://github.com/pytorch/executorch/pull/9613) and it's pretty inconvenient that they're incidentally committed-to externally. Mark them deprecated so we have the option to drop that commitment in (IIUC) 0.7.