### PR TITLE
Update pinned optimum-executorch commit hash in the CI

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -536,9 +536,8 @@ jobs:
         git clone https://github.com/huggingface/optimum-executorch
         cd optimum-executorch
         # There is no release yet, for CI stability, always test from the same commit on main
-        git checkout 6a7e83f3eee2976fa809335bfb78a45b1ea1cb25
-        pip install .
-        pip install accelerate sentencepiece
+        git checkout 577a2b19670e4c643a5c6ecb09bf47b9a699e7c6
+        pip install .[tests]
         pip list
         echo "::endgroup::"
 


### PR DESCRIPTION
Previous attempt to bump HF transformers version to latest is reverted due to llava model imcompatibility. This PR is to just ensure the CI are able to test `optimum-executorch` with latest version of HF transformers and upcoming `executorch==0.6.0`.

Note: This change is purely on CI and only for optimum-executorch, should not affect other models like llava.
