### PR TITLE
Arm backend: Use gitlab and bump version of ethos-u-core-driver to 25.02

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "backends/arm/third-party/ethos-u-core-driver"]
 	path = backends/arm/third-party/ethos-u-core-driver
-	url = https://github.com/pytorch-labs/ethos-u-core-driver-mirror
+	url = https://git.gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-driver.git
 [submodule "backends/arm/third-party/serialization_lib"]
 	path = backends/arm/third-party/serialization_lib
-	url = https://github.com/pytorch-labs/tosa_serialization_lib-mirror
+	url = https://git.gitlab.arm.com/tosa/tosa-serialization.git
 [submodule "backends/vulkan/third-party/Vulkan-Headers"]
 	path = backends/vulkan/third-party/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -51,7 +51,7 @@ set(PYTHON_EXECUTABLE
 file(MAKE_DIRECTORY ${ETHOS_SDK_PATH}/../ethos_u)
 
 include(FetchContent)
-set(ethos_u_base_rev "24.08")
+set(ethos_u_base_rev "25.02")
 FetchContent_Declare(
   ethos_u
   GIT_REPOSITORY https://git.gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u.git

--- a/examples/arm/executor_runner/pte_to_header.py
+++ b/examples/arm/executor_runner/pte_to_header.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-# Copyright 2023-2024 Arm Limited and/or its affiliates.
+# Copyright 2023-2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@ import binascii
 import os
 from argparse import ArgumentParser, ArgumentTypeError
 
-# Also see: https://git.mlplatform.org/ml/ethos-u/ml-embedded-evaluation-kit.git/tree/scripts/py/gen_model_cpp.py
+# Also see: https://git.gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit/-/blob/main/scripts/py/gen_model_cpp.py?ref_type=heads
 
 bytes_per_line = 32
 hex_digits_per_line = bytes_per_line * 2

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -55,12 +55,8 @@ else
     echo "[main] Error: only x86-64 & aarch64/arm64 architecture is supported for now!"; exit 1;
 fi
 
-# ethos-u
-ethos_u_repo_url="https://review.mlplatform.org/ml/ethos-u/ethos-u"
-ethos_u_base_rev="24.08"
-
 # tosa reference model
-tosa_reference_model_url="https://review.mlplatform.org/tosa/reference_model"
+tosa_reference_model_url="https://git.gitlab.arm.com/tosa/tosa-reference-model.git"
 tosa_reference_model_rev="70ed0b40fa831387e36abdb4f7fb9670a3464f5a"
 
 # vela


### PR DESCRIPTION
This bumps ethos-u-core-driver to the latest version 25.02 and move more external deps to use to gitlab repo.


cc @digantdesai @freddan80 @per @oscarandersson8218