### PR TITLE
Check for null method in module execute

### DIFF
--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -236,6 +236,8 @@ runtime::Result<std::vector<runtime::EValue>> Module::execute(
   ET_CHECK_OK_OR_RETURN_ERROR(load_method(method_name));
   auto& method = methods_.at(method_name).method;
   auto& inputs = methods_.at(method_name).inputs;
+  
+  ET_CHECK_OR_RETURN_ERROR(method != nullptr, InvalidArgument, "Method is null");
 
   for (size_t i = 0; i < input_values.size(); ++i) {
     if (!input_values[i].isNone()) {


### PR DESCRIPTION
Summary: This is an attempt to partially mitigate use after free crashes when a module is unloaded during inference. This is not a supported use pattern, but it doesn't to sanity check here to avoid a crash.

Differential Revision: D71968421


