### PR TITLE
Fix CoreML pybinding module

### DIFF
--- a/backends/apple/coreml/TARGETS
+++ b/backends/apple/coreml/TARGETS
@@ -72,7 +72,7 @@ runtime.cxx_python_extension(
     headers = glob([
         "runtime/inmemoryfs/**/*.hpp",
     ]),
-    base_module = "",
+    base_module = "executorch.backends.apple.coreml",
     compiler_flags = [
         "-std=c++17",
     ],


### PR DESCRIPTION
Summary: I updated the module name in D71931252 and only made the change in CMake. This fixes the buck build.

Reviewed By: kirklandsign

Differential Revision: D71988950
