### PR TITLE
Unbreak CI job failures caused by cmake upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,9 @@ include(tools/cmake/Utils.cmake)
 include(CMakeDependentOption)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
+# Set a flag to override the compatiblity error caused by CMake 4.0.0+ dropping support for
+# things like `cmake_minimum_required (VERSION 3.0.2 FATAL_ERROR)`
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -123,6 +123,9 @@ def install_requirements(use_pytorch_nightly):
     # This is usually not recommended.
     new_env = os.environ.copy()
     new_env["USE_CPP"] = "1"  # install torchao kernels
+    # Set a flag to override the compatiblity error caused by CMake 4.0.0+ dropping support for
+    # things like `cmake_minimum_required (VERSION 3.0.2 FATAL_ERROR)`
+    new_env["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
     subprocess.run(
         [
             sys.executable,

--- a/setup.py
+++ b/setup.py
@@ -703,14 +703,15 @@ class CustomBuild(build):
             # like `TorchConfig.cmake` that are provided by pip packages.
             f"-DCMAKE_PREFIX_PATH={cmake_prefix_path}",
             f"-DCMAKE_BUILD_TYPE={cfg}",
-            # A temporary flag for overriding exception caused by CMake 4.0.0+
-            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
             # Enable logging even when in release mode. We are building for
             # desktop, where saving a few kB is less important than showing
             # useful error information to users.
             "-DEXECUTORCH_ENABLE_LOGGING=ON",
             "-DEXECUTORCH_LOG_LEVEL=Info",
             "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15",
+            # Set a flag to override the compatiblity error caused by CMake 4.0.0+ dropping support for
+            # things like `cmake_minimum_required (VERSION 3.0.2 FATAL_ERROR)`
+            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
             # The separate host project is only required when cross-compiling,
             # and it can cause build race conditions (libflatcc.a errors) when
             # enabled. TODO(dbort): Remove this override once this option is

--- a/setup.py
+++ b/setup.py
@@ -703,6 +703,8 @@ class CustomBuild(build):
             # like `TorchConfig.cmake` that are provided by pip packages.
             f"-DCMAKE_PREFIX_PATH={cmake_prefix_path}",
             f"-DCMAKE_BUILD_TYPE={cfg}",
+            # A temporary flag for overriding exception caused by CMake 4.0.0+
+            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
             # Enable logging even when in release mode. We are building for
             # desktop, where saving a few kB is less important than showing
             # useful error information to users.


### PR DESCRIPTION
Summary:

CMake is upgraded to 4.0.0 and it's imcompatible with `cmake_minimum_required(VERSION 3.0.2)` from
`third-party/gflags/CMakeLists.txt:73`

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
