### PR TITLE
Pin cmake version < 4.0.0

### DIFF
--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -160,7 +160,7 @@ function setup_tosa_reference_model() {
     # reference_model flatbuffers version clashes with Vela.
     # go with Vela's since it newer.
     # Vela's flatbuffer requirement is expected to loosen, then remove this. MLETORCH-565
-    pip install tosa-tools@git+${tosa_reference_model_url}@${tosa_reference_model_rev} --no-dependencies flatbuffers
+    CMAKE_POLICY_VERSION_MINIMUM=3.5 pip install tosa-tools@git+${tosa_reference_model_url}@${tosa_reference_model_rev} --no-dependencies flatbuffers
 
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "cmake",  # For building binary targets in the wheel.
+  "cmake<4.0.0",  # For building binary targets in the wheel. 4.0.0 breaks third-party CMake build so temporarily pin the version.
   "pip>=23",  # For building the pip package.
   "pyyaml",  # Imported by the kernel codegen tools.
   "setuptools>=63",  # For building the pip package contents.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-cmake>=3.19  # For building binary targets in the wheel.
+cmake>=3.19, <4.0.0  # For building binary targets in the wheel.
 pip>=23  # For building the pip package.
 pyyaml  # Imported by the kernel codegen tools.
 setuptools>=63  # For building the pip package contents.


### PR DESCRIPTION
### Summary
So that we can still build third-party projects.

### Test plan
CI
