### PR TITLE
[XNNPACK] Serialize weights as fp16 rather than fp32

### DIFF
--- a/backends/xnnpack/operators/op_conv2d.py
+++ b/backends/xnnpack/operators/op_conv2d.py
@@ -82,7 +82,6 @@ class Conv2d(NodeVisitor):
         weight_quant_params = QuantParams.from_weights(
             kernel_node, self._exported_program
         )
-        fp32_static_weights = kernel_node.meta["val"].dtype == torch.float16
 
         if weight_quant_params is not None and weight_quant_params.per_channel:
             if is_transpose:
@@ -102,8 +101,8 @@ class Conv2d(NodeVisitor):
             convert_to_nhwc=True,
             swap_in_out_for_weights=is_depthwise_conv or is_transpose,
             quant_params=weight_quant_params,
-            fp32_static_weights=fp32_static_weights,
             groups=groups if is_transpose else 1,
+            force_fp32=True,
         )
         kwargs["filter_id"] = vals_to_ids[get_input_node(node, 1)]
 
@@ -127,13 +126,14 @@ class Conv2d(NodeVisitor):
             bias_quant_params = QuantParams.from_bias(
                 bias_node, weight_quant_params, input_quant_params
             )
+
             self.define_tensor(
                 get_input_node(node, 2),
                 xnn_graph,
                 vals_to_ids,
                 convert_to_nhwc=False,
                 quant_params=bias_quant_params,
-                fp32_static_weights=fp32_static_weights,
+                force_fp32=True,
             )
             kwargs["bias_id"] = vals_to_ids[get_input_node(node, 2)]
 

--- a/backends/xnnpack/operators/op_linear.py
+++ b/backends/xnnpack/operators/op_linear.py
@@ -59,7 +59,6 @@ class LinearVisitor(NodeVisitor):
             xnn_graph,
             vals_to_ids,
             quant_params=weight_quant_params,
-            fp32_static_weights=True,
         )
         filter_id = vals_to_ids[weight_node]
 
@@ -69,12 +68,18 @@ class LinearVisitor(NodeVisitor):
             bias_quant_params = QuantParams.from_bias(
                 bias_node, weight_quant_params, input_quant_params
             )
+            # For dynamic quantization, there are no kernels with fp16 bias
+            # So we need to force the fp16 bias to fp32
+            force_fp32 = False
+            if input_quant_params is not None and input_quant_params.is_dynamic:
+                force_fp32 = True
+
             self.define_tensor(
                 get_input_node(node, 2),
                 xnn_graph,
                 vals_to_ids,
                 quant_params=bias_quant_params,
-                fp32_static_weights=True,
+                force_fp32=force_fp32,
             )
             bias_id = vals_to_ids[bias_node]
         else:

--- a/backends/xnnpack/test/ops/test_linear.py
+++ b/backends/xnnpack/test/ops/test_linear.py
@@ -605,9 +605,7 @@ class TestLinear(unittest.TestCase):
 
                     if legacy_partitioner:
                         tester.to_edge()
-                        tester.partition(
-                            Partition(DynamicallyQuantizedPartitioner)
-                        ).dump_artifact()
+                        tester.partition(Partition(DynamicallyQuantizedPartitioner))
                         # should have [add]mm node
                         if uses_bias:
                             tester.check(
@@ -624,7 +622,7 @@ class TestLinear(unittest.TestCase):
                     else:
                         tester.to_edge_transform_and_lower(
                             ToEdgeTransformAndLower([DynamicallyQuantizedPartitioner])
-                        ).dump_artifact()
+                        )
                         # should not have a delegate node
                         tester.check_not(
                             [
@@ -717,7 +715,7 @@ class TestLinear(unittest.TestCase):
                     num_batch_dims=num_batch_dims,
                     uses_bias=use_bias,
                     dtype=torch.float16,
-                    atol=5e-2,  # TODO(T212995726): Investigate right atol for rand[n] inputs
+                    atol=5e-3,  # TODO(T212995726): Investigate right atol for rand[n] inputs
                 )
 
     def test_fp32_linear(self):


### PR DESCRIPTION
### Summary
Previously we've used FP32_STATIC_WEIGHTS flag in xnnpack to coerce fp32 weights into fp16 for linear and conv. This allowed us to mimc fp16 computation because the weights would be converted and packed as fp16 at runtime. However, this  means we lose the benefit of the smaller .pte file because the weights are serialized as fp32 rather than fp16. Additionally, we still have to load the weights as fp32, since they are converted at runtime. This has some poor effects on performance

### Test plan
```
python -m unittest backends.xnnpack.test.ops.test_linear.TestLinear.test_fp16_linear
python -m unittest backends.xnnpack.test.ops.test_linear.TestLinear
python -m unittest backends.xnnpack.test.ops.test_conv2d.TestConv2d
```

Llama 3.2 with bf16 weights:
Before:
```
-rw-r--r--  1 maxren  staff  5468937344 Mar 28 17:00 llama3_2_fp16_direct_convert_runtime.pte
```
After:
```
-rw-r--r--  1 maxren  staff  2997443712 Mar 28 16:57 llama3_2_fp16_direct_convert_runtime.pte
```