### PR TITLE
use kUnsetDebugHandle for unset debug handle in etdump delegation log

### DIFF
--- a/devtools/etdump/etdump_flatcc.cpp
+++ b/devtools/etdump/etdump_flatcc.cpp
@@ -352,8 +352,21 @@ void ETDumpGen::log_intermediate_output_delegate_helper(
     const char* name,
     DebugHandle delegate_debug_index,
     const T& output) {
+  // Previously we compared delegate_debug_index to -1 to check if it is set,
+  // but this is not a good solution because delegate_debug_index is of
+  // DebugHandle type which is a uint32_t. Also we have a specific value for
+  // runtime::kUnsetDebugHandle to represent an unset debug handle.
+  //
+  // To maintain backward compatibility:
+  // 1. We keep the comparison with -1 (cast to DebugHandle)
+  // 2. We add comparison with runtime::kUnsetDebugHandle
+  //
+  // TODO(gasoonjia): In the future, we should remove the comparison with -1 and
+  // only compare with runtime::kUnsetDebugHandle.
   ET_CHECK_MSG(
-      (name == nullptr) ^ (delegate_debug_index == -1),
+      (name == nullptr) ^
+          (delegate_debug_index == runtime::kUnsetDebugHandle ||
+           delegate_debug_index == static_cast<DebugHandle>(-1)),
       "Only name or delegate_debug_index can be valid. Check DelegateMappingBuilder documentation for more details.");
 
   check_ready_to_add_events();


### PR DESCRIPTION
Summary: as title. See comments in code for better reason

Differential Revision: D72095995


