### PR TITLE
Validate that method inputs have the expected dim order

### DIFF
--- a/runtime/core/exec_aten/util/test/dim_order_util_test.cpp
+++ b/runtime/core/exec_aten/util/test/dim_order_util_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+using executorch::runtime::dim_order_to_c_string;
 using executorch::runtime::dim_order_to_stride;
 using executorch::runtime::Error;
 using executorch::runtime::is_channels_last_dim_order;
@@ -345,4 +346,21 @@ TEST_F(DimOrderUtilTest, TooManyDimsReturnsError) {
   auto error = dim_order_to_stride(
       sizes.data(), dim_order.data(), kTooManyDims, strides.data());
   EXPECT_EQ(error, Error::InvalidArgument);
+}
+
+TEST(DimOrderUtilTest, DimOrderToCStringSimple) {
+  std::array<executorch::aten::DimOrderType, 4> dim_order = {0, 1, 2, 3};
+  const auto expected = "(0, 1, 2, 3)";
+  auto c_str = dim_order_to_c_string(dim_order.data(), dim_order.size());
+
+  EXPECT_TRUE(strcmp(c_str.data(), expected) == 0);
+}
+
+TEST(DimOrderUtilTest, DimOrderToCStringHandlesOverflow) {
+  const auto dim_count = 1000;
+  std::vector<executorch::aten::DimOrderType> dim_order(dim_count);
+  std::iota(dim_order.begin(), dim_order.end(), 0);
+
+  auto c_str = dim_order_to_c_string(dim_order.data(), dim_count);
+  EXPECT_EQ(c_str[c_str.size() - 1], '\0');
 }


### PR DESCRIPTION
Summary:
Currently, there is no check for the correct dim order when setting method inputs. If the input tensor has a different dim order than was used in export, it will silently give garbage outputs by treating the input tensor as having a different dim order than it does. To catch this case, I've added an additional check in `method.set_input` to enforce that the dim order matches.

I've also added a `dim_order_to_c_string` utility method in "dim_order_util.h" to aid in printing usable error messages.

Differential Revision: D72106471


