### PR TITLE
Fix breaks from googletest upgrade

### DIFF
--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <bitset>
+#include <iomanip>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Summary: Add missing include for standard C++ library

Reviewed By: 8Keep


