### PR TITLE
Add ET_PRI_* macros for Tensor methods that differ with ATen

### DIFF
--- a/kernels/portable/cpu/op_convolution_backward.cpp
+++ b/kernels/portable/cpu/op_convolution_backward.cpp
@@ -42,7 +42,7 @@ bool check_convolution_backward_args(
       transposed == false, "Transposed Convolution Backward not supported yet");
   ET_CHECK_OR_RETURN_FALSE(
       weight.dim() == 4,
-      "Only 2D Convolution Backward supported for now; weight.dim() = %zd",
+      "Only 2D Convolution Backward supported for now; weight.dim() = %" ET_PRI_TENSOR_DIM,
       weight.dim());
 
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(weight, input));
@@ -93,7 +93,8 @@ bool check_convolution_backward_args(
 
   ET_CHECK_OR_RETURN_FALSE(
       grad_output.dim() == input.dim(),
-      "grad_output should have same number of dimensions as input; grad_output.dim() = %zd, input.dim() = %zd",
+      "grad_output should have same number of dimensions as input; grad_output.dim() = %" ET_PRI_TENSOR_DIM
+      ", input.dim() = %" ET_PRI_TENSOR_DIM,
       grad_output.dim(),
       input.dim());
 

--- a/kernels/portable/cpu/op_linear_scratch_example.cpp
+++ b/kernels/portable/cpu/op_linear_scratch_example.cpp
@@ -42,19 +42,22 @@ bool check_linear_scratch_example_args(
     Tensor& scratch) {
   ET_CHECK_OR_RETURN_FALSE(
       input.size(1) == weight.size(1),
-      "Unexpected weight size 1; input.size(1) = %zd, weight.size(1) = %zd",
+      "Unexpected weight size 1; input.size(1) = %" ET_PRI_TENSOR_SIZE
+      ", weight.size(1) = %" ET_PRI_TENSOR_SIZE,
       input.size(1),
       weight.size(1));
 
   ET_CHECK_OR_RETURN_FALSE(
       scratch.size(0) == input.size(0),
-      "Unexpected scratch size 0; scratch.size(0) = %zd, input.size(0) = %zd",
+      "Unexpected scratch size 0; scratch.size(0) = %" ET_PRI_TENSOR_SIZE
+      ", input.size(0) = %" ET_PRI_TENSOR_SIZE,
       scratch.size(0),
       input.size(0));
 
   ET_CHECK_OR_RETURN_FALSE(
       scratch.size(1) == weight.size(0),
-      "Unexpected scratch size 1; scratch.size(1) = %zd, weight.size(0) = %zd",
+      "Unexpected scratch size 1; scratch.size(1) = %" ET_PRI_TENSOR_SIZE
+      ", weight.size(0) = %" ET_PRI_TENSOR_SIZE,
       scratch.size(1),
       weight.size(0));
 

--- a/kernels/portable/cpu/op_max_pool2d_with_indices_backward.cpp
+++ b/kernels/portable/cpu/op_max_pool2d_with_indices_backward.cpp
@@ -62,7 +62,8 @@ bool check_max_pool2d_backward_args(
 
   ET_CHECK_OR_RETURN_FALSE(
       grad_output.dim() == input.dim(),
-      "grad_output should have same number of dimensions as input; grad_output.dim() = %zd, input.dim() = %zd",
+      "grad_output should have same number of dimensions as input; grad_output.dim() = %" ET_PRI_TENSOR_DIM
+      ", input.dim() = %" ET_PRI_TENSOR_DIM,
       grad_output.dim(),
       input.dim());
 

--- a/kernels/portable/cpu/op_repeat_interleave.cpp
+++ b/kernels/portable/cpu/op_repeat_interleave.cpp
@@ -26,7 +26,7 @@ bool check_repeat_interleave_args(
       static_cast<int>(repeats.scalar_type()));
   ET_CHECK_OR_RETURN_FALSE(
       repeats.dim() == 1,
-      "repeats must be 1-D; repeats.dim() = %zd",
+      "repeats must be 1-D; repeats.dim() = %" ET_PRI_TENSOR_DIM,
       repeats.dim());
   ET_CHECK_OR_RETURN_FALSE(
       output_size_value == repeats_sum,

--- a/kernels/portable/cpu/op_topk.cpp
+++ b/kernels/portable/cpu/op_topk.cpp
@@ -32,7 +32,7 @@ bool check_topk_args(
   ET_CHECK_OR_RETURN_FALSE(
       k >= 0 && k <= nonempty_size(in, dim),
       "selected index k out of range; k = %" PRId64 ", dim = %" PRId64
-      ", in.dim() = %zd, nonempty_size(in, dim) = %zd",
+      ", in.dim() = %" ET_PRI_TENSOR_DIM ", nonempty_size(in, dim) = %zd",
       k,
       dim,
       in.dim(),

--- a/kernels/portable/cpu/util/activation_ops_util.cpp
+++ b/kernels/portable/cpu/util/activation_ops_util.cpp
@@ -43,7 +43,8 @@ bool check_glu_args(const Tensor& in, int64_t dim, Tensor& out) {
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_rank(in, out));
   ET_CHECK_OR_RETURN_FALSE(
       out.size(non_negative_dim) == dim_size / 2,
-      "output tensor must have half the size of the input tensor along the specified dimension; out.size(%zu) = %zd, dim_size = %zd",
+      "output tensor must have half the size of the input tensor along the specified dimension; out.size(%zu) = %" ET_PRI_TENSOR_SIZE
+      ", dim_size = %zd",
       non_negative_dim,
       out.size(non_negative_dim),
       dim_size);

--- a/kernels/portable/cpu/util/advanced_index_util.cpp
+++ b/kernels/portable/cpu/util/advanced_index_util.cpp
@@ -296,14 +296,15 @@ bool get_index_out_target_size(
 
   ET_CHECK_OR_RETURN_FALSE(
       static_cast<ssize_t>(num_null_indices + num_indexed_dims) <= in.dim(),
-      "Indexing too many dimensions; num_null_indices = %zu, num_indexed_dims = %zu, in.dim() = %zd",
+      "Indexing too many dimensions; num_null_indices = %zu, num_indexed_dims = %zu, in.dim() = %" ET_PRI_TENSOR_DIM,
       num_null_indices,
       num_indexed_dims,
       in.dim());
 
   ET_CHECK_OR_RETURN_FALSE(
       in.dim() + broadcast_ndim - num_indexed_dims <= kTensorDimensionLimit,
-      "Out tensor would exceed number of allowed dimensions; in.dim() = %zd, broadcast_ndim = %zu, num_indexed_dims = %zu, kTensorDimensionLimit = %zu",
+      "Out tensor would exceed number of allowed dimensions; in.dim() = %" ET_PRI_TENSOR_DIM
+      ", broadcast_ndim = %zu, num_indexed_dims = %zu, kTensorDimensionLimit = %zu",
       in.dim(),
       broadcast_ndim,
       num_indexed_dims,

--- a/kernels/portable/cpu/util/index_util.cpp
+++ b/kernels/portable/cpu/util/index_util.cpp
@@ -84,7 +84,7 @@ bool check_index_select_args(
   if (index.dim() > 0 && in.dim() == 0) {
     ET_CHECK_OR_RETURN_FALSE(
         index.numel() == 1,
-        "index_select: Index to scalar must have exactly 1 value; index.numel() = %zd",
+        "index_select: Index to scalar must have exactly 1 value; index.numel() = %" ET_PRI_TENSOR_NUMEL,
         index.numel());
   }
 
@@ -155,7 +155,7 @@ bool check_scatter_add_args(
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(self, src));
   ET_CHECK_OR_RETURN_FALSE(
       index.scalar_type() == ScalarType::Long,
-      "Expected dypte int64 for index; index.scalar_type() = %d",
+      "Expected dtype int64 for index; index.scalar_type() = %d",
       static_cast<int>(index.scalar_type()));
   ET_LOG_AND_RETURN_IF_FALSE(tensor_has_dim(self, dim));
 

--- a/kernels/portable/cpu/util/kernel_ops_util.cpp
+++ b/kernels/portable/cpu/util/kernel_ops_util.cpp
@@ -279,7 +279,7 @@ bool check_avg_pool2d_args(
   ET_CHECK_OR_RETURN_FALSE(
       (in.dim() == 3 && in.size(0) > 0 && in.size(1) > 0 && in.size(2) > 0) ||
           (in.dim() == 4 && in.size(1) > 0 && in.size(2) > 0 && in.size(3) > 0),
-      "Expected 3D or 4D (batch mode) tensor with optional 0 dim batch size for input; in.dim() = %zd",
+      "Expected 3D or 4D (batch mode) tensor with optional 0 dim batch size for input; in.dim() = %" ET_PRI_TENSOR_DIM,
       in.dim());
 
   ET_LOG_AND_RETURN_IF_FALSE(
@@ -351,7 +351,8 @@ bool check_convolution_args(
     ET_CHECK_OR_RETURN_FALSE(
         bias.value().size(0) == transposed ? groups * weight.size(1)
                                            : weight.size(0),
-        "bias length must equal number of output channels, but got %zd; expected %" PRId64,
+        "bias length must equal number of output channels, but got %" ET_PRI_TENSOR_SIZE
+        "; expected %" PRId64,
         bias.value().size(0),
         transposed ? groups * weight.size(1) : weight.size(0));
   }
@@ -491,7 +492,7 @@ bool check_max_pool2d_with_indices_args(
   ET_CHECK_OR_RETURN_FALSE(
       (in.dim() == 3 && in.size(0) > 0 && in.size(1) > 0 && in.size(2) > 0) ||
           (in.dim() == 4 && in.size(1) > 0 && in.size(2) > 0 && in.size(3) > 0),
-      "Expected 3D or 4D (batch mode) tensor with optional 0 dim batch size for input; in.dim() = %zd",
+      "Expected 3D or 4D (batch mode) tensor with optional 0 dim batch size for input; in.dim() = %" ET_PRI_TENSOR_DIM,
       in.dim());
 
   ET_LOG_AND_RETURN_IF_FALSE(
@@ -559,7 +560,7 @@ bool check_constant_pad_args(
 
   ET_CHECK_OR_RETURN_FALSE(
       static_cast<ssize_t>(pad.size() / 2) <= in.dim(),
-      "Padding array contains too many elements; pad.size()/2 = %zu, in.dim() = %zd",
+      "Padding array contains too many elements; pad.size()/2 = %zu, in.dim() = %" ET_PRI_TENSOR_DIM,
       pad.size() / 2,
       in.dim());
 

--- a/kernels/portable/cpu/util/normalization_ops_util.cpp
+++ b/kernels/portable/cpu/util/normalization_ops_util.cpp
@@ -88,14 +88,16 @@ bool check_layer_norm_args(
       ndim);
   ET_CHECK_OR_RETURN_FALSE(
       in.dim() >= static_cast<ssize_t>(ndim),
-      "Expected input tensor to have rank >= the length of normalized_shape; in.dim() = %zd, ndim = %zu",
+      "Expected input tensor to have rank >= the length of normalized_shape; in.dim() = %" ET_PRI_TENSOR_DIM
+      ", ndim = %zu",
       in.dim(),
       ndim);
   size_t shift = in.dim() - ndim;
   for (const auto d : c10::irange(ndim)) {
     ET_CHECK_OR_RETURN_FALSE(
         in.size(d + shift) == normalized_shape[d],
-        "Expected normalized_shape to match the sizes of input's rightmost dimensions; in.size(%zu) = %zd, normalized_shape[%zu] = %" PRId64,
+        "Expected normalized_shape to match the sizes of input's rightmost dimensions; in.size(%zu) = %" ET_PRI_TENSOR_SIZE
+        ", normalized_shape[%zu] = %" PRId64,
         d + shift,
         in.size(d + shift),
         d,
@@ -166,7 +168,8 @@ bool check_group_norm_args(
   ET_CHECK_OR_RETURN_FALSE(
       !weight.has_value() ||
           (weight.value().dim() == 1 && weight.value().size(0) == C),
-      "Expected weight to be a vector of size equal to the number of channels in input; weight.has_value() = %d, weight.dim() = %zd, weight.size(0) = %zd, C = %" PRId64,
+      "Expected weight to be a vector of size equal to the number of channels in input; weight.has_value() = %d, weight.dim() = %" ET_PRI_TENSOR_DIM
+      ", weight.size(0) = %" ET_PRI_TENSOR_SIZE ", C = %" PRId64,
       weight.has_value(),
       weight.has_value() ? weight.value().dim() : -1,
       weight.has_value() ? weight.value().size(0) : -1,
@@ -174,7 +177,8 @@ bool check_group_norm_args(
   ET_CHECK_OR_RETURN_FALSE(
       !bias.has_value() ||
           (bias.value().dim() == 1 && bias.value().size(0) == C),
-      "Expected bias to be a vector of size equal to the number of channels in input; bias.has_value() = %d, bias.dim() = %zd, bias.size(0) = %zd, C = %" PRId64,
+      "Expected bias to be a vector of size equal to the number of channels in input; bias.has_value() = %d, bias.dim() = %" ET_PRI_TENSOR_DIM
+      ", bias.size(0) = %" ET_PRI_TENSOR_SIZE ", C = %" PRId64,
       bias.has_value(),
       bias.has_value() ? bias.value().dim() : -1,
       bias.has_value() ? bias.value().size(0) : -1,

--- a/kernels/portable/cpu/util/repeat_util.cpp
+++ b/kernels/portable/cpu/util/repeat_util.cpp
@@ -28,7 +28,7 @@ bool check_repeat_args(
   // Ensure the self tensors list is non-empty.
   ET_CHECK_OR_RETURN_FALSE(
       static_cast<ssize_t>(repeats.size()) >= self.dim(),
-      "Number of dimensions of repeat dims can not be smaller than number of dimensions of tensor; repeats.size() = %zu, self.dim() = %zd",
+      "Number of dimensions of repeat dims can not be smaller than number of dimensions of tensor; repeats.size() = %zu, self.dim() = %" ET_PRI_TENSOR_DIM,
       repeats.size(),
       self.dim());
 
@@ -43,7 +43,8 @@ bool check_repeat_args(
   /// Check if out.size() is legal.
   ET_CHECK_OR_RETURN_FALSE(
       static_cast<size_t>(out.dim()) == repeats.size(),
-      "The dimension of out shall equal size of repeats, but now is %zd and %zu",
+      "The dimension of out shall equal size of repeats, but now is %" ET_PRI_TENSOR_DIM
+      " and %zu",
       out.dim(),
       repeats.size());
 

--- a/kernels/portable/cpu/util/slice_util.cpp
+++ b/kernels/portable/cpu/util/slice_util.cpp
@@ -20,19 +20,19 @@ bool check_narrow_copy_args(
     const Tensor& in,
     int64_t dim,
     int64_t start,
-    int64_t lenth,
+    int64_t length,
     Tensor& out) {
   ET_LOG_AND_RETURN_IF_FALSE(in.dim() > 0);
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, out));
   ET_LOG_AND_RETURN_IF_FALSE(tensor_has_dim(in, dim));
   ET_CHECK_OR_RETURN_FALSE(
-      lenth >= 0, "lenth must be non-negative; lenth = %" PRId64, lenth);
+      length >= 0, "length must be non-negative; length = %" PRId64, length);
   ET_LOG_AND_RETURN_IF_FALSE(start >= -in.size(dim));
   ET_LOG_AND_RETURN_IF_FALSE(start <= in.size(dim));
   if (start < 0) {
     start += in.size(dim);
   }
-  ET_LOG_AND_RETURN_IF_FALSE(start + lenth <= in.size(dim));
+  ET_LOG_AND_RETURN_IF_FALSE(start + length <= in.size(dim));
   return true;
 }
 

--- a/runtime/core/exec_aten/exec_aten.h
+++ b/runtime/core/exec_aten/exec_aten.h
@@ -95,6 +95,18 @@ inline ssize_t compute_numel(const SizesType* sizes, ssize_t dim) {
       c10::multiply_integers(c10::ArrayRef<SizesType>(sizes, dim)));
 }
 
+#undef ET_PRI_TENSOR_SIZE
+#define ET_PRI_TENSOR_SIZE PRId64
+
+#undef ET_PRI_TENSOR_DIM
+#define ET_PRI_TENSOR_DIM PRId64
+
+#undef ET_PRI_TENSOR_NUMEL
+#define ET_PRI_TENSOR_NUMEL PRId64
+
+#undef ET_PRI_SIZES_AND_STRIDES
+#define ET_PRI_SIZES_AND_STRIDES PRId64
+
 #else // Use executor types
 
 using Tensor = torch::executor::Tensor;

--- a/runtime/core/portable_type/tensor_impl.h
+++ b/runtime/core/portable_type/tensor_impl.h
@@ -270,6 +270,26 @@ ssize_t compute_numel(
     const ::executorch::runtime::etensor::TensorImpl::SizesType* sizes,
     ssize_t dim);
 
+/// Appropriate format specifier for the result of calling
+/// size(). Must be used instead of using zd directly to support ATen
+/// mode.
+#define ET_PRI_TENSOR_SIZE "zd"
+
+/// Appropriate format specifier for the result of calling
+/// dim(). Must be used instead of using zd directly to support ATen
+/// mode.
+#define ET_PRI_TENSOR_DIM "zd"
+
+/// Appropriate format specifier for the result of calling
+/// numel(). Must be used instead of using zd directly to support ATen
+/// mode.
+#define ET_PRI_TENSOR_NUMEL "zd"
+
+// Appropriate format specifier for elements of sizes() and
+// strides(). Must be used instead of using d directly to support ATen
+// mode.
+#define ET_PRI_SIZES_AND_STRIDES "d"
+
 } // namespace etensor
 } // namespace runtime
 } // namespace executorch


### PR DESCRIPTION
#9751 added a bunch of logging to error messages. We discovered after commit that it caused -Wformat warnings (turned into errors via -Werror) in ATen mode, because a bunch of Tensor methods return different types between ExecuTorch and ATen. This PR adds formatting macros to be used with this methods and uses them.