### PR TITLE
Turn on XNNPACK by default for wheels

### DIFF
--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -32,7 +32,7 @@ install_executorch() {
   which pip
   # Install executorch, this assumes that Executorch is checked out in the
   # current directory.
-  ./install_executorch.sh --pybind xnnpack "$@"
+  ./install_executorch.sh "$@"
   # Just print out the list of packages for debugging
   pip list
 }

--- a/install_executorch.py
+++ b/install_executorch.py
@@ -207,14 +207,10 @@ def main(args):
     use_pytorch_nightly = True
 
     wants_pybindings_off, pybind_defines = _list_pybind_defines(args)
-    if not wants_pybindings_off:
-        if len(pybind_defines) > 0:
-            # If the user explicitly provides a list of bindings, just use them
-            cmake_args += pybind_defines
-        else:
-            # If the user has not set pybindings off but also has not provided
-            # a list, then turn on xnnpack by default
-            cmake_args.append("-DEXECUTORCH_BUILD_XNNPACK=ON")
+    if wants_pybindings_off:
+        cmake_args.append("-DEXECUTORCH_BUILD_PYBIND=OFF")
+    else:
+        cmake_args += pybind_defines
 
     if args.clean:
         clean()

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ class ShouldBuild:
 
     @classmethod
     def xnnpack(cls) -> bool:
-        return cls._is_cmake_arg_enabled("EXECUTORCH_BUILD_XNNPACK", default=False)
+        return cls._is_cmake_arg_enabled("EXECUTORCH_BUILD_XNNPACK", default=True)
 
     @classmethod
     def training(cls) -> bool:
@@ -729,6 +729,9 @@ class CustomBuild(build):
                 "-DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON",  # add quantized ops to pybindings.
                 "-DEXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT=ON",
             ]
+
+            if ShouldBuild.xnnpack():
+                cmake_args += ["-DEXECUTORCH_BUILD_XNNPACK=ON"]
 
             if ShouldBuild.training():
                 build_args += ["--target", "_training_lib"]


### PR DESCRIPTION
### Summary

We pretty much always include xnnpack when building wheels, so why not just turn it on by default? If users want it off, they can opt-out.

![image](https://github.com/user-attachments/assets/f7c7003d-1768-4858-a777-b47064f65e77)


### Test plan

CI
