### PR TITLE
[ExecuTorch][to_backend] Introduce preprocess_all method to backend details

### DIFF
--- a/exir/backend/backend_details.py
+++ b/exir/backend/backend_details.py
@@ -73,3 +73,12 @@ class BackendDetails(ABC):
         # Users should return a compiled blob - a binary that can run the desired
         # program in the backend.
         pass
+    
+    @staticmethod
+    # it's a virtual method and inheritant class needs to implement the actual function
+    @abstractmethod
+    def preprocess_all(
+        edge_programs: Dict[str, List[ExportedProgram]],
+        compile_specs: Dict[str, List[List[CompileSpec]]],
+    ) -> Dict[str, list[PreprocessResult]]:
+        pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #9811
* __->__ #9810

We introduce the new static method preprocess_all. This is not an enforced method because preprocess() is enforced and can be used instead.

Ideally, I want the default implementation of preprocess_all, to just loop through the exported programs for each method and use preprocess() to lower them. However since each are static methods, I wasn't able to find a good way to do this. Suggestions would be greatly appreciated for that.

Differential Revision: [D69954544](https://our.internmc.facebook.com/intern/diff/D69954544/)