### PR TITLE
Arm backend: Disable test case test_w2l_arm.py::test_w2l_u85_BI

### DIFF
--- a/backends/arm/test/models/test_w2l_arm.py
+++ b/backends/arm/test/models/test_w2l_arm.py
@@ -132,6 +132,7 @@ class TestW2L(unittest.TestCase):
     @pytest.mark.slow
     @pytest.mark.corstone_fvp
     @conftest.expectedFailureOnFVP  # TODO: MLETORCH-761
+    @pytest.mark.skip(reason="Intermittent timeout issue: MLETORCH-856")
     def test_w2l_u85_BI(self):
         tester = self._test_w2l_ethos_BI_pipeline(
             self.w2l,


### PR DESCRIPTION
test_w2l_arm.py::test_w2l_u85_BI fails intermittently by timing out. Disable the test case until we have a solution.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218