### PR TITLE
Fix breaks from googletest upgrade (vulkan_compute_api_test) (#9760)

### DIFF
--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <bitset>
+#include <iomanip>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Summary:

Missing include in vulkan_compute_api_test.cpp - added

Reviewed By: SS-JIA

Differential Revision: D72139603




cc @SS-JIA @manuelcandales @cbilgin