### PR TITLE
Arm backend: Limit number of build jobs

### DIFF
--- a/backends/arm/scripts/build_portable_kernels.sh
+++ b/backends/arm/scripts/build_portable_kernels.sh
@@ -75,7 +75,7 @@ cmake                                                 \
     -B"${et_build_dir}/examples/arm"                  \
     "${et_root_dir}/examples/arm"
 
-cmake --build "${et_build_dir}/examples/arm" --parallel --config ${build_type} --
+cmake --build "${et_build_dir}/examples/arm" -j$(nproc) --config ${build_type} --
 
 set +x
 

--- a/backends/arm/scripts/build_quantized_ops_aot_lib.sh
+++ b/backends/arm/scripts/build_quantized_ops_aot_lib.sh
@@ -51,4 +51,4 @@ CXXFLAGS="-fno-exceptions -fno-rtti" cmake \
     -B${et_build_dir}                         \
     .
 
-cmake --build ${et_build_dir} --parallel -- quantized_ops_aot_lib
+cmake --build ${et_build_dir} -j$(nproc) -- quantized_ops_aot_lib


### PR DESCRIPTION
In certain build environments, without limiting the number of build jobs, build may abort because memory is running low.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218