### PR TITLE
Arm backend: Convert assert to throw ValueError in op_tanh

### DIFF
--- a/backends/arm/operators/op_tanh.py
+++ b/backends/arm/operators/op_tanh.py
@@ -34,5 +34,14 @@ class TanhVisitor_080_MI(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        assert inputs[0].dtype == output.dtype == ts.DType.FP32
+        if len(node.all_input_nodes) != 1:
+            raise ValueError(
+                f"Expected 1 input for {self.target}, got {len(node.all_input_nodes)}"
+            )
+        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
+            raise ValueError(
+                f"Input and output for {self.target} need to be FP32, got input_dtype: "
+                f"{inputs[0].dtype} and output_dtype: {output.dtype}"
+            )
+
         tosa_graph.addOperator(TosaOp.Op().TANH, [inputs[0].name], [output.name])


### PR DESCRIPTION
Asserts are converted to proper raises to ensure graph integrity.

It should not be possible for tanh to have more than 1 input for a correctly formatted graph, but in the node visitor we cannot know for sure that the graph is formatted correctly.

torch.tanh supports more data types than fp32, which is why it should be checked.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218