### PR TITLE
Arm backend: Remove use of TOSA_DBG_VERBOSE

### DIFF
--- a/backends/arm/tosa_backend.py
+++ b/backends/arm/tosa_backend.py
@@ -11,7 +11,6 @@
 # JIT compiler flows.
 #
 import logging
-import os
 from typing import cast, final, List
 
 import serializer.tosa_serializer as ts  # type: ignore
@@ -34,10 +33,6 @@ from torch.fx import Node
 
 # TOSA backend debug functionality
 logger = logging.getLogger(__name__)
-TOSA_DBG_VERBOSE = os.environ.get("TOSA_DBG_VERBOSE") == "1"
-if TOSA_DBG_VERBOSE:
-    logging.basicConfig(level=logging.INFO)
-    logger.setLevel(logging.INFO)
 
 
 def _get_first_delegation_tag(graph_module) -> str | None:

--- a/backends/arm/tosa_partitioner.py
+++ b/backends/arm/tosa_partitioner.py
@@ -6,7 +6,6 @@
 # pyre-unsafe
 
 import logging
-import os
 from typing import Callable, List, Optional, Sequence, Tuple
 
 import torch
@@ -33,11 +32,6 @@ from torch.fx.passes.operator_support import OperatorSupportBase
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-TOSA_DBG_VERBOSE = os.environ.get("TOSA_DBG_VERBOSE") == "1"
-if TOSA_DBG_VERBOSE:
-    logging.basicConfig(level=logging.INFO)
-    logger.setLevel(logging.INFO)
 
 
 def is_quant_node(node: torch.fx.node.Node) -> bool:

--- a/backends/arm/tosa_utils.py
+++ b/backends/arm/tosa_utils.py
@@ -19,10 +19,6 @@ from serializer.tosa_serializer import TosaOp
 from torch.fx import Node
 
 logger = logging.getLogger(__name__)
-TOSA_DBG_VERBOSE = os.environ.get("TOSA_DBG_VERBOSE") == "1"
-if TOSA_DBG_VERBOSE:
-    logging.basicConfig(level=logging.INFO)
-    logger.setLevel(logging.INFO)
 
 
 def dbg_node(node: torch.fx.Node, graph_module: torch.fx.GraphModule):


### PR DESCRIPTION
Environment variable TOSA_DBG_VERBOSE was used to determine and setting the logging levels inside ArmBackend. This patch removes all uses of that variable.

cc @digantdesai @freddan80 @per @zingo