### PR TITLE
Arm backend: Handle memory mode corectly in test_model.py

### DIFF
--- a/backends/arm/test/test_model.py
+++ b/backends/arm/test/test_model.py
@@ -176,6 +176,7 @@ def build_ethosu_runtime(
     pte_file: str,
     target: str,
     system_config: str,
+    memory_mode: str,
     extra_flags: str,
     elf_build_path: str,
 ):
@@ -195,6 +196,7 @@ def build_ethosu_runtime(
             f"--target={target}",
             "--build_type=Release",
             f"--system_config={system_config}",
+            f"--memory_mode={memory_mode}",
             extra_build_flag,
             f"--output={elf_build_path}",
         ]
@@ -256,6 +258,7 @@ if __name__ == "__main__":
                 pte_file,
                 args.target,
                 args.system_config,
+                args.memory_mode,
                 args.extra_flags,
                 elf_build_path,
             )


### PR DESCRIPTION
This fix a bug that when you used non default memory mode the PTE was correctly build but the elf was still build with the default mode.

Change-Id: I1a7a70d6a161c740a2562814acc2cc7e99b410f5


cc @digantdesai @freddan80 @per @oscarandersson8218