### PR TITLE
Arm backend: Skip instead of returning in Llama test

### DIFF
--- a/backends/arm/test/models/test_llama.py
+++ b/backends/arm/test/models/test_llama.py
@@ -11,6 +11,7 @@ import os
 import sys
 import unittest
 
+import pytest
 import torch
 
 from executorch.backends.arm.test import common, conftest
@@ -102,7 +103,7 @@ class TestLlama(unittest.TestCase):
         llama_model, llama_inputs, llama_meta = self.prepare_model()
 
         if llama_model is None and llama_inputs is None and llama_meta is None:
-            return
+            pytest.skip("Missing model and/or input files")
 
         with torch.no_grad():
             (


### PR DESCRIPTION
If the user does not provide input files with the --llama_inputs argument, the test is not run. Change the return statement into a pytest.skip so that the test output show a skip rather than a pass.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218