### PR TITLE
Arm backend: Add pytest.mark.flaky on U85 tests in test_mm.py

### DIFF
--- a/backends/arm/test/ops/test_mm.py
+++ b/backends/arm/test/ops/test_mm.py
@@ -6,6 +6,7 @@
 
 from typing import Callable
 
+import pytest
 import torch
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import (
@@ -53,6 +54,7 @@ def test_mm_tosa_u55(test_data_generator: Callable[[], tuple]):
 
 
 @parameterized.expand(MM.test_data_generators)
+@pytest.mark.flaky  # Investigate flakiness (MLETORCH-870)
 def test_mm_tosa_u85(test_data_generator: Callable[[], tuple]):
     test_data = test_data_generator()
     EthosU85PipelineBI[test_t](MM(), test_data, MM.aten_op, MM.exir_op).run()
@@ -67,6 +69,7 @@ def test_mm_tosa_u55_on_fvp(test_data_generator: Callable[[], tuple]):
 
 @parameterized.expand(MM.test_data_generators)
 @common.SkipIfNoCorstone320
+@pytest.mark.flaky  # Investigate flakiness (MLETORCH-870)
 def test_mm_tosa_u85_on_fvp(test_data_generator: Callable[[], tuple]):
     test_data = test_data_generator()
     EthosU85PipelineBI[test_t](


### PR DESCRIPTION
The output verification sometimes fails for the mm tests on U85. Add pytest.mark.flaky decorators to the tests to prevent sporadic failures.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218