### PR TITLE
Arm backend: Convert assert to throw ValueError in op_exp

### DIFF
--- a/backends/arm/operators/op_exp.py
+++ b/backends/arm/operators/op_exp.py
@@ -36,7 +36,14 @@ class ExpVisitor_0_80_MI(NodeVisitor):
         output: TosaArg,
     ) -> None:
 
-        assert len(node.all_input_nodes) == 1
-        assert inputs[0].dtype == output.dtype == ts.DType.FP32
+        if len(node.all_input_nodes) != 1:
+            raise ValueError(
+                f"Expected 1 input for {self.target}, got {len(node.all_input_nodes)}"
+            )
+        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
+            raise ValueError(
+                f"Input and output for {self.target} need to be FP32, got input dtype: "
+                f"{inputs[0].dtype} and output dtype: {output.dtype}"
+            )
 
         tosa_graph.addOperator(TosaOp.Op().EXP, [inputs[0].name], [output.name])


### PR DESCRIPTION
Asserts are converted to proper raises to ensure graph integrity.

It should not be possible for exp to have more than 1 input for a correctly formatted graph, but in the node visitor we cannot know for sure that the graph is formatted correctly.

torch.exp supports more data types than fp32, which is why it should be checked.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218