### PR TITLE
Arm backend: Convert assert to raise ValueError for comparison operators

### DIFF
--- a/backends/arm/operators/op_eq.py
+++ b/backends/arm/operators/op_eq.py
@@ -34,9 +34,11 @@ class EqualVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        assert (
-            inputs[0].dtype == inputs[1].dtype
-        ), "EQ must have the same dtypes as input"
+        if inputs[0].dtype != inputs[1].dtype:
+            raise TypeError(
+                "All inputs need to have the same data type for operator EQ but got "
+                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
+            )
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_ge.py
+++ b/backends/arm/operators/op_ge.py
@@ -34,9 +34,11 @@ class GreaterEqualVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        assert (
-            inputs[0].dtype == inputs[1].dtype
-        ), "GE must have the same dtypes as input"
+        if inputs[0].dtype != inputs[1].dtype:
+            raise TypeError(
+                "All inputs need to have the same data type for operator GE but got "
+                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
+            )
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_gt.py
+++ b/backends/arm/operators/op_gt.py
@@ -34,9 +34,11 @@ class GreaterThanVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        assert (
-            inputs[0].dtype == inputs[1].dtype
-        ), "GT must have the same dtypes as input"
+        if inputs[0].dtype != inputs[1].dtype:
+            raise TypeError(
+                "All inputs need to have the same data type for operator GT but got "
+                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
+            )
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_le.py
+++ b/backends/arm/operators/op_le.py
@@ -34,9 +34,11 @@ class LessEqualVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        assert (
-            inputs[0].dtype == inputs[1].dtype
-        ), "LE must have the same dtypes as input"
+        if inputs[0].dtype != inputs[1].dtype:
+            raise TypeError(
+                "All inputs need to have the same data type for operator LE but got "
+                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
+            )
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_lt.py
+++ b/backends/arm/operators/op_lt.py
@@ -34,9 +34,11 @@ class LessThanVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        assert (
-            inputs[0].dtype == inputs[1].dtype
-        ), "LT must have the same dtypes as input"
+        if inputs[0].dtype != inputs[1].dtype:
+            raise TypeError(
+                "All inputs need to have the same data type for operator LT but got "
+                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
+            )
 
         input_nodes = inputs
         # Handle quantization


### PR DESCRIPTION
Asserts are converted to proper raises to ensure graph integrity.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218