### PR TITLE
[ez][release blocker fix] Insert `linalg_vector_norm` into decomp table used for Edge export

### DIFF
--- a/exir/tracer.py
+++ b/exir/tracer.py
@@ -631,8 +631,18 @@ def _default_decomposition_table(
         ]
         # pyre-fixme[7]: Expected `Dict[OpOverload, typing.Callable[..., executorch.e...
         return get_decompositions(decomp_opset)
+
+    decomps = default_decompositions()
+    # Add edge specific decompositions
+    additional_decomp_ops = [
+        # TODO: Eventually this op should be added to the core decompo table, and will not
+        # need to be added here.
+        torch.ops.aten.linalg_vector_norm.default,
+    ]
+    additional_decomps = get_decompositions(additional_decomp_ops)
+    decomps.update(additional_decomps)
     # pyre-fixme[7]: Expected `Dict[OpOverload, typing.Callable[..., executorch.exir....
-    return default_decompositions()
+    return decomps
 
 
 def dynamo_trace(


### PR DESCRIPTION

Summary:
## Context

Addresses this [release blocker](https://github.com/orgs/pytorch/projects/99/views/1?pane=issue&itemId=104088363&issue=pytorch%7Cpytorch%7C150207) issue. Some models cannot export because they use `linalg_vector_norm` which is not currently an ATen operator.

I initially tried adding the op to the core decomp table, but the decomp is not passing pytorch correctness tests. Please see https://github.com/pytorch/pytorch/pull/150241 for more details.

## Changes

Since we currently cannot include the op in PyTorch's decomp table, instead we can insert the op into the edge decomp table directly.

This PR is a simple change to add `linalg_vector_norm` directly to the edge decomp table.

Test Plan:
Tested exporting and running a model with the `linalg_vector_norm` op via the following script.

```
import torch
from executorch.exir import to_edge_transform_and_lower, EdgeCompileConfig
from torch.export import Dim, export

from executorch.extension.pybindings.portable_lib import (  # @manual
    _load_for_executorch_from_buffer,
)

class Model(torch.nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, x):
        return torch.linalg.vector_norm(x, 2)

model = Model()
inputs = (torch.randn(1,1,16,16),)
dynamic_shapes = {
    "x": {
        2: Dim("h", min=16, max=1024),
        3: Dim("w", min=16, max=1024),
    }
}

exported_program = export(model, inputs, dynamic_shapes=dynamic_shapes)
executorch_program = to_edge_transform_and_lower(
    exported_program,
    compile_config=EdgeCompileConfig(_check_ir_validity=False),
).to_executorch()


executorch_module = _load_for_executorch_from_buffer(
    executorch_program.buffer
)

model_output = executorch_module.run_method(
    "forward", tuple(inputs)
)

print(model_output)
```
