### PR TITLE
Expose L4 ops to ExecuTorch Client and add MWA to ExecuTorch Client

### DIFF
--- a/kernels/quantized/targets.bzl
+++ b/kernels/quantized/targets.bzl
@@ -61,6 +61,10 @@ def define_common_targets():
         name = "all_quantized_ops",
         ops_schema_yaml_target = ":quantized.yaml",
         define_static_targets = True,
+        visibility = [
+                "//executorch/...",
+                "@EXECUTORCH_CLIENTS",
+        ],
     )
 
     # On Windows we can only compile these two ops currently, so adding a


### PR DESCRIPTION
Summary:
Expose L4 ops to ExecuTorch Client and add MWA to ExecuTorch Client
- This is needed to add Llama4 Runners to MWA

Reviewed By: larryliu0820

Differential Revision: D72598211


