### PR TITLE
[Release 0.6] update torchao pin

### DIFF
--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -61,7 +61,7 @@ jobs:
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
       # Meta's macOS runners do not have Xcode, so use GitHub's runners.
-      runner-type: macos-15-xlarge
+      runner-type: macos-latest-xlarge
       setup-miniconda: true
       smoke-test-script: ${{ matrix.smoke-test-script }}
       trigger-event: ${{ github.event_name }}

--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -61,7 +61,7 @@ jobs:
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
       # Meta's macOS runners do not have Xcode, so use GitHub's runners.
-      runner-type: macos-latest-xlarge
+      runner-type: macos-15-xlarge
       setup-miniconda: true
       smoke-test-script: ${{ matrix.smoke-test-script }}
       trigger-event: ${{ github.event_name }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,8 @@ dependencies=[
   "ruamel.yaml",
   "sympy",
   "tabulate",
-  "torchao==0.10.0"
+  # Keep this version in sync with: third-party/ao pin
+  "torchao==0.10.0",
   "typing-extensions",
   # Keep this version in sync with: ./backends/apple/coreml/scripts/install_requirements.sh
   "coremltools==8.2; platform_system == 'Darwin'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies=[
   "ruamel.yaml",
   "sympy",
   "tabulate",
+  "torchao==0.10.0"
   "typing-extensions",
   # Keep this version in sync with: ./backends/apple/coreml/scripts/install_requirements.sh
   "coremltools==8.2; platform_system == 'Darwin'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,6 @@ dependencies=[
   "ruamel.yaml",
   "sympy",
   "tabulate",
-  # Keep this version in sync with: third-party/ao pin
-  "torchao==0.10.0",
   "typing-extensions",
   # Keep this version in sync with: ./backends/apple/coreml/scripts/install_requirements.sh
   "coremltools==8.2; platform_system == 'Darwin'",


### PR DESCRIPTION
This PR is the first step to addressing https://github.com/pytorch/executorch/issues/9940 and making torchao installable on ET/release/0.6.

1. This PR bumps torchao pin to torchao/release/0.10.0 branch.

2. We will follow-up with a PR in release/0.6 to bump the pin and add torchao==0.10.0 to the pyproject.toml file.