### PR TITLE
[Release 0.6] bump torchao pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies=[
   "ruamel.yaml",
   "sympy",
   "tabulate",
+  "torchao==0.10.0",
   "typing-extensions",
   # Keep this version in sync with: ./backends/apple/coreml/scripts/install_requirements.sh
   "coremltools==8.2; platform_system == 'Darwin'",


### PR DESCRIPTION
This PR bumps the torchao pins for the ExecuTorch 0.6 release branch to the torchao 0.10.0 release:

1. The pin in third-party/ao is bumped to branch "release/0.10.0".
2. We add "torchao==0.10.0" to the pyproject.toml.

This is intended to address https://github.com/pytorch/executorch/issues/9940 and follows the corresponding bin bump in third-party/ao on main (https://github.com/pytorch/executorch/pull/9947/files).