### PR TITLE
[RELEASE 0.6] Change maven to 0.6.0-rc1 in Getting Started

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -119,8 +119,10 @@ To add the library to your app, add the following dependency to gradle build rul
 ```
 # app/build.gradle.kts
 dependencies {
-  implementation("org.pytorch:executorch-android:0.5.1")
+  implementation("org.pytorch:executorch-android:0.6.0-rc3")
 }
+
+# See latest available versions in https://mvnrepository.com/artifact/org.pytorch/executorch-android
 ```
 
 #### Runtime APIs


### PR DESCRIPTION
Will need to drop -rc1 suffix before the release.