### PR TITLE
Add support for the default float, int and bool types for executorch::runtime::etensor::Scalar to` method

### DIFF
--- a/runtime/core/portable_type/scalar_type.h
+++ b/runtime/core/portable_type/scalar_type.h
@@ -126,6 +126,19 @@ struct alignas(1) Float8_e4m3fnuz {
   _(uint32_t, UInt32) /* 28 */                                               \
   _(uint64_t, UInt64) /* 29 */
 
+
+  #define ET_FORALL_FLOAT_INT_BOOL_TYPES(_)                                                 \
+  _(uint8_t, Byte)                                                                          \
+  _(int8_t, Char)                                                                           \
+  _(int16_t, Short)                                                                         \
+  _(int, Int)                                                                               \
+  _(int64_t, Long)                                                                          \
+  _(::executorch::runtime::etensor::Half, Half)                                             \
+  _(float, Float)                                                                           \
+  _(double, Double)                                                                         \
+  _(bool, Bool)                                                                             \
+  _(::executorch::runtime::etensor::BFloat16, BFloat16)
+
 /**
  * Data types (dtypes) that can be used as element types in ETensors.
  */

--- a/runtime/core/portable_type/test/scalar_test.cpp
+++ b/runtime/core/portable_type/test/scalar_test.cpp
@@ -7,6 +7,8 @@
  */
 
 #include <executorch/runtime/core/portable_type/scalar.h>
+#include <executorch/runtime/core/portable_type/bfloat16.h>
+#include <executorch/runtime/core/portable_type/half.h>
 #include <executorch/test/utils/DeathTest.h>
 #include <gtest/gtest.h>
 
@@ -15,8 +17,16 @@ using executorch::runtime::etensor::Scalar;
 TEST(ScalarTest, ToScalarType) {
   Scalar s_d((double)3.141);
   EXPECT_EQ(s_d.to<double>(), 3.141);
+  EXPECT_EQ(s_d.to<float>(), (float)3.141);
+  EXPECT_EQ(s_d.to<::executorch::runtime::etensor::Half>(), (::executorch::runtime::etensor::Half)3.141);
+  EXPECT_EQ(s_d.to<::executorch::runtime::etensor::BFloat16>(), (::executorch::runtime::etensor::BFloat16)3.141);
+
   Scalar s_i((int64_t)3);
   EXPECT_EQ(s_i.to<int64_t>(), 3);
+  EXPECT_EQ(s_i.to<int32_t>(), 3);
+  EXPECT_EQ(s_i.to<int16_t>(), 3);
+  EXPECT_EQ(s_i.to<int8_t>(), 3);
+  EXPECT_EQ(s_i.to<bool>(), true);
   Scalar s_b(true);
   EXPECT_EQ(s_b.to<bool>(), true);
 }


### PR DESCRIPTION
### Summary
* Added support for `float`, `::executorch::runtime::etensor::Half`, and `::executorch::runtime::etensor::BFloat16` for `to` method of ExecuTorch's Scalar 
* Replaced separate `to` methods with `to##name()` macros (same as [PyTorch c10::Scalar](https://github.com/pytorch/pytorch/blob/main/c10/core/Scalar.h#L115)). 
* Added constructor for `float` type. 
* This PR does not cover `uint16/32/64_t` types (since 'uint64_t' can overflow' int64_t', separate logic is required) and does not include `executorch::runtime::etensor::complex`. 
* I haven’t added overflow checks before because  I'm not sure if I can copy (c10 dir in executorch) [`c10::overflows.h` from torch](https://github.com/pytorch/pytorch/blob/main/c10/util/overflows.h).  (I will add an overflow check after I figure out what is the right way to do this :))


I need a bit further guidance related to adding support for more complex types and handling overflows:
1. I'm thinking about whether it’s better to create a separate `TypeCast.h` for typecasting (similar to PyTorch c10). Would this be better than having the casting code in the `Scalar` class?
2. Can I copy and use `c10::overflows.h` from pytorch c10 to handle overflows?

Fixes #9500 

P.S. If you have any concerns about this PR, please let me know, I will fix :)


### Test plan

I added tests in' runtime/core/portable_type/test/scalar_test.cpp' for additional types types. 
