### PR TITLE
[arm][ez] Add `xfail` for `norm` tests

### DIFF
--- a/backends/arm/test/models/test_torch_functions.py
+++ b/backends/arm/test/models/test_torch_functions.py
@@ -101,6 +101,7 @@ test_parameters = {test[0]: test[1:] for test in module_tests}
         "Requires dynamic output shape.",
         "topk": "NotImplementedError: No registered serialization name for <class 'torch.return_types.topk'> found",
         "sort": "NotImplementedError: No registered serialization name for <class 'torch.return_types.sort'> found",
+        "norm": "An error occurred when running the 'KeepDimsFalseToSqueezePass' pass after the following passes:",
     },
 )
 def test_torch_fns_MI(test_data):
@@ -129,6 +130,7 @@ def test_torch_fns_MI(test_data):
         "topk": "NotImplementedError: No registered serialization name for <class 'torch.return_types.topk'> found",
         "sort": "NotImplementedError: No registered serialization name for <class 'torch.return_types.sort'> found",
         "t": "MLETORCH-855: Issue with Quantization folding.",
+        "norm": "An error occurred when running the 'KeepDimsFalseToSqueezePass' pass after the following passes:",
     },
     strict=False,
 )


### PR DESCRIPTION

Summary:
## Context

https://github.com/pytorch/executorch/pull/9938 made it so that `linalg_vector_norm` is now decomposed when exporting to Edge. However, this broke some tests in the arm delegate because export passes cannot handle the decomposed operator sequence. To account for this, add `xfail` for the failing tests since `linalg_vector_norm` is not supported in TOSA yet.


## Changes

Add `xfail` for `norm` tests in `test_torch_functions.py`

Test Plan:
## Test Plan

Check CI that failing test is recovered.
