### PR TITLE
[pytorch/executorch][diff_train] [ez][release blocker fix] Insert `linalg_vector_norm` into decomp table used for Edge export (#9938)

### DIFF
--- a/exir/tracer.py
+++ b/exir/tracer.py
@@ -631,8 +631,18 @@ def _default_decomposition_table(
         ]
         # pyre-fixme[7]: Expected `Dict[OpOverload, typing.Callable[..., executorch.e...
         return get_decompositions(decomp_opset)
+
+    decomps = default_decompositions()
+    # Add edge specific decompositions
+    additional_decomp_ops = [
+        # TODO: Eventually this op should be added to the core decompo table, and will not
+        # need to be added here.
+        torch.ops.aten.linalg_vector_norm.default,
+    ]
+    additional_decomps = get_decompositions(additional_decomp_ops)
+    decomps.update(additional_decomps)
     # pyre-fixme[7]: Expected `Dict[OpOverload, typing.Callable[..., executorch.exir....
-    return default_decompositions()
+    return decomps
 
 
 def dynamo_trace(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

## Context

Addresses this [release
blocker](https://github.com/orgs/pytorch/projects/99/views/1?pane=issue&itemId=104088363&issue=pytorch%7Cpytorch%7C150207)
issue. Some models cannot export because they use `linalg_vector_norm`
which is not currently an ATen operator.

I initially tried adding the op to the core decomp table, but the decomp
is not passing pytorch correctness tests. Please see
https://github.com/pytorch/pytorch/pull/150241 for more details.

## Changes

Since we currently cannot include the op in PyTorch's decomp table,
instead we can insert the op into the edge decomp table directly.

This PR is a simple change to add `linalg_vector_norm` directly to the
edge decomp table.


Internal:
<< DO NOT EDIT BELOW THIS LINE >>

**GitHub Author**: Sicheng Stephen Jia <ssjia@meta.com> (Meta Employee)
**GitHub Repo**: [pytorch/executorch](https://github.com/pytorch/executorch)
**GitHub Pull Request**: [#9938](https://github.com/pytorch/executorch/pull/9938)

Initially generated by: https://www.internalfb.com/intern/sandcastle/job/4503601401156690/

This was imported as part of a Diff Train.
Please review this as soon as possible. Since it is a direct copy of a commit on
GitHub, there shouldn't be much to do.

diff-train-source-id: c2e3e17af3945a756aaee023f2e9d55d4baab637

Differential Revision: [D72729066](https://our.internmc.facebook.com/intern/diff/D72729066/)