### PR TITLE
[pytorch/executorch][diff_train] Add maven version in main in Getting Started page (#9980)

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -111,6 +111,8 @@ To add the library to your app, add the following dependency to gradle build rul
 dependencies {
   implementation("org.pytorch:executorch-android:0.5.1")
 }
+
+# See latest available versions in https://mvnrepository.com/artifact/org.pytorch/executorch-android
 ```
 
 #### Runtime APIs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Internal:
<< DO NOT EDIT BELOW THIS LINE >>

**GitHub Author**: Mergen Nachin <mnachin@meta.com> (Meta Employee)
**GitHub Repo**: [pytorch/executorch](https://github.com/pytorch/executorch)
**GitHub Pull Request**: [#9980](https://github.com/pytorch/executorch/pull/9980)

Initially generated by: https://www.internalfb.com/intern/sandcastle/job/36028798801202800/

This was imported as part of a Diff Train.
Please review this as soon as possible. Since it is a direct copy of a commit on
GitHub, there shouldn't be much to do.

diff-train-source-id: 9b7a8783951bd6eb7b68b08fe80e888bb54fdf6c

Differential Revision: [D72729754](https://our.internmc.facebook.com/intern/diff/D72729754/)