### PR TITLE
[ez] Remove duplicate log_intermediate_output_delegate_helper

### DIFF
--- a/devtools/etdump/etdump_flatcc.cpp
+++ b/devtools/etdump/etdump_flatcc.cpp
@@ -323,40 +323,32 @@ Result<bool> ETDumpGen::log_intermediate_output_delegate(
     const char* name,
     DelegateDebugIntId delegate_debug_index,
     const ArrayRef<Tensor> output) {
-  log_intermediate_output_delegate_helper(name, delegate_debug_index, output);
-  Result<bool> result = log_intermediate_output_delegate_helper(
+  return log_intermediate_output_delegate_helper(
       name, delegate_debug_index, output);
-  return result;
 }
 
 Result<bool> ETDumpGen::log_intermediate_output_delegate(
     const char* name,
     DelegateDebugIntId delegate_debug_index,
     const int& output) {
-  log_intermediate_output_delegate_helper(name, delegate_debug_index, output);
-  Result<bool> result = log_intermediate_output_delegate_helper(
+  return log_intermediate_output_delegate_helper(
       name, delegate_debug_index, output);
-  return result;
 }
 
 Result<bool> ETDumpGen::log_intermediate_output_delegate(
     const char* name,
     DelegateDebugIntId delegate_debug_index,
     const bool& output) {
-  log_intermediate_output_delegate_helper(name, delegate_debug_index, output);
-  Result<bool> result = log_intermediate_output_delegate_helper(
+  return log_intermediate_output_delegate_helper(
       name, delegate_debug_index, output);
-  return result;
 }
 
 Result<bool> ETDumpGen::log_intermediate_output_delegate(
     const char* name,
     DelegateDebugIntId delegate_debug_index,
     const double& output) {
-  log_intermediate_output_delegate_helper(name, delegate_debug_index, output);
-  Result<bool> result = log_intermediate_output_delegate_helper(
+  return log_intermediate_output_delegate_helper(
       name, delegate_debug_index, output);
-  return result;
 }
 
 template <typename T>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #10053

- Remove duplicate `log_intermediate_output_delegate_helper()`
- Return directly rather than getting the value first.

Differential Revision: [D72768360](https://our.internmc.facebook.com/intern/diff/D72768360/)