### PR TITLE
Use certifi certs for buck download

### DIFF
--- a/tools/cmake/resolve_buck.py
+++ b/tools/cmake/resolve_buck.py
@@ -9,6 +9,7 @@
 import argparse
 import os
 import platform
+import ssl
 import stat
 import sys
 import urllib.request
@@ -18,6 +19,7 @@ from pathlib import Path
 from typing import Sequence, Union
 
 import buck_util
+import certifi
 import zstd
 
 """
@@ -201,26 +203,23 @@ def resolve_buck2(args: argparse.Namespace) -> Union[str, int]:
             if os.path.isfile(buck2_local_path):
                 return buck2_local_path
 
-            buck2_archive_url = f"https://github.com/facebook/buck2/releases/download/{target_buck_version}/{buck_info.archive_name}"
+        buck2_archive_url = f"https://github.com/facebook/buck2/releases/download/{target_buck_version}/{buck_info.archive_name}"
 
-            try:
-                print(f"Downloading buck2 from {buck2_archive_url}...", file=sys.stderr)
-                archive_file, _ = urllib.request.urlretrieve(buck2_archive_url)
+        print(f"Downloading buck2 from {buck2_archive_url}...", file=sys.stderr)
+        ssl_context = ssl.create_default_context(cafile=certifi.where())
 
-                # Extract and chmod.
-                with open(archive_file, "rb") as f:
-                    data = f.read()
-                    decompressed_bytes = zstd.decompress(data)
+        with urllib.request.urlopen(buck2_archive_url, context=ssl_context) as request:
+            # Extract and chmod.
+            data = request.read()
+            decompressed_bytes = zstd.decompress(data)
 
-                with open(buck2_local_path, "wb") as f:
-                    f.write(decompressed_bytes)
+            with open(buck2_local_path, "wb") as f:
+                f.write(decompressed_bytes)
 
-                file_stat = os.stat(buck2_local_path)
-                os.chmod(buck2_local_path, file_stat.st_mode | stat.S_IEXEC)
-            finally:
-                os.remove(archive_file)
+        file_stat = os.stat(buck2_local_path)
+        os.chmod(buck2_local_path, file_stat.st_mode | stat.S_IEXEC)
 
-            return buck2_local_path
+    return buck2_local_path
 
 
 def main():


### PR DESCRIPTION
### Summary
Depending on how Python is installed and managed, it is common for certificates to not be installed out of box on Macs. This can cause the download of buck2 as part of the build process to fail with a certificate error.

While the ultimate solution for this is for the user to install certs in their environment, we can smooth this over a bit for build by pointing urllib at the certifi package certs, which we install as part of install_requirements.

### Test plan
I worked with @nil-is-all to verify that this fix allowed him to build and install ExecuTorch from a clean environment. Without this change, he was seeing cert failure errors during buck download.