### PR TITLE
Arm backend: Convert asserts to raise errors in op_reciprocal

### DIFF
--- a/backends/arm/operators/op_reciprocal.py
+++ b/backends/arm/operators/op_reciprocal.py
@@ -34,7 +34,16 @@ class ReciprocalVisitor_080_MI(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        assert inputs[0].dtype == output.dtype == ts.DType.FP32
+        if len(node.all_input_nodes) != 1:
+            raise ValueError(
+                f"Expected 1 input for {self.target}, got {len(node.all_input_nodes)}"
+            )
+        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
+            raise ValueError(
+                f"Input and output for {self.target} need to be FP32, got "
+                f"{inputs[0].dtype=} and {output.dtype=}"
+            )
+
         tosa_graph.addOperator(
             ts.TosaOp.Op().RECIPROCAL, [inputs[0].name], [output.name]
         )


### PR DESCRIPTION
Asserts are converted to proper raises to ensure graph integrity.

Improve error messages and add additional check that there's only one input.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218