### PR TITLE
Arm backend: Convert asserts to raise errors in op_rsqrt

### DIFF
--- a/backends/arm/operators/op_rsqrt.py
+++ b/backends/arm/operators/op_rsqrt.py
@@ -34,5 +34,14 @@ class RsqrtVisitor_080_MI(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        assert inputs[0].dtype == output.dtype == ts.DType.FP32
+        if len(node.all_input_nodes) != 1:
+            raise ValueError(
+                f"Expected 1 input for {self.target}, got {len(node.all_input_nodes)}"
+            )
+        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
+            raise ValueError(
+                f"Input and output for {self.target} need to be FP32, got "
+                f"{inputs[0].dtype=} and {output.dtype=}"
+            )
+
         tosa_graph.addOperator(ts.TosaOp.Op().RSQRT, [inputs[0].name], [output.name])


### PR DESCRIPTION
Asserts are converted to proper raises to ensure graph integrity.

Improve error messages and add additional check that both input and output are of data type fp32.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218