### PR TITLE
[0.6 release][ez] fix unittest-arm

### DIFF
--- a/backends/arm/test/models/test_torch_functions.py
+++ b/backends/arm/test/models/test_torch_functions.py
@@ -129,8 +129,6 @@ def test_torch_fns_MI(test_data):
         "Requires dynamic output shape.",
         "topk": "NotImplementedError: No registered serialization name for <class 'torch.return_types.topk'> found",
         "sort": "NotImplementedError: No registered serialization name for <class 'torch.return_types.sort'> found",
-        "t": "MLETORCH-855: Issue with Quantization folding.",
-        "norm": "An error occurred when running the 'KeepDimsFalseToSqueezePass' pass after the following passes:",
     },
 )
 def test_torch_fns_BI(test_data):


### PR DESCRIPTION
### Summary

As title. For some reason, there are two tests which fail on `main` but pass on release branch. Therefore, remove expected failures from the test.

### Test plan

Ran the `test_torch_functions.py` test locally.

```
(executorch) ssjia@devvm5117 ~/scratch/executorch (ssj_release_fix_arm_tests●)$ pytest backends/arm/test/models/test_torch_functions.py
===================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.10.0, pytest-8.0.1, pluggy-1.4.0
rootdir: /home/ssjia/scratch/executorch/backends/arm/test
configfile: pytest.ini
plugins: anyio-4.6.0, hypothesis-6.98.10, xdist-3.5.0, rerunfailures-15.0
collected 20 items                                                                                                                                                                                                            

backends/arm/test/models/test_torch_functions.py .....xx.xx......x.xx                                                                                                                                                   [100%]

====================================================================================================== warnings summary =======================================================================================================
../../anaconda3/envs/executorch/lib/python3.10/site-packages/executorch/exir/dialects/edge/_ops.py:9
  /home/ssjia/anaconda3/envs/executorch/lib/python3.10/site-packages/executorch/exir/dialects/edge/_ops.py:9: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

../../anaconda3/envs/executorch/lib/python3.10/site-packages/executorch/extension/pybindings/portable_lib.py:20
  /home/ssjia/anaconda3/envs/executorch/lib/python3.10/site-packages/executorch/extension/pybindings/portable_lib.py:20: ExperimentalWarning: This API is experimental and subject to change without notice.
    _warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================= 13 passed, 7 xfailed, 2 warnings in 32.29s ==========================================================================================
```