### PR TITLE
[#9971] Gracefully error out in ETDump for set_debug_buffer

### DIFF
--- a/devtools/etdump/etdump_flatcc.cpp
+++ b/devtools/etdump/etdump_flatcc.cpp
@@ -536,15 +536,17 @@ ETDumpResult ETDumpGen::get_etdump_data() {
   return result;
 }
 
-void ETDumpGen::set_debug_buffer(Span<uint8_t> buffer) {
+Result<bool> ETDumpGen::set_debug_buffer(Span<uint8_t> buffer) {
   Result<BufferDataSink> bds_ret = BufferDataSink::create(buffer);
-  ET_CHECK_MSG(
+  ET_CHECK_OR_RETURN_ERROR(
       bds_ret.ok(),
+      InvalidArgument,
       "Failed to create data sink from debug buffer with error 0x%" PRIx32,
       static_cast<uint32_t>(bds_ret.error()));
 
   buffer_data_sink_ = std::move(bds_ret.get());
   data_sink_ = &buffer_data_sink_;
+  return true;
 }
 
 void ETDumpGen::set_data_sink(DataSinkBase* data_sink) {

--- a/devtools/etdump/etdump_flatcc.h
+++ b/devtools/etdump/etdump_flatcc.h
@@ -154,7 +154,7 @@ class ETDumpGen : public ::executorch::runtime::EventTracer {
   virtual void set_delegation_intermediate_output_filter(
       EventTracerFilterBase* event_tracer_filter) override;
 
-  void set_debug_buffer(::executorch::runtime::Span<uint8_t> buffer);
+  Result<bool> set_debug_buffer(::executorch::runtime::Span<uint8_t> buffer);
   void set_data_sink(DataSinkBase* data_sink);
   ETDumpResult get_etdump_data();
   size_t get_num_blocks();


### PR DESCRIPTION
## Summary
Following https://github.com/pytorch/executorch/issues/9971
Start with a relatively simple method. 

Update set_debug_bugffer. Use ET_CHECK_OR_RETURN_ERROR instead. 
If unable to pass error, update the return type as Result
Note: Not sure if InvalidArgument is a good one ( maybe memory not allocated?). Please feel free to comment. 
##Test
test/run_oss_cpp_tests.sh

@Gasoonjia @zhenyan-zhang-meta  Thanks

