### PR TITLE
[doc] Link Hugging Face models to the ExecuTorch doc

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -43,7 +43,8 @@ ExecuTorch provides hardware acceleration for a wide variety of hardware. The mo
 For mobile use cases, consider using XNNPACK for Android and Core ML or XNNPACK for iOS as a first step. See [Hardware Backends](backends-overview.md) for more information.
 
 ### Exporting
-Exporting is done using Python APIs. ExecuTorch provides a high degree of customization during the export process, but the typical flow is as follows. This example uses the MobileNet V2 image classification model implementation in torchvision, but the process supports any [export-compliant](https://pytorch.org/docs/stable/export.html) PyTorch model.
+Exporting is done using Python APIs. ExecuTorch provides a high degree of customization during the export process, but the typical flow is as follows. This example uses the MobileNet V2 image classification model implementation in torchvision, but the process supports any [export-compliant](https://pytorch.org/docs/stable/export.html) PyTorch model. For users working with Hugging Face models,
+you can find a list of supported models in the [*huggingface/optimum-executorch*](https://github.com/huggingface/optimum-executorch) repo.
 
 ```python
 import torch
@@ -100,6 +101,8 @@ print(torch.allclose(output[0], eager_reference_output, rtol=1e-3, atol=1e-5))
 ```
 
 For complete examples of exporting and running the model, please refer to our [examples GitHub repository](https://github.com/pytorch-labs/executorch-examples/tree/main/mv2/python).
+
+Additionally, if you work with Hugging Face models, the [*huggingface/optimum-executorch*](https://github.com/huggingface/optimum-executorch) library simplifies running these models end-to-end with ExecuTorch, using familiar Hugging Face APIs. Visit the repository for specific examples and supported models.
 
 <hr/>
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -43,6 +43,7 @@ ExecuTorch provides support for:
 #### Examples
 - [Android Demo Apps](https://github.com/pytorch-labs/executorch-examples/tree/main/dl3/android/DeepLabV3Demo#executorch-android-demo-app)
 - [iOS Demo Apps](demo-apps-ios.md)
+- [Hugging Face Models](https://github.com/huggingface/optimum-executorch/blob/main/README.md)
 #### Backends
 - [Overview](backends-overview)
 - [XNNPACK](backends-xnnpack)


### PR DESCRIPTION
### Summary
ExecuTorch doc and repo have been successfully linked to the main entry on [Hugging Face doc](https://huggingface.co/docs/optimum/main/en/index), now we need to link the Hugging Face doc and repo ([`huggingface/optimum-executorch`](https://github.com/huggingface/optimum-executorch)) to ExecuTorch doc for seamless experience.

### Test plan
Doc build on CI
