### PR TITLE
add BoxWithNMSLimit_out to DSP as a custom portable op

### DIFF
--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -39,6 +39,7 @@ def define_common_targets():
         ]),
         visibility = [
             "//executorch/...",
+            "@EXECUTORCH_CLIENTS",
         ],
         deps = select({
             "DEFAULT": [],


### PR DESCRIPTION
Summary:
**This PR to be changed when NMS is migrated to ET as an portable op**
Changed the c10 client to be used by internal party

Callsite: https://www.internalfb.com/code/fbsource/[3c01ebf76a180e7f6b5ddd8e50f4be695d85180f]/fbcode/vizard_projects/midas_haptic/model/haptic.py?lines=509-532
Reference implementation: https://www.internalfb.com/code/fbsource/fbcode/caffe2/fb/custom_ops/maskrcnn/box_with_nms_limit.cpp

This op will be migrated and supported by ExecuTorch as a portable op in the future.

Differential Revision: D72275947


