### PR TITLE
Fix compiler warnings in a few places

### DIFF
--- a/runtime/core/exec_aten/testing_util/tensor_factory.h
+++ b/runtime/core/exec_aten/testing_util/tensor_factory.h
@@ -133,7 +133,7 @@ inline bool check_dim_order(
   size_t gauss_sum = 0;
   std::vector<int> count(dim_order.size(), 0);
   for (int i = 0; i < dim_order.size(); i++) {
-    if (dim_order[i] < 0 || dim_order[i] >= sizes.size()) {
+    if (dim_order[i] >= sizes.size()) {
       return false;
     }
     gauss_sum += static_cast<size_t>(dim_order[i]) + 1;

--- a/test/utils/DeathTest.h
+++ b/test/utils/DeathTest.h
@@ -15,6 +15,10 @@
 
 #include <gtest/gtest.h>
 
+#ifndef ET_BUILD_MODE_COV
+#define ET_BUILD_MODE_COV 0
+#endif // ET_BUILD_MODE_COV
+
 #if ET_BUILD_MODE_COV
 
 /**


### PR DESCRIPTION
Summary: There are two places that are emitting warnings, causing builds with -Werror to fail. Neither are correctness issues, but this PR cleans them up to enable build with -Werror.

Differential Revision: D72996608




cc @larryliu0820 @JacobSzwejbka @lucylq