### PR TITLE
Set the default list of models running on private devices

### DIFF
--- a/.github/workflows/android-perf-private-device-experiment.yml
+++ b/.github/workflows/android-perf-private-device-experiment.yml
@@ -57,6 +57,6 @@ jobs:
       id-token: write
       contents: read
     with:
-      models: ${{ inputs.models }}
+      models: ${{ inputs.models || 'mv3,meta-llama/Llama-3.2-1B-Instruct-SpinQuant_INT4_EO8,meta-llama/Llama-3.2-1B-Instruct-QLORA_INT4_EO8' }}
       devices: google_pixel_3_private_rooted
       benchmark_configs: ${{ inputs.benchmark_configs }}


### PR DESCRIPTION
I missed this in https://github.com/pytorch/executorch/pull/10192 for the schedule workflow case.  So, it wrongly fail back to `llama`

### Testing

https://github.com/pytorch/executorch/actions/runs/14481092309.  The results shows up on HUD correctly now https://hud.pytorch.org/benchmark/llms?startTime=Wed%2C%2009%20Apr%202025%2000%3A31%3A41%20GMT&stopTime=Wed%2C%2016%20Apr%202025%2000%3A31%3A41%20GMT&granularity=day&lBranch=update-default-private-devices&lCommit=9fa6a49250fdbd96e8f7a5f4765bc6b32b41b6ce&rBranch=update-default-private-devices&rCommit=9fa6a49250fdbd96e8f7a5f4765bc6b32b41b6ce&repoName=pytorch%2Fexecutorch&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=Google%20Pixel%203%20(Rooted)%20(Android%2012)&archName=All%20Platforms