### PR TITLE
Add redirects for relocated docs

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -17,6 +17,7 @@ parameterized==0.9.0
 
 # Doc build requirements, same as https://github.com/pytorch/pytorch/blob/main/.ci/docker/requirements-docs.txt
 sphinx==5.3.0
+sphinx-reredirects==0.1.4
 sphinx-gallery==0.14.0
 breathe==4.34.0
 exhale==0.2.3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,6 +62,7 @@ extensions = [
     "myst_parser",
     "sphinx_design",
     "sphinx_gallery.gen_gallery",
+    "sphinx_reredirects",
 ]
 
 if not FBCODE:
@@ -193,6 +194,24 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/", None),
     "numpy": ("https://docs.scipy.org/doc/numpy/", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
+}
+
+# Redirects for moved pages
+redirects = {
+    "getting-started-setup": "getting-started.html",
+    "export-overview": "using-executorch-export.html",
+    "runtime-build-and-cross-compilation": "using-executorch-building-from-source.html",
+    "tutorials/export-to-executorch-tutorial": "../using-executorch-export.html",
+    "running-a-model-cpp-tutorial": "using-executorch-cpp.html",
+    "build-run-vulkan": "backends-vulkan.html",
+    "executorch-arm-delegate-tutorial": "backends-arm-ethos-u.html",
+    "build-run-coreml": "backends-coreml.html",
+    "build-run-mediatek-backend": "backends-mediatek.html",
+    "build-run-mps": "backends-mps.html",
+    "build-run-qualcomm-ai-engine-direct-backend": "backends-qualcomm.html",
+    "build-run-xtensa": "backends-cadence.html",
+    "apple-runtime": "using-executorch-ios.html",
+    "tutorials/devtools-integration-tutorial": "../using-executorch-troubleshooting.html",
 }
 
 # Custom directives defintions to create cards on main landing page


### PR DESCRIPTION
### Summary
We've moved a number of doc pages in 0.6. This PR adds the sphinx-reredirects extension, which adds a sphinx feature to define redirected doc pages. I've used this to declare redirects for key relocated doc pages to preserve SEO and incoming external links.

Solves #8728.

### Test plan
I've locally built and served the docs and navigated to each of the redirected URLs. I confirmed that all redirect as expected.


cc @mergennachin @byjlw