### PR TITLE
Add quantized kernels to executorch_jni_full

### DIFF
--- a/extension/android/jni/BUCK
+++ b/extension/android/jni/BUCK
@@ -72,6 +72,7 @@ non_fbcode_target(_kind = fb_android_cxx_library,
         "//xplat/executorch/extension/module:module_static",
         "//xplat/executorch/extension/runner_util:inputs_static",
         "//xplat/executorch/extension/tensor:tensor_static",
+        "//xplat/executorch/kernels/quantized:generated_lib_static",
     ],
 )
 


### PR DESCRIPTION
Summary: Add quantized kernels to the `executorch_jni_full` target to enable use of the kernels (esp. quantized embeddings) in existing production targets.

Differential Revision: D73089140




cc @kirklandsign @cbilgin