### PR TITLE
Increase Android perf test timeout to 4h

### DIFF
--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -392,7 +392,7 @@ jobs:
       fail-fast: false
     with:
       # Due to scheduling a job may be pushed beyond the default 60m threshold
-      timeout: 120
+      timeout: 240
       device-type: android
       runner: linux.2xlarge
       test-infra-ref: ''


### PR DESCRIPTION
This is to ensure that the benchmark running on the 2 experimental private devices could finish https://github.com/pytorch/executorch/actions/runs/14484430048/job/40628062995.  Then we can see how much time the 2 private devices take to finish all the combination to decide how much cool down time we want.