### PR TITLE
retrieve cadence_passes in apply_jarvis_passes

### DIFF
--- a/backends/cadence/aot/pass_utils.py
+++ b/backends/cadence/aot/pass_utils.py
@@ -35,8 +35,8 @@ class CadencePassAttribute:
 ALL_CADENCE_PASSES: dict[ExportPass, CadencePassAttribute] = {}
 
 
-def get_cadence_pass_attribute(p: ExportPass) -> CadencePassAttribute:
-    return ALL_CADENCE_PASSES[p]
+def get_cadence_pass_attribute(p: ExportPass) -> Optional[CadencePassAttribute]:
+    return ALL_CADENCE_PASSES.get(p, None)
 
 
 # A decorator that registers a pass.
@@ -61,7 +61,8 @@ def create_cadence_pass_filter(
     def _filter(p: ExportPass) -> bool:
         pass_attribute = get_cadence_pass_attribute(p)
         return (
-            pass_attribute.opt_level is not None
+            pass_attribute is not None
+            and pass_attribute.opt_level is not None
             and pass_attribute.opt_level <= opt_level
             and (not pass_attribute.debug_pass or debug)
         )


### PR DESCRIPTION
Summary:
Merge cadence passes in apply_jarvis_passes.
This method partition OS passes an jarvis passes on the pass filter:
- OSS passes remain the same order as original jarvis passes `remove -> fusion -> replacement `
- **TODO1**: Jarvis only has `ReplaceMatmulWithTransposedMatmulPass` and `ReplaceAvgPoolWithChannelLastAvgPoolPass` left. Matmul should also be used by vision backend should is OSS-able. TBC by mcremon-meta
- Jarvis should keep `precompute_for_quantized_linear_pass` simplify because it's only used by v3. skrtskrtfb will make it as a ExportPass.
- Jarvis passes are appended to OSS passes
- OSS flow:  OSS pass filter applies on opt-level and is-debug. Apply OSS pass filter on OSS passes, which guarentee correct results
- Jarvis flow:  Jarvis pass filter applies on opt-level and is-debug backend. The same filter cannot be reused from OSS because passes are registered in separate pass dictionaries. To get the correct set of passes after filtetring,
  1. merge OSS & jarvis pass filter, 
  2. combine OSS & jarvis passes, 
  3. apply the merged filter on all passes. 
**Note**: The filter should return true if __OSS pass attribute **OR**  Jarvis pass attribute matches with the filtering criteria__.
- Test filter adds coverage in corner case when some passes are filtered by opt-level

Differential Revision: D72999266


