### PR TITLE
Fix bugs in executorch package

### DIFF
--- a/examples/models/llama/source_transformation/quantize.py
+++ b/examples/models/llama/source_transformation/quantize.py
@@ -164,7 +164,7 @@ def quantize(  # noqa C901
 
         try:
             # torchao 0.3+
-            from torchao._eval import InputRecorder  # pyre-fixme[21]
+            from torchao._models._eval import InputRecorder
         except ImportError:
             from torchao.quantization.GPTQ import InputRecorder  # pyre-ignore
 


### PR DESCRIPTION
Summary: There were bugs in `executorch`, which did not update `InputRecorder` import from `torchao` given changes in the path, which also required adding dependency to import `lm_eval`.

Differential Revision: D73166222


