### PR TITLE
Qualcomm AI Engine Direct - add op support list

### DIFF
--- a/backends/qualcomm/builders/README.md
+++ b/backends/qualcomm/builders/README.md
@@ -8,6 +8,7 @@ Thank you for contributing to Qualcomm AI Engine Direct delegate for ExecuTorch.
     * [Check Operator Spec](#check-operator-spec)
     * [Implementation](#implementation)
     * [Quantizer Annotation](#quantizer-annotation)
+* [Operator Support Status](#operator-support-status)
 * [Issues](#issues)
 * [Pull Requests](#pull-requests)
 
@@ -246,7 +247,7 @@ Now, we can start to fill in function body step by step:
             nodes_to_wrappers,
         )
     ```
-    The logic should be similar and straightforward. Please carefully set arguments `tensor_type` 
+    The logic should be similar and straightforward. Please carefully set arguments `tensor_type`
     according to tensors' property.
 
 3. Define parameters:
@@ -354,6 +355,128 @@ Now, we can start to fill in function body step by step:
 
 ### Quantizer Annotation
 The operator now should be functional for Qualcomm backends. For operator to work in fixed-precision, we should also make `QnnQuantizer` to correctly insert observers for recording calibrated encodings. Please read more on the [Quantization Annotation Tutorial](../quantizer//README.md).
+
+## Operator Support Status
+Please help update following table if you are contributing new operators:
+
+| Operators | HTP - 77/116 Enabled |
+|-----------|---------|
+| Argmax | &cross; |
+| Argmin | &check; |
+| BatchNorm | &check; |
+| BatchToSpace | &cross; |
+| Cast | &check; |
+| ChannelShuffle | &cross; |
+| Concat | &check; |
+| Conv2d | &check; |
+| Conv3d | &cross; |
+| Convert | &check; |
+| CreateSparse | &cross; |
+| CumulativeSum | &check; |
+| DepthToSpace | &check; |
+| DepthWiseConv2d | &check; |
+| Dequantize | &check; |
+| DetectionOutput | &cross; |
+| ElementWiseAbs | &check; |
+| ElementWiseAdd | &check; |
+| ElementWiseAnd | &check; |
+| ElementWiseAsin | &cross; |
+| ElementWiseAtan | &cross; |
+| ElementWiseBinary | &cross; |
+| ElementWiseCeil | &check; |
+| ElementWiseCos | &check; |
+| ElementWiseDivide | &check; |
+| ElementWiseEqual | &check; |
+| ElementWiseExp | &check; |
+| ElementWiseFloor | &cross; |
+| ElementWiseFloorDiv | &cross; |
+| ElementWiseGreater | &check; |
+| ElementWiseGreaterEqual | &check; |
+| ElementWiseLess | &check; |
+| ElementWiseLessEqual | &check; |
+| ElementWiseLog | &check; |
+| ElementWiseMaximum | &check; |
+| ElementWiseMinimum | &check; |
+| ElementWiseMultiply | &check; |
+| ElementWiseNeg | &check; |
+| ElementWiseNeuron | &check; |
+| ElementWiseNot | &check; |
+| ElementWiseNotEqual | &check; |
+| ElementWiseOr | &check; |
+| ElementWisePower | &check; |
+| ElementWiseRound | &cross; |
+| ElementWiseRsqrt | &check; |
+| ElementWiseSelect | &check; |
+| ElementWiseSign | &cross; |
+| ElementWiseSin | &check; |
+| ElementWiseSquaredDifference | &cross; |
+| ElementWiseSquareRoot | &check; |
+| ElementWiseSubtract | &check; |
+| ElementWiseUnary | &cross; |
+| ElementWiseXor | &cross; |
+| Elu | &check; |
+| ExpandDims | &check; |
+| ExtractGlimpse | &cross; |
+| ExtractPatches | &cross; |
+| FullyConnected | &check; |
+| Gather | &check; |
+| GatherElements | &cross; |
+| GatherNd | &check; |
+| Gelu | &check; |
+| GetSparseIndices | &cross; |
+| GetSparseValues | &cross; |
+| GridSample | &cross; |
+| GroupNorm | &check; |
+| HardSwish | &check; |
+| InstanceNorm | &check; |
+| L2Norm | &cross; |
+| LayerNorm | &check; |
+| LogSoftmax | &check; |
+| Lrn | &cross; |
+| Lstm | &cross; |
+| MatMul | &check; |
+| MultiClassNms | &cross; |
+| NonMaxSuppression | &cross; |
+| Nonzero | &cross; |
+| OneHot | &cross; |
+| Pack | &check; |
+| Pad | &check; |
+| PoolAvg2d | &check; |
+| PoolAvg3d | &cross; |
+| PoolMax2d | &check; |
+| Prelu | &check; |
+| Quantize | &check; |
+| ReduceMax | &check; |
+| ReduceMean | &check; |
+| ReduceMin | &cross; |
+| ReduceSum | &check; |
+| Relu | &check; |
+| Relu1 | &cross; |
+| Relu6 | &cross; |
+| ReluMinMax | &check; |
+| Reshape | &check; |
+| Resize | &cross; |
+| ResizeBilinear | &check; |
+| ResizeNearestNeighbor | &check; |
+| RoiAlign | &cross; |
+| RmsNorm | &check; |
+| ScatterElements | &cross; |
+| ScatterNd | &check; |
+| Sigmoid | &check; |
+| Softmax | &check; |
+| SpaceToBatch | &cross; |
+| SpaceToDepth | &check; |
+| SparseToDense | &cross; |
+| Split | &check; |
+| Squeeze | &check; |
+| StridedSlice | &check; |
+| Tanh | &check; |
+| Tile | &check; |
+| TopK | &check; |
+| TransPose | &check; |
+| TransPoseConv2d | &check; |
+| TransPoseConv3d | &cross; |
+| Unpack | &check; |
 
 ## Issues
 Please refer to the [issue section](../README.md#issues) for more information.

--- a/backends/qualcomm/builders/op_amax.py
+++ b/backends/qualcomm/builders/op_amax.py
@@ -13,7 +13,7 @@ import torch
 from executorch.backends.qualcomm.utils.constants import QCOM_AXIS_ORDER, QCOM_DATA
 
 from .node_visitor import NodeVisitor, register_node_visitor
-from .qnn_constants import OpAmax, QNN_OP_PACKAGE_NAME_QTI_AISW
+from .qnn_constants import OpReduceMax, QNN_OP_PACKAGE_NAME_QTI_AISW
 
 
 @register_node_visitor
@@ -61,12 +61,12 @@ class AMax(NodeVisitor):
         reduce_max_op = PyQnnWrapper.PyQnnOpWrapper(
             node.name,
             QNN_OP_PACKAGE_NAME_QTI_AISW,
-            OpAmax.op_name,
+            OpReduceMax.op_name,
         )
         reduce_max_op.AddInputTensors([input_tensor_wrapper])
         reduce_max_op.AddOutputTensors([output_tensor_wrapper])
         reduce_max_op.AddTensorParam(
-            OpAmax.param_axes,
+            OpReduceMax.param_axes,
             PyQnnWrapper.Qnn_DataType_t.QNN_DATATYPE_UINT_32,
             len(mean_dims_shape),
             mean_dims_shape,
@@ -76,7 +76,7 @@ class AMax(NodeVisitor):
         if len(node.args) > 2:
             keep_dims = cast(bool, node.args[2])
             reduce_max_op.AddScalarParam(
-                OpAmax.param_keep_dims,
+                OpReduceMax.param_keep_dims,
                 PyQnnWrapper.Qnn_DataType_t.QNN_DATATYPE_BOOL_8,
                 {QCOM_DATA: keep_dims},
             )

--- a/backends/qualcomm/builders/op_sqrt.py
+++ b/backends/qualcomm/builders/op_sqrt.py
@@ -10,7 +10,7 @@ import executorch.backends.qualcomm.python.PyQnnWrapperAdaptor as PyQnnWrapper
 import torch
 
 from .node_visitor import NodeVisitor, register_node_visitor
-from .qnn_constants import OpElementWiseSqrt, QNN_OP_PACKAGE_NAME_QTI_AISW
+from .qnn_constants import OpElementWiseSquareRoot, QNN_OP_PACKAGE_NAME_QTI_AISW
 
 
 @register_node_visitor
@@ -51,7 +51,7 @@ class SQRT(NodeVisitor):
         sqrt_op = PyQnnWrapper.PyQnnOpWrapper(
             node.name,
             QNN_OP_PACKAGE_NAME_QTI_AISW,
-            OpElementWiseSqrt.op_name,
+            OpElementWiseSquareRoot.op_name,
         )
         sqrt_op.AddInputTensors(sqrt_input_tensors)
         sqrt_op.AddOutputTensors(sqrt_output_tensors)

--- a/backends/qualcomm/builders/qnn_constants.py
+++ b/backends/qualcomm/builders/qnn_constants.py
@@ -15,9 +15,9 @@ QNN_OP_PACKAGE_NAME_QTI_AISW = "qti.aisw"
 
 
 @dataclass(init=False, frozen=True)
-class OpAmax:
-    op_name: str = "ReduceMax"
-    param_axes: str = "axes"
+class OpArgmin:
+    op_name: str = "Argmin"
+    param_axis: str = "axis"
     param_keep_dims: str = "keep_dims"
 
 
@@ -219,7 +219,7 @@ class OpElementWiseSelect:
 
 
 @dataclass(init=False, frozen=True)
-class OpElementWiseSqrt:
+class OpElementWiseSquareRoot:
     op_name = "ElementWiseSquareRoot"
 
 
@@ -365,16 +365,16 @@ class OpQuantize:
 
 
 @dataclass(init=False, frozen=True)
-class OpReduceMean:
-    op_name: str = "ReduceMean"
+class OpReduceMax:
+    op_name: str = "ReduceMax"
     param_axes: str = "axes"
     param_keep_dims: str = "keep_dims"
 
 
 @dataclass(init=False, frozen=True)
-class OpArgmin:
-    op_name: str = "Argmin"
-    param_axis: str = "axis"
+class OpReduceMean:
+    op_name: str = "ReduceMean"
+    param_axes: str = "axes"
     param_keep_dims: str = "keep_dims"
 
 


### PR DESCRIPTION
### Summary
- add op support list of HTP BE
- rearrange a bit for matching QNN document

Fixes #10220.

### Test plan
python backends/qualcomm/tests/test_qnn_delegate.py TestQNNQuantizedOperator -s $DEVICE_SN -b build-android -m SM8750