### PR TITLE
NXP backend: Enable initial unit tests workflow

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -716,3 +716,29 @@ jobs:
       build-mode: Release
       build-tool: cmake
       docker-image: executorch-ubuntu-22.04-clang12
+
+  unittest-nxp-neutron:
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: linux.2xlarge
+      docker-image: executorch-ubuntu-22.04-clang12
+      submodules: 'true'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 90
+      script: |
+        set -eux
+        
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+        
+        # Build and install Executorch
+        PYTHON_EXECUTABLE=python \
+        CMAKE_ARGS="-DEXECUTORCH_BUILD_NXP_NEUTRON=ON" \
+        .ci/scripts/setup-linux.sh --build-tool "cmake"
+        
+        # Run pytest
+        PYTHON_EXECUTABLE=python bash backends/nxp/run_unittests.sh

--- a/backends/nxp/run_unittests.sh
+++ b/backends/nxp/run_unittests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright 2025 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+set -eux
+
+SCRIPT_DIR=$(dirname $(readlink -fm $0))
+EXECUTORCH_DIR=$(dirname $(dirname $SCRIPT_DIR))
+
+cd $EXECUTORCH_DIR
+
+# '-c /dev/null' is used to ignore root level pytest.ini.
+PYTHONPATH=`cd ..; pwd` pytest -c /dev/null backends/nxp/tests/


### PR DESCRIPTION
### Summary
Initial workflow definition for running unit tests for Neutron (NXP) backend. 

cc @digantdesai @JakeStevens @robert-kalmar