### PR TITLE
Use __XTENSA__ in et_pal.cpp

### DIFF
--- a/backends/cadence/runtime/et_pal.cpp
+++ b/backends/cadence/runtime/et_pal.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#if defined(XTENSA)
+#if defined(__XTENSA__)
 
 #include <stdio.h>
 #include <sys/times.h>


### PR DESCRIPTION
Summary: `XTENSA` is no longer defined. Replacing with `__XTENSA__` instead.

Reviewed By: Vysarat

Differential Revision: D73198222


