### PR TITLE
Add aten_lib to executorch_llama

### DIFF
--- a/devtools/bundled_program/bundled_program.cpp
+++ b/devtools/bundled_program/bundled_program.cpp
@@ -33,7 +33,7 @@ using ::executorch::runtime::EValue;
 using ::executorch::runtime::Result;
 
 namespace executorch {
-namespace bundled_program {
+namespace BUNDLED_PROGRAM_NAMESPACE {
 
 namespace {
 
@@ -433,5 +433,5 @@ bool is_bundled_program(void* file_data, ET_UNUSED size_t file_data_len) {
       file_data);
 }
 
-} // namespace bundled_program
+} // namespace BUNDLED_PROGRAM_NAMESPACE
 } // namespace executorch

--- a/devtools/bundled_program/bundled_program.h
+++ b/devtools/bundled_program/bundled_program.h
@@ -10,9 +10,14 @@
 
 #include <executorch/runtime/core/memory_allocator.h>
 #include <executorch/runtime/executor/method.h>
+#ifdef USE_ATEN_LIB
+#define BUNDLED_PROGRAM_NAMESPACE bundled_program::aten
+#else // !USE_ATEN_LIB
+#define BUNDLED_PROGRAM_NAMESPACE bundled_program
+#endif // USE_ATEN_LIB
 
 namespace executorch {
-namespace bundled_program {
+namespace BUNDLED_PROGRAM_NAMESPACE {
 
 /**
  * An opaque pointer to a serialized bundled program.
@@ -94,7 +99,7 @@ ET_DEPRECATED inline bool is_bundled_program(void* file_data) {
   return is_bundled_program(file_data, 128);
 }
 
-} // namespace bundled_program
+} // namespace BUNDLED_PROGRAM_NAMESPACE
 } // namespace executorch
 
 namespace torch {
@@ -103,13 +108,13 @@ namespace bundled_program {
 // TODO(T197294990): Remove these deprecated aliases once all users have moved
 // to the new `::executorch` namespaces.
 using serialized_bundled_program =
-    ::executorch::bundled_program::SerializedBundledProgram;
+    ::executorch::BUNDLED_PROGRAM_NAMESPACE::SerializedBundledProgram;
 
 ET_NODISCARD inline ::executorch::runtime::Error LoadBundledInput(
     Method& method,
     serialized_bundled_program* bundled_program_ptr,
     size_t testset_idx) {
-  return ::executorch::bundled_program::load_bundled_input(
+  return ::executorch::BUNDLED_PROGRAM_NAMESPACE::load_bundled_input(
       method, bundled_program_ptr, testset_idx);
 }
 
@@ -120,7 +125,7 @@ VerifyResultWithBundledExpectedOutput(
     size_t testset_idx,
     double rtol = 1e-5,
     double atol = 1e-8) {
-  return ::executorch::bundled_program::verify_method_outputs(
+  return ::executorch::BUNDLED_PROGRAM_NAMESPACE::verify_method_outputs(
       method, bundled_program_ptr, testset_idx, rtol, atol);
 }
 
@@ -129,13 +134,14 @@ ET_NODISCARD inline ::executorch::runtime::Error GetProgramData(
     size_t file_data_len,
     const void** out_program_data,
     size_t* out_program_data_len) {
-  return ::executorch::bundled_program::get_program_data(
+  return ::executorch::BUNDLED_PROGRAM_NAMESPACE::get_program_data(
       file_data, file_data_len, out_program_data, out_program_data_len);
 }
 
 inline bool IsBundledProgram(void* file_data) {
   // 128 is enough data to contain the identifier in the flatbuffer header.
-  return ::executorch::bundled_program::is_bundled_program(file_data, 128);
+  return ::executorch::BUNDLED_PROGRAM_NAMESPACE::is_bundled_program(
+      file_data, 128);
 }
 } // namespace bundled_program
 } // namespace executor

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -84,7 +84,7 @@ void et_pal_emit_log_message(
 }
 
 namespace py = pybind11;
-using executorch::bundled_program::verify_method_outputs;
+using executorch::BUNDLED_PROGRAM_NAMESPACE::verify_method_outputs;
 using ::executorch::ET_RUNTIME_NAMESPACE::BackendInterface;
 using ::executorch::ET_RUNTIME_NAMESPACE::get_backend_class;
 using ::executorch::ET_RUNTIME_NAMESPACE::get_backend_name;
@@ -826,7 +826,7 @@ struct PyModule final {
       const std::string method_name,
       size_t testset_idx) {
     const void* bundled_program_ptr = m.get_bundled_program_ptr();
-    Error status = executorch::bundled_program::load_bundled_input(
+    Error status = executorch::BUNDLED_PROGRAM_NAMESPACE::load_bundled_input(
         module_->get_method(method_name), bundled_program_ptr, testset_idx);
     THROW_IF_ERROR(
         status,
@@ -842,14 +842,14 @@ struct PyModule final {
       double atol = 1e-8) {
     const void* bundled_program_ptr = m.get_bundled_program_ptr();
     auto& method = module_->get_method(method_name);
-    Error status = executorch::bundled_program::load_bundled_input(
+    Error status = executorch::BUNDLED_PROGRAM_NAMESPACE::load_bundled_input(
         method, bundled_program_ptr, testset_idx);
     THROW_IF_ERROR(
         status,
         "load_bundled_input failed with status 0x%" PRIx32,
         static_cast<uint32_t>(status));
     py::list outputs = plan_execute(method_name);
-    status = executorch::bundled_program::verify_method_outputs(
+    status = executorch::BUNDLED_PROGRAM_NAMESPACE::verify_method_outputs(
         method, bundled_program_ptr, testset_idx, rtol, atol);
     THROW_IF_ERROR(
         status,

--- a/shim_et/xplat/executorch/extension/pybindings/pybindings.bzl
+++ b/shim_et/xplat/executorch/extension/pybindings/pybindings.bzl
@@ -21,9 +21,9 @@ PORTABLE_MODULE_DEPS = [
 ] + get_all_cpu_backend_targets()
 
 ATEN_MODULE_DEPS = [
-    "//executorch/runtime/kernel:operator_registry",
+    "//executorch/runtime/kernel:operator_registry_aten",
     "//executorch/runtime/executor:program_aten",
-    "//executorch/runtime/core/exec_aten:lib",
+    "//executorch/runtime/core/exec_aten:lib_aten",
     "//executorch/devtools/bundled_program/schema:bundled_program_schema_fbs",
     "//executorch/extension/data_loader:buffer_data_loader",
     "//executorch/extension/data_loader:mmap_data_loader",


### PR DESCRIPTION
Summary:
We now can link both ATen lib and portable lib into the same binary/.so file.

This makes us easy to use aten_mode lib as well as portable lib in the same bento kernel.

Reviewed By: tarun292

Differential Revision: D73282334


