### PR TITLE
Use dependency injection for runner

### DIFF
--- a/examples/demo-apps/apple_ios/LLaMA/LLaMARunner/LLaMARunner/Exported/LLaMARunner.mm
+++ b/examples/demo-apps/apple_ios/LLaMA/LLaMARunner/LLaMARunner/Exported/LLaMARunner.mm
@@ -31,7 +31,7 @@ NSErrorDomain const LLaVARunnerErrorDomain = @"LLaVARunnerErrorDomain";
   self = [super init];
   if (self) {
     [ExecuTorchLog.sharedLog addSink:self];
-    _runner = std::make_unique<example::Runner>(
+    _runner = example::Runner::create(
         modelPath.UTF8String, tokenizerPath.UTF8String);
   }
   return self;

--- a/examples/models/llama/main.cpp
+++ b/examples/models/llama/main.cpp
@@ -4,6 +4,7 @@
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
+ * @lint-ignore-every CLANGTIDY facebook-hte-Deprecated
  */
 
 #include <gflags/gflags.h>
@@ -80,18 +81,16 @@ int32_t main(int32_t argc, char** argv) {
   }
 #endif
   // create llama runner
-  // @lint-ignore CLANGTIDY facebook-hte-Deprecated
-  example::Runner runner(model_path, tokenizer_path, data_path);
+  std::unique_ptr<example::Runner> runner =
+      example::Runner::create(model_path, tokenizer_path, data_path);
 
   if (warmup) {
-    // @lint-ignore CLANGTIDY facebook-hte-Deprecated
-    runner.warmup(prompt, /*max_new_tokens=*/seq_len);
+    runner->warmup(prompt, /*max_new_tokens=*/seq_len);
   }
   // generate
   executorch::extension::llm::GenerationConfig config{
       .seq_len = seq_len, .temperature = temperature};
-  // @lint-ignore CLANGTIDY facebook-hte-Deprecated
-  runner.generate(prompt, config);
+  runner->generate(prompt, config);
 
   return 0;
 }

--- a/examples/models/llama/runner/test/CMakeLists.txt
+++ b/examples/models/llama/runner/test/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This file should be formatted with
+# ~~~
+# cmake-format -i CMakeLists.txt
+# ~~~
+# It should also be cmake-lint clean.
+#
+
+cmake_minimum_required(VERSION 3.19)
+
+set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../..)
+
+include(${EXECUTORCH_ROOT}/tools/cmake/Test.cmake)
+
+set(_test_srcs test_runner.cpp)
+
+et_cxx_test(
+  test_runner
+  SOURCES
+  ${_test_srcs}
+  EXTRA_LIBS
+  executorch
+)

--- a/examples/models/llama/runner/test/TARGETS
+++ b/examples/models/llama/runner/test/TARGETS
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/examples/models/llama/runner/test/targets.bzl
+++ b/examples/models/llama/runner/test/targets.bzl
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    runtime.cxx_test(
+        name = "test_runner",
+        srcs = ["test_runner.cpp"],
+        deps = [
+            "//executorch/examples/models/llama/runner:runner",
+            "//executorch/extension/llm/runner:irunner",
+            "//executorch/extension/llm/runner:stats",
+            "//executorch/extension/llm/runner:text_token_generator",
+            "//executorch/extension/llm/runner:text_decoder_runner",
+            "//executorch/extension/llm/runner:text_prefiller",
+            "//executorch/extension/module:module",
+            "//executorch/runtime/core:core",
+            "//executorch/runtime/platform:platform",
+            "//executorch/runtime/core/exec_aten/testing_util:tensor_util",
+        ],
+    )

--- a/examples/models/llama/runner/test/test_runner.cpp
+++ b/examples/models/llama/runner/test/test_runner.cpp
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ * @lint-ignore-every CLANGTIDY facebook-hte-Deprecated
+ */
+
+#include <executorch/examples/models/llama/runner/runner.h>
+#include <executorch/extension/llm/runner/irunner.h>
+#include <executorch/extension/llm/runner/text_token_generator.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using namespace example;
+using executorch::extension::llm::GenerationConfig;
+using executorch::extension::llm::Stats;
+using executorch::extension::llm::TextDecoderRunner;
+using executorch::extension::llm::TextPrefiller;
+using executorch::extension::llm::TextTokenGenerator;
+using executorch::runtime::Error;
+using executorch::runtime::Result;
+using executorch::runtime::testing::TensorFactory;
+// Mock classes for dependencies
+class MockTokenizer : public ::tokenizers::Tokenizer {
+ public:
+  MOCK_METHOD(::tokenizers::Error, load, (const std::string&), ());
+  MOCK_METHOD(bool, is_loaded, (), (const));
+  MOCK_METHOD(
+      ::tokenizers::Result<std::vector<uint64_t>>,
+      encode,
+      (const std::string&, int8_t, int8_t),
+      (const));
+  MOCK_METHOD(
+      ::tokenizers::Result<std::string>,
+      decode,
+      (uint64_t, uint64_t),
+      (const));
+  MOCK_METHOD(uint64_t, bos_tok, (), (const));
+  MOCK_METHOD(uint64_t, eos_tok, (), (const));
+  MOCK_METHOD(uint64_t, vocab_size, (), (const));
+};
+
+class MockModule : public ::executorch::extension::Module {
+ public:
+  MockModule() : Module("") {}
+  MOCK_METHOD(
+      Error,
+      load,
+      (const executorch::runtime::Program::Verification),
+      (override));
+  MOCK_METHOD(bool, is_loaded, (), (const, override));
+  MOCK_METHOD(
+      Result<std::vector<executorch::runtime::EValue>>,
+      execute,
+      (const std::string&, const std::vector<executorch::runtime::EValue>&),
+      (override));
+};
+
+class MockTextDecoderRunner : public TextDecoderRunner {
+ public:
+  MockTextDecoderRunner() : TextDecoderRunner(nullptr, false) {}
+  MOCK_METHOD(
+      Result<executorch::aten::Tensor>,
+      step,
+      (executorch::extension::TensorPtr&, executorch::extension::TensorPtr&),
+      ());
+  MOCK_METHOD(bool, is_method_loaded, (), ());
+  MOCK_METHOD(Result<uint64_t>, prefill, (std::vector<uint64_t>&, int64_t), ());
+  MOCK_METHOD(::executorch::runtime::Error, load, (), ());
+};
+
+class MockTextPrefiller : public TextPrefiller {
+ public:
+  explicit MockTextPrefiller(TextDecoderRunner* text_decoder_runner)
+      : TextPrefiller(text_decoder_runner, false, false, 0) {}
+  MOCK_METHOD(
+      Result<uint64_t>,
+      prefill,
+      (std::vector<uint64_t>&, int64_t&),
+      ());
+  MOCK_METHOD(::executorch::runtime::Error, load, (), ());
+  MOCK_METHOD(bool, is_loaded, (), ());
+};
+
+// Callback counter class for tests
+class CallbackCounter {
+ public:
+  CallbackCounter() : count_(0) {}
+
+  void callback(const std::string& token) {
+    (void)token;
+    count_++;
+  }
+
+  int getCount() const {
+    return count_;
+  }
+
+ private:
+  int count_;
+};
+
+// Test fixture for Runner tests - minimal setup
+class RunnerTest : public Test {
+ protected:
+  // Helper functions to create and set up mock objects
+  std::unique_ptr<MockTokenizer> createMockTokenizer() {
+    auto tokenizer = std::make_unique<MockTokenizer>();
+
+    // Set up default behavior for the tokenizer
+    ON_CALL(*tokenizer, is_loaded).WillByDefault(Return(true));
+    ON_CALL(*tokenizer, encode)
+        .WillByDefault([](const std::string&, int8_t, int8_t) {
+          return ::tokenizers::Result<std::vector<uint64_t>>(
+              std::vector<uint64_t>{1, 2, 3});
+        });
+
+    ON_CALL(*tokenizer, decode).WillByDefault([](uint64_t, uint64_t) {
+      return ::tokenizers::Result<std::string>("token");
+    });
+
+    ON_CALL(*tokenizer, bos_tok()).WillByDefault(Return(1));
+    ON_CALL(*tokenizer, eos_tok()).WillByDefault(Return(2));
+    ON_CALL(*tokenizer, vocab_size()).WillByDefault(Return(100));
+
+    return tokenizer;
+  }
+
+  std::unique_ptr<MockTextDecoderRunner> createMockTextDecoderRunner() {
+    auto text_decoder_runner = std::make_unique<MockTextDecoderRunner>();
+    ON_CALL(*text_decoder_runner, step)
+        .WillByDefault([&](executorch::extension::TensorPtr&,
+                           executorch::extension::TensorPtr&) {
+          return Result<executorch::aten::Tensor>(tensor);
+        });
+    ON_CALL(*text_decoder_runner, is_method_loaded())
+        .WillByDefault(Return(true));
+    return text_decoder_runner;
+  }
+
+  std::unique_ptr<MockTextPrefiller> createMockTextPrefiller(
+      TextDecoderRunner* text_decoder_runner) {
+    auto text_prefiller =
+        std::make_unique<MockTextPrefiller>(text_decoder_runner);
+    ON_CALL(*text_prefiller, is_loaded()).WillByDefault(Return(true));
+    // Set up default behavior for the text prefiller
+    ON_CALL(*text_prefiller, prefill)
+        .WillByDefault([](const std::vector<uint64_t>&, int64_t) {
+          return Result<uint64_t>(4);
+        });
+
+    return text_prefiller;
+  }
+
+  std::unique_ptr<TextTokenGenerator> createTextTokenGenerator(
+      ::tokenizers::Tokenizer* tokenizer,
+      TextDecoderRunner* text_decoder_runner,
+      Stats* stats) {
+    auto eos_ids = std::make_unique<std::unordered_set<uint64_t>>(
+        std::unordered_set<uint64_t>{100});
+    return std::make_unique<TextTokenGenerator>(
+        tokenizer,
+        text_decoder_runner,
+        true, // use_kv_cache
+        std::move(eos_ids),
+        stats);
+  }
+
+  std::unordered_map<std::string, int64_t> createDefaultMetadata() {
+    return {
+        {"enable_dynamic_shape", false},
+        {"get_max_seq_len", 128},
+        {"get_max_context_len", 128},
+        {"use_kv_cache", true},
+    };
+  }
+
+ protected:
+  Stats stats_;
+  std::vector<float> return_logits_ = {0.1f, 0.2f, 0.3f, 0.4f};
+  TensorFactory<executorch::aten::ScalarType::Float> tf;
+  executorch::aten::Tensor tensor = tf.make({1, 4}, return_logits_);
+};
+
+// Test that generate() calls the token callback exactly max_new_tokens times
+TEST_F(RunnerTest, GenerateCallsCallbackExactlyMaxNewTokensTimes) {
+  // Create mock instances using helper functions
+  auto tokenizer = createMockTokenizer();
+  auto text_decoder_runner = createMockTextDecoderRunner();
+  auto text_prefiller = createMockTextPrefiller(text_decoder_runner.get());
+
+  // Set up expectations for the tokenizer encode method
+  EXPECT_CALL(*tokenizer, encode(_, _, _))
+      .WillOnce(Return(::tokenizers::Result<std::vector<uint64_t>>(
+          std::vector<uint64_t>{1, 2, 3})));
+
+  // Set up expectations for the text prefiller
+  EXPECT_CALL(*text_prefiller, prefill(_, _))
+      .WillOnce(Return(Result<uint64_t>(4)));
+
+  // Set up expectations for load methods
+  EXPECT_CALL(*text_prefiller, is_loaded()).WillRepeatedly(Return(true));
+
+  std::unique_ptr<executorch::llm::Stats> stats =
+      std::make_unique<executorch::llm::Stats>();
+  // Create a real TextTokenGenerator
+  auto text_token_generator = createTextTokenGenerator(
+      tokenizer.get(), text_decoder_runner.get(), stats.get());
+
+  // Create a Runner with our mocked components
+  Runner runner(
+      createDefaultMetadata(),
+      std::unique_ptr<::tokenizers::Tokenizer>(tokenizer.release()),
+      std::make_unique<MockModule>(),
+      std::move(text_decoder_runner),
+      std::unique_ptr<::executorch::extension::llm::TextPrefiller>(
+          text_prefiller.release()),
+      std::move(text_token_generator),
+      std::move(stats));
+
+  // Load
+  runner.load();
+
+  // Set up the generation config with a specific max_new_tokens value
+  GenerationConfig config;
+  config.max_new_tokens = 10;
+  config.echo = false;
+
+  // Create a callback counter
+  CallbackCounter counter;
+
+  // Call generate with our callback
+  Error err = runner.generate(
+      "test prompt", config, [&counter](const std::string& token) {
+        counter.callback(token);
+      });
+
+  // Verify the callback was called exactly max_new_tokens times
+  // The first token is generated by prefill, and the rest by the token
+  // generator
+  EXPECT_EQ(counter.getCount(), config.max_new_tokens);
+  EXPECT_EQ(err, Error::Ok);
+}
+
+// Test that warmup() calls generate with the warming flag set
+TEST_F(RunnerTest, WarmupCallsGenerateWithWarmingFlag) {
+  // Create mock instances using helper functions
+  auto tokenizer = createMockTokenizer();
+  auto text_decoder_runner = createMockTextDecoderRunner();
+  auto text_prefiller = createMockTextPrefiller(text_decoder_runner.get());
+
+  // Set up expectations for the tokenizer encode method
+  EXPECT_CALL(*tokenizer, encode(_, _, _))
+      .WillOnce(Return(::tokenizers::Result<std::vector<uint64_t>>(
+          std::vector<uint64_t>{1, 2, 3})));
+
+  // Set up expectations for the text prefiller
+  EXPECT_CALL(*text_prefiller, prefill(_, _))
+      .WillOnce(Return(Result<uint64_t>(4)));
+
+  EXPECT_CALL(*text_prefiller, is_loaded()).WillRepeatedly(Return(true));
+
+  std::unique_ptr<executorch::llm::Stats> stats =
+      std::make_unique<executorch::llm::Stats>();
+  // Create a TextTokenGenerator
+  auto text_token_generator = createTextTokenGenerator(
+      tokenizer.get(), text_decoder_runner.get(), stats.get());
+
+  // Create a Runner with our mocked components
+  Runner runner(
+      createDefaultMetadata(),
+      std::move(tokenizer),
+      std::make_unique<MockModule>(),
+      std::move(text_decoder_runner),
+      std::unique_ptr<::executorch::extension::llm::TextPrefiller>(
+          text_prefiller.release()),
+      std::move(text_token_generator),
+      std::move(stats));
+
+  // Load
+  runner.load();
+
+  // Call warmup
+  Error err = runner.warmup("test prompt", 5);
+
+  // Verify the result
+  EXPECT_EQ(err, Error::Ok);
+}
+
+// Test that is_loaded() returns true when components are initialized
+TEST_F(RunnerTest, IsLoadedReturnsTrueWhenComponentsInitialized) {
+  // Create mock instances using helper functions
+  auto tokenizer = createMockTokenizer();
+  auto text_decoder_runner = createMockTextDecoderRunner();
+  auto text_prefiller = createMockTextPrefiller(text_decoder_runner.get());
+
+  std::unique_ptr<executorch::llm::Stats> stats =
+      std::make_unique<executorch::llm::Stats>();
+  // Create a real TextTokenGenerator
+  auto text_token_generator = createTextTokenGenerator(
+      tokenizer.get(), text_decoder_runner.get(), stats.get());
+
+  // Create a Runner with our mocked components
+  Runner runner(
+      createDefaultMetadata(),
+      std::unique_ptr<::tokenizers::Tokenizer>(tokenizer.release()),
+      std::make_unique<MockModule>(),
+      std::move(text_decoder_runner),
+      std::unique_ptr<::executorch::extension::llm::TextPrefiller>(
+          text_prefiller.release()),
+      std::move(text_token_generator),
+      std::move(stats));
+
+  // Load
+  runner.load();
+
+  // Verify is_loaded returns true
+  EXPECT_TRUE(runner.is_loaded());
+}

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -165,16 +165,13 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
           tokenizer_path->toStdString().c_str(),
           temperature);
     } else if (model_type_category == MODEL_TYPE_CATEGORY_LLM) {
-      if (data_path != nullptr) {
-        runner_ = std::make_unique<example::Runner>(
-            model_path->toStdString().c_str(),
-            tokenizer_path->toStdString().c_str(),
-            data_path->toStdString().c_str());
-      } else {
-        runner_ = std::make_unique<example::Runner>(
-            model_path->toStdString().c_str(),
-            tokenizer_path->toStdString().c_str());
-      }
+      std::optional<const std::string> data_path_str = data_path
+          ? std::optional<const std::string>{data_path->toStdString()}
+          : std::nullopt;
+      runner_ = example::Runner::create(
+          model_path->toStdString(),
+          tokenizer_path->toStdString(),
+          data_path_str);
 #if defined(EXECUTORCH_BUILD_MEDIATEK)
     } else if (model_type_category == MODEL_TYPE_MEDIATEK_LLAMA) {
       runner_ = std::make_unique<MTKLlamaRunner>(

--- a/extension/benchmark/apple/Benchmark/Tests/LLaMA/LLaMATests.mm
+++ b/extension/benchmark/apple/Benchmark/Tests/LLaMA/LLaMATests.mm
@@ -74,8 +74,12 @@ using namespace ::executorch::runtime;
   NSString *tokenizerPath = resources[@"tokenizer"];
   return @{
     @"generate" : ^(XCTestCase *testCase){
-      auto __block runner = std::make_unique<example::Runner>(
+      auto __block runner = example::Runner::create(
           modelPath.UTF8String, tokenizerPath.UTF8String);
+      if (!runner) {
+        XCTFail("Failed to create runner");
+        return;
+      }
       const auto status = runner->load();
       if (status != Error::Ok) {
         XCTFail("Load failed with error %i", status);

--- a/extension/llm/runner/text_prefiller.h
+++ b/extension/llm/runner/text_prefiller.h
@@ -49,6 +49,23 @@ class ET_EXPERIMENTAL TextPrefiller {
       std::vector<uint64_t>& prompt_tokens,
       int64_t& start_pos);
 
+  /**
+   * Load the necessary resources for the TextPrefiller.
+   * This method should be called before using the prefill methods.
+   */
+  ::executorch::runtime::Error load() {
+    return text_decoder_runner_->load();
+  }
+
+  /**
+   * Check if the TextPrefiller has been successfully loaded.
+   * @return True if the resources are loaded, false otherwise.
+   */
+  bool inline is_loaded() const {
+    // Implementation to check if resources are loaded
+    return text_decoder_runner_->is_method_loaded();
+  }
+
  private:
   /**
    * Note: TextPrefiller does not own the TextDecoderRunner instance.

--- a/extension/llm/runner/text_token_generator.h
+++ b/extension/llm/runner/text_token_generator.h
@@ -137,6 +137,23 @@ class ET_EXPERIMENTAL TextTokenGenerator {
     should_stop_ = true;
   }
 
+  /**
+   * Load the necessary resources for TextTokenGenerator.
+   * This method should be called before using the generate() method.
+   */
+  ::executorch::runtime::Error load() {
+    return text_decoder_runner_->load();
+  }
+
+  /**
+   * Check if the TextTokenGenerator has been successfully loaded.
+   * @return True if the resources are loaded, false otherwise.
+   */
+  bool inline is_loaded() const {
+    // Implementation to check if resources are loaded
+    return tokenizer_->is_loaded() && text_decoder_runner_->is_method_loaded();
+  }
+
  private:
   /**
    * Note: TextTokenGenerator does not own the tokenizer_ and


### PR DESCRIPTION
Summary:
Pass in runner components, move most of the instantiation logic from `load()` to a new static API `create()`.

This adds testability to runner components.

Differential Revision: D73165546


