### PR TITLE
Exporting start_time in InstructionEvent to Inspector (#10295)

### DIFF
--- a/devtools/inspector/tests/event_blocks_test.py
+++ b/devtools/inspector/tests/event_blocks_test.py
@@ -518,6 +518,7 @@ class TestEventBlock(unittest.TestCase):
                     delegate_debug_metadatas if is_delegated else []
                 ),
                 _instruction_id=event_signature.instruction_id,
+                _start_time=[0, 0, 0],
             )
             self.assertEqual(event, expected_event)
 


### PR DESCRIPTION
Summary:

ETDump profiled data does not include start_time information when Inspector analyzes Events. Although InstructionEvent's ProfileEvent member contains start_time and end_time information, they are used to only elpased_time which is exposed to Inspect. However, without the information, we are unable to visualize the time-series view of operator executions. This diff is to expose the start_time to Inspector so that it can access the start_time information.

#### A resulting visualization example with start_time
 {F1977252760}

Differential Revision: D72740782


