### PR TITLE
[ET-VK][ez] Streamline + fix enabling device extensions

### DIFF
--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -107,7 +107,33 @@ VkDevice create_logical_device(
       nullptr, // pEnabledFeatures
   };
 
-  device_create_info.pNext = physical_device.extension_features;
+  void* extension_list_top = nullptr;
+
+#ifdef VK_KHR_16bit_storage
+  VkPhysicalDevice16BitStorageFeatures shader_16bit_storage{
+      physical_device.shader_16bit_storage};
+
+  shader_16bit_storage.pNext = extension_list_top;
+  extension_list_top = &shader_16bit_storage;
+#endif /* VK_KHR_16bit_storage */
+
+#ifdef VK_KHR_8bit_storage
+  VkPhysicalDevice8BitStorageFeatures shader_8bit_storage{
+      physical_device.shader_8bit_storage};
+
+  shader_8bit_storage.pNext = extension_list_top;
+  extension_list_top = &shader_8bit_storage;
+#endif /* VK_KHR_8bit_storage */
+
+#ifdef VK_KHR_shader_float16_int8
+  VkPhysicalDeviceShaderFloat16Int8Features shader_float16_int8_types{
+      physical_device.shader_float16_int8_types};
+
+  shader_float16_int8_types.pNext = extension_list_top;
+  extension_list_top = &shader_float16_int8_types;
+#endif /* VK_KHR_shader_float16_int8 */
+
+  device_create_info.pNext = extension_list_top;
 
   VkDevice handle = nullptr;
   VK_CHECK(vkCreateDevice(

--- a/backends/vulkan/runtime/vk_api/Device.cpp
+++ b/backends/vulkan/runtime/vk_api/Device.cpp
@@ -34,7 +34,6 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
       shader_float16_int8_types{
           VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR},
 #endif /* VK_KHR_shader_float16_int8 */
-      extension_features{nullptr},
       queue_families{},
       num_compute_queues(0),
       supports_int16_shader_types(false),
@@ -57,34 +56,24 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
 
   // Create linked list to query availability of extensions
 
+  void* extension_list_top = nullptr;
+
 #ifdef VK_KHR_16bit_storage
-  extension_features = &shader_16bit_storage;
-  features2.pNext = &shader_16bit_storage;
-#elif defined(VK_KHR_8bit_storage)
-  extension_features = &shader_8bit_storage;
-  features2.pNext = &shader_8bit_storage;
-#elif defined(VK_KHR_shader_float16_int8)
-  extension_features = &shader_float16_int8_types;
-  features2.pNext = &shader_float16_int8_types;
+  shader_16bit_storage.pNext = extension_list_top;
+  extension_list_top = &shader_16bit_storage;
 #endif /* VK_KHR_16bit_storage */
 
-#if defined(VK_KHR_16bit_storage) && defined(VK_KHR_8bit_storage)
-  shader_16bit_storage.pNext = &shader_8bit_storage;
-#elif defined(VK_KHR_16bit_storage) && defined(VK_KHR_shader_float16_int8)
-  shader_16bit_storage.pNext = &shader_float16_int8_types;
-#elif defined(VK_KHR_16bit_storage)
-  shader_16bit_storage.pNext = nullptr;
-#endif
-
-#if defined(VK_KHR_8bit_storage) && defined(VK_KHR_shader_float16_int8)
-  shader_8bit_storage.pNext = &shader_float16_int8_types;
-#elif defined(VK_KHR_8bit_storage)
-  shader_8bit_storage.pNext = nullptr;
-#endif
+#ifdef VK_KHR_8bit_storage
+  shader_8bit_storage.pNext = extension_list_top;
+  extension_list_top = &shader_8bit_storage;
+#endif /* VK_KHR_8bit_storage */
 
 #ifdef VK_KHR_shader_float16_int8
-  shader_float16_int8_types.pNext = nullptr;
-#endif
+  shader_float16_int8_types.pNext = extension_list_top;
+  extension_list_top = &shader_float16_int8_types;
+#endif /* VK_KHR_shader_float16_int8 */
+
+  features2.pNext = extension_list_top;
 
   vkGetPhysicalDeviceFeatures2(handle, &features2);
 

--- a/backends/vulkan/runtime/vk_api/Device.h
+++ b/backends/vulkan/runtime/vk_api/Device.h
@@ -37,9 +37,6 @@ struct PhysicalDevice final {
   VkPhysicalDeviceShaderFloat16Int8Features shader_float16_int8_types;
 #endif /* VK_KHR_shader_float16_int8 */
 
-  // Head of the linked list of extensions to be requested
-  void* extension_features;
-
   // Available GPU queues
   std::vector<VkQueueFamilyProperties> queue_families;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #10353
* __->__ #10352

## Changes

Simplify the logic to construct a linked list of physical device feature structs

When constructing the logical device, construct the linked list of device features to enable instead of using a stored pointer from the constructor of `PhysicalDevice`. The reason is that due to possible moves, the stored pointer may be invalid by the time the `Adapter` instance is constructed. It is safer to reconstruct the device features linked list at the time it is needed.

Differential Revision: [D73438721](https://our.internmc.facebook.com/intern/diff/D73438721/)