### PR TITLE
[ET-VK][ez] Store physical device identity metadata

### DIFF
--- a/backends/vulkan/runtime/vk_api/Device.cpp
+++ b/backends/vulkan/runtime/vk_api/Device.cpp
@@ -13,6 +13,7 @@
 #include <executorch/backends/vulkan/runtime/vk_api/Exception.h>
 
 #include <bitset>
+#include <cctype>
 #include <cstring>
 
 namespace vkcompute {
@@ -40,7 +41,9 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
       has_unified_memory(false),
       has_timestamps(false),
       timestamp_period(0),
-      min_ubo_alignment(0) {
+      min_ubo_alignment(0),
+      device_name{},
+      device_type{DeviceType::UNKNOWN} {
   // Extract physical device properties
   vkGetPhysicalDeviceProperties(handle, &properties);
 
@@ -106,6 +109,24 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
     if (p.queueFlags & VK_QUEUE_COMPUTE_BIT) {
       num_compute_queues += p.queueCount;
     }
+  }
+
+  // Obtain device identity metadata
+  device_name = std::string(properties.deviceName);
+  std::transform(
+      device_name.begin(),
+      device_name.end(),
+      device_name.begin(),
+      [](unsigned char c) { return std::tolower(c); });
+
+  if (device_name.find("adreno") != std::string::npos) {
+    device_type = DeviceType::ADRENO;
+  } else if (device_name.find("swiftshader") != std::string::npos) {
+    device_type = DeviceType::SWIFTSHADER;
+  } else if (device_name.find("nvidia") != std::string::npos) {
+    device_type = DeviceType::NVIDIA;
+  } else if (device_name.find("mali") != std::string::npos) {
+    device_type = DeviceType::MALI;
   }
 }
 

--- a/backends/vulkan/runtime/vk_api/Device.h
+++ b/backends/vulkan/runtime/vk_api/Device.h
@@ -18,6 +18,14 @@
 namespace vkcompute {
 namespace vkapi {
 
+enum class DeviceType : uint32_t {
+  UNKNOWN,
+  NVIDIA,
+  MALI,
+  ADRENO,
+  SWIFTSHADER,
+};
+
 struct PhysicalDevice final {
   // Handle
   VkPhysicalDevice handle;
@@ -47,6 +55,10 @@ struct PhysicalDevice final {
   bool has_timestamps;
   float timestamp_period;
   size_t min_ubo_alignment;
+
+  // Device identity
+  std::string device_name;
+  DeviceType device_type;
 
   explicit PhysicalDevice(VkPhysicalDevice);
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #10353
* #10352

## Context

Lay the groundwork for storing device identity metadata. This will allow operator implementations to select and/or configure compute shaders based on the GPU that is being used.

Differential Revision: [D73438723](https://our.internmc.facebook.com/intern/diff/D73438723/)