### PR TITLE
Rename some "jarvis" instances into "falcon" or "cadence"

### DIFF
--- a/backends/cadence/aot/replace_ops.py
+++ b/backends/cadence/aot/replace_ops.py
@@ -675,8 +675,8 @@ class ReplaceConstantPadNdWithSlicePass(ExportPass):
 @register_cadence_pass(CadencePassAttribute(opt_level=0))
 class ReplaceAtenConvolutionWithJarvisConvolutionPass(ExportPass):
     """
-    Replace aten convolution op with jarvis-specific convolution op, since the
-    aten version is not supported by jarvis.
+    Replace aten convolution op with cadence-specific convolution op, since the
+    aten version is not supported by cadence.
     Also remove convolution stride if the output size along the strided dimension
     is 1. We can enable more transformations (e.g., conv -> linear replacement)
     for unit-stride convolutions.
@@ -1896,7 +1896,7 @@ class ReplaceSingleElementTensorArgumentsFromFullOpWithScalarPass(ExportPass):
 @register_cadence_pass(CadencePassAttribute(opt_level=0))
 class ReplaceAtenAvgPoolWithJarvisAvgPoolPass(ExportPass):
     """
-    Replace the aten avg_pool op with the jarvis custom avg_pool2d op.
+    Replace the aten avg_pool op with the cadence custom avg_pool2d op.
     """
 
     def call_operator(self, op, args, kwargs, meta):


### PR DESCRIPTION
Summary:
As titled, including:
- `apply_jarvis_passes` to `apply_falcon_passes`, since the passes are maintained by the falcon team and they're not used only for the (currently named) jarvis compiler

Reviewed By: zonglinpeng

Differential Revision: D73398040


