### PR TITLE
Update module wrapper so that params are explicitly registered to the wrapper

### DIFF
--- a/test/models/targets.bzl
+++ b/test/models/targets.bzl
@@ -156,6 +156,7 @@ def define_common_targets():
         "ModuleAddMul",
         "ModuleAddLarge",
         "ModuleSubLarge",
+        "ModuleLinear",
     ]
 
     # Name of the backend to use when exporting delegated programs.


### PR DESCRIPTION
Pull Request resolved: https://github.com/pytorch/executorch/pull/10305

Seeing issue with linear where the fqns for constants disappear.

Registering self.method_name as a submodule of wrapper means that the parameters are registered to the wrapper. thanks @angelayi for the fix!

```
  File "/data/users/lfq/fbsource/buck-out/v2/gen/fbcode/1af94fa701700343/executorch/test/models/__export_delegated_program__/export_delegated_program#link-tree/torch/export/_trace.py", line 1980, in _export_for_training
    export_artifact = export_func(
  File "/data/users/lfq/fbsource/buck-out/v2/gen/fbcode/1af94fa701700343/executorch/test/models/__export_delegated_program__/export_delegated_program#link-tree/torch/export/_trace.py", line 1473, in _strict_export
    _replace_param_buffer_names(param_buffer_table, export_graph_signature)
  File "/data/users/lfq/fbsource/buck-out/v2/gen/fbcode/1af94fa701700343/executorch/test/models/__export_delegated_program__/export_delegated_program#link-tree/torch/export/_trace.py", line 272, in _replace_param_buffer_names
    spec.target = param_buffer_table[spec.target]
KeyError: 'L__self___fn___self___linear.weight'
```
ghstack-source-id: 279346028
@exported-using-ghexport

Differential Revision: [D73279618](https://our.internmc.facebook.com/intern/diff/D73279618/)