### PR TITLE
[ET-VK][ez] Enable Vulkan tests to build for Android in OSS + misc fixes

### DIFF
--- a/backends/vulkan/cmake/ShaderLibrary.cmake
+++ b/backends/vulkan/cmake/ShaderLibrary.cmake
@@ -29,9 +29,11 @@ if(ANDROID)
     message(FATAL_ERROR "ANDROID_NDK not set")
   endif()
 
-  set(GLSLC_PATH
-      "${ANDROID_NDK}/shader-tools/${ANDROID_NDK_HOST_SYSTEM_NAME}/glslc"
-  )
+  if(NOT GLSLC_PATH)
+    set(GLSLC_PATH
+        "${ANDROID_NDK}/shader-tools/${ANDROID_NDK_HOST_SYSTEM_NAME}/glslc"
+    )
+  endif()
 else()
   find_program(GLSLC_PATH glslc PATHS $ENV{PATH})
 
@@ -56,7 +58,7 @@ function(gen_vulkan_shader_lib_cpp shaders_path)
       ${shaders_path} --output-path ${VULKAN_SHADERGEN_OUT_PATH}
       --glslc-path=${GLSLC_PATH}
       --tmp-dir-path=${VULKAN_SHADERGEN_OUT_PATH}/shader_cache/ --env
-      ${VULKAN_GEN_ARG_ENV}
+      ${VULKAN_GEN_ARG_ENV} --optimize
     DEPENDS ${shaders_path}/*
             ${EXECUTORCH_ROOT}/backends/vulkan/runtime/gen_vulkan_spv.py
   )

--- a/backends/vulkan/test/CMakeLists.txt
+++ b/backends/vulkan/test/CMakeLists.txt
@@ -17,14 +17,16 @@
 cmake_minimum_required(VERSION 3.19)
 project(executorch)
 
+if(ANDROID)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
+endif()
+
 find_package(executorch CONFIG REQUIRED COMPONENTS vulkan_backend)
 find_package(GTest CONFIG REQUIRED)
 
 # Only build tests if Vulkan was compiled
-find_library(LIB_VULKAN_BACKEND vulkan_backend)
-
-if(LIB_VULKAN_BACKEND)
-
+if(TARGET vulkan_backend)
   if(NOT EXECUTORCH_ROOT)
     set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
   endif()

--- a/backends/vulkan/test/op_tests/CMakeLists.txt
+++ b/backends/vulkan/test/op_tests/CMakeLists.txt
@@ -17,6 +17,11 @@
 cmake_minimum_required(VERSION 3.19)
 project(executorch)
 
+if(ANDROID)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
+endif()
+
 find_package(executorch CONFIG REQUIRED COMPONENTS vulkan_backend)
 find_package(GTest CONFIG REQUIRED)
 
@@ -31,16 +36,14 @@ endif()
 include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
 
 get_torch_base_path(TORCH_BASE_PATH)
-message(STATUS "torch base path: ${TORCH_BASE_PATH}")
+if(NOT TORCH_INSTALL_PREFIX)
+  set(TORCH_INSTALL_PREFIX ${TORCH_BASE_PATH})
+endif()
 
-# Only build tests if Vulkan was compiled
-find_library(LIB_VULKAN_BACKEND vulkan_backend)
-find_library(LIB_TORCH torch ${TORCH_BASE_PATH}/lib)
-find_library(LIB_TORCH_CPU torch_cpu ${TORCH_BASE_PATH}/lib)
-find_library(LIB_C10 c10 ${TORCH_BASE_PATH}/lib)
-
-message(STATUS "Vulkan backend lib ${LIB_VULKAN_BACKEND}")
-message(STATUS "Torch ${LIB_TORCH}")
+# libtorch is needed for Vulkan correctness tests
+find_library(LIB_TORCH torch HINTS ${TORCH_INSTALL_PREFIX}/lib)
+find_library(LIB_TORCH_CPU torch_cpu HINTS ${TORCH_INSTALL_PREFIX}/lib)
+find_library(LIB_C10 c10 HINTS ${TORCH_INSTALL_PREFIX}/lib)
 
 if(NOT PYTHON_EXECUTABLE)
   set(PYTHON_EXECUTABLE python3)
@@ -88,7 +91,7 @@ function(vulkan_op_test test_name test_src)
   add_test(${test_name} ${test_name})
 endfunction()
 
-if(LIB_VULKAN_BACKEND AND LIB_TORCH)
+if(TARGET vulkan_backend AND LIB_TORCH)
   find_library(
     CUSTOM_OPS_LIB custom_ops_aot_lib
     HINTS ${CMAKE_INSTALL_PREFIX}/executorch/extension/llm/custom_ops


### PR DESCRIPTION

Summary:
## Changes

Modified the `CMakeLists.txt` of test targets to be able to build for Android.

Apply SPIR-V optimization when building Vulkan compute shaders.

Test Plan:
## Test Plan

Built and ran test binaries on local Android device.

After installing main ET C++ libs for Android...


Build compute_api_test binary.

```
pp cmake backends/vulkan/test \
  -DCMAKE_INSTALL_PREFIX=cmake-android-out \
  -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
  -DANDROID_ABI=arm64-v8a \
  -DANDROID_PLATFORM=android-28 \
  -DPYTHON_EXECUTABLE=python \
  -DCMAKE_BUILD_TYPE=Release \
  -Bcmake-android-out/backends/vulkan/test && \
cmake --build cmake-android-out/backends/vulkan/test -j16 --config Release
```

Push and run on device:

```
adb -s $IP push cmake-android-out/backends/vulkan/test/vulkan_compute_api_test /data/local/tmp/test_bin && \
adb -s $IP shell /data/local/tmp/test_bin \
    --gtest_filter="*add*"
```

Build the operator test binaries:

```
rm -rf cmake-out/backends/vulkan/test/op_tests && \
pp cmake backends/vulkan/test/op_tests \
  -DCMAKE_INSTALL_PREFIX=cmake-android-out \
  -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
  -DANDROID_ABI=arm64-v8a \
  -DANDROID_PLATFORM=android-28 \
  -DPYTHON_EXECUTABLE=python \
  -DCMAKE_BUILD_TYPE=Release \
  -DTORCH_OPS_YAML_PATH=/home/ssjia/Github/pytorch/aten/src/ATen/native \
  -DTORCH_INSTALL_PREFIX=/home/ssjia/Github/pytorch/build_android \
  -Bcmake-android-out/backends/vulkan/test/op_tests && \
cmake --build cmake-android-out/backends/vulkan/test/op_tests -j16 --config Release
```

Push and run on device. Note that these binaries require `libtorch` so files to be pushed to the device as well.

```

# Push torch libs
adb -s $IP push /home/ssjia/Github/pytorch/build_android/lib/libtorch.so /data/local/tmp/ && \
adb -s $IP push /home/ssjia/Github/pytorch/build_android/lib/libtorch_cpu.so /data/local/tmp/ && \
adb -s $IP push /home/ssjia/Github/pytorch/build_android/lib/libc10.so /data/local/tmp/ && \
adb push $ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/lib/clang/18/lib/linux/aarch64/libomp.so /data/local/tmp/libomp.so


adb -s $IP push cmake-android-out/backends/vulkan/test/op_tests/vulkan_linear_weight_int4_test /data/local/tmp/test_bin && \
adb -s $IP shell LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/test_bin
```
