### PR TITLE
[ExecuTorch][#10364] Add Protected Method Getter in `extension.Module`

### DIFF
--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -302,5 +302,15 @@ runtime::Error Module::set_output(
       output_tensor.mutable_data_ptr(), output_tensor.nbytes(), output_index);
 }
 
+ET_NODISCARD inline runtime::Result<Method*> Module::get_method(
+    const std::string& method_name) {
+  ET_CHECK_OR_RETURN_ERROR(
+      methods_.count(method_name) > 0,
+      InvalidArgument,
+      "no such method in program: %s",
+      method_name.c_str());
+  return methods_[method_name].method.get();
+}
+
 } // namespace extension
 } // namespace executorch

--- a/extension/module/module.h
+++ b/extension/module/module.h
@@ -493,6 +493,16 @@ class Module {
   std::unique_ptr<NamedDataMap> data_map_;
 
  protected:
+  /**
+   * Get a method by method name.
+   *
+   * @param[in] method_name The name of the method to get.
+   *
+   * @returns A Result object containing either a pointer to the requested
+   *          method or an error to indicate failure.
+   */
+  ET_NODISCARD inline runtime::Result<Method*> get_method(
+      const std::string& method_name);
   std::unordered_map<std::string, MethodHolder> methods_;
 
   friend class ExecuTorchJni;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #10374

# Context

This issue is a step of https://github.com/pytorch/executorch/discussions/9638. In the discussion, we want to unblock having `extension/Module` as the single source of implementation, which means that `pybindings/PyModule` should use `extension/Module` rather than its own.

Although we are decouping method getter from `pybindings` implementation, method getter itself is still needed. To keep having the method getter while not exposing it, we can create a protected method getter and confine it's usage inside child classes that we are about to create.

# Proposal

Add a protected `get_method` to `extension.Module`, taking method name string as an input.

Differential Revision: [D73473766](https://our.internmc.facebook.com/intern/diff/D73473766/)