### PR TITLE
Enable quant fusion and const propagation by default

### DIFF
--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -102,3 +102,6 @@ class ExecutorchBackendConfig:
     # serialized in the PTE file. Its value is ignored if mutable buffers are not
     # memory planned as the names must be serialized in that case.
     emit_mutable_buffer_names: bool = False
+
+    # If set to true, we run quant fusion and constant propagation passes
+    do_quant_fusion_and_const_prop: bool = False

--- a/exir/passes/TARGETS
+++ b/exir/passes/TARGETS
@@ -154,6 +154,8 @@ python_library(
         "//caffe2:torch",
         "//executorch/exir:pass_base",
         "//executorch/exir/dialects:lib",
+        "//pytorch/ao:torchao",
+        "//executorch/exir/passes:constant_prop_pass",
     ],
 )
 

--- a/exir/passes/constant_prop_pass.py
+++ b/exir/passes/constant_prop_pass.py
@@ -31,8 +31,8 @@ from torch.utils import _pytree as pytree
 _DEFAULT_SKIP_TARGETS = {exir_ops.edge.aten.full.default}
 
 # Skipping transpose/permute for now because https://github.com/pytorch/executorch/issues/10499
-_DEFAULT_SKIP_TARGETS.add(exir_ops.edge.transpose.int)
-_DEFAULT_SKIP_TARGETS.add(exir_ops.edge.permute.default)
+_DEFAULT_SKIP_TARGETS.add(exir_ops.edge.aten.transpose.int)
+_DEFAULT_SKIP_TARGETS.add(exir_ops.edge.aten.permute.default)
 
 # Do not const prop quantization primitives
 _QDQ_OPS = [

--- a/exir/passes/constant_prop_pass.py
+++ b/exir/passes/constant_prop_pass.py
@@ -30,10 +30,6 @@ from torch.utils import _pytree as pytree
 # Propagating aten.full can significantly increase compiled model size.
 _DEFAULT_SKIP_TARGETS = {exir_ops.edge.aten.full.default}
 
-# Skipping transpose/permute for now because https://github.com/pytorch/executorch/issues/10499
-_DEFAULT_SKIP_TARGETS.add(exir_ops.edge.aten.transpose.int)
-_DEFAULT_SKIP_TARGETS.add(exir_ops.edge.aten.permute.default)
-
 # Do not const prop quantization primitives
 _QDQ_OPS = [
     exir_ops.edge.quantized_decomposed.dequantize_per_channel.default,

--- a/exir/passes/quant_fusion_pass.py
+++ b/exir/passes/quant_fusion_pass.py
@@ -10,6 +10,8 @@ from executorch.exir.pass_base import ExportPass
 from torch.fx import GraphModule, subgraph_rewriter
 from torch.fx.passes.infra.pass_base import PassResult
 from torch.utils import _pytree as pytree
+from executorch.exir.passes.constant_prop_pass import constant_prop_pass
+from torch.export import ExportedProgram
 
 from ._quant_patterns_and_replacements import get_quant_patterns_and_replacements
 
@@ -139,3 +141,13 @@ class QuantFusionPass(ExportPass):
         graph_module.graph.lint()
         graph_module.graph.eliminate_dead_code()
         return PassResult(graph_module, True)
+
+
+def quant_fusion_and_const_prop_pass(program: ExportedProgram) -> ExportedProgram:
+    gm = program.graph_module
+    gm_res = QuantFusionPass(_fix_node_meta_val=True)(gm)
+    gm = gm_res.graph_module
+    
+    # Do const prop pass to remove packing/dtype conversion ops
+    program = constant_prop_pass(program)
+    return program

--- a/exir/passes/quant_fusion_pass.py
+++ b/exir/passes/quant_fusion_pass.py
@@ -7,11 +7,11 @@
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
+from executorch.exir.passes.constant_prop_pass import constant_prop_pass
+from torch.export import ExportedProgram
 from torch.fx import GraphModule, subgraph_rewriter
 from torch.fx.passes.infra.pass_base import PassResult
 from torch.utils import _pytree as pytree
-from executorch.exir.passes.constant_prop_pass import constant_prop_pass
-from torch.export import ExportedProgram
 
 from ._quant_patterns_and_replacements import get_quant_patterns_and_replacements
 
@@ -147,7 +147,7 @@ def quant_fusion_and_const_prop_pass(program: ExportedProgram) -> ExportedProgra
     gm = program.graph_module
     gm_res = QuantFusionPass(_fix_node_meta_val=True)(gm)
     gm = gm_res.graph_module
-    
+
     # Do const prop pass to remove packing/dtype conversion ops
     program = constant_prop_pass(program)
     return program

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -1532,7 +1532,7 @@ class EdgeProgramManager:
                     raise Exception(
                         "Cannot run do_quant_fusion_and_const_prop on a graph with a backward signature intended for on-device training."
                         " Please set do_quant_fusion_and_const_prop to False in the ExecutorchBackendConfig."
-                     )
+                    )
                 program = quant_fusion_and_const_prop_pass(program)
             program = weights_to_outputs_pass(program)
             program = unsafe_remove_auto_functionalized_pass(program)

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -52,6 +52,7 @@ from executorch.exir.passes.insert_write_back_for_buffers_pass import (
 from executorch.exir.passes.normalize_view_copy_base_pass import (
     NormalizeViewCopyBasePass,
 )
+from executorch.exir.passes.quant_fusion_pass import quant_fusion_and_const_prop_pass
 from executorch.exir.passes.remove_graph_asserts_pass import (
     RemoveGraphAssertsPass,
     RemoveNonCoreAtenOpGraphAssertsPass,
@@ -1524,9 +1525,15 @@ class EdgeProgramManager:
             after it has been transformed to the ExecuTorch backend.
         """
         config = config if config else ExecutorchBackendConfig()
-
         execution_programs: Dict[str, ExportedProgram] = {}
         for name, program in self._edge_programs.items():
+            if config.do_quant_fusion_and_const_prop:
+                if program.graph_signature.backward_signature is not None:
+                    raise Exception(
+                        "Cannot run do_quant_fusion_and_const_prop on a graph with a backward signature intended for on-device training."
+                        " Please set do_quant_fusion_and_const_prop to False in the ExecutorchBackendConfig."
+                     )
+                program = quant_fusion_and_const_prop_pass(program)
             program = weights_to_outputs_pass(program)
             program = unsafe_remove_auto_functionalized_pass(program)
             gm, new_signature = insert_write_back_for_buffers_pass(program)

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -1279,6 +1279,7 @@ class TestPasses(unittest.TestCase):
             def __init__(self):
                 super().__init__()
                 self.linear = torch.nn.Linear(3, 3)
+                self.w = torch.randn(3, 3)
 
             def t(self, val):
                 return val + 1
@@ -1293,8 +1294,9 @@ class TestPasses(unittest.TestCase):
                 return self.linear(val) - self.f(val)
 
             def forward(self, pred, x):
+                out = torch.nn.functional.linear(x, self.w.to(torch.float16).to(torch.float32))
                 return torch.ops.higher_order.cond(
-                    pred, self.true_fn, self.false_fn, [x]
+                    pred, self.true_fn, self.false_fn, [out]
                 )
 
         mod = Module()
@@ -1304,14 +1306,41 @@ class TestPasses(unittest.TestCase):
             export(mod, (pred, x), strict=True),
             compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
         )
-        error_msg = r"constant_prop_pass for control flow is not supported yet."
+        expected_out = edge.exported_program().module()(pred, x)
 
-        # TODO(chenlai): enable constant prop pass for control flow
-        with self.assertRaisesRegex(
-            RuntimeError,
-            error_msg,
-        ):
-            _ = constant_prop_pass(edge.exported_program())
+        warn_log = "constant_prop_pass does not constant propagate in control flow modules"
+        with self.assertLogs(level="WARNING") as log:
+            program = constant_prop_pass(edge.exported_program())
+            self.assertIn(warn_log, log.output[0])
+
+        out = program.module()(pred, x)
+        self.assertTrue(torch.allclose(expected_out, out))
+
+        # dtype casts in parent module are const propagated
+        FileCheck().check("executorch_exir_dialects_edge__ops_aten_mm_default(x, _prop_tensor_constant").run(program.graph_module.code)
+    
+    def test_constant_prop_pass_quant_primitives(self) -> None:
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w_int = torch.ones(3, 3, dtype=torch.int8)
+                self.w_scale = 3.0
+                self.w_zero_point = 3
+
+            def forward(self, x):
+                w_dq = torch.ops.quantized_decomposed.dequantize_per_tensor.default(
+                    self.w_int, self.w_scale, self.w_zero_point, -127, 128, torch.int8)
+                return torch.nn.functional.linear(x, w_dq)
+        
+        mod = M()
+        x = torch.randn([3])
+        mod(x)
+        edge = to_edge(
+            export(mod, (x,), strict=True),
+            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
+        )
+        constant_prop_pass(edge.exported_program())
+        FileCheck().check("executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default").run(edge.exported_program().graph_module.code)
 
     def test_mutable_buffers(self) -> None:
         def count_copies(gm: torch.fx.GraphModule) -> int:

--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -20,6 +20,7 @@ import torch
 from executorch.backends.transforms.duplicate_dynamic_quant_chain import (
     DuplicateDynamicQuantChainPass,
 )
+from executorch.backends.xnnpack._passes.convert_to_linear import ConvertToLinearPass
 from executorch.exir import EdgeProgramManager, to_edge_transform_and_lower
 from executorch.exir.backend.partitioner import Partitioner
 
@@ -508,9 +509,9 @@ class LLMEdgeManager:
             # If there are Linear operations left in the graph, let's execute
             # them with the optimized op_linear rather than materializing a
             # transpose followed by a regular op_mm.
-            # Disabling because ConvertToLinearPass is not a sound pass: 
+            # TODO: ConvertToLinearPass is not a sound pass and we should fix it
             # https://github.com/pytorch/executorch/issues/10499
-            # ConvertToLinearPass(),
+            ConvertToLinearPass(),
         ]
         if passes:
             # pyre-fixme[6]: In call `list.extend`, for 1st positional argument,


### PR DESCRIPTION
Summary: This diff enables quant fusion and constant propagation by default in ExecuTorch.  It occurs after all to_edge passes, but before memory planning.

Differential Revision: D73513516


