### PR TITLE
Add CI workflow to check c10 is synced with PyTorch

### DIFF
--- a/.ci/scripts/check_c10_sync.sh
+++ b/.ci/scripts/check_c10_sync.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -exu
+ls pytorch/.git || git clone https://github.com/pytorch/pytorch.git
+pushd pytorch
+git checkout "$(< ../.ci/docker/ci_commit_pins/pytorch.txt)"
+popd
+"$(dirname "${BASH_SOURCE[0]}")"/diff_c10_mirror_with_pytorch.sh

--- a/.ci/scripts/compare_dirs.sh
+++ b/.ci/scripts/compare_dirs.sh
@@ -23,6 +23,7 @@ if [ ! -d "$dir1" ] || [ ! -d "$dir2" ]; then
     exit 1
 fi
 
+exit_status=0
 while IFS= read -r -d '' file; do
     base=$(basename "$file")
     case "$base" in
@@ -45,9 +46,9 @@ while IFS= read -r -d '' file; do
     if [ -n "$differences" ]; then
         echo "Error: Mismatch detected in file '$file':" >&2
         echo "$differences" >&2
-        exit 1
+        exit_status=1
     fi
     set -x
 done < <(find "$dir1" -type f -print0)
-# If no mismatches were found, exit with success status
-exit 0
+
+exit $exit_status

--- a/.ci/scripts/compare_dirs.sh
+++ b/.ci/scripts/compare_dirs.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eux
+
+# Check if dir1's files are also found in dir2 with the same
+# contents. Exempt files named BUCK, CMakeLists.txt, TARGETS, or
+# targets.bzl.
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 dir1 dir2" >&2
+    exit 1
+fi
+dir1="$1"
+dir2="$2"
+
+if [ ! -d "$dir1" ] || [ ! -d "$dir2" ]; then
+    echo "Error: Both directories must exist" >&2
+    exit 1
+fi
+
+while IFS= read -r -d '' file; do
+    base=$(basename "$file")
+    case "$base" in
+        "BUCK"|"CMakeLists.txt"|"TARGETS"|"targets.bzl")
+            continue
+            ;;
+    esac
+    # Construct the corresponding path in the second directory
+    file2="$dir2/${file#$dir1/}"
+    # Check if the corresponding file exists in the second directory
+    if [ ! -f "$file2" ]; then
+        echo "Error: File '$file' found in '$dir1' but not found in '$dir2'" >&2
+        exit 1
+    fi
+    # Compare the contents of the two files using diff
+    set +ex
+    differences=$(diff -u -p "$file" "$file2")
+    set -e # leave x off
+    # If there are any differences, print an error message and exit with failure status
+    if [ -n "$differences" ]; then
+        echo "Error: Mismatch detected in file '$file':" >&2
+        echo "$differences" >&2
+        exit 1
+    fi
+    set -x
+done < <(find "$dir1" -type f -print0)
+# If no mismatches were found, exit with success status
+exit 0

--- a/.ci/scripts/diff_c10_mirror_with_pytorch.sh
+++ b/.ci/scripts/diff_c10_mirror_with_pytorch.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+$(dirname "${BASH_SOURCE[0]}")/compare_dirs.sh runtime/core/portable_type/c10/c10 pytorch/c10

--- a/.github/workflows/check-c10-sync.yml
+++ b/.github/workflows/check-c10-sync.yml
@@ -29,4 +29,4 @@ jobs:
           pushd pytorch || return
           git checkout "$(< ../.ci/docker/ci_commit_pins/pytorch.txt)"
           popd
-          .ci/scripts/diff_c10_mirror_with_pytorch.sh
+          .ci/scripts/check_c10_sync.sh

--- a/.github/workflows/check_c10_sync.yml
+++ b/.github/workflows/check_c10_sync.yml
@@ -1,0 +1,32 @@
+name: check-c10-sync
+
+on:
+  pull_request:
+    paths:
+      - .ci/docker/ci_commit_pins/pytorch.txt
+      - .ci/scripts/compare_dirs.sh
+      - .ci/scripts/diff_c10_mirror_with_pytorch.sh
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+jobs:
+  check-c10-sync:
+    permissions:
+      id-token: write
+      contents: read
+    name: check-c10-sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Clone PyTorch
+        run: |
+          set -ex
+          git clone https://github.com/pytorch/pytorch.git
+          pushd pytorch || return
+          git checkout "$(< ../.ci/docker/ci_commit_pins/pytorch.txt)"
+          popd
+          .ci/scripts/diff_c10_mirror_with_pytorch.sh

--- a/runtime/core/portable_type/c10/c10/macros/Macros.h
+++ b/runtime/core/portable_type/c10/c10/macros/Macros.h
@@ -241,7 +241,7 @@ using namespace c10::xpu;
 #ifdef __HIPCC__
 // Unlike CUDA, HIP requires a HIP header to be included for __host__ to work.
 // We do this #include here so that C10_HOST_DEVICE and friends will Just Work.
-// See https://github.com/ROCm-Developer-Tools/HIP/issues/441
+// See https://github.com/ROCm/hip/issues/441
 #include <hip/hip_runtime.h>
 #endif
 

--- a/runtime/core/portable_type/c10/c10/util/Half.h
+++ b/runtime/core/portable_type/c10/c10/util/Half.h
@@ -243,12 +243,7 @@ C10_HOST_DEVICE inline float fp16_ieee_to_fp32_value(uint16_t h) {
   // const float exp_scale = 0x1.0p-112f;
   constexpr uint32_t scale_bits = (uint32_t)15 << 23;
   float exp_scale_val = 0;
-#if defined(_MSC_VER) && defined(__clang__)
-  __builtin_memcpy(&exp_scale_val, &scale_bits, sizeof(exp_scale_val));
-#else
   std::memcpy(&exp_scale_val, &scale_bits, sizeof(exp_scale_val));
-#endif
-
   const float exp_scale = exp_scale_val;
   const float normalized_value =
       fp32_from_bits((two_w >> 4) + exp_offset) * exp_scale;

--- a/runtime/core/portable_type/c10/c10/util/bit_cast.h
+++ b/runtime/core/portable_type/c10/c10/util/bit_cast.h
@@ -3,7 +3,7 @@
 #include <cstring>
 #include <type_traits>
 
-#if __has_include(<bit>) && (defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L)
+#if __has_include(<bit>) && (__cplusplus >= 202002L || (defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L))
 #include <bit>
 #define C10_HAVE_STD_BIT_CAST 1
 #else

--- a/runtime/core/portable_type/c10/c10/util/irange.h
+++ b/runtime/core/portable_type/c10/c10/util/irange.h
@@ -24,7 +24,7 @@ struct integer_iterator {
   using pointer = I*;
   using reference = I&;
 
-  explicit constexpr integer_iterator(I value) : value(value) {}
+  explicit constexpr integer_iterator(I value_) : value(value_) {}
 
   constexpr I operator*() const {
     return value;
@@ -103,7 +103,7 @@ template <
     typename Integer2,
     std::enable_if_t<std::is_integral_v<Integer1>, bool> = true,
     std::enable_if_t<std::is_integral_v<Integer2>, bool> = true>
-constexpr integer_range<Integer2> irange(Integer1 begin, Integer2 end) {
+integer_range<Integer2> irange(Integer1 begin, Integer2 end) {
   // If end<=begin then the range is empty; we can achieve this effect by
   // choosing the larger of {begin, end} as the loop terminator
   return {


### PR DESCRIPTION
This script checks that all files in our c10 copy are in sync with our pinned version of PyTorch.

NOTE TO REVIEWERS: as part reviewing this PR, please weigh in on whether this is a sensible policy. Instinctively, I wanted to allow temporary divergence from the pinned PyTorch version, but I'm unable to articulate why. It now seems like this is the only sensible policy, as our c10 copy is logically part of our PyTorch pin.

Test Plan: 1) detected us being out of sync when I wrote this PR
2) CI to run it and make sure that we are clean now