### PR TITLE
always turn on dynamo for map (#150962)

### DIFF
--- a/exir/tests/control_flow_models.py
+++ b/exir/tests/control_flow_models.py
@@ -87,7 +87,7 @@ class FTMapBasic(Module):
         def f(x, y):
             return x + y
 
-        return torch.ops.higher_order.map(f, xs, y) + xs
+        return torch._higher_order_ops.map(f, xs, y) + xs
 
     def get_random_inputs(self):
         return torch.rand(2, 4), torch.rand(4)


### PR DESCRIPTION
Summary:
Reland D72896450

Make map consistent with other control flow ops. After the change, map is able to support accessing closures in the map fn.

Differential Revision: D73138427


