### PR TITLE
[Android] Support 16bit output data as raw data byte[]

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
@@ -714,7 +714,7 @@ public abstract class Tensor {
       tensor = new Tensor_int8(data, shape);
     } else if (DType.HALF.jniCode == dtype) {
       tensor = new Tensor_raw_data_16b(data, shape, DType.HALF);
-    } else if (DType.HALF.jniCode == dtype) {
+    } else if (DType.BFLOAT16.jniCode == dtype) {
       tensor = new Tensor_raw_data_16b(data, shape, DType.BFLOAT16);
     } else {
       throw new IllegalArgumentException("Unknown Tensor dtype");


### PR DESCRIPTION
In java, when the returned dtype is fp16 or bf16, instead of crash, use byte[] to represent these raw data, and let user parse the byte[]

We don't support fp16 or bf16 as input dtype. User can convert to fp32.

Resolved: https://github.com/pytorch/executorch/issues/9881
Resolved: https://github.com/pytorch/executorch/issues/10371


cc @cbilgin @guangy10 @huydhn @shoumikhin