### PR TITLE
[Android] Add Tensor_unsupoprted return type instead of crash

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/DType.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/DType.java
@@ -73,4 +73,13 @@ public enum DType {
   DType(int jniCode) {
     this.jniCode = jniCode;
   }
+
+  public static DType fromJniCode(int jniCode) {
+    for (DType dtype : values()) {
+      if (dtype.jniCode == jniCode) {
+        return dtype;
+      }
+    }
+    throw new IllegalArgumentException("No DType found for jniCode " + jniCode);
+  }
 }

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
@@ -634,7 +634,7 @@ public abstract class Tensor {
     private final ByteBuffer data;
     private final DType myDtype;
 
-    private Tensor_raw_data_16b(ByteBuffer data, long[] shape, DType dtype) {
+    private Tensor_unknown(ByteBuffer data, long[] shape, DType dtype) {
       super(shape);
       this.data = data;
       this.myDtype = dtype;

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
@@ -630,6 +630,27 @@ public abstract class Tensor {
     }
   }
 
+  static class Tensor_unknown extends Tensor {
+    private final ByteBuffer data;
+    private final DType myDtype;
+
+    private Tensor_raw_data_16b(ByteBuffer data, long[] shape, DType dtype) {
+      super(shape);
+      this.data = data;
+      this.myDtype = dtype;
+    }
+
+    @Override
+    public DType dtype() {
+      return myDtype;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("Tensor(%s, dtype=%d)", Arrays.toString(shape), this.myDtype);
+    }
+  }
+
   // region checks
   private static void checkArgument(boolean expression, String errorMessage, Object... args) {
     if (!expression) {
@@ -675,7 +696,7 @@ public abstract class Tensor {
     } else if (DType.INT8.jniCode == dtype) {
       tensor = new Tensor_int8(data, shape);
     } else {
-      throw new IllegalArgumentException("Unknown Tensor dtype");
+      tensor = new Tensor_unknown(data, shape, dtype);
     }
     tensor.mHybridData = hybridData;
     return tensor;

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
@@ -8,6 +8,7 @@
 
 package org.pytorch.executorch;
 
+import android.util.Log;
 import com.facebook.jni.HybridData;
 import com.facebook.jni.annotations.DoNotStrip;
 import java.nio.Buffer;
@@ -630,14 +631,17 @@ public abstract class Tensor {
     }
   }
 
-  static class Tensor_unknown extends Tensor {
+  static class Tensor_unsupported extends Tensor {
     private final ByteBuffer data;
     private final DType myDtype;
 
-    private Tensor_unknown(ByteBuffer data, long[] shape, DType dtype) {
+    private Tensor_unsupported(ByteBuffer data, long[] shape, DType dtype) {
       super(shape);
       this.data = data;
       this.myDtype = dtype;
+      Log.e(
+          "ExecuTorch",
+          toString() + " in Java. Please consider re-export the model with proper return type");
     }
 
     @Override
@@ -647,7 +651,8 @@ public abstract class Tensor {
 
     @Override
     public String toString() {
-      return String.format("Tensor(%s, dtype=%d)", Arrays.toString(shape), this.myDtype);
+      return String.format(
+          "Unsupported tensor(%s, dtype=%d)", Arrays.toString(shape), this.myDtype);
     }
   }
 
@@ -696,7 +701,7 @@ public abstract class Tensor {
     } else if (DType.INT8.jniCode == dtype) {
       tensor = new Tensor_int8(data, shape);
     } else {
-      tensor = new Tensor_unknown(data, shape, dtype);
+      tensor = new Tensor_unsupported(data, shape, DType.fromJniCode(dtype));
     }
     tensor.mHybridData = hybridData;
     return tensor;

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
@@ -651,8 +651,7 @@ public abstract class Tensor {
 
     @Override
     public String toString() {
-      return String.format(
-          "Unsupported tensor(%s, dtype=%d)", Arrays.toString(shape), this.mDtype);
+      return String.format("Unsupported tensor(%s, dtype=%d)", Arrays.toString(shape), this.mDtype);
     }
   }
 

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
@@ -633,12 +633,12 @@ public abstract class Tensor {
 
   static class Tensor_unsupported extends Tensor {
     private final ByteBuffer data;
-    private final DType myDtype;
+    private final DType mDtype;
 
     private Tensor_unsupported(ByteBuffer data, long[] shape, DType dtype) {
       super(shape);
       this.data = data;
-      this.myDtype = dtype;
+      this.mDtype = dtype;
       Log.e(
           "ExecuTorch",
           toString() + " in Java. Please consider re-export the model with proper return type");
@@ -646,13 +646,13 @@ public abstract class Tensor {
 
     @Override
     public DType dtype() {
-      return myDtype;
+      return mDtype;
     }
 
     @Override
     public String toString() {
       return String.format(
-          "Unsupported tensor(%s, dtype=%d)", Arrays.toString(shape), this.myDtype);
+          "Unsupported tensor(%s, dtype=%d)", Arrays.toString(shape), this.mDtype);
     }
   }
 


### PR DESCRIPTION
Create a Tensor_unsupoprted object, which user can query its dtype and shape, but no other op supported. It will give an error saying user should re-export a model which Java supports.

Resolved: https://github.com/pytorch/executorch/issues/10371