### PR TITLE
Fix `numel()` downcast in executorch/backends/vulkan/test/utils/test_utils.cpp +2

### DIFF
--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -114,7 +114,7 @@ void record_bitw8_image_to_nchw_nobitw8buffer_op(
     api::vTensor& v_src,
     api::StagingBuffer& dst_buffer) {
   vkapi::PipelineBarrier pipeline_barrier{};
-  uint32_t buffer_len = utils::safe_downcast<uint32_t>(dst_buffer.numel() / 4);
+  auto buffer_len = utils::safe_downcast<uint32_t>(dst_buffer.numel() / 4);
   utils::uvec3 global_wg_size = {buffer_len, 1, 1};
 
   std::string kernel_name = "bitw8_image_to_nchw_nobitw8buffer";

--- a/backends/xnnpack/runtime/utils/utils.h
+++ b/backends/xnnpack/runtime/utils/utils.h
@@ -132,7 +132,7 @@ executorch::runtime::Error QuantizePerTensor(
     double scale,
     int zero_point) {
   const float* rdata = rtensor.const_data_ptr<float>();
-  int numel = rtensor.numel();
+  auto numel = rtensor.numel();
   ET_CHECK_OR_RETURN_ERROR(
       (std::is_same<T, uint8_t>::value || std::is_same<T, int8_t>::value),
       Internal,


### PR DESCRIPTION
Summary: `numel()` has type `int64_t`. The implicit downcasts fix in this change artificially truncate data ranges which can lead to hard-to-debug errors and SEVs. Using `auto` ensures that the correct data type is used.

Reviewed By: dtolnay

Differential Revision: D73534006




cc @SS-JIA @manuelcandales @cbilgin