### PR TITLE
Fix `numel()` downcast in dper_lib/silvertorch/core/legacy/tools/eval/tests/TestUtil.cpp +2

### DIFF
--- a/backends/cadence/fusion_g3/operators/op_mean.cpp
+++ b/backends/cadence/fusion_g3/operators/op_mean.cpp
@@ -106,7 +106,7 @@ Tensor& mean_out(
     const float* __restrict__ p_inp =
         (const float* __restrict__)in.const_data_ptr<float>();
 
-    int num_elm = in.numel();
+    auto num_elm = in.numel();
 
     int num_inp_dims = in.dim();
     int num_out_dims = out.dim();


### PR DESCRIPTION
Summary: `numel()` has type `int64_t`. The implicit downcasts fix in this change artificially truncate data ranges which can lead to hard-to-debug errors and SEVs. Using `auto` ensures that the correct data type is used.

Reviewed By: dtolnay

Differential Revision: D73533979


