### PR TITLE
Test fix

### DIFF
--- a/exir/TARGETS
+++ b/exir/TARGETS
@@ -16,7 +16,6 @@ python_library(
         "//caffe2:torch",
         "//executorch/exir/operator:convert",
         "//executorch/extension/pytree:pylib",
-        "//pytorch/ao:torchao",
     ],
 )
 

--- a/exir/tracer.py
+++ b/exir/tracer.py
@@ -643,22 +643,6 @@ def _default_decomposition_table(
     # pyre-fixme[7]: Expected `Dict[OpOverload, typing.Callable[..., executorch.exir....
 
     never_decompose = []
-    try:
-        # Do not decompose torchao quant primitives
-        # They have decompositions registered for inductor/CUDA, but in ExecuTorch we
-        # just pattern match them and lower to delegates
-        import torchao  # noqa: F401
-
-        never_decompose.extend(
-            [
-                torch.ops.torchao.quantize_affine.default,
-                torch.ops.torchao.dequantize_affine.default,
-                torch.ops.torchao.choose_qparams_affine.default,
-            ]
-        )
-    except:
-        pass
-
     for op in never_decompose:
         decomps.pop(op, None)
     return decomps  # pyre-fixme[7]


### PR DESCRIPTION
Summary:
Depending on torchao target is breaking internal test due to cuda compile error (T222166791):


```
bcode/pytorch/ao/torchao/csrc/cuda/fp6_llm/utils_parallel_dequant.cuh(74): error: identifier "__nv_bfloat16" is undefined

1 error detected in the compilation of "fbcode/pytorch/ao/torchao/csrc/cuda/fp6_llm/fp6_linear.cu".
Traceback (most recent call last):
  File "/re_cwd/buck-out/v2/gen/fbcode/a0ae4acecfdc28a2/tools/build/__wrap_nvcc.py__/./resources/wrap_nvcc.py.sh", line 666, in <module>
    main()
  File "/re_cwd/buck-out/v2/gen/fbcode/a0ae4acecfdc28a2/tools/build/__wrap_nvcc.py__/./resources/wrap_nvcc.py.sh", line 662, in main
    run_nvcc(config, flags, buck_scratch)
  File "/re_cwd/buck-out/v2/gen/fbcode/a0ae4acecfdc28a2/tools/build/__wrap_nvcc.py__/./resources/wrap_nvcc.py.sh", line 554, in run_nvcc
    subprocess.run([nvcc_bin] + args, check=True, env=e)
```

Differential Revision: D73557581


