### PR TITLE
Update pyproject.toml pins

### DIFF
--- a/.ci/scripts/setup-linux.sh
+++ b/.ci/scripts/setup-linux.sh
@@ -16,8 +16,8 @@ read -r BUILD_TOOL BUILD_MODE EDITABLE < <(parse_args "$@")
 # have already been installed, so we use PyTorch build from source here instead
 # of nightly. This allows CI to test against latest commits from PyTorch
 if [[ "${EDITABLE:-false}" == "true" ]]; then
-  install_executorch --use-pt-pinned-commit --editable
+  install_executorch --editable
 else
-  install_executorch --use-pt-pinned-commit
+  install_executorch
 fi
 build_executorch_runner "${BUILD_TOOL}" "${BUILD_MODE}"

--- a/.ci/scripts/setup-linux.sh
+++ b/.ci/scripts/setup-linux.sh
@@ -21,7 +21,3 @@ else
   install_executorch --use-pt-pinned-commit
 fi
 build_executorch_runner "${BUILD_TOOL}" "${BUILD_MODE}"
-
-if [[ "${GITHUB_BASE_REF:-}" == *main* || "${GITHUB_BASE_REF:-}" == *gh* ]]; then
-  do_not_use_nightly_on_ci
-fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ dependencies=[
   "ruamel.yaml",
   "sympy",
   "tabulate",
+  "torch==2.7.0",
+  "torchaudio==2.7.0",
+  "torchvision==0.22.0",
   "torchao==0.10.0",
   "typing-extensions",
   # Keep this version in sync with: ./backends/apple/coreml/scripts/install_requirements.sh


### PR DESCRIPTION
Update pyproject.toml to use torch 2.7, torchaudio 2.7, and torchvision 0.22.

All are released on PyPi.
