### PR TITLE
Disable executor_runner for iOS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,7 +665,10 @@ install(FILES tools/cmake/executorch-config.cmake DESTINATION lib/cmake/ExecuTor
 #
 # executor_runner: Host tool that demonstrates program execution.
 #
-option(EXECUTORCH_BUILD_EXECUTOR_RUNNER "Build the executor_runner executable" ON)
+cmake_dependent_option(
+  EXECUTORCH_BUILD_EXECUTOR_RUNNER "Build the executor_runner executable" ON
+  "NOT CMAKE_TOOLCHAIN_IOS" OFF
+)
 
 # Add googletest if any test targets should be built
 if(BUILD_TESTING)


### PR DESCRIPTION
### Summary
Fixes an issue introduced in https://github.com/pytorch/executorch/pull/10320

### Test plan
CI

```
$ ./scripts/build_apple_frameworks.sh --Release --Debug --coreml --custom --mps --optimized --portable --quantized --xnnpack
```