### PR TITLE
Use a local strong NSError for methods with nested autorelease pool

### DIFF
--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
@@ -715,9 +715,8 @@ ETCoreMLModelDebugInfo * _Nullable get_model_debug_info(const inmemoryfs::InMemo
     id<ETCoreMLModelExecutor> executor = [self executorWithHandle:handle];
     if (!executor) {
         ETCoreMLLogErrorAndSetNSError(error,
-                                      0,
-                                      "%@: Model is already unloaded.",
-                                      NSStringFromClass(self.class));
+                                      ETCoreMLErrorInternalError,
+                                      "Model is already unloaded.");
         return result;
     }
 
@@ -725,8 +724,7 @@ ETCoreMLModelDebugInfo * _Nullable get_model_debug_info(const inmemoryfs::InMemo
     if (args.count != model.orderedInputNames.count + model.orderedOutputNames.count) {
         ETCoreMLLogErrorAndSetNSError(error,
                                       ETCoreMLErrorCorruptedModel,
-                                      "%@: Model is invalid, expected args count to be %lu but got %lu.",
-                                      NSStringFromClass(self.class),
+                                      "Model is invalid, expected args count to be %lu but got %lu.",
                                       static_cast<unsigned long>(model.orderedInputNames.count + model.orderedOutputNames.count),
                                       args.count);
         return result;
@@ -767,17 +765,15 @@ ETCoreMLModelDebugInfo * _Nullable get_model_debug_info(const inmemoryfs::InMemo
     id<ETCoreMLModelExecutor> executor = [self executorWithHandle:handle];
     if (!executor) {
         ETCoreMLLogErrorAndSetNSError(error,
-                                      0,
-                                      "%@: Model is already unloaded.",
-                                      NSStringFromClass(self.class));
+                                      ETCoreMLErrorInternalError,
+                                      "Model is already unloaded.");
         return result;
     }
     ETCoreMLModel *model = executor.model;
     if (argsVec.size() != model.orderedInputNames.count + model.orderedOutputNames.count) {
         ETCoreMLLogErrorAndSetNSError(error,
                                       ETCoreMLErrorCorruptedModel,
-                                      "%@: Model is invalid, expected args count to be %lu but got %lu.",
-                                      NSStringFromClass(self.class),
+                                      "Model is invalid, expected args count to be %lu but got %lu.",
                                       static_cast<unsigned long>(model.orderedInputNames.count + model.orderedOutputNames.count),
                                       argsVec.size());
         return result;

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelAnalyzer.mm
@@ -138,7 +138,8 @@ static constexpr NSInteger MAX_MODEL_OUTPUTS_COUNT = 50;
     if (!self.debugger) {
         return nil;
     }
-    
+
+    NSError *localError = nil;
     NSArray<MLMultiArray *> *modelOutputs = nil;
     NSArray<ETCoreMLModelStructurePath *> *operationPaths = self.debugger.operationPaths;
     NSDictionary<ETCoreMLModelStructurePath *, NSString *> *operationPathToDebugSymbolMap = self.debugger.operationPathToDebugSymbolMap;
@@ -150,8 +151,11 @@ static constexpr NSInteger MAX_MODEL_OUTPUTS_COUNT = 50;
                                                                               options:predictionOptions
                                                                                inputs:inputs
                                                                          modelOutputs:&modelOutputs
-                                                                                error:error];
+                                                                                error:&localError];
             if (!outputs) {
+                if (error) {
+                    *error = localError;
+                }
                 return nil;
             }
             

--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelDebugger.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelDebugger.mm
@@ -661,9 +661,15 @@ NSDictionary<ETCoreMLModelStructurePath *, NSString *> *get_operation_path_to_de
 
 - (nullable NSArray<DebuggableModel *> *)modelsWithOutputsOfOperationsAtPath:(NSArray<ETCoreMLModelStructurePath *> *)paths
                                                                        error:(NSError* __autoreleasing *)error {
+    NSError *localError = nil;
+    NSArray<DebuggableModel *> *result = nil;
     @autoreleasepool {
-        return [self _modelsWithOutputsOfOperationsAtPath:paths error:error];
+        result = [self _modelsWithOutputsOfOperationsAtPath:paths error:&localError];
     }
+    if (!result && error) {
+        *error = localError;
+    }
+    return result;
 }
 
 - (nullable ETCoreMLModelOutputs *)outputsOfOperationsAtPaths:(NSArray<ETCoreMLModelStructurePath *> *)paths
@@ -671,27 +677,30 @@ NSDictionary<ETCoreMLModelStructurePath *, NSString *> *get_operation_path_to_de
                                                        inputs:(id<MLFeatureProvider>)inputs
                                                  modelOutputs:(NSArray<MLMultiArray *> *_Nullable __autoreleasing *_Nonnull)modelOutputs
                                                         error:(NSError* __autoreleasing *)error {
-    NSArray<MLMultiArray *> *lModelOutputs = nil;
-    NSMutableDictionary<ETCoreMLModelStructurePath *, MLMultiArray *> *result = [NSMutableDictionary dictionaryWithCapacity:paths.count];
+    NSError *localError = nil;
+    BOOL success = NO;
+    NSArray<MLMultiArray *> *localModelOutputs = nil;
+    ETCoreMLModelOutputs *result = [NSMutableDictionary dictionaryWithCapacity:paths.count];
     @autoreleasepool {
-        NSArray<DebuggableModel *> *models = [self modelsWithOutputsOfOperationsAtPath:paths error:error];
-        if (!models) {
-            return nil;
-        }
-        
-        for (DebuggableModel *pair in models) {
-            id<MLFeatureProvider> outputFeatures = [pair.first predictionFromFeatures:inputs options:options error:error];
-            set_intermediate_outputs(outputFeatures, paths, result);
-            if (modelOutputs) {
-                set_model_outputs(outputFeatures, self.outputNames, &lModelOutputs);
-            }
+        NSArray<DebuggableModel *> *models = [self modelsWithOutputsOfOperationsAtPath:paths error:&localError];
+        success = models != nil;
+        if (success) {
+          for (DebuggableModel *pair in models) {
+              id<MLFeatureProvider> outputFeatures = [pair.first predictionFromFeatures:inputs options:options error:&localError];
+              set_intermediate_outputs(outputFeatures, paths, result);
+              if (modelOutputs) {
+                  set_model_outputs(outputFeatures, self.outputNames, &localModelOutputs);
+              }
+          }
         }
     }
-    
+    if (!success && error) {
+        *error = localError;
+        return nil;
+    }
     if (modelOutputs) {
-        *modelOutputs = lModelOutputs;
+        *modelOutputs = localModelOutputs;
     }
-    
     return result;
 }
 


### PR DESCRIPTION
Otherwise, the out `NSError` arg get assigned an autoreleasing `NSError` object that gets deallocated when the nested autorelease pool is drained and no error is reported:

```objectivec
- (BOOL)foo:(NSError **)error {
    if (error) {
        // Creates an autoreleased error object.
        *error = [NSError errorWithDomain:@"DemoDomain" code:42 userInfo:nil];
    }
    return NO;
}

- (BOOL)bar:(NSError **)error {
    @autoreleasepool {
        // foo: returns NO, sets *error to an autoreleased NSError.
        // But as soon as we leave this block, that NSError is released.
        return [self foo:error];
    }
}

- (void)run {
    NSError *error = nil;
    if (![self bar:&error]) {  // Crash here even before entering the if-statement below due to `objc_storeStrong` call on the autoreleased error out arg.
        // Even if we manage to get here by marking the error var as __autoreleasing above,
        // Error now points at freed memory, so we get another crash or garbage.
        NSLog(@"❌ Faulty: error code = %ld", (long)error.code);
    }
}
```

We introduce a local error var to hold onto the autoreleased `NSError` created by some other API like `foo` and use it to initialize the out `NSError` arg:

```objectivec
- (BOOL)bar:(NSError **)error {
    NSError *localError = nil;
    BOOL ok = NO;

    @autoreleasepool {
        ok = [self foo:&localError];
        // ARC retains localError here when assigning the autoreleased object.
    }

    if (!ok && error) {
        *error = localError;  // Safe - localError survived the pool drain.
    }
    return ok;
}

- (void)run {
    NSError *error = nil;
    if (![self bar:&error]) {
        if (error) {  // Don't forget to still check the error var.
          // Now this reliably logs “42”
          NSLog(@"✅ Fixed: error code = %ld", (long)error.code);
        }
    }
}
```

Another important observation is that generally it's required to check if the out `NSError` has been set despite the returned status.

And a more trickier crash happens even before the control reaches error handling. The compiler assumes the error local var in the `run` method is `__strong`, so it generates `objc_storeStrong` call. Whereas in fact it points to an  `__autoreleasing` object (that gets deallocated when the pool drains as we clarified), and thus such a call on it will lead to a crash regardless, we won't even reach the code that tries to access `code` on it. Unless we indeed introduce a local strong var inside `bar` to be assigned to the out `NSError` arg and so make the generated `objc_storeStrong` call a legit one. Although, that issue can technically be resolved differently - by marking `error` var in `run` as `__autoreleasing` to skip the `objc_storeStrong` call. But that still doesn't help reporting the actual error, since it's gonna be nil after the nested autorelease pool drainage inside `bar`. And apparently having the nested autorelease pool is important enough, so we can't avoid it and have to use such workarounds.