### PR TITLE
Arm backend: Broaden exception handling for unsupported ops

### DIFF
--- a/backends/arm/tosa_backend.py
+++ b/backends/arm/tosa_backend.py
@@ -125,7 +125,7 @@ class TOSABackend(BackendDetails):
                     # This will only happen if an unpartitioned graph is passed without
                     # any checking of compatibility.
                     raise RuntimeError(f"{node.name} is unsupported op {node.op}")
-            except (AssertionError, RuntimeError, ValueError):
+            except Exception:
                 dbg_fail(node, graph_module, tosa_graph, artifact_path)
                 raise
 


### PR DESCRIPTION
Previously, only AssertionError, RuntimeError, and ValueError were caught during node translation failures in the TOSA backend. This patch broadens the exception catch to all Exception types to ensure robust error reporting via `dbg_fail()` even for unexpected errors.

This change helps avoid silent crashes or unhelpful tracebacks during backend lowering of unsupported or misconfigured nodes.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218