### PR TITLE
Arm backend: Update op_view for TOSA 1.0

### DIFF
--- a/backends/arm/operators/op_view.py
+++ b/backends/arm/operators/op_view.py
@@ -63,11 +63,12 @@ class ViewVisitor(NodeVisitor):
 
         tosa_graph = cast(ts.TosaSerializer, tosa_graph)
 
-        if len(output.shape) == 0:
-            raise ValueError(f"No output shape for {output}")
-
-        shape_len = len(output.shape)
-        shape_data = list(tosa_shape(output.shape, output.dim_order))
+        if len(output.shape) != 0:
+            shape_len = len(output.shape)
+            shape_data = list(tosa_shape(output.shape, output.dim_order))
+        else:
+            shape_len = 1
+            shape_data = [0]
 
         shape = tosa_graph.addConst(
             [shape_len],


### PR DESCRIPTION
Make op_view lower rank 0 outputs instead of raising an exception. Rank 0 outputs are triggered by test_amin.py and test_amax.py .

cc @digantdesai @freddan80 @per @zingo