### PR TITLE
Arm backend:  Add TOSA VGF encapsulated compilation target.

### DIFF
--- a/backends/arm/TARGETS
+++ b/backends/arm/TARGETS
@@ -7,6 +7,8 @@ python_library(
         "ethosu_partitioner.py",
         "tosa_backend.py",
         "tosa_partitioner.py",
+        "vgf_backend.py",
+        "vgf_partitioner.py",
     ],
     deps = [
         ":arm_backend",

--- a/backends/arm/arm_backend.py
+++ b/backends/arm/arm_backend.py
@@ -25,7 +25,6 @@ class ArmCompileSpecBuilder:
         self.output_format = None
         self.path_for_intermediates = None
         self.tosa_spec = None
-        self.input_order = None
 
     def vgf_compile_spec(
         self,
@@ -157,13 +156,6 @@ class ArmCompileSpecBuilder:
         if self.path_for_intermediates is not None:
             self.compile_spec.append(
                 CompileSpec("debug_artifact_path", self.path_for_intermediates.encode())
-            )
-
-        if self.input_order:
-            self.compile_spec.append(
-                CompileSpec(
-                    "input_order", " ".join(map(str, self.input_order)).encode()
-                )
             )
 
         return self.compile_spec

--- a/backends/arm/arm_vela.py
+++ b/backends/arm/arm_vela.py
@@ -23,12 +23,11 @@ except ImportError:
 
 # Pack either input or output tensor block, compose the related arrays into
 # per-io structs to simplify runtime use.
-def vela_bin_pack_io(prefix, data, shape_order=None):
+def vela_bin_pack_io(prefix, data):
     vela_input_shapes = data[prefix + "_shape"]
 
-    order = shape_order if shape_order else range(len(vela_input_shapes))
     ios = struct.pack("<i", len(vela_input_shapes))
-    for i in order:
+    for i in range(len(vela_input_shapes)):
         io_shape = vela_input_shapes[i]
         io_elem_size = data[prefix + "_elem_size"][i]
         io_offset = data[prefix + "_offset"][i]
@@ -45,9 +44,7 @@ def vela_bin_pack_io(prefix, data, shape_order=None):
 # Output via Vela to binary stream for ArmBackendEthosU
 # WARNING: Do not change this without changing VelaBinStream.cpp as that
 #          function consumes this format and the two need to align.
-def vela_compile(
-    tosa_flatbuffer: bytes, args: List[str], shape_order=None, verbose: bool = False
-):
+def vela_compile(tosa_flatbuffer: bytes, args: List[str], verbose: bool = False):
     """
     Compile a TOSA graph to a binary stream for ArmBackendEthosU using Vela.
     """
@@ -98,7 +95,7 @@ def vela_compile(
             bin_blocks["scratch_data"] = b"\x00" * block_length
 
             # Capture inputs and outputs
-            bin_blocks["inputs"] = vela_bin_pack_io("input", data, shape_order)
+            bin_blocks["inputs"] = vela_bin_pack_io("input", data)
             bin_blocks["outputs"] = vela_bin_pack_io("output", data)
 
             bin_blocks["vela_end_stream"] = b""

--- a/backends/arm/ethosu_backend.py
+++ b/backends/arm/ethosu_backend.py
@@ -42,12 +42,9 @@ class EthosUBackend(BackendDetails):
         representation to a target specific binary stream.
         """
         compile_flags = []
-        input_order = []
         for spec in compile_spec:
             if spec.key == "compile_flags":
                 compile_flags.append(spec.value.decode())
-            if spec.key == "input_order":
-                input_order = list(map(int, spec.value.decode().split(",")))
 
         if len(compile_flags) == 0:
             # Not testing for compile_flags correctness here, just that they are
@@ -60,7 +57,6 @@ class EthosUBackend(BackendDetails):
         binary = vela_compile(
             tosa_flatbuffer,
             compile_flags,
-            input_order,
             verbose=logger.getEffectiveLevel() == logging.INFO,
         )
         return binary

--- a/backends/arm/ethosu_backend.py
+++ b/backends/arm/ethosu_backend.py
@@ -35,7 +35,7 @@ class EthosUBackend(BackendDetails):
 
     @staticmethod
     def _compile_tosa_flatbuffer(
-        tosa_flatbuffer: bytes, compile_spec: list[CompileSpec]
+        tosa_flatbuffer: bytes, compile_spec: List[CompileSpec]
     ) -> bytes:
         """
         Static helper method to do the compilation of the TOSA flatbuffer

--- a/backends/arm/quantizer/__init__.py
+++ b/backends/arm/quantizer/__init__.py
@@ -9,6 +9,7 @@ from .arm_quantizer import (  # noqa
     EthosUQuantizer,
     get_symmetric_quantization_config,
     TOSAQuantizer,
+    VgfQuantizer,
 )
 
 # Used in tests

--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -27,6 +27,7 @@ from .quantization_annotator import annotate_graph
 from executorch.backends.arm.arm_backend import (
     get_tosa_spec,
     is_ethosu,
+    is_vgf,
 )  # usort: skip
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from torch.ao.quantization.fake_quantize import (
@@ -52,6 +53,7 @@ from torch.fx import GraphModule, Node
 __all__ = [
     "TOSAQuantizer",
     "EthosUQuantizer",
+    "VgfQuantizer",
     "get_symmetric_quantization_config",
 ]
 
@@ -355,6 +357,15 @@ class EthosUQuantizer(TOSAQuantizer):
     def __init__(self, compile_spec: list[CompileSpec]) -> None:
         if not is_ethosu(compile_spec):
             raise RuntimeError("compile spec is not targeting Ethos-U")
+
+        tosa_spec = get_tosa_spec(compile_spec)
+        super().__init__(tosa_spec)
+
+
+class VgfQuantizer(TOSAQuantizer):
+    def __init__(self, compile_spec: list[CompileSpec]) -> None:
+        if not is_vgf(compile_spec):
+            raise RuntimeError("compile spec is not targeting VGF")
 
         tosa_spec = get_tosa_spec(compile_spec)
         super().__init__(tosa_spec)

--- a/backends/arm/tosa_backend.py
+++ b/backends/arm/tosa_backend.py
@@ -35,15 +35,15 @@ from torch.fx import Node
 logger = logging.getLogger(__name__)
 
 
-def _get_first_delegation_tag(graph_module) -> str | None:
-    """Get the first delegation tag from the graph_module or return None."""
+def arm_get_first_delegation_tag(graph_module) -> str:
+    """Get the first delegation tag from the graph_module or return empty string."""
     for node in graph_module.graph.nodes:
         tag = node.meta.get("delegation_tag")
         if tag:
             return tag
 
     logger.debug("No delegation tag found in partition.")
-    return None
+    return ""
 
 
 @final
@@ -136,7 +136,7 @@ class TOSABackend(BackendDetails):
                 )
 
         if artifact_path:
-            tag = _get_first_delegation_tag(graph_module)
+            tag = arm_get_first_delegation_tag(graph_module)
             dbg_tosa_dump(
                 tosa_graph,
                 artifact_path,

--- a/backends/arm/tosa_backend.py
+++ b/backends/arm/tosa_backend.py
@@ -63,7 +63,6 @@ class TOSABackend(BackendDetails):
         artifact_path = None
         output_format = ""
         compile_flags = []
-        input_order = []
         for spec in compile_spec:
             if spec.key == "debug_artifact_path":
                 artifact_path = spec.value.decode()
@@ -71,8 +70,6 @@ class TOSABackend(BackendDetails):
                 output_format = spec.value.decode()
             if spec.key == "compile_flags":
                 compile_flags.append(spec.value.decode())
-            if spec.key == "input_order":
-                input_order = list(map(int, spec.value.decode().split(",")))
 
         # Check that the output format is set correctly in the compile spec
         if output_format != "tosa":
@@ -128,12 +125,6 @@ class TOSABackend(BackendDetails):
             except Exception:
                 dbg_fail(node, graph_module, tosa_graph, artifact_path)
                 raise
-
-        if len(input_order) > 0:
-            if input_count != len(input_order):
-                raise RuntimeError(
-                    "The rank of the input order is not equal to amount of input tensors"
-                )
 
         if artifact_path:
             tag = arm_get_first_delegation_tag(graph_module)

--- a/backends/arm/vgf_backend.py
+++ b/backends/arm/vgf_backend.py
@@ -1,0 +1,126 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+#
+# Main implementation of AoT flow to partition and preprocess for VGF target
+# backends. This flow converts via TOSA, to an encoding of TOSA known as VGF
+# this form is used where the final JIT compile is performed on target (in the
+# runtime delegate executorch::runtime::BackendInterface::init
+#
+
+import logging
+import os
+import subprocess
+import tempfile
+from typing import final, List
+
+from executorch.backends.arm.tosa_backend import (
+    arm_get_first_delegation_tag,
+    TOSABackend,
+)
+from executorch.exir.backend.backend_details import BackendDetails, PreprocessResult
+from executorch.exir.backend.compile_spec_schema import CompileSpec
+from torch.export.exported_program import ExportedProgram
+
+# debug functionality
+logger = logging.getLogger(__name__)
+
+
+@final
+class VgfBackend(BackendDetails):
+    """
+    BackendDetails subclass for delegation to VGF compatible devices. This enables
+    encapsulated TOSA on target device and JIT compilation on suitable platforms.
+    """
+
+    @staticmethod
+    def _compile_tosa_flatbuffer(
+        tosa_flatbuffer: bytes,
+        compile_spec: List[CompileSpec],
+        tag_name: str = "",
+    ) -> bytes:
+        """
+        Static helper method to do the compilation of the TOSA flatbuffer
+        representation to a target specific binary stream.
+        """
+        compile_flags = []
+        artifact_path = None
+        for spec in compile_spec:
+            if spec.key == "compile_flags":
+                compile_flags.append(spec.value.decode())
+            if spec.key == "debug_artifact_path":
+                artifact_path = spec.value.decode()
+
+        # Pass on the TOSA flatbuffer to the vgf compiler.
+        binary = vgf_compile(tosa_flatbuffer, compile_flags, artifact_path, tag_name)
+        return binary
+
+    @staticmethod
+    def preprocess(
+        edge_program: ExportedProgram,
+        compile_spec: List[CompileSpec],
+    ) -> PreprocessResult:
+        logger.info(f"{VgfBackend.__name__} preprocess")
+
+        # deduce TOSA compile_spec from VGF compile spec. We get a new
+        # compile spec list, containing only elements relevant for the
+        # TOSABackend.
+        tosa_compile_spec = TOSABackend.filter_tosa_compile_specs(compile_spec)
+
+        # Backends doesn't allow inheritance, as stated in comments in exir/backend/backend_api.py
+        # ('All backend implementation are final...'), so use composition instead.
+        # preprocess returns the serialized TOSA flatbuffer in .processed_bytes,
+        # which can be passed on to next compilation step.
+        tosa_preprocess = TOSABackend.preprocess(edge_program, tosa_compile_spec)
+
+        tag_name = arm_get_first_delegation_tag(edge_program.graph_module)
+
+        binary = VgfBackend._compile_tosa_flatbuffer(
+            tosa_preprocess.processed_bytes, compile_spec, tag_name
+        )
+
+        return PreprocessResult(processed_bytes=binary)
+
+
+def vgf_compile(
+    tosa_flatbuffer: bytes,
+    compile_flags: List[str],
+    artifact_path: str | None = None,
+    tag_name: str = "",
+):
+    with tempfile.TemporaryDirectory() as tmpdir:
+
+        # We currently write out a flatbuffer as input to the converter
+        tosaname = f"output_{tag_name}.tosa"
+        tosa_path = os.path.join(tmpdir, tosaname)
+        with open(tosa_path, "wb") as f:
+            f.write(tosa_flatbuffer)
+
+        additional_flags = " ".join(compile_flags)
+        vgf_path = tosa_path + ".vgf"
+        conversion_command = (
+            f"converter-backend {additional_flags} -i {tosa_path} -o {vgf_path}"
+        )
+        try:
+            subprocess.run(
+                [conversion_command], shell=True, check=True, capture_output=True
+            )
+        except subprocess.CalledProcessError as process_error:
+            raise RuntimeError(
+                f"Vgf compiler ('{conversion_command}') failed with error:\n \
+                {process_error.stderr.decode()}\n \
+                Stdout:\n{process_error.stdout.decode()}"
+            )
+
+        if artifact_path is not None:
+            logger.info(f"Emitting debug output to: {vgf_path=}")
+            os.makedirs(artifact_path, exist_ok=True)
+            cp = f"cp {vgf_path} {artifact_path}"
+            subprocess.run(cp, shell=True, check=True, capture_output=False)
+
+        vgf_bytes = open(vgf_path, "rb").read()
+        return vgf_bytes

--- a/backends/arm/vgf_partitioner.py
+++ b/backends/arm/vgf_partitioner.py
@@ -1,0 +1,32 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from typing import final, List, Optional, Sequence
+
+from executorch.backends.arm.arm_backend import (
+    is_vgf,
+)  # usort: skip
+from executorch.backends.arm.tosa_partitioner import TOSAPartitioner
+from executorch.backends.arm.vgf_backend import VgfBackend
+from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.exir.backend.partitioner import DelegationSpec
+from torch.fx.passes.operator_support import OperatorSupportBase
+
+
+@final
+class VgfPartitioner(TOSAPartitioner):
+    def __init__(
+        self,
+        compile_spec: List[CompileSpec],
+        additional_checks: Optional[Sequence[OperatorSupportBase]] = None,
+    ) -> None:
+        if not is_vgf(compile_spec):
+            raise RuntimeError("compile spec is not targeting Vgf")
+
+        # Override the delegation spec for Vgf
+        self.delegation_spec = DelegationSpec(VgfBackend.__name__, compile_spec)
+        self.additional_checks = additional_checks

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -317,19 +317,12 @@ def get_compile_spec(
         except:
             tosa_spec = TosaSpecification.create_from_string("TOSA-0.80+BI")
         spec_builder = ArmCompileSpecBuilder().tosa_compile_spec(tosa_spec)
-    elif "ethos-u55" in target:
+    elif "ethos-u" in target:
         spec_builder = ArmCompileSpecBuilder().ethosu_compile_spec(
             target,
             system_config=system_config,
             memory_mode=memory_mode,
-            extra_flags="--debug-force-regor --output-format=raw --verbose-operators --verbose-cycle-estimate",
-        )
-    elif "ethos-u85" in target:
-        spec_builder = ArmCompileSpecBuilder().ethosu_compile_spec(
-            target,
-            system_config=system_config,
-            memory_mode=memory_mode,
-            extra_flags="--output-format=raw --verbose-operators --verbose-cycle-estimate",
+            extra_flags="--verbose-operators --verbose-cycle-estimate",
         )
 
     if intermediates is not None:
@@ -520,22 +513,6 @@ def get_args():
         and models[args.model_name].can_delegate is False
     ):
         raise RuntimeError(f"Model {args.model_name} cannot be delegated.")
-
-    if "ethos-u" in args.target and args.system_config is None:
-        if "u55" in args.target:
-            args.system_config = "Ethos_U55_High_End_Embedded"
-        elif "u85" in args.target:
-            args.system_config = "Ethos_U85_SYS_DRAM_Mid"
-        else:
-            raise RuntimeError(f"Invalid target name {args.target}")
-
-    if "ethos-u" in args.target and args.memory_mode is None:
-        if "u55" in args.target:
-            args.memory_mode = "Shared_Sram"
-        elif "u85" in args.target:
-            args.memory_mode = "Sram_Only"
-        else:
-            raise RuntimeError(f"Invalid target name {args.target}")
 
     return args
 


### PR DESCRIPTION
Add TOSA VGF encapsulated compilation target.

This change enables support for "vgf" files which wrap TOSA output and include memory planning for target devices which can JIT TOSA to the target ISA on-device.

 - Add a VgfQuantizer (same as TOSAQuantizer)
 - Add a VgfBackend and VgfPartitioner to produce TOSA wrapped in a VGF
 - Requires yet to be released converter_backend

Signed-off-by: Rob Elliott <robert.elliott@arm.com>
Change-Id: I764c32c33c503eb44200e9a7d98caa8fae8a4882

### Test plan
As this is a new encapsulation with a tool that's not yet released, integration with unit tests will come in a subsequent commit.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218