### PR TITLE
[serialization_lib][1.00] update consumers

### DIFF
--- a/backends/arm/TARGETS
+++ b/backends/arm/TARGETS
@@ -24,7 +24,9 @@ python_library(
         "fbsource//third-party/pypi/flatbuffers:flatbuffers",
         "fbsource//third-party/pypi/ml-dtypes:ml-dtypes",
         "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/serializer:serializer",
+        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/serializer:serializer",
         "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/tosa:tosa",
+        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/tosa:tosa",
         ":arm_vela",
         ":process_node",
         "//executorch/backends/arm/operators:lib",
@@ -37,6 +39,7 @@ python_library(
     srcs = ["process_node.py"],
     deps = [
         "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/tosa:tosa",
+        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/tosa:tosa",
         "//executorch/backends/arm/operators:node_visitor",
         "//executorch/backends/arm:tosa_mapping",
         "//executorch/backends/arm:tosa_quant_utils",
@@ -60,6 +63,7 @@ python_library(
     ],
     deps = [
         "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/serializer:serializer",
+        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/serializer:serializer",
         "//caffe2:torch",
     ],
 )
@@ -71,7 +75,9 @@ python_library(
     deps = [
         "fbsource//third-party/pypi/numpy:numpy",
         "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/serializer:serializer",
+        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/serializer:serializer",
         "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/tosa:tosa",
+        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/tosa:tosa",
         ":tosa_mapping",
         "//executorch/exir/dialects:lib",
     ],

--- a/backends/arm/operators/TARGETS
+++ b/backends/arm/operators/TARGETS
@@ -15,6 +15,7 @@ python_library(
     srcs = glob(["op_*.py", "ops_*.py"]),
     deps = [
         "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/tosa:tosa",
+        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/tosa:tosa",
         ":node_visitor",
         "//executorch/backends/arm:tosa_mapping",
         "//executorch/backends/arm:tosa_quant_utils",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #10480
* #10479
* __->__ #10478
* #10477

Get ready to support v1.0 alongside v0.80 version for tosa_tools/serialization_lib

Differential Revision: [D73642293](https://our.internmc.facebook.com/intern/diff/D73642293/)