### PR TITLE
Add device type (public, private) and id

### DIFF
--- a/.github/scripts/extract_benchmark_results.py
+++ b/.github/scripts/extract_benchmark_results.py
@@ -349,7 +349,8 @@ def transform(
     # Overwrite the device name here with the job name as it has more information about
     # the device, i.e. Samsung Galaxy S22 5G instead of just Samsung
     for r in benchmark_results:
-        r["deviceInfo"]["device"] = job_name
+        is_private_device = job_report.get("is_private_instance", False)
+        r["deviceInfo"]["device"] = f"{job_name} (private)" if is_private_device else job_name
 
     # From https://github.com/pytorch/pytorch/wiki/How-to-integrate-with-PyTorch-OSS-benchmark-database
     return [

--- a/.github/scripts/extract_benchmark_results.py
+++ b/.github/scripts/extract_benchmark_results.py
@@ -366,7 +366,7 @@ def transform(
                     "benchmark_config": json.dumps(benchmark_config),
                     "job_conclusion": "SUCCESS",
                     "job_arn": job_report.get("arn", ""),
-                    "instance_arn": job_request.get("instance_arn", ""),
+                    "instance_arn": job_report.get("instance_arn", ""),
                 },
             },
             "model": {

--- a/.github/scripts/extract_benchmark_results.py
+++ b/.github/scripts/extract_benchmark_results.py
@@ -364,6 +364,7 @@ def transform(
                     "benchmark_config": json.dumps(benchmark_config),
                     "job_conclusion": "SUCCESS",
                     "job_arn": job_report.get("arn", ""),
+                    "instance_arn": job_request.get("instance_arn", ""),
                 },
             },
             "model": {

--- a/.github/scripts/extract_benchmark_results.py
+++ b/.github/scripts/extract_benchmark_results.py
@@ -350,7 +350,9 @@ def transform(
     # the device, i.e. Samsung Galaxy S22 5G instead of just Samsung
     for r in benchmark_results:
         is_private_device = job_report.get("is_private_instance", False)
-        r["deviceInfo"]["device"] = f"{job_name} (private)" if is_private_device else job_name
+        r["deviceInfo"]["device"] = (
+            f"{job_name} (private)" if is_private_device else job_name
+        )
 
     # From https://github.com/pytorch/pytorch/wiki/How-to-integrate-with-PyTorch-OSS-benchmark-database
     return [

--- a/.github/workflows/apple-perf-private-device-experiment.yml
+++ b/.github/workflows/apple-perf-private-device-experiment.yml
@@ -1,18 +1,16 @@
 name: apple-perf (private devices)
 
 on:
-  # TODO (huydhn): Disable the schedule run until we land the change to add device pool and device name
-  # to separate between public and private iOS devices
-  # schedule:
-  # - cron: 0 0,4,8,12,16,20 * * *
+  schedule:
+   - cron: 0 0,4,8,12,16,20 * * *
   pull_request:
     paths:
       - .github/workflows/apple-perf-private-device-experiment.yml
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - .github/workflows/apple-perf-private-device-experiment.yml
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/apple-perf-private-device-experiment.yml
   # Note: GitHub has an upper limit of 10 inputs
   workflow_dispatch:
     inputs:

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -436,7 +436,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pytorch/test-infra/.github/workflows/mobile_job.yml@main
+    # TESTING
+    uses: pytorch/test-infra/.github/workflows/mobile_job.yml@add-device-type-and-id
     strategy:
       matrix: ${{ fromJson(needs.set-parameters.outputs.benchmark_configs) }}
       fail-fast: false
@@ -446,7 +447,8 @@ jobs:
       device-type: ios
       # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS
       runner: linux.2xlarge
-      test-infra-ref: ''
+      # TESTING
+      test-infra-ref: add-device-type-and-id
       # This is the ARN of ExecuTorch project on AWS
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6
       device-pool-arn: ${{ matrix.device_arn }}

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -436,8 +436,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    # TESTING
-    uses: pytorch/test-infra/.github/workflows/mobile_job.yml@add-device-type-and-id
+    uses: pytorch/test-infra/.github/workflows/mobile_job.yml@main
     strategy:
       matrix: ${{ fromJson(needs.set-parameters.outputs.benchmark_configs) }}
       fail-fast: false
@@ -447,8 +446,7 @@ jobs:
       device-type: ios
       # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS
       runner: linux.2xlarge
-      # TESTING
-      test-infra-ref: add-device-type-and-id
+      test-infra-ref: ''
       # This is the ARN of ExecuTorch project on AWS
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6
       device-pool-arn: ${{ matrix.device_arn }}


### PR DESCRIPTION
And also enable Apple benchmark there. This depends on https://github.com/pytorch/test-infra/pull/6579

(Revert https://github.com/pytorch/executorch/commit/b415af07be46569903d4d03bd66195b9afa85a96 for testing as it currently breaks building Apple benchmark app, I'll put it back before landing cc @shoumikhin )

### Testing

https://hud.pytorch.org/benchmark/llms?startTime=Sat%2C%2019%20Apr%202025%2007%3A11%3A18%20GMT&stopTime=Sat%2C%2026%20Apr%202025%2007%3A11%3A18%20GMT&granularity=day&lBranch=enable-apple-benchmark-private-device&lCommit=46b6eab37da51c83304353df4d403ccbb9991ec4&rBranch=enable-apple-benchmark-private-device&rCommit=46b6eab37da51c83304353df4d403ccbb9991ec4&repoName=pytorch%2Fexecutorch&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=All%20Devices&archName=All%20Platforms

where the private device is marked private.
