### PR TITLE
Remove graph prints in tests

### DIFF
--- a/backends/cadence/aot/tests/test_fusion_ops_passes.py
+++ b/backends/cadence/aot/tests/test_fusion_ops_passes.py
@@ -328,7 +328,6 @@ class TestFusionPasses(TestFusionPassesBase):
         model = M()
         graph_module = export_to_edge(model, (inputs,)).exported_program().graph_module
         graph_module = FuseQuantDequantToRequantizePass()(graph_module).graph_module
-        graph_module.print_readable()
 
         self.check_op_counts(
             graph_module,

--- a/backends/cadence/aot/tests/test_memory_passes.py
+++ b/backends/cadence/aot/tests/test_memory_passes.py
@@ -711,7 +711,6 @@ class TestMemTransform(unittest.TestCase):
             .exported_program()
             .graph_module
         )
-        graph_module.print_readable()
         self.assertEqual(count_node(graph_module, torch.ops.aten._cat_nop.out), 1)
         self.assertEqual(
             count_node(graph_module, torch.ops.aten._slice_copy_nop.Tensor_out), 0
@@ -741,7 +740,6 @@ class TestMemTransform(unittest.TestCase):
             .exported_program()
             .graph_module
         )
-        graph_module.print_readable()
         self.assertEqual(count_node(graph_module, torch.ops.aten._cat_nop.out), 2)
         self.assertEqual(count_node(graph_module, torch.ops.aten.cat.out), 0)
         self.verify_nop_memory_alloc(graph_module)

--- a/backends/cadence/aot/tests/test_remove_ops_passes.py
+++ b/backends/cadence/aot/tests/test_remove_ops_passes.py
@@ -100,7 +100,6 @@ class TestRemoveOpsPasses(unittest.TestCase):
         p = RemoveNopAddOpPass()
 
         graph_after_passes = cast(PassResult, p(graph_module)).graph_module
-        graph_module.print_readable()
         self.assertEqual(
             count_node(graph_after_passes, exir_ops.edge.aten.add.Tensor),
             0,
@@ -140,7 +139,6 @@ class TestRemoveOpsPasses(unittest.TestCase):
         p = RemoveNopMulOpPass()
 
         graph_after_passes = cast(PassResult, p(graph_module)).graph_module
-        graph_module.print_readable()
         self.assertEqual(
             count_node(graph_after_passes, exir_ops.edge.aten.mul.Tensor),
             0,


### PR DESCRIPTION
Summary: Remove some clutter in the logs. If we want to keep them, let's put it at debug log level at least

Differential Revision: D73741049


