### PR TITLE
Replace usage of deprecated `distutils.(file|dir)_util`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,9 +18,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import distutils.file_util
 import glob
 import os
+import shutil
 import sys
 from typing import Any
 
@@ -135,7 +135,7 @@ for i in range(len(sphinx_gallery_conf["examples_dirs"])):
     # Copy .md files from source dir to gallery dir
     for f in glob.glob(os.path.join(source_dir, "*.md")):
 
-        distutils.file_util.copy_file(f, gallery_dir, update=True)
+        shutil.copyfile(f, gallery_dir)
 
 source_suffix = [".rst", ".md"]
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/FAI-PEP/pull/543

`distutils` has been deprecated since Python 3.10, and [removed in Python 3.12](https://docs.python.org/3/whatsnew/3.12.html#distutils).

Existing usage will now raise the following error under Python 3.12+:

```
ModuleNotFoundError: No module named 'distutils'
```

This diff replaces `distutils` usage according to [PEP-632 migration advice](https://peps.python.org/pep-0632/#migration-advice).

---

I generated this diff by looking for all usages of `distutils.*copy_(tree|file)` and replaced them with `shutil.copy(tree|file)`. These should be close to drop-in replacements!

Differential Revision: D73804939


