### PR TITLE
Remove #include <span>

### DIFF
--- a/runtime/core/test/span_test.cpp
+++ b/runtime/core/test/span_test.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <executorch/runtime/core/span.h>
-#include <span>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #10533

Remove # include span

Seems like it is not needed. Also part of C++20, not 17, which caused some errors when I was building et tests locally.

```
error: 10:10: fatal error: span: No such file or directory 10 | #include <span> | ^~~~~~ compilation terminated. gmake\[2\]: \*\*\* \[runtime79: runtime/core/test/CMakeFiles/runtime\_core\_test.dir/span\_test.cpp.o\] Error 1 gmake\[1\]: \*\*\* \[CMakeFiles5899: runtime/core/test/CMakeFiles/runtime\_core\_test.dir/all\] Error 2 gmake\[1\]: \*\*\* Waiting for unfinished jobs....
```

Differential Revision: [D73810585](https://our.internmc.facebook.com/intern/diff/D73810585/)