### PR TITLE
Fix coreml rank0

### DIFF
--- a/.ci/scripts/test_model.sh
+++ b/.ci/scripts/test_model.sh
@@ -222,7 +222,7 @@ test_model_with_coreml() {
 
   DTYPE=float16
 
-  "${PYTHON_EXECUTABLE}" -m examples.apple.coreml.scripts.export --model_name="${MODEL_NAME}" --compute_precision "${DTYPE}"
+  "${PYTHON_EXECUTABLE}" -m examples.apple.coreml.scripts.export --model_name="${MODEL_NAME}" --compute_precision "${DTYPE}" --use_partitioner
   EXPORTED_MODEL=$(find "." -type f -name "${MODEL_NAME}*.pte" -print -quit)
 
   if [ -n "$EXPORTED_MODEL" ]; then

--- a/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
@@ -203,10 +203,7 @@ Error CoreMLBackendDelegate::execute(BackendExecutionContext& context,
     size_t nInputs = nArgs.first;
     size_t nOutputs = nArgs.second;
     delegate_args.reserve(nInputs + nOutputs);
-    
-    // Container to hold wrapped scalar input args
-    std::vector<executorch::extension::TensorPtr> wrapped_scalars;
-    
+
     // inputs
     for (size_t i = 0; i < nInputs; i++) {
         auto multi_array = get_multi_array(args[i], ArgType::Input);

--- a/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
@@ -88,13 +88,12 @@ std::optional<MultiArray> get_multi_array(EValue *eValue, ArgType argType) {
         ET_LOG(Error, "%s: DataType=%d is not supported", ETCoreMLStrings.delegateIdentifier.UTF8String, (int)tensor.scalar_type());
         return std::nullopt;
     }
-    
     std::vector<ssize_t> strides(tensor.strides().begin(), tensor.strides().end());
     std::vector<size_t> shape(tensor.sizes().begin(), tensor.sizes().end());
     
     // If tensor is rank 0, wrap in rank 1
     // See https://github.com/apple/coremltools/blob/8.2/coremltools/converters/mil/frontend/torch/exir_utils.py#L73
-    if (strides.size() == 0) {
+    if (shape.size() == 0) {
         shape.push_back(1);
         strides.push_back(1);
     }

--- a/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
@@ -241,6 +241,12 @@ Error CoreMLBackendDelegate::execute(BackendExecutionContext& context,
     std::array<SizesType, kTensorDimensionLimit> new_shape;
     for (size_t i = nInputs; i < nInputs + nOutputs; i++) {
         Tensor& t = args[i]->toTensor();
+        // If t has rank 0, do not resize.  delegate_args[i] will have rank 1
+        // because we resized it in get_multi_array
+        if (t.dim() == 0) {
+            continue;
+        }
+
         int rank = delegate_args[i].layout().rank();
         assert (rank <= new_shape.size());
         for (int d = 0; d < rank; d++) {

--- a/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
@@ -88,6 +88,7 @@ std::optional<MultiArray> get_multi_array(EValue *eValue, ArgType argType) {
         ET_LOG(Error, "%s: DataType=%d is not supported", ETCoreMLStrings.delegateIdentifier.UTF8String, (int)tensor.scalar_type());
         return std::nullopt;
     }
+    
     std::vector<ssize_t> strides(tensor.strides().begin(), tensor.strides().end());
     std::vector<size_t> shape(tensor.sizes().begin(), tensor.sizes().end());
     

--- a/backends/apple/coreml/runtime/test/ETCoreMLModelManagerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLModelManagerTests.mm
@@ -113,7 +113,7 @@ using namespace executorchcoreml;
     XCTAssertNotNil(inputs);
     MLMultiArray *output = [ETCoreMLTestUtils filledMultiArrayWithShape:inputs[0].shape dataType:inputs[0].dataType repeatedValue:@(0) error:&localError];
     NSArray<MLMultiArray *> *args = [inputs arrayByAddingObject:output];
-    XCTAssertTrue([self.modelManager executeModelWithHandle:handle 
+    XCTAssertTrue([self.modelManager executeModelWithHandle:handle
                                                        args:args
                                              loggingOptions:executorchcoreml::ModelLoggingOptions()
                                                 eventLogger:nullptr
@@ -172,10 +172,10 @@ using namespace executorchcoreml;
         [ETCoreMLTestUtils inputsForModel:model repeatedValues:@[@(2), @(3)] error:&localError];
     XCTAssert(inputArrays);
 
-    std::vector<executorchcoreml::MultiArray> multiArrays;
+    std::vector<MultiArray> multiArrays;
     multiArrays.reserve(inputArrays.count + model.orderedOutputNames.count);
     for (MLMultiArray *array in inputArrays) {
-        auto dataTypeOpt = executorchcoreml::to_multiarray_data_type(array.dataType);
+        auto dataTypeOpt = to_multiarray_data_type(array.dataType);
         XCTAssert(dataTypeOpt.has_value());
         auto dataType = dataTypeOpt.value();
 
@@ -192,7 +192,7 @@ using namespace executorchcoreml;
         }
 
         multiArrays.emplace_back(array.dataPointer,
-                                 executorchcoreml::MultiArray::MemoryLayout(dataType, dims, strides));
+                                 MultiArray::MemoryLayout(dataType, dims, strides));
     }
 
     auto inputLayout = multiArrays[0].layout();
@@ -205,15 +205,15 @@ using namespace executorchcoreml;
         auto originalLayout = multiArrays[0].layout();
         auto corruptedDims = originalLayout.shape();
         corruptedDims[0] += 1;
-        multiArrays[0] = executorchcoreml::MultiArray(multiArrays[0].data(),
-                                                      executorchcoreml::MultiArray::MemoryLayout(originalLayout.dataType(),
+        multiArrays[0] = MultiArray(multiArrays[0].data(),
+                                    MultiArray::MemoryLayout(originalLayout.dataType(),
                                                              corruptedDims,
                                                              originalLayout.strides()));
     }
 
     BOOL success = [self.modelManager executeModelWithHandle:modelHandle
                                                     argsVec:multiArrays
-                                             loggingOptions:executorchcoreml::ModelLoggingOptions()
+                                             loggingOptions:ModelLoggingOptions()
                                                 eventLogger:nullptr
                                                       error:&localError];
     XCTAssertFalse(success);

--- a/backends/apple/coreml/runtime/test/ETCoreMLModelManagerTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLModelManagerTests.mm
@@ -172,10 +172,10 @@ using namespace executorchcoreml;
         [ETCoreMLTestUtils inputsForModel:model repeatedValues:@[@(2), @(3)] error:&localError];
     XCTAssert(inputArrays);
 
-    std::vector<MultiArray> multiArrays;
+    std::vector<executorchcoreml::MultiArray> multiArrays;
     multiArrays.reserve(inputArrays.count + model.orderedOutputNames.count);
     for (MLMultiArray *array in inputArrays) {
-        auto dataTypeOpt = to_multiarray_data_type(array.dataType);
+        auto dataTypeOpt = executorchcoreml::to_multiarray_data_type(array.dataType);
         XCTAssert(dataTypeOpt.has_value());
         auto dataType = dataTypeOpt.value();
 
@@ -192,7 +192,7 @@ using namespace executorchcoreml;
         }
 
         multiArrays.emplace_back(array.dataPointer,
-                                 MultiArray::MemoryLayout(dataType, dims, strides));
+                                 executorchcoreml::MultiArray::MemoryLayout(dataType, dims, strides));
     }
 
     auto inputLayout = multiArrays[0].layout();
@@ -205,15 +205,15 @@ using namespace executorchcoreml;
         auto originalLayout = multiArrays[0].layout();
         auto corruptedDims = originalLayout.shape();
         corruptedDims[0] += 1;
-        multiArrays[0] = MultiArray(multiArrays[0].data(),
-                                    MultiArray::MemoryLayout(originalLayout.dataType(),
+        multiArrays[0] = executorchcoreml::MultiArray(multiArrays[0].data(),
+                                                      executorchcoreml::MultiArray::MemoryLayout(originalLayout.dataType(),
                                                              corruptedDims,
                                                              originalLayout.strides()));
     }
 
     BOOL success = [self.modelManager executeModelWithHandle:modelHandle
                                                     argsVec:multiArrays
-                                             loggingOptions:ModelLoggingOptions()
+                                             loggingOptions:executorchcoreml::ModelLoggingOptions()
                                                 eventLogger:nullptr
                                                       error:&localError];
     XCTAssertFalse(success);


### PR DESCRIPTION
coremltools wraps rank 0 tensors as rank1 tensors in the AOT flow when producing a PTE file.  This PR:

* Applies the same change on the coreml runtime
* Changes CoreML model tests to use the partitioner

Fixes https://github.com/pytorch/executorch/issues/10451