### PR TITLE
Unbreak pytree Buck build

### DIFF
--- a/extension/pytree/targets.bzl
+++ b/extension/pytree/targets.bzl
@@ -11,6 +11,9 @@ def define_common_targets():
         name = "pytree",
         srcs = [],
         exported_headers = ["pytree.h", "function_ref.h"],
+        exported_deps = [
+            "//executorch/runtime/core:core",
+        ],
         visibility = [
             "//executorch/...",
             "@EXECUTORCH_CLIENTS",


### PR DESCRIPTION
D73688265/#10441 broke it. Apparently nothing covered by OSS unittest-buck uses it.