### PR TITLE
Arm backend: Add table ops to CheckProperQuantization

### DIFF
--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -18,6 +18,7 @@ from executorch.backends.arm._passes.fuse_constant_ops_pass import ComputeConsta
 from executorch.backends.arm._passes.fuse_quantized_activation_pass import (
     FuseQuantizedActivationPass,
 )
+from executorch.backends.arm._passes.insert_table_ops import TableOps
 from executorch.backends.arm.operator_support.ethos_u55_support import (
     EthosU55DtypeSupport,
     EthosU55NotSupported,
@@ -298,6 +299,24 @@ class CheckProperQuantization(OperatorSupportBase):
 
     dq_op = exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default
     q_op = exir_ops.edge.quantized_decomposed.quantize_per_tensor.default
+    targeted_ops = (
+        exir_ops.edge.aten.add.Tensor,
+        exir_ops.edge.aten.avg_pool2d.default,
+        exir_ops.edge.aten.bmm.default,
+        exir_ops.edge.aten.convolution.default,
+        exir_ops.edge.aten.full.default,
+        exir_ops.edge.aten.full_like.default,
+        exir_ops.edge.aten.hardtanh.default,
+        exir_ops.edge.aten.linear.default,
+        exir_ops.edge.aten.max_pool2d_with_indices.default,
+        exir_ops.edge.aten.mm.default,
+        exir_ops.edge.aten.mul.Tensor,
+        exir_ops.edge.aten.relu.default,
+        exir_ops.edge.aten.sub.Tensor,
+        exir_ops.edge.aten.upsample_bilinear2d.vec,
+        exir_ops.edge.aten.upsample_nearest2d.vec,
+        *TableOps.included_ops(),
+    )
 
     def __init__(self, reporter: WhyNoPartitionReporter):
         self.reporter = reporter
@@ -356,30 +375,7 @@ class CheckProperQuantization(OperatorSupportBase):
     ) -> bool:
         output_quantized = False
         input_quantized = False
-        if node.target not in (
-            exir_ops.edge.aten.add.Tensor,
-            exir_ops.edge.aten.avg_pool2d.default,
-            exir_ops.edge.aten.bmm.default,
-            exir_ops.edge.aten.convolution.default,
-            exir_ops.edge.aten.exp.default,
-            exir_ops.edge.aten.full.default,
-            exir_ops.edge.aten.full_like.default,
-            exir_ops.edge.aten.hardtanh.default,
-            exir_ops.edge.aten.linear.default,
-            exir_ops.edge.aten.log.default,
-            exir_ops.edge.aten.max_pool2d_with_indices.default,
-            exir_ops.edge.aten.mm.default,
-            exir_ops.edge.aten.mul.Tensor,
-            exir_ops.edge.aten.reciprocal.default,
-            exir_ops.edge.aten.relu.default,
-            exir_ops.edge.aten.rsqrt.default,
-            exir_ops.edge.aten.sigmoid.default,
-            exir_ops.edge.aten.sub.Tensor,
-            exir_ops.edge.aten.tanh.default,
-            exir_ops.edge.aten.upsample_bilinear2d.vec,
-            exir_ops.edge.aten.upsample_nearest2d.vec,
-            exir_ops.edge.aten.gelu.default,
-        ):
+        if node.target not in self.targeted_ops:
             return True
         elif node.target in (
             exir_ops.edge.aten.bmm.default,


### PR DESCRIPTION
Use TableOps.included_ops() to get all table ops. This removes the risk of forgetting to add ops to CheckProperQuantization when supporting new table ops.


cc @digantdesai @freddan80 @per @zingo