### PR TITLE
Arm backend: Build executorch with -j$(nproc)

### DIFF
--- a/backends/arm/scripts/build_executorch.sh
+++ b/backends/arm/scripts/build_executorch.sh
@@ -137,7 +137,7 @@ cmake                                                 \
 
 echo "[$(basename $0)] Configured CMAKE"
 
-cmake --build ${et_build_dir} --parallel --target install --config ${build_type} --
+cmake --build ${et_build_dir} -j$(nproc) --target install --config ${build_type} --
 
 set +x
 


### PR DESCRIPTION
This avoids crashes when building on certain systems.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218