### PR TITLE
Remove strictness in export calls

### DIFF
--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -88,7 +88,7 @@ def trace(
 
     # Export with dynamo
     program = torch.export.export_for_training(
-        model, inputs, strict=True
+        model, inputs
     ).run_decompositions(decomp_table)
 
     if dump_graphs:


### PR DESCRIPTION
Summary: The new PT default has been to do non-strict export for a little while now. We have explicit strict because the PT compiler team preserved the current behavior at the time, but we should be able to remove it and match the default. It might also make more models go through.

Differential Revision: D73859317


