### PR TITLE
[MPS] float16 naming fixed and inexistent mps_logical_not model removed

### DIFF
--- a/backends/apple/mps/setup.md
+++ b/backends/apple/mps/setup.md
@@ -76,12 +76,12 @@ cd executorch
 ## Run the mv3 generated model using the mps_executor_runner
 
 ```bash
-./cmake-out/examples/apple/mps/mps_executor_runner --model_path mv3_mps_bundled_fp16.pte --bundled_program
+./cmake-out/examples/apple/mps/mps_executor_runner --model_path mv3_mps_float16_bundled.pte --bundled_program
 ```
 
 - You should see the following results. Note that no output file will be generated in this example:
 ```
-I 00:00:00.003290 executorch:mps_executor_runner.mm:286] Model file mv3_mps_bundled_fp16.pte is loaded.
+I 00:00:00.003290 executorch:mps_executor_runner.mm:286] Model file mv3_mps_float16_bundled.pte is loaded.
 I 00:00:00.003306 executorch:mps_executor_runner.mm:292] Program methods: 1
 I 00:00:00.003308 executorch:mps_executor_runner.mm:294] Running method forward
 I 00:00:00.003311 executorch:mps_executor_runner.mm:349] Setting up non-const buffer 1, size 606112.
@@ -118,7 +118,7 @@ python3 -m examples.apple.mps.scripts.mps_example --model_name="mv3" --generate_
 ```
 2. Run your Program on the ExecuTorch runtime and generate an [ETDump](../../../docs/source/etdump.md).
 ```
-./cmake-out/examples/apple/mps/mps_executor_runner --model_path mv3_mps_bundled_fp16.pte --bundled_program --dump-outputs
+./cmake-out/examples/apple/mps/mps_executor_runner --model_path mv3_mps_float16_bundled.pte --bundled_program --dump-outputs
 ```
 3. Create an instance of the Inspector API by passing in the ETDump you have sourced from the runtime along with the optionally generated ETRecord from step 1.
 ```bash

--- a/examples/apple/mps/executor_runner/mps_executor_runner.mm
+++ b/examples/apple/mps/executor_runner/mps_executor_runner.mm
@@ -359,7 +359,7 @@ int main(int argc, char** argv) {
   if (FLAGS_bundled_program) {
     double rtol = 1e-05;
     double atol = 1e-08;
-    if (strstr(model_path, "fp16")) {
+    if (strstr(model_path, "float16")) {
       rtol = 1e-01;
       atol = 1e-01;
     } else if (strstr(model_path, "mv3")           ||

--- a/examples/apple/mps/scripts/build_mps_executor_runner.sh
+++ b/examples/apple/mps/scripts/build_mps_executor_runner.sh
@@ -60,5 +60,3 @@ cmake \
 cmake --build cmake-out/examples/apple/mps -j9 --config "$MODE"
 
 echo "Build succeeded!"
-
-./cmake-out/examples/apple/mps/mps_executor_runner --model_path mps_logical_not.pte --bundled_program


### PR DESCRIPTION
Upstream mps fixes by @versi379


Summary of changes:
- Updated generated model name in MPS Backend documentation.
- Removed extra line running an inexistent model when building mps_executor_runner.

cc @cccclai , @shoumikhin 
