### PR TITLE
Allow removing permute pairs in addition to transpose pairs (#10501)

### DIFF
--- a/backends/cadence/aot/passes.py
+++ b/backends/cadence/aot/passes.py
@@ -14,7 +14,7 @@ import torch.utils._pytree as pytree
 from executorch.backends.cadence.aot.fuse_ops import (
     CadenceFuseOpsInGraph,
     FuseFullThenReshapePass,
-    FuseTransposeOpPairsPass,
+    FuseTransposeOrPermuteOpPairsPass,
 )
 from executorch.backends.cadence.aot.pass_utils import (
     CadencePassAttribute,
@@ -83,7 +83,7 @@ def get_passes_in_default_order() -> List[ExportPass]:
         CadenceSimplifyOpsInGraph.passes,
         FinalizePipeline,
         FuseFullThenReshapePass,
-        FuseTransposeOpPairsPass,
+        FuseTransposeOrPermuteOpPairsPass,
         RemoveNopSliceOrViewOpPass,
     ]
     return pytree.tree_flatten(passes)[0]

--- a/backends/cadence/aot/tests/test_fusion_ops_passes.py
+++ b/backends/cadence/aot/tests/test_fusion_ops_passes.py
@@ -8,6 +8,7 @@
 
 
 import unittest
+from typing import Tuple
 
 import executorch.backends.cadence.aot.ops_registrations  # noqa
 import torch
@@ -20,7 +21,7 @@ from executorch.backends.cadence.aot.fuse_ops import (
     FuseFullThenReshapePass,
     FuseMulIntoDequantPass,
     FuseQuantDequantToRequantizePass,
-    FuseTransposeOpPairsPass,
+    FuseTransposeOrPermuteOpPairsPass,
 )
 from executorch.backends.cadence.aot.graph_builder import GraphBuilder
 from executorch.backends.cadence.aot.pass_utils import count_node, op_counts_match
@@ -509,6 +510,24 @@ class TestFusionPasses(TestFusionPassesBase):
         )
 
 
+class TestFuseTransposeOrPermuteOpPairsPass(TestFusionPassesBase):
+    def _create_operator(
+        self, builder: GraphBuilder, op: torch._ops.OpOverload, x: ProxyValue
+    ) -> ProxyValue:
+        if op == exir_ops.edge.quantized_decomposed.quantize_per_tensor.default:
+            return builder.call_operator(
+                op=op,
+                args=(x, 1.2, 3, 0, 127, torch.int8),
+            )
+        elif op == exir_ops.edge.cadence.quantized_relu.per_tensor:
+            return builder.call_operator(
+                op=op,
+                args=(x, 0, 0, 0, 0),
+            )
+        else:
+            raise ValueError(f"Unsupported op: {op}")
+
+
 class TestFuseTransposeOpPairsPass(TestFusionPassesBase):
     def _create_operator(
         self, builder: GraphBuilder, op: torch._ops.OpOverload, x: ProxyValue
@@ -528,83 +547,168 @@ class TestFuseTransposeOpPairsPass(TestFusionPassesBase):
 
     @parameterized.expand(
         [
-            exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
-            exir_ops.edge.cadence.quantized_relu.per_tensor,
+            # transpose -> quant -> same transpose => fuse
+            (
+                True,
+                [0, 1],
+                True,
+                [0, 1],
+                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+                True,
+            ),
+            # same with different input size
+            (
+                True,
+                [0, 1],
+                True,
+                [0, 1],
+                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+                True,
+                [4, 4, 4],
+            ),
+            # transpose -> quant -> same transpose => fuse (same with transpose dimensions in different order, and with different skip quant op)
+            (
+                True,
+                [0, 1],
+                True,
+                [1, 0],
+                exir_ops.edge.cadence.quantized_relu.per_tensor,
+                True,
+            ),
+            # transpose -> quant -> different transpose => don't fuse
+            (
+                True,
+                [0, 1],
+                True,
+                [0, 2],
+                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+                False,
+            ),
+            # permutation -> quant -> opposite permutation => fuse
+            (
+                False,
+                [1, 2, 0],
+                False,
+                [2, 0, 1],
+                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+                True,
+            ),
+            # same with different input size
+            (
+                False,
+                [1, 2, 0],
+                False,
+                [2, 0, 1],
+                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+                True,
+                [4, 4, 4],
+            ),
+            # permutation -> quant -> not the opposite permutation => don't fuse
+            (
+                False,
+                [1, 2, 0],
+                False,
+                [1, 2, 0],
+                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+                False,
+            ),
+            # same with different input size
+            (
+                False,
+                [1, 2, 0],
+                False,
+                [1, 2, 0],
+                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+                False,
+                [4, 4, 4],
+            ),
+            # transpose -> quant -> transpose as a permutation => fuse
+            (
+                True,
+                [0, 1],
+                False,
+                [1, 0, 2],
+                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+                True,
+            ),
+            # transpose -> quant -> not opposite permutation => fuse
+            (
+                True,
+                [0, 1],
+                False,
+                [0, 2, 1],
+                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+                False,
+            ),
         ],
     )
-    def test_fuse_transpose_pairs(self, op: torch._ops.OpOverload):
-        # Create a graph with transpose -> quant -> transpose.
+    def test_fuse_transpose_permute_pairs(
+        self,
+        is_op1_transpose: bool,
+        perm1: list[int],
+        is_op2_transpose: bool,
+        perm2: list[int],
+        quant_op: torch._ops.OpOverload,
+        expected_is_fused: bool,
+        dims: Tuple[int, int, int] = (2, 3, 4),
+    ):
+        # Create a graph with transpose/permute -> quant -> transpose/permute.
         builder = GraphBuilder()
-        x = builder.placeholder("x", torch.randn(2, 3))
-        transpose_node = builder.call_operator(
-            op=exir_ops.edge.aten.transpose_copy.int,
-            args=(x, 0, 1),
+        x = builder.placeholder("x", torch.randn(dims))
+        op1 = (
+            exir_ops.edge.aten.transpose_copy.int
+            if is_op1_transpose
+            else exir_ops.edge.aten.permute_copy.default
         )
-        quant_node = self._create_operator(builder, op, transpose_node)
-        transpose_node = builder.call_operator(
-            op=exir_ops.edge.aten.transpose_copy.int,
-            args=(quant_node, 0, 1),
+        node1 = builder.call_operator(
+            op=op1,
+            args=(x, perm1[0], perm1[1]) if is_op1_transpose else (x, list(perm1)),
         )
-        builder.output([transpose_node])
+        quant_node = self._create_operator(builder, quant_op, node1)
+        op2 = (
+            exir_ops.edge.aten.transpose_copy.int
+            if is_op2_transpose
+            else exir_ops.edge.aten.permute_copy.default
+        )
+        node2 = builder.call_operator(
+            op=op2,
+            args=(
+                (quant_node, perm2[0], perm2[1])
+                if is_op2_transpose
+                else (quant_node, list(perm2))
+            ),
+        )
+        builder.output([node2])
         gm = builder.get_graph_module()
+        expected_op_counts = {
+            quant_op: 1,
+        }
+        expected_op_counts[op1] = 1
+        expected_op_counts[op2] = expected_op_counts.get(op2, 0) + 1
         self.check_op_counts(
             gm,
-            expected_op_counts={
-                exir_ops.edge.aten.transpose_copy.int: 2,
-                op: 1,
-            },
+            # pyre-fixme[6]: Incompatible parameter type
+            expected_op_counts=expected_op_counts,
         )
 
-        # Check that the pass fuses the two transpose ops.
-        fusion_pass_result = FuseTransposeOpPairsPass()(gm)
+        # Check that the pass fuses the two transpose/permute ops.
+        fusion_pass_result = FuseTransposeOrPermuteOpPairsPass()(gm)
         self.assertIsNotNone(fusion_pass_result)
         gm_after_pass = fusion_pass_result.graph_module
+        if expected_is_fused:
+            expected_op_counts[op1] = 0
+            expected_op_counts[op2] = 0
         self.check_op_counts(
             gm_after_pass,
-            expected_op_counts={
-                exir_ops.edge.aten.transpose_copy.int: 0,
-                op: 1,
-            },
-        )
-
-    def test_no_fusion_for_transpose_pairs(self):
-        # Create a graph with transpose -> quant -> transpose.
-        builder = GraphBuilder()
-        x = builder.placeholder("x", torch.randn(2, 3, 4))
-        transpose_node = builder.call_operator(
-            op=exir_ops.edge.aten.transpose_copy.int,
-            args=(x, 0, 1),
-        )
-        quant_node = builder.call_operator(
-            op=exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
-            args=(transpose_node, 1.2, 3, 0, 127, torch.int8),
-        )
-        transpose_node = builder.call_operator(
-            op=exir_ops.edge.aten.transpose_copy.int,
-            args=(quant_node, 1, 2),
-        )
-        builder.output(transpose_node)
-        gm = builder.get_graph_module()
-        self.check_op_counts(
-            gm,
-            expected_op_counts={
-                exir_ops.edge.aten.transpose_copy.int: 2,
-                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default: 1,
-            },
-        )
-
-        # No fusion.
-        gm_after_pass = FuseTransposeOpPairsPass()(gm).graph_module
-        self.check_op_counts(
-            gm_after_pass,
-            expected_op_counts={
-                exir_ops.edge.aten.transpose_copy.int: 2,
-                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default: 1,
-            },
+            # pyre-fixme[6]: Incompatible parameter type
+            expected_op_counts=expected_op_counts,
         )
 
     def test_fusion_for_forked_transposes(self):
-        # Create a graph with transpose -> quant -> transpose.
+        # Create a graph with
+        # transpose -> quant -> transpose.
+        #           -> quant -> transpose.
+        #           -> quant -> transpose.
         builder = GraphBuilder()
         x = builder.placeholder("x", torch.randn(2, 3, 4, dtype=torch.float32))
         transpose_node = builder.call_operator(
@@ -634,8 +738,8 @@ class TestFuseTransposeOpPairsPass(TestFusionPassesBase):
             },
         )
 
-        # Fuse the all the transpose ops.
-        gm_after_pass = FuseTransposeOpPairsPass()(gm).graph_module
+        # Fuse all the transpose ops.
+        gm_after_pass = FuseTransposeOrPermuteOpPairsPass()(gm).graph_module
         self.check_op_counts(
             gm_after_pass,
             expected_op_counts={


### PR DESCRIPTION
Summary:

Pull Request resolved:

As titled. Gets us 27% better cycles on Activity Classification (at opt level 3).

Can be improved further (when fused permutations are not an identity), task is T222295719

Differential Revision: D73619452
