### PR TITLE
Fix num nonbatch dims calculation

### DIFF
--- a/backends/xnnpack/operators/quant_params.py
+++ b/backends/xnnpack/operators/quant_params.py
@@ -149,6 +149,8 @@ class QuantParams:
 
         while users_list:
             current_user = users_list.pop()
+            if "linear" in str(current_user.target):
+                return False
             if "convolution" in str(current_user.target):
                 return True
             users_list.extend(current_user.users)


### PR DESCRIPTION
Summary: This will search for if there exists a conv in the graph, and then set the num nonbatch dims to 3. If we find a linear before conv, then the nonbatch dims should be 1. Again per the todo, we should parse the number of nonbatch dims from the affine quant node in the future.

Differential Revision: D73967842


