### PR TITLE
Enable do_quant_fusion_and_const_prop by default

### DIFF
--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -104,4 +104,4 @@ class ExecutorchBackendConfig:
     emit_mutable_buffer_names: bool = False
 
     # If set to true, we run quant fusion and constant propagation passes
-    do_quant_fusion_and_const_prop: bool = False
+    do_quant_fusion_and_const_prop: bool = True

--- a/exir/tests/test_joint_graph.py
+++ b/exir/tests/test_joint_graph.py
@@ -10,7 +10,7 @@ import unittest
 import torch
 import torch._dynamo
 
-from executorch.exir import to_edge
+from executorch.exir import to_edge, ExecutorchBackendConfig
 
 from executorch.extension.pybindings.portable_lib import (
     _load_for_executorch_from_buffer,
@@ -49,8 +49,11 @@ class TestJointGraph(unittest.TestCase):
                 break
 
         orig_outputs = len(output_node.args[0])
-
-        et = edge.to_executorch()
+     
+        config = ExecutorchBackendConfig(
+            do_quant_fusion_and_const_prop=False,
+        )
+        et = edge.to_executorch(config)
 
         weight_output_specs = [
             spec

--- a/exir/tests/test_memory_planning.py
+++ b/exir/tests/test_memory_planning.py
@@ -769,7 +769,8 @@ class TestMisc(unittest.TestCase):
         ep = export(net, inputs, strict=True)
         ep = _export_forward_backward(ep)
         ep = to_edge(ep)
-        ep = ep.to_executorch()
+        config = ExecutorchBackendConfig(do_quant_fusion_and_const_prop=False)
+        ep = ep.to_executorch(config)
 
         ep.dump_executorch_program(True)
 

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -1085,7 +1085,16 @@ class TestPasses(unittest.TestCase):
         self.assertEqual(ep.graph_signature.input_specs[1].arg.name, "b_a")
 
         # Validate that the program successfully passes validation to executorch:
-        edge.to_executorch()
+
+        # The test fails when do_quant_fusion_and_const_prop=True, but it is not related to
+        # the pass, but rather that memory planning fails (AssertionError: graph_output_allocated not set)
+        # when a graph has no user inputs and no operations.  We can construct a failure case
+        # even with do_quant_fusion_and_const_prop = False by changing the forward method in NoUserInputs
+        # to just return self.a
+        config = exir.ExecutorchBackendConfig(
+            do_quant_fusion_and_const_prop=False,
+        )
+        edge.to_executorch(config)
 
     def test_constant_prop_pass_for_parameter(self) -> None:
         def count_additions(gm: torch.fx.GraphModule) -> int:

--- a/exir/tests/test_remove_view_copy.py
+++ b/exir/tests/test_remove_view_copy.py
@@ -102,6 +102,7 @@ class TestRemoveViewCopy(unittest.TestCase):
             config=ExecutorchBackendConfig(
                 remove_view_copy=True,
                 memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+                do_quant_fusion_and_const_prop=False,
             ),
         )
 

--- a/extension/training/examples/XOR/export_model.py
+++ b/extension/training/examples/XOR/export_model.py
@@ -32,7 +32,8 @@ def _export_model(external_mutable_weights: bool = False):
     # Lower the graph to executorch.
     ep = ep.to_executorch(
         config=ExecutorchBackendConfig(
-            external_mutable_weights=external_mutable_weights
+            external_mutable_weights=external_mutable_weights,
+            do_quant_fusion_and_const_prop=False,
         )
     )
     return ep

--- a/extension/training/pybindings/test/test.py
+++ b/extension/training/pybindings/test/test.py
@@ -9,7 +9,7 @@
 import unittest
 
 import torch
-from executorch.exir import to_edge
+from executorch.exir import to_edge, ExecutorchBackendConfig
 
 from executorch.extension.training import (
     _load_for_executorch_for_training_from_buffer,
@@ -36,7 +36,8 @@ class TestTraining(unittest.TestCase):
         ep = torch.export.export(m, m.get_inputs(), strict=True)
         ep = _export_forward_backward(ep)
         ep = to_edge(ep)
-        ep = ep.to_executorch()
+        config = ExecutorchBackendConfig(do_quant_fusion_and_const_prop=False)
+        ep = ep.to_executorch(config)
         buffer = ep.buffer
         tm = _load_for_executorch_for_training_from_buffer(buffer)
 


### PR DESCRIPTION
Summary:
This diff enables const_prop + quant fusion during to_executorch by default (do_quant_fusion_and_const_prop: bool = True in ExecuTorchBackendConfig).

This requires updating various tests in CI.

Differential Revision: D73749914


