### PR TITLE
Make quantize_pt2 return an ExportedProgram instead of a GraphModule

### DIFF
--- a/backends/cadence/aot/tests/test_replace_ops_passes.py
+++ b/backends/cadence/aot/tests/test_replace_ops_passes.py
@@ -16,7 +16,6 @@ from executorch.backends.cadence.aot import compiler
 from executorch.backends.cadence.aot.compiler import (
     export_to_edge,
     quantize_and_export_to_edge,
-    quantize_pt2,
 )
 from executorch.backends.cadence.aot.graph_builder import (
     GraphBuilder,
@@ -113,9 +112,8 @@ class TestReplaceOpsPasses(unittest.TestCase):
         Y = torch.randn(y_shape)
         p = ReplaceMatmulWithTransposedMatmulPass()
         inputs = (X, Y)
-        quantized_model = quantize_pt2(model, inputs)
         graph_module = (
-            export_to_edge(quantized_model, inputs).exported_program().graph_module
+            quantize_and_export_to_edge(model, inputs).exported_program().graph_module
         )
         # pyre-fixme[16]: Optional type has no attribute `graph_module`
         graph_after_passes = p(graph_module).graph_module


### PR DESCRIPTION
Summary:
This will help differentiating the fp32 models from the quantized models, and prevent people from using the wrong APIs.
For fp32 cases, we have a `torch.nn.Module`, which we trace and then lower. For quantized cases, we trace, quantize, and lower.

After this diff, `export_to_<edge, executorch>` will ONLY handle non-quantized cases, and importantly, the sequence of `quantize_pt2` and then `export_to_<edge, executorch>` will not work anymore. Those cases should use the (existing) `lower_ep_to_<edge, executorch>` instead.

Differential Revision: D73722640


