### PR TITLE
Update install script and building from source docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It supports a wide range of models including LLMs (Large Language Models), CV (C
 Platform Support:
 - Operating Systems:
   - iOS
-  - Mac
+  - MacOS (ARM64)
   - Android
   - Linux
   - Microcontrollers

--- a/docs/source/backends-xnnpack.md
+++ b/docs/source/backends-xnnpack.md
@@ -14,7 +14,7 @@ The XNNPACK delegate is the ExecuTorch solution for CPU execution on mobile CPUs
 - ARM64 on Android, iOS, macOS, Linux, and Windows.
 - ARMv7 (with NEON) on Android.
 - ARMv6 (with VFPv2) on Linux.
-- x86 and x86-64 (up to AVX512) on Windows, Linux, macOS, Android, and iOS simulator.
+- x86 and x86-64 (up to AVX512) on Windows, Linux, Android.
 
 ## Development Requirements
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -10,8 +10,9 @@ The following are required to install the ExecuTorch host libraries, needed to e
 
 - Python 3.10 - 3.12
 - g++ version 7 or higher, clang++ version 5 or higher, or another C++17-compatible toolchain.
-- Linux or MacOS operating system (Arm or x86).
-  - Windows is supported via WSL.
+- Linux (x86_64 or ARM64) or macOS (ARM64).
+    - Intel-based macOS systems require building PyTorch from source (see [Building From Source](using-executorch-building-from-source.md) for instructions).
+    - Windows is supported via WSL.
 
 ## Installation
 To use ExecuTorch, you will need to install both the Python package and the appropriate platform-specific runtime libraries. Pip is the recommended way to install the ExecuTorch python package.

--- a/docs/source/using-executorch-building-from-source.md
+++ b/docs/source/using-executorch-building-from-source.md
@@ -61,7 +61,7 @@ Or alternatively, [install conda on your machine](https://conda.io/projects/cond
    # Install ExecuTorch pip package and its dependencies, as well as
    # development tools like CMake.
    # If developing on a Mac, make sure to install the Xcode Command Line Tools first.
-   # Intel-based macOS systems require building PyTorch from source (see below)
+   # Intel-based macOS systems require building PyTorch, Torchvision, and Torchaudio from source (see below)
    ./install_executorch.sh
    ```
   

--- a/docs/source/using-executorch-building-from-source.md
+++ b/docs/source/using-executorch-building-from-source.md
@@ -16,7 +16,7 @@ Linux (x86_64)
 - Ubuntu 20.04.6 LTS+
 - RHEL 8+
 
-macOS (x86_64/M1/M2)
+macOS (x86_64/ARM64)
 - Big Sur (11.0)+
 
 Windows (x86_64)
@@ -56,12 +56,20 @@ Or alternatively, [install conda on your machine](https://conda.io/projects/cond
    conda create -yn executorch python=3.10.0 && conda activate executorch
    ```
 
-## Install ExecuTorch pip package from Source
+## Install ExecuTorch pip package from source
    ```bash
    # Install ExecuTorch pip package and its dependencies, as well as
    # development tools like CMake.
    # If developing on a Mac, make sure to install the Xcode Command Line Tools first.
+   # Intel-based macOS systems require building PyTorch from source (see below)
    ./install_executorch.sh
+   ```
+  
+  Use the [`--use-pt-pinned-commit` flag](https://github.com/pytorch/executorch/blob/main/install_executorch.sh) to install Executorch with an existing PyTorch build.  
+  See the [PyTorch instructions](https://github.com/pytorch/pytorch#installation) on how to build PyTorch from source.
+
+   ```bash
+   ./install_executorch.sh --use-pt-pinned-commit
    ```
 
    Not all backends are built into the pip wheel by default. You can link these missing/experimental backends by turning on the corresponding cmake flag. For example, to include the MPS backend:

--- a/docs/source/using-executorch-building-from-source.md
+++ b/docs/source/using-executorch-building-from-source.md
@@ -61,22 +61,22 @@ Or alternatively, [install conda on your machine](https://conda.io/projects/cond
    # Install ExecuTorch pip package and its dependencies, as well as
    # development tools like CMake.
    # If developing on a Mac, make sure to install the Xcode Command Line Tools first.
-   # Intel-based macOS systems require building PyTorch, Torchvision, and Torchaudio from source (see below)
+   # Intel-based macOS systems require building PyTorch from source (see below)
    ./install_executorch.sh
    ```
   
-  See the [PyTorch instructions](https://github.com/pytorch/pytorch#installation) on how to build PyTorch from source.  
+   See the [PyTorch instructions](https://github.com/pytorch/pytorch#installation) on how to build PyTorch from source.  
 
-  Use the [`--use-pt-pinned-commit` flag](../../install_executorch.py) to install ExecuTorch with an existing PyTorch build:
+   Use the [`--use-pt-pinned-commit` flag](../../install_executorch.py) to install ExecuTorch with an existing PyTorch build:
 
    ```bash
    ./install_executorch.sh --use-pt-pinned-commit
    ```
 
-  For Intel-based macOS systems, use the [`--use-pt-pinned-commit --minimal` flags](../../install_executorch.py):
-  ```bash
-  ./install_executorch.sh --use-pt-pinned-commit --minimal
-  ```
+   For Intel-based macOS systems, use the [`--use-pt-pinned-commit --minimal` flags](../../install_executorch.py):
+   ```bash
+   ./install_executorch.sh --use-pt-pinned-commit --minimal
+   ```
 
    Not all backends are built into the pip wheel by default. You can link these missing/experimental backends by turning on the corresponding cmake flag. For example, to include the MPS backend:
 

--- a/docs/source/using-executorch-building-from-source.md
+++ b/docs/source/using-executorch-building-from-source.md
@@ -65,12 +65,18 @@ Or alternatively, [install conda on your machine](https://conda.io/projects/cond
    ./install_executorch.sh
    ```
   
-  Use the [`--use-pt-pinned-commit` flag](https://github.com/pytorch/executorch/blob/main/install_executorch.sh) to install Executorch with an existing PyTorch build.  
-  See the [PyTorch instructions](https://github.com/pytorch/pytorch#installation) on how to build PyTorch from source.
+  See the [PyTorch instructions](https://github.com/pytorch/pytorch#installation) on how to build PyTorch from source.  
+
+  Use the [`--use-pt-pinned-commit` flag](../../install_executorch.py) to install ExecuTorch with an existing PyTorch build:
 
    ```bash
    ./install_executorch.sh --use-pt-pinned-commit
    ```
+
+  For Intel-based macOS systems, use the [`--use-pt-pinned-commit --minimal` flags](../../install_executorch.py):
+  ```bash
+  ./install_executorch.sh --use-pt-pinned-commit --minimal
+  ```
 
    Not all backends are built into the pip wheel by default. You can link these missing/experimental backends by turning on the corresponding cmake flag. For example, to include the MPS backend:
 

--- a/docs/source/using-executorch-ios.md
+++ b/docs/source/using-executorch-ios.md
@@ -4,7 +4,7 @@ ExecuTorch supports both iOS and macOS via Objective-C, Swift, and C++. ExecuTor
 
 ## Integration
 
-The ExecuTorch Runtime for iOS and macOS is distributed as a collection of prebuilt [.xcframework](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle) binary targets. These targets are compatible with both iOS and macOS devices and simulators and are available in both release and debug modes:
+The ExecuTorch Runtime for iOS and macOS (ARM64) is distributed as a collection of prebuilt [.xcframework](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle) binary targets. These targets are compatible with both iOS and macOS devices and simulators and are available in both release and debug modes:
 
 * `executorch` - Main Runtime components
 * `backend_coreml` - Core ML backend
@@ -113,6 +113,13 @@ python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
 # CoreML-only requirements:
 ./backends/apple/coreml/scripts/install_requirements.sh
 ```
+
+- **Intel-based macOS** systems require building PyTorch from source:  
+  - Use the [`--use-pt-pinned-commit` flag](https://github.com/pytorch/executorch/blob/main/install_requirements.sh) to install Executorch with an existing PyTorch build.  
+    See the [PyTorch instructions](https://github.com/pytorch/pytorch#installation) on how to build PyTorch from source.
+    ```bash
+    ./install_requirements.sh --use-pt-pinned-commit
+    ```
 
 5. Install [CMake](https://cmake.org):
 

--- a/docs/source/using-executorch-ios.md
+++ b/docs/source/using-executorch-ios.md
@@ -115,10 +115,10 @@ python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
 ```
 
 - **Intel-based macOS** systems require building PyTorch, Torchvision, and Torchaudio from source:  
-  - Use the [`--use-pt-pinned-commit` flag](https://github.com/pytorch/executorch/blob/main/install_requirements.sh) to install Executorch with an existing PyTorch build.  
+  - Use the [`--use-pt-pinned-commit --minimal` flags](https://github.com/pytorch/executorch/blob/main/install_executorch.py) to install Executorch with an existing PyTorch build.  
     See the [PyTorch instructions](https://github.com/pytorch/pytorch#installation) on how to build PyTorch from source.
     ```bash
-    ./install_requirements.sh --use-pt-pinned-commit
+    ./install_executorch.sh --use-pt-pinned-commit --minimal
     ```
 
 5. Install [CMake](https://cmake.org):

--- a/docs/source/using-executorch-ios.md
+++ b/docs/source/using-executorch-ios.md
@@ -114,7 +114,7 @@ python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
 ./backends/apple/coreml/scripts/install_requirements.sh
 ```
 
-- **Intel-based macOS** systems require building PyTorch from source:  
+- **Intel-based macOS** systems require building PyTorch, Torchvision, and Torchaudio from source:  
   - Use the [`--use-pt-pinned-commit` flag](https://github.com/pytorch/executorch/blob/main/install_requirements.sh) to install Executorch with an existing PyTorch build.  
     See the [PyTorch instructions](https://github.com/pytorch/pytorch#installation) on how to build PyTorch from source.
     ```bash

--- a/docs/source/using-executorch-ios.md
+++ b/docs/source/using-executorch-ios.md
@@ -114,13 +114,6 @@ python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
 ./backends/apple/coreml/scripts/install_requirements.sh
 ```
 
-- **Intel-based macOS** systems require building PyTorch, Torchvision, and Torchaudio from source:  
-  - Use the [`--use-pt-pinned-commit --minimal` flags](https://github.com/pytorch/executorch/blob/main/install_executorch.py) to install Executorch with an existing PyTorch build.  
-    See the [PyTorch instructions](https://github.com/pytorch/pytorch#installation) on how to build PyTorch from source.
-    ```bash
-    ./install_executorch.sh --use-pt-pinned-commit --minimal
-    ```
-
 5. Install [CMake](https://cmake.org):
 
 Download the macOS binary distribution from the [CMake website](https://cmake.org/download), open the `.dmg` file, move `CMake.app` to the `/Applications` directory, and then run the following command to install the CMake command-line tools:

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -75,6 +75,10 @@ NIGHTLY_VERSION = "dev20250601"
 
 
 def install_requirements(use_pytorch_nightly):
+    # Prevent pip install on Intel-based macOS systems (no prebuilt PyTorch binaries available).
+    if use_pytorch_nightly and is_intel_mac_os():
+        sys.exit(1)
+
     # pip packages needed by exir.
     TORCH_PACKAGE = [
         # Setting use_pytorch_nightly to false to test the pinned PyTorch commit. Note
@@ -161,6 +165,24 @@ def install_optional_example_requirements(use_pytorch_nightly):
         ],
         check=True,
     )
+
+
+# Prebuilt binaries for Intel-based macOS are no longer available on PyPI; users must compile from source.
+# PyTorch stopped building macOS x86_64 binaries since version 2.3.0 (January 2024).
+def is_intel_mac_os():
+    # Returns True if running on Intel-based macOS
+    if platform.system().lower() == "darwin" and platform.machine().lower() in (
+        "x86",
+        "x86_64",
+        "i386",
+    ):
+        print(
+            "ERROR: Prebuilt PyTorch binaries are no longer available for Intel-based macOS.\n"
+            "Please compile from source by following https://pytorch.org/executorch/0.6/using-executorch-building-from-source.html",
+            file=sys.stderr,
+        )
+        return True
+    return False
 
 
 def main(args):

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -170,15 +170,15 @@ def install_optional_example_requirements(use_pytorch_nightly):
 # Prebuilt binaries for Intel-based macOS are no longer available on PyPI; users must compile from source.
 # PyTorch stopped building macOS x86_64 binaries since version 2.3.0 (January 2024).
 def is_intel_mac_os():
-    # Returns True if running on Intel-based macOS
+    # Returns True if running on Intel macOS
     if platform.system().lower() == "darwin" and platform.machine().lower() in (
         "x86",
         "x86_64",
         "i386",
     ):
         print(
-            "ERROR: Prebuilt PyTorch binaries are no longer available for Intel-based macOS.\n"
-            "Please compile from source by following https://pytorch.org/executorch/0.6/using-executorch-building-from-source.html",
+            "ERROR: Prebuilt PyTorch wheels are no longer available for Intel-based macOS.\n"
+            "Please build from source by following https://docs.pytorch.org/executorch/main/using-executorch-building-from-source.html",
             file=sys.stderr,
         )
         return True

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -75,8 +75,13 @@ NIGHTLY_VERSION = "dev20250601"
 
 
 def install_requirements(use_pytorch_nightly):
-    # Prevent pip install on Intel-based macOS systems (no prebuilt PyTorch binaries available).
+    # Skip pip install on Intel macOS if using nightly.
     if use_pytorch_nightly and is_intel_mac_os():
+        print(
+            "ERROR: Prebuilt PyTorch wheels are no longer available for Intel-based macOS.\n"
+            "Please build from source by following https://docs.pytorch.org/executorch/main/using-executorch-building-from-source.html",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     # pip packages needed by exir.
@@ -171,18 +176,12 @@ def install_optional_example_requirements(use_pytorch_nightly):
 # PyTorch stopped building macOS x86_64 binaries since version 2.3.0 (January 2024).
 def is_intel_mac_os():
     # Returns True if running on Intel macOS
-    if platform.system().lower() == "darwin" and platform.machine().lower() in (
+    return platform.system().lower() == "darwin" and platform.machine().lower() in (
         "x86",
         "x86_64",
         "i386",
-    ):
-        print(
-            "ERROR: Prebuilt PyTorch wheels are no longer available for Intel-based macOS.\n"
-            "Please build from source by following https://docs.pytorch.org/executorch/main/using-executorch-building-from-source.html",
-            file=sys.stderr,
-        )
-        return True
-    return False
+    )
+
 
 
 def main(args):

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -183,7 +183,6 @@ def is_intel_mac_os():
     )
 
 
-
 def main(args):
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -175,7 +175,7 @@ def install_optional_example_requirements(use_pytorch_nightly):
 # Prebuilt binaries for Intel-based macOS are no longer available on PyPI; users must compile from source.
 # PyTorch stopped building macOS x86_64 binaries since version 2.3.0 (January 2024).
 def is_intel_mac_os():
-    # Returns True if running on Intel macOS
+    # Returns True if running on Intel macOS.
     return platform.system().lower() == "darwin" and platform.machine().lower() in (
         "x86",
         "x86_64",


### PR DESCRIPTION
### Summary
- Updated `install_requirements.sh` to improve compatibility with source-built PyTorch and Intel macOS systems.
- Added checks to prevent install commands from altering existing PyTorch builds by adding the `--no-deps` flag.
- Removed `torchaudio` and `torchvision` dependencies  for Intel macOS systems to avoid compatibility issues.

Fixes #9772 

### Test plan
Tested executorch installations with source-built PyTorch on:
- Intel-macOS with PyTorch 2.7.0, Python 3.12.9
- ARM64 macOS with PyTorch 2.8.0a0, Python 3.12.9  

Validated by exporting and running the MobileNet V2 image classification model, following the examples on the [Getting Started with ExecuTorch](https://pytorch.org/executorch/stable/getting-started.html) page.


cc @larryliu0820 @jathu