### PR TITLE
Handle unsupported pybind inputs non-fatally

### DIFF
--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -757,7 +757,9 @@ struct PyModule final {
       } else if (py::isinstance<py::int_>(python_input)) {
         cpp_inputs.push_back(EValue(py::cast<int64_t>(python_input)));
       } else {
-        ET_ASSERT_UNREACHABLE_MSG("Unsupported pytype: %s", type_str.c_str());
+        throw std::runtime_error(
+            "Unsupported python type " + type_str +
+            ". Ensure that inputs are passed as a flat list of tensors.");
       }
     }
 

--- a/extension/pybindings/test/make_test.py
+++ b/extension/pybindings/test/make_test.py
@@ -464,6 +464,16 @@ def make_test(  # noqa: C901
 
                 tester.assertEqual(str(expected), str(executorch_output))
 
+        def test_unsupported_input_type(tester):
+            exported_program, inputs = create_program(ModuleAdd())
+            executorch_module = load_fn(exported_program.buffer)
+
+            # Pass an unsupported input type to the module.
+            inputs = ([*inputs],)
+
+            # This should raise a Python error, not hit a fatal assert in the C++ code.
+            tester.assertRaises(RuntimeError, executorch_module, inputs)
+
         ######### RUN TEST CASES #########
         test_e2e(tester)
         test_multiple_entry(tester)
@@ -479,5 +489,6 @@ def make_test(  # noqa: C901
         test_method_meta(tester)
         test_bad_name(tester)
         test_verification_config(tester)
+        test_unsupported_input_type(tester)
 
     return wrapper


### PR DESCRIPTION
Summary: Currently, passing unsupported python types to pybind method execution, such as lists, dicts, or tuples, will crash the kernel due to hitting an assert. This PR updates the logic to raise an exception, which gets nicely bubbled up to the notebook. This gives the user a nicer error message and does not crash the bento/jupyter process.

Differential Revision: D74118509


