### PR TITLE
Make lower_ep_to<edge, cadence, executorch> private functions and remove external call sites

### DIFF
--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -199,7 +199,7 @@ def export_program(
     return expo_program
 
 
-def lower_ep_to_edge(
+def _lower_ep_to_edge(
     expo_program: ExportedProgram,
     dump_graphs: bool = False,
     constant_methods: Optional[dict[str, object]] = None,
@@ -250,7 +250,7 @@ def export_to_edge(
     expo_program = export_program(model, inputs)
 
     # Lower the model to edge IR.
-    edge_prog_manager = lower_ep_to_edge(expo_program, dump_graphs, constant_methods)
+    edge_prog_manager = _lower_ep_to_edge(expo_program, dump_graphs, constant_methods)
 
     return edge_prog_manager
 
@@ -272,14 +272,14 @@ def quantize_and_export_to_edge(
         dump_graphs=dump_graphs,
     )
 
-    return lower_ep_to_edge(
+    return _lower_ep_to_edge(
         quantized_model,
         dump_graphs=dump_graphs,
         constant_methods=constant_methods,
     )
 
 
-def lower_ep_to_cadence(
+def _lower_ep_to_cadence(
     program: ExportedProgram,
     dump_graphs: bool = False,
     opt_level: int = 1,
@@ -287,7 +287,7 @@ def lower_ep_to_cadence(
     """
     Lower an existing ExportedProgram to edge IR and apply frontend optimization passes.
     """
-    edge_prog_manager = lower_ep_to_edge(program, dump_graphs=dump_graphs)
+    edge_prog_manager = _lower_ep_to_edge(program, dump_graphs=dump_graphs)
     cadence_passes = get_cadence_passes(opt_level)
 
     # Run a couple required passes for quant/dequant ops
@@ -329,7 +329,7 @@ def quantize_and_export_to_cadence(
     """
     quantized_model = quantize_pt2(model, inputs)
 
-    return lower_ep_to_cadence(
+    return _lower_ep_to_cadence(
         quantized_model,
         opt_level=opt_level,
         dump_graphs=dump_graphs,

--- a/backends/cadence/aot/tests/test_remove_ops_passes.py
+++ b/backends/cadence/aot/tests/test_remove_ops_passes.py
@@ -511,7 +511,7 @@ class TestRemoveOpsPasses(unittest.TestCase):
         inputs = (x,)
 
         graph_module = (
-            compiler.export_to_edge(
+            export_to_edge(
                 model,
                 inputs,
             )


### PR DESCRIPTION
Summary:
Those functions are not meant to be called directly. Mark them private with an underscore and remove most call sites.

`lower_ep_to_cadence` is fully private

Differential Revision: D74089120


