### PR TITLE
extension/module should depend on executorch_core

### DIFF
--- a/extension/module/CMakeLists.txt
+++ b/extension/module/CMakeLists.txt
@@ -27,7 +27,7 @@ if(CMAKE_TOOLCHAIN_IOS
 else()
   add_library(extension_module SHARED ${_extension_module__srcs})
 endif()
-target_link_libraries(extension_module PRIVATE executorch extension_data_loader extension_flat_tensor)
+target_link_libraries(extension_module PRIVATE executorch_core extension_data_loader extension_flat_tensor)
 target_include_directories(extension_module PUBLIC ${EXECUTORCH_ROOT}/..)
 target_compile_options(
   extension_module PUBLIC -Wno-deprecated-declarations -fPIC
@@ -37,7 +37,7 @@ target_compile_options(
 # after cleaning up CMake targets.
 add_library(extension_module_static STATIC ${_extension_module__srcs})
 target_link_libraries(
-  extension_module_static PRIVATE executorch extension_data_loader extension_flat_tensor
+  extension_module_static PRIVATE executorch_core extension_data_loader extension_flat_tensor
 )
 target_include_directories(extension_module_static PUBLIC ${EXECUTORCH_ROOT}/..)
 target_compile_options(


### PR DESCRIPTION
No need to know about prim ops. Up to user.
