### PR TITLE
Remove unused vulkan_executor_runner_lib

### DIFF
--- a/backends/vulkan/CMakeLists.txt
+++ b/backends/vulkan/CMakeLists.txt
@@ -132,13 +132,6 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*(iOS|ios\.toolchain)\.cmake$")
     vulkan_backend
   )
   target_compile_options(vulkan_executor_runner PUBLIC ${VULKAN_CXX_FLAGS})
-
-  add_library(vulkan_executor_runner_lib STATIC ${VULKAN_RUNNER_SRCS})
-  target_link_libraries(
-    vulkan_executor_runner_lib ${_executor_runner_libs} vulkan_schema
-    vulkan_backend
-  )
-  target_compile_options(vulkan_executor_runner_lib PUBLIC ${VULKAN_CXX_FLAGS})
 endif()
 
 # Test targets


### PR DESCRIPTION
If some executor_runner needs to use vulkan, just add vulkan_schema and vulkan_backend


cc @SS-JIA @manuelcandales @cbilgin