### PR TITLE
vulkan_backend is not necessarily static

### DIFF
--- a/backends/vulkan/CMakeLists.txt
+++ b/backends/vulkan/CMakeLists.txt
@@ -109,11 +109,11 @@ file(GLOB vulkan_backend_cpp ${RUNTIME_PATH}/*.cpp)
 list(APPEND vulkan_backend_cpp ${vulkan_graph_cpp})
 list(APPEND vulkan_backend_cpp ${vulkan_standard_shaders_cpp})
 
-add_library(vulkan_backend STATIC ${vulkan_backend_cpp})
+add_library(vulkan_backend ${vulkan_backend_cpp})
 target_include_directories(
   vulkan_backend PRIVATE ${SCHEMA_INCLUDE_DIR} ${COMMON_INCLUDES}
 )
-target_link_libraries(vulkan_backend PRIVATE vulkan_schema executorch)
+target_link_libraries(vulkan_backend PRIVATE vulkan_schema executorch_core)
 target_compile_options(vulkan_backend PRIVATE ${VULKAN_CXX_FLAGS})
 # Link this library with --whole-archive due to dynamic backend registration
 target_link_options_shared_lib(vulkan_backend)


### PR DESCRIPTION
Remove STATIC keyword to make shared possible. Meanwhile, it should depend on executorch_core, not executorch


cc @SS-JIA @manuelcandales @cbilgin