### PR TITLE
xnnpack_backend doesn't need to be STATIC only

### DIFF
--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -116,7 +116,7 @@ set(xnnpack_third_party pthreadpool extension_threadpool cpuinfo)
 include(cmake/Dependencies.cmake)
 
 list(TRANSFORM _xnnpack_backend__srcs PREPEND "${EXECUTORCH_ROOT}/")
-add_library(xnnpack_backend STATIC ${_xnnpack_backend__srcs})
+add_library(xnnpack_backend ${_xnnpack_backend__srcs})
 target_link_libraries(
   xnnpack_backend PUBLIC ${xnnpack_third_party} executorch_core xnnpack_schema extension_threadpool
 )


### PR DESCRIPTION
If we build it as shared it should also work