### PR TITLE
[CMake] data_loader and runner_util use executorch_core

### DIFF
--- a/extension/data_loader/CMakeLists.txt
+++ b/extension/data_loader/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 list(TRANSFORM _extension_data_loader__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(extension_data_loader ${_extension_data_loader__srcs})
-target_link_libraries(extension_data_loader executorch)
+target_link_libraries(extension_data_loader executorch_core)
 target_include_directories(extension_data_loader PUBLIC ${EXECUTORCH_ROOT}/..)
 target_compile_options(extension_data_loader PUBLIC ${_common_compile_options})
 

--- a/extension/runner_util/CMakeLists.txt
+++ b/extension/runner_util/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 list(TRANSFORM _extension_runner_util__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(extension_runner_util ${_extension_runner_util__srcs})
-target_link_libraries(extension_runner_util executorch)
+target_link_libraries(extension_runner_util executorch_core)
 target_include_directories(extension_runner_util PUBLIC ${EXECUTORCH_ROOT}/..)
 target_compile_options(extension_runner_util PUBLIC ${_common_compile_options})
 

--- a/extension/runner_util/targets.bzl
+++ b/extension/runner_util/targets.bzl
@@ -23,6 +23,6 @@ def define_common_targets():
             ],
             exported_deps = [
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
-                "//executorch/runtime/executor:program" + aten_suffix,
+                "//executorch/runtime/executor:program_no_prim_ops" + aten_suffix,
             ],
         )

--- a/tools/cmake/cmake_deps.toml
+++ b/tools/cmake/cmake_deps.toml
@@ -178,7 +178,6 @@ filters = [
 ]
 deps = [
   "executorch_core",
-  "executorch",
 ]
 
 [targets.extension_flat_tensor_schema]
@@ -223,7 +222,6 @@ filters = [
   ".cpp$",
 ]
 deps = [
-  "executorch",
   "executorch_core",
 ]
 


### PR DESCRIPTION
### Summary
They don't depend on executorch prim_ops. No executorch_srcs.cmake change before and after.
### Test plan
CI