### PR TITLE
extension/module doesn't depend on prim_ops

### DIFF
--- a/extension/module/targets.bzl
+++ b/extension/module/targets.bzl
@@ -28,6 +28,6 @@ def define_common_targets():
                 "//executorch/extension/flat_tensor:flat_tensor_data_map" + aten_suffix,
             ],
             exported_deps = [
-                "//executorch/runtime/executor:program" + aten_suffix,
+                "//executorch/runtime/executor:program_no_prim_ops" + aten_suffix,
             ],
         )


### PR DESCRIPTION
Summary:
This makes sense because extension/module doesn't need prim_ops to work.

This is safe because as long as a user of extension/module uses another ops_lib, prim_ops (program) is implicitly added.

See https://www.internalfb.com/code/fbsource/xplat/executorch/codegen/codegen.bzl?lines=692

Differential Revision: D74227949


