### PR TITLE
Arm backend: Add non-interactive in git hook

### DIFF
--- a/backends/arm/scripts/pre-push
+++ b/backends/arm/scripts/pre-push
@@ -4,6 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Calling this script with any argument is equal to launching it in
+# non-interactive mode. "$#" gives the number of positional arguments.
+[ "$#" -eq 0 ] && is_script_interactive=1 || is_script_interactive=0
+
 RESET='\e[0m'
 RED='\e[31m'
 GREEN='\e[32m'
@@ -31,8 +35,10 @@ VERBS="Add|Fix|Update|Refactor|Improve|Remove|Change|Implement|Create|Modify|"\
 
 # Remote branch
 REMOTE=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null)
-
-if [ -z "$REMOTE" ]; then
+if [ $is_script_interactive -eq 0 ]; then
+    # Just use the one commit
+    COMMITS=$(git rev-list HEAD -n 1)
+elif [ -z "$REMOTE" ]; then
     echo -e "${WARNING} Could not find upstream branch to compare to."
     echo "Please specify the number of commits you are pushing."
     echo -n "Enter number of commits to check (default 1): " > /dev/tty
@@ -155,14 +161,17 @@ for COMMIT in ${COMMITS}; do
     if [[ ! "$SUBJECT" =~ ^"Arm backend":\ (${VERBS}) ]]; then
         echo -e "${WARNING} Subject should start with 'Arm backend: '"\
             "followed by an imperative verb." >&2
-        echo -n "There are warnings in your commit message. Do you want to"\
-            "ignore the warning (y/N): " > /dev/tty
 
-        read USER_INPUT < /dev/tty
+        if [ $is_script_interactive -eq 1 ]; then
+            echo -n "There are warnings in your commit message. Do you want to"\
+                "ignore the warning (y/N): " > /dev/tty
 
-        # Check user input for warnings
-        if [[ ! "$USER_INPUT" =~ ^[Yy]$ ]]; then
-            FAILED=1
+            read USER_INPUT < /dev/tty
+
+            # Check user input for warnings
+            if [[ ! "$USER_INPUT" =~ ^[Yy]$ ]]; then
+                FAILED=1
+            fi
         fi
     fi
 


### PR DESCRIPTION
The pre-push script is a nice to have script as a git hook for your work with the arm backend.

In fact, it is so nice that we would like it to be part of CI jobs but to make that happen it needs to be non-interactive.

This patch adds support for launching the script and never ending up in a scenario where the user has to interact with it.

Signed-off-by: per.held@arm.com

Change-Id: I345a3a71f1b81446228150baf4db28bf4a47b0f1


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218