### PR TITLE
Create skeleton for a build preset GitHub workflow

### DIFF
--- a/.github/workflows/build-presets.yml
+++ b/.github/workflows/build-presets.yml
@@ -1,0 +1,13 @@
+name: Build Presets
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - release/*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true


### PR DESCRIPTION
### Summary

As part of https://github.com/pytorch/executorch/issues/10715, this creates the foundation for a dedicated workflow to test build presets. 


### Test plan

Workflows need to be committed to main first, before it can be run.