### PR TITLE
[ET-VK] Using width packed bias in conv1d op to slightly improve speed and memory.

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
@@ -483,7 +483,7 @@ void add_conv1d_node(
       weight,
       /*transposed = */ false,
       /*storage_type = */ utils::kTexture3D,
-      /*memory_layout = */ utils::kChannelsPacked);
+      /*memory_layout = */ utils::kWidthPacked);
 
   float out_min_val = 0.0f;
   float out_max_val = 0.0f;


### PR DESCRIPTION
Summary: This diff changes bias tensor packing for conv1d op from channels to width packed, which reduces tensor memory footprint and reduces wasted texel fetch.

Differential Revision: D74208485


