### PR TITLE
Kernels should depend on executorch_core

### DIFF
--- a/configurations/CMakeLists.txt
+++ b/configurations/CMakeLists.txt
@@ -59,7 +59,7 @@ if(EXECUTORCH_BUILD_KERNELS_OPTIMIZED)
     optimized_kernels
     ${_optimized_native_cpu_ops_lib_portable_kernels_lib}
     DEPS
-    executorch
+    executorch_core
   )
 
   install(TARGETS optimized_native_cpu_ops_lib DESTINATION lib)

--- a/examples/models/llama/CMakeLists.txt
+++ b/examples/models/llama/CMakeLists.txt
@@ -80,14 +80,12 @@ find_package(gflags REQUIRED)
 # find `executorch` libraries Same as for gflags
 set(executorch_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../lib/cmake/ExecuTorch)
 find_package(executorch CONFIG REQUIRED)
-if(CMAKE_TOOLCHAIN_IOS OR ANDROID)
-  target_link_options_shared_lib(executorch)
-endif()
+target_link_options_shared_lib(executorch)
 
 # llama_runner library
 add_subdirectory(runner)
 
-set(link_libraries gflags)
+set(link_libraries executorch gflags)
 set(_srcs main.cpp)
 
 if(EXECUTORCH_BUILD_KERNELS_OPTIMIZED)
@@ -224,10 +222,6 @@ target_include_directories(
 )
 target_link_libraries(llama_main PUBLIC llama_runner ${link_libraries})
 target_compile_options(llama_main PUBLIC ${_common_compile_options})
-
-if(APPLE)
-  target_link_options_shared_lib(executorch)
-endif()
 
 # Print all summary
 executorch_print_configuration_summary()

--- a/examples/models/llama/runner/CMakeLists.txt
+++ b/examples/models/llama/runner/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
   add_library(llama_runner SHARED ${_llama_runner__srcs})
 endif()
 
-set(llama_runner_deps executorch extension_data_loader extension_module
+set(llama_runner_deps executorch_core extension_data_loader extension_module
                       extension_tensor
 )
 

--- a/examples/models/llava/CMakeLists.txt
+++ b/examples/models/llava/CMakeLists.txt
@@ -89,14 +89,12 @@ endif()
 # find `executorch` libraries Same as for gflags
 set(executorch_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../lib/cmake/ExecuTorch)
 find_package(executorch CONFIG REQUIRED)
-if(CMAKE_TOOLCHAIN_IOS OR ANDROID)
-  target_link_options_shared_lib(executorch)
-endif()
+target_link_options_shared_lib(executorch)
 
 # llava_runner library
 add_subdirectory(runner)
 
-set(LINK_LIBS gflags)
+set(LINK_LIBS executorch gflags)
 if(NOT LLAVA_RUNNER_NO_TORCH_DUMMY_IMAGE)
   list(APPEND LINK_LIBS torch)
 endif()
@@ -211,10 +209,6 @@ endif()
 target_include_directories(llava_main PUBLIC ${_common_include_directories})
 target_link_libraries(llava_main PUBLIC llava_runner ${link_libraries})
 target_compile_options(llava_main PUBLIC ${_common_compile_options})
-
-if(APPLE)
-  target_link_options_shared_lib(executorch)
-endif()
 
 # Print all summary
 executorch_print_configuration_summary()

--- a/examples/models/llava/runner/CMakeLists.txt
+++ b/examples/models/llava/runner/CMakeLists.txt
@@ -40,7 +40,7 @@ add_subdirectory(
 
 add_library(llava_runner STATIC ${_llava_runner__srcs})
 
-set(llava_runner_deps executorch extension_data_loader extension_llm_runner
+set(llava_runner_deps executorch_core extension_data_loader extension_llm_runner
                       extension_module extension_tensor
 )
 

--- a/extension/flat_tensor/CMakeLists.txt
+++ b/extension/flat_tensor/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 list(TRANSFORM _extension_flat_tensor__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(extension_flat_tensor ${_extension_flat_tensor__srcs})
-target_link_libraries(extension_flat_tensor executorch extension_data_loader)
+target_link_libraries(extension_flat_tensor executorch_core)
 target_include_directories(
   extension_flat_tensor
   PUBLIC ${EXECUTORCH_ROOT}/..

--- a/kernels/optimized/CMakeLists.txt
+++ b/kernels/optimized/CMakeLists.txt
@@ -71,7 +71,7 @@ target_compile_options(optimized_kernels PUBLIC ${_common_compile_options})
 #
 # optimized_ops_lib: Register optimized ops kernels into Executorch runtime
 gen_operators_lib(
-  LIB_NAME "optimized_ops_lib" KERNEL_LIBS optimized_kernels DEPS executorch
+  LIB_NAME "optimized_ops_lib" KERNEL_LIBS optimized_kernels DEPS executorch_core
 )
 
 install(

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -142,13 +142,13 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode"
 endif()
 
 add_library(quantized_kernels ${_quantized_kernels__srcs})
-target_link_libraries(quantized_kernels PRIVATE executorch)
+target_link_libraries(quantized_kernels PRIVATE executorch_core)
 target_compile_options(quantized_kernels PUBLIC ${_common_compile_options})
 # Build a library for _quantized_kernels_srcs
 #
 # quantized_ops_lib: Register quantized ops kernels into Executorch runtime
 gen_operators_lib(
-  LIB_NAME "quantized_ops_lib" KERNEL_LIBS quantized_kernels DEPS executorch
+  LIB_NAME "quantized_ops_lib" KERNEL_LIBS quantized_kernels DEPS executorch_core
 )
 
 install(


### PR DESCRIPTION
Kernels don't need to use prim ops

llama and llava runner.exe should depend on executorch_core+prim_ops explicitly