### PR TITLE
Update aot_arm_compiler.py

### DIFF
--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -113,7 +113,7 @@ def get_model_and_inputs_from_name(
         spec = importlib.util.spec_from_file_location("tmp_model", model_name)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-        model = module.ModelUnderTest
+        model = module.ModelUnderTest()
         if example_inputs is None:
             example_inputs = module.ModelInputs
     # Case 4: Model is in an saved model file torch.save(model)


### PR DESCRIPTION
Found an error when trying to use the aot_arm_compiler.py with a custom model defined in an external python file:

```python
import torch

class ModelUnderTest(torch.nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, x):
        return x +x
    
ModelInputs = (torch.ones(5),)
```
Error message: TypeError: Module.eval() missing 1 required positional argument: 'self'

This patch fixes the problem.



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218