### PR TITLE
Make constant_folding's _DEFAULT_SKIP_TARGETS public

### DIFF
--- a/exir/passes/constant_prop_pass.py
+++ b/exir/passes/constant_prop_pass.py
@@ -29,7 +29,8 @@ from torch.utils import _pytree as pytree
 
 # Avoid propagating constants for `exir.ops.edge.aten.full.default`.
 # Propagating aten.full can significantly increase compiled model size.
-_DEFAULT_SKIP_TARGETS = {exir_ops.edge.aten.full.default}
+_DEFAULT_SKIP_TARGETS_NO_QUANT = {exir_ops.edge.aten.full.default}
+_DEFAULT_SKIP_TARGETS = set(_DEFAULT_SKIP_TARGETS_NO_QUANT)
 
 # Do not const prop quantization primitives
 _QUANT_PRIMITIVES_EDGE = [aten_to_edge(op) for op in _QUANT_PRIMITIVES]
@@ -46,6 +47,10 @@ _PRIMITIVE_TYPES = (
     torch.dtype,
     torch.layout,
 )
+
+
+def get_default_skip_targets_no_quant() -> set[EdgeOpOverload]:
+    return _DEFAULT_SKIP_TARGETS_NO_QUANT
 
 
 def is_const(


### PR DESCRIPTION
Summary: This follows D73513516 and allows customers of constant_prop_pass to use previous defaults

Differential Revision: D74349918


