### PR TITLE
Vulkan tests use executorch_core

### DIFF
--- a/backends/vulkan/test/CMakeLists.txt
+++ b/backends/vulkan/test/CMakeLists.txt
@@ -82,7 +82,7 @@ if(TARGET vulkan_backend)
   )
   target_include_directories(vulkan_compute_api_test PRIVATE ${COMMON_INCLUDES})
   target_link_libraries(
-    vulkan_compute_api_test PRIVATE GTest::gtest_main vulkan_backend executorch
+    vulkan_compute_api_test PRIVATE GTest::gtest_main vulkan_backend executorch_core
                                     test_shaderlib
   )
   target_compile_options(vulkan_compute_api_test PRIVATE ${VULKAN_CXX_FLAGS})

--- a/backends/vulkan/test/op_tests/CMakeLists.txt
+++ b/backends/vulkan/test/op_tests/CMakeLists.txt
@@ -81,7 +81,7 @@ function(vulkan_op_test test_name test_src)
     ${test_name}
     PRIVATE GTest::gtest_main
             vulkan_backend
-            executorch
+            executorch_core
             ${LIB_TORCH}
             ${LIB_TORCH_CPU}
             ${LIB_C10}


### PR DESCRIPTION
cc @SS-JIA @manuelcandales @cbilgin

in buck it doesn't depend on executorch with prim_ops either