### PR TITLE
Automatically announce declared options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,9 @@ project(executorch)
 include(${PROJECT_SOURCE_DIR}/tools/cmake/common/preset.cmake)
 include(${PROJECT_SOURCE_DIR}/tools/cmake/preset/default.cmake)
 
+# Print all the configs that were called with announce_configured_options.
+print_configured_options()
+
 # MARK: - End EXECUTORCH_H12025_BUILD_MIGRATION ----------------------------------------------------
 
 include(tools/cmake/Utils.cmake)

--- a/tools/cmake/Utils.cmake
+++ b/tools/cmake/Utils.cmake
@@ -30,10 +30,6 @@ function(executorch_print_configuration_summary)
   message(STATUS "  BUCK2                         : ${BUCK2}")
   message(STATUS "  PYTHON_EXECUTABLE             : ${PYTHON_EXECUTABLE}")
   message(STATUS "  FLATC_EXECUTABLE              : ${FLATC_EXECUTABLE}")
-  message(
-    STATUS
-      "  EXECUTORCH_ENABLE_LOGGING              : ${EXECUTORCH_ENABLE_LOGGING}"
-  )
   message(STATUS "  EXECUTORCH_ENABLE_PROGRAM_VERIFICATION : "
                  "${EXECUTORCH_ENABLE_PROGRAM_VERIFICATION}"
   )


### PR DESCRIPTION
### Summary

Instead of manually printing all the options in `tools/cmake/Utils.cmake`, let's just "automatically" print all the configured options.

### Test plan

```
$ ./scripts/build_apple_frameworks.sh --Debug

-- --- Configurated Options ---

-- EXECUTORCH_ENABLE_LOGGING : ON
-- ---------------------------

```

```
$ ./scripts/build_apple_frameworks.sh --Release

-- --- Configurated Options ---

-- EXECUTORCH_ENABLE_LOGGING : OFF
-- ---------------------------

```


cc @larryliu0820