### PR TITLE
Allow options to be set by presets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,8 +178,6 @@ option(EXECUTORCH_BUILD_ARM_BAREMETAL
        "Build the Arm Baremetal flow for Cortex-M and Ethos-U" OFF
 )
 
-option(EXECUTORCH_BUILD_COREML "Build the Core ML backend" OFF)
-
 option(EXECUTORCH_BUILD_KERNELS_CUSTOM "Build the custom kernels" OFF)
 
 option(EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT "Build the custom ops lib for AOT"

--- a/tools/cmake/Utils.cmake
+++ b/tools/cmake/Utils.cmake
@@ -47,10 +47,6 @@ function(executorch_print_configuration_summary)
   )
   message(
     STATUS
-      "  EXECUTORCH_BUILD_COREML                : ${EXECUTORCH_BUILD_COREML}"
-  )
-  message(
-    STATUS
       "  EXECUTORCH_BUILD_CPUINFO               : ${EXECUTORCH_BUILD_CPUINFO}"
   )
   message(

--- a/tools/cmake/common/preset.cmake
+++ b/tools/cmake/common/preset.cmake
@@ -26,6 +26,7 @@ function(announce_configured_options NAME)
   endif()
 endfunction()
 
+
 # Print the configured options.
 function(print_configured_options)
   get_property(_options GLOBAL PROPERTY _announce_configured_options)
@@ -52,12 +53,14 @@ function(print_configured_options)
   message(STATUS "---------------------------")
 endfunction()
 
+
 # Enforce option names to always start with EXECUTORCH.
 function(enforce_executorch_option_name NAME)
   if(NOT "${NAME}" MATCHES "^EXECUTORCH_")
     message(FATAL_ERROR "Option name '${NAME}' must start with EXECUTORCH_")
   endif()
 endfunction()
+
 
 # Define an overridable option.
 #   1) If the option is already defined in the process, then store that in cache
@@ -76,4 +79,15 @@ macro(define_overridable_option NAME DESCRIPTION VALUE_TYPE DEFAULT_VALUE)
   endif()
 
   announce_configured_options(${NAME})
+endmacro()
+
+
+# Set an overridable option.
+macro(set_overridable_option NAME VALUE)
+  # If the user has explitily set the option, do not override it.
+  if(DEFINED ${NAME})
+    return()
+  endif()
+
+  set(${NAME} ${VALUE} CACHE STRING "")
 endmacro()

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -15,3 +15,4 @@ endif()
 # MARK: - Definitions
 
 define_overridable_option(EXECUTORCH_ENABLE_LOGGING "Build with ET_LOG_ENABLED" BOOL ${_is_build_type_debug})
+define_overridable_option(EXECUTORCH_BUILD_COREML "Build the Core ML backend" BOOL OFF)

--- a/tools/cmake/preset/macos-arm64.cmake
+++ b/tools/cmake/preset/macos-arm64.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set_overridable_option(EXECUTORCH_BUILD_COREML ON)


### PR DESCRIPTION
### Summary

In this diff we create a helper that will allow presets to set options. Again this is mostly a helper to check if the option has been defined already, then no-oping.

To test it, I also create the first preset `macos-arm64`. I will test it in upcoming diffs.

### Test plan

pytest for now, manual test in future diffs


cc @larryliu0820