### PR TITLE
Create a macos-arm64 preset

### DIFF
--- a/.github/workflows/build-presets.yml
+++ b/.github/workflows/build-presets.yml
@@ -11,3 +11,20 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
+
+jobs:
+  apple:
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    strategy:
+      matrix:
+        preset: [macos-arm64]
+    with:
+      job-name: build
+      runner: macos-latest-xlarge
+      python-version: 3.12
+      submodules: recursive
+      script: |
+        set -eux
+        ${CONDA_RUN} ./install_requirements.sh > /dev/null
+        ${CONDA_RUN} cmake --preset ${{ matrix.preset }}
+        ${CONDA_RUN} cmake --build cmake-out --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ project(executorch)
 # MARK: - Start EXECUTORCH_H12025_BUILD_MIGRATION --------------------------------------------------
 
 include(${PROJECT_SOURCE_DIR}/tools/cmake/common/preset.cmake)
+
+load_build_preset()
 include(${PROJECT_SOURCE_DIR}/tools/cmake/preset/default.cmake)
 
 # Print all the configs that were called with announce_configured_options.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,33 @@
+{
+  "version": 10,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 31,
+    "patch": 0
+  },
+  "$comment": "On-device AI across mobile, embedded and edge for PyTorch.",
+  "configurePresets": [
+    {
+      "name": "common",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/cmake-out",
+      "generator": "Unix Makefiles"
+    },
+    {
+      "name": "macos-arm64",
+      "inherits": ["common"],
+      "generator": "Xcode",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/third-party/ios-cmake/ios.toolchain.cmake",
+        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/macos-arm64.cmake",
+        "PLATFORM": "MAC_ARM64",
+        "DEPLOYMENT_TARGET": "10.15"
+      },
+      "condition": {
+        "lhs": "${hostSystemName}",
+        "type": "equals",
+        "rhs": "Darwin"
+      }
+    }
+  ]
+}

--- a/tools/cmake/Utils.cmake
+++ b/tools/cmake/Utils.cmake
@@ -313,6 +313,11 @@ function(resolve_python_executable)
         python
         PARENT_SCOPE
     )
+  elseif(DEFINED ENV{VIRTUAL_ENV})
+    set(PYTHON_EXECUTABLE
+      $ENV{VIRTUAL_ENV}/bin/python3
+      PARENT_SCOPE
+    )
   else()
     set(PYTHON_EXECUTABLE
         python3

--- a/tools/cmake/common/preset.cmake
+++ b/tools/cmake/common/preset.cmake
@@ -91,3 +91,14 @@ macro(set_overridable_option NAME VALUE)
 
   set(${NAME} ${VALUE} CACHE STRING "")
 endmacro()
+
+# Detemine the build preset and load it.
+macro(load_build_preset)
+  if(DEFINED EXECUTORCH_BUILD_PRESET_FILE)
+    announce_configured_options(EXECUTORCH_BUILD_PRESET_FILE)
+    message(STATUS "Loading build preset: ${EXECUTORCH_BUILD_PRESET_FILE}")
+    include(${EXECUTORCH_BUILD_PRESET_FILE})
+  endif()
+  # For now, just continue if the preset file is not set. In the future, we will
+  # try to determine a preset file.
+endmacro()


### PR DESCRIPTION
### Summary

* Create the base for a macos-arm64 preset — bigger migration in future diffs
* Create an Apple CI job to test builds

### Test plan

CI +

```
$ cmake --preset macos-arm64

-- Loading build preset: /Users/jathu/executorch/tools/cmake/preset/macos-arm64.cmake
-- --- Configurated Options ---

-- EXECUTORCH_BUILD_PRESET_FILE : /Users/jathu/executorch/tools/cmake/preset/macos-arm64.cmake
-- EXECUTORCH_ENABLE_LOGGING    : ON
-- EXECUTORCH_BUILD_COREML      : ON
-- ---------------------------

$ cmake --build cmake-out --parallel
```

cc @larryliu0820