### PR TITLE
to make TIE quantized conv operator to fall back to hifi quantized conv op instead of cpu op for shapes not supported by the TIE kernel.

### DIFF
--- a/backends/cadence/hifi/operators/operators.h
+++ b/backends/cadence/hifi/operators/operators.h
@@ -12,6 +12,7 @@
   _(uint8_t, Byte)                           \
   _(int8_t, Char)
 
+using ::executorch::aten::IntArrayRef;
 using ::executorch::aten::optional;
 using ::executorch::aten::ScalarType;
 using ::executorch::aten::Tensor;
@@ -65,6 +66,44 @@ void quantized_linear_per_tensor_out(
     int64_t out_shift,
     int64_t out_zero_point,
     __ET_UNUSED const optional<Tensor>& offset,
+    Tensor& out);
+
+void quantized_conv_out(
+    __ET_UNUSED KernelRuntimeContext& ctx,
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& bias,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation,
+    int64_t groups,
+    int64_t in_zero_point,
+    const Tensor& weight_zero_point,
+    const Tensor& bias_scale,
+    double output_scale,
+    int64_t output_zero_point,
+    __ET_UNUSED const Tensor& out_multiplier,
+    __ET_UNUSED const Tensor& out_shift,
+    bool channel_last,
+    Tensor& out);
+
+void quantized_conv_per_tensor_out(
+    __ET_UNUSED KernelRuntimeContext& ctx,
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& bias,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation,
+    int64_t groups,
+    int64_t in_zero_point,
+    int64_t weight_zero_point,
+    double bias_scale,
+    double output_scale,
+    int64_t output_zero_point,
+    __ET_UNUSED int64_t out_multiplier,
+    __ET_UNUSED int64_t out_shift,
+    bool channel_last,
     Tensor& out);
 
 } // namespace native


### PR DESCRIPTION
Summary: some quantized conv shape are not supported by the TIE operator, right now the tie op will fall back to CPU op. with this diff would fall back to use the operator from the hifi non-tie backend instead.

Differential Revision: D74337713


