### PR TITLE
Arm backend: Suppress colors in pre-push if non-interactive

### DIFF
--- a/backends/arm/scripts/pre-push
+++ b/backends/arm/scripts/pre-push
@@ -8,11 +8,13 @@
 # non-interactive mode. "$#" gives the number of positional arguments.
 [ "$#" -eq 0 ] && is_script_interactive=1 || is_script_interactive=0
 
-RESET='\e[0m'
-RED='\e[31m'
-GREEN='\e[32m'
-YELLOW='\e[33m'
-BLUE='\e[34m'
+if [ $is_script_interactive -eq 1 ]; then
+    RESET='\e[0m'
+    RED='\e[31m'
+    GREEN='\e[32m'
+    YELLOW='\e[33m'
+    BLUE='\e[34m'
+fi
 
 INFO="${BLUE}[INFO]${RESET}"
 WARNING="${YELLOW}[WARNING]${RESET}"


### PR DESCRIPTION
Dont try to print with colors in the pre-push script if the script is non-interactive. This is to avoid getting broken output in the CI which doesnt support colors.

Signed-off-by: per.held@arm.com

Change-Id: I58b6a45de8b8403fa39ecbe299d380f3ca9fba62



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218