### PR TITLE
[ET-VK] Reducing memory wastage by tightening DescriptorPoolConfig values.

### DIFF
--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -594,13 +594,13 @@ void ComputeGraph::prepare() {
           prepack_descriptor_counts_.field) * \
       config_.descriptor_pool_safety_factor))
 
-  uint32_t max_sets = MERGE_FIELD(descriptor_pool_max_sets);
-  vkapi::DescriptorPoolConfig config{
+  const uint32_t max_sets = MERGE_FIELD(descriptor_pool_max_sets);
+  const vkapi::DescriptorPoolConfig config{
       max_sets,
-      std::max(MERGE_FIELD(descriptor_uniform_buffer_count), max_sets),
-      std::max(MERGE_FIELD(descriptor_storage_buffer_count), max_sets),
-      std::max(MERGE_FIELD(descriptor_combined_sampler_count), max_sets),
-      std::max(MERGE_FIELD(descriptor_storage_image_count), max_sets),
+      MERGE_FIELD(descriptor_uniform_buffer_count),
+      MERGE_FIELD(descriptor_storage_buffer_count),
+      MERGE_FIELD(descriptor_combined_sampler_count),
+      MERGE_FIELD(descriptor_storage_image_count),
       1u,
   };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #10787
* #10785
* __->__ #10784
* #10777

This change replaces std::max(*descriptor_type_count*, max_sets) with *descriptor_type_count*, when creating DescriptorPoolConfig in ComputeGraph since Vulkan does not need to have at least one of each *descriptor_type_count* per set.

Differential Revision: [D74452971](https://our.internmc.facebook.com/intern/diff/D74452971/)