### PR TITLE
[ET-VK] Moving device capabilities check to DispatchNode and PrepackNode ctor.

### DIFF
--- a/backends/vulkan/runtime/graph/ops/DispatchNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/DispatchNode.cpp
@@ -33,6 +33,7 @@ DispatchNode::DispatchNode(
       spec_vars_(spec_vars),
       push_constants_(push_constants) {
   graph.update_descriptor_counts(shader, /*execute = */ true);
+  graph.context()->check_device_capabilities(shader_);
 }
 
 void DispatchNode::encode(ComputeGraph* graph) {
@@ -41,8 +42,6 @@ void DispatchNode::encode(ComputeGraph* graph) {
   }
   api::Context* const context = graph->context();
   vkapi::PipelineBarrier pipeline_barrier{};
-
-  context->check_device_capabilities(shader_);
 
   std::unique_lock<std::mutex> cmd_lock = context->dispatch_lock();
 

--- a/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
@@ -45,6 +45,7 @@ PrepackNode::PrepackNode(
       push_constants_(push_constants) {
   graph.update_descriptor_counts(shader, /*execute = */ false);
   graph.update_descriptor_counts(noop_shader_, /*execute = */ false);
+  graph.context()->check_device_capabilities(shader_);
 }
 
 api::StagingBuffer PrepackNode::create_staging_buffer(ComputeGraph* graph) {
@@ -69,8 +70,6 @@ api::StagingBuffer PrepackNode::create_staging_buffer(ComputeGraph* graph) {
 
 void PrepackNode::encode(ComputeGraph* graph) {
   api::Context* const context = graph->context();
-
-  context->check_device_capabilities(shader_);
 
   vTensorPtr packed = graph->get_tensor(packed_);
   api::StagingBuffer staging = create_staging_buffer(graph);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #10787
* __->__ #10785
* #10784
* #10777

The changes in this diff move the device capabilities check from the encode method to the constructor of DispatchNode and PrepackNode classes.

Differential Revision: [D74481839](https://our.internmc.facebook.com/intern/diff/D74481839/)