### PR TITLE
Move EXECUTORCH_PAL_DEFAULT to default preset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,15 +100,6 @@ else()
   set(_default_release_disabled_options ON)
 endif()
 
-# Let users override which PAL defaults to use.
-#
-# TODO(dbort): Add another option that lets users point to a specific source
-# file; if set, would override the default option.
-set(EXECUTORCH_PAL_DEFAULT
-    "posix"
-    CACHE STRING
-          "Which PAL default implementation to use: one of {posix, minimal}"
-)
 
 if(NOT EXECUTORCH_ENABLE_LOGGING)
   # Avoid pulling in the logging strings, which can be large. Note that this
@@ -477,17 +468,7 @@ list(FILTER _executorch_core__srcs EXCLUDE REGEX
 )
 
 # Add the source file that maps to the requested default PAL implementation.
-if(EXECUTORCH_PAL_DEFAULT MATCHES "^(posix|minimal)$")
-  message(STATUS "executorch: Using PAL default '${EXECUTORCH_PAL_DEFAULT}'")
-  list(APPEND _executorch_core__srcs
-       "runtime/platform/default/${EXECUTORCH_PAL_DEFAULT}.cpp"
-  )
-else()
-  message(
-    FATAL_ERROR "Unknown EXECUTORCH_PAL_DEFAULT \"${EXECUTORCH_PAL_DEFAULT}\". "
-                "Expected one of {posix, minimal}."
-  )
-endif()
+list(APPEND _executorch_core__srcs ${EXECUTORCH_PAL_DEFAULT_FILE_PATH})
 
 add_library(executorch_core ${_executorch_core__srcs})
 

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -14,10 +14,36 @@ endif()
 
 # MARK: - Overridable Options
 
-define_overridable_option(EXECUTORCH_ENABLE_LOGGING "Build with ET_LOG_ENABLED" BOOL ${_is_build_type_debug})
-define_overridable_option(EXECUTORCH_BUILD_COREML "Build the Core ML backend" BOOL OFF)
+define_overridable_option(
+  EXECUTORCH_ENABLE_LOGGING
+  "Build with ET_LOG_ENABLED"
+  BOOL ${_is_build_type_debug}
+)
+define_overridable_option(
+  EXECUTORCH_BUILD_COREML
+  "Build the Core ML backend"
+  BOOL OFF
+)
 define_overridable_option(
   EXECUTORCH_FLATBUFFERS_MAX_ALIGNMENT
   "Exir lets users set the alignment of tensor data embedded in the flatbuffer, and some users need an alignment larger than the default, which is typically 32."
   STRING 1024
 )
+define_overridable_option(
+  EXECUTORCH_PAL_DEFAULT
+  "Which PAL default implementation to use. Choices: posix, minimal"
+  STRING "posix"
+)
+define_overridable_option(
+  EXECUTORCH_PAL_DEFAULT_FILE_PATH
+  "PAL implementation file path"
+  STRING "${PROJECT_SOURCE_DIR}/runtime/platform/default/${EXECUTORCH_PAL_DEFAULT}.cpp"
+)
+
+
+# MARK: - Validations
+# At this point all the options should be configured with their final value.
+
+if(NOT EXISTS ${EXECUTORCH_PAL_DEFAULT_FILE_PATH})
+  message(FATAL_ERROR "PAL default implementation (EXECUTORCH_PAL_DEFAULT=${EXECUTORCH_PAL_DEFAULT}) file not found: ${EXECUTORCH_PAL_DEFAULT_FILE_PATH}. Choices: posix, minimal")
+endif()


### PR DESCRIPTION
### Summary
TSIA

### Test plan

CI + 

```
$ cmake --preset macos-arm64 && cmake --build cmake-out --parallel
```
```
$ cmake -DEXECUTORCH_PAL_DEFAULT=fake --preset macos-arm64

CMake Error at tools/cmake/preset/default.cmake:48 (message):
  PAL default implementation (fake) file not found:
  /Users/jathu/executorch/runtime/platform/default/fake.cpp
Call Stack (most recent call first):
  CMakeLists.txt:53 (include)
```

cc @larryliu0820