### PR TITLE
Move EXECUTORCH_LOG_LEVEL to default preset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,27 +108,7 @@ if(NOT EXECUTORCH_ENABLE_LOGGING)
   add_definitions(-DET_LOG_ENABLED=0)
 endif()
 
-# Configure log level. Must be one of debug, info, error, fatal.
-set(EXECUTORCH_LOG_LEVEL
-    "Info"
-    CACHE STRING "Build with the given ET_MIN_LOG_LEVEL value"
-)
-string(TOLOWER "${EXECUTORCH_LOG_LEVEL}" LOG_LEVEL_LOWER)
-if(LOG_LEVEL_LOWER STREQUAL "debug")
-  add_definitions(-DET_MIN_LOG_LEVEL=Debug)
-elseif(LOG_LEVEL_LOWER STREQUAL "info")
-  add_definitions(-DET_MIN_LOG_LEVEL=Info)
-elseif(LOG_LEVEL_LOWER STREQUAL "error")
-  add_definitions(-DET_MIN_LOG_LEVEL=Error)
-elseif(LOG_LEVEL_LOWER STREQUAL "fatal")
-  add_definitions(-DET_MIN_LOG_LEVEL=Fatal)
-else()
-  message(
-    SEND_ERROR
-      "Unknown log level \"${EXECUTORCH_LOG_LEVEL}\". Expected one of Debug, "
-      + "Info, Error, or Fatal."
-  )
-endif()
+add_definitions(-DET_MIN_LOG_LEVEL=${ET_MIN_LOG_LEVEL})
 
 option(EXECUTORCH_ENABLE_PROGRAM_VERIFICATION
        "Build with ET_ENABLE_PROGRAM_VERIFICATION"

--- a/tools/cmake/Utils.cmake
+++ b/tools/cmake/Utils.cmake
@@ -32,9 +32,6 @@ function(executorch_print_configuration_summary)
   message(STATUS "  EXECUTORCH_ENABLE_PROGRAM_VERIFICATION : "
                  "${EXECUTORCH_ENABLE_PROGRAM_VERIFICATION}"
   )
-  message(
-    STATUS "  EXECUTORCH_LOG_LEVEL                   : ${EXECUTORCH_LOG_LEVEL}"
-  )
   message(STATUS "  EXECUTORCH_BUILD_ANDROID_JNI           : "
                  "${EXECUTORCH_BUILD_ANDROID_JNI}"
   )

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -39,11 +39,28 @@ define_overridable_option(
   "PAL implementation file path"
   STRING "${PROJECT_SOURCE_DIR}/runtime/platform/default/${EXECUTORCH_PAL_DEFAULT}.cpp"
 )
-
+define_overridable_option(
+  EXECUTORCH_LOG_LEVEL
+  "Build with the given ET_MIN_LOG_LEVEL value"
+  STRING "Info"
+)
 
 # MARK: - Validations
 # At this point all the options should be configured with their final value.
 
 if(NOT EXISTS ${EXECUTORCH_PAL_DEFAULT_FILE_PATH})
   message(FATAL_ERROR "PAL default implementation (EXECUTORCH_PAL_DEFAULT=${EXECUTORCH_PAL_DEFAULT}) file not found: ${EXECUTORCH_PAL_DEFAULT_FILE_PATH}. Choices: posix, minimal")
+endif()
+
+string(TOLOWER "${EXECUTORCH_LOG_LEVEL}" _executorch_log_level_lower)
+if(_executorch_log_level_lower STREQUAL "debug")
+  set(ET_MIN_LOG_LEVEL Debug)
+elseif(_executorch_log_level_lower STREQUAL "info")
+  set(ET_MIN_LOG_LEVEL Info)
+elseif(_executorch_log_level_lower STREQUAL "error")
+  set(ET_MIN_LOG_LEVEL Error)
+elseif(_executorch_log_level_lower STREQUAL "fatal")
+  set(ET_MIN_LOG_LEVEL Fatal)
+else()
+  message(FATAL_ERROR "Unknown EXECUTORCH_LOG_LEVEL '${EXECUTORCH_LOG_LEVEL}'. Choices: Debug, Info, Error, Fatal")
 endif()


### PR DESCRIPTION
### Summary
TSIA

### Test plan

CI +

```
$ cmake --preset macos-arm64 && cmake --build cmake-out --parallel
```
```
$ cmake -DEXECUTORCH_LOG_LEVEL=fake --preset macos-arm64

CMake Error at tools/cmake/preset/default.cmake:65 (message):
  Unknown EXECUTORCH_LOG_LEVEL 'fake'.  Choices: Debug, Info, Error, Fatal
Call Stack (most recent call first):
  CMakeLists.txt:53 (include)
``` 

cc @larryliu0820