### PR TITLE
Move EXECUTORCH_ENABLE_PROGRAM_VERIFICATION to default preset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,16 +91,6 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 # Instead please use `find_package(executorch REQUIRED)` in the example
 # directory and add a new executable in the example `CMakeLists.txt`.
 
-# _default_release_disabled_options: default value for options that should be
-# disabled in Release mode by default. Users can still manually enable them,
-# though.
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  set(_default_release_disabled_options OFF)
-else()
-  set(_default_release_disabled_options ON)
-endif()
-
-
 if(NOT EXECUTORCH_ENABLE_LOGGING)
   # Avoid pulling in the logging strings, which can be large. Note that this
   # will set the compiler flag for all targets in this directory, and for all
@@ -110,10 +100,6 @@ endif()
 
 add_definitions(-DET_MIN_LOG_LEVEL=${ET_MIN_LOG_LEVEL})
 
-option(EXECUTORCH_ENABLE_PROGRAM_VERIFICATION
-       "Build with ET_ENABLE_PROGRAM_VERIFICATION"
-       ${_default_release_disabled_options}
-)
 if(NOT EXECUTORCH_ENABLE_PROGRAM_VERIFICATION)
   # Avoid pulling in the flatbuffer data verification logic, which can add about
   # 20kB. Note that this will set the compiler flag for all targets in this

--- a/tools/cmake/Utils.cmake
+++ b/tools/cmake/Utils.cmake
@@ -29,9 +29,6 @@ function(executorch_print_configuration_summary)
   message(STATUS "  CMAKE_TOOLCHAIN_FILE          : ${CMAKE_TOOLCHAIN_FILE}")
   message(STATUS "  BUCK2                         : ${BUCK2}")
   message(STATUS "  PYTHON_EXECUTABLE             : ${PYTHON_EXECUTABLE}")
-  message(STATUS "  EXECUTORCH_ENABLE_PROGRAM_VERIFICATION : "
-                 "${EXECUTORCH_ENABLE_PROGRAM_VERIFICATION}"
-  )
   message(STATUS "  EXECUTORCH_BUILD_ANDROID_JNI           : "
                  "${EXECUTORCH_BUILD_ANDROID_JNI}"
   )

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -44,6 +44,11 @@ define_overridable_option(
   "Build with the given ET_MIN_LOG_LEVEL value"
   STRING "Info"
 )
+define_overridable_option(
+  EXECUTORCH_ENABLE_PROGRAM_VERIFICATION
+  "Build with ET_ENABLE_PROGRAM_VERIFICATION"
+  BOOL ${_is_build_type_debug}
+)
 
 # MARK: - Validations
 # At this point all the options should be configured with their final value.


### PR DESCRIPTION
### Summary
TSIA

### Test plan

CI +

```
$ cmake --preset macos-arm64 && cmake --build cmake-out --parallel
$ cmake -DEXECUTORCH_ENABLE_PROGRAM_VERIFICATION=OFF --preset macos-arm64 && cmake --build cmake-out --parallel
$ cmake -DEXECUTORCH_ENABLE_PROGRAM_VERIFICATION=ON --preset macos-arm64 && cmake --build cmake-out --parallel
``` 

cc @larryliu0820