### PR TITLE
Move EXECUTORCH_ENABLE_EVENT_TRACER to default preset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,9 +107,6 @@ if(NOT EXECUTORCH_ENABLE_PROGRAM_VERIFICATION)
   add_definitions(-DET_ENABLE_PROGRAM_VERIFICATION=0)
 endif()
 
-option(EXECUTORCH_ENABLE_EVENT_TRACER "Build with ET_EVENT_TRACER_ENABLED=ON"
-       OFF
-)
 if(EXECUTORCH_ENABLE_EVENT_TRACER)
   add_definitions(-DET_EVENT_TRACER_ENABLED)
 endif()
@@ -788,11 +785,7 @@ if(EXECUTORCH_BUILD_EXECUTOR_RUNNER)
   endif()
 
   if(EXECUTORCH_ENABLE_EVENT_TRACER)
-    if(EXECUTORCH_BUILD_DEVTOOLS)
-      list(APPEND _executor_runner_libs etdump flatccrt)
-    else()
-      message(SEND_ERROR "Use of 'EXECUTORCH_ENABLE_EVENT_TRACER' requires 'EXECUTORCH_BUILD_DEVTOOLS' to be enabled.")
-    endif()
+    list(APPEND _executor_runner_libs etdump flatccrt)
   endif()
 
   if(EXECUTORCH_BUILD_COREML)

--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -162,14 +162,7 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*(iOS|ios\.toolchain)\.cmake$")
   add_executable(xnn_executor_runner ${_xnn_executor_runner__srcs})
 
   if(EXECUTORCH_ENABLE_EVENT_TRACER)
-    if(EXECUTORCH_BUILD_DEVTOOLS)
-      list(APPEND xnn_executor_runner_libs etdump)
-    else()
-      message(
-        SEND_ERROR
-          "Use of 'EXECUTORCH_ENABLE_EVENT_TRACER' requires 'EXECUTORCH_BUILD_DEVTOOLS' to be enabled."
-      )
-    endif()
+    list(APPEND xnn_executor_runner_libs etdump)
   endif()
 
   target_link_libraries(xnn_executor_runner gflags ${xnn_executor_runner_libs})

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -49,6 +49,11 @@ define_overridable_option(
   "Build with ET_ENABLE_PROGRAM_VERIFICATION"
   BOOL ${_is_build_type_debug}
 )
+define_overridable_option(
+  EXECUTORCH_ENABLE_EVENT_TRACER
+  "Build with ET_EVENT_TRACER_ENABLED"
+  BOOL OFF
+)
 
 # MARK: - Validations
 # At this point all the options should be configured with their final value.
@@ -56,6 +61,7 @@ define_overridable_option(
 if(NOT EXISTS ${EXECUTORCH_PAL_DEFAULT_FILE_PATH})
   message(FATAL_ERROR "PAL default implementation (EXECUTORCH_PAL_DEFAULT=${EXECUTORCH_PAL_DEFAULT}) file not found: ${EXECUTORCH_PAL_DEFAULT_FILE_PATH}. Choices: posix, minimal")
 endif()
+
 
 string(TOLOWER "${EXECUTORCH_LOG_LEVEL}" _executorch_log_level_lower)
 if(_executorch_log_level_lower STREQUAL "debug")
@@ -68,4 +74,11 @@ elseif(_executorch_log_level_lower STREQUAL "fatal")
   set(ET_MIN_LOG_LEVEL Fatal)
 else()
   message(FATAL_ERROR "Unknown EXECUTORCH_LOG_LEVEL '${EXECUTORCH_LOG_LEVEL}'. Choices: Debug, Info, Error, Fatal")
+endif()
+
+
+if(EXECUTORCH_ENABLE_EVENT_TRACER)
+  if(NOT EXECUTORCH_BUILD_DEVTOOLS)
+    message(FATAL_ERROR "Use of 'EXECUTORCH_ENABLE_EVENT_TRACER' requires 'EXECUTORCH_BUILD_DEVTOOLS' to be enabled.")
+  endif()
 endif()


### PR DESCRIPTION
### Summary
TSIA

### Test plan

```
$ cmake --preset macos-arm64 && cmake --build cmake-out --parallel
```

```
$ cmake -DEXECUTORCH_ENABLE_EVENT_TRACER=ON --preset macos-arm64 && cmake --build cmake-out --parallel

CMake Error at tools/cmake/preset/default.cmake:82 (message):
  Use of 'EXECUTORCH_ENABLE_EVENT_TRACER' requires
  'EXECUTORCH_BUILD_DEVTOOLS' to be enabled.
Call Stack (most recent call first):
  CMakeLists.txt:53 (include)
```

```
$ cmake -DEXECUTORCH_ENABLE_EVENT_TRACER=ON -DEXECUTORCH_BUILD_DEVTOOLS=ON --preset macos-arm64 && cmake --build cmake-out --parallel
```



cc @larryliu0820