### PR TITLE
Delete EXECUTORCH_BUILD_ANDROID_JNI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,8 +128,6 @@ else()
   set(CMAKE_CXX_FLAGS_RELEASE "-O2 ${CMAKE_CXX_FLAGS_RELEASE}")
 endif()
 
-option(EXECUTORCH_BUILD_ANDROID_JNI "Build Android JNI" OFF)
-
 option(EXECUTORCH_BUILD_ARM_BAREMETAL
        "Build the Arm Baremetal flow for Cortex-M and Ethos-U" OFF
 )

--- a/tools/cmake/Utils.cmake
+++ b/tools/cmake/Utils.cmake
@@ -29,9 +29,6 @@ function(executorch_print_configuration_summary)
   message(STATUS "  CMAKE_TOOLCHAIN_FILE          : ${CMAKE_TOOLCHAIN_FILE}")
   message(STATUS "  BUCK2                         : ${BUCK2}")
   message(STATUS "  PYTHON_EXECUTABLE             : ${PYTHON_EXECUTABLE}")
-  message(STATUS "  EXECUTORCH_BUILD_ANDROID_JNI           : "
-                 "${EXECUTORCH_BUILD_ANDROID_JNI}"
-  )
   message(STATUS "  EXECUTORCH_BUILD_ARM_BAREMETAL         : "
                  "${EXECUTORCH_BUILD_ARM_BAREMETAL}"
   )


### PR DESCRIPTION
### Summary
Seems like this isn't used anywhere.

### Test plan

```
$ rg EXECUTORCH_BUILD_ANDROID_JNI --hidden
```


cc @larryliu0820