### PR TITLE
Update export and build from source docs

### DIFF
--- a/docs/source/using-executorch-building-from-source.md
+++ b/docs/source/using-executorch-building-from-source.md
@@ -188,14 +188,17 @@ cmake --build cmake-out -j9
 
 ## Use an example binary `executor_runner` to execute a .pte file
 
-First, generate an `add.pte` or other ExecuTorch program file using the
-instructions as described in
-[Preparing a Model](getting-started.md#preparing-the-model).
+First, generate a .pte file, either by exporting an example model or following
+the instructions in [Model Export and Lowering](using-executorch-export.md).
 
+To generate a simple model file, run the following command from the ExecuTorch directory. It
+will create a file named "add.pte" in the current directory.
+```
+python -m examples.portable.scripts.export --model_name="add"
+```
 Then, pass it to the command line tool:
-
 ```bash
-./cmake-out/executor_runner --model_path path/to/model.pte
+./cmake-out/executor_runner --model_path add.pte
 ```
 
 You should see the message "Model executed successfully" followed


### PR DESCRIPTION
### Summary
This PR makes some small updates to the docs in a few places. In the Build from Source page, I've added an explicit command to generate a test model (add.pte) to use with the executor_runner.

In the Exporting and Lowering page, I've added some details on advanced export and lowering techniques, including state management, dynamic control flow, and multi-method .ptes.

### Test plan
I've built and viewed the docs locally to validate the changes.


cc @mergennachin @byjlw