### PR TITLE
Arm backend: Rescale fixes for TOSA 1.0

### DIFF
--- a/backends/arm/operators/op_conv2d.py
+++ b/backends/arm/operators/op_conv2d.py
@@ -277,17 +277,29 @@ class Conv2dVisitor(NodeVisitor):
             input_qparams = get_input_qparams(node)
             input_zp = input_qparams[0].zp
 
-        tosa_graph.addConst([1], output.dtype, [input_zp], name=f"{node.name}_input_zp")
-        tosa_graph.addConst([1], output.dtype, [0], name=f"{node.name}_weight_zp")
+        # The output type is int32 when input type is int8.
+        conv2d_output_name = output.name
+        if output.dtype == ts.DType.INT8:
+            conv2d_res = tosa_graph.addIntermediate(
+                tosa_shape(output.shape, output.dim_order), ts.DType.INT32
+            )
+            conv2d_output_name = conv2d_res.name
         acc_type = (
             inputs[0].dtype if inputs[0].dtype == ts.DType.FP32 else ts.DType.INT32
+        )
+
+        tosa_graph.addConst(
+            [1], output.dtype, [input_zp], name=f"{conv2d_output_name}_input_zp"
+        )
+        tosa_graph.addConst(
+            [1], output.dtype, [0], name=f"{conv2d_output_name}_weight_zp"
         )
 
         # Non-bias case.
         if len(node.all_input_nodes) == 2:
             # Create a zero bias tensor if not presented
             out_channels = weight.shape[0]
-            bias_name = "bias" + node.name.split("default", 1)[1]
+            bias_name = f"{conv2d_output_name}_bias"
             bias_type = output.dtype
             if output.dtype == ts.DType.INT8:
                 # Conv is quantized to int8, but the TOSA operator has
@@ -300,14 +312,6 @@ class Conv2dVisitor(NodeVisitor):
                 [0] * out_channels,
                 name=bias_name,
             )
-
-        # The output type is int32 when input type is int8.
-        conv2d_output_name = output.name
-        if output.dtype == ts.DType.INT8:
-            conv2d_res = tosa_graph.addIntermediate(
-                tosa_shape(output.shape, output.dim_order), ts.DType.INT32
-            )
-            conv2d_output_name = conv2d_res.name
 
         # Given input.shape is (N, Ci, H, W), and weight.shape is (Co, Ci/G, H, W)
         in_channels = input.shape[1]
@@ -373,8 +377,8 @@ class Conv2dVisitor(NodeVisitor):
                 input.name,
                 weight_name,
                 bias.name,
-                f"{node.name}_input_zp",
-                f"{node.name}_weight_zp",
+                f"{conv2d_output_name}_input_zp",
+                f"{conv2d_output_name}_weight_zp",
             ],
             [conv2d_output_name],
             attr,

--- a/backends/arm/operators/op_rescale.py
+++ b/backends/arm/operators/op_rescale.py
@@ -16,8 +16,8 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
 )
-from executorch.backends.arm.tosa_mapping import TosaArg
-from executorch.backends.arm.tosa_quant_utils import create_const_ops_for_rescale
+from executorch.backends.arm.tosa_mapping import map_dtype, TosaArg
+from executorch.backends.arm.tosa_quant_utils import build_rescale
 
 from executorch.backends.arm.tosa_specification import TosaSpecification
 from torch.fx import Node
@@ -98,53 +98,29 @@ class RescaleVisitor_INT(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 5)
 
-        input_dtype = node.all_input_nodes[0].meta["val"].dtype
+        input_dtype = inputs[0].dtype
         output_dtype = cast(torch.dtype, node.args[1])
         scale = cast(float, node.args[2])
         input_zp = cast(int, node.args[3])
         output_zp = cast(int, node.args[4])
 
-        if input_dtype != torch.int8 and input_zp != 0:
+        if input_dtype != map_dtype(torch.int8, self.tosa_spec) and input_zp != 0:
             raise ValueError(
                 f"If input dtype is not int8, input_zp must be 0. Got input_dtype{input_dtype=}, {input_zp=}"
             )
         if output_dtype != torch.int8 and output_zp != 0:
             raise ValueError(
-                f"If output dtype is not int8, output_zp must be 0. Got {output_dtype=}, {output_zp=}"
+                f"If output dtype is not int8, output_zp must be 0. Got {ts.DTypeNames[output_dtype]}, {output_zp=}"
             )
 
-        # scale32 gives higher accuracy but for a higher HW cost.
-        # For now, always go for scale32.
-        scale_32 = True
-        scale_width = 32 if scale_32 else 16
-        multipliers, shifts = tosa_quant_utils.compute_multiplier_and_shift(
-            [scale], scale_width
-        )
-
-        rescale_inputs = create_const_ops_for_rescale(
+        build_rescale(
             tosa_graph,
-            input_dtype,
-            inputs[0].name,
-            multipliers,
-            shifts,
-            input_zp,
-            output_zp,
-            ts,
-        )
-
-        attr_rescale = ts.TosaSerializerAttribute()
-
-        attr_rescale.RescaleAttribute(
-            scale32=scale_32,
+            scale=[scale],
+            input_node=inputs[0],
+            output_name=output.name,
+            output_type=output.dtype,
+            input_zp=input_zp,
+            output_zp=output_zp,
             rounding_mode=RoundingMode.SINGLE_ROUND,
             per_channel=False,
-            input_unsigned=False,
-            output_unsigned=False,
-        )
-
-        tosa_graph.addOperator(
-            ts.TosaOp.Op().RESCALE,
-            [inputs[0].name, *rescale_inputs],
-            [output.name],
-            attr_rescale,
         )

--- a/backends/arm/tosa_quant_utils.py
+++ b/backends/arm/tosa_quant_utils.py
@@ -239,7 +239,7 @@ def create_const_ops_for_rescale(
     tosa_fb,
     scale_32,
     input_dtype,
-    input_name,
+    node_name,
     multipliers,
     shifts,
     input_zp,
@@ -252,16 +252,16 @@ def create_const_ops_for_rescale(
         (len(multipliers),),
         ts.DType.INT32 if scale_32 else ts.DType.INT16,
         multipliers,
-        name=input_name + "_multipliers",
+        name=node_name + "_multipliers",
     )
     shifts = tosa_fb.addConst(
-        (len(shifts),), ts.DType.INT8, shifts, name=input_name + "_shifts"
+        (len(shifts),), ts.DType.INT8, shifts, name=node_name + "_shifts"
     )
     input_zp = tosa_fb.addConst(
-        [1], input_dtype, [input_zp], name=input_name + "_input_zp"
+        [1], input_dtype, [input_zp], name=node_name + "_input_zp"
     )
     output_zp = tosa_fb.addConst(
-        [1], output_dtype, [output_zp], name=input_name + "_output_zp"
+        [1], output_dtype, [output_zp], name=node_name + "_output_zp"
     )
 
     return [multipliers.name, shifts.name, input_zp.name, output_zp.name]
@@ -281,8 +281,6 @@ def build_rescale(
     import serializer.tosa_serializer as ts  # type: ignore
     import tosa.Op as TosaOp  # type: ignore
 
-    input_name = input_node.name
-
     scaleWidth = 32
     is_scale32 = True
     multipliers, shifts = compute_multiplier_and_shift(scale, scaleWidth)
@@ -290,7 +288,7 @@ def build_rescale(
         tosa_fb,
         is_scale32,
         input_node.dtype,
-        input_name,
+        output_name,
         multipliers,
         shifts,
         input_zp,


### PR DESCRIPTION
### Summary
- Adds support for INT16 rescales for TOSA 1.0.
- Updates names of const-tensors for TOSA 1.0.


### Test plan
Tested through public and internal CI.


cc @digantdesai @freddan80 @per @zingo