### PR TITLE
Make qwen3 compatible with ao-quantized checkpoints

### DIFF
--- a/examples/models/qwen3/convert_weights.py
+++ b/examples/models/qwen3/convert_weights.py
@@ -61,6 +61,13 @@ def qwen_3_tune_to_meta(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.
 
 
 def load_checkpoint(input_dir: str) -> Dict:
+    # 1. Torchao-quantized checkpoint.
+    quantized_path = os.path.join(input_dir, "pytorch_model.bin")
+    if os.path.exists(quantized_path):
+        sd = torch.load(quantized_path, map_location="cpu", weights_only=True)
+        return sd
+
+    # 2. Official HuggingFace checkpoint.
     index_path = os.path.join(input_dir, "model.safetensors.index.json")
     if os.path.exists(index_path):
         # Sharded checkpoint.


### PR DESCRIPTION
```
python -m executorch.examples.models.qwen3.convert_weights <path to directory containt pytorch_model.bin> ao-qwen3-4b.pth
python -m examples.models.llama.export_llama --model qwen3-4b --checkpoint ao-qwen3-4b.pth --params examples/models/qwen3/4b_config.json -kv --use_sdpa_with_kv_cache -d fp32 --output_name="hummingbird-qwen3-4b_x_long_context.pte" --verbose --max_seq_length=1024 --max_context_length=1024 -X --metadata '{"get_bos_id": 151644, "get_eos_ids":[151645]}'
```