### PR TITLE
Add floatValue to ExecuTorch value

### DIFF
--- a/extension/apple/ExecuTorch/Exported/ExecuTorchValue.h
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchValue.h
@@ -40,6 +40,8 @@ typedef NSInteger ExecuTorchIntegerValue
     NS_SWIFT_BRIDGED_TYPEDEF NS_SWIFT_NAME(IntegerValue);
 typedef double ExecuTorchDoubleValue
     NS_SWIFT_BRIDGED_TYPEDEF NS_SWIFT_NAME(DoubleValue);
+typedef float ExecuTorchFloatValue
+    NS_SWIFT_BRIDGED_TYPEDEF NS_SWIFT_NAME(FloatValue);
 
 /**
  * A dynamic value type used by ExecuTorch.
@@ -101,6 +103,13 @@ __attribute__((deprecated("This API is experimental.")))
 @property(nonatomic, readonly) ExecuTorchDoubleValue doubleValue NS_SWIFT_NAME(double);
 
 /**
+ * The float value if the tag is ExecuTorchValueTagDouble.
+ *
+ * @return An float representing the float value.
+ */
+ @property(nonatomic, readonly) ExecuTorchFloatValue floatValue NS_SWIFT_NAME(float);
+
+/**
  * Returns YES if the value is of type None.
  *
  * @return A BOOL indicating whether the value is None.
@@ -148,6 +157,13 @@ __attribute__((deprecated("This API is experimental.")))
  * @return A BOOL indicating whether the value is a double.
  */
 @property(nonatomic, readonly) BOOL isDouble;
+
+/**
+ * Returns YES if the value is a float.
+ *
+ * @return A BOOL indicating whether the value is a float.
+ */
+ @property(nonatomic, readonly) BOOL isFloat;
 
 /**
  * Creates an instance encapsulating a Tensor.

--- a/extension/apple/ExecuTorch/Exported/ExecuTorchValue.mm
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchValue.mm
@@ -88,6 +88,11 @@
   return [(ExecuTorchScalarValue)_value doubleValue];
 }
 
+- (ExecuTorchFloatValue)floatValue {
+  ET_CHECK(self.isFloat);
+  return [(ExecuTorchScalarValue)_value floatValue];
+}
+
 - (BOOL)isNone {
   return _tag == ExecuTorchValueTagNone;
 }
@@ -115,6 +120,11 @@
 }
 
 - (BOOL)isDouble {
+  return _tag == ExecuTorchValueTagDouble;
+}
+
+- (BOOL)isFloat {
+  // EValue does not have a separate tag for float.
   return _tag == ExecuTorchValueTagDouble;
 }
 


### PR DESCRIPTION
Summary:
I think we can have an utility to return floats back.
I would not create a new tag, but just use the double value and return it as float if the user needs float

Differential Revision: D74603334




cc @mergennachin @byjlw