### PR TITLE
Allow graceful handling of cpuinfo init failure

### DIFF
--- a/extension/threadpool/threadpool.cpp
+++ b/extension/threadpool/threadpool.cpp
@@ -96,7 +96,11 @@ void ThreadPool::run(
 // get_threadpool is not thread safe due to leak_corrupted_threadpool
 // Make this part threadsafe: TODO(kimishpatel)
 ThreadPool* get_threadpool() {
-  ET_CHECK_MSG(cpuinfo_initialize(), "cpuinfo initialization failed");
+  if (!cpuinfo_initialize()) {
+    ET_LOG(Error, "cpuinfo initialization failed");
+    return nullptr; // NOLINT(facebook-hte-NullableReturn)
+  }
+
   int num_threads = cpuinfo_get_processors_count();
   /*
    * For llvm-tsan, holding limit for the number of locks for a single thread


### PR DESCRIPTION
Summary: Don't fatally assert when cpuinfo_initialize fails. This can happen in rare cases on weird hardware. This change instead logs an error and allows execution to continue without the threadpool.

Differential Revision: D74604740

Test Plan:
I locally modified cpuinfo_initialize to always return false. I then attempted to run a model (dl3_xnnpack_fp32.pte) with executor_runner_optimized. With this change, it outputs the following:
```
E 00:00:00.001021 executorch:XNNPACKBackend.cpp:49] Failed to initialize, XNNPACK status: 0x5
I 00:00:00.087180 executorch:executor_runner_lib.cpp:410] Model file /home/gjcomer/dl3_xnnpack_fp32.pte is loaded.
I 00:00:00.087213 executorch:executor_runner_lib.cpp:420] Running method forward
I 00:00:00.087231 executorch:executor_runner_lib.cpp:470] Setting up planned buffer 0, size 61424384.
E 00:00:00.110105 executorch:method.cpp:78] Backend XnnpackBackend is not available.
F 00:00:00.110144 executorch:executor_runner_lib.cpp:517] In function executor_runner_benchmark(), assert failed (method.ok()): load_me
```