### PR TITLE
Default to file load mode in module

### DIFF
--- a/extension/module/module.h
+++ b/extension/module/module.h
@@ -53,7 +53,7 @@ class Module {
    */
   explicit Module(
       const std::string& file_path,
-      const LoadMode load_mode = LoadMode::MmapUseMlock,
+      const LoadMode load_mode = LoadMode::File,
       std::unique_ptr<runtime::EventTracer> event_tracer = nullptr);
 
   /**
@@ -68,7 +68,7 @@ class Module {
   explicit Module(
       const std::string& file_path,
       const std::string& data_map_path,
-      const LoadMode load_mode = LoadMode::MmapUseMlock,
+      const LoadMode load_mode = LoadMode::File,
       std::unique_ptr<runtime::EventTracer> event_tracer = nullptr);
 
   /**
@@ -481,7 +481,7 @@ class Module {
 
   std::string file_path_;
   std::string data_map_path_;
-  LoadMode load_mode_{LoadMode::MmapUseMlock};
+  LoadMode load_mode_{LoadMode::File};
   std::shared_ptr<Program> program_;
   std::unique_ptr<runtime::DataLoader> data_loader_;
   std::unique_ptr<runtime::MemoryAllocator> memory_allocator_;


### PR DESCRIPTION
Summary:
We've seen a number of people hit issues with mlock as the default load mode. In particular, mlock will fail above a certain PTE size and may require elevated permissions on some systems. We should not default to using mlock and can leave at as an opt-in optimization.

Differential Revision: D74607072


