### PR TITLE
[ET-VK] custom memory pools

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -40,6 +40,10 @@ Context::Context(size_t adapter_i, const ContextConfig& config)
       cmd_mutex_{},
       cmd_(VK_NULL_HANDLE, 0u),
       submit_count_{0u},
+      // Custom memory pools
+      custom_vma_pool_(
+          adapter_p_->vma().handle(),
+          adapter_p_->num_memory_types()),
       // Memory Management
       buffer_clearlist_mutex_{},
       buffers_to_clear_{},
@@ -58,6 +62,13 @@ Context::~Context() {
     adapter_p_->return_queue(queue_);
   } catch (...) {
   }
+}
+
+vkapi::MemoryPoolManager* Context::get_custom_memory_pool_ptr() {
+  if (config_.use_custom_vma_pools) {
+    return &custom_vma_pool_;
+  }
+  return nullptr;
 }
 
 void Context::initialize_querypool() {

--- a/backends/vulkan/runtime/api/api.h
+++ b/backends/vulkan/runtime/api/api.h
@@ -30,3 +30,4 @@
 #include <executorch/backends/vulkan/runtime/vk_api/memory/Allocator.h>
 #include <executorch/backends/vulkan/runtime/vk_api/memory/Buffer.h>
 #include <executorch/backends/vulkan/runtime/vk_api/memory/Image.h>
+#include <executorch/backends/vulkan/runtime/vk_api/memory/Pool.h>

--- a/backends/vulkan/runtime/api/containers/ParamsBuffer.cpp
+++ b/backends/vulkan/runtime/api/containers/ParamsBuffer.cpp
@@ -36,7 +36,8 @@ ParamsBuffer::ParamsBuffer(const ParamsBuffer& other)
     : context_p_(other.context_p_), vulkan_buffer_{} {
   if (other.vulkan_buffer_) {
     vulkan_buffer_ = context_p_->adapter_ptr()->vma().create_uniform_buffer(
-        other.vulkan_buffer_.mem_size());
+        other.vulkan_buffer_.mem_size(),
+        context_p_->get_custom_memory_pool_ptr());
 
     memcpy_to_buffer(other.vulkan_buffer_, vulkan_buffer_);
   }
@@ -55,7 +56,8 @@ ParamsBuffer& ParamsBuffer::operator=(const ParamsBuffer& other) {
 
     if (other.vulkan_buffer_) {
       vulkan_buffer_ = context_p_->adapter_ptr()->vma().create_uniform_buffer(
-          other.vulkan_buffer_.mem_size());
+          other.vulkan_buffer_.mem_size(),
+          context_p_->get_custom_memory_pool_ptr());
 
       memcpy_to_buffer(other.vulkan_buffer_, vulkan_buffer_);
     }

--- a/backends/vulkan/runtime/api/containers/ParamsBuffer.h
+++ b/backends/vulkan/runtime/api/containers/ParamsBuffer.h
@@ -35,8 +35,9 @@ class ParamsBuffer final {
   // constructor from the one above.
   ParamsBuffer(Context* context_p, const VkDeviceSize nbytes, const bool unused)
       : context_p_(context_p),
-        vulkan_buffer_(
-            context_p_->adapter_ptr()->vma().create_uniform_buffer(nbytes)) {}
+        vulkan_buffer_(context_p_->adapter_ptr()->vma().create_uniform_buffer(
+            nbytes,
+            context_p->get_custom_memory_pool_ptr())) {}
 
   ParamsBuffer(const ParamsBuffer&);
   ParamsBuffer& operator=(const ParamsBuffer&);

--- a/backends/vulkan/runtime/api/containers/StagingBuffer.h
+++ b/backends/vulkan/runtime/api/containers/StagingBuffer.h
@@ -35,7 +35,8 @@ class StagingBuffer final {
       : context_p_(context_p),
         dtype_(dtype),
         vulkan_buffer_(context_p_->adapter_ptr()->vma().create_staging_buffer(
-            element_size(dtype_) * numel)),
+            element_size(dtype_) * numel,
+            context_p_->get_custom_memory_pool_ptr())),
         mapped_data_(nullptr) {}
 
   StagingBuffer(const StagingBuffer&) = delete;

--- a/backends/vulkan/runtime/api/containers/Tensor.cpp
+++ b/backends/vulkan/runtime/api/containers/Tensor.cpp
@@ -292,7 +292,8 @@ vkapi::VulkanImage allocate_image(
       sampler_props,
       sampler,
       /*allow_transfer = */ true,
-      /*allocate_memory = */ allocate_memory);
+      /*allocate_memory = */ allocate_memory,
+      /*pool_manager = */ context_ptr->get_custom_memory_pool_ptr());
 }
 
 vkapi::VulkanBuffer allocate_buffer(
@@ -301,8 +302,6 @@ vkapi::VulkanBuffer allocate_buffer(
     const utils::StorageType storage_type,
     const vkapi::ScalarType dtype,
     const bool allocate_memory) {
-  vkapi::Adapter* adapter_ptr = context_ptr->adapter_ptr();
-
   switch (storage_type) {
     case utils::kBuffer:
       break;
@@ -313,8 +312,10 @@ vkapi::VulkanBuffer allocate_buffer(
 
   VK_CHECK_COND(numel <= context_ptr->adapter_ptr()->max_buffer_numel());
 
-  return adapter_ptr->vma().create_storage_buffer(
-      element_size(dtype) * numel, allocate_memory);
+  return context_ptr->adapter_ptr()->vma().create_storage_buffer(
+      element_size(dtype) * numel,
+      allocate_memory,
+      context_ptr->get_custom_memory_pool_ptr());
 }
 
 vTensorStorage::vTensorStorage(

--- a/backends/vulkan/runtime/graph/GraphConfig.cpp
+++ b/backends/vulkan/runtime/graph/GraphConfig.cpp
@@ -40,6 +40,7 @@ GraphConfig::GraphConfig() {
       cmd_config,
       descriptor_pool_config,
       query_pool_config,
+      false,
   };
 
   // Empirically selected safety factor. If descriptor pools start running out

--- a/backends/vulkan/runtime/graph/containers/SharedObject.cpp
+++ b/backends/vulkan/runtime/graph/containers/SharedObject.cpp
@@ -39,7 +39,9 @@ void SharedObject::allocate(ComputeGraph* const graph) {
       graph->context()->adapter_ptr()->vma().gpuonly_resource_create_info();
 
   allocation = graph->context()->adapter_ptr()->vma().create_allocation(
-      aggregate_memory_requirements, alloc_create_info);
+      aggregate_memory_requirements,
+      alloc_create_info,
+      graph->context()->get_custom_memory_pool_ptr());
 }
 
 void SharedObject::bind_users(ComputeGraph* const graph) {

--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -110,6 +110,10 @@ class Adapter final {
     return physical_device_.has_unified_memory;
   }
 
+  inline uint32_t num_memory_types() const {
+    return physical_device_.memory_properties.memoryTypeCount;
+  }
+
   inline uint32_t num_compute_queues() const {
     return physical_device_.num_compute_queues;
   }

--- a/backends/vulkan/runtime/vk_api/memory/Allocator.h
+++ b/backends/vulkan/runtime/vk_api/memory/Allocator.h
@@ -19,6 +19,7 @@
 #include <executorch/backends/vulkan/runtime/vk_api/memory/Allocation.h>
 #include <executorch/backends/vulkan/runtime/vk_api/memory/Buffer.h>
 #include <executorch/backends/vulkan/runtime/vk_api/memory/Image.h>
+#include <executorch/backends/vulkan/runtime/vk_api/memory/Pool.h>
 
 namespace vkcompute {
 namespace vkapi {
@@ -48,11 +49,16 @@ class Allocator final {
   VmaAllocator allocator_;
 
  public:
+  inline VmaAllocator handle() {
+    return allocator_;
+  }
+
   VmaAllocationCreateInfo gpuonly_resource_create_info();
 
   Allocation create_allocation(
       const VkMemoryRequirements& memory_requirements,
-      const VmaAllocationCreateInfo& create_info);
+      const VmaAllocationCreateInfo& create_info,
+      MemoryPoolManager* pool_manager = nullptr);
 
   VulkanImage create_image(
       const VkDevice,
@@ -64,18 +70,24 @@ class Allocator final {
       const VulkanImage::SamplerProperties&,
       VkSampler,
       const bool allow_transfer = false,
-      const bool allocate_memory = true);
+      const bool allocate_memory = true,
+      MemoryPoolManager* pool_manager = nullptr);
 
-  VulkanBuffer create_staging_buffer(const VkDeviceSize);
+  VulkanBuffer create_staging_buffer(
+      const VkDeviceSize,
+      MemoryPoolManager* pool_manager = nullptr);
 
   VulkanBuffer create_storage_buffer(
       const VkDeviceSize,
-      const bool allocate_memory = true);
+      const bool allocate_memory = true,
+      MemoryPoolManager* pool_manager = nullptr);
 
   /*
    * Create a uniform buffer with a specified size
    */
-  VulkanBuffer create_uniform_buffer(const VkDeviceSize);
+  VulkanBuffer create_uniform_buffer(
+      const VkDeviceSize,
+      MemoryPoolManager* pool_manager = nullptr);
 
   /*
    * Create a uniform buffer containing the data in an arbitrary struct

--- a/backends/vulkan/runtime/vk_api/memory/Buffer.cpp
+++ b/backends/vulkan/runtime/vk_api/memory/Buffer.cpp
@@ -11,6 +11,21 @@
 namespace vkcompute {
 namespace vkapi {
 
+VkBufferCreateInfo generate_buffer_create_info(
+    VkDeviceSize size,
+    VkBufferUsageFlags usage) {
+  return VkBufferCreateInfo{
+      VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      size, // size
+      usage, // usage
+      VK_SHARING_MODE_EXCLUSIVE, // sharingMode
+      0u, // queueFamilyIndexCount
+      nullptr, // pQueueFamilyIndices
+  };
+}
+
 //
 // VulkanBuffer
 //
@@ -42,16 +57,8 @@ VulkanBuffer::VulkanBuffer(
     buffer_properties_.mem_range = 1u;
   }
 
-  const VkBufferCreateInfo buffer_create_info{
-      VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, // sType
-      nullptr, // pNext
-      0u, // flags
-      buffer_properties_.size, // size
-      usage, // usage
-      VK_SHARING_MODE_EXCLUSIVE, // sharingMode
-      0u, // queueFamilyIndexCount
-      nullptr, // pQueueFamilyIndices
-  };
+  const VkBufferCreateInfo buffer_create_info =
+      generate_buffer_create_info(buffer_properties_.size, usage);
 
   if (allocate_memory) {
     VK_CHECK(vmaCreateBuffer(

--- a/backends/vulkan/runtime/vk_api/memory/Buffer.h
+++ b/backends/vulkan/runtime/vk_api/memory/Buffer.h
@@ -27,6 +27,10 @@ class vTensorStorage;
 
 namespace vkapi {
 
+VkBufferCreateInfo generate_buffer_create_info(
+    VkDeviceSize size,
+    VkBufferUsageFlags usage);
+
 using MemoryAccessFlags = uint8_t;
 
 enum MemoryAccessType : MemoryAccessFlags {

--- a/backends/vulkan/runtime/vk_api/memory/Image.cpp
+++ b/backends/vulkan/runtime/vk_api/memory/Image.cpp
@@ -11,6 +11,32 @@
 namespace vkcompute {
 namespace vkapi {
 
+VkImageCreateInfo generate_image_create_info(
+    VkImageType image_type,
+    VkFormat image_format,
+    VkExtent3D image_extents,
+    VkImageTiling image_tiling,
+    VkImageUsageFlags image_usage,
+    VkImageLayout initial_layout) {
+  return VkImageCreateInfo{
+      VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      image_type, // imageType
+      image_format, // format
+      image_extents, // extents
+      1u, // mipLevels
+      1u, // arrayLayers
+      VK_SAMPLE_COUNT_1_BIT, // samples
+      image_tiling, // tiling
+      image_usage, // usage
+      VK_SHARING_MODE_EXCLUSIVE, // sharingMode
+      0u, // queueFamilyIndexCount
+      nullptr, // pQueueFamilyIndices
+      initial_layout, // initialLayout
+  };
+}
+
 //
 // ImageSampler
 //
@@ -146,23 +172,13 @@ VulkanImage::VulkanImage(
     image_properties_.image_extents.depth = 1u;
   }
 
-  const VkImageCreateInfo image_create_info{
-      VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, // sType
-      nullptr, // pNext
-      0u, // flags
-      image_properties_.image_type, // imageType
-      image_properties_.image_format, // format
-      image_properties_.image_extents, // extents
-      1u, // mipLevels
-      1u, // arrayLayers
-      VK_SAMPLE_COUNT_1_BIT, // samples
-      image_properties_.image_tiling, // tiling
-      image_properties_.image_usage, // usage
-      VK_SHARING_MODE_EXCLUSIVE, // sharingMode
-      0u, // queueFamilyIndexCount
-      nullptr, // pQueueFamilyIndices
-      layout_, // initialLayout
-  };
+  const VkImageCreateInfo image_create_info = generate_image_create_info(
+      image_properties_.image_type,
+      image_properties_.image_format,
+      image_properties_.image_extents,
+      image_properties_.image_tiling,
+      image_properties_.image_usage,
+      layout_);
 
   if (allocate_memory) {
     VK_CHECK(vmaCreateImage(

--- a/backends/vulkan/runtime/vk_api/memory/Image.h
+++ b/backends/vulkan/runtime/vk_api/memory/Image.h
@@ -30,6 +30,14 @@ class vTensorStorage;
 
 namespace vkapi {
 
+VkImageCreateInfo generate_image_create_info(
+    VkImageType image_type,
+    VkFormat image_format,
+    VkExtent3D image_extents,
+    VkImageTiling image_tiling,
+    VkImageUsageFlags image_usage,
+    VkImageLayout initial_layout = VK_IMAGE_LAYOUT_UNDEFINED);
+
 class ImageSampler final {
  public:
   struct Properties final {

--- a/backends/vulkan/runtime/vk_api/memory/Pool.cpp
+++ b/backends/vulkan/runtime/vk_api/memory/Pool.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/vk_api/memory/Pool.h>
+
+#include <executorch/backends/vulkan/runtime/vk_api/Exception.h>
+
+namespace vkcompute {
+namespace vkapi {
+
+VmaPool create_memory_pool(
+    const VmaAllocator allocator,
+    const uint32_t mem_type_idx,
+    const size_t block_size = 0,
+    const size_t max_block_count = 0) {
+  VmaPoolCreateInfo create_info = {
+      mem_type_idx, // memoryTypeIndex
+      0u, // flags
+      block_size, // blockSize
+      0u, // minBlockCount
+      max_block_count, // maxBlockCount
+      0.0, // priority
+      0u, // minAllocationAlignment
+      nullptr};
+
+  VmaPool pool = VK_NULL_HANDLE;
+  VK_CHECK(vmaCreatePool(allocator, &create_info, &pool));
+  return pool;
+}
+
+MemoryPool::MemoryPool()
+    : allocator(VK_NULL_HANDLE),
+      memory_type_idx(0u),
+      block_size(0u),
+      max_block_count(0u),
+      handle(VK_NULL_HANDLE) {}
+
+MemoryPool::MemoryPool(MemoryPool&& other) noexcept
+    : allocator(other.allocator),
+      memory_type_idx(other.memory_type_idx),
+      block_size(other.block_size),
+      max_block_count(other.max_block_count),
+      handle(other.handle) {
+  other.handle = VK_NULL_HANDLE;
+}
+
+MemoryPool& MemoryPool::operator=(MemoryPool&& other) noexcept {
+  VmaAllocator tmp_allocator = allocator;
+  VmaPool tmp_handle = handle;
+
+  allocator = other.allocator;
+  memory_type_idx = other.memory_type_idx;
+  block_size = other.block_size;
+  max_block_count = other.max_block_count;
+  handle = other.handle;
+
+  other.allocator = tmp_allocator;
+  other.handle = tmp_handle;
+
+  return *this;
+}
+
+void MemoryPool::initialize() {
+  VK_CHECK_COND(handle == VK_NULL_HANDLE);
+  handle = create_memory_pool(
+      allocator, memory_type_idx, block_size, max_block_count);
+}
+
+MemoryPool::~MemoryPool() {
+  if (handle != VK_NULL_HANDLE) {
+    vmaDestroyPool(allocator, handle);
+  }
+}
+
+MemoryPoolManager::MemoryPoolManager(
+    VmaAllocator vma_allocator,
+    const uint32_t num_memory_types)
+    : allocator{vma_allocator}, memory_pools(num_memory_types) {
+  for (int i = 0; i < num_memory_types; ++i) {
+    memory_pools.at(i).allocator = allocator;
+    memory_pools.at(i).memory_type_idx = i;
+  }
+}
+
+VmaPool MemoryPoolManager::get_memory_pool(const uint32_t memory_type_idx) {
+  VK_CHECK_COND(memory_type_idx < memory_pools.size());
+  MemoryPool& pool = memory_pools.at(memory_type_idx);
+  if (pool.handle == VK_NULL_HANDLE) {
+    pool.initialize();
+  }
+  return pool.handle;
+}
+
+uint32_t MemoryPoolManager::get_memory_type_idx(
+    const VmaAllocationCreateInfo alloc_create_info) const {
+  uint32_t memory_type_idx = 0u;
+  VK_CHECK(vmaFindMemoryTypeIndex(
+      allocator,
+      UINT32_MAX, // memoryTypeBits - using all available memory types
+      &alloc_create_info,
+      &memory_type_idx));
+  return memory_type_idx;
+}
+
+uint32_t MemoryPoolManager::get_memory_type_idx(
+    const VmaAllocationCreateInfo alloc_create_info,
+    const VkImageCreateInfo image_create_info) const {
+  uint32_t memory_type_idx = 0u;
+  VK_CHECK(vmaFindMemoryTypeIndexForImageInfo(
+      allocator, &image_create_info, &alloc_create_info, &memory_type_idx));
+  return memory_type_idx;
+}
+
+uint32_t MemoryPoolManager::get_memory_type_idx(
+    const VmaAllocationCreateInfo alloc_create_info,
+    const VkBufferCreateInfo buffer_create_info) const {
+  uint32_t memory_type_idx = 0u;
+  VK_CHECK(vmaFindMemoryTypeIndexForBufferInfo(
+      allocator, &buffer_create_info, &alloc_create_info, &memory_type_idx));
+  return memory_type_idx;
+}
+
+} // namespace vkapi
+} // namespace vkcompute

--- a/backends/vulkan/runtime/vk_api/memory/Pool.h
+++ b/backends/vulkan/runtime/vk_api/memory/Pool.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadMemberName
+
+#include <executorch/backends/vulkan/runtime/vk_api/memory/vma_api.h>
+#include <executorch/backends/vulkan/runtime/vk_api/vk_api.h>
+
+#include <vector>
+
+namespace vkcompute {
+namespace vkapi {
+
+struct MemoryPool final {
+  MemoryPool();
+
+  MemoryPool(const MemoryPool& other) = delete;
+  MemoryPool& operator=(const MemoryPool& other) = delete;
+
+  MemoryPool(MemoryPool&& other) noexcept;
+  MemoryPool& operator=(MemoryPool&& other) noexcept;
+
+  ~MemoryPool();
+
+  void initialize();
+
+  VmaAllocator allocator;
+  uint32_t memory_type_idx;
+  size_t block_size;
+  size_t max_block_count;
+  VmaPool handle;
+};
+
+class MemoryPoolManager final {
+ public:
+  explicit MemoryPoolManager(
+      VmaAllocator vma_allocator,
+      const uint32_t num_memory_types);
+
+  VmaPool get_memory_pool(const uint32_t memory_type_idx);
+
+  uint32_t get_memory_type_idx(
+      const VmaAllocationCreateInfo alloc_create_info) const;
+
+  uint32_t get_memory_type_idx(
+      const VmaAllocationCreateInfo alloc_create_info,
+      const VkImageCreateInfo image_create_info) const;
+
+  uint32_t get_memory_type_idx(
+      const VmaAllocationCreateInfo alloc_create_info,
+      const VkBufferCreateInfo buffer_create_info) const;
+
+ private:
+  VmaAllocator allocator;
+  std::vector<MemoryPool> memory_pools;
+};
+
+} // namespace vkapi
+} // namespace vkcompute


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #10831

## Context

Currently, in ET-VK all memory allocations are done through the default memory pool of VMA (Vulkan Memory Allocator). This has some consequences:

* Memory Pool Behaviour (e.g. block size, allocation algorithm, etc.) cannot be configured on a per-model basis
* When a model is unloaded, GPU memory is not guaranteed to be freed since VMA may elect to hold on to the allocated memory for future use

This PR introduces the ability for models to use a custom VMA memory pool to allocate memory for tensors belonging to that model. This addresses the two points listed above, and makes it possible for VMA to release all memory used for a model once the model is unloaded. Additionally, using a custom VMA memory pool is optional.

Differential Revision: [D74617843](https://our.internmc.facebook.com/intern/diff/D74617843/)