### PR TITLE
Arm backend: Add test for DeiT Tiny for TOSA BI

### DIFF
--- a/backends/arm/test/models/test_deit_tiny_arm.py
+++ b/backends/arm/test/models/test_deit_tiny_arm.py
@@ -11,7 +11,10 @@ import timm
 
 import torch
 
-from executorch.backends.arm.test.tester.test_pipeline import TosaPipelineMI
+from executorch.backends.arm.test.tester.test_pipeline import (
+    TosaPipelineBI,
+    TosaPipelineMI,
+)
 
 from timm.data import IMAGENET_INCEPTION_MEAN, IMAGENET_INCEPTION_STD
 from torchvision import transforms
@@ -39,6 +42,19 @@ def test_deit_tiny_tosa_MI():
         exir_op=[],
         use_to_edge_transform_and_lower=True,
         atol=6.5,  # This needs to go down: MLETORCH-940
+        qtol=1,
+    )
+    pipeline.run()
+
+
+def test_deit_tiny_tosa_BI():
+    pipeline = TosaPipelineBI[input_t](
+        deit_tiny,
+        model_inputs,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+        atol=3.0,  # This needs to go down: MLETORCH-956
         qtol=1,
     )
     pipeline.run()


### PR DESCRIPTION
Add test case for the DeiT Tiny model for the TOSA BI profile. At this time the output of the model differs from the reference implementation by a mean absolute error of around 2.5, which is too high. An internal ticket has been raised to resolve this issue.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218