### PR TITLE
Arm backend: Reenable test_fuse_const_ops_tosa_BI

### DIFF
--- a/backends/arm/test/passes/test_fuse_constant_ops_pass.py
+++ b/backends/arm/test/passes/test_fuse_constant_ops_pass.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import operator
-import unittest
 from typing import Tuple
 
 import torch
@@ -13,10 +12,7 @@ from executorch.backends.arm._passes.fuse_constant_ops_pass import (
     FuseConstantArgsPass,
 )
 from executorch.backends.arm.test import common
-from executorch.backends.arm.test.tester.test_pipeline import (
-    PassPipeline,
-    TosaPipelineBI,
-)
+from executorch.backends.arm.test.tester.test_pipeline import PassPipeline
 
 input_t = Tuple[torch.Tensor]  # Input x
 
@@ -111,15 +107,14 @@ def test_fuse_const_ops_tosa_MI(module: torch.nn.Module):
     pipeline.run()
 
 
-@unittest.skip("Test failing on internal CI")
 @common.parametrize("module", modules)
 def test_fuse_const_ops_tosa_BI(module: torch.nn.Module):
-    pipeline = TosaPipelineBI[input_t](
+    pipeline = PassPipeline[input_t](
         module,
         (torch.rand(10, 10),),
-        [],
-        [],
         quantize=True,
-        use_to_edge_transform_and_lower=True,
+        ops_before_pass=module.ops_before_pass,
+        ops_after_pass=module.ops_after_pass,
+        passes_with_exported_program=[ComputeConstantOpsAOT, FuseConstantArgsPass],
     )
     pipeline.run()


### PR DESCRIPTION
The fusing of constant ops now works for TOSA BI again.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218