### PR TITLE
Arm backend: Fix mypy linting in pre-push

### DIFF
--- a/backends/arm/scripts/pre-push
+++ b/backends/arm/scripts/pre-push
@@ -76,7 +76,7 @@ for COMMIT in ${COMMITS}; do
 
     # lintrunner on latest patches.
     echo -e "${INFO} Lintrunner"
-    lintrunner --revision ${COMMIT}
+    MYPYPATH=./src/ lintrunner --revision ${COMMIT}^1
     if [[ $? != 0 ]]; then
         echo -e "${ERROR} Failed linting"
         FAILED=1


### PR DESCRIPTION
- Adds ./src/ to MYPYPATH to find imports for editable install
- Make --revision point to the commit before the commit to be linted. Since lintrunner compares files diffing between --revision and HEAD, pointing it to the the latest commit (== HEAD) results in no files being linted.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218