### PR TITLE
Remove EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT

### DIFF
--- a/.ci/scripts/build-qnn-sdk.sh
+++ b/.ci/scripts/build-qnn-sdk.sh
@@ -39,8 +39,7 @@ set_up_aot() {
       -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
       -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
       -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \
-      -DPYTHON_EXECUTABLE=python3 \
-      -DEXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT=OFF
+      -DPYTHON_EXECUTABLE=python3
   cmake --build $PWD --target "PyQnnManagerAdaptor" "PyQnnWrapperAdaptor" -j$(nproc)
   # install Python APIs to correct import path
   # The filename might vary depending on your Python and host version.

--- a/backends/arm/scripts/build_executorch.sh
+++ b/backends/arm/scripts/build_executorch.sh
@@ -82,7 +82,6 @@ if [ "$build_with_etdump" = true ] ; then
         -DEXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL=ON       \
         -DEXECUTORCH_BUILD_DEVTOOLS=ON                    \
         -DEXECUTORCH_ENABLE_EVENT_TRACER=ON               \
-        -DEXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT=ON      \
         -DFLATCC_ALLOW_WERROR=OFF                         \
         -B"${et_build_host_dir}"                          \
         "${et_root_dir}"
@@ -111,7 +110,6 @@ if [ "$build_with_etdump" = true ] ; then
     # Add DevTools flags use in the Target build below
     build_with_etdump_flags="-DEXECUTORCH_BUILD_DEVTOOLS=ON                    \
                             -DEXECUTORCH_ENABLE_EVENT_TRACER=ON               \
-                            -DEXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT=OFF     \
                             -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=OFF      \
                             -DFLATCC_ALLOW_WERROR=OFF                         \
                             -DFLATCC_EXECUTABLE=${et_build_host_dir}/bin/flatcc "

--- a/docs/source/backends-qualcomm.md
+++ b/docs/source/backends-qualcomm.md
@@ -143,8 +143,7 @@ cmake .. \
   -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
   -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
   -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \
-  -DPYTHON_EXECUTABLE=python3 \
-  -DEXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT=OFF
+  -DPYTHON_EXECUTABLE=python3
 
 # nproc is used to detect the number of available CPU.
 # If it is not applicable, please feel free to use the number you want.

--- a/setup.py
+++ b/setup.py
@@ -714,11 +714,6 @@ class CustomBuild(build):
             "-DEXECUTORCH_ENABLE_LOGGING=ON",
             "-DEXECUTORCH_LOG_LEVEL=Info",
             "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15",
-            # The separate host project is only required when cross-compiling,
-            # and it can cause build race conditions (libflatcc.a errors) when
-            # enabled. TODO(dbort): Remove this override once this option is
-            # managed by cmake itself.
-            "-DEXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT=OFF",
             "-DEXECUTORCH_BUILD_TESTS=ON",
         ]
 


### PR DESCRIPTION
### Summary
I forgot to do this in https://github.com/pytorch/executorch/pull/10855. But since we build flatcc for the host now, we don't need this variable.

### Test plan

CI

```
$ rg EXECUTORCH_SEPARATE_FLATCC_HOST_PROJECT --hidden -g '!.git/'
```

cc @larryliu0820